### PR TITLE
Tolerate one-tick fill position-price rounding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ All notable user-facing changes will be documented in this file.
 - Live trailing fill confirmation now accepts reconstructed position-price
   differences of at most one effective executable price tick to accommodate
   exchange rounding or truncation of sub-tick VWAPs, including Hyperliquid's
-  significant-digit price ladder. Fill identity and reconstructed position size
-  remain strict, the explicit position-opening replay retains its ordinary
-  half-tick requirement, larger discrepancies remain fail-closed, and acceptance
-  beyond the ordinary half-tick comparison emits one warning plus a structured
-  diagnostic when confirmation clears.
+  significant-digit price ladder and its asymmetric spacing across powers of
+  ten. Fill identity and reconstructed position size remain strict, the explicit
+  position-opening replay retains its ordinary half-tick requirement, larger
+  discrepancies remain fail-closed, and acceptance beyond the ordinary half-tick
+  comparison emits one warning plus a structured diagnostic when confirmation
+  clears.
 
 - Binance and Bitget private order updates now use the connector's actual exchange hedge mode for
   mandatory long/short attribution even when `live.hedge_mode=false` disables simultaneous

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live trailing fill confirmation now accepts reconstructed position-price
+  differences of at most one exchange price tick to accommodate exchange
+  rounding or truncation of sub-tick VWAPs. Fill identity and reconstructed
+  position size remain strict, larger discrepancies remain fail-closed, and
+  acceptance beyond the ordinary half-tick comparison emits one warning when
+  confirmation clears.
+
 - Live trailing fill confirmation can now recover from a polluted historical
   `psize`/`pprice` residue when the exchange supplies an explicit position
   opening timestamp. Recovery is restricted to a single identified opening fill

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable user-facing changes will be documented in this file.
 ## Unreleased
 
 - Live trailing fill confirmation now accepts reconstructed position-price
-  differences of at most one exchange price tick to accommodate exchange
-  rounding or truncation of sub-tick VWAPs. Fill identity and reconstructed
-  position size remain strict, larger discrepancies remain fail-closed, and
-  acceptance beyond the ordinary half-tick comparison emits one warning when
-  confirmation clears.
+  differences of at most one effective executable price tick to accommodate
+  exchange rounding or truncation of sub-tick VWAPs, including Hyperliquid's
+  significant-digit price ladder. Fill identity and reconstructed position size
+  remain strict, the explicit position-opening replay retains its ordinary
+  half-tick requirement, larger discrepancies remain fail-closed, and acceptance
+  beyond the ordinary half-tick comparison emits one warning plus a structured
+  diagnostic when confirmation clears.
 
 - Binance and Bitget private order updates now use the connector's actual exchange hedge mode for
   mandatory long/short attribution even when `live.hedge_mode=false` disables simultaneous

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -39,11 +39,16 @@
    and update-only position timestamps do not establish this boundary. Successful use
    emits a warning and a structured fallback diagnostic only after every confirmation
    predicate, including the required post-snapshot fill generation, has cleared.
-   Ordinary recorded after-state price comparison accepts at most one exchange price
-   tick because exchanges may round or truncate a sub-tick reconstructed VWAP. Quantity
-   and fill identity remain strict. Acceptance outside the ordinary half-tick comparison
-   but within one full tick emits one warning after confirmation clears; discrepancies
-   larger than one tick remain pending.
+   Ordinary recorded after-state price comparison accepts at most one effective
+   executable price tick because exchanges may round or truncate a sub-tick reconstructed
+   VWAP. The effective tick is connector-aware, including Hyperliquid's decimal and
+   significant-digit price ladder, and the inclusive boundary admits only floating-point
+   representation slack. Quantity and fill identity remain strict. The explicit
+   position-opening replay retains the ordinary half-tick comparison because it has no
+   reconstructed VWAP rounding evidence. Acceptance outside that comparison but within
+   one full tick emits one warning and `fill.position_price_tolerance_used` with bounded
+   numeric discrepancy context after confirmation clears; larger discrepancies remain
+   pending.
 10. A degraded synthetic PnL row inside the configured live risk lookback is not
     authoritative merely because cache metadata proves time coverage. Refetch bounded
     windows around each such row, preserving the pre-repair incremental checkpoint and

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -39,6 +39,11 @@
    and update-only position timestamps do not establish this boundary. Successful use
    emits a warning and a structured fallback diagnostic only after every confirmation
    predicate, including the required post-snapshot fill generation, has cleared.
