### PR TITLE
Fix Bitget UTA recursion and noisy churn resets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Fixed Bitget UTA open-order normalization recursively deriving position side from close-only
+  effect and close-only effect from position side in effective one-way mode. UTA orders with an
+  explicit `posSide` now derive close-only effect directly from the authoritative `side` plus
+  `posSide` tuple.
+- Fixed multi-collateral quote-value movement continuously resetting live order-churn evidence.
+  The account epoch now follows the hysteresis-snapped sizing balance plus authoritative fills,
+  realized PnL, and positions instead of exact raw quote-valued balance.
 - Fixed live order-churn evidence treating the execution loop's normal 30-second scheduled wait as
   a provenance gap, which could prevent the account-wide churn gate from activating for slowly
   moving EMA-based orders.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ All notable user-facing changes will be documented in this file.
   `posSide` tuple.
 - Fixed multi-collateral quote-value movement continuously resetting live order-churn evidence.
   The account epoch now follows the hysteresis-snapped sizing balance plus authoritative fills,
-  realized PnL, and positions instead of exact raw quote-valued balance.
+  realized PnL, positions, and Rust-reported risk-phase transitions instead of exact raw
+  quote-valued balance. While a Rust risk-critical order or realized-loss block is active, churn
+  admission cannot defer any order for that symbol and position side.
 - Fixed live order-churn evidence treating the execution loop's normal 30-second scheduled wait as
   a provenance gap, which could prevent the account-wide churn gate from activating for slowly
   moving EMA-based orders.

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -130,7 +130,10 @@ Handling in Passivbot:
    `reduceOnly`.
 2. Normalize UTA open orders from the explicit exchange/CCXT `side` field for
    buy/sell direction, and from `posSide` for long/short position side.
-3. Keep classic Bitget v2/mix `tradeSide`/`reduceOnly` handling separate.
+3. If the effective account mode is one-way but a UTA order still reports an explicit long/short
+   `posSide`, derive close-only effect directly from its `side` plus `posSide` action tuple. If it
+   does not report that tuple, require an authoritative native `reduceOnly` value.
+4. Keep classic Bitget v2/mix `tradeSide`/`reduceOnly` handling separate.
 
 ### `since` is effectively exclusive for OHLCV paging
 

--- a/docs/plans/account_wide_order_replacement_churn_gate_plan.md
+++ b/docs/plans/account_wide_order_replacement_churn_gate_plan.md
@@ -354,13 +354,20 @@ History compatibility has both account-wide and scoped epochs because the Rust p
 account-wide dependencies. The account epoch covers hysteresis-snapped wallet balance,
 per-symbol/position-side signed position size and average entry price,
 authoritative fill identity, the exact `realized_pnl_cumsum_max` and
-`realized_pnl_cumsum_last` values passed to Rust, global strategy/live configuration, and effective
-hedge/one-way mode. It excludes equity, available margin,
+`realized_pnl_cumsum_last` values passed to Rust, Rust-reported active risk pairs, global
+strategy/live configuration, and effective hedge/one-way mode. An active risk pair is any
+symbol/position-side for which Rust emits a risk-critical order or a realized-loss-gate block. It
+excludes equity, available margin,
 unrealized PnL, raw quote-valued balance, mark/liquidation price, mark-to-market notional, and other
 price-derived exchange fields. On multi-collateral venues, raw balance may change solely because a
 collateral asset's quote value changes; including it would continuously erase churn evidence.
