### PR TITLE
Document Python 3.14 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,13 @@ concurrency:
 
 jobs:
   python:
-    name: Python 3.12
+    name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.14"]
     steps:
       - name: Check out repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -26,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: |
             requirements-live.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ All notable user-facing changes will be documented in this file.
 - Documented Python 3.12+ support, including Python 3.14, and fixed reentrant candle fetch-lock
   cleanup so a missing bookkeeping record no longer suppresses an exception raised by the
   protected operation. CI now builds the Rust extension and runs the Python suite on both Python
-  3.12 and 3.14.
+  3.12 and 3.14. Reentrancy is now restricted to the owning asyncio task, so parallel requests
+  sharing one candle manager serialize same-symbol/timeframe fetches correctly.
 
 - Backtests now treat a finite balance depleted by fills as liquidation before recomputing orders,
   so extreme optimizer candidates terminate normally instead of panicking an optimizer worker.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Documented Python 3.12+ support, including Python 3.14, and fixed reentrant candle fetch-lock
+  cleanup so a missing bookkeeping record no longer suppresses an exception raised by the
+  protected operation.
+
 - Live candle orchestration now reads bounded cache-only native 1h EMA carry-forward from the 1h
   index, requires a complete native window, isolates carried values from the active EMA cache, and
   applies the background refresher's surface-count staleness limit using the active live/replay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable user-facing changes will be documented in this file.
 ## Unreleased
 
 - Documented Python 3.12 and 3.14 support, explicitly excluding Python 3.13 until its dependency
-  set is supported, and fixed reentrant candle fetch-lock
+  set is supported and bounding package metadata to those validated minor versions, and fixed
+  reentrant candle fetch-lock
   cleanup so a missing bookkeeping record no longer suppresses an exception raised by the
   protected operation. CI now builds the Rust extension and runs the Python suite on both Python
   3.12 and 3.14. Reentrancy is now restricted to the owning asyncio task, so parallel requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable user-facing changes will be documented in this file.
 
 - Documented Python 3.12+ support, including Python 3.14, and fixed reentrant candle fetch-lock
   cleanup so a missing bookkeeping record no longer suppresses an exception raised by the
-  protected operation.
+  protected operation. CI now builds the Rust extension and runs the Python suite on both Python
+  3.12 and 3.14.
 
 - Live candle orchestration now reads bounded cache-only native 1h EMA carry-forward from the 1h
   index, requires a complete native window, isolates carried values from the active EMA cache, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
-- Documented Python 3.12+ support, including Python 3.14, and fixed reentrant candle fetch-lock
+- Documented Python 3.12 and 3.14 support, explicitly excluding Python 3.13 until its dependency
+  set is supported, and fixed reentrant candle fetch-lock
   cleanup so a missing bookkeeping record no longer suppresses an exception raised by the
   protected operation. CI now builds the Rust extension and runs the Python suite on both Python
   3.12 and 3.14. Reentrancy is now restricted to the owning asyncio task, so parallel requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ All notable user-facing changes will be documented in this file.
   cleanup so a missing bookkeeping record no longer suppresses an exception raised by the
   protected operation. CI now builds the Rust extension and runs the Python suite on both Python
   3.12 and 3.14. Reentrancy is now restricted to the owning asyncio task, so parallel requests
-  sharing one candle manager serialize same-symbol/timeframe fetches correctly.
+  sharing one candle manager serialize same-symbol/timeframe fetches correctly. Installation
+  examples now create the venv with the explicitly selected supported interpreter instead of
+  assuming the system `python3` points to it.
 
 - Backtests now treat a finite balance depleted by fills as liquidation before recomputing orders,
   so extreme optimizer candidates terminate normally instead of panicking an optimizer worker.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,10 @@ Create a virtual environment to manage dependencies:
 
  **Linux/macOS:**
 ```sh
-python3 -m venv venv
+# Replace python3.14 with the installed Python 3.12+ executable you want Passivbot to use.
+PYTHON_BIN=python3.14
+"$PYTHON_BIN" --version
+"$PYTHON_BIN" -m venv venv
 ```
 
  **Windows (Command Prompt or PowerShell):**

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Passivbot manages underperforming, or "stuck", positions by realizing small loss
 
 To install Passivbot and its dependencies, follow the steps below.
 
