### PR TITLE
Preserve completed candle freshness row counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ All notable user-facing changes will be documented in this file.
   freshness summary when that surface is required. The summary is derived only
   from the frozen planning signature and reports expected/real close ages plus
   bounded tail-gap fallback counts; `live-performance-report` validates and
-  aggregates the same proof. It does not reread candles or change planning,
-  exchange access, orders, strategy, or risk behavior.
+  aggregates the same proof. Public row-count fields avoid secret-key redaction
+  so the persisted evidence remains machine-readable. It does not reread
+  candles or change planning, exchange access, orders, strategy, or risk
+  behavior.
 
 - `passivbot tool hsl-replay-benchmark` now reports exclusive timing profiles
   for fixture construction, replay internals, final-state projection, candidate

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,27 +22,46 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR #1328, `Report completed candle decision freshness`; branch:
-  `codex/decision-freshness-report`, based on canonical
-  `0a57187ff9f0def7eb4976721f5b04d17f03fb74`.
-- Scope: project completed-1m-candle freshness from each frozen planning
-  snapshot into bounded `snapshot.built` diagnostics, then validate and
-  aggregate expected-close age, last-real-close age, and allowed tail-gap
-  fallback evidence in `live-performance-report`.
+- PR #1331, `Preserve completed candle freshness row counts`; branch:
+  `codex/completed-candle-summary-redaction-fix`, based on canonical
+  `c0386ff5673d93b732786cf12c4cd48f6a381767`.
+- Scope: rename the public completed-candle source-row count so the live-event
+  secret-key sanitizer preserves its numeric value, then consume and project
+  that non-sensitive key in `live-performance-report`.
 - Behavior boundary: observability producer and read-only reporting only. The
-  producer reads the immutable planning signature and configured tail-gap bound;
-  it does not reread candles or change exchange access, planning readiness,
-  strategy, orders, risk, cache state, or process control.
+  fix changes no sanitizer exception, candle read, exchange access, planning
+  readiness, strategy, order, risk, cache, or process-control behavior.
 - Validation: 362 focused performance-report and planning-snapshot tests passed
-  after current-master integration. Regression coverage proves signature-only
-  derivation, strict timestamp and row validation, bounded/sorted symbol samples,
-  malformed/missing proof accounting, report aggregation, and omission when the
-  candle surface is not required. Python compilation and diff checks passed.
+  on exact head `ff6c5606c621acd7fba689ad81b7b8a7755f162a`. A runtime
+  redaction probe preserved the numeric source-row count while redacting genuine
+  signature, API-key, and token fields. Python compilation and diff checks
+  passed.
 - Review gate: final exact-head Hermes approval plus green Python/Rust CI.
   Built-in Codex automatic review is additional and every finding must be
   verified and resolved.
 - Expected VPS action: tracked-clean pull, guarded exact-pane restart, and
-  immediate plus settled smoke because the structured event payload changes.
+  immediate plus settled smoke, followed by a natural performance report that
+  proves corrected numeric freshness evidence.
+
+## Deployed Baseline (PR #1328)
+
+- PR #1328 merged as canonical
+  `c0386ff5673d93b732786cf12c4cd48f6a381767` after exact-head Hermes
+  approval, a green built-in Codex review, and green Python/Rust CI. VPS5
+  fast-forwarded tracked-clean from `0a57187ff9f0def7eb4976721f5b04d17f03fb74`.
+- Rust source fingerprint and compiled stamp remained
+  `691bff9683deec9382a4e96ab6a107c14145f88edd6ae2f8e2380b8ba6824449`;
+  no Rust build was required. The guarded runner gracefully restarted only exact
+  panes `%358`-`%362` without force. Bot PIDs
+  `1056607/1056616/1056610/1056619/1056613` became
+  `1057982/1057991/1057985/1057994/1057988`, while protected `misc:0.0`
+  remained `%8`/PID `434835`.
+- The bounded two-minute restart smoke was hard-green with complete five-bot
+  shutdown/startup evidence and zero hard, monitor, or text-log failures. A
+  natural post-restart performance report then classified all seven observed
+  completed-candle summaries as malformed because the sanitizer had replaced
+  `signature_row_count` with `[redacted]`. No direct exchange call or event was
+  manufactured; active PR #1331 corrects only this public diagnostic contract.
 
 ## Deployed Baseline (PR #1326)
 

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -1545,9 +1545,9 @@ PR #1288's bounded target-identity stability, and PR #1289's plan binding are
 merged, deployed, and naturally validated without process control. PR #1290's
 pane-parent relaunch classification and the restart preparation/orchestration
 slices through PR #1309 are also merged and deployed. Later slices through PR
