### PR TITLE
Structure bulk open-order snapshot deltas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Large open-order snapshot deltas now emit one bounded `open_orders.snapshot_delta` INFO event per
+  added or removed direction, with only the direction and order count. The event reaches structured,
+  monitor, console, and text sinks with the `[order]` tag; reconciliation and order behavior are
+  unchanged, and a bounded legacy INFO fallback remains when the structured console is unavailable.
+
 - Incident bundle manifest and command-result summaries now retain the
   embedded live smoke report's text-log `scan_cost` metadata. The archive's
   full smoke report, log reads, matching, redaction, filtering, verdicts,

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -104,6 +104,20 @@ count. An all-pending batch must not present its known PnL as zero. The legacy d
 fallback only when the structured live-event console is disabled or its pipeline is absent. Runtime
 sink degradation remains isolated by the event pipeline and must not activate dual writing.
 
+## Open-Orders Snapshot Deltas
+
+`open_orders.snapshot_delta` replaces the aggregate INFO lines for open-order snapshot additions or
+removals larger than 20 orders. It emits at most one event for each qualifying aggregate direction,
+with `direction=added|removed` and `order_count` as its only payload fields. The event is routed to
+structured, monitor, console, and durable text sinks at INFO with the `[order]` console tag.
+
+Snapshots of 20 orders or fewer retain the existing per-order logging behavior. The event is
+diagnostic-only: emission or sink failure must not affect reconciliation, unexpected-change
+classification, guardrails, confirmations, balance handling, or follow-up refreshes. It never
+retains order rows, identifiers, symbols, prices, raw payloads, exception text, or samples.
+When the structured console is disabled or unavailable, the same bounded count retains one legacy
+`[order]` INFO fallback; the two console paths never intentionally write the same observation.
+
 ## Fresh-Entry Eligibility
 
 Completed normal live plans emit `entry.initial_eligibility` to structured and monitor sinks. The

--- a/docs/ai/generated/live_event_registry.md
+++ b/docs/ai/generated/live_event_registry.md
@@ -70,6 +70,7 @@ The code-owned registries live in `src/live/event_bus.py`. Payload and emission 
 - `hsl.status`
 - `hsl.transition`
 - `market.snapshot_diagnostic_skipped`
+- `open_orders.snapshot_delta`
 - `order_wave.completed`
 - `order_wave.started`
 - `planning.defer_summary`
@@ -205,6 +206,7 @@ The code-owned registries live in `src/live/event_bus.py`. Payload and emission 
 - `min_effective_cost_blocked`
 - `new_fill`
 - `new_fill_batch`
+- `open_orders_snapshot_delta`
 - `open_tail_projection`
 - `optional_ema_dropped`
 - `pending_exchange_config`

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,7 +22,7 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch `codex/open-orders-snapshot-delta-event`, based on canonical
+- PR #1341; branch `codex/open-orders-snapshot-delta-event`, based on canonical
   `bc31fafdbdf045f9c003e49fa6877b721c834600`.
 - Scope: replace the two legacy aggregate INFO lines emitted when an
   authoritative open-order snapshot adds or removes more than 20 orders with

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,7 +22,8 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR #1341; branch `codex/open-orders-snapshot-delta-event`, based on canonical
+- PR #1341, `Structure bulk open-order snapshot deltas`; branch
+  `codex/open-orders-snapshot-delta-event`, based on canonical
   `bc31fafdbdf045f9c003e49fa6877b721c834600`.
 - Scope: replace the two legacy aggregate INFO lines emitted when an
   authoritative open-order snapshot adds or removes more than 20 orders with
@@ -1733,11 +1734,11 @@ PR #1288's bounded target-identity stability, and PR #1289's plan binding are
 merged, deployed, and naturally validated without process control. PR #1290's
 pane-parent relaunch classification and the restart preparation/orchestration
 slices through PR #1309 are also merged and deployed. Later logging slices
