### PR TITLE
Add Hyperliquid balance composition diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Hyperliquid `balance.changed` composition diagnostics now parse only proven
+  unified-account `info.balances` coin and signed total fields from the
+  already-fetched balance response. Non-unified payloads remain explicitly
+  unavailable; malformed unified shapes remain diagnostic failures. The bounded
+  rows add no exchange calls, valuation inference, scalar-balance changes,
+  planning, order, or risk behavior, and raw connector payloads remain excluded.
+
 - Binance `balance.changed` composition diagnostics now normalize only CCXT's
   documented unified `total`, `free`, `used`, and explicit `debt` maps from the
   already-fetched balance response. The bounded rows add no exchange calls,
@@ -16,10 +23,9 @@ All notable user-facing changes will be documented in this file.
   PnL, explicit liability, collateral state, and field provenance. Equal-total
   collateral substitutions are durable through a separate composition
   signature, while console admission remains snapped-balance based and shows at
-  most two sanitized assets. Generic, Binance, and Hyperliquid paths report a
-  stable unavailable diagnostic until their own parsers are added; balance
-  calculation, API calls, refresh cadence, planning, orders, and risk are
-  unchanged.
+  most two sanitized assets. Generic paths report a stable unavailable
+  diagnostic until their own parsers are added; balance calculation, API calls,
+  refresh cadence, planning, orders, and risk are unchanged.
 
 - Full live smoke reports now retain a separately bounded sample of hard
   structured problem events, with authoritative total, retained, and truncated

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -29,6 +29,14 @@ Any legacy raw-only balance apply replaces a previous composition with an
 explicit unavailable state; it must never pair stale asset rows with a fresh
 aggregate balance.
 
+Hyperliquid contributes rows only for proven unified responses with
+`info.balances` as a list. Each retained row uses only its `coin` asset and
+finite signed `total`, with field provenance; no hold/free/used, liability,
+price, USD value, collateral, or HIP-3 position inference is permitted.
+Non-unified responses are explicitly unavailable, while malformed unified
+shapes are malformed diagnostics. This parser uses the already-fetched balance
+response and does not alter scalar balance extraction or staged refresh calls.
+
 Balance publication occurs on the existing aggregate raw/snapped transition or
 on a changed full normalized composition signature, including a change in an
 omitted row. Console admission remains based solely on snapped-balance

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,21 +22,20 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/binance-balance-composition`, based on canonical
-  `a0db60f9ca97dbc5b9b37aa3230fce97eb0917ce` after PR #1313.
-- PR: #1316.
-- Scope: second connector-specific implementation of backlog item 20. Parse
-  only Binance's already-fetched CCXT unified `total`, `free`, `used`, and
-  explicit `debt` maps into the existing bounded balance-composition contract.
-  OKX remains on its connector-specific parser; generic and Hyperliquid paths
-  remain explicitly unavailable until separately proven.
+- Branch: `codex/hyperliquid-balance-composition`, based on canonical
+  `e7fe7f796fb76a829003933dc7e5d937c6df8c64` after PR #1316.
+- PR: not opened.
+- Scope: third connector-specific implementation of backlog item 20. Parse
+  only proven Hyperliquid unified `info.balances` coin and finite signed total
+  rows from the already-fetched response. Non-unified payloads remain explicitly
+  unavailable; HIP-3 position responses remain out of scope.
 - Behavior boundary: no new exchange/ticker/API calls and no change to scalar
   balance calculation, refresh cadence, planning, execution scheduling,
   orders, risk, valuation, or console materiality. Composition-only changes
   remain durable and off the console.
-- Validation: focused unified-map, explicit-debt, missing/non-finite,
-  raw-leakage, public-provenance, Binance-hook, staged-carry, balance-state,
-  and event-pipeline regressions.
+- Validation: focused unified-row, missing/non-finite, zero, collision/bounds,
+  raw-leakage, Hyperliquid cache/hook, staged-carry, balance-state, and
+  event-pipeline regressions.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
 - Expected VPS action: this behavior-changing diagnostic slice requires a
@@ -44,6 +43,22 @@ Estimated completion:
   it must not manufacture balance events or contact an exchange directly.
 
 ## Deployed Baseline
+
+- PR #1316 merged as canonical `e7fe7f796fb76a829003933dc7e5d937c6df8c64`.
+  It adds bounded Binance CCXT unified composition diagnostics while preserving
+  scalar balance, exchange-call, planning, order, risk, and console-admission
+  behavior.
+- VPS5 fast-forwarded tracked-clean from `a0db60f9` without a Rust rebuild.
+  The exact panes `%358`-`%362` gracefully restarted without force; old PIDs
+  `1038760/1038769/1038763/1038772/1038766` became
+  `1040903/1040911/1040905/1040914/1040908`.
+- The exact `1784404124757..1784404777859` window selected 7/1,012 event files
+  totaling `19420705` bytes, retained five stopping/stopped/startup cohorts, and
+  had zero hard, monitor, or text-log issues. Delayed target sampling was 3/3
+  with `R=4,S=1` and no extras; `misc:0.0` stayed `%8`/PID `434835`. No direct
+  exchange call or event was manufactured.
+
+## Previous Deployed Baseline
 
 - PR #1313 merged as canonical `a0db60f9ca97dbc5b9b37aa3230fce97eb0917ce`.
   It adds the bounded OKX-first balance-composition diagnostic and preserves

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/hyperliquid-balance-composition`, based on canonical
   `e7fe7f796fb76a829003933dc7e5d937c6df8c64` after PR #1316.
