### PR TITLE
Fix EMA-anchor stress exposure denominator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable user-facing changes will be documented in this file.
   now be unique. Dataset preparation restricts exchange-specific preloads to the union of
   explicitly requested scenario coins when every assigned scenario names its coins. Resume
   validation rejects objective-scenario changes, including old results that predate the setting.
+  The bundled balanced EMA-anchor suite keeps the configured position-count denominator in every
+  non-base stress scenario and fixes both total-exposure-enforcer threshold bounds at `1.0`.
 
 - `passivbot tool crash-finder` can discover ordered low-to-later-high pumps as well as
   high-to-later-low crashes via `--direction up|both`. Generated idiosyncratic stress scenarios

--- a/configs/ema_anchor_opt_balanced_2026-07-24.json
+++ b/configs/ema_anchor_opt_balanced_2026-07-24.json
@@ -50,7 +50,8 @@
                     "binance"
                 ],
                 "overrides": {
-                    "bot.short.risk.total_wallet_exposure_limit": 0.0
+                    "bot.short.risk.total_wallet_exposure_limit": 0.0,
+                    "backtest.dynamic_wel_by_tradability": false
                 }
             },
             {
@@ -70,7 +71,8 @@
                     "binance"
                 ],
                 "overrides": {
-                    "bot.long.risk.total_wallet_exposure_limit": 0.0
+                    "bot.long.risk.total_wallet_exposure_limit": 0.0,
+                    "backtest.dynamic_wel_by_tradability": false
                 }
             },
             {
@@ -107,7 +109,8 @@
                     "bybit"
                 ],
                 "overrides": {
-                    "bot.short.risk.total_wallet_exposure_limit": 0.0
+                    "bot.short.risk.total_wallet_exposure_limit": 0.0,
+                    "backtest.dynamic_wel_by_tradability": false
                 }
             },
             {
@@ -144,7 +147,8 @@
                     "bybit"
                 ],
                 "overrides": {
-                    "bot.long.risk.total_wallet_exposure_limit": 0.0
+                    "bot.long.risk.total_wallet_exposure_limit": 0.0,
+                    "backtest.dynamic_wel_by_tradability": false
                 }
             },
             {
@@ -185,7 +189,8 @@
                     "bybit"
                 ],
                 "overrides": {
-                    "bot.short.risk.total_wallet_exposure_limit": 0.0
+                    "bot.short.risk.total_wallet_exposure_limit": 0.0,
+                    "backtest.dynamic_wel_by_tradability": false
                 }
             },
             {
@@ -224,7 +229,8 @@
                     "bybit"
                 ],
                 "overrides": {
-                    "bot.long.risk.total_wallet_exposure_limit": 0.0
+                    "bot.long.risk.total_wallet_exposure_limit": 0.0,
+                    "backtest.dynamic_wel_by_tradability": false
                 }
             },
             {
@@ -272,7 +278,8 @@
                     "bybit"
                 ],
                 "overrides": {
-                    "bot.short.risk.total_wallet_exposure_limit": 0.0
+                    "bot.short.risk.total_wallet_exposure_limit": 0.0,
+                    "backtest.dynamic_wel_by_tradability": false
                 }
             },
             {
@@ -318,7 +325,8 @@
                     "bybit"
                 ],
                 "overrides": {
-                    "bot.long.risk.total_wallet_exposure_limit": 0.0
+                    "bot.long.risk.total_wallet_exposure_limit": 0.0,
+                    "backtest.dynamic_wel_by_tradability": false
                 }
             },
             {
@@ -384,7 +392,8 @@
                     "bybit"
                 ],
                 "overrides": {
-                    "bot.short.risk.total_wallet_exposure_limit": 0.0
+                    "bot.short.risk.total_wallet_exposure_limit": 0.0,
+                    "backtest.dynamic_wel_by_tradability": false
                 }
             },
             {
@@ -450,7 +459,8 @@
                     "bybit"
                 ],
                 "overrides": {
-                    "bot.long.risk.total_wallet_exposure_limit": 0.0
+                    "bot.long.risk.total_wallet_exposure_limit": 0.0,
+                    "backtest.dynamic_wel_by_tradability": false
                 }
             },
             {
@@ -464,6 +474,7 @@
                     "binance"
                 ],
                 "overrides": {
+                    "backtest.dynamic_wel_by_tradability": false,
                     "coin_overrides": {
                         "OM": {
                             "live": {
@@ -486,6 +497,7 @@
                     "bybit"
                 ],
                 "overrides": {
+                    "backtest.dynamic_wel_by_tradability": false,
                     "coin_overrides": {
                         "DEXE": {
                             "live": {
@@ -507,6 +519,7 @@
                     "bybit"
                 ],
                 "overrides": {
+                    "backtest.dynamic_wel_by_tradability": false,
                     "coin_overrides": {
                         "ALGO": {
                             "live": {
@@ -529,6 +542,7 @@
                     "bybit"
                 ],
                 "overrides": {
+                    "backtest.dynamic_wel_by_tradability": false,
                     "coin_overrides": {
                         "UNI": {
                             "live": {
@@ -876,8 +890,8 @@
                         0.001
                     ],
                     "total_exposure_enforcer_threshold": [
-                        0.8,
-                        1.01,
+                        1.0,
+                        1.0,
                         0.001
                     ],
                     "total_wallet_exposure_limit": [
@@ -1034,8 +1048,8 @@
                         0.001
                     ],
                     "total_exposure_enforcer_threshold": [
-                        0.8,
-                        1.01,
+                        1.0,
+                        1.0,
                         0.001
                     ],
                     "total_wallet_exposure_limit": [


### PR DESCRIPTION
## Summary

- keep `backtest.dynamic_wel_by_tradability` enabled for the base scenario
- disable it in all 14 non-base crash/pump scenarios so reduced stress-test coin sets preserve each candidate's configured `n_positions` exposure denominator
- fix both long and short `total_exposure_enforcer_threshold` bounds at `1.0`

## Why

The stress scenarios intentionally restrict their coin sets for targeted coverage and optimizer speed. With dynamic WEL-by-tradability enabled, those reduced universes also reduced the effective position-count denominator—down to one in the idiosyncratic scenarios—so the suite tested artificial concentration rather than the production portfolio allocation. The base scenario remains dynamic, while crash/pump scenarios now isolate price stress without changing per-slot exposure sizing.

## Validation

- hydrated the config and verified the base remains unchanged while all 14 stress scenarios set the override to `false`
- `pytest -q tests/test_config_optimize_suite.py tests/test_suite_runner.py` (31 passed)
- `PYTHONPATH=src python src/tools/check_ai_docs.py` (0 errors; existing word-count warning)
- JSON parse and `git diff --check`