### PR TITLE
Harden connector health classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Supported CCXT private order streams now isolate malformed semantic rows from websocket
+  transport health: unnormalizable rows are discarded with a bounded warning and force an
+  authoritative account-state refresh, while valid rows in the same message are processed without
+  reconnecting. Bitget side-attribution failures now use this path without logging raw payloads.
+- Binance's explicit `MarginModeAlreadySet` response is now treated as a successful configuration
+  no-op at DEBUG instead of an ERROR; unknown margin-mode failures retain their existing loud
+  handling.
+
 - KuCoin private order updates now use the connector's actual exchange hedge mode for mandatory
   long/short attribution even when `live.hedge_mode=false` disables simultaneous strategy
   exposure, preventing valid updates without one-way `reduceOnly` metadata from reconnecting the

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -43,6 +43,14 @@ even beyond the normal foreign-writer lookback. Recovered rows always force an
 authoritative account refresh. Sparse foreign, explicitly one-way,
 identity-conflicting, or unmarked notifications remain rejected.
 
+A successful private-websocket read and a valid individual order row are separate health
+boundaries. When a supported CCXT connector receives a row whose mandatory side, position-side,
+quantity, or close-only semantics cannot be normalized, it discards that row, requests an
+authoritative account-state refresh, and emits a bounded warning. Other valid rows from the same
+websocket message remain usable. A semantic row rejection must not be reported as a transport
+disconnect or consume the websocket reconnect budget; actual watch/read failures retain the
+bounded reconnect backoff.
+
 ## Broker Agreement Attribution
 
 Problem:

--- a/src/exchanges/binance.py
+++ b/src/exchanges/binance.py
@@ -8,6 +8,7 @@ from passivbot_exceptions import FatalBotException
 import asyncio
 import random
 import re
+from ccxt.base.errors import MarginModeAlreadySet
 from utils import symbol_to_coin, ts_to_date, utc_ms
 from pure_funcs import flatten
 from procedures import load_broker_code
@@ -624,6 +625,11 @@ class BinanceBot(CCXTBot):
             try:
                 res_margin = await coros_to_call_margin_mode[symbol]
                 to_print += f"margin={format_exchange_config_response(res_margin)}"
