### PR TITLE
Retain hard problem evidence in smoke summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ All notable user-facing changes will be documented in this file.
 - Full live smoke reports now retain a separately bounded sample of hard
   structured problem events, with authoritative total, retained, and truncated
   counts. Later warning-level attention can no longer hide every classification
-  behind a nonzero hard-problem count; the existing mixed latest-event sample
-  and all runtime behavior remain unchanged.
+  behind a nonzero hard-problem count. Concise summary, brief, and incident
+  bundle smoke metadata now retain the same bounded hard-only evidence; the
+  existing mixed latest-event sample and all runtime behavior remain unchanged.
 
 - HSL replay now recognizes every ordered, fill-derived scope flatten as an
   episode boundary, including multiple close-and-reentry transitions within

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -174,6 +174,9 @@ attention therefore cannot remove every hard classification while the report rem
 The hard-only sample uses the caller's existing `max_problem_events` bound and the same compact,
 redacted event projection as the mixed sample. It is reporting evidence only and must not change
 problem classification, recovery matching, smoke verdicts, process control, or live behavior.
+Concise summary, brief, and incident-bundle compact smoke metadata retain the same object shape,
+with an independently bounded value-safe sample and `retained`/`truncated` recalculated for that
+projection.
 
 ## Cycle Degradation
 

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,6 +24,7 @@ Estimated completion:
 
 - Branch: `codex/hard-problem-summary-evidence`, based on canonical
   `5d06887b78c2790efd15e1bd67bae6b3f5d96636` after PR #1310.
