### PR TITLE
Record immutable runtime and fill provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ All notable user-facing changes will be documented in this file.
   calculation, API calls, refresh cadence, planning, orders, and risk are
   unchanged.
 
+- Live startups now persist an immutable, non-secret runtime manifest and expose
+  the same Python commit, config hash, embedded Rust source fingerprint, loaded
+  Rust artifact hash, version, and run id through bounded startup events and
+  monitor state. Newly discovered fill events retain which runtime first
+  ingested them without falsely claiming that runtime created the order;
+  refreshes preserve existing attribution and leave legacy fills unattributed.
+
 - Full live smoke reports now retain a separately bounded sample of hard
   structured problem events, with authoritative total, retained, and truncated
   counts. Later warning-level attention can no longer hide every classification

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -15,6 +15,25 @@
    against `live.fee_pct_sanity_abs_max`; outliers use the fallback percentage.
 6. Do not mix legacy/missing-contract cache rows with current rows. Repair or
    rebuild legacy fill-event caches before using trading-critical accounting.
+7. Newly discovered fills may carry immutable `provenance` with attribution
+   `first_ingested_by_runtime`. This identifies the Passivbot runtime that first
+   persisted the fill locally; it does not claim that runtime created the order
+   or caused the exchange fill. Refresh and deduplication preserve an existing
+   provenance record, including the absence of provenance on legacy cache rows.
+   Historical rows are never retroactively attributed.
+
+## Runtime Provenance
+
+The optional fill provenance record contains the runtime run id, Passivbot
+version, Python Git commit and tracked-dirty state, canonical config hash, Rust
+crate version, embedded Rust source fingerprint, loaded extension artifact hash,
+runtime start timestamp, and the local first-ingestion timestamp. It contains
+hashes rather than raw config, paths, commands, API payloads, or credentials.
+
+The runtime identity proves which local runtime first ingested a fill after this
+contract was introduced. Determining which historical runtime submitted an
+order remains a separate attribution exercise using client-order identifiers,
+logs, runtime windows, and immutable manifests.
 
 ## Exchange Endpoint Map (Quick Lookup)
 
@@ -49,6 +68,8 @@ merely because an auxiliary endpoint failed.
 1. Deduplication correctness.
 2. Pagination completeness for high-activity windows.
 3. PnL attachment behavior when auxiliary endpoints fail.
+4. Provenance round-trip, preservation during refresh/deduplication, and legacy
+   rows remaining unattributed.
 
 ## Key Code
 

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -43,6 +43,25 @@ snapshots independently of the exception payload.
 
 The generated value reference is `../generated/live_event_registry.md`.
 
+## Runtime Identity
+
+Each live `Passivbot` instance creates one immutable runtime identity before its
+monitor and fill manager are initialized. Startup writes it once to
+`caches/runtime/<exchange>/<user>/<run_id>.json`, logs one bounded hash-only
+summary, emits `runtime.started`, and includes the same identity in `bot.started`,
+monitor manifests, and monitor snapshots.
+
+The identity binds a run id and start timestamp to the Passivbot version, Python
+Git commit and tracked-dirty state, canonical config SHA-256, embedded Rust
+source fingerprint, Rust crate version, and SHA-256 of the extension actually
+loaded by Python. It must not include raw config, commands, absolute paths,
+credentials, or exchange payloads. Manifest and event publication failures are
+observability-only and do not change trading behavior.
+
+The Rust artifact hash and embedded source fingerprint are distinct evidence:
+the artifact cannot embed its own final hash, while the build-time source
+fingerprint identifies the Rust input used to produce it.
+
 ## Startup Timing Budgets
 
 `live.startup_phase_budgets` may define optional diagnostic budgets for the canonical

--- a/docs/ai/generated/live_event_registry.md
+++ b/docs/ai/generated/live_event_registry.md
@@ -84,6 +84,7 @@ The code-owned registries live in `src/live/event_bus.py`. Payload and emission 
 - `risk.entry_cooldown_delta_anchored`
 - `risk.mode_changed`
 - `risk.realized_loss_gate_blocked`
+- `runtime.started`
 - `rust_orchestrator.called`
 - `rust_orchestrator.returned`
 - `sink.degraded`

--- a/passivbot-rust/build.rs
+++ b/passivbot-rust/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-env-changed=PASSIVBOT_RUST_SOURCE_FINGERPRINT");
+}

--- a/passivbot-rust/src/lib.rs
+++ b/passivbot-rust/src/lib.rs
@@ -16,9 +16,21 @@ mod utils;
 
 use coin_selection::{select_coin_indices_py, select_forager_candidates_py};
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
 use pyo3::wrap_pyfunction;
 use python::*;
 use utils::*;
+
+#[pyfunction]
+fn runtime_build_info(py: Python<'_>) -> PyResult<PyObject> {
+    let info = PyDict::new_bound(py);
+    info.set_item("crate_version", env!("CARGO_PKG_VERSION"))?;
+    info.set_item(
+        "source_fingerprint",
+        option_env!("PASSIVBOT_RUST_SOURCE_FINGERPRINT").unwrap_or("unknown"),
+    )?;
+    Ok(info.into())
+}
 
 /// A Python module implemented in Rust.
 #[pymodule]
@@ -26,6 +38,7 @@ fn passivbot_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<HlcvsBundlePy>()?;
     m.add_class::<EquityHardStopRollingPeakPy>()?;
     m.add_class::<EquityHardStopRuntimePy>()?;
