### PR TITLE
Redact candle remote fetch diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,12 @@ All notable user-facing changes will be documented in this file.
   Maintainer cancellation, execution-loop waits, session closing, shutdown timing, and process
   control are unchanged.
 
+- Candle remote-fetch callbacks, HLCV progress logs, archive fetch/day diagnostics, structured
+  remote-call events, and fake-live candle traces now retain bounded exception types, URL hashes,
+  parameter keys, stage, attempt, timing, and correlation without arbitrary exception messages,
+  request URLs, or request-parameter values. Fetches, retry/backoff and rate-limit classification,
+  archive availability, cache behavior, and trading behavior are unchanged.
+
 - Fill-history refresh failure diagnostics now retain bounded exception types alongside existing
   source, coverage, retry, timing, count, and endpoint context without arbitrary exception
   messages or exception-value tracebacks. This includes exchange-specific fill fetchers, cache

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -13,6 +13,11 @@
 4. Fill only internal gaps within the configured tolerance. Larger internal gaps must be repaired,
    excluded from the returned tradable window, or fail; do not make them tradable via synthetic rows.
 5. Synthesize zero-candles only for verified gaps where the downstream consumer requires a dense array.
+6. Remote-fetch diagnostics retain only bounded exception type, URL hash, parameter keys,
+   operation/stage, symbol/timeframe, attempt/status/timing, and correlation. Manager callbacks,
+   HLCV progress logs, archive fetch/day logs, structured events, and fake-live traces do not retain
+   exception text or repr, raw request URLs, or request-parameter values. This diagnostic boundary
+   must not alter retry, rate-limit classification, exception propagation, or cache behavior.
 
 ## Non-Obvious Details
 
@@ -93,6 +98,9 @@ Cache paths use `to_standard_exchange_name()` rather than raw CCXT identifiers s
 4. Backtest/live parity for live tail-gap EMA projection behavior.
 5. Binance archive threshold, publication-lag, checksum, source-order, non-overwrite, and CCXT
    fallback behavior, including public unauthenticated download smokes.
+6. Hostile remote-fetch diagnostics are redacted at the manager callback boundary and remain
+   redacted after repeated sanitization by direct consumers. Concurrent archive requests preserve
+   correlation through URL hashes rather than raw URLs.
 
 ## Key Code
 

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -172,6 +172,19 @@ legacy recovery heuristics do not require projecting untrusted class names.
 Monitor error events use the same hostile-metadata-safe exception-type boundary; diagnostic
 publication must not replace the original refresh exception.
 
+## Candle Remote-Fetch Diagnostics
+
+Candle manager callbacks are sanitized before any live-event, HLCV, or fake-live consumer receives
+them. CCXT and archive diagnostics retain code-owned stage, symbol/timeframe, attempt/status/timing,
+bounded exception type, parameter keys, and a SHA-256 URL hash where needed for correlation. They
+exclude exception text and repr, raw request URLs, and request-parameter values.
+
+`remote.call_started`, `remote.call_succeeded`, `remote.call_failed`, and
+`remote.call_throttled` preserve start/result correlation after this redaction, including concurrent
+archive calls keyed by URL hash. Repeated consumer-side sanitization must be idempotent. Redaction
+and sink failure cannot change fetches, retries, backoff, rate-limit classification, archive
+availability, cache behavior, or trading decisions.
+
 ## Open-Orders Snapshot Deltas
 
 `open_orders.snapshot_delta` replaces the aggregate INFO lines for open-order snapshot additions or

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,8 +22,11 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Implementation branch `codex/candle-refresh-diagnostic-redaction` is based on
-  canonical `64928305f0f5b4b8bc1da353a579a5d492b47648`; no PR is open yet.
+- Open PR #1356, `Redact candle remote fetch diagnostics`, on branch
+  `codex/candle-refresh-diagnostic-redaction`, based on canonical
+  `64928305f0f5b4b8bc1da353a579a5d492b47648`. Resolve its exact head from live
+  metadata; the commit containing this handoff is the intended final review
+  head unless a verified finding requires a semantic fix.
 - Scope: remove arbitrary exception values, raw request URLs, and request
   parameter values from candle remote-fetch callbacks, HLCV progress logs,
   archive fetch/day diagnostics, and fake-live candle traces while retaining

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -1,6 +1,6 @@
 # Live Logging Overhaul Current Status
 
-Updated: 2026-07-20.
+Updated: 2026-07-23.
 
 This is the compact operational source for the active logging-overhaul loop.
 Read it before the historical progress ledger. Update it whenever the active
@@ -22,28 +22,49 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Open PR #1348, `Redact shutdown failure diagnostics`, on branch
-  `codex/shutdown-diagnostic-redaction`, based on canonical
-  `67416ee4f7fef2dc3ffac001d50e82c0322ee72b`. Resolve its exact head from live
-  metadata; the commit containing this handoff is a moving review head.
-- Scope: remove arbitrary exception values from `bot.shutdown.stage` failures,
-  event-pipeline close failure warnings, per-maintainer cancellation errors,
-  and shutdown fallback logs while retaining bounded exception type, stage,
-  task count, timeout, status, and elapsed-time context.
-- Behavior boundary: diagnostic retention and projection only. Maintainer
-  cancellation, execution-loop waits, session closing, shutdown timing,
-  process control, event routing, and trading behavior remain unchanged.
-- Baseline: maintainer-stop/await, execution-loop-wait, private/public session
-  close, stage-delivery, event-pipeline-close, and legacy cleanup failures
-  still render or retain raw exception text.
+- Implementation branch `codex/candle-refresh-diagnostic-redaction` is based on
+  canonical `64928305f0f5b4b8bc1da353a579a5d492b47648`; no PR is open yet.
+- Scope: remove arbitrary exception values, raw request URLs, and request
+  parameter values from candle remote-fetch callbacks, HLCV progress logs,
+  archive fetch/day diagnostics, and fake-live candle traces while retaining
+  bounded exception type, URL hash, parameter keys, operation/stage,
+  symbol/timeframe, attempt/status/timing, and remote-call correlation.
+- Behavior boundary: diagnostic retention and projection only. Fetches,
+  archive availability, retry/backoff and rate-limit classification,
+  exception propagation, cache behavior, event routing, and trading behavior
+  remain unchanged.
+- Baseline: normal live structured remote-call events are already redacted,
+  but their upstream manager callback and the HLCV/fake-live/archive
+  diagnostic consumers can still retain raw exception text, request URLs, or
+  request parameter values.
 - Review gate: exact-current-head Hermes approval plus green Python/Rust CI.
   Built-in Codex automatic review is additional and every finding must be
   verified and resolved.
 - Expected VPS action: tracked-clean pull plus one exact-five graceful restart
