### PR TITLE
Redact legacy diagnostic exception text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ All notable user-facing changes will be documented in this file.
 
 - Legacy monitor error events and WebSocket reconnect diagnostics now retain bounded exception
   classifications without arbitrary exception messages, request URLs, response text, or formatted
-  exception-value tracebacks. Safe event context, reconnect cadence, retry behavior, monitor
-  persistence, and trading behavior are unchanged.
+  exception-value tracebacks. Monitor error context is field-specific and credential-shaped values
+  are rejected; suspicious stack labels are replaced and frame emission reflects actual DEBUG
+  output. Reconnect cadence, retry behavior, monitor persistence, and trading behavior are
+  unchanged.
 
 - The `ema.unavailable` and `ema.fallback_used` events and their dedicated legacy summaries now
   retain only code-owned reason classifications, bounded EMA/error types, symbols, spans, ages,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ All notable user-facing changes will be documented in this file.
 - Legacy monitor error events and WebSocket reconnect diagnostics now retain bounded exception
   classifications without arbitrary exception messages, request URLs, response text, or formatted
   exception-value tracebacks. Monitor error context is restricted to known code-owned
-  classifications and bounded counts; suspicious stack labels are replaced and frame emission
-  reflects actual DEBUG output. Reconnect cadence, retry behavior, monitor persistence, and trading
+  classifications, and reconnect DEBUG output retains only bounded stack depth rather than frame
+  labels or line values. Reconnect cadence, retry behavior, monitor persistence, and trading
   behavior are unchanged.
 
 - The `ema.unavailable` and `ema.fallback_used` events and their dedicated legacy summaries now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Legacy monitor error events and WebSocket reconnect diagnostics now retain bounded exception
+  classifications without arbitrary exception messages, request URLs, response text, or formatted
+  exception-value tracebacks. Safe event context, reconnect cadence, retry behavior, monitor
+  persistence, and trading behavior are unchanged.
+
 - The `ema.unavailable` and `ema.fallback_used` events and their dedicated legacy summaries now
   retain only code-owned reason classifications, bounded EMA/error types, symbols, spans, ages,
   and counts. Malformed typed values are normalized or omitted, adjacent EMA failure logs retain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ All notable user-facing changes will be documented in this file.
 
 - Legacy monitor error events and WebSocket reconnect diagnostics now retain bounded exception
   classifications without arbitrary exception messages, request URLs, response text, or formatted
-  exception-value tracebacks. Monitor error context is field-specific and credential-shaped values
-  are rejected; suspicious stack labels are replaced and frame emission reflects actual DEBUG
-  output. Reconnect cadence, retry behavior, monitor persistence, and trading behavior are
-  unchanged.
+  exception-value tracebacks. Monitor error context is restricted to known code-owned
+  classifications and bounded counts; suspicious stack labels are replaced and frame emission
+  reflects actual DEBUG output. Reconnect cadence, retry behavior, monitor persistence, and trading
+  behavior are unchanged.
 
 - The `ema.unavailable` and `ema.fallback_used` events and their dedicated legacy summaries now
   retain only code-owned reason classifications, bounded EMA/error types, symbols, spans, ages,

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -267,11 +267,11 @@ event emission failure must not change exchange configuration control flow or re
 
 `websocket.reconnect` retains bounded reconnect count, retry delay, reason classification,
 rate-limit state, warning visibility, DEBUG stack-frame-emission state, and optional exception type.
-The human warning/debug projection may retain the same classifications and sanitized stack frames,
-but must not render the exception value, raw reason text, request URLs, responses, or formatted
-exception-value traceback. Suspicious frame labels are replaced rather than normalized, and a frame
-is marked emitted only when DEBUG logging accepts it. Reconnect cadence, retry behavior, and
-connector control flow are independent of observability delivery.
+The human warning/debug projection may retain the same classifications and bounded stack depth, but
+must not render frame labels, line values, the exception value, raw reason text, request URLs,
+responses, or formatted exception-value traceback. A stack diagnostic is marked emitted only when
+DEBUG logging accepts it. Reconnect cadence, retry behavior, and connector control flow are
+independent of observability delivery.
 
 ## Execution-Loop Incidents
 

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -266,11 +266,12 @@ event emission failure must not change exchange configuration control flow or re
 ## WebSocket Reconnect Diagnostics
 
 `websocket.reconnect` retains bounded reconnect count, retry delay, reason classification,
-rate-limit state, warning visibility, stack-frame-presence state, and optional exception type. The
-human warning/debug projection may retain the same classifications and sanitized stack frames, but
-must not render the exception value, raw reason text, request URLs, responses, or formatted
-exception-value traceback. Reconnect cadence, retry behavior, and connector control flow are
-independent of observability delivery.
+rate-limit state, warning visibility, DEBUG stack-frame-emission state, and optional exception type.
+The human warning/debug projection may retain the same classifications and sanitized stack frames,
+but must not render the exception value, raw reason text, request URLs, responses, or formatted
+exception-value traceback. Suspicious frame labels are replaced rather than normalized, and a frame
+is marked emitted only when DEBUG logging accepts it. Reconnect cadence, retry behavior, and
+connector control flow are independent of observability delivery.
 
 ## Execution-Loop Incidents
 

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -263,6 +263,15 @@ success remains INFO until the connector can prove whether it changed state; fai
 existing operator-visible warning or error. The event route remains structured/monitor-only, and
 event emission failure must not change exchange configuration control flow or results.
 
+## WebSocket Reconnect Diagnostics
+
+`websocket.reconnect` retains bounded reconnect count, retry delay, reason classification,
+rate-limit state, warning visibility, stack-frame-presence state, and optional exception type. The
+human warning/debug projection may retain the same classifications and sanitized stack frames, but
+must not render the exception value, raw reason text, request URLs, responses, or formatted
+exception-value traceback. Reconnect cadence, retry behavior, and connector control flow are
+independent of observability delivery.
+
 ## Execution-Loop Incidents
 
 An execution-loop failure publishes a bounded `error.bot` record and an equivalent first-occurrence

--- a/docs/ai/features/monitor_persistence.md
+++ b/docs/ai/features/monitor_persistence.md
@@ -5,6 +5,11 @@
 `src/monitor_publisher.py` owns monitor appends, snapshots, manifest checkpoints, rotation,
 retention, and startup recovery. Persistence failures stay visible but never alter trading behavior.
 
+`record_error` retains the event kind, tags, safe caller context, and a bounded exception type. It
+must not persist exception messages, request URLs, responses, tracebacks, or caller-supplied raw
+diagnostic aliases. More detailed incident context belongs in an explicitly sanitized event or
+protected developer path; persistence behavior and caller control flow remain unchanged.
+
 Event sequences are monotonic within a monitor root, including across unclean restart. The startup
 watermark is the maximum of the manifest and checksummed segment recovery metadata. Never infer an
 envelope sequence from payload bytes or an invalid row.

--- a/docs/ai/features/monitor_persistence.md
+++ b/docs/ai/features/monitor_persistence.md
@@ -5,11 +5,11 @@
 `src/monitor_publisher.py` owns monitor appends, snapshots, manifest checkpoints, rotation,
 retention, and startup recovery. Persistence failures stay visible but never alter trading behavior.
 
-`record_error` retains the event kind, tags, field-specific code-owned caller context, and a bounded
-exception type. It must not persist exception messages, request URLs, responses, tracebacks, or
-caller-supplied raw diagnostic aliases. More detailed incident context belongs in an explicitly
-sanitized event or protected developer path; persistence behavior and caller control flow remain
-unchanged.
+`record_error` retains the event kind, tags, known code-owned source/stage classifications, bounded
+integer counts, and a bounded exception type. It must not persist arbitrary caller strings,
+exception messages, request URLs, responses, tracebacks, or caller-supplied raw diagnostic aliases.
+More detailed incident context belongs in an explicitly sanitized event or protected developer
+path; persistence behavior and caller control flow remain unchanged.
 
 Event sequences are monotonic within a monitor root, including across unclean restart. The startup
 watermark is the maximum of the manifest and checksummed segment recovery metadata. Never infer an