+   Ordinary recorded after-state price comparison accepts at most one exchange price
+   tick because exchanges may round or truncate a sub-tick reconstructed VWAP. Quantity
+   and fill identity remain strict. Acceptance outside the ordinary half-tick comparison
+   but within one full tick emits one warning after confirmation clears; discrepancies
+   larger than one tick remain pending.
 10. A degraded synthetic PnL row inside the configured live risk lookback is not
     authoritative merely because cache metadata proves time coverage. Refetch bounded
     windows around each such row, preserving the pre-repair incremental checkpoint and

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -42,13 +42,14 @@
    Ordinary recorded after-state price comparison accepts at most one effective
    executable price tick because exchanges may round or truncate a sub-tick reconstructed
    VWAP. The effective tick is connector-aware, including Hyperliquid's decimal and
-   significant-digit price ladder, and the inclusive boundary admits only floating-point
-   representation slack. Quantity and fill identity remain strict. The explicit
-   position-opening replay retains the ordinary half-tick comparison because it has no
-   reconstructed VWAP rounding evidence. Acceptance outside that comparison but within
-   one full tick emits one warning and `fill.position_price_tolerance_used` with bounded
-   numeric discrepancy context after confirmation clears; larger discrepancies remain
-   pending.
+   significant-digit price ladder. It is derived from both compared prices so the
+   narrower, lower-side interval governs discrepancies that cross a power-of-ten
+   boundary; the inclusive boundary admits only floating-point representation slack.
+   Quantity and fill identity remain strict. The explicit position-opening replay retains
+   the ordinary half-tick comparison because it has no reconstructed VWAP rounding
+   evidence. Acceptance outside that comparison but within one full tick emits one
+   warning and `fill.position_price_tolerance_used` with bounded numeric discrepancy
+   context after confirmation clears; larger discrepancies remain pending.
 10. A degraded synthetic PnL row inside the configured live risk lookback is not
     authoritative merely because cache metadata proves time coverage. Refetch bounded
     windows around each such row, preserving the pre-repair incremental checkpoint and

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -412,6 +412,16 @@ profiles. When an outcome carries an exception object or result, its payload ret
 raw responses, and tracebacks. This diagnostic redaction does not alter event routing, emitter
 isolation, executor retries or re-raises, exchange calls, or trading behavior.
 
+## Fill Confirmation Fallbacks
+
+`fill.position_price_tolerance_used` records the accepted bounded numeric difference
+between a reconstructed fill after-state price and the authoritative exchange position
+price. It includes the effective connector-aware price tick, absolute delta, delta in
+ticks, and applied tolerance; it contains no raw fill or exchange payload. The event is
+published only after identity, size, refresh-generation, and price predicates clear.
+The existing warning remains the console/text projection, so the structured event itself
+does not produce a second console line.
+
 ## HSL Replay Timing
 
 For coin-mode `hsl.replay.completed`, `full_elapsed_s` is total replay time;

--- a/docs/ai/generated/live_event_registry.md
+++ b/docs/ai/generated/live_event_registry.md
@@ -52,6 +52,7 @@ The code-owned registries live in `src/live/event_bus.py`. Payload and emission 
 - `execution.create_succeeded`
 - `fill.ingested`
 - `fill.position_open_boundary_recovery_used`
+- `fill.position_price_tolerance_used`
 - `fills.ingested_summary`
 - `fills.refresh_summary`
 - `forager.eligibility_changed`

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -389,19 +389,36 @@ class HyperliquidBot(CCXTBot):
             "only_isolated": only_isolated,
         }
 
-    def _effective_position_price_tick(self, symbol: str, price: float) -> float:
+    def _effective_position_price_tick(
+        self,
+        symbol: str,
+        price: float,
+        comparison_price: float | None = None,
+    ) -> float:
         """Account for Hyperliquid's decimal and significant-digit price ladder."""
-        static_step = super()._effective_position_price_tick(symbol, price)
-        price = abs(float(price))
-        if not math.isfinite(price) or price <= 0.0:
+        static_step = super()._effective_position_price_tick(
+            symbol, price, comparison_price
+        )
+        prices = [abs(float(price))]
+        if comparison_price is not None:
+            prices.append(abs(float(comparison_price)))
+        positive_prices = [
+            candidate
+            for candidate in prices
+            if math.isfinite(candidate) and candidate > 0.0
+        ]
+        if not positive_prices:
             return static_step
