### PR TITLE
Report incident time-window scan cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Incident bundles now include bounded `scan_cost` metadata for their
+  independent time-window event scan in the full report, manifest, and command
+  result. The metadata uses the same elapsed-time, successful file/record,
+  read-method, and physical-versus-decoded byte contract as the other live
+  artifact reports; event matching, truncation, archive contents, verdicts,
+  exchange access, and live behavior are unchanged.
+
 - `live-smoke-report` now includes bounded monitor `scan_cost` metadata in
   full, summary, and brief output, matching the elapsed time, successfully
   read files and records, read methods, and physical-versus-decoded byte

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,7 +22,7 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Pending PR, `Report incident time-window scan cost`; branch:
+- PR #1338, `Report incident time-window scan cost`; branch:
   `codex/live-incident-scan-cost`, based on canonical
   `848eb60c502b7af21dd7aa52f50f86aece552bd9`.
 - Scope: expose bounded elapsed-time, byte, successful-file, record, and

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -1,6 +1,6 @@
 # Live Logging Overhaul Current Status
 
-Updated: 2026-07-19.
+Updated: 2026-07-20.
 
 This is the compact operational source for the active logging-overhaul loop.
 Read it before the historical progress ledger. Update it whenever the active
@@ -22,26 +22,57 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR #1337, `Report live smoke scan cost`; branch:
-  `codex/live-smoke-scan-cost`, based on canonical
-  `e0927ed86f0b10ed8187d8e6a523017baefb98b3`.
-- Scope: expose the same bounded elapsed-time, byte, file, record, and
-  read-method cost metadata for the monitor scan used by
-  `live-smoke-report`, including its full, summary, and brief projections.
+- Pending PR, `Report incident time-window scan cost`; branch:
+  `codex/live-incident-scan-cost`, based on canonical
+  `848eb60c502b7af21dd7aa52f50f86aece552bd9`.
+- Scope: expose bounded elapsed-time, byte, successful-file, record, and
+  read-method cost metadata for the independent event scan used by incident
+  bundle time-window reports, including the full report, manifest summary, and
+  command result.
 - Behavior boundary: read-only local tooling only. The slice changes no event
-  producer, file selection, parsed result, smoke verdict, monitor persistence,
-  exchange access, logs, process inspection/control, planning, strategy,
-  order, or risk behavior.
-- Baseline: a bounded five-minute VPS5 brief smoke scanned six current event
-  files and 7,515 records in 4.29 seconds wall time but could not report exact
-  bytes or read methods. The active slice closes only that diagnostic gap.
+  producer, file selection, matching, truncation, bundle payload selection,
+  verdict, monitor persistence, exchange access, logs, process
+  inspection/control, planning, strategy, order, or risk behavior.
+- Baseline: incident time-window reports expose discovered/scanned files and
+  matched events but cannot identify actual records/bytes read, read methods,
+  or scan elapsed time. The active slice closes only that diagnostic gap using
+  the contract now shared by event query, performance report, and smoke report.
 - Review gate: exact-current-head Hermes approval plus green Python/Rust CI.
   Built-in Codex automatic review is additional and every finding must be
   verified and resolved.
-- Expected VPS action: tracked-clean pull plus bounded read-only report smokes;
-  no bot restart or process signal.
+- Expected VPS action: tracked-clean pull plus one bounded read-only incident
+  bundle smoke; no bot restart or process signal.
 
-## Deployed Baseline (PR #1333)
+## Deployed Baseline (PR #1329 After PR #1337)
+
+- PR #1337 merged exact reviewed head
+  `51a82c23230daf4aea5ec68784ef7168293b408e` as canonical
+  `7d463dca56e1b29840954876a25a3f4d0e5df961` after exact-head Hermes and
+  built-in Codex approval plus green Python/Rust CI. VPS5 fast-forwarded
+  tracked-clean from `e0927ed86f0b10ed8187d8e6a523017baefb98b3`
+  without a Rust build. A settled bounded smoke was `ok=true`, found all five
+  exact processes, and reported six `seek_tail` files, 10,388 records,
+  18,777,444 known physical/decoded bytes, and 5,751.099 ms through the new
+  smoke `scan_cost` projection.
+- External PR #1329 then merged exact mechanical-integration head
+  `6bd2eb0a0a49d21107a2c45ff9784e737d5c4d1c` as canonical
+  `848eb60c502b7af21dd7aa52f50f86aece552bd9`. The maintainer explicitly
+  approved its contributor CI; exact-head Hermes review and Python/Rust CI
+  were green. The target-relative result remained the previously reviewed
+  one-line aware-UTC timestamp fix. VPS5 fast-forwarded tracked-clean again
+  without a Rust build or restart because the changed Gate.io quarantine
+  timestamp path is startup-only and did not warrant disrupting running bots.
+- Immediate smokes retained natural KuCoin authoritative-state timeouts and
+  were not mislabeled green. The final settled five-minute smoke was `ok=true`
+  with zero hard failures, zero failed remote calls, all five exact processes,
+  and a tracked-clean repository at `848eb60c`; its monitor scan reported six
+  `seek_tail` files, 9,471 records, 17,038,544 known physical/decoded bytes,
+  and 4,021.646 ms. Throughout both pulls, bot PIDs
+  `1066081/1066091/1066084/1066093/1066087`, pane parents `%358`-`%362`, and
+  protected `misc:0.0` `%8`/PID `434835` remained unchanged. No direct
+  exchange call, event manufacture, restart, or process signal occurred.
+
+## Previous Deployed Baseline (PR #1333)
 
 - PR #1333 merged exact reviewed head
   `ce5a24d72ea811c6b04a376bbd9fcd228ab4c9af` as canonical
