### PR TITLE
Reduce forager EMA work and clarify readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Forager monitor health now distinguishes approved candidates that are
+  temporarily unrankable because volume/log-range or required candidate EMA
+  inputs are unavailable from active-symbol trading degradation. Open-tail
+  forager projection now computes only close EMAs because ranking metrics must
+  come from real candles, and latest-value EMA calculations avoid allocating an
+  unused full series.
+
 - Live trailing fill confirmation can now recover from a polluted historical
   `psize`/`pprice` residue when the exchange supplies an explicit position
   opening timestamp. Recovery is restricted to a single identified opening fill

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ All notable user-facing changes will be documented in this file.
 
 - Forager monitor health now distinguishes approved candidates that are
   temporarily unrankable because volume/log-range or required candidate EMA
-  inputs are unavailable from active-symbol trading degradation. Open-tail
-  forager projection now computes only close EMAs because ranking metrics must
-  come from real candles, and latest-value EMA calculations avoid allocating an
-  unused full series.
+  inputs are unavailable from active-symbol trading degradation. Ranking-feature
+  health is populated by the active Rust-orchestrator preparation path, candidate
+  labels use the same market-age eligibility as live selection, and active-symbol
+  EMA failures retain their active degradation reason. Open-tail forager projection
+  computes only close EMAs because ranking metrics must come from real candles,
+  and latest-value EMA calculations avoid allocating an unused full series.
 
 - Binance and Bitget private order updates now use the connector's actual exchange hedge mode for
   mandatory long/short attribution even when `live.hedge_mode=false` disables simultaneous

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1833,7 +1833,9 @@ All notable user-facing changes will be documented in this file.
 - Forager monitor readiness is now scoped to the exact symbols evaluated by the
   latest EMA bundle, optional cache-only metric gaps are classified as
   candidate health failures, and open-tail projection preserves log-range
-  inputs required by held or explicitly normal strategies.
+  inputs required by held or explicitly normal strategies. Completed-candle
+  forager ranking metrics now have a distinct Rust input channel so coincident
+  strategy and ranking spans cannot reuse projected values for coin selection.
 - `passivbot tool live-smoke-report` now reports timestamp/nonce
   `cycle.degraded` events recovered by a subsequent successful
   `exchange.time_sync` event as recovered problem events instead of hard smoke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ All notable user-facing changes will be documented in this file.
   temporarily unrankable because volume/log-range or required candidate EMA
   inputs are unavailable from active-symbol trading degradation. Ranking-feature
   health is populated by the active Rust-orchestrator preparation path, candidate
-  labels use the same market-age eligibility as live selection, and active-symbol
-  EMA failures retain their active degradation reason. Open-tail forager projection
-  computes only close EMAs because ranking metrics must come from real candles,
-  and latest-value EMA calculations avoid allocating an unused full series.
+  labels use the same market-age and effective-minimum-cost eligibility as live
+  selection, candidate health is cleared before a failed replacement bundle can
+  leave stale state behind, and active-symbol EMA failures retain their active
+  degradation reason. Open-tail forager projection computes only close EMAs
+  because ranking metrics must come from real candles, and latest-value EMA
+  calculations avoid allocating an unused full series.
 
 - Binance and Bitget private order updates now use the connector's actual exchange hedge mode for
   mandatory long/short attribution even when `live.hedge_mode=false` disables simultaneous

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1830,6 +1830,10 @@ All notable user-facing changes will be documented in this file.
   reasons and candidate error types in concise smoke output, making
   `cache_only_fetch_failed` vs `never_fetched_cache_only` visible without a
   separate event query.
+- Forager monitor readiness is now scoped to the exact symbols evaluated by the
+  latest EMA bundle, optional cache-only metric gaps are classified as
+  candidate health failures, and open-tail projection preserves log-range
+  inputs required by held or explicitly normal strategies.
 - `passivbot tool live-smoke-report` now reports timestamp/nonce
   `cycle.degraded` events recovered by a subsequent successful
   `exchange.time_sync` event as recovered problem events instead of hard smoke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ All notable user-facing changes will be documented in this file.
   inputs are unavailable from active-symbol trading degradation. Ranking-feature
   health is populated by the active Rust-orchestrator preparation path, candidate
   labels use the same market-age and effective-minimum-cost eligibility as live
-  selection, candidate health is cleared before a failed replacement bundle can
-  leave stale state behind, and active-symbol EMA failures retain their active
+  selection, all EMA health is cleared before a failed replacement bundle can
+  leave stale state behind, candidates remain explicitly unrankable until a
+  bundle completes, and active-symbol EMA failures retain their active
   degradation reason. Open-tail forager projection computes only close EMAs
   because ranking metrics must come from real candles, and latest-value EMA
   calculations avoid allocating an unused full series.

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -94,6 +94,15 @@
 11. Quote-volume EMA is derived from normalized CCXT base volume and typical price
     (`base_volume * (high + low + close) / 3`). It is an approximation when an exchange, including
     WEEX, does not expose raw quote turnover through unified OHLCV.
+12. Open-tail projection requests only the metrics its caller may consume.
+    Forager projection requests close EMAs only; quote-volume and log-range
+    ranking inputs continue to come from current or bounded cached real candles.
+    Identical projections within one finalized bucket reuse a bounded in-memory
+    result keyed by the candle index mtime, cached-tail timestamp, requested
+    spans, and projection horizon; local candle persistence invalidates it.
+    Latest-value EMA calculations use a scalar recurrence rather than allocating
+    a full output series. Full EMA series remain available to callers that need
+    every intermediate value.
 
 Cache paths use `to_standard_exchange_name()` rather than raw CCXT identifiers such as
 `binanceusdm` or `kucoinfutures`.

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -439,6 +439,12 @@ terminal event.
 
 `forager.eligibility_changed` is a bounded structured/monitor-only record of approved/ignored
 membership changes. It does not retain config paths, raw sources, or full lists.
+Monitor market entries label a forager candidate only when the same live
+`is_approved` predicate admits its coin and position side, including minimum
+market age. Ranking-feature unavailability is refreshed from the active
+orchestrator EMA preparation path on every bundle load. Candidate-only EMA
+failures remain distinct from flat active/normal-symbol degradation; monitor
+tradability must not relabel the latter as a candidate-only failure.
 
 `config.market_compatibility` records configured symbols removed by existing market filters.
 Approved-symbol incompatibility is degraded; ignored-symbol incompatibility is skipped. HIP-3

--- a/docs/ai/features/strategy_runtime.md
+++ b/docs/ai/features/strategy_runtime.md
@@ -84,7 +84,11 @@ candidate but is marked `forager.rankable=false`; this is distinct from an
 active symbol losing a required strategy input. The Rust payload still fails
 closed for an unrankable candidate. Monitor health must preserve that stage
 distinction so operators do not mistake a bounded candidate-ranking exclusion
-for an exchange market becoming intrinsically nontradable.
+for an exchange market becoming intrinsically nontradable. Before the current
+EMA bundle completes—or after a replacement bundle fails—eligible candidates
+remain visible with `forager.rankable=false` and
+`ema_bundle_unevaluated`; monitor health must not infer readiness from empty
+failure sets.
 
 ## Trailing Martingale Semantics
 

--- a/docs/ai/features/strategy_runtime.md
+++ b/docs/ai/features/strategy_runtime.md
@@ -69,6 +69,23 @@ for 1-minute candle inputs and `_1h` for 1-hour candle inputs, for example
 `forager_volatility_ema_span_1m`. Generic strategy EMA spans such as `ema_span_0` and `ema_span_1`
 remain unsuffixed because their timeframe comes from the strategy's base candle stream.
 
+## Forager Readiness Stages
+
+Live health distinguishes three stages:
+
+1. The candidate universe contains approved, age-eligible, cost-eligible symbols.
+2. A rankable candidate has the required real-candle quote-volume and log-range
+   features.
+3. A Rust-tradable symbol also has every strategy, trailing, and risk input
+   needed for its current mode.
+
+A flat candidate with unavailable ranking features remains visible as a forager
+candidate but is marked `forager.rankable=false`; this is distinct from an
+active symbol losing a required strategy input. The Rust payload still fails
+closed for an unrankable candidate. Monitor health must preserve that stage
+distinction so operators do not mistake a bounded candidate-ranking exclusion
+for an exchange market becoming intrinsically nontradable.
+
 ## Trailing Martingale Semantics
 
 Entries and closes use threshold/retracement fields.

--- a/docs/ai/features/strategy_runtime.md
+++ b/docs/ai/features/strategy_runtime.md
@@ -92,7 +92,9 @@ failure sets. Bundle readiness is scoped to the exact evaluated symbol set, so
 a newly age- or cost-eligible candidate remains unevaluated until a subsequent
 bundle includes it. Forager candidate ranking continues to use completed-candle
 metrics; held and explicitly normal symbols nevertheless retain any open-tail
-log-range projections required by their active strategy.
+log-range projections required by their active strategy. Live orchestration
+passes completed-candle forager metrics separately from strategy EMA maps so a
+shared span cannot leak a projected strategy value into coin ranking.
 
 ## Trailing Martingale Semantics
 

--- a/docs/ai/features/strategy_runtime.md
+++ b/docs/ai/features/strategy_runtime.md
@@ -88,7 +88,11 @@ for an exchange market becoming intrinsically nontradable. Before the current
 EMA bundle completes—or after a replacement bundle fails—eligible candidates
 remain visible with `forager.rankable=false` and
 `ema_bundle_unevaluated`; monitor health must not infer readiness from empty
