### PR TITLE
Redact HSL history replay diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- HSL history-replay candle-fetch and passive cache-observer diagnostics now retain bounded
+  exception types only. Candle fallback and degraded replay outputs, retries, cache behavior, and
+  trading state are unchanged.
+
 - Reconciliation diagnostics for trace recording, order-churn evidence, and malformed open-order
   snapshots now retain only bounded exception types. This diagnostic-only redaction does not change
   order planning, churn availability, malformed-order guardrails, or exchange-action gating.

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -327,6 +327,12 @@ Cache events use `hsl.replay.cache` with `cache_status=hit|miss|rejected`. Cache
 rejections are non-authoritative performance outcomes and fall back to exchange-derived replay.
 Cache write/load rejection reasons and coin replay failures retain bounded exception types only,
 never exception text, tracebacks, or unsafe exception class names.
+HSL historical candle-fetch failures and passive account-series or replay-matrix cache observers
+follow the same boundary. Failed per-symbol progress events retain their existing stage, status,
+reason, symbol, timeframe, and timing fields plus a bounded exception type; the corresponding
+text diagnostics retain no exception text or unsafe exception class names. Redaction does
+not change candle fallback or degradation, retries, replay continuation, cache clearing, pair-only
+cache drops, timeline/compact replay, or trading state.
 Pair progress exposes `applied_rows`/`total_applied_rows` and scan-cost fields
 `scanned_rows`/`total_scanned_rows`/`scanned_rows_per_second`/`pair_elapsed_s`.
 `is_held_pair`, `is_cooldown_pair`, and `pair_idx` expose deterministic

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -13330,7 +13330,7 @@ class Passivbot:
                                     ),
                                     3,
                                 ),
-                                "error_type": type(exc).__name__,
+                                "error_type": bounded_exception_type(exc),
                             },
                             symbol=sym,
                             status="failed",
@@ -13347,7 +13347,11 @@ class Passivbot:
                 *(fetch_replay_candles(sym) for sym in sorted(price_replay_symbols))
             ):
                 if exc is not None:
-                    logging.error(f"error fetching candles for {sym} {exc}")
+                    logging.error(
+                        "error fetching candles for %s | error_type=%s",
+                        Passivbot._log_symbol(sym),
+                        bounded_exception_type(exc),
+                    )
                     arr = np.empty((0,), dtype=CANDLE_DTYPE)
                 if arr is None:
                     arr = np.empty((0,), dtype=CANDLE_DTYPE)
@@ -13375,10 +13379,11 @@ class Passivbot:
                     ):
                         if exc is not None:
                             logging.error(
-                                "error fetching %s candles for %s during equity history replay: %s",
+                                "error fetching %s candles for %s during equity history replay "
+                                "| error_type=%s",
                                 timeframe,
-                                sym,
-                                exc,
+                                Passivbot._log_symbol(sym),
+                                bounded_exception_type(exc),
                             )
                             continue
                         if arr is None or arr.size == 0:
@@ -13565,10 +13570,9 @@ class Passivbot:
                 replay_account_rows.clear()
                 logging.warning(
                     "[risk] HSL account series row build failed; "
-                    "skipping account series cache | ts=%s error=%s: %s",
+                    "skipping account series cache | ts=%s error_type=%s",
                     minute_ts,
-                    type(exc).__name__,
-                    exc,
+                    bounded_exception_type(exc),
                 )
 
         def _collect_replay_matrix_rows(minute_ts: int, *, record: bool) -> None:
