### PR TITLE
Allow compatible protective and ordinary closes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Non-panic protective reducers may now coexist with compatible ordinary grid, trailing, or
+  EMA-anchor closes for the same position. Passivbot still selects only one protective reducer,
+  keeps panic close exclusive, reserves reducer quantity before trimming ordinary closes, and caps
+  aggregate reduce-only quantity to the position in Rust planning and live reconciliation. The
+  realized-loss gate evaluates the selected reducer first. This restores simultaneous unstuck plus
+  trailing close behavior for `trailing_grid_v7` without a strategy-specific exemption.
+
 - `trailing_grid_v7` with zero entry cooldown now preserves v7's simultaneous grid-entry ladder
   when a later trailing leg uses retracement. Positive entry cooldowns and canonical
   `trailing_martingale` retracement staging remain unchanged.

--- a/docs/ai/features/strategy_runtime.md
+++ b/docs/ai/features/strategy_runtime.md
@@ -122,6 +122,21 @@ If `close.retracement_base_pct <= 0.0` and `close.threshold_we_weight == 0.0`, r
 have the same price. Rust intentionally emits one full-position close in that case; `close.qty_pct`
 is effectively moot because multiple same-price slices would be redundant.
 
+## Close Reducer Compatibility
+
+For each coin and position side, Rust selects at most one protective reducer per ideal-order batch.
+HSL panic is exclusive. TWEL/WEL exposure repair takes precedence over auto-unstuck, and the
+closest-to-fill candidate wins when competing reducers have the same priority.
+
+A selected non-panic reducer may coexist with ordinary grid, trailing, or EMA-anchor closes. Its
+quantity is reserved first; if aggregate close quantity would exceed the position, ordinary closes
+are trimmed furthest-from-fill first against the remaining quantity. Aggregate reduce-only quantity
+must never exceed the position after quantity-step and effective-minimum handling. The cumulative
+realized-loss gate applies after this allocation and evaluates the selected reducer before ordinary
+closes. Live reconciliation reapplies the same aggregate cap against current exchange position
+size, still trimming ordinary closes before the reducer if the position shrank after planning.
+This contract is shared by every strategy kind, including `trailing_grid_v7`.
+
 ## Source Of Truth
 
 Rust owns strategy dispatch and order behavior. If Python docs, adapters, or tests imply old

--- a/docs/config.bot.md
+++ b/docs/config.bot.md
@@ -260,6 +260,21 @@ create or cancel ordinary orders for them, and they do not count toward active
 slots, auto unstuck, or WEL/TWEL candidate selection. They still count toward
 same-side TWEL measurement and toward the TWEL entry-gate baseline.
 
+## Close Reducer Compatibility
+
+Passivbot selects at most one protective reducer for each coin+pside in one
+ideal-order batch. Panic close is exclusive. TWEL/WEL exposure repair takes
+precedence over auto-unstuck, and only one competing reducer survives.
+
+Ordinary strategy closes are independent reduction intent and may coexist with
+the selected non-panic reducer. The reducer quantity is reserved first; ordinary
+grid, trailing, or EMA-anchor closes are kept within the remaining position
+quantity and trimmed furthest-from-fill first if necessary. The aggregate remains
+reduce-only and capped to the position, and the realized-loss gate evaluates the
+selected reducer before ordinary closes in the resulting mixed close set. Live
+reconciliation preserves the same reducer-first reservation if the position
+shrinks between planning and order submission.
+
 ## Risk-Control Stack
 
 Risk controls are layered from ordinary position management to emergency

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -336,6 +336,11 @@ If a position is stuck, the bot uses profits from other positions to realize los
   - `if wallet_exposure / wallet_exposure_limit > unstuck_threshold: unstucking enabled`
   - Example: If a position size is `$500` and max allowed position size is `$1000`, the position is 50% full. If `unstuck_threshold = 0.45`, unstuck the position until its size is `$450`.
 
+One non-panic protective reducer (TWEL/WEL auto-reduce or auto-unstuck) may coexist with ordinary
+grid, trailing, or EMA-anchor closes for the same position. Passivbot reserves the reducer quantity
+first and caps ordinary closes to the remaining position quantity. Panic close remains exclusive,
+and competing protective reducers do not stack.
+
 ### Filter Parameters
 
 Forager coin selection now uses a two-stage model: coarse volume pruning, then weighted ranking across volume, EMA readiness, and volatility.

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -870,6 +870,10 @@ Remaining implementation details:
       Implemented: same-priority reducer pruning now has long/short regression
       coverage proving bid/ask-reachable reducers win before farther passive
       reducers.
+      Superseded by the shared close-allocation contract: current behavior still
+      selects one protective reducer, but a selected non-panic reducer may coexist
+      with ordinary closes whose aggregate quantity fits the position. Panic
+      remains exclusive, and ordinary closes are trimmed before reducer quantity.
 - [x] Contract docs batch: unstuck min-qty overshoot, inherited lookbacks,
       HSL/config-change risks, statelessness, `pnls_max_lookback_days`, and
       HSL-enabled startup warning.

--- a/docs/risk_management.md
+++ b/docs/risk_management.md
@@ -86,6 +86,14 @@ The global realized-loss gate remains separate. `live.max_realized_loss_pct`
 can still block a non-panic unstuck close if the projected fill would breach
 that realized-loss floor.
 
+Auto-unstuck may be emitted in the same ideal-order batch as compatible ordinary
+grid, trailing, or EMA-anchor closes for that position. Passivbot keeps only one
+protective reducer, reserves its quantity, and caps ordinary closes to the
+remaining position size. Panic close remains exclusive, and exposure reducers
+still take precedence over auto-unstuck. The realized-loss gate evaluates the
+selected reducer before ordinary closes, and live reconciliation reapplies the
+cap against the latest position without consuming reducer quantity first.
+
 Auto-unstuck allowance is reconstructed from the configured
 `live.pnls_max_lookback_days` fill/PnL window. Enabling auto-unstuck on an
 account with existing history can therefore inherit prior profits or losses

--- a/docs/v7_to_v8_migration.md
+++ b/docs/v7_to_v8_migration.md
@@ -28,6 +28,10 @@ ratio modes. V8 still uses its current shared execution, risk, forager, unstuck,
 runtime. Those surrounding systems can cause a migrated config to trade differently even when the
 strategy parameters are preserved exactly.
 
