### PR TITLE
Fix Bybit trailing fill confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Trailing-position fill confirmation now treats exchange position-update
+  timestamps as advisory and proves readiness with a successful post-position
+  fill refresh, a new fill identity for runtime changes, and matching fill
+  after-state. This prevents Bybit's later `updatedTime` from leaving valid
+  trailing positions permanently nontradable. Repeated unavailable warnings are
+  bounded, and monitor market state now exposes the actual planner tradability
+  plus fill-confirmation predicates and watermarks.
+
 - `passivbot tool runtime-attribution` now reconciles the producer's exact
   12-character lowercase-hex startup-log run-id prefix with one complete
   manifest or startup-event identity when exchange, user, prefix, and start time

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -1433,6 +1433,9 @@ class Passivbot:
         self._trailing_unchanged_info_log_interval_ms = self.STATUS_OPERATOR_HEARTBEAT_INTERVAL_MS
         self._trailing_operator_visible_baseline_by_key = {}
         self._trailing_operator_visible_ms_by_key = {}
+        self._trailing_unavailable_warning_signature = ()
+        self._trailing_unavailable_warning_last_ms = 0
+        self._trailing_unavailable_warning_interval_ms = 5 * 60 * 1000
 
         # Realized-loss gate logging throttle
         self._loss_gate_last_log_ms = {}
@@ -8258,9 +8261,6 @@ class Passivbot:
         pending_fill_confirmations = dict(
             getattr(self, "_trailing_pending_fill_confirmations", {}) or {}
         )
-        pending_fill_min_timestamps = dict(
-            getattr(self, "_trailing_pending_fill_min_timestamps", {}) or {}
-        )
         pending_fill_min_generations = dict(
             getattr(self, "_trailing_pending_fill_min_generations", {}) or {}
         )
@@ -8274,6 +8274,7 @@ class Passivbot:
             getattr(self, "_trailing_fill_refresh_generation", 0) or 0
         )
         current_epochs: dict[tuple[str, str], str] = {}
+        confirmation_diagnostics: dict[tuple[str, str], dict] = {}
 
         for symbol, psides in required_trailing.items():
             for pside in psides:
@@ -8285,31 +8286,56 @@ class Passivbot:
                     current_timestamp = (
                         None if anchor is None else int(anchor["timestamp"])
                     )
-                    minimum_timestamp = pending_fill_min_timestamps.get(epoch_key)
                     minimum_fill_generation = pending_fill_min_generations.get(
                         epoch_key
                     )
                     expected_position_state = pending_position_states.get(epoch_key)
