### PR TITLE
Fix trailing fill-fetch watermark proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ All notable user-facing changes will be documented in this file.
   same execution. This is offline diagnostic output only; HSL state, replay
   behavior, exchange access, orders, and risk are unchanged.
 
+- Trailing fill-confirmation watermarks now advance only when a fill fetch
+  actually completes. Exhausted historical fill-gap retries still perform a
+  recent-fill refresh, keeping trailing confirmation live while historical PnL
+  coverage remains independently fail-closed.
+
 - Trailing-position fill confirmation now treats exchange position-update
   timestamps as advisory and proves readiness with a successful post-position
   fill refresh, a new fill identity for runtime changes, and matching fill

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -4709,12 +4709,14 @@ class FillEventsManager:
         overlap: int = 20,
         gap_hours: float = 12.0,
         force_refetch_gaps: bool = False,
-    ) -> None:
+    ) -> bool:
         """Refresh fills for a requested lookback window using cache-derived coverage.
 
         Open-ended lookbacks are tracked in cache metadata so bots can avoid
         re-running the same expensive history bootstrap after restart when the
         early portion of the lookback legitimately contains no fills.
+
+        Returns True only after at least one exchange fill fetch completes.
         """
         await self.ensure_loaded()
         start_ms = int(start_ms)
@@ -4726,7 +4728,7 @@ class FillEventsManager:
                 overlap=overlap,
                 force_refetch_gaps=force_refetch_gaps,
             )
-            return
+            return True
 
         coverage_end_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
 
@@ -4787,6 +4789,12 @@ class FillEventsManager:
                 await self.refresh_latest(overlap=overlap)
                 blocking_gaps = blocking_known_gaps()
             if blocking_gaps:
+                if not retried_ranges:
+                    # Historical coverage may remain blocked after its bounded
+                    # retry budget is exhausted. A recent refresh is still
+                    # required so trailing confirmation can prove its fill
+                    # cache current without weakening the PnL coverage gate.
+                    await self.refresh_latest(overlap=overlap)
                 gap = blocking_gaps[0]
                 bounds = gap_bounds(gap)
                 range_label = (
@@ -4802,7 +4810,7 @@ class FillEventsManager:
                     str(gap.get("retry_count", "unknown")),
                     str(gap.get("confidence", "unknown")),
                 )
-                return
+                return True
 
         metadata = self.cache.load_metadata()
         covered_start_ms = int(metadata.get("covered_start_ms", 0) or 0)
@@ -4834,7 +4842,7 @@ class FillEventsManager:
                 _format_ms(oldest_event_ts) if oldest_event_ts else "None",
             )
             await self.refresh_latest(overlap=overlap)
-            return
+            return True
 
         if metadata_claims_history_without_events:
             logger.warning(
@@ -4868,6 +4876,7 @@ class FillEventsManager:
             await self.refresh(start_ms=start_ms, end_ms=None)
 
         self.cache.mark_covered_start(start_ms)
+        return True
 
     async def refresh_range(
         self,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -11152,6 +11152,7 @@ class Passivbot:
             coverage_ready = bool(coverage_status.get("ready", False))
             needs_full_refresh = lookback.is_all and not coverage_ready
             needs_lookback_refresh = (not lookback.is_all) and not coverage_ready
+            fill_fetch_completed = False
             history_scope = str(coverage_status.get("history_scope", "unknown"))
             if not coverage_ready:
                 now_ms = utc_ms()
@@ -11208,6 +11209,7 @@ class Passivbot:
                     start_ms=None if age_limit is None else int(age_limit),
                     end_ms=None,
                 )
+                fill_fetch_completed = True
                 cache = getattr(self._pnls_manager, "cache", None)
                 mark_covered_start = getattr(cache, "mark_covered_start", None)
                 if age_limit is not None and callable(mark_covered_start):
@@ -11229,12 +11231,15 @@ class Passivbot:
                     self._pnls_manager, "refresh_for_lookback", None
                 )
                 if age_limit is not None and callable(refresh_for_lookback):
-                    await refresh_for_lookback(start_ms=int(age_limit))
+                    fill_fetch_completed = bool(
+                        await refresh_for_lookback(start_ms=int(age_limit))
+                    )
                 else:
                     await self._pnls_manager.refresh(
                         start_ms=None if age_limit is None else int(age_limit),
                         end_ms=None,
                     )
