### PR TITLE
Recover Hyperliquid websocket order semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ All notable user-facing changes will be documented in this file.
 - Reduced Hyperliquid account-state refresh churn by recovering websocket order-update semantics
   from Passivbot's own acknowledged order record when the exchange order id matches exactly.
   Every supplied native, unified, and client identity must agree, along with existing websocket
-  side, raw side, position-side, and reduce-only metadata. Recovered partial-fill updates force an
+  side, raw side, raw status, position-side, and reduce-only metadata. This includes
+  Hyperliquid-native `oid` and `cloid` identities. Recovered partial-fill updates force an
   authoritative refresh; ambiguous, contradictory, and foreign updates still fail closed.
 
 - Backtests now treat a finite balance depleted by fills as liquidation before recomputing orders,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Reduced Hyperliquid account-state refresh churn by recovering websocket order-update semantics
+  from Passivbot's own acknowledged order record when the exchange order id matches exactly.
+  Ambiguous, contradictory, and foreign updates still fail closed and request authoritative state.
+
 - Live candle orchestration now reads bounded cache-only native 1h EMA carry-forward from the 1h
   index, requires a complete native window, isolates carried values from the active EMA cache, and
   applies the background refresher's surface-count staleness limit using the active live/replay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable user-facing changes will be documented in this file.
 
 - Reduced Hyperliquid account-state refresh churn by recovering websocket order-update semantics
   from Passivbot's own acknowledged order record when the exchange order id matches exactly.
-  Ambiguous, contradictory, and foreign updates still fail closed and request authoritative state.
+  Existing websocket position-side and reduce-only metadata must agree with that record; ambiguous,
+  contradictory, and foreign updates still fail closed and request authoritative state.
 
 - Live candle orchestration now reads bounded cache-only native 1h EMA carry-forward from the 1h
   index, requires a complete native window, isolates carried values from the active EMA cache, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ All notable user-facing changes will be documented in this file.
 
 - Reduced Hyperliquid account-state refresh churn by recovering websocket order-update semantics
   from Passivbot's own acknowledged order record when the exchange order id matches exactly.
-  Existing websocket side, raw side, position-side, and reduce-only metadata must agree with that
-  record; ambiguous, contradictory, and foreign updates still fail closed and request authoritative
-  state.
+  Every supplied native, unified, and client identity must agree, along with existing websocket
+  side, raw side, position-side, and reduce-only metadata. Recovered partial-fill updates force an
+  authoritative refresh; ambiguous, contradictory, and foreign updates still fail closed.
 
 - Backtests now treat a finite balance depleted by fills as liquidation before recomputing orders,
   so extreme optimizer candidates terminate normally instead of panicking an optimizer worker.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ All notable user-facing changes will be documented in this file.
   from Passivbot's own acknowledged order record when the exchange order id matches exactly.
   Every supplied native, unified, and client identity must agree, along with existing websocket
   side, raw side, raw status, position-side, and reduce-only metadata. This includes
-  Hyperliquid-native `oid` and `cloid` identities. Recovered partial-fill updates force an
-  authoritative refresh; ambiguous, contradictory, and foreign updates still fail closed.
+  Hyperliquid-native `oid` and `cloid` identities, with `cloid` retained in acknowledged-order
+  records. Recovered partial-fill updates force an authoritative refresh; ambiguous,
+  contradictory, and foreign updates still fail closed.
 
 - Backtests now treat a finite balance depleted by fills as liquidation before recomputing orders,
   so extreme optimizer candidates terminate normally instead of panicking an optimizer worker.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ All notable user-facing changes will be documented in this file.
 
 - Reduced Hyperliquid account-state refresh churn by recovering websocket order-update semantics
   from Passivbot's own acknowledged order record when the exchange order id matches exactly.
-  Existing websocket position-side and reduce-only metadata must agree with that record; ambiguous,
-  contradictory, and foreign updates still fail closed and request authoritative state.
+  Existing websocket side, raw side, position-side, and reduce-only metadata must agree with that
+  record; ambiguous, contradictory, and foreign updates still fail closed and request authoritative
+  state.
 
 - Backtests now treat a finite balance depleted by fills as liquidation before recomputing orders,
   so extreme optimizer candidates terminate normally instead of panicking an optimizer worker.

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -811,6 +811,39 @@ class HyperliquidBot(CCXTBot):
         )
         if action_side != position_side:
             return None
+        info = order.get("info")
+        raw_info = info if isinstance(info, dict) else {}
+        explicit_position_sides = [
+            value
+            for value in (
+                order.get("position_side"),
+                raw_info.get("positionSide"),
+            )
+            if value not in (None, "")
+        ]
+        if any(
+            str(value).lower() != position_side for value in explicit_position_sides
+        ):
+            return None
+        durable_position_side = self._durable_order_position_side(order)
+        if (
+            durable_position_side in {"long", "short"}
+            and durable_position_side != position_side
+        ):
+            return None
+        authoritative_reduce_source = raw_info if raw_info else order
+        reduce_only_keys = ("reduce_only", "reduceOnly", "is_reduce_only")
+        has_explicit_reduce_only = any(
+            key in authoritative_reduce_source for key in reduce_only_keys
+        )
+        websocket_reduce_only = self._strict_order_reduce_only_response(order)
+        if has_explicit_reduce_only and not isinstance(websocket_reduce_only, bool):
+            return None
+        if (
+            isinstance(websocket_reduce_only, bool)
+            and websocket_reduce_only != reduce_only
+        ):
+            return None
         return position_side, reduce_only
 
     def determine_pos_side(self, order):

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -707,6 +707,10 @@ class HyperliquidBot(CCXTBot):
                         order["_pb_order_semantics_source"] = (
                             "acknowledged_exchange_order_id"
                         )
