### PR TITLE
Redact event bus degradation diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Event-bus degradation diagnostics now retain bounded exception types and canonical dropped-event
+  labels only. Sink isolation, queue behavior, counters for registered events, timing, return
+  values, event routing, and trading behavior are unchanged.
+
 - Failed Rust-orchestrator return events now retain bounded exception types instead of persisted
   exception text. Existing timing and correlation metadata, event delivery, orchestration, and
   trading behavior are unchanged.

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -54,6 +54,13 @@ retain exception text, request URLs, credentials, response bodies, paths, or oth
 from the sink exception. Sink counters and pipeline timings remain available through health
 snapshots independently of the exception payload.
 
+Queue-full and pipeline-closing degradation diagnostics retain a canonical registered event type
+only. Unsafe, malformed, sensitive-marker-bearing, or unregistered labels normalize to
+`unknown_event` in the drop counter, message, and `dropped_event_type`; canonical event labels are
+unchanged. Monitor-delivery and generic emitter fallback warnings follow the same bounded event-type
+and exception-type rule. These diagnostics remain isolated from event routing, queue semantics,
+sink timing/counters, caller return values, and trading behavior.
+
 ## Emitter Failure Diagnostics
 
 Best-effort live event emitters remain isolated from their callers. If event construction,

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -16,6 +16,7 @@ import uuid
 from typing import Any, Iterable, Mapping, Protocol
 
 from live.balance_composition import format_balance_composition_sample
+from live.diagnostic_safety import bounded_exception_type
 
 
 SCHEMA_VERSION = 1
@@ -591,6 +592,17 @@ PHASE1_EVENT_TYPES = {
 LEGACY_EVENT_TYPE_ALIASES = {
     "planning_unavailable": EventTypes.PLANNING_UNAVAILABLE,
 }
+_REGISTERED_EVENT_TYPES = frozenset(
+    value
+    for name, value in vars(EventTypes).items()
+    if name.isupper() and type(value) is str
+)
+_DIAGNOSTIC_EVENT_TYPE_MAX_LEN = 120
+_DIAGNOSTIC_EVENT_TYPE_SENSITIVE_RE = re.compile(
+    r"(?i)(?:api_?key|apikey|authorization|cookie|passphrase|password|private_?key|"
+    r"privatekey|secret|signature|token|wallet_?address|walletaddress)"
+)
+_UNKNOWN_DIAGNOSTIC_EVENT_TYPE = "unknown_event"
 
 
 VALID_LEVELS = {"trace", "debug", "info", "warning", "error", "critical"}
@@ -638,6 +650,20 @@ def monotonic_ms() -> int:
 def normalize_event_type(event_type: object) -> str:
     raw = str(event_type)
     return LEGACY_EVENT_TYPE_ALIASES.get(raw, raw)
+
+
+def bounded_diagnostic_event_type(event_type: object) -> str:
+    """Return a public-safe event type for failure and degradation diagnostics."""
+    if type(event_type) is not str:
+        return _UNKNOWN_DIAGNOSTIC_EVENT_TYPE
+    normalized = LEGACY_EVENT_TYPE_ALIASES.get(event_type, event_type)
+    if (
+        len(normalized) > _DIAGNOSTIC_EVENT_TYPE_MAX_LEN
+        or _DIAGNOSTIC_EVENT_TYPE_SENSITIVE_RE.search(normalized)
+        or normalized not in _REGISTERED_EVENT_TYPES
+    ):
+        return _UNKNOWN_DIAGNOSTIC_EVENT_TYPE
+    return normalized
 
 
 def payload_hash(payload: Any) -> str:
@@ -3558,12 +3584,18 @@ class LiveEventPipeline:
             with self._enqueue_lock:
                 if self._stop.is_set():
                     enqueued = False
+                    dropped_event_type = bounded_diagnostic_event_type(
+                        live_event.event_type
+                    )
                     with self._state_lock:
-                        self.drop_counters[live_event.event_type] += 1
+                        self.drop_counters[dropped_event_type] += 1
                     self._record_degraded(
                         reason_code=ReasonCodes.SINK_PIPELINE_CLOSING,
-                        message=f"live event pipeline closing; dropped {live_event.event_type}",
-                        data={"dropped_event_type": live_event.event_type},
+                        message=(
+                            "live event pipeline closing; dropped "
+                            f"{dropped_event_type}"
+                        ),
+                        data={"dropped_event_type": dropped_event_type},
                     )
                 else:
                     try:
@@ -3575,12 +3607,18 @@ class LiveEventPipeline:
                         )
                     except queue.Full:
                         enqueued = False