-failure sets.
+failure sets. Bundle readiness is scoped to the exact evaluated symbol set, so
+a newly age- or cost-eligible candidate remains unevaluated until a subsequent
+bundle includes it. Forager candidate ranking continues to use completed-candle
+metrics; held and explicitly normal symbols nevertheless retain any open-tail
+log-range projections required by their active strategy.
 
 ## Trailing Martingale Semantics
 

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -1517,6 +1517,7 @@ impl<'a> Backtest<'a> {
                     next_candle,
                     effective_min_cost,
                     emas,
+                    forager_m1: None,
                     long: orchestrator::SymbolSideInput {
                         mode: mode_long,
                         position: pos_long,

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -394,6 +394,11 @@ mod core {
         pub next_candle: Option<NextCandle>,
         pub effective_min_cost: f64,
         pub emas: EmaBundle,
+        /// Optional completed-candle-only metrics for forager ranking. Live
+        /// supplies this when strategy EMAs may include an open-tail
+        /// projection; backtest and older callers fall back to `emas.m1`.
+        #[serde(default)]
+        pub forager_m1: Option<EmaTimeframeBundle>,
         pub long: SymbolSideInput,
         pub short: SymbolSideInput,
     }
@@ -2059,6 +2064,7 @@ mod core {
         out.clear();
         out.reserve(symbols.len());
         for s in symbols {
+            let forager_m1 = s.forager_m1.as_ref().unwrap_or(&s.emas.m1);
             let side = match pside {
                 PositionSide::Long => &s.long,
                 PositionSide::Short => &s.short,
@@ -2131,10 +2137,13 @@ mod core {
                 require_forager_input(
                     s.symbol_idx,
                     "forager_volume_score",
-                    ema_lookup(&s.emas.m1.volume, side.bot_params.filter_volume_ema_span_1m)
-                        .ok_or(OrchestratorError::MissingEma {
-                            symbol_idx: s.symbol_idx,
-                        })?,
+                    ema_lookup(
+                        &forager_m1.volume,
+                        side.bot_params.filter_volume_ema_span_1m,
+                    )
+                    .ok_or(OrchestratorError::MissingEma {
+                        symbol_idx: s.symbol_idx,
+                    })?,
                 )?
             } else {
                 0.0
@@ -2144,7 +2153,7 @@ mod core {
                     s.symbol_idx,
                     "forager_volatility_score",
                     ema_lookup(
-                        &s.emas.m1.log_range,
+                        &forager_m1.log_range,
                         side.bot_params.filter_volatility_ema_span_1m,
                     )
                     .ok_or(OrchestratorError::MissingEma {
@@ -4144,6 +4153,7 @@ mod core {
                 next_candle: None,
                 effective_min_cost: 0.0,
                 emas,
+                forager_m1: None,
                 long: SymbolSideInput {
                     mode: None,
                     position: Position::default(),
@@ -5602,6 +5612,71 @@ mod core {
             assert!((reducer.qty + 1.0).abs() < 1e-9);
             assert!((ordinary.qty + 0.5).abs() < 1e-9);
             assert!((closes.iter().map(|order| order.qty.abs()).sum::<f64>() - 1.5).abs() < 1e-9);
+        }
+
+        #[test]
+        fn forager_uses_explicit_completed_candle_metrics() {
+            let mut sym0 = make_basic_symbol(0);
+            let mut sym1 = make_basic_symbol(1);
+            // Strategy maps may contain projected open-tail values.
+            sym0.emas.m1.log_range = vec![(10.0, 100.0)];
+            sym1.emas.m1.log_range = vec![(10.0, 1.0)];
+            // Ranking must instead use completed-candle-only values.
+            sym0.forager_m1 = Some(EmaTimeframeBundle {
+                log_range: vec![(10.0, 1.0)],
+                volume: vec![(10.0, 1.0)],
+                ..Default::default()
+            });
+            sym1.forager_m1 = Some(EmaTimeframeBundle {
+                log_range: vec![(10.0, 10.0)],
+                volume: vec![(10.0, 1.0)],
+                ..Default::default()
+            });
+
+            let mut global_bp = BotParamsPair::default();
+            global_bp.long.total_wallet_exposure_limit = 1000.0;
+            global_bp.long.n_positions = 1;
+            global_bp.long.forager_volume_drop_pct = 0.0;
+            global_bp.long.forager_score_weights.volume = 0.0;
+            global_bp.long.forager_score_weights.ema_readiness = 0.0;
+            global_bp.long.forager_score_weights.volatility = 1.0;
+            global_bp.short.total_wallet_exposure_limit = 0.0;
+            global_bp.short.n_positions = 0;
+
+            let input = OrchestratorInput {
+                balance: 1_000_000.0,
+                balance_raw: 1_000_000.0,
+                timestamp_ms: 0,
+                global: OrchestratorGlobal {
+                    filter_by_min_effective_cost: false,
+                    market_orders_allowed: false,
+                    market_order_near_touch_threshold: 0.001,
+                    market_order_slippage_pct: 0.0,
+                    panic_close_market: false,
+                    auto_unstuck_allowed: Some(true),
+                    unstuck_allowance_long: 0.0,
+                    unstuck_allowance_short: 0.0,
+                    max_realized_loss_pct: 1.0,
+                    realized_pnl_cumsum_max: 0.0,
+                    realized_pnl_cumsum_last: 0.0,
+                    sort_global: true,
+                    global_bot_params: global_bp,
+                    hedge_mode: true,
+                    strategy_kind: StrategyKind::TrailingMartingale,
+                },
+                symbols: vec![sym0, sym1],
+                peek_hints: None,
+                forager_hysteresis: None,
+            };
+
+            let out = compute_ideal_orders_for_test(&input).unwrap();
+            let selection = out
+                .diagnostics
+                .forager_selections
+                .iter()
+                .find(|selection| selection.pside == PositionSide::Long)
+                .unwrap();
+            assert_eq!(selection.selected_symbol_indices, vec![1]);
         }
 
         #[test]

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -810,6 +810,20 @@ class CandlestickManager:
             {}
         )
         self._tf_range_cache_cap = 8
+        self._projected_open_tail_ema_cache: Dict[
+            str,
+            OrderedDict[
+                Tuple[
+                    int,
+                    int,
+                    int,
+                    int,
+                    Tuple[Tuple[str, Tuple[float, ...]], ...],
+                ],
+                Dict[str, Dict[float, float]],
+            ],
+        ] = {}
+        self._projected_open_tail_ema_cache_cap = 4
         self._step_warning_keys: set[Tuple[str, str, str]] = set()
         # Deduplication for zero-candle synthesis warnings - only warn once per unique gap
         # Key: (symbol, first_ts) to identify a gap by its starting point
@@ -2633,6 +2647,8 @@ class CandlestickManager:
             return
         arr = np.sort(_ensure_dtype(batch), order="ts")
         tf_norm = self._normalize_timeframe_arg(timeframe, tf)
+        if tf_norm == "1m":
+            self._projected_open_tail_ema_cache.pop(symbol, None)
 
         # Update inception_ts if this is new earliest data for 1m (defer save until end)
         if tf_norm == "1m":
@@ -6959,7 +6975,32 @@ class CandlestickManager:
     # ----- EMA helpers -----
 
     def _ema(self, values: np.ndarray, span: float) -> float:
-        return float(self._ema_series(values, span)[-1])
+        """Return the final bias-corrected EMA without allocating a full series."""
+        n = int(values.shape[0])
+        if n == 0:
+            return float("nan")
+        span = float(span)
+        alpha = 2.0 / (span + 1.0)
+        one_minus = 1.0 - alpha
+        first_finite_idx = None
+        for i in range(n):
+            if np.isfinite(float(values[i])):
+                first_finite_idx = i
+                break
+        if first_finite_idx is None:
+            return float("nan")
+        num = float(values[first_finite_idx])
+        den = 1.0
+        for i in range(first_finite_idx + 1, n):
+            value = float(values[i])
+            if not np.isfinite(value):
+                continue
+            num = alpha * value + one_minus * num
+            den = alpha + one_minus * den
+            if den <= np.finfo(np.float64).tiny:
+                num = alpha * value
+                den = alpha
+        return float(num / den)
 
     def _ema_series(self, values: np.ndarray, span: float) -> np.ndarray:
         """Return bias-corrected EMA (pandas ewm adjust=True) over `values`."""
@@ -7090,6 +7131,32 @@ class CandlestickManager:
         normalized = self._normalize_spans_by_metric(spans_by_metric)
         if not normalized:
             return {}
+        try:
+            index_mtime_ns = int(
+                os.stat(self._index_path(symbol, timeframe="1m")).st_mtime_ns
+            )
+        except (FileNotFoundError, OSError):
+            index_mtime_ns = 0
+        cache_key = (
+            int(latest_expected),
+            int(last_cached),
+            int(max_tail_gap),
+            index_mtime_ns,
+            tuple(
+                (metric_key, tuple(float(span) for span in spans))
+                for metric_key, spans in sorted(normalized.items())
+            ),
+        )
+        projection_cache = self._projected_open_tail_ema_cache.setdefault(
+            symbol, OrderedDict()
+        )
+        cached = projection_cache.get(cache_key)
+        if cached is not None:
+            projection_cache.move_to_end(cache_key)
+            return {
+                metric_key: dict(values)
+                for metric_key, values in cached.items()
+            }
         max_span = max(span for spans in normalized.values() for span in spans)
         window_candles = max(1, int(math.ceil(max_span)))
         start_ts = min(
@@ -7161,6 +7228,12 @@ class CandlestickManager:
                 else:
                     metric_out[span] = float(self._ema(tail, span))
             out[metric_key] = metric_out
+        projection_cache[cache_key] = {
+            metric_key: dict(values) for metric_key, values in out.items()
+        }
+        projection_cache.move_to_end(cache_key)
+        while len(projection_cache) > self._projected_open_tail_ema_cache_cap:
+            projection_cache.popitem(last=False)
         return out
 
     async def get_latest_cached_ema_metrics(

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -16302,6 +16302,9 @@ class Passivbot:
         m1_close_emas = snapshot["m1_close_emas"]
         m1_volume_emas = snapshot["m1_volume_emas"]
         m1_log_range_emas = snapshot["m1_log_range_emas"]
+        forager_m1_log_range_emas = snapshot.get(
+            "forager_m1_log_range_emas", m1_log_range_emas
+        )
         h1_log_range_emas = snapshot["h1_log_range_emas"]
         trailing_unavailable_symbols = set(
             getattr(self, "_orchestrator_trailing_unavailable_symbols", set())
@@ -16428,6 +16431,12 @@ class Passivbot:
                 [float(k), float(v)]
                 for k, v in sorted(m1_log_range_emas[symbol].items())
             ]
+            forager_m1_lr_pairs = [
+                [float(k), float(v)]
+                for k, v in sorted(
+                    forager_m1_log_range_emas.get(symbol, {}).items()
+                )
+            ]
             h1_lr_pairs = [
                 [float(k), float(v)]
                 for k, v in sorted(h1_log_range_emas[symbol].items())
@@ -16450,6 +16459,11 @@ class Passivbot:
                             "volume": m1_volume_pairs,
                         },
                         "h1": {"close": [], "log_range": h1_lr_pairs, "volume": []},
+                    },
+                    "forager_m1": {
+                        "close": [],
+                        "log_range": forager_m1_lr_pairs,
+                        "volume": m1_volume_pairs,
                     },
                     "long": side_input("long"),
                     "short": side_input("short"),
@@ -16586,6 +16600,7 @@ class Passivbot:
         }
         self._orchestrator_ema_bundle_completed = False
         self._orchestrator_ema_bundle_symbols = set()
+        self._orchestrator_forager_m1_log_range_emas = {}
         self._orchestrator_ema_unavailable_symbols = set()
         self._orchestrator_candidate_ema_unavailable_symbols = set()
         self._orchestrator_ema_unavailable_reasons = {}
@@ -17779,11 +17794,12 @@ class Passivbot:
             Passivbot._raise_if_shutdown_requested(self, "orchestrator_ema_bundle")
             if sym in cache_only_never_fetched:
                 mark_ema_unavailable(sym, "never_fetched_cache_only")
-                return {}, {}, {}, {}
+                return {}, {}, {}, {}, {}
             required_m1_lr_for_symbol = sorted(need_m1_lr_spans[sym])
             requested_m1_lr_spans = sorted(
                 set(m1_lr_spans) | set(required_m1_lr_for_symbol)
             )
+            forager_lr1m: Optional[dict[float, float]] = None
             try:
                 projection_ctx = projection_contexts.get(sym)
                 if projection_ctx is not None:
@@ -17876,17 +17892,21 @@ class Passivbot:
                         )
                         lr1m = {**optional_lr1m, **required_lr1m}
                 elif is_forager_mode():
-                    optional_lr1m = await fetch_map(
+                    forager_lr1m = await fetch_map(
                         sym,
-                        [
-                            span
-                            for span in m1_lr_spans
-                            if span not in lr1m
-                        ],
+                        m1_lr_spans,
                         ema_lr_1m,
                         "m1_log_range",
                     )
-                    lr1m = {**optional_lr1m, **lr1m}
+                    lr1m = {**forager_lr1m, **lr1m}
+                if forager_lr1m is None:
+                    forager_lr1m = {
+                        span: lr1m[span]
+                        for span in m1_lr_spans
+                        if span in lr1m
+                    }
+                if forager_lr1m is None:
+                    forager_lr1m = {}
             except Exception as exc:
                 if not required_ema_can_mark_nontradable(sym):
                     raise
@@ -17911,14 +17931,13 @@ class Passivbot:
                     ema_candle_health_context(sym),
                     interval_ms=15 * 60 * 1000,
                 )
-                return {}, {}, {}, {}
+                return {}, {}, {}, {}, {}
             missing_required_volume = [
                 span for span in sorted(required_forager_volume_spans) if span not in vol
             ]
             missing_required_forager_lr1m = [
-                span
-                for span in sorted(required_forager_m1_lr_spans)
-                if span not in lr1m
+                span for span in sorted(required_forager_m1_lr_spans)
+                if span not in forager_lr1m
             ]
             if missing_required_volume or missing_required_forager_lr1m:
                 reasons = []
@@ -17957,7 +17976,9 @@ class Passivbot:
                 )
             if sym in cache_only_symbols:
                 missing_volume = [span for span in m1_volume_spans if span not in vol]
-                missing_lr1m = [span for span in requested_m1_lr_spans if span not in lr1m]
+                missing_lr1m = [
+                    span for span in m1_lr_spans if span not in forager_lr1m
+                ]
                 if missing_volume or missing_lr1m:
                     missing_bits = []
                     if missing_volume:
@@ -17966,8 +17987,8 @@ class Passivbot:
                         missing_bits.append("missing_log_range")
                     mark_ema_unavailable(sym, "+".join(missing_bits) or "incomplete")
                     if not (missing_required_volume or missing_required_forager_lr1m):
-                        return {}, {}, {}, {}
-            return close, vol, lr1m, h1
+                        return {}, {}, {}, {}, {}
+            return close, vol, lr1m, h1, forager_lr1m
 
         # Ordering: symbols with open positions first (they need EMA data
         # for correct order calculation), remaining symbols shuffled to
@@ -18007,16 +18028,18 @@ class Passivbot:
         m1_close_emas: dict[str, dict[float, float]] = {}
         m1_volume_emas: dict[str, dict[float, float]] = {}
         m1_log_range_emas: dict[str, dict[float, float]] = {}
+        forager_m1_log_range_emas: dict[str, dict[float, float]] = {}
         h1_log_range_emas: dict[str, dict[float, float]] = {}
         errors: list[tuple[str, BaseException]] = []
         for sym, res in zip(ordered_symbols, symbol_results):
             if isinstance(res, BaseException):
                 errors.append((sym, res))
                 continue
-            close, vol, lr1m, h1 = res
+            close, vol, lr1m, h1, forager_lr1m = res
             m1_close_emas[sym] = close
             m1_volume_emas[sym] = vol
             m1_log_range_emas[sym] = lr1m
+            forager_m1_log_range_emas[sym] = forager_lr1m
             h1_log_range_emas[sym] = h1
         if optional_ema_drops:
             parts = []
@@ -18231,9 +18254,9 @@ class Passivbot:
             if vol_span_long in m1_volume_emas[s]
         }
         log_ranges_long = {
-            s: m1_log_range_emas[s][lr_span_long]
+            s: forager_m1_log_range_emas[s][lr_span_long]
             for s in symbols
-            if lr_span_long in m1_log_range_emas[s]
+            if lr_span_long in forager_m1_log_range_emas[s]
         }
         rank_feature_unavailable_by_side = {
             "long": set(),
@@ -18259,7 +18282,8 @@ class Passivbot:
                     and volume_span not in m1_volume_emas.get(symbol, {})
                 ) or (
                     log_range_required
-                    and log_range_span not in m1_log_range_emas.get(symbol, {})
+                    and log_range_span
+                    not in forager_m1_log_range_emas.get(symbol, {})
                 ):
                     rank_feature_unavailable_by_side[pside].add(symbol)
         self._forager_rank_feature_unavailable_by_side = (
@@ -18295,6 +18319,10 @@ class Passivbot:
             for reason, reason_symbols in ema_unavailable_reasons.items()
         }
         self._orchestrator_ema_bundle_symbols = set(symbols)
+        self._orchestrator_forager_m1_log_range_emas = {
+            symbol: dict(values)
+            for symbol, values in forager_m1_log_range_emas.items()
+        }
         self._orchestrator_ema_bundle_completed = True
         Passivbot._emit_ema_bundle_completed_event(
             self,
@@ -18359,6 +18387,9 @@ class Passivbot:
             self._forager_new_normal_warmup_symbols = pending
         ema_unavailable_symbols = set(
             getattr(self, "_orchestrator_ema_unavailable_symbols", set())
+        )
+        forager_m1_log_range_emas = getattr(
+            self, "_orchestrator_forager_m1_log_range_emas", {}
         )
         trailing_unavailable_symbols = set(
             getattr(self, "_orchestrator_trailing_unavailable_symbols", set())
@@ -18505,6 +18536,12 @@ class Passivbot:
                 [float(k), float(v)]
                 for k, v in sorted(m1_log_range_emas[symbol].items())
             ]
+            forager_m1_lr_pairs = [
+                [float(k), float(v)]
+                for k, v in sorted(
+                    forager_m1_log_range_emas.get(symbol, {}).items()
+                )
+            ]
             h1_lr_pairs = [
                 [float(k), float(v)]
                 for k, v in sorted(h1_log_range_emas[symbol].items())
@@ -18525,6 +18562,11 @@ class Passivbot:
                             "volume": m1_volume_pairs,
                         },
                         "h1": {"close": [], "log_range": h1_lr_pairs, "volume": []},
+                    },
+                    "forager_m1": {
+                        "close": [],
+                        "log_range": forager_m1_lr_pairs,
+                        "volume": m1_volume_pairs,
                     },
                     "long": side_input("long"),
                     "short": side_input("short"),

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -16580,6 +16580,10 @@ class Passivbot:
         """
         # Gather full EMA context for the live symbol universe.
         # Python should provide the market-state bundle; Rust decides which branches use it.
+        self._forager_rank_feature_unavailable_by_side = {
+            "long": set(),
+            "short": set(),
+        }
         Passivbot._emit_ema_bundle_started_event(self, symbols=symbols, modes=modes)
         need_close_spans: dict[str, set[float]] = {s: set() for s in symbols}
         need_m1_lr_spans: dict[str, set[float]] = {s: set() for s in symbols}
@@ -18200,6 +18204,36 @@ class Passivbot:
             for s in symbols
             if lr_span_long in m1_log_range_emas[s]
         }
+        rank_feature_unavailable_by_side = {
+            "long": set(),
+            "short": set(),
+        }
+        for pside, volume_span, log_range_span in (
+            ("long", vol_span_long, lr_span_long),
+            ("short", vol_span_short, lr_span_short),
+        ):
+            if not bool(is_forager_mode(pside)):
+                continue
+            volume_required = volume_span > 0.0 and (
+                _forager_volume_drop_pct(pside) > 0.0
+                or _forager_score_weight(pside, "volume") != 0.0
+            )
+            log_range_required = (
+                log_range_span > 0.0
+                and _forager_score_weight(pside, "volatility") != 0.0
+            )
+            for symbol in symbols:
+                if (
+                    volume_required
+                    and volume_span not in m1_volume_emas.get(symbol, {})
+                ) or (
+                    log_range_required
+                    and log_range_span not in m1_log_range_emas.get(symbol, {})
+                ):
+                    rank_feature_unavailable_by_side[pside].add(symbol)
+        self._forager_rank_feature_unavailable_by_side = (
+            rank_feature_unavailable_by_side
+        )
         self._orchestrator_ema_unavailable_symbols = set(ema_unavailable_symbols)
         candidate_reason_names = {
             reason
@@ -18214,7 +18248,8 @@ class Passivbot:
         }
         self._orchestrator_candidate_ema_unavailable_symbols = {
             symbol
-            for items in candidate_ema_unavailable_details.values()
+            for reason, items in candidate_ema_unavailable_details.items()
+            if reason in candidate_reason_names
             for symbol, _error_type, _ema_types, _spans in items
         } | {
             symbol

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -16585,6 +16585,7 @@ class Passivbot:
             "short": set(),
         }
         self._orchestrator_ema_bundle_completed = False
+        self._orchestrator_ema_bundle_symbols = set()
         self._orchestrator_ema_unavailable_symbols = set()
         self._orchestrator_candidate_ema_unavailable_symbols = set()
         self._orchestrator_ema_unavailable_reasons = {}
@@ -17658,6 +17659,10 @@ class Passivbot:
             dict[float, float] | None,
             dict[float, float] | None,
         ]:
+            project_strategy_log_range = bool(
+                required_m1_lr_for_symbol
+                and sym not in cache_only_symbols
+            )
             projection_metrics = {
                 "close": sorted(need_close_spans[sym]),
             }
@@ -17668,6 +17673,8 @@ class Passivbot:
                         "log_range": requested_m1_lr_spans,
                     }
                 )
+            elif project_strategy_log_range:
+                projection_metrics["log_range"] = required_m1_lr_for_symbol
             try:
                 projected = await self.cm.get_projected_open_tail_ema_metrics(
                     sym,
@@ -17690,18 +17697,26 @@ class Passivbot:
                 )
                 raise
             close = dict(projected.get("close", {}))
-            if is_forager_mode():
+            if is_forager_mode() and not project_strategy_log_range:
                 vol = None
                 lr1m = None
             else:
-                vol = projected_optional_map(
-                    sym, projected, "qv", m1_volume_spans, "m1_volume"
+                vol = (
+                    None
+                    if is_forager_mode()
+                    else projected_optional_map(
+                        sym, projected, "qv", m1_volume_spans, "m1_volume"
+                    )
                 )
                 lr1m = projected_optional_map(
                     sym,
                     projected,
                     "log_range",
-                    requested_m1_lr_spans,
+                    (
+                        required_m1_lr_for_symbol
+                        if is_forager_mode()
+                        else requested_m1_lr_spans
+                    ),
                     "m1_log_range",
                 )
             missing_close = [
@@ -17714,7 +17729,7 @@ class Passivbot:
                     "[ema] projected open-tail close EMA incomplete for "
                     f"{sym}: spans={','.join(f'{span:.8g}' for span in missing_close)}"
                 )
-            if not is_forager_mode():
+            if not is_forager_mode() or project_strategy_log_range:
                 missing_required_lr1m = [
                     span
                     for span in required_m1_lr_for_symbol
@@ -17860,6 +17875,18 @@ class Passivbot:
                             "m1_log_range",
                         )
                         lr1m = {**optional_lr1m, **required_lr1m}
+                elif is_forager_mode():
+                    optional_lr1m = await fetch_map(
+                        sym,
+                        [
+                            span
+                            for span in m1_lr_spans
+                            if span not in lr1m
+                        ],
+                        ema_lr_1m,
+                        "m1_log_range",
+                    )
+                    lr1m = {**optional_lr1m, **lr1m}
             except Exception as exc:
                 if not required_ema_can_mark_nontradable(sym):
                     raise
@@ -18247,6 +18274,9 @@ class Passivbot:
                 "cache_only_fetch_failed",
                 "candidate_required_ema_unavailable",
                 "never_fetched_cache_only",
+                "missing_volume",
+                "missing_log_range",
+                "missing_volume+missing_log_range",
             }
             or str(reason).startswith("missing_required_forager_")
         }
@@ -18264,6 +18294,7 @@ class Passivbot:
             str(reason): set(reason_symbols)
             for reason, reason_symbols in ema_unavailable_reasons.items()
         }
+        self._orchestrator_ema_bundle_symbols = set(symbols)
         self._orchestrator_ema_bundle_completed = True
         Passivbot._emit_ema_bundle_completed_event(
             self,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -9511,6 +9511,14 @@ class Passivbot:
         # filter coins by min effective cost
         # filter coins by relative volume
         # filter coins by log range
+        if self.is_forager_mode(pside):
+            unavailable_by_side = getattr(
+                self, "_forager_rank_feature_unavailable_by_side", None
+            )
+            if not isinstance(unavailable_by_side, dict):
+                unavailable_by_side = {}
+            unavailable_by_side[pside] = set()
+            self._forager_rank_feature_unavailable_by_side = unavailable_by_side
         if self.get_forced_PB_mode(pside):
             return []
         candidates = self.approved_coins_minus_ignored_coins[pside]
@@ -9599,6 +9607,9 @@ class Passivbot:
             ]
             if feature_unavailable:
                 feature_unavailable_count = len(feature_unavailable)
+                self._forager_rank_feature_unavailable_by_side[pside] = set(
+                    feature_unavailable
+                )
                 Passivbot._emit_forager_feature_unavailable_event(
                     self,
                     pside=pside,
@@ -17639,14 +17650,20 @@ class Passivbot:
             dict[float, float] | None,
             dict[float, float] | None,
         ]:
+            projection_metrics = {
+                "close": sorted(need_close_spans[sym]),
+            }
+            if not is_forager_mode():
+                projection_metrics.update(
+                    {
+                        "qv": m1_volume_spans,
+                        "log_range": requested_m1_lr_spans,
+                    }
+                )
             try:
                 projected = await self.cm.get_projected_open_tail_ema_metrics(
                     sym,
-                    {
-                        "close": sorted(need_close_spans[sym]),
-                        "qv": m1_volume_spans,
-                        "log_range": requested_m1_lr_spans,
-                    },
+                    projection_metrics,
                     latest_expected_ts=int(projection_ctx["latest_expected_ts"]),
                     last_cached_ts=int(projection_ctx["last_cached_ts"]),
                     max_tail_gap_ms=int(projection_ctx["max_tail_gap_ms"]),
@@ -17665,16 +17682,20 @@ class Passivbot:
                 )
                 raise
             close = dict(projected.get("close", {}))
-            vol = projected_optional_map(
-                sym, projected, "qv", m1_volume_spans, "m1_volume"
-            )
-            lr1m = projected_optional_map(
-                sym,
-                projected,
-                "log_range",
-                requested_m1_lr_spans,
-                "m1_log_range",
-            )
+            if is_forager_mode():
+                vol = None
+                lr1m = None
+            else:
+                vol = projected_optional_map(
+                    sym, projected, "qv", m1_volume_spans, "m1_volume"
+                )
+                lr1m = projected_optional_map(
+                    sym,
+                    projected,
+                    "log_range",
+                    requested_m1_lr_spans,
+                    "m1_log_range",
+                )
             missing_close = [
                 span
                 for span in sorted(need_close_spans[sym])
@@ -17685,13 +17706,7 @@ class Passivbot:
                     "[ema] projected open-tail close EMA incomplete for "
                     f"{sym}: spans={','.join(f'{span:.8g}' for span in missing_close)}"
                 )
-            if is_forager_mode():
-                # In forager mode, open-tail projection is valid for close EMA
-                # readiness only. Quote-volume and log-range ranking inputs must
-                # use current or cached real-candle EMA values.
-                vol = None
-                lr1m = None
-            else:
+            if not is_forager_mode():
                 missing_required_lr1m = [
                     span
                     for span in required_m1_lr_for_symbol
@@ -18186,6 +18201,30 @@ class Passivbot:
             if lr_span_long in m1_log_range_emas[s]
         }
         self._orchestrator_ema_unavailable_symbols = set(ema_unavailable_symbols)
+        candidate_reason_names = {
+            reason
+            for reason in ema_unavailable_reasons
+            if reason
+            in {
+                "cache_only_fetch_failed",
+                "candidate_required_ema_unavailable",
+                "never_fetched_cache_only",
+            }
+            or str(reason).startswith("missing_required_forager_")
+        }
+        self._orchestrator_candidate_ema_unavailable_symbols = {
+            symbol
+            for items in candidate_ema_unavailable_details.values()
+            for symbol, _error_type, _ema_types, _spans in items
+        } | {
+            symbol
+            for reason in candidate_reason_names
+            for symbol in ema_unavailable_reasons.get(reason, [])
+        }
+        self._orchestrator_ema_unavailable_reasons = {
+            str(reason): set(reason_symbols)
+            for reason, reason_symbols in ema_unavailable_reasons.items()
+        }
         Passivbot._emit_ema_bundle_completed_event(
             self,
             symbols=symbols,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -16584,6 +16584,8 @@ class Passivbot:
             "long": set(),
             "short": set(),
         }
+        self._orchestrator_candidate_ema_unavailable_symbols = set()
+        self._orchestrator_ema_unavailable_reasons = {}
         Passivbot._emit_ema_bundle_started_event(self, symbols=symbols, modes=modes)
         need_close_spans: dict[str, set[float]] = {s: set() for s in symbols}
         need_m1_lr_spans: dict[str, set[float]] = {s: set() for s in symbols}

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -16584,6 +16584,8 @@ class Passivbot:
             "long": set(),
             "short": set(),
         }
+        self._orchestrator_ema_bundle_completed = False
+        self._orchestrator_ema_unavailable_symbols = set()
         self._orchestrator_candidate_ema_unavailable_symbols = set()
         self._orchestrator_ema_unavailable_reasons = {}
         Passivbot._emit_ema_bundle_started_event(self, symbols=symbols, modes=modes)
@@ -18262,6 +18264,7 @@ class Passivbot:
             str(reason): set(reason_symbols)
             for reason, reason_symbols in ema_unavailable_reasons.items()
         }
+        self._orchestrator_ema_bundle_completed = True
         Passivbot._emit_ema_bundle_completed_event(
             self,
             symbols=symbols,

--- a/src/passivbot_monitor.py
+++ b/src/passivbot_monitor.py
@@ -603,6 +603,9 @@ def _build_monitor_market_section(self) -> dict[str, dict]:
     rank_feature_unavailable_by_side = getattr(
         self, "_forager_rank_feature_unavailable_by_side", {}
     ) or {}
+    ema_bundle_completed = bool(
+        getattr(self, "_orchestrator_ema_bundle_completed", False)
+    )
     trailing_unavailable_symbols = set(
         getattr(self, "_orchestrator_trailing_unavailable_symbols", set()) or set()
     )
@@ -688,6 +691,8 @@ def _build_monitor_market_section(self) -> dict[str, dict]:
                 in set(rank_feature_unavailable_by_side.get(pside, set()) or set())
             )
             rankability_reasons = []
+            if not ema_bundle_completed:
+                rankability_reasons.append("ema_bundle_unevaluated")
             if rank_feature_psides:
                 rankability_reasons.append("ranking_features_unavailable")
             if symbol in candidate_ema_unavailable_symbols:

--- a/src/passivbot_monitor.py
+++ b/src/passivbot_monitor.py
@@ -589,6 +589,20 @@ def _build_monitor_market_section(self) -> dict[str, dict]:
     ema_unavailable_symbols = set(
         getattr(self, "_orchestrator_ema_unavailable_symbols", set()) or set()
     )
+    candidate_ema_unavailable_symbols = set(
+        getattr(
+            self,
+            "_orchestrator_candidate_ema_unavailable_symbols",
+            set(),
+        )
+        or set()
+    )
+    ema_unavailable_reasons = getattr(
+        self, "_orchestrator_ema_unavailable_reasons", {}
+    ) or {}
+    rank_feature_unavailable_by_side = getattr(
+        self, "_forager_rank_feature_unavailable_by_side", {}
+    ) or {}
     trailing_unavailable_symbols = set(
         getattr(self, "_orchestrator_trailing_unavailable_symbols", set()) or set()
     )
@@ -610,7 +624,11 @@ def _build_monitor_market_section(self) -> dict[str, dict]:
         if not market_active:
             tradability_reasons.append("market_inactive")
         if symbol in ema_unavailable_symbols:
-            tradability_reasons.append("required_ema_unavailable")
+            tradability_reasons.append(
+                "forager_candidate_required_ema_unavailable"
+                if symbol in candidate_ema_unavailable_symbols
+                else "required_ema_unavailable"
+            )
         symbol_trailing_reasons = trailing_unavailable_reasons.get(symbol, [])
         if isinstance(symbol_trailing_reasons, str):
             symbol_trailing_reasons = [symbol_trailing_reasons]
@@ -644,6 +662,40 @@ def _build_monitor_market_section(self) -> dict[str, dict]:
             "has_open_orders": bool(getattr(self, "open_orders", {}).get(symbol)),
             "has_position": bool(self.has_position(symbol=symbol)),
         }
+        forager_candidate_psides = []
+        for pside in ("long", "short"):
+            try:
+                forager_side = bool(self.is_forager_mode(pside))
+            except Exception:
+                forager_side = False
+            if forager_side and symbol in set(
+                approved_minus_ignored.get(pside, set()) or set()
+            ):
+                forager_candidate_psides.append(pside)
+        if forager_candidate_psides:
+            rank_feature_psides = sorted(
+                pside
+                for pside in forager_candidate_psides
+                if symbol
+                in set(rank_feature_unavailable_by_side.get(pside, set()) or set())
+            )
+            rankability_reasons = []
+            if rank_feature_psides:
+                rankability_reasons.append("ranking_features_unavailable")
+            if symbol in candidate_ema_unavailable_symbols:
+                rankability_reasons.append("required_ema_unavailable")
+            matching_ema_reasons = sorted(
+                str(reason)
+                for reason, reason_symbols in ema_unavailable_reasons.items()
+                if symbol in set(reason_symbols or set())
+            )
+            entry["forager"] = {
+                "candidate_psides": sorted(forager_candidate_psides),
+                "rankable": not rankability_reasons,
+                "rankability_reasons": sorted(set(rankability_reasons)),
+                "ranking_feature_unavailable_psides": rank_feature_psides,
+                "ema_unavailable_reasons": matching_ema_reasons,
+            }
         if symbol in trailing_unavailable_symbols:
             entry["trailing_unavailable_psides"] = sorted(
                 str(pside)

--- a/src/passivbot_monitor.py
+++ b/src/passivbot_monitor.py
@@ -606,6 +606,9 @@ def _build_monitor_market_section(self) -> dict[str, dict]:
     ema_bundle_completed = bool(
         getattr(self, "_orchestrator_ema_bundle_completed", False)
     )
+    ema_bundle_symbols = set(
+        getattr(self, "_orchestrator_ema_bundle_symbols", set()) or set()
+    )
     trailing_unavailable_symbols = set(
         getattr(self, "_orchestrator_trailing_unavailable_symbols", set()) or set()
     )
@@ -691,7 +694,7 @@ def _build_monitor_market_section(self) -> dict[str, dict]:
                 in set(rank_feature_unavailable_by_side.get(pside, set()) or set())
             )
             rankability_reasons = []
-            if not ema_bundle_completed:
+            if not ema_bundle_completed or symbol not in ema_bundle_symbols:
                 rankability_reasons.append("ema_bundle_unevaluated")
             if rank_feature_psides:
                 rankability_reasons.append("ranking_features_unavailable")

--- a/src/passivbot_monitor.py
+++ b/src/passivbot_monitor.py
@@ -672,7 +672,13 @@ def _build_monitor_market_section(self) -> dict[str, dict]:
                 age_eligible_approved = bool(self.is_approved(pside, symbol))
             except Exception:
                 age_eligible_approved = False
-            if forager_side and age_eligible_approved:
+            try:
+                min_cost_eligible = bool(
+                    self.effective_min_cost_is_low_enough(pside, symbol)
+                )
+            except Exception:
+                min_cost_eligible = False
+            if forager_side and age_eligible_approved and min_cost_eligible:
                 forager_candidate_psides.append(pside)
         if forager_candidate_psides:
             rank_feature_psides = sorted(

--- a/src/passivbot_monitor.py
+++ b/src/passivbot_monitor.py
@@ -668,9 +668,11 @@ def _build_monitor_market_section(self) -> dict[str, dict]:
                 forager_side = bool(self.is_forager_mode(pside))
             except Exception:
                 forager_side = False
-            if forager_side and symbol in set(
-                approved_minus_ignored.get(pside, set()) or set()
-            ):
+            try:
+                age_eligible_approved = bool(self.is_approved(pside, symbol))
+            except Exception:
+                age_eligible_approved = False
+            if forager_side and age_eligible_approved:
                 forager_candidate_psides.append(pside)
         if forager_candidate_psides:
             rank_feature_psides = sorted(

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -62,6 +62,25 @@ def test_ema_series_skips_leading_nonfinite_without_poisoning_window(tmp_path):
     assert math.isnan(float(cm._ema_series(np.asarray([float("nan")]), span=3.0)[-1]))
 
 
+@pytest.mark.parametrize("span", [1.0, 2.5, 10.0, 100.0])
+def test_final_ema_matches_full_series_without_allocation(tmp_path, span):
+    cm = CandlestickManager(
+        exchange=None,
+        exchange_name="test",
+        cache_dir=str(tmp_path / "caches"),
+    )
+    values = np.asarray(
+        [float("nan"), 1.0, 2.0, float("nan"), -3.0, 8.0, 13.0],
+        dtype=np.float64,
+    )
+
+    assert cm._ema(values, span) == pytest.approx(
+        float(cm._ema_series(values, span)[-1]),
+        rel=0.0,
+        abs=1e-15,
+    )
+
+
 @pytest.mark.asyncio
 async def test_latest_ema_log_range_ignores_leading_nonfinite_sample(tmp_path):
     class _Ex:

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -4746,6 +4746,14 @@ async def test_projected_open_tail_ema_metrics_are_read_only(tmp_path, monkeypat
     )
     cm._cache[symbol] = seed.copy()
     cm._ema_cache[symbol] = {("sentinel", 1.0, str(ONE_MIN_MS)): (123.0, last_cached, last_cached)}
+    get_candles_calls = {"count": 0}
+    original_get_candles = cm.get_candles
+
+    async def counted_get_candles(*args, **kwargs):
+        get_candles_calls["count"] += 1
+        return await original_get_candles(*args, **kwargs)
+
+    monkeypatch.setattr(cm, "get_candles", counted_get_candles)
 
     projected = await cm.get_projected_open_tail_ema_metrics(
         symbol,
@@ -4754,6 +4762,14 @@ async def test_projected_open_tail_ema_metrics_are_read_only(tmp_path, monkeypat
         last_cached_ts=last_cached,
         max_tail_gap_ms=10 * ONE_MIN_MS,
     )
+    cached_projection = await cm.get_projected_open_tail_ema_metrics(
+        symbol,
+        {"close": [4.0], "qv": [4.0], "log_range": [4.0]},
+        latest_expected_ts=latest_expected,
+        last_cached_ts=last_cached,
+        max_tail_gap_ms=10 * ONE_MIN_MS,
+    )
+    cached_projection["close"][4.0] = -1.0
 
     projected_rows = np.array(
         [
@@ -4777,6 +4793,8 @@ async def test_projected_open_tail_ema_metrics_are_read_only(tmp_path, monkeypat
         ("sentinel", 1.0, str(ONE_MIN_MS)): (123.0, last_cached, last_cached)
     }
     assert math.isfinite(projected["qv"][4.0])
+    assert get_candles_calls["count"] == 1
+    assert projected["close"][4.0] == pytest.approx(100.0)
 
 
 @pytest.mark.asyncio
@@ -4813,6 +4831,7 @@ async def test_projected_open_tail_ema_recomputes_when_late_real_candles_arrive(
         dtype=CANDLE_DTYPE,
     )
     cm._persist_batch(symbol, real_late, timeframe="1m", merge_cache=True, last_refresh_ms=t61)
+    assert symbol not in cm._projected_open_tail_ema_cache
     monkeypatch.setattr("time.time", lambda: (t61 + ONE_MIN_MS) / 1000.0)
 
     ema = await cm.get_latest_ema_close(symbol, 4.0, allow_remote_fetch=False)

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -737,6 +737,39 @@ async def test_forager_selected_flat_normal_missing_close_ema_marks_unavailable(
     assert symbol not in volumes_long
     assert symbol not in log_ranges_long
     assert bot._orchestrator_ema_unavailable_symbols == {symbol}
+    assert bot._orchestrator_candidate_ema_unavailable_symbols == set()
+    assert bot._orchestrator_ema_unavailable_reasons == {
+        "flat_active_required_ema_unavailable": {symbol}
+    }
+    assert bot._forager_rank_feature_unavailable_by_side == {
+        "long": {symbol},
+        "short": {symbol},
+    }
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_ema_bundle_clears_stale_rank_feature_failures():
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    symbol = "BTC/USDT:USDT"
+    bot = _BundleReproBot(symbol, close_mode="value")
+    _enable_forager_required_ranking(bot)
+    bot._forager_rank_feature_unavailable_by_side = {
+        "long": {symbol},
+        "short": {symbol},
+    }
+
+    await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+        bot, [symbol], bot.PB_modes
+    )
+
+    assert bot._forager_rank_feature_unavailable_by_side == {
+        "long": set(),
+        "short": set(),
+    }
 
 
 def test_trailing_grid_v7_py_orchestrator_rejects_incomplete_strategy_params():

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -1290,12 +1290,19 @@ async def test_active_forager_open_tail_projects_strategy_required_log_range():
         project_open_tail=True,
         projected_close_ema={span0: 101.0, span1: 102.0, span2: 103.0},
         projected_qv_ema={10.0: 999999.0},
-        projected_log_range_ema={60.0: 0.0099},
+        projected_log_range_ema={10.0: 0.0099},
         qv_mode="nan",
         lr1m_mode="nan",
         cached_qv_ema={10.0: 250000.0},
         cached_log_range_ema={10.0: 0.0015},
     )
+
+    def colliding_strategy_params(_pside, _symbol=None):
+        params = _rust_strategy_params(volatility_ema_span_1m=10.0)
+        params["entry"]["threshold_volatility_1m_weight"] = 1.0
+        return params
+
+    bot._strategy_params_to_rust_dict = colliding_strategy_params
     _enable_forager_required_ranking(bot)
     mode_overrides = {"long": {symbol: "normal"}, "short": {symbol: "manual"}}
 
@@ -1313,11 +1320,13 @@ async def test_active_forager_open_tail_projects_strategy_required_log_range():
     assert bot.projection_metric_requests == [
         {
             "close": [span0, span2, span1],
-            "log_range": [60.0],
+            "log_range": [span0],
         }
     ]
-    assert m1_log_range_emas[symbol][60.0] == pytest.approx(0.0099)
-    assert m1_log_range_emas[symbol][span0] == pytest.approx(0.0015)
+    assert m1_log_range_emas[symbol][span0] == pytest.approx(0.0099)
+    assert bot._orchestrator_forager_m1_log_range_emas[symbol][
+        span0
+    ] == pytest.approx(0.0015)
     assert m1_volume_emas[symbol][span0] == pytest.approx(250000.0)
     assert volumes_long[symbol] == pytest.approx(250000.0)
     assert _log_ranges_long[symbol] == pytest.approx(0.0015)

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -1273,6 +1273,58 @@ async def test_active_forager_open_tail_uses_cached_ranking_not_projected_values
 
 
 @pytest.mark.asyncio
+async def test_active_forager_open_tail_projects_strategy_required_log_range():
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    symbol = "AAVE/USDT:USDT"
+    span0 = 10.0
+    span1 = 20.0
+    span2 = (span0 * span1) ** 0.5
+    bot = _BundleReproBot(
+        symbol,
+        close_mode="value",
+        entry_m1_weight=1.0,
+        project_open_tail=True,
+        projected_close_ema={span0: 101.0, span1: 102.0, span2: 103.0},
+        projected_qv_ema={10.0: 999999.0},
+        projected_log_range_ema={60.0: 0.0099},
+        qv_mode="nan",
+        lr1m_mode="nan",
+        cached_qv_ema={10.0: 250000.0},
+        cached_log_range_ema={10.0: 0.0015},
+    )
+    _enable_forager_required_ranking(bot)
+    mode_overrides = {"long": {symbol: "normal"}, "short": {symbol: "manual"}}
+
+    (
+        _m1_close_emas,
+        m1_volume_emas,
+        m1_log_range_emas,
+        _h1_log_range_emas,
+        volumes_long,
+        _log_ranges_long,
+    ) = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+        bot, [symbol], mode_overrides
+    )
+
+    assert bot.projection_metric_requests == [
+        {
+            "close": [span0, span2, span1],
+            "log_range": [60.0],
+        }
+    ]
+    assert m1_log_range_emas[symbol][60.0] == pytest.approx(0.0099)
+    assert m1_log_range_emas[symbol][span0] == pytest.approx(0.0015)
+    assert m1_volume_emas[symbol][span0] == pytest.approx(250000.0)
+    assert volumes_long[symbol] == pytest.approx(250000.0)
+    assert _log_ranges_long[symbol] == pytest.approx(0.0015)
+    assert bot._orchestrator_ema_projection_symbols == {symbol}
+
+
+@pytest.mark.asyncio
 async def test_candidate_only_missing_required_forager_features_marks_unavailable(caplog):
     try:
         import passivbot as pb_mod
@@ -1322,6 +1374,7 @@ async def test_candidate_only_missing_required_forager_features_marks_unavailabl
     assert symbol not in volumes_long
     assert symbol not in log_ranges_long
     assert bot._orchestrator_ema_unavailable_symbols == {symbol}
+    assert bot._orchestrator_candidate_ema_unavailable_symbols == {symbol}
     assert not any(
         "missing required forager EMA HYPE" in record.message
         and "action=mark_nontradable_until_fresh" in record.message
@@ -1342,6 +1395,63 @@ async def test_candidate_only_missing_required_forager_features_marks_unavailabl
         and group["symbols"]["sample"] == [symbol]
         for group in event_data["unavailable_reasons"]
     )
+
+
+@pytest.mark.asyncio
+async def test_cache_only_optional_metric_gaps_are_candidate_unavailable():
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    symbol = "HYPE/USDT:USDT"
+    now_ms = int(time.time() * 1000)
+    bot = _BundleReproBot(
+        symbol,
+        close_mode="value",
+        projected_close_ema={
+            10.0: 100.0,
+            (10.0 * 20.0) ** 0.5: 100.0,
+            20.0: 100.0,
+        },
+        qv_mode="nan",
+        lr1m_mode="nan",
+    )
+    bot.PB_modes = {"long": {symbol: "manual"}, "short": {symbol: "manual"}}
+    bot.active_symbols = []
+    bot.cm.get_last_refresh_ms = lambda _symbol: now_ms
+    bot.cm.get_last_final_ts = lambda _symbol, timeframe=None: now_ms - 60_000
+    bot._candle_staleness_ms = lambda _symbol, now_ms=None: 0
+    bot.is_forager_mode = lambda *args, **kwargs: True
+    original_bot_value = bot.bot_value
+
+    def bot_value(pside, key):
+        if key == "forager_score_weights":
+            return {"volume": 0.0, "volatility": 0.0}
+        if key == "forager_volume_drop_pct":
+            return 0.0
+        return original_bot_value(pside, key)
+
+    bot.bot_value = bot_value
+
+    (
+        m1_close_emas,
+        m1_volume_emas,
+        m1_log_range_emas,
+        _h1_log_range_emas,
+        _volumes_long,
+        _log_ranges_long,
+    ) = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+        bot, [symbol], bot.PB_modes
+    )
+
+    assert m1_close_emas[symbol] == {}
+    assert m1_volume_emas[symbol] == {}
+    assert m1_log_range_emas[symbol] == {}
+    assert bot._orchestrator_ema_unavailable_reasons == {
+        "missing_volume+missing_log_range": {symbol}
+    }
+    assert bot._orchestrator_candidate_ema_unavailable_symbols == {symbol}
 
 
 @pytest.mark.asyncio

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -1613,15 +1613,19 @@ async def test_open_tail_projection_missing_close_span_fails_loudly():
         projected_close_ema={span0: 201.0},
     )
     bot._orchestrator_candidate_ema_unavailable_symbols = {"STALE/USDT:USDT"}
+    bot._orchestrator_ema_unavailable_symbols = {"STALE/USDT:USDT"}
     bot._orchestrator_ema_unavailable_reasons = {
         "candidate_required_ema_unavailable": {"STALE/USDT:USDT"}
     }
+    bot._orchestrator_ema_bundle_completed = True
 
     with pytest.raises(RuntimeError, match="projected open-tail close EMA incomplete"):
         await pb_mod.Passivbot._load_orchestrator_ema_bundle(bot, [symbol], bot.PB_modes)
 
     assert bot._orchestrator_candidate_ema_unavailable_symbols == set()
+    assert bot._orchestrator_ema_unavailable_symbols == set()
     assert bot._orchestrator_ema_unavailable_reasons == {}
+    assert bot._orchestrator_ema_bundle_completed is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -1612,9 +1612,16 @@ async def test_open_tail_projection_missing_close_span_fails_loudly():
         project_open_tail=True,
         projected_close_ema={span0: 201.0},
     )
+    bot._orchestrator_candidate_ema_unavailable_symbols = {"STALE/USDT:USDT"}
+    bot._orchestrator_ema_unavailable_reasons = {
+        "candidate_required_ema_unavailable": {"STALE/USDT:USDT"}
+    }
 
     with pytest.raises(RuntimeError, match="projected open-tail close EMA incomplete"):
         await pb_mod.Passivbot._load_orchestrator_ema_bundle(bot, [symbol], bot.PB_modes)
+
+    assert bot._orchestrator_candidate_ema_unavailable_symbols == set()
+    assert bot._orchestrator_ema_unavailable_reasons == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -409,6 +409,7 @@ class _BundleReproBot:
             None if cached_log_range_ema is None else dict(cached_log_range_ema)
         )
         self.cached_metric_calls = []
+        self.projection_metric_requests = []
         self.qv_mode = qv_mode
         self.lr1m_mode = lr1m_mode
         self.project_open_tail_after_health_calls = project_open_tail_after_health_calls
@@ -512,6 +513,12 @@ class _BundleReproBot:
                 max_tail_gap_ms,
             ):
                 self.outer.projected_open_tail_called = True
+                self.outer.projection_metric_requests.append(
+                    {
+                        key: list(value)
+                        for key, value in spans_by_metric.items()
+                    }
+                )
                 if self.outer.projection_error is not None:
                     raise self.outer.projection_error
                 qv = (
@@ -1229,6 +1236,7 @@ async def test_active_forager_open_tail_uses_cached_ranking_not_projected_values
     assert bot._orchestrator_ema_unavailable_symbols == set()
     assert bot._orchestrator_ema_projection_symbols == {symbol}
     assert {call["timeframe"] for call in bot.cached_metric_calls} == {"1m"}
+    assert set(bot.projection_metric_requests[0]) == {"close"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -6764,6 +6764,13 @@ async def test_build_monitor_snapshot_includes_market_forager_unstuck_and_recent
                 return True
             return pside == "long"
 
+        def is_approved(self, pside, symbol):
+            return (
+                symbol
+                in set(self.approved_coins_minus_ignored_coins.get(pside, set()))
+                and symbol not in set(self.ignored_coins.get(pside, set()))
+            )
+
         def live_value(self, key):
             if key == "forced_mode_long":
                 return ""
@@ -6932,6 +6939,50 @@ async def test_build_monitor_snapshot_includes_market_forager_unstuck_and_recent
     )
     assert snapshot["recent"]["order_executions"][0]["execution_timestamp"] == 123456
     assert snapshot["recent"]["order_cancellations"][0]["pb_order_type"] == "close_unstuck_long"
+
+
+def test_monitor_forager_candidates_use_live_age_eligibility():
+    import passivbot as pb_mod
+
+    old_symbol = "OLD/USDT:USDT"
+    young_symbol = "YOUNG/USDT:USDT"
+
+    class FakeBot:
+        _build_monitor_market_section = pb_mod.Passivbot._build_monitor_market_section
+
+        def __init__(self):
+            self.active_symbols = []
+            self.positions = {}
+            self.open_orders = {}
+            self.trailing_prices = {}
+            self.effective_min_cost = {}
+            self.approved_coins = {
+                "long": {old_symbol, young_symbol},
+                "short": set(),
+            }
+            self.ignored_coins = {"long": set(), "short": set()}
+            self.approved_coins_minus_ignored_coins = {
+                "long": {old_symbol, young_symbol},
+                "short": set(),
+            }
+            self.markets_dict = {
+                old_symbol: {"active": True},
+                young_symbol: {"active": True},
+            }
+
+        def is_forager_mode(self, pside):
+            return pside == "long"
+
+        def is_approved(self, pside, symbol):
+            return pside == "long" and symbol == old_symbol
+
+        def has_position(self, pside=None, symbol=None):
+            return False
+
+    market = FakeBot()._build_monitor_market_section()
+
+    assert market[old_symbol]["forager"]["candidate_psides"] == ["long"]
+    assert "forager" not in market[young_symbol]
 
 
 def test_monitor_trailing_section_marks_ema_anchor_diagnostics_not_applicable():

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -6568,6 +6568,10 @@ async def test_build_monitor_snapshot_includes_market_forager_unstuck_and_recent
             self._orchestrator_ema_unavailable_symbols = set()
             self._orchestrator_candidate_ema_unavailable_symbols = set()
             self._orchestrator_ema_bundle_completed = True
+            self._orchestrator_ema_bundle_symbols = {
+                "BTC/USDT:USDT",
+                "ETH/USDT:USDT",
+            }
             self._orchestrator_ema_unavailable_reasons = {}
             self._forager_rank_feature_unavailable_by_side = {
                 "long": {"ETH/USDT:USDT"}
@@ -6974,6 +6978,7 @@ def test_monitor_forager_candidates_use_live_age_eligibility():
                 young_symbol: {"active": True},
             }
             self._orchestrator_ema_bundle_completed = True
+            self._orchestrator_ema_bundle_symbols = {old_symbol, young_symbol}
 
         def is_forager_mode(self, pside):
             return pside == "long"
@@ -7022,6 +7027,10 @@ def test_monitor_forager_candidates_use_live_min_cost_eligibility():
                 expensive_symbol: {"active": True},
             }
             self._orchestrator_ema_bundle_completed = True
+            self._orchestrator_ema_bundle_symbols = {
+                cheap_symbol,
+                expensive_symbol,
+            }
 
         def is_forager_mode(self, pside):
             return pside == "long"
@@ -7045,6 +7054,58 @@ def test_monitor_forager_candidates_use_live_min_cost_eligibility():
     startup_market = startup_bot._build_monitor_market_section()
     assert startup_market[cheap_symbol]["forager"]["rankable"] is False
     assert startup_market[cheap_symbol]["forager"]["rankability_reasons"] == [
+        "ema_bundle_unevaluated"
+    ]
+
+
+def test_monitor_new_forager_candidate_waits_for_next_ema_bundle():
+    import passivbot as pb_mod
+
+    evaluated_symbol = "EVALUATED/USDT:USDT"
+    new_symbol = "NEW/USDT:USDT"
+
+    class FakeBot:
+        _build_monitor_market_section = pb_mod.Passivbot._build_monitor_market_section
+
+        def __init__(self):
+            self.active_symbols = []
+            self.positions = {}
+            self.open_orders = {}
+            self.trailing_prices = {}
+            self.effective_min_cost = {}
+            self.approved_coins = {
+                "long": {evaluated_symbol, new_symbol},
+                "short": set(),
+            }
+            self.ignored_coins = {"long": set(), "short": set()}
+            self.approved_coins_minus_ignored_coins = {
+                "long": {evaluated_symbol, new_symbol},
+                "short": set(),
+            }
+            self.markets_dict = {
+                evaluated_symbol: {"active": True},
+                new_symbol: {"active": True},
+            }
+            self._orchestrator_ema_bundle_completed = True
+            self._orchestrator_ema_bundle_symbols = {evaluated_symbol}
+
+        def is_forager_mode(self, pside):
+            return pside == "long"
+
+        def is_approved(self, pside, symbol):
+            return pside == "long"
+
+        def effective_min_cost_is_low_enough(self, pside, symbol):
+            return pside == "long"
+
+        def has_position(self, pside=None, symbol=None):
+            return False
+
+    market = FakeBot()._build_monitor_market_section()
+
+    assert market[evaluated_symbol]["forager"]["rankable"] is True
+    assert market[new_symbol]["forager"]["rankable"] is False
+    assert market[new_symbol]["forager"]["rankability_reasons"] == [
         "ema_bundle_unevaluated"
     ]
 

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -6771,6 +6771,9 @@ async def test_build_monitor_snapshot_includes_market_forager_unstuck_and_recent
                 and symbol not in set(self.ignored_coins.get(pside, set()))
             )
 
+        def effective_min_cost_is_low_enough(self, pside, symbol):
+            return True
+
         def live_value(self, key):
             if key == "forced_mode_long":
                 return ""
@@ -6976,6 +6979,9 @@ def test_monitor_forager_candidates_use_live_age_eligibility():
         def is_approved(self, pside, symbol):
             return pside == "long" and symbol == old_symbol
 
+        def effective_min_cost_is_low_enough(self, pside, symbol):
+            return True
+
         def has_position(self, pside=None, symbol=None):
             return False
 
@@ -6983,6 +6989,53 @@ def test_monitor_forager_candidates_use_live_age_eligibility():
 
     assert market[old_symbol]["forager"]["candidate_psides"] == ["long"]
     assert "forager" not in market[young_symbol]
+
+
+def test_monitor_forager_candidates_use_live_min_cost_eligibility():
+    import passivbot as pb_mod
+
+    cheap_symbol = "CHEAP/USDT:USDT"
+    expensive_symbol = "EXPENSIVE/USDT:USDT"
+
+    class FakeBot:
+        _build_monitor_market_section = pb_mod.Passivbot._build_monitor_market_section
+
+        def __init__(self):
+            self.active_symbols = []
+            self.positions = {}
+            self.open_orders = {}
+            self.trailing_prices = {}
+            self.effective_min_cost = {}
+            self.approved_coins = {
+                "long": {cheap_symbol, expensive_symbol},
+                "short": set(),
+            }
+            self.ignored_coins = {"long": set(), "short": set()}
+            self.approved_coins_minus_ignored_coins = {
+                "long": {cheap_symbol, expensive_symbol},
+                "short": set(),
+            }
+            self.markets_dict = {
+                cheap_symbol: {"active": True},
+                expensive_symbol: {"active": True},
+            }
+
+        def is_forager_mode(self, pside):
+            return pside == "long"
+
+        def is_approved(self, pside, symbol):
+            return pside == "long"
+
+        def effective_min_cost_is_low_enough(self, pside, symbol):
+            return pside == "long" and symbol == cheap_symbol
+
+        def has_position(self, pside=None, symbol=None):
+            return False
+
+    market = FakeBot()._build_monitor_market_section()
+
+    assert market[cheap_symbol]["forager"]["candidate_psides"] == ["long"]
+    assert "forager" not in market[expensive_symbol]
 
 
 def test_monitor_trailing_section_marks_ema_anchor_diagnostics_not_applicable():

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -6566,6 +6566,11 @@ async def test_build_monitor_snapshot_includes_market_forager_unstuck_and_recent
                 "ETH/USDT:USDT": {"active": True},
             }
             self._orchestrator_ema_unavailable_symbols = set()
+            self._orchestrator_candidate_ema_unavailable_symbols = set()
+            self._orchestrator_ema_unavailable_reasons = {}
+            self._forager_rank_feature_unavailable_by_side = {
+                "long": {"ETH/USDT:USDT"}
+            }
             self._orchestrator_trailing_unavailable_symbols = {"BTC/USDT:USDT"}
             self._orchestrator_trailing_unavailable_reasons = {
                 "BTC/USDT:USDT": ["position_fill_confirmation_pending"]
@@ -6868,6 +6873,20 @@ async def test_build_monitor_snapshot_includes_market_forager_unstuck_and_recent
         "long"
     ]["minimum_fill_refresh_generation"] == 3
     assert snapshot["market"]["ETH/USDT:USDT"]["tradable"] is True
+    assert snapshot["market"]["BTC/USDT:USDT"]["forager"] == {
+        "candidate_psides": ["long"],
+        "rankable": True,
+        "rankability_reasons": [],
+        "ranking_feature_unavailable_psides": [],
+        "ema_unavailable_reasons": [],
+    }
+    assert snapshot["market"]["ETH/USDT:USDT"]["forager"] == {
+        "candidate_psides": ["long"],
+        "rankable": False,
+        "rankability_reasons": ["ranking_features_unavailable"],
+        "ranking_feature_unavailable_psides": ["long"],
+        "ema_unavailable_reasons": [],
+    }
     assert snapshot["market"]["BTC/USDT:USDT"]["c_mult"] == pytest.approx(1.0)
     assert snapshot["market"]["BTC/USDT:USDT"]["entry_volatility_logrange_ema"]["long"] == pytest.approx(
         0.0

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -6567,6 +6567,7 @@ async def test_build_monitor_snapshot_includes_market_forager_unstuck_and_recent
             }
             self._orchestrator_ema_unavailable_symbols = set()
             self._orchestrator_candidate_ema_unavailable_symbols = set()
+            self._orchestrator_ema_bundle_completed = True
             self._orchestrator_ema_unavailable_reasons = {}
             self._forager_rank_feature_unavailable_by_side = {
                 "long": {"ETH/USDT:USDT"}
@@ -6972,6 +6973,7 @@ def test_monitor_forager_candidates_use_live_age_eligibility():
                 old_symbol: {"active": True},
                 young_symbol: {"active": True},
             }
+            self._orchestrator_ema_bundle_completed = True
 
         def is_forager_mode(self, pside):
             return pside == "long"
@@ -7019,6 +7021,7 @@ def test_monitor_forager_candidates_use_live_min_cost_eligibility():
                 cheap_symbol: {"active": True},
                 expensive_symbol: {"active": True},
             }
+            self._orchestrator_ema_bundle_completed = True
 
         def is_forager_mode(self, pside):
             return pside == "long"
@@ -7036,6 +7039,14 @@ def test_monitor_forager_candidates_use_live_min_cost_eligibility():
 
     assert market[cheap_symbol]["forager"]["candidate_psides"] == ["long"]
     assert "forager" not in market[expensive_symbol]
+
+    startup_bot = FakeBot()
+    del startup_bot._orchestrator_ema_bundle_completed
+    startup_market = startup_bot._build_monitor_market_section()
+    assert startup_market[cheap_symbol]["forager"]["rankable"] is False
+    assert startup_market[cheap_symbol]["forager"]["rankability_reasons"] == [
+        "ema_bundle_unevaluated"
+    ]
 
 
 def test_monitor_trailing_section_marks_ema_anchor_diagnostics_not_applicable():


### PR DESCRIPTION
## Summary

- distinguish approved forager candidates that are temporarily unrankable from active-symbol required-EMA degradation in monitor state
- retain per-side ranking-feature unavailability and candidate EMA reasons for operator diagnostics
- request only close EMAs from open-tail projection in forager mode; quote-volume and log-range ranking inputs still come from current or bounded cached real candles
- memoize identical projected bundles within a finalized bucket using spans, horizon, cached-tail timestamp, and cross-process-visible index mtime; local 1m persistence invalidates the cache
- compute final EMA values with the exact scalar `adjust=True` recurrence without allocating an unused full output series

## Root cause

Flat forager candidates and active tradable symbols were grouped under the same monitor-level required-EMA label, obscuring whether forager selection itself was merely waiting for rank features. CPU inspection also showed multi-second EMA bundle preparation dominated live cycles while Rust planning took only milliseconds; projected ranking metrics were calculated and deliberately discarded, identical projections repeated within a minute, and latest-value EMA calls allocated full series.

## Validation

- `tests/test_candlestick_manager.py`
- `tests/test_missing_ema_fix.py`
- `tests/test_live_candle_budget.py`
- `tests/test_passivbot_monitor.py`
- `tests/test_coin_filtering.py`
- Python bytecode compilation for the changed runtime modules

All passed using the repository Python 3.12 environment with the worktree source on `PYTHONPATH`.