### PR TITLE
Redact config refresh failure events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Exchange-configuration refresh failure events now retain bounded exception types instead of
+  exception text. Periodic and connector-local payloads continue to preserve their existing
+  outcome and response metadata, best-effort delivery, and configuration control flow.
+
 - Candle disk-load and persistence observer diagnostics now retain only code-owned stages, bounded
   exception types, and stable control-flow actions. Monitor persistence and cache-flush reporting
   remain independently best-effort; callback ordering, throttling, completed disk persistence/load

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -404,13 +404,14 @@ and distinguish the observed result in `data.outcome`:
 - `unchanged`: the exchange explicitly reported that the requested setting already matched
 - `failed`: the request raised or returned a connector-classified failure
 
-Connector-local payloads include only bounded `context`, `operation`, `outcome`, optional
-digit-only `response_code`, `error_type`, and the envelope's `symbol`. They exclude raw responses, exception
-text, request parameters, URLs, and tracebacks. An explicit unchanged outcome is DEBUG; confirmed
-success remains INFO until the connector can prove whether it changed state; failures retain their
-existing operator-visible warning or error. The event route remains structured/monitor-only, and
-event emission failure must log only a bounded exception type, preserve exchange configuration
-control flow and results, and never replace an original configuration exception.
+Periodic and connector-local failure payloads include only bounded `context`, `operation`,
+`outcome`, optional digit-only `response_code`, `error_type`, and the envelope's `symbol`. They
+omit raw responses, exception text, request parameters, URLs, and tracebacks. An explicit
+unchanged outcome is DEBUG; confirmed success remains INFO until the connector can prove whether
+it changed state; failures retain their existing operator-visible warning or error. The event route
+remains structured/monitor-only, and event emission failure must log only a bounded exception type,
+preserve exchange configuration control flow and results, and never replace an original
+configuration exception.
 
 ## WebSocket Reconnect Diagnostics
 

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -404,14 +404,15 @@ and distinguish the observed result in `data.outcome`:
 - `unchanged`: the exchange explicitly reported that the requested setting already matched
 - `failed`: the request raised or returned a connector-classified failure
 
-Periodic and connector-local failure payloads include only bounded `context`, `operation`,
-`outcome`, optional digit-only `response_code`, `error_type`, and the envelope's `symbol`. They
-omit raw responses, exception text, request parameters, URLs, and tracebacks. An explicit
-unchanged outcome is DEBUG; confirmed success remains INFO until the connector can prove whether
-it changed state; failures retain their existing operator-visible warning or error. The event route
-remains structured/monitor-only, and event emission failure must log only a bounded exception type,
-preserve exchange configuration control flow and results, and never replace an original
-configuration exception.
+Failure payloads include only bounded `context`, `operation`, `outcome`, optional digit-only
+`response_code`, `error_type`, and the envelope's `symbol`. Periodic refresh records may also
+include `started_ms` and `elapsed_ms`; current connector-local per-symbol outcomes do not supply
+those timing fields. These payloads omit raw responses, exception text, request parameters, URLs,
+and tracebacks. An explicit unchanged outcome is DEBUG; confirmed success remains INFO until the
+connector can prove whether it changed state; failures retain their existing operator-visible
+warning or error. The event route remains structured/monitor-only, and event emission failure must
+log only a bounded exception type, preserve exchange configuration control flow and results, and
+never replace an original configuration exception.
 
 ## WebSocket Reconnect Diagnostics
 

--- a/src/exchanges/okx.py
+++ b/src/exchanges/okx.py
@@ -1,5 +1,6 @@
 from exchanges.ccxt_bot import CCXTBot, format_exchange_config_response
 from live.balance_composition import normalize_okx_balance_composition
+from live.diagnostic_safety import bounded_exception_type
 from passivbot import logging
 import passivbot_rust as pbr
 
@@ -280,13 +281,13 @@ class OKXBot(CCXTBot):
                 symbol=symbol,
                 outcome=outcome,
                 response_code=response_code,
-                error_type=type(error).__name__ if error is not None else None,
+                error=error,
                 level=level,
             )
         except Exception as exc:
             logging.debug(
                 "[event] failed to emit OKX exchange config-refresh outcome | error_type=%s",
-                type(exc).__name__,
+                bounded_exception_type(exc),
             )
 
     async def update_exchange_config_by_symbols(self, symbols: [str]):

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -956,8 +956,7 @@ def _emit_exchange_config_refresh_event_unchecked(
         ),
     }
     if error is not None:
-        data["error_type"] = type(error).__name__
-        data["error"] = _sanitize_remote_text(error, max_len=500)
+        data["error_type"] = _bounded_exception_type(error)
     elif error_type is not None:
         data["error_type"] = _bounded_exchange_config_event_field(
             error_type, _EXCHANGE_CONFIG_EVENT_ERROR_TYPE_RE

--- a/tests/test_exchange_config_refresh_event.py
+++ b/tests/test_exchange_config_refresh_event.py
@@ -64,10 +64,18 @@ async def test_maintenance_exchange_config_refresh_success_emits_event():
 @pytest.mark.asyncio
 async def test_maintenance_exchange_config_refresh_failure_is_sanitized_and_reraised():
     bot, sink = _make_bot_with_event_sink()
-    exc = RuntimeError("binanceusdm apiKey=supersecret code=-4084")
+    hostile_error_type = type(
+        "HostileTokenClass",
+        (RuntimeError,),
+        {"__module__": "hostile.example.invalid"},
+    )
+    exc = hostile_error_type(
+        "credential=supersecret token=event-token "
+        "https://example.invalid/config Traceback: hostile-message"
+    )
     bot.init_markets = AsyncMock(side_effect=exc)
 
-    with pytest.raises(RuntimeError) as raised:
+    with pytest.raises(hostile_error_type) as raised:
         await bot._refresh_markets_for_maintenance()
 
     assert raised.value is exc
@@ -80,8 +88,18 @@ async def test_maintenance_exchange_config_refresh_failure_is_sanitized_and_rera
     assert event.level == "warning"
     assert event.reason_code == ReasonCodes.EXCHANGE_CONFIG_REFRESH_FAILED
     assert event.data["error_type"] == "RuntimeError"
-    assert "supersecret" not in event.data["error"]
-    assert "[redacted]" in event.data["error"]
+    assert "error" not in event.data
+    event_repr = repr(event)
+    for unsafe_value in (
+        "HostileTokenClass",
+        "hostile-message",
+        "example.invalid",
+        "credential",
+        "supersecret",
+        "event-token",
+        "Traceback",
+    ):
+        assert unsafe_value not in event_repr
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 

--- a/tests/test_okx_exchange_config.py
+++ b/tests/test_okx_exchange_config.py
@@ -17,6 +17,8 @@ sys.modules.setdefault(
 )
 
 from exchanges.okx import OKXBot
+from live.event_bus import EventTypes
+from live.event_emitters import emit_exchange_config_refresh_event
 
 
 SYMBOL = "BTC/USDT:USDT"
@@ -54,7 +56,7 @@ async def test_okx_margin_response_emits_confirmed_outcome_and_keeps_info_log(ca
         "symbol": SYMBOL,
         "outcome": "confirmed",
         "response_code": None,
-        "error_type": None,
+        "error": None,
         "level": "info",
     }
     assert "margin=ok" in caplog.text
@@ -78,7 +80,7 @@ async def test_okx_59107_emits_unchanged_debug_outcome_and_demotes_legacy_log(ca
         "symbol": SYMBOL,
         "outcome": "unchanged",
         "response_code": "59107",
-        "error_type": None,
+        "error": None,
         "level": "debug",
     }
     record = next(record for record in caplog.records if "margin=ok (unchanged)" in record.message)
@@ -88,8 +90,9 @@ async def test_okx_59107_emits_unchanged_debug_outcome_and_demotes_legacy_log(ca
 
 @pytest.mark.asyncio
 async def test_okx_51039_emits_warning_failure_outcome_and_continues(caplog):
+    exc = RuntimeError('{"code":"51039","apiKey":"SECRET"}')
     cca = types.SimpleNamespace(
-        set_margin_mode=AsyncMock(side_effect=RuntimeError('{"code":"51039","apiKey":"SECRET"}'))
+        set_margin_mode=AsyncMock(side_effect=exc)
     )
     bot = _make_bot(cca)
 
@@ -103,7 +106,7 @@ async def test_okx_51039_emits_warning_failure_outcome_and_continues(caplog):
         "symbol": SYMBOL,
         "outcome": "failed",
         "response_code": "51039",
-        "error_type": "RuntimeError",
+        "error": exc,
         "level": "warning",
     }
     assert "unable to adjust margin mode/leverage" in caplog.text
@@ -112,10 +115,9 @@ async def test_okx_51039_emits_warning_failure_outcome_and_continues(caplog):
 
 @pytest.mark.asyncio
 async def test_okx_generic_failure_emits_bounded_error_outcome(caplog):
+    exc = RuntimeError("https://example.invalid/api?apiKey=SECRET")
     cca = types.SimpleNamespace(
-        set_margin_mode=AsyncMock(
-            side_effect=RuntimeError("https://example.invalid/api?apiKey=SECRET")
-        )
+        set_margin_mode=AsyncMock(side_effect=exc)
     )
     bot = _make_bot(cca)
 
@@ -129,12 +131,88 @@ async def test_okx_generic_failure_emits_bounded_error_outcome(caplog):
         "symbol": SYMBOL,
         "outcome": "failed",
         "response_code": None,
-        "error_type": "RuntimeError",
+        "error": exc,
         "level": "error",
     }
     assert "cross-margin update failed" in caplog.text
     assert "error_type=RuntimeError" in caplog.text
     assert "SECRET" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_okx_hostile_failure_event_uses_bounded_exception_projection(caplog):
