### PR TITLE
Redact HSL replay diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- HSL replay cache and replay-lifecycle diagnostics now retain bounded exception types without
+  exception messages, tracebacks, or unsafe exception class names. Cache write failures remain
+  nonfatal, cache reuse still falls back to authoritative replay, and HSL readiness and protection
+  behavior are unchanged.
+
 - Fixed Bitget UTA open-order normalization recursively deriving position side from close-only
   effect and close-only effect from position side in effective one-way mode. UTA orders with an
   explicit `posSide` now derive close-only effect directly from the authoritative `side` plus

--- a/docs/ai/features/equity_hard_stop_loss.md
+++ b/docs/ai/features/equity_hard_stop_loss.md
@@ -26,6 +26,10 @@ HSL drawdown state is scoped by `live.hsl_signal_mode`:
    proven non-flat intervention snapshot; an entry or partial-close fill is not flatten evidence.
 6. Restart reconstruction uses exchange state, fill/PnL history, candles where required, config, and
    current time. Local latch and replay-cache files are accelerators or diagnostics, not authority.
+7. Replay-cache write, reuse, and completed-replay persistence failures are nonfatal performance
+   outcomes. They retain only a bounded exception type in diagnostics and fall back to authoritative
+   replay when reuse is unavailable. Coin replay failures retain the same bounded classification
+   without changing exception propagation or held-pair protection and flat-pair entry blocking.
 
 ## Failure Semantics
 

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -295,6 +295,8 @@ For coin-mode `hsl.replay.completed`, `full_elapsed_s` is total replay time;
 
 Cache events use `hsl.replay.cache` with `cache_status=hit|miss|rejected`. Cache misses and
 rejections are non-authoritative performance outcomes and fall back to exchange-derived replay.