+            except MarginModeAlreadySet:
+                logging.debug(
+                    "[config] %s margin mode unchanged | error_type=MarginModeAlreadySet",
+                    log_symbol,
+                )
             except Exception as e:
                 logging.error(
                     "[config] %s cross-margin update failed | %s",

--- a/src/exchanges/bitget.py
+++ b/src/exchanges/bitget.py
@@ -179,7 +179,7 @@ class BitgetBot(CCXTBot):
             side = str(order.get("side") or info.get("side") or "").lower()
             if side in ("buy", "sell"):
                 return side
-            raise Exception(f"failed to determine UTA side {order}")
+            raise ValueError("bitget UTA order missing explicit buy/sell side")
         if "info" in order:
             if all([x in order["info"] for x in ["tradeSide", "reduceOnly", "posSide"]]):
                 if order["info"]["tradeSide"] == "close":
@@ -195,7 +195,7 @@ class BitgetBot(CCXTBot):
         side = str(order.get("side") or (order.get("info") or {}).get("side") or "").lower()
         if side in {"buy", "sell"}:
             return side
-        raise Exception(f"failed to determine side {order}")
+        raise ValueError("bitget order missing authoritative side")
 
     def _normalize_open_orders(self, fetched: list) -> list:
         """Bitget override: derive side from tradeSide/posSide."""

--- a/src/exchanges/ccxt_bot.py
+++ b/src/exchanges/ccxt_bot.py
@@ -651,8 +651,44 @@ class CCXTBot(Passivbot):
                     break
                 raw_orders = await self._do_watch_orders()
                 consecutive_failures = 0
-                normalized = [self._normalize_order_update(o) for o in raw_orders]
-                self.handle_order_update(normalized)
+                normalized = []
+                untrusted = []
+                for order in raw_orders:
+                    try:
+                        normalized.append(self._normalize_order_update(order))
+                    except (KeyError, TypeError, ValueError) as exc:
+                        untrusted.append((order, exc))
+                if untrusted:
+                    symbols = {
+                        str(order.get("symbol") or "")
+                        for order, _exc in untrusted
+                        if isinstance(order, dict) and order.get("symbol")
+                    }
+                    now_monotonic = time.monotonic()
+                    last_warning = float(
+                        getattr(
+                            self,
+                            "_untrusted_order_ws_last_warning_monotonic",
+                            float("-inf"),
+                        )
+                    )
+                    if now_monotonic - last_warning >= 60.0:
+                        logging.warning(
+                            "[ws] %s order updates lacked authoritative order semantics; "
+                            "discarding %d rows and requesting account-state refresh | symbols=%s",
+                            self.exchange,
+                            len(untrusted),
+                            self._log_symbols(sorted(symbols), limit=8),
+                        )
+                        self._untrusted_order_ws_last_warning_monotonic = now_monotonic
+                    self._mark_account_critical_state_dirty(
+                        reason="order_ws_semantics_unavailable",
+                        symbols=symbols,
+                        source=f"{self.exchange}_order_ws",
+                        level=logging.DEBUG,
+                    )
+                if normalized:
+                    self.handle_order_update(normalized)
             except asyncio.CancelledError:
                 break
             except Exception as e:

--- a/tests/exchanges/test_ccxt_bot_hooks.py
+++ b/tests/exchanges/test_ccxt_bot_hooks.py
@@ -114,6 +114,60 @@ class TestWatchOrdersTemplateMethod:
         assert call_args[0]["qty"] == 1.0
 
     @pytest.mark.asyncio
+    async def test_discards_semantically_invalid_row_without_reconnecting(self):
+        """A bad payload row should trigger REST refresh, not a transport reconnect."""
+        from exchanges.bitget import BitgetBot
+
+        bot = BitgetBot.__new__(BitgetBot)
+        bot.ccp = MagicMock()
+        bot.ccp.has = {"watchOrders": True}
+        bot.exchange = "bitget"
+        bot.is_uta = True
+        bot.stop_websocket = False
+        bot._health_ws_reconnects = 0
+        bot._untrusted_order_ws_last_warning_monotonic = float("-inf")
+        bot._log_symbols = lambda symbols, limit=8: ",".join(symbols[:limit]) or "-"
+        dirty = []
+        bot._mark_account_critical_state_dirty = lambda **kwargs: dirty.append(kwargs)
+        bot._do_watch_orders = AsyncMock(
+            return_value=[
+                {
+                    "symbol": "BAD/USDT:USDT",
+                    "amount": 1.0,
+                    "info": {},
+                },
+                {
+                    "symbol": "BTC/USDT:USDT",
+                    "side": "buy",
+                    "amount": 2.0,
+                    "info": {"posSide": "long"},
+                },
+            ]
+        )
+
+        def stop_after_call(_orders):
+            bot.stop_websocket = True
+
+        bot.handle_order_update = MagicMock(side_effect=stop_after_call)
+
+        await bot.watch_orders()
+
+        bot._do_watch_orders.assert_awaited_once()
+        bot.handle_order_update.assert_called_once()
+        [normalized] = bot.handle_order_update.call_args.args[0]
+        assert normalized["symbol"] == "BTC/USDT:USDT"
+        assert normalized["position_side"] == "long"
+        assert bot._health_ws_reconnects == 0
+        assert dirty == [
+            {
+                "reason": "order_ws_semantics_unavailable",
+                "symbols": {"BAD/USDT:USDT"},
+                "source": "bitget_order_ws",
+                "level": 10,
+            }
+        ]
+
+    @pytest.mark.asyncio
     async def test_reconnect_backoff_increases_after_consecutive_failures(self, monkeypatch):
         """Repeated watch failures should back off instead of reconnecting every second."""
         from exchanges.ccxt_bot import CCXTBot

--- a/tests/test_exchange_config_updates.py
+++ b/tests/test_exchange_config_updates.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from ccxt.base.errors import BadRequest, RateLimitExceeded
+from ccxt.base.errors import BadRequest, MarginModeAlreadySet, RateLimitExceeded
 from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline, ReasonCodes
 
 
@@ -67,6 +67,34 @@ def make_kucoin_config_bot():
     bot.hedge_mode = True
     bot.max_leverage = {}
     return bot
+
+
+@pytest.mark.asyncio
+async def test_binance_already_set_margin_mode_is_successful_noop(caplog):
+    from exchanges.binance import BinanceBot
+
+    symbol = "BTC/USDT:USDT"
+    bot = BinanceBot.__new__(BinanceBot)
+    bot.cca = SimpleNamespace(
+        set_margin_mode=AsyncMock(
+            side_effect=MarginModeAlreadySet("No need to change margin type")
+        ),
+        set_leverage=AsyncMock(return_value={"leverage": 5}),
+    )
+    bot._get_margin_mode_for_symbol = lambda _symbol: "cross"
+    bot._calc_leverage_for_symbol = lambda _symbol: 5
+
+    with caplog.at_level(logging.DEBUG):
+        await bot.update_exchange_config_by_symbols([symbol])
+
+    bot.cca.set_margin_mode.assert_awaited_once_with("cross", symbol=symbol)
+    bot.cca.set_leverage.assert_awaited_once_with(5, symbol=symbol)
+    assert "margin mode unchanged" in caplog.text
+    assert not [
+        record
+        for record in caplog.records
+        if record.levelno >= logging.ERROR and "margin" in record.getMessage()
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- isolate per-row private-order websocket normalization failures from transport failures, discard only untrusted rows, and request authoritative account refresh without reconnecting
- make Bitget semantic failures bounded and payload-redacted
- classify Binance MarginModeAlreadySet as a successful DEBUG-level no-op while preserving loud handling for unknown failures

## Validation

- connector/reconciliation suite: 233 passed
- Python compile and `git diff --check`
- authenticated live Bitget validation received a malformed semantic row, emitted one bounded warning, refreshed account state, continued order execution, and recorded zero transport reconnects and zero degraded cycles
- authenticated live Binance validation completed exchange configuration and order execution with zero margin-mode errors and zero degraded cycles