+                    failed_predicates = []
+                    if current_epoch is None:
+                        failed_predicates.append("missing_fill_anchor")
+                    elif not current_epoch.startswith("fill:"):
+                        failed_predicates.append("non_fill_anchor")
+                    elif current_epoch == baseline_epoch:
+                        failed_predicates.append("fill_identity_unchanged")
                     if (
-                        current_epoch is None
-                        or not current_epoch.startswith("fill:")
-                        or current_epoch == baseline_epoch
-                        or (
-                            minimum_timestamp is not None
-                            and current_timestamp < int(minimum_timestamp)
-                        )
-                        or (
-                            minimum_fill_generation is not None
-                            and fill_refresh_generation
-                            < int(minimum_fill_generation)
-                        )
-                        or (
-                            expected_position_state is not None
-                            and not self._fill_anchor_matches_position_state(
-                                symbol, expected_position_state, anchor
-                            )
+                        minimum_fill_generation is not None
+                        and fill_refresh_generation < int(minimum_fill_generation)
+                    ):
+                        failed_predicates.append("post_snapshot_fill_refresh_pending")
+                    if (
+                        current_epoch is not None
+                        and current_epoch.startswith("fill:")
+                        and expected_position_state is not None
+                        and not self._fill_anchor_matches_position_state(
+                            symbol, expected_position_state, anchor
                         )
                     ):
+                        failed_predicates.append("fill_after_state_mismatch")
+                    if failed_predicates:
+                        position_update_timestamp = self._position_update_timestamp_ms(
+                            symbol, pside
+                        )
+                        detail = {
+                            "failed_predicates": failed_predicates,
+                            "baseline_fill_epoch": baseline_epoch,
+                            "current_fill_epoch": current_epoch,
+                            "fill_timestamp_ms": current_timestamp,
+                            "position_update_timestamp_ms": position_update_timestamp,
+                            "fill_refresh_generation": fill_refresh_generation,
+                            "minimum_fill_refresh_generation": minimum_fill_generation,
+                            "fill_precedes_position_update": bool(
+                                current_timestamp is not None
+                                and position_update_timestamp is not None
+                                and current_timestamp < position_update_timestamp
+                            ),
+                        }
+                        if expected_position_state is not None:
+                            detail["expected_position_size"] = expected_position_state[0]
+                            detail["expected_position_price"] = expected_position_state[1]
+                        if anchor is not None:
+                            detail["fill_after_position_size"] = anchor.get("psize")
+                            detail["fill_after_position_price"] = anchor.get("pprice")
+                        confirmation_diagnostics[epoch_key] = detail
                         self.trailing_prices[symbol][pside] = (
                             _trailing_bundle_default_dict()
                         )
@@ -8320,7 +8346,6 @@ class Passivbot:
                         last_position_changes.get(symbol, {}).pop(pside, None)
                         continue
                     pending_fill_confirmations.pop(epoch_key, None)
-                    pending_fill_min_timestamps.pop(epoch_key, None)
                     pending_fill_min_generations.pop(epoch_key, None)
                     pending_position_states.pop(epoch_key, None)
                     associated_fill_epochs[epoch_key] = current_epoch
@@ -8335,10 +8360,10 @@ class Passivbot:
                     self.trailing_prices[symbol][pside] = _trailing_bundle_default_dict()
         self._trailing_position_change_epochs = current_epochs
         self._trailing_pending_fill_confirmations = pending_fill_confirmations
-        self._trailing_pending_fill_min_timestamps = pending_fill_min_timestamps
         self._trailing_pending_fill_min_generations = pending_fill_min_generations
         self._trailing_pending_position_states = pending_position_states
         self._trailing_position_snapshot_fill_epochs = associated_fill_epochs
+        self._trailing_fill_confirmation_diagnostics = confirmation_diagnostics
 
         # Build concurrent fetches per symbol that has position changes
         fetch_plan = {}
@@ -8411,18 +8436,83 @@ class Passivbot:
 
         unavailable_symbols = set()
         unavailable_by_symbol: dict[str, list[str]] = defaultdict(list)
+        warning_signature_parts = [
+            (reason, tuple(sorted(reason_symbols)))
+            for reason, reason_symbols in sorted(unavailable_reasons.items())
+            if reason_symbols
+        ]
+        confirmation_predicate_signature = tuple(
+            (
+                symbol,
+                pside,
+                tuple(detail.get("failed_predicates", [])),
+            )
+            for (symbol, pside), detail in sorted(confirmation_diagnostics.items())
+        )
+        warning_signature = tuple(warning_signature_parts)
+        if confirmation_predicate_signature:
+            warning_signature += (
+                ("confirmation_predicates", confirmation_predicate_signature),
+            )
+        now_ms = utc_ms()
+        previous_warning_signature = tuple(
+            getattr(self, "_trailing_unavailable_warning_signature", ()) or ()
+        )
+        last_warning_ms = int(
+            getattr(self, "_trailing_unavailable_warning_last_ms", 0) or 0
+        )
+        warning_interval_ms = int(
+            getattr(
+                self,
+                "_trailing_unavailable_warning_interval_ms",
+                5 * 60 * 1000,
+            )
+            or 5 * 60 * 1000
+        )
+        operator_warning_due = bool(warning_signature) and (
+            warning_signature != previous_warning_signature
+            or now_ms - last_warning_ms >= warning_interval_ms
+        )
         for reason, reason_symbols in sorted(unavailable_reasons.items()):
             if not reason_symbols:
                 continue
             unavailable_symbols.update(reason_symbols)
             for symbol in sorted(reason_symbols):
                 unavailable_by_symbol[symbol].append(reason)
-            logging.warning(
-                "[trailing] trailing state unavailable reason=%s symbols=%s "
-                "action=mark_nontradable_until_fresh",
-                reason,
-                Passivbot._log_symbols(sorted(reason_symbols), limit=12),
-            )
+            if operator_warning_due:
+                confirmation_detail = ""
+                if reason == "position_fill_confirmation_pending":
+                    samples = []
+                    for (symbol, pside), detail in sorted(
+                        confirmation_diagnostics.items()
+                    )[:2]:
+                        samples.append(
+                            "%s:%s(failed=%s,fill_ts=%s,position_update_ts=%s,"
+                            "fill_generation=%s,min_fill_generation=%s)"
+                            % (
+                                symbol,
+                                pside,
+                                "|".join(detail["failed_predicates"]),
+                                detail.get("fill_timestamp_ms"),
+                                detail.get("position_update_timestamp_ms"),
+                                detail.get("fill_refresh_generation"),
+                                detail.get("minimum_fill_refresh_generation"),
+                            )
+                        )
+                    if samples:
+                        confirmation_detail = " confirmation_details=" + ";".join(
+                            samples
+                        )
+                logging.warning(
+                    "[trailing] trailing state unavailable reason=%s symbols=%s "
+                    "action=mark_nontradable_until_fresh%s",
+                    reason,
+                    Passivbot._log_symbols(sorted(reason_symbols), limit=12),
+                    confirmation_detail,
+                )
+        self._trailing_unavailable_warning_signature = warning_signature
+        if operator_warning_due:
+            self._trailing_unavailable_warning_last_ms = now_ms
         self._orchestrator_trailing_unavailable_symbols = unavailable_symbols
         self._orchestrator_trailing_unavailable_reasons = {
             symbol: sorted(reasons)
@@ -13891,9 +13981,6 @@ class Passivbot:
         pending = dict(
             getattr(self, "_trailing_pending_fill_confirmations", {}) or {}
         )
-        pending_min_timestamps = dict(
-            getattr(self, "_trailing_pending_fill_min_timestamps", {}) or {}
-        )
         pending_min_fill_generations = dict(
             getattr(self, "_trailing_pending_fill_min_generations", {}) or {}
         )
@@ -13920,21 +14007,13 @@ class Passivbot:
                 new_size = position_state.get(key, (0.0, 0.0))[0]
                 if new_size != 0.0 and self.is_trailing(symbol, pside):
                     pending[key] = previous_snapshot_fill_epochs.get(key)
-                    position_ts = self._position_update_timestamp_ms(symbol, pside)
-                    if position_ts is None:
-                        pending_min_timestamps.pop(key, None)
-                        pending_min_fill_generations[key] = (
-                            fill_refresh_started_generation + 1
-                        )
-                        pending_position_states[key] = position_state[key]
-                        request_post_position_fill_confirmation = True
-                    else:
-                        pending_min_timestamps[key] = position_ts
-                        pending_min_fill_generations.pop(key, None)
-                        pending_position_states.pop(key, None)
+                    pending_min_fill_generations[key] = (
+                        fill_refresh_started_generation + 1
+                    )
+                    pending_position_states[key] = position_state[key]
+                    request_post_position_fill_confirmation = True
                 else:
                     pending.pop(key, None)
-                    pending_min_timestamps.pop(key, None)
                     pending_min_fill_generations.pop(key, None)
                     pending_position_states.pop(key, None)
         else:
@@ -13943,44 +14022,23 @@ class Passivbot:
                 symbol, pside = key
                 if state[0] == 0.0 or not self.is_trailing(symbol, pside):
                     continue
-                position_ts = self._position_update_timestamp_ms(symbol, pside)
-                fill_anchor = current_fill_anchors.get(key)
-                if position_ts is not None:
-                    fill_is_current = fill_anchor is not None and int(
-                        fill_anchor["timestamp"]
-                    ) >= position_ts
-                else:
-                    # A reconstructed same-state fill cannot prove freshness on
-                    # restart: unseen round-trip fills may return to the same
-                    # size and average price.  Require a successful fill refresh
-                    # that starts in a later authoritative cohort.
-                    fill_is_current = False
-                if fill_is_current:
-                    pending_min_fill_generations.pop(key, None)
-                    pending_position_states.pop(key, None)
-                    continue
                 self.trailing_prices.setdefault(symbol, {})
                 self.trailing_prices[symbol][pside] = _trailing_bundle_default_dict()
-                if position_ts is None:
-                    pending[key] = None
-                    pending_min_timestamps.pop(key, None)
-                    pending_min_fill_generations[key] = (
-                        fill_refresh_started_generation + 1
-                    )
-                    pending_position_states[key] = state
-                    request_post_position_fill_confirmation = True
-                else:
-                    pending[key] = (
-                        None if fill_anchor is None else str(fill_anchor["epoch"])
-                    )
-                    pending_min_timestamps[key] = position_ts
-                    pending_min_fill_generations.pop(key, None)
-                    pending_position_states.pop(key, None)
+                # Exchange position update timestamps describe the position
+                # record, not the corresponding trade.  In particular, Bybit's
+                # updatedTime may follow the confirming fill's execTime.  Treat
+                # that timestamp as diagnostic only and prove readiness through
+                # a post-snapshot fill refresh plus matching fill after-state.
+                pending[key] = None
+                pending_min_fill_generations[key] = (
+                    fill_refresh_started_generation + 1
+                )
+                pending_position_states[key] = state
+                request_post_position_fill_confirmation = True
         if request_post_position_fill_confirmation:
             self._request_authoritative_confirmation({"fills"})
         self._trailing_position_snapshot_fill_epochs = previous_snapshot_fill_epochs
         self._trailing_pending_fill_confirmations = pending
-        self._trailing_pending_fill_min_timestamps = pending_min_timestamps
         self._trailing_pending_fill_min_generations = pending_min_fill_generations
         self._trailing_pending_position_states = pending_position_states
         return fetched_positions_old, self.fetched_positions

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -1124,6 +1124,7 @@ class Passivbot:
         self._authoritative_refresh_plan_surfaces = set()
         self._authoritative_pending_confirmations = {}
         self._trailing_fill_refresh_started_generation = 0
+        self._trailing_fill_fetch_generation = 0
         self._trailing_fill_refresh_generation = 0
         self._authoritative_barrier_last_log_key = None
         self._authoritative_barrier_last_log_ms = 0
@@ -8270,8 +8271,8 @@ class Passivbot:
         associated_fill_epochs = dict(
             getattr(self, "_trailing_position_snapshot_fill_epochs", {}) or {}
         )
-        fill_refresh_generation = int(
-            getattr(self, "_trailing_fill_refresh_generation", 0) or 0
+        fill_fetch_generation = int(
+            getattr(self, "_trailing_fill_fetch_generation", 0) or 0
         )
         current_epochs: dict[tuple[str, str], str] = {}
         confirmation_diagnostics: dict[tuple[str, str], dict] = {}
@@ -8299,7 +8300,7 @@ class Passivbot:
                         failed_predicates.append("fill_identity_unchanged")
                     if (
                         minimum_fill_generation is not None
-                        and fill_refresh_generation < int(minimum_fill_generation)
+                        and fill_fetch_generation < int(minimum_fill_generation)
                     ):
                         failed_predicates.append("post_snapshot_fill_refresh_pending")
                     if (
@@ -8321,7 +8322,7 @@ class Passivbot:
                             "current_fill_epoch": current_epoch,
                             "fill_timestamp_ms": current_timestamp,
                             "position_update_timestamp_ms": position_update_timestamp,
-                            "fill_refresh_generation": fill_refresh_generation,
+                            "fill_refresh_generation": fill_fetch_generation,
                             "minimum_fill_refresh_generation": minimum_fill_generation,
                             "fill_precedes_position_update": bool(
                                 current_timestamp is not None
@@ -11092,6 +11093,7 @@ class Passivbot:
                     )
                     or 0
                 ),
+                int(getattr(self, "_trailing_fill_fetch_generation", 0) or 0),
                 int(getattr(self, "_trailing_fill_refresh_generation", 0) or 0),
             )
             + 1
@@ -11276,6 +11278,11 @@ class Passivbot:
 
             # Find and log new events (those not in cache before refresh)
             all_events = self._pnls_manager.get_events()
+            # Trailing fill confirmation only needs proof that a fill-cache
+            # refresh completed after the position snapshot. Keep this
+            # separate from the risk-authoritative fills generation below,
+            # which must still wait for PnL enrichment and history coverage.
+            self._trailing_fill_fetch_generation = fill_refresh_attempt_generation
             new_events = []
             enriched_events = []
             seen_new_source_ids: set[str] = set()
@@ -13992,7 +13999,7 @@ class Passivbot:
                 getattr(self, "_trailing_fill_refresh_started_generation", 0)
                 or 0
             ),
-            int(getattr(self, "_trailing_fill_refresh_generation", 0) or 0),
+            int(getattr(self, "_trailing_fill_fetch_generation", 0) or 0),
         )
         request_post_position_fill_confirmation = False
         if previous_position_state is not None:

--- a/src/passivbot_monitor.py
+++ b/src/passivbot_monitor.py
@@ -585,11 +585,45 @@ def _build_monitor_market_section(self) -> dict[str, dict]:
         symbols |= set(ignored.get(pside, set()) or set())
     market_snapshot_cache = getattr(getattr(self, "market_snapshot_provider", None), "_cache", {})
     runtime_hints = getattr(self, "_monitor_runtime_market_hints", {})
+    ema_unavailable_symbols = set(
+        getattr(self, "_orchestrator_ema_unavailable_symbols", set()) or set()
+    )
+    trailing_unavailable_symbols = set(
+        getattr(self, "_orchestrator_trailing_unavailable_symbols", set()) or set()
+    )
+    trailing_unavailable_reasons = getattr(
+        self, "_orchestrator_trailing_unavailable_reasons", {}
+    ) or {}
+    trailing_unavailable_psides = getattr(
+        self, "_orchestrator_trailing_unavailable_psides", {}
+    ) or {}
+    fill_confirmation_diagnostics = getattr(
+        self, "_trailing_fill_confirmation_diagnostics", {}
+    ) or {}
     out: dict[str, dict] = {}
     for symbol in sorted(symbols):
+        market_active = bool(
+            getattr(self, "markets_dict", {}).get(symbol, {}).get("active", True)
+        )
+        tradability_reasons = []
+        if not market_active:
+            tradability_reasons.append("market_inactive")
+        if symbol in ema_unavailable_symbols:
+            tradability_reasons.append("required_ema_unavailable")
+        symbol_trailing_reasons = trailing_unavailable_reasons.get(symbol, [])
+        if isinstance(symbol_trailing_reasons, str):
+            symbol_trailing_reasons = [symbol_trailing_reasons]
+        tradability_reasons.extend(
+            str(reason) for reason in symbol_trailing_reasons if reason
+        )
         entry: dict[str, Any] = {
             "active_symbol": symbol in set(getattr(self, "active_symbols", []) or []),
-            "tradable": bool(getattr(self, "markets_dict", {}).get(symbol, {}).get("active", True)),
+            "tradable": bool(
+                market_active
+                and symbol not in ema_unavailable_symbols
+                and symbol not in trailing_unavailable_symbols
+            ),
+            "tradability_reasons": sorted(set(tradability_reasons)),
             "approved": {
                 "long": symbol in set(approved_minus_ignored.get("long", set()) or set()),
                 "short": symbol in set(approved_minus_ignored.get("short", set()) or set()),
@@ -609,6 +643,19 @@ def _build_monitor_market_section(self) -> dict[str, dict]:
             "has_open_orders": bool(getattr(self, "open_orders", {}).get(symbol)),
             "has_position": bool(self.has_position(symbol=symbol)),
         }
+        if symbol in trailing_unavailable_symbols:
+            entry["trailing_unavailable_psides"] = sorted(
+                str(pside)
+                for pside in trailing_unavailable_psides.get(symbol, [])
+                if pside
+            )
+        confirmation_by_pside = {
+            pside: dict(fill_confirmation_diagnostics[(symbol, pside)])
+            for pside in ("long", "short")
+            if (symbol, pside) in fill_confirmation_diagnostics
+        }
+        if confirmation_by_pside:
+            entry["trailing_fill_confirmation"] = confirmation_by_pside
         cached = market_snapshot_cache.get(symbol)
         if cached is not None:
             try:

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -5130,6 +5130,7 @@ async def test_update_pnls_window_lookback_stays_blocked_when_known_gap_persists
         "retry_count": 3,
         "next_retry_ms": now_ms + 60_000,
     }
