### PR TITLE
Redact failed Rust orchestrator events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Failed Rust-orchestrator return events now retain bounded exception types instead of persisted
+  exception text. Existing timing and correlation metadata, event delivery, orchestration, and
+  trading behavior are unchanged.
+
 - Executor churn-admission and fresh-entry eligibility diagnostics now retain bounded exception
   types only. Existing admission/defer reasons, batch limits, fail-closed behavior, trace handling,
   event delivery isolation, scheduling, and trading behavior are unchanged.

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -290,6 +290,14 @@ return the original order object sequence without retaining exception messages, 
 class names, URLs, credentials, tokens, or tracebacks. Fetch parameters, missing-price handling,
 complete-price sorting, reconciliation, planning, and trading behavior remain unchanged.
 
+## Rust Orchestrator Returned Events
+
+Failed `rust_orchestrator.returned` events retain their existing timing, input hash, cycle and
+remote-call correlation, error level/status/tags, and one bounded exception type used for both
+`reason_code` and `data.error_type`. They omit exception text, URLs, credentials, and unsafe class
+metadata. This diagnostic redaction does not change Rust orchestration, event ordering or
+isolation, caller propagation, connector calls, or trading behavior.
+
 ## Fresh-Entry Eligibility
 
 Completed normal live plans emit `entry.initial_eligibility` to structured and monitor sinks. The

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -2657,14 +2657,10 @@ def _emit_rust_orchestrator_returned_event_unchecked(
     reason_code = None
     if failed:
         err = error or RuntimeError("rust orchestrator failed")
+        error_type = _bounded_exception_type(err)
         tags.append("error")
-        reason_code = type(err).__name__
-        data.update(
-            {
-                "error_type": type(err).__name__,
-                "error": _sanitize_remote_text(err, max_len=500),
-            }
-        )
+        reason_code = error_type
+        data["error_type"] = error_type
     else:
         if output_hash is not None:
             raw_hash = str(output_hash)

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -996,6 +996,9 @@ def test_rust_orchestrator_emitters_record_bounded_summaries():
     import passivbot as pb_mod
 
     sink = ListEventSink()
+    secret = "rust-orchestrator-secret"
+    url = "https://example.invalid/rust?token=rust-orchestrator-token"
+    error_type = type("RustOrchestratorFailure" + "X" * 120, (RuntimeError,), {})
 
     class FakeBot:
         _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
@@ -1043,7 +1046,7 @@ def test_rust_orchestrator_emitters_record_bounded_summaries():
         status="failed",
         input_hash="failed_input_hash",
         elapsed_ms=9,
-        error=ValueError("MissingEma { symbol_idx: 0 } apiKey=SECRET token SECRET"),
+        error=error_type(f"orchestrator failed secret={secret} url={url}"),
     )
 
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
@@ -1064,20 +1067,27 @@ def test_rust_orchestrator_emitters_record_bounded_summaries():
     assert returned.event_type == EventTypes.RUST_ORCHESTRATOR_RETURNED
     assert returned.status == "succeeded"
     assert returned.raw_hash == "output_hash"
-    assert returned.data["elapsed_ms"] == 12
-    assert returned.data["input_hash"] == "input_hash"
-    assert returned.data["output_hash"] == "output_hash"
-    assert returned.data["order_count"] == 5
-    assert returned.data["diagnostic_keys"] == ["forager", "min_cost"]
+    assert returned.data == {
+        "elapsed_ms": 12,
+        "input_hash": "input_hash",
+        "output_hash": "output_hash",
+        "order_count": 5,
+        "diagnostic_keys": ["forager", "min_cost"],
+    }
     assert failed.event_type == EventTypes.RUST_ORCHESTRATOR_RETURNED
     assert failed.level == "error"
     assert failed.status == "failed"
-    assert failed.reason_code == "ValueError"
+    assert failed.reason_code == "RuntimeError"
     assert failed.raw_hash == "failed_input_hash"
-    assert failed.data["error_type"] == "ValueError"
-    assert "MissingEma" in failed.data["error"]
-    assert "SECRET" not in failed.data["error"]
-    assert "[redacted]" in failed.data["error"]
+    assert failed.data == {
+        "elapsed_ms": 9,
+        "input_hash": "failed_input_hash",
+        "error_type": "RuntimeError",
+    }
+    assert "error" not in failed.data
+    assert error_type.__name__ not in str(failed.data)
+    assert secret not in str(failed.data)
+    assert url not in str(failed.data)
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 


### PR DESCRIPTION
@codex review

## Scope

Category: observability producer.

Failed `rust_orchestrator.returned` events now retain a bounded exception type instead of exception text or unsafe class metadata. Successful orchestrator events and unrelated event families are unchanged.

## Behavior

Diagnostic-only. Existing event type, level, status, component, tags, correlation identifiers, hashes, timing, event ordering, wrapper isolation, caller propagation, Rust calls, and trading behavior are unchanged.

## Validation

- Focused Rust-orchestrator event tests passed.
- The full Python test suite passed with the exact current Rust extension.
- 221 Rust tests passed.
- Event-registry and documentation checks passed.
- Cargo check, Rust formatting, Python compilation, extension fingerprint, and diff checks passed.

## Reviewer Focus

Confirm failed events retain only the bounded `reason_code` and `error_type`, omit exception text entirely, and preserve successful event payloads and all orchestration behavior.