@@ -1630,11 +1661,12 @@ PR #1286's aggregate-only follow-up, PR #1287's exact tmux target preflight,
 PR #1288's bounded target-identity stability, and PR #1289's plan binding are
 merged, deployed, and naturally validated without process control. PR #1290's
 pane-parent relaunch classification and the restart preparation/orchestration
-slices through PR #1309 are also merged and deployed. Later slices through PR
-#1335, including subsequently merged PR #1333, are deployed at canonical
-`e0927ed86f0b10ed8187d8e6a523017baefb98b3`; their current evidence is recorded
-above. The active smoke-scan cost slice measures the remaining read-only smoke
-artifact work without changing scan or verdict behavior.
+slices through PR #1309 are also merged and deployed. Later logging slices
+through PR #1337, followed by adjacent PR #1329, are deployed at canonical
+`848eb60c502b7af21dd7aa52f50f86aece552bd9`; their current evidence is recorded
+above. The active incident time-window scan-cost slice measures the remaining
+read-only bundle artifact work without changing scan selection or verdict
+behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,38 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1333)
+## Latest Canonical Deployment (PR #1329 After PR #1337)
+
+- PR #1337 merged exact reviewed head
+  `51a82c23230daf4aea5ec68784ef7168293b408e` as canonical
+  `7d463dca56e1b29840954876a25a3f4d0e5df961` after exact-head Hermes and
+  built-in Codex approval plus green Python/Rust CI. VPS5 fast-forwarded
+  tracked-clean from `e0927ed86f` without a Rust build or process signal.
+- Its settled bounded five-minute smoke was `ok=true` with zero hard failures,
+  all five exact processes, and known scan-cost evidence: six `seek_tail`
+  files, 10,388 records, 18,777,444 physical/decoded bytes, and 5,751.099 ms.
+  The immediate sample retained a natural KuCoin timeout and correctly stayed
+  red until that event aged out.
+- External PR #1329 then merged exact mechanical-integration head
+  `6bd2eb0a0a49d21107a2c45ff9784e737d5c4d1c` as canonical
+  `848eb60c502b7af21dd7aa52f50f86aece552bd9`. The maintainer explicitly
+  approved contributor CI; Hermes and Python/Rust CI were green, and the
+  target-relative result remained the reviewed one-line aware-UTC timestamp
+  fix. VPS5 fast-forwarded tracked-clean without a Rust build or restart; the
+  startup-only maintenance-path change did not warrant disrupting running
+  bots.
+- Bot PIDs `1066081/1066091/1066084/1066093/1066087`, pane parents
+  `%358`-`%362`, and protected `misc:0.0` `%8`/PID `434835` remained unchanged.
+  A later natural KuCoin orders timeout kept the immediate post-pull sample
+  red. The final settled five-minute smoke was `ok=true` with zero hard
+  failures, zero failed remote calls, all five exact processes, a tracked-clean
+  repository at `848eb60c`, and six `seek_tail` files reading 9,471 records and
+  17,038,544 known physical/decoded bytes in 4,021.646 ms. No direct exchange
+  call, manufactured event, restart, or process signal occurred. The remaining
+  incident-bundle time-window scan lacks exact byte/read-method cost, motivating
+  the active `codex/live-incident-scan-cost` slice.
+
+## Previous Canonical Deployment (PR #1333)
 
 - PR #1333 merged exact reviewed head
   `ce5a24d72ea811c6b04a376bbd9fcd228ab4c9af` as canonical

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -206,6 +206,16 @@ def _build_time_window_report(
             "enabled": False,
             "filters": {},
             "files_scanned": 0,
+            "scan_cost": {
+                "elapsed_ms": 0.0,
+                "physical_bytes_read": 0,
+                "physical_bytes_known": True,
+                "decoded_bytes_read": 0,
+                "decoded_bytes_known": True,
+                "files_read": 0,
+                "records_read": 0,
+                "read_methods": {},
+            },
             "file_discovery": {},
             "matched_events": 0,
             "events_truncated": False,
@@ -240,6 +250,7 @@ def _build_time_window_report(
     issues: list[dict[str, Any]] = []
     events: list[dict[str, Any]] = []
     matched_events = 0
+    records_total = 0
     max_events = max(0, int(limit))
     max_event_tail_lines = max(0, int(event_tail_lines))
     max_event_file_count_per_bot = max(0, int(max_event_files_per_bot))
@@ -252,6 +263,12 @@ def _build_time_window_report(
     event_files_before_limit = 0
     event_files_skipped_by_limit = 0
     event_file_limit_groups = 0
+    scan_physical_bytes_read = 0
+    scan_physical_bytes_known = True
+    scan_decoded_bytes_read = 0
+    scan_decoded_bytes_known = True
+    scan_files_read = 0
+    scan_read_methods: Counter[str] = Counter()
     file_discovery: dict[str, Any] = {
         "candidate_files": 0,
         "event_segments": 0,
@@ -287,6 +304,7 @@ def _build_time_window_report(
             _limit_recent_event_files_per_bot(files, max_event_file_count_per_bot)
         )
 
+    scan_started_at = time.perf_counter()
     for path in files:
         try:
             with event_file_rows(path, max_tail_lines=max_event_tail_lines) as (
@@ -309,6 +327,7 @@ def _build_time_window_report(
                     line = raw_line.strip()
                     if not line:
                         continue
+                    records_total += 1
                     try:
                         row = json.loads(line)
                     except json.JSONDecodeError as exc:
@@ -352,7 +371,19 @@ def _build_time_window_report(
                                 include_data=include_data,
                             )
                         )
+            scan_files_read += 1
+            if row_window.physical_bytes_read is None:
+                scan_physical_bytes_known = False
+            else:
+                scan_physical_bytes_read += int(row_window.physical_bytes_read)
+            if row_window.decoded_bytes_read is None:
+                scan_decoded_bytes_known = False
+            else:
+                scan_decoded_bytes_read += int(row_window.decoded_bytes_read)
+            scan_read_methods[str(row_window.method)] += 1
         except OSError as exc:
+            scan_physical_bytes_known = False
+            scan_decoded_bytes_known = False
             issues.append(
                 {
                     "path": str(path),
@@ -362,10 +393,25 @@ def _build_time_window_report(
                     "message": str(exc),
                 }
             )
+    scan_elapsed_ms = round((time.perf_counter() - scan_started_at) * 1000, 3)
     report = {
         "enabled": True,
         "filters": filters,
         "files_scanned": len(files),
+        "scan_cost": {
+            "elapsed_ms": scan_elapsed_ms,
+            "physical_bytes_read": (
+                scan_physical_bytes_read if scan_physical_bytes_known else None
+            ),
+            "physical_bytes_known": scan_physical_bytes_known,
+            "decoded_bytes_read": (
+                scan_decoded_bytes_read if scan_decoded_bytes_known else None
+            ),
+            "decoded_bytes_known": scan_decoded_bytes_known,
+            "files_read": scan_files_read,
+            "records_read": records_total,
+            "read_methods": dict(sorted(scan_read_methods.items())),
+        },
         "file_discovery": file_discovery,
         "matched_events": matched_events,
         "events_truncated": matched_events > len(events),
@@ -861,6 +907,7 @@ def _time_window_result_summary(window_report: dict[str, Any]) -> dict[str, Any]
     return {
         "enabled": window_report["enabled"],
         "files_scanned": window_report["files_scanned"],
+        "scan_cost": window_report["scan_cost"],
         "file_discovery": window_report["file_discovery"],
         "matched_events": window_report["matched_events"],
         "events_truncated": window_report["events_truncated"],

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+import gzip
 import json
 import os
 import subprocess
 import tarfile
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
 
+import live.incident_bundle as incident_bundle_module
 import live.smoke_report as smoke_report_module
+from live.event_file_rows import EventRowWindow
 from live.incident_bundle import (
     _copy_event_segments,
     _redact_url_userinfo,
@@ -83,6 +87,234 @@ def _read_tar_json(tar, name: str):
     member = tar.extractfile(name)
     assert member is not None
     return json.loads(member.read().decode())
+
+
+def _assert_nonnegative_elapsed_scan_cost(scan_cost, expected):
+    assert set(scan_cost) == {
+        "elapsed_ms",
+        "physical_bytes_read",
+        "physical_bytes_known",
+        "decoded_bytes_read",
+        "decoded_bytes_known",
+        "files_read",
+        "records_read",
+        "read_methods",
+    }
+    assert isinstance(scan_cost["elapsed_ms"], float)
+    assert scan_cost["elapsed_ms"] >= 0.0
+    actual = {
+        key: value for key, value in scan_cost.items() if key != "elapsed_ms"
+    }
+    assert actual == expected
+
+
+def test_incident_bundle_time_window_scan_cost_full_read_counts_nonblank_rows(tmp_path):
+    events_path = (
+        tmp_path / "monitor" / "binance" / "binance_01" / "events" / "current.ndjson"
+    )
+    first = json.dumps(_monitor_row(event_type="cycle.completed", seq=1, ts=1000))
+    second = json.dumps(_monitor_row(event_type="cycle.completed", seq=2, ts=2000))
+    events_path.parent.mkdir(parents=True)
+    events_path.write_text(f"{first}\n\n{second}\n", encoding="utf-8")
+
+    report = incident_bundle_module._build_time_window_report(
+        tmp_path / "monitor",
+        since_ms=0,
+        until_ms=None,
+        include_rotated=False,
+        include_data=False,
+        limit=10,
+    )
+
+    _assert_nonnegative_elapsed_scan_cost(
+        report["scan_cost"],
+        {
+            "physical_bytes_read": events_path.stat().st_size,
+            "physical_bytes_known": True,
+            "decoded_bytes_read": events_path.stat().st_size,
+            "decoded_bytes_known": True,
+            "files_read": 1,
+            "records_read": 2,
+            "read_methods": {"full_scan": 1},
+        },
+    )
+    assert report["matched_events"] == 2
+
+
+def test_incident_bundle_time_window_scan_cost_seek_tail_counts_selected_rows(tmp_path):
+    events_path = (
+        tmp_path / "monitor" / "binance" / "binance_01" / "events" / "current.ndjson"
+    )
+    _write_ndjson(
+        events_path,
+        [
+            _monitor_row(event_type="cycle.completed", seq=1, ts=1000),
+            _monitor_row(event_type="cycle.completed", seq=2, ts=2000),
+            _monitor_row(event_type="cycle.completed", seq=3, ts=3000),
+        ],
+    )
+
+    report = incident_bundle_module._build_time_window_report(
+        tmp_path / "monitor",
+        since_ms=0,
+        until_ms=None,
+        include_rotated=False,
+        include_data=False,
+        event_tail_lines=1,
+        limit=10,
+    )
+
+    _assert_nonnegative_elapsed_scan_cost(
+        report["scan_cost"],
+        {
+            "physical_bytes_read": events_path.stat().st_size,
+            "physical_bytes_known": True,
+            "decoded_bytes_read": events_path.stat().st_size,
+            "decoded_bytes_known": True,
+            "files_read": 1,
+            "records_read": 1,
+            "read_methods": {"seek_tail": 1},
+        },
+    )
+    assert [event["seq"] for event in report["events"]] == [3]
+
+
+def test_incident_bundle_time_window_scan_cost_gzip_tracks_physical_and_decoded_bytes(
+    tmp_path,
+):
+    events_path = (
+        tmp_path
+        / "monitor"
+        / "binance"
+        / "binance_01"
+        / "events"
+        / "20260719.ndjson.gz"
+    )
+    rows = [
+        _monitor_row(
+            event_type="cycle.completed",
+            seq=index,
+            ts=index * 1000,
+            data={"padding": "x" * 1000},
+        )
+        for index in range(1, 5)
+    ]
+    decoded = "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows).encode()
+    events_path.parent.mkdir(parents=True)
+    with gzip.open(events_path, "wb") as stream:
+        stream.write(decoded)
+
+    report = incident_bundle_module._build_time_window_report(
+        tmp_path / "monitor",
+        since_ms=0,
+        until_ms=None,
+        include_rotated=True,
+        include_data=False,
+        limit=10,
+    )
+
+    _assert_nonnegative_elapsed_scan_cost(
+        report["scan_cost"],
+        {
+            "physical_bytes_read": events_path.stat().st_size,
+            "physical_bytes_known": True,
+            "decoded_bytes_read": len(decoded),
+            "decoded_bytes_known": True,
+            "files_read": 1,
+            "records_read": 4,
+            "read_methods": {"full_scan": 1},
+        },
+    )
+    assert report["scan_cost"]["physical_bytes_read"] < report["scan_cost"][
+        "decoded_bytes_read"
+    ]
+
+
+def test_incident_bundle_time_window_scan_cost_marks_failed_or_unmeasurable_reads_unknown(
+    tmp_path,
+    monkeypatch,
+):
+    for exchange in ("binance", "okx"):
+        _write_ndjson(
+            tmp_path
+            / "monitor"
+            / exchange
+            / f"{exchange}_01"
+            / "events"
+            / "current.ndjson",
+            [_monitor_row(event_type="cycle.completed", seq=1, ts=1000)],
+        )
+
+    @contextmanager
+    def fake_event_file_rows(path, *, max_tail_lines=0):
+        del max_tail_lines
+        if "okx" in path.parts:
+            raise OSError("unavailable for test")
+        yield [
+            (1, json.dumps(_monitor_row(event_type="cycle.completed", seq=1, ts=1000)))
+        ], EventRowWindow(method="unmeasurable")
+
+    monkeypatch.setattr(
+        incident_bundle_module,
+        "event_file_rows",
+        fake_event_file_rows,
+    )
+
+    report = incident_bundle_module._build_time_window_report(
+        tmp_path / "monitor",
+        since_ms=0,
+        until_ms=None,
+        include_rotated=False,
+        include_data=False,
+        limit=10,
+    )
+
+    _assert_nonnegative_elapsed_scan_cost(
+        report["scan_cost"],
+        {
+            "physical_bytes_read": None,
+            "physical_bytes_known": False,
+            "decoded_bytes_read": None,
+            "decoded_bytes_known": False,
+            "files_read": 1,
+            "records_read": 1,
+            "read_methods": {"unmeasurable": 1},
+        },
+    )
+    assert report["files_scanned"] == 2
+    assert report["issues"] == [
+        {
+            "path": str(
+                tmp_path / "monitor" / "okx" / "okx_01" / "events" / "current.ndjson"
+            ),
+            "line": None,
+            "severity": "error",
+            "code": "read_failed",
+            "message": "unavailable for test",
+        }
+    ]
+
+
+def test_incident_bundle_time_window_scan_cost_is_zero_and_known_when_disabled(tmp_path):
+    report = incident_bundle_module._build_time_window_report(
+        tmp_path / "monitor",
+        since_ms=None,
+        until_ms=None,
+        include_rotated=False,
+        include_data=False,
+        limit=10,
+    )
+
+    assert report["scan_cost"] == {
+        "elapsed_ms": 0.0,
+        "physical_bytes_read": 0,
+        "physical_bytes_known": True,
+        "decoded_bytes_read": 0,
+        "decoded_bytes_known": True,
+        "files_read": 0,
+        "records_read": 0,
+        "read_methods": {},
+    }
 
 
 def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_path):
@@ -802,6 +1034,8 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
     }
     assert manifest["time_window"] == report["time_window"]
     assert manifest["time_window"]["matched_events"] == window_report["matched_events"]
+    assert report["time_window"]["scan_cost"] == window_report["scan_cost"]
+    assert manifest["time_window"]["scan_cost"] == window_report["scan_cost"]
     assert manifest["performance_report"] == report["performance_report"]
     assert performance_report["event_window"] == report["performance_report"][
         "event_window"


### PR DESCRIPTION
## Summary
- expose bounded `scan_cost` metadata for incident-bundle time-window event scans
- project the exact scan-cost object through the full report, manifest summary, and command result
- preserve event discovery, matching, truncation, bundle contents, verdicts, exchange access, and live behavior

## Validation
- `/Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_live_incident_bundle.py tests/test_live_event_query.py tests/test_live_smoke_report.py tests/test_ai_docs.py tests/test_live_event_registry_docs.py`
- `/Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/incident_bundle.py tests/test_live_incident_bundle.py`
- `src/tools/check_ai_docs.py` (0 errors; existing size warning)
- `git diff --check`
- generated live-event registry check remains stale identically on exact base `848eb60c`; generator and generated file are unchanged in this PR

## Deployment evidence
- PR #1337 deployed tracked-clean to VPS5 without build, restart, or signal; settled smoke was green and exposed exact monitor scan cost
- adjacent PR #1329 then deployed tracked-clean at `848eb60c` without build, restart, or signal
- final five-minute smoke: `ok=true`, zero hard failures, zero failed remote calls, all five configured processes, repository clean; `misc:0.0` preserved

## Expected VPS action
- tracked-clean pull plus one bounded read-only incident-bundle smoke
- no bot restart or process signal

@codex review