### PR TITLE
Fix trailing confirmation with partial fill history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ All notable user-facing changes will be documented in this file.
   fills use stable content-based identities rather than history-list indices. Position snapshots
   preserve distinct exchange opening times, while timestamp-free positions retry with
   progressively wider history windows and retain the fills confirmation barrier between attempts.
+  Widening starts only after the required recent post-snapshot confirmation, tracks progress per
+  coin and position side, and is capped at a two-year live recovery horizon to avoid unbounded
+  exchange pagination.
 
 - Bybit closed-PnL refreshes now cover requested history with explicit,
   contiguous sub-seven-day windows and cursor pagination inside each window.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ All notable user-facing changes will be documented in this file.
   exchange state; price and quantity alone cannot prove a flat-to-position transition. Id-less
   fills use stable content-based identities rather than history-list indices. Position snapshots
   preserve distinct exchange opening times, while timestamp-free positions retry with
-  progressively wider history windows and retain the fills confirmation barrier between attempts.
+  progressively wider history windows outside the account-wide execution barrier, so only the
+  affected trailing coin and position side remain nontradable between attempts.
   Widening starts only after the required recent post-snapshot confirmation, tracks progress per
   coin and position side, and is capped at a two-year live recovery horizon to avoid unbounded
   exchange pagination.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,6 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
-- Fixed live trailing fill confirmation getting stuck after restart when cached fill history starts
-  mid-position and therefore cannot reconstruct the exchange position's exact size or average
-  price. A completed post-snapshot fill refresh and current fill identity now restore trailing
-  extrema while reconstructed fill after-state remains diagnostic-only. Id-less fills use stable
-  content-based identities rather than history-list indices, so loading older history cannot
-  falsely confirm a new position-changing fill.
-
 - Backtests now treat a finite balance depleted by fills as liquidation before recomputing orders,
   so extreme optimizer candidates terminate normally instead of panicking an optimizer worker.
   Other invalid orchestrator inputs now propagate as backtest errors without unwinding Rust.
@@ -19,7 +12,8 @@ All notable user-facing changes will be documented in this file.
   loading or repairing local fill caches, widens fill-history fetches with bounded backoff when a
   position remains tied to a stale or mismatched fill, and recognizes an exact full-opening fill
   even when older truncated history polluted its reconstructed post-fill size. Affected trailing
-  positions remain fail-closed until the refreshed fill evidence matches exchange state.
+  positions remain fail-closed until the refreshed fill evidence matches exchange state. Id-less
+  fills use stable content-based identities rather than history-list indices.
 
 - Live candle orchestration now reads bounded cache-only native 1h EMA carry-forward from the 1h
   index, requires a complete native window, isolates carried values from the active EMA cache, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable user-facing changes will be documented in this file.
   exchange state; price and quantity alone cannot prove a flat-to-position transition. Id-less
   fills use stable content-based identities rather than history-list indices. Position snapshots
   preserve distinct exchange opening times, while timestamp-free positions retry with
-  progressively wider history windows.
+  progressively wider history windows and retain the fills confirmation barrier between attempts.
 
 - Bybit closed-PnL refreshes now cover requested history with explicit,
   contiguous sub-seven-day windows and cursor pagination inside each window.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Fixed live trailing fill confirmation getting stuck after restart when cached fill history starts
+  mid-position and therefore cannot reconstruct the exchange position's exact size or average
+  price. A completed post-snapshot fill refresh and current fill identity now restore trailing
+  extrema while reconstructed fill after-state remains diagnostic-only.
+
 - Live candle orchestration now reads bounded cache-only native 1h EMA carry-forward from the 1h
   index, requires a complete native window, isolates carried values from the active EMA cache, and
   applies the background refresher's surface-count staleness limit using the active live/replay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,11 @@ All notable user-facing changes will be documented in this file.
   progressively wider history windows outside the account-wide execution barrier, so only the
   affected trailing coin and position side remain nontradable between attempts.
   Widening starts only in background recovery after the required recent post-snapshot confirmation,
-  tracks progress per coin and position side, and is capped by venue retention (365 days on WEEX,
-  otherwise a conservative two-year horizon) to avoid unbounded exchange pagination.
+  tracks progress per coin and position side, and is capped by connector pagination capacity
+  (two years on Bybit, otherwise one year) to avoid unbounded exchange pagination. Sparse Bybit
+  trade history now traverses empty recent windows instead of stopping before older fills, while
+  stale fill state remains part of the blocking authoritative refresh rather than being displaced
+  by a background recovery.
 
 - Bybit closed-PnL refreshes now cover requested history with explicit,
   contiguous sub-seven-day windows and cursor pagination inside each window.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ All notable user-facing changes will be documented in this file.
 
 - Live fill confirmation now preserves the last successful exchange-refresh timestamp while
   loading or repairing local fill caches, widens fill-history fetches with bounded backoff when a
-  position remains tied to a stale or mismatched fill, and recognizes an exact full-opening fill
-  even when older truncated history polluted its reconstructed post-fill size. Affected trailing
-  positions remain fail-closed until the refreshed fill evidence matches exchange state. Id-less
+  position remains tied to a stale or mismatched fill, starting before the earliest available
+  position/open timestamp even when that predates the configured PnL window. Affected trailing
+  positions remain fail-closed until refreshed history reconstructs a post-fill state matching
+  exchange state; price and quantity alone cannot prove a flat-to-position transition. Id-less
   fills use stable content-based identities rather than history-list indices.
 
 - Live candle orchestration now reads bounded cache-only native 1h EMA carry-forward from the 1h

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@ All notable user-facing changes will be documented in this file.
   preserve distinct exchange opening times, while timestamp-free positions retry with
   progressively wider history windows outside the account-wide execution barrier, so only the
   affected trailing coin and position side remain nontradable between attempts.
-  Widening starts only after the required recent post-snapshot confirmation, tracks progress per
-  coin and position side, and is capped at a two-year live recovery horizon to avoid unbounded
-  exchange pagination.
+  Widening starts only in background recovery after the required recent post-snapshot confirmation,
+  tracks progress per coin and position side, and is capped by venue retention (365 days on WEEX,
+  otherwise a conservative two-year horizon) to avoid unbounded exchange pagination.
 
 - Bybit closed-PnL refreshes now cover requested history with explicit,
   contiguous sub-seven-day windows and cursor pagination inside each window.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ All notable user-facing changes will be documented in this file.
 - Fixed live trailing fill confirmation getting stuck after restart when cached fill history starts
   mid-position and therefore cannot reconstruct the exchange position's exact size or average
   price. A completed post-snapshot fill refresh and current fill identity now restore trailing
-  extrema while reconstructed fill after-state remains diagnostic-only.
+  extrema while reconstructed fill after-state remains diagnostic-only. Id-less fills use stable
+  content-based identities rather than history-list indices, so loading older history cannot
+  falsely confirm a new position-changing fill.
 
 - Live candle orchestration now reads bounded cache-only native 1h EMA carry-forward from the 1h
   index, requires a complete native window, isolates carried values from the active EMA cache, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ All notable user-facing changes will be documented in this file.
   so extreme optimizer candidates terminate normally instead of panicking an optimizer worker.
   Other invalid orchestrator inputs now propagate as backtest errors without unwinding Rust.
 
+- Live fill confirmation now preserves the last successful exchange-refresh timestamp while
+  loading or repairing local fill caches, widens fill-history fetches with bounded backoff when a
+  position remains tied to a stale or mismatched fill, and recognizes an exact full-opening fill
+  even when older truncated history polluted its reconstructed post-fill size. Affected trailing
+  positions remain fail-closed until the refreshed fill evidence matches exchange state.
+
 - Live candle orchestration now reads bounded cache-only native 1h EMA carry-forward from the 1h
   index, requires a complete native window, isolates carried values from the active EMA cache, and
   applies the background refresher's surface-count staleness limit using the active live/replay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ All notable user-facing changes will be documented in this file.
   position/open timestamp even when that predates the configured PnL window. Affected trailing
   positions remain fail-closed until refreshed history reconstructs a post-fill state matching
   exchange state; price and quantity alone cannot prove a flat-to-position transition. Id-less
-  fills use stable content-based identities rather than history-list indices.
+  fills use stable content-based identities rather than history-list indices. Position snapshots
+  preserve distinct exchange opening times, while timestamp-free positions retry with
+  progressively wider history windows.
 
 - Bybit closed-PnL refreshes now cover requested history with explicit,
   contiguous sub-seven-day windows and cursor pagination inside each window.

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -27,10 +27,9 @@
    offline.
 9. A position whose latest fill identity or reconstructed after-state does not
    match the authoritative exchange position remains nontradable. Live orchestration
-   retries from the position/fill anchor with bounded in-memory backoff; it may accept
-   an exact full-opening fill whose direction, quantity, and price independently match
-   the whole exchange position even when an older truncated cache polluted the fill's
-   reconstructed `psize`/`pprice`.
+   retries from the position/fill anchor with bounded in-memory backoff. Direction,
+   quantity, and price alone do not prove a flat-to-position transition when truncated
+   history has polluted reconstructed `psize`/`pprice`.
 
 ## Runtime Provenance
 

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -21,6 +21,16 @@
    or caused the exchange fill. Refresh and deduplication preserve an existing
    provenance record, including the absence of provenance on legacy cache rows.
    Historical rows are never retroactively attributed.
+8. `last_refresh_ms` records a completed exchange fetch, not local cache loading,
+   normalization, or doctor repair. Preserving that distinction ensures the first
+   incremental refresh after restart covers fills which occurred while the bot was
+   offline.
+9. A position whose latest fill identity or reconstructed after-state does not
+   match the authoritative exchange position remains nontradable. Live orchestration
+   retries from the position/fill anchor with bounded in-memory backoff; it may accept
+   an exact full-opening fill whose direction, quantity, and price independently match
+   the whole exchange position even when an older truncated cache polluted the fill's
+   reconstructed `psize`/`pprice`.
 
 ## Runtime Provenance
 

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -1806,8 +1806,18 @@ class FillEventCache:
                 ) from exc
             raise
 
-    def update_metadata_from_events(self, events: Sequence[FillEvent]) -> None:
-        """Update metadata timestamps based on events."""
+    def update_metadata_from_events(
+        self,
+        events: Sequence[FillEvent],
+        *,
+        mark_refreshed: bool = True,
+    ) -> None:
+        """Update cached event bounds and optionally record a remote refresh.
+
+        Loading and normalizing local cache files is not an exchange refresh.
+        Callers doing local-only maintenance must leave ``last_refresh_ms``
+        unchanged so the next incremental fetch still covers bot downtime.
+        """
         if not events:
             return
 
@@ -1824,7 +1834,10 @@ class FillEventCache:
         if newest > current_newest:
             metadata["newest_event_ts"] = newest
 
-        metadata["last_refresh_ms"] = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+        if mark_refreshed:
+            metadata["last_refresh_ms"] = int(
+                datetime.now(tz=timezone.utc).timestamp() * 1000
+            )
         metadata["pnl_contract"] = PNL_CONTRACT_CURRENT
         self.save_metadata(metadata)
 
@@ -3474,7 +3487,9 @@ class FillEventsManager:
                 if normalized_days:
                     self.cache.save_days(self._events_for_days(self._events, normalized_days))
                 if synthesized_days or normalized_days:
-                    self.cache.update_metadata_from_events(self._events)
+                    self.cache.update_metadata_from_events(
+                        self._events, mark_refreshed=False
+                    )
 
             logger.debug(
                 "[fills] ensure_loaded: %d cached events (dropped %d without raw)",
@@ -4112,7 +4127,9 @@ class FillEventsManager:
         legacy_contract = metadata_legacy or record_legacy
         report["legacy_contract"] = legacy_contract
         if metadata_legacy and not record_legacy and auto_repair:
-            self.cache.update_metadata_from_events(self._events)
+            self.cache.update_metadata_from_events(
+                self._events, mark_refreshed=False
+            )
             report["repaired"] = True
             report["anomaly_events_after"] = 0
             report["anomaly_examples_after"] = []
@@ -4188,7 +4205,9 @@ class FillEventsManager:
         report["anomaly_examples"] = anomalies[:5]
         if not anomalies or not auto_repair:
             if legacy_contract and auto_repair and not record_legacy:
-                self.cache.update_metadata_from_events(self._events)
+                self.cache.update_metadata_from_events(
+                    self._events, mark_refreshed=False
+                )
                 report["repaired"] = True
                 report["anomaly_events_after"] = 0
                 report["anomaly_examples_after"] = []
@@ -4248,7 +4267,9 @@ class FillEventsManager:
         apply_hyperliquid_raw_psize_overrides(payload)
         self._events = [FillEvent.from_dict(ev) for ev in payload]
         self.cache.save(self._events)
-        self.cache.update_metadata_from_events(self._events)
+        self.cache.update_metadata_from_events(
+            self._events, mark_refreshed=False
+        )
 
         remaining = self._scan_bybit_qty_inflation(self._events)
         report["anomaly_events_after"] = len(remaining)
@@ -4394,7 +4415,9 @@ class FillEventsManager:
         compute_psize_pprice(repaired_payload)
         self._events = [FillEvent.from_dict(ev) for ev in repaired_payload]
         self.cache.save(self._events)
-        self.cache.update_metadata_from_events(self._events)
+        self.cache.update_metadata_from_events(
+            self._events, mark_refreshed=False
+        )
         report["backup_path"] = backup_path
         report["degraded_events_after"] = degraded_count
         report["anomaly_events_after"] = degraded_count

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -5270,7 +5270,12 @@ class BybitFetcher(BaseFetcher):
                     len(batch) if batch else 0,
                 )
             if not batch:
