### PR TITLE
Retain smoke log scan cost in incident summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Incident bundle manifest and command-result summaries now retain the
+  embedded live smoke report's text-log `scan_cost` metadata. The archive's
+  full smoke report, log reads, matching, redaction, filtering, verdicts,
+  exchange access, and live behavior are unchanged.
+
 - `live-smoke-report` log scans now include bounded `scan_cost` metadata in
   full, summary, and brief output. The metadata reports elapsed time,
   successfully read files and selected tail lines, read methods, and known

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,29 +22,53 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR #1339, `Report live smoke log scan cost`; branch:
-  `codex/live-log-scan-cost`, based on canonical
-  `f9ceb9678448201af0c0cc5f40f889b661d3021c`.
-- Scope: expose bounded elapsed-time, byte, successful-file, selected-line,
-  and read-method cost metadata for the text-log scan used by
-  `live-smoke-report`, including full, summary, and brief projections.
+- Pending PR, `Retain smoke log scan cost in incident summaries`; branch:
+  `codex/live-incident-log-scan-cost`, based on canonical
+  `3311085dce8b7540f5a26e809229180d5f784c25`.
+- Scope: propagate the already-computed live smoke text-log `scan_cost`
+  unchanged through the incident bundle manifest summary and command result.
 - Behavior boundary: read-only local tooling only. The slice changes no event
-  producer, log discovery, sequential read strategy, tail selection, line
-  numbering, matching, redaction, time-window filtering, verdict, monitor
-  persistence, exchange access, process inspection/control, planning,
-  strategy, order, or risk behavior.
-- Baseline: PR #1338's bounded VPS5 incident bundle scanned eight selected log
-  files and considered 321 in-window lines after skipping 2,943 older lines,
-  but the log report could not identify successful reads, physical/decoded
-  bytes, read methods, or elapsed scan time. The active slice closes only that
-  diagnostic gap using the established `scan_cost` schema.
+  producer, archive content, log discovery or reads, matching, redaction,
+  filtering, verdict, monitor persistence, exchange access, process
+  inspection/control, planning, strategy, order, or risk behavior.
+- Baseline: PR #1339's deployed incident archive contains exact log
+  `scan_cost` in `smoke_report.json`, but the bundle manifest summary and
+  command result omit it because their dedicated log-summary projector does
+  not retain the field. The active slice closes only that projection gap.
 - Review gate: exact-current-head Hermes approval plus green Python/Rust CI.
   Built-in Codex automatic review is additional and every finding must be
   verified and resolved.
-- Expected VPS action: tracked-clean pull plus bounded read-only smoke and
-  incident-bundle reports; no bot restart or process signal.
+- Expected VPS action: tracked-clean pull plus one bounded read-only incident
+  bundle; no bot restart or process signal.
 
-## Deployed Baseline (PR #1338)
+## Deployed Baseline (PR #1339)
+
+- PR #1339 merged exact reviewed head
+  `c66a306a4b20485d31e3806913c1f2d90279ecb7` as canonical
+  `3311085dce8b7540f5a26e809229180d5f784c25` after exact-head Hermes approval
+  and green Python/Rust CI. Built-in Codex was additionally requested and had
+  posted no finding when the proportional temporary gate merged the PR.
+- VPS5 guarded-prepared tracked-clean from
+  `f9ceb9678448201af0c0cc5f40f889b661d3021c` without a Rust build, bot
+  restart, or process signal. The source fingerprint and compiled stamp stayed
+  `691bff9683deec9382a4e96ab6a107c14145f88edd6ae2f8e2380b8ba6824449`.
+- The bounded direct smoke proved the new log `scan_cost`: eight `full_scan`
+  files, 3,442 selected records, 512,497 known physical/decoded bytes, and
+  742.868 ms. It found all five exact processes and a tracked-clean repository
+  at `3311085d`; its non-green verdict correctly retained two natural KuCoin
+  authoritative-balance `RequestTimeout` events.
+- The matching incident archive retained its exact log `scan_cost` in
+  `smoke_report.json`: eight `full_scan` files, 3,446 selected records,
+  513,283 known physical/decoded bytes, and 642.116 ms. Live inspection proved
+  that only the manifest and command-result summaries omitted that field,
+  motivating the active projection-only slice.
+- Incident collection briefly observed unchanged bots in `D` state. Repeated
+  passive samples settled the same exact PIDs to `R/R/R/S/R`; pane parents
+  `%358`-`%362` and protected `misc:0.0` `%8`/PID `434835` were unchanged. No
+  direct exchange call, manufactured event, build, restart, or process signal
+  occurred.
+
+## Previous Deployed Baseline (PR #1338)
 
 - PR #1338 merged exact reviewed head
   `8924c4ff30f96b8ea3dbf58fc6a97d1faa54514d` as canonical
