### PR TITLE
Recover missing live fill confirmations after restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable user-facing changes will be documented in this file.
   so extreme optimizer candidates terminate normally instead of panicking an optimizer worker.
   Other invalid orchestrator inputs now propagate as backtest errors without unwinding Rust.
 
+- Live fill confirmation now preserves the last successful exchange-refresh timestamp while
+  loading or repairing local fill caches, widens fill-history fetches with bounded backoff when a
+  position remains tied to a stale or mismatched fill, and recognizes an exact full-opening fill
+  even when older truncated history polluted its reconstructed post-fill size. Affected trailing
+  positions remain fail-closed until the refreshed fill evidence matches exchange state.
+
 - Live candle orchestration now reads bounded cache-only native 1h EMA carry-forward from the 1h
   index, requires a complete native window, isolates carried values from the active EMA cache, and
   applies the background refresher's surface-count staleness limit using the active live/replay

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -21,6 +21,16 @@
    or caused the exchange fill. Refresh and deduplication preserve an existing
    provenance record, including the absence of provenance on legacy cache rows.
    Historical rows are never retroactively attributed.
+8. `last_refresh_ms` records a completed exchange fetch, not local cache loading,
+   normalization, or doctor repair. Preserving that distinction ensures the first
+   incremental refresh after restart covers fills which occurred while the bot was
+   offline.
+9. A position whose latest fill identity or reconstructed after-state does not
+   match the authoritative exchange position remains nontradable. Live orchestration
+   retries from the position/fill anchor with bounded in-memory backoff; it may accept
+   an exact full-opening fill whose direction, quantity, and price independently match
+   the whole exchange position even when an older truncated cache polluted the fill's
+   reconstructed `psize`/`pprice`.
 
 ## Runtime Provenance
 

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -1806,8 +1806,18 @@ class FillEventCache:
                 ) from exc
             raise
 
-    def update_metadata_from_events(self, events: Sequence[FillEvent]) -> None:
-        """Update metadata timestamps based on events."""
+    def update_metadata_from_events(
+        self,
+        events: Sequence[FillEvent],
+        *,
+        mark_refreshed: bool = True,
+    ) -> None:
+        """Update cached event bounds and optionally record a remote refresh.
+
+        Loading and normalizing local cache files is not an exchange refresh.
+        Callers doing local-only maintenance must leave ``last_refresh_ms``
+        unchanged so the next incremental fetch still covers bot downtime.
+        """
         if not events:
             return
 
@@ -1824,7 +1834,10 @@ class FillEventCache:
         if newest > current_newest:
             metadata["newest_event_ts"] = newest
 
-        metadata["last_refresh_ms"] = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+        if mark_refreshed:
+            metadata["last_refresh_ms"] = int(
+                datetime.now(tz=timezone.utc).timestamp() * 1000
+            )
         metadata["pnl_contract"] = PNL_CONTRACT_CURRENT
         self.save_metadata(metadata)
 
@@ -3474,7 +3487,9 @@ class FillEventsManager:
                 if normalized_days:
                     self.cache.save_days(self._events_for_days(self._events, normalized_days))
                 if synthesized_days or normalized_days:
