### PR TITLE
Validate per-bot shutdown lifecycle evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Shutdown evidence in live smoke reports now distinguishes complete and
+  incomplete latest shutdown lifecycles per bot. Restart smoke validation uses
+  distinct complete bots instead of aggregate event counts, so duplicate
+  stopping or stopped events from one bot cannot satisfy a multi-bot restart
+  gate; general smoke verdicts and live runtime behavior remain unchanged.
+
 - Live smoke reports now include a bounded diagnostics-only event-pipeline
   integrity verdict from each bot's latest health snapshot. Cumulative drops,
   sink errors, and workers unexpectedly absent outside orderly pipeline shutdown

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/shutdown-lifecycle-completeness`, based on canonical
   `bc2c90267be418344ec883fcf17fae856bc568cd` after PR #1320.
-- PR: pending.
+- PR: #1321.
 - Scope: derive the latest bounded shutdown lifecycle per observed bot and make
   restart evidence require distinct complete bot lifecycles instead of
   aggregate `bot.stopping` and `bot.stopped` counts.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,27 +22,45 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/event-pipeline-integrity-smoke`, based on canonical
-  `0dbfbca74b029353a0e11888e71077fa711835ff` after PR #1314.
-- PR: #1320.
-- Scope: add a separate bounded diagnostic integrity verdict for the latest
-  structured-event pipeline snapshots. Event drops, sink errors, and a worker
-  that is dead outside orderly pipeline shutdown must be visible without
-  changing the existing trading/process smoke verdict.
-- Behavior boundary: read-only smoke report, concise/brief projections, tests,
-  changelog, and project state only. No event producer, queue, sink, monitor
-  persistence, console, exchange, order, risk, readiness, configuration, or
-  process-control behavior changes.
-- Validation: focused report/projection tests must prove loss is visible while
-  top-level `ok`, `attention`, and `hard_failures` retain their current
-  semantics; orderly shutdown must not create a false dead-worker incident.
+- Branch: `codex/shutdown-lifecycle-completeness`, based on canonical
+  `bc2c90267be418344ec883fcf17fae856bc568cd` after PR #1320.
+- PR: pending.
+- Scope: derive the latest bounded shutdown lifecycle per observed bot and make
+  restart evidence require distinct complete bot lifecycles instead of
+  aggregate `bot.stopping` and `bot.stopped` counts.
+- Behavior boundary: read-only smoke report, restart-evidence evaluation,
+  concise/brief projections, tests, changelog, and project state only. No event
+  producer, monitor persistence, console, exchange, order, risk, readiness,
+  configuration, restart execution, or process-control behavior changes.
+- Validation: focused report/projection tests must prove duplicate events from
+  one bot cannot satisfy a multi-bot restart gate, incomplete latest lifecycles
+  remain visible, out-of-order input is handled by canonical event ordering,
+  and top-level smoke verdicts retain their current semantics.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
-  Python and Rust CI while Grok is halted; additional Codex findings must still
-  be adjudicated.
+  Python and Rust CI while Grok is halted. Repository automatic Codex review is
+  additional; any findings it posts must still be adjudicated.
 - Expected VPS action: pull and bounded read-only report only after merge. The
   slice is diagnostics-only and does not warrant a bot restart.
 
 ## Deployed Baseline
