### PR TITLE
Report completed candle decision freshness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Planning snapshot diagnostics now include a bounded completed-1m-candle
+  freshness summary when that surface is required. The summary is derived only
+  from the frozen planning signature and reports expected/real close ages plus
+  bounded tail-gap fallback counts; `live-performance-report` validates and
+  aggregates the same proof. It does not reread candles or change planning,
+  exchange access, orders, strategy, or risk behavior.
+
 - `passivbot tool hsl-replay-benchmark` now reports exclusive timing profiles
   for fixture construction, replay internals, final-state projection, candidate
   and dense-reference runs, equivalence comparison, and residual orchestration.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,7 +22,8 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR #1328; branch: `codex/decision-freshness-report`, based on canonical
+- PR #1328, `Report completed candle decision freshness`; branch:
+  `codex/decision-freshness-report`, based on canonical
   `0a57187ff9f0def7eb4976721f5b04d17f03fb74`.
 - Scope: project completed-1m-candle freshness from each frozen planning
   snapshot into bounded `snapshot.built` diagnostics, then validate and

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,7 +22,7 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/decision-freshness-report`, based on canonical
+- PR #1328; branch: `codex/decision-freshness-report`, based on canonical
   `0a57187ff9f0def7eb4976721f5b04d17f03fb74`.
 - Scope: project completed-1m-candle freshness from each frozen planning
   snapshot into bounded `snapshot.built` diagnostics, then validate and
@@ -1524,10 +1524,10 @@ PR #1286's aggregate-only follow-up, PR #1287's exact tmux target preflight,
 PR #1288's bounded target-identity stability, and PR #1289's plan binding are
 merged, deployed, and naturally validated without process control. PR #1290's
 pane-parent relaunch classification and the restart preparation/orchestration
-slices through PR #1309 are also merged and deployed. Current VPS5 is hard-green
-at canonical `f1ae7970393e8299d1b0a98c8ff68d42adddd2d0`. The active
-`codex/hard-problem-evidence` slice makes every nonzero hard smoke verdict
-diagnosable from a separately bounded hard-only sample.
+slices through PR #1309 are also merged and deployed. Later slices through PR
+#1326 are merged and deployed at canonical
+`0a57187ff9f0def7eb4976721f5b04d17f03fb74`; their current evidence is recorded
+above. PR #1328 is the active completed-candle decision-freshness slice.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,32 +22,61 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/hsl-replay-stage-profile`, based on canonical
-  `881978dec502296c4ab990c34bf06fdf74f024b2`.
-- Scope: make the existing deterministic offline coin-HSL replay benchmark
-  attribute elapsed work to bounded stages, including held/background replay
-  samples and the residual replay orchestration that is currently hidden by
-  the aggregate elapsed value.
-- Behavior boundary: offline benchmark tooling and tests only. No live HSL,
-  trading, exchange, runtime producer, order, risk, config, restart, cache, or
-  process behavior changes.
-- Validation: focused benchmark tests must prove stable stage taxonomy, exact
-  call/sample accounting, nonnegative elapsed/residual math, unchanged dense
-  reference equivalence, distinct compact candidate/reference accounting,
-  timeline self-reference without double-counting, and zero
-  network/cache/latch/monitor side effects.
-- Review gate: implementation is complete in commits `a08f5f8dc6` and
-  `1414702a8d`; 18 focused tests, Python compilation, documentation checks,
-  and diff checks passed. The exact 43,201-minute/30-symbol compact run was
-  equivalent to its dense reference and completed in `163.56s` wall time. Its
-  candidate run took `2.899s`; the dense-reference run took `156.390s`, with
-  `147.403s` now attributed to residual replay orchestration. The final
-  exact head requires Hermes approval plus green Python/Rust CI; built-in Codex
-  review is additional and every finding must be resolved.
-- Expected VPS action: after merge, tracked-clean pull plus a bounded offline
-  benchmark smoke only; no bot restart or signal is required.
+- Branch: `codex/decision-freshness-report`, based on canonical
+  `0a57187ff9f0def7eb4976721f5b04d17f03fb74`.
+- Scope: project completed-1m-candle freshness from each frozen planning
+  snapshot into bounded `snapshot.built` diagnostics, then validate and
+  aggregate expected-close age, last-real-close age, and allowed tail-gap
+  fallback evidence in `live-performance-report`.
+- Behavior boundary: observability producer and read-only reporting only. The
+  producer reads the immutable planning signature and configured tail-gap bound;
+  it does not reread candles or change exchange access, planning readiness,
+  strategy, orders, risk, cache state, or process control.
+- Validation: 362 focused performance-report and planning-snapshot tests passed
+  after current-master integration. Regression coverage proves signature-only
+  derivation, strict timestamp and row validation, bounded/sorted symbol samples,
+  malformed/missing proof accounting, report aggregation, and omission when the
+  candle surface is not required. Python compilation and diff checks passed.
+- Review gate: final exact-head Hermes approval plus green Python/Rust CI.
+  Built-in Codex automatic review is additional and every finding must be
+  verified and resolved.
+- Expected VPS action: tracked-clean pull, guarded exact-pane restart, and
+  immediate plus settled smoke because the structured event payload changes.
 