-Passivbot requires **Python 3.12**. Earlier versions are not supported.
+Passivbot requires **Python 3.12 or newer**. Earlier versions are not supported.
 
 ### Upgrading a v7 config
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Passivbot manages underperforming, or "stuck", positions by realizing small loss
 
 To install Passivbot and its dependencies, follow the steps below.
 
-Passivbot requires **Python 3.12 or newer**. Earlier versions are not supported.
+Passivbot supports **Python 3.12 and Python 3.14**. Python 3.13 is not supported by the pinned
+dependency set.
 
 ### Upgrading a v7 config
 
@@ -88,7 +89,7 @@ Create a virtual environment to manage dependencies:
 
  **Linux/macOS:**
 ```sh
-# Replace python3.14 with the installed Python 3.12+ executable you want Passivbot to use.
+# Replace python3.14 with the installed supported executable (python3.12 or python3.14).
 PYTHON_BIN=python3.14
 "$PYTHON_BIN" --version
 "$PYTHON_BIN" -m venv venv

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,10 @@ This guide collects all steps (and common pitfalls) for setting up Passivbot on 
 
 ## 1. Prerequisites
 
-- **Python 3.12** – Earlier versions are no longer supported. On Debian/Ubuntu use `sudo apt install python3.12 python3.12-venv python3.12-dev`.
+- **Python 3.12 or newer** – Earlier versions are no longer supported. On Debian/Ubuntu systems
+  whose default interpreter is Python 3.12+, install it and its build headers with
+  `sudo apt install python3 python3-venv python3-dev`. Otherwise install a supported newer
+  interpreter, then confirm the selected `python3 --version` reports Python 3.12+.
 - **Rust toolchain** – Passivbot’s hot paths live in Rust. Install via [rustup](https://rustup.rs/) if `rustc --version` is not available.
 - **C build tools** – Ubuntu/Debian: `sudo apt install build-essential`. macOS: Xcode command-line tools (`xcode-select --install`).
 - **Virtual environment** – Strongly recommended so dependencies do not leak into the system interpreter.
@@ -16,8 +19,8 @@ This guide collects all steps (and common pitfalls) for setting up Passivbot on 
  git clone https://github.com/enarjord/passivbot.git
  cd passivbot
 
-# Create + activate Python 3.12 venv (inside repo root)
- python3.12 -m venv venv
+# Create + activate a Python 3.12+ venv (inside repo root)
+ python3 -m venv venv
  source venv/bin/activate  # Windows: venv\Scripts\activate
 ```
 
@@ -50,7 +53,8 @@ Common errors:
 
 - `error: linker cc not found` → install build tools: `sudo apt install build-essential`. On macOS ensure Xcode CLT is installed.
 - `No such command 'maturin'` → re-run `pip install -r requirements-rust.txt`.
-- `failed to run custom build command … cc not found` on WSL/Ubuntu → install `python3-dev` (`sudo apt install python3.12-dev`).
+- `failed to run custom build command … cc not found` on WSL/Ubuntu → install the compiler and
+  Python headers (`sudo apt install build-essential python3-dev`).
 - `failed to parse manifest ... feature edition2024 is required` or `cargo metadata ... failed` during `python3 -m pip install -e ".[full]"` → your Rust/Cargo is too old for the transitive crates Cargo resolved. Update Rust with `rustup update stable`, confirm `cargo --version` / `rustc --version`, then retry the install. If you installed Rust from distro packages, prefer the `rustup` toolchain instead.
 
 ## 5. Verify the install
@@ -102,7 +106,7 @@ If you see linker errors after an OS update (e.g. new glibc), rebuild the extens
 | `feature edition2024 is required` during the Rust build | Update Rust with `rustup update stable`, then retry `python3 -m pip install -e ".[full]"`. |
 | `python3 -m pip install … failed due to SSL` | Update `certifi` or set `PIP_CERT` if corporate proxies intercept TLS. |
 | `maturin develop` can’t find Python | Ensure you run it inside the venv (`which python` should point to `venv/bin/python`). |
-| `TypeError: unsupported operand type(s) for |: ...` | You are running an unsupported Python version; install Python 3.12 and recreate the venv with `python3.12 -m venv venv`. |
+| `TypeError: unsupported operand type(s) for |: ...` | You are running an unsupported Python version; install Python 3.12+ and recreate the venv with that interpreter. |
 
 For more detail, see [docs/troubleshooting.md](troubleshooting.md).
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,8 +4,8 @@ This guide collects all steps (and common pitfalls) for setting up Passivbot on 
 
 ## 1. Prerequisites
 