-- PR: not opened.
+- PR: #1317.
 - Scope: third connector-specific implementation of backlog item 20. Parse
   only proven Hyperliquid unified `info.balances` coin and finite signed total
   rows from the already-fetched response. Non-unified payloads remain explicitly

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,23 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1313)
+## Latest Canonical Deployment (PR #1316)
+
+- PR #1316 merged as canonical `e7fe7f796fb76a829003933dc7e5d937c6df8c64`.
+  It adds bounded Binance CCXT unified composition diagnostics without changing
+  scalar balance, exchange calls, planning, orders, risk, or console admission.
+- VPS5 fast-forwarded tracked-clean from `a0db60f9` without a Rust rebuild and
+  gracefully restarted only exact panes `%358`-`%362` without force. Old PIDs
+  `1038760/1038769/1038763/1038772/1038766` became
+  `1040903/1040911/1040905/1040914/1040908`.
+- The exact `1784404124757..1784404777859` window selected 7/1,012 event files
+  totaling `19420705` bytes, retained five stopping/stopped/startup cohorts, and
+  had zero hard, monitor, or text-log issues. Delayed 3/3 target sampling was
+  `R=4,S=1` with no extras; `misc:0.0` remained `%8`/PID `434835`. No direct
+  exchange call or event was manufactured.
+- The exact merge is the base for the Hyperliquid unified-only composition slice.
+
+## Previous Canonical Deployment (PR #1313)
 
 - PR #1313 merged as canonical `a0db60f9ca97dbc5b9b37aa3230fce97eb0917ce`.
   It adds bounded OKX asset composition to `balance.changed` without changing

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -1081,13 +1081,16 @@ Related detailed plans:
     the live default branch before the cutover can be considered complete.
 
 20. [ ] Per-asset collateral, debt, and valuation balance events.
