### PR TITLE
Add bounded restart and smoke orchestration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `passivbot tool live-restart-smoke-run`, an explicit local orchestrator
+  that requires exact repository, Rust-source, supervisor-command, and target
+  contracts before invoking the existing exact-pane graceful restart executor.
+  After a successful restart it waits one caller-bounded observation interval
+  and runs the existing bounded in-memory smoke collector over the exact
+  restart-through-observation window. It emits aggregate restart counts and
+  sanitized smoke evidence only, never pulls or builds code, SSHes, applies
+  force escalation or broad process-pattern signals, or writes report files;
+  post-action smoke failures leave the relaunched bots running and fail red for
+  operator follow-up.
+
 - Added `passivbot tool live-repository-prepare`, an explicit local executor
   that fetches only the pinned public canonical `origin/master`, requires exact
   caller-confirmed

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,38 +22,49 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/restart-repository-prepare`, based on canonical
-  `300fdd703fee9e1ce0e9c54df43bb7b1dcb858d8` after PR #1305.
-- PR: #1306. Slice: exact canonical repository preparation before the existing
-  local restart executor can sample or signal any target.
-- Triggering evidence: reviewed deploys still require separate manual
-  `origin/master` pull and Rust freshness commands before the executor can
-  consume its exact repository-head and Rust-source contracts. Those steps are
-  not yet machine-bound to the reviewed target commit.
-- Scope: require exact current/target heads, tracked-clean canonical `master`, no
-  in-progress Git operation, pinned public canonical `origin`, exact fetched
-  `origin/master`, and true ancestry; then fast-forward with hooks disabled and
-  without force, and verify/rebuild Rust in a fresh bounded child process
-  against an operator-confirmed source fingerprint.
-- Behavior boundary: the tool may fetch Git, update the tracked worktree, and
-  write Rust build artifacts only after `--execute`. It preserves untracked
-  files and emits no path, URL, Git stderr, build output, or command content.
-  SSH, exchange/credential access, supervisor parsing, live-process signals or
-  starts, force checkout/reset, and rollback remain excluded. A Rust failure
-  after fast-forward leaves the checkout at the target but not restart-ready.
-- Validation: real temporary-origin fast-forward, dirty/branch/operation/head/
-  target/ancestry failures, untracked preservation, child source-mismatch
-  rejection, CLI dispatch, existing restart tooling, compilation, and docs.
+- Branch: `codex/restart-smoke-orchestrator`, based on canonical
+  `0d1b06b82f3bab011e29a350b4a5276c2ebd5356` after PR #1306.
+- PR: pending. Slice: one bounded exact-pane graceful restart followed by one
+  exact restart-through-observation smoke collection.
+- Triggering evidence: repository preparation, exact target sampling, graceful
+  restart execution, retained-window collection, and sanitized evaluation are
+  individually available, but the production sequence still relies on manual
+  timestamp capture and command handoff between the restart and smoke tools.
+- Scope: independently require a complete stable target sample, invoke the
+  existing executor unchanged, require aggregate completion for every expected
+  target, wait one caller-bounded interval, and invoke the existing collector
+  with exact epoch-millisecond bounds. Malformed producer reports and bounded
+  collector exceptions fail closed without exposing private target details.
+- Behavior boundary: explicit `--execute` may gracefully signal and relaunch
+  only the configured exact tmux panes. The tool does not SSH, pull/build,
+  access credentials or exchanges directly, write reports, use broad process
+  patterns, poll/retry smoke collection, or apply automatic force escalation.
+  Configured bots resume normal exchange access and file writes. Post-action
+  smoke failure leaves them running and returns red for operator follow-up.
+- Validation: success/failure sequencing, strict target and executor contracts,
+  no-action preflight rejection, manual-recovery projection, exact clock bounds,
+  sanitized collector errors, CLI dispatch, existing restart tooling, complete
+  Python/Rust suites, compilation, and docs.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
-- Expected VPS action: manual pull to make the new tool available, then an exact
-  same-head/no-build preparation smoke plus wrong-target rejection. Do not
-  restart or signal bots.
+- Expected VPS action: use the merged repository-preparation tool to reach the
+  reviewed merge commit, verify exact targets and private fingerprints, then
+  run one no-force five-target restart with bounded post-restart smoke. Preserve
+  `misc:0.0`; stop for manual recovery if graceful execution does not finish.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `300fdd703fee9e1ce0e9c54df43bb7b1dcb858d8` after PR #1305. Exact-head Hermes
+  `0d1b06b82f3bab011e29a350b4a5276c2ebd5356` after PR #1306. Exact-head Hermes
+  and Python/Rust CI were green. VPS5 first fast-forwarded to make the
+  repository-preparation tool available, without a bot restart or signal. Its
+  same-head execution returned green with no repository move or Rust build and
+  exact source/stamp/final fingerprints; a valid but wrong target commit failed
+  with `fetched_target_head_mismatch` before any build. All five configured pane
+  parents and unrelated `misc:0.0` remained unchanged, and tracked state stayed
+  clean.
+- PR #1305 previously deployed at
+  `300fdd703fee9e1ce0e9c54df43bb7b1dcb858d8`. Exact-head Hermes
   and Python/Rust CI were green. VPS5 fast-forwarded without a bot restart or
   signal. The merged collector selected 10/1,008 managed event segments for the
   exact retained bounds `1784316350000..1784317500000`, projected

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/restart-smoke-orchestrator`, based on canonical
   `0d1b06b82f3bab011e29a350b4a5276c2ebd5356` after PR #1306.
-- PR: pending. Slice: one bounded exact-pane graceful restart followed by one
+- PR: #1307. Slice: one bounded exact-pane graceful restart followed by one
   exact restart-through-observation smoke collection.
 - Triggering evidence: repository preparation, exact target sampling, graceful
   restart execution, retained-window collection, and sanitized evaluation are

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,23 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1305)
+## Latest Canonical Deployment (PR #1306)
+
+- PR #1306 merged as canonical
+  `0d1b06b82f3bab011e29a350b4a5276c2ebd5356` after exact-current-head Hermes
+  approval and green Python/Rust CI. It binds canonical `origin/master`
+  fast-forward and Rust runtime preparation to exact caller-confirmed current
+  and target commits plus a source fingerprint before restart execution.
+- VPS5 first fast-forwarded to make the tool available without a bot restart or
+  signal. A same-head execution returned green with no repository move or build;
+  a valid wrong target failed with `fetched_target_head_mismatch` before build.
+  Tracked state, all five configured pane parents, and `misc:0.0` stayed
+  unchanged.
+- The active follow-up composes the existing exact-pane graceful executor and
+  bounded retained-window collector over one restart-through-observation window.
+  Remote-host control and force escalation remain separate.
+
+## Previous Canonical Deployment (PR #1305)
 
 - PR #1305 merged as canonical
   `300fdd703fee9e1ce0e9c54df43bb7b1dcb858d8` after exact-current-head Hermes
@@ -27,7 +43,7 @@ merge, live smoke evidence changes, or new gaps are discovered.
   all five shutdown/startup cohorts, and returned `ok=true` with zero hard
   failures. A malformed expected head rejected before producers with exit 2.
 - All five pane parents and `misc:0.0` retained their exact IDs/PIDs and the
-  checkout stayed tracked-clean. The active follow-up binds canonical
+  checkout stayed tracked-clean. PR #1306 subsequently bound canonical
   fetch/fast-forward and Rust runtime preparation before restart execution;
   force escalation remains separate.
 

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -240,9 +240,10 @@ Related detailed plans:
    `repository.root` for shareable reports and surfaces explicit
    dropped-unparsed attention/hard counters when the opt-in log-window drop
    policy suppresses contextless hard-looking log fragments. The safe local