-  and bounded settled smoke because live shutdown diagnostics change; preserve
+  and bounded settled smoke because live candle diagnostics change; preserve
   `misc:0.0`.
-- Next candidate: candle refresh/cache-maintenance diagnostic redaction after
-  this dependent runtime slice merges.
+- Next candidate: cache/index/migration diagnostic redaction after this remote
+  fetch slice merges.
+
+## Deployed Baseline (PR #1348)
+
+- PR #1348 merged exact approved head
+  `3adba8fd3d55a3a2b26081bf5517ccff611f73d9` as canonical
+  `acccfdac51d27c5fde114821c939cd77b933685f` after exact-head Hermes
+  approval, green Python/Rust CI, and a direct-consumer fix retaining the new
+  bounded `error_type` in shutdown smoke evidence.
+- VPS5 fast-forwarded tracked-clean to the merge commit and restarted only the
+  configured panes `%358`-`%362`; protected `misc:0.0` remained `%8`/PID
+  `434835`. The bounded restart window retained complete five-bot shutdown and
+  startup identity, zero hard failures, zero hard text-log matches, zero
+  monitor warnings/errors, and no event-pipeline integrity failure.
+- A current 2026-07-23 local-only preflight still found VPS5 exact and
+  tracked-clean at the same merge commit with all five configured bots
+  matched, stable PIDs, zero missing/duplicate/extra/config failures, and no
+  process control. Its three one-second samples observed transient system I/O
+  wait, including one persistent process in that short window, without a hard
+  process-contract failure. No direct authenticated exchange request or event
+  was manufactured.
 
 ## Deployed Baseline (PR #1347)
 

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,27 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1347)
+## Latest Canonical Deployment (PR #1348)
+
+- PR #1348 merged exact approved head `3adba8fd3d` as canonical
+  `acccfdac51d27c5fde114821c939cd77b933685f` after exact-head Hermes
+  approval, green Python/Rust CI, and a direct-consumer correction retaining
+  bounded shutdown `error_type` evidence in live smoke reports.
+- VPS5 fast-forwarded tracked-clean and restarted only configured panes
+  `%358`-`%362`; the bounded restart window proved complete five-bot shutdown
+  and startup identity with zero hard failures, hard text-log matches,
+  monitor warnings/errors, or event-pipeline integrity failures. Protected
+  `misc:0.0` remained `%8`/PID `434835`.
+- A 2026-07-23 local-only preflight found the checkout still exact and
+  tracked-clean at the same merge commit, five stable expected PIDs, and zero
+  missing, duplicate, extra, config, or scan failures. The short sample
+  retained transient I/O-wait pressure without a hard process-contract
+  failure. No authenticated exchange request, manufactured event, or process
+  action occurred. The active follow-up redacts upstream candle remote-fetch
+  callback and retained diagnostic surfaces; cache/index/migration
+  diagnostics remain a later slice.
+
+## Previous Canonical Deployment (PR #1347)
 
 - PR #1347 merged exact approved head `5ef012ed5f` as canonical
   `67416ee4f7fef2dc3ffac001d50e82c0322ee72b` after exact-head Hermes

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -32,11 +32,13 @@ from __future__ import annotations
 
 import asyncio
 import calendar
+import hashlib
 import inspect
 import json
 import logging
 import math
 import os
+import re
 import shutil
 import sys
 
@@ -66,6 +68,7 @@ from legacy_data_migrator import (
     merge_duplicate_symbol_directories,
     normalize_ccxt_volume_to_base,
 )
+from live.diagnostic_safety import bounded_exception_type
 from utils import symbol_to_coin
 
 # Suppress portalocker's "timeout has no effect in blocking mode" warning
