### PR TITLE
Fix gaps in Bybit closed PnL pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable user-facing changes will be documented in this file.
   so extreme optimizer candidates terminate normally instead of panicking an optimizer worker.
   Other invalid orchestrator inputs now propagate as backtest errors without unwinding Rust.
 
+- Bybit closed-PnL refreshes now cover requested history with explicit,
+  contiguous sub-seven-day windows and cursor pagination inside each window.
+  Sparse pages no longer create gaps in older realized-PnL history, and endpoint
+  or pagination failures propagate instead of returning a partial result as a
+  successful refresh.
+
 - Live candle orchestration now reads bounded cache-only native 1h EMA carry-forward from the 1h
   index, requires a complete native window, isolates carried values from the active EMA cache, and
   applies the background refresher's surface-count staleness limit using the active live/replay

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -60,13 +60,20 @@ Handling:
 
 Problem:
 
-1. Cursor pagination has limited historical reach.
-2. Time-based pagination can skip records when windows exceed page limits.
+1. Supplying only `endTime` makes Bybit search the preceding seven days.
+2. Deriving the next window from a sparse page's oldest row can skip records
+   between that row and the current window boundary.
+3. A time window may still contain more than one page.
 
 Handling in Passivbot:
 
-1. Use hybrid pagination (cursor for recent, time-window for older).
-2. Deduplicate by `orderId`.
+1. Partition the requested range into explicit contiguous windows shorter than
+   seven days, passing both `startTime` and `endTime`.
+2. Cursor-paginate each window to exhaustion before moving to the next older
+   window.
+3. Deduplicate by `orderId`.
+4. Propagate endpoint and pagination-progress failures; incomplete closed-PnL
+   history must not be treated as a successful fetch.
 
 Primary reference: `src/fill_events_manager.py` (`BybitFetcher._fetch_positions_history`).
 

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -40,7 +40,7 @@ logs, runtime windows, and immutable manifests.
 | Exchange | Primary Fills Source | PnL/Close Source |
 |----------|----------------------|------------------|
 | Binance | `fetch_my_trades` | income history |
-| Bybit | `fetch_my_trades` | closed-pnl (hybrid pagination) |
+| Bybit | `fetch_my_trades` | closed-pnl (explicit time windows + cursor pagination) |
 | Bitget | `fetch_my_trades` | embedded in trade payload |
 | Hyperliquid | fill events | embedded |
 | OKX | `fetch_my_trades` | positions history |
@@ -51,7 +51,10 @@ logs, runtime windows, and immutable manifests.
 ## Non-Obvious Details
 
 1. Exchanges split fill/PnL data across different endpoints.
-2. Bybit requires hybrid pagination for better closed-PnL completeness.
+2. Bybit closed-PnL history is fetched in contiguous windows shorter than the
+   endpoint's seven-day maximum. Every window is cursor-paginated to exhaustion
+   before moving to the next older window; sparse pages do not determine window
+   boundaries.
 3. Historical retention limits can make old PnL records unavailable.
 4. WEEX trade-detail queries are limited to 100 rows and seven days per request,
    with up to 365 days of retention; its client order id may require an order-detail lookup.

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -5289,107 +5289,57 @@ class BybitFetcher(BaseFetcher):
         return deduped
 
     async def _fetch_positions_history(self, start_ms: int, end_ms: int) -> List[Dict[str, object]]:
-        """Fetch closed-pnl records using Bybit's raw API with hybrid pagination.
+        """Fetch closed-PnL records in explicit contiguous time windows.
 
