### PR TITLE
Fix inactive forager candidate 1h readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,10 +46,13 @@ All notable user-facing changes will be documented in this file.
   off unavailable native-1h leading-prefix retries only after successful fetches, keeps known-stale
   unfetched surfaces pending, and derives staleness from the actually refreshable universe. Forced
   native higher-timeframe reads bypass partial range-cache hits, preserve complete disk coverage
-  when a retry returns only a partial range, and invalidate the refreshed timeframe's EMA cache.
-  Backoff is scoped to the requested window size, while zero-budget cycles perform no fetches or
-  per-symbol warmup computation even with open slots. This prevents cache-only planning from
-  freezing the selection universe around incumbents whose 1h log-range cache alone remained fresh.
+  when a retry returns only a partial range, keep incomplete ranges out of reusable EMA state, and
+  invalidate the refreshed timeframe's EMA cache. Backoff is scoped to the requested window and
+  begins only after a nonempty fetch still proves its leading gap. Health-only scans do not consume
+  fetch tokens, and native 1h work is scheduled only for nonzero strategy weights. Zero-budget
+  cycles perform no fetches or per-symbol warmup computation even with open slots. This prevents
+  cache-only planning from freezing the selection universe around incumbents whose 1h log-range
+  cache alone remained fresh.
 
 - Live startups now persist an immutable, non-secret runtime manifest and expose
   the same Python commit, config hash, embedded Rust source fingerprint, loaded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ All notable user-facing changes will be documented in this file.
   calculation, API calls, refresh cadence, planning, orders, and risk are
   unchanged.
 
+- Live forager background refresh now schedules the native 1h candle windows required by inactive
+  candidates in addition to their 1m inputs. Candidate refresh budgeting operates per
+  symbol/timeframe surface and rotates incomplete surfaces across cycles, preventing cache-only
+  planning from freezing the selection universe around incumbents whose 1h log-range cache alone
+  happened to remain fresh.
+
 - Full live smoke reports now retain a separately bounded sample of hard
   structured problem events, with authoritative total, retained, and truncated
   counts. Later warning-level attention can no longer hide every classification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,11 @@ All notable user-facing changes will be documented in this file.
   stale-tail limits, interleaves 1m and 1h health checks while prioritizing cold 1m fetches, backs
   off unavailable native-1h leading-prefix retries only after successful fetches, keeps known-stale
   unfetched surfaces pending, and derives staleness from the actually refreshable universe. Forced
-  native higher-timeframe reads bypass partial range-cache hits, while zero-budget cycles perform no
-  fetches or per-symbol warmup computation even with open slots. This prevents cache-only planning
-  from freezing the selection universe around incumbents whose 1h log-range cache alone remained
-  fresh.
+  native higher-timeframe reads bypass partial range-cache hits, preserve complete disk coverage
+  when a retry returns only a partial range, and invalidate the refreshed timeframe's EMA cache.
+  Backoff is scoped to the requested window size, while zero-budget cycles perform no fetches or
+  per-symbol warmup computation even with open slots. This prevents cache-only planning from
+  freezing the selection universe around incumbents whose 1h log-range cache alone remained fresh.
 
 - Full live smoke reports now retain a separately bounded sample of hard
   structured problem events, with authoritative total, retained, and truncated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@ All notable user-facing changes will be documented in this file.
 
 - Live forager background refresh now schedules the native 1h candle windows required by inactive
   candidates in addition to their 1m inputs. Candidate refresh budgeting operates per
-  symbol/timeframe surface and rotates incomplete surfaces across cycles, preventing cache-only
-  planning from freezing the selection universe around incumbents whose 1h log-range cache alone
-  happened to remain fresh.
+  symbol/timeframe surface, bounds and rotates cache-health scans, honors configured warmup and
+  stale-tail limits, prioritizes cold 1m basis before 1h backfills, and makes forced native
+  higher-timeframe reads bypass partial range-cache hits. This prevents cache-only planning from
+  freezing the selection universe around incumbents whose 1h log-range cache alone remained fresh.
 
 - Full live smoke reports now retain a separately bounded sample of hard
   structured problem events, with authoritative total, retained, and truncated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,8 @@ All notable user-facing changes will be documented in this file.
   unfetched surfaces pending, and derives staleness from the actually refreshable universe. Forced
   native higher-timeframe reads bypass partial range-cache hits, preserve complete disk coverage
   when a retry returns only a partial range, keep incomplete ranges out of reusable EMA state, and
-  invalidate the refreshed timeframe's EMA cache. Backoff is scoped to the requested window and
+  invalidate the refreshed timeframe's EMA cache and overlapping range-cache entries. Backoff is
+  scoped to the requested window and
   begins only after a nonempty fetch still proves its leading gap. Health-only scans do not consume
   fetch tokens, and native 1h work is scheduled only for nonzero strategy weights. Zero-budget
   cycles perform no fetches or per-symbol warmup computation even with open slots. This prevents

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,12 @@ All notable user-facing changes will be documented in this file.
   candidates in addition to their 1m inputs. Candidate refresh budgeting operates per
   symbol/timeframe surface, bounds and rotates cache-health scans, honors configured warmup and
   stale-tail limits, interleaves 1m and 1h health checks while prioritizing cold 1m fetches, backs
-  off unavailable native-1h leading-prefix retries, and makes forced native higher-timeframe reads
-  bypass partial range-cache hits. Zero-budget cycles also skip per-symbol warmup computation. This
-  prevents cache-only planning from
-  freezing the selection universe around incumbents whose 1h log-range cache alone remained fresh.
+  off unavailable native-1h leading-prefix retries only after successful fetches, keeps known-stale
+  unfetched surfaces pending, and derives staleness from the actually refreshable universe. Forced
+  native higher-timeframe reads bypass partial range-cache hits, while zero-budget cycles perform no
+  fetches or per-symbol warmup computation even with open slots. This prevents cache-only planning
+  from freezing the selection universe around incumbents whose 1h log-range cache alone remained
+  fresh.
 
 - Full live smoke reports now retain a separately bounded sample of hard
   structured problem events, with authoritative total, retained, and truncated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,10 @@ All notable user-facing changes will be documented in this file.
 - Live forager background refresh now schedules the native 1h candle windows required by inactive
   candidates in addition to their 1m inputs. Candidate refresh budgeting operates per
   symbol/timeframe surface, bounds and rotates cache-health scans, honors configured warmup and
-  stale-tail limits, prioritizes cold 1m basis before 1h backfills, and makes forced native
-  higher-timeframe reads bypass partial range-cache hits. This prevents cache-only planning from
+  stale-tail limits, interleaves 1m and 1h health checks while prioritizing cold 1m fetches, backs
+  off unavailable native-1h leading-prefix retries, and makes forced native higher-timeframe reads
+  bypass partial range-cache hits. Zero-budget cycles also skip per-symbol warmup computation. This
+  prevents cache-only planning from
   freezing the selection universe around incumbents whose 1h log-range cache alone remained fresh.
 
 - Full live smoke reports now retain a separately bounded sample of hard

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -37,9 +37,12 @@
    current day and two preceding complete UTC days.
 8. Live forager planning is cache-only for inactive candidates. Its background refresher must warm
    every required native candle surface, including both 1m inputs and native 1h log-range inputs,
-   using the same per-symbol strategy requirements as startup warmup. Refresh budgets count
-   symbol/timeframe fetches, and incomplete surfaces remain queued fairly across cycle and
-   wall-time caps.
+   using the same per-symbol strategy requirements and explicit warmup cap as startup warmup.
+   Tail-only gaps remain eligible within the configured candidate staleness window; missing basis
+   and internal gaps do not. Refresh budgets count symbol/timeframe fetches, health scans are
+   bounded and rotated across cycles, and never-attempted 1m surfaces precede native 1h backfills.
+   A forced native higher-timeframe refresh bypasses in-memory range and complete-disk
+   short-circuits so a partial cached range cannot consume budget without retrying the exchange.
 
 Cache paths use `to_standard_exchange_name()` rather than raw CCXT identifiers such as
 `binanceusdm` or `kucoinfutures`.

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -41,9 +41,12 @@
    Tail-only gaps remain eligible within the configured candidate staleness window; missing basis
    and internal gaps do not. Refresh budgets count symbol/timeframe fetches, health scans are
    bounded and rotated across cycles, interleave each candidate's 1m and native 1h health surfaces,
-   and prioritize never-attempted 1m fetches before native 1h backfills. A native 1h range with a
-   fresh tail and only an unavailable leading prefix remains nontradable and is retried at most
-   once per 24 hours instead of consuming refresh budget every cycle.
+   keep discovered-but-unfetched stale surfaces pending, and prioritize never-attempted 1m fetches
+   before native 1h backfills. Staleness targets count only surfaces handled by this background
+   refresher, excluding urgent active symbols. A native 1h range with a fresh tail and only an
+   unavailable leading prefix remains nontradable and is retried at most once per 24 hours after a
+   successful fetch; failed fetches remain eligible for normal retry. A zero OHLCV network budget
+   disables candidate fetches even when entry slots are open.
    A forced native higher-timeframe refresh bypasses in-memory range and complete-disk
    short-circuits so a partial cached range cannot consume budget without retrying the exchange.
 

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -35,6 +35,11 @@
    SHA-256 sidecar before parsing, and write only invalid v2 rows. Monthly archives are attempted
    only after Binance's first-Monday publication window plus a buffer; daily archives exclude the
    current day and two preceding complete UTC days.
+8. Live forager planning is cache-only for inactive candidates. Its background refresher must warm
+   every required native candle surface, including both 1m inputs and native 1h log-range inputs,
+   using the same per-symbol strategy requirements as startup warmup. Refresh budgets count
+   symbol/timeframe fetches, and incomplete surfaces remain queued fairly across cycle and
+   wall-time caps.
 
 Cache paths use `to_standard_exchange_name()` rather than raw CCXT identifiers such as
 `binanceusdm` or `kucoinfutures`.

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -40,7 +40,10 @@
    using the same per-symbol strategy requirements and explicit warmup cap as startup warmup.
    Tail-only gaps remain eligible within the configured candidate staleness window; missing basis
    and internal gaps do not. Refresh budgets count symbol/timeframe fetches, health scans are
-   bounded and rotated across cycles, and never-attempted 1m surfaces precede native 1h backfills.
+   bounded and rotated across cycles, interleave each candidate's 1m and native 1h health surfaces,
+   and prioritize never-attempted 1m fetches before native 1h backfills. A native 1h range with a
+   fresh tail and only an unavailable leading prefix remains nontradable and is retried at most
+   once per 24 hours instead of consuming refresh budget every cycle.
    A forced native higher-timeframe refresh bypasses in-memory range and complete-disk
    short-circuits so a partial cached range cannot consume budget without retrying the exchange.
 

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -45,10 +45,13 @@
    before native 1h backfills. Staleness targets count only surfaces handled by this background
    refresher, excluding urgent active symbols. A native 1h range with a fresh tail and only an
    unavailable leading prefix remains nontradable and is retried at most once per 24 hours after a
-   successful fetch; failed fetches remain eligible for normal retry. A zero OHLCV network budget
-   disables candidate fetches even when entry slots are open.
+   successful fetch of the same requested window size; changed requirements and failed fetches
+   remain eligible for normal retry. A zero OHLCV network budget disables candidate fetches even
+   when entry slots are open.
    A forced native higher-timeframe refresh bypasses in-memory range and complete-disk
    short-circuits so a partial cached range cannot consume budget without retrying the exchange.
+   Fresh remote rows overwrite matching disk rows, but partial remote results retain any existing
+   disk coverage, and affected higher-timeframe EMA cache entries are invalidated.
 
 Cache paths use `to_standard_exchange_name()` rather than raw CCXT identifiers such as
 `binanceusdm` or `kucoinfutures`.

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -36,22 +36,26 @@
    only after Binance's first-Monday publication window plus a buffer; daily archives exclude the
    current day and two preceding complete UTC days.
 8. Live forager planning is cache-only for inactive candidates. Its background refresher must warm
-   every required native candle surface, including both 1m inputs and native 1h log-range inputs,
-   using the same per-symbol strategy requirements and explicit warmup cap as startup warmup.
+   every consumed native candle surface, including 1m inputs and native 1h log-range inputs with a
+   nonzero strategy weight, using the same per-symbol requirements and explicit warmup cap as the
+   live EMA bundle.
    Tail-only gaps remain eligible within the configured candidate staleness window; missing basis
    and internal gaps do not. Refresh budgets count symbol/timeframe fetches, health scans are
    bounded and rotated across cycles, interleave each candidate's 1m and native 1h health surfaces,
-   keep discovered-but-unfetched stale surfaces pending, and prioritize never-attempted 1m fetches
-   before native 1h backfills. Staleness targets count only surfaces handled by this background
+   keep discovered-but-unfetched stale surfaces pending, charge tokens only for selected fetches,
+   and prioritize never-attempted 1m fetches before native 1h backfills. Staleness targets count
+   only surfaces handled by this background
    refresher, excluding urgent active symbols. A native 1h range with a fresh tail and only an
    unavailable leading prefix remains nontradable and is retried at most once per 24 hours after a
-   successful fetch of the same requested window size; changed requirements and failed fetches
-   remain eligible for normal retry. A zero OHLCV network budget disables candidate fetches even
-   when entry slots are open.
+   successful nonempty fetch which still proves the same requested leading-prefix gap; changed
+   requirements, empty results, partial pagination failures, and other failed fetches remain
+   eligible for normal retry. A zero OHLCV network budget disables candidate fetches even when
+   entry slots are open.
    A forced native higher-timeframe refresh bypasses in-memory range and complete-disk
    short-circuits so a partial cached range cannot consume budget without retrying the exchange.
    Fresh remote rows overwrite matching disk rows, but partial remote results retain any existing
-   disk coverage, and affected higher-timeframe EMA cache entries are invalidated.
+   disk coverage without entering the reusable range or EMA caches. Affected higher-timeframe EMA
+   cache entries are invalidated, and higher-timeframe EMAs require full requested coverage.
 
 Cache paths use `to_standard_exchange_name()` rather than raw CCXT identifiers such as
 `binanceusdm` or `kucoinfutures`.

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -2604,6 +2604,30 @@ class CandlestickManager:
         else:
             del self._ema_cache[symbol]
 