+                        dropped_event_type = bounded_diagnostic_event_type(
+                            live_event.event_type
+                        )
                         with self._state_lock:
-                            self.drop_counters[live_event.event_type] += 1
+                            self.drop_counters[dropped_event_type] += 1
                         self._record_degraded(
                             reason_code=ReasonCodes.QUEUE_FULL,
-                            message=f"live event queue full; dropped {live_event.event_type}",
-                            data={"dropped_event_type": live_event.event_type},
+                            message=(
+                                "live event queue full; dropped "
+                                f"{dropped_event_type}"
+                            ),
+                            data={"dropped_event_type": dropped_event_type},
                         )
         if require_enqueue and not enqueued:
             return None
@@ -3873,10 +3911,11 @@ class LiveEventPipeline:
     ) -> None:
         with self._state_lock:
             self.sink_error_counters[name] += 1
+        error_type = bounded_exception_type(exc)
         self._record_degraded(
             reason_code=sink_failed_reason_code(name),
-            message=f"{name} sink failed: {type(exc).__name__}",
-            data={"sink": name, "error_type": type(exc).__name__},
+            message=f"{name} sink failed: {error_type}",
+            data={"sink": name, "error_type": error_type},
             sink_write_timing=sink_write_timing,
         )
 
@@ -3931,14 +3970,14 @@ class LiveEventPipeline:
                         self.sink_error_counters["monitor"] += 1
                     logging.warning(
                         "[event] failed to emit sink.degraded to monitor: %s",
-                        type(exc.error).__name__,
+                        bounded_exception_type(exc.error),
                     )
                 except Exception as exc:
                     with self._state_lock:
                         self.sink_error_counters["monitor"] += 1
                     logging.warning(
                         "[event] failed to emit sink.degraded to monitor: %s",
-                        type(exc).__name__,
+                        bounded_exception_type(exc),
                     )
                 finally:
                     if sink_write_timing is not None:
@@ -3966,9 +4005,20 @@ def emit_event(
             emit_kwargs["defer_sync_sinks_until_enqueued"] = True
         return pipeline.emit(event, **emit_kwargs)
     except Exception as exc:
+        try:
+            raw_event_type = (
+                event.event_type
+                if isinstance(event, LiveEvent)
+                else event.get("event_type")
+                if isinstance(event, Mapping)
+                else None
+            )
+        except Exception:
+            raw_event_type = None
+        event_type = bounded_diagnostic_event_type(raw_event_type)
         logging.debug(
             "[event] failed to emit %s error_type=%s",
-            getattr(event, "event_type", event),
-            type(exc).__name__,
+            event_type,
+            bounded_exception_type(exc),
         )
         return None

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -625,6 +625,32 @@ def test_pipeline_queue_overflow_is_observable_without_raising():
     assert pipeline.drop_counters[EventTypes.DATA_PACKET_UPDATED] == 1
     assert pipeline.degraded_events[-1].event_type == EventTypes.SINK_DEGRADED
     assert pipeline.degraded_events[-1].reason_code == "queue_full"
+    assert pipeline.degraded_events[-1].data == {
+        "dropped_event_type": EventTypes.DATA_PACKET_UPDATED
+    }
+
+
+def test_bounded_diagnostic_event_type_preserves_only_registered_labels():
+    assert (
+        live_event_bus_module.bounded_diagnostic_event_type(
+            EventTypes.DATA_PACKET_UPDATED
+        )
+        == EventTypes.DATA_PACKET_UPDATED
+    )
+    assert (
+        live_event_bus_module.bounded_diagnostic_event_type("planning_unavailable")
+        == EventTypes.PLANNING_UNAVAILABLE
+    )
+    for unsafe_value in (
+        "secret.event",
+        "event." + "x" * 200,
+        1,
+        None,
+    ):
+        assert (
+            live_event_bus_module.bounded_diagnostic_event_type(unsafe_value)
+            == "unknown_event"
+        )
 
 
 def test_pipeline_health_snapshot_reports_queue_and_degraded_counters():
@@ -1272,8 +1298,11 @@ def test_pipeline_queue_overflow_is_logged_and_monitor_visible(caplog):
     assert any("live event queue full" in record.message for record in caplog.records)
 
 
-def test_sink_failure_degrades_observability_without_raising(monkeypatch):
+def test_sink_failure_degrades_observability_without_raising(monkeypatch, caplog):
     clock = {"ns": 1_000_000_000}
+    secret = "sink-secret"
+    hostile_type_name = "SinkApiKeyFailure"
+    HostileSinkFailure = type(hostile_type_name, (OSError,), {})
     monkeypatch.setattr(
         live_event_bus_module.time,
         "monotonic_ns",
@@ -1283,8 +1312,8 @@ def test_sink_failure_degrades_observability_without_raising(monkeypatch):
     class FailingSink:
         def write(self, event):
             clock["ns"] += 3_000_000
-            raise OSError(
-                "disk full https://example.invalid/private?api_key=do-not-retain"
+            raise HostileSinkFailure(
+                f"disk full https://example.invalid/private?api_key={secret}\nTraceback"
             )
 
     class ControlledMonitorSink(ListEventSink):
@@ -1299,10 +1328,11 @@ def test_sink_failure_degrades_observability_without_raising(monkeypatch):
         routes={EventTypes.SNAPSHOT_BUILT: EventRoute(structured=True, monitor=False)},
     )
 
-    event = pipeline.emit(LiveEvent(EventTypes.SNAPSHOT_BUILT))
+    with caplog.at_level(logging.WARNING):
+        event = pipeline.emit(LiveEvent(EventTypes.SNAPSHOT_BUILT))
+        assert pipeline.flush(timeout=2.0) is True
 
     assert event.event_type == EventTypes.SNAPSHOT_BUILT
-    assert pipeline.flush(timeout=2.0) is True
     assert pipeline.sink_error_counters["structured"] == 1
     timing = pipeline.health_snapshot()
     assert timing["event_structured_sink_write_count"] == 1
@@ -1322,9 +1352,97 @@ def test_sink_failure_degrades_observability_without_raising(monkeypatch):
         "sink": "structured",
         "error_type": "OSError",
     }
-    assert "do-not-retain" not in repr(pipeline.degraded_events)
-    assert "do-not-retain" not in repr(monitor.events)
+    emitted_diagnostics = "\n".join(
+        [repr(pipeline.degraded_events), repr(monitor.events)]
+        + [record.getMessage() for record in caplog.records]
+    )
+    for unsafe_value in (
+        hostile_type_name,
+        secret,
+        "example.invalid",
+        "Traceback",
+    ):
+        assert unsafe_value not in emitted_diagnostics
     assert pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.parametrize("prepare_error", [False, True])
+def test_degraded_monitor_warning_uses_bounded_exception_type(caplog, prepare_error):
+    secret = "monitor-secret"
+    hostile_type_name = "MonitorTokenFailure"
+    HostileMonitorFailure = type(hostile_type_name, (OSError,), {})
+
+    class FailingMonitor(MonitorEventSink):
+        def _write_with_timing(self, event):
+            error = HostileMonitorFailure(
+                f"https://example.invalid/monitor?token={secret}\nTraceback"
+            )
+            if prepare_error:
+                raise live_event_bus_module._MonitorEventPrepareError(
+                    error,
+                    live_event_bus_module._empty_monitor_phase_timing(),
+                )
+            raise error
+
+    pipeline = LiveEventPipeline(
+        monitor_sinks=[FailingMonitor(object())],
+        start=False,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        pipeline._record_degraded(
+            reason_code=ReasonCodes.QUEUE_FULL,
+            message="live event queue full; dropped unknown_event",
+            data={"dropped_event_type": "unknown_event"},
+        )
+
+    assert pipeline.sink_error_counters["monitor"] == 1
+    assert pipeline.degraded_events[-1].data == {"dropped_event_type": "unknown_event"}
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert "failed to emit sink.degraded to monitor: OSError" in messages
+    for unsafe_value in (
+        hostile_type_name,
+        secret,
+        "example.invalid",
+        "Traceback",
+    ):
+        assert unsafe_value not in messages
+
+
+@pytest.mark.parametrize("pipeline_closing", [False, True])
+def test_drop_diagnostics_bound_hostile_event_types(caplog, pipeline_closing):
+    secret = "event-secret"
+    hostile_event_type = f"secret.event https://example.invalid/?token={secret}\nTraceback"
+    monitor = ListEventSink()
+    pipeline = LiveEventPipeline(
+        queue_maxsize=1,
+        start=False,
+        monitor_sinks=[monitor],
+    )
+
+    with caplog.at_level(logging.WARNING):
+        if pipeline_closing:
+            pipeline._stop.set()
+        else:
+            assert pipeline.emit(LiveEvent(hostile_event_type)) is not None
+        assert (
+            pipeline.emit(LiveEvent(hostile_event_type), require_enqueue=True) is None
+        )
+
+    expected_reason = (
+        ReasonCodes.SINK_PIPELINE_CLOSING if pipeline_closing else ReasonCodes.QUEUE_FULL
+    )
+    assert pipeline.drop_counters == {"unknown_event": 1}
+    assert pipeline.health_snapshot()["event_drop_counts"] == {"unknown_event": 1}
+    assert pipeline.degraded_events[-1].reason_code == expected_reason
+    assert pipeline.degraded_events[-1].data == {"dropped_event_type": "unknown_event"}
+    assert monitor.events[-1] == pipeline.degraded_events[-1]
+    emitted_diagnostics = "\n".join(
+        [repr(pipeline.degraded_events), repr(monitor.events)]
+        + [record.getMessage() for record in caplog.records]
+    )
+    for unsafe_value in (hostile_event_type, secret, "example.invalid", "Traceback"):
+        assert unsafe_value not in emitted_diagnostics
 
 
 def test_monitor_sink_none_ack_records_monitor_sink_failure():
@@ -1931,6 +2049,47 @@ def test_emit_event_failure_log_omits_exception_text(caplog):
     )
     assert all(secret not in message for message in messages)
     assert all("pipeline-secret" not in message for message in messages)
+
+
+def test_emit_event_failure_log_bounds_hostile_event_type_and_exception_class(caplog):
+    secret = "fallback-secret"
+    hostile_type_name = "FallbackPrivateKeyFailure"
+    HostilePipelineFailure = type(hostile_type_name, (RuntimeError,), {})
+    hostile_event_type = f"secret.event https://example.invalid/?token={secret}\nTraceback"
+
+    class FailingPipeline:
+        def emit(self, *_args, **_kwargs):
+            raise HostilePipelineFailure(secret)
+
+    class HostileEventMapping(dict):
+        def get(self, *_args, **_kwargs):
+            raise RuntimeError(
+                f"https://example.invalid/mapping?token={secret}\nTraceback"
+            )
+
+    bot = type("Bot", (), {"_live_event_pipeline": FailingPipeline()})()
+
+    with caplog.at_level(logging.DEBUG):
+        for event in (
+            {"event_type": hostile_event_type},
+            HostileEventMapping(event_type=hostile_event_type),
+        ):
+            assert live_event_bus_module.emit_event(bot, event) is None
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert sum(
+        "failed to emit unknown_event error_type=RuntimeError" in message
+        for message in messages
+    ) == 2
+    emitted_diagnostics = "\n".join(messages)
+    for unsafe_value in (
+        hostile_type_name,
+        hostile_event_type,
+        secret,
+        "example.invalid",
+        "Traceback",
+    ):
+        assert unsafe_value not in emitted_diagnostics
 
 
 def test_ema_fallback_console_formatter_is_bounded_without_mutating_payload():


### PR DESCRIPTION
@codex review

## Scope

Category: observability producer.

Event-bus sink failures, degradation-delivery fallbacks, queue-full and pipeline-closing diagnostics, and the outer event-emission fallback now retain bounded exception types and registered event labels only. Unsafe or unregistered diagnostic labels normalize to `unknown_event`. Generic event-payload budgeting is intentionally out of scope.

## Behavior

Diagnostic-only. Registered event labels, event routing, sink isolation, queue semantics, normal drop-counter keys, sink counters, pipeline timing, caller return values, and trading behavior are unchanged. Operational action: none.

## Validation

- 10 focused failure/degradation regressions passed.
- The complete event-bus test module passed.
- The full Python test suite passed with the exact current Rust extension.
- 221 Rust tests passed.
- Event-registry and documentation checks passed.
- Cargo check, Rust formatting, Python compilation, extension fingerprint, privacy scan, and diff checks passed.

## Reviewer Focus

Confirm unsafe exception classes and event labels cannot reach degraded events, monitor output, health drop counters, or fallback logs, while registered labels and all isolation, timing, counter, and return contracts remain unchanged.