### PR TITLE
Fix live candle tail EMA handoffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live candle orchestration now reads bounded cache-only native 1h EMA carry-forward from the 1h
+  index and applies the configured forager staleness limit to actual refresh lateness. A
+  minute-boundary open-tail projection is also retried before reusing a previous close EMA,
+  avoiding transient candidate drops and unnecessary close-EMA fallback on WEEX and other
+  exchanges without weakening active-symbol fail-closed behavior.
+
 - Canonical live-event payloads now make a bounded JSON-compatible copy at construction time,
   revalidate that copy at persistence boundaries, redact sensitive keys before retention, and
   record aggregate truncation metadata only when a limit applies. Event identity, routing, monitor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ All notable user-facing changes will be documented in this file.
 ## Unreleased
 
 - Live candle orchestration now reads bounded cache-only native 1h EMA carry-forward from the 1h
-  index and applies the configured forager staleness limit to actual refresh lateness. A
-  minute-boundary open-tail projection is also retried before reusing a previous close EMA,
-  avoiding transient candidate drops and unnecessary close-EMA fallback on WEEX and other
+  index, requires a complete native window, isolates carried values from the active EMA cache, and
+  applies the background refresher's surface-count staleness limit using the active live/replay
+  clock. A minute-boundary open-tail projection is also retried before reusing a previous close
+  EMA, avoiding transient candidate drops and unnecessary close-EMA fallback on WEEX and other
   exchanges without weakening active-symbol fail-closed behavior.
 
 - Canonical live-event payloads now make a bounded JSON-compatible copy at construction time,

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -60,8 +60,11 @@
    live EMA bundle.
    Cache-only EMA carry-forward must read the index and candle range for the requested native
    timeframe. When the newest native 1h bucket has only just become due, the previous cached 1h
-   EMA may remain eligible only for the configured wall-clock candidate staleness window; the
-   one-hour bucket interval itself is not counted as one hour of refresh lateness.
+   EMA may remain eligible only for the candidate staleness window computed from the same
+   refreshable surface count used by the background refresher and measured on the candle manager's
+   active live/replay clock; the one-hour bucket interval itself is not counted as one hour of
+   refresh lateness. Cached carry-forward requires full requested-window coverage and must not
+   populate the normal active-strategy EMA cache.
    Tail-only gaps remain eligible within the configured candidate staleness window; missing basis
    and internal gaps do not. Refresh budgets count symbol/timeframe fetches, health scans are
    bounded and rotated across cycles, interleave each candidate's 1m and native 1h health surfaces,

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -58,6 +58,10 @@
    every consumed native candle surface, including 1m inputs and native 1h log-range inputs with a
    nonzero strategy weight, using the same per-symbol requirements and explicit warmup cap as the
    live EMA bundle.
+   Cache-only EMA carry-forward must read the index and candle range for the requested native
+   timeframe. When the newest native 1h bucket has only just become due, the previous cached 1h
+   EMA may remain eligible only for the configured wall-clock candidate staleness window; the
+   one-hour bucket interval itself is not counted as one hour of refresh lateness.
    Tail-only gaps remain eligible within the configured candidate staleness window; missing basis
    and internal gaps do not. Refresh budgets count symbol/timeframe fetches, health scans are
    bounded and rotated across cycles, interleave each candidate's 1m and native 1h health surfaces,

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -3670,12 +3670,28 @@ class CandlestickManager:
         """Public helper to read last refresh timestamp (ms) from index metadata."""
         return self._get_last_refresh_ms(symbol)
 
-    def get_last_final_ts(self, symbol: str) -> int:
-        """Return last finalized candle timestamp (ms) seen for this symbol, or 0 if unknown."""
-        idx = self._ensure_symbol_index(symbol)
+    def get_last_final_ts(
+        self,
+        symbol: str,
+        timeframe: Optional[str] = None,
+        *,
+        tf: Optional[str] = None,
+    ) -> int:
+        """Return the last locally cached finalized timestamp for one timeframe."""
+        idx = self._ensure_symbol_index(symbol, timeframe=timeframe, tf=tf)
         try:
-            return int(idx.get("meta", {}).get("last_final_ts", 0))
+            last_final = int(idx.get("meta", {}).get("last_final_ts", 0) or 0)
         except Exception:
+            last_final = 0
+        if last_final > 0:
+            return last_final
+        try:
+            return max(
+                int(shard.get("max_ts", 0) or 0)
+                for shard in (idx.get("shards", {}) or {}).values()
+                if isinstance(shard, dict)
+            )
+        except (TypeError, ValueError):
             return 0
 
     def _set_last_refresh_meta(
@@ -7161,7 +7177,10 @@ class CandlestickManager:
         normalized = self._normalize_spans_by_metric(spans_by_metric)
         if not normalized:
             return {}
-        last_cached = _floor_minute(int(self.get_last_final_ts(symbol) or 0))
+        last_cached = int(
+            self.get_last_final_ts(symbol, timeframe=timeframe) or 0
+        )
+        last_cached = (last_cached // period_ms) * period_ms
         if last_cached <= 0:
             return {}
         latest_expected = (int(self._now_ms()) // period_ms) * period_ms - period_ms
@@ -8074,6 +8093,15 @@ class CandlestickManager:
             "count": int(arr.shape[0]),
             "crc32": crc,
         }
+        meta = idx.setdefault("meta", {})
+        meta["last_final_ts"] = max(
+            int(meta.get("last_final_ts", 0) or 0),
+            int(arr[-1]["ts"]),
+        )
+        observed_start = meta.get("observed_start_ts", meta.get("inception_ts"))
+        if observed_start is None or int(arr[0]["ts"]) < int(observed_start):
+            meta["observed_start_ts"] = int(arr[0]["ts"])
+            meta["inception_ts"] = int(arr[0]["ts"])
         key = f"{symbol}::{tf_norm}"
         self._index[key] = idx
 

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -7210,18 +7210,12 @@ class CandlestickManager:
             fill_trailing_gaps=False,
             allow_remote_fetch=False,
         )
-        if raw.size == 0 or not self._ema_window_has_required_coverage(
-            raw,
-            start_ts,
-            int(last_cached),
-            timeframe=timeframe,
+        if raw.size == 0 or not candle_range_has_full_coverage(
+            raw, start_ts, int(last_cached), timeframe=timeframe
         ):
             return {}
 
         out: Dict[str, float] = {}
-        tf_key = str(period_ms)
-        now = self._now_ms()
-        cache = self._ema_cache.setdefault(symbol, {})
         for metric_key, spans in normalized.items():
             for span in spans:
                 span_candles = max(1, int(math.ceil(span)))
@@ -7247,11 +7241,6 @@ class CandlestickManager:
                 val = float(self._ema(series, span))
                 if math.isfinite(val):
                     out[str(metric_key)] = val
-                    cache[(str(metric_key), float(span), tf_key)] = (
-                        val,
-                        int(last_cached),
-                        int(now),
-                    )
         return out
 
     async def _latest_finalized_range(

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -16379,9 +16379,13 @@ class Passivbot:
             for sym in priority_symbols:
                 forager_cached_metric_max_age_by_symbol[sym] = priority_max_age_ms
             if secondary_symbols:
+                secondary_surface_count = sum(
+                    1 + int(bool(need_h1_lr_spans.get(sym)))
+                    for sym in secondary_symbols
+                )
                 secondary_max_age_ms = int(
                     Passivbot._forager_target_staleness_ms(
-                        self, len(secondary_symbols), max_calls_i
+                        self, secondary_surface_count, max_calls_i
                     )
                 )
                 now_ms = utc_ms()
@@ -16503,17 +16507,17 @@ class Passivbot:
             if timeframe == "1h":
                 # A newly finalized hourly bucket is one full candle interval
                 # ahead of the prior cached bucket. Enforce the configured
-                # budget against wall-clock lateness since that bucket became
-                # due, then include the expected interval for the cache reader's
-                # timestamp-gap bound.
+                # budget against the candle manager's replay-aware clock since
+                # that bucket became due, then include the expected interval for
+                # the cache reader's timestamp-gap bound.
                 period_ms = 60 * ONE_MIN_MS
                 try:
                     last_cached = int(
                         self.cm.get_last_final_ts(symbol, timeframe=timeframe) or 0
                     )
+                    now_ms = int(self.cm._now_ms())
                 except Exception:
                     return None
-                now_ms = int(utc_ms())
                 latest_expected = (now_ms // period_ms) * period_ms - period_ms
                 if last_cached <= 0:
                     return None

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -16489,29 +16489,60 @@ class Passivbot:
         forager_cached_ema_fallbacks: dict[str, list[tuple[str, float, int]]] = {}
 
         async def fetch_cached_forager_metric(
-            symbol: str, span: float, metric_key: str
+            symbol: str,
+            span: float,
+            metric_key: str,
+            *,
+            timeframe: str = "1m",
+            diagnostic_key: Optional[str] = None,
         ) -> Optional[float]:
             max_staleness_ms = forager_cached_metric_max_age_by_symbol.get(symbol)
             if max_staleness_ms is None:
                 return None
+            cached_age_ms: Optional[int] = None
+            if timeframe == "1h":
+                # A newly finalized hourly bucket is one full candle interval
+                # ahead of the prior cached bucket. Enforce the configured
+                # budget against wall-clock lateness since that bucket became
+                # due, then include the expected interval for the cache reader's
+                # timestamp-gap bound.
+                period_ms = 60 * ONE_MIN_MS
+                try:
+                    last_cached = int(
+                        self.cm.get_last_final_ts(symbol, timeframe=timeframe) or 0
+                    )
+                except Exception:
+                    return None
+                now_ms = int(utc_ms())
+                latest_expected = (now_ms // period_ms) * period_ms - period_ms
+                if last_cached <= 0:
+                    return None
+                if last_cached < latest_expected:
+                    first_missing_finalized_at = last_cached + 2 * period_ms
+                    cached_age_ms = max(0, now_ms - first_missing_finalized_at)
+                    if cached_age_ms > int(max_staleness_ms):
+                        return None
+                max_staleness_ms = int(max_staleness_ms) + 60 * ONE_MIN_MS
             cached = await Passivbot._get_forager_cached_ema_metrics(
                 self,
                 symbol,
                 {metric_key: float(span)},
                 max_staleness_ms=int(max_staleness_ms),
                 window_candles=max(1, int(math.ceil(float(span)))),
+                timeframe=timeframe,
             )
             if metric_key not in cached:
                 return None
             val = float(cached[metric_key])
             if not math.isfinite(val):
                 return None
-            try:
-                age_ms = int(Passivbot._candle_staleness_ms(self, symbol))
-            except Exception:
-                age_ms = -1
+            if cached_age_ms is None:
+                try:
+                    cached_age_ms = int(Passivbot._candle_staleness_ms(self, symbol))
+                except Exception:
+                    cached_age_ms = -1
             forager_cached_ema_fallbacks.setdefault(symbol, []).append(
-                (metric_key, float(span), int(age_ms))
+                (diagnostic_key or metric_key, float(span), int(cached_age_ms))
             )
             return val
 
@@ -16569,6 +16600,10 @@ class Passivbot:
             metric_key = {"m1_volume": "qv", "m1_log_range": "log_range"}.get(
                 ema_type
             )
+            metric_timeframe = "1m"
+            if ema_type == "h1_log_range" and symbol in cache_only_symbols:
+                metric_key = "log_range"
+                metric_timeframe = "1h"
             for sp in spans:
                 Passivbot._raise_if_shutdown_requested(self, f"required_ema_{ema_type}")
                 span = float(sp)
@@ -16582,7 +16617,13 @@ class Passivbot:
                         continue
                     reason = f"non-finite {ema_type} value {val}"
                 if metric_key is not None:
-                    fallback = await fetch_cached_forager_metric(symbol, span, metric_key)
+                    fallback = await fetch_cached_forager_metric(
+                        symbol,
+                        span,
+                        metric_key,
+                        timeframe=metric_timeframe,
+                        diagnostic_key=ema_type,
+                    )
                     if fallback is not None:
                         out[span] = fallback
                         continue
@@ -16701,7 +16742,7 @@ class Passivbot:
             now_ms = int(utc_ms())
             max_fallback_age_ms = int(Passivbot._close_ema_fallback_max_age_ms(self))
             prev_by_span = self._orchestrator_prev_close_ema.setdefault(symbol, {})
-            missing: list[tuple[float, str]] = []
+            primary_missing: list[tuple[float, str]] = []
             for sp in spans:
                 Passivbot._raise_if_shutdown_requested(self, "close_ema")
                 span = float(sp)
@@ -16733,6 +16774,23 @@ class Passivbot:
                         reason = f"non-finite close EMA value {val}"
                 if reason is None:
                     continue
+                primary_missing.append((span, reason))
+            if not primary_missing:
+                return out
+
+            # A minute may finalize between the cycle's initial health snapshot
+            # and the EMA read. Recheck open-tail eligibility before carrying a
+            # previous EMA forward so live behavior uses the current projected
+            # completed-candle surface whenever that projection is valid.
+            if refresh_open_tail_projection_context(symbol) is not None:
+                detail = "; ".join(
+                    [f"span={sp:.8g} reason={why}" for sp, why in primary_missing]
+                )
+                raise MissingCloseEma(symbol, primary_missing, detail)
+
+            missing: list[tuple[float, str]] = []
+            for span, reason in primary_missing:
+                key = (symbol, span)
                 prev = prev_by_span.get(span)
                 if prev is not None:
                     prev_val = float(prev[0])
@@ -16990,7 +17048,9 @@ class Passivbot:
                             sym, sorted(need_close_spans[sym]), log_on_missing=False
                         )
                     except MissingCloseEma as exc:
-                        late_projection_ctx = refresh_open_tail_projection_context(sym)
+                        late_projection_ctx = projection_contexts.get(
+                            sym
+                        ) or refresh_open_tail_projection_context(sym)
                         if late_projection_ctx is None:
                             log_missing_close_ema(sym, exc.missing)
                             raise
@@ -17904,6 +17964,7 @@ class Passivbot:
         *,
         max_staleness_ms: Optional[int],
         window_candles: Optional[int] = None,
+        timeframe: str = "1m",
     ) -> dict[str, float]:
         """Read bounded cache-derived qv/log-range EMAs for stale forager ranking."""
         fn = getattr(self.cm, "get_latest_cached_ema_metrics", None)
@@ -17915,7 +17976,7 @@ class Passivbot:
                 spans_by_metric,
                 max_staleness_ms=max_staleness_ms,
                 window_candles=window_candles,
-                timeframe="1m",
+                timeframe=timeframe,
             )
         except Exception as exc:
             logging.debug(

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -167,6 +167,7 @@ async def test_latest_cached_h1_ema_metrics_use_h1_index(tmp_path):
     )
 
     assert out["log_range"] > 0.0
+    assert symbol not in cm._ema_cache
     too_stale = await cm.get_latest_cached_ema_metrics(
         symbol,
         {"log_range": 4.0},
@@ -175,6 +176,40 @@ async def test_latest_cached_h1_ema_metrics_use_h1_index(tmp_path):
         timeframe="1h",
     )
     assert too_stale == {}
+
+
+@pytest.mark.asyncio
+async def test_latest_cached_h1_ema_rejects_internal_gap_on_non_weex(tmp_path):
+    class _Ex:
+        id = "bybit"
+
+    cm = CandlestickManager(
+        exchange=_Ex(), exchange_name="bybit", cache_dir=str(tmp_path / "caches")
+    )
+    symbol = "GAPPED-H1/USDT:USDT"
+    hour_ms = 60 * ONE_MIN_MS
+    now_ms = 10 * hour_ms
+    cm._now_ms = lambda: now_ms
+    candles = np.array(
+        [
+            (5 * hour_ms, 100.0, 102.0, 99.0, 101.0, 2.0),
+            (6 * hour_ms, 101.0, 103.0, 100.0, 102.0, 3.0),
+            (8 * hour_ms, 104.0, 106.0, 103.0, 105.0, 5.0),
+        ],
+        dtype=CANDLE_DTYPE,
+    )
+    cm._persist_batch(symbol, candles, timeframe="1h")
+
+    out = await cm.get_latest_cached_ema_metrics(
+        symbol,
+        {"log_range": 4.0},
+        max_staleness_ms=60 * ONE_MIN_MS,
+        window_candles=4,
+        timeframe="1h",
+    )
+
+    assert out == {}
+    assert symbol not in cm._ema_cache
 
 
 @pytest.mark.parametrize("debug", [False])

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -129,6 +129,54 @@ async def test_latest_cached_ema_metrics_carries_values_without_tail_zeroing(tmp
     assert too_stale == {}
 
 
+@pytest.mark.asyncio
+async def test_latest_cached_h1_ema_metrics_use_h1_index(tmp_path):
+    class _Ex:
+        id = "weex"
+
+    cm = CandlestickManager(
+        exchange=_Ex(), exchange_name="weex", cache_dir=str(tmp_path / "caches")
+    )
+    symbol = "STALE-H1/USDT:USDT"
+    hour_ms = 60 * ONE_MIN_MS
+    now_ms = 10 * hour_ms
+    latest_expected = 9 * hour_ms
+    last_cached = 8 * hour_ms
+    cm._now_ms = lambda: now_ms
+    candles = np.array(
+        [
+            (5 * hour_ms, 100.0, 102.0, 99.0, 101.0, 2.0),
+            (6 * hour_ms, 101.0, 103.0, 100.0, 102.0, 3.0),
+            (7 * hour_ms, 102.0, 105.0, 101.0, 104.0, 4.0),
+            (last_cached, 104.0, 106.0, 103.0, 105.0, 5.0),
+        ],
+        dtype=CANDLE_DTYPE,
+    )
+    cm._persist_batch(symbol, candles, timeframe="1h")
+
+    assert cm.get_last_final_ts(symbol, timeframe="1h") == last_cached
+    cm._ensure_symbol_index(symbol, timeframe="1h")["meta"]["last_final_ts"] = 0
+    assert cm.get_last_final_ts(symbol, timeframe="1h") == last_cached
+    assert cm.get_last_final_ts(symbol) == 0
+    out = await cm.get_latest_cached_ema_metrics(
+        symbol,
+        {"log_range": 4.0},
+        max_staleness_ms=latest_expected - last_cached,
+        window_candles=4,
+        timeframe="1h",
+    )
+
+    assert out["log_range"] > 0.0
+    too_stale = await cm.get_latest_cached_ema_metrics(
+        symbol,
+        {"log_range": 4.0},
+        max_staleness_ms=30 * ONE_MIN_MS,
+        window_candles=4,
+        timeframe="1h",
+    )
+    assert too_stale == {}
+
+
 @pytest.mark.parametrize("debug", [False])
 def test_standardize_gaps_inserts_zero_candles(tmp_path, debug):
     class _Ex:

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -1437,6 +1437,45 @@ async def test_late_open_tail_projection_recovers_required_close_ema(caplog):
 
 
 @pytest.mark.asyncio
+async def test_late_open_tail_projection_precedes_available_previous_close_ema():
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    symbol = "ENA/USDT:USDT"
+    span0 = 10.0
+    span1 = 20.0
+    span2 = (span0 * span1) ** 0.5
+    prev = {span0: 100.04, span1: 100.03, span2: 100.02}
+    projected = {span0: 201.0, span1: 202.0, span2: 203.0}
+    bot = _BundleReproBot(
+        symbol,
+        close_mode="nan",
+        prev_close_ema=prev,
+        project_open_tail_after_health_calls=1,
+        projected_close_ema=projected,
+    )
+    bot.projected_open_tail_called = False
+
+    (
+        m1_close_emas,
+        _m1_volume_emas,
+        _m1_log_range_emas,
+        _h1_log_range_emas,
+        _volumes_long,
+        _log_ranges_long,
+    ) = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+        bot, [symbol], bot.PB_modes
+    )
+
+    assert bot.completed_candle_health_calls >= 2
+    assert bot.projected_open_tail_called is True
+    assert m1_close_emas[symbol] == pytest.approx(projected)
+    assert bot._orchestrator_close_ema_fallback_counts == {}
+
+
+@pytest.mark.asyncio
 async def test_late_open_tail_projection_recovers_required_m1_log_range():
     try:
         import passivbot as pb_mod
@@ -1729,6 +1768,76 @@ async def test_required_h1_log_range_ema_present_in_bundle():
     ) = await pb_mod.Passivbot._load_orchestrator_ema_bundle(bot, [symbol], bot.PB_modes)
 
     assert h1_log_range_emas[symbol][4.0] == pytest.approx(0.0042)
+
+
+@pytest.mark.asyncio
+async def test_cache_only_forager_uses_bounded_cached_h1_log_range(monkeypatch):
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    symbol = "AAVE/USDT:USDT"
+    hour_ms = 60 * 60_000
+    fixed_now_ms = 10 * hour_ms + 5 * 60_000
+    clock = {"now_ms": fixed_now_ms}
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: clock["now_ms"])
+    bot = _BundleReproBot(
+        symbol,
+        close_mode="value",
+        h1_mode="nan",
+        entry_h1_span_hours=4.0,
+        cached_qv_ema={10.0: 250000.0},
+        cached_log_range_ema={4.0: 0.0042, 10.0: 0.0015},
+        projected_close_ema={
+            10.0: 100.0,
+            (10.0 * 20.0) ** 0.5: 100.0,
+            20.0: 100.0,
+        },
+    )
+    bot.PB_modes = {"long": {symbol: "manual"}, "short": {symbol: "manual"}}
+    bot.active_symbols = []
+    bot.cm.get_last_refresh_ms = lambda _symbol: fixed_now_ms
+    bot.cm.get_last_final_ts = (
+        lambda _symbol, timeframe=None: 8 * hour_ms
+        if timeframe == "1h"
+        else fixed_now_ms - 60_000
+    )
+    bot._candle_staleness_ms = lambda _symbol, now_ms=None: 0
+    _enable_forager_required_ranking(bot)
+
+    (
+        _m1_close_emas,
+        _m1_volume_emas,
+        _m1_log_range_emas,
+        h1_log_range_emas,
+        _volumes_long,
+        _log_ranges_long,
+    ) = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+        bot, [symbol], bot.PB_modes
+    )
+
+    assert h1_log_range_emas[symbol][4.0] == pytest.approx(0.0042)
+    h1_calls = [
+        call for call in bot.cached_metric_calls if call["timeframe"] == "1h"
+    ]
+    assert len(h1_calls) == 1
+    assert h1_calls[0]["spans_by_metric"] == {"log_range": 4.0}
+    assert h1_calls[0]["max_staleness_ms"] >= 60 * 60_000
+
+    clock["now_ms"] = 10 * hour_ms + 11 * 60_000
+    (
+        _m1_close_emas,
+        _m1_volume_emas,
+        _m1_log_range_emas,
+        stale_h1_log_range_emas,
+        _volumes_long,
+        _log_ranges_long,
+    ) = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+        bot, [symbol], bot.PB_modes
+    )
+    assert stale_h1_log_range_emas[symbol] == {}
+    assert bot._orchestrator_ema_unavailable_symbols == {symbol}
 
 
 @pytest.mark.asyncio

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -1781,7 +1781,19 @@ async def test_cache_only_forager_uses_bounded_cached_h1_log_range(monkeypatch):
     hour_ms = 60 * 60_000
     fixed_now_ms = 10 * hour_ms + 5 * 60_000
     clock = {"now_ms": fixed_now_ms}
