### PR TITLE
Report live smoke log scan cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `live-smoke-report` log scans now include bounded `scan_cost` metadata in
+  full, summary, and brief output. The metadata reports elapsed time,
+  successfully read files and selected tail lines, read methods, and known
+  physical-versus-decoded bytes without changing log discovery, sequential
+  reads, matching, redaction, window filtering, smoke verdicts, exchange
+  access, or live behavior.
+
 - Incident bundles now include bounded `scan_cost` metadata for their
   independent time-window event scan in the full report, manifest, and command
   result. The metadata uses the same elapsed-time, successful file/record,

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,28 +22,51 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR #1338, `Report incident time-window scan cost`; branch:
-  `codex/live-incident-scan-cost`, based on canonical
-  `848eb60c502b7af21dd7aa52f50f86aece552bd9`.
-- Scope: expose bounded elapsed-time, byte, successful-file, record, and
-  read-method cost metadata for the independent event scan used by incident
-  bundle time-window reports, including the full report, manifest summary, and
-  command result.
+- Pending PR, `Report live smoke log scan cost`; branch:
+  `codex/live-log-scan-cost`, based on canonical
+  `f9ceb9678448201af0c0cc5f40f889b661d3021c`.
+- Scope: expose bounded elapsed-time, byte, successful-file, selected-line,
+  and read-method cost metadata for the text-log scan used by
+  `live-smoke-report`, including full, summary, and brief projections.
 - Behavior boundary: read-only local tooling only. The slice changes no event
-  producer, file selection, matching, truncation, bundle payload selection,
-  verdict, monitor persistence, exchange access, logs, process
-  inspection/control, planning, strategy, order, or risk behavior.
-- Baseline: incident time-window reports expose discovered/scanned files and
-  matched events but cannot identify actual records/bytes read, read methods,
-  or scan elapsed time. The active slice closes only that diagnostic gap using
-  the contract now shared by event query, performance report, and smoke report.
+  producer, log discovery, sequential read strategy, tail selection, line
+  numbering, matching, redaction, time-window filtering, verdict, monitor
+  persistence, exchange access, process inspection/control, planning,
+  strategy, order, or risk behavior.
+- Baseline: PR #1338's bounded VPS5 incident bundle scanned eight selected log
+  files and considered 321 in-window lines after skipping 2,943 older lines,
+  but the log report could not identify successful reads, physical/decoded
+  bytes, read methods, or elapsed scan time. The active slice closes only that
+  diagnostic gap using the established `scan_cost` schema.
 - Review gate: exact-current-head Hermes approval plus green Python/Rust CI.
   Built-in Codex automatic review is additional and every finding must be
   verified and resolved.
-- Expected VPS action: tracked-clean pull plus one bounded read-only incident
-  bundle smoke; no bot restart or process signal.
+- Expected VPS action: tracked-clean pull plus bounded read-only smoke and
+  incident-bundle reports; no bot restart or process signal.
 
-## Deployed Baseline (PR #1329 After PR #1337)
+## Deployed Baseline (PR #1338)
+
+- PR #1338 merged exact reviewed head
+  `8924c4ff30f96b8ea3dbf58fc6a97d1faa54514d` as canonical
+  `f9ceb9678448201af0c0cc5f40f889b661d3021c` after exact-head Hermes approval
+  and green Python/Rust CI. Built-in Codex was additionally requested and had
+  posted no finding when the proportional temporary gate merged the PR.
+- VPS5 guarded-prepared tracked-clean from
+  `848eb60c502b7af21dd7aa52f50f86aece552bd9` without a Rust build, bot
+  restart, or process signal. The source fingerprint and compiled stamp stayed
+  `691bff9683deec9382a4e96ab6a107c14145f88edd6ae2f8e2380b8ba6824449`.
+- The bounded five-minute incident bundle was `ok=true`, found all five exact
+  processes, and projected identical time-window `scan_cost` through the full
+  report, manifest, and command result: six `seek_tail` files, 8,848 records,
+  15,501,809 known physical/decoded bytes, and 3,515.111 ms. Its repository
+  evidence was tracked-clean at `f9ceb967`.
+- An immediate post-bundle identity snapshot observed four bot processes in
+  transient `D` state. After 30 seconds the unchanged exact PIDs were
+  `R/R/S/R/R`; pane parents `%358`-`%362` and protected `misc:0.0`
+  `%8`/PID `434835` were unchanged. No direct exchange call, manufactured
+  event, build, restart, or process signal occurred.
+
+## Previous Deployed Baseline (PR #1329 After PR #1337)
 
 - PR #1337 merged exact reviewed head
   `51a82c23230daf4aea5ec68784ef7168293b408e` as canonical
