### PR TITLE
Fix degraded PnL cache recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ All notable user-facing changes will be documented in this file.
 
 - Live fill recovery now performs bounded historical refetches around degraded
   synthetic realized-PnL rows even when cache metadata already proves the configured
-  lookback. Authoritative replacements are reported as enrichment, health PnL changes
-  only by the replacement delta, and unresolved degraded rows defer risk planning with
-  exponential backoff instead of consuming the generic bot restart budget.
+  lookback. Repair-only fetches preserve the incremental checkpoint and rotate through
+  at most four disjoint ranges per authoritative cycle. Authoritative replacements are
+  reported as enrichment; uptime health adds the full authoritative PnL for cached rows
+  not previously counted by this process and applies only the replacement delta for
+  runtime-counted rows. Unresolved degraded rows defer risk planning with exponential
+  backoff instead of consuming the generic bot restart budget.
 
 - Documented Python 3.12 and 3.14 support, explicitly excluding Python 3.13 until its dependency
   set is supported and bounding package metadata to those validated minor versions, and fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ All notable user-facing changes will be documented in this file.
   fallible refresh work; uptime health adds the full authoritative PnL for cached rows
   not previously counted by this process and applies a delta against the exact synthetic
   amount counted at runtime. Outstanding synthetic accounting is discarded after
-  enrichment. Unresolved degraded rows defer risk planning with exponential backoff
-  instead of consuming the generic bot restart budget.
+  enrichment. Unresolved degraded rows defer risk planning with exponential backoff,
+  retain pending/degraded PnL counts in structured cycle diagnostics, and do not consume
+  the generic bot restart budget.
 
 - WEEX REST and private WebSocket clients now use IPv4 transport so API keys
   bound to the host's public IPv4 address do not fail with `-1056 ILLEGAL_IP`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ All notable user-facing changes will be documented in this file.
 - Live fill recovery now performs bounded historical refetches around degraded
   synthetic realized-PnL rows even when cache metadata already proves the configured
   lookback. Repair-only fetches preserve the incremental checkpoint and rotate through
-  at most four disjoint ranges per authoritative cycle. Authoritative replacements are
-  reported as enrichment; uptime health adds the full authoritative PnL for cached rows
-  not previously counted by this process and applies only the replacement delta for
-  runtime-counted rows. Unresolved degraded rows defer risk planning with exponential
-  backoff instead of consuming the generic bot restart budget.
+  at most four independently bounded execution ranges per authoritative cycle. Bybit
+  repair also advances a separately bounded closed-PnL update-time window so delayed
+  records remain discoverable. Authoritative replacements are reported before later
+  fallible refresh work; uptime health adds the full authoritative PnL for cached rows
+  not previously counted by this process and applies a delta against the exact synthetic
+  amount counted at runtime. Outstanding synthetic accounting is discarded after
+  enrichment. Unresolved degraded rows defer risk planning with exponential backoff
+  instead of consuming the generic bot restart budget.
 
 - WEEX REST and private WebSocket clients now use IPv4 transport so API keys
   bound to the host's public IPv4 address do not fail with `-1056 ILLEGAL_IP`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live fill recovery now performs bounded historical refetches around degraded
+  synthetic realized-PnL rows even when cache metadata already proves the configured
+  lookback. Authoritative replacements are reported as enrichment, health PnL changes
+  only by the replacement delta, and unresolved degraded rows defer risk planning with
+  exponential backoff instead of consuming the generic bot restart budget.
+
 - Documented Python 3.12 and 3.14 support, explicitly excluding Python 3.13 until its dependency
   set is supported and bounding package metadata to those validated minor versions, and fixed
   reentrant candle fetch-lock

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -32,10 +32,15 @@
    history has polluted reconstructed `psize`/`pprice`.
 10. A degraded synthetic PnL row inside the configured live risk lookback is not
     authoritative merely because cache metadata proves time coverage. Refetch bounded
-    windows around each such row, preserve ordinary recent-fill overlap for routine
-    ingestion, and defer risk planning without consuming restart budget until the row
-    is authoritatively replaced. Replacement diagnostics count pending or synthetic
-    rows becoming authoritative; health PnL applies only the old-to-new net-PnL delta.
+    windows around each such row, preserving the pre-repair incremental checkpoint and
+    processing at most four disjoint repair ranges per authoritative cycle. Rotate
+    remaining ranges across backed-off cycles so one unresolved range cannot starve the
+    others. Preserve ordinary recent-fill overlap for routine ingestion, and defer risk
+    planning without consuming restart budget until every in-lookback row is
+    authoritatively replaced. Replacement diagnostics count pending or synthetic rows
+    becoming authoritative. Uptime health adds the full authoritative net PnL when the
+    previous cached value was not counted by this process, and applies only the
+    old-to-new delta when it was.
 
 ## Runtime Provenance
 
@@ -79,7 +84,9 @@ logs, runtime windows, and immutable manifests.
 5. Old synthetic rows remain outside ordinary recent-fill overlap to avoid repeatedly
    widening every routine refresh. Risk-blocking degraded rows use a separate bounded
    repair path so proven coverage cannot strand an otherwise recoverable authoritative
-   exchange record.
+   exchange record. Repair-only calls do not advance `last_refresh_ms`; the subsequent
+   ordinary recent refresh must still cover downtime from the prior successful
+   checkpoint.
 
 ## Failure Semantics And Risks
 

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -30,6 +30,12 @@
    retries from the position/fill anchor with bounded in-memory backoff. Direction,
    quantity, and price alone do not prove a flat-to-position transition when truncated
    history has polluted reconstructed `psize`/`pprice`.
+10. A degraded synthetic PnL row inside the configured live risk lookback is not
+    authoritative merely because cache metadata proves time coverage. Refetch bounded
+    windows around each such row, preserve ordinary recent-fill overlap for routine
+    ingestion, and defer risk planning without consuming restart budget until the row
+    is authoritatively replaced. Replacement diagnostics count pending or synthetic
+    rows becoming authoritative; health PnL applies only the old-to-new net-PnL delta.
 
 ## Runtime Provenance
 
@@ -70,6 +76,10 @@ logs, runtime windows, and immutable manifests.
    Full responses are recursively split into disjoint time windows because the endpoint does not
    guarantee row ordering or expose a stable cursor. Saturation within one millisecond is unavailable
    rather than silently treated as complete.
+5. Old synthetic rows remain outside ordinary recent-fill overlap to avoid repeatedly
+   widening every routine refresh. Risk-blocking degraded rows use a separate bounded
+   repair path so proven coverage cannot strand an otherwise recoverable authoritative
+   exchange record.
 
 ## Failure Semantics And Risks
 
@@ -88,6 +98,8 @@ merely because an auxiliary endpoint failed.
 3. PnL attachment behavior when auxiliary endpoints fail.
 4. Provenance round-trip, preservation during refresh/deduplication, and legacy
    rows remaining unattributed.
+5. Old degraded synthetic PnL is refetched in bounded windows, authoritative
+   replacement is persisted, and unresolved rows defer live planning without restarts.
 
 ## Key Code
 

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -33,14 +33,18 @@
 10. A degraded synthetic PnL row inside the configured live risk lookback is not
     authoritative merely because cache metadata proves time coverage. Refetch bounded
     windows around each such row, preserving the pre-repair incremental checkpoint and
-    processing at most four disjoint repair ranges per authoritative cycle. Rotate
-    remaining ranges across backed-off cycles so one unresolved range cannot starve the
-    others. Preserve ordinary recent-fill overlap for routine ingestion, and defer risk
-    planning without consuming restart budget until every in-lookback row is
-    authoritatively replaced. Replacement diagnostics count pending or synthetic rows
-    becoming authoritative. Uptime health adds the full authoritative net PnL when the
-    previous cached value was not counted by this process, and applies only the
-    old-to-new delta when it was.
+    processing at most four independently bounded execution ranges per authoritative
+    cycle. Rotate remaining events across backed-off cycles so one unresolved row cannot
+    starve the others. Connectors whose authoritative PnL endpoint uses a timestamp
+    different from execution time must search that timestamp independently in bounded,
+    advancing windows while retaining the narrow execution lookup. Preserve ordinary
+    recent-fill overlap for routine ingestion, and defer risk planning without consuming
+    restart budget until every in-lookback row is authoritatively replaced. Report every
+    successful replacement before attempting later fallible fetches. Uptime health adds
+    the full authoritative net PnL when the previous cached value was not counted by this
+    process, and applies a delta against the exact net PnL previously counted for an
+    outstanding runtime synthetic row. Discard that temporary accounting after
+    enrichment; authoritative fills must not accumulate identity state.
 
 ## Runtime Provenance
 
@@ -86,7 +90,9 @@ logs, runtime windows, and immutable manifests.
    repair path so proven coverage cannot strand an otherwise recoverable authoritative
    exchange record. Repair-only calls do not advance `last_refresh_ms`; the subsequent
    ordinary recent refresh must still cover downtime from the prior successful
-   checkpoint.
+   checkpoint. Bybit keeps the execution-time range narrow while rotating a separate
+   closed-PnL `updatedTime` range toward the present; each auxiliary range spans at most
+   one day.
 
 ## Failure Semantics And Risks
 

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -44,7 +44,9 @@
     the full authoritative net PnL when the previous cached value was not counted by this
     process, and applies a delta against the exact net PnL previously counted for an
     outstanding runtime synthetic row. Discard that temporary accounting after
-    enrichment; authoritative fills must not accumulate identity state.
+    enrichment; authoritative fills must not accumulate identity state. Structured
+    `cycle.degraded` diagnostics preserve bounded `pending_pnl_count` and
+    `degraded_pnl_count` fields through the centralized payload sanitizer.
 
 ## Runtime Provenance
 

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -1503,6 +1503,7 @@ GAP_REASON_CONFIRMED = "confirmed_legitimate"
 GAP_REASON_MANUAL = "manual"
 PENDING_PNL_REFRESH_MARGIN_MS = 5 * 60 * 1000
 KUCOIN_POSITION_HISTORY_LOOKAHEAD_MS = 10 * 60 * 1000
+DEGRADED_PNL_REPAIR_MAX_INTERVALS_PER_CYCLE = 4
 
 
 class KnownGap(TypedDict, total=False):
@@ -3252,6 +3253,7 @@ class FillEventsManager:
         self._events: List[FillEvent] = []
         self._loaded = False
         self._lock = asyncio.Lock()
+        self._degraded_pnl_repair_attempted_ranges: set[tuple[int, int]] = set()
 
     def _apply_fee_policy(
         self,
@@ -4437,6 +4439,7 @@ class FillEventsManager:
         *,
         start_ms: Optional[int] = None,
         end_ms: Optional[int] = None,
+        mark_refreshed: bool = True,
     ) -> None:
         await self.ensure_loaded()
         logger.debug(
@@ -4672,8 +4675,10 @@ class FillEventsManager:
 
         # Update cache metadata with timestamps
         if self._events:
-            self.cache.update_metadata_from_events(self._events)
-        else:
+            self.cache.update_metadata_from_events(
+                self._events, mark_refreshed=mark_refreshed
+            )
+        elif mark_refreshed:
             self.cache.mark_refreshed()
         if fetched_bounded_range:
             # A successful bounded fetch proves the retried range even when the
@@ -4782,12 +4787,15 @@ class FillEventsManager:
             if int(ev.timestamp) >= lower_bound and int(ev.timestamp) <= upper_bound
         ]
         if not degraded_before:
+            self._degraded_pnl_repair_attempted_ranges = set()
             return {
                 "attempted": False,
                 "before_count": 0,
                 "repaired_count": 0,
                 "remaining_count": 0,
                 "range_count": 0,
+                "total_range_count": 0,
+                "deferred_range_count": 0,
             }
 
         intervals = self._merge_intervals(
@@ -4802,18 +4810,41 @@ class FillEventsManager:
                 for ev in degraded_before
             ]
         )
