### PR TITLE
Report live artifact scan cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `live-event-query` and `live-performance-report` now include bounded
+  `scan_cost` metadata for elapsed artifact-scan time, successfully read files
+  and records, read methods, and physical versus decoded byte totals. Explicit
+  known flags prevent failed or unmeasurable reads from appearing complete;
+  query selection, results, monitor data, exchange access, and live behavior
+  are unchanged.
+
 - Planning snapshot diagnostics now include a bounded completed-1m-candle
   freshness summary when that surface is required. The summary is derived only
   from the frozen planning signature and reports expected/real close ages plus

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - PR #1333, `Report live artifact scan cost`; branch:
   `codex/live-artifact-scan-cost`, based on canonical
-  `0a6be3ed00261c6d6a2cdbe0f2588e5709e670f1`.
+  `419839fb494388266bf0b3a54563ac8e24123f0b`.
 - Scope: expose bounded elapsed-time, byte, file, record, and read-method cost
   metadata for `live-event-query` and `live-performance-report` artifact scans.
 - Behavior boundary: read-only local tooling only. The slice changes no event

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -1584,8 +1584,8 @@ PR #1288's bounded target-identity stability, and PR #1289's plan binding are
 merged, deployed, and naturally validated without process control. PR #1290's
 pane-parent relaunch classification and the restart preparation/orchestration
 slices through PR #1309 are also merged and deployed. Later slices through PR
-#1331 are merged and deployed at canonical
-`0a6be3ed00261c6d6a2cdbe0f2588e5709e670f1`; their current evidence is recorded
+#1334 are merged and deployed at canonical
+`97aa36da4c9a9885c840ea48590837e28e5b8069`; their current evidence is recorded
 above. The active artifact-scan cost slice measures read-only query/report work
 without changing scan behavior.
 

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,28 +22,45 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR #1331, `Preserve completed candle freshness row counts`; branch:
-  `codex/completed-candle-summary-redaction-fix`, based on canonical
-  `c0386ff5673d93b732786cf12c4cd48f6a381767`.
-- Scope: rename the public completed-candle source-row count so the live-event
-  secret-key sanitizer preserves its numeric value, then consume and project
-  that non-sensitive key in `live-performance-report`.
-- Behavior boundary: observability producer and read-only reporting only. The
-  fix changes no sanitizer exception, candle read, exchange access, planning
-  readiness, strategy, order, risk, cache, or process-control behavior.
-- Validation: 362 focused performance-report and planning-snapshot tests passed
-  on exact head `ff6c5606c621acd7fba689ad81b7b8a7755f162a`. A runtime
-  redaction probe preserved the numeric source-row count while redacting genuine
-  signature, API-key, and token fields. Python compilation and diff checks
-  passed.
-- Review gate: final exact-head Hermes approval plus green Python/Rust CI.
+- PR pending, `Report live artifact scan cost`; branch:
+  `codex/live-artifact-scan-cost`, based on canonical
+  `0a6be3ed00261c6d6a2cdbe0f2588e5709e670f1`.
+- Scope: expose bounded elapsed-time, byte, file, record, and read-method cost
+  metadata for `live-event-query` and `live-performance-report` artifact scans.
+- Behavior boundary: read-only local tooling only. The slice changes no event
+  producer, file selection, query result, monitor persistence, exchange access,
+  planning, strategy, order, risk, or process-control behavior.
+- Review gate: exact-current-head Hermes approval plus green Python/Rust CI.
   Built-in Codex automatic review is additional and every finding must be
   verified and resolved.
-- Expected VPS action: tracked-clean pull, guarded exact-pane restart, and
-  immediate plus settled smoke, followed by a natural performance report that
-  proves corrected numeric freshness evidence.
+- Expected VPS action: tracked-clean pull plus bounded read-only report smokes;
+  no bot restart or process signal.
 