@@ -1662,11 +1685,10 @@ PR #1288's bounded target-identity stability, and PR #1289's plan binding are
 merged, deployed, and naturally validated without process control. PR #1290's
 pane-parent relaunch classification and the restart preparation/orchestration
 slices through PR #1309 are also merged and deployed. Later logging slices
-through PR #1337, followed by adjacent PR #1329, are deployed at canonical
-`848eb60c502b7af21dd7aa52f50f86aece552bd9`; their current evidence is recorded
-above. The active incident time-window scan-cost slice measures the remaining
-read-only bundle artifact work without changing scan selection or verdict
-behavior.
+through PR #1338, including adjacent PR #1329, are deployed at canonical
+`f9ceb9678448201af0c0cc5f40f889b661d3021c`; their current evidence is recorded
+above. The active log scan-cost slice measures the remaining read-only text-log
+artifact work without changing discovery, matching, or verdict behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,7 +22,7 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Pending PR, `Report live smoke log scan cost`; branch:
+- PR #1339, `Report live smoke log scan cost`; branch:
   `codex/live-log-scan-cost`, based on canonical
   `f9ceb9678448201af0c0cc5f40f889b661d3021c`.
 - Scope: expose bounded elapsed-time, byte, successful-file, selected-line,

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,30 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1329 After PR #1337)
+## Latest Canonical Deployment (PR #1338)
+
+- PR #1338 merged exact reviewed head
+  `8924c4ff30f96b8ea3dbf58fc6a97d1faa54514d` as canonical
+  `f9ceb9678448201af0c0cc5f40f889b661d3021c` after exact-head Hermes approval
+  and green Python/Rust CI. Built-in Codex was additionally requested and had
+  posted no finding when the proportional temporary gate merged the PR.
+- VPS5 guarded-prepared tracked-clean from `848eb60c50` without a Rust build,
+  bot restart, or signal; the Rust source fingerprint/stamp remained
+  `691bff9683deec9382a4e96ab6a107c14145f88edd6ae2f8e2380b8ba6824449`.
+- The bounded five-minute incident bundle was `ok=true`, found all five exact
+  processes, retained a clean `f9ceb967` repository, and projected identical
+  time-window scan cost through the full report, manifest, and command result:
+  six `seek_tail` files, 8,848 records, 15,501,809 known physical/decoded bytes,
+  and 3,515.111 ms.
+- The immediate post-bundle identity sample observed four unchanged bot PIDs
+  in transient `D` state. Thirty seconds later those same PIDs were
+  `R/R/S/R/R`; pane parents `%358`-`%362` and protected `misc:0.0`
+  `%8`/PID `434835` remained unchanged. No direct exchange call, manufactured
+  event, build, restart, or process signal occurred. The same bundle scanned
+  eight selected text logs but exposed no byte/read-method cost, motivating the
+  active `codex/live-log-scan-cost` slice.
+
+## Previous Canonical Deployment (PR #1329 After PR #1337)
 
 - PR #1337 merged exact reviewed head
   `51a82c23230daf4aea5ec68784ef7168293b408e` as canonical

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -9400,15 +9400,6 @@ def _recent_log_files(root: str | Path, *, max_files: int) -> list[Path]:
     ]
 
 
