### PR TITLE
Redact cycle degradation exception payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ All notable user-facing changes will be documented in this file.
 
 - `cycle.degraded` structured events no longer retain raw exception text or
   request URLs from generic execution-loop failures or fill-history coverage
-  deferrals. Stable reason codes, bounded exception types, cycle correlation,
-  safe operational details, and phase timings remain available; retry,
-  recovery, restart, and trading behavior are unchanged.
+  deferrals. A strict payload allow-list also drops nested spelling variants and
+  unknown caller fields. Stable reason codes, bounded exception types, cycle
+  correlation, safe operational details, and phase timings remain available;
+  retry, recovery, restart, and trading behavior are unchanged.
 
 - Added `passivbot tool live-restart-smoke-run`, an explicit local orchestrator
   that requires exact repository, Rust-source, supervisor-command, and target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `cycle.degraded` structured events no longer retain raw exception text or
+  request URLs from generic execution-loop failures or fill-history coverage
+  deferrals. Stable reason codes, bounded exception types, cycle correlation,
+  safe operational details, and phase timings remain available; retry,
+  recovery, restart, and trading behavior are unchanged.
+
 - Added `passivbot tool live-restart-smoke-run`, an explicit local orchestrator
   that requires exact repository, Rust-source, supervisor-command, and target
   contracts before invoking the existing exact-pane graceful restart executor.

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -163,10 +163,11 @@ execution-loop policy.
 
 `cycle.degraded` retains the stable reason code, bounded exception type, cycle correlation, safe
 operational details, and phase timings needed to explain an incomplete live cycle. Exception text,
-request URLs, request/response payloads, and tracebacks are excluded from this event, including
-generic execution-loop failures and fill-history coverage deferrals. The existing execution-loop
-incident family remains the bounded source for safe status, code, endpoint, and action
-classifications.
+request URLs, request/response payloads, tracebacks, and unknown caller fields are excluded from
+this event, including nested spelling variants and generic execution-loop failures or fill-history
+coverage deferrals. Only the event family's bounded classification, timing, counter, authoritative
+barrier, and staged-readiness fields are retained. The existing execution-loop incident family
+remains the bounded source for safe status, code, endpoint, and action classifications.
 
 This payload boundary is observability-only. Exception propagation, retries, time-sync recovery,
 restart thresholds, fill-history refresh requests, cycle deferral, and trading behavior are

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -159,6 +159,19 @@ must not retain `latest_error`. These projections are observability-only: error 
 timestamp recovery, restart thresholds, backoff, and trading behavior remain owned by the existing
 execution-loop policy.
 
