### PR TITLE
Redact shutdown failure diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Shutdown-stage failure diagnostics now retain bounded exception types alongside existing stage,
+  task-count, timeout, and elapsed-time context without arbitrary exception messages, request URLs,
+  response text, or credentials. Event-delivery and event-pipeline-close fallback logs use the
+  same classification, as do per-maintainer cancellation and legacy cleanup failures.
+  Maintainer cancellation, execution-loop waits, session closing, shutdown timing, and process
+  control are unchanged.
+
 - Fill-history refresh failure diagnostics now retain bounded exception types alongside existing
   source, coverage, retry, timing, count, and endpoint context without arbitrary exception
   messages or exception-value tracebacks. This includes exchange-specific fill fetchers, cache

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -308,6 +308,17 @@ responses, or formatted exception-value traceback. A stack diagnostic is marked 
 DEBUG logging accepts it. Reconnect cadence, retry behavior, and connector control flow are
 independent of observability delivery.
 
+## Shutdown Failure Diagnostics
+
+`bot.shutdown.stage` failure records retain the code-owned stage, bounded exception type, elapsed
+time, and applicable task-count or timeout context. The event and its human fallback exclude
+exception messages, request URLs, response text, credentials, and traceback values. Failure to
+deliver the structured stage may emit one DEBUG fallback with only the stage and bounded exception
+type. Event-pipeline close failures retain the same bounded type in their warning. These diagnostics
+do not alter task cancellation, execution-loop waits, session closing, shutdown timing, process
+control, or event-pipeline isolation. Per-maintainer cancellation failures and the legacy cleanup
+helper apply the same type-only boundary.
+
 ## Execution-Loop Incidents
 
 An execution-loop failure publishes a bounded `error.bot` record and an equivalent first-occurrence

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,33 +22,54 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Open PR #1347, `Redact fill refresh failure diagnostics`, on branch
-  `codex/fill-history-diagnostic-redaction`, based on canonical
-  `4192e709d46d3ef9516025e121ddad15c0d0cd6e`. Resolve its exact head from live
-  metadata; the commit containing this handoff is a moving review head.
-- Scope: remove arbitrary exception values from structured fill-refresh
-  summaries, exchange-specific fetcher diagnostics, request timing, staged
-  remote-call events, cache reads/doctor repair, startup/process handling, blocking/routine/coverage
-  callers, and HSL flatten confirmation while retaining bounded exception
-  type, validated numeric status/code, and existing source, coverage, retry, timing, count,
-  and code-owned endpoint context. Complete chunked text inspection plus a bounded
-  cause/context graph preserves caller-specific retry marker case rules and timestamp recovery for
-  redacted wrappers, including the legacy class-name marker heuristic without projecting that name.
-  Adjacent
-  monitor, metadata-capture, and HSL progress
-  diagnostics use the same safe type boundary.
-- Behavior boundary: diagnostic retention and projection only. Exception
-  propagation, refresh and retry behavior, fill accounting, planning, orders,
-  risk, and trading behavior remain unchanged.
-- Baseline: these fill-history paths still retain sanitized or raw exception
-  text even though the shared live-event contract requires code-owned context
-  and bounded exception classifications.
+- Pending PR on branch `codex/shutdown-diagnostic-redaction`, based on canonical
+  `67416ee4f7fef2dc3ffac001d50e82c0322ee72b`. Resolve its exact head and PR
+  number from live metadata; the commit containing this handoff is a moving
+  review head.
+- Scope: remove arbitrary exception values from `bot.shutdown.stage` failures,
+  event-pipeline close failure warnings, per-maintainer cancellation errors,
+  and shutdown fallback logs while retaining bounded exception type, stage,
+  task count, timeout, status, and elapsed-time context.
+- Behavior boundary: diagnostic retention and projection only. Maintainer
+  cancellation, execution-loop waits, session closing, shutdown timing,
+  process control, event routing, and trading behavior remain unchanged.
+- Baseline: maintainer-stop/await, execution-loop-wait, private/public session
+  close, stage-delivery, event-pipeline-close, and legacy cleanup failures
+  still render or retain raw exception text.
 - Review gate: exact-current-head Hermes approval plus green Python/Rust CI.
   Built-in Codex automatic review is additional and every finding must be
   verified and resolved.
 - Expected VPS action: tracked-clean pull plus one exact-five graceful restart
