### PR TITLE
Report live smoke scan cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `live-smoke-report` now includes bounded monitor `scan_cost` metadata in
+  full, summary, and brief output, matching the elapsed time, successfully
+  read files and records, read methods, and physical-versus-decoded byte
+  semantics exposed by the event query and performance report. This is
+  diagnostic-only and does not change smoke verdicts, event selection,
+  parsing, logs, process inspection, exchange access, or live behavior.
+
 - `live-event-query` and `live-performance-report` now include bounded
   `scan_cost` metadata for elapsed artifact-scan time, successfully read files
   and records, read methods, and physical versus decoded byte totals. Explicit

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,7 +22,7 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Pending PR, `Report live smoke scan cost`; branch:
+- PR #1337, `Report live smoke scan cost`; branch:
   `codex/live-smoke-scan-cost`, based on canonical
   `e0927ed86f0b10ed8187d8e6a523017baefb98b3`.
 - Scope: expose the same bounded elapsed-time, byte, file, record, and

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,21 +22,47 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR #1333, `Report live artifact scan cost`; branch:
-  `codex/live-artifact-scan-cost`, based on canonical
-  `02fb43f6398fc9edba64849cf2ed0bf0f7a6af09`.
-- Scope: expose bounded elapsed-time, byte, file, record, and read-method cost
-  metadata for `live-event-query` and `live-performance-report` artifact scans.
+- Pending PR, `Report live smoke scan cost`; branch:
+  `codex/live-smoke-scan-cost`, based on canonical
+  `e0927ed86f0b10ed8187d8e6a523017baefb98b3`.
+- Scope: expose the same bounded elapsed-time, byte, file, record, and
+  read-method cost metadata for the monitor scan used by
+  `live-smoke-report`, including its full, summary, and brief projections.
 - Behavior boundary: read-only local tooling only. The slice changes no event
-  producer, file selection, query result, monitor persistence, exchange access,
-  planning, strategy, order, risk, or process-control behavior.
+  producer, file selection, parsed result, smoke verdict, monitor persistence,
+  exchange access, logs, process inspection/control, planning, strategy,
+  order, or risk behavior.
+- Baseline: a bounded five-minute VPS5 brief smoke scanned six current event
+  files and 7,515 records in 4.29 seconds wall time but could not report exact
+  bytes or read methods. The active slice closes only that diagnostic gap.
 - Review gate: exact-current-head Hermes approval plus green Python/Rust CI.
   Built-in Codex automatic review is additional and every finding must be
   verified and resolved.
 - Expected VPS action: tracked-clean pull plus bounded read-only report smokes;
   no bot restart or process signal.
 
-## Deployed Baseline (PR #1335)
+## Deployed Baseline (PR #1333)
+
+- PR #1333 merged exact reviewed head
+  `ce5a24d72ea811c6b04a376bbd9fcd228ab4c9af` as canonical
+  `e0927ed86f0b10ed8187d8e6a523017baefb98b3` after exact-head Hermes
+  approval, a green built-in Codex review, and green Python/Rust CI. VPS5
+  fast-forwarded tracked-clean from
+  `02fb43f6398fc9edba64849cf2ed0bf0f7a6af09` without a Rust build; the
+  source fingerprint/stamp remained
+  `691bff9683deec9382a4e96ab6a107c14145f88edd6ae2f8e2380b8ba6824449`.
+- The bounded five-minute event query was `ok=true` and reported five files,
+  8,133 records, 13,926,420 known physical/decoded bytes, and 4,793.586 ms.
+  The matching performance report was `ok=true` with zero errors/warnings and
+  reported six files, 8,661 records, 14,740,828 known physical/decoded bytes,
+  and 4,781.454 ms. Both used only `seek_tail` reads.
+- No bot was restarted or signalled. Bot PIDs
+  `1066081/1066091/1066084/1066093/1066087`, pane parents `%358`-`%362`, and
+  protected `misc:0.0` `%8`/PID `434835` remained unchanged. Final process
+  states were all `Rl+`; the checkout remained tracked-clean. No direct
+  exchange call or event was manufactured.
+
+## Previous Deployed Baseline (PR #1335)
 
 - PR #1335 merged exact reviewed head
   `c4d5b8e55f6fd453fd707999ae74ec2dd127e55d` as canonical