+    hostile_error_type = type(
+        "HostileTokenClass",
+        (RuntimeError,),
+        {"__module__": "hostile.example.invalid"},
+    )
+    exc = hostile_error_type(
+        "credential=supersecret token=event-token "
+        "https://example.invalid/config Traceback: hostile-message"
+    )
+    cca = types.SimpleNamespace(set_margin_mode=AsyncMock(side_effect=exc))
+    bot = _make_bot(cca)
+    bot._emit_live_event = Mock()
+    bot._emit_exchange_config_refresh_event = lambda **kwargs: (
+        emit_exchange_config_refresh_event(bot, **kwargs)
+    )
+
+    with caplog.at_level(logging.ERROR):
+        await bot.update_exchange_config_by_symbols([SYMBOL])
+
+    bot._emit_live_event.assert_called_once()
+    event_type, = bot._emit_live_event.call_args.args
+    event_kwargs = bot._emit_live_event.call_args.kwargs
+    assert event_type == EventTypes.EXCHANGE_CONFIG_REFRESH
+    assert event_kwargs["data"]["error_type"] == "RuntimeError"
+    event_repr = repr(event_kwargs)
+    for unsafe_value in (
+        "HostileTokenClass",
+        "hostile-message",
+        "example.invalid",
+        "credential",
+        "supersecret",
+        "event-token",
+        "Traceback",
+    ):
+        assert unsafe_value not in event_repr
+    assert "cross-margin update failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_okx_hostile_event_failure_logs_bounded_type_and_preserves_success(caplog):
+    hostile_error_type = type(
+        "HostileTokenClass",
+        (RuntimeError,),
+        {"__module__": "hostile.example.invalid"},
+    )
+    emitter_error = hostile_error_type(
+        "credential=supersecret token=event-token "
+        "https://example.invalid/config Traceback: hostile-message"
+    )
+    cca = types.SimpleNamespace(set_margin_mode=AsyncMock(return_value={"code": "0"}))
+    bot = _make_bot(cca, emitter=Mock(side_effect=emitter_error))
+
+    with caplog.at_level(logging.DEBUG):
+        await bot.update_exchange_config_by_symbols([SYMBOL])
+
+    assert any(
+        record.getMessage()
+        == "[event] failed to emit OKX exchange config-refresh outcome | "
+        "error_type=RuntimeError"
+        for record in caplog.records
+    )
+    assert "margin=ok" in caplog.text
+    for unsafe_value in (
+        "HostileTokenClass",
+        "hostile-message",
+        "example.invalid",
+        "credential",
+        "supersecret",
+        "event-token",
+        "Traceback",
+    ):
+        assert unsafe_value not in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
@codex review

## Scope

Category: structured observability producer.

Remove persisted exception text from failed `exchange.config_refresh` events. Failure payloads now retain only a bounded exception type alongside their existing bounded configuration metadata.

## Behavior

Diagnostic-only. Event status, level, reason, context, operation, timing, outcome, response code, symbol, routing, and best-effort isolation are unchanged. Periodic refreshes still re-raise the exact original exception; connector configuration control flow and trading behavior are unchanged.

## Validation

- Full Python test suite passed with the exact current Rust extension.
- Eleven focused periodic and connector configuration tests passed.
- `221` Rust tests passed.
- `cargo check --tests`, `cargo fmt --check`, AI docs, generated registry, documentation tests, Python compilation, extension fingerprint, and diff checks passed.

## Reviewer Focus

Confirm failed refresh events omit exception text and unsafe class metadata while retaining a bounded exception type, and confirm the original refresh exception identity and all configuration control flow remain unchanged.