### PR TITLE
Redact coin-list refresh diagnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Approved/ignored coin-list refresh failure diagnostics now retain only a bounded exception type
+  and the stable `return_from_coin_list_refresh` action. Existing refresh return, list/universe and
+  eligibility update semantics, scheduling, risk, HSL, and trading behavior are unchanged.
+
 - Unrealized-PnL aggregation failure diagnostics now retain only a bounded exception type and the
   stable `return_zero` action. The existing immediate `0.0` fallback, price fetching, balance and
   equity handling, scheduling, risk, HSL, and trading behavior are unchanged.

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -103,6 +103,14 @@ failure records only a bounded type and `stop_progress_logger`; explicit cancell
 propagates. These diagnostics do not change refresh propagation, balance anchors, scheduling,
 reconciliation, balance handling, cleanup, timing, fallback values, or event schemas.
 
+## Coin-List Refresh Failure Diagnostics
+
+The outer approved/ignored coin-list refresh failure diagnostic retains only a bounded exception
+type and the `return_from_coin_list_refresh` action. It never retains exception messages, unsafe
+exception class names, URLs, credentials, tokens, or tracebacks. This redaction does not alter the
+existing return, list/universe/eligibility update semantics, scheduling, risk, HSL, or trading
+behavior.
+
 When unrealized-PnL aggregation cannot calculate a fetched position, its ERROR diagnostic retains
 only a bounded exception type and the `return_zero` action. It immediately returns the existing
 `0.0` fallback without retaining exception text, unsafe class metadata, URLs, credentials, or a

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -19616,8 +19616,11 @@ class Passivbot:
                 pass
             self._log_coin_symbol_fallback_summary()
         except Exception as e:
-            logging.error(f"error with refresh_approved_ignored_coins_lists {e}")
-            traceback.print_exc()
+            logging.error(
+                "[forager] approved/ignored coin refresh failed | "
+                "error_type=%s action=return_from_coin_list_refresh",
+                bounded_exception_type(e),
+            )
 
     def _log_coin_symbol_fallback_summary(self):
         """Emit a brief summary of symbol/coin mapping fallbacks (once per change)."""

--- a/tests/test_live_coin_lists.py
+++ b/tests/test_live_coin_lists.py
@@ -643,3 +643,70 @@ def test_refresh_approved_ignored_coin_lists_does_not_restore_legacy_output_on_e
         record for record in caplog.records if record.message.startswith("[forager]")
     ]
     assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_refresh_approved_ignored_coin_lists_redacts_outer_failure_and_returns(
+    caplog, capsys
+):
+    bot = _make_eligibility_event_bot()
+    filter_calls = []
+    fallback_summary_called = False
+    hostile_error = type(
+        "ApiTokenCredentialsError",
+        (Exception,),
+        {},
+    )(
+        "hostile-message https://coin-list.invalid/refresh?api_key=operator-secret&token=token-123"
+    )
+
+    def fail_filter(pside, symbols):
+        filter_calls.append((pside, set(symbols)))
+        raise hostile_error
+
+    def record_fallback_summary():
+        nonlocal fallback_summary_called
+        fallback_summary_called = True
+
+    bot._filter_approved_symbols = fail_filter
+    bot._log_coin_symbol_fallback_summary = record_fallback_summary
+
+    with caplog.at_level(logging.ERROR):
+        result = bot.refresh_approved_ignored_coins_lists()
+
+    diagnostic = next(
+        record.getMessage()
+        for record in caplog.records
+        if "approved/ignored coin refresh failed" in record.getMessage()
+    )
+    captured = capsys.readouterr()
+    output = "\n".join((caplog.text, captured.out, captured.err))
+
+    assert result is None
+    assert filter_calls == [
+        (
+            "long",
+            {f"A{index:02d}/USDT:USDT" for index in range(14)},
+        )
+    ]
+    assert fallback_summary_called is False
+    assert bot.approved_coins["long"] == {
+        f"A{index:02d}/USDT:USDT" for index in range(14)
+    }
+    assert bot.ignored_coins == {"long": {"IGNORED/USDT:USDT"}, "short": set()}
+    assert bot.approved_coins_minus_ignored_coins == {}
+    assert diagnostic == (
+        "[forager] approved/ignored coin refresh failed | "
+        "error_type=Exception action=return_from_coin_list_refresh"
+    )
+    assert captured.out == ""
+    assert captured.err == ""
+    for unsafe_value in (
+        "hostile-message",
+        "ApiTokenCredentialsError",
+        "https://coin-list.invalid",
+        "api_key",
+        "operator-secret",
+        "token-123",
+        "Traceback",
+    ):
+        assert unsafe_value not in output


### PR DESCRIPTION
@codex review

## Scope

Category: observability producer.

Redact the outer approved/ignored coin-list refresh failure diagnostic. It now retains only a bounded exception type and the stable `return_from_coin_list_refresh` action instead of the caught exception value and traceback.

## Behavior

Diagnostic-only. Existing refresh return and list/universe/eligibility update semantics, scheduling, risk, HSL, and trading behavior are unchanged.

Operational action: none.

## Validation

- Full Python test suite passed with the exact current Rust extension.
- Focused hostile-metadata and documentation tests passed.
- `221` Rust tests passed.
- `cargo check --tests` and `cargo fmt --check` passed.
- AI docs, generated live-event registry, Python compilation, and diff checks passed.

## Reviewer Focus

Confirm the handler still returns normally at the same failure boundary, preserves the existing partial-update semantics, and excludes exception messages, unsafe class metadata, URLs, credentials, tokens, and tracebacks from logging and stderr.