### PR TITLE
Add historical runtime attribution report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ All notable user-facing changes will be documented in this file.
   calculation, API calls, refresh cadence, planning, orders, and risk are
   unchanged.
 
+- Added `passivbot tool runtime-attribution`, a bounded, read-only local report
+  that correlates fill caches and monitor fill history with immutable runtime
+  manifests, structured startup events, and legacy startup logs. It keeps
+  recorded first-ingestion identity separate from non-proving producer-window
+  candidates, leaves legacy fills unattributed, supports trailing-only and
+  account/symbol/time filters, and can fail when selected fills lack recorded
+  provenance without contacting exchanges or controlling bots.
+
 - Full live smoke reports now retain a separately bounded sample of hard
   structured problem events, with authoritative total, retained, and truncated
   counts. Later warning-level attention can no longer hide every classification

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -24,6 +24,7 @@ current task.
 | Equity Hard Stop Loss episodes, replay, flattening, cooldown | `error_contract.md`, `features/equity_hard_stop_loss.md`, `features/fill_events_manager.md` |
 | Candles, OHLCV coverage, gaps, projections | `error_contract.md`, `features/candlestick_manager.md`; add `features/exchange_integrations.md` for remote fetch behavior |
 | Fill/PnL ingestion, fees, coverage | `error_contract.md`, `features/fill_events_manager.md`, relevant exchange contract |
+| Historical runtime/fill attribution | `features/runtime_attribution.md`, `features/fill_events_manager.md`, `features/live_events.md` |
 | Commands, tests, backtests, optimizer, execution safety | `runbooks/commands.md` |
 | Autonomous PR review | `runbooks/pr_review.md` |
 | Crash discovery and stress-suite generation | `runbooks/crash_discovery.md` |

--- a/docs/ai/features/README.md
+++ b/docs/ai/features/README.md
@@ -8,6 +8,7 @@ Open only the contract for the subsystem being changed.
 | Stock perpetuals (HIP-3) | `stock_perps.md` |
 | Candles, cache continuity, and projections | `candlestick_manager.md` |
 | Fill/PnL ingestion and coverage | `fill_events_manager.md` |
+| Historical runtime/fill attribution | `runtime_attribution.md` |
 | Equity Hard Stop Loss episodes and cooldown boundaries | `equity_hard_stop_loss.md` |
 | Raw versus snapped balance | `balance_routing.md` |
 | Monitor persistence, recovery, rotation, retention | `monitor_persistence.md` |

