### PR TITLE
Redact live candle lifecycle diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@ All notable user-facing changes will be documented in this file.
   messages, repr values, or exception-value tracebacks. Cache contents, migration and cleanup
   behavior, lock handling, retries, fallbacks, and trading behavior are unchanged.
 
+- Live candle completed-close fallback, startup/index/background warmup, forager refresh, active
+  refresh, and refresh-cap diagnostics now retain bounded exception types without arbitrary
+  exception messages or exception-value tracebacks. Warmup, cancellation, lock retry, refresh
+  scheduling, fallback values, readiness, and trading behavior are unchanged.
+
 - Fill-history refresh failure diagnostics now retain bounded exception types alongside existing
   source, coverage, retry, timing, count, and endpoint context without arbitrary exception
   messages or exception-value tracebacks. This includes exchange-specific fill fetchers, cache

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -22,6 +22,10 @@
    inception metadata, and deferred index writes retain bounded exception type instead of exception
    text, repr, or exception-value traceback. Redaction must not alter cache contents, migration and
    cleanup behavior, lock handling, retries, fallbacks, or exception propagation.
+8. Direct live lifecycle diagnostics for completed-close fallback, startup/index/background
+   warmup, forager refresh, active refresh, and refresh-cap handling retain bounded exception type
+   instead of exception text or exception-value traceback. Redaction must not alter warmup,
+   cancellation, lock retry, refresh scheduling, fallback values, readiness, or trading behavior.
 
 ## Non-Obvious Details
 
@@ -107,6 +111,9 @@ Cache paths use `to_standard_exchange_name()` rather than raw CCXT identifiers s
    correlation through URL hashes rather than raw URLs.
 7. Hostile local-storage failures retain bounded exception classification without exception values
    while preserving the original cache, migration, lock, and fallback outcomes.
+8. Hostile live lifecycle failures retain bounded exception classification without exception values
+   or traceback text while preserving completed-close fallback, warmup, cancellation, lock retry,
+   refresh scheduling, readiness, and return behavior.
 
 ## Key Code
 

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -7421,8 +7421,7 @@ class CandlestickManager:
                     "debug",
                     "get_last_prices_completed_close_failed",
                     symbol=sym,
-                    error_type=type(exc).__name__,
-                    error=str(exc),
+                    error_type=bounded_exception_type(exc),
                 )
                 return 0.0
 

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -18818,7 +18818,7 @@ class Passivbot:
                     break
                 logging.warning(
                     "Timed out acquiring candle lock for %s; forager refresh will retry "
-                    "error_type=%s",
+                    "| error_type=%s",
                     Passivbot._log_symbol(sym),
                     bounded_exception_type(exc),
                 )
@@ -18934,7 +18934,7 @@ class Passivbot:
                 except TimeoutError as exc:
                     logging.warning(
                         "Timed out acquiring candle lock for %s; will retry next cycle "
-                        "error_type=%s",
+                        "| error_type=%s",
                         sym,
                         bounded_exception_type(exc),
                     )

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -3402,7 +3402,10 @@ class Passivbot:
             try:
                 await self.warmup_trading_ready_candles()
             except Exception as e:
-                logging.info("[boot] trading-ready candle warmup skipped due to: %s", e)
+                logging.info(
+                    "[boot] trading-ready candle warmup skipped | error_type=%s",
+                    bounded_exception_type(e),
+                )
             Passivbot._startup_timing_mark(self, "active-candle")
             if self.stop_signal_received:
                 self._monitor_emit_stop(
@@ -4802,7 +4805,10 @@ class Passivbot:
                 end_final_hour,
             )
         except Exception as e:
-            logging.info("[boot] candle index rebuild skipped due to: %s", e)
+            logging.info(
+                "[boot] candle index rebuild skipped | error_type=%s",
+                bounded_exception_type(e),
+            )
 
         sem = asyncio.Semaphore(max(1, int(concurrency)))
         completed = 0
@@ -5120,7 +5126,8 @@ class Passivbot:
             raise
         except Exception as exc:
             logging.error(
-                "[candle] background warmup failed: %s", exc, exc_info=True
+                "[candle] background warmup failed | error_type=%s",
+                bounded_exception_type(exc),
             )
 
     async def start_background_candle_warmup(self) -> None:
