### PR TITLE
Fix GateIO startup with CCXT 4.5.66

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
-- Gate.io live startup now resolves the canonical `gateio` name to CCXT
-  4.5.66's `gate` REST and WebSocket client id while retaining `gateio` for
-  user-facing configuration, caches, and logs.
+- Gate.io live startup now selects CCXT 4.5.66's `gate` REST and WebSocket
+  clients at session construction while retaining canonical `gateio` identity
+  for user-facing configuration, market settings, caches, and logs.
 
 - Window-bounded live smoke collection now accepts a monitor with only
   `current.ndjson` when the bounded monitor manifest proves that segment covers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Gate.io live startup now resolves the canonical `gateio` name to CCXT
+  4.5.66's `gate` REST and WebSocket client id while retaining `gateio` for
+  user-facing configuration, caches, and logs.
+
 - Window-bounded live smoke collection now accepts a monitor with only
   `current.ndjson` when the bounded monitor manifest proves that segment covers
   the requested window start; missing or invalid coverage evidence still fails

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -851,7 +851,7 @@ class CandlestickManager:
         # Base timeframe for storage/fetching is always 1m; higher TFs are per-call
         self._ccxt_timeframe = "1m"
         # Determine exchange id and adjust defaults per exchange quirks
-        self._ex_id = getattr(self.exchange, "id", self.exchange_name) or self.exchange_name
+        self._ex_id = self.exchange_name or getattr(self.exchange, "id", "")
         self._ccxt_limit_default = 1000
         self._ccxt_page_overlap_candles = 0
         self._record_payload_gaps_as_known = False

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -851,7 +851,12 @@ class CandlestickManager:
         # Base timeframe for storage/fetching is always 1m; higher TFs are per-call
         self._ccxt_timeframe = "1m"
         # Determine exchange id and adjust defaults per exchange quirks
-        self._ex_id = self.exchange_name or getattr(self.exchange, "id", "")
+        client_id = getattr(self.exchange, "id", self.exchange_name) or self.exchange_name
+        self._ex_id = (
+            "gateio"
+            if str(client_id).lower() == "gate" and self.exchange_name == "gateio"
+            else client_id
+        )
         self._ccxt_limit_default = 1000
         self._ccxt_page_overlap_candles = 0
         self._record_payload_gaps_as_known = False

--- a/src/custom_endpoint_overrides.py
+++ b/src/custom_endpoint_overrides.py
@@ -168,7 +168,7 @@ class CustomEndpointConfig:
         self._source_path = source_path
         self._defaults = _ensure_exchange_shape(defaults)
         self._exchanges = {
-            key.lower(): _ensure_exchange_shape(value) for key, value in exchanges.items()
+            key.lower(): _ensure_explicit_exchange_shape(value) for key, value in exchanges.items()
         }
 
     @property
@@ -187,6 +187,22 @@ class CustomEndpointConfig:
             return None
         key = exchange_id.lower()
         merged = _deep_merge_dicts(self._defaults, self._exchanges.get(key))
+        resolved = _build_resolved(exchange_id=key, payload=merged)
+        return None if resolved.is_noop() else resolved
+
+    def get_override_with_aliases(
+        self, exchange_id: str, aliases: Iterable[str]
+    ) -> Optional[ResolvedEndpointOverride]:
+        """Resolve defaults, then aliases, then the canonical exchange id."""
+        if not exchange_id:
+            return None
+        key = exchange_id.lower()
+        merged = dict(self._defaults)
+        for alias in aliases:
+            alias_key = str(alias or "").lower()
+            if alias_key and alias_key != key:
+                merged = _deep_merge_dicts(merged, self._exchanges.get(alias_key))
+        merged = _deep_merge_dicts(merged, self._exchanges.get(key))
         resolved = _build_resolved(exchange_id=key, payload=merged)
         return None if resolved.is_noop() else resolved
 