-through PR #1339, including adjacent PR #1329, are deployed at canonical
-`3311085dce8b7540f5a26e809229180d5f784c25`; their current evidence is recorded
-above. The active incident-summary slice closes the observed log scan-cost
-projection gap without changing archive content, reads, matching, or verdict
-behavior.
+through PR #1340, including adjacent PR #1329, are deployed at canonical
+`bc31fafdbdf045f9c003e49fa6877b721c834600`; their current evidence is recorded
+above. Active PR #1341 migrates only the remaining bulk open-order snapshot
+count lines into the bounded structured event contract while preserving the
+existing threshold, legacy fallback, reconciliation, and trading behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,26 +22,50 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR #1340, `Retain smoke log scan cost in incident summaries`; branch:
-  `codex/live-incident-log-scan-cost`, based on canonical
-  `3311085dce8b7540f5a26e809229180d5f784c25`.
-- Scope: propagate the already-computed live smoke text-log `scan_cost`
-  unchanged through the incident bundle manifest summary and command result.
-- Behavior boundary: read-only local tooling only. The slice changes no event
-  producer, archive content, log discovery or reads, matching, redaction,
-  filtering, verdict, monitor persistence, exchange access, process
-  inspection/control, planning, strategy, order, or risk behavior.
-- Baseline: PR #1339's deployed incident archive contains exact log
-  `scan_cost` in `smoke_report.json`, but the bundle manifest summary and
-  command result omit it because their dedicated log-summary projector does
-  not retain the field. The active slice closes only that projection gap.
+- Branch `codex/open-orders-snapshot-delta-event`, based on canonical
+  `bc31fafdbdf045f9c003e49fa6877b721c834600`.
+- Scope: replace the two legacy aggregate INFO lines emitted when an
+  authoritative open-order snapshot adds or removes more than 20 orders with
+  one bounded structured `open_orders.snapshot_delta` event per direction.
+- Behavior boundary: logging migration only. The event retains operator-visible
+  INFO/text projection and persists only the direction and count. It changes no
+  order rows, snapshot application, reconciliation classification, guardrail,
+  confirmation, balance handling, exchange access, planning, strategy, order,
+  or risk behavior.
+- Baseline: smaller deltas already retain per-order developer logs while the
+  bulk path emits only uncorrelated stdlib count lines. Config-age reporting was
+  considered but deferred because runtime currently has no canonical config
+  freshness timestamp or reload contract.
 - Review gate: exact-current-head Hermes approval plus green Python/Rust CI.
   Built-in Codex automatic review is additional and every finding must be
   verified and resolved.
-- Expected VPS action: tracked-clean pull plus one bounded read-only incident
-  bundle; no bot restart or process signal.
+- Expected VPS action: tracked-clean pull and bounded passive event/process
+  validation. Because the producer path changes, restart only the exact five
+  configured panes if the merged diff and guarded preflight warrant activation;
+  preserve `misc:0.0`.
 
-## Deployed Baseline (PR #1339)
+## Deployed Baseline (PR #1340)
+
+- PR #1340 merged exact reviewed head
+  `d9e88d6da9282bc53a355dc3ce18a9cba6de45eb` as canonical
+  `bc31fafdbdf045f9c003e49fa6877b721c834600` after exact-head Hermes approval,
+  green Python/Rust CI, and a finding-free built-in Codex review.
+- VPS5 guarded-prepared tracked-clean from
+  `3311085dce8b7540f5a26e809229180d5f784c25` without a Rust build, bot restart,
+  or process signal. The source fingerprint and compiled stamp stayed
+  `691bff9683deec9382a4e96ab6a107c14145f88edd6ae2f8e2380b8ba6824449`.
+- The bounded incident bundle
+  `/tmp/passivbot_incident_bundle_pr1340_bc31fafdbd.tar.gz` proved identical log
+  `scan_cost` in the command result, manifest, and archived full smoke report:
+  eight `full_scan` files, 3,787 selected records, 573,578 known
+  physical/decoded bytes, and 847.006 ms.
+- The bundle correctly remained non-green on one natural KuCoin authoritative
+  balance `RequestTimeout`. All five exact bot PIDs and pane parents remained
+  intact, final passive sampling retained normal `R`/`S` states, and protected
+  `misc:0.0` remained `%8`/PID `434835`. No direct exchange call, manufactured
+  event, build, restart, or process signal occurred.
+
+## Previous Deployed Baseline (PR #1339)
 
 - PR #1339 merged exact reviewed head
   `c66a306a4b20485d31e3806913c1f2d90279ecb7` as canonical

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,27 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1339)
+## Latest Canonical Deployment (PR #1340)
+
+- PR #1340 merged exact reviewed head
+  `d9e88d6da9282bc53a355dc3ce18a9cba6de45eb` as canonical
+  `bc31fafdbdf045f9c003e49fa6877b721c834600` after exact-head Hermes approval,
+  green Python/Rust CI, and a finding-free built-in Codex review.
+- VPS5 guarded-prepared tracked-clean from `3311085dce` without a Rust build,
+  restart, or signal; the Rust source fingerprint/stamp remained
+  `691bff9683deec9382a4e96ab6a107c14145f88edd6ae2f8e2380b8ba6824449`.
+- The bounded incident bundle retained exact matching log `scan_cost` in its
+  command result, manifest, and archived full smoke report: eight `full_scan`
+  files, 3,787 selected records, 573,578 known physical/decoded bytes, and
+  847.006 ms. It correctly remained non-green on one natural KuCoin
+  authoritative-balance `RequestTimeout`.
+- All five exact bot PIDs and pane parents remained intact; settled passive
+  sampling retained normal `R`/`S` states and protected `misc:0.0` `%8`/PID
+  `434835`. No direct exchange call, manufactured event, build, restart, or
+  process signal occurred. The next logging migration replaces the remaining
+  bulk open-order snapshot stdlib count lines with a bounded structured event.
+
+## Previous Canonical Deployment (PR #1339)
 
 - PR #1339 merged exact reviewed head
   `c66a306a4b20485d31e3806913c1f2d90279ecb7` as canonical

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -161,6 +161,7 @@ class EventTypes:
     CYCLE_DEGRADED = "cycle.degraded"
     DATA_PACKET_UPDATED = "data_packet.updated"
     SNAPSHOT_BUILT = "snapshot.built"