--- a/docs/ai/features/monitor_persistence.md
+++ b/docs/ai/features/monitor_persistence.md
@@ -5,11 +5,11 @@
 `src/monitor_publisher.py` owns monitor appends, snapshots, manifest checkpoints, rotation,
 retention, and startup recovery. Persistence failures stay visible but never alter trading behavior.
 
-`record_error` retains the event kind, tags, known code-owned source/stage classifications, bounded
-integer counts, and a bounded exception type. It must not persist arbitrary caller strings,
-exception messages, request URLs, responses, tracebacks, or caller-supplied raw diagnostic aliases.
-More detailed incident context belongs in an explicitly sanitized event or protected developer
-path; persistence behavior and caller control flow remain unchanged.
+`record_error` retains the event kind, tags, known code-owned source/stage classifications, and a
+bounded exception type. It must not persist arbitrary caller strings or numbers, exception messages,
+request URLs, responses, tracebacks, or caller-supplied raw diagnostic aliases. More detailed
+incident context belongs in an explicitly sanitized event or protected developer path; persistence
+behavior and caller control flow remain unchanged.
 
 Event sequences are monotonic within a monitor root, including across unclean restart. The startup
 watermark is the maximum of the manifest and checksummed segment recovery metadata. Never infer an

--- a/docs/ai/features/monitor_persistence.md
+++ b/docs/ai/features/monitor_persistence.md
@@ -5,10 +5,11 @@
 `src/monitor_publisher.py` owns monitor appends, snapshots, manifest checkpoints, rotation,
 retention, and startup recovery. Persistence failures stay visible but never alter trading behavior.
 
-`record_error` retains the event kind, tags, safe caller context, and a bounded exception type. It
-must not persist exception messages, request URLs, responses, tracebacks, or caller-supplied raw
-diagnostic aliases. More detailed incident context belongs in an explicitly sanitized event or
-protected developer path; persistence behavior and caller control flow remain unchanged.
+`record_error` retains the event kind, tags, field-specific code-owned caller context, and a bounded
+exception type. It must not persist exception messages, request URLs, responses, tracebacks, or
+caller-supplied raw diagnostic aliases. More detailed incident context belongs in an explicitly
+sanitized event or protected developer path; persistence behavior and caller control flow remain
+unchanged.
 
 Event sequences are monotonic within a monitor root, including across unclean restart. The startup
 watermark is the maximum of the manifest and checksummed segment recovery metadata. Never infer an

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -29,10 +29,10 @@ Estimated completion:
   from live PR metadata because this status update is the final handoff delta.
 - Scope: remove arbitrary exception text from legacy
   `MonitorPublisher.record_error` payloads and WebSocket reconnect human
-  diagnostics. Monitor error events retain safe caller context and a bounded
-  exception type; reconnect diagnostics retain bounded reason/error type,
-  cadence, retry delay, and sanitized stack-frame evidence without rendering
-  the exception value.
+  diagnostics. Monitor error events retain known code-owned source/stage
+  classifications and a bounded exception type; reconnect diagnostics retain
+  bounded reason/error type, cadence, retry delay, and count-only stack depth
+  without frame labels, line values, or the exception value.
 - Behavior boundary: observability payload and projection only. Monitor event
   framing, sequence, rotation, retention, and sink isolation remain unchanged,
   as do reconnect cadence, retry/backoff, connector calls, exception

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,9 +22,11 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch `codex/diagnostic-exception-redaction`, based on canonical
-  `986e5d52f88692d1b6531bc38c307352c08e9cb9`; the pull request is pending
-  publication. Resolve the active review head from live branch/PR metadata.
+- PR #1345 `Redact legacy diagnostic exception text`; branch
+  `codex/diagnostic-exception-redaction`, based on canonical
+  `986e5d52f88692d1b6531bc38c307352c08e9cb9`. Its semantic predecessor is
+  `2087466167c59389ebf797bf2b9f2f732aaf96cb`; resolve the active review head
+  from live PR metadata because this status update is the final handoff delta.
 - Scope: remove arbitrary exception text from legacy
   `MonitorPublisher.record_error` payloads and WebSocket reconnect human
   diagnostics. Monitor error events retain safe caller context and a bounded

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -1848,10 +1848,12 @@ pane-parent relaunch classification and the restart preparation/orchestration
 slices through PR #1309 are also merged and deployed. Later logging slices
 through PR #1343, including adjacent PR #1329, are deployed at canonical
 `7e26a9062a88ecf211729d7d718fb4530630c4ba`; their current evidence is recorded
-above. Active PR #1344 on `codex/ema-diagnostic-redaction` removes arbitrary
-exception and fallback-reason text from EMA event and human fallback payloads
-without changing EMA calculation, fallback selection, candidate availability,
-or trading behavior. Resolve its exact current head from live PR metadata.
+above. PR #1344's EMA diagnostic redaction is merged and deployed at canonical
+`986e5d52f88692d1b6531bc38c307352c08e9cb9`. Active PR #1345 on
+`codex/diagnostic-exception-redaction` removes arbitrary exception text from
+legacy monitor errors and WebSocket reconnect diagnostics without changing
+reconnect cadence, retry behavior, monitor persistence, or trading behavior.
+Resolve its exact current head from live PR metadata.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,37 +22,65 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR #1344 `Redact EMA diagnostics at the producer boundary`; branch
-  `codex/ema-diagnostic-redaction`, based on canonical
-  `7e26a9062a88ecf211729d7d718fb4530630c4ba`. The active review head is the
-  commit containing this status update; resolve its exact SHA from live PR
-  #1344 metadata. Its reviewed predecessor is
-  `d67cbffc415ba6b54eb6d44385c7d0f0f91d0638`. The pushed semantic head
-  `f442e4a66e0f78fd628b6e5724fd5865f9ec395c` received a finding-free
-  independent Sol review after two exact-head finding/fix rounds.
-- Scope: remove arbitrary exception and fallback-reason text from
-  `ema.unavailable` and `ema.fallback_used` structured, monitor, console, text,
-  debug-profile, and legacy fallback paths while retaining code-owned reason
-  classifications, bounded EMA/error types, symbols, spans, ages, and counts.
-  Malformed typed values normalize or drop at the producer boundary, adjacent
-  EMA failure logs retain only exception type, and legacy warnings remain when
-  the structured event was not admitted to the queue or its synchronous console
-  projection failed.
-- Behavior boundary: observability payload and projection only. EMA
-  calculation, prior-value and cached fallback selection, candidate
-  availability, scheduling, retries, planning, orders, risk, and caller control
-  flow remain unchanged.
-- Baseline: structured payloads still retain candidate `example_error`, debug
-  `inner_reasons`, optional-drop reason text, and close-fallback reason text.
-  Human fallbacks also project raw reason or exception values, while the normal
-  console derives EMA identity by parsing the candidate exception message.
+- Branch `codex/diagnostic-exception-redaction`, based on canonical
+  `986e5d52f88692d1b6531bc38c307352c08e9cb9`; the pull request is pending
+  publication. Resolve the active review head from live branch/PR metadata.
+- Scope: remove arbitrary exception text from legacy
+  `MonitorPublisher.record_error` payloads and WebSocket reconnect human
+  diagnostics. Monitor error events retain safe caller context and a bounded
+  exception type; reconnect diagnostics retain bounded reason/error type,
+  cadence, retry delay, and sanitized stack-frame evidence without rendering
+  the exception value.
+- Behavior boundary: observability payload and projection only. Monitor event
+  framing, sequence, rotation, retention, and sink isolation remain unchanged,
+  as do reconnect cadence, retry/backoff, connector calls, exception
+  propagation, planning, orders, risk, and trading behavior.
+- Baseline: `MonitorPublisher.record_error` unconditionally persists
+  `str(error)` as `payload.message`; a value-free scan of the latest 4 MB from
+  each of six VPS5 current event segments parsed 9,396 rows and found one
+  natural `error.bot` message field. `_log_ws_reconnect` also writes the raw
+  exception and a formatted traceback containing the exception value, while
+  the existing structured reconnect event is already bounded.
 - Review gate: exact-current-head Hermes approval plus green Python/Rust CI.
   Built-in Codex automatic review is additional and every finding must be
   verified and resolved. The final handoff/status head requires fresh review
   and CI before merge.
 - Expected VPS action: tracked-clean pull plus one exact-five graceful restart