@@ -279,6 +295,25 @@ def _ensure_exchange_shape(data: Optional[Mapping[str, object]]) -> Dict[str, ob
     payload["disable_ws"] = bool(payload.get("disable_ws", False))
     payload["rest"] = dict(rest)
     return dict(payload)
+
+
+def _ensure_explicit_exchange_shape(data: Mapping[str, object]) -> Dict[str, object]:
+    """Validate an exchange override without materializing unspecified defaults."""
+    normalized = _ensure_exchange_shape(data)
+    explicit: Dict[str, object] = {}
+    if "disable_ws" in data:
+        explicit["disable_ws"] = normalized["disable_ws"]
+    if "rest" in data:
+        raw_rest = data["rest"]
+        assert isinstance(raw_rest, Mapping)
+        normalized_rest = normalized["rest"]
+        explicit_rest = {
+            key: normalized_rest[key]
+            for key in ("rewrite_domains", "url_overrides", "extra_headers")
+            if key in raw_rest
+        }
+        explicit["rest"] = explicit_rest
+    return explicit
 
 
 def _deep_merge_dicts(
@@ -379,6 +414,14 @@ def resolve_custom_endpoint_override(exchange_id: str) -> Optional[ResolvedEndpo
     return config.get_override(exchange_id) if config else None
 
 
+def resolve_custom_endpoint_override_with_aliases(
+    exchange_id: str, aliases: Iterable[str]
+) -> Optional[ResolvedEndpointOverride]:
+    """Resolve an exchange override with lower-precedence library id aliases."""
+    config = get_cached_custom_endpoint_config()
+    return config.get_override_with_aliases(exchange_id, aliases) if config else None
+
+
 def get_custom_endpoint_source() -> Optional[Path]:
     """Return the filesystem path the current overrides were loaded from."""
     return _CONFIG_SOURCE_PATH
@@ -448,4 +491,5 @@ __all__ = [
     "get_custom_endpoint_source",
     "load_custom_endpoint_config",
     "resolve_custom_endpoint_override",
+    "resolve_custom_endpoint_override_with_aliases",
 ]

--- a/src/exchanges/gateio.py
+++ b/src/exchanges/gateio.py
@@ -20,7 +20,14 @@ class GateIOBot(CCXTBot):
 
     def create_ccxt_sessions(self):
         """GateIO: Add broker header to CCXT config."""
-        super().create_ccxt_sessions()
+        # CCXT 4.5.66 exposes Gate.io clients under ``gate``. Keep Passivbot's
+        # exchange identity canonical everywhere outside client construction.
+        canonical_ccxt_id = self.exchange_ccxt_id
+        try:
+            self.exchange_ccxt_id = "gate"
+            super().create_ccxt_sessions()
+        finally:
+            self.exchange_ccxt_id = canonical_ccxt_id
         # Add broker header to both clients
         headers = {"X-Gate-Channel-Id": self.broker_code} if self.broker_code else {}
         for client in [self.cca, self.ccp]:

--- a/src/exchanges/gateio.py
+++ b/src/exchanges/gateio.py
@@ -1,9 +1,12 @@
 from exchanges.ccxt_bot import CCXTBot
 from passivbot import logging
 
-from utils import ts_to_date, utc_ms
+from utils import to_ccxt_client_id, ts_to_date, utc_ms
 from config.access import require_live_value
-from custom_endpoint_overrides import get_custom_endpoint_source, resolve_custom_endpoint_override
+from custom_endpoint_overrides import (
+    get_custom_endpoint_source,
+    resolve_custom_endpoint_override_with_aliases,
+)
 
 
 class GateIOBot(CCXTBot):
@@ -21,21 +24,22 @@ class GateIOBot(CCXTBot):
 
     def create_ccxt_sessions(self):
         """GateIO: Add broker header to CCXT config."""
-        if self.endpoint_override is None:
-            self.endpoint_override = resolve_custom_endpoint_override("gate")
-            if self.endpoint_override is not None:
-                self.ws_enabled = not self.endpoint_override.disable_ws
+        endpoint_override = resolve_custom_endpoint_override_with_aliases("gateio", ("gate",))
+        if endpoint_override != self.endpoint_override:
+            self.endpoint_override = endpoint_override
+            self.ws_enabled = endpoint_override is None or not endpoint_override.disable_ws
+            if endpoint_override is not None:
                 logging.info(
-                    "Custom endpoint override active for gate "
+                    "Custom endpoint override active for gateio/gate "
                     "(disable_ws=%s, source=%s)",
-                    self.endpoint_override.disable_ws,
+                    endpoint_override.disable_ws,
                     get_custom_endpoint_source() or "auto-discovered",
                 )
         # CCXT 4.5.66 exposes Gate.io clients under ``gate``. Keep Passivbot's
         # exchange identity canonical everywhere outside client construction.
         canonical_ccxt_id = self.exchange_ccxt_id
         try:
-            self.exchange_ccxt_id = "gate"
+            self.exchange_ccxt_id = to_ccxt_client_id(canonical_ccxt_id)
             super().create_ccxt_sessions()
         finally:
             self.exchange_ccxt_id = canonical_ccxt_id

--- a/src/exchanges/gateio.py
+++ b/src/exchanges/gateio.py
@@ -3,6 +3,7 @@ from passivbot import logging
 
 from utils import ts_to_date, utc_ms
 from config.access import require_live_value
+from custom_endpoint_overrides import get_custom_endpoint_source, resolve_custom_endpoint_override
 
 
 class GateIOBot(CCXTBot):
@@ -20,6 +21,16 @@ class GateIOBot(CCXTBot):
 
     def create_ccxt_sessions(self):
         """GateIO: Add broker header to CCXT config."""
+        if self.endpoint_override is None:
+            self.endpoint_override = resolve_custom_endpoint_override("gate")
+            if self.endpoint_override is not None:
+                self.ws_enabled = not self.endpoint_override.disable_ws
+                logging.info(
+                    "Custom endpoint override active for gate "
+                    "(disable_ws=%s, source=%s)",
+                    self.endpoint_override.disable_ws,
+                    get_custom_endpoint_source() or "auto-discovered",
+                )
         # CCXT 4.5.66 exposes Gate.io clients under ``gate``. Keep Passivbot's
         # exchange identity canonical everywhere outside client construction.
         canonical_ccxt_id = self.exchange_ccxt_id

--- a/src/tools/probe_ticker_capabilities.py
+++ b/src/tools/probe_ticker_capabilities.py
@@ -9,6 +9,7 @@ from typing import Any
 import ccxt.async_support as ccxt_async
 
 from procedures import load_user_info
+from utils import to_ccxt_client_id
 
 
 PRICE_FIELDS = ("last", "bid", "ask")
@@ -40,9 +41,13 @@ def build_ccxt_config(user_info: dict[str, Any]) -> dict[str, Any]:
 
 
 def create_exchange(exchange_id: str, user_info: dict[str, Any] | None = None):
-    exchange_class = getattr(ccxt_async, exchange_id, None)
+    client_id = to_ccxt_client_id(exchange_id)
+    exchange_class = getattr(ccxt_async, client_id, None)
     if exchange_class is None:
-        raise ValueError(f"exchange {exchange_id!r} not found in ccxt.async_support")
+        raise ValueError(
+            f"exchange {exchange_id!r} (CCXT client id {client_id!r}) "
+            "not found in ccxt.async_support"
+        )
     user_info = user_info or {}
     options = dict(user_info.get("options", {}) if isinstance(user_info.get("options"), dict) else {})
     options["defaultType"] = "swap"
@@ -51,7 +56,7 @@ def create_exchange(exchange_id: str, user_info: dict[str, Any] | None = None):
     session = exchange_class(config)
     session.options.update(options)
     session.options["defaultType"] = "swap"
-    if exchange_id == "hyperliquid":
+    if client_id == "hyperliquid":
         session.options.setdefault(
             "fetchMarkets",
             {"types": ["swap", "hip3"], "hip3": {"dex": ["xyz"]}},

--- a/src/utils.py
+++ b/src/utils.py
@@ -552,7 +552,6 @@ def to_ccxt_exchange_id(exchange: str) -> str:
 
     Examples:
     - "binance" -> "binanceusdm"
-    - "gateio"  -> "gate"
     - "kucoin"  -> "kucoinfutures"
     - "kraken"  -> "krakenfutures"
 
@@ -563,10 +562,9 @@ def to_ccxt_exchange_id(exchange: str) -> str:
     ex = (exchange or "").lower()
     valid = set(getattr(ccxt, "exchanges", []))
 
-    # Explicit mappings for canonical names whose CCXT ids differ.
-    explicit_ids = {"binance": "binanceusdm", "gateio": "gate"}
-    if ex in explicit_ids:
-        return explicit_ids[ex]
+    # Explicit mapping for known special case
+    if ex == "binance":
+        return "binanceusdm"
 
     # If already a futures/perp id, keep as-is
     if ex.endswith("usdm") or ex.endswith("futures"):
@@ -587,16 +585,12 @@ def to_standard_exchange_name(exchange: str) -> str:
 
     Examples:
     - "binanceusdm" -> "binance"
-    - "gate" -> "gateio"
     - "kucoinfutures" -> "kucoin"
     - "krakenfutures" -> "kraken"
 
     If the exchange doesn't have a known suffix, returns it unchanged.
     """
     ex = (exchange or "").lower()
-
-    if ex == "gate":
-        return "gateio"
 
     # Remove known futures suffixes
     for suffix in ("usdm", "futures"):

--- a/src/utils.py
+++ b/src/utils.py
@@ -552,6 +552,7 @@ def to_ccxt_exchange_id(exchange: str) -> str:
 
     Examples:
     - "binance" -> "binanceusdm"
+    - "gateio"  -> "gate"
     - "kucoin"  -> "kucoinfutures"
     - "kraken"  -> "krakenfutures"
 
@@ -562,9 +563,10 @@ def to_ccxt_exchange_id(exchange: str) -> str:
     ex = (exchange or "").lower()
     valid = set(getattr(ccxt, "exchanges", []))
 
-    # Explicit mapping for known special case
-    if ex == "binance":
-        return "binanceusdm"
+    # Explicit mappings for canonical names whose CCXT ids differ.
+    explicit_ids = {"binance": "binanceusdm", "gateio": "gate"}
+    if ex in explicit_ids:
+        return explicit_ids[ex]
 
     # If already a futures/perp id, keep as-is
     if ex.endswith("usdm") or ex.endswith("futures"):
@@ -585,12 +587,16 @@ def to_standard_exchange_name(exchange: str) -> str:
 
     Examples:
     - "binanceusdm" -> "binance"
+    - "gate" -> "gateio"
     - "kucoinfutures" -> "kucoin"
     - "krakenfutures" -> "kraken"
 
     If the exchange doesn't have a known suffix, returns it unchanged.
     """
     ex = (exchange or "").lower()
+
+    if ex == "gate":
+        return "gateio"
 
     # Remove known futures suffixes
     for suffix in ("usdm", "futures"):

--- a/src/utils.py
+++ b/src/utils.py
@@ -579,6 +579,12 @@ def to_ccxt_exchange_id(exchange: str) -> str:
     return ex
 
 
+def to_ccxt_client_id(exchange: str) -> str:
+    """Return the CCXT class id used only when constructing a client session."""
+    exchange_id = to_ccxt_exchange_id(exchange)
+    return "gate" if exchange_id == "gateio" else exchange_id
+
+
 def to_standard_exchange_name(exchange: str) -> str:
     """
     Convert a ccxt exchange id to the canonical short form used in configs, caches, and logs.

--- a/src/utils.py
+++ b/src/utils.py
@@ -498,9 +498,9 @@ async def load_markets(
     Note: Uses the exchange name as-is (e.g., "binance" not "binanceusdm") for
     consistency with other cache paths (pnls, ohlcv, fill_events).
     """
-    # Prefer cc.id when a ccxt instance is supplied, otherwise use the provided exchange string.
-    # Denormalize to use canonical form for cache paths (e.g., "binance" not "binanceusdm")
-    ex = to_standard_exchange_name(getattr(cc, "id", None) or exchange or "")
+    # The explicit exchange name is the canonical cache identity. A supplied
+    # client's library id may differ (for example Gate.io is ``gate`` in CCXT).
+    ex = to_standard_exchange_name(exchange or getattr(cc, "id", None) or "")
     markets_path = os.path.join("caches", ex, "markets.json")
 
     # Try cache first

--- a/tests/test_custom_endpoints.py
+++ b/tests/test_custom_endpoints.py
@@ -61,6 +61,40 @@ def test_load_custom_endpoint_config_parses_binance_override(tmp_path):
     assert config.get_override("unknown") is None
 
 
+def test_alias_override_merges_between_defaults_and_canonical():
+    config = CustomEndpointConfig(
+        source_path=None,
+        defaults={
+            "disable_ws": False,
+            "rest": {"extra_headers": {"X-Default": "1", "X-Precedence": "default"}},
+        },
+        exchanges={
+            "gate": {
+                "disable_ws": True,
+                "rest": {
+                    "extra_headers": {"X-Alias": "1", "X-Precedence": "alias"},
+                    "url_overrides": {"public": "https://gate-alias.example"},
+                },
+            },
+            "gateio": {
+                "rest": {"extra_headers": {"X-Precedence": "canonical"}},
+            },
+        },
+    )
+
+    override = config.get_override_with_aliases("gateio", ("gate",))
+
+    assert override is not None
+    assert override.exchange_id == "gateio"
+    assert override.disable_ws is True
+    assert override.rest_url_overrides["public"] == "https://gate-alias.example"
+    assert override.rest_extra_headers == {
+        "X-Default": "1",
+        "X-Alias": "1",
+        "X-Precedence": "canonical",
+    }
+
+
 def test_apply_rest_overrides_to_ccxt_updates_urls_and_headers():
     override = ResolvedEndpointOverride(
         exchange_id="binanceusdm",

--- a/tests/test_exchange_name_normalization.py
+++ b/tests/test_exchange_name_normalization.py
@@ -1,8 +1,11 @@
+from pathlib import Path
 from types import SimpleNamespace
 
 import ccxt.async_support as ccxt_async
 import ccxt.pro as ccxt_pro
+import pytest
 
+import exchanges.gateio as gateio_module
 import utils
 from exchanges.ccxt_bot import CCXTBot
 from exchanges.gateio import GateIOBot
@@ -21,6 +24,8 @@ def test_gateio_session_boundary_resolves_current_rest_and_pro_clients(monkeypat
     bot = GateIOBot.__new__(GateIOBot)
     bot.exchange_ccxt_id = "gateio"
     bot.broker_code = None
+    bot.endpoint_override = None
+    bot.ws_enabled = True
 
     bot.create_ccxt_sessions()
 
@@ -30,6 +35,76 @@ def test_gateio_session_boundary_resolves_current_rest_and_pro_clients(monkeypat
     assert getattr(ccxt_pro, resolved_ids[0]).__name__ == "gate"
     assert utils.to_ccxt_exchange_id("gateio") == "gateio"
     assert utils.to_standard_exchange_name("gateio") == "gateio"
+
+
+def test_gateio_session_boundary_accepts_gate_endpoint_override(monkeypatch):
+    alias_override = SimpleNamespace(disable_ws=True)
+    constructed = []
+
+    monkeypatch.setattr(
+        gateio_module,
+        "resolve_custom_endpoint_override",
+        lambda exchange_id: alias_override if exchange_id == "gate" else None,
+    )
+    monkeypatch.setattr(gateio_module, "get_custom_endpoint_source", lambda: None)
+
+    def create_sessions(bot):
+        constructed.append((bot.exchange_ccxt_id, bot.endpoint_override, bot.ws_enabled))
+        bot.cca = SimpleNamespace(headers={})
+        bot.ccp = None
+
+    monkeypatch.setattr(CCXTBot, "create_ccxt_sessions", create_sessions)
+    bot = GateIOBot.__new__(GateIOBot)
+    bot.exchange_ccxt_id = "gateio"
+    bot.broker_code = None
+    bot.endpoint_override = None
+    bot.ws_enabled = True
+
+    bot.create_ccxt_sessions()
+
+    assert constructed == [("gate", alias_override, False)]
+    assert bot.exchange_ccxt_id == "gateio"
+
+
+def test_gateio_session_boundary_prefers_canonical_endpoint_override(monkeypatch):
+    canonical_override = SimpleNamespace(disable_ws=False)
+
+    def fail_alias_lookup(_exchange_id):
+        raise AssertionError("gate alias must not replace a canonical override")
+
+    monkeypatch.setattr(gateio_module, "resolve_custom_endpoint_override", fail_alias_lookup)
+
+    def create_sessions(bot):
+        assert bot.endpoint_override is canonical_override
+        bot.cca = SimpleNamespace(headers={})
+        bot.ccp = SimpleNamespace(headers={})
+
+    monkeypatch.setattr(CCXTBot, "create_ccxt_sessions", create_sessions)
+    bot = GateIOBot.__new__(GateIOBot)
+    bot.exchange_ccxt_id = "gateio"
+    bot.broker_code = None
+    bot.endpoint_override = canonical_override
+    bot.ws_enabled = True
+
+    bot.create_ccxt_sessions()
+
+    assert bot.exchange_ccxt_id == "gateio"
+
+
+@pytest.mark.asyncio
+async def test_gateio_market_cache_uses_explicit_canonical_identity(tmp_path, monkeypatch):
+    class GateClient:
+        id = "gate"
+
+        async def load_markets(self, _reload):
+            return {"BTC/USDT:USDT": {"swap": True, "base": "BTC"}}
+
+    monkeypatch.chdir(tmp_path)
+
+    await utils.load_markets("gateio", max_age_ms=0, verbose=False, cc=GateClient())
+
+    assert Path("caches/gateio/markets.json").is_file()
+    assert not Path("caches/gate/markets.json").exists()
 
 
 def test_gateio_hlcv_identity_keeps_cache_and_fee_overrides():

--- a/tests/test_exchange_name_normalization.py
+++ b/tests/test_exchange_name_normalization.py
@@ -7,6 +7,7 @@ import pytest
 
 import exchanges.gateio as gateio_module
 import utils
+from candlestick_manager import CandlestickManager, ONE_MIN_MS
 from exchanges.ccxt_bot import CCXTBot
 from exchanges.gateio import GateIOBot
 from hlcv_preparation import HLCVManager
@@ -33,6 +34,7 @@ def test_gateio_session_boundary_resolves_current_rest_and_pro_clients(monkeypat
     assert bot.exchange_ccxt_id == "gateio"
     assert getattr(ccxt_async, resolved_ids[0]).__name__ == "gate"
     assert getattr(ccxt_pro, resolved_ids[0]).__name__ == "gate"
+    assert utils.to_ccxt_client_id("gateio") == "gate"
     assert utils.to_ccxt_exchange_id("gateio") == "gateio"
     assert utils.to_standard_exchange_name("gateio") == "gateio"
 
@@ -43,8 +45,10 @@ def test_gateio_session_boundary_accepts_gate_endpoint_override(monkeypatch):
 
     monkeypatch.setattr(
         gateio_module,
-        "resolve_custom_endpoint_override",
-        lambda exchange_id: alias_override if exchange_id == "gate" else None,
+        "resolve_custom_endpoint_override_with_aliases",
+        lambda exchange_id, aliases: (
+            alias_override if exchange_id == "gateio" and aliases == ("gate",) else None
+        ),
     )
     monkeypatch.setattr(gateio_module, "get_custom_endpoint_source", lambda: None)
 
@@ -69,10 +73,11 @@ def test_gateio_session_boundary_accepts_gate_endpoint_override(monkeypatch):
 def test_gateio_session_boundary_prefers_canonical_endpoint_override(monkeypatch):
     canonical_override = SimpleNamespace(disable_ws=False)
 
-    def fail_alias_lookup(_exchange_id):
-        raise AssertionError("gate alias must not replace a canonical override")
-
-    monkeypatch.setattr(gateio_module, "resolve_custom_endpoint_override", fail_alias_lookup)
+    monkeypatch.setattr(
+        gateio_module,
+        "resolve_custom_endpoint_override_with_aliases",
+        lambda _exchange_id, _aliases: canonical_override,
+    )
 
     def create_sessions(bot):
         assert bot.endpoint_override is canonical_override
@@ -89,6 +94,23 @@ def test_gateio_session_boundary_prefers_canonical_endpoint_override(monkeypatch
     bot.create_ccxt_sessions()
 
     assert bot.exchange_ccxt_id == "gateio"
+
+
+def test_gateio_candle_manager_uses_canonical_identity(tmp_path):
+    class GateClient:
+        id = "gate"
+
+    manager = CandlestickManager(
+        exchange=GateClient(),
+        exchange_name="gateio",
+        cache_dir=str(tmp_path / "caches"),
+    )
+    rows = [[ONE_MIN_MS, 100.0, 101.0, 99.0, 100.0, 1_000.0]]
+
+    normalized = manager._normalize_ccxt_ohlcv(rows)
+
+    assert manager._ex_id == "gateio"
+    assert float(normalized[0]["bv"]) == pytest.approx(10.0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_exchange_name_normalization.py
+++ b/tests/test_exchange_name_normalization.py
@@ -1,13 +1,53 @@
+from types import SimpleNamespace
+
 import ccxt.async_support as ccxt_async
 import ccxt.pro as ccxt_pro
 
 import utils
+from exchanges.ccxt_bot import CCXTBot
+from exchanges.gateio import GateIOBot
+from hlcv_preparation import HLCVManager
 
 
-def test_gateio_ccxt_id_resolves_current_rest_and_pro_clients():
-    ccxt_id = utils.to_ccxt_exchange_id("gateio")
+def test_gateio_session_boundary_resolves_current_rest_and_pro_clients(monkeypatch):
+    resolved_ids = []
 
-    assert ccxt_id == "gate"
-    assert getattr(ccxt_async, ccxt_id).__name__ == "gate"
-    assert getattr(ccxt_pro, ccxt_id).__name__ == "gate"
-    assert utils.to_standard_exchange_name(ccxt_id) == "gateio"
+    def create_sessions(bot):
+        resolved_ids.append(bot.exchange_ccxt_id)
+        bot.cca = SimpleNamespace(headers={})
+        bot.ccp = SimpleNamespace(headers={})
+
+    monkeypatch.setattr(CCXTBot, "create_ccxt_sessions", create_sessions)
+    bot = GateIOBot.__new__(GateIOBot)
+    bot.exchange_ccxt_id = "gateio"
+    bot.broker_code = None
+
+    bot.create_ccxt_sessions()
+
+    assert resolved_ids == ["gate"]
+    assert bot.exchange_ccxt_id == "gateio"
+    assert getattr(ccxt_async, resolved_ids[0]).__name__ == "gate"
+    assert getattr(ccxt_pro, resolved_ids[0]).__name__ == "gate"
+    assert utils.to_ccxt_exchange_id("gateio") == "gateio"
+    assert utils.to_standard_exchange_name("gateio") == "gateio"
+
+
+def test_gateio_hlcv_identity_keeps_cache_and_fee_overrides():
+    manager = HLCVManager("gateio", start_date="2026-01-01", end_date="2026-01-02")
+    manager.markets = {
+        "BTC/USDT:USDT": {
+            "base": "BTC",
+            "maker": 0.001,
+            "taker": 0.001,
+            "contractSize": 1.0,
+            "limits": {"cost": {"min": 1.0}, "amount": {"min": 0.001}},
+            "precision": {"price": 0.1, "amount": 0.001},
+        }
+    }
+
+    settings = manager.get_market_specific_settings("BTC")
+
+    assert manager.exchange == "gateio"
+    assert manager.cache_filepaths["markets"] == "caches/gateio/markets.json"
+    assert settings["maker_fee"] == 0.0002
+    assert settings["taker_fee"] == 0.0005

--- a/tests/test_exchange_name_normalization.py
+++ b/tests/test_exchange_name_normalization.py
@@ -1,0 +1,13 @@
+import ccxt.async_support as ccxt_async
+import ccxt.pro as ccxt_pro
+
+import utils
+
+
+def test_gateio_ccxt_id_resolves_current_rest_and_pro_clients():
+    ccxt_id = utils.to_ccxt_exchange_id("gateio")
+
+    assert ccxt_id == "gate"
+    assert getattr(ccxt_async, ccxt_id).__name__ == "gate"
+    assert getattr(ccxt_pro, ccxt_id).__name__ == "gate"
+    assert utils.to_standard_exchange_name(ccxt_id) == "gateio"

--- a/tests/test_ticker_probe_tool.py
+++ b/tests/test_ticker_probe_tool.py
@@ -240,6 +240,23 @@ def test_create_exchange_sets_default_type_swap_before_load_markets(monkeypatch)
     assert session.options["defaultType"] == "swap"
 
 
+def test_create_exchange_resolves_gateio_client_id(monkeypatch):
+    class GateSession:
+        def __init__(self, config):
+            self.config = config
+            self.options = {}
+
+    monkeypatch.setattr(
+        "tools.probe_ticker_capabilities.ccxt_async.gate",
+        GateSession,
+    )
+
+    session = create_exchange("gateio")
+
+    assert isinstance(session, GateSession)
+    assert session.options["defaultType"] == "swap"
+
+
 @pytest.mark.asyncio
 async def test_probe_exchange_ticker_endpoints_records_all_endpoint_shapes():
     class FakeExchange:


### PR DESCRIPTION
@codex review

## Scope

Runtime compatibility hotfix for the reviewed CCXT 4.5.66 upgrade. Select CCXT's `gate` REST/Pro classes only at client-construction boundaries; Passivbot retains canonical `gateio` identity for configuration, caches, HLCV, fees, and migration paths.

## Incident evidence

After canonical `77b97ab8c7b7c4e6ba70025c3ca53e828aa0a321` was deployed to VPS5, the guarded five-pane restart completed, but GateIO exited during startup with `AttributeError: module ccxt.async_support has no attribute gateio; Did you mean: gate?`. The other four exact bots remained running. No production source patch or broad process action was applied.

## Review follow-up

- Removed the initial global name mapping after Hermes identified HLCV fee and cache/migration regressions.
- Scoped `gate` to REST/Pro and ticker-probe client construction while restoring canonical `gateio` in `finally`.
- Made the explicit exchange argument authoritative for market-cache identity, preventing the CCXT client's `gate` id from creating `caches/gate`.
- Merged custom endpoint precedence as `defaults < gate < gateio`, including `disable_ws`, URLs, and headers.
- Narrowly canonicalized CandlestickManager only for the confirmed `client.id='gate'` plus `exchange_name='gateio'` pair, preserving all other client-id behavior.
- Corrected the intermediate candle-identity CI regression and added the exact lock-watchdog regression to the focused validation.

## Non-goals

- no exchange request or order behavior change
- no credential, strategy, risk, HSL, or Rust change
- no compatibility shim for unpinned CCXT versions

## Validation

- 228 focused Python tests passed across GateIO normalization, CCXT order contracts/hooks, utility maps, custom endpoints, ticker-probe tooling, candle behavior, and the exact lock-watchdog regression under installed CCXT 4.5.66
- Python compilation for all changed Python modules and tests
- `git diff --check`
- exact-head GitHub Python 3.12 and Rust CI passed
- exact-head Hermes approval and built-in Codex review with no findings

## Expected VPS action

Pull the reviewed merge, verify exact repository/dependency/Rust contracts, then relaunch only the stopped GateIO pane and run bounded immediate plus settled smoke. Preserve the four healthy bot processes and `misc:0.0`.

## Residual risk

The regressions construct or stub CCXT clients without contacting a network. Authenticated/live GateIO requests remain intentionally untested; live validation is limited to the observed startup boundary after merge.
