### PR TITLE
Fix Gate CCXT exchange alias handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ All notable user-facing changes will be documented in this file.
   logs its normalization to Passivbot's canonical `gateio` identity, and consistently
   selects the dedicated Gate.io connector. Standalone market loading now also
   translates `gateio` to CCXT's renamed `gate` client without changing canonical
-  cache, broker, event, or persisted-state paths.
+  cache, broker, event, or persisted-state paths. Gate's numeric REST account UID
+  is normalized to the string required by CCXT Pro, preventing private order
+  WebSocket reconnect loops after otherwise successful startup.
 
 - Monitor `state.latest.json` snapshots now refresh from a serialized background
   maintainer at least every five seconds, independently of successful planning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Gate.io live configuration now accepts CCXT's `gate` exchange label as an alias,
+  logs its normalization to Passivbot's canonical `gateio` identity, and consistently
+  selects the dedicated Gate.io connector. Standalone market loading now also
+  translates `gateio` to CCXT's renamed `gate` client without changing canonical
+  cache, broker, event, or persisted-state paths.
+
 - Monitor `state.latest.json` snapshots now refresh from a serialized background
   maintainer at least every five seconds, independently of successful planning
   cycles. Prolonged authoritative-data or planning degradation therefore remains

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -171,6 +171,17 @@ Handling in Passivbot:
 
 ## Gate.io Futures
 
+### Exchange identity boundary
+
+Passivbot's canonical exchange identity is `gateio`. This identity owns connector
+routing, cache and event paths, broker attribution, and persisted state. CCXT 4.5.66
+renamed only its client class to `gate`.
+
+For compatibility, `api-keys.json` may specify either `"exchange": "gateio"` or
+`"exchange": "gate"`. Passivbot normalizes the latter to `gateio` and logs that
+migration. Only CCXT REST and WebSocket client construction translates `gateio` to
+`gate`; do not add parallel `gate` identities to internal registries or state paths.
+
 ### Contract order text must start with `t-`
 
 Problem:

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -181,6 +181,8 @@ For compatibility, `api-keys.json` may specify either `"exchange": "gateio"` or
 `"exchange": "gate"`. Passivbot normalizes the latter to `gateio` and logs that
 migration. Only CCXT REST and WebSocket client construction translates `gateio` to
 `gate`; do not add parallel `gate` identities to internal registries or state paths.
+Normalize Gate's numeric REST account `user` value to a string before assigning it
+as CCXT Pro's private futures subscription UID.
 
 ### Contract order text must start with `t-`
 

--- a/src/exchanges/gateio.py
+++ b/src/exchanges/gateio.py
@@ -78,7 +78,10 @@ class GateIOBot(CCXTBot):
             raise KeyError(f"{self.exchange}: fetch_balance response missing info[0]")
         primary = info[0]
         if not hasattr(self, "uid") or not self.uid:
-            self.uid = primary["user"]
+            # Gate's REST payload currently returns ``user`` as an integer,
+            # while CCXT Pro's private futures subscription treats the UID as
+            # a string and calls len() on it while signing the request.
+            self.uid = str(primary["user"])
             self.cca.uid = self.uid
             if self.ccp is not None:
                 self.ccp.uid = self.uid

--- a/src/procedures.py
+++ b/src/procedures.py
@@ -21,6 +21,7 @@ from utils import (
     date_to_ts,
     get_first_ohlcv_iteratively,
     load_ccxt_instance,
+    to_standard_exchange_name,
 )
 import sys
 import passivbot_rust as pbr
@@ -46,6 +47,8 @@ from pure_funcs import (
     sort_dict_keys,
     flatten,
 )
+
+_EXCHANGE_ALIAS_MIGRATIONS_LOGGED: set[tuple[str, str, str]] = set()
 
 
 def get_all_eligible_symbols(exchange="binance"):
@@ -176,6 +179,21 @@ def load_user_info(user: str, api_keys_path="api-keys.json") -> dict:
 
     # Overlay all fields from the user's entry (passthrough for CCXTBot)
     result.update(api_keys[user])
