### PR TITLE
Redact foreign-writer cleanup diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Foreign-writer safety shutdown diagnostics now retain only bounded maintainer-cleanup failure
+  types and a stable continuation action. Stop flags, cleanup invocation, and terminal
+  foreign-writer stop behavior are unchanged.
+
 - Redact observer-only balance and position refresh diagnostic fallbacks, including their shared
   market-snapshot structured and legacy projections, while preserving existing refresh
   continuation behavior.

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -100,6 +100,12 @@ failure records only a bounded type and `stop_progress_logger`; explicit cancell
 propagates. These diagnostics do not change refresh propagation, balance anchors, scheduling,
 reconciliation, balance handling, cleanup, timing, fallback values, or event schemas.
 
+Foreign-writer safety shutdown keeps its terminal stop behavior when best-effort data-maintainer
+cleanup fails. The ERROR diagnostic retains only a bounded exception type and the stable
+`continue_foreign_writer_stop` action; it never retains exception text, unsafe exception class
+names, URLs, credentials, or tracebacks. This diagnostic redaction does not alter stop flags,
+maintainer invocation, foreign-writer detection, or the terminal exception.
+
 ## EMA Diagnostic Redaction
 
 `ema.unavailable` and `ema.fallback_used` retain only code-owned reason classifications, bounded

--- a/src/live/reconciler.py
+++ b/src/live/reconciler.py
@@ -8,6 +8,7 @@ import time
 from collections import Counter
 from typing import Iterable, Optional
 
+from live.diagnostic_safety import bounded_exception_type
 from live.fresh_entry_eligibility import FreshEntryEligibilityTrace
 from live.freshness import ACCOUNT_SURFACES
 from live.order_churn_gate import (
@@ -729,7 +730,11 @@ async def stop_for_foreign_passivbot_orders(
         try:
             bot.stop_data_maintainers(verbose=False)
         except Exception as exc:
-            logging.error("[safety] failed to stop data maintainers: %s", exc)
+            logging.error(
+                "[safety] failed to stop data maintainers | error_type=%s "
+                "action=continue_foreign_writer_stop",
+                bounded_exception_type(exc),
+            )
     raise Exception("foreign Passivbot writer detected; stopping bot")
 
 

--- a/tests/test_foreign_passivbot_detection.py
+++ b/tests/test_foreign_passivbot_detection.py
@@ -1081,3 +1081,42 @@ async def test_detect_foreign_passivbot_orders_stops_after_unique_threshold():
 
     assert len(bot.foreign_passivbot_seen) == pb_mod.FOREIGN_PASSIVBOT_MAX_UNIQUE_PER_WINDOW
     assert bot.stop_signal_received is True
+
+
+@pytest.mark.asyncio
+async def test_foreign_writer_stop_redacts_maintainer_failure_and_still_propagates(caplog):
+    import passivbot as pb_mod
+
+    bot = _make_detection_bot(now_ts=2_000_000, start_ts=1_000_000)
+    calls = []
+    hostile_error = type("CredentialLeakError", (Exception,), {})
+
+    def fail_maintainer_stop(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise hostile_error("token=foreign-secret https://example.invalid/maintainers")
+
+    bot.stop_data_maintainers = fail_maintainer_stop
+    custom_id = _pb_custom_id("entry_grid_normal_long", "foreign")
+    detections = [
+        (
+            {"symbol": "BTC/USDT:USDT", "custom_id": custom_id},
+            "entry_grid_normal_long",
+            custom_id,
+            2_000_000,
+        )
+    ]
+
+    with caplog.at_level(logging.ERROR), pytest.raises(
+        Exception, match="foreign Passivbot writer detected"
+    ):
+        await pb_mod.Passivbot._stop_for_foreign_passivbot_orders(bot, detections, 1)
+
+    assert calls == [((), {"verbose": False})]
+    assert bot._foreign_passivbot_stop_requested is True
+    assert bot.stop_signal_received is True
+    assert "action=continue_foreign_writer_stop" in caplog.text
+    assert "error_type=Exception" in caplog.text
+    assert "CredentialLeakError" not in caplog.text
+    assert "foreign-secret" not in caplog.text
+    assert "example.invalid" not in caplog.text
+    assert any(record.levelno == logging.ERROR for record in caplog.records)


### PR DESCRIPTION
@codex

## Category
Observability producer

## Summary
- redact maintainer-cleanup failures during foreign-writer safety shutdown
- retain a bounded exception type and stable continuation action
- add hostile-exception coverage for the terminal stop contract

## Behavior
Foreign-writer detection still sets the stop flags, invokes maintainer cleanup, and raises the terminal safety exception. Only the cleanup-failure diagnostic payload changes; detection, order handling, and trading behavior are unchanged. No operational action is required.

## Validation
- 19 focused foreign-writer tests
- full Python suite: 4,602 passed, 121 skipped
- 221 Rust tests
- Rust test check and formatting check
- exact Rust extension source verification
- AI documentation and generated event-registry checks
- Python compile and diff checks
- publication privacy scan