-    Status: partial, OKX plus Binance. Connector-specific slices normalize
-    OKX's already-fetched `info.data[0].details` and Binance's already-fetched
-    CCXT unified balance maps into bounded deterministic asset rows. Generic
-    and Hyperliquid staged paths remain explicitly unavailable. Neither slice
-    adds exchange calls or changes scalar balance, planning, orders, risk, or
-    console materiality. Other connector parsers and any broader asset contract
-    remain open. A 2026-07-14 evaluation confirmed that the existing
+    Status: partial, OKX plus Binance plus Hyperliquid unified-account totals.
+    Connector-specific slices normalize OKX's already-fetched
+    `info.data[0].details`, Binance's already-fetched CCXT unified balance maps,
+    and proven Hyperliquid unified `info.balances` coin/total rows into bounded
+    deterministic asset rows. Hyperliquid non-unified payloads remain explicitly
+    unavailable; HIP-3 position responses remain out of scope. Gate.io and
+    KuCoin remain fixture/contract work. These slices add no exchange calls or
+    changes to scalar balance, planning, orders, risk, or console materiality.
+    Other connector parsers and any broader asset contract remain open. A
+    2026-07-14 evaluation confirmed that the existing
     `balance.changed` event and console projection expose only aggregate raw
     balance, hysteresis-snapped balance, equity, deltas, and source. The
     authoritative refresh already receives the exact raw balance response

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -10,7 +10,10 @@ import passivbot_rust as pbr
 from ccxt.base.errors import RateLimitExceeded
 
 from exchanges.ccxt_bot import CCXTBot, format_exchange_config_response
-from live.balance_composition import malformed_balance_composition
+from live.balance_composition import (
+    malformed_balance_composition,
+    normalize_hyperliquid_unified_balance_composition,
+)
 from passivbot import logging
 from passivbot_exceptions import FatalBotException
 from utils import symbol_to_coin, ts_to_date, utc_ms
@@ -677,6 +680,10 @@ class HyperliquidBot(CCXTBot):
             if str(row.get("coin") or "") == self.quote:
                 return _validate_total(row.get("total"))
         raise KeyError(f"unified Hyperliquid balance payload missing total for {self.quote}")