-## Deployed Baseline (PR #1328)
+## Deployed Baseline (PR #1331)
+
+- PR #1331 merged as canonical
+  `0a6be3ed00261c6d6a2cdbe0f2588e5709e670f1` after exact-head Hermes
+  approval, a green built-in Codex review, and green Python/Rust CI. VPS5
+  fast-forwarded tracked-clean from
+  `c0386ff5673d93b732786cf12c4cd48f6a381767` without a Rust build; the source
+  fingerprint/stamp remained
+  `691bff9683deec9382a4e96ab6a107c14145f88edd6ae2f8e2380b8ba6824449`.
+- The guarded runner gracefully restarted only exact panes `%358`-`%362`.
+  Bot PIDs `1057982/1057991/1057985/1057994/1057988` became
+  `1059196/1059205/1059199/1059208/1059202`; pane parents were unchanged and
+  protected `misc:0.0` remained `%8`/PID `434835`.
+- The immediate bounded smoke was hard-green with complete five-bot lifecycle
+  evidence, zero hard/monitor/text-log failures, `81/81` account-critical
+  calls, `436/436` remote calls, and five stable processes. The settled smoke
+  remained hard-green with `65/65` account-critical and `345/345` remote calls,
+  zero latest degraded cycles, both remaining HSL replays complete, and five
+  stable processes.
+- Natural post-restart snapshots persisted numeric `source_row_count` values
+  `36` and `1`. The exact-window performance report produced two summary and
+  metric observations with zero malformed or missing proofs. No direct exchange
+  call or event was manufactured.
+
+## Previous Deployed Baseline (PR #1328)
 
 - PR #1328 merged as canonical
   `c0386ff5673d93b732786cf12c4cd48f6a381767` after exact-head Hermes
@@ -61,7 +78,7 @@ Estimated completion:
   natural post-restart performance report then classified all seven observed
   completed-candle summaries as malformed because the sanitizer had replaced
   `signature_row_count` with `[redacted]`. No direct exchange call or event was
-  manufactured; active PR #1331 corrects only this public diagnostic contract.
+  manufactured; merged PR #1331 corrected only this public diagnostic contract.
 
 ## Deployed Baseline (PR #1326)
 
@@ -1545,9 +1562,10 @@ PR #1288's bounded target-identity stability, and PR #1289's plan binding are
 merged, deployed, and naturally validated without process control. PR #1290's
 pane-parent relaunch classification and the restart preparation/orchestration
 slices through PR #1309 are also merged and deployed. Later slices through PR
-#1328 are merged and deployed at canonical
-`c0386ff5673d93b732786cf12c4cd48f6a381767`; their current evidence is recorded
-above. PR #1331 is the active completed-candle row-count redaction fix.
+#1331 are merged and deployed at canonical
+`0a6be3ed00261c6d6a2cdbe0f2588e5709e670f1`; their current evidence is recorded
+above. The active artifact-scan cost slice measures read-only query/report work
+without changing scan behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,7 +22,7 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR pending, `Report live artifact scan cost`; branch:
+- PR #1333, `Report live artifact scan cost`; branch:
   `codex/live-artifact-scan-cost`, based on canonical
   `0a6be3ed00261c6d6a2cdbe0f2588e5709e670f1`.
 - Scope: expose bounded elapsed-time, byte, file, record, and read-method cost

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,31 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1328)
+## Latest Canonical Deployment (PR #1331)
+
+- PR #1331 merged as canonical
+  `0a6be3ed00261c6d6a2cdbe0f2588e5709e670f1` after exact-head Hermes and
+  built-in Codex reviews plus green Python/Rust CI. VPS5 fast-forwarded
+  tracked-clean from `c0386ff567` without a Rust build; the Rust source
+  fingerprint/stamp remained
+  `691bff9683deec9382a4e96ab6a107c14145f88edd6ae2f8e2380b8ba6824449`.
+- The guarded runner gracefully restarted only exact panes `%358`-`%362`.
+  Bot PIDs `1057982/1057991/1057985/1057994/1057988` became
+  `1059196/1059205/1059199/1059208/1059202`; pane parents were unchanged and
+  protected `misc:0.0` stayed `%8`/PID `434835`.
+- The immediate smoke was hard-green with complete five-bot lifecycle evidence,
+  zero hard/monitor/text-log failures, `81/81` account-critical calls,
+  `436/436` remote calls, and five stable processes. The settled smoke remained
+  hard-green with `65/65` account-critical and `345/345` remote calls, zero
+  latest degraded cycles, both remaining HSL replays complete, and five stable
+  processes.
+- Natural post-restart snapshots persisted numeric `source_row_count` values
+  `36` and `1`; the exact-window performance report produced two summary and
+  metric observations with zero malformed or missing proofs. No direct exchange
+  call or event was manufactured. Active `codex/live-artifact-scan-cost` adds
+  bounded read-only artifact scan-cost evidence without changing scan results.
+
+## Previous Canonical Deployment (PR #1328)
 
 - PR #1328 merged as canonical
   `c0386ff5673d93b732786cf12c4cd48f6a381767` after exact-head Hermes and