-    monkeypatch.setattr(pb_mod, "utc_ms", lambda: clock["now_ms"])
+    wall_clock_ms = fixed_now_ms + 365 * 24 * hour_ms
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: wall_clock_ms)
+    staleness_inputs = []
+
+    def target_staleness(_bot, surface_count, max_calls):
+        staleness_inputs.append((surface_count, max_calls))
+        return 10 * 60_000
+
+    monkeypatch.setattr(
+        pb_mod.Passivbot,
+        "_forager_target_staleness_ms",
+        target_staleness,
+    )
     bot = _BundleReproBot(
         symbol,
         close_mode="value",
@@ -1797,12 +1809,14 @@ async def test_cache_only_forager_uses_bounded_cached_h1_log_range(monkeypatch):
     )
     bot.PB_modes = {"long": {symbol: "manual"}, "short": {symbol: "manual"}}
     bot.active_symbols = []
+    bot.config["live"]["max_ohlcv_fetches_per_minute"] = 1
     bot.cm.get_last_refresh_ms = lambda _symbol: fixed_now_ms
     bot.cm.get_last_final_ts = (
         lambda _symbol, timeframe=None: 8 * hour_ms
         if timeframe == "1h"
         else fixed_now_ms - 60_000
     )
+    bot.cm._now_ms = lambda: clock["now_ms"]
     bot._candle_staleness_ms = lambda _symbol, now_ms=None: 0
     _enable_forager_required_ranking(bot)
 
