### PR TITLE
Redact hourly maintenance diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Hourly candle disk-audit, maintenance-cycle, and exchange-config event-emitter fallback
+  diagnostics now retain only bounded exception types. Audit continuation, maintenance retry,
+  market refresh, and exchange-config result behavior are unchanged.
+
 - HSL replay cache and replay-lifecycle diagnostics now retain bounded exception types without
   exception messages, tracebacks, or unsafe exception class names. Cache write failures remain
   nonfatal, cache reuse still falls back to authoritative replay, and HSL readiness and protection

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -22,6 +22,8 @@
    inception metadata, and deferred index writes retain bounded exception type instead of exception
    text, repr, or exception-value traceback. Redaction must not alter cache contents, migration and
    cleanup behavior, lock handling, retries, fallbacks, or exception propagation.
+   The periodic disk-coverage audit stamps its check timestamp before auditing; an audit failure is
+   type-only and does not prevent the regular market refresh or normal cycle sleep.
 8. Direct live lifecycle diagnostics for completed-close fallback, startup/index/background
    warmup, forager refresh, active refresh, and refresh-cap handling retain bounded exception type
    instead of exception text or exception-value traceback. Redaction must not alter warmup,

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -330,7 +330,8 @@ digit-only `response_code`, `error_type`, and the envelope's `symbol`. They excl
 text, request parameters, URLs, and tracebacks. An explicit unchanged outcome is DEBUG; confirmed
 success remains INFO until the connector can prove whether it changed state; failures retain their
 existing operator-visible warning or error. The event route remains structured/monitor-only, and
-event emission failure must not change exchange configuration control flow or results.
+event emission failure must log only a bounded exception type, preserve exchange configuration
+control flow and results, and never replace an original configuration exception.
 
 ## WebSocket Reconnect Diagnostics
 

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -19007,9 +19007,8 @@ class Passivbot:
                         await self.audit_required_candle_disk_coverage()
                     except Exception as exc:
                         logging.error(
-                            "error running candle disk coverage audit: %s",
-                            exc,
-                            exc_info=True,
+                            "[candle] disk coverage audit failed | action=continue error_type=%s",
+                            bounded_exception_type(exc),
                         )
                 # update markets dict once every hour, with per-instance jitter
                 hourly_interval_ms = 1000 * 60 * 60 + int(jitter_s * 1000)
@@ -19030,7 +19029,11 @@ class Passivbot:
                         await asyncio.sleep(10)
                 await asyncio.sleep(1)
             except Exception as e:
-                logging.error("error with %s %s", get_function_name(), e, exc_info=True)
+                logging.error(
+                    "[hourly] maintenance cycle failed | "
+                    "action=check_error_budget_then_retry error_type=%s",
+                    bounded_exception_type(e),
+                )
                 await self.restart_bot_on_too_many_errors()
                 await asyncio.sleep(5)
 
@@ -19039,8 +19042,9 @@ class Passivbot:
             self._emit_exchange_config_refresh_event(**kwargs)
         except Exception as exc:
             logging.debug(
-                "[event] failed to emit maintenance exchange config-refresh event: %s",
-                exc,
+                "[event] failed to emit maintenance exchange config-refresh event | "
+                "action=preserve_result error_type=%s",
+                bounded_exception_type(exc),
             )
 
     async def _refresh_markets_for_maintenance(self):

--- a/tests/test_exchange_config_refresh_event.py
+++ b/tests/test_exchange_config_refresh_event.py
@@ -34,7 +34,7 @@ def _make_bot_with_event_sink():
 
 
 def _raise_emit_failure(**_kwargs):
-    raise RuntimeError("emit failed")
+    raise RuntimeError("token=event-secret\ntraceback-value")
 
 
 @pytest.mark.asyncio
@@ -86,27 +86,48 @@ async def test_maintenance_exchange_config_refresh_failure_is_sanitized_and_rera
 
 
 @pytest.mark.asyncio
-async def test_maintenance_exchange_config_emit_failure_preserves_success():
+async def test_maintenance_exchange_config_emit_failure_is_redacted_and_preserves_success(caplog):
     bot, _sink = _make_bot_with_event_sink()
     bot.init_markets = AsyncMock(return_value="ok")
     bot._emit_exchange_config_refresh_event = _raise_emit_failure
 
-    assert await bot._refresh_markets_for_maintenance() == "ok"
+    with caplog.at_level("DEBUG"):
+        assert await bot._refresh_markets_for_maintenance() == "ok"
+
     bot.init_markets.assert_awaited_once_with(verbose=False)
+    assert (
+        "[event] failed to emit maintenance exchange config-refresh event | "
+        "action=preserve_result error_type=RuntimeError"
+        in caplog.text
+    )
+    assert "event-secret" not in caplog.text
+    assert "traceback-value" not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
 
 
 @pytest.mark.asyncio
-async def test_maintenance_exchange_config_emit_failure_preserves_original_error():
+async def test_maintenance_exchange_config_emit_failure_is_redacted_and_preserves_original_error(
+    caplog,
+):
     bot, _sink = _make_bot_with_event_sink()
     exc = RuntimeError("exchange failed")
     bot.init_markets = AsyncMock(side_effect=exc)
     bot._emit_exchange_config_refresh_event = _raise_emit_failure
 
