### PR TITLE
Select the largest protective reducer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,11 +49,12 @@ All notable user-facing changes will be documented in this file.
   Hyperliquid carries ambiguous signed-action debits across `userRateLimit` refreshes, preventing
   overlapping requests from overstating available action headroom, and failed required margin-mode
   writes now leave dependent creates pending instead of marking the symbol configured.
-- Protective reducer arbitration now keeps the largest requested absolute reduction among active
-  panic, TWEL/WEL auto-reduce, and auto-unstuck intents for each position instead of using a fixed
-  type priority or summing quantities. Equal-size ties keep panic first and otherwise prefer the
-  closest-to-fill candidate, so a tiny auto-reduce can no longer suppress a materially larger
-  unstuck close.
+- Protective reducer arbitration now keeps the largest loss-admissible requested absolute
+  reduction among active panic, TWEL/WEL auto-reduce, and auto-unstuck intents for each position
+  instead of using a fixed type priority or summing quantities. If the realized-loss gate blocks
+  the largest non-panic intent, Passivbot tries the next-largest intent before giving up protective
+  reduction. Equal-size ties keep panic first and otherwise prefer the closest-to-fill candidate,
+  so a tiny auto-reduce can no longer suppress a materially larger unstuck close.
 - Non-panic protective reducers may now coexist with compatible ordinary grid, trailing, or
   EMA-anchor closes for the same position. Passivbot still selects only one protective reducer,
   keeps panic close exclusive, reserves reducer quantity before trimming ordinary closes, and caps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,12 +49,14 @@ All notable user-facing changes will be documented in this file.
   Hyperliquid carries ambiguous signed-action debits across `userRateLimit` refreshes, preventing
   overlapping requests from overstating available action headroom, and failed required margin-mode
   writes now leave dependent creates pending instead of marking the symbol configured.
-- Protective reducer arbitration now keeps the largest loss-admissible requested absolute
+- Protective reducer arbitration now keeps the largest loss-admissible final absolute
   reduction among active panic, TWEL/WEL auto-reduce, and auto-unstuck intents for each position
   instead of using a fixed type priority or summing quantities. If the realized-loss gate blocks
   the largest non-panic intent, Passivbot tries the next-largest intent before giving up protective
   reduction. Equal-size ties keep panic first and otherwise prefer the closest-to-fill candidate,
-  so a tiny auto-reduce can no longer suppress a materially larger unstuck close.
+  so a tiny auto-reduce can no longer suppress a materially larger unstuck close. Reducer sizing is
+  finalized before its loss is checked, and a shared batch loss allowance is spent on finalized
+  reducers largest-first rather than in symbol iteration order.
 - Non-panic protective reducers may now coexist with compatible ordinary grid, trailing, or
   EMA-anchor closes for the same position. Passivbot still selects only one protective reducer,
   keeps panic close exclusive, reserves reducer quantity before trimming ordinary closes, and caps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@ All notable user-facing changes will be documented in this file.
   Hyperliquid carries ambiguous signed-action debits across `userRateLimit` refreshes, preventing
   overlapping requests from overstating available action headroom, and failed required margin-mode
   writes now leave dependent creates pending instead of marking the symbol configured.
+- Protective reducer arbitration now keeps the largest requested absolute reduction among active
+  panic, TWEL/WEL auto-reduce, and auto-unstuck intents for each position instead of using a fixed
+  type priority or summing quantities. Equal-size ties keep panic first and otherwise prefer the
+  closest-to-fill candidate, so a tiny auto-reduce can no longer suppress a materially larger
+  unstuck close.
 - Non-panic protective reducers may now coexist with compatible ordinary grid, trailing, or
   EMA-anchor closes for the same position. Passivbot still selects only one protective reducer,
   keeps panic close exclusive, reserves reducer quantity before trimming ordinary closes, and caps

--- a/docs/ai/features/strategy_runtime.md
+++ b/docs/ai/features/strategy_runtime.md
@@ -133,21 +133,22 @@ is effectively moot because multiple same-price slices would be redundant.
 
 For each coin and position side, Rust selects at most one protective reducer per ideal-order batch.
 Active panic, TWEL/WEL exposure-repair, and auto-unstuck intents are consolidated by keeping the
-largest loss-admissible requested absolute reduction, not by summing their quantities. If the
-realized-loss gate blocks the largest non-panic intent, Rust tries the next-largest intent. This
-prevents a small auto-reduce from suppressing a materially larger unstuck close while retaining a
-smaller safety fallback when the larger close would exceed the loss budget. A full-position HSL
-panic is therefore largest and remains exclusive; equal-size ties keep panic first and otherwise
-prefer the closest-to-fill candidate.
+largest loss-admissible absolute reduction after final position/minimum sizing, not by summing
+their quantities. If the realized-loss gate blocks the largest non-panic intent, Rust tries the
+next-largest intent. This prevents a small auto-reduce from suppressing a materially larger unstuck
+close while retaining a smaller safety fallback when the larger close would exceed the loss
+budget. A full-position HSL panic is therefore largest and remains exclusive; equal-size ties keep
+panic first and otherwise prefer the closest-to-fill candidate.
 
 A selected non-panic reducer may coexist with ordinary grid, trailing, or EMA-anchor closes. Its
 quantity is reserved first; if aggregate close quantity would exceed the position, ordinary closes
 are trimmed furthest-from-fill first against the remaining quantity. Aggregate reduce-only quantity
 must never exceed the position after quantity-step and effective-minimum handling. The cumulative
-realized-loss gate participates in this allocation and evaluates reducer candidates largest-first,
-then evaluates ordinary closes after the selected reducer. Live reconciliation reapplies the same
-aggregate cap against current exchange position size, still trimming ordinary closes before the
-reducer if the position shrank after planning.
+realized-loss gate participates in this allocation, checks the final reducer size, and spends the
+shared batch allowance on final reducer quantities largest-first rather than in symbol iteration
+order. It then evaluates ordinary closes after the selected reducers. Live reconciliation reapplies
+the same aggregate cap against current exchange position size, still trimming ordinary closes
+before the reducer if the position shrank after planning.
 This contract is shared by every strategy kind, including `trailing_grid_v7`.
 
 ## Source Of Truth

--- a/docs/ai/features/strategy_runtime.md
+++ b/docs/ai/features/strategy_runtime.md
@@ -133,18 +133,21 @@ is effectively moot because multiple same-price slices would be redundant.
 
 For each coin and position side, Rust selects at most one protective reducer per ideal-order batch.
 Active panic, TWEL/WEL exposure-repair, and auto-unstuck intents are consolidated by keeping the
-largest requested absolute reduction, not by summing their quantities. This prevents a small
-auto-reduce from suppressing a materially larger unstuck close. A full-position HSL panic is
-therefore largest and remains exclusive; equal-size ties keep panic first and otherwise prefer the
-closest-to-fill candidate.
+largest loss-admissible requested absolute reduction, not by summing their quantities. If the
+realized-loss gate blocks the largest non-panic intent, Rust tries the next-largest intent. This
+prevents a small auto-reduce from suppressing a materially larger unstuck close while retaining a
+smaller safety fallback when the larger close would exceed the loss budget. A full-position HSL
+panic is therefore largest and remains exclusive; equal-size ties keep panic first and otherwise
+prefer the closest-to-fill candidate.
 
 A selected non-panic reducer may coexist with ordinary grid, trailing, or EMA-anchor closes. Its
 quantity is reserved first; if aggregate close quantity would exceed the position, ordinary closes
 are trimmed furthest-from-fill first against the remaining quantity. Aggregate reduce-only quantity
 must never exceed the position after quantity-step and effective-minimum handling. The cumulative
-realized-loss gate applies after this allocation and evaluates the selected reducer before ordinary
-closes. Live reconciliation reapplies the same aggregate cap against current exchange position
-size, still trimming ordinary closes before the reducer if the position shrank after planning.
+realized-loss gate participates in this allocation and evaluates reducer candidates largest-first,
+then evaluates ordinary closes after the selected reducer. Live reconciliation reapplies the same
+aggregate cap against current exchange position size, still trimming ordinary closes before the
+reducer if the position shrank after planning.
 This contract is shared by every strategy kind, including `trailing_grid_v7`.
 
 ## Source Of Truth

--- a/docs/ai/features/strategy_runtime.md
+++ b/docs/ai/features/strategy_runtime.md
@@ -132,8 +132,11 @@ is effectively moot because multiple same-price slices would be redundant.
 ## Close Reducer Compatibility
 
 For each coin and position side, Rust selects at most one protective reducer per ideal-order batch.
-HSL panic is exclusive. TWEL/WEL exposure repair takes precedence over auto-unstuck, and the
-closest-to-fill candidate wins when competing reducers have the same priority.
+Active panic, TWEL/WEL exposure-repair, and auto-unstuck intents are consolidated by keeping the
+largest requested absolute reduction, not by summing their quantities. This prevents a small
+auto-reduce from suppressing a materially larger unstuck close. A full-position HSL panic is
+therefore largest and remains exclusive; equal-size ties keep panic first and otherwise prefer the
+closest-to-fill candidate.
 
 A selected non-panic reducer may coexist with ordinary grid, trailing, or EMA-anchor closes. Its
 quantity is reserved first; if aggregate close quantity would exceed the position, ordinary closes

--- a/docs/config.bot.md
+++ b/docs/config.bot.md
@@ -264,20 +264,21 @@ same-side TWEL measurement and toward the TWEL entry-gate baseline.
 
 Passivbot selects at most one protective reducer for each coin+pside in one
 ideal-order batch. Competing panic, TWEL/WEL auto-reduce, and auto-unstuck
-intents are consolidated by keeping the largest loss-admissible requested
-absolute reduction, not their sum. If the realized-loss gate blocks the largest
-non-panic intent, Passivbot tries the next-largest intent. Equal-size ties keep
-panic first and otherwise prefer the closest-to-fill candidate. A full-position
-panic close remains exclusive.
+intents are consolidated by keeping the largest loss-admissible final absolute
+reduction after position/minimum sizing, not their sum. If the realized-loss
+gate blocks the largest non-panic intent, Passivbot tries the next-largest
+intent. Equal-size ties keep panic first and otherwise prefer the
+closest-to-fill candidate. A full-position panic close remains exclusive.
 
 Ordinary strategy closes are independent reduction intent and may coexist with
 the selected non-panic reducer. The reducer quantity is reserved first; ordinary
 grid, trailing, or EMA-anchor closes are kept within the remaining position
 quantity and trimmed furthest-from-fill first if necessary. The aggregate remains
 reduce-only and capped to the position, and the realized-loss gate evaluates
