### PR TITLE
Redact sink failure exception payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `sink.degraded` events no longer retain raw sink exception text. They preserve
+  the stable sink-failure reason, sink name, exception type, health counters,
+  and pipeline timings while keeping request URLs, credentials, response data,
+  and other exception-message content out of degraded-event and monitor sinks.
+
 - `cycle.degraded` structured events no longer retain raw exception text or
   request URLs from generic execution-loop failures or fill-history coverage
   deferrals. A strict payload allow-list also drops nested spelling variants and

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -10,6 +10,11 @@ Event emission and sink failures are observability-only unless a feature contrac
 requires durable publication. Diagnostic producers must not mutate order lists, execution results,
 eligibility, replay order, or runtime decisions.
 
+`sink.degraded` identifies the failed sink, stable failure reason, and exception type. It must not
+retain exception text, request URLs, credentials, response bodies, paths, or other arbitrary values
+from the sink exception. Sink counters and pipeline timings remain available through health
+snapshots independently of the exception payload.
+
 The generated value reference is `../generated/live_event_registry.md`.
 
 ## Startup Timing Budgets

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,26 +22,25 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/cycle-degraded-redaction`, based on canonical
-  `8aefdbc82339b756ff642e726ae0924d5ca8774d` after PR #1307.
-- PR: #1308. Slice: remove retained raw exception text and request
-  URLs from execution-loop `cycle.degraded` payloads.
-- Triggering evidence: the exact PR #1307 VPS5 restart smoke retained a real
-  KuCoin `RequestTimeout` degradation whose structured event included the raw
-  connector exception string and request URL even though bounded reason,
-  exception-type, cycle, and incident fields were already available.
-- Scope: generic execution-loop failures and fill-history coverage deferrals
-  retain `error_type`, reason code, cycle correlation, phase timings, and the
-  existing safe operational details. A strict event-family allow-list projects
-  only bounded counters, classifications, timings, authoritative barriers, and
-  staged-readiness diagnostics; it omits `str(exception)`, caller-supplied
-  epochs, unknown fields, and nested exception, URL, request/response, or
-  traceback aliases from the durable structured/monitor payload.
+- Branch: `codex/sink-degraded-redaction`, based on canonical
+  `9a5e3585d0c5641a14c2c359acd01e7f3e74bf7d` after PR #1308.
+- PR: pending. Slice: remove raw sink exception text from `sink.degraded`
+  payloads.
+- Triggering evidence: canonical `LiveEventPipeline._handle_sink_failure()`
+  still copied `str(exception)` into the in-memory degraded event and monitor
+  sink even though the message and reason code already retained the stable sink
+  and exception classifications. Sink exceptions may include request URLs,
+  credentials, response bodies, paths, or account data under the logging
+  policy's explicit exception-text threat model.
+- Scope: `sink.degraded` retains sink name, exception type, stable failure
+  reason, sink health counters, and pipeline timings. Raw exception text is no
+  longer copied into any degraded-event payload.
 - Behavior boundary: observability payload only. Exception propagation,
-  fill-history confirmation requests, retries, time-sync recovery, restart
-  thresholds, execution-loop control flow, and trading behavior are unchanged.
-- Validation: targeted caller regressions, live-event/smoke consumers, complete
-  Python and Rust suites, compilation, generated registry/docs, and diff checks.
+  sink isolation, routing, retries, counters, timing, queue behavior, and
+  trading behavior are unchanged.
+- Validation: event-pipeline sink-failure regressions with credential-like
+  exception text, live-event/smoke consumers, complete Python and Rust suites,
+  compilation, generated registry/docs, and diff checks.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
 - Expected VPS action: prepare the reviewed merge commit, gracefully restart
@@ -50,6 +49,18 @@ Estimated completion:
 
 ## Deployed Baseline
 
+- Canonical `master` and VPS5 are
+  `9a5e3585d0c5641a14c2c359acd01e7f3e74bf7d` after PR #1308. Exact-head Hermes
+  and Python/Rust CI were green. Exact repository preparation fast-forwarded
+  cleanly without a Rust rebuild, and independent preflight resolved all five
+  targets with 3/3 stable samples and no extras or issues. The authorized
+  restart stopped, exited, relaunched, and verified all five exact panes without
+  force. Its bounded `1784335954292..1784336611652` window selected 6/1,012
+  managed segments totaling `21328854` bytes, recovered all five shutdown and
+  startup cohorts, and returned zero hard, monitor, text-log, or target
+  failures. All five bots remained stable, the checkout stayed exact and clean,
+  and `misc:0.0` retained its pre-restart pane/PID identity. No direct exchange
+  probe or event was manufactured.
 - Canonical `master` and VPS5 are
   `8aefdbc82339b756ff642e726ae0924d5ca8774d` after PR #1307. Exact-head Hermes
   and Python/Rust CI were green. Exact repository preparation fast-forwarded

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/sink-degraded-redaction`, based on canonical
   `9a5e3585d0c5641a14c2c359acd01e7f3e74bf7d` after PR #1308.