+    bot._trailing_fill_fetch_generation = 7
     bot._pnls_manager = _Manager(cached_events)
     bot.init_pnls = AsyncMock()
     bot.live_value = lambda key: bot.config["live"][key]
@@ -5148,6 +5149,7 @@ async def test_update_pnls_window_lookback_stays_blocked_when_known_gap_persists
     bot._pnls_manager.refresh_latest.assert_not_awaited()
     assert bot._last_fill_refresh_pending_pnl_count == 0
     assert "fills" not in getattr(bot, "_authoritative_surface_signatures", {})
+    assert bot._trailing_fill_fetch_generation == 8
     retry_state = getattr(bot, "_fill_coverage_retry_state", {})
     assert retry_state["next_retry_ms"] > wall_ms["value"]
 
@@ -5155,12 +5157,14 @@ async def test_update_pnls_window_lookback_stays_blocked_when_known_gap_persists
 
     assert result is False
     bot._pnls_manager.refresh_for_lookback.assert_awaited_once_with(start_ms=start_ms)
+    assert bot._trailing_fill_fetch_generation == 8
 
     wall_ms["value"] = int(retry_state["next_retry_ms"]) + 1
     result = await bot.update_pnls(source="staged_blocking")
 
     assert result is False
     assert bot._pnls_manager.refresh_for_lookback.await_count == 2
+    assert bot._trailing_fill_fetch_generation == 10
 
 
 @pytest.mark.asyncio
@@ -5482,9 +5486,11 @@ async def test_update_pnls_propagates_unexpected_refresh_errors():
     bot._monitor_record_error = lambda *args, **kwargs: None
     bot.logging_level = 0
     bot._health_rate_limits = 0
+    bot._trailing_fill_fetch_generation = 7
 
     with pytest.raises(RuntimeError, match="fill refresh failed"):
         await bot.update_pnls()