-- **Python 3.12 or newer** – Earlier versions are no longer supported. On Debian/Ubuntu systems
-  whose default interpreter is Python 3.12+, install it and its build headers with
+- **Python 3.12 or 3.14** – Earlier versions and Python 3.13 are not supported. On Debian/Ubuntu
+  systems whose default interpreter is a supported version, install it and its build headers with
   `sudo apt install python3 python3-venv python3-dev`. Otherwise install a supported newer
   interpreter and note its executable name, such as `python3.14`.
 - **Rust toolchain** – Passivbot’s hot paths live in Rust. Install via [rustup](https://rustup.rs/) if `rustc --version` is not available.
@@ -19,7 +19,7 @@ This guide collects all steps (and common pitfalls) for setting up Passivbot on 
  git clone https://github.com/enarjord/passivbot.git
  cd passivbot
 
-# Select the supported interpreter you installed. Use python3 only if it is already 3.12+.
+# Select the supported interpreter you installed. Use python3 only if it is 3.12 or 3.14.
  PYTHON_BIN=python3.14
  "$PYTHON_BIN" --version
 
@@ -29,8 +29,8 @@ This guide collects all steps (and common pitfalls) for setting up Passivbot on 
  python --version
 ```
 
-Replace `python3.14` with another installed Python 3.12+ executable as needed. Do not assume the
-system `python3` changed when a versioned interpreter was installed alongside it.
+Replace `python3.14` with `python3.12` as needed. Do not assume the system `python3` changed when
+a versioned interpreter was installed alongside it.
 
 ## 3. Install Passivbot
 
@@ -119,7 +119,7 @@ If you see linker errors after an OS update (e.g. new glibc), rebuild the extens
 | `feature edition2024 is required` during the Rust build | Update Rust with `rustup update stable`, then retry `python3 -m pip install -e ".[full]"`. |
 | `python3 -m pip install … failed due to SSL` | Update `certifi` or set `PIP_CERT` if corporate proxies intercept TLS. |
 | `maturin develop` can’t find Python | Ensure you run it inside the venv (`which python` should point to `venv/bin/python`). |
-| `TypeError: unsupported operand type(s) for |: ...` | You are running an unsupported Python version; install Python 3.12+ and recreate the venv with that interpreter. |
+| `TypeError: unsupported operand type(s) for |: ...` | You are running an unsupported Python version; install Python 3.12 or 3.14 and recreate the venv with that interpreter. |
 
 For more detail, see [docs/troubleshooting.md](troubleshooting.md).
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,7 +7,7 @@ This guide collects all steps (and common pitfalls) for setting up Passivbot on 
 - **Python 3.12 or newer** – Earlier versions are no longer supported. On Debian/Ubuntu systems
   whose default interpreter is Python 3.12+, install it and its build headers with
   `sudo apt install python3 python3-venv python3-dev`. Otherwise install a supported newer
-  interpreter, then confirm the selected `python3 --version` reports Python 3.12+.
+  interpreter and note its executable name, such as `python3.14`.
 - **Rust toolchain** – Passivbot’s hot paths live in Rust. Install via [rustup](https://rustup.rs/) if `rustc --version` is not available.
 - **C build tools** – Ubuntu/Debian: `sudo apt install build-essential`. macOS: Xcode command-line tools (`xcode-select --install`).
 - **Virtual environment** – Strongly recommended so dependencies do not leak into the system interpreter.
@@ -19,10 +19,18 @@ This guide collects all steps (and common pitfalls) for setting up Passivbot on 
  git clone https://github.com/enarjord/passivbot.git
  cd passivbot
 
-# Create + activate a Python 3.12+ venv (inside repo root)
- python3 -m venv venv
+# Select the supported interpreter you installed. Use python3 only if it is already 3.12+.
+ PYTHON_BIN=python3.14
+ "$PYTHON_BIN" --version
+
+# Create + activate the venv with that exact interpreter (inside repo root)
+ "$PYTHON_BIN" -m venv venv
  source venv/bin/activate  # Windows: venv\Scripts\activate
+ python --version
 ```
+
+Replace `python3.14` with another installed Python 3.12+ executable as needed. Do not assume the
+system `python3` changed when a versioned interpreter was installed alongside it.
 
 ## 3. Install Passivbot
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -49,6 +49,11 @@ source venv/bin/activate
 maturin develop --release
 ```
 
+The Rust crate's default features include `abi3-py312`, so one extension build
+targets the stable Python 3.12 ABI and remains loadable by newer supported
+interpreters, including Python 3.14. Do not use `--no-default-features` to test
+the supported installation path: that disables the ABI3 compatibility feature.
+
 Common errors:
 
 - `error: linker cc not found` → install build tools: `sudo apt install build-essential`. On macOS ensure Xcode CLT is installed.

--- a/docs/release_notes_v8.0.0.md
+++ b/docs/release_notes_v8.0.0.md
@@ -7,7 +7,7 @@ mainline release.
 
 ## Before upgrading
 
-- Use Python 3.12 and a current stable Rust toolchain.
+- Use Python 3.12 or newer and a current stable Rust toolchain.
 - Back up the config you currently run and keep the exact v7 revision needed
   to reproduce its behavior.
 - Do not point v8 at an unreviewed v7 config. Normal v8 loading does not
@@ -121,7 +121,7 @@ before enabling or changing HSL settings.
 
 ## Upgrade checklist
 
-1. Install v8 in a Python 3.12 virtual environment and rebuild the Rust
+1. Install v8 in a Python 3.12+ virtual environment and rebuild the Rust
    extension.
 2. Migrate the v7 config or start from the canonical v8 example.
 3. Resolve every migration report item; do not rely on best-effort output as a

--- a/docs/release_notes_v8.0.0.md
+++ b/docs/release_notes_v8.0.0.md
@@ -7,7 +7,7 @@ mainline release.
 
 ## Before upgrading
 
-- Use Python 3.12 or newer and a current stable Rust toolchain.
+- Use Python 3.12 or 3.14 and a current stable Rust toolchain.
 - Back up the config you currently run and keep the exact v7 revision needed
   to reproduce its behavior.
 - Do not point v8 at an unreviewed v7 config. Normal v8 loading does not
@@ -121,7 +121,7 @@ before enabling or changing HSL settings.
 
 ## Upgrade checklist
 
-1. Install v8 in a Python 3.12+ virtual environment and rebuild the Rust
+1. Install v8 in a Python 3.12 or 3.14 virtual environment and rebuild the Rust
    extension.
 2. Migrate the v7 config or start from the canonical v8 example.
 3. Resolve every migration report item; do not rely on best-effort output as a

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -157,5 +157,5 @@ Then rerun:
 maturin develop --release
 ```
 
-If you are still seeing the wrong interpreter, recreate the venv with Python 3.12 or newer and
-reinstall Passivbot inside that venv.
+If you are still seeing the wrong interpreter, recreate the venv with a supported interpreter
+(Python 3.12 or 3.14; not 3.13) and reinstall Passivbot inside that venv.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -157,4 +157,5 @@ Then rerun:
 maturin develop --release
 ```
 
-If you are still seeing the wrong interpreter, recreate the venv from the desired Python 3.12 install and reinstall Passivbot inside that venv.
+If you are still seeing the wrong interpreter, recreate the venv with Python 3.12 or newer and
+reinstall Passivbot inside that venv.

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ DEV_REQUIREMENTS = parse_requirements("requirements-dev.txt")
 setup(
     name="passivbot",
     version=VERSION_NS["__version__"],
-    python_requires=">=3.12",
+    python_requires=">=3.12,!=3.13.*",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     py_modules=discover_py_modules(),

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ DEV_REQUIREMENTS = parse_requirements("requirements-dev.txt")
 setup(
     name="passivbot",
     version=VERSION_NS["__version__"],
-    python_requires=">=3.12,!=3.13.*",
+    python_requires=">=3.12,<3.15,!=3.13.*",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     py_modules=discover_py_modules(),

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -1940,13 +1940,11 @@ class CandlestickManager:
                 yield
             finally:
                 record = self._held_fetch_locks.get(key)
-                if record is None:
-                    return
-                if record.count <= 1:
+                if record is not None and record.count <= 1:
                     self._held_fetch_locks.pop(key, None)
                     self._cancel_fetch_lock_watchdog(key)
                     await self._release_lock(record.lock, record.path, symbol, tf_norm)
-                else:
+                elif record is not None:
                     self._held_fetch_locks[key] = _LockRecord(
                         lock=record.lock,
                         path=record.path,

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -223,6 +223,7 @@ class _LockRecord:
     count: int
     acquired_at: float
     path: str
+    owner_task: Optional[asyncio.Task[Any]]
 
 
 class GapEntry(TypedDict, total=False):
@@ -837,7 +838,9 @@ class CandlestickManager:
         self._lock_backoff_initial = float(_LOCK_BACKOFF_INITIAL)
         self._lock_backoff_max = float(_LOCK_BACKOFF_MAX)
         self._lock_hold_timeout_seconds = max(60.0, self._lock_timeout_seconds * 6.0)
-        # Reentrant bookkeeping for portalocker fetch locks: key -> _LockRecord
+        # Reentrant bookkeeping for portalocker fetch locks: key -> _LockRecord.
+        # Reentrancy is valid only within the owning asyncio task; a different
+        # coroutine using this manager must wait for the same symbol/timeframe.
         self._held_fetch_locks: Dict[Tuple[str, str], _LockRecord] = {}
         self._fetch_lock_watchdogs: Dict[Tuple[str, str], asyncio.Task] = {}
         self._shutdown_guard = threading.Lock()
@@ -1921,13 +1924,15 @@ class CandlestickManager:
 
         lock_path = self._fetch_lock_path(symbol, tf_norm)
         key = (symbol, tf_norm)
+        current_task = asyncio.current_task()
         held = self._held_fetch_locks.get(key)
-        if held is not None:
+        if held is not None and held.owner_task is current_task:
             self._held_fetch_locks[key] = _LockRecord(
                 lock=held.lock,
                 path=held.path,
                 count=held.count + 1,
                 acquired_at=held.acquired_at,
+                owner_task=held.owner_task,
             )
             self._log(
                 "debug",
@@ -1950,6 +1955,7 @@ class CandlestickManager:
                         path=record.path,
                         count=record.count - 1,
                         acquired_at=record.acquired_at,
+                        owner_task=record.owner_task,
                     )
             return
 
@@ -1976,6 +1982,7 @@ class CandlestickManager:
                     path=lock_path,
                     count=1,
                     acquired_at=acquired_at,
+                    owner_task=current_task,
                 )
                 self._start_fetch_lock_watchdog(
                     key,

--- a/tests/test_candlestick_manager_locking.py
+++ b/tests/test_candlestick_manager_locking.py
@@ -170,6 +170,40 @@ async def test_reentrant_fetch_lock_does_not_suppress_body_exception_when_record
     assert cm._held_fetch_locks == {}
 
 
+@pytest.mark.asyncio
+async def test_fetch_lock_is_reentrant_only_for_owning_task(tmp_path):
+    cm = CandlestickManager(
+        exchange=FakeExchange(),
+        exchange_name="hyperliquid",
+        cache_dir=str(tmp_path / "caches"),
+        default_window_candles=5,
+    )
+    key = ("BTC/USDC:USDC", "1m")
+    contender_entered = asyncio.Event()
+
+    async def contend_for_lock():
+        async with cm._acquire_fetch_lock(*key):
+            contender_entered.set()
+
+    async with cm._acquire_fetch_lock(*key):
+        owner_record = cm._held_fetch_locks[key]
+        assert owner_record.owner_task is asyncio.current_task()
+
+        # Nested acquisition by the owning task remains reentrant.
+        async with cm._acquire_fetch_lock(*key):
+            assert cm._held_fetch_locks[key].count == 2
+        assert cm._held_fetch_locks[key].count == 1
+
+        # A separate task using the same manager must wait.
+        contender = asyncio.create_task(contend_for_lock())
+        await asyncio.sleep(cm._lock_backoff_initial * 1.5)
+        assert not contender_entered.is_set()
+
+    await asyncio.wait_for(contender, timeout=1.0)
+    assert contender_entered.is_set()
+    assert cm._held_fetch_locks == {}
+
+
 def test_read_lockfile_owner_defaults_to_full_context_for_stale_waiting(tmp_path):
     cm = CandlestickManager(
         exchange=FakeExchange(),

--- a/tests/test_candlestick_manager_locking.py
+++ b/tests/test_candlestick_manager_locking.py
@@ -145,6 +145,31 @@ async def test_fetch_lock_watchdog_logs_stale_local_holder_without_release(tmp_p
     assert len(rendered) <= 240
 
 
+@pytest.mark.asyncio
+async def test_reentrant_fetch_lock_does_not_suppress_body_exception_when_record_missing(
+    tmp_path,
+):
+    cm = CandlestickManager(
+        exchange=FakeExchange(),
+        exchange_name="hyperliquid",
+        cache_dir=str(tmp_path / "caches"),
+        default_window_candles=5,
+    )
+    key = ("BTC/USDC:USDC", "1m")
+
+    async with cm._acquire_fetch_lock(*key):
+        outer_record = cm._held_fetch_locks[key]
+        try:
+            with pytest.raises(RuntimeError, match="body failure"):
+                async with cm._acquire_fetch_lock(*key):
+                    cm._held_fetch_locks.pop(key)
+                    raise RuntimeError("body failure")
+        finally:
+            cm._held_fetch_locks[key] = outer_record
+
+    assert cm._held_fetch_locks == {}
+
+
 def test_read_lockfile_owner_defaults_to_full_context_for_stale_waiting(tmp_path):
     cm = CandlestickManager(
         exchange=FakeExchange(),

--- a/tests/test_config_utils_helpers.py
+++ b/tests/test_config_utils_helpers.py
@@ -1381,6 +1381,34 @@ def _single_line_help(help_text: str) -> str:
     return " ".join(help_text.split())
 
 
+def _assert_help_option_aliases(
+    help_text: str, long_option: str, short_option: str, metavar: str
+) -> None:
+    """Assert argparse exposes both aliases without depending on render order."""
+    normalized = _single_line_help(help_text)
+    long_rendered = f"{long_option} {metavar}"
+    short_rendered = f"{short_option} {metavar}"
+    assert (
+        f"{long_rendered}, {short_rendered}" in normalized
+        or f"{short_rendered}, {long_rendered}" in normalized
+        or f"{long_option}, {short_rendered}" in normalized
+        or f"{short_option}, {long_rendered}" in normalized
+    )
+
+
+@pytest.mark.parametrize(
+    "rendered",
+    [
+        "--symbols CSV_OR_PATH, -s CSV_OR_PATH",
+        "-s CSV_OR_PATH, --symbols CSV_OR_PATH",
+        "--symbols, -s CSV_OR_PATH",
+        "-s, --symbols CSV_OR_PATH",
+    ],
+)
+def test_help_option_alias_assertion_accepts_supported_argparse_orderings(rendered):
+    _assert_help_option_aliases(rendered, "--symbols", "-s", "CSV_OR_PATH")
+
+
 def test_optimize_default_help_groups_common_flags_and_hides_bounds():
     config = get_template_config()
     help_text = _format_parser_help_with_config("optimize", config, help_all=False)
@@ -1388,18 +1416,28 @@ def test_optimize_default_help_groups_common_flags_and_hides_bounds():
     assert "Coin Selection:" in help_text
     assert "Date Range:" in help_text
     assert "Optimizer:" in help_text
-    assert "--symbols CSV_OR_PATH, -s CSV_OR_PATH" in help_text
-    assert "--population-size INT, -ps INT" in help_text
-    assert "--backend BACKEND, -ob BACKEND" in help_text
+    _assert_help_option_aliases(help_text, "--symbols", "-s", "CSV_OR_PATH")
+    _assert_help_option_aliases(help_text, "--population-size", "-ps", "INT")
+    _assert_help_option_aliases(help_text, "--backend", "-ob", "BACKEND")
     assert "--limits JSON_OR_HJSON" in help_text
-    assert "-l SPEC, --limit SPEC" in help_text
+    _assert_help_option_aliases(help_text, "--limit", "-l", "SPEC")
     assert "--clear-limits" in help_text
-    assert "--minimum-coin-age-days FLOAT, -mcad FLOAT" in help_text
-    assert "--hedge-mode Y/N, -hm Y/N" in help_text
-    assert "--market-orders-allowed Y/N, -moa Y/N" in help_text
-    assert "--market-order-near-touch-threshold FLOAT, -montt FLOAT" in help_text
-    assert "--max-realized-loss-pct FLOAT, -mrlp FLOAT" in help_text
-    assert "--pnls-max-lookback-days FLOAT|all, -pmld FLOAT|all" in help_text
+    _assert_help_option_aliases(
+        help_text, "--minimum-coin-age-days", "-mcad", "FLOAT"
+    )
+    _assert_help_option_aliases(help_text, "--hedge-mode", "-hm", "Y/N")
+    _assert_help_option_aliases(
+        help_text, "--market-orders-allowed", "-moa", "Y/N"
+    )
+    _assert_help_option_aliases(
+        help_text, "--market-order-near-touch-threshold", "-montt", "FLOAT"
+    )
+    _assert_help_option_aliases(
+        help_text, "--max-realized-loss-pct", "-mrlp", "FLOAT"
+    )
+    _assert_help_option_aliases(
+        help_text, "--pnls-max-lookback-days", "-pmld", "FLOAT|all"
+    )
     assert "--bot.long.entry_grid_inflation_enabled" not in help_text
     assert "--bot.long.hsl.enabled" not in help_text
     assert "--optimize_population_size" not in help_text
@@ -1418,10 +1456,14 @@ def test_optimize_help_all_shows_hidden_bounds_flags():
         in help_text
     )
     assert "--limits JSON_OR_HJSON" in help_text
-    assert "-l SPEC, --limit SPEC" in help_text
-    assert "--hedge-mode Y/N, -hm Y/N" in help_text
-    assert "--market-order-near-touch-threshold FLOAT, -montt FLOAT" in help_text
-    assert "--max-realized-loss-pct FLOAT, -mrlp FLOAT" in help_text
+    _assert_help_option_aliases(help_text, "--limit", "-l", "SPEC")
+    _assert_help_option_aliases(help_text, "--hedge-mode", "-hm", "Y/N")
+    _assert_help_option_aliases(
+        help_text, "--market-order-near-touch-threshold", "-montt", "FLOAT"
+    )
+    _assert_help_option_aliases(
+        help_text, "--max-realized-loss-pct", "-mrlp", "FLOAT"
+    )
     assert "--bot.long.hsl.enabled Y/N" in help_text
     assert "--bot.short.hsl.enabled Y/N" in help_text
     assert "--bot.long.hsl.orange_tier_mode VALUE" in help_text
@@ -1466,13 +1508,17 @@ def test_live_default_help_shows_curated_groups():
     assert "Coin Selection:" in help_text
     assert "Behavior:" in help_text
     assert "Runtime:" in help_text
-    assert "--symbols CSV_OR_PATH, -s CSV_OR_PATH" in help_text
+    _assert_help_option_aliases(help_text, "--symbols", "-s", "CSV_OR_PATH")
     assert "--ignored-coins CSV_OR_PATH" in help_text
     assert "--minimum-coin-age-days FLOAT" in help_text
     assert "--hedge-mode Y/N" in help_text
-    assert "--market-order-near-touch-threshold FLOAT, -montt FLOAT" in help_text
-    assert "--pnls-max-lookback-days FLOAT|all, -pmld FLOAT|all" in help_text
-    assert "--user VALUE, -u VALUE" in help_text
+    _assert_help_option_aliases(
+        help_text, "--market-order-near-touch-threshold", "-montt", "FLOAT"
+    )
+    _assert_help_option_aliases(
+        help_text, "--pnls-max-lookback-days", "-pmld", "FLOAT|all"
+    )
+    _assert_help_option_aliases(help_text, "--user", "-u", "VALUE")
     assert "--live.auto_gs" not in help_text
     assert "--optimize.iters" not in help_text
 
@@ -1485,14 +1531,24 @@ def test_backtest_default_help_hides_optimize_flags_and_shows_suite_controls():
     assert "Date Range:" in help_text
     assert "Backtest Runtime:" in help_text
     assert "Suite:" in help_text
-    assert "--symbols CSV_OR_PATH, -s CSV_OR_PATH" in help_text
+    _assert_help_option_aliases(help_text, "--symbols", "-s", "CSV_OR_PATH")
     assert "--ignored-coins CSV_OR_PATH" in help_text
-    assert "--minimum-coin-age-days FLOAT, -mcad FLOAT" in help_text
-    assert "--hedge-mode Y/N, -hm Y/N" in help_text
-    assert "--market-orders-allowed Y/N, -moa Y/N" in help_text
-    assert "--market-order-near-touch-threshold FLOAT, -montt FLOAT" in help_text
-    assert "--max-realized-loss-pct FLOAT, -mrlp FLOAT" in help_text
-    assert "--pnls-max-lookback-days FLOAT|all, -pmld FLOAT|all" in help_text
+    _assert_help_option_aliases(
+        help_text, "--minimum-coin-age-days", "-mcad", "FLOAT"
+    )
+    _assert_help_option_aliases(help_text, "--hedge-mode", "-hm", "Y/N")
+    _assert_help_option_aliases(
+        help_text, "--market-orders-allowed", "-moa", "Y/N"
+    )
+    _assert_help_option_aliases(
+        help_text, "--market-order-near-touch-threshold", "-montt", "FLOAT"
+    )
+    _assert_help_option_aliases(
+        help_text, "--max-realized-loss-pct", "-mrlp", "FLOAT"
+    )
+    _assert_help_option_aliases(
+        help_text, "--pnls-max-lookback-days", "-pmld", "FLOAT|all"
+    )
     assert "--aggregate-default MODE" in help_text
     assert "--iters INT, -i INT" not in help_text
 
@@ -1701,7 +1757,9 @@ def test_backtest_default_help_shows_live_near_touch_threshold_override():
     config = get_template_config()
     help_text = _format_parser_help_with_config("backtest", config, help_all=False)
 
-    assert "--market-order-near-touch-threshold FLOAT, -montt FLOAT" in help_text
+    _assert_help_option_aliases(
+        help_text, "--market-order-near-touch-threshold", "-montt", "FLOAT"
+    )
     assert "--maker-fee-override FLOAT" in help_text
     assert "--taker-fee-override FLOAT" in help_text
 

--- a/tests/test_python_support_contract.py
+++ b/tests/test_python_support_contract.py
@@ -1,0 +1,28 @@
+import ast
+from pathlib import Path
+
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+
+def test_setup_python_requires_matches_supported_versions():
+    setup_path = Path(__file__).resolve().parents[1] / "setup.py"
+    tree = ast.parse(setup_path.read_text(encoding="utf-8"))
+    setup_call = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "setup"
+    )
+    python_requires = next(
+        keyword.value.value
+        for keyword in setup_call.keywords
+        if keyword.arg == "python_requires"
+        and isinstance(keyword.value, ast.Constant)
+    )
+    supported = SpecifierSet(python_requires)
+
+    assert Version("3.12") in supported
+    assert Version("3.13") not in supported
+    assert Version("3.14") in supported

--- a/tests/test_python_support_contract.py
+++ b/tests/test_python_support_contract.py
@@ -26,3 +26,4 @@ def test_setup_python_requires_matches_supported_versions():
     assert Version("3.12") in supported
     assert Version("3.13") not in supported
     assert Version("3.14") in supported
+    assert Version("3.15") not in supported


### PR DESCRIPTION
## Summary

- document the supported Python 3.12 and 3.14 contract and explicitly reject Python 3.13 until its
  pinned dependency set is supported
- explain that the Rust extension's default `abi3-py312` feature is the supported Python 3.14 build path
- run CI on both Python 3.12 and 3.14
- make CLI help tests accept both supported argparse alias renderings
- remove the Python 3.14 `return`-inside-`finally` warning without suppressing protected-operation exceptions
- restrict candle fetch-lock reentrancy to the owning asyncio task, so parallel requests sharing
  one manager cannot bypass same-symbol/timeframe serialization
- create virtual environments with the explicitly selected supported interpreter instead of
  assuming a side-by-side install replaced the system `python3`

## Root cause

Python 3.14 support was already implemented through the Rust crate's default `abi3-py312` feature, but installation documentation still described Python 3.12 as the only supported interpreter. The first Python 3.14 CI run successfully built and loaded the Rust extension, then exposed five test assertions which depended on Python 3.12's repeated-metavar help rendering. Python 3.14 renders the same aliases with one shared metavar.

Testing PyO3 with `--no-default-features` is not representative of Passivbot's supported install path because that explicitly disables `abi3-py312`.

The next Python 3.14 run completed 4,664 tests before exposing a timing-dependent candle concurrency
failure. The manager tracked reentrancy only by symbol/timeframe, so another asyncio task could be
mistaken for a nested acquisition by the lock owner. The lock record now carries its owning task;
true nested calls remain reentrant while competing tasks wait.

## Validation

- `pytest -q tests/test_config_utils_helpers.py tests/test_candlestick_manager_locking.py`
- 20 repeated passes of `TestConcurrentAccess::test_parallel_requests_same_symbol`
- direct Python 3.14 assertion of `--symbols, -s CSV_OR_PATH` and `-l, --limit SPEC`
- `python -m compileall -q src tests/test_config_utils_helpers.py tests/test_candlestick_manager_locking.py`
- `PYTHONPATH=src python src/tools/check_ai_docs.py`
- `PYTHONPATH=src python src/tools/generate_live_event_registry.py --check`
- `git diff --check`