+    def _invalidate_tf_range_cache(
+        self,
+        symbol: str,
+        *,
+        timeframe: str,
+        start_ts: int,
+        end_ts: int,
+    ) -> None:
+        """Invalidate cached ranges overlapping persisted candles for one timeframe."""
+        sym_cache = self._tf_range_cache.get(symbol)
+        if not sym_cache:
+            return
+        overlapping = [
+            key
+            for key in sym_cache
+            if str(key[0]) == str(timeframe)
+            and int(key[1]) <= int(end_ts)
+            and int(key[2]) >= int(start_ts)
+        ]
+        for key in overlapping:
+            sym_cache.pop(key, None)
+        if not sym_cache:
+            self._tf_range_cache.pop(symbol, None)
+
     def needs_ema_recompute(self, symbol: str) -> bool:
         """Check if EMAs for a symbol should be recomputed due to synthetic data replacement.
 
@@ -5847,6 +5871,14 @@ class CandlestickManager:
                     else:
                         out = fetched_out
                     self._invalidate_ema_cache(symbol, timeframe=out_tf)
+                    if fetched_out.size:
+                        self._invalidate_tf_range_cache(
+                            symbol,
+                            timeframe=out_tf,
+                            start_ts=int(_ts_index(fetched_out)[0]),
+                            end_ts=int(_ts_index(fetched_out)[-1]),
+                        )
+                        sym_cache = self._tf_range_cache.setdefault(symbol, OrderedDict())
                     if self._candle_range_has_full_coverage(
                         out, int(start_ts), int(end_ts), int(period_ms)
                     ):

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -5704,18 +5704,23 @@ class CandlestickManager:
                 sym_cache = self._tf_range_cache.setdefault(symbol, OrderedDict())
                 if cache_key in sym_cache:
                     arr_cached, fetched_at = sym_cache[cache_key]
-                    try:
-                        sym_cache.move_to_end(cache_key)
-                    except Exception:
-                        pass
-                    if (
-                        max_age_ms is None
-                        or (
-                            max_age_ms > 0
-                            and (now - int(fetched_at)) <= int(max_age_ms)
-                        )
+                    if self._candle_range_has_full_coverage(
+                        arr_cached, int(start_ts), int(end_ts), int(period_ms)
                     ):
-                        return arr_cached
+                        try:
+                            sym_cache.move_to_end(cache_key)
+                        except Exception:
+                            pass
+                        if (
+                            max_age_ms is None
+                            or (
+                                max_age_ms > 0
+                                and (now - int(fetched_at)) <= int(max_age_ms)
+                            )
+                        ):
+                            return arr_cached
+                    else:
+                        sym_cache.pop(cache_key, None)
 
                 # If disk has full coverage for this TF window, serve it without network
                 if max_age_ms != 0 and isinstance(disk_arr, np.ndarray) and disk_arr.size:
@@ -5794,6 +5799,7 @@ class CandlestickManager:
                         nonlocal persisted_batches
                         persisted_batches = True
                         self._persist_batch(symbol, batch, timeframe=out_tf)
+                        self._invalidate_ema_cache(symbol, timeframe=out_tf)
 
                     try:
                         fetched = await self._fetch_ohlcv_paginated(
@@ -5802,6 +5808,7 @@ class CandlestickManager:
                             int(end_excl),
                             timeframe=out_tf,
                             on_batch=_persist_tf_batch,
+                            raise_on_partial_empty_page=max_age_ms == 0,
                         )
                     except TypeError:
                         fetched = await self._fetch_ohlcv_paginated(
@@ -5811,6 +5818,10 @@ class CandlestickManager:
                             timeframe=out_tf,
                         )
                     if fetched.size == 0:
+                        if max_age_ms == 0:
+                            sym_cache.pop(cache_key, None)
+                            self._tf_range_cache[symbol] = sym_cache
+                            return fetched
                         if isinstance(disk_arr, np.ndarray) and disk_arr.size:
                             out = self._slice_ts_range(disk_arr, start_ts, end_ts)
                             sym_cache[cache_key] = (out, int(now))
@@ -5836,13 +5847,18 @@ class CandlestickManager:
                     else:
                         out = fetched_out
                     self._invalidate_ema_cache(symbol, timeframe=out_tf)
-                    sym_cache[cache_key] = (out, int(now))
-                    try:
-                        sym_cache.move_to_end(cache_key)
-                    except Exception:
-                        pass
-                    while len(sym_cache) > self._tf_range_cache_cap:
-                        sym_cache.popitem(last=False)
+                    if self._candle_range_has_full_coverage(
+                        out, int(start_ts), int(end_ts), int(period_ms)
+                    ):
+                        sym_cache[cache_key] = (out, int(now))
+                        try:
+                            sym_cache.move_to_end(cache_key)
+                        except Exception:
+                            pass
+                        while len(sym_cache) > self._tf_range_cache_cap:
+                            sym_cache.popitem(last=False)
+                    else:
+                        sym_cache.pop(cache_key, None)
                     self._tf_range_cache[symbol] = sym_cache
                     return out
 
@@ -7025,6 +7041,33 @@ class CandlestickManager:
             return False
         return bool(np.any(timestamps == int(end_ts)))
 
+    def _candle_range_has_full_coverage(
+        self,
+        arr: np.ndarray,
+        start_ts: int,
+        end_ts: int,
+        period_ms: int,
+    ) -> bool:
+        """Return whether candles cover every requested bucket exactly once."""
+        if not isinstance(arr, np.ndarray) or arr.size == 0 or period_ms <= 0:
+            return False
+        try:
+            timestamps = np.unique(np.asarray(arr["ts"], dtype=np.int64))
+        except (KeyError, TypeError, ValueError):
+            return False
+        expected_len = int((int(end_ts) - int(start_ts)) // int(period_ms)) + 1
+        if (
+            expected_len <= 0
+            or timestamps.size != expected_len
+            or int(timestamps[0]) != int(start_ts)
+            or int(timestamps[-1]) != int(end_ts)
+        ):
+            return False
+        return bool(
+            expected_len == 1
+            or np.all(np.diff(timestamps) == int(period_ms))
+        )
+
     async def get_latest_ema_close(
         self,
         symbol: str,
@@ -7301,6 +7344,10 @@ class CandlestickManager:
             return float("nan")
         if not self._ema_window_has_expected_tail(arr, end_ts):
             return float("nan")
+        if period_ms > ONE_MIN_MS and not self._candle_range_has_full_coverage(
+            arr, start_ts, end_ts, period_ms
+        ):
+            return float("nan")
         series = series_fn(arr)
         res = float(self._ema(series, span))
         cache[key] = (res, int(end_ts), int(now))
@@ -7374,6 +7421,12 @@ class CandlestickManager:
                 out[metric_key] = float("nan")
             return out
         if not self._ema_window_has_expected_tail(raw, end_ts):
+            for metric_key in missing:
+                out[metric_key] = float("nan")
+            return out
+        if period_ms > ONE_MIN_MS and not self._candle_range_has_full_coverage(
+            raw, start_ts, end_ts, period_ms
+        ):
             for metric_key in missing:
                 out[metric_key] = float("nan")
             return out

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -2584,9 +2584,24 @@ class CandlestickManager:
         )
         return 0
 
-    def _invalidate_ema_cache(self, symbol: str) -> None:
-        """Invalidate all cached EMA values for a symbol, forcing recomputation."""
-        if symbol in self._ema_cache:
+    def _invalidate_ema_cache(
+        self, symbol: str, *, timeframe: Optional[str] = None
+    ) -> None:
+        """Invalidate cached EMA values for a symbol, optionally for one timeframe."""
+        if symbol not in self._ema_cache:
+            return
+        if timeframe is None:
+            del self._ema_cache[symbol]
+            return
+        tf_key = str(_tf_to_ms(timeframe))
+        retained = {
+            key: value
+            for key, value in self._ema_cache[symbol].items()
+            if len(key) < 3 or str(key[2]) != tf_key
+        }
+        if retained:
+            self._ema_cache[symbol] = retained
+        else:
             del self._ema_cache[symbol]
 
     def needs_ema_recompute(self, symbol: str) -> bool:
@@ -5808,9 +5823,19 @@ class CandlestickManager:
                             self._tf_range_cache[symbol] = sym_cache
                             return out
                         return fetched
-                    out = self._slice_ts_range(fetched, start_ts, end_ts)
-                    if out.size and not persisted_batches:
-                        self._persist_batch(symbol, out, timeframe=out_tf)
+                    fetched_out = self._slice_ts_range(fetched, start_ts, end_ts)
+                    if fetched_out.size and not persisted_batches:
+                        self._persist_batch(symbol, fetched_out, timeframe=out_tf)
+                    if isinstance(disk_arr, np.ndarray) and disk_arr.size:
+                        disk_out = self._slice_ts_range(disk_arr, start_ts, end_ts)
+                        out = self._slice_ts_range(
+                            self._merge_overwrite(disk_out, fetched_out),
+                            start_ts,
+                            end_ts,
+                        )
+                    else:
+                        out = fetched_out
+                    self._invalidate_ema_cache(symbol, timeframe=out_tf)
                     sym_cache[cache_key] = (out, int(now))
                     try:
                         sym_cache.move_to_end(cache_key)

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -5695,13 +5695,15 @@ class CandlestickManager:
                         pass
                     if (
                         max_age_ms is None
-                        or max_age_ms == 0
-                        or (now - int(fetched_at)) <= int(max_age_ms)
+                        or (
+                            max_age_ms > 0
+                            and (now - int(fetched_at)) <= int(max_age_ms)
+                        )
                     ):
                         return arr_cached
 
                 # If disk has full coverage for this TF window, serve it without network
-                if isinstance(disk_arr, np.ndarray) and disk_arr.size:
+                if max_age_ms != 0 and isinstance(disk_arr, np.ndarray) and disk_arr.size:
                     out_disk = self._slice_ts_range(disk_arr, start_ts, end_ts)
                     if out_disk.size:
                         # verify full coverage with proper step
@@ -5744,7 +5746,7 @@ class CandlestickManager:
                     except Exception:
                         disk_arr = None
 
-                    if isinstance(disk_arr, np.ndarray) and disk_arr.size:
+                    if max_age_ms != 0 and isinstance(disk_arr, np.ndarray) and disk_arr.size:
                         out_disk = self._slice_ts_range(disk_arr, start_ts, end_ts)
                         if out_disk.size:
                             tsd = _ts_index(out_disk)

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -4275,6 +4275,117 @@ class Passivbot:
             error_label="live warmup",
         )
 
+    @staticmethod
+    def _required_h1_log_range_span_for_strategy(
+        strategy_params: dict,
+        *,
+        pside: str,
+        symbol: str,
+        strategy_kind: str,
+    ) -> float:
+        """Return the native-1h span only when live strategy logic consumes it."""
+        requirements = strategy_warmup_requirements(
+            strategy_params,
+            pside=pside,
+            symbol=symbol,
+            error_label="live warmup",
+        )
+        h1_span = float(requirements.max_h1_span_hours)
+        if h1_span <= 0.0:
+            return 0.0
+        h1_weight = max(
+            strategy_abs_max_weight(
+                strategy_params,
+                context=f"strategy {pside}.entry_volatility_1h_weight",
+                symbol=symbol,
+                pside=pside,
+                error_label="live warmup",
+                optional=False,
+                paths=(
+                    ("entry", "threshold_volatility_1h_weight"),
+                    ("entry", "retracement_volatility_1h_weight"),
+                    ("entry", "grid_spacing_volatility_weight"),
+                    ("entry", "trailing_threshold_volatility_weight"),
+                    ("entry", "trailing_retracement_volatility_weight"),
+                    ("entry_weight_volatility_1h",),
+                    ("offset_volatility_1h_weight",),
+                ),
+            ),
+            strategy_abs_max_weight(
+                strategy_params,
+                context=f"strategy {pside}.close_volatility_1h_weight",
+                symbol=symbol,
+                pside=pside,
+                error_label="live warmup",
+                optional=strategy_kind == "trailing_grid_v7",
+                paths=(
+                    ("close", "threshold_volatility_1h_weight"),
+                    ("close", "retracement_volatility_1h_weight"),
+                    ("close_weight_volatility_1h",),
+                    ("offset_volatility_1h_weight",),
+                ),
+            ),
+        )
+        return h1_span if h1_weight > 0.0 else 0.0
+
+    def _live_required_h1_log_range_span(
+        self, pside: str, symbol: str
+    ) -> float:
+        """Return the native-1h span required by this live side and symbol."""
+        strategy_getter = getattr(self, "_strategy_params_to_rust_dict", None)
+        if callable(strategy_getter):
+            strategy_params = strategy_getter(pside, symbol)
+        else:
+            def legacy_value(key: str) -> float:
+                try:
+                    raw = self.bp(pside, key, symbol)
+                except KeyError:
+                    return 0.0
+                return Passivbot._positive_finite_warmup_value(
+                    raw,
+                    context=f"legacy strategy {pside}.{key}",
+                    symbol=symbol,
+                )
+
+            h1_span = legacy_value("entry_volatility_ema_span_1h")
+            if h1_span <= 0.0:
+                h1_span = legacy_value("entry_volatility_ema_span_hours")
+            if h1_span <= 0.0:
+                h1_span = legacy_value("volatility_ema_span_1h")
+            strategy_params = {
+                "ema_span_0": legacy_value("ema_span_0"),
+                "ema_span_1": legacy_value("ema_span_1"),
+                "volatility_ema_span_1m": legacy_value(
+                    "entry_volatility_ema_span_1m"
+                ),
+                "volatility_ema_span_1h": h1_span,
+                "entry": {
+                    "threshold_volatility_1m_weight": legacy_value(
+                        "entry_weight_volatility_1m"
+                    ),
+                    "threshold_volatility_1h_weight": legacy_value(
+                        "entry_weight_volatility_1h"
+                    ),
+                },
+                "close": {
+                    "threshold_volatility_1m_weight": legacy_value(
+                        "close_weight_volatility_1m"
+                    ),
+                    "threshold_volatility_1h_weight": legacy_value(
+                        "close_weight_volatility_1h"
+                    ),
+                },
+            }
+        strategy_kind = normalize_strategy_kind(
+            self.config.get("live", {}).get("strategy_kind")
+        )
+        return Passivbot._required_h1_log_range_span_for_strategy(
+            strategy_params,
+            pside=pside,
+            symbol=symbol,
+            strategy_kind=strategy_kind,
+        )
+
     def _live_forager_warmup_value(self, pside: str, key: str, symbol: str) -> float:
         """Return grouped forager indicator spans for live candle warmup."""
         bot_value = getattr(self, "bot_value", None)
@@ -15380,43 +15491,13 @@ class Passivbot:
                     )
                 if m1_lr_weight > 0.0 and m1_lr_span > 0.0 and math.isfinite(m1_lr_span):
                     need_m1_lr_spans[symbol].add(m1_lr_span)
-                h1_span = requirements.max_h1_span_hours
-                h1_lr_weight = 0.0
-                if h1_span > 0.0:
-                    h1_lr_weight = max(
-                        strategy_abs_max_weight(
-                            strategy_params,
-                            context=f"strategy {pside}.entry_volatility_1h_weight",
-                            symbol=symbol,
-                            pside=pside,
-                            error_label="live warmup",
-                            optional=False,
-                            paths=(
-                                ("entry", "threshold_volatility_1h_weight"),
-                                ("entry", "retracement_volatility_1h_weight"),
-                                ("entry", "grid_spacing_volatility_weight"),
-                                ("entry", "trailing_threshold_volatility_weight"),
-                                ("entry", "trailing_retracement_volatility_weight"),
-                                ("entry_weight_volatility_1h",),
-                                ("offset_volatility_1h_weight",),
-                            ),
-                        ),
-                        strategy_abs_max_weight(
-                            strategy_params,
-                            context=f"strategy {pside}.close_volatility_1h_weight",
-                            symbol=symbol,
-                            pside=pside,
-                            error_label="live warmup",
-                            optional=strategy_kind == "trailing_grid_v7",
-                            paths=(
-                                ("close", "threshold_volatility_1h_weight"),
-                                ("close", "retracement_volatility_1h_weight"),
-                                ("close_weight_volatility_1h",),
-                                ("offset_volatility_1h_weight",),
-                            ),
-                        ),
-                    )
-                if h1_lr_weight > 0.0 and h1_span > 0.0 and math.isfinite(h1_span):
+                h1_span = Passivbot._required_h1_log_range_span_for_strategy(
+                    strategy_params,
+                    pside=pside,
+                    symbol=symbol,
+                    strategy_kind=strategy_kind,
+                )
+                if h1_span > 0.0 and math.isfinite(h1_span):
                     need_h1_lr_spans[symbol].add(h1_span)
 
         # Forager metrics use global spans (per side); include them for all symbols.
@@ -17797,6 +17878,7 @@ class Passivbot:
         *,
         max_cycle_budget: Optional[int] = None,
         initial_tokens: Optional[float] = None,
+        consume: bool = True,
     ) -> int:
         """Token bucket budget for forager candle refreshes."""
         if initial_tokens is None:
@@ -17806,6 +17888,7 @@ class Passivbot:
             max_calls_per_minute,
             max_cycle_budget=max_cycle_budget,
             initial_tokens=initial_tokens,
+            consume=consume,
         )
 
     def _token_bucket_budget(
@@ -17815,8 +17898,9 @@ class Passivbot:
         *,
         max_cycle_budget: Optional[int] = None,
         initial_tokens: Optional[float] = None,
+        consume: bool = True,
     ) -> int:
-        """Return a bounded token-bucket budget for best-effort candle refreshes."""
+        """Return available token budget, optionally consuming the returned amount."""
         try:
             max_calls = int(max_calls_per_minute)
         except Exception:
@@ -17839,7 +17923,7 @@ class Passivbot:
         budget = int(tokens)
         if max_cycle_budget is not None:
             budget = min(budget, max(0, int(max_cycle_budget)))
-        state["tokens"] = float(tokens - budget)
+        state["tokens"] = float(tokens - budget if consume else tokens)
         state["last_ms"] = int(now)
         setattr(self, state_attr, state)
         return max(0, budget)
@@ -18092,6 +18176,7 @@ class Passivbot:
             max_calls,
             max_cycle_budget=cycle_cap,
             initial_tokens=cycle_cap,
+            consume=False,
         )
         if budget <= 0:
             return
@@ -18153,13 +18238,24 @@ class Passivbot:
         if not isinstance(surface_checks, dict):
             surface_checks = {}
 
+        required_h1_symbols: set[str] = set()
+        for pside, symbols in refreshable_by_side.items():
+            for sym in symbols:
+                if int(per_symbol_h1_hours.get(sym, 0) or 0) <= 0:
+                    continue
+                if (
+                    Passivbot._live_required_h1_log_range_span(self, pside, sym)
+                    > 0.0
+                ):
+                    required_h1_symbols.add(sym)
+
         surface_specs: List[Tuple[str, str, int]] = []
         for sym in candidates:
             surface_specs.append(
                 ("1m", sym, max(1, int(per_symbol_win.get(sym, default_win))))
             )
             h1_hours = int(per_symbol_h1_hours.get(sym, 0) or 0)
-            if h1_hours > 0:
+            if h1_hours > 0 and sym in required_h1_symbols:
                 surface_specs.append(("1h", sym, h1_hours))
         required_surface_count = len(surface_specs)
         target_age_ms = self._forager_target_staleness_ms(
@@ -18250,6 +18346,19 @@ class Passivbot:
             return
 
         stale.sort(key=lambda item: item[0])
+        if (
+            max_refresh_ms > 0
+            and utc_ms() - refresh_started_ms >= max_refresh_ms
+        ):
+            return
+        budget = self._forager_refresh_budget(
+            max_calls,
+            max_cycle_budget=min(cycle_cap, len(stale)),
+            initial_tokens=cycle_cap,
+            consume=True,
+        )
+        if budget <= 0:
+            return
         to_refresh = stale[:budget]
         if not to_refresh:
             return
@@ -18351,12 +18460,33 @@ class Passivbot:
                         0.001,
                         float(max_refresh_ms - elapsed_ms) / 1000.0,
                     )
-                    await asyncio.wait_for(candle_task, timeout=remaining_s)
+                    refreshed = await asyncio.wait_for(
+                        candle_task, timeout=remaining_s
+                    )
                 else:
-                    await candle_task
-                surface_successes[(sym, timeframe, int(required_candles))] = int(
-                    utc_ms()
-                )
+                    refreshed = await candle_task
+                if timeframe == "1h":
+                    try:
+                        refreshed_rows = int(refreshed.size)
+                    except (AttributeError, TypeError, ValueError):
+                        try:
+                            refreshed_rows = len(refreshed)
+                        except (TypeError, ValueError):
+                            refreshed_rows = 0
+                    post_health = Passivbot._candidate_candle_surface_health(
+                        self,
+                        sym,
+                        timeframe,
+                        required_candles,
+                        now_ms=utc_ms(),
+                    )
+                    success_key = (sym, timeframe, int(required_candles))
+                    if refreshed_rows > 0 and bool(
+                        post_health.get("leading_gap_only")
+                    ):
+                        surface_successes[success_key] = int(utc_ms())
+                    else:
+                        surface_successes.pop(success_key, None)
                 self._forager_surface_success_ms = surface_successes
                 refreshed_count += 1
                 if fetch_delay_s > 0:

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -7668,6 +7668,59 @@ class Passivbot:
             return max(0, int(now - last_refresh))
         return int(now)
 
+    def _candidate_candle_surface_health(
+        self,
+        symbol: str,
+        timeframe: str,
+        required_candles: int,
+        *,
+        now_ms: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Return cache-only readiness for one background forager candle surface."""
+        now = utc_ms() if now_ms is None else int(now_ms)
+        tf = str(timeframe)
+        try:
+            health = self.cm.get_completed_candle_health(
+                symbol,
+                {tf: max(1, int(required_candles))},
+                now_ms=now,
+            )
+            report = (health.get("timeframes", {}) or {}).get(tf, {})
+            if report:
+                last_cached_ts = report.get("last_cached_ts")
+                loaded_rows = int(report.get("loaded_rows", 0) or 0)
+                no_basis = loaded_rows <= 0 or last_cached_ts is None
+                return {
+                    "coverage_ok": bool(report.get("coverage_ok")),
+                    "age_ms": (
+                        int(now)
+                        if no_basis
+                        else int(report.get("last_cached_age_ms") or 0)
+                    ),
+                    "missing_candles": int(report.get("missing_candles", 0) or 0),
+                    "tail_gap_candles": int(report.get("tail_gap_candles", 0) or 0),
+                    "no_basis": no_basis,
+                }
+        except Exception:
+            # Compatibility fallback for lightweight candle-manager doubles and
+            # old cache layouts. The live manager supplies the detailed report.
+            if tf != "1m":
+                return {
+                    "coverage_ok": False,
+                    "age_ms": int(now),
+                    "missing_candles": max(1, int(required_candles)),
+                    "tail_gap_candles": max(1, int(required_candles)),
+                    "no_basis": True,
+                }
+        age_ms = Passivbot._candle_staleness_ms(self, symbol, now_ms=now)
+        return {
+            "coverage_ok": age_ms <= 0,
+            "age_ms": int(age_ms),
+            "missing_candles": 0 if age_ms <= 0 else 1,
+            "tail_gap_candles": 0 if age_ms <= 0 else 1,
+            "no_basis": age_ms >= now,
+        }
+
     def _rank_symbols_by_candle_staleness(
         self, symbols: Iterable[str], *, now_ms: Optional[int] = None
     ) -> list[str]:
@@ -17916,7 +17969,7 @@ class Passivbot:
             )
 
     async def _refresh_forager_candidate_candles(self) -> None:
-        """Best-effort refresh for forager candidate symbols to avoid large bursts."""
+        """Best-effort refresh for required forager candidate candle surfaces."""
         if not self.is_forager_mode():
             return
         max_calls = get_optional_live_value(
@@ -17954,6 +18007,42 @@ class Passivbot:
         if not all_candidates:
             return
 
+        try:
+            warmup_ratio = float(
+                get_optional_live_value(self.config, "warmup_ratio", 0.0) or 0.0
+            )
+        except Exception:
+            warmup_ratio = 0.0
+        try:
+            max_warmup_minutes = int(
+                get_optional_live_value(self.config, "max_warmup_minutes", 0) or 0
+            )
+        except Exception:
+            max_warmup_minutes = 0
+        per_symbol_win, per_symbol_h1_hours, _ = compute_live_warmup_windows(
+            candidates_by_side,
+            lambda pside, key, sym: self.bp(pside, key, sym),
+            forager_enabled={pside: True for pside in candidates_by_side},
+            strategy_lookup=lambda pside, key, sym: Passivbot._live_strategy_warmup_value(
+                self, pside, key, sym
+            ),
+            forager_lookup=lambda pside, key, sym: Passivbot._live_forager_warmup_value(
+                self, pside, key, sym
+            ),
+            warmup_ratio=warmup_ratio,
+            max_warmup_minutes=max_warmup_minutes,
+        )
+        try:
+            default_win = int(getattr(self.cm, "default_window_candles", 120) or 120)
+        except Exception:
+            default_win = 120
+        for sym in per_symbol_win:
+            per_symbol_win[sym] = max(default_win, int(per_symbol_win[sym]))
+
+        required_surface_count = sum(
+            1 + (1 if int(per_symbol_h1_hours.get(sym, 0) or 0) > 0 else 0)
+            for sym in all_candidates
+        )
         cycle_cap = (
             max(1, int(math.ceil(float(max_calls) / 4.0))) if max_calls > 0 else 0
         )
@@ -17969,7 +18058,7 @@ class Passivbot:
                 if budget <= 0:
                     return
             else:
-                budget = len(all_candidates)
+                budget = required_surface_count
         else:
             if max_calls <= 0:
                 return
@@ -17991,28 +18080,67 @@ class Passivbot:
 
         if slots_open_any:
             rate_limit_age_ms = self._forager_target_staleness_ms(
-                len(all_candidates), max_calls
+                required_surface_count, max_calls
             )
             # Respect rate limit even with open slots; floor at 60s for responsiveness.
             target_age_ms = max(60_000, rate_limit_age_ms) if max_calls > 0 else 60_000
         else:
             target_age_ms = self._forager_target_staleness_ms(
-                len(all_candidates), max_calls
+                required_surface_count, max_calls
             )
         now = utc_ms()
-        stale: List[Tuple[int, str]] = []
+        surface_attempts = getattr(self, "_forager_surface_attempt_ms", None)
+        if not isinstance(surface_attempts, dict):
+            surface_attempts = {}
+        eligible_surface_keys: set[Tuple[str, str]] = set()
+        stale: List[
+            Tuple[Tuple[int, int, int, int, int, str], str, str, int, Dict[str, Any]]
+        ] = []
         for sym in candidates:
-            age_ms = self._candle_staleness_ms(sym, now_ms=now)
-            if age_ms > target_age_ms:
-                stale.append((age_ms, sym))
+            surfaces = [("1m", max(1, int(per_symbol_win.get(sym, default_win))))]
+            h1_hours = int(per_symbol_h1_hours.get(sym, 0) or 0)
+            if h1_hours > 0:
+                surfaces.append(("1h", h1_hours))
+            for timeframe, required_candles in surfaces:
+                surface_key = (sym, timeframe)
+                eligible_surface_keys.add(surface_key)
+                surface_health = Passivbot._candidate_candle_surface_health(
+                    self,
+                    sym,
+                    timeframe,
+                    required_candles,
+                    now_ms=now,
+                )
+                age_ms = int(surface_health.get("age_ms", 0) or 0)
+                if bool(surface_health.get("coverage_ok")) and age_ms <= target_age_ms:
+                    continue
+                last_attempt_ms = int(surface_attempts.get(surface_key, 0) or 0)
+                priority = (
+                    last_attempt_ms,
+                    0 if bool(surface_health.get("no_basis")) else 1,
+                    -int(surface_health.get("tail_gap_candles", 0) or 0),
+                    -int(surface_health.get("missing_candles", 0) or 0),
+                    -age_ms,
+                    f"{sym}:{timeframe}",
+                )
+                stale.append((priority, sym, timeframe, required_candles, surface_health))
+        surface_attempts = {
+            key: int(value)
+            for key, value in surface_attempts.items()
+            if key in eligible_surface_keys
+        }
+        self._forager_surface_attempt_ms = surface_attempts
         if not stale:
             return
 
-        stale.sort(key=lambda item: (-int(item[0]), item[1]))
-        to_refresh = [sym for _, sym in stale[:budget]]
+        stale.sort(key=lambda item: item[0])
+        to_refresh = stale[:budget]
         if not to_refresh:
             return
-        stale_by_symbol = {sym: int(age_ms) for age_ms, sym in stale}
+        stale_by_surface = {
+            (sym, timeframe): int(surface_health.get("age_ms", 0) or 0)
+            for _priority, sym, timeframe, _required, surface_health in stale
+        }
 
         max_refresh_s_raw = get_optional_live_value(
             self.config, "max_forager_candle_refresh_seconds", 45
@@ -18033,11 +18161,11 @@ class Passivbot:
             if boot_elapsed >= boot_delay_ms:
                 last_log = int(getattr(self, "_forager_refresh_log_last_ms", 0) or 0)
                 if (now - last_log) >= 90_000:
-                    oldest_ms = int(stale[0][0]) if stale else 0
+                    oldest_ms = max(stale_by_surface.values(), default=0)
                     logging.debug(
-                        "[candle] forager refresh slots_open=%s candidates=%d stale=%d budget=%d oldest=%ds target=%ds",
+                        "[candle] forager refresh slots_open=%s surfaces=%d stale=%d budget=%d oldest=%ds target=%ds",
                         "yes" if slots_open_any else "no",
-                        len(all_candidates),
+                        required_surface_count,
                         len(stale),
                         len(to_refresh),
                         int(oldest_ms / 1000),
@@ -18047,24 +18175,10 @@ class Passivbot:
         except Exception:
             pass
 
-        end_ts = (now // ONE_MIN_MS) * ONE_MIN_MS - ONE_MIN_MS
-        try:
-            default_win = int(getattr(self.cm, "default_window_candles", 120) or 120)
-        except Exception:
-            default_win = 120
-        try:
-            warmup_ratio = float(
-                get_optional_live_value(self.config, "warmup_ratio", 0.0)
-            )
-        except Exception:
-            warmup_ratio = 0.0
-        try:
-            max_warmup_minutes = int(
-                get_optional_live_value(self.config, "max_warmup_minutes", 0) or 0
-            )
-        except Exception:
-            max_warmup_minutes = 0
-        span_buffer = 1.0 + max(0.0, warmup_ratio)
+        end_ts_by_timeframe = {
+            "1m": (now // ONE_MIN_MS) * ONE_MIN_MS - ONE_MIN_MS,
+            "1h": (now // (60 * ONE_MIN_MS)) * (60 * ONE_MIN_MS) - 60 * ONE_MIN_MS,
+        }
 
         fetch_delay_s = self._get_fetch_delay_seconds()
         refresh_started_ms = utc_ms()
@@ -18076,11 +18190,11 @@ class Passivbot:
                 getattr(self, "_forager_refresh_start_log_last_ms", 0) or 0
             )
             if refresh_started_ms - last_start_log >= 60_000:
-                oldest_ms = int(stale[0][0]) if stale else 0
+                oldest_ms = max(stale_by_surface.values(), default=0)
                 logging.debug(
-                    "[candle] forager refresh starting slots_open=%s candidates=%d stale=%d refreshing=%d oldest=%ds target=%ds",
+                    "[candle] forager refresh starting slots_open=%s surfaces=%d stale=%d refreshing=%d oldest=%ds target=%ds",
                     "yes" if slots_open_any else "no",
-                    len(all_candidates),
+                    required_surface_count,
                     len(stale),
                     len(to_refresh),
                     int(oldest_ms / 1000),
@@ -18090,7 +18204,9 @@ class Passivbot:
         except Exception:
             pass
 
-        for idx, sym in enumerate(to_refresh, start=1):
+        for idx, (_priority, sym, timeframe, required_candles, _health) in enumerate(
+            to_refresh, start=1
+        ):
             if Passivbot._shutdown_requested(self):
                 logging.debug("[shutdown] aborting forager candle refresh")
                 return
@@ -18101,55 +18217,26 @@ class Passivbot:
                     self,
                     symbol=sym,
                     max_refresh_ms=int(max_refresh_ms),
-                    stale_age_ms=int(stale_by_symbol.get(sym, 0)),
+                    stale_age_ms=int(stale_by_surface.get((sym, timeframe), 0)),
                     target_age_ms=int(target_age_ms),
                     refreshed_count=int(refreshed_count),
                     total_count=len(to_refresh),
                 )
                 break
             try:
-                max_span = 0.0
-                for pside, syms in candidates_by_side.items():
-                    if sym not in syms:
-                        continue
-                    for key in (
-                        "ema_span_0",
-                        "ema_span_1",
-                        "volatility_ema_span_1m",
-                        "offset_volatility_ema_span_1m",
-                        "entry_volatility_ema_span_1m",
-                    ):
-                        max_span = max(
-                            max_span,
-                            Passivbot._live_strategy_warmup_value(
-                                self, pside, key, sym
-                            ),
-                        )
-                    for key in (
-                        "forager_volume_ema_span_1m",
-                        "forager_volatility_ema_span_1m",
-                    ):
-                        max_span = max(
-                            max_span,
-                            Passivbot._live_forager_warmup_value(
-                                self, pside, key, sym
-                            ),
-                        )
-                win = (
-                    max(default_win, int(math.ceil(max_span * span_buffer)))
-                    if max_span > 0.0
-                    else default_win
-                )
-                if max_warmup_minutes > 0:
-                    win = min(int(win), int(max_warmup_minutes))
-                start_ts = end_ts - ONE_MIN_MS * max(1, win)
+                period_ms = ONE_MIN_MS if timeframe == "1m" else 60 * ONE_MIN_MS
+                end_ts = int(end_ts_by_timeframe[timeframe])
+                start_ts = end_ts - period_ms * max(1, int(required_candles))
+                surface_attempts[(sym, timeframe)] = int(utc_ms())
+                self._forager_surface_attempt_ms = surface_attempts
                 candle_task = self.cm.get_candles(
                     sym,
                     start_ts=start_ts,
                     end_ts=end_ts,
                     max_age_ms=0,
+                    timeframe=timeframe,
                     strict=False,
-                    max_lookback_candles=win,
+                    max_lookback_candles=int(required_candles),
                 )
                 if max_refresh_ms > 0:
                     remaining_s = max(
@@ -18184,7 +18271,7 @@ class Passivbot:
                         "[candle] forager refresh progress %d/%d last=%s elapsed=%ds",
                         idx,
                         len(to_refresh),
-                        Passivbot._log_symbol(sym),
+                        f"{Passivbot._log_symbol(sym)}:{timeframe}",
                         elapsed_s,
                     )
                     last_progress_ms = now_ms
@@ -18198,7 +18285,7 @@ class Passivbot:
                         self,
                         symbol=sym,
                         max_refresh_ms=int(max_refresh_ms),
-                        stale_age_ms=int(stale_by_symbol.get(sym, 0)),
+                        stale_age_ms=int(stale_by_surface.get((sym, timeframe), 0)),
                         target_age_ms=int(target_age_ms),
                         refreshed_count=int(refreshed_count),
                         total_count=len(to_refresh),

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -7690,6 +7690,8 @@ class Passivbot:
                 last_cached_ts = report.get("last_cached_ts")
                 loaded_rows = int(report.get("loaded_rows", 0) or 0)
                 no_basis = loaded_rows <= 0 or last_cached_ts is None
+                missing_candles = int(report.get("missing_candles", 0) or 0)
+                tail_gap_candles = int(report.get("tail_gap_candles", 0) or 0)
                 return {
                     "coverage_ok": bool(report.get("coverage_ok")),
                     "age_ms": (
@@ -7697,8 +7699,11 @@ class Passivbot:
                         if no_basis
                         else int(report.get("last_cached_age_ms") or 0)
                     ),
-                    "missing_candles": int(report.get("missing_candles", 0) or 0),
-                    "tail_gap_candles": int(report.get("tail_gap_candles", 0) or 0),
+                    "missing_candles": missing_candles,
+                    "tail_gap_candles": tail_gap_candles,
+                    "tail_only": bool(report.get("open_tail_gap"))
+                    and missing_candles > 0
+                    and missing_candles == tail_gap_candles,
                     "no_basis": no_basis,
                 }
         except Exception:
@@ -7710,6 +7715,7 @@ class Passivbot:
                     "age_ms": int(now),
                     "missing_candles": max(1, int(required_candles)),
                     "tail_gap_candles": max(1, int(required_candles)),
+                    "tail_only": False,
                     "no_basis": True,
                 }
         age_ms = Passivbot._candle_staleness_ms(self, symbol, now_ms=now)
@@ -7718,6 +7724,7 @@ class Passivbot:
             "age_ms": int(age_ms),
             "missing_candles": 0 if age_ms <= 0 else 1,
             "tail_gap_candles": 0 if age_ms <= 0 else 1,
+            "tail_only": age_ms > 0,
             "no_basis": age_ms >= now,
         }
 
@@ -18036,8 +18043,13 @@ class Passivbot:
             default_win = int(getattr(self.cm, "default_window_candles", 120) or 120)
         except Exception:
             default_win = 120
+        minimum_1m_window = (
+            min(default_win, max_warmup_minutes)
+            if max_warmup_minutes > 0
+            else default_win
+        )
         for sym in per_symbol_win:
-            per_symbol_win[sym] = max(default_win, int(per_symbol_win[sym]))
+            per_symbol_win[sym] = max(minimum_1m_window, int(per_symbol_win[sym]))
 
         required_surface_count = sum(
             1 + (1 if int(per_symbol_h1_hours.get(sym, 0) or 0) > 0 else 0)
@@ -18089,47 +18101,89 @@ class Passivbot:
                 required_surface_count, max_calls
             )
         now = utc_ms()
+        max_refresh_s_raw = get_optional_live_value(
+            self.config, "max_forager_candle_refresh_seconds", 45
+        )
+        try:
+            max_refresh_s = float(max_refresh_s_raw)
+        except Exception:
+            max_refresh_s = 45.0
+        max_refresh_ms = int(max(0.0, max_refresh_s) * 1000.0)
+        refresh_started_ms = utc_ms()
+
         surface_attempts = getattr(self, "_forager_surface_attempt_ms", None)
         if not isinstance(surface_attempts, dict):
             surface_attempts = {}
-        eligible_surface_keys: set[Tuple[str, str]] = set()
-        stale: List[
-            Tuple[Tuple[int, int, int, int, int, str], str, str, int, Dict[str, Any]]
-        ] = []
+        surface_checks = getattr(self, "_forager_surface_check_ms", None)
+        if not isinstance(surface_checks, dict):
+            surface_checks = {}
+
+        surface_specs: List[Tuple[str, str, int]] = []
         for sym in candidates:
-            surfaces = [("1m", max(1, int(per_symbol_win.get(sym, default_win))))]
+            surface_specs.append(
+                ("1m", sym, max(1, int(per_symbol_win.get(sym, default_win))))
+            )
             h1_hours = int(per_symbol_h1_hours.get(sym, 0) or 0)
             if h1_hours > 0:
-                surfaces.append(("1h", h1_hours))
-            for timeframe, required_candles in surfaces:
-                surface_key = (sym, timeframe)
-                eligible_surface_keys.add(surface_key)
-                surface_health = Passivbot._candidate_candle_surface_health(
-                    self,
-                    sym,
-                    timeframe,
-                    required_candles,
-                    now_ms=now,
-                )
-                age_ms = int(surface_health.get("age_ms", 0) or 0)
-                if bool(surface_health.get("coverage_ok")) and age_ms <= target_age_ms:
-                    continue
-                last_attempt_ms = int(surface_attempts.get(surface_key, 0) or 0)
-                priority = (
-                    last_attempt_ms,
-                    0 if bool(surface_health.get("no_basis")) else 1,
-                    -int(surface_health.get("tail_gap_candles", 0) or 0),
-                    -int(surface_health.get("missing_candles", 0) or 0),
-                    -age_ms,
-                    f"{sym}:{timeframe}",
-                )
-                stale.append((priority, sym, timeframe, required_candles, surface_health))
+                surface_specs.append(("1h", sym, h1_hours))
+        eligible_surface_keys = {(sym, timeframe) for timeframe, sym, _ in surface_specs}
         surface_attempts = {
             key: int(value)
             for key, value in surface_attempts.items()
             if key in eligible_surface_keys
         }
+        surface_checks = {
+            key: int(value)
+            for key, value in surface_checks.items()
+            if key in eligible_surface_keys
+        }
+        surface_specs.sort(
+            key=lambda item: (
+                int(surface_checks.get((item[1], item[0]), 0) or 0),
+                0 if item[0] == "1m" else 1,
+                f"{item[1]}:{item[0]}",
+            )
+        )
+        health_scan_budget = min(len(surface_specs), max(8, int(budget) * 4))
+        stale: List[
+            Tuple[Tuple[int, int, int, int, str], str, str, int, Dict[str, Any]]
+        ] = []
+        for scan_idx, (timeframe, sym, required_candles) in enumerate(
+            surface_specs[:health_scan_budget]
+        ):
+            if (
+                max_refresh_ms > 0
+                and scan_idx > 0
+                and utc_ms() - refresh_started_ms >= max_refresh_ms
+            ):
+                break
+            surface_key = (sym, timeframe)
+            surface_health = Passivbot._candidate_candle_surface_health(
+                self,
+                sym,
+                timeframe,
+                required_candles,
+                now_ms=now,
+            )
+            surface_checks[surface_key] = int(utc_ms())
+            age_ms = int(surface_health.get("age_ms", 0) or 0)
+            no_basis = bool(surface_health.get("no_basis"))
+            tail_only = bool(surface_health.get("tail_only")) and not no_basis
+            if age_ms <= target_age_ms and (
+                bool(surface_health.get("coverage_ok")) or tail_only
+            ):
+                continue
+            last_attempt_ms = int(surface_attempts.get(surface_key, 0) or 0)
+            priority = (
+                last_attempt_ms,
+                0 if no_basis else 1,
+                0 if timeframe == "1m" else 1,
+                -age_ms,
+                f"{sym}:{timeframe}",
+            )
+            stale.append((priority, sym, timeframe, required_candles, surface_health))
         self._forager_surface_attempt_ms = surface_attempts
+        self._forager_surface_check_ms = surface_checks
         if not stale:
             return
 
@@ -18141,15 +18195,6 @@ class Passivbot:
             (sym, timeframe): int(surface_health.get("age_ms", 0) or 0)
             for _priority, sym, timeframe, _required, surface_health in stale
         }
-
-        max_refresh_s_raw = get_optional_live_value(
-            self.config, "max_forager_candle_refresh_seconds", 45
-        )
-        try:
-            max_refresh_s = float(max_refresh_s_raw)
-        except Exception:
-            max_refresh_s = 45.0
-        max_refresh_ms = int(max(0.0, max_refresh_s) * 1000.0)
 
         # Throttled visibility into forager refresh behavior (debug only).
         try:
@@ -18181,7 +18226,6 @@ class Passivbot:
         }
 
         fetch_delay_s = self._get_fetch_delay_seconds()
-        refresh_started_ms = utc_ms()
         last_progress_ms = refresh_started_ms
         refreshed_count = 0
         paused_by_cap = False

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -7692,6 +7692,17 @@ class Passivbot:
                 no_basis = loaded_rows <= 0 or last_cached_ts is None
                 missing_candles = int(report.get("missing_candles", 0) or 0)
                 tail_gap_candles = int(report.get("tail_gap_candles", 0) or 0)
+                missing_spans = list(report.get("missing_spans", []) or [])
+                start_ts = report.get("start_ts")
+                leading_gap_only = bool(
+                    not report.get("open_tail_gap")
+                    and len(missing_spans) == 1
+                    and start_ts is not None
+                    and len(missing_spans[0]) >= 2
+                    and int(missing_spans[0][0]) <= int(start_ts)
+                    and last_cached_ts is not None
+                    and int(missing_spans[0][1]) < int(last_cached_ts)
+                )
                 return {
                     "coverage_ok": bool(report.get("coverage_ok")),
                     "age_ms": (
@@ -7704,6 +7715,7 @@ class Passivbot:
                     "tail_only": bool(report.get("open_tail_gap"))
                     and missing_candles > 0
                     and missing_candles == tail_gap_candles,
+                    "leading_gap_only": leading_gap_only,
                     "no_basis": no_basis,
                 }
         except Exception:
@@ -7716,6 +7728,7 @@ class Passivbot:
                     "missing_candles": max(1, int(required_candles)),
                     "tail_gap_candles": max(1, int(required_candles)),
                     "tail_only": False,
+                    "leading_gap_only": False,
                     "no_basis": True,
                 }
         age_ms = Passivbot._candle_staleness_ms(self, symbol, now_ms=now)
@@ -7725,6 +7738,7 @@ class Passivbot:
             "missing_candles": 0 if age_ms <= 0 else 1,
             "tail_gap_candles": 0 if age_ms <= 0 else 1,
             "tail_only": age_ms > 0,
+            "leading_gap_only": False,
             "no_basis": age_ms >= now,
         }
 