@@ -18385,9 +18392,8 @@ class Passivbot:
             )
         except Exception as exc:
             logging.debug(
-                "[candle] forager refresh cap log failed | error_type=%s error=%s",
-                type(exc).__name__,
-                exc,
+                "[candle] forager refresh cap log failed | error_type=%s",
+                bounded_exception_type(exc),
             )
 
     async def _refresh_forager_candidate_candles(self) -> None:
@@ -18811,16 +18817,16 @@ class Passivbot:
                     )
                     break
                 logging.warning(
-                    "Timed out acquiring candle lock for %s; forager refresh will retry (%s)",
+                    "Timed out acquiring candle lock for %s; forager refresh will retry "
+                    "error_type=%s",
                     Passivbot._log_symbol(sym),
-                    exc,
+                    bounded_exception_type(exc),
                 )
             except Exception as exc:
                 logging.error(
-                    "error refreshing forager candles for %s: %s",
+                    "error refreshing forager candles for %s | error_type=%s",
                     Passivbot._log_symbol(sym),
-                    exc,
-                    exc_info=True,
+                    bounded_exception_type(exc),
                 )
         try:
             elapsed_s = int(max(0, utc_ms() - refresh_started_ms) / 1000)
@@ -18851,7 +18857,8 @@ class Passivbot:
             raise
         except Exception as exc:
             logging.error(
-                "[candle] forager candidate refresh failed: %s", exc, exc_info=True
+                "[candle] forager candidate refresh failed | error_type=%s",
+                bounded_exception_type(exc),
             )
 
     def _schedule_forager_candidate_candle_refresh(self) -> None:
@@ -18926,13 +18933,16 @@ class Passivbot:
                         )
                 except TimeoutError as exc:
                     logging.warning(
-                        "Timed out acquiring candle lock for %s; will retry next cycle (%s)",
+                        "Timed out acquiring candle lock for %s; will retry next cycle "
+                        "error_type=%s",
                         sym,
-                        exc,
+                        bounded_exception_type(exc),
                     )
                 except Exception as exc:
                     logging.error(
-                        "error refreshing candles for %s: %s", sym, exc, exc_info=True
+                        "error refreshing candles for %s | error_type=%s",
+                        sym,
+                        bounded_exception_type(exc),
                     )
             signature, missing = Passivbot._completed_candle_freshness_signature(
                 self, ordered_symbols, now_ms=now
@@ -18952,11 +18962,14 @@ class Passivbot:
         except Exception as e:
             if Passivbot._shutdown_requested(self):
                 logging.debug(
-                    "[shutdown] stopped candle refresh during shutdown: %s", e
+                    "[shutdown] stopped candle refresh during shutdown | error_type=%s",
+                    bounded_exception_type(e),
                 )
                 return False
-            logging.error(f"error with {get_function_name()} {e}")
-            traceback.print_exc()
+            logging.error(
+                "[candle] active refresh failed | action=return_false error_type=%s",
+                bounded_exception_type(e),
+            )
             return False
 
     async def maintain_hourly_cycle(self):

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -2022,6 +2022,37 @@ async def test_get_last_prices_uses_completed_candles_not_bulk_tickers(monkeypat
 
 
 @pytest.mark.asyncio
+async def test_get_last_prices_bounds_failed_completed_close_diagnostic(tmp_path):
+    class _Ex:
+        id = "bybit"
+
+    secret = "https://private.example.test/?api_key=SECRET_LAST_PRICE"
+    cm = CandlestickManager(exchange=_Ex(), exchange_name="bybit", cache_dir=str(tmp_path / "caches"))
+    diagnostics = []
+
+    async def fake_completed_close(symbol, **kwargs):
+        if symbol == "BROKEN/USDT:USDT":
+            raise RuntimeError(secret)
+        return 123.45
+
+    cm.get_latest_completed_close = fake_completed_close
+    cm._log = lambda level, event, **data: diagnostics.append((level, event, data))
+
+    prices = await cm.get_last_prices(["BROKEN/USDT:USDT", "OK/USDT:USDT"])
+
+    assert prices == {"BROKEN/USDT:USDT": 0.0, "OK/USDT:USDT": 123.45}
+    assert diagnostics == [
+        (
+            "debug",
+            "get_last_prices_completed_close_failed",
+            {"symbol": "BROKEN/USDT:USDT", "error_type": "RuntimeError"},
+        )
+    ]
+    assert secret not in repr(diagnostics)
+    assert "Traceback" not in repr(diagnostics)
+
+
+@pytest.mark.asyncio
 async def test_remote_ohlcv_fetch_spacing_paces_concurrent_calls(tmp_path):
     class _Ex:
         id = "okx"

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -414,6 +414,271 @@ async def test_forager_candidate_refresh_scheduler_coalesces_running_task():
 
 
 @pytest.mark.asyncio
+async def test_live_candle_refresh_failures_are_bounded_and_continue_unaffected_symbols(
+    monkeypatch, caplog
+):
+    import passivbot as pb_mod
+
+    now_ms = 1_000_000
+    secret = "wss://private.example.test/?api_key=CANDLE_REFRESH_SECRET"
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: now_ms)
+
+    class FakeCM:
+        default_window_candles = 120
+
+        def __init__(self):
+            self.calls = []
+
+        def is_rate_limited(self):
+            return False
+
+        async def get_candles(self, symbol, **kwargs):
+            self.calls.append(symbol)
+            if symbol == "TIMEOUT/USDT:USDT":
+                raise TimeoutError(secret)
+            if symbol == "BROKEN/USDT:USDT":
+                raise RuntimeError(secret)
+            return []
+
+    class Ledger:
+        def __init__(self):
+            self.stamps = []
+
+        def stamp(self, *args, **kwargs):
+            self.stamps.append((args, kwargs))
+
+    class ActiveBot:
+        stop_signal_received = False
+        _shutdown_in_progress = False
+
+        def __init__(self):
+            self.cm = FakeCM()
+            self.ledger = Ledger()
+
+        def _get_fetch_delay_seconds(self):
+            return 0.0
+
+        def _maybe_log_candle_refresh(self, *args, **kwargs):
+            return None
+
+        def _urgent_active_candle_symbols(self):
+            return ["BROKEN/USDT:USDT", "OK/USDT:USDT"]
+
+        def _completed_candle_health_now_ms(self):
+            return now_ms
+
+        def _completed_candle_freshness_signature(self, symbols, *, now_ms):
+            return (("completed", tuple(symbols)),), []
+
+        def _ensure_freshness_ledger(self):
+            return self.ledger
+
+        _shutdown_requested = pb_mod.Passivbot._shutdown_requested
+
+    monkeypatch.setattr(
+        pb_mod.Passivbot,
+        "_urgent_active_candle_symbols",
+        lambda _bot: ["TIMEOUT/USDT:USDT", "BROKEN/USDT:USDT", "OK/USDT:USDT"],
+    )
+    monkeypatch.setattr(
+        pb_mod.Passivbot,
+        "_completed_candle_freshness_signature",
+        lambda _bot, symbols, *, now_ms: ((("completed", tuple(symbols)),), []),
+    )
+    bot = ActiveBot()
+    with caplog.at_level(logging.WARNING):
+        assert await pb_mod.Passivbot.update_ohlcvs_1m_for_actives(bot) is True
+
+    assert bot.cm.calls == [
+        "TIMEOUT/USDT:USDT",
+        "BROKEN/USDT:USDT",
+        "OK/USDT:USDT",
+    ]
+    assert bot.ledger.stamps
+    assert "Timed out acquiring candle lock for TIMEOUT/USDT:USDT" in caplog.text
+    assert "error refreshing candles for BROKEN/USDT:USDT" in caplog.text
+    assert "error_type=TimeoutError" in caplog.text
+    assert "error_type=RuntimeError" in caplog.text
+    assert secret not in caplog.text
+    assert "Traceback" not in caplog.text
+
+    caplog.clear()
+
+    class OuterFailureBot:
+        stop_signal_received = False
+        _shutdown_in_progress = False
+        _shutdown_requested = pb_mod.Passivbot._shutdown_requested
+
+    monkeypatch.setattr(
+        pb_mod.Passivbot,
+        "_completed_candle_health_now_ms",
+        lambda _bot: (_ for _ in ()).throw(RuntimeError(secret)),
+    )
+    with caplog.at_level(logging.ERROR):
+        assert await pb_mod.Passivbot.update_ohlcvs_1m_for_actives(OuterFailureBot()) is False
+
+    assert "active refresh failed" in caplog.text
+    assert "action=return_false" in caplog.text
+    assert "error_type=RuntimeError" in caplog.text
+    assert secret not in caplog.text
+    assert "Traceback" not in caplog.text
+
+    caplog.clear()
+
+    class ShutdownFailureBot(OuterFailureBot):
+        stop_signal_received = True
+
+    with caplog.at_level(logging.DEBUG):
+        assert await pb_mod.Passivbot.update_ohlcvs_1m_for_actives(ShutdownFailureBot()) is False
+
+    assert "stopped candle refresh during shutdown" in caplog.text
+    assert "error_type=RuntimeError" in caplog.text
+    assert secret not in caplog.text
+    assert "Traceback" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_forager_refresh_task_and_cap_log_bound_failure_diagnostics(monkeypatch, caplog):
+    import passivbot as pb_mod
+
+    secret = "https://private.example.test/?secret=FORAGER_REFRESH_SECRET"
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: 1_000_000)
+
+    class FakeBot:
+        def __init__(self):
+            self.stop_signal_received = False
+            self._shutdown_in_progress = False
+
+        async def _refresh_forager_candidate_candles(self):
+            raise RuntimeError(secret)
+
+        _shutdown_requested = pb_mod.Passivbot._shutdown_requested
+
+    bot = FakeBot()
+    with caplog.at_level(logging.DEBUG):
+        await pb_mod.Passivbot._forager_candidate_candle_refresh_task(bot)
+
+        def raise_while_formatting(_symbol):
+            raise RuntimeError(secret)
+
+        monkeypatch.setattr(pb_mod.Passivbot, "_log_symbol", raise_while_formatting)
+        pb_mod.Passivbot._log_forager_refresh_wall_time_cap(
+            bot,
+            symbol="BROKEN/USDT:USDT",
+            max_refresh_ms=60_000,
+            stale_age_ms=60_000,
+            target_age_ms=30_000,
+            refreshed_count=0,
+            total_count=1,
+        )
+
+    assert "forager candidate refresh failed" in caplog.text
+    assert "forager refresh cap log failed" in caplog.text
+    assert caplog.text.count("error_type=RuntimeError") == 2
+    assert secret not in caplog.text
+    assert "Traceback" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_forager_refresh_bounds_per_symbol_timeout_and_failure(monkeypatch, caplog):
+    import passivbot as pb_mod
+
+    now_ms = 1_000_000
+    secret = "https://private.example.test/?token=FORAGER_SYMBOL_SECRET"
+    symbols = ["TIMEOUT/USDT:USDT", "BROKEN/USDT:USDT", "OK/USDT:USDT"]
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: now_ms)
+    monkeypatch.setattr(
+        pb_mod,
+        "compute_live_warmup_windows",
+        lambda *args, **kwargs: (
+            {symbol: 10 for symbol in symbols},
+            {symbol: 0 for symbol in symbols},
+            {symbol: True for symbol in symbols},
+        ),
+    )
+    monkeypatch.setattr(pb_mod.Passivbot, "_urgent_active_candle_symbols", lambda _bot: [])
+    monkeypatch.setattr(
+        pb_mod.Passivbot,
+        "_forager_refresh_budget",
+        lambda _bot, *args, **kwargs: 3,
+    )
+    monkeypatch.setattr(
+        pb_mod.Passivbot,
+        "_forager_target_staleness_ms",
+        lambda _bot, *args, **kwargs: 0,
+    )
+    monkeypatch.setattr(
+        pb_mod.Passivbot,
+        "_candidate_candle_surface_health",
+        lambda _bot, *args, **kwargs: {"age_ms": 60_000, "coverage_ok": False, "no_basis": True},
+    )
+
+    class FakeCM:
+        default_window_candles = 120
+
+        def __init__(self):
+            self.calls = []
+
+        async def get_candles(self, symbol, **kwargs):
+            self.calls.append(symbol)
+            if symbol == "TIMEOUT/USDT:USDT":
+                raise TimeoutError(secret)
+            if symbol == "BROKEN/USDT:USDT":
+                raise RuntimeError(secret)
+            return []
+
+    class FakeBot:
+        config = {
+            "live": {
+                "max_ohlcv_fetches_per_minute": 12,
+                "max_forager_candle_refresh_seconds": 0,
+            }
+        }
+        approved_coins_minus_ignored_coins = {"long": set(symbols), "short": set()}
+        stop_signal_received = False
+        _shutdown_in_progress = False
+        start_time_ms = now_ms
+
+        def __init__(self):
+            self.cm = FakeCM()
+
+        def is_forager_mode(self, pside=None):
+            return pside in (None, "long")
+
+        def get_max_n_positions(self, pside):
+            return 3 if pside == "long" else 0
+
+        def get_current_n_positions(self, pside):
+            return 0
+
+        def bp(self, *args, **kwargs):
+            return 0.0
+
+        def _get_fetch_delay_seconds(self):
+            return 0.0
+
+        def _forager_refresh_budget(self, *args, **kwargs):
+            return 3
+
+        def _forager_target_staleness_ms(self, *args, **kwargs):
+            return 0
+
+        _shutdown_requested = pb_mod.Passivbot._shutdown_requested
+
+    bot = FakeBot()
+    with caplog.at_level(logging.WARNING):
+        await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
+
+    assert bot.cm.calls == sorted(symbols)
+    assert "Timed out acquiring candle lock for TIMEOUT" in caplog.text
+    assert "error refreshing forager candles for BROKEN" in caplog.text
+    assert caplog.text.count("error_type=TimeoutError") == 1
+    assert caplog.text.count("error_type=RuntimeError") == 1
+    assert secret not in caplog.text
+    assert "Traceback" not in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_orchestrator_ema_bundle_uses_cache_only_for_secondary_forager_symbols(
     monkeypatch,
 ):
