### PR TITLE
Prefer ready pull requests for completed work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,12 @@ or order-construction work; it is not mandatory for unrelated documentation or t
 Before broad edits, inspect the branch, recent commits, worktree status, and relevant callers/tests.
 For reviews against a moving branch, refresh the target ref and record the reviewed SHAs.
 
+Publish completed, validated work as a regular ready-for-review pull request by default. Before
+publication, make the branch clean, make the PR body accurate, and run the required author checks.
+Do not use a draft PR as a holding area for work the agent knows is incomplete; continue locally or
+report the blocker instead. Use a draft only when the user explicitly requests early collaboration
+on incomplete work. A regular PR still requires current-head review and CI before merge.
+
 Run validation proportional to the changed contract. Bug fixes require regression coverage. Rust
 changes require Rust tests, a rebuilt and verified Python extension where applicable, and parity or
 integration checks for affected Python callers. See `docs/ai/validation.md` and

--- a/docs/plans/live_logging_overhaul_pr_loop_workflow.md
+++ b/docs/plans/live_logging_overhaul_pr_loop_workflow.md
@@ -91,9 +91,11 @@ before push or merge.
 - Keep dependent work serial. Use parallel PRs only when they are truly
   orthogonal and merge-order independent.
 
-Use a draft PR while implementation or author validation is incomplete. Mark it
-ready only after the branch is clean, the PR body is accurate, and required
-author tests pass.
+Regular ready-for-review PRs are the default and preferred publication state.
+Finish implementation and author validation before publishing: the branch must
+be clean, the PR body accurate, and required author tests passing. Do not
+publish known-premature work merely to create a PR. Use a draft only when the
+user or maintainer explicitly requests early collaboration on incomplete work.
 
 ## PR Body Contract
 
@@ -150,8 +152,9 @@ State:
    artifacts in the main checkout and on VPS5.
 5. Implement and validate proportionally. Use real fake-live, backtest, or
    optimize smokes when touched behavior warrants them.
-6. Open a draft PR if work remains; otherwise open ready with the PR body
-   contract.
+6. Finish the selected slice and author validation, then open a regular
+   ready-for-review PR with the PR body contract. Use a draft only after an
+   explicit request for early collaboration on incomplete work.
 7. Let Luna/deterministic polling monitor GitHub. Sol does not wait in a
    high-cost semantic loop.
 8. Verify every finding against the current branch. Apply the narrow fix,


### PR DESCRIPTION
## What

- make regular, ready-for-review pull requests the repository-wide default for completed Passivbot work
- require implementation, author validation, a clean branch, and an accurate PR body before publication
- reserve draft PRs for explicitly requested early collaboration on incomplete work
- align the live logging PR-loop publication step with the repository-wide rule

## Why

The previous generic publishing helper defaulted to drafts even after implementation and author validation were complete. Drafts suppress normal review automation until a maintainer manually marks them ready, adding an unnecessary handoff and encouraging publication of work the agent already knows is premature.

The new Passivbot rule keeps incomplete work local or reports a blocker. Completed work is published ready for review, while merge readiness still requires exact-head review and CI.

## Impact

- completed agent-authored PRs should trigger normal review automation immediately
- maintainers no longer need to click “Ready for review” for routine completed work
- drafts remain available when a user or maintainer explicitly wants early collaboration
- no runtime, trading, exchange, configuration, or deployment behavior changes

## Checks

- `PYTHONPATH=src .../venv/bin/python src/tools/check_ai_docs.py`
- `PYTHONPATH=src .../venv/bin/python src/tools/generate_live_event_registry.py --check`
- `PYTHONPATH=src .../venv/bin/python -m pytest tests/test_ai_docs.py tests/test_live_event_registry_docs.py -q`
- `git diff --check`
