### PR TITLE
Redact EMA diagnostics at the producer boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable user-facing changes will be documented in this file.
 
 - The `ema.unavailable` and `ema.fallback_used` events and their dedicated legacy summaries now
   retain only code-owned reason classifications, bounded EMA/error types, symbols, spans, ages,
-  and counts. These paths no longer retain arbitrary exception or fallback-reason text; EMA
+  and counts. Malformed typed values are normalized or omitted, adjacent EMA failure logs retain
+  only exception type, and a bounded legacy warning remains when the structured event was not
+  emitted. These paths no longer retain arbitrary exception or fallback-reason text; EMA
   calculation, fallback selection, candidate availability, and trading behavior are unchanged.
 
 - Noncritical market-snapshot diagnostic skips now use the existing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- The `ema.unavailable` and `ema.fallback_used` events and their dedicated legacy summaries now
+  retain only code-owned reason classifications, bounded EMA/error types, symbols, spans, ages,
+  and counts. These paths no longer retain arbitrary exception or fallback-reason text; EMA
+  calculation, fallback selection, candidate availability, and trading behavior are unchanged.
+
 - Noncritical market-snapshot diagnostic skips now use the existing
   `market.snapshot_diagnostic_skipped` event as the sole normal warning when the structured console
   is available. The bounded event and legacy fallback retain only stable context and exception type;

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -67,6 +67,21 @@ only when the event emitter or structured console owner is unavailable. Event or
 not alter position/balance refresh, state mutation, scheduling, retries, planning, orders, risk, or
 the caller's existing decision to continue after this noncritical diagnostic failure.
 
+## EMA Diagnostic Redaction
+
+`ema.unavailable` and `ema.fallback_used` retain only code-owned reason classifications, bounded
+EMA types (`m1_close`, `m1_volume`, `m1_log_range`, or `h1_log_range`), exception types, symbols,
+spans, ages, fallback counts, and cycle correlation. Their normal and debug payloads never retain
+arbitrary exception messages, URLs, credentials, raw fallback reasons, or reason fragments parsed
+from exception text. Console formatting derives EMA identity from an explicit safe field rather
+than inspecting an exception message.
+
+When structured console ownership is unavailable, the bounded legacy warning follows the same
+redaction boundary. Event or sink failure must not alter EMA calculation, cached fallback
+selection, candidate availability, scheduling, retries, planning, orders, risk, or caller control
+flow. Downstream smoke and incident redaction remains defense in depth, not the primary payload
+boundary.
+
 The generated value reference is `../generated/live_event_registry.md`.
 
 ## Runtime Identity

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -74,10 +74,13 @@ EMA types (`m1_close`, `m1_volume`, `m1_log_range`, or `h1_log_range`), exceptio
 spans, ages, fallback counts, and cycle correlation. Their normal and debug payloads never retain
 arbitrary exception messages, URLs, credentials, raw fallback reasons, or reason fragments parsed
 from exception text. Console formatting derives EMA identity from an explicit safe field rather
-than inspecting an exception message.
+than inspecting an exception message. Malformed symbols and classifications normalize to bounded
+sentinels, unsupported metric names are omitted, and non-finite spans are omitted. Adjacent EMA
+failure logs retain only code-owned context and exception type.
 
-When structured console ownership is unavailable, the bounded legacy warning follows the same
-redaction boundary. Event or sink failure must not alter EMA calculation, cached fallback
+The structured event owns the normal warning only after its emitter reports success and the
+structured console owner is available. Otherwise, the bounded legacy warning remains and follows
+the same redaction boundary. Event or sink failure must not alter EMA calculation, cached fallback
 selection, candidate availability, scheduling, retries, planning, orders, risk, or caller control
 flow. Downstream smoke and incident redaction remains defense in depth, not the primary payload
 boundary.

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -79,11 +79,11 @@ sentinels, unsupported metric names are omitted, and non-finite spans are omitte
 failure logs retain only code-owned context and exception type.
 
 The structured event owns the normal warning only after its emitter reports success and the
-structured console owner is available. Otherwise, the bounded legacy warning remains and follows
-the same redaction boundary. Event or sink failure must not alter EMA calculation, cached fallback
-selection, candidate availability, scheduling, retries, planning, orders, risk, or caller control
-flow. Downstream smoke and incident redaction remains defense in depth, not the primary payload
-boundary.
+structured console owner is available. Success requires queue admission and no synchronous console
+sink failure. Otherwise, the bounded legacy warning remains and follows the same redaction
+boundary. Event or sink failure must not alter EMA calculation, cached fallback selection,
+candidate availability, scheduling, retries, planning, orders, risk, or caller control flow.
+Downstream smoke and incident redaction remains defense in depth, not the primary payload boundary.
 
 The generated value reference is `../generated/live_event_registry.md`.
 

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -80,10 +80,12 @@ failure logs retain only code-owned context and exception type.
 
 The structured event owns the normal warning only after its emitter reports success and the
 structured console owner is available. Success requires queue admission and no synchronous console
-sink failure. Otherwise, the bounded legacy warning remains and follows the same redaction
-boundary. Event or sink failure must not alter EMA calculation, cached fallback selection,
-candidate availability, scheduling, retries, planning, orders, risk, or caller control flow.
-Downstream smoke and incident redaction remains defense in depth, not the primary payload boundary.
+sink failure; these owner events defer console/text projection until after queue admission so a
+rejected event cannot produce both projections. Otherwise, the bounded legacy warning remains and
+follows the same redaction boundary. Event or sink failure must not alter EMA calculation, cached
+fallback selection, candidate availability, scheduling, retries, planning, orders, risk, or caller
+control flow. Downstream smoke and incident redaction remains defense in depth, not the primary
+payload boundary.
 
 The generated value reference is `../generated/live_event_registry.md`.
 

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -29,6 +29,9 @@ Estimated completion:
   `ema.unavailable` and `ema.fallback_used` structured, monitor, console, text,
   debug-profile, and legacy fallback paths while retaining code-owned reason
   classifications, bounded EMA/error types, symbols, spans, ages, and counts.
+  Malformed typed values normalize or drop at the producer boundary, adjacent
+  EMA failure logs retain only exception type, and legacy warnings remain when
+  the structured event was not emitted successfully.
 - Behavior boundary: observability payload and projection only. EMA
   calculation, prior-value and cached fallback selection, candidate
   availability, scheduling, retries, planning, orders, risk, and caller control

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,28 +22,50 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR #1343, `Consolidate market-snapshot diagnostic warnings`; branch
-  `codex/market-snapshot-diagnostic-projection`, based on canonical
-  `644d058f3975a2772f96bf10281f3873dca7112c`.
-- Scope: make the existing `market.snapshot_diagnostic_skipped` event the sole
-  normal console/text warning for noncritical position-change and balance
-  diagnostics when the structured console is available, while retaining one
-  bounded legacy fallback when no event console owner exists.
-- Behavior boundary: logging projection only. The existing planning/market
-  snapshot lookup, position/balance refresh, state mutation, and caller
-  continuation are unchanged. The event and fallback retain only stable
-  context and exception type, not arbitrary exception text.
-- Baseline: the helper already emits the durable bounded event, but its route is
-  console/text disabled and it always writes a second stdlib warning containing
-  raw exception text. The public emitter also swallows failures without
-  returning ownership status, so the fallback cannot currently distinguish a
-  successful event from a failed emission.
+- Pre-create slice `Redact EMA diagnostic payloads`; branch
+  `codex/ema-diagnostic-redaction`, based on canonical
+  `7e26a9062a88ecf211729d7d718fb4530630c4ba`.
+- Scope: remove arbitrary exception and fallback-reason text from
+  `ema.unavailable` and `ema.fallback_used` structured, monitor, console, text,
+  debug-profile, and legacy fallback paths while retaining code-owned reason
+  classifications, bounded EMA/error types, symbols, spans, ages, and counts.
+- Behavior boundary: observability payload and projection only. EMA
+  calculation, prior-value and cached fallback selection, candidate
+  availability, scheduling, retries, planning, orders, risk, and caller control
+  flow remain unchanged.
+- Baseline: structured payloads still retain candidate `example_error`, debug
+  `inner_reasons`, optional-drop reason text, and close-fallback reason text.
+  Human fallbacks also project raw reason or exception values, while the normal
+  console derives EMA identity by parsing the candidate exception message.
 - Review gate: exact-current-head Hermes approval plus green Python/Rust CI.
   Built-in Codex automatic review is additional and every finding must be
   verified and resolved.
 - Expected VPS action: tracked-clean pull plus one exact-five graceful restart
-  and bounded settled smoke because live console ownership changes; preserve
-  `misc:0.0`.
+  and bounded settled smoke because live event and fallback payloads change;
+  preserve `misc:0.0`.
+
+## Deployed Baseline (PR #1343)
+
+- PR #1343 merged exact approved head
+  `2ee1382781e28e8e1d3341a43e22ef527b86f283` as canonical
+  `7e26a9062a88ecf211729d7d718fb4530630c4ba` after exact-head Hermes approval,
+  green Python/Rust CI, and a finding-free built-in Codex review.
+- VPS5 guarded-prepared tracked-clean from
+  `644d058f3975a2772f96bf10281f3873dca7112c` without a Rust build. The source
+  fingerprint/stamp remained
+  `691bff9683deec9382a4e96ab6a107c14145f88edd6ae2f8e2380b8ba6824449`.
+- The bounded exact-target orchestrator gracefully restarted only panes
+  `%358`-`%362` as PIDs `1075081/1075090/1075084/1075093/1075087`. All five
+  shutdown and startup identities completed without force or broad-pattern
+  signals.
+- The integrated 120-second smoke was hard-green with zero hard failures, log
+  attention matches, monitor warnings, or monitor errors. Its repository,
+  shutdown, startup, target, and smoke-contract gates all passed. Final
+  three-sample verification found the exact five processes stable with no
+  missing, duplicate, or extra process; the tracked checkout remained clean and
+  protected `misc:0.0` stayed `%8`/PID `434835`. The target diagnostic event did
+  not need to occur naturally for this ownership rollout. No direct
+  authenticated exchange call or event was manufactured.
 
 ## Deployed Baseline (PR #1342)
 
@@ -1784,11 +1806,12 @@ PR #1288's bounded target-identity stability, and PR #1289's plan binding are
 merged, deployed, and naturally validated without process control. PR #1290's
 pane-parent relaunch classification and the restart preparation/orchestration
 slices through PR #1309 are also merged and deployed. Later logging slices
-through PR #1342, including adjacent PR #1329, are deployed at canonical
-`644d058f3975a2772f96bf10281f3873dca7112c`; their current evidence is recorded
-above. Active PR #1343 consolidates noncritical market-snapshot diagnostic
-warning ownership and redaction without changing position/balance refresh or
-caller continuation behavior.
+through PR #1343, including adjacent PR #1329, are deployed at canonical
+`7e26a9062a88ecf211729d7d718fb4530630c4ba`; their current evidence is recorded
+above. Active pre-create `codex/ema-diagnostic-redaction` removes arbitrary
+exception and fallback-reason text from EMA event and human fallback payloads
+without changing EMA calculation, fallback selection, candidate availability,
+or trading behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,9 +22,11 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Pre-create slice `Redact EMA diagnostic payloads`; branch
+- PR #1344 `Redact EMA diagnostics at the producer boundary`; branch
   `codex/ema-diagnostic-redaction`, based on canonical
-  `7e26a9062a88ecf211729d7d718fb4530630c4ba`.
+  `7e26a9062a88ecf211729d7d718fb4530630c4ba`. The pushed semantic head
+  `f442e4a66e0f78fd628b6e5724fd5865f9ec395c` received a finding-free
+  independent Sol review after two exact-head finding/fix rounds.
 - Scope: remove arbitrary exception and fallback-reason text from
   `ema.unavailable` and `ema.fallback_used` structured, monitor, console, text,
   debug-profile, and legacy fallback paths while retaining code-owned reason
@@ -43,7 +45,8 @@ Estimated completion:
   console derives EMA identity by parsing the candidate exception message.
 - Review gate: exact-current-head Hermes approval plus green Python/Rust CI.
   Built-in Codex automatic review is additional and every finding must be
-  verified and resolved.
+  verified and resolved. The final handoff/status head requires fresh review
+  and CI before merge.
 - Expected VPS action: tracked-clean pull plus one exact-five graceful restart
   and bounded settled smoke because live event and fallback payloads change;
   preserve `misc:0.0`.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -31,7 +31,8 @@ Estimated completion:
   classifications, bounded EMA/error types, symbols, spans, ages, and counts.
   Malformed typed values normalize or drop at the producer boundary, adjacent
   EMA failure logs retain only exception type, and legacy warnings remain when
-  the structured event was not emitted successfully.
+  the structured event was not admitted to the queue or its synchronous console
+  projection failed.
 - Behavior boundary: observability payload and projection only. EMA
   calculation, prior-value and cached fallback selection, candidate
   availability, scheduling, retries, planning, orders, risk, and caller control

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,10 @@ Estimated completion:
 
 - PR #1344 `Redact EMA diagnostics at the producer boundary`; branch
   `codex/ema-diagnostic-redaction`, based on canonical
-  `7e26a9062a88ecf211729d7d718fb4530630c4ba`. The pushed semantic head
+  `7e26a9062a88ecf211729d7d718fb4530630c4ba`. The active review head is the
+  commit containing this status update; resolve its exact SHA from live PR
+  #1344 metadata. Its reviewed predecessor is
+  `d67cbffc415ba6b54eb6d44385c7d0f0f91d0638`. The pushed semantic head
   `f442e4a66e0f78fd628b6e5724fd5865f9ec395c` received a finding-free
   independent Sol review after two exact-head finding/fix rounds.
 - Scope: remove arbitrary exception and fallback-reason text from