-   exact-target restart executor is implemented; repository pull, Rust rebuild,
-   remote-host orchestration, automatic force escalation, and post-restart
-   monitor/log smoke orchestration remain outside it. A 2026-06-30 follow-up made the
+   exact-target restart executor and canonical repository preparation are
+   implemented; remote-host orchestration and automatic force escalation remain
+   outside them. The active slice composes the executor with one bounded
+   post-restart monitor/log smoke window. A 2026-06-30 follow-up made the
    existing startup timing evidence visible in `live-smoke-report --summary`
    and `--brief`, so repeated smoke loops can see slow startup phases without
    opening the full report. Another 2026-06-30 follow-up made bounded text-log
@@ -392,10 +393,16 @@ Related detailed plans:
      failures. The active follow-up binds canonical `origin/master`
      fast-forward and Rust runtime preparation to caller-confirmed commits and
      source inputs before the restart executor can act.
+   - 2026-07-17: PR #1306 merged and deployed exact canonical repository
+     preparation. A same-head VPS5 smoke proved the no-move/no-build path, and a
+     wrong target failed before build while all five panes and `misc:0.0`
+     remained unchanged. The active follow-up composes the existing exact-pane
+     executor and bounded collector over one exact restart-through-observation
+     window without force escalation or report files.
 
-   Remaining refinements: review and deploy the active safe pull/build slice;
-   post-restart smoke orchestration remains open, as does any separately
-   reviewed force-escalation policy.
+   Remaining refinements: review and deploy the active post-restart smoke
+   orchestration slice. Remote-host control and any force-escalation policy
+   remain separate review boundaries.
    The concise and brief summaries are intentionally bounded; further changes
    should target missing smoke fields rather than larger chat-facing payloads.
    2026-06-26 VPS5 deploy evidence: after PR #709, one Ctrl+C round stopped

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -508,6 +508,31 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   run bounded local `tmux`, `ps`, and `git` inventory reads; it does not SSH,
   pull/build, contact a network or exchange, access credentials, signal/start
   processes, or perform force escalation. Use `--compact` for single-line JSON.
+- `passivbot tool live-restart-smoke-run SUPERVISOR_CONFIG MONITOR_ROOT
+  --session-name SESSION --expected-repository-head COMMIT
+  --expected-rust-source-fingerprint SHA256
+  --expected-supervisor-fingerprint SHA256 --expected-targets N --execute`
+  composes the existing exact-pane restart executor and bounded in-memory smoke
+  collector into one local operation. Before any signal it independently
+  requires a complete stable target sample with the exact caller-confirmed
+  target count and private supervisor-command fingerprint; the executor then
+  rechecks the clean repository head, Rust source and loaded-extension stamp,
+  supervisor contract, and exact pane/process identities at its own action
+  boundaries. A green restart must account for every expected target as stop
+  requested, exited, relaunch requested, relaunch succeeded, and stably
+  verified. The orchestrator then waits one bounded observation interval
+  (`--smoke-wait-s`, default 600 seconds, maximum 1,800) and evaluates the exact
+  restart-through-observation epoch-millisecond window. It performs no polling
+  retry loop and no automatic force escalation. A pre-action failure leaves
+  targets untouched; a post-action executor failure reports manual recovery;
+  and a red or unavailable smoke report leaves relaunched bots running while
+  returning `restart_completed_smoke_failed`. Output includes only aggregate
+  restart counts and the existing sanitized collector projection, never target
+  names, pane IDs, process IDs, commands, paths, fingerprints, or raw reports.
+  The tool does not SSH, pull/build, access credentials or exchanges directly,
+  use broad process-pattern signals, or write report files. The configured live
+  bots resume their normal exchange access and runtime file writes after
+  relaunch.
 - `passivbot tool live-performance-report` summarizes local live monitor event timings for
   operator performance analysis. It is read-only and does not contact exchanges. Use
   `--recent-minutes` for a time window, `--summary` for a bounded operator projection, and