-Authoritative fills, realized-PnL cumulative values, and position transitions still reset the
-account epoch immediately, while a material wallet change advances the hysteresis-snapped balance.
+Rust continues to consume exact raw balance for risk decisions. Entry into or exit from a
+Rust-reported risk phase resets the account epoch immediately, and every ideal order sharing an
+active risk symbol/position-side bypasses economy-only churn deferral. This covers raw-balance
+changes that alter realized-loss, TWEL, or unstuck behavior without treating valuation-only raw
+balance ticks as policy transitions. Authoritative fills, realized-PnL cumulative values, and
+position transitions also reset the account epoch immediately, while a material wallet change
+advances the hysteresis-snapped balance.
 A change clears all ideal history before classifying the next complete Rust plan. A scoped
 epoch covers each symbol's effective `PB_modes`, approved/ignored membership, forager membership,
 and active-universe membership. A scoped change clears only that symbol's history. This prevents a
@@ -381,8 +388,8 @@ account-wide reset unless the changed metadata also alters an account-wide Rust 
 Continuously changing prices, EMAs, volatility, trailing extrema, raw quote-valued balance, and
 other price-derived account fields are excluded; including them would continuously reset the
 evidence gate and defeat its purpose. A new authoritative fill identity, realized-PnL
-cumulative-value change, hysteresis-snapped wallet-balance change, or signed
-position-size/average-entry-price transition advances the account epoch because
+cumulative-value change, Rust-reported risk-phase transition, hysteresis-snapped wallet-balance
+change, or signed position-size/average-entry-price transition advances the account epoch because
 TWEL, entry gates, realized-loss/unstuck policy, risk ordering, and portfolio sizing may change
 ideals on other symbols. This also preserves
 the existing contract that every fill resets trailing extrema and prevents pre-fill evidence from
@@ -952,9 +959,9 @@ events use bounded periodic summaries.
     final cancellation barrier is now account-wide for hedge and one-way modes alike.
 20. **Bitget UTA close semantics:** its documented `side` plus `posSide` hedge action overrides a
     literal `reduceOnly=NO`; classic/one-way Bitget handling stays separate.
-21. **Cross-symbol risk state:** fill identity, realized Rust balance/position inputs, global
-    configuration changes, and uncertain dependencies advance an account epoch and clear all ideal
-    history; price-derived exchange state does not.
+21. **Cross-symbol risk state:** fill identity, snapped balance/position inputs, Rust-reported risk
+    phases, global configuration changes, and uncertain dependencies advance an account epoch and
+    clear all ideal history; price-derived exchange state does not.
 22. **Runtime eligibility:** effective `PB_modes`, approved/ignored sets, forager membership, and
     active-universe membership are symbol-scoped compatibility inputs; hedge capability remains
     account-wide.
@@ -968,8 +975,9 @@ events use bounded periodic summaries.
     used/surplus fields are validated before unused prepaid weight is admitted.
 27. **Stability gaps:** failed generations and explicit derived cadence gaps break the tight prefix;
     sparse snapshots cannot prove stability.
-28. **Price-driven epoch fields:** only realized Rust balance inputs, signed position size/average
-    entry, fill identity, and static/runtime policy enter epochs; mark-to-market fields are excluded.
+28. **Price-driven epoch fields:** only snapped balance, signed position size/average entry, fill
+    identity, Rust-reported risk phases, and static/runtime policy enter epochs; mark-to-market
+    fields are excluded. Exact raw balance remains a Rust risk input, not an epoch scalar.
 29. **Cross-symbol cancel dependency:** any stale cancellation blocks every non-panic create until a
     full authoritative refresh and complete Rust replan.
 30. **One-way position attribution:** prefer durable PB metadata, otherwise use the reviewed
@@ -1028,9 +1036,10 @@ events use bounded periodic summaries.
 - a current ideal already satisfied by an actual order still reserves its historical mate before an
   unmatched peer is classified;
 - raw list reordering and dictionary order do not change outcomes;
-- WEEX balance normalization subtracts `unrealizePnl` from V3 account equity so mark-to-market
-  movement leaves Rust wallet balance and the churn account epoch unchanged, while realized wallet
-  changes still advance the epoch.
+- WEEX balance normalization subtracts `unrealizePnl` from V3 account equity so position
+  mark-to-market movement does not alter Rust raw balance. On any venue, a raw-balance risk change
+  advances the churn epoch when it changes Rust's active risk pairs; a material wallet change also
+  advances the snapped-balance epoch.
 
 ### Per-symbol history and heuristic
 