+                    fill_fetch_completed = True
                     cache = getattr(self._pnls_manager, "cache", None)
                     mark_covered_start = getattr(cache, "mark_covered_start", None)
                     if age_limit is not None and callable(mark_covered_start):
@@ -11275,6 +11280,7 @@ class Passivbot:
                         overlap=20,
                         last_refresh_overlap_ms=int(overlap_minutes * 60 * 1000),
                     )
+                fill_fetch_completed = True
 
             # Find and log new events (those not in cache before refresh)
             all_events = self._pnls_manager.get_events()
@@ -11282,7 +11288,8 @@ class Passivbot:
             # refresh completed after the position snapshot. Keep this
             # separate from the risk-authoritative fills generation below,
             # which must still wait for PnL enrichment and history coverage.
-            self._trailing_fill_fetch_generation = fill_refresh_attempt_generation
+            if fill_fetch_completed:
+                self._trailing_fill_fetch_generation = fill_refresh_attempt_generation
             new_events = []
             enriched_events = []
             seen_new_source_ids: set[str] = set()

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -4962,6 +4962,76 @@ async def test_manager_refresh_for_lookback_retries_known_gap_before_latest(tmp_
     assert manager.cache.get_known_gaps() == []
 
 
+@pytest.mark.asyncio
+async def test_manager_refresh_for_lookback_refreshes_latest_when_gap_retries_exhausted(
+    tmp_path: Path,
+):
+    cache_dir = tmp_path / "fills_lookback_exhausted_gap"
+    cache = FillEventCache(cache_dir)
+    start_ms = int((datetime.now(timezone.utc) - timedelta(days=2)).timestamp() * 1000)
+    gap_start = start_ms + 60 * 60 * 1000
+    gap_end = start_ms + 2 * 60 * 60 * 1000
+    event_ts = start_ms + 3 * 60 * 60 * 1000
+    event = FillEvent.from_dict(
+        dict(
+            id="post-gap-fill",
+            timestamp=event_ts,
+            datetime="",
+            symbol="BTC/USDT",
+            side="buy",
+            qty=0.1,
+            price=10,
+            pnl=0.0,
+            pb_order_type="entry",
+            position_side="long",
+            client_order_id="cid-post-gap-fill",
+        )
+    )
+    cache.save([event])
+    cache.save_metadata(
+        {
+            "last_refresh_ms": event_ts,
+            "oldest_event_ts": event_ts,
+            "newest_event_ts": event_ts,
+            "covered_start_ms": start_ms,
+            "history_scope": "window",
+            "known_gaps": [
+                {
+                    "start_ts": gap_start,
+                    "end_ts": gap_end,
+                    "retry_count": 3,
+                    "reason": GAP_REASON_FETCH_FAILED,
+                    "confidence": 0.0,
+                }
+            ],
+        }
+    )
+
+    class _RecordingFetcher(BaseFetcher):
+        def __init__(self):
+            self.calls: List[Tuple[Optional[int], Optional[int]]] = []
+
+        async def fetch(self, since_ms, until_ms, detail_cache, on_batch=None):
+            self.calls.append((since_ms, until_ms))
+            if on_batch:
+                on_batch([])
+            return []
+
+    fetcher = _RecordingFetcher()
+    manager = FillEventsManager(
+        exchange="bybit",
+        user="default",
+        fetcher=fetcher,
+        cache_path=cache_dir,
+    )
+
+    completed = await manager.refresh_for_lookback(start_ms=start_ms)
+
+    assert completed is True
+    assert fetcher.calls == [(event_ts, None)]
+    assert manager.cache.get_known_gaps()[0]["retry_count"] == 3
+
+
 def test_clear_gap_persists_partial_trim_and_middle_split(tmp_path: Path):
     cache = FillEventCache(tmp_path / "fills_clear_gap")
     cache.save_metadata(

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -5000,6 +5000,7 @@ async def test_update_pnls_window_lookback_bootstraps_when_coverage_unproven():
 
         async def _refresh_for_lookback(self, *, start_ms):
             self.cache.mark_covered_start(start_ms)
+            return True
 
         def get_events(self, start_ms=None):
             if start_ms is None:
@@ -5105,6 +5106,7 @@ async def test_update_pnls_window_lookback_stays_blocked_when_known_gap_persists
 
         async def _refresh_for_lookback(self, *, start_ms):
             self.cache.mark_covered_start(start_ms)
+            return False
 
         def get_events(self, start_ms=None):
             if start_ms is None:
@@ -5149,7 +5151,7 @@ async def test_update_pnls_window_lookback_stays_blocked_when_known_gap_persists
     bot._pnls_manager.refresh_latest.assert_not_awaited()
     assert bot._last_fill_refresh_pending_pnl_count == 0
     assert "fills" not in getattr(bot, "_authoritative_surface_signatures", {})
-    assert bot._trailing_fill_fetch_generation == 8
+    assert bot._trailing_fill_fetch_generation == 7
     retry_state = getattr(bot, "_fill_coverage_retry_state", {})
     assert retry_state["next_retry_ms"] > wall_ms["value"]
 
@@ -5157,14 +5159,14 @@ async def test_update_pnls_window_lookback_stays_blocked_when_known_gap_persists
 
     assert result is False
     bot._pnls_manager.refresh_for_lookback.assert_awaited_once_with(start_ms=start_ms)
-    assert bot._trailing_fill_fetch_generation == 8
+    assert bot._trailing_fill_fetch_generation == 7
 
     wall_ms["value"] = int(retry_state["next_retry_ms"]) + 1
     result = await bot.update_pnls(source="staged_blocking")
 
     assert result is False
     assert bot._pnls_manager.refresh_for_lookback.await_count == 2
-    assert bot._trailing_fill_fetch_generation == 10
+    assert bot._trailing_fill_fetch_generation == 7
 
 
 @pytest.mark.asyncio
@@ -5230,6 +5232,7 @@ async def test_update_pnls_window_lookback_records_fills_after_known_gap_repair(
         async def _refresh_for_lookback(self, *, start_ms):
             self.cache.known_gaps = []
             self.cache.mark_covered_start(start_ms)
+            return True
 
         def get_events(self, start_ms=None):
             if start_ms is None:


### PR DESCRIPTION
## What

- make `FillEventsManager.refresh_for_lookback()` report whether an exchange fill fetch completed
- advance the trailing fill-fetch watermark only when that proof is true
- perform a recent-fill refresh when historical known-gap retries are exhausted
- retain the independent fail-closed historical PnL coverage gate

## Why

A late P1 review on merged PR #1325 identified that `refresh_for_lookback()` could return early for a blocking known fill-history gap whose retries were exhausted. The caller then advanced `_trailing_fill_fetch_generation` even though no post-position exchange fill fetch had occurred. A matching but stale cached fill anchor could therefore satisfy trailing confirmation and make the symbol tradable on unproven state.

## Impact

- no-op lookback refreshes can no longer satisfy trailing fill confirmation
- exhausted historical gap repair still refreshes recent fills, so trailing liveness is not coupled to old PnL coverage
- failed recent refreshes propagate through the existing error policy and do not advance the watermark
- historical PnL coverage remains unavailable/fail-closed while its gap persists
- no authenticated exchange or live-bot action was used for validation

## Review finding addressed

- PR #1325 late inline P1: “Advance trailing generation only after an actual fetch” ([discussion](https://github.com/enarjord/passivbot/pull/1325#discussion_r3610937062))

Earlier #1325 review findings were superseded and verified fixed on its final merged head; this was the only later actionable finding.

## Checks

- `PYTHONPATH=src .../venv/bin/python -m pytest tests/test_fill_events_manager.py -q`
- `PYTHONPATH=src .../venv/bin/python -m pytest tests/test_passivbot_balance_split.py -q`
- `PYTHONPATH=src .../venv/bin/python -m pytest tests/test_unstucking_safeguards.py -q`
- `PYTHONPATH=src .../venv/bin/python -m pytest tests/test_run_fake_live.py -q`
- `PYTHONPATH=src .../venv/bin/python -m pytest tests/test_order_orchestration.py -q`
- `PYTHONPATH=src .../venv/bin/python -m compileall -q src/passivbot.py src/fill_events_manager.py`
- `git diff --check origin/master...HEAD`
