### PR TITLE
Deduplicate bounded runtime attribution identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool runtime-attribution` now reconciles the producer's exact
+  12-character lowercase-hex startup-log run-id prefix with one complete
+  manifest or startup-event identity when exchange, user, prefix, and start time
+  agree within two seconds. Ambiguous, incomplete, malformed, or out-of-bound
+  observations remain separate; the read-only tool still does not contact
+  exchanges or control bots.
+
 - Shutdown evidence in live smoke reports now distinguishes complete and
   incomplete latest shutdown lifecycles per bot. Restart smoke validation uses
   distinct complete bots instead of aggregate event counts, so duplicate

--- a/docs/ai/features/runtime_attribution.md
+++ b/docs/ai/features/runtime_attribution.md
@@ -19,8 +19,11 @@ The report keeps two claims separate:
 Legacy fills without embedded provenance remain explicitly unattributed. The
 tool never assigns them to the runtime that happened to read or re-save them.
 Legacy startup banners can establish a runtime window without establishing a
-version. Bounded startup hash prefixes merge with a full manifest/event identity
-only when account, start timestamp, and run-id prefix agree uniquely.
+version. A bounded startup-log run-id prefix merges with a complete
+manifest/event identity only when it is the producer's exact 12-character,
+lowercase-hex `uuid4().hex[:12]` form; exchange, user, and prefix agree
+uniquely; and their start timestamps differ by at most two seconds. Ambiguous,
+incomplete, malformed, or out-of-bound identities remain separate observations.
 
 ## Inputs And Output
 

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,25 +22,49 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/historical-runtime-attribution`, merged with canonical
-  `fc9dad83cd3ecf51cae15e8dda66afb7cfb895a1` at
-  `d351cd2c7f489ff56edaf2679e16aff6a57e5bb6`.
-- PR: #1315.
-- Scope: bounded, read-only local attribution of fill caches and monitor fill
-  history to recorded first-ingestion provenance and non-proving runtime-window
-  candidates.
-- Behavior boundary: offline attribution tool, CLI wiring, docs, and tests only.
-  No trading, exchange, runtime producer, order, risk, config, restart, or
-  process behavior changes.
-- Validation: focused attribution and CLI tests must preserve legacy fills as
-  unattributed, recognize canonical `first_ingested_by_runtime` provenance, and
-  retain bounded, fail-closed scans.
-- Review gate: current-head review is pending on the final integrated branch
-  after its documentation evidence is committed.
-- Expected VPS action: tracked-clean pull plus a bounded read-only attribution
-  smoke after merge. The tool is local-only and does not require a bot restart.
+- Branch: `codex/runtime-attribution-log-dedup`, based exactly on PR #1315's
+  canonical merge `308702523760ae7a0b309419ae1616b0a4938721`.
+- Scope: reconcile the producer's exact 12-character lowercase-hex startup-log
+  `uuid4().hex[:12]` prefix with one complete runtime manifest/event identity
+  when exchange, user, prefix, and a two-second maximum start-time skew agree.
+  Ambiguous, incomplete, malformed, out-of-scope, and out-of-bound records
+  remain separate.
+- Triggering PR #1315 deployment/smoke evidence: the full manifest started at
+  `1784414326269` ms while its matching bounded startup log used
+  `1784414328000` ms with the same run-id prefix, a `1731` ms skew that produced
+  duplicate runtime observations.
+- Behavior boundary: offline attribution parsing, docs, and tests only. No
+  trading, exchange, runtime producer, order, risk, config, restart, or process
+  behavior changes.
+- Validation: focused attribution tests cover the observed `1731` ms pair, the
+  inclusive two-second limit, short/uppercase prefixes, incomplete identities,
+  scope isolation, and ambiguity.
+- Review gate: final exact-head Hermes approval plus green Python/Rust CI.
+  Built-in Codex automatic review is additional, not a replacement for either.
+- Expected VPS action: after merge, a bounded read-only attribution smoke only;
+  no bot restart is required.
 
