### PR TITLE
Redact state refresh observer diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- State-refresh position-change and progress-observer fallback diagnostics now retain only bounded
+  exception types and stable actions. Balance handling, cancellation propagation, staged refresh
+  cleanup, timing, fallback values, and event schemas are unchanged.
+
 - Market-snapshot provider primary-fetch, missing-symbol retry, cache-sink, fallback, pre-create
   gate, event-emitter, and eligibility-trace diagnostics now retain only bounded exception types and
   stable actions. Snapshot fallback order, fail-closed order filtering, block attribution, cache-sink

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -88,6 +88,13 @@ tracebacks, request details, credentials, or arbitrary payload fragments. Redact
 provider fallback order, optional completed candle fallback, fail-closed create filtering,
 entry-block attribution, cache-sink suppression, trace isolation, or exception cause chaining.
 
+Observer-only staged refresh diagnostics follow the same rule. A position-change observer failure
+that is not owned by the market-snapshot diagnostic path records only a bounded exception type and
+the `continue_balance_update` action before balance handling proceeds. A non-cancellation progress
+logger failure records only a bounded type and `stop_progress_logger`; explicit cancellation still
+propagates. These diagnostics do not change staged fetch propagation, cleanup, timing, fallback
+values, or event schemas.
+
 ## EMA Diagnostic Redaction
 
 `ema.unavailable` and `ema.fallback_used` retain only code-owned reason classifications, bounded

--- a/src/live/state_refresh.py
+++ b/src/live/state_refresh.py
@@ -154,7 +154,11 @@ async def refresh_authoritative_state_staged(bot) -> bool:
             if not bot._log_noncritical_market_snapshot_error(
                 "position-change diagnostics", e
             ):
-                logging.error(f"error logging position changes {e}")
+                logging.error(
+                    "[state] position-change diagnostics failed | "
+                    "error_type=%s action=continue_balance_update",
+                    bounded_exception_type(e),
+                )
         await bot.handle_balance_update(source=balance_source)
     bot._finalize_authoritative_refresh_consistency(plan)
     return True
