### PR TITLE
Retain hard problem smoke evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Full live smoke reports now retain a separately bounded sample of hard
+  structured problem events, with authoritative total, retained, and truncated
+  counts. Later warning-level attention can no longer hide every classification
+  behind a nonzero hard-problem count; the existing mixed latest-event sample
+  and all runtime behavior remain unchanged.
+
 - HSL replay now recognizes every ordered, fill-derived scope flatten as an
   episode boundary, including multiple close-and-reentry transitions within
   one replay minute and compact coin replay without historical unrealized PnL.

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -164,6 +164,17 @@ must not retain `latest_error`. These projections are observability-only: error 
 timestamp recovery, restart thresholds, backoff, and trading behavior remain owned by the existing
 execution-loop policy.
 
+## Smoke Hard-Problem Evidence
+
+Full live smoke reports keep the existing bounded latest mixed `problem_events` sample and expose
+an independent `hard_problem_events` object. Its `count` is the authoritative full-window hard
+count; `retained` and `truncated` describe the bounded chronological `sample`. Later non-hard
+attention therefore cannot remove every hard classification while the report remains red.
+
+The hard-only sample uses the caller's existing `max_problem_events` bound and the same compact,
+redacted event projection as the mixed sample. It is reporting evidence only and must not change
+problem classification, recovery matching, smoke verdicts, process control, or live behavior.
+
 ## Cycle Degradation
 
 `cycle.degraded` retains the stable reason code, bounded exception type, cycle correlation, safe

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/hard-problem-evidence`, based on canonical
   `f1ae7970393e8299d1b0a98c8ff68d42adddd2d0` after PR #1299.
-- PR: pending. Slice: retain bounded hard-event classifications independently
+- PR: #1310. Slice: retain bounded hard-event classifications independently
   of the mixed latest problem-event sample.
 - Triggering evidence: the PR #1309 restart smoke correctly reported two hard
   structured problem events, but its bounded mixed `problem_events` sample

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -1,6 +1,6 @@
 # Live Logging Overhaul Current Status
 
-Updated: 2026-07-17.
+Updated: 2026-07-18.
 
 This is the compact operational source for the active logging-overhaul loop.
 Read it before the historical progress ledger. Update it whenever the active
@@ -22,33 +22,58 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/sink-degraded-redaction`, based on canonical
-  `9a5e3585d0c5641a14c2c359acd01e7f3e74bf7d` after PR #1308.
-- PR: #1309. Slice: remove raw sink exception text from `sink.degraded`
-  payloads.
-- Triggering evidence: canonical `LiveEventPipeline._handle_sink_failure()`
-  still copied `str(exception)` into the in-memory degraded event and monitor
-  sink even though the message and reason code already retained the stable sink
-  and exception classifications. Sink exceptions may include request URLs,
-  credentials, response bodies, paths, or account data under the logging
-  policy's explicit exception-text threat model.
-- Scope: `sink.degraded` retains sink name, exception type, stable failure
-  reason, sink health counters, and pipeline timings. Raw exception text is no
-  longer copied into any degraded-event payload.
-- Behavior boundary: observability payload only. Exception propagation,
-  sink isolation, routing, retries, counters, timing, queue behavior, and
-  trading behavior are unchanged.
-- Validation: event-pipeline sink-failure regressions with credential-like
-  exception text, live-event/smoke consumers, complete Python and Rust suites,
-  compilation, generated registry/docs, and diff checks.
+- Branch: `codex/hard-problem-evidence`, based on canonical
+  `f1ae7970393e8299d1b0a98c8ff68d42adddd2d0` after PR #1299.
+- PR: pending. Slice: retain bounded hard-event classifications independently
+  of the mixed latest problem-event sample.
+- Triggering evidence: the PR #1309 restart smoke correctly reported two hard
+  structured problem events, but its bounded mixed `problem_events` sample
+  exposed only one hard classification. The shared `deque(maxlen=N)` allows
+  later warning-level attention to evict hard evidence while the authoritative
+  hard count remains nonzero.
+- Scope: full smoke reports add `hard_problem_events` with authoritative
+  `count`, bounded chronological `sample`, and explicit `retained` and
+  `truncated` counts. Existing mixed sample ordering, recovery classification,
+  verdicts, event schemas, and command behavior remain unchanged.
+- Behavior boundary: read-only report projection only. Event publication,
+  recovery, process control, exchange access, and trading behavior are
+  unchanged.
+- Validation: focused mixed-eviction, positive truncation, and zero-bound
+  regressions; complete smoke-report tests; AI-doc, compile, and diff checks;
+  complete Python and Rust suites before publication.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
-- Expected VPS action: prepare the reviewed merge commit, gracefully restart
-  the five exact configured bot panes to load the producer change, preserve
-  `misc:0.0`, and run bounded immediate plus settled smoke checks.
+- Expected VPS action: prepare the reviewed merge commit and run bounded
+  read-only report verification. No bot restart or process signal is required
+  for this offline reporting-tool change.
 
 ## Deployed Baseline
 
