### PR TITLE
Profile offline HSL replay stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool hsl-replay-benchmark` now reports exclusive timing profiles
+  for fixture construction, replay internals, final-state projection, candidate
+  and dense-reference runs, equivalence comparison, and residual orchestration.
+  Compact-history benchmarks retain the dense-reference timing evidence they
+  use for equivalence, while timeline-reference runs avoid double-counting the
+  same execution. This is offline diagnostic output only; HSL state, replay
+  behavior, exchange access, orders, and risk are unchanged.
+
 - `passivbot tool runtime-attribution` now reconciles the producer's exact
   12-character lowercase-hex startup-log run-id prefix with one complete
   manifest or startup-event identity when exchange, user, prefix, and start time

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -1,6 +1,6 @@
 # Live Logging Overhaul Current Status
 
-Updated: 2026-07-18.
+Updated: 2026-07-19.
 
 This is the compact operational source for the active logging-overhaul loop.
 Read it before the historical progress ledger. Update it whenever the active
@@ -22,30 +22,53 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/runtime-attribution-log-dedup`, integrated with canonical
-  `8b433cc22b087b0efab51ba2bcf003f1e2b31806` after the semantic slice was
-  based on PR #1315's merge `308702523760ae7a0b309419ae1616b0a4938721`.
-- Scope: reconcile the producer's exact 12-character lowercase-hex startup-log
-  `uuid4().hex[:12]` prefix with one complete runtime manifest/event identity
-  when exchange, user, prefix, and a two-second maximum start-time skew agree.
-  Ambiguous, incomplete, malformed, out-of-scope, and out-of-bound records
-  remain separate.
-- Triggering PR #1315 deployment/smoke evidence: the full manifest started at
-  `1784414326269` ms while its matching bounded startup log used
-  `1784414328000` ms with the same run-id prefix, a `1731` ms skew that produced
-  duplicate runtime observations.
-- Behavior boundary: offline attribution parsing, docs, and tests only. No
-  trading, exchange, runtime producer, order, risk, config, restart, or process
-  behavior changes.
-- Validation: focused attribution tests cover the observed `1731` ms pair, the
-  inclusive two-second limit, short/uppercase prefixes, incomplete identities,
-  scope isolation, and ambiguity.
-- Review gate: final exact-head Hermes approval plus green Python/Rust CI.
-  Built-in Codex automatic review is additional, not a replacement for either.
-- Expected VPS action: after merge, a bounded read-only attribution smoke only;
-  no bot restart is required.
+- Branch: `codex/hsl-replay-stage-profile`, based on canonical
+  `881978dec502296c4ab990c34bf06fdf74f024b2`.
+- Scope: make the existing deterministic offline coin-HSL replay benchmark
+  attribute elapsed work to bounded stages, including held/background replay
+  samples and the residual replay orchestration that is currently hidden by
+  the aggregate elapsed value.
+- Behavior boundary: offline benchmark tooling and tests only. No live HSL,
+  trading, exchange, runtime producer, order, risk, config, restart, cache, or
+  process behavior changes.
+- Validation: focused benchmark tests must prove stable stage taxonomy, exact
+  call/sample accounting, nonnegative elapsed/residual math, unchanged dense
+  reference equivalence, distinct compact candidate/reference accounting,
+  timeline self-reference without double-counting, and zero
+  network/cache/latch/monitor side effects.
+- Review gate: implementation is complete in commits `a08f5f8dc6` and
+  `1414702a8d`; 18 focused tests, Python compilation, documentation checks,
+  and diff checks passed. The exact 43,201-minute/30-symbol compact run was
+  equivalent to its dense reference and completed in `163.56s` wall time. Its
+  candidate run took `2.899s`; the dense-reference run took `156.390s`, with
+  `147.403s` now attributed to residual replay orchestration. The final
+  exact head requires Hermes approval plus green Python/Rust CI; built-in Codex
+  review is additional and every finding must be resolved.
+- Expected VPS action: after merge, tracked-clean pull plus a bounded offline
+  benchmark smoke only; no bot restart or signal is required.
 
