### PR TITLE
Refresh monitor snapshots during degraded cycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Monitor `state.latest.json` snapshots now refresh from a serialized background
+  maintainer at least every five seconds, independently of successful planning
+  cycles. Prolonged authoritative-data or planning degradation therefore remains
+  visible without concurrent snapshot builds or any change to trading behavior.
+
 - Live fill recovery now performs bounded historical refetches around degraded
   synthetic realized-PnL rows even when cache metadata already proves the configured
   lookback. Repair-only fetches preserve the incremental checkpoint and rotate through

--- a/docs/ai/features/monitor_persistence.md
+++ b/docs/ai/features/monitor_persistence.md
@@ -5,6 +5,13 @@
 `src/monitor_publisher.py` owns monitor appends, snapshots, manifest checkpoints, rotation,
 retention, and startup recovery. Persistence failures stay visible but never alter trading behavior.
 
+`state.latest.json` is refreshed by a serialized background maintainer, independent
+of whether the trading loop reaches a valid planning snapshot. Successful and
+degraded cycles may also request a flush; concurrent requests serialize and the
+publisher's configured interval remains the write throttle. The independent
+maintainer uses a five-second minimum cadence to keep degraded state visible
+without turning diagnostic persistence into a high-frequency trading dependency.
+
 `record_error` retains the event kind, tags, known code-owned source/stage classifications, and a
 bounded exception type. It must not persist arbitrary caller strings or numbers, exception messages,
 request URLs, responses, tracebacks, or caller-supplied raw diagnostic aliases. More detailed

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -19670,6 +19670,22 @@ class Passivbot:
                 await self.restart_bot_on_too_many_errors()
                 await asyncio.sleep(5)
 
+    async def maintain_monitor_snapshot(self):
+        """Refresh diagnostics independently of successful planning cycles."""
+        publisher = getattr(self, "monitor_publisher", None)
+        if publisher is None:
+            return
+        interval_seconds = max(
+            5.0,
+            float(getattr(publisher, "snapshot_interval_ms", 1_000) or 1_000)
+            / 1_000.0,
+        )
+        while not self.stop_signal_received:
+            await self._monitor_flush_snapshot()
+            await self._sleep_unless_shutdown(
+                interval_seconds, stage="monitor_snapshot_interval"
+            )
+
     def _emit_maintenance_exchange_config_refresh_event(self, **kwargs):
         try:
             self._emit_exchange_config_refresh_event(**kwargs)
@@ -19711,6 +19727,8 @@ class Passivbot:
                 self.maintainers.pop("hsl_coin_replay")
             self.stop_data_maintainers()
         maintainer_names = ["maintain_hourly_cycle"]
+        if getattr(self, "monitor_publisher", None) is not None:
+            maintainer_names.append("maintain_monitor_snapshot")
         if self.ws_enabled:
             maintainer_names.append("watch_orders")
         else:

--- a/src/passivbot_monitor.py
+++ b/src/passivbot_monitor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import math
 import os
@@ -1764,9 +1765,14 @@ async def _monitor_flush_snapshot(self, *, force: bool = False, ts: Optional[int
     publisher = getattr(self, "monitor_publisher", None)
     if publisher is None:
         return False
-    try:
-        snapshot = await self._build_monitor_snapshot(now_ms=ts)
-        return publisher.write_snapshot(snapshot, ts=ts, force=force)
-    except Exception as exc:
-        logging.error("[monitor] failed building monitor snapshot: %s", exc)
-        return False
+    lock = getattr(self, "_monitor_snapshot_flush_lock", None)
+    if lock is None:
+        lock = asyncio.Lock()
+        self._monitor_snapshot_flush_lock = lock
+    async with lock:
+        try:
+            snapshot = await self._build_monitor_snapshot(now_ms=ts)
+            return publisher.write_snapshot(snapshot, ts=ts, force=force)
+        except Exception as exc:
+            logging.error("[monitor] failed building monitor snapshot: %s", exc)
+            return False

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -7057,6 +7057,93 @@ async def test_ema_anchor_monitor_snapshot_flush_skips_legacy_trailing_params():
     }
 
 
+@pytest.mark.asyncio
+async def test_monitor_snapshot_flushes_are_serialized():
+    import passivbot as pb_mod
+
+    class FakePublisher:
+        def write_snapshot(self, snapshot, *, ts=None, force=False):
+            return True
+
+    class FakeBot:
+        _monitor_flush_snapshot = pb_mod.Passivbot._monitor_flush_snapshot
+
+        def __init__(self):
+            self.monitor_publisher = FakePublisher()
+            self.active_builds = 0
+            self.max_active_builds = 0
+
+        async def _build_monitor_snapshot(self, *, now_ms=None):
+            self.active_builds += 1
+            self.max_active_builds = max(self.max_active_builds, self.active_builds)
+            await asyncio.sleep(0)
+            self.active_builds -= 1
+            return {}
+
+    bot = FakeBot()
+
+    assert await asyncio.gather(
+        bot._monitor_flush_snapshot(force=True),
+        bot._monitor_flush_snapshot(force=True),
+    ) == [True, True]
+    assert bot.max_active_builds == 1
+
+
+@pytest.mark.asyncio
+async def test_monitor_snapshot_maintainer_runs_without_planning_cycles():
+    import passivbot as pb_mod
+
+    bot = SimpleNamespace(
+        monitor_publisher=SimpleNamespace(snapshot_interval_ms=1),
+        stop_signal_received=False,
+    )
+    flush_count = 0
+
+    async def flush_snapshot():
+        nonlocal flush_count
+        flush_count += 1
+        if flush_count == 2:
+            bot.stop_signal_received = True
+        return True
+
+    async def sleep_unless_shutdown(_seconds, *, stage):
+        assert stage == "monitor_snapshot_interval"
+        await asyncio.sleep(0)
+
+    bot._monitor_flush_snapshot = flush_snapshot
+    bot._sleep_unless_shutdown = sleep_unless_shutdown
+
+    await pb_mod.Passivbot.maintain_monitor_snapshot(bot)
+
+    assert flush_count == 2
+
+
+@pytest.mark.asyncio
+async def test_monitor_snapshot_maintainer_is_registered_when_enabled():
+    import passivbot as pb_mod
+
+    bot = pb_mod.Passivbot.__new__(pb_mod.Passivbot)
+    bot.ws_enabled = False
+    bot.monitor_publisher = SimpleNamespace(snapshot_interval_ms=1_000)
+    blocker = asyncio.Event()
+
+    async def wait_for_stop():
+        await blocker.wait()
+
+    bot.maintain_hourly_cycle = wait_for_stop
+    bot.maintain_monitor_snapshot = wait_for_stop
+
+    await bot.start_data_maintainers()
+
+    assert set(bot.maintainers) == {
+        "maintain_hourly_cycle",
+        "maintain_monitor_snapshot",
+    }
+    tasks = list(bot.maintainers.values())
+    bot.stop_data_maintainers(verbose=False)
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+
 def test_monitor_trailing_section_includes_trailing_grid_v7_diagnostics():
     import passivbot as pb_mod
 


### PR DESCRIPTION
## Summary

- add an independent monitor-snapshot maintainer so early degraded execution-loop paths cannot leave state.latest.json stale
- serialize background and execution-loop snapshot writes
- enforce a five-second minimum cadence to bound diagnostic CPU and I/O
- keep persistence diagnostic-only and independent of trading decisions
- document the lifecycle and add concurrency/maintainer regressions

## Validation

- full Python test suite passed with an isolated source-matched Rust extension
- targeted monitor persistence tests passed
- git diff --check passed