### PR TITLE
Redact refresh observer diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Redact observer-only balance and position refresh diagnostic fallbacks, including their shared
+  market-snapshot structured and legacy projections, while preserving existing refresh
+  continuation behavior.
+
 - State-refresh position-change and progress-observer fallback diagnostics now retain only bounded
   exception types and stable actions. Balance handling, cancellation propagation, staged refresh
   cleanup, timing, fallback values, and event schemas are unchanged.

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -77,7 +77,9 @@ exception text, request details, account values, credentials, URLs, payloads, or
 
 The event is the sole normal console/text warning when the structured console is available. Its
 projection is bounded to the normal 240-character record budget. One bounded stdlib warning remains
-only when the event emitter or structured console owner is unavailable. Event or sink failure must
+only when the event emitter or structured console owner is unavailable. The structured event,
+legacy warning, and emitter-failure DEBUG diagnostic use the same hostile-metadata-safe bounded
+exception type and retain neither the raw class name nor exception text. Event or sink failure must
 not alter position/balance refresh, state mutation, scheduling, retries, planning, orders, risk, or
 the caller's existing decision to continue after this noncritical diagnostic failure.
 
@@ -88,12 +90,15 @@ tracebacks, request details, credentials, or arbitrary payload fragments. Redact
 provider fallback order, optional completed candle fallback, fail-closed create filtering,
 entry-block attribution, cache-sink suppression, trace isolation, or exception cause chaining.
 
-Observer-only staged refresh diagnostics follow the same rule. A position-change observer failure
-that is not owned by the market-snapshot diagnostic path records only a bounded exception type and
-the `continue_balance_update` action before balance handling proceeds. A non-cancellation progress
-logger failure records only a bounded type and `stop_progress_logger`; explicit cancellation still
-propagates. These diagnostics do not change staged fetch propagation, cleanup, timing, fallback
-values, or event schemas.
+Observer-only position and balance diagnostics follow the same rule. A non-market-snapshot balance
+equity observer failure records only a bounded exception type and the
+`preserve_balance_anchors_and_schedule` action. A position-change observer failure records only a
+bounded exception type and a stable continuation action: `return_updated_positions` for a
+standalone positions refresh, `continue_balance_reconciliation` for a combined positions/balance
+refresh, or `continue_balance_update` for staged refresh. A non-cancellation progress logger
+failure records only a bounded type and `stop_progress_logger`; explicit cancellation still
+propagates. These diagnostics do not change refresh propagation, balance anchors, scheduling,
+reconciliation, balance handling, cleanup, timing, fallback values, or event schemas.
 
 ## EMA Diagnostic Redaction
 

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -86,9 +86,6 @@ _CYCLE_DEGRADED_SYMBOL_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:/-]{0,159}")
 _MARKET_SNAPSHOT_DIAGNOSTIC_CONTEXT_RE = re.compile(
     r"[A-Za-z0-9_][A-Za-z0-9_ .:-]{0,95}"
 )
