### PR TITLE
Consolidate pre-create snapshot skip warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Pre-create planning and market-snapshot skips now use the existing
+  `execution.create_skipped` event as the sole normal warning when the structured console is
+  available. The bounded event retains the stable reason, stage, count, symbols, and exception
+  type without raw exception text; the legacy warning remains a fallback, and create filtering is
+  unchanged.
+
 - Large open-order snapshot deltas now emit one bounded `open_orders.snapshot_delta` INFO event per
   added or removed direction, with only the direction and order count. The event reaches structured,
   monitor, console, and text sinks with the `[order]` tag; reconciliation and order behavior are

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -162,6 +162,14 @@ are deterministic and bounded; payloads contain no order price, quantity, raw pa
 secret, or exception text. Planning failure, deferral, shutdown interruption, or diagnostic failure
 omits the event rather than publishing a misleading candidate-free result.
 
+Pre-create planning-snapshot and market-snapshot gate failures use
+`execution.create_skipped` as the sole normal console/text warning when the structured console is
+available. The event retains the code-owned reason and message plus bounded order/symbol counts,
+stage, safe detail fields, and exception type; it excludes raw exception text and arbitrary
+payloads. The legacy warning remains only when the event emitter or structured console owner is
+unavailable. Event or sink failure must not change refresh attempts, entry-block attribution, the
+returned create list, or any planning, execution, order, and risk decision.
+
 ## Connector Call Boundary
 
 `execution.create_connector_call_started` and `execution.cancel_connector_call_started` are

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,7 +22,7 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR pending, `Consolidate pre-create snapshot skip warnings`; branch
+- PR #1342, `Consolidate pre-create snapshot skip warnings`; branch
   `codex/pre-create-market-snapshot-projection`, based on canonical
   `524a6d2795015afee7cc1dd916880e4e48a6e13b`.
 - Scope: make the existing `execution.create_skipped` event the sole normal

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,30 +22,53 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR #1341, `Structure bulk open-order snapshot deltas`; branch
-  `codex/open-orders-snapshot-delta-event`, based on canonical
-  `bc31fafdbdf045f9c003e49fa6877b721c834600`.
-- Scope: replace the two legacy aggregate INFO lines emitted when an
-  authoritative open-order snapshot adds or removes more than 20 orders with
-  one bounded structured `open_orders.snapshot_delta` event per direction.
-- Behavior boundary: logging migration only. The event retains operator-visible
-  INFO/text projection and persists only the direction and count. It changes no
-  order rows, snapshot application, reconciliation classification, guardrail,
-  confirmation, balance handling, exchange access, planning, strategy, order,
-  or risk behavior.
-- Baseline: smaller deltas already retain per-order developer logs while the
-  bulk path emits only uncorrelated stdlib count lines. Config-age reporting was
-  considered but deferred because runtime currently has no canonical config
-  freshness timestamp or reload contract.
+- PR pending, `Consolidate pre-create snapshot skip warnings`; branch
+  `codex/pre-create-market-snapshot-projection`, based on canonical
+  `524a6d2795015afee7cc1dd916880e4e48a6e13b`.
+- Scope: make the existing `execution.create_skipped` event the sole normal
+  warning for pre-create planning-snapshot and market-snapshot failures when
+  the structured console is available, while retaining one bounded legacy
+  fallback when no event console owner exists.
+- Behavior boundary: logging projection only. The existing planning/market
+  snapshot gate, refresh attempts, reason codes, entry-block attribution, and
+  returned create list are unchanged. Raw exception text remains excluded from
+  structured/monitor/console/text data.
+- Baseline: all three fail-closed skip branches already emit the bounded event,
+  but also write an unconditional stdlib warning. The failed-refresh legacy
+  line additionally includes raw exception text even though the event retains
+  only its safe exception type.
 - Review gate: exact-current-head Hermes approval plus green Python/Rust CI.
   Built-in Codex automatic review is additional and every finding must be
   verified and resolved.
-- Expected VPS action: tracked-clean pull and bounded passive event/process
-  validation. Because the producer path changes, restart only the exact five
-  configured panes if the merged diff and guarded preflight warrant activation;
-  preserve `misc:0.0`.
+- Expected VPS action: tracked-clean pull plus one exact-five graceful restart
+  and bounded settled smoke because live console ownership changes; preserve
+  `misc:0.0`.
 
