### PR TITLE
Add Binance balance composition diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Binance `balance.changed` composition diagnostics now normalize only CCXT's
+  documented unified `total`, `free`, `used`, and explicit `debt` maps from the
+  already-fetched balance response. The bounded rows add no exchange calls,
+  valuation inference, scalar-balance changes, planning, order, or risk
+  behavior; raw connector payloads remain excluded.
+
 - `balance.changed` now carries a bounded optional asset-composition diagnostic
   from the same authoritative balance response. The first connector parser is
   OKX: it reports only documented account-detail amount, USD value, unrealized

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -20,11 +20,11 @@ orders, risk, readiness, or execution scheduling.
 The object contains a stable `status` (`available`, `unavailable`, or
 `malformed`), bounded source/reason classification, `count`, `retained`,
 `truncated`, and at most eight deterministic `asset_balances` rows. Rows retain
-only connector-proven asset, amount, USD value, unrealized PnL, explicit
-liability, collateral-enabled state, and bounded field provenance. Missing or
-non-finite values are absent; a connector must not infer debt, price, or a
-neutral zero. Raw account payloads, arbitrary response keys, addresses,
-credentials, and internal composition signatures are never emitted.
+only connector-proven asset, total/free/used amount, USD value, unrealized PnL,
+explicit liability, collateral-enabled state, and bounded field provenance.
+Missing or non-finite values are absent; a connector must not infer debt,
+price, or a neutral zero. Raw account payloads, arbitrary response keys,
+addresses, credentials, and internal composition signatures are never emitted.
 Any legacy raw-only balance apply replaces a previous composition with an
 explicit unavailable state; it must never pair stale asset rows with a fresh
 aggregate balance.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,21 +22,21 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/balance-composition-observability`, based on canonical
-  `32156cbc251d666902f20b8b000a9a1dfe05a0a2` after PR #1311.
-- PR: #1313.
-- Scope: first connector-specific implementation of backlog item 20. Carry a
-  bounded normalized balance-composition diagnostic through staged refresh and
-  attach it to `balance.changed`; parse only already-fetched OKX
-  `info.data[0].details` fields, while generic, Binance, and Hyperliquid paths
-  carry an explicit unavailable state until their parsers exist.
+- Branch: `codex/binance-balance-composition`, based on canonical
+  `a0db60f9ca97dbc5b9b37aa3230fce97eb0917ce` after PR #1313.
+- PR: pending.
+- Scope: second connector-specific implementation of backlog item 20. Parse
+  only Binance's already-fetched CCXT unified `total`, `free`, `used`, and
+  explicit `debt` maps into the existing bounded balance-composition contract.
+  OKX remains on its connector-specific parser; generic and Hyperliquid paths
+  remain explicitly unavailable until separately proven.
 - Behavior boundary: no new exchange/ticker/API calls and no change to scalar
   balance calculation, refresh cadence, planning, execution scheduling,
-  orders, risk, or console materiality. Composition-only changes are durable
-  but remain off the console.
-- Validation: focused parser, raw-leakage, truncation/signature, staged-carry,
-  composition-only emission, duplicate suppression, legacy-call, and console
-  bounds regressions, plus targeted existing balance/event tests.
+  orders, risk, valuation, or console materiality. Composition-only changes
+  remain durable and off the console.
+- Validation: focused unified-map, explicit-debt, missing/non-finite,
+  raw-leakage, public-provenance, Binance-hook, staged-carry, balance-state,
+  and event-pipeline regressions.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
 - Expected VPS action: this behavior-changing diagnostic slice requires a
@@ -45,21 +45,40 @@ Estimated completion:
 
 ## Deployed Baseline
 
-- PR #1311 merged as canonical `32156cbc251d666902f20b8b000a9a1dfe05a0a2`.
-  It carries bounded hard-only problem evidence into smoke summary, brief, and
-  incident-bundle metadata without changing runtime event production or
-  trading behavior.
-- VPS5 prepared the exact clean merge without a Rust rebuild or bot restart.
-  The immediate bounded smoke retained one natural KuCoin positions timeout in
-  `hard_problem_events`; a settled five-minute smoke was hard-green with an
-  empty hard sample. A bounded incident bundle for the natural timeout carried
-  the same hard-only count, retention, truncation, and sanitized sample in its
-  command result and archived manifest. All five configured bot panes and
-  `misc:0.0` remained unchanged throughout.
+- PR #1313 merged as canonical `a0db60f9ca97dbc5b9b37aa3230fce97eb0917ce`.
+  It adds the bounded OKX-first balance-composition diagnostic and preserves
+  scalar balance, exchange-call, planning, order, risk, and console-admission
+  behavior.
+- VPS5 fast-forwarded cleanly from `32156cbc`. The first guarded preparation
+  failed closed after the repository move because the caller supplied a Rust
+  fingerprint from a different local untracked `Cargo.lock`; no bot was
+  signalled. A same-head target-derived proof then passed with no Rust rebuild
+  and exact source/stamp/runtime-artifact agreement.
+- The authorized exact-pane executor gracefully stopped, exited, relaunched,
+  and verified only `%358/%359/%360/%361/%362`; old bot PIDs
+  `1036076/1036085/1036080/1036088/1036082` became
+  `1038760/1038769/1038763/1038772/1038766` with no force signal. The exact
+  lifecycle window `1784401342000..1784402056447` selected 6/1,011 managed
+  segments totaling `39263703` bytes, retained all five stopping/stopped/startup
+  cohorts, and returned zero hard, monitor, text-log, repository, or target
+  failures. A wider pre-action window correctly retained one earlier natural
+  KuCoin `RequestTimeout` instead of hiding it.
+- A natural post-restart OKX `balance.changed` event carried two bounded
+  connector-proven asset rows with no raw payload. Final targets remained 3/3
+  stable and exact, the checkout remained tracked-clean, and protected
+  `misc:0.0` stayed `%8`/PID `434835`. No direct exchange request or event was
+  manufactured.
 - The merge is the exact base for this slice.
 
 ## Previous Deployed Baseline
 
+- PR #1311 merged as canonical `32156cbc251d666902f20b8b000a9a1dfe05a0a2`.
+  It carries bounded hard-only problem evidence into smoke summary, brief, and
+  incident-bundle metadata without changing runtime event production or
+  trading behavior. VPS5 prepared the exact clean merge without a Rust rebuild
+  or bot restart; one immediate natural KuCoin positions timeout was retained,
+  the settled smoke was hard-green, and all five bot panes plus `misc:0.0`
+  remained unchanged.
 - PR #1310 merged as canonical `5d06887b78c2790efd15e1bd67bae6b3f5d96636`.
   It added full-report `hard_problem_events` with authoritative `count`,
   bounded chronological `sample`, and explicit `retained`/`truncated` counts;

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/binance-balance-composition`, based on canonical
   `a0db60f9ca97dbc5b9b37aa3230fce97eb0917ce` after PR #1313.