+## Cycle Degradation
+
+`cycle.degraded` retains the stable reason code, bounded exception type, cycle correlation, safe
+operational details, and phase timings needed to explain an incomplete live cycle. Exception text,
+request URLs, request/response payloads, and tracebacks are excluded from this event, including
+generic execution-loop failures and fill-history coverage deferrals. The existing execution-loop
+incident family remains the bounded source for safe status, code, endpoint, and action
+classifications.
+
+This payload boundary is observability-only. Exception propagation, retries, time-sync recovery,
+restart thresholds, fill-history refresh requests, cycle deferral, and trading behavior are
+unchanged.
+
 ## Trailing And Unstuck Status Materiality
 
 `trailing.status` and `unstuck.status` retain one complete observation every five minutes while the

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,38 +22,48 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/restart-smoke-orchestrator`, based on canonical
-  `0d1b06b82f3bab011e29a350b4a5276c2ebd5356` after PR #1306.
-- PR: #1307. Slice: one bounded exact-pane graceful restart followed by one
-  exact restart-through-observation smoke collection.
-- Triggering evidence: repository preparation, exact target sampling, graceful
-  restart execution, retained-window collection, and sanitized evaluation are
-  individually available, but the production sequence still relies on manual
-  timestamp capture and command handoff between the restart and smoke tools.
-- Scope: independently require a complete stable target sample, invoke the
-  existing executor unchanged, require aggregate completion for every expected
-  target, wait one caller-bounded interval, and invoke the existing collector
-  with exact epoch-millisecond bounds. Malformed producer reports and bounded
-  collector exceptions fail closed without exposing private target details.
-- Behavior boundary: explicit `--execute` may gracefully signal and relaunch
-  only the configured exact tmux panes. The tool does not SSH, pull/build,
-  access credentials or exchanges directly, write reports, use broad process
-  patterns, poll/retry smoke collection, or apply automatic force escalation.
-  Configured bots resume normal exchange access and file writes. Post-action
-  smoke failure leaves them running and returns red for operator follow-up.
-- Validation: success/failure sequencing, strict target and executor contracts,
-  no-action preflight rejection, manual-recovery projection, exact clock bounds,
-  sanitized collector errors, CLI dispatch, existing restart tooling, complete
-  Python/Rust suites, compilation, and docs.
+- Branch: `codex/cycle-degraded-redaction`, based on canonical
+  `8aefdbc82339b756ff642e726ae0924d5ca8774d` after PR #1307.
+- PR: pending publication. Slice: remove retained raw exception text and request
+  URLs from execution-loop `cycle.degraded` payloads.
+- Triggering evidence: the exact PR #1307 VPS5 restart smoke retained a real
+  KuCoin `RequestTimeout` degradation whose structured event included the raw
+  connector exception string and request URL even though bounded reason,
+  exception-type, cycle, and incident fields were already available.
+- Scope: generic execution-loop failures and fill-history coverage deferrals
+  retain `error_type`, reason code, cycle correlation, phase timings, and the
+  existing safe operational details, but omit `str(exception)` and defensively
+  remove exception, URL, request/response, and traceback fields from the durable
+  structured/monitor payload.
+- Behavior boundary: observability payload only. Exception propagation,
+  fill-history confirmation requests, retries, time-sync recovery, restart
+  thresholds, execution-loop control flow, and trading behavior are unchanged.
+- Validation: targeted caller regressions, live-event/smoke consumers, complete
+  Python and Rust suites, compilation, generated registry/docs, and diff checks.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
-- Expected VPS action: use the merged repository-preparation tool to reach the
-  reviewed merge commit, verify exact targets and private fingerprints, then
-  run one no-force five-target restart with bounded post-restart smoke. Preserve
-  `misc:0.0`; stop for manual recovery if graceful execution does not finish.
+- Expected VPS action: prepare the reviewed merge commit, gracefully restart
+  the five exact configured bot panes to load the producer change, preserve
+  `misc:0.0`, and run bounded immediate plus settled smoke checks.
 
 ## Deployed Baseline
 
+- Canonical `master` and VPS5 are
+  `8aefdbc82339b756ff642e726ae0924d5ca8774d` after PR #1307. Exact-head Hermes
+  and Python/Rust CI were green. Exact repository preparation fast-forwarded
+  cleanly without a Rust rebuild; independent preflight resolved all five
+  targets with 3/3 stable samples and no extras or issues.
+- The merged orchestrator gracefully stopped, observed exit, relaunched, and
+  verified all five exact targets with no force signal. The bounded window
+  `1784332307933..1784332994590` selected 6/1,012 managed event segments
+  totaling `19335163` projected bytes and recovered five stopping, five stopped,
+  and five startup cohorts. Repository, target, monitor, and text-log gates were
+  green, but smoke correctly remained red on one real KuCoin positions-fetch
+  `RequestTimeout`; a second later timeout showed recovery was not yet proven.
+  All bots were left running. Pane parents stayed unchanged, tracked state
+  stayed clean, and `misc:0.0` remained `%8`, PID `434835`. No direct exchange
+  probe or event was manufactured. The retained raw exception string exposed
+  the active redaction follow-up.
 - Canonical `master` and VPS5 are
   `0d1b06b82f3bab011e29a350b4a5276c2ebd5356` after PR #1306. Exact-head Hermes
   and Python/Rust CI were green. VPS5 first fast-forwarded to make the

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -32,9 +32,11 @@ Estimated completion:
   exception-type, cycle, and incident fields were already available.
 - Scope: generic execution-loop failures and fill-history coverage deferrals
   retain `error_type`, reason code, cycle correlation, phase timings, and the
-  existing safe operational details, but omit `str(exception)` and defensively
-  remove exception, URL, request/response, and traceback fields from the durable
-  structured/monitor payload.
+  existing safe operational details. A strict event-family allow-list projects
+  only bounded counters, classifications, timings, authoritative barriers, and
+  staged-readiness diagnostics; it omits `str(exception)`, caller-supplied
+  epochs, unknown fields, and nested exception, URL, request/response, or
+  traceback aliases from the durable structured/monitor payload.
 - Behavior boundary: observability payload only. Exception propagation,
   fill-history confirmation requests, retries, time-sync recovery, restart
   thresholds, execution-loop control flow, and trading behavior are unchanged.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/cycle-degraded-redaction`, based on canonical
   `8aefdbc82339b756ff642e726ae0924d5ca8774d` after PR #1307.
