### PR TITLE
Redact live event emitter failure diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Best-effort live event emitter failure diagnostics, including HSL event emitters, now retain
+  bounded exception types instead of arbitrary exception messages that may contain request URLs,
+  response text, or credentials. Event payloads, routing, sink isolation, retries, HSL behavior,
+  and trading behavior are unchanged.
+
 - Legacy monitor error events and WebSocket reconnect diagnostics now retain bounded exception
   classifications without arbitrary exception messages, request URLs, response text, or formatted
   exception-value tracebacks. Monitor error context is restricted to known code-owned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
-- Best-effort live event emitter failure diagnostics, including HSL event emitters, now retain
-  bounded exception types instead of arbitrary exception messages that may contain request URLs,
-  response text, or credentials. Event payloads, routing, sink isolation, retries, HSL behavior,
-  and trading behavior are unchanged.
+- Best-effort live event emitter failure diagnostics, including HSL event emitters and the
+  event-adjacent HSL coin-status human-log fallback, now retain bounded exception types instead of
+  arbitrary exception messages that may contain request URLs, response text, or credentials.
+  Event payloads, routing, sink isolation, retries, HSL behavior, and trading behavior are
+  unchanged.
 
 - Legacy monitor error events and WebSocket reconnect diagnostics now retain bounded exception
   classifications without arbitrary exception messages, request URLs, response text, or formatted

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -60,8 +60,10 @@ Best-effort live event emitters remain isolated from their callers. If event con
 sanitization, or publication fails, the developer DEBUG diagnostic may retain bounded code-owned
 event, action, stage, symbol, or position-side context and a bounded exception type. It must not
 retain the caught exception value, traceback, request URL, response body, credential, or arbitrary
-payload fragment. Redacting the diagnostic must not change the emitter's return value, exception
-isolation, event routing, retries, scheduling, HSL/risk behavior, or trading behavior.
+payload fragment. Invalid type names and identifier-shaped names containing credential markers
+normalize to `Error` before the safe type is bounded. Redacting the diagnostic must not change the
+emitter's return value, exception isolation, event routing, retries, scheduling, HSL/risk behavior,
+or trading behavior.
 The same redaction applies when the event-adjacent HSL coin-status human projection fails; the
 structured `hsl.status` event must still be attempted independently. Other non-event HSL
 diagnostics are outside this contract.

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -60,10 +60,10 @@ Best-effort live event emitters remain isolated from their callers. If event con
 sanitization, or publication fails, the developer DEBUG diagnostic may retain bounded code-owned
 event, action, stage, symbol, or position-side context and a bounded exception type. It must not
 retain the caught exception value, traceback, request URL, response body, credential, or arbitrary
-payload fragment. Invalid type names and identifier-shaped names containing credential markers
-normalize to `Error` before the safe type is bounded. Redacting the diagnostic must not change the
-emitter's return value, exception isolation, event routing, retries, scheduling, HSL/risk behavior,
-or trading behavior.
+payload fragment. Non-built-in string metadata, invalid type names, and identifier-shaped names
+containing credential markers normalize to `Error` before the safe type is bounded. Redacting the
+diagnostic must not change the emitter's return value, exception isolation, event routing, retries,
+scheduling, HSL/risk behavior, or trading behavior.
 The same redaction applies when the event-adjacent HSL coin-status human projection fails; the
 structured `hsl.status` event must still be attempted independently. Other non-event HSL
 diagnostics are outside this contract.

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -62,6 +62,9 @@ event, action, stage, symbol, or position-side context and a bounded exception t
 retain the caught exception value, traceback, request URL, response body, credential, or arbitrary
 payload fragment. Redacting the diagnostic must not change the emitter's return value, exception
 isolation, event routing, retries, scheduling, HSL/risk behavior, or trading behavior.
+The same redaction applies when the event-adjacent HSL coin-status human projection fails; the
+structured `hsl.status` event must still be attempted independently. Other non-event HSL
+diagnostics are outside this contract.
 
 ## Market Snapshot Diagnostic Skips
 

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -54,6 +54,15 @@ retain exception text, request URLs, credentials, response bodies, paths, or oth
 from the sink exception. Sink counters and pipeline timings remain available through health
 snapshots independently of the exception payload.
 
+## Emitter Failure Diagnostics
+
+Best-effort live event emitters remain isolated from their callers. If event construction,
+sanitization, or publication fails, the developer DEBUG diagnostic may retain bounded code-owned
+event, action, stage, symbol, or position-side context and a bounded exception type. It must not
+retain the caught exception value, traceback, request URL, response body, credential, or arbitrary
+payload fragment. Redacting the diagnostic must not change the emitter's return value, exception
+isolation, event routing, retries, scheduling, HSL/risk behavior, or trading behavior.
+
 ## Market Snapshot Diagnostic Skips
 
 `market.snapshot_diagnostic_skipped` records noncritical position-change and balance diagnostics

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -27,7 +27,9 @@ Estimated completion:
   from live metadata after publication.
 - Scope: replace arbitrary caught exception values in best-effort live event
   emitter failure diagnostics with bounded exception types, including HSL
-  event emitters. Preserve existing code-owned event/action context.
+  event emitters and the event-adjacent HSL coin-status human projection.
+  Preserve existing code-owned event/action context. Other non-event HSL
+  diagnostics remain follow-up work.
 - Behavior boundary: developer DEBUG projection only. Event payloads, routing,
   sink isolation, emitter return values, retries, planning, orders, HSL, risk,
   and trading behavior remain unchanged.
@@ -1868,8 +1870,9 @@ above. PR #1344's EMA diagnostic redaction is merged and deployed at canonical
 WebSocket diagnostic redaction is merged and deployed at canonical
 `49cb68e56b20d71fbe42d33f31906d3a9c793e90`. The active
 `codex/event-emitter-exception-redaction` slice removes arbitrary caught
-exception values from best-effort live event emitter diagnostics without
-changing emitter isolation, event payloads, HSL, risk, or trading behavior.
+exception values from best-effort live event emitter diagnostics and the
+event-adjacent HSL coin-status human projection without changing emitter
+isolation, event payloads, HSL, risk, or trading behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,9 +22,10 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch `codex/event-emitter-exception-redaction`, based on canonical
-  `49cb68e56b20d71fbe42d33f31906d3a9c793e90`; resolve its PR and active head
-  from live metadata after publication.
+- Open PR #1346, `Redact live event emitter failure diagnostics`, on branch
+  `codex/event-emitter-exception-redaction`, based on canonical
+  `49cb68e56b20d71fbe42d33f31906d3a9c793e90`. Resolve its active head from
+  live metadata; the commit containing this handoff is a moving review head.
 - Scope: replace arbitrary caught exception values in best-effort live event
   emitter failure diagnostics with bounded exception types, including HSL
   event emitters and the event-adjacent HSL coin-status human projection.
@@ -1868,11 +1869,13 @@ through PR #1343, including adjacent PR #1329, are deployed at canonical
 above. PR #1344's EMA diagnostic redaction is merged and deployed at canonical
 `986e5d52f88692d1b6531bc38c307352c08e9cb9`. PR #1345's legacy monitor and
 WebSocket diagnostic redaction is merged and deployed at canonical