-                break
+                if params["endTime"] - start_ms < self._max_span_ms:
+                    break
+                params["endTime"] = max(
+                    start_ms, params["endTime"] - self._max_span_ms
+                )
+                continue
             batch.sort(key=lambda x: x["timestamp"])
             results.extend(batch)
             if len(batch) < self.trade_limit:

--- a/src/live/state_refresh.py
+++ b/src/live/state_refresh.py
@@ -196,8 +196,16 @@ async def capture_positions_staged_snapshot(bot) -> tuple[object, list[dict]]:
 def authoritative_staged_refresh_plan(bot) -> set[str]:
     """Return the minimal staged authoritative surfaces needed this cycle."""
     pending = set(getattr(bot, "_authoritative_pending_confirmations", {}) or {})
+    trailing_recovery_due = getattr(
+        bot, "_trailing_fill_recovery_prefetch_due", None
+    )
+    should_prefetch_trailing_recovery = bool(
+        callable(trailing_recovery_due) and trailing_recovery_due()
+    )
     if pending == {"open_orders"}:
         plan = {"open_orders"}
+        if should_prefetch_trailing_recovery:
+            bot._schedule_routine_fill_refresh_prefetch(reason="trailing_recovery")
         bot._authoritative_refresh_plan_surfaces = set(plan)
         return plan
     plan = {"balance", "positions", "open_orders", "fills"}
@@ -218,6 +226,8 @@ def authoritative_staged_refresh_plan(bot) -> set[str]:
         ):
             plan.discard("fills")
             logging.debug("[state] staged routine fills refresh scheduled in background")
+    if should_prefetch_trailing_recovery and "fills" not in plan:
+        bot._schedule_routine_fill_refresh_prefetch(reason="trailing_recovery")
     bot._authoritative_refresh_plan_surfaces = set(plan)
     return plan
 

--- a/src/live/state_refresh.py
+++ b/src/live/state_refresh.py
@@ -218,6 +218,15 @@ def authoritative_staged_refresh_plan(bot) -> set[str]:
             logging.debug(
                 "[state] staged fills refresh required: risk lookback coverage unproven"
             )
+        elif should_prefetch_trailing_recovery and (
+            bot._schedule_routine_fill_refresh_prefetch(
+                reason="trailing_recovery"
+            )
+        ):
+            plan.discard("fills")
+            logging.debug(
+                "[state] trailing fill recovery scheduled outside blocking staged refresh"
+            )
         elif not bot._staged_fills_refresh_due():
             plan.discard("fills")
             logging.debug("[state] staged fills refresh deferred until next minute boundary")
@@ -226,8 +235,6 @@ def authoritative_staged_refresh_plan(bot) -> set[str]:
         ):
             plan.discard("fills")
             logging.debug("[state] staged routine fills refresh scheduled in background")
-    if should_prefetch_trailing_recovery and "fills" not in plan:
-        bot._schedule_routine_fill_refresh_prefetch(reason="trailing_recovery")
     bot._authoritative_refresh_plan_surfaces = set(plan)
     return plan
 

--- a/src/live/state_refresh.py
+++ b/src/live/state_refresh.py
@@ -218,8 +218,10 @@ def authoritative_staged_refresh_plan(bot) -> set[str]:
             logging.debug(
                 "[state] staged fills refresh required: risk lookback coverage unproven"
             )
-        elif should_prefetch_trailing_recovery and (
-            bot._schedule_routine_fill_refresh_prefetch(
+        elif (
+            should_prefetch_trailing_recovery
+            and bot._staged_fills_can_prefetch_routine()
+            and bot._schedule_routine_fill_refresh_prefetch(
                 reason="trailing_recovery"
             )
         ):

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -8535,6 +8535,7 @@ class Passivbot:
                         and fill_fetch_generation < int(minimum_fill_generation)
                     ):
                         failed_predicates.append("post_snapshot_fill_refresh_pending")
+                    fill_after_state_matches = True
                     if (
                         current_epoch is not None
                         and current_epoch.startswith("fill:")
@@ -8543,7 +8544,7 @@ class Passivbot:
                             symbol, expected_position_state, anchor
                         )
                     ):
-                        failed_predicates.append("fill_after_state_mismatch")
+                        fill_after_state_matches = False
                     if failed_predicates:
                         position_update_timestamp = self._position_update_timestamp_ms(
                             symbol, pside
@@ -8578,6 +8579,21 @@ class Passivbot:
                         unavailable_psides[symbol].add(pside)
                         last_position_changes.get(symbol, {}).pop(pside, None)
                         continue
+                    if not fill_after_state_matches:
+                        # Fill-event psize/pprice are reconstructed from the
+                        # locally available history and may be inaccurate when
+                        # that history starts mid-position.  A completed
+                        # post-snapshot refresh plus a current fill identity is
+                        # the authoritative proof required by trailing: the
+                        # contract resets extrema after every fill for the
+                        # symbol and position side, irrespective of after-state.
+                        logging.info(
+                            "[trailing] accepted fresh fill identity despite reconstructed "
+                            "after-state mismatch | symbol=%s pside=%s "
+                            "action=use_post_refresh_fill_identity",
+                            self._log_symbol(symbol),
+                            pside,
+                        )
                     pending_fill_confirmations.pop(epoch_key, None)
                     pending_fill_min_generations.pop(epoch_key, None)
                     pending_position_states.pop(epoch_key, None)

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -8297,6 +8297,25 @@ class Passivbot:
                 return update_ts
         return None
 
+    def _position_open_timestamp_from_row(self, position: dict) -> int | None:
+        """Return an explicit exchange-reported position opening time."""
+        open_keys = (
+            "open_time",
+            "openTime",
+            "createdTime",
+            "createTime",
+            "cTime",
+        )
+        candidates = [position.get(key) for key in open_keys]
+        info = position.get("info")
+        if isinstance(info, dict):
+            candidates.extend(info.get(key) for key in open_keys)
+        for candidate in candidates:
+            open_ts = self._parse_position_anchor_timestamp_ms(candidate)
+            if open_ts is not None:
+                return open_ts
+        return None
+
     def _position_anchor_timestamp_ms(self, symbol: str, pside: str) -> int | None:
         position = self.positions.get(symbol, {}).get(pside, {})
         return self._position_anchor_timestamp_from_row(position)
@@ -11569,7 +11588,8 @@ class Passivbot:
             "fill_identity_unchanged",
             "fill_after_state_mismatch",
         }
-        candidates: list[int] = []
+        anchored_candidates: list[int] = []
+        missing_anchor_cohorts: list[tuple[str, str]] = []
         cohorts: list[tuple[str, str]] = []
         for raw_key, detail in diagnostics.items():
             if not isinstance(raw_key, tuple) or len(raw_key) != 2:
@@ -11587,17 +11607,20 @@ class Passivbot:
                 except (TypeError, ValueError, OverflowError):
                     anchor_ts = None
             if anchor_ts is None:
-                continue
-            candidates.append(max(0, int(anchor_ts) - 5 * ONE_MIN_MS))
+                missing_anchor_cohorts.append((symbol, pside))
+            else:
+                anchored_candidates.append(
+                    max(0, int(anchor_ts) - 5 * ONE_MIN_MS)
+                )
             cohorts.append((symbol, pside))
-        if not candidates:
+        if not cohorts:
             return None
 
-        start_ms = min(candidates)
-        # `age_limit` bounds PnL accounting, not current-position
-        # reconciliation. A position may legitimately predate that window.
-        recovery_key = (tuple(sorted(cohorts)), int(start_ms))
         now_ms = utc_ms()
+        recovery_key = (
+            tuple(sorted(cohorts)),
+            tuple(sorted(missing_anchor_cohorts)),
+        )
         state = dict(
             getattr(self, "_trailing_fill_history_recovery_state", {}) or {}
         )
@@ -11611,6 +11634,29 @@ class Passivbot:
             if state.get("key") == recovery_key
             else 1
         )
+        candidates = list(anchored_candidates)
+        if missing_anchor_cohorts:
+            try:
+                history_now_ms = int(self.get_exchange_time())
+            except Exception:
+                history_now_ms = now_ms
+            if age_limit is None:
+                candidates.append(0)
+            else:
+                base_window_ms = max(
+                    24 * 60 * ONE_MIN_MS,
+                    history_now_ms - int(age_limit),
+                )
+                widened_window_ms = base_window_ms * (2**retry_count)
+                candidates.append(
+                    max(0, history_now_ms - widened_window_ms)
+                )
+        if not candidates:
+            return None
+        start_ms = min(candidates)
+        # `age_limit` bounds PnL accounting, not current-position
+        # reconciliation. Timestamp-free positions progressively widen beyond
+        # that window; timestamped positions start before their opening anchor.
         delay_ms = min(
             60 * ONE_MIN_MS,
             5 * ONE_MIN_MS * (2 ** min(retry_count - 1, 4)),
@@ -11620,6 +11666,7 @@ class Passivbot:
             "retry_count": retry_count,
             "last_attempt_ms": now_ms,
             "next_retry_ms": now_ms + delay_ms,
+            "start_ms": start_ms,
         }
         logging.warning(
             "[fills] widening refresh for unresolved position/fill confirmation | "
@@ -14539,6 +14586,9 @@ class Passivbot:
                     "short": {"size": 0.0, "price": 0.0},
                 }
             normalized_position = {"size": psize, "price": pprice}
+            open_ts = self._position_open_timestamp_from_row(elm)
+            if open_ts is not None:
+                normalized_position["openTime"] = open_ts
             anchor_ts = self._position_anchor_timestamp_from_row(elm)
             if anchor_ts is not None:
                 normalized_position["timestamp"] = anchor_ts

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -11595,15 +11595,14 @@ class Passivbot:
         except Exception:
             history_now_ms = now_ms
         day_ms = 24 * 60 * ONE_MIN_MS
-        # Bound recovery to the venue's documented history retention. WEEX
-        # retains at most 365 days; the conservative generic bound matches
-        # Bybit's two-year execution-history retention. Older unresolved
-        # states remain fail-closed.
-        max_window_days = (
-            365
-            if str(getattr(self, "exchange", "")).lower() == "weex"
-            else 730
-        )
+        # Bound recovery to a horizon the connector can actually traverse.
+        # Bybit's sub-seven-day windows fit two years within its 200-request
+        # cap. Classic Bitget and KuCoin need roughly one request per day and
+        # cap pagination at 400 requests, so they (and the conservative
+        # default) stop at one year. Older unresolved states remain
+        # fail-closed.
+        exchange = str(getattr(self, "exchange", "")).lower()
+        max_window_days = 730 if exchange == "bybit" else 365
         max_window_ms = max_window_days * day_ms
         earliest_recovery_ms = max(1, history_now_ms - max_window_ms)
 

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -8301,6 +8301,46 @@ class Passivbot:
         position = self.positions.get(symbol, {}).get(pside, {})
         return self._position_anchor_timestamp_from_row(position)
 
+    def _position_history_anchor_timestamp_ms(
+        self, symbol: str, pside: str
+    ) -> int | None:
+        """Return the earliest exchange position timestamp usable for fill recovery.
+
+        Candle anchoring prefers the latest position update. Fill-history recovery
+        has the opposite requirement: start before the position opened so the
+        reconstructed state includes every entry and reduction still available
+        from the exchange.
+        """
+        position = self.positions.get(symbol, {}).get(pside, {})
+        timestamp_keys = (
+            "open_time",
+            "openTime",
+            "createdTime",
+            "createTime",
+            "cTime",
+            "timestamp",
+            "timestamp_ms",
+            "lastUpdateTimestamp",
+            "updateTime",
+            "updatedTime",
+            "update_time",
+            "updated_at",
+            "uTime",
+        )
+        candidates = [position.get(key) for key in timestamp_keys]
+        info = position.get("info")
+        if isinstance(info, dict):
+            candidates.extend(info.get(key) for key in timestamp_keys)
+        parsed = [
+            timestamp
+            for timestamp in (
+                self._parse_position_anchor_timestamp_ms(candidate)
+                for candidate in candidates
+            )
+            if timestamp is not None
+        ]
+        return min(parsed) if parsed else None
+
     def _position_update_timestamp_ms(self, symbol: str, pside: str) -> int | None:
         position = self.positions.get(symbol, {}).get(pside, {})
         return self._position_update_timestamp_from_row(position)
@@ -8400,31 +8440,11 @@ class Passivbot:
             ):
                 return True
 