-  and bounded settled smoke because live event and fallback payloads change;
-  preserve `misc:0.0`.
+  and bounded settled smoke because live monitor and reconnect diagnostics
+  change; preserve `misc:0.0`.
+
+## Deployed Baseline (PR #1344)
+
+- PR #1344 merged exact approved head
+  `6a4fe26f90e8cb25f0dc09ecc39a067658addfa8` as canonical
+  `986e5d52f88692d1b6531bc38c307352c08e9cb9` after exact-head Hermes approval,
+  green Python/Rust CI, and a finding-free built-in Codex review. Independent
+  Sol review approved the semantic predecessor
+  `f442e4a66e0f78fd628b6e5724fd5865f9ec395c`; the final delta only corrected
+  the active handoff.
+- VPS5 guarded-prepared tracked-clean from
+  `7e26a9062a88ecf211729d7d718fb4530630c4ba` without a Rust build. The source
+  fingerprint/stamp remained
+  `691bff9683deec9382a4e96ab6a107c14145f88edd6ae2f8e2380b8ba6824449`, and the
+  compiled artifact SHA remained
+  `7611f3eff1d8702ff29d90490a1aba490db5c816e7e3f09a2c33e5c4085da023`.
+- The bounded exact-target orchestrator gracefully restarted only panes
+  `%358`-`%362` as PIDs `1076279/1076288/1076282/1076291/1076285`. All five
+  targets stopped, exited, relaunched, and verified without force or
+  broad-pattern signals.
+- The integrated 120-second smoke correctly remained non-green on one natural
+  KuCoin authoritative-balance `RequestTimeout`, represented by one hard
+  `cycle.degraded` event. It had zero hard text-log matches, monitor warnings,
+  or monitor errors. A strictly post-incident settled window then had a green
+  internal smoke contract with zero hard problem events, hard log matches,
+  monitor warnings, or monitor errors; its outer collector omitted the earlier
+  shutdown/startup cohorts by construction and therefore was not itself a
+  restart-evidence verdict.
+- Final three-sample verification found all five replacement processes stable
+  in state `R`, with no missing, duplicate, or extra live process. The checkout
+  was exact and tracked-clean, pre-existing untracked configs/probes were
+  preserved, and protected `misc:0.0` stayed `%8`/PID `434835`. No direct
+  authenticated exchange call or event was manufactured.
 
 ## Deployed Baseline (PR #1343)
 

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,31 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1343)
+## Latest Canonical Deployment (PR #1344)
+
+- PR #1344 merged exact approved head
+  `6a4fe26f90e8cb25f0dc09ecc39a067658addfa8` as canonical
+  `986e5d52f88692d1b6531bc38c307352c08e9cb9` after exact-head Hermes approval,
+  green Python/Rust CI, and a finding-free built-in Codex review. Independent
+  Sol review approved the semantic predecessor `f442e4a66e`; the final delta
+  only corrected the active handoff.
+- VPS5 guarded-prepared tracked-clean from `7e26a9062a8` without a Rust build;
+  the Rust source fingerprint/stamp and compiled artifact remained unchanged.
+  The exact-target orchestrator gracefully restarted only panes `%358`-`%362`
+  as PIDs `1076279/1076288/1076282/1076291/1076285`; all five exited,
+  relaunched, and verified without force or broad-pattern signals.
+- The integrated smoke correctly stayed red on one natural KuCoin
+  authoritative-balance `RequestTimeout` and had zero hard log matches or
+  monitor warnings/errors. A strictly post-incident settled window had a green
+  internal smoke contract with zero hard problem events, hard log matches, or
+  monitor warnings/errors. Final three-sample target verification retained five
+  stable exact processes in state `R`, a tracked-clean checkout, preserved
+  untracked artifacts, and protected `misc:0.0` `%8`/PID `434835`. No direct
+  authenticated exchange call or event was manufactured. The next redaction
+  slice removes arbitrary exception text from legacy monitor error events and
+  WebSocket reconnect diagnostics.
+
+## Previous Canonical Deployment (PR #1343)
 
 - PR #1343 merged exact approved head
   `2ee1382781e28e8e1d3341a43e22ef527b86f283` as canonical

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -904,7 +904,9 @@ def _emit_websocket_reconnect_event_unchecked(
         "traceback_emitted": bool(traceback_emitted),
     }
     if exc is not None:
-        data["error_type"] = type(exc).__name__
+        data["error_type"] = _bounded_exchange_time_sync_field(
+            type(exc).__name__, _EXCHANGE_TIME_SYNC_ERROR_TYPE_RE
+        )
     _safe_emit(
         bot,
         EventTypes.WEBSOCKET_RECONNECT,

--- a/src/monitor_publisher.py
+++ b/src/monitor_publisher.py
@@ -57,22 +57,24 @@ _EVENT_RECOVERY_MARKER = b',"_recovery":{"checksum":"'
 _EVENT_RECOVERY_SEQ_SEPARATOR = b'","seq":'
 _EVENT_RECOVERY_TRAILER_MAX_BYTES = 160
 _MONITOR_ERROR_TYPE_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,79}")
-_MONITOR_ERROR_CONTEXT_RE = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_.:-]{0,159}")
-_MONITOR_ERROR_SENSITIVE_RE = re.compile(
-    r"(?:api[_-]?key|secret|token|signature|authorization|auth|password|cookie|"
-    r"credential|bearer|basic|sk[_-]?live)",
-    re.IGNORECASE,
-)
 _MONITOR_ERROR_CONTEXT_MAX_INT = (1 << 63) - 1
-_MONITOR_ERROR_CONTEXT_TOKEN_KEYS = (
-    "source",
-    "stage",
-    "operation",
-    "action",
-    "status",
-    "code",
-    "cycle_id",
-)
+_MONITOR_ERROR_CONTEXT_VALUES = {
+    "source": frozenset(("start_bot", "run_execution_loop", "update_pnls")),
+    "stage": frozenset(
+        (
+            "start",
+            "boot_stagger",
+            "format_approved_ignored_coins",
+            "init_markets",
+            "warmup_trading_ready_candles",
+            "equity_hard_stop_initialize_from_history",
+            "equity_hard_stop_initialize_coin_from_history",
+            "post_init_sleep",
+            "start_data_maintainers",
+            "start_background_candle_warmup",
+        )
+    ),
+}
 _MONITOR_ERROR_CONTEXT_COUNT_KEYS = (
     "attempt",
     "count",
@@ -87,15 +89,9 @@ def _safe_monitor_error_context(payload: Any) -> dict[str, Any]:
     if not isinstance(payload, dict):
         return {}
     context: dict[str, Any] = {}
-    for key in _MONITOR_ERROR_CONTEXT_TOKEN_KEYS:
+    for key, allowed_values in _MONITOR_ERROR_CONTEXT_VALUES.items():
         value = payload.get(key)
-        if value is None:
-            continue
-        if not isinstance(value, str):
-            continue
-        if _MONITOR_ERROR_SENSITIVE_RE.search(value):
-            continue
-        if _MONITOR_ERROR_CONTEXT_RE.fullmatch(value):
+        if isinstance(value, str) and value in allowed_values:
             context[key] = value
     for key in _MONITOR_ERROR_CONTEXT_COUNT_KEYS:
         value = payload.get(key)

--- a/src/monitor_publisher.py
+++ b/src/monitor_publisher.py
@@ -57,7 +57,6 @@ _EVENT_RECOVERY_MARKER = b',"_recovery":{"checksum":"'
 _EVENT_RECOVERY_SEQ_SEPARATOR = b'","seq":'
 _EVENT_RECOVERY_TRAILER_MAX_BYTES = 160
 _MONITOR_ERROR_TYPE_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,79}")