+        # The significant-digit ladder changes spacing at powers of ten. The
+        # lower endpoint determines the interval crossing that boundary.
+        ladder_price = min(positive_prices)
         decimal_places = max(0, int(getattr(self, "n_decimal_places", 6) or 6))
         significant_figures = max(
             1, int(getattr(self, "n_significant_figures", 5) or 5)
         )
         decimal_step = 10.0 ** (-decimal_places)
         significant_step = 10.0 ** (
-            math.floor(math.log10(price)) - significant_figures + 1
+            math.floor(math.log10(ladder_price)) - significant_figures + 1
         )
         return max(static_step, decimal_step, significant_step)
 

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -389,6 +389,22 @@ class HyperliquidBot(CCXTBot):
             "only_isolated": only_isolated,
         }
 
+    def _effective_position_price_tick(self, symbol: str, price: float) -> float:
+        """Account for Hyperliquid's decimal and significant-digit price ladder."""
+        static_step = super()._effective_position_price_tick(symbol, price)
+        price = abs(float(price))
+        if not math.isfinite(price) or price <= 0.0:
+            return static_step
+        decimal_places = max(0, int(getattr(self, "n_decimal_places", 6) or 6))
+        significant_figures = max(
+            1, int(getattr(self, "n_significant_figures", 5) or 5)
+        )
+        decimal_step = 10.0 ** (-decimal_places)
+        significant_step = 10.0 ** (
+            math.floor(math.log10(price)) - significant_figures + 1
+        )
+        return max(static_step, decimal_step, significant_step)
+
     def _requires_isolated_margin(self, symbol: str) -> bool:
         """Check if a symbol requires isolated margin mode.
 

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -238,6 +238,7 @@ class EventTypes:
     FILL_POSITION_OPEN_BOUNDARY_RECOVERY_USED = (
         "fill.position_open_boundary_recovery_used"
     )
+    FILL_POSITION_PRICE_TOLERANCE_USED = "fill.position_price_tolerance_used"
     POSITION_CHANGED = "position.changed"
     BALANCE_CHANGED = "balance.changed"
     RISK_MODE_CHANGED = "risk.mode_changed"
@@ -582,6 +583,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.FILL_INGESTED,
     EventTypes.FILLS_INGESTED_SUMMARY,
     EventTypes.FILL_POSITION_OPEN_BOUNDARY_RECOVERY_USED,
+    EventTypes.FILL_POSITION_PRICE_TOLERANCE_USED,
     EventTypes.POSITION_CHANGED,
     EventTypes.BALANCE_CHANGED,
     EventTypes.RISK_MODE_CHANGED,
@@ -1401,6 +1403,9 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.FILLS_INGESTED_SUMMARY: EventRoute(console=True, text=True),
     EventTypes.FILL_POSITION_OPEN_BOUNDARY_RECOVERY_USED: EventRoute(
         console=True, text=True
+    ),
+    EventTypes.FILL_POSITION_PRICE_TOLERANCE_USED: EventRoute(
+        console=False, text=False
     ),
     EventTypes.POSITION_CHANGED: EventRoute(console=True, text=True),
     EventTypes.BALANCE_CHANGED: EventRoute(console=True, text=True),

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -8500,7 +8500,10 @@ class Passivbot:
         c_mult = abs(float(getattr(self, "c_mults", {}).get(symbol, 1.0) or 1.0))
         position_size_in_fill_units = abs(position_size) * c_mult
         qty_tolerance = max(qty_step * c_mult * 0.5, 1e-12)
-        price_tolerance = max(price_step * 0.5, abs(position_price) * 1e-9, 1e-12)
+        strict_price_tolerance = max(
+            price_step * 0.5, abs(position_price) * 1e-9, 1e-12
+        )
+        price_tolerance = max(price_step, abs(position_price) * 1e-9, 1e-12)
         if "psize" in anchor and "pprice" in anchor:
             fill_size = abs(float(anchor["psize"]))
             fill_price = float(anchor["pprice"])
@@ -8508,9 +8511,12 @@ class Passivbot:
                 math.isfinite(fill_size)
                 and math.isfinite(fill_price)
                 and abs(fill_size - position_size_in_fill_units) <= qty_tolerance
-                and abs(fill_price - position_price) <= price_tolerance
             ):
-                return "recorded_after_state"
+                price_delta = abs(fill_price - position_price)
+                if price_delta <= strict_price_tolerance:
+                    return "recorded_after_state"
+                if price_delta <= price_tolerance:
+                    return "recorded_after_state_price_tolerance"
 
         if self._position_open_fill_replay_matches_state(
             symbol,
@@ -8697,6 +8703,34 @@ class Passivbot:
                 symbol=symbol,
                 pside=pside,
             ),
+        )
+
+    def _log_bounded_fill_position_price_discrepancy(
+        self,
+        symbol: str,
+        pside: str,
+        state: tuple[float, float],
+        anchor: dict,
+    ) -> None:
+        """Report exchange rounding accepted only after confirmation clears."""
+        exchange_price = float(state[1])
+        reconstructed_price = float(anchor["pprice"])
+        price_step = abs(
+            float(getattr(self, "price_steps", {}).get(symbol, 0.0) or 0.0)
+        )
+        price_delta = abs(reconstructed_price - exchange_price)
+        delta_ticks = price_delta / price_step if price_step > 0.0 else 0.0
+        logging.warning(
+            "[fills] accepted bounded reconstructed position-price discrepancy | "
+            "symbol=%s pside=%s exchange_price=%.12g reconstructed_price=%.12g "
+            "delta=%.12g ticks=%.6g tolerance=%.12g",
+            self._log_symbol(symbol),
+            pside,
+            exchange_price,
+            reconstructed_price,
+            price_delta,
+            delta_ticks,
+            max(price_step, abs(exchange_price) * 1e-9, 1e-12),
         )
 
     def _latest_fill_position_change_epochs(self) -> dict[tuple[str, str], str]:
@@ -8921,6 +8955,16 @@ class Passivbot:
                     if position_match_kind == "position_open_boundary":
                         self._emit_position_open_fill_recovery_used(
                             symbol, pside, anchor
+                        )
+                    elif (
+                        position_match_kind
+                        == "recorded_after_state_price_tolerance"
+                    ):
+                        self._log_bounded_fill_position_price_discrepancy(
+                            symbol,
+                            pside,
+                            expected_position_state,
+                            anchor,
                         )
                     pending_fill_confirmations.pop(epoch_key, None)
                     pending_fill_min_generations.pop(epoch_key, None)

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -8480,9 +8480,14 @@ class Passivbot:
             is not None
         )
 
-    def _effective_position_price_tick(self, symbol: str, price: float) -> float:
+    def _effective_position_price_tick(
+        self,
+        symbol: str,
+        price: float,
+        comparison_price: float | None = None,
+    ) -> float:
         """Return the connector's effective executable-price increment."""
