### PR TITLE
Fix EMA Anchor monitor snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable user-facing changes will be documented in this file.
 
 - EMA Anchor live monitor snapshots now mark trailing diagnostics as not
   applicable instead of requesting unrelated trailing-martingale parameters
-  and repeatedly failing snapshot publication.
+  and repeatedly failing snapshot publication. The trailing diagnostics tool
+  ignores metadata-only entries when inferring a snapshot symbol.
 
 - Gate.io live startup now selects CCXT 4.5.66's `gate` REST and WebSocket
   clients at session construction while retaining canonical `gateio` identity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ All notable user-facing changes will be documented in this file.
 - EMA Anchor live monitor snapshots now mark trailing diagnostics as not
   applicable instead of requesting unrelated trailing-martingale parameters
   and repeatedly failing snapshot publication. The trailing diagnostics tool
-  ignores metadata-only entries when inferring a snapshot symbol.
+  rejects snapshots that explicitly mark those diagnostics unsupported unless
+  the operator selects explicit wizard mode.
 
 - Gate.io live startup now selects CCXT 4.5.66's `gate` REST and WebSocket
   clients at session construction while retaining canonical `gateio` identity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- EMA Anchor live monitor snapshots now mark trailing diagnostics as not
+  applicable instead of requesting unrelated trailing-martingale parameters
+  and repeatedly failing snapshot publication.
+
 - Window-bounded live smoke collection now accepts a monitor with only
   `current.ndjson` when the bounded monitor manifest proves that segment covers
   the requested window start; missing or invalid coverage evidence still fails