+
+- PR #1320 merged as canonical
+  `bc2c90267be418344ec883fcf17fae856bc568cd`. It adds a separate bounded
+  event-pipeline integrity diagnostic for cumulative drops, sink errors, and
+  workers unexpectedly dead outside orderly shutdown, without changing the
+  general smoke or trading/process verdicts.
+- VPS5 fast-forwarded tracked-clean from PR #1314 without a Rust build, bot
+  restart, or process signal. The exact five target PIDs and pane parents were
+  unchanged, target sampling remained 3/3 stable with no extras or issues, and
+  protected `misc:0.0` remained `%8`/PID `434835`.
+- The merged report showed integrity green for all five bots with zero drops,
+  sink errors, unexpectedly dead workers, queue backlog, unfinished work, or
+  degraded pipeline counters. The wider smoke retained natural KuCoin
+  `RequestTimeout` events instead of hiding them; the latest affected cycle
+  subsequently completed successfully without intervention. No direct exchange
+  request, process action, or event was manufactured.
+
+## Previous Deployed Baseline (PR #1314)
 
 - PR #1314 merged as canonical `0dbfbca74b029353a0e11888e71077fa711835ff`.
   It records immutable runtime/Rust/config provenance and fill-to-runtime

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,26 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1314; Through PR #1319)
+## Latest Canonical Deployment (PR #1320; Through PR #1319)
+
+- PR #1320 merged as canonical
+  `bc2c90267be418344ec883fcf17fae856bc568cd` after exact-head Hermes approval
+  and green Python/Rust CI. It exposes event-pipeline drops, sink errors, and
+  unexpectedly dead workers through a separate bounded diagnostic integrity
+  verdict while preserving general smoke and trading/process semantics.
+- VPS5 fast-forwarded tracked-clean from PR #1314 without a Rust build, bot
+  restart, or process signal. Exact five-bot target sampling remained 3/3
+  stable with unchanged PIDs and no extras or issues; protected `misc:0.0`
+  remained `%8`/PID `434835`.
+- All five latest pipeline snapshots were integrity-green with zero drops, sink
+  errors, unexpectedly dead workers, backlog, unfinished work, or degraded
+  counters. The wider report retained natural KuCoin `RequestTimeout` events;
+  the latest affected cycle subsequently completed successfully without
+  intervention. No direct exchange request, process action, or event was
+  manufactured. The active follow-up makes bounded shutdown evidence complete
+  per distinct bot rather than trusting aggregate lifecycle counts.
+
+## Previous Canonical Deployment (PR #1314; Through PR #1319)
 
 - PR #1319 merged as canonical `84c8e040334820ccc049787c82048358e18179c6`.
   Its offline fake-live shutdown-clock repair changes no live runtime, producer,

--- a/src/live/restart_smoke_evidence.py
+++ b/src/live/restart_smoke_evidence.py
@@ -315,17 +315,42 @@ def _shutdown_gate(report: dict[str, Any], *, expected_targets: int) -> dict[str
     shutdown = shutdown if isinstance(shutdown, dict) else {}
     event_types = shutdown.get("event_types")
     event_types = event_types if isinstance(event_types, dict) else {}
+    lifecycle = shutdown.get("lifecycle")
+    lifecycle = lifecycle if isinstance(lifecycle, dict) else {}
     stopping_count = _count(event_types.get("bot.stopping"))
     stopped_count = _count(event_types.get("bot.stopped"))
+    observed_bots = _count(lifecycle.get("observed_bots"))
+    complete_bots = _count(lifecycle.get("complete_bots"))
+    incomplete_bots = _count(lifecycle.get("incomplete_bots"))
+    lifecycle_counts_valid = (
+        lifecycle.get("proof_scope") == "distinct_observed_bots"
+        and lifecycle.get("coverage_complete") is True
+        and lifecycle.get("identity_complete") is True
+        and _is_non_negative_int(lifecycle.get("invalid_identity_events"))
+        and _count(lifecycle.get("invalid_identity_events")) == 0
+        and _is_non_negative_int(lifecycle.get("observed_bots"))
+        and _is_non_negative_int(lifecycle.get("complete_bots"))
+        and _is_non_negative_int(lifecycle.get("incomplete_bots"))
+        and observed_bots == complete_bots + incomplete_bots
+    )
     return {
         "ok": (
             _is_non_negative_int(event_types.get("bot.stopping"))
             and _is_non_negative_int(event_types.get("bot.stopped"))
             and stopping_count >= expected_targets
             and stopped_count >= expected_targets
+            and lifecycle_counts_valid
+            and complete_bots >= expected_targets
         ),
         "stopping_count": stopping_count,
         "stopped_count": stopped_count,
+        "observed_bots": observed_bots,
+        "complete_bots": complete_bots,
+        "incomplete_bots": incomplete_bots,
+        "proof_scope": lifecycle.get("proof_scope"),
+        "coverage_complete": lifecycle.get("coverage_complete"),
+        "identity_complete": lifecycle.get("identity_complete"),
+        "invalid_identity_events": _count(lifecycle.get("invalid_identity_events")),
     }
 
 

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -6120,7 +6120,35 @@ def _shutdown_event_group(
             for key in ("cycle_id", "snapshot_id", "plan_id", "action_id")
             if ids.get(key) is not None
         },
+        "_identity_valid": _shutdown_event_identity_valid(live_event, row),
     }
