### PR TITLE
Fix Binance and Bitget hedge order attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Binance and Bitget private order updates now use the connector's actual exchange hedge mode for
+  mandatory long/short attribution even when `live.hedge_mode=false` disables simultaneous
+  strategy exposure. Valid hedge-account updates no longer enter the one-way normalization path
+  and reconnect their watchers merely because native `reduceOnly` metadata is absent.
+
 - KuCoin REST and private WebSocket clients now use IPv4 transport so API keys
   restricted to a host's stable public IPv4 address are not rejected when the
   host also has IPv6 connectivity.

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -45,6 +45,15 @@ Handling in Passivbot:
 4. For each broker-agreement exchange, verify the actual signed CCXT/raw request includes the required broker field/header/tag.
 5. Add regression tests at the request-construction boundary when changing exchange sessions, signing, or order payload code.
 
+## Exchange Hedge Mode Versus Strategy Hedge Mode
+
+`live.hedge_mode=false` disables simultaneous long and short strategy exposure; it does not put an
+exchange account into one-way mode. Binance and Bitget connectors keep the exchange account in
+hedge mode. Their private order updates must therefore normalize `position_side` and close-only
+semantics from the exchange's actual mode and explicit `positionSide`/`posSide` fields even when
+the strategy setting is false. Only connectors whose `hedge_mode` capability is actually false may
+use the one-way side plus `reduceOnly` attribution path.
+
 ## Bybit
 
 ### Broker referer header
@@ -129,7 +138,9 @@ Handling:
 
 1. Treat current same-mode success as success (`code=00000`, `data.posMode=hedge_mode`).
 2. Let unknown `set_position_mode` failures raise unless a verified Bitget no-op code is added with a targeted test.
-3. Require explicit side-disambiguating payloads for order/fill normalization instead of defaulting to long; open orders should carry `posSide`, while fills may use `tradeSide`/`side`/`posMode`.
+3. Normalize against the actual exchange account mode, not `live.hedge_mode`, which only controls
+   simultaneous strategy exposure.
+4. Require explicit side-disambiguating payloads for order/fill normalization instead of defaulting to long; open orders should carry `posSide`, while fills may use `tradeSide`/`side`/`posMode`.
 
 ### UTA / Elite hedge-mode order direction
 

--- a/src/exchanges/binance.py
+++ b/src/exchanges/binance.py
@@ -88,10 +88,7 @@ class BinanceBot(CCXTBot):
         exchange_position_side = str(
             info.get("positionSide") or info.get("ps") or ""
         ).lower()
-        if not bool(
-            getattr(self, "_config_hedge_mode", True)
-            and getattr(self, "hedge_mode", True)
-        ):
+        if not bool(getattr(self, "hedge_mode", True)):
             return self._normalize_one_way_position_side(order)
         if exchange_position_side in {"long", "short"}:
             return exchange_position_side
@@ -109,8 +106,7 @@ class BinanceBot(CCXTBot):
             info.get("positionSide") or info.get("ps") or ""
         ).lower()
         if exchange_position_side == "both" or not bool(
-            getattr(self, "_config_hedge_mode", True)
-            and getattr(self, "hedge_mode", True)
+            getattr(self, "hedge_mode", True)
         ):
             reduce_only = self._strict_order_reduce_only_response(order)
             if not isinstance(reduce_only, bool):

--- a/src/exchanges/bitget.py
+++ b/src/exchanges/bitget.py
@@ -102,10 +102,7 @@ class BitgetBot(CCXTBot):
 
     def _get_position_side_for_order(self, order: dict) -> str:
         """Bitget provides posSide in info."""
