### PR TITLE
Fix fake-live shutdown monitor snapshot clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Fake-live scenario-time callbacks now retain their original offline fake
+  client through graceful shutdown. The final monitor snapshot can therefore
+  complete after the bot releases its public-session reference, without a
+  spurious `NoneType.now_ms` error or any change to live timekeeping, exchange
+  sessions, trading behavior, or event payloads.
+
 - Offline fake-live runs now retain the already-emitted redacted structured
   event envelopes as a run artifact. The coin-mode HSL RED regression uses that
   evidence to prove a panic fill is followed by an available planning snapshot

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,26 +22,33 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/fake-live-post-panic-observability`, based on canonical
-  `eb82e256c2dfeac29af158f389f93a7ddba8eae2` after PR #1317.
-- PR: #1318.
-- Scope: backlog item 15. Persist the already-emitted redacted structured
-  events as a fake-live run artifact, then make the existing coin-mode RED
-  scenario prove the post-panic data-packet/snapshot handoff stays available.
-- Behavior boundary: offline fake-exchange harness and tests only. No live
-  producer, HSL math, readiness gate, exchange adapter, order, risk, config,
-  console, monitor-persistence, or runtime behavior changes.
-- Validation: focused artifact capture, redaction, pipeline-flush, and
-  coin-mode RED/panic-fill/post-panic availability regressions plus the fake-live
-  suite. The test must fail if the recovered handoff emits
-  `planning.unavailable` or lacks a later available `snapshot.built` event.
+- Branch: `codex/fake-live-shutdown-monitor`, based on canonical
+  `8ca7f034bce7ffaaa99800590c88651de4d267c5` after PR #1318.
+- PR: not open yet.
+- Scope: repair the offline fake-live scenario clock retained by PR #1318's
+  graceful-shutdown event capture. The final monitor snapshot must remain able
+  to read scenario time after shutdown releases `bot.cca`.
+- Behavior boundary: offline fake-exchange harness, tests, changelog, and
+  compact project state only. No live time source, shutdown ordering, monitor
+  producer, event payload, HSL math, readiness gate, exchange adapter, order,
+  risk, config, console, monitor-persistence, or runtime behavior changes.
+- Validation: unit coverage for both retained fake-time callbacks after
+  `bot.cca` is cleared, an artifact-level graceful-shutdown regression proving
+  the monitor snapshot error is absent while terminal lifecycle events remain,
+  then the fake-live and relevant monitor/event suites.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
-  Python and Rust CI while Grok is halted.
+  Python and Rust CI while Grok is halted; additional Codex findings must still
+  be adjudicated.
 - Expected VPS action: none. The slice is offline tooling/tests/docs and must
   not contact an exchange, deploy code, or control live processes.
 
 ## Deployed Baseline
 
+- PR #1318 merged as canonical `8ca7f034bce7ffaaa99800590c88651de4d267c5`.
+  It adds bounded redacted structured-event artifacts and post-panic planning
+  availability proof to the offline fake-live harness. No VPS action was
+  warranted because it changes no live producer, runtime, exchange, order,
+  risk, or configuration behavior.
 - PR #1317 merged as canonical `eb82e256c2dfeac29af158f389f93a7ddba8eae2`.
   It adds bounded Hyperliquid unified-account composition diagnostics without
   changing scalar balance, exchange calls, planning, orders, risk, or console

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/fake-live-shutdown-monitor`, based on canonical
   `8ca7f034bce7ffaaa99800590c88651de4d267c5` after PR #1318.
-- PR: not open yet.
+- PR: #1319.
 - Scope: repair the offline fake-live scenario clock retained by PR #1318's
   graceful-shutdown event capture. The final monitor snapshot must remain able
   to read scenario time after shutdown releases `bot.cca`.

--- a/src/tools/run_fake_live.py
+++ b/src/tools/run_fake_live.py
@@ -462,9 +462,10 @@ def _prime_fake_candles(bot, fake_client: FakeCCXTClient) -> None:
 
 def _install_runtime_overrides(bot, scenario: dict) -> None:
     if hasattr(bot, "cca") and isinstance(bot.cca, FakeCCXTClient):
