### PR TITLE
Add exact live repository preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `passivbot tool live-repository-prepare`, an explicit local executor
+  that fetches only the pinned public canonical `origin/master`, requires exact
+  caller-confirmed
+  current and target commits, a tracked-clean `master` checkout with no Git
+  operation in progress, and a hook-disabled true fast-forward before moving
+  the worktree.
+  It then verifies or rebuilds the Rust extension in a fresh bounded child
+  process and requires an exact caller-confirmed source fingerprint before the
+  checkout is restart-ready. It preserves untracked files and never SSHes,
+  contacts exchanges, signals or starts live bots, force-checks out, or rolls
+  back a target whose Rust preparation failed.
+
 - Added `passivbot tool live-restart-smoke-evidence`, a pure fail-closed
   evaluator for already-generated full restart target and smoke JSON reports.
   It binds stable exact-target evidence and bounded post-restart monitor/log,

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,48 +22,51 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/restart-smoke-window-selection`, based on canonical
-  `9e8d1343e0f1f43fc3207d611a8b06d88af8b6c0` after PR #1303.
-- PR: #1305. Slice: bound exact historical smoke collection by managed event
-  rotation intervals instead of decompressing the complete retained archive.
-- Triggering evidence: the first VPS5 #1303 collector run discovered 1,012 event
-  segments totaling about 801 MB and remained CPU-active beyond ten minutes.
-  The exact collector PID was interrupted without touching bot panes. A
-  two-recent-segment cap returned in 20.9 seconds but correctly failed closed
-  because it omitted the restart lifecycle. An in-memory interval prototype
-  selected 10 overlapping segments and returned the full green verdict in 37.3
-  seconds.
-- Scope: parse code-owned UTC rotation-close labels, require predecessor coverage
-  for every discovered bot event stream, read only overlapping segments, and
-  fail before content scanning on malformed names, missing coverage, more than
-  eight files per bot, more than 128 files total, or more than 128 MiB selected.
-- Behavior boundary: the selector is opt-in for the restart collector; general
-  smoke-report behavior is unchanged. Local reads and bounded `tmux`/`ps`/`git`
-  inventory remain allowed. SSH, pull/build, network or exchange access,
-  credentials, process signals/starts, force escalation, and file writes remain
-  excluded.
-- Validation: synthetic overlap, gzip/UUID, malformed-name, missing-coverage,
-  per-bot/global-file/byte-limit, collection wiring/redaction, existing smoke,
-  CLI, compilation, and docs regressions.
+- Branch: `codex/restart-repository-prepare`, based on canonical
+  `300fdd703fee9e1ce0e9c54df43bb7b1dcb858d8` after PR #1305.
+- PR: pending. Slice: exact canonical repository preparation before the existing
+  local restart executor can sample or signal any target.
+- Triggering evidence: reviewed deploys still require separate manual
+  `origin/master` pull and Rust freshness commands before the executor can
+  consume its exact repository-head and Rust-source contracts. Those steps are
+  not yet machine-bound to the reviewed target commit.
+- Scope: require exact current/target heads, tracked-clean canonical `master`, no
+  in-progress Git operation, pinned public canonical `origin`, exact fetched
+  `origin/master`, and true ancestry; then fast-forward with hooks disabled and
+  without force, and verify/rebuild Rust in a fresh bounded child process
+  against an operator-confirmed source fingerprint.
+- Behavior boundary: the tool may fetch Git, update the tracked worktree, and
+  write Rust build artifacts only after `--execute`. It preserves untracked
+  files and emits no path, URL, Git stderr, build output, or command content.
+  SSH, exchange/credential access, supervisor parsing, live-process signals or
+  starts, force checkout/reset, and rollback remain excluded. A Rust failure
+  after fast-forward leaves the checkout at the target but not restart-ready.
+- Validation: real temporary-origin fast-forward, dirty/branch/operation/head/
+  target/ancestry failures, untracked preservation, child source-mismatch
+  rejection, CLI dispatch, existing restart tooling, compilation, and docs.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
-- Expected VPS action: pull and rerun the collector against exact PR #1296 bounds
-  `1784316350000..1784317500000`, then verify malformed-expectation rejection.
-  Do not restart or signal bots.
+- Expected VPS action: manual pull to make the new tool available, then an exact
+  same-head/no-build preparation smoke plus wrong-target rejection. Do not
+  restart or signal bots.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `9e8d1343e0f1f43fc3207d611a8b06d88af8b6c0` after PR #1303. Exact-head Hermes
+  `300fdd703fee9e1ce0e9c54df43bb7b1dcb858d8` after PR #1305. Exact-head Hermes
   and Python/Rust CI were green. VPS5 fast-forwarded without a bot restart or
-  signal. The first complete-archive collector run was interrupted after more
-  than ten CPU-active minutes by exact collector PID only; all five bot panes
-  retained parent PIDs `856294/856332/856364/856398/856434`, tracked state
-  stayed clean, and `misc:0.0` remained `%8`, PID `434835`. A read-only in-memory
-  interval prototype selected 10/1,012 segments and recovered five stopping,
-  five stopped, and five startup cohorts with zero hard failures in 37.3
-  seconds. This is triggering evidence for the active bounded-selection slice,
-  not yet deployed collector behavior.
+  signal. The merged collector selected 10/1,008 managed event segments for the
+  exact retained bounds `1784316350000..1784317500000`, projected
+  `131834602` scan bytes under the 128 MiB cap, and recovered five stopping,
+  five stopped, and five startup cohorts with zero hard failures. A malformed
+  expected head exited 2 before collection. All five bot pane parents stayed
+  `856294/856332/856364/856398/856434`, tracked state stayed clean, and
+  `misc:0.0` remained `%8`, PID `434835`.
+- PR #1303 previously deployed at
+  `9e8d1343e0f1f43fc3207d611a8b06d88af8b6c0`. Its first complete-archive
+  collector run was interrupted after more than ten CPU-active minutes by
+  exact collector PID only. A read-only prototype selected 10/1,012 segments
+  and recovered the complete lifecycle in 37.3 seconds, triggering PR #1305.
 - PR #1302 previously deployed at
   `0b5503b2a9ee4817618b7aca25dab417af4292dd`. The retained PR #1296 window
   evaluated green with exact bounds `1784316350000..1784317500000`; a

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/restart-repository-prepare`, based on canonical
   `300fdd703fee9e1ce0e9c54df43bb7b1dcb858d8` after PR #1305.