@@ -1063,9 +1072,12 @@ events use bounded periodic summaries.
   not reset it;
 - price, EMA, volatility, trailing extrema, equity, available margin, unrealized PnL, mark/liquidation
   price, and mark-to-market notional changes do not reset history;
-- authoritative fill identity, realized-PnL cumulative max/last, hysteresis-snapped wallet balance,
-  signed position size, and average-entry-price transitions reset account-wide history
+- authoritative fill identity, realized-PnL cumulative max/last, Rust-reported active risk pairs,
+  hysteresis-snapped wallet balance, signed position size, and average-entry-price transitions reset
+  account-wide history
   before the first new-phase plan;
+- every ideal order for a Rust-reported active risk pair fails open past churn evidence and cannot
+  be distance- or allowance-deferred by the churn gate;
 - a policy-history reset does not clear account-wide attempt timestamps;
 - compaction, if implemented, preserves logical results across fast/slow planning cadence.
 
@@ -1153,7 +1165,8 @@ events use bounded periodic summaries.
 
 ### Slice 2: pure per-symbol evidence helper
 
-- Implement immutable snapshots, exact realized-PnL/snapped-balance/position compatibility epochs,
+- Implement immutable snapshots, exact realized-PnL/snapped-balance/position and Rust risk-phase
+  compatibility epochs,
   pruning/optional compaction, deterministic
   one-to-one tight/wider association, newest stability clearing, and account-wide rolling attempt
   accounting.
@@ -1276,8 +1289,9 @@ consequences, and connector assumptions—not merely wording:
 - Is the one-cycle ordinary latency acceptable for parity and missed-fill risk?
 - Is the proposed RAM-only canonical exception truly bounded to operational economy and incapable
   of weakening safety after reset?
-- Do account/scoped compatibility epochs reset snapped balance, position, fill identity, and exact
-  realized-PnL cumulative max/last inputs account-wide, runtime modes/lists/forager membership only
+- Do account/scoped compatibility epochs reset snapped balance, position, fill identity, exact
+  realized-PnL cumulative max/last inputs, and Rust-reported risk-phase transitions account-wide,
+  runtime modes/lists/forager membership only
   for affected symbols, and configured operator changes account-wide, while excluding equity,
   margin, unrealized PnL, mark/liquidation prices, other moving fields, and attempt-ledger refunds?
 - What interactions remain with config reload, forager symbol churn, HSL, WEL/TWEL, unstuck,

--- a/docs/plans/account_wide_order_replacement_churn_gate_plan.md
+++ b/docs/plans/account_wide_order_replacement_churn_gate_plan.md
@@ -351,13 +351,17 @@ the same logical presence answers at every relevant timestamp.
 ### Planning-policy compatibility
 
 History compatibility has both account-wide and scoped epochs because the Rust plan has
-account-wide dependencies. The account epoch covers hysteresis-snapped wallet balance, raw realized
-wallet balance, per-symbol/position-side signed position size and average entry price,
+account-wide dependencies. The account epoch covers hysteresis-snapped wallet balance,
+per-symbol/position-side signed position size and average entry price,
 authoritative fill identity, the exact `realized_pnl_cumsum_max` and
 `realized_pnl_cumsum_last` values passed to Rust, global strategy/live configuration, and effective
 hedge/one-way mode. It excludes equity, available margin,