+    assert bot._trailing_fill_fetch_generation == 7
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
     events = [
         event
@@ -5499,6 +5505,60 @@ async def test_update_pnls_propagates_unexpected_refresh_errors():
     assert event.data["error"] == "fill refresh failed"
     assert event.data["coverage_ready_before"] is True
     assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+async def test_update_pnls_rate_limit_does_not_advance_trailing_fetch_generation():
+    bot = Passivbot.__new__(Passivbot)
+    cached_events = [
+        SimpleNamespace(timestamp=1_700_000_000_000, id="fill-1", source_ids=["fill-1"])
+    ]
+
+    class _Manager:
+        def __init__(self, events):
+            self._events = list(events)
+            self.refresh = AsyncMock()
+            self.refresh_latest = AsyncMock(
+                side_effect=passivbot_module.RateLimitExceeded("rate limited")
+            )
+
+        def get_events(self):
+            return list(self._events)
+
+        def get_history_scope(self):
+            return "all"
+
+        def set_history_scope(self, scope):
+            pass
+
+    bot.stop_signal_received = False
+    bot.config = {
+        "live": {
+            "fills_recent_overlap_minutes": 10.0,
+            "pnls_max_lookback_days": "all",
+        }
+    }
+    bot._pnls_manager = _Manager(cached_events)
+    bot.init_pnls = AsyncMock()
+    bot.live_value = lambda key: bot.config["live"][key]
+    bot.get_exchange_time = lambda: 1_700_000_060_000
+    bot._log_new_fill_events = lambda new_events: None
+    monitor_events = []
+    bot._monitor_record_event = lambda *args, **kwargs: monitor_events.append(
+        (args, kwargs)
+    )
+    bot._monitor_record_error = lambda *args, **kwargs: None
+    bot._emit_fills_refresh_summary_event = lambda **kwargs: None
+    bot.logging_level = 0
+    bot._health_rate_limits = 0
+    bot._trailing_fill_fetch_generation = 7
+
+    result = await bot.update_pnls()
+
+    assert result is False
+    assert bot._health_rate_limits == 1
+    assert len(monitor_events) == 1
+    assert bot._trailing_fill_fetch_generation == 7
 
 
 @pytest.mark.asyncio
@@ -5552,10 +5612,12 @@ async def test_update_pnls_emits_summary_when_exchange_time_resync_handles_error
     bot._maybe_recover_exchange_time_sync = AsyncMock(return_value=True)
     bot.logging_level = 0
     bot._health_rate_limits = 0
+    bot._trailing_fill_fetch_generation = 7
 
     result = await bot.update_pnls()
 
     assert result is False
+    assert bot._trailing_fill_fetch_generation == 7
     bot._maybe_recover_exchange_time_sync.assert_awaited_once()
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
     events = [
@@ -5619,11 +5681,13 @@ async def test_update_pnls_suppresses_inflight_shutdown_refresh_error(caplog):
     )
     bot.logging_level = 2
     bot._health_rate_limits = 0
+    bot._trailing_fill_fetch_generation = 7
 
     with caplog.at_level(logging.DEBUG):
         result = await bot.update_pnls()
 
     assert result is False
+    assert bot._trailing_fill_fetch_generation == 7
     assert monitor_errors == []
     assert not [record for record in caplog.records if record.levelno >= logging.ERROR]
     assert any(

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -4872,6 +4872,7 @@ async def test_update_pnls_all_lookback_uses_incremental_refresh_when_cache_is_f
     bot.logging_level = 0
     bot._health_rate_limits = 0
     bot._trailing_fill_refresh_started_generation = 4
+    bot._trailing_fill_fetch_generation = 4
     bot._trailing_fill_refresh_generation = 4
 
     result = await bot.update_pnls()
@@ -4883,7 +4884,66 @@ async def test_update_pnls_all_lookback_uses_incremental_refresh_when_cache_is_f
         last_refresh_overlap_ms=10 * 60 * 1000,
     )
     assert bot._pnls_manager.history_scope == "all"
+    assert bot._trailing_fill_fetch_generation == 5
     assert bot._trailing_fill_refresh_generation == 5
+
+
+@pytest.mark.asyncio
+async def test_update_pnls_pending_enrichment_advances_only_trailing_fetch_generation():
+    bot = Passivbot.__new__(Passivbot)
+    cached_events = [
+        SimpleNamespace(
+            timestamp=1_700_000_000_000,
+            id="unrelated-close-fill",
+            source_ids=["unrelated-close-fill"],
+            pnl_status="pending",
+        )
+    ]
+
+    class _Manager:
+        def __init__(self, events):
+            self._events = list(events)
+            self.refresh = AsyncMock()
+            self.refresh_latest = AsyncMock()
+
+        def get_events(self):
+            return list(self._events)
+
+        def get_history_scope(self):
+            return "all"
+
+        def set_history_scope(self, scope):
+            pass
+
+    bot.stop_signal_received = False
+    bot.config = {
+        "live": {
+            "fills_recent_overlap_minutes": 10.0,
+            "pnls_max_lookback_days": "all",
+        }
+    }
+    bot._pnls_manager = _Manager(cached_events)
+    bot.init_pnls = AsyncMock()
+    bot.live_value = lambda key: bot.config["live"][key]
+    bot.get_exchange_time = lambda: 1_700_000_060_000
+    bot._log_new_fill_events = lambda new_events: None
+    bot._monitor_record_event = lambda *args, **kwargs: None
+    bot._monitor_record_error = lambda *args, **kwargs: None
+    bot.logging_level = 0
+    bot._health_rate_limits = 0
+    bot._trailing_fill_refresh_started_generation = 4
+    bot._trailing_fill_fetch_generation = 4
+    bot._trailing_fill_refresh_generation = 4
+
+    result = await bot.update_pnls()
+
+    assert result is False
+    bot._pnls_manager.refresh_latest.assert_awaited_once_with(
+        overlap=20,
+        last_refresh_overlap_ms=10 * 60 * 1000,
+    )
+    assert bot._trailing_fill_fetch_generation == 5
+    assert bot._trailing_fill_refresh_generation == 4
 
 
 @pytest.mark.asyncio
@@ -7957,6 +8017,7 @@ async def test_planning_snapshot_freezes_data_packet_revisions_through_cycle(mon
     bot.exchange = "fake"
     bot.coin_overrides = {}
     _disable_entry_cooldown_delta_guard_for_staged_refresh_test(bot)
+    bot.is_trailing = lambda symbol, pside=None: False
     bot.active_symbols = [symbol]
     bot.PB_modes = {"long": {}, "short": {}}
     bot.cm = SimpleNamespace(

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -5628,6 +5628,24 @@ async def test_build_monitor_snapshot_includes_market_forager_unstuck_and_recent
                 "BTC/USDT:USDT": {"active": True},
                 "ETH/USDT:USDT": {"active": True},
             }
+            self._orchestrator_ema_unavailable_symbols = set()
+            self._orchestrator_trailing_unavailable_symbols = {"BTC/USDT:USDT"}
+            self._orchestrator_trailing_unavailable_reasons = {
+                "BTC/USDT:USDT": ["position_fill_confirmation_pending"]
+            }
+            self._orchestrator_trailing_unavailable_psides = {
+                "BTC/USDT:USDT": ["long"]
+            }
+            self._trailing_fill_confirmation_diagnostics = {
+                ("BTC/USDT:USDT", "long"): {
+                    "failed_predicates": ["post_snapshot_fill_refresh_pending"],
+                    "fill_timestamp_ms": 123000,
+                    "position_update_timestamp_ms": 123100,
+                    "fill_refresh_generation": 2,
+                    "minimum_fill_refresh_generation": 3,
+                    "fill_precedes_position_update": True,
+                }
+            }
             self.recent_order_executions = [
                 {
                         "symbol": "BTC/USDT:USDT",
@@ -5902,6 +5920,17 @@ async def test_build_monitor_snapshot_includes_market_forager_unstuck_and_recent
     )
     assert snapshot["positions"]["BTC/USDT:USDT"]["long"]["upnl"] == pytest.approx(0.5)
     assert snapshot["market"]["BTC/USDT:USDT"]["last_price"] == pytest.approx(100500.0)
+    assert snapshot["market"]["BTC/USDT:USDT"]["tradable"] is False
+    assert snapshot["market"]["BTC/USDT:USDT"]["tradability_reasons"] == [
+        "position_fill_confirmation_pending"
+    ]
+    assert snapshot["market"]["BTC/USDT:USDT"]["trailing_unavailable_psides"] == [
+        "long"
+    ]
+    assert snapshot["market"]["BTC/USDT:USDT"]["trailing_fill_confirmation"][
+        "long"
+    ]["minimum_fill_refresh_generation"] == 3
+    assert snapshot["market"]["ETH/USDT:USDT"]["tradable"] is True
     assert snapshot["market"]["BTC/USDT:USDT"]["c_mult"] == pytest.approx(1.0)
     assert snapshot["market"]["BTC/USDT:USDT"]["entry_volatility_logrange_ema"]["long"] == pytest.approx(
         0.0

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -3,6 +3,7 @@ import logging
 import math
 import sys
 import types
+from unittest.mock import AsyncMock
 
 import pytest
 import numpy as np
@@ -1402,7 +1403,7 @@ async def test_position_delta_waits_for_new_fill_identity_across_refresh_cohorts
             symbol, "long", 240_000, "new-fill", psize=1.5, pprice=101.0
         )
     )
-    bot._trailing_fill_refresh_generation = 1
+    bot._trailing_fill_fetch_generation = 1
     await bot.update_trailing_data()
 
     assert bot._trailing_pending_fill_confirmations == {}
@@ -1470,7 +1471,7 @@ async def test_fill_prefetch_before_position_delta_waits_for_post_snapshot_refre
         "failed_predicates"
     ] == ["post_snapshot_fill_refresh_pending"]
 
-    bot._trailing_fill_refresh_generation = 1
+    bot._trailing_fill_fetch_generation = 1
     await bot.update_trailing_data()
 
     assert bot._trailing_pending_fill_confirmations == {}
@@ -1533,7 +1534,7 @@ async def test_unchanged_position_snapshot_does_not_associate_prefetched_fill():
         )
 
     bot.cm.get_candles = complete_new_epoch_candles