-- PR: pending.
+- PR: #1316.
 - Scope: second connector-specific implementation of backlog item 20. Parse
   only Binance's already-fetched CCXT unified `total`, `free`, `used`, and
   explicit `debt` maps into the existing bounded balance-composition contract.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,30 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1311)
+## Latest Canonical Deployment (PR #1313)
+
+- PR #1313 merged as canonical `a0db60f9ca97dbc5b9b37aa3230fce97eb0917ce`.
+  It adds bounded OKX asset composition to `balance.changed` without changing
+  scalar balance, exchange calls, planning, orders, risk, or console admission.
+- VPS5 fast-forwarded cleanly from `32156cbc`. A wrong caller-side Rust
+  fingerprint failed closed after the repository move and before any bot
+  signal; the same-head target-derived proof then passed without a Rust build
+  and matched the loaded extension stamp and artifact.
+- The guarded executor gracefully restarted only the five exact configured
+  panes without force. The exact `1784401342000..1784402056447` lifecycle
+  window selected 6/1,011 managed segments totaling `39263703` bytes, recovered
+  all five stopping/stopped/startup cohorts, and was hard-green across target,
+  repository, monitor, and text-log gates. A broader pre-action window retained
+  one earlier natural KuCoin `RequestTimeout`, correctly separating it from the
+  restart lifecycle rather than suppressing it.
+- Final targets were 3/3 stable with new exact bot PIDs
+  `1038760/1038769/1038763/1038772/1038766`; pane parents and protected
+  `misc:0.0` `%8`/PID `434835` were unchanged. Natural post-restart OKX balance
+  events carried the bounded two-asset composition. No direct exchange request
+  or event was manufactured.
+- The exact merge is the base for the Binance CCXT unified composition slice.
+
+## Previous Canonical Deployment (PR #1311)
 
 - PR #1311 merged as canonical `32156cbc251d666902f20b8b000a9a1dfe05a0a2`.
   It carries bounded hard-only problem-event evidence into concise smoke,

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -1081,13 +1081,13 @@ Related detailed plans:
     the live default branch before the cutover can be considered complete.
 
 20. [ ] Per-asset collateral, debt, and valuation balance events.