+
+    def _normalize_balance_diagnostics(self, fetched: object) -> dict:
+        """Expose only bounded totals from a proven unified balance payload."""
+        return normalize_hyperliquid_unified_balance_composition(fetched)
 
     def _hl_position_unrealized_pnl(self, position: dict) -> float:
         """Exchange-reported unrealized PnL for a CCXT Hyperliquid position payload.

--- a/src/live/balance_composition.py
+++ b/src/live/balance_composition.py
@@ -217,6 +217,59 @@ def normalize_ccxt_balance_composition(fetched: Any) -> dict[str, Any]:
     )
 
 
+def normalize_hyperliquid_unified_balance_composition(fetched: Any) -> dict[str, Any]:
+    """Normalize only proven unified Hyperliquid ``info.balances`` rows."""
+    source = "hyperliquid.info.balances"
+    if not isinstance(fetched, Mapping):
+        return malformed_balance_composition(source=source, reason="invalid_payload")
+    info = fetched.get("info")
+    if not isinstance(info, Mapping):
+        return malformed_balance_composition(source=source, reason="missing_info")
+    if "balances" not in info:
+        return unavailable_balance_composition(reason="non_unified_payload")
+    balances = info.get("balances")
+    if not isinstance(balances, list):
+        return malformed_balance_composition(source=source, reason="invalid_balances")
+    if not balances:
+        return malformed_balance_composition(source=source, reason="empty_balances")
+
+    rows_by_asset: dict[str, dict[str, Any]] = {}
+    collided_assets: set[str] = set()
+    invalid_row_count = 0
+    for balance in balances:
+        if not isinstance(balance, Mapping):
+            invalid_row_count += 1
+            continue
+        asset = _asset_name(balance.get("coin"))
+        amount = _finite_number(balance.get("total"))
+        if asset is None or amount is None:
+            invalid_row_count += 1
+            continue
+        if asset in collided_assets:
+            invalid_row_count += 1
+            continue
+        if asset in rows_by_asset:
+            # Case-normalized duplicate coins have no deterministic single total.
+            rows_by_asset.pop(asset)
+            collided_assets.add(asset)
+            invalid_row_count += 1
+            continue
+        rows_by_asset[asset] = {
+            "asset": asset,
+            "field_provenance": {"asset": "coin", "amount": "total"},
+            "amount": amount,
+        }
+
+    if not rows_by_asset:
+        return malformed_balance_composition(source=source, reason="no_valid_rows")
+    return _finalize_snapshot(
+        status="available",
+        source=source,
+        assets=list(rows_by_asset.values()),
+        invalid_row_count=invalid_row_count,
+    )
+
+
 def public_balance_composition(value: Any) -> dict[str, Any] | None:
     """Copy only the bounded event contract; never publish an internal signature."""
     if not isinstance(value, Mapping):
@@ -234,6 +287,7 @@ def public_balance_composition(value: Any) -> dict[str, Any] | None:
             "unsupported",
             "normalizer",
             "ccxt.unified_balance",
+            "hyperliquid.info.balances",
             "okx.info.data[0].details",
         }
         or not isinstance(assets, list)
@@ -264,7 +318,7 @@ def public_balance_composition(value: Any) -> dict[str, Any] | None:
         provenance = item.get("field_provenance")
         if isinstance(provenance, Mapping):
             allowed_sources = {
-                "asset": {"ccy", "currency_map_key"},
+                "asset": {"ccy", "coin", "currency_map_key"},
                 "amount": {"cashBal", "total"},
                 "free_amount": {"free"},
                 "used_amount": {"used"},

--- a/tests/ccxt_upgrade/test_order_contracts.py
+++ b/tests/ccxt_upgrade/test_order_contracts.py
@@ -195,7 +195,7 @@ async def test_binance_staged_snapshot_uses_fresh_positions_for_open_order_symbo
 
 
 @pytest.mark.asyncio
-async def test_hyperliquid_staged_snapshot_carries_unavailable_diagnostics_not_raw_balance():
+async def test_hyperliquid_staged_snapshot_carries_malformed_diagnostics_not_raw_balance():
     bot = HyperliquidBot.__new__(HyperliquidBot)
 
     async def capture_positions_balance():
@@ -212,7 +212,9 @@ async def test_hyperliquid_staged_snapshot_carries_unavailable_diagnostics_not_r
     )
 
     assert snapshot["balance"] == 100.0
-    assert snapshot["balance_composition"]["status"] == "unavailable"
+    assert snapshot["balance_composition"]["status"] == "malformed"
+    assert snapshot["balance_composition"]["source"] == "hyperliquid.info.balances"
+    assert snapshot["balance_composition"]["reason"] == "missing_info"
     assert "private-balance" not in str(snapshot["balance_composition"])
 
 

--- a/tests/test_balance_composition.py
+++ b/tests/test_balance_composition.py
@@ -11,6 +11,7 @@ from live.balance_composition import (
     format_balance_composition_sample,
     malformed_balance_composition,
     normalize_ccxt_balance_composition,
+    normalize_hyperliquid_unified_balance_composition,
     normalize_okx_balance_composition,
     public_balance_composition,
     unavailable_balance_composition,
@@ -27,6 +28,10 @@ from live import state_refresh
 
 def _okx_payload(details):
     return {"info": {"data": [{"details": details}]}}
+
+
+def _hyperliquid_unified_payload(balances):
+    return {"info": {"balances": balances}}
 
 
 def test_okx_balance_composition_keeps_only_proven_detail_fields():
@@ -252,6 +257,100 @@ def test_ccxt_balance_composition_case_collision_is_order_independent():
     ]
     assert first["asset_balances"] == second["asset_balances"]
     assert balance_composition_signature(first) == balance_composition_signature(second)
+
+
+def test_hyperliquid_unified_balance_composition_keeps_only_coin_and_signed_total():
+    snapshot = normalize_hyperliquid_unified_balance_composition(
+        _hyperliquid_unified_payload(
+            [
+                {"coin": "USDC", "total": "-12.5", "hold": "1", "address": "secret"},
+                {"coin": "btc", "total": "0", "apiKey": "must-not-leak"},
+            ]
+        )
+    )
+
+    assert snapshot["status"] == "available"
+    assert snapshot["source"] == "hyperliquid.info.balances"
+    assert snapshot["asset_balances"] == [
+        {
+            "asset": "BTC",
+            "field_provenance": {"asset": "coin", "amount": "total"},
+            "amount": 0.0,
+        },
+        {
+            "asset": "USDC",
+            "field_provenance": {"asset": "coin", "amount": "total"},
+            "amount": -12.5,
+        },
+    ]
+    assert public_balance_composition(snapshot)["asset_balances"] == snapshot["asset_balances"]
+    assert "secret" not in str(snapshot)
+    assert "apiKey" not in str(snapshot)
+
+
+def test_hyperliquid_balance_composition_is_explicit_for_non_unified_and_malformed_rows():
+    non_unified = normalize_hyperliquid_unified_balance_composition(
+        {"info": {"marginSummary": {"accountValue": "10"}}}
+    )
+    malformed_balances = normalize_hyperliquid_unified_balance_composition(
+        {"info": {"balances": {}}}
+    )
+    empty_balances = normalize_hyperliquid_unified_balance_composition(
+        _hyperliquid_unified_payload([])
+    )
+    malformed_rows = normalize_hyperliquid_unified_balance_composition(
+        _hyperliquid_unified_payload(
+            [{"coin": "\x1b[31mBAD", "total": "1"}, {"coin": "USDC", "total": "nan"}]
+        )
+    )
+
+    assert non_unified["status"] == "unavailable"
+    assert non_unified["reason"] == "non_unified_payload"
+    assert malformed_balances == malformed_balance_composition(
+        source="hyperliquid.info.balances", reason="invalid_balances"
+    )
+    assert empty_balances == malformed_balance_composition(
+        source="hyperliquid.info.balances", reason="empty_balances"
+    )
+    assert malformed_rows == malformed_balance_composition(
+        source="hyperliquid.info.balances", reason="no_valid_rows"
+    )
+
+
+def test_hyperliquid_balance_composition_is_deterministic_bounded_and_drops_collisions():
+    balances = [
+        {"coin": f"ASSET{i:02d}", "total": str(i)}
+        for i in range(ASSET_BALANCE_MAX_ROWS + 2, 0, -1)
+    ]
+    first = normalize_hyperliquid_unified_balance_composition(
+        _hyperliquid_unified_payload(balances)
+    )
+    second = normalize_hyperliquid_unified_balance_composition(
+        _hyperliquid_unified_payload(list(reversed(balances)))
+    )
+    collided = normalize_hyperliquid_unified_balance_composition(
+        _hyperliquid_unified_payload(
+            [
+                {"coin": "BTC", "total": "1"},
+                {"coin": "btc", "total": "2"},
+                {"coin": "USDC", "total": "3"},
+            ]
+        )
+    )
+
+    assert first["asset_balances"] == second["asset_balances"]
+    assert balance_composition_signature(first) == balance_composition_signature(second)
+    assert first["count"] == ASSET_BALANCE_MAX_ROWS + 2
+    assert first["retained"] == ASSET_BALANCE_MAX_ROWS
+    assert first["truncated"] == 2
+    assert collided["invalid_row_count"] == 1
+    assert collided["asset_balances"] == [
+        {
+            "asset": "USDC",
+            "field_provenance": {"asset": "coin", "amount": "total"},
+            "amount": 3.0,
+        }
+    ]
 
 
 def test_binance_balance_diagnostic_hook_uses_ccxt_unified_contract():

--- a/tests/test_hyperliquid_balance_cache.py
+++ b/tests/test_hyperliquid_balance_cache.py
@@ -475,7 +475,10 @@ async def test_hyperliquid_combined_fetch_handles_unified_balance_payload(stubbe
     HIP3_UPNL = -0.456789  # HIP-3 dex uPNL, surfaced at the CCXT top level
 
     class _UnifiedCCA:
+        balance_calls = 0
+
         async def fetch_balance(self):
+            self.balance_calls += 1
             return {
                 "total": {"USDC": UNIFIED_TOTAL},
                 "info": {
@@ -539,6 +542,55 @@ async def test_hyperliquid_combined_fetch_handles_unified_balance_payload(stubbe
     assert {p["symbol"] for p in positions} == {"BTC/USDC:USDC", "XYZ-SP500/USDC:USDC"}
     assert any(p["symbol"] == "BTC/USDC:USDC" and p["margin_used"] == pytest.approx(1.039948) for p in positions)
     assert any(p["symbol"] == "XYZ-SP500/USDC:USDC" and p["margin_used"] == pytest.approx(0.69617) for p in positions)
+    assert bot.cca.balance_calls == 1
+
+    composition = bot._normalize_balance_diagnostics(raw_snapshot["balance"])
+
+    assert composition["asset_balances"] == [
+        {
+            "asset": "USDC",
+            "field_provenance": {"asset": "coin", "amount": "total"},
+            "amount": UNIFIED_TOTAL,
+        }
+    ]
+    assert balance == pytest.approx(50.14595463)
+    assert bot.cca.balance_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_hyperliquid_staged_balance_capture_reuses_unified_response(stubbed_modules):
+    HyperliquidBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    bot = HyperliquidBot.__new__(HyperliquidBot)
+    calls = {"capture": 0, "balance": 0}
+    raw_balance = {"info": {"balances": [{"coin": "USDC", "total": "42.5"}]}}
+
+    class _NoBalanceFetchCCA:
+        async def fetch_balance(self):
+            calls["balance"] += 1
+            raise AssertionError("staged diagnostics must reuse the captured balance response")
+
+    async def fake_capture_positions_balance_staged_snapshot():
+        calls["capture"] += 1
+        return {"balance": raw_balance}, [], 17.25
+
+    async def passthrough_timed_fetch(_label, coro, _timings_ms):
+        return await coro
+
+    bot._capture_positions_balance_staged_snapshot = fake_capture_positions_balance_staged_snapshot
+    bot._timed_authoritative_fetch = passthrough_timed_fetch
+    bot.cca = _NoBalanceFetchCCA()
+
+    snapshot = await bot.capture_authoritative_state_staged_snapshot({"balance"}, {})
+
+    assert calls == {"capture": 1, "balance": 0}
+    assert snapshot["balance"] == pytest.approx(17.25)
+    assert snapshot["balance_composition"]["asset_balances"] == [
+        {
+            "asset": "USDC",
+            "field_provenance": {"asset": "coin", "amount": "total"},
+            "amount": 42.5,
+        }
+    ]
 
 
 def test_hyperliquid_position_unrealized_pnl_fails_loud(stubbed_modules):


### PR DESCRIPTION
## Scope

- Category: observability producer.
- Normalize only proven Hyperliquid unified-account `info.balances` rows from the already-fetched balance response.
- Retain only sanitized asset `coin`, finite signed `total`, and exact field provenance.
- Record the exact PR #1316 VPS5 deployment and settled smoke evidence.

## Non-goals and behavior

- No new exchange, ticker, or API calls.
- No hold/free/used, debt, price, USD value, collateral, or HIP-3 position inference.
- Non-unified payloads remain explicitly unavailable; malformed unified shapes remain explicit malformed diagnostics.
- No scalar-balance, fetch-cadence, planning, execution-scheduling, order, risk, readiness, valuation, or console-admission change.
- Raw connector payloads, arbitrary fields, addresses, and credentials remain excluded.

## VPS action

- After merge: prepare, restart, and bounded smoke because the running Hyperliquid bot must load the new producer.
- PR #1316 deploy evidence is included: exact clean `e7fe7f796f`, no Rust rebuild, only exact panes `%358`-`%362` restarted without force, complete hard-green lifecycle window, delayed `R=4,S=1` stable targets, and protected `misc:0.0`.

## Validation

- Full Python suite passed against an exact-worktree rebuilt and stamped Rust extension.
- Focused balance-composition, Hyperliquid cache/staged, balance-state, event-bus, and AI-doc suites passed.
- 210 Rust tests passed.
- `cargo check --tests --offline` and `cargo fmt --check` passed.
- Python compilation, AI-doc, generated registry, and `git diff --check` passed.
- Independent pre-PR review finding for empty unified balances was fixed with a regression test.

## Reviewer focus

- Verify only `info.balances[*].coin` and finite signed `total` reach the public contract.
- Verify non-unified and malformed payloads remain distinguishable and bounded.
- Verify collisions, omitted rows, and signatures are deterministic.
- Verify staged normalization reuses the captured response and cannot affect scalar balance or exchange-call count.