-_MONITOR_ERROR_CONTEXT_MAX_INT = (1 << 63) - 1
 _MONITOR_ERROR_CONTEXT_VALUES = {
     "source": frozenset(("start_bot", "run_execution_loop", "update_pnls")),
     "stage": frozenset(
@@ -75,10 +74,6 @@ _MONITOR_ERROR_CONTEXT_VALUES = {
         )
     ),
 }
-_MONITOR_ERROR_CONTEXT_COUNT_KEYS = (
-    "attempt",
-    "count",
-)
 
 
 def _empty_monitor_event_phase_timing() -> dict[str, int]:
@@ -92,12 +87,6 @@ def _safe_monitor_error_context(payload: Any) -> dict[str, Any]:
     for key, allowed_values in _MONITOR_ERROR_CONTEXT_VALUES.items():
         value = payload.get(key)
         if isinstance(value, str) and value in allowed_values:
-            context[key] = value
-    for key in _MONITOR_ERROR_CONTEXT_COUNT_KEYS:
-        value = payload.get(key)
-        if isinstance(value, bool) or not isinstance(value, int):
-            continue
-        if 0 <= value <= _MONITOR_ERROR_CONTEXT_MAX_INT:
             context[key] = value
     return context
 

--- a/src/monitor_publisher.py
+++ b/src/monitor_publisher.py
@@ -5,7 +5,9 @@ import hashlib
 import errno
 import json
 import logging
+import math
 import os
+import re
 import stat
 import threading
 import time
@@ -55,10 +57,55 @@ _EVENT_RECOVERY_CHECKSUM_BYTES = 16
 _EVENT_RECOVERY_MARKER = b',"_recovery":{"checksum":"'
 _EVENT_RECOVERY_SEQ_SEPARATOR = b'","seq":'
 _EVENT_RECOVERY_TRAILER_MAX_BYTES = 160
+_MONITOR_ERROR_TYPE_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,79}")
+_MONITOR_ERROR_CONTEXT_RE = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_./:-]{0,159}")
+_MONITOR_ERROR_CONTEXT_MAX_INT = (1 << 63) - 1
+_MONITOR_ERROR_CONTEXT_KEYS = (
+    "source",
+    "stage",
+    "operation",
+    "action",
+    "status",
+    "code",
+    "endpoint",
+    "cycle_id",
+    "attempt",
+    "count",
+)
 
 
 def _empty_monitor_event_phase_timing() -> dict[str, int]:
     return {key: 0 for key in _MONITOR_EVENT_PHASE_TIMING_KEYS}
+
+
+def _safe_monitor_error_context(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {}
+    context: dict[str, Any] = {}
+    for key in _MONITOR_ERROR_CONTEXT_KEYS:
+        value = payload.get(key)
+        if value is None:
+            continue
+        if isinstance(value, bool):
+            context[key] = value
+        elif isinstance(value, int):
+            if (
+                -_MONITOR_ERROR_CONTEXT_MAX_INT
+                <= value
+                <= _MONITOR_ERROR_CONTEXT_MAX_INT
+            ):
+                context[key] = value
+        elif isinstance(value, float):
+            if math.isfinite(value):
+                context[key] = value
+        else:
+            try:
+                text = str(value)
+            except Exception:
+                continue
+            if "://" not in text and _MONITOR_ERROR_CONTEXT_RE.fullmatch(text):
+                context[key] = text
+    return context
 
 
 def _merge_retention_timing(target: dict[str, int], source: dict[str, int]) -> None:
@@ -1173,9 +1220,11 @@ class MonitorPublisher:
         symbol: Optional[str] = None,
         pside: Optional[str] = None,
     ) -> Optional[dict]:
-        error_payload = dict(payload or {})
-        error_payload["error_type"] = type(error).__name__
-        error_payload["message"] = str(error)
+        error_payload = _safe_monitor_error_context(payload)
+        error_type = type(error).__name__
+        error_payload["error_type"] = (
+            error_type if _MONITOR_ERROR_TYPE_RE.fullmatch(error_type) else "unknown"
+        )
         return self.record_event(
             kind,
             tags or ("error",),

--- a/src/monitor_publisher.py
+++ b/src/monitor_publisher.py
@@ -5,7 +5,6 @@ import hashlib
 import errno
 import json
 import logging
-import math
 import os
 import re
 import stat
@@ -58,17 +57,23 @@ _EVENT_RECOVERY_MARKER = b',"_recovery":{"checksum":"'
 _EVENT_RECOVERY_SEQ_SEPARATOR = b'","seq":'
 _EVENT_RECOVERY_TRAILER_MAX_BYTES = 160
 _MONITOR_ERROR_TYPE_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,79}")
-_MONITOR_ERROR_CONTEXT_RE = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_./:-]{0,159}")
+_MONITOR_ERROR_CONTEXT_RE = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_.:-]{0,159}")
+_MONITOR_ERROR_SENSITIVE_RE = re.compile(
+    r"(?:api[_-]?key|secret|token|signature|authorization|auth|password|cookie|"
+    r"credential|bearer|basic|sk[_-]?live)",
+    re.IGNORECASE,
+)
 _MONITOR_ERROR_CONTEXT_MAX_INT = (1 << 63) - 1
-_MONITOR_ERROR_CONTEXT_KEYS = (
+_MONITOR_ERROR_CONTEXT_TOKEN_KEYS = (
     "source",
     "stage",
     "operation",
     "action",
     "status",
     "code",
-    "endpoint",
     "cycle_id",
+)
+_MONITOR_ERROR_CONTEXT_COUNT_KEYS = (
     "attempt",
     "count",
 )
@@ -82,29 +87,22 @@ def _safe_monitor_error_context(payload: Any) -> dict[str, Any]:
     if not isinstance(payload, dict):
         return {}
     context: dict[str, Any] = {}
-    for key in _MONITOR_ERROR_CONTEXT_KEYS:
+    for key in _MONITOR_ERROR_CONTEXT_TOKEN_KEYS:
         value = payload.get(key)
         if value is None:
             continue
-        if isinstance(value, bool):
+        if not isinstance(value, str):
+            continue
+        if _MONITOR_ERROR_SENSITIVE_RE.search(value):
+            continue
+        if _MONITOR_ERROR_CONTEXT_RE.fullmatch(value):
             context[key] = value
-        elif isinstance(value, int):
-            if (
-                -_MONITOR_ERROR_CONTEXT_MAX_INT
-                <= value
-                <= _MONITOR_ERROR_CONTEXT_MAX_INT
-            ):
-                context[key] = value
-        elif isinstance(value, float):
-            if math.isfinite(value):
-                context[key] = value
-        else:
-            try:
-                text = str(value)
-            except Exception:
-                continue
-            if "://" not in text and _MONITOR_ERROR_CONTEXT_RE.fullmatch(text):
-                context[key] = text
+    for key in _MONITOR_ERROR_CONTEXT_COUNT_KEYS:
+        value = payload.get(key)
+        if isinstance(value, bool) or not isinstance(value, int):
+            continue
+        if 0 <= value <= _MONITOR_ERROR_CONTEXT_MAX_INT:
+            context[key] = value
     return context
 
 

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -6632,7 +6632,11 @@ class Passivbot:
                             if char.isascii() and (char.isalnum() or char in "._-")
                         )[:48]
                     raw_function_name = str(frame.name)