-    Status: partial, OKX-first. The first connector-specific slice normalizes
-    only OKX's already-fetched `info.data[0].details` into bounded deterministic
-    asset rows and carries an explicit unavailable/malformed diagnostic state
-    for generic, Binance, and Hyperliquid staged paths. It does not add exchange
-    calls or change scalar balance, planning, orders, risk, or console
-    materiality. Other connector parsers and any broader asset contract remain
-    open. A 2026-07-14 evaluation confirmed that the existing
+    Status: partial, OKX plus Binance. Connector-specific slices normalize
+    OKX's already-fetched `info.data[0].details` and Binance's already-fetched
+    CCXT unified balance maps into bounded deterministic asset rows. Generic
+    and Hyperliquid staged paths remain explicitly unavailable. Neither slice
+    adds exchange calls or changes scalar balance, planning, orders, risk, or
+    console materiality. Other connector parsers and any broader asset contract
+    remain open. A 2026-07-14 evaluation confirmed that the existing
     `balance.changed` event and console projection expose only aggregate raw
     balance, hysteresis-snapped balance, equity, deltas, and source. The
     authoritative refresh already receives the exact raw balance response
@@ -1147,6 +1147,10 @@ Related detailed plans:
     for unsupported or malformed breakdowns.
 
     Work log:
+    - 2026-07-18: Binance follow-up normalized only CCXT's documented unified
+      `total`, `free`, `used`, and explicit `debt` maps from the same fetched
+      response. It excludes raw `info`, arbitrary fields, non-finite values,
+      and valuation inference while reusing existing bounds and signatures.
     - 2026-07-18: OKX-first slice added bounded rows for `ccy`, `cashBal`,
       `eqUsd`, `upl`, `collateralEnabled`, and explicit `liab`, with per-field
       provenance, deterministic truncation, an omitted-row-sensitive internal

--- a/src/exchanges/binance.py
+++ b/src/exchanges/binance.py
@@ -1,5 +1,8 @@
 from exchanges.ccxt_bot import CCXTBot, format_exchange_config_response
-from live.balance_composition import malformed_balance_composition
+from live.balance_composition import (
+    malformed_balance_composition,
+    normalize_ccxt_balance_composition,
+)
 from passivbot import logging
 from passivbot_exceptions import FatalBotException
 
@@ -269,6 +272,10 @@ class BinanceBot(CCXTBot):
                     task.cancel()
             await asyncio.gather(*tasks.values(), return_exceptions=True)
             raise
+
+    def _normalize_balance_diagnostics(self, fetched: object) -> dict:
+        """Expose only CCXT's bounded unified Binance balance maps."""
+        return normalize_ccxt_balance_composition(fetched)
 
     async def _fetch_open_orders_for_staged_symbols(self, symbols: set[str]) -> list:
         scoped = await self._do_fetch_open_orders_for_symbols(symbols)

--- a/src/live/balance_composition.py
+++ b/src/live/balance_composition.py
@@ -156,6 +156,67 @@ def normalize_okx_balance_composition(fetched: Any) -> dict[str, Any]:
     )
 
 