-        del price
+        del price, comparison_price
         return abs(
             float(getattr(self, "price_steps", {}).get(symbol, 0.0) or 0.0)
         )
@@ -8519,22 +8524,9 @@ class Passivbot:
         if not all(math.isfinite(value) for value in (position_size, position_price)):
             return None
         qty_step = abs(float(getattr(self, "qty_steps", {}).get(symbol, 0.0) or 0.0))
-        effective_price_tick = self._effective_position_price_tick(
-            symbol, position_price
-        )
         c_mult = abs(float(getattr(self, "c_mults", {}).get(symbol, 1.0) or 1.0))
         position_size_in_fill_units = abs(position_size) * c_mult
         qty_tolerance = max(qty_step * c_mult * 0.5, 1e-12)
-        strict_price_tolerance = max(
-            effective_price_tick * 0.5,
-            abs(position_price) * 1e-9,
-            1e-12,
-        )
-        price_tolerance = max(
-            effective_price_tick,
-            abs(position_price) * 1e-9,
-            1e-12,
-        )
         if "psize" in anchor and "pprice" in anchor:
             fill_size = abs(float(anchor["psize"]))
             fill_price = float(anchor["pprice"])
@@ -8543,6 +8535,19 @@ class Passivbot:
                 and math.isfinite(fill_price)
                 and abs(fill_size - position_size_in_fill_units) <= qty_tolerance
             ):
+                effective_price_tick = self._effective_position_price_tick(
+                    symbol, position_price, fill_price
+                )
+                strict_price_tolerance = max(
+                    effective_price_tick * 0.5,
+                    abs(position_price) * 1e-9,
+                    1e-12,
+                )
+                price_tolerance = max(
+                    effective_price_tick,
+                    abs(position_price) * 1e-9,
+                    1e-12,
+                )
                 if self._within_absolute_tolerance(
                     fill_price, position_price, strict_price_tolerance
                 ):
@@ -8558,7 +8563,6 @@ class Passivbot:
             state,
             anchor,
             qty_tolerance=qty_tolerance,
-            price_tolerance=strict_price_tolerance,
         ):
             return "position_open_boundary"
         return None