--- a/src/live/restart_smoke_orchestrator.py
+++ b/src/live/restart_smoke_orchestrator.py
@@ -1,0 +1,498 @@
+from __future__ import annotations
+
+import math
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+# isort: off
+from live.restart_executor import (
+    DEFAULT_POLL_INTERVAL_S,
+    DEFAULT_PREFLIGHT_INTERVAL_S,
+    DEFAULT_PREFLIGHT_SAMPLES,
+    DEFAULT_SHUTDOWN_TIMEOUT_S,
+    DEFAULT_STARTUP_TIMEOUT_S,
+    DEFAULT_VERIFICATION_INTERVAL_S,
+    DEFAULT_VERIFICATION_SAMPLES,
+    execute_live_restart,
+)
+from live.restart_smoke_collection import (
+    DEFAULT_TARGET_SAMPLE_INTERVAL_S,
+    DEFAULT_TARGET_SAMPLES,
+    build_live_restart_smoke_collection,
+)
+from live.restart_smoke_evidence import (
+    validate_live_restart_smoke_expectations,
+)
+from live.restart_smoke_targets import (
+    MAX_TARGET_SAMPLE_INTERVAL_S,
+    MAX_TARGET_SAMPLES,
+    build_live_restart_target_report,
+)
+# isort: on
+
+DEFAULT_SMOKE_WAIT_S = 600.0
+MAX_SMOKE_WAIT_S = 1800.0
+_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+_RESTART_OUTCOMES = frozenset(
+    {
+        "completed",
+        "manual_recovery_required",
+        "preflight_failed",
+        "recovered_with_errors",
+        "restart_in_progress",
+    }
+)
+
+SAFETY_CONTRACT = {
+    "local_only": True,
+    "ssh": False,
+    "git_pull": False,
+    "builds": False,
+    "direct_network_access": False,
+    "direct_exchange_access": False,
+    "credential_store_access": False,
+    "signals_live_processes": True,
+    "starts_live_processes": True,
+    "configured_live_processes_may_contact_exchanges": True,
+    "configured_live_processes_may_write_files": True,
+    "signals_exact_tmux_panes_only": True,
+    "automatic_force_signal": False,
+    "broad_process_pattern_signals": False,
+    "post_restart_collection_read_only": True,
+    "writes_report_files": False,
+    "requires_execute_confirmation": True,
+    "requires_expected_repository_head": True,
+    "requires_expected_rust_source_fingerprint": True,
+    "requires_expected_supervisor_fingerprint": True,
+    "requires_expected_targets": True,
+}
+
+
+def _bounded_smoke_wait(value: float) -> float:
+    if isinstance(value, bool):
+        raise ValueError(
+            "smoke_wait_s must be greater than 0 and at most "
+            f"{MAX_SMOKE_WAIT_S:g}"
+        )
+    wait_s = float(value)
+    if (
+        not math.isfinite(wait_s)
+        or wait_s <= 0.0
+        or wait_s > MAX_SMOKE_WAIT_S
+    ):
+        raise ValueError(
+            "smoke_wait_s must be greater than 0 and at most "
+            f"{MAX_SMOKE_WAIT_S:g}"
+        )
+    return wait_s
+
+
+def _required_text(value: str | Path, *, field: str) -> str:
+    if value is None:
+        raise ValueError(f"{field} must be non-empty")
+    text = str(value).strip()
+    if not text:
+        raise ValueError(f"{field} must be non-empty")
+    return text
+
+
+def _validate_smoke_collection_options(
+    *,
+    target_samples: int,
+    target_sample_interval_s: float,
+) -> None:
+    if (
+        type(target_samples) is not int
+        or target_samples < 2
+        or target_samples > MAX_TARGET_SAMPLES
+    ):
+        raise ValueError(
+            f"smoke_target_samples must be between 2 and {MAX_TARGET_SAMPLES}"
+        )
+    if (
+        not isinstance(target_sample_interval_s, (int, float))
+        or isinstance(target_sample_interval_s, bool)
+        or not math.isfinite(target_sample_interval_s)
+        or target_sample_interval_s < 0.0
+        or target_sample_interval_s > MAX_TARGET_SAMPLE_INTERVAL_S
+    ):
+        raise ValueError(
+            "smoke_target_interval_s must be between 0 and "
+            f"{MAX_TARGET_SAMPLE_INTERVAL_S:g}"
+        )
+
+
+def _valid_rust_fingerprint(value: str) -> str:
+    fingerprint = str(value or "").strip()
+    if not _SHA256_PATTERN.fullmatch(fingerprint):
+        raise ValueError(
+            "expected_rust_source_fingerprint must be 64 lowercase hex "
+            "characters"
+        )
+    return fingerprint
+
+
+def _exact_int(value: Any, expected: int) -> bool:
+    return type(value) is int and value == expected
+
+
+def _epoch_ms() -> int:
+    return time.time_ns() // 1_000_000
+
+
+def _target_preflight_ok(
+    report: dict[str, Any],
+    *,
+    expected_targets: int,
+    expected_supervisor_fingerprint: str,
+) -> bool:
+    issues = report.get("issues")
+    extra_panes = report.get("extra_panes")
+    targets = report.get("targets")
+    sampling = report.get("sampling")
+    sampling = sampling if isinstance(sampling, dict) else {}
+    contract = report.get("supervisor_contract")
+    contract = contract if isinstance(contract, dict) else {}
+    return bool(
+        report.get("tool") == "live-restart-target-report"
+        and _exact_int(report.get("schema_version"), 1)
+        and report.get("ok") is True
+        and _exact_int(report.get("hard_failures"), 0)
+        and issues == []
+        and extra_panes == []
+        and isinstance(targets, list)
+        and len(targets) == expected_targets
+        and _exact_int(report.get("expected_targets"), expected_targets)
+        and _exact_int(report.get("resolved_targets"), expected_targets)
+        and _exact_int(
+            report.get("relaunch_ready_targets"), expected_targets
+        )
+        and _exact_int(report.get("relaunch_unready_targets"), 0)
+        and type(sampling.get("requested_samples")) is int
+        and sampling.get("requested_samples") >= 2
+        and _exact_int(
+            sampling.get("collected_samples"),
+            sampling["requested_samples"],
+        )
+        and _exact_int(
+            sampling.get("successful_samples"),
+            sampling["requested_samples"],
+        )
+        and _exact_int(sampling.get("failed_samples"), 0)
+        and sampling.get("failed_sample_issues") == []
+        and sampling.get("stable") is True
+        and sampling.get("supervisor_contract_stable") is True
+        and sampling.get("supervisor_contract_changed") is False
+        and _exact_int(sampling.get("stable_targets"), expected_targets)
+        and _exact_int(sampling.get("changed_target_count"), 0)
+        and _exact_int(sampling.get("changed_targets_truncated"), 0)
+        and sampling.get("changed_targets") == []
+        and contract.get("fingerprint") == expected_supervisor_fingerprint
+        and contract.get("source") == "parsed_supervisor_config"
+        and contract.get("algorithm") == "sha256"
+        and _exact_int(contract.get("target_count"), expected_targets)
+        and contract.get("command_content_exposed") is False
+    )
+
+
+def _strict_nonnegative_int(value: Any) -> int | None:
+    if type(value) is not int or value < 0:
+        return None
+    return value
+
+
+def _restart_summary(
+    report: dict[str, Any],
+    *,
+    expected_targets: int,
+    expected_supervisor_fingerprint: str,
+) -> dict[str, Any]:
+    targets = report.get("targets")
+    target_rows = targets if isinstance(targets, list) else []
+    verification = report.get("verification")
+    verification = verification if isinstance(verification, dict) else {}
+    verification_contract = verification.get("supervisor_contract")
+    verification_contract = (
+        verification_contract
+        if isinstance(verification_contract, dict)
+        else {}
+    )
+    hard_failures = _strict_nonnegative_int(report.get("hard_failures"))
+    verified_targets = _strict_nonnegative_int(
+        verification.get("resolved_targets")
+    )
+    target_counts = {
+        "targets": len(target_rows),
+        "stop_requested": sum(
+            row.get("stop_requested") is True
+            for row in target_rows
+            if isinstance(row, dict)
+        ),
+        "exited": sum(
+            row.get("exited") is True
+            for row in target_rows
+            if isinstance(row, dict)
+        ),
+        "relaunch_requested": sum(
+            row.get("relaunch_requested") is True
+            for row in target_rows
+            if isinstance(row, dict)
+        ),
+        "relaunch_succeeded": sum(
+            row.get("relaunch_succeeded") is True
+            for row in target_rows
+            if isinstance(row, dict)
+        ),
+        "verified_targets": verified_targets,
+    }
+    report_shape_valid = bool(
+        report.get("tool") == "live-restart-executor"
+        and _exact_int(report.get("schema_version"), 3)
+        and report.get("outcome") in _RESTART_OUTCOMES
+        and type(report.get("action_started")) is bool
+        and hard_failures is not None
+        and isinstance(report.get("issues"), list)
+        and isinstance(targets, list)
+        and all(isinstance(row, dict) for row in target_rows)
+    )
+    completed_contract_valid = bool(
+        report_shape_valid
+        and report.get("outcome") == "completed"
+        and report.get("action_started") is True
+        and hard_failures == 0
+        and report.get("issues") == []
+        and all(count == expected_targets for count in target_counts.values())
+        and verification.get("ok") is True
+        and _exact_int(verification.get("hard_failures"), 0)
+        and _exact_int(
+            verification.get("expected_targets"), expected_targets
+        )
+        and _exact_int(
+            verification.get("relaunch_ready_targets"), expected_targets
+        )
+        and verification_contract.get("fingerprint")
+        == expected_supervisor_fingerprint
+        and _exact_int(
+            verification_contract.get("target_count"), expected_targets
+        )
+        and verification_contract.get("command_content_exposed") is False
+    )
+    contract_valid = bool(
+        report_shape_valid
+        and (
+            completed_contract_valid
+            if report.get("ok") is True
+            else hard_failures > 0
+        )
+    )
+    return {
+        "ok": report.get("ok") is True and completed_contract_valid,
+        "contract_valid": contract_valid,
+        "outcome": (
+            report.get("outcome")
+            if report.get("outcome") in _RESTART_OUTCOMES
+            else None
+        ),
+        "action_started": report.get("action_started") is True,
+        "hard_failures": hard_failures,
+        **target_counts,
+        "verification_ok": verification.get("ok") is True,
+    }
+
+
+def _issue(code: str, **fields: Any) -> dict[str, Any]:
+    return {"code": code, "severity": "error", **fields}
+
+
+def _finish_report(report: dict[str, Any]) -> dict[str, Any]:
+    issues = report.get("issues")
+    issue_rows = issues if isinstance(issues, list) else []
+    report["hard_failures"] = len(issue_rows)
+    return report
+
+
+def _smoke_collection_contract_valid(report: dict[str, Any]) -> bool:
+    hard_failures = _strict_nonnegative_int(report.get("hard_failures"))
+    issues = report.get("issues")
+    return bool(
+        report.get("tool") == "live-restart-smoke-collect"
+        and _exact_int(report.get("schema_version"), 1)
+        and type(report.get("ok")) is bool
+        and hard_failures is not None
+        and isinstance(issues, list)
+        and all(isinstance(issue, dict) for issue in issues)
+        and isinstance(report.get("gates"), dict)
+        and isinstance(report.get("evidence"), dict)
+        and (
+            hard_failures == 0 and issues == []
+            if report.get("ok") is True
+            else hard_failures > 0
+        )
+    )
+
+
+def execute_live_restart_smoke(
+    supervisor_config: str | Path,
+    *,
+    session_name: str,
+    monitor_root: str | Path,
+    expected_repository_head: str,
+    expected_rust_source_fingerprint: str,
+    expected_supervisor_fingerprint: str,
+    expected_targets: int,
+    logs_root: str | Path | None = None,
+    smoke_wait_s: float = DEFAULT_SMOKE_WAIT_S,
+    preflight_samples: int = DEFAULT_PREFLIGHT_SAMPLES,
+    preflight_interval_s: float = DEFAULT_PREFLIGHT_INTERVAL_S,
+    shutdown_timeout_s: float = DEFAULT_SHUTDOWN_TIMEOUT_S,
+    startup_timeout_s: float = DEFAULT_STARTUP_TIMEOUT_S,
+    poll_interval_s: float = DEFAULT_POLL_INTERVAL_S,
+    verification_samples: int = DEFAULT_VERIFICATION_SAMPLES,
+    verification_interval_s: float = DEFAULT_VERIFICATION_INTERVAL_S,
+    smoke_target_samples: int = DEFAULT_TARGET_SAMPLES,
+    smoke_target_interval_s: float = DEFAULT_TARGET_SAMPLE_INTERVAL_S,
+    execute: bool = False,
+) -> dict[str, Any]:
+    """Restart exact local targets, then collect one bounded smoke window."""
+    supervisor_config = _required_text(
+        supervisor_config, field="supervisor_config"
+    )
+    session_name = _required_text(session_name, field="session_name")
+    monitor_root = _required_text(monitor_root, field="monitor_root")
+    if logs_root is not None:
+        logs_root = _required_text(logs_root, field="logs_root")
+    validate_live_restart_smoke_expectations(
+        expected_repository_head=expected_repository_head,
+        expected_supervisor_fingerprint=expected_supervisor_fingerprint,
+        expected_targets=expected_targets,
+    )
+    rust_fingerprint = _valid_rust_fingerprint(
+        expected_rust_source_fingerprint
+    )
+    wait_s = _bounded_smoke_wait(smoke_wait_s)
+    _validate_smoke_collection_options(
+        target_samples=smoke_target_samples,
+        target_sample_interval_s=smoke_target_interval_s,
+    )
+    if not execute:
+        raise ValueError("execute must be true")
+
+    report: dict[str, Any] = {
+        "tool": "live-restart-smoke-run",
+        "schema_version": 1,
+        "ok": False,
+        "outcome": "preflight_failed",
+        "action_started": False,
+        "hard_failures": 0,
+        "restart": None,
+        "smoke": None,
+        "window": None,
+        "issues": [],
+        "safety": dict(SAFETY_CONTRACT),
+    }
+    issues: list[dict[str, Any]] = report["issues"]
+    preflight = build_live_restart_target_report(
+        supervisor_config,
+        session_name=session_name,
+        config_base_dir=Path.cwd(),
+        samples=preflight_samples,
+        sample_interval_s=preflight_interval_s,
+    )
+    if not _target_preflight_ok(
+        preflight,
+        expected_targets=expected_targets,
+        expected_supervisor_fingerprint=expected_supervisor_fingerprint,
+    ):
+        issues.append(_issue("target_preflight_failed"))
+        return _finish_report(report)
+
+    since_ms = _epoch_ms()
+    restart = execute_live_restart(
+        supervisor_config,
+        session_name=session_name,
+        expected_supervisor_fingerprint=expected_supervisor_fingerprint,
+        expected_repository_head=expected_repository_head,
+        expected_rust_source_fingerprint=rust_fingerprint,
+        config_base_dir=Path.cwd(),
+        preflight_samples=preflight_samples,
+        preflight_interval_s=preflight_interval_s,
+        shutdown_timeout_s=shutdown_timeout_s,
+        startup_timeout_s=startup_timeout_s,
+        poll_interval_s=poll_interval_s,
+        verification_samples=verification_samples,
+        verification_interval_s=verification_interval_s,
+        execute=True,
+    )
+    restart_summary = _restart_summary(
+        restart,
+        expected_targets=expected_targets,
+        expected_supervisor_fingerprint=expected_supervisor_fingerprint,
+    )
+    report["restart"] = restart_summary
+    report["action_started"] = restart_summary["action_started"]
+    if not restart_summary["ok"]:
+        report["outcome"] = (
+            "manual_recovery_required"
+            if restart_summary["action_started"]
+            else "preflight_failed"
+        )
+        issues.append(
+            _issue(
+                "restart_failed"
+                if restart_summary["contract_valid"]
+                else "restart_contract_invalid"
+            )
+        )
+        return _finish_report(report)
+
+    report["outcome"] = "restart_completed_smoke_pending"
+    time.sleep(wait_s)
+    until_ms = _epoch_ms()
+    report["window"] = {
+        "since_ms": since_ms,
+        "until_ms": until_ms,
+        "observation_wait_s": wait_s,
+    }
+    if until_ms <= since_ms:
+        report["outcome"] = "restart_completed_smoke_failed"
+        issues.append(_issue("smoke_window_clock_invalid"))
+        return _finish_report(report)
+
+    try:
+        smoke = build_live_restart_smoke_collection(
+            supervisor_config,
+            session_name=session_name,
+            monitor_root=monitor_root,
+            logs_root=logs_root,
+            expected_repository_head=expected_repository_head,
+            expected_supervisor_fingerprint=expected_supervisor_fingerprint,
+            expected_targets=expected_targets,
+            since_ms=since_ms,
+            until_ms=until_ms,
+            target_samples=smoke_target_samples,
+            target_sample_interval_s=smoke_target_interval_s,
+        )
+    except (OSError, RuntimeError, ValueError) as exc:
+        report["outcome"] = "restart_completed_smoke_failed"
+        issues.append(
+            _issue(
+                "smoke_collection_failed",
+                error_class=exc.__class__.__name__,
+            )
+        )
+        return _finish_report(report)
+    if not _smoke_collection_contract_valid(smoke):
+        report["outcome"] = "restart_completed_smoke_failed"
+        issues.append(_issue("smoke_contract_invalid"))
+        return _finish_report(report)
+    report["smoke"] = smoke
+    if smoke.get("ok") is not True:
+        report["outcome"] = "restart_completed_smoke_failed"
+        issues.append(_issue("smoke_failed"))
+        return _finish_report(report)
+
+    report["ok"] = True
+    report["outcome"] = "completed"
+    return _finish_report(report)