-  and bounded settled smoke because live fill diagnostics change;
-  preserve `misc:0.0`.
+  and bounded settled smoke because live shutdown diagnostics change; preserve
+  `misc:0.0`.
+- Next candidate: candle refresh/cache-maintenance diagnostic redaction after
+  this dependent runtime slice merges.
+
+## Deployed Baseline (PR #1347)
+
+- PR #1347 merged exact approved head
+  `5ef012ed5f9422e9d7a84862f28e2e5cb017d21d` as canonical
+  `67416ee4f7fef2dc3ffac001d50e82c0322ee72b` after exact-head Hermes
+  approval, green Python/Rust CI, and finding-free built-in Codex and
+  independent Sol reviews.
+- VPS5 guarded-prepared tracked-clean from
+  `4192e709d46d3ef9516025e121ddad15c0d0cd6e` without a Rust build. The source
+  fingerprint/stamp remained
+  `691bff9683deec9382a4e96ab6a107c14145f88edd6ae2f8e2380b8ba6824449`, and the
+  compiled artifact SHA remained
+  `7611f3eff1d8702ff29d90490a1aba490db5c816e7e3f09a2c33e5c4085da023`.
+- The exact-target orchestrator gracefully restarted only panes `%358`-`%362`;
+  old PIDs `1079121/1079130/1079124/1079133/1079127` exited and replacement
+  PIDs `1080755/1080764/1080758/1080767/1080761` relaunched and verified
+  without force or broad-pattern signals.
+- The integrated 120-second smoke was hard-green with complete shutdown and
+  startup identity, zero hard failures, zero hard text-log or attention
+  matches, and zero monitor warnings or errors. A bounded settled smoke found
+  all five exact processes stable with no PID churn, persistent uninterruptible
+  state, failed fill refresh, remote-call failure, event-pipeline integrity
+  issue, or hard diagnostic evidence. The checkout remained exact and
+  tracked-clean, while protected `misc:0.0` stayed `%8`/PID `434835`. No direct
+  authenticated exchange call or event was manufactured.
 
 ## Deployed Baseline (PR #1346)
 

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,10 +22,10 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Pending PR on branch `codex/shutdown-diagnostic-redaction`, based on canonical
-  `67416ee4f7fef2dc3ffac001d50e82c0322ee72b`. Resolve its exact head and PR
-  number from live metadata; the commit containing this handoff is a moving
-  review head.
+- Open PR #1348, `Redact shutdown failure diagnostics`, on branch
+  `codex/shutdown-diagnostic-redaction`, based on canonical
+  `67416ee4f7fef2dc3ffac001d50e82c0322ee72b`. Resolve its exact head from live
+  metadata; the commit containing this handoff is a moving review head.
 - Scope: remove arbitrary exception values from `bot.shutdown.stage` failures,
   event-pipeline close failure warnings, per-maintainer cancellation errors,
   and shutdown fallback logs while retaining bounded exception type, stage,

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,30 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1346)
+## Latest Canonical Deployment (PR #1347)
+
+- PR #1347 merged exact approved head `5ef012ed5f` as canonical
+  `67416ee4f7fef2dc3ffac001d50e82c0322ee72b` after exact-head Hermes
+  approval, green Python/Rust CI, and finding-free built-in Codex and
+  independent Sol reviews.
+- VPS5 guarded-prepared tracked-clean from `4192e709d46` without a Rust build;
+  the Rust source fingerprint/stamp and compiled artifact remained unchanged.
+  The exact-target orchestrator gracefully restarted only panes `%358`-`%362`;
+  old PIDs `1079121/1079130/1079124/1079133/1079127` exited and replacement
+  PIDs `1080755/1080764/1080758/1080767/1080761` relaunched and verified
+  without force or broad-pattern signals.
+- The integrated 120-second smoke was hard-green with complete shutdown and
+  startup identity, zero hard failures, zero hard text-log or attention
+  matches, and zero monitor warnings or errors. A bounded settled smoke found
+  all five exact processes stable with no PID churn, persistent uninterruptible
+  state, failed fill refresh, remote-call failure, event-pipeline integrity
+  issue, or hard diagnostic evidence. The checkout remained exact and
+  tracked-clean, and protected `misc:0.0` stayed `%8`/PID `434835`. No direct
+  authenticated exchange call or event was manufactured. The next slice
+  redacts shutdown-stage failure diagnostics; candle refresh/cache-maintenance
+  diagnostics remain the next candidate after that slice.
+
+## Previous Canonical Deployment (PR #1346)
 
 - PR #1346 merged exact approved head `377cb1dc60` as canonical
   `4192e709d46d3ef9516025e121ddad15c0d0cd6e` after exact-head Hermes

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -6078,6 +6078,7 @@ def _compact_shutdown_event_data(live_event: dict[str, Any]) -> dict[str, Any]:
         "threshold_s",
         "closed",
         "inline",