+
+
+def _shutdown_event_identity_valid(
+    live_event: dict[str, Any], row: dict[str, Any]
+) -> bool:
+    live_exchange = live_event.get("exchange")
+    live_user = live_event.get("user")
+    row_exchange = row.get("exchange")
+    row_user = row.get("user")
+    if live_exchange not in (None, "") and row_exchange not in (None, ""):
+        if live_exchange != row_exchange:
+            return False
+    if live_user not in (None, "") and row_user not in (None, ""):
+        if live_user != row_user:
+            return False
+    exchange = live_exchange or row_exchange
+    user = live_user or row_user
+    return (
+        type(exchange) is str
+        and type(user) is str
+        and bool(exchange.strip())
+        and bool(user.strip())
+        and len(exchange) <= 120
+        and len(user) <= 120
+        and exchange not in {"unknown_exchange", "unknown"}
+        and user not in {"unknown_user", "unknown"}
+    )
 
 
 def _merge_shutdown_event_group(
@@ -6168,6 +6196,8 @@ def _merge_shutdown_event_group(
 def _summarize_shutdown_events(
     groups: dict[tuple[Any, ...], dict[str, Any]],
     event_type_counts: Counter[str],
+    *,
+    coverage_complete: bool,
 ) -> dict[str, Any]:
     ordered = sorted(
         groups.values(),
@@ -6183,16 +6213,94 @@ def _summarize_shutdown_events(
         {
             key: value
             for key, value in group.items()
-            if key not in {"latest_path", "latest_line", "latest_seq"}
+            if key
+            not in {"latest_path", "latest_line", "latest_seq", "_identity_valid"}
             and value not in (None, {}, [])
         }
         for group in ordered[:SHUTDOWN_EVENT_GROUP_LIMIT]
     ]
+    lifecycle = _summarize_shutdown_lifecycle(
+        groups,
+        coverage_complete=coverage_complete,
+    )
     return {
         "total": sum(int(group.get("count", 0)) for group in groups.values()),
         "groups_truncated": len(ordered) > SHUTDOWN_EVENT_GROUP_LIMIT,
         "event_types": dict(event_type_counts.most_common()),
         "groups": compact_groups,
+        "lifecycle": lifecycle,
+    }
+
+
+def _shutdown_event_position(group: dict[str, Any]) -> tuple[int, int, str, int]:
+    return _sort_event_position_key(
+        ts=group.get("latest_ts"),
+        seq=group.get("latest_seq"),
+        path=group.get("latest_path") or "",
+        line_no=int(group.get("latest_line") or 0),
+    )
+
+
+def _summarize_shutdown_lifecycle(
+    groups: dict[tuple[Any, ...], dict[str, Any]],
+    *,
+    coverage_complete: bool,
+) -> dict[str, Any]:
+    """Project the latest in-window stop boundary for each observed bot."""
+    boundaries_by_bot: dict[str, dict[str, dict[str, Any]]] = {}
+    invalid_identity_events = 0
+    for group in groups.values():
+        event_type = group.get("event_type")
+        if event_type not in {EventTypes.BOT_STOPPING, EventTypes.BOT_STOPPED}:
+            continue
+        if group.get("_identity_valid") is not True:
+            invalid_identity_events += int(group.get("count") or 0)
+            continue
+        bot = str(group.get("bot") or "unknown")
+        boundaries = boundaries_by_bot.setdefault(bot, {})
+        previous = boundaries.get(str(event_type))
+        if previous is None or _shutdown_event_position(group) > _shutdown_event_position(
+            previous
+        ):
+            boundaries[str(event_type)] = group
+
+    rows: list[dict[str, Any]] = []
+    for bot, boundaries in boundaries_by_bot.items():
+        stopping = boundaries.get(EventTypes.BOT_STOPPING)
+        stopped = boundaries.get(EventTypes.BOT_STOPPED)
+        stopping_position = _shutdown_event_position(stopping or {})
+        stopped_position = _shutdown_event_position(stopped or {})
+        complete = (
+            stopping is not None
+            and stopped is not None
+            and stopped_position > stopping_position
+        )
+        latest = stopped if stopped_position > stopping_position else stopping
+        row = {
+            "bot": _redact_log_text(bot, max_len=120),
+            "state": "complete" if complete else "incomplete",
+            "latest_boundary": "stopped" if latest is stopped else "stopping",
+            "latest_ts": latest.get("latest_ts") if isinstance(latest, dict) else None,
+        }
+        rows.append({key: value for key, value in row.items() if value is not None})
+    rows.sort(
+        key=lambda row: (
+            -int(_non_negative_int(row.get("latest_ts")) or 0),
+            str(row.get("bot") or ""),
+        )
+    )
+    complete_bots = sum(1 for row in rows if row.get("state") == "complete")
+    retained_rows = rows[:SHUTDOWN_EVENT_GROUP_LIMIT]
+    return {
+        "proof_scope": "distinct_observed_bots",
+        "coverage_complete": bool(coverage_complete),
+        "identity_complete": invalid_identity_events == 0,
+        "invalid_identity_events": invalid_identity_events,
+        "observed_bots": len(rows),
+        "complete_bots": complete_bots,
+        "incomplete_bots": len(rows) - complete_bots,
+        "rows_truncated": len(rows) > SHUTDOWN_EVENT_GROUP_LIMIT,
+        "rows": retained_rows,
     }
 
 
@@ -9163,6 +9271,15 @@ def _scan_events(
         "shutdown_events": _summarize_shutdown_events(
             shutdown_event_groups,
             shutdown_event_type_counts,
+            coverage_complete=(
+                event_tail_limited_files == 0
+                and event_files_skipped_by_limit == 0
+                and invalid_window_ts == 0
+                and (
+                    segment_selection is None
+                    or segment_selection.get("complete") is True
+                )
+            ),
         ),
         "event_window": _event_window_report(
             since_ms=since_ms,
@@ -10521,7 +10638,44 @@ def summarize_live_smoke_report(
         "shutdown_events": _summary_limited_groups(
             shutdown_events,
             limit=max_groups,
-        ),
+        )
+        | {
+            "lifecycle": {
+                "proof_scope": (shutdown_events.get("lifecycle") or {}).get(
+                    "proof_scope"
+                ),
+                "coverage_complete": (shutdown_events.get("lifecycle") or {}).get(
+                    "coverage_complete"
+                ),
+                "identity_complete": (shutdown_events.get("lifecycle") or {}).get(
+                    "identity_complete"
+                ),
+                "invalid_identity_events": _count_value(
+                    (shutdown_events.get("lifecycle") or {}).get(
+                        "invalid_identity_events"
+                    )
+                ),
+                "observed_bots": _count_value(
+                    (shutdown_events.get("lifecycle") or {}).get("observed_bots")
+                ),
+                "complete_bots": _count_value(
+                    (shutdown_events.get("lifecycle") or {}).get("complete_bots")
+                ),
+                "incomplete_bots": _count_value(
+                    (shutdown_events.get("lifecycle") or {}).get("incomplete_bots")
+                ),
+                "rows": ((shutdown_events.get("lifecycle") or {}).get("rows") or [])[
+                    :max_groups
+                ],
+                "rows_truncated": len(
+                    (shutdown_events.get("lifecycle") or {}).get("rows") or []
+                )
+                > max_groups
+                or bool(
+                    (shutdown_events.get("lifecycle") or {}).get("rows_truncated")
+                ),
+            }
+        },
     }
 
 
@@ -11812,6 +11966,10 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
         "shutdown_events": {
             "total": _count_value(shutdown_events.get("total")),
             "event_types": shutdown_events.get("event_types") or {},
+            "lifecycle": {
+                key: _count_value((shutdown_events.get("lifecycle") or {}).get(key))
+                for key in ("observed_bots", "complete_bots", "incomplete_bots")
+            },
         },
     }
 

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -6189,6 +6189,7 @@ def _merge_shutdown_event_group(
             "latest_message",
             "latest_data",
             "latest_ids",
+            "_identity_valid",
         ):
             existing[field] = group.get(field)
 
@@ -6198,6 +6199,7 @@ def _summarize_shutdown_events(
     event_type_counts: Counter[str],
     *,
     coverage_complete: bool,
+    invalid_identity_events: int,
 ) -> dict[str, Any]:
     ordered = sorted(
         groups.values(),
@@ -6222,6 +6224,7 @@ def _summarize_shutdown_events(
     lifecycle = _summarize_shutdown_lifecycle(
         groups,
         coverage_complete=coverage_complete,
+        invalid_identity_events=invalid_identity_events,
     )
     return {
         "total": sum(int(group.get("count", 0)) for group in groups.values()),
@@ -6245,16 +6248,15 @@ def _summarize_shutdown_lifecycle(
     groups: dict[tuple[Any, ...], dict[str, Any]],
     *,
     coverage_complete: bool,
+    invalid_identity_events: int,
 ) -> dict[str, Any]:
     """Project the latest in-window stop boundary for each observed bot."""
     boundaries_by_bot: dict[str, dict[str, dict[str, Any]]] = {}
-    invalid_identity_events = 0
     for group in groups.values():
         event_type = group.get("event_type")
         if event_type not in {EventTypes.BOT_STOPPING, EventTypes.BOT_STOPPED}:
             continue
         if group.get("_identity_valid") is not True:
-            invalid_identity_events += int(group.get("count") or 0)
             continue
         bot = str(group.get("bot") or "unknown")
         boundaries = boundaries_by_bot.setdefault(bot, {})
@@ -8680,6 +8682,7 @@ def _scan_events(
     risk_event_type_counts: Counter[str] = Counter()
     shutdown_event_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     shutdown_event_type_counts: Counter[str] = Counter()
+    shutdown_invalid_identity_events = 0
     problem_event_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     if max_event_file_count_per_bot and files:
         event_files_before_limit = len(files)
@@ -9055,15 +9058,22 @@ def _scan_events(
                         )
                     if event_type in SHUTDOWN_EVENT_TYPES:
                         shutdown_event_type_counts[str(event_type)] += 1
+                        shutdown_group = _shutdown_event_group(
+                            bot_key=bot_key,
+                            row=row,
+                            live_event=live_event,
+                            path=path,
+                            line_no=line_no,
+                        )
+                        if (
+                            event_type
+                            in {EventTypes.BOT_STOPPING, EventTypes.BOT_STOPPED}
+                            and shutdown_group.get("_identity_valid") is not True
+                        ):
+                            shutdown_invalid_identity_events += 1
                         _merge_shutdown_event_group(
                             shutdown_event_groups,
-                            _shutdown_event_group(
-                                bot_key=bot_key,
-                                row=row,
-                                live_event=live_event,
-                                path=path,
-                                line_no=line_no,
-                            ),
+                            shutdown_group,
                         )
                     level = live_event.get("level")
                     if level:
@@ -9271,6 +9281,7 @@ def _scan_events(
         "shutdown_events": _summarize_shutdown_events(
             shutdown_event_groups,
             shutdown_event_type_counts,
+            invalid_identity_events=shutdown_invalid_identity_events,
             coverage_complete=(
                 event_tail_limited_files == 0
                 and event_files_skipped_by_limit == 0

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -684,6 +684,11 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
     assert report["smoke_report"]["shutdown_events"] == {
         "total": 1,
         "event_types": {"bot.shutdown.stage": 1},
+        "lifecycle": {
+            "observed_bots": 0,
+            "complete_bots": 0,
+            "incomplete_bots": 0,
+        },
     }
     assert report["smoke_report"]["remote_calls"] == {
         "total": 1,

--- a/tests/test_live_restart_smoke_collection.py
+++ b/tests/test_live_restart_smoke_collection.py
@@ -102,7 +102,17 @@ def _smoke_report(*, head: str = HEAD, attention: bool = False) -> dict:
             "samples": ["secret log line"],
         },
         "shutdown_events": {
-            "event_types": {"bot.stopping": 2, "bot.stopped": 2}
+            "event_types": {"bot.stopping": 2, "bot.stopped": 2},
+            "lifecycle": {
+                "proof_scope": "distinct_observed_bots",
+                "coverage_complete": True,
+                "identity_complete": True,
+                "invalid_identity_events": 0,
+                "observed_bots": 2,
+                "complete_bots": 2,
+                "incomplete_bots": 0,
+                "rows": [],
+            },
         },
         "startup_timings": [
             {"bot": "private/bot-one", "phases": {"startup": {}}},

--- a/tests/test_live_restart_smoke_evidence.py
+++ b/tests/test_live_restart_smoke_evidence.py
@@ -109,7 +109,17 @@ def _smoke_report(*, targets: int = 2) -> dict:
             "window": _window(),
         },
         "shutdown_events": {
-            "event_types": {"bot.stopping": targets, "bot.stopped": targets}
+            "event_types": {"bot.stopping": targets, "bot.stopped": targets},
+            "lifecycle": {
+                "proof_scope": "distinct_observed_bots",
+                "coverage_complete": True,
+                "identity_complete": True,
+                "invalid_identity_events": 0,
+                "observed_bots": targets,
+                "complete_bots": targets,
+                "incomplete_bots": 0,
+                "rows": [],
+            },
         },
         "startup_timings": [
             {"bot": f"venue/bot_{index}", "phases": {"startup": {}}}
@@ -404,6 +414,59 @@ def test_evaluator_rejects_missing_shutdown_and_startup_evidence():
 
     assert report["ok"] is False
     assert {"shutdown_evidence_missing", "startup_evidence_missing"} <= _codes(report)
+
+
+def test_evaluator_rejects_duplicate_shutdown_events_from_one_bot():
+    smoke = _smoke_report()
+    smoke["shutdown_events"] = {
+        "event_types": {"bot.stopping": 2, "bot.stopped": 2},
+        "lifecycle": {
+            "proof_scope": "distinct_observed_bots",
+            "coverage_complete": True,
+            "identity_complete": True,
+            "invalid_identity_events": 0,
+            "observed_bots": 1,
+            "complete_bots": 1,
+            "incomplete_bots": 0,
+            "rows": [],
+        },
+    }
+
+    report = _evaluate(smoke_report=smoke)
+
+    assert report["ok"] is False
+    assert report["gates"]["shutdown"] == {
+        "ok": False,
+        "stopping_count": 2,
+        "stopped_count": 2,
+        "observed_bots": 1,
+        "complete_bots": 1,
+        "incomplete_bots": 0,
+        "proof_scope": "distinct_observed_bots",
+        "coverage_complete": True,
+        "identity_complete": True,
+        "invalid_identity_events": 0,
+    }
+    assert "shutdown_evidence_missing" in _codes(report)
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("coverage_complete", False),
+        ("identity_complete", False),
+        ("invalid_identity_events", 1),
+        ("proof_scope", "expected_bot_identities"),
+    ],
+)
+def test_evaluator_rejects_incomplete_or_invalid_shutdown_lifecycle(key, value):
+    smoke = _smoke_report()
+    smoke["shutdown_events"]["lifecycle"][key] = value
+
+    report = _evaluate(smoke_report=smoke)
+
+    assert report["ok"] is False
+    assert "shutdown_evidence_missing" in _codes(report)
 
 
 def test_attention_evidence_remains_green():

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -5878,6 +5878,23 @@ def test_live_smoke_report_shutdown_lifecycle_excludes_inconsistent_identity(
     assert lifecycle["observed_bots"] == 0
 
 
+def test_live_smoke_report_shutdown_lifecycle_refreshes_merged_identity_validity(
+    tmp_path,
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    valid = _monitor_row(event_type="bot.stopping", seq=1, ts=1000)
+    invalid = _monitor_row(event_type="bot.stopping", seq=2, ts=2000)
+    invalid["user"] = "other_user"
+    _write_ndjson(events_dir / "current.ndjson", [valid, invalid])
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+
+    lifecycle = report["shutdown_events"]["lifecycle"]
+    assert lifecycle["identity_complete"] is False
+    assert lifecycle["invalid_identity_events"] == 1
+    assert lifecycle["observed_bots"] == 0
+
+
 def test_live_smoke_report_shutdown_lifecycle_rows_are_bounded(tmp_path):
     monitor_root = tmp_path / "monitor"
     for index in range(smoke_report_module.SHUTDOWN_EVENT_GROUP_LIMIT + 1):

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -5740,6 +5740,24 @@ def test_live_smoke_report_summarizes_shutdown_events(tmp_path):
         "bot.shutdown.stage": 1,
         "bot.stopped": 1,
     }
+    assert report["shutdown_events"]["lifecycle"] == {
+        "proof_scope": "distinct_observed_bots",
+        "coverage_complete": True,
+        "identity_complete": True,
+        "invalid_identity_events": 0,
+        "observed_bots": 1,
+        "complete_bots": 1,
+        "incomplete_bots": 0,
+        "rows_truncated": False,
+        "rows": [
+            {
+                "bot": "binance/binance_01",
+                "state": "complete",
+                "latest_boundary": "stopped",
+                "latest_ts": 3000,
+            }
+        ],
+    }
     assert [group["event_type"] for group in report["shutdown_events"]["groups"]] == [
         "bot.stopped",
         "bot.shutdown.stage",
@@ -5757,6 +5775,9 @@ def test_live_smoke_report_summarizes_shutdown_events(tmp_path):
     assert summary["shutdown_events"]["total"] == 3
     assert summary["shutdown_events"]["groups_truncated"] is True
     assert len(summary["shutdown_events"]["groups"]) == 2
+    assert summary["shutdown_events"]["lifecycle"] == report["shutdown_events"]["lifecycle"] | {
+        "rows_truncated": False
+    }
     assert brief["shutdown_events"] == {
         "total": 3,
         "event_types": {
@@ -5764,7 +5785,242 @@ def test_live_smoke_report_summarizes_shutdown_events(tmp_path):
             "bot.shutdown.stage": 1,
             "bot.stopped": 1,
         },
+        "lifecycle": {
+            "observed_bots": 1,
+            "complete_bots": 1,
+            "incomplete_bots": 0,
+        },
     }
+
+
+def test_live_smoke_report_shutdown_lifecycle_is_neutral_without_boundaries(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [_monitor_row(event_type="cycle.completed", seq=1, ts=1000)],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    brief = summarize_live_smoke_report_brief(report)
+
+    assert report["ok"] is True
+    assert report["attention"] is False
+    assert report["hard_failures"] == 0
+    assert report["shutdown_events"]["lifecycle"] == {
+        "proof_scope": "distinct_observed_bots",
+        "coverage_complete": True,
+        "identity_complete": True,
+        "invalid_identity_events": 0,
+        "observed_bots": 0,
+        "complete_bots": 0,
+        "incomplete_bots": 0,
+        "rows_truncated": False,
+        "rows": [],
+    }
+    assert brief["shutdown_events"]["lifecycle"] == {
+        "observed_bots": 0,
+        "complete_bots": 0,
+        "incomplete_bots": 0,
+    }
+
+
+def test_live_smoke_report_shutdown_lifecycle_excludes_unknown_identities(tmp_path):
+    events_dir = tmp_path / "monitor" / "unknown_exchange" / "unknown_user" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.stopping",
+                seq=1,
+                ts=1000,
+                exchange="unknown_exchange",
+                user="unknown_user",
+            ),
+            _monitor_row(
+                event_type="bot.stopped",
+                seq=2,
+                ts=2000,
+                exchange="unknown_exchange",
+                user="unknown_user",
+            ),
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+
+    assert report["ok"] is True
+    assert report["shutdown_events"]["lifecycle"] == {
+        "proof_scope": "distinct_observed_bots",
+        "coverage_complete": True,
+        "identity_complete": False,
+        "invalid_identity_events": 2,
+        "observed_bots": 0,
+        "complete_bots": 0,
+        "incomplete_bots": 0,
+        "rows_truncated": False,
+        "rows": [],
+    }
+
+
+def test_live_smoke_report_shutdown_lifecycle_excludes_inconsistent_identity(
+    tmp_path,
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    row = _monitor_row(event_type="bot.stopping", seq=1, ts=1000)
+    row["payload"]["_live_event"]["user"] = "other_user"
+    _write_ndjson(events_dir / "current.ndjson", [row])
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+
+    lifecycle = report["shutdown_events"]["lifecycle"]
+    assert lifecycle["identity_complete"] is False
+    assert lifecycle["invalid_identity_events"] == 1
+    assert lifecycle["observed_bots"] == 0
+
+
+def test_live_smoke_report_shutdown_lifecycle_rows_are_bounded(tmp_path):
+    monitor_root = tmp_path / "monitor"
+    for index in range(smoke_report_module.SHUTDOWN_EVENT_GROUP_LIMIT + 1):
+        events_dir = monitor_root / "binance" / f"bot_{index:02d}" / "events"
+        _write_ndjson(
+            events_dir / "current.ndjson",
+            [
+                _monitor_row(
+                    event_type="bot.stopping",
+                    seq=index + 1,
+                    ts=1000 + index,
+                    user=f"bot_{index:02d}",
+                )
+            ],
+        )
+
+    report = build_live_smoke_report(monitor_root, logs_root=None)
+    lifecycle = report["shutdown_events"]["lifecycle"]
+
+    assert lifecycle["observed_bots"] == smoke_report_module.SHUTDOWN_EVENT_GROUP_LIMIT + 1
+    assert lifecycle["rows_truncated"] is True
+    assert len(lifecycle["rows"]) == smoke_report_module.SHUTDOWN_EVENT_GROUP_LIMIT
+
+
+def test_live_smoke_report_shutdown_lifecycle_marks_tail_limited_coverage_incomplete(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.stopping", seq=1, ts=1000),
+            _monitor_row(event_type="bot.stopped", seq=2, ts=2000),
+        ],
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        event_tail_lines=1,
+    )
+
+    lifecycle = report["shutdown_events"]["lifecycle"]
+    assert lifecycle["coverage_complete"] is False
+    assert lifecycle["observed_bots"] == 1
+    assert lifecycle["complete_bots"] == 0
+
+
+def test_live_smoke_report_shutdown_lifecycle_uses_latest_event_position_across_files(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.stopping",
+                seq=30,
+                ts=1000,
+                user="complete",
+            ),
+            _monitor_row(
+                event_type="bot.stopping",
+                seq=40,
+                ts=4000,
+                user="incomplete",
+            ),
+        ],
+    )
+    _write_ndjson(
+        events_dir / "2026-07-10T00-00-00.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.stopped",
+                seq=20,
+                ts=2000,
+                user="complete",
+            ),
+            _monitor_row(
+                event_type="bot.stopped",
+                seq=10,
+                ts=3000,
+                user="incomplete",
+            ),
+        ],
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        include_rotated=True,
+        max_event_files_per_bot=2,
+    )
+
+    assert report["shutdown_events"]["lifecycle"] == {
+        "proof_scope": "distinct_observed_bots",
+        "coverage_complete": True,
+        "identity_complete": True,
+        "invalid_identity_events": 0,
+        "observed_bots": 2,
+        "complete_bots": 1,
+        "incomplete_bots": 1,
+        "rows_truncated": False,
+        "rows": [
+            {
+                "bot": "binance/incomplete",
+                "state": "incomplete",
+                "latest_boundary": "stopping",
+                "latest_ts": 4000,
+            },
+            {
+                "bot": "binance/complete",
+                "state": "complete",
+                "latest_boundary": "stopped",
+                "latest_ts": 2000,
+            },
+        ],
+    }
+
+
+def test_live_smoke_report_shutdown_lifecycle_does_not_reuse_older_completion(
+    tmp_path,
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.stopping", seq=1, ts=1000),
+            _monitor_row(event_type="bot.stopped", seq=2, ts=2000),
+            _monitor_row(event_type="bot.stopping", seq=3, ts=3000),
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+
+    lifecycle = report["shutdown_events"]["lifecycle"]
+    assert lifecycle["observed_bots"] == 1
+    assert lifecycle["complete_bots"] == 0
+    assert lifecycle["incomplete_bots"] == 1
+    assert lifecycle["rows"] == [
+        {
+            "bot": "binance/binance_01",
+            "state": "incomplete",
+            "latest_boundary": "stopping",
+            "latest_ts": 3000,
+        }
+    ]
 
 
 def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):


### PR DESCRIPTION
## Scope

- Category: read-only tooling.
- Derive the latest bounded `bot.stopping`/`bot.stopped` lifecycle per observed bot in live smoke reports.
- Require distinct complete bot lifecycles in restart-smoke evidence instead of trusting aggregate event counts.
- Project bounded lifecycle counts through full, concise, brief, and incident-bundle smoke output.
- Record PR #1320 deployment evidence and the active logging slice.

## Behavior boundary

- General smoke `ok`, `attention`, and `hard_failures` semantics are unchanged.
- No live event producer, monitor persistence, exchange call, strategy, order, risk, readiness, configuration, restart execution, or process-control behavior changes.
- Restart evidence now fails closed on duplicate one-bot event inflation, incomplete scan coverage, or invalid/inconsistent bot identity. The proof scope is explicitly distinct observed bot count; the supervisor contract does not expose expected exchange/user identities.

## Validation

- Full `pytest -q` passed.
- All smoke, incident-bundle, restart executor, target, plan, collection, evidence, and orchestrator tests passed.
- `src/tools/check_ai_docs.py` passed with 0 errors and the existing aggregate word-count warning.
- `git diff --check` passed.
- Exact loaded Rust extension verified after repository-helper rebuild: source/stamp `b3ab1ec2b16b5c6ecb98eedad30c2db796dcd38555cfcf75a0d561dd53198f2b`, artifact `955f7c4f955fca19288fbbdf34ca2c18549315cb9906a0cae9bd20b17c1c8efa`. No Rust source changed.

## Reviewer focus

- Latest-boundary ordering across rotated files and repeated shutdown cohorts.
- Fail-closed coverage and identity validation in restart evidence.
- Bounded projections and preservation of general smoke verdict semantics.

## VPS action

After merge: fast-forward the tracked-clean VPS5 checkout and run a bounded read-only report. No bot restart is warranted.