-unrealized PnL, mark/liquidation price, mark-to-market notional, and other price-derived exchange
-fields. A change clears all ideal history before classifying the next complete Rust plan. A scoped
+unrealized PnL, raw quote-valued balance, mark/liquidation price, mark-to-market notional, and other
+price-derived exchange fields. On multi-collateral venues, raw balance may change solely because a
+collateral asset's quote value changes; including it would continuously erase churn evidence.
+Authoritative fills, realized-PnL cumulative values, and position transitions still reset the
+account epoch immediately, while a material wallet change advances the hysteresis-snapped balance.
+A change clears all ideal history before classifying the next complete Rust plan. A scoped
 epoch covers each symbol's effective `PB_modes`, approved/ignored membership, forager membership,
 and active-universe membership. A scoped change clears only that symbol's history. This prevents a
 rotating empty forager slot from continuously erasing evidence for unrelated resting orders. It is
@@ -374,10 +378,11 @@ normalizer. `init_markets()` may refresh these values while the process remains 
 clears that symbol's history before classifying its next current ideal; it does not require an
 account-wide reset unless the changed metadata also alters an account-wide Rust input.
 
-Continuously changing prices, EMAs, volatility, trailing extrema, and price-derived account fields
-are excluded; including them would continuously reset the evidence gate and defeat its purpose. A
-new authoritative fill identity, realized-PnL cumulative-value change, realized wallet-balance
-change, or signed position-size/average-entry-price transition advances the account epoch because
+Continuously changing prices, EMAs, volatility, trailing extrema, raw quote-valued balance, and
+other price-derived account fields are excluded; including them would continuously reset the
+evidence gate and defeat its purpose. A new authoritative fill identity, realized-PnL
+cumulative-value change, hysteresis-snapped wallet-balance change, or signed
+position-size/average-entry-price transition advances the account epoch because
 TWEL, entry gates, realized-loss/unstuck policy, risk ordering, and portfolio sizing may change
 ideals on other symbols. This also preserves
 the existing contract that every fill resets trailing extrema and prevents pre-fill evidence from
@@ -1058,8 +1063,8 @@ events use bounded periodic summaries.
   not reset it;
 - price, EMA, volatility, trailing extrema, equity, available margin, unrealized PnL, mark/liquidation
   price, and mark-to-market notional changes do not reset history;
-- authoritative fill identity, realized-PnL cumulative max/last, raw/snapped realized wallet
-  balance, signed position size, and average-entry-price transitions reset account-wide history
+- authoritative fill identity, realized-PnL cumulative max/last, hysteresis-snapped wallet balance,
+  signed position size, and average-entry-price transitions reset account-wide history
   before the first new-phase plan;
 - a policy-history reset does not clear account-wide attempt timestamps;
 - compaction, if implemented, preserves logical results across fast/slow planning cadence.
@@ -1148,7 +1153,7 @@ events use bounded periodic summaries.
 
 ### Slice 2: pure per-symbol evidence helper
 
-- Implement immutable snapshots, exact realized-PnL/balance/position compatibility epochs,
+- Implement immutable snapshots, exact realized-PnL/snapped-balance/position compatibility epochs,
   pruning/optional compaction, deterministic
   one-to-one tight/wider association, newest stability clearing, and account-wide rolling attempt
   accounting.
@@ -1271,7 +1276,7 @@ consequences, and connector assumptions—not merely wording:
 - Is the one-cycle ordinary latency acceptable for parity and missed-fill risk?
 - Is the proposed RAM-only canonical exception truly bounded to operational economy and incapable
   of weakening safety after reset?
-- Do account/scoped compatibility epochs reset exact realized Rust balance/position/fill and
+- Do account/scoped compatibility epochs reset snapped balance, position, fill identity, and exact
   realized-PnL cumulative max/last inputs account-wide, runtime modes/lists/forager membership only
   for affected symbols, and configured operator changes account-wide, while excluding equity,
   margin, unrealized PnL, mark/liquidation prices, other moving fields, and attempt-ledger refunds?

--- a/src/exchanges/bitget.py
+++ b/src/exchanges/bitget.py
@@ -126,11 +126,10 @@ class BitgetBot(CCXTBot):
                     raise ValueError("bitget UTA one-way order missing reduceOnly")
                 return reduce_only
             side = str(order.get("side") or info.get("side") or "").lower()