-## Deployed Baseline (PR #1340)
+## Deployed Baseline (PR #1341)
+
+- PR #1341 merged exact approved head
+  `d56ffc3617d9ebed4e0ebb3b98d4b6a80fb2b89c` as canonical
+  `524a6d2795015afee7cc1dd916880e4e48a6e13b` after exact-head Hermes approval,
+  green Python/Rust CI, and a finding-free built-in Codex review of the semantic
+  head; the final delta only corrected the active operator handoff.
+- VPS5 guarded-prepared tracked-clean from
+  `bc31fafdbdf045f9c003e49fa6877b721c834600` without a Rust build. The source
+  fingerprint/stamp remained
+  `691bff9683deec9382a4e96ab6a107c14145f88edd6ae2f8e2380b8ba6824449`, and the
+  compiled artifact SHA remained
+  `7611f3eff1d8702ff29d90490a1aba490db5c816e7e3f09a2c33e5c4085da023`.
+- The bounded exact-target orchestrator gracefully stopped all five old bot
+  PIDs `1066081/1066091/1066084/1066093/1066087` and relaunched only the same
+  panes with PIDs `1072420/1072429/1072423/1072432/1072426`; all five shutdown
+  and startup cohorts were complete, with no force or broad-pattern signal.
+- The 120-second settled smoke was hard-green with zero hard failures, log
+  attention matches, monitor warnings, or monitor errors. Its exact-target and
+  repository gates were green, and a final passive sample settled the five bots
+  to normal `R/R/R/R/S` states. Pane parents `%358`-`%362` remained unchanged,
+  and protected `misc:0.0` stayed `%8`/PID `434835`. No direct authenticated
+  exchange call or event was manufactured.
+
+## Previous Deployed Baseline (PR #1340)
 
 - PR #1340 merged exact reviewed head
   `d9e88d6da9282bc53a355dc3ce18a9cba6de45eb` as canonical
@@ -1734,11 +1757,10 @@ PR #1288's bounded target-identity stability, and PR #1289's plan binding are
 merged, deployed, and naturally validated without process control. PR #1290's
 pane-parent relaunch classification and the restart preparation/orchestration
 slices through PR #1309 are also merged and deployed. Later logging slices
-through PR #1340, including adjacent PR #1329, are deployed at canonical
-`bc31fafdbdf045f9c003e49fa6877b721c834600`; their current evidence is recorded
-above. Active PR #1341 migrates only the remaining bulk open-order snapshot
-count lines into the bounded structured event contract while preserving the
-existing threshold, legacy fallback, reconciliation, and trading behavior.
+through PR #1341, including adjacent PR #1329, are deployed at canonical
+`524a6d2795015afee7cc1dd916880e4e48a6e13b`; their current evidence is recorded
+above. The active pre-create snapshot slice consolidates duplicate warning
+projection without changing the existing fail-closed gate or refresh behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,27 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1340)
+## Latest Canonical Deployment (PR #1341)
+
+- PR #1341 merged exact approved head
+  `d56ffc3617d9ebed4e0ebb3b98d4b6a80fb2b89c` as canonical
+  `524a6d2795015afee7cc1dd916880e4e48a6e13b` after exact-head Hermes approval,
+  green Python/Rust CI, and a finding-free built-in Codex semantic review.
+- VPS5 guarded-prepared tracked-clean from `bc31fafdbdf` without a Rust build;
+  the Rust source fingerprint/stamp stayed
+  `691bff9683deec9382a4e96ab6a107c14145f88edd6ae2f8e2380b8ba6824449`.
+- The exact-target orchestrator gracefully stopped all five old bot PIDs and
+  relaunched only panes `%358`-`%362` as PIDs
+  `1072420/1072429/1072423/1072432/1072426`. Shutdown, startup, and stable target
+  coverage were complete, with no force or broad-pattern signal.
+- The 120-second settled smoke was hard-green with zero hard failures, log
+  attention matches, monitor warnings, or monitor errors. Final passive states
+  were `R/R/R/R/S`; the checkout remained clean, pane parents remained stable,
+  and protected `misc:0.0` stayed `%8`/PID `434835`. No direct authenticated
+  exchange call or event was manufactured. The next logging migration removes
+  duplicate legacy warnings from existing pre-create snapshot skip events.
+
+## Previous Canonical Deployment (PR #1340)
 
 - PR #1340 merged exact reviewed head
   `d9e88d6da9282bc53a355dc3ce18a9cba6de45eb` as canonical

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -1186,6 +1186,73 @@ def _console_create_filter_summary(event: LiveEvent) -> list[str]:
     return parts
 
 