+- Canonical `master` and VPS5 are
+  `f1ae7970393e8299d1b0a98c8ff68d42adddd2d0` after PR #1299. The clean
+  checkout fast-forwarded from PR #1309 without a Rust rebuild after five
+  targets passed 3/3 stable preflight samples with no extras or issues. The
+  authorized exact-pane restart stopped, exited, relaunched, and verified all
+  five targets without force. Its bounded
+  `1784392681320..1784393372572` window selected 10/1,011 managed segments
+  totaling `66399577` bytes, recovered all five stopping, stopped, and startup
+  cohorts, and returned zero hard, monitor, text-log, repository, or target
+  failures. The checkout remained exact and tracked-clean; all five pane
+  parents and protected `misc:0.0` `%8`/PID `434835` remained stable. No direct
+  exchange probe or event was manufactured.
+- PR #1309 merged as
+  `50c37db6049206634b62f45798a8b240a035e3b5` after exact-current-head Hermes
+  approval and green Python/Rust CI. It removed raw exception text from
+  `sink.degraded` while preserving stable sink and exception classifications.
+  VPS5 prepared the exact merge without a Rust rebuild and gracefully restarted
+  all five exact panes. The bounded `1784339097380..1784339763543` window
+  recovered complete shutdown/startup cohorts and left every bot running, but
+  correctly remained red on two hard structured problem events including a
+  real KuCoin positions-fetch `RequestTimeout`. Only one hard classification
+  remained visible in the bounded mixed sample, exposing the active
+  hard-evidence-retention follow-up. Repository, target, monitor, and text-log
+  gates stayed green, tracked state stayed clean, and `misc:0.0` remained
+  unchanged.
 - Canonical `master` and VPS5 are
   `9a5e3585d0c5641a14c2c359acd01e7f3e74bf7d` after PR #1308. Exact-head Hermes
   and Python/Rust CI were green. Exact repository preparation fast-forwarded
@@ -1278,9 +1303,11 @@ with five stable exact processes and recovered uninterruptible observations.
 PR #1286's aggregate-only follow-up, PR #1287's exact tmux target preflight,
 PR #1288's bounded target-identity stability, and PR #1289's plan binding are
 merged, deployed, and naturally validated without process control. PR #1290's
-pane-parent relaunch classification is also merged and deployed. The active
-`codex/restart-target-contract-fingerprint` slice binds target stability to the
-parsed supervisor command contract without exposing or executing commands.
+pane-parent relaunch classification and the restart preparation/orchestration
+slices through PR #1309 are also merged and deployed. Current VPS5 is hard-green
+at canonical `f1ae7970393e8299d1b0a98c8ff68d42adddd2d0`. The active
+`codex/hard-problem-evidence` slice makes every nonzero hard smoke verdict
+diagnosable from a separately bounded hard-only sample.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,29 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1307)
+## Latest Canonical Deployment (PR #1309; Current Through PR #1299)
+
+- PR #1309 merged as canonical
+  `50c37db6049206634b62f45798a8b240a035e3b5` after exact-current-head Hermes
+  approval and green Python/Rust CI. It removes raw sink exception text while
+  retaining stable sink, reason, exception-type, counter, and timing evidence.
+- VPS5 prepared the exact merge without a Rust rebuild and gracefully stopped,
+  exited, relaunched, and verified all five configured panes without force. The
+  exact `1784339097380..1784339763543` window recovered complete shutdown and
+  startup cohorts and left every bot running, but correctly remained red on two
+  hard structured events, including a real KuCoin positions-fetch
+  `RequestTimeout`. Only one hard classification remained in the bounded mixed
+  problem-event sample, exposing the active hard-only retention follow-up.
+- Canonical master later advanced through behavior-changing PR #1299 to
+  `f1ae7970393e8299d1b0a98c8ff68d42adddd2d0`. VPS5 prepared that exact head,
+  restarted only the same five verified panes, and returned hard-green over
+  `1784392681320..1784393372572`: 10/1,011 managed segments and `66399577`
+  bytes, complete five-bot shutdown/startup evidence, and zero hard, monitor,
+  text-log, repository, or target failures. The checkout stayed tracked-clean,
+  all pane parents remained stable, and protected `misc:0.0` stayed `%8`, PID
+  `434835`. No direct exchange request or event was manufactured.
+
+## Previous Canonical Deployment (PR #1307)
 
 - PR #1307 merged as canonical
   `8aefdbc82339b756ff642e726ae0924d5ca8774d` after exact-current-head Hermes

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -8488,7 +8488,11 @@ def _scan_events(
             "hard_problem_events": 0,
         }
     )