-            position_side = self._get_position_side_for_order(order)
             if side not in {"buy", "sell"}:
                 raise ValueError("bitget UTA order missing explicit buy/sell side")
-            return (position_side == "long" and side == "sell") or (
-                position_side == "short" and side == "buy"
+            return (raw_position_side == "long" and side == "sell") or (
+                raw_position_side == "short" and side == "buy"
             )
         trade_side = str(info.get("tradeSide") or "").lower()
         if trade_side in {"open", "close"}:

--- a/src/live/reconciler.py
+++ b/src/live/reconciler.py
@@ -981,6 +981,55 @@ async def calc_orders_to_cancel_and_create(bot):
     )
 
 
+def order_churn_risk_active_pairs_from_rust_output(
+    out: dict, idx_to_symbol: dict[int, str]
+) -> tuple[tuple[str, str], ...]:
+    """Return symbol/pside pairs whose Rust plan is under an active risk phase.
+
+    Raw balance is intentionally not an epoch scalar: quote-valued collateral may
+    move on every market tick.  Rust remains authoritative for raw-balance risk
+    behavior, and its emitted risk-critical orders plus realized-loss blocks are
+    the behavioral phase boundary needed by churn reconciliation.
+    """
+    if not isinstance(out, dict):
+        raise ValueError("Rust orchestrator output must be a dict")
+    pairs: set[tuple[str, str]] = set()
+
+    def add_pair(item: dict, *, context: str) -> None:
+        if not isinstance(item, dict):
+            raise ValueError(f"Rust {context} item must be a dict")
+        try:
+            symbol_idx = int(item["symbol_idx"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(f"Rust {context} item missing valid symbol_idx") from exc
+        symbol = idx_to_symbol.get(symbol_idx)
+        if not symbol:
+            raise ValueError(f"Rust {context} item has unknown symbol_idx {symbol_idx}")
+        pside = str(item.get("pside") or "").lower()
+        if pside not in {"long", "short"}:
+            raise ValueError(f"Rust {context} item missing valid pside")
+        pairs.add((str(symbol), pside))
+
+    orders = out.get("orders", [])
+    if not isinstance(orders, list):
+        raise ValueError("Rust orchestrator orders must be a list")
+    for order in orders:
+        if not isinstance(order, dict):
+            raise ValueError("Rust orchestrator order must be a dict")
+        if str(order.get("execution_priority") or "").lower() == "risk_critical":
+            add_pair(order, context="risk-critical order")
+
+    diagnostics = out.get("diagnostics", {})
+    if not isinstance(diagnostics, dict):
+        raise ValueError("Rust orchestrator diagnostics must be a dict")
+    loss_gate_blocks = diagnostics.get("loss_gate_blocks", [])
+    if not isinstance(loss_gate_blocks, list):
+        raise ValueError("Rust loss_gate_blocks must be a list")
+    for block in loss_gate_blocks:
+        add_pair(block, context="loss-gate block")
+    return tuple(sorted(pairs))
+
+
 def _order_churn_account_epoch(bot) -> tuple:
     positions = []
     for symbol, sides in sorted((getattr(bot, "positions", {}) or {}).items()):
@@ -1024,6 +1073,7 @@ def _order_churn_account_epoch(bot) -> tuple:
         fill_signature,
         round(float(pnl_stats.get("max", 0.0) or 0.0), 12),
         round(float(pnl_stats.get("last", 0.0) or 0.0), 12),
+        tuple(getattr(bot, "_order_churn_risk_active_pairs", ()) or ()),
         config_signature,
         bool(getattr(bot, "_config_hedge_mode", False) and getattr(bot, "hedge_mode", False)),
     )
@@ -1241,9 +1291,19 @@ def prepare_order_churn_evidence(
         window_seconds=window_seconds,
         max_generation_gap_seconds=_order_churn_max_generation_gap_seconds(bot),
     )
+    risk_active_pairs = set(
+        getattr(bot, "_order_churn_risk_active_pairs", ()) or ()
+    )
     for orders in valid_ideals.values():
         for order in orders:
             decision = decisions.get(id(order), ChurnDecision(False, "unavailable"))
+            pair = (str(order.get("symbol") or ""), str(order.get("position_side") or ""))
+            if pair in risk_active_pairs:
+                # Raw-balance risk behavior remains owned by Rust.  Never let
+                # economy-only churn admission delay any order sharing the
+                # affected symbol/pside while that risk phase is active.
+                decision = ChurnDecision(False, "rust_risk_phase_active")
+                decisions[id(order)] = decision
             order["_churn_evidence"] = bool(decision.churn_evidenced)
             order["_churn_reason"] = decision.reason
     _emit_order_churn_evidence_summary(

--- a/src/live/reconciler.py
+++ b/src/live/reconciler.py
@@ -1020,7 +1020,6 @@ def _order_churn_account_epoch(bot) -> tuple:
     )
     return (
         round(float(bot.get_hysteresis_snapped_balance()), 12),
-        round(float(bot.get_raw_balance()), 12),
         tuple(positions),
         fill_signature,
         round(float(pnl_stats.get("max", 0.0) or 0.0), 12),

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -1151,6 +1151,7 @@ class Passivbot:
         self.pside_int_map = {"long": 0, "short": 1}
         self.PB_modes = {"long": {}, "short": {}}
         self._order_churn_gate_state = OrderChurnGateState()
+        self._order_churn_risk_active_pairs: tuple[tuple[str, str], ...] = ()
         self.approved_coins = {"long": set(), "short": set()}
         self.ignored_coins = {"long": set(), "short": set()}
         self.approved_coins_minus_ignored_coins = {"long": set(), "short": set()}
@@ -17626,6 +17627,11 @@ class Passivbot:
         output_hash = payload_hash_raw(out_json)
         orders = out.get("orders", [])
         diagnostics = out.get("diagnostics", {})
+        self._order_churn_risk_active_pairs = (
+            reconciler.order_churn_risk_active_pairs_from_rust_output(
+                out, idx_to_symbol
+            )
+        )
         self._emit_rust_orchestrator_returned_event(
             rust_call_id=rust_call_id,
             status="succeeded",

--- a/tests/test_order_churn_gate.py
+++ b/tests/test_order_churn_gate.py
@@ -378,6 +378,50 @@ def test_first_prepare_emits_ram_reset_and_fails_open(monkeypatch):
     assert emitted[0]["reset_count"] == 0
 
 
+def test_active_rust_risk_pair_bypasses_observed_churn(monkeypatch):
+    state = OrderChurnGateState()
+    symbol = "BTC/USDT:USDT"
+
+    class Bot:
+        _order_churn_gate_state = state
+        _order_churn_risk_active_pairs = ((symbol, "long"),)
+        active_symbols = [symbol]
+        open_orders = {}
+        positions = {}
+
+        @staticmethod
+        def live_value(key):
+            return {
+                "order_replacement_churn_gate_activation_count": 10,
+                "order_replacement_churn_gate_window_minutes": 10.0,
+                "order_replacement_churn_gate_stability_minutes": 2.0,
+                "order_match_tolerance_pct": 0.0002,
+                "order_replacement_churn_gate_tracking_tolerance_pct": 0.002,
+                "execution_delay_seconds": 2.0,
+            }[key]
+
+    monkeypatch.setattr(reconciler, "_order_churn_account_epoch", lambda _bot: ("e",))
+    monkeypatch.setattr(
+        reconciler,
+        "_order_churn_symbol_compatibility_epochs",
+        lambda _bot, symbols: {item: ("m",) for item in symbols},
+    )
+    monkeypatch.setattr(reconciler.time, "monotonic", lambda: 0.0)
+    first = _order(price=100.0)
+    reconciler.prepare_order_churn_evidence(
+        Bot(), {symbol: [first]}, generation=state.begin_generation()
+    )
+
+    monkeypatch.setattr(reconciler.time, "monotonic", lambda: 5.0)
+    moved = _order(price=100.1)
+    reconciler.prepare_order_churn_evidence(
+        Bot(), {symbol: [moved]}, generation=state.begin_generation()
+    )
+
+    assert moved["_churn_evidence"] is False
+    assert moved["_churn_reason"] == "rust_risk_phase_active"
+
+
 def test_downstream_normalization_outage_is_symbol_scoped(monkeypatch):
     state = OrderChurnGateState()
     btc = "BTC/USDT:USDT"

--- a/tests/test_order_reconciliation_contract.py
+++ b/tests/test_order_reconciliation_contract.py
@@ -966,6 +966,7 @@ def test_account_epoch_tracks_realized_and_global_inputs_not_scoped_runtime_poli
             self.snapped_balance = 100.0
             self.pnl_max = 2.0
             self.pnl_last = 1.0
+            self._order_churn_risk_active_pairs = ()
 
         def get_hysteresis_snapped_balance(self):
             return self.snapped_balance
@@ -990,6 +991,9 @@ def test_account_epoch_tracks_realized_and_global_inputs_not_scoped_runtime_poli
     bot.raw_balance = 101.0
     assert reconciler._order_churn_account_epoch(bot) == baseline
     bot.raw_balance = 100.0
+    bot._order_churn_risk_active_pairs = ((symbol, "long"),)
+    assert reconciler._order_churn_account_epoch(bot) != baseline
+    bot._order_churn_risk_active_pairs = ()
     bot.snapped_balance = 101.0
     assert reconciler._order_churn_account_epoch(bot) != baseline
     bot.snapped_balance = 100.0
@@ -1016,6 +1020,38 @@ def test_account_epoch_tracks_realized_and_global_inputs_not_scoped_runtime_poli
     with_fill_signature = reconciler._order_churn_account_epoch(bot)
     bot._authoritative_surface_signatures["fills"] = ((1, "fill-b"),)
     assert reconciler._order_churn_account_epoch(bot) != with_fill_signature
+
+
+def test_rust_risk_active_pairs_cover_risk_orders_and_loss_gate_blocks():
+    idx_to_symbol = {
+        0: "BTC/USDT:USDT",
+        1: "ETH/USDT:USDT",
+        2: "SOL/USDT:USDT",
+    }
+    out = {
+        "orders": [
+            {
+                "symbol_idx": 0,
+                "pside": "long",
+                "execution_priority": "ordinary",
+            },
+            {
+                "symbol_idx": 1,
+                "pside": "short",
+                "execution_priority": "risk_critical",
+            },
+        ],
+        "diagnostics": {
+            "loss_gate_blocks": [
+                {"symbol_idx": 2, "pside": "long"},
+                {"symbol_idx": 1, "pside": "short"},
+            ]
+        },
+    }
+
+    assert reconciler.order_churn_risk_active_pairs_from_rust_output(
+        out, idx_to_symbol
+    ) == (("ETH/USDT:USDT", "short"), ("SOL/USDT:USDT", "long"))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_order_reconciliation_contract.py
+++ b/tests/test_order_reconciliation_contract.py
@@ -318,6 +318,43 @@ def test_bitget_one_way_open_order_normalizer_uses_action_tuple():
 
 
 @pytest.mark.parametrize(
+    ("side", "pos_side", "expected_close"),
+    [
+        ("buy", "long", False),
+        ("sell", "long", True),
+        ("sell", "short", False),
+        ("buy", "short", True),
+    ],
+)
+def test_bitget_uta_one_way_open_order_normalizer_uses_action_tuple_without_recursion(
+    side, pos_side, expected_close
+):
+    bot = BitgetBot.__new__(BitgetBot)
+    bot.is_uta = True
+    bot._config_hedge_mode = False
+    bot.hedge_mode = False
+    bot._record_live_margin_mode_from_payload = lambda _order: None
+    order = {
+        "id": "1",
+        "symbol": "BTC/USDT:USDT",
+        "side": side,
+        "amount": 1.0,
+        "timestamp": 1,
+        "clientOrderId": "",
+        # Bitget UTA may report the literal as false for an action which
+        # closes the explicit posSide.  The action tuple is authoritative.
+        "reduceOnly": False,
+        "info": {"side": side, "posSide": pos_side, "reduceOnly": "NO"},
+    }
+
+    [normalized] = bot._normalize_open_orders([order])
+
+    assert normalized["position_side"] == pos_side
+    assert normalized["side"] == side
+    assert bot._canonical_open_order_reduce_only(normalized) is expected_close
+
+
+@pytest.mark.parametrize(
     ("side", "trade_side", "expected_pside", "expected_close"),
     [
         ("buy", "open", "long", False),
@@ -947,8 +984,11 @@ def test_account_epoch_tracks_realized_and_global_inputs_not_scoped_runtime_poli
     bot.positions[symbol]["long"]["liquidation_price"] = 60.0
     assert reconciler._order_churn_account_epoch(bot) == baseline
 
+    # Raw balance may be quote-valued collateral and therefore move with the
+    # market even without a fill or transfer. Rust sizing uses the snapped
+    # balance, while fills/PnL/positions provide phase-change evidence.
     bot.raw_balance = 101.0
-    assert reconciler._order_churn_account_epoch(bot) != baseline
+    assert reconciler._order_churn_account_epoch(bot) == baseline
     bot.raw_balance = 100.0
     bot.snapped_balance = 101.0
     assert reconciler._order_churn_account_epoch(bot) != baseline


### PR DESCRIPTION
## Summary

- break the Bitget UTA effective-one-way recursion between position-side and close-only normalization
- derive UTA close-only effect directly from the authoritative `side` plus explicit `posSide` tuple
- stop price-sensitive raw multi-collateral balance movement from resetting order-churn evidence
- retain exact raw balance as Rust's risk/accounting input
- derive active risk pairs from Rust risk-critical orders and realized-loss blocks, reset churn compatibility when that phase changes, and bypass churn deferral for every order on an active risk pair
- retain resets for hysteresis-snapped sizing balance, authoritative fills, realized PnL, positions, and global configuration
- update the exchange contract, churn design documentation, changelog, and regression coverage

## Root cause

VPS3 `bitget_01` exhausted its restart budget because a UTA order carrying `posSide` entered a cycle: position-side normalization requested close-only normalization, which requested position-side normalization again.

Separately, Bybit multi-collateral `balance_raw` changed with collateral quote valuation even without fills or position changes, continuously clearing the RAM-only churn history. Simply excluding raw balance was incomplete because Rust still uses it for realized-loss, TWEL, and unstuck decisions. The revised implementation follows Rust's behavioral risk phase rather than each price-derived scalar tick: entering or leaving an active risk pair clears pre-phase history, and churn admission cannot defer orders for that pair while the phase remains active.

## Validation

- `python -m pytest -q` (full Python suite passed)
- `python -m pytest -q tests/test_order_reconciliation_contract.py tests/ccxt_upgrade/test_order_contracts.py`
- `python -m pytest -q tests/test_order_churn_gate.py tests/test_order_churn_executor.py tests/test_order_churn_cancel_first.py`
- `PYTHONPATH=src python src/tools/check_ai_docs.py`
- `PYTHONPATH=src python src/tools/generate_live_event_registry.py --check`
- `python -m pytest -q tests/test_ai_docs.py`
- `python -m compileall -q src/exchanges/bitget.py src/live/reconciler.py`
- `git diff --check`

No live bot was restarted and no authenticated exchange probe was performed as part of this PR.