-        # A cache whose retained history starts mid-position can carry a
-        # phantom reconstructed psize into every later fill.  The latest fill
-        # itself still proves a flat-to-position transition when its direction,
-        # entire quantity, and price exactly match the authoritative exchange
-        # position.  This narrow proof does not accept partial entries, DCA, or
-        # a mismatched average price.
-        required = ("qty", "price", "side")
-        if not all(field in anchor for field in required):
-            return False
-        fill_side = str(anchor["side"]).lower()
-        opening_side = "buy" if str(pside).lower() == "long" else "sell"
-        if fill_side != opening_side:
-            return False
-        try:
-            anchor_c_mult = abs(float(anchor.get("c_mult", c_mult) or c_mult))
-            opening_qty = abs(float(anchor["qty"])) * anchor_c_mult
-            opening_price = float(anchor["price"])
-        except (TypeError, ValueError, OverflowError):
-            return False
-        return (
-            math.isfinite(opening_qty)
-            and math.isfinite(opening_price)
-            and abs(opening_qty - position_size_in_fill_units) <= qty_tolerance
-            and abs(opening_price - position_price) <= price_tolerance
-        )
+        # Price and quantity alone cannot prove this fill opened the entire
+        # position: unseen reductions can produce the same live size/average.
+        # Keep the cohort pending until refreshed history reconstructs a
+        # matching post-fill state.
+        return False
 
     def _latest_fill_position_change_epochs(self) -> dict[tuple[str, str], str]:
         """Return the newest known fill identity for each symbol and position side."""
@@ -11560,7 +11580,7 @@ class Passivbot:
             if not failed.intersection(recoverable_predicates):
                 continue
             symbol, pside = str(raw_key[0]), str(raw_key[1])
-            anchor_ts = self._position_anchor_timestamp_ms(symbol, pside)
+            anchor_ts = self._position_history_anchor_timestamp_ms(symbol, pside)
             if anchor_ts is None:
                 try:
                     anchor_ts = int(detail.get("fill_timestamp_ms") or 0) or None
@@ -11574,8 +11594,8 @@ class Passivbot:
             return None
 
         start_ms = min(candidates)
-        if age_limit is not None:
-            start_ms = max(int(age_limit), start_ms)
+        # `age_limit` bounds PnL accounting, not current-position
+        # reconciliation. A position may legitimately predate that window.
         recovery_key = (tuple(sorted(cohorts)), int(start_ms))
         now_ms = utc_ms()
         state = dict(

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -8355,29 +8355,31 @@ class Passivbot:
                         event, fallback_occurrence_by_index.get(event_index, 0)
                     ),
                 }
-                for field in ("psize", "pprice"):
+                for field in ("psize", "pprice", "qty", "price", "c_mult"):
                     try:
                         value = float(getattr(event, field))
                     except (AttributeError, TypeError, ValueError, OverflowError):
                         continue
                     if math.isfinite(value):
                         anchor[field] = value
+                side = str(getattr(event, "side", "") or "").lower()
+                if side:
+                    anchor["side"] = side
                 anchors[key] = anchor
         return anchors
 
     def _fill_anchor_matches_position_state(
-        self, symbol: str, state: tuple[float, float], anchor: dict | None
+        self,
+        symbol: str,
+        pside: str,
+        state: tuple[float, float],
+        anchor: dict | None,
     ) -> bool:
         """Whether a fill's recorded after-state matches an exchange position."""
-        if anchor is None or "psize" not in anchor or "pprice" not in anchor:
+        if anchor is None:
             return False
         position_size, position_price = state
-        fill_size = abs(float(anchor["psize"]))
-        fill_price = float(anchor["pprice"])
-        if not all(
-            math.isfinite(value)
-            for value in (position_size, position_price, fill_size, fill_price)
-        ):
+        if not all(math.isfinite(value) for value in (position_size, position_price)):
             return False
         qty_step = abs(float(getattr(self, "qty_steps", {}).get(symbol, 0.0) or 0.0))
         price_step = abs(
@@ -8387,9 +8389,42 @@ class Passivbot:
         position_size_in_fill_units = abs(position_size) * c_mult
         qty_tolerance = max(qty_step * c_mult * 0.5, 1e-12)
         price_tolerance = max(price_step * 0.5, abs(position_price) * 1e-9, 1e-12)
-        return abs(fill_size - position_size_in_fill_units) <= qty_tolerance and abs(
-            fill_price - position_price
-        ) <= price_tolerance
+        if "psize" in anchor and "pprice" in anchor:
+            fill_size = abs(float(anchor["psize"]))
+            fill_price = float(anchor["pprice"])
+            if (
+                math.isfinite(fill_size)
+                and math.isfinite(fill_price)
+                and abs(fill_size - position_size_in_fill_units) <= qty_tolerance
+                and abs(fill_price - position_price) <= price_tolerance
+            ):
+                return True
+
+        # A cache whose retained history starts mid-position can carry a
+        # phantom reconstructed psize into every later fill.  The latest fill
+        # itself still proves a flat-to-position transition when its direction,
+        # entire quantity, and price exactly match the authoritative exchange
+        # position.  This narrow proof does not accept partial entries, DCA, or
+        # a mismatched average price.
+        required = ("qty", "price", "side")
+        if not all(field in anchor for field in required):
+            return False
+        fill_side = str(anchor["side"]).lower()
+        opening_side = "buy" if str(pside).lower() == "long" else "sell"
+        if fill_side != opening_side:
+            return False
+        try:
+            anchor_c_mult = abs(float(anchor.get("c_mult", c_mult) or c_mult))
+            opening_qty = abs(float(anchor["qty"])) * anchor_c_mult
+            opening_price = float(anchor["price"])
+        except (TypeError, ValueError, OverflowError):
+            return False
+        return (
+            math.isfinite(opening_qty)
+            and math.isfinite(opening_price)
+            and abs(opening_qty - position_size_in_fill_units) <= qty_tolerance
+            and abs(opening_price - position_price) <= price_tolerance
+        )
 
     def _latest_fill_position_change_epochs(self) -> dict[tuple[str, str], str]:
         """Return the newest known fill identity for each symbol and position side."""
@@ -8569,7 +8604,7 @@ class Passivbot:
                         and current_epoch.startswith("fill:")
                         and expected_position_state is not None
                         and not self._fill_anchor_matches_position_state(
-                            symbol, expected_position_state, anchor
+                            symbol, pside, expected_position_state, anchor
                         )
                     ):
                         fill_after_state_matches = False
@@ -8641,6 +8676,8 @@ class Passivbot:
         self._trailing_pending_position_states = pending_position_states
         self._trailing_position_snapshot_fill_epochs = associated_fill_epochs
         self._trailing_fill_confirmation_diagnostics = confirmation_diagnostics
+        if not confirmation_diagnostics:
+            self._trailing_fill_history_recovery_state = {}
 
         # Build concurrent fetches per symbol that has position changes
         fetch_plan = {}
@@ -11508,6 +11545,89 @@ class Passivbot:
                 since_ms=since_ms,
             )
 
+    def _trailing_fill_history_recovery_start_ms(
+        self, age_limit: int | None
+    ) -> int | None:
+        """Return a bounded refetch start for unresolved position/fill state.
+
+        Routine confirmation refreshes intentionally cover only recent fills.
+        If that leaves a position tied to a stale or mismatched fill, retry from
+        the exchange-reported position anchor (or the stale fill itself) with
+        an in-memory exponential backoff.  The affected position remains
+        nontradable until normal confirmation succeeds.
+        """
+        diagnostics = dict(
+            getattr(self, "_trailing_fill_confirmation_diagnostics", {}) or {}
+        )
+        recoverable_predicates = {
+            "missing_fill_anchor",
+            "non_fill_anchor",
+            "fill_identity_unchanged",
+            "fill_after_state_mismatch",
+        }
+        candidates: list[int] = []
+        cohorts: list[tuple[str, str]] = []
+        for raw_key, detail in diagnostics.items():
+            if not isinstance(raw_key, tuple) or len(raw_key) != 2:
+                continue
+            if not isinstance(detail, dict):
+                continue
+            failed = set(detail.get("failed_predicates") or [])
+            if not failed.intersection(recoverable_predicates):
+                continue
+            symbol, pside = str(raw_key[0]), str(raw_key[1])
+            anchor_ts = self._position_anchor_timestamp_ms(symbol, pside)
+            if anchor_ts is None:
+                try:
+                    anchor_ts = int(detail.get("fill_timestamp_ms") or 0) or None
+                except (TypeError, ValueError, OverflowError):
+                    anchor_ts = None
+            if anchor_ts is None:
+                continue
+            candidates.append(max(0, int(anchor_ts) - 5 * ONE_MIN_MS))
+            cohorts.append((symbol, pside))
+        if not candidates:
+            return None
+
+        start_ms = min(candidates)
+        if age_limit is not None:
+            start_ms = max(int(age_limit), start_ms)
+        recovery_key = (tuple(sorted(cohorts)), int(start_ms))
+        now_ms = utc_ms()
+        state = dict(
+            getattr(self, "_trailing_fill_history_recovery_state", {}) or {}
+        )
+        if state.get("key") == recovery_key and now_ms < int(
+            state.get("next_retry_ms", 0) or 0
+        ):
+            return None
+
+        retry_count = (
+            int(state.get("retry_count", 0) or 0) + 1
+            if state.get("key") == recovery_key
+            else 1
+        )
+        delay_ms = min(
+            60 * ONE_MIN_MS,
+            5 * ONE_MIN_MS * (2 ** min(retry_count - 1, 4)),
+        )
+        self._trailing_fill_history_recovery_state = {
+            "key": recovery_key,
+            "retry_count": retry_count,
+            "last_attempt_ms": now_ms,
+            "next_retry_ms": now_ms + delay_ms,
+        }
+        logging.warning(
+            "[fills] widening refresh for unresolved position/fill confirmation | "
+            "cohorts=%s start=%s retry=%d next_retry_minutes=%.1f "
+            "action=refetch_then_keep_nontradable_until_confirmed",
+            ",".join(f"{symbol}:{pside}" for symbol, pside in sorted(cohorts)),
+            ts_to_date(start_ms)[:19],
+            retry_count,
+            delay_ms / ONE_MIN_MS,
+        )
+        return start_ms
+
     async def _update_pnls_locked(
         self,
         *,
@@ -11696,6 +11816,11 @@ class Passivbot:
                         end_ms=None,
                     )
                 else:
+                    recovery_start_ms = (
+                        self._trailing_fill_history_recovery_start_ms(age_limit)
+                        if confirmation_refresh
+                        else None
+                    )
                     overlap_minutes_key = (
                         "fills_confirmation_overlap_minutes"
                         if confirmation_refresh
@@ -11709,10 +11834,17 @@ class Passivbot:
                         )
                     )
                     overlap_minutes = max(0.0, overlap_minutes)
-                    await self._pnls_manager.refresh_latest(
-                        overlap=20,
-                        last_refresh_overlap_ms=int(overlap_minutes * 60 * 1000),
-                    )
+                    if recovery_start_ms is not None:
+                        refresh_mode = "trailing_confirmation_recovery"
+                        await self._pnls_manager.refresh(
+                            start_ms=int(recovery_start_ms),
+                            end_ms=None,
+                        )
+                    else:
+                        await self._pnls_manager.refresh_latest(
+                            overlap=20,
+                            last_refresh_overlap_ms=int(overlap_minutes * 60 * 1000),
+                        )
                 fill_fetch_completed = True
 
             # Find and log new events (those not in cache before refresh)
@@ -11789,7 +11921,13 @@ class Passivbot:
                 )
             elapsed_ms = int(max(0, utc_ms() - refresh_started_ms))
             blocking_or_confirmation_refresh = (
-                refresh_mode in {"full", "lookback_bootstrap", "incremental_confirm"}
+                refresh_mode
+                in {
+                    "full",
+                    "lookback_bootstrap",
+                    "incremental_confirm",
+                    "trailing_confirmation_recovery",
+                }
                 or "confirm" in str(source)
                 or "staged" in str(source)
             )

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -11593,11 +11593,16 @@ class Passivbot:
         except Exception:
             history_now_ms = now_ms
         day_ms = 24 * 60 * ONE_MIN_MS
-        # Use a conservative two-year live recovery horizon. This matches
-        # Bybit's documented execution-history retention and prevents an
-        # update-only position from requesting an impossible epoch-to-now
-        # pagination walk. Older unresolved states remain fail-closed.
-        max_window_ms = 730 * day_ms
+        # Bound recovery to the venue's documented history retention. WEEX
+        # retains at most 365 days; the conservative generic bound matches
+        # Bybit's two-year execution-history retention. Older unresolved
+        # states remain fail-closed.
+        max_window_days = (
+            365
+            if str(getattr(self, "exchange", "")).lower() == "weex"
+            else 730
+        )
+        max_window_ms = max_window_days * day_ms
         earliest_recovery_ms = max(1, history_now_ms - max_window_ms)
 
         previous_state = dict(
@@ -11952,9 +11957,13 @@ class Passivbot:
                         end_ms=None,
                     )
                 else:
+                    # Mandatory account-wide confirmations must stay on the
+                    # bounded recent path. Potentially expensive history
+                    # widening is reserved for the nonblocking trailing
+                    # recovery prefetch.
                     recovery_start_ms = (
                         self._trailing_fill_history_recovery_start_ms(age_limit)
-                        if confirmation_refresh or trailing_recovery_refresh
+                        if trailing_recovery_refresh
                         else None
                     )
                     overlap_minutes_key = (

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -8698,13 +8698,7 @@ class Passivbot:
         self._trailing_pending_position_states = pending_position_states
         self._trailing_position_snapshot_fill_epochs = associated_fill_epochs
         self._trailing_fill_confirmation_diagnostics = confirmation_diagnostics
-        if confirmation_diagnostics:
-            # A successful fetch may have cleared the account-wide barrier even
-            # though this position still lacks matching fill evidence. Keep
-            # requesting post-snapshot fill refreshes so timestamp-free recovery
-            # can advance through its progressively wider windows.
-            self._request_authoritative_confirmation({"fills"})
-        else:
+        if not confirmation_diagnostics:
             self._trailing_fill_history_recovery_state = {}
 
         # Build concurrent fetches per symbol that has position changes
@@ -11726,6 +11720,46 @@ class Passivbot:
         )
         return start_ms
 
+    def _trailing_fill_recovery_prefetch_due(self) -> bool:
+        """Whether unresolved trailing evidence needs a nonblocking fill prefetch."""
+        if "fills" in (
+            getattr(self, "_authoritative_pending_confirmations", {}) or {}
+        ):
+            return False
+        diagnostics = dict(
+            getattr(self, "_trailing_fill_confirmation_diagnostics", {}) or {}
+        )
+        recoverable_predicates = {
+            "missing_fill_anchor",
+            "non_fill_anchor",
+            "fill_identity_unchanged",
+            "fill_after_state_mismatch",
+        }
+        cohort_states = dict(
+            (
+                getattr(self, "_trailing_fill_history_recovery_state", {}) or {}
+            ).get("cohorts", {})
+            or {}
+        )
+        now_ms = utc_ms()
+        for raw_key, detail in diagnostics.items():
+            if not isinstance(raw_key, tuple) or len(raw_key) != 2:
+                continue
+            if not isinstance(detail, dict):
+                continue
+            failed = set(detail.get("failed_predicates") or [])
+            if not failed.intersection(recoverable_predicates):
+                continue
+            if "post_snapshot_fill_refresh_pending" in failed:
+                # The position snapshot itself arms the authoritative fills
+                # confirmation; do not race it with a background recovery.
+                continue
+            cohort = (str(raw_key[0]), str(raw_key[1]))
+            state = dict(cohort_states.get(cohort, {}) or {})
+            if now_ms >= int(state.get("next_retry_ms", 0) or 0):
+                return True
+        return False
+
     async def _update_pnls_locked(
         self,
         *,
@@ -11902,6 +11936,10 @@ class Passivbot:
                     getattr(self, "_authoritative_pending_confirmations", {}) or {}
                 )
                 confirmation_refresh = "fills" in pending