+    OPEN_ORDERS_SNAPSHOT_DELTA = "open_orders.snapshot_delta"
     PLANNING_UNAVAILABLE = "planning.unavailable"
     PLANNING_DEFER_SUMMARY = "planning.defer_summary"
     PLANNING_SYMBOL_STATE = "planning.symbol_state"
@@ -325,6 +326,7 @@ class ReasonCodes:
     MEMORY_SNAPSHOT = "memory_snapshot"
     NEW_FILL = "new_fill"
     NEW_FILL_BATCH = "new_fill_batch"
+    OPEN_ORDERS_SNAPSHOT_DELTA = "open_orders_snapshot_delta"
     OPEN_TAIL_PROJECTION = "open_tail_projection"
     OPTIONAL_EMA_DROPPED = "optional_ema_dropped"
     PENDING_EXCHANGE_CONFIG = "pending_exchange_config"
@@ -492,6 +494,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.CYCLE_DEGRADED,
     EventTypes.DATA_PACKET_UPDATED,
     EventTypes.SNAPSHOT_BUILT,
+    EventTypes.OPEN_ORDERS_SNAPSHOT_DELTA,
     EventTypes.PLANNING_UNAVAILABLE,
     EventTypes.PLANNING_DEFER_SUMMARY,
     EventTypes.PLANNING_SYMBOL_STATE,
@@ -803,6 +806,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.CYCLE_DEGRADED: EventRoute(console=True, text=True),
     EventTypes.DATA_PACKET_UPDATED: EventRoute(console=False),
     EventTypes.SNAPSHOT_BUILT: EventRoute(console=False),
+    EventTypes.OPEN_ORDERS_SNAPSHOT_DELTA: EventRoute(console=True, text=True),
     EventTypes.PLANNING_UNAVAILABLE: EventRoute(
         console=True, text=True, throttle_interval_ms=60_000
     ),