-## Deployed Baseline
+## Deployed Baseline (PR #1315)
+
+- PR #1315 merged as canonical
+  `308702523760ae7a0b309419ae1616b0a4938721`. The guarded tracked-clean
+  fast-forward was `fc9dad83` to the exact merge; the exact target-derived Rust
+  fingerprint/stamp
+  `691bff9683deec9382a4e96ab6a107c14145f88edd6ae2f8e2380b8ba6824449` matched
+  without a Rust build, bot restart, or signal.
+- The bounded Hyperliquid attribution smoke selected 13 files totaling
+  `3695111` bytes, scanned 50 fills with 37 trailing, and reported zero warnings.
+  All 37 legacy first-ingestion and 37 producer-attribution records correctly
+  remained unattributed.
+- The same smoke observed the full manifest start `1784414326269` ms and its
+  matching startup-log prefix at `1784414328000` ms, exposing the `1731` ms
+  second-resolution duplicate-runtime condition addressed by the active slice.
+- Bot PIDs `1044483/1044492/1044486/1044495/1044489` remained unchanged;
+  protected `misc:0.0` remained pane `%8`/PID `434835`. Final exact target
+  sampling retained those PIDs in normal `R/S` states with a tracked-clean
+  checkout. No direct exchange call or event was manufactured.
+
+## Previous Deployed Baseline (PR #1321)
 
 - PR #1321 deployed as canonical
   `fc9dad83cd3ecf51cae15e8dda66afb7cfb895a1`. It completes distinct latest

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,8 +22,9 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/runtime-attribution-log-dedup`, based exactly on PR #1315's
-  canonical merge `308702523760ae7a0b309419ae1616b0a4938721`.
+- Branch: `codex/runtime-attribution-log-dedup`, integrated with canonical
+  `8b433cc22b087b0efab51ba2bcf003f1e2b31806` after the semantic slice was
+  based on PR #1315's merge `308702523760ae7a0b309419ae1616b0a4938721`.
 - Scope: reconcile the producer's exact 12-character lowercase-hex startup-log
   `uuid4().hex[:12]` prefix with one complete runtime manifest/event identity
   when exchange, user, prefix, and a two-second maximum start-time skew agree.
@@ -44,7 +45,31 @@ Estimated completion:
 - Expected VPS action: after merge, a bounded read-only attribution smoke only;
   no bot restart is required.
 
-## Deployed Baseline (PR #1315)
+## Deployed Baseline (PR #1312)
+
+- PR #1312 merged as canonical
+  `8b433cc22b087b0efab51ba2bcf003f1e2b31806`. The guarded tracked-clean
+  fast-forward from `30870252` required no Rust build; source fingerprint and
+  compiled stamp remained
+  `691bff9683deec9382a4e96ab6a107c14145f88edd6ae2f8e2380b8ba6824449`,
+  with artifact SHA-256
+  `7611f3eff1d8702ff29d90490a1aba490db5c816e7e3f09a2c33e5c4085da023`.
+- The guarded runner gracefully restarted only exact panes `%358`-`%362`
+  without force. Old bot PIDs
+  `1044483/1044492/1044486/1044495/1044489` became
+  `1048663/1048672/1048666/1048675/1048669`; pane parents and protected
+  `misc:0.0` `%8`/PID `434835` were unchanged.
+- The exact `1784426343279..1784426527215` lifecycle window retained complete
+  five-bot shutdown/startup proof and one naturally emitted hard event rather
+  than hiding it. A fresh `1784426762780..1784426882865` window had zero smoke
+  hard failures, log errors, or monitor errors. The subsequent ordinary
+  two-minute report was hard-green with `46/46` account-critical calls
+  successful, successful latest observed cycles, and no latest degraded cycle.
+- Final target sampling was 3/3 stable with five exact processes, no missing,
+  duplicate, or extra targets, and a tracked-clean repository. No direct
+  exchange request or event was manufactured.
+
+## Previous Deployed Baseline (PR #1315)
 
 - PR #1315 merged as canonical
   `308702523760ae7a0b309419ae1616b0a4938721`. The guarded tracked-clean

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,23 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1315)
+## Latest Canonical Deployment (PR #1312)
+
+- PR #1312 merged as canonical `8b433cc22b087b0efab51ba2bcf003f1e2b31806`.
+  Guarded tracked-clean fast-forwarded `30870252` to that exact merge without a
+  Rust build; source fingerprint/stamp remained `691bff9683deec9382a4e96ab6a107c14145f88edd6ae2f8e2380b8ba6824449`.
+- The guarded runner gracefully restarted only panes `%358`-`%362` without
+  force. Bot PIDs `1044483/1044492/1044486/1044495/1044489` became
+  `1048663/1048672/1048666/1048675/1048669`; pane parents and protected
+  `misc:0.0` `%8`/PID `434835` were unchanged.
+- The complete five-bot lifecycle window retained one natural hard event. A
+  fresh settled window had zero smoke hard failures, log errors, or monitor
+  errors, and the ordinary two-minute report was hard-green with `46/46`
+  account-critical calls successful and no latest degraded cycle. Final exact
+  target sampling was 3/3 stable with no extras or issues. No direct exchange
+  request or event was manufactured.
+
+## Previous Canonical Deployment (PR #1315)
 
 - PR #1315 merged as canonical `308702523760ae7a0b309419ae1616b0a4938721`.
   Guarded tracked-clean fast-forwarded `fc9dad83` to that exact merge after the

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,24 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1321)
+## Latest Canonical Deployment (PR #1315)
+
+- PR #1315 merged as canonical `308702523760ae7a0b309419ae1616b0a4938721`.
+  Guarded tracked-clean fast-forwarded `fc9dad83` to that exact merge after the
+  target Rust fingerprint/stamp
+  `691bff9683deec9382a4e96ab6a107c14145f88edd6ae2f8e2380b8ba6824449` matched;
+  no Rust build, bot restart, or signal was needed.
+- The bounded Hyperliquid attribution smoke selected 13 files/`3695111` bytes,
+  scanned 50 fills (37 trailing), and had zero warnings. All 37 legacy
+  first-ingestion and 37 producer-attribution records remained correctly
+  unattributed; the full manifest `1784414326269` ms and matching prefix log
+  `1784414328000` ms exposed the `1731` ms duplicate-runtime condition.
+- Bot PIDs `1044483/1044492/1044486/1044495/1044489` and protected `misc:0.0`
+  `%8`/PID `434835` were unchanged. Final exact sampling retained normal `R/S`
+  states and a tracked-clean checkout; no direct exchange call or event was
+  manufactured.
+
+## Previous Canonical Deployment (PR #1321)
 
 - PR #1321 merged as canonical
   `fc9dad83cd3ecf51cae15e8dda66afb7cfb895a1`. It completes bounded latest

--- a/src/live/runtime_attribution.py
+++ b/src/live/runtime_attribution.py
@@ -19,6 +19,7 @@ DEFAULT_MAX_TOTAL_BYTES = 2 * 1024 * 1024 * 1024
 DEFAULT_MAX_FILLS = 250_000
 MAX_REPORTED_WARNINGS = 200
 MAX_SOURCES_PER_RECORD = 32
+MAX_RUNTIME_LOG_START_SKEW_MS = 2_000
 
 _RUNTIME_KEYS = (
     "schema_version",
@@ -40,6 +41,10 @@ _RUNTIME_LINE_RE = re.compile(
     r"\[runtime\]\s+run=(?P<run_id>\S+)\s+pb=(?P<version>\S+)\s+"
     r"python=(?P<python>\S+)\s+config=(?P<config>\S+)\s+"
     r"rust_source=(?P<rust_source>\S+)\s+rust_artifact=(?P<rust_artifact>\S+)"
+)
+_RUNTIME_LOG_RUN_ID_PREFIX_RE = re.compile(r"^[0-9a-f]{12}$")
+_FULL_RUNTIME_IDENTITY_SOURCE_KINDS = frozenset(
+    {"runtime_manifest", "monitor_manifest", "monitor_event"}
 )
 
 
@@ -507,6 +512,30 @@ def _collect_logs(roots: Sequence[Path], budget: ScanBudget) -> list[dict[str, A
     return records
 
 
+def _is_full_manifest_or_event_identity(record: Mapping[str, Any]) -> bool:
+    identity = record.get("identity")
+    if not isinstance(identity, Mapping) or any(
+        identity.get(key) in (None, "", "unknown") for key in _RUNTIME_KEYS
+    ):
+        return False
+    sources = record.get("sources")
+    return isinstance(sources, list) and any(
+        isinstance(source, Mapping)
+        and source.get("kind") in _FULL_RUNTIME_IDENTITY_SOURCE_KINDS
+        for source in sources
+    )
+
+
+def _has_bounded_runtime_log_identity(record: Mapping[str, Any]) -> bool:
+    if _RUNTIME_LOG_RUN_ID_PREFIX_RE.fullmatch(str(record.get("run_id") or "")) is None:
+        return False
+    sources = record.get("sources")
+    return isinstance(sources, list) and any(
+        isinstance(source, Mapping) and source.get("kind") == "runtime_log"
+        for source in sources
+    )
+
+
 def _merge_runtimes(records: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
     ordered = sorted(
         records,
@@ -552,22 +581,23 @@ def _merge_runtimes(records: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
                 _append_source(target, source)
             merged.remove(legacy)
 
-    # Bounded startup log lines carry hash/run-id prefixes; merge them into the
-    # full manifest/event identity when the scope and start timestamp agree.
+    # Producer logs uuid4().hex[:12] at second resolution. Join that prefix only
+    # to one complete manifest/event identity in the same scope.
     for partial in list(merged):
         partial_id = str(partial["run_id"])
+        if not _has_bounded_runtime_log_identity(partial):
+            continue
         candidates = [
             item
             for item in merged
             if item is not partial
             and item["exchange"] == partial["exchange"]
             and item["user"] == partial["user"]
-            and abs(item["started_at_ms"] - partial["started_at_ms"]) <= 1_000
-            and (
-                str(item["run_id"]).startswith(partial_id)
-                or partial_id.startswith(str(item["run_id"]))
-            )
+            and abs(item["started_at_ms"] - partial["started_at_ms"])
+            <= MAX_RUNTIME_LOG_START_SKEW_MS
+            and str(item["run_id"]).startswith(partial_id)
             and len(str(item["run_id"])) > len(partial_id)
+            and _is_full_manifest_or_event_identity(item)
         ]
         if len(candidates) != 1:
             continue

--- a/src/live/runtime_attribution.py
+++ b/src/live/runtime_attribution.py
@@ -43,6 +43,7 @@ _RUNTIME_LINE_RE = re.compile(
     r"rust_source=(?P<rust_source>\S+)\s+rust_artifact=(?P<rust_artifact>\S+)"
 )
 _RUNTIME_LOG_RUN_ID_PREFIX_RE = re.compile(r"^[0-9a-f]{12}$")
+_FULL_RUNTIME_RUN_ID_RE = re.compile(r"^[0-9a-f]{32}$")
 _FULL_RUNTIME_IDENTITY_SOURCE_KINDS = frozenset(
     {"runtime_manifest", "monitor_manifest", "monitor_event"}
 )
@@ -518,6 +519,12 @@ def _is_full_manifest_or_event_identity(record: Mapping[str, Any]) -> bool:
         identity.get(key) in (None, "", "unknown") for key in _RUNTIME_KEYS
     ):
         return False
+    run_id = str(record.get("run_id") or "")
+    if (
+        _FULL_RUNTIME_RUN_ID_RE.fullmatch(run_id) is None
+        or identity.get("run_id") != run_id
+    ):
+        return False
     sources = record.get("sources")
     return isinstance(sources, list) and any(
         isinstance(source, Mapping)
@@ -527,7 +534,10 @@ def _is_full_manifest_or_event_identity(record: Mapping[str, Any]) -> bool:
 
 
 def _has_bounded_runtime_log_identity(record: Mapping[str, Any]) -> bool:
-    if _RUNTIME_LOG_RUN_ID_PREFIX_RE.fullmatch(str(record.get("run_id") or "")) is None:
+    if (
+        _RUNTIME_LOG_RUN_ID_PREFIX_RE.fullmatch(str(record.get("run_id") or ""))
+        is None
+    ):
         return False
     sources = record.get("sources")
     return isinstance(sources, list) and any(

--- a/tests/test_runtime_attribution.py
+++ b/tests/test_runtime_attribution.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -37,6 +38,32 @@ def _roots(tmp_path: Path) -> dict:
         "monitor_roots": [tmp_path / "monitor"],
         "log_roots": [tmp_path / "logs"],
     }
+
+
+def _log_timestamp(timestamp_ms: int) -> str:
+    return datetime.fromtimestamp(timestamp_ms / 1000, tz=timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+
+def _write_runtime_log(
+    path: Path,
+    *,
+    timestamp_ms: int,
+    exchange: str,
+    user: str,
+    run_id_prefix: str,
+    marker: str,
+) -> None:
+    timestamp = _log_timestamp(timestamp_ms)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"{timestamp} INFO     ║  PASSIVBOT  │  {exchange}:{user}  │  now  ║\n"
+        f"{timestamp} INFO     [runtime] run={run_id_prefix} pb=8.0.0 "
+        f"python={marker * 12} config={marker * 12} rust_source={marker * 12} "
+        f"rust_artifact={marker * 12}\n",
+        encoding="utf-8",
+    )
 
 
 def test_report_separates_recorded_ingestion_from_producer_candidate(tmp_path: Path):
@@ -136,18 +163,17 @@ def test_trailing_filter_and_monitor_fill_deduplication(tmp_path: Path):
     }
 
 
-def test_runtime_log_prefix_merges_with_full_manifest_identity(tmp_path: Path):
+def test_runtime_log_prefix_merges_with_full_manifest_identity_at_live_skew(tmp_path: Path):
     roots = _roots(tmp_path)
-    identity = _identity("1234567890abcdef", 1_000, "c")
+    identity = _identity("1234567890abcdef", 1_784_414_326_269, "c")
     _write_json(tmp_path / "runtime" / "bybit" / "alice" / "run.json", identity)
-    log_path = tmp_path / "logs" / "alice.log"
-    log_path.parent.mkdir(parents=True)
-    log_path.write_text(
-        "1970-01-01T00:00:01Z INFO     ║  PASSIVBOT  │  bybit:alice  │  now  ║\n"
-        "1970-01-01T00:00:01Z INFO     [runtime] run=1234567890ab pb=8.0.0 "
-        "python=cccccccccccc config=cccccccccccc rust_source=cccccccccccc "
-        "rust_artifact=cccccccccccc\n",
-        encoding="utf-8",
+    _write_runtime_log(
+        tmp_path / "logs" / "alice.log",
+        timestamp_ms=1_784_414_328_000,
+        exchange="bybit",
+        user="alice",
+        run_id_prefix="1234567890ab",
+        marker="c",
     )
 
     report = build_runtime_attribution_report(**roots)
@@ -160,6 +186,156 @@ def test_runtime_log_prefix_merges_with_full_manifest_identity(tmp_path: Path):
         "runtime_manifest",
         "legacy_startup_log",
     }
+
+
+@pytest.mark.parametrize(
+    ("manifest_started_at_ms", "expected_runtime_count"),
+    [(1_000, 1), (999, 2)],
+    ids=["exact_two_second_limit_merges", "one_ms_over_limit_stays_separate"],
+)
+def test_runtime_log_prefix_start_skew_boundary(
+    tmp_path: Path, manifest_started_at_ms: int, expected_runtime_count: int
+):
+    roots = _roots(tmp_path)
+    identity = _identity("abcdef0123456789", manifest_started_at_ms, "e")
+    _write_json(tmp_path / "runtime" / "bybit" / "alice" / "run.json", identity)
+    _write_runtime_log(
+        tmp_path / "logs" / "alice.log",
+        timestamp_ms=3_000,
+        exchange="bybit",
+        user="alice",
+        run_id_prefix="abcdef012345",
+        marker="e",
+    )
+
+    report = build_runtime_attribution_report(**roots)
+
+    assert report["summary"]["runtime_count"] == expected_runtime_count
+
+
+def test_runtime_log_prefix_does_not_merge_ambiguous_full_identities(tmp_path: Path):
+    roots = _roots(tmp_path)
+    _write_json(
+        tmp_path / "runtime" / "bybit" / "alice" / "run-1.json",
+        _identity("abcdef0123456789", 5_000, "f"),
+    )
+    _write_json(
+        tmp_path / "runtime" / "bybit" / "alice" / "run-2.json",
+        _identity("abcdef012345fedc", 6_000, "g"),
+    )
+    _write_runtime_log(
+        tmp_path / "logs" / "alice.log",
+        timestamp_ms=7_000,
+        exchange="bybit",
+        user="alice",
+        run_id_prefix="abcdef012345",
+        marker="f",
+    )
+
+    report = build_runtime_attribution_report(**roots)
+
+    assert report["summary"]["runtime_count"] == 3
+    assert {runtime["run_id"] for runtime in report["runtimes"]} == {
+        "abcdef0123456789",
+        "abcdef012345fedc",
+        "abcdef012345",
+    }
+
+
+@pytest.mark.parametrize(
+    ("run_id", "run_id_prefix"),
+    [
+        ("abcdef0123456789", "abcdef01234"),
+        ("ABCDEF0123456789", "ABCDEF012345"),
+    ],
+    ids=["short_prefix", "uppercase_prefix"],
+)
+def test_runtime_log_prefix_requires_producer_shape(
+    tmp_path: Path, run_id: str, run_id_prefix: str
+):
+    roots = _roots(tmp_path)
+    _write_json(
+        tmp_path / "runtime" / "bybit" / "alice" / "run.json",
+        _identity(run_id, 5_000, "i"),
+    )
+    _write_runtime_log(
+        tmp_path / "logs" / "alice.log",
+        timestamp_ms=7_000,
+        exchange="bybit",
+        user="alice",
+        run_id_prefix=run_id_prefix,
+        marker="i",
+    )
+
+    report = build_runtime_attribution_report(**roots)
+
+    assert report["summary"]["runtime_count"] == 2
+    assert {runtime["run_id"] for runtime in report["runtimes"]} == {run_id, run_id_prefix}
+
+
+@pytest.mark.parametrize("source_kind", ["manifest", "monitor_event"])
+def test_runtime_log_prefix_does_not_merge_incomplete_canonical_identity(
+    tmp_path: Path, source_kind: str
+):
+    roots = _roots(tmp_path)
+    identity = _identity("abcdef0123456789", 5_000, "j")
+    identity.pop("rust_artifact_sha256")
+    if source_kind == "manifest":
+        _write_json(tmp_path / "runtime" / "bybit" / "alice" / "run.json", identity)
+    else:
+        path = tmp_path / "monitor" / "bybit" / "alice" / "events" / "current.ndjson"
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "kind": "runtime.started",
+                    "payload": {
+                        "live_event": {"exchange": "bybit", "user": "alice", "data": identity}
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+    _write_runtime_log(
+        tmp_path / "logs" / "alice.log",
+        timestamp_ms=7_000,
+        exchange="bybit",
+        user="alice",
+        run_id_prefix="abcdef012345",
+        marker="j",
+    )
+
+    report = build_runtime_attribution_report(**roots)
+
+    assert report["summary"]["runtime_count"] == 2
+
+
+@pytest.mark.parametrize(
+    ("manifest_exchange", "manifest_user"),
+    [("binance", "alice"), ("bybit", "bob")],
+    ids=["different_exchange", "different_user"],
+)
+def test_runtime_log_prefix_does_not_merge_different_scope(
+    tmp_path: Path, manifest_exchange: str, manifest_user: str
+):
+    roots = _roots(tmp_path)
+    _write_json(
+        tmp_path / "runtime" / manifest_exchange / manifest_user / "run.json",
+        _identity("abcdef0123456789", 5_000, "h"),
+    )
+    _write_runtime_log(
+        tmp_path / "logs" / "alice.log",
+        timestamp_ms=7_000,
+        exchange="bybit",
+        user="alice",
+        run_id_prefix="abcdef012345",
+        marker="h",
+    )
+
+    report = build_runtime_attribution_report(**roots)
+
+    assert report["summary"]["runtime_count"] == 2
 
 
 def test_monitor_runtime_event_is_accepted_without_runtime_manifest(tmp_path: Path):

--- a/tests/test_runtime_attribution.py
+++ b/tests/test_runtime_attribution.py
@@ -165,7 +165,9 @@ def test_trailing_filter_and_monitor_fill_deduplication(tmp_path: Path):
 
 def test_runtime_log_prefix_merges_with_full_manifest_identity_at_live_skew(tmp_path: Path):
     roots = _roots(tmp_path)
-    identity = _identity("1234567890abcdef", 1_784_414_326_269, "c")
+    identity = _identity(
+        "1234567890abcdef1234567890abcdef", 1_784_414_326_269, "c"
+    )
     _write_json(tmp_path / "runtime" / "bybit" / "alice" / "run.json", identity)
     _write_runtime_log(
         tmp_path / "logs" / "alice.log",
@@ -197,7 +199,9 @@ def test_runtime_log_prefix_start_skew_boundary(
     tmp_path: Path, manifest_started_at_ms: int, expected_runtime_count: int
 ):
     roots = _roots(tmp_path)
-    identity = _identity("abcdef0123456789", manifest_started_at_ms, "e")
+    identity = _identity(
+        "abcdef0123456789abcdef0123456789", manifest_started_at_ms, "e"
+    )
     _write_json(tmp_path / "runtime" / "bybit" / "alice" / "run.json", identity)
     _write_runtime_log(
         tmp_path / "logs" / "alice.log",
@@ -217,11 +221,11 @@ def test_runtime_log_prefix_does_not_merge_ambiguous_full_identities(tmp_path: P
     roots = _roots(tmp_path)
     _write_json(
         tmp_path / "runtime" / "bybit" / "alice" / "run-1.json",
-        _identity("abcdef0123456789", 5_000, "f"),
+        _identity("abcdef0123456789abcdef0123456789", 5_000, "f"),
     )
     _write_json(
         tmp_path / "runtime" / "bybit" / "alice" / "run-2.json",
-        _identity("abcdef012345fedc", 6_000, "g"),
+        _identity("abcdef012345fedcabcdef012345fedc", 6_000, "g"),
     )
     _write_runtime_log(
         tmp_path / "logs" / "alice.log",
@@ -236,8 +240,8 @@ def test_runtime_log_prefix_does_not_merge_ambiguous_full_identities(tmp_path: P
 
     assert report["summary"]["runtime_count"] == 3
     assert {runtime["run_id"] for runtime in report["runtimes"]} == {
-        "abcdef0123456789",
-        "abcdef012345fedc",
+        "abcdef0123456789abcdef0123456789",
+        "abcdef012345fedcabcdef012345fedc",
         "abcdef012345",
     }
 
@@ -245,8 +249,8 @@ def test_runtime_log_prefix_does_not_merge_ambiguous_full_identities(tmp_path: P
 @pytest.mark.parametrize(
     ("run_id", "run_id_prefix"),
     [
-        ("abcdef0123456789", "abcdef01234"),
-        ("ABCDEF0123456789", "ABCDEF012345"),
+        ("abcdef0123456789abcdef0123456789", "abcdef01234"),
+        ("abcdef0123456789abcdef0123456789", "ABCDEF012345"),
     ],
     ids=["short_prefix", "uppercase_prefix"],
 )
@@ -273,12 +277,46 @@ def test_runtime_log_prefix_requires_producer_shape(
     assert {runtime["run_id"] for runtime in report["runtimes"]} == {run_id, run_id_prefix}
 
 
+@pytest.mark.parametrize(
+    "run_id",
+    [
+        "abcdef012345-not-a-uuid",
+        "abcdef012345zzzzzzzzzzzzzzzzzzzz",
+    ],
+    ids=["non_uuid_shape", "non_hex_full_id"],
+)
+def test_runtime_log_prefix_does_not_merge_malformed_full_identity(
+    tmp_path: Path, run_id: str
+):
+    roots = _roots(tmp_path)
+    _write_json(
+        tmp_path / "runtime" / "bybit" / "alice" / "run.json",
+        _identity(run_id, 5_000, "k"),
+    )
+    _write_runtime_log(
+        tmp_path / "logs" / "alice.log",
+        timestamp_ms=7_000,
+        exchange="bybit",
+        user="alice",
+        run_id_prefix="abcdef012345",
+        marker="k",
+    )
+
+    report = build_runtime_attribution_report(**roots)
+
+    assert report["summary"]["runtime_count"] == 2
+    assert {runtime["run_id"] for runtime in report["runtimes"]} == {
+        run_id,
+        "abcdef012345",
+    }
+
+
 @pytest.mark.parametrize("source_kind", ["manifest", "monitor_event"])
 def test_runtime_log_prefix_does_not_merge_incomplete_canonical_identity(
     tmp_path: Path, source_kind: str
 ):
     roots = _roots(tmp_path)
-    identity = _identity("abcdef0123456789", 5_000, "j")
+    identity = _identity("abcdef0123456789abcdef0123456789", 5_000, "j")
     identity.pop("rust_artifact_sha256")
     if source_kind == "manifest":
         _write_json(tmp_path / "runtime" / "bybit" / "alice" / "run.json", identity)
@@ -322,7 +360,7 @@ def test_runtime_log_prefix_does_not_merge_different_scope(
     roots = _roots(tmp_path)
     _write_json(
         tmp_path / "runtime" / manifest_exchange / manifest_user / "run.json",
-        _identity("abcdef0123456789", 5_000, "h"),
+        _identity("abcdef0123456789abcdef0123456789", 5_000, "h"),
     )
     _write_runtime_log(
         tmp_path / "logs" / "alice.log",


### PR DESCRIPTION
## Summary

- reconcile the producer's exact 12-character lowercase-hex startup-log run-id prefix with one complete 32-character lowercase-hex manifest or monitor identity when exchange, user, prefix, and start time agree uniquely within two seconds
- keep ambiguous, incomplete, malformed, cross-scope, and out-of-bound observations separate
- document the attribution contract and record the exact PR #1312 VPS5 deployment evidence

## Behavior Boundary

This changes the offline, read-only `runtime-attribution` parser only. It does not change runtime producers, exchange calls, trading, planning, orders, risk, configuration, restart behavior, or process control.

## Validation

- `PYTHONPATH=src .../venv/bin/python -m pytest tests/test_runtime_attribution.py -q` (`20 passed`)
- `PYTHONPATH=src .../venv/bin/python -m py_compile src/live/runtime_attribution.py tests/test_runtime_attribution.py`
- `PYTHONPATH=src .../venv/bin/python src/tools/check_ai_docs.py` (`0 errors`; existing repository-wide word-count warning only)
- `git diff --check`

Regression coverage includes the observed `1731 ms` live skew, the inclusive two-second boundary, one millisecond beyond the boundary, malformed log prefixes, malformed full identities, ambiguous matches, incomplete canonical identities, and exchange/user scope isolation.

## Deploy Evidence Carried Forward

PR #1312 merged as `8b433cc22b087b0efab51ba2bcf003f1e2b31806` and VPS5 fast-forwarded tracked-clean without a Rust rebuild. The guarded runner restarted only exact panes `%358`-`%362` without force; all five targets relaunched and verified, and `misc:0.0` remained `%8`/PID `434835`. The initial lifecycle window retained one natural hard event. A fresh settled window had zero smoke hard failures, log errors, or monitor errors; the ordinary two-minute report was hard-green with `46/46` account-critical calls successful and no latest degraded cycle.

## Gate And Deploy Impact

- required merge gate: exact-current-head Hermes approval plus green Python and Rust CI
- built-in Codex automatic review is additional and findings must be resolved
- expected VPS action after merge: bounded read-only attribution smoke only; no bot restart
