### PR TITLE
Redact unrealized PnL diagnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Unrealized-PnL aggregation failure diagnostics now retain only a bounded exception type and the
+  stable `return_zero` action. The existing immediate `0.0` fallback, price fetching, balance and
+  equity handling, scheduling, risk, HSL, and trading behavior are unchanged.
+
 - Shared live diagnostic-event fallback and diagnostic-step failures now log only their stable
   context and a bounded exception type. Their existing return values, isolation, routing, retry,
   scheduling, and trading behavior are unchanged.

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -103,6 +103,12 @@ failure records only a bounded type and `stop_progress_logger`; explicit cancell
 propagates. These diagnostics do not change refresh propagation, balance anchors, scheduling,
 reconciliation, balance handling, cleanup, timing, fallback values, or event schemas.
 
+When unrealized-PnL aggregation cannot calculate a fetched position, its ERROR diagnostic retains
+only a bounded exception type and the `return_zero` action. It immediately returns the existing
+`0.0` fallback without retaining exception text, unsafe class metadata, URLs, credentials, or a
+traceback; price fetching, iteration, balance/equity handling, state, scheduling, risk, HSL, and
+trading behavior are unchanged.
+
 Foreign-writer safety shutdown keeps its terminal stop behavior when best-effort data-maintainer
 cleanup fails. The ERROR diagnostic retains only a bounded exception type and the stable
 `continue_foreign_writer_stop` action; it never retains exception text, unsafe exception class

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -11139,8 +11139,10 @@ class Passivbot:
                 if upnl:
                     upnl_sum += upnl
             except Exception as e:
-                logging.error(f"error calculating upnl sum {e}")
-                traceback.print_exc()
+                logging.error(
+                    "[balance] upnl calculation failed error_type=%s action=return_zero",
+                    bounded_exception_type(e),
+                )
                 return 0.0
         return upnl_sum
 

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -76,6 +76,52 @@ def _hostile_runtime_error(detail: str) -> RuntimeError:
     return error_cls(detail)
 
 
+@pytest.mark.asyncio
+async def test_calc_upnl_sum_redacts_failure_and_returns_zero(caplog, capsys, monkeypatch):
+    bot = Passivbot.__new__(Passivbot)
+    symbol = "BTC/USDT:USDT"
+    bot.fetched_positions = [
+        {
+            "symbol": symbol,
+            "position_side": "long",
+            "price": 100.0,
+            "size": 1.0,
+        }
+    ]
+    bot.inverse = False
+    bot.c_mults = {symbol: 1.0}
+
+    async def fake_last_prices(*_args, **_kwargs):
+        return {symbol: 101.0}
+
+    bot._get_live_last_prices = fake_last_prices
+    hostile_detail = "https://hostile.example.invalid/upnl?credential=secret-token"
+
+    def fail_calc_pnl(*_args, **_kwargs):
+        raise _hostile_runtime_error(hostile_detail)
+
+    monkeypatch.setattr(passivbot_module, "calc_pnl", fail_calc_pnl)
+
+    with caplog.at_level(logging.ERROR):
+        assert await bot.calc_upnl_sum() == 0.0
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert messages == [
+        "[balance] upnl calculation failed error_type=RuntimeError action=return_zero"
+    ]
+    captured = capsys.readouterr()
+    rendered = caplog.text + captured.out + captured.err
+    for unsafe in (
+        hostile_detail,
+        "ApiKeySecretError",
+        "https://",
+        "credential",
+        "secret-token",
+        "Traceback",
+    ):
+        assert unsafe not in rendered
+
+
 class _SafeRiskCache:
     def get_known_gaps(self):
         return []


### PR DESCRIPTION
@codex review

## Scope

Category: observability producer.

Redact the unrealized-PnL aggregation failure diagnostic. It now retains only a bounded exception type and the stable `return_zero` action instead of the caught exception value and traceback.

## Behavior

Diagnostic-only. The existing immediate `0.0` fallback, price fetching, position iteration, balance and equity handling, state, scheduling, risk, HSL, and trading behavior are unchanged.

Operational action: none.

## Validation

- Full Python test suite passed with the exact current Rust extension.
- Focused hostile-metadata and container contract tests passed.
- `221` Rust tests passed.
- `cargo check --tests` and `cargo fmt --check` passed.
- AI docs, generated live-event registry, documentation tests, Python compilation, and diff checks passed.

## Reviewer Focus

Confirm the helper still returns `0.0` immediately on the first per-position calculation failure, and that exception messages, unsafe class metadata, URLs, credentials, and tracebacks cannot reach the diagnostic.