-`49cb68e56b20d71fbe42d33f31906d3a9c793e90`. The active
-`codex/event-emitter-exception-redaction` slice removes arbitrary caught
-exception values from best-effort live event emitter diagnostics and the
-event-adjacent HSL coin-status human projection without changing emitter
-isolation, event payloads, HSL, risk, or trading behavior.
+`49cb68e56b20d71fbe42d33f31906d3a9c793e90`. Open PR #1346, `Redact live
+event emitter failure diagnostics`, on
+`codex/event-emitter-exception-redaction` removes arbitrary caught exception
+values from best-effort live event emitter diagnostics and the event-adjacent
+HSL coin-status human projection without changing emitter isolation, event
+payloads, HSL, risk, or trading behavior. Resolve its exact head from live
+metadata.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -1864,11 +1864,12 @@ slices through PR #1309 are also merged and deployed. Later logging slices
 through PR #1343, including adjacent PR #1329, are deployed at canonical
 `7e26a9062a88ecf211729d7d718fb4530630c4ba`; their current evidence is recorded
 above. PR #1344's EMA diagnostic redaction is merged and deployed at canonical
-`986e5d52f88692d1b6531bc38c307352c08e9cb9`. Active PR #1345 on
-`codex/diagnostic-exception-redaction` removes arbitrary exception text from
-legacy monitor errors and WebSocket reconnect diagnostics without changing
-reconnect cadence, retry behavior, monitor persistence, or trading behavior.
-Resolve its exact current head from live PR metadata.
+`986e5d52f88692d1b6531bc38c307352c08e9cb9`. PR #1345's legacy monitor and
+WebSocket diagnostic redaction is merged and deployed at canonical
+`49cb68e56b20d71fbe42d33f31906d3a9c793e90`. The active
+`codex/event-emitter-exception-redaction` slice removes arbitrary caught
+exception values from best-effort live event emitter diagnostics without
+changing emitter isolation, event payloads, HSL, risk, or trading behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,34 +22,49 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR #1345 `Redact legacy diagnostic exception text`; branch
-  `codex/diagnostic-exception-redaction`, based on canonical
-  `986e5d52f88692d1b6531bc38c307352c08e9cb9`. Its semantic predecessor is
-  `2087466167c59389ebf797bf2b9f2f732aaf96cb`; resolve the active review head
-  from live PR metadata because this status update is the final handoff delta.
-- Scope: remove arbitrary exception text from legacy
-  `MonitorPublisher.record_error` payloads and WebSocket reconnect human
-  diagnostics. Monitor error events retain known code-owned source/stage
-  classifications and a bounded exception type; reconnect diagnostics retain
-  bounded reason/error type, cadence, retry delay, and count-only stack depth
-  without frame labels, line values, or the exception value.
-- Behavior boundary: observability payload and projection only. Monitor event
-  framing, sequence, rotation, retention, and sink isolation remain unchanged,
-  as do reconnect cadence, retry/backoff, connector calls, exception
-  propagation, planning, orders, risk, and trading behavior.
-- Baseline: `MonitorPublisher.record_error` unconditionally persists
-  `str(error)` as `payload.message`; a value-free scan of the latest 4 MB from
-  each of six VPS5 current event segments parsed 9,396 rows and found one
-  natural `error.bot` message field. `_log_ws_reconnect` also writes the raw
-  exception and a formatted traceback containing the exception value, while
-  the existing structured reconnect event is already bounded.
+- Branch `codex/event-emitter-exception-redaction`, based on canonical
+  `49cb68e56b20d71fbe42d33f31906d3a9c793e90`; resolve its PR and active head
+  from live metadata after publication.
+- Scope: replace arbitrary caught exception values in best-effort live event
+  emitter failure diagnostics with bounded exception types, including HSL
+  event emitters. Preserve existing code-owned event/action context.
+- Behavior boundary: developer DEBUG projection only. Event payloads, routing,
+  sink isolation, emitter return values, retries, planning, orders, HSL, risk,
+  and trading behavior remain unchanged.
+- Baseline: the central event-bus failure diagnostic and recent EMA emitters
+  already retain exception type only, while many adjacent event-emitter catch
+  paths still interpolate the raw exception value into the developer text log.
 - Review gate: exact-current-head Hermes approval plus green Python/Rust CI.
   Built-in Codex automatic review is additional and every finding must be
-  verified and resolved. The final handoff/status head requires fresh review
-  and CI before merge.
+  verified and resolved.
 - Expected VPS action: tracked-clean pull plus one exact-five graceful restart
-  and bounded settled smoke because live monitor and reconnect diagnostics
-  change; preserve `misc:0.0`.
+  and bounded settled smoke because live event failure projection changes;
+  preserve `misc:0.0`.
+
+## Deployed Baseline (PR #1345)
+
+- PR #1345 merged exact approved head
+  `e9322f9b50de46fc054f0424751f6f0bea802c7f` as canonical
+  `49cb68e56b20d71fbe42d33f31906d3a9c793e90` after exact-head Hermes
+  approval, green Python/Rust CI, and finding-free built-in Codex and
+  independent Sol reviews.
+- VPS5 guarded-prepared tracked-clean from
+  `986e5d52f88692d1b6531bc38c307352c08e9cb9` without a Rust build. The source
+  fingerprint/stamp remained
+  `691bff9683deec9382a4e96ab6a107c14145f88edd6ae2f8e2380b8ba6824449`, and the
+  compiled artifact SHA remained
+  `7611f3eff1d8702ff29d90490a1aba490db5c816e7e3f09a2c33e5c4085da023`.
+- The bounded exact-target orchestrator gracefully restarted only panes
+  `%358`-`%362` as PIDs `1077958/1077967/1077961/1077970/1077964`. All five
+  prior processes exited and all five exact targets relaunched and verified
+  without force or broad-pattern signals.
+- The integrated 120-second smoke was hard-green with complete shutdown and
+  startup identity, zero hard failures, zero hard text-log or attention
+  matches, and zero monitor warnings or errors. Final three-sample target
+  verification found all five replacement processes stable with no missing,
+  duplicate, or extra live process. The checkout remained exact and
+  tracked-clean, and protected `misc:0.0` stayed `%8`/PID `434835`. No direct
+  authenticated exchange call or event was manufactured.
 
 ## Deployed Baseline (PR #1344)
 

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,27 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1344)
+## Latest Canonical Deployment (PR #1345)
+
+- PR #1345 merged exact approved head `e9322f9b50` as canonical
+  `49cb68e56b20d71fbe42d33f31906d3a9c793e90` after exact-head Hermes
+  approval, green Python/Rust CI, and finding-free built-in Codex and
+  independent Sol reviews.
+- VPS5 guarded-prepared tracked-clean from `986e5d52f8` without a Rust build;
+  the Rust source fingerprint/stamp and compiled artifact remained unchanged.
+  The exact-target orchestrator gracefully restarted only panes `%358`-`%362`
+  as PIDs `1077958/1077967/1077961/1077970/1077964`; all five prior processes
+  exited and all five targets relaunched and verified without force or
+  broad-pattern signals.
+- The integrated 120-second smoke was hard-green with complete shutdown and
+  startup identity, zero hard failures, zero hard log or attention matches,
+  and zero monitor warnings or errors. Final three-sample target verification
+  retained five stable exact processes, a tracked-clean checkout, and
+  protected `misc:0.0` `%8`/PID `434835`. No direct authenticated exchange
+  call or event was manufactured. The next redaction slice removes arbitrary
+  caught exception values from best-effort live event emitter diagnostics.
+
+## Previous Canonical Deployment (PR #1344)
 
 - PR #1344 merged exact approved head
   `6a4fe26f90e8cb25f0dc09ecc39a067658addfa8` as canonical

--- a/src/live/diagnostic_safety.py
+++ b/src/live/diagnostic_safety.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import re
+
+EXCEPTION_TYPE_MAX_LEN = 80
+_SENSITIVE_EXCEPTION_TYPE_RE = re.compile(
+    r"(?i)(?:^|_)(?:api_?key|apikey|authorization|auth|cookie|passphrase|password|"
+    r"private_?key|privatekey|secret|signature|token|wallet_?address|walletaddress)"
+    r"(?:_|$)"
+)
+
+
+def bounded_exception_type(exc: BaseException) -> str:
+    try:
+        name = type(exc).__name__
+        if not isinstance(name, str):
+            return "Error"
+        if (
+            not name
+            or not name.isascii()
+            or not name.isidentifier()
+            or _SENSITIVE_EXCEPTION_TYPE_RE.search(name)
+        ):
+            return "Error"
+        return name[:EXCEPTION_TYPE_MAX_LEN]
+    except BaseException:
+        return "Error"

--- a/src/live/diagnostic_safety.py
+++ b/src/live/diagnostic_safety.py
@@ -12,7 +12,7 @@ _SENSITIVE_EXCEPTION_TYPE_RE = re.compile(
 def bounded_exception_type(exc: BaseException) -> str:
     try:
         name = type(exc).__name__
-        if not isinstance(name, str):
+        if type(name) is not str:
             return "Error"
         if (
             not name

--- a/src/live/diagnostic_safety.py
+++ b/src/live/diagnostic_safety.py
@@ -4,9 +4,8 @@ import re
 
 EXCEPTION_TYPE_MAX_LEN = 80
 _SENSITIVE_EXCEPTION_TYPE_RE = re.compile(
-    r"(?i)(?:^|_)(?:api_?key|apikey|authorization|auth|cookie|passphrase|password|"
-    r"private_?key|privatekey|secret|signature|token|wallet_?address|walletaddress)"
-    r"(?:_|$)"
+    r"(?i)(?:api_?key|apikey|authorization|cookie|passphrase|password|private_?key|"
+    r"privatekey|secret|signature|token|wallet_?address|walletaddress)"
 )
 
 

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -116,11 +116,10 @@ def _bounded_exception_type(exc: BaseException) -> str:
         name = type(exc).__name__
         if not isinstance(name, str):
             return "Error"
-        bounded = name[:_EXCEPTION_TYPE_MAX_LEN]
-        if not bounded or not bounded.isascii() or not bounded.isidentifier():
+        if not name or not name.isascii() or not name.isidentifier():
             return "Error"
-        return bounded
-    except Exception:
+        return name[:_EXCEPTION_TYPE_MAX_LEN]
+    except BaseException:
         return "Error"
 
 

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -114,12 +114,14 @@ _CYCLE_DEGRADED_INVALID_SYMBOL_LIST_KEYS = (
 def _bounded_exception_type(exc: BaseException) -> str:
     try:
         name = type(exc).__name__
+        if not isinstance(name, str):
+            return "Error"
+        bounded = name[:_EXCEPTION_TYPE_MAX_LEN]
+        if not bounded or not bounded.isascii() or not bounded.isidentifier():
+            return "Error"
+        return bounded
     except Exception:
         return "Error"
-    bounded = name[:_EXCEPTION_TYPE_MAX_LEN]
-    if not bounded or not bounded.isascii() or not bounded.isidentifier():
-        return "Error"
-    return bounded
 
 
 _CYCLE_DEGRADED_INVALID_INT_KEYS = (

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -33,7 +33,10 @@ def set_live_event_context_ids(bot: Any, **kwargs: str | None) -> None:
     try:
         pipeline.with_context_ids(**kwargs)
     except Exception as exc:
-        logging.debug("[event] failed updating live event context: %s", exc)
+        logging.debug(
+            "[event] failed updating live event context: %s",
+            _bounded_exception_type(exc),
+        )
 
 
 def next_live_event_remote_call_id(bot: Any, prefix: str = "rc") -> str:
@@ -56,6 +59,7 @@ _EXCHANGE_CONFIG_EVENT_RESPONSE_CODE_RE = re.compile(r"-?[0-9]{1,12}")
 _EXCHANGE_CONFIG_EVENT_ERROR_TYPE_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,79}")
 _EXCHANGE_CONFIG_EVENT_OUTCOMES = {"confirmed", "unchanged", "failed"}
 _LIVE_EVENT_LEVELS = {"debug", "info", "warning", "error"}
+_EXCEPTION_TYPE_MAX_LEN = 80
 _MEMORY_SNAPSHOT_MAX_BYTES = (1 << 63) - 1
 _MEMORY_SNAPSHOT_MAX_COUNT = 1_000_000_000
 _MEMORY_SNAPSHOT_MAX_DELTA_PCT = 1_000_000.0
@@ -105,6 +109,19 @@ _CYCLE_DEGRADED_INVALID_SYMBOL_LIST_KEYS = (
     "extra_symbols",
     "changed_symbols",
 )
+
+
+def _bounded_exception_type(exc: BaseException) -> str:
+    try:
+        name = type(exc).__name__
+    except Exception:
+        return "Error"
+    bounded = name[:_EXCEPTION_TYPE_MAX_LEN]
+    if not bounded or not bounded.isascii() or not bounded.isidentifier():
+        return "Error"
+    return bounded
+
+
 _CYCLE_DEGRADED_INVALID_INT_KEYS = (
     "latest_expected_ts",
     "last_cached_ts",
@@ -562,7 +579,7 @@ def _add_execution_debug_profile(
         logging.debug(
             "[event] failed to build execution debug payload type=%s: %s",
             event_type,
-            exc,
+            _bounded_exception_type(exc),
         )
 
 
@@ -812,7 +829,7 @@ def emit_authoritative_remote_call_event(
             "[event] failed to emit authoritative remote call event surface=%s stage=%s: %s",
             surface,
             stage,
-            exc,
+            _bounded_exception_type(exc),
         )
         return remote_call_id
 
@@ -878,7 +895,10 @@ def emit_exchange_time_sync_event(bot: Any, *args: Any, **kwargs: Any) -> None:
     try:
         _emit_exchange_time_sync_event_unchecked(bot, *args, **kwargs)
     except Exception as exc:
-        logging.debug("[event] failed to emit exchange time-sync event: %s", exc)
+        logging.debug(
+            "[event] failed to emit exchange time-sync event: %s",
+            _bounded_exception_type(exc),
+        )
 
 
 def _emit_websocket_reconnect_event_unchecked(
@@ -925,7 +945,10 @@ def emit_websocket_reconnect_event(bot: Any, *args: Any, **kwargs: Any) -> None:
     try:
         _emit_websocket_reconnect_event_unchecked(bot, *args, **kwargs)
     except Exception as exc:
-        logging.debug("[event] failed to emit websocket reconnect event: %s", exc)
+        logging.debug(
+            "[event] failed to emit websocket reconnect event: %s",
+            _bounded_exception_type(exc),
+        )
 
 
 def _emit_exchange_config_refresh_event_unchecked(
@@ -996,7 +1019,10 @@ def emit_exchange_config_refresh_event(
     try:
         _emit_exchange_config_refresh_event_unchecked(bot, *args, **kwargs)
     except Exception as exc:
-        logging.debug("[event] failed to emit exchange config-refresh event: %s", exc)
+        logging.debug(
+            "[event] failed to emit exchange config-refresh event: %s",
+            _bounded_exception_type(exc),
+        )
 
 
 def begin_live_event_cycle(bot: Any, *, loop_start_ms: int) -> str:
@@ -1185,7 +1211,10 @@ def emit_planning_defer_summary_event(
             },
         )
     except Exception as exc:
-        logging.debug("[event] failed to emit planning defer summary event: %s", exc)
+        logging.debug(
+            "[event] failed to emit planning defer summary event: %s",
+            _bounded_exception_type(exc),
+        )
 
 
 def emit_planning_symbol_state_event(
@@ -1269,7 +1298,10 @@ def emit_planning_symbol_state_event(
             },
         )
     except Exception as exc:
-        logging.debug("[event] failed to emit planning symbol state event: %s", exc)
+        logging.debug(
+            "[event] failed to emit planning symbol state event: %s",
+            _bounded_exception_type(exc),
+        )
 
 
 def emit_order_wave_completed_event(
@@ -1353,7 +1385,10 @@ def emit_order_wave_started_event(bot: Any, wave: dict | None) -> None:
             data=data,
         )
     except Exception as exc:
-        logging.debug("[event] failed to emit order wave started event: %s", exc)
+        logging.debug(
+            "[event] failed to emit order wave started event: %s",
+            _bounded_exception_type(exc),
+        )
 
 
 def _safe_float(value: Any) -> float | None:
@@ -1554,7 +1589,10 @@ def emit_memory_snapshot_event(
             data=data,
         )
     except Exception as exc:
-        logging.debug("[event] failed to emit memory snapshot event: %s", exc)
+        logging.debug(
+            "[event] failed to emit memory snapshot event: %s",
+            _bounded_exception_type(exc),
+        )
         return None
 
 
@@ -1679,7 +1717,10 @@ def _best_effort_rust_input_symbol_debug_sample(
     try:
         return rust_input_symbol_debug_sample(input_symbols, idx_to_symbol=idx_to_symbol)
     except Exception as exc:
-        logging.debug("[event] failed to build rust input debug sample: %s", exc)
+        logging.debug(
+            "[event] failed to build rust input debug sample: %s",
+            _bounded_exception_type(exc),
+        )
         return None
 
 
@@ -1691,7 +1732,10 @@ def _best_effort_rust_output_order_debug_sample(
     try:
         return rust_output_order_debug_sample(orders, idx_to_symbol=idx_to_symbol)
     except Exception as exc:
-        logging.debug("[event] failed to build rust output debug sample: %s", exc)
+        logging.debug(
+            "[event] failed to build rust output debug sample: %s",
+            _bounded_exception_type(exc),
+        )
         return None
 
 
@@ -1771,7 +1815,7 @@ def emit_startup_timing_event(bot: Any, *args: Any, **kwargs: Any) -> None:
         logging.debug(
             "[event] failed to emit %s: %s",
             EventTypes.BOT_STARTUP_TIMING,
-            exc,
+            _bounded_exception_type(exc),
         )
 
 
@@ -1798,7 +1842,10 @@ def emit_health_summary_event(bot: Any, *args: Any, **kwargs: Any) -> Any:
     try:
         return _emit_health_summary_event_unchecked(bot, *args, **kwargs)
     except Exception as exc:
-        logging.debug("[event] failed to emit health summary event: %s", exc)
+        logging.debug(
+            "[event] failed to emit health summary event: %s",
+            _bounded_exception_type(exc),
+        )
         return None
 
 
@@ -1840,7 +1887,7 @@ def emit_market_snapshot_diagnostic_skipped_event(
     except Exception as exc:
         logging.debug(
             "[event] failed to emit market snapshot diagnostic skipped event error_type=%s",
-            type(exc).__name__,
+            _bounded_exception_type(exc),
         )
         return False
 
@@ -2016,7 +2063,10 @@ def emit_state_refresh_timing_event(bot: Any, *args: Any, **kwargs: Any) -> None
     try:
         _emit_state_refresh_timing_event_unchecked(bot, *args, **kwargs)
     except Exception as exc:
-        logging.debug("[event] failed to emit state refresh timing event: %s", exc)
+        logging.debug(
+            "[event] failed to emit state refresh timing event: %s",
+            _bounded_exception_type(exc),
+        )
 
 
 def _stat_summary_payload(value: Any) -> dict[str, int]:
@@ -2084,7 +2134,8 @@ def emit_state_refresh_timing_summary_event(
         _emit_state_refresh_timing_summary_event_unchecked(bot, *args, **kwargs)
     except Exception as exc:
         logging.debug(
-            "[event] failed to emit state refresh timing summary event: %s", exc
+            "[event] failed to emit state refresh timing summary event: %s",
+            _bounded_exception_type(exc),
         )
 
 
@@ -2129,7 +2180,10 @@ def emit_state_refresh_progress_event(bot: Any, *args: Any, **kwargs: Any) -> No
     try:
         _emit_state_refresh_progress_event_unchecked(bot, *args, **kwargs)
     except Exception as exc:
-        logging.debug("[event] failed to emit state refresh progress event: %s", exc)
+        logging.debug(
+            "[event] failed to emit state refresh progress event: %s",
+            _bounded_exception_type(exc),
+        )
 
 
 def _emit_execution_loop_error_burst_event_unchecked(
@@ -2189,7 +2243,10 @@ def emit_execution_loop_error_burst_event(bot: Any, *args: Any, **kwargs: Any) -
     try:
         _emit_execution_loop_error_burst_event_unchecked(bot, *args, **kwargs)
     except Exception as exc:
-        logging.debug("[event] failed to emit execution loop error burst event: %s", exc)
+        logging.debug(
+            "[event] failed to emit execution loop error burst event: %s",
+            _bounded_exception_type(exc),
+        )
 
 
 def _symbol_sample(symbols: Any, *, limit: int = 12) -> dict[str, Any]:
@@ -2521,7 +2578,7 @@ def _safe_emit(bot: Any, event_type: str, **kwargs: Any) -> Any:
         logging.debug(
             "[event] failed to emit %s error_type=%s",
             event_type,
-            type(exc).__name__,
+            _bounded_exception_type(exc),
         )
         return None
 
@@ -2605,7 +2662,7 @@ def emit_rust_orchestrator_called_event(bot: Any, *args: Any, **kwargs: Any) -> 
         logging.debug(
             "[event] failed to emit %s: %s",
             EventTypes.RUST_ORCHESTRATOR_CALLED,
-            exc,
+            _bounded_exception_type(exc),
         )
 
 
@@ -2682,7 +2739,7 @@ def emit_rust_orchestrator_returned_event(bot: Any, *args: Any, **kwargs: Any) -
         logging.debug(
             "[event] failed to emit %s: %s",
             EventTypes.RUST_ORCHESTRATOR_RETURNED,
-            exc,
+            _bounded_exception_type(exc),
         )
 
 
@@ -2731,7 +2788,7 @@ def emit_forager_feature_unavailable_event(bot: Any, *args: Any, **kwargs: Any) 
         logging.debug(
             "[event] failed to emit %s: %s",
             EventTypes.FORAGER_FEATURE_UNAVAILABLE,
-            exc,
+            _bounded_exception_type(exc),
         )
 
 
@@ -2791,7 +2848,7 @@ def emit_forager_eligibility_changed_event(
         logging.debug(
             "[event] failed to emit %s: %s",
             EventTypes.FORAGER_ELIGIBILITY_CHANGED,
-            exc,
+            _bounded_exception_type(exc),
         )
 
 
@@ -2827,7 +2884,7 @@ def _flush_live_event_pipeline_after_terminal_emit(bot: Any) -> None:
     except Exception as exc:
         logging.debug(
             "[event] terminal market compatibility flush failed: %s",
-            type(exc).__name__,
+            _bounded_exception_type(exc),
         )
 
 
@@ -2884,7 +2941,7 @@ def emit_hip3_account_mode_unsupported_event(
     except Exception as exc:
         logging.debug(
             "[event] failed to emit HIP-3 account-mode compatibility event: %s",
-            type(exc).__name__,
+            _bounded_exception_type(exc),
         )
         return False
 
@@ -2986,7 +3043,7 @@ def emit_config_market_compatibility_event(
         logging.debug(
             "[event] failed to emit %s: %s",
             EventTypes.CONFIG_MARKET_COMPATIBILITY,
-            exc,
+            _bounded_exception_type(exc),
         )
         return False
 
@@ -3048,7 +3105,7 @@ def emit_isolated_only_market_blocked_event(
     except Exception as exc:
         logging.debug(
             "[event] failed to emit isolated-only market compatibility event: %s",
-            type(exc).__name__,
+            _bounded_exception_type(exc),
         )
         return False
 
@@ -3132,7 +3189,7 @@ def emit_forager_selection_event(bot: Any, *args: Any, **kwargs: Any) -> None:
         logging.debug(
             "[event] failed to emit %s: %s",
             EventTypes.FORAGER_SELECTION,
-            exc,
+            _bounded_exception_type(exc),
         )
 
 
@@ -3183,7 +3240,7 @@ def emit_candle_tail_projected_event(bot: Any, *args: Any, **kwargs: Any) -> Non
         logging.debug(
             "[event] failed to emit %s: %s",
             EventTypes.CANDLE_TAIL_PROJECTED,
-            exc,
+            _bounded_exception_type(exc),
         )
 
 
@@ -3304,7 +3361,7 @@ def emit_candle_coverage_checked_event(bot: Any, *args: Any, **kwargs: Any) -> N
         logging.debug(
             "[event] failed to emit %s: %s",
             EventTypes.CANDLE_COVERAGE_CHECKED,
-            exc,
+            _bounded_exception_type(exc),
         )
 
 
@@ -3426,7 +3483,7 @@ def emit_cache_load_completed_event(bot: Any, *args: Any, **kwargs: Any) -> None
         logging.debug(
             "[event] failed to emit %s: %s",
             EventTypes.CACHE_LOAD_COMPLETED,
-            exc,
+            _bounded_exception_type(exc),
         )
 
 
@@ -3476,7 +3533,7 @@ def emit_cache_flush_completed_event(bot: Any, *args: Any, **kwargs: Any) -> Non
         logging.debug(
             "[event] failed to emit %s: %s",
             EventTypes.CACHE_FLUSH_COMPLETED,
-            exc,
+            _bounded_exception_type(exc),
         )
 
 
@@ -3543,7 +3600,7 @@ def emit_cache_warmup_decision_event(bot: Any, *args: Any, **kwargs: Any) -> Non
         logging.debug(
             "[event] failed to emit %s: %s",
             EventTypes.CACHE_WARMUP_DECISION,
-            exc,
+            _bounded_exception_type(exc),
         )
 
 
@@ -3590,7 +3647,7 @@ def emit_ema_bundle_started_event(bot: Any, *args: Any, **kwargs: Any) -> None:
         logging.debug(
             "[event] failed to emit %s error_type=%s",
             EventTypes.EMA_BUNDLE_STARTED,
-            type(exc).__name__,
+            _bounded_exception_type(exc),
         )
 
 
@@ -3632,7 +3689,7 @@ def emit_ema_bundle_completed_event(bot: Any, *args: Any, **kwargs: Any) -> None
         logging.debug(
             "[event] failed to emit %s error_type=%s",
             EventTypes.EMA_BUNDLE_COMPLETED,
-            type(exc).__name__,
+            _bounded_exception_type(exc),
         )
 
 
@@ -3715,7 +3772,7 @@ def emit_ema_fallback_used_event(bot: Any, *args: Any, **kwargs: Any) -> bool:
         logging.debug(
             "[event] failed to emit %s error_type=%s",
             EventTypes.EMA_FALLBACK_USED,
-            type(exc).__name__,
+            _bounded_exception_type(exc),
         )
         return False
 
@@ -3800,7 +3857,7 @@ def emit_ema_unavailable_event(bot: Any, *args: Any, **kwargs: Any) -> bool:
         logging.debug(
             "[event] failed to emit %s error_type=%s",
             EventTypes.EMA_UNAVAILABLE,
-            type(exc).__name__,
+            _bounded_exception_type(exc),
         )
         return False
 
@@ -3917,7 +3974,7 @@ def emit_action_planned_event(
         logging.debug(
             "[event] failed to emit %s: %s",
             EventTypes.ACTION_PLANNED,
-            exc,
+            _bounded_exception_type(exc),
         )
 
 
@@ -3976,7 +4033,7 @@ def emit_initial_entry_distance_gate_event(
             "[event] failed to emit initial entry distance gate event type=%s symbol=%s: %s",
             event_type,
             order.get("symbol") if isinstance(order, dict) else None,
-            exc,
+            _bounded_exception_type(exc),
         )
 
 
@@ -4155,7 +4212,7 @@ def emit_execution_connector_call_started_event(
             "[event] failed to emit connector call event action=%s route=%s error_type=%s",
             action,
             connector_route,
-            type(exc).__name__,
+            _bounded_exception_type(exc),
         )
 
 
@@ -4217,7 +4274,7 @@ def emit_execution_create_filter_event(
             event_type,
             status,
             reason_code,
-            type(exc).__name__,
+            _bounded_exception_type(exc),
         )
         return False
 
@@ -4251,7 +4308,7 @@ def emit_initial_entry_eligibility_event(
         logging.debug(
             "[event] failed to emit %s: %s",
             EventTypes.ENTRY_INITIAL_ELIGIBILITY,
-            exc,
+            _bounded_exception_type(exc),
         )
 
 
@@ -4325,7 +4382,7 @@ def emit_execution_order_event(
             event_type,
             action,
             status,
-            exc,
+            _bounded_exception_type(exc),
         )
 
 
@@ -4368,7 +4425,10 @@ def emit_execution_confirmation_requested_event(
             data=data,
         )
     except Exception as exc:
-        logging.debug("[event] failed to emit confirmation requested event: %s", exc)
+        logging.debug(
+            "[event] failed to emit confirmation requested event: %s",
+            _bounded_exception_type(exc),
+        )
 
 
 def emit_execution_confirmation_satisfied_event(
@@ -4421,7 +4481,10 @@ def emit_execution_confirmation_satisfied_event(
             data=data,
         )
     except Exception as exc:
-        logging.debug("[event] failed to emit confirmation satisfied event: %s", exc)
+        logging.debug(
+            "[event] failed to emit confirmation satisfied event: %s",
+            _bounded_exception_type(exc),
+        )
 
 
 def emit_execution_confirmation_timeout_event(
@@ -4479,7 +4542,10 @@ def emit_execution_confirmation_timeout_event(
             data=data,
         )
     except Exception as exc:
-        logging.debug("[event] failed to emit confirmation timeout event: %s", exc)
+        logging.debug(
+            "[event] failed to emit confirmation timeout event: %s",
+            _bounded_exception_type(exc),
+        )
 
 
 def emit_risk_mode_changed_event(
@@ -4534,7 +4600,7 @@ def emit_risk_mode_changed_event(
             "[event] failed to emit risk mode changed event pside=%s symbol=%s: %s",
             pside,
             symbol,
-            exc,
+            _bounded_exception_type(exc),
         )
 
 
@@ -4577,7 +4643,7 @@ def emit_realized_loss_gate_blocked_event(
             "[event] failed to emit realized loss gate event pside=%s symbol=%s: %s",
             pside,
             symbol,
-            exc,
+            _bounded_exception_type(exc),
         )
 
 
@@ -4619,7 +4685,7 @@ def emit_entry_cooldown_delta_anchored_event(
             "[event] failed to emit entry cooldown delta event pside=%s symbol=%s: %s",
             pside,
             symbol,
-            exc,
+            _bounded_exception_type(exc),
         )
 
 
@@ -4659,7 +4725,7 @@ def emit_entry_min_effective_cost_blocked_event(
             "[event] failed to emit min effective cost event pside=%s symbol=%s: %s",
             pside,
             symbol,
-            exc,
+            _bounded_exception_type(exc),
         )
 
 
@@ -4825,7 +4891,7 @@ def emit_trailing_status_event(
             symbol,
             pside,
             kind,
-            exc,
+            _bounded_exception_type(exc),
         )
 
 
@@ -4868,7 +4934,10 @@ def emit_unstuck_status_event(
             },
         )
     except Exception as exc:
-        logging.debug("[event] failed to emit unstuck status event: %s", exc)
+        logging.debug(
+            "[event] failed to emit unstuck status event: %s",
+            _bounded_exception_type(exc),
+        )
 
 
 def emit_unstuck_selection_event(
@@ -4911,7 +4980,7 @@ def emit_unstuck_selection_event(
             "[event] failed to emit unstuck selection event pside=%s symbol=%s: %s",
             pside,
             symbol,
-            exc,
+            _bounded_exception_type(exc),
         )
 
 
@@ -4953,7 +5022,10 @@ def emit_balance_changed_event(
             data=data,
         )
     except Exception as exc:
-        logging.debug("[event] failed to emit balance changed event: %s", exc)
+        logging.debug(
+            "[event] failed to emit balance changed event: %s",
+            _bounded_exception_type(exc),
+        )
 
 
 def _fill_coverage_summary(status: Any) -> dict[str, Any]:
@@ -5021,7 +5093,10 @@ def _best_effort_fill_refresh_debug_payload(**kwargs: Any) -> dict[str, Any] | N
     try:
         return _fill_refresh_debug_payload(**kwargs)
     except Exception as exc:
-        logging.debug("[event] failed to build fill refresh debug payload: %s", exc)
+        logging.debug(
+            "[event] failed to build fill refresh debug payload: %s",
+            _bounded_exception_type(exc),
+        )
         return None
 
 
@@ -5053,7 +5128,10 @@ def _best_effort_fill_ingested_debug_payload(
     try:
         return _fill_ingested_debug_payload(event, payload=payload)
     except Exception as exc:
-        logging.debug("[event] failed to build fill ingested debug payload: %s", exc)
+        logging.debug(
+            "[event] failed to build fill ingested debug payload: %s",
+            _bounded_exception_type(exc),
+        )
         return None
 
 
@@ -5186,7 +5264,10 @@ def emit_fills_refresh_summary_event(bot: Any, *args: Any, **kwargs: Any) -> Non
     try:
         _emit_fills_refresh_summary_event_unchecked(bot, *args, **kwargs)
     except Exception as exc:
-        logging.debug("[event] failed to emit fills refresh summary event: %s", exc)
+        logging.debug(
+            "[event] failed to emit fills refresh summary event: %s",
+            _bounded_exception_type(exc),
+        )
 
 
 def emit_fill_ingested_event(
@@ -5239,7 +5320,10 @@ def emit_fill_ingested_event(
             data={key: value for key, value in data.items() if value is not None},
         )
     except Exception as exc:
-        logging.debug("[event] failed to emit fill ingested event: %s", exc)
+        logging.debug(
+            "[event] failed to emit fill ingested event: %s",
+            _bounded_exception_type(exc),
+        )
 
 
 def emit_fills_ingested_summary_event(
@@ -5267,7 +5351,10 @@ def emit_fills_ingested_summary_event(
             },
         )
     except Exception as exc:
-        logging.debug("[event] failed to emit fills ingested summary event: %s", exc)
+        logging.debug(
+            "[event] failed to emit fills ingested summary event: %s",
+            _bounded_exception_type(exc),
+        )
 
 
 def emit_position_changed_event(
@@ -5320,4 +5407,7 @@ def emit_position_changed_event(
             },
         )
     except Exception as exc:
-        logging.debug("[event] failed to emit position changed event: %s", exc)
+        logging.debug(
+            "[event] failed to emit position changed event: %s",
+            _bounded_exception_type(exc),
+        )

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -20,6 +20,7 @@ from live.event_bus import (
     utc_ms,
 )
 from live.balance_composition import public_balance_composition
+from live.diagnostic_safety import bounded_exception_type as _bounded_exception_type
 
 
 def current_live_event_cycle_id(bot: Any) -> str | None:
@@ -59,7 +60,6 @@ _EXCHANGE_CONFIG_EVENT_RESPONSE_CODE_RE = re.compile(r"-?[0-9]{1,12}")
 _EXCHANGE_CONFIG_EVENT_ERROR_TYPE_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,79}")
 _EXCHANGE_CONFIG_EVENT_OUTCOMES = {"confirmed", "unchanged", "failed"}
 _LIVE_EVENT_LEVELS = {"debug", "info", "warning", "error"}
-_EXCEPTION_TYPE_MAX_LEN = 80
 _MEMORY_SNAPSHOT_MAX_BYTES = (1 << 63) - 1
 _MEMORY_SNAPSHOT_MAX_COUNT = 1_000_000_000
 _MEMORY_SNAPSHOT_MAX_DELTA_PCT = 1_000_000.0
@@ -109,19 +109,6 @@ _CYCLE_DEGRADED_INVALID_SYMBOL_LIST_KEYS = (
     "extra_symbols",
     "changed_symbols",
 )
-
-
-def _bounded_exception_type(exc: BaseException) -> str:
-    try:
-        name = type(exc).__name__
-        if not isinstance(name, str):
-            return "Error"
-        if not name or not name.isascii() or not name.isidentifier():
-            return "Error"
-        return name[:_EXCEPTION_TYPE_MAX_LEN]
-    except BaseException:
-        return "Error"
-
 
 _CYCLE_DEGRADED_INVALID_INT_KEYS = (
     "latest_expected_ts",

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -71,11 +71,10 @@ def _bounded_hsl_exception_type(exc: BaseException) -> str:
         name = type(exc).__name__
         if not isinstance(name, str):
             return "Error"
-        bounded = name[:_HSL_EXCEPTION_TYPE_MAX_LEN]
-        if not bounded or not bounded.isascii() or not bounded.isidentifier():
+        if not name or not name.isascii() or not name.isidentifier():
             return "Error"
-        return bounded
-    except Exception:
+        return name[:_HSL_EXCEPTION_TYPE_MAX_LEN]
+    except BaseException:
         return "Error"
 
 

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -28,6 +28,7 @@ from config.coerce import (
 )
 from config.pnl_lookback import parse_pnls_max_lookback_days
 from fill_events_manager import signed_fee_paid_from_payload
+from live.diagnostic_safety import bounded_exception_type as _bounded_hsl_exception_type
 from live.event_bus import EventTypes, ReasonCodes, live_event_debug_profile_enabled
 from passivbot_exceptions import RestartBotException
 from utils import make_get_filepath
@@ -63,21 +64,6 @@ _HSL_COIN_REPLAY_STARTUP_YIELD_ROWS = 1_000
 _HSL_COIN_REPLAY_BACKGROUND_YIELD_ROWS = 100
 _HSL_COIN_REPLAY_BACKGROUND_YIELD_SLEEP_S = 0.01
 _HSL_FLATTEN_FILL_REFRESH_INTERVAL_MS = 5_000
-_HSL_EXCEPTION_TYPE_MAX_LEN = 80
-
-
-def _bounded_hsl_exception_type(exc: BaseException) -> str:
-    try:
-        name = type(exc).__name__
-        if not isinstance(name, str):
-            return "Error"
-        if not name or not name.isascii() or not name.isidentifier():
-            return "Error"
-        return name[:_HSL_EXCEPTION_TYPE_MAX_LEN]
-    except BaseException:
-        return "Error"
-
-
 def _hsl_flat_epsilon(qty_step: Any = 0.0) -> float:
     try:
         step = abs(float(qty_step or 0.0))

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -63,6 +63,18 @@ _HSL_COIN_REPLAY_STARTUP_YIELD_ROWS = 1_000
 _HSL_COIN_REPLAY_BACKGROUND_YIELD_ROWS = 100
 _HSL_COIN_REPLAY_BACKGROUND_YIELD_SLEEP_S = 0.01
 _HSL_FLATTEN_FILL_REFRESH_INTERVAL_MS = 5_000
+_HSL_EXCEPTION_TYPE_MAX_LEN = 80
+
+
+def _bounded_hsl_exception_type(exc: BaseException) -> str:
+    try:
+        name = type(exc).__name__
+    except Exception:
+        return "Error"
+    bounded = name[:_HSL_EXCEPTION_TYPE_MAX_LEN]
+    if not bounded or not bounded.isascii() or not bounded.isidentifier():
+        return "Error"
+    return bounded
 
 
 def _hsl_flat_epsilon(qty_step: Any = 0.0) -> float:
@@ -200,7 +212,7 @@ def _best_effort_hsl_debug_payload(
         logging.debug(
             "[event] failed to build HSL debug payload type=%s: %s",
             event_type,
-            exc,
+            _bounded_hsl_exception_type(exc),
         )
         return None
 
@@ -258,7 +270,11 @@ def _emit_hsl_event(
                 data=event_data,
             ) is not None
     except Exception as exc:
-        logging.debug("[event] failed to emit HSL live event type=%s: %s", event_type, exc)
+        logging.debug(
+            "[event] failed to emit HSL live event type=%s: %s",
+            event_type,
+            _bounded_hsl_exception_type(exc),
+        )
     if live_event_delivered:
         return
     try:
@@ -276,7 +292,7 @@ def _emit_hsl_event(
         logging.debug(
             "[event] failed to emit HSL legacy monitor event type=%s: %s",
             event_type,
-            exc,
+            _bounded_hsl_exception_type(exc),
         )
 
 
@@ -313,7 +329,7 @@ def _emit_runtime_forced_mode_changed_event(
             "[event] failed to emit HSL runtime forced mode event pside=%s symbol=%s: %s",
             pside,
             symbol,
-            exc,
+            _bounded_hsl_exception_type(exc),
         )
 
 
@@ -431,7 +447,11 @@ def _emit_hsl_replay_event(
             reason_code=reason_code,
         )
     except Exception as exc:
-        logging.debug("[event] failed to emit HSL replay event type=%s: %s", event_type, exc)
+        logging.debug(
+            "[event] failed to emit HSL replay event type=%s: %s",
+            event_type,
+            _bounded_hsl_exception_type(exc),
+        )
 
 
 def _calc_hsl_pnl(position_side, entry_price, close_price, qty, c_mult):
@@ -4137,7 +4157,7 @@ def _equity_hard_stop_maybe_emit_raw_red_pending(
             "[event] failed to emit HSL raw-red pending event pside=%s symbol=%s: %s",
             pside,
             symbol,
-            exc,
+            _bounded_hsl_exception_type(exc),
         )
 
 
@@ -7010,7 +7030,7 @@ def _equity_hard_stop_emit_coin_status(self, pside: str, symbol: str, metrics: d
                     "[event] failed to log HSL coin status symbol=%s pside=%s: %s",
                     symbol,
                     pside,
-                    exc,
+                    _bounded_hsl_exception_type(exc),
                 )
         _emit_hsl_event(
             self,
@@ -7037,7 +7057,7 @@ def _equity_hard_stop_emit_coin_status(self, pside: str, symbol: str, metrics: d
             "[event] failed to emit HSL coin status symbol=%s pside=%s: %s",
             symbol,
             pside,
-            exc,
+            _bounded_hsl_exception_type(exc),
         )
 
 

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -69,12 +69,14 @@ _HSL_EXCEPTION_TYPE_MAX_LEN = 80
 def _bounded_hsl_exception_type(exc: BaseException) -> str:
     try:
         name = type(exc).__name__
+        if not isinstance(name, str):
+            return "Error"
+        bounded = name[:_HSL_EXCEPTION_TYPE_MAX_LEN]
+        if not bounded or not bounded.isascii() or not bounded.isidentifier():
+            return "Error"
+        return bounded
     except Exception:
         return "Error"
-    bounded = name[:_HSL_EXCEPTION_TYPE_MAX_LEN]
-    if not bounded or not bounded.isascii() or not bounded.isidentifier():
-        return "Error"
-    return bounded
 
 
 def _hsl_flat_epsilon(qty_step: Any = 0.0) -> float:

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -76,6 +76,32 @@ def test_hsl_event_emitter_failure_logs_type_without_secret(caplog):
     assert "Error" in caplog.text
     assert sensitive_identifier not in caplog.text
 
+    camelcase_sensitive_identifier = "ApiKeyProdSecretHSL123"
+    camelcase_sensitive_type = type(
+        camelcase_sensitive_identifier, (RuntimeError,), {}
+    )
+
+    def fail_with_camelcase_sensitive_identifier(*_args, **_kwargs):
+        raise camelcase_sensitive_type("safe")
+
+    bot._emit_live_event = fail_with_camelcase_sensitive_identifier
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        assert (
+            hsl._emit_hsl_event(
+                bot,
+                "hsl.status",
+                ("hsl", "risk"),
+                {},
+                pside="long",
+                symbol="BTC/USDT:USDT",
+            )
+            is None
+        )
+
+    assert "Error" in caplog.text
+    assert camelcase_sensitive_identifier not in caplog.text
+
     invalid_suffix = "H" * 80 + "\napi_secret=tail-hsl-class-name-secret"
     invalid_suffix_type = type(invalid_suffix, (RuntimeError,), {})
 

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -52,10 +52,34 @@ def test_hsl_event_emitter_failure_logs_type_without_secret(caplog):
     assert secret not in caplog.text
     assert url not in caplog.text
 
+    invalid_suffix = "H" * 80 + "\napi_secret=tail-hsl-class-name-secret"
+    invalid_suffix_type = type(invalid_suffix, (RuntimeError,), {})
+
+    def fail_with_invalid_suffix(*_args, **_kwargs):
+        raise invalid_suffix_type("safe")
+
+    bot._emit_live_event = fail_with_invalid_suffix
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        assert (
+            hsl._emit_hsl_event(
+                bot,
+                "hsl.status",
+                ("hsl", "risk"),
+                {},
+                pside="long",
+                symbol="BTC/USDT:USDT",
+            )
+            is None
+        )
+
+    assert "Error" in caplog.text
+    assert "tail-hsl-class-name-secret" not in caplog.text
+
     class HostileExceptionMeta(type):
         @property
         def __name__(cls):
-            return None
+            raise KeyboardInterrupt("api_secret=hostile-hsl-property-secret")
 
     hostile_type = HostileExceptionMeta(
         "HostileHslEventEmitterFailure", (RuntimeError,), {}
@@ -81,6 +105,7 @@ def test_hsl_event_emitter_failure_logs_type_without_secret(caplog):
 
     assert "Error" in caplog.text
     assert "hostile-hsl-metadata-secret" not in caplog.text
+    assert "hostile-hsl-property-secret" not in caplog.text
 
 
 class FakeRiskCache:

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -21,6 +21,38 @@ class FakeHslBot(SimpleNamespace):
     pass
 
 
+def test_hsl_event_emitter_failure_logs_type_without_secret(caplog):
+    secret = "api_secret=hsl-event-secret"
+    url = "https://private.example.invalid/v1/hsl?token=hsl-event-token"
+
+    class HslEventEmitterFailure(RuntimeError):
+        pass
+
+    def fail_emit(*_args, **_kwargs):
+        raise HslEventEmitterFailure(f"request failed {secret} {url}")
+
+    bot = SimpleNamespace(
+        _live_event_pipeline=object(),
+        _live_event_current_cycle_id="cy_hsl_redaction",
+        _emit_live_event=fail_emit,
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        emitted = hsl._emit_hsl_event(
+            bot,
+            "hsl.status",
+            ("hsl", "risk"),
+            {},
+            pside="long",
+            symbol="BTC/USDT:USDT",
+        )
+
+    assert emitted is None
+    assert "HslEventEmitterFailure" in caplog.text
+    assert secret not in caplog.text
+    assert url not in caplog.text
+
+
 class FakeRiskCache:
     def __init__(self, covered_start_ms=1, history_scope="all"):
         self.covered_start_ms = covered_start_ms

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -102,6 +102,40 @@ def test_hsl_event_emitter_failure_logs_type_without_secret(caplog):
     assert "Error" in caplog.text
     assert camelcase_sensitive_identifier not in caplog.text
 
+    class HostileName(str):
+        def __getitem__(self, _key):
+            return "api_secret=hostile-hsl-slice-secret"
+
+    class HostileSliceMeta(type):
+        @property
+        def __name__(cls):
+            return HostileName("SafeLookingHslFailure")
+
+    hostile_slice_type = HostileSliceMeta(
+        "HostileSliceHslFailure", (RuntimeError,), {}
+    )
+
+    def fail_with_hostile_slice(*_args, **_kwargs):
+        raise hostile_slice_type("safe")
+
+    bot._emit_live_event = fail_with_hostile_slice
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        assert (
+            hsl._emit_hsl_event(
+                bot,
+                "hsl.status",
+                ("hsl", "risk"),
+                {},
+                pside="long",
+                symbol="BTC/USDT:USDT",
+            )
+            is None
+        )
+
+    assert "Error" in caplog.text
+    assert "hostile-hsl-slice-secret" not in caplog.text
+
     invalid_suffix = "H" * 80 + "\napi_secret=tail-hsl-class-name-secret"
     invalid_suffix_type = type(invalid_suffix, (RuntimeError,), {})
 

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -52,6 +52,30 @@ def test_hsl_event_emitter_failure_logs_type_without_secret(caplog):
     assert secret not in caplog.text
     assert url not in caplog.text
 
+    sensitive_identifier = "ApiKey_prod_super_secret_HSL123"
+    sensitive_identifier_type = type(sensitive_identifier, (RuntimeError,), {})
+
+    def fail_with_sensitive_identifier(*_args, **_kwargs):
+        raise sensitive_identifier_type("safe")
+
+    bot._emit_live_event = fail_with_sensitive_identifier
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        assert (
+            hsl._emit_hsl_event(
+                bot,
+                "hsl.status",
+                ("hsl", "risk"),
+                {},
+                pside="long",
+                symbol="BTC/USDT:USDT",
+            )
+            is None
+        )
+
+    assert "Error" in caplog.text
+    assert sensitive_identifier not in caplog.text
+
     invalid_suffix = "H" * 80 + "\napi_secret=tail-hsl-class-name-secret"
     invalid_suffix_type = type(invalid_suffix, (RuntimeError,), {})
 

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -52,6 +52,36 @@ def test_hsl_event_emitter_failure_logs_type_without_secret(caplog):
     assert secret not in caplog.text
     assert url not in caplog.text
 
+    class HostileExceptionMeta(type):
+        @property
+        def __name__(cls):
+            return None
+
+    hostile_type = HostileExceptionMeta(
+        "HostileHslEventEmitterFailure", (RuntimeError,), {}
+    )
+
+    def fail_with_hostile_type(*_args, **_kwargs):
+        raise hostile_type("api_secret=hostile-hsl-metadata-secret")
+
+    bot._emit_live_event = fail_with_hostile_type
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        assert (
+            hsl._emit_hsl_event(
+                bot,
+                "hsl.status",
+                ("hsl", "risk"),
+                {},
+                pside="long",
+                symbol="BTC/USDT:USDT",
+            )
+            is None
+        )
+
+    assert "Error" in caplog.text
+    assert "hostile-hsl-metadata-secret" not in caplog.text
+
 
 class FakeRiskCache:
     def __init__(self, covered_start_ms=1, history_scope="all"):

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -2803,22 +2803,30 @@ def test_coin_hsl_status_logs_distance_only_for_open_position(caplog, monkeypatc
 
     import passivbot_hsl as hsl_mod
 
+    secret = "api_key=hsl-log-projection-secret"
+    url = "https://private.example.invalid/v1/hsl?token=hsl-log-token"
+
     def fail_info(*args, **kwargs):
-        raise RuntimeError("logging failed")
+        raise RuntimeError(f"logging failed {secret} {url}")
 
     caplog.clear()
     sink.events.clear()
     monkeypatch.setattr(hsl_mod.logging, "info", fail_info)
     failing_log_bot = FakeBot(has_position=True)
-    failing_log_bot._equity_hard_stop_emit_coin_status(
-        "long",
-        "NEAR/USDT:USDT",
-        metrics | {"timestamp_ms": 30_000},
-    )
+    with caplog.at_level(logging.DEBUG):
+        failing_log_bot._equity_hard_stop_emit_coin_status(
+            "long",
+            "NEAR/USDT:USDT",
+            metrics | {"timestamp_ms": 30_000},
+        )
 
     assert failing_log_bot._live_event_pipeline.flush(timeout=2.0) is True
     assert sink.events[-1].event_type == EventTypes.HSL_STATUS
     assert sink.events[-1].data["dist_to_red"] == pytest.approx(0.04)
+    assert "failed to log HSL coin status" in caplog.text
+    assert "RuntimeError" in caplog.text
+    assert secret not in caplog.text
+    assert url not in caplog.text
 
 
 def test_startup_timing_marks_log_once(monkeypatch, caplog):

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -138,10 +138,29 @@ def test_event_emitter_failure_logs_bounded_exception_type_without_secret(caplog
     assert "error_type=Error" in caplog.text
     assert "class-name-secret" not in caplog.text
 
+    invalid_suffix = "V" * 80 + "\napi_key=tail-class-name-secret"
+    invalid_suffix_type = type(invalid_suffix, (RuntimeError,), {})
+
+    class InvalidSuffixTypeBot:
+        def _emit_live_event(self, *_args, **_kwargs):
+            raise invalid_suffix_type("safe")
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        assert (
+            live_event_emitters._safe_emit(
+                InvalidSuffixTypeBot(), EventTypes.HEALTH_SUMMARY
+            )
+            is None
+        )
+
+    assert "error_type=Error" in caplog.text
+    assert "tail-class-name-secret" not in caplog.text
+
     class HostileExceptionMeta(type):
         @property
         def __name__(cls):
-            return None
+            raise KeyboardInterrupt("api_key=hostile-metadata-property-secret")
 
     hostile_type = HostileExceptionMeta(
         "HostileEventEmitterFailure", (RuntimeError,), {}
@@ -162,6 +181,7 @@ def test_event_emitter_failure_logs_bounded_exception_type_without_secret(caplog
 
     assert "error_type=Error" in caplog.text
     assert "hostile-metadata-secret" not in caplog.text
+    assert "hostile-metadata-property-secret" not in caplog.text
 
 
 def test_live_event_cycle_helpers_emit_structured_events():

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -178,6 +178,35 @@ def test_event_emitter_failure_logs_bounded_exception_type_without_secret(caplog
     assert "error_type=Error" in caplog.text
     assert camelcase_sensitive_identifier not in caplog.text
 
+    class HostileName(str):
+        def __getitem__(self, _key):
+            return "api_key=hostile-slice-secret"
+
+    class HostileSliceMeta(type):
+        @property
+        def __name__(cls):
+            return HostileName("SafeLookingEventFailure")
+
+    hostile_slice_type = HostileSliceMeta(
+        "HostileSliceEventFailure", (RuntimeError,), {}
+    )
+
+    class HostileSliceTypeBot:
+        def _emit_live_event(self, *_args, **_kwargs):
+            raise hostile_slice_type("safe")
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        assert (
+            live_event_emitters._safe_emit(
+                HostileSliceTypeBot(), EventTypes.HEALTH_SUMMARY
+            )
+            is None
+        )
+
+    assert "error_type=Error" in caplog.text
+    assert "hostile-slice-secret" not in caplog.text
+
     invalid_suffix = "V" * 80 + "\napi_key=tail-class-name-secret"
     invalid_suffix_type = type(invalid_suffix, (RuntimeError,), {})
 

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -138,6 +138,31 @@ def test_event_emitter_failure_logs_bounded_exception_type_without_secret(caplog
     assert "error_type=Error" in caplog.text
     assert "class-name-secret" not in caplog.text
 
+    class HostileExceptionMeta(type):
+        @property
+        def __name__(cls):
+            return None
+
+    hostile_type = HostileExceptionMeta(
+        "HostileEventEmitterFailure", (RuntimeError,), {}
+    )
+
+    class HostileTypeBot:
+        def _emit_live_event(self, *_args, **_kwargs):
+            raise hostile_type("api_key=hostile-metadata-secret")
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        assert (
+            live_event_emitters._safe_emit(
+                HostileTypeBot(), EventTypes.HEALTH_SUMMARY
+            )
+            is None
+        )
+
+    assert "error_type=Error" in caplog.text
+    assert "hostile-metadata-secret" not in caplog.text
+
 
 def test_live_event_cycle_helpers_emit_structured_events():
     import passivbot as pb_mod

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -100,6 +100,45 @@ class RecorderPublisher:
         self.closed = True
 
 
+def test_event_emitter_failure_logs_bounded_exception_type_without_secret(caplog):
+    secret = "api_key=event-emitter-secret"
+    url = "https://private.example.invalid/v1/orders?token=event-emitter-token"
+    error_type = type("EventEmitterFailure" + "X" * 120, (RuntimeError,), {})
+
+    class FakeBot:
+        def _emit_live_event(self, *_args, **_kwargs):
+            raise error_type(f"request failed {secret} {url}")
+
+    with caplog.at_level(logging.DEBUG):
+        emitted = live_event_emitters._safe_emit(FakeBot(), EventTypes.HEALTH_SUMMARY)
+
+    bounded_type = error_type.__name__[:80]
+    assert emitted is None
+    assert len(bounded_type) == 80
+    assert f"error_type={bounded_type}" in caplog.text
+    assert error_type.__name__ not in caplog.text
+    assert secret not in caplog.text
+    assert url not in caplog.text
+
+    invalid_type = type("Invalid\napi_key=class-name-secret", (RuntimeError,), {})
+
+    class InvalidTypeBot:
+        def _emit_live_event(self, *_args, **_kwargs):
+            raise invalid_type("safe")
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        assert (
+            live_event_emitters._safe_emit(
+                InvalidTypeBot(), EventTypes.HEALTH_SUMMARY
+            )
+            is None
+        )
+
+    assert "error_type=Error" in caplog.text
+    assert "class-name-secret" not in caplog.text
+
+
 def test_live_event_cycle_helpers_emit_structured_events():
     import passivbot as pb_mod
 

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -138,6 +138,25 @@ def test_event_emitter_failure_logs_bounded_exception_type_without_secret(caplog
     assert "error_type=Error" in caplog.text
     assert "class-name-secret" not in caplog.text
 
+    sensitive_identifier = "ApiKey_prod_super_secret_ABC123"
+    sensitive_identifier_type = type(sensitive_identifier, (RuntimeError,), {})
+
+    class SensitiveIdentifierTypeBot:
+        def _emit_live_event(self, *_args, **_kwargs):
+            raise sensitive_identifier_type("safe")
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        assert (
+            live_event_emitters._safe_emit(
+                SensitiveIdentifierTypeBot(), EventTypes.HEALTH_SUMMARY
+            )
+            is None
+        )
+
+    assert "error_type=Error" in caplog.text
+    assert sensitive_identifier not in caplog.text
+
     invalid_suffix = "V" * 80 + "\napi_key=tail-class-name-secret"
     invalid_suffix_type = type(invalid_suffix, (RuntimeError,), {})
 

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -157,6 +157,27 @@ def test_event_emitter_failure_logs_bounded_exception_type_without_secret(caplog
     assert "error_type=Error" in caplog.text
     assert sensitive_identifier not in caplog.text
 
+    camelcase_sensitive_identifier = "ApiKeyProdSecretABC123"
+    camelcase_sensitive_type = type(
+        camelcase_sensitive_identifier, (RuntimeError,), {}
+    )
+
+    class CamelcaseSensitiveTypeBot:
+        def _emit_live_event(self, *_args, **_kwargs):
+            raise camelcase_sensitive_type("safe")
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        assert (
+            live_event_emitters._safe_emit(
+                CamelcaseSensitiveTypeBot(), EventTypes.HEALTH_SUMMARY
+            )
+            is None
+        )
+
+    assert "error_type=Error" in caplog.text
+    assert camelcase_sensitive_identifier not in caplog.text
+
     invalid_suffix = "V" * 80 + "\napi_key=tail-class-name-secret"
     invalid_suffix_type = type(invalid_suffix, (RuntimeError,), {})
 


### PR DESCRIPTION
## Scope

Category: runtime projection.

- Replace arbitrary caught exception values in best-effort live event emitter failure diagnostics with bounded ASCII exception types through one shared diagnostic helper.
- Apply the same boundary to HSL event emitter/build failures and the event-adjacent HSL coin-status human-log fallback while preserving their existing code-owned event, stage, symbol, and position-side context.
- Validate complete exception type names before truncation and fail closed to `Error` for missing, non-built-in-string, non-ASCII, non-identifier, hostile, or credential-marker-bearing metadata, including CamelCase markers.
- Record PR #1345 merge and VPS5 deployment evidence in the active status and historical ledger.

Non-goals: no structured event payload, route, queue, sink, retry, scheduling, monitor persistence, planning, order, fill, HSL, risk, exchange, or trading behavior change. Other non-event HSL diagnostics and the separately identified fill-history diagnostic redaction remain follow-up work.

## Expected Impact

All 69 `[event]` DEBUG failure sites in `src/live/event_emitters.py` and `src/passivbot_hsl.py`, including the event-adjacent HSL coin-status human projection, retain only a bounded exception type instead of arbitrary exception messages that may contain request URLs, response text, or credentials. Complete invalid names, hostile `str` subclasses, and names such as `ApiKey_prod_super_secret_ABC123` or `ApiKeyProdSecretABC123` normalize to `Error`. Best-effort return and fallback behavior is unchanged, including hostile exception-class metadata, and `hsl.status` emission remains independent of human-log projection failure.

Expected VPS action: tracked-clean pull, one exact-five graceful restart, and bounded immediate/settled smoke; preserve `misc:0.0`.

## Validation

- `tests/test_passivbot_monitor.py`: 101 passed
- `tests/test_hsl_coin_mode.py`: 147 passed
- `tests/test_passivbot_balance_split.py`: 265 passed with the import-only CCXT version shim required by the shared local venv
- focused secret/URL/pathological-type regressions: 3 passed
- `tests/test_ai_docs.py tests/test_live_event_registry_docs.py`: 4 passed
- changed Python files compile
- shared-helper probes return an 80-character bound for a safe long type and `Error` for underscore-delimited or CamelCase credential metadata, hostile string subclasses, and invalid overlength suffixes
- AST audit: 69 event DEBUG calls, zero direct raw caught-exception arguments
- live event registry check passes
- AI docs check: 0 errors, existing word-count warning only
- `git diff --check` passes
- independent Sol review of `aaf305134bf26f37107a6985bd30e37f86ce46b9` found the hostile `str`-subclass slicing bypass; it is fixed with event and HSL regressions, and exact-current-head delta review is required

`isort --check-only` passes for the new shared helper. Existing touched modules/tests retain their historical import shape; the only new imports bind the shared helper, and the branch avoids unrelated normalization churn. GitHub Python and Rust CI remain required on the exact PR head.

## Reviewer Focus

- Confirm every best-effort emitter/build catch retains type-only diagnostics and cannot leak exception values through DEBUG text.
- Confirm complete exception type metadata is validated before truncation, credential marker substrings fail closed regardless of identifier style, and hostile metadata access cannot escape the observability-only helper.
- Confirm HSL coin-status human-log failure retains only exception type while structured `hsl.status` emission continues independently.
- Confirm other non-event HSL log calls and structured emission calls remain behaviorally unchanged.

@codex review