@@ -31,7 +55,7 @@ merge, live smoke evidence changes, or new gaps are discovered.
   replaced `signature_row_count` with `[redacted]`. The performance report
   therefore classified all seven observed summaries as malformed and produced
   zero freshness metrics. No direct exchange call or event was manufactured.
-  Active PR #1331 renames only the public diagnostic/report count fields so the
+  Merged PR #1331 renamed only the public diagnostic/report count fields so the
   values remain numeric without weakening secret redaction.
 
 ## Previous Canonical Deployment (PR #1326)

--- a/src/live/event_file_rows.py
+++ b/src/live/event_file_rows.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 
-@dataclass(frozen=True)
+@dataclass
 class EventRowWindow:
     limited: bool = False
     skipped_lines: int | None = None
@@ -15,6 +15,8 @@ class EventRowWindow:
     skipped_bytes: int = 0
     line_numbers_exact: bool = True
     method: str = "full_scan"
+    physical_bytes_read: int | None = None
+    decoded_bytes_read: int | None = None
 
 
 def _open_text(path: Path):
@@ -35,6 +37,8 @@ def _plain_tail_rows(path: Path, *, max_lines: int) -> tuple[list[tuple[int, str
             skipped_bytes=0,
             line_numbers_exact=True,
             method="seek_tail",
+            physical_bytes_read=0,
+            decoded_bytes_read=0,
         )
 
     chunk_size = 64 * 1024
@@ -73,22 +77,41 @@ def _plain_tail_rows(path: Path, *, max_lines: int) -> tuple[list[tuple[int, str
         skipped_bytes=skipped_bytes,
         line_numbers_exact=line_numbers_exact,
         method="seek_tail",
+        physical_bytes_read=len(data),
+        decoded_bytes_read=len(data),
     )
 
 
 @contextmanager
-def event_file_rows(path: Path, *, max_tail_lines: int = 0):
+def event_file_rows(path: Path, *, max_tail_lines: int = 0, text_opener=None):
     tail_lines = max(0, int(max_tail_lines))
+    opener = _open_text if text_opener is None else text_opener
     if tail_lines <= 0:
-        with _open_text(path) as stream:
-            yield enumerate(stream, start=1), EventRowWindow()
+        try:
+            physical_bytes_read = int(path.stat().st_size)
+        except OSError:
+            physical_bytes_read = None
+        window = EventRowWindow(
+            physical_bytes_read=physical_bytes_read,
+            decoded_bytes_read=(
+                None if path.name.endswith(".gz") else physical_bytes_read
+            ),
+        )
+        with opener(path) as stream:
+            yield enumerate(stream, start=1), window
+            if path.name.endswith(".gz"):
+                buffer = getattr(stream, "buffer", None)
+                if buffer is not None:
+                    window.decoded_bytes_read = int(buffer.tell())
         return
     if not path.name.endswith(".gz"):
         rows, window = _plain_tail_rows(path, max_lines=tail_lines)
         yield rows, window
         return
+    physical_bytes_read = int(path.stat().st_size)
     with _open_text(path) as stream:
         rows = deque(enumerate(stream, start=1), maxlen=tail_lines)
+        decoded_bytes_read = int(stream.buffer.tell())
     skipped_lines = max(0, int(rows[0][0]) - 1) if rows else 0
     yield rows, EventRowWindow(
         limited=True,
@@ -97,4 +120,6 @@ def event_file_rows(path: Path, *, max_tail_lines: int = 0):
         skipped_bytes=0,
         line_numbers_exact=True,
         method="sequential_gzip_tail",
+        physical_bytes_read=physical_bytes_read,
+        decoded_bytes_read=decoded_bytes_read,
     )

--- a/src/live/event_file_rows.py
+++ b/src/live/event_file_rows.py
@@ -25,6 +25,28 @@ def _open_text(path: Path):
     return open(path, "r", encoding="utf-8", errors="replace")
 
 
+def _stream_position(stream) -> int | None:
+    tell = getattr(stream, "tell", None)
+    if not callable(tell):
+        return None
+    try:
+        position = int(tell())
+    except (OSError, TypeError, ValueError):
+        return None
+    return position if position >= 0 else None
+
+
+def _full_scan_read_positions(path: Path, stream) -> tuple[int | None, int | None]:
+    buffer = getattr(stream, "buffer", None)
+    if path.name.endswith(".gz"):
+        return (
+            _stream_position(getattr(buffer, "fileobj", None)),
+            _stream_position(buffer),
+        )
+    position = _stream_position(buffer)
+    return position, position
+
+
 def _plain_tail_rows(path: Path, *, max_lines: int) -> tuple[list[tuple[int, str]], EventRowWindow]:
     if max_lines <= 0:
         return [], EventRowWindow()
@@ -87,22 +109,12 @@ def event_file_rows(path: Path, *, max_tail_lines: int = 0, text_opener=None):
     tail_lines = max(0, int(max_tail_lines))
     opener = _open_text if text_opener is None else text_opener
     if tail_lines <= 0:
-        try:
-            physical_bytes_read = int(path.stat().st_size)
-        except OSError:
-            physical_bytes_read = None
-        window = EventRowWindow(
-            physical_bytes_read=physical_bytes_read,
-            decoded_bytes_read=(
-                None if path.name.endswith(".gz") else physical_bytes_read
-            ),
-        )
+        window = EventRowWindow()
         with opener(path) as stream:
             yield enumerate(stream, start=1), window
-            if path.name.endswith(".gz"):
-                buffer = getattr(stream, "buffer", None)
-                if buffer is not None:
-                    window.decoded_bytes_read = int(buffer.tell())
+            window.physical_bytes_read, window.decoded_bytes_read = _full_scan_read_positions(
+                path, stream
+            )
         return
     if not path.name.endswith(".gz"):
         rows, window = _plain_tail_rows(path, max_lines=tail_lines)

--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import time
 from collections.abc import Iterable as IterableABC
 from collections import Counter, defaultdict
 from dataclasses import asdict, dataclass
@@ -1388,6 +1389,12 @@ def build_event_report(
     event_tail_skipped_bytes = 0
     event_tail_line_numbers_exact = True
     event_tail_methods: Counter[str] = Counter()
+    scan_physical_bytes_read = 0
+    scan_physical_bytes_known = True
+    scan_decoded_bytes_read = 0
+    scan_decoded_bytes_known = True
+    scan_files_read = 0
+    scan_read_methods: Counter[str] = Counter()
     issues: list[EventIssue] = []
     discovery = EventFileDiscovery(files=[])
     try:
@@ -1507,6 +1514,7 @@ def build_event_report(
     )
     has_query_filter = has_non_cycle_filter or window_enabled or trace_without_cycle
 
+    scan_started_at = time.perf_counter()
     for path in files:
         try:
             with event_file_rows(path, max_tail_lines=max_event_tail_lines) as (
@@ -1717,10 +1725,24 @@ def build_event_report(
                                     user=record_user,
                                 )
                             )
+            scan_files_read += 1
+            if row_window.physical_bytes_read is None:
+                scan_physical_bytes_known = False
+            else:
+                scan_physical_bytes_read += int(row_window.physical_bytes_read)
+            if row_window.decoded_bytes_read is None:
+                scan_decoded_bytes_known = False
+            else:
+                scan_decoded_bytes_read += int(row_window.decoded_bytes_read)
+            scan_read_methods[str(row_window.method)] += 1
         except OSError as exc:
+            scan_physical_bytes_known = False
+            scan_decoded_bytes_known = False
             issues.append(
                 EventIssue(str(path), None, "error", "read_failed", str(exc))
             )
+
+    scan_elapsed_ms = round((time.perf_counter() - scan_started_at) * 1000, 3)
 
     if has_query_filter and not include_rotated and discovery.rotated_skipped > 0:
         issues.append(
@@ -1745,6 +1767,20 @@ def build_event_report(
         "include_rotated": bool(include_rotated),
         "files": [str(path) for path in files],
         "files_scanned": len(files),
+        "scan_cost": {
+            "elapsed_ms": scan_elapsed_ms,
+            "physical_bytes_read": (
+                scan_physical_bytes_read if scan_physical_bytes_known else None
+            ),
+            "physical_bytes_known": scan_physical_bytes_known,
+            "decoded_bytes_read": (
+                scan_decoded_bytes_read if scan_decoded_bytes_known else None
+            ),
+            "decoded_bytes_known": scan_decoded_bytes_known,
+            "files_read": scan_files_read,
+            "records_read": records_total,
+            "read_methods": dict(sorted(scan_read_methods.items())),
+        },
         "file_discovery": discovery.to_dict(),
         "records_total": records_total,
         "live_events": live_events,

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -4,6 +4,7 @@ import gzip
 import json
 import math
 import statistics
+import time
 from collections import Counter
 from numbers import Integral
 from pathlib import Path
@@ -50,6 +51,7 @@ _PERFORMANCE_REPORT_SECTION_BASE_KEYS = (
     "root",
     "include_rotated",
     "files_scanned",
+    "scan_cost",
     "file_discovery",
     "records_total",
     "live_events",
@@ -5687,6 +5689,12 @@ def build_live_performance_report(
     event_types: Counter[str] = Counter()
     bots: Counter[str] = Counter()
     event_tail_methods: Counter[str] = Counter()
+    scan_physical_bytes_read = 0
+    scan_physical_bytes_known = True
+    scan_decoded_bytes_read = 0
+    scan_decoded_bytes_known = True
+    scan_files_read = 0
+    scan_read_methods: Counter[str] = Counter()
 
     def process_event_row(
         path: Path,
@@ -5802,43 +5810,53 @@ def build_live_performance_report(
         account_state_changes.add(row=row, live_event=live_event)
         risk_activity.add(row=row, live_event=live_event)
 
+    scan_started_at = time.perf_counter()
     for path in files:
         try:
-            if max_event_tail_lines:
-                with event_file_rows(
-                    path, max_tail_lines=max_event_tail_lines
-                ) as (row_iter, row_window):
-                    if row_window.limited:
-                        event_window["event_tail_limited_files"] += 1
-                        if row_window.skipped_lines is None:
-                            event_window["event_tail_skipped_lines_exact"] = False
-                        else:
-                            event_window["event_tail_skipped_lines"] += int(
-                                row_window.skipped_lines
-                            )
-                        event_window["event_tail_skipped_bytes"] += int(
-                            row_window.skipped_bytes
+            with event_file_rows(
+                path,
+                max_tail_lines=max_event_tail_lines,
+                text_opener=_open_text,
+            ) as (row_iter, row_window):
+                if max_event_tail_lines and row_window.limited:
+                    event_window["event_tail_limited_files"] += 1
+                    if row_window.skipped_lines is None:
+                        event_window["event_tail_skipped_lines_exact"] = False
+                    else:
+                        event_window["event_tail_skipped_lines"] += int(
+                            row_window.skipped_lines
                         )
-                        event_window["event_tail_line_numbers_exact"] = bool(
-                            event_window["event_tail_line_numbers_exact"]
-                            and row_window.line_numbers_exact
-                        )
-                        event_tail_methods[str(row_window.method)] += 1
-                    source_complete = (
-                        not row_window.limited or row_window.skipped_lines == 0
+                    event_window["event_tail_skipped_bytes"] += int(
+                        row_window.skipped_bytes
                     )
-                    for line_no, raw_line in row_iter:
-                        process_event_row(
-                            path,
-                            int(line_no),
-                            raw_line,
-                            source_complete=source_complete,
-                        )
+                    event_window["event_tail_line_numbers_exact"] = bool(
+                        event_window["event_tail_line_numbers_exact"]
+                        and row_window.line_numbers_exact
+                    )
+                    event_tail_methods[str(row_window.method)] += 1
+                source_complete = (
+                    not row_window.limited or row_window.skipped_lines == 0
+                )
+                for line_no, raw_line in row_iter:
+                    process_event_row(
+                        path,
+                        int(line_no),
+                        raw_line,
+                        source_complete=source_complete,
+                    )
+            scan_files_read += 1
+            if row_window.physical_bytes_read is None:
+                scan_physical_bytes_known = False
             else:
-                with _open_text(path) as stream:
-                    for line_no, raw_line in enumerate(stream, start=1):
-                        process_event_row(path, int(line_no), raw_line)
+                scan_physical_bytes_read += int(row_window.physical_bytes_read)
+            if row_window.decoded_bytes_read is None:
+                scan_decoded_bytes_known = False
+            else:
+                scan_decoded_bytes_read += int(row_window.decoded_bytes_read)
+            scan_read_methods[str(row_window.method)] += 1
         except OSError as exc:
+            scan_physical_bytes_known = False
+            scan_decoded_bytes_known = False
             issues.append(
                 {
                     "path": _user_safe_display_path(path),
@@ -5853,6 +5871,7 @@ def build_live_performance_report(
     warning_count = sum(1 for issue in issues if issue.get("severity") == "warning")
     if max_event_tail_lines:
         event_window["event_tail_methods"] = dict(sorted(event_tail_methods.items()))
+    scan_elapsed_ms = round((time.perf_counter() - scan_started_at) * 1000, 3)
     performance_groups = accumulator.groups_list()
     decision_boundary_groups = decision_boundary.groups_list()
     input_staleness_groups = input_staleness.groups_list()
@@ -5864,6 +5883,20 @@ def build_live_performance_report(
         "include_rotated": bool(include_rotated),
         "files": [_user_safe_display_path(path) for path in files],
         "files_scanned": len(files),
+        "scan_cost": {
+            "elapsed_ms": scan_elapsed_ms,
+            "physical_bytes_read": (
+                scan_physical_bytes_read if scan_physical_bytes_known else None
+            ),
+            "physical_bytes_known": scan_physical_bytes_known,
+            "decoded_bytes_read": (
+                scan_decoded_bytes_read if scan_decoded_bytes_known else None
+            ),
+            "decoded_bytes_known": scan_decoded_bytes_known,
+            "files_read": scan_files_read,
+            "records_read": int(records_total),
+            "read_methods": dict(sorted(scan_read_methods.items())),
+        },
         "file_discovery": file_discovery,
         "records_total": int(records_total),
         "live_events": int(live_events),
@@ -5945,6 +5978,7 @@ def summarize_live_performance_report(
         "root": report.get("root"),
         "include_rotated": bool(report.get("include_rotated")),
         "files_scanned": int(report.get("files_scanned") or 0),
+        "scan_cost": report.get("scan_cost") or {},
         "file_discovery": report.get("file_discovery") or {},
         "records_total": int(report.get("records_total") or 0),
         "live_events": int(report.get("live_events") or 0),

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -1734,6 +1734,88 @@ def test_event_file_rows_seek_tail_skips_plain_ndjson_prefix(tmp_path):
     assert [json.loads(raw_line)["seq"] for _, raw_line in kept_rows] == [2, 3]
 
 
+def test_event_query_scan_cost_tracks_plain_full_and_seek_tail_reads(tmp_path):
+    path = tmp_path / "monitor" / "binance" / "binance_01" / "events" / "current.ndjson"
+    _write_ndjson(
+        path,
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                cycle_id="cy_1",
+                seq=1,
+                ts=1000,
+                data={"payload": "x" * 70_000},
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                cycle_id="cy_2",
+                seq=2,
+                ts=2000,
+                data={"payload": "x" * 130_000},
+            ),
+            _monitor_row(event_type="cycle.completed", cycle_id="cy_3", seq=3, ts=3000),
+        ],
+    )
+    expected_bytes = path.stat().st_size
+
+    full_report = build_event_report(tmp_path / "monitor")
+    full_scan_cost = full_report["scan_cost"]
+
+    assert full_scan_cost["elapsed_ms"] >= 0
+    assert full_scan_cost["physical_bytes_read"] == expected_bytes
+    assert full_scan_cost["physical_bytes_known"] is True
+    assert full_scan_cost["decoded_bytes_read"] == expected_bytes
+    assert full_scan_cost["decoded_bytes_known"] is True
+    assert full_scan_cost["files_read"] == 1
+    assert full_scan_cost["records_read"] == 3
+    assert full_scan_cost["read_methods"] == {"full_scan": 1}
+
+    tail_report = build_event_report(tmp_path / "monitor", event_tail_lines=1)
+    tail_scan_cost = tail_report["scan_cost"]
+
+    assert tail_scan_cost["physical_bytes_read"] < expected_bytes
+    assert tail_scan_cost["physical_bytes_known"] is True
+    assert tail_scan_cost["decoded_bytes_read"] == tail_scan_cost["physical_bytes_read"]
+    assert tail_scan_cost["decoded_bytes_known"] is True
+    assert tail_scan_cost["files_read"] == 1
+    assert tail_scan_cost["records_read"] == 1
+    assert tail_scan_cost["read_methods"] == {"seek_tail": 1}
+
+
+def test_event_query_scan_cost_distinguishes_gzip_physical_and_decoded_bytes(tmp_path):
+    path = (
+        tmp_path
+        / "monitor"
+        / "binance"
+        / "binance_01"
+        / "events"
+        / "2026-07-19T00-00-00.ndjson.gz"
+    )
+    _write_gz_ndjson(
+        path,
+        [
+            _monitor_row(event_type="cycle.completed", cycle_id="cy_1", seq=1, ts=1000),
+            _monitor_row(event_type="cycle.completed", cycle_id="cy_2", seq=2, ts=2000),
+        ],
+    )
+    with gzip.open(path, "rb") as stream:
+        expected_decoded_bytes = len(stream.read())
+
+    report = build_event_report(
+        tmp_path / "monitor",
+        include_rotated=True,
+        event_tail_lines=1,
+    )
+
+    assert report["scan_cost"]["physical_bytes_read"] == path.stat().st_size
+    assert report["scan_cost"]["physical_bytes_known"] is True
+    assert report["scan_cost"]["decoded_bytes_read"] == expected_decoded_bytes
+    assert report["scan_cost"]["decoded_bytes_known"] is True
+    assert report["scan_cost"]["files_read"] == 1
+    assert report["scan_cost"]["records_read"] == 1
+    assert report["scan_cost"]["read_methods"] == {"sequential_gzip_tail": 1}
+
+
 def test_event_query_timeline_renders_cycle_and_query_matches(tmp_path):
     events_dir = tmp_path / "monitor" / "okx" / "okx_faisal" / "events"
     _write_ndjson(

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -1734,6 +1734,46 @@ def test_event_file_rows_seek_tail_skips_plain_ndjson_prefix(tmp_path):
     assert [json.loads(raw_line)["seq"] for _, raw_line in kept_rows] == [2, 3]
 
 
+def test_event_file_rows_full_scan_uses_post_read_plain_stream_position(tmp_path):
+    path = tmp_path / "current.ndjson"
+    initial_line = json.dumps({"payload": "x" * 20_000}) + "\n"
+    appended_line = json.dumps({"seq": 2}) + "\n"
+    path.write_text(initial_line, encoding="utf-8")
+
+    class _AppendAfterFirstLine:
+        def __init__(self, stream):
+            self._stream = stream
+            self.buffer = stream.buffer
+            self._appended = False
+
+        def __enter__(self):
+            self._stream.__enter__()
+            return self
+
+        def __exit__(self, *args):
+            return self._stream.__exit__(*args)
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            line = next(self._stream)
+            if not self._appended:
+                with open(path, "a", encoding="utf-8") as output:
+                    output.write(appended_line)
+                self._appended = True
+            return line
+
+    def open_and_append(_path):
+        return _AppendAfterFirstLine(open(path, "r", encoding="utf-8"))
+
+    with event_file_rows(path, text_opener=open_and_append) as (rows, window):
+        assert list(rows) == [(1, initial_line), (2, appended_line)]
+
+    assert window.physical_bytes_read == path.stat().st_size
+    assert window.decoded_bytes_read == path.stat().st_size
+
+
 def test_event_query_scan_cost_tracks_plain_full_and_seek_tail_reads(tmp_path):
     path = tmp_path / "monitor" / "binance" / "binance_01" / "events" / "current.ndjson"
     _write_ndjson(

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gzip
 import io
 import json
 import os
@@ -6256,6 +6257,75 @@ def test_live_performance_report_event_tail_lines_bounds_monitor_scan(tmp_path):
     assert report["performance"]["groups"][0]["count"] == 2
 
 
+def test_live_performance_report_scan_cost_aggregates_plain_and_gzip_reads(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    plain_path = events_dir / "current.ndjson"
+    gzip_path = events_dir / "2026-07-19T00-00-00.ndjson.gz"
+    _write_ndjson(
+        plain_path,
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                data={"elapsed_ms": 1000},
+            )
+        ],
+    )
+    gzip_rows = [
+        _monitor_row(
+            event_type="cycle.completed",
+            seq=2,
+            ts=2000,
+            data={"elapsed_ms": 2000},
+        )
+    ]
+    gzip_path.parent.mkdir(parents=True, exist_ok=True)
+    with gzip.open(gzip_path, "wt", encoding="utf-8") as stream:
+        for row in gzip_rows:
+            stream.write(json.dumps(row, sort_keys=True) + "\n")
+    with gzip.open(gzip_path, "rb") as stream:
+        gzip_decoded_bytes = len(stream.read())
+
+    report = build_live_performance_report(tmp_path / "monitor", include_rotated=True)
+    scan_cost = report["scan_cost"]
+
+    assert scan_cost["elapsed_ms"] >= 0
+    assert scan_cost["physical_bytes_read"] == (
+        plain_path.stat().st_size + gzip_path.stat().st_size
+    )
+    assert scan_cost["physical_bytes_known"] is True
+    assert scan_cost["decoded_bytes_read"] == plain_path.stat().st_size + gzip_decoded_bytes
+    assert scan_cost["decoded_bytes_known"] is True
+    assert scan_cost["files_read"] == 2
+    assert scan_cost["records_read"] == 2
+    assert scan_cost["read_methods"] == {"full_scan": 2}
+
+
+def test_live_performance_report_scan_cost_survives_summary_and_section_projection(tmp_path):
+    events_path = (
+        tmp_path / "monitor" / "binance" / "binance_01" / "events" / "current.ndjson"
+    )
+    _write_ndjson(
+        events_path,
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                data={"elapsed_ms": 1000},
+            )
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    summary = summarize_live_performance_report(report)
+    projected = project_live_performance_report_sections(report, ["performance"])
+
+    assert summary["scan_cost"] == report["scan_cost"]
+    assert projected["scan_cost"] == report["scan_cost"]
+
+
 def test_live_performance_report_cli_event_tail_lines(tmp_path, capsys):
     events_path = (
         tmp_path / "monitor" / "binance" / "binance_01" / "events" / "current.ndjson"
@@ -6566,6 +6636,13 @@ def test_live_performance_report_redacts_file_paths_and_oserror_messages(monkeyp
         "~/passivbot/monitor/binance/binance_01/events/current.ndjson"
     )
     assert report["issues"][0]["message"] == "Permission denied"
+    assert report["scan_cost"]["physical_bytes_read"] is None
+    assert report["scan_cost"]["physical_bytes_known"] is False
+    assert report["scan_cost"]["decoded_bytes_read"] is None
+    assert report["scan_cost"]["decoded_bytes_known"] is False
+    assert report["scan_cost"]["files_read"] == 0
+    assert report["scan_cost"]["records_read"] == 0
+    assert report["scan_cost"]["read_methods"] == {}
     assert "/root/passivbot" not in rendered
 
 


### PR DESCRIPTION
## Scope

Category: read-only tooling.

- Add bounded `scan_cost` metadata to `live-event-query` and
  `live-performance-report`.
- Report scan elapsed time, successfully read files/records, read methods, and
  physical versus decoded byte totals.
- Mark physical and decoded totals unknown when an exact consumed-stream
  position is unavailable or a read fails.
- Preserve post-read positions for growing plain monitor segments and separate
  compressed physical bytes from decoded gzip bytes.
- Record the completed PR #1335 VPS5 deploy and natural validation evidence
  in the logging-overhaul status and progress ledger.

## Motivation

The existing bounded VPS5 shapes took 9.34 seconds for `live-event-query` and
16.84 seconds for `live-performance-report`, while current metadata described
selection and tail skips but not the work actually performed. This slice adds
measurement only; it does not attempt an index or optimization.

## Behavior And Non-Goals

- No change to event-file discovery, selection, tail bounds, parsing, query
  matches, report metrics, redaction, or summary section semantics.
- No event producer, monitor persistence, exchange, planning, strategy, order,
  risk, cache, or process-control change.
- No index, reverse scan, early stop, or new enforcement threshold.

Expected VPS action: tracked-clean pull and bounded read-only query/report
smokes. No bot restart or process signal.

## Current-Base Integration

- Previous reviewed head: `42d80e91fdf8f061cb817f4b241d3230f9c46de1`.
- Current head: `ce5a24d72ea811c6b04a376bbd9fcd228ab4c9af`.
- Integrated canonical base: `02fb43f6398fc9edba64849cf2ed0bf0f7a6af09`.
- The target-relative `src/` and `tests/` patch is byte-for-byte identical
  before and after integration.
- The only conflict was `CHANGELOG.md`; the resolution preserves the
  `scan_cost`, Gate.io, and EMA Anchor entries.
- Status/progress documentation now records the completed PR #1335 deploy and
  recovery evidence.

## Validation

- `PYTHONPATH=src .../python -m pytest -q tests/test_live_event_query.py tests/test_live_performance_report.py tests/test_ai_docs.py tests/test_live_event_registry_docs.py` (`180 passed`)
- `PYTHONPATH=src .../python -m py_compile src/live/event_file_rows.py src/live/event_query.py src/live/performance_report.py`
- `PYTHONPATH=src .../python src/tools/check_ai_docs.py` (0 errors; existing size warning)
- `PYTHONPATH=src .../python src/tools/generate_live_event_registry.py --check` reports stale generated documentation identically on exact canonical `02fb43f6398fc9edba64849cf2ed0bf0f7a6af09`; this inherited drift is not introduced by the PR.
- `git diff --check refs/remotes/origin/master...HEAD`
- Touched-area silent-handling audit; matches were pre-existing optional/reporting defaults outside this change.

## Reviewer Focus

- Post-context stream-position accounting for growing plain files and gzip.
- Unknown-byte semantics after failed or unmeasurable reads.
- Preservation of existing query/report results and summary projection.
- Current-base integration and PR #1335 deployment evidence.

@codex review this PR.