+
+    raw_exchange = str(result.get("exchange", "")).strip()
+    canonical_exchange = to_standard_exchange_name(raw_exchange)
+    if raw_exchange.lower() == "gate" and canonical_exchange == "gateio":
+        result["exchange"] = canonical_exchange
+        migration_key = (os.path.abspath(api_keys_path), user, raw_exchange.lower())
+        if migration_key not in _EXCHANGE_ALIAS_MIGRATIONS_LOGGED:
+            _EXCHANGE_ALIAS_MIGRATIONS_LOGGED.add(migration_key)
+            logging.info(
+                "[config] api-keys.json exchange alias %r normalized to canonical %r "
+                "for user %s",
+                raw_exchange,
+                canonical_exchange,
+                user,
+            )
 
     return result
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -19,6 +19,7 @@ import portalocker  # type: ignore
 from custom_endpoint_overrides import (
     apply_rest_overrides_to_ccxt,
     resolve_custom_endpoint_override,
+    resolve_custom_endpoint_override_with_aliases,
 )
 
 warnings.filterwarnings(
@@ -598,6 +599,12 @@ def to_standard_exchange_name(exchange: str) -> str:
     """
     ex = (exchange or "").lower()
 
+    # CCXT 4.5.66 renamed its Gate.io client from ``gateio`` to ``gate``.
+    # Passivbot retains ``gateio`` as the canonical identity for connector
+    # routing, caches, broker attribution, events, and persisted state.
+    if ex == "gate":
+        return "gateio"
+
     # Remove known futures suffixes
     for suffix in ("usdm", "futures"):
         if ex.endswith(suffix):
@@ -638,21 +645,24 @@ def load_ccxt_instance(exchange_id: str, enable_rate_limit: bool = True, timeout
     The returned instance should be closed by the caller with: await cc.close()
     """
     ex = to_ccxt_exchange_id(exchange_id)
+    client_id = to_ccxt_client_id(ex)
     try:
-        cc = getattr(ccxt, ex)(
+        cc = getattr(ccxt, client_id)(
             {
                 "enableRateLimit": bool(enable_rate_limit),
                 # Default ccxt timeout can be too low for long lookbacks; raise to be tolerant.
                 "timeout": int(timeout_ms),
             }
         )
-    except Exception:
-        raise RuntimeError(f"ccxt exchange '{ex}' not available")
+    except Exception as exc:
+        raise RuntimeError(
+            f"ccxt exchange client {client_id!r} not available for canonical exchange {ex!r}"
+        ) from exc
     try:
         cc.options["defaultType"] = "swap"
-        if ex == "okx":
+        if client_id == "okx":
             cc.options["fetchMarkets"] = {"types": ["swap"]}
-        if ex == "hyperliquid":
+        if client_id == "hyperliquid":
             # Include HIP-3 stock perps from TradeXYZ
             cc.options["fetchMarkets"] = {
                 "types": ["swap", "hip3"],
@@ -662,7 +672,11 @@ def load_ccxt_instance(exchange_id: str, enable_rate_limit: bool = True, timeout
             }
     except Exception:
         pass
-    override = resolve_custom_endpoint_override(ex)
+    override = (
+        resolve_custom_endpoint_override_with_aliases(ex, (client_id,))
+        if client_id != ex
+        else resolve_custom_endpoint_override(ex)
+    )
     apply_rest_overrides_to_ccxt(cc, override)
     return cc
 

--- a/tests/ccxt_upgrade/test_order_contracts.py
+++ b/tests/ccxt_upgrade/test_order_contracts.py
@@ -937,7 +937,7 @@ def test_gateio_get_balance_uses_cross_available_for_multi_currency_margin():
             "USDT": {"total": 0.000000000035},
             "info": [
                 {
-                    "user": "16770081",
+                    "user": 16770081,
                     "margin_mode_name": "multi_currency",
                     "cross_available": "724.95615",
                 }

--- a/tests/test_exchange_name_normalization.py
+++ b/tests/test_exchange_name_normalization.py
@@ -6,6 +6,8 @@ import ccxt.pro as ccxt_pro
 import pytest
 
 import exchanges.gateio as gateio_module
+import passivbot
+import procedures
 import utils
 from candlestick_manager import CandlestickManager, ONE_MIN_MS
 from exchanges.ccxt_bot import CCXTBot
@@ -37,6 +39,97 @@ def test_gateio_session_boundary_resolves_current_rest_and_pro_clients(monkeypat
     assert utils.to_ccxt_client_id("gateio") == "gate"
     assert utils.to_ccxt_exchange_id("gateio") == "gateio"
     assert utils.to_standard_exchange_name("gateio") == "gateio"
+    assert utils.to_standard_exchange_name("gate") == "gateio"
+
+
+def test_gate_api_key_alias_normalizes_to_canonical_identity(tmp_path, caplog):
+    api_keys_path = tmp_path / "api-keys.json"
+    api_keys_path.write_text(
+        '{"gate_user": {"exchange": "gate", "key": "redacted", "secret": "redacted"}}',
+        encoding="utf-8",
+    )
+
+    with caplog.at_level("INFO"):
+        user_info = procedures.load_user_info(
+            "gate_user", api_keys_path=str(api_keys_path)
+        )
+
+    assert user_info["exchange"] == "gateio"
+    assert "exchange alias 'gate' normalized to canonical 'gateio'" in caplog.text
+
+
+def test_gate_api_key_alias_log_is_emitted_once_per_process(tmp_path, caplog):
+    api_keys_path = tmp_path / "api-keys.json"
+    api_keys_path.write_text(
+        '{"gate_user": {"exchange": "gate", "key": "redacted", "secret": "redacted"}}',
+        encoding="utf-8",
+    )
+
+    with caplog.at_level("INFO"):
+        procedures.load_user_info("gate_user", api_keys_path=str(api_keys_path))
+        procedures.load_user_info("gate_user", api_keys_path=str(api_keys_path))
+
+    assert caplog.text.count("exchange alias 'gate' normalized") == 1
+
+
+def test_gateio_api_key_identity_remains_canonical_without_alias_log(tmp_path, caplog):
+    api_keys_path = tmp_path / "api-keys.json"
+    api_keys_path.write_text(
+        '{"gate_user": {"exchange": "gateio", "key": "redacted", "secret": "redacted"}}',
+        encoding="utf-8",
+    )
+
+    with caplog.at_level("INFO"):
+        user_info = procedures.load_user_info(
+            "gate_user", api_keys_path=str(api_keys_path)
+        )
+
+    assert user_info["exchange"] == "gateio"
+    assert "exchange alias" not in caplog.text
+
+
+def test_gate_api_key_alias_selects_dedicated_gateio_connector(tmp_path, monkeypatch):
+    api_keys_path = tmp_path / "api-keys.json"
+    api_keys_path.write_text(
+        '{"gate_user": {"exchange": "gate", "key": "redacted", "secret": "redacted"}}',
+        encoding="utf-8",
+    )
+    def load_alias_user(user):
+        return procedures.load_user_info(user, api_keys_path=str(api_keys_path))
+
+    bot = SimpleNamespace()
+
+    monkeypatch.setattr(passivbot, "load_user_info", load_alias_user)
+    monkeypatch.setattr(gateio_module, "GateIOBot", lambda _config: bot)
+
+    result = passivbot.setup_bot({"live": {"user": "gate_user"}})
+
+    assert result is bot
+    assert result._order_churn_gate_enabled_for_connector is True
+
+
+def test_gateio_standalone_ccxt_loader_uses_gate_client(monkeypatch):
+    constructed = []
+
+    class GateClient:
+        def __init__(self, config):
+            constructed.append(config)
+            self.options = {}
+
+    monkeypatch.setattr(utils.ccxt, "gate", GateClient)
+    monkeypatch.setattr(
+        utils,
+        "resolve_custom_endpoint_override_with_aliases",
+        lambda exchange_id, aliases: (
+            None if (exchange_id, aliases) == ("gateio", ("gate",)) else "unexpected"
+        ),
+    )
+
+    client = utils.load_ccxt_instance("gateio")
+
+    assert isinstance(client, GateClient)
+    assert client.options["defaultType"] == "swap"
+    assert constructed == [{"enableRateLimit": True, "timeout": 60_000}]
 
 
 def test_gateio_session_boundary_accepts_gate_endpoint_override(monkeypatch):


### PR DESCRIPTION
## Summary

- retain `gateio` as Passivbot's canonical connector, cache, broker, event, and persisted-state identity
- accept CCXT's `gate` label in `api-keys.json`, normalize it to `gateio`, and emit one clear compatibility log per process
- translate `gateio` to CCXT's `gate` class at standalone REST client construction as well as dedicated connector session construction
- normalize Gate's numeric REST account UID to the string CCXT Pro requires for private futures order subscriptions
- document the identity boundary and add regression coverage

## Root cause

CCXT 4.5.66 removed the `gateio` client class in favor of `gate`. Preliminary market loading still constructed `gateio`, while changing the configured exchange to `gate` bypassed Passivbot's dedicated `GateIOBot` and selected the generic adapter. After correcting that boundary, Gate's numeric account UID exposed a second incompatibility: CCXT Pro expects a string UID and otherwise raises `TypeError` while subscribing to private futures orders.

## Validation

- focused Gate identity, connector-routing, endpoint-override, and order-contract tests
- complete Python test suite using a Rust extension built from the target branch sources
- manual authenticated live smoke with both `gateio` and `gate` configuration labels, including startup readiness and private order WebSocket subscription
- `git diff --check`
