### PR TITLE
Redact candle observer diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Candle disk-load and persistence observer diagnostics now retain only code-owned stages, bounded
+  exception types, and stable control-flow actions. Monitor persistence and cache-flush reporting
+  remain independently best-effort; callback ordering, throttling, completed disk persistence/load
+  behavior, event schemas, and trading behavior are unchanged.
+
 - Startup monitor-publisher and live-event-pipeline installation diagnostics now retain bounded
   exception types and stable continuation actions without exception messages, unsafe class names,
   URLs, credentials, tokens, or tracebacks. Monitor enablement, pipeline installation, startup

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -79,6 +79,16 @@ they never retain exception messages, unsafe class names, URLs, credentials, tok
 Their monitor-enabled behavior, pipeline-install condition, assignments, startup continuation, and
 all runtime and trading behavior remain unchanged.
 
+## Candle Persistence Observer Diagnostics
+
+Candle disk-load and persisted-batch observer diagnostics retain only their code-owned stage, a
+bounded exception type, and stable control-flow action: `return_from_cache_load_observer`,
+`continue_to_cache_flush_observer`, `return_from_persist_observer`, or
+`return_from_cache_flush_observer`. They never retain exception messages, unsafe class names, URLs,
+credentials, tokens, or tracebacks. Monitor persistence and cache-flush reporting remain
+independently best-effort; redaction does not change callback placement, throttling, suppression,
+completed disk persistence/load behavior, event schemas, or trading behavior.
+
 ## Market Snapshot Diagnostic Skips
 
 `market.snapshot_diagnostic_skipped` records noncritical position-change and balance diagnostics

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -6790,7 +6790,11 @@ class Passivbot:
             last_by_key[key] = now
             self._emit_cache_load_completed_event(data)
         except Exception as exc:
-            logging.debug("[event] failed handling cache load event: %s", exc)
+            logging.debug(
+                "[event] failed handling cache load event | "
+                "error_type=%s action=return_from_cache_load_observer",
+                bounded_exception_type(exc),
+            )
 
     def _handle_candle_persist_event(
         self,
@@ -6801,11 +6805,19 @@ class Passivbot:
         try:
             self._monitor_handle_candlestick_persist(symbol, timeframe, batch)
         except Exception as exc:
-            logging.debug("[monitor] failed handling candlestick persist: %s", exc)
+            logging.debug(
+                "[monitor] failed handling candlestick persist | "
+                "error_type=%s action=continue_to_cache_flush_observer",
+                bounded_exception_type(exc),
+            )
         try:
             self._handle_candle_cache_flush_event(symbol, timeframe, batch)
         except Exception as exc:
-            logging.debug("[event] failed handling cache flush event: %s", exc)
+            logging.debug(
+                "[event] failed handling cache flush event | "
+                "error_type=%s action=return_from_persist_observer",
+                bounded_exception_type(exc),
+            )
 
     def _handle_candle_cache_flush_event(
         self,
@@ -6876,7 +6888,11 @@ class Passivbot:
             last_by_key[key] = now
             self._emit_cache_flush_completed_event(data)
         except Exception as exc:
-            logging.debug("[event] failed handling cache flush event: %s", exc)
+            logging.debug(
+                "[event] failed handling cache flush event | "
+                "error_type=%s action=return_from_cache_flush_observer",
+                bounded_exception_type(exc),
+            )
 
     def _install_live_event_pipeline(self) -> Optional[LiveEventPipeline]:
         publisher = getattr(self, "monitor_publisher", None)

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -3399,6 +3399,100 @@ def test_candle_persist_handler_preserves_monitor_and_emits_flush_summary():
     ]
 
 
+def test_candle_observer_failures_redact_hostile_exceptions_and_keep_flush_independent(
+    caplog, capsys
+):
+    import passivbot as pb_mod
+
+    secret = "https://hostile.example.invalid/candles?api_key=observer-secret&token=observer-token"
+    unsafe_type = type("ApiKeyCandleObserverFailure", (RuntimeError,), {})
+    error = unsafe_type(secret)
+
+    class FakeBot:
+        _handle_candle_disk_load_event = (
+            pb_mod.Passivbot._handle_candle_disk_load_event
+        )
+        _handle_candle_persist_event = pb_mod.Passivbot._handle_candle_persist_event
+        _handle_candle_cache_flush_event = (
+            pb_mod.Passivbot._handle_candle_cache_flush_event
+        )
+
+        def __init__(self):
+            self._cache_load_event_throttle_seconds = 0.0
+            self._cache_flush_event_throttle_seconds = 0.0
+            self.flush_events = []
+            self.monitor_calls = 0
+
+        def _emit_cache_load_completed_event(self, _payload):
+            raise error
+
+        def _monitor_handle_candlestick_persist(self, _symbol, _timeframe, _batch):
+            self.monitor_calls += 1
+            if self.monitor_calls == 1:
+                raise error
+
+        def _emit_cache_flush_completed_event(self, payload):
+            self.flush_events.append(dict(payload))
+
+    bot = FakeBot()
+    batch = np.array(
+        [(60_000, 1.0, 2.0, 0.5, 1.5, 10.0)], dtype=pb_mod.CANDLE_DTYPE
+    )
+
+    def fail_cache_flush_handoff(*_args):
+        raise error
+
+    def fail_cache_flush_emission(_payload):
+        raise error
+
+    with caplog.at_level(logging.DEBUG):
+        bot._handle_candle_disk_load_event(
+            {
+                "symbol": "BTC/USDT:USDT",
+                "timeframe": "1m",
+                "loaded_rows": 1,
+            }
+        )
+        bot._handle_candle_persist_event("BTC/USDT:USDT", "1m", batch)
+        bot._handle_candle_cache_flush_event = fail_cache_flush_handoff
+        bot._handle_candle_persist_event("BTC/USDT:USDT", "1m", batch)
+        bot._emit_cache_flush_completed_event = fail_cache_flush_emission
+        pb_mod.Passivbot._handle_candle_cache_flush_event(
+            bot, "BTC/USDT:USDT", "1m", batch
+        )
+
+    captured = capsys.readouterr()
+    messages = [record.getMessage() for record in caplog.records]
+    complete_output = "\n".join((caplog.text, captured.out, captured.err))
+
+    assert messages == [
+        "[event] failed handling cache load event | "
+        "error_type=RuntimeError action=return_from_cache_load_observer",
+        "[monitor] failed handling candlestick persist | "
+        "error_type=RuntimeError action=continue_to_cache_flush_observer",
+        "[event] failed handling cache flush event | "
+        "error_type=RuntimeError action=return_from_persist_observer",
+        "[event] failed handling cache flush event | "
+        "error_type=RuntimeError action=return_from_cache_flush_observer",
+    ]
+    assert bot.flush_events == [
+        {
+            "symbol": "BTC/USDT:USDT",
+            "timeframe": "1m",
+            "persisted_rows": 1,
+            "persisted_start_ts": 60_000,
+            "persisted_end_ts": 60_000,
+        }
+    ]
+    assert bot.monitor_calls == 2
+    assert secret not in complete_output
+    assert unsafe_type.__name__ not in complete_output
+    assert "hostile.example.invalid" not in complete_output
+    assert "api_key" not in complete_output.lower()
+    assert "token" not in complete_output.lower()
+    assert "Traceback" not in complete_output
+
+
 def test_forager_and_ema_summary_emitters_are_best_effort_on_malformed_inputs(caplog):
     import passivbot as pb_mod
 


### PR DESCRIPTION
@codex review

## Scope

Category: observability producer.

Redact candle disk-load, monitor-persistence, persist-to-cache-flush, and cache-flush observer failure diagnostics. They now retain only code-owned stages, bounded exception types, and stable control-flow actions instead of caught exception values.

## Behavior

Diagnostic-only. DEBUG levels and monitor/event tags, callback placement, separate failure boundaries, throttle and suppression ordering, monitor/cache-flush independence, completed disk persistence/load behavior, event schemas, runtime behavior, and trading behavior are unchanged.

Operational action: none.

## Validation

- Full Python test suite passed with the exact current Rust extension.
- Full monitor-focused module and hostile-metadata regression passed.
- `221` Rust tests passed.
- `cargo check --tests` and `cargo fmt --check` passed.
- AI docs, generated live-event registry, documentation tests, Python compilation, and diff checks passed.

## Reviewer Focus

Confirm all four failure boundaries retain their exact DEBUG tags and control flow, especially that monitor persistence failure still allows cache-flush reporting, while exception messages, unsafe class metadata, URLs, credentials, tokens, and tracebacks are excluded.