### PR TITLE
Add balanced crash and pump suite optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ All notable user-facing changes will be documented in this file.
 - Optimizer suites may set `optimize.objective_scenario` (or
   `--objective-scenario LABEL`) to score performance objectives on one named scenario while
   continuing to enforce limits against configured suite aggregates. Suite scenario labels must
-  now be unique.
+  now be unique. Dataset preparation restricts exchange-specific preloads to the union of
+  explicitly requested scenario coins when every assigned scenario names its coins.
 
 - `passivbot tool crash-finder` can discover ordered low-to-later-high pumps as well as
   high-to-later-low crashes via `--direction up|both`. Generated idiosyncratic stress scenarios

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,14 @@ All notable user-facing changes will be documented in this file.
   `--objective-scenario LABEL`) to score performance objectives on one named scenario while
   continuing to enforce limits against configured suite aggregates. Suite scenario labels must
   now be unique. Dataset preparation restricts exchange-specific preloads to the union of
-  explicitly requested scenario coins when every assigned scenario names its coins.
+  explicitly requested scenario coins when every assigned scenario names its coins. Resume
+  validation rejects objective-scenario changes, including old results that predate the setting.
 
 - `passivbot tool crash-finder` can discover ordered low-to-later-high pumps as well as
   high-to-later-low crashes via `--direction up|both`. Generated idiosyncratic stress scenarios
   may use `--scenario-force-normal adverse` to isolate long exposure during crashes and short
-  exposure during pumps.
+  exposure during pumps. CSV regeneration preserves all stored directions unless explicitly
+  filtered with `--direction`.
 
 - Canonical live-event payloads now make a bounded JSON-compatible copy at construction time,
   revalidate that copy at persistence boundaries, redact sensitive keys before retention, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ All notable user-facing changes will be documented in this file.
   EMA, avoiding transient candidate drops and unnecessary close-EMA fallback on WEEX and other
   exchanges without weakening active-symbol fail-closed behavior.
 
+- Optimizer suites may set `optimize.objective_scenario` (or
+  `--objective-scenario LABEL`) to score performance objectives on one named scenario while
+  continuing to enforce limits against configured suite aggregates. Suite scenario labels must
+  now be unique.
+
+- `passivbot tool crash-finder` can discover ordered low-to-later-high pumps as well as
+  high-to-later-low crashes via `--direction up|both`. Generated idiosyncratic stress scenarios
+  may use `--scenario-force-normal adverse` to isolate long exposure during crashes and short
+  exposure during pumps.
+
 - Canonical live-event payloads now make a bounded JSON-compatible copy at construction time,
   revalidate that copy at persistence boundaries, redact sensitive keys before retention, and
   record aggregate truncation metadata only when a limit applies. Event identity, routing, monitor

