### PR TITLE
Bound live event payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Canonical live-event payloads now make a bounded JSON-compatible copy at construction time,
+  revalidate that copy at persistence boundaries, redact sensitive keys before retention, and
+  record aggregate truncation metadata only when a limit applies. Event identity, routing, monitor
+  envelope structure, and trading behavior are unchanged; legacy direct monitor history, order,
+  and raw-fill storage remain outside this payload boundary.
+
 - Event-bus degradation diagnostics now retain bounded exception types and canonical dropped-event
   labels only. Sink isolation, queue behavior, counters for registered events, timing, return
   values, event routing, and trading behavior are unchanged.

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -10,6 +10,30 @@ Event emission and sink failures are observability-only unless a feature contrac
 requires durable publication. Diagnostic producers must not mutate order lists, execution results,
 eligibility, replay order, or runtime decisions.
 
+## Canonical Payload Budget
+
+Each `LiveEvent` constructor makes a non-mutating, JSON-compatible bounded copy of its canonical
+`data` mapping before the event reaches any sink. Under-limit data is preserved apart from existing
+sensitive-key redaction. The copy has a maximum nesting depth of six, 64 items per list, 128 keys
+per mapping, 256 inspected mapping entries, 512 characters per string, 128 characters per key,
+4,096 traversed nodes, and 32 KiB of serialized `data` including metadata. Strings retain their
+prefix with a stable truncation suffix; lists retain prefixes without marker objects; excess keys
+and items are omitted.
+
+Sensitive keys redact before their values are retained. Cycles, over-depth values, unsupported
+values, and node-limit values become stable classification strings; arbitrary object rendering is
+not retained. When any boundary changes data, the reserved root `_live_event_budget` object records
+only versioned aggregate counters. A caller cannot supply or override that object. The metadata
+contains no source paths, payload fragments, or other caller values.
+
+The same bounded `data` appears in `to_dict()` and the monitor event envelope. This construction-time
+budget is revalidated by serialization, monitor projection, context replacement, and pipeline
+emission so post-construction caller mutation cannot bypass redaction or size limits. Revalidation
+preserves existing aggregate budget metadata without double-counting it. The boundary is
+diagnostic-only: it does not alter event identity, schema fields, routes, sinks, caller returns, or
+trading behavior. It applies only to canonical `LiveEvent.data`; direct legacy `MonitorPublisher`
+history, order, and raw-fill storage contracts remain unchanged.
+
 ## Balance Composition Diagnostics
 
 `balance.changed` may carry an optional `balance_composition` object from the

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import Counter, deque
-from dataclasses import asdict, dataclass, field, replace
+from dataclasses import asdict, dataclass, field, fields, replace
 from datetime import datetime, timezone
 import hashlib
 import json
@@ -13,6 +13,7 @@ import threading
 import time
 from types import MappingProxyType
 import uuid
+import weakref
 from typing import Any, Iterable, Mapping, Protocol
 
 from live.balance_composition import format_balance_composition_sample
@@ -22,6 +23,17 @@ from live.diagnostic_safety import bounded_exception_type
 SCHEMA_VERSION = 1
 REDACTED = "[redacted]"
 LIVE_EVENT_MONITOR_PAYLOAD_KEY = "_live_event"