+        "error_type",
         "error",
     ):
         if key not in data or data.get(key) is None:

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -6832,7 +6832,10 @@ class Passivbot:
                 logging.warning("[monitor] live event pipeline close timed out")
             return closed
         except Exception as exc:
-            logging.warning("[monitor] live event pipeline close failed: %s", exc)
+            logging.warning(
+                "[monitor] live event pipeline close failed (%s)",
+                bounded_exception_type(exc),
+            )
             return False
         finally:
             self._live_event_pipeline = None
@@ -6884,7 +6887,11 @@ class Passivbot:
                 data=payload,
             )
         except Exception as exc:
-            logging.debug("[shutdown] failed emitting shutdown stage %s: %s", stage, exc)
+            logging.debug(
+                "[shutdown] failed emitting shutdown stage %s (%s)",
+                stage,
+                bounded_exception_type(exc),
+            )
         if emitted is None:
             log_level = logging.INFO
             if level == "warning":
@@ -6930,13 +6937,14 @@ class Passivbot:
                     if task is not None:
                         maintainer_tasks.append(task)
         except Exception as e:
-            logging.error("[shutdown] error stopping maintainers: %s", e)
+            error_type = bounded_exception_type(e)
+            logging.error("[shutdown] error stopping maintainers (%s)", error_type)
             self._emit_shutdown_stage(
                 "maintainers_stop_failed",
                 status="failed",
                 level="error",
                 message="error stopping maintainer tasks",
-                data={"error": str(e)},
+                data={"error_type": error_type},
             )
         if maintainer_tasks:
             try:
@@ -7001,15 +7009,20 @@ class Passivbot:
                     )
                     pass
             except Exception as e:
+                error_type = bounded_exception_type(e)
                 logging.error(
-                    "[shutdown] error awaiting maintainer cancellation: %s", e
+                    "[shutdown] error awaiting maintainer cancellation (%s)",
+                    error_type,
                 )
                 self._emit_shutdown_stage(
                     "maintainers_await_failed",
                     status="failed",
                     level="error",
                     message="error awaiting maintainer tasks",
-                    data={"task_count": len(maintainer_tasks), "error": str(e)},
+                    data={
+                        "task_count": len(maintainer_tasks),
+                        "error_type": error_type,
+                    },
                 )
         execution_loop_stopped = getattr(self, "_execution_loop_stopped", None)
         execution_loop_task = getattr(self, "_execution_loop_task", None)
@@ -7101,13 +7114,16 @@ class Passivbot:
                     message="execution loop cancelled during shutdown",
                 )
             except Exception as e:
-                logging.debug("[shutdown] error waiting for execution loop: %s", e)
+                error_type = bounded_exception_type(e)
+                logging.debug(
+                    "[shutdown] error waiting for execution loop (%s)", error_type
+                )
                 self._emit_shutdown_stage(
                     "execution_loop_wait_failed",
                     status="failed",
                     level="error",
                     message="error waiting for execution loop",
-                    data={"error": str(e)},
+                    data={"error_type": error_type},
                 )
             finally:
                 try:
@@ -7124,13 +7140,16 @@ class Passivbot:
                     message="private ccxt session closed",
                 )
         except Exception as e:
-            logging.error("[shutdown] error closing private ccxt session: %s", e)
+            error_type = bounded_exception_type(e)
+            logging.error(
+                "[shutdown] error closing private ccxt session (%s)", error_type
+            )
             self._emit_shutdown_stage(
                 "private_session_close_failed",
                 status="failed",
                 level="error",
                 message="error closing private ccxt session",
-                data={"error": str(e)},
+                data={"error_type": error_type},
             )
         try:
             if getattr(self, "cca", None) is not None:
@@ -7141,13 +7160,16 @@ class Passivbot:
                     message="public ccxt session closed",
                 )
         except Exception as e:
-            logging.error("[shutdown] error closing public ccxt session: %s", e)
+            error_type = bounded_exception_type(e)
+            logging.error(
+                "[shutdown] error closing public ccxt session (%s)", error_type
+            )
             self._emit_shutdown_stage(
                 "public_session_close_failed",
                 status="failed",
                 level="error",
                 message="error closing public ccxt session",
-                data={"error": str(e)},
+                data={"error_type": error_type},
             )
         await self._monitor_flush_snapshot(force=True, ts=utc_ms())
         self._emit_shutdown_stage(
@@ -8032,7 +8054,11 @@ class Passivbot:
             try:
                 res[key] = self.maintainers[key].cancel()
             except Exception as e:
-                logging.error(f"error stopping maintainer {key} {e}")
+                logging.error(
+                    "error stopping maintainer %s (%s)",
+                    key,
+                    bounded_exception_type(e),
+                )
         if hasattr(self, "WS_ohlcvs_1m_tasks"):
             res0s = {}
             for key in self.WS_ohlcvs_1m_tasks:
@@ -8040,7 +8066,11 @@ class Passivbot:
                     res0 = self.WS_ohlcvs_1m_tasks[key].cancel()
                     res0s[key] = res0
                 except Exception as e:
-                    logging.error(f"error stopping WS_ohlcvs_1m_tasks {key} {e}")
+                    logging.error(
+                        "error stopping WS_ohlcvs_1m_tasks %s (%s)",
+                        key,
+                        bounded_exception_type(e),
+                    )
             if res0s:
                 if verbose:
                     logging.debug(f"stopped ohlcvs watcher tasks {res0s}")
@@ -19852,7 +19882,7 @@ async def shutdown_bot(bot):
     except asyncio.TimeoutError:
         print("Shutdown timed out after 3 seconds. Forcing exit.")
     except Exception as e:
-        print(f"Error during shutdown: {e}")
+        print(f"Error during shutdown ({bounded_exception_type(e)}).")
 
 
 async def main():

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -6049,6 +6049,7 @@ def test_live_smoke_report_summarizes_shutdown_events(tmp_path):
                     "elapsed_s": 6.25,
                     "task_count": 4,
                     "timeout_s": 5.0,
+                    "error_type": "RuntimeError",
                     "error": "api_key=AKIA123 Authorization: Bearer TOKEN123",
                 },
             ),
@@ -6103,6 +6104,7 @@ def test_live_smoke_report_summarizes_shutdown_events(tmp_path):
     assert stage_group["status"] == "degraded"
     assert stage_group["latest_data"]["elapsed_s"] == 6.25
     assert stage_group["latest_data"]["task_count"] == 4
+    assert stage_group["latest_data"]["error_type"] == "RuntimeError"
     assert "AKIA123" not in stage_group["latest_data"]["error"]
     assert "TOKEN123" not in stage_group["latest_data"]["error"]
     assert "latest_message" not in stage_group

