### PR TITLE
Redact fill refresh failure diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ All notable user-facing changes will be documented in this file.
   confirmation, and direct refresh callers. Validated numeric status/code and code-owned endpoint
   labels remain available. Publication and time-sync classification cannot replace the original
   refresh failure through hostile exception metadata, and wrapped timestamp failures remain
-  recoverable through a bounded cause-chain check. Exception propagation, fill accounting, refresh
-  cadence, planning, risk, and trading behavior are unchanged.
+  recoverable through a bounded cause/context graph check. Code-owned recovery markers are scanned
+  across complete exception text using bounded temporary chunks, preserving existing retry
+  classification without retaining that text. Exception propagation, fill accounting, refresh cadence,
+  planning, risk, and trading behavior are unchanged.
 
 - Best-effort live event emitter failure diagnostics, including HSL event emitters and the
   event-adjacent HSL coin-status human-log fallback, now retain bounded exception types instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Fill-history refresh failure diagnostics now retain bounded exception types alongside existing
+  source, coverage, retry, timing, count, and endpoint context without arbitrary exception
+  messages or exception-value tracebacks. Exception propagation, fill accounting, refresh cadence,
+  planning, risk, and trading behavior are unchanged.
+
 - Best-effort live event emitter failure diagnostics, including HSL event emitters and the
   event-adjacent HSL coin-status human-log fallback, now retain bounded exception types instead of
   arbitrary exception messages that may contain request URLs, response text, or credentials.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ All notable user-facing changes will be documented in this file.
 
 - Fill-history refresh failure diagnostics now retain bounded exception types alongside existing
   source, coverage, retry, timing, count, and endpoint context without arbitrary exception
-  messages or exception-value tracebacks. This includes exchange-specific fill fetchers, staged
-  remote-call events, startup initialization, HSL flatten confirmation, and direct refresh callers.
-  Safe numeric status and bounded exchange code remain available, and monitor publication cannot
+  messages or exception-value tracebacks. This includes exchange-specific fill fetchers, cache
+  reads, staged remote-call events, startup/process handling, HSL flatten confirmation, and direct
+  refresh callers. Validated numeric status and exchange code remain available, and publication cannot
   replace the original refresh failure through hostile exception metadata. Exception propagation,
   fill accounting, refresh cadence, planning, risk, and trading behavior are unchanged.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ All notable user-facing changes will be documented in this file.
 
 - Fill-history refresh failure diagnostics now retain bounded exception types alongside existing
   source, coverage, retry, timing, count, and endpoint context without arbitrary exception
-  messages or exception-value tracebacks. Exception propagation, fill accounting, refresh cadence,
-  planning, risk, and trading behavior are unchanged.
+  messages or exception-value tracebacks. Safe numeric status and bounded exchange code remain
+  available, and monitor publication cannot replace the original refresh failure through hostile
+  exception metadata. Exception propagation, fill accounting, refresh cadence, planning, risk,
+  and trading behavior are unchanged.
 
 - Best-effort live event emitter failure diagnostics, including HSL event emitters and the
   event-adjacent HSL coin-status human-log fallback, now retain bounded exception types instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ All notable user-facing changes will be documented in this file.
 - Fill-history refresh failure diagnostics now retain bounded exception types alongside existing
   source, coverage, retry, timing, count, and endpoint context without arbitrary exception
   messages or exception-value tracebacks. This includes exchange-specific fill fetchers, cache
-  reads, staged remote-call events, startup/process handling, HSL flatten confirmation, and direct
-  refresh callers. Validated numeric status and exchange code remain available, and publication cannot
-  replace the original refresh failure through hostile exception metadata. Exception propagation,
-  fill accounting, refresh cadence, planning, risk, and trading behavior are unchanged.
+  reads and doctor repair, staged remote-call events, startup/process handling, HSL flatten
+  confirmation, and direct refresh callers. Validated numeric status/code and code-owned endpoint
+  labels remain available. Publication and time-sync classification cannot replace the original
+  refresh failure through hostile exception metadata, and wrapped timestamp failures remain
+  recoverable through a bounded cause-chain check. Exception propagation, fill accounting, refresh
+  cadence, planning, risk, and trading behavior are unchanged.
 
 - Best-effort live event emitter failure diagnostics, including HSL event emitters and the
   event-adjacent HSL coin-status human-log fallback, now retain bounded exception types instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ All notable user-facing changes will be documented in this file.
   refresh failure through hostile exception metadata, and wrapped timestamp failures remain
   recoverable through a bounded cause/context graph check. Code-owned recovery markers are scanned
   across complete exception text using bounded temporary chunks, preserving existing retry
-  classification and caller-specific marker case rules without retaining that text. Exception propagation, fill accounting, refresh cadence,
-  planning, risk, and trading behavior are unchanged.
+  classification and caller-specific marker case rules without retaining that text. Legacy
+  class-name recovery markers are inspected without projecting untrusted names. Exception
+  propagation, fill accounting, refresh cadence, planning, risk, and trading behavior are unchanged.
 
 - Best-effort live event emitter failure diagnostics, including HSL event emitters and the
   event-adjacent HSL coin-status human-log fallback, now retain bounded exception types instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable user-facing changes will be documented in this file.
   refresh failure through hostile exception metadata, and wrapped timestamp failures remain
   recoverable through a bounded cause/context graph check. Code-owned recovery markers are scanned
   across complete exception text using bounded temporary chunks, preserving existing retry
-  classification without retaining that text. Exception propagation, fill accounting, refresh cadence,
+  classification and caller-specific marker case rules without retaining that text. Exception propagation, fill accounting, refresh cadence,
   planning, risk, and trading behavior are unchanged.
 
 - Best-effort live event emitter failure diagnostics, including HSL event emitters and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ All notable user-facing changes will be documented in this file.
 
 - Fill-history refresh failure diagnostics now retain bounded exception types alongside existing
   source, coverage, retry, timing, count, and endpoint context without arbitrary exception
-  messages or exception-value tracebacks. Safe numeric status and bounded exchange code remain
-  available, and monitor publication cannot replace the original refresh failure through hostile
-  exception metadata. Exception propagation, fill accounting, refresh cadence, planning, risk,
-  and trading behavior are unchanged.
+  messages or exception-value tracebacks. This includes exchange-specific fill fetchers, staged
+  remote-call events, startup initialization, HSL flatten confirmation, and direct refresh callers.
+  Safe numeric status and bounded exchange code remain available, and monitor publication cannot
+  replace the original refresh failure through hostile exception metadata. Exception propagation,
+  fill accounting, refresh cadence, planning, risk, and trading behavior are unchanged.
 
 - Best-effort live event emitter failure diagnostics, including HSL event emitters and the
   event-adjacent HSL coin-status human-log fallback, now retain bounded exception types instead of

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -161,7 +161,9 @@ boundary follow the same classification-only rule. Redaction is diagnostic-only:
 propagation, retry and coverage behavior, fill accounting, planning, risk, and trading behavior
 remain unchanged.
 
-The blocking failure line may also retain a validated numeric status and bounded exchange code.
+Cache-read contract failures and the outer process failure projection follow the same rule so a
+preserved exception cause cannot be exposed by an unsanitized startup traceback. The blocking
+failure line may also retain validated numeric status and exchange code.
 Monitor error events use the same hostile-metadata-safe exception-type boundary; diagnostic
 publication must not replace the original refresh exception.
 

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -158,6 +158,10 @@ text, request URLs, response bodies, credentials, or exception-value tracebacks.
 diagnostic-only: exception propagation, retry and coverage behavior, fill accounting, planning,
 risk, and trading behavior remain unchanged.
 
+The blocking failure line may also retain a validated numeric status and bounded exchange code.
+Monitor error events use the same hostile-metadata-safe exception-type boundary; diagnostic
+publication must not replace the original refresh exception.
+
 ## Open-Orders Snapshot Deltas
 
 `open_orders.snapshot_delta` replaces the aggregate INFO lines for open-order snapshot additions or

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -164,7 +164,8 @@ remain unchanged.
 Cache-read/doctor failures and the outer process failure projection follow the same rule so a
 preserved exception cause cannot be exposed by an unsanitized startup traceback. The blocking
 failure line may also retain validated numeric status/code and a code-owned endpoint label.
-Time-sync classification may inspect bounded exception text and a bounded cause chain, but that
+Time-sync and exchange recovery classification may inspect complete exception text in bounded
+temporary chunks and traverse both cause/context edges within a fixed node budget, but that
 inspection must not retain the text or replace the original failure.
 Monitor error events use the same hostile-metadata-safe exception-type boundary; diagnostic
 publication must not replace the original refresh exception.

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -166,7 +166,8 @@ preserved exception cause cannot be exposed by an unsanitized startup traceback.
 failure line may also retain validated numeric status/code and a code-owned endpoint label.
 Time-sync and exchange recovery classification may inspect complete exception text in bounded
 temporary chunks and traverse both cause/context edges within a fixed node budget, but that
-inspection must not retain the text or replace the original failure.
+inspection must not retain the text, broaden caller-specific marker case rules, or replace the
+original failure.
 Monitor error events use the same hostile-metadata-safe exception-type boundary; diagnostic
 publication must not replace the original refresh exception.
 

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -151,6 +151,13 @@ count. An all-pending batch must not present its known PnL as zero. The legacy d
 fallback only when the structured live-event console is disabled or its pipeline is absent. Runtime
 sink degradation remains isolated by the event pipeline and must not activate dual writing.
 
+Fill refresh failures retain code-owned source, refresh mode, coverage, retry, timing, and count
+context plus a bounded exception type. The structured `fills.refresh_summary`, manager request
+timing line, blocking refresh failure line, and routine-prefetch fallback must not retain exception
+text, request URLs, response bodies, credentials, or exception-value tracebacks. Redaction is
+diagnostic-only: exception propagation, retry and coverage behavior, fill accounting, planning,
+risk, and trading behavior remain unchanged.
+
 ## Open-Orders Snapshot Deltas
 
 `open_orders.snapshot_delta` replaces the aggregate INFO lines for open-order snapshot additions or

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -152,11 +152,14 @@ fallback only when the structured live-event console is disabled or its pipeline
 sink degradation remains isolated by the event pipeline and must not activate dual writing.
 
 Fill refresh failures retain code-owned source, refresh mode, coverage, retry, timing, and count
-context plus a bounded exception type. The structured `fills.refresh_summary`, manager request
-timing line, blocking refresh failure line, and routine-prefetch fallback must not retain exception
-text, request URLs, response bodies, credentials, or exception-value tracebacks. Redaction is
-diagnostic-only: exception propagation, retry and coverage behavior, fill accounting, planning,
-risk, and trading behavior remain unchanged.
+context plus a bounded exception type. The structured `fills.refresh_summary`, exchange-specific
+fetcher and manager request-timing lines, staged authoritative remote-call failure, blocking and
+routine-prefetch fallbacks, startup initialization boundary, fill-coverage retry, and HSL flatten
+confirmation must not retain exception text, request URLs, response bodies, credentials, or
+exception-value tracebacks. Metadata-capture and HSL progress-emitter failures at the same caller
+boundary follow the same classification-only rule. Redaction is diagnostic-only: exception
+propagation, retry and coverage behavior, fill accounting, planning, risk, and trading behavior
+remain unchanged.
 
 The blocking failure line may also retain a validated numeric status and bounded exchange code.
 Monitor error events use the same hostile-metadata-safe exception-type boundary; diagnostic

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -161,9 +161,11 @@ boundary follow the same classification-only rule. Redaction is diagnostic-only:
 propagation, retry and coverage behavior, fill accounting, planning, risk, and trading behavior
 remain unchanged.
 
-Cache-read contract failures and the outer process failure projection follow the same rule so a
+Cache-read/doctor failures and the outer process failure projection follow the same rule so a
 preserved exception cause cannot be exposed by an unsanitized startup traceback. The blocking
-failure line may also retain validated numeric status and exchange code.
+failure line may also retain validated numeric status/code and a code-owned endpoint label.
+Time-sync classification may inspect bounded exception text and a bounded cause chain, but that
+inspection must not retain the text or replace the original failure.
 Monitor error events use the same hostile-metadata-safe exception-type boundary; diagnostic
 publication must not replace the original refresh exception.
 

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -167,7 +167,8 @@ failure line may also retain validated numeric status/code and a code-owned endp
 Time-sync and exchange recovery classification may inspect complete exception text in bounded
 temporary chunks and traverse both cause/context edges within a fixed node budget, but that
 inspection must not retain the text, broaden caller-specific marker case rules, or replace the
-original failure.
+original failure. Control-flow-only class-name inspection follows the same non-retaining rule so
+legacy recovery heuristics do not require projecting untrusted class names.
 Monitor error events use the same hostile-metadata-safe exception-type boundary; diagnostic
 publication must not replace the original refresh exception.
 

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,29 +22,48 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Open PR #1346, `Redact live event emitter failure diagnostics`, on branch
-  `codex/event-emitter-exception-redaction`, based on canonical
-  `49cb68e56b20d71fbe42d33f31906d3a9c793e90`. Resolve its active head from
-  live metadata; the commit containing this handoff is a moving review head.
-- Scope: replace arbitrary caught exception values in best-effort live event
-  emitter failure diagnostics with bounded exception types, including HSL
-  event emitters and the event-adjacent HSL coin-status human projection.
-  Preserve existing code-owned event/action context. Other non-event HSL
-  diagnostics remain follow-up work.
-- Behavior boundary: developer DEBUG projection only. Event payloads, routing,
-  sink isolation, emitter return values, retries, planning, orders, HSL, risk,
-  and trading behavior remain unchanged.
-- Baseline: the central event-bus failure diagnostic and recent EMA emitters
-  already retain exception type only, while many adjacent event-emitter catch
-  paths still interpolate the raw exception value into the developer text log.
+- Active branch `codex/fill-history-diagnostic-redaction`, based on canonical
+  `4192e709d46d3ef9516025e121ddad15c0d0cd6e`; resolve its PR and exact head
+  from live metadata after publication.
+- Scope: remove arbitrary exception values from structured fill-refresh
+  summaries, fill-fetch request timing, blocking refresh failure logs, and
+  routine-prefetch fallback logs while retaining bounded exception type and
+  existing source, coverage, retry, timing, count, and endpoint context.
+- Behavior boundary: diagnostic retention and projection only. Exception
+  propagation, refresh and retry behavior, fill accounting, planning, orders,
+  risk, and trading behavior remain unchanged.
+- Baseline: these fill-history paths still retain sanitized or raw exception
+  text even though the shared live-event contract requires code-owned context
+  and bounded exception classifications.
 - Review gate: exact-current-head Hermes approval plus green Python/Rust CI.
   Built-in Codex automatic review is additional and every finding must be
   verified and resolved.
 - Expected VPS action: tracked-clean pull plus one exact-five graceful restart
-  and bounded settled smoke because live event failure projection changes;
+  and bounded settled smoke because live fill diagnostics change;
   preserve `misc:0.0`.
 
-## Deployed Baseline (PR #1345)
+## Deployed Baseline (PR #1346)
+
+- PR #1346 merged exact approved head
+  `377cb1dc60cade68fda6fc5ef031e6b4a559d6bd` as canonical
+  `4192e709d46d3ef9516025e121ddad15c0d0cd6e` after exact-head Hermes
+  approval, green Python/Rust CI, and finding-free built-in Codex and
+  independent Sol reviews.
+- VPS5 guarded-prepared tracked-clean from
+  `49cb68e56b20d71fbe42d33f31906d3a9c793e90` without a Rust build. The source
+  fingerprint/stamp and compiled artifact remained unchanged.
+- The exact-target orchestrator gracefully restarted only panes `%358`-`%362`;
+  old PIDs `1077958/1077967/1077961/1077970/1077964` exited and replacement
+  PIDs `1079121/1079130/1079124/1079133/1079127` relaunched and verified
+  without force or broad-pattern signals.
+- The integrated 120-second smoke was hard-green with complete shutdown and
+  startup identity, zero hard failures, zero hard text-log or attention
+  matches, and zero monitor warnings or errors. A bounded settled check found
+  all five exact processes stable at the deployed head, while protected
+  `misc:0.0` remained `%8`/PID `434835`. No direct authenticated exchange call
+  or event was manufactured.
+
+## Previous Deployed Baseline (PR #1345)
 
 - PR #1345 merged exact approved head
   `e9322f9b50de46fc054f0424751f6f0bea802c7f` as canonical
@@ -1869,13 +1888,13 @@ through PR #1343, including adjacent PR #1329, are deployed at canonical
 above. PR #1344's EMA diagnostic redaction is merged and deployed at canonical
 `986e5d52f88692d1b6531bc38c307352c08e9cb9`. PR #1345's legacy monitor and
 WebSocket diagnostic redaction is merged and deployed at canonical
