### PR TITLE
Redact order-sort price diagnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Order-sort market-price fetch failure diagnostics now retain only a bounded exception type and
+  the stable `preserve_original_order` action. The existing empty-price fallback, original-order
+  preservation, reconciliation, planning, and trading behavior are unchanged.
+
 - Approved/ignored coin-list refresh failure diagnostics now retain only a bounded exception type
   and the stable `return_from_coin_list_refresh` action. Existing refresh return, list/universe and
   eligibility update semantics, scheduling, risk, HSL, and trading behavior are unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
-- Order-sort market-price fetch failure diagnostics now retain only a bounded exception type and
-  the stable `preserve_original_order` action. The existing empty-price fallback, original-order
-  preservation, reconciliation, planning, and trading behavior are unchanged.
+- Order-sort market-price fetch failure diagnostics now retain bounded symbol context, a bounded
+  exception type, and the stable `preserve_original_order` action. The existing empty-price
+  fallback, original-order preservation, reconciliation, planning, and trading behavior are
+  unchanged.
 
 - Approved/ignored coin-list refresh failure diagnostics now retain only a bounded exception type
   and the stable `return_from_coin_list_refresh` action. Existing refresh return, list/universe and

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -264,6 +264,14 @@ only bounded exception types. They exclude exception text, untrusted exception c
 and traceback data; this diagnostic redaction does not change churn availability, malformed-order
 guardrails, planned orders, or exchange-action gating.
 
+## Order-Sort Price-Fetch Diagnostics
+
+Market-price fetch failures while sorting orders retain only a bounded exception type and the
+stable `preserve_original_order` action. They use the existing empty-price-map path to return the
+original order object sequence without retaining exception messages, unsafe exception class names,
+URLs, credentials, tokens, or tracebacks. Fetch parameters, missing-price handling, complete-price
+sorting, reconciliation, planning, and trading behavior remain unchanged.
+
 ## Fresh-Entry Eligibility
 
 Completed normal live plans emit `entry.initial_eligibility` to structured and monitor sinks. The

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -266,11 +266,11 @@ guardrails, planned orders, or exchange-action gating.
 
 ## Order-Sort Price-Fetch Diagnostics
 
-Market-price fetch failures while sorting orders retain only a bounded exception type and the
-stable `preserve_original_order` action. They use the existing empty-price-map path to return the
-original order object sequence without retaining exception messages, unsafe exception class names,
-URLs, credentials, tokens, or tracebacks. Fetch parameters, missing-price handling, complete-price
-sorting, reconciliation, planning, and trading behavior remain unchanged.
+Market-price fetch failures while sorting orders retain bounded symbol context, a bounded exception
+type, and the stable `preserve_original_order` action. They use the existing empty-price-map path to
+return the original order object sequence without retaining exception messages, unsafe exception
+class names, URLs, credentials, tokens, or tracebacks. Fetch parameters, missing-price handling,
+complete-price sorting, reconciliation, planning, and trading behavior remain unchanged.
 
 ## Fresh-Entry Eligibility
 

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -18068,10 +18068,10 @@ class Passivbot:
             )
         except Exception as exc:
             logging.warning(
-                "[order] market price lookup failed for order sorting; preserving original order | symbols=%s error_type=%s error=%s",
+                "[order] market price lookup failed for order sorting | "
+                "symbols=%s error_type=%s action=preserve_original_order",
                 Passivbot._log_symbols(tuple(sorted(symbols)), limit=8),
-                type(exc).__name__,
-                exc,
+                bounded_exception_type(exc),
             )
             prices = {}
         for symbol in symbols:

--- a/tests/test_order_orchestration.py
+++ b/tests/test_order_orchestration.py
@@ -1592,3 +1592,68 @@ async def test_order_sort_preserves_original_order_when_market_price_missing(cap
     assert not to_cancel
     assert [order["price"] for order in to_create] == [95.0, 101.0]
     assert any("preserving to_create order" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_order_sort_fetch_failure_redacts_diagnostic_and_preserves_original_order(
+    caplog, capsys
+):
+    symbol = "BTC/USDT"
+    bot = OrchestrationBot({})
+    bot.register_symbol(symbol)
+    first = _make_order(symbol, "buy", "long", 0.5, 95.0, "entry_grid_cropped_long")
+    second = _make_order(symbol, "buy", "long", 0.5, 101.0, "entry_grid_normal_long")
+    orders = [first, second]
+    fetch_calls = []
+    hostile_detail = (
+        "hostile-message https://order-sort.invalid/price?api_key=operator-secret&token=token-123"
+    )
+    hostile_error = type("ApiTokenCredentialsError", (RuntimeError,), {})(hostile_detail)
+
+    async def fail_get_live_last_prices(symbols, **kwargs):
+        fetch_calls.append((symbols, kwargs))
+        raise hostile_error
+
+    bot._fetch_market_prices = types.MethodType(Passivbot._fetch_market_prices, bot)
+    bot._get_live_last_prices = fail_get_live_last_prices
+
+    with caplog.at_level(logging.WARNING):
+        result = await bot._sort_orders_by_market_diff(orders, log_label="to_create")
+
+    diagnostic = next(
+        record.getMessage()
+        for record in caplog.records
+        if "market price lookup failed for order sorting" in record.getMessage()
+    )
+    captured = capsys.readouterr()
+    output = "\n".join((caplog.text, captured.out, captured.err))
+
+    assert result == orders
+    assert result is not orders
+    assert all(returned is original for returned, original in zip(result, orders))
+    assert fetch_calls == [
+        (
+            {symbol},
+            {
+                "max_age_ms": 10_000,
+                "context": "order_sort",
+                "allow_completed_candle_fallback": True,
+            },
+        )
+    ]
+    assert diagnostic == (
+        "[order] market price lookup failed for order sorting | "
+        "symbols=BTC error_type=RuntimeError action=preserve_original_order"
+    )
+    assert captured.out == ""
+    assert captured.err == ""
+    for unsafe_value in (
+        "hostile-message",
+        "ApiTokenCredentialsError",
+        "https://order-sort.invalid",
+        "api_key",
+        "operator-secret",
+        "token-123",
+        "Traceback",
+    ):
+        assert unsafe_value not in output


### PR DESCRIPTION
@codex review

## Scope

Category: observability producer.

Redact the market-price fetch failure diagnostic used while sorting order deltas. It now retains only bounded symbol context, a bounded exception type, and the stable `preserve_original_order` action instead of the caught exception value and raw class name.

## Behavior

Diagnostic-only. Empty input handling, fetch parameters, the empty-price fallback, missing-price handling, complete-price sorting, reconciliation, planning, and trading behavior are unchanged.

Operational action: none.

## Validation

- Full Python test suite passed with the exact current Rust extension.
- Focused order-orchestration hostile-metadata tests passed.
- `221` Rust tests passed.
- `cargo check --tests` and `cargo fmt --check` passed.
- AI docs, generated live-event registry, documentation tests, Python compilation, and diff checks passed.

## Reviewer Focus

Confirm a fetch failure still follows the empty-price path and returns a new list containing the exact original order objects in the same sequence, while excluding exception messages, unsafe class metadata, URLs, credentials, tokens, and tracebacks.