-## Deployed Baseline (PR #1322)
+## Deployed Baseline (PR #1326)
+
+- PR #1326 merged as canonical
+  `0a57187ff9f0def7eb4976721f5b04d17f03fb74` after exact-head Hermes
+  approval, a green built-in Codex review, and green Python/Rust CI. VPS5
+  fast-forwarded tracked-clean from `ac9ff15029cb728eeb33563c134f196df3e3a49e`.
+- Rust source fingerprint and compiled stamp remained
+  `691bff9683deec9382a4e96ab6a107c14145f88edd6ae2f8e2380b8ba6824449`;
+  no Rust build, bot restart, or process signal was required.
+- The bounded offline 240-minute/eight-symbol benchmark matched compact and
+  dense-reference final state and all 240 replay samples. It emitted both
+  exclusive stage taxonomies and reported zero network, cache, latch, and
+  monitor side effects.
+- Exact bot PIDs `1056607/1056616/1056610/1056619/1056613` remained running,
+  the checkout stayed tracked-clean, and protected `misc:0.0` remained
+  `%8`/PID `434835`. No direct exchange call or event was manufactured.
+
+## Previous Deployed Baseline (PR #1325)
+
+- PR #1325 merged as canonical
+  `ac9ff15029cb728eeb33563c134f196df3e3a49e`. Its successful fill-fetch
+  generation confirms trailing readiness independently of unrelated pending
+  PnL while the risk-authoritative generation remains fail-closed.
+- VPS5 fast-forwarded tracked-clean from `881978dec502296c4ab990c34bf06fdf74f024b2`
+  without a Rust build. The guarded runner gracefully restarted only exact panes
+  `%358`-`%362` without force; the five bot PIDs became
+  `1056607/1056616/1056610/1056619/1056613` and `misc:0.0` remained unchanged.
+- The immediate smoke was hard-green with `58/58` account-critical and
+  `224/224` remote calls successful. The settled smoke was also hard-green with
+  `17/17` account-critical and `328/328` remote calls successful, zero hard,
+  monitor, or text-log failures, three completed HSL replays, and no latest
+  degraded cycle. No direct exchange call or event was manufactured.
+
+## Previous Deployed Baseline (PR #1322)
 
 - PR #1322 merged as canonical
   `881978dec502296c4ab990c34bf06fdf74f024b2`. VPS5 fast-forwarded

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,38 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1322)
+## Latest Canonical Deployment (PR #1326)
+
+- PR #1326 merged as canonical
+  `0a57187ff9f0def7eb4976721f5b04d17f03fb74` after exact-head Hermes and
+  built-in Codex reviews plus green Python/Rust CI. VPS5 fast-forwarded
+  tracked-clean from `ac9ff15029` without a Rust build, bot restart, or signal.
+- A bounded offline 240-minute/eight-symbol HSL benchmark matched compact and
+  dense-reference final state and all 240 replay samples, emitted both exclusive
+  stage taxonomies, and reported zero network/cache/latch/monitor side effects.
+- Exact bot PIDs `1056607/1056616/1056610/1056619/1056613` and protected
+  `misc:0.0` `%8`/PID `434835` remained unchanged. No direct exchange call or
+  event was manufactured. The active freshness slice projects completed-candle
+  readiness from frozen planning signatures into bounded diagnostics.
+
+## Previous Canonical Deployment (PR #1325)
+
+- PR #1325 merged as canonical
+  `ac9ff15029cb728eeb33563c134f196df3e3a49e` after exact-head Hermes and
+  built-in Codex reviews plus green Python/Rust CI. It separates successful
+  trailing fill-fetch confirmation from the risk-authoritative refresh
+  generation while preserving fail-closed risk behavior.
+- VPS5 fast-forwarded tracked-clean from `881978dec5` without a Rust build and
+  gracefully restarted only exact panes `%358`-`%362`. The five bot PIDs became
+  `1056607/1056616/1056610/1056619/1056613`; protected `misc:0.0` remained
+  `%8`/PID `434835`.
+- Immediate and settled smokes were hard-green. The immediate window had
+  `58/58` account-critical and `224/224` remote calls successful; the settled
+  window had `17/17` and `328/328`, zero hard/monitor/text-log failures, three
+  completed HSL replays, and no latest degraded cycle. No direct exchange call
+  or event was manufactured.
+
+## Previous Canonical Deployment (PR #1322)
 
 - PR #1322 merged as canonical
   `881978dec502296c4ab990c34bf06fdf74f024b2`. VPS5 fast-forwarded

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -5,6 +5,7 @@ import json
 import math
 import statistics
 from collections import Counter
+from numbers import Integral
 from pathlib import Path
 from typing import Any
 