--- a/docs/ai/features/runtime_attribution.md
+++ b/docs/ai/features/runtime_attribution.md
@@ -1,0 +1,61 @@
+# Runtime Attribution
+
+## Contract
+
+`passivbot tool runtime-attribution` reads local fill caches, monitor history,
+runtime manifests, structured startup events, and bounded text startup logs. It
+does not contact exchanges, inspect processes, mutate caches, or control bots.
+
+The report keeps two claims separate:
+
+1. `first_ingestion` is `recorded` only when a fill itself carries
+   `first_ingested_by_runtime` provenance. This proves which runtime first
+   persisted that fill locally, not which runtime submitted its order.
+2. `producer_attribution` correlates the exchange fill timestamp with observed
+   runtime start windows. Even a single matching window is a candidate, sets
+   `proven=false`, and requires client-order IDs plus contemporaneous
+   order/execution logs for stronger attribution.
+
+Legacy fills without embedded provenance remain explicitly unattributed. The
+tool never assigns them to the runtime that happened to read or re-save them.
+Legacy startup banners can establish a runtime window without establishing a
+version. Bounded startup hash prefixes merge with a full manifest/event identity
+only when account, start timestamp, and run-id prefix agree uniquely.
+
+## Inputs And Output
+
+Defaults scan:
+
+- `caches/fill_events` for canonical daily fill arrays
+- `caches/runtime` for immutable per-run manifests
+- `monitor` for manifests, structured events, and fill history
+- `logs` for startup banners and bounded runtime identity lines
+
+Repeat `--exchange`, `--user`, or `--symbol` to filter the report. Use
+`--trailing-only` to isolate trailing order types. `--since-ms` and `--until-ms`
+bound exchange fill timestamps. File count, fill-record count, per-file bytes,
+and total scanned bytes fail closed; parse warnings are capped and report only
+path and stable error classification, not file contents.
+
+`--fail-on-unattributed` exits 1 if any selected fill lacks recorded
+first-ingestion provenance. It does not treat a candidate producer window as
+proof.
+
+```bash
+passivbot tool runtime-attribution --exchange bybit --user account_01 --compact
+passivbot tool runtime-attribution --trailing-only --fail-on-unattributed
+```
+
+## Validation
+
+- recorded versus legacy first-ingestion classification
+- runtime-window candidate boundaries across consecutive starts
+- runtime manifest, monitor event, bounded startup log, and fill-history parsing
+- fill deduplication across cache and monitor history
+- trailing-only filters and fail-closed scan limits
+
+## Key Code
+
+- `src/live/runtime_attribution.py`
+- `src/tools/runtime_attribution.py`
+- `tests/test_runtime_attribution.py`

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,43 +22,39 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/shutdown-lifecycle-completeness`, based on canonical
-  `bc2c90267be418344ec883fcf17fae856bc568cd` after PR #1320.
-- PR: #1321.
-- Scope: derive the latest bounded shutdown lifecycle per observed bot and make
-  restart evidence require distinct complete bot lifecycles instead of
-  aggregate `bot.stopping` and `bot.stopped` counts.
-- Behavior boundary: read-only smoke report, restart-evidence evaluation,
-  concise/brief projections, tests, changelog, and project state only. No event
-  producer, monitor persistence, console, exchange, order, risk, readiness,
-  configuration, restart execution, or process-control behavior changes.
-- Validation: focused report/projection tests must prove duplicate events from
-  one bot cannot satisfy a multi-bot restart gate, incomplete latest lifecycles
-  remain visible, out-of-order input is handled by canonical event ordering,
-  and top-level smoke verdicts retain their current semantics.
-- Review gate: temporary maintainer-authorized exact-head Hermes plus green
-  Python and Rust CI while Grok is halted. Repository automatic Codex review is
-  additional; any findings it posts must still be adjudicated.
-- Expected VPS action: pull and bounded read-only report only after merge. The
-  slice is diagnostics-only and does not warrant a bot restart.
+- Branch: `codex/historical-runtime-attribution`, merged with canonical
+  `fc9dad83cd3ecf51cae15e8dda66afb7cfb895a1` at
+  `d351cd2c7f489ff56edaf2679e16aff6a57e5bb6`.
+- PR: #1315.
+- Scope: bounded, read-only local attribution of fill caches and monitor fill
+  history to recorded first-ingestion provenance and non-proving runtime-window
+  candidates.
+- Behavior boundary: offline attribution tool, CLI wiring, docs, and tests only.
+  No trading, exchange, runtime producer, order, risk, config, restart, or
+  process behavior changes.
+- Validation: focused attribution and CLI tests must preserve legacy fills as
+  unattributed, recognize canonical `first_ingested_by_runtime` provenance, and
+  retain bounded, fail-closed scans.
+- Review gate: current-head review is pending on the final integrated branch
+  after its documentation evidence is committed.
+- Expected VPS action: tracked-clean pull plus a bounded read-only attribution
+  smoke after merge. The tool is local-only and does not require a bot restart.
 
 ## Deployed Baseline
 
-- PR #1320 merged as canonical
-  `bc2c90267be418344ec883fcf17fae856bc568cd`. It adds a separate bounded
-  event-pipeline integrity diagnostic for cumulative drops, sink errors, and
-  workers unexpectedly dead outside orderly shutdown, without changing the
-  general smoke or trading/process verdicts.
-- VPS5 fast-forwarded tracked-clean from PR #1314 without a Rust build, bot
-  restart, or process signal. The exact five target PIDs and pane parents were
-  unchanged, target sampling remained 3/3 stable with no extras or issues, and
-  protected `misc:0.0` remained `%8`/PID `434835`.
-- The merged report showed integrity green for all five bots with zero drops,
-  sink errors, unexpectedly dead workers, queue backlog, unfinished work, or
-  degraded pipeline counters. The wider smoke retained natural KuCoin
-  `RequestTimeout` events instead of hiding them; the latest affected cycle
-  subsequently completed successfully without intervention. No direct exchange
-  request, process action, or event was manufactured.
+- PR #1321 deployed as canonical
+  `fc9dad83cd3ecf51cae15e8dda66afb7cfb895a1`. It completes distinct latest
+  shutdown lifecycle diagnostics without changing event producers, trading, or
+  process behavior.
+- VPS5 fast-forwarded tracked-clean at `fc9dad83`; bot PIDs
+  `1044483/1044492/1044486/1044495/1044489` were unchanged, and protected
+  `misc:0.0` remained pane `%8`/PID `434835`.
+- The initial smoke retained four natural KuCoin degraded cycles/timeouts rather
+  than hiding them. The settled two-minute smoke was `ok=true` with
+  `hard_failures=0`, `44/44` account-critical calls and `243/243` remote calls
+  successful, and five configured processes stable.
+- This was diagnostics-only: no Rust build, bot restart, signal, direct exchange
+  call, or event was manufactured.
 
 ## Previous Deployed Baseline (PR #1314)
 

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,22 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1320; Through PR #1319)
+## Latest Canonical Deployment (PR #1321)
+
+- PR #1321 merged as canonical
+  `fc9dad83cd3ecf51cae15e8dda66afb7cfb895a1`. It completes bounded latest
+  shutdown lifecycle diagnostics without changing producers, trading, or
+  process behavior.
+- VPS5 fast-forwarded tracked-clean at that head. Bot PIDs
+  `1044483/1044492/1044486/1044495/1044489` were unchanged, and `misc:0.0`
+  remained pane `%8`/PID `434835`.
+- The initial smoke retained four natural KuCoin degraded cycles/timeouts. The
+  settled two-minute smoke was `ok=true`, `hard_failures=0`, with `44/44`
+  account-critical and `243/243` remote calls successful and five configured
+  processes stable. No Rust build, bot restart, signal, direct exchange call,
+  or event was manufactured.
+
+## Previous Canonical Deployment (PR #1320; Through PR #1319)
 
 - PR #1320 merged as canonical
   `bc2c90267be418344ec883fcf17fae856bc568cd` after exact-head Hermes approval

--- a/src/live/runtime_attribution.py
+++ b/src/live/runtime_attribution.py
@@ -1,0 +1,839 @@
+"""Read-only attribution of local fills to observed Passivbot runtime windows."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Optional, Sequence
+
+
+SCHEMA_VERSION = 1
+DEFAULT_MAX_FILES = 20_000
+DEFAULT_MAX_BYTES_PER_FILE = 256 * 1024 * 1024
+DEFAULT_MAX_TOTAL_BYTES = 2 * 1024 * 1024 * 1024
+DEFAULT_MAX_FILLS = 250_000
+MAX_REPORTED_WARNINGS = 200
+MAX_SOURCES_PER_RECORD = 32
+
+_RUNTIME_KEYS = (
+    "schema_version",
+    "run_id",
+    "started_at_ms",
+    "passivbot_version",
+    "python_git_commit",
+    "python_git_dirty",
+    "config_sha256",
+    "rust_crate_version",
+    "rust_source_sha256",
+    "rust_artifact_sha256",
+)
+_LOG_TS_RE = re.compile(r"^(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)\s+")
+_STARTUP_BANNER_RE = re.compile(
+    r"PASSIVBOT\s+│\s+(?P<exchange>[^:│\s]+):(?P<user>[^│\s]+)\s+│"
+)
+_RUNTIME_LINE_RE = re.compile(
+    r"\[runtime\]\s+run=(?P<run_id>\S+)\s+pb=(?P<version>\S+)\s+"
+    r"python=(?P<python>\S+)\s+config=(?P<config>\S+)\s+"
+    r"rust_source=(?P<rust_source>\S+)\s+rust_artifact=(?P<rust_artifact>\S+)"
+)
+
+
+class AttributionScanLimitError(ValueError):
+    pass
+
+
+@dataclass
+class ScanBudget:
+    max_files: int = DEFAULT_MAX_FILES
+    max_bytes_per_file: int = DEFAULT_MAX_BYTES_PER_FILE
+    max_total_bytes: int = DEFAULT_MAX_TOTAL_BYTES
+    max_fills: int = DEFAULT_MAX_FILLS
+    files_scanned: int = 0
+    bytes_scanned: int = 0
+    fills_scanned: int = 0
+    warnings: list[dict[str, str]] = field(default_factory=list)
+    warnings_suppressed: int = 0
+    _seen: set[Path] = field(default_factory=set)
+
+    def read_bytes(self, path: Path) -> bytes:
+        resolved = path.resolve()
+        if resolved not in self._seen:
+            if self.files_scanned >= self.max_files:
+                raise AttributionScanLimitError(
+                    f"scan exceeds max_files={self.max_files}; narrow the input roots"
+                )
+            self._seen.add(resolved)
+            self.files_scanned += 1
+        size = path.stat().st_size
+        if size > self.max_bytes_per_file:
+            raise AttributionScanLimitError(
+                f"file exceeds max_bytes_per_file={self.max_bytes_per_file}: {path}"
+            )
+        if path.suffix == ".gz":
+            with gzip.open(path, "rb") as handle:
+                data = handle.read(self.max_bytes_per_file + 1)
+        else:
+            data = path.read_bytes()
+        charged_bytes = max(size, len(data))
+        if self.bytes_scanned + charged_bytes > self.max_total_bytes:
+            raise AttributionScanLimitError(
+                f"scan exceeds max_total_bytes={self.max_total_bytes}; narrow the input roots"
+            )
+        self.bytes_scanned += charged_bytes
+        return data
+
+    def warn(self, path: Path, reason: str) -> None:
+        if len(self.warnings) < MAX_REPORTED_WARNINGS:
+            self.warnings.append({"path": str(path), "reason": str(reason)})
+        else:
+            self.warnings_suppressed += 1
+
+    def count_fill(self) -> None:
+        self.fills_scanned += 1
+        if self.fills_scanned > self.max_fills:
+            raise AttributionScanLimitError(
+                f"scan exceeds max_fills={self.max_fills}; narrow the input roots or filters"
+            )
+
+
+def _iter_files(roots: Sequence[Path], predicate) -> Iterable[tuple[Path, Path]]:
+    seen: set[Path] = set()
+    for root in roots:
+        root = Path(root).expanduser()
+        candidates = [root] if root.is_file() else sorted(root.rglob("*")) if root.exists() else []
+        for path in candidates:
+            if not path.is_file() or not predicate(path):
+                continue
+            resolved = path.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            yield root, path
+
+
+def _scope_from_path(root: Path, path: Path) -> tuple[str, str]:
+    try:
+        parts = path.relative_to(root).parts
+    except ValueError:
+        return "", ""
+    if len(parts) >= 3:
+        return str(parts[0]), str(parts[1])
+    if root.parent.parent.name in {"fill_events", "runtime"}:
+        return root.parent.name, root.name
+    if root.parent.name in {"fill_events", "runtime"} and parts:
+        return root.name, str(parts[0])
+    return "", ""
+
+
+def _append_source(record: dict[str, Any], source: dict[str, str]) -> None:
+    sources = record.setdefault("sources", [])
+    if source in sources:
+        return
+    if len(sources) < MAX_SOURCES_PER_RECORD:
+        sources.append(source)
+    else:
+        record["sources_suppressed"] = int(record.get("sources_suppressed") or 0) + 1
+
+
+def _resolve_filtered_scope(
+    exchange: str,
+    user: str,
+    accepted_exchanges: set[str],
+    accepted_users: set[str],
+) -> Optional[tuple[str, str]]:
+    if not exchange and len(accepted_exchanges) == 1:
+        exchange = next(iter(accepted_exchanges))
+    if not user and len(accepted_users) == 1:
+        user = next(iter(accepted_users))
+    if (exchange and not _matches(exchange, accepted_exchanges)) or (
+        user and not _matches(user, accepted_users)
+    ):
+        return None
+    return exchange, user
+
+
+def _safe_json_bytes(path: Path, budget: ScanBudget) -> Any:
+    try:
+        raw = budget.read_bytes(path)
+        if len(raw) > budget.max_bytes_per_file:
+            raise AttributionScanLimitError(
+                f"decompressed file exceeds max_bytes_per_file={budget.max_bytes_per_file}: {path}"
+            )
+        return json.loads(raw.decode("utf-8"))
+    except AttributionScanLimitError:
+        raise
+    except Exception as exc:
+        budget.warn(path, type(exc).__name__)
+        return None
+
+
+def _safe_ndjson(path: Path, budget: ScanBudget) -> Iterable[dict[str, Any]]:
+    try:
+        raw = budget.read_bytes(path)
+        if len(raw) > budget.max_bytes_per_file:
+            raise AttributionScanLimitError(
+                f"decompressed file exceeds max_bytes_per_file={budget.max_bytes_per_file}: {path}"
+            )
+    except AttributionScanLimitError:
+        raise
+    except Exception as exc:
+        budget.warn(path, type(exc).__name__)
+        return
+    for line_number, line in enumerate(raw.decode("utf-8", errors="replace").splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            value = json.loads(line)
+        except Exception:
+            budget.warn(path, f"invalid_json_line:{line_number}")
+            continue
+        if isinstance(value, dict):
+            yield value
+
+
+def _normalize_identity(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    identity = {key: value[key] for key in _RUNTIME_KEYS if key in value}
+    if "run_id" in identity:
+        identity["run_id"] = str(identity["run_id"])
+    if "started_at_ms" in identity:
+        try:
+            identity["started_at_ms"] = int(identity["started_at_ms"])
+        except (TypeError, ValueError):
+            identity.pop("started_at_ms", None)
+    return identity
+
+
+def _runtime_record(
+    identity: Mapping[str, Any],
+    *,
+    exchange: str,
+    user: str,
+    source: str,
+    source_kind: str,
+) -> Optional[dict[str, Any]]:
+    normalized = _normalize_identity(identity)
+    started_at_ms = int(normalized.get("started_at_ms") or 0)
+    if started_at_ms <= 0:
+        return None
+    run_id = str(normalized.get("run_id") or "")
+    if not run_id:
+        digest = hashlib.sha256(
+            f"{exchange}\0{user}\0{started_at_ms}".encode("utf-8")
+        ).hexdigest()[:20]
+        run_id = f"legacy-{digest}"
+        normalized["run_id"] = run_id
+    return {
+        "run_id": run_id,
+        "exchange": str(exchange or ""),
+        "user": str(user or ""),
+        "started_at_ms": started_at_ms,
+        "ended_before_ms": None,
+        "identity": normalized,
+        "sources": [{"kind": source_kind, "path": source}],
+    }
+
+
+def _collect_runtime_manifests(
+    roots: Sequence[Path],
+    budget: ScanBudget,
+    accepted_exchanges: set[str],
+    accepted_users: set[str],
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for root, path in _iter_files(roots, lambda item: item.suffix == ".json"):
+        exchange, user = _scope_from_path(root, path)
+        scope = _resolve_filtered_scope(exchange, user, accepted_exchanges, accepted_users)
+        if scope is None:
+            continue
+        exchange, user = scope
+        value = _safe_json_bytes(path, budget)
+        if not isinstance(value, dict):
+            continue
+        record = _runtime_record(
+            value,
+            exchange=str(value.get("exchange") or exchange),
+            user=str(value.get("user") or user),
+            source=str(path),
+            source_kind="runtime_manifest",
+        )
+        if record is not None:
+            records.append(record)
+    return records
+
+
+def _runtime_from_monitor_record(
+    value: Mapping[str, Any],
+    path: Path,
+    *,
+    fallback_exchange: str = "",
+    fallback_user: str = "",
+) -> Optional[dict[str, Any]]:
+    kind = str(value.get("kind") or "")
+    payload = value.get("payload")
+    payload = payload if isinstance(payload, Mapping) else {}
+    live_event = payload.get("live_event")
+    live_event = live_event if isinstance(live_event, Mapping) else {}
+    data = live_event.get("data")
+    data = data if isinstance(data, Mapping) else {}
+    identity: Any = None
+    if kind == "runtime.started":
+        identity = data
+    elif kind in {"bot.started", "bot.start"}:
+        identity = data.get("runtime") or payload.get("runtime")
+    if not isinstance(identity, Mapping):
+        return None
+    exchange = str(
+        live_event.get("exchange")
+        or value.get("exchange")
+        or payload.get("exchange")
+        or fallback_exchange
+    )
+    user = str(
+        live_event.get("user")
+        or value.get("user")
+        or payload.get("user")
+        or fallback_user
+    )
+    return _runtime_record(
+        identity,
+        exchange=exchange,
+        user=user,
+        source=str(path),
+        source_kind="monitor_event",
+    )
+
+
+def _compact_fill(
+    value: Mapping[str, Any],
+    *,
+    exchange: str,
+    user: str,
+    source: str,
+    source_kind: str,
+) -> Optional[dict[str, Any]]:
+    try:
+        timestamp = int(value.get("timestamp") or value.get("ts") or 0)
+    except (TypeError, ValueError):
+        return None
+    fill_id = str(value.get("id") or "")
+    if timestamp <= 0 or not fill_id:
+        return None
+    provenance = value.get("provenance")
+    provenance = dict(provenance) if isinstance(provenance, Mapping) else {}
+    return {
+        "id": fill_id,
+        "timestamp": timestamp,
+        "exchange": str(exchange or value.get("exchange") or ""),
+        "user": str(user or value.get("user") or ""),
+        "symbol": str(value.get("symbol") or ""),
+        "position_side": str(value.get("position_side") or value.get("pside") or ""),
+        "side": str(value.get("side") or ""),
+        "pb_order_type": str(value.get("pb_order_type") or ""),
+        "client_order_id": str(value.get("client_order_id") or ""),
+        "source_ids": [str(item) for item in (value.get("source_ids") or []) if item],
+        "provenance": provenance,
+        "sources": [{"kind": source_kind, "path": source}],
+    }
+
+
+def _collect_fill_cache(
+    roots: Sequence[Path],
+    budget: ScanBudget,
+    accepted_exchanges: set[str],
+    accepted_users: set[str],
+) -> list[dict[str, Any]]:
+    fills: list[dict[str, Any]] = []
+    for root, path in _iter_files(
+        roots,
+        lambda item: item.suffix == ".json" and item.name != "metadata.json",
+    ):
+        exchange, user = _scope_from_path(root, path)
+        scope = _resolve_filtered_scope(exchange, user, accepted_exchanges, accepted_users)
+        if scope is None:
+            continue
+        exchange, user = scope
+        value = _safe_json_bytes(path, budget)
+        if not isinstance(value, list):
+            continue
+        for item in value:
+            if not isinstance(item, Mapping):
+                continue
+            fill = _compact_fill(
+                item,
+                exchange=exchange,
+                user=user,
+                source=str(path),
+                source_kind="fill_cache",
+            )
+            if fill is not None:
+                budget.count_fill()
+                fills.append(fill)
+    return fills
+
+
+def _collect_monitor(
+    roots: Sequence[Path],
+    budget: ScanBudget,
+    accepted_exchanges: set[str],
+    accepted_users: set[str],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    runtimes: list[dict[str, Any]] = []
+    fills: list[dict[str, Any]] = []
+    for root, path in _iter_files(
+        roots,
+        lambda item: item.name == "manifest.json"
+        or item.name.endswith(".ndjson")
+        or item.name.endswith(".ndjson.gz"),
+    ):
+        exchange, user = _scope_from_path(root, path)
+        scope = _resolve_filtered_scope(exchange, user, accepted_exchanges, accepted_users)
+        if scope is None:
+            continue
+        exchange, user = scope
+        if path.name == "manifest.json":
+            value = _safe_json_bytes(path, budget)
+            if not isinstance(value, Mapping):
+                continue
+            identity = value.get("runtime")
+            record = _runtime_record(
+                identity if isinstance(identity, Mapping) else {},
+                exchange=str(value.get("exchange") or exchange),
+                user=str(value.get("user") or user),
+                source=str(path),
+                source_kind="monitor_manifest",
+            )
+            if record is not None:
+                runtimes.append(record)
+            continue
+        for value in _safe_ndjson(path, budget):
+            runtime = _runtime_from_monitor_record(
+                value,
+                path,
+                fallback_exchange=exchange,
+                fallback_user=user,
+            )
+            if runtime is not None:
+                runtimes.append(runtime)
+            if str(value.get("stream") or "") != "fills" or str(value.get("kind") or "") != "fill":
+                continue
+            payload = value.get("payload")
+            if not isinstance(payload, Mapping):
+                continue
+            fill = _compact_fill(
+                payload,
+                exchange=str(value.get("exchange") or exchange),
+                user=str(value.get("user") or user),
+                source=str(path),
+                source_kind="monitor_fill_history",
+            )
+            if fill is not None:
+                budget.count_fill()
+                fills.append(fill)
+    return runtimes, fills
+
+
+def _parse_log_ts(line: str) -> int:
+    match = _LOG_TS_RE.match(line)
+    if match is None:
+        return 0
+    try:
+        parsed = datetime.strptime(match.group("ts"), "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=timezone.utc
+        )
+    except ValueError:
+        return 0
+    return int(parsed.timestamp() * 1000)
+
+
+def _collect_logs(roots: Sequence[Path], budget: ScanBudget) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for _root, path in _iter_files(
+        roots,
+        lambda item: item.suffix in {".log", ".gz"} or ".log." in item.name,
+    ):
+        try:
+            raw = budget.read_bytes(path)
+            if len(raw) > budget.max_bytes_per_file:
+                raise AttributionScanLimitError(
+                    "decompressed file exceeds "
+                    f"max_bytes_per_file={budget.max_bytes_per_file}: {path}"
+                )
+        except AttributionScanLimitError:
+            raise
+        except Exception as exc:
+            budget.warn(path, type(exc).__name__)
+            continue
+        latest: Optional[dict[str, Any]] = None
+        for line in raw.decode("utf-8", errors="replace").splitlines():
+            timestamp = _parse_log_ts(line)
+            banner = _STARTUP_BANNER_RE.search(line)
+            if banner is not None and timestamp > 0:
+                latest = _runtime_record(
+                    {"started_at_ms": timestamp},
+                    exchange=banner.group("exchange"),
+                    user=banner.group("user"),
+                    source=str(path),
+                    source_kind="legacy_startup_log",
+                )
+                if latest is not None:
+                    records.append(latest)
+                continue
+            runtime_match = _RUNTIME_LINE_RE.search(line)
+            if runtime_match is None or latest is None:
+                continue
+            if timestamp > 0 and timestamp - int(latest["started_at_ms"]) > 60_000:
+                continue
+            dirty_python = runtime_match.group("python")
+            latest["run_id"] = runtime_match.group("run_id")
+            latest["identity"].update(
+                {
+                    "run_id": runtime_match.group("run_id"),
+                    "passivbot_version": runtime_match.group("version"),
+                    "python_git_commit": dirty_python.removesuffix("+dirty"),
+                    "python_git_dirty": dirty_python.endswith("+dirty"),
+                    "config_sha256": runtime_match.group("config"),
+                    "rust_source_sha256": runtime_match.group("rust_source"),
+                    "rust_artifact_sha256": runtime_match.group("rust_artifact"),
+                }
+            )
+            _append_source(latest, {"kind": "runtime_log", "path": str(path)})
+    return records
+
+
+def _merge_runtimes(records: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    ordered = sorted(
+        records,
+        key=lambda item: (
+            str(item.get("exchange") or ""),
+            str(item.get("user") or ""),
+            int(item.get("started_at_ms") or 0),
+            str(item.get("run_id") or ""),
+        ),
+    )
+    merged: list[dict[str, Any]] = []
+    by_run: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for record in ordered:
+        key = (record["exchange"], record["user"], record["run_id"])
+        existing = by_run.get(key)
+        if existing is None:
+            merged.append(record)
+            by_run[key] = record
+            continue
+        existing["started_at_ms"] = min(existing["started_at_ms"], record["started_at_ms"])
+        existing["identity"].update(
+            {key: value for key, value in record["identity"].items() if value not in (None, "")}
+        )
+        for source in record["sources"]:
+            _append_source(existing, source)
+
+    # A legacy banner and a manifest/event within one second describe the same start.
+    for legacy in list(merged):
+        if not str(legacy["run_id"]).startswith("legacy-"):
+            continue
+        candidates = [
+            item
+            for item in merged
+            if item is not legacy
+            and item["exchange"] == legacy["exchange"]
+            and item["user"] == legacy["user"]
+            and abs(item["started_at_ms"] - legacy["started_at_ms"]) <= 1_000
+            and not str(item["run_id"]).startswith("legacy-")
+        ]
+        if len(candidates) == 1:
+            target = candidates[0]
+            for source in legacy["sources"]:
+                _append_source(target, source)
+            merged.remove(legacy)
+
+    # Bounded startup log lines carry hash/run-id prefixes; merge them into the
+    # full manifest/event identity when the scope and start timestamp agree.
+    for partial in list(merged):
+        partial_id = str(partial["run_id"])
+        candidates = [
+            item
+            for item in merged
+            if item is not partial
+            and item["exchange"] == partial["exchange"]
+            and item["user"] == partial["user"]
+            and abs(item["started_at_ms"] - partial["started_at_ms"]) <= 1_000
+            and (
+                str(item["run_id"]).startswith(partial_id)
+                or partial_id.startswith(str(item["run_id"]))
+            )
+            and len(str(item["run_id"])) > len(partial_id)
+        ]
+        if len(candidates) != 1:
+            continue
+        target = candidates[0]
+        for key, value in partial["identity"].items():
+            if key not in target["identity"] or target["identity"][key] in (None, "", "unknown"):
+                target["identity"][key] = value
+        for source in partial["sources"]:
+            _append_source(target, source)
+        merged.remove(partial)
+
+    groups: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for record in merged:
+        groups.setdefault((record["exchange"], record["user"]), []).append(record)
+    for group in groups.values():
+        group.sort(key=lambda item: (item["started_at_ms"], item["run_id"]))
+        starts = sorted({item["started_at_ms"] for item in group})
+        for record in group:
+            next_starts = [start for start in starts if start > record["started_at_ms"]]
+            record["ended_before_ms"] = min(next_starts) if next_starts else None
+            identity = record["identity"]
+            known = sum(
+                1
+                for key in _RUNTIME_KEYS
+                if key in identity and identity[key] not in (None, "", "unknown")
+            )
+            if known <= 2:
+                record["identity_status"] = "legacy_start_only"
+            elif known == len(_RUNTIME_KEYS):
+                record["identity_status"] = "full"
+            else:
+                record["identity_status"] = "partial"
+            record["sources"] = sorted(
+                record["sources"], key=lambda item: (item["kind"], item["path"])
+            )
+    return sorted(
+        merged,
+        key=lambda item: (item["exchange"], item["user"], item["started_at_ms"], item["run_id"]),
+    )
+
+
+def _merge_fills(records: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    merged: dict[tuple[str, str, str, int, str], dict[str, Any]] = {}
+    for record in records:
+        key = (
+            record["exchange"],
+            record["user"],
+            record["id"],
+            record["timestamp"],
+            record["symbol"],
+        )
+        existing = merged.get(key)
+        if existing is None:
+            merged[key] = record
+            continue
+        if record["provenance"] and not existing["provenance"]:
+            existing["provenance"] = record["provenance"]
+        for field in ("position_side", "side", "pb_order_type", "client_order_id"):
+            if not existing[field] and record[field]:
+                existing[field] = record[field]
+        existing["source_ids"] = sorted(set(existing["source_ids"]) | set(record["source_ids"]))
+        for source in record["sources"]:
+            _append_source(existing, source)
+    return sorted(
+        merged.values(),
+        key=lambda item: (item["timestamp"], item["exchange"], item["user"], item["id"]),
+    )
+
+
+def _matches(value: str, accepted: set[str]) -> bool:
+    return not accepted or str(value).lower() in accepted
+
+
+def _attribute_fill(fill: dict[str, Any], runtimes: Sequence[dict[str, Any]]) -> None:
+    provenance = fill.pop("provenance", {})
+    provenance_runtime = provenance.get("runtime") if isinstance(provenance, Mapping) else None
+    provenance_runtime = provenance_runtime if isinstance(provenance_runtime, Mapping) else {}
+    provenance_run_id = str(provenance_runtime.get("run_id") or "")
+    if (
+        isinstance(provenance, Mapping)
+        and provenance.get("attribution") == "first_ingested_by_runtime"
+        and provenance_run_id
+    ):
+        fill["first_ingestion"] = {
+            "status": "recorded",
+            "run_id": provenance_run_id,
+            "first_ingested_at_ms": provenance.get("first_ingested_at_ms"),
+            "runtime_identity": _normalize_identity(provenance_runtime),
+        }
+    else:
+        fill["first_ingestion"] = {
+            "status": "unattributed",
+            "reason": "legacy_or_missing_fill_provenance",
+        }
+
+    candidates = []
+    for runtime in runtimes:
+        if runtime["exchange"] != fill["exchange"] or runtime["user"] != fill["user"]:
+            continue
+        if fill["timestamp"] < runtime["started_at_ms"]:
+            continue
+        ended_before_ms = runtime.get("ended_before_ms")
+        if ended_before_ms is not None and fill["timestamp"] >= ended_before_ms:
+            continue
+        candidates.append(runtime["run_id"])
+    if len(candidates) == 1:
+        status = "single_runtime_window_candidate"
+        reason = "fill_timestamp_within_one_observed_runtime_window"
+    elif candidates:
+        status = "ambiguous_runtime_window"
+        reason = "overlapping_runtime_observations"
+    else:
+        status = "unattributed"
+        reason = "no_observed_runtime_window_at_fill_timestamp"
+    fill["producer_attribution"] = {
+        "status": status,
+        "candidate_run_ids": sorted(candidates),
+        "reason": reason,
+        "proven": False,
+        "caveat": (
+            "Runtime-window correlation does not prove which binary submitted the order; "
+            "use client-order IDs and contemporaneous order/execution logs when available."
+        ),
+    }
+    fill["is_trailing"] = "trailing" in fill["pb_order_type"].lower()
+    fill["sources"] = sorted(fill["sources"], key=lambda item: (item["kind"], item["path"]))
+
+
+def build_runtime_attribution_report(
+    *,
+    fill_roots: Sequence[str | Path] = ("caches/fill_events",),
+    runtime_roots: Sequence[str | Path] = ("caches/runtime",),
+    monitor_roots: Sequence[str | Path] = ("monitor",),
+    log_roots: Sequence[str | Path] = ("logs",),
+    exchanges: Sequence[str] = (),
+    users: Sequence[str] = (),
+    symbols: Sequence[str] = (),
+    since_ms: Optional[int] = None,
+    until_ms: Optional[int] = None,
+    trailing_only: bool = False,
+    max_files: int = DEFAULT_MAX_FILES,
+    max_bytes_per_file: int = DEFAULT_MAX_BYTES_PER_FILE,
+    max_total_bytes: int = DEFAULT_MAX_TOTAL_BYTES,
+    max_fills: int = DEFAULT_MAX_FILLS,
+) -> dict[str, Any]:
+    if max_files <= 0 or max_bytes_per_file <= 0 or max_total_bytes <= 0 or max_fills <= 0:
+        raise ValueError("scan limits must be positive")
+    if since_ms is not None and until_ms is not None and since_ms > until_ms:
+        raise ValueError("since_ms must be less than or equal to until_ms")
+    accepted_exchanges = {str(item).lower() for item in exchanges if str(item)}
+    accepted_users = {str(item).lower() for item in users if str(item)}
+    accepted_symbols = {str(item).lower() for item in symbols if str(item)}
+    budget = ScanBudget(
+        max_files=max_files,
+        max_bytes_per_file=max_bytes_per_file,
+        max_total_bytes=max_total_bytes,
+        max_fills=max_fills,
+    )
+    fill_paths = [Path(item) for item in fill_roots]
+    runtime_paths = [Path(item) for item in runtime_roots]
+    monitor_paths = [Path(item) for item in monitor_roots]
+    log_paths = [Path(item) for item in log_roots]
+
+    runtimes = _collect_runtime_manifests(
+        runtime_paths,
+        budget,
+        accepted_exchanges,
+        accepted_users,
+    )
+    monitor_runtimes, monitor_fills = _collect_monitor(
+        monitor_paths,
+        budget,
+        accepted_exchanges,
+        accepted_users,
+    )
+    runtimes.extend(monitor_runtimes)
+    runtimes.extend(_collect_logs(log_paths, budget))
+    runtimes = _merge_runtimes(runtimes)
+
+    fills = _merge_fills(
+        _collect_fill_cache(
+            fill_paths,
+            budget,
+            accepted_exchanges,
+            accepted_users,
+        )
+        + monitor_fills
+    )
+    filtered_fills: list[dict[str, Any]] = []
+    for fill in fills:
+        if not _matches(fill["exchange"], accepted_exchanges):
+            continue
+        if not _matches(fill["user"], accepted_users):
+            continue
+        if not _matches(fill["symbol"], accepted_symbols):
+            continue
+        if since_ms is not None and fill["timestamp"] < since_ms:
+            continue
+        if until_ms is not None and fill["timestamp"] > until_ms:
+            continue
+        _attribute_fill(fill, runtimes)
+        if trailing_only and not fill["is_trailing"]:
+            continue
+        filtered_fills.append(fill)
+
+    filtered_runtimes = [
+        runtime
+        for runtime in runtimes
+        if _matches(runtime["exchange"], accepted_exchanges)
+        and _matches(runtime["user"], accepted_users)
+    ]
+    first_ingestion_counts: dict[str, int] = {}
+    producer_counts: dict[str, int] = {}
+    trailing_count = 0
+    for fill in filtered_fills:
+        first_status = fill["first_ingestion"]["status"]
+        producer_status = fill["producer_attribution"]["status"]
+        first_ingestion_counts[first_status] = first_ingestion_counts.get(first_status, 0) + 1
+        producer_counts[producer_status] = producer_counts.get(producer_status, 0) + 1
+        trailing_count += int(fill["is_trailing"])
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "contract": {
+            "first_ingestion": (
+                "Recorded provenance identifies the runtime that first persisted a fill locally."
+            ),
+            "producer_attribution": (
+                "Runtime windows are candidates only and never prove which binary "
+                "submitted an order."
+            ),
+        },
+        "inputs": {
+            "fill_roots": [str(item) for item in fill_paths],
+            "runtime_roots": [str(item) for item in runtime_paths],
+            "monitor_roots": [str(item) for item in monitor_paths],
+            "log_roots": [str(item) for item in log_paths],
+            "filters": {
+                "exchanges": sorted(accepted_exchanges),
+                "users": sorted(accepted_users),
+                "symbols": sorted(accepted_symbols),
+                "since_ms": since_ms,
+                "until_ms": until_ms,
+                "trailing_only": bool(trailing_only),
+            },
+            "limits": {
+                "max_files": max_files,
+                "max_fills": max_fills,
+                "max_bytes_per_file": max_bytes_per_file,
+                "max_total_bytes": max_total_bytes,
+            },
+        },
+        "scan": {
+            "files_scanned": budget.files_scanned,
+            "bytes_scanned": budget.bytes_scanned,
+            "fills_scanned": budget.fills_scanned,
+            "warnings": budget.warnings,
+            "warnings_suppressed": budget.warnings_suppressed,
+        },
+        "summary": {
+            "runtime_count": len(filtered_runtimes),
+            "fill_count": len(filtered_fills),
+            "trailing_fill_count": trailing_count,
+            "first_ingestion_status_counts": first_ingestion_counts,
+            "producer_attribution_status_counts": producer_counts,
+        },
+        "runtimes": filtered_runtimes,
+        "fills": filtered_fills,
+    }

--- a/src/passivbot_cli/main.py
+++ b/src/passivbot_cli/main.py
@@ -112,6 +112,10 @@ TOOL_COMMANDS: dict[str, CommandSpec] = {
         "tools.log_secret_inventory",
         "read-only value-free inventory of secret-like local log material",
     ),
+    "runtime-attribution": CommandSpec(
+        "tools.runtime_attribution",
+        "attribute local fills to recorded ingestion and candidate runtime windows",
+    ),
     "live-incident-bundle": CommandSpec(
         "tools.live_incident_bundle",
         "collect local live incident evidence into a tarball",

--- a/src/tools/runtime_attribution.py
+++ b/src/tools/runtime_attribution.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SRC_ROOT = Path(__file__).resolve().parents[1]
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from live.runtime_attribution import (  # noqa: E402
+    AttributionScanLimitError,
+    DEFAULT_MAX_BYTES_PER_FILE,
+    DEFAULT_MAX_FILES,
+    DEFAULT_MAX_FILLS,
+    DEFAULT_MAX_TOTAL_BYTES,
+    build_runtime_attribution_report,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="passivbot tool runtime-attribution",
+        description=(
+            "Build a read-only local report linking fills to recorded first-ingestion "
+            "identity and candidate runtime windows."
+        ),
+    )
+    parser.add_argument("--fill-root", action="append", default=None)
+    parser.add_argument("--runtime-root", action="append", default=None)
+    parser.add_argument("--monitor-root", action="append", default=None)
+    parser.add_argument("--log-root", action="append", default=None)
+    parser.add_argument("--exchange", action="append", default=[])
+    parser.add_argument("--user", action="append", default=[])
+    parser.add_argument("--symbol", action="append", default=[])
+    parser.add_argument("--since-ms", type=int)
+    parser.add_argument("--until-ms", type=int)
+    parser.add_argument(
+        "--trailing-only",
+        action="store_true",
+        help="Return only fills whose Passivbot order type is trailing.",
+    )
+    parser.add_argument("--max-files", type=int, default=DEFAULT_MAX_FILES)
+    parser.add_argument("--max-fills", type=int, default=DEFAULT_MAX_FILLS)
+    parser.add_argument("--max-total-bytes", type=int, default=DEFAULT_MAX_TOTAL_BYTES)
+    parser.add_argument(
+        "--max-bytes-per-file",
+        type=int,
+        default=DEFAULT_MAX_BYTES_PER_FILE,
+    )
+    parser.add_argument(
+        "--fail-on-unattributed",
+        action="store_true",
+        help="Exit 1 when any selected fill lacks recorded first-ingestion provenance.",
+    )
+    parser.add_argument("--compact", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        report = build_runtime_attribution_report(
+            fill_roots=args.fill_root or ("caches/fill_events",),
+            runtime_roots=args.runtime_root or ("caches/runtime",),
+            monitor_roots=args.monitor_root or ("monitor",),
+            log_roots=args.log_root or ("logs",),
+            exchanges=args.exchange,
+            users=args.user,
+            symbols=args.symbol,
+            since_ms=args.since_ms,
+            until_ms=args.until_ms,
+            trailing_only=args.trailing_only,
+            max_files=args.max_files,
+            max_bytes_per_file=args.max_bytes_per_file,
+            max_total_bytes=args.max_total_bytes,
+            max_fills=args.max_fills,
+        )
+    except (AttributionScanLimitError, ValueError) as exc:
+        print(f"passivbot tool runtime-attribution: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(report, indent=None if args.compact else 2, sort_keys=True))
+    if args.fail_on_unattributed:
+        unattributed = report["summary"]["first_ingestion_status_counts"].get(
+            "unattributed", 0
+        )
+        if unattributed:
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_passivbot_cli.py
+++ b/tests/test_passivbot_cli.py
@@ -147,6 +147,7 @@ def test_tool_help_lists_supported_tools(capsys):
     assert "inspect-ohlcvs" in out
     assert "live-event-query" in out
     assert "log-secret-inventory" in out
+    assert "runtime-attribution" in out
     assert "merge-paretos" in out
     assert "monitor-dev" in out
     assert "monitor-relay" in out
@@ -324,6 +325,25 @@ def test_live_event_query_tool_dispatch_forwards_module_and_prog(monkeypatch):
         "cy_1",
     ]
     assert captured["prog_env"] == "passivbot tool live-event-query"
+
+
+def test_runtime_attribution_tool_dispatch_forwards_module_and_prog(monkeypatch):
+    captured = {}
+
+    def fake_invoke_module_main(module_name):
+        captured["module_name"] = module_name
+        captured["argv"] = sys.argv[:]
+        captured["prog_env"] = os.environ.get("PASSIVBOT_CLI_PROG")
+        return True, 0
+
+    monkeypatch.setattr(cli_main, "_invoke_module_main", fake_invoke_module_main)
+
+    assert cli_main.main(["tool", "runtime-attribution", "--trailing-only"]) == 0
+    assert captured == {
+        "module_name": "tools.runtime_attribution",
+        "argv": ["passivbot tool runtime-attribution", "--trailing-only"],
+        "prog_env": "passivbot tool runtime-attribution",
+    }
 
 
 def test_live_smoke_report_tool_dispatch_forwards_module_and_prog(monkeypatch):

--- a/tests/test_runtime_attribution.py
+++ b/tests/test_runtime_attribution.py
@@ -1,0 +1,270 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from live.runtime_attribution import (
+    AttributionScanLimitError,
+    build_runtime_attribution_report,
+)
+from tools import runtime_attribution as runtime_attribution_tool
+
+
+def _identity(run_id: str, started_at_ms: int, marker: str) -> dict:
+    return {
+        "schema_version": 1,
+        "run_id": run_id,
+        "started_at_ms": started_at_ms,
+        "passivbot_version": "8.0.0",
+        "python_git_commit": marker * 40,
+        "python_git_dirty": False,
+        "config_sha256": marker * 64,
+        "rust_crate_version": "0.1.0",
+        "rust_source_sha256": marker * 64,
+        "rust_artifact_sha256": marker * 64,
+    }
+
+
+def _write_json(path: Path, value) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+def _roots(tmp_path: Path) -> dict:
+    return {
+        "fill_roots": [tmp_path / "fills"],
+        "runtime_roots": [tmp_path / "runtime"],
+        "monitor_roots": [tmp_path / "monitor"],
+        "log_roots": [tmp_path / "logs"],
+    }
+
+
+def test_report_separates_recorded_ingestion_from_producer_candidate(tmp_path: Path):
+    roots = _roots(tmp_path)
+    run_1 = _identity("run-1", 1_000, "a")
+    run_2 = _identity("run-2", 2_000, "b")
+    _write_json(tmp_path / "runtime" / "bybit" / "alice" / "run-1.json", run_1)
+    _write_json(tmp_path / "runtime" / "bybit" / "alice" / "run-2.json", run_2)
+    _write_json(
+        tmp_path / "fills" / "bybit" / "alice" / "1970-01-01.json",
+        [
+            {
+                "id": "legacy-trailing",
+                "timestamp": 1_500,
+                "symbol": "BTC/USDT:USDT",
+                "position_side": "long",
+                "side": "buy",
+                "pb_order_type": "entry_trailing_normal_long",
+                "client_order_id": "cid-1",
+            },
+            {
+                "id": "recorded-grid",
+                "timestamp": 2_500,
+                "symbol": "ETH/USDT:USDT",
+                "position_side": "short",
+                "side": "sell",
+                "pb_order_type": "entry_grid_normal_short",
+                "client_order_id": "cid-2",
+                "provenance": {
+                    "schema_version": 1,
+                    "attribution": "first_ingested_by_runtime",
+                    "first_ingested_at_ms": 3_000,
+                    "runtime": run_2,
+                },
+            },
+        ],
+    )
+
+    report = build_runtime_attribution_report(**roots)
+
+    assert report["summary"]["runtime_count"] == 2
+    assert report["summary"]["fill_count"] == 2
+    legacy, recorded = report["fills"]
+    assert legacy["is_trailing"] is True
+    assert legacy["first_ingestion"]["status"] == "unattributed"
+    assert legacy["producer_attribution"] == {
+        "status": "single_runtime_window_candidate",
+        "candidate_run_ids": ["run-1"],
+        "reason": "fill_timestamp_within_one_observed_runtime_window",
+        "proven": False,
+        "caveat": (
+            "Runtime-window correlation does not prove which binary submitted the order; "
+            "use client-order IDs and contemporaneous order/execution logs when available."
+        ),
+    }
+    assert recorded["first_ingestion"]["status"] == "recorded"
+    assert recorded["first_ingestion"]["run_id"] == "run-2"
+    assert recorded["producer_attribution"]["candidate_run_ids"] == ["run-2"]
+
+
+def test_trailing_filter_and_monitor_fill_deduplication(tmp_path: Path):
+    roots = _roots(tmp_path)
+    fill = {
+        "id": "fill-1",
+        "timestamp": 1_500,
+        "symbol": "BTC/USDT:USDT",
+        "position_side": "long",
+        "side": "buy",
+        "pb_order_type": "entry_trailing_normal_long",
+        "client_order_id": "cid-1",
+    }
+    _write_json(tmp_path / "fills" / "bybit" / "alice" / "day.json", [fill])
+    monitor_path = tmp_path / "monitor" / "bybit" / "alice" / "history" / "fills.ndjson"
+    monitor_path.parent.mkdir(parents=True)
+    monitor_path.write_text(
+        json.dumps(
+            {
+                "ts": 1_500,
+                "kind": "fill",
+                "stream": "fills",
+                "exchange": "bybit",
+                "user": "alice",
+                "payload": fill,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = build_runtime_attribution_report(**roots, trailing_only=True)
+
+    assert report["summary"]["fill_count"] == 1
+    assert report["summary"]["trailing_fill_count"] == 1
+    assert {source["kind"] for source in report["fills"][0]["sources"]} == {
+        "fill_cache",
+        "monitor_fill_history",
+    }
+
+
+def test_runtime_log_prefix_merges_with_full_manifest_identity(tmp_path: Path):
+    roots = _roots(tmp_path)
+    identity = _identity("1234567890abcdef", 1_000, "c")
+    _write_json(tmp_path / "runtime" / "bybit" / "alice" / "run.json", identity)
+    log_path = tmp_path / "logs" / "alice.log"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text(
+        "1970-01-01T00:00:01Z INFO     ║  PASSIVBOT  │  bybit:alice  │  now  ║\n"
+        "1970-01-01T00:00:01Z INFO     [runtime] run=1234567890ab pb=8.0.0 "
+        "python=cccccccccccc config=cccccccccccc rust_source=cccccccccccc "
+        "rust_artifact=cccccccccccc\n",
+        encoding="utf-8",
+    )
+
+    report = build_runtime_attribution_report(**roots)
+
+    assert report["summary"]["runtime_count"] == 1
+    runtime = report["runtimes"][0]
+    assert runtime["run_id"] == identity["run_id"]
+    assert {source["kind"] for source in runtime["sources"]} == {
+        "runtime_log",
+        "runtime_manifest",
+        "legacy_startup_log",
+    }
+
+
+def test_monitor_runtime_event_is_accepted_without_runtime_manifest(tmp_path: Path):
+    roots = _roots(tmp_path)
+    identity = _identity("run-monitor", 4_000, "d")
+    path = tmp_path / "monitor" / "bybit" / "alice" / "events" / "current.ndjson"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "kind": "runtime.started",
+                "payload": {
+                    "live_event": {
+                        "exchange": "bybit",
+                        "user": "alice",
+                        "data": identity,
+                    }
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = build_runtime_attribution_report(**roots)
+
+    assert report["runtimes"][0]["run_id"] == "run-monitor"
+    assert report["runtimes"][0]["sources"][0]["kind"] == "monitor_event"
+
+
+def test_scan_limits_fail_closed(tmp_path: Path):
+    roots = _roots(tmp_path)
+    _write_json(tmp_path / "fills" / "bybit" / "alice" / "day.json", [{"x": "y" * 100}])
+    with pytest.raises(AttributionScanLimitError, match="max_bytes_per_file"):
+        build_runtime_attribution_report(**roots, max_bytes_per_file=10)
+
+
+def test_fill_limit_fails_closed_before_unbounded_report(tmp_path: Path):
+    roots = _roots(tmp_path)
+    _write_json(
+        tmp_path / "fills" / "bybit" / "alice" / "day.json",
+        [
+            {"id": "fill-1", "timestamp": 1_000},
+            {"id": "fill-2", "timestamp": 2_000},
+        ],
+    )
+    with pytest.raises(AttributionScanLimitError, match="max_fills=1"):
+        build_runtime_attribution_report(**roots, max_fills=1)
+
+
+def test_total_byte_limit_fails_closed(tmp_path: Path):
+    roots = _roots(tmp_path)
+    _write_json(
+        tmp_path / "fills" / "bybit" / "alice" / "day.json",
+        [{"id": "fill-1", "timestamp": 1_000}],
+    )
+    with pytest.raises(AttributionScanLimitError, match="max_total_bytes=10"):
+        build_runtime_attribution_report(
+            **roots,
+            max_bytes_per_file=1_000,
+            max_total_bytes=10,
+        )
+
+
+def test_account_specific_fill_root_uses_singleton_scope_filters(tmp_path: Path):
+    account_root = tmp_path / "account-cache"
+    _write_json(
+        account_root / "day.json",
+        [{"id": "fill-1", "timestamp": 1_000, "symbol": "BTC/USDT:USDT"}],
+    )
+    report = build_runtime_attribution_report(
+        fill_roots=[account_root],
+        runtime_roots=[],
+        monitor_roots=[],
+        log_roots=[],
+        exchanges=["bybit"],
+        users=["alice"],
+    )
+    assert report["fills"][0]["exchange"] == "bybit"
+    assert report["fills"][0]["user"] == "alice"
+
+
+def test_cli_fail_on_unattributed_returns_one(tmp_path: Path, capsys):
+    fill_root = tmp_path / "fills"
+    _write_json(
+        fill_root / "bybit" / "alice" / "day.json",
+        [{"id": "legacy", "timestamp": 1_500, "symbol": "BTC/USDT:USDT"}],
+    )
+    empty = tmp_path / "empty"
+    assert (
+        runtime_attribution_tool.main(
+            [
+                "--fill-root",
+                str(fill_root),
+                "--runtime-root",
+                str(empty),
+                "--monitor-root",
+                str(empty),
+                "--log-root",
+                str(empty),
+                "--fail-on-unattributed",
+                "--compact",
+            ]
+        )
+        == 1
+    )
+    report = json.loads(capsys.readouterr().out)
+    assert report["summary"]["first_ingestion_status_counts"] == {"unattributed": 1}


### PR DESCRIPTION
## Summary

- add a bounded, read-only runtime-attribution tool that scans local fill caches, monitor fill history, immutable runtime manifests, structured startup events, and bounded text startup logs
- keep recorded first-ingestion provenance separate from non-proving producer runtime-window candidates
- deduplicate fill evidence across cache and monitor history, retain bounded source paths, and highlight trailing order types
- support exchange, user, symbol, timestamp, and trailing-only filters plus fail-closed file, fill, per-file byte, total-byte, and warning limits
- integrate canonical master through PR #1321 and record its VPS5 deployment evidence

## Scope And Boundaries

- Scope category: `read-only tooling`.
- Touched surfaces: offline attribution report, CLI wiring, tests, feature docs, changelog, and logging-overhaul state/evidence.
- No live producer, exchange request, trading, planning, order, risk, configuration, restart, process-control, or Rust behavior changes.
- Expected VPS action after merge: tracked-clean pull plus one bounded read-only attribution smoke. No bot restart or signal.

## Attribution Contract

A recorded first-ingestion runtime proves only which runtime first persisted the fill locally. Runtime-window correlation never claims which binary submitted an order; every producer candidate remains `proven=false` and points operators to client-order IDs and contemporaneous execution logs. Legacy fills remain unattributed.

The integrated reader matches the canonical PR #1314 runtime identity and `first_ingested_by_runtime` fill-provenance schemas. PR #1320 and PR #1321 integration added no attribution behavior delta.

## Validation

Exact head: `11e54ba43c1203a5ccd3e24a0e9f4187b04080ad`.

- full Python suite: passed
- focused attribution, CLI, AI-doc, runtime-identity, and fill-provenance suites: 214 passed
- Rust: 210 tests passed; `cargo check --tests` passed
- exact Rust extension rebuilt and verified: source stamp/fingerprint `94586772c5506bd83f83e41d0d2c273d8f19d8ee432c336fd17b477f08519a5f`
- empty-root end-to-end CLI smoke: passed with zero files/fills/runtimes and no warnings
- a deliberately over-broad local scan failed closed at the explicit 512 MiB cap; the narrowed account/log-root scan completed with one runtime, zero fills, and no warnings
- `py_compile`, generated event registry check, AI-doc check, and `git diff --check`: passed; AI-doc check retained only the existing aggregate word-count warning

## PR #1321 Deployment Evidence

- VPS5 fast-forwarded tracked-clean to `fc9dad83cd3ecf51cae15e8dda66afb7cfb895a1` without a Rust build, bot restart, or process signal.
- Bot PIDs `1044483/1044492/1044486/1044495/1044489` remained unchanged; protected `misc:0.0` remained pane `%8`, PID `434835`.
- The initial smoke retained four natural KuCoin degraded cycles/timeouts rather than hiding them.
- The settled two-minute smoke was `ok=true`, `hard_failures=0`, with `44/44` account-critical calls and `243/243` remote calls successful and all five configured processes stable.
- No direct exchange request or event was manufactured.

## Reviewer Focus

- attribution claims must remain weaker than exchange-side order authorship
- malformed or oversized local artifacts must remain bounded and fail closed
- source-path and warning output must remain bounded and must not expose artifact contents
- integration with canonical runtime identity/provenance must not retroactively attribute legacy fills

Residual risk: attribution depends on retained manifests, fill caches, monitor events, startup logs, and timestamp quality. It improves reconstruction but cannot prove exchange-side order authorship for legacy or incomplete evidence.