--- a/src/live/restart_smoke_orchestrator.py
+++ b/src/live/restart_smoke_orchestrator.py
@@ -143,11 +143,13 @@ def _epoch_ms() -> int:
 
 
 def _target_preflight_ok(
-    report: dict[str, Any],
+    report: Any,
     *,
     expected_targets: int,
     expected_supervisor_fingerprint: str,
 ) -> bool:
+    if not isinstance(report, dict):
+        return False
     issues = report.get("issues")
     extra_panes = report.get("extra_panes")
     targets = report.get("targets")
@@ -204,11 +206,26 @@ def _strict_nonnegative_int(value: Any) -> int | None:
 
 
 def _restart_summary(
-    report: dict[str, Any],
+    report: Any,
     *,
     expected_targets: int,
     expected_supervisor_fingerprint: str,
 ) -> dict[str, Any]:
+    if not isinstance(report, dict):
+        return {
+            "ok": False,
+            "contract_valid": False,
+            "outcome": None,
+            "action_started": True,
+            "hard_failures": None,
+            "targets": 0,
+            "stop_requested": 0,
+            "exited": 0,
+            "relaunch_requested": 0,
+            "relaunch_succeeded": 0,
+            "verified_targets": None,
+            "verification_ok": False,
+        }
     targets = report.get("targets")
     target_rows = targets if isinstance(targets, list) else []
     verification = report.get("verification")