@@ -1815,10 +1818,10 @@ pane-parent relaunch classification and the restart preparation/orchestration
 slices through PR #1309 are also merged and deployed. Later logging slices
 through PR #1343, including adjacent PR #1329, are deployed at canonical
 `7e26a9062a88ecf211729d7d718fb4530630c4ba`; their current evidence is recorded
-above. Active pre-create `codex/ema-diagnostic-redaction` removes arbitrary
+above. Active PR #1344 on `codex/ema-diagnostic-redaction` removes arbitrary
 exception and fallback-reason text from EMA event and human fallback payloads
 without changing EMA calculation, fallback selection, candidate availability,
-or trading behavior.
+or trading behavior. Resolve its exact current head from live PR metadata.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,28 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1342)
+## Latest Canonical Deployment (PR #1343)
+
+- PR #1343 merged exact approved head
+  `2ee1382781e28e8e1d3341a43e22ef527b86f283` as canonical
+  `7e26a9062a88ecf211729d7d718fb4530630c4ba` after exact-head Hermes approval,
+  green Python/Rust CI, and a finding-free built-in Codex review.
+- VPS5 guarded-prepared tracked-clean from `644d058f3975` without a Rust build;
+  the Rust source fingerprint/stamp stayed
+  `691bff9683deec9382a4e96ab6a107c14145f88edd6ae2f8e2380b8ba6824449`.
+- The exact-target orchestrator gracefully restarted only panes `%358`-`%362`
+  as PIDs `1075081/1075090/1075084/1075093/1075087`; shutdown, startup, and
+  stable target coverage were complete without force or broad-pattern signals.
+- The integrated 120-second smoke was hard-green with zero hard failures, log
+  attention matches, monitor warnings, or monitor errors. Repository,
+  shutdown, startup, target, and smoke-contract gates all passed; final
+  three-sample target verification retained five stable exact processes and a
+  tracked-clean checkout, while protected `misc:0.0` stayed `%8`/PID `434835`.
+  No direct authenticated exchange call or event was manufactured. The next
+  logging slice removes arbitrary exception and fallback-reason text from EMA
+  diagnostics upstream of every sink.
+
+## Previous Canonical Deployment (PR #1342)
 
 - PR #1342 merged exact approved head
   `8bae713d56f682744a09033f86a46a546b92ca3e` as canonical

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -4073,8 +4073,8 @@ def emit_event(
         return pipeline.emit(event, require_enqueue=require_enqueue, **overrides)
     except Exception as exc:
         logging.debug(
-            "[event] failed to emit %s: %s",
+            "[event] failed to emit %s error_type=%s",
             getattr(event, "event_type", event),
-            exc,
+            type(exc).__name__,
         )
         return None

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -2431,19 +2431,6 @@ def _bounded_ema_console_span(value: object) -> str:
     return f"{span:.6g}"
 
 
-def _bounded_ema_console_reason(value: object, *, limit: int) -> str:
-    reason = str(value or "").strip()
-    if reason.startswith("non-finite close EMA value"):
-        return "non_finite"
-    if re.fullmatch(r"[A-Za-z0-9_.-]+", reason):
-        return _bounded_ema_console_text(reason, limit=limit)
-    if ":" in reason:
-        error_type = reason.split(":", 1)[0].strip()
-        if re.fullmatch(r"[A-Za-z0-9_.-]+", error_type):
-            return _bounded_ema_console_text(error_type, limit=limit)
-    return "error"
-
-
 def _ema_fallback_examples(data: Mapping[str, Any]) -> list[Mapping[str, Any]]:
     examples = data.get("examples")
     if not isinstance(examples, Mapping):
@@ -2478,7 +2465,18 @@ def _format_ema_fallback_console_example(
             f"[{span_text}]",
             f" age={_bounded_ema_console_count(example.get('max_age_ms'))}ms",
             f" n={_bounded_ema_console_count(example.get('max_fallbacks'))}",
-            f" why={_bounded_ema_console_reason(example.get('reason'), limit=reason_limit)}",
+            " ema="
+            + _bounded_ema_console_text(
+                example.get("ema_type"), limit=reason_limit
+            ),
+            " why="
+            + _bounded_ema_console_text(
+                example.get("reason_code"), limit=reason_limit
+            ),
+            " err="
+            + _bounded_ema_console_text(
+                example.get("error_type"), limit=reason_limit
+            ),
         )
     )
 
@@ -2486,6 +2484,15 @@ def _format_ema_fallback_console_example(
 def format_ema_fallback_console(data: Mapping[str, Any]) -> str:
     """Render the close-EMA fallback warning without generic event decoration."""
     examples = _ema_fallback_examples(data)
+    ema_type = next(
+        (
+            str(example.get("ema_type"))
+            for example in examples
+            if example.get("ema_type")
+            in {"m1_close", "m1_volume", "m1_log_range", "h1_log_range"}
+        ),
+        None,
+    )
     max_age_ms = max(
         (_data_int(example, "max_age_ms") or 0 for example in examples), default=0
     )
@@ -2516,6 +2523,8 @@ def format_ema_fallback_console(data: Mapping[str, Any]) -> str:
         f"age={_bounded_ema_console_count(max_age_ms)}ms",
         f"streak={_bounded_ema_console_count(max_fallbacks)}",
     ]
+    if ema_type:
+        parts.append(f"ema={ema_type}")
     emitted_examples = 0
     for example in examples:
         if emitted_examples >= _EMA_FALLBACK_CONSOLE_EXAMPLE_LIMIT:
@@ -2541,12 +2550,6 @@ _EMA_UNAVAILABLE_CONSOLE_RECORD_LIMIT = 188
 _EMA_UNAVAILABLE_COMPACT_GROUP_LIMIT = 19
 _EMA_UNAVAILABLE_COMPACT_ERROR_LIMIT = 13
 _EMA_UNAVAILABLE_COMPACT_SYMBOL_LIMIT = 14
-_EMA_UNAVAILABLE_EMA_TYPE_RE = re.compile(
-    r"\b(?P<ema_type>m1_close|m1_volume|m1_log_range|h1_log_range)\s+EMA\b",
-    re.IGNORECASE,
-)
-
-
 def _ema_unavailable_console_group(data: Mapping[str, Any]) -> Mapping[str, Any]:
     groups = data.get("candidate_unavailable_groups")
     if not isinstance(groups, (list, tuple)):
@@ -2581,13 +2584,19 @@ def _ema_unavailable_console_symbol_preview(
 
 
 def _ema_unavailable_console_ema_type(group: Mapping[str, Any]) -> str | None:
-    example_error = group.get("example_error")
-    match = _EMA_UNAVAILABLE_EMA_TYPE_RE.search(str(example_error or ""))
-    if match is None:
+    ema_types = group.get("ema_types")
+    if not isinstance(ema_types, (list, tuple)):
         return None
-    return _bounded_ema_console_text(
-        match.group("ema_type"), limit=_EMA_UNAVAILABLE_CONSOLE_ERROR_LIMIT
-    )
+    for item in ema_types:
+        if isinstance(item, Mapping):
+            value = item.get("ema_type")
+        else:
+            value = item
+        if value in {"m1_close", "m1_volume", "m1_log_range", "h1_log_range"}:
+            return _bounded_ema_console_text(
+                value, limit=_EMA_UNAVAILABLE_CONSOLE_ERROR_LIMIT
+            )
+    return None
 
 
 def format_ema_unavailable_console(data: Mapping[str, Any]) -> str:

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -3657,8 +3657,10 @@ class LiveEventPipeline:
         event: LiveEvent | Mapping[str, Any],
         *,
         require_enqueue: bool = False,
+        defer_sync_sinks_until_enqueued: bool = False,
         **overrides: Any,
     ) -> LiveEvent | None:
+        require_enqueue = bool(require_enqueue or defer_sync_sinks_until_enqueued)
         if isinstance(event, LiveEvent):
             live_event = event
         else:
@@ -3667,20 +3669,8 @@ class LiveEventPipeline:
             live_event = replace(live_event, **overrides)
         live_event = live_event.with_context(self.context)
         route = self.route_for(live_event)
-        if (
-            route.console
-            and self.console_sink is not None
-            and _console_sink_event_visible(live_event)
-            and self._should_emit_throttled_sink("console", live_event, route)
-        ):
-            self._write_sink("console", self.console_sink, live_event)
-        if (
-            route.text
-            and self.text_sink is not None
-            and _operator_sink_event_visible(live_event)
-            and self._should_emit_throttled_sink("text", live_event, route)
-        ):
-            self._write_sink("text", self.text_sink, live_event)
+        if not defer_sync_sinks_until_enqueued:
+            self._emit_sync_sinks(live_event, route)
         enqueued = True
         if route.structured or route.monitor:
             with self._enqueue_lock:
@@ -3712,7 +3702,25 @@ class LiveEventPipeline:
                         )
         if require_enqueue and not enqueued:
             return None
+        if defer_sync_sinks_until_enqueued:
+            self._emit_sync_sinks(live_event, route)
         return live_event
