### PR TITLE
Redact reconciler diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Reconciliation diagnostics for trace recording, order-churn evidence, and malformed open-order
+  snapshots now retain only bounded exception types. This diagnostic-only redaction does not change
+  order planning, churn availability, malformed-order guardrails, or exchange-action gating.
+
 - Foreign-writer safety shutdown diagnostics now retain only bounded maintainer-cleanup failure
   types and a stable continuation action. Stop flags, cleanup invocation, and terminal
   foreign-writer stop behavior are unchanged.

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -242,6 +242,11 @@ These events are diagnostic projections only. The causal history, rolling counte
 cancel-first state are updated directly in the planner and executor, and sink failure cannot alter
 the selected exchange actions.
 
+Reconciliation trace, churn-summary, normalization, and malformed-open-order diagnostics retain
+only bounded exception types. They exclude exception text, untrusted exception class names, URLs,
+and traceback data; this diagnostic redaction does not change churn availability, malformed-order
+guardrails, planned orders, or exchange-action gating.
+
 ## Fresh-Entry Eligibility
 
 Completed normal live plans emit `entry.initial_eligibility` to structured and monitor sinks. The

--- a/src/live/reconciler.py
+++ b/src/live/reconciler.py
@@ -81,7 +81,7 @@ def _trace_record(
             "[entry] fresh-entry eligibility trace disabled during reconciliation | "
             "method=%s error_type=%s",
             method,
-            type(exc).__name__,
+            bounded_exception_type(exc),
         )
         return None
 
