### PR TITLE
test(logging): capture fake-live post-panic recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Offline fake-live runs now retain the already-emitted redacted structured
+  event envelopes as a run artifact. The coin-mode HSL RED regression uses that
+  evidence to prove a panic fill is followed by an available planning snapshot
+  without a post-panic `planning.unavailable` handoff, while leaving live event
+  production, HSL behavior, exchange calls, orders, and risk unchanged.
+
 - Hyperliquid `balance.changed` composition diagnostics now parse only proven
   unified-account `info.balances` coin and signed total fields from the
   already-fetched balance response. Non-unified payloads remain explicitly

--- a/docs/fake_live.md
+++ b/docs/fake_live.md
@@ -66,9 +66,20 @@ Each run writes a timestamped directory containing:
 - `fills.json`
 - `positions.json`
 - `hsl_trace.json`
+- `live_events.json`: redacted structured `LiveEvent.to_dict()` envelopes, including graceful
+  shutdown
 - `snapshots/step_*.json` if `--snapshot-each-step` is enabled
 
 This makes it easy to inspect the exact replay state at each step.
+
+`live_events.json` is a bounded in-memory diagnostic capture of at most the latest 2,000 envelopes,
+attached to the existing live-event pipeline before bot startup.
+`run_metadata.json.live_event_capture` records the total, retained, truncated, and maximum retained
+counts so dropping older envelopes is explicit. If disabled console and monitor output leave no
+default pipeline, fake-live installs a capture-only pipeline with the same bot context; it does not
+re-enable either output. The capture closes with the bot before serialization and contains no raw
+exchange payloads. Event IDs and timestamps are runtime-specific, so this file is not part of
+deterministic cross-run artifact comparison.
 
 Regression philosophy:
 

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/fake-live-post-panic-observability`, based on canonical
   `eb82e256c2dfeac29af158f389f93a7ddba8eae2` after PR #1317.
-- PR: not opened.
+- PR: #1318.
 - Scope: backlog item 15. Persist the already-emitted redacted structured
   events as a fake-live run artifact, then make the existing coin-mode RED
   scenario prove the post-panic data-packet/snapshot handoff stays available.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,27 +22,43 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/hyperliquid-balance-composition`, based on canonical
-  `e7fe7f796fb76a829003933dc7e5d937c6df8c64` after PR #1316.
-- PR: #1317.
-- Scope: third connector-specific implementation of backlog item 20. Parse
-  only proven Hyperliquid unified `info.balances` coin and finite signed total
-  rows from the already-fetched response. Non-unified payloads remain explicitly
-  unavailable; HIP-3 position responses remain out of scope.
-- Behavior boundary: no new exchange/ticker/API calls and no change to scalar
-  balance calculation, refresh cadence, planning, execution scheduling,
-  orders, risk, valuation, or console materiality. Composition-only changes
-  remain durable and off the console.
-- Validation: focused unified-row, missing/non-finite, zero, collision/bounds,
-  raw-leakage, Hyperliquid cache/hook, staged-carry, balance-state, and
-  event-pipeline regressions.
+- Branch: `codex/fake-live-post-panic-observability`, based on canonical
+  `eb82e256c2dfeac29af158f389f93a7ddba8eae2` after PR #1317.
+- PR: not opened.
+- Scope: backlog item 15. Persist the already-emitted redacted structured
+  events as a fake-live run artifact, then make the existing coin-mode RED
+  scenario prove the post-panic data-packet/snapshot handoff stays available.
+- Behavior boundary: offline fake-exchange harness and tests only. No live
+  producer, HSL math, readiness gate, exchange adapter, order, risk, config,
+  console, monitor-persistence, or runtime behavior changes.
+- Validation: focused artifact capture, redaction, pipeline-flush, and
+  coin-mode RED/panic-fill/post-panic availability regressions plus the fake-live
+  suite. The test must fail if the recovered handoff emits
+  `planning.unavailable` or lacks a later available `snapshot.built` event.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
-- Expected VPS action: this behavior-changing diagnostic slice requires a
-  bounded prepare/restart/smoke decision only after exact-head review and CI;
-  it must not manufacture balance events or contact an exchange directly.
+- Expected VPS action: none. The slice is offline tooling/tests/docs and must
+  not contact an exchange, deploy code, or control live processes.
 
 ## Deployed Baseline