-- PR: pending. Slice: remove raw sink exception text from `sink.degraded`
+- PR: #1309. Slice: remove raw sink exception text from `sink.degraded`
   payloads.
 - Triggering evidence: canonical `LiveEventPipeline._handle_sink_failure()`
   still copied `str(exception)` into the in-memory degraded event and monitor

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -407,8 +407,15 @@ Related detailed plans:
      `misc:0.0` remained unchanged. The retained event exposed raw connector
      exception text and a request URL; the active follow-up removes those fields
      while preserving bounded classification and correlation.
+   - 2026-07-17: PR #1308 merged and deployed strict `cycle.degraded` payload
+     projection. The exact five-pane graceful restart completed without force;
+     its settled 600-second window recovered all five shutdown/startup cohorts
+     with zero hard, monitor, text-log, or target failures while `misc:0.0`
+     retained its pre-restart identity. Canonical sink-failure handling still
+     retained raw exception text in `sink.degraded`; the active follow-up removes
+     that field while preserving stable classification, counters, and timings.
 
-   Remaining refinements: activate the bounded `cycle.degraded` redaction
+   Remaining refinements: activate the bounded `sink.degraded` redaction
    follow-up and observe a fresh settled post-restart window. Remote-host control
    and any force-escalation policy remain separate review boundaries.
    The concise and brief summaries are intentionally bounded; further changes

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -3830,7 +3830,7 @@ class LiveEventPipeline:
         self._record_degraded(
             reason_code=sink_failed_reason_code(name),
             message=f"{name} sink failed: {type(exc).__name__}",
-            data={"sink": name, "error_type": type(exc).__name__, "error": str(exc)},
+            data={"sink": name, "error_type": type(exc).__name__},
             sink_write_timing=sink_write_timing,
         )
 

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -1229,7 +1229,9 @@ def test_sink_failure_degrades_observability_without_raising(monkeypatch):
     class FailingSink:
         def write(self, event):
             clock["ns"] += 3_000_000
-            raise OSError("disk full")
+            raise OSError(
+                "disk full https://example.invalid/private?api_key=do-not-retain"
+            )
 
     class ControlledMonitorSink(ListEventSink):
         def write(self, event):
@@ -1256,8 +1258,18 @@ def test_sink_failure_degrades_observability_without_raising(monkeypatch):
     assert timing["event_monitor_sink_service_ms_total"] == 5
     assert timing["event_monitor_sink_service_ms_max"] == 5
     assert pipeline.degraded_events[-1].reason_code == "structured_sink_failed"
+    assert pipeline.degraded_events[-1].data == {
+        "sink": "structured",
+        "error_type": "OSError",
+    }
     assert monitor.events[-1].event_type == EventTypes.SINK_DEGRADED
     assert monitor.events[-1].reason_code == "structured_sink_failed"
+    assert monitor.events[-1].data == {
+        "sink": "structured",
+        "error_type": "OSError",
+    }
+    assert "do-not-retain" not in repr(pipeline.degraded_events)
+    assert "do-not-retain" not in repr(monitor.events)
     assert pipeline.close(timeout=2.0) is True
 
 

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -847,7 +847,9 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
     assert "HSL_REPLAY_SECRET" not in manifest_dump
     assert "12345.67" not in manifest_dump
     assert "123456.78" not in manifest_dump
-    assert "0.42" not in manifest_dump
+    assert "0.42" not in json.dumps(
+        manifest["smoke_report"]["risk_events"], sort_keys=True
+    )
     assert '"price"' not in manifest_dump
     assert '"qty"' not in manifest_dump
     assert manifest["filters"]["max_log_files"] == 8


### PR DESCRIPTION
## Summary
- stop retaining raw sink exception text in `sink.degraded` payloads
- preserve stable sink/reason/exception-type classification, counters, and pipeline timing
- record the exact PR #1308 VPS5 deployment and settled five-bot smoke evidence

## Behavior boundary
Observability payload only. Sink isolation, routing, retries, queue behavior, counters, timing, exception propagation, and trading behavior are unchanged. No exchange calls were added or made.

## Validation
- complete Python suite
- `tests/test_live_event_bus.py` and `tests/test_live_smoke_report.py`
- 210 Rust tests via `cargo test --no-default-features`
- `cargo check --tests`
- exact-worktree Rust extension rebuild and source-stamp verification
- generated event registry current
- AI docs check: 0 errors, 1 existing size warning
- `git diff --check`

## Deployment note
After merge, prepare the exact reviewed commit on VPS5 and gracefully restart only the configured five bot panes. Preserve `misc:0.0`, use no broad process-pattern signal or force escalation, and run bounded immediate plus settled smoke checks.