-- PR: pending. Slice: exact canonical repository preparation before the existing
+- PR: #1306. Slice: exact canonical repository preparation before the existing
   local restart executor can sample or signal any target.
 - Triggering evidence: reviewed deploys still require separate manual
   `origin/master` pull and Rust freshness commands before the executor can

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,23 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1303)
+## Latest Canonical Deployment (PR #1305)
+
+- PR #1305 merged as canonical
+  `300fdd703fee9e1ce0e9c54df43bb7b1dcb858d8` after exact-current-head Hermes
+  approval and green Python/Rust CI. It bounds exact historical restart-smoke
+  collection by managed rotation intervals with predecessor, per-bot,
+  global-file, and projected uncompressed-byte proof before event scanning.
+- VPS5 fast-forwarded without a restart or bot signal. The retained PR #1296
+  window selected 10/1,008 segments and `131834602` projected bytes, recovered
+  all five shutdown/startup cohorts, and returned `ok=true` with zero hard
+  failures. A malformed expected head rejected before producers with exit 2.
+- All five pane parents and `misc:0.0` retained their exact IDs/PIDs and the
+  checkout stayed tracked-clean. The active follow-up binds canonical
+  fetch/fast-forward and Rust runtime preparation before restart execution;
+  force escalation remains separate.
+
+## Previous Canonical Deployment (PR #1303)
 
 - PR #1303 merged as canonical
   `9e8d1343e0f1f43fc3207d611a8b06d88af8b6c0` after exact-current-head Hermes

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -385,9 +385,17 @@ Related detailed plans:
      rotation intervals overlapping that window and returned the complete green
      five-bot lifecycle verdict in 37.3 seconds. The active follow-up makes that
      interval selection fail-closed and caps per-bot, global-file, and byte scope.
+   - 2026-07-17: PR #1305 merged and deployed fail-closed interval selection
+     without a bot restart or signal. The exact retained window selected
+     10/1,008 segments and `131834602` projected bytes under the 128 MiB cap,
+     recovered all five shutdown/startup cohorts, and returned zero hard
+     failures. The active follow-up binds canonical `origin/master`
+     fast-forward and Rust runtime preparation to caller-confirmed commits and
+     source inputs before the restart executor can act.
 
-   Remaining refinements: safe pull/build and post-restart smoke orchestration
-   remain open, as does any separately reviewed force-escalation policy.
+   Remaining refinements: review and deploy the active safe pull/build slice;
+   post-restart smoke orchestration remains open, as does any separately
+   reviewed force-escalation policy.
    The concise and brief summaries are intentionally bounded; further changes
    should target missing smoke fields rather than larger chat-facing payloads.
    2026-06-26 VPS5 deploy evidence: after PR #709, one Ctrl+C round stopped

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -448,6 +448,26 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   exchange access and normal runtime file writes. Run the read-only target
   report first, retain the Rust fingerprint from build verification, and pass
   both exact fingerprints; command content is never emitted.
+- `passivbot tool live-repository-prepare --expected-current-head COMMIT
+  --expected-target-head COMMIT --expected-rust-source-fingerprint SHA256
+  --execute` prepares the local canonical checkout before target sampling or
+  restart execution. It runs only on tracked-clean `master` with no merge,
+  rebase, cherry-pick, revert, or bisect in progress; requires `origin` to be
+  the pinned public canonical HTTPS repository; fetches only `origin/master`;
+  requires the fetched commit to equal the caller-confirmed
+  target and descend from the caller-confirmed current head; and moves the
+  checkout only with a hook-disabled `git merge --ff-only`. It preserves
+  untracked files and
+  emits no remote URL, path, Git stderr, build output, or command content.
+  After the fast-forward it starts a fresh bounded Python child that rejects an
+  unexpected Rust source fingerprint before compiling, rebuilds only when the
+  repository helper reports the extension stale, and verifies the loaded
+  extension stamp plus a final source rehash. A build timeout targets only that
+  child process group. The tool does not SSH, access credentials or exchanges,
+  signal/start live bots, use force checkout/reset, or perform rollback. If
+  Rust preparation fails after a valid fast-forward, the report leaves the
+  checkout at the reviewed target but marks it not restart-ready; rerun after
+  correcting the build contract before invoking `live-restart-executor`.
 - `passivbot tool live-restart-smoke-evidence TARGET_REPORT_JSON
   SMOKE_REPORT_JSON --expected-repository-head COMMIT
   --expected-supervisor-fingerprint SHA256 --expected-targets N` evaluates two