--- a/configs/ema_anchor_opt_balanced_2026-07-24.json
+++ b/configs/ema_anchor_opt_balanced_2026-07-24.json
@@ -1,0 +1,1226 @@
+{
+    "backtest": {
+        "aggregate": {
+            "default": "mean"
+        },
+        "balance_sample_divider": 60,
+        "base_dir": "backtests",
+        "btc_collateral_cap": 0.0,
+        "btc_collateral_ltv_cap": null,
+        "candle_interval_minutes": 1,
+        "coin_sources": {},
+        "compress_cache": true,
+        "dynamic_wel_by_tradability": true,
+        "end_date": "now",
+        "exchanges": [
+            "binance",
+            "bybit"
+        ],
+        "filter_by_min_effective_cost": false,
+        "gap_tolerance_ohlcvs_minutes": 120,
+        "hlcvs_data_dir": null,
+        "hlcvs_data_override_mode": "intersection",
+        "liquidation_threshold": 0.05,
+        "maker_fee_override": 0.0004,
+        "market_order_slippage_pct": 0.0005,
+        "market_settings": {
+            "overrides": {},
+            "overrides_by_exchange": {}
+        },
+        "market_settings_sources": {},
+        "ohlcv_source_dir": null,
+        "scenarios": [
+            {
+                "label": "base",
+                "start_date": "2022-06-01"
+            },
+            {
+                "label": "crash_2020_03_13_02_market_wide",
+                "start_date": "2020-03-06",
+                "end_date": "2020-04-17",
+                "coins": [
+                    "ATOM",
+                    "BCH",
+                    "BNB",
+                    "ETH",
+                    "LTC",
+                    "TRX"
+                ],
+                "exchanges": [
+                    "binance"
+                ],
+                "overrides": {
+                    "bot.short.risk.total_wallet_exposure_limit": 0.0
+                }
+            },
+            {
+                "label": "pump_2020_03_13_02_market_wide",
+                "start_date": "2020-03-06",
+                "end_date": "2020-04-17",
+                "coins": [
+                    "ATOM",
+                    "BCH",
+                    "BNB",
+                    "ETH",
+                    "LTC",
+                    "TRX",
+                    "XRP"
+                ],
+                "exchanges": [
+                    "binance"
+                ],
+                "overrides": {
+                    "bot.long.risk.total_wallet_exposure_limit": 0.0
+                }
+            },
+            {
+                "label": "crash_2021_05_19_12_market_wide",
+                "start_date": "2021-05-12",
+                "end_date": "2021-06-23",
+                "coins": [
+                    "AAVE",
+                    "ADA",
+                    "ATOM",
+                    "AVAX",
+                    "BCH",
+                    "BNB",
+                    "BTC",
+                    "DOGE",
+                    "DOT",
+                    "ETC",
+                    "ETH",
+                    "FIL",
+                    "HBAR",
+                    "LINK",
+                    "LTC",
+                    "NEAR",
+                    "SOL",
+                    "TRX",
+                    "UNI",
+                    "XLM",
+                    "XMR",
+                    "XRP",
+                    "ZEC"
+                ],
+                "exchanges": [
+                    "binance",
+                    "bybit"
+                ],
+                "overrides": {
+                    "bot.short.risk.total_wallet_exposure_limit": 0.0
+                }
+            },
+            {
+                "label": "pump_2021_05_19_13_market_wide",
+                "start_date": "2021-05-12",
+                "end_date": "2021-06-23",
+                "coins": [
+                    "AAVE",
+                    "ADA",
+                    "ATOM",
+                    "AVAX",
+                    "BCH",
+                    "BNB",
+                    "BTC",
+                    "DOGE",
+                    "DOT",
+                    "ETC",
+                    "ETH",
+                    "FIL",
+                    "HBAR",
+                    "LINK",
+                    "LTC",
+                    "NEAR",
+                    "SOL",
+                    "TRX",
+                    "UNI",
+                    "XLM",
+                    "XMR",
+                    "XRP",
+                    "ZEC"
+                ],
+                "exchanges": [
+                    "binance",
+                    "bybit"
+                ],
+                "overrides": {
+                    "bot.long.risk.total_wallet_exposure_limit": 0.0
+                }
+            },
+            {
+                "label": "crash_2022_05_11_12_market_wide",
+                "start_date": "2022-05-04",
+                "end_date": "2022-06-15",
+                "coins": [
+                    "AAVE",
+                    "ADA",
+                    "ALGO",
+                    "ATOM",
+                    "AVAX",
+                    "BCH",
+                    "BNB",
+                    "CRO",
+                    "DOGE",
+                    "DOT",
+                    "ETC",
+                    "ETH",
+                    "FIL",
+                    "HBAR",
+                    "ICP",
+                    "JST",
+                    "LINK",
+                    "LTC",
+                    "NEAR",
+                    "SHIB",
+                    "SOL",
+                    "TRX",
+                    "UNI",
+                    "XLM",
+                    "XMR",
+                    "XRP",
+                    "ZEC"
+                ],
+                "exchanges": [
+                    "binance",
+                    "bybit"
+                ],
+                "overrides": {
+                    "bot.short.risk.total_wallet_exposure_limit": 0.0
+                }
+            },
+            {
+                "label": "pump_2022_05_11_13_market_wide",
+                "start_date": "2022-05-04",
+                "end_date": "2022-06-15",
+                "coins": [
+                    "AAVE",
+                    "ADA",
+                    "ALGO",
+                    "ATOM",
+                    "AVAX",
+                    "BCH",
+                    "BNB",
+                    "DOGE",
+                    "DOT",
+                    "ETC",
+                    "ETH",
+                    "FIL",
+                    "HBAR",
+                    "ICP",
+                    "JST",
+                    "LINK",
+                    "LTC",
+                    "NEAR",
+                    "SHIB",
+                    "SOL",
+                    "TRX",
+                    "UNI",
+                    "XMR",
+                    "XRP",
+                    "ZEC"
+                ],
+                "exchanges": [
+                    "binance",
+                    "bybit"
+                ],
+                "overrides": {
+                    "bot.long.risk.total_wallet_exposure_limit": 0.0
+                }
+            },
+            {
+                "label": "crash_2024_01_03_12_market_wide",
+                "start_date": "2023-12-27",
+                "end_date": "2024-02-07",
+                "coins": [
+                    "AAVE",
+                    "ADA",
+                    "ALGO",
+                    "APT",
+                    "ARB",
+                    "ATOM",
+                    "AVAX",
+                    "BCH",
+                    "BNB",
+                    "CRO",
+                    "DOGE",
+                    "DOT",
+                    "ETC",
+                    "ETH",
+                    "FIL",
+                    "HBAR",
+                    "ICP",
+                    "INJ",
+                    "KAS",
+                    "LINK",
+                    "LTC",
+                    "NEAR",
+                    "PEPE",
+                    "QNT",
+                    "SHIB",
+                    "SOL",
+                    "SUI",
+                    "TON",
+                    "UNI",
+                    "WLD",
+                    "XLM",
+                    "XMR",
+                    "XRP",
+                    "ZEC"
+                ],
+                "exchanges": [
+                    "binance",
+                    "bybit"
+                ],
+                "overrides": {
+                    "bot.short.risk.total_wallet_exposure_limit": 0.0
+                }
+            },
+            {
+                "label": "pump_2024_01_03_12_market_wide",
+                "start_date": "2023-12-27",
+                "end_date": "2024-02-07",
+                "coins": [
+                    "AAVE",
+                    "ADA",
+                    "ALGO",
+                    "APT",
+                    "ARB",
+                    "ATOM",
+                    "AVAX",
+                    "BNB",
+                    "CRO",
+                    "DOGE",
+                    "DOT",
+                    "ETC",
+                    "FIL",
+                    "HBAR",
+                    "ICP",
+                    "INJ",
+                    "KAS",
+                    "LINK",
+                    "LTC",
+                    "NEAR",
+                    "PEPE",
+                    "QNT",
+                    "SHIB",
+                    "SOL",
+                    "SUI",
+                    "TON",
+                    "UNI",
+                    "WLD",
+                    "XLM",
+                    "XMR",
+                    "XRP",
+                    "ZEC"
+                ],
+                "exchanges": [
+                    "binance",
+                    "bybit"
+                ],
+                "overrides": {
+                    "bot.long.risk.total_wallet_exposure_limit": 0.0
+                }
+            },
+            {
+                "label": "crash_2025_10_10_21_market_wide",
+                "start_date": "2025-10-03",
+                "end_date": "2025-11-14",
+                "coins": [
+                    "AAVE",
+                    "ADA",
+                    "ALGO",
+                    "APT",
+                    "ARB",
+                    "ASTER",
+                    "ATOM",
+                    "AVAX",
+                    "BCH",
+                    "BNB",
+                    "BTC",
+                    "CRO",
+                    "DEXE",
+                    "DOGE",
+                    "DOT",
+                    "ENA",
+                    "ETC",
+                    "ETH",
+                    "FIL",
+                    "HBAR",
+                    "HYPE",
+                    "ICP",
+                    "INJ",
+                    "JST",
+                    "KAS",
+                    "LINK",
+                    "LTC",
+                    "M",
+                    "MNT",
+                    "MORPHO",
+                    "NEAR",
+                    "OKB",
+                    "OM",
+                    "ONDO",
+                    "PAXG",
+                    "PEPE",
+                    "POL",
+                    "QNT",
+                    "RENDER",
+                    "SHIB",
+                    "SKY",
+                    "SOL",
+                    "SUI",
+                    "TAO",
+                    "TON",
+                    "UNI",
+                    "WLD",
+                    "WLFI",
+                    "XLM",
+                    "XMR",
+                    "XRP",
+                    "ZEC"
+                ],
+                "exchanges": [
+                    "binance",
+                    "bybit"
+                ],
+                "overrides": {
+                    "bot.short.risk.total_wallet_exposure_limit": 0.0
+                }
+            },
+            {
+                "label": "pump_2025_10_10_21_market_wide",
+                "start_date": "2025-10-03",
+                "end_date": "2025-11-14",
+                "coins": [
+                    "AAVE",
+                    "ADA",
+                    "ALGO",
+                    "APT",
+                    "ARB",
+                    "ASTER",
+                    "ATOM",
+                    "AVAX",
+                    "BCH",
+                    "BNB",
+                    "BTC",
+                    "CRO",
+                    "DEXE",
+                    "DOGE",
+                    "DOT",
+                    "ENA",
+                    "ETC",
+                    "ETH",
+                    "FIL",
+                    "HBAR",
+                    "HYPE",
+                    "ICP",
+                    "INJ",
+                    "JST",
+                    "KAS",
+                    "LINK",
+                    "LTC",
+                    "M",
+                    "MNT",
+                    "MORPHO",
+                    "NEAR",
+                    "OKB",
+                    "OM",
+                    "ONDO",
+                    "PAXG",
+                    "PEPE",
+                    "POL",
+                    "QNT",
+                    "RENDER",
+                    "SHIB",
+                    "SKY",
+                    "SOL",
+                    "SUI",
+                    "TAO",
+                    "TON",
+                    "UNI",
+                    "WLD",
+                    "WLFI",
+                    "XLM",
+                    "XMR",
+                    "XRP",
+                    "ZEC"
+                ],
+                "exchanges": [
+                    "binance",
+                    "bybit"
+                ],
+                "overrides": {
+                    "bot.long.risk.total_wallet_exposure_limit": 0.0
+                }
+            },
+            {
+                "label": "crash_2025_04_13_18_om",
+                "start_date": "2025-04-06",
+                "end_date": "2025-05-18",
+                "coins": [
+                    "OM"
+                ],
+                "exchanges": [
+                    "binance"
+                ],
+                "overrides": {
+                    "coin_overrides": {
+                        "OM": {
+                            "live": {
+                                "forced_mode_long": "normal",
+                                "forced_mode_short": "manual"
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "label": "crash_2025_06_02_19_dexe",
+                "start_date": "2025-05-26",
+                "end_date": "2025-07-07",
+                "coins": [
+                    "DEXE"
+                ],
+                "exchanges": [
+                    "binance",
+                    "bybit"
+                ],
+                "overrides": {
+                    "coin_overrides": {
+                        "DEXE": {
+                            "live": {
+                                "forced_mode_long": "normal",
+                                "forced_mode_short": "manual"
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "label": "pump_2021_11_18_04_algo",
+                "start_date": "2021-11-11",
+                "end_date": "2021-12-23",
+                "coins": [
+                    "ALGO"
+                ],
+                "exchanges": [
+                    "bybit"
+                ],
+                "overrides": {
+                    "coin_overrides": {
+                        "ALGO": {
+                            "live": {
+                                "forced_mode_long": "manual",
+                                "forced_mode_short": "normal"
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "label": "pump_2024_02_23_14_uni",
+                "start_date": "2024-02-16",
+                "end_date": "2024-03-29",
+                "coins": [
+                    "UNI"
+                ],
+                "exchanges": [
+                    "binance",
+                    "bybit"
+                ],
+                "overrides": {
+                    "coin_overrides": {
+                        "UNI": {
+                            "live": {
+                                "forced_mode_long": "manual",
+                                "forced_mode_short": "normal"
+                            }
+                        }
+                    }
+                }
+            }
+        ],
+        "start_date": "2021-04-20",
+        "starting_balance": 100000,
+        "suite_enabled": true,
+        "taker_fee_override": 0.00055,
+        "visible_metrics": [
+            "adg_strategy_eq",
+            "sortino_ratio_strategy_eq",
+            "strategy_eq_recovery_days_max",
+            "position_held_days_max",
+            "drawdown_worst_strategy_eq",
+            "loss_profit_ratio",
+            "backtest_completion_ratio"
+        ],
+        "volume_normalization": true
+    },
+    "bot": {
+        "long": {
+            "forager": {
+                "score_weights": {
+                    "ema_readiness": 0.08,
+                    "volatility": 0.48,
+                    "volume": 0.44
+                },
+                "volatility_ema_span_1m": 661.0,
+                "volume_drop_pct": 0.06,
+                "volume_ema_span_1m": 2369.0
+            },
+            "hsl": {
+                "cooldown_minutes_after_red": 3981.0,
+                "ema_span_minutes": 644.0,
+                "enabled": false,
+                "no_restart_drawdown_threshold": 1,
+                "orange_tier_mode": "tp_only_with_active_entry_cancellation",
+                "panic_close_order_type": "limit",
+                "red_threshold": 0.025,
+                "tier_ratios": {
+                    "orange": 0.75,
+                    "yellow": 0.5
+                }
+            },
+            "risk": {
+                "entry_cooldown_minutes": 7.1,
+                "n_positions": 5.0,
+                "position_exposure_enforcer_enabled": false,
+                "position_exposure_enforcer_threshold": 1.0,
+                "total_exposure_enforcer_enabled": false,
+                "total_exposure_enforcer_policy": "reduce_overweight",
+                "total_exposure_enforcer_threshold": 1.004,
+                "total_exposure_entry_gate_enabled": true,
+                "total_wallet_exposure_limit": 1.0,
+                "we_excess_allowance_mode": "bounded",
+                "we_excess_allowance_pct": 0.2
+            },
+            "strategy": {
+                "ema_anchor": {
+                    "base_qty_pct": 0.06,
+                    "ema_span_0": 415.0,
+                    "ema_span_1": 793.0,
+                    "entry_double_down_factor": 1.2,
+                    "offset": 0.0193,
+                    "offset_psize_weight": 0.3576,
+                    "offset_volatility_1h_weight": 13.0,
+                    "offset_volatility_1m_weight": 0.4,
+                    "offset_volatility_ema_span_1h": 448.0,
+                    "offset_volatility_ema_span_1m": 664.0
+                }
+            },
+            "unstuck": {
+                "close_pct": 0.028,
+                "ema_dist": -0.086,
+                "ema_gating_enabled": true,
+                "enabled": false,
+                "loss_allowance_pct": 0.0065,
+                "threshold": 0.46
+            }
+        },
+        "short": {
+            "forager": {
+                "score_weights": {
+                    "ema_readiness": 0.08,
+                    "volatility": 0.48,
+                    "volume": 0.44
+                },
+                "volatility_ema_span_1m": 661.0,
+                "volume_drop_pct": 0.06,
+                "volume_ema_span_1m": 2369.0
+            },
+            "hsl": {
+                "cooldown_minutes_after_red": 3981.0,
+                "ema_span_minutes": 644.0,
+                "enabled": false,
+                "no_restart_drawdown_threshold": 1,
+                "orange_tier_mode": "tp_only_with_active_entry_cancellation",
+                "panic_close_order_type": "limit",
+                "red_threshold": 0.025,
+                "tier_ratios": {
+                    "orange": 0.75,
+                    "yellow": 0.5
+                }
+            },
+            "risk": {
+                "entry_cooldown_minutes": 7.1,
+                "n_positions": 5.0,
+                "position_exposure_enforcer_enabled": false,
+                "position_exposure_enforcer_threshold": 1.0,
+                "total_exposure_enforcer_enabled": false,
+                "total_exposure_enforcer_policy": "reduce_overweight",
+                "total_exposure_enforcer_threshold": 1.004,
+                "total_exposure_entry_gate_enabled": true,
+                "total_wallet_exposure_limit": 1.0,
+                "we_excess_allowance_mode": "bounded",
+                "we_excess_allowance_pct": 0.2
+            },
+            "strategy": {
+                "ema_anchor": {
+                    "base_qty_pct": 0.06,
+                    "ema_span_0": 415.0,
+                    "ema_span_1": 793.0,
+                    "entry_double_down_factor": 1.2,
+                    "offset": 0.0193,
+                    "offset_psize_weight": 0.3576,
+                    "offset_volatility_1h_weight": 13.0,
+                    "offset_volatility_1m_weight": 0.4,
+                    "offset_volatility_ema_span_1h": 448.0,
+                    "offset_volatility_ema_span_1m": 664.0
+                }
+            },
+            "unstuck": {
+                "close_pct": 0.028,
+                "ema_dist": -0.086,
+                "ema_gating_enabled": true,
+                "enabled": false,
+                "loss_allowance_pct": 0.0065,
+                "threshold": 0.46
+            }
+        }
+    },
+    "coin_overrides": {},
+    "config_version": "v8.0.0",
+    "live": {
+        "approved_coins": [
+            "BTC",
+            "ETH",
+            "BNB",
+            "XRP",
+            "SOL",
+            "TRX",
+            "HYPE",
+            "DOGE",
+            "ZEC",
+            "XLM",
+            "ADA",
+            "LINK",
+            "XMR",
+            "CC",
+            "BCH",
+            "GRAM",
+            "LTC",
+            "HBAR",
+            "SUI",
+            "AVAX",
+            "NEAR",
+            "UNI",
+            "TAO",
+            "ASTER",
+            "ONDO",
+            "AAVE",
+            "DOT",
+            "WLD",
+            "MNT",
+            "MORPHO",
+            "POL",
+            "ATOM",
+            "RENDER",
+            "KAS",
+            "ENA",
+            "ALGO",
+            "FIL",
+            "ARB",
+            "APT",
+            "INJ"
+        ],
+        "auto_gs": true,
+        "balance_hysteresis_snap_pct": 0.01,
+        "balance_override": null,
+        "candle_lock_timeout_seconds": 10,
+        "custom_endpoints_path": null,
+        "defer_broad_candle_warmup": true,
+        "enable_archive_candle_fetch": false,
+        "execution_delay_seconds": 2,
+        "fee_conversion_max_age_ms": 86400000,
+        "fee_pct_fallback": 0.0002,
+        "fee_pct_sanity_abs_max": 0.001,
+        "fills_confirmation_overlap_minutes": 60,
+        "fills_recent_overlap_minutes": 10,
+        "filter_by_min_effective_cost": true,
+        "forager_score_hysteresis_pct": 0.02,
+        "force_cold_startup": false,
+        "forced_mode_long": "",
+        "forced_mode_short": "",
+        "hedge_mode": false,
+        "hsl_accept_incomplete_history": false,
+        "hsl_position_during_cooldown_policy": "panic",
+        "hsl_signal_mode": "coin",
+        "ignored_coins": {
+            "long": [],
+            "short": []
+        },
+        "inactive_coin_candle_ttl_minutes": 10,
+        "initial_entry_exec_max_market_dist_pct": 0.005,
+        "leverage": 10,
+        "limit_order_create_max_market_dist_pct": 0.8,
+        "margin_mode_preference": "cross",
+        "market_order_near_touch_threshold": 0.001,
+        "market_orders_allowed": false,
+        "market_snapshot_ticker_strategy": "auto",
+        "max_active_candle_tail_gap_minutes": 10,
+        "max_concurrent_api_requests": null,
+        "max_disk_candles_per_symbol_per_tf": 2000000,
+        "max_forager_candle_refresh_seconds": 45,
+        "max_forager_candle_staleness_minutes": null,
+        "max_memory_candles_per_symbol": 200000,
+        "max_n_cancellations_per_batch": 5,
+        "max_n_creations_per_batch": 3,
+        "max_n_restarts_per_day": 10,
+        "max_ohlcv_fetches_per_minute": 30,
+        "max_realized_loss_pct": 1,
+        "max_warmup_minutes": 0,
+        "minimum_coin_age_days": 60,
+        "order_match_tolerance_pct": 0.0002,
+        "pnls_max_lookback_days": 30.0,
+        "recv_window_ms": 5000,
+        "strategy_kind": "ema_anchor",
+        "time_in_force": "good_till_cancelled",
+        "user": "hyperliquid_canon",
+        "warmup_concurrency": 0,
+        "warmup_jitter_seconds": 30,
+        "warmup_ratio": 0.3
+    },
+    "logging": {
+        "backup_count": 5,
+        "dir": "logs",
+        "level": 1,
+        "live_event_debug_profiles": [],
+        "max_bytes_mb": 10.0,
+        "memory_snapshot_interval_minutes": 30,
+        "persist_to_file": true,
+        "rotation": false,
+        "volume_refresh_info_threshold_seconds": 30
+    },
+    "monitor": {
+        "checkpoint_interval_minutes": 10.0,
+        "compress_rotated_segments": true,
+        "emit_completed_candles": true,
+        "enabled": true,
+        "event_rotation_mb": 128.0,
+        "event_rotation_minutes": 60.0,
+        "include_raw_fill_payloads": false,
+        "max_total_bytes": 1073741824,
+        "price_tick_min_interval_ms": 500,
+        "retain_candles": true,
+        "retain_days": 7.0,
+        "retain_fills": true,
+        "retain_price_ticks": true,
+        "root_dir": "monitor",
+        "snapshot_interval_seconds": 1.0
+    },
+    "optimize": {
+        "backend": "pymoo",
+        "bounds": {
+            "long": {
+                "forager": {
+                    "score_weights_ema_readiness": [
+                        0,
+                        1,
+                        0.01
+                    ],
+                    "score_weights_volatility": [
+                        0,
+                        1,
+                        0.01
+                    ],
+                    "score_weights_volume": [
+                        0,
+                        1,
+                        0.01
+                    ],
+                    "volatility_ema_span_1m": [
+                        10,
+                        2880,
+                        1
+                    ],
+                    "volume_drop_pct": [
+                        0.02,
+                        1,
+                        0.01
+                    ],
+                    "volume_ema_span_1m": [
+                        180,
+                        2880,
+                        1
+                    ]
+                },
+                "hsl": {
+                    "cooldown_minutes_after_red": [
+                        2160,
+                        2160,
+                        10
+                    ],
+                    "ema_span_minutes": [
+                        720,
+                        720,
+                        1
+                    ],
+                    "red_threshold": [
+                        0.15,
+                        0.15,
+                        0.001
+                    ]
+                },
+                "risk": {
+                    "entry_cooldown_minutes": [
+                        0,
+                        60,
+                        0.1
+                    ],
+                    "n_positions": [
+                        3,
+                        10
+                    ],
+                    "position_exposure_enforcer_threshold": [
+                        1,
+                        1,
+                        0.001
+                    ],
+                    "total_exposure_enforcer_threshold": [
+                        0.8,
+                        1.01,
+                        0.001
+                    ],
+                    "total_wallet_exposure_limit": [
+                        0.1,
+                        1.2,
+                        0.01
+                    ],
+                    "we_excess_allowance_pct": [
+                        0.0,
+                        0.25,
+                        0.01
+                    ]
+                },
+                "strategy": {
+                    "ema_anchor": {
+                        "base_qty_pct": [
+                            0.001,
+                            0.08,
+                            0.0001
+                        ],
+                        "ema_span_0": [
+                            30,
+                            2880,
+                            1
+                        ],
+                        "ema_span_1": [
+                            30,
+                            2880,
+                            1
+                        ],
+                        "entry_double_down_factor": [
+                            0.0,
+                            1.5,
+                            0.01
+                        ],
+                        "offset_volatility_ema_span_1h": [
+                            1,
+                            672,
+                            1
+                        ],
+                        "offset": [
+                            0.0001,
+                            0.02,
+                            0.0001
+                        ],
+                        "offset_psize_weight": [
+                            0,
+                            5,
+                            0.0001
+                        ],
+                        "offset_volatility_1h_weight": [
+                            0,
+                            20,
+                            0.1
+                        ],
+                        "offset_volatility_1m_weight": [
+                            0,
+                            20,
+                            0.1
+                        ],
+                        "offset_volatility_ema_span_1m": [
+                            5,
+                            720,
+                            1
+                        ]
+                    }
+                },
+                "unstuck": {
+                    "close_pct": [
+                        0.01,
+                        0.12,
+                        0.001
+                    ],
+                    "ema_dist": [
+                        -0.2,
+                        0.01,
+                        0.0001
+                    ],
+                    "loss_allowance_pct": [
+                        0.005,
+                        0.2,
+                        0.0001
+                    ],
+                    "threshold": [
+                        0.4,
+                        0.9,
+                        0.001
+                    ]
+                }
+            },
+            "short": {
+                "forager": {
+                    "score_weights_ema_readiness": [
+                        0,
+                        1,
+                        0.01
+                    ],
+                    "score_weights_volatility": [
+                        0,
+                        1,
+                        0.01
+                    ],
+                    "score_weights_volume": [
+                        0,
+                        1,
+                        0.01
+                    ],
+                    "volatility_ema_span_1m": [
+                        10,
+                        2880,
+                        1
+                    ],
+                    "volume_drop_pct": [
+                        0.02,
+                        1,
+                        0.01
+                    ],
+                    "volume_ema_span_1m": [
+                        180,
+                        2880,
+                        1
+                    ]
+                },
+                "hsl": {
+                    "cooldown_minutes_after_red": [
+                        2160,
+                        2160,
+                        10
+                    ],
+                    "ema_span_minutes": [
+                        720,
+                        720,
+                        1
+                    ],
+                    "red_threshold": [
+                        0.15,
+                        0.15,
+                        0.001
+                    ]
+                },
+                "risk": {
+                    "entry_cooldown_minutes": [
+                        0,
+                        60,
+                        0.1
+                    ],
+                    "n_positions": [
+                        3,
+                        10
+                    ],
+                    "position_exposure_enforcer_threshold": [
+                        1,
+                        1,
+                        0.001
+                    ],
+                    "total_exposure_enforcer_threshold": [
+                        0.8,
+                        1.01,
+                        0.001
+                    ],
+                    "total_wallet_exposure_limit": [
+                        0.1,
+                        1.2,
+                        0.01
+                    ],
+                    "we_excess_allowance_pct": [
+                        0.0,
+                        0.25,
+                        0.01
+                    ]
+                },
+                "strategy": {
+                    "ema_anchor": {
+                        "base_qty_pct": [
+                            0.001,
+                            0.08,
+                            0.0001
+                        ],
+                        "ema_span_0": [
+                            30,
+                            2880,
+                            1
+                        ],
+                        "ema_span_1": [
+                            30,
+                            2880,
+                            1
+                        ],
+                        "entry_double_down_factor": [
+                            0.0,
+                            1.5,
+                            0.01
+                        ],
+                        "offset_volatility_ema_span_1h": [
+                            1,
+                            672,
+                            1
+                        ],
+                        "offset": [
+                            0.0001,
+                            0.02,
+                            0.0001
+                        ],
+                        "offset_psize_weight": [
+                            0,
+                            5,
+                            0.0001
+                        ],
+                        "offset_volatility_1h_weight": [
+                            0,
+                            20,
+                            0.1
+                        ],
+                        "offset_volatility_1m_weight": [
+                            0,
+                            20,
+                            0.1
+                        ],
+                        "offset_volatility_ema_span_1m": [
+                            5,
+                            720,
+                            1
+                        ]
+                    }
+                },
+                "unstuck": {
+                    "close_pct": [
+                        0.01,
+                        0.12,
+                        0.001
+                    ],
+                    "ema_dist": [
+                        -0.2,
+                        0.01,
+                        0.0001
+                    ],
+                    "loss_allowance_pct": [
+                        0.005,
+                        0.2,
+                        0.0001
+                    ],
+                    "threshold": [
+                        0.4,
+                        0.9,
+                        0.001
+                    ]
+                }
+            }
+        },
+        "compress_results_file": true,
+        "crossover_eta": 20,
+        "crossover_probability": 0.64,
+        "enable_overrides": [],
+        "fixed_params": [
+            "long.unstuck",
+            "short.unstuck"
+        ],
+        "fixed_runtime_overrides": {
+            "bot.long.hsl.restart_after_red_policy": "always",
+            "bot.short.hsl.restart_after_red_policy": "always"
+        },
+        "iters": 500000,
+        "limits": [
+            {
+                "enabled": true,
+                "metric": "drawdown_worst_strategy_eq",
+                "penalize_if": "greater_than",
+                "stat": "max",
+                "value": 0.5
+            },
+            {
+                "enabled": true,
+                "metric": "backtest_completion_ratio",
+                "penalize_if": "less_than",
+                "stat": "min",
+                "value": 0.995
+            },
+            {
+                "enabled": true,
+                "metric": "strategy_eq_recovery_days_max",
+                "penalize_if": "greater_than",
+                "stat": "max",
+                "value": 120.0
+            },
+            {
+                "enabled": true,
+                "metric": "position_held_days_max",
+                "penalize_if": "greater_than",
+                "stat": "max",
+                "value": 60.0
+            }
+        ],
+        "mutation_eta": 20,
+        "mutation_indpb": 0.0135135135,
+        "mutation_probability": 0.34,
+        "n_cpus": 16,
+        "offspring_multiplier": 1,
+        "pareto_max_size": 3000,
+        "population_size": 256,
+        "pymoo": {
+            "algorithm": "auto",
+            "algorithms": {
+                "nsga2": {},
+                "nsga3": {
+                    "ref_dirs": {
+                        "method": "das_dennis",
+                        "n_partitions": "auto"
+                    }
+                }
+            },
+            "shared": {
+                "crossover_eta": 20.0,
+                "crossover_prob_var": 0.5,
+                "eliminate_duplicates": true,
+                "mutation_eta": 20.0,
+                "mutation_prob_var": "auto"
+            }
+        },
+        "round_to_n_significant_digits": 3,
+        "scoring": [
+            {
+                "goal": "max",
+                "metric": "adg_strategy_eq"
+            },
+            {
+                "goal": "max",
+                "metric": "sortino_ratio_strategy_eq"
+            },
+            {
+                "goal": "min",
+                "metric": "strategy_eq_recovery_days_max"
+            },
+            {
+                "goal": "min",
+                "metric": "position_held_days_max"
+            },
+            {
+                "goal": "min",
+                "metric": "drawdown_worst_strategy_eq"
+            }
+        ],
+        "seed": null,
+        "write_all_results": true,
+        "objective_scenario": "base"
+    }
+}

--- a/configs/suites/ema_anchor_balanced_stress_2026-07-24.json
+++ b/configs/suites/ema_anchor_balanced_stress_2026-07-24.json
@@ -1,0 +1,515 @@
+{
+    "backtest": {
+        "suite_enabled": true,
+        "scenarios": [
+            {
+                "label": "crash_2020_03_13_02_market_wide",
+                "start_date": "2020-03-06",
+                "end_date": "2020-04-17",
+                "coins": [
+                    "ATOM",
+                    "BCH",
+                    "BNB",
+                    "ETH",
+                    "LTC",
+                    "TRX"
+                ],
+                "exchanges": [
+                    "binance"
+                ],
+                "overrides": {
+                    "bot.short.risk.total_wallet_exposure_limit": 0.0
+                }
+            },
+            {
+                "label": "pump_2020_03_13_02_market_wide",
+                "start_date": "2020-03-06",
+                "end_date": "2020-04-17",
+                "coins": [
+                    "ATOM",
+                    "BCH",
+                    "BNB",
+                    "ETH",
+                    "LTC",
+                    "TRX",
+                    "XRP"
+                ],
+                "exchanges": [
+                    "binance"
+                ],
+                "overrides": {
+                    "bot.long.risk.total_wallet_exposure_limit": 0.0
+                }
+            },
+            {
+                "label": "crash_2021_05_19_12_market_wide",
+                "start_date": "2021-05-12",
+                "end_date": "2021-06-23",
+                "coins": [
+                    "AAVE",
+                    "ADA",
+                    "ATOM",
+                    "AVAX",
+                    "BCH",
+                    "BNB",
+                    "BTC",
+                    "DOGE",
+                    "DOT",
+                    "ETC",
+                    "ETH",
+                    "FIL",
+                    "HBAR",
+                    "LINK",
+                    "LTC",
+                    "NEAR",
+                    "SOL",
+                    "TRX",
+                    "UNI",
+                    "XLM",
+                    "XMR",
+                    "XRP",
+                    "ZEC"
+                ],
+                "exchanges": [
+                    "binance",
+                    "bybit"
+                ],
+                "overrides": {
+                    "bot.short.risk.total_wallet_exposure_limit": 0.0
+                }
+            },
+            {
+                "label": "pump_2021_05_19_13_market_wide",
+                "start_date": "2021-05-12",
+                "end_date": "2021-06-23",
+                "coins": [
+                    "AAVE",
+                    "ADA",
+                    "ATOM",
+                    "AVAX",
+                    "BCH",
+                    "BNB",
+                    "BTC",
+                    "DOGE",
+                    "DOT",
+                    "ETC",
+                    "ETH",
+                    "FIL",
+                    "HBAR",
+                    "LINK",
+                    "LTC",
+                    "NEAR",
+                    "SOL",
+                    "TRX",
+                    "UNI",
+                    "XLM",
+                    "XMR",
+                    "XRP",
+                    "ZEC"
+                ],
+                "exchanges": [
+                    "binance",
+                    "bybit"
+                ],
+                "overrides": {
+                    "bot.long.risk.total_wallet_exposure_limit": 0.0
+                }
+            },
+            {
+                "label": "crash_2022_05_11_12_market_wide",
+                "start_date": "2022-05-04",
+                "end_date": "2022-06-15",
+                "coins": [
+                    "AAVE",
+                    "ADA",
+                    "ALGO",
+                    "ATOM",
+                    "AVAX",
+                    "BCH",
+                    "BNB",
+                    "CRO",
+                    "DOGE",
+                    "DOT",
+                    "ETC",
+                    "ETH",
+                    "FIL",
+                    "HBAR",
+                    "ICP",
+                    "JST",
+                    "LINK",
+                    "LTC",
+                    "NEAR",
+                    "SHIB",
+                    "SOL",
+                    "TRX",
+                    "UNI",
+                    "XLM",
+                    "XMR",
+                    "XRP",
+                    "ZEC"
+                ],
+                "exchanges": [
+                    "binance",
+                    "bybit"
+                ],
+                "overrides": {
+                    "bot.short.risk.total_wallet_exposure_limit": 0.0
+                }
+            },
+            {
+                "label": "pump_2022_05_11_13_market_wide",
+                "start_date": "2022-05-04",
+                "end_date": "2022-06-15",
+                "coins": [
+                    "AAVE",
+                    "ADA",
+                    "ALGO",
+                    "ATOM",
+                    "AVAX",
+                    "BCH",
+                    "BNB",
+                    "DOGE",
+                    "DOT",
+                    "ETC",
+                    "ETH",
+                    "FIL",
+                    "HBAR",
+                    "ICP",
+                    "JST",
+                    "LINK",
+                    "LTC",
+                    "NEAR",
+                    "SHIB",
+                    "SOL",
+                    "TRX",
+                    "UNI",
+                    "XMR",
+                    "XRP",
+                    "ZEC"
+                ],
+                "exchanges": [
+                    "binance",
+                    "bybit"
+                ],
+                "overrides": {
+                    "bot.long.risk.total_wallet_exposure_limit": 0.0
+                }
+            },
+            {
+                "label": "crash_2024_01_03_12_market_wide",
+                "start_date": "2023-12-27",
+                "end_date": "2024-02-07",
+                "coins": [
+                    "AAVE",
+                    "ADA",
+                    "ALGO",
+                    "APT",
+                    "ARB",
+                    "ATOM",
+                    "AVAX",
+                    "BCH",
+                    "BNB",
+                    "CRO",
+                    "DOGE",
+                    "DOT",
+                    "ETC",
+                    "ETH",
+                    "FIL",
+                    "HBAR",
+                    "ICP",
+                    "INJ",
+                    "KAS",
+                    "LINK",
+                    "LTC",
+                    "NEAR",
+                    "PEPE",
+                    "QNT",
+                    "SHIB",
+                    "SOL",
+                    "SUI",
+                    "TON",
+                    "UNI",
+                    "WLD",
+                    "XLM",
+                    "XMR",
+                    "XRP",
+                    "ZEC"
+                ],
+                "exchanges": [
+                    "binance",
+                    "bybit"
+                ],
+                "overrides": {
+                    "bot.short.risk.total_wallet_exposure_limit": 0.0
+                }
+            },
+            {
+                "label": "pump_2024_01_03_12_market_wide",
+                "start_date": "2023-12-27",
+                "end_date": "2024-02-07",
+                "coins": [
+                    "AAVE",
+                    "ADA",
+                    "ALGO",
+                    "APT",
+                    "ARB",
+                    "ATOM",
+                    "AVAX",
+                    "BNB",
+                    "CRO",
+                    "DOGE",
+                    "DOT",
+                    "ETC",
+                    "FIL",
+                    "HBAR",
+                    "ICP",
+                    "INJ",
+                    "KAS",
+                    "LINK",
+                    "LTC",
+                    "NEAR",
+                    "PEPE",
+                    "QNT",
+                    "SHIB",
+                    "SOL",
+                    "SUI",
+                    "TON",
+                    "UNI",
+                    "WLD",
+                    "XLM",
+                    "XMR",
+                    "XRP",
+                    "ZEC"
+                ],
+                "exchanges": [
+                    "binance",
+                    "bybit"
+                ],
+                "overrides": {
+                    "bot.long.risk.total_wallet_exposure_limit": 0.0
+                }
+            },
+            {
+                "label": "crash_2025_10_10_21_market_wide",
+                "start_date": "2025-10-03",
+                "end_date": "2025-11-14",
+                "coins": [
+                    "AAVE",
+                    "ADA",
+                    "ALGO",
+                    "APT",
+                    "ARB",
+                    "ASTER",
+                    "ATOM",
+                    "AVAX",
+                    "BCH",
+                    "BNB",
+                    "BTC",
+                    "CRO",
+                    "DEXE",
+                    "DOGE",
+                    "DOT",
+                    "ENA",
+                    "ETC",
+                    "ETH",
+                    "FIL",
+                    "HBAR",
+                    "HYPE",
+                    "ICP",
+                    "INJ",
+                    "JST",
+                    "KAS",
+                    "LINK",
+                    "LTC",
+                    "M",
+                    "MNT",
+                    "MORPHO",
+                    "NEAR",
+                    "OKB",
+                    "OM",
+                    "ONDO",
+                    "PAXG",
+                    "PEPE",
+                    "POL",
+                    "QNT",
+                    "RENDER",
+                    "SHIB",
+                    "SKY",
+                    "SOL",
+                    "SUI",
+                    "TAO",
+                    "TON",
+                    "UNI",
+                    "WLD",
+                    "WLFI",
+                    "XLM",
+                    "XMR",
+                    "XRP",
+                    "ZEC"
+                ],
+                "exchanges": [
+                    "binance",
+                    "bybit"
+                ],
+                "overrides": {
+                    "bot.short.risk.total_wallet_exposure_limit": 0.0
+                }
+            },
+            {
+                "label": "pump_2025_10_10_21_market_wide",
+                "start_date": "2025-10-03",
+                "end_date": "2025-11-14",
+                "coins": [
+                    "AAVE",
+                    "ADA",
+                    "ALGO",
+                    "APT",
+                    "ARB",
+                    "ASTER",
+                    "ATOM",
+                    "AVAX",
+                    "BCH",
+                    "BNB",
+                    "BTC",
+                    "CRO",
+                    "DEXE",
+                    "DOGE",
+                    "DOT",
+                    "ENA",
+                    "ETC",
+                    "ETH",
+                    "FIL",
+                    "HBAR",
+                    "HYPE",
+                    "ICP",
+                    "INJ",
+                    "JST",
+                    "KAS",
+                    "LINK",
+                    "LTC",
+                    "M",
+                    "MNT",
+                    "MORPHO",
+                    "NEAR",
+                    "OKB",
+                    "OM",
+                    "ONDO",
+                    "PAXG",
+                    "PEPE",
+                    "POL",
+                    "QNT",
+                    "RENDER",
+                    "SHIB",
+                    "SKY",
+                    "SOL",
+                    "SUI",
+                    "TAO",
+                    "TON",
+                    "UNI",
+                    "WLD",
+                    "WLFI",
+                    "XLM",
+                    "XMR",
+                    "XRP",
+                    "ZEC"
+                ],
+                "exchanges": [
+                    "binance",
+                    "bybit"
+                ],
+                "overrides": {
+                    "bot.long.risk.total_wallet_exposure_limit": 0.0
+                }
+            },
+            {
+                "label": "crash_2025_04_13_18_om",
+                "start_date": "2025-04-06",
+                "end_date": "2025-05-18",
+                "coins": [
+                    "OM"
+                ],
+                "exchanges": [
+                    "binance"
+                ],
+                "overrides": {
+                    "coin_overrides": {
+                        "OM": {
+                            "live": {
+                                "forced_mode_long": "normal",
+                                "forced_mode_short": "manual"
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "label": "crash_2025_06_02_19_dexe",
+                "start_date": "2025-05-26",
+                "end_date": "2025-07-07",
+                "coins": [
+                    "DEXE"
+                ],
+                "exchanges": [
+                    "binance",
+                    "bybit"
+                ],
+                "overrides": {
+                    "coin_overrides": {
+                        "DEXE": {
+                            "live": {
+                                "forced_mode_long": "normal",
+                                "forced_mode_short": "manual"
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "label": "pump_2021_11_18_04_algo",
+                "start_date": "2021-11-11",
+                "end_date": "2021-12-23",
+                "coins": [
+                    "ALGO"
+                ],
+                "exchanges": [
+                    "bybit"
+                ],
+                "overrides": {
+                    "coin_overrides": {
+                        "ALGO": {
+                            "live": {
+                                "forced_mode_long": "manual",
+                                "forced_mode_short": "normal"
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "label": "pump_2024_02_23_14_uni",
+                "start_date": "2024-02-16",
+                "end_date": "2024-03-29",
+                "coins": [
+                    "UNI"
+                ],
+                "exchanges": [
+                    "binance",
+                    "bybit"
+                ],
+                "overrides": {
+                    "coin_overrides": {
+                        "UNI": {
+                            "live": {
+                                "forced_mode_long": "manual",
+                                "forced_mode_short": "normal"
+                            }
+                        }
+                    }
+                }
+            }
+        ],
+        "aggregate": {
+            "default": "mean"
+        }
+    }
+}

--- a/docs/ai/runbooks/crash_discovery.md
+++ b/docs/ai/runbooks/crash_discovery.md
@@ -1,17 +1,19 @@
 # Crash Discovery And Stress-Suite Runbook
 
-`passivbot tool crash-finder` finds difficult historical periods in local OHLCV data and generates
+`passivbot tool crash-finder` finds difficult historical crashes and pumps in local OHLCV data and generates
 backtest/optimizer scenario suites. Keep output under
 `crash_finder_results/<date>_crash_scenarios/`; it is local research evidence, not PR content.
 
 ## Modes And Semantics
 
 - Full discovery reads cached 1m candles, builds epoch-aligned discovery candles, finds ordered
-  high-to-later-low events, clusters them, and generates scenarios.
+  high-to-later-low and/or low-to-later-high events, clusters them by direction, and generates
+  scenarios.
 - `--clusters-csv` regenerates suites from existing clusters without reading candles. It cannot
   discover events added by a later data download.
 - `--timeframe` defaults to `1h`; wider candles may combine unrelated moves and shift cluster time.
 - `--threshold` is log return (`-0.10` is about a 9.5% decline).
+- `--pump-threshold` is a positive log return (`0.10` is about a 10.5% rally).
 - `--min-valid-minutes` counts valid source rows per discovery candle.
 
 Do not replace the ordered metric with plain high/low range; range cannot prove that the high
@@ -41,11 +43,11 @@ passivbot tool crash-finder \
   --root caches/ohlcvs \
   --exchange binance --exchange bybit \
   --source-timeframe 1m --timeframe 1h \
-  --threshold -0.10 --min-valid-minutes 2 \
+  --direction both --threshold -0.10 --pump-threshold 0.10 --min-valid-minutes 2 \
   --top-per-coin 20 --top-clusters 80 \
   --pre-days 14 --post-days 60 \
   --scenario-coin-mode affected --scenario-kind all \
-  --scenario-force-normal both --scenario-merge-overlaps \
+  --scenario-force-normal adverse --scenario-merge-overlaps \
   --write-filtered-suites \
   --output-dir crash_finder_results/$(date +%F)_crash_scenarios
 ```
@@ -72,6 +74,10 @@ coverage and preserves scan metadata.
 ## Scenario Contract
 
 - Market-wide scenarios include affected coins but never force individual coins to normal mode.
+- Idiosyncratic `adverse` scenarios isolate long exposure for crashes and short exposure for
+  pumps by setting the opposite side to manual mode.
+- Market-wide `adverse` scenarios isolate the whole portfolio side by setting the non-adverse
+  side's `total_wallet_exposure_limit` to zero without forcing individual coins.
 - Forced-normal overrides apply only to idiosyncratic events and at most two coins per scenario.
 - Split overlapping force targets into repeated scenarios when more than two are required.
 - Every scenario coin has source data overlapping its date range on at least one scenario exchange.

--- a/docs/ai/runbooks/crash_discovery.md
+++ b/docs/ai/runbooks/crash_discovery.md
@@ -10,7 +10,8 @@ backtest/optimizer scenario suites. Keep output under
   high-to-later-low and/or low-to-later-high events, clusters them by direction, and generates
   scenarios.
 - `--clusters-csv` regenerates suites from existing clusters without reading candles. It cannot
-  discover events added by a later data download.
+  discover events added by a later data download. It preserves every direction present in the CSV
+  unless `--direction down|up` is explicitly supplied as a regeneration filter.
 - `--timeframe` defaults to `1h`; wider candles may combine unrelated moves and shift cluster time.
 - `--threshold` is log return (`-0.10` is about a 9.5% decline).
 - `--pump-threshold` is a positive log return (`0.10` is about a 10.5% rally).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -647,6 +647,9 @@ The optimizer reuses the backtest suite configuration when `--suite [y/n]` is en
 - **backtest.suite_enabled**: Can be toggled for optimizer runs via `--suite [y/n]` on `passivbot optimize`.
 - **backtest.aggregate**: Per-metric aggregation rules applied to scenario results before feeding into `optimize.scoring` and `optimize.limits`.
 - **backtest.scenarios**: Scenario dictionaries. Each one may override `coins`, `ignored_coins`, `start_date`, `end_date`, `exchanges`, `coin_sources`, and `overrides` (arbitrary config path overrides).
+- **optimize.objective_scenario**: Optional unique scenario label used for objective scoring.
+  Limits remain suite-aggregated, so a common pattern is `base` performance scoring with
+  worst-case stress limits.
 
 Use `--suite-config path/to/file.json` to layer additional scenario definitions at runtime.
 

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -401,6 +401,13 @@ Key fields (directly under `backtest`):
 - `backtest.scenarios`: list of scenario dictionaries (same schema as backtest scenarios)
 - `backtest.aggregate`: how to combine per-scenario metrics (default: `{"default": "mean"}`)
 
+Set `optimize.objective_scenario` to a unique scenario label (commonly `base`) when the suite
+exists primarily as a robustness gate. Objectives are then read from that scenario, while
+`optimize.limits` continue to use the suite aggregation and each limit's `stat`. This supports
+optimizing performance on a representative long period while enforcing worst-case drawdown,
+completion, and recovery constraints across shorter stress periods. The equivalent CLI override
+is `--objective-scenario LABEL`.
+
 Suite mode is opt-in. The default schema/example config does not enable it automatically.
 
 During evaluation the optimizer records:
@@ -408,7 +415,8 @@ During evaluation the optimizer records:
 - Per-scenario combined metrics (the same mean/min/max/std set produced by standalone
   backtests). These are exposed on each individual as `<label>__{metric}`.
 - Aggregated metrics computed with the `backtest.aggregate` rules (default `mean`).
-  These aggregated values feed directly into `optimize.scoring` and `optimize.limits`.
+  These aggregated values feed `optimize.limits` and, unless `optimize.objective_scenario` is set,
+  `optimize.scoring`.
 
 See [Suite Examples](suite_examples.md) for practical scenario configurations including exchange
 comparisons, date range testing, and parameter sensitivity analysis.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -150,7 +150,7 @@ passivbot tool trailing-inspect \
 ## Crash finder
 
 `passivbot tool crash-finder` builds larger discovery candles from local v2 1m OHLCV data and
-scans them for severe crash windows. The discovery timeframe is parameterized with `--timeframe`
+scans them for severe crash and pump windows. The discovery timeframe is parameterized with `--timeframe`
 and defaults to `1h`; `4h` and `12h` are useful alternatives for slower market-wide moves. The
 scanner groups valid source rows once, while retaining their order inside each candle so a low
 before a later high is not misclassified as a crash.
@@ -170,10 +170,12 @@ passivbot tool crash-finder \
   --exchange bybit \
   --source-timeframe 1m \
   --timeframe 1h \
+  --direction both \
   --threshold -0.10 \
+  --pump-threshold 0.10 \
   --pre-days 14 \
   --post-days 60 \
-  --scenario-force-normal both \
+  --scenario-force-normal adverse \
   --scenario-merge-overlaps \
   --write-filtered-suites \
   --output-dir crash_finder_results/$(date +%F)_crash_scenarios
@@ -190,6 +192,9 @@ passivbot tool crash-finder \
 
 Useful suite controls:
 
+- `--direction down|up|both` chooses high-to-later-low crashes, low-to-later-high pumps, or both.
+  `--threshold` is the negative crash threshold and `--pump-threshold` is the positive pump
+  threshold, both expressed as log returns.
 - `--scenario-kind market-wide` keeps broad market crashes only.
 - `--scenario-kind coin-focused` keeps non-market-wide crashes, including isolated multi-coin
   clusters such as a DEXE/M event.
@@ -199,6 +204,9 @@ Useful suite controls:
   only for idiosyncratic non-market-wide crash coins. Market-wide scenario coins are not forced.
   If a merged scenario would contain more than two forced coins, the tool splits it into repeated
   scenario windows with at most two forced coins per scenario.
+- `--scenario-force-normal adverse` forces long normal/short manual for idiosyncratic crashes and
+  long manual/short normal for idiosyncratic pumps. For market-wide events it enables only the
+  adverse portfolio side: long for crashes and short for pumps.
 - `--scenario-merge-overlaps` merges scenarios whose generated date windows overlap, preserving
   the earliest start, latest end, union of coins, and worst-severity label.
 

--- a/src/config/hydrate.py
+++ b/src/config/hydrate.py
@@ -226,6 +226,10 @@ def apply_non_live_adjustments(
     if population_size is not None and population_size <= 0:
         raise ValueError("optimize.population_size must be > 0 when set")
     result["optimize"]["population_size"] = population_size
+    objective_scenario = result["optimize"].get("objective_scenario")
+    if objective_scenario is not None:
+        objective_scenario = str(objective_scenario).strip() or None
+    result["optimize"]["objective_scenario"] = objective_scenario
     result["optimize"]["seed"] = normalize_optional_seed(result["optimize"].get("seed"))
 
     current_limits = deepcopy(result["optimize"].get("limits", []))

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -488,6 +488,7 @@ def get_template_config():
                     "mutation_indpb": 0.0135135135,
                     "mutation_probability": 0.34,
                     "n_cpus": 4,
+                    "objective_scenario": None,
                     "offspring_multiplier": 1,
                     "pareto_max_size": 1000,
                     "population_size": None,

--- a/src/config_utils.py
+++ b/src/config_utils.py
@@ -1432,6 +1432,18 @@ RESERVED_CLI_ARGS = {
         "group": {"optimize": "Optimizer"},
         "help": "Optimizer scoring metrics, for example adg_pnl,loss_profit_ratio.",
     },
+    "optimize.objective_scenario": {
+        "visible": ["--objective-scenario"],
+        "hidden": ["--optimize.objective_scenario", "--optimize_objective_scenario"],
+        "type": str,
+        "metavar": "LABEL",
+        "commands": {"optimize"},
+        "group": {"optimize": "Optimizer"},
+        "help": (
+            "Use one suite scenario for scoring objectives while keeping optimize.limits "
+            "evaluated against suite aggregates."
+        ),
+    },
     "optimize.population_size": {
         "visible": ["--population-size", "-ps"],
         "hidden": ["--optimize.population_size", "--optimize_population_size"],
@@ -1810,6 +1822,7 @@ def _classify_optimize_argument(full_name: str, help_all: bool) -> Optional[str]
         "optimize.iters",
         "optimize.backend",
         "optimize.n_cpus",
+        "optimize.objective_scenario",
         "optimize.pareto_max_size",
         "optimize.population_size",
         "optimize.scoring",

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -723,6 +723,7 @@ def _resume_config_mismatches(entry: dict, config: dict) -> list[str]:
             "mutation_indpb",
             "mutation_probability",
             "offspring_multiplier",
+            "objective_scenario",
             "population_size",
             "pymoo",
             "round_to_n_significant_digits",
@@ -1595,16 +1596,23 @@ class Evaluator:
             aggregate_cfg=aggregate_cfg,
         )
 
-    def calc_fitness(self, analyses_combined, *, return_raw_objectives: bool = False):
+    def calc_fitness(
+        self,
+        analyses_combined,
+        *,
+        limit_metrics=None,
+        return_raw_objectives: bool = False,
+    ):
+        limit_metrics = analyses_combined if limit_metrics is None else limit_metrics
         per_objective_modifier = [0.0] * len(self.scoring_specs)
         global_modifier = 0.0
         for check in self.limit_checks:
-            val = resolve_metric_value(analyses_combined, check["metric_key"])
+            val = resolve_metric_value(limit_metrics, check["metric_key"])
             if val is None:
                 raise ValueError(
                     "missing optimizer limit metric "
                     f"{check['metric_key']!r} for limit on {check['metric']!r}; "
-                    f"available metrics: {_format_available_metric_keys(analyses_combined)}"
+                    f"available metrics: {_format_available_metric_keys(limit_metrics)}"
                 )
             penalty = compute_limit_violation(check, val)
             if not penalty:
@@ -1675,6 +1683,20 @@ class SuiteEvaluator:
         self.base = base_evaluator
         self.contexts = scenario_contexts
         self.aggregate_cfg = aggregate_cfg
+        objective_scenario = self.base.config["optimize"].get("objective_scenario")
+        self.objective_scenario = (
+            str(objective_scenario).strip() if objective_scenario is not None else None
+        )
+        if not self.objective_scenario:
+            self.objective_scenario = None
+        if self.objective_scenario is not None:
+            labels = [ctx.label for ctx in self.contexts]
+            if self.objective_scenario not in labels:
+                raise ValueError(
+                    "optimize.objective_scenario "
+                    f"{self.objective_scenario!r} is not present in backtest.scenarios; "
+                    f"available labels: {', '.join(labels)}"
+                )
         self.base.build_limit_checks(self.aggregate_cfg)
         # Cache for master dataset attachments (shared across scenarios)
         self._master_attachments: Dict[str, Dict[str, Any]] = {"hlcvs": {}, "btc": {}}
@@ -2017,7 +2039,18 @@ class SuiteEvaluator:
         aggregated_values = aggregate_summary.get("aggregated", {})
         for metric, agg_value in aggregated_values.items():
             flat_stats[f"{metric}_mean"] = agg_value
-        objectives, total_penalty = self.base.calc_fitness(flat_stats)
+        objective_stats = flat_stats
+        if self.objective_scenario is not None:
+            objective_result = next(
+                result
+                for result in scenario_results
+                if result.scenario.label == self.objective_scenario
+            )
+            objective_stats = flatten_metric_stats(objective_result.metrics.get("stats", {}))
+        objectives, total_penalty = self.base.calc_fitness(
+            objective_stats,
+            limit_metrics=flat_stats,
+        )
         objectives_map = {f"w_{i}": val for i, val in enumerate(objectives)}
         _profile_add(timings, "fitness_payload_ms", phase_start)
 
@@ -2027,6 +2060,8 @@ class SuiteEvaluator:
             "constraint_violation": total_penalty,
             "liquidated": liquidated,
         }
+        if self.objective_scenario is not None:
+            metrics_payload["objective_scenario"] = self.objective_scenario
         if timings is not None:
             timings["total_ms"] = (time.perf_counter() - profile_total_start) * 1000.0
             profile_payload = {

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -730,6 +730,9 @@ def _resume_config_mismatches(entry: dict, config: dict) -> list[str]:
             "scoring",
         },
     )
+    # Objective source changes invalidate checkpoint fitness, including resumes
+    # from artifacts written before objective_scenario existed.
+    old_opt_compare.setdefault("objective_scenario", None)
     new_opt_compare = _resume_subset(new_opt, old_opt_compare.keys())
     _append_resume_section_mismatches(mismatches, "optimize", old_opt_compare, new_opt_compare)
 

--- a/src/suite_runner.py
+++ b/src/suite_runner.py
@@ -541,6 +541,16 @@ def build_scenarios(
             )
         )
 
+    label_counts: Dict[str, int] = {}
+    for scenario in scenarios:
+        label_counts[scenario.label] = label_counts.get(scenario.label, 0) + 1
+    duplicate_labels = sorted(label for label, count in label_counts.items() if count > 1)
+    if duplicate_labels:
+        raise ValueError(
+            "config.backtest.scenarios labels must be unique; duplicate label(s): "
+            + ", ".join(duplicate_labels)
+        )
+
     aggregate_cfg = deepcopy(suite_cfg.get("aggregate", {"default": "mean"}))
     return scenarios, aggregate_cfg
 

--- a/src/suite_runner.py
+++ b/src/suite_runner.py
@@ -459,6 +459,29 @@ def _config_for_dataset_window(
     return cfg
 
 
+def _config_for_dataset_coins(
+    base_config: Dict[str, Any],
+    scenarios: Sequence[SuiteScenario],
+) -> Dict[str, Any]:
+    """Restrict a preload to the coins its assigned scenarios can use."""
+
+    if not scenarios or any(scenario.coins is None for scenario in scenarios):
+        return base_config
+    required_coins = sorted(
+        {coin for scenario in scenarios for coin in (scenario.coins or [])}
+    )
+    if not required_coins:
+        return base_config
+    cfg = deepcopy(base_config)
+    approved_coins = cfg.setdefault("live", {}).get("approved_coins")
+    if isinstance(approved_coins, dict):
+        cfg["live"]["approved_coins"]["long"] = list(required_coins)
+        cfg["live"]["approved_coins"]["short"] = list(required_coins)
+    else:
+        cfg["live"]["approved_coins"] = list(required_coins)
+    return cfg
+
+
 def _log_dataset_window(dataset_label: str, window: DatasetWindow) -> None:
     logging.info(
         "[suite] dataset window %s start=%s end=%s scenarios=%s",
@@ -753,10 +776,29 @@ async def prepare_master_datasets(
     use_combined = len(exchanges) > 1
 
     if use_combined:
+        exchange_set = {str(exchange) for exchange in exchanges}
+        combined_scenarios = [
+            scenario
+            for scenario in (scenarios or [])
+            if set(scenario.exchanges or exchanges) == exchange_set
+        ]
+        individual_scenarios = {
+            str(exchange): [
+                scenario
+                for scenario in (scenarios or [])
+                if set(scenario.exchanges or exchanges) != exchange_set
+                and str(exchange) in set(scenario.exchanges or exchanges)
+            ]
+            for exchange in (needed_individual_exchanges or set())
+        }
         # Prepare combined (best-per-coin) dataset
         combined_window = dataset_windows["combined"]
         _log_dataset_window("combined", combined_window)
         combined_config = _config_for_dataset_window(base_config, combined_window)
+        combined_config = _config_for_dataset_coins(
+            combined_config,
+            combined_scenarios or list(scenarios or []),
+        )
         (
             coins,
             hlcvs,
@@ -803,6 +845,10 @@ async def prepare_master_datasets(
                     )
                 _log_dataset_window(exchange, exchange_window)
                 exchange_config = _config_for_dataset_window(base_config, exchange_window)
+                exchange_config = _config_for_dataset_coins(
+                    exchange_config,
+                    individual_scenarios.get(str(exchange), []),
+                )
                 (
                     ex_coins,
                     ex_hlcvs,
@@ -832,6 +878,11 @@ async def prepare_master_datasets(
                 del ex_hlcvs, ex_btc_usd_prices
     else:
         for exchange in exchanges:
+            exchange_scenarios = [
+                scenario
+                for scenario in (scenarios or [])
+                if str(exchange) in set(scenario.exchanges or exchanges)
+            ]
             exchange_window = dataset_windows.get(exchange)
             if exchange_window is None:
                 exchange_window = DatasetWindow(
@@ -841,6 +892,10 @@ async def prepare_master_datasets(
                 )
             _log_dataset_window(exchange, exchange_window)
             exchange_config = _config_for_dataset_window(base_config, exchange_window)
+            exchange_config = _config_for_dataset_coins(
+                exchange_config,
+                exchange_scenarios,
+            )
             (
                 coins,
                 hlcvs,

--- a/src/tools/crash_finder.py
+++ b/src/tools/crash_finder.py
@@ -1123,7 +1123,7 @@ def _build_suite_payloads_from_clusters(
 def run_from_clusters_csv(args: argparse.Namespace) -> dict[str, Any]:
     clusters_csv = Path(args.clusters_csv).expanduser()
     clusters = load_clusters_csv(clusters_csv)
-    if args.direction != "both":
+    if getattr(args, "_direction_explicit", True) and args.direction != "both":
         clusters = [cluster for cluster in clusters if cluster.direction == args.direction]
     selected_clusters = list(clusters[: args.top_clusters] if args.top_clusters > 0 else clusters)
     scanned_ranges_path = clusters_csv.parent / "scanned_ranges.csv"
@@ -1325,6 +1325,18 @@ def run_scan(args: argparse.Namespace) -> dict[str, Any]:
     }
 
 
+class _StoreDirection(argparse.Action):
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: str,
+        option_string: str | None = None,
+    ) -> None:
+        setattr(namespace, self.dest, values)
+        setattr(namespace, "_direction_explicit", True)
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="passivbot tool crash-finder",
@@ -1363,8 +1375,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--direction",
         choices=("down", "up", "both"),
         default="down",
-        help="Discover crashes, pumps, or both (default: down, preserving legacy behavior).",
+        action=_StoreDirection,
+        help=(
+            "Discover crashes, pumps, or both (default: down). With --clusters-csv, omitted "
+            "--direction preserves every direction already present in the CSV."
+        ),
     )
+    parser.set_defaults(_direction_explicit=False)
     parser.add_argument(
         "--pump-threshold",
         type=float,

--- a/src/tools/crash_finder.py
+++ b/src/tools/crash_finder.py
@@ -88,6 +88,9 @@ class CrashEvent:
     bucket_high: float
     bucket_low: float
     previous_close: float | None
+    direction: str = "down"
+    ordered_low_to_later_high_log: float | None = None
+    prev_close_high_log: float | None = None
 
 
 @dataclass(frozen=True)
@@ -105,6 +108,7 @@ class CrashCluster:
     affected_coins: list[str]
     exchanges: list[str]
     market_wide: bool
+    direction: str = "down"
 
 
 @dataclass(frozen=True)
@@ -196,6 +200,12 @@ def _worst_ordered_high_to_later_low_log(high: np.ndarray, low: np.ndarray) -> f
     prefix_high = np.maximum.accumulate(high)
     ratios = low / prefix_high
     return float(np.log(np.min(ratios)))
+
+
+def _worst_ordered_low_to_later_high_log(high: np.ndarray, low: np.ndarray) -> float:
+    prefix_low = np.minimum.accumulate(low)
+    ratios = high / prefix_low
+    return float(np.log(np.max(ratios)))
 
 
 def _duration_timeframe_to_ms(timeframe: str) -> int:
@@ -324,6 +334,8 @@ def scan_symbol(
     bucket_ms: int,
     min_valid_minutes: int,
     threshold: float,
+    direction: str,
+    pump_threshold: float,
     rank_metric: str,
 ) -> tuple[list[CrashEvent], ScannedRange]:
     start_ts = _floor_ts(symbol_range.first_ts, interval_ms)
@@ -376,17 +388,49 @@ def scan_symbol(
         bucket_high = float(np.max(high))
         bucket_low = float(np.min(low))
         range_log = float(np.log(bucket_low / bucket_high))
-        ordered_log = _worst_ordered_high_to_later_low_log(high, low)
+        ordered_down_log = _worst_ordered_high_to_later_low_log(high, low)
+        ordered_up_log = _worst_ordered_low_to_later_high_log(high, low)
         prev_close_low_log = None
+        prev_close_high_log = None
         if prev_close is not None and np.isfinite(prev_close) and prev_close > 0.0:
             prev_close_low_log = float(np.log(bucket_low / prev_close))
+            prev_close_high_log = float(np.log(bucket_high / prev_close))
         if rank_metric == "range":
-            threshold_value = range_log
+            down_threshold_value = range_log
+            up_threshold_value = -range_log
         elif rank_metric == "prev-close":
-            threshold_value = prev_close_low_log if prev_close_low_log is not None else ordered_log
+            down_threshold_value = (
+                prev_close_low_log if prev_close_low_log is not None else ordered_down_log
+            )
+            up_threshold_value = (
+                prev_close_high_log if prev_close_high_log is not None else ordered_up_log
+            )
         else:
-            threshold_value = ordered_log
-        if threshold_value <= threshold:
+            down_threshold_value = ordered_down_log
+            up_threshold_value = ordered_up_log
+        event_ts = int(bucket_id * bucket_ms)
+        if direction in {"down", "both"} and down_threshold_value <= threshold:
+            events.append(
+                CrashEvent(
+                    exchange=symbol_range.exchange,
+                    symbol=symbol_range.symbol,
+                    coin=coin,
+                    timeframe=scan_timeframe,
+                    timestamp=event_ts,
+                    timestamp_iso=_ts_to_iso(event_ts),
+                    valid_minutes=int(len(indices)),
+                    range_log=range_log,
+                    ordered_high_to_later_low_log=ordered_down_log,
+                    prev_close_low_log=prev_close_low_log,
+                    bucket_high=bucket_high,
+                    bucket_low=bucket_low,
+                    previous_close=prev_close,
+                    direction="down",
+                    ordered_low_to_later_high_log=ordered_up_log,
+                    prev_close_high_log=prev_close_high_log,
+                )
+            )
+        if direction in {"up", "both"} and up_threshold_value >= pump_threshold:
             event_ts = int(bucket_id * bucket_ms)
             events.append(
                 CrashEvent(
@@ -398,11 +442,14 @@ def scan_symbol(
                     timestamp_iso=_ts_to_iso(event_ts),
                     valid_minutes=int(len(indices)),
                     range_log=range_log,
-                    ordered_high_to_later_low_log=ordered_log,
+                    ordered_high_to_later_low_log=ordered_down_log,
                     prev_close_low_log=prev_close_low_log,
                     bucket_high=bucket_high,
                     bucket_low=bucket_low,
                     previous_close=prev_close,
+                    direction="up",
+                    ordered_low_to_later_high_log=ordered_up_log,
+                    prev_close_high_log=prev_close_high_log,
                 )
             )
         prev_close = float(close[-1])
@@ -424,6 +471,20 @@ def scan_symbol(
 
 
 def _event_severity(event: CrashEvent, rank_metric: str) -> float:
+    if event.direction == "up":
+        if rank_metric == "range":
+            value = -event.range_log
+        elif rank_metric == "prev-close":
+            value = (
+                event.prev_close_high_log
+                if event.prev_close_high_log is not None
+                else event.ordered_low_to_later_high_log
+            )
+        else:
+            value = event.ordered_low_to_later_high_log
+        if value is None:
+            raise ValueError(f"pump event missing {rank_metric} severity metric")
+        return -float(value)
     if rank_metric == "range":
         return event.range_log
     if rank_metric == "prev-close":
@@ -440,9 +501,9 @@ def select_top_events(
     dedupe_window_ms: int,
     rank_metric: str,
 ) -> list[CrashEvent]:
-    grouped: dict[tuple[str, str], list[CrashEvent]] = {}
+    grouped: dict[tuple[str, str, str], list[CrashEvent]] = {}
     for event in events:
-        grouped.setdefault((event.exchange, event.symbol), []).append(event)
+        grouped.setdefault((event.exchange, event.symbol, event.direction), []).append(event)
 
     selected: list[CrashEvent] = []
     for key_events in grouped.values():
@@ -467,12 +528,15 @@ def _sanitize_label_piece(value: str) -> str:
     return "".join(out).strip("_") or "event"
 
 
-def _cluster_label(timestamp: int, market_wide: bool, coins: Sequence[str]) -> str:
+def _cluster_label(
+    timestamp: int, market_wide: bool, coins: Sequence[str], direction: str = "down"
+) -> str:
     base = datetime.fromtimestamp(int(timestamp) / 1000, tz=UTC).strftime("%Y_%m_%d_%H")
+    prefix = "pump" if direction == "up" else "crash"
     if market_wide:
-        return f"crash_{base}_market_wide"
+        return f"{prefix}_{base}_market_wide"
     suffix = "_".join(_sanitize_label_piece(coin) for coin in list(coins)[:3])
-    return f"crash_{base}_{suffix}"
+    return f"{prefix}_{base}_{suffix}"
 
 
 def cluster_events(
@@ -487,13 +551,21 @@ def cluster_events(
     clusters_raw: list[list[CrashEvent]] = []
     current: list[CrashEvent] = []
     current_last_ts: int | None = None
-    for event in sorted(events, key=lambda item: (item.timestamp, item.symbol)):
-        if current_last_ts is None or event.timestamp - current_last_ts <= cluster_window_ms:
+    current_direction: str | None = None
+    for event in sorted(events, key=lambda item: (item.direction, item.timestamp, item.symbol)):
+        if (
+            current_last_ts is None
+            or (
+                event.direction == current_direction
+                and event.timestamp - current_last_ts <= cluster_window_ms
+            )
+        ):
             current.append(event)
         else:
             clusters_raw.append(current)
             current = [event]
         current_last_ts = event.timestamp
+        current_direction = event.direction
     if current:
         clusters_raw.append(current)
 
@@ -502,12 +574,13 @@ def cluster_events(
         worst = min(raw, key=lambda item: (_event_severity(item, rank_metric), item.timestamp))
         coins = sorted({event.coin for event in raw if event.coin})
         exchanges = sorted({event.exchange for event in raw})
+        direction = worst.direction
         market_wide = len(coins) >= min_market_wide_coins
         start_ts = min(event.timestamp for event in raw)
         end_ts = max(event.timestamp for event in raw)
         clusters.append(
             CrashCluster(
-                label=_cluster_label(worst.timestamp, market_wide, coins),
+                label=_cluster_label(worst.timestamp, market_wide, coins, direction),
                 timestamp=worst.timestamp,
                 timestamp_iso=_ts_to_iso(worst.timestamp),
                 start_ts=start_ts,
@@ -520,6 +593,7 @@ def cluster_events(
                 affected_coins=coins,
                 exchanges=exchanges,
                 market_wide=market_wide,
+                direction=direction,
             )
         )
     return sorted(clusters, key=lambda item: (item.severity, item.timestamp))
@@ -565,6 +639,7 @@ def build_suite_payload(
                 "exchanges": list(cluster.exchanges),
                 "severity": cluster.severity,
                 "market_wide": cluster.market_wide,
+                "direction": cluster.direction,
             }
         )
     if merge_overlaps:
@@ -610,25 +685,33 @@ def _merge_overlapping_scenario_specs(scenario_specs: Sequence[dict[str, Any]]) 
     if not scenario_specs:
         return []
     merged: list[dict[str, Any]] = []
-    for spec in sorted(scenario_specs, key=lambda item: (item["start_dt"], item["severity"])):
-        if not merged or spec["start_dt"] > merged[-1]["end_dt"]:
-            merged.append({**spec, "labels": [spec["label"]]})
-            continue
-        current = merged[-1]
-        current["end_dt"] = max(current["end_dt"], spec["end_dt"])
-        current["coins"] = sorted(dict.fromkeys([*current["coins"], *spec["coins"]]))
-        current["exchanges"] = sorted(dict.fromkeys([*current["exchanges"], *spec["exchanges"]]))
-        current["market_wide"] = bool(current["market_wide"] or spec["market_wide"])
-        current["force_coins"] = (
-            []
-            if current["market_wide"]
-            else sorted(dict.fromkeys([*current["force_coins"], *spec["force_coins"]]))
-        )
-        current["labels"].append(spec["label"])
-        if spec["severity"] < current["severity"]:
-            current["severity"] = spec["severity"]
-            current["label"] = spec["label"]
-    return merged
+    by_direction: dict[str, list[dict[str, Any]]] = {}
+    for spec in scenario_specs:
+        by_direction.setdefault(str(spec.get("direction") or "down"), []).append(spec)
+    for direction_specs in by_direction.values():
+        direction_merged: list[dict[str, Any]] = []
+        for spec in sorted(direction_specs, key=lambda item: (item["start_dt"], item["severity"])):
+            if not direction_merged or spec["start_dt"] > direction_merged[-1]["end_dt"]:
+                direction_merged.append({**spec, "labels": [spec["label"]]})
+                continue
+            current = direction_merged[-1]
+            current["end_dt"] = max(current["end_dt"], spec["end_dt"])
+            current["coins"] = sorted(dict.fromkeys([*current["coins"], *spec["coins"]]))
+            current["exchanges"] = sorted(
+                dict.fromkeys([*current["exchanges"], *spec["exchanges"]])
+            )
+            current["market_wide"] = bool(current["market_wide"] or spec["market_wide"])
+            current["force_coins"] = (
+                []
+                if current["market_wide"]
+                else sorted(dict.fromkeys([*current["force_coins"], *spec["force_coins"]]))
+            )
+            current["labels"].append(spec["label"])
+            if spec["severity"] < current["severity"]:
+                current["severity"] = spec["severity"]
+                current["label"] = spec["label"]
+        merged.extend(direction_merged)
+    return sorted(merged, key=lambda item: (item["start_dt"], item["direction"], item["label"]))
 
 
 def _scenario_spec_to_payload_items(
@@ -705,7 +788,20 @@ def _scenario_payload_item(
         scenario["coins"] = list(coins)
     if spec["exchanges"]:
         scenario["exchanges"] = list(spec["exchanges"])
-    overrides = _forced_normal_overrides(force_coins, force_normal=force_normal)
+    if force_normal == "adverse" and spec["market_wide"]:
+        if str(spec.get("direction") or "down") == "up":
+            scenario["overrides"] = {
+                "bot.long.risk.total_wallet_exposure_limit": 0.0,
+            }
+        else:
+            scenario["overrides"] = {
+                "bot.short.risk.total_wallet_exposure_limit": 0.0,
+            }
+    overrides = _forced_normal_overrides(
+        force_coins,
+        force_normal=force_normal,
+        direction=str(spec.get("direction") or "down"),
+    )
     if overrides:
         scenario["overrides"] = {"coin_overrides": overrides}
     return scenario
@@ -745,10 +841,19 @@ def _force_coin_groups(coins: Sequence[str], *, force_normal: str) -> list[list[
     return [unique[idx : idx + 2] for idx in range(0, len(unique), 2)]
 
 
-def _forced_normal_overrides(coins: Sequence[str], *, force_normal: str) -> dict[str, Any]:
+def _forced_normal_overrides(
+    coins: Sequence[str], *, force_normal: str, direction: str = "down"
+) -> dict[str, Any]:
     if force_normal == "none" or not coins:
         return {}
     live_payload: dict[str, str] = {}
+    if force_normal == "adverse":
+        if direction == "up":
+            live_payload["forced_mode_long"] = "manual"
+            live_payload["forced_mode_short"] = "normal"
+        else:
+            live_payload["forced_mode_long"] = "normal"
+            live_payload["forced_mode_short"] = "manual"
     if force_normal in {"long", "both"}:
         live_payload["forced_mode_long"] = "normal"
     if force_normal in {"short", "both"}:
@@ -797,6 +902,7 @@ def load_clusters_csv(path: Path) -> list[CrashCluster]:
                 affected_coins=coins,
                 exchanges=exchanges,
                 market_wide=_parse_csv_bool(row.get("market_wide")),
+                direction=str(row.get("direction") or "down"),
             )
         )
     return sorted(clusters, key=lambda item: (item.severity, item.timestamp))
@@ -882,6 +988,7 @@ def write_outputs(
             "affected_coins",
             "exchanges",
             "market_wide",
+            "direction",
         ],
     )
     _write_csv(scanned_path, scanned_rows, list(ScannedRange.__dataclass_fields__.keys()))
@@ -937,6 +1044,7 @@ def write_cluster_suite_outputs(
             "affected_coins",
             "exchanges",
             "market_wide",
+            "direction",
         ],
     )
     suite_path.write_text(json.dumps(suite_payload, indent=2, sort_keys=False) + "\n", encoding="utf-8")
@@ -1015,6 +1123,8 @@ def _build_suite_payloads_from_clusters(
 def run_from_clusters_csv(args: argparse.Namespace) -> dict[str, Any]:
     clusters_csv = Path(args.clusters_csv).expanduser()
     clusters = load_clusters_csv(clusters_csv)
+    if args.direction != "both":
+        clusters = [cluster for cluster in clusters if cluster.direction == args.direction]
     selected_clusters = list(clusters[: args.top_clusters] if args.top_clusters > 0 else clusters)
     scanned_ranges_path = clusters_csv.parent / "scanned_ranges.csv"
     scanned_ranges = load_scanned_ranges_csv(scanned_ranges_path) if scanned_ranges_path.exists() else []
@@ -1066,6 +1176,10 @@ def run_scan(args: argparse.Namespace) -> dict[str, Any]:
         )
     if args.min_valid_minutes <= 0:
         raise ValueError("min-valid-minutes must be positive")
+    if args.threshold >= 0.0:
+        raise ValueError("threshold must be negative")
+    if args.pump_threshold <= 0.0:
+        raise ValueError("pump-threshold must be positive")
     exchanges = sorted(
         dict.fromkeys(str(exchange).strip().lower() for exchange in (args.exchange or []))
     )
@@ -1110,6 +1224,8 @@ def run_scan(args: argparse.Namespace) -> dict[str, Any]:
                 bucket_ms=bucket_ms,
                 min_valid_minutes=args.min_valid_minutes,
                 threshold=args.threshold,
+                direction=args.direction,
+                pump_threshold=args.pump_threshold,
                 rank_metric=args.rank_metric,
             )
         except (FileNotFoundError, OSError, ValueError) as exc:
@@ -1191,7 +1307,9 @@ def run_scan(args: argparse.Namespace) -> dict[str, Any]:
         "timeframe": scan_timeframe,
         "exchanges": exchanges,
         "rank_metric": args.rank_metric,
+        "direction": args.direction,
         "threshold": args.threshold,
+        "pump_threshold": args.pump_threshold,
         "symbols_attempted": len(symbol_ranges),
         "symbols_scanned": len(scanned_ranges),
         "symbols_failed": len(scan_errors),
@@ -1210,7 +1328,9 @@ def run_scan(args: argparse.Namespace) -> dict[str, Any]:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="passivbot tool crash-finder",
-        description="Scan local v2 OHLCV cache data for the worst historical crash windows.",
+        description=(
+            "Scan local v2 OHLCV cache data for the worst historical crash and pump windows."
+        ),
     )
     parser.add_argument("--root", default=str(DEFAULT_ROOT), help="v2 OHLCV cache root.")
     parser.add_argument(
@@ -1238,6 +1358,18 @@ def build_parser() -> argparse.ArgumentParser:
         type=float,
         default=-0.10,
         help="Only keep crash candidates at or below this log-return severity.",
+    )
+    parser.add_argument(
+        "--direction",
+        choices=("down", "up", "both"),
+        default="down",
+        help="Discover crashes, pumps, or both (default: down, preserving legacy behavior).",
+    )
+    parser.add_argument(
+        "--pump-threshold",
+        type=float,
+        default=0.10,
+        help="Only keep pump candidates at or above this positive log-return severity.",
     )
     parser.add_argument("--top-per-coin", type=int, default=10)
     parser.add_argument("--top-clusters", type=int, default=30)
@@ -1272,11 +1404,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--scenario-force-normal",
-        choices=("none", "long", "short", "both"),
+        choices=("none", "long", "short", "both", "adverse"),
         default="none",
         help=(
             "Emit forced_mode_* = normal overrides for idiosyncratic non-market-wide "
-            "crash coins, with at most two forced coins per scenario."
+            "event coins, with at most two forced coins per scenario. 'adverse' forces "
+            "long-only exposure for crashes and short-only exposure for pumps."
         ),
     )
     parser.add_argument(

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -4197,6 +4197,19 @@ def test_resume_config_mismatches_rejects_changed_backend():
     assert any("optimize.backend" in mismatch for mismatch in mismatches)
 
 
+def test_resume_config_mismatches_rejects_adding_objective_scenario_to_old_result():
+    entry = _resume_validation_entry()
+    config = deepcopy(entry)
+    config["optimize"]["objective_scenario"] = "base"
+
+    mismatches = optimize._resume_config_mismatches(entry, config)
+
+    assert any(
+        "optimize.objective_scenario: 'None' -> 'base'" in mismatch
+        for mismatch in mismatches
+    )
+
+
 def test_resume_config_mismatches_allows_machine_local_optimizer_settings():
     entry = _resume_validation_entry()
     entry["optimize"]["n_cpus"] = 6

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -3569,6 +3569,25 @@ class TestEvaluator:
             "drawdown_worst_strategy_eq_max",
         ]
 
+    def test_suite_objective_scenario_must_match_context_label(self):
+        from optimize import Evaluator, SuiteEvaluator
+        from config_utils import get_template_config
+
+        mock_config = get_template_config()
+        mock_config["optimize"]["objective_scenario"] = "base"
+        base = Evaluator(
+            hlcvs_specs={},
+            btc_usd_specs={},
+            msss={},
+            config=mock_config,
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="optimize.objective_scenario 'base' is not present",
+        ):
+            SuiteEvaluator(base, [], {"default": "mean"})
+
     def test_evaluate_converts_recoverable_backtest_panic_to_penalty(self):
         from optimize import Evaluator, INVALID_BACKTEST_CANDIDATE_PENALTY
         from config_utils import get_template_config

--- a/tests/test_config_optimize_suite.py
+++ b/tests/test_config_optimize_suite.py
@@ -35,6 +35,16 @@ def test_suite_aggregate_default_preserved():
     assert formatted["backtest"]["aggregate"]["default"] == "median"
 
 
+def test_optimizer_objective_scenario_is_preserved():
+    base = get_template_config()
+    base["_raw"] = deepcopy(base)
+    base["optimize"]["objective_scenario"] = " base "
+
+    formatted = format_config(deepcopy(base), verbose=False)
+
+    assert formatted["optimize"]["objective_scenario"] == "base"
+
+
 def test_optimizer_preserves_explicit_hsl_aggregate_config():
     """Optimizer must not inherit template metric-specific aggregate overrides."""
     cfg = load_prepared_config("configs/examples/hsl_npos1.json", verbose=False)

--- a/tests/test_crash_finder_tool.py
+++ b/tests/test_crash_finder_tool.py
@@ -28,6 +28,8 @@ def test_crash_finder_defaults_to_hourly_discovery_from_minute_candles():
 
     assert args.source_timeframe == "1m"
     assert args.timeframe == "1h"
+    assert args.direction == "down"
+    assert args.pump_threshold == 0.10
     assert args.exchange == ["binance", "bybit"]
     assert crash_finder._duration_timeframe_to_ms("4h") == 4 * HOUR_MS
     assert crash_finder._duration_timeframe_to_ms("12h") == 12 * HOUR_MS
@@ -131,6 +133,136 @@ def test_ordered_metric_does_not_treat_low_before_high_as_crash(tmp_path):
     )
 
     assert payload["events_selected"] == 0
+
+
+def test_ordered_metric_discovers_low_to_later_high_as_pump(tmp_path):
+    root = tmp_path / "ohlcvs"
+    catalog = OhlcvCatalog(root / "catalog.sqlite")
+    store = OhlcvStore(root, catalog)
+    hour_ts = month_start_ts(2025, 5) + 5 * HOUR_MS
+    timestamps = np.array([hour_ts + idx * 60_000 for idx in range(4)], dtype=np.int64)
+    values = np.asarray(
+        [
+            [20.0, 20.0, 20.0, 1.0],
+            [30.0, 30.0, 30.0, 1.0],
+            [60.0, 60.0, 60.0, 1.0],
+            [100.0, 100.0, 100.0, 1.0],
+        ],
+        dtype=np.float32,
+    )
+    store.write_rows("binance", "1m", "PUMP/USDT:USDT", timestamps, values)
+
+    payload = crash_finder.run_scan(
+        crash_finder.build_parser().parse_args(
+            [
+                "--root",
+                str(root),
+                "--direction",
+                "both",
+                "--threshold",
+                "-0.50",
+                "--pump-threshold",
+                "0.50",
+                "--min-valid-minutes",
+                "2",
+                "--rank-metric",
+                "ordered",
+                "--timeframe",
+                "4h",
+            ]
+        )
+    )
+
+    assert payload["events_selected"] == 1
+    assert payload["events"][0]["direction"] == "up"
+    assert payload["events"][0]["ordered_low_to_later_high_log"] > 1.0
+    assert payload["clusters"][0]["label"].startswith("pump_")
+
+
+def test_adverse_force_mode_is_directional():
+    timestamp = month_start_ts(2025, 5) + 5 * HOUR_MS
+    common = {
+        "timestamp": timestamp,
+        "timestamp_iso": crash_finder._ts_to_iso(timestamp),
+        "start_ts": timestamp,
+        "end_ts": timestamp,
+        "start_iso": crash_finder._ts_to_iso(timestamp),
+        "end_iso": crash_finder._ts_to_iso(timestamp),
+        "severity": -1.0,
+        "event_count": 1,
+        "affected_coin_count": 1,
+        "affected_coins": ["TEST"],
+        "exchanges": ["binance"],
+        "market_wide": False,
+    }
+    clusters = [
+        crash_finder.CrashCluster(label="crash_test", direction="down", **common),
+        crash_finder.CrashCluster(label="pump_test", direction="up", **common),
+    ]
+
+    payload = crash_finder.build_suite_payload(
+        clusters,
+        pre_days=1,
+        post_days=1,
+        top_clusters=0,
+        coin_mode="affected",
+        scenario_kind="all",
+        force_normal="adverse",
+        merge_overlaps=True,
+        all_scanned_coins=["TEST"],
+    )
+
+    scenarios = {item["label"]: item for item in payload["backtest"]["scenarios"]}
+    assert scenarios["crash_test"]["overrides"]["coin_overrides"]["TEST"]["live"] == {
+        "forced_mode_long": "normal",
+        "forced_mode_short": "manual",
+    }
+    assert scenarios["pump_test"]["overrides"]["coin_overrides"]["TEST"]["live"] == {
+        "forced_mode_long": "manual",
+        "forced_mode_short": "normal",
+    }
+
+
+def test_adverse_force_mode_isolates_market_wide_side():
+    timestamp = month_start_ts(2025, 5) + 5 * HOUR_MS
+    common = {
+        "timestamp": timestamp,
+        "timestamp_iso": crash_finder._ts_to_iso(timestamp),
+        "start_ts": timestamp,
+        "end_ts": timestamp,
+        "start_iso": crash_finder._ts_to_iso(timestamp),
+        "end_iso": crash_finder._ts_to_iso(timestamp),
+        "severity": -1.0,
+        "event_count": 3,
+        "affected_coin_count": 3,
+        "affected_coins": ["BTC", "ETH", "SOL"],
+        "exchanges": ["binance"],
+        "market_wide": True,
+    }
+    clusters = [
+        crash_finder.CrashCluster(label="crash_market", direction="down", **common),
+        crash_finder.CrashCluster(label="pump_market", direction="up", **common),
+    ]
+
+    payload = crash_finder.build_suite_payload(
+        clusters,
+        pre_days=1,
+        post_days=1,
+        top_clusters=0,
+        coin_mode="affected",
+        scenario_kind="all",
+        force_normal="adverse",
+        merge_overlaps=True,
+        all_scanned_coins=["BTC", "ETH", "SOL"],
+    )
+
+    scenarios = {item["label"]: item for item in payload["backtest"]["scenarios"]}
+    assert scenarios["crash_market"]["overrides"] == {
+        "bot.short.risk.total_wallet_exposure_limit": 0.0,
+    }
+    assert scenarios["pump_market"]["overrides"] == {
+        "bot.long.risk.total_wallet_exposure_limit": 0.0,
+    }
 
 
 def test_larger_scan_timeframe_combines_source_minutes_across_hour_boundary(tmp_path):

--- a/tests/test_crash_finder_tool.py
+++ b/tests/test_crash_finder_tool.py
@@ -857,6 +857,32 @@ def test_clusters_csv_fast_path_does_not_create_empty_scan_artifacts(tmp_path):
     assert not (out_dir / "scan_errors.csv").exists()
 
 
+def test_clusters_csv_preserves_directions_unless_explicitly_filtered(tmp_path):
+    clusters_csv = tmp_path / "crash_clusters.csv"
+    clusters_csv.write_text(
+        "\n".join(
+            [
+                "label,timestamp,timestamp_iso,start_ts,end_ts,start_iso,end_iso,severity,event_count,affected_coin_count,affected_coins,exchanges,market_wide,direction",
+                "crash_test,1744567200000,2025-04-13T18:00:00Z,1744567200000,1744567200000,2025-04-13T18:00:00Z,2025-04-13T18:00:00Z,-1.0,1,1,OM,binance,False,down",
+                "pump_test,1744653600000,2025-04-14T18:00:00Z,1744653600000,1744653600000,2025-04-14T18:00:00Z,2025-04-14T18:00:00Z,-1.0,1,1,ALGO,bybit,False,up",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    parser = crash_finder.build_parser()
+
+    unfiltered = crash_finder.run_scan(
+        parser.parse_args(["--clusters-csv", str(clusters_csv)])
+    )
+    down_only = crash_finder.run_scan(
+        parser.parse_args(["--clusters-csv", str(clusters_csv), "--direction", "down"])
+    )
+
+    assert {cluster["direction"] for cluster in unfiltered["clusters"]} == {"down", "up"}
+    assert [cluster["direction"] for cluster in down_only["clusters"]] == ["down"]
+
+
 def test_logging_configuration_honors_requested_level_with_existing_handlers():
     logging.basicConfig(level=logging.INFO, force=True)
 

--- a/tests/test_optimizer_limits_integration.py
+++ b/tests/test_optimizer_limits_integration.py
@@ -63,6 +63,25 @@ def test_evaluator_returns_weighted_metric_when_within_limits():
     assert pytest.approx(penalty) == 0.0
 
 
+def test_evaluator_can_score_one_metric_source_and_limit_another():
+    limits = [
+        {"metric": "drawdown_worst", "penalize_if": "greater_than", "value": 0.4, "stat": "max"},
+    ]
+    cfg = _make_config(limits, scoring=["adg"])
+    evaluator = Evaluator({}, {}, {}, cfg)
+
+    objective_stats = {"adg_mean": 0.002}
+    suite_limit_stats = {"drawdown_worst_max": 0.45}
+    scores, penalty = evaluator.calc_fitness(
+        objective_stats,
+        limit_metrics=suite_limit_stats,
+    )
+
+    expected_penalty = (0.45 - 0.4) * 1e6
+    assert scores == pytest.approx((expected_penalty,))
+    assert penalty == pytest.approx(expected_penalty)
+
+
 def test_limit_penalty_applies_only_to_matching_objective():
     limits = [
         {

--- a/tests/test_suite_runner.py
+++ b/tests/test_suite_runner.py
@@ -152,6 +152,21 @@ def test_build_scenarios_rejects_non_mapping_scenarios():
         build_scenarios({"scenarios": ["not-a-mapping"]})
 
 
+def test_build_scenarios_rejects_duplicate_labels():
+    with pytest.raises(
+        ValueError,
+        match=r"config\.backtest\.scenarios labels must be unique; duplicate label\(s\): repeated",
+    ):
+        build_scenarios(
+            {
+                "scenarios": [
+                    {"label": "repeated"},
+                    {"label": "repeated"},
+                ]
+            }
+        )
+
+
 def test_apply_scenario_filters_unavailable_coins():
     base_config = {
         "backtest": {

--- a/tests/test_suite_runner.py
+++ b/tests/test_suite_runner.py
@@ -489,7 +489,7 @@ async def test_prepare_master_datasets_uses_scenario_windows_for_individual_exch
             label="binance_only",
             start_date="2025-01-01",
             end_date=None,
-            coins=None,
+            coins=["BTC", "ETH"],
             ignored_coins=None,
             exchanges=["binance"],
         ),
@@ -497,7 +497,7 @@ async def test_prepare_master_datasets_uses_scenario_windows_for_individual_exch
             label="bybit_only",
             start_date="2025-01-01",
             end_date=None,
-            coins=None,
+            coins=["SOL"],
             ignored_coins=None,
             exchanges=["bybit"],
         ),
@@ -510,6 +510,7 @@ async def test_prepare_master_datasets_uses_scenario_windows_for_individual_exch
                 exchange,
                 config["backtest"]["start_date"],
                 config["backtest"]["end_date"],
+                config["live"]["approved_coins"]["long"],
             )
         )
         timestamps = np.array([0, 60_000], dtype=np.int64)
@@ -538,9 +539,9 @@ async def test_prepare_master_datasets_uses_scenario_windows_for_individual_exch
     )
 
     assert calls == [
-        ("combined", "2021", "2026-05-21"),
-        ("binance", "2025-01-01", "2026-05-21"),
-        ("bybit", "2025-01-01", "2026-05-21"),
+        ("combined", "2021", "2026-05-21", ["BTC"]),
+        ("binance", "2025-01-01", "2026-05-21", ["BTC", "ETH"]),
+        ("bybit", "2025-01-01", "2026-05-21", ["SOL"]),
     ]
     assert any(
         "[suite] dataset window binance start=2025-01-01 end=2026-05-21 scenarios=binance_only"


### PR DESCRIPTION
Summary:
- extend crash-finder with ordered pump discovery and adverse-side stress scenarios
- add objective_scenario so suite objectives may come from base while limits remain suite-wide
- add a balanced 14-stress-scenario EMA-anchor suite and recommended optimize config

Validation:
- 259 focused optimizer, suite, config, and crash-finder tests
- 161 config, aggregation, Pareto, and suite-source tests
- bounded real CLI optimizer smoke (2 scenarios, 4 evaluations)
- full local-cache bidirectional discovery over 123 symbol ranges (112 verified, 11 checksum skips)