@@ -1824,6 +1838,7 @@ async def test_cache_only_forager_uses_bounded_cached_h1_log_range(monkeypatch):
     assert len(h1_calls) == 1
     assert h1_calls[0]["spans_by_metric"] == {"log_range": 4.0}
     assert h1_calls[0]["max_staleness_ms"] >= 60 * 60_000
+    assert (2, 1) in staleness_inputs
 
     clock["now_ms"] = 10 * hour_ms + 11 * 60_000
     (


### PR DESCRIPTION
## Summary

- make native-timeframe cache metadata and cached EMA reads use the requested timeframe, including legacy higher-timeframe indexes whose top-level tail metadata is zero
- require complete cached carry-forward windows and keep those values isolated from the active-strategy EMA cache
- let cache-only forager candidates carry the previous native 1h log-range EMA only within the background refresher's surface-count staleness target, measured on the candle manager's active live/replay clock
- recheck newly emerged 1m open-tail projection eligibility before admitting previous-close EMA fallback
- document the native-1h carry-forward contract and add user-facing release notes

## Root cause

WEEX native 1h shards were present and complete, but the cache-only EMA reader anchored every request to the 1m index. At an hour boundary, inactive candidates therefore failed their required native 1h lookup until the background refresh caught up.

Separately, a minute could finalize after the orchestrator's initial candle-health snapshot. If close-EMA calculation then found the new tail missing and a previous EMA existed, the fallback was consumed immediately; the late open-tail projection retry only ran when no previous EMA was available. That inverted the intended projection-before-fallback order.

Review follow-up also found that the first implementation inherited exchange-specific sparse-window acceptance, wrote carried results into the shared active EMA cache, used wall time rather than the fake-live replay clock, and counted symbols rather than refreshable 1m/1h surfaces when deriving h1 freshness. The follow-up commit fixes all four boundaries.

A small public, unauthenticated CCXT probe returned continuous recent 1m and 1h sequences for BTC, AAVE, and WLD, supporting an orchestration/cache diagnosis rather than exchange-side missing buckets.

## Validation

- `PYTHONPATH=src python -m pytest -q tests/test_missing_ema_fix.py tests/test_candlestick_manager.py tests/test_live_candle_budget.py tests/test_coin_filtering.py` — 207 passed
- `PYTHONPATH=src python -m compileall -q src tests/test_missing_ema_fix.py tests/test_candlestick_manager.py`
- `git diff --check`

The repository-wide `pytest -q` command was also attempted, but collection was blocked by the shared development venv's pre-existing Rust source-stamp mismatch (`Loaded Rust extension does not match current Rust sources`). This branch changes no Rust source, and the isolated worktree was deliberately not allowed to rebuild or restamp the shared venv while orthogonal optimizer work is active.