+def normalize_ccxt_balance_composition(fetched: Any) -> dict[str, Any]:
+    """Normalize only CCXT's documented unified per-currency balance maps."""
+    source = "ccxt.unified_balance"
+    if not isinstance(fetched, Mapping):
+        return malformed_balance_composition(source=source, reason="invalid_payload")
+    total = fetched.get("total")
+    if not isinstance(total, Mapping):
+        return malformed_balance_composition(source=source, reason="missing_total")
+
+    balance_maps = {
+        field: value
+        for field, key in (
+            ("amount", "total"),
+            ("free_amount", "free"),
+            ("used_amount", "used"),
+            ("liability", "debt"),
+        )
+        if isinstance((value := fetched.get(key)), Mapping)
+    }
+    rows_by_asset: dict[str, dict[str, Any]] = {}
+    seen_fields: set[tuple[str, str]] = set()
+    invalid_row_count = 0
+    for field, balance_map in balance_maps.items():
+        provenance = {
+            "amount": "total",
+            "free_amount": "free",
+            "used_amount": "used",
+            "liability": "debt",
+        }[field]
+        for raw_asset, raw_value in balance_map.items():
+            asset = _asset_name(raw_asset)
+            if asset is None:
+                invalid_row_count += 1
+                continue
+            row = rows_by_asset.setdefault(
+                asset,
+                {
+                    "asset": asset,
+                    "field_provenance": {"asset": "currency_map_key"},
+                },
+            )
+            field_key = (field, asset)
+            if field_key in seen_fields:
+                invalid_row_count += 1
+                row.pop(field, None)
+                row["field_provenance"].pop(field, None)
+                continue
+            seen_fields.add(field_key)
+            value = _finite_number(raw_value)
+            if value is not None:
+                row[field] = value
+                row["field_provenance"][field] = provenance
+
+    return _finalize_snapshot(
+        status="available",
+        source=source,
+        assets=list(rows_by_asset.values()),
+        invalid_row_count=invalid_row_count,
+    )
+
+
 def public_balance_composition(value: Any) -> dict[str, Any] | None:
     """Copy only the bounded event contract; never publish an internal signature."""
     if not isinstance(value, Mapping):
@@ -168,7 +229,13 @@ def public_balance_composition(value: Any) -> dict[str, Any] | None:
     truncated = value.get("truncated")
     if (
         status not in {"available", "unavailable", "malformed"}
-        or source not in {"unsupported", "normalizer", "okx.info.data[0].details"}
+        or source
+        not in {
+            "unsupported",
+            "normalizer",
+            "ccxt.unified_balance",
+            "okx.info.data[0].details",
+        }
         or not isinstance(assets, list)
         or not all(isinstance(item, int) and item >= 0 for item in (count, retained, truncated))
     ):
@@ -181,7 +248,14 @@ def public_balance_composition(value: Any) -> dict[str, Any] | None:
         if asset is None:
             return None
         row: dict[str, Any] = {"asset": asset}
-        for key in ("amount", "usd_value", "unrealized_pnl", "liability"):
+        for key in (
+            "amount",
+            "free_amount",
+            "used_amount",
+            "usd_value",
+            "unrealized_pnl",
+            "liability",
+        ):
             number = _finite_number(item.get(key))
             if number is not None:
                 row[key] = number
@@ -190,17 +264,24 @@ def public_balance_composition(value: Any) -> dict[str, Any] | None:
         provenance = item.get("field_provenance")
         if isinstance(provenance, Mapping):
             allowed_sources = {
-                "asset": "ccy",
-                "amount": "cashBal",
+                "asset": {"ccy", "currency_map_key"},
+                "amount": {"cashBal", "total"},
+                "free_amount": {"free"},
+                "used_amount": {"used"},
                 "usd_value": "eqUsd",
                 "unrealized_pnl": "upl",
-                "liability": "liab",
+                "liability": {"debt", "liab"},
                 "collateral_enabled": "collateralEnabled",
             }
             clean_provenance = {
-                key: expected
+                key: provenance.get(key)
                 for key, expected in allowed_sources.items()
-                if provenance.get(key) == expected and (key == "asset" or key in row)
+                if (
+                    provenance.get(key) in expected
+                    if isinstance(expected, set)
+                    else provenance.get(key) == expected
+                )
+                and (key == "asset" or key in row)
             }
             if clean_provenance:
                 row["field_provenance"] = clean_provenance

--- a/tests/ccxt_upgrade/test_order_contracts.py
+++ b/tests/ccxt_upgrade/test_order_contracts.py
@@ -131,7 +131,7 @@ async def test_binance_staged_snapshot_uses_fresh_positions_for_open_order_symbo
     bot._record_live_margin_mode_from_payload = lambda payload: None
 
     async def capture_balance_snapshot():