@@ -453,6 +454,13 @@ def _non_negative_ms(value: Any) -> int | None:
     return int(round(number))
 
 
+def _strict_non_negative_int(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        return None
+    parsed = int(value)
+    return parsed if parsed >= 0 else None
+
+
 def _non_negative_number(value: Any) -> float | int | None:
     number = _finite_float(value)
     if number is None or number < 0:
@@ -879,6 +887,26 @@ class _InputStalenessAccumulator:
         self.market_snapshot_configured_max_age_values: list[int] = []
         self.market_snapshot_configured_excess_values: list[int] = []
         self.market_snapshot_source_counts: Counter[str] = Counter()
+        self.completed_candle_required_snapshots = 0
+        self.completed_candle_required_surface_unknown_snapshots = 0
+        self.completed_candle_summary_observations = 0
+        self.completed_candle_summary_missing_proof_count = 0
+        self.completed_candle_summary_malformed_proof_count = 0
+        self.completed_candle_summary_no_valid_rows_count = 0
+        self.completed_candle_metric_observations = 0
+        self.completed_candle_signature_row_values: list[int] = []
+        self.completed_candle_valid_row_values: list[int] = []
+        self.completed_candle_invalid_row_values: list[int] = []
+        self.completed_candle_fallback_count_values: list[int] = []
+        self.completed_candle_fallback_symbol_count_values: list[int] = []
+        self.completed_candle_expected_age_values: dict[str, list[int]] = {
+            label: [] for label in ("min", "mean", "max")
+        }
+        self.completed_candle_real_age_values: dict[str, list[int]] = {
+            label: [] for label in ("min", "mean", "max")
+        }
+        self.completed_candle_max_tail_gap_age_values: list[int] = []
+        self.completed_candle_configured_max_tail_gap_values: list[int] = []
         self.rust_calls_seen = 0
         self.packet_refs_missing = 0
         self.snapshot_to_rust_exact_matches = 0
@@ -911,6 +939,148 @@ class _InputStalenessAccumulator:
             self.groups[group_key] = group
         group.add(value_ms, row=row, live_event=live_event)
 
+    def _consume_completed_candle_summary(
+        self,
+        *,
+        row: dict[str, Any],
+        live_event: dict[str, Any],
+        data: dict[str, Any],
+    ) -> None:
+        required_surfaces = data.get("required_surfaces")
+        if not isinstance(required_surfaces, list):
+            self.completed_candle_required_surface_unknown_snapshots += 1
+            return
+        if "completed_candles" not in {str(surface) for surface in required_surfaces}:
+            return
+        self.completed_candle_required_snapshots += 1
+        summary = data.get("completed_candle_summary")
+        if not isinstance(summary, dict):
+            self.completed_candle_summary_missing_proof_count += 1
+            return
+        self.completed_candle_summary_observations += 1
+
+        def count(name: str) -> int | None:
+            return _strict_non_negative_int(summary.get(name))
+
+        signature_rows = count("signature_row_count")
+        valid_rows = count("valid_row_count")
+        invalid_rows = count("invalid_row_count")
+        fallback_count = count("tail_gap_fallback_count")
+        fallback_symbol_count = count("tail_gap_fallback_symbol_count")
+        if (
+            summary.get("required") is not True
+            or summary.get("timeframe") != "1m"
+            or signature_rows is None
+            or valid_rows is None
+            or invalid_rows is None
+            or fallback_count is None
+            or fallback_symbol_count is None
+            or signature_rows != valid_rows + invalid_rows
+            or fallback_count > valid_rows
+            or fallback_symbol_count > fallback_count
+        ):
+            self.completed_candle_summary_malformed_proof_count += 1
+            return
+        samples = summary.get("tail_gap_fallback_symbol_samples")
+        symbols_truncated = summary.get("tail_gap_fallback_symbols_truncated")
+        if (
+            not isinstance(samples, list)
+            or len(samples) > 8
+            or any(not isinstance(symbol, str) or not symbol for symbol in samples)
+            or len(set(samples)) != len(samples)
+            or samples != sorted(samples)
+            or not isinstance(symbols_truncated, bool)
+            or (symbols_truncated and (len(samples) != 8 or fallback_symbol_count <= len(samples)))
+            or (not symbols_truncated and len(samples) != fallback_symbol_count)
+        ):
+            self.completed_candle_summary_malformed_proof_count += 1
+            return
+        self.completed_candle_signature_row_values.append(signature_rows)
+        self.completed_candle_valid_row_values.append(valid_rows)
+        self.completed_candle_invalid_row_values.append(invalid_rows)
+        self.completed_candle_fallback_count_values.append(fallback_count)
+        self.completed_candle_fallback_symbol_count_values.append(fallback_symbol_count)
+        configured_max_tail_gap_ms = _strict_non_negative_int(
+            summary.get("configured_max_tail_gap_ms")
+        )
+        if configured_max_tail_gap_ms is not None:
+            self.completed_candle_configured_max_tail_gap_values.append(
+                configured_max_tail_gap_ms
+            )
+        if invalid_rows:
+            self.completed_candle_summary_malformed_proof_count += 1
+            return
+        if valid_rows == 0:
+            self.completed_candle_summary_no_valid_rows_count += 1
+            return
+
+        def ages(name: str) -> dict[str, int] | None:
+            value = summary.get(name)
+            if not isinstance(value, dict):
+                return None
+            parsed = {
+                label: _strict_non_negative_int(value.get(f"{label}_ms"))
+                for label in ("min", "mean", "max")
+            }
+            if any(item is None for item in parsed.values()):
+                return None
+            if not (parsed["min"] <= parsed["mean"] <= parsed["max"]):
+                return None
+            return {label: int(item) for label, item in parsed.items()}
+
+        expected_ages = ages("expected_close_age")
+        real_ages = ages("last_real_close_age")
+        if expected_ages is None or real_ages is None:
+            self.completed_candle_summary_malformed_proof_count += 1
+            return
+        if any(real_ages[label] < expected_ages[label] for label in expected_ages):
+            self.completed_candle_summary_malformed_proof_count += 1
+            return
+        max_tail_gap_age_ms = _strict_non_negative_int(summary.get("max_tail_gap_age_ms"))
+        if fallback_count == 0 and max_tail_gap_age_ms is not None:
+            self.completed_candle_summary_malformed_proof_count += 1
+            return
+        if fallback_count > 0 and max_tail_gap_age_ms is None:
+            self.completed_candle_summary_malformed_proof_count += 1
+            return
+        if (
+            max_tail_gap_age_ms is not None
+            and configured_max_tail_gap_ms is not None
+            and max_tail_gap_age_ms > configured_max_tail_gap_ms
+        ):
+            self.completed_candle_summary_malformed_proof_count += 1
+            return
+        self.completed_candle_metric_observations += 1
+        for source, values in (
+            ("expected_close", expected_ages),
+            ("last_real_close", real_ages),
+        ):
+            target = (
+                self.completed_candle_expected_age_values
+                if source == "expected_close"
+                else self.completed_candle_real_age_values
+            )
+            for label, value_ms in values.items():
+                target[label].append(value_ms)
+                self._add_group(
+                    row=row,
+                    live_event=live_event,
+                    operation=f"input_staleness.completed_candles.{source}.{label}",
+                    value_ms=value_ms,
+                    timing_kind="close_age_at_snapshot",
+                    trading_impact="blocks_indicator_readiness",
+                )
+        if max_tail_gap_age_ms is not None:
+            self.completed_candle_max_tail_gap_age_values.append(max_tail_gap_age_ms)
+            self._add_group(
+                row=row,
+                live_event=live_event,
+                operation="input_staleness.completed_candles.tail_gap.max",
+                value_ms=max_tail_gap_age_ms,
+                timing_kind="tail_gap_age_at_snapshot",
+                trading_impact="blocks_indicator_readiness",
+            )
+
     def add(
         self,
         *,
@@ -941,6 +1111,9 @@ class _InputStalenessAccumulator:
             cycle_id = _event_cycle_id(live_event)
             if cycle_id:
                 self.snapshot_ts_by_cycle[(bot, int(cycle_scope), cycle_id)] = int(timestamp_ms)
+            self._consume_completed_candle_summary(
+                row=row, live_event=live_event, data=data
+            )
             surface_ages = data.get("surface_ages")
             if isinstance(surface_ages, list):
                 for surface in surface_ages:
@@ -1138,6 +1311,48 @@ class _InputStalenessAccumulator:
                     self.market_snapshot_configured_excess_values
                 ),
                 "sources": dict(self.market_snapshot_source_counts.most_common(12)),
+            },
+            "completed_candles": {
+                "required_snapshots": int(self.completed_candle_required_snapshots),
+                "required_surface_unknown_snapshots": int(
+                    self.completed_candle_required_surface_unknown_snapshots
+                ),
+                "summary_observations": int(self.completed_candle_summary_observations),
+                "missing_proof_count": int(self.completed_candle_summary_missing_proof_count),
+                "malformed_proof_count": int(
+                    self.completed_candle_summary_malformed_proof_count
+                ),
+                "no_valid_rows_count": int(
+                    self.completed_candle_summary_no_valid_rows_count
+                ),
+                "metric_observations": int(self.completed_candle_metric_observations),
+                "signature_rows": _number_summary(
+                    self.completed_candle_signature_row_values
+                ),
+                "valid_rows": _number_summary(self.completed_candle_valid_row_values),
+                "invalid_rows": _number_summary(
+                    self.completed_candle_invalid_row_values
+                ),
+                "tail_gap_fallback_count": _number_summary(
+                    self.completed_candle_fallback_count_values
+                ),
+                "tail_gap_fallback_symbol_count": _number_summary(
+                    self.completed_candle_fallback_symbol_count_values
+                ),
+                "expected_close_age_ms": {
+                    label: _number_summary(values)
+                    for label, values in self.completed_candle_expected_age_values.items()
+                },
+                "last_real_close_age_ms": {
+                    label: _number_summary(values)
+                    for label, values in self.completed_candle_real_age_values.items()
+                },
+                "max_tail_gap_age_ms": _number_summary(
+                    self.completed_candle_max_tail_gap_age_values
+                ),
+                "configured_max_tail_gap_ms": _number_summary(
+                    self.completed_candle_configured_max_tail_gap_values
+                ),
             },
             "rust_calls_seen": int(self.rust_calls_seen),
             "packet_refs_missing": int(self.packet_refs_missing),