+
+- PR #1317 merged as canonical `eb82e256c2dfeac29af158f389f93a7ddba8eae2`.
+  It adds bounded Hyperliquid unified-account composition diagnostics without
+  changing scalar balance, exchange calls, planning, orders, risk, or console
+  admission.
+- VPS5 fast-forwarded tracked-clean from `e7fe7f79` without a Rust rebuild.
+  The exact panes `%358`-`%362` gracefully restarted without force; old PIDs
+  `1040903/1040911/1040905/1040914/1040908` became
+  `1042130/1042139/1042133/1042142/1042136`.
+- The exact `1784407239491..1784407888217` window selected 10/1,011 event
+  segments totaling `72553076` bytes, retained all five
+  stopping/stopped/startup cohorts, and had zero hard, monitor, text-log,
+  repository, or target failures. Delayed 3/3 sampling recovered one transient
+  GateIO `D` observation to final `R=4,S=1`, with five stable PIDs and no extras
+  or issues. Protected `misc:0.0` stayed `%8`/PID `434835`. No direct exchange
+  call or event was manufactured.
+
+## Previous Deployed Baseline (PR #1316)
 
 - PR #1316 merged as canonical `e7fe7f796fb76a829003933dc7e5d937c6df8c64`.
   It adds bounded Binance CCXT unified composition diagnostics while preserving
@@ -58,7 +74,7 @@ Estimated completion:
   with `R=4,S=1` and no extras; `misc:0.0` stayed `%8`/PID `434835`. No direct
   exchange call or event was manufactured.
 
-## Previous Deployed Baseline
+## Previous Deployed Baseline (PR #1313)
 
 - PR #1313 merged as canonical `a0db60f9ca97dbc5b9b37aa3230fce97eb0917ce`.
   It adds the bounded OKX-first balance-composition diagnostic and preserves

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,26 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1316)
+## Latest Canonical Deployment (PR #1317)
+
+- PR #1317 merged as canonical `eb82e256c2dfeac29af158f389f93a7ddba8eae2`.
+  It adds bounded Hyperliquid unified-account composition diagnostics without
+  changing scalar balance, exchange calls, planning, orders, risk, or console
+  admission.
+- VPS5 fast-forwarded tracked-clean from `e7fe7f79` without a Rust rebuild and
+  gracefully restarted only exact panes `%358`-`%362` without force. Old PIDs
+  `1040903/1040911/1040905/1040914/1040908` became
+  `1042130/1042139/1042133/1042142/1042136`.
+- The exact `1784407239491..1784407888217` window selected 10/1,011 event
+  segments totaling `72553076` bytes, retained all five shutdown/startup
+  cohorts, and was hard-green across monitor, text-log, repository, and target
+  gates. Delayed 3/3 sampling recovered one transient GateIO `D` observation to
+  final `R=4,S=1`, with five stable PIDs and no extras. Protected `misc:0.0`
+  remained `%8`/PID `434835`. No direct exchange call or event was manufactured.
+- The exact merge is the base for the offline fake-live post-panic
+  observability regression slice.
+
+## Previous Canonical Deployment (PR #1316)
 
 - PR #1316 merged as canonical `e7fe7f796fb76a829003933dc7e5d937c6df8c64`.
   It adds bounded Binance CCXT unified composition diagnostics without changing
@@ -29,7 +48,7 @@ merge, live smoke evidence changes, or new gaps are discovered.
   had zero hard, monitor, or text-log issues. Delayed 3/3 target sampling was
   `R=4,S=1` with no extras; `misc:0.0` remained `%8`/PID `434835`. No direct
   exchange call or event was manufactured.
-- The exact merge is the base for the Hyperliquid unified-only composition slice.
+- The exact merge was the base for the Hyperliquid unified-only composition slice.
 
 ## Previous Canonical Deployment (PR #1313)
 

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -921,6 +921,13 @@ Related detailed plans:
       fake-live suite and seven pside HSL end-to-end scenarios remain green;
       add a dedicated coin-mode post-panic scenario and fix the epoch handoff
       separately from HSL episode-finalization math.
+    - 2026-07-18: Canonical master now completes that coin-mode post-panic
+      handoff: the panic close fills, authoritative account surfaces refresh,
+      cooldown ends, and normal selection resumes without the former missing
+      surface failure. The active regression slice persists the already-emitted
+      redacted live-event envelopes in fake-live artifacts and makes the
+      scenario prove a later available planning snapshot with no
+      `planning.unavailable` handoff event.
 
 16. [x] Websocket reconnect diagnostics.
     Status: completed by PR #1170.