@@ -147,7 +147,7 @@ def _initialize_fresh_entry_trace(
     except Exception as exc:
         logging.debug(
             "[entry] fresh-entry eligibility trace initialization failed | error_type=%s",
-            type(exc).__name__,
+            bounded_exception_type(exc),
         )
         return None
 
@@ -1175,7 +1175,7 @@ def _emit_order_churn_evidence_summary(
     except Exception as exc:
         logging.debug(
             "[event] order churn evidence emitter failed | error_type=%s",
-            type(exc).__name__,
+            bounded_exception_type(exc),
         )
 
 
@@ -1276,7 +1276,7 @@ def prepare_order_churn_evidence(
                 "[order] churn evidence unavailable for symbol; leaving its actual orders "
                 "untouched | symbol=%s | error_type=%s",
                 _pb_attr("Passivbot")._log_symbol(symbol),
-                type(exc).__name__,
+                bounded_exception_type(exc),
             )
             continue
         valid_ideals[symbol] = orders
@@ -1849,10 +1849,10 @@ def snapshot_actual_orders(
                 logging.error(
                     "[order] malformed open order snapshot; "
                     "marking account-critical open-orders surface unavailable | symbol=%s | "
-                    "order_id=%s | reason=%s",
+                    "order_id=%s | error_type=%s",
                     _pb_attr("Passivbot")._log_symbol(symbol),
                     order_id or "unknown",
-                    exc,
+                    bounded_exception_type(exc),
                 )
         if return_symbol:
             actual_orders[symbol] = symbol_orders

--- a/src/live/reconciler.py
+++ b/src/live/reconciler.py
@@ -1845,13 +1845,11 @@ def snapshot_actual_orders(
             except (TypeError, KeyError, ValueError, OverflowError) as exc:
                 malformed_symbols.add(symbol)
                 malformed_counts[symbol] = malformed_counts.get(symbol, 0) + 1
-                order_id = order.get("id") if isinstance(order, dict) else None
                 logging.error(
                     "[order] malformed open order snapshot; "
                     "marking account-critical open-orders surface unavailable | symbol=%s | "
-                    "order_id=%s | error_type=%s",
+                    "error_type=%s",
                     _pb_attr("Passivbot")._log_symbol(symbol),
-                    order_id or "unknown",
                     bounded_exception_type(exc),
                 )
         if return_symbol:

--- a/tests/test_fresh_entry_eligibility_integration.py
+++ b/tests/test_fresh_entry_eligibility_integration.py
@@ -67,6 +67,37 @@ def test_eligibility_emitter_builds_schema_valid_correlated_event():
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_reconciliation_trace_diagnostics_redact_hostile_failure_metadata(caplog):
+    secret = "trace-secret https://example.invalid/trace"
+    hostile_error = type("ApiKeySecretError", (RuntimeError,), {})
+
+    class Trace:
+        def record_evaluated(self, *_args, **_kwargs):
+            raise hostile_error(secret)
+
+    with caplog.at_level("DEBUG"):
+        assert (
+            reconciler._trace_record(
+                Trace(), "record_evaluated", "BTC/USDT:USDT", "long"
+            )
+            is None
+        )
+
+    class Bot:
+        @property
+        def active_symbols(self):
+            raise hostile_error(secret)
+
+    with caplog.at_level("DEBUG"):
+        assert reconciler._initialize_fresh_entry_trace(Bot(), {}, {}) is None
+
+    rendered = "\n".join(record.getMessage() for record in caplog.records)
+    assert "error_type=RuntimeError" in rendered
+    assert hostile_error.__name__ not in rendered
+    assert secret not in rendered
+    assert "example.invalid" not in rendered
+
+
 def _reconciliation_bot(symbol: str, actual_orders: list[dict]) -> Passivbot:
     bot = Passivbot.__new__(Passivbot)
     bot.active_symbols = [symbol]

--- a/tests/test_order_churn_gate.py
+++ b/tests/test_order_churn_gate.py
@@ -422,13 +422,14 @@ def test_active_rust_risk_pair_bypasses_observed_churn(monkeypatch):
     assert moved["_churn_reason"] == "rust_risk_phase_active"
 
 
-def test_downstream_normalization_outage_is_symbol_scoped(monkeypatch):
+def test_downstream_normalization_outage_is_symbol_scoped(monkeypatch, caplog):
     state = OrderChurnGateState()
     btc = "BTC/USDT:USDT"
     eth = "ETH/USDT:USDT"
     valid = _order(price=100.0)
     invalid = {**_order(price=10.0), "symbol": eth}
-    invalid.pop("qty")
+    hostile_error = type("ApiKeySecretError", (ValueError,), {})
+    secret = "normalization-secret https://example.invalid/normalization"
 
     class Bot:
         _order_churn_gate_state = state
@@ -454,17 +455,59 @@ def test_downstream_normalization_outage_is_symbol_scoped(monkeypatch):
         lambda _bot, symbols: {symbol: ("m",) for symbol in symbols},
     )
     monkeypatch.setattr(reconciler.time, "monotonic", lambda: 1.0)
+    original_normalize = reconciler.normalize_ideal_orders
+
+    def normalize_or_fail(orders):
+        if orders[0]["symbol"] == eth:
+            raise hostile_error(secret)
+        return original_normalize(orders)
+
+    monkeypatch.setattr(reconciler, "normalize_ideal_orders", normalize_or_fail)
 
     generation = state.begin_generation()
-    unavailable = reconciler.prepare_order_churn_evidence(
-        Bot(), {btc: [valid], eth: [invalid]}, generation=generation
-    )
+    with caplog.at_level("ERROR"):
+        unavailable = reconciler.prepare_order_churn_evidence(
+            Bot(), {btc: [valid], eth: [invalid]}, generation=generation
+        )
 
     assert unavailable == {eth}
     assert btc in state.history_by_symbol
     assert eth not in state.history_by_symbol
     assert valid["_churn_reason"] == "no_history"
     assert invalid["_churn_reason"] == "normalization_unavailable"
+    rendered = "\n".join(record.getMessage() for record in caplog.records)
+    assert "error_type=ValueError" in rendered
+    assert hostile_error.__name__ not in rendered
+    assert secret not in rendered
+    assert "example.invalid" not in rendered
+
+
+def test_churn_evidence_emitter_failure_redacts_hostile_metadata(caplog):
+    hostile_error = type("ApiKeySecretError", (RuntimeError,), {})
+    secret = "emitter-secret https://example.invalid/emitter"
+    state = OrderChurnGateState()
+
+    class Bot:
+        def _emit_order_churn_evidence_event(self, **_kwargs):
+            raise hostile_error(secret)
+
+    with caplog.at_level("DEBUG"):
+        reconciler._emit_order_churn_evidence_summary(
+            Bot(),
+            state=state,
+            generation=1,
+            reset=False,
+            decisions=[],
+            symbols=["BTC/USDT:USDT"],
+        )
+
+    rendered = "\n".join(record.getMessage() for record in caplog.records)
+    assert "error_type=RuntimeError" in rendered
+    assert hostile_error.__name__ not in rendered
+    assert secret not in rendered
+    assert "example.invalid" not in rendered
+    assert state.history_by_symbol == {}
+    assert state.reset_count == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -11028,8 +11028,15 @@ async def test_malformed_actual_open_order_blocks_account_wide_creates(caplog):
     bot._get_live_last_prices = fake_get_live_last_prices
     bot.live_value = lambda key: 0.0 if key == "order_match_tolerance_pct" else 0.0
 
+    secret = "open-order-secret https://example.invalid/open-order"
+    hostile_error = type("ApiKeySecretError", (ValueError,), {})
+
+    class HostileQuantity:
+        def __float__(self):
+            raise hostile_error(secret)
+
     malformed_order = _guardrail_order(id="malformed-entry")
-    malformed_order.pop("qty")
+    malformed_order["qty"] = HostileQuantity()
     bot.open_orders = {"BTC/USDT:USDT": [malformed_order], "ETH/USDT:USDT": []}
     ideal_orders = {
         "BTC/USDT:USDT": [
@@ -11073,6 +11080,10 @@ async def test_malformed_actual_open_order_blocks_account_wide_creates(caplog):
     }
     assert "malformed open order snapshot" in caplog.text
     assert "malformed_open_order_snapshot" in caplog.text
+    assert "error_type=ValueError" in caplog.text
+    assert hostile_error.__name__ not in caplog.text
+    assert secret not in caplog.text
+    assert "example.invalid" not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -11029,14 +11029,15 @@ async def test_malformed_actual_open_order_blocks_account_wide_creates(caplog):
     bot.live_value = lambda key: 0.0 if key == "order_match_tolerance_pct" else 0.0
 
     secret = "open-order-secret https://example.invalid/open-order"
+    unsafe_order_id = "token=order-id-secret https://example.invalid/order-id"
     hostile_error = type("ApiKeySecretError", (ValueError,), {})
 
-    class HostileQuantity:
+    class HostilePrice:
         def __float__(self):
             raise hostile_error(secret)
 
-    malformed_order = _guardrail_order(id="malformed-entry")
-    malformed_order["qty"] = HostileQuantity()
+    malformed_order = _guardrail_order(id=unsafe_order_id)
+    malformed_order["price"] = HostilePrice()
     bot.open_orders = {"BTC/USDT:USDT": [malformed_order], "ETH/USDT:USDT": []}
     ideal_orders = {
         "BTC/USDT:USDT": [
@@ -11083,6 +11084,8 @@ async def test_malformed_actual_open_order_blocks_account_wide_creates(caplog):
     assert "error_type=ValueError" in caplog.text
     assert hostile_error.__name__ not in caplog.text
     assert secret not in caplog.text
+    assert unsafe_order_id not in caplog.text
+    assert "order-id-secret" not in caplog.text
     assert "example.invalid" not in caplog.text
 
 


### PR DESCRIPTION
@codex review

## Scope

Category: observability producer.

Bound exception diagnostics in reconciliation trace recording, order-churn evidence, and malformed open-order snapshots. The affected catches now retain only a safe exception type.

## Behavior

This is diagnostic-only. It does not change order planning, churn availability, malformed-order guardrails, fail-closed exchange-action gating, returns, or exception propagation. No operational action is required.

## Validation

- 337 focused reconciliation tests passed
- 4,604 full Python tests passed; 121 skipped
- 221 Rust tests passed
- Rust check and format passed
- exact Rust extension source verification passed
- AI documentation and live-event registry checks passed
- Python compilation and diff checks passed

## Review focus

Confirm hostile exception class names and messages cannot reach these diagnostics, and that symbol-scoped/account-wide safety behavior is unchanged.