### PR TITLE
Redact candle health diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,11 @@ All notable user-facing changes will be documented in this file.
   exception messages or exception-value tracebacks. Warmup, cancellation, lock retry, refresh
   scheduling, fallback values, readiness, and trading behavior are unchanged.
 
+- Live candle health-window, health-summary, trailing-fetch, freshness-readiness, and tail-gap
+  diagnostics now retain bounded exception types without arbitrary exception messages. Health
+  fallbacks, symbol/position-side availability, trailing deferral, readiness results, and trading
+  behavior are unchanged.
+
 - Fill-history refresh failure diagnostics now retain bounded exception types alongside existing
   source, coverage, retry, timing, count, and endpoint context without arbitrary exception
   messages or exception-value tracebacks. This includes exchange-specific fill fetchers, cache

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -26,6 +26,10 @@
    warmup, forager refresh, active refresh, and refresh-cap handling retain bounded exception type
    instead of exception text or exception-value traceback. Redaction must not alter warmup,
    cancellation, lock retry, refresh scheduling, fallback values, readiness, or trading behavior.
+9. Direct live health and trailing diagnostics retain bounded exception type instead of exception
+   text in health-window construction, health summaries, trailing fetch failures, freshness
+   readiness, and tail-gap projection logging. Redaction must not alter fallback values,
+   symbol/position-side availability, trailing deferral, readiness results, or trading behavior.
 
 ## Non-Obvious Details
 
@@ -114,6 +118,9 @@ Cache paths use `to_standard_exchange_name()` rather than raw CCXT identifiers s
 8. Hostile live lifecycle failures retain bounded exception classification without exception values
    or traceback text while preserving completed-close fallback, warmup, cancellation, lock retry,
    refresh scheduling, readiness, and return behavior.
+9. Hostile live health and trailing failures retain bounded exception classification without
+   exception values while preserving fallback values, affected symbol/position-side unavailability,
+   trailing deferral, readiness results, and unaffected consumers.
 
 ## Key Code
 

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -5402,30 +5402,27 @@ class Passivbot:
                 max_n = int(self.get_max_n_positions(pside))
             except Exception as exc:
                 logging.debug(
-                    "[candle] unable to read max positions for health windows | pside=%s error_type=%s error=%s",
+                    "[candle] unable to read max positions for health windows | pside=%s error_type=%s",
                     pside,
-                    type(exc).__name__,
-                    exc,
+                    bounded_exception_type(exc),
                 )
                 max_n = 0
             try:
                 current_n = int(self.get_current_n_positions(pside))
             except Exception as exc:
                 logging.debug(
-                    "[candle] unable to read current positions for health windows | pside=%s error_type=%s error=%s",
+                    "[candle] unable to read current positions for health windows | pside=%s error_type=%s",
                     pside,
-                    type(exc).__name__,
-                    exc,
+                    bounded_exception_type(exc),
                 )
                 try:
                     current_n = len(self.get_symbols_with_pos(pside))
                 except Exception as fallback_exc:
                     logging.debug(
                         "[candle] unable to infer current positions for health windows | "
-                        "pside=%s error_type=%s error=%s",
+                        "pside=%s error_type=%s",
                         pside,
-                        type(fallback_exc).__name__,
-                        fallback_exc,
+                        bounded_exception_type(fallback_exc),
                     )
                     current_n = 0
             slots_open = max_n > current_n
@@ -5435,10 +5432,9 @@ class Passivbot:
                 )
             except Exception as exc:
                 logging.debug(
-                    "[candle] unable to read forager mode for health windows | pside=%s error_type=%s error=%s",
+                    "[candle] unable to read forager mode for health windows | pside=%s error_type=%s",
                     pside,
-                    type(exc).__name__,
-                    exc,
+                    bounded_exception_type(exc),
                 )
                 forager_enabled[pside] = False
             try:
@@ -5448,10 +5444,9 @@ class Passivbot:
                     syms = set(self.get_symbols_with_pos(pside))
             except Exception as exc:
                 logging.debug(
-                    "[candle] unable to build symbol set for health windows | pside=%s error_type=%s error=%s",
+                    "[candle] unable to build symbol set for health windows | pside=%s error_type=%s",
                     pside,
-                    type(exc).__name__,
-                    exc,
+                    bounded_exception_type(exc),
                 )
                 syms = set()
             if symbol_filter is not None:
@@ -5726,9 +5721,8 @@ class Passivbot:
                 logging.debug("[candle] health ok | symbols=%d", len(symbol_reports))
         except Exception as exc:
             logging.debug(
-                "[candle] health diagnostics failed | error_type=%s error=%s",
-                type(exc).__name__,
-                exc,
+                "[candle] health diagnostics failed | error_type=%s",
+                bounded_exception_type(exc),
             )
 
     def _candle_health_missing_is_actionable(
@@ -8584,7 +8578,11 @@ class Passivbot:
             except Exception as e:
                 unavailable_reasons["candle_fetch_failed"].add(sym)
                 unavailable_psides[sym].update(required_trailing.get(sym, set()))
-                logging.debug("failed to fetch candles for trailing %s: %s", sym, e)
+                logging.debug(
+                    "[trailing] candle fetch failed | symbol=%s reason=candle_fetch_failed action=mark_unavailable error_type=%s",
+                    Passivbot._log_symbol(sym),
+                    bounded_exception_type(e),
+                )
                 results[sym] = None
 
         # Compute trailing metrics per symbol/side
@@ -10403,8 +10401,7 @@ class Passivbot:
                         {
                             "symbol": symbol,
                             "reason": "candle_health_failed",
-                            "error_type": type(exc).__name__,
-                            "error": str(exc),
+                            "error_type": bounded_exception_type(exc),
                         }
                     )
                     continue
@@ -10647,9 +10644,8 @@ class Passivbot:
             )
         except Exception as exc:
             logging.debug(
-                "[candle] active tail-gap fallback log failed | error_type=%s error=%s",
-                type(exc).__name__,
-                exc,
+                "[candle] active tail-gap fallback log failed | error_type=%s",
+                bounded_exception_type(exc),
             )
 
     def _completed_candle_signature_mismatch_details(

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -2088,6 +2088,62 @@ def test_forager_target_staleness_obeys_configured_cap():
     assert target_ms == 10 * 60_000
 
 
+def test_required_candle_health_window_failures_are_bounded_and_keep_other_side_windows(caplog):
+    import passivbot as pb_mod
+
+    secret = "api_key=health-window-secret\nTraceback (most recent call last)"
+
+    class FakeCM:
+        pass
+
+    class FakeBot:
+        cm = FakeCM()
+        config = {"live": {}}
+
+        def get_max_n_positions(self, pside):
+            if pside == "long":
+                raise RuntimeError(secret)
+            return 2
+
+        def get_current_n_positions(self, pside):
+            if pside == "long":
+                raise RuntimeError(secret)
+            return 1
+
+        def get_symbols_with_pos(self, pside):
+            if pside == "long":
+                raise RuntimeError(secret)
+            return {"SHORT/USDT:USDT"}
+
+        def is_forager_mode(self, pside):
+            if pside == "long":
+                raise RuntimeError(secret)
+            return False
+
+        def get_symbols_approved_or_has_pos(self, pside):
+            if pside == "long":
+                raise RuntimeError(secret)
+            return {"SHORT/USDT:USDT"}
+
+        def bp(self, pside, key, symbol):
+            return 0.0
+
+    with caplog.at_level(logging.DEBUG):
+        windows = pb_mod.Passivbot._required_candle_windows_by_symbol(FakeBot())
+
+    messages = [record.getMessage() for record in caplog.records if "health windows" in record.message]
+    assert len(messages) == 5
+    assert all("pside=long" in message and "error_type=RuntimeError" in message for message in messages)
+    assert all(secret not in message and "Traceback" not in message for message in messages)
+    assert windows == {
+        "SHORT/USDT:USDT": {
+            "1m": {"candles": 1, "required": True},
+            "15m": {"candles": 1, "required": False},
+            "1h": {"candles": 1, "required": False},
+        }
+    }
+
+
 def test_startup_active_candle_symbols_include_positions_orders_and_active():
     import passivbot as pb_mod
 
@@ -4388,6 +4444,69 @@ def test_completed_candle_freshness_allows_bounded_active_tail_gap(monkeypatch, 
         and record.levelno == logging.INFO
         for record in caplog.records
     )
+
+
+def test_completed_candle_health_failure_payload_is_bounded_and_keeps_other_symbols(caplog):
+    import passivbot as pb_mod
+
+    secret = "token=candle-health-secret\nTraceback (most recent call last)"
+
+    class FakeCM:
+        def get_completed_candle_health(self, symbol, windows, *, now_ms=None):
+            assert windows == {"1m": 1}
+            if symbol == "BAD/USDT:USDT":
+                raise RuntimeError(secret)
+            return {
+                "ok": True,
+                "timeframes": {
+                    "1m": {"coverage_ok": True, "latest_expected_ts": 120_000}
+                },
+            }
+
+    bot = pb_mod.Passivbot.__new__(pb_mod.Passivbot)
+    bot.cm = FakeCM()
+
+    with caplog.at_level(logging.DEBUG):
+        signature, missing = pb_mod.Passivbot._completed_candle_freshness_signature(
+            bot, ["BAD/USDT:USDT", "GOOD/USDT:USDT"], now_ms=180_000
+        )
+
+    assert signature == (("GOOD/USDT:USDT", 120_000),)
+    assert missing == [
+        {
+            "symbol": "BAD/USDT:USDT",
+            "reason": "candle_health_failed",
+            "error_type": "RuntimeError",
+        }
+    ]
+    rendered = "\n".join(record.getMessage() for record in caplog.records)
+    assert secret not in rendered
+    assert "Traceback" not in rendered
+
+
+def test_completed_candle_tail_gap_fallback_log_failure_is_bounded(caplog):
+    import passivbot as pb_mod
+
+    secret = "password=tail-gap-secret\nTraceback (most recent call last)"
+
+    class FailingSignatures:
+        def __iter__(self):
+            raise RuntimeError(secret)
+
+    bot = pb_mod.Passivbot.__new__(pb_mod.Passivbot)
+
+    with caplog.at_level(logging.DEBUG):
+        pb_mod.Passivbot._log_completed_candle_tail_gap_fallbacks(bot, FailingSignatures())
+
+    records = [
+        record
+        for record in caplog.records
+        if "active tail-gap fallback log failed" in record.message
+    ]
+    assert len(records) == 1
+    assert records[0].getMessage().endswith("error_type=RuntimeError")
+    assert secret not in records[0].getMessage()
+    assert "Traceback" not in records[0].getMessage()
 
 
 def test_completed_candle_tail_gap_fallback_repeats_at_debug(monkeypatch, caplog):

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -4797,6 +4797,32 @@ def test_candle_health_summary_projection_preserves_debug_payload_and_transition
     }
 
 
