### PR TITLE
Report event-pipeline integrity in live smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live smoke reports now include a bounded diagnostics-only event-pipeline
+  integrity verdict from each bot's latest health snapshot. Cumulative drops,
+  sink errors, and workers unexpectedly absent outside orderly pipeline shutdown
+  are explicit attention evidence; existing smoke, process, trading, and
+  top-level attention verdicts remain unchanged.
+
 - Fake-live scenario-time callbacks now retain their original offline fake
   client through graceful shutdown. The final monitor snapshot can therefore
   complete after the bot releases its public-session reference, without a

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,27 +22,56 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/fake-live-shutdown-monitor`, based on canonical
-  `8ca7f034bce7ffaaa99800590c88651de4d267c5` after PR #1318.
-- PR: #1319.
-- Scope: repair the offline fake-live scenario clock retained by PR #1318's
-  graceful-shutdown event capture. The final monitor snapshot must remain able
-  to read scenario time after shutdown releases `bot.cca`.
-- Behavior boundary: offline fake-exchange harness, tests, changelog, and
-  compact project state only. No live time source, shutdown ordering, monitor
-  producer, event payload, HSL math, readiness gate, exchange adapter, order,
-  risk, config, console, monitor-persistence, or runtime behavior changes.
-- Validation: unit coverage for both retained fake-time callbacks after
-  `bot.cca` is cleared, an artifact-level graceful-shutdown regression proving
-  the monitor snapshot error is absent while terminal lifecycle events remain,
-  then the fake-live and relevant monitor/event suites.
+- Branch: `codex/event-pipeline-integrity-smoke`, based on canonical
+  `0dbfbca74b029353a0e11888e71077fa711835ff` after PR #1314.
+- PR: #1320.
+- Scope: add a separate bounded diagnostic integrity verdict for the latest
+  structured-event pipeline snapshots. Event drops, sink errors, and a worker
+  that is dead outside orderly pipeline shutdown must be visible without
+  changing the existing trading/process smoke verdict.
+- Behavior boundary: read-only smoke report, concise/brief projections, tests,
+  changelog, and project state only. No event producer, queue, sink, monitor
+  persistence, console, exchange, order, risk, readiness, configuration, or
+  process-control behavior changes.
+- Validation: focused report/projection tests must prove loss is visible while
+  top-level `ok`, `attention`, and `hard_failures` retain their current
+  semantics; orderly shutdown must not create a false dead-worker incident.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted; additional Codex findings must still
   be adjudicated.
-- Expected VPS action: none. The slice is offline tooling/tests/docs and must
-  not contact an exchange, deploy code, or control live processes.
+- Expected VPS action: pull and bounded read-only report only after merge. The
+  slice is diagnostics-only and does not warrant a bot restart.
 
 ## Deployed Baseline
+
+- PR #1314 merged as canonical `0dbfbca74b029353a0e11888e71077fa711835ff`.
+  It records immutable runtime/Rust/config provenance and fill-to-runtime
+  attribution without changing strategy, order, risk, or exchange behavior.
+  PR #1319 had already merged as `84c8e040334820ccc049787c82048358e18179c6`
+  with its offline fake-live shutdown-clock repair and required no VPS action.
+- VPS5 fast-forwarded tracked-clean from `eb82e256c2` to the exact PR #1314
+  merge. A deliberately wrong Rust fingerprint failed closed before build or
+  signal. The exact target-derived fingerprint
+  `691bff9683deec9382a4e96ab6a107c14145f88edd6ae2f8e2380b8ba6824449`
+  then rebuilt and verified the loaded extension after restoring the explicit
+  `/root/.cargo/bin` non-login PATH.
+- The guarded runner stopped, exited, relaunched, and verified all five exact
+  panes without force. Bot PIDs
+  `1042130/1042139/1042133/1042142/1042136` became
+  `1044483/1044492/1044486/1044495/1044489`. The exact
+  `1784414260464..1784414921350` window selected 10/1,011 event segments and
+  `73414648` bytes with complete lifecycle, repository, target, monitor, and
+  text-log evidence, but correctly remained red on one natural KuCoin
+  authoritative-refresh `RequestTimeout` at `1784414448511`.
+- KuCoin subsequently emitted readiness evidence and successful authoritative
+  calls without intervention. The exact settled
+  `1784414681768..1784415199226` report was hard-green with zero hard problem
+  events, log matches, monitor errors, or process failures. Final target
+  sampling was 3/3 stable with states `R=3,S=2`, no extras or issues, and
+  protected `misc:0.0` remained `%8`/PID `434835`. No direct exchange request
+  or event was manufactured.
+
+## Previous Deployed Baseline (PRs #1318 And #1317)
 
 - PR #1318 merged as canonical `8ca7f034bce7ffaaa99800590c88651de4d267c5`.
   It adds bounded redacted structured-event artifacts and post-panic planning

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,36 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1317)
+## Latest Canonical Deployment (PR #1314; Through PR #1319)
+
+- PR #1319 merged as canonical `84c8e040334820ccc049787c82048358e18179c6`.
+  Its offline fake-live shutdown-clock repair changes no live runtime, producer,
+  exchange, strategy, or process behavior, so no VPS action was warranted.
+- PR #1314 then merged as canonical
+  `0dbfbca74b029353a0e11888e71077fa711835ff`. It records immutable runtime,
+  Rust, config, and fill-attribution provenance without changing strategy,
+  order, risk, or exchange behavior.
+- VPS5 fast-forwarded tracked-clean from `eb82e256c2`. A deliberately wrong
+  Rust fingerprint failed closed before build or signal. The exact
+  target-derived `691bff9683deec9382a4e96ab6a107c14145f88edd6ae2f8e2380b8ba6824449`
+  fingerprint rebuilt and verified the loaded extension after the non-login
+  shell PATH was explicitly bound to `/root/.cargo/bin`.
+- The guarded runner gracefully restarted only exact panes `%358`-`%362`
+  without force. Old PIDs `1042130/1042139/1042133/1042142/1042136` became
+  `1044483/1044492/1044486/1044495/1044489`. The bounded
+  `1784414260464..1784414921350` window selected 10/1,011 segments totaling
+  `73414648` bytes and retained complete lifecycle evidence, but correctly
+  remained red on one natural KuCoin authoritative-refresh `RequestTimeout`.
+- KuCoin recovered without intervention. The settled
+  `1784414681768..1784415199226` report was hard-green with zero hard problem
+  events, log matches, monitor errors, or process failures. Final target
+  sampling was 3/3 stable with no extras or issues; protected `misc:0.0`
+  remained `%8`/PID `434835`. No direct exchange request or event was
+  manufactured. The active follow-up exposes event-pipeline loss as a separate
+  diagnostics-only integrity verdict while preserving top-level smoke
+  semantics.
+
+## Previous Canonical Deployment (PR #1317)
 
 - PR #1317 merged as canonical `eb82e256c2dfeac29af158f389f93a7ddba8eae2`.
   It adds bounded Hyperliquid unified-account composition diagnostics without

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -4869,6 +4869,23 @@ def _summarize_event_pipeline_health(
         }
         for group in ordered[:EVENT_PIPELINE_HEALTH_GROUP_LIMIT]
     ]
+    integrity_sources = {
+        "drops": sum(
+            int(group.get("latest_dropped_total") or 0) for group in groups.values()
+        ),
+        "sink_errors": sum(
+            int(group.get("latest_sink_error_total") or 0)
+            for group in groups.values()
+        ),
+        "unexpectedly_dead_workers": sum(
+            1
+            for group in groups.values()
+            if group.get("latest_worker_alive") is False
+            and group.get("latest_pipeline_stopping") is not True
+        ),
+    }
+    integrity_sources["total"] = sum(integrity_sources.values())
+    integrity_attention_count = int(integrity_sources["total"])
     out = {
         "total": sum(int(group.get("count", 0)) for group in groups.values()),
         "groups_truncated": len(ordered) > EVENT_PIPELINE_HEALTH_GROUP_LIMIT,
@@ -4897,6 +4914,12 @@ def _summarize_event_pipeline_health(
         "latest_stopping_count": sum(
             1 for group in groups.values() if group.get("latest_pipeline_stopping") is True
         ),
+        "integrity": {
+            "ok": integrity_attention_count == 0,
+            "attention": integrity_attention_count > 0,
+            "attention_count": integrity_attention_count,
+            "source_counts": integrity_sources,
+        },
         "groups": compact_groups,
     }
     processed_counts = [
@@ -9838,6 +9861,7 @@ def _summary_limited_groups(
                 "latest_worker_not_alive_count"
             ),
             "latest_stopping_count": summary.get("latest_stopping_count"),
+            "integrity": summary.get("integrity"),
             "latest_cpu_percent_max": summary.get("latest_cpu_percent_max"),
             "latest_cpu_reporting_bots": summary.get("latest_cpu_reporting_bots"),
             "latest_memory_percent_max": summary.get("latest_memory_percent_max"),
@@ -11725,6 +11749,7 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
                 "latest_stopping_count": _count_value(
                     event_pipeline_health.get("latest_stopping_count")
                 ),
+                "integrity": event_pipeline_health.get("integrity"),
                 "event_types": event_pipeline_health.get("event_types") or {},
             }.items()
             if value is not None

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -668,6 +668,17 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         "latest_degraded_total": 3,
         "latest_worker_not_alive_count": 1,
         "latest_stopping_count": 1,
+        "integrity": {
+            "ok": False,
+            "attention": True,
+            "attention_count": 3,
+            "source_counts": {
+                "drops": 2,
+                "sink_errors": 1,
+                "unexpectedly_dead_workers": 0,
+                "total": 3,
+            },
+        },
         "event_types": {"health.summary": 1},
     }
     assert report["smoke_report"]["shutdown_events"] == {

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2883,12 +2883,24 @@ def test_live_smoke_report_summarizes_event_pipeline_health(tmp_path):
     assert health["groups"][0]["latest_sink_error_counts"] == {"monitor": 1}
     assert health["groups"][0]["latest_worker_alive"] is False
     assert health["groups"][0]["latest_pipeline_stopping"] is True
+    assert health["integrity"] == {
+        "ok": False,
+        "attention": True,
+        "attention_count": 3,
+        "source_counts": {
+            "drops": 2,
+            "sink_errors": 1,
+            "unexpectedly_dead_workers": 0,
+            "total": 3,
+        },
+    }
     assert report["ok"] is True
     assert report["hard_failures"] == 0
     assert summary["event_pipeline_health"]["total"] == 2
     assert summary["event_pipeline_health"]["groups"][0]["latest_ids"] == {
         "cycle_id": "cy_health_2"
     }
+    assert summary["event_pipeline_health"]["integrity"] == health["integrity"]
     assert brief["event_pipeline"] == {
         "total": 2,
         "bots": 1,
@@ -2899,6 +2911,7 @@ def test_live_smoke_report_summarizes_event_pipeline_health(tmp_path):
         "latest_degraded_total": 3,
         "latest_worker_not_alive_count": 1,
         "latest_stopping_count": 1,
+        "integrity": health["integrity"],
         "event_types": {"health.summary": 2},
     }
 
@@ -3187,11 +3200,23 @@ def test_live_smoke_report_event_pipeline_health_aggregates_multi_bot_queue_over
         "order.created": 5,
     }
     assert health["groups"][1]["latest_sink_error_counts"] == {"structured": 2}
+    assert health["integrity"] == {
+        "ok": False,
+        "attention": True,
+        "attention_count": 10,
+        "source_counts": {
+            "drops": 7,
+            "sink_errors": 3,
+            "unexpectedly_dead_workers": 0,
+            "total": 10,
+        },
+    }
     assert report["ok"] is True
     assert report["attention"] is False
     assert summary["event_pipeline_health"]["total"] == 3
     assert summary["event_pipeline_health"]["groups_truncated"] is True
     assert summary["event_pipeline_health"]["groups"][0]["bot"] == "okx/okx_01"
+    assert summary["event_pipeline_health"]["integrity"] == health["integrity"]
     assert brief["event_pipeline"] == {
         "total": 3,
         "bots": 2,
@@ -3202,7 +3227,116 @@ def test_live_smoke_report_event_pipeline_health_aggregates_multi_bot_queue_over
         "latest_degraded_total": 6,
         "latest_worker_not_alive_count": 1,
         "latest_stopping_count": 1,
+        "integrity": health["integrity"],
         "event_types": {"health.summary": 3},
+    }
+
+
+def test_live_smoke_report_event_pipeline_integrity_is_diagnostic_only(tmp_path):
+    events_dir = tmp_path / "monitor" / "okx" / "okx_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="health.summary",
+                seq=1,
+                ts=1000,
+                level="debug",
+                reason_code="periodic_health_summary",
+                data={
+                    "event_dropped_total": 4,
+                    "event_sink_error_total": 3,
+                    "event_degraded_count": 99,
+                    "event_pipeline_stopping": False,
+                    "event_pipeline_worker_alive": False,
+                },
+            )
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    summary = summarize_live_smoke_report(report)
+    brief = summarize_live_smoke_report_brief(report)
+    section = project_live_smoke_report_sections(report, ["event_pipeline"])
+
+    expected = {
+        "ok": False,
+        "attention": True,
+        "attention_count": 8,
+        "source_counts": {
+            "drops": 4,
+            "sink_errors": 3,
+            "unexpectedly_dead_workers": 1,
+            "total": 8,
+        },
+    }
+    assert report["event_pipeline_health"]["integrity"] == expected
+    assert summary["event_pipeline_health"]["integrity"] == expected
+    assert brief["event_pipeline"]["integrity"] == expected
+    assert section["event_pipeline_health"]["integrity"] == expected
+    assert report["ok"] is True
+    assert report["attention"] is False
+    assert report["attention_sources"] == {
+        "problem_events": 0,
+        "log_attention_matches": 0,
+        "dropped_unparsed_attention_matches": 0,
+        "total": 0,
+    }
+
+
+def test_live_smoke_report_event_pipeline_integrity_ignores_orderly_shutdown_worker(
+    tmp_path,
+):
+    events_dir = tmp_path / "monitor" / "okx" / "okx_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="health.summary",
+                seq=1,
+                ts=1000,
+                level="debug",
+                reason_code="periodic_health_summary",
+                data={
+                    "event_pipeline_stopping": True,
+                    "event_pipeline_worker_alive": False,
+                },
+            )
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+
+    assert report["event_pipeline_health"]["integrity"] == {
+        "ok": True,
+        "attention": False,
+        "attention_count": 0,
+        "source_counts": {
+            "drops": 0,
+            "sink_errors": 0,
+            "unexpectedly_dead_workers": 0,
+            "total": 0,
+        },
+    }
+    assert report["ok"] is True
+    assert report["attention"] is False
+
+
+def test_live_smoke_report_event_pipeline_integrity_without_pipeline_evidence_is_neutral(
+    tmp_path,
+):
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+
+    assert report["event_pipeline_health"]["integrity"] == {
+        "ok": True,
+        "attention": False,
+        "attention_count": 0,
+        "source_counts": {
+            "drops": 0,
+            "sink_errors": 0,
+            "unexpectedly_dead_workers": 0,
+            "total": 0,
+        },
     }
 
 


### PR DESCRIPTION
## Scope

Category: read-only tooling / observability report.

- Add a bounded `event_pipeline_health.integrity` verdict from each bot's latest pipeline snapshot.
- Report cumulative event drops, sink errors, and workers unexpectedly not alive outside orderly pipeline shutdown.
- Project the same verdict through full, concise, brief, section, and incident-bundle outputs.
- Record PR #1314 deployment and settled VPS5 evidence in the active logging-overhaul state.

## Behavior

This is diagnostics-only. Existing top-level smoke `ok`, `attention`, `hard_failures`, process/trading interpretation, event production, queue/sink behavior, monitor persistence, exchange access, orders, risk, readiness, configuration, and process control are unchanged.

No pipeline evidence remains a neutral green diagnostic result. A worker that is not alive while `event_pipeline_stopping=true` is excluded from unexpected-dead-worker attention.

Expected VPS action after merge: pull and bounded read-only report; no bot restart.

## Validation

- `pytest -q tests/test_live_smoke_report.py tests/test_live_incident_bundle.py tests/test_live_restart_smoke_collection.py tests/test_live_restart_smoke_evidence.py tests/test_live_restart_smoke_orchestrator.py tests/test_live_restart_smoke_plan.py tests/test_ai_docs.py`
- `PYTHONPATH=src python src/tools/check_ai_docs.py` (0 errors; existing word-budget warning)
- `python -m py_compile src/live/smoke_report.py`
- `git diff --check`

The affected integration suite passed after updating the incident-bundle exact projection.

## Deploy Evidence Recorded

PR #1314 deployed at `0dbfbca74b029353a0e11888e71077fa711835ff`. The exact five-pane restart completed without force. Its initial 600-second window retained one natural KuCoin authoritative-refresh `RequestTimeout`; the exact settled `1784414681768..1784415199226` window was hard-green. Final targets were 3/3 stable with no extras, and `misc:0.0` remained unchanged.

## Reviewer Focus

- Cumulative-count semantics versus the latest snapshot per bot.
- Orderly shutdown exclusion for a non-alive worker.
- Preservation of existing top-level smoke verdicts.
- Bounded projection consistency across report consumers.