-    bot._trailing_fill_refresh_generation = 1
+    bot._trailing_fill_fetch_generation = 1
     await bot.update_trailing_data()
 
     assert bot._trailing_pending_fill_confirmations == {}
@@ -1597,7 +1598,7 @@ async def test_restart_same_state_waits_for_post_position_fill_refresh():
     # A fill refresh already in flight before the position snapshot cannot
     # satisfy the post-position watermark even if it completes later.
     bot._trailing_fill_refresh_started_generation = 1
-    bot._trailing_fill_refresh_generation = 0
+    bot._trailing_fill_fetch_generation = 0
 
     bot._apply_positions_snapshot(
         [
@@ -1628,7 +1629,7 @@ async def test_restart_same_state_waits_for_post_position_fill_refresh():
         symbol: ["position_fill_confirmation_pending"]
     }
 
-    bot._trailing_fill_refresh_generation = 1
+    bot._trailing_fill_fetch_generation = 1
     await bot.update_trailing_data()
     assert bot._trailing_pending_fill_confirmations == {(symbol, "long"): None}
 
@@ -1645,7 +1646,7 @@ async def test_restart_same_state_waits_for_post_position_fill_refresh():
         ]
     )
     bot._trailing_fill_refresh_started_generation = 2
-    bot._trailing_fill_refresh_generation = 2
+    bot._trailing_fill_fetch_generation = 2
     await bot.update_trailing_data()
 
     assert bot._trailing_pending_fill_confirmations == {}
@@ -1670,7 +1671,7 @@ async def test_runtime_delta_without_update_time_rejects_mismatched_prefetched_f
     bot.is_trailing = lambda sym, pside=None: pside == "long"
     bot.get_exchange_time = lambda: 361_000
     bot._trailing_fill_refresh_started_generation = 1
-    bot._trailing_fill_refresh_generation = 1
+    bot._trailing_fill_fetch_generation = 1
 
     bot._apply_positions_snapshot(
         [
@@ -1689,7 +1690,7 @@ async def test_runtime_delta_without_update_time_rejects_mismatched_prefetched_f
         )
     )
     bot._trailing_fill_refresh_started_generation = 2