--- a/tests/test_maintainer_logging.py
+++ b/tests/test_maintainer_logging.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from passivbot import Passivbot
+from passivbot import Passivbot, shutdown_bot
 
 
 class _Task:
@@ -15,8 +15,11 @@ class _Task:
 
 
 class _FailingTask:
+    def __init__(self, message="cancel failed"):
+        self.message = message
+
     def cancel(self):
-        raise RuntimeError("cancel failed")
+        raise RuntimeError(self.message)
 
 
 class _AsyncClient:
@@ -43,14 +46,48 @@ def test_stop_data_maintainers_keeps_success_detail_at_debug(caplog):
 
 
 def test_stop_data_maintainers_keeps_cancellation_failures_at_error(caplog):
-    bot = SimpleNamespace(maintainers={"hourly": _FailingTask()})
+    bot = SimpleNamespace(
+        maintainers={
+            "hourly": _FailingTask(
+                "token=maintainer-secret https://private.invalid/maintainer"
+            )
+        },
+        WS_ohlcvs_1m_tasks={
+            "BTC": _FailingTask(
+                "authorization=websocket-secret https://private.invalid/websocket"
+            )
+        },
+    )
 
     with caplog.at_level(logging.DEBUG):
         result = Passivbot.stop_data_maintainers(bot)
 
     assert result == {}
-    assert "error stopping maintainer hourly cancel failed" in caplog.text
+    assert "error stopping maintainer hourly (RuntimeError)" in caplog.text
+    assert "error stopping WS_ohlcvs_1m_tasks BTC (RuntimeError)" in caplog.text
+    assert "maintainer-secret" not in caplog.text
+    assert "websocket-secret" not in caplog.text
+    assert "private.invalid" not in caplog.text
     assert any(record.levelno == logging.ERROR for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_shutdown_bot_redacts_close_failure_text(capsys):
+    class _FailingBot:
+        def stop_data_maintainers(self):
+            return None
+
+        async def close(self):
+            raise RuntimeError(
+                "signature=shutdown-secret https://private.invalid/shutdown"
+            )
+
+    await shutdown_bot(_FailingBot())
+
+    output = capsys.readouterr().out
+    assert "Error during shutdown (RuntimeError)." in output
+    assert "shutdown-secret" not in output
+    assert "private.invalid" not in output
 
 
 @pytest.mark.asyncio

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -1175,6 +1175,166 @@ async def test_shutdown_gracefully_emits_stage_events():
     )
 
 