+        interval_count = len(intervals)
+        attempted_ranges = set(
+            getattr(self, "_degraded_pnl_repair_attempted_ranges", set()) or set()
+        )
+        attempted_ranges.intersection_update(intervals)
+        unattempted_intervals = [
+            interval for interval in intervals if interval not in attempted_ranges
+        ]
+        if not unattempted_intervals:
+            attempted_ranges.clear()
+            unattempted_intervals = list(intervals)
+        selected_count = min(
+            len(unattempted_intervals),
+            DEGRADED_PNL_REPAIR_MAX_INTERVALS_PER_CYCLE,
+        )
+        selected_intervals = unattempted_intervals[:selected_count]
         logger.info(
             "[fills] refetching authoritative PnL for degraded cached fills | "
-            "exchange=%s user=%s events=%d ranges=%d oldest=%s newest=%s",
+            "exchange=%s user=%s events=%d ranges=%d/%d oldest=%s newest=%s",
             self.exchange,
             self.user,
             len(degraded_before),
-            len(intervals),
+            len(selected_intervals),
+            interval_count,
             _format_ms(min(ev.timestamp for ev in degraded_before)),
             _format_ms(max(ev.timestamp for ev in degraded_before)),
         )
-        for interval_start, interval_end in intervals:
-            await self.refresh(start_ms=interval_start, end_ms=interval_end)
+        for interval_start, interval_end in selected_intervals:
+            attempted_ranges.add((interval_start, interval_end))
+            self._degraded_pnl_repair_attempted_ranges = attempted_ranges
+            await self.refresh(
+                start_ms=interval_start,
+                end_ms=interval_end,
+                mark_refreshed=False,
+            )
 
         degraded_after = [
             ev
@@ -4842,7 +4873,10 @@ class FillEventsManager:
             "before_count": len(degraded_before),
             "repaired_count": repaired_count,
             "remaining_count": len(degraded_after),
-            "range_count": len(intervals),
+            "range_count": len(selected_intervals),
+            "total_range_count": interval_count,
+            "deferred_range_count": len(unattempted_intervals)
+            - len(selected_intervals),
         }
 
     async def refresh_for_lookback(

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -1504,6 +1504,7 @@ GAP_REASON_MANUAL = "manual"
 PENDING_PNL_REFRESH_MARGIN_MS = 5 * 60 * 1000
 KUCOIN_POSITION_HISTORY_LOOKAHEAD_MS = 10 * 60 * 1000
 DEGRADED_PNL_REPAIR_MAX_INTERVALS_PER_CYCLE = 4
+DEGRADED_PNL_REPAIR_MAX_INTERVAL_SPAN_MS = 24 * 60 * 60 * 1000
 
 
 class KnownGap(TypedDict, total=False):
@@ -3253,7 +3254,9 @@ class FillEventsManager:
         self._events: List[FillEvent] = []
         self._loaded = False
         self._lock = asyncio.Lock()
-        self._degraded_pnl_repair_attempted_ranges: set[tuple[int, int]] = set()
+        self._degraded_pnl_repair_attempted_keys: set[str] = set()
+        self._degraded_pnl_repair_aux_cursor_ms: dict[str, int] = {}
+        self._degraded_pnl_repair_aux_completed_keys: set[str] = set()
 
     def _apply_fee_policy(
         self,
@@ -4440,6 +4443,7 @@ class FillEventsManager:
         start_ms: Optional[int] = None,
         end_ms: Optional[int] = None,
         mark_refreshed: bool = True,
+        degraded_pnl_aux_range: Optional[Tuple[int, int]] = None,
     ) -> None:
         await self.ensure_loaded()
         logger.debug(
@@ -4604,9 +4608,22 @@ class FillEventsManager:
                     fetched_batches.append(bounded)
 
         try:
-            fetched_events = await self.fetcher.fetch(
-                start_ms, end_ms, detail_cache, on_batch=collect_batch
+            repair_fetch = getattr(
+                self.fetcher, "fetch_degraded_pnl_repair", None
             )
+            if degraded_pnl_aux_range is not None and callable(repair_fetch):
+                fetched_events = await repair_fetch(
+                    start_ms,
+                    end_ms,
+                    int(degraded_pnl_aux_range[0]),
+                    int(degraded_pnl_aux_range[1]),
+                    detail_cache,
+                    on_batch=collect_batch,
+                )
+            else:
+                fetched_events = await self.fetcher.fetch(
+                    start_ms, end_ms, detail_cache, on_batch=collect_batch
+                )
         except RateLimitExceeded:
             # Preserve bounded-range failures as known gaps so retry logic can
             # revisit them.  We still re-raise to fail loudly on critical input.
@@ -4787,7 +4804,9 @@ class FillEventsManager:
             if int(ev.timestamp) >= lower_bound and int(ev.timestamp) <= upper_bound
         ]
         if not degraded_before:
-            self._degraded_pnl_repair_attempted_ranges = set()
+            self._degraded_pnl_repair_attempted_keys = set()
+            self._degraded_pnl_repair_aux_cursor_ms = {}
+            self._degraded_pnl_repair_aux_completed_keys = set()
             return {
                 "attempted": False,
                 "before_count": 0,
@@ -4798,53 +4817,103 @@ class FillEventsManager:
                 "deferred_range_count": 0,
             }
 
-        intervals = self._merge_intervals(
-            [
-                (
-                    max(lower_bound, int(ev.timestamp) - PENDING_PNL_REFRESH_MARGIN_MS),
-                    min(
-                        upper_bound,
-                        int(ev.timestamp) + KUCOIN_POSITION_HISTORY_LOOKAHEAD_MS,
-                    ),
-                )
-                for ev in degraded_before
-            ]
+        def repair_key(event: FillEvent) -> str:
+            source_ids = sorted(
+                str(value)
+                for value in getattr(event, "source_ids", None) or ()
+                if value
+            )
+            if source_ids:
+                return f"source:{source_ids[0]}"
+            event_id = str(getattr(event, "id", "") or "")
+            if event_id:
+                return f"id:{event_id}"
+            return (
+                f"event:{getattr(event, 'symbol', '')}:"
+                f"{getattr(event, 'position_side', '')}:{int(event.timestamp)}:"
+                f"{getattr(event, 'side', '')}:{getattr(event, 'qty', '')}"
+            )
+
+        keyed_events = [(repair_key(event), event) for event in degraded_before]
+        current_keys = {key for key, _event in keyed_events}
+        attempted_keys = set(self._degraded_pnl_repair_attempted_keys)
+        attempted_keys.intersection_update(current_keys)
+        self._degraded_pnl_repair_aux_cursor_ms = {
+            key: cursor
+            for key, cursor in self._degraded_pnl_repair_aux_cursor_ms.items()
+            if key in current_keys
+        }
+        self._degraded_pnl_repair_aux_completed_keys.intersection_update(
+            current_keys
         )
-        interval_count = len(intervals)
-        attempted_ranges = set(
-            getattr(self, "_degraded_pnl_repair_attempted_ranges", set()) or set()
-        )
-        attempted_ranges.intersection_update(intervals)
-        unattempted_intervals = [
-            interval for interval in intervals if interval not in attempted_ranges
+        unattempted_events = [
+            (key, event)
+            for key, event in keyed_events
+            if key not in attempted_keys
         ]
-        if not unattempted_intervals:
-            attempted_ranges.clear()
-            unattempted_intervals = list(intervals)
+        if not unattempted_events:
+            attempted_keys.clear()
+            unattempted_events = list(keyed_events)
         selected_count = min(
-            len(unattempted_intervals),
+            len(unattempted_events),
             DEGRADED_PNL_REPAIR_MAX_INTERVALS_PER_CYCLE,
         )
-        selected_intervals = unattempted_intervals[:selected_count]
+        selected_events = unattempted_events[:selected_count]
         logger.info(
             "[fills] refetching authoritative PnL for degraded cached fills | "
             "exchange=%s user=%s events=%d ranges=%d/%d oldest=%s newest=%s",
             self.exchange,
             self.user,
             len(degraded_before),
-            len(selected_intervals),
-            interval_count,
+            len(selected_events),
+            len(keyed_events),
             _format_ms(min(ev.timestamp for ev in degraded_before)),
             _format_ms(max(ev.timestamp for ev in degraded_before)),
         )
-        for interval_start, interval_end in selected_intervals:
-            attempted_ranges.add((interval_start, interval_end))
-            self._degraded_pnl_repair_attempted_ranges = attempted_ranges
+        repair_fetch = getattr(self.fetcher, "fetch_degraded_pnl_repair", None)
+        for key, event in selected_events:
+            event_timestamp = int(event.timestamp)
+            interval_start = max(
+                lower_bound,
+                event_timestamp - PENDING_PNL_REFRESH_MARGIN_MS,
+            )
+            interval_end = min(
+                upper_bound,
+                event_timestamp + KUCOIN_POSITION_HISTORY_LOOKAHEAD_MS,
+            )
+            aux_range = None
+            if callable(repair_fetch):
+                cursor = max(
+                    interval_start,
+                    int(
+                        self._degraded_pnl_repair_aux_cursor_ms.get(
+                            key, interval_start
+                        )
+                    ),
+                )
+                if key in self._degraded_pnl_repair_aux_completed_keys:
+                    # The prior scan reached the moving upper bound. Start a
+                    # fresh bounded pass so an eventually consistent record
+                    # cannot remain stranded in an already visited window.
+                    cursor = interval_start
+                    self._degraded_pnl_repair_aux_completed_keys.discard(key)
+                aux_end = min(
+                    upper_bound,
+                    cursor + DEGRADED_PNL_REPAIR_MAX_INTERVAL_SPAN_MS,
+                )
+                aux_range = (cursor, aux_end)
+            attempted_keys.add(key)
+            self._degraded_pnl_repair_attempted_keys = attempted_keys
             await self.refresh(
                 start_ms=interval_start,
                 end_ms=interval_end,
                 mark_refreshed=False,
+                degraded_pnl_aux_range=aux_range,
             )
+            if aux_range is not None:
+                self._degraded_pnl_repair_aux_cursor_ms[key] = aux_range[1]
+                if aux_range[1] >= upper_bound:
+                    self._degraded_pnl_repair_aux_completed_keys.add(key)
 
         degraded_after = [
             ev
@@ -4873,10 +4942,9 @@ class FillEventsManager:
             "before_count": len(degraded_before),
             "repaired_count": repaired_count,
             "remaining_count": len(degraded_after),
-            "range_count": len(selected_intervals),
-            "total_range_count": interval_count,
-            "deferred_range_count": len(unattempted_intervals)
-            - len(selected_intervals),
+            "range_count": len(selected_events),
+            "total_range_count": len(keyed_events),
+            "deferred_range_count": len(unattempted_events) - len(selected_events),
         }
 
     async def refresh_for_lookback(
@@ -5347,16 +5415,53 @@ class BybitFetcher(BaseFetcher):
     ) -> List[Dict[str, object]]:
         end_ms = until_ms or (self._now_ms() + 60 * 60 * 1000)
         start_ms = since_ms or max(0, end_ms - self._default_span_ms)
+        return await self._fetch_ranges(
+            trade_start_ms=start_ms,
+            trade_end_ms=end_ms,
+            pnl_start_ms=start_ms,
+            pnl_end_ms=end_ms,
+            detail_cache=detail_cache,
+            on_batch=on_batch,
+        )
 
-        trades = await self._fetch_my_trades(start_ms, end_ms)
-        positions = await self._fetch_positions_history(start_ms, end_ms)
+    async def fetch_degraded_pnl_repair(
+        self,
+        trade_start_ms: int,
+        trade_end_ms: int,
+        pnl_start_ms: int,
+        pnl_end_ms: int,
+        detail_cache: Dict[str, Tuple[str, str]],
+        on_batch: Optional[Callable[[List[Dict[str, object]]], None]] = None,
+    ) -> List[Dict[str, object]]:
+        """Refetch executions while independently searching closed-PnL update time."""
+        return await self._fetch_ranges(
+            trade_start_ms=int(trade_start_ms),
+            trade_end_ms=int(trade_end_ms),
+            pnl_start_ms=int(pnl_start_ms),
+            pnl_end_ms=int(pnl_end_ms),
+            detail_cache=detail_cache,
+            on_batch=on_batch,
+        )
+
+    async def _fetch_ranges(
+        self,
+        *,
+        trade_start_ms: int,
+        trade_end_ms: int,
+        pnl_start_ms: int,
+        pnl_end_ms: int,
+        detail_cache: Dict[str, Tuple[str, str]],
+        on_batch: Optional[Callable[[List[Dict[str, object]]], None]] = None,
+    ) -> List[Dict[str, object]]:
+        trades = await self._fetch_my_trades(trade_start_ms, trade_end_ms)
+        positions = await self._fetch_positions_history(pnl_start_ms, pnl_end_ms)
 
         events = self._combine(trades, positions, detail_cache)
         events = [
             ev
             for ev in events
-            if (since_ms is None or ev["timestamp"] >= since_ms)
-            and (until_ms is None or ev["timestamp"] <= until_ms)
+            if ev["timestamp"] >= trade_start_ms
+            and ev["timestamp"] <= trade_end_ms
         ]
         events.sort(key=lambda ev: ev["timestamp"])
         events = _coalesce_events(events)
@@ -5369,10 +5474,15 @@ class BybitFetcher(BaseFetcher):
                 on_batch(day_map[day])
 
         logger.debug(
-            "BybitFetcher.fetch: done (events=%d, trades=%d, positions=%d)",
+            "BybitFetcher.fetch: done (events=%d, trades=%d, positions=%d, "
+            "trade_range=%s..%s, pnl_range=%s..%s)",
             len(events),
             len(trades),
             len(positions),
+            _format_ms(trade_start_ms),
+            _format_ms(trade_end_ms),
+            _format_ms(pnl_start_ms),
+            _format_ms(pnl_end_ms),
         )
         return events
 

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -4756,6 +4756,95 @@ class FillEventsManager:
             )
         await self.refresh(start_ms=start_ms, end_ms=None)
 
+    async def refresh_degraded_pnl_events(
+        self,
+        *,
+        start_ms: Optional[int] = None,
+        end_ms: Optional[int] = None,
+    ) -> Dict[str, object]:
+        """Refetch bounded windows around risk-blocking synthetic PnL events.
+
+        A cache may already prove the configured history lookback while still
+        containing an old degraded PnL reconstruction.  Ordinary recent-fill
+        overlap intentionally excludes old synthetic rows, so those events
+        need a separate targeted path to acquire authoritative exchange data.
+        """
+        await self.ensure_loaded()
+        lower_bound = max(0, int(start_ms or 0))
+        upper_bound = int(
+            end_ms
+            if end_ms is not None
+            else datetime.now(tz=timezone.utc).timestamp() * 1000
+        )
+        degraded_before = [
+            ev
+            for ev in self.degraded_pnl_events(self._events)
+            if int(ev.timestamp) >= lower_bound and int(ev.timestamp) <= upper_bound
+        ]
+        if not degraded_before:
+            return {
+                "attempted": False,
+                "before_count": 0,
+                "repaired_count": 0,
+                "remaining_count": 0,
+                "range_count": 0,
+            }
+
+        intervals = self._merge_intervals(
+            [
+                (
+                    max(lower_bound, int(ev.timestamp) - PENDING_PNL_REFRESH_MARGIN_MS),
+                    min(
+                        upper_bound,
+                        int(ev.timestamp) + KUCOIN_POSITION_HISTORY_LOOKAHEAD_MS,
+                    ),
+                )
+                for ev in degraded_before
+            ]
+        )
+        logger.info(
+            "[fills] refetching authoritative PnL for degraded cached fills | "
+            "exchange=%s user=%s events=%d ranges=%d oldest=%s newest=%s",
+            self.exchange,
+            self.user,
+            len(degraded_before),
+            len(intervals),
+            _format_ms(min(ev.timestamp for ev in degraded_before)),
+            _format_ms(max(ev.timestamp for ev in degraded_before)),
+        )
+        for interval_start, interval_end in intervals:
+            await self.refresh(start_ms=interval_start, end_ms=interval_end)
+
+        degraded_after = [
+            ev
+            for ev in self.degraded_pnl_events(self._events)
+            if int(ev.timestamp) >= lower_bound and int(ev.timestamp) <= upper_bound
+        ]
+        repaired_count = max(0, len(degraded_before) - len(degraded_after))
+        if degraded_after:
+            logger.warning(
+                "[fills] authoritative PnL remains unavailable after bounded repair | "
+                "exchange=%s user=%s repaired=%d remaining=%d action=defer_risk_planning",
+                self.exchange,
+                self.user,
+                repaired_count,
+                len(degraded_after),
+            )
+        else:
+            logger.info(
+                "[fills] authoritative PnL repair complete | exchange=%s user=%s repaired=%d",
+                self.exchange,
+                self.user,
+                repaired_count,
+            )
+        return {
+            "attempted": True,
+            "before_count": len(degraded_before),
+            "repaired_count": repaired_count,
+            "remaining_count": len(degraded_after),
+            "range_count": len(intervals),
+        }
+
     async def refresh_for_lookback(
         self,
         start_ms: int,
@@ -5060,7 +5149,20 @@ class FillEventsManager:
 
     @staticmethod
     def synthetic_pnl_events(events: Iterable[FillEvent]) -> List[FillEvent]:
-        return [ev for ev in events if _is_synthetic_pnl_source(ev.pnl_source)]
+        return [
+            ev
+            for ev in events
+            if _is_synthetic_pnl_source(getattr(ev, "pnl_source", ""))
+        ]
+
+    @staticmethod
+    def degraded_pnl_events(events: Iterable[FillEvent]) -> List[FillEvent]:
+        return [
+            ev
+            for ev in events
+            if str(getattr(ev, "pnl_source", "") or "").lower()
+            == PNL_SOURCE_SYNTHETIC_DEGRADED
+        ]
 
     @staticmethod
     def assert_no_pending_pnl(events: Iterable[FillEvent], *, context: str) -> None:

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -281,7 +281,12 @@ def _sanitize_cycle_degraded_payload(value: Any) -> dict[str, Any]:
     out: dict[str, Any] = {}
     if "timings_ms" in value:
         out["timings_ms"] = _cycle_degraded_int_map(value.get("timings_ms"))
-    for key in ("retry_count", "failed_count"):
+    for key in (
+        "retry_count",
+        "failed_count",
+        "pending_pnl_count",
+        "degraded_pnl_count",
+    ):
         parsed = _cycle_degraded_non_negative_int(value.get(key))
         if parsed is not None:
             out[key] = parsed

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -5151,12 +5151,14 @@ def _fill_refresh_debug_payload(
     new_count: int | None = None,
     enriched_count: int | None = None,
     pending_pnl_count: int | None = None,
+    degraded_pnl_count: int | None = None,
 ) -> dict[str, Any]:
     before_count = _safe_int(event_count_before)
     after_count = _safe_int(event_count_after)
     new_value = _safe_int(new_count)
     enriched_value = _safe_int(enriched_count)
     pending_value = _safe_int(pending_pnl_count)
+    degraded_value = _safe_int(degraded_pnl_count)
     data: dict[str, Any] = {
         "coverage_before_keys": _mapping_key_sample(coverage_before),
         "coverage_after_keys": _mapping_key_sample(coverage_after),
@@ -5165,6 +5167,7 @@ def _fill_refresh_debug_payload(
         "new_count": new_value,
         "enriched_count": enriched_value,
         "pending_pnl_count": pending_value,
+        "degraded_pnl_count": degraded_value,
     }
     if before_count is not None and after_count is not None:
         data["event_count_delta"] = int(after_count) - int(before_count)
@@ -5247,6 +5250,7 @@ def _emit_fills_refresh_summary_event_unchecked(
     new_count: int | None = None,
     enriched_count: int | None = None,
     pending_pnl_count: int | None = None,
+    degraded_pnl_count: int | None = None,
     coverage_before: dict[str, Any] | None = None,
     coverage_after: dict[str, Any] | None = None,
     overlap_minutes: float | None = None,
@@ -5279,6 +5283,7 @@ def _emit_fills_refresh_summary_event_unchecked(
         "new_count": _safe_int(new_count),
         "enriched_count": _safe_int(enriched_count),
         "pending_pnl_count": _safe_int(pending_pnl_count),
+        "degraded_pnl_count": _safe_int(degraded_pnl_count),
     }
     if coverage_before_summary:
         data["coverage_before"] = coverage_before_summary
@@ -5339,6 +5344,7 @@ def _emit_fills_refresh_summary_event_unchecked(
             new_count=new_count,
             enriched_count=enriched_count,
             pending_pnl_count=pending_pnl_count,
+            degraded_pnl_count=degraded_pnl_count,
         )
         if debug:
             data["debug_profile"] = "fills"

--- a/src/live/state_refresh.py
+++ b/src/live/state_refresh.py
@@ -43,6 +43,7 @@ async def refresh_protective_authoritative_state(bot) -> bool:
     bot._begin_authoritative_refresh_epoch()
     bot._last_authoritative_block_reason = None
     bot._last_authoritative_pending_pnl_count = 0
+    bot._last_authoritative_degraded_pnl_count = 0
     plan = {"balance", "positions", "open_orders"}
     bot._authoritative_refresh_plan_surfaces = set(plan)
     snapshot = await bot._fetch_authoritative_state_staged_snapshot(plan)
@@ -88,6 +89,7 @@ async def refresh_authoritative_state_staged(bot) -> bool:
     """Refresh live account state through the staged authoritative cohort."""
     bot._last_authoritative_block_reason = None
     bot._last_authoritative_pending_pnl_count = 0
+    bot._last_authoritative_degraded_pnl_count = 0
     plan = bot._authoritative_staged_refresh_plan()
     snapshot = await bot._fetch_authoritative_state_staged_snapshot(plan)
     fetched_balance = snapshot.get("balance")
@@ -101,9 +103,16 @@ async def refresh_authoritative_state_staged(bot) -> bool:
     if "open_orders" in plan and fetched_open_orders in [None, False]:
         return False
     if "fills" in plan and not pnls_ok:
-        bot._last_authoritative_block_reason = "pending_pnl"
         bot._last_authoritative_pending_pnl_count = int(
             snapshot.get("pending_pnl_count", 0) or 0
+        )
+        bot._last_authoritative_degraded_pnl_count = int(
+            snapshot.get("degraded_pnl_count", 0) or 0
+        )
+        bot._last_authoritative_block_reason = (
+            "degraded_pnl"
+            if bot._last_authoritative_degraded_pnl_count
+            else "pending_pnl"
         )
         return False
     prepared_balance_snapshot = None
@@ -734,5 +743,8 @@ async def fetch_authoritative_state_staged_snapshot(bot, plan: set[str]) -> dict
             out["pnls_ok"] = result
             out["pending_pnl_count"] = int(
                 getattr(bot, "_last_fill_refresh_pending_pnl_count", 0) or 0
+            )
+            out["degraded_pnl_count"] = int(
+                getattr(bot, "_last_fill_refresh_degraded_pnl_count", 0) or 0
             )
     return out

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -1502,6 +1502,7 @@ class Passivbot:
         self._health_orders_cancelled = 0
         self._health_fills = 0
         self._health_pnl = 0.0  # sum of realized PnL from fills
+        self._health_counted_fill_keys: set[str] = set()
         self._health_errors = 0
         self._health_ws_reconnects = 0
         self._health_rate_limits = 0
@@ -12338,9 +12339,11 @@ class Passivbot:
 
         # Track fills and PnL for health summary
         self._health_fills += len(new_events)
-        self._health_pnl += sum(
-            fill_event_net_pnl(ev) for ev in new_events if not fill_event_pnl_pending(ev)
-        )
+        for event in new_events:
+            if fill_event_pnl_pending(event):
+                continue
+            self._health_pnl += fill_event_net_pnl(event)
+            Passivbot._mark_health_fill_pnl_counted(self, event)
 
         batch_summary = len(new_events) > 20
         pending_count = 0
@@ -12401,35 +12404,54 @@ class Passivbot:
                     pending_pnl_count=pending_count,
                 )
 
+    @staticmethod
+    def _health_fill_identity_keys(event: object) -> set[str]:
+        keys: set[str] = set()
+        event_id = str(getattr(event, "id", "") or "")
+        if event_id:
+            keys.add(f"id:{event_id}")
+        for source_id in getattr(event, "source_ids", None) or ():
+            normalized = str(source_id or "")
+            if normalized:
+                keys.add(f"source:{normalized}")
+        return keys
+
+    def _health_fill_pnl_was_counted(self, event: object) -> bool:
+        counted = set(getattr(self, "_health_counted_fill_keys", set()) or set())
+        return bool(Passivbot._health_fill_identity_keys(event) & counted)
+
+    def _mark_health_fill_pnl_counted(self, event: object) -> None:
+        counted = getattr(self, "_health_counted_fill_keys", None)
+        if counted is None:
+            counted = set()
+            self._health_counted_fill_keys = counted
+        counted.update(Passivbot._health_fill_identity_keys(event))
+
     def _log_enriched_fill_events(self, transitions: list[tuple[object, object]]) -> None:
         """Log authoritative PnL replacing pending or synthetic cached values."""
         if not transitions:
             return
-        self._health_pnl += sum(
-            fill_event_net_pnl(event)
-            - (
-                0.0
-                if fill_event_pnl_pending(previous)
-                else fill_event_net_pnl(previous)
-            )
-            for previous, event in transitions
-        )
         for previous, event in sorted(
             transitions, key=lambda item: item[1].timestamp
         ):
+            previous_counted = Passivbot._health_fill_pnl_was_counted(self, previous)
+            previous_net_pnl = (
+                fill_event_net_pnl(previous)
+                if previous_counted and not fill_event_pnl_pending(previous)
+                else 0.0
+            )
+            pnl_delta = fill_event_net_pnl(event) - previous_net_pnl
+            self._health_pnl += pnl_delta
+            Passivbot._mark_health_fill_pnl_counted(self, event)
             previous_source = str(
                 getattr(previous, "pnl_source", "") or "pending"
             ).lower()
             logging.info(
                 "[fill] authoritative realized pnl replaced cached estimate | "
-                "previous_source=%s pnl_delta=%+.8g | %s",
+                "previous_source=%s previous_counted=%s pnl_delta=%+.8g | %s",
                 previous_source,
-                fill_event_net_pnl(event)
-                - (
-                    0.0
-                    if fill_event_pnl_pending(previous)
-                    else fill_event_net_pnl(previous)
-                ),
+                str(previous_counted).lower(),
+                pnl_delta,
                 self._log_fill_event(event),
             )
 

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -1502,7 +1502,7 @@ class Passivbot:
         self._health_orders_cancelled = 0
         self._health_fills = 0
         self._health_pnl = 0.0  # sum of realized PnL from fills
-        self._health_counted_fill_keys: set[str] = set()
+        self._health_counted_synthetic_pnl_by_key: dict[str, float] = {}
         self._health_errors = 0
         self._health_ws_reconnects = 0
         self._health_rate_limits = 0
@@ -11835,6 +11835,11 @@ class Passivbot:
         coverage_status: dict[str, Any] = {}
         post_refresh_coverage_status: dict[str, Any] = {}
         lookback_config_value = None
+        enriched_events: list[tuple[object, object]] = []
+
+        def flush_enriched_events() -> list[tuple[object, object]]:
+            return []
+
         await self.init_pnls()  # will do nothing if already initiated
 
         if self._pnls_manager is None:
@@ -11867,6 +11872,56 @@ class Passivbot:
                     existing_source_ids.add(ev.id)
                     existing_by_source_id[str(ev.id)] = ev
 
+            handled_enrichment_keys: set[str] = set()
+
+            def event_identity_keys(event: object) -> set[str]:
+                keys = {
+                    f"source:{str(value)}"
+                    for value in getattr(event, "source_ids", None) or ()
+                    if value
+                }
+                event_id = str(getattr(event, "id", "") or "")
+                if event_id:
+                    keys.add(f"id:{event_id}")
+                return keys
+
+            def collect_enriched_events() -> list[tuple[object, object]]:
+                transitions: list[tuple[object, object]] = []
+                for current in self._pnls_manager.get_events():
+                    current_keys = event_identity_keys(current)
+                    if current_keys & handled_enrichment_keys:
+                        continue
+                    previous = existing_by_id.get(
+                        str(getattr(current, "id", "") or "")
+                    )
+                    if previous is None:
+                        for source_id in getattr(current, "source_ids", None) or ():
+                            previous = existing_by_source_id.get(str(source_id))
+                            if previous is not None:
+                                break
+                    if previous is None:
+                        continue
+                    previous_needs_enrichment = (
+                        fill_event_pnl_pending(previous)
+                        or bool(
+                            FillEventsManager.synthetic_pnl_events([previous])
+                        )
+                    )
+                    current_is_authoritative = (
+                        not fill_event_pnl_pending(current)
+                        and not FillEventsManager.synthetic_pnl_events([current])
+                    )
+                    if previous_needs_enrichment and current_is_authoritative:
+                        transitions.append((previous, current))
+                        handled_enrichment_keys.update(current_keys)
+                if transitions:
+                    self._log_enriched_fill_events(transitions)
+                    self._request_authoritative_confirmation(ACCOUNT_SURFACES)
+                    enriched_events.extend(transitions)
+                return transitions
+
+            flush_enriched_events = collect_enriched_events
+
             # Check whether the cache proves the configured fill-history
             # lookback before risk gates consume realized PnL.
             events = self._pnls_manager.get_events()
@@ -11892,10 +11947,13 @@ class Passivbot:
             )
             if coverage_ready and degraded_before and callable(repair_degraded):
                 degraded_repair_attempted = True
-                await repair_degraded(
-                    start_ms=None if age_limit is None else int(age_limit),
-                    end_ms=int(self.get_exchange_time()),
-                )
+                try:
+                    await repair_degraded(
+                        start_ms=None if age_limit is None else int(age_limit),
+                        end_ms=int(self.get_exchange_time()),
+                    )
+                finally:
+                    flush_enriched_events()
             if not coverage_ready:
                 now_ms = utc_ms()
                 if self._fill_coverage_retry_deferred(coverage_status, now_ms):
@@ -12048,6 +12106,7 @@ class Passivbot:
 
             # Find and log new events (those not in cache before refresh)
             all_events = self._pnls_manager.get_events()
+            flush_enriched_events()
             # Trailing fill confirmation only needs proof that a fill-cache
             # refresh completed after the position snapshot. Keep this
             # separate from the risk-authoritative fills generation below,
@@ -12055,7 +12114,6 @@ class Passivbot:
             if fill_fetch_completed:
                 self._trailing_fill_fetch_generation = fill_refresh_attempt_generation
             new_events = []
-            enriched_events = []
             seen_new_source_ids: set[str] = set()
             for ev in all_events:
                 src_ids = getattr(ev, "source_ids", None)
@@ -12066,25 +12124,6 @@ class Passivbot:
                 if not src_ids:
                     continue
                 if any(src_id in existing_source_ids for src_id in src_ids):
-                    prev = existing_by_id.get(str(getattr(ev, "id", "")))
-                    if prev is None:
-                        for src_id in src_ids:
-                            prev = existing_by_source_id.get(src_id)
-                            if prev is not None:
-                                break
-                    previous_needs_enrichment = (
-                        prev is not None
-                        and (
-                            fill_event_pnl_pending(prev)
-                            or bool(FillEventsManager.synthetic_pnl_events([prev]))
-                        )
-                    )
-                    current_is_authoritative = (
-                        not fill_event_pnl_pending(ev)
-                        and not FillEventsManager.synthetic_pnl_events([ev])
-                    )
-                    if previous_needs_enrichment and current_is_authoritative:
-                        enriched_events.append((prev, ev))
                     continue
                 if any(src_id in seen_new_source_ids for src_id in src_ids):
                     continue
@@ -12092,9 +12131,6 @@ class Passivbot:
                 seen_new_source_ids.update(src_ids)
             if new_events:
                 self._log_new_fill_events(new_events)
-                self._request_authoritative_confirmation(ACCOUNT_SURFACES)
-            if enriched_events:
-                self._log_enriched_fill_events(enriched_events)
                 self._request_authoritative_confirmation(ACCOUNT_SURFACES)
             pending_pnl_events = FillEventsManager.pending_pnl_events(all_events)
             degraded_pnl_events = [
@@ -12202,6 +12238,7 @@ class Passivbot:
             return pnls_safe and coverage_ready_after
 
         except RateLimitExceeded as e:
+            flush_enriched_events()
             if self._shutdown_requested():
                 logging.debug(
                     "[shutdown] fill refresh stopped during rate-limit handling"
@@ -12230,6 +12267,7 @@ class Passivbot:
             )
             return False
         except Exception as e:
+            flush_enriched_events()
             if self._shutdown_requested():
                 logging.debug(
                     "[shutdown] fill refresh stopped during in-flight request | error_type=%s",
@@ -12342,8 +12380,10 @@ class Passivbot:
         for event in new_events:
             if fill_event_pnl_pending(event):
                 continue
-            self._health_pnl += fill_event_net_pnl(event)
-            Passivbot._mark_health_fill_pnl_counted(self, event)
+            net_pnl = fill_event_net_pnl(event)
+            self._health_pnl += net_pnl
+            if FillEventsManager.synthetic_pnl_events([event]):
+                Passivbot._mark_health_fill_pnl_counted(self, event, net_pnl)
 
         batch_summary = len(new_events) > 20
         pending_count = 0
@@ -12416,16 +12456,35 @@ class Passivbot:
                 keys.add(f"source:{normalized}")
         return keys
 
-    def _health_fill_pnl_was_counted(self, event: object) -> bool:
-        counted = set(getattr(self, "_health_counted_fill_keys", set()) or set())
-        return bool(Passivbot._health_fill_identity_keys(event) & counted)
+    def _health_fill_counted_net_pnl(self, event: object) -> float | None:
+        counted = getattr(self, "_health_counted_synthetic_pnl_by_key", {}) or {}
+        for key in Passivbot._health_fill_identity_keys(event):
+            if key in counted:
+                return float(counted[key])
+        return None
 
-    def _mark_health_fill_pnl_counted(self, event: object) -> None:
-        counted = getattr(self, "_health_counted_fill_keys", None)
+    def _mark_health_fill_pnl_counted(
+        self, event: object, net_pnl: float | None = None
+    ) -> None:
+        counted = getattr(self, "_health_counted_synthetic_pnl_by_key", None)
         if counted is None:
-            counted = set()
-            self._health_counted_fill_keys = counted
-        counted.update(Passivbot._health_fill_identity_keys(event))
+            counted = {}
+            self._health_counted_synthetic_pnl_by_key = counted
+        amount = (
+            fill_event_net_pnl(event)
+            if net_pnl is None
+            else float(net_pnl)
+        )
+        for key in Passivbot._health_fill_identity_keys(event):
+            counted[key] = amount
+
+    def _forget_health_fill_pnl_counted(self, *events: object) -> None:
+        counted = getattr(self, "_health_counted_synthetic_pnl_by_key", None)
+        if not counted:
+            return
+        for event in events:
+            for key in Passivbot._health_fill_identity_keys(event):
+                counted.pop(key, None)
 
     def _log_enriched_fill_events(self, transitions: list[tuple[object, object]]) -> None:
         """Log authoritative PnL replacing pending or synthetic cached values."""
@@ -12434,15 +12493,12 @@ class Passivbot:
         for previous, event in sorted(
             transitions, key=lambda item: item[1].timestamp
         ):
-            previous_counted = Passivbot._health_fill_pnl_was_counted(self, previous)
-            previous_net_pnl = (
-                fill_event_net_pnl(previous)
-                if previous_counted and not fill_event_pnl_pending(previous)
-                else 0.0
-            )
+            counted_net_pnl = Passivbot._health_fill_counted_net_pnl(self, previous)
+            previous_counted = counted_net_pnl is not None
+            previous_net_pnl = float(counted_net_pnl or 0.0)
             pnl_delta = fill_event_net_pnl(event) - previous_net_pnl
             self._health_pnl += pnl_delta
-            Passivbot._mark_health_fill_pnl_counted(self, event)
+            Passivbot._forget_health_fill_pnl_counted(self, previous, event)
             previous_source = str(
                 getattr(previous, "pnl_source", "") or "pending"
             ).lower()

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -6063,7 +6063,7 @@ class Passivbot:
         self._execution_loop_task_is_inline = True
         self._execution_loop_stopped = execution_loop_stopped
         failed_update_pos_oos_pnls_ohlcvs_count = 0
-        pending_pnl_authoritative_retry_count = 0
+        unsafe_pnl_authoritative_retry_count = 0
         max_n_fails = 10
         if self._equity_hard_stop_enabled():
             if self._equity_hard_stop_signal_mode() == "coin":
@@ -6120,35 +6120,65 @@ class Passivbot:
                             data={"timings_ms": dict(loop_timings_ms)},
                         )
                         break
-                    if (
-                        getattr(self, "_last_authoritative_block_reason", None)
-                        == "pending_pnl"
-                    ):
-                        pending_pnl_authoritative_retry_count += 1
+                    if getattr(self, "_last_authoritative_block_reason", None) in {
+                        "pending_pnl",
+                        "degraded_pnl",
+                    }:
+                        unsafe_pnl_authoritative_retry_count += 1
                         failed_update_pos_oos_pnls_ohlcvs_count = 0
                         retry_delay_seconds = (
                             self._pending_pnl_authoritative_retry_delay_seconds(
-                                pending_pnl_authoritative_retry_count
+                                unsafe_pnl_authoritative_retry_count
                             )
                         )
-                        self._maybe_log_pending_pnl_authoritative_block(
+                        self._maybe_log_pnl_authoritative_block(
                             retry_delay_seconds=retry_delay_seconds
                         )
                         self._emit_live_cycle_degraded(
                             cycle_id=cycle_id,
-                            reason_code="pending_pnl_authoritative_refresh",
+                            reason_code=(
+                                "degraded_pnl_authoritative_refresh"
+                                if getattr(
+                                    self, "_last_authoritative_block_reason", None
+                                )
+                                == "degraded_pnl"
+                                else "pending_pnl_authoritative_refresh"
+                            ),
                             data={
-                                "retry_count": pending_pnl_authoritative_retry_count,
+                                "retry_count": unsafe_pnl_authoritative_retry_count,
                                 "retry_delay_seconds": retry_delay_seconds,
+                                "pending_pnl_count": int(
+                                    getattr(
+                                        self,
+                                        "_last_authoritative_pending_pnl_count",
+                                        0,
+                                    )
+                                    or 0
+                                ),
+                                "degraded_pnl_count": int(
+                                    getattr(
+                                        self,
+                                        "_last_authoritative_degraded_pnl_count",
+                                        0,
+                                    )
+                                    or 0
+                                ),
                                 "timings_ms": dict(loop_timings_ms),
                             },
                         )
                         await self._sleep_unless_shutdown(
                             retry_delay_seconds,
-                            stage="pending_pnl_authoritative_retry",
+                            stage=(
+                                "degraded_pnl_authoritative_retry"
+                                if getattr(
+                                    self, "_last_authoritative_block_reason", None
+                                )
+                                == "degraded_pnl"
+                                else "pending_pnl_authoritative_retry"
+                            ),
                         )
                     else:
-                        pending_pnl_authoritative_retry_count = 0
+                        unsafe_pnl_authoritative_retry_count = 0
                         failed_update_pos_oos_pnls_ohlcvs_count += 1
                         self._emit_live_cycle_degraded(
                             cycle_id=cycle_id,
@@ -6167,7 +6197,7 @@ class Passivbot:
                         if failed_update_pos_oos_pnls_ohlcvs_count > max_n_fails:
                             await self.restart_bot_on_too_many_errors()
                     continue
-                pending_pnl_authoritative_retry_count = 0
+                unsafe_pnl_authoritative_retry_count = 0
                 failed_update_pos_oos_pnls_ohlcvs_count = 0
                 if self.stop_signal_received:
                     self._emit_live_cycle_degraded(
@@ -6538,18 +6568,23 @@ class Passivbot:
         delay = PENDING_PNL_AUTHORITATIVE_RETRY_BASE_SECONDS * (2**retry_index)
         return float(min(PENDING_PNL_AUTHORITATIVE_RETRY_MAX_SECONDS, delay))
 
-    def _maybe_log_pending_pnl_authoritative_block(
+    def _maybe_log_pnl_authoritative_block(
         self, *, retry_delay_seconds: float
     ) -> None:
         pending_count = int(getattr(self, "_last_authoritative_pending_pnl_count", 0) or 0)
+        degraded_count = int(
+            getattr(self, "_last_authoritative_degraded_pnl_count", 0) or 0
+        )
         now = utc_ms()
         last_log = int(getattr(self, "_pending_pnl_authoritative_block_log_ms", 0) or 0)
         if now - last_log < 60_000:
             return
         self._pending_pnl_authoritative_block_log_ms = now
         logging.info(
-            "[fills] authoritative refresh waiting for realized PnL enrichment | pending_pnl=%d action=retry_without_restart retry_in=%.1fs",
+            "[fills] authoritative refresh waiting for realized PnL enrichment | "
+            "pending_pnl=%d degraded_pnl=%d action=retry_without_restart retry_in=%.1fs",
             pending_count,
+            degraded_count,
             float(retry_delay_seconds),
         )
 
@@ -11844,7 +11879,22 @@ class Passivbot:
             needs_full_refresh = lookback.is_all and not coverage_ready
             needs_lookback_refresh = (not lookback.is_all) and not coverage_ready
             fill_fetch_completed = False
+            degraded_repair_attempted = False
             history_scope = str(coverage_status.get("history_scope", "unknown"))
+            degraded_before = [
+                event
+                for event in FillEventsManager.degraded_pnl_events(events)
+                if age_limit is None or int(event.timestamp) >= int(age_limit)
+            ]
+            repair_degraded = getattr(
+                self._pnls_manager, "refresh_degraded_pnl_events", None
+            )
+            if coverage_ready and degraded_before and callable(repair_degraded):
+                degraded_repair_attempted = True
+                await repair_degraded(
+                    start_ms=None if age_limit is None else int(age_limit),
+                    end_ms=int(self.get_exchange_time()),
+                )
             if not coverage_ready:
                 now_ms = utc_ms()
                 if self._fill_coverage_retry_deferred(coverage_status, now_ms):
@@ -11992,6 +12042,8 @@ class Passivbot:
                             last_refresh_overlap_ms=int(overlap_minutes * 60 * 1000),
                         )
                 fill_fetch_completed = True
+            if degraded_repair_attempted:
+                refresh_mode = f"{refresh_mode}_with_degraded_pnl_repair"
 
             # Find and log new events (those not in cache before refresh)
             all_events = self._pnls_manager.get_events()
@@ -12019,12 +12071,19 @@ class Passivbot:
                             prev = existing_by_source_id.get(src_id)
                             if prev is not None:
                                 break
-                    if (
+                    previous_needs_enrichment = (
                         prev is not None
-                        and fill_event_pnl_pending(prev)
-                        and not fill_event_pnl_pending(ev)
-                    ):
-                        enriched_events.append(ev)
+                        and (
+                            fill_event_pnl_pending(prev)
+                            or bool(FillEventsManager.synthetic_pnl_events([prev]))
+                        )
+                    )
+                    current_is_authoritative = (
+                        not fill_event_pnl_pending(ev)
+                        and not FillEventsManager.synthetic_pnl_events([ev])
+                    )
+                    if previous_needs_enrichment and current_is_authoritative:
+                        enriched_events.append((prev, ev))
                     continue
                 if any(src_id in seen_new_source_ids for src_id in src_ids):
                     continue
@@ -12037,15 +12096,21 @@ class Passivbot:
                 self._log_enriched_fill_events(enriched_events)
                 self._request_authoritative_confirmation(ACCOUNT_SURFACES)
             pending_pnl_events = FillEventsManager.pending_pnl_events(all_events)
+            degraded_pnl_events = [
+                event
+                for event in FillEventsManager.degraded_pnl_events(all_events)
+                if age_limit is None or int(event.timestamp) >= int(age_limit)
+            ]
             self._last_fill_refresh_pending_pnl_count = len(pending_pnl_events)
-            pnls_complete = not pending_pnl_events
+            self._last_fill_refresh_degraded_pnl_count = len(degraded_pnl_events)
+            pnls_safe = not pending_pnl_events and not degraded_pnl_events
             post_refresh_coverage_status = self._pnl_history_coverage_status(
                 start_ms=age_limit,
                 end_ms=self.get_exchange_time(),
                 lookback=lookback,
             )
             coverage_ready_after = bool(post_refresh_coverage_status.get("ready", False))
-            if pnls_complete and coverage_ready_after:
+            if pnls_safe and coverage_ready_after:
                 self._clear_fill_coverage_retry_defer()
                 self._record_authoritative_surface(
                     "fills", self._fill_events_signature(all_events)
@@ -12053,7 +12118,7 @@ class Passivbot:
                 self._trailing_fill_refresh_generation = (
                     fill_refresh_attempt_generation
                 )
-            elif pnls_complete and not coverage_ready_after:
+            elif pnls_safe and not coverage_ready_after:
                 self._record_fill_coverage_retry_defer(post_refresh_coverage_status)
                 state = getattr(self, "_fill_coverage_retry_state", {}) or {}
                 next_retry_ms = int(state.get("next_retry_ms", 0) or 0)
@@ -12083,7 +12148,10 @@ class Passivbot:
                 else logging.DEBUG
             )
             logging.debug(
-                "[fills] refresh timing | source=%s mode=%s | elapsed=%dms | before=%d after=%d new=%d | lookback=%s scope=%s coverage_ready=%s coverage_reason=%s overlap_minutes=%s pending_pnl=%d",
+                "[fills] refresh timing | source=%s mode=%s | elapsed=%dms | "
+                "before=%d after=%d new=%d | lookback=%s scope=%s "
+                "coverage_ready=%s coverage_reason=%s overlap_minutes=%s "
+                "pending_pnl=%d degraded_pnl=%d",
                 source,
                 refresh_mode,
                 elapsed_ms,
@@ -12096,18 +12164,23 @@ class Passivbot:
                 str(post_refresh_coverage_status.get("reason", "unknown")),
                 (f"{overlap_minutes:.3f}" if overlap_minutes is not None else "-"),
                 len(pending_pnl_events),
+                len(degraded_pnl_events),
             )
             self._emit_fills_refresh_summary_event(
                 source=source,
                 refresh_mode=refresh_mode,
-                status="succeeded" if pnls_complete and coverage_ready_after else "deferred",
+                status="succeeded" if pnls_safe and coverage_ready_after else "deferred",
                 reason_code=(
                     "fills_refresh_succeeded"
-                    if pnls_complete and coverage_ready_after
+                    if pnls_safe and coverage_ready_after
                     else (
                         "pending_pnl_enrichment"
-                        if not pnls_complete
-                        else "fill_history_coverage_unavailable"
+                        if pending_pnl_events
+                        else (
+                            "degraded_pnl_enrichment"
+                            if degraded_pnl_events
+                            else "fill_history_coverage_unavailable"
+                        )
                     )
                 ),
                 elapsed_ms=elapsed_ms,
@@ -12118,13 +12191,14 @@ class Passivbot:
                 new_count=len(new_events),
                 enriched_count=len(enriched_events),
                 pending_pnl_count=len(pending_pnl_events),
+                degraded_pnl_count=len(degraded_pnl_events),
                 coverage_before=coverage_status,
                 coverage_after=post_refresh_coverage_status,
                 overlap_minutes=overlap_minutes,
                 level=logging.getLevelName(structured_event_level).lower(),
             )
 
-            return pnls_complete and coverage_ready_after
+            return pnls_safe and coverage_ready_after
 
         except RateLimitExceeded as e:
             if self._shutdown_requested():
@@ -12327,16 +12401,35 @@ class Passivbot:
                     pending_pnl_count=pending_count,
                 )
 
-    def _log_enriched_fill_events(self, events: list) -> None:
-        """Log realized-PnL enrichment for already seen close fills."""
-        if not events:
+    def _log_enriched_fill_events(self, transitions: list[tuple[object, object]]) -> None:
+        """Log authoritative PnL replacing pending or synthetic cached values."""
+        if not transitions:
             return
         self._health_pnl += sum(
-            fill_event_net_pnl(ev) for ev in events if not fill_event_pnl_pending(ev)
+            fill_event_net_pnl(event)
+            - (
+                0.0
+                if fill_event_pnl_pending(previous)
+                else fill_event_net_pnl(previous)
+            )
+            for previous, event in transitions
         )
-        for event in sorted(events, key=lambda e: e.timestamp):
+        for previous, event in sorted(
+            transitions, key=lambda item: item[1].timestamp
+        ):
+            previous_source = str(
+                getattr(previous, "pnl_source", "") or "pending"
+            ).lower()
             logging.info(
-                "[fill] enriched realized pnl for previously pending fill | %s",
+                "[fill] authoritative realized pnl replaced cached estimate | "
+                "previous_source=%s pnl_delta=%+.8g | %s",
+                previous_source,
+                fill_event_net_pnl(event)
+                - (
+                    0.0
+                    if fill_event_pnl_pending(previous)
+                    else fill_event_net_pnl(previous)
+                ),
                 self._log_fill_event(event),
             )
 

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -4764,6 +4764,96 @@ async def test_manager_refresh_latest_skips_old_synthetic_pnl_repair_window(
 
 
 @pytest.mark.asyncio
+async def test_manager_targeted_repair_heals_old_degraded_pnl(tmp_path: Path):
+    cache_dir = tmp_path / "fills_old_degraded_targeted_repair"
+    now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+    entry_ts = now_ms - 28 * 24 * 60 * 60 * 1000
+    close_ts = entry_ts + 60_000
+    entry = dict(
+        id="entry",
+        timestamp=entry_ts,
+        datetime="",
+        symbol="SOL/USDT:USDT",
+        side="buy",
+        qty=5.0,
+        price=100.0,
+        pnl=0.0,
+        pnl_status="complete",
+        pb_order_type="entry_grid_long",
+        position_side="long",
+        client_order_id="cid-entry",
+    )
+    pending_close = dict(
+        id="close",
+        timestamp=close_ts,
+        datetime="",
+        symbol="SOL/USDT:USDT",
+        side="sell",
+        qty=-6.0,
+        price=103.0,
+        pnl=0.0,
+        pnl_status="pending",
+        pb_order_type="close_grid_long",
+        position_side="long",
+        client_order_id="cid-close",
+    )
+    authoritative_close = dict(pending_close)
+    authoritative_close["pnl"] = 12.0
+    authoritative_close["pnl_status"] = "complete"
+
+    class _RecordingFetcher(BaseFetcher):
+        def __init__(self):
+            self.calls: List[Tuple[Optional[int], Optional[int]]] = []
+            self.batches = [[entry, pending_close], [authoritative_close]]
+
+        async def fetch(self, since_ms, until_ms, detail_cache, on_batch=None):
+            self.calls.append((since_ms, until_ms))
+            batch = [dict(event) for event in self.batches.pop(0)]
+            if since_ms is not None:
+                batch = [event for event in batch if event["timestamp"] >= since_ms]
+            if until_ms is not None:
+                batch = [event for event in batch if event["timestamp"] <= until_ms]
+            if on_batch and batch:
+                on_batch(batch)
+            return batch
+
+    fetcher = _RecordingFetcher()
+    manager = FillEventsManager(
+        exchange="bybit",
+        user="default",
+        fetcher=fetcher,
+        cache_path=cache_dir,
+        fee_pct_fallback=0.0,
+    )
+
+    await manager.refresh()
+    close = next(event for event in manager.get_events() if event.id == "close")
+    assert close.pnl_source == fem.PNL_SOURCE_SYNTHETIC_DEGRADED
+    assert close.pnl_synthetic_reason == "close_exceeds_known_position"
+
+    report = await manager.refresh_degraded_pnl_events(
+        start_ms=entry_ts - 60_000,
+        end_ms=now_ms,
+    )
+
+    assert fetcher.calls[1] == (
+        max(entry_ts - 60_000, close_ts - fem.PENDING_PNL_REFRESH_MARGIN_MS),
+        close_ts + fem.KUCOIN_POSITION_HISTORY_LOOKAHEAD_MS,
+    )
+    assert report == {
+        "attempted": True,
+        "before_count": 1,
+        "repaired_count": 1,
+        "remaining_count": 0,
+        "range_count": 1,
+    }
+    close = next(event for event in manager.get_events() if event.id == "close")
+    assert close.pnl == pytest.approx(12.0)
+    assert close.pnl_source == fem.PNL_SOURCE_AUTHORITATIVE
+    assert not FillEventsManager.degraded_pnl_events(manager.get_events())
+
+
+@pytest.mark.asyncio
 async def test_manager_synthesizes_pending_close_pnl_with_contract_value(
     tmp_path: Path, caplog
 ):

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -4804,7 +4804,7 @@ async def test_manager_targeted_repair_heals_old_degraded_pnl(tmp_path: Path):
     class _RecordingFetcher(BaseFetcher):
         def __init__(self):
             self.calls: List[Tuple[Optional[int], Optional[int]]] = []
-            self.batches = [[entry, pending_close], [authoritative_close]]
+            self.batches = [[entry, pending_close], [authoritative_close], []]
 
         async def fetch(self, since_ms, until_ms, detail_cache, on_batch=None):
             self.calls.append((since_ms, until_ms))
@@ -4830,6 +4830,10 @@ async def test_manager_targeted_repair_heals_old_degraded_pnl(tmp_path: Path):
     close = next(event for event in manager.get_events() if event.id == "close")
     assert close.pnl_source == fem.PNL_SOURCE_SYNTHETIC_DEGRADED
     assert close.pnl_synthetic_reason == "close_exceeds_known_position"
+    previous_refresh_ms = close_ts + 2 * 60 * 60 * 1000
+    metadata = manager.cache.load_metadata()
+    metadata["last_refresh_ms"] = previous_refresh_ms
+    manager.cache.save_metadata(metadata)
 
     report = await manager.refresh_degraded_pnl_events(
         start_ms=entry_ts - 60_000,
@@ -4846,11 +4850,81 @@ async def test_manager_targeted_repair_heals_old_degraded_pnl(tmp_path: Path):
         "repaired_count": 1,
         "remaining_count": 0,
         "range_count": 1,
+        "total_range_count": 1,
+        "deferred_range_count": 0,
     }
+    assert manager.cache.load_metadata()["last_refresh_ms"] == previous_refresh_ms
     close = next(event for event in manager.get_events() if event.id == "close")
     assert close.pnl == pytest.approx(12.0)
     assert close.pnl_source == fem.PNL_SOURCE_AUTHORITATIVE
     assert not FillEventsManager.degraded_pnl_events(manager.get_events())
+
+    overlap_ms = 60_000
+    await manager.refresh_latest(
+        overlap=20,
+        last_refresh_overlap_ms=overlap_ms,
+    )
+    assert fetcher.calls[2] == (previous_refresh_ms - overlap_ms, None)
+
+
+@pytest.mark.asyncio
+async def test_manager_degraded_pnl_repair_caps_and_rotates_ranges(tmp_path: Path):
+    manager = FillEventsManager(
+        exchange="bybit",
+        user="default",
+        fetcher=BaseFetcher(),
+        cache_path=tmp_path / "fills_degraded_repair_cap",
+    )
+    start_ms = 1_700_000_000_000
+    interval_spacing_ms = 30 * 60 * 1000
+    manager._events = [
+        types.SimpleNamespace(
+            timestamp=start_ms + index * interval_spacing_ms,
+            pnl_source=fem.PNL_SOURCE_SYNTHETIC_DEGRADED,
+        )
+        for index in range(6)
+    ]
+    manager._loaded = True
+    manager.refresh = AsyncMock()
+
+    first = await manager.refresh_degraded_pnl_events(
+        start_ms=start_ms - 60_000,
+        end_ms=start_ms + 6 * interval_spacing_ms,
+    )
+    first_calls = list(manager.refresh.await_args_list)
+
+    assert first["range_count"] == fem.DEGRADED_PNL_REPAIR_MAX_INTERVALS_PER_CYCLE
+    assert first["total_range_count"] == 6
+    assert first["deferred_range_count"] == 2
+    assert len(first_calls) == 4
+    assert all(call.kwargs["mark_refreshed"] is False for call in first_calls)
+
+    manager.refresh.reset_mock()
+    second = await manager.refresh_degraded_pnl_events(
+        start_ms=start_ms - 60_000,
+        end_ms=start_ms + 6 * interval_spacing_ms,
+    )
+    second_calls = list(manager.refresh.await_args_list)
+
+    assert second["range_count"] == 2
+    assert second["total_range_count"] == 6
+    assert second["deferred_range_count"] == 0
+    assert len(second_calls) == 2
+    assert {
+        (
+            call.kwargs["start_ms"],
+            call.kwargs["end_ms"],
+        )
+        for call in first_calls
+    }.isdisjoint(
+        {
+            (
+                call.kwargs["start_ms"],
+                call.kwargs["end_ms"],
+            )
+            for call in second_calls
+        }
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -7,7 +7,7 @@ import types
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -3069,6 +3069,43 @@ async def test_bybit_closed_pnl_fetch_propagates_api_error():
 
 
 @pytest.mark.asyncio
+async def test_bybit_degraded_repair_uses_independent_trade_and_pnl_ranges():
+    fetcher = BybitFetcher(api=object())
+    trade_start_ms = 1_700_000_000_000
+    trade_end_ms = trade_start_ms + 15 * 60_000
+    pnl_start_ms = trade_start_ms + 3 * 86_400_000
+    pnl_end_ms = pnl_start_ms + 86_400_000
+    trade = {"id": "trade-1"}
+    position = {"id": "position-1"}
+    event = {
+        "id": "trade-1",
+        "timestamp": trade_start_ms + 60_000,
+    }
+    fetcher._fetch_my_trades = AsyncMock(return_value=[trade])
+    fetcher._fetch_positions_history = AsyncMock(return_value=[position])
+    fetcher._combine = MagicMock(return_value=[event])
+
+    out = await fetcher.fetch_degraded_pnl_repair(
+        trade_start_ms,
+        trade_end_ms,
+        pnl_start_ms,
+        pnl_end_ms,
+        detail_cache={},
+    )
+
+    assert len(out) == 1
+    assert out[0]["id"] == event["id"]
+    assert out[0]["timestamp"] == event["timestamp"]
+    fetcher._fetch_my_trades.assert_awaited_once_with(
+        trade_start_ms, trade_end_ms
+    )
+    fetcher._fetch_positions_history.assert_awaited_once_with(
+        pnl_start_ms, pnl_end_ms
+    )
+    fetcher._combine.assert_called_once_with([trade], [position], {})
+
+
+@pytest.mark.asyncio
 async def test_bybit_fetcher_uses_detail_cache(monkeypatch):
     base_ts = int(datetime.now(timezone.utc).timestamp() * 1000)
     trades_batches = [
@@ -4876,7 +4913,7 @@ async def test_manager_degraded_pnl_repair_caps_and_rotates_ranges(tmp_path: Pat
         cache_path=tmp_path / "fills_degraded_repair_cap",
     )
     start_ms = 1_700_000_000_000
-    interval_spacing_ms = 30 * 60 * 1000
+    interval_spacing_ms = 60_000
     manager._events = [
         types.SimpleNamespace(
             timestamp=start_ms + index * interval_spacing_ms,
@@ -4888,8 +4925,8 @@ async def test_manager_degraded_pnl_repair_caps_and_rotates_ranges(tmp_path: Pat
     manager.refresh = AsyncMock()
 
     first = await manager.refresh_degraded_pnl_events(
-        start_ms=start_ms - 60_000,
-        end_ms=start_ms + 6 * interval_spacing_ms,
+        start_ms=start_ms - 10 * 60_000,
+        end_ms=start_ms + 20 * 60_000,
     )
     first_calls = list(manager.refresh.await_args_list)
 
@@ -4898,11 +4935,17 @@ async def test_manager_degraded_pnl_repair_caps_and_rotates_ranges(tmp_path: Pat
     assert first["deferred_range_count"] == 2
     assert len(first_calls) == 4
     assert all(call.kwargs["mark_refreshed"] is False for call in first_calls)
+    assert all(
+        call.kwargs["end_ms"] - call.kwargs["start_ms"]
+        <= fem.PENDING_PNL_REFRESH_MARGIN_MS
+        + fem.KUCOIN_POSITION_HISTORY_LOOKAHEAD_MS
+        for call in first_calls
+    )
 
     manager.refresh.reset_mock()
     second = await manager.refresh_degraded_pnl_events(
-        start_ms=start_ms - 60_000,
-        end_ms=start_ms + 6 * interval_spacing_ms,
+        start_ms=start_ms - 10 * 60_000,
+        end_ms=start_ms + 20 * 60_000,
     )
     second_calls = list(manager.refresh.await_args_list)
 
@@ -4924,6 +4967,63 @@ async def test_manager_degraded_pnl_repair_caps_and_rotates_ranges(tmp_path: Pat
             )
             for call in second_calls
         }
+    )
+
+
+@pytest.mark.asyncio
+async def test_manager_degraded_pnl_repair_advances_bounded_auxiliary_windows(
+    tmp_path: Path,
+):
+    class _DelayedPnlFetcher(BaseFetcher):
+        async def fetch_degraded_pnl_repair(self, *args, **kwargs):
+            return []
+
+    manager = FillEventsManager(
+        exchange="bybit",
+        user="default",
+        fetcher=_DelayedPnlFetcher(),
+        cache_path=tmp_path / "fills_degraded_delayed_aux",
+    )
+    event_ts = 1_700_000_000_000
+    upper_bound = event_ts + 3 * fem.DEGRADED_PNL_REPAIR_MAX_INTERVAL_SPAN_MS
+    manager._events = [
+        types.SimpleNamespace(
+            id="close-1",
+            source_ids=["trade-1"],
+            timestamp=event_ts,
+            pnl_source=fem.PNL_SOURCE_SYNTHETIC_DEGRADED,
+        )
+    ]
+    manager._loaded = True
+    manager.refresh = AsyncMock()
+
+    await manager.refresh_degraded_pnl_events(
+        start_ms=event_ts - 10 * 60_000,
+        end_ms=upper_bound,
+    )
+    first_aux_range = manager.refresh.await_args.kwargs[
+        "degraded_pnl_aux_range"
+    ]
+
+    manager.refresh.reset_mock()
+    await manager.refresh_degraded_pnl_events(
+        start_ms=event_ts - 10 * 60_000,
+        end_ms=upper_bound,
+    )
+    second_aux_range = manager.refresh.await_args.kwargs[
+        "degraded_pnl_aux_range"
+    ]
+
+    assert first_aux_range[1] - first_aux_range[0] <= (
+        fem.DEGRADED_PNL_REPAIR_MAX_INTERVAL_SPAN_MS
+    )
+    assert second_aux_range[0] == first_aux_range[1]
+    assert second_aux_range[1] > first_aux_range[1]
+    assert manager.refresh.await_args.kwargs["start_ms"] == (
+        event_ts - fem.PENDING_PNL_REFRESH_MARGIN_MS
+    )
+    assert manager.refresh.await_args.kwargs["end_ms"] == (
+        event_ts + fem.KUCOIN_POSITION_HISTORY_LOOKAHEAD_MS
     )
 
 

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -6303,7 +6303,10 @@ async def test_update_pnls_window_lookback_uses_incremental_when_coverage_proven
 
 
 @pytest.mark.asyncio
-async def test_update_pnls_repairs_old_degraded_pnl_before_marking_fills_authoritative():
+@pytest.mark.parametrize("failure_stage", [None, "repair", "routine"])
+async def test_update_pnls_repairs_old_degraded_pnl_before_marking_fills_authoritative(
+    failure_stage,
+):
     bot = Passivbot.__new__(Passivbot)
     now_ms = 1_800_000_000_000
     lookback_days = 30.0
@@ -6358,6 +6361,8 @@ async def test_update_pnls_repairs_old_degraded_pnl_before_marking_fills_authori
 
         async def _repair_degraded(self, **_kwargs):
             self._events = [authoritative]
+            if failure_stage == "repair":
+                raise RuntimeError("later repair range unavailable")
             return {
                 "attempted": True,
                 "before_count": 1,
@@ -6389,6 +6394,10 @@ async def test_update_pnls_repairs_old_degraded_pnl_before_marking_fills_authori
     }
     bot._authoritative_pending_confirmations = {}
     bot._pnls_manager = _Manager()
+    if failure_stage == "routine":
+        bot._pnls_manager.refresh_latest.side_effect = RuntimeError(
+            "routine refresh unavailable"
+        )
     bot.init_pnls = AsyncMock()
     bot.live_value = lambda key: bot.config["live"][key]
     bot.get_exchange_time = lambda: now_ms
@@ -6401,22 +6410,35 @@ async def test_update_pnls_repairs_old_degraded_pnl_before_marking_fills_authori
     bot._emit_fills_refresh_summary_event = MagicMock()
     bot.logging_level = 0
     bot._health_rate_limits = 0
+    bot._shutdown_requested = lambda: False
+    bot._maybe_recover_exchange_time_sync = AsyncMock(return_value=False)
 
-    result = await bot.update_pnls(source="staged_blocking")
+    if failure_stage is not None:
+        with pytest.raises(RuntimeError, match="unavailable"):
+            await bot.update_pnls(source="staged_blocking")
+        result = None
+    else:
+        result = await bot.update_pnls(source="staged_blocking")
 
-    assert result is True
+    if failure_stage is None:
+        assert result is True
     bot._pnls_manager.refresh_degraded_pnl_events.assert_awaited_once_with(
         start_ms=start_ms,
         end_ms=now_ms,
     )
-    bot._pnls_manager.refresh_latest.assert_awaited_once_with(
-        overlap=20,
-        last_refresh_overlap_ms=10 * 60 * 1000,
-    )
+    if failure_stage == "repair":
+        bot._pnls_manager.refresh_latest.assert_not_awaited()
+    else:
+        bot._pnls_manager.refresh_latest.assert_awaited_once_with(
+            overlap=20,
+            last_refresh_overlap_ms=10 * 60 * 1000,
+        )
     bot._log_enriched_fill_events.assert_called_once()
     previous, current = bot._log_enriched_fill_events.call_args.args[0][0]
     assert previous is degraded
     assert current is authoritative
+    if failure_stage is not None:
+        return
     summary = bot._emit_fills_refresh_summary_event.call_args.kwargs
     assert summary["refresh_mode"] == "incremental_recent_with_degraded_pnl_repair"
     assert summary["enriched_count"] == 1

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -38,6 +38,7 @@ sys.modules.setdefault(
 
 from passivbot import Passivbot
 import passivbot as passivbot_module
+import fill_events_manager as fem
 from config import get_template_config, prepare_config
 from freshness_ledger import ACCOUNT_SURFACES, LIVE_STATE_SURFACES, FreshnessLedger
 from live.planning_availability import PlanningAvailability
@@ -6302,6 +6303,129 @@ async def test_update_pnls_window_lookback_uses_incremental_when_coverage_proven
 
 
 @pytest.mark.asyncio
+async def test_update_pnls_repairs_old_degraded_pnl_before_marking_fills_authoritative():
+    bot = Passivbot.__new__(Passivbot)
+    now_ms = 1_800_000_000_000
+    lookback_days = 30.0
+    start_ms = now_ms - int(lookback_days * 86_400_000)
+    degraded = SimpleNamespace(
+        timestamp=start_ms + 60_000,
+        id="degraded-close",
+        source_ids=["degraded-close"],
+        symbol="SOL/USDT:USDT",
+        position_side="long",
+        side="sell",
+        qty=-4.0,
+        price=103.0,
+        pnl=5.0,
+        fee_paid=-0.1,
+        pnl_status="complete",
+        pnl_source=fem.PNL_SOURCE_SYNTHETIC_DEGRADED,
+    )
+    authoritative = SimpleNamespace(
+        **{
+            **vars(degraded),
+            "pnl": 3.0,
+            "pnl_source": fem.PNL_SOURCE_AUTHORITATIVE,
+        }
+    )
+
+    class _Cache:
+        def load_metadata(self):
+            return {
+                "covered_start_ms": start_ms,
+                "oldest_event_ts": degraded.timestamp,
+                "history_scope": "window",
+                "known_gaps": [],
+            }
+
+        def get_known_gaps(self):
+            return []
+
+        def get_covered_start_ms(self):
+            return start_ms
+
+    class _Manager:
+        def __init__(self):
+            self._events = [degraded]
+            self.cache = _Cache()
+            self.refresh = AsyncMock()
+            self.refresh_latest = AsyncMock()
+            self.refresh_for_lookback = AsyncMock()
+            self.refresh_degraded_pnl_events = AsyncMock(
+                side_effect=self._repair_degraded
+            )
+
+        async def _repair_degraded(self, **_kwargs):
+            self._events = [authoritative]
+            return {
+                "attempted": True,
+                "before_count": 1,
+                "repaired_count": 1,
+                "remaining_count": 0,
+                "range_count": 1,
+            }
+
+        def get_events(self, start_ms=None, end_ms=None):
+            events = list(self._events)
+            if start_ms is not None:
+                events = [event for event in events if event.timestamp >= start_ms]
+            if end_ms is not None:
+                events = [event for event in events if event.timestamp <= end_ms]
+            return events
+
+        def get_history_scope(self):
+            return "window"
+
+        def set_history_scope(self, _scope):
+            pass
+
+    bot.stop_signal_received = False
+    bot.config = {
+        "live": {
+            "fills_recent_overlap_minutes": 10.0,
+            "pnls_max_lookback_days": lookback_days,
+        }
+    }
+    bot._authoritative_pending_confirmations = {}
+    bot._pnls_manager = _Manager()
+    bot.init_pnls = AsyncMock()
+    bot.live_value = lambda key: bot.config["live"][key]
+    bot.get_exchange_time = lambda: now_ms
+    bot._log_new_fill_events = MagicMock()
+    bot._log_enriched_fill_events = MagicMock()
+    bot._request_authoritative_confirmation = MagicMock()
+    bot._record_authoritative_surface = MagicMock()
+    bot._monitor_record_event = lambda *args, **kwargs: None
+    bot._monitor_record_error = lambda *args, **kwargs: None
+    bot._emit_fills_refresh_summary_event = MagicMock()
+    bot.logging_level = 0
+    bot._health_rate_limits = 0
+
+    result = await bot.update_pnls(source="staged_blocking")
+
+    assert result is True
+    bot._pnls_manager.refresh_degraded_pnl_events.assert_awaited_once_with(
+        start_ms=start_ms,
+        end_ms=now_ms,
+    )
+    bot._pnls_manager.refresh_latest.assert_awaited_once_with(
+        overlap=20,
+        last_refresh_overlap_ms=10 * 60 * 1000,
+    )
+    bot._log_enriched_fill_events.assert_called_once()
+    previous, current = bot._log_enriched_fill_events.call_args.args[0][0]
+    assert previous is degraded
+    assert current is authoritative
+    summary = bot._emit_fills_refresh_summary_event.call_args.kwargs
+    assert summary["refresh_mode"] == "incremental_recent_with_degraded_pnl_repair"
+    assert summary["enriched_count"] == 1
+    assert summary["degraded_pnl_count"] == 0
+    assert summary["reason_code"] == "fills_refresh_succeeded"
+    assert bot._last_fill_refresh_degraded_pnl_count == 0
+
+
+@pytest.mark.asyncio
 async def test_update_pnls_uses_confirmation_overlap_when_fills_pending():
     bot = Passivbot.__new__(Passivbot)
     cached_events = [
@@ -7481,6 +7605,8 @@ async def test_refresh_authoritative_state_staged_does_not_publish_when_fills_fa
             "positions": [{"symbol": "BTC/USDT:USDT"}],
             "open_orders": [],
             "pnls_ok": False,
+            "pending_pnl_count": 0,
+            "degraded_pnl_count": 1,
         }
     )
     bot._apply_positions_snapshot = MagicMock()
@@ -7497,6 +7623,9 @@ async def test_refresh_authoritative_state_staged_does_not_publish_when_fills_fa
     bot._apply_open_orders_snapshot.assert_not_awaited()
     bot.handle_balance_update.assert_not_awaited()
     bot._finalize_authoritative_refresh_consistency.assert_not_called()
+    assert bot._last_authoritative_block_reason == "degraded_pnl"
+    assert bot._last_authoritative_pending_pnl_count == 0
+    assert bot._last_authoritative_degraded_pnl_count == 1
 
 
 @pytest.mark.asyncio
@@ -11986,6 +12115,70 @@ async def test_run_execution_loop_waits_on_pending_pnl_without_restart(monkeypat
     assert sleep_seconds[:7] == [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 60.0]
     assert sleep_seconds[7:12] == [60.0] * 5
     assert {stage for _seconds, stage in sleeps} == {"pending_pnl_authoritative_retry"}
+
+
+@pytest.mark.asyncio
+async def test_run_execution_loop_waits_on_degraded_pnl_without_restart():
+    bot = Passivbot.__new__(Passivbot)
+    cycle = {"n": 0}
+    sleeps = []
+
+    async def fake_sleep_unless_shutdown(seconds, *, stage):
+        sleeps.append((seconds, stage))
+
+    bot.stop_signal_received = False
+    bot.execution_scheduled = False
+    bot.state_change_detected_by_symbol = set()
+    bot.debug_mode = True
+    bot._equity_hard_stop_enabled = lambda *args, **kwargs: False
+    bot._set_log_silence_watchdog_context = lambda *args, **kwargs: None
+    bot._maybe_log_health_summary = lambda: None
+    bot._maybe_log_unstuck_status = lambda: None
+    bot._monitor_flush_snapshot = AsyncMock()
+    bot.restart_bot_on_too_many_errors = AsyncMock()
+    bot._sleep_unless_shutdown = fake_sleep_unless_shutdown
+    bot._emit_live_cycle_degraded = MagicMock()
+    bot.live_value = lambda key: 0.0 if key == "execution_delay_seconds" else False
+
+    async def fake_refresh_authoritative_state():
+        cycle["n"] += 1
+        if cycle["n"] <= 3:
+            bot._last_authoritative_block_reason = "degraded_pnl"
+            bot._last_authoritative_pending_pnl_count = 0
+            bot._last_authoritative_degraded_pnl_count = 1
+            return False
+        bot._begin_authoritative_refresh_epoch()
+        for surface, sig in (
+            ("balance", ("b", 1)),
+            ("positions", ("p", 1)),
+            ("open_orders", ("o", 1)),
+            ("fills", ("f", 1)),
+            ("completed_candles", tuple()),
+        ):
+            bot._record_authoritative_surface(surface, sig)
+        return True
+
+    bot.refresh_authoritative_state = fake_refresh_authoritative_state
+    bot.prepare_planning_universe = AsyncMock()
+    bot.refresh_market_state_if_needed = AsyncMock(return_value=True)
+    bot.execute_to_exchange = AsyncMock(return_value={"executed_cycle": 4})
+
+    result = await bot.run_execution_loop()
+
+    assert result == {"executed_cycle": 4}
+    bot.restart_bot_on_too_many_errors.assert_not_awaited()
+    assert sleeps == [
+        (1.0, "degraded_pnl_authoritative_retry"),
+        (2.0, "degraded_pnl_authoritative_retry"),
+        (4.0, "degraded_pnl_authoritative_retry"),
+    ]
+    degraded_events = [
+        call.kwargs
+        for call in bot._emit_live_cycle_degraded.call_args_list
+        if call.kwargs["reason_code"] == "degraded_pnl_authoritative_refresh"
+    ]
+    assert len(degraded_events) == 3
+    assert all(event["data"]["degraded_pnl_count"] == 1 for event in degraded_events)
 
 
 @pytest.mark.asyncio

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -4706,7 +4706,7 @@ def test_log_new_fill_events_emits_fill_ingested_event():
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
-def test_log_enriched_fill_events_applies_only_authoritative_pnl_delta(caplog):
+def test_log_enriched_cached_fill_adds_full_authoritative_pnl_to_health(caplog):
     import passivbot as pb_mod
 
     class FakeBot:
@@ -4715,6 +4715,7 @@ def test_log_enriched_fill_events_applies_only_authoritative_pnl_delta(caplog):
 
         def __init__(self):
             self._health_pnl = 100.0
+            self._health_counted_fill_keys = set()
 
     previous = SimpleNamespace(
         id="degraded-close",
@@ -4737,8 +4738,49 @@ def test_log_enriched_fill_events_applies_only_authoritative_pnl_delta(caplog):
     with caplog.at_level(logging.INFO):
         bot._log_enriched_fill_events([(previous, authoritative)])
 
-    assert bot._health_pnl == pytest.approx(98.0)
+    assert bot._health_pnl == pytest.approx(102.9)
     assert "previous_source=synthetic_fill_reconstruction_degraded" in caplog.text
+    assert "previous_counted=false" in caplog.text
+    assert "pnl_delta=+2.9" in caplog.text
+
+
+def test_log_enriched_runtime_fill_applies_authoritative_pnl_delta(caplog):
+    import passivbot as pb_mod
+
+    class FakeBot:
+        _log_enriched_fill_events = pb_mod.Passivbot._log_enriched_fill_events
+        _log_fill_event = lambda self, event: f"id={event.id}"
+
+        def __init__(self):
+            self._health_pnl = 100.0
+            self._health_counted_fill_keys = set()
+
+    previous = SimpleNamespace(
+        id="degraded-close",
+        source_ids=["trade-1"],
+        timestamp=1_700_000_000_000,
+        pnl=5.0,
+        fee_paid=-0.1,
+        pnl_status="complete",
+        pnl_source="synthetic_fill_reconstruction_degraded",
+    )
+    authoritative = SimpleNamespace(
+        id="authoritative-close",
+        source_ids=["trade-1"],
+        timestamp=previous.timestamp,
+        pnl=3.0,
+        fee_paid=-0.1,
+        pnl_status="complete",
+        pnl_source="authoritative",
+    )
+    bot = FakeBot()
+    pb_mod.Passivbot._mark_health_fill_pnl_counted(bot, previous)
+
+    with caplog.at_level(logging.INFO):
+        bot._log_enriched_fill_events([(previous, authoritative)])
+
+    assert bot._health_pnl == pytest.approx(98.0)
+    assert "previous_counted=true" in caplog.text
     assert "pnl_delta=-2" in caplog.text
 
 

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -314,6 +314,8 @@ def test_live_event_cycle_helpers_emit_structured_events():
                 },
             },
             "authoritative_epoch": 999999,
+            "pending_pnl_count": 2,
+            "degraded_pnl_count": 1,
         },
     )
     assert bot._current_live_event_cycle_id() is None
@@ -364,6 +366,8 @@ def test_live_event_cycle_helpers_emit_structured_events():
                 ]
             },
         },
+        "pending_pnl_count": 2,
+        "degraded_pnl_count": 1,
         "authoritative_epoch": "[redacted]",
     }
     assert "SECRET" not in str(events[1].data)

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -4656,6 +4656,7 @@ def test_log_new_fill_events_emits_fill_ingested_event():
             self.monitor_publisher = RecorderPublisher()
             self._health_fills = 0
             self._health_pnl = 0.0
+            self._health_counted_synthetic_pnl_by_key = {}
 
     source_ids = ["trade-a", "trade-b"]
     source_derived_fill_id = "+".join(source_ids)
@@ -4715,7 +4716,7 @@ def test_log_enriched_cached_fill_adds_full_authoritative_pnl_to_health(caplog):
 
         def __init__(self):
             self._health_pnl = 100.0
-            self._health_counted_fill_keys = set()
+            self._health_counted_synthetic_pnl_by_key = {}
 
     previous = SimpleNamespace(
         id="degraded-close",
@@ -4753,7 +4754,7 @@ def test_log_enriched_runtime_fill_applies_authoritative_pnl_delta(caplog):
 
         def __init__(self):
             self._health_pnl = 100.0
-            self._health_counted_fill_keys = set()
+            self._health_counted_synthetic_pnl_by_key = {}
 
     previous = SimpleNamespace(
         id="degraded-close",
@@ -4775,6 +4776,12 @@ def test_log_enriched_runtime_fill_applies_authoritative_pnl_delta(caplog):
     )
     bot = FakeBot()
     pb_mod.Passivbot._mark_health_fill_pnl_counted(bot, previous)
+    assert bot._health_counted_synthetic_pnl_by_key
+    assert all(
+        value == pytest.approx(4.9)
+        for value in bot._health_counted_synthetic_pnl_by_key.values()
+    )
+    previous.pnl = 50.0
 
     with caplog.at_level(logging.INFO):
         bot._log_enriched_fill_events([(previous, authoritative)])
@@ -4782,6 +4789,7 @@ def test_log_enriched_runtime_fill_applies_authoritative_pnl_delta(caplog):
     assert bot._health_pnl == pytest.approx(98.0)
     assert "previous_counted=true" in caplog.text
     assert "pnl_delta=-2" in caplog.text
+    assert bot._health_counted_synthetic_pnl_by_key == {}
 
 
 def test_log_new_fill_events_uses_structured_console_without_legacy_duplicate(caplog):
@@ -4820,6 +4828,7 @@ def test_log_new_fill_events_uses_structured_console_without_legacy_duplicate(ca
             self.monitor_publisher = RecorderPublisher()
             self._health_fills = 0
             self._health_pnl = 0.0
+            self._health_counted_synthetic_pnl_by_key = {}
 
     event = SimpleNamespace(
         id="fill-1",
@@ -4842,6 +4851,7 @@ def test_log_new_fill_events_uses_structured_console_without_legacy_duplicate(ca
     with caplog.at_level(logging.INFO):
         bot._log_new_fill_events([event])
 
+    assert bot._health_counted_synthetic_pnl_by_key == {}
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
     assert [event.event_type for event in structured.events] == [EventTypes.FILL_INGESTED]
     assert [event.event_type for event in console.events] == [EventTypes.FILL_INGESTED]

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -4706,6 +4706,42 @@ def test_log_new_fill_events_emits_fill_ingested_event():
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_log_enriched_fill_events_applies_only_authoritative_pnl_delta(caplog):
+    import passivbot as pb_mod
+
+    class FakeBot:
+        _log_enriched_fill_events = pb_mod.Passivbot._log_enriched_fill_events
+        _log_fill_event = lambda self, event: f"id={event.id}"
+
+        def __init__(self):
+            self._health_pnl = 100.0
+
+    previous = SimpleNamespace(
+        id="degraded-close",
+        timestamp=1_700_000_000_000,
+        pnl=5.0,
+        fee_paid=-0.1,
+        pnl_status="complete",
+        pnl_source="synthetic_fill_reconstruction_degraded",
+    )
+    authoritative = SimpleNamespace(
+        id="degraded-close",
+        timestamp=previous.timestamp,
+        pnl=3.0,
+        fee_paid=-0.1,
+        pnl_status="complete",
+        pnl_source="authoritative",
+    )
+    bot = FakeBot()
+
+    with caplog.at_level(logging.INFO):
+        bot._log_enriched_fill_events([(previous, authoritative)])
+
+    assert bot._health_pnl == pytest.approx(98.0)
+    assert "previous_source=synthetic_fill_reconstruction_degraded" in caplog.text
+    assert "pnl_delta=-2" in caplog.text
+
+
 def test_log_new_fill_events_uses_structured_console_without_legacy_duplicate(caplog):
     import passivbot as pb_mod
 
@@ -5162,6 +5198,7 @@ def test_fills_refresh_debug_profile_adds_bounded_coverage_shape():
         new_count=2,
         enriched_count=1,
         pending_pnl_count=0,
+        degraded_pnl_count=1,
         coverage_before={
             "ready": False,
             "reason": "window_coverage_not_proven",
@@ -5201,6 +5238,7 @@ def test_fills_refresh_debug_profile_adds_bounded_coverage_shape():
         "new_count": 2,
         "enriched_count": 1,
         "pending_pnl_count": 0,
+        "degraded_pnl_count": 1,
         "event_count_delta": 4,
         "coverage_before_ready": False,
         "coverage_before_reason": "window_coverage_not_proven",


### PR DESCRIPTION
## Summary

- refetch bounded historical windows around degraded synthetic PnL rows inside the configured live risk lookback, even when cache metadata already proves time coverage
- treat unresolved degraded PnL as an unavailable authoritative fill surface and defer planning with the existing exponential no-restart backoff
- count pending/synthetic to authoritative transitions as enrichment, expose `degraded_pnl_count`, and apply only the replacement PnL delta to health accounting
- document the recovery and failure contract

## Root cause

Routine fill refresh deliberately excludes old synthetic rows. When a cache already proved the configured lookback, an old degraded row could therefore remain indefinitely even though the exchange still retained its authoritative PnL record. Risk planning correctly rejected the degraded row, but the resulting generic runtime error consumed restart budget and could not heal itself.

## Safety and behavior

The repair path is bounded to small windows around the affected fill timestamps and remains separate from ordinary recent-fill overlap. If authoritative data is still unavailable, the fill surface remains fail-closed and planning is retried with exponential backoff without creating, cancelling, or preserving orders from stale inputs.

## Validation

- `PYTHONPATH=src .../pytest -q tests/test_fill_events_manager.py tests/test_passivbot_balance_split.py tests/test_passivbot_monitor.py tests/test_live_event_bus.py tests/test_ai_docs.py tests/test_live_event_registry_docs.py`
- `PYTHONPATH=src .../python src/tools/check_ai_docs.py` (0 errors; existing word-count warnings only)
- `PYTHONPATH=src .../python src/tools/generate_live_event_registry.py --check`
- `git diff --check`
- approved authenticated read-only Bybit verification against the incident execution: one targeted repair range replaced the degraded synthetic row with authoritative gross PnL and positions-history provenance; no account state was modified

A repository-wide `pytest -q` attempt stopped during collection because the shared development venv contains a Rust extension stale relative to the checkout. This PR does not modify Rust; the complete affected Python/contract suites above pass.