### PR TITLE
Prevent optimizer hangs after worker failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable user-facing changes will be documented in this file.
   or pagination failures propagate instead of returning a partial result as a
   successful refresh.
 
+- Unexpected PyMoo worker failures and process exits now abort optimization visibly instead of
+  leaving the optimizer polling forever for a lost result.
+
 - Live candle orchestration now reads bounded cache-only native 1h EMA carry-forward from the 1h
   index, requires a complete native window, isolates carried values from the active EMA cache, and
   applies the background refresher's surface-count staleness limit using the active live/replay

--- a/src/optimization/backend_shared.py
+++ b/src/optimization/backend_shared.py
@@ -147,10 +147,13 @@ def drain_async_results(
     poll_interval_seconds: float = 0.05,
     on_result: Callable[[Any, Any], None],
     on_interrupt: Callable[[dict], None] | None = None,
+    pending_health_check: Callable[[], None] | None = None,
 ) -> int:
     completed = 0
     try:
         while pending:
+            if pending_health_check is not None:
+                pending_health_check()
             ready = [res for res in pending if res.ready()]
             if not ready:
                 time.sleep(max(0.0, float(poll_interval_seconds)))
@@ -175,6 +178,7 @@ def stream_async_results(
     max_pending: int | None = None,
     poll_interval_seconds: float = 0.05,
     on_interrupt: Callable[[dict], None] | None = None,
+    pending_health_check: Callable[[], None] | None = None,
 ) -> int:
     max_pending = None if max_pending is None else max(1, int(max_pending))
     iterator = iter(items)