+
+    def _emit_sync_sinks(self, live_event: LiveEvent, route: EventRoute) -> None:
+        if (
+            route.console
+            and self.console_sink is not None
+            and _console_sink_event_visible(live_event)
+            and self._should_emit_throttled_sink("console", live_event, route)
+        ):
+            self._write_sink("console", self.console_sink, live_event)
+        if (
+            route.text
+            and self.text_sink is not None
+            and _operator_sink_event_visible(live_event)
+            and self._should_emit_throttled_sink("text", live_event, route)
+        ):
+            self._write_sink("text", self.text_sink, live_event)
 
     def _should_emit_throttled_sink(
         self, sink_name: str, event: LiveEvent, route: EventRoute
@@ -4062,6 +4070,7 @@ def emit_event(
     event: LiveEvent | Mapping[str, Any],
     *,
     require_enqueue: bool = False,
+    defer_sync_sinks_until_enqueued: bool = False,
     **overrides: Any,
 ) -> Any:
     pipeline = getattr(bot, "_live_event_pipeline", None)
@@ -4070,7 +4079,10 @@ def emit_event(
     if pipeline is None or not callable(getattr(pipeline, "emit", None)):
         return None
     try:
-        return pipeline.emit(event, require_enqueue=require_enqueue, **overrides)
+        emit_kwargs = {"require_enqueue": require_enqueue, **overrides}
+        if defer_sync_sinks_until_enqueued:
+            emit_kwargs["defer_sync_sinks_until_enqueued"] = True
+        return pipeline.emit(event, **emit_kwargs)
     except Exception as exc:
         logging.debug(
             "[event] failed to emit %s error_type=%s",

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -2229,11 +2229,32 @@ def _ema_map_summary(values: dict[str, dict[float, float]] | None) -> dict[str, 
 _EMA_DIAGNOSTIC_TYPES = frozenset(
     ("m1_close", "m1_volume", "m1_log_range", "h1_log_range")
 )
+_EMA_DIAGNOSTIC_REASON_CODES = frozenset(
+    (
+        "cache_only_fetch_failed",
+        "candidate_required_ema_unavailable",
+        "exception",
+        "flat_active_required_ema_unavailable",
+        "incomplete",
+        "missing_log_range",
+        "missing_required_forager_log_range",
+        "missing_required_forager_volume",
+        "missing_required_forager_volume+missing_required_forager_log_range",
+        "missing_volume",
+        "missing_volume+missing_log_range",
+        "never_fetched_cache_only",
+        "non_finite_value",
+        "projected_metric_missing",
+        "projected_metric_non_finite",
+        "required_missing",
+        "unknown_failure",
+    )
+)
 
 
 def _safe_ema_reason_code(value: Any, *, default: str = "unknown_failure") -> str:
     candidate = str(value or "")
-    return candidate if re.fullmatch(r"[a-z][a-z0-9_]{0,63}", candidate) else default
+    return candidate if candidate in _EMA_DIAGNOSTIC_REASON_CODES else default
 
 
 def _safe_ema_error_type(value: Any) -> str:
@@ -2384,7 +2405,7 @@ def _ema_unavailable_debug_summary(
             ema_type_counts.update(ema_types)
             spans.extend(item_spans)
         group: dict[str, Any] = {
-            "reason": str(reason),
+            "reason": _safe_ema_reason_code(reason),
             "symbols": _symbol_sample(symbols),
             "error_types": sorted(error_types)[:4],
         }
@@ -2399,7 +2420,7 @@ def _ema_unavailable_debug_summary(
 
     unavailable_groups = [
         {
-            "reason": str(reason),
+            "reason": _safe_ema_reason_code(reason),
             "symbols": _symbol_sample(symbols or ()),
         }
         for reason, symbols in sorted((ema_unavailable_reasons or {}).items())[:limit]
@@ -2417,7 +2438,12 @@ def _reason_symbol_summary(
 ) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
     for reason, symbols in sorted((values or {}).items())[:limit]:
-        out.append({"reason": str(reason), "symbols": _symbol_sample(symbols)})
+        out.append(
+            {
+                "reason": _safe_ema_reason_code(reason),
+                "symbols": _symbol_sample(symbols),
+            }
+        )
     return out
 
 

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -1103,6 +1103,7 @@ def emit_live_event(
     raw_ref: str | None = None,
     raw_hash: str | None = None,
     require_enqueue: bool = False,
+    defer_sync_sinks_until_enqueued: bool = False,
 ):
     return emit_event(
         bot,
@@ -1135,6 +1136,7 @@ def emit_live_event(
             raw_hash=raw_hash,
         ),
         require_enqueue=require_enqueue,
+        defer_sync_sinks_until_enqueued=defer_sync_sinks_until_enqueued,
     )
 
 
@@ -3648,6 +3650,7 @@ def _emit_ema_warning_event(bot: Any, event_type: str, **kwargs: Any) -> bool:
     emitted = bot._emit_live_event(
         event_type,
         require_enqueue=True,
+        defer_sync_sinks_until_enqueued=True,
         **kwargs,
     )
     console_errors_after = _console_sink_error_count(bot)

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -2226,6 +2226,27 @@ def _ema_map_summary(values: dict[str, dict[float, float]] | None) -> dict[str, 
     }
 
 
+_EMA_DIAGNOSTIC_TYPES = frozenset(
+    ("m1_close", "m1_volume", "m1_log_range", "h1_log_range")
+)
+
+
+def _safe_ema_reason_code(value: Any, *, default: str = "unknown_failure") -> str:
+    candidate = str(value or "")
+    return candidate if re.fullmatch(r"[a-z][a-z0-9_]{0,63}", candidate) else default
+
+
+def _safe_ema_error_type(value: Any) -> str:
+    candidate = str(value or "")
+    return candidate if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]{0,63}", candidate) else "Error"
+
+
+def _safe_ema_types(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple, set, frozenset)):
+        return ()
+    return tuple(sorted({str(item) for item in value if str(item) in _EMA_DIAGNOSTIC_TYPES}))
+
+
 def _fallback_examples(
     values: dict[str, list[tuple[Any, ...]]] | None,
     *,
@@ -2237,7 +2258,9 @@ def _fallback_examples(
         ages: list[int] = []
         counts: list[int] = []
         metrics: set[str] = set()
-        reason = None
+        reason_code = None
+        error_type = None
+        ema_type = None
         for item in items or []:
             if not isinstance(item, (list, tuple)):
                 continue
@@ -2264,8 +2287,11 @@ def _fallback_examples(
                     count = _safe_int(item[2])
                     if count is not None:
                         counts.append(count)
-                if len(item) >= 4 and item[3] is not None:
-                    reason = str(item[3])[:160]
+                if len(item) >= 4:
+                    reason_code = _safe_ema_reason_code(item[3])
+                if len(item) >= 5:
+                    error_type = _safe_ema_error_type(item[4])
+                ema_type = "m1_close"
         example: dict[str, Any] = {
             "symbol": str(symbol),
             "count": len(items or []),
@@ -2277,61 +2303,68 @@ def _fallback_examples(
             example["max_age_ms"] = max(ages)
         if counts:
             example["max_fallbacks"] = max(counts)
-        if reason:
-            example["reason"] = reason
+        if ema_type:
+            example["ema_type"] = ema_type
+        if reason_code:
+            example["reason_code"] = reason_code
+        if error_type:
+            example["error_type"] = error_type
         examples.append(example)
     return examples
 
 
+def _candidate_detail_tuple(item: Any) -> tuple[str, str, tuple[str, ...], tuple[float, ...]]:
+    if not isinstance(item, (list, tuple)):
+        return str(item), "Error", (), ()
+    symbol = str(item[0]) if len(item) >= 1 else ""
+    error_type = _safe_ema_error_type(item[1]) if len(item) >= 2 else "Error"
+    ema_types = _safe_ema_types(item[2]) if len(item) >= 3 else ()
+    raw_spans = item[3] if len(item) >= 4 and isinstance(item[3], (list, tuple)) else ()
+    spans = tuple(
+        span for value in raw_spans if (span := _safe_float(value)) is not None
+    )
+    return symbol, error_type, ema_types, spans
+
+
 def _candidate_unavailable_summary(
-    values: dict[str, list[tuple[str, str, str]]] | None,
+    values: dict[str, list[tuple]] | None,
     *,
     limit: int = 8,
 ) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
     for reason, items in sorted((values or {}).items())[:limit]:
-        symbols = sorted({str(symbol) for symbol, _error_type, _error in items or []})
+        details = [_candidate_detail_tuple(item) for item in items or []]
+        symbols = sorted({symbol for symbol, _error_type, _ema_types, _spans in details})
         error_types = sorted(
-            {str(error_type) for _symbol, error_type, _error in items or []}
+            {error_type for _symbol, error_type, _ema_types, _spans in details}
         )
-        example_error = next(
-            (str(error) for _symbol, _error_type, error in items or [] if error),
-            "",
+        ema_type_counts: Counter[str] = Counter(
+            ema_type
+            for _symbol, _error_type, ema_types, _spans in details
+            for ema_type in ema_types
         )
+        spans = [
+            span
+            for _symbol, _error_type, _ema_types, item_spans in details
+            for span in item_spans
+        ]
         out.append(
             {
-                "reason": str(reason),
+                "reason": _safe_ema_reason_code(reason),
                 "symbols": _symbol_sample(symbols),
                 "error_types": error_types[:4],
-                "example_error": example_error[:160] if example_error else None,
+                "ema_types": [
+                    {"ema_type": key, "count": int(count)}
+                    for key, count in sorted(ema_type_counts.items())
+                ][:limit],
+                "spans": _span_sample(spans),
             }
         )
     return out
 
 
-_EMA_TYPE_RE = re.compile(
-    r"\b(?:missing\s+required\s+)?"
-    r"(?P<ema_type>m1_close|m1_volume|m1_log_range|h1_log_range)\s+EMA\b",
-    re.IGNORECASE,
-)
-_EMA_SPAN_REASON_RE = re.compile(
-    r"\bspan=(?P<span>[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?)"
-    r"\s+reason=(?P<reason>[^;|]+)",
-    re.IGNORECASE,
-)
-
-
-def _candidate_detail_tuple(item: Any) -> tuple[str, str, str]:
-    if not isinstance(item, (list, tuple)):
-        return str(item), "", ""
-    symbol = str(item[0]) if len(item) >= 1 else ""
-    error_type = str(item[1]) if len(item) >= 2 else ""
-    error = str(item[2]) if len(item) >= 3 else ""
-    return symbol, error_type, error
-
-
 def _ema_unavailable_debug_summary(
-    candidate_values: dict[str, list[tuple[str, str, str]]] | None,
+    candidate_values: dict[str, list[tuple]] | None,
     ema_unavailable_reasons: dict[str, list[str]] | None,
     *,
     limit: int = 8,
@@ -2342,22 +2375,14 @@ def _ema_unavailable_debug_summary(
         error_types: set[str] = set()
         ema_type_counts: Counter[str] = Counter()
         spans: list[float] = []
-        inner_reason_counts: Counter[str] = Counter()
         for raw_item in raw_items or []:
-            symbol, error_type, error = _candidate_detail_tuple(raw_item)
+            symbol, error_type, ema_types, item_spans = _candidate_detail_tuple(raw_item)
             if symbol:
                 symbols.add(symbol)
             if error_type:
                 error_types.add(error_type)
-            for match in _EMA_TYPE_RE.finditer(error or ""):
-                ema_type_counts[match.group("ema_type").lower()] += 1
-            for match in _EMA_SPAN_REASON_RE.finditer(error or ""):
-                span = _safe_float(match.group("span"))
-                if span is not None:
-                    spans.append(span)
-                inner_reason = str(match.group("reason") or "").strip()
-                if inner_reason:
-                    inner_reason_counts[inner_reason[:120]] += 1
+            ema_type_counts.update(ema_types)
+            spans.extend(item_spans)
         group: dict[str, Any] = {
             "reason": str(reason),
             "symbols": _symbol_sample(symbols),
@@ -2370,13 +2395,6 @@ def _ema_unavailable_debug_summary(
             ][:limit]
         if spans:
             group["spans"] = _span_sample(spans)
-        if inner_reason_counts:
-            group["inner_reasons"] = [
-                {"reason": key, "count": int(count)}
-                for key, count in sorted(
-                    inner_reason_counts.items(), key=lambda kv: (-kv[1], kv[0])
-                )[:limit]
-            ]
         candidate_groups.append(group)
 
     unavailable_groups = [
@@ -3553,7 +3571,7 @@ def _emit_ema_fallback_used_event_unchecked(
     bot: Any,
     *,
     close_ema_recoveries: dict[str, list[tuple[float, int]]] | None = None,
-    close_ema_fallbacks: dict[str, list[tuple[float, int, int, str]]] | None = None,
+    close_ema_fallbacks: dict[str, list[tuple[float, int, int, str, str]]] | None = None,
     forager_cached_ema_fallbacks: dict[str, list[tuple[str, float, int]]] | None = None,
 ) -> None:
     recovered_count = sum(len(items) for items in (close_ema_recoveries or {}).values())
@@ -3603,15 +3621,17 @@ def emit_ema_fallback_used_event(bot: Any, *args: Any, **kwargs: Any) -> None:
 def _emit_ema_unavailable_event_unchecked(
     bot: Any,
     *,
-    optional_ema_drops: dict[tuple[str, str], list[tuple[str, float]]] | None = None,
-    candidate_ema_unavailable_details: dict[str, list[tuple[str, str, str]]] | None = None,
+    optional_ema_drops: dict[tuple[str, str, str], list[tuple[str, float]]] | None = None,
+    candidate_ema_unavailable_details: dict[str, list[tuple]] | None = None,
     ema_unavailable_reasons: dict[str, list[str]] | None = None,
 ) -> None:
     optional_count = sum(len(items) for items in (optional_ema_drops or {}).values())
     candidate_symbols = {
         str(symbol)
         for items in (candidate_ema_unavailable_details or {}).values()
-        for symbol, _error_type, _error in items
+        for symbol, _error_type, _ema_types, _spans in (
+            _candidate_detail_tuple(item) for item in items
+        )
     }
     unavailable_symbols = {
         str(symbol)
@@ -3628,11 +3648,16 @@ def _emit_ema_unavailable_event_unchecked(
         else ReasonCodes.OPTIONAL_EMA_DROPPED
     )
     optional_summary = []
-    for (ema_type, reason), items in sorted((optional_ema_drops or {}).items())[:8]:
+    for (ema_type, drop_reason_code, error_type), items in sorted(
+        (optional_ema_drops or {}).items()
+    )[:8]:
         optional_summary.append(
             {
-                "ema_type": str(ema_type),
-                "reason": str(reason)[:160],
+                "ema_type": str(ema_type)
+                if str(ema_type) in _EMA_DIAGNOSTIC_TYPES
+                else "unknown",
+                "reason_code": _safe_ema_reason_code(drop_reason_code),
+                "error_type": _safe_ema_error_type(error_type),
                 "symbols": _symbol_sample(symbol for symbol, _span in items),
                 "spans": _span_sample(span for _symbol, span in items),
             }

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -5,6 +5,7 @@ import hashlib
 import math
 import re
 from collections import Counter
+from collections.abc import Mapping
 from typing import Any
 
 from live.event_bus import (
@@ -3583,9 +3584,9 @@ def emit_ema_bundle_started_event(bot: Any, *args: Any, **kwargs: Any) -> None:
         _emit_ema_bundle_started_event_unchecked(bot, *args, **kwargs)
     except Exception as exc:
         logging.debug(
-            "[event] failed to emit %s: %s",
+            "[event] failed to emit %s error_type=%s",
             EventTypes.EMA_BUNDLE_STARTED,
-            exc,
+            type(exc).__name__,
         )
 
 
@@ -3625,10 +3626,37 @@ def emit_ema_bundle_completed_event(bot: Any, *args: Any, **kwargs: Any) -> None
         _emit_ema_bundle_completed_event_unchecked(bot, *args, **kwargs)
     except Exception as exc:
         logging.debug(
-            "[event] failed to emit %s: %s",
+            "[event] failed to emit %s error_type=%s",
             EventTypes.EMA_BUNDLE_COMPLETED,
-            exc,
+            type(exc).__name__,
         )
+
+
+def _console_sink_error_count(bot: Any) -> int | None:
+    pipeline = getattr(bot, "_live_event_pipeline", None)
+    counters = getattr(pipeline, "sink_error_counters", None)
+    if not isinstance(counters, Mapping):
+        return None
+    try:
+        return int(counters.get("console", 0) or 0)
+    except (TypeError, ValueError):
+        return None
+
+
+def _emit_ema_warning_event(bot: Any, event_type: str, **kwargs: Any) -> bool:
+    console_errors_before = _console_sink_error_count(bot)
+    emitted = bot._emit_live_event(
+        event_type,
+        require_enqueue=True,
+        **kwargs,
+    )
+    console_errors_after = _console_sink_error_count(bot)
+    console_ok = (
+        console_errors_before is None
+        or console_errors_after is None
+        or console_errors_after == console_errors_before
+    )
+    return emitted is not None and console_ok
 
 
 def _emit_ema_fallback_used_event_unchecked(
@@ -3644,7 +3672,8 @@ def _emit_ema_fallback_used_event_unchecked(
     if not (recovered_count or close_fallback_count or forager_count):
         return False
     level = "warning" if close_fallback_count else "debug"
-    emitted = bot._emit_live_event(
+    return _emit_ema_warning_event(
+        bot,
         EventTypes.EMA_FALLBACK_USED,
         level=level,
         component="ema.bundle",
@@ -3672,7 +3701,6 @@ def _emit_ema_fallback_used_event_unchecked(
             },
         },
     )
-    return emitted is not None
 
 
 def emit_ema_fallback_used_event(bot: Any, *args: Any, **kwargs: Any) -> bool:
@@ -3747,7 +3775,8 @@ def _emit_ema_unavailable_event_unchecked(
             candidate_ema_unavailable_details,
             ema_unavailable_reasons,
         )
-    emitted = bot._emit_live_event(
+    return _emit_ema_warning_event(
+        bot,
         EventTypes.EMA_UNAVAILABLE,
         level=level,
         component="ema.bundle",
@@ -3757,7 +3786,6 @@ def _emit_ema_unavailable_event_unchecked(
         reason_code=reason_code,
         data=data,
     )
-    return emitted is not None
 
 
 def emit_ema_unavailable_event(bot: Any, *args: Any, **kwargs: Any) -> bool:

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -2229,6 +2229,11 @@ def _ema_map_summary(values: dict[str, dict[float, float]] | None) -> dict[str, 
 _EMA_DIAGNOSTIC_TYPES = frozenset(
     ("m1_close", "m1_volume", "m1_log_range", "h1_log_range")
 )
+_EMA_FALLBACK_METRICS = frozenset(("qv", "log_range"))
+_EMA_SYMBOL_RE = re.compile(
+    r"[A-Za-z0-9._-]+(?::[A-Za-z0-9._-]+)?/"
+    r"[A-Za-z0-9._-]+(?::[A-Za-z0-9._-]+)?"
+)
 _EMA_DIAGNOSTIC_REASON_CODES = frozenset(
     (
         "cache_only_fetch_failed",
@@ -2268,6 +2273,32 @@ def _safe_ema_types(value: Any) -> tuple[str, ...]:
     return tuple(sorted({str(item) for item in value if str(item) in _EMA_DIAGNOSTIC_TYPES}))
 
 
+def _safe_ema_symbol(value: Any) -> str:
+    candidate = str(value or "")
+    if len(candidate) <= 96 and _EMA_SYMBOL_RE.fullmatch(candidate):
+        return candidate
+    return "unknown"
+
+
+def _ema_symbol_sample(symbols: Any, *, limit: int = 12) -> dict[str, Any]:
+    if symbols is None:
+        return _symbol_sample((), limit=limit)
+    try:
+        values = (_safe_ema_symbol(symbol) for symbol in symbols)
+    except TypeError:
+        values = (_safe_ema_symbol(symbols),)
+    return _symbol_sample(values, limit=limit)
+
+
+def _ema_span_sample(spans: Any, *, limit: int = 8) -> list[float]:
+    finite = []
+    for value in spans or ():
+        span = _safe_finite_float(value)
+        if span is not None:
+            finite.append(span)
+    return _span_sample(finite, limit=limit)
+
+
 def _fallback_examples(
     values: dict[str, list[tuple[Any, ...]]] | None,
     *,
@@ -2286,9 +2317,10 @@ def _fallback_examples(
             if not isinstance(item, (list, tuple)):
                 continue
             if len(item) >= 1 and isinstance(item[0], str):
-                metrics.add(str(item[0]))
+                if str(item[0]) in _EMA_FALLBACK_METRICS:
+                    metrics.add(str(item[0]))
                 if len(item) >= 2:
-                    span = _safe_float(item[1])
+                    span = _safe_finite_float(item[1])
                     if span is not None:
                         spans.append(span)
                 if len(item) >= 3:
@@ -2297,7 +2329,7 @@ def _fallback_examples(
                         ages.append(age)
             else:
                 if len(item) >= 1:
-                    span = _safe_float(item[0])
+                    span = _safe_finite_float(item[0])
                     if span is not None:
                         spans.append(span)
                 if len(item) >= 2:
@@ -2314,9 +2346,9 @@ def _fallback_examples(
                     error_type = _safe_ema_error_type(item[4])
                 ema_type = "m1_close"
         example: dict[str, Any] = {
-            "symbol": str(symbol),
+            "symbol": _safe_ema_symbol(symbol),
             "count": len(items or []),
-            "spans": _span_sample(spans),
+            "spans": _ema_span_sample(spans),
         }
         if metrics:
             example["metrics"] = sorted(metrics)
@@ -2337,12 +2369,14 @@ def _fallback_examples(
 def _candidate_detail_tuple(item: Any) -> tuple[str, str, tuple[str, ...], tuple[float, ...]]:
     if not isinstance(item, (list, tuple)):
         return str(item), "Error", (), ()
-    symbol = str(item[0]) if len(item) >= 1 else ""
+    symbol = _safe_ema_symbol(item[0]) if len(item) >= 1 else "unknown"
     error_type = _safe_ema_error_type(item[1]) if len(item) >= 2 else "Error"
     ema_types = _safe_ema_types(item[2]) if len(item) >= 3 else ()
     raw_spans = item[3] if len(item) >= 4 and isinstance(item[3], (list, tuple)) else ()
     spans = tuple(
-        span for value in raw_spans if (span := _safe_float(value)) is not None
+        span
+        for value in raw_spans
+        if (span := _safe_finite_float(value)) is not None
     )
     return symbol, error_type, ema_types, spans
 
@@ -2372,13 +2406,13 @@ def _candidate_unavailable_summary(
         out.append(
             {
                 "reason": _safe_ema_reason_code(reason),
-                "symbols": _symbol_sample(symbols),
+                "symbols": _ema_symbol_sample(symbols),
                 "error_types": error_types[:4],
                 "ema_types": [
                     {"ema_type": key, "count": int(count)}
                     for key, count in sorted(ema_type_counts.items())
                 ][:limit],
-                "spans": _span_sample(spans),
+                "spans": _ema_span_sample(spans),
             }
         )
     return out
@@ -2406,7 +2440,7 @@ def _ema_unavailable_debug_summary(
             spans.extend(item_spans)
         group: dict[str, Any] = {
             "reason": _safe_ema_reason_code(reason),
-            "symbols": _symbol_sample(symbols),
+            "symbols": _ema_symbol_sample(symbols),
             "error_types": sorted(error_types)[:4],
         }
         if ema_type_counts:
@@ -2415,13 +2449,13 @@ def _ema_unavailable_debug_summary(
                 for key, count in sorted(ema_type_counts.items())
             ][:limit]
         if spans:
-            group["spans"] = _span_sample(spans)
+            group["spans"] = _ema_span_sample(spans)
         candidate_groups.append(group)
 
     unavailable_groups = [
         {
             "reason": _safe_ema_reason_code(reason),
-            "symbols": _symbol_sample(symbols or ()),
+            "symbols": _ema_symbol_sample(symbols or ()),
         }
         for reason, symbols in sorted((ema_unavailable_reasons or {}).items())[:limit]
     ]
@@ -2441,7 +2475,7 @@ def _reason_symbol_summary(
         out.append(
             {
                 "reason": _safe_ema_reason_code(reason),
-                "symbols": _symbol_sample(symbols),
+                "symbols": _ema_symbol_sample(symbols),
             }
         )
     return out
@@ -2479,7 +2513,11 @@ def _safe_emit(bot: Any, event_type: str, **kwargs: Any) -> Any:
     try:
         return bot._emit_live_event(event_type, **kwargs)
     except Exception as exc:
-        logging.debug("[event] failed to emit %s: %s", event_type, exc)
+        logging.debug(
+            "[event] failed to emit %s error_type=%s",
+            event_type,
+            type(exc).__name__,
+        )
         return None
 
 
@@ -3599,15 +3637,14 @@ def _emit_ema_fallback_used_event_unchecked(
     close_ema_recoveries: dict[str, list[tuple[float, int]]] | None = None,
     close_ema_fallbacks: dict[str, list[tuple[float, int, int, str, str]]] | None = None,
     forager_cached_ema_fallbacks: dict[str, list[tuple[str, float, int]]] | None = None,
-) -> None:
+) -> bool:
     recovered_count = sum(len(items) for items in (close_ema_recoveries or {}).values())
     close_fallback_count = sum(len(items) for items in (close_ema_fallbacks or {}).values())
     forager_count = sum(len(items) for items in (forager_cached_ema_fallbacks or {}).values())
     if not (recovered_count or close_fallback_count or forager_count):
-        return
+        return False
     level = "warning" if close_fallback_count else "debug"
-    _safe_emit(
-        bot,
+    emitted = bot._emit_live_event(
         EventTypes.EMA_FALLBACK_USED,
         level=level,
         component="ema.bundle",
@@ -3617,11 +3654,15 @@ def _emit_ema_fallback_used_event_unchecked(
         reason_code=ReasonCodes.EMA_FALLBACK_USED,
         data={
             "close_recovered_count": int(recovered_count),
-            "close_recovered_symbols": _symbol_sample((close_ema_recoveries or {}).keys()),
+            "close_recovered_symbols": _ema_symbol_sample(
+                (close_ema_recoveries or {}).keys()
+            ),
             "close_fallback_count": int(close_fallback_count),
-            "close_fallback_symbols": _symbol_sample((close_ema_fallbacks or {}).keys()),
+            "close_fallback_symbols": _ema_symbol_sample(
+                (close_ema_fallbacks or {}).keys()
+            ),
             "forager_cached_fallback_count": int(forager_count),
-            "forager_cached_fallback_symbols": _symbol_sample(
+            "forager_cached_fallback_symbols": _ema_symbol_sample(
                 (forager_cached_ema_fallbacks or {}).keys()
             ),
             "examples": {
@@ -3631,17 +3672,19 @@ def _emit_ema_fallback_used_event_unchecked(
             },
         },
     )
+    return emitted is not None
 
 
-def emit_ema_fallback_used_event(bot: Any, *args: Any, **kwargs: Any) -> None:
+def emit_ema_fallback_used_event(bot: Any, *args: Any, **kwargs: Any) -> bool:
     try:
-        _emit_ema_fallback_used_event_unchecked(bot, *args, **kwargs)
+        return _emit_ema_fallback_used_event_unchecked(bot, *args, **kwargs)
     except Exception as exc:
         logging.debug(
-            "[event] failed to emit %s: %s",
+            "[event] failed to emit %s error_type=%s",
             EventTypes.EMA_FALLBACK_USED,
-            exc,
+            type(exc).__name__,
         )
+        return False
 
 
 def _emit_ema_unavailable_event_unchecked(
@@ -3650,22 +3693,22 @@ def _emit_ema_unavailable_event_unchecked(
     optional_ema_drops: dict[tuple[str, str, str], list[tuple[str, float]]] | None = None,
     candidate_ema_unavailable_details: dict[str, list[tuple]] | None = None,
     ema_unavailable_reasons: dict[str, list[str]] | None = None,
-) -> None:
+) -> bool:
     optional_count = sum(len(items) for items in (optional_ema_drops or {}).values())
     candidate_symbols = {
-        str(symbol)
+        _safe_ema_symbol(symbol)
         for items in (candidate_ema_unavailable_details or {}).values()
         for symbol, _error_type, _ema_types, _spans in (
             _candidate_detail_tuple(item) for item in items
         )
     }
     unavailable_symbols = {
-        str(symbol)
+        _safe_ema_symbol(symbol)
         for items in (ema_unavailable_reasons or {}).values()
         for symbol in items
     }
     if not (optional_count or candidate_symbols or unavailable_symbols):
-        return
+        return False
     level = "warning" if candidate_symbols else "debug"
     status = "degraded" if candidate_symbols or unavailable_symbols else "skipped"
     reason_code = (
@@ -3684,18 +3727,18 @@ def _emit_ema_unavailable_event_unchecked(
                 else "unknown",
                 "reason_code": _safe_ema_reason_code(drop_reason_code),
                 "error_type": _safe_ema_error_type(error_type),
-                "symbols": _symbol_sample(symbol for symbol, _span in items),
-                "spans": _span_sample(span for _symbol, span in items),
+                "symbols": _ema_symbol_sample(symbol for symbol, _span in items),
+                "spans": _ema_span_sample(span for _symbol, span in items),
             }
         )
     data = {
         "optional_drop_count": int(optional_count),
         "optional_drop_groups": optional_summary,
-        "candidate_unavailable": _symbol_sample(candidate_symbols),
+        "candidate_unavailable": _ema_symbol_sample(candidate_symbols),
         "candidate_unavailable_groups": _candidate_unavailable_summary(
             candidate_ema_unavailable_details
         ),
-        "unavailable": _symbol_sample(unavailable_symbols),
+        "unavailable": _ema_symbol_sample(unavailable_symbols),
         "unavailable_reasons": _reason_symbol_summary(ema_unavailable_reasons),
     }
     if live_event_debug_profile_enabled(bot, "ema"):
@@ -3704,8 +3747,7 @@ def _emit_ema_unavailable_event_unchecked(
             candidate_ema_unavailable_details,
             ema_unavailable_reasons,
         )
-    _safe_emit(
-        bot,
+    emitted = bot._emit_live_event(
         EventTypes.EMA_UNAVAILABLE,
         level=level,
         component="ema.bundle",
@@ -3715,17 +3757,19 @@ def _emit_ema_unavailable_event_unchecked(
         reason_code=reason_code,
         data=data,
     )
+    return emitted is not None
 
 
-def emit_ema_unavailable_event(bot: Any, *args: Any, **kwargs: Any) -> None:
+def emit_ema_unavailable_event(bot: Any, *args: Any, **kwargs: Any) -> bool:
     try:
-        _emit_ema_unavailable_event_unchecked(bot, *args, **kwargs)
+        return _emit_ema_unavailable_event_unchecked(bot, *args, **kwargs)
     except Exception as exc:
         logging.debug(
-            "[event] failed to emit %s: %s",
+            "[event] failed to emit %s error_type=%s",
             EventTypes.EMA_UNAVAILABLE,
-            exc,
+            type(exc).__name__,
         )
+        return False
 
 
 def _short_order_id(value: Any, *, max_len: int = 32) -> str | None:

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -15844,10 +15844,12 @@ class Passivbot:
         cache_only_symbols: set[str] = set()
         ema_unavailable_symbols: set[str] = set()
         ema_unavailable_reasons: dict[str, list[str]] = {}
-        candidate_ema_unavailable_details: dict[str, list[tuple[str, str, str]]] = {}
-        optional_ema_drops: dict[tuple[str, str], list[tuple[str, float]]] = {}
+        candidate_ema_unavailable_details: dict[
+            str, list[tuple[str, str, tuple[str, ...], tuple[float, ...]]]
+        ] = {}
+        optional_ema_drops: dict[tuple[str, str, str], list[tuple[str, float]]] = {}
         close_ema_recoveries: dict[str, list[tuple[float, int]]] = {}
-        close_ema_fallbacks: dict[str, list[tuple[float, int, int, str]]] = {}
+        close_ema_fallbacks: dict[str, list[tuple[float, int, int, str, str]]] = {}
 
         def log_ema_issue(
             key: tuple,
@@ -15866,9 +15868,19 @@ class Passivbot:
                 logging.debug(message, *args)
 
         def record_optional_ema_drop(
-            ema_type: str, symbol: str, span: float, reason: str
+            ema_type: str,
+            symbol: str,
+            span: float,
+            reason_code: str,
+            error_type: str,
         ) -> None:
-            optional_ema_drops.setdefault((ema_type, reason), []).append((symbol, span))
+            optional_ema_drops.setdefault((ema_type, reason_code, error_type), []).append(
+                (symbol, span)
+            )
+
+        def ema_error_type(exc: Exception) -> str:
+            name = type(exc).__name__
+            return name if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]{0,63}", name) else "Error"
 
         def mark_ema_unavailable(symbol: str, reason: str) -> None:
             ema_unavailable_symbols.add(symbol)
@@ -16298,7 +16310,7 @@ class Passivbot:
                             out[span] = fallback
                             continue
                     record_optional_ema_drop(
-                        ema_type, symbol, span, f"{type(e).__name__}: {e}"
+                        ema_type, symbol, span, "exception", ema_error_type(e)
                     )
                     continue
                 if math.isfinite(val):
@@ -16312,7 +16324,7 @@ class Passivbot:
                             out[span] = fallback
                             continue
                     record_optional_ema_drop(
-                        ema_type, symbol, span, f"non-finite value {val}"
+                        ema_type, symbol, span, "non_finite_value", "NonFiniteValue"
                     )
             return out
 
@@ -16365,10 +16377,24 @@ class Passivbot:
                             symbol, ema_type, [sp for sp, _why in missing]
                         ),
                     )
-                raise RuntimeError(
+                raise MissingRequiredEma(symbol, ema_type, missing, detail)
+            return out
+
+        class MissingRequiredEma(RuntimeError):
+            def __init__(
+                self,
+                symbol: str,
+                ema_type: str,
+                missing: list[tuple[float, str]],
+                detail: str,
+            ):
+                super().__init__(
                     f"[ema] missing required {ema_type} EMA for {symbol}: {detail}"
                 )
-            return out
+                self.symbol = symbol
+                self.ema_type = ema_type
+                self.missing = list(missing)
+                self.detail = detail
 
         class MissingCloseEma(RuntimeError):
             def __init__(
@@ -16385,6 +16411,31 @@ class Passivbot:
                 self.missing = list(missing)
                 self.detail = detail
 
+        def close_ema_reason_detail(reason: str) -> tuple[str, str]:
+            if str(reason).startswith("non-finite close EMA value"):
+                return "non_finite_value", "NonFiniteValue"
+            error_type = str(reason).split(":", 1)[0].strip()
+            if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]{0,63}", error_type):
+                return "exception", error_type
+            return "unknown_failure", "Error"
+
+        def candidate_ema_detail(
+            exc: Exception,
+        ) -> tuple[str, tuple[str, ...], tuple[float, ...]]:
+            if isinstance(exc, MissingCloseEma):
+                return (
+                    ema_error_type(exc),
+                    ("m1_close",),
+                    tuple(float(span) for span, _reason in exc.missing),
+                )
+            if isinstance(exc, MissingRequiredEma):
+                return (
+                    ema_error_type(exc),
+                    (exc.ema_type,),
+                    tuple(float(span) for span, _reason in exc.missing),
+                )
+            return ema_error_type(exc), (), ()
+
         def log_missing_close_ema(symbol: str, missing: list[tuple[float, str]]) -> None:
             max_fallback_age_ms = int(Passivbot._close_ema_fallback_max_age_ms(self))
             stale = [
@@ -16396,11 +16447,11 @@ class Passivbot:
                 log_ema_issue(
                     ("close_fallback_stale", symbol),
                     required_ema_log_level(symbol),
-                    "[ema] close EMA fallback stale %s spans=%s max_age_ms=%d action=block_until_fresh reason=%s | %s",
+                    "[ema] close EMA fallback stale %s spans=%s max_age_ms=%d action=block_until_fresh reason=previous_close_ema_stale error_type=%s | %s",
                     Passivbot._log_symbol(symbol),
                     ",".join(f"{sp:.8g}" for sp, _why in stale[:8]),
                     max_fallback_age_ms,
-                    stale[0][1],
+                    close_ema_reason_detail(stale[0][1])[1],
                     ema_candle_health_context(symbol),
                     interval_ms=60 * 60 * 1000,
                 )
@@ -16478,20 +16529,22 @@ class Passivbot:
                             + 1
                         )
                         self._orchestrator_close_ema_fallback_counts[key] = n_fallbacks
+                        reason_code, error_type = close_ema_reason_detail(reason)
                         close_ema_fallbacks.setdefault(symbol, []).append(
-                            (span, age_ms, n_fallbacks, reason)
+                            (span, age_ms, n_fallbacks, reason_code, error_type)
                         )
                         log_ema_issue(
                             ("close_fallback", symbol, span),
                             logging.DEBUG,
                             "[ema] close EMA fallback %s span=%.8g ema=%.12g age_ms=%d"
-                            " n_fallbacks=%d reason=%s",
+                            " n_fallbacks=%d reason=%s error_type=%s",
                             Passivbot._log_symbol(symbol),
                             span,
                             prev_val,
                             age_ms,
                             n_fallbacks,
-                            reason,
+                            reason_code,
+                            error_type,
                         )
                         continue
                 missing.append((span, reason))
@@ -16520,7 +16573,8 @@ class Passivbot:
                         ema_type,
                         symbol,
                         span,
-                        f"projected open-tail {metric_key} EMA missing",
+                        "projected_metric_missing",
+                        "MissingProjectedMetric",
                     )
                     continue
                 val = float(metric_values[span])
@@ -16531,7 +16585,8 @@ class Passivbot:
                         ema_type,
                         symbol,
                         span,
-                        f"projected open-tail {metric_key} EMA non-finite value {val}",
+                        "projected_metric_non_finite",
+                        "NonFiniteValue",
                     )
             return out
 
@@ -16795,17 +16850,17 @@ class Passivbot:
                 else:
                     reason = "flat_active_required_ema_unavailable"
                 mark_ema_unavailable(sym, reason)
+                error_type, ema_types, spans = candidate_ema_detail(exc)
                 candidate_ema_unavailable_details.setdefault(reason, []).append(
-                    (sym, type(exc).__name__, str(exc))
+                    (sym, error_type, ema_types, spans)
                 )
                 log_ema_issue(
                     ("required_ema_unavailable", sym),
                     required_ema_log_level(sym),
-                    "[ema] required EMA unavailable %s action=mark_nontradable_until_fresh reason=%s error_type=%s error=%s | %s",
+                    "[ema] required EMA unavailable %s action=mark_nontradable_until_fresh reason=%s error_type=%s | %s",
                     Passivbot._log_symbol(sym),
                     reason,
-                    type(exc).__name__,
-                    exc,
+                    error_type,
                     ema_candle_health_context(sym),
                     interval_ms=15 * 60 * 1000,
                 )
@@ -16919,18 +16974,19 @@ class Passivbot:
         if optional_ema_drops:
             parts = []
             total = 0
-            for (ema_type, reason), items in sorted(optional_ema_drops.items()):
+            for (ema_type, reason_code, error_type), items in sorted(optional_ema_drops.items()):
                 total += len(items)
                 symbols_for_reason = sorted({symbol for symbol, _span in items})
                 spans_for_reason = sorted({float(span) for _symbol, span in items})
                 parts.append(
-                    "%s:n=%d symbols=%s spans=%s reason=%s"
+                    "%s:n=%d symbols=%s spans=%s reason=%s error_type=%s"
                     % (
                         ema_type,
                         len(items),
                         Passivbot._log_symbols(symbols_for_reason, limit=8),
                         ",".join(f"{span:.8g}" for span in spans_for_reason[:6]),
-                        str(reason)[:120],
+                        reason_code,
+                        error_type,
                     )
                 )
             logging.debug(
@@ -16969,25 +17025,37 @@ class Passivbot:
             max_fallbacks = max(
                 count
                 for items in close_ema_fallbacks.values()
-                for _span, _age_ms, count, _reason in items
+                for _span, _age_ms, count, _reason_code, _error_type in items
             )
             max_age_ms = max(
                 age_ms
                 for items in close_ema_fallbacks.values()
-                for _span, age_ms, _count, _reason in items
+                for _span, age_ms, _count, _reason_code, _error_type in items
             )
             examples = []
             for symbol, items in sorted(close_ema_fallbacks.items())[:8]:
                 spans = ",".join(
-                    f"{span:.8g}" for span, _age, _count, _reason in sorted(items)[:6]
+                    f"{span:.8g}"
+                    for span, _age, _count, _reason_code, _error_type in sorted(items)[:6]
                 )
-                symbol_max_age_ms = max(age for _span, age, _count, _reason in items)
-                symbol_max_fallbacks = max(count for _span, _age, count, _reason in items)
-                reason = next((why for _span, _age, _count, why in items if why), "")
+                symbol_max_age_ms = max(
+                    age for _span, age, _count, _reason_code, _error_type in items
+                )
+                symbol_max_fallbacks = max(
+                    count for _span, _age, count, _reason_code, _error_type in items
+                )
+                reason_code, error_type = next(
+                    (
+                        (code, error)
+                        for _span, _age, _count, code, error in items
+                        if code or error
+                    ),
+                    ("-", "-"),
+                )
                 examples.append(
                     f"{Passivbot._log_symbol(symbol)} spans={spans} "
                     f"max_age_ms={symbol_max_age_ms} max_fallbacks={symbol_max_fallbacks} "
-                    f"reason={str(reason)[:80]}"
+                    f"reason={reason_code} error_type={error_type}"
                 )
             log_ema_issue(
                 ("close_ema_fallback_summary",),
@@ -17029,18 +17097,31 @@ class Passivbot:
             parts = []
             all_symbols: set[str] = set()
             for reason, items in sorted(candidate_ema_unavailable_details.items()):
-                unique_symbols = sorted({symbol for symbol, _error_type, _error in items})
+                unique_symbols = sorted(
+                    {symbol for symbol, _error_type, _ema_types, _spans in items}
+                )
                 all_symbols.update(unique_symbols)
-                error_types = sorted({error_type for _symbol, error_type, _error in items})
-                example_error = next((error for _symbol, _error_type, error in items if error), "")
+                error_types = sorted(
+                    {
+                        error_type
+                        for _symbol, error_type, _ema_types, _spans in items
+                    }
+                )
+                ema_types = sorted(
+                    {
+                        ema_type
+                        for _symbol, _error_type, item_ema_types, _spans in items
+                        for ema_type in item_ema_types
+                    }
+                )
                 parts.append(
-                    "%s:n=%d symbols=%s error_types=%s example=%s"
+                    "%s:n=%d symbols=%s error_types=%s ema_types=%s"
                     % (
                         reason,
                         len(unique_symbols),
                         Passivbot._log_symbols(unique_symbols, limit=10),
                         ",".join(error_types[:4]),
-                        str(example_error)[:160],
+                        ",".join(ema_types[:4]) or "-",
                     )
                 )
             log_ema_issue(

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -16202,10 +16202,9 @@ class Passivbot:
                 ctx = Passivbot._active_tail_gap_projection_context(self, sym)
             except Exception as exc:
                 logging.debug(
-                    "[candle] open-tail EMA projection context failed %s | error_type=%s error=%s",
+                    "[candle] open-tail EMA projection context failed %s | error_type=%s",
                     Passivbot._log_symbol(sym),
                     type(exc).__name__,
-                    exc,
                 )
                 ctx = None
             if ctx is None and sym in forager_projection_max_age_by_symbol:
@@ -16227,10 +16226,9 @@ class Passivbot:
                         }
                 except Exception as exc:
                     logging.debug(
-                        "[candle] forager tail projection context failed %s | error_type=%s error=%s",
+                        "[candle] forager tail projection context failed %s | error_type=%s",
                         Passivbot._log_symbol(sym),
                         type(exc).__name__,
-                        exc,
                     )
             if ctx is not None:
                 projection_contexts[sym] = ctx
@@ -16658,13 +16656,12 @@ class Passivbot:
                 log_ema_issue(
                     ("open_tail_projection_failed", sym),
                     logging.WARNING,
-                    "[candle] open-tail EMA projection failed %s tail_gap_age_ms=%s latest_expected_ts=%s last_cached_ts=%s error_type=%s error=%s",
+                    "[candle] open-tail EMA projection failed %s tail_gap_age_ms=%s latest_expected_ts=%s last_cached_ts=%s error_type=%s",
                     Passivbot._log_symbol(sym),
                     projection_ctx.get("tail_gap_age_ms"),
                     projection_ctx.get("latest_expected_ts"),
                     projection_ctx.get("last_cached_ts"),
                     type(exc).__name__,
-                    exc,
                     interval_ms=15 * 60 * 1000,
                 )
                 raise
@@ -16715,10 +16712,9 @@ class Passivbot:
                 ctx = Passivbot._active_tail_gap_projection_context(self, sym)
             except Exception as exc:
                 logging.debug(
-                    "[candle] late open-tail EMA projection context failed %s | error_type=%s error=%s",
+                    "[candle] late open-tail EMA projection context failed %s | error_type=%s",
                     Passivbot._log_symbol(sym),
                     type(exc).__name__,
-                    exc,
                 )
                 return None
             if ctx is not None:
@@ -17015,10 +17011,18 @@ class Passivbot:
                 max_fallbacks,
                 "; ".join(examples),
             )
-        close_fallback_structured_console = (
-            Passivbot._ema_fallback_structured_console_available(self)
-            if close_ema_fallbacks
-            else False
+        ema_fallback_event_emitted = bool(
+            Passivbot._emit_ema_fallback_used_event(
+                self,
+                close_ema_recoveries=close_ema_recoveries,
+                close_ema_fallbacks=close_ema_fallbacks,
+                forager_cached_ema_fallbacks=forager_cached_ema_fallbacks,
+            )
+        )
+        close_fallback_structured_console = bool(
+            close_ema_fallbacks
+            and ema_fallback_event_emitted
+            and Passivbot._ema_fallback_structured_console_available(self)
         )
         if close_ema_fallbacks and not close_fallback_structured_console:
             fallback_count = sum(len(items) for items in close_ema_fallbacks.values())
@@ -17088,10 +17092,18 @@ class Passivbot:
                 "; ".join(examples),
                 interval_ms=15 * 60 * 1000,
             )
-        required_ema_unavailable_structured_console = (
-            Passivbot._ema_unavailable_structured_console_available(self)
-            if candidate_ema_unavailable_details
-            else False
+        ema_unavailable_event_emitted = bool(
+            Passivbot._emit_ema_unavailable_event(
+                self,
+                optional_ema_drops=optional_ema_drops,
+                candidate_ema_unavailable_details=candidate_ema_unavailable_details,
+                ema_unavailable_reasons=ema_unavailable_reasons,
+            )
+        )
+        required_ema_unavailable_structured_console = bool(
+            candidate_ema_unavailable_details
+            and ema_unavailable_event_emitted
+            and Passivbot._ema_unavailable_structured_console_available(self)
         )
         if candidate_ema_unavailable_details and not required_ema_unavailable_structured_console:
             parts = []
@@ -17133,12 +17145,6 @@ class Passivbot:
                 "; ".join(parts[:4]),
                 interval_ms=15 * 60 * 1000,
             )
-        Passivbot._emit_ema_fallback_used_event(
-            self,
-            close_ema_recoveries=close_ema_recoveries,
-            close_ema_fallbacks=close_ema_fallbacks,
-            forager_cached_ema_fallbacks=forager_cached_ema_fallbacks,
-        )
         if errors:
             fatal = next(
                 (err for _sym, err in errors if not isinstance(err, Exception)), None
@@ -17147,10 +17153,9 @@ class Passivbot:
                 raise fatal
             for sym, err in errors[1:]:
                 logging.debug(
-                    "[ema] additional symbol EMA bundle failure %s: %s: %s",
+                    "[ema] additional symbol EMA bundle failure %s error_type=%s",
                     Passivbot._log_symbol(sym),
                     type(err).__name__,
-                    err,
                 )
             raise errors[0][1]
         if ema_unavailable_reasons:
@@ -17168,13 +17173,6 @@ class Passivbot:
                 len(ema_unavailable_reasons),
                 "; ".join(parts[:4]),
             )
-        Passivbot._emit_ema_unavailable_event(
-            self,
-            optional_ema_drops=optional_ema_drops,
-            candidate_ema_unavailable_details=candidate_ema_unavailable_details,
-            ema_unavailable_reasons=ema_unavailable_reasons,
-        )
-
         # Convenience: compute the single-span values used by legacy forager logging.
         volumes_long = {
             s: m1_volume_emas[s][vol_span_long]
@@ -17682,11 +17680,10 @@ class Passivbot:
             )
         except Exception as exc:
             logging.debug(
-                "[ema] forager cached EMA unavailable %s metrics=%s error_type=%s error=%s",
+                "[ema] forager cached EMA unavailable %s metrics=%s error_type=%s",
                 Passivbot._log_symbol(symbol),
                 ",".join(sorted(str(k) for k in spans_by_metric)),
                 type(exc).__name__,
-                exc,
             )
             return {}
         if not isinstance(out, dict):

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -1797,14 +1797,18 @@ def test_ema_fallback_console_formatter_retains_compact_warning_semantics():
                     "spans": [10.0, 20.0],
                     "max_age_ms": 120_000,
                     "max_fallbacks": 3,
-                    "reason": "previous_ema_timeout",
+                    "ema_type": "m1_close",
+                    "reason_code": "exception",
+                    "error_type": "TimeoutError",
                 },
                 {
                     "symbol": "ETH/USDT:USDT",
                     "spans": [30.0],
                     "max_age_ms": 60_000,
                     "max_fallbacks": 2,
-                    "reason": "cache_read_timeout",
+                    "ema_type": "m1_close",
+                    "reason_code": "exception",
+                    "error_type": "RequestTimeout",
                 },
             ]
         },
@@ -1817,14 +1821,17 @@ def test_ema_fallback_console_formatter_retains_compact_warning_semantics():
     assert message.startswith("[ema] close fallback n=3 sym=2(BTC/USDT:USDT,ETH/USDT:USDT)")
     assert "age=120000ms" in message
     assert "streak=3" in message
-    assert "ex=BTC/USDT:USDT[10,20] age=120000ms n=3 why=previous_ema_time" in message
+    assert (
+        "ex=BTC/USDT:USDT[10,20] age=120000ms n=3 ema=m1_close "
+        "why=exception err=TimeoutError"
+    ) in message
     assert "recovered" not in message
     assert "reason=" not in message
     assert format_console_event(event) == message
     assert event.to_dict() == before
 
 
-def test_ema_fallback_console_formatter_classifies_exception_reason_without_message():
+def test_ema_fallback_console_formatter_uses_safe_fields_without_raw_reason():
     message = format_ema_fallback_console(
         {
             "close_fallback_count": 1,
@@ -1836,14 +1843,18 @@ def test_ema_fallback_console_formatter_classifies_exception_reason_without_mess
                         "spans": [60.0],
                         "max_age_ms": 1000,
                         "max_fallbacks": 1,
-                        "reason": "RequestTimeout: https://private.example/token",
+                        "ema_type": "m1_close",
+                        "reason_code": "exception",
+                        "error_type": "RequestTimeout",
+                        "reason": "https://private.example/token",
                     }
                 ]
             },
         }
     )
 
-    assert "why=RequestTimeout" in message
+    assert "why=exception" in message
+    assert "err=RequestTimeout" in message
     assert "private.example" not in message
 
 
@@ -1862,14 +1873,18 @@ def test_ema_fallback_console_formatter_is_bounded_without_mutating_payload():
                     "spans": [1e300, 1e-300, 999.0],
                     "max_age_ms": maximum,
                     "max_fallbacks": maximum,
-                    "reason": "timeout " * 10_000,
+                    "ema_type": "m1_close",
+                    "reason_code": "exception",
+                    "error_type": "TimeoutError",
                 },
                 {
                     "symbol": "B" * 10_000,
                     "spans": [2e300],
                     "max_age_ms": maximum,
                     "max_fallbacks": maximum,
-                    "reason": "stale " * 10_000,
+                    "ema_type": "m1_close",
+                    "reason_code": "non_finite_value",
+                    "error_type": "NonFiniteValue",
                 },
             ]
         },
@@ -1885,7 +1900,8 @@ def test_ema_fallback_console_formatter_is_bounded_without_mutating_payload():
     assert "sym=999999999+(XXXXXXXXXXXXXXXX,YYYYYYYYYYYYYYYY)" in message
     assert "age=999999999+ms" in message
     assert "streak=999999999+" in message
-    assert "ex=AAAAAAAA" in message
+    assert "ema=m1_close" in message
+    assert "private.example" not in message
     assert event.to_dict() == before
 
 
@@ -1906,8 +1922,8 @@ def test_ema_unavailable_console_route_throttles_human_projection_but_keeps_deta
                 "reason": "cache_only_fetch_failed",
                 "symbols": {"count": 1, "sample": ["BTC/USDT:USDT"]},
                 "error_types": ["RuntimeError"],
-                "example_error": "missing required h1_log_range EMA",
-                "per_symbol_diagnostic": "detail must stay structured",
+                "ema_types": [{"ema_type": "h1_log_range", "count": 1}],
+                "spans": [672.0],
             }
         ],
     }
@@ -1930,9 +1946,9 @@ def test_ema_unavailable_console_route_throttles_human_projection_but_keeps_deta
     assert text.events == [first, boundary]
     assert pipeline.flush(timeout=2.0) is True
     assert structured.events == [first, throttled, boundary]
-    assert structured.events[0].data["candidate_unavailable_groups"][0][
-        "per_symbol_diagnostic"
-    ] == "detail must stay structured"
+    assert structured.events[0].data["candidate_unavailable_groups"][0]["ema_types"] == [
+        {"ema_type": "h1_log_range", "count": 1}
+    ]
     assert pipeline.close(timeout=2.0) is True
 
 
@@ -1954,11 +1970,8 @@ def test_ema_unavailable_console_formatter_is_bounded_and_retains_required_signa
                     ],
                 },
                 "error_types": ["MissingLogRangeEma", "RuntimeError"],
-                "example_error": (
-                    "[ema] missing required h1_log_range EMA for BTC/USDT:USDT: "
-                    "span=672 reason=non-finite value"
-                ),
-                "per_symbol_diagnostic": "x" * 10_000,
+                "ema_types": [{"ema_type": "h1_log_range", "count": 1}],
+                "spans": [672.0],
             }
         ],
     }
@@ -1975,7 +1988,7 @@ def test_ema_unavailable_console_formatter_is_bounded_and_retains_required_signa
     )
     assert len(longest_prefix + message) <= 240
     assert "SOL/USDT:USDT" not in message
-    assert "per_symbol_diagnostic" not in message
+    assert "example_error" not in message
     assert format_console_event(event) == message
     assert event.to_dict() == before
 
@@ -1989,7 +2002,7 @@ def test_ema_unavailable_console_formatter_keeps_identity_under_pathological_len
                 "reason": "r" * 10_000,
                 "symbols": {"count": maximum, "sample": ["S" * 10_000] * 3},
                 "error_types": ["E" * 10_000],
-                "example_error": "missing required h1_log_range EMA",
+                "ema_types": [{"ema_type": "h1_log_range", "count": maximum}],
             }
         ],
     }

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -1858,6 +1858,28 @@ def test_ema_fallback_console_formatter_uses_safe_fields_without_raw_reason():
     assert "private.example" not in message
 
 
+def test_emit_event_failure_log_omits_exception_text(caplog):
+    secret = "https://private.example/path?api_key=pipeline-secret"
+
+    class FailingPipeline:
+        def emit(self, *_args, **_kwargs):
+            raise RuntimeError(secret)
+
+    bot = type("Bot", (), {"_live_event_pipeline": FailingPipeline()})()
+    event = LiveEvent("ema.fallback_used", data={"safe": True})
+
+    with caplog.at_level(logging.DEBUG):
+        assert live_event_bus_module.emit_event(bot, event) is None
+
+    messages = [record.message for record in caplog.records]
+    assert any(
+        "failed to emit ema.fallback_used error_type=RuntimeError" in message
+        for message in messages
+    )
+    assert all(secret not in message for message in messages)
+    assert all("pipeline-secret" not in message for message in messages)
+
+
 def test_ema_fallback_console_formatter_is_bounded_without_mutating_payload():
     maximum = (1 << 63) - 1
     data = {

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -837,6 +837,38 @@ async def test_close_ema_fallback_event_console_owns_normal_warning(caplog, monk
 
 
 @pytest.mark.asyncio
+async def test_close_ema_fallback_legacy_summary_omits_raw_exception_text(caplog):
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    symbol = "AVAX/USDT:USDT"
+    spans = (10.0, (10.0 * 20.0) ** 0.5, 20.0)
+    bot = _BundleReproBot(
+        symbol,
+        close_mode="timeout",
+        prev_close_ema={span: 100.0 for span in spans},
+    )
+    bot.live_event_console_enabled = False
+    bot._live_event_pipeline = None
+
+    with caplog.at_level(logging.WARNING):
+        await pb_mod.Passivbot._load_orchestrator_ema_bundle(bot, [symbol], bot.PB_modes)
+
+    summaries = [
+        record.message
+        for record in caplog.records
+        if "close EMA fallback summary" in record.message
+    ]
+    assert len(summaries) == 1
+    assert "reason=exception" in summaries[0]
+    assert "error_type=TimeoutError" in summaries[0]
+    assert "kucoinfutures GET" not in summaries[0]
+    assert "RequestTimeout" not in summaries[0]
+
+
+@pytest.mark.asyncio
 async def test_candidate_ema_unavailable_logs_single_warning_summary(caplog):
     try:
         import passivbot as pb_mod
@@ -844,7 +876,7 @@ async def test_candidate_ema_unavailable_logs_single_warning_summary(caplog):
         pytest.skip("passivbot module not importable in test environment")
 
     symbols = ["AVAX/USDT:USDT", "TAO/USDT:USDT"]
-    bot = _BundleReproBot(symbols[0], close_mode="nan")
+    bot = _BundleReproBot(symbols[0], close_mode="timeout")
     bot.PB_modes = {"long": {}, "short": {}}
     bot.positions = {
         symbol: {
@@ -887,6 +919,13 @@ async def test_candidate_ema_unavailable_logs_single_warning_summary(caplog):
     assert not any("missing required close EMA AVAX" in message for message in warning_messages)
     assert not any("required EMA unavailable TAO" in message for message in warning_messages)
     assert not any("missing required close EMA TAO" in message for message in warning_messages)
+    summaries = [
+        message for message in warning_messages if "required EMA unavailable summary" in message
+    ]
+    assert "error_types=MissingCloseEma" in summaries[0]
+    assert "ema_types=m1_close" in summaries[0]
+    assert "kucoinfutures GET" not in summaries[0]
+    assert "RequestTimeout" not in summaries[0]
 
 
 @pytest.mark.asyncio
@@ -1369,7 +1408,8 @@ async def test_open_tail_projection_missing_optional_metrics_are_diagnostic(capl
     assert optional_logs
     assert "m1_volume" in optional_logs[-1]
     assert "m1_log_range" in optional_logs[-1]
-    assert "projected open-tail" in optional_logs[-1]
+    assert "reason=projected_metric_missing" in optional_logs[-1]
+    assert "error_type=MissingProjectedMetric" in optional_logs[-1]
 
 
 @pytest.mark.asyncio

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -384,6 +384,8 @@ class _BundleReproBot:
         qv_mode="value",
         lr1m_mode="value",
         project_open_tail_after_health_calls=None,
+        projection_error=None,
+        cached_metric_error=None,
     ):
         self.symbol = symbol
         self.PB_modes = {"long": {symbol: "normal"}, "short": {symbol: "manual"}}
@@ -410,6 +412,8 @@ class _BundleReproBot:
         self.qv_mode = qv_mode
         self.lr1m_mode = lr1m_mode
         self.project_open_tail_after_health_calls = project_open_tail_after_health_calls
+        self.projection_error = projection_error
+        self.cached_metric_error = cached_metric_error
         self.completed_candle_health_calls = 0
         self._orchestrator_close_ema_fallback_counts = {}
         self.config = {"live": {"max_forager_candle_staleness_minutes": 10}}
@@ -508,6 +512,8 @@ class _BundleReproBot:
                 max_tail_gap_ms,
             ):
                 self.outer.projected_open_tail_called = True
+                if self.outer.projection_error is not None:
+                    raise self.outer.projection_error
                 qv = (
                     {float(span): 250000.0 for span in spans_by_metric.get("qv", [])}
                     if self.outer.projected_qv_ema is None
@@ -545,6 +551,8 @@ class _BundleReproBot:
                 window_candles=None,
                 timeframe="1m",
             ):
+                if self.outer.cached_metric_error is not None:
+                    raise self.outer.cached_metric_error
                 self.outer.cached_metric_calls.append(
                     {
                         "symbol": symbol,
@@ -819,6 +827,7 @@ async def test_close_ema_fallback_event_console_owns_normal_warning(caplog, monk
 
     def emit_ema_fallback(bot_arg, **kwargs):
         emitted.append((bot_arg, kwargs))
+        return True
 
     monkeypatch.setattr(
         pb_mod.Passivbot,
@@ -834,6 +843,50 @@ async def test_close_ema_fallback_event_console_owns_normal_warning(caplog, monk
     assert emitted[0][0] is bot
     assert emitted[0][1]["close_ema_fallbacks"]
     assert not any("close EMA fallback summary" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_close_ema_fallback_event_failure_keeps_legacy_warning(caplog, monkeypatch):
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    symbol = "AVAX/USDT:USDT"
+    spans = (10.0, (10.0 * 20.0) ** 0.5, 20.0)
+    bot = _BundleReproBot(
+        symbol,
+        close_mode="timeout",
+        prev_close_ema={span: 100.0 for span in spans},
+    )
+    bot.live_event_console_enabled = True
+    bot._live_event_pipeline = type(
+        "Pipeline", (), {"console_sink": object(), "emit": lambda self, event: event}
+    )()
+
+    def fail_ema_fallback(_bot_arg, **_kwargs):
+        return False
+
+    monkeypatch.setattr(
+        pb_mod.Passivbot,
+        "_emit_ema_fallback_used_event",
+        staticmethod(fail_ema_fallback),
+    )
+    bot._emit_ema_fallback_used_event = fail_ema_fallback
+
+    with caplog.at_level(logging.WARNING):
+        await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+            bot, [symbol], bot.PB_modes
+        )
+
+    summaries = [
+        record.message
+        for record in caplog.records
+        if "close EMA fallback summary" in record.message
+    ]
+    assert len(summaries) == 1
+    assert "reason=exception" in summaries[0]
+    assert "kucoinfutures GET" not in summaries[0]
 
 
 @pytest.mark.asyncio
@@ -965,6 +1018,7 @@ async def test_candidate_ema_unavailable_event_console_owns_normal_warning(caplo
 
     def emit_ema_unavailable(bot_arg, **kwargs):
         emitted.append((bot_arg, kwargs))
+        return True
 
     monkeypatch.setattr(
         pb_mod.Passivbot,
@@ -982,6 +1036,57 @@ async def test_candidate_ema_unavailable_event_console_owns_normal_warning(caplo
     assert not any(
         "required EMA unavailable summary" in record.message for record in caplog.records
     )
+
+
+@pytest.mark.asyncio
+async def test_candidate_ema_unavailable_event_failure_keeps_legacy_warning(
+    caplog, monkeypatch
+):
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    symbol = "AVAX/USDT:USDT"
+    bot = _BundleReproBot(symbol, close_mode="timeout")
+    bot.PB_modes = {"long": {}, "short": {}}
+    bot.positions = {
+        symbol: {
+            "long": {"size": 0.0, "price": 0.0},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+    }
+    bot.cm.get_last_refresh_ms = lambda _symbol: int(time.time() * 1000)
+    bot._candle_staleness_ms = lambda _symbol, now_ms=None: 0
+    _enable_forager_required_ranking(bot)
+    bot.live_event_console_enabled = True
+    bot._live_event_pipeline = type(
+        "Pipeline", (), {"console_sink": object(), "emit": lambda self, event: event}
+    )()
+
+    def fail_ema_unavailable(_bot_arg, **_kwargs):
+        return False
+
+    monkeypatch.setattr(
+        pb_mod.Passivbot,
+        "_emit_ema_unavailable_event",
+        staticmethod(fail_ema_unavailable),
+    )
+    bot._emit_ema_unavailable_event = fail_ema_unavailable
+
+    with caplog.at_level(logging.WARNING):
+        await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+            bot, [symbol], bot.PB_modes
+        )
+
+    summaries = [
+        record.message
+        for record in caplog.records
+        if "required EMA unavailable summary" in record.message
+    ]
+    assert len(summaries) == 1
+    assert "error_types=MissingCloseEma" in summaries[0]
+    assert "kucoinfutures GET" not in summaries[0]
 
 
 def _enable_forager_required_ranking(bot):
@@ -1430,6 +1535,72 @@ async def test_open_tail_projection_missing_close_span_fails_loudly():
 
     with pytest.raises(RuntimeError, match="projected open-tail close EMA incomplete"):
         await pb_mod.Passivbot._load_orchestrator_ema_bundle(bot, [symbol], bot.PB_modes)
+
+
+@pytest.mark.asyncio
+async def test_open_tail_projection_failure_log_omits_exception_text(caplog):
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    secret = "https://private.example/path?api_key=projection-secret"
+    symbol = "AVAX/USDT:USDT"
+    bot = _BundleReproBot(
+        symbol,
+        close_mode="timeout",
+        project_open_tail=True,
+        projection_error=TimeoutError(secret),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(TimeoutError, match="private.example"):
+            await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+                bot, [symbol], bot.PB_modes
+            )
+
+    messages = [record.message for record in caplog.records]
+    assert any(
+        "open-tail EMA projection failed" in message
+        and "error_type=TimeoutError" in message
+        for message in messages
+    )
+    assert all(secret not in message for message in messages)
+    assert all("projection-secret" not in message for message in messages)
+
+
+@pytest.mark.asyncio
+async def test_cached_forager_ema_failure_log_omits_exception_text(caplog):
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    secret = "https://private.example/path?api_key=cached-secret"
+    symbol = "AVAX/USDT:USDT"
+    bot = _BundleReproBot(
+        symbol,
+        close_mode="value",
+        cached_metric_error=TimeoutError(secret),
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        result = await pb_mod.Passivbot._get_forager_cached_ema_metrics(
+            bot,
+            symbol,
+            {"qv": 10.0},
+            max_staleness_ms=60_000,
+        )
+
+    assert result == {}
+    messages = [record.message for record in caplog.records]
+    assert any(
+        "forager cached EMA unavailable" in message
+        and "error_type=TimeoutError" in message
+        for message in messages
+    )
+    assert all(secret not in message for message in messages)
+    assert all("cached-secret" not in message for message in messages)
 
 
 @pytest.mark.asyncio

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -2074,17 +2074,25 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
     )
     bot._emit_ema_fallback_used_event(
         close_ema_recoveries={"BTC/USDT:USDT": [(100.0, 1)]},
-        close_ema_fallbacks={"ETH/USDT:USDT": [(100.0, 120_000, 2, "stale")]},
+        close_ema_fallbacks={
+            "ETH/USDT:USDT": [
+                (100.0, 120_000, 2, "exception", "TimeoutError")
+            ]
+        },
         forager_cached_ema_fallbacks={
             "DOGE/USDT:USDT": [("qv", 60.0, 180_000)]
         },
     )
     bot._emit_ema_unavailable_event(
         optional_ema_drops={
-            ("h1_log_range", "missing_optional"): [("SOL/USDT:USDT", 24.0)]
+            ("h1_log_range", "projected_metric_missing", "MissingProjectedMetric"): [
+                ("SOL/USDT:USDT", 24.0)
+            ]
         },
         candidate_ema_unavailable_details={
-            "required_missing": [("XRP/USDT:USDT", "ValueError", "missing")]
+            "required_missing": [
+                ("XRP/USDT:USDT", "ValueError", ("h1_log_range",), (24.0,))
+            ]
         },
         ema_unavailable_reasons={"cache_only_never_fetched": ["ADA/USDT:USDT"]},
     )
@@ -2552,7 +2560,7 @@ def test_candle_events_debug_profile_adds_bounded_tail_and_coverage_shape():
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
-def test_ema_unavailable_event_debug_profile_adds_parsed_readiness_detail():
+def test_ema_unavailable_event_debug_profile_keeps_safe_readiness_detail():
     import passivbot as pb_mod
 
     sink = ListEventSink()
@@ -2580,15 +2588,14 @@ def test_ema_unavailable_event_debug_profile_adds_parsed_readiness_detail():
                 (
                     "BTC/USDT:USDT",
                     "RuntimeError",
-                    "[ema] missing required h1_log_range EMA for BTC/USDT:USDT: "
-                    "span=672 reason=non-finite h1_log_range value nan; "
-                    "span=1100 reason=non-finite h1_log_range value nan",
+                    ("h1_log_range",),
+                    (672.0, 1100.0),
                 ),
                 (
                     "ETH/USDT:USDT",
                     "RuntimeError",
-                    "[ema] missing required m1_log_range EMA for ETH/USDT:USDT: "
-                    "span=500 reason=missing required window",
+                    ("m1_log_range",),
+                    (500.0,),
                 ),
             ]
         },
@@ -2611,10 +2618,7 @@ def test_ema_unavailable_event_debug_profile_adds_parsed_readiness_detail():
         {"ema_type": "m1_log_range", "count": 1},
     ]
     assert group["spans"] == [500.0, 672.0, 1100.0]
-    assert group["inner_reasons"] == [
-        {"reason": "non-finite h1_log_range value nan", "count": 2},
-        {"reason": "missing required window", "count": 1},
-    ]
+    assert "inner_reasons" not in group
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
@@ -2646,7 +2650,8 @@ def test_ema_unavailable_event_debug_profile_not_enabled_by_candles_profile():
                 (
                     "BTC/USDT:USDT",
                     "RuntimeError",
-                    "[ema] missing required h1_log_range EMA for BTC/USDT:USDT",
+                    ("h1_log_range",),
+                    (672.0,),
                 )
             ]
         }
@@ -2657,6 +2662,81 @@ def test_ema_unavailable_event_debug_profile_not_enabled_by_candles_profile():
     assert event.event_type == EventTypes.EMA_UNAVAILABLE
     assert "debug_profile" not in event.data
     assert "debug" not in event.data
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_ema_event_payloads_keep_safe_diagnostics_across_all_sinks():
+    import passivbot as pb_mod
+
+    structured = ListEventSink()
+    monitor = ListEventSink()
+    console = ListEventSink()
+    text = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_ema_fallback_used_event = pb_mod.Passivbot._emit_ema_fallback_used_event
+        _emit_ema_unavailable_event = pb_mod.Passivbot._emit_ema_unavailable_event
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+
+        def __init__(self):
+            self.exchange = "binance"
+            self.user = "binance_01"
+            self.bot_id = "bot_1"
+            self.live_event_debug_profiles = ("ema",)
+            self._live_event_current_cycle_id = "cy_ema_redaction"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[structured],
+                monitor_sinks=[monitor],
+                console_sink=console,
+                text_sink=text,
+            )
+
+    secret = "https://private.example/path?api_key=secret-token"
+    bot = FakeBot()
+    bot._emit_ema_fallback_used_event(
+        close_ema_fallbacks={
+            "BTC/USDT:USDT": [
+                (60.0, 1_000, 2, "exception", "RequestTimeout", secret)
+            ]
+        }
+    )
+    bot._emit_ema_unavailable_event(
+        optional_ema_drops={
+            ("m1_volume", "exception", "RequestTimeout"): [("ETH/USDT:USDT", 60.0)]
+        },
+        candidate_ema_unavailable_details={
+            "cache_only_fetch_failed": [
+                ("ETH/USDT:USDT", "RequestTimeout", ("m1_volume",), (60.0,), secret)
+            ]
+        },
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    emitted = [*structured.events, *monitor.events, *console.events, *text.events]
+    assert len(emitted) == 8
+    serialized = json.dumps([event.to_dict() for event in emitted], sort_keys=True)
+    assert secret not in serialized
+    assert "secret-token" not in serialized
+    unavailable = next(
+        event for event in structured.events if event.event_type == EventTypes.EMA_UNAVAILABLE
+    )
+    candidate_group = unavailable.data["candidate_unavailable_groups"][0]
+    assert candidate_group["ema_types"] == [{"ema_type": "m1_volume", "count": 1}]
+    assert candidate_group["spans"] == [60.0]
+    assert "example_error" not in candidate_group
+    assert "inner_reasons" not in unavailable.data["debug"]["candidate_groups"][0]
+    optional_group = unavailable.data["optional_drop_groups"][0]
+    assert optional_group["reason_code"] == "exception"
+    assert optional_group["error_type"] == "RequestTimeout"
+    fallback = next(
+        event for event in structured.events if event.event_type == EventTypes.EMA_FALLBACK_USED
+    )
+    fallback_example = fallback.data["examples"]["close_fallback"][0]
+    assert fallback_example["ema_type"] == "m1_close"
+    assert fallback_example["reason_code"] == "exception"
+    assert fallback_example["error_type"] == "RequestTimeout"
+    assert "reason" not in fallback_example
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -2834,6 +2834,123 @@ def test_ema_event_payloads_reject_malformed_typed_values():
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_ema_bundle_emitter_failure_logs_omit_exception_text(caplog):
+    secret = "https://private.example/path?api_key=bundle-secret"
+
+    class FailingSymbols:
+        def __bool__(self):
+            raise RuntimeError(secret)
+
+    with caplog.at_level(logging.DEBUG):
+        live_event_emitters.emit_ema_bundle_started_event(
+            object(),
+            symbols=FailingSymbols(),
+            modes={},
+        )
+        live_event_emitters.emit_ema_bundle_completed_event(
+            object(),
+            symbols=FailingSymbols(),
+            m1_close_emas={},
+            m1_volume_emas={},
+            m1_log_range_emas={},
+            h1_log_range_emas={},
+        )
+
+    messages = [record.message for record in caplog.records]
+    assert any(
+        "failed to emit ema.bundle.started error_type=RuntimeError" in message
+        for message in messages
+    )
+    assert any(
+        "failed to emit ema.bundle.completed error_type=RuntimeError" in message
+        for message in messages
+    )
+    assert all(secret not in message for message in messages)
+    assert all("bundle-secret" not in message for message in messages)
+
+
+def test_ema_warning_event_reports_console_sink_failure():
+    import passivbot as pb_mod
+
+    class FailingConsoleSink:
+        def write(self, _event):
+            raise RuntimeError("console unavailable")
+
+    structured = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_ema_fallback_used_event = pb_mod.Passivbot._emit_ema_fallback_used_event
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        exchange = "binance"
+        user = "binance_01"
+        bot_id = "bot_1"
+        _live_event_current_cycle_id = "cy_console_failure"
+
+        def __init__(self):
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[structured],
+                console_sink=FailingConsoleSink(),
+            )
+
+    bot = FakeBot()
+    assert (
+        bot._emit_ema_fallback_used_event(
+            close_ema_fallbacks={
+                "BTC/USDT:USDT": [
+                    (60.0, 1_000, 2, "exception", "RuntimeError")
+                ]
+            }
+        )
+        is False
+    )
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert any(
+        event.event_type == EventTypes.EMA_FALLBACK_USED for event in structured.events
+    )
+    assert bot._live_event_pipeline.sink_error_counters["console"] >= 1
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_ema_warning_event_reports_closed_pipeline_enqueue_failure():
+    import passivbot as pb_mod
+
+    structured = ListEventSink()
+    console = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_ema_unavailable_event = pb_mod.Passivbot._emit_ema_unavailable_event
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        exchange = "binance"
+        user = "binance_01"
+        bot_id = "bot_1"
+        _live_event_current_cycle_id = "cy_closed_pipeline"
+
+        def __init__(self):
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[structured],
+                console_sink=console,
+            )
+
+    bot = FakeBot()
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+    assert (
+        bot._emit_ema_unavailable_event(
+            candidate_ema_unavailable_details={
+                "required_missing": [
+                    ("BTC/USDT:USDT", "RuntimeError", ("m1_close",), (60.0,))
+                ]
+            }
+        )
+        is False
+    )
+    assert not any(
+        event.event_type == EventTypes.EMA_UNAVAILABLE for event in structured.events
+    )
+    assert bot._live_event_pipeline.drop_counters[EventTypes.EMA_UNAVAILABLE] == 1
+
+
 def test_ema_event_emission_failure_logs_type_only(caplog):
     secret = "https://private.example/path?api_key=emit-secret"
 

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -2697,19 +2697,22 @@ def test_ema_event_payloads_keep_safe_diagnostics_across_all_sinks():
     bot._emit_ema_fallback_used_event(
         close_ema_fallbacks={
             "BTC/USDT:USDT": [
-                (60.0, 1_000, 2, "exception", "RequestTimeout", secret)
+                (60.0, 1_000, 2, "secret_marker", "RequestTimeout", secret)
             ]
         }
     )
     bot._emit_ema_unavailable_event(
         optional_ema_drops={
-            ("m1_volume", "exception", "RequestTimeout"): [("ETH/USDT:USDT", 60.0)]
+            ("m1_volume", "secret_marker", "RequestTimeout"): [
+                ("ETH/USDT:USDT", 60.0)
+            ]
         },
         candidate_ema_unavailable_details={
-            "cache_only_fetch_failed": [
+            "secret_marker": [
                 ("ETH/USDT:USDT", "RequestTimeout", ("m1_volume",), (60.0,), secret)
             ]
         },
+        ema_unavailable_reasons={"secret_marker": ["ETH/USDT:USDT"]},
     )
 
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
@@ -2718,23 +2721,27 @@ def test_ema_event_payloads_keep_safe_diagnostics_across_all_sinks():
     serialized = json.dumps([event.to_dict() for event in emitted], sort_keys=True)
     assert secret not in serialized
     assert "secret-token" not in serialized
+    assert "secret_marker" not in serialized
     unavailable = next(
         event for event in structured.events if event.event_type == EventTypes.EMA_UNAVAILABLE
     )
     candidate_group = unavailable.data["candidate_unavailable_groups"][0]
     assert candidate_group["ema_types"] == [{"ema_type": "m1_volume", "count": 1}]
     assert candidate_group["spans"] == [60.0]
+    assert candidate_group["reason"] == "unknown_failure"
     assert "example_error" not in candidate_group
     assert "inner_reasons" not in unavailable.data["debug"]["candidate_groups"][0]
     optional_group = unavailable.data["optional_drop_groups"][0]
-    assert optional_group["reason_code"] == "exception"
+    assert optional_group["reason_code"] == "unknown_failure"
     assert optional_group["error_type"] == "RequestTimeout"
+    assert unavailable.data["unavailable_reasons"][0]["reason"] == "unknown_failure"
+    assert unavailable.data["debug"]["unavailable_groups"][0]["reason"] == "unknown_failure"
     fallback = next(
         event for event in structured.events if event.event_type == EventTypes.EMA_FALLBACK_USED
     )
     fallback_example = fallback.data["examples"]["close_fallback"][0]
     assert fallback_example["ema_type"] == "m1_close"
-    assert fallback_example["reason_code"] == "exception"
+    assert fallback_example["reason_code"] == "unknown_failure"
     assert fallback_example["error_type"] == "RequestTimeout"
     assert "reason" not in fallback_example
     assert bot._live_event_pipeline.close(timeout=2.0) is True

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -2948,6 +2948,9 @@ def test_ema_warning_event_reports_closed_pipeline_enqueue_failure():
     assert not any(
         event.event_type == EventTypes.EMA_UNAVAILABLE for event in structured.events
     )
+    assert not any(
+        event.event_type == EventTypes.EMA_UNAVAILABLE for event in console.events
+    )
     assert bot._live_event_pipeline.drop_counters[EventTypes.EMA_UNAVAILABLE] == 1
 
 

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -2747,6 +2747,127 @@ def test_ema_event_payloads_keep_safe_diagnostics_across_all_sinks():
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_ema_event_payloads_reject_malformed_typed_values():
+    import passivbot as pb_mod
+
+    structured = ListEventSink()
+    monitor = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_ema_fallback_used_event = pb_mod.Passivbot._emit_ema_fallback_used_event
+        _emit_ema_unavailable_event = pb_mod.Passivbot._emit_ema_unavailable_event
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+
+        def __init__(self):
+            self.exchange = "binance"
+            self.user = "binance_01"
+            self.bot_id = "bot_1"
+            self.live_event_debug_profiles = ("ema",)
+            self._live_event_current_cycle_id = "cy_ema_malformed"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[structured],
+                monitor_sinks=[monitor],
+            )
+
+    secret = "https://private.example/path?api_key=typed-secret"
+    bot = FakeBot()
+    assert bot._emit_ema_fallback_used_event(
+        close_ema_fallbacks={
+            secret: [(float("inf"), 1_000, 2, secret, secret, secret)]
+        },
+        forager_cached_ema_fallbacks={
+            secret: [(secret, float("nan"), 1_000)]
+        },
+    )
+    assert bot._emit_ema_unavailable_event(
+        optional_ema_drops={
+            (secret, secret, secret): [(secret, float("inf"))]
+        },
+        candidate_ema_unavailable_details={
+            secret: [
+                (
+                    secret,
+                    secret,
+                    (secret,),
+                    (float("inf"), float("nan")),
+                    secret,
+                )
+            ]
+        },
+        ema_unavailable_reasons={secret: [secret]},
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    emitted = [*structured.events, *monitor.events]
+    assert len(emitted) == 4
+    serialized = json.dumps([event.to_dict() for event in emitted], sort_keys=True)
+    assert secret not in serialized
+    assert "typed-secret" not in serialized
+    assert "Infinity" not in serialized
+    assert "NaN" not in serialized
+
+    fallback = next(
+        event for event in structured.events if event.event_type == EventTypes.EMA_FALLBACK_USED
+    )
+    for examples in fallback.data["examples"].values():
+        for example in examples:
+            assert example["symbol"] == "unknown"
+            assert example["spans"] == []
+            assert secret not in json.dumps(example, sort_keys=True)
+
+    unavailable = next(
+        event for event in structured.events if event.event_type == EventTypes.EMA_UNAVAILABLE
+    )
+    optional = unavailable.data["optional_drop_groups"][0]
+    assert optional["ema_type"] == "unknown"
+    assert optional["reason_code"] == "unknown_failure"
+    assert optional["error_type"] == "Error"
+    assert optional["symbols"]["sample"] == ["unknown"]
+    assert optional["spans"] == []
+    candidate = unavailable.data["candidate_unavailable_groups"][0]
+    assert candidate["reason"] == "unknown_failure"
+    assert candidate["symbols"]["sample"] == ["unknown"]
+    assert candidate["error_types"] == ["Error"]
+    assert candidate["ema_types"] == []
+    assert candidate["spans"] == []
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_ema_event_emission_failure_logs_type_only(caplog):
+    secret = "https://private.example/path?api_key=emit-secret"
+
+    class FailingBot:
+        exchange = "binance"
+        user = "binance_01"
+        bot_id = "bot_1"
+        _live_event_current_cycle_id = "cy_ema_emit_failure"
+
+        def _emit_live_event(self, *_args, **_kwargs):
+            raise RuntimeError(secret)
+
+    with caplog.at_level(logging.DEBUG):
+        assert (
+            live_event_emitters.emit_ema_fallback_used_event(
+                FailingBot(),
+                close_ema_fallbacks={
+                    "BTC/USDT:USDT": [
+                        (60.0, 1_000, 2, "exception", "RuntimeError")
+                    ]
+                },
+            )
+            is False
+        )
+
+    messages = [record.message for record in caplog.records]
+    assert any(
+        "failed to emit ema.fallback_used error_type=RuntimeError" in message
+        for message in messages
+    )
+    assert all(secret not in message for message in messages)
+    assert all("emit-secret" not in message for message in messages)
+
+
 @pytest.mark.asyncio
 async def test_candle_disk_coverage_audit_emits_structured_events(monkeypatch):
     import passivbot as pb_mod


### PR DESCRIPTION
@codex review

## Summary

- remove arbitrary exception and fallback-reason text from `ema.unavailable`, `ema.fallback_used`, their debug projections, and dedicated legacy warnings
- retain only code-owned reason classifications plus bounded EMA/error types, symbols, finite spans, ages, and counts
- normalize malformed typed diagnostics, keep adjacent EMA failure logs type-only, and retain the legacy warning when the structured event was not emitted successfully
- record the guarded PR #1343 VPS5 exact-five restart and green settled-smoke evidence

## Behavior boundary

Observability payload and projection only. This does not change EMA calculation, prior-value or cached fallback selection, candidate availability, scheduling, retries, planning, orders, risk, or caller control flow. No Rust, exchange connector, runtime configuration, or schema behavior changes.

## Validation

- 274 focused event bus, monitor, and EMA tests passed
- 44 stock-perp event-emission compatibility tests passed
- 6 downstream EMA live performance, incident, smoke, and query tests passed
- 4 AI-doc and generated-registry tests passed
- `tools.check_ai_docs`: 0 errors, one existing word-count warning
- touched Python modules compile; `git diff --check` passes
- independent Sol review approved exact head `f442e4a66e0f78fd628b6e5724fd5865f9ec395c`

## Deployment

After merge, guarded tracked-clean VPS5 update plus one exact-five graceful restart and bounded pre/post and settled smoke. Preserve `misc:0.0`; no broad process-pattern signals.

## Reviewer focus

- no arbitrary exception/reason text reaches structured, monitor, console, text, debug-profile, or dedicated legacy EMA diagnostic paths
- malformed tuple fields and non-finite spans cannot bypass producer-owned redaction
- legacy warning ownership changes only after successful structured-event emission