-    bot._trailing_fill_refresh_generation = 2
+    bot._trailing_fill_fetch_generation = 2
     bot._apply_positions_snapshot(
         [
             {
@@ -1717,7 +1718,7 @@ async def test_runtime_delta_without_update_time_rejects_mismatched_prefetched_f
 
     bot.cm.get_candles = complete_matching_epoch_candles
     bot._trailing_fill_refresh_started_generation = 3
-    bot._trailing_fill_refresh_generation = 3
+    bot._trailing_fill_fetch_generation = 3
     await bot.update_trailing_data()
 
     assert bot._trailing_pending_fill_confirmations == {
@@ -1733,7 +1734,7 @@ async def test_runtime_delta_without_update_time_rejects_mismatched_prefetched_f
         )
     )
     bot._trailing_fill_refresh_started_generation = 4
-    bot._trailing_fill_refresh_generation = 4
+    bot._trailing_fill_fetch_generation = 4
     await bot.update_trailing_data()
 
     assert bot._trailing_pending_fill_confirmations == {}
@@ -1741,6 +1742,83 @@ async def test_runtime_delta_without_update_time_rejects_mismatched_prefetched_f
         (symbol, "long"): "fill:240000:matching-fill"
     }
     assert bot._orchestrator_trailing_unavailable_symbols == set()
+
+
+@pytest.mark.asyncio
+async def test_matching_trailing_fill_confirms_while_unrelated_pnl_is_pending():
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    old_fill = _DummyFillEvent(
+        symbol, "long", 120_000, "old-fill", psize=1.0, pprice=100.0
+    )
+
+    class _RefreshablePnlsManager(_DummyPnlsManager):
+        def __init__(self, events):
+            super().__init__(events)
+            self.refresh = AsyncMock()
+            self.refresh_latest = AsyncMock()
+
+        def get_history_scope(self):
+            return "all"
+
+        def set_history_scope(self, scope):
+            pass
+
+    bot._pnls_manager = _RefreshablePnlsManager([old_fill])
+    bot.init_pnls = AsyncMock()
+    bot.is_trailing = lambda sym, pside=None: pside == "long"
+    bot.get_exchange_time = lambda: 361_000
+    bot._emit_fills_refresh_summary_event = lambda **kwargs: None
+
+    bot._apply_positions_snapshot(
+        [
+            {
+                "symbol": symbol,
+                "position_side": "long",
+                "size": 1.0,
+                "price": 100.0,
+            }
+        ]
+    )
+    bot._apply_positions_snapshot(
+        [
+            {
+                "symbol": symbol,
+                "position_side": "long",
+                "size": 1.5,
+                "price": 101.0,
+            }
+        ]
+    )
+    bot._pnls_manager._events.append(
+        _DummyFillEvent(
+            symbol, "long", 240_000, "matching-fill", psize=1.5, pprice=101.0
+        )
+    )
+    unrelated_pending = _DummyFillEvent(
+        "OTHER/USDT", "short", 240_000, "pending-close"
+    )
+    unrelated_pending.pnl_status = "pending"
+    bot._pnls_manager._events.append(unrelated_pending)
+
+    assert await bot.update_pnls() is False
+    assert bot._trailing_fill_fetch_generation == 1
+    assert getattr(bot, "_trailing_fill_refresh_generation", 0) == 0
+
+    async def complete_matching_epoch_candles(*args, **kwargs):
+        return _make_candles(
+            [(300_000, 101.0, 103.0, 100.0, 102.0, 1.0)]
+        )
+
+    bot.cm.get_candles = complete_matching_epoch_candles
+    await bot.update_trailing_data()
+
+    assert bot._trailing_pending_fill_confirmations == {}
+    assert bot._orchestrator_trailing_unavailable_symbols == set()
+    assert bot.trailing_prices[symbol]["long"]["max_since_open"] == pytest.approx(
+        103.0
+    )
 
 
 @pytest.mark.asyncio
@@ -1817,7 +1895,7 @@ async def test_restart_accepts_matching_fill_before_bybit_position_update_time_a
     # A successful fill refresh after the position snapshot proves the cache is
     # current. The matching fill after-state is authoritative even though
     # Bybit's position updatedTime is later than the fill execTime.
-    bot._trailing_fill_refresh_generation = 1
+    bot._trailing_fill_fetch_generation = 1
     await bot.update_trailing_data()
 
     assert bot._trailing_pending_fill_confirmations == {}

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -1398,8 +1398,11 @@ async def test_position_delta_waits_for_new_fill_identity_across_refresh_cohorts
     }
 
     bot._pnls_manager._events.append(
-        _DummyFillEvent(symbol, "long", 240_000, "new-fill")
+        _DummyFillEvent(
+            symbol, "long", 240_000, "new-fill", psize=1.5, pprice=101.0
+        )
     )
+    bot._trailing_fill_refresh_generation = 1
     await bot.update_trailing_data()
 
     assert bot._trailing_pending_fill_confirmations == {}
@@ -1410,7 +1413,7 @@ async def test_position_delta_waits_for_new_fill_identity_across_refresh_cohorts
 
 
 @pytest.mark.asyncio
-async def test_fill_prefetch_before_position_delta_confirms_new_position_epoch():
+async def test_fill_prefetch_before_position_delta_waits_for_post_snapshot_refresh():
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
     symbol = _set_basic_state(bot)
@@ -1441,7 +1444,9 @@ async def test_fill_prefetch_before_position_delta_confirms_new_position_epoch()
     ]
     bot._apply_positions_snapshot(baseline)
     bot._pnls_manager._events.append(
-        _DummyFillEvent(symbol, "long", 240_000, "new-fill")
+        _DummyFillEvent(
+            symbol, "long", 240_000, "new-fill", psize=1.5, pprice=101.0
+        )
     )
     bot._begin_authoritative_refresh_epoch()
     bot._apply_positions_snapshot(changed)
@@ -1456,6 +1461,16 @@ async def test_fill_prefetch_before_position_delta_confirms_new_position_epoch()
         )
 
     bot.cm.get_candles = complete_new_epoch_candles
+    await bot.update_trailing_data()
+
+    assert bot._trailing_pending_fill_confirmations == {
+        (symbol, "long"): "fill:120000:old-fill"
+    }
+    assert bot._trailing_fill_confirmation_diagnostics[(symbol, "long")][
+        "failed_predicates"
+    ] == ["post_snapshot_fill_refresh_pending"]
+
+    bot._trailing_fill_refresh_generation = 1
     await bot.update_trailing_data()
 
     assert bot._trailing_pending_fill_confirmations == {}
@@ -1518,6 +1533,7 @@ async def test_unchanged_position_snapshot_does_not_associate_prefetched_fill():
         )
 
     bot.cm.get_candles = complete_new_epoch_candles