-#1326 are merged and deployed at canonical
-`0a57187ff9f0def7eb4976721f5b04d17f03fb74`; their current evidence is recorded
-above. PR #1328 is the active completed-candle decision-freshness slice.
+#1328 are merged and deployed at canonical
+`c0386ff5673d93b732786cf12c4cd48f6a381767`; their current evidence is recorded
+above. PR #1331 is the active completed-candle row-count redaction fix.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,26 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1326)
+## Latest Canonical Deployment (PR #1328)
+
+- PR #1328 merged as canonical
+  `c0386ff5673d93b732786cf12c4cd48f6a381767` after exact-head Hermes and
+  built-in Codex reviews plus green Python/Rust CI. VPS5 fast-forwarded
+  tracked-clean from `0a57187ff9f0def7eb4976721f5b04d17f03fb74` without a
+  Rust build.
+- The guarded runner gracefully restarted only exact panes `%358`-`%362`.
+  Old bot PIDs `1056607/1056616/1056610/1056619/1056613` became
+  `1057982/1057991/1057985/1057994/1057988`; protected `misc:0.0` stayed
+  `%8`/PID `434835`. The two-minute smoke was hard-green with complete five-bot
+  lifecycle evidence and zero hard, monitor, or text-log failures.
+- Natural `snapshot.built` evidence exposed that the secret-key sanitizer
+  replaced `signature_row_count` with `[redacted]`. The performance report
+  therefore classified all seven observed summaries as malformed and produced
+  zero freshness metrics. No direct exchange call or event was manufactured.
+  Active PR #1331 renames only the public diagnostic/report count fields so the
+  values remain numeric without weakening secret redaction.
+
+## Previous Canonical Deployment (PR #1326)
 
 - PR #1326 merged as canonical
   `0a57187ff9f0def7eb4976721f5b04d17f03fb74` after exact-head Hermes and

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -894,7 +894,7 @@ class _InputStalenessAccumulator:
         self.completed_candle_summary_malformed_proof_count = 0
         self.completed_candle_summary_no_valid_rows_count = 0
         self.completed_candle_metric_observations = 0
-        self.completed_candle_signature_row_values: list[int] = []
+        self.completed_candle_source_row_values: list[int] = []
         self.completed_candle_valid_row_values: list[int] = []
         self.completed_candle_invalid_row_values: list[int] = []
         self.completed_candle_fallback_count_values: list[int] = []
@@ -962,7 +962,7 @@ class _InputStalenessAccumulator:
         def count(name: str) -> int | None:
             return _strict_non_negative_int(summary.get(name))
 
-        signature_rows = count("signature_row_count")
+        source_rows = count("source_row_count")
         valid_rows = count("valid_row_count")
         invalid_rows = count("invalid_row_count")
         fallback_count = count("tail_gap_fallback_count")
@@ -970,12 +970,12 @@ class _InputStalenessAccumulator:
         if (
             summary.get("required") is not True
             or summary.get("timeframe") != "1m"
-            or signature_rows is None
+            or source_rows is None
             or valid_rows is None
             or invalid_rows is None
             or fallback_count is None
             or fallback_symbol_count is None
-            or signature_rows != valid_rows + invalid_rows
+            or source_rows != valid_rows + invalid_rows
             or fallback_count > valid_rows
             or fallback_symbol_count > fallback_count
         ):
@@ -995,7 +995,7 @@ class _InputStalenessAccumulator:
         ):
             self.completed_candle_summary_malformed_proof_count += 1
             return
-        self.completed_candle_signature_row_values.append(signature_rows)
+        self.completed_candle_source_row_values.append(source_rows)
         self.completed_candle_valid_row_values.append(valid_rows)
         self.completed_candle_invalid_row_values.append(invalid_rows)
         self.completed_candle_fallback_count_values.append(fallback_count)
@@ -1326,8 +1326,8 @@ class _InputStalenessAccumulator:
                     self.completed_candle_summary_no_valid_rows_count
                 ),
                 "metric_observations": int(self.completed_candle_metric_observations),