-                    if _WS_STACK_COMPONENT_SENSITIVE_RE.search(raw_function_name):
+                    if (
+                        "://" in raw_function_name
+                        or any(char in raw_function_name for char in "?=#&/")
+                        or _WS_STACK_COMPONENT_SENSITIVE_RE.search(raw_function_name)
+                    ):
                         function_name = "redacted"
                     else:
                         function_name = "".join(

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -182,11 +182,6 @@ from strategy_warmup import (
 
 NetworkError = ccxt_errors.NetworkError
 RateLimitExceeded = ccxt_errors.RateLimitExceeded
-_WS_STACK_COMPONENT_SENSITIVE_RE = re.compile(
-    r"(?:api[_-]?key|secret|token|signature|authorization|password|cookie|"
-    r"credential|bearer|sk[_-]?live)",
-    re.IGNORECASE,
-)
 # Some isolated tests stub ccxt.base.errors without RequestTimeout; treat it as a
 # NetworkError-class transient startup error when the dedicated symbol is absent.
 RequestTimeout = getattr(ccxt_errors, "RequestTimeout", NetworkError)
@@ -6616,45 +6611,14 @@ class Passivbot:
                 reconnect_no <= 1
                 or now_ms - last_traceback_ms >= 15 * 60 * 1000
             ):
-                stack_frames = []
-                for frame in traceback.extract_tb(exc.__traceback__)[-4:]:
-                    raw_file_name = str(frame.filename)
-                    if (
-                        "://" in raw_file_name
-                        or any(char in raw_file_name for char in "?=#&")
-                        or _WS_STACK_COMPONENT_SENSITIVE_RE.search(raw_file_name)
-                    ):
-                        file_name = "redacted"
-                    else:
-                        file_name = "".join(
-                            char
-                            for char in Path(raw_file_name).name
-                            if char.isascii() and (char.isalnum() or char in "._-")
-                        )[:48]
-                    raw_function_name = str(frame.name)
-                    if (
-                        "://" in raw_function_name
-                        or any(char in raw_function_name for char in "?=#&/")
-                        or _WS_STACK_COMPONENT_SENSITIVE_RE.search(raw_function_name)
-                    ):
-                        function_name = "redacted"
-                    else:
-                        function_name = "".join(
-                            char
-                            for char in raw_function_name
-                            if char.isascii() and (char.isalnum() or char == "_")
-                        )[:48]
-                    stack_frames.append(
-                        f"{file_name or 'unknown'}:{max(0, int(frame.lineno))}:"
-                        f"{function_name or 'unknown'}"
-                    )
-                if stack_frames:
+                stack_depth = len(traceback.extract_tb(exc.__traceback__)[-4:])
+                if stack_depth:
                     traceback_emitted = True
                     self._ws_reconnect_traceback_last_ms = now_ms
                     logging.debug(
-                        "[ws] %s: reconnect stack_frames=%s",
+                        "[ws] %s: reconnect stack_frames=%d",
                         exchange,
-                        " <- ".join(stack_frames),
+                        stack_depth,
                     )
         self._emit_websocket_reconnect_event(
             reconnect_no=reconnect_no,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -24,6 +24,7 @@ from numbers import Integral
 import passivbot_rust as pbr
 import logging
 import math
+import re
 from pathlib import Path
 from cli_utils import (
     add_help_all_argument,
@@ -178,10 +179,14 @@ from strategy_warmup import (
     strategy_warmup_requirements,
     strategy_warmup_value,
 )
-import re
 
 NetworkError = ccxt_errors.NetworkError
 RateLimitExceeded = ccxt_errors.RateLimitExceeded
+_WS_STACK_COMPONENT_SENSITIVE_RE = re.compile(
+    r"(?:api[_-]?key|secret|token|signature|authorization|password|cookie|"
+    r"credential|bearer|sk[_-]?live)",
+    re.IGNORECASE,
+)
 # Some isolated tests stub ccxt.base.errors without RequestTimeout; treat it as a
 # NetworkError-class transient startup error when the dedicated symbol is absent.
 RequestTimeout = getattr(ccxt_errors, "RequestTimeout", NetworkError)
@@ -6607,19 +6612,34 @@ class Passivbot:
             last_traceback_ms = int(
                 getattr(self, "_ws_reconnect_traceback_last_ms", 0) or 0
             )
-            if reconnect_no <= 1 or now_ms - last_traceback_ms >= 15 * 60 * 1000:
+            if logging.getLogger().isEnabledFor(logging.DEBUG) and (
+                reconnect_no <= 1
+                or now_ms - last_traceback_ms >= 15 * 60 * 1000
+            ):
                 stack_frames = []
                 for frame in traceback.extract_tb(exc.__traceback__)[-4:]:
-                    file_name = "".join(
-                        char
-                        for char in Path(frame.filename).name
-                        if char.isascii() and (char.isalnum() or char in "._-")
-                    )[:48]
-                    function_name = "".join(
-                        char
-                        for char in frame.name
-                        if char.isascii() and (char.isalnum() or char == "_")
-                    )[:48]
+                    raw_file_name = str(frame.filename)
+                    if (
+                        "://" in raw_file_name
+                        or any(char in raw_file_name for char in "?=#&")
+                        or _WS_STACK_COMPONENT_SENSITIVE_RE.search(raw_file_name)
+                    ):
+                        file_name = "redacted"
+                    else:
+                        file_name = "".join(
+                            char
+                            for char in Path(raw_file_name).name
+                            if char.isascii() and (char.isalnum() or char in "._-")
+                        )[:48]
+                    raw_function_name = str(frame.name)
+                    if _WS_STACK_COMPONENT_SENSITIVE_RE.search(raw_function_name):
+                        function_name = "redacted"
+                    else:
+                        function_name = "".join(
+                            char
+                            for char in raw_function_name
+                            if char.isascii() and (char.isalnum() or char == "_")
+                        )[:48]
                     stack_frames.append(
                         f"{file_name or 'unknown'}:{max(0, int(frame.lineno))}:"
                         f"{function_name or 'unknown'}"

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -6611,7 +6611,11 @@ class Passivbot:
                 reconnect_no <= 1
                 or now_ms - last_traceback_ms >= 15 * 60 * 1000
             ):
-                stack_depth = len(traceback.extract_tb(exc.__traceback__)[-4:])
+                stack_depth = 0
+                current_tb = exc.__traceback__
+                while current_tb is not None and stack_depth < 4:
+                    stack_depth += 1
+                    current_tb = current_tb.tb_next
                 if stack_depth:
                     traceback_emitted = True
                     self._ws_reconnect_traceback_last_ms = now_ms

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -6563,6 +6563,16 @@ class Passivbot:
         reconnect_no = int(reconnect_no or 0)
         retry_delay_s = max(0.0, float(retry_delay_s or 0.0))
         reason = str(reason or "connection_lost")
+        if reason not in {"connection_lost", "rate_limited", "time_sync"}:
+            reason = "other"
+        error_type = None
+        if exc is not None:
+            candidate_error_type = type(exc).__name__
+            error_type = (
+                candidate_error_type
+                if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]{0,79}", candidate_error_type)
+                else "unknown"
+            )
         warning_visible = Passivbot._should_log_ws_reconnect_warning(
             self, reconnect_no
         )
@@ -6576,7 +6586,7 @@ class Passivbot:
                 retry_delay_s,
             )
         else:
-            exc_name = type(exc).__name__ if exc is not None else reason
+            exc_name = error_type if error_type is not None else reason
             logging.log(
                 level,
                 "[ws] %s: connection lost (reconnect #%d), retrying in %.1fs: %s",
@@ -6588,23 +6598,40 @@ class Passivbot:
         traceback_emitted = False
         if exc is not None:
             logging.debug(
-                "[ws] %s: reconnect reason=%s exception=%s", exchange, reason, exc
+                "[ws] %s: reconnect reason=%s error_type=%s",
+                exchange,
+                reason,
+                error_type,
             )
             now_ms = utc_ms()
             last_traceback_ms = int(
                 getattr(self, "_ws_reconnect_traceback_last_ms", 0) or 0
             )
             if reconnect_no <= 1 or now_ms - last_traceback_ms >= 15 * 60 * 1000:
-                traceback_emitted = True
-                self._ws_reconnect_traceback_last_ms = now_ms
-                logging.debug(
-                    "[ws] %s: reconnect traceback follows (throttled)", exchange
-                )
-                logging.debug(
-                    "".join(
-                        traceback.format_exception(type(exc), exc, exc.__traceback__)
+                stack_frames = []
+                for frame in traceback.extract_tb(exc.__traceback__)[-4:]:
+                    file_name = "".join(
+                        char
+                        for char in Path(frame.filename).name
+                        if char.isascii() and (char.isalnum() or char in "._-")
+                    )[:48]
+                    function_name = "".join(
+                        char
+                        for char in frame.name
+                        if char.isascii() and (char.isalnum() or char == "_")
+                    )[:48]
+                    stack_frames.append(
+                        f"{file_name or 'unknown'}:{max(0, int(frame.lineno))}:"
+                        f"{function_name or 'unknown'}"
                     )
-                )
+                if stack_frames:
+                    traceback_emitted = True
+                    self._ws_reconnect_traceback_last_ms = now_ms
+                    logging.debug(
+                        "[ws] %s: reconnect stack_frames=%s",
+                        exchange,
+                        " <- ".join(stack_frames),
+                    )
         self._emit_websocket_reconnect_event(
             reconnect_no=reconnect_no,
             retry_delay_s=retry_delay_s,

--- a/tests/test_monitor_publisher.py
+++ b/tests/test_monitor_publisher.py
@@ -92,7 +92,7 @@ def test_monitor_publisher_record_error_redacts_diagnostic_fields_and_keeps_safe
         payload={
             "source": "start_bot",
             "operation": "load_account",
-            "attempt": 2,
+            "attempt": 1_234_567_890_123_456_789,
             "status": schemeless_url,
             "count": 1 << 80,
             "stage": "init_markets",
@@ -129,7 +129,6 @@ def test_monitor_publisher_record_error_redacts_diagnostic_fields_and_keeps_safe
     assert event["payload"] == {
         "source": "start_bot",
         "stage": "init_markets",
-        "attempt": 2,
         "error_type": "RuntimeError",
     }
 
@@ -140,14 +139,12 @@ def test_monitor_publisher_record_error_redacts_diagnostic_fields_and_keeps_safe
             "source": opaque_token,
             "stage": opaque_token,
             "status": opaque_token,
-            "attempt": 3,
+            "attempt": 1_234_567_890_123_456_789,
+            "count": 123_456_789_012_345_678,
         },
         ts=1_235,
     )
-    assert opaque_event["payload"] == {
-        "attempt": 3,
-        "error_type": "RuntimeError",
-    }
+    assert opaque_event["payload"] == {"error_type": "RuntimeError"}
 
     serialized = publisher.current_events_path.read_text()
     assert secret not in serialized

--- a/tests/test_monitor_publisher.py
+++ b/tests/test_monitor_publisher.py
@@ -72,6 +72,8 @@ def test_monitor_publisher_record_error_redacts_diagnostic_fields_and_keeps_safe
 ):
     publisher = _make_publisher(tmp_path)
     secret = "https://api.example.test/private?api_key=top-secret Authorization: Bearer top-secret"
+    schemeless_secret = "api.example.test/private/api_key/top-secret"
+    schemeless_url = "api.kucoin.com/api/v1/accounts"
 
     class Unrenderable:
         def __str__(self):
@@ -83,10 +85,14 @@ def test_monitor_publisher_record_error_redacts_diagnostic_fields_and_keeps_safe
         tags=("error", "bot"),
         payload={
             "source": "startup",
+            "operation": "load_account",
             "attempt": 2,
             "status": Unrenderable(),
             "count": 1 << 80,
-            "stage": secret,
+            "stage": schemeless_url,
+            "endpoint": schemeless_secret,
+            "code": "api_key_top-secret",
+            "action": "sk_live_123456",
             "message": secret,
             "error": secret,
             "error_repr": secret,
@@ -114,12 +120,15 @@ def test_monitor_publisher_record_error_redacts_diagnostic_fields_and_keeps_safe
     assert event["pside"] == "long"
     assert event["payload"] == {
         "source": "startup",
+        "operation": "load_account",
         "attempt": 2,
         "error_type": "RuntimeError",
     }
 
     serialized = publisher.current_events_path.read_text()
     assert secret not in serialized
+    assert schemeless_secret not in serialized
+    assert schemeless_url not in serialized
     assert publisher.record_event("bot.stop", ("bot",), ts=1_235)["seq"] == 2
     assert len(publisher.current_events_path.read_text().splitlines()) == 2
 

--- a/tests/test_monitor_publisher.py
+++ b/tests/test_monitor_publisher.py
@@ -39,7 +39,9 @@ def test_monitor_publisher_writes_manifest_events_and_snapshot(tmp_path):
 
     event = publisher.record_event("bot.start", ("bot", "lifecycle"), {"status": "starting"}, ts=1000)
     assert event["seq"] == 1
-    publisher.record_error("error.bot", RuntimeError("boom"), payload={"source": "test"}, ts=1001)
+    publisher.record_error(
+        "error.bot", RuntimeError("boom"), payload={"source": "start_bot"}, ts=1001
+    )
     publisher.close()
 
     root = tmp_path / "bybit" / "user01"
@@ -52,7 +54,7 @@ def test_monitor_publisher_writes_manifest_events_and_snapshot(tmp_path):
     events = [json.loads(line) for line in (root / "events" / "current.ndjson").read_text().splitlines()]
     assert [event["kind"] for event in events] == ["bot.start", "error.bot"]
     assert events[1]["payload"]["error_type"] == "RuntimeError"
-    assert events[1]["payload"]["source"] == "test"
+    assert events[1]["payload"]["source"] == "start_bot"
 
     written = publisher.write_snapshot(
         {"meta": {"custom": "value"}, "account": {"balance_raw": 123.0}},
@@ -74,6 +76,10 @@ def test_monitor_publisher_record_error_redacts_diagnostic_fields_and_keeps_safe
     secret = "https://api.example.test/private?api_key=top-secret Authorization: Bearer top-secret"
     schemeless_secret = "api.example.test/private/api_key/top-secret"
     schemeless_url = "api.kucoin.com/api/v1/accounts"
+    opaque_token = (
+        "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0."
+        "dGhpc19pc19vcGFxdWVfYnl0ZXM"
+    )
 
     class Unrenderable:
         def __str__(self):
@@ -84,15 +90,17 @@ def test_monitor_publisher_record_error_redacts_diagnostic_fields_and_keeps_safe
         RuntimeError(secret),
         tags=("error", "bot"),
         payload={
-            "source": "startup",
+            "source": "start_bot",
             "operation": "load_account",
             "attempt": 2,
-            "status": Unrenderable(),
+            "status": schemeless_url,
             "count": 1 << 80,
-            "stage": schemeless_url,
+            "stage": "init_markets",
             "endpoint": schemeless_secret,
             "code": "api_key_top-secret",
             "action": "sk_live_123456",
+            "cycle_id": opaque_token,
+            "detail": Unrenderable(),
             "message": secret,
             "error": secret,
             "error_repr": secret,
@@ -119,9 +127,25 @@ def test_monitor_publisher_record_error_redacts_diagnostic_fields_and_keeps_safe
     assert event["symbol"] == "BTC/USDT:USDT"
     assert event["pside"] == "long"
     assert event["payload"] == {
-        "source": "startup",
-        "operation": "load_account",
+        "source": "start_bot",
+        "stage": "init_markets",
         "attempt": 2,
+        "error_type": "RuntimeError",
+    }
+
+    opaque_event = publisher.record_error(
+        "error.bot",
+        RuntimeError("safe"),
+        payload={
+            "source": opaque_token,
+            "stage": opaque_token,
+            "status": opaque_token,
+            "attempt": 3,
+        },
+        ts=1_235,
+    )
+    assert opaque_event["payload"] == {
+        "attempt": 3,
         "error_type": "RuntimeError",
     }
 
@@ -129,8 +153,9 @@ def test_monitor_publisher_record_error_redacts_diagnostic_fields_and_keeps_safe
     assert secret not in serialized
     assert schemeless_secret not in serialized
     assert schemeless_url not in serialized
-    assert publisher.record_event("bot.stop", ("bot",), ts=1_235)["seq"] == 2
-    assert len(publisher.current_events_path.read_text().splitlines()) == 2
+    assert opaque_token not in serialized
+    assert publisher.record_event("bot.stop", ("bot",), ts=1_236)["seq"] == 3
+    assert len(publisher.current_events_path.read_text().splitlines()) == 3
 
 
 def test_monitor_publisher_record_error_bounds_pathological_exception_type(tmp_path):

--- a/tests/test_monitor_publisher.py
+++ b/tests/test_monitor_publisher.py
@@ -67,6 +67,73 @@ def test_monitor_publisher_writes_manifest_events_and_snapshot(tmp_path):
     assert snapshot["account"]["balance_raw"] == 123.0
 
 
+def test_monitor_publisher_record_error_redacts_diagnostic_fields_and_keeps_safe_context(
+    tmp_path,
+):
+    publisher = _make_publisher(tmp_path)
+    secret = "https://api.example.test/private?api_key=top-secret Authorization: Bearer top-secret"
+
+    class Unrenderable:
+        def __str__(self):
+            raise RuntimeError(secret)
+
+    event = publisher.record_error(
+        "error.bot",
+        RuntimeError(secret),
+        tags=("error", "bot"),
+        payload={
+            "source": "startup",
+            "attempt": 2,
+            "status": Unrenderable(),
+            "count": 1 << 80,
+            "stage": secret,
+            "message": secret,
+            "error": secret,
+            "error_repr": secret,
+            "exception": secret,
+            "traceback": secret,
+            "url": secret,
+            "raw_response": secret,
+            "authorization": secret,
+            "context": {
+                "operation": "load_account",
+                "response_body": secret,
+                "nested": {"request_headers": secret, "safe": "kept"},
+            },
+        },
+        ts=1_234,
+        symbol="BTC/USDT:USDT",
+        pside="long",
+    )
+
+    assert event["ts"] == 1_234
+    assert event["seq"] == 1
+    assert event["kind"] == "error.bot"
+    assert event["tags"] == ["error", "bot"]
+    assert event["symbol"] == "BTC/USDT:USDT"
+    assert event["pside"] == "long"
+    assert event["payload"] == {
+        "source": "startup",
+        "attempt": 2,
+        "error_type": "RuntimeError",
+    }
+
+    serialized = publisher.current_events_path.read_text()
+    assert secret not in serialized
+    assert publisher.record_event("bot.stop", ("bot",), ts=1_235)["seq"] == 2
+    assert len(publisher.current_events_path.read_text().splitlines()) == 2
+
+
+def test_monitor_publisher_record_error_bounds_pathological_exception_type(tmp_path):
+    publisher = _make_publisher(tmp_path)
+    pathological_error = type("Error" + "X" * 512, (Exception,), {})
+
+    event = publisher.record_error("error.bot", pathological_error("safe"))
+
+    assert event["payload"]["error_type"] == "unknown"
+    assert len(event["payload"]["error_type"]) <= 80
+
+
 def test_monitor_publisher_records_fills_ticks_and_completed_candles(tmp_path):
     publisher = _make_publisher(tmp_path, price_tick_min_interval_ms=500)
 

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -2999,22 +2999,20 @@ def test_ws_reconnect_redacts_sensitive_traceback_frame_components(monkeypatch, 
         monitor_sinks=[],
     )
     monkeypatch.setattr(passivbot_module, "utc_ms", lambda: 1_000_000)
-    source = (
-        "def api_key_SECRET_TOKEN():\n"
-        "    raise TimeoutError('safe')\n"
-        "api_key_SECRET_TOKEN()\n"
+    def raise_timeout():
+        raise TimeoutError("safe")
+
+    sensitive_function = types.FunctionType(
+        raise_timeout.__code__.replace(
+            co_name="wss://ws.example/private?id=opaque123",
+            co_filename="wss://ws.example/private?api_key=SECRET_TOKEN",
+        ),
+        globals(),
     )
 
     with caplog.at_level(logging.DEBUG):
         try:
-            exec(
-                compile(
-                    source,
-                    "wss://ws.example/private?api_key=SECRET_TOKEN",
-                    "exec",
-                ),
-                {},
-            )
+            sensitive_function()
         except TimeoutError as exc:
             Passivbot._log_ws_reconnect(
                 bot,
@@ -3024,6 +3022,7 @@ def test_ws_reconnect_redacts_sensitive_traceback_frame_components(monkeypatch, 
                 exc=exc,
             )
 
+    assert "opaque123" not in caplog.text
     assert "SECRET_TOKEN" not in caplog.text
     assert "api_key" not in caplog.text
     assert "wss://" not in caplog.text

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -3027,7 +3027,6 @@ def test_ws_reconnect_redacts_sensitive_traceback_frame_components(monkeypatch, 
     assert "api_key" not in caplog.text
     assert "wss://" not in caplog.text
     assert "stack_frames=" in caplog.text
-    assert "redacted" in caplog.text
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
     assert sink.events[-1].data["traceback_emitted"] is True
     assert bot._live_event_pipeline.close(timeout=2.0) is True

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -3032,6 +3032,46 @@ def test_ws_reconnect_redacts_sensitive_traceback_frame_components(monkeypatch, 
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_ws_reconnect_bounds_stack_depth_without_extracting_traceback(
+    monkeypatch, caplog
+):
+    sink = ListEventSink()
+    bot = Passivbot.__new__(Passivbot)
+    bot.exchange = "kucoin"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: 1_000_000)
+    monkeypatch.setattr(
+        passivbot_module.traceback,
+        "extract_tb",
+        lambda *_args, **_kwargs: pytest.fail("traceback extraction must stay unused"),
+    )
+
+    def raise_deep(depth):
+        if depth:
+            return raise_deep(depth - 1)
+        raise TimeoutError("safe")
+
+    with caplog.at_level(logging.DEBUG):
+        try:
+            raise_deep(12)
+        except TimeoutError as exc:
+            Passivbot._log_ws_reconnect(
+                bot,
+                reconnect_no=1,
+                retry_delay_s=1.0,
+                reason="connection_lost",
+                exc=exc,
+            )
+
+    assert "stack_frames=4" in caplog.text
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert sink.events[-1].data["traceback_emitted"] is True
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_ws_reconnect_does_not_consume_traceback_cadence_when_debug_disabled(
     monkeypatch, caplog
 ):

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -2899,15 +2899,27 @@ def test_ws_reconnect_emits_bounded_structured_event(monkeypatch, caplog):
     )
     now_ms = [1_000]
     monkeypatch.setattr(passivbot_module, "utc_ms", lambda: now_ms[0])
+    exception_value = "wss://ws.example.test/reconnect?api_key=SECRET_TOKEN"
 
     with caplog.at_level(logging.DEBUG):
-        Passivbot._log_ws_reconnect(
-            bot,
-            reconnect_no=1,
-            retry_delay_s=1.25,
-            reason="time_sync",
-            exc=TimeoutError("api_key=SECRET ping timeout"),
-        )
+        try:
+            raise TimeoutError(exception_value)
+        except TimeoutError as exc:
+            Passivbot._log_ws_reconnect(
+                bot,
+                reconnect_no=1,
+                retry_delay_s=1.25,
+                reason="time_sync",
+                exc=exc,
+            )
+
+    assert exception_value not in caplog.text
+    assert "SECRET_TOKEN" not in caplog.text
+    assert "wss://" not in caplog.text
+    assert "error_type=TimeoutError" in caplog.text
+    assert "reconnect #1" in caplog.text
+    assert "stack_frames=" in caplog.text
+    assert "Traceback" not in caplog.text
 
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
     events = [
@@ -2958,6 +2970,23 @@ def test_ws_reconnect_emits_bounded_structured_event(monkeypatch, caplog):
         "warning_visible": False,
         "traceback_emitted": False,
     }
+
+    pathological_error = type("Error" + "X" * 512, (Exception,), {})
+    with caplog.at_level(logging.DEBUG):
+        Passivbot._log_ws_reconnect(
+            bot,
+            reconnect_no=5,
+            retry_delay_s=3.0,
+            reason="private reason wss://SECRET",
+            exc=pathological_error("wss://SECRET?api_key=SECRET"),
+        )
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    pathological_event = sink.events[-1]
+    assert pathological_event.data["reason"] == "other"
+    assert pathological_event.data["error_type"] == "unknown"
+    assert pathological_event.data["traceback_emitted"] is False
+    assert "error_type=unknown" in caplog.text
+    assert "wss://SECRET" not in caplog.text
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -2990,6 +2990,95 @@ def test_ws_reconnect_emits_bounded_structured_event(monkeypatch, caplog):
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_ws_reconnect_redacts_sensitive_traceback_frame_components(monkeypatch, caplog):
+    sink = ListEventSink()
+    bot = Passivbot.__new__(Passivbot)
+    bot.exchange = "kucoin"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: 1_000_000)
+    source = (
+        "def api_key_SECRET_TOKEN():\n"
+        "    raise TimeoutError('safe')\n"
+        "api_key_SECRET_TOKEN()\n"
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        try:
+            exec(
+                compile(
+                    source,
+                    "wss://ws.example/private?api_key=SECRET_TOKEN",
+                    "exec",
+                ),
+                {},
+            )
+        except TimeoutError as exc:
+            Passivbot._log_ws_reconnect(
+                bot,
+                reconnect_no=1,
+                retry_delay_s=1.0,
+                reason="connection_lost",
+                exc=exc,
+            )
+
+    assert "SECRET_TOKEN" not in caplog.text
+    assert "api_key" not in caplog.text
+    assert "wss://" not in caplog.text
+    assert "stack_frames=" in caplog.text
+    assert "redacted" in caplog.text
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert sink.events[-1].data["traceback_emitted"] is True
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_ws_reconnect_does_not_consume_traceback_cadence_when_debug_disabled(
+    monkeypatch, caplog
+):
+    sink = ListEventSink()
+    bot = Passivbot.__new__(Passivbot)
+    bot.exchange = "kucoin"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: 1_000_000)
+
+    try:
+        raise TimeoutError("safe")
+    except TimeoutError as exc:
+        with caplog.at_level(logging.INFO):
+            Passivbot._log_ws_reconnect(
+                bot,
+                reconnect_no=1,
+                retry_delay_s=1.0,
+                reason="connection_lost",
+                exc=exc,
+            )
+        assert bot._live_event_pipeline.flush(timeout=2.0) is True
+        assert sink.events[-1].data["traceback_emitted"] is False
+        assert not hasattr(bot, "_ws_reconnect_traceback_last_ms")
+        assert "stack_frames=" not in caplog.text
+
+        caplog.clear()
+        with caplog.at_level(logging.DEBUG):
+            Passivbot._log_ws_reconnect(
+                bot,
+                reconnect_no=2,
+                retry_delay_s=1.0,
+                reason="connection_lost",
+                exc=exc,
+            )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert sink.events[-1].data["traceback_emitted"] is True
+    assert bot._ws_reconnect_traceback_last_ms == 1_000_000
+    assert "stack_frames=" in caplog.text
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 @pytest.mark.asyncio
 async def test_background_candle_warmup_marks_full_warmup_ready(monkeypatch, caplog):
     bot = Passivbot.__new__(Passivbot)


### PR DESCRIPTION
## Scope

Category: observability producer and runtime projection.

- Remove arbitrary exception messages and caller-supplied raw diagnostic aliases from legacy `MonitorPublisher.record_error` persistence.
- Retain only exact code-owned source/stage classifications and a bounded exception type.
- Replace WebSocket reconnect exception values, frame labels, line values, and formatted exception tracebacks with bounded reason/error classifications and count-only stack depth capped at four.
- Bound the structured `websocket.reconnect` exception type at the same producer boundary.
- Record PR #1344 merge and VPS5 deployment evidence in the active status and historical ledger.

Non-goals: no monitor framing, sequence, rotation, retention, sink isolation, reconnect cadence, retry/backoff, connector call, exception propagation, exchange interaction, planning, order, risk, or trading change.

## Expected Impact

Legacy monitor error events and WebSocket reconnect human diagnostics no longer retain arbitrary exception text, numbers, URLs, response-like fields, credentials, traceback labels, line values, or formatted exception-value tracebacks. Safe classifications, bounded stack depth, and operational correlation remain available. Trading and reconnect behavior are unchanged.

Expected VPS action: tracked-clean pull, one exact-five graceful restart, and bounded immediate/settled smoke; preserve `misc:0.0`.

## Validation

- `tests/test_monitor_publisher.py`: 50 passed
- `tests/test_live_event_bus.py`: 133 passed
- `tests/test_passivbot_balance_split.py`: 265 passed
- `tests/test_passivbot_monitor.py`: 100 passed
- `tests/test_live_smoke_report.py -k 'problem_event or hard_problem'`: 13 passed
- `tests/test_ai_docs.py tests/test_live_event_registry_docs.py`: 4 passed
- changed Python files compile
- live event registry check passes
- AI docs check: 0 errors, existing word-count warning only
- `git diff --check` passes

The shared local venv has stale CCXT 4.5.48 while the repository pins 4.5.66. The Passivbot-heavy suite used an import-time version override only; it does not exercise CCXT behavior. GitHub CI must validate under the pinned dependency.

## Reviewer Focus

- Confirm `record_error` preserves the current code-owned source/stage classifications and event sequencing while failing closed on all other caller values.
- Confirm reconnect DEBUG evidence contains only stack depth capped at four, with no traceback-derived label, line, path, URL, credential, source-code, or exception value.
- Confirm stack-depth counting is O(1), `traceback_emitted` remains truthful, and no retry/reconnect control flow changes.

@codex review