-## Deployed Baseline (PR #1312)
+## Deployed Baseline (PR #1322)
+
+- PR #1322 merged as canonical
+  `881978dec502296c4ab990c34bf06fdf74f024b2`. VPS5 fast-forwarded
+  tracked-clean from `8b433cc22b087b0efab51ba2bcf003f1e2b31806` without a Rust
+  build, bot restart, or process signal.
+- The exact Hyperliquid attribution smoke scanned 26 selected artifacts and
+  `15763500` bytes, read 51 fill records, returned 37 trailing fills and zero
+  warnings, and reduced the previously duplicated `1784414326269` runtime to
+  one cohort carrying `runtime_manifest`, `monitor_event`,
+  `legacy_startup_log`, and `runtime_log` sources.
+- Smaller explicit scan caps failed closed before the successful exact-file
+  smoke. Temporary over-broad scanner PIDs created by interrupted local-only
+  commands were identity-checked and terminated exactly; no bot or tmux pane
+  was signalled.
+- Final local-only target sampling was hard-green with five expected and stable
+  bot PIDs, no missing, duplicate, or extra process, and natural recovery from
+  one transient `D` observation to `R=5`. The checkout remained tracked-clean,
+  no scanner remained, and protected `misc:0.0` stayed `%8`/PID `434835`. No
+  direct exchange call or event was manufactured.
+
+## Previous Deployed Baseline (PR #1312)
 
 - PR #1312 merged as canonical
   `8b433cc22b087b0efab51ba2bcf003f1e2b31806`. The guarded tracked-clean

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,25 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1312)
+## Latest Canonical Deployment (PR #1322)
+
+- PR #1322 merged as canonical
+  `881978dec502296c4ab990c34bf06fdf74f024b2`. VPS5 fast-forwarded
+  tracked-clean from `8b433cc22` without a Rust build, bot restart, or process
+  signal.
+- The exact-file Hyperliquid attribution smoke scanned 26 artifacts and
+  `15763500` bytes, read 51 fill records, returned 37 trailing fills and zero
+  warnings, and reconciled the previous `1731` ms manifest/log skew into one
+  four-source runtime cohort. Smaller explicit bounds failed closed before the
+  successful run; temporary scanner PIDs from interrupted commands were
+  identity-checked and terminated exactly without touching bots or panes.
+- Final local-only target sampling was hard-green with five expected/stable
+  processes and no missing, duplicate, extra, or temporary scanner process.
+  One transient `D` observation recovered naturally to `R=5`; protected
+  `misc:0.0` remained `%8`/PID `434835`. No direct exchange call or event was
+  manufactured.
+
+## Previous Canonical Deployment (PR #1312)
 
 - PR #1312 merged as canonical `8b433cc22b087b0efab51ba2bcf003f1e2b31806`.
   Guarded tracked-clean fast-forwarded `30870252` to that exact merge without a

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -102,7 +102,16 @@ slices.
     slice extends this to a 43,201-minute, 30-pair fixture with held and
     historical-flat pairs, cooldown/panic transitions, same-timestamp fills,
     account-balance changes, EMA smoothing, and exact dense-reference state and
-    sample-count comparison. Deeper internal-stage profiling remains open.
+    sample-count comparison. The stage-profile slice adds exclusive candidate,
+    dense-reference, equivalence-comparison, fixture, history-load,
+    held/background sample, current-UPnL, projection, and residual-orchestration
+    timings. Production cache discovery/decode, exchange backfill, and event
+    emission remain outside this in-memory benchmark and still require separate
+    evidence. On the exact 43,201-minute/30-symbol fixture, the compact
+    candidate run took `2.899s` and the dense-reference run took `156.390s`;
+    `147.403s` of reference full-replay time was residual orchestration after
+    `5.873s` of measured held/background metric sampling. Candidate and
+    reference fixture contract, sample counts, and final state all matched.
 - [ ] Acceptance: before optimizing, the report identifies the dominant cost
   category and provides a repeatable local benchmark.
 
@@ -649,8 +658,10 @@ Trading-impact labels:
   - Active candidate: the benchmark distinguishes held/background pairs and
     samples, reports expected cooperative yields, supports an explicit
     43,201-minute local-scale mode, includes cooldown/panic and account-balance
-    transitions, and compares candidate and dense-reference final state plus
-    sample counts. It can also report tracemalloc current/peak bytes.
+    transitions, compares candidate and dense-reference final state plus
+    sample counts, and reports exclusive per-run and whole-pipeline stage
+    profiles without counting reference execution as candidate replay time. It
+    can also report tracemalloc current/peak bytes.
 
 - [ ] Index fill events once by `(pside, symbol)`.
   - Reuse that index for replay contracts, panic detection, position-size