-                    self.cache.update_metadata_from_events(self._events)
+                    self.cache.update_metadata_from_events(
+                        self._events, mark_refreshed=False
+                    )
 
             logger.debug(
                 "[fills] ensure_loaded: %d cached events (dropped %d without raw)",
@@ -4112,7 +4127,9 @@ class FillEventsManager:
         legacy_contract = metadata_legacy or record_legacy
         report["legacy_contract"] = legacy_contract
         if metadata_legacy and not record_legacy and auto_repair:
-            self.cache.update_metadata_from_events(self._events)
+            self.cache.update_metadata_from_events(
+                self._events, mark_refreshed=False
+            )
             report["repaired"] = True
             report["anomaly_events_after"] = 0
             report["anomaly_examples_after"] = []
@@ -4188,7 +4205,9 @@ class FillEventsManager:
         report["anomaly_examples"] = anomalies[:5]
         if not anomalies or not auto_repair:
             if legacy_contract and auto_repair and not record_legacy:
-                self.cache.update_metadata_from_events(self._events)
+                self.cache.update_metadata_from_events(
+                    self._events, mark_refreshed=False
+                )
                 report["repaired"] = True
                 report["anomaly_events_after"] = 0
                 report["anomaly_examples_after"] = []
@@ -4248,7 +4267,9 @@ class FillEventsManager:
         apply_hyperliquid_raw_psize_overrides(payload)
         self._events = [FillEvent.from_dict(ev) for ev in payload]
         self.cache.save(self._events)
-        self.cache.update_metadata_from_events(self._events)
+        self.cache.update_metadata_from_events(
+            self._events, mark_refreshed=False
+        )
 
         remaining = self._scan_bybit_qty_inflation(self._events)
         report["anomaly_events_after"] = len(remaining)
@@ -4394,7 +4415,9 @@ class FillEventsManager:
         compute_psize_pprice(repaired_payload)
         self._events = [FillEvent.from_dict(ev) for ev in repaired_payload]
         self.cache.save(self._events)
-        self.cache.update_metadata_from_events(self._events)
+        self.cache.update_metadata_from_events(
+            self._events, mark_refreshed=False
+        )
         report["backup_path"] = backup_path
         report["degraded_events_after"] = degraded_count
         report["anomaly_events_after"] = degraded_count

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -8327,29 +8327,31 @@ class Passivbot:
                     "timestamp": int(event.timestamp),
                     "epoch": self._fill_position_change_epoch(event, event_index),
                 }
-                for field in ("psize", "pprice"):
+                for field in ("psize", "pprice", "qty", "price", "c_mult"):
                     try:
                         value = float(getattr(event, field))
                     except (AttributeError, TypeError, ValueError, OverflowError):
                         continue
                     if math.isfinite(value):
                         anchor[field] = value
+                side = str(getattr(event, "side", "") or "").lower()
+                if side:
+                    anchor["side"] = side
                 anchors[key] = anchor
         return anchors
 
     def _fill_anchor_matches_position_state(
-        self, symbol: str, state: tuple[float, float], anchor: dict | None
+        self,
+        symbol: str,
+        pside: str,
+        state: tuple[float, float],
+        anchor: dict | None,
     ) -> bool:
         """Whether a fill's recorded after-state matches an exchange position."""
-        if anchor is None or "psize" not in anchor or "pprice" not in anchor:
+        if anchor is None:
             return False
         position_size, position_price = state