+def test_emit_shutdown_stage_redacts_event_delivery_exception_text(caplog):
+    bot = Passivbot.__new__(Passivbot)
+    bot._shutdown_started_monotonic = None
+
+    def fail_event(*args, **kwargs):
+        raise RuntimeError("token=shutdown-secret https://private.invalid/request")
+
+    bot._emit_live_event = fail_event
+
+    with caplog.at_level(logging.DEBUG):
+        bot._emit_shutdown_stage("event_delivery_failed", status="failed", level="error")
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(
+        "failed emitting shutdown stage event_delivery_failed (RuntimeError)" in message
+        for message in messages
+    )
+    assert all("shutdown-secret" not in message for message in messages)
+    assert all("private.invalid" not in message for message in messages)
+
+
+@pytest.mark.asyncio
+async def test_shutdown_gracefully_redacts_maintainer_and_session_failure_text(caplog):
+    bot = Passivbot.__new__(Passivbot)
+    bot._shutdown_in_progress = False
+    bot.stop_signal_received = False
+    events = []
+
+    def emit_event(event_type, *args, **kwargs):
+        events.append((event_type, kwargs))
+        return object()
+
+    def fail_maintainer_stop(*args, **kwargs):
+        raise RuntimeError("token=maintainer-secret https://private.invalid/stop")
+
+    class _FailingCloser:
+        def __init__(self, label):
+            self.label = label
+
+        async def close(self):
+            raise RuntimeError(
+                f"authorization={self.label}-secret https://private.invalid/close"
+            )
+
+    bot._emit_live_event = emit_event
+    bot._monitor_emit_stop = lambda *args, **kwargs: None
+    bot._monitor_flush_snapshot = AsyncMock()
+    bot.monitor_publisher = None
+    bot.stop_data_maintainers = fail_maintainer_stop
+    bot.maintainers = {}
+    bot.WS_ohlcvs_1m_tasks = {}
+    bot._execution_loop_task = None
+    bot._execution_loop_stopped = None
+    bot.ccp = _FailingCloser("private")
+    bot.cca = _FailingCloser("public")
+    bot._live_event_pipeline = None
+
+    with caplog.at_level(logging.DEBUG):
+        await bot.shutdown_gracefully()
+
+    failed_stages = {
+        kwargs["reason_code"]: kwargs["data"]
+        for event_type, kwargs in events
+        if event_type == EventTypes.BOT_SHUTDOWN_STAGE
+        and kwargs["status"] == "failed"
+    }
+    assert failed_stages == {
+        "maintainers_stop_failed": {
+            "error_type": "RuntimeError",
+            "stage": "maintainers_stop_failed",
+            "elapsed_s": failed_stages["maintainers_stop_failed"]["elapsed_s"],
+        },
+        "private_session_close_failed": {
+            "error_type": "RuntimeError",
+            "stage": "private_session_close_failed",
+            "elapsed_s": failed_stages["private_session_close_failed"]["elapsed_s"],
+        },
+        "public_session_close_failed": {
+            "error_type": "RuntimeError",
+            "stage": "public_session_close_failed",
+            "elapsed_s": failed_stages["public_session_close_failed"]["elapsed_s"],
+        },
+    }
+    retained = repr(events) + "\n" + "\n".join(
+        record.getMessage() for record in caplog.records
+    )
+    assert "maintainer-secret" not in retained
+    assert "private-secret" not in retained
+    assert "public-secret" not in retained
+    assert "private.invalid" not in retained
+
+
+@pytest.mark.asyncio
+async def test_shutdown_gracefully_redacts_await_failure_text(caplog):
+    bot = Passivbot.__new__(Passivbot)
+    bot._shutdown_in_progress = False
+    bot.stop_signal_received = False
+    events = []
+
+    def emit_event(event_type, *args, **kwargs):
+        events.append((event_type, kwargs))
+        return object()
+
+    class _InvalidMaintainer:
+        def __repr__(self):
+            return "<password=maintainer-await-secret>"
+
+    class _FailingStopEvent:
+        def __init__(self):
+            self.was_set = False
+
+        async def wait(self):
+            raise RuntimeError("signature=execution-wait-secret")
+
+        def set(self):
+            self.was_set = True
+
+    async def active_execution_loop():
+        await asyncio.sleep(3600)
+
+    execution_task = asyncio.create_task(active_execution_loop())
+    execution_stopped = _FailingStopEvent()
+
+    bot._emit_live_event = emit_event
+    bot._monitor_emit_stop = lambda *args, **kwargs: None
+    bot._monitor_flush_snapshot = AsyncMock()
+    bot.monitor_publisher = None
+    bot.stop_data_maintainers = lambda *args, **kwargs: None
+    bot.maintainers = {"invalid": _InvalidMaintainer()}
+    bot.WS_ohlcvs_1m_tasks = {}
+    bot._execution_loop_task = execution_task
+    bot._execution_loop_stopped = execution_stopped
+    bot.ccp = None
+    bot.cca = None
+    bot._live_event_pipeline = None
+
+    with caplog.at_level(logging.DEBUG):
+        await bot.shutdown_gracefully()
+
+    failed_stages = {
+        kwargs["reason_code"]: kwargs["data"]
+        for event_type, kwargs in events
+        if event_type == EventTypes.BOT_SHUTDOWN_STAGE
+        and kwargs["status"] == "failed"
+    }
+    assert failed_stages["maintainers_await_failed"]["error_type"] == "TypeError"
+    assert failed_stages["maintainers_await_failed"]["task_count"] == 1
+    assert failed_stages["execution_loop_wait_failed"]["error_type"] == "RuntimeError"
+    assert execution_stopped.was_set is True
+    retained = repr(events) + "\n" + "\n".join(
+        record.getMessage() for record in caplog.records
+    )
+    assert "maintainer-await-secret" not in retained
+    assert "execution-wait-secret" not in retained
+
+    execution_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await execution_task
+
+
 @pytest.mark.asyncio
 async def test_shutdown_gracefully_emits_slow_stage_after_threshold():
     bot = Passivbot.__new__(Passivbot)

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -5961,6 +5961,31 @@ def test_close_live_event_pipeline_is_best_effort_and_clears_reference():
     assert bot._live_event_pipeline is None
 
 