@@ -13623,12 +13627,11 @@ class Passivbot:
                     replay_matrix_rows.pop(pair, None)
                     logging.warning(
                         "[risk] HSL[%s:%s] replay matrix row build failed; "
-                        "skipping cache for this pair | ts=%s error=%s: %s",
+                        "skipping cache for this pair | ts=%s error_type=%s",
                         pside,
                         Passivbot._log_symbol(sym),
                         minute_ts,
-                        type(exc).__name__,
-                        exc,
+                        bounded_exception_type(exc),
                     )
 
         history_minutes = int(max(0, (end_minute - start_minute) // ONE_MIN_MS)) + 1

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -2076,6 +2076,94 @@ async def test_balance_equity_history_paces_replay_candle_fetches(monkeypatch):
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+@pytest.mark.asyncio
+async def test_balance_equity_history_redacts_failed_candle_fetch_diagnostics(monkeypatch, caplog):
+    bot = Passivbot.__new__(Passivbot)
+    bot.config = {"live": {}}
+    bot.exchange = "hyperliquid"
+    bot.user = "test_user"
+    bot.init_pnls = AsyncMock()
+    bot.live_value = lambda key: "all" if key == "pnls_max_lookback_days" else None
+    base_ts = 1_800_000_000_000
+    end_ts = base_ts + 5_001 * 60_000
+    symbol = "ETH/USDT:USDT"
+    bot.get_exchange_time = lambda: end_ts
+    bot.get_raw_balance = lambda: 100.0
+    bot.get_symbol_id_inv = lambda value: value
+    bot.positions = {
+        symbol: {
+            "long": {"size": 1.0, "price": 100.0},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+    }
+    bot._pnls_manager = None
+    bot.inverse = False
+    bot._candle_fetch_concurrency = lambda *, context="runtime": 1
+    bot._get_fetch_delay_seconds = lambda: 0.0
+    sink = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot._live_event_current_cycle_id = "cy_hsl_history_failure"
+    bot._emit_live_event = Passivbot._emit_live_event.__get__(bot, Passivbot)
+    bot.c_mults = {symbol: 1.0}
+    monkeypatch.setattr(
+        passivbot_module, "compute_psize_pprice", lambda *args, **kwargs: None
+    )
+    hostile = "token=hsl-history-secret https://example.invalid/hsl-history"
+
+    class _CM:
+        async def get_candles(self, sym, **kwargs):
+            raise _hostile_runtime_error(hostile)
+
+    bot.cm = _CM()
+    fill_events = [
+        {
+            "timestamp": base_ts,
+            "symbol": symbol,
+            "position_side": "long",
+            "side": "buy",
+            "qty": 1.0,
+            "price": 100.0,
+            "pnl": 0.0,
+        }
+    ]
+
+    with caplog.at_level(logging.ERROR):
+        history = await bot.get_balance_equity_history(
+            fill_events=fill_events,
+            current_balance=100.0,
+            hsl_replay_signal_mode="coin",
+        )
+
+    assert history["timeline"]
+    assert history["metadata"]["missing_price_symbols"] == [symbol]
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    failed_events = [
+        event
+        for event in sink.events
+        if event.reason_code == ReasonCodes.HSL_PRICE_HISTORY_SYMBOL_FETCH_COMPLETED
+        and event.status == "failed"
+    ]
+    assert {event.data["timeframe"] for event in failed_events} == {"1m", "5m"}
+    assert {event.data["error_type"] for event in failed_events} == {"RuntimeError"}
+    assert all(
+        event.data["stage"] == "price_history_symbol_fetch_completed"
+        for event in failed_events
+    )
+    assert all("elapsed_s" in event.data for event in failed_events)
+    rendered_events = "\n".join(str(event.data) for event in failed_events)
+    assert hostile not in rendered_events
+    assert "ApiKeySecretError" not in rendered_events
+    assert "example.invalid" not in rendered_events
+    assert "error_type=RuntimeError" in caplog.text
+    assert hostile not in caplog.text
+    assert "ApiKeySecretError" not in caplog.text
+    assert "example.invalid" not in caplog.text
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_pside_timeline_synthesis_rejects_inconsistent_pside_pnl():
     # Codex P1: the trust boundary must reject a v5 account series whose
     # account-level pnl and per-pside pnl describe different realized streams.
@@ -2483,7 +2571,7 @@ async def test_balance_equity_history_first_minute_realized_pnl_attributes_pside
 
 
 @pytest.mark.asyncio
-async def test_balance_equity_history_builds_replay_matrices_for_held_pairs(monkeypatch):
+async def test_balance_equity_history_builds_replay_matrices_for_held_pairs(monkeypatch, caplog):
     bot = Passivbot.__new__(Passivbot)
     bot.config = {"live": {}}
     bot.exchange = "kucoin"
@@ -2615,9 +2703,41 @@ async def test_balance_equity_history_builds_replay_matrices_for_held_pairs(monk
     assert history_no_mode["hsl_replay_matrices"] == {}
     assert history_no_mode["hsl_replay_account_series"] == []
 
+    hostile = "token=hsl-observer-secret https://example.invalid/hsl-observer"
+    account_row_builder = passivbot_module.pb_hsl._hsl_replay_account_series_row
+
+    def raising_account_row_builder(**kwargs):
+        raise _hostile_runtime_error(hostile)
+
+    monkeypatch.setattr(
+        passivbot_module.pb_hsl,
+        "_hsl_replay_account_series_row",
+        raising_account_row_builder,
+    )
+    with caplog.at_level(logging.WARNING):
+        history_account_degraded = await bot.get_balance_equity_history(
+            fill_events=fill_events,
+            current_balance=100.0,
+            hsl_replay_signal_mode="coin",
+        )
+    assert history_account_degraded["hsl_replay_matrices"] == matrices
+    assert history_account_degraded["hsl_replay_account_series"] == []
+    assert len(history_account_degraded["timeline"]) == len(history["timeline"])
+    assert "error_type=RuntimeError" in caplog.text
+    assert hostile not in caplog.text
+    assert "ApiKeySecretError" not in caplog.text
+    assert "example.invalid" not in caplog.text
+
+    monkeypatch.setattr(
+        passivbot_module.pb_hsl,
+        "_hsl_replay_account_series_row",
+        account_row_builder,
+    )
+    caplog.clear()
+
     # A failing matrix row build must drop the pair's cache, not the replay.
     def raising_row_builder(**kwargs):
-        raise ValueError("synthetic matrix row failure")
+        raise _hostile_runtime_error(hostile)
 
     monkeypatch.setattr(
         passivbot_module.pb_hsl, "_hsl_replay_matrix_row", raising_row_builder
@@ -2630,6 +2750,10 @@ async def test_balance_equity_history_builds_replay_matrices_for_held_pairs(monk
     assert history_degraded["hsl_replay_matrices"] == {}
     assert history_degraded["hsl_replay_account_series"] == []
     assert len(history_degraded["timeline"]) == len(history["timeline"])
+    assert "error_type=RuntimeError" in caplog.text
+    assert hostile not in caplog.text
+    assert "ApiKeySecretError" not in caplog.text
+    assert "example.invalid" not in caplog.text
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 


### PR DESCRIPTION
@codex review

## Scope

Category: observability producer.

Bound exception diagnostics produced by active HSL history replay during candle fetches and passive replay-cache observation.

## Behavior

This is diagnostic-only. It preserves failed-candle degradation, retries, event stage/status/reason and timing, replay continuation, account-cache clearing, pair-scoped cache drops, timeline and compact replay outputs, and trading state. No operational action is required.

## Validation

- 3 focused HSL replay tests passed
- 4,605 full Python tests passed; 121 skipped
- 221 Rust tests passed
- Rust check and format passed
- exact Rust extension source verification passed
- AI documentation and live-event registry checks passed
- Python compilation and diff checks passed

## Review focus

Confirm hostile exception metadata is excluded from both structured progress events and text diagnostics, and that candle and cache degradation semantics remain unchanged.