### PR TITLE
Redact startup observer diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Startup monitor-publisher and live-event-pipeline installation diagnostics now retain bounded
+  exception types and stable continuation actions without exception messages, unsafe class names,
+  URLs, credentials, tokens, or tracebacks. Monitor enablement, pipeline installation, startup
+  continuation, and trading behavior are unchanged.
+
 - Order-sort market-price fetch failure diagnostics now retain bounded symbol context, a bounded
   exception type, and the stable `preserve_original_order` action. The existing empty-price
   fallback, original-order preservation, reconciliation, planning, and trading behavior are

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -71,6 +71,14 @@ The same redaction applies when the event-adjacent HSL coin-status human project
 structured `hsl.status` event must still be attempted independently. Other non-event HSL
 diagnostics are outside this contract.
 
+Startup monitor-publisher construction failures retain the existing ERROR `[monitor]` projection,
+while live-event-pipeline installation failures retain their existing WARNING `[monitor]` or
+`[event]` projection. These startup-observer diagnostics retain only a bounded exception type and
+the stable `continue_without_monitor_publisher` or `continue_without_live_event_pipeline` action;
+they never retain exception messages, unsafe class names, URLs, credentials, tokens, or tracebacks.
+Their monitor-enabled behavior, pipeline-install condition, assignments, startup continuation, and
+all runtime and trading behavior remain unchanged.
+
 ## Market Snapshot Diagnostic Skips
 
 `market.snapshot_diagnostic_skipped` records noncritical position-change and balance diagnostics

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -507,6 +507,23 @@ def _log_process_failure(label: str, exc: BaseException) -> None:
     )
 
 
+def _log_startup_observer_failure(
+    level: int,
+    tag: str,
+    message: str,
+    action: str,
+    exc: BaseException,
+) -> None:
+    logging.log(
+        level,
+        "[%s] %s | error_type=%s action=%s",
+        tag,
+        message,
+        bounded_exception_type(exc),
+        action,
+    )
+
+
 _EXECUTION_LOOP_ERROR_ENDPOINTS = frozenset(
     {
         "account-overview",
@@ -1250,8 +1267,12 @@ class Passivbot:
                     runtime_identity=self.runtime_identity.to_dict(),
                 )
             except Exception as exc:
-                logging.error(
-                    "[monitor] failed to initialize monitor publisher: %s", exc
+                _log_startup_observer_failure(
+                    logging.ERROR,
+                    "monitor",
+                    "failed to initialize monitor publisher",
+                    "continue_without_monitor_publisher",
+                    exc,
                 )
                 self.monitor_publisher = None
                 self._live_event_pipeline = None
@@ -1260,9 +1281,21 @@ class Passivbot:
                 self._install_live_event_pipeline()
             except Exception as exc:
                 if self.monitor_publisher is not None and not self.live_event_console_enabled:
-                    logging.warning("[monitor] live event pipeline disabled: %s", exc)
+                    _log_startup_observer_failure(
+                        logging.WARNING,
+                        "monitor",
+                        "live event pipeline disabled",
+                        "continue_without_live_event_pipeline",
+                        exc,
+                    )
                 else:
-                    logging.warning("[event] live event pipeline disabled: %s", exc)
+                    _log_startup_observer_failure(
+                        logging.WARNING,
+                        "event",
+                        "live event pipeline disabled",
+                        "continue_without_live_event_pipeline",
+                        exc,
+                    )
                 self._live_event_pipeline = None
         # CandlestickManager settings from config.live
         # Use denormalized exchange name for cache paths (e.g., "binance" not "binanceusdm")

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -6004,6 +6004,59 @@ def test_live_event_pipeline_records_candle_remote_fetch_only_with_monitor_sink(
     assert bot._live_event_pipeline_records_candle_remote_fetch() is False
 
 
+def test_startup_observer_failure_logs_redact_hostile_exception_metadata(caplog, capsys):
+    import passivbot as pb_mod
+
+    secret = "https://hostile.example.invalid/v1/orders?api_key=startup-secret&token=observer-token"
+    unsafe_type = type("ApiKeyStartupObserverFailure", (RuntimeError,), {})
+    error = unsafe_type(secret)
+    cases = (
+        (
+            logging.ERROR,
+            "monitor",
+            "failed to initialize monitor publisher",
+            "continue_without_monitor_publisher",
+        ),
+        (
+            logging.WARNING,
+            "monitor",
+            "live event pipeline disabled",
+            "continue_without_live_event_pipeline",
+        ),
+        (
+            logging.WARNING,
+            "event",
+            "live event pipeline disabled",
+            "continue_without_live_event_pipeline",
+        ),
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        for level, tag, message, action in cases:
+            pb_mod._log_startup_observer_failure(level, tag, message, action, error)
+
+    captured = capsys.readouterr()
+    messages = [record.getMessage() for record in caplog.records]
+    complete_output = "\n".join((caplog.text, captured.out, captured.err))
+    expected_records = [
+        (
+            level,
+            f"[{tag}] {message} | error_type=RuntimeError action={action}",
+        )
+        for level, tag, message, action in cases
+    ]
+
+    assert [
+        (record.levelno, message) for record, message in zip(caplog.records, messages)
+    ] == expected_records
+    assert secret not in complete_output
+    assert unsafe_type.__name__ not in complete_output
+    assert "hostile.example.invalid" not in complete_output
+    assert "api_key" not in complete_output.lower()
+    assert "token" not in complete_output.lower()
+    assert "Traceback" not in complete_output
+
+
 def test_close_live_event_pipeline_is_best_effort_and_clears_reference():
     import passivbot as pb_mod
 


### PR DESCRIPTION
@codex review

## Scope

Category: observability producer.

Redact startup monitor-publisher construction and live-event-pipeline installation failure diagnostics. They now retain their existing level and monitor/event tag plus a bounded exception type and stable continuation action instead of the caught exception value.

## Behavior

Diagnostic-only. Monitor enablement, publisher construction arguments, pipeline-install conditions, reference assignments, startup continuation, runtime behavior, and trading behavior are unchanged.

Operational action: none.

## Validation

- Full Python test suite passed with the exact current Rust extension.
- Full monitor-focused module and hostile-metadata regression passed.
- `221` Rust tests passed.
- `cargo check --tests` and `cargo fmt --check` passed.
- AI docs, generated live-event registry, documentation tests, Python compilation, and diff checks passed.

## Reviewer Focus

Confirm the three catch sites retain their exact ERROR/WARNING level, monitor/event tag, assignments, and startup continuation while excluding exception messages, unsafe class metadata, URLs, credentials, tokens, and tracebacks.