+LIVE_EVENT_BUDGET_METADATA_KEY = "_live_event_budget"
+LIVE_EVENT_BUDGET_VERSION = 1
+LIVE_EVENT_MAX_DATA_DEPTH = 6
+LIVE_EVENT_MAX_LIST_ITEMS = 64
+LIVE_EVENT_MAX_MAPPING_KEYS = 128
+LIVE_EVENT_MAX_MAPPING_INSPECTIONS = 256
+LIVE_EVENT_MAX_STRING_CHARS = 512
+LIVE_EVENT_MAX_KEY_CHARS = 128
+LIVE_EVENT_MAX_DATA_BYTES = 32 * 1024
+LIVE_EVENT_MAX_NODES = 4_096
+LIVE_EVENT_BUDGET_COUNTER_MAX = 1_000_000
 LIVE_EVENT_ID_KEYS = (
     "bot_id",
     "cycle_id",
@@ -703,6 +715,459 @@ def redact_payload(value: Any) -> Any:
     return value
 
 
+_LIVE_EVENT_TRUNCATION_SUFFIX = "...<truncated>"
+_LIVE_EVENT_DEPTH_LIMITED = "[depth-limited]"
+_LIVE_EVENT_CYCLE_LIMITED = "[cycle-limited]"
+_LIVE_EVENT_NODE_LIMITED = "[node-limited]"
+_LIVE_EVENT_UNSUPPORTED = "[unsupported]"
+_LIVE_EVENT_UNSUPPORTED_KEY = "[unsupported-key]"
+_LIVE_EVENT_MAX_INTEGER_BITS = 4_096
+_LIVE_EVENT_OMIT_LIST_ITEM = object()
+_LIVE_EVENT_BUDGET_COUNTER_FIELDS = (
+    "omitted_keys",
+    "omitted_items",
+    "truncated_strings",
+    "truncated_keys",
+    "depth_limited",
+    "cycle_limited",
+    "byte_limited",
+    "unsupported_values",
+    "node_limited",
+    "reserved_keys",
+)
+
+
+class _CanonicalLiveEventData(dict[str, Any]):
+    """Private marker for data normalized by this module."""
+
+
+_LIVE_EVENT_BUDGET_REGISTRY_LOCK = threading.Lock()
+_LIVE_EVENT_BUDGET_REGISTRY: dict[
+    int,
+    tuple[
+        weakref.ReferenceType[_CanonicalLiveEventData],
+        tuple[int, ...],
+    ],
+] = {}
+
+
+def _discard_live_event_budget_metadata(
+    data_id: int,
+    data_ref: weakref.ReferenceType[_CanonicalLiveEventData],
+) -> None:
+    with _LIVE_EVENT_BUDGET_REGISTRY_LOCK:
+        current = _LIVE_EVENT_BUDGET_REGISTRY.get(data_id)
+        if current is not None and current[0] is data_ref:
+            _LIVE_EVENT_BUDGET_REGISTRY.pop(data_id, None)
+
+
+def _canonical_live_event_data(
+    value: Mapping[str, Any],
+    *,
+    budget_metadata: Mapping[str, int] | None = None,
+) -> _CanonicalLiveEventData:
+    canonical = _CanonicalLiveEventData(value)
+    if budget_metadata is None:
+        return canonical
+    metadata_values = tuple(
+        int(budget_metadata[field_name])
+        for field_name in _LIVE_EVENT_BUDGET_COUNTER_FIELDS
+    )
+    canonical_id = id(canonical)
+    canonical_ref = weakref.ref(
+        canonical,
+        lambda data_ref: _discard_live_event_budget_metadata(
+            canonical_id,
+            data_ref,
+        ),
+    )
+    with _LIVE_EVENT_BUDGET_REGISTRY_LOCK:
+        _LIVE_EVENT_BUDGET_REGISTRY[canonical_id] = (
+            canonical_ref,
+            metadata_values,
+        )
+    return canonical
+
+
+def _copy_canonical_live_event_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _copy_canonical_live_event_value(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_copy_canonical_live_event_value(item) for item in value]
+    return value
+
+
+@dataclass
+class _LiveEventBudgetState:
+    omitted_keys: int = 0
+    omitted_items: int = 0
+    truncated_strings: int = 0
+    truncated_keys: int = 0
+    depth_limited: int = 0
+    cycle_limited: int = 0
+    byte_limited: int = 0
+    unsupported_values: int = 0
+    node_limited: int = 0
+    reserved_keys: int = 0
+    nodes: int = 0
+
+    def add(self, field_name: str, amount: int = 1) -> None:
+        current = getattr(self, field_name)
+        setattr(
+            self,
+            field_name,
+            min(LIVE_EVENT_BUDGET_COUNTER_MAX, current + max(0, int(amount))),
+        )
+
+    def changed(self) -> bool:
+        return any(getattr(self, field_name) for field_name in _LIVE_EVENT_BUDGET_COUNTER_FIELDS)
+
+
+def _truncate_live_event_text(value: str, limit: int) -> str:
+    if len(value) <= limit:
+        return value
+    return value[: limit - len(_LIVE_EVENT_TRUNCATION_SUFFIX)] + _LIVE_EVENT_TRUNCATION_SUFFIX
+
+
+def _bounded_live_event_key(key: object) -> tuple[str, bool, bool]:
+    """Return key text, whether it was shortened, and whether its value must redact."""
+    if isinstance(key, str):
+        value = key
+    elif key is None:
+        value = "None"
+    elif type(key) is bool:
+        value = "True" if key else "False"
+    elif type(key) is int:
+        if key.bit_length() > _LIVE_EVENT_MAX_INTEGER_BITS:
+            return _LIVE_EVENT_UNSUPPORTED_KEY, False, True
+        value = str(key)
+    elif type(key) is float:
+        value = str(key)
+    else:
+        return _LIVE_EVENT_UNSUPPORTED_KEY, False, True
+    if len(value) > LIVE_EVENT_MAX_KEY_CHARS:
+        return _truncate_live_event_text(value, LIVE_EVENT_MAX_KEY_CHARS), True, True
+    return value, False, False
+
+
+def _live_event_collection_omitted_count(value: object, retained: int) -> int:
+    try:
+        return max(1, len(value) - retained)
+    except Exception:
+        return 1
+
+
+def _live_event_mapping_omitted_count(
+    value: Mapping[Any, Any],
+    *,
+    processed_keys: int,
+    root_budget_key_present: bool,
+) -> int:
+    try:
+        total_keys = (
+            dict.__len__(value)
+            if isinstance(value, dict)
+            else len(value)
+        )
+    except Exception:
+        return 1
+    caller_key_count = total_keys - int(root_budget_key_present)
+    return max(1, caller_key_count - processed_keys)
+
+
+def _bounded_live_event_value(
+    value: Any,
+    *,
+    depth: int,
+    ancestors: set[int],
+    state: _LiveEventBudgetState,
+    is_root: bool = False,
+    omit_on_limit: bool = False,
+    existing_budget_metadata: Mapping[str, int] | None = None,
+) -> Any:
+    if state.nodes >= LIVE_EVENT_MAX_NODES:
+        state.add("node_limited")
+        return _LIVE_EVENT_OMIT_LIST_ITEM if omit_on_limit else _LIVE_EVENT_NODE_LIMITED
+    state.nodes += 1
+    if depth > LIVE_EVENT_MAX_DATA_DEPTH:
+        state.add("depth_limited")
+        return _LIVE_EVENT_OMIT_LIST_ITEM if omit_on_limit else _LIVE_EVENT_DEPTH_LIMITED
+    if value is None or type(value) is bool:
+        return value
+    if isinstance(value, str):
+        if len(value) > LIVE_EVENT_MAX_STRING_CHARS:
+            state.add("truncated_strings")
+            return _truncate_live_event_text(value, LIVE_EVENT_MAX_STRING_CHARS)
+        return value
+    if type(value) is int:
+        if value.bit_length() <= _LIVE_EVENT_MAX_INTEGER_BITS:
+            return value
+        state.add("unsupported_values")
+        return _LIVE_EVENT_OMIT_LIST_ITEM if omit_on_limit else _LIVE_EVENT_UNSUPPORTED
+    if type(value) is float:
+        if math.isfinite(value):
+            return value
+        state.add("unsupported_values")
+        return _LIVE_EVENT_OMIT_LIST_ITEM if omit_on_limit else _LIVE_EVENT_UNSUPPORTED
+    if isinstance(value, Mapping):
+        value_id = id(value)
+        if value_id in ancestors:
+            state.add("cycle_limited")
+            return (
+                _LIVE_EVENT_OMIT_LIST_ITEM
+                if omit_on_limit
+                else _LIVE_EVENT_CYCLE_LIMITED
+            )
+        ancestors.add(value_id)
+        normalized: dict[str, Any] = {}
+        processed_keys = 0
+        root_budget_key_present = False
+        if is_root:
+            if isinstance(value, dict):
+                root_budget_key_present = dict.__contains__(
+                    value,
+                    LIVE_EVENT_BUDGET_METADATA_KEY,
+                )
+            else:
+                try:
+                    value[LIVE_EVENT_BUDGET_METADATA_KEY]
+                    root_budget_key_present = True
+                except KeyError:
+                    pass
+                except Exception:
+                    state.add("unsupported_values")
+        if root_budget_key_present and existing_budget_metadata is None:
+            state.add("reserved_keys")
+        try:
+            items = iter(value.items())
+            for index in range(LIVE_EVENT_MAX_MAPPING_INSPECTIONS):
+                try:
+                    item = next(items)
+                except StopIteration:
+                    break
+                try:
+                    key, child = item
+                except (TypeError, ValueError):
+                    state.add("unsupported_values")
+                    continue
+                normalized_key, key_truncated, force_redaction = _bounded_live_event_key(key)
+                if is_root and normalized_key == LIVE_EVENT_BUDGET_METADATA_KEY:
+                    if (
+                        existing_budget_metadata is None
+                        and not root_budget_key_present
+                    ):
+                        state.add("reserved_keys")
+                    continue
+                if processed_keys >= LIVE_EVENT_MAX_MAPPING_KEYS:
+                    state.add(
+                        "omitted_keys",
+                        _live_event_mapping_omitted_count(
+                            value,
+                            processed_keys=processed_keys,
+                            root_budget_key_present=root_budget_key_present,
+                        ),
+                    )
+                    break
+                processed_keys += 1
+                if key_truncated:
+                    state.add("truncated_keys")
+                if normalized_key == _LIVE_EVENT_UNSUPPORTED_KEY:
+                    state.add("unsupported_values")
+                if normalized_key in normalized and (key_truncated or force_redaction):
+                    state.add("omitted_keys")
+                    continue
+                if force_redaction or _is_sensitive_key(normalized_key):
+                    normalized[normalized_key] = REDACTED
+                else:
+                    normalized[normalized_key] = _bounded_live_event_value(
+                        child,
+                        depth=depth + 1,
+                        ancestors=ancestors,
+                        state=state,
+                    )
+            else:
+                state.add(
+                    "omitted_keys",
+                    _live_event_mapping_omitted_count(
+                        value,
+                        processed_keys=processed_keys,
+                        root_budget_key_present=root_budget_key_present,
+                    ),
+                )
+        except Exception:
+            state.add("unsupported_values")
+        finally:
+            ancestors.remove(value_id)
+        return normalized
+    if isinstance(value, (list, tuple)):
+        value_id = id(value)
+        if value_id in ancestors:
+            state.add("cycle_limited")
+            return (
+                _LIVE_EVENT_OMIT_LIST_ITEM
+                if omit_on_limit
+                else _LIVE_EVENT_CYCLE_LIMITED
+            )
+        ancestors.add(value_id)
+        normalized_items: list[Any] = []
+        try:
+            for index, child in enumerate(value):
+                if index >= LIVE_EVENT_MAX_LIST_ITEMS:
+                    state.add(
+                        "omitted_items",
+                        _live_event_collection_omitted_count(value, index),
+                    )
+                    break
+                normalized_child = _bounded_live_event_value(
+                    child,
+                    depth=depth + 1,
+                    ancestors=ancestors,
+                    state=state,
+                    omit_on_limit=True,
+                )
+                if normalized_child is _LIVE_EVENT_OMIT_LIST_ITEM:
+                    state.add(
+                        "omitted_items",
+                        _live_event_collection_omitted_count(value, index),
+                    )
+                    break
+                normalized_items.append(normalized_child)
+        except Exception:
+            state.add("unsupported_values")
+        finally:
+            ancestors.remove(value_id)
+        return normalized_items
+    state.add("unsupported_values")
+    return _LIVE_EVENT_OMIT_LIST_ITEM if omit_on_limit else _LIVE_EVENT_UNSUPPORTED
+
+
+def _live_event_budget_metadata(state: _LiveEventBudgetState) -> dict[str, int]:
+    return {
+        "version": LIVE_EVENT_BUDGET_VERSION,
+        "omitted_keys": state.omitted_keys,
+        "omitted_items": state.omitted_items,
+        "truncated_strings": state.truncated_strings,
+        "truncated_keys": state.truncated_keys,
+        "depth_limited": state.depth_limited,
+        "cycle_limited": state.cycle_limited,
+        "byte_limited": state.byte_limited,
+        "unsupported_values": state.unsupported_values,
+        "node_limited": state.node_limited,
+        "reserved_keys": state.reserved_keys,
+    }
+
+
+def _existing_live_event_budget_metadata(
+    value: Mapping[str, Any] | None,
+) -> dict[str, int] | None:
+    if not isinstance(value, _CanonicalLiveEventData):
+        return None
+    with _LIVE_EVENT_BUDGET_REGISTRY_LOCK:
+        registered = _LIVE_EVENT_BUDGET_REGISTRY.get(id(value))
+    if registered is None or registered[0]() is not value:
+        return None
+    metadata_values = registered[1]
+    if len(metadata_values) != len(_LIVE_EVENT_BUDGET_COUNTER_FIELDS):
+        return None
+    normalized = {"version": LIVE_EVENT_BUDGET_VERSION}
+    for field_name, field_value in zip(
+        _LIVE_EVENT_BUDGET_COUNTER_FIELDS,
+        metadata_values,
+    ):
+        if (
+            type(field_value) is not int
+            or field_value < 0
+            or field_value > LIVE_EVENT_BUDGET_COUNTER_MAX
+        ):
+            return None
+        normalized[field_name] = field_value
+    return normalized
+
+
+def _live_event_json_size(value: Mapping[str, Any]) -> int:
+    return len(
+        json.dumps(
+            value,
+            ensure_ascii=True,
+            allow_nan=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    )
+
+
+def bounded_live_event_data(value: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return the canonical, non-mutating JSON-safe data payload for one LiveEvent."""
+    state = _LiveEventBudgetState()
+    existing_budget_metadata = _existing_live_event_budget_metadata(value)
+    if isinstance(value, Mapping):
+        normalized = _bounded_live_event_value(
+            value,
+            depth=0,
+            ancestors=set(),
+            state=state,
+            is_root=True,
+            existing_budget_metadata=existing_budget_metadata,
+        )
+    elif value is None:
+        normalized = {}
+    else:
+        state.add("unsupported_values")
+        normalized = {}
+    assert isinstance(normalized, dict)
+    if existing_budget_metadata is not None:
+        for field_name in _LIVE_EVENT_BUDGET_COUNTER_FIELDS:
+            state.add(field_name, existing_budget_metadata[field_name])
+    if (
+        existing_budget_metadata is None
+        and not state.changed()
+        and _live_event_json_size(normalized) <= LIVE_EVENT_MAX_DATA_BYTES
+    ):
+        return _canonical_live_event_data(normalized)
+    payload = dict(normalized)
+    metadata = _live_event_budget_metadata(state)
+    payload[LIVE_EVENT_BUDGET_METADATA_KEY] = metadata
+    if _live_event_json_size(payload) <= LIVE_EVENT_MAX_DATA_BYTES:
+        return _canonical_live_event_data(payload, budget_metadata=metadata)
+
+    state.add("byte_limited")
+    keys = list(normalized)
+    base_omitted_keys = state.omitted_keys
+    low = 0
+    high = len(keys)
+    retained_count = 0
+    while low <= high:
+        candidate_count = (low + high) // 2
+        metadata = _live_event_budget_metadata(state)
+        metadata["omitted_keys"] = min(
+            LIVE_EVENT_BUDGET_COUNTER_MAX,
+            base_omitted_keys + len(keys) - candidate_count,
+        )
+        candidate = {
+            key: normalized[key] for key in keys[:candidate_count]
+        }
+        candidate[LIVE_EVENT_BUDGET_METADATA_KEY] = metadata
+        if _live_event_json_size(candidate) <= LIVE_EVENT_MAX_DATA_BYTES:
+            retained_count = candidate_count
+            low = candidate_count + 1
+        else:
+            high = candidate_count - 1
+
+    state.add("omitted_keys", len(keys) - retained_count)
+    payload = {key: normalized[key] for key in keys[:retained_count]}
+    metadata = _live_event_budget_metadata(state)
+    payload[LIVE_EVENT_BUDGET_METADATA_KEY] = metadata
+    if _live_event_json_size(payload) > LIVE_EVENT_MAX_DATA_BYTES:
+        state.add("omitted_keys", retained_count)
+        metadata = _live_event_budget_metadata(state)
+        payload = {
+            LIVE_EVENT_BUDGET_METADATA_KEY: metadata
+        }
+    return _canonical_live_event_data(payload, budget_metadata=metadata)
+
+
 @dataclass(frozen=True)
 class LiveEvent:
     event_type: str
@@ -748,22 +1213,31 @@ class LiveEvent:
             object.__setattr__(self, "status", status)
         object.__setattr__(self, "event_type", normalize_event_type(self.event_type))
         object.__setattr__(self, "tags", tuple(str(tag) for tag in self.tags))
-        object.__setattr__(self, "data", dict(redact_payload(dict(self.data or {}))))
+        object.__setattr__(self, "data", bounded_live_event_data(self.data))
 
     def with_context(self, context: "LiveEventContext") -> "LiveEvent":
         return context.apply(self)
 
     def to_dict(self) -> dict[str, Any]:
-        data = asdict(self)
+        data = {
+            item.name: getattr(self, item.name)
+            for item in fields(self)
+            if item.name != "data"
+        }
         data["tags"] = list(self.tags)
-        data["data"] = dict(self.data)
+        data["data"] = _copy_canonical_live_event_value(
+            bounded_live_event_data(self.data)
+        )
         return data
 
     def to_json(self) -> str:
         return json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
 
     def to_monitor_event(self) -> tuple[str, tuple[str, ...], dict[str, Any]]:
-        payload = dict(self.data)
+        canonical_data = _copy_canonical_live_event_value(
+            bounded_live_event_data(self.data)
+        )
+        payload = dict(canonical_data)
         payload[LIVE_EVENT_MONITOR_PAYLOAD_KEY] = {
             "schema_version": self.schema_version,
             "event_id": self.event_id,
@@ -782,7 +1256,7 @@ class LiveEvent:
             "status": self.status,
             "reason_code": self.reason_code,
             "message": self.message,
-            "data": dict(self.data),
+            "data": dict(canonical_data),
             "raw_ref": self.raw_ref,
             "raw_hash": self.raw_hash,
             "ids": {key: getattr(self, key) for key in LIVE_EVENT_ID_KEYS},
@@ -3571,11 +4045,19 @@ class LiveEventPipeline:
         require_enqueue = bool(require_enqueue or defer_sync_sinks_until_enqueued)
         if isinstance(event, LiveEvent):
             live_event = event
+            revalidated = False
         else:
             live_event = LiveEvent(**dict(event))
+            revalidated = True
         if overrides:
             live_event = replace(live_event, **overrides)
-        live_event = live_event.with_context(self.context)
+            revalidated = True
+        contextual_event = live_event.with_context(self.context)
+        if contextual_event is not live_event:
+            revalidated = True
+        live_event = contextual_event
+        if not revalidated:
+            live_event = replace(live_event, data=live_event.data)
         route = self.route_for(live_event)
         if not defer_sync_sinks_until_enqueued:
             self._emit_sync_sinks(live_event, route)

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 import json
 import logging
 import queue
@@ -14,7 +15,14 @@ from live.event_bus import (
     EventRoute,
     EventTags,
     EventTypes,
+    LIVE_EVENT_BUDGET_METADATA_KEY,
     LIVE_EVENT_DEBUG_PROFILES,
+    LIVE_EVENT_MAX_DATA_BYTES,
+    LIVE_EVENT_MAX_DATA_DEPTH,
+    LIVE_EVENT_MAX_LIST_ITEMS,
+    LIVE_EVENT_MAX_MAPPING_INSPECTIONS,
+    LIVE_EVENT_MAX_MAPPING_KEYS,
+    LIVE_EVENT_MAX_STRING_CHARS,
     ListEventSink,
     LiveEvent,
     LiveEventContext,
@@ -304,6 +312,381 @@ def test_live_event_serializes_stable_envelope_and_redacts_sensitive_data():
     assert data["data"]["nested"]["safe"] == "ok"
     assert data["data"]["rows"][0]["signature"] == REDACTED
     assert json.loads(event.to_json())["event_type"] == event.event_type
+
+
+def test_live_event_data_budget_preserves_under_limit_json_and_redaction_without_marker():
+    source = {
+        "planning": {"ready": True, "candidate_count": 3},
+        "order_wave": {"created": 2, "cancelled": 1},
+        "health": {"queue_depth": 4, "healthy": True},
+        "apiKey": "secret",
+    }
+    expected_source = {
+        "planning": {"ready": True, "candidate_count": 3},
+        "order_wave": {"created": 2, "cancelled": 1},
+        "health": {"queue_depth": 4, "healthy": True},
+        "apiKey": "secret",
+    }
+
+    event = LiveEvent(EventTypes.CYCLE_COMPLETED, data=source)
+    monitor_payload = event.to_monitor_event()[2]
+
+    assert source == expected_source
+    assert event.data == {
+        "planning": {"ready": True, "candidate_count": 3},
+        "order_wave": {"created": 2, "cancelled": 1},
+        "health": {"queue_depth": 4, "healthy": True},
+        "apiKey": REDACTED,
+    }
+    assert LIVE_EVENT_BUDGET_METADATA_KEY not in event.data
+    assert event.to_dict()["data"] == event.data
+    assert monitor_payload["_live_event"]["data"] == event.data
+    assert monitor_payload["planning"] == event.data["planning"]
+
+
+def test_live_event_data_budget_bounds_shape_cycles_and_unsafe_values_without_mutation():
+    class Unrenderable:
+        def __repr__(self):
+            raise AssertionError("unsupported values must not render")
+
+        def __str__(self):
+            raise AssertionError("unsupported values must not render")
+
+    cycle: dict[str, object] = {}
+    cycle["self"] = cycle
+    deep: dict[str, object] = {}
+    cursor = deep
+    for _ in range(LIVE_EVENT_MAX_DATA_DEPTH + 2):
+        child: dict[str, object] = {}
+        cursor["child"] = child
+        cursor = child
+    long_key = "k" * 140
+    source = {
+        "apiKey": "secret",
+        "long_text": "x" * (LIVE_EVENT_MAX_STRING_CHARS + 8),
+        long_key: "must_not_be_retained",
+        "items": list(range(LIVE_EVENT_MAX_LIST_ITEMS + 3)),
+        "mapping": {
+            f"key_{index:03d}": index
+            for index in range(LIVE_EVENT_MAX_MAPPING_KEYS + 3)
+        },
+        "deep": deep,
+        "cycle": cycle,
+        LIVE_EVENT_BUDGET_METADATA_KEY: {"injected": "untrusted"},
+        "unsupported": Unrenderable(),
+        "nonfinite": float("nan"),
+    }
+
+    event = LiveEvent(EventTypes.PLANNING_UNAVAILABLE, data=source)
+    serialized = json.dumps(event.data, allow_nan=False, sort_keys=True)
+    metadata = event.data[LIVE_EVENT_BUDGET_METADATA_KEY]
+
+    assert source["apiKey"] == "secret"
+    assert source[long_key] == "must_not_be_retained"
+    assert source["cycle"] is cycle
+    assert event.data["apiKey"] == REDACTED
+    assert event.data["long_text"].endswith("...<truncated>")
+    assert len(event.data["items"]) == LIVE_EVENT_MAX_LIST_ITEMS
+    assert event.data["items"] == list(range(LIVE_EVENT_MAX_LIST_ITEMS))
+    assert len(event.data["mapping"]) == LIVE_EVENT_MAX_MAPPING_KEYS
+    assert event.data["cycle"]["self"] == "[cycle-limited]"
+    assert "[depth-limited]" in serialized
+    assert event.data["unsupported"] == "[unsupported]"
+    assert event.data["nonfinite"] == "[unsupported]"
+    assert "must_not_be_retained" not in serialized
+    assert "untrusted" not in serialized
+    assert metadata["version"] == 1
+    assert metadata["omitted_keys"] >= 3
+    assert metadata["omitted_items"] == 3
+    assert metadata["truncated_strings"] == 1
+    assert metadata["truncated_keys"] == 1
+    assert metadata["depth_limited"] >= 1
+    assert metadata["cycle_limited"] == 1
+    assert metadata["unsupported_values"] >= 2
+    assert metadata["reserved_keys"] == 1
+
+
+def test_live_event_data_budget_enforces_final_serialized_byte_limit_in_order():
+    source = {
+        f"order_wave_{index:03d}": "x" * LIVE_EVENT_MAX_STRING_CHARS
+        for index in range(LIVE_EVENT_MAX_MAPPING_KEYS)
+    }
+
+    event = LiveEvent(EventTypes.ORDER_WAVE_COMPLETED, data=source)
+    metadata = event.data[LIVE_EVENT_BUDGET_METADATA_KEY]
+    encoded = json.dumps(
+        event.data,
+        ensure_ascii=True,
+        allow_nan=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+    assert len(encoded) <= LIVE_EVENT_MAX_DATA_BYTES
+    assert metadata["byte_limited"] >= 1
+    assert metadata["omitted_keys"] >= 1
+    assert event.data["order_wave_000"] == "x" * LIVE_EVENT_MAX_STRING_CHARS
+    assert "order_wave_127" not in event.data
+
+
+def test_live_event_data_budget_byte_pruning_uses_bounded_serialization_passes(
+    monkeypatch,
+):
+    calls = 0
+    original = live_event_bus_module._live_event_json_size
+
+    def counted_json_size(value):
+        nonlocal calls
+        calls += 1
+        return original(value)
+
+    monkeypatch.setattr(
+        live_event_bus_module,
+        "_live_event_json_size",
+        counted_json_size,
+    )
+
+    LiveEvent(
+        EventTypes.ORDER_WAVE_COMPLETED,
+        data={
+            f"order_wave_{index:03d}": "x" * LIVE_EVENT_MAX_STRING_CHARS
+            for index in range(LIVE_EVENT_MAX_MAPPING_KEYS)
+        },
+    )
+
+    assert calls <= 12
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_omitted_keys", "expected_reserved_keys"),
+    [
+        (
+            {
+                **{"key_000": "x" * (LIVE_EVENT_MAX_STRING_CHARS + 1)},
+                **{
+                    f"key_{index:03d}": index
+                    for index in range(1, LIVE_EVENT_MAX_MAPPING_KEYS)
+                },
+            },
+            0,
+            0,
+        ),
+        (
+            {
+                f"key_{index:03d}": index
+                for index in range(LIVE_EVENT_MAX_MAPPING_KEYS + 1)
+            },
+            1,
+            0,
+        ),
+        (
+            {
+                LIVE_EVENT_BUDGET_METADATA_KEY: {"forged": True},
+                **{
+                    f"key_{index:03d}": index
+                    for index in range(LIVE_EVENT_MAX_MAPPING_KEYS + 1)
+                },
+            },
+            1,
+            1,
+        ),
+        (
+            {
+                **{
+                    f"key_{index:03d}": index
+                    for index in range(LIVE_EVENT_MAX_MAPPING_KEYS + 1)
+                },
+                LIVE_EVENT_BUDGET_METADATA_KEY: {"forged": True},
+            },
+            1,
+            1,
+        ),
+    ],
+)
+def test_live_event_data_budget_saturated_root_metadata_is_idempotent(
+    source,
+    expected_omitted_keys,
+    expected_reserved_keys,
+):
+    event = LiveEvent(EventTypes.CYCLE_COMPLETED, data=source)
+
+    for metadata in (
+        event.data[LIVE_EVENT_BUDGET_METADATA_KEY],
+        event.to_dict()["data"][LIVE_EVENT_BUDGET_METADATA_KEY],
+    ):
+        assert metadata["omitted_keys"] == expected_omitted_keys
+        assert metadata["reserved_keys"] == expected_reserved_keys
+
+    contextual = LiveEventContext(exchange="test_exchange").apply(event)
+    contextual_metadata = contextual.data[LIVE_EVENT_BUDGET_METADATA_KEY]
+    assert contextual_metadata["omitted_keys"] == expected_omitted_keys
+    assert contextual_metadata["reserved_keys"] == expected_reserved_keys
+
+    sink = ListEventSink()
+    pipeline = LiveEventPipeline(structured_sinks=[sink], monitor_sinks=[])
+    emitted = pipeline.emit(contextual)
+    assert emitted is not None
+    assert pipeline.flush(timeout=2.0) is True
+    emitted_metadata = emitted.data[LIVE_EVENT_BUDGET_METADATA_KEY]
+    assert emitted_metadata["omitted_keys"] == expected_omitted_keys
+    assert emitted_metadata["reserved_keys"] == expected_reserved_keys
+    assert sink.events == [emitted]
+    assert pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.parametrize("marker_first", [True, False])
+def test_live_event_data_budget_non_dict_mapping_reserves_saturated_root_marker(
+    marker_first,
+):
+    class OrderedMapping(Mapping):
+        def __init__(self, items):
+            self._items = list(items)
+            self._values = dict(items)
+
+        def __getitem__(self, key):
+            return self._values[key]
+
+        def __iter__(self):
+            return iter(self._values)
+
+        def __len__(self):
+            return len(self._values)
+
+        def items(self):
+            return iter(self._items)
+
+    caller_items = [
+        (f"key_{index:03d}", index)
+        for index in range(LIVE_EVENT_MAX_MAPPING_KEYS + 1)
+    ]
+    marker_item = (LIVE_EVENT_BUDGET_METADATA_KEY, {"forged": True})
+    items = (
+        [marker_item, *caller_items]
+        if marker_first
+        else [*caller_items, marker_item]
+    )
+
+    event = LiveEvent(
+        EventTypes.CYCLE_COMPLETED,
+        data=OrderedMapping(items),
+    )
+
+    metadata = event.to_dict()["data"][LIVE_EVENT_BUDGET_METADATA_KEY]
+    assert metadata["omitted_keys"] == 1
+    assert metadata["reserved_keys"] == 1
+
+
+def test_live_event_data_budget_caps_inspection_of_malformed_mapping_items():
+    class InfiniteMalformedMapping(Mapping):
+        def __init__(self):
+            self.inspections = 0
+
+        def __getitem__(self, key):
+            raise KeyError(key)
+
+        def __iter__(self):
+            return iter(())
+
+        def __len__(self):
+            return 0
+
+        def items(self):
+            while True:
+                self.inspections += 1
+                yield object()
+
+    source = InfiniteMalformedMapping()
+    event = LiveEvent(EventTypes.CYCLE_COMPLETED, data=source)
+
+    assert source.inspections == LIVE_EVENT_MAX_MAPPING_INSPECTIONS
+    metadata = event.data[LIVE_EVENT_BUDGET_METADATA_KEY]
+    assert metadata["omitted_keys"] == 1
+    assert metadata["unsupported_values"] == LIVE_EVENT_MAX_MAPPING_INSPECTIONS
+
+
+def test_live_event_data_budget_limits_global_traversal(monkeypatch):
+    monkeypatch.setattr(live_event_bus_module, "LIVE_EVENT_MAX_NODES", 4)
+
+    event = LiveEvent(
+        EventTypes.CYCLE_COMPLETED,
+        data={"values": [{"value": 1}, {"value": 2}, {"value": 3}]},
+    )
+
+    assert event.data["values"][0] == {"value": 1}
+    assert event.data["values"] == [{"value": 1}]
+    assert event.data[LIVE_EVENT_BUDGET_METADATA_KEY]["node_limited"] >= 1
+    assert event.data[LIVE_EVENT_BUDGET_METADATA_KEY]["omitted_items"] == 2
+
+
+def test_live_event_data_budget_revalidates_mutated_data_at_every_output_boundary():
+    source = {"nested": {"items": [{"value": 1}]}}
+    event = LiveEvent(EventTypes.CYCLE_COMPLETED, data=source)
+
+    dict.__setitem__(event.data, "apiKey", "secret")
+    list.append(
+        event.data["nested"]["items"],
+        {"apiKey": "secret", "blob": "x" * 100_000},
+    )
+
+    direct_data = event.to_dict()["data"]
+    assert direct_data["apiKey"] == REDACTED
+    assert direct_data["nested"]["items"][1]["apiKey"] == REDACTED
+    assert direct_data["nested"]["items"][1]["blob"].endswith("...<truncated>")
+
+    contextual = LiveEventContext(exchange="test_exchange").apply(event)
+    dict.__setitem__(contextual.data, "auth_token", "secret")
+    dict.__setitem__(contextual.data, "oversized", "y" * 100_000)
+    sink = ListEventSink()
+    pipeline = LiveEventPipeline(structured_sinks=[sink], monitor_sinks=[])
+    emitted = pipeline.emit(contextual)
+
+    assert emitted is not contextual
+    assert emitted.data["apiKey"] == REDACTED
+    assert emitted.data["auth_token"] == REDACTED
+    assert len(emitted.data["oversized"]) == LIVE_EVENT_MAX_STRING_CHARS
+    assert (
+        len(
+            json.dumps(
+                emitted.data,
+                ensure_ascii=True,
+                allow_nan=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        )
+        <= LIVE_EVENT_MAX_DATA_BYTES
+    )
+    assert pipeline.flush(timeout=2.0) is True
+    assert sink.events == [emitted]
+    assert pipeline.close(timeout=2.0) is True
+
+
+def test_live_event_data_budget_visible_metadata_cannot_erase_or_forge_counters():
+    limited = LiveEvent(
+        EventTypes.CYCLE_COMPLETED,
+        data={"items": list(range(LIVE_EVENT_MAX_LIST_ITEMS + 1))},
+    )
+    visible_metadata = limited.data[LIVE_EVENT_BUDGET_METADATA_KEY]
+    visible_metadata["omitted_items"] = 0
+    limited.data._budget_metadata = (999,) * 10
+
+    projected = limited.to_dict()["data"]
+    assert projected[LIVE_EVENT_BUDGET_METADATA_KEY]["omitted_items"] == 1
+
+    dict.__delitem__(limited.data, LIVE_EVENT_BUDGET_METADATA_KEY)
+    projected = limited.to_dict()["data"]
+    assert projected[LIVE_EVENT_BUDGET_METADATA_KEY]["omitted_items"] == 1
+
+    clean = LiveEvent(EventTypes.CYCLE_COMPLETED, data={"ready": True})
+    forged_metadata = dict(projected[LIVE_EVENT_BUDGET_METADATA_KEY])
+    forged_metadata["omitted_keys"] = 999
+    dict.__setitem__(
+        clean.data,
+        LIVE_EVENT_BUDGET_METADATA_KEY,
+        forged_metadata,
+    )
+
+    projected = clean.to_dict()["data"]
+    assert projected[LIVE_EVENT_BUDGET_METADATA_KEY]["omitted_keys"] == 0
+    assert projected[LIVE_EVENT_BUDGET_METADATA_KEY]["reserved_keys"] == 1
 
 
 def test_live_event_context_propagates_ids_without_overwriting_event_values():
@@ -4040,6 +4423,36 @@ def test_monitor_event_sink_writes_real_monitor_event_stream(tmp_path):
     assert rows[0]["payload"]["_live_event"]["ids"]["cycle_id"] == "cy_1"
     assert rows[0]["payload"]["_live_event"]["reason_code"] == "stale_ema"
     assert rows[0]["payload"]["_live_event"]["data"]["apiKey"] == REDACTED
+
+
+def test_monitor_event_sink_persists_the_same_budgeted_canonical_data(tmp_path):
+    publisher = _make_monitor_publisher(tmp_path)
+    pipeline = LiveEventPipeline(
+        context=LiveEventContext(exchange="bybit", user="user01"),
+        structured_sinks=[],
+        monitor_sinks=[MonitorEventSink(publisher)],
+    )
+    event = pipeline.emit(
+        LiveEvent(
+            EventTypes.PLANNING_UNAVAILABLE,
+            data={
+                "availability": "missing_candles",
+                "samples": list(range(LIVE_EVENT_MAX_LIST_ITEMS + 1)),
+            },
+            ts_ms=12345,
+        )
+    )
+
+    assert event is not None
+    assert pipeline.flush(timeout=2.0) is True
+    assert pipeline.close(timeout=2.0) is True
+
+    event_path = tmp_path / "bybit" / "user01" / "events" / "current.ndjson"
+    row = json.loads(event_path.read_text().splitlines()[0])
+    persisted_data = row["payload"]["_live_event"]["data"]
+    assert persisted_data == event.data
+    assert row["payload"]["availability"] == "missing_candles"
+    assert persisted_data[LIVE_EVENT_BUDGET_METADATA_KEY]["omitted_items"] == 1
 
 
 def test_cycle_events_are_reconstructable_by_cycle_id():

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -6,6 +6,12 @@ import os
 
 import pytest
 
+from live.event_bus import (
+    EventTypes,
+    LIVE_EVENT_BUDGET_METADATA_KEY,
+    LIVE_EVENT_MAX_LIST_ITEMS,
+    LiveEvent,
+)
 from live.event_file_rows import event_file_rows
 from live.event_query import (
     build_event_report,
@@ -901,6 +907,43 @@ def test_event_query_filters_by_debug_profile(tmp_path):
 def test_event_query_rejects_malformed_data_eq_filter(tmp_path):
     with pytest.raises(ValueError, match="key=value"):
         build_event_report(tmp_path, data_eq="missing_equals")
+
+
+def test_event_query_includes_budgeted_data_without_affecting_data_eq_filters(tmp_path):
+    event = LiveEvent(
+        EventTypes.PLANNING_UNAVAILABLE,
+        data={
+            "availability": "missing_candles",
+            "samples": list(range(LIVE_EVENT_MAX_LIST_ITEMS + 1)),
+        },
+    )
+    event_type, tags, payload = event.to_monitor_event()
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            {
+                "exchange": "binance",
+                "user": "binance_01",
+                "kind": event_type,
+                "tags": list(tags),
+                "payload": payload,
+                "seq": 1,
+                "ts": 1000,
+            }
+        ],
+    )
+
+    report = build_event_report(
+        tmp_path / "monitor",
+        data_eq="availability=missing_candles",
+        include_data=True,
+    )
+
+    assert report["query"]["matched_events"] == 1
+    data = report["query"]["events"][0]["data"]
+    assert data["availability"] == "missing_candles"
+    assert data[LIVE_EVENT_BUDGET_METADATA_KEY]["omitted_items"] == 1
 
 
 def test_event_query_filters_by_remaining_event_ids(tmp_path):

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -9,6 +9,12 @@ from types import SimpleNamespace
 
 import pytest
 import live.performance_report as performance_report_module
+from live.event_bus import (
+    EventTypes,
+    LIVE_EVENT_BUDGET_METADATA_KEY,
+    LIVE_EVENT_MAX_LIST_ITEMS,
+    LiveEvent,
+)
 from live.performance_report import (
     build_live_performance_report,
     project_live_performance_report_sections,
@@ -103,6 +109,37 @@ def _operation_duration_groups_by_operation(report):
         group["operation"]: group
         for group in report["operation_durations"]["groups"]
     }
+
+
+def test_live_performance_report_ignores_canonical_budget_metadata(tmp_path):
+    event = LiveEvent(
+        EventTypes.CYCLE_COMPLETED,
+        data={
+            "elapsed_ms": 10,
+            "samples": list(range(LIVE_EVENT_MAX_LIST_ITEMS + 1)),
+        },
+    )
+    event_type, tags, payload = event.to_monitor_event()
+    events_dir = tmp_path / "monitor" / "test_exchange" / "test_user" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            {
+                "exchange": "test_exchange",
+                "user": "test_user",
+                "kind": event_type,
+                "tags": list(tags),
+                "payload": payload,
+                "seq": 1,
+                "ts": 1000,
+            }
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+
+    assert report["performance"]["groups"]
+    assert LIVE_EVENT_BUDGET_METADATA_KEY not in json.dumps(report, sort_keys=True)
 
 
 def test_live_performance_report_aggregates_cycle_state_remote_and_hsl_timings(tmp_path):

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -8,6 +8,12 @@ from pathlib import Path
 
 import pytest
 
+from live.event_bus import (
+    EventTypes,
+    LIVE_EVENT_BUDGET_METADATA_KEY,
+    LIVE_EVENT_MAX_LIST_ITEMS,
+    LiveEvent,
+)
 import live.event_file_rows as event_file_rows_module
 import live.smoke_report as smoke_report_module
 from live.smoke_report import (
@@ -92,6 +98,37 @@ def _write_minimal_monitor_event(monitor_root):
             )
         ],
     )
+
+
+def test_live_smoke_report_ignores_canonical_budget_metadata(tmp_path):
+    event = LiveEvent(
+        EventTypes.CYCLE_COMPLETED,
+        data={
+            "elapsed_ms": 10,
+            "samples": list(range(LIVE_EVENT_MAX_LIST_ITEMS + 1)),
+        },
+    )
+    event_type, tags, payload = event.to_monitor_event()
+    events_dir = tmp_path / "monitor" / "test_exchange" / "test_user" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            {
+                "exchange": "test_exchange",
+                "user": "test_user",
+                "kind": event_type,
+                "tags": list(tags),
+                "payload": payload,
+                "seq": 1,
+                "ts": 1000,
+            }
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+
+    assert report["monitor"]["live_events"] == 1
+    assert LIVE_EVENT_BUDGET_METADATA_KEY not in json.dumps(report, sort_keys=True)
 
 
 def test_live_smoke_report_scans_monitor_segments_once(tmp_path, monkeypatch):


### PR DESCRIPTION
@codex review

## Summary

- bound canonical `LiveEvent.data` at construction and persistence boundaries
- redact sensitive keys before retention and keep final serialized data within 32 KiB
- preserve typed list prefixes and publish aggregate limit counters only when data changes
- keep direct legacy monitor history, order, and raw-fill storage outside this boundary

## Compatibility

- under-limit JSON-compatible payloads remain unchanged apart from existing redaction
- event identity, routing, sink selection, monitor envelope structure, and trading behavior are unchanged
- post-construction payload mutation is revalidated before serialization or sink delivery

## Validation

- full Python test suite
- 221 Rust tests
- Rust test compilation and formatting checks
- live-event registry and AI documentation checks
- source-matched Rust extension verification

Operational action: none.
