### PR TITLE
Add bounded balance composition observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `balance.changed` now carries a bounded optional asset-composition diagnostic
+  from the same authoritative balance response. The first connector parser is
+  OKX: it reports only documented account-detail amount, USD value, unrealized
+  PnL, explicit liability, collateral state, and field provenance. Equal-total
+  collateral substitutions are durable through a separate composition
+  signature, while console admission remains snapped-balance based and shows at
+  most two sanitized assets. Generic, Binance, and Hyperliquid paths report a
+  stable unavailable diagnostic until their own parsers are added; balance
+  calculation, API calls, refresh cadence, planning, orders, and risk are
+  unchanged.
+
 - Full live smoke reports now retain a separately bounded sample of hard
   structured problem events, with authoritative total, retained, and truncated
   counts. Later warning-level attention can no longer hide every classification

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -10,6 +10,29 @@ Event emission and sink failures are observability-only unless a feature contrac
 requires durable publication. Diagnostic producers must not mutate order lists, execution results,
 eligibility, replay order, or runtime decisions.
 
+## Balance Composition Diagnostics
+
+`balance.changed` may carry an optional `balance_composition` object from the
+same already-fetched authoritative balance response. It is diagnostic metadata
+only: it must not affect scalar balance calculation, refresh cadence, planning,
+orders, risk, readiness, or execution scheduling.
+
+The object contains a stable `status` (`available`, `unavailable`, or
+`malformed`), bounded source/reason classification, `count`, `retained`,
+`truncated`, and at most eight deterministic `asset_balances` rows. Rows retain
+only connector-proven asset, amount, USD value, unrealized PnL, explicit
+liability, collateral-enabled state, and bounded field provenance. Missing or
+non-finite values are absent; a connector must not infer debt, price, or a
+neutral zero. Raw account payloads, arbitrary response keys, addresses,
+credentials, and internal composition signatures are never emitted.
+
+Balance publication occurs on the existing aggregate raw/snapped transition or
+on a changed full normalized composition signature, including a change in an
+omitted row. Console admission remains based solely on snapped-balance
+materiality. Visible balance lines may append a sanitized sample of at most two
+retained assets; composition-only changes remain structured/text durable but
+stay off the console.
+
 `sink.degraded` identifies the failed sink, stable failure reason, and exception type. It must not
 retain exception text, request URLs, credentials, response bodies, paths, or other arbitrary values
 from the sink exception. Sink counters and pipeline timings remain available through health

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -25,6 +25,9 @@ liability, collateral-enabled state, and bounded field provenance. Missing or
 non-finite values are absent; a connector must not infer debt, price, or a
 neutral zero. Raw account payloads, arbitrary response keys, addresses,
 credentials, and internal composition signatures are never emitted.
+Any legacy raw-only balance apply replaces a previous composition with an
+explicit unavailable state; it must never pair stale asset rows with a fresh
+aggregate balance.
 
 Balance publication occurs on the existing aggregate raw/snapped transition or
 on a changed full normalized composition signature, including a change in an

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/balance-composition-observability`, based on canonical
   `32156cbc251d666902f20b8b000a9a1dfe05a0a2` after PR #1311.
-- PR: not yet opened.
+- PR: #1313.
 - Scope: first connector-specific implementation of backlog item 20. Carry a
   bounded normalized balance-composition diagnostic through staged refresh and
   attach it to `balance.changed`; parse only already-fetched OKX

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,44 +22,52 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/hard-problem-summary-evidence`, based on canonical
-  `5d06887b78c2790efd15e1bd67bae6b3f5d96636` after PR #1310.
-- PR: #1311.
-- Scope: carry bounded, value-safe `hard_problem_events` evidence into concise
-  summary, brief, and compact incident-bundle smoke metadata. Existing mixed
-  sample ordering, hard verdict/count semantics, recovery classification,
-  redaction, event production, and `max_problem_events` bounds remain
-  unchanged.
-- Triggering evidence: PR #1310 fixed the full report after the PR #1309
-  restart smoke exposed mixed-sample eviction, but concise and brief summaries
-  still project only hard counts and grouped types. Incident bundles consume
-  the brief projection, so those operator surfaces can remain red without the
-  separately retained hard classifications now available in the full report.
-- Behavior boundary: read-only report projection only. Event publication,
-  recovery, process control, exchange access, and trading behavior are
-  unchanged.
-- Validation: focused mixed-eviction, summary/brief truncation, zero-bound,
-  incident-bundle manifest, and CLI regressions; complete Python and Rust
-  suites; Rust check/format; AI-doc, registry, compile, and diff checks.
+- Branch: `codex/balance-composition-observability`, based on canonical
+  `32156cbc251d666902f20b8b000a9a1dfe05a0a2` after PR #1311.
+- PR: not yet opened.
+- Scope: first connector-specific implementation of backlog item 20. Carry a
+  bounded normalized balance-composition diagnostic through staged refresh and
+  attach it to `balance.changed`; parse only already-fetched OKX
+  `info.data[0].details` fields, while generic, Binance, and Hyperliquid paths
+  carry an explicit unavailable state until their parsers exist.
+- Behavior boundary: no new exchange/ticker/API calls and no change to scalar
+  balance calculation, refresh cadence, planning, execution scheduling,
+  orders, risk, or console materiality. Composition-only changes are durable
+  but remain off the console.
+- Validation: focused parser, raw-leakage, truncation/signature, staged-carry,
+  composition-only emission, duplicate suppression, legacy-call, and console
+  bounds regressions, plus targeted existing balance/event tests.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
-- Expected VPS action: pull the reviewed merge and run bounded read-only smoke
-  verification. No Rust rebuild, bot restart, or process signal is required
-  for this offline reporting-tool change.
+- Expected VPS action: this behavior-changing diagnostic slice requires a
+  bounded prepare/restart/smoke decision only after exact-head review and CI;
+  it must not manufacture balance events or contact an exchange directly.
 
 ## Deployed Baseline