@@ -1605,10 +1631,10 @@ PR #1288's bounded target-identity stability, and PR #1289's plan binding are
 merged, deployed, and naturally validated without process control. PR #1290's
 pane-parent relaunch classification and the restart preparation/orchestration
 slices through PR #1309 are also merged and deployed. Later slices through PR
-#1335 are merged and deployed at canonical
-`02fb43f6398fc9edba64849cf2ed0bf0f7a6af09`; their current evidence is recorded
-above. The active artifact-scan cost slice measures read-only query/report work
-without changing scan behavior.
+#1335, including subsequently merged PR #1333, are deployed at canonical
+`e0927ed86f0b10ed8187d8e6a523017baefb98b3`; their current evidence is recorded
+above. The active smoke-scan cost slice measures the remaining read-only smoke
+artifact work without changing scan or verdict behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,28 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1335)
+## Latest Canonical Deployment (PR #1333)
+
+- PR #1333 merged exact reviewed head
+  `ce5a24d72ea811c6b04a376bbd9fcd228ab4c9af` as canonical
+  `e0927ed86f0b10ed8187d8e6a523017baefb98b3` after exact-head Hermes and
+  built-in Codex reviews plus green Python/Rust CI. VPS5 fast-forwarded
+  tracked-clean from `02fb43f639` without a Rust build; the Rust source
+  fingerprint/stamp remained unchanged.
+- The bounded five-minute event query reported five files, 8,133 records,
+  13,926,420 known physical/decoded bytes, and 4,793.586 ms. The matching
+  performance report reported six files, 8,661 records, 14,740,828 known
+  physical/decoded bytes, and 4,781.454 ms with zero errors/warnings. Both
+  reports were `ok=true` and used only bounded `seek_tail` reads.
+- No bot restart or signal was required. Bot PIDs
+  `1066081/1066091/1066084/1066093/1066087`, pane parents `%358`-`%362`, and
+  protected `misc:0.0` `%8`/PID `434835` remained unchanged; all five bots
+  were `Rl+` and the checkout remained tracked-clean. A bounded smoke-report
+  baseline took 4.29 seconds but exposed no byte/read-method cost, motivating
+  the active diagnostic-only `codex/live-smoke-scan-cost` slice. No direct
+  exchange call or event was manufactured.
+
+## Previous Canonical Deployment (PR #1335)
 
 - PR #1335 merged exact reviewed head
   `c4d5b8e55f6fd453fd707999ae74ec2dd127e55d` as canonical

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -8669,6 +8669,12 @@ def _scan_events(
     event_files_before_limit = 0
     event_files_skipped_by_limit = 0
     event_file_limit_groups = 0
+    scan_physical_bytes_read = 0
+    scan_physical_bytes_known = True
+    scan_decoded_bytes_read = 0
+    scan_decoded_bytes_known = True
+    scan_files_read = 0
+    scan_read_methods: Counter[str] = Counter()
     startup_timing_records: dict[str, list[dict[str, Any]]] = defaultdict(list)
     startup_latest_started: dict[str, dict[str, Any]] = {}
     remote_call_failure_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
@@ -8715,6 +8721,7 @@ def _scan_events(
             _limit_recent_event_files_per_bot(files, max_event_file_count_per_bot)
         )
 
+    scan_started_at = time.perf_counter()
     for path in files:
         try:
             with event_file_rows(path, max_tail_lines=max_event_tail_lines) as (
@@ -9138,12 +9145,25 @@ def _scan_events(
                     )
                     if startup_timing is not None:
                         startup_timing_records[bot_key].append(startup_timing)
+            scan_files_read += 1
+            if row_window.physical_bytes_read is None:
+                scan_physical_bytes_known = False
+            else:
+                scan_physical_bytes_read += int(row_window.physical_bytes_read)
+            if row_window.decoded_bytes_read is None:
+                scan_decoded_bytes_known = False
+            else:
+                scan_decoded_bytes_read += int(row_window.decoded_bytes_read)
+            scan_read_methods[str(row_window.method)] += 1
         except OSError as exc:
+            scan_physical_bytes_known = False
+            scan_decoded_bytes_known = False
             issues.append(
                 _monitor_issue(path, None, "error", "read_failed", str(exc))
             )
             invalid_rows += 1
 
+    scan_elapsed_ms = round((time.perf_counter() - scan_started_at) * 1000, 3)
     recovered_problem_events = _problem_event_recovery_report(
         problem_records, time_sync_recoveries
     )
@@ -9189,6 +9209,20 @@ def _scan_events(
             "root": str(Path(root).expanduser()),
             "include_rotated": bool(include_rotated),
             "files_scanned": len(files),
+            "scan_cost": {
+                "elapsed_ms": scan_elapsed_ms,
+                "physical_bytes_read": (
+                    scan_physical_bytes_read if scan_physical_bytes_known else None
+                ),
+                "physical_bytes_known": scan_physical_bytes_known,
+                "decoded_bytes_read": (
+                    scan_decoded_bytes_read if scan_decoded_bytes_known else None
+                ),
+                "decoded_bytes_known": scan_decoded_bytes_known,
+                "files_read": scan_files_read,
+                "records_read": records_total,
+                "read_methods": dict(sorted(scan_read_methods.items())),
+            },
             "records_total": records_total,
             "live_events": live_events,
             "legacy_events": legacy_events,
@@ -9720,6 +9754,7 @@ def build_live_smoke_report(
             "root": event_report.get("root"),
             "include_rotated": event_report.get("include_rotated"),
             "files_scanned": event_report.get("files_scanned"),
+            "scan_cost": event_report.get("scan_cost"),
             "records_total": event_report.get("records_total"),
             "live_events": event_report.get("live_events"),
             "legacy_events": event_report.get("legacy_events"),
@@ -10459,6 +10494,7 @@ def summarize_live_smoke_report(
                 "legacy_events",
                 "error_count",
                 "warning_count",
+                "scan_cost",
                 "file_discovery",
             )
             if key in monitor
@@ -11632,6 +11668,7 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
                 "legacy_events",
                 "error_count",
                 "warning_count",
+                "scan_cost",
                 "file_discovery",
             )
             if key in monitor

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -148,6 +148,159 @@ def test_live_smoke_report_scans_monitor_segments_once(tmp_path, monkeypatch):
     assert report["event_window"]["events_considered"] == 1
 
 
+def test_live_smoke_report_scan_cost_tracks_plain_full_and_seek_tail_reads(tmp_path):
+    path = tmp_path / "monitor" / "binance" / "binance_01" / "events" / "current.ndjson"
+    _write_ndjson(
+        path,
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                data={"payload": "x" * 70_000},
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=2,
+                ts=2000,
+                data={"payload": "x" * 130_000},
+            ),
+            _monitor_row(event_type="cycle.completed", seq=3, ts=3000),
+        ],
+    )
+    expected_bytes = path.stat().st_size
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    scan_cost = report["monitor"]["scan_cost"]
+
+    assert scan_cost["elapsed_ms"] >= 0
+    assert scan_cost["physical_bytes_read"] == expected_bytes
+    assert scan_cost["physical_bytes_known"] is True
+    assert scan_cost["decoded_bytes_read"] == expected_bytes
+    assert scan_cost["decoded_bytes_known"] is True
+    assert scan_cost["files_read"] == 1
+    assert scan_cost["records_read"] == 3
+    assert scan_cost["read_methods"] == {"full_scan": 1}
+    assert summarize_live_smoke_report(report)["monitor"]["scan_cost"] == scan_cost
+    assert summarize_live_smoke_report_brief(report)["monitor"]["scan_cost"] == scan_cost
+
+    tail_report = build_live_smoke_report(
+        tmp_path / "monitor", logs_root=None, event_tail_lines=1
+    )
+    tail_scan_cost = tail_report["monitor"]["scan_cost"]
+
+    assert tail_scan_cost["physical_bytes_read"] < expected_bytes
+    assert tail_scan_cost["physical_bytes_known"] is True
+    assert tail_scan_cost["decoded_bytes_read"] == tail_scan_cost["physical_bytes_read"]
+    assert tail_scan_cost["decoded_bytes_known"] is True
+    assert tail_scan_cost["files_read"] == 1
+    assert tail_scan_cost["records_read"] == 1
+    assert tail_scan_cost["read_methods"] == {"seek_tail": 1}
+
+
+def test_live_smoke_report_scan_cost_distinguishes_gzip_physical_and_decoded_bytes(
+    tmp_path,
+):
+    path = (
+        tmp_path
+        / "monitor"
+        / "binance"
+        / "binance_01"
+        / "events"
+        / "2026-07-19T00-00-00.ndjson.gz"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with gzip.open(path, "wt", encoding="utf-8") as stream:
+        for row in (
+            _monitor_row(event_type="cycle.completed", seq=1, ts=1000),
+            _monitor_row(event_type="cycle.completed", seq=2, ts=2000),
+        ):
+            stream.write(json.dumps(row, sort_keys=True) + "\n")
+    with gzip.open(path, "rb") as stream:
+        expected_decoded_bytes = len(stream.read())
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        include_rotated=True,
+        event_tail_lines=1,
+    )
+    scan_cost = report["monitor"]["scan_cost"]
+
+    assert scan_cost["physical_bytes_read"] == path.stat().st_size
+    assert scan_cost["physical_bytes_known"] is True
+    assert scan_cost["decoded_bytes_read"] == expected_decoded_bytes
+    assert scan_cost["decoded_bytes_known"] is True
+    assert scan_cost["files_read"] == 1
+    assert scan_cost["records_read"] == 1
+    assert scan_cost["read_methods"] == {"sequential_gzip_tail": 1}
+
+
+def test_live_smoke_report_scan_cost_marks_unmeasurable_and_failed_reads_unknown(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "monitor" / "binance" / "binance_01" / "events" / "current.ndjson"
+    row = _monitor_row(event_type="cycle.completed", seq=1, ts=1000)
+    _write_ndjson(path, [row])
+
+    class UnmeasurableRows:
+        def __enter__(self):
+            return (
+                iter([(1, json.dumps(row, sort_keys=True) + "\n")]),
+                event_file_rows_module.EventRowWindow(),
+            )
+
+        def __exit__(self, *args):
+            return False
+
+    monkeypatch.setattr(
+        smoke_report_module,
+        "event_file_rows",
+        lambda *args, **kwargs: UnmeasurableRows(),
+    )
+    unmeasurable = build_live_smoke_report(tmp_path / "monitor", logs_root=None)[
+        "monitor"
+    ]["scan_cost"]
+
+    assert unmeasurable["physical_bytes_read"] is None
+    assert unmeasurable["physical_bytes_known"] is False
+    assert unmeasurable["decoded_bytes_read"] is None
+    assert unmeasurable["decoded_bytes_known"] is False
+    assert unmeasurable["files_read"] == 1
+    assert unmeasurable["records_read"] == 1
+    assert unmeasurable["read_methods"] == {"full_scan": 1}
+
+    class FailingRows:
+        def __enter__(self):
+            raise OSError(13, "Permission denied")
+
+        def __exit__(self, *args):
+            return False
+
+    monkeypatch.setattr(
+        smoke_report_module,
+        "event_file_rows",
+        lambda *args, **kwargs: FailingRows(),
+    )
+    failed = build_live_smoke_report(tmp_path / "monitor", logs_root=None)["monitor"]
+
+    assert failed["issues"][0]["code"] == "read_failed"
+    assert failed["scan_cost"]["elapsed_ms"] >= 0
+    assert {
+        key: value
+        for key, value in failed["scan_cost"].items()
+        if key != "elapsed_ms"
+    } == {
+        "physical_bytes_read": None,
+        "physical_bytes_known": False,
+        "decoded_bytes_read": None,
+        "decoded_bytes_known": False,
+        "files_read": 0,
+        "records_read": 0,
+        "read_methods": {},
+    }
+
+
 def test_live_smoke_report_event_tail_lines_bounds_monitor_scan(tmp_path):
     events_path = (
         tmp_path / "monitor" / "binance" / "binance_01" / "events" / "current.ndjson"


### PR DESCRIPTION
## Summary
- add bounded monitor scan-cost metadata to live-smoke-report full, summary, and brief output
- report elapsed time, successful files/records, read methods, and physical-versus-decoded bytes using the established event-query/performance-report contract
- record PR #1333 deployment evidence and the VPS5 smoke baseline that exposed this diagnostic gap

## Boundary
Read-only local tooling only. This changes no file selection, parsed event result, smoke verdict, event producer, persistence, log scan, process inspection/control, exchange access, planning, strategy, order, or risk behavior.

## Validation
- 176 focused Python tests passed
- py_compile passed
- git diff --check passed
- AI documentation check: 0 errors, one pre-existing size warning
- generated event registry is stale identically on exact canonical base e0927ed86f0b10ed8187d8e6a523017baefb98b3

## Deploy expectation
Tracked-clean VPS5 pull and bounded read-only report smokes only; no restart or process signal.

@codex review