-- PR: pending publication. Slice: remove retained raw exception text and request
+- PR: #1308. Slice: remove retained raw exception text and request
   URLs from execution-loop `cycle.degraded` payloads.
 - Triggering evidence: the exact PR #1307 VPS5 restart smoke retained a real
   KuCoin `RequestTimeout` degradation whose structured event included the raw

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,24 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1306)
+## Latest Canonical Deployment (PR #1307)
+
+- PR #1307 merged as canonical
+  `8aefdbc82339b756ff642e726ae0924d5ca8774d` after exact-current-head Hermes
+  approval and green Python/Rust CI. It composes the exact local restart
+  executor with one bounded restart-through-observation smoke collection.
+- VPS5 prepared the exact merge cleanly, then stopped, exited, relaunched, and
+  verified all five configured targets without force. The exact window
+  `1784332307933..1784332994590` selected 6/1,012 retained segments and recovered
+  five stopping/stopped/startup cohorts. Smoke correctly remained red on one
+  real KuCoin positions-fetch `RequestTimeout`; a second later timeout meant
+  recovery was not yet proven, so every bot was left running.
+- Repository and target gates remained green, pane parents and `misc:0.0` stayed
+  unchanged, and no direct exchange request or event was manufactured. The raw
+  exception string retained by `cycle.degraded` exposed the active bounded
+  redaction follow-up; remote-host control and force escalation remain separate.
+
+## Previous Canonical Deployment (PR #1306)
 
 - PR #1306 merged as canonical
   `0d1b06b82f3bab011e29a350b4a5276c2ebd5356` after exact-current-head Hermes

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -399,10 +399,18 @@ Related detailed plans:
      remained unchanged. The active follow-up composes the existing exact-pane
      executor and bounded collector over one exact restart-through-observation
      window without force escalation or report files.
+   - 2026-07-17: PR #1307 merged and deployed the exact restart-through-smoke
+     orchestrator. Graceful execution stopped, exited, relaunched, and verified
+     all five configured targets without force; the bounded collector recovered
+     all five shutdown/startup cohorts. Smoke honestly remained red on a real
+     KuCoin positions-fetch timeout while every bot stayed running and
+     `misc:0.0` remained unchanged. The retained event exposed raw connector
+     exception text and a request URL; the active follow-up removes those fields
+     while preserving bounded classification and correlation.
 
-   Remaining refinements: review and deploy the active post-restart smoke
-   orchestration slice. Remote-host control and any force-escalation policy
-   remain separate review boundaries.
+   Remaining refinements: activate the bounded `cycle.degraded` redaction
+   follow-up and observe a fresh settled post-restart window. Remote-host control
+   and any force-escalation policy remain separate review boundaries.
    The concise and brief summaries are intentionally bounded; further changes
    should target missing smoke fields rather than larger chat-facing payloads.
    2026-06-26 VPS5 deploy evidence: after PR #709, one Ctrl+C round stopped

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -73,19 +73,44 @@ _EXCHANGE_TIME_SYNC_CLIENT_RE = re.compile(
 )
 _EXCHANGE_TIME_SYNC_ERROR_TYPE_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,79}")
 _EXCHANGE_TIME_SYNC_CLIENT_SAMPLE_LIMIT = 8