--- a/src/tools/run_fake_live.py
+++ b/src/tools/run_fake_live.py
@@ -6,9 +6,10 @@ import json
 import logging
 import os
 import sys
+from collections import deque
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List
 
 import numpy as np
 
@@ -19,10 +20,26 @@ from config import load_prepared_config
 from config.pnl_lookback import parse_pnls_max_lookback_days
 from exchanges.fake import FakeCCXTClient, load_fake_scenario
 from fill_events_manager import FillEvent, FillEventCache
+from live.event_bus import LiveEvent, LiveEventContext, LiveEventPipeline
 from logging_setup import configure_logging
 import passivbot as passivbot_mod
 from passivbot import setup_bot, shutdown_bot
 from procedures import ensure_parent_directory
+
+
+MAX_CAPTURED_LIVE_EVENTS = 2_000
+
+
+class _BoundedLiveEventSink:
+    def __init__(self, max_retained: int = MAX_CAPTURED_LIVE_EVENTS) -> None:
+        self.max_retained = max(1, int(max_retained))
+        self.events: deque[LiveEvent] = deque(maxlen=self.max_retained)
+        self.total = 0
+
+    def write(self, event: LiveEvent) -> LiveEvent:
+        self.total += 1
+        self.events.append(event)
+        return event
 
 
 def _build_output_dir(root: str | None, scenario: dict) -> Path:
@@ -141,6 +158,54 @@ def _attach_file_logging(path: Path) -> logging.Handler:
         handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
     root.addHandler(handler)
     return handler
+
+
+def _install_live_event_capture(
+    bot,
+) -> tuple[_BoundedLiveEventSink, Callable[[], None]]:
+    """Attach a fake-live artifact sink without replacing normal event sinks."""
+    pipeline = getattr(bot, "_live_event_pipeline", None)
+    capture_sink = _BoundedLiveEventSink()
+    owns_pipeline = pipeline is None
+    if owns_pipeline:
+        pipeline = LiveEventPipeline(
+            context=LiveEventContext(
+                exchange=getattr(bot, "exchange", None),
+                user=getattr(bot, "user", None),
+                bot_id=getattr(bot, "bot_id", None),
+            ),
+            structured_sinks=(capture_sink,),
+        )
+        bot._live_event_pipeline = pipeline
+        existing_sinks = ()
+    else:
+        if not callable(getattr(pipeline, "flush", None)):
+            raise RuntimeError("fake-live event pipeline does not support capture flushing")
+        existing_sinks = tuple(getattr(pipeline, "structured_sinks", ()))
+        pipeline.structured_sinks = (*existing_sinks, capture_sink)
+
+    def restore() -> None:
+        if getattr(bot, "_live_event_pipeline", None) is not pipeline:
+            return
+        if owns_pipeline:
+            pipeline.close(timeout=2.0)
+            bot._live_event_pipeline = None
+        else:
+            pipeline.structured_sinks = existing_sinks
+
+    return capture_sink, restore
+
+
+def _serialize_live_event_capture(
+    capture_sink: _BoundedLiveEventSink,
+) -> tuple[list[dict], dict]:
+    retained = len(capture_sink.events)
+    return [event.to_dict() for event in capture_sink.events], {
+        "total": capture_sink.total,
+        "retained": retained,
+        "truncated": capture_sink.total - retained,
+        "max_retained": capture_sink.max_retained,
+    }
 
 
 def _extract_hsl_trace(bot) -> Dict[str, dict]:
@@ -670,6 +735,7 @@ def _load_run_artifacts(output_dir: Path) -> dict[str, Any]:
         "remote_calls": _load("remote_calls.json", []),
         "remote_call_summary": _load("remote_call_summary.json", {}),
         "candle_remote_fetches": _load("candle_remote_fetches.json", []),
+        "live_events": _load("live_events.json", []),
         "log_text": log_path.read_text(encoding="utf-8") if log_path.exists() else "",
     }
 