-reducer candidates largest-first before ordinary closes in the resulting mixed
-close set. Live reconciliation preserves the same reducer-first reservation if
-the position shrinks between planning and order submission.
+the final reducer quantities largest-first across the batch before ordinary
+closes in the resulting mixed close set. Live reconciliation preserves the same
+reducer-first reservation if the position shrinks between planning and order
+submission.
 
 ## Risk-Control Stack
 

--- a/docs/config.bot.md
+++ b/docs/config.bot.md
@@ -263,8 +263,10 @@ same-side TWEL measurement and toward the TWEL entry-gate baseline.
 ## Close Reducer Compatibility
 
 Passivbot selects at most one protective reducer for each coin+pside in one
-ideal-order batch. Panic close is exclusive. TWEL/WEL exposure repair takes
-precedence over auto-unstuck, and only one competing reducer survives.
+ideal-order batch. Competing panic, TWEL/WEL auto-reduce, and auto-unstuck
+intents are consolidated by keeping the largest requested absolute reduction,
+not their sum. Equal-size ties keep panic first and otherwise prefer the
+closest-to-fill candidate. A full-position panic close remains exclusive.
 
 Ordinary strategy closes are independent reduction intent and may coexist with
 the selected non-panic reducer. The reducer quantity is reserved first; ordinary

--- a/docs/config.bot.md
+++ b/docs/config.bot.md
@@ -264,18 +264,20 @@ same-side TWEL measurement and toward the TWEL entry-gate baseline.
 
 Passivbot selects at most one protective reducer for each coin+pside in one
 ideal-order batch. Competing panic, TWEL/WEL auto-reduce, and auto-unstuck
-intents are consolidated by keeping the largest requested absolute reduction,
-not their sum. Equal-size ties keep panic first and otherwise prefer the
-closest-to-fill candidate. A full-position panic close remains exclusive.
+intents are consolidated by keeping the largest loss-admissible requested
+absolute reduction, not their sum. If the realized-loss gate blocks the largest
+non-panic intent, Passivbot tries the next-largest intent. Equal-size ties keep
+panic first and otherwise prefer the closest-to-fill candidate. A full-position
+panic close remains exclusive.
 
 Ordinary strategy closes are independent reduction intent and may coexist with
 the selected non-panic reducer. The reducer quantity is reserved first; ordinary
 grid, trailing, or EMA-anchor closes are kept within the remaining position
 quantity and trimmed furthest-from-fill first if necessary. The aggregate remains
-reduce-only and capped to the position, and the realized-loss gate evaluates the
-selected reducer before ordinary closes in the resulting mixed close set. Live
-reconciliation preserves the same reducer-first reservation if the position
-shrinks between planning and order submission.
+reduce-only and capped to the position, and the realized-loss gate evaluates
+reducer candidates largest-first before ordinary closes in the resulting mixed
+close set. Live reconciliation preserves the same reducer-first reservation if
+the position shrinks between planning and order submission.
 
 ## Risk-Control Stack
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -340,8 +340,9 @@ One non-panic protective reducer (TWEL/WEL auto-reduce or auto-unstuck) may coex
 grid, trailing, or EMA-anchor closes for the same position. Passivbot reserves the reducer quantity
 first and caps ordinary closes to the remaining position quantity. Panic close remains exclusive,
 and competing protective reducers do not stack: Passivbot keeps the largest loss-admissible
-requested absolute reduction rather than summing active safety intents, trying the next-largest
-intent when the realized-loss gate blocks a larger non-panic close.
+absolute reduction after final position/minimum sizing rather than summing active safety intents,
+trying the next-largest intent when the realized-loss gate blocks a larger non-panic close.
+Final reducer quantities compete largest-first across the shared batch loss allowance.
 
 ### Filter Parameters
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -339,8 +339,9 @@ If a position is stuck, the bot uses profits from other positions to realize los
 One non-panic protective reducer (TWEL/WEL auto-reduce or auto-unstuck) may coexist with ordinary
 grid, trailing, or EMA-anchor closes for the same position. Passivbot reserves the reducer quantity
 first and caps ordinary closes to the remaining position quantity. Panic close remains exclusive,
-and competing protective reducers do not stack: Passivbot keeps the largest requested absolute
-reduction rather than summing active safety intents.
+and competing protective reducers do not stack: Passivbot keeps the largest loss-admissible
+requested absolute reduction rather than summing active safety intents, trying the next-largest
+intent when the realized-loss gate blocks a larger non-panic close.
 
 ### Filter Parameters
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -339,7 +339,8 @@ If a position is stuck, the bot uses profits from other positions to realize los
 One non-panic protective reducer (TWEL/WEL auto-reduce or auto-unstuck) may coexist with ordinary
 grid, trailing, or EMA-anchor closes for the same position. Passivbot reserves the reducer quantity
 first and caps ordinary closes to the remaining position quantity. Panic close remains exclusive,
-and competing protective reducers do not stack.
+and competing protective reducers do not stack: Passivbot keeps the largest requested absolute
+reduction rather than summing active safety intents.
 
 ### Filter Parameters
 

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -875,9 +875,9 @@ Remaining implementation details:
       with ordinary closes whose aggregate quantity fits the position. Panic
       remains exclusive, and ordinary closes are trimmed before reducer quantity.
       The current canonical policy later replaced fixed reducer-type priority by
-      selecting the largest loss-admissible requested absolute protective
-      reduction, without summing competing intents; a loss-blocked candidate
-      falls back to the next-largest active safety intent.
+      selecting the largest loss-admissible final absolute protective reduction
+      after position/minimum sizing, without summing competing intents; a
+      loss-blocked candidate falls back to the next-largest active safety intent.
 - [x] Contract docs batch: unstuck min-qty overshoot, inherited lookbacks,
       HSL/config-change risks, statelessness, `pnls_max_lookback_days`, and
       HSL-enabled startup warning.

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -875,8 +875,9 @@ Remaining implementation details:
       with ordinary closes whose aggregate quantity fits the position. Panic
       remains exclusive, and ordinary closes are trimmed before reducer quantity.
       The current canonical policy later replaced fixed reducer-type priority by
-      selecting the largest requested absolute protective reduction, without
-      summing competing intents.
+      selecting the largest loss-admissible requested absolute protective
+      reduction, without summing competing intents; a loss-blocked candidate
+      falls back to the next-largest active safety intent.
 - [x] Contract docs batch: unstuck min-qty overshoot, inherited lookbacks,
       HSL/config-change risks, statelessness, `pnls_max_lookback_days`, and
       HSL-enabled startup warning.

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -874,6 +874,9 @@ Remaining implementation details:
       selects one protective reducer, but a selected non-panic reducer may coexist
       with ordinary closes whose aggregate quantity fits the position. Panic
       remains exclusive, and ordinary closes are trimmed before reducer quantity.
+      The current canonical policy later replaced fixed reducer-type priority by
+      selecting the largest requested absolute protective reduction, without
+      summing competing intents.
 - [x] Contract docs batch: unstuck min-qty overshoot, inherited lookbacks,
       HSL/config-change risks, statelessness, `pnls_max_lookback_days`, and
       HSL-enabled startup warning.

--- a/docs/risk_management.md
+++ b/docs/risk_management.md
@@ -89,10 +89,12 @@ that realized-loss floor.
 Auto-unstuck may be emitted in the same ideal-order batch as compatible ordinary
 grid, trailing, or EMA-anchor closes for that position. Passivbot keeps only one
 protective reducer, reserves its quantity, and caps ordinary closes to the
-remaining position size. Panic close remains exclusive, and exposure reducers
-still take precedence over auto-unstuck. The realized-loss gate evaluates the
-selected reducer before ordinary closes, and live reconciliation reapplies the
-cap against the latest position without consuming reducer quantity first.
+remaining position size. Competing panic, exposure-repair, and auto-unstuck
+intents are consolidated by keeping the largest requested absolute reduction,
+not their sum. A full-position panic remains exclusive. The realized-loss gate
+evaluates the selected reducer before ordinary closes, and live reconciliation
+reapplies the cap against the latest position without consuming reducer quantity
+first.
 
 Auto-unstuck allowance is reconstructed from the configured
 `live.pnls_max_lookback_days` fill/PnL window. Enabling auto-unstuck on an

--- a/docs/risk_management.md
+++ b/docs/risk_management.md
@@ -90,11 +90,12 @@ Auto-unstuck may be emitted in the same ideal-order batch as compatible ordinary
 grid, trailing, or EMA-anchor closes for that position. Passivbot keeps only one
 protective reducer, reserves its quantity, and caps ordinary closes to the
 remaining position size. Competing panic, exposure-repair, and auto-unstuck
-intents are consolidated by keeping the largest requested absolute reduction,
-not their sum. A full-position panic remains exclusive. The realized-loss gate
-evaluates the selected reducer before ordinary closes, and live reconciliation
-reapplies the cap against the latest position without consuming reducer quantity
-first.
+intents are consolidated by keeping the largest loss-admissible requested
+absolute reduction, not their sum. If the realized-loss gate blocks the largest
+non-panic intent, Passivbot tries the next-largest intent. A full-position panic
+remains exclusive. The realized-loss gate evaluates reducer candidates
+largest-first before ordinary closes, and live reconciliation reapplies the cap
+against the latest position without consuming reducer quantity first.
 
 Auto-unstuck allowance is reconstructed from the configured
 `live.pnls_max_lookback_days` fill/PnL window. Enabling auto-unstuck on an

--- a/docs/risk_management.md
+++ b/docs/risk_management.md
@@ -90,12 +90,13 @@ Auto-unstuck may be emitted in the same ideal-order batch as compatible ordinary
 grid, trailing, or EMA-anchor closes for that position. Passivbot keeps only one
 protective reducer, reserves its quantity, and caps ordinary closes to the
 remaining position size. Competing panic, exposure-repair, and auto-unstuck