-        return {"raw": "balance"}, 100.0
+        return {"total": {"USDT": 100.0}}, 100.0
 
     async def capture_positions_snapshot():
         return [{"raw": "position"}], [
@@ -176,8 +176,17 @@ async def test_binance_staged_snapshot_uses_fresh_positions_for_open_order_symbo
 
     assert fetched_symbols == ["SOL/USDT:USDT", None]
     assert snapshot["balance"] == 100.0
-    assert snapshot["balance_composition"]["status"] == "unavailable"
-    assert "raw" not in snapshot["balance_composition"]
+    assert snapshot["balance_composition"]["status"] == "available"
+    assert snapshot["balance_composition"]["asset_balances"] == [
+        {
+            "asset": "USDT",
+            "field_provenance": {
+                "asset": "currency_map_key",
+                "amount": "total",
+            },
+            "amount": 100.0,
+        }
+    ]
     assert snapshot["positions"][0]["symbol"] == "SOL/USDT:USDT"
     assert snapshot["open_orders"][0]["symbol"] == "SOL/USDT:USDT"
     assert snapshot["open_orders"][0]["position_side"] == "long"

--- a/tests/test_balance_composition.py
+++ b/tests/test_balance_composition.py
@@ -4,11 +4,13 @@ import math
 
 import pytest
 
+from exchanges.binance import BinanceBot
 from live.balance_composition import (
     ASSET_BALANCE_MAX_ROWS,
     balance_composition_signature,
     format_balance_composition_sample,
     malformed_balance_composition,
+    normalize_ccxt_balance_composition,
     normalize_okx_balance_composition,
     public_balance_composition,
     unavailable_balance_composition,
@@ -115,6 +117,157 @@ def test_okx_balance_composition_omits_missing_and_nonfinite_but_keeps_proven_ze
             "amount": 0.0,
         }
     ]
+
+
+def test_ccxt_balance_composition_keeps_only_unified_balance_maps():
+    snapshot = normalize_ccxt_balance_composition(
+        {
+            "total": {"USDT": 120.0, "BTC": "0.25"},
+            "free": {"USDT": 100.0, "BTC": "0.2"},
+            "used": {"USDT": 20.0, "BTC": "0.05"},
+            "debt": {"USDT": "3.5"},
+            "info": {"apiKey": "must-not-leak", "assets": [{"secret": "value"}]},
+            "timestamp": 123456,
+        }
+    )
+
+    assert snapshot["status"] == "available"
+    assert snapshot["source"] == "ccxt.unified_balance"
+    assert snapshot["count"] == 2
+    assert snapshot["asset_balances"] == [
+        {
+            "asset": "BTC",
+            "field_provenance": {
+                "asset": "currency_map_key",
+                "amount": "total",
+                "free_amount": "free",
+                "used_amount": "used",
+            },
+            "amount": 0.25,
+            "free_amount": 0.2,
+            "used_amount": 0.05,
+        },
+        {
+            "asset": "USDT",
+            "field_provenance": {
+                "asset": "currency_map_key",
+                "amount": "total",
+                "free_amount": "free",
+                "used_amount": "used",
+                "liability": "debt",
+            },
+            "amount": 120.0,
+            "free_amount": 100.0,
+            "used_amount": 20.0,
+            "liability": 3.5,
+        },
+    ]
+    assert "secret" not in str(snapshot)
+    assert "apiKey" not in str(snapshot)
+
+
+def test_ccxt_balance_composition_is_explicit_for_missing_or_partial_fields():
+    malformed = normalize_ccxt_balance_composition({"free": {"USDT": 1.0}})
+    snapshot = normalize_ccxt_balance_composition(
+        {
+            "total": {"USDT": 0, "BTC": "nan", "\x1b[31mBAD": 1},
+            "free": {"BTC": 0.1},
+            "used": None,
+            "debt": {"BTC": "inf"},
+        }
+    )
+
+    assert malformed == malformed_balance_composition(
+        source="ccxt.unified_balance", reason="missing_total"
+    )
+    assert snapshot["invalid_row_count"] == 1
+    assert snapshot["asset_balances"] == [
+        {
+            "asset": "BTC",
+            "field_provenance": {
+                "asset": "currency_map_key",
+                "free_amount": "free",
+            },
+            "free_amount": 0.1,
+        },
+        {
+            "asset": "USDT",
+            "field_provenance": {
+                "asset": "currency_map_key",
+                "amount": "total",
+            },
+            "amount": 0.0,
+        },
+    ]
+
+
+def test_ccxt_balance_composition_public_contract_keeps_bounded_provenance():
+    public = public_balance_composition(
+        normalize_ccxt_balance_composition(
+            {
+                "total": {"USDT": 10.0},
+                "free": {"USDT": 7.0},
+                "used": {"USDT": 3.0},
+                "debt": {"USDT": 2.0},
+            }
+        )
+    )
+
+    assert public["asset_balances"] == [
+        {
+            "asset": "USDT",
+            "amount": 10.0,
+            "free_amount": 7.0,
+            "used_amount": 3.0,
+            "liability": 2.0,
+            "field_provenance": {
+                "asset": "currency_map_key",
+                "amount": "total",
+                "free_amount": "free",
+                "used_amount": "used",
+                "liability": "debt",
+            },
+        }
+    ]
+
+
+def test_ccxt_balance_composition_case_collision_is_order_independent():
+    first = normalize_ccxt_balance_composition(
+        {"total": {"BTC": 1.0, "btc": 2.0}, "free": {"BTC": 0.5}}
+    )
+    second = normalize_ccxt_balance_composition(
+        {"total": {"btc": 2.0, "BTC": 1.0}, "free": {"BTC": 0.5}}
+    )
+
+    assert first["invalid_row_count"] == 1
+    assert first["asset_balances"] == [
+        {
+            "asset": "BTC",
+            "field_provenance": {
+                "asset": "currency_map_key",
+                "free_amount": "free",
+            },
+            "free_amount": 0.5,
+        }
+    ]
+    assert first["asset_balances"] == second["asset_balances"]
+    assert balance_composition_signature(first) == balance_composition_signature(second)
+
+
+def test_binance_balance_diagnostic_hook_uses_ccxt_unified_contract():
+    snapshot = BinanceBot._normalize_balance_diagnostics(
+        object(),
+        {
+            "total": {"USDT": 10.0},
+            "free": {"USDT": 8.0},
+            "used": {"USDT": 2.0},
+            "info": {"private": "must-not-leak"},
+        },
+    )
+
+    assert snapshot["source"] == "ccxt.unified_balance"
+    assert snapshot["asset_balances"][0]["asset"] == "USDT"
+    assert "private" not in str(snapshot)
 
 
 def test_composition_signature_covers_omitted_rows_and_order_is_deterministic():