-        fill_size = abs(float(anchor["psize"]))
-        fill_price = float(anchor["pprice"])
-        if not all(
-            math.isfinite(value)
-            for value in (position_size, position_price, fill_size, fill_price)
-        ):
+        if not all(math.isfinite(value) for value in (position_size, position_price)):
             return False
         qty_step = abs(float(getattr(self, "qty_steps", {}).get(symbol, 0.0) or 0.0))
         price_step = abs(
@@ -8359,9 +8361,42 @@ class Passivbot:
         position_size_in_fill_units = abs(position_size) * c_mult
         qty_tolerance = max(qty_step * c_mult * 0.5, 1e-12)
         price_tolerance = max(price_step * 0.5, abs(position_price) * 1e-9, 1e-12)
-        return abs(fill_size - position_size_in_fill_units) <= qty_tolerance and abs(
-            fill_price - position_price
-        ) <= price_tolerance
+        if "psize" in anchor and "pprice" in anchor:
+            fill_size = abs(float(anchor["psize"]))
+            fill_price = float(anchor["pprice"])
+            if (
+                math.isfinite(fill_size)
+                and math.isfinite(fill_price)
+                and abs(fill_size - position_size_in_fill_units) <= qty_tolerance
+                and abs(fill_price - position_price) <= price_tolerance
+            ):
+                return True
+
+        # A cache whose retained history starts mid-position can carry a
+        # phantom reconstructed psize into every later fill.  The latest fill
+        # itself still proves a flat-to-position transition when its direction,
+        # entire quantity, and price exactly match the authoritative exchange
+        # position.  This narrow proof does not accept partial entries, DCA, or
+        # a mismatched average price.
+        required = ("qty", "price", "side")
+        if not all(field in anchor for field in required):
+            return False
+        fill_side = str(anchor["side"]).lower()
+        opening_side = "buy" if str(pside).lower() == "long" else "sell"
+        if fill_side != opening_side:
+            return False
+        try:
+            anchor_c_mult = abs(float(anchor.get("c_mult", c_mult) or c_mult))
+            opening_qty = abs(float(anchor["qty"])) * anchor_c_mult
+            opening_price = float(anchor["price"])
+        except (TypeError, ValueError, OverflowError):
+            return False
+        return (
+            math.isfinite(opening_qty)
+            and math.isfinite(opening_price)
+            and abs(opening_qty - position_size_in_fill_units) <= qty_tolerance
+            and abs(opening_price - position_price) <= price_tolerance
+        )
 
     def _latest_fill_position_change_epochs(self) -> dict[tuple[str, str], str]:
         """Return the newest known fill identity for each symbol and position side."""
@@ -8540,7 +8575,7 @@ class Passivbot:
                         and current_epoch.startswith("fill:")
                         and expected_position_state is not None
                         and not self._fill_anchor_matches_position_state(
-                            symbol, expected_position_state, anchor
+                            symbol, pside, expected_position_state, anchor
                         )
                     ):
                         failed_predicates.append("fill_after_state_mismatch")
@@ -8597,6 +8632,8 @@ class Passivbot:
         self._trailing_pending_position_states = pending_position_states
         self._trailing_position_snapshot_fill_epochs = associated_fill_epochs
         self._trailing_fill_confirmation_diagnostics = confirmation_diagnostics
+        if not confirmation_diagnostics:
+            self._trailing_fill_history_recovery_state = {}
 
         # Build concurrent fetches per symbol that has position changes
         fetch_plan = {}
@@ -11464,6 +11501,89 @@ class Passivbot:
                 since_ms=since_ms,
             )
 
+    def _trailing_fill_history_recovery_start_ms(
+        self, age_limit: int | None
+    ) -> int | None:
+        """Return a bounded refetch start for unresolved position/fill state.
+
+        Routine confirmation refreshes intentionally cover only recent fills.
+        If that leaves a position tied to a stale or mismatched fill, retry from
+        the exchange-reported position anchor (or the stale fill itself) with
+        an in-memory exponential backoff.  The affected position remains
+        nontradable until normal confirmation succeeds.
+        """
+        diagnostics = dict(
+            getattr(self, "_trailing_fill_confirmation_diagnostics", {}) or {}
+        )
+        recoverable_predicates = {
+            "missing_fill_anchor",
+            "non_fill_anchor",
+            "fill_identity_unchanged",
+            "fill_after_state_mismatch",
+        }
+        candidates: list[int] = []
+        cohorts: list[tuple[str, str]] = []
+        for raw_key, detail in diagnostics.items():
+            if not isinstance(raw_key, tuple) or len(raw_key) != 2:
+                continue
+            if not isinstance(detail, dict):
+                continue
+            failed = set(detail.get("failed_predicates") or [])
+            if not failed.intersection(recoverable_predicates):
+                continue
+            symbol, pside = str(raw_key[0]), str(raw_key[1])
+            anchor_ts = self._position_anchor_timestamp_ms(symbol, pside)
+            if anchor_ts is None:
+                try:
+                    anchor_ts = int(detail.get("fill_timestamp_ms") or 0) or None
+                except (TypeError, ValueError, OverflowError):
+                    anchor_ts = None
+            if anchor_ts is None:
+                continue
+            candidates.append(max(0, int(anchor_ts) - 5 * ONE_MIN_MS))
+            cohorts.append((symbol, pside))
+        if not candidates:
+            return None
+
+        start_ms = min(candidates)
+        if age_limit is not None:
+            start_ms = max(int(age_limit), start_ms)
+        recovery_key = (tuple(sorted(cohorts)), int(start_ms))
+        now_ms = utc_ms()
+        state = dict(
+            getattr(self, "_trailing_fill_history_recovery_state", {}) or {}
+        )
+        if state.get("key") == recovery_key and now_ms < int(
+            state.get("next_retry_ms", 0) or 0
+        ):
+            return None
+
+        retry_count = (
+            int(state.get("retry_count", 0) or 0) + 1
+            if state.get("key") == recovery_key
+            else 1
+        )
+        delay_ms = min(
+            60 * ONE_MIN_MS,
+            5 * ONE_MIN_MS * (2 ** min(retry_count - 1, 4)),
+        )
+        self._trailing_fill_history_recovery_state = {
+            "key": recovery_key,
+            "retry_count": retry_count,
+            "last_attempt_ms": now_ms,
+            "next_retry_ms": now_ms + delay_ms,
+        }
+        logging.warning(
+            "[fills] widening refresh for unresolved position/fill confirmation | "
+            "cohorts=%s start=%s retry=%d next_retry_minutes=%.1f "
+            "action=refetch_then_keep_nontradable_until_confirmed",
+            ",".join(f"{symbol}:{pside}" for symbol, pside in sorted(cohorts)),
+            ts_to_date(start_ms)[:19],
+            retry_count,
+            delay_ms / ONE_MIN_MS,
+        )
+        return start_ms
+
     async def _update_pnls_locked(
         self,
         *,
@@ -11652,6 +11772,11 @@ class Passivbot:
                         end_ms=None,
                     )
                 else:
+                    recovery_start_ms = (
+                        self._trailing_fill_history_recovery_start_ms(age_limit)
+                        if confirmation_refresh
+                        else None
+                    )
                     overlap_minutes_key = (
                         "fills_confirmation_overlap_minutes"
                         if confirmation_refresh
@@ -11665,10 +11790,17 @@ class Passivbot:
                         )
                     )
                     overlap_minutes = max(0.0, overlap_minutes)
-                    await self._pnls_manager.refresh_latest(
-                        overlap=20,
-                        last_refresh_overlap_ms=int(overlap_minutes * 60 * 1000),
-                    )
+                    if recovery_start_ms is not None:
+                        refresh_mode = "trailing_confirmation_recovery"
+                        await self._pnls_manager.refresh(
+                            start_ms=int(recovery_start_ms),
+                            end_ms=None,
+                        )
+                    else:
+                        await self._pnls_manager.refresh_latest(
+                            overlap=20,
+                            last_refresh_overlap_ms=int(overlap_minutes * 60 * 1000),
+                        )
                 fill_fetch_completed = True
 
             # Find and log new events (those not in cache before refresh)
@@ -11745,7 +11877,13 @@ class Passivbot:
                 )
             elapsed_ms = int(max(0, utc_ms() - refresh_started_ms))
             blocking_or_confirmation_refresh = (
-                refresh_mode in {"full", "lookback_bootstrap", "incremental_confirm"}
+                refresh_mode
+                in {
+                    "full",
+                    "lookback_bootstrap",
+                    "incremental_confirm",
+                    "trailing_confirmation_recovery",
+                }
                 or "confirm" in str(source)
                 or "staged" in str(source)
             )

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -4825,6 +4825,39 @@ async def test_manager_refresh_records_successful_empty_refresh(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_manager_cache_load_does_not_advance_last_exchange_refresh(
+    tmp_path: Path, sample_events
+):
+    cache_dir = tmp_path / "fills_local_load_preserves_refresh"
+    cached = [FillEvent.from_dict(dict(event)) for event in sample_events]
+    cache = FillEventCache(cache_dir)
+    cache.save(cached)
+    previous_refresh_ms = sample_events[-1]["timestamp"] + 60_000
+    cache.save_metadata(
+        {
+            "last_refresh_ms": previous_refresh_ms,
+            "oldest_event_ts": sample_events[0]["timestamp"],
+            "newest_event_ts": sample_events[-1]["timestamp"],
+            "covered_start_ms": sample_events[0]["timestamp"],
+            "known_gaps": [],
+            "history_scope": "window",
+            "pnl_contract": fem.PNL_CONTRACT_CURRENT,
+        }
+    )
+    fetcher = _StaticFetcher([])
+    manager = FillEventsManager(
+        exchange="bitget",
+        user="default",
+        fetcher=fetcher,
+        cache_path=cache_dir,
+    )
+
+    await manager.ensure_loaded()
+
+    assert manager.cache.load_metadata()["last_refresh_ms"] == previous_refresh_ms
+
+
+@pytest.mark.asyncio
 async def test_manager_refresh_logs_slow_successful_fetcher_request_timing_at_debug(
     tmp_path: Path, caplog, monkeypatch
 ):

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -6354,6 +6354,85 @@ async def test_update_pnls_uses_confirmation_overlap_when_fills_pending():
 
 
 @pytest.mark.asyncio
+async def test_update_pnls_widens_refresh_for_mismatched_trailing_fill_anchor(
+    monkeypatch,
+):
+    bot = Passivbot.__new__(Passivbot)
+    now_ms = 1_800_000_000_000
+    position_anchor_ms = now_ms - 2 * 60 * 60 * 1000
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: now_ms)
+    symbol = "WLD/USDT:USDT"
+    cached_events = [
+        SimpleNamespace(
+            timestamp=position_anchor_ms - 24 * 60 * 60 * 1000,
+            id="stale-close",
+            source_ids=["stale-close"],
+        )
+    ]
+
+    class _Manager:
+        def __init__(self):
+            self._events = list(cached_events)
+            self.refresh = AsyncMock()
+            self.refresh_latest = AsyncMock()
+
+        def get_events(self):
+            return list(self._events)
+
+        def get_history_scope(self):
+            return "all"
+
+        def set_history_scope(self, scope):
+            pass
+
+    bot.stop_signal_received = False
+    bot.config = {
+        "live": {
+            "fills_confirmation_overlap_minutes": 60.0,
+            "fills_recent_overlap_minutes": 10.0,
+            "pnls_max_lookback_days": "all",
+        }
+    }
+    bot.positions = {
+        symbol: {
+            "long": {
+                "size": 165.0,
+                "price": 0.3896,
+                "timestamp": position_anchor_ms,
+            }
+        }
+    }
+    bot._trailing_fill_confirmation_diagnostics = {
+        (symbol, "long"): {
+            "failed_predicates": ["fill_after_state_mismatch"],
+            "fill_timestamp_ms": cached_events[0].timestamp,
+        }
+    }
+    bot._authoritative_pending_confirmations = {"fills": 2}
+    bot._pnls_manager = _Manager()
+    bot.init_pnls = AsyncMock()
+    bot.live_value = lambda key: bot.config["live"][key]
+    bot.get_exchange_time = lambda: now_ms
+    bot._log_new_fill_events = lambda new_events: None
+    bot._monitor_record_event = lambda *args, **kwargs: None
+    bot._monitor_record_error = lambda *args, **kwargs: None
+    bot.logging_level = 0
+    bot._health_rate_limits = 0
+
+    result = await bot.update_pnls()
+
+    assert result is True
+    bot._pnls_manager.refresh.assert_awaited_once_with(
+        start_ms=position_anchor_ms - 5 * 60 * 1000,
+        end_ms=None,
+    )
+    bot._pnls_manager.refresh_latest.assert_not_awaited()
+    state = bot._trailing_fill_history_recovery_state
+    assert state["retry_count"] == 1
+    assert state["next_retry_ms"] == now_ms + 5 * 60 * 1000
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("shutdown_requested", [False, True])
 async def test_update_pnls_propagates_unexpected_refresh_errors_without_retaining_text(
     caplog, capsys, shutdown_requested

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -839,6 +839,10 @@ class _DummyFillEvent:
         pb_order_type: str = "unknown",
         psize: float | None = None,
         pprice: float | None = None,
+        side: str | None = None,
+        qty: float | None = None,
+        price: float | None = None,
+        c_mult: float | None = None,
     ):
         self.symbol = symbol
         self.position_side = position_side