-_CYCLE_DEGRADED_OMITTED_DATA_KEYS = frozenset(
-    {
-        "error",
-        "exception",
-        "exception_text",
-        "raw_request",
-        "raw_response",
-        "request",
-        "request_url",
-        "response",
-        "traceback",
-        "url",
-    }
+_CYCLE_DEGRADED_CODE_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_.:-]{0,95}")
+_CYCLE_DEGRADED_CONTEXT_RE = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_ .:-]{0,127}")
+_CYCLE_DEGRADED_SYMBOL_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:/-]{0,159}")
+_CYCLE_DEGRADED_READINESS_LIST_KEYS = (
+    "missing",
+    "changed",
+    "required",
+)
+_CYCLE_DEGRADED_INVALID_CODE_KEYS = (
+    "reason",
+    "mismatch_type",
+    "error_type",
+)
+_CYCLE_DEGRADED_INVALID_SYMBOL_KEYS = (
+    "symbol",
+)
+_CYCLE_DEGRADED_INVALID_SYMBOL_LIST_KEYS = (
+    "symbols",
+    "expected_symbols",
+    "stamped_symbols",
+    "missing_symbols",
+    "extra_symbols",
+    "changed_symbols",
+)
+_CYCLE_DEGRADED_INVALID_INT_KEYS = (
+    "latest_expected_ts",
+    "last_cached_ts",
+    "missing_candles",
+    "tail_gap_candles",
+    "tail_gap_age_ms",
+    "max_tail_gap_ms",
+    "expected_count",
+    "stamped_count",
+    "missing_count",
+    "extra_count",
+    "changed_count",
+    "age_ms",
+    "max_age_ms",
 )
 
 
@@ -116,18 +141,173 @@ def _sanitize_remote_fetch_payload(payload: dict[str, Any]) -> dict[str, Any]:
     return data
 
 