-                "signature_rows": _number_summary(
-                    self.completed_candle_signature_row_values
+                "source_rows": _number_summary(
+                    self.completed_candle_source_row_values
                 ),
                 "valid_rows": _number_summary(self.completed_candle_valid_row_values),
                 "invalid_rows": _number_summary(

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -9817,7 +9817,7 @@ class Passivbot:
 
         signature = snapshot.completed_candle_signature
         rows = list(signature) if isinstance(signature, (list, tuple)) else []
-        signature_row_count = len(rows)
+        source_row_count = len(rows)
         invalid_row_count = 0 if isinstance(signature, (list, tuple)) else 1
         expected_close_ages = []
         real_close_ages = []
@@ -9889,7 +9889,7 @@ class Passivbot:
         result = {
             "required": True,
             "timeframe": "1m",
-            "signature_row_count": signature_row_count,
+            "source_row_count": source_row_count,
             "valid_row_count": len(expected_close_ages),
             "invalid_row_count": int(invalid_row_count),
             "tail_gap_fallback_count": int(fallback_count),

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1036,7 +1036,7 @@ def test_live_performance_report_completed_candle_freshness_summary(tmp_path):
     valid_summary = {
         "required": True,
         "timeframe": "1m",
-        "signature_row_count": 2,
+        "source_row_count": 2,
         "valid_row_count": 2,
         "invalid_row_count": 0,
         "tail_gap_fallback_count": 1,
@@ -1074,7 +1074,7 @@ def test_live_performance_report_completed_candle_freshness_summary(tmp_path):
                     "required_surfaces": ["completed_candles"],
                     "completed_candle_summary": {
                         **valid_summary,
-                        "signature_row_count": "2",
+                        "source_row_count": "2",
                     },
                 },
             ),
@@ -1099,7 +1099,7 @@ def test_live_performance_report_completed_candle_freshness_summary(tmp_path):
                     "completed_candle_summary": {
                         "required": True,
                         "timeframe": "1m",
-                        "signature_row_count": 2,
+                        "source_row_count": 2,
                         "valid_row_count": 0,
                         "invalid_row_count": 2,
                         "tail_gap_fallback_count": 0,
@@ -1132,7 +1132,7 @@ def test_live_performance_report_completed_candle_freshness_summary(tmp_path):
     assert completed["malformed_proof_count"] == 3
     assert completed["no_valid_rows_count"] == 0
     assert completed["metric_observations"] == 1
-    assert completed["signature_rows"]["max"] == 2
+    assert completed["source_rows"]["max"] == 2
     assert completed["valid_rows"]["max"] == 2
     assert completed["invalid_rows"]["max"] == 2
     assert completed["tail_gap_fallback_count"]["max"] == 1

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -8103,7 +8103,7 @@ def test_completed_candle_snapshot_summary_is_bounded_and_signature_only():
     assert summary == {
         "required": True,
         "timeframe": "1m",
-        "signature_row_count": 14,
+        "source_row_count": 14,
         "valid_row_count": 11,
         "invalid_row_count": 3,
         "tail_gap_fallback_count": 10,
@@ -8116,6 +8116,11 @@ def test_completed_candle_snapshot_summary_is_bounded_and_signature_only():
         "configured_max_tail_gap_ms": 120_000,
     }
     assert "api_key" not in json.dumps(summary, sort_keys=True)
+    serialized = LiveEvent(
+        event_type="snapshot.built", data={"completed_candle_summary": summary}
+    )
+    assert serialized.data["completed_candle_summary"]["source_row_count"] == 14
+    assert "[redacted]" not in json.dumps(serialized.data, sort_keys=True)
 
 
 def test_completed_candle_snapshot_summary_is_omitted_when_not_required():
@@ -8169,7 +8174,7 @@ def test_completed_candle_snapshot_summary_rejects_coerced_timestamps():
 
     summary = bot._completed_candle_summary_from_snapshot(snapshot)
 
-    assert summary["signature_row_count"] == 2
+    assert summary["source_row_count"] == 2
     assert summary["valid_row_count"] == 0
     assert summary["invalid_row_count"] == 2
     assert "expected_close_age" not in summary


### PR DESCRIPTION
@codex review

## Scope

- Rename the public completed-candle diagnostic count from `signature_row_count` to `source_row_count` so the live-event secret-key sanitizer does not replace the integer with `[redacted]`.
- Make `live-performance-report` validate the corrected field and expose `source_rows` rather than another public key containing `signature`.
- Add a regression that serializes the real summary through `LiveEvent` and proves the row count remains numeric while existing secret redaction is unchanged.
- Record the exact PR #1328 VPS5 deployment and the natural redaction defect in the canonical logging handoff.

Scope category: observability event/report contract correction.

## Behavior boundary

Diagnostics only. This does not reread candles or change exchange access, planning readiness, strategy, orders, risk, cache state, or process control. Historical already-redacted rows remain malformed because their original counts cannot be recovered.

## Validation

- 362 focused performance-report and planning-snapshot tests passed on semantic head `ff6c5606c621acd7fba689ad81b7b8a7755f162a`; the only later commit is the handoff/deploy-evidence update.
- Runtime redaction probe retained numeric `source_row_count` while redacting genuine `signature`, `api_key`, and `token` values.
- On current head `83cfb0a604`, AI docs validation has 0 errors (one existing word-count warning), `tests/test_ai_docs.py` has 3 passed, and diff checks pass.
- Python compilation passed.

## Deploy evidence from PR #1328

PR #1328 merged as `c0386ff5673d93b732786cf12c4cd48f6a381767`. VPS5 fast-forwarded tracked-clean from `0a57187ff9f0def7eb4976721f5b04d17f03fb74`; the Rust fingerprint/stamp remained `691bff9683deec9382a4e96ab6a107c14145f88edd6ae2f8e2380b8ba6824449` and no build was needed. The guarded runner gracefully restarted only exact panes `%358`-`%362`: old bot PIDs `1056607/1056616/1056610/1056619/1056613` became `1057982/1057991/1057985/1057994/1057988`; protected `misc:0.0` remained `%8`/PID `434835`. The two-minute restart smoke was hard-green with complete five-bot shutdown/startup proof and zero monitor or text-log errors.

Natural post-restart `snapshot.built` events exposed the follow-up defect: `live-event-query` showed `signature_row_count: "[redacted]"`, and `live-performance-report` counted all seven observed summaries as malformed with zero metric observations. No direct exchange call or event was manufactured.

## Expected VPS action

Tracked-clean pull, guarded exact-five-pane restart, immediate/settled smoke, and a natural `live-performance-report` check proving corrected numeric freshness evidence.