@@ -849,6 +853,14 @@ class _DummyFillEvent:
             self.psize = psize
         if pprice is not None:
             self.pprice = pprice
+        if side is not None:
+            self.side = side
+        if qty is not None:
+            self.qty = qty
+        if price is not None:
+            self.price = price
+        if c_mult is not None:
+            self.c_mult = c_mult
 
 
 class _DummyPnlsManager:
@@ -1483,10 +1495,16 @@ async def test_fill_prefetch_before_position_delta_waits_for_post_snapshot_refre
         "failed_predicates"
     ] == ["post_snapshot_fill_refresh_pending"]
 
+    bot._trailing_fill_history_recovery_state = {
+        "key": (((symbol, "long"),), 120_000),
+        "retry_count": 3,
+        "next_retry_ms": 1_800_000_000_000,
+    }
     bot._trailing_fill_fetch_generation = 1
     await bot.update_trailing_data()
 
     assert bot._trailing_pending_fill_confirmations == {}
+    assert bot._trailing_fill_history_recovery_state == {}
     assert bot._orchestrator_trailing_unavailable_symbols == set()
     assert bot.trailing_prices[symbol]["long"]["max_since_open"] == pytest.approx(
         103.0
@@ -1591,6 +1609,30 @@ def test_restart_without_update_timestamp_requires_matching_fill_after_state():
         (symbol, "long"): (1.0, 101.0)
     }
     assert "fills" in bot._authoritative_pending_confirmations