@@ -18014,6 +18028,32 @@ class Passivbot:
         if not all_candidates:
             return
 
+        cycle_cap = (
+            max(1, int(math.ceil(float(max_calls) / 4.0))) if max_calls > 0 else 0
+        )
+        budget: Optional[int] = None
+        if slots_open_any:
+            if max_calls > 0:
+                # Respect rate limit even with open slots; do not spend a full
+                # accumulated minute budget in one post-execution cleanup phase.
+                budget = self._forager_refresh_budget(
+                    max_calls,
+                    max_cycle_budget=cycle_cap,
+                    initial_tokens=cycle_cap,
+                )
+                if budget <= 0:
+                    return
+        else:
+            if max_calls <= 0:
+                return
+            budget = self._forager_refresh_budget(
+                max_calls,
+                max_cycle_budget=cycle_cap,
+                initial_tokens=cycle_cap,
+            )
+            if budget <= 0:
+                return
+
         try:
             warmup_ratio = float(
                 get_optional_live_value(self.config, "warmup_ratio", 0.0) or 0.0
@@ -18055,32 +18095,8 @@ class Passivbot:
             1 + (1 if int(per_symbol_h1_hours.get(sym, 0) or 0) > 0 else 0)
             for sym in all_candidates
         )
-        cycle_cap = (
-            max(1, int(math.ceil(float(max_calls) / 4.0))) if max_calls > 0 else 0
-        )
-        if slots_open_any:
-            if max_calls > 0:
-                # Respect rate limit even with open slots; do not spend a full
-                # accumulated minute budget in one post-execution cleanup phase.
-                budget = self._forager_refresh_budget(
-                    max_calls,
-                    max_cycle_budget=cycle_cap,
-                    initial_tokens=cycle_cap,
-                )
-                if budget <= 0:
-                    return
-            else:
-                budget = required_surface_count
-        else:
-            if max_calls <= 0:
-                return
-            budget = self._forager_refresh_budget(
-                max_calls,
-                max_cycle_budget=cycle_cap,
-                initial_tokens=cycle_cap,
-            )
-            if budget <= 0:
-                return
+        if budget is None:
+            budget = required_surface_count
 
         # Skip only the urgent per-cycle candle universe. The staged orchestrator
         # managed universe may include flat graceful-stop symbols; those still
@@ -18140,8 +18156,8 @@ class Passivbot:
         surface_specs.sort(
             key=lambda item: (
                 int(surface_checks.get((item[1], item[0]), 0) or 0),
+                str(item[1]),
                 0 if item[0] == "1m" else 1,
-                f"{item[1]}:{item[0]}",
             )
         )
         health_scan_budget = min(len(surface_specs), max(8, int(budget) * 4))
@@ -18174,6 +18190,17 @@ class Passivbot:
             ):
                 continue
             last_attempt_ms = int(surface_attempts.get(surface_key, 0) or 0)
