### PR TITLE
Redact executor admission diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Executor churn-admission and fresh-entry eligibility diagnostics now retain bounded exception
+  types only. Existing admission/defer reasons, batch limits, fail-closed behavior, trace handling,
+  event delivery isolation, scheduling, and trading behavior are unchanged.
+
 - Ambiguous create diagnostics now retain bounded exception types only. Existing ambiguous
   bookkeeping, restart behavior, acknowledgement handling, event emission, and trading behavior
   are unchanged.

--- a/src/live/executor.py
+++ b/src/live/executor.py
@@ -272,7 +272,7 @@ async def _apply_order_churn_final_admission(
             except Exception as exc:
                 logging.debug(
                     "[event] order churn admission emitter failed | error_type=%s",
-                    type(exc).__name__,
+                    bounded_exception_type(exc),
                 )
         return selected
     window_seconds = (
@@ -306,7 +306,7 @@ async def _apply_order_churn_final_admission(
         except Exception as exc:
             logging.warning(
                 "[order] fresh market data unavailable for churn-gate final admission | error_type=%s",
-                type(exc).__name__,
+                bounded_exception_type(exc),
             )
             market_prices = {}
     admission: dict[int, tuple[str, bool]] = {}
@@ -390,7 +390,7 @@ async def _apply_order_churn_final_admission(
                     action_headroom = None
                     logging.warning(
                         "[order] connector churn headroom unavailable | error_type=%s",
-                        type(exc).__name__,
+                        bounded_exception_type(exc),
                     )
             if action_headroom is None:
                 deferred.append(order)
@@ -535,7 +535,7 @@ async def _apply_order_churn_final_admission(
         except Exception as exc:
             logging.debug(
                 "[event] order churn admission emitter failed | error_type=%s",
-                type(exc).__name__,
+                bounded_exception_type(exc),
             )
     return selected
 
@@ -564,7 +564,7 @@ def _record_fresh_entry_orders(
             "[entry] fresh-entry eligibility trace disabled during execution | "
             "method=%s error_type=%s",
             method,
-            type(exc).__name__,
+            bounded_exception_type(exc),
         )
 
 
@@ -579,7 +579,7 @@ def _emit_fresh_entry_eligibility(bot, passivbot_cls, wave) -> None:
     except Exception as exc:
         logging.debug(
             "[entry] fresh-entry eligibility payload build failed | error_type=%s",
-            type(exc).__name__,
+            bounded_exception_type(exc),
         )
         return
     try:
@@ -587,7 +587,7 @@ def _emit_fresh_entry_eligibility(bot, passivbot_cls, wave) -> None:
     except Exception as exc:
         logging.debug(
             "[entry] fresh-entry eligibility event emission failed | error_type=%s",
-            type(exc).__name__,
+            bounded_exception_type(exc),
         )
 
 

--- a/tests/test_fresh_entry_eligibility_integration.py
+++ b/tests/test_fresh_entry_eligibility_integration.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 from live import event_emitters, executor, market_data, reconciler
@@ -276,6 +278,129 @@ async def test_final_batch_cap_classifies_eligible_and_blocked_without_changing_
     assert records[second["symbol"]]["outcome"] == "blocked_candidate"
     assert records[second["symbol"]]["reason_counts"] == {"batch_capacity": 1}
     assert bot._fresh_entry_eligibility_trace is None
+
+
+def test_fresh_entry_trace_recorder_diagnostic_bounds_hostile_exception_type(caplog):
+    hostile_name = "TokenFreshEntryTraceRecorderFailure"
+    secret = "https://hostile.example.invalid/entry?token=trace-secret"
+    HostileError = type(hostile_name, (RuntimeError,), {})
+    order = _initial("BTC/USDT:USDT")
+
+    class FailingTrace(FreshEntryEligibilityTrace):
+        def record_eligible_orders(self, _orders):
+            raise HostileError(secret)
+
+    class Bot:
+        _fresh_entry_eligibility_trace = FailingTrace()
+
+    bot = Bot()
+    with caplog.at_level(logging.DEBUG):
+        executor._record_fresh_entry_orders(bot, "record_eligible_orders", [order])
+
+    assert bot._fresh_entry_eligibility_trace is None
+    records = [
+        record
+        for record in caplog.records
+        if record.getMessage().startswith("[entry] fresh-entry eligibility trace disabled")
+    ]
+    assert [(record.levelno, record.getMessage()) for record in records] == [
+        (
+            logging.DEBUG,
+            "[entry] fresh-entry eligibility trace disabled during execution | "
+            "method=record_eligible_orders error_type=RuntimeError",
+        )
+    ]
+    rendered = "\n".join(record.getMessage() for record in records)
+    assert hostile_name not in rendered
+    assert secret not in rendered
+    assert "hostile.example.invalid" not in rendered
+
+
+def test_fresh_entry_payload_diagnostic_bounds_hostile_exception_type(caplog):
+    hostile_name = "PrivateKeyFreshEntryPayloadFailure"
+    secret = "https://hostile.example.invalid/entry?token=payload-secret"
+    HostileError = type(hostile_name, (RuntimeError,), {})
+
+    class FailingTrace(FreshEntryEligibilityTrace):
+        def to_event_data(self, max_records=32):
+            raise HostileError(secret)
+
+    class Bot:
+        _fresh_entry_eligibility_trace = FailingTrace()
+
+    class Emitter:
+        emitted = []
+
+        @staticmethod
+        def _emit_initial_entry_eligibility_event(*_args, **_kwargs):
+            Emitter.emitted.append(True)
+
+    bot = Bot()
+    with caplog.at_level(logging.DEBUG):
+        executor._emit_fresh_entry_eligibility(bot, Emitter, {"event_id": "ow_1"})
+
+    assert bot._fresh_entry_eligibility_trace is None
+    assert Emitter.emitted == []
+    records = [
+        record
+        for record in caplog.records
+        if record.getMessage().startswith("[entry] fresh-entry eligibility payload build failed")
+    ]
+    assert [(record.levelno, record.getMessage()) for record in records] == [
+        (
+            logging.DEBUG,
+            "[entry] fresh-entry eligibility payload build failed | error_type=RuntimeError",
+        )
+    ]
+    rendered = "\n".join(record.getMessage() for record in records)
+    assert hostile_name not in rendered
+    assert secret not in rendered
+    assert "hostile.example.invalid" not in rendered
+
+
+def test_fresh_entry_event_emission_diagnostic_bounds_hostile_exception_type(caplog):
+    hostile_name = "AuthorizationFreshEntryEmissionFailure"
+    secret = "https://hostile.example.invalid/entry?token=emission-secret"
+    HostileError = type(hostile_name, (RuntimeError,), {})
+    payload = {"records_total": 0, "records": []}
+
+    class Trace(FreshEntryEligibilityTrace):
+        def to_event_data(self, max_records=32):
+            return payload
+
+    class Bot:
+        _fresh_entry_eligibility_trace = Trace()
+
+    class Emitter:
+        emitted = []
+
+        @staticmethod
+        def _emit_initial_entry_eligibility_event(_bot, *, data, wave=None):
+            Emitter.emitted.append((data, wave))
+            raise HostileError(secret)
+
+    bot = Bot()
+    wave = {"event_id": "ow_1"}
+    with caplog.at_level(logging.DEBUG):
+        executor._emit_fresh_entry_eligibility(bot, Emitter, wave)
+
+    assert bot._fresh_entry_eligibility_trace is None
+    assert Emitter.emitted == [(payload, wave)]
+    records = [
+        record
+        for record in caplog.records
+        if record.getMessage().startswith("[entry] fresh-entry eligibility event emission failed")
+    ]
+    assert [(record.levelno, record.getMessage()) for record in records] == [
+        (
+            logging.DEBUG,
+            "[entry] fresh-entry eligibility event emission failed | error_type=RuntimeError",
+        )
+    ]
+    rendered = "\n".join(record.getMessage() for record in records)
+    assert hostile_name not in rendered
+    assert secret not in rendered
+    assert "hostile.example.invalid" not in rendered
 
 
 @pytest.mark.asyncio

--- a/tests/test_order_churn_executor.py
+++ b/tests/test_order_churn_executor.py
@@ -265,6 +265,122 @@ async def test_diagnostic_emitter_failure_cannot_change_admission():
 
 
 @pytest.mark.asyncio
+async def test_churn_admission_emitter_diagnostics_bound_hostile_exception_types(caplog):
+    hostile_name = "AuthorizationChurnAdmissionEmitterFailure"
+    secret = "https://hostile.example.invalid/churn?token=emitter-secret"
+    HostileError = type(hostile_name, (RuntimeError,), {})
+
+    def fail_event(**_kwargs):
+        raise HostileError(secret)
+
+    bot = _Bot()
+    bot._emit_order_churn_admission_event = fail_event
+    stable = _order("stable", price=90.0, churn=False)
+
+    with caplog.at_level(logging.DEBUG):
+        bot.values["order_replacement_churn_gate_activation_count"] = 0
+        assert await _apply_order_churn_final_admission(bot, [stable]) == [stable]
+        assert stable["_churn_gate_reason"] == "disabled"
+
+        bot.values["order_replacement_churn_gate_activation_count"] = 10
+        assert await _apply_order_churn_final_admission(bot, [stable]) == [stable]
+        assert stable["_churn_gate_reason"] == "no_churn_evidence"
+
+    records = [
+        record
+        for record in caplog.records
+        if record.getMessage().startswith("[event] order churn admission emitter failed")
+    ]
+    assert [(record.levelno, record.getMessage()) for record in records] == [
+        (
+            logging.DEBUG,
+            "[event] order churn admission emitter failed | error_type=RuntimeError",
+        ),
+        (
+            logging.DEBUG,
+            "[event] order churn admission emitter failed | error_type=RuntimeError",
+        ),
+    ]
+    rendered = "\n".join(record.getMessage() for record in records)
+    assert hostile_name not in rendered
+    assert secret not in rendered
+    assert "hostile.example.invalid" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_churn_market_data_diagnostic_bounds_hostile_exception_type(caplog):
+    hostile_name = "PrivateKeyChurnMarketDataFailure"
+    secret = "https://hostile.example.invalid/churn?token=market-secret"
+    HostileError = type(hostile_name, (RuntimeError,), {})
+
+    async def fail_market_data(*_args, **_kwargs):
+        raise HostileError(secret)
+
+    bot = _Bot()
+    bot._fetch_fresh_order_churn_market_prices = fail_market_data
+    churn = _order("churn", price=99.0)
+    stable = _order("stable", price=90.0, churn=False)
+
+    with caplog.at_level(logging.DEBUG):
+        admitted = await _apply_order_churn_final_admission(bot, [churn, stable])
+
+    assert admitted == [stable]
+    assert churn["_churn_gate_reason"] == "market_price_unavailable"
+    records = [
+        record
+        for record in caplog.records
+        if record.getMessage().startswith("[order] fresh market data unavailable")
+    ]
+    assert [(record.levelno, record.getMessage()) for record in records] == [
+        (
+            logging.WARNING,
+            "[order] fresh market data unavailable for churn-gate final admission | "
+            "error_type=RuntimeError",
+        )
+    ]
+    rendered = "\n".join(record.getMessage() for record in records)
+    assert hostile_name not in rendered
+    assert secret not in rendered
+    assert "hostile.example.invalid" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_churn_headroom_diagnostic_bounds_hostile_exception_type(caplog):
+    hostile_name = "SecretChurnHeadroomFailure"
+    secret = "https://hostile.example.invalid/churn?token=headroom-secret"
+    HostileError = type(hostile_name, (RuntimeError,), {})
+
+    async def fail_headroom():
+        raise HostileError(secret)
+
+    bot = _Bot()
+    bot._order_churn_far_create_headroom = fail_headroom
+    churn = _order("churn", price=99.0)
+    stable = _order("stable", price=90.0, churn=False)
+
+    with caplog.at_level(logging.DEBUG):
+        admitted = await _apply_order_churn_final_admission(bot, [churn, stable])
+
+    assert admitted == [stable]
+    assert churn["_churn_gate_reason"] == "action_headroom_unavailable"
+    records = [
+        record
+        for record in caplog.records
+        if record.getMessage().startswith("[order] connector churn headroom unavailable")
+    ]
+    assert [(record.levelno, record.getMessage()) for record in records] == [
+        (
+            logging.WARNING,
+            "[order] connector churn headroom unavailable | error_type=RuntimeError",
+        )
+    ]
+    rendered = "\n".join(record.getMessage() for record in records)
+    assert hostile_name not in rendered
+    assert secret not in rendered
+    assert "hostile.example.invalid" not in rendered
+
+
+@pytest.mark.asyncio
 async def test_cancellation_capacity_diagnostics_bound_hostile_exception_types(
     monkeypatch, caplog
 ):


### PR DESCRIPTION
@codex review

## Scope

Category: observability producer.

Bound exception types in order-churn admission diagnostics and fresh-entry eligibility trace diagnostics. Structured event schemas and unrelated executor diagnostics are unchanged.

## Behavior

Diagnostic-only. Existing log levels, tags, messages, fields, admission order and reasons, fail-closed behavior, batch limits, trace reset semantics, event isolation, scheduling, connector calls, and trading behavior are unchanged.

## Validation

- 29 focused admission and eligibility tests passed.
- The full Python test suite passed with the exact current Rust extension.
- 221 Rust tests passed.
- Cargo check, Rust formatting, Python compilation, extension fingerprint, and diff checks passed.

## Reviewer Focus

Confirm the seven selected projections replace only unsafe class-name rendering with bounded exception types while preserving admission and defer outcomes, trace handling, and diagnostic sink isolation.