### PR TITLE
Redact market snapshot provider diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
-- Market-snapshot provider, fallback, pre-create gate, event-emitter, and eligibility-trace
-  diagnostics now retain only bounded exception types and stable actions. Snapshot fallback order,
-  fail-closed order filtering, block attribution, trace isolation, and exception cause chaining are
-  unchanged.
+- Market-snapshot provider primary-fetch, missing-symbol retry, cache-sink, fallback, pre-create
+  gate, event-emitter, and eligibility-trace diagnostics now retain only bounded exception types and
+  stable actions. Snapshot fallback order, fail-closed order filtering, block attribution, cache-sink
+  suppression, trace isolation, and exception cause chaining are unchanged.
 
 - Hourly candle disk-audit, maintenance-cycle, and exchange-config event-emitter fallback
   diagnostics now retain only bounded exception types. Audit continuation, maintenance retry,

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -81,12 +81,12 @@ only when the event emitter or structured console owner is unavailable. Event or
 not alter position/balance refresh, state mutation, scheduling, retries, planning, orders, risk, or
 the caller's existing decision to continue after this noncritical diagnostic failure.
 
-Adjacent market-snapshot provider, fallback, pre-create gate, event-emitter, and eligibility-trace
-diagnostics retain only bounded exception types and stable code-owned actions. They never retain
-exception messages, unsafe exception class names, tracebacks, request details, credentials, or
-arbitrary payload fragments. Redaction must not change provider fallback order, optional completed
-candle fallback, fail-closed create filtering, entry-block attribution, trace isolation, or
-exception cause chaining.
+Adjacent market-snapshot provider primary-fetch, missing-symbol retry, cache-sink, fallback,
+pre-create gate, event-emitter, and eligibility-trace diagnostics retain only bounded exception types
+and stable code-owned actions. They never retain exception messages, unsafe exception class names,
+tracebacks, request details, credentials, or arbitrary payload fragments. Redaction must not change
+provider fallback order, optional completed candle fallback, fail-closed create filtering,
+entry-block attribution, cache-sink suppression, trace isolation, or exception cause chaining.
 
 ## EMA Diagnostic Redaction
 

--- a/src/live/market_snapshot.py
+++ b/src/live/market_snapshot.py
@@ -6,6 +6,7 @@ import math
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Iterable, Optional
 
+from live.diagnostic_safety import bounded_exception_type
 from utils import utc_ms
 
 