-        if not bool(
-            getattr(self, "_config_hedge_mode", True)
-            and getattr(self, "hedge_mode", True)
-        ):
+        if not bool(getattr(self, "hedge_mode", True)):
             return self._normalize_one_way_position_side(order)
         position_side = str(
             order.get("position_side")

--- a/tests/test_order_reconciliation_contract.py
+++ b/tests/test_order_reconciliation_contract.py
@@ -180,9 +180,9 @@ def test_bybit_rejects_noncanonical_position_idx(raw_position_idx):
 @pytest.mark.parametrize(
     ("bot_cls", "info", "extra_attrs"),
     [
-        (BinanceBot, {"positionSide": "BOTH"}, {}),
+        (BinanceBot, {"positionSide": "BOTH"}, {"hedge_mode": False}),
         (BybitBot, {"positionIdx": 0}, {}),
-        (BitgetBot, {}, {"is_uta": False}),
+        (BitgetBot, {}, {"is_uta": False, "hedge_mode": False}),
         (HyperliquidBot, {}, {}),
         (GateIOBot, {}, {}),
         (KucoinBot, {}, {}),
@@ -220,9 +220,9 @@ def test_effective_one_way_orders_cover_all_side_close_only_tuples(
 @pytest.mark.parametrize(
     ("bot_cls", "info", "extra_attrs"),
     [
-        (BinanceBot, {"positionSide": "BOTH"}, {}),
+        (BinanceBot, {"positionSide": "BOTH"}, {"hedge_mode": False}),
         (BybitBot, {"positionIdx": 0}, {}),
-        (BitgetBot, {}, {"is_uta": False}),
+        (BitgetBot, {}, {"is_uta": False, "hedge_mode": False}),
         (HyperliquidBot, {}, {}),
         (GateIOBot, {}, {}),
         (KucoinBot, {}, {}),
@@ -300,6 +300,20 @@ def test_binance_one_way_open_order_normalizer_uses_action_tuple():
     assert normalized["position_side"] == "short"
 
 
+def test_binance_exchange_hedge_order_ignores_strategy_one_way_setting():
+    bot = BinanceBot.__new__(BinanceBot)
+    bot._config_hedge_mode = False
+    bot.hedge_mode = True
+    order = {
+        "symbol": "BTC/USDT:USDT",
+        "side": "sell",
+        "info": {"positionSide": "LONG"},
+    }
+
+    assert bot._get_position_side_for_order(order) == "long"
+    assert bot._canonical_open_order_reduce_only(order) is True
+
+
 def test_bitget_one_way_open_order_normalizer_uses_action_tuple():
     bot = BitgetBot.__new__(BitgetBot)
     bot.is_uta = False
@@ -321,6 +335,21 @@ def test_bitget_one_way_open_order_normalizer_uses_action_tuple():
 
     assert normalized["position_side"] == "short"
     assert normalized["side"] == "sell"
+
+
+def test_bitget_exchange_hedge_order_ignores_strategy_one_way_setting():
+    bot = BitgetBot.__new__(BitgetBot)
+    bot.is_uta = False
+    bot._config_hedge_mode = False
+    bot.hedge_mode = True
+    order = {
+        "symbol": "BTC/USDT:USDT",
+        "side": "sell",
+        "info": {"side": "sell", "posSide": "long", "tradeSide": "close"},
+    }
+
+    assert bot._get_position_side_for_order(order) == "long"
+    assert bot._canonical_open_order_reduce_only(order) is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- normalize Binance and Bitget private order updates against the connector's actual exchange hedge capability
- keep `live.hedge_mode` scoped to strategy exposure instead of treating it as exchange account mode
- preserve the one-way side plus `reduceOnly` path when a connector is actually one-way
- document the exchange-mode/strategy-mode boundary and add regression coverage for both hedge and one-way paths

## Root cause

Both connectors set the exchange account to hedge mode during startup, but their open-order attribution combined the exchange capability with `live.hedge_mode`. When strategy hedge mode was disabled, valid exchange hedge updates were routed through one-way normalization and could fail because hedge responses do not necessarily carry native `reduceOnly` metadata.

## Validation

- `PYTHONPATH=src python -m pytest -q tests/test_order_reconciliation_contract.py tests/ccxt_upgrade/test_order_contracts.py tests/test_bitget_side_pside.py` (206 passed)
- `git diff --check`