+def test_candle_health_summary_failure_is_bounded(monkeypatch, caplog):
+    secret = "api_secret=health-summary-secret\nTraceback (most recent call last)"
+    bot = Passivbot.__new__(Passivbot)
+    bot.active_symbols = ["BTC/USDT:USDT"]
+    bot.open_orders = {}
+    bot.positions = {}
+
+    def fail_report(_symbols):
+        raise RuntimeError(secret)
+
+    monkeypatch.setattr(bot, "build_required_candle_health_report", fail_report)
+
+    with caplog.at_level(logging.DEBUG):
+        bot._maybe_log_candle_health_summary()
+
+    records = [
+        record
+        for record in caplog.records
+        if "[candle] health diagnostics failed" in record.message
+    ]
+    assert len(records) == 1
+    assert records[0].getMessage().endswith("error_type=RuntimeError")
+    assert secret not in records[0].getMessage()
+    assert "Traceback" not in records[0].getMessage()
+
+
 def test_memory_snapshot_is_interesting_only_initially_or_on_large_change():
     bot = Passivbot.__new__(Passivbot)
 

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -1066,18 +1066,30 @@ async def test_trailing_fetch_failure_preserves_bundle_and_marks_symbol_unavaila
     }
     bot.is_trailing = lambda sym, pside=None: pside == "long"
 
+    secret = "credential=trailing-secret\nTraceback (most recent call last)"
+
     async def fail_get_candles(*args, **kwargs):
-        raise RuntimeError("remote down")
+        raise RuntimeError(secret)
 
     bot.cm.get_candles = fail_get_candles
 
-    caplog.set_level(logging.WARNING)
+    caplog.set_level(logging.DEBUG)
     await bot.update_trailing_data()
 
     assert bot.trailing_prices[symbol]["long"] == previous_bundle
     assert bot._orchestrator_trailing_unavailable_symbols == {symbol}
-    assert any("[trailing]" in record.message for record in caplog.records)
-    assert any("candle_fetch_failed" in record.message for record in caplog.records)
+    records = [
+        record
+        for record in caplog.records
+        if "[trailing] candle fetch failed" in record.message
+    ]
+    assert len(records) == 1
+    assert "[trailing]" in records[0].message
+    assert "symbol=TEST" in records[0].message
+    assert "action=mark_unavailable" in records[0].message
+    assert records[0].getMessage().endswith("error_type=RuntimeError")
+    assert secret not in records[0].getMessage()
+    assert "Traceback" not in records[0].getMessage()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
@codex

## Summary
- retain bounded exception types without arbitrary exception text in live candle health-window and health-summary diagnostics
- redact trailing-fetch, freshness-readiness, and tail-gap failure diagnostics
- preserve fallback values, symbol and position-side availability, trailing deferral, readiness results, and trading behavior

## Validation
- full Python test suite
- targeted candle budget, trailing safeguard, and health-summary regressions
- 221 Rust tests
- cargo check --tests
- cargo fmt --check
- AI documentation and generated live-event registry checks