--- a/src/passivbot_monitor.py
+++ b/src/passivbot_monitor.py
@@ -1489,7 +1489,22 @@ def _build_monitor_trailing_section(
         balance_strategy = balance_raw
     config = getattr(self, "config", {})
     live_cfg = config.get("live", {}) if isinstance(config, dict) else {}
-    strategy_kind = str(live_cfg.get("strategy_kind") or "").strip().lower()
+    strategy_kind = str(
+        live_cfg.get("strategy_kind") or "trailing_martingale"
+    ).strip().lower()
+    if strategy_kind not in {"trailing_martingale", "trailing_grid_v7"}:
+        reason = (
+            "strategy_has_no_trailing_diagnostics"
+            if strategy_kind == "ema_anchor"
+            else "strategy_not_supported_by_trailing_monitor"
+        )
+        return {
+            "_meta": {
+                "diagnostics_supported": False,
+                "strategy_kind": strategy_kind,
+                "reason": reason,
+            }
+        }
     out: dict[str, dict[str, Any]] = {}
     for symbol, market_entry in sorted(market.items()):
         if not isinstance(market_entry, dict):

--- a/src/trailing_diagnostics_tool.py
+++ b/src/trailing_diagnostics_tool.py
@@ -238,6 +238,16 @@ def _resolve_symbol_alias(query: str, snapshot: dict[str, Any]) -> tuple[Optiona
     return matches[0], None
 
 
+def _unsupported_trailing_diagnostics(snapshot: dict[str, Any]) -> Optional[dict[str, Any]]:
+    trailing = snapshot_payload(snapshot).get("trailing", {})
+    if not isinstance(trailing, dict):
+        return None
+    metadata = trailing.get("_meta", {})
+    if isinstance(metadata, dict) and metadata.get("diagnostics_supported") is False:
+        return metadata
+    return None
+
+
 def _load_snapshot_from_path(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
@@ -409,7 +419,11 @@ class TrailingDiagnosticsState:
         return changed
 
     def can_reload_from_snapshot(self) -> bool:
-        return self.config is not None and self.snapshot is not None
+        return (
+            self.config is not None
+            and self.snapshot is not None
+            and _unsupported_trailing_diagnostics(self.snapshot) is None
+        )
 
     def reload_symbol_pside(self, symbol: str, pside: str) -> None:
         if not self.can_reload_from_snapshot():
@@ -452,12 +466,8 @@ def create_state_from_sources(
     if snapshot is not None:
         snap = snapshot_payload(snapshot)
         trailing = snap.get("trailing", {})
-        trailing_meta = trailing.get("_meta", {}) if isinstance(trailing, dict) else {}
-        if (
-            not wizard
-            and isinstance(trailing_meta, dict)
-            and trailing_meta.get("diagnostics_supported") is False
-        ):
+        trailing_meta = _unsupported_trailing_diagnostics(snapshot)
+        if not wizard and trailing_meta is not None:
             strategy_kind = str(trailing_meta.get("strategy_kind") or "unknown")
             reason = str(trailing_meta.get("reason") or "not_supported")
             raise ValueError(
@@ -738,8 +748,8 @@ def execute_command(state: TrailingDiagnosticsState, command: str) -> bool:
         if not args:
             state.status_lines = ["symbol requires a coin or full symbol"]
             return False
-        if state.snapshot is None or state.config is None:
-            state.status_lines = ["symbol switching requires snapshot + config source"]
+        if not state.can_reload_from_snapshot():
+            state.status_lines = ["symbol switching requires a supported snapshot + config source"]
             return False
         resolved, error = _resolve_symbol_alias(" ".join(args), state.snapshot)
         if error:
@@ -753,7 +763,7 @@ def execute_command(state: TrailingDiagnosticsState, command: str) -> bool:
             state.status_lines = ["side requires 'long' or 'short'"]
             return False
         new_pside = args[0].lower()
-        if state.snapshot is None or state.config is None:
+        if not state.can_reload_from_snapshot():
             state.inputs["pside"] = new_pside
             state.pside = new_pside
             state.status_lines = [f"Updated side to {new_pside} in manual mode."]

--- a/src/trailing_diagnostics_tool.py
+++ b/src/trailing_diagnostics_tool.py
@@ -458,8 +458,13 @@ def create_state_from_sources(
         else:
             snap = snapshot_payload(snapshot)
             trailing = snap.get("trailing", {})
-            if isinstance(trailing, dict) and trailing:
-                symbol = sorted(trailing)[0]
+            trailing_symbols = (
+                sorted(key for key in trailing if not str(key).startswith("_"))
+                if isinstance(trailing, dict)
+                else []
+            )
+            if trailing_symbols:
+                symbol = trailing_symbols[0]
             else:
                 market = snap.get("market", {})
                 if isinstance(market, dict) and market:

--- a/src/trailing_diagnostics_tool.py
+++ b/src/trailing_diagnostics_tool.py
@@ -450,14 +450,26 @@ def create_state_from_sources(
     )
     snapshot = _load_snapshot_from_path(resolved_snapshot) if resolved_snapshot and resolved_snapshot.exists() else None
     if snapshot is not None:
+        snap = snapshot_payload(snapshot)
+        trailing = snap.get("trailing", {})
+        trailing_meta = trailing.get("_meta", {}) if isinstance(trailing, dict) else {}
+        if (
+            not wizard
+            and isinstance(trailing_meta, dict)
+            and trailing_meta.get("diagnostics_supported") is False
+        ):
+            strategy_kind = str(trailing_meta.get("strategy_kind") or "unknown")
+            reason = str(trailing_meta.get("reason") or "not_supported")
+            raise ValueError(
+                "snapshot trailing diagnostics are not supported for strategy "
+                f"'{strategy_kind}' ({reason}); use --wizard for explicit manual inputs"
+            )
         if symbol:
             resolved_symbol, error = _resolve_symbol_alias(symbol, snapshot)
             if error:
                 raise ValueError(error)
             symbol = resolved_symbol
         else:
-            snap = snapshot_payload(snapshot)
-            trailing = snap.get("trailing", {})
             trailing_symbols = (
                 sorted(key for key in trailing if not str(key).startswith("_"))
                 if isinstance(trailing, dict)

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -5989,6 +5989,148 @@ async def test_build_monitor_snapshot_includes_market_forager_unstuck_and_recent
     assert snapshot["recent"]["order_cancellations"][0]["pb_order_type"] == "close_unstuck_long"
 
 
+def test_monitor_trailing_section_marks_ema_anchor_diagnostics_not_applicable():
+    import passivbot as pb_mod
+
+    class FakeBot:
+        _build_monitor_trailing_section = pb_mod.Passivbot._build_monitor_trailing_section
+
+        def __init__(self):
+            self.config = {"live": {"strategy_kind": "ema_anchor"}}
+            self.positions = {
+                "BTC/USDT:USDT": {
+                    "long": {"size": 0.1, "price": 100.0},
+                    "short": {"size": 0.0, "price": 0.0},
+                },
+                "ETH/USDT:USDT": {
+                    "long": {"size": 0.0, "price": 0.0},
+                    "short": {"size": -0.2, "price": 50.0},
+                },
+            }
+
+        def _strategy_params_to_rust_dict(self, pside, symbol=None):
+            raise AssertionError(
+                f"EMA Anchor {pside} monitor path must not request trailing strategy params"
+            )
+
+        def bp(self, pside, key, symbol=None):
+            raise AssertionError(
+                f"EMA Anchor {pside} monitor path must not request legacy key {key}"
+            )
+
+    payload = FakeBot()._build_monitor_trailing_section(
+        balance_raw=100.0,
+        market={
+            "BTC/USDT:USDT": {
+                "last_price": 101.0,
+                "trailing": {"long": {"max_since_open": 102.0}},
+            },
+            "ETH/USDT:USDT": {
+                "last_price": 49.0,
+                "trailing": {"short": {"min_since_open": 48.0}},
+            },
+        },
+    )
+
+    assert payload == {
+        "_meta": {
+            "diagnostics_supported": False,
+            "strategy_kind": "ema_anchor",
+            "reason": "strategy_has_no_trailing_diagnostics",
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_ema_anchor_monitor_snapshot_flush_skips_legacy_trailing_params():
+    import passivbot as pb_mod
+
+    class FakePublisher:
+        def __init__(self):
+            self.snapshot = None
+
+        def write_snapshot(self, snapshot, *, ts=None, force=False):
+            self.snapshot = snapshot
+            return True
+
+    class FakeBot:
+        _build_monitor_snapshot = pb_mod.Passivbot._build_monitor_snapshot
+        _build_monitor_trailing_section = pb_mod.Passivbot._build_monitor_trailing_section
+        _monitor_flush_snapshot = pb_mod.Passivbot._monitor_flush_snapshot
+
+        def __init__(self):
+            self.config = {"live": {"strategy_kind": "ema_anchor"}}
+            self.exchange = "fake"
+            self.user = "ema_anchor_monitor_test"
+            self.quote = "USDT"
+            self.start_time_ms = 1
+            self.open_orders = {}
+            self.PB_modes = {"long": {}, "short": {}}
+            self._runtime_forced_modes = {"long": {}, "short": {}}
+            self.positions = {
+                "BTC/USDT:USDT": {
+                    "long": {"size": 0.1, "price": 100.0},
+                    "short": {"size": 0.0, "price": 0.0},
+                },
+                "ETH/USDT:USDT": {
+                    "long": {"size": 0.0, "price": 0.0},
+                    "short": {"size": -0.2, "price": 50.0},
+                },
+            }
+            self.monitor_publisher = FakePublisher()
+
+        def get_raw_balance(self):
+            return 100.0
+
+        def get_hysteresis_snapped_balance(self):
+            return 100.0
+
+        def _build_monitor_market_section(self):
+            return {
+                "BTC/USDT:USDT": {"last_price": 101.0},
+                "ETH/USDT:USDT": {"last_price": 49.0},
+            }
+
+        def _build_monitor_positions_section(self, *, balance_raw, market):
+            return self.positions
+
+        def _build_health_summary_payload(self, *, now_ms):
+            return {}
+
+        def _monitor_hsl_payload(self, pside):
+            return {}
+
+        async def _build_monitor_forager_section(self):
+            return {}
+
+        def _build_monitor_unstuck_section(self):
+            return {}
+
+        def _build_monitor_recent_section(self):
+            return {}
+
+        def _strategy_params_to_rust_dict(self, pside, symbol=None):
+            raise AssertionError(
+                f"EMA Anchor {pside} snapshot must not request trailing strategy params"
+            )
+
+        def bp(self, pside, key, symbol=None):
+            raise AssertionError(
+                f"EMA Anchor {pside} snapshot must not request legacy key {key}"
+            )
+
+    bot = FakeBot()
+
+    assert await bot._monitor_flush_snapshot(force=True, ts=300_000) is True
+    assert bot.monitor_publisher.snapshot["trailing"] == {
+        "_meta": {
+            "diagnostics_supported": False,
+            "strategy_kind": "ema_anchor",
+            "reason": "strategy_has_no_trailing_diagnostics",
+        }
+    }
+
+
 def test_monitor_trailing_section_includes_trailing_grid_v7_diagnostics():
     import passivbot as pb_mod
 

--- a/tests/test_trailing_diagnostics.py
+++ b/tests/test_trailing_diagnostics.py
@@ -14,6 +14,7 @@ from trailing_diagnostics import (
 from trailing_diagnostics_tool import (
     TrailingDiagnosticsState,
     WIZARD_CORE_KEYS,
+    create_state_from_sources,
     execute_command,
     render_screen,
 )
@@ -101,6 +102,50 @@ def _sample_snapshot():
             },
         }
     }
+
+
+def test_snapshot_symbol_inference_ignores_trailing_metadata(tmp_path, monkeypatch):
+    snapshot = _sample_snapshot()
+    snapshot["payload"]["trailing"] = {
+        "_meta": {
+            "diagnostics_supported": False,
+            "strategy_kind": "ema_anchor",
+            "reason": "strategy_has_no_trailing_diagnostics",
+        }
+    }
+    snapshot_path = tmp_path / "snapshot.json"
+    snapshot_path.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        "trailing_diagnostics_tool.load_prepared_config",
+        lambda *args, **kwargs: _sample_config(),
+    )
+    monkeypatch.setattr(
+        "trailing_diagnostics_tool._load_snapshot_from_path", lambda path: snapshot
+    )
+    captured = {}
+
+    def fake_build_inputs(config, loaded_snapshot, *, symbol, pside):
+        captured.update(symbol=symbol, pside=pside)
+        return {"symbol": symbol, "pside": pside}
+
+    monkeypatch.setattr(
+        "trailing_diagnostics_tool.build_trailing_inputs_from_snapshot",
+        fake_build_inputs,
+    )
+
+    state = create_state_from_sources(
+        config_path="config.json",
+        monitor_root=None,
+        exchange=None,
+        user=None,
+        snapshot_path=str(snapshot_path),
+        symbol=None,
+        pside="long",
+        wizard=False,
+    )
+
+    assert captured == {"symbol": "BTC/USDT:USDT", "pside": "long"}
+    assert state.symbol == "BTC/USDT:USDT"
 
 
 def _hype_trailing_martingale_close_inputs():

--- a/tests/test_trailing_diagnostics.py
+++ b/tests/test_trailing_diagnostics.py
@@ -137,6 +137,46 @@ def test_ema_anchor_snapshot_requires_explicit_trailing_wizard(tmp_path):
         )
 
 
+def test_ema_anchor_wizard_state_cannot_reload_unsupported_snapshot(
+    tmp_path, monkeypatch
+):
+    snapshot = _sample_snapshot()
+    snapshot["payload"]["trailing"] = {
+        "_meta": {
+            "diagnostics_supported": False,
+            "strategy_kind": "ema_anchor",
+            "reason": "strategy_has_no_trailing_diagnostics",
+        }
+    }
+    snapshot_path = tmp_path / "snapshot.json"
+    snapshot_path.write_text(json.dumps(snapshot), encoding="utf-8")
+    config_path = Path(__file__).parents[1] / "configs" / "examples" / "ema_anchor.json"
+    monkeypatch.setattr(
+        "trailing_diagnostics_tool.prompt_manual_wizard", lambda defaults: defaults
+    )
+
+    state = create_state_from_sources(
+        config_path=str(config_path),
+        monitor_root=None,
+        exchange=None,
+        user=None,
+        snapshot_path=str(snapshot_path),
+        symbol=None,
+        pside="long",
+        wizard=True,
+    )
+
+    assert state.can_reload_from_snapshot() is False
+    assert execute_command(state, "side short") is False
+    assert state.pside == "short"
+    assert state.status_lines == ["Updated side to short in manual mode."]
+    assert execute_command(state, "symbol BTC") is False
+    assert state.symbol == "BTC/USDT:USDT"
+    assert state.status_lines == [
+        "symbol switching requires a supported snapshot + config source"
+    ]
+
+
 def _hype_trailing_martingale_close_inputs():
     return {
         "symbol": "HYPE/USDT:USDT",

--- a/tests/test_trailing_diagnostics.py
+++ b/tests/test_trailing_diagnostics.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import json
 import os
 import subprocess
 import sys
@@ -104,7 +105,7 @@ def _sample_snapshot():
     }
 
 
-def test_snapshot_symbol_inference_ignores_trailing_metadata(tmp_path, monkeypatch):
+def test_ema_anchor_snapshot_requires_explicit_trailing_wizard(tmp_path):
     snapshot = _sample_snapshot()
     snapshot["payload"]["trailing"] = {
         "_meta": {
@@ -114,38 +115,26 @@ def test_snapshot_symbol_inference_ignores_trailing_metadata(tmp_path, monkeypat
         }
     }
     snapshot_path = tmp_path / "snapshot.json"
-    snapshot_path.write_text("{}", encoding="utf-8")
-    monkeypatch.setattr(
-        "trailing_diagnostics_tool.load_prepared_config",
-        lambda *args, **kwargs: _sample_config(),
-    )
-    monkeypatch.setattr(
-        "trailing_diagnostics_tool._load_snapshot_from_path", lambda path: snapshot
-    )
-    captured = {}
+    snapshot_path.write_text(json.dumps(snapshot), encoding="utf-8")
+    config_path = Path(__file__).parents[1] / "configs" / "examples" / "ema_anchor.json"
 
-    def fake_build_inputs(config, loaded_snapshot, *, symbol, pside):
-        captured.update(symbol=symbol, pside=pside)
-        return {"symbol": symbol, "pside": pside}
-
-    monkeypatch.setattr(
-        "trailing_diagnostics_tool.build_trailing_inputs_from_snapshot",
-        fake_build_inputs,
-    )
-
-    state = create_state_from_sources(
-        config_path="config.json",
-        monitor_root=None,
-        exchange=None,
-        user=None,
-        snapshot_path=str(snapshot_path),
-        symbol=None,
-        pside="long",
-        wizard=False,
-    )
-
-    assert captured == {"symbol": "BTC/USDT:USDT", "pside": "long"}
-    assert state.symbol == "BTC/USDT:USDT"
+    with pytest.raises(
+        ValueError,
+        match=(
+            "snapshot trailing diagnostics are not supported for strategy "
+            "'ema_anchor'.*use --wizard"
+        ),
+    ):
+        create_state_from_sources(
+            config_path=str(config_path),
+            monitor_root=None,
+            exchange=None,
+            user=None,
+            snapshot_path=str(snapshot_path),
+            symbol=None,
+            pside="long",
+            wizard=False,
+        )
 
 
 def _hype_trailing_martingale_close_inputs():


### PR DESCRIPTION
## Summary

- route live monitor trailing diagnostics by strategy kind
- mark EMA Anchor trailing diagnostics as not applicable instead of reading unrelated trailing-martingale fields
- cover long/short EMA Anchor state through direct monitor and snapshot-flush regressions

## Root cause

`_build_monitor_trailing_section()` treated every strategy other than `trailing_grid_v7` as a legacy trailing strategy. With `live.strategy_kind = "ema_anchor"`, snapshot publication therefore requested absent fields such as `entry_grid_double_down_factor` and failed repeatedly.

## Validation

- `python -m pytest tests/test_passivbot_monitor.py -q` (94 passed)
- `python -m pytest tests/test_passivbot_balance_split.py -k trailing_status -q` (3 passed)
- `python -m pytest tests/test_monitor_tui.py -q` (17 passed)
- focused EMA Anchor, snapshot, trailing-martingale, and trailing-grid-v7 monitor selection (3 passed)
- `PYTHONPATH=src python -m compileall -q src/passivbot_monitor.py tests/test_passivbot_monitor.py`
- `PYTHONPATH=src python src/tools/check_ai_docs.py` (0 errors; existing word-count warning)
- `PYTHONPATH=src python src/tools/generate_live_event_registry.py --check`
- `python -m pytest tests/test_ai_docs.py tests/test_live_event_registry_docs.py -q` (4 passed)

The full Python suite was attempted but collection stopped because the shared local virtualenv's compiled Rust extension predates current `origin/master`. No full-suite test reached this change; CI will rebuild the extension in a clean environment.