-        bot.get_exchange_time = lambda: int(bot.cca.now_ms)
+        fake_client = bot.cca
+        bot.get_exchange_time = lambda: int(fake_client.now_ms)
         if hasattr(bot, "cm"):
-            bot.cm._now_ms_callback = lambda: int(bot.cca.now_ms)
+            bot.cm._now_ms_callback = lambda: int(fake_client.now_ms)
 
 
 def _fake_active_red_psides(bot) -> List[str]:

--- a/tests/test_run_fake_live.py
+++ b/tests/test_run_fake_live.py
@@ -192,6 +192,7 @@ async def test_fake_live_persists_events_when_console_pipeline_is_disabled(tmp_p
             event.get("event_type") == EventTypes.BOT_STOPPED
             for event in artifacts["live_events"]
         )
+        assert "[monitor] failed building monitor snapshot" not in artifacts["log_text"]
         capture = artifacts["run_metadata"]["live_event_capture"]
         assert capture["total"] == capture["retained"] == len(artifacts["live_events"])
         assert capture["truncated"] == 0
@@ -608,11 +609,15 @@ def test_bot_params_to_rust_dict_ignores_removed_entry_grid_inflation_flag():
     assert out["unstuck_loss_allowance_pct"] == pytest.approx(0.025)
 
 
-def test_install_runtime_overrides_sets_exchange_time_override():
+def test_install_runtime_overrides_keep_scenario_time_after_client_shutdown():
     client = FakeCCXTClient(_scenario(), quote="USDT")
-    bot = type("Bot", (), {"cca": client})()
+    cm = type("CandlestickManager", (), {})()
+    bot = type("Bot", (), {"cca": client, "cm": cm})()
     _install_runtime_overrides(bot, {})
+    bot.cca = None
+
     assert bot.get_exchange_time() == client.now_ms
+    assert bot.cm._now_ms_callback() == client.now_ms
 
 
 def test_compare_run_artifacts_reports_no_diff_for_matching_payloads():


### PR DESCRIPTION
## Scope

- Category: read-only tooling
- Retain the original offline `FakeCCXTClient` as the scenario-time source for
  fake-live runtime callbacks.
- Add unit and artifact-level regression coverage for graceful shutdown after
  `bot.cca` is released.
- Update the changelog and compact logging-overhaul status.

## Behavior

The final fake-live monitor snapshot can still read scenario time after
`shutdown_gracefully()` closes and clears the bot's public-session reference.
This removes the spurious `NoneType.now_ms` monitor-build error while retaining
the terminal structured lifecycle events.

Non-goals: no changes to live timekeeping, shutdown ordering, monitor
production, event payloads, exchange adapters or calls, HSL/risk/order logic,
configuration, console behavior, or monitor persistence.

Expected VPS action: none. This is an offline fake-exchange harness and test
repair only.

## Validation

- `pytest tests/test_run_fake_live.py -q` (34 passed)
- `pytest tests/test_passivbot_monitor.py tests/test_live_event_bus.py tests/test_ai_docs.py tests/test_live_event_registry_docs.py -q` (passed)
- full `pytest -q` against isolated exact-source Rust extension (passed)
- `passivbot-rust/cargotest.sh` (210 passed)
- exact Rust source/stamp fingerprint: `11cc8d7d7361a435cfadd4a56c012dbe31719707a81a2bdec95c5566aa99c1f0`
- `py_compile`, `check_ai_docs.py`, generated event-registry check, and `git diff --check` (passed; existing AI-doc word-count warning only)

No authenticated exchange calls, deployments, or live process actions were
performed.

## Review Focus

- lifetime of the captured mutable fake scenario clock
- non-vacuity of the shutdown artifact regression
- preservation of the offline-only behavior boundary

Residual risk: `FakeCCXTClient.close()` is currently a no-op. If it later
invalidates scenario time, that contract and regression will need to change.