-`49cb68e56b20d71fbe42d33f31906d3a9c793e90`. Open PR #1346, `Redact live
-event emitter failure diagnostics`, on
-`codex/event-emitter-exception-redaction` removes arbitrary caught exception
-values from best-effort live event emitter diagnostics and the event-adjacent
-HSL coin-status human projection without changing emitter isolation, event
-payloads, HSL, risk, or trading behavior. Resolve its exact head from live
-metadata.
+`49cb68e56b20d71fbe42d33f31906d3a9c793e90`. PR #1346's live-event-emitter
+and event-adjacent HSL diagnostic redaction is merged and deployed at canonical
+`4192e709d46d3ef9516025e121ddad15c0d0cd6e`. The active fill-history
+diagnostic-redaction slice removes retained exception values from fill-refresh
+summaries and human diagnostics without changing refresh, fill, planning,
+risk, or trading behavior. Resolve its PR and exact head from live metadata
+after publication.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -33,7 +33,8 @@ Estimated completion:
   type, validated numeric status/code, and existing source, coverage, retry, timing, count,
   and code-owned endpoint context. Complete chunked text inspection plus a bounded
   cause/context graph preserves caller-specific retry marker case rules and timestamp recovery for
-  redacted wrappers. Adjacent
+  redacted wrappers, including the legacy class-name marker heuristic without projecting that name.
+  Adjacent
   monitor, metadata-capture, and HSL progress
   diagnostics use the same safe type boundary.
 - Behavior boundary: diagnostic retention and projection only. Exception

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -28,10 +28,11 @@ Estimated completion:
   metadata; the commit containing this handoff is a moving review head.
 - Scope: remove arbitrary exception values from structured fill-refresh
   summaries, exchange-specific fetcher diagnostics, request timing, staged
-  remote-call events, cache reads, startup/process handling, blocking/routine/coverage
+  remote-call events, cache reads/doctor repair, startup/process handling, blocking/routine/coverage
   callers, and HSL flatten confirmation while retaining bounded exception
   type, validated numeric status/code, and existing source, coverage, retry, timing, count,
-  and endpoint context. Adjacent monitor, metadata-capture, and HSL progress
+  and code-owned endpoint context. Bounded cause-chain inspection preserves timestamp
+  recovery for redacted wrappers. Adjacent monitor, metadata-capture, and HSL progress
   diagnostics use the same safe type boundary.
 - Behavior boundary: diagnostic retention and projection only. Exception
   propagation, refresh and retry behavior, fill accounting, planning, orders,

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -31,8 +31,9 @@ Estimated completion:
   remote-call events, cache reads/doctor repair, startup/process handling, blocking/routine/coverage
   callers, and HSL flatten confirmation while retaining bounded exception
   type, validated numeric status/code, and existing source, coverage, retry, timing, count,
-  and code-owned endpoint context. Bounded cause-chain inspection preserves timestamp
-  recovery for redacted wrappers. Adjacent monitor, metadata-capture, and HSL progress
+  and code-owned endpoint context. Complete chunked text inspection plus a bounded
+  cause/context graph preserves retry and timestamp recovery for redacted wrappers. Adjacent
+  monitor, metadata-capture, and HSL progress
   diagnostics use the same safe type boundary.
 - Behavior boundary: diagnostic retention and projection only. Exception
   propagation, refresh and retry behavior, fill accounting, planning, orders,

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -32,7 +32,8 @@ Estimated completion:
   callers, and HSL flatten confirmation while retaining bounded exception
   type, validated numeric status/code, and existing source, coverage, retry, timing, count,
   and code-owned endpoint context. Complete chunked text inspection plus a bounded
-  cause/context graph preserves retry and timestamp recovery for redacted wrappers. Adjacent
+  cause/context graph preserves caller-specific retry marker case rules and timestamp recovery for
+  redacted wrappers. Adjacent
   monitor, metadata-capture, and HSL progress
   diagnostics use the same safe type boundary.
 - Behavior boundary: diagnostic retention and projection only. Exception

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -27,11 +27,12 @@ Estimated completion:
   `4192e709d46d3ef9516025e121ddad15c0d0cd6e`. Resolve its exact head from live
   metadata; the commit containing this handoff is a moving review head.
 - Scope: remove arbitrary exception values from structured fill-refresh
-  summaries, fill-fetch request timing, blocking refresh failure logs, and
-  routine-prefetch fallback logs while retaining bounded exception type, safe
-  status/code, and existing source, coverage, retry, timing, count, and
-  endpoint context. The adjacent monitor error sink uses the same safe type
-  boundary so publication cannot mask the refresh failure.
+  summaries, exchange-specific fetcher diagnostics, request timing, staged
+  remote-call events, startup initialization, blocking/routine/coverage
+  callers, and HSL flatten confirmation while retaining bounded exception
+  type, safe status/code, and existing source, coverage, retry, timing, count,
+  and endpoint context. Adjacent monitor, metadata-capture, and HSL progress
+  diagnostics use the same safe type boundary.
 - Behavior boundary: diagnostic retention and projection only. Exception
   propagation, refresh and retry behavior, fill accounting, planning, orders,
   risk, and trading behavior remain unchanged.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,9 +22,10 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Active branch `codex/fill-history-diagnostic-redaction`, based on canonical
-  `4192e709d46d3ef9516025e121ddad15c0d0cd6e`; resolve its PR and exact head
-  from live metadata after publication.
+- Open PR #1347, `Redact fill refresh failure diagnostics`, on branch
+  `codex/fill-history-diagnostic-redaction`, based on canonical
+  `4192e709d46d3ef9516025e121ddad15c0d0cd6e`. Resolve its exact head from live
+  metadata; the commit containing this handoff is a moving review head.
 - Scope: remove arbitrary exception values from structured fill-refresh
   summaries, fill-fetch request timing, blocking refresh failure logs, and
   routine-prefetch fallback logs while retaining bounded exception type and
@@ -1890,11 +1891,10 @@ above. PR #1344's EMA diagnostic redaction is merged and deployed at canonical
 WebSocket diagnostic redaction is merged and deployed at canonical
 `49cb68e56b20d71fbe42d33f31906d3a9c793e90`. PR #1346's live-event-emitter
 and event-adjacent HSL diagnostic redaction is merged and deployed at canonical
-`4192e709d46d3ef9516025e121ddad15c0d0cd6e`. The active fill-history
-diagnostic-redaction slice removes retained exception values from fill-refresh
-summaries and human diagnostics without changing refresh, fill, planning,
-risk, or trading behavior. Resolve its PR and exact head from live metadata
-after publication.
+`4192e709d46d3ef9516025e121ddad15c0d0cd6e`. Open PR #1347, `Redact fill
+refresh failure diagnostics`, removes retained exception values from
+fill-refresh summaries and human diagnostics without changing refresh, fill,
+planning, risk, or trading behavior. Resolve its exact head from live metadata.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -28,9 +28,9 @@ Estimated completion:
   metadata; the commit containing this handoff is a moving review head.
 - Scope: remove arbitrary exception values from structured fill-refresh
   summaries, exchange-specific fetcher diagnostics, request timing, staged
-  remote-call events, startup initialization, blocking/routine/coverage
+  remote-call events, cache reads, startup/process handling, blocking/routine/coverage
   callers, and HSL flatten confirmation while retaining bounded exception
-  type, safe status/code, and existing source, coverage, retry, timing, count,
+  type, validated numeric status/code, and existing source, coverage, retry, timing, count,
   and endpoint context. Adjacent monitor, metadata-capture, and HSL progress
   diagnostics use the same safe type boundary.
 - Behavior boundary: diagnostic retention and projection only. Exception

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -28,8 +28,10 @@ Estimated completion:
   metadata; the commit containing this handoff is a moving review head.
 - Scope: remove arbitrary exception values from structured fill-refresh
   summaries, fill-fetch request timing, blocking refresh failure logs, and
-  routine-prefetch fallback logs while retaining bounded exception type and
-  existing source, coverage, retry, timing, count, and endpoint context.
+  routine-prefetch fallback logs while retaining bounded exception type, safe
+  status/code, and existing source, coverage, retry, timing, count, and
+  endpoint context. The adjacent monitor error sink uses the same safe type
+  boundary so publication cannot mask the refresh failure.
 - Behavior boundary: diagnostic retention and projection only. Exception
   propagation, refresh and retry behavior, fill accounting, planning, orders,
   risk, and trading behavior remain unchanged.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,27 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1345)
+## Latest Canonical Deployment (PR #1346)
+
+- PR #1346 merged exact approved head `377cb1dc60` as canonical
+  `4192e709d46d3ef9516025e121ddad15c0d0cd6e` after exact-head Hermes
+  approval, green Python/Rust CI, and finding-free built-in Codex and
+  independent Sol reviews.
+- VPS5 guarded-prepared tracked-clean from `49cb68e56b2` without a Rust build;
+  the Rust source fingerprint/stamp and compiled artifact remained unchanged.
+  The exact-target orchestrator gracefully restarted only panes `%358`-`%362`;
+  old PIDs `1077958/1077967/1077961/1077970/1077964` exited and replacement
+  PIDs `1079121/1079130/1079124/1079133/1079127` relaunched and verified
+  without force or broad-pattern signals.
+- The integrated 120-second smoke was hard-green with complete shutdown and
+  startup identity, zero hard failures, zero hard text-log or attention
+  matches, and zero monitor warnings or errors. A bounded settled check found
+  all five exact processes stable, the checkout exact and tracked-clean, and
+  protected `misc:0.0` preserved as `%8`/PID `434835`. No direct authenticated
+  exchange call or event was manufactured. The next redaction slice removes
+  arbitrary exception values from fill-history refresh diagnostics.
+
+## Previous Canonical Deployment (PR #1345)
 
 - PR #1345 merged exact approved head `e9322f9b50` as canonical
   `49cb68e56b20d71fbe42d33f31906d3a9c793e90` after exact-head Hermes

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -1568,11 +1568,16 @@ class FillEventCache:
                 with path.open("r", encoding="utf-8") as fh:
                     payload = json.load(fh) or []
             except Exception as exc:
-                logger.warning("[fills] cache load: failed to read %s (%s)", path, exc)
+                error_type = bounded_exception_type(exc)
+                logger.warning(
+                    "[fills] cache load: failed to read %s | error_type=%s",
+                    path,
+                    error_type,
+                )
                 if not allow_legacy_contract:
                     raise FillEventCacheContractError(
                         f"fill-event cache file {path} is unreadable and cannot be used for "
-                        f"trading-critical accounting: {exc}"
+                        f"trading-critical accounting; error_type={error_type}"
                     ) from exc
                 continue
             for raw in payload:
@@ -1599,7 +1604,8 @@ class FillEventCache:
                 except Exception as exc:
                     raise FillEventCacheContractError(
                         f"fill-event cache record {path} is malformed and cannot be used for "
-                        f"trading-critical accounting: {exc}"
+                        "trading-critical accounting; "
+                        f"error_type={bounded_exception_type(exc)}"
                     ) from exc
         events.sort(key=lambda ev: ev.timestamp)
         logger.debug(
@@ -1763,7 +1769,11 @@ class FillEventCache:
                 data.setdefault(key, default[key])
             self._metadata = data
         except Exception as exc:
-            logger.warning("[fills] cache metadata: failed to read %s (%s)", self.metadata_path, exc)
+            logger.warning(
+                "[fills] cache metadata: failed to read %s | error_type=%s",
+                self.metadata_path,
+                bounded_exception_type(exc),
+            )
             self._metadata = default
 
         return self._metadata

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -110,7 +110,9 @@ def _is_disk_full_error(exc: BaseException) -> bool:
             return True
     except BaseException:
         pass
-    return exception_text_contains(exc, ("no space left on device",))
+    return exception_text_contains(
+        exc, ("No space left on device",), case_sensitive=True
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -6101,7 +6103,9 @@ class GateioFetcher(BaseFetcher):
                 continue
             except Exception as exc:
                 # Check if it's a rate limit error in disguise
-                if exception_text_contains(exc, ("too_many_requests",)):
+                if exception_text_contains(
+                    exc, ("TOO_MANY_REQUESTS",), case_sensitive=True
+                ):
                     consecutive_rate_limits += 1
                     sleep_time = min(2**consecutive_rate_limits, 30)
                     logger.debug(

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -2398,8 +2398,8 @@ class BitgetFetcher(BaseFetcher):
         for res in results:
             if isinstance(res, Exception):
                 logger.error(
-                    "BitgetFetcher._flush_detail_tasks: detail fetch failed: %s",
-                    res,
+                    "BitgetFetcher._flush_detail_tasks: detail fetch failed error_type=%s",
+                    bounded_exception_type(res),
                 )
                 continue
             total += res or 0
@@ -2534,9 +2534,9 @@ class BitgetFetcher(BaseFetcher):
             resolved = self._symbol_resolver(market_symbol)
         except Exception as exc:
             logger.warning(
-                "BitgetFetcher._resolve_symbol: resolver failed for %s (%s); using fallback",
+                "BitgetFetcher._resolve_symbol: resolver failed for %s error_type=%s; using fallback",
                 market_symbol,
-                exc,
+                bounded_exception_type(exc),
             )
             resolved = None
         if resolved:
@@ -2662,7 +2662,11 @@ class BinanceFetcher(BaseFetcher):
                     if pending is not task and not pending.done():
                         pending.cancel()
                 await asyncio.gather(*trade_tasks.values(), return_exceptions=True)
-                logger.error("BinanceFetcher.fetch: error fetching trades for %s (%s)", symbol, exc)
+                logger.error(
+                    "BinanceFetcher.fetch: error fetching trades for %s error_type=%s",
+                    symbol,
+                    bounded_exception_type(exc),
+                )
                 raise
             for trade in trades:
                 event = self._normalize_trade(trade)
@@ -2820,8 +2824,8 @@ class BinanceFetcher(BaseFetcher):
                     event, event_id, res = await task
                 except Exception as exc:
                     logger.debug(
-                        "BinanceFetcher.fetch: order-detail enrichment failed (%s)",
-                        exc,
+                        "BinanceFetcher.fetch: order-detail enrichment failed error_type=%s",
+                        bounded_exception_type(exc),
                     )
                     continue
                 if res:
@@ -2879,9 +2883,9 @@ class BinanceFetcher(BaseFetcher):
             detail = await self.api.fetch_order(order_id, symbol)
         except Exception as exc:  # pragma: no cover - live API dependent
             logger.debug(
-                "BinanceFetcher._enrich_with_order_details: fetch_order failed for %s (%s)",
+                "BinanceFetcher._enrich_with_order_details: fetch_order failed for %s error_type=%s",
                 order_id,
-                exc,
+                bounded_exception_type(exc),
             )
             return None
         info = detail.get("info") if isinstance(detail, dict) else detail
@@ -3050,18 +3054,23 @@ class BinanceFetcher(BaseFetcher):
         except Exception as exc:  # pragma: no cover - depends on live API
             if self._stop_requested():
                 logger.debug(
-                    "BinanceFetcher._fetch_symbol_trades: stopped during shutdown for %s (%s)",
+                    "BinanceFetcher._fetch_symbol_trades: stopped during shutdown for %s error_type=%s",
                     ccxt_symbol,
-                    exc,
+                    bounded_exception_type(exc),
                 )
                 return []
             msg = str(exc).lower() if exc else ""
             if "does not have market symbol" in msg or "market symbol" in msg:
                 self._note_unsupported_symbol(ccxt_symbol)
                 return []
-            logger.error("BinanceFetcher._fetch_symbol_trades: error %s (%s)", ccxt_symbol, exc)
+            logger.error(
+                "BinanceFetcher._fetch_symbol_trades: error %s error_type=%s",
+                ccxt_symbol,
+                bounded_exception_type(exc),
+            )
             raise RuntimeError(
-                f"Binance trade-history fetch failed for {ccxt_symbol}: {exc}"
+                "Binance trade-history fetch failed for "
+                f"{ccxt_symbol} error_type={bounded_exception_type(exc)}"
             ) from exc
 
     def _normalize_income(
@@ -3141,7 +3150,10 @@ class BinanceFetcher(BaseFetcher):
         try:
             items = provider() or []
         except Exception as exc:
-            logger.warning("BinanceFetcher._collect_symbols: provider failed (%s)", exc)
+            logger.warning(
+                "BinanceFetcher._collect_symbols: provider failed error_type=%s",
+                bounded_exception_type(exc),
+            )
             return []
         symbols: List[str] = []
         for raw in items:
@@ -3158,7 +3170,11 @@ class BinanceFetcher(BaseFetcher):
             if resolved:
                 return resolved
         except Exception as exc:
-            logger.warning("BinanceFetcher._resolve_symbol: resolver failed for %s (%s)", value, exc)
+            logger.warning(
+                "BinanceFetcher._resolve_symbol: resolver failed for %s error_type=%s",
+                value,
+                bounded_exception_type(exc),
+            )
         return str(value)
 
 
@@ -3266,13 +3282,13 @@ class FillEventsManager:
                 ticker = await fetch_ticker(symbol)
             except Exception as exc:
                 logger.debug(
-                    "[fills] fee conversion ticker unavailable | exchange=%s user=%s pair=%s/%s symbol=%s error=%s",
+                    "[fills] fee conversion ticker unavailable | exchange=%s user=%s pair=%s/%s symbol=%s error_type=%s",
                     self.exchange,
                     self.user,
                     fee_currency,
                     quote_currency,
                     symbol,
-                    exc,
+                    bounded_exception_type(exc),
                 )
                 continue
             if not isinstance(ticker, dict):
@@ -4428,7 +4444,9 @@ class FillEventsManager:
                 parsed_events.append((raw, event))
             if malformed_events:
                 preview = ", ".join(
-                    f"id={raw.get('id')!r} error={exc}" for raw, exc in malformed_events[:3]
+                    "id="
+                    f"{raw.get('id')!r} error_type={bounded_exception_type(exc)}"
+                    for raw, exc in malformed_events[:3]
                 )
                 extra = "" if len(malformed_events) <= 3 else f", +{len(malformed_events) - 3} more"
                 raise ValueError(
@@ -5288,7 +5306,10 @@ class BybitFetcher(BaseFetcher):
             try:
                 response = await self.api.private_get_v5_position_closed_pnl(params)
             except Exception as exc:
-                logger.warning("BybitFetcher._fetch_positions_history: API error: %s", exc)
+                logger.warning(
+                    "BybitFetcher._fetch_positions_history: API error_type=%s",
+                    bounded_exception_type(exc),
+                )
                 break
 
             batch = response.get("result", {}).get("list", [])
@@ -5329,7 +5350,10 @@ class BybitFetcher(BaseFetcher):
                 try:
                     response = await self.api.private_get_v5_position_closed_pnl(params)
                 except Exception as exc:
-                    logger.warning("BybitFetcher._fetch_positions_history: API error: %s", exc)
+                    logger.warning(
+                        "BybitFetcher._fetch_positions_history: API error_type=%s",
+                        bounded_exception_type(exc),
+                    )
                     break
 
                 batch = response.get("result", {}).get("list", [])
@@ -5619,10 +5643,10 @@ class HyperliquidFetcher(BaseFetcher):
                     logger.warning("%s", msg)
                     raise RateLimitExceeded(msg) from exc
                 logger.debug(
-                    "HyperliquidFetcher.fetch: rate limit exceeded (retry %d/%d), sleeping (%s)",
+                    "HyperliquidFetcher.fetch: rate limit exceeded (retry %d/%d), sleeping error_type=%s",
                     rate_limit_retries,
                     max_rate_limit_retries,
-                    exc,
+                    bounded_exception_type(exc),
                 )
                 await asyncio.sleep(min(30.0, 2.0 ** rate_limit_retries))
                 # Reset prev_params so the retry is not flagged as repeated
@@ -5903,7 +5927,7 @@ class WeexFetcher(BaseFetcher):
                     logger.debug(
                         "WeexFetcher: fetch_order failed order=%s error_type=%s",
                         order_id,
-                        type(exc).__name__,
+                        bounded_exception_type(exc),
                     )
                     return key, ""
                 info = order.get("info") if isinstance(order, dict) else {}
@@ -6054,7 +6078,9 @@ class GateioFetcher(BaseFetcher):
                 consecutive_rate_limits += 1
                 sleep_time = min(2**consecutive_rate_limits, 30)
                 logger.debug(
-                    "GateioFetcher._fetch_trades: rate-limited (%s); sleeping %.1fs", exc, sleep_time
+                    "GateioFetcher._fetch_trades: rate-limited error_type=%s; sleeping %.1fs",
+                    bounded_exception_type(exc),
+                    sleep_time,
                 )
                 await asyncio.sleep(sleep_time)
                 continue
@@ -6064,8 +6090,8 @@ class GateioFetcher(BaseFetcher):
                     consecutive_rate_limits += 1
                     sleep_time = min(2**consecutive_rate_limits, 30)
                     logger.debug(
-                        "GateioFetcher._fetch_trades: rate-limited (%s); sleeping %.1fs",
-                        exc,
+                        "GateioFetcher._fetch_trades: rate-limited error_type=%s; sleeping %.1fs",
+                        bounded_exception_type(exc),
                         sleep_time,
                     )
                     await asyncio.sleep(sleep_time)
@@ -6160,7 +6186,10 @@ class GateioFetcher(BaseFetcher):
             try:
                 batch = await self.api.fetch_closed_orders(params=params)
             except RateLimitExceeded as exc:
-                logger.debug("GateioFetcher._fetch_orders_for_pnl: rate-limited (%s); sleeping", exc)
+                logger.debug(
+                    "GateioFetcher._fetch_orders_for_pnl: rate-limited error_type=%s; sleeping",
+                    bounded_exception_type(exc),
+                )
                 await asyncio.sleep(1.0)
                 continue
 
@@ -6918,9 +6947,9 @@ class KucoinFetcher(BaseFetcher):
             detail = await self.api.fetch_order(order_id, symbol)
         except Exception as exc:  # pragma: no cover - live API dependent
             logger.debug(
-                "KucoinFetcher._enrich_with_order_details: fetch_order failed for %s (%s)",
+                "KucoinFetcher._enrich_with_order_details: fetch_order failed for %s error_type=%s",
                 order_id,
-                exc,
+                bounded_exception_type(exc),
             )
             return None
         info = detail.get("info") if isinstance(detail, dict) else detail
@@ -7103,7 +7132,10 @@ class OkxFetcher(BaseFetcher):
                 else:
                     response = await self.api.private_get_trade_fills_history(params)
             except RateLimitExceeded as exc:
-                logger.debug("OkxFetcher: rate limit hit, sleeping (%s)", exc)
+                logger.debug(
+                    "OkxFetcher: rate limit hit, sleeping error_type=%s",
+                    bounded_exception_type(exc),
+                )
                 await asyncio.sleep(2.0)
                 continue
 

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -41,6 +41,7 @@ from bitget_normalization import (
     normalize_uta_fill_payload as _normalize_uta_fill_payload,
 )
 from config import load_input_config, prepare_config
+from live.diagnostic_safety import bounded_exception_type
 
 try:
     from utils import ts_to_date  # type: ignore
@@ -2025,7 +2026,6 @@ class FillFetchRequestStats:
                 "total_ms": 0,
                 "max_ms": 0,
                 "last_error_type": "",
-                "last_error": "",
             },
         )
         data["count"] += 1
@@ -2043,11 +2043,9 @@ class FillFetchRequestStats:
                 "total_ms": 0,
                 "max_ms": 0,
                 "last_error_type": "",
-                "last_error": "",
             },
         )
-        data["last_error_type"] = type(exc).__name__
-        data["last_error"] = str(exc)[:240]
+        data["last_error_type"] = bounded_exception_type(exc)
 
     @property
     def count(self) -> int:
@@ -2077,11 +2075,8 @@ class FillFetchRequestStats:
             if errors:
                 suffix = f",err={errors}"
                 error_type = str(data.get("last_error_type") or "")
-                error_msg = str(data.get("last_error") or "")
                 if error_type:
                     suffix += f",err_type={error_type}"
-                if error_msg:
-                    suffix += f",err_msg={error_msg}"
             parts.append(f"{name}:n={count},sum={total_ms}ms,max={max_ms}ms{suffix}")
         if len(self.calls) > limit:
             parts.append(f"+{len(self.calls) - limit} endpoints")

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -41,7 +41,7 @@ from bitget_normalization import (
     normalize_uta_fill_payload as _normalize_uta_fill_payload,
 )
 from config import load_input_config, prepare_config
-from live.diagnostic_safety import bounded_exception_type
+from live.diagnostic_safety import bounded_exception_type, exception_text_contains
 
 try:
     from utils import ts_to_date  # type: ignore
@@ -105,9 +105,12 @@ class FillEventCacheContractError(RuntimeError):
 
 
 def _is_disk_full_error(exc: BaseException) -> bool:
-    if isinstance(exc, OSError) and getattr(exc, "errno", None) == errno.ENOSPC:
-        return True
-    return "No space left on device" in str(exc)
+    try:
+        if isinstance(exc, OSError) and getattr(exc, "errno", None) == errno.ENOSPC:
+            return True
+    except BaseException:
+        pass
+    return exception_text_contains(exc, ("no space left on device",))
 
 
 # ---------------------------------------------------------------------------
@@ -1658,9 +1661,10 @@ class FillEventCache:
                     payload = json.load(fh) or []
             except Exception as exc:
                 logger.warning(
-                    "[fills-doctor] could not inspect fill cache file for legacy contract repair | path=%s error=%s",
+                    "[fills-doctor] could not inspect fill cache file for legacy contract repair | "
+                    "path=%s error_type=%s",
                     path,
-                    exc,
+                    bounded_exception_type(exc),
                 )
                 continue
             if not isinstance(payload, list):
@@ -3069,8 +3073,9 @@ class BinanceFetcher(BaseFetcher):
                     bounded_exception_type(exc),
                 )
                 return []
-            msg = str(exc).lower() if exc else ""
-            if "does not have market symbol" in msg or "market symbol" in msg:
+            if exception_text_contains(
+                exc, ("does not have market symbol", "market symbol")
+            ):
                 self._note_unsupported_symbol(ccxt_symbol)
                 return []
             logger.error(
@@ -6096,7 +6101,7 @@ class GateioFetcher(BaseFetcher):
                 continue
             except Exception as exc:
                 # Check if it's a rate limit error in disguise
-                if "TOO_MANY_REQUESTS" in str(exc):
+                if exception_text_contains(exc, ("too_many_requests",)):
                     consecutive_rate_limits += 1
                     sleep_time = min(2**consecutive_rate_limits, 30)
                     logger.debug(

--- a/src/live/diagnostic_safety.py
+++ b/src/live/diagnostic_safety.py
@@ -77,6 +77,32 @@ def bounded_exception_type(exc: BaseException) -> str:
         return "Error"
 
 
+def _text_contains(
+    text: str,
+    needles: tuple[str, ...],
+    *,
+    case_sensitive: bool = False,
+    chunk_chars: int = 4096,
+) -> bool:
+    if type(text) is not str or type(case_sensitive) is not bool:
+        return False
+    search_needles = tuple(
+        needle if case_sensitive else needle.lower()
+        for needle in needles
+        if type(needle) is str and needle
+    )
+    if not search_needles or type(chunk_chars) is not int or chunk_chars <= 0:
+        return False
+    overlap = max(len(needle) for needle in search_needles) - 1
+    for start in range(0, len(text), chunk_chars):
+        chunk_start = max(0, start - overlap)
+        chunk = text[chunk_start : start + chunk_chars]
+        searchable_chunk = chunk if case_sensitive else chunk.lower()
+        if any(needle in searchable_chunk for needle in search_needles):
+            return True
+    return False
+
+
 def exception_text_contains(
     exc: BaseException,
     needles: tuple[str, ...],
@@ -86,24 +112,27 @@ def exception_text_contains(
 ) -> bool:
     """Inspect exception text in bounded temporary chunks without returning it."""
     try:
-        text = str(exc)
-        if type(text) is not str or type(case_sensitive) is not bool:
-            return False
-        search_needles = tuple(
-            needle if case_sensitive else needle.lower()
-            for needle in needles
-            if type(needle) is str and needle
+        return _text_contains(
+            str(exc),
+            needles,
+            case_sensitive=case_sensitive,
+            chunk_chars=chunk_chars,
         )
-        if not search_needles or type(chunk_chars) is not int or chunk_chars <= 0:
-            return False
-        overlap = max(len(needle) for needle in search_needles) - 1
-        for start in range(0, len(text), chunk_chars):
-            chunk_start = max(0, start - overlap)
-            chunk = text[chunk_start : start + chunk_chars]
-            searchable_chunk = chunk if case_sensitive else chunk.lower()
-            if any(needle in searchable_chunk for needle in search_needles):
-                return True
+    except BaseException:
         return False
+
+
+def exception_type_name_contains(
+    exc: BaseException,
+    needles: tuple[str, ...],
+    *,
+    case_sensitive: bool = False,
+) -> bool:
+    """Inspect the real class name for control flow without projecting that name."""
+    try:
+        cls = type(exc)
+        name = type.__getattribute__(cls, "__name__")
+        return _text_contains(name, needles, case_sensitive=case_sensitive)
     except BaseException:
         return False
 

--- a/src/live/diagnostic_safety.py
+++ b/src/live/diagnostic_safety.py
@@ -81,18 +81,27 @@ def exception_text_contains(
     exc: BaseException,
     needles: tuple[str, ...],
     *,
-    max_chars: int = 4096,
+    chunk_chars: int = 4096,
 ) -> bool:
-    """Inspect bounded exception text for code-owned markers without returning it."""
+    """Inspect exception text in bounded temporary chunks without returning it."""
     try:
         text = str(exc)
         if type(text) is not str:
             return False
-        lowered = text[:max_chars].lower()
-        return any(
-            type(needle) is str and needle.lower() in lowered
+        lowered_needles = tuple(
+            needle.lower()
             for needle in needles
+            if type(needle) is str and needle
         )
+        if not lowered_needles or type(chunk_chars) is not int or chunk_chars <= 0:
+            return False
+        overlap = max(len(needle) for needle in lowered_needles) - 1
+        for start in range(0, len(text), chunk_chars):
+            chunk_start = max(0, start - overlap)
+            lowered_chunk = text[chunk_start : start + chunk_chars].lower()
+            if any(needle in lowered_chunk for needle in lowered_needles):
+                return True
+        return False
     except BaseException:
         return False
 

--- a/src/live/diagnostic_safety.py
+++ b/src/live/diagnostic_safety.py
@@ -131,7 +131,7 @@ def exception_type_name_contains(
     """Inspect the real class name for control flow without projecting that name."""
     try:
         cls = type(exc)
-        name = type.__dict__["__name__"].__get__(cls, type)
+        name = str.__str__(type.__dict__["__name__"].__get__(cls, type))
         return _text_contains(name, needles, case_sensitive=case_sensitive)
     except BaseException:
         return False

--- a/src/live/diagnostic_safety.py
+++ b/src/live/diagnostic_safety.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import sys
 
 EXCEPTION_TYPE_MAX_LEN = 80
 _SENSITIVE_EXCEPTION_TYPE_RE = re.compile(
@@ -41,6 +42,17 @@ def _trusted_exception_module(module: str) -> bool:
     )
 
 
+def _module_exports_exception_class(module: str, name: str, cls: type) -> bool:
+    try:
+        module_obj = sys.modules.get(module)
+        if type(module_obj) is not type(sys):
+            return False
+        namespace = type(sys).__getattribute__(module_obj, "__dict__")
+        return type(namespace) is dict and namespace.get(name) is cls
+    except BaseException:
+        return False
+
+
 def bounded_exception_type(exc: BaseException) -> str:
     try:
         mro = type.__getattribute__(type(exc), "__mro__")
@@ -57,11 +69,32 @@ def bounded_exception_type(exc: BaseException) -> str:
                 and name.isascii()
                 and name.isidentifier()
                 and not _SENSITIVE_EXCEPTION_TYPE_RE.search(name)
+                and _module_exports_exception_class(module, name, cls)
             ):
                 return name[:EXCEPTION_TYPE_MAX_LEN]
         return "Error"
     except BaseException:
         return "Error"
+
+
+def exception_text_contains(
+    exc: BaseException,
+    needles: tuple[str, ...],
+    *,
+    max_chars: int = 4096,
+) -> bool:
+    """Inspect bounded exception text for code-owned markers without returning it."""
+    try:
+        text = str(exc)
+        if type(text) is not str:
+            return False
+        lowered = text[:max_chars].lower()
+        return any(
+            type(needle) is str and needle.lower() in lowered
+            for needle in needles
+        )
+    except BaseException:
+        return False
 
 
 def _exact_scalar_text(value: object) -> str | None:

--- a/src/live/diagnostic_safety.py
+++ b/src/live/diagnostic_safety.py
@@ -131,7 +131,7 @@ def exception_type_name_contains(
     """Inspect the real class name for control flow without projecting that name."""
     try:
         cls = type(exc)
-        name = type.__getattribute__(cls, "__name__")
+        name = type.__dict__["__name__"].__get__(cls, type)
         return _text_contains(name, needles, case_sensitive=case_sensitive)
     except BaseException:
         return False

--- a/src/live/diagnostic_safety.py
+++ b/src/live/diagnostic_safety.py
@@ -29,11 +29,16 @@ def bounded_exception_type(exc: BaseException) -> str:
 
 
 def _exact_scalar_text(value: object) -> str | None:
-    if type(value) is str:
-        return value
-    if type(value) is int:
-        return str(value)
-    return None
+    try:
+        if type(value) is str:
+            return value
+        if type(value) is int:
+            if int.bit_length(value) > 160:
+                return None
+            return str(value)
+        return None
+    except BaseException:
+        return None
 
 
 def _bounded_exception_attribute(
@@ -41,26 +46,12 @@ def _bounded_exception_attribute(
     names: tuple[str, ...],
     pattern: re.Pattern[str],
 ) -> str | None:
-    for name in names:
-        try:
-            value = getattr(exc, name, None)
-        except BaseException:
-            continue
-        text = _exact_scalar_text(value)
-        if (
-            text is not None
-            and text.isascii()
-            and pattern.fullmatch(text)
-            and not _SENSITIVE_EXCEPTION_TYPE_RE.search(text)
-        ):
-            return text
     try:
-        info = getattr(exc, "info", None)
-    except BaseException:
-        info = None
-    if type(info) is dict:
         for name in names:
-            value = info.get(name)
+            try:
+                value = getattr(exc, name, None)
+            except BaseException:
+                continue
             text = _exact_scalar_text(value)
             if (
                 text is not None
@@ -69,7 +60,24 @@ def _bounded_exception_attribute(
                 and not _SENSITIVE_EXCEPTION_TYPE_RE.search(text)
             ):
                 return text
-    return None
+        try:
+            info = getattr(exc, "info", None)
+        except BaseException:
+            info = None
+        if type(info) is dict:
+            for name in names:
+                value = info.get(name)
+                text = _exact_scalar_text(value)
+                if (
+                    text is not None
+                    and text.isascii()
+                    and pattern.fullmatch(text)
+                    and not _SENSITIVE_EXCEPTION_TYPE_RE.search(text)
+                ):
+                    return text
+        return None
+    except BaseException:
+        return None
 
 
 def bounded_exception_status(exc: BaseException) -> str | None:

--- a/src/live/diagnostic_safety.py
+++ b/src/live/diagnostic_safety.py
@@ -55,6 +55,7 @@ def _bounded_exception_attribute(
             text = _exact_scalar_text(value)
             if (
                 text is not None
+                and len(text) <= 80
                 and text.isascii()
                 and pattern.fullmatch(text)
                 and not _SENSITIVE_EXCEPTION_TYPE_RE.search(text)
@@ -70,6 +71,7 @@ def _bounded_exception_attribute(
                 text = _exact_scalar_text(value)
                 if (
                     text is not None
+                    and len(text) <= 80
                     and text.isascii()
                     and pattern.fullmatch(text)
                     and not _SENSITIVE_EXCEPTION_TYPE_RE.search(text)

--- a/src/live/diagnostic_safety.py
+++ b/src/live/diagnostic_safety.py
@@ -8,22 +8,58 @@ _SENSITIVE_EXCEPTION_TYPE_RE = re.compile(
     r"privatekey|secret|signature|token|wallet_?address|walletaddress)"
 )
 _EXCEPTION_STATUS_RE = re.compile(r"[0-9]{1,3}")
-_EXCEPTION_CODE_RE = re.compile(r"-?[A-Za-z0-9][A-Za-z0-9_-]{0,47}")
+_EXCEPTION_CODE_RE = re.compile(r"-?[0-9]{1,12}")
+_TRUSTED_EXCEPTION_MODULE_PREFIXES = (
+    "aiohttp",
+    "asyncio",
+    "binance_ohlcv_archive",
+    "builtins",
+    "candlestick_manager",
+    "ccxt",
+    "custom_endpoint_overrides",
+    "exchanges",
+    "fill_events_manager",
+    "hlcv_preparation",
+    "hlcvs_manifest",
+    "httpx",
+    "live",
+    "metrics_schema",
+    "pareto_store",
+    "passivbot",
+    "passivbot_exceptions",
+    "requests",
+    "ssl",
+    "urllib3",
+    "websockets",
+)
+
+
+def _trusted_exception_module(module: str) -> bool:
+    return any(
+        module == prefix or module.startswith(f"{prefix}.")
+        for prefix in _TRUSTED_EXCEPTION_MODULE_PREFIXES
+    )
 
 
 def bounded_exception_type(exc: BaseException) -> str:
     try:
-        name = type(exc).__name__
-        if type(name) is not str:
+        mro = type.__getattribute__(type(exc), "__mro__")
+        if type(mro) is not tuple:
             return "Error"
-        if (
-            not name
-            or not name.isascii()
-            or not name.isidentifier()
-            or _SENSITIVE_EXCEPTION_TYPE_RE.search(name)
-        ):
-            return "Error"
-        return name[:EXCEPTION_TYPE_MAX_LEN]
+        for cls in mro:
+            module = type.__getattribute__(cls, "__module__")
+            name = type.__getattribute__(cls, "__name__")
+            if type(module) is not str or not _trusted_exception_module(module):
+                continue
+            if (
+                type(name) is str
+                and name
+                and name.isascii()
+                and name.isidentifier()
+                and not _SENSITIVE_EXCEPTION_TYPE_RE.search(name)
+            ):
+                return name[:EXCEPTION_TYPE_MAX_LEN]
+        return "Error"
     except BaseException:
         return "Error"
 

--- a/src/live/diagnostic_safety.py
+++ b/src/live/diagnostic_safety.py
@@ -7,6 +7,8 @@ _SENSITIVE_EXCEPTION_TYPE_RE = re.compile(
     r"(?i)(?:api_?key|apikey|authorization|cookie|passphrase|password|private_?key|"
     r"privatekey|secret|signature|token|wallet_?address|walletaddress)"
 )
+_EXCEPTION_STATUS_RE = re.compile(r"[0-9]{1,3}")
+_EXCEPTION_CODE_RE = re.compile(r"-?[A-Za-z0-9][A-Za-z0-9_-]{0,47}")
 
 
 def bounded_exception_type(exc: BaseException) -> str:
@@ -24,3 +26,63 @@ def bounded_exception_type(exc: BaseException) -> str:
         return name[:EXCEPTION_TYPE_MAX_LEN]
     except BaseException:
         return "Error"
+
+
+def _exact_scalar_text(value: object) -> str | None:
+    if type(value) is str:
+        return value
+    if type(value) is int:
+        return str(value)
+    return None
+
+
+def _bounded_exception_attribute(
+    exc: BaseException,
+    names: tuple[str, ...],
+    pattern: re.Pattern[str],
+) -> str | None:
+    for name in names:
+        try:
+            value = getattr(exc, name, None)
+        except BaseException:
+            continue
+        text = _exact_scalar_text(value)
+        if (
+            text is not None
+            and text.isascii()
+            and pattern.fullmatch(text)
+            and not _SENSITIVE_EXCEPTION_TYPE_RE.search(text)
+        ):
+            return text
+    try:
+        info = getattr(exc, "info", None)
+    except BaseException:
+        info = None
+    if type(info) is dict:
+        for name in names:
+            value = info.get(name)
+            text = _exact_scalar_text(value)
+            if (
+                text is not None
+                and text.isascii()
+                and pattern.fullmatch(text)
+                and not _SENSITIVE_EXCEPTION_TYPE_RE.search(text)
+            ):
+                return text
+    return None
+
+
+def bounded_exception_status(exc: BaseException) -> str | None:
+    return _bounded_exception_attribute(
+        exc,
+        ("http_status", "status", "status_code", "statusCode"),
+        _EXCEPTION_STATUS_RE,
+    )
+
+
+def bounded_exception_code(exc: BaseException) -> str | None:
+    return _bounded_exception_attribute(
+        exc,
+        ("code", "exact", "error_code", "retCode", "errorCode"),
+        _EXCEPTION_CODE_RE,
+    )

--- a/src/live/diagnostic_safety.py
+++ b/src/live/diagnostic_safety.py
@@ -81,25 +81,27 @@ def exception_text_contains(
     exc: BaseException,
     needles: tuple[str, ...],
     *,
+    case_sensitive: bool = False,
     chunk_chars: int = 4096,
 ) -> bool:
     """Inspect exception text in bounded temporary chunks without returning it."""
     try:
         text = str(exc)
-        if type(text) is not str:
+        if type(text) is not str or type(case_sensitive) is not bool:
             return False
-        lowered_needles = tuple(
-            needle.lower()
+        search_needles = tuple(
+            needle if case_sensitive else needle.lower()
             for needle in needles
             if type(needle) is str and needle
         )
-        if not lowered_needles or type(chunk_chars) is not int or chunk_chars <= 0:
+        if not search_needles or type(chunk_chars) is not int or chunk_chars <= 0:
             return False
-        overlap = max(len(needle) for needle in lowered_needles) - 1
+        overlap = max(len(needle) for needle in search_needles) - 1
         for start in range(0, len(text), chunk_chars):
             chunk_start = max(0, start - overlap)
-            lowered_chunk = text[chunk_start : start + chunk_chars].lower()
-            if any(needle in lowered_chunk for needle in lowered_needles):
+            chunk = text[chunk_start : start + chunk_chars]
+            searchable_chunk = chunk if case_sensitive else chunk.lower()
+            if any(needle in searchable_chunk for needle in search_needles):
                 return True
         return False
     except BaseException:

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -761,9 +761,7 @@ def _emit_authoritative_remote_call_event_unchecked(
     if elapsed_ms is not None:
         data["elapsed_ms"] = int(elapsed_ms)
     if error is not None:
-        data["error_type"] = type(error).__name__
-        data["error"] = _sanitize_remote_text(error, max_len=500)
-        data["error_repr"] = _sanitize_remote_text(repr(error), max_len=500)
+        data["error_type"] = _bounded_exception_type(error)
     elif stage != "start":
         data.update(_authoritative_result_summary(surface, result))
     if live_event_debug_profile_enabled(bot, "remote_calls"):

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -864,7 +864,7 @@ def _emit_exchange_time_sync_event_unchecked(
                 source, _EXCHANGE_TIME_SYNC_SOURCE_RE
             ),
             "error_type": _bounded_exchange_time_sync_field(
-                type(error).__name__, _EXCHANGE_TIME_SYNC_ERROR_TYPE_RE
+                _bounded_exception_type(error), _EXCHANGE_TIME_SYNC_ERROR_TYPE_RE
             ),
             "hook_available": bool(hook_available),
             "recovered": recovered,

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -5220,8 +5220,7 @@ def _emit_fills_refresh_summary_event_unchecked(
     if quarantine_reason is not None:
         data["quarantine_reason"] = str(quarantine_reason)
     if error is not None:
-        data["error_type"] = type(error).__name__
-        data["error"] = _sanitize_remote_text(error, max_len=500)
+        data["error_type"] = _bounded_exception_type(error)
     if live_event_debug_profile_enabled(bot, "fills"):
         debug = _best_effort_fill_refresh_debug_payload(
             coverage_before=coverage_before,

--- a/src/live/state_refresh.py
+++ b/src/live/state_refresh.py
@@ -7,6 +7,7 @@ import sys
 from config.access import get_optional_config_value
 from live import event_emitters
 from live.balance_composition import malformed_balance_composition, unavailable_balance_composition
+from live.diagnostic_safety import bounded_exception_type
 from utils import ts_to_date, utc_ms
 
 
@@ -278,13 +279,15 @@ async def routine_fill_refresh_prefetch_task(bot, *, reason: str) -> None:
         raise
     except Exception as exc:
         if bot._shutdown_requested():
-            logging.debug("[shutdown] routine fills prefetch stopped: %s", exc)
+            logging.debug(
+                "[shutdown] routine fills prefetch stopped | error_type=%s",
+                bounded_exception_type(exc),
+            )
             return
         logging.warning(
-            "[fills] routine prefetch failed; blocking/confirmation refresh will retry | reason=%s error_type=%s error=%s",
+            "[fills] routine prefetch failed; blocking/confirmation refresh will retry | reason=%s error_type=%s",
             reason,
-            type(exc).__name__,
-            exc,
+            bounded_exception_type(exc),
         )
 
 

--- a/src/live/state_refresh.py
+++ b/src/live/state_refresh.py
@@ -323,9 +323,9 @@ async def timed_authoritative_fetch(bot, surface: str, coro, timings_ms: dict[st
                 )
             except Exception as exc:
                 logging.debug(
-                    "[diagnostic] failed to capture %s data packet metadata: %s",
+                    "[diagnostic] failed to capture %s data packet metadata | error_type=%s",
                     surface,
-                    exc,
+                    bounded_exception_type(exc),
                 )
         return result
     except Exception as exc:

--- a/src/monitor_publisher.py
+++ b/src/monitor_publisher.py
@@ -17,6 +17,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterable, Optional
 
+from live.diagnostic_safety import bounded_exception_type
+
 
 _MONITOR_EVENT_PHASE_TIMING_KEYS = (
     "lock_wait_ns",
@@ -56,7 +58,6 @@ _EVENT_RECOVERY_CHECKSUM_BYTES = 16
 _EVENT_RECOVERY_MARKER = b',"_recovery":{"checksum":"'
 _EVENT_RECOVERY_SEQ_SEPARATOR = b'","seq":'
 _EVENT_RECOVERY_TRAILER_MAX_BYTES = 160
-_MONITOR_ERROR_TYPE_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,79}")
 _MONITOR_ERROR_CONTEXT_VALUES = {
     "source": frozenset(("start_bot", "run_execution_loop", "update_pnls")),
     "stage": frozenset(
@@ -1204,10 +1205,7 @@ class MonitorPublisher:
         pside: Optional[str] = None,
     ) -> Optional[dict]:
         error_payload = _safe_monitor_error_context(payload)
-        error_type = type(error).__name__
-        error_payload["error_type"] = (
-            error_type if _MONITOR_ERROR_TYPE_RE.fullmatch(error_type) else "unknown"
-        )
+        error_payload["error_type"] = bounded_exception_type(error)
         return self.record_event(
             kind,
             tags or ("error",),

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -67,6 +67,7 @@ from live.diagnostic_safety import (
     bounded_exception_code,
     bounded_exception_status,
     bounded_exception_type,
+    exception_text_contains,
 )
 from live.freshness import ACCOUNT_SURFACES, LIVE_STATE_SURFACES, FreshnessLedger
 from live.events import DiagnosticEvent, emit_diagnostic_event, run_diagnostic_step
@@ -492,6 +493,26 @@ def _log_process_failure(label: str, exc: BaseException) -> None:
         bounded_exception_status(exc) or "-",
         bounded_exception_code(exc) or "-",
     )
+
+
+_EXECUTION_LOOP_ERROR_ENDPOINTS = frozenset(
+    {
+        "account-overview",
+        "accounts",
+        "balance",
+        "candles",
+        "fills",
+        "my-trades",
+        "ohlcv",
+        "open-orders",
+        "orders",
+        "positions",
+        "ticker",
+        "tickers",
+        "time",
+        "trades",
+    }
+)
 
 
 def compute_live_warmup_windows(
@@ -2309,26 +2330,44 @@ class Passivbot:
 
     def _is_exchange_time_sync_error(self, exc: BaseException) -> bool:
         """Return True for CCXT timestamp/nonce errors recoverable by clock sync."""
-        exc_name = type(exc).__name__.lower()
-        text = str(exc).lower()
-        combined = f"{exc_name} {text}"
-        if isinstance(exc, getattr(ccxt_errors, "InvalidNonce", tuple())):
-            return True
-        return any(
-            needle in combined
-            for needle in (
-                "invalidnonce",
-                "invalid nonce",
-                "kc-api-timestamp",
-                "recvwindow",
-                "recv window",
-                "timestamp for this request",
-                "outside of the recvwindow",
-                '"code":-1021',
-                "'code': -1021",
-                "code=-1021",
-            )
+        needles = (
+            "invalidnonce",
+            "invalid nonce",
+            "kc-api-timestamp",
+            "recvwindow",
+            "recv window",
+            "timestamp for this request",
+            "outside of the recvwindow",
+            '"code":-1021',
+            "'code': -1021",
+            "code=-1021",
         )
+        current: BaseException | None = exc
+        seen: set[int] = set()
+        for _ in range(8):
+            if current is None or id(current) in seen:
+                break
+            seen.add(id(current))
+            try:
+                if isinstance(current, getattr(ccxt_errors, "InvalidNonce", tuple())):
+                    return True
+            except BaseException:
+                pass
+            if "invalidnonce" in bounded_exception_type(current).lower():
+                return True
+            if exception_text_contains(current, needles):
+                return True
+            next_exc = None
+            for attr in ("__cause__", "__context__"):
+                try:
+                    candidate = BaseException.__getattribute__(current, attr)
+                except BaseException:
+                    continue
+                if isinstance(candidate, BaseException):
+                    next_exc = candidate
+                    break
+            current = next_exc
+        return False
 
     async def _maybe_recover_exchange_time_sync(
         self, exc: BaseException, *, source: str
@@ -5786,12 +5825,8 @@ class Passivbot:
         if not match:
             return "unknown"
         url = match.group(0).split("?", 1)[0].rstrip("/")
-        endpoint = url.rsplit("/", 1)[-1]
-        return self._execution_loop_error_field(
-            endpoint,
-            re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,47}"),
-            fallback="unknown",
-        )
+        endpoint = url.rsplit("/", 1)[-1].lower()
+        return endpoint if endpoint in _EXECUTION_LOOP_ERROR_ENDPOINTS else "unknown"
 
     def _log_execution_loop_error_burst(self, fields: dict[str, str]) -> None:
         """Summarize repeated execution-loop failures without hiding individual errors."""

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -981,7 +981,8 @@ class Passivbot:
             f"status={status} recovered={str(recovered).lower()} "
             f"synced={len(synced_clients)}[{client_summary(synced_clients)}] "
             f"failed={len(failed_clients)}[{client_summary(failed_clients)}] "
-            f"error_type={token(type(error).__name__, Passivbot._EXCHANGE_TIME_SYNC_CONSOLE_ERROR_TYPE_MAX_LEN)}"
+            "error_type="
+            f"{token(bounded_exception_type(error), Passivbot._EXCHANGE_TIME_SYNC_CONSOLE_ERROR_TYPE_MAX_LEN)}"
         )
 
     async def _handle_order_write_failures(
@@ -2342,12 +2343,18 @@ class Passivbot:
             "'code': -1021",
             "code=-1021",
         )
-        current: BaseException | None = exc
+        pending: list[BaseException] = [exc]
+        queued: set[int] = {id(exc)}
         seen: set[int] = set()
         for _ in range(8):
-            if current is None or id(current) in seen:
+            if not pending:
                 break
-            seen.add(id(current))
+            current = pending.pop(0)
+            current_id = id(current)
+            queued.discard(current_id)
+            if current_id in seen:
+                continue
+            seen.add(current_id)
             try:
                 if isinstance(current, getattr(ccxt_errors, "InvalidNonce", tuple())):
                     return True
@@ -2357,16 +2364,22 @@ class Passivbot:
                 return True
             if exception_text_contains(current, needles):
                 return True
-            next_exc = None
             for attr in ("__cause__", "__context__"):
                 try:
                     candidate = BaseException.__getattribute__(current, attr)
                 except BaseException:
                     continue
-                if isinstance(candidate, BaseException):
-                    next_exc = candidate
-                    break
-            current = next_exc
+                try:
+                    candidate_id = id(candidate)
+                    if (
+                        isinstance(candidate, BaseException)
+                        and candidate_id not in seen
+                        and candidate_id not in queued
+                    ):
+                        pending.append(candidate)
+                        queued.add(candidate_id)
+                except BaseException:
+                    continue
         return False
 
     async def _maybe_recover_exchange_time_sync(
@@ -2396,7 +2409,9 @@ class Passivbot:
                     f"->{Passivbot._format_exchange_time_sync_offset(after)}"
                 )
             except Exception as sync_exc:
-                failed_clients.append(f"{client_name}:{type(sync_exc).__name__}")
+                failed_clients.append(
+                    f"{client_name}:{bounded_exception_type(sync_exc)}"
+                )
         if not synced_clients and not failed_clients:
             logging.warning(
                 "%s",

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -484,6 +484,16 @@ def order_has_match(order, orders, tolerance_qty=0.01, tolerance_price=0.002):
     return False
 
 
+def _log_process_failure(label: str, exc: BaseException) -> None:
+    logging.error(
+        "%s | error_type=%s status=%s code=%s",
+        label,
+        bounded_exception_type(exc),
+        bounded_exception_status(exc) or "-",
+        bounded_exception_code(exc) or "-",
+    )
+
+
 def compute_live_warmup_windows(
     symbols_by_side: Dict[str, set],
     bp_lookup: Callable[[str, str, str], float],
@@ -3360,6 +3370,9 @@ class Passivbot:
             raise
         except Exception as exc:
             error_ts = utc_ms()
+            error_type = bounded_exception_type(exc)
+            error_status = bounded_exception_status(exc) or "-"
+            error_code = bounded_exception_code(exc) or "-"
             self._monitor_record_error(
                 "error.bot",
                 exc,
@@ -3371,17 +3384,20 @@ class Passivbot:
             self._monitor_emit_stop(
                 "startup_error",
                 ts=error_ts,
-                payload={"stage": boot_stage, "error_type": type(exc).__name__},
+                payload={"stage": boot_stage, "error_type": error_type},
             )
             if self._startup_exception_is_terminal(exc, boot_stage):
                 logging.critical(
-                    "[boot] terminal startup validation failure | stage=%s error_type=%s error=%s",
+                    "[boot] terminal startup validation failure | "
+                    "stage=%s error_type=%s status=%s code=%s",
                     boot_stage,
-                    type(exc).__name__,
-                    exc,
+                    error_type,
+                    error_status,
+                    error_code,
                 )
                 raise FatalBotException(
-                    f"terminal startup validation failure during {boot_stage}: {exc}"
+                    f"terminal startup validation failure during {boot_stage}; "
+                    f"error_type={error_type} status={error_status} code={error_code}"
                 ) from exc
             raise
 
@@ -5753,64 +5769,18 @@ class Passivbot:
 
     def _execution_loop_error_fields(self, exc: BaseException) -> dict[str, str]:
         """Return bounded classifications for execution-loop incident projections."""
-        fields: dict[str, str] = {
-            "error_type": self._execution_loop_error_field(
-                type(exc).__name__, re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,79}")
-            ),
-            "status": "-",
-            "code": "-",
+        return {
+            "error_type": bounded_exception_type(exc),
+            "status": bounded_exception_status(exc) or "-",
+            "code": bounded_exception_code(exc) or "-",
             "endpoint": self._execution_loop_error_endpoint(exc),
         }
-        for attr in ("http_status", "status", "status_code"):
-            try:
-                value = getattr(exc, attr, None)
-            except Exception:
-                continue
-            status = self._execution_loop_error_field(
-                value, re.compile(r"[0-9]{1,3}")
-            )
-            if status != "-":
-                fields["status"] = status
-                break
-        for attr in ("code", "exact", "error_code"):
-            try:
-                value = getattr(exc, attr, None)
-            except Exception:
-                continue
-            code = self._execution_loop_error_field(
-                value, re.compile(r"-?[A-Za-z0-9][A-Za-z0-9_-]{0,47}")
-            )
-            if code != "-":
-                fields["code"] = code
-                break
-        try:
-            info = getattr(exc, "info", None)
-        except Exception:
-            info = None
-        if isinstance(info, dict):
-            for key in ("code", "retCode", "errorCode"):
-                value = info.get(key)
-                code = self._execution_loop_error_field(
-                    value, re.compile(r"-?[A-Za-z0-9][A-Za-z0-9_-]{0,47}")
-                )
-                if code != "-":
-                    fields["code"] = code
-                    break
-            for key in ("status", "statusCode"):
-                value = info.get(key)
-                status = self._execution_loop_error_field(
-                    value, re.compile(r"[0-9]{1,3}")
-                )
-                if status != "-":
-                    fields["status"] = status
-                    break
-        return fields
 
     def _execution_loop_error_endpoint(self, exc: BaseException) -> str:
         """Extract a bounded endpoint classification without retaining the URL."""
         try:
             error = str(exc)
-        except Exception:
+        except BaseException:
             return "unknown"
         match = re.search(r"https?://[^\s\"'<>]+", error)
         if not match:
@@ -6284,7 +6254,7 @@ class Passivbot:
             except (RestartBotException, FatalBotException) as e:
                 self._emit_live_cycle_degraded(
                     cycle_id=cycle_id,
-                    reason_code=type(e).__name__,
+                    reason_code=bounded_exception_type(e),
                     data={"timings_ms": dict(loop_timings_ms)},
                     level="warning",
                 )
@@ -6297,8 +6267,9 @@ class Passivbot:
                         data={"timings_ms": dict(loop_timings_ms)},
                     )
                     logging.debug(
-                        "[shutdown] execution loop stopped during rate-limit handling: %s",
-                        e,
+                        "[shutdown] execution loop stopped during rate-limit handling | "
+                        "error_type=%s",
+                        bounded_exception_type(e),
                     )
                     break
                 self._health_errors += 1
@@ -6316,7 +6287,7 @@ class Passivbot:
                     cycle_id=cycle_id,
                     reason_code="rate_limit",
                     data={
-                        "error_type": type(e).__name__,
+                        "error_type": bounded_exception_type(e),
                         "timings_ms": dict(loop_timings_ms),
                     },
                     level="warning",
@@ -6359,7 +6330,7 @@ class Passivbot:
                     cycle_id=cycle_id,
                     reason_code="fill_history_coverage_unavailable",
                     data={
-                        "error_type": type(e).__name__,
+                        "error_type": bounded_exception_type(e),
                         "timings_ms": dict(loop_timings_ms),
                     },
                     level="warning",
@@ -6368,11 +6339,12 @@ class Passivbot:
                     1.0, stage="fill_history_coverage_retry"
                 )
             except Exception as e:
+                error_type = bounded_exception_type(e)
                 self._emit_live_cycle_degraded(
                     cycle_id=cycle_id,
-                    reason_code=type(e).__name__,
+                    reason_code=error_type,
                     data={
-                        "error_type": type(e).__name__,
+                        "error_type": error_type,
                         "timings_ms": dict(loop_timings_ms),
                     },
                     level="error",
@@ -20026,16 +19998,14 @@ async def main():
             await bot.start_bot()
         except FatalBotException as e:
             fatal_error = e
-            logging.error(f"passivbot fatal error {e}")
+            _log_process_failure("passivbot fatal error", e)
         except asyncio.CancelledError as e:
             if bot.stop_signal_received or getattr(bot, "_shutdown_in_progress", False):
                 logging.info("passivbot cancellation received during shutdown")
             else:
-                logging.error(f"passivbot cancelled unexpectedly {e}")
-                traceback.print_exc()
+                _log_process_failure("passivbot cancelled unexpectedly", e)
         except Exception as e:
-            logging.error(f"passivbot error {e}")
-            traceback.print_exc()
+            _log_process_failure("passivbot error", e)
         finally:
             try:
                 if bot.stop_signal_received or getattr(

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -68,6 +68,7 @@ from live.diagnostic_safety import (
     bounded_exception_status,
     bounded_exception_type,
     exception_text_contains,
+    exception_type_name_contains,
 )
 from live.freshness import ACCOUNT_SURFACES, LIVE_STATE_SURFACES, FreshnessLedger
 from live.events import DiagnosticEvent, emit_diagnostic_event, run_diagnostic_step
@@ -2360,7 +2361,7 @@ class Passivbot:
                     return True
             except BaseException:
                 pass
-            if "invalidnonce" in bounded_exception_type(current).lower():
+            if exception_type_name_contains(current, ("invalidnonce",)):
                 return True
             if exception_text_contains(current, needles):
                 return True

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -63,6 +63,7 @@ from live.data_packets import (
     DataPacketMetadata,
     build_data_packet_metadata,
 )
+from live.diagnostic_safety import bounded_exception_type
 from live.freshness import ACCOUNT_SURFACES, LIVE_STATE_SURFACES, FreshnessLedger
 from live.events import DiagnosticEvent, emit_diagnostic_event, run_diagnostic_step
 from live.event_bus import (
@@ -11641,7 +11642,8 @@ class Passivbot:
         except Exception as e:
             if self._shutdown_requested():
                 logging.debug(
-                    "[shutdown] fill refresh stopped during in-flight request: %s", e
+                    "[shutdown] fill refresh stopped during in-flight request | error_type=%s",
+                    bounded_exception_type(e),
                 )
                 return False
             if await self._maybe_recover_exchange_time_sync(e, source="update_pnls"):
@@ -11666,11 +11668,8 @@ class Passivbot:
                 payload={"source": "update_pnls"},
             )
             logging.error(
-                "[fills] Failed to update FillEventsManager | error_type=%s status=%s code=%s error=%s",
-                type(e).__name__,
-                getattr(e, "status", "-"),
-                getattr(e, "code", "-"),
-                e,
+                "[fills] Failed to update FillEventsManager | error_type=%s",
+                bounded_exception_type(e),
             )
             self._emit_fills_refresh_summary_event(
                 source=source,
@@ -11685,8 +11684,6 @@ class Passivbot:
                 error=e,
                 level="error",
             )
-            if self.logging_level >= 2:
-                traceback.print_exc()
             raise
 
     # -------------------------------------------------------------------------

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -63,7 +63,11 @@ from live.data_packets import (
     DataPacketMetadata,
     build_data_packet_metadata,
 )
-from live.diagnostic_safety import bounded_exception_type
+from live.diagnostic_safety import (
+    bounded_exception_code,
+    bounded_exception_status,
+    bounded_exception_type,
+)
 from live.freshness import ACCOUNT_SURFACES, LIVE_STATE_SURFACES, FreshnessLedger
 from live.events import DiagnosticEvent, emit_diagnostic_event, run_diagnostic_step
 from live.event_bus import (
@@ -11668,8 +11672,10 @@ class Passivbot:
                 payload={"source": "update_pnls"},
             )
             logging.error(
-                "[fills] Failed to update FillEventsManager | error_type=%s",
+                "[fills] Failed to update FillEventsManager | error_type=%s status=%s code=%s",
                 bounded_exception_type(e),
+                bounded_exception_status(e) or "-",
+                bounded_exception_code(e) or "-",
             )
             self._emit_fills_refresh_summary_event(
                 source=source,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -5890,8 +5890,8 @@ class Passivbot:
         """Record a runtime loop failure and apply the existing restart budget policy."""
         if self._shutdown_requested():
             logging.debug(
-                "[shutdown] execution loop stopped during in-flight refresh: %s",
-                exc,
+                "[shutdown] execution loop stopped during in-flight refresh | error_type=%s",
+                bounded_exception_type(exc),
             )
             return False
         if allow_time_sync_recovery and await self._maybe_recover_exchange_time_sync(
@@ -6344,15 +6344,16 @@ class Passivbot:
                         data={"timings_ms": dict(loop_timings_ms)},
                     )
                     logging.debug(
-                        "[shutdown] execution loop stopped during fill-history coverage retry: %s",
-                        e,
+                        "[shutdown] execution loop stopped during fill-history coverage retry | "
+                        "error_type=%s",
+                        bounded_exception_type(e),
                     )
                     break
                 self._request_authoritative_confirmation({"fills"})
                 logging.warning(
                     "[fills] live planning deferred pending fill-history coverage | "
-                    "action=refresh_lookback_before_retry error=%s",
-                    e,
+                    "action=refresh_lookback_before_retry error_type=%s",
+                    bounded_exception_type(e),
                 )
                 self._emit_live_cycle_degraded(
                     cycle_id=cycle_id,
@@ -11244,7 +11245,10 @@ class Passivbot:
                 if callable(get_history_scope):
                     history_scope = get_history_scope()
             except Exception as exc:
-                logging.debug("[event] failed to read fill-cache history scope: %s", exc)
+                logging.debug(
+                    "[event] failed to read fill-cache history scope | error_type=%s",
+                    bounded_exception_type(exc),
+                )
             self._emit_fills_refresh_summary_event(
                 source="startup",
                 refresh_mode="cache_load",
@@ -11259,8 +11263,12 @@ class Passivbot:
             self._pnls_initialized = True
 
         except Exception as e:
-            logging.error("Failed to initialize FillEventsManager: %s", e)
-            traceback.print_exc()
+            logging.error(
+                "Failed to initialize FillEventsManager | error_type=%s status=%s code=%s",
+                bounded_exception_type(e),
+                bounded_exception_status(e) or "-",
+                bounded_exception_code(e) or "-",
+            )
             raise
 
     async def update_pnls(
@@ -12874,9 +12882,9 @@ class Passivbot:
                 )
             except Exception as exc:
                 logging.debug(
-                    "[event] failed to emit HSL history progress stage=%s: %s",
+                    "[event] failed to emit HSL history progress stage=%s error_type=%s",
                     stage,
-                    exc,
+                    bounded_exception_type(exc),
                 )
 
         _safe_float = Passivbot._hsl_fill_safe_float

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -3199,11 +3199,10 @@ async def _equity_hard_stop_flatten_fill_timestamp_with_refresh(
         except Exception as exc:
             logging.warning(
                 "[risk] HSL[%s%s] flatten-fill refresh failed; keeping scope protective | "
-                "error=%s: %s",
+                "error_type=%s",
                 pside,
                 f":{symbol}" if symbol is not None else "",
-                type(exc).__name__,
-                exc,
+                _bounded_hsl_exception_type(exc),
             )
         if refresh_ready:
             stop_ts_ms = self._equity_hard_stop_latest_flatten_fill_timestamp_optional_ms(

--- a/tests/test_diagnostic_safety.py
+++ b/tests/test_diagnostic_safety.py
@@ -43,3 +43,29 @@ def test_bounded_exception_status_and_code_contain_hostile_metadata():
 
     assert bounded_exception_status(error) is None
     assert bounded_exception_code(error) is None
+
+
+def test_bounded_exception_status_and_code_contain_hostile_info_keys():
+    secret = "api_key=info-key-secret"
+
+    class HostileKey:
+        def __hash__(self):
+            return hash("status")
+
+        def __eq__(self, other):
+            raise KeyboardInterrupt(secret)
+
+    error = RuntimeError(secret)
+    error.info = {HostileKey(): "429"}
+
+    assert bounded_exception_status(error) is None
+    assert bounded_exception_code(error) is None
+
+
+def test_bounded_exception_status_and_code_reject_oversized_integers():
+    error = RuntimeError("api_key=integer-secret")
+    error.status = 10**10_000
+    error.code = -(10**10_000)
+
+    assert bounded_exception_status(error) is None
+    assert bounded_exception_code(error) is None

--- a/tests/test_diagnostic_safety.py
+++ b/tests/test_diagnostic_safety.py
@@ -1,26 +1,42 @@
 from live.diagnostic_safety import (
     bounded_exception_code,
     bounded_exception_status,
+    bounded_exception_type,
 )
 
 
 def test_bounded_exception_status_and_code_keep_safe_direct_values():
     error = RuntimeError("api_key=hidden")
     error.status = "503"
-    error.code = "TEMP_UNAVAILABLE"
+    error.code = "10006"
 
     assert bounded_exception_status(error) == "503"
-    assert bounded_exception_code(error) == "TEMP_UNAVAILABLE"
+    assert bounded_exception_code(error) == "10006"
 
 
 def test_bounded_exception_status_and_code_use_safe_info_fallbacks():
     error = RuntimeError("api_key=hidden")
     error.status = "500?api_key=hidden"
-    error.code = "ApiKeyProdSecret"
-    error.info = {"status": "429", "retCode": "RATE_LIMIT"}
+    error.code = "sk_live_7E4v93kR2mN6pQ8t"
+    error.info = {"status": "429", "retCode": "-1003"}
 
     assert bounded_exception_status(error) == "429"
-    assert bounded_exception_code(error) == "RATE_LIMIT"
+    assert bounded_exception_code(error) == "-1003"
+
+
+def test_bounded_exception_code_rejects_identifier_shaped_values():
+    error = RuntimeError("api_key=hidden")
+    error.code = "sk_live_7E4v93kR2mN6pQ8t"
+    error.info = {"retCode": "RATE_LIMIT"}
+
+    assert bounded_exception_code(error) is None
+
+
+def test_bounded_exception_type_uses_trusted_mro_classification():
+    opaque_error = type("sk_live_7E4v93kR2mN6pQ8t", (RuntimeError,), {})
+
+    assert bounded_exception_type(opaque_error("api_key=hidden")) == "RuntimeError"
+    assert bounded_exception_type(RuntimeError("api_key=hidden")) == "RuntimeError"
 
 
 def test_bounded_exception_status_and_code_contain_hostile_metadata():

--- a/tests/test_diagnostic_safety.py
+++ b/tests/test_diagnostic_safety.py
@@ -60,6 +60,12 @@ def test_exception_text_contains_catches_hostile_string_conversion():
     assert exception_text_contains(HostileError(), ("recvwindow",)) is False
 
 
+def test_exception_text_contains_scans_late_markers_across_bounded_chunks():
+    error = RuntimeError(("x" * 5000) + " TOO_MANY_REQUESTS")
+
+    assert exception_text_contains(error, ("too_many_requests",)) is True
+
+
 def test_bounded_exception_status_and_code_contain_hostile_metadata():
     secret = "api_key=attribute-secret"
 

--- a/tests/test_diagnostic_safety.py
+++ b/tests/test_diagnostic_safety.py
@@ -1,0 +1,45 @@
+from live.diagnostic_safety import (
+    bounded_exception_code,
+    bounded_exception_status,
+)
+
+
+def test_bounded_exception_status_and_code_keep_safe_direct_values():
+    error = RuntimeError("api_key=hidden")
+    error.status = "503"
+    error.code = "TEMP_UNAVAILABLE"
+
+    assert bounded_exception_status(error) == "503"
+    assert bounded_exception_code(error) == "TEMP_UNAVAILABLE"
+
+
+def test_bounded_exception_status_and_code_use_safe_info_fallbacks():
+    error = RuntimeError("api_key=hidden")
+    error.status = "500?api_key=hidden"
+    error.code = "ApiKeyProdSecret"
+    error.info = {"status": "429", "retCode": "RATE_LIMIT"}
+
+    assert bounded_exception_status(error) == "429"
+    assert bounded_exception_code(error) == "RATE_LIMIT"
+
+
+def test_bounded_exception_status_and_code_contain_hostile_metadata():
+    secret = "api_key=attribute-secret"
+
+    class HostileError(RuntimeError):
+        @property
+        def status(self):
+            raise KeyboardInterrupt(secret)
+
+        @property
+        def code(self):
+            raise SystemExit(secret)
+
+        @property
+        def info(self):
+            raise GeneratorExit(secret)
+
+    error = HostileError(secret)
+
+    assert bounded_exception_status(error) is None
+    assert bounded_exception_code(error) is None

--- a/tests/test_diagnostic_safety.py
+++ b/tests/test_diagnostic_safety.py
@@ -113,6 +113,19 @@ def test_exception_type_name_contains_rejects_metaclass_name_descriptor_forgery(
     )
 
 
+def test_exception_type_name_contains_normalizes_stored_string_subclass():
+    class HostileName(str):
+        def lower(self):
+            raise KeyboardInterrupt("api_key=hostile-name-subclass")
+
+    class WrappedFailure(RuntimeError):
+        pass
+
+    WrappedFailure.__name__ = HostileName("WrappedInvalidNonceFailure")
+
+    assert exception_type_name_contains(WrappedFailure(), ("invalidnonce",))
+
+
 def test_bounded_exception_status_and_code_contain_hostile_metadata():
     secret = "api_key=attribute-secret"
 

--- a/tests/test_diagnostic_safety.py
+++ b/tests/test_diagnostic_safety.py
@@ -66,6 +66,18 @@ def test_exception_text_contains_scans_late_markers_across_bounded_chunks():
     assert exception_text_contains(error, ("too_many_requests",)) is True
 
 
+def test_exception_text_contains_preserves_case_sensitive_matching():
+    upper = RuntimeError(("x" * 5000) + " TOO_MANY_REQUESTS")
+    lower = RuntimeError(("x" * 5000) + " too_many_requests")
+
+    assert exception_text_contains(
+        upper, ("TOO_MANY_REQUESTS",), case_sensitive=True
+    )
+    assert not exception_text_contains(
+        lower, ("TOO_MANY_REQUESTS",), case_sensitive=True
+    )
+
+
 def test_bounded_exception_status_and_code_contain_hostile_metadata():
     secret = "api_key=attribute-secret"
 

--- a/tests/test_diagnostic_safety.py
+++ b/tests/test_diagnostic_safety.py
@@ -2,6 +2,7 @@ from live.diagnostic_safety import (
     bounded_exception_code,
     bounded_exception_status,
     bounded_exception_type,
+    exception_text_contains,
 )
 
 
@@ -37,6 +38,26 @@ def test_bounded_exception_type_uses_trusted_mro_classification():
 
     assert bounded_exception_type(opaque_error("api_key=hidden")) == "RuntimeError"
     assert bounded_exception_type(RuntimeError("api_key=hidden")) == "RuntimeError"
+
+
+def test_bounded_exception_type_rejects_forged_trusted_module():
+    forged_error = type(
+        "sk_live_7E4v93kR2mN6pQ8t",
+        (RuntimeError,),
+        {"__module__": "ccxt"},
+    )
+
+    assert bounded_exception_type(forged_error("api_key=hidden")) == "RuntimeError"
+
+
+def test_exception_text_contains_catches_hostile_string_conversion():
+    secret = "api_key=hostile-string-secret"
+
+    class HostileError(RuntimeError):
+        def __str__(self):
+            raise KeyboardInterrupt(secret)
+
+    assert exception_text_contains(HostileError(), ("recvwindow",)) is False
 
 
 def test_bounded_exception_status_and_code_contain_hostile_metadata():

--- a/tests/test_diagnostic_safety.py
+++ b/tests/test_diagnostic_safety.py
@@ -69,3 +69,9 @@ def test_bounded_exception_status_and_code_reject_oversized_integers():
 
     assert bounded_exception_status(error) is None
     assert bounded_exception_code(error) is None
+
+    error.status = "5" * 10_000
+    error.code = "A" * 10_000
+
+    assert bounded_exception_status(error) is None
+    assert bounded_exception_code(error) is None

--- a/tests/test_diagnostic_safety.py
+++ b/tests/test_diagnostic_safety.py
@@ -99,6 +99,20 @@ def test_exception_type_name_contains_is_hostile_metadata_safe_and_non_projectin
     )
 
 
+def test_exception_type_name_contains_rejects_metaclass_name_descriptor_forgery():
+    class ForgedNameMeta(type):
+        @property
+        def __name__(cls):
+            return "InvalidNonceForged"
+
+    class UnrelatedFailure(RuntimeError, metaclass=ForgedNameMeta):
+        pass
+
+    assert not exception_type_name_contains(
+        UnrelatedFailure(), ("invalidnonce",)
+    )
+
+
 def test_bounded_exception_status_and_code_contain_hostile_metadata():
     secret = "api_key=attribute-secret"
 

--- a/tests/test_diagnostic_safety.py
+++ b/tests/test_diagnostic_safety.py
@@ -3,6 +3,7 @@ from live.diagnostic_safety import (
     bounded_exception_status,
     bounded_exception_type,
     exception_text_contains,
+    exception_type_name_contains,
 )
 
 
@@ -75,6 +76,26 @@ def test_exception_text_contains_preserves_case_sensitive_matching():
     )
     assert not exception_text_contains(
         lower, ("TOO_MANY_REQUESTS",), case_sensitive=True
+    )
+
+
+def test_exception_type_name_contains_is_hostile_metadata_safe_and_non_projecting():
+    secret = "api_key=hostile-type-metadata"
+
+    class HostileMeta(type):
+        def __getattribute__(cls, name):
+            if name == "__name__":
+                raise KeyboardInterrupt(secret)
+            return super().__getattribute__(name)
+
+    class WrappedInvalidNonceFailure(RuntimeError, metaclass=HostileMeta):
+        pass
+
+    assert exception_type_name_contains(
+        WrappedInvalidNonceFailure(), ("invalidnonce",)
+    )
+    assert not exception_type_name_contains(
+        WrappedInvalidNonceFailure(), ("unrelated",)
     )
 
 

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -696,6 +696,34 @@ async def test_binance_fetcher_trade_history_errors_are_not_income_only_events(m
 
 
 @pytest.mark.asyncio
+async def test_binance_fetcher_hostile_error_text_preserves_original_failure():
+    secret = "api_key=binance-hostile-string"
+
+    class HostileError(RuntimeError):
+        def __str__(self):
+            raise KeyboardInterrupt(secret)
+
+    original = HostileError()
+
+    class FailingTradeAPI:
+        async def fetch_my_trades(self, *_args, **_kwargs):
+            raise original
+
+    fetcher = BinanceFetcher(
+        api=FailingTradeAPI(),
+        symbol_resolver=lambda sym: sym or "",
+        positions_provider=lambda: [],
+        open_orders_provider=lambda: [],
+    )
+
+    with pytest.raises(RuntimeError) as captured:
+        await fetcher._fetch_symbol_trades("BTC/USDT:USDT", None, None)
+
+    assert captured.value.__cause__ is original
+    assert secret not in str(captured.value)
+
+
+@pytest.mark.asyncio
 async def test_binance_fetcher_time_bounds_filtering(monkeypatch):
     """Test that events outside time bounds are filtered."""
     income_events = [
@@ -1909,6 +1937,27 @@ async def test_doctor_reports_unsupported_legacy_cache_without_raising(tmp_path:
     assert report["anomaly_examples"] == ["legacy-bitget-entry"]
     assert report["anomaly_events_after"] == 0
     assert FillEventCache(cache_dir).load() == []
+
+
+def test_doctor_cache_read_failure_omits_exception_value(
+    tmp_path: Path, monkeypatch, caplog
+):
+    cache_dir = tmp_path / "doctor_read_failure"
+    cache_dir.mkdir()
+    (cache_dir / "2023-11-14.json").write_text("[]", encoding="utf-8")
+    secret = "api_key=doctor-secret"
+
+    def fail_load(_fh):
+        raise RuntimeError(secret)
+
+    monkeypatch.setattr(fem.json, "load", fail_load)
+
+    with caplog.at_level(logging.WARNING, logger=fem.logger.name):
+        result = FillEventCache(cache_dir).quarantine_legacy_record_files()
+
+    assert result == {"backup_path": None, "moved_files": []}
+    assert "error_type=RuntimeError" in caplog.text
+    assert secret not in caplog.text
 
 
 @pytest.mark.asyncio
@@ -6683,6 +6732,28 @@ class _FakeGateioAPI:
         if not self._orders_batches:
             return []
         return self._orders_batches.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_gateio_fetcher_hostile_error_text_preserves_original_failure():
+    secret = "api_key=gateio-hostile-string"
+
+    class HostileError(RuntimeError):
+        def __str__(self):
+            raise KeyboardInterrupt(secret)
+
+    original = HostileError()
+
+    class FailingGateioAPI:
+        async def private_futures_get_settle_my_trades_timerange(self, _params):
+            raise original
+
+    fetcher = GateioFetcher(FailingGateioAPI(), trade_limit=100)
+
+    with pytest.raises(HostileError) as captured:
+        await fetcher._fetch_trades(1_700_000_000_000, 1_700_000_060_000)
+
+    assert captured.value is original
 
 
 def _make_gateio_trade(

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -4691,12 +4691,15 @@ async def test_manager_refresh_logs_slow_successful_fetcher_request_timing_at_de
 
 
 @pytest.mark.asyncio
-async def test_manager_refresh_logs_fetcher_error_detail(tmp_path: Path, caplog):
+async def test_manager_refresh_logs_bounded_fetcher_error_type_without_secret(
+    tmp_path: Path, caplog
+):
     cache_dir = tmp_path / "fills_request_error_timing"
+    secret = "api_key=super-secret-value"
 
     class _Api:
         async def fetch_a(self):
-            raise RuntimeError("remote timeout detail")
+            raise RuntimeError(f"remote timeout detail {secret}")
 
     class _ApiFetcher(BaseFetcher):
         def __init__(self):
@@ -4714,7 +4717,7 @@ async def test_manager_refresh_logs_fetcher_error_detail(tmp_path: Path, caplog)
     )
 
     with caplog.at_level(logging.INFO, logger=fem.logger.name):
-        with pytest.raises(RuntimeError, match="remote timeout detail"):
+        with pytest.raises(RuntimeError, match=secret):
             await manager.refresh(start_ms=123, end_ms=456)
 
     timing_records = [
@@ -4726,7 +4729,35 @@ async def test_manager_refresh_logs_fetcher_error_detail(tmp_path: Path, caplog)
     assert timing_records[0].levelno == logging.INFO
     assert "fetch_a:n=1" in timing_records[0].message
     assert "err_type=RuntimeError" in timing_records[0].message
-    assert "err_msg=remote timeout detail" in timing_records[0].message
+    assert "err_msg=" not in timing_records[0].message
+    assert secret not in timing_records[0].message
+
+
+def test_fill_fetch_request_timing_error_type_rejects_sensitive_and_hostile_metadata():
+    class _HostileExceptionMeta(type):
+        @property
+        def __name__(cls):
+            raise RuntimeError("api_key=super-secret-value")
+
+    class _HostileError(RuntimeError, metaclass=_HostileExceptionMeta):
+        pass
+
+    long_safe_name = "SafeError" + "x" * 100
+    stats = fem.FillFetchRequestStats()
+    stats.record("safe", 0, ok=False)
+    stats.record_error_detail("safe", type(long_safe_name, (RuntimeError,), {})())
+    stats.record("sensitive", 0, ok=False)
+    stats.record_error_detail("sensitive", type("ApiKeyProdSecret", (RuntimeError,), {})())
+    stats.record("hostile", 0, ok=False)
+    stats.record_error_detail("hostile", _HostileError("api_key=super-secret-value"))
+
+    rendered = stats.format_endpoints()
+
+    assert f"err_type={long_safe_name[:80]}" in rendered
+    assert long_safe_name not in rendered
+    assert rendered.count("err_type=Error") == 2
+    assert "api_key=super-secret-value" not in rendered
+    assert "ApiKeyProdSecret" not in rendered
 
 
 def test_fill_event_cache_disk_full_raises_clear_error(tmp_path: Path, monkeypatch, sample_events):

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -6796,6 +6796,33 @@ async def test_gateio_fetcher_classifies_late_rate_limit_marker(monkeypatch):
     sleep.assert_awaited_once_with(2)
 
 
+@pytest.mark.asyncio
+async def test_gateio_fetcher_does_not_broaden_rate_limit_marker_case(monkeypatch):
+    class LowercaseMarkerAPI:
+        def __init__(self):
+            self.calls = 0
+
+        async def private_futures_get_settle_my_trades_timerange(self, _params):
+            self.calls += 1
+            raise RuntimeError("too_many_requests")
+
+    api = LowercaseMarkerAPI()
+    sleep = AsyncMock()
+    monkeypatch.setattr(fem.asyncio, "sleep", sleep)
+    fetcher = GateioFetcher(api, trade_limit=100)
+
+    with pytest.raises(RuntimeError, match="too_many_requests"):
+        await fetcher._fetch_trades(1_700_000_000_000, 1_700_000_060_000)
+
+    assert api.calls == 1
+    sleep.assert_not_awaited()
+
+
+def test_disk_full_text_fallback_preserves_marker_case():
+    assert fem._is_disk_full_error(RuntimeError("No space left on device"))
+    assert not fem._is_disk_full_error(RuntimeError("no space left on device"))
+
+
 def _make_gateio_trade(
     trade_id: str,
     order_id: str,

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -1715,6 +1715,34 @@ def test_fill_event_cache_rejects_malformed_current_contract_record(tmp_path: Pa
         FillEventCache(cache_dir).load()
 
 
+def test_fill_event_cache_malformed_record_omits_exception_value(
+    tmp_path: Path, monkeypatch
+):
+    cache_dir = tmp_path / "fills"
+    cache_dir.mkdir()
+    (cache_dir / "metadata.json").write_text(
+        json.dumps({"pnl_contract": fem.PNL_CONTRACT_CURRENT}),
+        encoding="utf-8",
+    )
+    (cache_dir / "2026-02-02.json").write_text(
+        json.dumps([{"pnl_contract": fem.PNL_CONTRACT_CURRENT}]),
+        encoding="utf-8",
+    )
+    secret = "signature=malformed-record-secret"
+
+    def fail_from_dict(_raw):
+        raise RuntimeError(secret)
+
+    monkeypatch.setattr(FillEvent, "from_dict", fail_from_dict)
+
+    with pytest.raises(FillEventCacheContractError) as exc_info:
+        FillEventCache(cache_dir).load()
+
+    assert "malformed" in str(exc_info.value)
+    assert "error_type=RuntimeError" in str(exc_info.value)
+    assert secret not in str(exc_info.value)
+
+
 def test_fill_event_cache_rejects_unreadable_current_contract_day(tmp_path: Path):
     cache_dir = tmp_path / "fills"
     cache_dir.mkdir()
@@ -1747,6 +1775,62 @@ def test_fill_event_cache_rejects_unreadable_current_contract_day(tmp_path: Path
 
     with pytest.raises(FillEventCacheContractError, match="unreadable"):
         FillEventCache(cache_dir).load()
+
+
+def test_fill_event_cache_read_failure_omits_exception_value(
+    tmp_path: Path, monkeypatch, caplog
+):
+    cache_dir = tmp_path / "fills"
+    cache_dir.mkdir()
+    (cache_dir / "metadata.json").write_text(
+        json.dumps({"pnl_contract": fem.PNL_CONTRACT_CURRENT}),
+        encoding="utf-8",
+    )
+    (cache_dir / "2026-02-02.json").write_text("[]", encoding="utf-8")
+    secret = "api_key=cache-read-secret"
+
+    class _CacheReadError(RuntimeError):
+        pass
+
+    original_load = fem.json.load
+
+    def fail_day_file(fh):
+        if Path(fh.name).name == "metadata.json":
+            return original_load(fh)
+        raise _CacheReadError(secret)
+
+    monkeypatch.setattr(fem.json, "load", fail_day_file)
+
+    with caplog.at_level(logging.WARNING, logger=fem.logger.name):
+        with pytest.raises(FillEventCacheContractError) as exc_info:
+            FillEventCache(cache_dir).load()
+
+    assert "error_type=RuntimeError" in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, _CacheReadError)
+    assert "error_type=RuntimeError" in caplog.text
+    assert secret not in str(exc_info.value)
+    assert secret not in caplog.text
+
+
+def test_fill_event_cache_metadata_failure_omits_exception_value(
+    tmp_path: Path, monkeypatch, caplog
+):
+    cache_dir = tmp_path / "fills"
+    cache_dir.mkdir()
+    (cache_dir / "metadata.json").write_text("{}", encoding="utf-8")
+    secret = "token=cache-metadata-secret"
+
+    def fail_metadata(_fh):
+        raise RuntimeError(secret)
+
+    monkeypatch.setattr(fem.json, "load", fail_metadata)
+
+    with caplog.at_level(logging.WARNING, logger=fem.logger.name):
+        metadata = FillEventCache(cache_dir).load_metadata()
+
+    assert metadata["history_scope"] == "unknown"
+    assert "error_type=RuntimeError" in caplog.text
+    assert secret not in caplog.text
 
 
 @pytest.mark.asyncio
@@ -4764,7 +4848,7 @@ async def test_manager_refresh_logs_bounded_fetcher_error_type_without_secret(
     assert len(timing_records) == 1
     assert timing_records[0].levelno == logging.INFO
     assert "fetch_a:n=1" in timing_records[0].message
-    assert "err_type=Error" in timing_records[0].message
+    assert "err_type=RuntimeError" in timing_records[0].message
     assert "err_msg=" not in timing_records[0].message
     assert secret_error_type.__name__ not in timing_records[0].message
     assert secret not in caplog.text
@@ -4790,9 +4874,10 @@ def test_fill_fetch_request_timing_error_type_rejects_sensitive_and_hostile_meta
 
     rendered = stats.format_endpoints()
 
-    assert f"err_type={long_safe_name[:80]}" in rendered
+    assert "err_type=RuntimeError" in rendered
     assert long_safe_name not in rendered
-    assert rendered.count("err_type=Error") == 2
+    assert rendered.count("err_type=RuntimeError") == 2
+    assert rendered.count("err_type=Error") == 1
     assert "api_key=super-secret-value" not in rendered
     assert "ApiKeyProdSecret" not in rendered
 

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -417,6 +417,37 @@ async def test_binance_fetch_symbol_trades_uses_now_bound_and_one_percent_margin
 
 
 @pytest.mark.asyncio
+async def test_binance_trade_fetch_redacts_secret_error_but_preserves_cause(caplog):
+    secret = "authorization=binance-fill-fetch-secret"
+
+    class _FailingAPI:
+        async def fetch_my_trades(self, *_args, **_kwargs):
+            raise RuntimeError(secret)
+
+    fetcher = BinanceFetcher(
+        api=_FailingAPI(),
+        symbol_resolver=lambda symbol: symbol or "",
+        now_func=lambda: 1_700_000_000_000,
+    )
+
+    with caplog.at_level(logging.ERROR, logger=fem.logger.name):
+        with pytest.raises(RuntimeError) as captured:
+            await fetcher._fetch_symbol_trades(
+                "BTC/USDT:USDT",
+                since_ms=1_699_999_000_000,
+                until_ms=1_700_000_000_000,
+            )
+
+    assert secret not in str(captured.value)
+    assert "BTC/USDT:USDT" in str(captured.value)
+    assert "error_type=RuntimeError" in str(captured.value)
+    assert isinstance(captured.value.__cause__, RuntimeError)
+    assert str(captured.value.__cause__) == secret
+    assert "error_type=RuntimeError" in caplog.text
+    assert secret not in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_binance_fetcher_enriches_missing_client_ids(monkeypatch):
     income_events = [
         {
@@ -652,12 +683,16 @@ async def test_binance_fetcher_trade_history_errors_are_not_income_only_events(m
         types.MethodType(fake_fetch_income, fetcher),
     )
 
-    with pytest.raises(RuntimeError, match="simulated trade-history outage"):
+    with pytest.raises(RuntimeError) as captured:
         await fetcher.fetch(
             since_ms=ts - 1,
             until_ms=ts + 1,
             detail_cache={},
         )
+
+    assert "simulated trade-history outage" not in str(captured.value)
+    assert isinstance(captured.value.__cause__, RuntimeError)
+    assert str(captured.value.__cause__) == "simulated trade-history outage"
 
 
 @pytest.mark.asyncio
@@ -4695,11 +4730,12 @@ async def test_manager_refresh_logs_bounded_fetcher_error_type_without_secret(
     tmp_path: Path, caplog
 ):
     cache_dir = tmp_path / "fills_request_error_timing"
-    secret = "api_key=super-secret-value"
+    secret = "api_key=fill-fetch-secret"
+    secret_error_type = type("ApiKeyFetchSecretError", (RuntimeError,), {})
 
     class _Api:
         async def fetch_a(self):
-            raise RuntimeError(f"remote timeout detail {secret}")
+            raise secret_error_type(secret)
 
     class _ApiFetcher(BaseFetcher):
         def __init__(self):
@@ -4728,9 +4764,10 @@ async def test_manager_refresh_logs_bounded_fetcher_error_type_without_secret(
     assert len(timing_records) == 1
     assert timing_records[0].levelno == logging.INFO
     assert "fetch_a:n=1" in timing_records[0].message
-    assert "err_type=RuntimeError" in timing_records[0].message
+    assert "err_type=Error" in timing_records[0].message
     assert "err_msg=" not in timing_records[0].message
-    assert secret not in timing_records[0].message
+    assert secret_error_type.__name__ not in timing_records[0].message
+    assert secret not in caplog.text
 
 
 def test_fill_fetch_request_timing_error_type_rejects_sensitive_and_hostile_metadata():

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -7,6 +7,7 @@ import types
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+from unittest.mock import AsyncMock
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -721,6 +722,23 @@ async def test_binance_fetcher_hostile_error_text_preserves_original_failure():
 
     assert captured.value.__cause__ is original
     assert secret not in str(captured.value)
+
+
+@pytest.mark.asyncio
+async def test_binance_fetcher_classifies_late_unsupported_symbol_marker():
+    class UnsupportedTradeAPI:
+        async def fetch_my_trades(self, *_args, **_kwargs):
+            raise RuntimeError(("x" * 5000) + " does not have market symbol")
+
+    fetcher = BinanceFetcher(
+        api=UnsupportedTradeAPI(),
+        symbol_resolver=lambda sym: sym or "",
+        positions_provider=lambda: [],
+        open_orders_provider=lambda: [],
+    )
+
+    assert await fetcher._fetch_symbol_trades("BTC/USDT:USDT", None, None) == []
+    assert fetcher._unsupported_symbols == {"BTC/USDT:USDT"}
 
 
 @pytest.mark.asyncio
@@ -6754,6 +6772,28 @@ async def test_gateio_fetcher_hostile_error_text_preserves_original_failure():
         await fetcher._fetch_trades(1_700_000_000_000, 1_700_000_060_000)
 
     assert captured.value is original
+
+
+@pytest.mark.asyncio
+async def test_gateio_fetcher_classifies_late_rate_limit_marker(monkeypatch):
+    class LateRateLimitAPI:
+        def __init__(self):
+            self.calls = 0
+
+        async def private_futures_get_settle_my_trades_timerange(self, _params):
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError(("x" * 5000) + " TOO_MANY_REQUESTS")
+            return []
+
+    api = LateRateLimitAPI()
+    sleep = AsyncMock()
+    monkeypatch.setattr(fem.asyncio, "sleep", sleep)
+    fetcher = GateioFetcher(api, trade_limit=100)
+
+    assert await fetcher._fetch_trades(1_700_000_000_000, 1_700_000_060_000) == []
+    assert api.calls == 2
+    sleep.assert_awaited_once_with(2)
 
 
 def _make_gateio_trade(

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -1490,6 +1490,40 @@ async def test_flatten_confirmation_refreshes_fills_and_rejects_pre_episode_anch
     assert state["last_missing_flatten_fill_refresh_ms"] == 0
 
 
+@pytest.mark.asyncio
+async def test_flatten_confirmation_refresh_failure_keeps_scope_protective_without_secret(
+    caplog,
+):
+    bot = make_coin_bot()
+    symbol = "A"
+    state = bot._hsl_coin_state("long", symbol)
+    state["pending_red_since_ms"] = 120_000
+    bot._pnls_manager = make_fake_pnls_manager([])
+    secret = "api_key=flatten-refresh-secret"
+
+    async def update_pnls(*, source, since_ms=None):
+        assert source == "hsl_flatten_confirmation"
+        assert since_ms == 120_000
+        raise RuntimeError(secret)
+
+    bot.update_pnls = update_pnls
+
+    with caplog.at_level(logging.WARNING):
+        stop_ts_ms = await bot._equity_hard_stop_flatten_fill_timestamp_with_refresh(
+            "long",
+            180_000,
+            symbol=symbol,
+            since_ms=state["pending_red_since_ms"],
+        )
+
+    assert stop_ts_ms is None
+    assert state["pending_stop_event"] is None
+    assert state["red_flat_confirmations"] == 0
+    assert state["last_missing_flatten_fill_log_ms"] == 180_000
+    assert "error_type=RuntimeError" in caplog.text
+    assert secret not in caplog.text
+
+
 def test_red_paused_forced_modes_block_entries_without_panic():
     bot = make_coin_bot()
     bot.positions = {"A": {"long": {"size": 1.0, "price": 100.0}, "short": {"size": 0.0}}}

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -48,7 +48,7 @@ def test_hsl_event_emitter_failure_logs_type_without_secret(caplog):
         )
 
     assert emitted is None
-    assert "HslEventEmitterFailure" in caplog.text
+    assert "RuntimeError" in caplog.text
     assert secret not in caplog.text
     assert url not in caplog.text
 

--- a/tests/test_monitor_publisher.py
+++ b/tests/test_monitor_publisher.py
@@ -161,8 +161,7 @@ def test_monitor_publisher_record_error_bounds_pathological_exception_type(tmp_p
 
     event = publisher.record_error("error.bot", pathological_error("safe"))
 
-    assert event["payload"]["error_type"] == pathological_error.__name__[:80]
-    assert len(event["payload"]["error_type"]) == 80
+    assert event["payload"]["error_type"] == "Exception"
 
 
 def test_monitor_publisher_record_error_contains_hostile_type_metadata(tmp_path):
@@ -192,7 +191,7 @@ def test_monitor_publisher_record_error_contains_hostile_type_metadata(tmp_path)
 
     sensitive_type = type("ApiKeyProdSecret", (RuntimeError,), {})
     sensitive_event = publisher.record_error("error.exchange", sensitive_type(secret))
-    assert sensitive_event["payload"]["error_type"] == "Error"
+    assert sensitive_event["payload"]["error_type"] == "RuntimeError"
     assert secret not in publisher.current_events_path.read_text()
 
 

--- a/tests/test_monitor_publisher.py
+++ b/tests/test_monitor_publisher.py
@@ -161,8 +161,39 @@ def test_monitor_publisher_record_error_bounds_pathological_exception_type(tmp_p
 
     event = publisher.record_error("error.bot", pathological_error("safe"))
 
-    assert event["payload"]["error_type"] == "unknown"
-    assert len(event["payload"]["error_type"]) <= 80
+    assert event["payload"]["error_type"] == pathological_error.__name__[:80]
+    assert len(event["payload"]["error_type"]) == 80
+
+
+def test_monitor_publisher_record_error_contains_hostile_type_metadata(tmp_path):
+    publisher = _make_publisher(tmp_path)
+    secret = "api_key=monitor-type-secret"
+
+    class _HostileExceptionMeta(type):
+        @property
+        def __name__(cls):
+            raise RuntimeError(secret)
+
+    class _HostileError(RuntimeError, metaclass=_HostileExceptionMeta):
+        pass
+
+    original = _HostileError(secret)
+    try:
+        try:
+            raise original
+        except _HostileError as error:
+            event = publisher.record_error("error.exchange", error)
+            raise
+    except _HostileError as reraised:
+        assert reraised is original
+
+    assert event["payload"]["error_type"] == "Error"
+    assert secret not in publisher.current_events_path.read_text()
+
+    sensitive_type = type("ApiKeyProdSecret", (RuntimeError,), {})
+    sensitive_event = publisher.record_error("error.exchange", sensitive_type(secret))
+    assert sensitive_event["payload"]["error_type"] == "Error"
+    assert secret not in publisher.current_events_path.read_text()
 
 
 def test_monitor_publisher_records_fills_ticks_and_completed_candles(tmp_path):

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -461,6 +461,84 @@ async def test_init_pnls_emits_cache_ready_event(monkeypatch):
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+@pytest.mark.asyncio
+async def test_init_pnls_failure_logs_bounded_classification_and_reraises(monkeypatch, caplog):
+    secret = "api_key=startup-fill-secret"
+
+    class _StartupFillError(RuntimeError):
+        pass
+
+    failure = _StartupFillError(secret)
+    failure.status = "503"
+    failure.code = "TEMP_UNAVAILABLE"
+
+    class _Manager:
+        def __init__(self, **_kwargs):
+            self._events = []
+
+        async def ensure_loaded(self):
+            raise failure
+
+    bot = Passivbot.__new__(Passivbot)
+    bot.runtime_identity = TEST_RUNTIME_IDENTITY
+    bot.exchange = "binance"
+    bot.user = "binance_01"
+    bot.config = {"live": {"pnls_max_lookback_days": "all"}}
+    bot._pnls_initialized = False
+
+    monkeypatch.delenv("PASSIVBOT_FILL_EVENTS_DOCTOR", raising=False)
+    monkeypatch.setattr(passivbot_module, "_extract_symbol_pool", lambda *_args: [])
+    monkeypatch.setattr(passivbot_module, "_build_fetcher_for_bot", lambda *_args: object())
+    monkeypatch.setattr(passivbot_module, "FillEventsManager", _Manager)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(_StartupFillError) as exc_info:
+            await Passivbot.init_pnls(bot)
+
+    assert exc_info.value is failure
+    assert "error_type=_StartupFillError" in caplog.text
+    assert "status=503" in caplog.text
+    assert "code=TEMP_UNAVAILABLE" in caplog.text
+    assert secret not in caplog.text
+    assert "Traceback" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_init_pnls_history_scope_failure_is_bounded_and_cache_remains_ready(
+    monkeypatch, caplog
+):
+    secret = "api_key=history-scope-secret"
+
+    class _Manager:
+        def __init__(self, **_kwargs):
+            self._events = [object()]
+
+        async def ensure_loaded(self):
+            return None
+
+        def get_history_scope(self):
+            raise RuntimeError(secret)
+
+    bot = Passivbot.__new__(Passivbot)
+    bot.runtime_identity = TEST_RUNTIME_IDENTITY
+    bot.exchange = "binance"
+    bot.user = "binance_01"
+    bot.config = {"live": {"pnls_max_lookback_days": "all"}}
+    bot._pnls_initialized = False
+
+    monkeypatch.delenv("PASSIVBOT_FILL_EVENTS_DOCTOR", raising=False)
+    monkeypatch.setattr(passivbot_module, "_extract_symbol_pool", lambda *_args: [])
+    monkeypatch.setattr(passivbot_module, "_build_fetcher_for_bot", lambda *_args: object())
+    monkeypatch.setattr(passivbot_module, "FillEventsManager", _Manager)
+
+    with caplog.at_level(logging.DEBUG):
+        await Passivbot.init_pnls(bot)
+
+    assert bot._pnls_initialized is True
+    assert "error_type=RuntimeError" in caplog.text
+    assert secret not in caplog.text
+
+
 def _counted_staged_account_refresh_bot(
     *,
     balance: float = 100.0,
@@ -612,24 +690,29 @@ async def test_staged_account_refresh_emits_data_packet_diagnostics():
 
 
 @pytest.mark.asyncio
-async def test_data_packet_capture_failure_does_not_block_authoritative_fetch():
+async def test_data_packet_capture_failure_does_not_block_authoritative_fetch(caplog):
     from live import state_refresh
 
+    secret = "api_key=data-packet-recorder-secret"
+
     def failing_recorder(*_args, **_kwargs):
-        raise RuntimeError("metadata recorder failed")
+        raise RuntimeError(secret)
 
     async def fetched_payload():
-        return ("raw-balance", 123.45)
+        return True
 
     bot = SimpleNamespace(_capture_live_data_packet_fetch_metadata=failing_recorder)
     timings_ms = {}
 
-    result = await state_refresh.timed_authoritative_fetch(
-        bot, "balance", fetched_payload(), timings_ms
-    )
+    with caplog.at_level(logging.DEBUG):
+        result = await state_refresh.timed_authoritative_fetch(
+            bot, "fills", fetched_payload(), timings_ms
+        )
 
-    assert result == ("raw-balance", 123.45)
-    assert timings_ms["balance"] >= 0
+    assert result is True
+    assert timings_ms["fills"] >= 0
+    assert "error_type=RuntimeError" in caplog.text
+    assert secret not in caplog.text
 
 
 def test_balance_data_packet_capture_accepts_legacy_raw_normalized_pair():
@@ -10788,7 +10871,9 @@ async def test_run_execution_loop_waits_on_pending_pnl_without_restart(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_run_execution_loop_retries_fill_history_coverage_without_restart(monkeypatch):
+async def test_run_execution_loop_retries_fill_history_coverage_without_restart(
+    monkeypatch, caplog
+):
     bot = Passivbot.__new__(Passivbot)
     cycle = {"n": 0}
     executes = []
@@ -10846,7 +10931,7 @@ async def test_run_execution_loop_retries_fill_history_coverage_without_restart(
         executes.append(("execute", prepare_cycle, cycle["n"]))
         if cycle["n"] == 1:
             raise passivbot_module.FillHistoryCoverageUnavailable(
-                "fill history coverage unknown for risk lookback"
+                "fill history coverage unknown api_key=coverage-secret"
             )
         return {"executed_cycle": cycle["n"]}
 
@@ -10855,7 +10940,8 @@ async def test_run_execution_loop_retries_fill_history_coverage_without_restart(
     bot.prepare_planning_universe = fake_prepare_planning_universe
     bot.execute_to_exchange = fake_execute_to_exchange
 
-    result = await bot.run_execution_loop()
+    with caplog.at_level(logging.WARNING):
+        result = await bot.run_execution_loop()
 
     assert result == {"executed_cycle": 2}
     bot.restart_bot_on_too_many_errors.assert_not_awaited()
@@ -10879,6 +10965,8 @@ async def test_run_execution_loop_retries_fill_history_coverage_without_restart(
         == "FillHistoryCoverageUnavailable"
     )
     assert "error" not in coverage_event["data"]
+    assert "error_type=FillHistoryCoverageUnavailable" in caplog.text
+    assert "coverage-secret" not in caplog.text
 
 
 @pytest.mark.asyncio
@@ -10970,7 +11058,7 @@ async def test_run_execution_loop_suppresses_inflight_shutdown_refresh_error(cap
 
     async def fake_refresh_authoritative_state():
         bot.stop_signal_received = True
-        raise RuntimeError("connector is closed")
+        raise RuntimeError("api_key=shutdown-refresh-secret")
 
     bot.refresh_authoritative_state = fake_refresh_authoritative_state
     bot.execute_to_exchange = AsyncMock()
@@ -10988,6 +11076,8 @@ async def test_run_execution_loop_suppresses_inflight_shutdown_refresh_error(cap
         "execution loop stopped during in-flight refresh" in r.message
         for r in caplog.records
     )
+    assert "error_type=RuntimeError" in caplog.text
+    assert "shutdown-refresh-secret" not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -5798,6 +5798,65 @@ async def test_routine_fill_prefetch_failure_logs_only_exception_type(
 
 
 @pytest.mark.asyncio
+async def test_update_pnls_failure_logs_only_bounded_status_and_code(caplog):
+    bot = Passivbot.__new__(Passivbot)
+    cached_events = [
+        SimpleNamespace(timestamp=1_700_000_000_000, id="fill-1", source_ids=["fill-1"])
+    ]
+
+    class _Manager:
+        history_scope = "all"
+
+        def __init__(self):
+            self.refresh = AsyncMock()
+            error = RuntimeError("api_key=fill-status-secret")
+            error.status = "503"
+            error.code = "TEMP_UNAVAILABLE"
+            error.info = {
+                "status": "500?api_key=hidden",
+                "code": "ApiKeyProdSecret",
+            }
+            self.refresh_latest = AsyncMock(side_effect=error)
+
+        def get_events(self):
+            return list(cached_events)
+
+        def get_history_scope(self):
+            return self.history_scope
+
+        def set_history_scope(self, scope):
+            self.history_scope = scope
+
+    bot.stop_signal_received = False
+    bot.config = {
+        "live": {
+            "fills_recent_overlap_minutes": 10.0,
+            "pnls_max_lookback_days": "all",
+        }
+    }
+    bot._pnls_manager = _Manager()
+    bot.init_pnls = AsyncMock()
+    bot.live_value = lambda key: "all" if key == "pnls_max_lookback_days" else None
+    bot.get_exchange_time = lambda: 1_700_000_060_000
+    bot._log_new_fill_events = lambda new_events: None
+    bot._monitor_record_event = lambda *args, **kwargs: None
+    bot._monitor_record_error = lambda *args, **kwargs: None
+    bot._emit_fills_refresh_summary_event = lambda *args, **kwargs: None
+    bot._maybe_recover_exchange_time_sync = AsyncMock(return_value=False)
+    bot._shutdown_requested = lambda: False
+    bot._health_rate_limits = 0
+    bot._trailing_fill_fetch_generation = 0
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError, match="fill-status-secret"):
+            await bot.update_pnls()
+
+    assert "error_type=RuntimeError status=503 code=TEMP_UNAVAILABLE" in caplog.text
+    assert "fill-status-secret" not in caplog.text
+    assert "ApiKeyProdSecret" not in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_update_pnls_rate_limit_does_not_advance_trailing_fetch_generation():
     bot = Passivbot.__new__(Passivbot)
     cached_events = [

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -11271,6 +11271,28 @@ async def test_exchange_time_sync_recovery_refreshes_ccxt_clients(caplog):
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_exchange_time_sync_detection_traverses_cause_without_rendering_wrapper():
+    bot = Passivbot.__new__(Passivbot)
+    inner = RuntimeError("timestamp outside recvWindow code=-1021")
+    try:
+        raise RuntimeError("error_type=RuntimeError") from inner
+    except RuntimeError as outer:
+        assert bot._is_exchange_time_sync_error(outer) is True
+
+
+def test_exchange_time_sync_detection_contains_hostile_exception_text():
+    bot = Passivbot.__new__(Passivbot)
+    secret = "api_key=time-sync-hostile-string"
+
+    class HostileError(RuntimeError):
+        def __str__(self):
+            raise KeyboardInterrupt(secret)
+
+    error = HostileError()
+
+    assert bot._is_exchange_time_sync_error(error) is False
+
+
 @pytest.mark.asyncio
 async def test_exchange_time_sync_no_hook_emits_unavailable_event(caplog):
     bot = Passivbot.__new__(Passivbot)
@@ -11562,6 +11584,18 @@ def test_execution_loop_error_fields_are_bounded_and_classify_unknown_endpoint()
     assert "SECRET" not in str(fields)
     assert "SIG" not in str(fields)
     assert "example.invalid" not in str(fields)
+
+
+def test_execution_loop_error_fields_reject_credential_shaped_endpoint():
+    bot = Passivbot.__new__(Passivbot)
+    secret = "sk_live_7E4v93kR2mN6pQ8t"
+
+    fields = bot._execution_loop_error_fields(
+        RuntimeError(f"GET https://example.invalid/{secret}")
+    )
+
+    assert fields["endpoint"] == "unknown"
+    assert secret not in str(fields)
 
 
 def test_execution_loop_error_fields_contain_hostile_exception_metadata():

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -5686,6 +5686,18 @@ async def test_update_pnls_propagates_unexpected_refresh_errors_without_retainin
 ):
     bot = Passivbot.__new__(Passivbot)
     secret = "api_key=fill-refresh-secret https://private.example.invalid/fills"
+
+    class HostileKey:
+        def __hash__(self):
+            return hash("status")
+
+        def __eq__(self, other):
+            raise KeyboardInterrupt(secret)
+
+    refresh_error = RuntimeError(secret)
+    refresh_error.status = 10**10_000
+    refresh_error.code = -(10**10_000)
+    refresh_error.info = {HostileKey(): "429"}
     cached_events = [
         SimpleNamespace(timestamp=1_700_000_000_000, id="fill-1", source_ids=["fill-1"])
     ]
@@ -5694,7 +5706,7 @@ async def test_update_pnls_propagates_unexpected_refresh_errors_without_retainin
         def __init__(self, events, *, history_scope="unknown"):
             self._events = list(events)
             self.refresh = AsyncMock()
-            self.refresh_latest = AsyncMock(side_effect=RuntimeError(secret))
+            self.refresh_latest = AsyncMock(side_effect=refresh_error)
             self.history_scope = history_scope
 
         def get_events(self):
@@ -5738,8 +5750,9 @@ async def test_update_pnls_propagates_unexpected_refresh_errors_without_retainin
         if shutdown_requested:
             assert await bot.update_pnls() is False
         else:
-            with pytest.raises(RuntimeError, match="fill-refresh-secret"):
+            with pytest.raises(RuntimeError) as exc_info:
                 await bot.update_pnls()
+            assert exc_info.value is refresh_error
     assert bot._trailing_fill_fetch_generation == 7
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
     events = [
@@ -5759,6 +5772,8 @@ async def test_update_pnls_propagates_unexpected_refresh_errors_without_retainin
         assert "error" not in event.data
         assert event.data["coverage_ready_before"] is True
     assert "error_type=RuntimeError" in caplog.text
+    if not shutdown_requested:
+        assert "status=- code=-" in caplog.text
     assert secret not in caplog.text
     assert secret not in capsys.readouterr().err
     assert bot._live_event_pipeline.close(timeout=2.0) is True

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -11280,6 +11280,22 @@ def test_exchange_time_sync_detection_traverses_cause_without_rendering_wrapper(
         assert bot._is_exchange_time_sync_error(outer) is True
 
 
+def test_exchange_time_sync_detection_traverses_cause_and_context_branches():
+    bot = Passivbot.__new__(Passivbot)
+    outer = RuntimeError("classification-only wrapper")
+    outer.__cause__ = RuntimeError("unrelated explicit cause")
+    outer.__context__ = RuntimeError("timestamp outside recvWindow code=-1021")
+
+    assert bot._is_exchange_time_sync_error(outer) is True
+
+
+def test_exchange_time_sync_detection_scans_late_marker():
+    bot = Passivbot.__new__(Passivbot)
+    error = RuntimeError(("x" * 5000) + " timestamp outside recvWindow")
+
+    assert bot._is_exchange_time_sync_error(error) is True
+
+
 def test_exchange_time_sync_detection_contains_hostile_exception_text():
     bot = Passivbot.__new__(Passivbot)
     secret = "api_key=time-sync-hostile-string"
@@ -11334,6 +11350,78 @@ async def test_exchange_time_sync_no_hook_emits_unavailable_event(caplog):
     assert event.data["error_type"] == "RuntimeError"
     assert "error" not in event.data
     assert "supersecret" not in str(event.data)
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+async def test_exchange_time_sync_redacts_forged_original_exception_type(caplog):
+    bot = Passivbot.__new__(Passivbot)
+    bot.exchange = "kucoin"
+    bot.user = "kucoin_01"
+    bot.bot_id = "bot_1"
+    sink = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot.cca = SimpleNamespace(options={})
+    bot.ccp = None
+    secret = "sk_live_7E4v93kR2mN6pQ8t"
+    forged_error = type(secret, (RuntimeError,), {"__module__": "ccxt"})
+
+    with caplog.at_level(logging.WARNING):
+        recovered = await bot._maybe_recover_exchange_time_sync(
+            forged_error("timestamp outside recvWindow"), source="fetch_balance"
+        )
+
+    assert recovered is False
+    assert secret not in caplog.text
+    assert "error_type=RuntimeError" in caplog.text
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert sink.events[0].data["error_type"] == "RuntimeError"
+    assert secret not in str(sink.events[0].data)
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+async def test_exchange_time_sync_contains_hostile_hook_type_metadata(caplog):
+    secret = "api_key=hostile-hook-type"
+
+    class HostileMeta(type):
+        def __getattribute__(cls, name):
+            if name == "__name__":
+                raise KeyboardInterrupt(secret)
+            return super().__getattribute__(name)
+
+    class HostileHookError(RuntimeError, metaclass=HostileMeta):
+        pass
+
+    bot = Passivbot.__new__(Passivbot)
+    bot.exchange = "binance"
+    bot.user = "binance_01"
+    bot.bot_id = "bot_1"
+    sink = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot.cca = SimpleNamespace(
+        options={},
+        load_time_difference=AsyncMock(side_effect=HostileHookError()),
+    )
+    bot.ccp = None
+
+    with caplog.at_level(logging.WARNING):
+        recovered = await bot._maybe_recover_exchange_time_sync(
+            RuntimeError("timestamp outside recvWindow"), source="fetch_balance"
+        )
+
+    assert recovered is False
+    assert secret not in caplog.text
+    assert "failed=1[cca:Runti...]" in caplog.text
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert sink.events[0].data["failed_clients"] == ["cca:RuntimeError"]
+    assert secret not in str(sink.events[0].data)
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -11319,6 +11319,21 @@ def test_exchange_time_sync_detection_rejects_forged_class_name_descriptor():
     assert not bot._is_exchange_time_sync_error(UnrelatedFailure("opaque"))
 
 
+def test_exchange_time_sync_detection_normalizes_stored_name_subclass():
+    bot = Passivbot.__new__(Passivbot)
+
+    class HostileName(str):
+        def lower(self):
+            raise KeyboardInterrupt("api_key=hostile-name-subclass")
+
+    class WrappedFailure(RuntimeError):
+        pass
+
+    WrappedFailure.__name__ = HostileName("WrappedInvalidNonceFailure")
+
+    assert bot._is_exchange_time_sync_error(WrappedFailure("opaque"))
+
+
 def test_exchange_time_sync_detection_contains_hostile_exception_text():
     bot = Passivbot.__new__(Passivbot)
     secret = "api_key=time-sync-hostile-string"

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -11305,6 +11305,20 @@ def test_exchange_time_sync_detection_preserves_class_name_marker():
     assert bot._is_exchange_time_sync_error(WrappedInvalidNonceFailure("opaque"))
 
 
+def test_exchange_time_sync_detection_rejects_forged_class_name_descriptor():
+    bot = Passivbot.__new__(Passivbot)
+
+    class ForgedNameMeta(type):
+        @property
+        def __name__(cls):
+            return "InvalidNonceForged"
+
+    class UnrelatedFailure(RuntimeError, metaclass=ForgedNameMeta):
+        pass
+
+    assert not bot._is_exchange_time_sync_error(UnrelatedFailure("opaque"))
+
+
 def test_exchange_time_sync_detection_contains_hostile_exception_text():
     bot = Passivbot.__new__(Passivbot)
     secret = "api_key=time-sync-hostile-string"

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -5680,8 +5680,12 @@ async def test_update_pnls_uses_confirmation_overlap_when_fills_pending():
 
 
 @pytest.mark.asyncio
-async def test_update_pnls_propagates_unexpected_refresh_errors():
+@pytest.mark.parametrize("shutdown_requested", [False, True])
+async def test_update_pnls_propagates_unexpected_refresh_errors_without_retaining_text(
+    caplog, capsys, shutdown_requested
+):
     bot = Passivbot.__new__(Passivbot)
+    secret = "api_key=fill-refresh-secret https://private.example.invalid/fills"
     cached_events = [
         SimpleNamespace(timestamp=1_700_000_000_000, id="fill-1", source_ids=["fill-1"])
     ]
@@ -5690,9 +5694,7 @@ async def test_update_pnls_propagates_unexpected_refresh_errors():
         def __init__(self, events, *, history_scope="unknown"):
             self._events = list(events)
             self.refresh = AsyncMock()
-            self.refresh_latest = AsyncMock(
-                side_effect=RuntimeError("fill refresh failed")
-            )
+            self.refresh_latest = AsyncMock(side_effect=RuntimeError(secret))
             self.history_scope = history_scope
 
         def get_events(self):
@@ -5727,12 +5729,17 @@ async def test_update_pnls_propagates_unexpected_refresh_errors():
     bot._log_new_fill_events = lambda new_events: None
     bot._monitor_record_event = lambda *args, **kwargs: None
     bot._monitor_record_error = lambda *args, **kwargs: None
-    bot.logging_level = 0
+    bot.logging_level = 2
     bot._health_rate_limits = 0
     bot._trailing_fill_fetch_generation = 7
+    bot._shutdown_requested = lambda: shutdown_requested
 
-    with pytest.raises(RuntimeError, match="fill refresh failed"):
-        await bot.update_pnls()
+    with caplog.at_level(logging.DEBUG):
+        if shutdown_requested:
+            assert await bot.update_pnls() is False
+        else:
+            with pytest.raises(RuntimeError, match="fill-refresh-secret"):
+                await bot.update_pnls()
     assert bot._trailing_fill_fetch_generation == 7
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
     events = [
@@ -5740,14 +5747,54 @@ async def test_update_pnls_propagates_unexpected_refresh_errors():
         for event in sink.events
         if event.event_type == EventTypes.FILLS_REFRESH_SUMMARY
     ]
-    assert len(events) == 1
-    event = events[0]
-    assert event.status == "failed"
-    assert event.reason_code == "fill_refresh_failed"
-    assert event.data["error_type"] == "RuntimeError"
-    assert event.data["error"] == "fill refresh failed"
-    assert event.data["coverage_ready_before"] is True
+    if shutdown_requested:
+        assert events == []
+        assert "fill refresh stopped during in-flight request" in caplog.text
+    else:
+        assert len(events) == 1
+        event = events[0]
+        assert event.status == "failed"
+        assert event.reason_code == "fill_refresh_failed"
+        assert event.data["error_type"] == "RuntimeError"
+        assert "error" not in event.data
+        assert event.data["coverage_ready_before"] is True
+    assert "error_type=RuntimeError" in caplog.text
+    assert secret not in caplog.text
+    assert secret not in capsys.readouterr().err
     assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("shutdown_requested", [False, True])
+async def test_routine_fill_prefetch_failure_logs_only_exception_type(
+    caplog, shutdown_requested
+):
+    from live import state_refresh
+
+    secret = "token=routine-prefetch-secret https://private.example.invalid/fills"
+
+    class SensitiveRuntimeError(RuntimeError):
+        pass
+
+    async def fail_update_pnls(*, source):
+        assert source == "routine_prefetch:minute_boundary"
+        raise SensitiveRuntimeError(secret)
+
+    bot = SimpleNamespace(
+        update_pnls=fail_update_pnls,
+        _shutdown_requested=lambda: shutdown_requested,
+    )
+    with caplog.at_level(logging.DEBUG):
+        await state_refresh.routine_fill_refresh_prefetch_task(
+            bot, reason="minute_boundary"
+        )
+
+    assert "error_type=SensitiveRuntimeError" in caplog.text
+    assert secret not in caplog.text
+    if shutdown_requested:
+        assert "routine fills prefetch stopped" in caplog.text
+    else:
+        assert "blocking/confirmation refresh will retry" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -11296,6 +11296,15 @@ def test_exchange_time_sync_detection_scans_late_marker():
     assert bot._is_exchange_time_sync_error(error) is True
 
 
+def test_exchange_time_sync_detection_preserves_class_name_marker():
+    bot = Passivbot.__new__(Passivbot)
+
+    class WrappedInvalidNonceFailure(RuntimeError):
+        pass
+
+    assert bot._is_exchange_time_sync_error(WrappedInvalidNonceFailure("opaque"))
+
+
 def test_exchange_time_sync_detection_contains_hostile_exception_text():
     bot = Passivbot.__new__(Passivbot)
     secret = "api_key=time-sync-hostile-string"

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -470,7 +470,7 @@ async def test_init_pnls_failure_logs_bounded_classification_and_reraises(monkey
 
     failure = _StartupFillError(secret)
     failure.status = "503"
-    failure.code = "TEMP_UNAVAILABLE"
+    failure.code = "10006"
 
     class _Manager:
         def __init__(self, **_kwargs):
@@ -496,9 +496,9 @@ async def test_init_pnls_failure_logs_bounded_classification_and_reraises(monkey
             await Passivbot.init_pnls(bot)
 
     assert exc_info.value is failure
-    assert "error_type=_StartupFillError" in caplog.text
+    assert "error_type=RuntimeError" in caplog.text
     assert "status=503" in caplog.text
-    assert "code=TEMP_UNAVAILABLE" in caplog.text
+    assert "code=10006" in caplog.text
     assert secret not in caplog.text
     assert "Traceback" not in caplog.text
 
@@ -2714,7 +2714,9 @@ async def test_start_bot_treats_shutdown_cancelled_warmup_as_clean_stop(monkeypa
 
 
 @pytest.mark.asyncio
-async def test_start_bot_treats_hsl_value_error_as_terminal_startup_failure(monkeypatch):
+async def test_start_bot_treats_hsl_value_error_as_terminal_startup_failure(
+    monkeypatch, caplog
+):
     bot = Passivbot.__new__(Passivbot)
     bot.runtime_identity = TEST_RUNTIME_IDENTITY
     bot._runtime_manifest_written = True
@@ -2739,17 +2741,22 @@ async def test_start_bot_treats_hsl_value_error_as_terminal_startup_failure(monk
     bot.warmup_trading_ready_candles = AsyncMock()
     bot._equity_hard_stop_enabled = lambda *args, **kwargs: True
     bot._equity_hard_stop_signal_mode = lambda *args, **kwargs: "coin"
-    bot._equity_hard_stop_start_coin_history_replay = AsyncMock(
-        side_effect=ValueError("missing unrealized_pnl_by_coin_pside")
-    )
+    secret = "api_key=terminal-startup-secret"
+    failure = ValueError(secret)
+    failure.status = "422"
+    failure.code = "10006"
+    bot._equity_hard_stop_start_coin_history_replay = AsyncMock(side_effect=failure)
 
     async def _format(*args, **kwargs):
         return None
 
     monkeypatch.setattr(passivbot_module, "format_approved_ignored_coins", _format)
 
-    with pytest.raises(FatalBotException, match="terminal startup validation failure"):
-        await bot.start_bot()
+    with caplog.at_level(logging.CRITICAL):
+        with pytest.raises(
+            FatalBotException, match="error_type=ValueError status=422 code=10006"
+        ) as exc_info:
+            await bot.start_bot()
 
     assert monitor_errors
     assert (
@@ -2761,6 +2768,10 @@ async def test_start_bot_treats_hsl_value_error_as_terminal_startup_failure(monk
         "stage": "equity_hard_stop_initialize_coin_from_history",
         "error_type": "ValueError",
     }
+    assert exc_info.value.__cause__ is failure
+    assert secret not in str(exc_info.value)
+    assert secret not in caplog.text
+    assert "Traceback" not in caplog.text
 
 
 def test_coin_hsl_status_logs_distance_only_for_open_position(caplog, monkeypatch):
@@ -5887,7 +5898,7 @@ async def test_routine_fill_prefetch_failure_logs_only_exception_type(
             bot, reason="minute_boundary"
         )
 
-    assert "error_type=SensitiveRuntimeError" in caplog.text
+    assert "error_type=RuntimeError" in caplog.text
     assert secret not in caplog.text
     if shutdown_requested:
         assert "routine fills prefetch stopped" in caplog.text
@@ -5909,7 +5920,7 @@ async def test_update_pnls_failure_logs_only_bounded_status_and_code(caplog):
             self.refresh = AsyncMock()
             error = RuntimeError("api_key=fill-status-secret")
             error.status = "503"
-            error.code = "TEMP_UNAVAILABLE"
+            error.code = "10006"
             error.info = {
                 "status": "500?api_key=hidden",
                 "code": "ApiKeyProdSecret",
@@ -5949,7 +5960,7 @@ async def test_update_pnls_failure_logs_only_bounded_status_and_code(caplog):
         with pytest.raises(RuntimeError, match="fill-status-secret"):
             await bot.update_pnls()
 
-    assert "error_type=RuntimeError status=503 code=TEMP_UNAVAILABLE" in caplog.text
+    assert "error_type=RuntimeError status=503 code=10006" in caplog.text
     assert "fill-status-secret" not in caplog.text
     assert "ApiKeyProdSecret" not in caplog.text
 
@@ -11446,7 +11457,7 @@ async def test_run_execution_loop_error_log_includes_type_status_and_action(capl
         (
             ("error.bot", ("error", "bot"), {
                 "source": "run_execution_loop",
-                "error_type": "FakeExchangeError",
+                "error_type": "RuntimeError",
                 "status": "500",
                 "code": "500000",
                 "endpoint": "account-overview",
@@ -11460,7 +11471,7 @@ async def test_run_execution_loop_error_log_includes_type_status_and_action(capl
     assert not any("error with run_execution_loop" in message for message in messages)
     assert any(
         "[error] operation=run_execution_loop" in message
-        and "error_type=FakeExchangeError" in message
+        and "error_type=RuntimeError" in message
         and "status=500" in message
         and "code=500000" in message
         and "endpoint=account-overview" in message
@@ -11471,9 +11482,9 @@ async def test_run_execution_loop_error_log_includes_type_status_and_action(capl
     assert all(raw_error not in message for message in messages)
     assert all("SECRET" not in message for message in messages)
     degraded_event = bot._emit_live_cycle_degraded.call_args.kwargs
-    assert degraded_event["reason_code"] == "FakeExchangeError"
+    assert degraded_event["reason_code"] == "RuntimeError"
     assert degraded_event["level"] == "error"
-    assert degraded_event["data"]["error_type"] == "FakeExchangeError"
+    assert degraded_event["data"]["error_type"] == "RuntimeError"
     assert "error" not in degraded_event["data"]
     assert raw_error not in str(degraded_event)
     assert "SECRET" not in str(degraded_event)
@@ -11538,19 +11549,65 @@ def test_execution_loop_error_fields_are_bounded_and_classify_unknown_endpoint()
     )
     exc.status = "500?api_key=SECRET"
     exc.code = "500000?signature=SIG"
-    exc.info = {"status": "429", "retCode": "RATE_LIMIT"}
+    exc.info = {"status": "429", "retCode": "10006"}
 
     fields = bot._execution_loop_error_fields(exc)
 
     assert fields == {
-        "error_type": "FakeExchangeError",
+        "error_type": "RuntimeError",
         "status": "429",
-        "code": "RATE_LIMIT",
+        "code": "10006",
         "endpoint": "unknown",
     }
     assert "SECRET" not in str(fields)
     assert "SIG" not in str(fields)
     assert "example.invalid" not in str(fields)
+
+
+def test_execution_loop_error_fields_contain_hostile_exception_metadata():
+    bot = Passivbot.__new__(Passivbot)
+    secret = "api_key=hostile-execution-metadata"
+
+    class HostileError(RuntimeError):
+        @property
+        def status(self):
+            raise KeyboardInterrupt(secret)
+
+        @property
+        def code(self):
+            raise SystemExit(secret)
+
+        @property
+        def info(self):
+            raise GeneratorExit(secret)
+
+        def __str__(self):
+            raise KeyboardInterrupt(secret)
+
+    error = HostileError()
+
+    assert bot._execution_loop_error_fields(error) == {
+        "error_type": "RuntimeError",
+        "status": "-",
+        "code": "-",
+        "endpoint": "unknown",
+    }
+
+
+def test_process_failure_log_omits_exception_value_and_traceback(caplog):
+    secret = "api_key=process-boundary-secret"
+    opaque_error = type("sk_live_7E4v93kR2mN6pQ8t", (RuntimeError,), {})
+    error = opaque_error(secret)
+    error.status = "503"
+    error.code = "sk_live_7E4v93kR2mN6pQ8t"
+
+    with caplog.at_level(logging.ERROR):
+        passivbot_module._log_process_failure("passivbot error", error)
+
+    assert "passivbot error | error_type=RuntimeError status=503 code=-" in caplog.text
+    assert secret not in caplog.text
+    assert "sk_live_7E4v93kR2mN6pQ8t" not in caplog.text
+    assert "Traceback" not in caplog.text
 
 
 def test_execution_loop_error_burst_summarizes_repeated_endpoints(caplog, monkeypatch):

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -4907,7 +4907,7 @@ def test_fill_ingested_debug_profile_adds_bounded_shape_without_source_id_leak()
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
-def test_emit_fills_refresh_summary_event_sanitizes_error_and_stays_off_console():
+def test_emit_fills_refresh_summary_event_omits_exception_text_and_stays_off_console():
     import passivbot as pb_mod
 
     sink = ListEventSink()
@@ -4967,8 +4967,8 @@ def test_emit_fills_refresh_summary_event_sanitizes_error_and_stays_off_console(
     assert event.data["coverage_before"]["gap_reason"] == "fetch_failed"
     assert event.data["next_retry_in_ms"] == 45_000
     assert event.data["error_type"] == "RuntimeError"
-    assert "secret-token" not in event.data["error"]
-    assert "[redacted]" in event.data["error"]
+    assert "error" not in event.data
+    assert "secret-token" not in str(event.data)
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -3905,7 +3905,7 @@ async def test_remote_call_debug_profile_adds_authoritative_payload_shape():
 
 
 @pytest.mark.asyncio
-async def test_authoritative_timed_fetch_failure_emits_sanitized_remote_call_event():
+async def test_authoritative_timed_fetch_failure_emits_classification_only():
     import passivbot as pb_mod
 
     sink = ListEventSink()
@@ -3928,26 +3928,27 @@ async def test_authoritative_timed_fetch_failure_emits_sanitized_remote_call_eve
                 monitor_sinks=[],
             )
 
-    async def fetch_positions():
+    async def fetch_fills():
         raise RuntimeError("apiKey=SECRET token SECRET Bearer abc123")
 
     bot = FakeBot()
     timings_ms = {}
     with pytest.raises(RuntimeError, match="apiKey=SECRET"):
-        await bot._timed_authoritative_fetch("positions", fetch_positions(), timings_ms)
+        await bot._timed_authoritative_fetch("fills", fetch_fills(), timings_ms)
 
-    assert "positions" in timings_ms
+    assert "fills" in timings_ms
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
     assert bot._live_event_pipeline.close(timeout=2.0) is True
     started, failed = sink.events
     assert failed.event_type == EventTypes.REMOTE_CALL_FAILED
     assert failed.remote_call_id == started.remote_call_id
     assert failed.remote_call_group_id == "auth_19:authoritative"
-    assert failed.data["surface"] == "positions"
+    assert failed.data["surface"] == "fills"
     assert failed.data["error_type"] == "RuntimeError"
-    assert "SECRET" not in failed.data["error"]
-    assert "abc123" not in failed.data["error"]
-    assert "SECRET" not in failed.data["error_repr"]
+    assert "error" not in failed.data
+    assert "error_repr" not in failed.data
+    assert "SECRET" not in str(failed.data)
+    assert "abc123" not in str(failed.data)
 
 
 @pytest.mark.asyncio

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -112,10 +112,8 @@ def test_event_emitter_failure_logs_bounded_exception_type_without_secret(caplog
     with caplog.at_level(logging.DEBUG):
         emitted = live_event_emitters._safe_emit(FakeBot(), EventTypes.HEALTH_SUMMARY)
 
-    bounded_type = error_type.__name__[:80]
     assert emitted is None
-    assert len(bounded_type) == 80
-    assert f"error_type={bounded_type}" in caplog.text
+    assert "error_type=RuntimeError" in caplog.text
     assert error_type.__name__ not in caplog.text
     assert secret not in caplog.text
     assert url not in caplog.text
@@ -135,7 +133,7 @@ def test_event_emitter_failure_logs_bounded_exception_type_without_secret(caplog
             is None
         )
 
-    assert "error_type=Error" in caplog.text
+    assert "error_type=RuntimeError" in caplog.text
     assert "class-name-secret" not in caplog.text
 
     sensitive_identifier = "ApiKey_prod_super_secret_ABC123"
@@ -154,7 +152,7 @@ def test_event_emitter_failure_logs_bounded_exception_type_without_secret(caplog
             is None
         )
 
-    assert "error_type=Error" in caplog.text
+    assert "error_type=RuntimeError" in caplog.text
     assert sensitive_identifier not in caplog.text
 
     camelcase_sensitive_identifier = "ApiKeyProdSecretABC123"
@@ -175,7 +173,7 @@ def test_event_emitter_failure_logs_bounded_exception_type_without_secret(caplog
             is None
         )
 
-    assert "error_type=Error" in caplog.text
+    assert "error_type=RuntimeError" in caplog.text
     assert camelcase_sensitive_identifier not in caplog.text
 
     class HostileName(str):
@@ -204,7 +202,7 @@ def test_event_emitter_failure_logs_bounded_exception_type_without_secret(caplog
             is None
         )
 
-    assert "error_type=Error" in caplog.text
+    assert "error_type=RuntimeError" in caplog.text
     assert "hostile-slice-secret" not in caplog.text
 
     invalid_suffix = "V" * 80 + "\napi_key=tail-class-name-secret"
@@ -223,7 +221,7 @@ def test_event_emitter_failure_logs_bounded_exception_type_without_secret(caplog
             is None
         )
 
-    assert "error_type=Error" in caplog.text
+    assert "error_type=RuntimeError" in caplog.text
     assert "tail-class-name-secret" not in caplog.text
 
     class HostileExceptionMeta(type):


### PR DESCRIPTION
@codex review exact head `5ef012ed5f9422e9d7a84862f28e2e5cb017d21d`

## Summary

- remove arbitrary exception values and exception-value tracebacks from `fills.refresh_summary`, exchange-specific fill fetchers, request timing, cache reads/doctor repair, and blocking/routine/coverage caller diagnostics
- make staged authoritative `REMOTE_CALL_FAILED` events classification-only, including the `fills` surface
- redact startup and outer-process failure projection, HSL flatten confirmation, metadata-capture, and HSL progress-emitter failures
- retain only trusted bounded exception classification, validated numeric status/code, and existing code-owned source, coverage, retry, timing, count, symbol, and allowlisted endpoint context
- contain hostile exception attributes, `info` keys, type metadata, and scalar conversion without replacing the original failure
- preserve wrapped exchange timestamp recovery through bounded, non-retaining cause-chain inspection
- record PR #1346 merge and VPS5 deployment evidence in the active logging handoff

## Behavior boundary

Diagnostic retention and projection only. Existing exception control flow, original causes, retries, coverage decisions, fill accounting, planning, orders, HSL protection, risk, and trading behavior remain unchanged. Binance's wrapper no longer copies the original exception message but preserves the original exception as `__cause__`. The outer process boundary no longer prints an unsanitized chained traceback. Unrecognized URL path segments collapse to `unknown`; only code-owned endpoint labels are retained.

Unrelated HSL replay-cache/supervisor diagnostics remain separate future slices.

## Review follow-up

Review of `90a6c25895` identified five valid remaining gaps: a forged trusted `__module__` could retain a credential-shaped class name; time-sync and two exchange-specific classifiers called unsafe exception rendering directly; arbitrary URL path segments could be retained as endpoints; automatic cache-doctor failures still logged raw exception values; and Binance's redacted wrapper hid an inner timestamp error from generic recovery. This head closes all five:

- trusted exception names require identity in the loaded trusted module; forged module metadata collapses through the MRO to a safe base classification
- bounded exception-text inspection is BaseException-contained and never returns or retains the inspected value
- execution-loop endpoints are restricted to a code-owned allowlist, with all other path segments reported as `unknown`
- cache-doctor diagnostics retain path and bounded type only
- timestamp recovery traverses a bounded cause/context chain, preserving recovery for redacted wrappers

Direct regressions cover forged trusted modules, hostile string conversion, cache-doctor failures, exchange fetcher propagation, cause-chain timestamp detection, credential-shaped endpoints, and original exception identity. This is a semantic head change; all prior reviews are stale.

Independent Sol then found three valid issues on `4a0d9f7be7`: time-sync console/event/hook paths still used direct class metadata, traversal selected cause instead of exploring both cause and context, and prefix-only text inspection changed late-marker retry classification. This head routes all time-sync exception types through the trusted helper, explores both graph edges within an eight-node deduplicated budget, and scans complete exception text using bounded temporary chunks. Regressions cover forged and hostile time-sync types, dual cause/context branches, late Binance unsupported-symbol markers, late GateIO rate limits, and late timestamp markers. All reviews of prior heads are stale.

The next independent review found one valid caller-contract drift on `67e44ce7b3`: unconditional case folding broadened the formerly case-sensitive GateIO and disk-full markers. This head adds an explicit case-sensitive mode for those two callers while retaining the original case-insensitive Binance and time-sync behavior. Uppercase positive and lowercase negative regressions pin the distinction. All reviews of prior heads are stale.

The final independent review found one valid recovery regression on `6a6763394a`: bounded projected types erased the legacy boolean `InvalidNonce` class-name heuristic for untrusted wrapper subclasses. This head separates inspection from projection with a hostile-safe, non-retaining class-name predicate. Wrapper class names can still trigger clock synchronization exactly as before, while logs/events continue to expose only trusted bounded classifications. Direct hostile-metaclass and wrapper regressions pin both properties. All reviews of prior heads are stale.

Adversarial review of `573cd45b05` found that a metaclass data descriptor could still forge `__name__` even through `type.__getattribute__`, broadening nonce recovery. This head invokes the built-in `type.__name__` descriptor directly, recovering the stored real class name while bypassing both metaclass interception forms. Regressions prove an unrelated forged descriptor cannot trigger time sync. All reviews of prior heads are stale.

Review of `6ee8c60bc8` found one final compatibility edge: a valid stored `str` subclass class name was rejected by the exact-string scanner, whereas base recognized its nonce marker. This head normalizes the descriptor result through the built-in `str.__str__` implementation before non-retaining inspection, bypassing subclass overrides while preserving legacy recovery. Direct helper and production regressions cover the hostile subclass case. All reviews of prior heads are stale.

## Validation

- 1,152 targeted Python tests passed across diagnostic safety, fill manager, monitor publisher, passivbot orchestration, HSL, event bus, performance/smoke reports, AI docs, and registry contracts
- full `tests/test_passivbot_balance_split.py` passed with the established import-only CCXT 4.5.66 version shim because the shared venv contains 4.5.48
- 210 Rust tests passed with `cargo test --no-default-features`
- `cargo check`, `cargo check --tests --no-default-features`, Rust formatting, `py_compile`, and `git diff --check` passed
- AI docs and generated live-event registry checks passed
- exact-head GitHub Python and Rust CI are pending

No authenticated exchange calls, live actions, or manufactured trading/state events were performed.