@@ -5777,6 +5992,7 @@ def summarize_live_performance_report(
                 input_staleness.get("snapshot_market_stale_count") or 0
             ),
             "market_snapshot": input_staleness.get("market_snapshot") or {},
+            "completed_candles": input_staleness.get("completed_candles") or {},
             "rust_calls_seen": int(input_staleness.get("rust_calls_seen") or 0),
             "packet_refs_missing": int(input_staleness.get("packet_refs_missing") or 0),
             "snapshot_to_rust_exact_matches": int(

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -20,6 +20,7 @@ import bisect
 import pprint
 import numpy as np
 import inspect
+from numbers import Integral
 import passivbot_rust as pbr
 import logging
 import math
@@ -9672,6 +9673,7 @@ class Passivbot:
             "sources": sorted(market_snapshot_sources)[:8],
             "sources_count": len(market_snapshot_sources),
         }
+        completed_candle_summary = self._completed_candle_summary_from_snapshot(snapshot)
         emit_diagnostic_event(
             self,
             DiagnosticEvent.build(
@@ -9689,6 +9691,11 @@ class Passivbot:
                         for key, value in market_snapshot_summary.items()
                         if value is not None
                     },
+                    **(
+                        {"completed_candle_summary": completed_candle_summary}
+                        if completed_candle_summary is not None
+                        else {}
+                    ),
                     "data_packets": [
                         {
                             "kind": packet.kind,
@@ -9708,6 +9715,108 @@ class Passivbot:
             ),
         )
         self._emit_planning_symbol_state_event(availability, context=context)
+
+    def _completed_candle_summary_from_snapshot(
+        self, snapshot: PlanningSnapshot
+    ) -> dict | None:
+        """Project frozen 1m candle signature freshness into bounded diagnostics only."""
+        if "completed_candles" not in set(snapshot.required_surfaces):
+            return None
+
+        signature = snapshot.completed_candle_signature
+        rows = list(signature) if isinstance(signature, (list, tuple)) else []
+        signature_row_count = len(rows)
+        invalid_row_count = 0 if isinstance(signature, (list, tuple)) else 1
+        expected_close_ages = []
+        real_close_ages = []
+        fallback_symbols = set()
+        fallback_count = 0
+        tail_gap_ages = []
+
+        def _timestamp(value) -> int | None:
+            if isinstance(value, bool) or not isinstance(value, Integral):
+                return None
+            parsed = int(value)
+            return parsed if parsed >= 0 else None
+
+        snapshot_ts_ms = _timestamp(snapshot.ts_ms)
+        if snapshot_ts_ms is None:
+            snapshot_ts_ms = 0
+            invalid_row_count += len(rows)
+            rows = []
+        for row in rows:
+            if not isinstance(row, (list, tuple)) or len(row) not in (2, 5):
+                invalid_row_count += 1
+                continue
+            symbol = row[0]
+            expected_open_ms = _timestamp(row[1])
+            if not isinstance(symbol, str) or not symbol or expected_open_ms is None:
+                invalid_row_count += 1
+                continue
+            real_open_ms = expected_open_ms
+            tail_gap_age_ms = None
+            if len(row) == 5:
+                if row[2] != "tail_gap_fallback":
+                    invalid_row_count += 1
+                    continue
+                real_open_ms = _timestamp(row[3])
+                tail_gap_age_ms = _timestamp(row[4])
+                if (
+                    real_open_ms is None
+                    or tail_gap_age_ms is None
+                    or expected_open_ms < real_open_ms
+                    or tail_gap_age_ms != expected_open_ms - real_open_ms
+                ):
+                    invalid_row_count += 1
+                    continue
+            expected_close_ages.append(
+                max(0, int(snapshot_ts_ms) - int(expected_open_ms + ONE_MIN_MS))
+            )
+            real_close_ages.append(
+                max(0, int(snapshot_ts_ms) - int(real_open_ms + ONE_MIN_MS))
+            )
+            if tail_gap_age_ms is not None:
+                fallback_count += 1
+                fallback_symbols.add(symbol)
+                tail_gap_ages.append(int(tail_gap_age_ms))
+
+        def _age_summary(values: list[int]) -> dict | None:
+            if not values:
+                return None
+            return {
+                "min_ms": int(min(values)),
+                "mean_ms": int(round(sum(values) / len(values))),
+                "max_ms": int(max(values)),
+            }
+
+        fallback_samples = sorted(fallback_symbols)[:8]
+        result = {
+            "required": True,
+            "timeframe": "1m",
+            "signature_row_count": signature_row_count,
+            "valid_row_count": len(expected_close_ages),
+            "invalid_row_count": int(invalid_row_count),
+            "tail_gap_fallback_count": int(fallback_count),
+            "tail_gap_fallback_symbol_count": len(fallback_symbols),
+            "tail_gap_fallback_symbol_samples": fallback_samples,
+            "tail_gap_fallback_symbols_truncated": len(fallback_symbols)
+            > len(fallback_samples),
+        }
+        expected_summary = _age_summary(expected_close_ages)
+        real_summary = _age_summary(real_close_ages)
+        if expected_summary is not None:
+            result["expected_close_age"] = expected_summary
+        if real_summary is not None:
+            result["last_real_close_age"] = real_summary
+        if tail_gap_ages:
+            result["max_tail_gap_age_ms"] = int(max(tail_gap_ages))
+        try:
+            result["configured_max_tail_gap_ms"] = int(
+                self._active_candle_tail_gap_max_ms()
+            )
+        except (AttributeError, TypeError, ValueError):
+            pass
+        return result
 
     def _emit_planning_unavailable_diagnostic(self, details: dict) -> None:
         emit_diagnostic_event(

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -372,6 +372,7 @@ from pure_funcs import (
 )
 
 ONE_MIN_MS = 60_000
+_COMPLETED_CANDLE_SYMBOL_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9:/._-]{0,159}")
 bot = None
 
 
@@ -9750,7 +9751,11 @@ class Passivbot:
                 continue
             symbol = row[0]
             expected_open_ms = _timestamp(row[1])
-            if not isinstance(symbol, str) or not symbol or expected_open_ms is None:
+            if (
+                not isinstance(symbol, str)
+                or _COMPLETED_CANDLE_SYMBOL_RE.fullmatch(symbol) is None
+                or expected_open_ms is None
+            ):
                 invalid_row_count += 1
                 continue
             real_open_ms = expected_open_ms

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1031,6 +1031,123 @@ def test_live_performance_report_market_snapshot_summary_counts_missing_sources(
     assert market["sources"] == {"ticker": 2, "websocket": 1}
 
 
+def test_live_performance_report_completed_candle_freshness_summary(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    valid_summary = {
+        "required": True,
+        "timeframe": "1m",
+        "signature_row_count": 2,
+        "valid_row_count": 2,
+        "invalid_row_count": 0,
+        "tail_gap_fallback_count": 1,
+        "tail_gap_fallback_symbol_count": 1,
+        "tail_gap_fallback_symbol_samples": ["ETH/USDT:USDT"],
+        "tail_gap_fallback_symbols_truncated": False,
+        "expected_close_age": {"min_ms": 10, "mean_ms": 20, "max_ms": 30},
+        "last_real_close_age": {"min_ms": 10, "mean_ms": 40, "max_ms": 70},
+        "max_tail_gap_age_ms": 60,
+        "configured_max_tail_gap_ms": 120,
+    }
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="snapshot.built",
+                seq=1,
+                ts=1_000,
+                data={
+                    "required_surfaces": ["balance", "completed_candles"],
+                    "completed_candle_summary": valid_summary,
+                },
+            ),
+            _monitor_row(
+                event_type="snapshot.built",
+                seq=2,
+                ts=2_000,
+                data={"required_surfaces": ["completed_candles"]},
+            ),
+            _monitor_row(
+                event_type="snapshot.built",
+                seq=3,
+                ts=3_000,
+                data={
+                    "required_surfaces": ["completed_candles"],
+                    "completed_candle_summary": {
+                        **valid_summary,
+                        "signature_row_count": "2",
+                    },
+                },
+            ),
+            _monitor_row(
+                event_type="snapshot.built",
+                seq=4,
+                ts=4_000,
+                data={
+                    "required_surfaces": ["completed_candles"],
+                    "completed_candle_summary": {
+                        **valid_summary,
+                        "tail_gap_fallback_count": 1.5,
+                    },
+                },
+            ),
+            _monitor_row(
+                event_type="snapshot.built",
+                seq=5,
+                ts=5_000,
+                data={
+                    "required_surfaces": ["completed_candles"],
+                    "completed_candle_summary": {
+                        "required": True,
+                        "timeframe": "1m",
+                        "signature_row_count": 2,
+                        "valid_row_count": 0,
+                        "invalid_row_count": 2,
+                        "tail_gap_fallback_count": 0,
+                        "tail_gap_fallback_symbol_count": 0,
+                        "tail_gap_fallback_symbol_samples": [],
+                        "tail_gap_fallback_symbols_truncated": False,
+                    },
+                },
+            ),
+            _monitor_row(
+                event_type="snapshot.built",
+                seq=6,
+                ts=6_000,
+                data={},
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    completed = report["input_staleness"]["completed_candles"]
+    groups = {
+        group["operation"]: group for group in report["input_staleness"]["groups"]
+    }
+    summary = summarize_live_performance_report(report, group_limit=1)
+
+    assert completed["required_snapshots"] == 5
+    assert completed["required_surface_unknown_snapshots"] == 1
+    assert completed["summary_observations"] == 4
+    assert completed["missing_proof_count"] == 1
+    assert completed["malformed_proof_count"] == 3
+    assert completed["no_valid_rows_count"] == 0
+    assert completed["metric_observations"] == 1
+    assert completed["signature_rows"]["max"] == 2
+    assert completed["valid_rows"]["max"] == 2
+    assert completed["invalid_rows"]["max"] == 2
+    assert completed["tail_gap_fallback_count"]["max"] == 1
+    assert completed["expected_close_age_ms"]["max"]["max"] == 30
+    assert completed["last_real_close_age_ms"]["max"]["max"] == 70
+    assert completed["max_tail_gap_age_ms"]["max"] == 60
+    assert completed["configured_max_tail_gap_ms"]["max"] == 120
+    assert groups["input_staleness.completed_candles.expected_close.max"][
+        "trading_impact"
+    ] == "blocks_indicator_readiness"
+    assert groups["input_staleness.completed_candles.last_real_close.max"]["max_ms"] == 70
+    assert groups["input_staleness.completed_candles.tail_gap.max"]["max_ms"] == 60
+    assert summary["input_staleness"]["completed_candles"] == completed
+
+
 def test_live_performance_report_input_staleness_handles_cycle_id_reuse(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -7956,7 +7956,20 @@ def test_completed_candle_snapshot_summary_is_bounded_and_signature_only():
                 (symbol, 180_000, "tail_gap_fallback", 60_000, 120_000)
                 for symbol in fallback_symbols
             ),
-            ("api_key=must_not_escape", "not-a-timestamp"),
+            (
+                "api_key=must_not_escape",
+                180_000,
+                "tail_gap_fallback",
+                60_000,
+                120_000,
+            ),
+            (
+                f"LONG{'X' * 160}/USDT:USDT",
+                180_000,
+                "tail_gap_fallback",
+                60_000,
+                120_000,
+            ),
             ("malformed", 180_000, "wrong_fallback", 60_000, 120_000),
         ),
     )
@@ -7966,9 +7979,9 @@ def test_completed_candle_snapshot_summary_is_bounded_and_signature_only():
     assert summary == {
         "required": True,
         "timeframe": "1m",
-        "signature_row_count": 13,
+        "signature_row_count": 14,
         "valid_row_count": 11,
-        "invalid_row_count": 2,
+        "invalid_row_count": 3,
         "tail_gap_fallback_count": 10,
         "tail_gap_fallback_symbol_count": 10,
         "tail_gap_fallback_symbol_samples": fallback_symbols[:8],

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -7936,6 +7936,109 @@ def test_build_staged_planning_snapshot_captures_exact_surface_contract():
     assert planning_snapshot.invalid_details(now_ms=passivbot_module.utc_ms()) == []
 
 
+def test_completed_candle_snapshot_summary_is_bounded_and_signature_only():
+    bot = Passivbot.__new__(Passivbot)
+    bot.config = {"live": {"max_active_candle_tail_gap_minutes": 2}}
+    bot.cm = SimpleNamespace(
+        get_completed_candle_health=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("snapshot summary must not read candles")
+        )
+    )
+    ordinary = "BTC/USDT:USDT"
+    fallback_symbols = [f"COIN{i:02d}/USDT:USDT" for i in range(10)]
+    snapshot = _availability_test_snapshot(
+        now_ms=300_000,
+        symbols=(ordinary,),
+        surfaces={"completed_candles": (7, 7, tuple())},
+        completed_candle_signature=(
+            (ordinary, 180_000),
+            *(
+                (symbol, 180_000, "tail_gap_fallback", 60_000, 120_000)
+                for symbol in fallback_symbols
+            ),
+            ("api_key=must_not_escape", "not-a-timestamp"),
+            ("malformed", 180_000, "wrong_fallback", 60_000, 120_000),
+        ),
+    )
+
+    summary = bot._completed_candle_summary_from_snapshot(snapshot)
+
+    assert summary == {
+        "required": True,
+        "timeframe": "1m",
+        "signature_row_count": 13,
+        "valid_row_count": 11,
+        "invalid_row_count": 2,
+        "tail_gap_fallback_count": 10,
+        "tail_gap_fallback_symbol_count": 10,
+        "tail_gap_fallback_symbol_samples": fallback_symbols[:8],
+        "tail_gap_fallback_symbols_truncated": True,
+        "expected_close_age": {"min_ms": 60_000, "mean_ms": 60_000, "max_ms": 60_000},
+        "last_real_close_age": {"min_ms": 60_000, "mean_ms": 169_091, "max_ms": 180_000},
+        "max_tail_gap_age_ms": 120_000,
+        "configured_max_tail_gap_ms": 120_000,
+    }
+    assert "api_key" not in json.dumps(summary, sort_keys=True)
+
+
+def test_completed_candle_snapshot_summary_is_omitted_when_not_required():
+    bot = Passivbot.__new__(Passivbot)
+    bot.config = {"live": {}}
+    snapshot = _availability_test_snapshot(
+        now_ms=300_000,
+        symbols=("BTC/USDT:USDT",),
+        surfaces={"balance": (7, 7, ("balance", "fresh"))},
+        completed_candle_signature=(("BTC/USDT:USDT", 180_000),),
+    )
+
+    assert bot._completed_candle_summary_from_snapshot(snapshot) is None
+
+
+def test_snapshot_built_omits_completed_candle_summary_when_not_required():
+    bot = Passivbot.__new__(Passivbot)
+    bot.config = {"live": {}}
+    bot._current_live_event_cycle_id = lambda: "cy_protective"
+    bot._emit_planning_symbol_state_event = lambda *_args, **_kwargs: None
+    events = []
+    bot._monitor_record_event = (
+        lambda kind, tags, payload=None, **kwargs: events.append(
+            {"kind": kind, "payload": dict(payload or {}), **kwargs}
+        )
+    )
+    snapshot = _availability_test_snapshot(
+        now_ms=300_000,
+        symbols=("BTC/USDT:USDT",),
+        surfaces={"balance": (7, 7, ("balance", "fresh"))},
+        completed_candle_signature=(("BTC/USDT:USDT", 180_000),),
+    )
+
+    bot._emit_snapshot_built_diagnostic(snapshot, context="protective")
+
+    assert "completed_candle_summary" not in events[-1]["payload"]
+
+
+def test_completed_candle_snapshot_summary_rejects_coerced_timestamps():
+    bot = Passivbot.__new__(Passivbot)
+    bot.config = {"live": {}}
+    snapshot = _availability_test_snapshot(
+        now_ms="300000",
+        symbols=("BTC/USDT:USDT",),
+        surfaces={"completed_candles": (7, 7, tuple())},
+        completed_candle_signature=(
+            ("BTC/USDT:USDT", "180000"),
+            ("ETH/USDT:USDT", 180_000.0),
+        ),
+    )
+
+    summary = bot._completed_candle_summary_from_snapshot(snapshot)
+
+    assert summary["signature_row_count"] == 2
+    assert summary["valid_row_count"] == 0
+    assert summary["invalid_row_count"] == 2
+    assert "expected_close_age" not in summary
+    assert "last_real_close_age" not in summary
+
+
 @pytest.mark.asyncio
 async def test_planning_snapshot_freezes_data_packet_revisions_through_cycle(monkeypatch):
     symbol = "BTC/USDT:USDT"


### PR DESCRIPTION
## Summary

- derive a bounded completed-1m-candle freshness summary from each frozen planning snapshot when that surface is required
- add expected-close age, last-real-close age, configured/observed tail-gap evidence, and strict malformed/missing proof accounting to `live-performance-report`
- keep symbol samples bounded and validated, and omit the projection entirely when completed candles are not a required surface
- record PR #1325 and #1326 deployment evidence and advance the compact logging-overhaul status

## Scope category

Observability producer plus read-only reporting.

## Behavior boundary

The producer reads only the immutable planning snapshot signature and the configured tail-gap bound. It does not reread candles, contact exchanges, mutate caches, or change planning readiness, strategy, orders, risk, configuration, or process control. The report consumes durable monitor events offline.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q -p no:cacheprovider tests/test_live_performance_report.py tests/test_passivbot_balance_split.py`: 362 passed
- Python compilation of all four touched Python/test files: passed
- `PYTHONPATH=src .../venv/bin/python src/tools/check_ai_docs.py`: 0 errors; existing word-count warning only
- `cargo check`: passed
- `git diff --check origin/master...HEAD`: passed

## Deployment evidence carried forward

PR #1325 is deployed at `ac9ff15029cb728eeb33563c134f196df3e3a49e` after an exact five-pane graceful restart. Immediate and settled smokes were hard-green; the settled window had `17/17` account-critical and `328/328` remote calls successful, zero hard/monitor/text-log failures, and no latest degraded cycle.

PR #1326 is deployed at `0a57187ff9f0def7eb4976721f5b04d17f03fb74` without a rebuild or process signal. Its bounded offline benchmark matched compact and dense-reference state/sample contracts and reported zero network/cache/latch/monitor side effects. The five bot PIDs and protected `misc:0.0` remained unchanged.

## Expected VPS action

Tracked-clean fast-forward, guarded exact-pane restart, and immediate plus settled smoke because this PR changes a structured event payload. Preserve `misc:0.0`.

## Reviewer focus

- signature-only derivation with no live candle reread
- strict integer/shape validation and bounded symbol handling
- fail-closed report accounting for missing or malformed freshness proof
- no change to trading, readiness, or risk decisions

@codex review