-        Uses a two-phase approach:
-        1. Cursor pagination for recent records (more efficient, no missed records)
-        2. Time-based sliding window for older records (cursor doesn't go back far enough)
-
-        This is necessary because:
-        - CCXT's fetch_positions_history uses time-based pagination which can miss records
-        - Bybit's cursor pagination only covers ~7 days of recent data
+        Bybit implicitly searches only ``endTime - 7 days`` when ``endTime`` is
+        supplied without ``startTime``.  Each explicit window is therefore
+        bounded below the seven-day limit and fully cursor-paginated before the
+        next older window begins.
         """
         results: Dict[str, Dict[str, object]] = {}  # Dedupe by orderId
         max_fetches = 500
         fetch_count = 0
-
-        # Phase 1: Use cursor pagination for recent records
-        params: Dict[str, object] = {
-            "category": "linear",
-            "limit": self.position_limit,
-            "endTime": int(end_ms),
-        }
-
-        cursor_oldest_ts = end_ms
-
-        while True:
-            fetch_count += 1
-            if fetch_count > max_fetches:
-                logger.warning(
-                    "BybitFetcher._fetch_positions_history: max fetches reached (%d)", max_fetches
-                )
-                break
-
-            try:
-                response = await self.api.private_get_v5_position_closed_pnl(params)
-            except Exception as exc:
-                logger.warning(
-                    "BybitFetcher._fetch_positions_history: API error_type=%s",
-                    bounded_exception_type(exc),
-                )
-                break
-
-            batch = response.get("result", {}).get("list", [])
-            if not batch:
-                break
-
-            self._process_closed_pnl_batch(batch, start_ms, results)
-
-            oldest_ts = int(batch[-1].get("updatedTime", 0)) if batch else 0
-            cursor_oldest_ts = oldest_ts
-
-            if oldest_ts <= start_ms:
-                break
-
-            cursor = response.get("result", {}).get("nextPageCursor")
-            if not cursor:
-                # Cursor exhausted - switch to time-based sliding window
-                break
-            params["cursor"] = cursor
-
-        # Phase 2: Time-based sliding window for older records (if cursor didn't reach start)
-        if cursor_oldest_ts > start_ms:
-            logger.debug(
-                "BybitFetcher._fetch_positions_history: cursor exhausted at %s, switching to time-based",
-                _format_ms(cursor_oldest_ts),
-            )
-            # Remove cursor and continue with time-based pagination
-            current_end = cursor_oldest_ts
-
-            while current_end > start_ms and fetch_count < max_fetches:
-                fetch_count += 1
-                params = {
+        current_end = int(end_ms)
+        while current_end >= start_ms:
+            window_start = max(int(start_ms), current_end - self._max_span_ms)
+            cursor: str | None = None
+            seen_cursors: set[str] = set()
+            while True:
+                if fetch_count >= max_fetches:
+                    raise RuntimeError(
+                        "BybitFetcher._fetch_positions_history: "
+                        f"max fetches reached ({max_fetches})"
+                    )
+                params: Dict[str, object] = {
                     "category": "linear",
                     "limit": self.position_limit,
+                    "startTime": int(window_start),
                     "endTime": int(current_end),
                 }
+                if cursor is not None:
+                    params["cursor"] = cursor
+                fetch_count += 1
+                response = await self.api.private_get_v5_position_closed_pnl(params)
+                result = response.get("result", {})
+                batch = result.get("list", [])
+                if batch:
+                    self._process_closed_pnl_batch(batch, start_ms, results)
 
-                try:
-                    response = await self.api.private_get_v5_position_closed_pnl(params)
-                except Exception as exc:
-                    logger.warning(
-                        "BybitFetcher._fetch_positions_history: API error_type=%s",
-                        bounded_exception_type(exc),
+                next_cursor = str(result.get("nextPageCursor") or "")
+                if not next_cursor:
+                    break
+                if next_cursor in seen_cursors:
+                    raise RuntimeError(
+                        "BybitFetcher._fetch_positions_history: "
+                        f"repeated cursor in window {_format_ms(window_start)}.."
+                        f"{_format_ms(current_end)}"
                     )
-                    break
+                seen_cursors.add(next_cursor)
+                cursor = next_cursor
 
-                batch = response.get("result", {}).get("list", [])
-                if not batch:
-                    # No more records, slide window back
-                    current_end = max(start_ms, current_end - self._max_span_ms)
-                    continue
-
-                self._process_closed_pnl_batch(batch, start_ms, results)
-
-                oldest_ts = int(batch[-1].get("updatedTime", 0)) if batch else 0
-                if oldest_ts <= start_ms:
-                    break
-
-                # Slide window: if batch was full, use oldest ts; otherwise jump back
-                if len(batch) >= self.position_limit:
-                    current_end = oldest_ts
-                else:
-                    current_end = max(start_ms, oldest_ts - self._max_span_ms)
+            if window_start <= start_ms:
+                break
+            current_end = window_start - 1
 
         logger.debug(
             "BybitFetcher._fetch_positions_history: fetched %d records in %d requests",

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -2950,6 +2950,95 @@ async def test_bybit_fetcher_merges_pnl_and_batches(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_bybit_closed_pnl_uses_contiguous_cursor_paginated_windows():
+    day_ms = 24 * 60 * 60 * 1000
+    end_ms = 2_000_000_000_000
+    start_ms = end_ms - 14 * day_ms
+
+    def record(order_id: str, timestamp: int) -> Dict[str, object]:
+        return {
+            "symbol": "XMRUSDT",
+            "orderId": order_id,
+            "side": "Sell",
+            "closedPnl": "1.0",
+            "closedSize": "0.1",
+            "avgEntryPrice": "300.0",
+            "avgExitPrice": "310.0",
+            "updatedTime": str(timestamp),
+            "createdTime": str(timestamp),
+            "leverage": "1",
+        }
+
+    class _WindowedBybitAPI:
+        markets = {}
+
+        def __init__(self):
+            self.calls: List[Dict[str, object]] = []
+            self.responses = [
+                {
+                    "result": {
+                        "list": [record("recent-1", end_ms - day_ms)],
+                        "nextPageCursor": "recent-page-2",
+                    }
+                },
+                {
+                    "result": {
+                        "list": [record("recent-2", end_ms - 2 * day_ms)],
+                        "nextPageCursor": "",
+                    }
+                },
+                {"result": {"list": [], "nextPageCursor": ""}},
+                {
+                    "result": {
+                        "list": [record("old-sparse", start_ms + day_ms)],
+                        "nextPageCursor": "",
+                    }
+                },
+            ]
+
+        async def private_get_v5_position_closed_pnl(self, params):
+            self.calls.append(dict(params))
+            return self.responses.pop(0)
+
+    api = _WindowedBybitAPI()
+    fetcher = BybitFetcher(api, max_span_days=6.5)
+
+    positions = await fetcher._fetch_positions_history(start_ms, end_ms)
+
+    assert {row["info"]["orderId"] for row in positions} == {
+        "recent-1",
+        "recent-2",
+        "old-sparse",
+    }
+    assert len(api.calls) == 4
+    assert api.calls[1]["cursor"] == "recent-page-2"
+    assert api.calls[1]["startTime"] == api.calls[0]["startTime"]
+    assert api.calls[1]["endTime"] == api.calls[0]["endTime"]
+    window_calls = [api.calls[0], api.calls[2], api.calls[3]]
+    assert window_calls[1]["endTime"] == window_calls[0]["startTime"] - 1
+    assert window_calls[2]["endTime"] == window_calls[1]["startTime"] - 1
+    assert window_calls[-1]["startTime"] == start_ms
+    assert all(
+        call["endTime"] - call["startTime"] <= fetcher._max_span_ms
+        for call in window_calls
+    )
+
+
+@pytest.mark.asyncio
+async def test_bybit_closed_pnl_fetch_propagates_api_error():
+    api = types.SimpleNamespace(
+        markets={},
+        private_get_v5_position_closed_pnl=AsyncMock(
+            side_effect=RuntimeError("closed-pnl unavailable")
+        ),
+    )
+    fetcher = BybitFetcher(api)
+
+    with pytest.raises(RuntimeError, match="closed-pnl unavailable"):
+        await fetcher._fetch_positions_history(1_900_000_000_000, 1_900_000_060_000)
+
+
+@pytest.mark.asyncio
 async def test_bybit_fetcher_uses_detail_cache(monkeypatch):
     base_ts = int(datetime.now(timezone.utc).timestamp() * 1000)
     trades_batches = [


### PR DESCRIPTION
## Summary

- fetch Bybit closed-PnL history in explicit contiguous windows shorter than seven days
- cursor-paginate every window to exhaustion before moving to the next older window
- reject repeated cursors and propagate endpoint/pagination failures rather than returning partial history as successful
- document the endpoint contract and add sparse-window/cursor regression coverage

## Root cause

Bybit searches only `endTime - 7 days` when a request supplies `endTime` without `startTime`. The old fallback derived its next `endTime` from the oldest row in a sparse page, then subtracted another 6.5 days. That skipped the interval between the request's implicit seven-day lower boundary and the derived next window.

Missing closed-PnL rows left corresponding close fills synthetic/degraded, which correctly caused Passivbot's realized-PnL safeguards to stop the affected bot. Explicit contiguous windows remove the gap while retaining order-ID deduplication.

Official endpoint contract: https://bybit-exchange.github.io/docs/v5/position/close-pnl

## Validation

- `python -m compileall -q src tests/test_fill_events_manager.py`
- `python -m pytest -q tests/test_fill_events_manager.py tests/test_passivbot_balance_split.py tests/test_unstucking_safeguards.py`
- `git diff --check origin/master...HEAD`