+_PRE_CREATE_SKIP_CONSOLE_RECORD_LIMIT = 188
+_PRE_CREATE_SKIP_REASON_CODES = {
+    ReasonCodes.PRE_CREATE_MARKET_SNAPSHOT_UNAVAILABLE,
+    ReasonCodes.PRE_CREATE_PLANNING_SNAPSHOT_INVALID,
+}
+
+
+def _bounded_pre_create_skip_console_token(value: object, *, limit: int) -> str:
+    cleaned = _format_console_label(value)
+    token = "".join(
+        char
+        if char.isascii()
+        and char.isprintable()
+        and not char.isspace()
+        and char not in {",", "=", "|", "[", "]"}
+        else "_"
+        for char in cleaned
+    )
+    return token[:limit] or "-"
+
+
+def _format_pre_create_skip_console(event: LiveEvent) -> str:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    parts = ["[gate]", "skipped"]
+    if event.cycle_id:
+        parts.append(
+            "cycle="
+            + _bounded_pre_create_skip_console_token(event.cycle_id, limit=32)
+        )
+    order_count = _data_int(data, "order_count")
+    if order_count is not None:
+        parts.append(f"orders={min(999_999_999, max(0, order_count))}")
+    raw_symbols = data.get("symbols")
+    if isinstance(raw_symbols, (list, tuple, set)):
+        symbols = [
+            _bounded_pre_create_skip_console_token(
+                _format_position_console_coin(symbol), limit=8
+            )
+            for symbol in list(raw_symbols)[:2]
+        ]
+        if symbols:
+            omitted = min(999, max(0, len(raw_symbols) - len(symbols)))
+            suffix = f",+{omitted}" if omitted else ""
+            parts.append("symbols=" + ",".join(symbols) + suffix)
+    error_type = _data_str(data, "error_type")
+    if error_type:
+        parts.append(
+            "error_type="
+            + _bounded_pre_create_skip_console_token(error_type, limit=24)
+        )
+    if event.reason_code:
+        parts.append(
+            "reason="
+            + _bounded_pre_create_skip_console_token(event.reason_code, limit=48)
+        )
+    stage_message = {
+        "planning_snapshot": "planning snapshot invalid before create",
+        "market_snapshot_refresh": "pre-create market snapshot refresh failed",
+        "market_snapshot_validation": "pre-create market snapshots are stale",
+    }.get(_data_str(data, "stage"))
+    if stage_message:
+        candidate = " ".join((*parts, stage_message))
+        if len(candidate) <= _PRE_CREATE_SKIP_CONSOLE_RECORD_LIMIT:
+            parts.append(stage_message)
+    return " ".join(parts)[:_PRE_CREATE_SKIP_CONSOLE_RECORD_LIMIT]
+
+
 def _console_entry_gate_summary(event: LiveEvent) -> list[str]:
     data = event.data if isinstance(event.data, Mapping) else {}
     parts: list[str] = []
@@ -2745,6 +2812,11 @@ def format_console_event(event: LiveEvent) -> str:
         return format_ema_unavailable_console(event.data)
     if event.event_type == EventTypes.FORAGER_ELIGIBILITY_CHANGED:
         return format_forager_eligibility_console(event.data)