+            if (
+                timeframe == "1h"
+                and bool(surface_health.get("leading_gap_only"))
+                and last_attempt_ms > 0
+                and now - last_attempt_ms < 24 * 60 * 60_000
+            ):
+                # A fresh native-1h tail with only a missing requested prefix is
+                # consistent with exchange history beginning after our warmup
+                # window. Keep the candidate unavailable, but do not spend REST
+                # budget retrying that unchanged prefix every refresh cycle.
+                continue
             priority = (
                 last_attempt_ms,
                 0 if no_basis else 1,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -18134,7 +18134,9 @@ class Passivbot:
         surface_successes = {
             key: int(value)
             for key, value in surface_successes.items()
-            if key in eligible_surface_keys
+            if isinstance(key, tuple)
+            and len(key) == 3
+            and (key[0], key[1]) in eligible_surface_keys
         }
         surface_checks = {
             key: int(value)
@@ -18179,7 +18181,8 @@ class Passivbot:
                 surface_checks[surface_key] = checked_ms
                 continue
             last_attempt_ms = int(surface_attempts.get(surface_key, 0) or 0)
-            last_success_ms = int(surface_successes.get(surface_key, 0) or 0)
+            surface_success_key = (sym, timeframe, int(required_candles))
+            last_success_ms = int(surface_successes.get(surface_success_key, 0) or 0)
             if (
                 timeframe == "1h"
                 and bool(surface_health.get("leading_gap_only"))
@@ -18311,7 +18314,9 @@ class Passivbot:
                     await asyncio.wait_for(candle_task, timeout=remaining_s)
                 else:
                     await candle_task
-                surface_successes[(sym, timeframe)] = int(utc_ms())
+                surface_successes[(sym, timeframe, int(required_candles))] = int(
+                    utc_ms()
+                )
                 self._forager_surface_success_ms = surface_successes
                 refreshed_count += 1
                 if fetch_delay_s > 0:

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -18000,6 +18000,8 @@ class Passivbot:
             max_calls = int(max_calls) if max_calls is not None else 0
         except Exception:
             max_calls = 0
+        if max_calls <= 0:
+            return
 
         candidates_by_side: Dict[str, set] = {}
         slots_open_any = False
@@ -18028,31 +18030,31 @@ class Passivbot:
         if not all_candidates:
             return
 
+        # Skip only the urgent per-cycle candle universe. The staged orchestrator
+        # managed universe may include flat graceful-stop symbols; those still
+        # need budgeted candidate refreshes for future forager readiness.
+        urgent = set(Passivbot._urgent_active_candle_symbols(self))
+        refreshable_by_side = {
+            pside: set(symbols) - urgent
+            for pside, symbols in candidates_by_side.items()
+            if set(symbols) - urgent
+        }
+        candidates = sorted(set().union(*refreshable_by_side.values()))
+        if not candidates:
+            return
+
         cycle_cap = (
             max(1, int(math.ceil(float(max_calls) / 4.0))) if max_calls > 0 else 0
         )
-        budget: Optional[int] = None
-        if slots_open_any:
-            if max_calls > 0:
-                # Respect rate limit even with open slots; do not spend a full
-                # accumulated minute budget in one post-execution cleanup phase.
-                budget = self._forager_refresh_budget(
-                    max_calls,
-                    max_cycle_budget=cycle_cap,
-                    initial_tokens=cycle_cap,
-                )
-                if budget <= 0:
-                    return
-        else:
-            if max_calls <= 0:
-                return
-            budget = self._forager_refresh_budget(
-                max_calls,
-                max_cycle_budget=cycle_cap,
-                initial_tokens=cycle_cap,
-            )
-            if budget <= 0:
-                return
+        # Respect the configured rate limit with or without open slots; do not
+        # spend a full accumulated minute budget in one cleanup phase.
+        budget = self._forager_refresh_budget(
+            max_calls,
+            max_cycle_budget=cycle_cap,
+            initial_tokens=cycle_cap,
+        )
+        if budget <= 0:
+            return
 
         try:
             warmup_ratio = float(
@@ -18067,9 +18069,9 @@ class Passivbot:
         except Exception:
             max_warmup_minutes = 0
         per_symbol_win, per_symbol_h1_hours, _ = compute_live_warmup_windows(
-            candidates_by_side,
+            refreshable_by_side,
             lambda pside, key, sym: self.bp(pside, key, sym),
-            forager_enabled={pside: True for pside in candidates_by_side},
+            forager_enabled={pside: True for pside in refreshable_by_side},
             strategy_lookup=lambda pside, key, sym: Passivbot._live_strategy_warmup_value(
                 self, pside, key, sym
             ),
@@ -18090,32 +18092,6 @@ class Passivbot:
         )
         for sym in per_symbol_win:
             per_symbol_win[sym] = max(minimum_1m_window, int(per_symbol_win[sym]))
-
-        required_surface_count = sum(
-            1 + (1 if int(per_symbol_h1_hours.get(sym, 0) or 0) > 0 else 0)
-            for sym in all_candidates
-        )
-        if budget is None:
-            budget = required_surface_count
-
-        # Skip only the urgent per-cycle candle universe. The staged orchestrator
-        # managed universe may include flat graceful-stop symbols; those still
-        # need budgeted candidate refreshes for future forager readiness.
-        urgent = set(Passivbot._urgent_active_candle_symbols(self))
-        candidates = sorted(all_candidates - urgent)
-        if not candidates:
-            return
-
-        if slots_open_any:
-            rate_limit_age_ms = self._forager_target_staleness_ms(
-                required_surface_count, max_calls
-            )
-            # Respect rate limit even with open slots; floor at 60s for responsiveness.
-            target_age_ms = max(60_000, rate_limit_age_ms) if max_calls > 0 else 60_000
-        else:
-            target_age_ms = self._forager_target_staleness_ms(
-                required_surface_count, max_calls
-            )
         now = utc_ms()
         max_refresh_s_raw = get_optional_live_value(
             self.config, "max_forager_candle_refresh_seconds", 45
@@ -18130,6 +18106,9 @@ class Passivbot:
         surface_attempts = getattr(self, "_forager_surface_attempt_ms", None)
         if not isinstance(surface_attempts, dict):
             surface_attempts = {}
+        surface_successes = getattr(self, "_forager_surface_success_ms", None)
+        if not isinstance(surface_successes, dict):
+            surface_successes = {}
         surface_checks = getattr(self, "_forager_surface_check_ms", None)
         if not isinstance(surface_checks, dict):
             surface_checks = {}
@@ -18142,10 +18121,19 @@ class Passivbot:
             h1_hours = int(per_symbol_h1_hours.get(sym, 0) or 0)
             if h1_hours > 0:
                 surface_specs.append(("1h", sym, h1_hours))
+        required_surface_count = len(surface_specs)
+        target_age_ms = self._forager_target_staleness_ms(
+            required_surface_count, max_calls
+        )
         eligible_surface_keys = {(sym, timeframe) for timeframe, sym, _ in surface_specs}
         surface_attempts = {
             key: int(value)
             for key, value in surface_attempts.items()
+            if key in eligible_surface_keys
+        }
+        surface_successes = {
+            key: int(value)
+            for key, value in surface_successes.items()
             if key in eligible_surface_keys
         }
         surface_checks = {
@@ -18181,25 +18169,28 @@ class Passivbot:
                 required_candles,
                 now_ms=now,
             )
-            surface_checks[surface_key] = int(utc_ms())
+            checked_ms = int(utc_ms())
             age_ms = int(surface_health.get("age_ms", 0) or 0)
             no_basis = bool(surface_health.get("no_basis"))
             tail_only = bool(surface_health.get("tail_only")) and not no_basis
             if age_ms <= target_age_ms and (
                 bool(surface_health.get("coverage_ok")) or tail_only
             ):
+                surface_checks[surface_key] = checked_ms
                 continue
             last_attempt_ms = int(surface_attempts.get(surface_key, 0) or 0)
+            last_success_ms = int(surface_successes.get(surface_key, 0) or 0)
             if (
                 timeframe == "1h"
                 and bool(surface_health.get("leading_gap_only"))
-                and last_attempt_ms > 0
-                and now - last_attempt_ms < 24 * 60 * 60_000
+                and last_success_ms > 0
+                and now - last_success_ms < 24 * 60 * 60_000
             ):
                 # A fresh native-1h tail with only a missing requested prefix is
                 # consistent with exchange history beginning after our warmup
                 # window. Keep the candidate unavailable, but do not spend REST
                 # budget retrying that unchanged prefix every refresh cycle.
+                surface_checks[surface_key] = checked_ms
                 continue
             priority = (
                 last_attempt_ms,
@@ -18210,6 +18201,7 @@ class Passivbot:
             )
             stale.append((priority, sym, timeframe, required_candles, surface_health))
         self._forager_surface_attempt_ms = surface_attempts
+        self._forager_surface_success_ms = surface_successes
         self._forager_surface_check_ms = surface_checks
         if not stale:
             return
@@ -18298,6 +18290,8 @@ class Passivbot:
                 period_ms = ONE_MIN_MS if timeframe == "1m" else 60 * ONE_MIN_MS
                 end_ts = int(end_ts_by_timeframe[timeframe])
                 start_ts = end_ts - period_ms * max(1, int(required_candles))
+                surface_checks[(sym, timeframe)] = int(utc_ms())
+                self._forager_surface_check_ms = surface_checks
                 surface_attempts[(sym, timeframe)] = int(utc_ms())
                 self._forager_surface_attempt_ms = surface_attempts
                 candle_task = self.cm.get_candles(
@@ -18317,6 +18311,8 @@ class Passivbot:
                     await asyncio.wait_for(candle_task, timeout=remaining_s)
                 else:
                     await candle_task
+                surface_successes[(sym, timeframe)] = int(utc_ms())
+                self._forager_surface_success_ms = surface_successes
                 refreshed_count += 1
                 if fetch_delay_s > 0:
                     sleep_s = fetch_delay_s

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -1196,6 +1196,138 @@ async def test_tf_force_refresh_retains_disk_coverage_and_invalidates_tf_ema(
     assert float(cached["c"][-1]) == pytest.approx(9.0)
 
 
+@pytest.mark.asyncio
+async def test_tf_force_refresh_keeps_partial_range_out_of_ema_cache(
+    monkeypatch, tmp_path
+):
+    fixed_now_ms = 1725590400000  # 2024-09-06 00:00:00 UTC
+    monkeypatch.setattr("time.time", lambda: fixed_now_ms / 1000.0)
+
+    class _Ex:
+        id = "okx"
+
+    cm = CandlestickManager(
+        exchange=_Ex(), exchange_name="okx", cache_dir=str(tmp_path / "caches")
+    )
+    symbol = "PARTIAL-EMA/USDT:USDT"
+    timeframe = "1h"
+    period_ms = 60 * ONE_MIN_MS
+    end_ts = (fixed_now_ms // period_ms) * period_ms - period_ms
+    start_ts = end_ts - 4 * period_ms
+
+    disk_tail = np.zeros(1, dtype=CANDLE_DTYPE)
+    disk_tail["ts"] = np.asarray([end_ts - period_ms], dtype=np.int64)
+    disk_tail["o"] = 1.0
+    disk_tail["h"] = 2.0
+    disk_tail["l"] = 0.5
+    disk_tail["c"] = 1.5
+    disk_tail["bv"] = 1.0
+    cm._persist_batch(symbol, disk_tail, timeframe=timeframe)
+    strict_flags = []
+
+    async def fake_fetch(
+        symbol_,
+        since_ms,
+        end_exclusive_ms,
+        *,
+        timeframe=None,
+        on_batch=None,
+        raise_on_partial_empty_page=False,
+    ):
+        strict_flags.append(bool(raise_on_partial_empty_page))
+        remote_tail = np.zeros(1, dtype=CANDLE_DTYPE)
+        remote_tail["ts"] = np.asarray([end_ts], dtype=np.int64)
+        remote_tail["o"] = 2.0
+        remote_tail["h"] = 3.0
+        remote_tail["l"] = 1.0
+        remote_tail["c"] = 2.5
+        remote_tail["bv"] = 1.0
+        if on_batch is not None:
+            on_batch(remote_tail)
+        return remote_tail
+
+    monkeypatch.setattr(cm, "_fetch_ohlcv_paginated", fake_fetch)
+
+    refreshed = await cm.get_candles(
+        symbol,
+        start_ts=start_ts,
+        end_ts=end_ts,
+        max_age_ms=0,
+        timeframe=timeframe,
+        max_lookback_candles=5,
+    )
+
+    cache_key = (timeframe, start_ts, end_ts)
+    assert strict_flags == [True]
+    assert refreshed.size == 2
+    assert cache_key not in cm._tf_range_cache[symbol]
+
+    ema = await cm.get_latest_ema_log_range(
+        symbol,
+        span=5.0,
+        max_age_ms=600_000,
+        timeframe=timeframe,
+        allow_remote_fetch=False,
+    )
+
+    assert np.isnan(ema)
+    assert ("log_range", 5.0, str(period_ms)) not in cm._ema_cache[symbol]
+
+
+@pytest.mark.asyncio
+async def test_tf_force_refresh_empty_result_does_not_fall_back_to_disk(
+    monkeypatch, tmp_path
+):
+    fixed_now_ms = 1725590400000  # 2024-09-06 00:00:00 UTC
+    monkeypatch.setattr("time.time", lambda: fixed_now_ms / 1000.0)
+
+    class _Ex:
+        id = "okx"
+
+    cm = CandlestickManager(
+        exchange=_Ex(), exchange_name="okx", cache_dir=str(tmp_path / "caches")
+    )
+    symbol = "EMPTY-REMOTE/USDT:USDT"
+    timeframe = "1h"
+    period_ms = 60 * ONE_MIN_MS
+    end_ts = (fixed_now_ms // period_ms) * period_ms - period_ms
+    start_ts = end_ts - 4 * period_ms
+
+    disk_tail = np.zeros(1, dtype=CANDLE_DTYPE)
+    disk_tail["ts"] = np.asarray([end_ts], dtype=np.int64)
+    disk_tail["o"] = 1.0
+    disk_tail["h"] = 2.0
+    disk_tail["l"] = 0.5
+    disk_tail["c"] = 1.5
+    disk_tail["bv"] = 1.0
+    cm._persist_batch(symbol, disk_tail, timeframe=timeframe)
+
+    async def fake_fetch(
+        symbol_,
+        since_ms,
+        end_exclusive_ms,
+        *,
+        timeframe=None,
+        on_batch=None,
+        raise_on_partial_empty_page=False,
+    ):
+        return np.empty((0,), dtype=CANDLE_DTYPE)
+
+    monkeypatch.setattr(cm, "_fetch_ohlcv_paginated", fake_fetch)
+
+    refreshed = await cm.get_candles(
+        symbol,
+        start_ts=start_ts,
+        end_ts=end_ts,
+        max_age_ms=0,
+        timeframe=timeframe,
+        max_lookback_candles=5,
+    )
+
+    assert refreshed.size == 0
+    assert (timeframe, start_ts, end_ts) not in cm._tf_range_cache[symbol]
+
+
 # EOF
 @pytest.mark.asyncio
 async def test_tf_range_cache_reuse_within_ttl(monkeypatch, tmp_path):

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -1114,6 +1114,88 @@ async def test_tf_force_refresh_bypasses_partial_range_cache(monkeypatch, tmp_pa
     assert int(out["ts"][-1]) == end_ts
 
 
+@pytest.mark.asyncio
+async def test_tf_force_refresh_retains_disk_coverage_and_invalidates_tf_ema(
+    monkeypatch, tmp_path
+):
+    fixed_now_ms = 1725590400000  # 2024-09-06 00:00:00 UTC
+    monkeypatch.setattr("time.time", lambda: fixed_now_ms / 1000.0)
+
+    class _Ex:
+        id = "okx"
+
+    cm = CandlestickManager(
+        exchange=_Ex(), exchange_name="okx", cache_dir=str(tmp_path / "caches")
+    )
+    symbol = "PARTIAL/USDT:USDT"
+    timeframe = "1h"
+    period_ms = 60 * ONE_MIN_MS
+    end_ts = (fixed_now_ms // period_ms) * period_ms - period_ms
+    start_ts = end_ts - 4 * period_ms
+
+    full = np.zeros(5, dtype=CANDLE_DTYPE)
+    full["ts"] = np.arange(start_ts, end_ts + period_ms, period_ms, dtype=np.int64)
+    full["o"] = 1.0
+    full["h"] = 2.0
+    full["l"] = 0.5
+    full["c"] = 1.5
+    full["bv"] = 1.0
+    cm._persist_batch(symbol, full, timeframe=timeframe)
+
+    h1_ema_key = ("log_range", 10.0, str(period_ms))
+    m1_ema_key = ("close", 10.0, str(ONE_MIN_MS))
+    cm._ema_cache[symbol] = {
+        h1_ema_key: (0.5, end_ts, fixed_now_ms),
+        m1_ema_key: (1.5, end_ts, fixed_now_ms),
+    }
+    calls = {"fetch": 0}
+
+    async def fake_fetch(
+        symbol_, since_ms, end_exclusive_ms, *, timeframe=None, on_batch=None
+    ):
+        calls["fetch"] += 1
+        partial = np.zeros(1, dtype=CANDLE_DTYPE)
+        partial["ts"] = np.asarray([end_ts], dtype=np.int64)
+        partial["o"] = 8.0
+        partial["h"] = 10.0
+        partial["l"] = 7.0
+        partial["c"] = 9.0
+        partial["bv"] = 2.0
+        if on_batch is not None:
+            on_batch(partial)
+        return partial
+
+    monkeypatch.setattr(cm, "_fetch_ohlcv_paginated", fake_fetch)
+
+    refreshed = await cm.get_candles(
+        symbol,
+        start_ts=start_ts,
+        end_ts=end_ts,
+        max_age_ms=0,
+        timeframe=timeframe,
+        max_lookback_candles=5,
+    )
+
+    assert calls["fetch"] == 1
+    assert refreshed.size == 5
+    assert float(refreshed["c"][-1]) == pytest.approx(9.0)
+    assert h1_ema_key not in cm._ema_cache[symbol]
+    assert m1_ema_key in cm._ema_cache[symbol]
+
+    cached = await cm.get_candles(
+        symbol,
+        start_ts=start_ts,
+        end_ts=end_ts,
+        max_age_ms=600_000,
+        timeframe=timeframe,
+        max_lookback_candles=5,
+    )
+
+    assert calls["fetch"] == 1
+    assert cached.size == 5
+    assert float(cached["c"][-1]) == pytest.approx(9.0)
+
+
 # EOF
 @pytest.mark.asyncio
 async def test_tf_range_cache_reuse_within_ttl(monkeypatch, tmp_path):

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -5,6 +5,7 @@ import time
 import math
 import json
 import zlib
+from collections import OrderedDict
 import pytest
 import numpy as np
 from pathlib import Path
@@ -1050,6 +1051,67 @@ async def test_concurrent_requests_share_fetch(tmp_path, monkeypatch):
     out1, out2 = await asyncio.gather(one_call(), one_call())
     assert out1.size > 0 and out2.size > 0
     assert calls["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_tf_force_refresh_bypasses_partial_range_cache(monkeypatch, tmp_path):
+    fixed_now_ms = 1725590400000  # 2024-09-06 00:00:00 UTC
+    monkeypatch.setattr("time.time", lambda: fixed_now_ms / 1000.0)
+
+    class _Ex:
+        id = "okx"
+
+    cm = CandlestickManager(
+        exchange=_Ex(), exchange_name="okx", cache_dir=str(tmp_path / "caches")
+    )
+    timeframe = "1h"
+    period_ms = 60 * ONE_MIN_MS
+    end_ts = (fixed_now_ms // period_ms) * period_ms - period_ms
+    start_ts = end_ts - 4 * period_ms
+    symbol = "FORCE/USDT:USDT"
+
+    partial = np.zeros(1, dtype=CANDLE_DTYPE)
+    partial["ts"] = np.asarray([start_ts], dtype=np.int64)
+    partial["o"] = 1.0
+    partial["h"] = 2.0
+    partial["l"] = 0.5
+    partial["c"] = 1.5
+    partial["bv"] = 1.0
+    cache_key = (timeframe, start_ts, end_ts)
+    cm._tf_range_cache[symbol] = OrderedDict(
+        [(cache_key, (partial, fixed_now_ms))]
+    )
+
+    calls = {"fetch": 0}
+
+    async def fake_fetch(
+        symbol_, since_ms, end_exclusive_ms, *, timeframe=None, on_batch=None
+    ):
+        calls["fetch"] += 1
+        ts = list(range(int(since_ms), int(end_exclusive_ms), period_ms))
+        arr = np.zeros(len(ts), dtype=CANDLE_DTYPE)
+        arr["ts"] = np.asarray(ts, dtype=np.int64)
+        arr["o"] = 1.0
+        arr["h"] = 2.0
+        arr["l"] = 0.5
+        arr["c"] = 1.5
+        arr["bv"] = 1.0
+        return arr
+
+    monkeypatch.setattr(cm, "_fetch_ohlcv_paginated", fake_fetch)
+
+    out = await cm.get_candles(
+        symbol,
+        start_ts=start_ts,
+        end_ts=end_ts,
+        max_age_ms=0,
+        timeframe=timeframe,
+        max_lookback_candles=5,
+    )
+
+    assert calls["fetch"] == 1
+    assert out.size == 5
+    assert int(out["ts"][-1]) == end_ts
 
 
 # EOF

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -1148,6 +1148,13 @@ async def test_tf_force_refresh_retains_disk_coverage_and_invalidates_tf_ema(
         h1_ema_key: (0.5, end_ts, fixed_now_ms),
         m1_ema_key: (1.5, end_ts, fixed_now_ms),
     }
+    shorter_start_ts = end_ts - 2 * period_ms
+    shorter_cache_key = (timeframe, shorter_start_ts, end_ts)
+    stale_shorter = full[-3:].copy()
+    stale_shorter["c"] = 1.5
+    cm._tf_range_cache[symbol] = OrderedDict(
+        [(shorter_cache_key, (stale_shorter, fixed_now_ms))]
+    )
     calls = {"fetch": 0}
 
     async def fake_fetch(
@@ -1181,6 +1188,7 @@ async def test_tf_force_refresh_retains_disk_coverage_and_invalidates_tf_ema(
     assert float(refreshed["c"][-1]) == pytest.approx(9.0)
     assert h1_ema_key not in cm._ema_cache[symbol]
     assert m1_ema_key in cm._ema_cache[symbol]
+    assert shorter_cache_key not in cm._tf_range_cache[symbol]
 
     cached = await cm.get_candles(
         symbol,
@@ -1194,6 +1202,19 @@ async def test_tf_force_refresh_retains_disk_coverage_and_invalidates_tf_ema(
     assert calls["fetch"] == 1
     assert cached.size == 5
     assert float(cached["c"][-1]) == pytest.approx(9.0)
+
+    shorter_cached = await cm.get_candles(
+        symbol,
+        start_ts=shorter_start_ts,
+        end_ts=end_ts,
+        max_age_ms=600_000,
+        timeframe=timeframe,
+        max_lookback_candles=3,
+    )
+
+    assert calls["fetch"] == 1
+    assert shorter_cached.size == 3
+    assert float(shorter_cached["c"][-1]) == pytest.approx(9.0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -2442,6 +2442,106 @@ async def test_forager_candidate_refresh_rotates_by_completed_candle_staleness(
 
 
 @pytest.mark.asyncio
+async def test_forager_candidate_refresh_warms_required_native_h1_surface(monkeypatch):
+    import passivbot as pb_mod
+
+    now_ms = 12 * 60 * 60_000
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: now_ms)
+    symbol = "H1/USDT:USDT"
+
+    class FakeCM:
+        default_window_candles = 120
+
+        def __init__(self):
+            self.calls = []
+
+        def get_completed_candle_health(self, _symbol, windows, now_ms=None):
+            timeframe = next(iter(windows))
+            required = int(windows[timeframe])
+            if timeframe == "1m":
+                return {
+                    "timeframes": {
+                        "1m": {
+                            "coverage_ok": True,
+                            "loaded_rows": required,
+                            "last_cached_ts": now_ms - 60_000,
+                            "last_cached_age_ms": 0,
+                            "missing_candles": 0,
+                            "tail_gap_candles": 0,
+                        }
+                    }
+                }
+            return {
+                "timeframes": {
+                    "1h": {
+                        "coverage_ok": False,
+                        "loaded_rows": 0,
+                        "last_cached_ts": None,
+                        "last_cached_age_ms": None,
+                        "missing_candles": required,
+                        "tail_gap_candles": required,
+                    }
+                }
+            }
+
+        async def get_candles(self, called_symbol, **kwargs):
+            self.calls.append((called_symbol, kwargs))
+            return []
+
+    class FakeBot:
+        config = {"live": {"max_ohlcv_fetches_per_minute": 4}}
+        approved_coins_minus_ignored_coins = {"long": {symbol}, "short": set()}
+        active_symbols = []
+        positions = {}
+        open_orders = {}
+        PB_modes = {"long": {symbol: "graceful_stop"}, "short": {}}
+        inactive_coin_candle_ttl_ms = 600_000
+        stop_signal_received = False
+        start_time_ms = 0
+        cm = FakeCM()
+
+        def is_forager_mode(self, pside=None):
+            return pside in (None, "long")
+
+        def get_max_n_positions(self, pside):
+            return 2 if pside == "long" else 0
+
+        def get_current_n_positions(self, _pside):
+            return 0
+
+        def _get_fetch_delay_seconds(self):
+            return 0.0
+
+        def bp(self, _pside, key, _symbol):
+            if key == "volatility_ema_span_1h":
+                return 784.0
+            if key in {
+                "ema_span_0",
+                "ema_span_1",
+                "forager_volume_ema_span_1m",
+                "forager_volatility_ema_span_1m",
+            }:
+                return 10.0
+            return 0.0
+
+        _forager_refresh_budget = pb_mod.Passivbot._forager_refresh_budget
+        _token_bucket_budget = pb_mod.Passivbot._token_bucket_budget
+        _forager_target_staleness_ms = pb_mod.Passivbot._forager_target_staleness_ms
+        _candle_staleness_ms = pb_mod.Passivbot._candle_staleness_ms
+
+    bot = FakeBot()
+    await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
+
+    assert len(bot.cm.calls) == 1
+    called_symbol, kwargs = bot.cm.calls[0]
+    assert called_symbol == symbol
+    assert kwargs["timeframe"] == "1h"
+    assert kwargs["max_lookback_candles"] == 784
+    assert kwargs["max_age_ms"] == 0
+    assert kwargs["end_ts"] % (60 * 60_000) == 0
+
+
+@pytest.mark.asyncio
 async def test_forager_candidate_refresh_success_detail_is_debug(monkeypatch, caplog):
     import logging
     import passivbot as pb_mod

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -2623,11 +2623,11 @@ async def test_forager_candidate_refresh_honors_warmup_cap_below_default(monkeyp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("max_calls", "available_budget", "expected_budget_calls"),
-    [(0, 0, 0), (4, 0, 1)],
+    ("max_calls", "available_budget", "slots_open", "expected_budget_calls"),
+    [(0, 0, False, 0), (0, 0, True, 0), (4, 0, False, 1)],
 )
 async def test_forager_candidate_refresh_skips_warmup_when_budget_is_zero(
-    monkeypatch, max_calls, available_budget, expected_budget_calls
+    monkeypatch, max_calls, available_budget, slots_open, expected_budget_calls
 ):
     import passivbot as pb_mod
 
@@ -2658,7 +2658,7 @@ async def test_forager_candidate_refresh_skips_warmup_when_budget_is_zero(
             return 1 if pside == "long" else 0
 
         def get_current_n_positions(self, pside):
-            return 1 if pside == "long" else 0
+            return 0 if pside == "long" and slots_open else 1
 
         def _forager_refresh_budget(self, *args, **kwargs):
             self.budget_calls += 1
@@ -2828,6 +2828,169 @@ async def test_forager_candidate_refresh_bounds_and_rotates_health_scans(monkeyp
     second_symbols = {symbol for symbol, _ in bot.cm.health_calls[8:]}
     assert len(bot.cm.health_calls) == 16
     assert first_symbols.isdisjoint(second_symbols)
+
+
+@pytest.mark.asyncio
+async def test_forager_candidate_refresh_keeps_unfetched_stale_surfaces_pending(
+    monkeypatch,
+):
+    import passivbot as pb_mod
+
+    now_holder = {"ms": 12 * 60 * 60_000}
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: now_holder["ms"])
+    symbols = {f"S{idx:03d}/USDT:USDT" for idx in range(20)}
+
+    class FakeCM:
+        default_window_candles = 120
+
+        def __init__(self):
+            self.fetch_calls = []
+
+        def get_completed_candle_health(self, _symbol, windows, now_ms=None):
+            required = int(windows["1m"])
+            return {
+                "timeframes": {
+                    "1m": {
+                        "coverage_ok": False,
+                        "loaded_rows": 0,
+                        "last_cached_ts": None,
+                        "last_cached_age_ms": None,
+                        "missing_candles": required,
+                        "tail_gap_candles": required,
+                    }
+                }
+            }
+
+        async def get_candles(self, symbol, **kwargs):
+            self.fetch_calls.append((symbol, kwargs))
+            return []
+
+    class FakeBot:
+        config = {"live": {"max_ohlcv_fetches_per_minute": 1}}
+        approved_coins_minus_ignored_coins = {"long": symbols, "short": set()}
+        active_symbols = []
+        positions = {}
+        open_orders = {}
+        inactive_coin_candle_ttl_ms = 600_000
+        stop_signal_received = False
+        start_time_ms = 0
+        cm = FakeCM()
+
+        def is_forager_mode(self, pside=None):
+            return pside in (None, "long")
+
+        def get_max_n_positions(self, pside):
+            return 1 if pside == "long" else 0
+
+        def get_current_n_positions(self, pside):
+            return 1 if pside == "long" else 0
+
+        def _get_fetch_delay_seconds(self):
+            return 0.0
+
+        def bp(self, _pside, key, _symbol):
+            if key in {"forager_volume_ema_span_1m", "forager_volatility_ema_span_1m"}:
+                return 10.0
+            return 0.0
+
+        _forager_refresh_budget = pb_mod.Passivbot._forager_refresh_budget
+        _token_bucket_budget = pb_mod.Passivbot._token_bucket_budget
+        _forager_target_staleness_ms = pb_mod.Passivbot._forager_target_staleness_ms
+        _candle_staleness_ms = pb_mod.Passivbot._candle_staleness_ms
+
+    bot = FakeBot()
+    await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
+    now_holder["ms"] += 60_000
+    await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
+
+    assert [symbol for symbol, _ in bot.cm.fetch_calls] == [
+        "S000/USDT:USDT",
+        "S001/USDT:USDT",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_forager_candidate_staleness_counts_only_refreshable_surfaces(monkeypatch):
+    import passivbot as pb_mod
+
+    now_ms = 12 * 60 * 60_000
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: now_ms)
+    inactive = "IDLE/USDT:USDT"
+    urgent = {f"ACTIVE{idx}/USDT:USDT" for idx in range(5)}
+    warmup_inputs = []
+
+    def fake_compute_live_warmup_windows(candidates_by_side, *args, **kwargs):
+        warmup_inputs.append(candidates_by_side)
+        return ({inactive: 120}, {inactive: 10}, 120)
+
+    monkeypatch.setattr(
+        pb_mod, "compute_live_warmup_windows", fake_compute_live_warmup_windows
+    )
+
+    class FakeCM:
+        default_window_candles = 120
+
+        def get_completed_candle_health(self, _symbol, windows, now_ms=None):
+            timeframe = next(iter(windows))
+            required = int(windows[timeframe])
+            return {
+                "timeframes": {
+                    timeframe: {
+                        "coverage_ok": True,
+                        "loaded_rows": required,
+                        "last_cached_ts": now_ms - 60_000,
+                        "last_cached_age_ms": 0,
+                        "missing_candles": 0,
+                        "tail_gap_candles": 0,
+                    }
+                }
+            }
+
+    class FakeBot:
+        config = {"live": {"max_ohlcv_fetches_per_minute": 4}}
+        approved_coins_minus_ignored_coins = {
+            "long": urgent | {inactive},
+            "short": set(),
+        }
+        active_symbols = []
+        positions = {}
+        open_orders = {}
+        PB_modes = {
+            "long": {**{symbol: "normal" for symbol in urgent}, inactive: "graceful_stop"},
+            "short": {},
+        }
+        inactive_coin_candle_ttl_ms = 600_000
+        stop_signal_received = False
+        start_time_ms = 0
+        cm = FakeCM()
+
+        def __init__(self):
+            self.staleness_counts = []
+
+        def is_forager_mode(self, pside=None):
+            return pside in (None, "long")
+
+        def get_max_n_positions(self, pside):
+            return 1 if pside == "long" else 0
+
+        def get_current_n_positions(self, pside):
+            return 1 if pside == "long" else 0
+
+        def bp(self, _pside, _key, _symbol):
+            return 0.0
+
+        def _forager_refresh_budget(self, *args, **kwargs):
+            return 1
+
+        def _forager_target_staleness_ms(self, surface_count, max_calls):
+            self.staleness_counts.append((surface_count, max_calls))
+            return 60_000
+
+    bot = FakeBot()
+    await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
+
+    assert warmup_inputs == [{"long": {inactive}}]
+    assert bot.staleness_counts == [(2, 4)]
 
 
 @pytest.mark.asyncio
@@ -3012,6 +3175,7 @@ async def test_forager_candidate_refresh_backs_off_native_h1_leading_gap(monkeyp
 
         def __init__(self):
             self.has_partial_h1 = False
+            self.fail_next_h1 = False
             self.fetch_calls = []
 
         def get_completed_candle_health(self, _symbol, windows, now_ms=None):
@@ -3067,6 +3231,9 @@ async def test_forager_candidate_refresh_backs_off_native_h1_leading_gap(monkeyp
 
         async def get_candles(self, symbol, **kwargs):
             self.fetch_calls.append((symbol, kwargs))
+            if kwargs["timeframe"] == "1h" and self.fail_next_h1:
+                self.fail_next_h1 = False
+                raise RuntimeError("transient 1h fetch failure")
             if kwargs["timeframe"] == "1h":
                 self.has_partial_h1 = True
             return []
@@ -3114,9 +3281,19 @@ async def test_forager_candidate_refresh_backs_off_native_h1_leading_gap(monkeyp
     assert [kwargs["timeframe"] for _, kwargs in bot.cm.fetch_calls] == ["1h"]
 
     now_holder["ms"] += 24 * 60 * 60_000
+    bot.cm.fail_next_h1 = True
     await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
 
     assert [kwargs["timeframe"] for _, kwargs in bot.cm.fetch_calls] == ["1h", "1h"]
+
+    now_holder["ms"] += 60_000
+    await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
+
+    assert [kwargs["timeframe"] for _, kwargs in bot.cm.fetch_calls] == [
+        "1h",
+        "1h",
+        "1h",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -3248,6 +3248,7 @@ async def test_forager_candidate_refresh_backs_off_native_h1_leading_gap(monkeyp
         stop_signal_received = False
         start_time_ms = 0
         cm = FakeCM()
+        h1_required = 10.0
 
         def is_forager_mode(self, pside=None):
             return pside in (None, "long")
@@ -3263,7 +3264,7 @@ async def test_forager_candidate_refresh_backs_off_native_h1_leading_gap(monkeyp
 
         def bp(self, _pside, key, _symbol):
             if key == "volatility_ema_span_1h":
-                return 10.0
+                return self.h1_required
             if key in {"forager_volume_ema_span_1m", "forager_volatility_ema_span_1m"}:
                 return 10.0
             return 0.0
@@ -3280,16 +3281,28 @@ async def test_forager_candidate_refresh_backs_off_native_h1_leading_gap(monkeyp
 
     assert [kwargs["timeframe"] for _, kwargs in bot.cm.fetch_calls] == ["1h"]
 
+    bot.h1_required = 20.0
+    now_holder["ms"] += 60_000
+    await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
+
+    assert [kwargs["timeframe"] for _, kwargs in bot.cm.fetch_calls] == ["1h", "1h"]
+    assert bot.cm.fetch_calls[-1][1]["max_lookback_candles"] == 20
+
     now_holder["ms"] += 24 * 60 * 60_000
     bot.cm.fail_next_h1 = True
     await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
 
-    assert [kwargs["timeframe"] for _, kwargs in bot.cm.fetch_calls] == ["1h", "1h"]
+    assert [kwargs["timeframe"] for _, kwargs in bot.cm.fetch_calls] == [
+        "1h",
+        "1h",
+        "1h",
+    ]
 
     now_holder["ms"] += 60_000
     await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
 
     assert [kwargs["timeframe"] for _, kwargs in bot.cm.fetch_calls] == [
+        "1h",
         "1h",
         "1h",
         "1h",

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -2622,6 +2622,56 @@ async def test_forager_candidate_refresh_honors_warmup_cap_below_default(monkeyp
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("max_calls", "available_budget", "expected_budget_calls"),
+    [(0, 0, 0), (4, 0, 1)],
+)
+async def test_forager_candidate_refresh_skips_warmup_when_budget_is_zero(
+    monkeypatch, max_calls, available_budget, expected_budget_calls
+):
+    import passivbot as pb_mod
+
+    warmup_calls = []
+
+    def fail_if_warmup_computed(*args, **kwargs):
+        warmup_calls.append((args, kwargs))
+        raise AssertionError("zero-budget refresh must not compute warmup windows")
+
+    monkeypatch.setattr(
+        pb_mod, "compute_live_warmup_windows", fail_if_warmup_computed
+    )
+
+    class FakeBot:
+        config = {"live": {"max_ohlcv_fetches_per_minute": max_calls}}
+        approved_coins_minus_ignored_coins = {
+            "long": {"IDLE/USDT:USDT"},
+            "short": set(),
+        }
+
+        def __init__(self):
+            self.budget_calls = 0
+
+        def is_forager_mode(self, pside=None):
+            return pside in (None, "long")
+
+        def get_max_n_positions(self, pside):
+            return 1 if pside == "long" else 0
+
+        def get_current_n_positions(self, pside):
+            return 1 if pside == "long" else 0
+
+        def _forager_refresh_budget(self, *args, **kwargs):
+            self.budget_calls += 1
+            return available_budget
+
+    bot = FakeBot()
+    await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
+
+    assert warmup_calls == []
+    assert bot.budget_calls == expected_budget_calls
+
+
+@pytest.mark.asyncio
 async def test_forager_candidate_refresh_tolerates_tail_within_target_age(monkeypatch):
     import passivbot as pb_mod
 
@@ -2854,6 +2904,219 @@ async def test_forager_candidate_refresh_prioritizes_cold_1m_before_1h(monkeypat
 
     assert len(bot.cm.calls) == 1
     assert bot.cm.calls[0][1]["timeframe"] == "1m"
+
+
+@pytest.mark.asyncio
+async def test_forager_candidate_refresh_interleaves_h1_health_scans(monkeypatch):
+    import passivbot as pb_mod
+
+    now_ms = 12 * 60 * 60_000
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: now_ms)
+    symbols = {f"S{idx:03d}/USDT:USDT" for idx in range(20)}
+
+    class FakeCM:
+        default_window_candles = 120
+
+        def __init__(self):
+            self.health_calls = []
+            self.fetch_calls = []
+
+        def get_completed_candle_health(self, symbol, windows, now_ms=None):
+            timeframe = next(iter(windows))
+            required = int(windows[timeframe])
+            self.health_calls.append((symbol, timeframe))
+            if timeframe == "1m":
+                return {
+                    "timeframes": {
+                        timeframe: {
+                            "coverage_ok": True,
+                            "loaded_rows": required,
+                            "last_cached_ts": now_ms - 60_000,
+                            "last_cached_age_ms": 0,
+                            "missing_candles": 0,
+                            "tail_gap_candles": 0,
+                        }
+                    }
+                }
+            return {
+                "timeframes": {
+                    timeframe: {
+                        "coverage_ok": False,
+                        "loaded_rows": 0,
+                        "last_cached_ts": None,
+                        "last_cached_age_ms": None,
+                        "missing_candles": required,
+                        "tail_gap_candles": required,
+                    }
+                }
+            }
+
+        async def get_candles(self, symbol, **kwargs):
+            self.fetch_calls.append((symbol, kwargs))
+            return []
+
+    class FakeBot:
+        config = {"live": {"max_ohlcv_fetches_per_minute": 1}}
+        approved_coins_minus_ignored_coins = {"long": symbols, "short": set()}
+        active_symbols = []
+        positions = {}
+        open_orders = {}
+        inactive_coin_candle_ttl_ms = 600_000
+        stop_signal_received = False
+        start_time_ms = 0
+        cm = FakeCM()
+
+        def is_forager_mode(self, pside=None):
+            return pside in (None, "long")
+
+        def get_max_n_positions(self, pside):
+            return 1 if pside == "long" else 0
+
+        def get_current_n_positions(self, pside):
+            return 1 if pside == "long" else 0
+
+        def _get_fetch_delay_seconds(self):
+            return 0.0
+
+        def bp(self, _pside, key, _symbol):
+            if key == "volatility_ema_span_1h":
+                return 10.0
+            if key in {"forager_volume_ema_span_1m", "forager_volatility_ema_span_1m"}:
+                return 10.0
+            return 0.0
+
+        _forager_refresh_budget = pb_mod.Passivbot._forager_refresh_budget
+        _token_bucket_budget = pb_mod.Passivbot._token_bucket_budget
+        _forager_target_staleness_ms = pb_mod.Passivbot._forager_target_staleness_ms
+        _candle_staleness_ms = pb_mod.Passivbot._candle_staleness_ms
+
+    bot = FakeBot()
+    await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
+
+    assert len(bot.cm.health_calls) == 8
+    assert {timeframe for _, timeframe in bot.cm.health_calls} == {"1m", "1h"}
+    assert len(bot.cm.fetch_calls) == 1
+    assert bot.cm.fetch_calls[0][1]["timeframe"] == "1h"
+
+
+@pytest.mark.asyncio
+async def test_forager_candidate_refresh_backs_off_native_h1_leading_gap(monkeypatch):
+    import passivbot as pb_mod
+
+    now_holder = {"ms": 48 * 60 * 60_000}
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: now_holder["ms"])
+    symbol = "LATE/USDT:USDT"
+
+    class FakeCM:
+        default_window_candles = 120
+
+        def __init__(self):
+            self.has_partial_h1 = False
+            self.fetch_calls = []
+
+        def get_completed_candle_health(self, _symbol, windows, now_ms=None):
+            timeframe = next(iter(windows))
+            required = int(windows[timeframe])
+            if timeframe == "1m":
+                return {
+                    "timeframes": {
+                        timeframe: {
+                            "coverage_ok": True,
+                            "loaded_rows": required,
+                            "last_cached_ts": now_ms - 60_000,
+                            "last_cached_age_ms": 0,
+                            "missing_candles": 0,
+                            "missing_spans": [],
+                            "tail_gap_candles": 0,
+                            "open_tail_gap": False,
+                        }
+                    }
+                }
+            if not self.has_partial_h1:
+                return {
+                    "timeframes": {
+                        timeframe: {
+                            "coverage_ok": False,
+                            "loaded_rows": 0,
+                            "last_cached_ts": None,
+                            "last_cached_age_ms": None,
+                            "missing_candles": required,
+                            "missing_spans": [],
+                            "tail_gap_candles": required,
+                            "open_tail_gap": False,
+                        }
+                    }
+                }
+            start_ts = now_ms - required * 60 * 60_000
+            last_cached_ts = now_ms - 60 * 60_000
+            return {
+                "timeframes": {
+                    timeframe: {
+                        "coverage_ok": False,
+                        "loaded_rows": required - 5,
+                        "start_ts": start_ts,
+                        "last_cached_ts": last_cached_ts,
+                        "last_cached_age_ms": 0,
+                        "missing_candles": 5,
+                        "missing_spans": [(start_ts, start_ts + 4 * 60 * 60_000)],
+                        "tail_gap_candles": 0,
+                        "open_tail_gap": False,
+                    }
+                }
+            }
+
+        async def get_candles(self, symbol, **kwargs):
+            self.fetch_calls.append((symbol, kwargs))
+            if kwargs["timeframe"] == "1h":
+                self.has_partial_h1 = True
+            return []
+
+    class FakeBot:
+        config = {"live": {"max_ohlcv_fetches_per_minute": 4}}
+        approved_coins_minus_ignored_coins = {"long": {symbol}, "short": set()}
+        active_symbols = []
+        positions = {}
+        open_orders = {}
+        inactive_coin_candle_ttl_ms = 600_000
+        stop_signal_received = False
+        start_time_ms = 0
+        cm = FakeCM()
+
+        def is_forager_mode(self, pside=None):
+            return pside in (None, "long")
+
+        def get_max_n_positions(self, pside):
+            return 1 if pside == "long" else 0
+
+        def get_current_n_positions(self, pside):
+            return 1 if pside == "long" else 0
+
+        def _get_fetch_delay_seconds(self):
+            return 0.0
+
+        def bp(self, _pside, key, _symbol):
+            if key == "volatility_ema_span_1h":
+                return 10.0
+            if key in {"forager_volume_ema_span_1m", "forager_volatility_ema_span_1m"}:
+                return 10.0
+            return 0.0
+
+        _forager_refresh_budget = pb_mod.Passivbot._forager_refresh_budget
+        _token_bucket_budget = pb_mod.Passivbot._token_bucket_budget
+        _forager_target_staleness_ms = pb_mod.Passivbot._forager_target_staleness_ms
+        _candle_staleness_ms = pb_mod.Passivbot._candle_staleness_ms
+
+    bot = FakeBot()
+    await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
+    now_holder["ms"] += 60_000
+    await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
+
+    assert [kwargs["timeframe"] for _, kwargs in bot.cm.fetch_calls] == ["1h"]
+
+    now_holder["ms"] += 24 * 60 * 60_000
+    await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
+
+    assert [kwargs["timeframe"] for _, kwargs in bot.cm.fetch_calls] == ["1h", "1h"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -2515,6 +2515,8 @@ async def test_forager_candidate_refresh_warms_required_native_h1_surface(monkey
         def bp(self, _pside, key, _symbol):
             if key == "volatility_ema_span_1h":
                 return 784.0
+            if key == "entry_weight_volatility_1h":
+                return 1.0
             if key in {
                 "ema_span_0",
                 "ema_span_1",
@@ -2669,6 +2671,170 @@ async def test_forager_candidate_refresh_skips_warmup_when_budget_is_zero(
 
     assert warmup_calls == []
     assert bot.budget_calls == expected_budget_calls
+
+
+@pytest.mark.asyncio
+async def test_forager_candidate_refresh_does_not_charge_healthy_scan(monkeypatch):
+    import passivbot as pb_mod
+
+    now_ms = 12 * 60 * 60_000
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: now_ms)
+    symbols = {f"S{idx:03d}/USDT:USDT" for idx in range(9)}
+    cold = "S008/USDT:USDT"
+
+    class FakeCM:
+        default_window_candles = 120
+
+        def __init__(self):
+            self.health_calls = []
+            self.fetch_calls = []
+
+        def get_completed_candle_health(self, symbol, windows, now_ms=None):
+            required = int(windows["1m"])
+            self.health_calls.append(symbol)
+            is_cold = symbol == cold
+            return {
+                "timeframes": {
+                    "1m": {
+                        "coverage_ok": not is_cold,
+                        "loaded_rows": 0 if is_cold else required,
+                        "last_cached_ts": None if is_cold else now_ms - 60_000,
+                        "last_cached_age_ms": None if is_cold else 0,
+                        "missing_candles": required if is_cold else 0,
+                        "tail_gap_candles": required if is_cold else 0,
+                    }
+                }
+            }
+
+        async def get_candles(self, symbol, **kwargs):
+            self.fetch_calls.append((symbol, kwargs))
+            return []
+
+    class FakeBot:
+        config = {"live": {"max_ohlcv_fetches_per_minute": 1}}
+        approved_coins_minus_ignored_coins = {"long": symbols, "short": set()}
+        active_symbols = []
+        positions = {}
+        open_orders = {}
+        inactive_coin_candle_ttl_ms = 600_000
+        stop_signal_received = False
+        start_time_ms = 0
+        cm = FakeCM()
+
+        def is_forager_mode(self, pside=None):
+            return pside in (None, "long")
+
+        def get_max_n_positions(self, pside):
+            return 1 if pside == "long" else 0
+
+        def get_current_n_positions(self, pside):
+            return 1 if pside == "long" else 0
+
+        def _get_fetch_delay_seconds(self):
+            return 0.0
+
+        def bp(self, _pside, key, _symbol):
+            if key in {
+                "forager_volume_ema_span_1m",
+                "forager_volatility_ema_span_1m",
+            }:
+                return 10.0
+            return 0.0
+
+        _forager_refresh_budget = pb_mod.Passivbot._forager_refresh_budget
+        _token_bucket_budget = pb_mod.Passivbot._token_bucket_budget
+        _forager_target_staleness_ms = pb_mod.Passivbot._forager_target_staleness_ms
+        _candle_staleness_ms = pb_mod.Passivbot._candle_staleness_ms
+
+    bot = FakeBot()
+    await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
+
+    assert len(bot.cm.health_calls) == 8
+    assert bot.cm.fetch_calls == []
+    assert bot._forager_refresh_state["tokens"] == pytest.approx(1.0)
+
+    await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
+
+    assert bot.cm.fetch_calls[0][0] == cold
+    assert bot._forager_refresh_state["tokens"] == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_forager_candidate_refresh_skips_unused_native_h1_surface(monkeypatch):
+    import passivbot as pb_mod
+
+    now_ms = 12 * 60 * 60_000
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: now_ms)
+    symbol = "UNUSED-H1/USDT:USDT"
+
+    class FakeCM:
+        default_window_candles = 120
+
+        def __init__(self):
+            self.health_calls = []
+            self.fetch_calls = []
+
+        def get_completed_candle_health(self, _symbol, windows, now_ms=None):
+            timeframe = next(iter(windows))
+            self.health_calls.append(timeframe)
+            required = int(windows[timeframe])
+            return {
+                "timeframes": {
+                    timeframe: {
+                        "coverage_ok": True,
+                        "loaded_rows": required,
+                        "last_cached_ts": now_ms - 60_000,
+                        "last_cached_age_ms": 0,
+                        "missing_candles": 0,
+                        "tail_gap_candles": 0,
+                    }
+                }
+            }
+
+        async def get_candles(self, symbol, **kwargs):
+            self.fetch_calls.append((symbol, kwargs))
+            return []
+
+    class FakeBot:
+        config = {"live": {"max_ohlcv_fetches_per_minute": 4}}
+        approved_coins_minus_ignored_coins = {"long": {symbol}, "short": set()}
+        active_symbols = []
+        positions = {}
+        open_orders = {}
+        inactive_coin_candle_ttl_ms = 600_000
+        stop_signal_received = False
+        start_time_ms = 0
+        cm = FakeCM()
+
+        def is_forager_mode(self, pside=None):
+            return pside in (None, "long")
+
+        def get_max_n_positions(self, pside):
+            return 1 if pside == "long" else 0
+
+        def get_current_n_positions(self, pside):
+            return 1 if pside == "long" else 0
+
+        def bp(self, _pside, key, _symbol):
+            if key == "volatility_ema_span_1h":
+                return 100.0
+            if key in {
+                "forager_volume_ema_span_1m",
+                "forager_volatility_ema_span_1m",
+            }:
+                return 10.0
+            return 0.0
+
+        _forager_refresh_budget = pb_mod.Passivbot._forager_refresh_budget
+        _token_bucket_budget = pb_mod.Passivbot._token_bucket_budget
+        _forager_target_staleness_ms = pb_mod.Passivbot._forager_target_staleness_ms
+        _candle_staleness_ms = pb_mod.Passivbot._candle_staleness_ms
+
+    bot = FakeBot()
+    await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
+
+    assert bot.cm.health_calls == ["1m"]
+    assert bot.cm.fetch_calls == []
 
 
 @pytest.mark.asyncio
@@ -2976,7 +3142,9 @@ async def test_forager_candidate_staleness_counts_only_refreshable_surfaces(monk
         def get_current_n_positions(self, pside):
             return 1 if pside == "long" else 0
 
-        def bp(self, _pside, _key, _symbol):
+        def bp(self, _pside, key, _symbol):
+            if key in {"volatility_ema_span_1h", "entry_weight_volatility_1h"}:
+                return 10.0 if key == "volatility_ema_span_1h" else 1.0
             return 0.0
 
         def _forager_refresh_budget(self, *args, **kwargs):
@@ -3053,6 +3221,8 @@ async def test_forager_candidate_refresh_prioritizes_cold_1m_before_1h(monkeypat
         def bp(self, _pside, key, _symbol):
             if key == "volatility_ema_span_1h":
                 return 784.0
+            if key == "entry_weight_volatility_1h":
+                return 1.0
             if key in {"forager_volume_ema_span_1m", "forager_volatility_ema_span_1m"}:
                 return 10.0
             return 0.0
@@ -3144,6 +3314,8 @@ async def test_forager_candidate_refresh_interleaves_h1_health_scans(monkeypatch
         def bp(self, _pside, key, _symbol):
             if key == "volatility_ema_span_1h":
                 return 10.0
+            if key == "entry_weight_volatility_1h":
+                return 1.0
             if key in {"forager_volume_ema_span_1m", "forager_volatility_ema_span_1m"}:
                 return 10.0
             return 0.0
@@ -3156,7 +3328,7 @@ async def test_forager_candidate_refresh_interleaves_h1_health_scans(monkeypatch
     bot = FakeBot()
     await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
 
-    assert len(bot.cm.health_calls) == 8
+    assert len(bot.cm.health_calls) == 9
     assert {timeframe for _, timeframe in bot.cm.health_calls} == {"1m", "1h"}
     assert len(bot.cm.fetch_calls) == 1
     assert bot.cm.fetch_calls[0][1]["timeframe"] == "1h"
@@ -3236,6 +3408,7 @@ async def test_forager_candidate_refresh_backs_off_native_h1_leading_gap(monkeyp
                 raise RuntimeError("transient 1h fetch failure")
             if kwargs["timeframe"] == "1h":
                 self.has_partial_h1 = True
+                return [object()]
             return []
 
     class FakeBot:
@@ -3265,6 +3438,8 @@ async def test_forager_candidate_refresh_backs_off_native_h1_leading_gap(monkeyp
         def bp(self, _pside, key, _symbol):
             if key == "volatility_ema_span_1h":
                 return self.h1_required
+            if key == "entry_weight_volatility_1h":
+                return 1.0
             if key in {"forager_volume_ema_span_1m", "forager_volatility_ema_span_1m"}:
                 return 10.0
             return 0.0
@@ -3307,6 +3482,110 @@ async def test_forager_candidate_refresh_backs_off_native_h1_leading_gap(monkeyp
         "1h",
         "1h",
     ]
+
+
+@pytest.mark.asyncio
+async def test_forager_candidate_refresh_does_not_back_off_empty_h1_result(monkeypatch):
+    import passivbot as pb_mod
+
+    now_holder = {"ms": 48 * 60 * 60_000}
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: now_holder["ms"])
+    symbol = "EMPTY-H1/USDT:USDT"
+
+    class FakeCM:
+        default_window_candles = 120
+
+        def __init__(self):
+            self.fetch_calls = []
+
+        def get_completed_candle_health(self, _symbol, windows, now_ms=None):
+            timeframe = next(iter(windows))
+            required = int(windows[timeframe])
+            if timeframe == "1m":
+                return {
+                    "timeframes": {
+                        timeframe: {
+                            "coverage_ok": True,
+                            "loaded_rows": required,
+                            "last_cached_ts": now_ms - 60_000,
+                            "last_cached_age_ms": 0,
+                            "missing_candles": 0,
+                            "missing_spans": [],
+                            "tail_gap_candles": 0,
+                            "open_tail_gap": False,
+                        }
+                    }
+                }
+            start_ts = now_ms - required * 60 * 60_000
+            last_cached_ts = now_ms - 60 * 60_000
+            return {
+                "timeframes": {
+                    timeframe: {
+                        "coverage_ok": False,
+                        "loaded_rows": required - 5,
+                        "start_ts": start_ts,
+                        "last_cached_ts": last_cached_ts,
+                        "last_cached_age_ms": 0,
+                        "missing_candles": 5,
+                        "missing_spans": [(start_ts, start_ts + 4 * 60 * 60_000)],
+                        "tail_gap_candles": 0,
+                        "open_tail_gap": False,
+                    }
+                }
+            }
+
+        async def get_candles(self, symbol, **kwargs):
+            self.fetch_calls.append((symbol, kwargs))
+            return [] if len(self.fetch_calls) == 1 else [object()]
+
+    class FakeBot:
+        config = {"live": {"max_ohlcv_fetches_per_minute": 4}}
+        approved_coins_minus_ignored_coins = {"long": {symbol}, "short": set()}
+        active_symbols = []
+        positions = {}
+        open_orders = {}
+        inactive_coin_candle_ttl_ms = 600_000
+        stop_signal_received = False
+        start_time_ms = 0
+        cm = FakeCM()
+
+        def is_forager_mode(self, pside=None):
+            return pside in (None, "long")
+
+        def get_max_n_positions(self, pside):
+            return 1 if pside == "long" else 0
+
+        def get_current_n_positions(self, pside):
+            return 1 if pside == "long" else 0
+
+        def _get_fetch_delay_seconds(self):
+            return 0.0
+
+        def bp(self, _pside, key, _symbol):
+            if key == "volatility_ema_span_1h":
+                return 10.0
+            if key == "entry_weight_volatility_1h":
+                return 1.0
+            if key in {
+                "forager_volume_ema_span_1m",
+                "forager_volatility_ema_span_1m",
+            }:
+                return 10.0
+            return 0.0
+
+        _forager_refresh_budget = pb_mod.Passivbot._forager_refresh_budget
+        _token_bucket_budget = pb_mod.Passivbot._token_bucket_budget
+        _forager_target_staleness_ms = pb_mod.Passivbot._forager_target_staleness_ms
+        _candle_staleness_ms = pb_mod.Passivbot._candle_staleness_ms
+
+    bot = FakeBot()
+    await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
+    now_holder["ms"] += 60_000
+    await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
+    now_holder["ms"] += 60_000
+    await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
+
+    assert len(bot.cm.fetch_calls) == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -2542,6 +2542,321 @@ async def test_forager_candidate_refresh_warms_required_native_h1_surface(monkey
 
 
 @pytest.mark.asyncio
+async def test_forager_candidate_refresh_honors_warmup_cap_below_default(monkeypatch):
+    import passivbot as pb_mod
+
+    now_ms = 12 * 60 * 60_000
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: now_ms)
+    symbol = "CAPPED/USDT:USDT"
+
+    class FakeCM:
+        default_window_candles = 120
+
+        def __init__(self):
+            self.calls = []
+
+        def get_completed_candle_health(self, _symbol, windows, now_ms=None):
+            required = int(windows["1m"])
+            return {
+                "timeframes": {
+                    "1m": {
+                        "coverage_ok": False,
+                        "loaded_rows": 0,
+                        "last_cached_ts": None,
+                        "last_cached_age_ms": None,
+                        "missing_candles": required,
+                        "tail_gap_candles": required,
+                    }
+                }
+            }
+
+        async def get_candles(self, called_symbol, **kwargs):
+            self.calls.append((called_symbol, kwargs))
+            return []
+
+    class FakeBot:
+        config = {
+            "live": {
+                "max_ohlcv_fetches_per_minute": 4,
+                "max_warmup_minutes": 60,
+            }
+        }
+        approved_coins_minus_ignored_coins = {"long": {symbol}, "short": set()}
+        active_symbols = []
+        positions = {}
+        open_orders = {}
+        inactive_coin_candle_ttl_ms = 600_000
+        stop_signal_received = False
+        start_time_ms = 0
+        cm = FakeCM()
+
+        def is_forager_mode(self, pside=None):
+            return pside in (None, "long")
+
+        def get_max_n_positions(self, pside):
+            return 1 if pside == "long" else 0
+
+        def get_current_n_positions(self, _pside):
+            return 0
+
+        def _get_fetch_delay_seconds(self):
+            return 0.0
+
+        def bp(self, _pside, key, _symbol):
+            if key in {"forager_volume_ema_span_1m", "forager_volatility_ema_span_1m"}:
+                return 500.0
+            return 0.0
+
+        _forager_refresh_budget = pb_mod.Passivbot._forager_refresh_budget
+        _token_bucket_budget = pb_mod.Passivbot._token_bucket_budget
+        _forager_target_staleness_ms = pb_mod.Passivbot._forager_target_staleness_ms
+        _candle_staleness_ms = pb_mod.Passivbot._candle_staleness_ms
+
+    bot = FakeBot()
+    await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
+
+    assert len(bot.cm.calls) == 1
+    _, kwargs = bot.cm.calls[0]
+    assert kwargs["timeframe"] == "1m"
+    assert kwargs["max_lookback_candles"] == 60
+
+
+@pytest.mark.asyncio
+async def test_forager_candidate_refresh_tolerates_tail_within_target_age(monkeypatch):
+    import passivbot as pb_mod
+
+    now_ms = 12 * 60 * 60_000
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: now_ms)
+    symbol = "TAIL/USDT:USDT"
+
+    class FakeCM:
+        default_window_candles = 120
+
+        def __init__(self):
+            self.calls = []
+
+        def get_completed_candle_health(self, _symbol, windows, now_ms=None):
+            required = int(windows["1m"])
+            return {
+                "timeframes": {
+                    "1m": {
+                        "coverage_ok": False,
+                        "loaded_rows": required - 1,
+                        "last_cached_ts": now_ms - 2 * 60_000,
+                        "last_cached_age_ms": 60_000,
+                        "missing_candles": 1,
+                        "open_tail_gap": True,
+                        "tail_gap_candles": 1,
+                    }
+                }
+            }
+
+        async def get_candles(self, called_symbol, **kwargs):
+            self.calls.append((called_symbol, kwargs))
+            return []
+
+    class FakeBot:
+        config = {
+            "live": {
+                "max_ohlcv_fetches_per_minute": 4,
+                "max_forager_candle_staleness_minutes": 10,
+            }
+        }
+        approved_coins_minus_ignored_coins = {"long": {symbol}, "short": set()}
+        active_symbols = []
+        positions = {}
+        open_orders = {}
+        inactive_coin_candle_ttl_ms = 600_000
+        stop_signal_received = False
+        start_time_ms = 0
+        cm = FakeCM()
+
+        def is_forager_mode(self, pside=None):
+            return pside in (None, "long")
+
+        def get_max_n_positions(self, pside):
+            return 1 if pside == "long" else 0
+
+        def get_current_n_positions(self, _pside):
+            return 0
+
+        def _get_fetch_delay_seconds(self):
+            return 0.0
+
+        def bp(self, _pside, key, _symbol):
+            if key in {"forager_volume_ema_span_1m", "forager_volatility_ema_span_1m"}:
+                return 10.0
+            return 0.0
+
+        _forager_refresh_budget = pb_mod.Passivbot._forager_refresh_budget
+        _token_bucket_budget = pb_mod.Passivbot._token_bucket_budget
+        _forager_target_staleness_ms = pb_mod.Passivbot._forager_target_staleness_ms
+        _candle_staleness_ms = pb_mod.Passivbot._candle_staleness_ms
+
+    bot = FakeBot()
+    await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
+
+    assert bot.cm.calls == []
+
+
+@pytest.mark.asyncio
+async def test_forager_candidate_refresh_bounds_and_rotates_health_scans(monkeypatch):
+    import passivbot as pb_mod
+
+    now_holder = {"ms": 12 * 60 * 60_000}
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: now_holder["ms"])
+    symbols = {f"S{idx:03d}/USDT:USDT" for idx in range(100)}
+
+    class FakeCM:
+        default_window_candles = 120
+
+        def __init__(self):
+            self.health_calls = []
+            self.fetch_calls = []
+
+        def get_completed_candle_health(self, symbol, windows, now_ms=None):
+            self.health_calls.append((symbol, dict(windows)))
+            required = int(windows["1m"])
+            return {
+                "timeframes": {
+                    "1m": {
+                        "coverage_ok": True,
+                        "loaded_rows": required,
+                        "last_cached_ts": now_ms - 60_000,
+                        "last_cached_age_ms": 0,
+                        "missing_candles": 0,
+                        "tail_gap_candles": 0,
+                    }
+                }
+            }
+
+        async def get_candles(self, symbol, **kwargs):
+            self.fetch_calls.append((symbol, kwargs))
+            return []
+
+    class FakeBot:
+        config = {"live": {"max_ohlcv_fetches_per_minute": 1}}
+        approved_coins_minus_ignored_coins = {"long": symbols, "short": set()}
+        active_symbols = []
+        positions = {}
+        open_orders = {}
+        inactive_coin_candle_ttl_ms = 600_000
+        stop_signal_received = False
+        start_time_ms = 0
+        cm = FakeCM()
+
+        def is_forager_mode(self, pside=None):
+            return pside in (None, "long")
+
+        def get_max_n_positions(self, pside):
+            return 1 if pside == "long" else 0
+
+        def get_current_n_positions(self, pside):
+            return 1 if pside == "long" else 0
+
+        def _get_fetch_delay_seconds(self):
+            return 0.0
+
+        def bp(self, _pside, key, _symbol):
+            if key in {"forager_volume_ema_span_1m", "forager_volatility_ema_span_1m"}:
+                return 10.0
+            return 0.0
+
+        _forager_refresh_budget = pb_mod.Passivbot._forager_refresh_budget
+        _token_bucket_budget = pb_mod.Passivbot._token_bucket_budget
+        _forager_target_staleness_ms = pb_mod.Passivbot._forager_target_staleness_ms
+        _candle_staleness_ms = pb_mod.Passivbot._candle_staleness_ms
+
+    bot = FakeBot()
+    await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
+    first_symbols = {symbol for symbol, _ in bot.cm.health_calls}
+    assert len(bot.cm.health_calls) == 8
+    assert bot.cm.fetch_calls == []
+
+    now_holder["ms"] += 60_000
+    await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
+    second_symbols = {symbol for symbol, _ in bot.cm.health_calls[8:]}
+    assert len(bot.cm.health_calls) == 16
+    assert first_symbols.isdisjoint(second_symbols)
+
+
+@pytest.mark.asyncio
+async def test_forager_candidate_refresh_prioritizes_cold_1m_before_1h(monkeypatch):
+    import passivbot as pb_mod
+
+    now_ms = 12 * 60 * 60_000
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: now_ms)
+    symbols = {"A/USDT:USDT", "B/USDT:USDT"}
+
+    class FakeCM:
+        default_window_candles = 120
+
+        def __init__(self):
+            self.calls = []
+
+        def get_completed_candle_health(self, _symbol, windows, now_ms=None):
+            timeframe = next(iter(windows))
+            required = int(windows[timeframe])
+            return {
+                "timeframes": {
+                    timeframe: {
+                        "coverage_ok": False,
+                        "loaded_rows": 0,
+                        "last_cached_ts": None,
+                        "last_cached_age_ms": None,
+                        "missing_candles": required,
+                        "tail_gap_candles": required,
+                    }
+                }
+            }
+
+        async def get_candles(self, symbol, **kwargs):
+            self.calls.append((symbol, kwargs))
+            return []
+
+    class FakeBot:
+        config = {"live": {"max_ohlcv_fetches_per_minute": 1}}
+        approved_coins_minus_ignored_coins = {"long": symbols, "short": set()}
+        active_symbols = []
+        positions = {}
+        open_orders = {}
+        inactive_coin_candle_ttl_ms = 600_000
+        stop_signal_received = False
+        start_time_ms = 0
+        cm = FakeCM()
+
+        def is_forager_mode(self, pside=None):
+            return pside in (None, "long")
+
+        def get_max_n_positions(self, pside):
+            return 1 if pside == "long" else 0
+
+        def get_current_n_positions(self, pside):
+            return 1 if pside == "long" else 0
+
+        def _get_fetch_delay_seconds(self):
+            return 0.0
+
+        def bp(self, _pside, key, _symbol):
+            if key == "volatility_ema_span_1h":
+                return 784.0
+            if key in {"forager_volume_ema_span_1m", "forager_volatility_ema_span_1m"}:
+                return 10.0
+            return 0.0
+
+        _forager_refresh_budget = pb_mod.Passivbot._forager_refresh_budget
+        _token_bucket_budget = pb_mod.Passivbot._token_bucket_budget
+        _forager_target_staleness_ms = pb_mod.Passivbot._forager_target_staleness_ms
+        _candle_staleness_ms = pb_mod.Passivbot._candle_staleness_ms
+
+    bot = FakeBot()
+    await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
+
+    assert len(bot.cm.calls) == 1
+    assert bot.cm.calls[0][1]["timeframe"] == "1m"
+
+
+@pytest.mark.asyncio
 async def test_forager_candidate_refresh_success_detail_is_debug(monkeypatch, caplog):
     import logging
     import passivbot as pb_mod


### PR DESCRIPTION
## Summary
- refresh every native candle surface required by inactive forager candidates, including native 1h log-range windows
- keep planning cache-only while rotating incomplete symbol/timeframe surfaces fairly within the existing refresh budget
- add regression coverage for a candidate with fresh 1m candles and a missing 784-hour 1h window

## Contract
Inactive-candidate planning remains cache-only. The background refresher now supplies the same per-symbol native 1m and 1h surfaces required by startup/readiness, so stale 1h data cannot silently freeze forager selection around active incumbents.

## Validation
- python -m py_compile src/passivbot.py tests/test_live_candle_budget.py
- pytest -q tests/test_live_warmup_windows.py tests/test_live_candle_budget.py
- pytest -q tests/test_candlestick_manager.py tests/test_ai_docs.py
- PYTHONPATH=src python src/tools/check_ai_docs.py (0 errors; existing word-count warning)
- git diff --check