@@ -1981,6 +2246,7 @@ async def test_warmup_candles_reuses_fresh_1m_cache(monkeypatch, caplog):
     cached_symbol = "CACHED/USDT:USDT"
     cold_symbols = [f"MISS{idx}/USDT:USDT" for idx in range(20)]
     symbols = [cached_symbol, *cold_symbols]
+    secret = "https://private.example.test/?token=CANDLE_INDEX_SECRET"
     monkeypatch.setattr(pb_mod, "utc_ms", lambda: now_ms)
 
     def fake_compute_live_warmup_windows(*args, **kwargs):
@@ -2066,6 +2332,7 @@ async def test_warmup_candles_reuses_fresh_1m_cache(monkeypatch, caplog):
 
         async def rebuild_required_candle_indices(self, *args, **kwargs):
             self.rebuild_calls.append((args, kwargs))
+            raise RuntimeError(secret)
 
     bot = FakeBot()
     events = []
@@ -2120,6 +2387,10 @@ async def test_warmup_candles_reuses_fresh_1m_cache(monkeypatch, caplog):
     }
     assert warmup_events[0]["data"]["window_min_candles"] == 12
     assert warmup_events[0]["data"]["window_max_candles"] == 12
+    assert "candle index rebuild skipped" in caplog.text
+    assert "error_type=RuntimeError" in caplog.text
+    assert secret not in caplog.text
+    assert "Traceback" not in caplog.text
 
 
 @pytest.mark.asyncio
