### PR TITLE
Redact open-orders fallback diagnostic

### DIFF
--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -7699,7 +7699,8 @@ class Passivbot:
                 emitted = emit_delta(direction=direction, order_count=order_count)
             except Exception as exc:
                 logging.debug(
-                    "[event] failed to emit open-orders snapshot delta: %s", exc
+                    "[event] failed to emit open-orders snapshot delta: %s",
+                    bounded_exception_type(exc),
                 )
         if emitted is None:
             structured_console_available = False

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -10897,6 +10897,34 @@ async def test_open_orders_snapshot_delta_uses_strictly_greater_than_twenty_thre
     assert len(logged_orders) == 20
 
 
+def test_open_orders_snapshot_delta_emitter_failure_is_bounded_and_keeps_fallback(caplog):
+    bot = _make_open_order_guardrail_bot()
+
+    def fail_emit_delta(**_kwargs):
+        raise RuntimeError(
+            "request=https://hostile.example.invalid/api?api_key=secret "
+            "authorization=Bearer token-123"
+        )
+
+    bot._emit_open_orders_snapshot_delta_event = fail_emit_delta
+
+    with caplog.at_level(logging.DEBUG):
+        bot._log_open_orders_snapshot_delta(direction="added", order_count=21)
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert "[event] failed to emit open-orders snapshot delta: RuntimeError" in messages
+    assert "[order] added 21 orders" in messages
+    output = "\n".join(messages)
+    for unsafe_value in (
+        "hostile.example.invalid",
+        "api_key",
+        "secret",
+        "authorization",
+        "token-123",
+    ):
+        assert unsafe_value not in output
+
+
 @pytest.mark.asyncio
 async def test_open_orders_snapshot_delta_console_sink_failure_does_not_change_reconciliation():
     class FailingConsoleSink:


### PR DESCRIPTION
@codex review

## Scope

Category: observability producer.

Redact the defensive open-orders snapshot-delta emitter failure diagnostic so it retains only a bounded exception type instead of the caught exception value.

## Behavior

Diagnostic-only. The DEBUG level and `[event]` tag, strictly-greater-than-20 threshold, structured event payload, failure boundary, and legacy `[order]` INFO fallback are unchanged. Reconciliation, guardrails, confirmations, balance handling, follow-up refreshes, and trading behavior are unchanged.

## Validation

- Full Python test suite passed with the exact current Rust extension.
- Seven focused open-orders snapshot-delta tests passed.
- `221` Rust tests passed.
- `cargo check --tests`, `cargo fmt --check`, Python compilation, extension fingerprint, and diff checks passed.

## Reviewer Focus

Confirm emitter failure still falls through to exactly one legacy INFO fallback while the DEBUG diagnostic excludes exception messages, URLs, credentials, tokens, and other arbitrary metadata.