-    problem_events: deque[dict[str, Any]] = deque(maxlen=max(0, int(max_problem_events)))
+    problem_event_limit = max(0, int(max_problem_events))
+    problem_events: deque[dict[str, Any]] = deque(maxlen=problem_event_limit)
+    hard_problem_events: deque[dict[str, Any]] = deque(
+        maxlen=problem_event_limit
+    )
     problem_records: list[dict[str, Any]] = []
     time_sync_recoveries: list[dict[str, Any]] = []
     invalid_rows = 0
@@ -9006,9 +9010,14 @@ def _scan_events(
             problem_event["recovered"] = True
             problem_event["recovery"] = record.get("recovery")
         problem_events.append(problem_event)
+        if hard:
+            hard_problem_events.append(problem_event)
 
     error_count = sum(1 for issue in issues if issue.get("severity") == "error")
     warning_count = sum(1 for issue in issues if issue.get("severity") == "warning")
+    hard_problem_event_count = sum(
+        int(value["hard_problem_events"]) for value in bots.values()
+    )
     return {
         "monitor": {
             "root": str(Path(root).expanduser()),
@@ -9044,12 +9053,16 @@ def _scan_events(
             for key, value in sorted(bots.items())
         ],
         "problem_events": list(problem_events),
+        "hard_problem_events": {
+            "count": hard_problem_event_count,
+            "retained": len(hard_problem_events),
+            "truncated": max(0, hard_problem_event_count - len(hard_problem_events)),
+            "sample": list(hard_problem_events),
+        },
         "problem_event_groups": _summarize_problem_event_groups(problem_event_groups),
         "recovered_problem_events": recovered_problem_events,
         "problem_event_count": sum(int(value["problem_events"]) for value in bots.values()),
-        "hard_problem_event_count": sum(
-            int(value["hard_problem_events"]) for value in bots.values()
-        ),
+        "hard_problem_event_count": hard_problem_event_count,
         "startup_timings": _summarize_startup_timings(
             _startup_records_after_latest_started(
                 startup_timing_records,
@@ -9582,6 +9595,7 @@ def build_live_smoke_report(
         "shutdown_events": event_scan["shutdown_events"],
         "event_window": event_scan["event_window"],
         "problem_events": event_scan["problem_events"],
+        "hard_problem_events": event_scan["hard_problem_events"],
         "problem_event_groups": event_scan["problem_event_groups"],
         "recovered_problem_events": event_scan["recovered_problem_events"],
         "problem_event_count": event_scan["problem_event_count"],

--- a/src/tools/live_smoke_report.py
+++ b/src/tools/live_smoke_report.py
@@ -135,7 +135,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--max-problem-events",
         type=int,
         default=50,
-        help="Maximum recent problem events to include.",
+        help=(
+            "Maximum recent mixed and hard-only problem events to include "
+            "in each full-report sample."
+        ),
     )
     parser.add_argument(
         "--max-log-files",

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -7170,6 +7170,165 @@ def test_live_smoke_report_distinguishes_attention_and_hard_structured_events(
     assert report["problem_events"][0]["hard"] is False
 
 
+def test_live_smoke_report_retains_hard_problem_evidence_after_mixed_sample_eviction(
+    tmp_path,
+):
+    events_dir = tmp_path / "monitor" / "bybit" / "bybit_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.stopped",
+                seq=1,
+                ts=1000,
+                status="failed",
+                level="critical",
+                reason_code="terminal_startup_failure",
+            ),
+            _monitor_row(
+                event_type="execution.create_failed",
+                seq=2,
+                ts=2000,
+                status="failed",
+                level="error",
+                reason_code="exchange_exception",
+            ),
+            *[
+                _monitor_row(
+                    event_type="ema.unavailable",
+                    seq=seq,
+                    ts=seq * 1000,
+                    status="degraded",
+                    level="warning",
+                    reason_code="required_ema_unavailable",
+                )
+                for seq in range(3, 6)
+            ],
+        ],
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        max_problem_events=2,
+    )
+
+    assert report["hard_problem_event_count"] == 2
+    assert [event["seq"] for event in report["problem_events"]] == [4, 5]
+    assert [event["hard"] for event in report["problem_events"]] == [False, False]
+    assert report["hard_problem_events"] == {
+        "count": 2,
+        "retained": 2,
+        "truncated": 0,
+        "sample": [
+            {
+                "event_type": "bot.stopped",
+                "exchange": "binance",
+                "hard": True,
+                "level": "critical",
+                "line": 1,
+                "path": str(events_dir / "current.ndjson"),
+                "reason_code": "terminal_startup_failure",
+                "seq": 1,
+                "status": "failed",
+                "ts": 1000,
+                "user": "binance_01",
+            },
+            {
+                "event_type": "execution.create_failed",
+                "exchange": "binance",
+                "hard": True,
+                "level": "error",
+                "line": 2,
+                "path": str(events_dir / "current.ndjson"),
+                "reason_code": "exchange_exception",
+                "seq": 2,
+                "status": "failed",
+                "ts": 2000,
+                "user": "binance_01",
+            },
+        ],
+    }
+
+
+def test_live_smoke_report_hard_problem_evidence_respects_zero_sample_limit(tmp_path):
+    events_dir = tmp_path / "monitor" / "bybit" / "bybit_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.stopped",
+                seq=1,
+                ts=1000,
+                status="failed",
+                level="critical",
+                reason_code="terminal_startup_failure",
+            ),
+            _monitor_row(
+                event_type="ema.unavailable",
+                seq=2,
+                ts=2000,
+                status="degraded",
+                level="warning",
+                reason_code="required_ema_unavailable",
+            ),
+        ],
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        max_problem_events=0,
+    )
+
+    assert report["problem_events"] == []
+    assert report["hard_problem_event_count"] == 1
+    assert report["hard_problem_events"] == {
+        "count": 1,
+        "retained": 0,
+        "truncated": 1,
+        "sample": [],
+    }
+
+
+def test_live_smoke_report_hard_problem_evidence_retains_latest_bounded_sample(
+    tmp_path,
+):
+    events_dir = tmp_path / "monitor" / "bybit" / "bybit_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.stopped",
+                seq=seq,
+                ts=seq * 1000,
+                status="failed",
+                level="critical",
+                reason_code=f"terminal_failure_{seq}",
+            )
+            for seq in range(1, 4)
+        ],
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        max_problem_events=2,
+    )
+
+    assert report["hard_problem_event_count"] == 3
+    assert report["hard_problem_events"] == {
+        "count": 3,
+        "retained": 2,
+        "truncated": 1,
+        "sample": report["problem_events"],
+    }
+    assert [event["seq"] for event in report["hard_problem_events"]["sample"]] == [
+        2,
+        3,
+    ]
+
+
 def test_live_smoke_report_summarizes_problem_event_groups(tmp_path):
     events_dir = tmp_path / "monitor" / "okx" / "okx_faisal" / "events"
     _write_ndjson(


### PR DESCRIPTION
## Summary

- retain an independently bounded hard-problem event sample in full live smoke reports
- preserve the existing mixed latest-event sample and authoritative hard verdict/count semantics
- record exact PR #1309 and current PR #1299 VPS5 deployment evidence

## Trigger

PR #1309's settled restart smoke reported two hard structured problem events, but the bounded mixed problem-event sample exposed only one hard classification. Later non-hard attention can evict hard events from that shared deque while the report remains red.

## Contract

`hard_problem_events` contains the authoritative full-window `count`, bounded chronological `sample`, and explicit `retained`/`truncated` counts. It uses the existing `max_problem_events` bound and compact redacted projection. Recovery matching, verdicts, process control, event emission, exchange access, and trading behavior are unchanged.

## Validation

- complete Python suite
- `pytest -q tests/test_live_smoke_report.py tests/test_passivbot_cli.py`
- `pytest -q tests/test_ai_docs.py tests/test_live_event_registry_docs.py tests/test_live_restart_smoke_evidence.py tests/test_live_restart_smoke_orchestrator.py`
- `PYTHONPATH=src python src/tools/check_ai_docs.py` (0 errors; existing size warning)
- `PYTHONPATH=src python src/tools/generate_live_event_registry.py --check`
- Python compile checks
- 210 Rust tests
- `cargo check --tests`
- `cargo fmt --check`
- `git diff --check`

## Deployment

Read-only reporting-tool change: after merge, prepare VPS5 to the exact reviewed commit and run bounded read-only verification. No bot restart or process signal is required.