+def test_close_live_event_pipeline_redacts_failure_text_and_clears_reference(caplog):
+    import passivbot as pb_mod
+
+    class FakePipeline:
+        def close(self, timeout):
+            raise RuntimeError("token=pipeline-secret https://private.invalid/close")
+
+    class FakeBot:
+        _close_live_event_pipeline = pb_mod.Passivbot._close_live_event_pipeline
+
+        def __init__(self):
+            self._live_event_pipeline = FakePipeline()
+
+    bot = FakeBot()
+
+    with caplog.at_level(logging.WARNING):
+        assert bot._close_live_event_pipeline(timeout=1.25) is False
+
+    assert bot._live_event_pipeline is None
+    messages = [record.getMessage() for record in caplog.records]
+    assert "[monitor] live event pipeline close failed (RuntimeError)" in messages
+    assert all("pipeline-secret" not in message for message in messages)
+    assert all("private.invalid" not in message for message in messages)
+
+
 @pytest.mark.asyncio
 async def test_shutdown_gracefully_closes_event_pipeline_before_monitor_publisher():
     import passivbot as pb_mod


### PR DESCRIPTION
@codex

## Scope

- Category: runtime behavior / diagnostic retention.
- Replace arbitrary exception messages in shutdown-stage events and fallback logs with bounded exception types.
- Apply the same boundary to live-event pipeline close failures, per-maintainer cancellation failures, and the legacy cleanup helper.
- Record the completed PR #1347 VPS5 deployment evidence and advance the logging-overhaul handoff.

## Behavior boundary

Maintainer cancellation, execution-loop waits, CCXT session closing, shutdown timing, process control, event routing, and trading behavior are unchanged. This changes retained/projected diagnostics only. No Rust, strategy, order, risk, exchange-call, config, or dependency behavior changes.

## Validation

- Full Python test suite: passed (4,463 collected node IDs; expected skips and existing warnings only).
- Focused shutdown/maintainer/pipeline regressions: 13 passed after the final scope expansion.
- `python -m py_compile` for touched Python and test modules: passed.
- `cargo test --no-default-features`: 210 passed.
- `cargo check --tests`: passed.
- `cargo fmt --all -- --check`: passed.
- `check_ai_docs.py`: 0 errors, 1 existing documentation-size warning.
- Generated live-event registry check: current.
- `git diff --check`: passed.
- Exact-worktree Rust extension rebuilt and verified before the full Python suite; no Rust source changed.

## Review focus

- Confirm no exception value or traceback can cross the touched shutdown diagnostic surfaces.
- Confirm type extraction failures remain isolated and shutdown control flow is byte-for-byte equivalent apart from diagnostic formatting.
- Confirm payload consumers tolerate the intentional `error` to `error_type` change for failed `bot.shutdown.stage` records.

## VPS action

After merge: tracked-clean pull, then one bounded graceful restart/smoke of only the configured five VPS5 bot panes. Preserve `misc:0.0`; no broad process-pattern signals.

No authenticated exchange request, trading event, live process action, or fabricated state was used during author validation.