@@ -78,6 +81,73 @@ warnings.filterwarnings(
 ONE_MIN_MS = 60_000
 
 _LOCK_TIMEOUT_SECONDS = 10.0
+_REMOTE_FETCH_ERROR_TYPE_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,79}")
+_REMOTE_FETCH_SENSITIVE_ERROR_TYPE_RE = re.compile(
+    r"(?i)(?:api_?key|apikey|authorization|cookie|passphrase|password|private_?key|"
+    r"privatekey|secret|signature|token|wallet_?address|walletaddress)"
+)
+_REMOTE_FETCH_PARAM_KEYS_MAX = 32
+
+
+def _bounded_remote_fetch_param_keys(value: Any) -> list[str]:
+    if isinstance(value, dict):
+        values = value.keys()
+    elif isinstance(value, (list, tuple)):
+        values = value
+    else:
+        return []
+    keys = []
+    for key in values:
+        if isinstance(key, str) and 0 < len(key) <= 80 and key.isascii():
+            keys.append(key)
+    return sorted(set(keys))[:_REMOTE_FETCH_PARAM_KEYS_MAX]
+
+
+def _bounded_remote_fetch_error_type(value: Any) -> str:
+    if (
+        not isinstance(value, str)
+        or not _REMOTE_FETCH_ERROR_TYPE_RE.fullmatch(value)
+        or _REMOTE_FETCH_SENSITIVE_ERROR_TYPE_RE.search(value)
+    ):
+        return "Error"
+    return value
+
+
+def _remote_fetch_url_hash(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def sanitize_remote_fetch_diagnostic(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the callback-safe projection of a remote-fetch diagnostic payload."""
+    data = dict(payload)
+    data.pop("error", None)
+    data.pop("error_repr", None)
+
+    raw_url = data.pop("url", None)
+    url_hash = _remote_fetch_url_hash(raw_url) if raw_url is not None else None
+    if url_hash is None:
+        candidate_hash = data.get("url_hash")
+        if isinstance(candidate_hash, str) and re.fullmatch(r"[0-9a-f]{64}", candidate_hash):
+            url_hash = candidate_hash
+    if url_hash is not None:
+        data["url_hash"] = url_hash
+    else:
+        data.pop("url_hash", None)
+
+    raw_params = data.pop("params", None)
+    param_keys = _bounded_remote_fetch_param_keys(
+        raw_params if isinstance(raw_params, dict) else data.pop("param_keys", None)
+    )
+    if param_keys:
+        data["param_keys"] = param_keys
+    else:
+        data.pop("param_keys", None)
+
+    if "error_type" in data:
+        data["error_type"] = _bounded_remote_fetch_error_type(data["error_type"])
+    return data
 
 
 class OhlcvFetchError(RuntimeError):
@@ -1551,7 +1621,7 @@ class CandlestickManager:
         if cb is None:
             return
         try:
-            cb(payload)
+            cb(sanitize_remote_fetch_diagnostic(payload))
         except Exception:
             # Must never break the fetch path due to logging/progress UI.
             return
@@ -4002,7 +4072,7 @@ class CandlestickManager:
                     since_ts=int(since_ms),
                     limit=request_limit,
                     attempt=attempt + 1,
-                    params=params,
+                    param_keys=_bounded_remote_fetch_param_keys(params),
                 )
                 if getattr(self, "_net_sem", None) is not None:
                     async with self._net_sem:  # type: ignore[attr-defined]
@@ -4065,8 +4135,8 @@ class CandlestickManager:
                 return res or []
             except Exception as e:  # pragma: no cover - network not used in tests
                 last_exc = e
-                err_type = type(e).__name__
-                err_repr = repr(e)
+                raw_err_type = type(e).__name__
+                err_type = bounded_exception_type(e)
                 elapsed_ms = int((time.monotonic() - t0) * 1000) if "t0" in locals() else None
                 self._emit_remote_fetch(
                     {
@@ -4080,8 +4150,6 @@ class CandlestickManager:
                         "elapsed_ms": elapsed_ms,
                         "params": dict(params) if "params" in locals() else None,
                         "error_type": err_type,
-                        "error": str(e),
-                        "error_repr": err_repr,
                     }
                 )
                 action = "exhausted" if attempt == max_attempts - 1 else "retry"
@@ -4109,7 +4177,7 @@ class CandlestickManager:
                     sleep_s = max(sleep_s, global_backoff)
                 # Bybit: be more persistent on transient network-ish errors.
                 if is_bybit and (
-                    err_type
+                    raw_err_type
                     in {"RequestTimeout", "NetworkError", "ExchangeNotAvailable", "DDoSProtection"}
                     or any(
                         x in msg_l
@@ -4866,6 +4934,7 @@ class CandlestickManager:
 
     async def _archive_fetch_bytes(self, url: str) -> Optional[bytes]:
         t0 = time.monotonic()
+        url_hash = _remote_fetch_url_hash(url)
         self._emit_remote_fetch(
             {
                 "kind": "archive_http_get",
@@ -4874,7 +4943,7 @@ class CandlestickManager:
                 "url": str(url),
             }
         )
-        self._log("debug", "archive_http_get", url=url)
+        self._log("debug", "archive_http_get", url_hash=url_hash)
 
         session = await self._get_http_session()
         try:
@@ -4893,15 +4962,14 @@ class CandlestickManager:
                     self._log(
                         "debug",
                         "archive_http_404",
-                        url=url,
+                        url_hash=url_hash,
                         elapsed_ms=int((time.monotonic() - t0) * 1000),
                     )
                     return None
                 resp.raise_for_status()
                 data = await resp.read()
         except Exception as e:
-            err_type = type(e).__name__
-            err_repr = repr(e)
+            err_type = bounded_exception_type(e)
             self._emit_remote_fetch(
                 {
                     "kind": "archive_http_get",
@@ -4909,18 +4977,14 @@ class CandlestickManager:
                     "exchange": str(self._ex_id),
                     "url": str(url),
                     "error_type": err_type,
-                    "error": str(e),
-                    "error_repr": err_repr,
                     "elapsed_ms": int((time.monotonic() - t0) * 1000),
                 }
             )
             self._log(
                 "debug",
                 "archive_http_error",
-                url=url,
+                url_hash=url_hash,
                 error_type=err_type,
-                error=str(e),
-                error_repr=err_repr,
             )
             raise
 
@@ -4937,7 +5001,7 @@ class CandlestickManager:
         self._log(
             "debug",
             "archive_http_ok",
-            url=url,
+            url_hash=url_hash,
             bytes=len(data),
             elapsed_ms=int((time.monotonic() - t0) * 1000),
         )
@@ -5145,7 +5209,11 @@ class CandlestickManager:
                 return self._ohlcv_df_to_day_arr(df, day_key)
             except Exception as e:
                 self._log(
-                    "debug", "hyperliquid_archive_error", symbol=symbol, day_key=day_key, error=str(e)
+                    "debug",
+                    "hyperliquid_archive_error",
+                    symbol=symbol,
+                    day_key=day_key,
+                    error_type=bounded_exception_type(e),
                 )
 
         # 2. For stock perps, try TradFi data fetch
@@ -5230,7 +5298,13 @@ class CandlestickManager:
                 return self._ohlcv_df_to_day_arr(df, day_key)
 
         except Exception as e:
-            self._log("debug", "tradfi_fetch_error", coin=coin, day_key=day_key, error=str(e))
+            self._log(
+                "debug",
+                "tradfi_fetch_error",
+                coin=coin,
+                day_key=day_key,
+                error_type=bounded_exception_type(e),
+            )
 
         return None
 
@@ -5539,17 +5613,13 @@ class CandlestickManager:
         # Semaphore to limit concurrent fetches
         sem = asyncio.Semaphore(max(1, parallel_days))
 
-        def _format_archive_exc(exc: BaseException) -> Tuple[str, str]:
-            """Return (error_type, error_repr) for logging."""
-            try:
-                return (type(exc).__name__, repr(exc))
-            except Exception:
-                return (type(exc).__name__, "<unrepresentable exception>")
+        def _format_archive_exc(exc: BaseException) -> str:
+            return bounded_exception_type(exc)
 
         async def fetch_single_day(
             day_info: Tuple[str, int, int],
-        ) -> Tuple[str, Optional[np.ndarray], Optional[Tuple[str, str]]]:
-            """Fetch a single day's archive data. Returns (day_key, array or None, (err_type, err_repr) or None)."""
+        ) -> Tuple[str, Optional[np.ndarray], Optional[str]]:
+            """Fetch a single day's archive data with a bounded failure type."""
             day_key, day_start, day_end = day_info
             async with sem:
                 try:
@@ -5608,24 +5678,22 @@ class CandlestickManager:
                 for i, result in enumerate(results):
                     day_key = batch[i][0]
                     if isinstance(result, Exception):
-                        err_type, err_repr = _format_archive_exc(result)
+                        err_type = _format_archive_exc(result)
                         self._log(
                             "warning",
                             "archive_day_failed",
                             symbol=symbol,
                             day=day_key,
-                            error=err_repr,
                             error_type=err_type,
                         )
                         skipped += 1
-                    elif result[2] is not None:  # (error_type, error_repr)
-                        err_type, err_repr = result[2]
+                    elif result[2] is not None:
+                        err_type = result[2]
                         self._log(
                             "warning",
                             "archive_day_failed",
                             symbol=symbol,
                             day=day_key,
-                            error=err_repr,
                             error_type=err_type,
                         )
                         skipped += 1

--- a/src/hlcv_preparation.py
+++ b/src/hlcv_preparation.py
@@ -15,7 +15,11 @@ from uuid import uuid4
 import numpy as np
 import pandas as pd
 
-from candlestick_manager import CandlestickManager, OhlcvTerminalEmptyPage
+from candlestick_manager import (
+    CandlestickManager,
+    OhlcvTerminalEmptyPage,
+    sanitize_remote_fetch_diagnostic,
+)
 from binance_ohlcv_archive import (
     BinanceArchiveRequest,
     BinanceArchiveResult,
@@ -345,6 +349,8 @@ class HLCVManager:
         INFO level without changing CandlestickManager verbosity globally.
         """
 
+        payload = sanitize_remote_fetch_diagnostic(payload)
+
         # Throttle per (kind, symbol, tf/stage) to avoid log spam.
         if not hasattr(self, "_download_log_last"):
             self._download_log_last = {}
@@ -375,14 +381,14 @@ class HLCVManager:
                     since_iso = None
 
                 logging.info(
-                    "[%s] download ccxt start symbol=%s tf=%s since=%s since_ms=%s limit=%s params=%s",
+                    "[%s] download ccxt start symbol=%s tf=%s since=%s since_ms=%s limit=%s param_keys=%s",
                     self.exchange,
                     symbol,
                     payload.get("tf"),
                     since_iso if since_iso is not None else since_ms,
                     since_ms,
                     payload.get("limit"),
-                    payload.get("params"),
+                    payload.get("param_keys"),
                 )
                 return
 
@@ -426,12 +432,11 @@ class HLCVManager:
                 # Let CandlestickManager warnings show the details; keep this concise.
                 if attempt == 1:
                     logging.warning(
-                        "[%s] download ccxt error symbol=%s tf=%s error_type=%s error=%s",
+                        "[%s] download ccxt error symbol=%s tf=%s error_type=%s",
                         self.exchange,
                         symbol,
                         tf,
                         payload.get("error_type"),
-                        payload.get("error"),
                     )
                 return
 

--- a/src/hlcv_preparation.py
+++ b/src/hlcv_preparation.py
@@ -432,10 +432,13 @@ class HLCVManager:
                 # Let CandlestickManager warnings show the details; keep this concise.
                 if attempt == 1:
                     logging.warning(
-                        "[%s] download ccxt error symbol=%s tf=%s error_type=%s",
+                        "[%s] download ccxt error symbol=%s tf=%s attempt=%s "
+                        "elapsed_ms=%s error_type=%s",
                         self.exchange,
                         symbol,
                         tf,
+                        payload.get("attempt"),
+                        payload.get("elapsed_ms"),
                         payload.get("error_type"),
                     )
                 return

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -21,6 +21,7 @@ from live.event_bus import (
 )
 from live.balance_composition import public_balance_composition
 from live.diagnostic_safety import bounded_exception_type as _bounded_exception_type
+from candlestick_manager import sanitize_remote_fetch_diagnostic
 
 
 def current_live_event_cycle_id(bot: Any) -> str | None:
@@ -134,24 +135,6 @@ def _sanitize_remote_text(value: Any, *, max_len: int = 500) -> str:
     if len(text) > max_len:
         text = f"{text[:max_len]}...<truncated>"
     return text
-
-
-def _sanitize_remote_url(value: Any) -> tuple[str, str | None]:
-    raw = str(value)
-    raw_hash = hashlib.sha256(raw.encode("utf-8")).hexdigest()
-    return "[redacted-url]", raw_hash
-
-
-def _sanitize_remote_fetch_payload(payload: dict[str, Any]) -> dict[str, Any]:
-    data = dict(payload)
-    data.pop("error", None)
-    data.pop("error_repr", None)
-    if data.get("url") is not None:
-        url, url_hash = _sanitize_remote_url(data["url"])
-        data["url"] = url
-        if url_hash is not None:
-            data["url_hash"] = url_hash
-    return data
 
 
 def _cycle_degraded_bounded_text(value: Any, pattern: re.Pattern[str]) -> str | None:
@@ -361,7 +344,7 @@ def _remote_fetch_payload_key(payload: dict[str, Any]) -> tuple[Any, ...]:
         payload.get("symbol"),
         payload.get("tf") or payload.get("timeframe"),
         payload.get("since_ts"),
-        payload.get("url"),
+        payload.get("url_hash") or payload.get("url"),
     )
 
 
@@ -421,7 +404,9 @@ def _remote_call_debug_payload(
     debug: dict[str, Any] = {
         "data_keys": _mapping_key_sample(data, limit=limit),
     }
-    if isinstance(data.get("params"), dict):
+    if isinstance(data.get("param_keys"), list):
+        debug["param_keys"] = [str(key) for key in data["param_keys"][:limit]]
+    elif isinstance(data.get("params"), dict):
         debug["param_keys"] = _mapping_key_sample(data.get("params"), limit=limit)
     if matched_start is not None:
         debug["matched_start"] = bool(matched_start)
@@ -627,12 +612,13 @@ def emit_candle_remote_fetch_event(bot: Any, payload: dict[str, Any]) -> Any:
     """Translate CandlestickManager remote-fetch callbacks into LiveEvents."""
     if not isinstance(payload, dict):
         return None
-    stage = str(payload.get("stage") or "").lower()
+    data = sanitize_remote_fetch_diagnostic(payload)
+    stage = str(data.get("stage") or "").lower()
     if not stage:
         return None
     if stage in _REMOTE_CALL_NONTERMINAL_STAGES:
         return None
-    key = _remote_fetch_payload_key(payload)
+    key = _remote_fetch_payload_key(data)
     call_map = getattr(bot, "_live_event_remote_call_ids", None)
     if not isinstance(call_map, dict):
         call_map = {}
@@ -662,7 +648,6 @@ def emit_candle_remote_fetch_event(bot: Any, payload: dict[str, Any]) -> Any:
             event_type = EventTypes.REMOTE_CALL_SUCCEEDED
             status = "skipped" if stage in {"not_found", "missing"} else "succeeded"
             level = "debug"
-    data = _sanitize_remote_fetch_payload(payload)
     if stage != "start" and not matched_start:
         data["orphan_result"] = True
     if live_event_debug_profile_enabled(bot, "remote_calls"):
@@ -679,9 +664,9 @@ def emit_candle_remote_fetch_event(bot: Any, payload: dict[str, Any]) -> Any:
         cycle_id=cycle_id,
         remote_call_id=remote_call_id,
         remote_call_group_id=remote_call_group_id,
-        symbol=str(payload.get("symbol")) if payload.get("symbol") is not None else None,
+        symbol=str(data.get("symbol")) if data.get("symbol") is not None else None,
         status=status,
-        reason_code=str(payload.get("kind") or ReasonCodes.REMOTE_FETCH),
+        reason_code=str(data.get("kind") or ReasonCodes.REMOTE_FETCH),
         data=data,
     )
 

--- a/src/tools/run_fake_live.py
+++ b/src/tools/run_fake_live.py
@@ -15,7 +15,7 @@ import numpy as np
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from candlestick_manager import CANDLE_DTYPE
+from candlestick_manager import CANDLE_DTYPE, sanitize_remote_fetch_diagnostic
 from config import load_prepared_config
 from config.pnl_lookback import parse_pnls_max_lookback_days
 from exchanges.fake import FakeCCXTClient, load_fake_scenario
@@ -137,11 +137,12 @@ def _install_candle_remote_fetch_trace(bot) -> tuple[List[dict], callable]:
     events: List[dict] = []
 
     def traced(payload: Dict[str, Any]) -> None:
-        item = dict(payload)
+        safe_payload = sanitize_remote_fetch_diagnostic(payload)
+        item = dict(safe_payload)
         item["event_index"] = len(events)
         events.append(item)
         if existing_cb is not None:
-            existing_cb(payload)
+            existing_cb(safe_payload)
 
     bot.cm._remote_fetch_callback = traced
     return events, lambda: setattr(bot.cm, "_remote_fetch_callback", existing_cb)

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -19,6 +19,7 @@ from candlestick_manager import (
     _GAP_MAX_RETRIES,
     _GATEIO_RECENT_1M_LIMIT_CANDLES,
     _floor_minute,
+    sanitize_remote_fetch_diagnostic,
 )
 from logging_setup import DEFAULT_DATEFMT, DEFAULT_FORMAT_WITH_PREFIX
 
@@ -300,7 +301,7 @@ async def test_get_candles_aborts_when_stop_requested(tmp_path):
         await cm.get_candles("FOO/USDT")
 
 
-def test_remote_fetch_callback_exception_is_isolated(tmp_path):
+def test_remote_fetch_callback_is_sanitized_and_exception_is_isolated(tmp_path):
     calls = []
 
     def callback(payload):
@@ -314,13 +315,34 @@ def test_remote_fetch_callback_exception_is_isolated(tmp_path):
         remote_fetch_callback=callback,
     )
 
-    cm._emit_remote_fetch({"kind": "ccxt_fetch_ohlcv", "stage": "start"})
+    url = "https://api.example.invalid/ohlcv?apiKey=SECRET"
+    cm._emit_remote_fetch(
+        {
+            "kind": "ccxt_fetch_ohlcv",
+            "stage": "error",
+            "url": url,
+            "params": {"until": 123, "apiKey": "SECRET"},
+            "error_type": "TokenError",
+            "error": f"GET {url}",
+            "error_repr": f"AuthError({url!r})",
+        }
+    )
 
-    assert calls == [{"kind": "ccxt_fetch_ohlcv", "stage": "start"}]
+    assert len(calls) == 1
+    payload = calls[0]
+    assert payload["param_keys"] == ["apiKey", "until"]
+    assert len(payload["url_hash"]) == 64
+    assert payload["error_type"] == "Error"
+    assert "url" not in payload
+    assert "params" not in payload
+    assert "error" not in payload
+    assert "error_repr" not in payload
+    assert "SECRET" not in str(payload)
+    assert sanitize_remote_fetch_diagnostic(payload) == payload
 
 
 @pytest.mark.asyncio
-async def test_ccxt_fetch_warning_uses_bounded_signature_and_keeps_callback_payload(
+async def test_ccxt_fetch_warning_uses_bounded_signature_and_sanitizes_callback_payload(
     tmp_path, monkeypatch
 ):
     url = "https://api.example.invalid/ohlcv?apiKey=SECRET&signature=abc"
@@ -400,7 +422,7 @@ async def test_ccxt_fetch_warning_uses_bounded_signature_and_keeps_callback_payl
         "attempt=1",
         "max_attempts=5",
         "elapsed_ms=",
-        "error_type=UrlBearingError",
+        "error_type=RuntimeError",
         "action=retry",
     ):
         assert field in retry_warning
@@ -411,7 +433,7 @@ async def test_ccxt_fetch_warning_uses_bounded_signature_and_keeps_callback_payl
         "attempt=5",
         "max_attempts=5",
         "elapsed_ms=",
-        "error_type=UrlBearingError",
+        "error_type=RuntimeError",
         "action=exhausted",
     ):
         assert field in exhausted_warning
@@ -432,9 +454,123 @@ async def test_ccxt_fetch_warning_uses_bounded_signature_and_keeps_callback_payl
 
     error_payloads = [payload for payload in callback_payloads if payload.get("stage") == "error"]
     assert error_payloads
-    assert error_payloads[0]["params"] == {"until": 1_723_456_059_999}
-    assert error_payloads[0]["error"] == url
-    assert error_payloads[0]["error_repr"] == repr(UrlBearingError(url))
+    assert error_payloads[0]["param_keys"] == ["until"]
+    assert error_payloads[0]["error_type"] == "RuntimeError"
+    assert "params" not in error_payloads[0]
+    assert "error" not in error_payloads[0]
+    assert "error_repr" not in error_payloads[0]
+    assert url not in str(error_payloads[0])
+
+
+@pytest.mark.asyncio
+async def test_ccxt_fetch_debug_log_keeps_param_keys_without_values(tmp_path, caplog):
+    class _Ex:
+        id = "bybit"
+
+        async def fetch_ohlcv(self, *_args, **_kwargs):
+            return []
+
+    cm = CandlestickManager(
+        exchange=_Ex(),
+        exchange_name="bybit",
+        cache_dir=str(tmp_path / "caches"),
+        debug=3,
+    )
+    caplog.set_level(int(getattr(logging, "TRACE", 5)), logger=cm.log.name)
+
+    await cm._ccxt_fetch_ohlcv_once(
+        "BTC/USDT:USDT",
+        since_ms=1_723_456_000_000,
+        limit=100,
+        end_exclusive_ms=1_723_456_060_000,
+        timeframe="1m",
+    )
+
+    fetch_lines = [
+        record.getMessage()
+        for record in caplog.records
+        if "event=ccxt_fetch_ohlcv " in record.getMessage()
+    ]
+    assert len(fetch_lines) == 1
+    assert "param_keys=['category']" in fetch_lines[0]
+    assert "params=" not in fetch_lines[0]
+    assert "linear" not in fetch_lines[0]
+
+
+@pytest.mark.asyncio
+async def test_archive_fetch_diagnostics_keep_only_url_hash_and_error_type(tmp_path, monkeypatch):
+    url = "https://data.example.invalid/archive.zip?apiKey=SECRET&signature=abc"
+
+    class UrlBearingError(RuntimeError):
+        pass
+
+    class _Response:
+        status = 500
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        def raise_for_status(self):
+            raise UrlBearingError(url)
+
+    class _Session:
+        def get(self, _url):
+            return _Response()
+
+    cm = CandlestickManager(exchange=None, exchange_name="binance", cache_dir=str(tmp_path / "caches"))
+    callback_payloads = []
+    logs = []
+    cm._remote_fetch_callback = callback_payloads.append
+
+    async def fake_get_session():
+        return _Session()
+
+    monkeypatch.setattr(cm, "_get_http_session", fake_get_session)
+    monkeypatch.setattr(cm, "_log", lambda level, event, **fields: logs.append((level, event, fields)))
+
+    with pytest.raises(UrlBearingError):
+        await cm._archive_fetch_bytes(url)
+
+    by_event = {event: fields for _level, event, fields in logs}
+    assert by_event["archive_http_get"]["url_hash"]
+    assert by_event["archive_http_error"] == {
+        "url_hash": by_event["archive_http_get"]["url_hash"],
+        "error_type": "RuntimeError",
+    }
+    assert all("url" not in payload for payload in callback_payloads)
+    assert all("error" not in payload and "error_repr" not in payload for payload in callback_payloads)
+    assert all("SECRET" not in str(payload) for payload in callback_payloads)
+
+
+@pytest.mark.asyncio
+async def test_archive_day_warning_keeps_only_bounded_error_type(tmp_path, monkeypatch):
+    url = "https://data.example.invalid/archive.zip?apiKey=SECRET&signature=abc"
+
+    class UrlBearingError(RuntimeError):
+        pass
+
+    cm = CandlestickManager(exchange=None, exchange_name="binance", cache_dir=str(tmp_path / "caches"))
+    logs = []
+    monkeypatch.setattr(cm, "_archive_supported", lambda: True)
+    monkeypatch.setattr(cm, "_get_authoritative_start_ts", lambda _symbol: None)
+    monkeypatch.setattr(cm, "_date_keys_between", lambda _start, _end: {"1970-01-01": (0, 86_340_000)})
+    monkeypatch.setattr(cm, "_iter_shard_paths", lambda _symbol, tf: {})
+    monkeypatch.setattr(cm, "_get_legacy_shard_paths", lambda _symbol, _tf: {})
+    monkeypatch.setattr(cm, "_ensure_symbol_index", lambda _symbol, tf: {"shards": {}})
+    monkeypatch.setattr(cm, "_log", lambda level, event, **fields: logs.append((level, event, fields)))
+
+    async def fail_archive_day(_symbol, _day_key):
+        raise UrlBearingError(url)
+
+    monkeypatch.setattr(cm, "_archive_fetch_day", fail_archive_day)
+
+    await cm._prefetch_archives_for_range("BTC/USDT:USDT", 0, 86_340_000, parallel_days=1)
+
+    warnings = [fields for level, event, fields in logs if level == "warning" and event == "archive_day_failed"]
+    assert warnings == [{"symbol": "BTC/USDT:USDT", "day": "1970-01-01", "error_type": "RuntimeError"}]
 
 
 @pytest.mark.asyncio

--- a/tests/test_hlcv_preparation.py
+++ b/tests/test_hlcv_preparation.py
@@ -243,6 +243,8 @@ def test_remote_fetch_log_sanitizes_hostile_legacy_payload(caplog):
                 "stage": "error",
                 "symbol": "BTC/USDT:USDT",
                 "tf": "1m",
+                "attempt": 1,
+                "elapsed_ms": 47,
                 "error_type": "AuthError",
                 "error": f"GET {url}",
                 "error_repr": f"AuthError({url!r})",
@@ -250,6 +252,8 @@ def test_remote_fetch_log_sanitizes_hostile_legacy_payload(caplog):
         )
 
     assert "param_keys=['apiKey', 'until']" in caplog.text
+    assert "attempt=1" in caplog.text
+    assert "elapsed_ms=47" in caplog.text
     assert "error_type=AuthError" in caplog.text
     assert "SECRET" not in caplog.text
     assert "signature=abc" not in caplog.text

--- a/tests/test_hlcv_preparation.py
+++ b/tests/test_hlcv_preparation.py
@@ -218,6 +218,44 @@ def test_remote_fetch_log_ccxt_ok_includes_returned_range(caplog):
     assert "last=2022-01-14T23:59:00Z" in caplog.text
 
 
+def test_remote_fetch_log_sanitizes_hostile_legacy_payload(caplog):
+    om = HLCVManager(
+        exchange="bybit",
+        start_date="2024-01-01",
+        end_date="2024-01-02",
+    )
+    url = "https://api.example.invalid/ohlcv?apiKey=SECRET&signature=abc"
+
+    with caplog.at_level("INFO"):
+        om._remote_fetch_log(
+            {
+                "kind": "ccxt_fetch_ohlcv",
+                "stage": "start",
+                "symbol": "BTC/USDT:USDT",
+                "tf": "1m",
+                "params": {"until": 123, "apiKey": "SECRET"},
+                "url": url,
+            }
+        )
+        om._remote_fetch_log(
+            {
+                "kind": "ccxt_fetch_ohlcv",
+                "stage": "error",
+                "symbol": "BTC/USDT:USDT",
+                "tf": "1m",
+                "error_type": "AuthError",
+                "error": f"GET {url}",
+                "error_repr": f"AuthError({url!r})",
+            }
+        )
+
+    assert "param_keys=['apiKey', 'until']" in caplog.text
+    assert "error_type=AuthError" in caplog.text
+    assert "SECRET" not in caplog.text
+    assert "signature=abc" not in caplog.text
+    assert url not in caplog.text
+
+
 # ============================================================================
 # Test Class: HLCVManager Basics
 # ============================================================================

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -3571,7 +3571,8 @@ def test_candle_remote_fetch_callback_emits_correlated_remote_call_events():
     assert succeeded.cycle_id == "cy_7"
     assert started.symbol == "BTC/USDT:USDT"
     assert succeeded.data["rows"] == 100
-    assert started.data["params"]["apiKey"] == "[redacted]"
+    assert started.data["param_keys"] == ["apiKey"]
+    assert "params" not in started.data
     assert "debug" not in started.data
     assert "debug" not in succeeded.data
     assert bot._live_event_remote_call_seq == 1
@@ -3671,7 +3672,14 @@ def test_candle_remote_fetch_url_is_sanitized_and_hashed():
 
     bot._handle_candle_remote_fetch_event({**base, "stage": "start"})
     bot._handle_candle_remote_fetch_event(
-        {**base, "stage": "not_found", "status": 404, "elapsed_ms": 12}
+        {
+            "kind": "archive_http_get",
+            "exchange": "binance",
+            "stage": "not_found",
+            "url_hash": hashlib.sha256(url.encode("utf-8")).hexdigest(),
+            "status": 404,
+            "elapsed_ms": 12,
+        }
     )
 
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
@@ -3679,11 +3687,53 @@ def test_candle_remote_fetch_url_is_sanitized_and_hashed():
     started, skipped = sink.events
     assert skipped.remote_call_id == started.remote_call_id
     for event in (started, skipped):
-        assert event.data["url"] == "[redacted-url]"
-        assert event.data["url_hash"]
-        assert len(event.data["url_hash"]) == 64
-        assert "SECRET" not in event.data["url"]
-        assert "signature=abc" not in event.data["url"]
+        assert event.data["url_hash"] == hashlib.sha256(url.encode("utf-8")).hexdigest()
+        assert "url" not in event.data
+        assert "SECRET" not in str(event.data)
+        assert "signature=abc" not in str(event.data)
+
+
+def test_candle_remote_fetch_url_hash_keeps_concurrent_archive_correlation():
+    sink = ListEventSink()
+    bot = _make_remote_fetch_event_bot(sink, cycle_id=None)
+    urls = [
+        "https://data.example/first.zip?apiKey=SECRET",
+        "https://data.example/second.zip?apiKey=SECRET",
+    ]
+    hashes = [hashlib.sha256(url.encode("utf-8")).hexdigest() for url in urls]
+
+    for url in urls:
+        bot._handle_candle_remote_fetch_event(
+            {
+                "kind": "archive_http_get",
+                "exchange": "binance",
+                "stage": "start",
+                "url": url,
+            }
+        )
+    for url_hash in reversed(hashes):
+        bot._handle_candle_remote_fetch_event(
+            {
+                "kind": "archive_http_get",
+                "exchange": "binance",
+                "stage": "not_found",
+                "url_hash": url_hash,
+                "status": 404,
+            }
+        )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+    first_started, second_started, second_skipped, first_skipped = sink.events
+    assert second_skipped.remote_call_id == second_started.remote_call_id
+    assert first_skipped.remote_call_id == first_started.remote_call_id
+    assert [event.data["url_hash"] for event in sink.events] == [
+        hashes[0],
+        hashes[1],
+        hashes[1],
+        hashes[0],
+    ]
+    assert bot._live_event_remote_call_ids == {}
 
 
 def test_candle_remote_fetch_throttled_stage_emits_throttled_event():

--- a/tests/test_run_fake_live.py
+++ b/tests/test_run_fake_live.py
@@ -6,6 +6,7 @@ import hjson
 import json
 import shutil
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -20,6 +21,7 @@ from tools.run_fake_live import (
     _apply_assertions,
     _compare_run_artifacts,
     _extract_hsl_trace,
+    _install_candle_remote_fetch_trace,
     _install_fake_user_override,
     _install_runtime_overrides,
     _load_run_artifacts,
@@ -30,6 +32,39 @@ from tools.run_fake_live import (
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_candle_remote_fetch_trace_sanitizes_hostile_payload():
+    forwarded = []
+    bot = SimpleNamespace(cm=SimpleNamespace(_remote_fetch_callback=forwarded.append))
+    events, restore = _install_candle_remote_fetch_trace(bot)
+    url = "https://api.example.invalid/ohlcv?apiKey=SECRET&signature=abc"
+
+    try:
+        bot.cm._remote_fetch_callback(
+            {
+                "kind": "ccxt_fetch_ohlcv",
+                "stage": "error",
+                "url": url,
+                "params": {"until": 123, "apiKey": "SECRET"},
+                "error_type": "AuthError",
+                "error": f"GET {url}",
+                "error_repr": f"AuthError({url!r})",
+            }
+        )
+    finally:
+        restore()
+
+    assert len(events) == 1
+    assert events[0]["event_index"] == 0
+    assert events[0]["param_keys"] == ["apiKey", "until"]
+    assert len(events[0]["url_hash"]) == 64
+    assert "url" not in events[0]
+    assert "params" not in events[0]
+    assert "error" not in events[0]
+    assert "error_repr" not in events[0]
+    assert "SECRET" not in str(events[0])
+    assert forwarded == [{key: value for key, value in events[0].items() if key != "event_index"}]
 
 
 def _cleanup_fake_user_state(user: str) -> None:


### PR DESCRIPTION
@codex

## Scope

- sanitize candle manager remote-fetch callbacks at the producer boundary
- retain bounded exception type, URL hash, parameter keys, stage, attempt, timing, and correlation
- apply the same safe projection to HLCV logs, archive diagnostics, structured live events, and fake-live traces
- record PR #1348 deployment evidence and the next cache/index diagnostic slice

## Behavior impact

Observability-only. Fetches, retries, backoff, rate-limit classification, exception propagation, archive availability, cache behavior, event routing, and trading behavior are unchanged.

## Non-goals

- cache/index/migration diagnostics
- retry or exchange behavior changes
- trading, risk, lock, or process-control changes

## Validation

- full Python test suite
- targeted candle, HLCV, monitor, fake-live, and AI-doc tests
- Rust test suite: 217 passed
- cargo check --tests
- cargo fmt --check
- exact-worktree Rust extension rebuilt, stamped, and loaded
- py_compile for changed modules
- git diff --check
- changed-hunk silent-handling audit

## VPS5

After merge, assess the canonical-master deployment delta before any pull because VPS5 currently remains at PR #1348 and master also contains intervening non-logging changes. Any authorized restart must target only the configured five bot panes and preserve misc:0.0.