@@ -195,6 +199,8 @@ def stream_async_results(
             if not pending:
                 continue
 
+            if pending_health_check is not None:
+                pending_health_check()
             ready = [res for res in pending if res.ready()]
             if not ready:
                 time.sleep(max(0.0, float(poll_interval_seconds)))

--- a/src/optimization/backends/pymoo_backend.py
+++ b/src/optimization/backends/pymoo_backend.py
@@ -190,9 +190,11 @@ def _evaluate_starting_individuals(
         ordered_payload_slots_bytes=approx_object_size(ordered_payloads),
     )
     completed = {"count": 0}
+    workers = runner._capture_pool_workers()
 
     def _on_result(context, payload):
         idx, vector = context
+        runner._raise_if_worker_failure(payload, idx)
         runner._record_result(
             payload.get("evaluation_vector", vector),
             payload.get("metrics") or {},
@@ -222,6 +224,7 @@ def _evaluate_starting_individuals(
         max_pending=max_pending,
         poll_interval_seconds=runner.poll_interval_seconds,
         on_interrupt=_on_interrupt,
+        pending_health_check=lambda: runner._raise_if_pool_workers_exited(workers),
     )
     slim_payloads = [payload for payload in ordered_payloads if payload is not None]
     log_seed_memory(

--- a/src/optimization/problem.py
+++ b/src/optimization/problem.py
@@ -19,6 +19,7 @@ _PYMOO_WORKER_EVALUATOR = None
 _PYMOO_WORKER_OVERRIDES_LIST: list[str] = []
 _PYMOO_WORKER_N_OBJ = 0
 _PYMOO_WORKER_HAS_CONSTRAINTS = False
+_PYMOO_WORKER_FAILURE_KEY = "__passivbot_pymoo_worker_failure__"
 OPTIMIZE_PROFILE_ENV = "PASSIVBOT_OPTIMIZE_PROFILE"
 
 
@@ -98,13 +99,21 @@ def _evaluate_pymoo_worker(
 def _evaluate_pymoo_worker_from_globals(vector: Sequence[float]) -> dict[str, Any]:
     if _PYMOO_WORKER_EVALUATOR is None:
         raise RuntimeError("pymoo worker evaluator not initialized")
-    return _evaluate_pymoo_worker(
-        _PYMOO_WORKER_EVALUATOR,
-        vector,
-        _PYMOO_WORKER_OVERRIDES_LIST,
-        _PYMOO_WORKER_N_OBJ,
-        _PYMOO_WORKER_HAS_CONSTRAINTS,
-    )
+    try:
+        return _evaluate_pymoo_worker(
+            _PYMOO_WORKER_EVALUATOR,
+            vector,
+            _PYMOO_WORKER_OVERRIDES_LIST,
+            _PYMOO_WORKER_N_OBJ,
+            _PYMOO_WORKER_HAS_CONSTRAINTS,
+        )
+    except BaseException as exc:
+        return {
+            _PYMOO_WORKER_FAILURE_KEY: {
+                "type": exc.__class__.__name__,
+                "message": str(exc),
+            }
+        }
 
 
 class PymooEvaluatorAdapter:
@@ -163,6 +172,38 @@ class PymooAsyncRecordingRunner:
         self.overrides_list = list(overrides_list or [])
         self.poll_interval_seconds = max(0.0, float(poll_interval_seconds))
 
+    def _capture_pool_workers(self) -> tuple[Any, ...]:
+        workers = getattr(self.pool, "_pool", ())
+        return tuple(workers or ())
+
+    @staticmethod
+    def _raise_if_pool_workers_exited(workers: Sequence[Any]) -> None:
+        exited = []
+        for worker in workers:
+            try:
+                exitcode = worker.exitcode
+            except Exception:
+                continue
+            if exitcode is not None:
+                exited.append(f"pid={getattr(worker, 'pid', None)} exitcode={exitcode}")
+        if exited:
+            raise RuntimeError(
+                "pymoo worker exited before returning all candidate results; "
+                "pending evaluations cannot be recovered safely "
+                f"({', '.join(exited)})"
+            )
+
+    @staticmethod
+    def _raise_if_worker_failure(payload: dict[str, Any], batch_index: int) -> None:
+        if _PYMOO_WORKER_FAILURE_KEY not in payload:
+            return
+        failure = payload[_PYMOO_WORKER_FAILURE_KEY]
+        raise RuntimeError(
+            "pymoo worker candidate evaluation failed "
+            f"at batch index {batch_index}: {failure.get('type', 'BaseException')}: "
+            f"{failure.get('message', '')}"
+        )
+
     def _record_result(self, vector, metrics) -> None:
         profile_enabled = _optimize_profile_enabled()
         started = time.perf_counter() if profile_enabled else 0.0
@@ -184,6 +225,7 @@ class PymooAsyncRecordingRunner:
 
     def __call__(self, _f, X):
         xs = list(X)
+        workers = self._capture_pool_workers()
         _set_pymoo_worker_globals(
             self.evaluator,
             self.overrides_list,
@@ -201,6 +243,7 @@ class PymooAsyncRecordingRunner:
 
         def _on_result(context, payload):
             idx, x = context
+            self._raise_if_worker_failure(payload, idx)
             self._record_result(
                 payload.get("evaluation_vector", x),
                 payload.get("metrics") or {},
@@ -214,6 +257,7 @@ class PymooAsyncRecordingRunner:
             pending,
             poll_interval_seconds=self.poll_interval_seconds,
             on_result=_on_result,
+            pending_health_check=lambda: self._raise_if_pool_workers_exited(workers),
         )
 
         return [payload for payload in ordered_results if payload is not None]

--- a/tests/optimization/test_problem.py
+++ b/tests/optimization/test_problem.py
@@ -68,6 +68,19 @@ class FakeAsyncPool:
         return FakeAsyncResult(fn(*args))
 
 
+class NeverReadyAsyncResult:
+    def ready(self):
+        return False
+
+
+class DeadWorkerPool:
+    def __init__(self):
+        self._pool = [type("DeadWorker", (), {"pid": 123, "exitcode": -9})()]
+
+    def apply_async(self, fn, args=()):
+        return NeverReadyAsyncResult()
+
+
 class PickleCheckingPool(FakeAsyncPool):
     def apply_async(self, fn, args=()):
         ForkingPickler.dumps((fn, args))
@@ -232,3 +245,51 @@ def test_async_recording_runner_uses_picklable_worker_target():
     assert len(results) == 1
     assert results[0]["F"].tolist() == [-1.5, 0.2]
     assert results[0]["G"].tolist() == [0.3]
+
+
+def test_async_recording_runner_surfaces_base_exception_from_worker():
+    class WorkerPanic(BaseException):
+        pass
+
+    class FailingEvaluator:
+        limit_checks = []
+
+        def evaluate(self, vector, overrides_list):
+            raise WorkerPanic("unexpected rust panic")
+
+    runner = PymooAsyncRecordingRunner(
+        evaluator=FailingEvaluator(),
+        has_constraints=False,
+        n_obj=1,
+        pool=FakeAsyncPool(),
+        recorder=MagicMock(),
+        template={"optimize": {"backend": "pymoo"}},
+        build_config_fn=MagicMock(),
+        overrides_fn=object(),
+    )
+
+    with np.testing.assert_raises_regex(
+        RuntimeError,
+        "batch index 0: WorkerPanic: unexpected rust panic",
+    ):
+        runner(object(), [np.asarray([0.25])])
+
+
+def test_async_recording_runner_fails_when_pool_worker_exits():
+    runner = PymooAsyncRecordingRunner(
+        evaluator=SingleObjectiveEvaluator(),
+        has_constraints=False,
+        n_obj=1,
+        pool=DeadWorkerPool(),
+        recorder=MagicMock(),
+        template={"optimize": {"backend": "pymoo"}},
+        build_config_fn=MagicMock(),
+        overrides_fn=object(),
+        poll_interval_seconds=0.0,
+    )
+
+    with np.testing.assert_raises_regex(
+        RuntimeError,
+        "pymoo worker exited.*pid=123 exitcode=-9",
+    ):
+        runner(object(), [np.asarray([0.25])])


### PR DESCRIPTION
## Summary

- return unexpected `BaseException` failures from PyMoo workers to the parent as a serializable failure envelope
- detect worker process exits while generation and starting-config results are pending
- abort with the failing batch index, exception type/message, or worker PID/exit code instead of polling forever for a lost `AsyncResult`

The balance-depletion trigger observed on the VPS is fixed separately in current `master` by #1391. This PR deliberately keeps unknown candidate/orchestrator failures fatal and adds the independent pool-level defense against another lost worker result.

## Root cause

`multiprocessing.Pool` replaces a worker that exits, but the outstanding `AsyncResult` owned by that worker may never become ready. The optimizer's drain loop therefore had no terminal condition and could poll forever while replacement workers sat idle.

## Validation

- rebuilt and restamped the Rust extension after rebasing onto current `master`; loaded source fingerprint matched exactly
- `PYTHONPATH=src python -m pytest -q tests/optimization` — 309 passed
- bounded real CLI smoke: XMR, Binance public candles, 8 evaluations, population 4, 2 workers — completed, flushed results, closed pool, and shut down cleanly
- `python -m py_compile` on all changed Python/test modules
- `git diff --check origin/master...HEAD`

No private VPS configs, logs, telemetry, or optimization artifacts are included.