+    if (
+        event.event_type == EventTypes.EXECUTION_CREATE_SKIPPED
+        and event.reason_code in _PRE_CREATE_SKIP_REASON_CODES
+    ):
+        return _format_pre_create_skip_console(event)
     if event.event_type in {
         EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED,
         EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED,

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -1180,6 +1180,9 @@ def _console_create_filter_summary(event: LiveEvent) -> list[str]:
     allowed_protective_create = _data_int(data, "allowed_protective_create")
     if allowed_protective_create is not None:
         parts.append(f"allow_protective_create={allowed_protective_create}")
+    error_type = _data_str(data, "error_type")
+    if error_type:
+        parts.append(f"error_type={error_type[:64]}")
     return parts
 
 

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -4031,7 +4031,7 @@ def emit_execution_create_filter_event(
     level: str = "debug",
     message: str | None = None,
     data: dict | None = None,
-) -> None:
+) -> bool:
     """Emit a bounded event for create orders filtered before exchange write."""
     try:
         order_wave_id, _action_id = _execution_event_ids(
@@ -4058,7 +4058,7 @@ def emit_execution_create_filter_event(
             extra=data,
             wave=wave,
         )
-        bot._emit_live_event(
+        emitted = bot._emit_live_event(
             event_type,
             level=level,
             component="execution.create_filter",
@@ -4070,14 +4070,16 @@ def emit_execution_create_filter_event(
             message=message,
             data={key: value for key, value in payload.items() if value is not None},
         )
+        return emitted is not None
     except Exception as exc:
         logging.debug(
-            "[event] failed to emit execution create filter event type=%s status=%s reason=%s: %s",
+            "[event] failed to emit execution create filter event type=%s status=%s reason=%s error_type=%s",
             event_type,
             status,
             reason_code,
-            exc,
+            type(exc).__name__,
         )
+        return False
 
 
 def emit_initial_entry_eligibility_event(

--- a/src/live/market_data.py
+++ b/src/live/market_data.py
@@ -78,7 +78,7 @@ def _emit_pre_create_skip_event(
     structured_console_available = _pre_create_skip_structured_console_available(bot)
     details_count = len(details or [])
     try:
-        emit_filter_event(
+        emitted = emit_filter_event(
             event_type=EventTypes.EXECUTION_CREATE_SKIPPED,
             status="skipped",
             reason_code=reason_code,
@@ -101,7 +101,7 @@ def _emit_pre_create_skip_event(
             type(exc).__name__,
         )
         return False
-    return structured_console_available
+    return structured_console_available and bool(emitted)
 
 
 def _record_fresh_entry_blocks(bot, orders: list[dict], reason: str) -> None:

--- a/src/live/market_data.py
+++ b/src/live/market_data.py
@@ -51,6 +51,16 @@ def _bounded_pre_create_skip_details(details: list[dict] | None) -> list[dict]:
     return bounded
 
 
+def _pre_create_skip_structured_console_available(bot) -> bool:
+    pipeline = getattr(bot, "_live_event_pipeline", None)
+    return bool(
+        callable(getattr(bot, "_emit_execution_create_filter_event", None))
+        and getattr(bot, "live_event_console_enabled", False)
+        and callable(getattr(pipeline, "emit", None))
+        and getattr(pipeline, "console_sink", None) is not None
+    )
+
+
 def _emit_pre_create_skip_event(
     bot,
     *,
@@ -61,27 +71,37 @@ def _emit_pre_create_skip_event(
     message: str,
     details: list[dict] | None = None,
     error_type: str | None = None,
-) -> None:
+) -> bool:
     emit_filter_event = getattr(bot, "_emit_execution_create_filter_event", None)
     if not callable(emit_filter_event):
-        return
+        return False
+    structured_console_available = _pre_create_skip_structured_console_available(bot)
     details_count = len(details or [])
-    emit_filter_event(
-        event_type=EventTypes.EXECUTION_CREATE_SKIPPED,
-        status="skipped",
-        reason_code=reason_code,
-        order_count=len(orders),
-        symbols=symbols,
-        level="warning",
-        message=message,
-        data={
-            "stage": stage,
-            "details": _bounded_pre_create_skip_details(details),
-            "details_count": details_count,
-            "details_truncated": details_count > 8,
-            "error_type": error_type,
-        },
-    )
+    try:
+        emit_filter_event(
+            event_type=EventTypes.EXECUTION_CREATE_SKIPPED,
+            status="skipped",
+            reason_code=reason_code,
+            order_count=len(orders),
+            symbols=symbols,
+            level="warning",
+            message=message,
+            data={
+                "stage": stage,
+                "details": _bounded_pre_create_skip_details(details),
+                "details_count": details_count,
+                "details_truncated": details_count > 8,
+                "error_type": error_type,
+            },
+        )
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit pre-create skip event stage=%s error_type=%s",
+            stage,
+            type(exc).__name__,
+        )
+        return False
+    return structured_console_available
 
 
 def _record_fresh_entry_blocks(bot, orders: list[dict], reason: str) -> None:
@@ -149,12 +169,7 @@ async def filter_fresh_market_snapshot_creations(
             in refreshable_reasons
             for item in planning_snapshot_invalid
         ):
-            logging.warning(
-                "[market] skipping order creation; planning snapshot invalid before create | symbols=%s details=%s",
-                bot._log_symbols(symbols, limit=12),
-                bot._log_compact_symbol_payload(planning_snapshot_invalid[:8]),
-            )
-            _emit_pre_create_skip_event(
+            structured_console_owned = _emit_pre_create_skip_event(
                 bot,
                 reason_code=ReasonCodes.PRE_CREATE_PLANNING_SNAPSHOT_INVALID,
                 orders=orders,
@@ -163,6 +178,12 @@ async def filter_fresh_market_snapshot_creations(
                 message="create orders skipped because planning snapshot is invalid before create",
                 details=planning_snapshot_invalid,
             )
+            if not structured_console_owned:
+                logging.warning(
+                    "[market] skipping order creation; planning snapshot invalid before create | symbols=%s details=%s",
+                    bot._log_symbols(symbols, limit=12),
+                    bot._log_compact_symbol_payload(planning_snapshot_invalid[:8]),
+                )
             _record_fresh_entry_blocks(
                 bot, orders, "pre_create_planning_snapshot_invalid"
             )
@@ -182,13 +203,7 @@ async def filter_fresh_market_snapshot_creations(
         bot._record_market_snapshot_surface(symbols, snapshots)
         invalid = bot._market_snapshot_signature_invalid(symbols)
     except Exception as exc:
-        logging.warning(
-            "[market] skipping order creation; failed pre-create market snapshot refresh | symbols=%s error_type=%s error=%s",
-            bot._log_symbols(symbols, limit=12),
-            type(exc).__name__,
-            exc,
-        )
-        _emit_pre_create_skip_event(
+        structured_console_owned = _emit_pre_create_skip_event(
             bot,
             reason_code=ReasonCodes.PRE_CREATE_MARKET_SNAPSHOT_UNAVAILABLE,
             orders=orders,
@@ -197,17 +212,18 @@ async def filter_fresh_market_snapshot_creations(
             message="create orders skipped because pre-create market snapshot refresh failed",
             error_type=type(exc).__name__,
         )
+        if not structured_console_owned:
+            logging.warning(
+                "[market] skipping order creation; failed pre-create market snapshot refresh | symbols=%s error_type=%s",
+                bot._log_symbols(symbols, limit=12),
+                type(exc).__name__,
+            )
         _record_fresh_entry_blocks(
             bot, orders, "pre_create_market_snapshot_unavailable"
         )
         return []
     if invalid:
-        logging.warning(
-            "[market] skipping order creation; stale pre-create market snapshots | symbols=%s details=%s",
-            bot._log_symbols(symbols, limit=12),
-            bot._log_compact_symbol_payload(invalid[:8]),
-        )
-        _emit_pre_create_skip_event(
+        structured_console_owned = _emit_pre_create_skip_event(
             bot,
             reason_code=ReasonCodes.PRE_CREATE_MARKET_SNAPSHOT_UNAVAILABLE,
             orders=orders,
@@ -216,6 +232,12 @@ async def filter_fresh_market_snapshot_creations(
             message="create orders skipped because pre-create market snapshots are stale",
             details=invalid,
         )
+        if not structured_console_owned:
+            logging.warning(
+                "[market] skipping order creation; stale pre-create market snapshots | symbols=%s details=%s",
+                bot._log_symbols(symbols, limit=12),
+                bot._log_compact_symbol_payload(invalid[:8]),
+            )
         _record_fresh_entry_blocks(
             bot, orders, "pre_create_market_snapshot_unavailable"
         )

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -2209,6 +2209,86 @@ def test_console_format_summarizes_create_filter_payload():
     )
 
 
+def test_console_format_bounds_pre_create_skip_with_error_and_many_symbols():
+    event = LiveEvent(
+        EventTypes.EXECUTION_CREATE_SKIPPED,
+        status="skipped",
+        cycle_id="cy_123456",
+        reason_code=ReasonCodes.PRE_CREATE_MARKET_SNAPSHOT_UNAVAILABLE,
+        message="unbounded message " * 100,
+        data={
+            "stage": "market_snapshot_refresh",
+            "order_count": 4,
+            "symbols": [
+                "BTC/USDT:USDT",
+                "ETH/USDT:USDT",
+                "SOL/USDT:USDT",
+                "XRP/USDT:USDT",
+            ],
+            "error_type": "ExchangeNotAvailable",
+        },
+    )
+
+    rendered = format_console_event(event)
+    longest_prefix = "2026-07-15T23:45:40Z WARNING  [hyperliquid] "
+
+    assert len(longest_prefix + rendered) <= 240
+    assert "cycle=cy_123456" in rendered
+    assert "orders=4" in rendered
+    assert "symbols=BTC,ETH,+2" in rendered
+    assert "error_type=ExchangeNotAvailable" in rendered
+    assert "reason=pre_create_market_snapshot_unavailable" in rendered
+    assert "pre-create market snapshot refresh failed" in rendered
+    assert "unbounded message" not in rendered
+
+    pathological = LiveEvent(
+        EventTypes.EXECUTION_CREATE_SKIPPED,
+        status="skipped",
+        cycle_id="C" * 1_000,
+        reason_code=ReasonCodes.PRE_CREATE_MARKET_SNAPSHOT_UNAVAILABLE,
+        message="M" * 10_000,
+        data={
+            "stage": "market_snapshot_refresh",
+            "order_count": 10**20,
+            "symbols": ["S" * 1_000] * 12,
+            "error_type": "E" * 1_000,
+        },
+    )
+
+    pathological_rendered = format_console_event(pathological)
+    assert len(longest_prefix + pathological_rendered) <= 240
+    assert "cycle=" + "C" * 32 in pathological_rendered
+    assert "orders=999999999" in pathological_rendered
+    assert "symbols=" + "S" * 8 + "," + "S" * 8 + ",+10" in pathological_rendered
+    assert "error_type=" + "E" * 24 in pathological_rendered
+    assert "reason=pre_create_market_snapshot_unavailable" in pathological_rendered
+
+
+def test_create_filter_emitter_reports_whether_live_event_emission_succeeded():
+    class Bot:
+        live_event_debug_profiles = ()
+
+        def _current_live_event_cycle_id(self):
+            return "cy_1"
+
+        def _emit_live_event(self, *_args, **_kwargs):
+            return None
+
+    bot = Bot()
+    kwargs = {
+        "event_type": EventTypes.EXECUTION_CREATE_SKIPPED,
+        "status": "skipped",
+        "reason_code": ReasonCodes.PRE_CREATE_MARKET_SNAPSHOT_UNAVAILABLE,
+        "order_count": 1,
+        "symbols": ["BTC/USDT:USDT"],
+    }
+
+    assert live_event_emitters.emit_execution_create_filter_event(bot, **kwargs) is False
+
+    bot._emit_live_event = lambda *_args, **_kwargs: LiveEvent("test.event")
+    assert live_event_emitters.emit_execution_create_filter_event(bot, **kwargs) is True
+
+
 def test_console_format_summarizes_low_balance_create_skip():
     event = LiveEvent(
         EventTypes.EXECUTION_CREATE_SKIPPED,

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -8788,16 +8788,23 @@ def test_staged_execution_defer_survives_planning_unavailable_emit_failure():
 
 
 @pytest.mark.asyncio
-async def test_pre_create_snapshot_filter_blocks_stale_market_snapshots():
+async def test_pre_create_snapshot_filter_blocks_stale_market_snapshots(caplog):
     bot = Passivbot.__new__(Passivbot)
     bot.config = {"live": {}}
     bot.exchange = "bybit"
     bot.freshness_ledger = FreshnessLedger(now_ms=0)
     bot._authoritative_refresh_epoch = 1
     sink = ListEventSink()
+    monitor_sink = ListEventSink()
+    console_sink = ListEventSink()
+    text_sink = ListEventSink()
+    bot.live_event_console_enabled = True
     bot._live_event_current_cycle_id = "cy_stale_pre_create_market_snapshot"
     bot._live_event_pipeline = LiveEventPipeline(
-        structured_sinks=[sink], monitor_sinks=[]
+        structured_sinks=[sink],
+        monitor_sinks=[monitor_sink],
+        console_sink=console_sink,
+        text_sink=text_sink,
     )
     symbol = "BTC/USDT:USDT"
 
@@ -8847,7 +8854,8 @@ async def test_pre_create_snapshot_filter_blocks_stale_market_snapshots():
         }
     ]
 
-    assert await bot._filter_fresh_market_snapshot_creations(orders) == []
+    with caplog.at_level(logging.WARNING):
+        assert await bot._filter_fresh_market_snapshot_creations(orders) == []
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
     events = [
         event
@@ -8868,20 +8876,40 @@ async def test_pre_create_snapshot_filter_blocks_stale_market_snapshots():
     assert event.data["details"][0]["reason"] == "stale"
     assert event.data["details"][0]["age_ms"] >= 20_000
     assert event.data["details"][0]["max_age_ms"] == 10_000
+    assert monitor_sink.events == [event]
+    assert console_sink.events == [event]
+    assert text_sink.events == [event]
+    console_message = format_console_event(event)
+    assert "reason=pre_create_market_snapshot_unavailable" in console_message
+    assert "create orders skipped because pre-create market snapshots are stale" in (
+        console_message
+    )
+    assert len(console_message) <= 240
+    assert not any(
+        "stale pre-create market snapshots" in record.getMessage()
+        for record in caplog.records
+    )
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
 @pytest.mark.asyncio
-async def test_pre_create_snapshot_filter_emits_failed_refresh_skip_event():
+async def test_pre_create_snapshot_filter_emits_failed_refresh_skip_event(caplog):
     bot = Passivbot.__new__(Passivbot)
     bot.config = {"live": {}}
     bot.exchange = "bybit"
     bot.freshness_ledger = FreshnessLedger(now_ms=0)
     bot._authoritative_refresh_epoch = 1
     sink = ListEventSink()
+    monitor_sink = ListEventSink()
+    console_sink = ListEventSink()
+    text_sink = ListEventSink()
+    bot.live_event_console_enabled = True
     bot._live_event_current_cycle_id = "cy_failed_pre_create_market_snapshot"
     bot._live_event_pipeline = LiveEventPipeline(
-        structured_sinks=[sink], monitor_sinks=[]
+        structured_sinks=[sink],
+        monitor_sinks=[monitor_sink],
+        console_sink=console_sink,
+        text_sink=text_sink,
     )
     symbol = "BTC/USDT:USDT"
     now_ms = passivbot_module.utc_ms()
@@ -8921,7 +8949,8 @@ async def test_pre_create_snapshot_filter_emits_failed_refresh_skip_event():
         }
     ]
 
-    assert await bot._filter_fresh_market_snapshot_creations(orders) == []
+    with caplog.at_level(logging.WARNING):
+        assert await bot._filter_fresh_market_snapshot_creations(orders) == []
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
     events = [
         event
@@ -8939,6 +8968,18 @@ async def test_pre_create_snapshot_filter_emits_failed_refresh_skip_event():
     assert event.data["stage"] == "market_snapshot_refresh"
     assert event.data["error_type"] == "RuntimeError"
     assert "exchange unavailable" not in json.dumps(event.data)
+    assert monitor_sink.events == [event]
+    assert console_sink.events == [event]
+    assert text_sink.events == [event]
+    console_message = format_console_event(event)
+    assert "error_type=RuntimeError" in console_message
+    assert "reason=pre_create_market_snapshot_unavailable" in console_message
+    assert "exchange unavailable" not in console_message
+    assert len(console_message) <= 240
+    assert not any(
+        "failed pre-create market snapshot refresh" in record.getMessage()
+        for record in caplog.records
+    )
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
@@ -9215,14 +9256,23 @@ async def test_pre_create_snapshot_filter_disables_limit_order_distance_guard(
 
 
 @pytest.mark.asyncio
-async def test_pre_create_snapshot_filter_blocks_non_market_planning_invalidation():
+async def test_pre_create_snapshot_filter_blocks_non_market_planning_invalidation(
+    caplog,
+):
     bot = Passivbot.__new__(Passivbot)
     bot.config = {"live": {}}
     bot.exchange = "bybit"
     sink = ListEventSink()
+    monitor_sink = ListEventSink()
+    console_sink = ListEventSink()
+    text_sink = ListEventSink()
+    bot.live_event_console_enabled = True
     bot._live_event_current_cycle_id = "cy_invalid_pre_create_planning_snapshot"
     bot._live_event_pipeline = LiveEventPipeline(
-        structured_sinks=[sink], monitor_sinks=[]
+        structured_sinks=[sink],
+        monitor_sinks=[monitor_sink],
+        console_sink=console_sink,
+        text_sink=text_sink,
     )
     symbol = "BTC/USDT:USDT"
     now_ms = passivbot_module.utc_ms()
@@ -9272,7 +9322,8 @@ async def test_pre_create_snapshot_filter_blocks_non_market_planning_invalidatio
         }
     ]
 
-    assert await bot._filter_fresh_market_snapshot_creations(orders) == []
+    with caplog.at_level(logging.WARNING):
+        assert await bot._filter_fresh_market_snapshot_creations(orders) == []
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
     events = [
         event
@@ -9291,7 +9342,109 @@ async def test_pre_create_snapshot_filter_blocks_non_market_planning_invalidatio
     assert event.data["details_count"] == 1
     assert event.data["details"][0]["surface"] == "positions"
     assert event.data["details"][0]["reason"] == "surface_epoch_too_old"
+    assert monitor_sink.events == [event]
+    assert console_sink.events == [event]
+    assert text_sink.events == [event]
+    console_message = format_console_event(event)
+    assert "reason=pre_create_planning_snapshot_invalid" in console_message
+    assert "create orders skipped because planning snapshot is invalid" in console_message
+    assert len(console_message) <= 240
+    assert not any(
+        "planning snapshot invalid before create" in record.getMessage()
+        for record in caplog.records
+    )
     assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("emitter_mode", ["missing", "raises"])
+async def test_pre_create_snapshot_filter_keeps_legacy_warning_without_event_owner(
+    caplog, emitter_mode
+):
+    def invalid_for_creations(_symbols):
+        return [
+            {
+                "surface": "positions",
+                "reason": "surface_epoch_too_old",
+                "epoch": 1,
+                "min_epoch": 2,
+            }
+        ]
+
+    def raising_emitter(**_kwargs):
+        raise RuntimeError("event pipeline unavailable with raw detail")
+
+    bot = SimpleNamespace(
+        _current_planning_snapshot_invalid_for_creations=invalid_for_creations,
+        _emit_execution_create_filter_event=(
+            None if emitter_mode == "missing" else raising_emitter
+        ),
+        _fresh_entry_eligibility_trace=None,
+        _live_event_pipeline=(
+            None
+            if emitter_mode == "missing"
+            else SimpleNamespace(emit=lambda _event: None, console_sink=object())
+        ),
+        live_event_console_enabled=emitter_mode == "raises",
+        _log_symbols=lambda symbols, limit=12: ",".join(symbols[:limit]),
+        _log_compact_symbol_payload=lambda _details: "positions:surface_epoch_too_old",
+    )
+    orders = [
+        {
+            "symbol": "BTC/USDT:USDT",
+            "side": "buy",
+            "position_side": "long",
+            "qty": 1.0,
+            "price": 99.0,
+        }
+    ]
+
+    with caplog.at_level(logging.WARNING):
+        assert await Passivbot._filter_fresh_market_snapshot_creations(bot, orders) == []
+
+    legacy_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if "planning snapshot invalid before create" in record.getMessage()
+    ]
+    assert legacy_messages == [
+        "[market] skipping order creation; planning snapshot invalid before create | "
+        "symbols=BTC/USDT:USDT details=positions:surface_epoch_too_old"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_pre_create_snapshot_refresh_legacy_fallback_excludes_raw_error(caplog):
+    async def failing_snapshots(*_args, **_kwargs):
+        raise RuntimeError("exchange unavailable with raw account detail")
+
+    bot = SimpleNamespace(
+        _current_planning_snapshot_invalid_for_creations=lambda _symbols: [],
+        _emit_execution_create_filter_event=None,
+        _fresh_entry_eligibility_trace=None,
+        _get_live_market_snapshots=failing_snapshots,
+        _live_market_snapshot_max_age_ms=lambda: 10_000,
+        _log_symbols=lambda symbols, limit=12: ",".join(symbols[:limit]),
+    )
+    orders = [
+        {
+            "symbol": "BTC/USDT:USDT",
+            "side": "buy",
+            "position_side": "long",
+            "qty": 1.0,
+            "price": 99.0,
+        }
+    ]
+
+    with caplog.at_level(logging.WARNING):
+        assert await Passivbot._filter_fresh_market_snapshot_creations(bot, orders) == []
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert messages == [
+        "[market] skipping order creation; failed pre-create market snapshot refresh | "
+        "symbols=BTC/USDT:USDT error_type=RuntimeError"
+    ]
+    assert "raw account detail" not in "\n".join(messages)
 
 
 def _make_open_order_guardrail_bot(*, epoch: int = 3):

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -8881,10 +8881,8 @@ async def test_pre_create_snapshot_filter_blocks_stale_market_snapshots(caplog):
     assert text_sink.events == [event]
     console_message = format_console_event(event)
     assert "reason=pre_create_market_snapshot_unavailable" in console_message
-    assert "create orders skipped because pre-create market snapshots are stale" in (
-        console_message
-    )
-    assert len(console_message) <= 240
+    assert "pre-create market snapshots are stale" in console_message
+    assert len("2026-07-15T23:45:40Z WARNING  [hyperliquid] " + console_message) <= 240
     assert not any(
         "stale pre-create market snapshots" in record.getMessage()
         for record in caplog.records
@@ -8975,7 +8973,7 @@ async def test_pre_create_snapshot_filter_emits_failed_refresh_skip_event(caplog
     assert "error_type=RuntimeError" in console_message
     assert "reason=pre_create_market_snapshot_unavailable" in console_message
     assert "exchange unavailable" not in console_message
-    assert len(console_message) <= 240
+    assert len("2026-07-15T23:45:40Z WARNING  [hyperliquid] " + console_message) <= 240
     assert not any(
         "failed pre-create market snapshot refresh" in record.getMessage()
         for record in caplog.records
@@ -9347,8 +9345,8 @@ async def test_pre_create_snapshot_filter_blocks_non_market_planning_invalidatio
     assert text_sink.events == [event]
     console_message = format_console_event(event)
     assert "reason=pre_create_planning_snapshot_invalid" in console_message
-    assert "create orders skipped because planning snapshot is invalid" in console_message
-    assert len(console_message) <= 240
+    assert "planning snapshot invalid before create" in console_message
+    assert len("2026-07-15T23:45:40Z WARNING  [hyperliquid] " + console_message) <= 240
     assert not any(
         "planning snapshot invalid before create" in record.getMessage()
         for record in caplog.records
@@ -9357,7 +9355,7 @@ async def test_pre_create_snapshot_filter_blocks_non_market_planning_invalidatio
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("emitter_mode", ["missing", "raises"])
+@pytest.mark.parametrize("emitter_mode", ["missing", "raises", "returns_none"])
 async def test_pre_create_snapshot_filter_keeps_legacy_warning_without_event_owner(
     caplog, emitter_mode
 ):
@@ -9374,18 +9372,24 @@ async def test_pre_create_snapshot_filter_keeps_legacy_warning_without_event_own
     def raising_emitter(**_kwargs):
         raise RuntimeError("event pipeline unavailable with raw detail")
 
+    def swallowed_emitter(**_kwargs):
+        return None
+
+    emitters = {
+        "missing": None,
+        "raises": raising_emitter,
+        "returns_none": swallowed_emitter,
+    }
     bot = SimpleNamespace(
         _current_planning_snapshot_invalid_for_creations=invalid_for_creations,
-        _emit_execution_create_filter_event=(
-            None if emitter_mode == "missing" else raising_emitter
-        ),
+        _emit_execution_create_filter_event=emitters[emitter_mode],
         _fresh_entry_eligibility_trace=None,
         _live_event_pipeline=(
             None
             if emitter_mode == "missing"
             else SimpleNamespace(emit=lambda _event: None, console_sink=object())
         ),
-        live_event_console_enabled=emitter_mode == "raises",
+        live_event_console_enabled=emitter_mode != "missing",
         _log_symbols=lambda symbols, limit=12: ",".join(symbols[:limit]),
         _log_compact_symbol_payload=lambda _details: "positions:surface_epoch_too_old",
     )


### PR DESCRIPTION
@codex review

## Scope

Category: observability producer / console projection.

- Make the existing `execution.create_skipped` event the sole normal
  console/text warning for pre-create planning-snapshot and market-snapshot
  failures when the structured console owner is available.
- Retain exactly one bounded legacy warning when the event emitter or
  structured console owner is unavailable.
- Project the already-bounded exception type for failed refreshes while
  removing raw exception text from the legacy fallback.
- Record PR #1341's exact merge, VPS5 restart, and settled-smoke evidence.

## Behavior Boundary

This changes logging ownership only. It does not change planning-snapshot or
market-snapshot validation, refresh attempts, fail-closed returns, reason
codes, fresh-entry block attribution, exchange calls, planning, reconciliation,
order construction, execution, strategy, or risk behavior. Event/sink failure
remains isolated from the trading path.

The stale-planning-snapshot refresh progress INFO remains unchanged. No event
type, reason code, route, schema, configuration, dependency, Rust source, or
generated registry value changes.

## Validation

Passed on base `524a6d2795015afee7cc1dd916880e4e48a6e13b`:

- complete `tests/test_passivbot_balance_split.py`
- complete `tests/test_live_event_bus.py`
- complete `tests/test_passivbot_monitor.py`
- complete `tests/test_fresh_entry_eligibility_integration.py`
- `tests/test_ai_docs.py` and `tests/test_live_event_registry_docs.py`
- Python compilation for both changed modules and the focused test file
- live-event registry generation check with `PYTHONPATH=src`
- AI-doc checker: zero errors, one existing word-count warning
- `git diff --check`

Focused regressions prove one structured/monitor/console/text event, no legacy
duplicate for all three skip branches, console records within 240 characters,
no raw exception text, unchanged reason/stage/cycle/count/symbol evidence, and
legacy fallback for both missing and throwing emitters.

## Deployment

Expected VPS action after merge: guarded tracked-clean pull, then one graceful
restart of only the exact five configured `passivbot` panes and a bounded
settled smoke. Preserve `misc:0.0`; no broad process-pattern signal, direct
authenticated exchange probe, or manufactured trading/state event.

PR #1341 is already deployed as canonical `524a6d2795…`. Its exact-five
orchestrator completed hard-green, the 120-second settled smoke had zero hard
failures/log attention/monitor warnings or errors, final states settled to
`R/R/R/R/S`, and `misc:0.0` remained `%8`/PID `434835`.

## Reviewer Focus

- structured-console ownership versus legacy fallback
- emitter/sink failure isolation and unchanged fail-closed create filtering
- absence of raw exception text and duplicate human warnings
- bounded console formatting and unchanged correlation/reason evidence

Residual risk is limited to observing a natural pre-create snapshot failure
after deployment; no such event will be manufactured.