@@ -95,11 +96,11 @@ class MarketSnapshotProvider:
             fetched, source = await self._fetch_tickers_for_missing(missing)
         except Exception as exc:
             self._log.warning(
-                "[market] ticker snapshot fetch failed | exchange=%s symbols=%s error_type=%s error=%s",
+                "[market] ticker snapshot fetch failed | exchange=%s symbols=%s "
+                "error_type=%s action=propagate",
                 self.exchange_name,
                 len(missing),
-                type(exc).__name__,
-                exc,
+                bounded_exception_type(exc),
             )
             raise RuntimeError(
                 f"[market] ticker snapshot fetch failed for {self.exchange_name}; "
@@ -131,10 +132,10 @@ class MarketSnapshotProvider:
                     self._cache_sink(symbol, float(snap.last), int(snap.fetched_ms))
                 except Exception as exc:
                     self._log.debug(
-                        "[market] snapshot cache sink failed | symbol=%s error_type=%s error=%s",
+                        "[market] snapshot cache sink failed | symbol=%s "
+                        "error_type=%s action=preserve_snapshot",
                         symbol,
-                        type(exc).__name__,
-                        exc,
+                        bounded_exception_type(exc),
                     )
 
         for symbol in missing:
@@ -155,11 +156,11 @@ class MarketSnapshotProvider:
                 )
             except Exception as exc:
                 self._log.warning(
-                    "[market] ticker missing-symbol retry failed | exchange=%s symbols=%s error_type=%s error=%s",
+                    "[market] ticker missing-symbol retry failed | exchange=%s symbols=%s "
+                    "error_type=%s action=propagate",
                     self.exchange_name,
                     len(missing_after),
-                    type(exc).__name__,
-                    exc,
+                    bounded_exception_type(exc),
                 )
                 raise RuntimeError(
                     f"[market] ticker missing-symbol retry failed for {self.exchange_name}; "
@@ -196,10 +197,10 @@ class MarketSnapshotProvider:
                         self._cache_sink(symbol, float(snap.last), int(snap.fetched_ms))
                     except Exception as exc:
                         self._log.debug(
-                            "[market] snapshot cache sink failed | symbol=%s error_type=%s error=%s",
+                            "[market] snapshot cache sink failed | symbol=%s "
+                            "error_type=%s action=preserve_snapshot",
                             symbol,
-                            type(exc).__name__,
-                            exc,
+                            bounded_exception_type(exc),
                         )
             for symbol in missing_after:
                 snap = self.get_cached(symbol, now_ms=retry_ms, max_age_ms=max_age_ms)

--- a/tests/test_market_snapshot.py
+++ b/tests/test_market_snapshot.py
@@ -1,8 +1,14 @@
 import asyncio
+import logging
 
 import pytest
 
 from market_snapshot import MarketSnapshotProvider
+
+
+def _unsafe_snapshot_exception(secret: str) -> RuntimeError:
+    unsafe_type = type("SnapshotCredentialFailure", (RuntimeError,), {})
+    return unsafe_type(secret)
 
 
 @pytest.mark.asyncio
@@ -183,6 +189,106 @@ async def test_market_snapshot_provider_raises_on_fetch_failure_for_missing_symb
     assert first["BTC/USDT:USDT"].last == 100.0
     with pytest.raises(RuntimeError, match="ticker snapshot fetch failed"):
         await provider.get_snapshots(["BTC/USDT:USDT", "ETH/USDT:USDT"], max_age_ms=60_000)
+
+
+@pytest.mark.asyncio
+async def test_market_snapshot_provider_redacts_primary_fetch_failure_and_preserves_cause(caplog):
+    secret = "api_key=provider-secret https://example.invalid/request"
+    original = _unsafe_snapshot_exception(secret)
+
+    async def fetch_tickers():
+        raise original
+
+    provider = MarketSnapshotProvider(exchange_name="bybit", fetch_tickers=fetch_tickers)
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(RuntimeError, match="ticker snapshot fetch failed") as raised:
+            await provider.get_snapshots(["BTC/USDT:USDT"], max_age_ms=60_000)
+
+    assert raised.value.__cause__ is original
+    assert "error_type=RuntimeError" in caplog.text
+    assert "action=propagate" in caplog.text
+    assert secret not in caplog.text
+    assert type(original).__name__ not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_market_snapshot_provider_redacts_missing_symbol_retry_failure_and_preserves_cause(
+    caplog,
+):
+    secret = "token=retry-secret https://example.invalid/retry"
+    original = _unsafe_snapshot_exception(secret)
+    calls = {"symbols": []}
+
+    async def fetch_tickers():
+        return {"BTC/USDT:USDT": {"bid": 99.0, "ask": 101.0, "last": 100.0}}
+
+    async def fetch_tickers_for_symbols(symbols):
+        calls["symbols"].append(list(symbols))
+        raise original
+
+    provider = MarketSnapshotProvider(
+        exchange_name="bybit",
+        fetch_tickers=fetch_tickers,
+        fetch_tickers_for_symbols=fetch_tickers_for_symbols,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(RuntimeError, match="ticker missing-symbol retry failed") as raised:
+            await provider.get_snapshots(
+                ["BTC/USDT:USDT", "ETH/USDT:USDT"], max_age_ms=60_000
+            )
+
+    assert calls["symbols"] == [["ETH/USDT:USDT"]]
+    assert raised.value.__cause__ is original
+    assert "error_type=RuntimeError" in caplog.text
+    assert "action=propagate" in caplog.text
+    assert secret not in caplog.text
+    assert type(original).__name__ not in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_retry", [False, True], ids=["initial", "retry"])
+async def test_market_snapshot_provider_cache_sink_failure_is_redacted_and_nonblocking(
+    use_retry, caplog
+):
+    secret = "password=cache-secret https://example.invalid/cache"
+    original = _unsafe_snapshot_exception(secret)
+    sink_calls = []
+
+    async def fetch_tickers():
+        return (
+            {"BTC/USDT:USDT": {"bid": 99.0, "ask": 101.0, "last": 100.0}}
+            if use_retry
+            else {"ETH/USDT:USDT": {"bid": 199.0, "ask": 201.0, "last": 200.0}}
+        )
+
+    async def fetch_tickers_for_symbols(symbols):
+        assert use_retry
+        assert symbols == ["ETH/USDT:USDT"]
+        return {"ETH/USDT:USDT": {"bid": 199.0, "ask": 201.0, "last": 200.0}}
+
+    def cache_sink(symbol, price, timestamp):
+        sink_calls.append((symbol, price, timestamp))
+        raise original
+
+    provider = MarketSnapshotProvider(
+        exchange_name="bybit",
+        fetch_tickers=fetch_tickers,
+        fetch_tickers_for_symbols=fetch_tickers_for_symbols if use_retry else None,
+        cache_sink=cache_sink,
+    )
+    symbols = ["BTC/USDT:USDT", "ETH/USDT:USDT"] if use_retry else ["ETH/USDT:USDT"]
+
+    with caplog.at_level(logging.DEBUG):
+        out = await provider.get_snapshots(symbols, max_age_ms=60_000)
+
+    assert set(out) == set(symbols)
+    assert [call[0] for call in sink_calls] == symbols
+    assert "error_type=RuntimeError" in caplog.text
+    assert "action=preserve_snapshot" in caplog.text
+    assert secret not in caplog.text
+    assert type(original).__name__ not in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
@codex

## Category
Observability producer

## Summary
- redact primary-fetch and missing-symbol retry diagnostics in the shared market-snapshot provider
- isolate cache-sink failures with bounded exception types and stable actions
- add hostile-exception regressions for both required-fetch and optional cache paths

## Behavior
Required fetch failures still propagate through the same sanitized RuntimeError with the original exception as its cause. Cache-sink failures remain non-blocking and preserve the successfully fetched snapshot. Fetch strategy, retry order, cancellation behavior, cache contents, and trading decisions are unchanged. No operational action is required.

## Validation
- 28 focused provider and diagnostic-safety tests
- full Python test suite
- 221 Rust tests
- Rust test check and formatting check
- current Rust extension source verification
- AI documentation and generated event-registry checks
- Python compile check
- diff and publication privacy scans