@@ -2360,7 +2631,7 @@ async def test_background_candle_warmup_failure_remains_error(caplog):
     records = [record for record in caplog.records if "background warmup failed" in record.message]
     assert len(records) == 1
     assert records[0].levelno == logging.ERROR
-    assert records[0].message == "[candle] background warmup failed: warmup failed"
+    assert records[0].message == "[candle] background warmup failed | error_type=RuntimeError"
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -495,7 +495,10 @@ async def test_live_candle_refresh_failures_are_bounded_and_continue_unaffected_
         "OK/USDT:USDT",
     ]
     assert bot.ledger.stamps
-    assert "Timed out acquiring candle lock for TIMEOUT/USDT:USDT" in caplog.text
+    assert (
+        "Timed out acquiring candle lock for TIMEOUT/USDT:USDT; "
+        "will retry next cycle | error_type=TimeoutError"
+    ) in caplog.text
     assert "error refreshing candles for BROKEN/USDT:USDT" in caplog.text
     assert "error_type=TimeoutError" in caplog.text
     assert "error_type=RuntimeError" in caplog.text
@@ -670,7 +673,10 @@ async def test_forager_refresh_bounds_per_symbol_timeout_and_failure(monkeypatch
         await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
 
     assert bot.cm.calls == sorted(symbols)
-    assert "Timed out acquiring candle lock for TIMEOUT" in caplog.text
+    assert (
+        "Timed out acquiring candle lock for TIMEOUT; "
+        "forager refresh will retry | error_type=TimeoutError"
+    ) in caplog.text
     assert "error refreshing forager candles for BROKEN" in caplog.text
     assert caplog.text.count("error_type=TimeoutError") == 1
     assert caplog.text.count("error_type=RuntimeError") == 1

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -2874,6 +2874,53 @@ async def test_start_bot_treats_shutdown_cancelled_warmup_as_clean_stop(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_start_bot_bounds_trading_ready_warmup_failure(monkeypatch, caplog):
+    bot = Passivbot.__new__(Passivbot)
+    bot.runtime_identity = TEST_RUNTIME_IDENTITY
+    bot._runtime_manifest_written = True
+    bot.exchange = "bybit"
+    bot.user = "test_user"
+    bot.quote = "USDT"
+    bot.start_time_ms = 1_000_000
+    bot.config = {"live": {}}
+    bot.debug_mode = False
+    bot.stop_signal_received = False
+    bot._shutdown_in_progress = False
+    bot._bot_ready = False
+    bot.user_info = {"exchange": "bybit"}
+    bot._log_startup_banner = lambda: None
+    bot._monitor_record_event = lambda *args, **kwargs: None
+    bot._monitor_record_error = lambda *args, **kwargs: None
+    bot._monitor_flush_snapshot = AsyncMock()
+    bot._monitor_emit_stop = lambda *args, **kwargs: None
+    bot.init_markets = AsyncMock()
+    bot._equity_hard_stop_enabled = lambda *args, **kwargs: False
+    secret = "api_key=trading-ready-warmup-secret"
+
+    async def _format(*args, **kwargs):
+        return None
+
+    async def _warmup():
+        raise RuntimeError(secret)
+
+    async def _sleep(*args, **kwargs):
+        bot.stop_signal_received = True
+
+    monkeypatch.setattr(passivbot_module, "format_approved_ignored_coins", _format)
+    bot.warmup_trading_ready_candles = _warmup
+    bot._sleep_unless_shutdown = _sleep
+
+    with caplog.at_level(logging.INFO):
+        await bot.start_bot()
+
+    assert bot.stop_signal_received is True
+    assert "trading-ready candle warmup skipped" in caplog.text
+    assert "error_type=RuntimeError" in caplog.text
+    assert secret not in caplog.text
+    assert "Traceback" not in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_start_bot_treats_hsl_value_error_as_terminal_startup_failure(
     monkeypatch, caplog
 ):
@@ -3399,6 +3446,25 @@ async def test_background_candle_warmup_marks_full_warmup_ready(monkeypatch, cap
 
     assert calls == [{"context": "background warmup"}]
     assert any("full-warmup-ready=4.25s" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_background_candle_warmup_bounds_failure_diagnostic(caplog):
+    bot = Passivbot.__new__(Passivbot)
+    secret = "wss://private.example.test/?token=BACKGROUND_SECRET"
+
+    async def warmup_candles_staggered(**kwargs):
+        raise RuntimeError(secret)
+
+    bot.warmup_candles_staggered = warmup_candles_staggered
+
+    with caplog.at_level(logging.ERROR):
+        await Passivbot._background_candle_warmup_task(bot)
+
+    assert "background warmup failed" in caplog.text
+    assert "error_type=RuntimeError" in caplog.text
+    assert secret not in caplog.text
+    assert "Traceback" not in caplog.text
 
 
 def _set_pnl_lookback(bot, *, lookback_days: float, now_ms: int) -> None:


### PR DESCRIPTION
@codex

## Summary
- replace arbitrary exception messages and exception-value tracebacks in live candle completed-close, warmup, forager-refresh, and active-refresh diagnostics with bounded exception types
- retain existing code-owned symbol, operation, action, and retry context
- preserve warmup, cancellation, lock retry, scheduling, fallback values, freshness/readiness, and trading behavior

## Scope
This is a diagnostic-retention change only. Trailing-planning, candle-health, HSL replay, hourly maintenance, and market-snapshot failure boundaries are intentionally outside this slice.

## Validation
- full Python test suite
- 217 Rust tests with `cargo test --no-default-features`
- `cargo check --tests`
- `cargo fmt --check`
- exact Rust extension rebuild, source stamp, and runtime verification
- AI documentation and generated event-registry checks
- Python compile and `git diff --check`