+- PR: #1311.
 - Scope: carry bounded, value-safe `hard_problem_events` evidence into concise
   summary, brief, and compact incident-bundle smoke metadata. Existing mixed
   sample ordering, hard verdict/count semantics, recovery classification,

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,32 +22,42 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/hard-problem-evidence`, based on canonical
-  `f1ae7970393e8299d1b0a98c8ff68d42adddd2d0` after PR #1299.
-- PR: #1310. Slice: retain bounded hard-event classifications independently
-  of the mixed latest problem-event sample.
-- Triggering evidence: the PR #1309 restart smoke correctly reported two hard
-  structured problem events, but its bounded mixed `problem_events` sample
-  exposed only one hard classification. The shared `deque(maxlen=N)` allows
-  later warning-level attention to evict hard evidence while the authoritative
-  hard count remains nonzero.
-- Scope: full smoke reports add `hard_problem_events` with authoritative
-  `count`, bounded chronological `sample`, and explicit `retained` and
-  `truncated` counts. Existing mixed sample ordering, recovery classification,
-  verdicts, event schemas, and command behavior remain unchanged.
+- Branch: `codex/hard-problem-summary-evidence`, based on canonical
+  `5d06887b78c2790efd15e1bd67bae6b3f5d96636` after PR #1310.
+- Scope: carry bounded, value-safe `hard_problem_events` evidence into concise
+  summary, brief, and compact incident-bundle smoke metadata. Existing mixed
+  sample ordering, hard verdict/count semantics, recovery classification,
+  redaction, event production, and `max_problem_events` bounds remain
+  unchanged.
+- Triggering evidence: PR #1310 fixed the full report after the PR #1309
+  restart smoke exposed mixed-sample eviction, but concise and brief summaries
+  still project only hard counts and grouped types. Incident bundles consume
+  the brief projection, so those operator surfaces can remain red without the
+  separately retained hard classifications now available in the full report.
 - Behavior boundary: read-only report projection only. Event publication,
   recovery, process control, exchange access, and trading behavior are
   unchanged.
-- Validation: focused mixed-eviction, positive truncation, and zero-bound
-  regressions; complete smoke-report tests; AI-doc, compile, and diff checks;
-  complete Python and Rust suites before publication.
+- Validation: focused mixed-eviction, summary/brief truncation, zero-bound,
+  incident-bundle manifest, and CLI regressions; complete Python and Rust
+  suites; Rust check/format; AI-doc, registry, compile, and diff checks.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
-- Expected VPS action: prepare the reviewed merge commit and run bounded
-  read-only report verification. No bot restart or process signal is required
+- Expected VPS action: pull the reviewed merge and run bounded read-only smoke
+  verification. No Rust rebuild, bot restart, or process signal is required
   for this offline reporting-tool change.
 
 ## Deployed Baseline
+
+- PR #1310 merged as canonical `5d06887b78c2790efd15e1bd67bae6b3f5d96636`.
+  It added full-report `hard_problem_events` with authoritative `count`,
+  bounded chronological `sample`, and explicit `retained`/`truncated` counts;
+  the existing concise/brief and incident-bundle projections were unchanged.
+- VPS5 prepared the exact clean merge without a Rust rebuild or bot restart.
+  The bounded read-only smoke was hard-green and exposed
+  `hard_problem_events={count:0,retained:0,truncated:0,sample:[]}`. All five
+  pane parents and `misc:0.0` remained unchanged.
+
+## Previous Deployed Baseline
 
 - Canonical `master` and VPS5 are
   `f1ae7970393e8299d1b0a98c8ff68d42adddd2d0` after PR #1299. The clean

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,19 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1309; Current Through PR #1299)
+## Latest Canonical Deployment (PR #1310)
+
+- PR #1310 merged as canonical `5d06887b78c2790efd15e1bd67bae6b3f5d96636`.
+  It added full-report `hard_problem_events` with authoritative `count`, a
+  bounded chronological `sample`, and explicit `retained`/`truncated` counts
+  while preserving the existing mixed sample, verdicts, recovery
+  classification, and runtime behavior.
+- VPS5 prepared that exact tracked-clean merge without a Rust rebuild or bot
+  restart. A bounded read-only smoke was hard-green and exposed
+  `hard_problem_events={count:0,retained:0,truncated:0,sample:[]}`; all five
+  pane parents and protected `misc:0.0` remained unchanged.
+
+## Previous Canonical Deployment (PR #1309; Current Through PR #1299)
 
 - PR #1309 merged as canonical
   `50c37db6049206634b62f45798a8b240a035e3b5` after exact-current-head Hermes

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -764,6 +764,14 @@ def _smoke_problem_events_result_summary(
     return _smoke_brief_section_result_summary(smoke_brief_summary, "problem_events")
 
 
+def _smoke_hard_problem_events_result_summary(
+    smoke_brief_summary: dict[str, Any],
+) -> dict[str, Any]:
+    return _smoke_brief_section_result_summary(
+        smoke_brief_summary, "hard_problem_events"
+    )
+
+
 def _smoke_process_result_summary(
     smoke_brief_summary: dict[str, Any],
 ) -> dict[str, Any]:
@@ -1247,6 +1255,9 @@ def build_live_incident_bundle(
     smoke_problem_events_summary = _smoke_problem_events_result_summary(
         smoke_brief_summary
     )
+    smoke_hard_problem_events_summary = _smoke_hard_problem_events_result_summary(
+        smoke_brief_summary
+    )
     smoke_process_summary = _smoke_process_result_summary(smoke_brief_summary)
     smoke_repository_summary = _smoke_repository_result_summary(smoke_brief_summary)
     smoke_monitor_summary = _smoke_monitor_result_summary(smoke_brief_summary)
@@ -1413,6 +1424,7 @@ def build_live_incident_bundle(
                 "monitor": smoke_monitor_summary,
                 **smoke_verdict_summary,
                 "problem_events": smoke_problem_events_summary,
+                "hard_problem_events": smoke_hard_problem_events_summary,
                 "execution": smoke_execution_summary,
                 "risk_events": smoke_risk_summary,
                 "ema_readiness": smoke_ema_readiness_summary,
@@ -1476,6 +1488,7 @@ def build_live_incident_bundle(
             "monitor": smoke_monitor_summary,
             **smoke_verdict_summary,
             "problem_events": smoke_problem_events_summary,
+            "hard_problem_events": smoke_hard_problem_events_summary,
             "execution": smoke_execution_summary,
             "risk_events": smoke_risk_summary,
             "ema_readiness": smoke_ema_readiness_summary,

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -10400,6 +10400,11 @@ def summarize_live_smoke_report(
             or len(problem_group_rows) > max_groups,
             "groups": problem_group_rows[:max_groups],
         },
+        "hard_problem_events": _project_hard_problem_events(
+            report.get("hard_problem_events"),
+            fallback_count=hard_problem_event_count,
+            limit=max_groups,
+        ),
         "remote_calls": _summary_limited_groups(
             report.get("remote_call_health") or {},
             limit=max_groups,
@@ -10501,6 +10506,62 @@ def _count_value(value: Any) -> int:
         return int(value)
     except (TypeError, ValueError):
         return 0
+
+
+def _project_hard_problem_events(
+    value: Any,
+    *,
+    fallback_count: Any,
+    limit: int,
+) -> dict[str, Any]:
+    """Keep a bounded, compact hard-event sample in report projections."""
+
+    source = value if isinstance(value, dict) else {}
+    count = max(0, _count_value(source.get("count")))
+    if not count:
+        count = max(0, _count_value(fallback_count))
+    sample = source.get("sample")
+    rows = sample if isinstance(sample, list) else []
+    safe_keys = (
+        "path",
+        "line",
+        "ts",
+        "seq",
+        "event_type",
+        "level",
+        "status",
+        "reason_code",
+        "exchange",
+        "user",
+        "symbol",
+        "pside",
+        "ids",
+        "latest_data",
+        "hard",
+        "recovered",
+        "recovery",
+    )
+    compact_rows: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        compact: dict[str, Any] = {}
+        for key in safe_keys:
+            if key not in row:
+                continue
+            safe_value = _compact_problem_event_data_value(row.get(key))
+            if safe_value not in (None, "", [], {}):
+                compact[key] = safe_value
+        if compact:
+            compact_rows.append(compact)
+    retained_sample = compact_rows[-max(0, int(limit)) :] if limit else []
+    retained = len(retained_sample)
+    return {
+        "count": count,
+        "retained": retained,
+        "truncated": max(0, count - retained),
+        "sample": retained_sample,
+    }
 
 
 def _brief_remote_call_slowest(summary: dict[str, Any]) -> list[dict[str, Any]]:
@@ -11421,6 +11482,11 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
             "non_hard": max(0, problem_event_count - hard_problem_event_count),
         }
         | _brief_problem_event_groups(report.get("problem_event_groups")),
+        "hard_problem_events": _project_hard_problem_events(
+            report.get("hard_problem_events"),
+            fallback_count=hard_problem_event_count,
+            limit=SMOKE_REPORT_BRIEF_PROBLEM_GROUP_LIMIT,
+        ),
         "remote_calls": _brief_remote_call_health(report.get("remote_call_health")),
         "account_critical_remote_calls": _brief_remote_call_health(
             report.get("account_critical_remote_call_health")

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -2343,3 +2343,66 @@ def test_live_incident_bundle_redacts_git_remote_url_userinfo():
         _redact_url_userinfo("git@github.com:enarjord/passivbot.git")
         == "git@github.com:enarjord/passivbot.git"
     )
+
+
+@pytest.mark.parametrize(
+    ("max_problem_events", "expected_retained", "expected_truncated"),
+    [(1, 1, 1), (0, 0, 2)],
+)
+def test_live_incident_bundle_retains_bounded_hard_problem_evidence(
+    tmp_path,
+    max_problem_events,
+    expected_retained,
+    expected_truncated,
+):
+    events_dir = tmp_path / "monitor" / "bybit" / "bybit_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.stopped",
+                seq=1,
+                ts=1000,
+                status="failed",
+                level="critical",
+                reason_code="terminal_startup_failure",
+            ),
+            _monitor_row(
+                event_type="execution.create_failed",
+                seq=2,
+                ts=2000,
+                status="failed",
+                level="error",
+                reason_code="exchange_exception",
+            ),
+            _monitor_row(
+                event_type="ema.unavailable",
+                seq=3,
+                ts=3000,
+                status="degraded",
+                level="warning",
+                reason_code="required_ema_unavailable",
+            ),
+        ],
+    )
+    output = tmp_path / f"incident-{max_problem_events}.tar.gz"
+
+    report = build_live_incident_bundle(
+        tmp_path / "monitor",
+        output_path=output,
+        logs_root="",
+        include_processes=False,
+        include_event_segments=False,
+        max_problem_events=max_problem_events,
+    )
+
+    hard_problem_events = report["smoke_report"]["hard_problem_events"]
+    assert hard_problem_events["count"] == 2
+    assert hard_problem_events["retained"] == expected_retained
+    assert hard_problem_events["truncated"] == expected_truncated
+    assert [event["seq"] for event in hard_problem_events["sample"]] == (
+        [2] if max_problem_events else []
+    )
+    with tarfile.open(output, "r:gz") as tar:
+        manifest = _read_tar_json(tar, "manifest.json")
+    assert manifest["smoke_report"]["hard_problem_events"] == hard_problem_events

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -7249,6 +7249,12 @@ def test_live_smoke_report_retains_hard_problem_evidence_after_mixed_sample_evic
             },
         ],
     }
+    assert summarize_live_smoke_report(report)["hard_problem_events"] == report[
+        "hard_problem_events"
+    ]
+    assert summarize_live_smoke_report_brief(report)["hard_problem_events"] == report[
+        "hard_problem_events"
+    ]
 
 
 def test_live_smoke_report_hard_problem_evidence_respects_zero_sample_limit(tmp_path):
@@ -7327,6 +7333,72 @@ def test_live_smoke_report_hard_problem_evidence_retains_latest_bounded_sample(
         2,
         3,
     ]
+
+
+def test_live_smoke_report_projects_bounded_hard_problem_evidence(tmp_path):
+    events_dir = tmp_path / "monitor" / "bybit" / "bybit_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.stopped",
+                seq=seq,
+                ts=seq * 1000,
+                status="failed",
+                level="critical",
+                reason_code=f"terminal_failure_{seq}",
+            )
+            for seq in range(1, 8)
+        ],
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        max_problem_events=7,
+    )
+    summary = summarize_live_smoke_report(report, max_groups=3)
+    brief = summarize_live_smoke_report_brief(report)
+
+    assert summary["hard_problem_events"] == {
+        "count": 7,
+        "retained": 3,
+        "truncated": 4,
+        "sample": report["hard_problem_events"]["sample"][-3:],
+    }
+    assert brief["hard_problem_events"] == {
+        "count": 7,
+        "retained": 5,
+        "truncated": 2,
+        "sample": report["hard_problem_events"]["sample"][-5:],
+    }
+
+
+def test_live_smoke_report_projects_zero_bound_hard_problem_evidence(tmp_path):
+    events_dir = tmp_path / "monitor" / "bybit" / "bybit_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.stopped",
+                seq=1,
+                ts=1000,
+                status="failed",
+                level="critical",
+                reason_code="terminal_startup_failure",
+            )
+        ],
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        max_problem_events=0,
+    )
+    expected = {"count": 1, "retained": 0, "truncated": 1, "sample": []}
+
+    assert summarize_live_smoke_report(report)["hard_problem_events"] == expected
+    assert summarize_live_smoke_report_brief(report)["hard_problem_events"] == expected
 
 
 def test_live_smoke_report_summarizes_problem_event_groups(tmp_path):
@@ -8160,6 +8232,12 @@ def test_live_smoke_report_cli_can_emit_concise_summary(tmp_path, capsys):
     assert "account_critical_remote_calls" in summary
     assert "bots" not in summary
     assert "problem_events" in summary
+    assert summary["hard_problem_events"] == {
+        "count": 0,
+        "retained": 0,
+        "truncated": 0,
+        "sample": [],
+    }
 
 
 def test_live_smoke_report_cli_can_emit_brief_summary(tmp_path, capsys):
@@ -8212,6 +8290,12 @@ def test_live_smoke_report_cli_can_emit_brief_summary(tmp_path, capsys):
     assert summary["problem_events"]["hard"] == 0
     assert summary["problem_events"]["total"] == 1
     assert summary["problem_events"]["non_hard"] == 1
+    assert summary["hard_problem_events"] == {
+        "count": 0,
+        "retained": 0,
+        "truncated": 0,
+        "sample": [],
+    }
     assert summary["problem_events"]["event_types"] == {"remote_call.failed": 1}
     assert summary["problem_events"]["event_types_truncated"] is False
     assert summary["problem_events"]["groups"] == [


### PR DESCRIPTION
## Summary

- retain bounded hard-only problem evidence in `live-smoke-report --summary` and `--brief`
- carry the same compact evidence into incident-bundle result and manifest smoke metadata
- recompute `retained` and `truncated` for each projection's existing output bound
- record PR #1310's exact no-restart VPS5 deployment evidence

## Scope

Category: **read-only tooling**.

Touched surfaces:
- smoke report summary/brief projection
- incident bundle compact smoke metadata
- focused report/bundle tests and logging-overhaul status documentation

Non-goals:
- no event producer or schema change
- no problem classification, recovery, or smoke-verdict change
- no exchange access, process control, restart behavior, or trading-path change
- existing mixed `problem_events` behavior remains unchanged

## Behavior

Full reports already retain a separately bounded `hard_problem_events` sample. Concise summaries
and incident bundles previously kept only hard counts/grouped types, so a red operator artifact
could still omit the retained hard classifications. They now expose:

```json
{"count": 2, "retained": 2, "truncated": 0, "sample": [...]}
```

Samples use the existing compact/redacted event projection and each surface's existing group limit.

## Validation

- focused `tests/test_live_smoke_report.py tests/test_live_incident_bundle.py`: passed
- complete Python suite: passed after rebuilding the exact-master Rust extension
- Rust: 210 tests passed with `--no-default-features`
- `cargo check --tests`: passed
- `cargo fmt --check`: passed
- changed Python module compile: passed
- AI documentation check: 0 errors; existing repository-wide size warning only
- generated live-event registry check: current
- `git diff --check`: passed

## Reviewer Focus

- summary/brief bounds remain independent and chronological
- authoritative count is preserved when sample retention is zero
- incident result and archived manifest expose the same safe hard-only evidence
- no runtime or verdict semantics changed

## VPS Action

Prepare the reviewed merge commit and run a bounded read-only smoke/incident projection check. No
Rust rebuild, bot restart, or process signal is required.