@@ -583,7 +587,11 @@ async def log_staged_refresh_progress_until(
     except asyncio.CancelledError:
         raise
     except Exception as exc:
-        logging.debug("[state] staged refresh progress logger stopped: %s", exc)
+        logging.debug(
+            "[state] staged refresh progress logger stopped | "
+            "error_type=%s action=stop_progress_logger",
+            bounded_exception_type(exc),
+        )
 
 
 async def fetch_authoritative_state_staged_snapshot(bot, plan: set[str]) -> dict:

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -6605,6 +6605,128 @@ async def test_refresh_authoritative_state_staged_applies_fake_snapshots():
 
 
 @pytest.mark.asyncio
+async def test_refresh_authoritative_state_staged_redacts_position_change_observer_failure(
+    caplog,
+):
+    from live import state_refresh
+
+    secret = "token=top-secret https://example.invalid/path"
+    position_change_error = _hostile_runtime_error(secret)
+    handled_sources = []
+    bot = SimpleNamespace(
+        _authoritative_staged_refresh_plan=lambda: {
+            "balance",
+            "positions",
+            "open_orders",
+        },
+        _fetch_authoritative_state_staged_snapshot=AsyncMock(
+            return_value={
+                "balance": 100.0,
+                "positions": [],
+                "open_orders": [],
+            }
+        ),
+        _prepare_balance_snapshot=lambda balance: {"balance": balance},
+        _apply_open_orders_snapshot=AsyncMock(return_value=True),
+        _apply_positions_snapshot=lambda positions: ([], {}),
+        _commit_balance_snapshot=MagicMock(),
+        _record_authoritative_surface=MagicMock(),
+        _positions_signature=lambda positions: (),
+        _update_entry_cooldown_position_delta_guard=MagicMock(),
+        _reconcile_balance_after_staged_refresh=MagicMock(),
+        _staged_balance_update_source=lambda: "REST",
+        get_hysteresis_snapped_balance=lambda: 100.0,
+        get_exchange_time=lambda: 1_700_000_000_000,
+        positions={},
+        _log_noncritical_market_snapshot_error=lambda *_args: False,
+        _finalize_authoritative_refresh_consistency=MagicMock(),
+    )
+
+    async def fail_log_position_changes(*_args):
+        raise position_change_error
+
+    async def record_balance_update(*, source):
+        handled_sources.append(source)
+
+    bot.log_position_changes = fail_log_position_changes
+    bot.handle_balance_update = record_balance_update
+
+    with caplog.at_level(logging.ERROR):
+        assert await state_refresh.refresh_authoritative_state_staged(bot) is True
+
+    assert handled_sources == ["REST"]
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert "error_type=RuntimeError" in messages
+    assert "action=continue_balance_update" in messages
+    assert secret not in messages
+    assert type(position_change_error).__name__ not in messages
+
+
+@pytest.mark.asyncio
+async def test_staged_refresh_progress_logger_redacts_non_cancellation_failure(caplog):
+    from live import state_refresh
+
+    secret = "token=top-secret https://example.invalid/path"
+    progress_error = _hostile_runtime_error(secret)
+
+    class FakeBot:
+        config = {"logging": {"staged_refresh_slow_surface_seconds": 0.01}}
+
+        async def _sleep_unless_shutdown(self, *_args, **_kwargs):
+            raise progress_error
+
+        def _shutdown_requested(self):
+            return False
+
+    pending_task = asyncio.create_task(asyncio.sleep(60.0))
+    try:
+        with caplog.at_level(logging.DEBUG):
+            await state_refresh.log_staged_refresh_progress_until(
+                FakeBot(),
+                {"balance"},
+                {},
+                {"balance": pending_task},
+                0,
+            )
+    finally:
+        pending_task.cancel()
+        await asyncio.gather(pending_task, return_exceptions=True)
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert "error_type=RuntimeError" in messages
+    assert "action=stop_progress_logger" in messages
+    assert secret not in messages
+    assert type(progress_error).__name__ not in messages
+
+
+@pytest.mark.asyncio
+async def test_staged_refresh_progress_logger_propagates_cancellation():
+    from live import state_refresh
+
+    class FakeBot:
+        config = {"logging": {"staged_refresh_slow_surface_seconds": 0.01}}
+
+        async def _sleep_unless_shutdown(self, *_args, **_kwargs):
+            raise asyncio.CancelledError("shutdown")
+
+        def _shutdown_requested(self):
+            return False
+
+    pending_task = asyncio.create_task(asyncio.sleep(60.0))
+    try:
+        with pytest.raises(asyncio.CancelledError, match="shutdown"):
+            await state_refresh.log_staged_refresh_progress_until(
+                FakeBot(),
+                {"balance"},
+                {},
+                {"balance": pending_task},
+                0,
+            )
+    finally:
+        pending_task.cancel()
+        await asyncio.gather(pending_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
 async def test_refresh_authoritative_state_staged_applies_bybit_snapshots():
     bot = Passivbot.__new__(Passivbot)
     bot.config = {"live": {}}


### PR DESCRIPTION
@codex

## Category
Observability producer

## Summary
- redact the fallback diagnostic when position-change observation fails during staged refresh
- redact non-cancellation progress-logger failures with a stable stop action
- add hostile-exception and cancellation regressions

## Behavior
Position-change observer failure still allows balance handling and staged refresh completion. A progress-logger failure still stops only that observer, while explicit cancellation continues to propagate. Required staged fetches, cleanup, timing, fallback values, event schemas, and trading decisions are unchanged. No operational action is required.

## Validation
- focused staged-refresh observer and cancellation tests
- full Python test suite
- 221 Rust tests
- Rust test check and formatting check
- current Rust extension source verification
- AI documentation and generated event-registry checks
- Python compile check
- diff and publication privacy scans