+    m.add_function(wrap_pyfunction!(runtime_build_info, m)?)?;
     m.add_function(wrap_pyfunction!(round_, m)?)?;
     m.add_function(wrap_pyfunction!(round_up, m)?)?;
     m.add_function(wrap_pyfunction!(round_dn, m)?)?;

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -24,7 +24,8 @@ import shutil
 import tempfile
 import time
 from collections import defaultdict, deque
-from dataclasses import dataclass, field
+from copy import deepcopy
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta, timezone
 from importlib import import_module
 from pathlib import Path
@@ -1333,13 +1334,14 @@ class FillEvent:
     fee_conversion_source: str = "none"
     fee_notional: float = 0.0
     fee_ratio: float = 0.0
+    provenance: Dict[str, object] = field(default_factory=dict)
 
     @property
     def key(self) -> str:
         return self.id
 
     def to_dict(self) -> Dict[str, object]:
-        return {
+        payload = {
             "id": self.id,
             "source_ids": list(self.source_ids) if self.source_ids is not None else [],
             "timestamp": self.timestamp,
@@ -1369,6 +1371,9 @@ class FillEvent:
             "c_mult": self.c_mult,
             "raw": self.raw if self.raw is not None else [],
         }
+        if self.provenance:
+            payload["provenance"] = deepcopy(self.provenance)
+        return payload
 
     @classmethod
     def from_dict(cls, data: Dict[str, object]) -> "FillEvent":
@@ -1434,6 +1439,11 @@ class FillEvent:
             pprice=float(data.get("pprice", 0.0)),
             c_mult=_payload_contract_multiplier(data),
             raw=_normalize_raw_field(data.get("raw")),
+            provenance=(
+                deepcopy(data.get("provenance"))
+                if isinstance(data.get("provenance"), dict)
+                else {}
+            ),
         )
 
     @property
@@ -3174,6 +3184,7 @@ class FillEventsManager:
         fee_pct_fallback: float = DEFAULT_FEE_PCT_FALLBACK,
         fee_pct_sanity_abs_max: float = DEFAULT_FEE_PCT_SANITY_ABS_MAX,
         fee_conversion_max_age_ms: int = DEFAULT_FEE_CONVERSION_MAX_AGE_MS,
+        runtime_identity: Optional[Dict[str, object]] = None,
     ) -> None:
         self.exchange = exchange
         self.user = user
@@ -3183,6 +3194,16 @@ class FillEventsManager:
         self.fee_pct_fallback = float(fee_pct_fallback)
         self.fee_pct_sanity_abs_max = float(fee_pct_sanity_abs_max)
         self.fee_conversion_max_age_ms = int(fee_conversion_max_age_ms)
+        self.runtime_identity = deepcopy(runtime_identity) if runtime_identity else {}
+        self._fill_provenance = (
+            {
+                "schema_version": 1,
+                "attribution": "first_ingested_by_runtime",
+                "runtime": deepcopy(self.runtime_identity),
+            }
+            if self.runtime_identity
+            else {}
+        )
         self._fee_conversion_cache: Dict[Tuple[str, str], Optional[float]] = {}
         self._fee_warning_reported_ids: set[str] = set()
         self._events: List[FillEvent] = []
@@ -4036,6 +4057,7 @@ class FillEventsManager:
             pprice=float(best_event.pprice),
             c_mult=float(best_event.c_mult),
             raw=raw_payload,
+            provenance=deepcopy(best_event.provenance),
         )
 
     async def run_doctor(self, *, auto_repair: bool = False) -> Dict[str, object]:
@@ -4418,6 +4440,10 @@ class FillEventsManager:
             for _raw, event in parsed_events:
                 source_ids = {str(source_id) for source_id in event.source_ids or [] if source_id}
                 replaced_ids: set[str] = set()
+                existing_events: List[FillEvent] = []
+                same_id_event = updated_map.get(event.id)
+                if same_id_event is not None:
+                    existing_events.append(same_id_event)
                 if source_ids:
                     overlapping_ids: set[str] = set()
                     for source_id in source_ids:
@@ -4431,6 +4457,11 @@ class FillEventsManager:
                     if overlapping_ids and not existing_source_ids <= source_ids:
                         continue
                     replaced_ids = overlapping_ids
+                    existing_events.extend(
+                        updated_map[existing_id]
+                        for existing_id in sorted(replaced_ids)
+                        if existing_id in updated_map
+                    )
                     for replaced_id in replaced_ids:
                         replaced = _drop_indexed_event(replaced_id)
                         if replaced is not None:
@@ -4450,6 +4481,22 @@ class FillEventsManager:
                     merged["pnl_source"] = prev.pnl_source
                     merged["pnl_synthetic_reason"] = prev.pnl_synthetic_reason
                     event = FillEvent.from_dict(merged)
+                preserved_provenance = next(
+                    (
+                        deepcopy(existing.provenance)
+                        for existing in existing_events
+                        if existing.provenance
+                    ),
+                    {},
+                )
+                if existing_events:
+                    event = replace(event, provenance=preserved_provenance)
+                elif self._fill_provenance:
+                    first_ingested = deepcopy(self._fill_provenance)
+                    first_ingested["first_ingested_at_ms"] = int(
+                        datetime.now(tz=timezone.utc).timestamp() * 1000
+                    )
+                    event = replace(event, provenance=first_ingested)
                 if prev is not None:
                     for source_id in prev.source_ids or []:
                         indexed = source_id_index.get(str(source_id))

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -146,6 +146,7 @@ def startup_timing_phase(data: object) -> str | None:
 
 
 class EventTypes:
+    RUNTIME_STARTED = "runtime.started"
     BOT_STARTED = "bot.started"
     BOT_READY = "bot.ready"
     BOT_STARTUP_TIMING = "bot.startup_timing"
@@ -477,6 +478,7 @@ def resolve_live_event_console_enabled(
 
 
 PHASE1_EVENT_TYPES = {
+    EventTypes.RUNTIME_STARTED,
     EventTypes.BOT_STARTED,
     EventTypes.BOT_READY,
     EventTypes.BOT_STARTUP_TIMING,
@@ -780,6 +782,7 @@ class EventRoute:
 
 DEFAULT_ROUTE = EventRoute(structured=True, monitor=True, console=False, text=False)
 DEFAULT_ROUTES: dict[str, EventRoute] = {
+    EventTypes.RUNTIME_STARTED: EventRoute(console=False, text=False),
     EventTypes.BOT_STARTED: EventRoute(console=True, text=True),
     EventTypes.BOT_READY: EventRoute(),
     EventTypes.BOT_STARTUP_TIMING: EventRoute(console=True, text=True),

--- a/src/monitor_publisher.py
+++ b/src/monitor_publisher.py
@@ -11,6 +11,7 @@ import threading
 import time
 import uuid
 from collections import deque
+from copy import deepcopy
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterable, Optional
@@ -139,6 +140,7 @@ class MonitorPublisher:
         price_tick_min_interval_ms: int,
         emit_completed_candles: bool,
         include_raw_fill_payloads: bool,
+        runtime_identity: Optional[dict] = None,
     ):
         self.exchange = str(exchange)
         self.user = str(user)
@@ -163,6 +165,7 @@ class MonitorPublisher:
         self.price_tick_min_interval_ms = max(0, int(price_tick_min_interval_ms))
         self.emit_completed_candles = bool(emit_completed_candles)
         self.include_raw_fill_payloads = bool(include_raw_fill_payloads)
+        self.runtime_identity = deepcopy(runtime_identity) if runtime_identity else {}
         self.pid = os.getpid()
         self.created_ts_ms = self._now_ms()
         self.last_snapshot_ms = 0
@@ -190,7 +193,14 @@ class MonitorPublisher:
         self._write_manifest()
 
     @classmethod
-    def from_config(cls, *, exchange: str, user: str, config: dict) -> "MonitorPublisher":
+    def from_config(
+        cls,
+        *,
+        exchange: str,
+        user: str,
+        config: dict,
+        runtime_identity: Optional[dict] = None,
+    ) -> "MonitorPublisher":
         return cls(
             exchange=exchange,
             user=user,
@@ -208,6 +218,7 @@ class MonitorPublisher:
             price_tick_min_interval_ms=int(config["price_tick_min_interval_ms"]),
             emit_completed_candles=bool(config["emit_completed_candles"]),
             include_raw_fill_payloads=bool(config["include_raw_fill_payloads"]),
+            runtime_identity=runtime_identity,
         )
 
     def _now_ms(self) -> int:
@@ -385,6 +396,7 @@ class MonitorPublisher:
             "updated_ts_ms": now_ms,
             "last_seq": self.seq,
             "current_segment_started_ms": self.current_segment_started_ms,
+            "runtime": deepcopy(self.runtime_identity),
             "history_current_segment_started_ms": dict(self.history_segment_started_ms),
             "paths": {
                 "root": str(self.root),
@@ -1188,6 +1200,7 @@ class MonitorPublisher:
                 meta = dict(payload.get("meta") or {})
                 meta.setdefault("exchange", self.exchange)
                 meta.setdefault("user", self.user)
+                meta.setdefault("runtime", deepcopy(self.runtime_identity))
                 meta["snapshot_ts_ms"] = now_ms
                 meta["seq"] = self.seq
                 payload["meta"] = meta

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -81,6 +81,7 @@ from live.event_bus import (
 )
 import live.event_emitters as live_event_emitters
 from monitor_publisher import MonitorPublisher
+from runtime_identity import build_runtime_identity, write_runtime_manifest
 from live.market_snapshot import MarketSnapshot, MarketSnapshotProvider
 from live.planning_availability import PlanningAvailability
 from live.planning_snapshot import PlanningSnapshot
@@ -1144,6 +1145,11 @@ class Passivbot:
         self._live_event_remote_call_ids = {}
         self._active_candle_incomplete_last_log_ms = {}
         self.start_time_ms = utc_ms()
+        self.runtime_identity = build_runtime_identity(
+            self.config,
+            started_at_ms=self.start_time_ms,
+        )
+        self._runtime_manifest_written = False
         self.bot_start_exchange_ts = int(self.get_exchange_time())
         self.orders_emitted_to_exchange: list[dict] = []
         self.foreign_passivbot_seen: dict[str, int] = {}
@@ -1162,6 +1168,7 @@ class Passivbot:
                     exchange=self.exchange,
                     user=self.user,
                     config=require_config_value(config, "monitor"),
+                    runtime_identity=self.runtime_identity.to_dict(),
                 )
             except Exception as exc:
                 logging.error(
@@ -2415,6 +2422,18 @@ class Passivbot:
         logging.info("╠%s╣", border)
         logging.info("║%s║", line2)
         logging.info("╚%s╝", border)
+        runtime = self.runtime_identity
+        dirty_suffix = "+dirty" if runtime.python_git_dirty else ""
+        logging.info(
+            "[runtime] run=%s pb=%s python=%s%s config=%s rust_source=%s rust_artifact=%s",
+            runtime.run_id[:12],
+            runtime.passivbot_version,
+            runtime.python_git_commit[:12],
+            dirty_suffix,
+            runtime.config_sha256[:12],
+            runtime.rust_source_sha256[:12],
+            runtime.rust_artifact_sha256[:12],
+        )
         if self._live_market_orders_allowed():
             logging.warning(
                 "[order] live market order execution is enabled | "
@@ -3111,6 +3130,16 @@ class Passivbot:
         Passivbot._install_asyncio_runtime_exception_handler(self)
         Passivbot._startup_timing_begin(self)
         self._log_startup_banner()
+        runtime_data = self.runtime_identity.to_dict()
+        if not self._runtime_manifest_written:
+            try:
+                write_runtime_manifest(
+                    self.runtime_identity,
+                    root=Path("caches/runtime") / self.exchange / self.user,
+                )
+                self._runtime_manifest_written = True
+            except Exception as exc:
+                logging.warning("[runtime] failed to persist immutable runtime manifest: %s", exc)
         self._bot_ready = False
         if not Passivbot._live_event_console_available(self):
             logging.info("[boot] starting bot %s...", self.exchange)
@@ -3123,6 +3152,7 @@ class Passivbot:
                 "pid": os.getpid(),
                 "quote": self.quote,
                 "start_time_ms": int(self.start_time_ms),
+                "runtime": runtime_data,
             }
             if live_event_debug_profiles:
                 bot_started_data["live_event_debug_profiles"] = live_event_debug_profiles
@@ -3135,6 +3165,7 @@ class Passivbot:
                     "pid": os.getpid(),
                     "quote": self.quote,
                     "start_time_ms": int(self.start_time_ms),
+                    "runtime": runtime_data,
                     **(
                         {"live_event_debug_profiles": live_event_debug_profiles}
                         if live_event_debug_profiles
@@ -3142,6 +3173,14 @@ class Passivbot:
                     ),
                 },
                 ts=int(self.start_time_ms),
+            )
+            self._emit_live_event(
+                EventTypes.RUNTIME_STARTED,
+                level="info",
+                component="lifecycle",
+                tags=("runtime", "lifecycle", "start"),
+                status="started",
+                data=runtime_data,
             )
             self._emit_live_event(
                 EventTypes.BOT_STARTED,
@@ -10522,6 +10561,7 @@ class Passivbot:
                 user=self.user,
                 fetcher=fetcher,
                 cache_path=cache_path,
+                runtime_identity=self.runtime_identity.to_dict(),
                 **fee_policy_kwargs_from_config(self.config),
             )
 

--- a/src/passivbot_monitor.py
+++ b/src/passivbot_monitor.py
@@ -378,6 +378,9 @@ def _monitor_fill_payload(self, event) -> dict:
         "client_order_id": getattr(event, "client_order_id", None),
         "source_ids": list(getattr(event, "source_ids", []) or []),
     }