@@ -1685,10 +1709,11 @@ PR #1288's bounded target-identity stability, and PR #1289's plan binding are
 merged, deployed, and naturally validated without process control. PR #1290's
 pane-parent relaunch classification and the restart preparation/orchestration
 slices through PR #1309 are also merged and deployed. Later logging slices
-through PR #1338, including adjacent PR #1329, are deployed at canonical
-`f9ceb9678448201af0c0cc5f40f889b661d3021c`; their current evidence is recorded
-above. The active log scan-cost slice measures the remaining read-only text-log
-artifact work without changing discovery, matching, or verdict behavior.
+through PR #1339, including adjacent PR #1329, are deployed at canonical
+`3311085dce8b7540f5a26e809229180d5f784c25`; their current evidence is recorded
+above. The active incident-summary slice closes the observed log scan-cost
+projection gap without changing archive content, reads, matching, or verdict
+behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,7 +22,7 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Pending PR, `Retain smoke log scan cost in incident summaries`; branch:
+- PR #1340, `Retain smoke log scan cost in incident summaries`; branch:
   `codex/live-incident-log-scan-cost`, based on canonical
   `3311085dce8b7540f5a26e809229180d5f784c25`.
 - Scope: propagate the already-computed live smoke text-log `scan_cost`

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,31 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1338)
+## Latest Canonical Deployment (PR #1339)
+
+- PR #1339 merged exact reviewed head
+  `c66a306a4b20485d31e3806913c1f2d90279ecb7` as canonical
+  `3311085dce8b7540f5a26e809229180d5f784c25` after exact-head Hermes approval
+  and green Python/Rust CI. Built-in Codex was additionally requested and had
+  posted no finding when the proportional temporary gate merged the PR.
+- VPS5 guarded-prepared tracked-clean from `f9ceb96784` without a Rust build,
+  restart, or signal; the Rust source fingerprint/stamp remained
+  `691bff9683deec9382a4e96ab6a107c14145f88edd6ae2f8e2380b8ba6824449`.
+- The bounded direct smoke reported eight `full_scan` log files, 3,442 selected
+  records, 512,497 known physical/decoded bytes, and 742.868 ms. Its non-green
+  verdict correctly retained two natural KuCoin authoritative-balance
+  `RequestTimeout` events rather than masking them.
+- The incident archive retained exact log scan cost in `smoke_report.json`:
+  eight `full_scan` files, 3,446 selected records, 513,283 known
+  physical/decoded bytes, and 642.116 ms. The manifest and command-result
+  summaries omitted the same field, motivating the active
+  `codex/live-incident-log-scan-cost` projection-only slice.
+- All five unchanged bot PIDs settled to `R/R/R/S/R`; pane parents
+  `%358`-`%362` and protected `misc:0.0` `%8`/PID `434835` remained unchanged.
+  No direct exchange call, manufactured event, build, restart, or process
+  signal occurred.
+
+## Previous Canonical Deployment (PR #1338)
 
 - PR #1338 merged exact reviewed head
   `8924c4ff30f96b8ea3dbf58fc6a97d1faa54514d` as canonical

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -732,6 +732,7 @@ def _smoke_log_result_summary(smoke_report: dict[str, Any]) -> dict[str, Any]:
         "tail_lines": logs.get("tail_lines"),
         "max_matches": logs.get("max_matches"),
         "files_scanned": logs.get("files_scanned"),
