### PR TITLE
Fix WEEX live reconciliation and churn-gate operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ All notable user-facing changes will be documented in this file.
   reported `reduceOnly=false`; WEEX close-only effect now follows its authoritative `side` plus
   `positionSide` action tuple. WEEX account equity is also normalized to realized wallet balance by
   excluding unrealized PnL, restoring live/backtest risk-input parity and preventing mark-to-market
-  churn-history resets. Repeated unchanged churn deferrals and history-reset diagnostics now remain
-  durable in structured events while INFO output is summarized at most every five minutes.
+  churn-history resets. Runtime forager/mode/list changes now invalidate churn evidence only for the
+  affected symbol, so a rotating empty forager slot cannot erase unrelated history account-wide.
+  Repeated unchanged churn deferrals and history-reset diagnostics now remain durable in structured
+  events while INFO output is summarized at most every five minutes.
 - Configs using the retired `live.initial_entry_exec_max_market_dist_pct` now migrate automatically
   to the account-wide replacement-churn gate. Positive values preserve the market-distance
   threshold and hydrate the other new settings from canonical defaults; null and non-positive values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Fixed WEEX V3 live reconciliation rejecting valid `COMBINED`-mode close orders when the response
+  reported `reduceOnly=false`; WEEX close-only effect now follows its authoritative `side` plus
+  `positionSide` action tuple. WEEX account equity is also normalized to realized wallet balance by
+  excluding unrealized PnL, restoring live/backtest risk-input parity and preventing mark-to-market
+  churn-history resets. Repeated unchanged churn deferrals and history-reset diagnostics now remain
+  durable in structured events while INFO output is summarized at most every five minutes.
 - Configs using the retired `live.initial_entry_exec_max_market_dist_pct` now migrate automatically
   to the account-wide replacement-churn gate. Positive values preserve the market-distance
   threshold and hydrate the other new settings from canonical defaults; null and non-positive values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Fixed live order-churn evidence treating the execution loop's normal 30-second scheduled wait as
+  a provenance gap, which could prevent the account-wide churn gate from activating for slowly
+  moving EMA-based orders.
 - Fixed WEEX V3 live reconciliation rejecting valid `COMBINED`-mode close orders when the response
   reported `reduceOnly=false`; WEEX close-only effect now follows its authoritative `side` plus
   `positionSide` action tuple. WEEX account equity is also normalized to realized wallet balance by

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -217,8 +217,19 @@ Handling in Passivbot:
 5. Require the raw symbol configuration to explicitly report `COMBINED` or
    `SEPARATED`; CCXT's normalized `hedged=false` is not sufficient evidence
    because it also represents missing or unknown raw mode state.
+6. In `COMBINED` mode, derive an open order's close-only effect exclusively from
+   `side` plus `positionSide`. Although V3 order-query responses expose a
+   `reduceOnly` field, ordinary V3 placement cannot set it and valid closes have
+   been observed returning `reduceOnly=false`; it is therefore not authoritative
+   for reconciliation.
+7. Normalize V3 account `balance` to realized wallet balance by subtracting the
+   same response row's `unrealizePnl`. Rust and backtests consume balance without
+   open-position mark-to-market PnL; passing WEEX equity directly changes risk
+   inputs and continuously invalidates churn evidence.
 
