### PR TITLE
Scope cancel-first create deferral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable user-facing changes will be documented in this file.
   is normalized to the string required by CCXT Pro, preventing private order
   WebSocket reconnect loops after otherwise successful startup.
 
+- Scope cancel-first create deferral to the symbol and position side of stale-order cancellations,
+  while retaining conservative account-wide deferral for malformed unscoped cancellations.
+
 - Monitor `state.latest.json` snapshots now refresh from a serialized background
   maintainer at least every five seconds, independently of successful planning
   cycles. Prolonged authoritative-data or planning degradation therefore remains

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ All notable user-facing changes will be documented in this file.
   is normalized to the string required by CCXT Pro, preventing private order
   WebSocket reconnect loops after otherwise successful startup.
 
-- Scope cancel-first create deferral to the symbol and position side of stale-order cancellations,
-  while retaining conservative account-wide deferral for malformed unscoped cancellations.
+- Scope cancel-first create deferral to the symbol and position side of stale-order cancellations
+  in hedge mode, or the whole symbol in one-way mode, while retaining conservative account-wide
+  deferral for malformed unscoped cancellations.
 
 - Monitor `state.latest.json` snapshots now refresh from a serialized background
   maintainer at least every five seconds, independently of successful planning

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -301,9 +301,10 @@ The account-wide replacement-churn policy emits structured, monitor-only summari
 - `order.churn_actions_accounted` records the action kind and number of logical creates or required
   connector configuration writes debited immediately before each connector call, plus the resulting
   rolling count. Cancellations are excluded from the generic window.
-- `execution.cancel_first_barrier` reports create deferral for the same symbol and position side
-  after a stale-order cancellation. Unrelated symbol/position-side creates may continue in the
-  same wave; an unscoped cancellation conservatively defers all ordinary creates. The stable
+- `execution.cancel_first_barrier` reports create deferral after a stale-order cancellation. In
+  effective hedge mode the scope is symbol and position side; in one-way mode it is the whole
+  symbol because long and short share one net exchange position. Unrelated scopes may continue in
+  the same wave; an unscoped cancellation conservatively defers all ordinary creates. The stable
   `account_cancel_first_barrier` reason-code name is retained for event-consumer compatibility.
   `execution.cancel_deferred` reports cancellation batch truncation.
 

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -301,8 +301,11 @@ The account-wide replacement-churn policy emits structured, monitor-only summari
 - `order.churn_actions_accounted` records the action kind and number of logical creates or required
   connector configuration writes debited immediately before each connector call, plus the resulting
   rolling count. Cancellations are excluded from the generic window.
-- `execution.cancel_first_barrier` reports account-wide create deferral after any stale-order
-  cancellation. `execution.cancel_deferred` reports cancellation batch truncation.
+- `execution.cancel_first_barrier` reports create deferral for the same symbol and position side
+  after a stale-order cancellation. Unrelated symbol/position-side creates may continue in the
+  same wave; an unscoped cancellation conservatively defers all ordinary creates. The stable
+  `account_cancel_first_barrier` reason-code name is retained for event-consumer compatibility.
+  `execution.cancel_deferred` reports cancellation batch truncation.
 
 These events are diagnostic projections only. The causal history, rolling counter, and
 cancel-first state are updated directly in the planner and executor, and sink failure cannot alter

--- a/src/live/executor.py
+++ b/src/live/executor.py
@@ -111,6 +111,17 @@ def _order_is_protective_create(order: dict) -> bool:
     return _order_is_reduce_only(order)
 
 
+def _cancel_first_scope(order: dict) -> tuple[str, str] | None:
+    """Return the position scope whose stale actual order is being replaced."""
+    if not isinstance(order, dict):
+        return None
+    symbol = str(order.get("symbol") or "")
+    position_side = str(order.get("position_side") or "").lower()
+    if not symbol or position_side not in {"long", "short"}:
+        return None
+    return symbol, position_side
+
+
 def _complete_terminal_signed_action_attempts(
     bot, tokens, results, orders, *, action: str
 ) -> None:
@@ -776,12 +787,21 @@ async def execute_order_plan(
             order_wave["cancel_ms"] = int(max(0, _utc_ms() - cancel_started_ms))
             order_wave["cancel_posted"] = len(res or [])
     if cancel_first_barrier:
+        cancel_scopes = {_cancel_first_scope(order) for order in to_cancel}
+        has_unscoped_cancel = None in cancel_scopes
+        cancel_scopes.discard(None)
+
+        def must_wait_for_cancel_confirmation(order: dict) -> bool:
+            scope = _cancel_first_scope(order)
+            return has_unscoped_cancel or scope is None or scope in cancel_scopes
+
         barrier_deferred = [
             order
             for order in to_create
             if not _is_dedicated_protective_market_panic(
                 bot, order, configure_creations=configure_creations
             )
+            and must_wait_for_cancel_confirmation(order)
         ]
         bypass_creates = [
             order
@@ -789,6 +809,7 @@ async def execute_order_plan(
             if _is_dedicated_protective_market_panic(
                 bot, order, configure_creations=configure_creations
             )
+            or not must_wait_for_cancel_confirmation(order)
         ]
         _record_fresh_entry_orders(
             bot,
@@ -800,7 +821,7 @@ async def execute_order_plan(
             order_wave["deferred_create"] += len(barrier_deferred)
         if barrier_deferred:
             logging.info(
-                "[order] account-wide cancel-first barrier deferred %d creates until full confirmation and replanning",
+                "[order] cancel-first barrier deferred %d same-position creates until confirmation and replanning",
                 len(barrier_deferred),
             )
             passivbot_cls._emit_execution_create_filter_event(
@@ -813,7 +834,23 @@ async def execute_order_plan(
                 wave=order_wave,
                 data={
                     "cancel_count": len(to_cancel),
-                    "dedicated_market_panic_bypass_count": len(bypass_creates),
+                    "cancel_scope_count": len(cancel_scopes),
+                    "unscoped_cancel_count": sum(
+                        _cancel_first_scope(order) is None for order in to_cancel
+                    ),
+                    "dedicated_market_panic_bypass_count": sum(
+                        _is_dedicated_protective_market_panic(
+                            bot, order, configure_creations=configure_creations
+                        )
+                        for order in to_create
+                    ),
+                    "unaffected_scope_create_count": sum(
+                        not _is_dedicated_protective_market_panic(
+                            bot, order, configure_creations=configure_creations
+                        )
+                        and not must_wait_for_cancel_confirmation(order)
+                        for order in to_create
+                    ),
                     "required_surfaces": sorted(
                         _authoritative_full_confirmation_surfaces(bot, passivbot_cls)
                     ),

--- a/src/live/executor.py
+++ b/src/live/executor.py
@@ -111,13 +111,21 @@ def _order_is_protective_create(order: dict) -> bool:
     return _order_is_reduce_only(order)
 
 
-def _cancel_first_scope(order: dict) -> tuple[str, str] | None:
-    """Return the position scope whose stale actual order is being replaced."""
+def _cancel_first_scope(bot, order: dict) -> tuple[str, str] | None:
+    """Return the independent exchange scope affected by a stale actual order."""
     if not isinstance(order, dict):
         return None
     symbol = str(order.get("symbol") or "")
+    if not symbol:
+        return None
+    effective_hedge_mode = bool(
+        getattr(bot, "_config_hedge_mode", False)
+        and getattr(bot, "hedge_mode", False)
+    )
+    if not effective_hedge_mode:
+        return symbol, ""
     position_side = str(order.get("position_side") or "").lower()
-    if not symbol or position_side not in {"long", "short"}:
+    if position_side not in {"long", "short"}:
         return None
     return symbol, position_side
 
@@ -787,12 +795,12 @@ async def execute_order_plan(
             order_wave["cancel_ms"] = int(max(0, _utc_ms() - cancel_started_ms))
             order_wave["cancel_posted"] = len(res or [])
     if cancel_first_barrier:
-        cancel_scopes = {_cancel_first_scope(order) for order in to_cancel}
+        cancel_scopes = {_cancel_first_scope(bot, order) for order in to_cancel}
         has_unscoped_cancel = None in cancel_scopes
         cancel_scopes.discard(None)
 
         def must_wait_for_cancel_confirmation(order: dict) -> bool:
-            scope = _cancel_first_scope(order)
+            scope = _cancel_first_scope(bot, order)
             return has_unscoped_cancel or scope is None or scope in cancel_scopes
 
         barrier_deferred = [
@@ -836,7 +844,7 @@ async def execute_order_plan(
                     "cancel_count": len(to_cancel),
                     "cancel_scope_count": len(cancel_scopes),
                     "unscoped_cancel_count": sum(
-                        _cancel_first_scope(order) is None for order in to_cancel
+                        _cancel_first_scope(bot, order) is None for order in to_cancel
                     ),
                     "dedicated_market_panic_bypass_count": sum(
                         _is_dedicated_protective_market_panic(

--- a/tests/test_order_churn_cancel_first.py
+++ b/tests/test_order_churn_cancel_first.py
@@ -107,7 +107,7 @@ def execution_shell(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_any_stale_actual_defers_all_normal_plan_creates_account_wide(
+async def test_stale_actual_defers_normal_create_for_same_symbol_and_pside(
     execution_shell,
 ):
     _wave, events = execution_shell
@@ -127,6 +127,66 @@ async def test_any_stale_actual_defers_all_normal_plan_creates_account_wide(
     ]
     assert barrier["reason_code"] == ReasonCodes.ACCOUNT_CANCEL_FIRST_BARRIER
     assert barrier["order_count"] == 1
+    assert barrier["data"]["cancel_scope_count"] == 1
+    assert barrier["data"]["unscoped_cancel_count"] == 0
+    assert barrier["data"]["dedicated_market_panic_bypass_count"] == 0
+    assert barrier["data"]["unaffected_scope_create_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_cancel_first_allows_creates_for_unaffected_position_scopes(
+    execution_shell,
+):
+    _wave, events = execution_shell
+    bot = _PlanBot()
+    stale = _order("stale")
+    same_scope = _order("same_scope")
+    other_pside = {**_order("other_pside"), "position_side": "short"}
+    other_symbol = {**_order("other_symbol"), "symbol": "ETH/USDT:USDT"}
+
+    await executor.execute_order_plan(
+        bot,
+        [stale],
+        [same_scope, other_pside, other_symbol],
+    )
+
+    assert bot.cancelled == [stale]
+    assert bot.created == [other_pside, other_symbol]
+    assert bot.confirmations == [{"balance", "positions", "open_orders", "fills"}]
+    [barrier] = [
+        event
+        for event in events
+        if event["event_type"] == EventTypes.EXECUTION_CANCEL_FIRST_BARRIER
+    ]
+    assert barrier["order_count"] == 1
+    assert barrier["data"]["cancel_scope_count"] == 1
+    assert barrier["data"]["unscoped_cancel_count"] == 0
+    assert barrier["data"]["dedicated_market_panic_bypass_count"] == 0
+    assert barrier["data"]["unaffected_scope_create_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_unscoped_cancel_conservatively_defers_all_normal_creates(
+    execution_shell,
+):
+    _wave, events = execution_shell
+    bot = _PlanBot()
+    stale = _order("stale")
+    stale.pop("position_side")
+    desired = {**_order("desired"), "symbol": "ETH/USDT:USDT"}
+
+    await executor.execute_order_plan(bot, [stale], [desired])
+
+    assert bot.cancelled == [stale]
+    assert bot.created == []
+    [barrier] = [
+        event
+        for event in events
+        if event["event_type"] == EventTypes.EXECUTION_CANCEL_FIRST_BARRIER
+    ]
+    assert barrier["order_count"] == 1
+    assert barrier["data"]["cancel_scope_count"] == 0
+    assert barrier["data"]["unscoped_cancel_count"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_order_churn_cancel_first.py
+++ b/tests/test_order_churn_cancel_first.py
@@ -27,6 +27,8 @@ class _PlanBot:
     debug_mode = False
     balance_threshold = 0.0
     quote = "USDT"
+    _config_hedge_mode = True
+    hedge_mode = True
     state_change_detected_by_symbol = set()
     _equity_hard_stop_coin_replay_pending_pairs = set()
     _order_churn_gate_state = None
@@ -163,6 +165,36 @@ async def test_cancel_first_allows_creates_for_unaffected_position_scopes(
     assert barrier["data"]["unscoped_cancel_count"] == 0
     assert barrier["data"]["dedicated_market_panic_bypass_count"] == 0
     assert barrier["data"]["unaffected_scope_create_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_cancel_first_defers_opposite_pside_on_same_symbol_in_one_way_mode(
+    execution_shell,
+):
+    _wave, events = execution_shell
+    bot = _PlanBot()
+    bot._config_hedge_mode = False
+    stale = _order("stale")
+    opposite_pside = {**_order("opposite_pside"), "position_side": "short"}
+    other_symbol = {**_order("other_symbol"), "symbol": "ETH/USDT:USDT"}
+
+    await executor.execute_order_plan(
+        bot,
+        [stale],
+        [opposite_pside, other_symbol],
+    )
+
+    assert bot.cancelled == [stale]
+    assert bot.created == [other_symbol]
+    [barrier] = [
+        event
+        for event in events
+        if event["event_type"] == EventTypes.EXECUTION_CANCEL_FIRST_BARRIER
+    ]
+    assert barrier["order_count"] == 1
+    assert barrier["data"]["cancel_scope_count"] == 1
+    assert barrier["data"]["unscoped_cancel_count"] == 0
+    assert barrier["data"]["unaffected_scope_create_count"] == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- scope cancel-first create deferral to symbol and position side in effective hedge mode
- defer the whole cancelled symbol in one-way mode, where long and short share one net exchange position
- allow ordinary creates for independent scopes to continue in the same execution wave
- retain conservative account-wide deferral when a cancellation lacks a valid scope
- retain the dedicated protective market-panic bypass and full authoritative confirmation request

## Contract

Scope category: trading-path.

This changes only the executor's post-cancel create barrier. It does not change Rust ideal-order generation, reconciliation matching, the 0.02% order tolerance, churn-gate history/config logic, or the rule that unmatched stale actual orders are cancelled.

The existing `account_cancel_first_barrier` reason-code name remains stable for event-consumer compatibility. Event data now distinguishes cancelled scopes, unscoped cancellations, dedicated panic bypasses, and ordinary unaffected-scope creates.

Expected VPS action: pull, restart, and observe normal order waves on one representative bot checkout. No configuration migration is required.

## Validation

- `python -m pytest tests/test_order_churn_cancel_first.py tests/test_order_churn_executor.py tests/test_exchange_config_updates.py::test_execute_order_plan_blocks_pending_hsl_entry_and_defers_close_after_cancel tests/test_ai_docs.py tests/test_live_event_bus.py -q` — 188 passed
- `python -m py_compile src/live/executor.py` — passed
- `git diff --check` — passed

The broader reconciliation-contract module could not be collected in the local worktree because the shared environment has CCXT 4.5.48 while this checkout requires 4.5.66; CI should exercise the repository-pinned environment.

## Reviewer focus

- malformed/unscoped cancellation fallback remains conservative
- hedge-mode position-side scopes remain independent, while one-way-mode deferral is symbol-wide
- cancellation exceptions still abort before any create call
- no stale-order retention or tolerance behavior changed