+        "scan_cost": logs.get("scan_cost"),
         "hard_matches": logs.get("hard_matches"),
         "attention_matches": logs.get("attention_matches"),
         "risk_attention_matches": logs.get("risk_attention_matches"),

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -679,7 +679,10 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         "events_skipped_after": 0,
         "invalid_window_ts": 0,
     }
-    assert report["smoke_report"]["logs"] == {
+    smoke_log_summary = report["smoke_report"]["logs"]
+    assert {
+        key: value for key, value in smoke_log_summary.items() if key != "scan_cost"
+    } == {
         "max_files": 8,
         "tail_lines": 500,
         "max_matches": 100,
@@ -706,6 +709,18 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
             "dropped_unparsed_hard_matches": 0,
         },
     }
+    _assert_nonnegative_elapsed_scan_cost(
+        smoke_log_summary["scan_cost"],
+        {
+            "physical_bytes_read": (logs_dir / "bot.log").stat().st_size,
+            "physical_bytes_known": True,
+            "decoded_bytes_read": (logs_dir / "bot.log").stat().st_size,
+            "decoded_bytes_known": True,
+            "files_read": 1,
+            "records_read": 1,
+            "read_methods": {"full_scan": 1},
+        },
+    )
     assert report["smoke_report"]["hard_failure_sources"] == {
         "monitor_errors": 0,
         "invalid_event_rows": 0,
@@ -1155,6 +1170,9 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
     assert smoke_report["logs"]["max_matches"] == report["smoke_report"]["logs"][
         "max_matches"
     ]
+    scan_cost = smoke_report["logs"]["scan_cost"]
+    assert report["smoke_report"]["logs"]["scan_cost"] == scan_cost
+    assert manifest["smoke_report"]["logs"]["scan_cost"] == scan_cost
     assert smoke_report["logs"]["window"] == report["smoke_report"]["logs"]["window"]
     assert smoke_report["remote_call_failures"]["total"] == 1
     assert smoke_report["execution_health"]["total"] == 1


### PR DESCRIPTION
@codex review

## Scope

Category: read-only tooling.

Retain the already-computed live smoke text-log `scan_cost` in the incident
bundle manifest summary and command result. The archived full
`smoke_report.json` already contains the field.

Touched surfaces:
- `src/live/incident_bundle.py::_smoke_log_result_summary`
- incident bundle projection regression coverage
- logging-overhaul deploy/status ledgers and changelog

Non-goals:
- no new log reads or archive payloads
- no discovery, tail selection, matching, redaction, filtering, or verdict changes
- no monitor persistence, process inspection/control, exchange access, planning,
  strategy, order, or risk changes

## Behavior Impact

Incident bundle manifest and command-result summaries now carry the exact same
`logs.scan_cost` object as the archived smoke report. All operational behavior
remains unchanged.

## VPS Action

Expected after merge: tracked-clean pull plus one bounded read-only incident
bundle smoke. No Rust build, bot restart, or process signal.

## Validation

- `pytest tests/test_live_incident_bundle.py tests/test_live_smoke_report.py tests/test_live_restart_smoke_plan.py tests/test_ai_docs.py tests/test_live_event_registry_docs.py` -> 203 passed
- `PYTHONPATH=src python src/tools/check_ai_docs.py` -> 0 errors, existing size warning only
- `PYTHONPATH=src python src/tools/generate_live_event_registry.py --check` -> current
- `python -m py_compile src/live/incident_bundle.py` -> passed
- `git diff --check` -> passed

## Reviewer Focus

Please verify that the field is propagated unchanged through command result,
manifest summary, and archived full report, and that no scan or verdict behavior
changes.

Residual risk is limited to a missing or incorrect diagnostic projection; the
source object is already bounded and redacted.