@@ -8571,7 +8575,6 @@ class Passivbot:
         anchor: dict,
         *,
         qty_tolerance: float,
-        price_tolerance: float,
     ) -> bool:
         """Replay fills from an exchange-proven position opening boundary.
 
@@ -8701,10 +8704,18 @@ class Passivbot:
         position_size, position_price = state
         c_mult = abs(float(getattr(self, "c_mults", {}).get(symbol, 1.0) or 1.0))
         expected_size = abs(position_size) * c_mult
+        effective_price_tick = self._effective_position_price_tick(
+            symbol, position_price, pprice
+        )
+        strict_price_tolerance = max(
+            effective_price_tick * 0.5,
+            abs(position_price) * 1e-9,
+            1e-12,
+        )
         return (
             abs(psize - expected_size) <= qty_tolerance
             and self._within_absolute_tolerance(
-                pprice, position_price, price_tolerance
+                pprice, position_price, strict_price_tolerance
             )
         )
 
@@ -8752,7 +8763,7 @@ class Passivbot:
         exchange_price = float(state[1])
         reconstructed_price = float(anchor["pprice"])
         effective_price_tick = self._effective_position_price_tick(
-            symbol, exchange_price
+            symbol, exchange_price, reconstructed_price
         )
         price_delta = abs(reconstructed_price - exchange_price)
         delta_ticks = (

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -8480,6 +8480,31 @@ class Passivbot:
             is not None
         )
 
+    def _effective_position_price_tick(self, symbol: str, price: float) -> float:
+        """Return the connector's effective executable-price increment."""
+        del price
+        return abs(
+            float(getattr(self, "price_steps", {}).get(symbol, 0.0) or 0.0)
+        )
+
+    @staticmethod
+    def _within_absolute_tolerance(
+        lhs: float, rhs: float, tolerance: float
+    ) -> bool:
+        """Compare at an inclusive float boundary with scale-aware ULP slack."""
+        if not all(math.isfinite(value) for value in (lhs, rhs, tolerance)):
+            return False
+        if tolerance < 0.0:
+            return False
+        slack = max(
+            math.ulp(lhs),
+            math.ulp(rhs),
+            math.ulp(tolerance),
+            tolerance * 1e-12,
+            1e-15,
+        )
+        return abs(lhs - rhs) <= tolerance + 4.0 * slack
+
     def _fill_anchor_position_state_match_kind(
         self,
         symbol: str,
@@ -8494,16 +8519,22 @@ class Passivbot:
         if not all(math.isfinite(value) for value in (position_size, position_price)):
             return None
         qty_step = abs(float(getattr(self, "qty_steps", {}).get(symbol, 0.0) or 0.0))
-        price_step = abs(
-            float(getattr(self, "price_steps", {}).get(symbol, 0.0) or 0.0)
+        effective_price_tick = self._effective_position_price_tick(
+            symbol, position_price
         )
         c_mult = abs(float(getattr(self, "c_mults", {}).get(symbol, 1.0) or 1.0))
         position_size_in_fill_units = abs(position_size) * c_mult
         qty_tolerance = max(qty_step * c_mult * 0.5, 1e-12)
         strict_price_tolerance = max(
-            price_step * 0.5, abs(position_price) * 1e-9, 1e-12
+            effective_price_tick * 0.5,
+            abs(position_price) * 1e-9,
+            1e-12,
         )
-        price_tolerance = max(price_step, abs(position_price) * 1e-9, 1e-12)
+        price_tolerance = max(
+            effective_price_tick,
+            abs(position_price) * 1e-9,
+            1e-12,
+        )
         if "psize" in anchor and "pprice" in anchor:
             fill_size = abs(float(anchor["psize"]))
             fill_price = float(anchor["pprice"])
@@ -8512,10 +8543,13 @@ class Passivbot:
                 and math.isfinite(fill_price)
                 and abs(fill_size - position_size_in_fill_units) <= qty_tolerance
             ):
-                price_delta = abs(fill_price - position_price)
-                if price_delta <= strict_price_tolerance:
+                if self._within_absolute_tolerance(
+                    fill_price, position_price, strict_price_tolerance
+                ):
                     return "recorded_after_state"
-                if price_delta <= price_tolerance:
+                if self._within_absolute_tolerance(
+                    fill_price, position_price, price_tolerance
+                ):
                     return "recorded_after_state_price_tolerance"
 
         if self._position_open_fill_replay_matches_state(
@@ -8524,7 +8558,7 @@ class Passivbot:
             state,
             anchor,
             qty_tolerance=qty_tolerance,
-            price_tolerance=price_tolerance,
+            price_tolerance=strict_price_tolerance,
         ):
             return "position_open_boundary"
         return None
@@ -8669,7 +8703,9 @@ class Passivbot:
         expected_size = abs(position_size) * c_mult
         return (
             abs(psize - expected_size) <= qty_tolerance
-            and abs(pprice - position_price) <= price_tolerance
+            and self._within_absolute_tolerance(
+                pprice, position_price, price_tolerance
+            )
         )
 
     def _emit_position_open_fill_recovery_used(
@@ -8705,7 +8741,7 @@ class Passivbot:
             ),
         )
 