+Cache write/load rejection reasons and coin replay failures retain bounded exception types only,
+never exception text, tracebacks, or unsafe exception class names.
 Pair progress exposes `applied_rows`/`total_applied_rows` and scan-cost fields
 `scanned_rows`/`total_scanned_rows`/`scanned_rows_per_second`/`pair_elapsed_s`.
 `is_held_pair`, `is_cooldown_pair`, and `pair_idx` expose deterministic

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -1762,7 +1762,7 @@ def _try_load_hsl_replay_matrix_cache(
             _hsl_replay_cache_status_data(
                 cache_status="rejected",
                 elapsed_s=elapsed_s,
-                reasons=[f"validation_exception:{type(exc).__name__}"],
+                reasons=[f"validation_exception:{_bounded_hsl_exception_type(exc)}"],
                 expected_metadata=expected_metadata,
             ),
             pside=pside,
@@ -1814,7 +1814,7 @@ def _try_load_hsl_replay_matrix_cache(
             _hsl_replay_cache_status_data(
                 cache_status="rejected",
                 elapsed_s=elapsed_s,
-                reasons=[f"load_exception:{type(exc).__name__}"],
+                reasons=[f"load_exception:{_bounded_hsl_exception_type(exc)}"],
                 expected_metadata=expected_metadata,
             ),
             pside=pside,
@@ -2319,12 +2319,11 @@ def _equity_hard_stop_persist_replay_matrices(self, history: dict[str, Any]) -> 
                 manifest = _write_hsl_replay_matrix_cache(cache_dir, rows, metadata)
             except Exception as exc:
                 logging.warning(
-                    "[risk] HSL[%s:%s] replay cache write failed | rows=%d error=%s: %s",
+                    "[risk] HSL[%s:%s] replay cache write failed | rows=%d error_type=%s",
                     pside,
                     symbol,
                     len(rows) if isinstance(rows, list) else -1,
-                    type(exc).__name__,
-                    exc,
+                    _bounded_hsl_exception_type(exc),
                 )
                 _emit_hsl_replay_event(
                     self,
@@ -2332,7 +2331,7 @@ def _equity_hard_stop_persist_replay_matrices(self, history: dict[str, Any]) -> 
                     _hsl_replay_cache_status_data(
                         cache_status="write_failed",
                         elapsed_s=time.monotonic() - started_s,
-                        reasons=[f"write_exception:{type(exc).__name__}"],
+                        reasons=[f"write_exception:{_bounded_hsl_exception_type(exc)}"],
                     ),
                     pside=pside,
                     symbol=symbol,
@@ -2384,10 +2383,9 @@ def _equity_hard_stop_persist_replay_matrices(self, history: dict[str, Any]) -> 
             )
         except Exception as exc:
             logging.warning(
-                "[risk] HSL account series replay cache write failed | rows=%d error=%s: %s",
+                "[risk] HSL account series replay cache write failed | rows=%d error_type=%s",
                 len(account_rows),
-                type(exc).__name__,
-                exc,
+                _bounded_hsl_exception_type(exc),
             )
             _emit_hsl_replay_event(
                 self,
@@ -2395,7 +2393,7 @@ def _equity_hard_stop_persist_replay_matrices(self, history: dict[str, Any]) -> 
                 _hsl_replay_cache_status_data(
                     cache_status="write_failed",
                     elapsed_s=time.monotonic() - started_s,
-                    reasons=[f"write_exception:{type(exc).__name__}"],
+                    reasons=[f"write_exception:{_bounded_hsl_exception_type(exc)}"],
                 ),
                 pside=_HSL_REPLAY_CACHE_ACCOUNT_PSIDE,
                 symbol=_HSL_REPLAY_CACHE_ACCOUNT_SYMBOL,
@@ -4888,9 +4886,8 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
             # to the authoritative full replay, never abort startup.
             logging.warning(
                 "[risk] HSL pside replay cache reuse failed; falling back to "
-                "full replay | error=%s: %s",
-                type(exc).__name__,
-                exc,
+                "full replay | error_type=%s",
+                _bounded_hsl_exception_type(exc),
             )
             history = None
         if history is not None:
@@ -5249,9 +5246,8 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
             # Cache persistence is a performance aid; a failure here must
             # never invalidate the completed replay.
             logging.warning(
-                "[risk] HSL replay cache persistence failed | error=%s: %s",
-                type(exc).__name__,
-                exc,
+                "[risk] HSL replay cache persistence failed | error_type=%s",
+                _bounded_hsl_exception_type(exc),
             )
     finally:
         if hasattr(self, "_set_log_silence_watchdog_context"):
@@ -5325,9 +5321,8 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             # to the authoritative full replay, never abort startup.
             logging.warning(
                 "[risk] HSL replay cache reuse failed; falling back to full "
-                "replay | error=%s: %s",
-                type(exc).__name__,
-                exc,
+                "replay | error_type=%s",
+                _bounded_hsl_exception_type(exc),
             )
             history = None
         if history is not None:
@@ -6627,9 +6622,8 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             # Cache persistence is a performance aid; a failure here must
             # never invalidate the completed replay.
             logging.warning(
-                "[risk] HSL replay cache persistence failed | error=%s: %s",
-                type(exc).__name__,
-                exc,
+                "[risk] HSL replay cache persistence failed | error_type=%s",
+                _bounded_hsl_exception_type(exc),
             )
     except asyncio.CancelledError:
         self._equity_hard_stop_coin_replay_failure = "shutdown_cancelled"
@@ -6655,16 +6649,14 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
         )
         raise
     except Exception as exc:
-        self._equity_hard_stop_coin_replay_failure = (
-            f"{type(exc).__name__}: {exc}"
-        )
+        self._equity_hard_stop_coin_replay_failure = _bounded_hsl_exception_type(exc)
         ready_event.set()
         _emit_hsl_replay_event(
             self,
             EventTypes.HSL_REPLAY_FAILED,
             {
                 "signal_mode": "coin",
-                "error_type": type(exc).__name__,
+                "error_type": _bounded_hsl_exception_type(exc),
                 "elapsed_s": round(time.monotonic() - initialization_started_s, 3),
                 "history_fetch_elapsed_s": round(history_fetch_elapsed_s, 3)
                 if "history_fetch_elapsed_s" in locals()

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -810,6 +810,65 @@ def test_hsl_replay_matrix_cache_try_load_emits_rejected_event(tmp_path):
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+@pytest.mark.parametrize(
+    ("stage", "expected_reason"),
+    [
+        ("validation", "validation_exception:RuntimeError"),
+        ("load", "load_exception:RuntimeError"),
+    ],
+)
+def test_hsl_replay_matrix_cache_try_load_redacts_hostile_exception_types(
+    tmp_path, monkeypatch, stage, expected_reason
+):
+    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline, ReasonCodes
+
+    secret = f"api_secret=hsl-cache-{stage}-secret"
+    unsafe_type = type(f"ApiKeyHslCache{stage.title()}Secret", (RuntimeError,), {})
+    bot = FakeHslBot()
+    sink = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot._emit_live_event = MethodType(Passivbot._emit_live_event, bot)
+    monkeypatch.setattr(hsl, "_hsl_replay_cache_validation_reasons", lambda *_a, **_k: [])
+    if stage == "validation":
+        def fail_validation(*_args, **_kwargs):
+            raise unsafe_type(secret)
+
+        monkeypatch.setattr(hsl, "_hsl_replay_cache_validation_reasons", fail_validation)
+    else:
+        (tmp_path / hsl._HSL_REPLAY_CACHE_MANIFEST_FILENAME).write_text("{}")
+
+        def fail_load(*_args, **_kwargs):
+            raise unsafe_type(secret)
+
+        monkeypatch.setattr(hsl.json, "loads", fail_load)
+
+    assert (
+        hsl._try_load_hsl_replay_matrix_cache(
+            bot,
+            tmp_path,
+            expected_metadata=_hsl_cache_metadata(),
+            pside="long",
+            symbol="BTC/USDT:USDT",
+        )
+        is None
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [event for event in sink.events if event.event_type == EventTypes.HSL_REPLAY_CACHE]
+    assert len(events) == 1
+    event = events[0]
+    assert event.status == "skipped"
+    assert event.reason_code == ReasonCodes.HSL_REPLAY_CACHE_REJECTED
+    assert event.data["cache_status"] == "rejected"
+    assert event.data["reasons"] == [expected_reason]
+    assert secret not in str(event.data)
+    assert unsafe_type.__name__ not in str(event.data)
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_hsl_replay_cache_config_digest_is_stable_and_hsl_scoped():
     bot = make_coin_bot()
     digest = hsl._hsl_replay_cache_config_digest(bot, "long")
@@ -1699,9 +1758,14 @@ def test_hsl_replay_cache_persist_matrices_write_failure_is_nonfatal(
 
     bot, sink = _make_persist_bot(tmp_path, monkeypatch)
     symbol = "BTC/USDT:USDT"
+    secret = "api_secret=hsl-pair-cache-write-secret"
+    unsafe_type = type("ApiKeyHslPairCacheWriteSecret", (RuntimeError,), {})
+
+    def fail_write(*_args, **_kwargs):
+        raise unsafe_type(secret)
+
+    monkeypatch.setattr(hsl, "_write_hsl_replay_matrix_cache", fail_write)
     rows = _hsl_cache_rows()
-    # Break 1m continuity so the fail-loud writer rejects the rows.
-    rows[-1] = dict(rows[-1], ts=rows[-1]["ts"] + 60_000)
     history = {
         "hsl_replay_matrices": {"long": {symbol: rows}},
         "hsl_replay_matrix_coverage": {
@@ -1718,7 +1782,11 @@ def test_hsl_replay_cache_persist_matrices_write_failure_is_nonfatal(
         written = hsl._equity_hard_stop_persist_replay_matrices(bot, history)
 
     assert written == 0
-    assert "replay cache write failed" in caplog.text
+    assert caplog.records[-1].getMessage() == (
+        f"[risk] HSL[long:{symbol}] replay cache write failed | rows=3 error_type=RuntimeError"
+    )
+    assert secret not in caplog.text
+    assert unsafe_type.__name__ not in caplog.text
     cache_dir = hsl._hsl_replay_cache_dir(bot, "long", symbol)
     assert hsl._hsl_replay_cache_validation_reasons(cache_dir) == ["manifest_missing"]
 
@@ -1735,7 +1803,67 @@ def test_hsl_replay_cache_persist_matrices_write_failure_is_nonfatal(
     assert event.pside == "long"
     assert event.symbol == symbol
     assert event.data["cache_status"] == "write_failed"
-    assert event.data["reasons"] == ["write_exception:ValueError"]
+    assert event.data["reasons"] == ["write_exception:RuntimeError"]
+    assert secret not in str(event.data)
+    assert unsafe_type.__name__ not in str(event.data)
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_hsl_replay_cache_account_write_failure_is_nonfatal_and_redacted(
+    tmp_path, monkeypatch, caplog
+):
+    import logging as logging_module
+
+    from live.event_bus import EventTypes, ReasonCodes
+
+    bot, sink = _make_persist_bot(tmp_path, monkeypatch)
+    secret = "api_secret=hsl-account-cache-write-secret"
+    unsafe_type = type("ApiKeyHslAccountCacheWriteSecret", (RuntimeError,), {})
+    original_write = hsl._write_hsl_replay_matrix_cache
+
+    def fail_account_write(*args, **kwargs):
+        if kwargs.get("series_kind") == "account_pnl":
+            raise unsafe_type(secret)
+        return original_write(*args, **kwargs)
+
+    monkeypatch.setattr(hsl, "_write_hsl_replay_matrix_cache", fail_account_write)
+    symbol = "BTC/USDT:USDT"
+    history = {
+        "hsl_replay_matrices": {"long": {symbol: _hsl_cache_rows()}},
+        "hsl_replay_account_series": _hsl_account_series_rows(),
+        "hsl_replay_matrix_coverage": {
+            "fill_covered_start_ms": 60_000,
+            "fill_covered_end_ms": 200_000,
+            "fill_history_scope": "window",
+            "fill_coverage_proven": True,
+            "candle_covered_start_ms": 60_000,
+            "candle_covered_end_ms": 180_000,
+        },
+    }
+
+    with caplog.at_level(logging_module.WARNING):
+        written = hsl._equity_hard_stop_persist_replay_matrices(bot, history)
+
+    assert written == 1
+    assert caplog.records[-1].getMessage() == (
+        "[risk] HSL account series replay cache write failed | rows=3 error_type=RuntimeError"
+    )
+    assert secret not in caplog.text
+    assert unsafe_type.__name__ not in caplog.text
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    failed_events = [
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.HSL_REPLAY_CACHE
+        and event.reason_code == ReasonCodes.HSL_REPLAY_CACHE_WRITE_FAILED
+    ]
+    assert len(failed_events) == 1
+    event = failed_events[0]
+    assert event.pside == hsl._HSL_REPLAY_CACHE_ACCOUNT_PSIDE
+    assert event.symbol == hsl._HSL_REPLAY_CACHE_ACCOUNT_SYMBOL
+    assert event.data["reasons"] == ["write_exception:RuntimeError"]
+    assert secret not in str(event.data)
+    assert unsafe_type.__name__ not in str(event.data)
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
@@ -2277,6 +2405,110 @@ async def test_coin_hsl_replay_cancels_when_shutdown_requested_after_history_loa
 
 
 @pytest.mark.asyncio
+async def test_coin_hsl_replay_failure_redacts_state_and_event_but_preserves_exception():
+    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
+
+    bot = make_coin_bot()
+    secret = "api_secret=hsl-coin-replay-before-ready-secret"
+    unsafe_type = type("ApiKeyHslCoinReplayBeforeReadySecret", (RuntimeError,), {})
+    sink = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot._emit_live_event = MethodType(Passivbot._emit_live_event, bot)
+
+    async def cache_miss(_now_ms):
+        return None
+
+    async def fail_history(*_args, **_kwargs):
+        raise unsafe_type(secret)
+
+    bot._equity_hard_stop_try_reuse_replay_cache = cache_miss
+    bot.get_balance_equity_history = fail_history
+
+    with pytest.raises(unsafe_type) as raised:
+        await bot._equity_hard_stop_start_coin_history_replay()
+
+    assert str(raised.value) == secret
+    assert bot._equity_hard_stop_coin_replay_failure == "RuntimeError"
+    assert bot._equity_hard_stop_coin_protective_ready is False
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    failed_events = [
+        event for event in sink.events if event.event_type == EventTypes.HSL_REPLAY_FAILED
+    ]
+    assert len(failed_events) == 1
+    assert failed_events[0].data["error_type"] == "RuntimeError"
+    assert secret not in str(failed_events[0].data)
+    assert unsafe_type.__name__ not in str(failed_events[0].data)
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+async def test_coin_hsl_cache_reuse_and_persistence_failures_are_redacted_and_nonfatal(
+    monkeypatch, caplog
+):
+    bot = make_coin_bot()
+    symbol = "A"
+    secret_reuse = "api_secret=hsl-coin-cache-reuse-secret"
+    secret_persist = "api_secret=hsl-coin-cache-persist-secret"
+    unsafe_reuse_type = type("ApiKeyHslCoinCacheReuseSecret", (RuntimeError,), {})
+    unsafe_persist_type = type("ApiKeyHslCoinCachePersistSecret", (RuntimeError,), {})
+    history_calls = []
+    bot.positions = {
+        symbol: {
+            "long": {"size": 1.0, "price": 100.0},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+    }
+
+    async def fail_reuse(_now_ms):
+        raise unsafe_reuse_type(secret_reuse)
+
+    async def full_history(*_args, **_kwargs):
+        history_calls.append(True)
+        return {
+            "timeline": [
+                {
+                    "timestamp": 60_000,
+                    "balance": 100.0,
+                    "realized_pnl": 0.0,
+                    "realized_pnl_by_coin_pside": {
+                        symbol: {"long": 0.0, "short": 0.0}
+                    },
+                    "unrealized_pnl_by_coin_pside": {
+                        symbol: {"long": -1.0, "short": 0.0}
+                    },
+                }
+            ],
+            "panic_flatten_events": [],
+            "fill_events": [],
+        }
+
+    def fail_persist(_history):
+        raise unsafe_persist_type(secret_persist)
+
+    monkeypatch.setattr(bot, "_equity_hard_stop_try_reuse_replay_cache", fail_reuse)
+    monkeypatch.setattr(bot, "get_balance_equity_history", full_history, raising=False)
+    monkeypatch.setattr(bot, "_equity_hard_stop_persist_replay_matrices", fail_persist)
+
+    with caplog.at_level(logging.WARNING):
+        await bot._equity_hard_stop_initialize_coin_from_history()
+
+    assert history_calls == [True]
+    assert bot._equity_hard_stop_coin_initialized is True
+    messages = [record.getMessage() for record in caplog.records if "HSL replay cache" in record.getMessage()]
+    assert messages == [
+        "[risk] HSL replay cache reuse failed; falling back to full replay | error_type=RuntimeError",
+        "[risk] HSL replay cache persistence failed | error_type=RuntimeError",
+    ]
+    assert secret_reuse not in caplog.text
+    assert secret_persist not in caplog.text
+    assert unsafe_reuse_type.__name__ not in caplog.text
+    assert unsafe_persist_type.__name__ not in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_coin_hsl_history_replay_emits_lifecycle_events():
     from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline, ReasonCodes
 
@@ -2777,6 +3009,8 @@ async def test_coin_hsl_partial_replay_restarts_if_pending_pair_becomes_held():
 
 @pytest.mark.asyncio
 async def test_coin_hsl_background_failure_keeps_pending_pair_blocked_without_retry():
+    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
+
     bot = make_coin_bot()
     bot.positions = {
         "Z": {
@@ -2806,9 +3040,18 @@ async def test_coin_hsl_background_failure_keeps_pending_pair_blocked_without_re
             "fill_events": [],
         }
 
+    secret = "api_secret=hsl-coin-replay-failure-secret"
+    unsafe_type = type("ApiKeyHslCoinReplayFailureSecret", (RuntimeError,), {})
+    sink = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot._emit_live_event = MethodType(Passivbot._emit_live_event, bot)
+
     async def failing_upnl(pside=None, symbol=None):
         if symbol == "A":
-            raise RuntimeError("flat replay failed")
+            raise unsafe_type(secret)
         return 0.0
 
     bot.get_balance_equity_history = fake_history
@@ -2821,13 +3064,22 @@ async def test_coin_hsl_background_failure_keeps_pending_pair_blocked_without_re
     assert getattr(bot, "_equity_hard_stop_coin_initialized", False) is False
     assert bot._equity_hard_stop_coin_replay_ready_pairs == {("long", "Z")}
     assert bot._equity_hard_stop_coin_replay_pending_pairs == {("long", "A")}
-    assert "flat replay failed" in bot._equity_hard_stop_coin_replay_failure
+    assert bot._equity_hard_stop_coin_replay_failure == "RuntimeError"
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    failed_events = [
+        event for event in sink.events if event.event_type == EventTypes.HSL_REPLAY_FAILED
+    ]
+    assert len(failed_events) == 1
+    assert failed_events[0].data["error_type"] == "RuntimeError"
+    assert secret not in str(failed_events[0].data)
+    assert unsafe_type.__name__ not in str(failed_events[0].data)
     await bot._equity_hard_stop_start_coin_history_replay()
     assert bot._equity_hard_stop_coin_replay_task is replay_task
 
     metrics = await bot._equity_hard_stop_check_coin()
     assert "long:Z" in metrics
     assert "long:A" not in metrics
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -4463,8 +4463,11 @@ async def test_hard_stop_initialize_from_history_survives_cache_persist_failure(
     async def fake_history(*, current_balance=None, **kwargs):
         return _minimal_pside_history()
 
+    secret = "api_secret=hsl-pside-cache-persist-secret"
+    unsafe_type = type("ApiKeyHslPsideCachePersistSecret", (RuntimeError,), {})
+
     def failing_persist(history):
-        raise RuntimeError("synthetic cache write failure")
+        raise unsafe_type(secret)
 
     monkeypatch.setattr(bot, "get_balance_equity_history", fake_history)
     monkeypatch.setattr(
@@ -4476,7 +4479,45 @@ async def test_hard_stop_initialize_from_history_survives_cache_persist_failure(
     with caplog.at_level(logging_module.WARNING):
         await bot._equity_hard_stop_initialize_from_history()
 
-    assert "HSL replay cache persistence failed" in caplog.text
+    assert caplog.records[-1].getMessage() == (
+        "[risk] HSL replay cache persistence failed | error_type=RuntimeError"
+    )
+    assert secret not in caplog.text
+    assert unsafe_type.__name__ not in caplog.text
+    assert _hsl_state(bot)["halted"] is False
+
+
+@pytest.mark.asyncio
+async def test_hard_stop_initialize_from_history_redacts_cache_reuse_failure(monkeypatch, caplog):
+    cfg = _dummy_config()
+    cfg["live"]["hsl_signal_mode"] = "unified"
+    bot = _make_dummy_bot(cfg)
+    _hsl_cfg(bot)["enabled"] = True
+    bot.balance = 100.0
+    secret = "api_secret=hsl-pside-cache-reuse-secret"
+    unsafe_type = type("ApiKeyHslPsideCacheReuseSecret", (RuntimeError,), {})
+    history_calls = []
+
+    async def failing_reuse(_now_ms):
+        raise unsafe_type(secret)
+
+    async def full_history(*, current_balance=None, **kwargs):
+        history_calls.append((current_balance, kwargs))
+        return _minimal_pside_history()
+
+    monkeypatch.setattr(bot, "_equity_hard_stop_try_reuse_pside_replay_cache", failing_reuse)
+    monkeypatch.setattr(bot, "get_balance_equity_history", full_history)
+    monkeypatch.setattr(bot, "_equity_hard_stop_persist_replay_matrices", lambda _h: 0)
+
+    with caplog.at_level(logging.WARNING):
+        await bot._equity_hard_stop_initialize_from_history()
+
+    assert len(history_calls) == 1
+    assert caplog.records[-1].getMessage() == (
+        "[risk] HSL pside replay cache reuse failed; falling back to full replay | error_type=RuntimeError"
+    )
+    assert secret not in caplog.text
+    assert unsafe_type.__name__ not in caplog.text
     assert _hsl_state(bot)["halted"] is False
 
 


### PR DESCRIPTION
@codex

## Scope
Category: observability producer.

- retain bounded exception types for HSL replay cache validation, loading, writes, reuse fallbacks, and completed-replay persistence
- keep coin replay failure state and events free of exception messages, tracebacks, and unsafe class names
- preserve authoritative replay fallback, nonfatal cache failures, original pre-readiness exception propagation, held-position protection, and flat-pair entry blocking

Explicit non-goals: hourly candle maintenance, RED-supervisor execution diagnostics, strategy behavior, replay ordering, readiness policy, and cache authority.

Expected behavior impact: diagnostic redaction only. No operational action is required.

## Validation
- full Python test suite
- 295 focused HSL and unstuck tests
- current Rust extension source verification
- 221 Rust tests
- cargo check --tests
- cargo fmt --check
- AI documentation and generated live-event registry checks

## Reviewer focus
- bounded cache event reason classifications
- cache fallback and persistence isolation
- pre- and post-protective-readiness failure behavior