+
+- PR #1311 merged as canonical `32156cbc251d666902f20b8b000a9a1dfe05a0a2`.
+  It carries bounded hard-only problem evidence into smoke summary, brief, and
+  incident-bundle metadata without changing runtime event production or
+  trading behavior.
+- VPS5 prepared the exact clean merge without a Rust rebuild or bot restart.
+  The immediate bounded smoke retained one natural KuCoin positions timeout in
+  `hard_problem_events`; a settled five-minute smoke was hard-green with an
+  empty hard sample. A bounded incident bundle for the natural timeout carried
+  the same hard-only count, retention, truncation, and sanitized sample in its
+  command result and archived manifest. All five configured bot panes and
+  `misc:0.0` remained unchanged throughout.
+- The merge is the exact base for this slice.
+
+## Previous Deployed Baseline
 
 - PR #1310 merged as canonical `5d06887b78c2790efd15e1bd67bae6b3f5d96636`.
   It added full-report `hard_problem_events` with authoritative `count`,
   bounded chronological `sample`, and explicit `retained`/`truncated` counts;
-  the existing concise/brief and incident-bundle projections were unchanged.
-- VPS5 prepared the exact clean merge without a Rust rebuild or bot restart.
-  The bounded read-only smoke was hard-green and exposed
-  `hard_problem_events={count:0,retained:0,truncated:0,sample:[]}`. All five
+  the concise/brief and incident-bundle projections were unchanged. VPS5
+  prepared the exact clean merge without a Rust rebuild or bot restart, and a
+  bounded read-only smoke was hard-green with
+  `hard_problem_events={count:0,retained:0,truncated:0,sample:[]}`; all five
   pane parents and `misc:0.0` remained unchanged.
-
-## Previous Deployed Baseline
-
 - Canonical `master` and VPS5 are
   `f1ae7970393e8299d1b0a98c8ff68d42adddd2d0` after PR #1299. The clean
   checkout fast-forwarded from PR #1309 without a Rust rebuild after five

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,21 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1310)
+## Latest Canonical Deployment (PR #1311)
+
+- PR #1311 merged as canonical `32156cbc251d666902f20b8b000a9a1dfe05a0a2`.
+  It carries bounded hard-only problem-event evidence into concise smoke,
+  brief, and incident-bundle projections without changing runtime event
+  production or trading behavior.
+- VPS5 prepared the exact clean merge without a Rust rebuild or bot restart.
+  The immediate bounded smoke retained one natural KuCoin positions timeout;
+  the settled five-minute smoke was hard-green with an empty hard sample. A
+  bounded incident bundle for that natural timeout carried the same hard-only
+  evidence in the command result and archived manifest. The five configured
+  bot panes and `misc:0.0` remained unchanged.
+- The exact merge is the base for the following balance-composition slice.
+
+## Previous Canonical Deployment (PR #1310)
 
 - PR #1310 merged as canonical `5d06887b78c2790efd15e1bd67bae6b3f5d96636`.
   It added full-report `hard_problem_events` with authoritative `count`, a

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -1081,7 +1081,13 @@ Related detailed plans:
     the live default branch before the cutover can be considered complete.
 
 20. [ ] Per-asset collateral, debt, and valuation balance events.
-    Status: open. A 2026-07-14 evaluation confirmed that the existing
+    Status: partial, OKX-first. The first connector-specific slice normalizes
+    only OKX's already-fetched `info.data[0].details` into bounded deterministic
+    asset rows and carries an explicit unavailable/malformed diagnostic state
+    for generic, Binance, and Hyperliquid staged paths. It does not add exchange
+    calls or change scalar balance, planning, orders, risk, or console
+    materiality. Other connector parsers and any broader asset contract remain
+    open. A 2026-07-14 evaluation confirmed that the existing
     `balance.changed` event and console projection expose only aggregate raw
     balance, hysteresis-snapped balance, equity, deltas, and source. The
     authoritative refresh already receives the exact raw balance response
@@ -1139,6 +1145,15 @@ Related detailed plans:
     balance; no duplicate event for an unchanged composition; bounded console
     formatting and sanitization; and explicit diagnostic-unavailable behavior
     for unsupported or malformed breakdowns.
+
+    Work log:
+    - 2026-07-18: OKX-first slice added bounded rows for `ccy`, `cashBal`,
+      `eqUsd`, `upl`, `collateralEnabled`, and explicit `liab`, with per-field
+      provenance, deterministic truncation, an omitted-row-sensitive internal
+      signature, and a two-row sanitized console sample. Generic, Binance, and
+      Hyperliquid staged refreshes carry normalized unavailable diagnostics
+      rather than raw balance payloads. No ticker/API call, scalar balance
+      calculation, refresh cadence, planning, order, or risk behavior changed.
 
 21. [ ] Historical secret-bearing text-log inventory and remediation.
     Status: partial. PR #1265 merged and deployed the bounded, value-free,

--- a/src/exchanges/binance.py
+++ b/src/exchanges/binance.py
@@ -1,4 +1,5 @@
 from exchanges.ccxt_bot import CCXTBot, format_exchange_config_response
+from live.balance_composition import malformed_balance_composition
 from passivbot import logging
 from passivbot_exceptions import FatalBotException
 
@@ -251,8 +252,16 @@ class BinanceBot(CCXTBot):
                     except AttributeError:
                         pass
             if "balance" in tasks:
-                _raw_balance, balance = await tasks["balance"]
+                raw_balance, balance = await tasks["balance"]
                 out["balance"] = balance
+                try:
+                    out["balance_composition"] = self._normalize_balance_diagnostics(
+                        raw_balance
+                    )
+                except Exception:
+                    out["balance_composition"] = malformed_balance_composition(
+                        source="normalizer", reason="normalizer_error"
+                    )
             return out
         except Exception:
             for task in tasks.values():

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -10,6 +10,7 @@ import passivbot_rust as pbr
 from ccxt.base.errors import RateLimitExceeded
 
 from exchanges.ccxt_bot import CCXTBot, format_exchange_config_response
+from live.balance_composition import malformed_balance_composition
 from passivbot import logging
 from passivbot_exceptions import FatalBotException
 from utils import symbol_to_coin, ts_to_date, utc_ms
@@ -922,6 +923,14 @@ class HyperliquidBot(CCXTBot):
                     out["positions"] = positions
                 if "balance" in plan:
                     out["balance"] = balance
+                    try:
+                        out["balance_composition"] = self._normalize_balance_diagnostics(
+                            _raw_snapshot["balance"]
+                        )
+                    except Exception:
+                        out["balance_composition"] = malformed_balance_composition(
+                            source="normalizer", reason="normalizer_error"
+                        )
             elif key == "open_orders":
                 out["open_orders"] = result
             elif key == "fills":