+    provenance = getattr(event, "provenance", {}) or {}
+    if provenance:
+        payload["provenance"] = dict(provenance)
     return {k: v for k, v in payload.items() if v is not None}
 
 
@@ -1664,6 +1667,9 @@ async def _build_monitor_snapshot(self, *, now_ms: Optional[int] = None) -> dict
             "pid": os.getpid(),
             "bot_start_ts_ms": self.start_time_ms,
             "current_cycle_ts_ms": now_ms,
+            "runtime": getattr(self, "runtime_identity", None).to_dict()
+            if getattr(self, "runtime_identity", None) is not None
+            else {},
         },
         "account": account,
         "health": self._build_health_summary_payload(now_ms=now_ms),

--- a/src/runtime_identity.py
+++ b/src/runtime_identity.py
@@ -1,0 +1,175 @@
+"""Immutable, non-secret identity for one live Passivbot runtime."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import subprocess
+import uuid
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+import passivbot_rust as pbr
+
+from passivbot_version import __version__
+from rust_utils import collect_runtime_provenance
+
+
+RUNTIME_IDENTITY_SCHEMA_VERSION = 1
+FILL_PROVENANCE_SCHEMA_VERSION = 1
+
+
+def _canonical_value(value: Any) -> Any:
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else str(value)
+    if isinstance(value, Mapping):
+        return {
+            str(key): _canonical_value(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+    if isinstance(value, (list, tuple)):
+        return [_canonical_value(item) for item in value]
+    if isinstance(value, (set, frozenset)):
+        items = [_canonical_value(item) for item in value]
+        return sorted(
+            items,
+            key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":")),
+        )
+    if isinstance(value, Path):
+        return str(value)
+    item = getattr(value, "item", None)
+    if callable(item):
+        try:
+            return _canonical_value(item())
+        except Exception:
+            pass
+    tolist = getattr(value, "tolist", None)
+    if callable(tolist):
+        try:
+            return _canonical_value(tolist())
+        except Exception:
+            pass
+    return str(value)
+
+
+def config_sha256(config: Mapping[str, Any]) -> str:
+    """Hash a canonical config without retaining or emitting its contents."""
+    payload = json.dumps(
+        _canonical_value(config),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _git_value(repo_root: Path, *args: str) -> Optional[str]:
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(repo_root), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5.0,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return completed.stdout.strip()
+
+
+def _rust_build_info() -> dict[str, str]:
+    getter = getattr(pbr, "runtime_build_info", None)
+    if not callable(getter):
+        return {}
+    try:
+        result = getter()
+    except Exception:
+        return {}
+    if not isinstance(result, dict):
+        return {}
+    return {str(key): str(value) for key, value in result.items() if value not in (None, "")}
+
+
+@dataclass(frozen=True)
+class RuntimeIdentity:
+    schema_version: int
+    run_id: str
+    started_at_ms: int
+    passivbot_version: str
+    python_git_commit: str
+    python_git_dirty: Optional[bool]
+    config_sha256: str
+    rust_crate_version: str
+    rust_source_sha256: str
+    rust_artifact_sha256: str
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+    def fill_provenance(self) -> dict[str, object]:
+        return {
+            "schema_version": FILL_PROVENANCE_SCHEMA_VERSION,
+            "attribution": "first_ingested_by_runtime",
+            "runtime": self.to_dict(),
+        }
+
+
+def build_runtime_identity(
+    config: Mapping[str, Any],
+    *,
+    started_at_ms: int,
+    repo_root: Optional[Path] = None,
+) -> RuntimeIdentity:
+    repo_root = (
+        Path(__file__).resolve().parents[1] if repo_root is None else Path(repo_root).resolve()
+    )
+    commit = _git_value(repo_root, "rev-parse", "HEAD") or "unknown"
+    status = _git_value(repo_root, "status", "--porcelain", "--untracked-files=no")
+    try:
+        config_digest = config_sha256(config)
+    except Exception:
+        config_digest = "unknown"
+    try:
+        rust_runtime = collect_runtime_provenance()
+    except Exception:
+        rust_runtime = {}
+    rust_build = _rust_build_info()
+    return RuntimeIdentity(
+        schema_version=RUNTIME_IDENTITY_SCHEMA_VERSION,
+        run_id=uuid.uuid4().hex,
+        started_at_ms=int(started_at_ms),
+        passivbot_version=str(__version__),
+        python_git_commit=commit,
+        python_git_dirty=None if status is None else bool(status),
+        config_sha256=config_digest,
+        rust_crate_version=str(rust_build.get("crate_version") or "unknown"),
+        rust_source_sha256=str(
+            rust_build.get("source_fingerprint")
+            or rust_runtime.get("runtime_module_source_stamp")
+            or "unknown"
+        ),
+        rust_artifact_sha256=str(rust_runtime.get("runtime_module_sha256") or "unknown"),
+    )
+
+
+def write_runtime_manifest(
+    identity: RuntimeIdentity,
+    *,
+    root: Path = Path("caches/runtime"),
+) -> Path:
+    """Persist one immutable manifest; an existing run id is never overwritten."""
+    root = Path(root)
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / f"{identity.run_id}.json"
+    payload = json.dumps(identity.to_dict(), sort_keys=True, separators=(",", ":")) + "\n"
+    with path.open("x", encoding="utf-8") as handle:
+        handle.write(payload)
+        handle.flush()
+        os.fsync(handle.fileno())
+    return path

--- a/src/rust_utils.py
+++ b/src/rust_utils.py
@@ -478,6 +478,9 @@ def maturin_develop_command() -> list[str]:
 
 def maturin_env() -> dict[str, str]:
     env = os.environ.copy()
+    fingerprint = source_fingerprint()
+    if fingerprint is not None:
+        env["PASSIVBOT_RUST_SOURCE_FINGERPRINT"] = fingerprint
     prefix = Path(sys.prefix)
     base_prefix = Path(getattr(sys, "base_prefix", sys.prefix))
     if prefix != base_prefix:

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -7177,3 +7177,78 @@ def test_hyperliquid_raw_start_position_overrides_wrong_reconstructed_psize():
 
     assert events[0]["psize"] == 0.0
     assert events[0]["pprice"] == 0.0
+
+
+def _provenance_test_fill() -> Dict[str, object]:
+    return {
+        "id": "fill-provenance-1",
+        "timestamp": 1_700_000_000_000,
+        "datetime": "",
+        "symbol": "BTC/USDT:USDT",
+        "side": "buy",
+        "qty": 0.1,
+        "price": 10_000.0,
+        "pnl": 0.0,
+        "fee_paid": -0.01,
+        "pb_order_type": "entry_trailing_normal_long",
+        "position_side": "long",
+        "client_order_id": "cid-provenance",
+    }
+
+
+def test_fill_event_provenance_round_trips_defensively():
+    payload = _provenance_test_fill()
+    payload["provenance"] = {
+        "schema_version": 1,
+        "attribution": "first_ingested_by_runtime",
+        "runtime": {"run_id": "run-1"},
+    }
+    event = FillEvent.from_dict(payload)
+    serialized = event.to_dict()
+    serialized["provenance"]["runtime"]["run_id"] = "mutated"
+    assert event.provenance["runtime"]["run_id"] == "run-1"
+    assert FillEvent.from_dict(event.to_dict()).provenance == event.provenance
+
+
+@pytest.mark.asyncio
+async def test_new_fill_records_first_ingesting_runtime(tmp_path: Path):
+    runtime = {"schema_version": 1, "run_id": "run-current"}
+    manager = FillEventsManager(
+        exchange="hyperliquid",
+        user="user",
+        fetcher=_StaticFetcher([_provenance_test_fill()]),
+        cache_path=tmp_path,
+        runtime_identity=runtime,
+    )
+
+    await manager.refresh()
+
+    event = manager.get_events()[0]
+    assert event.provenance["schema_version"] == 1
+    assert event.provenance["attribution"] == "first_ingested_by_runtime"
+    assert event.provenance["runtime"] == runtime
+    assert event.provenance["first_ingested_at_ms"] >= event.timestamp
+    assert FillEventCache(tmp_path).load()[0].provenance == event.provenance
+
+
+@pytest.mark.asyncio
+async def test_refresh_does_not_reattribute_legacy_cached_fill(tmp_path: Path):
+    cached = FillEvent.from_dict(_provenance_test_fill())
+    FillEventCache(tmp_path).save([cached])
+    manager = FillEventsManager(
+        exchange="hyperliquid",
+        user="user",
+        fetcher=_StaticFetcher([_provenance_test_fill()]),
+        cache_path=tmp_path,
+        runtime_identity={"schema_version": 1, "run_id": "run-later"},
+    )
+
+    await manager.ensure_loaded()
+    assert manager.get_events()[0].provenance == {}
+    await manager.refresh()
+
+    assert manager.get_events()[0].provenance == {}
+    assert FillEventCache(tmp_path).load()[0].provenance == {}
+    data_files = [path for path in tmp_path.glob("*.json") if path.name != "metadata.json"]
+    persisted = json.loads(data_files[0].read_text())
+    assert "provenance" not in persisted[0]

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -385,6 +385,10 @@ def test_route_table_keeps_data_events_off_console_by_default():
     assert DEFAULT_ROUTES[EventTypes.HSL_TRANSITION].text is True
     assert DEFAULT_ROUTES[EventTypes.BOT_STARTED].console is True
     assert DEFAULT_ROUTES[EventTypes.BOT_STARTED].text is True
+    assert DEFAULT_ROUTES[EventTypes.RUNTIME_STARTED].structured is True
+    assert DEFAULT_ROUTES[EventTypes.RUNTIME_STARTED].monitor is True
+    assert DEFAULT_ROUTES[EventTypes.RUNTIME_STARTED].console is False
+    assert DEFAULT_ROUTES[EventTypes.RUNTIME_STARTED].text is False
     assert DEFAULT_ROUTES[EventTypes.BOT_READY].structured is True
     assert DEFAULT_ROUTES[EventTypes.BOT_READY].monitor is True
     assert DEFAULT_ROUTES[EventTypes.BOT_READY].console is False

--- a/tests/test_monitor_publisher.py
+++ b/tests/test_monitor_publisher.py
@@ -34,7 +34,8 @@ def _make_publisher(tmp_path, **overrides):
 
 
 def test_monitor_publisher_writes_manifest_events_and_snapshot(tmp_path):
-    publisher = _make_publisher(tmp_path)
+    runtime = {"schema_version": 1, "run_id": "run-123"}
+    publisher = _make_publisher(tmp_path, runtime_identity=runtime)
 
     event = publisher.record_event("bot.start", ("bot", "lifecycle"), {"status": "starting"}, ts=1000)
     assert event["seq"] == 1
@@ -46,6 +47,7 @@ def test_monitor_publisher_writes_manifest_events_and_snapshot(tmp_path):
     assert manifest["last_seq"] == 2
     assert manifest["capabilities"]["history"] is True
     assert manifest["capabilities"]["history_streams"]["fills"] is True
+    assert manifest["runtime"] == runtime
 
     events = [json.loads(line) for line in (root / "events" / "current.ndjson").read_text().splitlines()]
     assert [event["kind"] for event in events] == ["bot.start", "error.bot"]
@@ -61,6 +63,7 @@ def test_monitor_publisher_writes_manifest_events_and_snapshot(tmp_path):
     snapshot = json.loads((root / "state.latest.json").read_text())
     assert snapshot["meta"]["custom"] == "value"
     assert snapshot["meta"]["seq"] == 2
+    assert snapshot["meta"]["runtime"] == runtime
     assert snapshot["account"]["balance_raw"] == 123.0
 
 

--- a/tests/test_order_orchestration.py
+++ b/tests/test_order_orchestration.py
@@ -5,6 +5,21 @@ import pytest
 import passivbot_rust as pbr
 from passivbot import Passivbot
 from exchanges.ccxt_bot import CCXTBot
+from runtime_identity import RuntimeIdentity
+
+
+TEST_RUNTIME_IDENTITY = RuntimeIdentity(
+    schema_version=1,
+    run_id="a" * 32,
+    started_at_ms=1_700_000_000_000,
+    passivbot_version="test",
+    python_git_commit="b" * 40,
+    python_git_dirty=False,
+    config_sha256="c" * 64,
+    rust_crate_version="test",
+    rust_source_sha256="d" * 64,
+    rust_artifact_sha256="e" * 64,
+)
 
 
 class OrchestrationBot(Passivbot):
@@ -163,6 +178,7 @@ def test_ema_anchor_limit_orders_route_to_ccxt_post_only_params(
 
 def test_startup_banner_warns_when_market_orders_allowed(caplog):
     bot = Passivbot.__new__(Passivbot)
+    bot.runtime_identity = TEST_RUNTIME_IDENTITY
     bot.user = "hyperliquid_pf1"
     bot.exchange = "hyperliquid"
     live_values = {

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -47,10 +47,25 @@ from planning_snapshot import (
     PlanningSnapshot,
     PlanningSurfaceStamp,
 )
+from runtime_identity import RuntimeIdentity
 from exchanges.binance import BinanceBot
 from live.balance_composition import (
     balance_composition_signature,
     normalize_okx_balance_composition,
+)
+
+
+TEST_RUNTIME_IDENTITY = RuntimeIdentity(
+    schema_version=1,
+    run_id="a" * 32,
+    started_at_ms=1_700_000_000_000,
+    passivbot_version="test",
+    python_git_commit="b" * 40,
+    python_git_dirty=False,
+    config_sha256="c" * 64,
+    rust_crate_version="test",
+    rust_source_sha256="d" * 64,
+    rust_artifact_sha256="e" * 64,
 )
 
 
@@ -199,6 +214,7 @@ async def test_init_pnls_quarantines_and_rebuilds_unsupported_legacy_cache(monke
             self.history_scope = scope
 
     bot = Passivbot.__new__(Passivbot)
+    bot.runtime_identity = TEST_RUNTIME_IDENTITY
     bot.exchange = "hyperliquid"
     bot.user = "vps_user"
     bot.config = {"live": {"pnls_max_lookback_days": 1.0}}
@@ -292,6 +308,7 @@ async def test_init_pnls_emits_quarantine_event_when_doctor_repairs_legacy_cache
             self.history_scope = scope
 
     bot = Passivbot.__new__(Passivbot)
+    bot.runtime_identity = TEST_RUNTIME_IDENTITY
     bot.exchange = "hyperliquid"
     bot.user = "vps_user"
     bot.config = {"live": {"pnls_max_lookback_days": 1.0}}
@@ -352,6 +369,7 @@ async def test_init_pnls_emits_cache_ready_event(monkeypatch):
 
     sink = ListEventSink()
     bot = Passivbot.__new__(Passivbot)
+    bot.runtime_identity = TEST_RUNTIME_IDENTITY
     bot.exchange = "binance"
     bot.user = "binance_01"
     bot.bot_id = "bot_1"
@@ -2494,6 +2512,8 @@ async def test_balance_equity_history_emits_zero_coin_upnl_for_flat_realized_sym
 @pytest.mark.asyncio
 async def test_start_bot_treats_shutdown_cancelled_warmup_as_clean_stop(monkeypatch):
     bot = Passivbot.__new__(Passivbot)
+    bot.runtime_identity = TEST_RUNTIME_IDENTITY
+    bot._runtime_manifest_written = True
     bot.exchange = "bybit"
     bot.user = "test_user"
     bot.quote = "USDT"
@@ -2537,6 +2557,8 @@ async def test_start_bot_treats_shutdown_cancelled_warmup_as_clean_stop(monkeypa
 @pytest.mark.asyncio
 async def test_start_bot_treats_hsl_value_error_as_terminal_startup_failure(monkeypatch):
     bot = Passivbot.__new__(Passivbot)
+    bot.runtime_identity = TEST_RUNTIME_IDENTITY
+    bot._runtime_manifest_written = True
     bot.exchange = "gateio"
     bot.user = "test_user"
     bot.quote = "USDT"

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -5119,6 +5119,10 @@ async def test_start_bot_records_startup_error_stop_and_early_snapshot(
             self.user = "bitget_01"
             self.quote = "USDT"
             self.start_time_ms = 1234567890
+            self.runtime_identity = SimpleNamespace(
+                to_dict=lambda: {"schema_version": 1, "run_id": "test-run"}
+            )
+            self._runtime_manifest_written = True
             self.debug_mode = False
             self.stop_signal_received = False
             self.snapshot_flushes = []
@@ -5240,6 +5244,11 @@ def test_log_new_fill_events_records_fill_history():
         pb_order_type="entry_grid_normal_long",
         client_order_id="cid-1",
         source_ids=["src-1"],
+        provenance={
+            "schema_version": 1,
+            "attribution": "first_ingested_by_runtime",
+            "runtime": {"run_id": "run-1"},
+        },
         raw={"exchange_fill_id": "ex-1"},
     )
 
@@ -5247,6 +5256,10 @@ def test_log_new_fill_events_records_fill_history():
 
     assert bot.monitor_publisher.fills[-1]["symbol"] == "BTC/USDT:USDT"
     assert bot.monitor_publisher.fills[-1]["payload"]["id"] == "fill-1"
+    assert (
+        bot.monitor_publisher.fills[-1]["payload"]["provenance"]["runtime"]["run_id"]
+        == "run-1"
+    )
     assert bot.monitor_publisher.events[-1]["kind"] == "order.filled"
     assert bot._health_fills == 1
     assert bot._health_pnl == pytest.approx(1.25)

--- a/tests/test_runtime_identity.py
+++ b/tests/test_runtime_identity.py
@@ -1,0 +1,98 @@
+from dataclasses import FrozenInstanceError
+import json
+
+import pytest
+
+import runtime_identity as runtime_identity_module
+from runtime_identity import (
+    RuntimeIdentity,
+    build_runtime_identity,
+    config_sha256,
+    write_runtime_manifest,
+)
+
+
+def _identity(**overrides) -> RuntimeIdentity:
+    values = {
+        "schema_version": 1,
+        "run_id": "a" * 32,
+        "started_at_ms": 1_700_000_000_000,
+        "passivbot_version": "8.0.0",
+        "python_git_commit": "b" * 40,
+        "python_git_dirty": False,
+        "config_sha256": "c" * 64,
+        "rust_crate_version": "0.1.0",
+        "rust_source_sha256": "d" * 64,
+        "rust_artifact_sha256": "e" * 64,
+    }
+    values.update(overrides)
+    return RuntimeIdentity(**values)
+
+
+def test_config_sha256_is_canonical_and_content_sensitive():
+    left = {"z": {3, 1, 2}, "nested": {"b": 2, "a": [1, 2]}}
+    right = {"nested": {"a": [1, 2], "b": 2}, "z": {2, 3, 1}}
+    assert config_sha256(left) == config_sha256(right)
+    assert config_sha256(left) != config_sha256({**right, "extra": True})
+
+
+def test_build_runtime_identity_records_loaded_binary_without_exposing_config(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(
+        runtime_identity_module,
+        "_git_value",
+        lambda _root, *args: "f" * 40 if args[0] == "rev-parse" else "",
+    )
+    monkeypatch.setattr(
+        runtime_identity_module,
+        "_rust_build_info",
+        lambda: {"crate_version": "0.2.0", "source_fingerprint": "1" * 64},
+    )
+    monkeypatch.setattr(
+        runtime_identity_module,
+        "collect_runtime_provenance",
+        lambda: {"runtime_module_sha256": "2" * 64},
+    )
+    config = {"api_secret": "must-not-be-recorded", "threshold": 0.1}
+    identity = build_runtime_identity(config, started_at_ms=123, repo_root=tmp_path)
+
+    assert identity.python_git_commit == "f" * 40
+    assert identity.python_git_dirty is False
+    assert identity.rust_source_sha256 == "1" * 64
+    assert identity.rust_artifact_sha256 == "2" * 64
+    assert "must-not-be-recorded" not in json.dumps(identity.to_dict())
+    with pytest.raises(FrozenInstanceError):
+        identity.run_id = "changed"
+
+
+def test_runtime_manifest_is_exclusive_and_fill_attribution_is_precise(tmp_path):
+    identity = _identity()
+    path = write_runtime_manifest(identity, root=tmp_path)
+    assert json.loads(path.read_text()) == identity.to_dict()
+    assert identity.fill_provenance()["attribution"] == "first_ingested_by_runtime"
+    with pytest.raises(FileExistsError):
+        write_runtime_manifest(identity, root=tmp_path)
+
+
+def test_runtime_identity_collection_failure_degrades_to_unknown(monkeypatch, tmp_path):
+    monkeypatch.setattr(runtime_identity_module, "_git_value", lambda *_args: None)
+    monkeypatch.setattr(runtime_identity_module, "_rust_build_info", lambda: {})
+    monkeypatch.setattr(
+        runtime_identity_module,
+        "collect_runtime_provenance",
+        lambda: (_ for _ in ()).throw(OSError("unreadable artifact")),
+    )
+    monkeypatch.setattr(
+        runtime_identity_module,
+        "config_sha256",
+        lambda _config: (_ for _ in ()).throw(TypeError("unhashable config")),
+    )
+
+    identity = build_runtime_identity({}, started_at_ms=123, repo_root=tmp_path)
+
+    assert identity.python_git_commit == "unknown"
+    assert identity.python_git_dirty is None
+    assert identity.config_sha256 == "unknown"
+    assert identity.rust_source_sha256 == "unknown"
+    assert identity.rust_artifact_sha256 == "unknown"

--- a/tests/test_rust_utils.py
+++ b/tests/test_rust_utils.py
@@ -271,6 +271,11 @@ def test_maturin_env_prefers_current_virtualenv(monkeypatch: pytest.MonkeyPatch)
     assert env["PATH"].startswith("/tmp/current-venv/bin")
 
 
+def test_maturin_env_embeds_source_fingerprint(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("rust_utils.source_fingerprint", lambda: "abc123")
+    assert maturin_env()["PASSIVBOT_RUST_SOURCE_FINGERPRINT"] == "abc123"
+
+
 def test_latest_source_mtime_includes_root_level_rs_files(tmp_path: Path):
     """Test that latest_source_mtime detects root-level .rs files (PR #537 fix)."""
     src_dir = tmp_path / "passivbot-rust"


### PR DESCRIPTION
## Summary
- create one immutable, non-secret runtime identity per live process, binding the Python commit and tracked-dirty state, canonical config hash, Passivbot version, Rust crate/source fingerprint, and loaded extension artifact hash
- persist an exclusive run manifest and expose the same identity through bounded startup logs/events and monitor manifests/snapshots
- annotate only newly discovered fills with the runtime and timestamp that first ingested them; preserve existing attribution and leave legacy rows unattributed
- embed Rust build information in the extension and verify the loaded artifact separately

## Attribution semantics
first_ingested_by_runtime intentionally does not claim that the runtime created the order or caused the exchange fill. Historical producer attribution still requires correlation with runtime windows, client-order IDs, logs, and manifests.

## Safety
The identity retains hashes only: no raw config, commands, absolute paths, credentials, or exchange payloads. Provenance publication is observability-only and does not affect trading decisions. Existing fill archives are not retroactively attributed, and empty legacy provenance is not added during persistence.

## Validation
- focused Python suite: runtime identity, Rust utilities, monitor publisher, fill manager, live event bus, Passivbot monitor, generated event docs, AI docs (all passed)
- cargo test --offline --no-default-features (210 passed)
- cargo check --offline --tests
- rebuilt the Python extension and verified embedded Rust source fingerprint equals current source fingerprint
- verified loaded extension artifact/source stamp with verify_loaded_runtime_extension
- generated live event registry check
- AI docs check: 0 errors, existing aggregate word-count warning only
- cargo fmt --check
- git diff --check