@@ -985,6 +989,7 @@ _CONSOLE_EVENT_TAGS = {
     EventTypes.CYCLE_COMPLETED: "cycle",
     EventTypes.CYCLE_DEGRADED: "cycle",
     EventTypes.PLANNING_UNAVAILABLE: "gate",
+    EventTypes.OPEN_ORDERS_SNAPSHOT_DELTA: "order",
     EventTypes.FORAGER_SELECTION: "forager",
     EventTypes.RUST_ORCHESTRATOR_RETURNED: "rust",
     EventTypes.ORDER_WAVE_COMPLETED: "execute",
@@ -2042,11 +2047,28 @@ def _console_unstuck_selection_summary(event: LiveEvent) -> list[str]:
     return parts
 
 
+_OPEN_ORDERS_SNAPSHOT_DELTA_CONSOLE_COUNT_LIMIT = 999_999_999
+
+
+def _console_open_orders_snapshot_delta_summary(event: LiveEvent) -> list[str]:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    direction = str(data.get("direction") or "unknown")
+    if direction not in {"added", "removed"}:
+        direction = "unknown"
+    count = _data_int(data, "order_count")
+    if count is None:
+        count = 0
+    count = min(_OPEN_ORDERS_SNAPSHOT_DELTA_CONSOLE_COUNT_LIMIT, max(0, count))
+    return [f"direction={direction}", f"order_count={count}"]
+
+
 def _console_data_summary(event: LiveEvent) -> list[str]:
     if event.event_type == EventTypes.BOT_STARTUP_TIMING:
         return _console_startup_timing_summary(event)
     if event.event_type == EventTypes.ORDER_WAVE_COMPLETED:
         return _console_order_wave_summary(event)
+    if event.event_type == EventTypes.OPEN_ORDERS_SNAPSHOT_DELTA:
+        return _console_open_orders_snapshot_delta_summary(event)
     if event.event_type in {
         EventTypes.EXECUTION_CREATE_DEFERRED,
         EventTypes.EXECUTION_CREATE_SKIPPED,

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -2427,6 +2427,33 @@ def _safe_emit(bot: Any, event_type: str, **kwargs: Any) -> Any:
         return None
 
 
+def emit_open_orders_snapshot_delta_event(
+    bot: Any,
+    *,
+    direction: str,
+    order_count: int,
+) -> Any:
+    """Emit the bounded aggregate path for large open-orders snapshot deltas."""
+    if direction not in {"added", "removed"}:
+        return None
+    try:
+        count = int(order_count)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if count <= 20:
+        return None
+    return _safe_emit(
+        bot,
+        EventTypes.OPEN_ORDERS_SNAPSHOT_DELTA,
+        level="info",
+        component="orders.snapshot",
+        tags=(EventTags.ORDER, EventTags.SNAPSHOT),
+        cycle_id=current_live_event_cycle_id(bot),
+        reason_code=ReasonCodes.OPEN_ORDERS_SNAPSHOT_DELTA,
+        data={"direction": direction, "order_count": count},
+    )
+
+
 def _emit_rust_orchestrator_called_event_unchecked(
     bot: Any,
     *,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -638,6 +638,9 @@ class Passivbot:
     _emit_live_cycle_completed = live_event_emitters.emit_live_cycle_completed
     _emit_live_cycle_degraded = live_event_emitters.emit_live_cycle_degraded
     _emit_live_event = live_event_emitters.emit_live_event
+    _emit_open_orders_snapshot_delta_event = (
+        live_event_emitters.emit_open_orders_snapshot_delta_event
+    )
     _emit_startup_timing_event = live_event_emitters.emit_startup_timing_event
     _emit_exchange_config_refresh_event = (
         live_event_emitters.emit_exchange_config_refresh_event
@@ -7485,6 +7488,31 @@ class Passivbot:
             msg += " | " + " ".join(extra_parts)
         logging.log(level, msg)
 
+    def _log_open_orders_snapshot_delta(
+        self, *, direction: str, order_count: int
+    ) -> None:
+        """Emit one bulk snapshot event, retaining legacy console fallback."""
+        pipeline = getattr(self, "_live_event_pipeline", None)
+        emit_delta = getattr(self, "_emit_open_orders_snapshot_delta_event", None)
+        structured_console_available = bool(
+            callable(emit_delta)
+            and Passivbot._live_event_console_available(self)
+            and callable(getattr(pipeline, "emit", None))
+            and getattr(pipeline, "console_sink", None) is not None
+        )
+        emitted = None
+        if callable(emit_delta):
+            try:
+                emitted = emit_delta(direction=direction, order_count=order_count)
+            except Exception as exc:
+                logging.debug(
+                    "[event] failed to emit open-orders snapshot delta: %s", exc
+                )
+        if emitted is None:
+            structured_console_available = False
+        if not structured_console_available:
+            logging.info("[order] %s %d orders", direction, order_count)
+
     def _live_market_orders_allowed(self) -> bool:
         value = self.live_value("market_orders_allowed")
         if isinstance(value, str):
@@ -14319,7 +14347,9 @@ class Passivbot:
         schedule_update_positions = False
         unexpected_removed_symbols = set()
         if len(removed_orders) > 20:
-            logging.info(f"removed {len(removed_orders)} orders")
+            self._log_open_orders_snapshot_delta(
+                direction="removed", order_count=len(removed_orders)
+            )
         for order in removed_orders:
             cancelled_by_bot = False
             if hasattr(self, "order_matches_bot_cancellation"):
@@ -14345,7 +14375,9 @@ class Passivbot:
                     context="bot_cancel_confirmed" if cancelled_by_bot else None,
                 )
         if len(added_orders) > 20:
-            logging.info(f"[order] added {len(added_orders)} new orders")
+            self._log_open_orders_snapshot_delta(
+                direction="added", order_count=len(added_orders)
+            )
         else:
             for order in added_orders:
                 created_by_bot = False

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -18,6 +18,7 @@ from live.event_bus import (
     DEFAULT_ROUTES,
     EventTags,
     EventTypes,
+    format_console_event,
     ListEventSink,
     LiveEvent,
     LiveEventPipeline,
@@ -9326,6 +9327,184 @@ def _guardrail_order(**overrides):
     }
     order.update(overrides)
     return order
+
+
+def _open_orders_snapshot_orders(prefix: str, count: int) -> list[dict]:
+    return [_guardrail_order(id=f"{prefix}-{index}") for index in range(count)]
+
+
+@pytest.mark.asyncio
+async def test_large_added_open_orders_snapshot_delta_event_is_bounded_and_operator_visible(
+    caplog,
+):
+    structured_sink = ListEventSink()
+    monitor_sink = ListEventSink()
+    console_sink = ListEventSink()
+    text_sink = ListEventSink()
+    bot = _make_open_order_guardrail_bot()
+    bot.exchange = "bybit"
+    bot.user = "user_01"
+    bot.bot_id = "bot_01"
+    bot.live_event_console_enabled = True
+    bot._live_event_current_cycle_id = "cy_open_orders_added"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[structured_sink],
+        monitor_sinks=[monitor_sink],
+        console_sink=console_sink,
+        text_sink=text_sink,
+    )
+    bot.open_orders = {}
+    bot.order_matches_recent_execution = lambda _order, max_age_ms=None: True
+    added_orders = _open_orders_snapshot_orders("added", 21)
+
+    with caplog.at_level(logging.INFO):
+        assert await Passivbot._apply_open_orders_snapshot(bot, added_orders) is True
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+
+    events = [
+        event
+        for event in structured_sink.events
+        if event.event_type == EventTypes.OPEN_ORDERS_SNAPSHOT_DELTA
+    ]
+    assert len(events) == 1
+    event = events[0]
+    assert event.event_type == EventTypes.OPEN_ORDERS_SNAPSHOT_DELTA
+    assert event.level == "info"
+    assert event.component == "orders.snapshot"
+    assert event.tags == (EventTags.ORDER, EventTags.SNAPSHOT)
+    assert event.cycle_id == "cy_open_orders_added"
+    assert event.status is None
+    assert event.reason_code == ReasonCodes.OPEN_ORDERS_SNAPSHOT_DELTA
+    assert event.data == {"direction": "added", "order_count": 21}
+    assert "id" not in event.data
+    assert "symbol" not in event.data
+    assert event in monitor_sink.events
+    assert console_sink.events == [event]
+    assert text_sink.events == [event]
+    assert format_console_event(event) == (
+        "[order] cycle=cy_open_orders_added direction=added order_count=21 "
+        "reason=open_orders_snapshot_delta"
+    )
+    assert "[order] added 21 orders" not in [
+        record.getMessage() for record in caplog.records
+    ]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+async def test_large_removed_open_orders_snapshot_delta_event_preserves_guardrails():
+    structured_sink = ListEventSink()
+    bot = _make_open_order_guardrail_bot(epoch=5)
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[structured_sink], monitor_sinks=[]
+    )
+    removed_orders = _open_orders_snapshot_orders("removed", 21)
+    bot.open_orders = {"BTC/USDT:USDT": removed_orders}
+    bot.fetched_open_orders = list(removed_orders)
+    bot.order_matches_bot_cancellation = lambda _order: False
+    bot.order_was_recently_cancelled = lambda _order: 0.0
+
+    assert (
+        await Passivbot._apply_open_orders_snapshot(
+            bot, [], allow_followup_positions_refresh=False
+        )
+        is True
+    )
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+
+    event = next(
+        event
+        for event in structured_sink.events
+        if event.event_type == EventTypes.OPEN_ORDERS_SNAPSHOT_DELTA
+    )
+    assert event.event_type == EventTypes.OPEN_ORDERS_SNAPSHOT_DELTA
+    assert event.data == {"direction": "removed", "order_count": 21}
+    assert bot.open_orders == {}
+    assert bot.execution_scheduled is True
+    assert bot.state_change_detected_by_symbol == {"BTC/USDT:USDT"}
+    assert bot._authoritative_pending_confirmations == {
+        surface: 6 for surface in ACCOUNT_SURFACES
+    }
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("direction", ["added", "removed"])
+async def test_open_orders_snapshot_delta_uses_strictly_greater_than_twenty_threshold(
+    direction,
+):
+    bot = _make_open_order_guardrail_bot()
+    emitted = []
+    logged_orders = []
+    bot._emit_open_orders_snapshot_delta_event = lambda **kwargs: emitted.append(kwargs)
+    bot.log_order_action = lambda *args, **kwargs: logged_orders.append((args, kwargs))
+    orders = _open_orders_snapshot_orders(direction, 20)
+    if direction == "added":
+        bot.open_orders = {}
+        bot.order_matches_recent_execution = lambda _order, max_age_ms=None: True
+        snapshot = orders
+    else:
+        bot.open_orders = {"BTC/USDT:USDT": orders}
+        bot.order_matches_bot_cancellation = lambda _order: True
+        bot.order_was_recently_cancelled = lambda _order: 0.0
+        snapshot = []
+
+    assert await Passivbot._apply_open_orders_snapshot(bot, snapshot) is True
+
+    assert emitted == []
+    assert len(logged_orders) == 20
+
+
+@pytest.mark.asyncio
+async def test_open_orders_snapshot_delta_console_sink_failure_does_not_change_reconciliation():
+    class FailingConsoleSink:
+        def write(self, _event):
+            raise OSError("console unavailable")
+
+    bot = _make_open_order_guardrail_bot(epoch=7)
+    bot.live_event_console_enabled = True
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[],
+        monitor_sinks=[],
+        console_sink=FailingConsoleSink(),
+    )
+    removed_orders = _open_orders_snapshot_orders("removed", 21)
+    bot.open_orders = {"BTC/USDT:USDT": removed_orders}
+    bot.fetched_open_orders = list(removed_orders)
+    bot.order_matches_bot_cancellation = lambda _order: False
+    bot.order_was_recently_cancelled = lambda _order: 0.0
+
+    assert (
+        await Passivbot._apply_open_orders_snapshot(
+            bot, [], allow_followup_positions_refresh=False
+        )
+        is True
+    )
+
+    assert bot.open_orders == {}
+    assert bot.execution_scheduled is True
+    assert bot.state_change_detected_by_symbol == {"BTC/USDT:USDT"}
+    assert bot._authoritative_pending_confirmations == {
+        surface: 8 for surface in ACCOUNT_SURFACES
+    }
+    assert bot._live_event_pipeline.sink_error_counters["console"] >= 1
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+async def test_large_open_orders_snapshot_delta_keeps_legacy_console_without_pipeline(caplog):
+    bot = _make_open_order_guardrail_bot()
+    bot.live_event_console_enabled = False
+    bot._live_event_pipeline = None
+    bot.open_orders = {}
+    bot.order_matches_recent_execution = lambda _order, max_age_ms=None: True
+    added_orders = _open_orders_snapshot_orders("added", 21)
+
+    with caplog.at_level(logging.INFO):
+        assert await Passivbot._apply_open_orders_snapshot(bot, added_orders) is True
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert "[order] added 21 orders" in messages
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- replace the two legacy bulk open-order snapshot INFO lines with one bounded `open_orders.snapshot_delta` event per qualifying direction
- retain only `direction` and `order_count`, route the event through structured, monitor, console, and text sinks, and keep a single `[order]` legacy fallback when the structured console is unavailable
- preserve the exact `>20` threshold, smaller per-order logging, reconciliation/guardrail behavior, and record the PR #1340 VPS5 deploy evidence

## Validation

- 255 `tests/test_passivbot_balance_split.py` tests passed
- 128 `tests/test_live_event_bus.py` tests passed
- 94 `tests/test_passivbot_monitor.py` tests passed
- generated live-event registry is current and its regression test passed
- AI docs check: 0 errors; one existing repository word-count warning
- Python compilation and `git diff --check` passed

## Boundaries

This is a logging migration only. It does not change exchange requests, snapshot contents, order classification, authoritative confirmations, balance handling, planning, strategy, orders, or risk behavior. No authenticated exchange call or trading/risk/state event was manufactured during validation.

@codex review