+
+
+def test_full_opening_fill_matches_position_despite_truncated_cache_psize():
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    anchor = {
+        "psize": 5.01,
+        "pprice": 63.8149,
+        "side": "buy",
+        "qty": 1.1,
+        "price": 58.717,
+        "c_mult": 1.0,
+    }
+
+    assert bot._fill_anchor_matches_position_state(
+        symbol, "long", (1.1, 58.717), anchor
+    )
+    assert not bot._fill_anchor_matches_position_state(
+        symbol, "long", (1.2, 58.717), anchor
+    )
+    assert not bot._fill_anchor_matches_position_state(
+        symbol, "short", (1.1, 58.717), anchor
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- preserve `last_refresh_ms` as the timestamp of an actual exchange fetch instead of advancing it during local cache loading, normalization, or doctor repair
- widen trailing fill-confirmation refreshes back to the authoritative position/fill anchor with bounded in-memory retry backoff when recent overlap cannot confirm the position
- accept a narrowly proven full-opening fill when truncated older cache history polluted reconstructed `psize`/`pprice`
- keep affected trailing positions nontradable until the normal fill-confirmation predicates pass

## Root cause

Two restart recovery paths could leave valid live positions permanently unconfirmed:

1. Loading a local fill cache advanced `last_refresh_ms` before any exchange request, so the first incremental refresh could skip fills which occurred while the bot was offline.
2. A retained history window beginning mid-position could carry a phantom reconstructed position into later fills, making the latest fill's cached after-state disagree with the authoritative exchange position even when that fill exactly opened the whole current position.

The recovery fetch is targeted and RAM-only. It retries from five minutes before the affected position/fill anchor with 5, 10, 20, 40, then 60 minute backoff, capped by the configured fill-history lookback. It does not relax the fail-closed trading gate.

## Validation

- `python -m compileall -q src tests/test_fill_events_manager.py tests/test_unstucking_safeguards.py tests/test_passivbot_balance_split.py`
- `python -m pytest -q tests/test_fill_events_manager.py tests/test_unstucking_safeguards.py tests/test_passivbot_balance_split.py`
- `git diff --check origin/master...HEAD`