+The shared close-allocation contract permits a selected non-panic protective reducer and compatible
+ordinary strategy closes to execute in the same wave when their aggregate quantity fits the
+position. This includes `trailing_grid_v7`; it is not a strategy-specific exemption.
+
 ## Before migrating
 
 1. Keep the exact v7 release or commit used by the existing deployment.

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -7121,6 +7121,141 @@ mod tests {
     }
 
     #[test]
+    fn trailing_grid_v7_fills_unstuck_and_trailing_close_in_same_candle() {
+        let hlcvs = Array3::from_shape_vec(
+            (2, 1, 4),
+            vec![
+                100.0, 100.0, 100.0, 1.0, //
+                102.0, 99.0, 100.0, 1.0,
+            ],
+        )
+        .unwrap();
+        let btc_usd_prices = Array1::from_vec(vec![20_000.0, 20_000.0]);
+
+        let mut bp_pair = BotParamsPair::default();
+        bp_pair.long.n_positions = 1;
+        bp_pair.long.total_wallet_exposure_limit = 10.0;
+        bp_pair.long.wallet_exposure_limit = 10.0;
+        bp_pair.long.risk_wel_enforcer_enabled = false;
+        bp_pair.long.risk_twel_enforcer_enabled = false;
+        bp_pair.long.unstuck_enabled = true;
+        bp_pair.long.unstuck_ema_gating_enabled = false;
+        bp_pair.long.unstuck_close_pct = 0.0195;
+        bp_pair.long.unstuck_threshold = 0.9;
+        bp_pair.long.unstuck_loss_allowance_pct = 0.01;
+        bp_pair.short.n_positions = 0;
+        bp_pair.short.total_wallet_exposure_limit = 0.0;
+        bp_pair.short.wallet_exposure_limit = 0.0;
+
+        let strategy = TrailingGridV7Params {
+            ema_span_0: 1.0,
+            ema_span_1: 1.0,
+            entry: TrailingGridV7EntryParams::default(),
+            close: TrailingGridV7CloseParams {
+                trailing_grid_ratio: 1.0,
+                trailing_qty_pct: 0.2624,
+                trailing_retracement_pct: 0.005,
+                trailing_threshold_pct: 0.01,
+                ..Default::default()
+            },
+        };
+        let strategy_params = StrategyParamsPairValue {
+            long: serde_json::to_value(strategy).unwrap(),
+            short: serde_json::to_value(strategy).unwrap(),
+        };
+        let backtest_params = BacktestParams {
+            starting_balance: 1_000.0,
+            maker_fee: 0.0,
+            taker_fee: 0.00055,
+            coins: vec!["TEST".to_string()],
+            active_coin_indices: None,
+            first_timestamp_ms: 0,
+            requested_start_timestamp_ms: 0,
+            first_valid_indices: vec![0],
+            last_valid_indices: vec![1],
+            warmup_minutes: vec![0],
+            trade_start_indices: vec![0],
+            global_warmup_bars: 0,
+            btc_collateral_cap: 0.0,
+            btc_collateral_ltv_cap: None,
+            metrics_only: true,
+            skip_btc_analysis: false,
+            filter_by_min_effective_cost: false,
+            dynamic_wel_by_tradability: false,
+            hedge_mode: true,
+            max_realized_loss_pct: 1.0,
+            pnls_max_lookback_days: 30.0,
+            liquidation_threshold: 0.05,
+            equity_hard_stop_loss: EquityHardStopLossConfig::default(),
+            market_orders_allowed: false,
+            market_order_near_touch_threshold: 0.001,
+            market_order_slippage_pct: 0.0005,
+            forager_score_hysteresis_pct: 0.0,
+            candle_interval_minutes: 1,
+        };
+        let exchange = ExchangeParams {
+            qty_step: 0.01,
+            price_step: 0.01,
+            min_qty: 0.0,
+            min_cost: 0.0,
+            c_mult: 1.0,
+            maker_fee: 0.0,
+            taker_fee: 0.00055,
+        };
+
+        let mut bt = Backtest::new_with_strategy_params(
+            hlcvs.view(),
+            btc_usd_prices.view(),
+            crate::strategies::StrategyKind::TrailingGridV7,
+            vec![bp_pair],
+            vec![strategy_params],
+            vec![exchange],
+            &backtest_params,
+        );
+        bt.positions.long[0] = Position {
+            size: 95.6,
+            price: 100.0,
+        };
+        bt.trailing_prices.long[0] = TrailingPriceBundle {
+            min_since_open: 99.0,
+            max_since_min: 102.0,
+            max_since_open: 102.0,
+            min_since_max: 100.0,
+        };
+        bt.orchestrator_input_cache = None;
+        bt.update_open_orders_all(0);
+
+        let staged_closes = &bt.open_orders.long[0].closes;
+        assert_eq!(staged_closes.len(), 2);
+        assert!(staged_closes.iter().any(|order| {
+            order.order.order_type == OrderType::CloseUnstuckLong
+                && (order.order.qty + 1.95).abs() < 1e-12
+        }));
+        assert!(staged_closes.iter().any(|order| {
+            order.order.order_type == OrderType::CloseTrailingLong
+                && (order.order.qty + 26.24).abs() < 1e-12
+        }));
+
+        bt.check_for_fills(1);
+
+        let same_candle_closes: Vec<&Fill> = bt
+            .fills
+            .iter()
+            .filter(|fill| fill.index == 1 && fill.fill_qty < 0.0)
+            .collect();
+        assert_eq!(same_candle_closes.len(), 2);
+        assert!(same_candle_closes
+            .iter()
+            .any(|fill| fill.order_type == OrderType::CloseUnstuckLong));
+        assert!(same_candle_closes
+            .iter()
+            .any(|fill| fill.order_type == OrderType::CloseTrailingLong));
+        assert!(same_candle_closes
+            .iter()
+            .all(|fill| fill.timestamp_ms == 60_000));
+    }
+
+    #[test]
     fn hard_stop_rolling_peak_strategy_pnl_respects_pnls_max_lookback_days() {
         let hlcvs = Array3::from_shape_vec((2, 1, 4), vec![1.0; 2 * 1 * 4]).unwrap();
         let btc_usd_prices = Array1::from_vec(vec![20_000.0, 20_000.0]);

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -617,7 +617,33 @@ mod core {
         }
     }
 