--- a/src/exchanges/okx.py
+++ b/src/exchanges/okx.py
@@ -1,4 +1,5 @@
 from exchanges.ccxt_bot import CCXTBot, format_exchange_config_response
+from live.balance_composition import normalize_okx_balance_composition
 from passivbot import logging
 import passivbot_rust as pbr
 
@@ -128,6 +129,10 @@ class OKXBot(CCXTBot):
                 raise KeyError(f"okx: fetch_balance response missing total[{self.quote!r}]")
             return float(total[self.quote])
         return balance
+
+    def _normalize_balance_diagnostics(self, fetched: object) -> dict:
+        """Expose only bounded documented OKX account-detail diagnostics."""
+        return normalize_okx_balance_composition(fetched)
 
     async def fetch_pnls(self, start_time: int = None, end_time: int = None, limit=None):
         if limit is None:

--- a/src/live/balance_composition.py
+++ b/src/live/balance_composition.py
@@ -1,0 +1,263 @@
+"""Bounded, connector-proven balance-composition diagnostics.
+
+The helpers in this module are observability-only.  They must never be used
+to calculate the trading balance or to decide whether an account is ready.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from typing import Any, Mapping
+
+
+ASSET_BALANCE_MAX_ROWS = 8
+ASSET_BALANCE_CONSOLE_SAMPLE_MAX = 2
+_ASSET_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,31}")
+
+
+def _finite_number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def _asset_name(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    asset = value.strip().upper()
+    return asset if _ASSET_RE.fullmatch(asset) else None
+
+
+def _collateral_enabled(value: Any) -> bool | None:
+    if value is True or value is False:
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1"}:
+            return True
+        if normalized in {"false", "0"}:
+            return False
+    return None
+
+
+def _signature(value: Mapping[str, Any]) -> str:
+    canonical = json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _finalize_snapshot(
+    *,
+    status: str,
+    source: str,
+    assets: list[dict[str, Any]],
+    reason: str | None = None,
+    invalid_row_count: int = 0,
+) -> dict[str, Any]:
+    ordered_assets = sorted(assets, key=lambda row: row["asset"])
+    count = len(ordered_assets)
+    retained_assets = ordered_assets[:ASSET_BALANCE_MAX_ROWS]
+    snapshot: dict[str, Any] = {
+        "status": status,
+        "source": source,
+        "asset_balances": retained_assets,
+        "count": count,
+        "retained": len(retained_assets),
+        "truncated": max(0, count - len(retained_assets)),
+    }
+    if reason is not None:
+        snapshot["reason"] = reason
+    if invalid_row_count:
+        snapshot["invalid_row_count"] = int(invalid_row_count)
+    signature_payload = dict(snapshot)
+    signature_payload["asset_balances"] = ordered_assets
+    snapshot["_signature"] = _signature(signature_payload)
+    return snapshot
+
+
+def unavailable_balance_composition(*, reason: str = "unsupported_connector") -> dict[str, Any]:
+    """Return one stable explicit state for connectors without a parser."""
+    return _finalize_snapshot(
+        status="unavailable",
+        source="unsupported",
+        reason=reason,
+        assets=[],
+    )
+
+
+def malformed_balance_composition(*, source: str, reason: str) -> dict[str, Any]:
+    """Return a bounded diagnostic failure without exposing response content."""
+    return _finalize_snapshot(
+        status="malformed",
+        source=source,
+        reason=reason,
+        assets=[],
+    )
+
+
+def normalize_okx_balance_composition(fetched: Any) -> dict[str, Any]:
+    """Normalize only documented OKX account-detail fields from one fetched response."""
+    source = "okx.info.data[0].details"
+    if not isinstance(fetched, Mapping):
+        return malformed_balance_composition(source=source, reason="invalid_payload")
+    info = fetched.get("info")
+    if not isinstance(info, Mapping):
+        return malformed_balance_composition(source=source, reason="missing_info")
+    data = info.get("data")
+    if not isinstance(data, list) or not data:
+        return malformed_balance_composition(source=source, reason="missing_data")
+    account = data[0]
+    if not isinstance(account, Mapping):
+        return malformed_balance_composition(source=source, reason="invalid_account")
+    details = account.get("details")
+    if not isinstance(details, list):
+        return malformed_balance_composition(source=source, reason="missing_details")
+
+    assets: list[dict[str, Any]] = []
+    invalid_row_count = 0
+    for detail in details:
+        if not isinstance(detail, Mapping):
+            invalid_row_count += 1
+            continue
+        asset = _asset_name(detail.get("ccy"))
+        if asset is None:
+            invalid_row_count += 1
+            continue
+        row: dict[str, Any] = {
+            "asset": asset,
+            "field_provenance": {"asset": "ccy"},
+        }
+        for field, payload_key in (
+            ("amount", "cashBal"),
+            ("usd_value", "eqUsd"),
+            ("unrealized_pnl", "upl"),
+            ("liability", "liab"),
+        ):
+            value = _finite_number(detail.get(payload_key))
+            if value is not None:
+                row[field] = value
+                row["field_provenance"][field] = payload_key
+        collateral = _collateral_enabled(detail.get("collateralEnabled"))
+        if collateral is not None:
+            row["collateral_enabled"] = collateral
+            row["field_provenance"]["collateral_enabled"] = "collateralEnabled"
+        assets.append(row)
+    return _finalize_snapshot(
+        status="available",
+        source=source,
+        assets=assets,
+        invalid_row_count=invalid_row_count,
+    )
+
+
+def public_balance_composition(value: Any) -> dict[str, Any] | None:
+    """Copy only the bounded event contract; never publish an internal signature."""
+    if not isinstance(value, Mapping):
+        return None
+    status = value.get("status")
+    source = value.get("source")
+    assets = value.get("asset_balances")
+    count = value.get("count")
+    retained = value.get("retained")
+    truncated = value.get("truncated")
+    if (
+        status not in {"available", "unavailable", "malformed"}
+        or source not in {"unsupported", "normalizer", "okx.info.data[0].details"}
+        or not isinstance(assets, list)
+        or not all(isinstance(item, int) and item >= 0 for item in (count, retained, truncated))
+    ):
+        return None
+    normalized_assets: list[dict[str, Any]] = []
+    for item in assets[:ASSET_BALANCE_MAX_ROWS]:
+        if not isinstance(item, Mapping):
+            return None
+        asset = _asset_name(item.get("asset"))
+        if asset is None:
+            return None
+        row: dict[str, Any] = {"asset": asset}
+        for key in ("amount", "usd_value", "unrealized_pnl", "liability"):
+            number = _finite_number(item.get(key))
+            if number is not None:
+                row[key] = number
+        if isinstance(item.get("collateral_enabled"), bool):
+            row["collateral_enabled"] = item["collateral_enabled"]
+        provenance = item.get("field_provenance")
+        if isinstance(provenance, Mapping):
+            allowed_sources = {
+                "asset": "ccy",
+                "amount": "cashBal",
+                "usd_value": "eqUsd",
+                "unrealized_pnl": "upl",
+                "liability": "liab",
+                "collateral_enabled": "collateralEnabled",
+            }
+            clean_provenance = {
+                key: expected
+                for key, expected in allowed_sources.items()
+                if provenance.get(key) == expected and (key == "asset" or key in row)
+            }
+            if clean_provenance:
+                row["field_provenance"] = clean_provenance
+        normalized_assets.append(row)
+    out: dict[str, Any] = {
+        "status": status,
+        "source": source,
+        "asset_balances": normalized_assets,
+        "count": count,
+        "retained": retained,
+        "truncated": truncated,
+    }
+    reason = value.get("reason")
+    if isinstance(reason, str) and re.fullmatch(r"[a-z_]{1,48}", reason):
+        out["reason"] = reason
+    invalid_row_count = value.get("invalid_row_count")
+    if isinstance(invalid_row_count, int) and invalid_row_count >= 0:
+        out["invalid_row_count"] = invalid_row_count
+    return out
+
+
+def balance_composition_signature(value: Any) -> str | None:
+    if not isinstance(value, Mapping):
+        return None
+    signature = value.get("_signature")
+    return signature if isinstance(signature, str) and len(signature) == 64 else None
+
+
+def format_balance_composition_sample(value: Any) -> str | None:
+    """Render at most two sanitized asset rows for an operator-facing balance line."""
+    public = public_balance_composition(value)
+    if not public or public.get("status") != "available":
+        return None
+    parts = []
+    for row in public["asset_balances"][:ASSET_BALANCE_CONSOLE_SAMPLE_MAX]:
+        asset = _asset_name(row.get("asset"))
+        if asset is None:
+            continue
+        amount = _finite_number(row.get("amount"))
+        usd_value = _finite_number(row.get("usd_value"))
+        liability = _finite_number(row.get("liability"))
+        values = []
+        if amount is not None:
+            values.append(f"a={amount:.6g}")
+        if usd_value is not None:
+            values.append(f"usd={usd_value:.6g}")
+        if liability is not None:
+            values.append(f"liab={liability:.6g}")
+        if row.get("collateral_enabled") is True:
+            values.append("coll=yes")
+        elif row.get("collateral_enabled") is False:
+            values.append("coll=no")
+        if values:
+            parts.append(f"{asset}:{','.join(values)}")
+    if not parts:
+        return None
+    omitted = max(0, int(public["count"]) - len(parts))
+    suffix = f"+{omitted} more" if omitted else ""
+    rendered = ";".join(parts)
+    return f"{rendered} {suffix}" if suffix else rendered

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -15,6 +15,8 @@ from types import MappingProxyType
 import uuid
 from typing import Any, Iterable, Mapping, Protocol
 
+from live.balance_composition import format_balance_composition_sample
+
 
 SCHEMA_VERSION = 1
 REDACTED = "[redacted]"
@@ -1477,11 +1479,13 @@ def _format_console_balance_changed(event: LiveEvent) -> str:
     )
     equity = _format_console_number(_data_number(data, "equity"))
     source = _format_console_label(_data_str(data, "source"))
-    return (
+    rendered = (
         f"[balance] {'raw':<5}{raw_transition} | "
         f"{'snap':<5}{snapped_transition} | "
         f"equity={equity} source={source}"
     )
+    sample = format_balance_composition_sample(data.get("balance_composition"))
+    return f"{rendered} assets={sample}" if sample else rendered
 
 
 def format_memory_snapshot_console(data: Mapping[str, Any]) -> str:

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -18,6 +18,7 @@ from live.event_bus import (
     startup_phase_readiness_contract,
     utc_ms,
 )
+from live.balance_composition import public_balance_composition
 
 
 def current_live_event_cycle_id(bot: Any) -> str | None:
@@ -4754,10 +4755,24 @@ def emit_balance_changed_event(
     balance_snapped: float,
     equity: float,
     source: str,
+    balance_composition: Any = None,
 ) -> None:
     try:
         raw_delta = float(balance_raw) - float(previous_balance_raw)
         snapped_delta = float(balance_snapped) - float(previous_balance_snapped)
+        data = {
+            "previous_balance_raw": float(previous_balance_raw),
+            "balance_raw": float(balance_raw),
+            "balance_raw_delta": raw_delta,
+            "previous_balance_snapped": float(previous_balance_snapped),
+            "balance_snapped": float(balance_snapped),
+            "balance_snapped_delta": snapped_delta,
+            "equity": float(equity),
+            "source": str(source),
+        }
+        composition = public_balance_composition(balance_composition)
+        if composition is not None:
+            data["balance_composition"] = composition
         bot._emit_live_event(
             EventTypes.BALANCE_CHANGED,
             level="info",
@@ -4766,16 +4781,7 @@ def emit_balance_changed_event(
             cycle_id=bot._current_live_event_cycle_id(),
             status="succeeded",
             reason_code=ReasonCodes.BALANCE_CHANGED,
-            data={
-                "previous_balance_raw": float(previous_balance_raw),
-                "balance_raw": float(balance_raw),
-                "balance_raw_delta": raw_delta,
-                "previous_balance_snapped": float(previous_balance_snapped),
-                "balance_snapped": float(balance_snapped),
-                "balance_snapped_delta": snapped_delta,
-                "equity": float(equity),
-                "source": str(source),
-            },
+            data=data,
         )
     except Exception as exc:
         logging.debug("[event] failed to emit balance changed event: %s", exc)

--- a/src/live/state_refresh.py
+++ b/src/live/state_refresh.py
@@ -6,6 +6,7 @@ import sys
 
 from config.access import get_optional_config_value
 from live import event_emitters
+from live.balance_composition import malformed_balance_composition, unavailable_balance_composition
 from utils import ts_to_date, utc_ms
 
 
@@ -45,12 +46,15 @@ async def refresh_protective_authoritative_state(bot) -> bool:
     bot._authoritative_refresh_plan_surfaces = set(plan)
     snapshot = await bot._fetch_authoritative_state_staged_snapshot(plan)
     fetched_balance = snapshot.get("balance")
+    balance_composition = snapshot.get("balance_composition")
     fetched_positions = snapshot.get("positions")
     fetched_open_orders = snapshot.get("open_orders")
 
     prepared_balance_snapshot = bot._prepare_balance_snapshot(fetched_balance)
     if prepared_balance_snapshot is None:
         return False
+    if balance_composition is not None:
+        prepared_balance_snapshot["balance_composition"] = balance_composition
     if fetched_positions in [None, False]:
         return False
     if fetched_open_orders in [None, False]:
@@ -86,6 +90,7 @@ async def refresh_authoritative_state_staged(bot) -> bool:
     plan = bot._authoritative_staged_refresh_plan()
     snapshot = await bot._fetch_authoritative_state_staged_snapshot(plan)
     fetched_balance = snapshot.get("balance")
+    balance_composition = snapshot.get("balance_composition")
     fetched_positions = snapshot.get("positions")
     fetched_open_orders = snapshot.get("open_orders")
     pnls_ok = snapshot.get("pnls_ok", True)
@@ -105,6 +110,8 @@ async def refresh_authoritative_state_staged(bot) -> bool:
         prepared_balance_snapshot = bot._prepare_balance_snapshot(fetched_balance)
         if prepared_balance_snapshot is None:
             return False
+        if balance_composition is not None:
+            prepared_balance_snapshot["balance_composition"] = balance_composition
 
     fetched_positions_old = None
     fetched_positions_new = None
@@ -152,12 +159,21 @@ async def refresh_authoritative_state_staged(bot) -> bool:
     return True
 
 
-async def capture_balance_staged_snapshot(bot) -> tuple[object, float]:
-    """Fetch a single balance payload and its normalized value for staged refresh."""
+async def capture_balance_staged_snapshot(bot) -> tuple[dict, float]:
+    """Fetch one balance response and retain only bounded diagnostics for staging."""
     if hasattr(bot, "capture_balance_snapshot"):
-        return await bot.capture_balance_snapshot()
+        raw_balance, balance = await bot.capture_balance_snapshot()
+        normalizer = getattr(bot, "_normalize_balance_diagnostics", None)
+        if not callable(normalizer):
+            return unavailable_balance_composition(), balance
+        try:
+            return normalizer(raw_balance), balance
+        except Exception:
+            return malformed_balance_composition(
+                source="normalizer", reason="normalizer_error"
+            ), balance
     balance = await bot.fetch_balance()
-    return None, balance
+    return unavailable_balance_composition(), balance
 
 
 async def capture_positions_staged_snapshot(bot) -> tuple[object, list[dict]]:
@@ -672,8 +688,9 @@ async def fetch_authoritative_state_staged_snapshot(bot, plan: set[str]) -> dict
     out = {"plan": set(plan), "pnls_ok": True}
     for key, result in zip(keys, results):
         if key == "balance":
-            _raw_balance, fetched_balance = result
+            balance_composition, fetched_balance = result
             out["balance"] = fetched_balance
+            out["balance_composition"] = balance_composition
         elif key == "positions":
             _raw_positions, fetched_positions = result
             out["positions"] = fetched_positions

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -13769,8 +13769,11 @@ class Passivbot:
         prepared = self._prepare_balance_snapshot(balance_raw)
         if prepared is None:
             return False
-        if balance_composition is not None:
-            prepared["balance_composition"] = balance_composition
+        prepared["balance_composition"] = (
+            balance_composition
+            if balance_composition is not None
+            else unavailable_balance_composition(reason="raw_only_refresh")
+        )
         self._commit_balance_snapshot(prepared)
         return True
 

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -51,6 +51,11 @@ from fill_events_manager import (
     signed_fee_paid_from_payload,
 )
 from live import executor, market_data, planning_gates, reconciler, state_refresh
+from live.balance_composition import (
+    balance_composition_signature,
+    format_balance_composition_sample,
+    unavailable_balance_composition,
+)
 from live.data_packets import (
     ACCOUNT_PACKET_KINDS,
     DataPacketMetadata,
@@ -10373,23 +10378,35 @@ class Passivbot:
             self._previous_balance_snapped = 0.0
         balance_raw = self.get_raw_balance()
         balance_snapped = self.get_hysteresis_snapped_balance()
-        if (
+        composition = getattr(self, "_balance_composition", None)
+        composition_signature = balance_composition_signature(composition)
+        previous_composition_signature = getattr(
+            self, "_previous_balance_composition_signature", None
+        )
+        composition_changed = (
+            composition_signature is not None
+            and composition_signature != previous_composition_signature
+        )
+        balance_changed = (
             balance_raw != self._previous_balance_raw
             or balance_snapped != self._previous_balance_snapped
-        ):
+        )
+        if balance_changed or composition_changed:
             snap_changed = balance_snapped != self._previous_balance_snapped
             try:
                 equity = balance_raw + (await self.calc_upnl_sum())
                 self._monitor_last_equity = float(equity)
                 if snap_changed and not Passivbot._live_event_console_available(self):
+                    composition_sample = format_balance_composition_sample(composition)
                     logging.info(
-                        "[balance] raw %.6f -> %.6f | snap %.6f -> %.6f | equity: %.4f source: %s",
+                        "[balance] raw %.6f -> %.6f | snap %.6f -> %.6f | equity: %.4f source: %s%s",
                         self._previous_balance_raw,
                         balance_raw,
                         self._previous_balance_snapped,
                         balance_snapped,
                         equity,
                         source,
+                        f" assets={composition_sample}" if composition_sample else "",
                     )
                 self._monitor_record_event(
                     "account.balance",
@@ -10416,6 +10433,7 @@ class Passivbot:
                         balance_snapped=float(balance_snapped),
                         equity=float(equity),
                         source=str(source),
+                        balance_composition=composition,
                     )
             except Exception as e:
                 if self._log_noncritical_market_snapshot_error(
@@ -10428,7 +10446,10 @@ class Passivbot:
             finally:
                 self._previous_balance_raw = balance_raw
                 self._previous_balance_snapped = balance_snapped
-                self.execution_scheduled = True
+                if composition_signature is not None:
+                    self._previous_balance_composition_signature = composition_signature
+                if balance_changed:
+                    self.execution_scheduled = True
 
     @staticmethod
     def _is_market_snapshot_error(exc: Exception) -> bool:
@@ -13739,11 +13760,17 @@ class Passivbot:
         self._trailing_pending_position_states = pending_position_states
         return fetched_positions_old, self.fetched_positions
 
-    def _apply_balance_snapshot(self, balance_raw) -> bool:
+    def _normalize_balance_diagnostics(self, _raw_balance) -> dict:
+        """Return the stable diagnostic state for connectors without a balance parser."""
+        return unavailable_balance_composition()
+
+    def _apply_balance_snapshot(self, balance_raw, balance_composition=None) -> bool:
         """Validate and apply a fetched balance snapshot to raw/snapped fields."""
         prepared = self._prepare_balance_snapshot(balance_raw)
         if prepared is None:
             return False
+        if balance_composition is not None:
+            prepared["balance_composition"] = balance_composition
         self._commit_balance_snapshot(prepared)
         return True
 
@@ -13836,6 +13863,8 @@ class Passivbot:
         self.previous_hysteresis_balance = prepared["previous_hysteresis_balance"]
         self.balance_raw = prepared["balance_raw"]
         self.balance = prepared["balance_snapped"]
+        if "balance_composition" in prepared:
+            self._balance_composition = prepared["balance_composition"]
 
     async def _apply_open_orders_snapshot(
         self,

--- a/tests/ccxt_upgrade/test_order_contracts.py
+++ b/tests/ccxt_upgrade/test_order_contracts.py
@@ -10,6 +10,7 @@ from exchanges.binance import BinanceBot
 from exchanges.bybit import BybitBot
 from exchanges.defx import DefxBot
 from exchanges.gateio import GateIOBot
+from exchanges.hyperliquid import HyperliquidBot
 from exchanges.kucoin import KucoinBot
 from exchanges.okx import OKXBot
 from passivbot import custom_id_has_explicit_passivbot_marker, custom_id_to_snake
@@ -175,11 +176,35 @@ async def test_binance_staged_snapshot_uses_fresh_positions_for_open_order_symbo
 
     assert fetched_symbols == ["SOL/USDT:USDT", None]
     assert snapshot["balance"] == 100.0
+    assert snapshot["balance_composition"]["status"] == "unavailable"
+    assert "raw" not in snapshot["balance_composition"]
     assert snapshot["positions"][0]["symbol"] == "SOL/USDT:USDT"
     assert snapshot["open_orders"][0]["symbol"] == "SOL/USDT:USDT"
     assert snapshot["open_orders"][0]["position_side"] == "long"
     assert seen_fill_scope == [["SOL/USDT:USDT"]]
     assert not hasattr(bot, "_fill_symbol_scope")
+
+
+@pytest.mark.asyncio
+async def test_hyperliquid_staged_snapshot_carries_unavailable_diagnostics_not_raw_balance():
+    bot = HyperliquidBot.__new__(HyperliquidBot)
+
+    async def capture_positions_balance():
+        return {"balance": {"raw": "private-balance"}, "positions": []}, [], 100.0
+
+    async def timed(_surface, coro, _timings):
+        return await coro
+
+    bot._capture_positions_balance_staged_snapshot = capture_positions_balance
+    bot._timed_authoritative_fetch = timed
+
+    snapshot = await bot.capture_authoritative_state_staged_snapshot(
+        {"balance", "positions"}, {}
+    )
+
+    assert snapshot["balance"] == 100.0
+    assert snapshot["balance_composition"]["status"] == "unavailable"
+    assert "private-balance" not in str(snapshot["balance_composition"])
 
 
 @pytest.mark.asyncio

--- a/tests/test_balance_composition.py
+++ b/tests/test_balance_composition.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from live.balance_composition import (
+    ASSET_BALANCE_MAX_ROWS,
+    balance_composition_signature,
+    format_balance_composition_sample,
+    malformed_balance_composition,
+    normalize_okx_balance_composition,
+    public_balance_composition,
+    unavailable_balance_composition,
+)
+from live.event_bus import (
+    EventTypes,
+    ListEventSink,
+    LiveEvent,
+    LiveEventPipeline,
+    format_console_event,
+)
+from live import state_refresh
+
+
+def _okx_payload(details):
+    return {"info": {"data": [{"details": details}]}}
+
+
+def test_okx_balance_composition_keeps_only_proven_detail_fields():
+    snapshot = normalize_okx_balance_composition(
+        _okx_payload(
+            [
+                {
+                    "ccy": "USDT",
+                    "cashBal": "12.5",
+                    "eqUsd": "12.4",
+                    "upl": "-0.1",
+                    "collateralEnabled": "true",
+                    "liab": "2",
+                    "secret": "must-not-leak",
+                },
+                {
+                    "ccy": "btc",
+                    "cashBal": "0.02",
+                    "eqUsd": "1300",
+                    "upl": "5",
+                    "collateralEnabled": False,
+                },
+            ]
+        )
+    )
+
+    assert snapshot["status"] == "available"
+    assert snapshot["count"] == 2
+    assert [row["asset"] for row in snapshot["asset_balances"]] == ["BTC", "USDT"]
+    usdt = snapshot["asset_balances"][1]
+    assert usdt == {
+        "asset": "USDT",
+        "field_provenance": {
+            "asset": "ccy",
+            "amount": "cashBal",
+            "usd_value": "eqUsd",
+            "unrealized_pnl": "upl",
+            "liability": "liab",
+            "collateral_enabled": "collateralEnabled",
+        },
+        "amount": 12.5,
+        "usd_value": 12.4,
+        "unrealized_pnl": -0.1,
+        "liability": 2.0,
+        "collateral_enabled": True,
+    }
+    assert "secret" not in str(snapshot)
+    assert "_signature" in snapshot
+
+
+def test_okx_balance_composition_marks_malformed_and_unsupported_states_explicitly():
+    malformed = normalize_okx_balance_composition({"info": {"data": [{}]}})
+    unsupported = unavailable_balance_composition()
+
+    assert malformed["status"] == "malformed"
+    assert malformed["reason"] == "missing_details"
+    assert malformed["asset_balances"] == []
+    assert unsupported["status"] == "unavailable"
+    assert unsupported["reason"] == "unsupported_connector"
+    assert public_balance_composition(malformed_balance_composition(
+        source="normalizer", reason="normalizer_error"
+    ))["status"] == "malformed"
+
+
+def test_okx_balance_composition_omits_missing_and_nonfinite_but_keeps_proven_zeroes():
+    snapshot = normalize_okx_balance_composition(
+        _okx_payload(
+            [
+                {
+                    "ccy": "USDC",
+                    "cashBal": "0",
+                    "eqUsd": "nan",
+                    "upl": "inf",
+                    "liab": None,
+                    "collateralEnabled": "unknown",
+                },
+                {"ccy": "\x1b[31mBAD", "cashBal": "1"},
+            ]
+        )
+    )
+
+    assert snapshot["count"] == 1
+    assert snapshot["invalid_row_count"] == 1
+    assert snapshot["asset_balances"] == [
+        {
+            "asset": "USDC",
+            "field_provenance": {"asset": "ccy", "amount": "cashBal"},
+            "amount": 0.0,
+        }
+    ]
+
+
+def test_composition_signature_covers_omitted_rows_and_order_is_deterministic():
+    details = [
+        {"ccy": f"ASSET{i:02d}", "cashBal": str(i), "eqUsd": str(i * 10)}
+        for i in range(ASSET_BALANCE_MAX_ROWS + 2, 0, -1)
+    ]
+    first = normalize_okx_balance_composition(_okx_payload(details))
+    changed = normalize_okx_balance_composition(
+        _okx_payload(
+            [
+                {**detail, "cashBal": "999"}
+                if detail["ccy"] == "ASSET10"
+                else detail
+                for detail in details
+            ]
+        )
+    )
+
+    assert [row["asset"] for row in first["asset_balances"]] == sorted(
+        row["asset"] for row in first["asset_balances"]
+    )
+    assert first["count"] == ASSET_BALANCE_MAX_ROWS + 2
+    assert first["retained"] == ASSET_BALANCE_MAX_ROWS
+    assert first["truncated"] == 2
+    assert first["asset_balances"] == changed["asset_balances"]
+    assert balance_composition_signature(first) != balance_composition_signature(changed)
+
+
+def test_public_composition_drops_unknown_raw_fields_and_console_sample_is_bounded():
+    snapshot = normalize_okx_balance_composition(
+        _okx_payload(
+            [
+                {"ccy": "BTC", "cashBal": "1", "eqUsd": "100", "apiKey": "secret"},
+                {"ccy": "USDT", "cashBal": "2", "eqUsd": "2"},
+                {"ccy": "ETH", "cashBal": "3", "eqUsd": "9"},
+            ]
+        )
+    )
+    public = public_balance_composition(snapshot)
+    public["asset_balances"][0]["raw_payload"] = {"password": "secret"}
+
+    event = LiveEvent(
+        EventTypes.BALANCE_CHANGED,
+        data={
+            "previous_balance_raw": 10.0,
+            "balance_raw": 11.0,
+            "balance_raw_delta": 1.0,
+            "previous_balance_snapped": 10.0,
+            "balance_snapped": 11.0,
+            "balance_snapped_delta": 1.0,
+            "equity": 11.0,
+            "source": "REST",
+            "balance_composition": public,
+        },
+    )
+    rendered = format_console_event(event)
+
+    assert "secret" not in str(public_balance_composition(public))
+    assert "raw_payload" not in str(public_balance_composition(public))
+    assert "assets=BTC:" in rendered
+    assert "USDT:" not in rendered
+    assert "+1 more" in rendered
+    assert len(rendered) < 240
+    assert not any(ord(char) < 32 or 127 <= ord(char) <= 159 for char in rendered)
+    assert format_balance_composition_sample(snapshot).count(";") <= 1
+    assert math.isfinite(snapshot["asset_balances"][0]["amount"])
+
+
+@pytest.mark.asyncio
+async def test_generic_staged_capture_carries_normalized_diagnostics_not_raw_payload():
+    raw_payload = {"info": {"data": [{"details": [{"ccy": "USDT", "cashBal": "1"}]}]}}
+
+    class Bot:
+        capture_calls = 0
+
+        async def capture_balance_snapshot(self):
+            self.capture_calls += 1
+            return raw_payload, 10.0
+
+        def _normalize_balance_diagnostics(self, payload):
+            assert payload is raw_payload
+            return normalize_okx_balance_composition(payload)
+
+    bot = Bot()
+    composition, balance = await state_refresh.capture_balance_staged_snapshot(bot)
+
+    assert bot.capture_calls == 1
+    assert balance == 10.0
+    assert composition["asset_balances"][0]["asset"] == "USDT"
+    assert raw_payload is not composition
+    assert "info" not in composition
+
+
+@pytest.mark.asyncio
+async def test_diagnostic_normalizer_failure_is_explicit_without_losing_scalar_balance():
+    class Bot:
+        async def capture_balance_snapshot(self):
+            return {"api_key": "secret"}, 10.0
+
+        def _normalize_balance_diagnostics(self, _payload):
+            raise RuntimeError("secret parser failure")
+
+    composition, balance = await state_refresh.capture_balance_staged_snapshot(Bot())
+
+    assert balance == 10.0
+    assert composition == malformed_balance_composition(
+        source="normalizer", reason="normalizer_error"
+    )
+    assert "secret" not in str(composition)
+
+
+def test_composition_only_balance_event_remains_durable_but_is_not_console_visible():
+    structured = ListEventSink()
+    console = ListEventSink()
+    pipeline = LiveEventPipeline(
+        structured_sinks=[structured], monitor_sinks=[], console_sink=console
+    )
+    event = LiveEvent(
+        EventTypes.BALANCE_CHANGED,
+        data={
+            "previous_balance_raw": 100.0,
+            "balance_raw": 100.0,
+            "balance_raw_delta": 0.0,
+            "previous_balance_snapped": 100.0,
+            "balance_snapped": 100.0,
+            "balance_snapped_delta": 0.0,
+            "equity": 100.0,
+            "source": "REST",
+            "balance_composition": normalize_okx_balance_composition(
+                _okx_payload([{"ccy": "USDT", "cashBal": "2"}])
+            ),
+        },
+    )
+
+    pipeline.emit(event)
+
+    assert pipeline.flush(timeout=2.0) is True
+    assert structured.events == [event]
+    assert console.events == []
+    assert pipeline.close(timeout=2.0) is True

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -48,6 +48,10 @@ from planning_snapshot import (
     PlanningSurfaceStamp,
 )
 from exchanges.binance import BinanceBot
+from live.balance_composition import (
+    balance_composition_signature,
+    normalize_okx_balance_composition,
+)
 
 
 class _SafeRiskCache:
@@ -11211,3 +11215,64 @@ async def test_run_execution_loop_propagates_fatal_bot_exception():
 
     with pytest.raises(FatalBotException, match="fatal"):
         await bot.run_execution_loop()
+
+
+def _balance_composition_fixture(amount: str) -> dict:
+    return normalize_okx_balance_composition(
+        {"info": {"data": [{"details": [{"ccy": "USDT", "cashBal": amount}]}]}}
+    )
+
+
+@pytest.mark.asyncio
+async def test_composition_only_balance_change_is_durable_but_does_not_schedule_execution():
+    bot = Passivbot.__new__(Passivbot)
+    bot.balance_raw = 100.0
+    bot.balance = 100.0
+    bot._previous_balance_raw = 100.0
+    bot._previous_balance_snapped = 100.0
+    bot._balance_composition = _balance_composition_fixture("2")
+    bot._previous_balance_composition_signature = balance_composition_signature(
+        _balance_composition_fixture("1")
+    )
+    bot.execution_scheduled = False
+    bot.live_event_console_enabled = False
+    bot._live_event_pipeline = None
+    bot._monitor_record_event = MagicMock()
+    bot._emit_balance_changed_event = MagicMock()
+    bot._log_noncritical_market_snapshot_error = lambda *_args: False
+
+    async def calc_upnl_sum():
+        return 0.0
+
+    bot.calc_upnl_sum = calc_upnl_sum
+
+    await bot.handle_balance_update(source="REST")
+
+    bot._emit_balance_changed_event.assert_called_once()
+    assert bot._emit_balance_changed_event.call_args.kwargs["balance_composition"][
+        "asset_balances"
+    ][0]["amount"] == pytest.approx(2.0)
+    assert bot.execution_scheduled is False
+
+    await bot.handle_balance_update(source="REST")
+
+    bot._emit_balance_changed_event.assert_called_once()
+
+
+def test_legacy_balance_apply_preserves_existing_composition_when_none_is_supplied():
+    bot = Passivbot.__new__(Passivbot)
+    composition = _balance_composition_fixture("1")
+    bot.quote = "USDT"
+    bot.balance = 100.0
+    bot.balance_raw = 100.0
+    bot._exchange_reported_balance_raw = 100.0
+    bot.balance_override = None
+    bot._balance_override_logged = False
+    bot.previous_hysteresis_balance = 100.0
+    bot.balance_hysteresis_snap_pct = 0.02
+    bot._balance_composition = composition
+
+    assert bot._apply_balance_snapshot(100.0) is True
+    assert bot.balance == pytest.approx(100.0)
+    assert bot.balance_raw == pytest.approx(100.0)
+    assert bot._balance_composition is composition

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -11259,7 +11259,7 @@ async def test_composition_only_balance_change_is_durable_but_does_not_schedule_
     bot._emit_balance_changed_event.assert_called_once()
 
 
-def test_legacy_balance_apply_preserves_existing_composition_when_none_is_supplied():
+def test_raw_only_balance_apply_replaces_stale_composition_with_unavailable():
     bot = Passivbot.__new__(Passivbot)
     composition = _balance_composition_fixture("1")
     bot.quote = "USDT"
@@ -11275,4 +11275,7 @@ def test_legacy_balance_apply_preserves_existing_composition_when_none_is_suppli
     assert bot._apply_balance_snapshot(100.0) is True
     assert bot.balance == pytest.approx(100.0)
     assert bot.balance_raw == pytest.approx(100.0)
-    assert bot._balance_composition is composition
+    assert bot._balance_composition["status"] == "unavailable"
+    assert bot._balance_composition["reason"] == "raw_only_refresh"
+    assert bot._balance_composition["asset_balances"] == []
+    assert bot._balance_composition is not composition


### PR DESCRIPTION
## Summary

- carry bounded balance-composition diagnostics from the same authoritative balance response
- add the first connector parser for proven OKX account-detail fields
- emit equal-total composition changes durably without scheduling execution
- keep unsupported connectors explicit and prevent raw account payloads from leaving capture scope

## Behavior boundary

- no new exchange, ticker, or API calls
- no change to scalar balance calculation, refresh cadence, planning, orders, risk, or readiness
- composition-only changes stay off the console and do not schedule execution
- console samples retain at most two sanitized assets and report the total omitted count

## Validation

- full Python suite passed on the exact-head Rust extension
- 421 focused balance, event-bus, and connector contract tests passed
- 210 Rust tests passed via `passivbot-rust/cargotest.sh`
- `cargo check` and `cargo fmt --check` passed
- AI-doc, registry, compile, and diff checks passed

## Deployment evidence carried forward

PR #1311 was prepared on VPS5 at exact canonical `32156cbc251d666902f20b8b000a9a1dfe05a0a2` without a Rust rebuild or restart. The immediate bounded smoke retained one natural KuCoin positions timeout; a settled five-minute smoke was hard-green, and a bounded incident bundle preserved the same sanitized hard-event evidence. The five configured bot panes and `misc:0.0` remained unchanged.

## Post-merge action

This is a behavior-changing diagnostic slice. After merge, prepare the exact VPS5 checkout and gracefully restart only the configured five bot panes, preserving `misc:0.0`, then run bounded immediate and settled smoke checks. Do not manufacture balance events or contact an exchange directly.