-def _sanitize_cycle_degraded_payload(value: Any) -> Any:
-    if isinstance(value, dict):
-        return {
-            key: _sanitize_cycle_degraded_payload(item)
-            for key, item in value.items()
-            if str(key).strip().lower() not in _CYCLE_DEGRADED_OMITTED_DATA_KEYS
-        }
-    if isinstance(value, list):
-        return [_sanitize_cycle_degraded_payload(item) for item in value]
-    if isinstance(value, tuple):
-        return tuple(_sanitize_cycle_degraded_payload(item) for item in value)
-    return value
+def _cycle_degraded_bounded_text(value: Any, pattern: re.Pattern[str]) -> str | None:
+    if value is None:
+        return None
+    try:
+        text = str(value).strip()
+    except Exception:
+        return None
+    if "://" in text or not pattern.fullmatch(text):
+        return None
+    return text
+
+
+def _cycle_degraded_non_negative_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _cycle_degraded_non_negative_number(value: Any) -> int | float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if not math.isfinite(parsed) or parsed < 0.0:
+        return None
+    return int(parsed) if parsed.is_integer() else parsed
+
+
+def _cycle_degraded_bounded_list(
+    value: Any,
+    pattern: re.Pattern[str],
+    *,
+    limit: int = 16,
+) -> list[str]:
+    if not isinstance(value, (list, tuple, set, frozenset)):
+        return []
+    out = []
+    for item in value:
+        text = _cycle_degraded_bounded_text(item, pattern)
+        if text is not None:
+            out.append(text)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def _cycle_degraded_int_map(value: Any, *, limit: int = 32) -> dict[str, int]:
+    if not isinstance(value, dict):
+        return {}
+    out = {}
+    for raw_key, raw_value in value.items():
+        key = _cycle_degraded_bounded_text(raw_key, _CYCLE_DEGRADED_CODE_RE)
+        parsed = _cycle_degraded_non_negative_int(raw_value)
+        if key is not None and parsed is not None:
+            out[key] = parsed
+        if len(out) >= limit:
+            break
+    return out
+
+
+def _sanitize_cycle_degraded_invalid_item(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    out: dict[str, Any] = {}
+    for key in _CYCLE_DEGRADED_INVALID_CODE_KEYS:
+        text = _cycle_degraded_bounded_text(value.get(key), _CYCLE_DEGRADED_CODE_RE)
+        if text is not None:
+            out[key] = text
+    for key in _CYCLE_DEGRADED_INVALID_SYMBOL_KEYS:
+        text = _cycle_degraded_bounded_text(value.get(key), _CYCLE_DEGRADED_SYMBOL_RE)
+        if text is not None:
+            out[key] = text
+    for key in _CYCLE_DEGRADED_INVALID_SYMBOL_LIST_KEYS:
+        if key in value:
+            out[key] = _cycle_degraded_bounded_list(
+                value.get(key), _CYCLE_DEGRADED_SYMBOL_RE, limit=12
+            )
+    for key in _CYCLE_DEGRADED_INVALID_INT_KEYS:
+        parsed = _cycle_degraded_non_negative_int(value.get(key))
+        if parsed is not None:
+            out[key] = parsed
+    return out
+
+
+def _sanitize_cycle_degraded_invalid(value: Any) -> dict[str, list[dict[str, Any]]]:
+    if not isinstance(value, dict):
+        return {}
+    out: dict[str, list[dict[str, Any]]] = {}
+    for raw_surface, raw_items in value.items():
+        surface = _cycle_degraded_bounded_text(
+            raw_surface, _CYCLE_DEGRADED_CODE_RE
+        )
+        if surface is None or not isinstance(raw_items, list):
+            continue
+        items = []
+        for raw_item in raw_items[:12]:
+            item = _sanitize_cycle_degraded_invalid_item(raw_item)
+            if item:
+                items.append(item)
+        if items:
+            out[surface] = items
+        if len(out) >= 16:
+            break
+    return out
+
+
+def _sanitize_cycle_degraded_readiness(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    out: dict[str, Any] = {}
+    for key in _CYCLE_DEGRADED_READINESS_LIST_KEYS:
+        if key in value:
+            out[key] = _cycle_degraded_bounded_list(
+                value.get(key), _CYCLE_DEGRADED_CODE_RE
+            )
+    epoch = _cycle_degraded_non_negative_int(value.get("epoch"))
+    if epoch is not None:
+        out["epoch"] = epoch
+    if "min_epochs" in value:
+        out["min_epochs"] = _cycle_degraded_int_map(value.get("min_epochs"))
+    context = _cycle_degraded_bounded_text(
+        value.get("context"), _CYCLE_DEGRADED_CONTEXT_RE
+    )
+    if context is not None:
+        out["context"] = context
+    defer_reason = _cycle_degraded_bounded_text(
+        value.get("defer_reason"), _CYCLE_DEGRADED_CODE_RE
+    )
+    if defer_reason is not None:
+        out["defer_reason"] = defer_reason
+    if "invalid" in value:
+        out["invalid"] = _sanitize_cycle_degraded_invalid(value.get("invalid"))
+    return out
+
+
+def _sanitize_cycle_degraded_payload(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    out: dict[str, Any] = {}
+    if "timings_ms" in value:
+        out["timings_ms"] = _cycle_degraded_int_map(value.get("timings_ms"))
+    for key in ("retry_count", "failed_count"):
+        parsed = _cycle_degraded_non_negative_int(value.get(key))
+        if parsed is not None:
+            out[key] = parsed
+    retry_delay_seconds = _cycle_degraded_non_negative_number(
+        value.get("retry_delay_seconds")
+    )
+    if retry_delay_seconds is not None:
+        out["retry_delay_seconds"] = retry_delay_seconds
+    for key, pattern in (
+        ("last_block_reason", _CYCLE_DEGRADED_CODE_RE),
+        ("error_type", _EXCHANGE_TIME_SYNC_ERROR_TYPE_RE),
+    ):
+        text = _cycle_degraded_bounded_text(value.get(key), pattern)
+        if text is not None:
+            out[key] = text
+    for key in ("barrier", "details"):
+        if key in value:
+            out[key] = _sanitize_cycle_degraded_readiness(value.get(key))
+    return out
 
 
 def _bounded_exchange_config_event_field(
@@ -872,8 +1052,8 @@ def emit_live_cycle_degraded(
     if not cycle_id:
         return
     payload = _sanitize_cycle_degraded_payload(dict(data or {}))
-    payload.setdefault(
-        "authoritative_epoch", int(getattr(bot, "_authoritative_refresh_epoch", 0) or 0)
+    payload["authoritative_epoch"] = int(
+        getattr(bot, "_authoritative_refresh_epoch", 0) or 0
     )
     bot._emit_live_event(
         EventTypes.CYCLE_DEGRADED,

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -73,6 +73,20 @@ _EXCHANGE_TIME_SYNC_CLIENT_RE = re.compile(
 )
 _EXCHANGE_TIME_SYNC_ERROR_TYPE_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,79}")
 _EXCHANGE_TIME_SYNC_CLIENT_SAMPLE_LIMIT = 8
+_CYCLE_DEGRADED_OMITTED_DATA_KEYS = frozenset(
+    {
+        "error",
+        "exception",
+        "exception_text",
+        "raw_request",
+        "raw_response",
+        "request",
+        "request_url",
+        "response",
+        "traceback",
+        "url",
+    }
+)
 
 
 def _sanitize_remote_text(value: Any, *, max_len: int = 500) -> str:
@@ -100,6 +114,20 @@ def _sanitize_remote_fetch_payload(payload: dict[str, Any]) -> dict[str, Any]:
         if url_hash is not None:
             data["url_hash"] = url_hash
     return data
+
+
+def _sanitize_cycle_degraded_payload(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _sanitize_cycle_degraded_payload(item)
+            for key, item in value.items()
+            if str(key).strip().lower() not in _CYCLE_DEGRADED_OMITTED_DATA_KEYS
+        }
+    if isinstance(value, list):
+        return [_sanitize_cycle_degraded_payload(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_sanitize_cycle_degraded_payload(item) for item in value)
+    return value
 
 
 def _bounded_exchange_config_event_field(
@@ -843,7 +871,7 @@ def emit_live_cycle_degraded(
 ) -> None:
     if not cycle_id:
         return
-    payload = dict(data or {})
+    payload = _sanitize_cycle_degraded_payload(dict(data or {}))
     payload.setdefault(
         "authoritative_epoch", int(getattr(bot, "_authoritative_refresh_epoch", 0) or 0)
     )

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -6174,7 +6174,6 @@ class Passivbot:
                     reason_code="fill_history_coverage_unavailable",
                     data={
                         "error_type": type(e).__name__,
-                        "error": str(e)[:500],
                         "timings_ms": dict(loop_timings_ms),
                     },
                     level="warning",
@@ -6188,7 +6187,6 @@ class Passivbot:
                     reason_code=type(e).__name__,
                     data={
                         "error_type": type(e).__name__,
-                        "error": str(e)[:500],
                         "timings_ms": dict(loop_timings_ms),
                     },
                     level="error",

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -9846,6 +9846,7 @@ async def test_run_execution_loop_retries_fill_history_coverage_without_restart(
     bot._maybe_log_unstuck_status = lambda: None
     bot._monitor_flush_snapshot = AsyncMock()
     bot.restart_bot_on_too_many_errors = AsyncMock()
+    bot._emit_live_cycle_degraded = MagicMock()
     bot._sleep_unless_shutdown = fake_sleep_unless_shutdown
     bot._log_settled_order_waves = lambda *args, **kwargs: None
     bot.live_value = lambda key: 0.0 if key == "execution_delay_seconds" else False
@@ -9896,6 +9897,17 @@ async def test_run_execution_loop_retries_fill_history_coverage_without_restart(
         ("market", 2),
         ("execute", False, 2),
     ]
+    coverage_event = next(
+        call.kwargs
+        for call in bot._emit_live_cycle_degraded.call_args_list
+        if call.kwargs["reason_code"] == "fill_history_coverage_unavailable"
+    )
+    assert coverage_event["level"] == "warning"
+    assert (
+        coverage_event["data"]["error_type"]
+        == "FillHistoryCoverageUnavailable"
+    )
+    assert "error" not in coverage_event["data"]
 
 
 @pytest.mark.asyncio
@@ -10333,6 +10345,7 @@ async def test_run_execution_loop_error_log_includes_type_status_and_action(capl
         (args, kwargs)
     )
     bot._monitor_record_error = MagicMock()
+    bot._emit_live_cycle_degraded = MagicMock()
     bot._maybe_recover_exchange_time_sync = AsyncMock(return_value=False)
     bot.restart_bot_on_too_many_errors = AsyncMock()
     bot.live_value = lambda key: 0.0 if key == "execution_delay_seconds" else False
@@ -10396,6 +10409,13 @@ async def test_run_execution_loop_error_log_includes_type_status_and_action(capl
     )
     assert all(raw_error not in message for message in messages)
     assert all("SECRET" not in message for message in messages)
+    degraded_event = bot._emit_live_cycle_degraded.call_args.kwargs
+    assert degraded_event["reason_code"] == "FakeExchangeError"
+    assert degraded_event["level"] == "error"
+    assert degraded_event["data"]["error_type"] == "FakeExchangeError"
+    assert "error" not in degraded_event["data"]
+    assert raw_error not in str(degraded_event)
+    assert "SECRET" not in str(degraded_event)
     debug_stack_messages = [
         record.message
         for record in caplog.records

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -132,14 +132,37 @@ def test_live_event_cycle_helpers_emit_structured_events():
         cycle_id=cycle_id,
         reason_code="execution_barrier",
         data={
-            "missing": ["open_orders"],
+            "barrier": {
+                "missing": ["open_orders"],
+                "requestURL": "https://example.invalid?api_key=SECRET",
+                "arbitrary": "api_key=SECRET",
+            },
             "error_type": "RequestTimeout",
             "error": "GET https://example.invalid?api_key=SECRET",
             "request_url": "https://example.invalid?api_key=SECRET",
+            "requestURL": "https://example.invalid?api_key=SECRET",
+            "exception-message": "api_key=SECRET",
+            "arbitrary": "api_key=SECRET",
             "details": {
                 "missing": ["positions"],
                 "response": {"api_key": "SECRET"},
+                "responseBody": "api_key=SECRET",
+                "exceptionMessage": "api_key=SECRET",
+                "arbitrary": "api_key=SECRET",
+                "invalid": {
+                    "completed_candles": [
+                        {
+                            "reason": "signature_mismatch",
+                            "mismatch_type": "completed_candle_target_changed",
+                            "changed_count": 1,
+                            "changed_symbols": ["BTC/USDT:USDT"],
+                            "responseBody": "api_key=SECRET",
+                            "arbitrary": "api_key=SECRET",
+                        }
+                    ]
+                },
             },
+            "authoritative_epoch": 999999,
         },
     )
     assert bot._current_live_event_cycle_id() is None
@@ -175,9 +198,21 @@ def test_live_event_cycle_helpers_emit_structured_events():
     ]
     assert events[1].reason_code == "execution_barrier"
     assert events[1].data == {
-        "missing": ["open_orders"],
+        "barrier": {"missing": ["open_orders"]},
         "error_type": "RequestTimeout",
-        "details": {"missing": ["positions"]},
+        "details": {
+            "missing": ["positions"],
+            "invalid": {
+                "completed_candles": [
+                    {
+                        "reason": "signature_mismatch",
+                        "mismatch_type": "completed_candle_target_changed",
+                        "changed_symbols": ["BTC/USDT:USDT"],
+                        "changed_count": 1,
+                    }
+                ]
+            },
+        },
         "authoritative_epoch": "[redacted]",
     }
     assert "SECRET" not in str(events[1].data)

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -131,7 +131,16 @@ def test_live_event_cycle_helpers_emit_structured_events():
     bot._emit_live_cycle_degraded(
         cycle_id=cycle_id,
         reason_code="execution_barrier",
-        data={"missing": ["open_orders"]},
+        data={
+            "missing": ["open_orders"],
+            "error_type": "RequestTimeout",
+            "error": "GET https://example.invalid?api_key=SECRET",
+            "request_url": "https://example.invalid?api_key=SECRET",
+            "details": {
+                "missing": ["positions"],
+                "response": {"api_key": "SECRET"},
+            },
+        },
     )
     assert bot._current_live_event_cycle_id() is None
     cycle_id_2 = bot._begin_live_event_cycle(loop_start_ms=1000)
@@ -165,6 +174,14 @@ def test_live_event_cycle_helpers_emit_structured_events():
         None,
     ]
     assert events[1].reason_code == "execution_barrier"
+    assert events[1].data == {
+        "missing": ["open_orders"],
+        "error_type": "RequestTimeout",
+        "details": {"missing": ["positions"]},
+        "authoritative_epoch": "[redacted]",
+    }
+    assert "SECRET" not in str(events[1].data)
+    assert "https://" not in str(events[1].data)
     assert events[3].data["orders_changed"] is True
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 


### PR DESCRIPTION
## Summary

- remove raw exception strings from generic execution-loop and fill-history coverage `cycle.degraded` payloads
- defensively omit nested exception, URL, request/response, and traceback fields from this event family
- retain stable reason codes, bounded exception types, cycle correlation, safe operational details, and phase timings
- record the exact PR #1307 deployment evidence that exposed this gap

## Behavior boundary

This changes observability payload retention only. Exception propagation, retries, fill-history confirmation, time-sync recovery, restart thresholds, execution-loop control flow, order planning, and trading behavior are unchanged.

## Validation

- complete Python test suite
- focused live event, monitor, balance split, event bus, and smoke report suites
- `cargo test --no-default-features` (210 passed)
- `cargo check --tests`
- exact worktree Rust extension rebuild and fingerprint verification
- generated event registry check
- AI docs check (0 errors; existing size warning only)
- `git diff --check`
- Python compilation check

## VPS action

After merge, prepare the exact reviewed merge commit and gracefully restart only the five configured bot panes. Preserve `misc:0.0`, use no force escalation, and run bounded immediate plus settled smoke checks.