-Primary reference: [WEEX V3 place-order API](https://www.weex.com/api-doc/contract/Transaction_API/PlaceOrder).
+Primary references: [WEEX V3 place-order API](https://www.weex.com/api-doc/contract/Transaction_API/PlaceOrder),
+[current-orders API](https://www.weex.com/api-doc/contract/Transaction_API/GetCurrentOrderStatus),
+and [account-balance API](https://www.weex.com/api-doc/contract/Account_API/GetAccountBalance).
 
 ### Market data and CCXT compatibility
 

--- a/docs/plans/account_wide_order_replacement_churn_gate_plan.md
+++ b/docs/plans/account_wide_order_replacement_churn_gate_plan.md
@@ -351,17 +351,20 @@ the same logical presence answers at every relevant timestamp.
 ### Planning-policy compatibility
 
 History compatibility has both account-wide and scoped epochs because the Rust plan has
-account-wide dependencies. The account epoch covers exactly the non-market state passed to Rust
-that can change allocation: hysteresis-snapped wallet balance, raw realized wallet balance,
-per-symbol/position-side signed position size and average entry price, authoritative fill identity,
-the exact `realized_pnl_cumsum_max` and `realized_pnl_cumsum_last` values passed to Rust, global
-strategy/live configuration, effective hedge/one-way mode, approved/ignored sets, forager
-membership, and the complete effective `PB_modes` map. It excludes equity, available margin,
+account-wide dependencies. The account epoch covers hysteresis-snapped wallet balance, raw realized
+wallet balance, per-symbol/position-side signed position size and average entry price,
+authoritative fill identity, the exact `realized_pnl_cumsum_max` and
+`realized_pnl_cumsum_last` values passed to Rust, global strategy/live configuration, and effective
+hedge/one-way mode. It excludes equity, available margin,
 unrealized PnL, mark/liquidation price, mark-to-market notional, and other price-derived exchange
 fields. A change clears all ideal history before classifying the next complete Rust plan. A scoped
-epoch may additionally cover coin overrides or other inputs proven not to influence cross-symbol
-allocation; a scoped change clears only that scope. The conservative initial implementation must
-use the account-wide epoch when dependency is uncertain. Neither reset clears account-wide attempt
+epoch covers each symbol's effective `PB_modes`, approved/ignored membership, forager membership,
+and active-universe membership. A scoped change clears only that symbol's history. This prevents a
+rotating empty forager slot from continuously erasing evidence for unrelated resting orders. It is
+safe despite cross-symbol allocation effects because Rust's current ideal remains authoritative:
+the reconciliation path still cancels stale actuals immediately, and any resulting price/quantity
+change is observed directly by the history classifier. Global config changes remain account-wide,
+including operator changes to configured modes or lists. Neither reset clears account-wide attempt
 timestamps: exchange writes already consumed remain consumed for the rolling window.
 
 Because snapshots are captured after exchange precision and sizing normalization, each symbol's
@@ -942,10 +945,11 @@ events use bounded periodic summaries.
 20. **Bitget UTA close semantics:** its documented `side` plus `posSide` hedge action overrides a
     literal `reduceOnly=NO`; classic/one-way Bitget handling stays separate.
 21. **Cross-symbol risk state:** fill identity, realized Rust balance/position inputs, global
-    config/list/mode changes, and uncertain dependencies advance an account epoch and clear all
-    ideal history; price-derived exchange state does not.
+    configuration changes, and uncertain dependencies advance an account epoch and clear all ideal
+    history; price-derived exchange state does not.
 22. **Runtime eligibility:** effective `PB_modes`, approved/ignored sets, forager membership, and
-    hedge capability are explicit compatibility inputs.
+    active-universe membership are symbol-scoped compatibility inputs; hedge capability remains
+    account-wide.
 23. **Market wording:** market/risk/near exemptions apply only to allowance waiting; dedicated
     protective market panic is the sole account-wide stale-barrier same-wave bypass.
 24. **Recovered stability:** a newest contiguous tight run spanning the stability horizon clears
@@ -1042,8 +1046,9 @@ events use bounded periodic summaries.
 - price-only and quantity-only churn;
 - neighboring grids, duplicate levels, growing/shrinking ladders, equal-cardinality rolls;
 - evidence expires exactly with the rolling window;
-- a scoped coin-override revision resets compatible history; global config, approved/ignored,
-  forager membership, effective mode, and hedge-capability revisions reset account-wide history;
+- a scoped coin-override revision resets compatible history; runtime approved/ignored membership,
+  forager membership, effective mode, and active-universe changes reset only the affected symbol;
+  global configuration and hedge-capability revisions reset account-wide history;
 - an hourly `init_markets()` refresh that changes price/quantity steps, minimums, contract
   multiplier, active status, or another normalization constraint resets only the affected symbol's
   history before its next classification; unchanged metadata and volatile raw exchange `info` do
@@ -1264,9 +1269,9 @@ consequences, and connector assumptions—not merely wording:
 - Is the proposed RAM-only canonical exception truly bounded to operational economy and incapable
   of weakening safety after reset?
 - Do account/scoped compatibility epochs reset exact realized Rust balance/position/fill and
-  realized-PnL cumulative max/last inputs, effective modes, lists, forager membership, and operator
-  changes while excluding equity, margin, unrealized PnL, mark/liquidation prices, other moving
-  fields, and attempt-ledger refunds?
+  realized-PnL cumulative max/last inputs account-wide, runtime modes/lists/forager membership only
+  for affected symbols, and configured operator changes account-wide, while excluding equity,
+  margin, unrealized PnL, mark/liquidation prices, other moving fields, and attempt-ledger refunds?
 - What interactions remain with config reload, forager symbol churn, HSL, WEL/TWEL, unstuck,
   auto-reduce, graceful stop, hedge mode, and one-way mode?
 

--- a/docs/plans/account_wide_order_replacement_churn_gate_plan.md
+++ b/docs/plans/account_wide_order_replacement_churn_gate_plan.md
@@ -911,8 +911,10 @@ events use bounded periodic summaries.
    state, and a fresh Rust plan. Batch truncation cannot strand a dependent creation.
 6. **Ordinary market promotion:** execution type is removed from the sequencing scope, so a
    Rust-promoted market creation cannot bypass its stale limit predecessor.
-7. **WEEX close semantics:** WEEX must normalize and verify its authoritative V3 response/action
-   semantics before enablement.
+7. **WEEX close semantics:** WEEX `COMBINED` mode must normalize close-only effect from the
+   authoritative V3 `side` plus `positionSide` action tuple. The response's `reduceOnly` literal
+   is not authoritative because regular V3 placement cannot set it and valid closes may report
+   `false`.
 8. **Defx metadata:** Defx is explicitly outside the supported live-exchange boundary and is not an
    implementation prerequisite.
 9. **Cancel acknowledgement after fills:** every limit order, including risk-critical, refreshes and
@@ -1013,7 +1015,10 @@ events use bounded periodic summaries.
 - one historical observation cannot satisfy multiple current candidates;
 - a current ideal already satisfied by an actual order still reserves its historical mate before an
   unmatched peer is classified;
-- raw list reordering and dictionary order do not change outcomes.
+- raw list reordering and dictionary order do not change outcomes;
+- WEEX balance normalization subtracts `unrealizePnl` from V3 account equity so mark-to-market
+  movement leaves Rust wallet balance and the churn account epoch unchanged, while realized wallet
+  changes still advance the epoch.
 
 ### Per-symbol history and heuristic
 

--- a/docs/plans/account_wide_order_replacement_churn_gate_plan.md
+++ b/docs/plans/account_wide_order_replacement_churn_gate_plan.md
@@ -440,11 +440,14 @@ same intent continued across it.
 for every attempted account-wide Rust planning cycle, including failures. A stability run may use
 only immediately consecutive successful generations; any unavailable/failed/invalid generation
 breaks it. Also require the current decision and every adjacent snapshot in the run to be separated
-by no more than `max(10 seconds, 3 * live.execution_delay_seconds)`. A larger wall-clock gap breaks
-the run even if no attempt was recorded. The tight prefix must span the full configured stability
-duration and contain at least two prior snapshots. After any generation or time gap, the candidate
-fails open until new contiguous evidence accumulates; two tight snapshots several minutes apart
-cannot clear older evidence.
+by no more than three nominal quiet execution cadences, with a 10-second floor. One nominal quiet
+cadence is `live.execution_delay_seconds` plus the execution loop's maximum 30-second scheduled
+wait for a websocket trigger. The scheduled wait is ordinary runtime behavior and therefore is not
+itself an evidence discontinuity. A larger wall-clock gap breaks the run even if no attempt was
+recorded. The tight prefix must span the full configured stability duration and contain at least
+two prior snapshots. After any generation or time gap, the candidate fails open until new
+contiguous evidence accumulates; two tight snapshots several minutes apart cannot clear older
+evidence.
 
 ### Deterministic matching
 

--- a/src/exchanges/weex.py
+++ b/src/exchanges/weex.py
@@ -254,7 +254,6 @@ class WeexBot(CCXTBot):
 
     def _canonical_open_order_reduce_only(self, order: dict) -> bool:
         """Normalize WEEX V3's authoritative hedge action to close-only effect."""
-        explicit = super()._canonical_open_order_reduce_only(order)
         side = str(
             order.get("side") or (order.get("info") or {}).get("side") or ""
         ).lower()
@@ -264,9 +263,50 @@ class WeexBot(CCXTBot):
         action_close = (position_side == "long" and side == "sell") or (
             position_side == "short" and side == "buy"
         )
-        if explicit is not None and bool(explicit) != action_close:
-            raise ValueError("weex order close-only response contradicts V3 action tuple")
+        # V3 COMBINED orders cannot send reduceOnly.  WEEX nevertheless exposes
+        # a response field with that name and has been observed returning false
+        # for valid side + positionSide closes.  Treating it as authoritative
+        # makes the bot reject its own resting close.  The documented hedge
+        # action tuple is the connector-native close-only contract.
         return action_close
+
+    def _get_balance(self, fetched: dict) -> float:
+        """Return WEEX wallet balance, excluding unrealized position PnL.
+
+        WEEX V3's ``balance`` moves with ``unrealizePnl``.  Passivbot's raw
+        balance is the realized wallet balance used by Rust and backtests, so
+        normalize equity back to wallet balance from the same authoritative
+        response row.
+        """
+        raw = fetched.get("info") if isinstance(fetched, dict) else None
+        rows = raw if isinstance(raw, list) else [raw]
+        matches = [
+            row
+            for row in rows
+            if isinstance(row, dict)
+            and str(row.get("asset") or "").upper() == self.quote
+        ]
+        if len(matches) != 1:
+            raise ValueError(
+                f"weex: balance response missing unique {self.quote} asset row"
+            )
+        row = matches[0]
+        try:
+            equity = float(row["balance"])
+            unrealized_pnl = float(row["unrealizePnl"])
+        except (KeyError, TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(
+                "weex: balance response missing finite balance/unrealizePnl"
+            ) from exc
+        wallet_balance = equity - unrealized_pnl
+        if not all(
+            math.isfinite(value)
+            for value in (equity, unrealized_pnl, wallet_balance)
+        ):
+            raise ValueError(
+                "weex: balance response contains non-finite balance/unrealizePnl"
+            )
+        return wallet_balance
 
     async def _do_fetch_tickers(self) -> list[dict]:
         return await self.cca.contract_get_capi_v3_market_ticker_bookticker()

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -3990,7 +3990,7 @@ def emit_order_churn_evidence_event(
             component="order.churn_history",
             tags=(EventTags.ORDER, EventTags.GATE, EventTags.MEMORY, EventTags.SNAPSHOT),
             cycle_id=current_live_event_cycle_id(bot),
-            status="reset" if reset else str(snapshot_status)[:24],
+            status="skipped" if snapshot_status == "skipped" else "succeeded",
             reason_code=ReasonCodes.ORDER_CHURN_HISTORY,
             data={
                 "generation": max(0, int(generation)),
@@ -4000,6 +4000,7 @@ def emit_order_churn_evidence_event(
                 "churn_count": max(0, int(churn_count)),
                 "reason_counts": bounded_reasons,
                 "history_symbol_count": max(0, int(history_symbol_count)),
+                "snapshot_status": str(snapshot_status)[:24],
                 "symbols": symbol_values[:12],
                 "symbols_count": len(symbol_values),
                 "symbols_truncated": len(symbol_values) > 12,
@@ -4062,7 +4063,7 @@ def emit_order_churn_admission_event(
             tags=(EventTags.ORDER, EventTags.GATE, EventTags.ACTION),
             cycle_id=current_live_event_cycle_id(bot),
             order_wave_id=order_wave_id,
-            status="evaluated",
+            status="succeeded",
             reason_code=ReasonCodes.ORDER_CHURN_ADMISSION,
             data=data,
         )
@@ -4095,7 +4096,7 @@ def emit_order_churn_actions_accounted_event(
             tags=(EventTags.ORDER, EventTags.ACTION, EventTags.GATE),
             cycle_id=current_live_event_cycle_id(bot),
             order_wave_id=order_wave_id,
-            status="accounted",
+            status="succeeded",
             reason_code=ReasonCodes.ORDER_CHURN_ACTION_ATTEMPT,
             data={
                 "action_count": max(0, int(action_count)),

--- a/src/live/executor.py
+++ b/src/live/executor.py
@@ -446,13 +446,33 @@ async def _apply_order_churn_final_admission(
                 projected_signed_actions += config_action_cost
                 projected_config_symbols.add(symbol)
     if deferred:
-        logging.info(
-            "[order] churn gate deferred %d far unstable creates | rolling_usage=%d activation_count=%d",
+        rolling_count = state.action_attempt_count(
+            now_monotonic=now_monotonic, window_seconds=window_seconds
+        )
+        console_signature = tuple(
+            sorted(
+                (
+                    str(order.get("_churn_gate_reason") or ""),
+                    str(order.get("symbol") or ""),
+                    str(order.get("position_side") or ""),
+                    str(order.get("pb_order_type") or ""),
+                )
+                for order in deferred
+            )
+        )
+        should_log, suppressed = state.should_log_console_event(
+            "create_deferred",
+            console_signature,
+            now_monotonic=now_monotonic,
+        )
+        log = logging.info if should_log else logging.debug
+        log(
+            "[order] churn gate deferred %d far unstable creates | rolling_usage=%d "
+            "activation_count=%d suppressed_repeats=%d",
             len(deferred),
-            state.action_attempt_count(
-                now_monotonic=now_monotonic, window_seconds=window_seconds
-            ),
+            rolling_count,
             activation_count,
+            suppressed,
         )
         _record_fresh_entry_orders(bot, "record_blocked_orders", deferred, "order_churn_gate")
         reason_codes = {

--- a/src/live/order_churn_gate.py
+++ b/src/live/order_churn_gate.py
@@ -343,7 +343,7 @@ class OrderChurnGateState:
     def reset_history_for_symbol_epochs(
         self, compatibility_epochs: Mapping[str, object]
     ) -> set[str]:
-        """Clear only histories normalized under changed symbol metadata."""
+        """Clear histories whose symbol-local market or runtime policy changed."""
         changed: set[str] = set()
         for symbol, epoch in compatibility_epochs.items():
             symbol = str(symbol)

--- a/src/live/order_churn_gate.py
+++ b/src/live/order_churn_gate.py
@@ -20,6 +20,8 @@ ORDER_CHURN_GATE_SUPPORTED_EXCHANGES = frozenset(
     }
 )
 
+ORDER_CHURN_CONSOLE_REPEAT_SECONDS = 5.0 * 60.0
+
 
 def connector_supports_order_churn_gate(bot) -> bool:
     """Return the explicit setup-time rollout decision for this connector.
@@ -288,6 +290,39 @@ class OrderChurnGateState:
         self.generation = 0
         self.account_epoch: object | None = None
         self.reset_count = 0
+        self.console_log_state: dict[str, dict[str, object]] = {}
+
+    def should_log_console_event(
+        self,
+        family: str,
+        signature: object,
+        *,
+        now_monotonic: float,
+        repeat_seconds: float = ORDER_CHURN_CONSOLE_REPEAT_SECONDS,
+    ) -> tuple[bool, int]:
+        """Throttle repeated INFO projections without suppressing events or decisions."""
+        if not family:
+            raise ValueError("console log family must be non-empty")
+        if not math.isfinite(now_monotonic):
+            raise ValueError("console log timestamp must be finite")
+        if not math.isfinite(repeat_seconds) or repeat_seconds <= 0.0:
+            raise ValueError("console log repeat interval must be finite and positive")
+        previous = self.console_log_state.get(family)
+        if previous is None or previous.get("signature") != signature:
+            self.console_log_state[family] = {
+                "signature": signature,
+                "last_log_monotonic": now_monotonic,
+                "suppressed_count": 0,
+            }
+            return True, 0
+        last_log = float(previous["last_log_monotonic"])
+        if now_monotonic - last_log >= repeat_seconds:
+            suppressed = int(previous.get("suppressed_count", 0) or 0)
+            previous["last_log_monotonic"] = now_monotonic
+            previous["suppressed_count"] = 0
+            return True, suppressed
+        previous["suppressed_count"] = int(previous.get("suppressed_count", 0) or 0) + 1
+        return False, 0
 
     def begin_generation(self) -> int:
         self.generation += 1

--- a/src/live/reconciler.py
+++ b/src/live/reconciler.py
@@ -43,6 +43,13 @@ def _utc_ms() -> int:
     return int(_utils_utc_ms())
 
 
+def _order_churn_max_generation_gap_seconds(bot) -> float:
+    """Return a cadence gap which includes the execution loop's quiet wait."""
+    execution_delay = float(bot.live_value("execution_delay_seconds"))
+    scheduled_wait = float(_pb_const("EXECUTION_SCHEDULED_WAIT_SECONDS"))
+    return max(10.0, 3.0 * (execution_delay + scheduled_wait))
+
+
 def _orders_removed_by_identity(before: list[dict], after: list[dict]) -> list[dict]:
     """Return objects removed by an existing filter without comparing mutable payloads."""
     remaining = Counter(id(order) for order in after)
@@ -1223,7 +1230,6 @@ def prepare_order_churn_evidence(
     stability_seconds = (
         float(bot.live_value("order_replacement_churn_gate_stability_minutes")) * 60.0
     )
-    execution_delay = float(bot.live_value("execution_delay_seconds"))
     decisions = state.evaluate_and_record(
         valid_ideals,
         generation=generation,
@@ -1234,7 +1240,7 @@ def prepare_order_churn_evidence(
         ),
         stability_seconds=stability_seconds,
         window_seconds=window_seconds,
-        max_generation_gap_seconds=max(10.0, 3.0 * execution_delay),
+        max_generation_gap_seconds=_order_churn_max_generation_gap_seconds(bot),
     )
     for orders in valid_ideals.values():
         for order in orders:

--- a/src/live/reconciler.py
+++ b/src/live/reconciler.py
@@ -1137,9 +1137,17 @@ def prepare_order_churn_evidence(
             "[order] churn evidence history initialized empty | reason=process_start"
         )
     elif reset:
-        logging.info(
-            "[order] churn evidence history reset | reason=account_epoch_changed reset_count=%d",
+        should_log, suppressed = state.should_log_console_event(
+            "history_reset_account_epoch",
+            "account_epoch_changed",
+            now_monotonic=time.monotonic(),
+        )
+        log = logging.info if should_log else logging.debug
+        log(
+            "[order] churn evidence history reset | reason=account_epoch_changed "
+            "reset_count=%d suppressed_repeats=%d",
             state.reset_count,
+            suppressed,
         )
     current_universe = set(ideal_orders)
     current_universe.update(getattr(bot, "active_symbols", []) or [])
@@ -1155,11 +1163,18 @@ def prepare_order_churn_evidence(
     )
     if scoped_resets:
         reset = True
-        logging.info(
+        should_log, suppressed = state.should_log_console_event(
+            "history_reset_symbol_metadata",
+            tuple(sorted(scoped_resets)),
+            now_monotonic=time.monotonic(),
+        )
+        log = logging.info if should_log else logging.debug
+        log(
             "[order] churn evidence history reset | reason=symbol_market_metadata_changed "
-            "symbols=%s reset_count=%d",
+            "symbols=%s reset_count=%d suppressed_repeats=%d",
             _pb_attr("Passivbot")._log_symbols(sorted(scoped_resets), limit=8),
             state.reset_count,
+            suppressed,
         )
     if activation_count <= 0:
         state.history_by_symbol.clear()

--- a/src/live/reconciler.py
+++ b/src/live/reconciler.py
@@ -1011,33 +1011,6 @@ def _order_churn_account_epoch(bot) -> tuple:
         separators=(",", ":"),
         default=str,
     )
-    modes = tuple(
-        (pside, str(symbol), str(mode))
-        for pside in ("long", "short")
-        for symbol, mode in sorted((getattr(bot, "PB_modes", {}) or {}).get(pside, {}).items())
-    )
-    approved = tuple(
-        (pside, tuple(sorted((getattr(bot, "approved_coins", {}) or {}).get(pside, set()))))
-        for pside in ("long", "short")
-    )
-    ignored = tuple(
-        (pside, tuple(sorted((getattr(bot, "ignored_coins", {}) or {}).get(pside, set()))))
-        for pside in ("long", "short")
-    )
-    approved_minus_ignored = tuple(
-        (
-            pside,
-            tuple(
-                sorted(
-                    (getattr(bot, "approved_coins_minus_ignored_coins", {}) or {}).get(
-                        pside, set()
-                    )
-                )
-            ),
-        )
-        for pside in ("long", "short")
-    )
-    active_symbols = tuple(sorted(getattr(bot, "active_symbols", []) or []))
     return (
         round(float(bot.get_hysteresis_snapped_balance()), 12),
         round(float(bot.get_raw_balance()), 12),
@@ -1046,11 +1019,6 @@ def _order_churn_account_epoch(bot) -> tuple:
         round(float(pnl_stats.get("max", 0.0) or 0.0), 12),
         round(float(pnl_stats.get("last", 0.0) or 0.0), 12),
         config_signature,
-        modes,
-        approved,
-        ignored,
-        approved_minus_ignored,
-        active_symbols,
         bool(getattr(bot, "_config_hedge_mode", False) and getattr(bot, "hedge_mode", False)),
     )
 
@@ -1059,6 +1027,23 @@ def _order_churn_symbol_compatibility_epochs(
     bot, symbols: Iterable[str]
 ) -> dict[str, tuple]:
     markets = getattr(bot, "markets_dict", {}) or {}
+    pb_modes = getattr(bot, "PB_modes", {}) or {}
+    approved = getattr(bot, "approved_coins", {}) or {}
+    ignored = getattr(bot, "ignored_coins", {}) or {}
+    approved_minus_ignored = (
+        getattr(bot, "approved_coins_minus_ignored_coins", {}) or {}
+    )
+    approved_by_pside = {
+        pside: set((approved.get(pside, {}) or {})) for pside in ("long", "short")
+    }
+    ignored_by_pside = {
+        pside: set((ignored.get(pside, {}) or {})) for pside in ("long", "short")
+    }
+    eligible_by_pside = {
+        pside: set((approved_minus_ignored.get(pside, {}) or {}))
+        for pside in ("long", "short")
+    }
+    active_symbols = set(getattr(bot, "active_symbols", []) or [])
     out: dict[str, tuple] = {}
     for symbol in sorted({str(symbol) for symbol in symbols if symbol}):
         market = markets.get(symbol, {}) if isinstance(markets, dict) else {}
@@ -1071,6 +1056,17 @@ def _order_churn_symbol_compatibility_epochs(
             float((getattr(bot, "min_costs", {}) or {}).get(symbol, 0.0) or 0.0),
             float((getattr(bot, "c_mults", {}) or {}).get(symbol, 1.0) or 1.0),
             bool(market.get("active", True)),
+            tuple(
+                (
+                    pside,
+                    str((pb_modes.get(pside, {}) or {}).get(symbol)),
+                    symbol in approved_by_pside[pside],
+                    symbol in ignored_by_pside[pside],
+                    symbol in eligible_by_pside[pside],
+                )
+                for pside in ("long", "short")
+            ),
+            symbol in active_symbols,
             json.dumps(
                 {
                     "precision": market.get("precision", {}),
@@ -1163,14 +1159,17 @@ def prepare_order_churn_evidence(
     )
     if scoped_resets:
         reset = True
+        # Dynamic forager selection may change different symbol pairs on each
+        # cycle. Keep that detail in the message and structured event without
+        # turning every new pair into an unthrottled INFO signature.
         should_log, suppressed = state.should_log_console_event(
-            "history_reset_symbol_metadata",
-            tuple(sorted(scoped_resets)),
+            "history_reset_symbol_compatibility",
+            "symbol_compatibility_changed",
             now_monotonic=time.monotonic(),
         )
         log = logging.info if should_log else logging.debug
         log(
-            "[order] churn evidence history reset | reason=symbol_market_metadata_changed "
+            "[order] churn evidence history reset | reason=symbol_compatibility_changed "
             "symbols=%s reset_count=%d suppressed_repeats=%d",
             _pb_attr("Passivbot")._log_symbols(sorted(scoped_resets), limit=8),
             state.reset_count,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -157,6 +157,12 @@ from collections import defaultdict, Counter
 from sortedcontainers import SortedDict
 
 
+# The execution loop may wait this long for a websocket-triggered replan after
+# its configured execution delay. Churn-history cadence checks must include
+# this normal quiet-period wait or ordinary live operation breaks provenance.
+EXECUTION_SCHEDULED_WAIT_SECONDS = 30
+
+
 class FillHistoryCoverageUnavailable(RuntimeError):
     """Raised when live risk gates need fill history whose lookback is unproven."""
 
@@ -6345,7 +6351,7 @@ class Passivbot:
                     stage="execution_delay",
                 )
                 mark_phase("execution_delay", phase_start_ms)
-                sleep_duration = 30
+                sleep_duration = EXECUTION_SCHEDULED_WAIT_SECONDS
                 self._set_log_silence_watchdog_context(
                     phase="runtime", stage="scheduled_wait"
                 )

--- a/tests/exchanges/test_weex.py
+++ b/tests/exchanges/test_weex.py
@@ -95,6 +95,61 @@ def test_weex_client_accepts_only_documented_success_envelope():
         )
 
 
+def test_weex_balance_excludes_unrealized_pnl_from_equity():
+    bot = _bot()
+    raw = [
+        {
+            "asset": "USDT",
+            "balance": "100.1875",
+            "availableBalance": "89.0",
+            "frozen": "10.0",
+            "unrealizePnl": "-0.25",
+        }
+    ]
+    unified = _ccxt_exchange().parse_balance(raw)
+
+    assert unified["total"]["USDT"] == pytest.approx(100.1875)
+    assert bot._get_balance(unified) == pytest.approx(100.4375)
+
+
+def test_weex_wallet_balance_is_stable_across_mark_to_market_changes():
+    bot = _bot()
+
+    def fetched(equity: float, unrealized_pnl: float) -> dict:
+        return {
+            "info": [
+                {
+                    "asset": "USDT",
+                    "balance": str(equity),
+                    "unrealizePnl": str(unrealized_pnl),
+                }
+            ]
+        }
+
+    assert bot._get_balance(fetched(100.2, -0.3)) == pytest.approx(100.5)
+    assert bot._get_balance(fetched(100.8, 0.3)) == pytest.approx(100.5)
+
+
+@pytest.mark.parametrize(
+    "info",
+    [
+        [],
+        [{"asset": "BTC", "balance": "1", "unrealizePnl": "0"}],
+        [
+            {"asset": "USDT", "balance": "1", "unrealizePnl": "0"},
+            {"asset": "USDT", "balance": "1", "unrealizePnl": "0"},
+        ],
+        [{"asset": "USDT", "balance": "1"}],
+        [{"asset": "USDT", "balance": "nan", "unrealizePnl": "0"}],
+    ],
+)
+def test_weex_balance_rejects_missing_ambiguous_or_nonfinite_wallet_inputs(info):
+    bot = _bot()
+
+    with pytest.raises(ValueError, match="balance response"):
+        bot._get_balance({"info": info})
+
+
 def test_weex_order_websocket_ignores_empty_order_event():
     exchange = ProWeex()
     client = MagicMock()

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -2374,6 +2374,58 @@ def test_create_filter_emitter_reports_whether_live_event_emission_succeeded():
     assert live_event_emitters.emit_execution_create_filter_event(bot, **kwargs) is True
 
 
+def test_order_churn_emitters_use_valid_live_event_statuses():
+    emitted = []
+
+    class Bot:
+        exchange = "weex"
+        user = "weex_01"
+
+        @staticmethod
+        def _current_live_event_cycle_id():
+            return "cy_1"
+
+        @staticmethod
+        def _emit_live_event(event_type, **kwargs):
+            event = LiveEvent(event_type, **kwargs)
+            emitted.append(event)
+            return event
+
+    bot = Bot()
+    assert live_event_emitters.emit_order_churn_evidence_event(
+        bot,
+        generation=1,
+        reset=True,
+        reset_count=1,
+        reason_counts={"no_history": 1},
+        churn_count=0,
+        order_count=1,
+        symbols=["BTC/USDT:USDT"],
+        history_symbol_count=1,
+        snapshot_status="observed",
+    )
+    assert live_event_emitters.emit_order_churn_admission_event(
+        bot,
+        orders=[],
+        rolling_count=1,
+        activation_count=10,
+        market_distance_threshold=0.005,
+        action_headroom=None,
+    )
+    assert live_event_emitters.emit_order_churn_actions_accounted_event(
+        bot,
+        action_count=1,
+        rolling_count=2,
+    )
+
+    assert [event.status for event in emitted] == [
+        "succeeded",
+        "succeeded",
+        "succeeded",
+    ]
+    assert emitted[0].data["snapshot_status"] == "observed"
+
+
 def test_console_format_summarizes_low_balance_create_skip():
     event = LiveEvent(
         EventTypes.EXECUTION_CREATE_SKIPPED,

--- a/tests/test_order_churn_executor.py
+++ b/tests/test_order_churn_executor.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import logging
 import math
+from unittest.mock import MagicMock
 
 import pytest
 
+from live import executor as executor_module
 from live.executor import (
     _apply_order_churn_final_admission,
     _complete_terminal_signed_action_attempts,
@@ -259,3 +262,40 @@ async def test_diagnostic_emitter_failure_cannot_change_admission():
     admitted = await _apply_order_churn_final_admission(bot, [stable])
 
     assert admitted == [stable]
+
+
+@pytest.mark.asyncio
+async def test_repeated_churn_deferral_keeps_structured_path_but_throttles_info(
+    monkeypatch, caplog
+):
+    bot = _Bot()
+    now = [100.0]
+    monkeypatch.setattr(executor_module.time, "monotonic", lambda: now[0])
+    structured_emitter = MagicMock()
+    monkeypatch.setattr(
+        executor_module._pb_attr("Passivbot"),
+        "_emit_execution_create_filter_event",
+        structured_emitter,
+    )
+    bot._order_churn_gate_state.record_action_attempts(10, now_monotonic=now[0])
+    far = _order("far", price=99.0)
+
+    with caplog.at_level(logging.DEBUG):
+        assert await _apply_order_churn_final_admission(bot, [far]) == []
+        now[0] = 101.0
+        assert await _apply_order_churn_final_admission(bot, [far]) == []
+        now[0] = 400.0
+        assert await _apply_order_churn_final_admission(bot, [far]) == []
+
+    records = [
+        record
+        for record in caplog.records
+        if "churn gate deferred" in record.getMessage()
+    ]
+    assert [record.levelno for record in records] == [
+        logging.INFO,
+        logging.DEBUG,
+        logging.INFO,
+    ]
+    assert "suppressed_repeats=1" in records[-1].getMessage()
+    assert structured_emitter.call_count == 3

--- a/tests/test_order_churn_gate.py
+++ b/tests/test_order_churn_gate.py
@@ -287,6 +287,51 @@ def test_prepare_prunes_history_only_symbol_without_appending_empty_snapshot(mon
     assert state.history_by_symbol == {}
 
 
+def test_live_generation_gap_allows_normal_scheduled_wait(monkeypatch):
+    class Bot:
+        @staticmethod
+        def live_value(key):
+            assert key == "execution_delay_seconds"
+            return 2.0
+
+    monkeypatch.setattr(
+        reconciler,
+        "_pb_const",
+        lambda key: 30.0 if key == "EXECUTION_SCHEDULED_WAIT_SECONDS" else None,
+    )
+
+    max_gap = reconciler._order_churn_max_generation_gap_seconds(Bot())
+    assert max_gap == 96.0
+
+    state = OrderChurnGateState()
+    first = _order(price=100.0)
+    generation = state.begin_generation()
+    state.evaluate_and_record(
+        {first["symbol"]: [first]},
+        generation=generation,
+        now_monotonic=0.0,
+        tight_tolerance=0.0002,
+        wider_tolerance=0.002,
+        stability_seconds=120.0,
+        window_seconds=600.0,
+        max_generation_gap_seconds=max_gap,
+    )
+    moved = _order(price=100.1)
+    generation = state.begin_generation()
+    decision = state.evaluate_and_record(
+        {moved["symbol"]: [moved]},
+        generation=generation,
+        now_monotonic=40.0,
+        tight_tolerance=0.0002,
+        wider_tolerance=0.002,
+        stability_seconds=120.0,
+        window_seconds=600.0,
+        max_generation_gap_seconds=max_gap,
+    )[id(moved)]
+    assert decision.churn_evidenced is True
+    assert decision.reason == "wider_but_not_tight"
+
+
 def test_first_prepare_emits_ram_reset_and_fails_open(monkeypatch):
     state = OrderChurnGateState()
     symbol = "BTC/USDT:USDT"

--- a/tests/test_order_churn_gate.py
+++ b/tests/test_order_churn_gate.py
@@ -584,3 +584,35 @@ def test_symbol_epoch_reset_is_scoped_and_preserves_attempts():
     assert "BTC/USDT:USDT" not in state.history_by_symbol
     assert "ETH/USDT:USDT" in state.history_by_symbol
     assert state.action_attempt_count(now_monotonic=1.0, window_seconds=600.0) == 1
+
+
+def test_console_projection_throttle_preserves_first_transition_and_periodic_summary():
+    state = OrderChurnGateState()
+    signature = (("allowance_exhausted", "BTC/USDT:USDT"),)
+
+    assert state.should_log_console_event(
+        "create_deferred", signature, now_monotonic=100.0, repeat_seconds=300.0
+    ) == (True, 0)
+    assert state.should_log_console_event(
+        "create_deferred", signature, now_monotonic=101.0, repeat_seconds=300.0
+    ) == (False, 0)
+    assert state.should_log_console_event(
+        "create_deferred", signature, now_monotonic=399.9, repeat_seconds=300.0
+    ) == (False, 0)
+    assert state.should_log_console_event(
+        "create_deferred", signature, now_monotonic=400.0, repeat_seconds=300.0
+    ) == (True, 2)
+
+
+def test_console_projection_throttle_logs_material_signature_change_immediately():
+    state = OrderChurnGateState()
+
+    assert state.should_log_console_event(
+        "history_reset", "account", now_monotonic=1.0
+    ) == (True, 0)
+    assert state.should_log_console_event(
+        "history_reset", "account", now_monotonic=2.0
+    ) == (False, 0)
+    assert state.should_log_console_event(
+        "history_reset", ("market", "BTC"), now_monotonic=3.0
+    ) == (True, 0)

--- a/tests/test_order_reconciliation_contract.py
+++ b/tests/test_order_reconciliation_contract.py
@@ -894,7 +894,7 @@ def test_hourly_market_refresh_changes_reset_symbol_compatibility_epoch(field, v
     assert reconciler._order_churn_symbol_compatibility_epochs(bot, {symbol}) != baseline
 
 
-def test_account_epoch_tracks_realized_rust_inputs_not_mark_to_market_fields():
+def test_account_epoch_tracks_realized_and_global_inputs_not_scoped_runtime_policy():
     symbol = "BTC/USDT:USDT"
 
     class Bot:
@@ -960,11 +960,70 @@ def test_account_epoch_tracks_realized_rust_inputs_not_mark_to_market_fields():
     bot.pnl_last = 1.1
     assert reconciler._order_churn_account_epoch(bot) != baseline
     bot.pnl_last = 1.0
-    bot.active_symbols = [symbol, "ETH/USDT:USDT"]
+    bot.config["live"]["execution_delay_seconds"] = 3.0
     assert reconciler._order_churn_account_epoch(bot) != baseline
+    bot.config["live"]["execution_delay_seconds"] = 2.0
+    # Runtime forager/mode/list changes are symbol-scoped: resetting them
+    # account-wide lets a rotating empty slot erase unrelated churn evidence.
+    bot.active_symbols = [symbol, "ETH/USDT:USDT"]
+    bot.PB_modes["long"][symbol] = "graceful_stop"
+    bot.approved_coins["long"].clear()
+    bot.ignored_coins["long"].add(symbol)
+    bot.approved_coins_minus_ignored_coins["long"].clear()
+    assert reconciler._order_churn_account_epoch(bot) == baseline
 
-    bot.active_symbols = [symbol]
     bot._authoritative_surface_signatures = {"fills": ((1, "fill-a"),)}
     with_fill_signature = reconciler._order_churn_account_epoch(bot)
     bot._authoritative_surface_signatures["fills"] = ((1, "fill-b"),)
     assert reconciler._order_churn_account_epoch(bot) != with_fill_signature
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "mode",
+        "approved",
+        "ignored",
+        "approved_minus_ignored",
+        "active",
+    ],
+)
+def test_runtime_policy_changes_reset_only_the_affected_symbol_epoch(mutation):
+    btc = "BTC/USDT:USDT"
+    eth = "ETH/USDT:USDT"
+
+    class Bot:
+        price_steps = {btc: 0.1, eth: 0.01}
+        qty_steps = {btc: 0.001, eth: 0.01}
+        min_qtys = {btc: 0.001, eth: 0.01}
+        min_costs = {btc: 5.0, eth: 5.0}
+        c_mults = {btc: 1.0, eth: 1.0}
+        markets_dict = {btc: {"active": True}, eth: {"active": True}}
+        PB_modes = {
+            "long": {btc: "normal", eth: "normal"},
+            "short": {btc: "normal", eth: "normal"},
+        }
+        approved_coins = {"long": {btc, eth}, "short": {btc, eth}}
+        ignored_coins = {"long": set(), "short": set()}
+        approved_coins_minus_ignored_coins = {
+            "long": {btc, eth},
+            "short": {btc, eth},
+        }
+        active_symbols = [btc, eth]
+
+    bot = Bot()
+    baseline = reconciler._order_churn_symbol_compatibility_epochs(bot, {btc, eth})
+    if mutation == "mode":
+        bot.PB_modes["long"][btc] = "graceful_stop"
+    elif mutation == "approved":
+        bot.approved_coins["long"].remove(btc)
+    elif mutation == "ignored":
+        bot.ignored_coins["long"].add(btc)
+    elif mutation == "approved_minus_ignored":
+        bot.approved_coins_minus_ignored_coins["long"].remove(btc)
+    else:
+        bot.active_symbols.remove(btc)
+
+    changed = reconciler._order_churn_symbol_compatibility_epochs(bot, {btc, eth})
+    assert changed[btc] != baseline[btc]
+    assert changed[eth] == baseline[eth]

--- a/tests/test_order_reconciliation_contract.py
+++ b/tests/test_order_reconciliation_contract.py
@@ -79,22 +79,34 @@ def test_supported_hedge_orders_do_not_fabricate_pside_from_client_id(bot_cls):
         bot._get_position_side_for_order(order)
 
 
-def test_weex_prefers_and_verifies_response_close_only_semantics():
+@pytest.mark.parametrize(
+    ("side", "position_side", "reported_reduce_only", "expected_close"),
+    [
+        ("buy", "LONG", False, False),
+        ("sell", "SHORT", False, False),
+        # WEEX V3 COMBINED has been observed returning reduceOnly=false for
+        # ordinary closes even though side + positionSide closes the position.
+        ("sell", "LONG", False, True),
+        ("buy", "SHORT", False, True),
+        # The response field is not part of the V3 placement contract, so the
+        # authoritative action tuple also wins when that literal is true.
+        ("buy", "LONG", True, False),
+    ],
+)
+def test_weex_uses_v3_action_tuple_not_response_reduce_only_literal(
+    side, position_side, reported_reduce_only, expected_close
+):
     bot = WeexBot.__new__(WeexBot)
-    close = {
-        "side": "sell",
-        "reduceOnly": True,
-        "info": {"positionSide": "LONG", "reduceOnly": True},
+    order = {
+        "side": side,
+        "reduceOnly": reported_reduce_only,
+        "info": {
+            "side": side.upper(),
+            "positionSide": position_side,
+            "reduceOnly": reported_reduce_only,
+        },
     }
-    assert bot._canonical_open_order_reduce_only(close) is True
-
-    contradictory = {
-        "side": "sell",
-        "reduceOnly": False,
-        "info": {"positionSide": "LONG", "reduceOnly": False},
-    }
-    with pytest.raises(ValueError, match="contradicts"):
-        bot._canonical_open_order_reduce_only(contradictory)
+    assert bot._canonical_open_order_reduce_only(order) is expected_close
 
 
 def test_bitget_uta_uses_action_tuple_even_when_literal_reduce_only_is_false():
@@ -934,6 +946,13 @@ def test_account_epoch_tracks_realized_rust_inputs_not_mark_to_market_fields():
     bot.positions[symbol]["long"]["unrealized_pnl"] = 20.0
     bot.positions[symbol]["long"]["liquidation_price"] = 60.0
     assert reconciler._order_churn_account_epoch(bot) == baseline
+
+    bot.raw_balance = 101.0
+    assert reconciler._order_churn_account_epoch(bot) != baseline
+    bot.raw_balance = 100.0
+    bot.snapped_balance = 101.0
+    assert reconciler._order_churn_account_epoch(bot) != baseline
+    bot.snapped_balance = 100.0
 
     bot.positions[symbol]["long"]["size"] = 1.1
     assert reconciler._order_churn_account_epoch(bot) != baseline


### PR DESCRIPTION
## Summary

- normalize WEEX V3 COMBINED-mode closes from the authoritative `side` plus `positionSide` tuple instead of the misleading `reduceOnly=false` response field
- normalize WEEX account balance to realized wallet balance by excluding unrealized PnL
- preserve churn evidence across unrelated forager/mode/list changes with symbol-scoped compatibility epochs
- keep churn diagnostics durable in structured events while throttling repeated console summaries
- use valid live-event statuses for churn evidence, admission, and accounting events
- include the execution loop's normal 30-second scheduled wait in churn provenance cadence, so slowly moving EMA orders can actually activate the gate

## Root cause

WEEX V3 order-query responses may report `reduceOnly=false` for valid close orders even though ordinary V3 placement does not accept a reduce-only flag. Reconciliation therefore rejected valid closes. WEEX also reports equity-like balance including unrealized PnL, which made Rust wallet inputs move with the market.

Separately, runtime forager membership was part of the account-wide churn epoch, invalid churn event statuses silently prevented diagnostics from persisting, and the provenance gap allowed only 10 seconds with this config while the live execution loop normally waits up to 30 seconds for a websocket-triggered replan. That last mismatch made the gate fail open indefinitely for orders moving roughly once per minute.

WEEX contracts used:
- https://www.weex.com/api-doc/contract/Transaction_API/PlaceOrder
- https://www.weex.com/api-doc/contract/Transaction_API/GetCurrentOrderStatus
- https://www.weex.com/api-doc/contract/Account_API/GetAccountBalance

## Live validation

Ran `passivbot live configs/ema_anchor_2026-07-22.json -u weex_01` on the funded WEEX account with long and short positions enabled.

Observed on head `b9d111626bab`:
- inherited MORPHO and WLD closes normalized and reconciled as reduce-only without malformed-order errors
- raw realized balance stayed stable while equity tracked open-position unrealized PnL
- 41–47 second quiet replanning gaps retained churn provenance and produced `wider_but_not_tight` evidence
- at 9/10 usage, exactly one distant replacement was admitted and the remainder deferred; at 10/10, distant unstable replacements were deferred
- stale resting orders were canceled before deferred replacements, and cancel-first confirmation/replanning prevented overlap
- near-market and genuinely new cohorts remained admissible above the threshold and counted against later capacity
- the rolling window pruned expired attempts
- repeated decisions remained in structured events while identical INFO output was suppressed
- active 1m/1h EMA inputs recovered after transient minute-boundary/cache warnings
- zero runtime errors and zero rate-limit incidents
- both pre-existing positions had valid resting reduce-only closes before clean shutdown

## Validation

- `./venv/bin/python -m pytest -q` — passed
- focused WEEX, reconciliation, churn-gate, executor, event-bus, CLI, and Hyperliquid-headroom tests — passed
- `PYTHONPATH=src ./venv/bin/python src/tools/check_ai_docs.py` — 0 errors (existing word-count warning)
- `PYTHONPATH=src ./venv/bin/python src/tools/generate_live_event_registry.py --check` — current
- `./venv/bin/python -m pytest -q tests/test_ai_docs.py tests/test_live_event_registry_docs.py` — passed
- `git diff --check` — passed