-def _tail_lines(path: Path, *, max_lines: int) -> list[tuple[int, str]]:
-    try:
-        with _open_text(path) as stream:
-            rows = deque(enumerate(stream, start=1), maxlen=max(0, int(max_lines)))
-    except OSError:
-        return []
-    return [(line_no, line.rstrip("\n")) for line_no, line in rows]
-
-
 def _parse_log_line_ts_ms(line: str) -> int | None:
     match = LOG_LINE_TS_PATTERN.match(str(line))
     if match is None:
@@ -9512,6 +9503,16 @@ def _scan_logs(
             "dropped_unparsed_matches": [],
             "dropped_unparsed_attention_matches": 0,
             "dropped_unparsed_hard_matches": 0,
+            "scan_cost": {
+                "elapsed_ms": 0.0,
+                "physical_bytes_read": 0,
+                "physical_bytes_known": True,
+                "decoded_bytes_read": 0,
+                "decoded_bytes_known": True,
+                "files_read": 0,
+                "records_read": 0,
+                "read_methods": {},
+            },
         }
     files = _recent_log_files(root, max_files=max_files)
     matches: list[dict[str, Any]] = []
@@ -9529,11 +9530,44 @@ def _scan_logs(
     dropped_unparsed_attention_matches = 0
     dropped_unparsed_hard_matches = 0
     dropped_unparsed_matches: list[dict[str, Any]] = []
+    scan_physical_bytes_read = 0
+    scan_physical_bytes_known = True
+    scan_decoded_bytes_read = 0
+    scan_decoded_bytes_known = True
+    scan_files_read = 0
+    scan_records_read = 0
+    scan_read_methods: Counter[str] = Counter()
+    scan_started_at = time.perf_counter()
     for path in files:
+        try:
+            with event_file_rows(
+                path,
+                max_tail_lines=0,
+                text_opener=_open_text,
+            ) as (rows, row_window):
+                selected_rows = deque(
+                    ((line_no, line.rstrip("\n")) for line_no, line in rows),
+                    maxlen=max(0, int(tail_lines)),
+                )
+            scan_files_read += 1
+            scan_records_read += len(selected_rows)
+            if row_window.physical_bytes_read is None:
+                scan_physical_bytes_known = False
+            else:
+                scan_physical_bytes_read += int(row_window.physical_bytes_read)
+            if row_window.decoded_bytes_read is None:
+                scan_decoded_bytes_known = False
+            else:
+                scan_decoded_bytes_read += int(row_window.decoded_bytes_read)
+            scan_read_methods[str(row_window.method)] += 1
+        except OSError:
+            scan_physical_bytes_known = False
+            scan_decoded_bytes_known = False
+            selected_rows = []
         log_context_ts_ms: int | None = None
         log_context_line_no: int | None = None
         log_context_text: str | None = None
-        for line_no, line in _tail_lines(path, max_lines=tail_lines):
+        for line_no, line in selected_rows:
             line_ts = _parse_log_line_ts_ms(line)
             if line_ts is not None:
                 log_context_ts_ms = line_ts
@@ -9614,6 +9648,7 @@ def _scan_logs(
                             log_context_text, max_len=500
                         )
                 matches.append(match)
+    scan_elapsed_ms = round((time.perf_counter() - scan_started_at) * 1000, 3)
     return {
         "root": str(Path(root).expanduser()),
         "max_files": max(0, int(max_files)),
@@ -9642,6 +9677,20 @@ def _scan_logs(
         "dropped_unparsed_matches": dropped_unparsed_matches,
         "dropped_unparsed_attention_matches": dropped_unparsed_attention_matches,
         "dropped_unparsed_hard_matches": dropped_unparsed_hard_matches,
+        "scan_cost": {
+            "elapsed_ms": scan_elapsed_ms,
+            "physical_bytes_read": (
+                scan_physical_bytes_read if scan_physical_bytes_known else None
+            ),
+            "physical_bytes_known": scan_physical_bytes_known,
+            "decoded_bytes_read": (
+                scan_decoded_bytes_read if scan_decoded_bytes_known else None
+            ),
+            "decoded_bytes_known": scan_decoded_bytes_known,
+            "files_read": scan_files_read,
+            "records_read": scan_records_read,
+            "read_methods": dict(sorted(scan_read_methods.items())),
+        },
     }
 
 
@@ -10591,6 +10640,7 @@ def summarize_live_smoke_report(
             "dropped_unparsed_hard_matches": int(
                 logs.get("dropped_unparsed_hard_matches") or 0
             ),
+            "scan_cost": logs.get("scan_cost"),
             "matches_truncated": len(matches) > max_groups,
             "matches": matches[:max_groups],
             "dropped_unparsed_matches_truncated": len(
@@ -11723,6 +11773,7 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
             "dropped_unparsed_hard_matches": _count_value(
                 logs.get("dropped_unparsed_hard_matches")
             ),
+            "scan_cost": logs.get("scan_cost"),
             "window": _brief_log_window(logs),
         }
         | _brief_log_match_samples(logs)

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -301,6 +301,121 @@ def test_live_smoke_report_scan_cost_marks_unmeasurable_and_failed_reads_unknown
     }
 
 
+def test_live_smoke_report_log_scan_cost_tracks_full_plain_and_gzip_reads(tmp_path):
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    plain_path = logs_dir / "plain.log"
+    plain_text = "first line\n\nlast plain line\n"
+    plain_path.write_text(plain_text, encoding="utf-8")
+    gzip_path = logs_dir / "archive.log.gz"
+    gzip_text = "older gzip line\nlast gzip line\n"
+    with gzip.open(gzip_path, "wt", encoding="utf-8") as stream:
+        stream.write(gzip_text)
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=logs_dir,
+        log_tail_lines=2,
+    )
+    scan_cost = report["logs"]["scan_cost"]
+
+    assert scan_cost["elapsed_ms"] >= 0
+    assert scan_cost["physical_bytes_read"] == (
+        plain_path.stat().st_size + gzip_path.stat().st_size
+    )
+    assert scan_cost["physical_bytes_known"] is True
+    assert scan_cost["decoded_bytes_read"] == len(plain_text.encode()) + len(
+        gzip_text.encode()
+    )
+    assert scan_cost["decoded_bytes_known"] is True
+    assert scan_cost["files_read"] == 2
+    assert scan_cost["records_read"] == 4
+    assert scan_cost["read_methods"] == {"full_scan": 2}
+    assert summarize_live_smoke_report(report)["logs"]["scan_cost"] == scan_cost
+    assert summarize_live_smoke_report_brief(report)["logs"]["scan_cost"] == scan_cost
+
+
+def test_live_smoke_report_log_scan_cost_marks_unmeasurable_and_failed_reads_unknown(
+    tmp_path, monkeypatch
+):
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "bot.log").write_text("first\n\nlast\n", encoding="utf-8")
+
+    class UnmeasurableRows:
+        def __enter__(self):
+            return (
+                iter([(4, "first\n"), (5, "\n"), (6, "last\n")]),
+                event_file_rows_module.EventRowWindow(),
+            )
+
+        def __exit__(self, *args):
+            return False
+
+    monkeypatch.setattr(
+        smoke_report_module,
+        "event_file_rows",
+        lambda *args, **kwargs: UnmeasurableRows(),
+    )
+    unmeasurable = build_live_smoke_report(
+        tmp_path / "monitor", logs_root=logs_dir, log_tail_lines=2
+    )["logs"]["scan_cost"]
+
+    assert unmeasurable["elapsed_ms"] >= 0
+    assert unmeasurable["physical_bytes_read"] is None
+    assert unmeasurable["physical_bytes_known"] is False
+    assert unmeasurable["decoded_bytes_read"] is None
+    assert unmeasurable["decoded_bytes_known"] is False
+    assert unmeasurable["files_read"] == 1
+    assert unmeasurable["records_read"] == 2
+    assert unmeasurable["read_methods"] == {"full_scan": 1}
+
+    class FailingRows:
+        def __enter__(self):
+            raise OSError(13, "Permission denied")
+
+        def __exit__(self, *args):
+            return False
+
+    monkeypatch.setattr(
+        smoke_report_module,
+        "event_file_rows",
+        lambda *args, **kwargs: FailingRows(),
+    )
+    failed = build_live_smoke_report(
+        tmp_path / "monitor", logs_root=logs_dir, log_tail_lines=2
+    )["logs"]["scan_cost"]
+
+    assert failed["elapsed_ms"] >= 0
+    assert {key: value for key, value in failed.items() if key != "elapsed_ms"} == {
+        "physical_bytes_read": None,
+        "physical_bytes_known": False,
+        "decoded_bytes_read": None,
+        "decoded_bytes_known": False,
+        "files_read": 0,
+        "records_read": 0,
+        "read_methods": {},
+    }
+
+
+def test_live_smoke_report_log_scan_cost_is_zero_known_without_logs_root(tmp_path):
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    scan_cost = report["logs"]["scan_cost"]
+
+    assert scan_cost == {
+        "elapsed_ms": 0.0,
+        "physical_bytes_read": 0,
+        "physical_bytes_known": True,
+        "decoded_bytes_read": 0,
+        "decoded_bytes_known": True,
+        "files_read": 0,
+        "records_read": 0,
+        "read_methods": {},
+    }
+    assert summarize_live_smoke_report(report)["logs"]["scan_cost"] == scan_cost
+    assert summarize_live_smoke_report_brief(report)["logs"]["scan_cost"] == scan_cost
+
+
 def test_live_smoke_report_event_tail_lines_bounds_monitor_scan(tmp_path):
     events_path = (
         tmp_path / "monitor" / "binance" / "binance_01" / "events" / "current.ndjson"
@@ -1755,7 +1870,19 @@ def test_live_smoke_report_brief_summary_projects_top_level_counters(tmp_path):
     }
     assert brief["monitor"]["live_events"] == 2
     assert brief["event_window"]["enabled"] is False
