### PR TITLE
Redact shared diagnostic failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Shared live diagnostic-event fallback and diagnostic-step failures now log only their stable
+  context and a bounded exception type. Their existing return values, isolation, routing, retry,
+  scheduling, and trading behavior are unchanged.
+
 - HSL history-replay candle-fetch and passive cache-observer diagnostics now retain bounded
   exception types only. Candle fallback and degraded replay outputs, retries, cache behavior, and
   trading state are unchanged.

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -64,6 +64,9 @@ payload fragment. Non-built-in string metadata, invalid type names, and identifi
 containing credential markers normalize to `Error` before the safe type is bounded. Redacting the
 diagnostic must not change the emitter's return value, exception isolation, event routing, retries,
 scheduling, HSL/risk behavior, or trading behavior.
+The shared diagnostic-event legacy monitor fallback and diagnostic-step wrapper follow this same
+boundary: their DEBUG logs retain the code-owned event kind or step label plus a bounded exception
+type, never the exception value or raw class metadata.
 The same redaction applies when the event-adjacent HSL coin-status human projection fails; the
 structured `hsl.status` event must still be attempted independently. Other non-event HSL
 diagnostics are outside this contract.

--- a/src/live/events.py
+++ b/src/live/events.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 import logging
 from typing import Any, Iterable, Mapping, TypeVar
 
+from live.diagnostic_safety import bounded_exception_type
 from live.event_bus import LiveEvent, emit_event
 
 
@@ -66,9 +67,9 @@ class DiagnosticEvent:
             )
         except Exception as exc:
             logging.debug(
-                "[diagnostic] failed to emit %s event: %s",
+                "[diagnostic] failed to emit %s event error_type=%s",
                 self.kind,
-                exc,
+                bounded_exception_type(exc),
             )
             return None
 
@@ -115,8 +116,8 @@ def run_diagnostic_step(
         return func()
     except Exception as exc:
         logging.debug(
-            "[diagnostic] %s failed: %s",
+            "[diagnostic] %s failed error_type=%s",
             str(label),
-            exc,
+            bounded_exception_type(exc),
         )
         return default

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -42,7 +42,7 @@ from live.event_bus import (
     startup_phase_readiness_contract,
     startup_timing_phase,
 )
-from live.events import DiagnosticEvent
+from live.events import DiagnosticEvent, run_diagnostic_step
 from monitor_publisher import MonitorPublisher
 
 
@@ -1621,6 +1621,52 @@ def test_diagnostic_event_falls_back_to_legacy_recorder_when_pipeline_queue_is_f
     assert first.emit(bot).event_type == EventTypes.PLANNING_UNAVAILABLE
     assert second.emit(bot) == "legacy"
     assert bot.calls[0][0][:3] == ("planning_unavailable", ("planning",), {"n": 2})
+
+
+def test_diagnostic_event_legacy_fallback_failure_redacts_hostile_exception_metadata(caplog):
+    secret = "https://hostile.example.invalid/v1/orders?api_key=legacy-monitor-secret"
+    unsafe_type = type("ApiKeyLegacyMonitorFailure", (RuntimeError,), {})
+
+    class LegacyBot:
+        def _monitor_record_event(self, *_args, **_kwargs):
+            raise unsafe_type(secret)
+
+    event = DiagnosticEvent.build("planning_unavailable", ("planning",), {"safe": True})
+
+    with caplog.at_level(logging.DEBUG):
+        assert event.emit(LegacyBot()) is None
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(
+        "[diagnostic] failed to emit planning_unavailable event error_type=RuntimeError"
+        in message
+        for message in messages
+    )
+    assert all(secret not in message for message in messages)
+    assert all("hostile.example.invalid" not in message for message in messages)
+    assert all("legacy-monitor-secret" not in message for message in messages)
+    assert all(unsafe_type.__name__ not in message for message in messages)
+
+
+def test_run_diagnostic_step_failure_redacts_hostile_exception_metadata(caplog):
+    secret = "https://hostile.example.invalid/v1/orders?token=diagnostic-step-secret"
+    unsafe_type = type("ApiKeyDiagnosticStepFailure", (RuntimeError,), {})
+
+    def fail():
+        raise unsafe_type(secret)
+
+    with caplog.at_level(logging.DEBUG):
+        assert run_diagnostic_step("finalize snapshot metadata", fail, default="fallback") == "fallback"
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(
+        "[diagnostic] finalize snapshot metadata failed error_type=RuntimeError" in message
+        for message in messages
+    )
+    assert all(secret not in message for message in messages)
+    assert all("hostile.example.invalid" not in message for message in messages)
+    assert all("diagnostic-step-secret" not in message for message in messages)
+    assert all(unsafe_type.__name__ not in message for message in messages)
 
 
 def test_console_format_is_compact_and_operator_facing():


### PR DESCRIPTION
@codex review

## Scope

Category: observability producer.

Redact caught exception values from the shared live diagnostic-event fallback and best-effort diagnostic-step wrapper. Their DEBUG diagnostics retain only the code-owned event kind or step label plus the existing bounded exception type.

## Behavior

Diagnostic-only. Return values, exception isolation, event routing, fallback behavior, retries, scheduling, state mutation, risk handling, and trading behavior are unchanged.

Operational action: none.

## Validation

- Full Python test suite passed with the exact current Rust extension.
- `133` focused live-event tests passed.
- `221` Rust tests passed.
- `cargo check --tests` and `cargo fmt --check` passed.
- AI docs, generated live-event registry, documentation tests, Python compilation, and diff checks passed.

## Reviewer Focus

Confirm hostile exception messages and unsafe class metadata cannot reach either shared DEBUG diagnostic, and that both existing fallback return contracts remain unchanged.