-_MARKET_SNAPSHOT_DIAGNOSTIC_ERROR_TYPE_RE = re.compile(
-    r"[A-Za-z_][A-Za-z0-9_]{0,79}"
-)
 _CYCLE_DEGRADED_READINESS_LIST_KEYS = (
     "missing",
     "changed",
@@ -1829,9 +1826,6 @@ def _emit_market_snapshot_diagnostic_skipped_event_unchecked(
     safe_context = _cycle_degraded_bounded_text(
         context, _MARKET_SNAPSHOT_DIAGNOSTIC_CONTEXT_RE
     ) or "unknown"
-    error_type = type(error).__name__
-    if not _MARKET_SNAPSHOT_DIAGNOSTIC_ERROR_TYPE_RE.fullmatch(error_type):
-        error_type = "unknown"
     emitted = bot._emit_live_event(
         EventTypes.MARKET_SNAPSHOT_DIAGNOSTIC_SKIPPED,
         level="warning",
@@ -1842,7 +1836,7 @@ def _emit_market_snapshot_diagnostic_skipped_event_unchecked(
         reason_code=ReasonCodes.MARKET_SNAPSHOT_DIAGNOSTIC_SKIPPED,
         data={
             "context": safe_context,
-            "error_type": error_type,
+            "error_type": _bounded_exception_type(error),
         },
     )
     return emitted is not None

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -11063,8 +11063,11 @@ class Passivbot:
                 ):
                     pass
                 else:
-                    logging.error(f"error with handle_balance_update {e}")
-                    traceback.print_exc()
+                    logging.error(
+                        "[balance] equity diagnostics failed | "
+                        "error_type=%s action=preserve_balance_anchors_and_schedule",
+                        bounded_exception_type(e),
+                    )
             finally:
                 self._previous_balance_raw = balance_raw
                 self._previous_balance_snapped = balance_snapped
@@ -11099,7 +11102,7 @@ class Passivbot:
             except Exception as event_exc:
                 logging.debug(
                     "[event] failed to emit market snapshot diagnostic skipped event error_type=%s",
-                    type(event_exc).__name__,
+                    bounded_exception_type(event_exc),
                 )
         if not (
             event_emitted
@@ -11109,7 +11112,7 @@ class Passivbot:
                 "%s",
                 format_market_snapshot_diagnostic_console(
                     context=context,
-                    error_type=type(exc).__name__,
+                    error_type=bounded_exception_type(exc),
                     cycle_id=Passivbot._current_live_event_cycle_id(self),
                 ),
             )
@@ -14637,7 +14640,11 @@ class Passivbot:
                 if not self._log_noncritical_market_snapshot_error(
                     "position-change diagnostics", e
                 ):
-                    logging.error(f"error logging position changes {e}")
+                    logging.error(
+                        "[pos] position-change diagnostics failed | "
+                        "error_type=%s action=return_updated_positions",
+                        bounded_exception_type(e),
+                    )
         return True
 
     async def update_balance(self):
@@ -14691,7 +14698,11 @@ class Passivbot:
                 if not self._log_noncritical_market_snapshot_error(
                     "position-change diagnostics", e
                 ):
-                    logging.error(f"error logging position changes {e}")
+                    logging.error(
+                        "[pos] position-change diagnostics failed | "
+                        "error_type=%s action=continue_balance_reconciliation",
+                        bounded_exception_type(e),
+                    )
         if positions_ok:
             self._record_authoritative_surface(
                 "positions", self._positions_signature(fetched_positions_new)

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -163,8 +163,9 @@ def test_noncritical_market_snapshot_error_emits_skipped_event(caplog):
         console_sink=console_sink,
         text_sink=text_sink,
     )
-    exc = RuntimeError(
-        "missing live market snapshots for upnl api_key=secret-token"
+    exc = _hostile_runtime_error(
+        "missing live market snapshots for upnl token=structured-secret "
+        "https://example.invalid/structured"
     )
 
     with caplog.at_level(logging.WARNING):
@@ -186,6 +187,9 @@ def test_noncritical_market_snapshot_error_emits_skipped_event(caplog):
     assert event.data["context"] == "upnl diagnostics"
     assert event.data["error_type"] == "RuntimeError"
     assert "error" not in event.data
+    assert type(exc).__name__ not in str(event.data)
+    assert "structured-secret" not in str(event.data)
+    assert "example.invalid" not in str(event.data)
     assert DEFAULT_ROUTES[EventTypes.MARKET_SNAPSHOT_DIAGNOSTIC_SKIPPED].console is True
     assert DEFAULT_ROUTES[EventTypes.MARKET_SNAPSHOT_DIAGNOSTIC_SKIPPED].text is True
     assert console_sink.events == [event]
@@ -198,8 +202,12 @@ def test_noncritical_market_snapshot_error_emits_skipped_event(caplog):
 def test_noncritical_market_snapshot_error_keeps_bounded_legacy_warning_without_event_owner(
     caplog, emitter_mode
 ):
+    emitter_failure = _hostile_runtime_error(
+        "token=emitter-secret https://example.invalid/emitter"
+    )
+
     def raising_emitter(**_kwargs):
-        raise RuntimeError("event pipeline failure with raw detail")
+        raise emitter_failure
 
     emitters = {
         "missing": None,
@@ -215,7 +223,10 @@ def test_noncritical_market_snapshot_error_keeps_bounded_legacy_warning_without_
         else SimpleNamespace(emit=lambda *_args, **_kwargs: None, console_sink=object())
     )
     bot._emit_market_snapshot_diagnostic_skipped_event = emitters[emitter_mode]
-    exc = RuntimeError("live market snapshots unavailable token=secret-token")
+    exc = _hostile_runtime_error(
+        "live market snapshots unavailable token=legacy-secret "
+        "https://example.invalid/legacy"
+    )
 
     with caplog.at_level(logging.WARNING):
         assert (
@@ -225,11 +236,50 @@ def test_noncritical_market_snapshot_error_keeps_bounded_legacy_warning_without_
     warnings = [record.getMessage() for record in caplog.records]
     assert len(warnings) == 1
     warning = warnings[0]
-    assert "secret-token" not in warning
-    assert "event pipeline failure" not in warning
     assert "error_type=RuntimeError" in warning
     assert "reason=market_snapshot_diagnostic_skipped" in warning
+    assert type(exc).__name__ not in warning
+    assert "legacy-secret" not in warning
+    assert "emitter-secret" not in warning
+    assert "example.invalid" not in warning
     assert len("2026-07-15T23:45:40Z WARNING  [hyperliquid] " + warning) <= 240
+
+
+def test_noncritical_market_snapshot_error_redacts_emitter_failure_debug(caplog):
+    diagnostic_error = _hostile_runtime_error(
+        "live market snapshots unavailable token=diagnostic-secret "
+        "https://example.invalid/diagnostic"
+    )
+    emitter_failure = _hostile_runtime_error(
+        "token=emitter-secret https://example.invalid/emitter-debug"
+    )
+    bot = Passivbot.__new__(Passivbot)
+    bot.live_event_console_enabled = False
+    bot._live_event_pipeline = None
+
+    def fail_emitter(**_kwargs):
+        raise emitter_failure
+
+    bot._emit_market_snapshot_diagnostic_skipped_event = fail_emitter
+
+    with caplog.at_level(logging.DEBUG):
+        assert (
+            bot._log_noncritical_market_snapshot_error(
+                "position-change diagnostics", diagnostic_error
+            )
+            is True
+        )
+
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert (
+        "failed to emit market snapshot diagnostic skipped event error_type=RuntimeError"
+        in messages
+    )
+    assert "reason=market_snapshot_diagnostic_skipped" in messages
+    assert type(diagnostic_error).__name__ not in messages
+    assert "diagnostic-secret" not in messages
+    assert "emitter-secret" not in messages
+    assert "example.invalid" not in messages
 
 
 @pytest.mark.asyncio
@@ -7291,6 +7341,100 @@ async def test_update_positions_only_updates_positions(monkeypatch):
     assert ok is True
     assert bot.fetched_positions[0]["symbol"] == "BTC/USDT:USDT"
     assert bot.positions["BTC/USDT:USDT"]["long"]["size"] == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_handle_balance_update_redacts_equity_observer_failure_and_preserves_anchors(
+    caplog,
+):
+    secret = "token=observer-secret https://example.invalid/equity"
+    observer_error = _hostile_runtime_error(secret)
+    bot = Passivbot.__new__(Passivbot)
+    bot.balance_raw = 120.0
+    bot.balance = 120.0
+    bot._previous_balance_raw = 100.0
+    bot._previous_balance_snapped = 100.0
+    bot.execution_scheduled = False
+    bot._log_noncritical_market_snapshot_error = lambda *_args: False
+
+    async def fail_calc_upnl_sum():
+        raise observer_error
+
+    bot.calc_upnl_sum = fail_calc_upnl_sum
+
+    with caplog.at_level(logging.ERROR):
+        await bot.handle_balance_update(source="REST")
+
+    assert bot._previous_balance_raw == pytest.approx(120.0)
+    assert bot._previous_balance_snapped == pytest.approx(120.0)
+    assert bot.execution_scheduled is True
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert "error_type=RuntimeError" in messages
+    assert "action=preserve_balance_anchors_and_schedule" in messages
+    assert secret not in messages
+    assert type(observer_error).__name__ not in messages
+    assert "Traceback" not in messages
+
+
+@pytest.mark.asyncio
+async def test_update_positions_redacts_observer_failure_and_returns_updated_positions(caplog):
+    secret = "token=observer-secret https://example.invalid/positions"
+    observer_error = _hostile_runtime_error(secret)
+    bot = Passivbot.__new__(Passivbot)
+    bot._fetch_and_apply_positions = AsyncMock(return_value=(True, [], []))
+    bot._log_noncritical_market_snapshot_error = lambda *_args: False
+
+    async def fail_log_position_changes(*_args):
+        raise observer_error
+
+    bot.log_position_changes = fail_log_position_changes
+
+    with caplog.at_level(logging.ERROR):
+        assert await bot.update_positions() is True
+
+    bot._fetch_and_apply_positions.assert_awaited_once()
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert "error_type=RuntimeError" in messages
+    assert "action=return_updated_positions" in messages
+    assert secret not in messages
+    assert type(observer_error).__name__ not in messages
+
+
+@pytest.mark.asyncio
+async def test_combined_refresh_redacts_observer_failure_and_continues_reconciliation(caplog):
+    secret = "token=observer-secret https://example.invalid/combined-refresh"
+    observer_error = _hostile_runtime_error(secret)
+    bot = Passivbot.__new__(Passivbot)
+    bot.update_balance = AsyncMock(return_value=True)
+    bot._fetch_and_apply_positions = AsyncMock(return_value=(True, [], []))
+    bot._log_noncritical_market_snapshot_error = lambda *_args: False
+    bot._record_authoritative_surface = MagicMock()
+    bot._positions_signature = lambda _positions: ()
+    bot._reconcile_balance_after_positions_and_balance_refresh = MagicMock(
+        return_value=False
+    )
+    bot.get_hysteresis_snapped_balance = lambda: 120.0
+    bot.handle_balance_update = AsyncMock()
+
+    async def fail_log_position_changes(*_args):
+        raise observer_error
+
+    bot.log_position_changes = fail_log_position_changes
+
+    with caplog.at_level(logging.ERROR):
+        assert await bot.update_positions_and_balance() == (True, True)
+
+    bot._reconcile_balance_after_positions_and_balance_refresh.assert_called_once()
+    bot.handle_balance_update.assert_awaited_once_with(source="REST")
+    assert [call.args[0] for call in bot._record_authoritative_surface.call_args_list] == [
+        "positions",
+        "balance",
+    ]
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert "error_type=RuntimeError" in messages
+    assert "action=continue_balance_reconciliation" in messages
+    assert secret not in messages
+    assert type(observer_error).__name__ not in messages
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
@codex

## Category
Observability producer

## Summary
- redact balance/equity observer fallback diagnostics
- redact standalone and combined position-refresh observer fallback diagnostics
- bound exception types in the shared market-snapshot structured, legacy, and emitter-failure projections
- add hostile-exception regressions for each continuation and projection contract

## Behavior
The affected observer failures still preserve balance anchors and scheduling, return successfully after applied position updates, and continue combined refresh reconciliation and balance handling. Market-snapshot classification and routing, required refresh propagation, event schemas, and trading decisions are unchanged. No operational action is required.

## Validation
- 9 focused caller/helper regressions
- 2 focused market-snapshot event tests
- full Python suite: 4,601 passed, 121 skipped
- 221 Rust tests
- Rust test check and formatting check
- exact Rust extension source verification
- AI documentation and generated event-registry checks
- Python compile and diff checks
- publication privacy scan