-    def _log_bounded_fill_position_price_discrepancy(
+    def _emit_bounded_fill_position_price_discrepancy(
         self,
         symbol: str,
         pside: str,
@@ -8715,11 +8751,20 @@ class Passivbot:
         """Report exchange rounding accepted only after confirmation clears."""
         exchange_price = float(state[1])
         reconstructed_price = float(anchor["pprice"])
-        price_step = abs(
-            float(getattr(self, "price_steps", {}).get(symbol, 0.0) or 0.0)
+        effective_price_tick = self._effective_position_price_tick(
+            symbol, exchange_price
         )
         price_delta = abs(reconstructed_price - exchange_price)
-        delta_ticks = price_delta / price_step if price_step > 0.0 else 0.0
+        delta_ticks = (
+            price_delta / effective_price_tick
+            if effective_price_tick > 0.0
+            else 0.0
+        )
+        price_tolerance = max(
+            effective_price_tick,
+            abs(exchange_price) * 1e-9,
+            1e-12,
+        )
         logging.warning(
             "[fills] accepted bounded reconstructed position-price discrepancy | "
             "symbol=%s pside=%s exchange_price=%.12g reconstructed_price=%.12g "
@@ -8730,7 +8775,26 @@ class Passivbot:
             reconstructed_price,
             price_delta,
             delta_ticks,
-            max(price_step, abs(exchange_price) * 1e-9, 1e-12),
+            price_tolerance,
+        )
+        emit_diagnostic_event(
+            self,
+            DiagnosticEvent.build(
+                EventTypes.FILL_POSITION_PRICE_TOLERANCE_USED,
+                ("diagnostic", "fills", "recovery", "fallback"),
+                {
+                    "recovery": "recorded_after_state_price_tolerance",
+                    "exchange_position_price": exchange_price,
+                    "reconstructed_position_price": reconstructed_price,
+                    "price_delta": price_delta,
+                    "effective_price_tick": effective_price_tick,
+                    "delta_ticks": delta_ticks,
+                    "price_tolerance": price_tolerance,
+                },
+                ts_ms=utc_ms(),
+                symbol=symbol,
+                pside=pside,
+            ),
         )
 
     def _latest_fill_position_change_epochs(self) -> dict[tuple[str, str], str]:
@@ -8960,7 +9024,7 @@ class Passivbot:
                         position_match_kind
                         == "recorded_after_state_price_tolerance"
                     ):
-                        self._log_bounded_fill_position_price_discrepancy(
+                        self._emit_bounded_fill_position_price_discrepancy(
                             symbol,
                             pside,
                             expected_position_state,

--- a/tests/test_stock_perps.py
+++ b/tests/test_stock_perps.py
@@ -160,6 +160,9 @@ class TestHyperliquidBotHIP3:
         assert bot._effective_position_price_tick(
             "PENNY/USDC:USDC", 0.00012345
         ) == pytest.approx(1e-6)
+        assert bot._effective_position_price_tick(
+            "BTC/USDC:USDC", 100_000.0, 99_990.0
+        ) == pytest.approx(1.0)
 
     def test_requires_isolated_margin_uses_market_metadata(self, bot_class):
         """HIP-3 isolated requirement must come from market metadata, not just prefix."""

--- a/tests/test_stock_perps.py
+++ b/tests/test_stock_perps.py
@@ -146,6 +146,21 @@ class TestHyperliquidBotHIP3:
         """Test HIP-3 max leverage constant is 10."""
         assert bot_class.HIP3_MAX_LEVERAGE == 10
 
+    def test_effective_position_price_tick_includes_significant_digits(
+        self, bot_class
+    ):
+        bot = object.__new__(bot_class)
+        bot.price_steps = {"BTC/USDC:USDC": 0.1, "PENNY/USDC:USDC": 1e-8}
+        bot.n_decimal_places = 6
+        bot.n_significant_figures = 5
+
+        assert bot._effective_position_price_tick(
+            "BTC/USDC:USDC", 60_000.0
+        ) == pytest.approx(1.0)
+        assert bot._effective_position_price_tick(
+            "PENNY/USDC:USDC", 0.00012345
+        ) == pytest.approx(1e-6)
+
     def test_requires_isolated_margin_uses_market_metadata(self, bot_class):
         """HIP-3 isolated requirement must come from market metadata, not just prefix."""
         # Create minimal bot instance for method testing

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -1535,6 +1535,74 @@ async def test_position_delta_waits_for_new_fill_identity_across_refresh_cohorts
 
 
 @pytest.mark.asyncio
+async def test_bounded_fill_position_price_discrepancy_clears_once(caplog):
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    old_fill = _DummyFillEvent(
+        symbol, "long", 120_000, "old-fill", psize=1.0, pprice=100.0
+    )
+    bot._pnls_manager = _DummyPnlsManager([old_fill])
+    bot._trailing_position_change_epochs = {
+        (symbol, "long"): "fill:120000:old-fill"
+    }
+    bot.is_trailing = lambda sym, pside=None: pside == "long"
+    bot.get_exchange_time = lambda: 361_000
+
+    bot._apply_positions_snapshot(
+        [
+            {
+                "symbol": symbol,
+                "position_side": "long",
+                "size": 1.0,
+                "price": 100.0,
+                "lastUpdateTimestamp": 120_000,
+            }
+        ]
+    )
+    bot._begin_authoritative_refresh_epoch()
+    bot._apply_positions_snapshot(
+        [
+            {
+                "symbol": symbol,
+                "position_side": "long",
+                "size": 1.5,
+                "price": 101.0095,
+                "lastUpdateTimestamp": 240_000,
+            }
+        ]
+    )
+    bot._pnls_manager._events.append(
+        _DummyFillEvent(
+            symbol,
+            "long",
+            240_000,
+            "new-fill",
+            psize=1.5,
+            pprice=101.0,
+        )
+    )
+    bot._trailing_fill_fetch_generation = 1
+
+    async def complete_candles(*args, **kwargs):
+        return _make_candles(
+            [
+                (240_000, 100.0, 102.0, 99.0, 101.0, 1.0),
+                (300_000, 101.0, 103.0, 100.0, 102.0, 1.0),
+            ]
+        )
+
+    bot.cm.get_candles = complete_candles
+    with caplog.at_level(logging.WARNING):
+        await bot.update_trailing_data()
+        await bot.update_trailing_data()
+
+    assert bot._trailing_pending_fill_confirmations == {}
+    message = "accepted bounded reconstructed position-price discrepancy"
+    assert caplog.text.count(message) == 1
+
+
+@pytest.mark.asyncio
 async def test_fill_prefetch_before_position_delta_waits_for_post_snapshot_refresh():
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
@@ -1729,6 +1797,38 @@ def test_matching_fill_shape_does_not_override_truncated_cache_psize():
     )
     assert not bot._fill_anchor_matches_position_state(
         symbol, "short", (1.1, 58.717), anchor
+    )
+
+
+def test_fill_after_state_position_price_tolerance_is_one_tick():
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    anchor = {"psize": 1.0, "pprice": 100.0}
+
+    assert (
+        bot._fill_anchor_position_state_match_kind(
+            symbol, "long", (1.0, 100.0049), anchor
+        )
+        == "recorded_after_state"
+    )
+    assert (
+        bot._fill_anchor_position_state_match_kind(
+            symbol, "long", (1.0, 100.0095), anchor
+        )
+        == "recorded_after_state_price_tolerance"
+    )
+    assert (
+        bot._fill_anchor_position_state_match_kind(
+            symbol, "long", (1.0, 100.0101), anchor
+        )
+        is None
+    )
+    assert (
+        bot._fill_anchor_position_state_match_kind(
+            symbol, "long", (1.02, 100.0095), anchor
+        )
+        is None
     )
 
 

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -1852,6 +1852,37 @@ def test_fill_after_state_position_price_tolerance_is_one_tick():
     )
 
 
+def test_hyperliquid_fill_price_tolerance_uses_discrepancy_side_tick():
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    bot._effective_position_price_tick = (
+        lambda _symbol, price, comparison_price=None: 1.0
+        if comparison_price is not None
+        and min(abs(price), abs(comparison_price)) < 100_000.0
+        else 10.0
+    )
+
+    assert (
+        bot._fill_anchor_position_state_match_kind(
+            symbol,
+            "long",
+            (1.0, 100_000.0),
+            {"psize": 1.0, "pprice": 99_999.0},
+        )
+        == "recorded_after_state_price_tolerance"
+    )
+    assert (
+        bot._fill_anchor_position_state_match_kind(
+            symbol,
+            "long",
+            (1.0, 100_000.0),
+            {"psize": 1.0, "pprice": 99_990.0},
+        )
+        is None
+    )
+
+
 def test_position_open_replay_retains_strict_half_tick_price_tolerance():
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -1538,6 +1538,10 @@ async def test_position_delta_waits_for_new_fill_identity_across_refresh_cohorts
 async def test_bounded_fill_position_price_discrepancy_clears_once(caplog):
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
+    diagnostic_events = []
+    bot._monitor_record_event = lambda kind, tags, payload, **kwargs: (
+        diagnostic_events.append((kind, tags, payload, kwargs))
+    )
     symbol = _set_basic_state(bot)
     old_fill = _DummyFillEvent(
         symbol, "long", 120_000, "old-fill", psize=1.0, pprice=100.0
@@ -1600,6 +1604,16 @@ async def test_bounded_fill_position_price_discrepancy_clears_once(caplog):
     assert bot._trailing_pending_fill_confirmations == {}
     message = "accepted bounded reconstructed position-price discrepancy"
     assert caplog.text.count(message) == 1
+    assert len(diagnostic_events) == 1
+    kind, tags, payload, kwargs = diagnostic_events[0]
+    assert kind == "fill.position_price_tolerance_used"
+    assert tags == ("diagnostic", "fills", "recovery", "fallback")
+    assert payload["recovery"] == "recorded_after_state_price_tolerance"
+    assert payload["effective_price_tick"] == pytest.approx(0.01)
+    assert payload["price_delta"] == pytest.approx(0.0095)
+    assert payload["delta_ticks"] == pytest.approx(0.95)
+    assert kwargs["symbol"] == symbol
+    assert kwargs["pside"] == "long"
 
 
 @pytest.mark.asyncio
@@ -1820,7 +1834,13 @@ def test_fill_after_state_position_price_tolerance_is_one_tick():
     )
     assert (
         bot._fill_anchor_position_state_match_kind(
-            symbol, "long", (1.0, 100.0101), anchor
+            symbol, "long", (1.0, 100.01), anchor
+        )
+        == "recorded_after_state_price_tolerance"
+    )
+    assert (
+        bot._fill_anchor_position_state_match_kind(
+            symbol, "long", (1.0, 100.0100001), anchor
         )
         is None
     )
@@ -1829,6 +1849,35 @@ def test_fill_after_state_position_price_tolerance_is_one_tick():
             symbol, "long", (1.02, 100.0095), anchor
         )
         is None
+    )
+
+
+def test_position_open_replay_retains_strict_half_tick_price_tolerance():
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    bot.positions[symbol]["long"] = {
+        "size": 1.0,
+        "price": 100.0,
+        "openTime": 180_000,
+        "lastUpdateTimestamp": 180_000,
+    }
+    opening_fill = _DummyFillEvent(
+        symbol,
+        "long",
+        180_000,
+        "opening-fill",
+        psize=9.0,
+        pprice=90.0,
+        qty=1.0,
+        price=100.0095,
+        source_ids=["opening-fill"],
+    )
+    bot._pnls_manager = _DummyPnlsManager([opening_fill])
+    anchor = bot._latest_fill_position_change_anchors()[(symbol, "long")]
+
+    assert not bot._fill_anchor_matches_position_state(
+        symbol, "long", (1.0, 100.0), anchor
     )
 
 


### PR DESCRIPTION
## Summary

- accept fill-reconstructed position prices within one exchange price tick of the authoritative exchange position
- retain the existing half-tick match as the ordinary path and emit one clear warning only when the wider bound is used
- keep fill identity and reconstructed position size strict; discrepancies larger than one tick remain pending
- document the live fill-confirmation contract

## Root cause

A weighted reconstructed VWAP may be sub-tick while an exchange reports a rounded or truncated position price. The previous half-tick comparison could therefore leave an otherwise confirmed position permanently blocked.

## Validation

- `tests/test_unstucking_safeguards.py`
- `tests/test_order_orchestration.py`
- `tests/test_passivbot_monitor.py`

All passed using the repository Python 3.12 environment with the worktree source on `PYTHONPATH`.