### PR DESCRIPTION
## Scope

- Category: observability producer
- Normalize only Binance's already-fetched CCXT unified `total`, `free`, `used`, and explicit `debt` maps into the existing bounded balance-composition contract.
- Carry total/free/used amounts and explicit liability with field provenance; reject non-finite values and deterministic case-colliding keys.
- Record the exact PR #1313 VPS5 deploy and smoke evidence in the logging status/ledger.

## Non-goals and behavior

- No new exchange, ticker, or API calls.
- No raw `info` payloads, arbitrary connector fields, price derivation, or inferred debt.
- No scalar-balance, refresh-cadence, planning, execution-scheduling, order, risk, or console-admission change.
- OKX keeps its existing connector parser; generic and Hyperliquid paths remain explicitly unavailable.

## VPS action

- After merge: prepare, restart, and bounded smoke because running Binance must load the new diagnostic producer.
- PR #1313 deploy evidence is included: exact clean `a0db60f9`, no Rust rebuild, five exact panes restarted without force, complete hard-green lifecycle window, stable targets, protected `misc:0.0`, and natural sanitized OKX composition evidence.

## Validation

- Full Python suite passed.
- 388 focused balance, staged-refresh, event-pipeline, and AI-doc tests passed.
- Rust wrapper: 210 passed.
- `cargo check --tests --offline` passed.
- `cargo fmt --check` passed.
- Python compilation passed.
- AI docs check: 0 errors; existing aggregate word-count warning only.
- `git diff --check` passed.

## Reviewer focus

- Verify only documented CCXT unified maps can reach the public event contract.
- Verify explicit `debt` sign is preserved without inference or inversion.
- Verify malformed diagnostics cannot affect the scalar Binance balance or staged refresh outcome.
- Verify case-colliding currency keys and omitted rows remain deterministic and bounded.
