### PR TITLE
Redact execution order failure events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Terminal and ambiguous execution-order events now retain bounded exception types instead of
+  persisted exception text. Existing envelope correlation, result summaries, debug profiles,
+  routing, executor behavior, exchange calls, and trading behavior are unchanged.
+
 - Exchange-configuration refresh failure events now retain bounded exception types instead of
   exception text. Periodic and connector-local payloads continue to preserve their existing
   outcome and response metadata, best-effort delivery, and configuration control flow.

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -360,6 +360,15 @@ The fixed fields are `action=create|cancel`,
 `connector_route=base|hyperliquid|okx`. Normal plan calls retain cycle, `order_wave_id`, and
 `action_id` correlation.
 
+## Terminal Execution Outcomes
+
+Terminal and ambiguous execution-order outcome events retain their existing envelope correlation,
+status, reason, action, bounded order metadata, result summaries, and optional bounded debug
+profiles. When an outcome carries an exception object or result, its payload retains only a bounded
+`error_type`; it omits exception text, unsafe exception class metadata, URLs, credentials, tokens,
+raw responses, and tracebacks. This diagnostic redaction does not alter event routing, emitter
+isolation, executor retries or re-raises, exchange calls, or trading behavior.
+
 ## HSL Replay Timing
 
 For coin-mode `hsl.replay.completed`, `full_elapsed_s` is total replay time;

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -4447,8 +4447,7 @@ def emit_execution_order_event(
         elif isinstance(result, BaseException):
             error = result
         if error is not None:
-            data["error_type"] = type(error).__name__
-            data["error"] = _sanitize_remote_text(error, max_len=500)
+            data["error_type"] = _bounded_exception_type(error)
         if extra:
             data.update(extra)
         _add_execution_debug_profile(

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -495,7 +495,7 @@ def _execution_debug_payload(
         if result.get("status") is not None:
             debug["result_status"] = str(result.get("status"))
     elif isinstance(result, BaseException):
-        debug["result_error_type"] = type(result).__name__
+        debug["result_error_type"] = _bounded_exception_type(result)
     if isinstance(extra, dict):
         debug["extra_keys"] = _mapping_key_sample(extra, limit=limit)
     if isinstance(wave, dict):

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -5388,6 +5388,80 @@ def test_execution_debug_profile_adds_bounded_order_write_shape():
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_execution_failure_event_redacts_hostile_exception_metadata():
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_execution_order_event = pb_mod.Passivbot._emit_execution_order_event
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+
+        def __init__(self):
+            self.exchange = "okx"
+            self.user = "okx_01"
+            self.bot_id = "bot_1"
+            self._live_event_current_cycle_id = "cy_execution_failure"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    hostile_type_name = "HostileTokenClass"
+    HostileError = type(hostile_type_name, (RuntimeError,), {})
+    hostile_value = (
+        "request https://hostile.example.invalid/orders?api_key=LEAKED "
+        "token=LEAKED\\nTraceback (most recent call last): SECRET"
+    )
+    bot = FakeBot()
+    order = {
+        "symbol": "BTC/USDT:USDT",
+        "side": "buy",
+        "position_side": "long",
+        "type": "limit",
+        "pb_order_type": "entry_grid_normal_long",
+        "qty": 0.01,
+        "price": 100000.0,
+        "reduce_only": False,
+        "custom_id": "cid-execution-failure-123",
+    }
+
+    bot._emit_execution_order_event(
+        event_type=EventTypes.EXECUTION_CREATE_FAILED,
+        order=order,
+        action="create",
+        status="failed",
+        reason_code=ReasonCodes.EXCHANGE_EXCEPTION,
+        level="warning",
+        index=2,
+        wave={"id": 23, "event_id": "ow_23"},
+        result=HostileError(hostile_value),
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    event = sink.events[-1]
+    assert event.event_type == EventTypes.EXECUTION_CREATE_FAILED
+    assert event.status == "failed"
+    assert event.reason_code == ReasonCodes.EXCHANGE_EXCEPTION
+    assert event.order_wave_id == "ow_23"
+    assert event.action_id == "ow_23:create:2"
+    assert event.tags == ("execution", "order", "create")
+    assert event.symbol == "BTC/USDT:USDT"
+    assert event.pside == "long"
+    assert event.side == "buy"
+    assert event.client_order_id == "cid-execution-failure-123"
+    assert event.data["error_type"] == "RuntimeError"
+    assert "error" not in event.data
+    rendered = json.dumps(event.to_dict(), sort_keys=True)
+    assert hostile_type_name not in rendered
+    assert hostile_value not in rendered
+    assert "hostile.example.invalid" not in rendered
+    assert "LEAKED" not in rendered
+    assert "Traceback" not in rendered
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_connector_call_event_is_bounded_and_correlated_to_batch_action():
     import passivbot as pb_mod
 

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -5402,6 +5402,7 @@ def test_execution_failure_event_redacts_hostile_exception_metadata():
             self.exchange = "okx"
             self.user = "okx_01"
             self.bot_id = "bot_1"
+            self.live_event_debug_profiles = ("execution",)
             self._live_event_current_cycle_id = "cy_execution_failure"
             self._live_event_pipeline = LiveEventPipeline(
                 structured_sinks=[sink],
@@ -5438,22 +5439,49 @@ def test_execution_failure_event_redacts_hostile_exception_metadata():
         wave={"id": 23, "event_id": "ow_23"},
         result=HostileError(hostile_value),
     )
+    bot._emit_execution_order_event(
+        event_type=EventTypes.EXECUTION_CANCEL_FAILED,
+        order=order,
+        action="cancel",
+        status="failed",
+        reason_code=ReasonCodes.EXCHANGE_EXCEPTION,
+        level="warning",
+        index=3,
+        wave={"id": 24, "event_id": "ow_24"},
+        error=HostileError(hostile_value),
+    )
 
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
-    event = sink.events[-1]
-    assert event.event_type == EventTypes.EXECUTION_CREATE_FAILED
-    assert event.status == "failed"
-    assert event.reason_code == ReasonCodes.EXCHANGE_EXCEPTION
-    assert event.order_wave_id == "ow_23"
-    assert event.action_id == "ow_23:create:2"
-    assert event.tags == ("execution", "order", "create")
-    assert event.symbol == "BTC/USDT:USDT"
-    assert event.pside == "long"
-    assert event.side == "buy"
-    assert event.client_order_id == "cid-execution-failure-123"
-    assert event.data["error_type"] == "RuntimeError"
-    assert "error" not in event.data
-    rendered = json.dumps(event.to_dict(), sort_keys=True)
+    result_event, explicit_error_event = sink.events[-2:]
+    assert result_event.event_type == EventTypes.EXECUTION_CREATE_FAILED
+    assert result_event.status == "failed"
+    assert result_event.reason_code == ReasonCodes.EXCHANGE_EXCEPTION
+    assert result_event.order_wave_id == "ow_23"
+    assert result_event.action_id == "ow_23:create:2"
+    assert result_event.tags == ("execution", "order", "create")
+    assert result_event.symbol == "BTC/USDT:USDT"
+    assert result_event.pside == "long"
+    assert result_event.side == "buy"
+    assert result_event.client_order_id == "cid-execution-failure-123"
+    assert result_event.data["error_type"] == "RuntimeError"
+    assert result_event.data["debug"]["result_error_type"] == "RuntimeError"
+    assert "error" not in result_event.data
+    assert explicit_error_event.event_type == EventTypes.EXECUTION_CANCEL_FAILED
+    assert explicit_error_event.status == "failed"
+    assert explicit_error_event.reason_code == ReasonCodes.EXCHANGE_EXCEPTION
+    assert explicit_error_event.order_wave_id == "ow_24"
+    assert explicit_error_event.action_id == "ow_24:cancel:3"
+    assert explicit_error_event.tags == ("execution", "order", "cancel")
+    assert explicit_error_event.symbol == "BTC/USDT:USDT"
+    assert explicit_error_event.pside == "long"
+    assert explicit_error_event.side == "buy"
+    assert explicit_error_event.client_order_id == "cid-execution-failure-123"
+    assert explicit_error_event.data["error_type"] == "RuntimeError"
+    assert "error" not in explicit_error_event.data
+    rendered = "\n".join(
+        json.dumps(event.to_dict(), sort_keys=True)
+        for event in (result_event, explicit_error_event)
+    )
     assert hostile_type_name not in rendered
     assert hostile_value not in rendered
     assert "hostile.example.invalid" not in rendered


### PR DESCRIPTION
@codex review

## Scope

Category: structured observability producer.

Remove persisted exception text from terminal and ambiguous execution-order events. Exception-bearing payloads now retain only a bounded exception type.

## Behavior

Diagnostic-only. Event types, status and reason codes, envelope correlation, bounded order metadata, result summaries, optional debug profiles, routing, and emitter isolation are unchanged. Executor retries and re-raises, exchange calls, and trading behavior are unchanged.

## Validation

- Full Python test suite passed with the exact current Rust extension.
- Focused execution debug-profile and hostile-metadata regressions passed.
- `221` Rust tests passed.
- `cargo check --tests`, `cargo fmt --check`, AI docs, generated registry, documentation tests, Python compilation, extension fingerprint, and diff checks passed.

## Reviewer Focus

Confirm exception-bearing create/cancel outcome events retain bounded types without exception text or unsafe class metadata while preserving action/wave/order correlation, result shaping, routing, and executor control flow.