### PR TITLE
Force WEEX CCXT clients to use IPv4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- WEEX REST and private WebSocket clients now use IPv4 transport so API keys
+  bound to the host's public IPv4 address do not fail with `-1056 ILLEGAL_IP`
+  when a dual-stack host would otherwise select IPv6.
+
 - Documented Python 3.12 and 3.14 support, explicitly excluding Python 3.13 until its dependency
   set is supported and bounding package metadata to those validated minor versions, and fixed
   reentrant candle fetch-lock

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -241,6 +241,21 @@ Primary references: [WEEX V3 place-order API](https://www.weex.com/api-doc/contr
 [current-orders API](https://www.weex.com/api-doc/contract/Transaction_API/GetCurrentOrderStatus),
 and [account-balance API](https://www.weex.com/api-doc/contract/Account_API/GetAccountBalance).
 
+### API whitelist transport
+
+Problem: WEEX API keys accept IPv4 whitelist entries, while a dual-stack host
+may select its IPv6 source address for `api-contract.weex.com`. Public market
+data then works, but private endpoints reject the authenticated request with
+`-1056 ILLEGAL_IP` even when the host's public IPv4 address is whitelisted.
+
+Handling: Both the REST and WebSocket WEEX CCXT clients use IPv4-only network
+connectors. Keep the host's stable public IPv4 address in the API-key whitelist;
+do not interpret `-1056` as a credential, signature, or Passivbot fill-history
+failure.
+
+Primary references: [WEEX V3 error codes](https://www.weex.com/api-doc/contract/ExampleOfErrorCode)
+and [WEEX API integration preparation](https://www.weex.com/api-doc/spot/QuickStart/IntegrationPreparation).
+
 ### Market data and CCXT compatibility
 
 Problem:

--- a/src/exchanges/weex.py
+++ b/src/exchanges/weex.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import math
 import re
+import socket
 import time
 
+import aiohttp
 import ccxt.async_support as ccxt_async
 import ccxt.pro as ccxt_pro
 
@@ -11,6 +13,34 @@ from config.access import require_live_value
 from exchanges.ccxt_bot import CCXTBot, format_exchange_config_response
 from passivbot import logging
 from utils import symbol_to_coin
+
+
+class _WeexIPv4TransportMixin:
+    """Keep WEEX traffic on the IPv4 address accepted by its API whitelist."""
+
+    def open(self):
+        if not self.own_session or self.session is not None:
+            return super().open()
+
+        # Let CCXT initialize its event loop, throttler, and SSL context without
+        # creating the default dual-stack connector.
+        self.own_session = False
+        try:
+            super().open()
+        finally:
+            self.own_session = True
+
+        self.tcp_connector = aiohttp.TCPConnector(
+            ssl=self.ssl_context,
+            loop=self.asyncio_loop,
+            enable_cleanup_closed=True,
+            family=socket.AF_INET,
+        )
+        self.session = aiohttp.ClientSession(
+            loop=self.asyncio_loop,
+            connector=self.tcp_connector,
+            trust_env=self.aiohttp_trust_env,
+        )
 
 
 class _WeexSuccessEnvelopeMixin:
@@ -51,11 +81,11 @@ class _WeexSuccessEnvelopeMixin:
         )
 
 
-class AsyncWeex(_WeexSuccessEnvelopeMixin, ccxt_async.weex):
+class AsyncWeex(_WeexIPv4TransportMixin, _WeexSuccessEnvelopeMixin, ccxt_async.weex):
     pass
 
 
-class ProWeex(_WeexSuccessEnvelopeMixin, ccxt_pro.weex):
+class ProWeex(_WeexIPv4TransportMixin, _WeexSuccessEnvelopeMixin, ccxt_pro.weex):
     def handle_orders(self, client, message):
         """Ignore WEEX order-channel heartbeats with no order rows.
 

--- a/tests/exchanges/test_weex.py
+++ b/tests/exchanges/test_weex.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import socket
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -62,6 +63,17 @@ def _bot(*, time_in_force: str = "gtc") -> WeexBot:
 
 def test_ccxt_contract_registry_uses_weex_adapter():
     assert get_bot_class("weex") is WeexBot
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("client_class", [AsyncWeex, ProWeex])
+async def test_weex_clients_use_ipv4_transport(client_class):
+    exchange = client_class()
+    try:
+        exchange.open()
+        assert exchange.tcp_connector._family == socket.AF_INET
+    finally:
+        await exchange.close()
 
 
 def test_weex_client_accepts_only_documented_success_envelope():


### PR DESCRIPTION
## Summary

- force both WEEX REST and Pro/WebSocket CCXT clients to create IPv4-only `aiohttp` connectors
- preserve CCXT's normal lazy session setup, SSL configuration, throttling, and close ownership
- document the WEEX IPv4 whitelist/`-1056 ILLEGAL_IP` contract and add an Unreleased changelog entry

## Root cause

On a dual-stack host, CCXT/aiohttp could connect to `api-contract.weex.com` over IPv6. WEEX's API-key whitelist UI accepts IPv4 entries, so public endpoints remained healthy while every authenticated endpoint returned `-1056 Invalid IP address`, even though the host's public IPv4 was correctly whitelisted.

IPv6-first retry/fallback was deliberately not added: an IPv6 attempt would be guaranteed to fail for a key whose whitelist cannot represent IPv6. The connector is therefore IPv4-only for WEEX, with no changes to other exchanges.

## Validation

- `python -m pytest -q tests/exchanges/test_weex.py` — 47 passed
- WEEX plus shared CCXT hook, exchange-name, and reconciliation suites — 244 passed
- deployed default `AsyncWeex` authenticated balance probe succeeded with `AF_INET`
- real WEEX live bot completed account/fill initialization, candle warmup, order WebSocket startup, Rust planning, cancel-first reconciliation, and acknowledged order creation with zero runtime errors

The production VPS venv intentionally lacks pytest, so tests were run in the repository development venv; the environment-specific authenticated and live checks were run on the deployment itself.