--- a/src/tools/hsl_replay_benchmark.py
+++ b/src/tools/hsl_replay_benchmark.py
@@ -91,44 +91,53 @@ def _timing_value(
     return {"calls": int(values["calls"]), "elapsed_ns": int(values["elapsed_ns"])}
 
 
+def _exclusive_elapsed_profile(
+    *, total_elapsed_ns: int, stages: dict[str, dict[str, int]], scope: str
+) -> dict[str, Any]:
+    accounted_elapsed_ns = sum(values["elapsed_ns"] for values in stages.values())
+    if accounted_elapsed_ns > total_elapsed_ns:
+        raise RuntimeError(
+            f"offline HSL benchmark {scope} stages exceed total elapsed time"
+        )
+    residual_elapsed_ns = total_elapsed_ns - accounted_elapsed_ns
+
+    def percent_of_total(elapsed_ns: int) -> float:
+        if total_elapsed_ns <= 0:
+            return 0.0
+        return min(100.0, max(0.0, elapsed_ns / total_elapsed_ns * 100.0))
+
+    percent_key = f"percent_of_{scope}"
+    return {
+        "elapsed_ns": total_elapsed_ns,
+        "accounted_elapsed_ns": accounted_elapsed_ns,
+        f"accounted_{percent_key}": percent_of_total(accounted_elapsed_ns),
+        "stages": {
+            stage: {**values, percent_key: percent_of_total(values["elapsed_ns"])}
+            for stage, values in stages.items()
+        },
+        "residual_orchestration": {
+            "elapsed_ns": residual_elapsed_ns,
+            percent_key: percent_of_total(residual_elapsed_ns),
+        },
+    }
+
+
 def _stage_profile(timings: dict[str, dict[str, int]]) -> dict[str, Any]:
     """Return exclusive replay timing shares plus uninstrumented orchestration."""
     full_replay = _timing_value(timings, "full_replay")
-    full_replay_elapsed_ns = full_replay["elapsed_ns"]
     stages = {
         stage: _timing_value(timings, stage) for stage in FULL_REPLAY_LEAF_STAGE_NAMES
     }
-    accounted_elapsed_ns = sum(values["elapsed_ns"] for values in stages.values())
-    if accounted_elapsed_ns > full_replay_elapsed_ns:
-        raise RuntimeError("offline HSL replay timing stages exceed full replay elapsed time")
-    residual_elapsed_ns = full_replay_elapsed_ns - accounted_elapsed_ns
-
-    def percent_of_full_replay(elapsed_ns: int) -> float:
-        if full_replay_elapsed_ns <= 0:
-            return 0.0
-        return min(100.0, max(0.0, elapsed_ns / full_replay_elapsed_ns * 100.0))
 
     return {
         "taxonomy": "exclusive_full_replay_leaf_stages_v1",
         "full_replay": {
-            **full_replay,
-            "accounted_elapsed_ns": accounted_elapsed_ns,
-            "accounted_percent_of_full_replay": percent_of_full_replay(
-                accounted_elapsed_ns
+            "calls": full_replay["calls"],
+            **_exclusive_elapsed_profile(
+                total_elapsed_ns=full_replay["elapsed_ns"],
+                stages=stages,
+                scope="full_replay",
             ),
-            "stages": {
-                stage: {
-                    **values,
-                    "percent_of_full_replay": percent_of_full_replay(
-                        values["elapsed_ns"]
-                    ),
-                }
-                for stage, values in stages.items()
-            },
-            "residual_orchestration": {
-                "elapsed_ns": residual_elapsed_ns,
-                "percent_of_full_replay": percent_of_full_replay(residual_elapsed_ns),
-            },
         },
         "outside_full_replay": {
             stage: _timing_value(timings, stage)
@@ -752,6 +761,7 @@ async def _run_hsl_replay_benchmark(
     if not 1 <= int(iterations) <= MAX_ITERATIONS:
         raise ValueError(f"iterations must be between 1 and {MAX_ITERATIONS}")
 
+    run_started_ns = time.perf_counter_ns()
     minutes, symbols, held_symbols = _validate_fixture_shape(
         minutes, symbols, held_symbols, local_scale=local_scale
     )
@@ -832,7 +842,8 @@ async def _run_hsl_replay_benchmark(
     full_replay_elapsed_ns = int(timing_totals["full_replay"]["elapsed_ns"])
     elapsed_seconds = max(full_replay_elapsed_ns, 1) / 1_000_000_000.0
     replay_rows = minutes * int(iterations)
-    return {
+    stage_profile = _stage_profile(timing_totals)
+    report = {
         "schema_version": BENCHMARK_SCHEMA_VERSION,
         "kind": "hsl_replay_benchmark",
         "offline": True,
@@ -885,7 +896,7 @@ async def _run_hsl_replay_benchmark(
         "timings": {
             stage: _timing_value(timing_totals, stage) for stage in TIMING_STAGE_NAMES
         },
-        "stage_profile": _stage_profile(timing_totals),
+        "stage_profile": stage_profile,
         "throughput": {
             "timeline_rows_per_second": replay_rows / elapsed_seconds,
             "pair_rows_per_second": expected_replay_samples / elapsed_seconds,
@@ -898,6 +909,20 @@ async def _run_hsl_replay_benchmark(
         },
         "side_effects": dict(sorted(side_effect_totals.items())),
     }
+    run_elapsed_ns = time.perf_counter_ns() - run_started_ns
+    run_stages = {
+        stage: _timing_value(timing_totals, stage)
+        for stage in ("fixture_construction", "full_replay", "final_state_projection")
+    }
+    stage_profile["run"] = {
+        "calls": 1,
+        **_exclusive_elapsed_profile(
+            total_elapsed_ns=run_elapsed_ns,
+            stages=run_stages,
+            scope="run",
+        ),
+    }
+    return report
 
 
 async def run_hsl_replay_benchmark(
@@ -917,6 +942,7 @@ async def run_hsl_replay_benchmark(
         raise ValueError(f"iterations must be between 1 and {MAX_ITERATIONS}")
     _validate_fixture_shape(minutes, symbols, held_symbols, local_scale=local_scale)
 
+    pipeline_started_ns = time.perf_counter_ns()
     tracing_started_here = False
     if profile_memory:
         if not tracemalloc.is_tracing():
@@ -932,8 +958,9 @@ async def run_hsl_replay_benchmark(
             local_scale=local_scale,
             history_format=history_format,
         )
+        reference_is_candidate = history_format == DENSE_REFERENCE_HISTORY_FORMAT
         reference_report = report
-        if history_format != DENSE_REFERENCE_HISTORY_FORMAT:
+        if not reference_is_candidate:
             reference_report = await _run_hsl_replay_benchmark(
                 minutes=minutes,
                 symbols=symbols,
@@ -942,13 +969,26 @@ async def run_hsl_replay_benchmark(
                 local_scale=local_scale,
                 history_format=DENSE_REFERENCE_HISTORY_FORMAT,
             )
-        report["dense_reference"] = {
+        dense_reference = {
             "history_format": DENSE_REFERENCE_HISTORY_FORMAT,
+            "same_run_as_candidate": reference_is_candidate,
             "fixture_scenario_sha256": reference_report["fixture"]["scenario_sha256"],
             "sample_counts": _sample_count_projection(reference_report),
             "output_state": reference_report["output_state"],
         }
+        if not reference_is_candidate:
+            dense_reference.update(
+                {
+                    "fixture": reference_report["fixture"],
+                    "timings": reference_report["timings"],
+                    "stage_profile": reference_report["stage_profile"],
+                    "throughput": reference_report["throughput"],
+                }
+            )
+        report["dense_reference"] = dense_reference
+        comparison_started_ns = time.perf_counter_ns()
         report["equivalence"] = compare_dense_reference_output(reference_report, report)
+        comparison_elapsed_ns = time.perf_counter_ns() - comparison_started_ns
         if profile_memory:
             current_bytes, peak_bytes = tracemalloc.get_traced_memory()
             report["memory"] = {
@@ -956,6 +996,31 @@ async def run_hsl_replay_benchmark(
                 "current_bytes": int(current_bytes),
                 "peak_bytes": int(peak_bytes),
             }
+        pipeline_stages = {
+            "candidate_run": {
+                "calls": 1,
+                "elapsed_ns": int(report["stage_profile"]["run"]["elapsed_ns"]),
+            }
+        }
+        if not reference_is_candidate:
+            pipeline_stages["dense_reference_run"] = {
+                "calls": 1,
+                "elapsed_ns": int(reference_report["stage_profile"]["run"]["elapsed_ns"]),
+            }
+        pipeline_stages["equivalence_comparison"] = {
+            "calls": 1,
+            "elapsed_ns": comparison_elapsed_ns,
+        }
+        pipeline_elapsed_ns = time.perf_counter_ns() - pipeline_started_ns
+        report["pipeline_profile"] = {
+            "taxonomy": "exclusive_benchmark_pipeline_stages_v1",
+            "calls": 1,
+            **_exclusive_elapsed_profile(
+                total_elapsed_ns=pipeline_elapsed_ns,
+                stages=pipeline_stages,
+                scope="pipeline",
+            ),
+        }
         return report
     finally:
         if tracing_started_here:

--- a/src/tools/hsl_replay_benchmark.py
+++ b/src/tools/hsl_replay_benchmark.py
@@ -16,7 +16,7 @@ import passivbot_rust as pbr
 from passivbot import Passivbot
 
 
-BENCHMARK_SCHEMA_VERSION = 2
+BENCHMARK_SCHEMA_VERSION = 3
 DEFAULT_MINUTES = 240
 DEFAULT_SYMBOLS = 8
 DEFAULT_ITERATIONS = 1
@@ -38,10 +38,103 @@ REFERENCE_SAMPLE_COUNT_KEYS = (
     "held_replay_samples",
     "background_replay_samples",
 )
+TIMING_STAGE_NAMES = (
+    "fixture_construction",
+    "history_load",
+    "cache_reuse_skipped",
+    "coin_metrics_sample",
+    "held_coin_metrics_sample",
+    "background_coin_metrics_sample",
+    "current_upnl",
+    "cache_persist_skipped",
+    "final_state_projection",
+    "full_replay",
+)
+FULL_REPLAY_LEAF_STAGE_NAMES = (
+    "history_load",
+    "cache_reuse_skipped",
+    "held_coin_metrics_sample",
+    "background_coin_metrics_sample",
+    "current_upnl",
+    "cache_persist_skipped",
+)
 
 
 def _fixture_symbol(index: int) -> str:
     return f"HSLBENCH{index:02d}/USDT:USDT"
+
+
+def _new_timing_totals() -> dict[str, dict[str, int]]:
+    return {
+        stage: {"calls": 0, "elapsed_ns": 0} for stage in TIMING_STAGE_NAMES
+    }
+
+
+def _record_elapsed(
+    timings: dict[str, dict[str, int]], stage: str, elapsed_ns: int
+) -> None:
+    values = timings[stage]
+    values["calls"] += 1
+    values["elapsed_ns"] += elapsed_ns
+
+
+def _record_timing(
+    timings: dict[str, dict[str, int]], stage: str, started_ns: int
+) -> None:
+    _record_elapsed(timings, stage, time.perf_counter_ns() - started_ns)
+
+
+def _timing_value(
+    timings: dict[str, dict[str, int]], stage: str
+) -> dict[str, int]:
+    values = timings[stage]
+    return {"calls": int(values["calls"]), "elapsed_ns": int(values["elapsed_ns"])}
+
+
+def _stage_profile(timings: dict[str, dict[str, int]]) -> dict[str, Any]:
+    """Return exclusive replay timing shares plus uninstrumented orchestration."""
+    full_replay = _timing_value(timings, "full_replay")
+    full_replay_elapsed_ns = full_replay["elapsed_ns"]
+    stages = {
+        stage: _timing_value(timings, stage) for stage in FULL_REPLAY_LEAF_STAGE_NAMES
+    }
+    accounted_elapsed_ns = sum(values["elapsed_ns"] for values in stages.values())
+    if accounted_elapsed_ns > full_replay_elapsed_ns:
+        raise RuntimeError("offline HSL replay timing stages exceed full replay elapsed time")
+    residual_elapsed_ns = full_replay_elapsed_ns - accounted_elapsed_ns
+
+    def percent_of_full_replay(elapsed_ns: int) -> float:
+        if full_replay_elapsed_ns <= 0:
+            return 0.0
+        return min(100.0, max(0.0, elapsed_ns / full_replay_elapsed_ns * 100.0))
+
+    return {
+        "taxonomy": "exclusive_full_replay_leaf_stages_v1",
+        "full_replay": {
+            **full_replay,
+            "accounted_elapsed_ns": accounted_elapsed_ns,
+            "accounted_percent_of_full_replay": percent_of_full_replay(
+                accounted_elapsed_ns
+            ),
+            "stages": {
+                stage: {
+                    **values,
+                    "percent_of_full_replay": percent_of_full_replay(
+                        values["elapsed_ns"]
+                    ),
+                }
+                for stage, values in stages.items()
+            },
+            "residual_orchestration": {
+                "elapsed_ns": residual_elapsed_ns,
+                "percent_of_full_replay": percent_of_full_replay(residual_elapsed_ns),
+            },
+        },
+        "outside_full_replay": {
+            stage: _timing_value(timings, stage)
+            for stage in ("fixture_construction", "final_state_projection")
+        },
+    }
 
 
 def _validate_fixture_shape(
@@ -456,24 +549,28 @@ def _make_offline_replay_bot(
         try:
             return history
         finally:
-            timings["history_load"]["calls"] += 1
-            timings["history_load"]["elapsed_ns"] += time.perf_counter_ns() - started_ns
+            _record_timing(timings, "history_load", started_ns)
 
     async def no_cache_reuse(*_args, **_kwargs):
-        timings["cache_reuse_skipped"]["calls"] += 1
-        return None
+        started_ns = time.perf_counter_ns()
+        try:
+            return None
+        finally:
+            _record_timing(timings, "cache_reuse_skipped", started_ns)
 
     async def current_upnl(*_args, **_kwargs):
         started_ns = time.perf_counter_ns()
         try:
             return 0.0
         finally:
-            timings["current_upnl"]["calls"] += 1
-            timings["current_upnl"]["elapsed_ns"] += time.perf_counter_ns() - started_ns
+            _record_timing(timings, "current_upnl", started_ns)
 
     def skip_cache_persist(*_args, **_kwargs):
-        timings["cache_persist_skipped"]["calls"] += 1
-        return 0
+        started_ns = time.perf_counter_ns()
+        try:
+            return 0
+        finally:
+            _record_timing(timings, "cache_persist_skipped", started_ns)
 
     def skip_latch_write(*_args, **_kwargs):
         side_effects["latch_writes"] += 1
@@ -486,12 +583,18 @@ def _make_offline_replay_bot(
 
     def profile_coin_metrics_sample(*args, **kwargs):
         started_ns = time.perf_counter_ns()
+        symbol = args[1] if len(args) > 1 else kwargs["symbol"]
+        sample_stage = (
+            "held_coin_metrics_sample"
+            if symbol in held_symbols
+            else "background_coin_metrics_sample"
+        )
         try:
             return original_apply_metrics(*args, **kwargs)
         finally:
-            timings["coin_metrics_sample"]["calls"] += 1
-            timings["coin_metrics_sample"]["elapsed_ns"] += time.perf_counter_ns() - started_ns
-            symbol = args[1] if len(args) > 1 else kwargs["symbol"]
+            elapsed_ns = time.perf_counter_ns() - started_ns
+            _record_elapsed(timings, "coin_metrics_sample", elapsed_ns)
+            _record_elapsed(timings, sample_stage, elapsed_ns)
             sample_counts[
                 "held_replay_samples" if symbol in held_symbols else "background_replay_samples"
             ] += 1
@@ -652,25 +755,30 @@ async def _run_hsl_replay_benchmark(
     minutes, symbols, held_symbols = _validate_fixture_shape(
         minutes, symbols, held_symbols, local_scale=local_scale
     )
-    if history_format == "timeline":
-        history = build_coin_hsl_history_fixture(
-            minutes=minutes,
-            symbols=symbols,
-            held_symbols=held_symbols,
-            local_scale=local_scale,
-        )
-    elif history_format == "compact":
-        history = build_coin_hsl_compact_fixture(
-            minutes=minutes,
-            symbols=symbols,
-            held_symbols=held_symbols,
-            local_scale=local_scale,
-        )
-    else:
-        raise ValueError(
-            "history_format must be one of timeline or compact, "
-            f"got {history_format!r}"
-        )
+    timing_totals = _new_timing_totals()
+    fixture_started_ns = time.perf_counter_ns()
+    try:
+        if history_format == "timeline":
+            history = build_coin_hsl_history_fixture(
+                minutes=minutes,
+                symbols=symbols,
+                held_symbols=held_symbols,
+                local_scale=local_scale,
+            )
+        elif history_format == "compact":
+            history = build_coin_hsl_compact_fixture(
+                minutes=minutes,
+                symbols=symbols,
+                held_symbols=held_symbols,
+                local_scale=local_scale,
+            )
+        else:
+            raise ValueError(
+                "history_format must be one of timeline or compact, "
+                f"got {history_format!r}"
+            )
+    finally:
+        _record_timing(timing_totals, "fixture_construction", fixture_started_ns)
     held_names = {_fixture_symbol(index) for index in range(held_symbols)}
     active_names = set(held_names)
     active_names.update(
@@ -679,12 +787,10 @@ async def _run_hsl_replay_benchmark(
         if event.get("symbol")
     )
     active_symbols = len(active_names)
-    timing_totals: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
     sample_counts: dict[str, int] = defaultdict(int)
     state_digests: list[str] = []
     state_projections: list[list[dict[str, Any]]] = []
     side_effect_totals: dict[str, int] = defaultdict(int)
-    full_replay_elapsed_ns = 0
     for _ in range(int(iterations)):
         bot = _make_offline_replay_bot(history, timing_totals, held_names, sample_counts)
         started_ns = time.perf_counter_ns()
@@ -694,8 +800,12 @@ async def _run_hsl_replay_benchmark(
             await bot._equity_hard_stop_initialize_coin_from_history()
         finally:
             logging.disable(previous_logging_disable)
-        full_replay_elapsed_ns += time.perf_counter_ns() - started_ns
-        state_projection = _state_projection(bot)
+            _record_timing(timing_totals, "full_replay", started_ns)
+        projection_started_ns = time.perf_counter_ns()
+        try:
+            state_projection = _state_projection(bot)
+        finally:
+            _record_timing(timing_totals, "final_state_projection", projection_started_ns)
         state_projections.append(state_projection)
         state_digests.append(_state_digest_from_projection(state_projection))
         for key, value in bot._offline_hsl_benchmark_side_effects.items():
@@ -719,6 +829,7 @@ async def _run_hsl_replay_benchmark(
     held_current_samples = held_symbols * int(iterations)
     background_current_samples = background_symbols * int(iterations)
     actual_sample_calls = int(timing_totals["coin_metrics_sample"]["calls"])
+    full_replay_elapsed_ns = int(timing_totals["full_replay"]["elapsed_ns"])
     elapsed_seconds = max(full_replay_elapsed_ns, 1) / 1_000_000_000.0
     replay_rows = minutes * int(iterations)
     return {
@@ -772,15 +883,9 @@ async def _run_hsl_replay_benchmark(
             ),
         },
         "timings": {
-            stage: {"calls": int(values["calls"]), "elapsed_ns": int(values["elapsed_ns"])}
-            for stage, values in sorted(timing_totals.items())
-        }
-        | {
-            "full_replay": {
-                "calls": int(iterations),
-                "elapsed_ns": int(full_replay_elapsed_ns),
-            }
+            stage: _timing_value(timing_totals, stage) for stage in TIMING_STAGE_NAMES
         },
+        "stage_profile": _stage_profile(timing_totals),
         "throughput": {
             "timeline_rows_per_second": replay_rows / elapsed_seconds,
             "pair_rows_per_second": expected_replay_samples / elapsed_seconds,

--- a/tests/test_hsl_replay_benchmark.py
+++ b/tests/test_hsl_replay_benchmark.py
@@ -22,7 +22,7 @@ def _without_timing(value):
         return {
             key: _without_timing(item)
             for key, item in value.items()
-            if key not in {"timings", "throughput", "stage_profile"}
+            if key not in {"timings", "throughput", "stage_profile", "pipeline_profile"}
         }
     if isinstance(value, list):
         return [_without_timing(item) for item in value]
@@ -157,6 +157,56 @@ def test_hsl_replay_benchmark_stage_profile_is_exclusive_and_bounded():
     assert profile["outside_full_replay"]["final_state_projection"]["calls"] == 2
 
 
+def _assert_exact_profile_accounting(profile, percent_key):
+    assert profile["accounted_elapsed_ns"] == sum(
+        stage["elapsed_ns"] for stage in profile["stages"].values()
+    )
+    assert profile["elapsed_ns"] == (
+        profile["accounted_elapsed_ns"]
+        + profile["residual_orchestration"]["elapsed_ns"]
+    )
+    for stage in list(profile["stages"].values()) + [
+        profile["residual_orchestration"]
+    ]:
+        assert stage["elapsed_ns"] >= 0
+        assert 0.0 <= stage[percent_key] <= 100.0
+
+
+def test_hsl_replay_benchmark_pipeline_profiles_distinct_runs_without_overlap():
+    report = asyncio.run(
+        hsl_replay_benchmark.run_hsl_replay_benchmark(
+            minutes=700, symbols=4, held_symbols=1, iterations=2
+        )
+    )
+
+    reference = report["dense_reference"]
+    assert reference["same_run_as_candidate"] is False
+    assert reference["fixture"]["history_format"] == "timeline"
+    assert reference["stage_profile"]["run"]["calls"] == 1
+    assert reference["stage_profile"]["full_replay"]["calls"] == 2
+    assert reference["stage_profile"]["outside_full_replay"][
+        "final_state_projection"
+    ]["calls"] == 2
+    assert reference["throughput"]["timeline_rows_per_second"] > 0.0
+    assert list(report["pipeline_profile"]["stages"]) == [
+        "candidate_run",
+        "dense_reference_run",
+        "equivalence_comparison",
+    ]
+
+    _assert_exact_profile_accounting(
+        report["stage_profile"]["full_replay"], "percent_of_full_replay"
+    )
+    _assert_exact_profile_accounting(report["stage_profile"]["run"], "percent_of_run")
+    _assert_exact_profile_accounting(
+        reference["stage_profile"]["full_replay"], "percent_of_full_replay"
+    )
+    _assert_exact_profile_accounting(
+        reference["stage_profile"]["run"], "percent_of_run"
+    )
+    _assert_exact_profile_accounting(report["pipeline_profile"], "percent_of_pipeline")
+
+
 def test_hsl_replay_benchmark_memory_profile_is_opt_in():
     report = asyncio.run(
         hsl_replay_benchmark.run_hsl_replay_benchmark(
@@ -263,6 +313,14 @@ def test_hsl_replay_benchmark_compact_and_timeline_reach_identical_state():
     assert timeline["side_effects"] == compact["side_effects"]
     assert timeline["fixture"]["scenario_sha256"] == compact["fixture"]["scenario_sha256"]
     assert compact["dense_reference"]["history_format"] == "timeline"
+    assert compact["dense_reference"]["same_run_as_candidate"] is False
+    assert timeline["dense_reference"]["same_run_as_candidate"] is True
+    assert "stage_profile" not in timeline["dense_reference"]
+    assert "throughput" not in timeline["dense_reference"]
+    assert list(timeline["pipeline_profile"]["stages"]) == [
+        "candidate_run",
+        "equivalence_comparison",
+    ]
     assert compact["equivalence"]["matches"] is True
     assert compact["equivalence"]["output_state"]["matches"] is True
     assert compact["equivalence"]["sample_counts"]["matches"] is True
@@ -295,7 +353,10 @@ def test_hsl_replay_benchmark_dense_reference_comparison_excludes_timing():
     candidate = copy.deepcopy(reference)
     candidate["timings"]["full_replay"]["elapsed_ns"] += 1
     candidate["stage_profile"]["full_replay"]["residual_orchestration"]["elapsed_ns"] += 1
+    candidate["stage_profile"]["run"]["residual_orchestration"]["elapsed_ns"] += 1
     candidate["stage_profile"]["full_replay"]["accounted_percent_of_full_replay"] = 0.0
+    candidate["pipeline_profile"]["elapsed_ns"] += 1
+    candidate["dense_reference"]["timings"]["full_replay"]["elapsed_ns"] += 1
 
     comparison = hsl_replay_benchmark.compare_dense_reference_output(reference, candidate)
 

--- a/tests/test_hsl_replay_benchmark.py
+++ b/tests/test_hsl_replay_benchmark.py
@@ -17,15 +17,15 @@ if bool(getattr(pbr, "__is_stub__", False)):
     pytest.skip("passivbot_rust extension not available", allow_module_level=True)
 
 
-def _without_elapsed_ns(value):
+def _without_timing(value):
     if isinstance(value, dict):
         return {
-            key: _without_elapsed_ns(item)
+            key: _without_timing(item)
             for key, item in value.items()
-            if key not in {"elapsed_ns", "throughput"}
+            if key not in {"timings", "throughput", "stage_profile"}
         }
     if isinstance(value, list):
-        return [_without_elapsed_ns(item) for item in value]
+        return [_without_timing(item) for item in value]
     return value
 
 
@@ -38,6 +38,7 @@ def test_hsl_replay_benchmark_is_deterministic_and_has_no_side_effects():
     )
 
     assert first["offline"] is True
+    assert first["schema_version"] == 3
     assert first["fixture"]["compact_rows"] == 4
     assert first["fixture"]["fill_events"] == 1
     assert first["counters"] == {
@@ -55,11 +56,19 @@ def test_hsl_replay_benchmark_is_deterministic_and_has_no_side_effects():
         "held_replay_samples": 8,
         "background_replay_samples": 0,
     }
-    assert first["timings"]["history_load"]["calls"] == 2
-    assert first["timings"]["coin_metrics_sample"]["calls"] == 10
-    assert first["timings"]["current_upnl"]["calls"] == 2
-    assert first["timings"]["cache_reuse_skipped"]["calls"] == 2
-    assert first["timings"]["cache_persist_skipped"]["calls"] == 2
+    assert {stage: first["timings"][stage]["calls"] for stage in first["timings"]} == {
+        "fixture_construction": 1,
+        "history_load": 2,
+        "cache_reuse_skipped": 2,
+        "coin_metrics_sample": 10,
+        "held_coin_metrics_sample": 10,
+        "background_coin_metrics_sample": 0,
+        "current_upnl": 2,
+        "cache_persist_skipped": 2,
+        "final_state_projection": 2,
+        "full_replay": 2,
+    }
+    assert all(values["elapsed_ns"] >= 0 for values in first["timings"].values())
     assert first["throughput"]["timeline_rows_per_second"] > 0.0
     assert first["throughput"]["pair_rows_per_second"] == pytest.approx(
         first["throughput"]["timeline_rows_per_second"]
@@ -76,7 +85,7 @@ def test_hsl_replay_benchmark_is_deterministic_and_has_no_side_effects():
     assert first["equivalence"]["matches"] is True
     assert first["equivalence"]["sample_counts"]["matches"] is True
     assert first["equivalence"]["output_state"]["matches"] is True
-    assert _without_elapsed_ns(first) == _without_elapsed_ns(second)
+    assert _without_timing(first) == _without_timing(second)
 
 
 def test_hsl_replay_benchmark_separates_held_and_background_work():
@@ -104,6 +113,48 @@ def test_hsl_replay_benchmark_separates_held_and_background_work():
         "held_replay_samples": 1_400,
         "background_replay_samples": 34,
     }
+    timings = report["timings"]
+    assert timings["held_coin_metrics_sample"]["calls"] == 1_402
+    assert timings["background_coin_metrics_sample"]["calls"] == 36
+    assert (
+        timings["held_coin_metrics_sample"]["calls"]
+        + timings["background_coin_metrics_sample"]["calls"]
+        == timings["coin_metrics_sample"]["calls"]
+    )
+    assert (
+        timings["held_coin_metrics_sample"]["elapsed_ns"]
+        + timings["background_coin_metrics_sample"]["elapsed_ns"]
+        == timings["coin_metrics_sample"]["elapsed_ns"]
+    )
+
+
+def test_hsl_replay_benchmark_stage_profile_is_exclusive_and_bounded():
+    report = asyncio.run(
+        hsl_replay_benchmark.run_hsl_replay_benchmark(
+            minutes=700, symbols=4, held_symbols=1, iterations=2
+        )
+    )
+
+    profile = report["stage_profile"]
+    full_replay = profile["full_replay"]
+    assert profile["taxonomy"] == "exclusive_full_replay_leaf_stages_v1"
+    assert list(full_replay["stages"]) == list(
+        hsl_replay_benchmark.FULL_REPLAY_LEAF_STAGE_NAMES
+    )
+    assert full_replay["accounted_elapsed_ns"] == sum(
+        stage["elapsed_ns"] for stage in full_replay["stages"].values()
+    )
+    assert full_replay["elapsed_ns"] == (
+        full_replay["accounted_elapsed_ns"]
+        + full_replay["residual_orchestration"]["elapsed_ns"]
+    )
+    for stage in list(full_replay["stages"].values()) + [
+        full_replay["residual_orchestration"]
+    ]:
+        assert stage["elapsed_ns"] >= 0
+        assert 0.0 <= stage["percent_of_full_replay"] <= 100.0
+    assert profile["outside_full_replay"]["fixture_construction"]["calls"] == 1
+    assert profile["outside_full_replay"]["final_state_projection"]["calls"] == 2
 
 
 def test_hsl_replay_benchmark_memory_profile_is_opt_in():
@@ -235,6 +286,22 @@ def test_hsl_replay_benchmark_dense_reference_comparison_detects_mismatch():
     assert comparison["sample_counts"]["matches"] is False
     assert comparison["output_state"]["matches"] is True
     assert comparison["matches"] is False
+
+
+def test_hsl_replay_benchmark_dense_reference_comparison_excludes_timing():
+    reference = asyncio.run(
+        hsl_replay_benchmark.run_hsl_replay_benchmark(minutes=8, symbols=3, held_symbols=1)
+    )
+    candidate = copy.deepcopy(reference)
+    candidate["timings"]["full_replay"]["elapsed_ns"] += 1
+    candidate["stage_profile"]["full_replay"]["residual_orchestration"]["elapsed_ns"] += 1
+    candidate["stage_profile"]["full_replay"]["accounted_percent_of_full_replay"] = 0.0
+
+    comparison = hsl_replay_benchmark.compare_dense_reference_output(reference, candidate)
+
+    assert comparison["sample_counts"]["matches"] is True
+    assert comparison["output_state"]["matches"] is True
+    assert comparison["matches"] is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- add schema-v3 exclusive timing profiles to the offline coin-HSL replay benchmark
- retain distinct compact candidate and dense-reference timing evidence, with timeline self-reference avoiding duplicate execution
- expose whole-pipeline candidate/reference/comparison timing and residual orchestration
- record the exact-scale benchmark result and PR #1322 deployment evidence

## Behavior boundary

Offline diagnostic tooling, tests, and documentation only. No live HSL, strategy, trading, exchange, runtime producer, cache, order, risk, config, restart, or process behavior changes.

## Validation

- `18 passed` in `tests/test_hsl_replay_benchmark.py`
- Python compilation passed
- `cargo check` passed
- AI docs check: 0 errors, existing word-count warning only
- `git diff --check` passed
- loaded Rust extension fingerprint/stamp matched `94586772c5506bd83f83e41d0d2c273d8f19d8ee432c336fd17b477f08519a5f`
- exact 43,201-minute/30-symbol compact run: `163.56s` wall, candidate `2.899s`, dense reference `156.390s`, reference residual orchestration `147.403s`
- candidate/reference fixture contract, sample counts, and final state matched

## Deployment evidence carried forward

PR #1322 is deployed on VPS5 at `881978dec502296c4ab990c34bf06fdf74f024b2`. Its exact-file runtime-attribution smoke scanned 26 artifacts/15,763,500 bytes with zero warnings and reconciled the observed four-source runtime cohort. Final local-only process sampling was hard-green with five stable configured bot PIDs, natural recovery from one transient `D`, no scanner remaining, and `misc:0.0` preserved.

## Expected VPS action

After merge: tracked-clean fast-forward and a bounded offline benchmark smoke only. No bot restart or signal is warranted.

## Review gate

Exact-current-head Hermes approval plus green Python and Rust CI. Built-in Codex review is additional; all findings must be resolved.