@@ -220,6 +237,12 @@ def _restart_summary(
         else {}
     )
     hard_failures = _strict_nonnegative_int(report.get("hard_failures"))
+    action_started_value = report.get("action_started")
+    action_started = (
+        action_started_value
+        if type(action_started_value) is bool
+        else True
+    )
     verified_targets = _strict_nonnegative_int(
         verification.get("resolved_targets")
     )
@@ -295,7 +318,7 @@ def _restart_summary(
             if report.get("outcome") in _RESTART_OUTCOMES
             else None
         ),
-        "action_started": report.get("action_started") is True,
+        "action_started": action_started,
         "hard_failures": hard_failures,
         **target_counts,
         "verification_ok": verification.get("ok") is True,
@@ -313,7 +336,9 @@ def _finish_report(report: dict[str, Any]) -> dict[str, Any]:
     return report
 
 
-def _smoke_collection_contract_valid(report: dict[str, Any]) -> bool:
+def _smoke_collection_contract_valid(report: Any) -> bool:
+    if not isinstance(report, dict):
+        return False
     hard_failures = _strict_nonnegative_int(report.get("hard_failures"))
     issues = report.get("issues")
     return bool(

--- a/src/passivbot_cli/main.py
+++ b/src/passivbot_cli/main.py
@@ -156,6 +156,10 @@ TOOL_COMMANDS: dict[str, CommandSpec] = {
         "tools.live_restart_smoke_collection",
         "collect and evaluate bounded local restart smoke evidence",
     ),
+    "live-restart-smoke-run": CommandSpec(
+        "tools.live_restart_smoke_run",
+        "restart exact local targets and collect bounded smoke evidence",
+    ),
     "live-restart-executor": CommandSpec(
         "tools.live_restart_executor",
         "gracefully restart exact verified local tmux targets",

--- a/src/tools/live_restart_smoke_run.py
+++ b/src/tools/live_restart_smoke_run.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SRC_ROOT = Path(__file__).resolve().parents[1]
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from live.restart_smoke_orchestrator import (  # noqa: E402  # isort: skip
+    DEFAULT_SMOKE_WAIT_S,
+    execute_live_restart_smoke,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="passivbot tool live-restart-smoke-run",
+        description=(
+            "Restart exact verified local tmux targets and collect one "
+            "bounded post-restart smoke window without pull/build or force "
+            "escalation."
+        ),
+    )
+    parser.add_argument("supervisor_config")
+    parser.add_argument("monitor_root")
+    parser.add_argument("--session-name", required=True)
+    parser.add_argument("--logs-root")
+    parser.add_argument("--expected-repository-head", required=True)
+    parser.add_argument("--expected-rust-source-fingerprint", required=True)
+    parser.add_argument("--expected-supervisor-fingerprint", required=True)
+    parser.add_argument("--expected-targets", required=True, type=int)
+    parser.add_argument(
+        "--smoke-wait-s", type=float, default=DEFAULT_SMOKE_WAIT_S
+    )
+    parser.add_argument("--shutdown-timeout-s", type=float, default=90.0)
+    parser.add_argument("--startup-timeout-s", type=float, default=180.0)
+    parser.add_argument("--poll-interval-s", type=float, default=2.0)
+    parser.add_argument("--preflight-samples", type=int, default=3)
+    parser.add_argument("--preflight-interval-s", type=float, default=5.0)
+    parser.add_argument("--verification-samples", type=int, default=3)
+    parser.add_argument("--verification-interval-s", type=float, default=5.0)
+    parser.add_argument("--smoke-target-samples", type=int, default=3)
+    parser.add_argument("--smoke-target-interval-s", type=float, default=1.0)
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--compact", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not args.execute:
+        parser.error("--execute is required")
+    try:
+        report = execute_live_restart_smoke(
+            args.supervisor_config,
+            session_name=args.session_name,
+            monitor_root=args.monitor_root,
+            logs_root=args.logs_root,
+            expected_repository_head=args.expected_repository_head,
+            expected_rust_source_fingerprint=(
+                args.expected_rust_source_fingerprint
+            ),
+            expected_supervisor_fingerprint=(
+                args.expected_supervisor_fingerprint
+            ),
+            expected_targets=args.expected_targets,
+            smoke_wait_s=args.smoke_wait_s,
+            shutdown_timeout_s=args.shutdown_timeout_s,
+            startup_timeout_s=args.startup_timeout_s,
+            poll_interval_s=args.poll_interval_s,
+            preflight_samples=args.preflight_samples,
+            preflight_interval_s=args.preflight_interval_s,
+            verification_samples=args.verification_samples,
+            verification_interval_s=args.verification_interval_s,
+            smoke_target_samples=args.smoke_target_samples,
+            smoke_target_interval_s=args.smoke_target_interval_s,
+            execute=True,
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
+    print(
+        json.dumps(
+            report,
+            indent=None if args.compact else 2,
+            sort_keys=True,
+        )
+    )
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_live_restart_smoke_orchestrator.py
+++ b/tests/test_live_restart_smoke_orchestrator.py
@@ -344,6 +344,29 @@ def test_malformed_executor_outcome_is_not_projected(monkeypatch):
     assert calls["smoke"] == []
 
 
+@pytest.mark.parametrize("malformed", [None, [], {"ok": True}])
+def test_malformed_executor_shape_requires_manual_recovery(
+    monkeypatch, malformed
+):
+    calls = _install_happy_dependencies(monkeypatch)
+    monkeypatch.setattr(
+        orchestrator_module,
+        "execute_live_restart",
+        lambda *_args, **_kwargs: malformed,
+    )
+
+    report = execute_live_restart_smoke(**_kwargs())
+
+    assert report["outcome"] == "manual_recovery_required"
+    assert report["action_started"] is True
+    assert report["restart"]["contract_valid"] is False
+    assert report["issues"] == [
+        {"code": "restart_contract_invalid", "severity": "error"}
+    ]
+    assert calls["sleep"] == []
+    assert calls["smoke"] == []
+
+
 def test_red_smoke_leaves_restart_complete_and_returns_red(monkeypatch):
     calls = _install_happy_dependencies(monkeypatch)
     monkeypatch.setattr(
@@ -379,6 +402,22 @@ def test_malformed_smoke_report_is_not_projected(monkeypatch):
     assert report["issues"] == [
         {"code": "smoke_contract_invalid", "severity": "error"}
     ]
+    assert "private-monitor-path" not in json.dumps(report, sort_keys=True)
+    assert calls["sleep"] == [10.0]
+
+
+def test_non_mapping_smoke_report_is_not_projected(monkeypatch):
+    calls = _install_happy_dependencies(monkeypatch)
+    monkeypatch.setattr(
+        orchestrator_module,
+        "build_live_restart_smoke_collection",
+        lambda *_args, **_kwargs: ["private-monitor-path"],
+    )
+
+    report = execute_live_restart_smoke(**_kwargs())
+
+    assert report["outcome"] == "restart_completed_smoke_failed"
+    assert report["smoke"] is None
     assert "private-monitor-path" not in json.dumps(report, sort_keys=True)
     assert calls["sleep"] == [10.0]
 

--- a/tests/test_live_restart_smoke_orchestrator.py
+++ b/tests/test_live_restart_smoke_orchestrator.py
@@ -1,0 +1,568 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+import live.restart_smoke_orchestrator as orchestrator_module
+from live.restart_smoke_orchestrator import execute_live_restart_smoke
+from passivbot_cli import main as cli_main
+from tools import live_restart_smoke_run
+
+HEAD = "a" * 40
+RUST_FINGERPRINT = "b" * 64
+SUPERVISOR_FINGERPRINT = "c" * 64
+TARGETS = 2
+
+
+def _target_preflight() -> dict:
+    return {
+        "tool": "live-restart-target-report",
+        "schema_version": 1,
+        "ok": True,
+        "hard_failures": 0,
+        "issues": [],
+        "extra_panes": [],
+        "expected_targets": TARGETS,
+        "resolved_targets": TARGETS,
+        "relaunch_ready_targets": TARGETS,
+        "relaunch_unready_targets": 0,
+        "supervisor_contract": {
+            "source": "parsed_supervisor_config",
+            "algorithm": "sha256",
+            "fingerprint": SUPERVISOR_FINGERPRINT,
+            "target_count": TARGETS,
+            "command_content_exposed": False,
+        },
+        "sampling": {
+            "requested_samples": 3,
+            "collected_samples": 3,
+            "successful_samples": 3,
+            "failed_samples": 0,
+            "failed_sample_issues": [],
+            "stable": True,
+            "supervisor_contract_stable": True,
+            "supervisor_contract_changed": False,
+            "stable_targets": TARGETS,
+            "changed_target_count": 0,
+            "changed_targets_truncated": 0,
+            "changed_targets": [],
+        },
+        "targets": [
+            {
+                "window_name": "private_bot_one",
+                "pane_id": "%100",
+                "process_pid": 1000,
+            },
+            {
+                "window_name": "private_bot_two",
+                "pane_id": "%101",
+                "process_pid": 1001,
+            },
+        ],
+    }
+
+
+def _restart_report(*, ok: bool = True, action_started: bool = True) -> dict:
+    issues = [] if ok else [{"code": "restart_problem", "severity": "error"}]
+    rows = [
+        {
+            "window_name": f"private_bot_{index}",
+            "pane_id": f"%{100 + index}",
+            "old_process_pid": 1000 + index,
+            "stop_requested": True,
+            "exited": True,
+            "relaunch_requested": True,
+            "relaunch_succeeded": True,
+        }
+        for index in range(TARGETS)
+    ]
+    return {
+        "tool": "live-restart-executor",
+        "schema_version": 3,
+        "ok": ok,
+        "outcome": (
+            "completed"
+            if ok
+            else (
+                "manual_recovery_required"
+                if action_started
+                else "preflight_failed"
+            )
+        ),
+        "action_started": action_started,
+        "hard_failures": 0 if ok else 1,
+        "issues": issues,
+        "targets": rows if action_started else [],
+        "verification": (
+            {
+                "ok": True,
+                "hard_failures": 0,
+                "expected_targets": TARGETS,
+                "resolved_targets": TARGETS,
+                "relaunch_ready_targets": TARGETS,
+                "supervisor_contract": {
+                    "fingerprint": SUPERVISOR_FINGERPRINT,
+                    "target_count": TARGETS,
+                    "command_content_exposed": False,
+                },
+            }
+            if ok
+            else {}
+        ),
+        "private_command": "passivbot live private-account",
+    }
+
+
+def _smoke_report(*, ok: bool = True) -> dict:
+    return {
+        "tool": "live-restart-smoke-collect",
+        "schema_version": 1,
+        "ok": ok,
+        "hard_failures": 0 if ok else 1,
+        "issues": [] if ok else [{"code": "startup_event_missing"}],
+        "gates": {"repository": {"ok": ok}},
+        "evidence": {"startup": {"targets": TARGETS if ok else 1}},
+    }
+
+
+def _kwargs() -> dict:
+    return {
+        "supervisor_config": "private-supervisor.yaml",
+        "session_name": "private-session",
+        "monitor_root": "private-monitor",
+        "logs_root": "private-logs",
+        "expected_repository_head": HEAD,
+        "expected_rust_source_fingerprint": RUST_FINGERPRINT,
+        "expected_supervisor_fingerprint": SUPERVISOR_FINGERPRINT,
+        "expected_targets": TARGETS,
+        "smoke_wait_s": 10.0,
+        "preflight_samples": 3,
+        "preflight_interval_s": 0.5,
+        "shutdown_timeout_s": 20.0,
+        "startup_timeout_s": 30.0,
+        "poll_interval_s": 0.25,
+        "verification_samples": 3,
+        "verification_interval_s": 0.5,
+        "smoke_target_samples": 3,
+        "smoke_target_interval_s": 0.25,
+        "execute": True,
+    }
+
+
+def _install_happy_dependencies(monkeypatch) -> dict[str, list]:
+    calls: dict[str, list] = {
+        "target": [],
+        "restart": [],
+        "sleep": [],
+        "smoke": [],
+    }
+    clock = iter([1_000_000, 1_010_000])
+    monkeypatch.setattr(orchestrator_module, "_epoch_ms", lambda: next(clock))
+    monkeypatch.setattr(
+        orchestrator_module,
+        "build_live_restart_target_report",
+        lambda *args, **kwargs: (
+            calls["target"].append((args, kwargs)) or _target_preflight()
+        ),
+    )
+    monkeypatch.setattr(
+        orchestrator_module,
+        "execute_live_restart",
+        lambda *args, **kwargs: (
+            calls["restart"].append((args, kwargs)) or _restart_report()
+        ),
+    )
+    monkeypatch.setattr(
+        orchestrator_module.time,
+        "sleep",
+        lambda value: calls["sleep"].append(value),
+    )
+    monkeypatch.setattr(
+        orchestrator_module,
+        "build_live_restart_smoke_collection",
+        lambda *args, **kwargs: (
+            calls["smoke"].append((args, kwargs)) or _smoke_report()
+        ),
+    )
+    return calls
+
+
+def test_restart_smoke_runs_exact_sequence_and_sanitizes_restart(monkeypatch):
+    calls = _install_happy_dependencies(monkeypatch)
+
+    report = execute_live_restart_smoke(**_kwargs())
+
+    assert report["ok"] is True
+    assert report["hard_failures"] == 0
+    assert report["outcome"] == "completed"
+    assert report["action_started"] is True
+    assert report["window"] == {
+        "since_ms": 1_000_000,
+        "until_ms": 1_010_000,
+        "observation_wait_s": 10.0,
+    }
+    assert report["restart"] == {
+        "ok": True,
+        "contract_valid": True,
+        "outcome": "completed",
+        "action_started": True,
+        "hard_failures": 0,
+        "targets": TARGETS,
+        "stop_requested": TARGETS,
+        "exited": TARGETS,
+        "relaunch_requested": TARGETS,
+        "relaunch_succeeded": TARGETS,
+        "verified_targets": TARGETS,
+        "verification_ok": True,
+    }
+    assert calls["sleep"] == [10.0]
+    assert calls["target"][0][1] == {
+        "session_name": "private-session",
+        "config_base_dir": orchestrator_module.Path.cwd(),
+        "samples": 3,
+        "sample_interval_s": 0.5,
+    }
+    assert calls["restart"][0][1]["execute"] is True
+    assert calls["smoke"][0][1]["since_ms"] == 1_000_000
+    assert calls["smoke"][0][1]["until_ms"] == 1_010_000
+    serialized = json.dumps(report, sort_keys=True)
+    for private_value in (
+        "private-supervisor.yaml",
+        "private-session",
+        "private-monitor",
+        "private-logs",
+        "private_bot_one",
+        "%100",
+        "old_process_pid",
+        "passivbot live private-account",
+        SUPERVISOR_FINGERPRINT,
+    ):
+        assert private_value not in serialized
+
+
+@pytest.mark.parametrize(
+    ("mutation", "value"),
+    [
+        (("resolved_targets",), 1),
+        (("issues",), [{"code": "hidden_failure"}]),
+        (("sampling", "failed_samples"), 1),
+        (("sampling", "changed_target_count"), 1),
+        (("supervisor_contract", "fingerprint"), "d" * 64),
+    ],
+)
+def test_outer_preflight_failure_prevents_action(monkeypatch, mutation, value):
+    calls = _install_happy_dependencies(monkeypatch)
+    failed = _target_preflight()
+    row = failed
+    for key in mutation[:-1]:
+        row = row[key]
+    row[mutation[-1]] = value
+    monkeypatch.setattr(
+        orchestrator_module,
+        "build_live_restart_target_report",
+        lambda *_args, **_kwargs: failed,
+    )
+
+    report = execute_live_restart_smoke(**_kwargs())
+
+    assert report["ok"] is False
+    assert report["hard_failures"] == 1
+    assert report["outcome"] == "preflight_failed"
+    assert report["issues"] == [
+        {"code": "target_preflight_failed", "severity": "error"}
+    ]
+    assert calls["restart"] == []
+    assert calls["sleep"] == []
+    assert calls["smoke"] == []
+
+
+@pytest.mark.parametrize("action_started", [False, True])
+def test_executor_failure_skips_sleep_and_collection(
+    monkeypatch, action_started
+):
+    calls = _install_happy_dependencies(monkeypatch)
+    monkeypatch.setattr(
+        orchestrator_module,
+        "execute_live_restart",
+        lambda *_args, **_kwargs: _restart_report(
+            ok=False, action_started=action_started
+        ),
+    )
+
+    report = execute_live_restart_smoke(**_kwargs())
+
+    assert report["outcome"] == (
+        "manual_recovery_required" if action_started else "preflight_failed"
+    )
+    assert report["issues"] == [
+        {"code": "restart_failed", "severity": "error"}
+    ]
+    assert calls["sleep"] == []
+    assert calls["smoke"] == []
+
+
+def test_malformed_green_executor_report_requires_manual_recovery(monkeypatch):
+    calls = _install_happy_dependencies(monkeypatch)
+    malformed = _restart_report()
+    malformed["targets"][0]["relaunch_succeeded"] = False
+    monkeypatch.setattr(
+        orchestrator_module,
+        "execute_live_restart",
+        lambda *_args, **_kwargs: malformed,
+    )
+
+    report = execute_live_restart_smoke(**_kwargs())
+
+    assert report["outcome"] == "manual_recovery_required"
+    assert report["restart"]["contract_valid"] is False
+    assert report["issues"] == [
+        {"code": "restart_contract_invalid", "severity": "error"}
+    ]
+    assert calls["sleep"] == []
+    assert calls["smoke"] == []
+
+
+def test_malformed_executor_outcome_is_not_projected(monkeypatch):
+    calls = _install_happy_dependencies(monkeypatch)
+    malformed = _restart_report()
+    malformed["outcome"] = "private-account-name"
+    monkeypatch.setattr(
+        orchestrator_module,
+        "execute_live_restart",
+        lambda *_args, **_kwargs: malformed,
+    )
+
+    report = execute_live_restart_smoke(**_kwargs())
+
+    assert report["restart"]["outcome"] is None
+    assert report["restart"]["contract_valid"] is False
+    assert "private-account-name" not in json.dumps(report, sort_keys=True)
+    assert calls["sleep"] == []
+    assert calls["smoke"] == []
+
+
+def test_red_smoke_leaves_restart_complete_and_returns_red(monkeypatch):
+    calls = _install_happy_dependencies(monkeypatch)
+    monkeypatch.setattr(
+        orchestrator_module,
+        "build_live_restart_smoke_collection",
+        lambda *_args, **_kwargs: _smoke_report(ok=False),
+    )
+
+    report = execute_live_restart_smoke(**_kwargs())
+
+    assert report["ok"] is False
+    assert report["action_started"] is True
+    assert report["outcome"] == "restart_completed_smoke_failed"
+    assert report["issues"] == [{"code": "smoke_failed", "severity": "error"}]
+    assert calls["sleep"] == [10.0]
+
+
+def test_malformed_smoke_report_is_not_projected(monkeypatch):
+    calls = _install_happy_dependencies(monkeypatch)
+    malformed = _smoke_report()
+    malformed["schema_version"] = True
+    malformed["private_value"] = "private-monitor-path"
+    monkeypatch.setattr(
+        orchestrator_module,
+        "build_live_restart_smoke_collection",
+        lambda *_args, **_kwargs: malformed,
+    )
+
+    report = execute_live_restart_smoke(**_kwargs())
+
+    assert report["outcome"] == "restart_completed_smoke_failed"
+    assert report["smoke"] is None
+    assert report["issues"] == [
+        {"code": "smoke_contract_invalid", "severity": "error"}
+    ]
+    assert "private-monitor-path" not in json.dumps(report, sort_keys=True)
+    assert calls["sleep"] == [10.0]
+
+
+def test_smoke_collection_error_is_sanitized_after_restart(monkeypatch):
+    calls = _install_happy_dependencies(monkeypatch)
+
+    def fail_collection(*_args, **_kwargs):
+        raise OSError("private-monitor-path")
+
+    monkeypatch.setattr(
+        orchestrator_module,
+        "build_live_restart_smoke_collection",
+        fail_collection,
+    )
+
+    report = execute_live_restart_smoke(**_kwargs())
+
+    assert report["outcome"] == "restart_completed_smoke_failed"
+    assert report["issues"] == [
+        {
+            "code": "smoke_collection_failed",
+            "severity": "error",
+            "error_class": "OSError",
+        }
+    ]
+    assert "private-monitor-path" not in json.dumps(report, sort_keys=True)
+    assert calls["sleep"] == [10.0]
+
+
+def test_nonadvancing_clock_skips_collection(monkeypatch):
+    calls = _install_happy_dependencies(monkeypatch)
+    clock = iter([1_000_000, 1_000_000])
+    monkeypatch.setattr(orchestrator_module, "_epoch_ms", lambda: next(clock))
+
+    report = execute_live_restart_smoke(**_kwargs())
+
+    assert report["outcome"] == "restart_completed_smoke_failed"
+    assert report["issues"] == [
+        {"code": "smoke_window_clock_invalid", "severity": "error"}
+    ]
+    assert calls["smoke"] == []
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"expected_repository_head": "bad"},
+        {"expected_rust_source_fingerprint": "bad"},
+        {"expected_supervisor_fingerprint": "bad"},
+        {"expected_targets": True},
+        {"monitor_root": ""},
+        {"logs_root": ""},
+        {"smoke_wait_s": 0.0},
+        {"smoke_wait_s": 1800.1},
+        {"smoke_target_samples": 1},
+        {"smoke_target_samples": True},
+        {"smoke_target_interval_s": -0.1},
+        {"smoke_target_interval_s": True},
+    ],
+)
+def test_invalid_confirmation_inputs_fail_before_preflight(
+    monkeypatch, override
+):
+    calls = _install_happy_dependencies(monkeypatch)
+    kwargs = _kwargs()
+    kwargs.update(override)
+
+    with pytest.raises(ValueError):
+        execute_live_restart_smoke(**kwargs)
+
+    assert calls["target"] == []
+    assert calls["restart"] == []
+
+
+def test_execute_confirmation_is_required_before_preflight(monkeypatch):
+    calls = _install_happy_dependencies(monkeypatch)
+    kwargs = _kwargs()
+    kwargs["execute"] = False
+
+    with pytest.raises(ValueError, match="execute must be true"):
+        execute_live_restart_smoke(**kwargs)
+
+    assert calls["target"] == []
+
+
+def test_cli_requires_execute(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        live_restart_smoke_run.main(
+            [
+                "supervisor.yaml",
+                "monitor",
+                "--session-name",
+                "passivbot",
+                "--expected-repository-head",
+                HEAD,
+                "--expected-rust-source-fingerprint",
+                RUST_FINGERPRINT,
+                "--expected-supervisor-fingerprint",
+                SUPERVISOR_FINGERPRINT,
+                "--expected-targets",
+                str(TARGETS),
+            ]
+        )
+
+    assert exc_info.value.code == 2
+    assert "--execute is required" in capsys.readouterr().err
+
+
+def test_cli_outputs_compact_report(monkeypatch, capsys):
+    green = {"tool": "live-restart-smoke-run", "ok": True}
+    monkeypatch.setattr(
+        live_restart_smoke_run,
+        "execute_live_restart_smoke",
+        lambda *_args, **_kwargs: green,
+    )
+
+    exit_code = live_restart_smoke_run.main(
+        [
+            "supervisor.yaml",
+            "monitor",
+            "--session-name",
+            "passivbot",
+            "--expected-repository-head",
+            HEAD,
+            "--expected-rust-source-fingerprint",
+            RUST_FINGERPRINT,
+            "--expected-supervisor-fingerprint",
+            SUPERVISOR_FINGERPRINT,
+            "--expected-targets",
+            str(TARGETS),
+            "--execute",
+            "--compact",
+        ]
+    )
+
+    assert exit_code == 0
+    assert capsys.readouterr().out == json.dumps(green, sort_keys=True) + "\n"
+
+
+def test_unified_cli_dispatches_restart_smoke_run(monkeypatch):
+    captured = {}
+
+    def fake_invoke_module_main(module_name):
+        captured["module_name"] = module_name
+        captured["argv"] = sys.argv[:]
+        captured["prog_env"] = os.environ.get("PASSIVBOT_CLI_PROG")
+        return True, 0
+
+    monkeypatch.setattr(
+        cli_main, "_invoke_module_main", fake_invoke_module_main
+    )
+    monkeypatch.setattr(cli_main, "_missing_full_install_markers", lambda: [])
+    argv = [
+        "tool",
+        "live-restart-smoke-run",
+        "supervisor.yaml",
+        "monitor",
+        "--session-name",
+        "passivbot",
+        "--expected-repository-head",
+        HEAD,
+        "--expected-rust-source-fingerprint",
+        RUST_FINGERPRINT,
+        "--expected-supervisor-fingerprint",
+        SUPERVISOR_FINGERPRINT,
+        "--expected-targets",
+        str(TARGETS),
+        "--execute",
+    ]
+
+    assert cli_main.main(argv) == 0
+    assert captured["module_name"] == "tools.live_restart_smoke_run"
+    assert captured["argv"][0] == "passivbot tool live-restart-smoke-run"
+    assert captured["argv"][1:] == argv[2:]
+    assert captured["prog_env"] == "passivbot tool live-restart-smoke-run"
+
+
+def test_safety_contract_keeps_force_and_broad_signals_disabled():
+    safety = orchestrator_module.SAFETY_CONTRACT
+
+    assert safety["signals_exact_tmux_panes_only"] is True
+    assert safety["automatic_force_signal"] is False
+    assert safety["broad_process_pattern_signals"] is False
+    assert safety["direct_exchange_access"] is False
+    assert safety["configured_live_processes_may_contact_exchanges"] is True
+    assert safety["writes_report_files"] is False


### PR DESCRIPTION
## Scope

Category: restart/deploy behavior.

Adds `passivbot tool live-restart-smoke-run`, which composes the existing exact-pane graceful restart executor with the existing bounded in-memory restart-smoke collector over one exact restart-through-observation window.

The orchestrator:

- requires caller-confirmed repository, Rust-source, supervisor-command, and target-count contracts
- independently requires a complete stable target sample before invoking the executor
- requires every expected target to be stopped, exited, relaunched, and stably verified before smoke collection
- waits one bounded observation interval and passes exact epoch-millisecond bounds to the collector
- emits aggregate restart counts plus the existing sanitized collector projection
- fails closed on malformed producer shapes and sanitizes bounded collector exceptions

It also records PR #1306 deploy evidence and updates the restart backlog/status/tooling docs.

## Non-goals and safety boundary

- no SSH or remote-host orchestration
- no Git pull/build; repository preparation remains owned by `live-repository-prepare`
- no direct credential or exchange access
- no broad process-pattern signals
- no SIGTERM/SIGKILL or automatic force escalation
- no smoke polling/retry loop and no report-file writes
- no trading, strategy, risk, exchange-connector, Rust, or configuration behavior changes

Configured live bots resume their normal exchange access and runtime file writes after relaunch. A post-action smoke failure leaves them running and returns a red operator result. Any force policy remains a separate review boundary.

## Expected impact

This turns the already-reviewed local restart and smoke components into one explicit, bounded operation while preserving their existing action and evidence contracts. Invalid smoke paths/options are rejected before any process action. An executor failure after action reports manual recovery and does not proceed to smoke collection.

Expected VPS action after merge: prepare the reviewed merge commit with `live-repository-prepare`, verify the exact five configured targets and private fingerprints, then run one no-force graceful restart with bounded post-restart smoke. Preserve `misc:0.0` and stop for manual recovery if graceful execution does not finish.

## Validation

- 158 focused restart/collector/target/CLI Python tests passed
- complete Python test suite passed
- 210 Rust tests passed with `passivbot-rust/cargotest.sh`
- exact local Rust source fingerprint matched the loaded extension stamp
- `flake8`, `isort --check-only`, `py_compile`, and `git diff --check` passed
- silent-handling audit found no matches in the new surface
- AI documentation check passed with 0 errors; generated event registry is current

## Review gate

While Grok remains maintainer-paused, require exact-current-head Hermes approval plus green Python 3.12 and Rust CI. Any semantic head change resets the Hermes gate.

## Reviewer focus

- all collector inputs that can fail deterministically are validated before the first possible signal
- executor success is rebound to the caller-confirmed target count and supervisor fingerprint
- malformed executor/collector reports cannot project private arbitrary text
- post-action failure classifications do not imply rollback or force recovery