-    fn prune_lower_priority_closes(
+    fn close_reducer_reachability_cmp(
+        a: &IdealOrder,
+        b: &IdealOrder,
+        ob: &OrderBook,
+    ) -> std::cmp::Ordering {
+        let da = order_price_diff_strict(a, ob);
+        let db = order_price_diff_strict(b, ob);
+        da.partial_cmp(&db)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.order_type.id().cmp(&b.order_type.id()))
+            .then_with(|| {
+                a.price
+                    .partial_cmp(&b.price)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| {
+                a.qty
+                    .partial_cmp(&b.qty)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+    }
+
+    fn is_protective_close_reducer(order_type: OrderType, pside: PositionSide) -> bool {
+        matches!(close_reducer_priority(order_type, pside), Some(0..=2))
+    }
+
+    fn prune_competing_close_reducers(
         orders: &mut Vec<IdealOrder>,
         pside: PositionSide,
         ob: &OrderBook,
@@ -628,27 +654,19 @@ mod core {
             .min();
         if let Some(priority) = highest {
             if priority < 3 {
+                let selected_reducer = orders
+                    .iter()
+                    .filter(|order| {
+                        close_reducer_priority(order.order_type, pside) == Some(priority)
+                    })
+                    .min_by(|a, b| close_reducer_reachability_cmp(a, b, ob))
+                    .cloned();
                 orders.retain(|order| {
-                    close_reducer_priority(order.order_type, pside).unwrap_or(3) == priority
+                    priority > 0 && close_reducer_priority(order.order_type, pside) == Some(3)
                 });
-                orders.sort_by(|a, b| {
-                    let da = order_price_diff_strict(a, ob);
-                    let db = order_price_diff_strict(b, ob);
-                    da.partial_cmp(&db)
-                        .unwrap_or(std::cmp::Ordering::Equal)
-                        .then_with(|| a.order_type.id().cmp(&b.order_type.id()))
-                        .then_with(|| {
-                            a.price
-                                .partial_cmp(&b.price)
-                                .unwrap_or(std::cmp::Ordering::Equal)
-                        })
-                        .then_with(|| {
-                            a.qty
-                                .partial_cmp(&b.qty)
-                                .unwrap_or(std::cmp::Ordering::Equal)
-                        })
-                });
-                orders.truncate(1);
+                if let Some(reducer) = selected_reducer {
+                    orders.push(reducer);
+                }
             }
         }
     }
@@ -1198,18 +1216,14 @@ mod core {
         // If the position itself is below effective min qty, collapse to a single close which
         // closes the entire position.
         if allow_below_min {
-            // pick closest-to-fill existing close if present; otherwise keep first
+            // Preserve a protective reducer when one is present. Otherwise pick the
+            // closest-to-fill ordinary close.
             closes.sort_by(|a, b| {
-                let da = order_price_diff_strict(a, ob);
-                let db = order_price_diff_strict(b, ob);
-                da.partial_cmp(&db)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-                    .then_with(|| a.order_type.id().cmp(&b.order_type.id()))
-                    .then_with(|| {
-                        a.price
-                            .partial_cmp(&b.price)
-                            .unwrap_or(std::cmp::Ordering::Equal)
-                    })
+                let a_reducer = is_protective_close_reducer(a.order_type, pside);
+                let b_reducer = is_protective_close_reducer(b.order_type, pside);
+                b_reducer
+                    .cmp(&a_reducer)
+                    .then_with(|| close_reducer_reachability_cmp(a, b, ob))
             });
             let mut keep = closes[0].clone();
             keep.qty = match pside {
@@ -1257,22 +1271,18 @@ mod core {
             // remainder into the least-likely-to-fill close matches the existing “trim furthest
             // first” heuristic and aligns legacy/orchestrator distribution.
             closes.sort_by(|a, b| {
-                let da = order_price_diff_strict(a, ob);
-                let db = order_price_diff_strict(b, ob);
-                da.partial_cmp(&db)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-                    .then_with(|| a.order_type.id().cmp(&b.order_type.id()))
-                    .then_with(|| {
-                        a.price
-                            .partial_cmp(&b.price)
-                            .unwrap_or(std::cmp::Ordering::Equal)
-                    })
+                let a_reducer = is_protective_close_reducer(a.order_type, pside);
+                let b_reducer = is_protective_close_reducer(b.order_type, pside);
+                b_reducer
+                    .cmp(&a_reducer)
+                    .then_with(|| close_reducer_reachability_cmp(a, b, ob))
             });
             if closes.is_empty() {
                 return;
             }
             // Set the selected close to close exactly the remaining position after other closes.
-            // After sorting by diff asc, the selected is the last (furthest).
+            // A protective reducer sorts first, so an ordinary close absorbs the remainder when
+            // one exists; otherwise the furthest reducer is used.
             let mut sum_other = 0.0_f64;
             if closes.len() > 1 {
                 for o in closes.iter().take(closes.len() - 1) {
@@ -1312,11 +1322,17 @@ mod core {
             return;
         }
 
-        // Sort furthest-from-fill first.
+        // Trim ordinary closes before a protective reducer. Within each class,
+        // trim furthest-from-fill first.
         closes.sort_by(|a, b| {
+            let a_reducer = is_protective_close_reducer(a.order_type, pside);
+            let b_reducer = is_protective_close_reducer(b.order_type, pside);
             let da = order_price_diff_strict(a, ob);
             let db = order_price_diff_strict(b, ob);
-            match db.partial_cmp(&da).unwrap_or(std::cmp::Ordering::Equal) {
+            match a_reducer
+                .cmp(&b_reducer)
+                .then_with(|| db.partial_cmp(&da).unwrap_or(std::cmp::Ordering::Equal))
+            {
                 std::cmp::Ordering::Equal => a
                     .order_type
                     .id()
@@ -1511,6 +1527,11 @@ mod core {
                 Some(sym) => &sym.exchange,
                 None => continue,
             };
+            // Evaluate the selected protective reducer before ordinary closes so an ordinary
+            // close cannot consume the realized-loss allowance reserved for risk reduction.
+            s.closes.sort_by_key(|order| {
+                !is_protective_close_reducer(order.order_type, PositionSide::Long)
+            });
             let mut kept: Vec<IdealOrder> = Vec::with_capacity(s.closes.len());
             for order in s.closes.drain(..) {
                 if !is_close_order_type(order.order_type)
@@ -1561,6 +1582,9 @@ mod core {
                 Some(sym) => &sym.exchange,
                 None => continue,
             };
+            s.closes.sort_by_key(|order| {
+                !is_protective_close_reducer(order.order_type, PositionSide::Short)
+            });
             let mut kept: Vec<IdealOrder> = Vec::with_capacity(s.closes.len());
             for order in s.closes.drain(..) {
                 if !is_close_order_type(order.order_type)
@@ -3499,10 +3523,11 @@ mod core {
         let twel_candidate_count_long = twel_selected_long.len();
         let twel_candidate_count_short = twel_selected_short.len();
 
-        // Trim closes per symbol to position size (furthest-first).
+        // Select one protective reducer per symbol, preserve compatible ordinary closes, and cap
+        // their aggregate to position size with reducer quantity reserved first.
         for s in per_long.iter_mut().filter_map(|v| v.as_mut()) {
             let sym = &input.symbols[s.symbol_idx];
-            prune_lower_priority_closes(&mut s.closes, PositionSide::Long, &sym.order_book);
+            prune_competing_close_reducers(&mut s.closes, PositionSide::Long, &sym.order_book);
             trim_closes_to_position(
                 PositionSide::Long,
                 &mut s.closes,
@@ -3513,7 +3538,7 @@ mod core {
         }
         for s in per_short.iter_mut().filter_map(|v| v.as_mut()) {
             let sym = &input.symbols[s.symbol_idx];
-            prune_lower_priority_closes(&mut s.closes, PositionSide::Short, &sym.order_book);
+            prune_competing_close_reducers(&mut s.closes, PositionSide::Short, &sym.order_book);
             trim_closes_to_position(
                 PositionSide::Short,
                 &mut s.closes,
@@ -4259,7 +4284,7 @@ mod core {
         }
 
         #[test]
-        fn close_pruning_keeps_single_closest_same_priority_reducer() {
+        fn close_reducer_selection_keeps_single_closest_reducer_and_ordinary_close() {
             let order_book = OrderBook {
                 bid: 100.0,
                 ask: 101.0,
@@ -4279,13 +4304,25 @@ mod core {
                     price: 101.1,
                     order_type: OrderType::CloseAutoReduceTwelLong,
                 },
+                IdealOrder {
+                    symbol_idx: 0,
+                    pside: PositionSide::Long,
+                    qty: -0.2,
+                    price: 101.5,
+                    order_type: OrderType::CloseGridLong,
+                },
             ];
 
-            prune_lower_priority_closes(&mut closes, PositionSide::Long, &order_book);
+            prune_competing_close_reducers(&mut closes, PositionSide::Long, &order_book);
 
-            assert_eq!(closes.len(), 1);
-            assert_eq!(closes[0].order_type, OrderType::CloseAutoReduceTwelLong);
-            assert!((closes[0].price - 101.1).abs() < 1e-12);
+            assert_eq!(closes.len(), 2);
+            assert!(closes.iter().any(|order| {
+                order.order_type == OrderType::CloseAutoReduceTwelLong
+                    && (order.price - 101.1).abs() < 1e-12
+            }));
+            assert!(closes
+                .iter()
+                .any(|order| order.order_type == OrderType::CloseGridLong));
         }
 
         #[test]
@@ -4311,7 +4348,7 @@ mod core {
                 },
             ];
 
-            prune_lower_priority_closes(&mut closes, PositionSide::Long, &order_book);
+            prune_competing_close_reducers(&mut closes, PositionSide::Long, &order_book);
 
             assert_eq!(closes.len(), 1);
             assert_eq!(closes[0].order_type, OrderType::CloseAutoReduceWelLong);
@@ -4341,7 +4378,7 @@ mod core {
                 },
             ];
 
-            prune_lower_priority_closes(&mut closes, PositionSide::Short, &order_book);
+            prune_competing_close_reducers(&mut closes, PositionSide::Short, &order_book);
 
             assert_eq!(closes.len(), 1);
             assert_eq!(closes[0].order_type, OrderType::CloseAutoReduceWelShort);
@@ -4378,9 +4415,79 @@ mod core {
                 },
             ];
 
-            prune_lower_priority_closes(&mut closes, PositionSide::Long, &order_book);
+            prune_competing_close_reducers(&mut closes, PositionSide::Long, &order_book);
 
             assert_eq!(closes.len(), 3);
+        }
+
+        #[test]
+        fn close_reducer_selection_preserves_ordinary_closes_with_unstuck() {
+            let order_book = OrderBook {
+                bid: 100.0,
+                ask: 101.0,
+            };
+            let mut closes = vec![
+                IdealOrder {
+                    symbol_idx: 0,
+                    pside: PositionSide::Long,
+                    qty: -1.95,
+                    price: 100.0,
+                    order_type: OrderType::CloseUnstuckLong,
+                },
+                IdealOrder {
+                    symbol_idx: 0,
+                    pside: PositionSide::Long,
+                    qty: -26.24,
+                    price: 100.5,
+                    order_type: OrderType::CloseTrailingLong,
+                },
+            ];
+
+            prune_competing_close_reducers(&mut closes, PositionSide::Long, &order_book);
+
+            assert_eq!(closes.len(), 2);
+            assert!(closes
+                .iter()
+                .any(|order| order.order_type == OrderType::CloseUnstuckLong));
+            assert!(closes
+                .iter()
+                .any(|order| order.order_type == OrderType::CloseTrailingLong));
+        }
+
+        #[test]
+        fn close_reducer_selection_keeps_panic_exclusive() {
+            let order_book = OrderBook {
+                bid: 100.0,
+                ask: 101.0,
+            };
+            let mut closes = vec![
+                IdealOrder {
+                    symbol_idx: 0,
+                    pside: PositionSide::Long,
+                    qty: -10.0,
+                    price: 100.0,
+                    order_type: OrderType::ClosePanicLong,
+                },
+                IdealOrder {
+                    symbol_idx: 0,
+                    pside: PositionSide::Long,
+                    qty: -1.0,
+                    price: 101.0,
+                    order_type: OrderType::CloseUnstuckLong,
+                },
+                IdealOrder {
+                    symbol_idx: 0,
+                    pside: PositionSide::Long,
+                    qty: -2.0,
+                    price: 102.0,
+                    order_type: OrderType::CloseTrailingLong,
+                },
+            ];
+
+            prune_competing_close_reducers(&mut closes, PositionSide::Long, &order_book);
+
+            assert_eq!(closes.len(), 1);
+            assert_eq!(closes[0].order_type, OrderType::ClosePanicLong);
         }
 
         #[test]
@@ -5204,6 +5311,52 @@ mod core {
                 "expected -0.5, got {}",
                 trimmed.qty
             );
+        }
+
+        #[test]
+        fn trim_closes_reserves_protective_reducer_before_ordinary_close() {
+            let ob = OrderBook {
+                bid: 100.0,
+                ask: 100.0,
+            };
+            let exchange = ExchangeParams {
+                qty_step: 0.1,
+                price_step: 0.1,
+                min_qty: 0.0,
+                min_cost: 0.0,
+                c_mult: 1.0,
+                ..Default::default()
+            };
+            let mut closes = vec![
+                IdealOrder {
+                    symbol_idx: 0,
+                    pside: PositionSide::Long,
+                    qty: -1.0,
+                    price: 100.5,
+                    order_type: OrderType::CloseTrailingLong,
+                },
+                IdealOrder {
+                    symbol_idx: 0,
+                    pside: PositionSide::Long,
+                    qty: -1.0,
+                    price: 102.0,
+                    order_type: OrderType::CloseUnstuckLong,
+                },
+            ];
+
+            trim_closes_to_position(PositionSide::Long, &mut closes, 1.5, &ob, &exchange);
+
+            let reducer = closes
+                .iter()
+                .find(|order| order.order_type == OrderType::CloseUnstuckLong)
+                .unwrap();
+            let ordinary = closes
+                .iter()
+                .find(|order| order.order_type == OrderType::CloseTrailingLong)
+                .unwrap();
+            assert!((reducer.qty + 1.0).abs() < 1e-9);
+            assert!((ordinary.qty + 0.5).abs() < 1e-9);
+            assert!((closes.iter().map(|order| order.qty.abs()).sum::<f64>() - 1.5).abs() < 1e-9);
         }
 
         #[test]

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -1522,113 +1522,65 @@ mod core {
         }
         let mut simulated_balance = balance_raw;
 
-        for s in per_long.iter_mut().filter_map(|v| v.as_mut()) {
-            let exchange = match input.symbols.get(s.symbol_idx) {
-                Some(sym) => &sym.exchange,
-                None => continue,
+        let mut gate_pass =
+            |per_side: &mut [Option<PerSymbolOrders>], pside, reducers_only: bool| {
+                for s in per_side.iter_mut().filter_map(|v| v.as_mut()) {
+                    let symbol = match input.symbols.get(s.symbol_idx) {
+                        Some(symbol) => symbol,
+                        None => continue,
+                    };
+                    let mut kept: Vec<IdealOrder> = Vec::with_capacity(s.closes.len());
+                    for order in s.closes.drain(..) {
+                        let is_gateable = is_close_order_type(order.order_type)
+                            && !is_panic_close_order_type(order.order_type);
+                        let is_reducer = is_protective_close_reducer(order.order_type, pside);
+                        if !is_gateable || is_reducer != reducers_only {
+                            kept.push(order);
+                            continue;
+                        }
+                        let Some(projected_pnl) = projected_close_pnl(
+                            &order,
+                            &s.pos,
+                            &symbol.exchange,
+                            &input.global,
+                            &symbol.order_book,
+                        ) else {
+                            kept.push(order);
+                            continue;
+                        };
+                        let balance_before = simulated_balance;
+                        let projected_balance_after = balance_before + projected_pnl;
+                        if projected_pnl < 0.0 && projected_balance_after < balance_floor - 1e-12 {
+                            diagnostics.loss_gate_blocks.push(LossGateBlock {
+                                symbol_idx: order.symbol_idx,
+                                pside: order.pside,
+                                order_type: order.order_type,
+                                qty: order.qty,
+                                price: order.price,
+                                projected_pnl,
+                                balance_before,
+                                projected_balance_after,
+                                balance_peak,
+                                balance_floor,
+                                max_realized_loss_pct: pct,
+                            });
+                            continue;
+                        }
+                        if projected_pnl < 0.0 {
+                            simulated_balance = projected_balance_after;
+                        }
+                        kept.push(order);
+                    }
+                    s.closes = kept;
+                }
             };
-            // Evaluate the selected protective reducer before ordinary closes so an ordinary
-            // close cannot consume the realized-loss allowance reserved for risk reduction.
-            s.closes.sort_by_key(|order| {
-                !is_protective_close_reducer(order.order_type, PositionSide::Long)
-            });
-            let mut kept: Vec<IdealOrder> = Vec::with_capacity(s.closes.len());
-            for order in s.closes.drain(..) {
-                if !is_close_order_type(order.order_type)
-                    || is_panic_close_order_type(order.order_type)
-                {
-                    kept.push(order);
-                    continue;
-                }
-                let symbol = &input.symbols[s.symbol_idx];
-                let Some(projected_pnl) = projected_close_pnl(
-                    &order,
-                    &s.pos,
-                    exchange,
-                    &input.global,
-                    &symbol.order_book,
-                ) else {
-                    kept.push(order);
-                    continue;
-                };
-                let balance_before = simulated_balance;
-                let projected_balance_after = balance_before + projected_pnl;
-                if projected_pnl < 0.0 && projected_balance_after < balance_floor - 1e-12 {
-                    diagnostics.loss_gate_blocks.push(LossGateBlock {
-                        symbol_idx: order.symbol_idx,
-                        pside: order.pside,
-                        order_type: order.order_type,
-                        qty: order.qty,
-                        price: order.price,
-                        projected_pnl,
-                        balance_before,
-                        projected_balance_after,
-                        balance_peak,
-                        balance_floor,
-                        max_realized_loss_pct: pct,
-                    });
-                    continue;
-                }
-                if projected_pnl < 0.0 {
-                    simulated_balance = projected_balance_after;
-                }
-                kept.push(order);
-            }
-            s.closes = kept;
-        }
 
-        for s in per_short.iter_mut().filter_map(|v| v.as_mut()) {
-            let exchange = match input.symbols.get(s.symbol_idx) {
-                Some(sym) => &sym.exchange,
-                None => continue,
-            };
-            s.closes.sort_by_key(|order| {
-                !is_protective_close_reducer(order.order_type, PositionSide::Short)
-            });
-            let mut kept: Vec<IdealOrder> = Vec::with_capacity(s.closes.len());
-            for order in s.closes.drain(..) {
-                if !is_close_order_type(order.order_type)
-                    || is_panic_close_order_type(order.order_type)
-                {
-                    kept.push(order);
-                    continue;
-                }
-                let symbol = &input.symbols[s.symbol_idx];
-                let Some(projected_pnl) = projected_close_pnl(
-                    &order,
-                    &s.pos,
-                    exchange,
-                    &input.global,
-                    &symbol.order_book,
-                ) else {
-                    kept.push(order);
-                    continue;
-                };
-                let balance_before = simulated_balance;
-                let projected_balance_after = balance_before + projected_pnl;
-                if projected_pnl < 0.0 && projected_balance_after < balance_floor - 1e-12 {
-                    diagnostics.loss_gate_blocks.push(LossGateBlock {
-                        symbol_idx: order.symbol_idx,
-                        pside: order.pside,
-                        order_type: order.order_type,
-                        qty: order.qty,
-                        price: order.price,
-                        projected_pnl,
-                        balance_before,
-                        projected_balance_after,
-                        balance_peak,
-                        balance_floor,
-                        max_realized_loss_pct: pct,
-                    });
-                    continue;
-                }
-                if projected_pnl < 0.0 {
-                    simulated_balance = projected_balance_after;
-                }
-                kept.push(order);
-            }
-            s.closes = kept;
-        }
+        // The simulated balance is shared by the whole batch, so run every selected protective
+        // reducer before allowing any ordinary close to consume realized-loss allowance.
+        gate_pass(per_long, PositionSide::Long, true);
+        gate_pass(per_short, PositionSide::Short, true);
+        gate_pass(per_long, PositionSide::Long, false);
+        gate_pass(per_short, PositionSide::Short, false);
     }
 
     fn twel_repair_target(bot: &BotParams) -> Option<f64> {
@@ -5986,6 +5938,102 @@ mod core {
             assert_eq!(diagnostics.loss_gate_blocks.len(), 1);
             let block = &diagnostics.loss_gate_blocks[0];
             assert_eq!(block.symbol_idx, 1);
+            assert!((block.balance_before - 940.0).abs() < 1e-12);
+            assert!((block.projected_balance_after - 880.0).abs() < 1e-12);
+            assert!((block.balance_floor - 900.0).abs() < 1e-12);
+        }
+
+        #[test]
+        fn realized_loss_gate_prioritizes_reducers_across_symbols() {
+            let mut sym0 = make_basic_symbol(0);
+            sym0.order_book = OrderBook {
+                bid: 94.0,
+                ask: 94.0,
+            };
+            sym0.exchange.maker_fee = 0.0;
+            sym0.long.position = Position {
+                size: 10.0,
+                price: 100.0,
+            };
+
+            let mut sym1 = make_basic_symbol(1);
+            sym1.order_book = sym0.order_book.clone();
+            sym1.exchange.maker_fee = 0.0;
+            sym1.long.position = sym0.long.position;
+
+            let input = OrchestratorInput {
+                timestamp_ms: 0,
+                balance: 1000.0,
+                balance_raw: 1000.0,
+                global: OrchestratorGlobal {
+                    filter_by_min_effective_cost: false,
+                    market_orders_allowed: false,
+                    market_order_near_touch_threshold: 0.001,
+                    market_order_slippage_pct: 0.0,
+                    panic_close_market: false,
+                    auto_unstuck_allowed: Some(true),
+                    unstuck_allowance_long: 0.0,
+                    unstuck_allowance_short: 0.0,
+                    max_realized_loss_pct: 0.1,
+                    realized_pnl_cumsum_max: 0.0,
+                    realized_pnl_cumsum_last: 0.0,
+                    sort_global: true,
+                    global_bot_params: BotParamsPair::default(),
+                    hedge_mode: true,
+                    strategy_kind: StrategyKind::TrailingMartingale,
+                },
+                symbols: vec![sym0.clone(), sym1.clone()],
+                peek_hints: None,
+                forager_hysteresis: None,
+            };
+            let mut per_long = vec![
+                Some(PerSymbolOrders {
+                    symbol_idx: 0,
+                    entries: vec![],
+                    closes: vec![IdealOrder {
+                        symbol_idx: 0,
+                        pside: PositionSide::Long,
+                        qty: -10.0,
+                        price: 94.0,
+                        order_type: OrderType::CloseGridLong,
+                    }],
+                    pos: sym0.long.position,
+                    mode: TradingMode::Normal,
+                }),
+                Some(PerSymbolOrders {
+                    symbol_idx: 1,
+                    entries: vec![],
+                    closes: vec![IdealOrder {
+                        symbol_idx: 1,
+                        pside: PositionSide::Long,
+                        qty: -10.0,
+                        price: 94.0,
+                        order_type: OrderType::CloseUnstuckLong,
+                    }],
+                    pos: sym1.long.position,
+                    mode: TradingMode::Normal,
+                }),
+            ];
+            let mut per_short: Vec<Option<PerSymbolOrders>> = vec![None, None];
+            let mut diagnostics = OrchestratorDiagnostics::default();
+
+            gate_lossy_closes_by_peak_balance(
+                &input,
+                &mut per_long,
+                &mut per_short,
+                &mut diagnostics,
+            );
+
+            assert!(per_long[0].as_ref().unwrap().closes.is_empty());
+            assert_eq!(per_long[1].as_ref().unwrap().closes.len(), 1);
+            assert_eq!(
+                per_long[1].as_ref().unwrap().closes[0].order_type,
+                OrderType::CloseUnstuckLong
+            );
+            assert_eq!(diagnostics.loss_gate_blocks.len(), 1);
+            let block = &diagnostics.loss_gate_blocks[0];
+            assert_eq!(block.symbol_idx, 0);
+            assert_eq!(block.order_type, OrderType::CloseGridLong);
             assert!((block.balance_before - 940.0).abs() < 1e-12);
             assert!((block.projected_balance_after - 880.0).abs() < 1e-12);
             assert!((block.balance_floor - 900.0).abs() < 1e-12);

--- a/src/live/reconciler.py
+++ b/src/live/reconciler.py
@@ -1307,6 +1307,21 @@ def _reduce_only_order_family(order: dict) -> tuple[str, str] | None:
     return pside, family
 
 
+_PROTECTIVE_REDUCE_ONLY_FAMILIES = frozenset(
+    {
+        "close_panic",
+        "close_auto_reduce_twel",
+        "close_auto_reduce_wel",
+        "close_unstuck",
+    }
+)
+
+
+def _order_is_protective_reducer(order: dict) -> bool:
+    family = _reduce_only_order_family(order)
+    return family is not None and family[1] in _PROTECTIVE_REDUCE_ONLY_FAMILIES
+
+
 def _trailing_unavailable_reasons(bot, symbol: str) -> set[str]:
     by_symbol = getattr(bot, "_orchestrator_trailing_unavailable_reasons", {}) or {}
     reasons = by_symbol.get(symbol, []) if isinstance(by_symbol, dict) else []
@@ -1735,10 +1750,16 @@ def finalize_reduce_only_orders(
             if total <= pos_size_abs + 1e-12:
                 continue
             excess = total - pos_size_abs
+            # Rust already caps a planned wave, but the position may shrink before live
+            # reconciliation. Preserve the selected protective reducer and trim ordinary closes
+            # first when this final exchange-state cap has to intervene.
             ro_sorted = sorted(
                 ro,
-                key=lambda o: order_market_diff(
-                    o.get("side", ""), float(o.get("price", 0.0)), market_price
+                key=lambda o: (
+                    0 if _order_is_protective_reducer(o) else 1,
+                    order_market_diff(
+                        o.get("side", ""), float(o.get("price", 0.0)), market_price
+                    ),
                 ),
                 reverse=True,
             )

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -111,7 +111,7 @@ def adaptive_strategy_params(**overrides):
     return base
 
 
-def trailing_grid_v7_strategy_params(**entry_overrides):
+def trailing_grid_v7_strategy_params(*, close_overrides=None, **entry_overrides):
     entry = {
         "grid_double_down_factor": 1.0,
         "grid_spacing_pct": 0.02,
@@ -130,19 +130,21 @@ def trailing_grid_v7_strategy_params(**entry_overrides):
         "volatility_ema_span_hours": 1.0,
     }
     entry.update(entry_overrides)
+    close = {
+        "grid_markup_start": 0.01,
+        "grid_markup_end": 0.01,
+        "grid_qty_pct": 1.0,
+        "trailing_grid_ratio": 0.0,
+        "trailing_qty_pct": 1.0,
+        "trailing_retracement_pct": 0.0,
+        "trailing_threshold_pct": 0.0,
+    }
+    close.update(close_overrides or {})
     return {
         "ema_span_0": 10.0,
         "ema_span_1": 20.0,
         "entry": entry,
-        "close": {
-            "grid_markup_start": 0.01,
-            "grid_markup_end": 0.01,
-            "grid_qty_pct": 1.0,
-            "trailing_grid_ratio": 0.0,
-            "trailing_qty_pct": 1.0,
-            "trailing_retracement_pct": 0.0,
-            "trailing_threshold_pct": 0.0,
-        },
+        "close": close,
     }
 
 
@@ -1905,7 +1907,7 @@ def test_json_output_is_deterministic():
     assert out1 == out2
 
 
-def test_unstuck_takes_priority_over_close_grid_and_is_capped():
+def test_unstuck_and_ordinary_close_coexist_and_are_capped():
     import passivbot_rust as pbr
 
     balance = 1_000.0
@@ -1941,7 +1943,7 @@ def test_unstuck_takes_priority_over_close_grid_and_is_capped():
     out = compute(pbr, inp)
     order_types = [o["order_type"] for o in out["orders"]]
     assert "close_unstuck_long" in order_types
-    assert "close_grid_long" not in order_types
+    assert "close_grid_long" in order_types
 
     closes = [
         o
@@ -1950,6 +1952,63 @@ def test_unstuck_takes_priority_over_close_grid_and_is_capped():
     ]
     total_close_qty = -sum(o["qty"] for o in closes if o["qty"] < 0.0)
     assert total_close_qty <= 10.0 + 1e-9
+
+
+def test_trailing_grid_v7_emits_compatible_unstuck_and_trailing_closes_together():
+    import passivbot_rust as pbr
+
+    long_bp = {
+        "wallet_exposure_limit": 10.0,
+        "total_wallet_exposure_limit": 10.0,
+        "risk_wel_enforcer_enabled": False,
+        "risk_twel_enforcer_enabled": False,
+        "unstuck_ema_gating_enabled": False,
+        "unstuck_close_pct": 0.0195,
+        "unstuck_threshold": 0.9,
+        "unstuck_loss_allowance_pct": 0.01,
+    }
+    strategy = trailing_grid_v7_strategy_params(
+        close_overrides={
+            "trailing_grid_ratio": 1.0,
+            "trailing_qty_pct": 0.2624,
+            "trailing_retracement_pct": 0.005,
+            "trailing_threshold_pct": 0.01,
+        }
+    )
+    sym = make_symbol(
+        0,
+        bid=100.0,
+        ask=100.0,
+        long_pos_size=95.6,
+        long_pos_price=100.0,
+        long_bp=long_bp,
+        long_strategy=strategy,
+        short_strategy=strategy,
+    )
+    sym["long"]["trailing"] = {
+        "min_since_open": 99.0,
+        "max_since_min": 102.0,
+        "max_since_open": 102.0,
+        "min_since_max": 100.0,
+    }
+    inp = make_input(
+        balance=1_000.0,
+        strategy_kind="trailing_grid_v7",
+        global_bp=bot_params_pair(long_overrides=long_bp),
+        symbols=[sym],
+    )
+    inp["global"]["unstuck_allowance_long"] = 1e9
+
+    out = compute(pbr, inp)
+    closes = {
+        order["order_type"]: order
+        for order in out["orders"]
+        if order["pside"] == "long" and order["qty"] < 0.0
+    }
+
+    assert closes["close_unstuck_long"]["qty"] == pytest.approx(-1.95)
+    assert closes["close_trailing_long"]["qty"] == pytest.approx(-26.24)
+    assert sum(abs(order["qty"]) for order in closes.values()) <= 95.6 + 1e-9
 
 
 def test_unstuck_uses_symbol_loss_allowance_pct_for_loss_cap():
@@ -2518,7 +2577,12 @@ def test_wel_auto_reduce_takes_priority_over_unstuck_for_same_position():
 
     assert "close_auto_reduce_wel_long" in order_types
     assert "close_unstuck_long" not in order_types
-    assert "close_grid_long" not in order_types
+    assert "close_grid_long" in order_types
+    assert sum(
+        abs(o["qty"])
+        for o in out["orders"]
+        if o["pside"] == "long" and o["qty"] < 0.0
+    ) <= 6.0 + 1e-9
 
 
 def test_wel_auto_reduce_takes_priority_over_short_unstuck_for_same_position():
@@ -2552,7 +2616,12 @@ def test_wel_auto_reduce_takes_priority_over_short_unstuck_for_same_position():
 
     assert "close_auto_reduce_wel_short" in order_types
     assert "close_unstuck_short" not in order_types
-    assert "close_grid_short" not in order_types
+    assert "close_grid_short" in order_types
+    assert sum(
+        abs(o["qty"])
+        for o in out["orders"]
+        if o["pside"] == "short" and o["qty"] > 0.0
+    ) <= 6.0 + 1e-9
 
 
 def test_twel_auto_reduce_takes_priority_over_unstuck_for_same_position():
@@ -2587,7 +2656,12 @@ def test_twel_auto_reduce_takes_priority_over_unstuck_for_same_position():
 
     assert "close_auto_reduce_twel_long" in order_types
     assert "close_unstuck_long" not in order_types
-    assert "close_grid_long" not in order_types
+    assert "close_grid_long" in order_types
+    assert sum(
+        abs(o["qty"])
+        for o in out["orders"]
+        if o["pside"] == "long" and o["qty"] < 0.0
+    ) <= 6.0 + 1e-9
 
 
 def test_twel_auto_reduce_takes_priority_over_short_unstuck_for_same_position():
@@ -2622,7 +2696,12 @@ def test_twel_auto_reduce_takes_priority_over_short_unstuck_for_same_position():
 
     assert "close_auto_reduce_twel_short" in order_types
     assert "close_unstuck_short" not in order_types
-    assert "close_grid_short" not in order_types
+    assert "close_grid_short" in order_types
+    assert sum(
+        abs(o["qty"])
+        for o in out["orders"]
+        if o["pside"] == "short" and o["qty"] > 0.0
+    ) <= 6.0 + 1e-9
 
 
 def test_twel_auto_reduce_includes_managed_modes_and_excludes_manual_panic():

--- a/tests/test_order_orchestration.py
+++ b/tests/test_order_orchestration.py
@@ -100,6 +100,78 @@ def _make_order(
     }
 
 
+def test_finalize_reduce_only_orders_keeps_compatible_unstuck_and_trailing_close():
+    symbol = "BTC/USDT"
+    bot = OrchestrationBot({symbol: 100.0})
+    bot.register_symbol(symbol)
+    bot.positions[symbol]["long"] = {"size": 95.60, "price": 100.0}
+    orders = {
+        symbol: [
+            _make_order(
+                symbol,
+                "sell",
+                "long",
+                1.95,
+                99.0,
+                "close_unstuck_long",
+                reduce_only=True,
+            ),
+            _make_order(
+                symbol,
+                "sell",
+                "long",
+                26.24,
+                101.0,
+                "close_trailing_long",
+                reduce_only=True,
+            ),
+        ]
+    }
+
+    finalized = bot._finalize_reduce_only_orders(orders, {symbol: 100.0})
+
+    assert [(order["pb_order_type"], order["qty"]) for order in finalized[symbol]] == [
+        ("close_unstuck_long", 1.95),
+        ("close_trailing_long", 26.24),
+    ]
+
+
+def test_finalize_reduce_only_orders_trims_ordinary_before_protective_reducer():
+    symbol = "BTC/USDT"
+    bot = OrchestrationBot({symbol: 100.0})
+    bot.register_symbol(symbol)
+    bot.positions[symbol]["long"] = {"size": 20.0, "price": 100.0}
+    orders = {
+        symbol: [
+            _make_order(
+                symbol,
+                "sell",
+                "long",
+                1.95,
+                99.0,
+                "close_unstuck_long",
+                reduce_only=True,
+            ),
+            _make_order(
+                symbol,
+                "sell",
+                "long",
+                26.24,
+                101.0,
+                "close_trailing_long",
+                reduce_only=True,
+            ),
+        ]
+    }
+
+    finalized = bot._finalize_reduce_only_orders(orders, {symbol: 100.0})
+    by_type = {order["pb_order_type"]: order["qty"] for order in finalized[symbol]}
+
+    assert by_type["close_unstuck_long"] == 1.95
+    assert by_type["close_trailing_long"] == 18.05
+    assert sum(by_type.values()) == 20.0
+
+
 def test_coin_hsl_pending_replay_mode_override_is_pair_scoped():
     bot = Passivbot.__new__(Passivbot)
     bot.hsl = {


### PR DESCRIPTION
## Summary

- replace broad close-type pruning with one-protective-reducer selection while preserving compatible grid, trailing, and EMA-anchor closes
- keep panic exclusive and TWEL/WEL-over-unstuck priority; reserve reducer quantity when aggregate closes need trimming
- apply the same reducer-first cap in live reconciliation if the position shrinks after Rust planning
- evaluate the selected reducer before ordinary closes in the realized-loss gate
- document the shared passivbot-wide contract, including `trailing_grid_v7`, without a strategy-specific exemption

## Regression coverage

- exact PB7 parity case: position `95.60`, unstuck close `1.95`, trailing close `26.24`
- deterministic backtest proves both close types fill in the same candle
- long/short WEL and TWEL priority tests retain ordinary closes while enforcing the aggregate position cap
- panic exclusivity, competing-reducer selection, reducer quantity reservation, and live finalizer position-shrink coverage

## Validation

- `cargo test --manifest-path passivbot-rust/Cargo.toml --no-default-features` (215 passed)
- `cargo check --manifest-path passivbot-rust/Cargo.toml --tests --no-default-features`
- `pytest -q tests/test_orchestrator_json_api.py tests/test_order_orchestration.py` (145 passed)
- `python src/tools/check_ai_docs.py` (0 errors; existing word-count warning)
- `python src/tools/generate_live_event_registry.py --check`
- `pytest -q tests/test_ai_docs.py tests/test_live_event_registry_docs.py` (4 passed)