+                trailing_recovery_refresh = bool(
+                    getattr(self, "_trailing_fill_confirmation_diagnostics", {})
+                    or {}
+                )
                 refresh_mode = (
                     "incremental_confirm"
                     if confirmation_refresh
@@ -11916,7 +11954,7 @@ class Passivbot:
                 else:
                     recovery_start_ms = (
                         self._trailing_fill_history_recovery_start_ms(age_limit)
-                        if confirmation_refresh
+                        if confirmation_refresh or trailing_recovery_refresh
                         else None
                     )
                     overlap_minutes_key = (

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -8699,7 +8699,13 @@ class Passivbot:
         self._trailing_pending_position_states = pending_position_states
         self._trailing_position_snapshot_fill_epochs = associated_fill_epochs
         self._trailing_fill_confirmation_diagnostics = confirmation_diagnostics
-        if not confirmation_diagnostics:
+        if confirmation_diagnostics:
+            # A successful fetch may have cleared the account-wide barrier even
+            # though this position still lacks matching fill evidence. Keep
+            # requesting post-snapshot fill refreshes so timestamp-free recovery
+            # can advance through its progressively wider windows.
+            self._request_authoritative_confirmation({"fills"})
+        else:
             self._trailing_fill_history_recovery_state = {}
 
         # Build concurrent fetches per symbol that has position changes

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -8323,33 +8323,25 @@ class Passivbot:
     def _position_history_anchor_timestamp_ms(
         self, symbol: str, pside: str
     ) -> int | None:
-        """Return the earliest exchange position timestamp usable for fill recovery.
+        """Return an exchange position-opening timestamp usable for fill recovery.
 
         Candle anchoring prefers the latest position update. Fill-history recovery
         has the opposite requirement: start before the position opened so the
         reconstructed state includes every entry and reduction still available
-        from the exchange.
+        from the exchange. An update-only timestamp is not an opening boundary;
+        callers must progressively widen history when no open/generic timestamp
+        is available.
         """
         position = self.positions.get(symbol, {}).get(pside, {})
-        timestamp_keys = (
-            "open_time",
-            "openTime",
-            "createdTime",
-            "createTime",
-            "cTime",
-            "timestamp",
-            "timestamp_ms",
-            "lastUpdateTimestamp",
-            "updateTime",
-            "updatedTime",
-            "update_time",
-            "updated_at",
-            "uTime",
-        )
-        candidates = [position.get(key) for key in timestamp_keys]
+        open_ts = self._position_open_timestamp_from_row(position)
+        if open_ts is not None:
+            return open_ts
+
+        generic_keys = ("timestamp", "timestamp_ms")
+        candidates = [position.get(key) for key in generic_keys]
         info = position.get("info")
         if isinstance(info, dict):
-            candidates.extend(info.get(key) for key in timestamp_keys)
+            candidates.extend(info.get(key) for key in generic_keys)
         parsed = [
             timestamp
             for timestamp in (
@@ -8358,6 +8350,13 @@ class Passivbot:
             )
             if timestamp is not None
         ]
+        update_ts = self._position_update_timestamp_from_row(position)
+        if update_ts is not None:
+            # Snapshot normalization stores its latest anchor in ``timestamp``.
+            # When that value is only a copy of the update time, it does not
+            # establish where the position opened. A genuinely earlier generic
+            # timestamp remains useful when an exchange exposes both.
+            parsed = [timestamp for timestamp in parsed if timestamp < update_ts]
         return min(parsed) if parsed else None
 
     def _position_update_timestamp_ms(self, symbol: str, pside: str) -> int | None:
@@ -11609,14 +11608,19 @@ class Passivbot:
             anchor_ts = self._position_history_anchor_timestamp_ms(symbol, pside)
             if anchor_ts is None:
                 try:
-                    anchor_ts = int(detail.get("fill_timestamp_ms") or 0) or None
+                    diagnostic_fill_ts = (
+                        int(detail.get("fill_timestamp_ms") or 0) or None
+                    )
                 except (TypeError, ValueError, OverflowError):
-                    anchor_ts = None
-            if anchor_ts is None:
+                    diagnostic_fill_ts = None
                 missing_anchor_cohorts.append((symbol, pside))
+                if diagnostic_fill_ts is not None:
+                    anchored_candidates.append(
+                        max(1, int(diagnostic_fill_ts) - 5 * ONE_MIN_MS)
+                    )
             else:
                 anchored_candidates.append(
-                    max(0, int(anchor_ts) - 5 * ONE_MIN_MS)
+                    max(1, int(anchor_ts) - 5 * ONE_MIN_MS)
                 )
             cohorts.append((symbol, pside))
         if not cohorts:
@@ -11647,7 +11651,10 @@ class Passivbot:
             except Exception:
                 history_now_ms = now_ms
             if age_limit is None:
-                candidates.append(0)
+                # Several exchange fetchers use falsey zero to mean "no start"
+                # and replace it with a short default window. One millisecond
+                # after the Unix epoch is an explicit, portable all-history bound.
+                candidates.append(1)
             else:
                 base_window_ms = max(
                     24 * 60 * ONE_MIN_MS,
@@ -11655,7 +11662,7 @@ class Passivbot:
                 )
                 widened_window_ms = base_window_ms * (2**retry_count)
                 candidates.append(
-                    max(0, history_now_ms - widened_window_ms)
+                    max(1, history_now_ms - widened_window_ms)
                 )
         if not candidates:
             return None

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -8598,7 +8598,6 @@ class Passivbot:
                         and fill_fetch_generation < int(minimum_fill_generation)
                     ):
                         failed_predicates.append("post_snapshot_fill_refresh_pending")
-                    fill_after_state_matches = True
                     if (
                         current_epoch is not None
                         and current_epoch.startswith("fill:")
@@ -8607,7 +8606,7 @@ class Passivbot:
                             symbol, pside, expected_position_state, anchor
                         )
                     ):
-                        fill_after_state_matches = False
+                        failed_predicates.append("fill_after_state_mismatch")
                     if failed_predicates:
                         position_update_timestamp = self._position_update_timestamp_ms(
                             symbol, pside
@@ -8642,21 +8641,6 @@ class Passivbot:
                         unavailable_psides[symbol].add(pside)
                         last_position_changes.get(symbol, {}).pop(pside, None)
                         continue
-                    if not fill_after_state_matches:
-                        # Fill-event psize/pprice are reconstructed from the
-                        # locally available history and may be inaccurate when
-                        # that history starts mid-position.  A completed
-                        # post-snapshot refresh plus a current fill identity is
-                        # the authoritative proof required by trailing: the
-                        # contract resets extrema after every fill for the
-                        # symbol and position side, irrespective of after-state.
-                        logging.info(
-                            "[trailing] accepted fresh fill identity despite reconstructed "
-                            "after-state mismatch | symbol=%s pside=%s "
-                            "action=use_post_refresh_fill_identity",
-                            self._log_symbol(symbol),
-                            pside,
-                        )
                     pending_fill_confirmations.pop(epoch_key, None)
                     pending_fill_min_generations.pop(epoch_key, None)
                     pending_position_states.pop(epoch_key, None)

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -11939,7 +11939,7 @@ class Passivbot:
                 trailing_recovery_refresh = bool(
                     getattr(self, "_trailing_fill_confirmation_diagnostics", {})
                     or {}
-                )
+                ) and source == "routine_prefetch:trailing_recovery"
                 refresh_mode = (
                     "incremental_confirm"
                     if confirmation_refresh

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -11593,9 +11593,26 @@ class Passivbot:
             "fill_identity_unchanged",
             "fill_after_state_mismatch",
         }
-        anchored_candidates: list[int] = []
-        missing_anchor_cohorts: list[tuple[str, str]] = []
-        cohorts: list[tuple[str, str]] = []
+        now_ms = utc_ms()
+        try:
+            history_now_ms = int(self.get_exchange_time())
+        except Exception:
+            history_now_ms = now_ms
+        day_ms = 24 * 60 * ONE_MIN_MS
+        # Use a conservative two-year live recovery horizon. This matches
+        # Bybit's documented execution-history retention and prevents an
+        # update-only position from requesting an impossible epoch-to-now
+        # pagination walk. Older unresolved states remain fail-closed.
+        max_window_ms = 730 * day_ms
+        earliest_recovery_ms = max(1, history_now_ms - max_window_ms)
+
+        previous_state = dict(
+            getattr(self, "_trailing_fill_history_recovery_state", {}) or {}
+        )
+        previous_cohort_states = dict(previous_state.get("cohorts", {}) or {})
+        cohort_states: dict[tuple[str, str], dict] = {}
+        attempted_cohorts: list[tuple[str, str]] = []
+        candidates: list[int] = []
         for raw_key, detail in diagnostics.items():
             if not isinstance(raw_key, tuple) or len(raw_key) != 2:
                 continue
@@ -11605,7 +11622,20 @@ class Passivbot:
             if not failed.intersection(recoverable_predicates):
                 continue
             symbol, pside = str(raw_key[0]), str(raw_key[1])
+            cohort = (symbol, pside)
+            cohort_state = dict(previous_cohort_states.get(cohort, {}) or {})
+            cohort_states[cohort] = cohort_state
+            # First satisfy the mandatory fetch generation after the position
+            # snapshot. Widen only if that recent confirmation completes and
+            # the reconstructed after-state still mismatches.
+            if "post_snapshot_fill_refresh_pending" in failed:
+                continue
+            if now_ms < int(cohort_state.get("next_retry_ms", 0) or 0):
+                continue
+
+            retry_count = int(cohort_state.get("retry_count", 0) or 0) + 1
             anchor_ts = self._position_history_anchor_timestamp_ms(symbol, pside)
+            missing_anchor = anchor_ts is None
             if anchor_ts is None:
                 try:
                     diagnostic_fill_ts = (
@@ -11613,82 +11643,86 @@ class Passivbot:
                     )
                 except (TypeError, ValueError, OverflowError):
                     diagnostic_fill_ts = None
-                missing_anchor_cohorts.append((symbol, pside))
+                base_window_ms = (
+                    max(day_ms, history_now_ms - int(age_limit))
+                    if age_limit is not None
+                    else 30 * day_ms
+                )
+                widened_window_ms = min(
+                    max_window_ms,
+                    base_window_ms * (2 ** min(retry_count, 10)),
+                )
+                candidate = max(
+                    earliest_recovery_ms,
+                    history_now_ms - widened_window_ms,
+                )
                 if diagnostic_fill_ts is not None:
-                    anchored_candidates.append(
-                        max(1, int(diagnostic_fill_ts) - 5 * ONE_MIN_MS)
+                    candidate = min(
+                        candidate,
+                        max(
+                            earliest_recovery_ms,
+                            int(diagnostic_fill_ts) - 5 * ONE_MIN_MS,
+                        ),
                     )
             else:
-                anchored_candidates.append(
-                    max(1, int(anchor_ts) - 5 * ONE_MIN_MS)
+                candidate = max(
+                    earliest_recovery_ms,
+                    int(anchor_ts) - 5 * ONE_MIN_MS,
                 )
-            cohorts.append((symbol, pside))
-        if not cohorts:
-            return None
-
-        now_ms = utc_ms()
-        recovery_key = (
-            tuple(sorted(cohorts)),
-            tuple(sorted(missing_anchor_cohorts)),
-        )
-        state = dict(
-            getattr(self, "_trailing_fill_history_recovery_state", {}) or {}
-        )
-        if state.get("key") == recovery_key and now_ms < int(
-            state.get("next_retry_ms", 0) or 0
-        ):
-            return None
-
-        retry_count = (
-            int(state.get("retry_count", 0) or 0) + 1
-            if state.get("key") == recovery_key
-            else 1
-        )
-        candidates = list(anchored_candidates)
-        if missing_anchor_cohorts:
-            try:
-                history_now_ms = int(self.get_exchange_time())
-            except Exception:
-                history_now_ms = now_ms
-            if age_limit is None:
-                # Several exchange fetchers use falsey zero to mean "no start"
-                # and replace it with a short default window. One millisecond
-                # after the Unix epoch is an explicit, portable all-history bound.
-                candidates.append(1)
+            at_history_bound = candidate <= earliest_recovery_ms
+            if at_history_bound:
+                delay_ms = 24 * 60 * ONE_MIN_MS
             else:
-                base_window_ms = max(
-                    24 * 60 * ONE_MIN_MS,
-                    history_now_ms - int(age_limit),
+                delay_ms = min(
+                    60 * ONE_MIN_MS,
+                    5 * ONE_MIN_MS * (2 ** min(retry_count - 1, 4)),
                 )
-                widened_window_ms = base_window_ms * (2**retry_count)
-                candidates.append(
-                    max(1, history_now_ms - widened_window_ms)
-                )
+            cohort_states[cohort] = {
+                "retry_count": retry_count,
+                "last_attempt_ms": now_ms,
+                "next_retry_ms": now_ms + delay_ms,
+                "start_ms": candidate,
+                "missing_anchor": missing_anchor,
+                "at_history_bound": at_history_bound,
+            }
+            candidates.append(candidate)
+            attempted_cohorts.append(cohort)
+
         if not candidates:
+            self._trailing_fill_history_recovery_state = (
+                {"cohorts": cohort_states} if cohort_states else {}
+            )
             return None
         start_ms = min(candidates)
         # `age_limit` bounds PnL accounting, not current-position
         # reconciliation. Timestamp-free positions progressively widen beyond
-        # that window; timestamped positions start before their opening anchor.
-        delay_ms = min(
-            60 * ONE_MIN_MS,
-            5 * ONE_MIN_MS * (2 ** min(retry_count - 1, 4)),
+        # that window up to the venue-history bound; timestamped positions start
+        # before their opening anchor when it remains within that bound.
+        next_retry_ms = min(
+            int(cohort_states[cohort]["next_retry_ms"])
+            for cohort in attempted_cohorts
+        )
+        retry_count = max(
+            int(cohort_states[cohort]["retry_count"])
+            for cohort in attempted_cohorts
         )
         self._trailing_fill_history_recovery_state = {
-            "key": recovery_key,
+            "cohorts": cohort_states,
             "retry_count": retry_count,
             "last_attempt_ms": now_ms,
-            "next_retry_ms": now_ms + delay_ms,
+            "next_retry_ms": next_retry_ms,
             "start_ms": start_ms,
         }
         logging.warning(
             "[fills] widening refresh for unresolved position/fill confirmation | "
             "cohorts=%s start=%s retry=%d next_retry_minutes=%.1f "
             "action=refetch_then_keep_nontradable_until_confirmed",
-            ",".join(f"{symbol}:{pside}" for symbol, pside in sorted(cohorts)),
+            ",".join(
+                f"{symbol}:{pside}" for symbol, pside in sorted(attempted_cohorts)
+            ),
             ts_to_date(start_ms)[:19],
             retry_count,
-            delay_ms / ONE_MIN_MS,
+            max(0, next_retry_ms - now_ms) / ONE_MIN_MS,
         )
         return start_ms
 

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -13,6 +13,7 @@ import traceback
 import argparse
 import asyncio
 import json
+import hashlib
 import sys
 import signal
 import hjson
@@ -8305,13 +8306,28 @@ class Passivbot:
         return self._position_update_timestamp_from_row(position)
 
     @staticmethod
-    def _fill_position_change_epoch(event, event_index: int) -> str:
-        timestamp = int(event.timestamp)
-        event_id = getattr(event, "id", None) or getattr(
-            event, "client_order_id", None
+    def _fill_position_change_fallback_key(event) -> str:
+        """Return an immutable content key for a fill without exchange identity."""
+        fields = (
+            int(event.timestamp),
+            str(getattr(event, "symbol", "") or ""),
+            str(getattr(event, "position_side", "") or ""),
+            str(getattr(event, "side", "") or ""),
+            str(getattr(event, "qty", "") or ""),
+            str(getattr(event, "price", "") or ""),
         )
+        payload = json.dumps(fields, ensure_ascii=True, separators=(",", ":"))
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:20]
+
+    @classmethod
+    def _fill_position_change_epoch(
+        cls, event, fallback_occurrence: int = 0
+    ) -> str:
+        timestamp = int(event.timestamp)
+        event_id = str(getattr(event, "id", "") or "")
         if not event_id:
-            event_id = f"event_index:{event_index}"
+            fallback_key = cls._fill_position_change_fallback_key(event)
+            event_id = f"fingerprint:{fallback_key}:{int(fallback_occurrence)}"
         return f"fill:{timestamp}:{event_id}"
 
     def _latest_fill_position_change_anchors(self) -> dict[tuple[str, str], dict]:
@@ -8319,13 +8335,25 @@ class Passivbot:
         manager = getattr(self, "_pnls_manager", None)
         events = [] if manager is None else manager.get_events()
         anchors: dict[tuple[str, str], dict] = {}
+        fallback_occurrences: dict[str, int] = defaultdict(int)
+        fallback_occurrence_by_index: dict[int, int] = {}
+        for event_index, event in enumerate(events):
+            if getattr(event, "id", None):
+                continue
+            fallback_key = self._fill_position_change_fallback_key(event)
+            fallback_occurrence_by_index[event_index] = fallback_occurrences[
+                fallback_key
+            ]
+            fallback_occurrences[fallback_key] += 1
         for event_index in range(len(events) - 1, -1, -1):
             event = events[event_index]
             key = (str(event.symbol), str(event.position_side))
             if key not in anchors:
                 anchor = {
                     "timestamp": int(event.timestamp),
-                    "epoch": self._fill_position_change_epoch(event, event_index),
+                    "epoch": self._fill_position_change_epoch(
+                        event, fallback_occurrence_by_index.get(event_index, 0)
+                    ),
                 }
                 for field in ("psize", "pprice"):
                     try:

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -2950,6 +2950,36 @@ async def test_bybit_fetcher_merges_pnl_and_batches(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_bybit_trade_fetch_traverses_empty_recent_windows():
+    day_ms = 24 * 60 * 60 * 1000
+    end_ms = 2_000_000_000_000
+    start_ms = end_ms - 14 * day_ms
+    older_trade = {
+        "id": "old-sparse",
+        "timestamp": start_ms + 2 * day_ms,
+        "amount": 0.1,
+        "price": 100.0,
+        "side": "buy",
+        "symbol": "BTC/USDT",
+        "info": {},
+    }
+    api = _FakeBybitAPI(
+        trades_batches=[[], [older_trade], []],
+        positions_batches=[],
+    )
+    fetcher = BybitFetcher(api, max_span_days=6.5)
+
+    trades = await fetcher._fetch_my_trades(start_ms, end_ms)
+
+    assert [trade["id"] for trade in trades] == ["old-sparse"]
+    assert len(api.trade_calls) == 3
+    assert api.trade_calls[1]["endTime"] == end_ms - fetcher._max_span_ms
+    assert api.trade_calls[2]["endTime"] == (
+        end_ms - 2 * fetcher._max_span_ms
+    )
+
+
+@pytest.mark.asyncio
 async def test_bybit_closed_pnl_uses_contiguous_cursor_paginated_windows():
     day_ms = 24 * 60 * 60 * 1000
     end_ms = 2_000_000_000_000

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -4825,6 +4825,39 @@ async def test_manager_refresh_records_successful_empty_refresh(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_manager_cache_load_does_not_advance_last_exchange_refresh(
+    tmp_path: Path, sample_events
+):
+    cache_dir = tmp_path / "fills_local_load_preserves_refresh"
+    cached = [FillEvent.from_dict(dict(event)) for event in sample_events]
+    cache = FillEventCache(cache_dir)
+    cache.save(cached)
+    previous_refresh_ms = sample_events[-1]["timestamp"] + 60_000
+    cache.save_metadata(
+        {
+            "last_refresh_ms": previous_refresh_ms,
+            "oldest_event_ts": sample_events[0]["timestamp"],
+            "newest_event_ts": sample_events[-1]["timestamp"],
+            "covered_start_ms": sample_events[0]["timestamp"],
+            "known_gaps": [],
+            "history_scope": "window",
+            "pnl_contract": fem.PNL_CONTRACT_CURRENT,
+        }
+    )
+    fetcher = _StaticFetcher([])
+    manager = FillEventsManager(
+        exchange="bitget",
+        user="default",
+        fetcher=fetcher,
+        cache_path=cache_dir,
+    )
+
+    await manager.ensure_loaded()
+
+    assert manager.cache.load_metadata()["last_refresh_ms"] == previous_refresh_ms
+
+
+@pytest.mark.asyncio
 async def test_manager_refresh_logs_slow_successful_fetcher_request_timing_at_debug(
     tmp_path: Path, caplog, monkeypatch
 ):

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -6435,6 +6435,84 @@ async def test_update_pnls_widens_refresh_for_mismatched_trailing_fill_anchor(
 
 
 @pytest.mark.asyncio
+async def test_mandatory_fill_confirmation_does_not_widen_trailing_recovery(
+    monkeypatch,
+):
+    bot = Passivbot.__new__(Passivbot)
+    now_ms = 1_800_000_000_000
+    position_anchor_ms = now_ms - 180 * 24 * 60 * 60 * 1000
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: now_ms)
+    symbol = "WLD/USDT:USDT"
+    cached_events = [
+        SimpleNamespace(
+            timestamp=position_anchor_ms,
+            id="stale-fill",
+            source_ids=["stale-fill"],
+        )
+    ]
+
+    class _Manager:
+        def __init__(self):
+            self._events = list(cached_events)
+            self.refresh = AsyncMock()
+            self.refresh_latest = AsyncMock()
+
+        def get_events(self):
+            return list(self._events)
+
+        def get_history_scope(self):
+            return "all"
+
+        def set_history_scope(self, scope):
+            pass
+
+    bot.stop_signal_received = False
+    bot.config = {
+        "live": {
+            "fills_confirmation_overlap_minutes": 60.0,
+            "fills_recent_overlap_minutes": 10.0,
+            "pnls_max_lookback_days": "all",
+        }
+    }
+    bot.positions = {
+        symbol: {
+            "long": {
+                "size": 1.0,
+                "price": 100.0,
+                "timestamp": position_anchor_ms,
+            }
+        }
+    }
+    bot.exchange = "weex"
+    bot._trailing_fill_confirmation_diagnostics = {
+        (symbol, "long"): {
+            "failed_predicates": ["fill_after_state_mismatch"],
+            "fill_timestamp_ms": position_anchor_ms,
+        }
+    }
+    bot._authoritative_pending_confirmations = {"fills": 2}
+    bot._pnls_manager = _Manager()
+    bot.init_pnls = AsyncMock()
+    bot.live_value = lambda key: bot.config["live"][key]
+    bot.get_exchange_time = lambda: now_ms
+    bot._log_new_fill_events = lambda new_events: None
+    bot._monitor_record_event = lambda *args, **kwargs: None
+    bot._monitor_record_error = lambda *args, **kwargs: None
+    bot.logging_level = 0
+    bot._health_rate_limits = 0
+
+    result = await bot.update_pnls(source="staged_refresh:fills_confirmation")
+
+    assert result is True
+    bot._pnls_manager.refresh.assert_not_awaited()
+    bot._pnls_manager.refresh_latest.assert_awaited_once_with(
+        overlap=20,
+        last_refresh_overlap_ms=60 * 60 * 1000,
+    )
+    assert getattr(bot, "_trailing_fill_history_recovery_state", {}) == {}
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("shutdown_requested", [False, True])
 async def test_update_pnls_propagates_unexpected_refresh_errors_without_retaining_text(
     caplog, capsys, shutdown_requested

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -9009,6 +9009,29 @@ def test_staged_refresh_plan_schedules_trailing_recovery_without_barrier(
     assert bot._authoritative_pending_confirmations == {}
 
 
+def test_staged_refresh_plan_keeps_stale_fills_during_trailing_recovery(
+    monkeypatch,
+):
+    bot = Passivbot.__new__(Passivbot)
+    bot.freshness_ledger = FreshnessLedger(now_ms=0)
+    bot._authoritative_pending_confirmations = {}
+    bot._pnl_history_coverage_ready_for_risk = lambda: True
+    bot._trailing_fill_recovery_prefetch_due = lambda: True
+    scheduled = []
+    bot._schedule_routine_fill_refresh_prefetch = (
+        lambda *, reason: scheduled.append(reason) or True
+    )
+    bot.freshness_ledger.stamp(
+        "fills", ("fills", "stale"), now_ms=120_010, epoch=1
+    )
+
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: 360_500)
+    plan = bot._authoritative_staged_refresh_plan()
+
+    assert scheduled == []
+    assert plan == {"balance", "positions", "open_orders", "fills"}
+
+
 def test_staged_refresh_plan_keeps_fills_when_risk_coverage_unproven(monkeypatch):
     bot = Passivbot.__new__(Passivbot)
     bot.freshness_ledger = FreshnessLedger(now_ms=0)

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -8905,6 +8905,30 @@ def test_staged_refresh_plan_defers_fills_until_next_minute(monkeypatch):
     assert plan == {"balance", "positions", "open_orders", "fills"}
 
 
+def test_staged_refresh_plan_schedules_trailing_recovery_without_barrier(
+    monkeypatch,
+):
+    bot = Passivbot.__new__(Passivbot)
+    bot.freshness_ledger = FreshnessLedger(now_ms=0)
+    bot._authoritative_pending_confirmations = {}
+    bot._pnl_history_coverage_ready_for_risk = lambda: True
+    bot._trailing_fill_recovery_prefetch_due = lambda: True
+    scheduled = []
+    bot._schedule_routine_fill_refresh_prefetch = (
+        lambda *, reason: scheduled.append(reason) or True
+    )
+    bot.freshness_ledger.stamp(
+        "fills", ("fills", "fresh"), now_ms=120_010, epoch=1
+    )
+
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: 120_500)
+    plan = bot._authoritative_staged_refresh_plan()
+
+    assert scheduled == ["trailing_recovery"]
+    assert plan == {"balance", "positions", "open_orders"}
+    assert bot._authoritative_pending_confirmations == {}
+
+
 def test_staged_refresh_plan_keeps_fills_when_risk_coverage_unproven(monkeypatch):
     bot = Passivbot.__new__(Passivbot)
     bot.freshness_ledger = FreshnessLedger(now_ms=0)

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -6354,6 +6354,85 @@ async def test_update_pnls_uses_confirmation_overlap_when_fills_pending():
 
 
 @pytest.mark.asyncio
+async def test_update_pnls_widens_refresh_for_mismatched_trailing_fill_anchor(
+    monkeypatch,
+):
+    bot = Passivbot.__new__(Passivbot)
+    now_ms = 1_800_000_000_000
+    position_anchor_ms = now_ms - 2 * 60 * 60 * 1000
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: now_ms)
+    symbol = "WLD/USDT:USDT"
+    cached_events = [
+        SimpleNamespace(
+            timestamp=position_anchor_ms - 24 * 60 * 60 * 1000,
+            id="stale-close",
+            source_ids=["stale-close"],
+        )
+    ]
+
+    class _Manager:
+        def __init__(self):
+            self._events = list(cached_events)
+            self.refresh = AsyncMock()
+            self.refresh_latest = AsyncMock()
+
+        def get_events(self):
+            return list(self._events)
+
+        def get_history_scope(self):
+            return "all"
+
+        def set_history_scope(self, scope):
+            pass
+
+    bot.stop_signal_received = False
+    bot.config = {
+        "live": {
+            "fills_confirmation_overlap_minutes": 60.0,
+            "fills_recent_overlap_minutes": 10.0,
+            "pnls_max_lookback_days": "all",
+        }
+    }
+    bot.positions = {
+        symbol: {
+            "long": {
+                "size": 165.0,
+                "price": 0.3896,
+                "timestamp": position_anchor_ms,
+            }
+        }
+    }
+    bot._trailing_fill_confirmation_diagnostics = {
+        (symbol, "long"): {
+            "failed_predicates": ["fill_after_state_mismatch"],
+            "fill_timestamp_ms": cached_events[0].timestamp,
+        }
+    }
+    bot._authoritative_pending_confirmations = {"fills": 2}
+    bot._pnls_manager = _Manager()
+    bot.init_pnls = AsyncMock()
+    bot.live_value = lambda key: bot.config["live"][key]
+    bot.get_exchange_time = lambda: now_ms
+    bot._log_new_fill_events = lambda new_events: None
+    bot._monitor_record_event = lambda *args, **kwargs: None
+    bot._monitor_record_error = lambda *args, **kwargs: None
+    bot.logging_level = 0
+    bot._health_rate_limits = 0
+
+    result = await bot.update_pnls()
+
+    assert result is True
+    bot._pnls_manager.refresh.assert_awaited_once_with(
+        start_ms=position_anchor_ms - 5 * 60 * 1000,
+        end_ms=None,
+    )
+    bot._pnls_manager.refresh_latest.assert_not_awaited()
+    state = bot._trailing_fill_history_recovery_state
+    assert state["retry_count"] == 1
+    assert state["next_retry_ms"] == now_ms + 5 * 60 * 1000
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("shutdown_requested", [False, True])
 async def test_update_pnls_propagates_unexpected_refresh_errors_without_retaining_text(
     caplog, capsys, shutdown_requested

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -6419,7 +6419,9 @@ async def test_update_pnls_widens_refresh_for_mismatched_trailing_fill_anchor(
     bot.logging_level = 0
     bot._health_rate_limits = 0
 
-    result = await bot.update_pnls()
+    result = await bot.update_pnls(
+        source="routine_prefetch:trailing_recovery"
+    )
 
     assert result is True
     bot._pnls_manager.refresh.assert_awaited_once_with(

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -1374,6 +1374,27 @@ def test_position_anchor_timestamp_prefers_update_fields_over_open_fields():
     assert bot._position_update_timestamp_ms(symbol, "long") == 360_000
 
 
+def test_fill_history_anchor_ignores_update_only_timestamp():
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    bot._apply_positions_snapshot(
+        [
+            {
+                "symbol": symbol,
+                "position_side": "long",
+                "size": 1.0,
+                "price": 100.0,
+                "updatedTime": "360000",
+            }
+        ]
+    )
+
+    assert bot.positions[symbol]["long"]["timestamp"] == 360_000
+    assert bot._position_history_anchor_timestamp_ms(symbol, "long") is None
+    assert bot._position_update_timestamp_ms(symbol, "long") == 360_000
+
+
 def test_position_snapshot_preserves_distinct_open_and_update_timestamps():
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
@@ -1764,6 +1785,29 @@ def test_timestamp_free_fill_history_recovery_progressively_widens(
         now_ms - 120 * day_ms
     )
     assert bot._trailing_fill_history_recovery_state["retry_count"] == 2
+
+
+def test_all_history_fill_recovery_uses_positive_epoch_start(monkeypatch):
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    now_ms = 1_800_000_000_000
+    monkeypatch.setattr(sys.modules["passivbot"], "utc_ms", lambda: now_ms)
+    bot.get_exchange_time = lambda: now_ms
+    bot.positions[symbol]["long"] = {
+        "size": 1.0,
+        "price": 100.0,
+        "lastUpdateTimestamp": now_ms - 60_000,
+    }
+    bot._trailing_fill_confirmation_diagnostics = {
+        (symbol, "long"): {
+            "failed_predicates": ["fill_after_state_mismatch"],
+            "fill_timestamp_ms": now_ms - 30_000,
+        }
+    }
+
+    assert bot._trailing_fill_history_recovery_start_ms(None) == 1
+    assert bot._trailing_fill_history_recovery_state["start_ms"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -839,12 +839,22 @@ class _DummyFillEvent:
         pb_order_type: str = "unknown",
         psize: float | None = None,
         pprice: float | None = None,
+        side: str = "buy",
+        qty: float = 1.0,
+        price: float = 100.0,
+        client_order_id: str = "",
+        source_ids: list[str] | None = None,
     ):
         self.symbol = symbol
         self.position_side = position_side
         self.timestamp = timestamp
         self.id = event_id
         self.pb_order_type = pb_order_type
+        self.side = side
+        self.qty = qty
+        self.price = price
+        self.client_order_id = client_order_id
+        self.source_ids = list(source_ids or [])
         if psize is not None:
             self.psize = psize
         if pprice is not None:
@@ -1193,6 +1203,49 @@ async def test_same_timestamp_fill_identity_advances_trailing_epoch():
     assert bot._trailing_position_change_epochs[(symbol, "long")] == (
         "fill:120000:fill-b"
     )
+
+
+def test_idless_fill_identity_is_prefix_stable_and_distinguishes_duplicate_fills():
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    first = _DummyFillEvent(
+        symbol,
+        "long",
+        120_000,
+        None,
+        qty=0.5,
+        price=100.0,
+    )
+    bot._pnls_manager = _DummyPnlsManager([first])
+
+    first_epoch = bot._latest_fill_position_change_epochs()[(symbol, "long")]
+    assert ":fingerprint:" in first_epoch
+
+    older = _DummyFillEvent(
+        symbol,
+        "long",
+        60_000,
+        None,
+        qty=0.25,
+        price=99.0,
+    )
+    bot._pnls_manager._events.insert(0, older)
+    assert bot._latest_fill_position_change_epochs()[(symbol, "long")] == first_epoch
+
+    duplicate = _DummyFillEvent(
+        symbol,
+        "long",
+        120_000,
+        None,
+        qty=0.5,
+        price=100.0,
+    )
+    bot._pnls_manager._events.append(duplicate)
+    duplicate_epoch = bot._latest_fill_position_change_epochs()[(symbol, "long")]
+
+    assert duplicate_epoch != first_epoch
+    assert duplicate_epoch.endswith(":1")
 
 
 @pytest.mark.asyncio
@@ -1749,6 +1802,82 @@ async def test_runtime_delta_accepts_fresh_identity_when_reconstructed_after_sta
         in record.getMessage()
         for record in caplog.records
     )
+
+
+@pytest.mark.asyncio
+async def test_runtime_delta_rejects_idless_fill_reindexed_by_older_history():
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    latest_known_fill = _DummyFillEvent(
+        symbol,
+        "long",
+        120_000,
+        None,
+        psize=1.0,
+        pprice=100.0,
+        qty=1.0,
+        price=100.0,
+    )
+    bot._pnls_manager = _DummyPnlsManager([latest_known_fill])
+    bot.is_trailing = lambda sym, pside=None: pside == "long"
+    bot.get_exchange_time = lambda: 361_000
+
+    baseline = [
+        {
+            "symbol": symbol,
+            "position_side": "long",
+            "size": 1.0,
+            "price": 100.0,
+            "lastUpdateTimestamp": 120_000,
+        }
+    ]
+    changed = [
+        {
+            "symbol": symbol,
+            "position_side": "long",
+            "size": 1.5,
+            "price": 101.0,
+            "lastUpdateTimestamp": 240_000,
+        }
+    ]
+    bot._apply_positions_snapshot(baseline)
+    bot._begin_authoritative_refresh_epoch()
+    bot._apply_positions_snapshot(changed)
+    baseline_epoch = bot._trailing_pending_fill_confirmations[(symbol, "long")]
+
+    older_fill = _DummyFillEvent(
+        symbol,
+        "long",
+        60_000,
+        None,
+        psize=0.5,
+        pprice=99.0,
+        qty=0.5,
+        price=99.0,
+    )
+    bot._pnls_manager._events.insert(0, older_fill)
+    bot._trailing_fill_fetch_generation = 1
+
+    async def complete_epoch_candles(*args, **kwargs):
+        return _make_candles(
+            [
+                (180_000, 100.0, 102.0, 99.0, 101.0, 1.0),
+                (240_000, 101.0, 103.0, 100.0, 102.0, 1.0),
+                (300_000, 102.0, 104.0, 101.0, 103.0, 1.0),
+            ]
+        )
+
+    bot.cm.get_candles = complete_epoch_candles
+    await bot.update_trailing_data()
+
+    assert bot._trailing_pending_fill_confirmations == {
+        (symbol, "long"): baseline_epoch
+    }
+    assert bot._latest_fill_position_change_epochs()[(symbol, "long")] == baseline_epoch
+    assert bot._orchestrator_trailing_unavailable_reasons == {
+        symbol: ["position_fill_confirmation_pending"]
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -2044,7 +2044,8 @@ async def test_runtime_delta_keeps_mismatched_after_state_pending():
     assert bot._orchestrator_trailing_unavailable_reasons == {
         symbol: ["position_fill_confirmation_pending"]
     }
-    assert "fills" in bot._authoritative_pending_confirmations
+    assert "fills" not in bot._authoritative_pending_confirmations
+    assert bot._trailing_fill_recovery_prefetch_due() is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -1795,6 +1795,7 @@ def test_timestamp_free_fill_history_recovery_progressively_widens(
 def test_all_history_fill_recovery_uses_bounded_progressive_start(monkeypatch):
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
+    bot.exchange = "bybit"
     symbol = _set_basic_state(bot)
     now_ms = 1_800_000_000_000
     monkeypatch.setattr(sys.modules["passivbot"], "utc_ms", lambda: now_ms)
@@ -1834,6 +1835,41 @@ def test_weex_fill_recovery_uses_venue_retention_bound(monkeypatch):
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
     bot.exchange = "weex"
+    symbol = _set_basic_state(bot)
+    now_ms = 1_800_000_000_000
+    day_ms = 24 * 60 * 60_000
+    monkeypatch.setattr(sys.modules["passivbot"], "utc_ms", lambda: now_ms)
+    bot.get_exchange_time = lambda: now_ms
+    bot.positions[symbol]["long"] = {
+        "size": 1.0,
+        "price": 100.0,
+        "lastUpdateTimestamp": now_ms - 60_000,
+    }
+    bot._trailing_fill_confirmation_diagnostics = {
+        (symbol, "long"): {
+            "failed_predicates": ["fill_after_state_mismatch"],
+        }
+    }
+
+    recovery_start_ms = None
+    for _ in range(5):
+        recovery_start_ms = bot._trailing_fill_history_recovery_start_ms(None)
+        bot._trailing_fill_history_recovery_state["cohorts"][
+            (symbol, "long")
+        ]["next_retry_ms"] = 0
+
+    assert recovery_start_ms == now_ms - 365 * day_ms
+    bounded_state = bot._trailing_fill_history_recovery_state["cohorts"][
+        (symbol, "long")
+    ]
+    assert bounded_state["at_history_bound"] is True
+
+
+@pytest.mark.parametrize("exchange", ["bitget", "kucoin", "gateio", "hyperliquid"])
+def test_fill_recovery_uses_conservative_connector_bound(monkeypatch, exchange):
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    bot.exchange = exchange
     symbol = _set_basic_state(bot)
     now_ms = 1_800_000_000_000
     day_ms = 24 * 60 * 60_000

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -1370,6 +1370,7 @@ def test_position_anchor_timestamp_prefers_update_fields_over_open_fields():
     )
 
     assert bot._position_anchor_timestamp_ms(symbol, "long") == 360_000
+    assert bot._position_history_anchor_timestamp_ms(symbol, "long") == 120_000
     assert bot._position_update_timestamp_ms(symbol, "long") == 360_000
 
 
@@ -1661,7 +1662,7 @@ def test_restart_without_update_timestamp_requires_matching_fill_after_state():
     assert "fills" in bot._authoritative_pending_confirmations
 
 
-def test_full_opening_fill_matches_position_despite_truncated_cache_psize():
+def test_matching_fill_shape_does_not_override_truncated_cache_psize():
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
     symbol = _set_basic_state(bot)
@@ -1674,7 +1675,7 @@ def test_full_opening_fill_matches_position_despite_truncated_cache_psize():
         "c_mult": 1.0,
     }
 
-    assert bot._fill_anchor_matches_position_state(
+    assert not bot._fill_anchor_matches_position_state(
         symbol, "long", (1.1, 58.717), anchor
     )
     assert not bot._fill_anchor_matches_position_state(
@@ -1682,6 +1683,33 @@ def test_full_opening_fill_matches_position_despite_truncated_cache_psize():
     )
     assert not bot._fill_anchor_matches_position_state(
         symbol, "short", (1.1, 58.717), anchor
+    )
+
+
+def test_fill_history_recovery_starts_before_open_even_outside_pnl_window():
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    now_ms = 1_800_000_000_000
+    minute_ms = 60_000
+    open_ms = now_ms - 60 * 24 * 60 * minute_ms
+    update_ms = now_ms - 2 * 60 * minute_ms
+    age_limit = now_ms - 30 * 24 * 60 * minute_ms
+    bot.positions[symbol]["long"].update(
+        {
+            "openTime": open_ms,
+            "lastUpdateTimestamp": update_ms,
+        }
+    )
+    bot._trailing_fill_confirmation_diagnostics = {
+        (symbol, "long"): {
+            "failed_predicates": ["fill_after_state_mismatch"],
+            "fill_timestamp_ms": update_ms,
+        }
+    }
+
+    assert bot._trailing_fill_history_recovery_start_ms(age_limit) == (
+        open_ms - 5 * minute_ms
     )
 
 

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -844,6 +844,7 @@ class _DummyFillEvent:
         price: float = 100.0,
         client_order_id: str = "",
         source_ids: list[str] | None = None,
+        c_mult: float | None = None,
     ):
         self.symbol = symbol
         self.position_side = position_side
@@ -859,6 +860,14 @@ class _DummyFillEvent:
             self.psize = psize
         if pprice is not None:
             self.pprice = pprice
+        if side is not None:
+            self.side = side
+        if qty is not None:
+            self.qty = qty
+        if price is not None:
+            self.price = price
+        if c_mult is not None:
+            self.c_mult = c_mult
 
 
 class _DummyPnlsManager:
@@ -1536,10 +1545,16 @@ async def test_fill_prefetch_before_position_delta_waits_for_post_snapshot_refre
         "failed_predicates"
     ] == ["post_snapshot_fill_refresh_pending"]
 
+    bot._trailing_fill_history_recovery_state = {
+        "key": (((symbol, "long"),), 120_000),
+        "retry_count": 3,
+        "next_retry_ms": 1_800_000_000_000,
+    }
     bot._trailing_fill_fetch_generation = 1
     await bot.update_trailing_data()
 
     assert bot._trailing_pending_fill_confirmations == {}
+    assert bot._trailing_fill_history_recovery_state == {}
     assert bot._orchestrator_trailing_unavailable_symbols == set()
     assert bot.trailing_prices[symbol]["long"]["max_since_open"] == pytest.approx(
         103.0
@@ -1644,6 +1659,30 @@ def test_restart_without_update_timestamp_requires_matching_fill_after_state():
         (symbol, "long"): (1.0, 101.0)
     }
     assert "fills" in bot._authoritative_pending_confirmations
+
+
+def test_full_opening_fill_matches_position_despite_truncated_cache_psize():
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    anchor = {
+        "psize": 5.01,
+        "pprice": 63.8149,
+        "side": "buy",
+        "qty": 1.1,
+        "price": 58.717,
+        "c_mult": 1.0,
+    }
+
+    assert bot._fill_anchor_matches_position_state(
+        symbol, "long", (1.1, 58.717), anchor
+    )
+    assert not bot._fill_anchor_matches_position_state(
+        symbol, "long", (1.2, 58.717), anchor
+    )
+    assert not bot._fill_anchor_matches_position_state(
+        symbol, "short", (1.1, 58.717), anchor
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -1907,6 +1907,9 @@ async def test_runtime_delta_keeps_mismatched_after_state_pending():
     bot.cm.get_candles = complete_matching_epoch_candles
     bot._trailing_fill_refresh_started_generation = 3
     bot._trailing_fill_fetch_generation = 3
+    # Simulate the account-wide barrier clearing the successful fetch before
+    # trailing validation observes that the fill evidence is still mismatched.
+    bot._authoritative_pending_confirmations = {}
     await bot.update_trailing_data()
 
     assert bot._trailing_pending_fill_confirmations == {
@@ -1918,6 +1921,7 @@ async def test_runtime_delta_keeps_mismatched_after_state_pending():
     assert bot._orchestrator_trailing_unavailable_reasons == {
         symbol: ["position_fill_confirmation_pending"]
     }
+    assert "fills" in bot._authoritative_pending_confirmations
 
 
 @pytest.mark.asyncio

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -1780,14 +1780,19 @@ def test_timestamp_free_fill_history_recovery_progressively_widens(
     assert bot._trailing_fill_history_recovery_start_ms(age_limit) == (
         now_ms - 60 * day_ms
     )
-    bot._trailing_fill_history_recovery_state["next_retry_ms"] = 0
+    cohort_state = bot._trailing_fill_history_recovery_state["cohorts"][
+        (symbol, "long")
+    ]
+    cohort_state["next_retry_ms"] = 0
     assert bot._trailing_fill_history_recovery_start_ms(age_limit) == (
         now_ms - 120 * day_ms
     )
-    assert bot._trailing_fill_history_recovery_state["retry_count"] == 2
+    assert bot._trailing_fill_history_recovery_state["cohorts"][
+        (symbol, "long")
+    ]["retry_count"] == 2
 
 
-def test_all_history_fill_recovery_uses_positive_epoch_start(monkeypatch):
+def test_all_history_fill_recovery_uses_bounded_progressive_start(monkeypatch):
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
     symbol = _set_basic_state(bot)
@@ -1806,8 +1811,82 @@ def test_all_history_fill_recovery_uses_positive_epoch_start(monkeypatch):
         }
     }
 
-    assert bot._trailing_fill_history_recovery_start_ms(None) == 1
-    assert bot._trailing_fill_history_recovery_state["start_ms"] == 1
+    expected_start_ms = now_ms - 60 * 24 * 60 * 60_000
+    assert bot._trailing_fill_history_recovery_start_ms(None) == expected_start_ms
+    assert (
+        bot._trailing_fill_history_recovery_state["start_ms"]
+        == expected_start_ms
+    )
+    for _ in range(4):
+        bot._trailing_fill_history_recovery_state["cohorts"][
+            (symbol, "long")
+        ]["next_retry_ms"] = 0
+        recovery_start_ms = bot._trailing_fill_history_recovery_start_ms(None)
+    assert recovery_start_ms == now_ms - 730 * 24 * 60 * 60_000
+    bounded_state = bot._trailing_fill_history_recovery_state["cohorts"][
+        (symbol, "long")
+    ]
+    assert bounded_state["at_history_bound"] is True
+    assert bounded_state["next_retry_ms"] == now_ms + 24 * 60 * 60_000
+
+
+def test_fill_recovery_waits_for_post_snapshot_confirmation(monkeypatch):
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    now_ms = 1_800_000_000_000
+    monkeypatch.setattr(sys.modules["passivbot"], "utc_ms", lambda: now_ms)
+    bot.get_exchange_time = lambda: now_ms
+    bot._trailing_fill_confirmation_diagnostics = {
+        (symbol, "long"): {
+            "failed_predicates": [
+                "post_snapshot_fill_refresh_pending",
+                "fill_after_state_mismatch",
+            ],
+            "fill_timestamp_ms": now_ms - 30_000,
+        }
+    }
+
+    assert bot._trailing_fill_history_recovery_start_ms(None) is None
+    assert bot._trailing_fill_history_recovery_state == {
+        "cohorts": {(symbol, "long"): {}}
+    }
+
+
+def test_fill_recovery_progress_survives_other_cohort_changes(monkeypatch):
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    first_symbol = _set_basic_state(bot)
+    second_symbol = "SECOND/USDT"
+    bot.positions[second_symbol] = {
+        "long": {"size": 1.0, "price": 100.0},
+        "short": {"size": 0.0, "price": 0.0},
+    }
+    now_ms = 1_800_000_000_000
+    day_ms = 24 * 60 * 60_000
+    age_limit = now_ms - 30 * day_ms
+    monkeypatch.setattr(sys.modules["passivbot"], "utc_ms", lambda: now_ms)
+    bot.get_exchange_time = lambda: now_ms
+    bot._trailing_fill_confirmation_diagnostics = {
+        (first_symbol, "long"): {"failed_predicates": ["missing_fill_anchor"]}
+    }
+
+    assert bot._trailing_fill_history_recovery_start_ms(age_limit) == (
+        now_ms - 60 * day_ms
+    )
+    bot._trailing_fill_history_recovery_state["cohorts"][
+        (first_symbol, "long")
+    ]["next_retry_ms"] = 0
+    bot._trailing_fill_confirmation_diagnostics[(second_symbol, "long")] = {
+        "failed_predicates": ["missing_fill_anchor"]
+    }
+
+    assert bot._trailing_fill_history_recovery_start_ms(age_limit) == (
+        now_ms - 120 * day_ms
+    )
+    cohort_states = bot._trailing_fill_history_recovery_state["cohorts"]
+    assert cohort_states[(first_symbol, "long")]["retry_count"] == 2
+    assert cohort_states[(second_symbol, "long")]["retry_count"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -1374,6 +1374,31 @@ def test_position_anchor_timestamp_prefers_update_fields_over_open_fields():
     assert bot._position_update_timestamp_ms(symbol, "long") == 360_000
 
 
+def test_position_snapshot_preserves_distinct_open_and_update_timestamps():
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+
+    bot._apply_positions_snapshot(
+        [
+            {
+                "symbol": symbol,
+                "position_side": "long",
+                "size": 1.0,
+                "price": 100.0,
+                "openTime": 120_000,
+                "updatedTime": 360_000,
+            }
+        ]
+    )
+
+    position = bot.positions[symbol]["long"]
+    assert position["openTime"] == 120_000
+    assert position["timestamp"] == 360_000
+    assert position["lastUpdateTimestamp"] == 360_000
+    assert bot._position_history_anchor_timestamp_ms(symbol, "long") == 120_000
+
+
 @pytest.mark.asyncio
 async def test_trailing_anchor_uses_position_timestamp_when_fill_history_is_out_of_window(
     monkeypatch,
@@ -1711,6 +1736,34 @@ def test_fill_history_recovery_starts_before_open_even_outside_pnl_window():
     assert bot._trailing_fill_history_recovery_start_ms(age_limit) == (
         open_ms - 5 * minute_ms
     )
+
+
+def test_timestamp_free_fill_history_recovery_progressively_widens(
+    monkeypatch,
+):
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    now_ms = 1_800_000_000_000
+    day_ms = 24 * 60 * 60_000
+    age_limit = now_ms - 30 * day_ms
+    monkeypatch.setattr(sys.modules["passivbot"], "utc_ms", lambda: now_ms)
+    bot.get_exchange_time = lambda: now_ms
+    bot.positions[symbol]["long"] = {"size": 1.0, "price": 100.0}
+    bot._trailing_fill_confirmation_diagnostics = {
+        (symbol, "long"): {
+            "failed_predicates": ["missing_fill_anchor"],
+        }
+    }
+
+    assert bot._trailing_fill_history_recovery_start_ms(age_limit) == (
+        now_ms - 60 * day_ms
+    )
+    bot._trailing_fill_history_recovery_state["next_retry_ms"] = 0
+    assert bot._trailing_fill_history_recovery_start_ms(age_limit) == (
+        now_ms - 120 * day_ms
+    )
+    assert bot._trailing_fill_history_recovery_state["retry_count"] == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -1669,7 +1669,10 @@ async def test_restart_same_state_waits_for_post_position_fill_refresh():
 
 
 @pytest.mark.asyncio
-async def test_runtime_delta_without_update_time_rejects_mismatched_prefetched_fill():
+async def test_runtime_delta_accepts_fresh_identity_when_reconstructed_after_state_mismatches(
+    caplog,
+):
+    caplog.set_level(logging.INFO)
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
     symbol = _set_basic_state(bot)
@@ -1725,7 +1728,10 @@ async def test_runtime_delta_without_update_time_rejects_mismatched_prefetched_f
 
     async def complete_matching_epoch_candles(*args, **kwargs):
         return _make_candles(
-            [(300_000, 101.0, 103.0, 100.0, 102.0, 1.0)]
+            [
+                (240_000, 100.0, 102.0, 99.0, 101.0, 1.0),
+                (300_000, 101.0, 103.0, 100.0, 102.0, 1.0),
+            ]
         )
 
     bot.cm.get_candles = complete_matching_epoch_candles
@@ -1733,27 +1739,82 @@ async def test_runtime_delta_without_update_time_rejects_mismatched_prefetched_f
     bot._trailing_fill_fetch_generation = 3
     await bot.update_trailing_data()
 
-    assert bot._trailing_pending_fill_confirmations == {
-        (symbol, "long"): "fill:120000:old-fill"
+    assert bot._trailing_pending_fill_confirmations == {}
+    assert bot._trailing_position_snapshot_fill_epochs == {
+        (symbol, "long"): "fill:180000:mismatched-fill"
     }
-    assert bot._orchestrator_trailing_unavailable_reasons == {
-        symbol: ["position_fill_confirmation_pending"]
-    }
-
-    bot._pnls_manager._events.append(
-        _DummyFillEvent(
-            symbol, "long", 240_000, "matching-fill", psize=1.5, pprice=101.0
-        )
+    assert bot._orchestrator_trailing_unavailable_symbols == set()
+    assert any(
+        "accepted fresh fill identity despite reconstructed after-state mismatch"
+        in record.getMessage()
+        for record in caplog.records
     )
-    bot._trailing_fill_refresh_started_generation = 4
-    bot._trailing_fill_fetch_generation = 4
+
+
+@pytest.mark.asyncio
+async def test_restart_accepts_fresh_fill_identity_when_cache_starts_mid_position(
+    caplog,
+):
+    caplog.set_level(logging.INFO)
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    bot._pnls_manager = _DummyPnlsManager(
+        [
+            _DummyFillEvent(
+                symbol,
+                "long",
+                120_000,
+                "partial-history-fill",
+                psize=0.4,
+                pprice=99.0,
+            )
+        ]
+    )
+    bot.is_trailing = lambda sym, pside=None: pside == "long"
+    bot.get_exchange_time = lambda: 361_000
+
+    bot._apply_positions_snapshot(
+        [
+            {
+                "symbol": symbol,
+                "position_side": "long",
+                "size": 1.5,
+                "price": 101.0,
+                "lastUpdateTimestamp": 240_000,
+            }
+        ]
+    )
+
+    async def complete_epoch_candles(*args, **kwargs):
+        return _make_candles(
+            [
+                (180_000, 100.0, 110.0, 90.0, 100.0, 1.0),
+                (240_000, 100.0, 111.0, 89.0, 101.0, 1.0),
+                (300_000, 101.0, 112.0, 88.0, 102.0, 1.0),
+            ]
+        )
+
+    bot.cm.get_candles = complete_epoch_candles
+    await bot.update_trailing_data()
+    assert bot._trailing_pending_fill_confirmations == {(symbol, "long"): None}
+
+    bot._trailing_fill_fetch_generation = 1
     await bot.update_trailing_data()
 
     assert bot._trailing_pending_fill_confirmations == {}
     assert bot._trailing_position_snapshot_fill_epochs == {
-        (symbol, "long"): "fill:240000:matching-fill"
+        (symbol, "long"): "fill:120000:partial-history-fill"
     }
     assert bot._orchestrator_trailing_unavailable_symbols == set()
+    assert bot.trailing_prices[symbol]["long"]["max_since_open"] == pytest.approx(
+        112.0
+    )
+    assert any(
+        "accepted fresh fill identity despite reconstructed after-state mismatch"
+        in record.getMessage()
+        for record in caplog.records
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -1830,6 +1830,40 @@ def test_all_history_fill_recovery_uses_bounded_progressive_start(monkeypatch):
     assert bounded_state["next_retry_ms"] == now_ms + 24 * 60 * 60_000
 
 
+def test_weex_fill_recovery_uses_venue_retention_bound(monkeypatch):
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    bot.exchange = "weex"
+    symbol = _set_basic_state(bot)
+    now_ms = 1_800_000_000_000
+    day_ms = 24 * 60 * 60_000
+    monkeypatch.setattr(sys.modules["passivbot"], "utc_ms", lambda: now_ms)
+    bot.get_exchange_time = lambda: now_ms
+    bot.positions[symbol]["long"] = {
+        "size": 1.0,
+        "price": 100.0,
+        "lastUpdateTimestamp": now_ms - 60_000,
+    }
+    bot._trailing_fill_confirmation_diagnostics = {
+        (symbol, "long"): {
+            "failed_predicates": ["fill_after_state_mismatch"],
+        }
+    }
+
+    recovery_start_ms = None
+    for _ in range(5):
+        recovery_start_ms = bot._trailing_fill_history_recovery_start_ms(None)
+        bot._trailing_fill_history_recovery_state["cohorts"][
+            (symbol, "long")
+        ]["next_retry_ms"] = 0
+
+    assert recovery_start_ms == now_ms - 365 * day_ms
+    bounded_state = bot._trailing_fill_history_recovery_state["cohorts"][
+        (symbol, "long")
+    ]
+    assert bounded_state["at_history_bound"] is True
+
+
 def test_fill_recovery_waits_for_post_snapshot_confirmation(monkeypatch):
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -1761,10 +1761,7 @@ async def test_restart_same_state_waits_for_post_position_fill_refresh():
 
 
 @pytest.mark.asyncio
-async def test_runtime_delta_accepts_fresh_identity_when_reconstructed_after_state_mismatches(
-    caplog,
-):
-    caplog.set_level(logging.INFO)
+async def test_runtime_delta_keeps_mismatched_after_state_pending():
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
     symbol = _set_basic_state(bot)
@@ -1831,16 +1828,15 @@ async def test_runtime_delta_accepts_fresh_identity_when_reconstructed_after_sta
     bot._trailing_fill_fetch_generation = 3
     await bot.update_trailing_data()
 
-    assert bot._trailing_pending_fill_confirmations == {}
-    assert bot._trailing_position_snapshot_fill_epochs == {
-        (symbol, "long"): "fill:180000:mismatched-fill"
+    assert bot._trailing_pending_fill_confirmations == {
+        (symbol, "long"): "fill:120000:old-fill"
     }
-    assert bot._orchestrator_trailing_unavailable_symbols == set()
-    assert any(
-        "accepted fresh fill identity despite reconstructed after-state mismatch"
-        in record.getMessage()
-        for record in caplog.records
-    )
+    assert bot._trailing_fill_confirmation_diagnostics[(symbol, "long")][
+        "failed_predicates"
+    ] == ["fill_after_state_mismatch"]
+    assert bot._orchestrator_trailing_unavailable_reasons == {
+        symbol: ["position_fill_confirmation_pending"]
+    }
 
 
 @pytest.mark.asyncio
@@ -1920,10 +1916,7 @@ async def test_runtime_delta_rejects_idless_fill_reindexed_by_older_history():
 
 
 @pytest.mark.asyncio
-async def test_restart_accepts_fresh_fill_identity_when_cache_starts_mid_position(
-    caplog,
-):
-    caplog.set_level(logging.INFO)
+async def test_restart_keeps_partial_history_fill_pending_until_recovery():
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
     symbol = _set_basic_state(bot)
@@ -1970,19 +1963,15 @@ async def test_restart_accepts_fresh_fill_identity_when_cache_starts_mid_positio
     bot._trailing_fill_fetch_generation = 1
     await bot.update_trailing_data()
 
-    assert bot._trailing_pending_fill_confirmations == {}
-    assert bot._trailing_position_snapshot_fill_epochs == {
-        (symbol, "long"): "fill:120000:partial-history-fill"
+    assert bot._trailing_pending_fill_confirmations == {
+        (symbol, "long"): None
     }
-    assert bot._orchestrator_trailing_unavailable_symbols == set()
-    assert bot.trailing_prices[symbol]["long"]["max_since_open"] == pytest.approx(
-        112.0
-    )
-    assert any(
-        "accepted fresh fill identity despite reconstructed after-state mismatch"
-        in record.getMessage()
-        for record in caplog.records
-    )
+    assert bot._trailing_fill_confirmation_diagnostics[(symbol, "long")][
+        "failed_predicates"
+    ] == ["fill_after_state_mismatch"]
+    assert bot._orchestrator_trailing_unavailable_reasons == {
+        symbol: ["position_fill_confirmation_pending"]
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- keep trailing positions fail-closed when the latest fill's reconstructed after-state does not match the authoritative exchange position
- preserve stable content-based identities for id-less fills so loading older history cannot fabricate a position-changing epoch
- preserve `last_refresh_ms` as the timestamp of an actual exchange fetch rather than local cache maintenance
- retry unresolved confirmation from the position/fill anchor with bounded in-memory backoff
- start recovery before the earliest exchange-provided position/open timestamp, even when that predates the configured PnL accounting window
- preserve distinct opening and update timestamps through snapshot normalization; update-only timestamps do not masquerade as opening boundaries
- wait for the required recent post-snapshot confirmation before widening historical recovery
- progressively widen timestamp-free recovery per coin and position side, preserving progress when other cohorts join or leave
- reserve potentially expensive widening for the nonblocking `routine_prefetch:trailing_recovery` path; mandatory account-wide fill confirmations remain recent
- cap recovery by connector pagination capacity: two years for Bybit and one year otherwise, with a one-day retry delay at the bound
- traverse empty recent Bybit trade-history windows so sparse older fills remain reachable
- keep stale fill state in the blocking authoritative refresh instead of displacing it with background recovery
- schedule unresolved historical recovery outside the account-wide execution barrier

## Safety boundary

A mismatched fill remains pending until refreshed history reconstructs a post-fill size and average matching the authoritative exchange position. Price and quantity alone are not accepted as proof of a flat-to-position transition because unseen reductions can produce the same live shape. Partial entries, DCA fills, mismatched averages, unchanged identities, missing anchors, and incomplete post-snapshot refreshes remain nontradable.

Historical recovery is an economy mechanism, not a relaxation: unresolved coin/position-side cohorts remain fail-closed when the venue no longer exposes enough history, while unrelated symbols and order classes remain tradable after the normal authoritative account confirmation settles. Long history pagination cannot be pulled into a mandatory account-wide confirmation.

## Validation

- `python -m compileall -q src tests/test_fill_events_manager.py tests/test_unstucking_safeguards.py tests/test_passivbot_balance_split.py tests/test_order_orchestration.py tests/test_passivbot_monitor.py tests/test_hyperliquid_balance_cache.py tests/test_order_reconciliation_contract.py`
- `python -m pytest -q tests/test_fill_events_manager.py tests/test_unstucking_safeguards.py tests/test_passivbot_balance_split.py tests/test_order_orchestration.py tests/test_passivbot_monitor.py tests/test_hyperliquid_balance_cache.py tests/test_order_reconciliation_contract.py`
- `git diff --check origin/master...HEAD`
- GitHub CI: Python 3.12, Python 3.14, and Rust