-    assert brief["logs"] == {
+    brief_logs = dict(brief["logs"])
+    scan_cost = brief_logs.pop("scan_cost")
+    assert scan_cost["elapsed_ms"] >= 0
+    assert scan_cost["physical_bytes_read"] == (
+        logs_dir / "kucoin_01.log"
+    ).stat().st_size
+    assert scan_cost["physical_bytes_known"] is True
+    assert scan_cost["decoded_bytes_read"] == scan_cost["physical_bytes_read"]
+    assert scan_cost["decoded_bytes_known"] is True
+    assert scan_cost["files_read"] == 1
+    assert scan_cost["records_read"] == 1
+    assert scan_cost["read_methods"] == {"full_scan": 1}
+    assert brief_logs == {
         "max_files": 8,
         "tail_lines": 10,
         "max_matches": 50,


### PR DESCRIPTION
## Summary
- expose bounded `logs.scan_cost` metadata in full, summary, and brief live-smoke output
- report elapsed time, successful files, selected parser lines, read methods, and physical/decoded bytes with explicit unknownness
- preserve existing log discovery, full sequential reads, deque tail selection, line numbering, matching, redaction, window filtering, verdicts, exchange access, and live behavior

## Validation
- `/Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_live_smoke_report.py tests/test_live_incident_bundle.py tests/test_live_restart_smoke_plan.py tests/test_ai_docs.py tests/test_live_event_registry_docs.py`
- `/Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py`
- `src/tools/check_ai_docs.py` (0 errors; existing size warning)
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python src/tools/generate_live_event_registry.py --check` (current)
- `git diff --check`

## Deployment evidence
- PR #1338 merged exact reviewed head `8924c4ff30` as canonical `f9ceb967`
- VPS5 guarded-prepared tracked-clean without Rust build, bot restart, or signal
- bounded incident bundle was green and projected six `seek_tail` files, 8,848 records, 15,501,809 known physical/decoded bytes, and 3,515.111 ms
- transient immediate post-bundle `D` states recovered after 30 seconds with exact PIDs, pane parents, and `misc:0.0` unchanged

## Expected VPS action
- tracked-clean pull plus bounded read-only smoke and incident-bundle reports
- no bot restart or process signal

@codex review