--- a/src/live/repository_prepare.py
+++ b/src/live/repository_prepare.py
@@ -1,0 +1,559 @@
+from __future__ import annotations
+
+import json
+import math
+import os
+import signal
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+CANONICAL_BRANCH = "master"
+CANONICAL_REMOTE = "origin"
+CANONICAL_REMOTE_REF = "refs/remotes/origin/master"
+CANONICAL_REMOTE_URLS = {
+    "https://github.com/enarjord/passivbot",
+    "https://github.com/enarjord/passivbot.git",
+}
+DEFAULT_BUILD_TIMEOUT_S = 1800.0
+MAX_BUILD_TIMEOUT_S = 3600.0
+RUST_RESULT_PREFIX = "PASSIVBOT_REPOSITORY_PREPARE_RESULT="
+
+SAFETY_CONTRACT = {
+    "local_only": True,
+    "ssh": False,
+    "network": True,
+    "git_network_access": True,
+    "git_remote": CANONICAL_REMOTE,
+    "git_branch": CANONICAL_BRANCH,
+    "fast_forward_only": True,
+    "direct_exchange_access": False,
+    "direct_credential_store_access": False,
+    "git_public_remote_only": True,
+    "signals_live_processes": False,
+    "starts_live_processes": False,
+    "subprocess_execution": True,
+    "reads_supervisor_config": False,
+    "writes_repository_checkout": True,
+    "writes_rust_build_artifacts": True,
+    "preserves_untracked_files": True,
+    "automatic_force_checkout": False,
+    "automatic_force_process_signal": False,
+    "build_timeout_process_group_only": True,
+    "signals_build_process_group_on_timeout": True,
+    "requires_execute_confirmation": True,
+    "requires_expected_current_head": True,
+    "requires_expected_target_head": True,
+    "requires_expected_rust_source_fingerprint": True,
+    "requires_canonical_remote_url": True,
+    "requires_tracked_clean_repository": True,
+}
+
+
+def _valid_head(value: str, *, field: str) -> str:
+    head = str(value or "").strip()
+    if len(head) != 40 or any(
+        character not in "0123456789abcdef" for character in head
+    ):
+        raise ValueError(f"{field} must be 40 lowercase hex characters")
+    return head
+
+
+def _valid_fingerprint(value: str) -> str:
+    fingerprint = str(value or "").strip()
+    if len(fingerprint) != 64 or any(
+        character not in "0123456789abcdef" for character in fingerprint
+    ):
+        raise ValueError(
+            "expected_rust_source_fingerprint must be 64 lowercase hex "
+            "characters"
+        )
+    return fingerprint
+
+
+def _bounded_build_timeout(value: float) -> float:
+    timeout = float(value)
+    if (
+        not math.isfinite(timeout)
+        or timeout <= 0.0
+        or timeout > MAX_BUILD_TIMEOUT_S
+    ):
+        raise ValueError(
+            "build_timeout_s must be greater than 0 and at most "
+            f"{MAX_BUILD_TIMEOUT_S:g}"
+        )
+    return timeout
+
+
+def _run_git(
+    root: Path,
+    arguments: list[str],
+    *,
+    timeout_s: float = 120.0,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *arguments],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        timeout=timeout_s,
+        check=False,
+    )
+
+
+def _git_stdout(
+    root: Path, arguments: list[str]
+) -> tuple[str | None, str | None]:
+    try:
+        result = _run_git(root, arguments)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return None, f"git_failed:{exc.__class__.__name__}"
+    if result.returncode != 0:
+        return None, "git_failed"
+    return result.stdout.strip(), None
+
+
+def _repository_root() -> Path | None:
+    output, error = _git_stdout(Path.cwd(), ["rev-parse", "--show-toplevel"])
+    if error is not None or not output:
+        return None
+    return Path(output).resolve()
+
+
+def _git_path_exists(root: Path, name: str) -> bool:
+    output, error = _git_stdout(root, ["rev-parse", "--git-path", name])
+    if error is not None or not output:
+        return True
+    path = Path(output)
+    if not path.is_absolute():
+        path = root / path
+    return path.exists()
+
+
+def _repository_snapshot(root: Path) -> dict[str, Any]:
+    branch, branch_error = _git_stdout(
+        root, ["symbolic-ref", "--quiet", "--short", "HEAD"]
+    )
+    head, head_error = _git_stdout(root, ["rev-parse", "HEAD"])
+    status, status_error = _git_stdout(
+        root, ["status", "--porcelain", "--untracked-files=no"]
+    )
+    operation_names = (
+        "MERGE_HEAD",
+        "CHERRY_PICK_HEAD",
+        "REVERT_HEAD",
+        "BISECT_LOG",
+        "rebase-apply",
+        "rebase-merge",
+    )
+    operations = [
+        name for name in operation_names if _git_path_exists(root, name)
+    ]
+    changes = [line for line in (status or "").splitlines() if line.strip()]
+    return {
+        "branch": branch,
+        "head": head,
+        "tracked_clean": status_error is None and not changes,
+        "tracked_changes": len(changes) if status_error is None else None,
+        "operation_in_progress": bool(operations),
+        "available": not any((branch_error, head_error, status_error)),
+    }
+
+
+def _canonical_remote_configured(root: Path) -> bool:
+    remote_url, error = _git_stdout(
+        root, ["remote", "get-url", CANONICAL_REMOTE]
+    )
+    return error is None and remote_url in CANONICAL_REMOTE_URLS
+
+
+def _snapshot_issue_codes(
+    snapshot: dict[str, Any], *, expected_head: str
+) -> list[str]:
+    issues: list[str] = []
+    if not snapshot.get("available"):
+        issues.append("repository_snapshot_unavailable")
+        return issues
+    if snapshot.get("branch") != CANONICAL_BRANCH:
+        issues.append("repository_branch_mismatch")
+    if snapshot.get("head") != expected_head:
+        issues.append("repository_head_mismatch")
+    if snapshot.get("tracked_clean") is not True:
+        issues.append("repository_tracked_dirty")
+    if snapshot.get("operation_in_progress") is not False:
+        issues.append("repository_operation_in_progress")
+    return issues
+
+
+def _sanitized_snapshot(snapshot: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "branch": snapshot.get("branch"),
+        "head": snapshot.get("head"),
+        "tracked_clean": snapshot.get("tracked_clean"),
+        "tracked_changes": snapshot.get("tracked_changes"),
+        "operation_in_progress": snapshot.get("operation_in_progress"),
+    }
+
+
+RUST_PREPARE_SCRIPT = r"""
+from __future__ import annotations
+
+import contextlib
+import importlib
+import json
+import os
+import sys
+from pathlib import Path
+
+from rust_utils import (
+    check_and_maybe_compile,
+    extension_needs_rebuild,
+    latest_source_mtime,
+    preferred_compiled_path,
+    source_fingerprint,
+    verify_loaded_runtime_extension,
+)
+
+PREFIX = "PASSIVBOT_REPOSITORY_PREPARE_RESULT="
+expected = sys.argv[1]
+result = {
+    "ok": False,
+    "build_required": None,
+    "build_attempted": False,
+    "source_fingerprint": None,
+    "final_source_fingerprint": None,
+    "compiled_source_stamp": None,
+    "compiled_sha256": None,
+    "source_matched": False,
+    "source_snapshot_stable": False,
+    "reason": None,
+}
+try:
+    before = source_fingerprint(Path("passivbot-rust"))
+    result["source_fingerprint"] = before
+    if before != expected:
+        result["reason"] = "rust_source_fingerprint_mismatch"
+    else:
+        build_required = extension_needs_rebuild(
+            preferred_compiled_path(), latest_source_mtime(), before
+        )
+        result["build_required"] = bool(build_required)
+        result["build_attempted"] = bool(build_required)
+        with open(os.devnull, "w", encoding="utf-8") as sink:
+            with contextlib.redirect_stdout(sink), contextlib.redirect_stderr(
+                sink
+            ):
+                check_and_maybe_compile()
+                importlib.import_module("passivbot_rust")
+                runtime = verify_loaded_runtime_extension(fingerprint=expected)
+        after = source_fingerprint(Path("passivbot-rust"))
+        stamp = runtime.get("runtime_compiled_source_stamp")
+        result.update(
+            {
+                "final_source_fingerprint": after,
+                "compiled_source_stamp": stamp,
+                "compiled_sha256": runtime.get("runtime_compiled_sha256"),
+                "source_matched": stamp == expected,
+                "source_snapshot_stable": before == after == expected,
+            }
+        )
+        result["ok"] = bool(
+            result["source_matched"] and result["source_snapshot_stable"]
+        )
+        if not result["ok"]:
+            result["reason"] = "rust_extension_source_mismatch"
+except Exception as exc:
+    result["reason"] = "rust_prepare_failed"
+    result["error_class"] = exc.__class__.__name__
+print(PREFIX + json.dumps(result, sort_keys=True, separators=(",", ":")))
+raise SystemExit(0 if result["ok"] else 1)
+"""
+
+
+def _terminate_process_group(process: subprocess.Popen[str]) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        if os.name == "posix":
+            os.killpg(process.pid, signal.SIGTERM)
+        else:
+            process.terminate()
+        process.wait(timeout=5.0)
+    except (OSError, subprocess.SubprocessError):
+        if process.poll() is None:
+            try:
+                if os.name == "posix":
+                    os.killpg(process.pid, signal.SIGKILL)
+                else:
+                    process.kill()
+            except OSError:
+                pass
+        try:
+            process.wait(timeout=5.0)
+        except (OSError, subprocess.SubprocessError):
+            pass
+
+
+def _prepare_rust_runtime(
+    root: Path,
+    *,
+    expected_fingerprint: str,
+    timeout_s: float,
+) -> dict[str, Any]:
+    env = os.environ.copy()
+    src_path = str(root / "src")
+    env["PYTHONPATH"] = (
+        f"{src_path}{os.pathsep}{env['PYTHONPATH']}"
+        if env.get("PYTHONPATH")
+        else src_path
+    )
+    try:
+        process = subprocess.Popen(
+            [sys.executable, "-c", RUST_PREPARE_SCRIPT, expected_fingerprint],
+            cwd=root,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            start_new_session=os.name == "posix",
+        )
+    except OSError as exc:
+        return {
+            "ok": False,
+            "reason": "rust_prepare_failed",
+            "error_class": exc.__class__.__name__,
+        }
+    try:
+        stdout, _ = process.communicate(timeout=timeout_s)
+    except subprocess.TimeoutExpired:
+        _terminate_process_group(process)
+        return {"ok": False, "reason": "rust_prepare_timeout"}
+
+    payload_line = next(
+        (
+            line
+            for line in reversed(stdout.splitlines())
+            if line.startswith(RUST_RESULT_PREFIX)
+        ),
+        None,
+    )
+    if payload_line is None:
+        return {"ok": False, "reason": "rust_prepare_result_missing"}
+    try:
+        payload = json.loads(payload_line.removeprefix(RUST_RESULT_PREFIX))
+    except (json.JSONDecodeError, TypeError):
+        return {"ok": False, "reason": "rust_prepare_result_invalid"}
+    if not isinstance(payload, dict):
+        return {"ok": False, "reason": "rust_prepare_result_invalid"}
+    if process.returncode != 0:
+        payload["ok"] = False
+    return payload
+
+
+def _issue(code: str, **fields: Any) -> dict[str, Any]:
+    return {"code": code, "severity": "error", **fields}
+
+
+def prepare_live_repository(
+    *,
+    expected_current_head: str,
+    expected_target_head: str,
+    expected_rust_source_fingerprint: str,
+    build_timeout_s: float = DEFAULT_BUILD_TIMEOUT_S,
+    execute: bool = False,
+) -> dict[str, Any]:
+    """Fast-forward master and prove its local Rust runtime contract."""
+    current_head = _valid_head(
+        expected_current_head, field="expected_current_head"
+    )
+    target_head = _valid_head(
+        expected_target_head, field="expected_target_head"
+    )
+    rust_fingerprint = _valid_fingerprint(expected_rust_source_fingerprint)
+    timeout = _bounded_build_timeout(build_timeout_s)
+    if not execute:
+        raise ValueError("execute must be true")
+
+    report: dict[str, Any] = {
+        "tool": "live-repository-prepare",
+        "schema_version": 1,
+        "ok": False,
+        "outcome": "rejected",
+        "action_started": False,
+        "repository_updated": False,
+        "repository": {
+            "expected_current_head": current_head,
+            "expected_target_head": target_head,
+            "fetched_target_head": None,
+            "initial": None,
+            "final": None,
+        },
+        "rust_extension": {
+            "expected_source_fingerprint": rust_fingerprint,
+            "ok": False,
+            "build_required": None,
+            "build_attempted": False,
+        },
+        "issues": [],
+        "safety": dict(SAFETY_CONTRACT),
+    }
+    issues: list[dict[str, Any]] = report["issues"]
+    root = _repository_root()
+    if root is None:
+        issues.append(_issue("repository_unavailable"))
+        return report
+
+    initial = _repository_snapshot(root)
+    report["repository"]["initial"] = _sanitized_snapshot(initial)
+    initial_issues = _snapshot_issue_codes(initial, expected_head=current_head)
+    if not _canonical_remote_configured(root):
+        initial_issues.append("repository_remote_mismatch")
+    if initial_issues:
+        issues.extend(_issue(code) for code in initial_issues)
+        return report
+
+    report["action_started"] = True
+    report["outcome"] = "failed"
+    try:
+        fetch = _run_git(
+            root,
+            [
+                "fetch",
+                "--no-tags",
+                CANONICAL_REMOTE,
+                f"refs/heads/{CANONICAL_BRANCH}:{CANONICAL_REMOTE_REF}",
+            ],
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        issues.append(
+            _issue("git_fetch_failed", error_class=exc.__class__.__name__)
+        )
+        return report
+    if fetch.returncode != 0:
+        issues.append(_issue("git_fetch_failed"))
+        return report
+
+    after_fetch = _repository_snapshot(root)
+    after_fetch_issues = _snapshot_issue_codes(
+        after_fetch, expected_head=current_head
+    )
+    if after_fetch_issues:
+        issues.append(_issue("repository_changed_during_fetch"))
+        return report
+
+    fetched_head, fetched_error = _git_stdout(
+        root, ["rev-parse", CANONICAL_REMOTE_REF]
+    )
+    report["repository"]["fetched_target_head"] = fetched_head
+    if fetched_error is not None or fetched_head is None:
+        issues.append(_issue("fetched_target_head_unavailable"))
+        return report
+    if fetched_head != target_head:
+        issues.append(_issue("fetched_target_head_mismatch"))
+        return report
+
+    try:
+        ancestry = _run_git(
+            root, ["merge-base", "--is-ancestor", current_head, target_head]
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        issues.append(
+            _issue(
+                "git_ancestry_check_failed",
+                error_class=exc.__class__.__name__,
+            )
+        )
+        return report
+    if ancestry.returncode == 1:
+        issues.append(_issue("target_not_fast_forward"))
+        return report
+    if ancestry.returncode != 0:
+        issues.append(_issue("git_ancestry_check_failed"))
+        return report
+
+    if current_head != target_head:
+        try:
+            merge = _run_git(
+                root,
+                [
+                    "-c",
+                    "core.hooksPath=/dev/null",
+                    "merge",
+                    "--ff-only",
+                    "--no-edit",
+                    CANONICAL_REMOTE_REF,
+                ],
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            issues.append(
+                _issue(
+                    "git_fast_forward_failed",
+                    error_class=exc.__class__.__name__,
+                )
+            )
+            return report
+        if merge.returncode != 0:
+            issues.append(_issue("git_fast_forward_failed"))
+            return report
+        report["repository_updated"] = True
+
+    prepared_snapshot = _repository_snapshot(root)
+    report["repository"]["final"] = _sanitized_snapshot(prepared_snapshot)
+    prepared_issues = _snapshot_issue_codes(
+        prepared_snapshot, expected_head=target_head
+    )
+    if prepared_issues:
+        issues.append(_issue("repository_post_update_mismatch"))
+        return report
+
+    rust_report = _prepare_rust_runtime(
+        root,
+        expected_fingerprint=rust_fingerprint,
+        timeout_s=timeout,
+    )
+    allowed_rust_fields = {
+        "ok",
+        "build_required",
+        "build_attempted",
+        "source_fingerprint",
+        "final_source_fingerprint",
+        "compiled_source_stamp",
+        "compiled_sha256",
+        "source_matched",
+        "source_snapshot_stable",
+        "reason",
+        "error_class",
+    }
+    report["rust_extension"] = {
+        "expected_source_fingerprint": rust_fingerprint,
+        **{
+            key: rust_report.get(key)
+            for key in allowed_rust_fields
+            if key in rust_report
+        },
+    }
+    if rust_report.get("ok") is not True:
+        reason = str(rust_report.get("reason") or "rust_prepare_failed")
+        if reason not in {
+            "rust_extension_source_mismatch",
+            "rust_prepare_failed",
+            "rust_prepare_result_invalid",
+            "rust_prepare_result_missing",
+            "rust_prepare_timeout",
+            "rust_source_fingerprint_mismatch",
+        }:
+            reason = "rust_prepare_failed"
+        issues.append(_issue(reason))
+        return report
+
+    final = _repository_snapshot(root)
+    report["repository"]["final"] = _sanitized_snapshot(final)
+    final_issues = _snapshot_issue_codes(final, expected_head=target_head)
+    if final_issues:
+        issues.append(_issue("repository_changed_during_rust_prepare"))
+        return report
+
+    report["ok"] = True
+    report["outcome"] = "completed"
+    return report

--- a/src/passivbot_cli/main.py
+++ b/src/passivbot_cli/main.py
@@ -160,6 +160,10 @@ TOOL_COMMANDS: dict[str, CommandSpec] = {
         "tools.live_restart_executor",
         "gracefully restart exact verified local tmux targets",
     ),
+    "live-repository-prepare": CommandSpec(
+        "tools.live_repository_prepare",
+        "fast-forward canonical master and prove the Rust runtime",
+    ),
     "inspect-ohlcvs": CommandSpec(
         "tools.inspect_ohlcvs",
         "inspect v2 OHLCV cache metadata and gaps (requires full install)",

--- a/src/tools/live_repository_prepare.py
+++ b/src/tools/live_repository_prepare.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SRC_ROOT = Path(__file__).resolve().parents[1]
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from live.repository_prepare import (  # noqa: E402  # isort: skip
+    DEFAULT_BUILD_TIMEOUT_S,
+    prepare_live_repository,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="passivbot tool live-repository-prepare",
+        description=(
+            "Fast-forward clean local canonical master to one exact "
+            "origin/master commit and prove its Rust runtime is "
+            "restart-ready."
+        ),
+    )
+    parser.add_argument("--expected-current-head", required=True)
+    parser.add_argument("--expected-target-head", required=True)
+    parser.add_argument("--expected-rust-source-fingerprint", required=True)
+    parser.add_argument(
+        "--build-timeout-s", type=float, default=DEFAULT_BUILD_TIMEOUT_S
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Confirm canonical fetch, fast-forward, and Rust preparation.",
+    )
+    parser.add_argument("--compact", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not args.execute:
+        parser.error("--execute is required")
+    try:
+        report = prepare_live_repository(
+            expected_current_head=args.expected_current_head,
+            expected_target_head=args.expected_target_head,
+            expected_rust_source_fingerprint=(
+                args.expected_rust_source_fingerprint
+            ),
+            build_timeout_s=args.build_timeout_s,
+            execute=True,
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
+    print(
+        json.dumps(
+            report, indent=None if args.compact else 2, sort_keys=True
+        )
+    )
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_live_repository_prepare.py
+++ b/tests/test_live_repository_prepare.py
@@ -1,0 +1,429 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import live.repository_prepare as prepare_module
+from live.repository_prepare import prepare_live_repository
+from passivbot_cli import main as cli_main
+from tools import live_repository_prepare
+
+RUST_FINGERPRINT = "c" * 64
+
+
+def _git(root: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _commit(root: Path, message: str, content: str) -> str:
+    (root / "tracked.txt").write_text(content, encoding="utf-8")
+    _git(root, "add", "tracked.txt")
+    _git(root, "commit", "-m", message)
+    return _git(root, "rev-parse", "HEAD")
+
+
+@pytest.fixture
+def repository_pair(tmp_path: Path, monkeypatch) -> dict[str, Path | str]:
+    origin = tmp_path / "origin.git"
+    seed = tmp_path / "seed"
+    checkout = tmp_path / "checkout"
+    origin.mkdir()
+    _git(origin, "init", "--bare", "--initial-branch=master")
+    seed.mkdir()
+    _git(seed, "init", "--initial-branch=master")
+    _git(seed, "config", "user.name", "Repository Prepare Test")
+    _git(seed, "config", "user.email", "repository-prepare@example.invalid")
+    current = _commit(seed, "initial", "initial\n")
+    _git(seed, "remote", "add", "origin", str(origin))
+    _git(seed, "push", "-u", "origin", "master")
+    _git(tmp_path, "clone", "--branch", "master", str(origin), str(checkout))
+    _git(checkout, "config", "user.name", "Repository Prepare Test")
+    _git(
+        checkout,
+        "config",
+        "user.email",
+        "repository-prepare@example.invalid",
+    )
+    target = _commit(seed, "target", "target\n")
+    _git(seed, "push", "origin", "master")
+    monkeypatch.setattr(
+        prepare_module, "_canonical_remote_configured", lambda _root: True
+    )
+    return {
+        "origin": origin,
+        "seed": seed,
+        "checkout": checkout,
+        "current": current,
+        "target": target,
+    }
+
+
+def _rust_ready(*_args, **_kwargs) -> dict:
+    return {
+        "ok": True,
+        "build_required": False,
+        "build_attempted": False,
+        "source_fingerprint": RUST_FINGERPRINT,
+        "final_source_fingerprint": RUST_FINGERPRINT,
+        "compiled_source_stamp": RUST_FINGERPRINT,
+        "compiled_sha256": "d" * 64,
+        "source_matched": True,
+        "source_snapshot_stable": True,
+        "reason": None,
+    }
+
+
+def _prepare(repository_pair: dict[str, Path | str], monkeypatch) -> dict:
+    checkout = repository_pair["checkout"]
+    assert isinstance(checkout, Path)
+    monkeypatch.chdir(checkout)
+    monkeypatch.setattr(prepare_module, "_prepare_rust_runtime", _rust_ready)
+    return prepare_live_repository(
+        expected_current_head=str(repository_pair["current"]),
+        expected_target_head=str(repository_pair["target"]),
+        expected_rust_source_fingerprint=RUST_FINGERPRINT,
+        build_timeout_s=1.0,
+        execute=True,
+    )
+
+
+def test_repository_prepare_fast_forwards_exact_master_and_preserves_untracked(
+    repository_pair, monkeypatch
+):
+    checkout = repository_pair["checkout"]
+    assert isinstance(checkout, Path)
+    artifact = checkout / "local-config.json"
+    artifact.write_text("{}\n", encoding="utf-8")
+
+    report = _prepare(repository_pair, monkeypatch)
+
+    assert report["ok"] is True
+    assert report["outcome"] == "completed"
+    assert report["action_started"] is True
+    assert report["repository_updated"] is True
+    assert (
+        report["repository"]["fetched_target_head"]
+        == repository_pair["target"]
+    )
+    assert report["repository"]["final"]["head"] == repository_pair["target"]
+    assert report["rust_extension"]["ok"] is True
+    assert _git(checkout, "rev-parse", "HEAD") == repository_pair["target"]
+    assert artifact.read_text(encoding="utf-8") == "{}\n"
+    assert report["safety"]["fast_forward_only"] is True
+    assert report["safety"]["signals_live_processes"] is False
+    assert report["safety"]["starts_live_processes"] is False
+    serialized = json.dumps(report, sort_keys=True)
+    assert str(checkout) not in serialized
+    assert str(repository_pair["origin"]) not in serialized
+
+
+def test_repository_prepare_rejects_tracked_changes_before_fetch(
+    repository_pair, monkeypatch
+):
+    checkout = repository_pair["checkout"]
+    assert isinstance(checkout, Path)
+    monkeypatch.chdir(checkout)
+    (checkout / "tracked.txt").write_text("dirty\n", encoding="utf-8")
+    monkeypatch.setattr(prepare_module, "_prepare_rust_runtime", _rust_ready)
+
+    report = prepare_live_repository(
+        expected_current_head=str(repository_pair["current"]),
+        expected_target_head=str(repository_pair["target"]),
+        expected_rust_source_fingerprint=RUST_FINGERPRINT,
+        execute=True,
+    )
+
+    assert report["ok"] is False
+    assert report["action_started"] is False
+    assert {issue["code"] for issue in report["issues"]} == {
+        "repository_tracked_dirty"
+    }
+    assert _git(checkout, "rev-parse", "HEAD") == repository_pair["current"]
+
+
+def test_repository_prepare_rejects_unexpected_fetched_target(
+    repository_pair, monkeypatch
+):
+    checkout = repository_pair["checkout"]
+    assert isinstance(checkout, Path)
+    monkeypatch.chdir(checkout)
+    monkeypatch.setattr(prepare_module, "_prepare_rust_runtime", _rust_ready)
+
+    report = prepare_live_repository(
+        expected_current_head=str(repository_pair["current"]),
+        expected_target_head="e" * 40,
+        expected_rust_source_fingerprint=RUST_FINGERPRINT,
+        execute=True,
+    )
+
+    assert report["ok"] is False
+    assert report["action_started"] is True
+    assert report["repository_updated"] is False
+    assert {issue["code"] for issue in report["issues"]} == {
+        "fetched_target_head_mismatch"
+    }
+    assert _git(checkout, "rev-parse", "HEAD") == repository_pair["current"]
+
+
+def test_repository_prepare_rejects_non_fast_forward_target(
+    repository_pair, monkeypatch
+):
+    checkout = repository_pair["checkout"]
+    assert isinstance(checkout, Path)
+    local_head = _commit(checkout, "local divergence", "local\n")
+    monkeypatch.chdir(checkout)
+    monkeypatch.setattr(prepare_module, "_prepare_rust_runtime", _rust_ready)
+
+    report = prepare_live_repository(
+        expected_current_head=local_head,
+        expected_target_head=str(repository_pair["target"]),
+        expected_rust_source_fingerprint=RUST_FINGERPRINT,
+        execute=True,
+    )
+
+    assert report["ok"] is False
+    assert report["repository_updated"] is False
+    assert {issue["code"] for issue in report["issues"]} == {
+        "target_not_fast_forward"
+    }
+    assert _git(checkout, "rev-parse", "HEAD") == local_head
+
+
+def test_repository_prepare_reports_rust_failure_after_safe_fast_forward(
+    repository_pair, monkeypatch
+):
+    checkout = repository_pair["checkout"]
+    assert isinstance(checkout, Path)
+    monkeypatch.chdir(checkout)
+    monkeypatch.setattr(
+        prepare_module,
+        "_prepare_rust_runtime",
+        lambda *_args, **_kwargs: {
+            "ok": False,
+            "build_required": False,
+            "build_attempted": False,
+            "source_fingerprint": "e" * 64,
+            "reason": "rust_source_fingerprint_mismatch",
+        },
+    )
+
+    report = prepare_live_repository(
+        expected_current_head=str(repository_pair["current"]),
+        expected_target_head=str(repository_pair["target"]),
+        expected_rust_source_fingerprint=RUST_FINGERPRINT,
+        execute=True,
+    )
+
+    assert report["ok"] is False
+    assert report["repository_updated"] is True
+    assert report["repository"]["final"]["head"] == repository_pair["target"]
+    assert report["rust_extension"]["build_attempted"] is False
+    assert {issue["code"] for issue in report["issues"]} == {
+        "rust_source_fingerprint_mismatch"
+    }
+    assert _git(checkout, "rev-parse", "HEAD") == repository_pair["target"]
+
+
+def test_rust_prepare_child_rejects_unexpected_source_before_build():
+    report = prepare_module._prepare_rust_runtime(
+        Path.cwd(),
+        expected_fingerprint="e" * 64,
+        timeout_s=30.0,
+    )
+
+    assert report["ok"] is False
+    assert report["reason"] == "rust_source_fingerprint_mismatch"
+    assert report["build_attempted"] is False
+
+
+def test_repository_prepare_requires_canonical_master(
+    repository_pair, monkeypatch
+):
+    checkout = repository_pair["checkout"]
+    assert isinstance(checkout, Path)
+    _git(checkout, "checkout", "-b", "feature")
+    monkeypatch.chdir(checkout)
+    monkeypatch.setattr(prepare_module, "_prepare_rust_runtime", _rust_ready)
+
+    report = prepare_live_repository(
+        expected_current_head=str(repository_pair["current"]),
+        expected_target_head=str(repository_pair["target"]),
+        expected_rust_source_fingerprint=RUST_FINGERPRINT,
+        execute=True,
+    )
+
+    assert report["action_started"] is False
+    assert {issue["code"] for issue in report["issues"]} == {
+        "repository_branch_mismatch"
+    }
+
+
+def test_repository_prepare_rejects_in_progress_operation(
+    repository_pair, monkeypatch
+):
+    checkout = repository_pair["checkout"]
+    assert isinstance(checkout, Path)
+    monkeypatch.chdir(checkout)
+    original = prepare_module._git_path_exists
+    monkeypatch.setattr(
+        prepare_module,
+        "_git_path_exists",
+        lambda root, name: (
+            True if name == "MERGE_HEAD" else original(root, name)
+        ),
+    )
+
+    report = prepare_live_repository(
+        expected_current_head=str(repository_pair["current"]),
+        expected_target_head=str(repository_pair["target"]),
+        expected_rust_source_fingerprint=RUST_FINGERPRINT,
+        execute=True,
+    )
+
+    assert report["action_started"] is False
+    assert {issue["code"] for issue in report["issues"]} == {
+        "repository_operation_in_progress"
+    }
+
+
+def test_repository_prepare_rejects_noncanonical_origin(
+    repository_pair, monkeypatch
+):
+    checkout = repository_pair["checkout"]
+    assert isinstance(checkout, Path)
+    monkeypatch.chdir(checkout)
+    monkeypatch.setattr(
+        prepare_module, "_canonical_remote_configured", lambda _root: False
+    )
+
+    report = prepare_live_repository(
+        expected_current_head=str(repository_pair["current"]),
+        expected_target_head=str(repository_pair["target"]),
+        expected_rust_source_fingerprint=RUST_FINGERPRINT,
+        execute=True,
+    )
+
+    assert report["action_started"] is False
+    assert {issue["code"] for issue in report["issues"]} == {
+        "repository_remote_mismatch"
+    }
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("expected_current_head", "abc", "40 lowercase hex"),
+        ("expected_target_head", "A" * 40, "40 lowercase hex"),
+        ("expected_rust_source_fingerprint", "abc", "64 lowercase hex"),
+    ],
+)
+def test_repository_prepare_validates_expectations_before_git(
+    monkeypatch, field, value, message
+):
+    monkeypatch.setattr(
+        prepare_module,
+        "_repository_root",
+        lambda: pytest.fail("git must not run for malformed expectations"),
+    )
+    kwargs = {
+        "expected_current_head": "a" * 40,
+        "expected_target_head": "b" * 40,
+        "expected_rust_source_fingerprint": RUST_FINGERPRINT,
+        "execute": True,
+    }
+    kwargs[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        prepare_live_repository(**kwargs)
+
+
+def test_repository_prepare_cli_requires_execute(capsys):
+    with pytest.raises(SystemExit) as exc:
+        live_repository_prepare.main(
+            [
+                "--expected-current-head",
+                "a" * 40,
+                "--expected-target-head",
+                "b" * 40,
+                "--expected-rust-source-fingerprint",
+                RUST_FINGERPRINT,
+            ]
+        )
+    assert exc.value.code == 2
+    assert "--execute is required" in capsys.readouterr().err
+
+
+def test_repository_prepare_cli_emits_sanitized_report(monkeypatch, capsys):
+    monkeypatch.setattr(
+        live_repository_prepare,
+        "prepare_live_repository",
+        lambda **_kwargs: {
+            "tool": "live-repository-prepare",
+            "schema_version": 1,
+            "ok": True,
+        },
+    )
+
+    result = live_repository_prepare.main(
+        [
+            "--expected-current-head",
+            "a" * 40,
+            "--expected-target-head",
+            "b" * 40,
+            "--expected-rust-source-fingerprint",
+            RUST_FINGERPRINT,
+            "--execute",
+            "--compact",
+        ]
+    )
+
+    assert result == 0
+    assert (
+        json.loads(capsys.readouterr().out)["tool"]
+        == "live-repository-prepare"
+    )
+
+
+def test_repository_prepare_dispatches_through_unified_cli(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def fake_invoke_module_main(module_name):
+        captured["module_name"] = module_name
+        captured["argv"] = cli_main.sys.argv[:]
+        captured["prog_env"] = cli_main.os.environ.get("PASSIVBOT_CLI_PROG")
+        return True, 0
+
+    monkeypatch.setattr(
+        cli_main, "_invoke_module_main", fake_invoke_module_main
+    )
+    monkeypatch.setattr(
+        cli_main, "_missing_full_install_markers", lambda: []
+    )
+
+    result = cli_main.main(
+        [
+            "tool",
+            "live-repository-prepare",
+            "--expected-current-head",
+            "a" * 40,
+        ]
+    )
+
+    assert result == 0
+    assert captured["module_name"] == "tools.live_repository_prepare"
+    assert captured["argv"] == [
+        "passivbot tool live-repository-prepare",
+        "--expected-current-head",
+        "a" * 40,
+    ]
+    assert captured["prog_env"] == "passivbot tool live-repository-prepare"


### PR DESCRIPTION
## Scope

Category: restart/deploy behavior.

Add `passivbot tool live-repository-prepare` as the canonical pre-restart
repository preparation boundary.

- pins the public HTTPS `origin` identity and fetches only `origin/master`
- requires exact caller-confirmed current and target SHAs
- requires tracked-clean `master` with no Git operation in progress
- requires exact fetched target and true fast-forward ancestry
- disables repository hooks and uses `git merge --ff-only`
- preserves untracked files
- verifies or rebuilds Rust in a fresh bounded child process only after the
  target source fingerprint matches
- emits sanitized state only

## Non-goals

- no SSH
- no exchange or credential access
- no supervisor parsing
- no live-process signals or starts
- no force checkout/reset or rollback
- no change to the existing restart executor or trading/event behavior

A Rust failure after a valid fast-forward intentionally leaves the checkout at
the reviewed target but marks it not restart-ready.

## Validation

- focused restart/tooling suite: 211 passed
- complete Python suite: passed
- Rust: 210 passed via `passivbot-rust/cargotest.sh`
- real exact-extension child verification: green, no rebuild required
- malformed CLI expectation: rejected before Git
- AI docs: 0 errors; generated event registry current
- `flake8`, `isort --check-only`, `py_compile`, and `git diff --check`: passed

## Reviewer focus

- TOCTOU boundaries around fetch, fast-forward, Rust preparation, and final
  snapshot
- canonical remote/ref and hook suppression
- child-process timeout containment and sanitized failure output
- explicit no-rollback behavior after a successful fast-forward

## VPS action

Pull/observe only. After merge, manually pull once to make the tool available,
then run an exact same-head/no-build preparation smoke and a wrong-target
rejection. Do not restart or signal bots.