+                        if self._hl_ws_order_has_fill_progress(order):
+                            order[
+                                "_pb_order_update_requires_authoritative_refresh"
+                            ] = True
                     try:
                         order["qty"] = order["amount"]
                     except (KeyError, TypeError, ValueError) as exc:
@@ -784,7 +788,19 @@ class HyperliquidBot(CCXTBot):
         """
         if not isinstance(order, dict):
             return None
-        exchange_id = self._extract_order_exchange_id(order)
+        info = order.get("info")
+        raw_info = info if isinstance(info, dict) else {}
+
+        exchange_id_keys = ("id", "order_id", "orderId", "orderID", "ordId", "oid")
+        exchange_ids = {
+            str(source.get(key))
+            for source in (order, raw_info)
+            for key in exchange_id_keys
+            if source.get(key) not in (None, "")
+        }
+        if len(exchange_ids) != 1:
+            return None
+        exchange_id = next(iter(exchange_ids))
         side = str(order.get("side") or "").lower()
         if not exchange_id or side not in {"buy", "sell"}:
             return None
@@ -796,6 +812,28 @@ class HyperliquidBot(CCXTBot):
         if len(matches) != 1:
             return None
         record = matches[0]
+        client_id_keys = (
+            "custom_id",
+            "customId",
+            "client_order_id",
+            "clientOrderId",
+            "client_oid",
+            "clientOid",
+            "clOrdId",
+        )
+        client_ids = {
+            self._canonical_passivbot_custom_id(str(source.get(key)))
+            for source in (order, raw_info)
+            for key in client_id_keys
+            if source.get(key) not in (None, "")
+        }
+        record_client_id = str(record.get("canonical_custom_id") or "")
+        if client_ids and (
+            not record_client_id
+            or len(client_ids) != 1
+            or next(iter(client_ids)) != record_client_id
+        ):
+            return None
         record_side = str(record.get("side") or "").lower()
         position_side = str(record.get("position_side") or "").lower()
         reduce_only = record.get("reduce_only")
@@ -811,8 +849,6 @@ class HyperliquidBot(CCXTBot):
         )
         if action_side != position_side:
             return None
-        info = order.get("info")
-        raw_info = info if isinstance(info, dict) else {}
         raw_side_value = raw_info.get("side")
         if raw_side_value not in (None, ""):
             raw_side = {
@@ -857,6 +893,31 @@ class HyperliquidBot(CCXTBot):
         ):
             return None
         return position_side, reduce_only
+
+    @staticmethod
+    def _hl_ws_order_has_fill_progress(order: dict) -> bool:
+        """Whether an open WS row proves that an acknowledged order has filled."""
+
+        def _number(key: str) -> float | None:
+            for source in (order, order.get("info", {})):
+                if not isinstance(source, dict) or source.get(key) in (None, ""):
+                    continue
+                try:
+                    value = float(source[key])
+                except (TypeError, ValueError, OverflowError):
+                    return None
+                return value if math.isfinite(value) and value >= 0.0 else None
+            return None
+
+        filled = _number("filled")
+        if filled is not None and filled > 0.0:
+            return True
+        amount = _number("amount")
+        remaining = _number("remaining")
+        if amount is None or remaining is None:
+            return False
+        tolerance = max(1e-12, amount * 1e-12)
+        return remaining < amount - tolerance
 
     def determine_pos_side(self, order):
         # Hyperliquid is one-way, but current position state must never label a

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -926,17 +926,38 @@ class HyperliquidBot(CCXTBot):
             return None
         authoritative_reduce_sources = raw_sources if raw_sources else (order,)
         reduce_only_keys = ("reduce_only", "reduceOnly", "is_reduce_only")
+        raw_has_explicit_reduce_only = False
         for source in authoritative_reduce_sources:
-            if not any(key in source for key in reduce_only_keys):
-                continue
-            websocket_reduce_only = self._strict_order_reduce_only_response(
-                {"info": source}
-            )
-            if (
-                not isinstance(websocket_reduce_only, bool)
-                or websocket_reduce_only != reduce_only
-            ):
-                return None
+            for key in reduce_only_keys:
+                if key not in source:
+                    continue
+                raw_has_explicit_reduce_only = True
+                websocket_reduce_only = self._strict_order_reduce_only_response(
+                    {"info": {key: source[key]}}
+                )
+                if (
+                    not isinstance(websocket_reduce_only, bool)
+                    or websocket_reduce_only != reduce_only
+                ):
+                    return None
+        if raw_sources:
+            for key in reduce_only_keys:
+                if key not in order:
+                    continue
+                value = order[key]
+                # CCXT may synthesize a unified False when the native payload
+                # omits reduceOnly. Preserve that compatibility, but never
+                # discard a supplied True or contradict native semantics.
+                if value is False and not raw_has_explicit_reduce_only:
+                    continue
+                websocket_reduce_only = self._strict_order_reduce_only_response(
+                    {"info": {key: value}}
+                )
+                if (
+                    not isinstance(websocket_reduce_only, bool)
+                    or websocket_reduce_only != reduce_only
+                ):
+                    return None
         return position_side, reduce_only
 
     @staticmethod

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -696,10 +696,23 @@ class HyperliquidBot(CCXTBot):
                 for order in res:
                     try:
                         order["position_side"] = self.determine_pos_side(order)
+                    except (KeyError, TypeError, ValueError) as exc:
+                        recovered = self._hl_acknowledged_ws_order_semantics(order)
+                        if recovered is None:
+                            untrusted.append((order, exc))
+                            continue
+                        position_side, reduce_only = recovered
+                        order["position_side"] = position_side
+                        order["reduceOnly"] = reduce_only
+                        order["_pb_order_semantics_source"] = (
+                            "acknowledged_exchange_order_id"
+                        )
+                    try:
                         order["qty"] = order["amount"]
-                        normalized.append(order)
                     except (KeyError, TypeError, ValueError) as exc:
                         untrusted.append((order, exc))
+                        continue
+                    normalized.append(order)
                 if untrusted:
                     symbols = {
                         str(order.get("symbol") or "")
@@ -756,6 +769,49 @@ class HyperliquidBot(CCXTBot):
                 )
                 await asyncio.sleep(1)
                 logging.debug("[ws] %s: reconnecting...", self.exchange)
+
+    def _hl_acknowledged_ws_order_semantics(
+        self, order: dict
+    ) -> tuple[str, bool] | None:
+        """Recover missing WS semantics from an exact acknowledged-order id.
+
+        Hyperliquid websocket order updates commonly omit ``reduceOnly`` and
+        client metadata.  Passivbot's acknowledged create records retain those
+        semantics together with the exchange-assigned order id.  An exact id
+        match is strong enough for websocket hint attribution; ambiguous,
+        malformed, contradictory, or foreign updates remain untrusted and
+        trigger the authoritative account-state refresh path.
+        """
+        if not isinstance(order, dict):
+            return None
+        exchange_id = self._extract_order_exchange_id(order)
+        side = str(order.get("side") or "").lower()
+        if not exchange_id or side not in {"buy", "sell"}:
+            return None
+        matches = [
+            record
+            for record in self._emitted_order_records()
+            if str(record.get("exchange_id") or "") == exchange_id
+        ]
+        if len(matches) != 1:
+            return None
+        record = matches[0]
+        record_side = str(record.get("side") or "").lower()
+        position_side = str(record.get("position_side") or "").lower()
+        reduce_only = record.get("reduce_only")
+        if (
+            record.get("status") != "acknowledged"
+            or record_side != side
+            or position_side not in {"long", "short"}
+            or not isinstance(reduce_only, bool)
+        ):
+            return None
+        action_side = self._derive_one_way_position_side(
+            {"side": side, "reduceOnly": reduce_only}
+        )
+        if action_side != position_side:
+            return None
+        return position_side, reduce_only
 
     def determine_pos_side(self, order):
         # Hyperliquid is one-way, but current position state must never label a

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -813,6 +813,18 @@ class HyperliquidBot(CCXTBot):
             return None
         info = order.get("info")
         raw_info = info if isinstance(info, dict) else {}
+        raw_side_value = raw_info.get("side")
+        if raw_side_value not in (None, ""):
+            raw_side = {
+                "a": "sell",
+                "ask": "sell",
+                "b": "buy",
+                "bid": "buy",
+                "buy": "buy",
+                "sell": "sell",
+            }.get(str(raw_side_value).strip().lower())
+            if raw_side is None or raw_side != side:
+                return None
         explicit_position_sides = [
             value
             for value in (

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -789,12 +789,23 @@ class HyperliquidBot(CCXTBot):
         if not isinstance(order, dict):
             return None
         info = order.get("info")
-        raw_info = info if isinstance(info, dict) else {}
+        info_wrapper = info if isinstance(info, dict) else {}
+        nested_order = info_wrapper.get("order")
+        raw_info = nested_order if isinstance(nested_order, dict) else info_wrapper
+        raw_source_candidates = (info_wrapper, raw_info)
+        raw_sources = tuple(
+            source
+            for index, source in enumerate(raw_source_candidates)
+            if source
+            and all(
+                source is not prior for prior in raw_source_candidates[:index]
+            )
+        )
 
         exchange_id_keys = ("id", "order_id", "orderId", "orderID", "ordId", "oid")
         exchange_ids = {
             str(source.get(key))
-            for source in (order, raw_info)
+            for source in (order, *raw_sources)
             for key in exchange_id_keys
             if source.get(key) not in (None, "")
         }
@@ -824,7 +835,7 @@ class HyperliquidBot(CCXTBot):
         )
         client_ids = {
             self._canonical_passivbot_custom_id(str(source.get(key)))
-            for source in (order, raw_info)
+            for source in (order, *raw_sources)
             for key in client_id_keys
             if source.get(key) not in (None, "")
         }
@@ -850,8 +861,12 @@ class HyperliquidBot(CCXTBot):
         )
         if action_side != position_side:
             return None
-        raw_side_value = raw_info.get("side")
-        if raw_side_value not in (None, ""):
+        raw_side_values = [
+            source.get("side")
+            for source in raw_sources
+            if source.get("side") not in (None, "")
+        ]
+        for raw_side_value in raw_side_values:
             raw_side = {
                 "a": "sell",
                 "ask": "sell",
@@ -862,8 +877,12 @@ class HyperliquidBot(CCXTBot):
             }.get(str(raw_side_value).strip().lower())
             if raw_side is None or raw_side != side:
                 return None
-        raw_status_value = raw_info.get("status")
-        if raw_status_value not in (None, ""):
+        raw_status_values = [
+            source.get("status")
+            for source in raw_sources
+            if source.get("status") not in (None, "")
+        ]
+        for raw_status_value in raw_status_values:
             normalized_status = {
                 "open": "open",
                 "opened": "open",
@@ -891,10 +910,8 @@ class HyperliquidBot(CCXTBot):
                 return None
         explicit_position_sides = [
             value
-            for value in (
-                order.get("position_side"),
-                raw_info.get("positionSide"),
-            )
+            for source in (order, *raw_sources)
+            for value in (source.get("position_side"), source.get("positionSide"))
             if value not in (None, "")
         ]
         if any(
@@ -907,19 +924,19 @@ class HyperliquidBot(CCXTBot):
             and durable_position_side != position_side
         ):
             return None
-        authoritative_reduce_source = raw_info if raw_info else order
+        authoritative_reduce_sources = raw_sources if raw_sources else (order,)
         reduce_only_keys = ("reduce_only", "reduceOnly", "is_reduce_only")
-        has_explicit_reduce_only = any(
-            key in authoritative_reduce_source for key in reduce_only_keys
-        )
-        websocket_reduce_only = self._strict_order_reduce_only_response(order)
-        if has_explicit_reduce_only and not isinstance(websocket_reduce_only, bool):
-            return None
-        if (
-            isinstance(websocket_reduce_only, bool)
-            and websocket_reduce_only != reduce_only
-        ):
-            return None
+        for source in authoritative_reduce_sources:
+            if not any(key in source for key in reduce_only_keys):
+                continue
+            websocket_reduce_only = self._strict_order_reduce_only_response(
+                {"info": source}
+            )
+            if (
+                not isinstance(websocket_reduce_only, bool)
+                or websocket_reduce_only != reduce_only
+            ):
+                return None
         return position_side, reduce_only
 
     @staticmethod

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -820,6 +820,7 @@ class HyperliquidBot(CCXTBot):
             "client_oid",
             "clientOid",
             "clOrdId",
+            "cloid",
         )
         client_ids = {
             self._canonical_passivbot_custom_id(str(source.get(key)))
@@ -860,6 +861,33 @@ class HyperliquidBot(CCXTBot):
                 "sell": "sell",
             }.get(str(raw_side_value).strip().lower())
             if raw_side is None or raw_side != side:
+                return None
+        raw_status_value = raw_info.get("status")
+        if raw_status_value not in (None, ""):
+            normalized_status = {
+                "open": "open",
+                "opened": "open",
+                "resting": "open",
+                "filled": "closed",
+                "closed": "closed",
+                "canceled": "canceled",
+                "cancelled": "canceled",
+                "rejected": "rejected",
+                "expired": "expired",
+            }.get(str(raw_status_value).strip().lower())
+            top_status = {
+                "open": "open",
+                "opened": "open",
+                "closed": "closed",
+                "filled": "closed",
+                "canceled": "canceled",
+                "cancelled": "canceled",
+                "rejected": "rejected",
+                "expired": "expired",
+            }.get(str(order.get("status") or "").strip().lower())
+            if normalized_status is None or (
+                top_status is not None and normalized_status != top_status
+            ):
                 return None
         explicit_position_sides = [
             value

--- a/src/live/reconciler.py
+++ b/src/live/reconciler.py
@@ -282,6 +282,7 @@ def extract_order_custom_id(order: dict) -> str:
         "order_link_id",
         "orderLinkId",
         "clOrdId",
+        "cloid",
         "text",
     )
     for source in (order, order.get("info", {})):

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -10994,6 +10994,8 @@ class Passivbot:
         for order in upd_list:
             if not isinstance(order, dict):
                 return False
+            if order.get("_pb_order_update_requires_authoritative_refresh") is True:
+                return False
             status = str(order.get("status") or "").lower()
             if status == "open":
                 if not self.order_matches_recent_execution(order):

--- a/tests/test_hyperliquid_balance_cache.py
+++ b/tests/test_hyperliquid_balance_cache.py
@@ -256,6 +256,14 @@ def test_hyperliquid_ws_order_rejects_ambiguous_acknowledged_id(stubbed_modules)
             "clientOrderId": "entry_initial_normal_long_different",
             "info": {"oid": 123, "side": "B", "sz": "0.01"},
         },
+        {
+            "info": {
+                "oid": 123,
+                "cloid": "entry_initial_normal_long_different",
+                "side": "B",
+                "sz": "0.01",
+            }
+        },
     ],
 )
 def test_hyperliquid_ws_order_rejects_conflicting_acknowledged_identity(
@@ -371,6 +379,18 @@ async def test_hyperliquid_recovered_partial_fill_forces_authoritative_refresh(
                 "info": {
                     "oid": 123,
                     "side": "A",
+                    "sz": "0.01",
+                },
+            },
+        ),
+        (
+            {},
+            {
+                "status": "open",
+                "info": {
+                    "oid": 123,
+                    "side": "B",
+                    "status": "filled",
                     "sz": "0.01",
                 },
             },

--- a/tests/test_hyperliquid_balance_cache.py
+++ b/tests/test_hyperliquid_balance_cache.py
@@ -199,6 +199,9 @@ async def test_hyperliquid_ws_order_recovers_semantics_from_exact_acknowledged_i
                 "symbol": "BTC/USDC:USDC",
                 "side": side,
                 "amount": 0.01,
+                # CCXT may synthesize False when the native WS payload omits
+                # reduceOnly. It must not contradict the acknowledged close.
+                "reduceOnly": False,
                 "info": {"oid": 123, "side": raw_side, "sz": "0.01"},
             }
         ]
@@ -420,6 +423,12 @@ async def test_hyperliquid_recovered_partial_fill_forces_authoritative_refresh(
     [
         ({"side": "sell", "position_side": "short"}, {}),
         ({}, {"position_side": "short"}),
+        (
+            {},
+            {
+                "reduceOnly": True,
+            },
+        ),
         (
             {},
             {

--- a/tests/test_hyperliquid_balance_cache.py
+++ b/tests/test_hyperliquid_balance_cache.py
@@ -248,8 +248,29 @@ def test_hyperliquid_ws_order_rejects_ambiguous_acknowledged_id(stubbed_modules)
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("record_overrides", "order_overrides"),
+    [
+        ({"side": "sell", "position_side": "short"}, {}),
+        ({}, {"position_side": "short"}),
+        (
+            {},
+            {
+                "position_side": "long",
+                "info": {
+                    "oid": 123,
+                    "side": "B",
+                    "sz": "0.01",
+                    "reduceOnly": True,
+                },
+            },
+        ),
+    ],
+)
 async def test_hyperliquid_ws_order_rejects_contradictory_acknowledged_semantics(
     stubbed_modules,
+    record_overrides,
+    order_overrides,
 ):
     HyperliquidBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
     bot = HyperliquidBot.__new__(HyperliquidBot)
@@ -258,17 +279,17 @@ async def test_hyperliquid_ws_order_rejects_contradictory_acknowledged_semantics
     bot._health_rate_limits = 0
     bot._log_symbols = lambda symbols, limit=8: ",".join(symbols[:limit])
     bot._hl_note_ws_symbols_for_dex_scope = lambda _orders: None
-    bot.orders_emitted_to_exchange = [
-        {
-            "timestamp": 1,
-            "exchange_id": "123",
-            "side": "sell",
-            "position_side": "short",
-            "reduce_only": False,
-            "pb_type": "entry_initial_normal_short",
-            "status": "acknowledged",
-        }
-    ]
+    record = {
+        "timestamp": 1,
+        "exchange_id": "123",
+        "side": "buy",
+        "position_side": "long",
+        "reduce_only": False,
+        "pb_type": "entry_initial_normal_long",
+        "status": "acknowledged",
+    }
+    record.update(record_overrides)
+    bot.orders_emitted_to_exchange = [record]
     handled = []
     dirty = []
     bot.handle_order_update = lambda orders: handled.append(orders)
@@ -276,15 +297,15 @@ async def test_hyperliquid_ws_order_rejects_contradictory_acknowledged_semantics
 
     async def watch_orders():
         bot.stop_websocket = True
-        return [
-            {
-                "id": "123",
-                "symbol": "BTC/USDC:USDC",
-                "side": "buy",
-                "amount": 0.01,
-                "info": {"oid": 123, "side": "B", "sz": "0.01"},
-            }
-        ]
+        order = {
+            "id": "123",
+            "symbol": "BTC/USDC:USDC",
+            "side": "buy",
+            "amount": 0.01,
+            "info": {"oid": 123, "side": "B", "sz": "0.01"},
+        }
+        order.update(order_overrides)
+        return [order]
 
     bot.ccp = types.SimpleNamespace(watch_orders=watch_orders)
 

--- a/tests/test_hyperliquid_balance_cache.py
+++ b/tests/test_hyperliquid_balance_cache.py
@@ -248,6 +248,105 @@ def test_hyperliquid_ws_order_rejects_ambiguous_acknowledged_id(stubbed_modules)
     )
 
 
+@pytest.mark.parametrize(
+    "order_overrides",
+    [
+        {"info": {"oid": 456, "side": "B", "sz": "0.01"}},
+        {
+            "clientOrderId": "entry_initial_normal_long_different",
+            "info": {"oid": 123, "side": "B", "sz": "0.01"},
+        },
+    ],
+)
+def test_hyperliquid_ws_order_rejects_conflicting_acknowledged_identity(
+    stubbed_modules,
+    order_overrides,
+):
+    HyperliquidBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    bot = HyperliquidBot.__new__(HyperliquidBot)
+    bot.orders_emitted_to_exchange = [
+        {
+            "timestamp": 1,
+            "exchange_id": "123",
+            "canonical_custom_id": "entry_initial_normal_long_local",
+            "side": "buy",
+            "position_side": "long",
+            "reduce_only": False,
+            "pb_type": "entry_initial_normal_long",
+            "status": "acknowledged",
+        }
+    ]
+    order = {
+        "id": "123",
+        "side": "buy",
+        "amount": 0.01,
+        "info": {"oid": 123, "side": "B", "sz": "0.01"},
+    }
+    order.update(order_overrides)
+
+    assert bot._hl_acknowledged_ws_order_semantics(order) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "progress",
+    [
+        {"filled": 0.004, "remaining": 0.006},
+        {"filled": 0.0, "remaining": 0.006},
+    ],
+)
+async def test_hyperliquid_recovered_partial_fill_forces_authoritative_refresh(
+    stubbed_modules,
+    progress,
+):
+    HyperliquidBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    bot = HyperliquidBot.__new__(HyperliquidBot)
+    bot.stop_websocket = False
+    bot._health_ws_reconnects = 0
+    bot._health_rate_limits = 0
+    bot._log_symbols = lambda symbols, limit=8: ",".join(symbols[:limit])
+    bot._hl_note_ws_symbols_for_dex_scope = lambda _orders: None
+    bot.orders_emitted_to_exchange = [
+        {
+            "timestamp": 1,
+            "exchange_id": "123",
+            "side": "buy",
+            "position_side": "long",
+            "reduce_only": False,
+            "pb_type": "entry_initial_normal_long",
+            "status": "acknowledged",
+        }
+    ]
+    handled = []
+    dirty = []
+    bot.handle_order_update = lambda orders: handled.extend(orders)
+    bot._mark_account_critical_state_dirty = lambda **kwargs: dirty.append(kwargs)
+
+    async def watch_orders():
+        bot.stop_websocket = True
+        return [
+            {
+                "id": "123",
+                "symbol": "BTC/USDC:USDC",
+                "status": "open",
+                "side": "buy",
+                "amount": 0.01,
+                **progress,
+                "info": {"oid": 123, "side": "B", "sz": "0.01"},
+            }
+        ]
+
+    bot.ccp = types.SimpleNamespace(watch_orders=watch_orders)
+
+    await bot.watch_orders()
+
+    assert dirty == []
+    assert len(handled) == 1
+    assert handled[0]["_pb_order_update_requires_authoritative_refresh"] is True
+    bot.order_matches_recent_execution = lambda _order: True
+    assert bot._ws_order_update_is_self_echo(handled) is False
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("record_overrides", "order_overrides"),

--- a/tests/test_hyperliquid_balance_cache.py
+++ b/tests/test_hyperliquid_balance_cache.py
@@ -145,10 +145,10 @@ async def test_hyperliquid_ws_order_without_reduce_only_requests_refresh_without
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("side", "position_side", "reduce_only"),
+    ("side", "raw_side", "position_side", "reduce_only"),
     [
-        ("buy", "long", False),
-        ("sell", "long", True),
+        ("buy", "B", "long", False),
+        ("sell", "A", "long", True),
     ],
 )
 async def test_hyperliquid_ws_order_recovers_semantics_from_exact_acknowledged_id(
@@ -156,6 +156,7 @@ async def test_hyperliquid_ws_order_recovers_semantics_from_exact_acknowledged_i
     monkeypatch,
     caplog,
     side,
+    raw_side,
     position_side,
     reduce_only,
 ):
@@ -198,7 +199,7 @@ async def test_hyperliquid_ws_order_recovers_semantics_from_exact_acknowledged_i
                 "symbol": "BTC/USDC:USDC",
                 "side": side,
                 "amount": 0.01,
-                "info": {"oid": 123, "side": "B", "sz": "0.01"},
+                "info": {"oid": 123, "side": raw_side, "sz": "0.01"},
             }
         ]
 
@@ -262,6 +263,16 @@ def test_hyperliquid_ws_order_rejects_ambiguous_acknowledged_id(stubbed_modules)
                     "side": "B",
                     "sz": "0.01",
                     "reduceOnly": True,
+                },
+            },
+        ),
+        (
+            {},
+            {
+                "info": {
+                    "oid": 123,
+                    "side": "A",
+                    "sz": "0.01",
                 },
             },
         ),

--- a/tests/test_hyperliquid_balance_cache.py
+++ b/tests/test_hyperliquid_balance_cache.py
@@ -248,6 +248,44 @@ def test_hyperliquid_ws_order_rejects_ambiguous_acknowledged_id(stubbed_modules)
     )
 
 
+def test_hyperliquid_ws_order_unwraps_native_ccxt_payload(stubbed_modules):
+    HyperliquidBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    bot = HyperliquidBot.__new__(HyperliquidBot)
+    bot.orders_emitted_to_exchange = [
+        {
+            "timestamp": 1,
+            "exchange_id": "123",
+            "canonical_custom_id": "entry_initial_normal_long_local",
+            "side": "buy",
+            "position_side": "long",
+            "reduce_only": False,
+            "pb_type": "entry_initial_normal_long",
+            "status": "acknowledged",
+        }
+    ]
+
+    recovered = bot._hl_acknowledged_ws_order_semantics(
+        {
+            "id": "123",
+            "side": "buy",
+            "amount": 0.01,
+            "status": "open",
+            "info": {
+                "order": {
+                    "oid": 123,
+                    "cloid": "entry_initial_normal_long_local",
+                    "side": "B",
+                    "sz": "0.01",
+                    "reduceOnly": False,
+                },
+                "status": "open",
+            },
+        }
+    )
+
+    assert recovered == ("long", False)
+
+
 @pytest.mark.parametrize(
     "order_overrides",
     [
@@ -262,6 +300,27 @@ def test_hyperliquid_ws_order_rejects_ambiguous_acknowledged_id(stubbed_modules)
                 "cloid": "entry_initial_normal_long_different",
                 "side": "B",
                 "sz": "0.01",
+            }
+        },
+        {
+            "info": {
+                "order": {
+                    "oid": 123,
+                    "cloid": "entry_initial_normal_long_different",
+                    "side": "B",
+                    "sz": "0.01",
+                },
+                "status": "open",
+            }
+        },
+        {
+            "info": {
+                "order": {
+                    "oid": 456,
+                    "side": "B",
+                    "sz": "0.01",
+                },
+                "status": "open",
             }
         },
     ],
@@ -392,6 +451,35 @@ async def test_hyperliquid_recovered_partial_fill_forces_authoritative_refresh(
                     "side": "B",
                     "status": "filled",
                     "sz": "0.01",
+                },
+            },
+        ),
+        (
+            {},
+            {
+                "status": "open",
+                "info": {
+                    "order": {
+                        "oid": 123,
+                        "side": "B",
+                        "sz": "0.01",
+                        "reduceOnly": True,
+                    },
+                    "status": "open",
+                },
+            },
+        ),
+        (
+            {},
+            {
+                "status": "open",
+                "info": {
+                    "order": {
+                        "oid": 123,
+                        "side": "B",
+                        "sz": "0.01",
+                    },
+                    "status": "filled",
                 },
             },
         ),

--- a/tests/test_hyperliquid_balance_cache.py
+++ b/tests/test_hyperliquid_balance_cache.py
@@ -144,6 +144,164 @@ async def test_hyperliquid_ws_order_without_reduce_only_requests_refresh_without
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("side", "position_side", "reduce_only"),
+    [
+        ("buy", "long", False),
+        ("sell", "long", True),
+    ],
+)
+async def test_hyperliquid_ws_order_recovers_semantics_from_exact_acknowledged_id(
+    stubbed_modules,
+    monkeypatch,
+    caplog,
+    side,
+    position_side,
+    reduce_only,
+):
+    hyperliquid_module = importlib.import_module("exchanges.hyperliquid")
+    HyperliquidBot = hyperliquid_module.HyperliquidBot
+    monkeypatch.setattr(hyperliquid_module.time, "monotonic", lambda: 100.0)
+    caplog.set_level(pylogging.WARNING)
+    bot = HyperliquidBot.__new__(HyperliquidBot)
+    bot.stop_websocket = False
+    bot._health_ws_reconnects = 0
+    bot._health_rate_limits = 0
+    bot._log_symbols = lambda symbols, limit=8: ",".join(symbols[:limit])
+    bot._hl_note_ws_symbols_for_dex_scope = lambda _orders: None
+    bot.orders_emitted_to_exchange = [
+        {
+            "timestamp": 1,
+            "exchange_id": "123",
+            "side": side,
+            "position_side": position_side,
+            "reduce_only": reduce_only,
+            "pb_type": "entry_initial_normal_long",
+            "status": "acknowledged",
+        }
+    ]
+    handled = []
+    dirty = []
+    bot.handle_order_update = lambda orders: handled.append(orders)
+    bot._mark_account_critical_state_dirty = lambda **kwargs: dirty.append(kwargs)
+
+    watch_calls = 0
+
+    async def watch_orders():
+        nonlocal watch_calls
+        watch_calls += 1
+        if watch_calls == 2:
+            bot.stop_websocket = True
+        return [
+            {
+                "id": "123",
+                "symbol": "BTC/USDC:USDC",
+                "side": side,
+                "amount": 0.01,
+                "info": {"oid": 123, "side": "B", "sz": "0.01"},
+            }
+        ]
+
+    bot.ccp = types.SimpleNamespace(watch_orders=watch_orders)
+
+    await bot.watch_orders()
+
+    assert bot._health_ws_reconnects == 0
+    assert len(handled) == 2
+    assert dirty == []
+    for [order] in handled:
+        assert order["position_side"] == position_side
+        assert order["reduceOnly"] is reduce_only
+        assert order["qty"] == 0.01
+        assert (
+            order["_pb_order_semantics_source"]
+            == "acknowledged_exchange_order_id"
+        )
+    assert not any(
+        "lacked authoritative order semantics" in rec.message
+        for rec in caplog.records
+    )
+
+
+def test_hyperliquid_ws_order_rejects_ambiguous_acknowledged_id(stubbed_modules):
+    HyperliquidBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    bot = HyperliquidBot.__new__(HyperliquidBot)
+    bot.orders_emitted_to_exchange = [
+        {
+            "timestamp": timestamp,
+            "exchange_id": "123",
+            "side": "buy",
+            "position_side": "long",
+            "reduce_only": False,
+            "pb_type": "entry_initial_normal_long",
+            "status": "acknowledged",
+        }
+        for timestamp in (1, 2)
+    ]
+
+    assert (
+        bot._hl_acknowledged_ws_order_semantics(
+            {"id": "123", "side": "buy", "amount": 0.01}
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_hyperliquid_ws_order_rejects_contradictory_acknowledged_semantics(
+    stubbed_modules,
+):
+    HyperliquidBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    bot = HyperliquidBot.__new__(HyperliquidBot)
+    bot.stop_websocket = False
+    bot._health_ws_reconnects = 0
+    bot._health_rate_limits = 0
+    bot._log_symbols = lambda symbols, limit=8: ",".join(symbols[:limit])
+    bot._hl_note_ws_symbols_for_dex_scope = lambda _orders: None
+    bot.orders_emitted_to_exchange = [
+        {
+            "timestamp": 1,
+            "exchange_id": "123",
+            "side": "sell",
+            "position_side": "short",
+            "reduce_only": False,
+            "pb_type": "entry_initial_normal_short",
+            "status": "acknowledged",
+        }
+    ]
+    handled = []
+    dirty = []
+    bot.handle_order_update = lambda orders: handled.append(orders)
+    bot._mark_account_critical_state_dirty = lambda **kwargs: dirty.append(kwargs)
+
+    async def watch_orders():
+        bot.stop_websocket = True
+        return [
+            {
+                "id": "123",
+                "symbol": "BTC/USDC:USDC",
+                "side": "buy",
+                "amount": 0.01,
+                "info": {"oid": 123, "side": "B", "sz": "0.01"},
+            }
+        ]
+
+    bot.ccp = types.SimpleNamespace(watch_orders=watch_orders)
+
+    await bot.watch_orders()
+
+    assert handled == []
+    assert dirty == [
+        {
+            "reason": "order_ws_semantics_unavailable",
+            "symbols": {"BTC/USDC:USDC"},
+            "source": "hyperliquid_order_ws",
+            "level": pylogging.DEBUG,
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_hyperliquid_already_gone_cancel_requests_full_confirmation(stubbed_modules):
     HyperliquidBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
     markers = []

--- a/tests/test_order_reconciliation_contract.py
+++ b/tests/test_order_reconciliation_contract.py
@@ -19,6 +19,12 @@ def _client_id(pb_order_type: str) -> str:
     return f"pb-0x{pbr.order_type_snake_to_id(pb_order_type):04x}-test"
 
 
+def test_hyperliquid_native_cloid_is_a_client_order_identity():
+    client_id = _client_id("entry_grid_normal_long")
+
+    assert reconciler.extract_order_custom_id({"info": {"cloid": client_id}}) == client_id
+
+
 @pytest.mark.parametrize(
     ("bot_cls", "extra", "side", "expected_pside", "expected_close"),
     [


### PR DESCRIPTION
## Summary

- recover missing Hyperliquid websocket order semantics only from an exact exchange-order ID in Passivbot's acknowledged create records
- require every supplied native, unified, and client identity, plus top-level side, raw exchange
  side, position side, and reduce-only semantics, to agree before accepting recovery
- validate Hyperliquid-native `oid`/`cloid` and reject raw terminal status that contradicts the
  unified websocket status
- retain native `cloid` as a client-order identity in acknowledged-order records
- force authoritative account-state refresh when a recovered still-open update reports any fill
  progress, rather than suppressing it as a local create echo
- keep ambiguous, unacknowledged, malformed, contradictory, and foreign updates on the existing fail-closed authoritative-refresh path

This reduces unnecessary account-state refresh churn without treating websocket order updates as authoritative account state.

## Validation

- `python -m compileall -q src tests/test_hyperliquid_balance_cache.py tests/test_order_reconciliation_contract.py`
- `pytest -q tests/test_hyperliquid_balance_cache.py tests/test_order_reconciliation_contract.py`
- `git diff --check`