+    bot._trailing_fill_refresh_generation = 1
     await bot.update_trailing_data()
 
     assert bot._trailing_pending_fill_confirmations == {}
@@ -1728,12 +1744,23 @@ async def test_runtime_delta_without_update_time_rejects_mismatched_prefetched_f
 
 
 @pytest.mark.asyncio
-async def test_restart_blocks_trailing_when_position_is_newer_than_fill_history():
+async def test_restart_accepts_matching_fill_before_bybit_position_update_time_after_refresh(
+    caplog,
+):
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
     symbol = _set_basic_state(bot)
     bot._pnls_manager = _DummyPnlsManager(
-        [_DummyFillEvent(symbol, "long", 120_000, "old-fill")]
+        [
+            _DummyFillEvent(
+                symbol,
+                "long",
+                120_000,
+                "bybit-fill",
+                psize=1.0,
+                pprice=101.0,
+            )
+        ]
     )
     bot.is_trailing = lambda sym, pside=None: pside == "long"
     bot.get_exchange_time = lambda: 361_000
@@ -1752,10 +1779,11 @@ async def test_restart_blocks_trailing_when_position_is_newer_than_fill_history(
 
     assert bot.positions[symbol]["long"]["timestamp"] == 240_000
     assert bot._trailing_pending_fill_confirmations == {
-        (symbol, "long"): "fill:120000:old-fill"
+        (symbol, "long"): None
     }
+    assert bot._trailing_pending_fill_min_generations == {(symbol, "long"): 1}
 
-    async def old_epoch_candles(*args, **kwargs):
+    async def complete_epoch_candles(*args, **kwargs):
         return _make_candles(
             [
                 (180_000, 100.0, 110.0, 90.0, 100.0, 1.0),
@@ -1764,7 +1792,8 @@ async def test_restart_blocks_trailing_when_position_is_newer_than_fill_history(
             ]
         )
 
-    bot.cm.get_candles = old_epoch_candles
+    bot.cm.get_candles = complete_epoch_candles
+    await bot.update_trailing_data()
     await bot.update_trailing_data()
 
     assert bot.trailing_prices[symbol]["long"] == _trailing_default()
@@ -1772,22 +1801,27 @@ async def test_restart_blocks_trailing_when_position_is_newer_than_fill_history(
         symbol: ["position_fill_confirmation_pending"]
     }
 
-    bot._pnls_manager._events.append(
-        _DummyFillEvent(symbol, "long", 180_000, "late-older-fill")
-    )
-    await bot.update_trailing_data()
+    detail = bot._trailing_fill_confirmation_diagnostics[(symbol, "long")]
+    assert detail["failed_predicates"] == ["post_snapshot_fill_refresh_pending"]
+    assert detail["fill_timestamp_ms"] == 120_000
+    assert detail["position_update_timestamp_ms"] == 240_000
+    assert detail["fill_precedes_position_update"] is True
+    warnings = [
+        record
+        for record in caplog.records
+        if "trailing state unavailable" in record.getMessage()
+    ]
+    assert len(warnings) == 1
+    assert "post_snapshot_fill_refresh_pending" in warnings[0].getMessage()
 
-    assert bot.trailing_prices[symbol]["long"] == _trailing_default()
-    assert bot._trailing_pending_fill_confirmations == {
-        (symbol, "long"): "fill:120000:old-fill"
-    }
-
-    bot._pnls_manager._events.append(
-        _DummyFillEvent(symbol, "long", 240_000, "matching-fill")
-    )
+    # A successful fill refresh after the position snapshot proves the cache is
+    # current. The matching fill after-state is authoritative even though
+    # Bybit's position updatedTime is later than the fill execTime.
+    bot._trailing_fill_refresh_generation = 1
     await bot.update_trailing_data()
 
     assert bot._trailing_pending_fill_confirmations == {}
+    assert bot._trailing_fill_confirmation_diagnostics == {}
     assert bot._orchestrator_trailing_unavailable_symbols == set()
     assert bot.trailing_prices[symbol]["long"]["max_since_open"] == pytest.approx(
         112.0


### PR DESCRIPTION
## What

- confirm trailing-position fills with a post-position fill refresh and matching fill after-state
- require a new fill identity for runtime position changes
- treat exchange position update timestamps as advisory diagnostics
- throttle unchanged trailing-unavailable warnings and expose confirmation predicates/watermarks
- make monitor `market[].tradable` match the Rust planner's EMA/trailing gates

## Why

Bybit may publish a position `updatedTime` a few milliseconds after the corresponding fill `execTime`. The previous timestamp comparison required the fill timestamp to be at least the position update timestamp, so a valid matching fill could remain in `position_fill_confirmation_pending` forever and keep the symbol nontradable.

The new proof uses the facts that establish cache freshness without assuming exchange timestamp ordering: a successful fill refresh started after the position snapshot, a new fill identity for runtime changes, and `psize`/`pprice` after-state matching the authoritative position.

## Impact

- valid Bybit trailing positions no longer remain permanently gated solely because `execTime < updatedTime`
- unresolved or mismatched fills remain fail-closed and nontradable
- startup waits for one post-position fill refresh before trailing state becomes ready
- unchanged warnings are emitted on transition and then at most every five minutes
- monitor snapshots report the actual planner gate and bounded confirmation diagnostics
- no exchange-call cadence change beyond the already-supported authoritative fill-confirmation request

## Checks

- `PYTHONPATH=src .../venv/bin/python -m pytest tests/test_unstucking_safeguards.py -q`
- `PYTHONPATH=src .../venv/bin/python -m pytest tests/test_passivbot_monitor.py -q`
- `PYTHONPATH=src .../venv/bin/python -m pytest tests/test_order_orchestration.py -q`
- `PYTHONPATH=src .../venv/bin/python -m pytest tests/test_run_fake_live.py -q`
- `PYTHONPATH=src .../venv/bin/python -m pytest tests/test_live_event_bus.py -q`
- `PYTHONPATH=src .../venv/bin/python -m compileall -q src/passivbot.py src/passivbot_monitor.py`
- `git diff --check`