@@ -822,7 +888,9 @@ async def _run_fake_case(
     log_handler = _attach_file_logging(log_path)
     _, restore_user_override = _install_fake_user_override(config, scenario_path, user)
     bot = None
+    bot_shutdown = False
     restore_candle_trace = lambda: None
+    restore_live_event_capture = lambda: None
 
     try:
         bot = setup_bot(config)
@@ -833,6 +901,7 @@ async def _run_fake_case(
         bot.debug_mode = True
         if not isinstance(bot.cca, FakeCCXTClient):
             raise TypeError("Fake harness expected bot.cca to be FakeCCXTClient")
+        live_event_sink, restore_live_event_capture = _install_live_event_capture(bot)
         candle_remote_fetches, restore_candle_trace = _install_candle_remote_fetch_trace(bot)
         _prime_fake_fill_cache(bot, bot.cca)
         _prime_fake_candles(bot, bot.cca)
@@ -849,6 +918,9 @@ async def _run_fake_case(
             snapshot_dir=snapshot_dir,
             run_initial_cycle=bool(scenario.get("run_initial_cycle", True)),
         )
+        pipeline = getattr(bot, "_live_event_pipeline", None)
+        if pipeline is None or not pipeline.flush(timeout=2.0):
+            raise RuntimeError("fake-live structured-event capture did not flush")
         log_text = log_path.read_text(encoding="utf-8") if log_path.exists() else ""
         remote_calls = bot.cca.export_request_log()
         remote_call_summary = _summarize_remote_calls(remote_calls)
@@ -864,30 +936,44 @@ async def _run_fake_case(
                 candle_remote_fetches=candle_remote_fetches,
             )
 
+        fake_exchange_state = bot.cca.export_state()
+        fills = list(bot.cca.fills)
+        positions = bot.cca.export_positions()
+        hsl_trace = _extract_hsl_trace(bot)
+        await bot.shutdown_gracefully()
+        bot_shutdown = True
+        live_events, live_event_capture = _serialize_live_event_capture(live_event_sink)
+
         _dump_json(output_dir / "step_summaries.json", step_summaries)
-        _dump_json(output_dir / "fake_exchange_state.json", bot.cca.export_state())
-        _dump_json(output_dir / "fills.json", bot.cca.fills)
-        _dump_json(output_dir / "positions.json", bot.cca.export_positions())
-        _dump_json(output_dir / "hsl_trace.json", _extract_hsl_trace(bot))
+        _dump_json(output_dir / "fake_exchange_state.json", fake_exchange_state)
+        _dump_json(output_dir / "fills.json", fills)
+        _dump_json(output_dir / "positions.json", positions)
+        _dump_json(output_dir / "hsl_trace.json", hsl_trace)
         _dump_json(
             output_dir / "run_metadata.json",
             {
                 "assertions_enforced": bool(enforce_assertions),
                 "user": str(config.get("live", {}).get("user") or ""),
                 "scenario_path": str(scenario_path),
+                "live_event_capture": live_event_capture,
             },
         )
         _dump_json(output_dir / "remote_calls.json", remote_calls)
         _dump_json(output_dir / "remote_call_summary.json", remote_call_summary)
         _dump_json(output_dir / "candle_remote_fetches.json", candle_remote_fetches)
+        _dump_json(output_dir / "live_events.json", live_events)
         return output_dir
     finally:
         try:
-            if bot is not None:
+            if bot is not None and not bot_shutdown:
                 await shutdown_bot(bot)
         finally:
             try:
                 restore_candle_trace()
+            except Exception:
+                pass
+            try:
+                restore_live_event_capture()
             except Exception:
                 pass
             restore_user_override()

--- a/tests/test_run_fake_live.py
+++ b/tests/test_run_fake_live.py
@@ -13,6 +13,7 @@ import tools.run_fake_live as run_fake_live_module
 from fill_events_manager import FillEvent, FillEventCache
 from config_utils import load_config
 from exchanges.fake import FakeCCXTClient
+from live.event_bus import EventTypes, LiveEvent
 from passivbot import setup_bot
 from tools.run_fake_live import (
     _async_main,
@@ -100,6 +101,103 @@ async def test_run_fake_bot_advances_until_timeline_end():
     summaries = await _run_fake_bot(bot, client, max_steps=None)
     assert bot.loop_calls == 3
     assert [row["step_index"] for row in summaries] == [0, 1, 2]
+
+
+@pytest.mark.fake_live
+def test_live_event_capture_uses_isolated_pipeline_without_default_pipeline():
+    class _NoDefaultPipelineBot:
+        exchange = "fake"
+        user = "fake_capture"
+        bot_id = "fake_capture_bot"
+        _live_event_pipeline = None
+
+    bot = _NoDefaultPipelineBot()
+    sink, restore = run_fake_live_module._install_live_event_capture(bot)
+    pipeline = bot._live_event_pipeline
+    try:
+        assert pipeline.console_sink is None
+        assert pipeline.monitor_sinks == ()
+        assert pipeline.structured_sinks == (sink,)
+        assert pipeline.emit(LiveEvent(EventTypes.BOT_STARTED)) is not None
+        assert pipeline.flush(timeout=2.0) is True
+        assert [event.event_type for event in sink.events] == [EventTypes.BOT_STARTED]
+    finally:
+        restore()
+    assert bot._live_event_pipeline is None
+
+
+@pytest.mark.fake_live
+def test_live_event_capture_serialization_reports_truncation():
+    sink = run_fake_live_module._BoundedLiveEventSink(max_retained=2)
+    for event_type in (
+        EventTypes.BOT_STARTED,
+        EventTypes.BOT_READY,
+        EventTypes.CYCLE_COMPLETED,
+    ):
+        sink.write(LiveEvent(event_type, data={"token": "secret-token"}))
+
+    events, metadata = run_fake_live_module._serialize_live_event_capture(sink)
+
+    assert [event["event_type"] for event in events] == [
+        EventTypes.BOT_READY,
+        EventTypes.CYCLE_COMPLETED,
+    ]
+    assert all(event["data"]["token"] == "[redacted]" for event in events)
+    assert metadata == {"total": 3, "retained": 2, "truncated": 1, "max_retained": 2}
+
+
+@pytest.mark.asyncio
+@pytest.mark.fake_live
+async def test_fake_live_persists_events_when_console_pipeline_is_disabled(tmp_path, monkeypatch):
+    import passivbot_rust as pbr
+
+    if getattr(pbr, "__is_stub__", False):
+        pytest.skip("requires real passivbot_rust extension")
+
+    monkeypatch.setenv("PASSIVBOT_LIVE_EVENT_CONSOLE", "0")
+    user = f"fake_capture_only_{tmp_path.name}"
+    _cleanup_fake_user_state(user)
+    scenario = hjson.loads(
+        (REPO_ROOT / "scenarios" / "fake_live" / "hsl_long_red_restart.hjson").read_text(
+            encoding="utf-8"
+        )
+    )
+    scenario.pop("assertions", None)
+    scenario["run_initial_cycle"] = False
+    scenario_path = tmp_path / "capture_only.hjson"
+    scenario_path.write_text(hjson.dumps(scenario), encoding="utf-8")
+
+    try:
+        args = argparse.Namespace(
+            config=str(REPO_ROOT / "configs" / "fake_live_hsl_btc.hjson"),
+            scenario=str(scenario_path),
+            user=user,
+            max_steps=0,
+            output_dir=str(tmp_path),
+            log_level=1,
+            snapshot_each_step=False,
+        )
+        assert await _async_main(args) == 0
+        run_dir = next(path for path in tmp_path.iterdir() if path.is_dir())
+        artifacts = _load_run_artifacts(run_dir)
+        assert any(
+            event.get("event_type") == EventTypes.BOT_STARTED
+            for event in artifacts["live_events"]
+        )
+        assert any(
+            event.get("event_type") == EventTypes.BOT_STOPPING
+            for event in artifacts["live_events"]
+        )
+        assert any(
+            event.get("event_type") == EventTypes.BOT_STOPPED
+            for event in artifacts["live_events"]
+        )
+        capture = artifacts["run_metadata"]["live_event_capture"]
+        assert capture["total"] == capture["retained"] == len(artifacts["live_events"])
+        assert capture["truncated"] == 0
+        assert capture["max_retained"] == run_fake_live_module.MAX_CAPTURED_LIVE_EVENTS
+    finally:
+        _cleanup_fake_user_state(user)
 
 
 @pytest.mark.fake_live
@@ -654,6 +752,9 @@ def test_load_run_artifacts_reads_expected_files(tmp_path):
     (tmp_path / "candle_remote_fetches.json").write_text(
         json.dumps([{"kind": "ccxt_fetch_ohlcv"}]), encoding="utf-8"
     )
+    (tmp_path / "live_events.json").write_text(
+        json.dumps([{"event_type": "snapshot.built"}]), encoding="utf-8"
+    )
     (tmp_path / "fake_live.log").write_text("hello\n", encoding="utf-8")
 
     loaded = _load_run_artifacts(tmp_path)
@@ -663,6 +764,7 @@ def test_load_run_artifacts_reads_expected_files(tmp_path):
     assert loaded["remote_calls"][0]["method"] == "fetch_balance"
     assert loaded["remote_call_summary"]["total_calls"] == 1
     assert loaded["candle_remote_fetches"][0]["kind"] == "ccxt_fetch_ohlcv"
+    assert loaded["live_events"][0]["event_type"] == "snapshot.built"
     assert loaded["log_text"] == "hello\n"
 
 
@@ -970,12 +1072,63 @@ async def test_coin_hsl_restart_scenario_uses_protective_supervisor(tmp_path):
         assert len(run_dirs) == 1
         artifacts = _load_run_artifacts(run_dirs[0])
         assert artifacts["positions"] == []
-        assert any(
-            fill.get("symbol") == "BTC/USDT:USDT"
+        events = artifacts["live_events"]
+        panic_close_idx = next(
+            idx
+            for idx, event in enumerate(events)
+            if event.get("event_type") == "execution.create_succeeded"
+            and event.get("symbol") == "BTC/USDT:USDT"
+            and event.get("pside") == "long"
+            and event.get("data", {}).get("pb_order_type") == "close_panic_long"
+            and event.get("data", {}).get("reduce_only") is True
+            and event.get("data", {}).get("result_status") == "closed"
+        )
+        panic_close = events[panic_close_idx]
+        panic_client_order_id = panic_close.get("client_order_id")
+        assert panic_client_order_id
+        panic_fill = next(
+            fill
+            for fill in artifacts["fills"]
+            if fill.get("clientOrderId") == panic_client_order_id
+            and fill.get("symbol") == "BTC/USDT:USDT"
             and fill.get("position_side") == "long"
             and fill.get("side") == "sell"
             and fill.get("reduceOnly") is True
-            for fill in artifacts["fills"]
+        )
+        assert panic_fill["id"] not in {"10", "11", "12"}
+        post_panic_positions_packet_idx = next(
+            idx
+            for idx, event in enumerate(events[panic_close_idx + 1 :], panic_close_idx + 1)
+            if event.get("event_type") == "data_packet.updated"
+            and event.get("data", {}).get("kind") == "positions"
+            and event.get("data", {}).get("coverage", {}).get("row_count") == 0
+        )
+        post_panic_positions_packet = events[post_panic_positions_packet_idx]["data"]
+        healthy_snapshot = next(
+            event
+            for event in events[post_panic_positions_packet_idx + 1 :]
+            if event.get("event_type") == "snapshot.built"
+            and event.get("data", {}).get("planning_availability", {}).get("status_counts", {}).get(
+                "unavailable", 0
+            )
+            == 0
+            and event.get("data", {}).get("planning_availability", {}).get(
+                "record_count", 0
+            )
+            > 0
+            and event.get("data", {}).get("planning_availability", {}).get(
+                "status_counts", {}
+            ).get("available", 0)
+            == event.get("data", {}).get("planning_availability", {}).get("record_count", 0)
+        )
+        assert any(
+            packet.get("kind") == "positions"
+            and packet.get("revision", 0) >= post_panic_positions_packet["revision"]
+            for packet in healthy_snapshot["data"]["data_packets"]
+        )
+        assert all(
+            event.get("event_type") != EventTypes.PLANNING_UNAVAILABLE
+            for event in events[panic_close_idx + 1 :]
         )
     finally:
         _cleanup_fake_user_state(user)


### PR DESCRIPTION
## Summary
- persist a bounded in-memory capture of already-emitted redacted live-event envelopes for offline fake-live runs
- expose total, retained, truncated, and maximum-retained counts and include graceful shutdown events
- strengthen the coin-mode HSL RED regression by linking the panic fill to its create event and proving a later non-vacuous available snapshot without post-panic planning unavailability
- record the exact PR #1317 VPS5 deployment evidence and advance the logging-overhaul status

## Behavior boundary
- offline fake-exchange tooling, tests, and documentation only
- no new live event producers, exchange calls, HSL math, readiness gates, orders, risk behavior, config, console routing, or monitor persistence
- no VPS deployment or restart expected for this slice

## Validation
- full Python test suite passed against an isolated exact-source Rust extension
- `26 passed`: `tests/test_run_fake_live.py -m fake_live`
- `128 passed`: `tests/test_live_event_bus.py`
- `4 passed`: AI docs and generated live-event registry checks
- `210 passed`: `passivbot-rust/cargotest.sh`
- `py_compile` and `git diff --check` passed
- independent delta review found no remaining findings

## Safety
- no authenticated exchange calls
- no manufactured trading, risk, lock, or state events
- no live-process actions