-    with pytest.raises(RuntimeError) as raised:
-        await bot._refresh_markets_for_maintenance()
+    with caplog.at_level("DEBUG"):
+        with pytest.raises(RuntimeError) as raised:
+            await bot._refresh_markets_for_maintenance()
 
     assert raised.value is exc
     bot.init_markets.assert_awaited_once_with(verbose=False)
+    assert (
+        "[event] failed to emit maintenance exchange config-refresh event | "
+        "action=preserve_result error_type=RuntimeError"
+        in caplog.text
+    )
+    assert "event-secret" not in caplog.text
+    assert "traceback-value" not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
 
 
 def test_exchange_config_outcome_metadata_is_bounded_and_value_safe():

--- a/tests/test_maintainer_logging.py
+++ b/tests/test_maintainer_logging.py
@@ -1,5 +1,6 @@
 import logging
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -123,3 +124,83 @@ async def test_hourly_maintenance_jitter_is_debug_only(caplog, monkeypatch):
 
     assert "[hourly] starting maintenance cycle (jitter=42.0s)" in caplog.text
     assert not [record for record in caplog.records if record.levelno == logging.INFO]
+
+
+@pytest.mark.asyncio
+async def test_hourly_candle_audit_failure_is_redacted_and_continues(caplog, monkeypatch):
+    now_ms = 4_000_000
+    sleeps = []
+    bot = SimpleNamespace(
+        stop_signal_received=False,
+        _mem_log_prev={"timestamp": now_ms},
+        memory_snapshot_interval_ms=3_600_000,
+        candle_disk_check_interval_ms=1,
+        candle_disk_check_boot_delay_ms=0,
+        _candle_disk_check_last_ms=0,
+        start_time_ms=0,
+        init_markets_last_update_ms=0,
+        audit_required_candle_disk_coverage=AsyncMock(
+            side_effect=RuntimeError("apiKey=audit-secret\ntraceback-value")
+        ),
+        _refresh_markets_for_maintenance=AsyncMock(),
+        restart_bot_on_too_many_errors=AsyncMock(),
+    )
+
+    async def sleep(seconds):
+        sleeps.append(seconds)
+        bot.stop_signal_received = True
+
+    monkeypatch.setattr("passivbot.utc_ms", lambda: now_ms)
+    monkeypatch.setattr("passivbot.random.uniform", lambda _start, _end: 0.0)
+    monkeypatch.setattr("passivbot.asyncio.sleep", sleep)
+
+    with caplog.at_level(logging.DEBUG):
+        await Passivbot.maintain_hourly_cycle(bot)
+
+    assert bot._candle_disk_check_last_ms == now_ms
+    bot.audit_required_candle_disk_coverage.assert_awaited_once_with()
+    bot._refresh_markets_for_maintenance.assert_awaited_once_with()
+    bot.restart_bot_on_too_many_errors.assert_not_awaited()
+    assert sleeps == [1]
+    assert (
+        "[candle] disk coverage audit failed | action=continue error_type=RuntimeError"
+        in caplog.text
+    )
+    assert "audit-secret" not in caplog.text
+    assert "traceback-value" not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_hourly_cycle_failure_is_redacted_and_retries_after_five_seconds(caplog, monkeypatch):
+    sleeps = []
+    bot = SimpleNamespace(
+        stop_signal_received=False,
+        _mem_log_prev=None,
+        _log_memory_snapshot=lambda now_ms: (_ for _ in ()).throw(
+            RuntimeError("authorization=cycle-secret\ntraceback-value")
+        ),
+        restart_bot_on_too_many_errors=AsyncMock(),
+    )
+
+    async def sleep(seconds):
+        sleeps.append(seconds)
+        bot.stop_signal_received = True
+
+    monkeypatch.setattr("passivbot.utc_ms", lambda: 1_000)
+    monkeypatch.setattr("passivbot.random.uniform", lambda _start, _end: 0.0)
+    monkeypatch.setattr("passivbot.asyncio.sleep", sleep)
+
+    with caplog.at_level(logging.DEBUG):
+        await Passivbot.maintain_hourly_cycle(bot)
+
+    bot.restart_bot_on_too_many_errors.assert_awaited_once_with()
+    assert sleeps == [5]
+    assert (
+        "[hourly] maintenance cycle failed | "
+        "action=check_error_budget_then_retry error_type=RuntimeError"
+        in caplog.text
+    )
+    assert "cycle-secret" not in caplog.text
+    assert "traceback-value" not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)


### PR DESCRIPTION
@codex

## Scope
Category: observability producer.

- replace hourly candle disk-audit and outer maintenance exception values/tracebacks with bounded exception types and stable action classifications
- redact maintenance exchange-config event-emitter fallback diagnostics
- preserve audit timestamping and continuation, market refresh, normal cycle sleep, error-budget checks, retry delay, successful results, and original maintenance exceptions

Explicit non-goals: candle coverage algorithms, market refresh semantics, rate-limit behavior, scheduler cadence, other maintenance families, and trading behavior.

Expected behavior impact: diagnostic redaction only. No operational action is required.

## Validation
- full Python test suite
- 12 focused maintainer and exchange-config event tests
- current Rust extension source verification
- 221 Rust tests
- cargo check --tests
- cargo fmt --check
- AI documentation and generated live-event registry checks

## Reviewer focus
- audit continuation versus outer-cycle retry behavior
- event-emitter failure isolation
- absence of exception values and tracebacks