-intents are consolidated by keeping the largest loss-admissible requested
-absolute reduction, not their sum. If the realized-loss gate blocks the largest
-non-panic intent, Passivbot tries the next-largest intent. A full-position panic
-remains exclusive. The realized-loss gate evaluates reducer candidates
-largest-first before ordinary closes, and live reconciliation reapplies the cap
-against the latest position without consuming reducer quantity first.
+intents are consolidated by keeping the largest loss-admissible final absolute
+reduction after position/minimum sizing, not their sum. If the realized-loss
+gate blocks the largest non-panic intent, Passivbot tries the next-largest
+intent. A full-position panic remains exclusive. The realized-loss gate
+evaluates reducer candidates largest-first across the shared batch allowance
+before ordinary closes, and live reconciliation reapplies the cap against the
+latest position without consuming reducer quantity first.
 
 Auto-unstuck allowance is reconstructed from the configured
 `live.pnls_max_lookback_days` fill/PnL window. Enabling auto-unstuck on an

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -650,6 +650,7 @@ mod core {
             .then_with(|| close_reducer_reachability_cmp(a, b, ob))
     }
 
+    #[cfg(test)]
     fn prune_competing_close_reducers(
         orders: &mut Vec<IdealOrder>,
         pside: PositionSide,
@@ -1628,6 +1629,51 @@ mod core {
         finalized
     }
 
+    fn finalized_reducer_candidates(
+        closes: &[IdealOrder],
+        pside: PositionSide,
+        position: &Position,
+        symbol: &SymbolInput,
+    ) -> Vec<FinalizedReducerCandidate> {
+        let mut candidates: Vec<FinalizedReducerCandidate> = closes
+            .iter()
+            .filter(|order| is_protective_close_reducer(order.order_type, pside))
+            .cloned()
+            .filter_map(|requested| {
+                let closes =
+                    finalized_closes_with_reducer(closes, Some(requested), pside, position, symbol);
+                let reducer = closes
+                    .iter()
+                    .find(|order| is_protective_close_reducer(order.order_type, pside))
+                    .cloned()?;
+                Some(FinalizedReducerCandidate { reducer, closes })
+            })
+            .collect();
+        candidates.sort_by(|a, b| {
+            close_reducer_preference_cmp(&a.reducer, &b.reducer, &symbol.order_book)
+        });
+        candidates
+    }
+
+    fn select_finalized_reducers_without_loss_gate(
+        input: &OrchestratorInput,
+        per_side: &mut [Option<PerSymbolOrders>],
+        pside: PositionSide,
+    ) {
+        for s in per_side.iter_mut().filter_map(|value| value.as_mut()) {
+            let Some(symbol) = input.symbols.get(s.symbol_idx) else {
+                continue;
+            };
+            let closes_without_reducer =
+                finalized_closes_with_reducer(&s.closes, None, pside, &s.pos, symbol);
+            s.closes = finalized_reducer_candidates(&s.closes, pside, &s.pos, symbol)
+                .into_iter()
+                .next()
+                .map(|candidate| candidate.closes)
+                .unwrap_or(closes_without_reducer);
+        }
+    }
+
     fn collect_reducer_candidates_for_side(
         input: &OrchestratorInput,
         per_side: &mut [Option<PerSymbolOrders>],
@@ -1642,34 +1688,9 @@ mod core {
             let Some(symbol) = input.symbols.get(s.symbol_idx) else {
                 continue;
             };
-            let mut requested_reducers: Vec<IdealOrder> = s
-                .closes
-                .iter()
-                .filter(|order| is_protective_close_reducer(order.order_type, pside))
-                .cloned()
-                .collect();
-            requested_reducers
-                .sort_by(|a, b| close_reducer_preference_cmp(a, b, &symbol.order_book));
-
             let closes_without_reducer =
                 finalized_closes_with_reducer(&s.closes, None, pside, &s.pos, symbol);
-            let candidates: Vec<FinalizedReducerCandidate> = requested_reducers
-                .into_iter()
-                .filter_map(|requested| {
-                    let closes = finalized_closes_with_reducer(
-                        &s.closes,
-                        Some(requested),
-                        pside,
-                        &s.pos,
-                        symbol,
-                    );
-                    let reducer = closes
-                        .iter()
-                        .find(|order| is_protective_close_reducer(order.order_type, pside))
-                        .cloned()?;
-                    Some(FinalizedReducerCandidate { reducer, closes })
-                })
-                .collect();
+            let candidates = finalized_reducer_candidates(&s.closes, pside, &s.pos, symbol);
             s.closes = closes_without_reducer.clone();
             if !candidates.is_empty() {
                 positions.push(ReducerPositionCandidates {
@@ -1734,23 +1755,6 @@ mod core {
         }
     }
 
-    fn trim_closes_for_side(
-        input: &OrchestratorInput,
-        per_side: &mut [Option<PerSymbolOrders>],
-        pside: PositionSide,
-    ) {
-        for s in per_side.iter_mut().filter_map(|v| v.as_mut()) {
-            let symbol = &input.symbols[s.symbol_idx];
-            trim_closes_to_position(
-                pside,
-                &mut s.closes,
-                s.pos.size,
-                &symbol.order_book,
-                &symbol.exchange,
-            );
-        }
-    }
-
     fn gate_ordinary_closes_for_side(
         input: &OrchestratorInput,
         per_side: &mut [Option<PerSymbolOrders>],
@@ -1793,24 +1797,8 @@ mod core {
         let mut loss_gate = realized_loss_gate_state(input);
 
         let Some(state) = loss_gate.as_mut() else {
-            for s in per_long.iter_mut().filter_map(|value| value.as_mut()) {
-                let symbol = &input.symbols[s.symbol_idx];
-                prune_competing_close_reducers(
-                    &mut s.closes,
-                    PositionSide::Long,
-                    &symbol.order_book,
-                );
-            }
-            for s in per_short.iter_mut().filter_map(|value| value.as_mut()) {
-                let symbol = &input.symbols[s.symbol_idx];
-                prune_competing_close_reducers(
-                    &mut s.closes,
-                    PositionSide::Short,
-                    &symbol.order_book,
-                );
-            }
-            trim_closes_for_side(input, per_long, PositionSide::Long);
-            trim_closes_for_side(input, per_short, PositionSide::Short);
+            select_finalized_reducers_without_loss_gate(input, per_long, PositionSide::Long);
+            select_finalized_reducers_without_loss_gate(input, per_short, PositionSide::Short);
             return;
         };
 
@@ -6470,6 +6458,76 @@ mod core {
             assert!((block.qty + 11.0).abs() < 1e-12);
             assert!((block.projected_balance_after - 890.0).abs() < 1e-12);
             assert!((block.balance_floor - 895.0).abs() < 1e-12);
+        }
+
+        #[test]
+        fn reducer_selection_uses_reachability_after_final_sizing() {
+            for max_realized_loss_pct in [0.5, 1.0] {
+                let mut sym = make_basic_symbol(0);
+                sym.order_book = OrderBook {
+                    bid: 100.0,
+                    ask: 100.0,
+                };
+                sym.exchange.qty_step = 0.5;
+                sym.exchange.min_qty = 9.0;
+                sym.exchange.min_cost = 0.0;
+                sym.exchange.maker_fee = 0.0;
+                sym.long.position = Position {
+                    size: 10.5,
+                    price: 100.0,
+                };
+
+                let input = OrchestratorInput {
+                    timestamp_ms: 0,
+                    balance: 1000.0,
+                    balance_raw: 1000.0,
+                    global: OrchestratorGlobal {
+                        max_realized_loss_pct,
+                        ..make_basic_global()
+                    },
+                    symbols: vec![sym.clone()],
+                    peek_hints: None,
+                    forager_hysteresis: None,
+                };
+                let mut per_long = vec![Some(PerSymbolOrders {
+                    symbol_idx: 0,
+                    entries: vec![],
+                    closes: vec![
+                        IdealOrder {
+                            symbol_idx: 0,
+                            pside: PositionSide::Long,
+                            qty: -10.0,
+                            price: 110.0,
+                            order_type: OrderType::CloseAutoReduceWelLong,
+                        },
+                        IdealOrder {
+                            symbol_idx: 0,
+                            pside: PositionSide::Long,
+                            qty: -9.5,
+                            price: 101.0,
+                            order_type: OrderType::CloseUnstuckLong,
+                        },
+                    ],
+                    pos: sym.long.position,
+                    mode: TradingMode::Normal,
+                })];
+                let mut per_short = vec![None];
+                let mut diagnostics = OrchestratorDiagnostics::default();
+
+                gate_lossy_closes_by_peak_balance(
+                    &input,
+                    &mut per_long,
+                    &mut per_short,
+                    &mut diagnostics,
+                );
+
+                let closes = &per_long[0].as_ref().unwrap().closes;
+                assert_eq!(closes.len(), 1);
+                assert_eq!(closes[0].order_type, OrderType::CloseUnstuckLong);
+                assert!((closes[0].qty + 10.5).abs() < 1e-12);
+                assert!((closes[0].price - 101.0).abs() < 1e-12);
+                assert!(diagnostics.loss_gate_blocks.is_empty());
+            }
         }
 
         #[test]

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -670,6 +670,14 @@ mod core {
         }
     }
 
+    #[derive(Clone, Copy)]
+    struct RealizedLossGateState {
+        pct: f64,
+        balance_peak: f64,
+        balance_floor: f64,
+        simulated_balance: f64,
+    }
+
     fn current_market_price(order_book: &OrderBook) -> f64 {
         if order_book.bid.is_finite()
             && order_book.ask.is_finite()
@@ -1500,95 +1508,225 @@ mod core {
         }
     }
 
+    fn realized_loss_gate_state(input: &OrchestratorInput) -> Option<RealizedLossGateState> {
+        let max_loss_pct = input.global.max_realized_loss_pct;
+        if !max_loss_pct.is_finite() || max_loss_pct >= 1.0 {
+            return None;
+        }
+        let pct = max_loss_pct.max(0.0);
+        let balance_raw = input_balance_raw(input);
+        if !balance_raw.is_finite() || balance_raw <= 0.0 {
+            return None;
+        }
+        let pnl_max = input.global.realized_pnl_cumsum_max;
+        let pnl_last = input.global.realized_pnl_cumsum_last;
+        if !pnl_max.is_finite() || !pnl_last.is_finite() {
+            return None;
+        }
+        let balance_peak = balance_raw + (pnl_max - pnl_last);
+        if !balance_peak.is_finite() || balance_peak <= 0.0 {
+            return None;
+        }
+        let balance_floor = balance_peak * (1.0 - pct);
+        if !balance_floor.is_finite() {
+            return None;
+        }
+        Some(RealizedLossGateState {
+            pct,
+            balance_peak,
+            balance_floor,
+            simulated_balance: balance_raw,
+        })
+    }
+
+    fn close_passes_realized_loss_gate(
+        input: &OrchestratorInput,
+        order: &IdealOrder,
+        position: &Position,
+        symbol: &SymbolInput,
+        state: &mut RealizedLossGateState,
+        diagnostics: &mut OrchestratorDiagnostics,
+    ) -> bool {
+        let Some(projected_pnl) = projected_close_pnl(
+            order,
+            position,
+            &symbol.exchange,
+            &input.global,
+            &symbol.order_book,
+        ) else {
+            return true;
+        };
+        let balance_before = state.simulated_balance;
+        let projected_balance_after = balance_before + projected_pnl;
+        if projected_pnl < 0.0 && projected_balance_after < state.balance_floor - 1e-12 {
+            diagnostics.loss_gate_blocks.push(LossGateBlock {
+                symbol_idx: order.symbol_idx,
+                pside: order.pside,
+                order_type: order.order_type,
+                qty: order.qty,
+                price: order.price,
+                projected_pnl,
+                balance_before,
+                projected_balance_after,
+                balance_peak: state.balance_peak,
+                balance_floor: state.balance_floor,
+                max_realized_loss_pct: state.pct,
+            });
+            return false;
+        }
+        if projected_pnl < 0.0 {
+            state.simulated_balance = projected_balance_after;
+        }
+        true
+    }
+
+    fn select_protective_reducers_for_side(
+        input: &OrchestratorInput,
+        per_side: &mut [Option<PerSymbolOrders>],
+        pside: PositionSide,
+        mut loss_gate: Option<&mut RealizedLossGateState>,
+        diagnostics: &mut OrchestratorDiagnostics,
+    ) {
+        for s in per_side.iter_mut().filter_map(|v| v.as_mut()) {
+            let Some(symbol) = input.symbols.get(s.symbol_idx) else {
+                continue;
+            };
+            if loss_gate.is_none() {
+                prune_competing_close_reducers(&mut s.closes, pside, &symbol.order_book);
+                continue;
+            }
+            let mut candidates: Vec<IdealOrder> = s
+                .closes
+                .iter()
+                .filter(|order| is_protective_close_reducer(order.order_type, pside))
+                .cloned()
+                .collect();
+            candidates.sort_by(|a, b| close_reducer_preference_cmp(a, b, &symbol.order_book));
+
+            let mut selected = None;
+            for candidate in candidates {
+                let allowed = if is_panic_close_order_type(candidate.order_type) {
+                    true
+                } else {
+                    close_passes_realized_loss_gate(
+                        input,
+                        &candidate,
+                        &s.pos,
+                        symbol,
+                        loss_gate.as_deref_mut().expect("loss gate checked above"),
+                        diagnostics,
+                    )
+                };
+                if allowed {
+                    selected = Some(candidate);
+                    break;
+                }
+            }
+
+            if selected
+                .as_ref()
+                .is_some_and(|order| is_panic_close_order_type(order.order_type))
+            {
+                s.closes.clear();
+            } else {
+                s.closes
+                    .retain(|order| !is_protective_close_reducer(order.order_type, pside));
+            }
+            if let Some(order) = selected {
+                s.closes.push(order);
+            }
+        }
+    }
+
+    fn trim_closes_for_side(
+        input: &OrchestratorInput,
+        per_side: &mut [Option<PerSymbolOrders>],
+        pside: PositionSide,
+    ) {
+        for s in per_side.iter_mut().filter_map(|v| v.as_mut()) {
+            let symbol = &input.symbols[s.symbol_idx];
+            trim_closes_to_position(
+                pside,
+                &mut s.closes,
+                s.pos.size,
+                &symbol.order_book,
+                &symbol.exchange,
+            );
+        }
+    }
+
+    fn gate_ordinary_closes_for_side(
+        input: &OrchestratorInput,
+        per_side: &mut [Option<PerSymbolOrders>],
+        pside: PositionSide,
+        state: &mut RealizedLossGateState,
+        diagnostics: &mut OrchestratorDiagnostics,
+    ) {
+        for s in per_side.iter_mut().filter_map(|v| v.as_mut()) {
+            let Some(symbol) = input.symbols.get(s.symbol_idx) else {
+                continue;
+            };
+            let mut kept = Vec::with_capacity(s.closes.len());
+            for order in s.closes.drain(..) {
+                let gateable = is_close_order_type(order.order_type)
+                    && !is_panic_close_order_type(order.order_type)
+                    && !is_protective_close_reducer(order.order_type, pside);
+                if !gateable
+                    || close_passes_realized_loss_gate(
+                        input,
+                        &order,
+                        &s.pos,
+                        symbol,
+                        state,
+                        diagnostics,
+                    )
+                {
+                    kept.push(order);
+                }
+            }
+            s.closes = kept;
+        }
+    }
+
     fn gate_lossy_closes_by_peak_balance(
         input: &OrchestratorInput,
         per_long: &mut [Option<PerSymbolOrders>],
         per_short: &mut [Option<PerSymbolOrders>],
         diagnostics: &mut OrchestratorDiagnostics,
     ) {
-        let max_loss_pct = input.global.max_realized_loss_pct;
-        if !max_loss_pct.is_finite() || max_loss_pct >= 1.0 {
-            return;
-        }
-        let pct = max_loss_pct.max(0.0);
-        let balance_raw = input_balance_raw(input);
-        if !balance_raw.is_finite() || balance_raw <= 0.0 {
-            return;
-        }
-        let pnl_max = input.global.realized_pnl_cumsum_max;
-        let pnl_last = input.global.realized_pnl_cumsum_last;
-        if !pnl_max.is_finite() || !pnl_last.is_finite() {
-            return;
-        }
-        let balance_peak = balance_raw + (pnl_max - pnl_last);
-        if !balance_peak.is_finite() || balance_peak <= 0.0 {
-            return;
-        }
-        let balance_floor = balance_peak * (1.0 - pct);
-        if !balance_floor.is_finite() {
-            return;
-        }
-        let mut simulated_balance = balance_raw;
+        let mut loss_gate = realized_loss_gate_state(input);
 
-        let mut gate_pass =
-            |per_side: &mut [Option<PerSymbolOrders>], pside, reducers_only: bool| {
-                for s in per_side.iter_mut().filter_map(|v| v.as_mut()) {
-                    let symbol = match input.symbols.get(s.symbol_idx) {
-                        Some(symbol) => symbol,
-                        None => continue,
-                    };
-                    let mut kept: Vec<IdealOrder> = Vec::with_capacity(s.closes.len());
-                    for order in s.closes.drain(..) {
-                        let is_gateable = is_close_order_type(order.order_type)
-                            && !is_panic_close_order_type(order.order_type);
-                        let is_reducer = is_protective_close_reducer(order.order_type, pside);
-                        if !is_gateable || is_reducer != reducers_only {
-                            kept.push(order);
-                            continue;
-                        }
-                        let Some(projected_pnl) = projected_close_pnl(
-                            &order,
-                            &s.pos,
-                            &symbol.exchange,
-                            &input.global,
-                            &symbol.order_book,
-                        ) else {
-                            kept.push(order);
-                            continue;
-                        };
-                        let balance_before = simulated_balance;
-                        let projected_balance_after = balance_before + projected_pnl;
-                        if projected_pnl < 0.0 && projected_balance_after < balance_floor - 1e-12 {
-                            diagnostics.loss_gate_blocks.push(LossGateBlock {
-                                symbol_idx: order.symbol_idx,
-                                pside: order.pside,
-                                order_type: order.order_type,
-                                qty: order.qty,
-                                price: order.price,
-                                projected_pnl,
-                                balance_before,
-                                projected_balance_after,
-                                balance_peak,
-                                balance_floor,
-                                max_realized_loss_pct: pct,
-                            });
-                            continue;
-                        }
-                        if projected_pnl < 0.0 {
-                            simulated_balance = projected_balance_after;
-                        }
-                        kept.push(order);
-                    }
-                    s.closes = kept;
-                }
-            };
+        // The simulated balance is shared by the whole batch. Select the largest admissible
+        // reducer for each position across both sides before ordinary closes can consume loss
+        // allowance. If a larger reducer is blocked, try the next-largest active safety intent.
+        select_protective_reducers_for_side(
+            input,
+            per_long,
+            PositionSide::Long,
+            loss_gate.as_mut(),
+            diagnostics,
+        );
+        select_protective_reducers_for_side(
+            input,
+            per_short,
+            PositionSide::Short,
+            loss_gate.as_mut(),
+            diagnostics,
+        );
 
-        // The simulated balance is shared by the whole batch, so run every selected protective
-        // reducer before allowing any ordinary close to consume realized-loss allowance.
-        gate_pass(per_long, PositionSide::Long, true);
-        gate_pass(per_short, PositionSide::Short, true);
-        gate_pass(per_long, PositionSide::Long, false);
-        gate_pass(per_short, PositionSide::Short, false);
+        trim_closes_for_side(input, per_long, PositionSide::Long);
+        trim_closes_for_side(input, per_short, PositionSide::Short);
+
+        if let Some(state) = loss_gate.as_mut() {
+            gate_ordinary_closes_for_side(input, per_long, PositionSide::Long, state, diagnostics);
+            gate_ordinary_closes_for_side(
+                input,
+                per_short,
+                PositionSide::Short,
+                state,
+                diagnostics,
+            );
+        }
     }
 
     fn twel_repair_target(bot: &BotParams) -> Option<f64> {
@@ -3457,32 +3595,8 @@ mod core {
         let twel_candidate_count_long = twel_selected_long.len();
         let twel_candidate_count_short = twel_selected_short.len();
 
-        // Select one protective reducer per symbol, preserve compatible ordinary closes, and cap
-        // their aggregate to position size with reducer quantity reserved first.
-        for s in per_long.iter_mut().filter_map(|v| v.as_mut()) {
-            let sym = &input.symbols[s.symbol_idx];
-            prune_competing_close_reducers(&mut s.closes, PositionSide::Long, &sym.order_book);
-            trim_closes_to_position(
-                PositionSide::Long,
-                &mut s.closes,
-                s.pos.size,
-                &sym.order_book,
-                &sym.exchange,
-            );
-        }
-        for s in per_short.iter_mut().filter_map(|v| v.as_mut()) {
-            let sym = &input.symbols[s.symbol_idx];
-            prune_competing_close_reducers(&mut s.closes, PositionSide::Short, &sym.order_book);
-            trim_closes_to_position(
-                PositionSide::Short,
-                &mut s.closes,
-                s.pos.size,
-                &sym.order_book,
-                &sym.exchange,
-            );
-        }
-
-        // Global realized-loss gate for close orders (all close types except panic).
+        // Select one loss-admissible protective reducer per symbol, cap aggregate close quantity,
+        // and apply the global realized-loss gate (all close types except panic).
         gate_lossy_closes_by_peak_balance(input, per_long, per_short, &mut diagnostics);
         push_twel_loss_gate_warnings(
             input,
@@ -6092,6 +6206,74 @@ mod core {
             assert!((block.balance_before - 940.0).abs() < 1e-12);
             assert!((block.projected_balance_after - 880.0).abs() < 1e-12);
             assert!((block.balance_floor - 900.0).abs() < 1e-12);
+        }
+
+        #[test]
+        fn realized_loss_gate_falls_back_to_smaller_protective_reducer() {
+            let mut sym = make_basic_symbol(0);
+            sym.order_book = OrderBook {
+                bid: 90.0,
+                ask: 90.0,
+            };
+            sym.exchange.maker_fee = 0.0;
+            sym.long.position = Position {
+                size: 10.0,
+                price: 100.0,
+            };
+
+            let input = OrchestratorInput {
+                timestamp_ms: 0,
+                balance: 1000.0,
+                balance_raw: 1000.0,
+                global: OrchestratorGlobal {
+                    max_realized_loss_pct: 0.05,
+                    ..make_basic_global()
+                },
+                symbols: vec![sym.clone()],
+                peek_hints: None,
+                forager_hysteresis: None,
+            };
+            let mut per_long = vec![Some(PerSymbolOrders {
+                symbol_idx: 0,
+                entries: vec![],
+                closes: vec![
+                    IdealOrder {
+                        symbol_idx: 0,
+                        pside: PositionSide::Long,
+                        qty: -6.0,
+                        price: 90.0,
+                        order_type: OrderType::CloseAutoReduceWelLong,
+                    },
+                    IdealOrder {
+                        symbol_idx: 0,
+                        pside: PositionSide::Long,
+                        qty: -4.0,
+                        price: 90.0,
+                        order_type: OrderType::CloseUnstuckLong,
+                    },
+                ],
+                pos: sym.long.position,
+                mode: TradingMode::Normal,
+            })];
+            let mut per_short = vec![None];
+            let mut diagnostics = OrchestratorDiagnostics::default();
+
+            gate_lossy_closes_by_peak_balance(
+                &input,
+                &mut per_long,
+                &mut per_short,
+                &mut diagnostics,
+            );
+
+            let closes = &per_long[0].as_ref().unwrap().closes;
+            assert_eq!(closes.len(), 1);
+            assert_eq!(closes[0].order_type, OrderType::CloseUnstuckLong);
+            assert!((closes[0].qty + 4.0).abs() < 1e-12);
+            assert_eq!(diagnostics.loss_gate_blocks.len(), 1);
+            let block = &diagnostics.loss_gate_blocks[0];
+            assert_eq!(block.order_type, OrderType::CloseAutoReduceWelLong);
+            assert!((block.projected_balance_after - 940.0).abs() < 1e-12);
+            assert!((block.balance_floor - 950.0).abs() < 1e-12);
         }
 
         #[test]

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -590,39 +590,12 @@ mod core {
         )
     }
 
-    fn is_higher_priority_reducer_than_unstuck(order_type: OrderType, pside: PositionSide) -> bool {
-        matches!(
-            (pside, order_type),
-            (PositionSide::Long, OrderType::ClosePanicLong)
-                | (PositionSide::Long, OrderType::CloseAutoReduceTwelLong)
-                | (PositionSide::Long, OrderType::CloseAutoReduceWelLong)
-                | (PositionSide::Short, OrderType::ClosePanicShort)
-                | (PositionSide::Short, OrderType::CloseAutoReduceTwelShort)
-                | (PositionSide::Short, OrderType::CloseAutoReduceWelShort)
-        )
-    }
-
     fn is_twel_close_order_type(order_type: OrderType, pside: PositionSide) -> bool {
         matches!(
             (pside, order_type),
             (PositionSide::Long, OrderType::CloseAutoReduceTwelLong)
                 | (PositionSide::Short, OrderType::CloseAutoReduceTwelShort)
         )
-    }
-
-    fn close_reducer_priority(order_type: OrderType, pside: PositionSide) -> Option<u8> {
-        match (pside, order_type) {
-            (PositionSide::Long, OrderType::ClosePanicLong)
-            | (PositionSide::Short, OrderType::ClosePanicShort) => Some(0),
-            (PositionSide::Long, OrderType::CloseAutoReduceTwelLong)
-            | (PositionSide::Long, OrderType::CloseAutoReduceWelLong)
-            | (PositionSide::Short, OrderType::CloseAutoReduceTwelShort)
-            | (PositionSide::Short, OrderType::CloseAutoReduceWelShort) => Some(1),
-            (PositionSide::Long, OrderType::CloseUnstuckLong)
-            | (PositionSide::Short, OrderType::CloseUnstuckShort) => Some(2),
-            _ if is_close_order_type(order_type) => Some(3),
-            _ => None,
-        }
     }
 
     fn close_reducer_reachability_cmp(
@@ -648,7 +621,33 @@ mod core {
     }
 
     fn is_protective_close_reducer(order_type: OrderType, pside: PositionSide) -> bool {
-        matches!(close_reducer_priority(order_type, pside), Some(0..=2))
+        matches!(
+            (pside, order_type),
+            (PositionSide::Long, OrderType::ClosePanicLong)
+                | (PositionSide::Long, OrderType::CloseAutoReduceTwelLong)
+                | (PositionSide::Long, OrderType::CloseAutoReduceWelLong)
+                | (PositionSide::Long, OrderType::CloseUnstuckLong)
+                | (PositionSide::Short, OrderType::ClosePanicShort)
+                | (PositionSide::Short, OrderType::CloseAutoReduceTwelShort)
+                | (PositionSide::Short, OrderType::CloseAutoReduceWelShort)
+                | (PositionSide::Short, OrderType::CloseUnstuckShort)
+        )
+    }
+
+    fn close_reducer_preference_cmp(
+        a: &IdealOrder,
+        b: &IdealOrder,
+        ob: &OrderBook,
+    ) -> std::cmp::Ordering {
+        // Larger reductions win. Reachability and stable order fields only break equal-size ties.
+        b.qty
+            .abs()
+            .total_cmp(&a.qty.abs())
+            .then_with(|| {
+                is_panic_close_order_type(b.order_type)
+                    .cmp(&is_panic_close_order_type(a.order_type))
+            })
+            .then_with(|| close_reducer_reachability_cmp(a, b, ob))
     }
 
     fn prune_competing_close_reducers(
@@ -656,26 +655,18 @@ mod core {
         pside: PositionSide,
         ob: &OrderBook,
     ) {
-        let highest = orders
+        let selected_reducer = orders
             .iter()
-            .filter_map(|order| close_reducer_priority(order.order_type, pside))
-            .min();
-        if let Some(priority) = highest {
-            if priority < 3 {
-                let selected_reducer = orders
-                    .iter()
-                    .filter(|order| {
-                        close_reducer_priority(order.order_type, pside) == Some(priority)
-                    })
-                    .min_by(|a, b| close_reducer_reachability_cmp(a, b, ob))
-                    .cloned();
-                orders.retain(|order| {
-                    priority > 0 && close_reducer_priority(order.order_type, pside) == Some(3)
-                });
-                if let Some(reducer) = selected_reducer {
-                    orders.push(reducer);
-                }
+            .filter(|order| is_protective_close_reducer(order.order_type, pside))
+            .min_by(|a, b| close_reducer_preference_cmp(a, b, ob))
+            .cloned();
+        if let Some(reducer) = selected_reducer {
+            if is_panic_close_order_type(reducer.order_type) {
+                orders.clear();
+            } else {
+                orders.retain(|order| !is_protective_close_reducer(order.order_type, pside));
             }
+            orders.push(reducer);
         }
     }
 
@@ -741,11 +732,7 @@ mod core {
         } else {
             ExecutionType::Limit
         };
-        let execution_priority = if is_panic_close_order_type(order.order_type)
-            || matches!(
-                close_reducer_priority(order.order_type, order.pside),
-                Some(1) | Some(2)
-            )
+        let execution_priority = if is_protective_close_reducer(order.order_type, order.pside)
             || (mode == TradingMode::GracefulStop && order.order_type.is_close())
         {
             ExecutionPriority::RiskCritical
@@ -3319,26 +3306,12 @@ mod core {
                 match ideal.pside {
                     PositionSide::Long => {
                         if let Some(s) = per_long.get_mut(idx).and_then(|v| v.as_mut()) {
-                            if !s.closes.iter().any(|o| {
-                                is_higher_priority_reducer_than_unstuck(
-                                    o.order_type,
-                                    PositionSide::Long,
-                                )
-                            }) {
-                                s.closes.push(ideal);
-                            }
+                            s.closes.push(ideal);
                         }
                     }
                     PositionSide::Short => {
                         if let Some(s) = per_short.get_mut(idx).and_then(|v| v.as_mut()) {
-                            if !s.closes.iter().any(|o| {
-                                is_higher_priority_reducer_than_unstuck(
-                                    o.order_type,
-                                    PositionSide::Short,
-                                )
-                            }) {
-                                s.closes.push(ideal);
-                            }
+                            s.closes.push(ideal);
                         }
                     }
                 }
@@ -3403,12 +3376,6 @@ mod core {
             );
             for (idx, order) in actions {
                 if let Some(s) = per_long.get_mut(idx).and_then(|v| v.as_mut()) {
-                    s.closes.retain(|o| {
-                        !matches!(
-                            o.order_type,
-                            OrderType::CloseAutoReduceWelLong | OrderType::CloseUnstuckLong
-                        )
-                    });
                     s.closes.push(IdealOrder {
                         symbol_idx: idx,
                         pside: PositionSide::Long,
@@ -3475,12 +3442,6 @@ mod core {
             );
             for (idx, order) in actions {
                 if let Some(s) = per_short.get_mut(idx).and_then(|v| v.as_mut()) {
-                    s.closes.retain(|o| {
-                        !matches!(
-                            o.order_type,
-                            OrderType::CloseAutoReduceWelShort | OrderType::CloseUnstuckShort
-                        )
-                    });
                     s.closes.push(IdealOrder {
                         symbol_idx: idx,
                         pside: PositionSide::Short,
@@ -4318,7 +4279,7 @@ mod core {
         }
 
         #[test]
-        fn close_reducer_selection_keeps_single_closest_reducer_and_ordinary_close() {
+        fn close_reducer_selection_keeps_largest_reducer_and_ordinary_close() {
             let order_book = OrderBook {
                 bid: 100.0,
                 ask: 101.0,
@@ -4327,16 +4288,16 @@ mod core {
                 IdealOrder {
                     symbol_idx: 0,
                     pside: PositionSide::Long,
-                    qty: -0.3,
-                    price: 102.0,
+                    qty: -0.01,
+                    price: 100.9,
                     order_type: OrderType::CloseAutoReduceWelLong,
                 },
                 IdealOrder {
                     symbol_idx: 0,
                     pside: PositionSide::Long,
-                    qty: -0.3,
-                    price: 101.1,
-                    order_type: OrderType::CloseAutoReduceTwelLong,
+                    qty: -0.81,
+                    price: 102.0,
+                    order_type: OrderType::CloseUnstuckLong,
                 },
                 IdealOrder {
                     symbol_idx: 0,
@@ -4351,8 +4312,7 @@ mod core {
 
             assert_eq!(closes.len(), 2);
             assert!(closes.iter().any(|order| {
-                order.order_type == OrderType::CloseAutoReduceTwelLong
-                    && (order.price - 101.1).abs() < 1e-12
+                order.order_type == OrderType::CloseUnstuckLong && (order.qty + 0.81).abs() < 1e-12
             }));
             assert!(closes
                 .iter()
@@ -4360,7 +4320,7 @@ mod core {
         }
 
         #[test]
-        fn close_pruning_prefers_reachable_long_reducer_with_same_priority() {
+        fn close_pruning_prefers_reachable_long_reducer_with_equal_size() {
             let order_book = OrderBook {
                 bid: 100.0,
                 ask: 101.0,
@@ -4390,7 +4350,7 @@ mod core {
         }
 
         #[test]
-        fn close_pruning_prefers_reachable_short_reducer_with_same_priority() {
+        fn close_pruning_prefers_reachable_short_reducer_with_equal_size() {
             let order_book = OrderBook {
                 bid: 100.0,
                 ask: 101.0,

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -678,6 +678,22 @@ mod core {
         simulated_balance: f64,
     }
 
+    #[derive(Clone)]
+    struct FinalizedReducerCandidate {
+        reducer: IdealOrder,
+        closes: Vec<IdealOrder>,
+    }
+
+    struct ReducerPositionCandidates {
+        pside: PositionSide,
+        slot_idx: usize,
+        position: Position,
+        candidates: Vec<FinalizedReducerCandidate>,
+        next_candidate_idx: usize,
+        selected_closes: Option<Vec<IdealOrder>>,
+        closes_without_reducer: Vec<IdealOrder>,
+    }
+
     fn current_market_price(order_book: &OrderBook) -> f64 {
         if order_book.bid.is_finite()
             && order_book.ask.is_finite()
@@ -1580,60 +1596,140 @@ mod core {
         true
     }
 
-    fn select_protective_reducers_for_side(
+    fn finalized_closes_with_reducer(
+        closes: &[IdealOrder],
+        reducer: Option<IdealOrder>,
+        pside: PositionSide,
+        position: &Position,
+        symbol: &SymbolInput,
+    ) -> Vec<IdealOrder> {
+        let mut finalized = if reducer
+            .as_ref()
+            .is_some_and(|order| is_panic_close_order_type(order.order_type))
+        {
+            Vec::new()
+        } else {
+            closes
+                .iter()
+                .filter(|order| !is_protective_close_reducer(order.order_type, pside))
+                .cloned()
+                .collect()
+        };
+        if let Some(order) = reducer {
+            finalized.push(order);
+        }
+        trim_closes_to_position(
+            pside,
+            &mut finalized,
+            position.size,
+            &symbol.order_book,
+            &symbol.exchange,
+        );
+        finalized
+    }
+
+    fn collect_reducer_candidates_for_side(
         input: &OrchestratorInput,
         per_side: &mut [Option<PerSymbolOrders>],
         pside: PositionSide,
-        mut loss_gate: Option<&mut RealizedLossGateState>,
-        diagnostics: &mut OrchestratorDiagnostics,
+        positions: &mut Vec<ReducerPositionCandidates>,
     ) {
-        for s in per_side.iter_mut().filter_map(|v| v.as_mut()) {
+        for (slot_idx, s) in per_side
+            .iter_mut()
+            .enumerate()
+            .filter_map(|(idx, value)| value.as_mut().map(|orders| (idx, orders)))
+        {
             let Some(symbol) = input.symbols.get(s.symbol_idx) else {
                 continue;
             };
-            if loss_gate.is_none() {
-                prune_competing_close_reducers(&mut s.closes, pside, &symbol.order_book);
-                continue;
-            }
-            let mut candidates: Vec<IdealOrder> = s
+            let mut requested_reducers: Vec<IdealOrder> = s
                 .closes
                 .iter()
                 .filter(|order| is_protective_close_reducer(order.order_type, pside))
                 .cloned()
                 .collect();
-            candidates.sort_by(|a, b| close_reducer_preference_cmp(a, b, &symbol.order_book));
+            requested_reducers
+                .sort_by(|a, b| close_reducer_preference_cmp(a, b, &symbol.order_book));
 
-            let mut selected = None;
-            for candidate in candidates {
-                let allowed = if is_panic_close_order_type(candidate.order_type) {
-                    true
-                } else {
-                    close_passes_realized_loss_gate(
-                        input,
-                        &candidate,
+            let closes_without_reducer =
+                finalized_closes_with_reducer(&s.closes, None, pside, &s.pos, symbol);
+            let candidates: Vec<FinalizedReducerCandidate> = requested_reducers
+                .into_iter()
+                .filter_map(|requested| {
+                    let closes = finalized_closes_with_reducer(
+                        &s.closes,
+                        Some(requested),
+                        pside,
                         &s.pos,
                         symbol,
-                        loss_gate.as_deref_mut().expect("loss gate checked above"),
-                        diagnostics,
-                    )
-                };
-                if allowed {
-                    selected = Some(candidate);
-                    break;
-                }
+                    );
+                    let reducer = closes
+                        .iter()
+                        .find(|order| is_protective_close_reducer(order.order_type, pside))
+                        .cloned()?;
+                    Some(FinalizedReducerCandidate { reducer, closes })
+                })
+                .collect();
+            s.closes = closes_without_reducer.clone();
+            if !candidates.is_empty() {
+                positions.push(ReducerPositionCandidates {
+                    pside,
+                    slot_idx,
+                    position: s.pos,
+                    candidates,
+                    next_candidate_idx: 0,
+                    selected_closes: None,
+                    closes_without_reducer,
+                });
             }
+        }
+    }
 
-            if selected
-                .as_ref()
-                .is_some_and(|order| is_panic_close_order_type(order.order_type))
+    fn batch_reducer_preference_cmp(
+        a: &ReducerPositionCandidates,
+        b: &ReducerPositionCandidates,
+    ) -> std::cmp::Ordering {
+        let a_order = &a.candidates[a.next_candidate_idx].reducer;
+        let b_order = &b.candidates[b.next_candidate_idx].reducer;
+        let a_pside_rank = match a.pside {
+            PositionSide::Long => 0u8,
+            PositionSide::Short => 1u8,
+        };
+        let b_pside_rank = match b.pside {
+            PositionSide::Long => 0u8,
+            PositionSide::Short => 1u8,
+        };
+        b_order
+            .qty
+            .abs()
+            .total_cmp(&a_order.qty.abs())
+            .then_with(|| {
+                is_panic_close_order_type(b_order.order_type)
+                    .cmp(&is_panic_close_order_type(a_order.order_type))
+            })
+            .then_with(|| a_order.symbol_idx.cmp(&b_order.symbol_idx))
+            .then_with(|| a_pside_rank.cmp(&b_pside_rank))
+            .then_with(|| a_order.order_type.id().cmp(&b_order.order_type.id()))
+            .then_with(|| a_order.price.total_cmp(&b_order.price))
+            .then_with(|| a_order.qty.total_cmp(&b_order.qty))
+    }
+
+    fn apply_selected_reducers_for_side(
+        per_side: &mut [Option<PerSymbolOrders>],
+        pside: PositionSide,
+        positions: Vec<ReducerPositionCandidates>,
+    ) {
+        for position in positions
+            .into_iter()
+            .filter(|position| position.pside == pside)
+        {
+            if let Some(s) = per_side
+                .get_mut(position.slot_idx)
+                .and_then(|value| value.as_mut())
             {
-                s.closes.clear();
-            } else {
-                s.closes
-                    .retain(|order| !is_protective_close_reducer(order.order_type, pside));
-            }
-            if let Some(order) = selected {
-                s.closes.push(order);
+                s.closes = position
+                    .selected_closes
+                    .unwrap_or(position.closes_without_reducer);
             }
         }
     }
@@ -1696,37 +1792,77 @@ mod core {
     ) {
         let mut loss_gate = realized_loss_gate_state(input);
 
-        // The simulated balance is shared by the whole batch. Select the largest admissible
-        // reducer for each position across both sides before ordinary closes can consume loss
-        // allowance. If a larger reducer is blocked, try the next-largest active safety intent.
-        select_protective_reducers_for_side(
-            input,
-            per_long,
-            PositionSide::Long,
-            loss_gate.as_mut(),
-            diagnostics,
-        );
-        select_protective_reducers_for_side(
-            input,
-            per_short,
-            PositionSide::Short,
-            loss_gate.as_mut(),
-            diagnostics,
-        );
+        let Some(state) = loss_gate.as_mut() else {
+            for s in per_long.iter_mut().filter_map(|value| value.as_mut()) {
+                let symbol = &input.symbols[s.symbol_idx];
+                prune_competing_close_reducers(
+                    &mut s.closes,
+                    PositionSide::Long,
+                    &symbol.order_book,
+                );
+            }
+            for s in per_short.iter_mut().filter_map(|value| value.as_mut()) {
+                let symbol = &input.symbols[s.symbol_idx];
+                prune_competing_close_reducers(
+                    &mut s.closes,
+                    PositionSide::Short,
+                    &symbol.order_book,
+                );
+            }
+            trim_closes_for_side(input, per_long, PositionSide::Long);
+            trim_closes_for_side(input, per_short, PositionSide::Short);
+            return;
+        };
 
-        trim_closes_for_side(input, per_long, PositionSide::Long);
-        trim_closes_for_side(input, per_short, PositionSide::Short);
+        // Finalize each candidate's executable close sizing before evaluating its loss. The
+        // simulated balance is shared by the whole batch, so consider each position's current
+        // largest candidate globally rather than spending the allowance in symbol iteration order.
+        let mut positions = Vec::new();
+        collect_reducer_candidates_for_side(input, per_long, PositionSide::Long, &mut positions);
+        collect_reducer_candidates_for_side(input, per_short, PositionSide::Short, &mut positions);
 
-        if let Some(state) = loss_gate.as_mut() {
-            gate_ordinary_closes_for_side(input, per_long, PositionSide::Long, state, diagnostics);
-            gate_ordinary_closes_for_side(
-                input,
-                per_short,
-                PositionSide::Short,
-                state,
-                diagnostics,
-            );
+        while let Some(position_idx) = positions
+            .iter()
+            .enumerate()
+            .filter(|(_, position)| {
+                position.selected_closes.is_none()
+                    && position.next_candidate_idx < position.candidates.len()
+            })
+            .min_by(|(_, a), (_, b)| batch_reducer_preference_cmp(a, b))
+            .map(|(idx, _)| idx)
+        {
+            let candidate_idx = positions[position_idx].next_candidate_idx;
+            let candidate = positions[position_idx].candidates[candidate_idx].clone();
+            let symbol = &input.symbols[candidate.reducer.symbol_idx];
+            let allowed = is_panic_close_order_type(candidate.reducer.order_type)
+                || close_passes_realized_loss_gate(
+                    input,
+                    &candidate.reducer,
+                    &positions[position_idx].position,
+                    symbol,
+                    state,
+                    diagnostics,
+                );
+            if allowed {
+                positions[position_idx].selected_closes = Some(candidate.closes);
+            } else {
+                positions[position_idx].next_candidate_idx += 1;
+            }
         }
+
+        let mut short_positions = Vec::new();
+        let mut long_positions = Vec::new();
+        for position in positions {
+            match position.pside {
+                PositionSide::Long => long_positions.push(position),
+                PositionSide::Short => short_positions.push(position),
+            }
+        }
+        apply_selected_reducers_for_side(per_long, PositionSide::Long, long_positions);
+        apply_selected_reducers_for_side(per_short, PositionSide::Short, short_positions);
+
+        gate_ordinary_closes_for_side(input, per_long, PositionSide::Long, state, diagnostics);
+        gate_ordinary_closes_for_side(input, per_short, PositionSide::Short, state, diagnostics);
     }
 
     fn twel_repair_target(bot: &BotParams) -> Option<f64> {
@@ -6274,6 +6410,151 @@ mod core {
             assert_eq!(block.order_type, OrderType::CloseAutoReduceWelLong);
             assert!((block.projected_balance_after - 940.0).abs() < 1e-12);
             assert!((block.balance_floor - 950.0).abs() < 1e-12);
+        }
+
+        #[test]
+        fn realized_loss_gate_checks_reducer_after_dust_is_absorbed() {
+            let mut sym = make_basic_symbol(0);
+            sym.order_book = OrderBook {
+                bid: 90.0,
+                ask: 90.0,
+            };
+            sym.exchange.qty_step = 1.0;
+            sym.exchange.min_qty = 10.0;
+            sym.exchange.min_cost = 0.0;
+            sym.exchange.maker_fee = 0.0;
+            sym.long.position = Position {
+                size: 11.0,
+                price: 100.0,
+            };
+
+            let input = OrchestratorInput {
+                timestamp_ms: 0,
+                balance: 1000.0,
+                balance_raw: 1000.0,
+                global: OrchestratorGlobal {
+                    max_realized_loss_pct: 0.105,
+                    ..make_basic_global()
+                },
+                symbols: vec![sym.clone()],
+                peek_hints: None,
+                forager_hysteresis: None,
+            };
+            let mut per_long = vec![Some(PerSymbolOrders {
+                symbol_idx: 0,
+                entries: vec![],
+                closes: vec![IdealOrder {
+                    symbol_idx: 0,
+                    pside: PositionSide::Long,
+                    qty: -10.0,
+                    price: 90.0,
+                    order_type: OrderType::CloseAutoReduceWelLong,
+                }],
+                pos: sym.long.position,
+                mode: TradingMode::Normal,
+            })];
+            let mut per_short = vec![None];
+            let mut diagnostics = OrchestratorDiagnostics::default();
+
+            gate_lossy_closes_by_peak_balance(
+                &input,
+                &mut per_long,
+                &mut per_short,
+                &mut diagnostics,
+            );
+
+            assert!(per_long[0].as_ref().unwrap().closes.is_empty());
+            assert_eq!(diagnostics.loss_gate_blocks.len(), 1);
+            let block = &diagnostics.loss_gate_blocks[0];
+            assert_eq!(block.order_type, OrderType::CloseAutoReduceWelLong);
+            assert!((block.qty + 11.0).abs() < 1e-12);
+            assert!((block.projected_balance_after - 890.0).abs() < 1e-12);
+            assert!((block.balance_floor - 895.0).abs() < 1e-12);
+        }
+
+        #[test]
+        fn realized_loss_gate_prioritizes_larger_reducers_across_symbols() {
+            let mut sym0 = make_basic_symbol(0);
+            sym0.order_book = OrderBook {
+                bid: 90.0,
+                ask: 90.0,
+            };
+            sym0.exchange.maker_fee = 0.0;
+            sym0.long.position = Position {
+                size: 4.0,
+                price: 100.0,
+            };
+
+            let mut sym1 = make_basic_symbol(1);
+            sym1.order_book = sym0.order_book.clone();
+            sym1.exchange.maker_fee = 0.0;
+            sym1.long.position = Position {
+                size: 6.0,
+                price: 100.0,
+            };
+
+            let input = OrchestratorInput {
+                timestamp_ms: 0,
+                balance: 1000.0,
+                balance_raw: 1000.0,
+                global: OrchestratorGlobal {
+                    max_realized_loss_pct: 0.07,
+                    ..make_basic_global()
+                },
+                symbols: vec![sym0.clone(), sym1.clone()],
+                peek_hints: None,
+                forager_hysteresis: None,
+            };
+            let mut per_long = vec![
+                Some(PerSymbolOrders {
+                    symbol_idx: 0,
+                    entries: vec![],
+                    closes: vec![IdealOrder {
+                        symbol_idx: 0,
+                        pside: PositionSide::Long,
+                        qty: -4.0,
+                        price: 90.0,
+                        order_type: OrderType::CloseUnstuckLong,
+                    }],
+                    pos: sym0.long.position,
+                    mode: TradingMode::Normal,
+                }),
+                Some(PerSymbolOrders {
+                    symbol_idx: 1,
+                    entries: vec![],
+                    closes: vec![IdealOrder {
+                        symbol_idx: 1,
+                        pside: PositionSide::Long,
+                        qty: -6.0,
+                        price: 90.0,
+                        order_type: OrderType::CloseAutoReduceWelLong,
+                    }],
+                    pos: sym1.long.position,
+                    mode: TradingMode::Normal,
+                }),
+            ];
+            let mut per_short = vec![None, None];
+            let mut diagnostics = OrchestratorDiagnostics::default();
+
+            gate_lossy_closes_by_peak_balance(
+                &input,
+                &mut per_long,
+                &mut per_short,
+                &mut diagnostics,
+            );
+
+            assert!(per_long[0].as_ref().unwrap().closes.is_empty());
+            let accepted = &per_long[1].as_ref().unwrap().closes;
+            assert_eq!(accepted.len(), 1);
+            assert_eq!(accepted[0].order_type, OrderType::CloseAutoReduceWelLong);
+            assert!((accepted[0].qty + 6.0).abs() < 1e-12);
+            assert_eq!(diagnostics.loss_gate_blocks.len(), 1);
+            let block = &diagnostics.loss_gate_blocks[0];
+            assert_eq!(block.symbol_idx, 0);
+            assert_eq!(block.order_type, OrderType::CloseUnstuckLong);
+            assert!((block.balance_before - 940.0).abs() < 1e-12);
+            assert!((block.projected_balance_after - 900.0).abs() < 1e-12);
+            assert!((block.balance_floor - 930.0).abs() < 1e-12);
         }
 
         #[test]

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -2656,6 +2656,44 @@ def test_larger_short_wel_auto_reduce_wins_over_unstuck_for_same_position():
     ) <= 6.0 + 1e-9
 
 
+def test_loss_gate_falls_back_from_larger_wel_to_smaller_unstuck():
+    import passivbot_rust as pbr
+
+    long_bp = {
+        "wallet_exposure_limit": 0.4,
+        "risk_wel_enforcer_threshold": 1.0,
+        "risk_twel_enforcer_enabled": False,
+        "total_wallet_exposure_limit": 1.0,
+        "n_positions": 1,
+        "unstuck_close_pct": 0.4,
+        "unstuck_threshold": 0.001,
+        "unstuck_ema_dist": 0.0,
+        "unstuck_loss_allowance_pct": 0.01,
+    }
+    global_bp = bot_params_pair(long_overrides=long_bp)
+    sym = make_symbol(
+        0,
+        bid=90.0,
+        ask=90.0,
+        long_pos_size=6.0,
+        long_pos_price=100.0,
+        long_bp=long_bp,
+    )
+    inp = make_input(balance=1_000.0, global_bp=global_bp, symbols=[sym])
+    inp["global"]["unstuck_allowance_long"] = 1e9
+    inp["global"]["max_realized_loss_pct"] = 0.019
+
+    out = compute(pbr, inp)
+    order_types = [o["order_type"] for o in out["orders"]]
+
+    assert "close_unstuck_long" in order_types
+    assert "close_auto_reduce_wel_long" not in order_types
+    assert any(
+        block["order_type"] == "close_auto_reduce_wel_long"
+        for block in out["diagnostics"]["loss_gate_blocks"]
+    )
+
+
 def test_larger_unstuck_wins_over_twel_auto_reduce_for_same_position():
     import passivbot_rust as pbr
 

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -2550,7 +2550,7 @@ def test_twel_reduce_portfolio_can_select_underweight_positions():
     assert {o["symbol_idx"] for o in twel_orders} == {0, 1}
 
 
-def test_twel_auto_reduce_takes_priority_over_wel_for_same_position():
+def test_larger_wel_auto_reduce_wins_over_twel_for_same_position():
     import passivbot_rust as pbr
 
     long_bp = {
@@ -2574,11 +2574,11 @@ def test_twel_auto_reduce_takes_priority_over_wel_for_same_position():
     out = compute(pbr, make_input(balance=1_000.0, global_bp=global_bp, symbols=[sym]))
     order_types = [o["order_type"] for o in out["orders"]]
 
-    assert "close_auto_reduce_twel_long" in order_types
-    assert "close_auto_reduce_wel_long" not in order_types
+    assert "close_auto_reduce_wel_long" in order_types
+    assert "close_auto_reduce_twel_long" not in order_types
 
 
-def test_wel_auto_reduce_takes_priority_over_unstuck_for_same_position():
+def test_larger_wel_auto_reduce_wins_over_unstuck_for_same_position():
     import passivbot_rust as pbr
 
     long_bp = {
@@ -2617,7 +2617,7 @@ def test_wel_auto_reduce_takes_priority_over_unstuck_for_same_position():
     ) <= 6.0 + 1e-9
 
 
-def test_wel_auto_reduce_takes_priority_over_short_unstuck_for_same_position():
+def test_larger_short_wel_auto_reduce_wins_over_unstuck_for_same_position():
     import passivbot_rust as pbr
 
     short_bp = {
@@ -2656,7 +2656,7 @@ def test_wel_auto_reduce_takes_priority_over_short_unstuck_for_same_position():
     ) <= 6.0 + 1e-9
 
 
-def test_twel_auto_reduce_takes_priority_over_unstuck_for_same_position():
+def test_larger_unstuck_wins_over_twel_auto_reduce_for_same_position():
     import passivbot_rust as pbr
 
     long_bp = {
@@ -2686,8 +2686,8 @@ def test_twel_auto_reduce_takes_priority_over_unstuck_for_same_position():
     out = compute(pbr, inp)
     order_types = [o["order_type"] for o in out["orders"]]
 
-    assert "close_auto_reduce_twel_long" in order_types
-    assert "close_unstuck_long" not in order_types
+    assert "close_unstuck_long" in order_types
+    assert "close_auto_reduce_twel_long" not in order_types
     assert "close_grid_long" in order_types
     assert sum(
         abs(o["qty"])
@@ -2696,7 +2696,7 @@ def test_twel_auto_reduce_takes_priority_over_unstuck_for_same_position():
     ) <= 6.0 + 1e-9
 
 
-def test_twel_auto_reduce_takes_priority_over_short_unstuck_for_same_position():
+def test_larger_short_unstuck_wins_over_twel_auto_reduce_for_same_position():
     import passivbot_rust as pbr
 
     short_bp = {
@@ -2726,8 +2726,8 @@ def test_twel_auto_reduce_takes_priority_over_short_unstuck_for_same_position():
     out = compute(pbr, inp)
     order_types = [o["order_type"] for o in out["orders"]]
 
-    assert "close_auto_reduce_twel_short" in order_types
-    assert "close_unstuck_short" not in order_types
+    assert "close_unstuck_short" in order_types
+    assert "close_auto_reduce_twel_short" not in order_types
     assert "close_grid_short" in order_types
     assert sum(
         abs(o["qty"])

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -2694,6 +2694,95 @@ def test_loss_gate_falls_back_from_larger_wel_to_smaller_unstuck():
     )
 
 
+def test_loss_gate_checks_wel_reducer_after_dust_is_absorbed():
+    import passivbot_rust as pbr
+
+    long_bp = {
+        "wallet_exposure_limit": 0.1,
+        "risk_wel_enforcer_threshold": 1.0,
+        "risk_twel_enforcer_enabled": False,
+        "total_wallet_exposure_limit": 2.0,
+        "n_positions": 1,
+    }
+    global_bp = bot_params_pair(long_overrides=long_bp)
+    sym = make_symbol(
+        0,
+        bid=90.0,
+        ask=90.0,
+        long_pos_size=11.0,
+        long_pos_price=100.0,
+        long_bp=long_bp,
+    )
+    sym["exchange"].update(
+        {"qty_step": 0.01, "min_qty": 10.0, "min_cost": 0.0, "maker_fee": 0.0}
+    )
+    inp = make_input(balance=1_000.0, global_bp=global_bp, symbols=[sym])
+    inp["global"]["max_realized_loss_pct"] = 0.105
+
+    out = compute(pbr, inp)
+
+    assert all(o["order_type"] != "close_auto_reduce_wel_long" for o in out["orders"])
+    block = next(
+        block
+        for block in out["diagnostics"]["loss_gate_blocks"]
+        if block["order_type"] == "close_auto_reduce_wel_long"
+    )
+    assert block["qty"] == pytest.approx(-11.0)
+    assert block["projected_balance_after"] == pytest.approx(890.0)
+    assert block["balance_floor"] == pytest.approx(895.0)
+
+
+def test_loss_gate_prioritizes_larger_wel_reducer_across_symbols():
+    import passivbot_rust as pbr
+
+    long_bp = {
+        "wallet_exposure_limit": 0.1,
+        "risk_wel_enforcer_threshold": 1.0,
+        "risk_twel_enforcer_enabled": False,
+        "total_wallet_exposure_limit": 2.0,
+        "n_positions": 2,
+    }
+    global_bp = bot_params_pair(long_overrides=long_bp)
+    sym0 = make_symbol(
+        0,
+        bid=90.0,
+        ask=90.0,
+        long_pos_size=5.0,
+        long_pos_price=100.0,
+        long_bp=long_bp,
+    )
+    sym1 = make_symbol(
+        1,
+        bid=90.0,
+        ask=90.0,
+        long_pos_size=7.0,
+        long_pos_price=100.0,
+        long_bp=long_bp,
+    )
+    sym0["exchange"]["maker_fee"] = 0.0
+    sym1["exchange"]["maker_fee"] = 0.0
+    inp = make_input(balance=1_000.0, global_bp=global_bp, symbols=[sym0, sym1])
+    inp["global"]["max_realized_loss_pct"] = 0.07
+
+    out = compute(pbr, inp)
+    wel_orders = [
+        order for order in out["orders"] if order["order_type"] == "close_auto_reduce_wel_long"
+    ]
+
+    assert len(wel_orders) == 1
+    assert wel_orders[0]["symbol_idx"] == 1
+    assert wel_orders[0]["qty"] == pytest.approx(-6.01)
+    block = next(
+        block
+        for block in out["diagnostics"]["loss_gate_blocks"]
+        if block["order_type"] == "close_auto_reduce_wel_long"
+    )
+    assert block["symbol_idx"] == 0
+    assert block["balance_before"] == pytest.approx(939.9)
+    assert block["projected_balance_after"] == pytest.approx(899.8)
+    assert block["balance_floor"] == pytest.approx(930.0)
+
+
 def test_larger_unstuck_wins_over_twel_auto_reduce_for_same_position():
     import passivbot_rust as pbr
 


### PR DESCRIPTION
## Summary

- consolidate competing panic, WEL/TWEL auto-reduce, and auto-unstuck intents by selecting the largest requested absolute reduction per coin and position side
- keep panic as the equal-size tie winner, then use price reachability and stable order fields for deterministic ties
- preserve compatible ordinary closes and the existing aggregate position-size cap
- update the canonical/user-facing reducer policy documentation and changelog

## Why

The previous fixed type priority allowed a tiny auto-reduce intent to suppress a materially larger unstuck close. The safety policy is still one protective reducer per wave, but the selected reducer now represents the maximum active reduction requirement rather than a type hierarchy or the sum of competing quantities.

## Validation

- `cargo test --no-default-features` (217 passed)
- `cargo check --tests`
- rebuilt and source-fingerprint-verified the real PyO3 extension
- affected orchestrator/unstuck Python tests (136 passed)
- order orchestration, realized-loss gate, WEL, and TWEL tests (89 passed)
- AI documentation checks and tests (3 passed; existing word-count warning only)
- `cargo fmt --check`
- `git diff --check`

The exact forum backtest replay was not rerun because its config and result artifacts were not provided. The Rust unit regression directly covers a 0.01 auto-reduce competing with a 0.81 unstuck intent, and long/short real-extension JSON API tests cover both larger-auto-reduce and larger-unstuck outcomes.