### PR TITLE
Fix sparse candle recovery and Gate balance stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,16 @@ All notable user-facing changes will be documented in this file.
   fields instead of treating available margin as equity.
 - KuCoin 1m sparse-gap repair now includes the nearest real candle on both sides of an unresolved
   interval, allowing one successful exchange payload to prove and materialize genuine no-trade
-  minutes without converting empty or one-sided fetch failures into candles. Background forager
-  refreshes also back off unchanged empty tails without ERROR spam while unexpected failures remain
-  loud.
+  minutes without converting empty, one-sided, malformed, or partially recovered responses into
+  candles. Failed contextual verification preserves the persistent gap and restarts its bounded
+  retry cooldown instead of consuming REST capacity on every candle read. Background forager
+  refreshes also back off unchanged empty tails without ERROR spam while unexpected failures
+  remain loud.
 - Trailing extrema now use the configured bounded active-candle tail projection for a missing open
   1m tail after otherwise dense post-fill coverage. The temporary flat zero-volume rows are not
   persisted, delayed real candles replace them on the next cycle, and leading, internal, or
-  over-limit gaps still make trailing state unavailable.
+  over-limit gaps still make trailing state unavailable. Structured diagnostics identify the
+  trailing consumer, symbol, position side, projection bounds, and consecutive fallback uses.
 
 - Flat forager-selected symbols with resting entries now degrade to nontradable when required EMA
   inputs are temporarily unavailable, allowing normal reconciliation to cancel the stale entry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Gate multi-currency futures balance now remains stable while resting orders reserve and release
+  margin, preventing balance-driven ideal-order resizing and reconciliation churn. Passivbot
+  reconstructs account margin balance from Gate's available, position-margin, and order-margin
+  fields instead of treating available margin as equity.
+- KuCoin 1m sparse-gap repair now includes the nearest real candle on both sides of an unresolved
+  interval, allowing one successful exchange payload to prove and materialize genuine no-trade
+  minutes without converting empty or one-sided fetch failures into candles. Background forager
+  refreshes also back off unchanged empty tails without ERROR spam while unexpected failures remain
+  loud.
+- Trailing extrema now use the configured bounded active-candle tail projection for a missing open
+  1m tail after otherwise dense post-fill coverage. The temporary flat zero-volume rows are not
+  persisted, delayed real candles replace them on the next cycle, and leading, internal, or
+  over-limit gaps still make trailing state unavailable.
+
 - Flat forager-selected symbols with resting entries now degrade to nontradable when required EMA
   inputs are temporarily unavailable, allowing normal reconciliation to cancel the stale entry
   instead of repeatedly crashing and restarting the whole live bot. Held positions and explicitly

--- a/docs/ai/error_contract.md
+++ b/docs/ai/error_contract.md
@@ -58,7 +58,11 @@ the previous close is known, overlap repair is scheduled, and the gap is within 
 stale tails must not be persisted or treated as verified zero-volume or zero-range history. Within
 the configured active-tail bound, an explicitly supported provisional in-memory projection may use
 flat zero-volume rows for active strategy inputs while authoritative overlap repair continues.
-Forager ranking quote-volume and log-range inputs retain their narrower carry-forward contract.
+Trailing-extrema reconstruction may use the same projection only for a still-open tail after dense
+post-fill coverage; it must not bridge a missing reset boundary or internal minute, and the
+projected rows must be discarded after that read so delayed authoritative highs and lows replace
+them immediately. Forager ranking quote-volume and log-range inputs retain their narrower
+carry-forward contract.
 
 Protective panic and reduce-only actions may proceed when their own account-critical and
 symbol-scoped requirements are fresh, even if unrelated strategy surfaces are unavailable.

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -62,7 +62,9 @@
    coverage from the first whole minute following the latest fill through the last cached candle.
    A missing reset boundary, internal minute, or tail beyond the bound remains unavailable. The
    temporary rows never enter candle shards or manager caches, so a delayed real high or low
-   replaces the projection on the next cycle.
+   replaces the projection on the next cycle. Each trailing consumer records structured projection
+   context by symbol and position side, including the authoritative and projected bounds, projected
+   candle count, and consecutive-use count; authoritative recovery clears that runtime context.
 7. Binance monthly and daily archive requests are parallel within each tier, verify the published
    SHA-256 sidecar before parsing, and write only invalid v2 rows. Monthly archives are attempted
    only after Binance's first-Monday publication window plus a buffer; daily archives exclude the

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -58,6 +58,11 @@
    bounds alone must not make a short residual gap unavailable.
    The open-tail age bound applies uniformly, including stock perps; venue category must not create
    an unbounded synthetic tail exception.
+   Trailing-extrema reconstruction may append the same temporary flat rows only after proving dense
+   coverage from the first whole minute following the latest fill through the last cached candle.
+   A missing reset boundary, internal minute, or tail beyond the bound remains unavailable. The
+   temporary rows never enter candle shards or manager caches, so a delayed real high or low
+   replaces the projection on the next cycle.
 7. Binance monthly and daily archive requests are parallel within each tier, verify the published
    SHA-256 sidecar before parsing, and write only invalid v2 rows. Monthly archives are attempted
    only after Binance's first-Monday publication window plus a buffer; daily archives exclude the
@@ -81,9 +86,11 @@
    retry is due or the current request disallows remote fetching, and must not become synthetic
    zero-volume continuity candles. Day-coalesced historical fetches split around deferred ranges
    rather than contacting the venue for them. Forced 1m and native higher-timeframe candidate
-   refreshes treat a terminal empty page after partial pagination as a
-   failed surface refresh so the caller can apply its bounded retry delay; an overlap page that
-   already covers the requested end is complete, not terminal-empty. Partial authoritative
+   refreshes use best-effort stale reads so a successful partial sparse response can continue into
+   gap repair. A terminal empty page, or a successful refresh which leaves an empty or unchanged
+   open tail, applies a bounded per-surface retry delay; these expected background outcomes are
+   DEBUG diagnostics, while required active reads and unexpected refresh failures remain loud. An
+   overlap page that already covers the requested end is complete, not terminal-empty. Partial authoritative
    recovery stamps the unresolved remainder with a new retry time, and deferred exclusions remain
    compact timestamp intervals even for large historical gaps.
    Live EMA reads are the deliberate exception for gaps already bounded by later authoritative
@@ -184,10 +191,12 @@
     second attempt in the same request. Historical pagination
     flushes deferred partial-page index writes before propagating terminal-empty
     failure.
-    Repeated terminal empty-page failures for a forager candle surface
-    use a bounded in-memory retry delay without converting missing data into
-    candles or hiding the first error. A partial authoritative response similarly
-    defers and excludes its unresolved remainder until the next eligible retry.
+    Repeated terminal empty-page failures and successful refreshes which make no
+    open-tail progress for a forager candle surface use a bounded in-memory retry
+    delay without converting missing data into candles. Expected background
+    sparse-tail outcomes are DEBUG diagnostics; unexpected failures remain loud.
+    A partial authoritative response similarly defers and excludes its unresolved
+    remainder until the next eligible retry.
 13. Open-tail projection requests only the metrics its caller may consume.
     Forager projection requests close EMAs only; quote-volume and log-range
     ranking inputs continue to come from current or bounded cached real candles.
@@ -198,7 +207,7 @@
     a full output series. Full EMA series remain available to callers that need
     every intermediate value. Live provisional internal-gap tolerance is separate from the
     simulation-only backtest gap tolerance.
-13. KuCoin omits kline buckets with no ticks. For native timeframes above 1m, gaps bounded by real
+14. KuCoin omits kline buckets with no ticks. For native timeframes above 1m, gaps bounded by real
     candles in the same successful payload, absent from that raw payload, and no wider than the
     fixed 120-minute live connector policy are materialized as flat zero-volume candles before
     persistence. The simulation-only `backtest.gap_tolerance_ohlcvs_minutes` setting remains owned
@@ -212,8 +221,12 @@
     always overwrites a persisted synthetic bucket. If a later payload contains a rejected real row
     at a cached sparse-placeholder timestamp, the placeholder is evicted so the bucket becomes
     unavailable and the timeframe index bounds are recomputed from the remaining shards. Leading,
-    trailing, failed-fetch, oversized, and unproven between-page gaps remain unavailable. The
-    established 1m path retains its verified-gap tracking and standardization.
+    trailing, failed-fetch, oversized, and unproven between-page gaps remain unavailable. For 1m
+    gaps initially classified as `auto_detected` or `fetch_failed`, a targeted retry may expand to
+    the nearest cached real candle on each side. Only when one successful raw payload returns both
+    boundaries while omitting the intervening timestamps may that exact range be promoted to
+    verified `no_trades` continuity. Empty, one-sided, terminal, or rejected payloads do not prove
+    the gap.
 
 Cache paths use `to_standard_exchange_name()` rather than raw CCXT identifiers such as
 `binanceusdm` or `kucoinfutures`.

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -331,6 +331,18 @@ must not synthesize or permanently classify the initially absent row. Recent
 tail gaps use time-spaced retries, remain unavailable meanwhile, and are removed
 from `known_gaps` as soon as the authoritative row is persisted.
 
+### Candle retention and held trailing positions
+
+Hyperliquid's `candleSnapshot` endpoint exposes only the most recent 5,000
+candles. A trailing position whose latest fill predates that 1m window therefore
+cannot reconstruct its extrema from a fresh host. Preserve and transfer the
+existing 1m candle cache when migrating such a live position. Passivbot must
+keep trailing state unavailable if the exact range from the first whole minute
+after the fill is not locally present; wider-timeframe candles or an
+earliest-available reset are not parity-safe substitutes. Once that range is
+dense, only the bounded non-persistent open-tail projection described in the
+candlestick-manager contract may bridge delayed current candles.
+
 ## WEEX Futures
 
 ### V3 hedge-order contract

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -162,6 +162,10 @@ Handling:
    accepted page bounds, or across the remaining requested range when fewer than two accepted
    timestamps exist. Eviction recomputes the cached timeframe's derived index bounds. Do not
    synthesize leading, trailing, failed-fetch, oversized, or unproven between-page gaps.
+4. For an unresolved 1m gap already bounded by cached real rows, retry with both boundary rows in
+   the requested range. Promote the exact omission to verified no-trade continuity only if one
+   successful raw payload returns both boundaries and no row inside the gap. This contextual proof
+   may repair an older persistent `fetch_failed` gap; empty or one-sided retries remain unavailable.
 
 ## Bitget Futures
 
@@ -244,6 +248,17 @@ Normalize Gate's numeric REST account `user` value to a string before assigning 
 as CCXT Pro's private futures subscription UID. Reject missing, null, empty, or
 non-string/non-integer identifiers before conversion; never cache a placeholder
 such as `"None"` as durable subscription state.
+
+### Multi-currency balance semantics
+
+Gate's `cross_available` is spendable margin, not stable account equity. Resting
+orders move value between `cross_available` and `cross_order_margin`, while open
+positions use `cross_initial_margin`. For multi-currency margin accounts, derive
+the strategy balance from the same authoritative futures-account row as
+`cross_available + cross_order_margin + cross_initial_margin`. Require all three
+finite fields. Do not feed `cross_available` alone to Rust, because ordinary
+order reservation would then resize ideal orders and create reconciliation
+churn. Classic accounts continue using CCXT's quote-currency total.
 
 ### Per-symbol leverage initializes the position risk limit
 

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -165,7 +165,9 @@ Handling:
 4. For an unresolved 1m gap already bounded by cached real rows, retry with both boundary rows in
    the requested range. Promote the exact omission to verified no-trade continuity only if one
    successful raw payload returns both boundaries and no row inside the gap. This contextual proof
-   may repair an older persistent `fetch_failed` gap; empty or one-sided retries remain unavailable.
+   may repair an older persistent `fetch_failed` gap. Empty, one-sided, malformed, or partially
+   recovered responses remain unavailable, preserve persistent gap status, and restart the
+   persistent retry cooldown rather than issuing another contextual request on every candle read.
 
 ## Bitget Futures
 

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -255,10 +255,13 @@ Gate's `cross_available` is spendable margin, not stable account equity. Resting
 orders move value between `cross_available` and `cross_order_margin`, while open
 positions use `cross_initial_margin`. For multi-currency margin accounts, derive
 the strategy balance from the same authoritative futures-account row as
-`cross_available + cross_order_margin + cross_initial_margin`. Require all three
-finite fields. Do not feed `cross_available` alone to Rust, because ordinary
-order reservation would then resize ideal orders and create reconciliation
-churn. Classic accounts continue using CCXT's quote-currency total.
+`cross_available + cross_order_margin + cross_initial_margin -
+cross_unrealised_pnl`. Require all four finite fields. Removing unrealized PnL
+preserves wallet-balance semantics because Passivbot adds position PnL separately
+when deriving equity. Do not feed `cross_available` alone to Rust, because
+ordinary order reservation would then resize ideal orders and create
+reconciliation churn. Classic accounts continue using CCXT's quote-currency
+total.
 
 ### Per-symbol leverage initializes the position risk limit
 

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -3218,6 +3218,47 @@ class CandlestickManager:
             retry_count=_GAP_MAX_RETRIES,
         )
 
+    def _defer_persistent_gap_retry(
+        self,
+        symbol: str,
+        start_ts: int,
+        end_ts: int,
+        *,
+        now_ms: Optional[int] = None,
+    ) -> bool:
+        """Restart the cooldown for persistent unresolved gaps after a failed proof.
+
+        Contextual KuCoin verification is a re-check of an already-persistent
+        gap, not the first attempt in a new ordinary retry sequence. Preserve
+        the persistent retry count and reason so an empty or one-sided response
+        cannot make every subsequent candle read issue another REST request.
+        """
+        now = self._now_ms() if now_ms is None else int(now_ms)
+        changed = False
+        gaps = self._get_known_gaps_enhanced(symbol)
+        for gap in gaps:
+            if (
+                int(gap["start_ts"]) <= int(end_ts)
+                and int(gap["end_ts"]) >= int(start_ts)
+                and int(gap.get("retry_count", 0)) >= _GAP_MAX_RETRIES
+                and str(gap.get("reason", GAP_REASON_AUTO))
+                in {GAP_REASON_AUTO, GAP_REASON_FETCH_FAILED}
+            ):
+                gap["retry_count"] = _GAP_MAX_RETRIES
+                gap["last_retry_at"] = now
+                changed = True
+        if changed:
+            self._save_known_gaps_enhanced(symbol, gaps)
+            self._log(
+                "debug",
+                "persistent_gap_verification_deferred",
+                symbol=symbol,
+                start_ts=int(start_ts),
+                end_ts=int(end_ts),
+                retry_after_ms=now + _GAP_PERSISTENT_RETRY_MS,
+            )
+        return changed
+
     def _is_recent_hyperliquid_gap(
         self,
         gap: GapEntry,
@@ -4802,6 +4843,78 @@ class CandlestickManager:
             except (IndexError, TypeError, ValueError, OverflowError):
                 return True
         return False
+
+    async def _fetch_kucoin_contextual_gap_page(
+        self,
+        symbol: str,
+        *,
+        left_boundary_ts: int,
+        right_boundary_ts: int,
+        gap_start_ts: int,
+        gap_end_ts: int,
+    ) -> Tuple[np.ndarray, bool]:
+        """Fetch one raw KuCoin page and verify an omission between real bounds.
+
+        The proof deliberately bypasses generic pagination's immediate
+        intra-page gap recording. Only one successful raw response containing
+        both selected boundary candles and no accepted or rejected row inside
+        the unresolved interval may certify that interval as no-trade
+        continuity.
+        """
+        left_ts = int(left_boundary_ts)
+        right_ts = int(right_boundary_ts)
+        gap_start = int(gap_start_ts)
+        gap_end = int(gap_end_ts)
+        request_since = left_ts
+        if (
+            self._ccxt_since_exclusive
+            and self._ccxt_page_overlap_candles > 0
+            and left_ts > 0
+        ):
+            request_since = max(
+                0,
+                left_ts
+                - ONE_MIN_MS * int(self._ccxt_page_overlap_candles),
+            )
+        requested_buckets = max(
+            2,
+            (right_ts - request_since) // ONE_MIN_MS + 1,
+        )
+        page = await self._ccxt_fetch_ohlcv_once(
+            symbol,
+            request_since,
+            min(int(self._ccxt_limit_default), int(requested_buckets)),
+            end_exclusive_ms=right_ts + ONE_MIN_MS,
+            tf="1m",
+        )
+        normalized = self._normalize_ccxt_ohlcv(page)
+        if normalized.size:
+            normalized = normalized[
+                (normalized["ts"] >= left_ts)
+                & (normalized["ts"] <= right_ts)
+            ]
+        accepted_timestamps = (
+            {int(ts) for ts in normalized["ts"]}
+            if normalized.size
+            else set()
+        )
+        rejected_timestamps = self._rejected_ccxt_ohlcv_timestamps(
+            page, normalized
+        )
+        proof = bool(
+            left_ts in accepted_timestamps
+            and right_ts in accepted_timestamps
+            and not self._ccxt_ohlcv_has_unidentifiable_rejected_row(page)
+            and not any(
+                gap_start <= int(ts) <= gap_end
+                for ts in rejected_timestamps
+            )
+            and not any(
+                gap_start <= int(ts) <= gap_end
+                for ts in accepted_timestamps
+            )
+        )
+        return normalized, proof
 
     def _evict_rejected_native_sparse_synthetics(
         self,
@@ -7668,6 +7781,21 @@ class CandlestickManager:
                         for gap in self._get_known_gaps_enhanced(symbol)
                     )
 
+                def persistent_unverified_gap_covering(
+                    s: int, e: int
+                ) -> Optional[GapEntry]:
+                    for gap in self._get_known_gaps_enhanced(symbol):
+                        if (
+                            int(gap["start_ts"]) <= int(s)
+                            and int(gap["end_ts"]) >= int(e)
+                            and int(gap.get("retry_count", 0))
+                            >= _GAP_MAX_RETRIES
+                            and str(gap.get("reason", GAP_REASON_AUTO))
+                            in {GAP_REASON_AUTO, GAP_REASON_FETCH_FAILED}
+                        ):
+                            return gap
+                    return None
+
                 def kucoin_verification_bounds(
                     candles: np.ndarray, s: int, e: int
                 ) -> Optional[Tuple[int, int]]:
@@ -7684,7 +7812,10 @@ class CandlestickManager:
                         and "kucoin" in self._ex_id.lower()
                     ):
                         return None
-                    if not span_has_unverified_gap_present(s, e):
+                    persistent_gap = persistent_unverified_gap_covering(s, e)
+                    if persistent_gap is None or not self._should_retry_gap(
+                        persistent_gap, now_ms=now
+                    ):
                         return None
                     real = np.sort(_ensure_dtype(candles), order="ts")
                     provisional = self._synthetic_timestamps.get(symbol, set())
@@ -7765,50 +7896,84 @@ class CandlestickManager:
                         else:
                             fetch_start = int(contextual_bounds[0])
                             end_excl_gap = int(contextual_bounds[1]) + ONE_MIN_MS
+                        contextual_verified = False
                         persisted_batches = False
+                        if contextual_bounds is not None:
+                            fetched, contextual_verified = (
+                                await self._fetch_kucoin_contextual_gap_page(
+                                    symbol,
+                                    left_boundary_ts=int(contextual_bounds[0]),
+                                    right_boundary_ts=int(contextual_bounds[1]),
+                                    gap_start_ts=int(s),
+                                    gap_end_ts=int(e),
+                                )
+                            )
+                        else:
 
-                        def _persist_gap_batch(batch: np.ndarray) -> None:
-                            nonlocal persisted_batches
-                            batch = self._slice_ts_range(_ensure_dtype(batch), start_ts, end_ts)
-                            if not batch.size:
-                                return
-                            persisted_batches = True
-                            self._persist_batch(
-                                symbol,
-                                batch,
-                                timeframe="1m",
-                                merge_cache=True,
-                                last_refresh_ms=now,
-                            )
-
-                        try:
-                            fetched = await self._fetch_ohlcv_paginated(
-                                symbol,
-                                fetch_start,
-                                end_excl_gap,
-                                on_batch=_persist_gap_batch,
-                                raise_on_partial_empty_page=max_age_ms == 0,
-                            )
-                        except TypeError:
-                            fetched = await self._fetch_ohlcv_paginated(
-                                symbol,
-                                fetch_start,
-                                end_excl_gap,
-                            )
-                        attempts += 1
-                        attempted.append((int(s), int(e)))
-                        fetched = self._slice_ts_range(_ensure_dtype(fetched), start_ts, end_ts)
-                        if fetched.size:
-                            if not persisted_batches:
+                            def _persist_gap_batch(batch: np.ndarray) -> None:
+                                nonlocal persisted_batches
+                                batch = self._slice_ts_range(
+                                    _ensure_dtype(batch), start_ts, end_ts
+                                )
+                                if not batch.size:
+                                    return
+                                persisted_batches = True
                                 self._persist_batch(
                                     symbol,
-                                    fetched,
+                                    batch,
                                     timeframe="1m",
                                     merge_cache=True,
                                     last_refresh_ms=now,
                                 )
+
+                            try:
+                                fetched = await self._fetch_ohlcv_paginated(
+                                    symbol,
+                                    fetch_start,
+                                    end_excl_gap,
+                                    on_batch=_persist_gap_batch,
+                                    raise_on_partial_empty_page=max_age_ms == 0,
+                                )
+                            except TypeError:
+                                fetched = await self._fetch_ohlcv_paginated(
+                                    symbol,
+                                    fetch_start,
+                                    end_excl_gap,
+                                )
+                        attempts += 1
+                        if contextual_bounds is None:
+                            attempted.append((int(s), int(e)))
+                        fetched = self._slice_ts_range(
+                            _ensure_dtype(fetched), start_ts, end_ts
+                        )
+                        if fetched.size and not persisted_batches:
+                            self._persist_batch(
+                                symbol,
+                                fetched,
+                                timeframe="1m",
+                                merge_cache=True,
+                                last_refresh_ms=now,
+                            )
+                        if contextual_bounds is not None:
+                            if contextual_verified:
+                                self._record_verified_gap(
+                                    symbol, int(s), int(e)
+                                )
+                            else:
+                                self._defer_persistent_gap_retry(
+                                    symbol,
+                                    int(s),
+                                    int(e),
+                                    now_ms=now,
+                                )
+                        if fetched.size:
                             arr = np.sort(self._cache[symbol], order="ts")
-                            sub = self._slice_ts_range(arr, start_ts, end_ts, assume_sorted=True)
+                            sub = self._slice_ts_range(
+                                arr,
+                                start_ts,
+                                end_ts,
+                                assume_sorted=True,
+                            )
                 # After attempts, recompute missing and tag remaining as known gaps
                 still_missing = self._missing_spans(sub, start_ts, inclusive_end)
                 # Stamp every attempted remainder, including a partially recovered

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -7659,6 +7659,51 @@ class CandlestickManager:
                                 return True
                     return False
 
+                def span_has_unverified_gap_present(s: int, e: int) -> bool:
+                    return any(
+                        int(gap["start_ts"]) <= int(e)
+                        and int(gap["end_ts"]) >= int(s)
+                        and str(gap.get("reason", GAP_REASON_AUTO))
+                        in {GAP_REASON_AUTO, GAP_REASON_FETCH_FAILED}
+                        for gap in self._get_known_gaps_enhanced(symbol)
+                    )
+
+                def kucoin_verification_bounds(
+                    candles: np.ndarray, s: int, e: int
+                ) -> Optional[Tuple[int, int]]:
+                    """Return real rows bracketing a KuCoin sparse 1m gap.
+
+                    A retry restricted to the absent timestamps cannot prove a
+                    no-trade interval: KuCoin simply returns an empty payload.
+                    Querying the nearest real row on each side lets one
+                    successful raw payload prove the omission without treating
+                    an outage or terminal empty page as market data.
+                    """
+                    if not self._record_payload_gaps_as_known or not (
+                        isinstance(self._ex_id, str)
+                        and "kucoin" in self._ex_id.lower()
+                    ):
+                        return None
+                    if not span_has_unverified_gap_present(s, e):
+                        return None
+                    real = np.sort(_ensure_dtype(candles), order="ts")
+                    provisional = self._synthetic_timestamps.get(symbol, set())
+                    if provisional:
+                        real = real[
+                            ~np.isin(
+                                real["ts"].astype(np.int64),
+                                np.asarray(tuple(provisional), dtype=np.int64),
+                            )
+                        ]
+                    if real.size < 2:
+                        return None
+                    timestamps = real["ts"].astype(np.int64)
+                    before = timestamps[timestamps < int(s)]
+                    after = timestamps[timestamps > int(e)]
+                    if before.size == 0 or after.size == 0:
+                        return None
+                    return int(before[-1]), int(after[0])
+
                 # Attempt limited targeted fetches for unknown spans
                 attempts = 0
                 max_attempts = 10 if self._ccxt_since_exclusive else 3
@@ -7666,19 +7711,28 @@ class CandlestickManager:
                 for s, e in missing:
                     if attempts >= max_attempts:
                         break
-                    if span_in_persistent_gap_present(s, e):
+                    contextual_bounds = kucoin_verification_bounds(sub, s, e)
+                    if (
+                        span_in_persistent_gap_present(s, e)
+                        and contextual_bounds is None
+                    ):
                         continue
-                    adjusted_gap_start = (
-                        self._fetch_start_after_deferred_gap_prefix(
-                            symbol,
-                            s,
-                            e,
-                            now_ms=now,
+                    if contextual_bounds is None:
+                        adjusted_gap_start = (
+                            self._fetch_start_after_deferred_gap_prefix(
+                                symbol,
+                                s,
+                                e,
+                                now_ms=now,
+                            )
                         )
-                    )
-                    if adjusted_gap_start is None:
-                        continue
-                    end_excl_gap = e + ONE_MIN_MS
+                        if adjusted_gap_start is None:
+                            continue
+                        fetch_start = int(adjusted_gap_start)
+                        end_excl_gap = int(e) + ONE_MIN_MS
+                    else:
+                        fetch_start = int(contextual_bounds[0])
+                        end_excl_gap = int(contextual_bounds[1]) + ONE_MIN_MS
                     async with self._acquire_fetch_lock(symbol, "1m"):
                         try:
                             self._load_from_disk(symbol, start_ts, end_ts, timeframe="1m")
@@ -7690,20 +7744,27 @@ class CandlestickManager:
                         sub = self._slice_ts_range(arr, start_ts, end_ts) if arr.size else arr
                         missing_now = self._missing_spans(sub, start_ts, inclusive_end)
                         if not any(
-                            ms <= adjusted_gap_start <= me
+                            ms <= int(s) <= me
                             for ms, me in missing_now
                         ):
                             continue
-                        adjusted_gap_start = (
-                            self._fetch_start_after_deferred_gap_prefix(
-                                symbol,
-                                adjusted_gap_start,
-                                e,
-                                now_ms=now,
+                        contextual_bounds = kucoin_verification_bounds(arr, s, e)
+                        if contextual_bounds is None:
+                            adjusted_gap_start = (
+                                self._fetch_start_after_deferred_gap_prefix(
+                                    symbol,
+                                    s,
+                                    e,
+                                    now_ms=now,
+                                )
                             )
-                        )
-                        if adjusted_gap_start is None:
-                            continue
+                            if adjusted_gap_start is None:
+                                continue
+                            fetch_start = int(adjusted_gap_start)
+                            end_excl_gap = int(e) + ONE_MIN_MS
+                        else:
+                            fetch_start = int(contextual_bounds[0])
+                            end_excl_gap = int(contextual_bounds[1]) + ONE_MIN_MS
                         persisted_batches = False
 
                         def _persist_gap_batch(batch: np.ndarray) -> None:
@@ -7723,7 +7784,7 @@ class CandlestickManager:
                         try:
                             fetched = await self._fetch_ohlcv_paginated(
                                 symbol,
-                                adjusted_gap_start,
+                                fetch_start,
                                 end_excl_gap,
                                 on_batch=_persist_gap_batch,
                                 raise_on_partial_empty_page=max_age_ms == 0,
@@ -7731,11 +7792,11 @@ class CandlestickManager:
                         except TypeError:
                             fetched = await self._fetch_ohlcv_paginated(
                                 symbol,
-                                s,
+                                fetch_start,
                                 end_excl_gap,
                             )
                         attempts += 1
-                        attempted.append((adjusted_gap_start, e))
+                        attempted.append((int(s), int(e)))
                         fetched = self._slice_ts_range(_ensure_dtype(fetched), start_ts, end_ts)
                         if fetched.size:
                             if not persisted_batches:
@@ -7756,11 +7817,18 @@ class CandlestickManager:
                 for s, e in attempted:
                     # find overlapping portion with any still missing
                     for ms, me in still_missing:
-                        if not (e < ms or s > me):
+                        unresolved_start = max(s, ms)
+                        unresolved_end = min(e, me)
+                        if (
+                            unresolved_start <= unresolved_end
+                            and span_has_unverified_gap_present(
+                                unresolved_start, unresolved_end
+                            )
+                        ):
                             self._add_known_gap(
                                 symbol,
-                                max(s, ms),
-                                min(e, me),
+                                unresolved_start,
+                                unresolved_end,
                                 reason=GAP_REASON_FETCH_FAILED,
                             )
 

--- a/src/exchanges/gateio.py
+++ b/src/exchanges/gateio.py
@@ -150,7 +150,7 @@ class GateIOBot(CCXTBot):
             # ideal orders on every reconciliation cycle. Reconstruct the
             # stable cross-margin balance from the same authoritative account
             # payload by adding back position and resting-order initial margin.
-            balance = sum(
+            margin_balance = sum(
                 float(primary[key])
                 for key in (
                     "cross_available",
@@ -158,6 +158,10 @@ class GateIOBot(CCXTBot):
                     "cross_order_margin",
                 )
             )
+            # Margin balance includes unrealized cross-position PnL. Passivbot
+            # adds position PnL separately when deriving equity, so remove it
+            # here to retain wallet-balance semantics and avoid double-counting.
+            balance = margin_balance - float(primary["cross_unrealised_pnl"])
             if not math.isfinite(balance):
                 raise ValueError(
                     f"{self.exchange}: fetch_balance response has non-finite "

--- a/src/exchanges/gateio.py
+++ b/src/exchanges/gateio.py
@@ -144,7 +144,25 @@ class GateIOBot(CCXTBot):
         if margin_mode_name == "classic":
             balance = float(balance_fetched[self.quote]["total"])
         elif margin_mode_name == "multi_currency":
-            balance = float(primary["cross_available"])
+            # ``cross_available`` is spendable margin, not account equity. It
+            # falls when resting orders reserve margin and rises again when
+            # those orders are cancelled, which would make Passivbot resize its
+            # ideal orders on every reconciliation cycle. Reconstruct the
+            # stable cross-margin balance from the same authoritative account
+            # payload by adding back position and resting-order initial margin.
+            balance = sum(
+                float(primary[key])
+                for key in (
+                    "cross_available",
+                    "cross_initial_margin",
+                    "cross_order_margin",
+                )
+            )
+            if not math.isfinite(balance):
+                raise ValueError(
+                    f"{self.exchange}: fetch_balance response has non-finite "
+                    "multi-currency margin balance"
+                )
         else:
             raise Exception(f"unknown margin_mode_name {balance_fetched}")
         return balance

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -3172,6 +3172,8 @@ def _emit_candle_tail_projected_event_unchecked(
     symbol: str,
     context: dict[str, Any] | None,
     reason_code: str = ReasonCodes.OPEN_TAIL_PROJECTION,
+    pside: str | None = None,
+    status: str = "recovered",
 ) -> None:
     ctx = dict(context or {})
     data: dict[str, Any] = {"timeframe": str(ctx.get("timeframe") or "1m")}
@@ -3182,10 +3184,14 @@ def _emit_candle_tail_projected_event_unchecked(
         "tail_gap_candles",
         "missing_candles",
         "max_tail_gap_ms",
+        "consecutive_uses",
     ):
         value = _safe_int(ctx.get(key))
         if value is not None:
             data[key] = value
+    consumer = ctx.get("consumer")
+    if consumer is not None:
+        data["consumer"] = str(consumer)
     reason = ctx.get("reason")
     if reason is not None:
         data["projection_reason"] = str(reason)
@@ -3197,10 +3203,15 @@ def _emit_candle_tail_projected_event_unchecked(
         EventTypes.CANDLE_TAIL_PROJECTED,
         level="debug",
         component="candle.tail_projection",
-        tags=(EventTags.CANDLE, EventTags.TAIL, EventTags.EMA),
+        tags=(
+            (EventTags.CANDLE, EventTags.TAIL, EventTags.TRAILING)
+            if data.get("consumer") == "trailing_extrema"
+            else (EventTags.CANDLE, EventTags.TAIL, EventTags.EMA)
+        ),
         cycle_id=current_live_event_cycle_id(bot),
         symbol=str(symbol),
-        status="recovered",
+        pside=str(pside) if pside is not None else None,
+        status=str(status),
         reason_code=str(reason_code),
         data=data,
     )

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -8144,6 +8144,11 @@ class Passivbot:
                         if no_basis
                         else int(report.get("last_cached_age_ms") or 0)
                     ),
+                    "last_cached_ts": (
+                        None
+                        if last_cached_ts is None
+                        else int(last_cached_ts)
+                    ),
                     "missing_candles": missing_candles,
                     "tail_gap_candles": tail_gap_candles,
                     "tail_only": bool(report.get("open_tail_gap"))
@@ -8164,6 +8169,7 @@ class Passivbot:
                     "tail_only": False,
                     "leading_gap_only": False,
                     "no_basis": True,
+                    "last_cached_ts": None,
                 }
         age_ms = Passivbot._candle_staleness_ms(self, symbol, now_ms=now)
         return {
@@ -8174,6 +8180,7 @@ class Passivbot:
             "tail_only": age_ms > 0,
             "leading_gap_only": False,
             "no_basis": age_ms >= now,
+            "last_cached_ts": None,
         }
 
     def _rank_symbols_by_candle_staleness(
@@ -8863,7 +8870,9 @@ class Passivbot:
 
         CandlestickManager may synthesize only confirmed internal no-trade gaps as
         zero-volume candles. Those dense rows match backtest continuity and are
-        accepted here; missing leading minutes or an open tail are not.
+        accepted here. A still-open tail may be projected as non-persistent flat
+        zero-volume rows within the same bounded grace period used by active EMA
+        inputs; missing leading or internal minutes remain unavailable.
         """
         now_ms = self._completed_candle_health_now_ms()
         latest_finalized = (now_ms // ONE_MIN_MS) * ONE_MIN_MS - ONE_MIN_MS
@@ -8877,14 +8886,55 @@ class Passivbot:
             return None
         subset = np.sort(subset, order="ts")
         timestamps = subset["ts"].astype(np.int64)
-        expected_count = (latest_finalized - first_eligible) // ONE_MIN_MS + 1
+        newest_ts = int(timestamps[-1])
+        expected_observed_count = (newest_ts - first_eligible) // ONE_MIN_MS + 1
         if (
-            timestamps.size != expected_count
+            timestamps.size != expected_observed_count
             or int(timestamps[0]) != first_eligible
-            or int(timestamps[-1]) != latest_finalized
             or (timestamps.size > 1 and np.any(np.diff(timestamps) != ONE_MIN_MS))
         ):
             return None
+        if newest_ts < latest_finalized:
+            try:
+                max_tail_minutes = float(
+                    get_optional_live_value(
+                        self.config,
+                        "max_active_candle_tail_gap_minutes",
+                        10.0,
+                    )
+                )
+            except Exception:
+                max_tail_minutes = 10.0
+            if (
+                not math.isfinite(max_tail_minutes)
+                or max_tail_minutes <= 0.0
+                or latest_finalized - newest_ts
+                > int(max_tail_minutes * ONE_MIN_MS)
+            ):
+                return None
+            previous_close = float(subset[-1]["c"])
+            if not math.isfinite(previous_close) or previous_close <= 0.0:
+                return None
+            projected = np.array(
+                [
+                    (
+                        ts,
+                        previous_close,
+                        previous_close,
+                        previous_close,
+                        previous_close,
+                        0.0,
+                    )
+                    for ts in range(
+                        newest_ts + ONE_MIN_MS,
+                        latest_finalized + ONE_MIN_MS,
+                        ONE_MIN_MS,
+                    )
+                ],
+                dtype=CANDLE_DTYPE,
+            )
+            if projected.size:
+                subset = np.concatenate([subset, projected])
         return subset
 
     def get_last_position_changes(self, symbol=None):
@@ -20064,7 +20114,7 @@ class Passivbot:
         except Exception:
             pass
 
-        for idx, (_priority, sym, timeframe, required_candles, _health) in enumerate(
+        for idx, (_priority, sym, timeframe, required_candles, pre_health) in enumerate(
             to_refresh, start=1
         ):
             if Passivbot._shutdown_requested(self):
@@ -20095,7 +20145,11 @@ class Passivbot:
                     sym,
                     start_ts=start_ts,
                     end_ts=end_ts,
-                    max_age_ms=0,
+                    # Background candidate refresh is best-effort. A 1ms TTL
+                    # still forces an ordinary stale read while allowing a
+                    # successful partial sparse response to reach gap repair
+                    # instead of aborting at a terminal empty page.
+                    max_age_ms=1,
                     timeframe=timeframe,
                     strict=False,
                     max_lookback_candles=int(required_candles),
@@ -20110,7 +20164,42 @@ class Passivbot:
                     )
                 else:
                     refreshed = await candle_task
-                surface_failure_retry_after.pop((sym, timeframe), None)
+                post_health = Passivbot._candidate_candle_surface_health(
+                    self,
+                    sym,
+                    timeframe,
+                    required_candles,
+                    now_ms=utc_ms(),
+                )
+                pre_last = pre_health.get("last_cached_ts")
+                post_last = post_health.get("last_cached_ts")
+                no_progress = (
+                    post_last is None
+                    or (
+                        pre_last is not None
+                        and int(post_last) <= int(pre_last)
+                    )
+                )
+                empty_or_unchanged_tail = bool(
+                    not post_health.get("coverage_ok")
+                    and no_progress
+                    and (
+                        post_health.get("no_basis")
+                        or post_health.get("tail_only")
+                    )
+                )
+                if empty_or_unchanged_tail:
+                    surface_failure_retry_after[(sym, timeframe)] = int(
+                        utc_ms() + _FORAGER_TERMINAL_EMPTY_RETRY_MS
+                    )
+                    logging.debug(
+                        "[candle] forager refresh made no tail progress | "
+                        "symbol=%s timeframe=%s action=defer_surface_retry",
+                        Passivbot._log_symbol(sym),
+                        timeframe,
+                    )
+                else:
+                    surface_failure_retry_after.pop((sym, timeframe), None)
                 self._forager_surface_failure_retry_after_ms = (
                     surface_failure_retry_after
                 )
@@ -20122,13 +20211,6 @@ class Passivbot:
                             refreshed_rows = len(refreshed)
                         except (TypeError, ValueError):
                             refreshed_rows = 0
-                    post_health = Passivbot._candidate_candle_surface_health(
-                        self,
-                        sym,
-                        timeframe,
-                        required_candles,
-                        now_ms=utc_ms(),
-                    )
                     success_key = (sym, timeframe, int(required_candles))
                     if refreshed_rows > 0 and bool(
                         post_health.get("leading_gap_only")
@@ -20197,11 +20279,20 @@ class Passivbot:
                     self._forager_surface_failure_retry_after_ms = (
                         surface_failure_retry_after
                     )
-                logging.error(
-                    "error refreshing forager candles for %s | error_type=%s",
-                    Passivbot._log_symbol(sym),
-                    error_type,
-                )
+                    logging.debug(
+                        "[candle] forager refresh reached terminal empty page | "
+                        "symbol=%s timeframe=%s action=defer_surface_retry "
+                        "error_type=%s",
+                        Passivbot._log_symbol(sym),
+                        timeframe,
+                        error_type,
+                    )
+                else:
+                    logging.error(
+                        "error refreshing forager candles for %s | error_type=%s",
+                        Passivbot._log_symbol(sym),
+                        error_type,
+                    )
         try:
             elapsed_s = int(max(0, utc_ms() - refresh_started_ms) / 1000)
             if paused_by_cap:

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -1569,6 +1569,10 @@ class Passivbot:
         self._trailing_unavailable_warning_signature = ()
         self._trailing_unavailable_warning_last_ms = 0
         self._trailing_unavailable_warning_interval_ms = 5 * 60 * 1000
+        self._trailing_tail_projection_counts: dict[tuple[str, str], int] = {}
+        self._orchestrator_trailing_projection_contexts: dict[
+            str, dict[str, dict]
+        ] = {}
 
         # Realized-loss gate logging throttle
         self._loss_gate_last_log_ms = {}
@@ -8865,8 +8869,8 @@ class Passivbot:
 
     def _completed_trailing_candle_subset(
         self, arr: np.ndarray, changed_ts: int
-    ) -> np.ndarray | None:
-        """Return dense finalized 1m candles after a fill, or None if incomplete.
+    ) -> tuple[np.ndarray | None, dict | None]:
+        """Return dense finalized post-fill candles and optional tail projection context.
 
         CandlestickManager may synthesize only confirmed internal no-trade gaps as
         zero-volume candles. Those dense rows match backtest continuity and are
@@ -8878,12 +8882,12 @@ class Passivbot:
         latest_finalized = (now_ms // ONE_MIN_MS) * ONE_MIN_MS - ONE_MIN_MS
         first_eligible = (int(changed_ts) // ONE_MIN_MS + 1) * ONE_MIN_MS
         if latest_finalized < first_eligible:
-            return None
+            return None, None
         subset = arr[
             (arr["ts"] >= first_eligible) & (arr["ts"] <= latest_finalized)
         ]
         if subset.size == 0:
-            return None
+            return None, None
         subset = np.sort(subset, order="ts")
         timestamps = subset["ts"].astype(np.int64)
         newest_ts = int(timestamps[-1])
@@ -8893,7 +8897,8 @@ class Passivbot:
             or int(timestamps[0]) != first_eligible
             or (timestamps.size > 1 and np.any(np.diff(timestamps) != ONE_MIN_MS))
         ):
-            return None
+            return None, None
+        projection_context = None
         if newest_ts < latest_finalized:
             try:
                 max_tail_minutes = float(
@@ -8911,10 +8916,10 @@ class Passivbot:
                 or latest_finalized - newest_ts
                 > int(max_tail_minutes * ONE_MIN_MS)
             ):
-                return None
+                return None, None
             previous_close = float(subset[-1]["c"])
             if not math.isfinite(previous_close) or previous_close <= 0.0:
-                return None
+                return None, None
             projected = np.array(
                 [
                     (
@@ -8935,7 +8940,18 @@ class Passivbot:
             )
             if projected.size:
                 subset = np.concatenate([subset, projected])
-        return subset
+                projection_context = {
+                    "timeframe": "1m",
+                    "consumer": "trailing_extrema",
+                    "latest_expected_ts": int(latest_finalized),
+                    "last_cached_ts": int(newest_ts),
+                    "tail_gap_age_ms": int(latest_finalized - newest_ts),
+                    "tail_gap_candles": int(projected.size),
+                    "missing_candles": int(projected.size),
+                    "max_tail_gap_ms": int(max_tail_minutes * ONE_MIN_MS),
+                    "reason": "open_tail_gap_projection",
+                }
+        return subset, projection_context
 
     def get_last_position_changes(self, symbol=None):
         """Return the most recent fill timestamp per symbol/side for trailing logic."""
@@ -8974,6 +8990,11 @@ class Passivbot:
         self._orchestrator_trailing_unavailable_symbols = set()
         self._orchestrator_trailing_unavailable_reasons = {}
         self._orchestrator_trailing_unavailable_psides = {}
+        previous_projection_counts = dict(
+            getattr(self, "_trailing_tail_projection_counts", {}) or {}
+        )
+        current_projection_counts: dict[tuple[str, str], int] = {}
+        projection_contexts: dict[str, dict[str, dict]] = defaultdict(dict)
         position_change_anchors = self._get_last_position_change_anchors()
         last_position_changes = {
             symbol: {
@@ -9183,7 +9204,11 @@ class Passivbot:
             for pside, changed_ts in last_position_changes[symbol].items():
                 if pside not in required_trailing.get(symbol, set()):
                     continue
-                subset = self._completed_trailing_candle_subset(arr, int(changed_ts))
+                subset, projection_context = (
+                    self._completed_trailing_candle_subset(
+                        arr, int(changed_ts)
+                    )
+                )
                 if subset is None:
                     unavailable_reasons[
                         "incomplete_trailing_candle_coverage"
@@ -9195,6 +9220,34 @@ class Passivbot:
                         subset["h"], subset["l"], subset["c"]
                     )
                     self.trailing_prices[symbol][pside] = bundle
+                    if projection_context is not None:
+                        projection_key = (symbol, pside)
+                        consecutive_uses = (
+                            int(
+                                previous_projection_counts.get(
+                                    projection_key, 0
+                                )
+                            )
+                            + 1
+                        )
+                        current_projection_counts[projection_key] = (
+                            consecutive_uses
+                        )
+                        projection_context = {
+                            **projection_context,
+                            "consecutive_uses": consecutive_uses,
+                        }
+                        projection_contexts[symbol][pside] = dict(
+                            projection_context
+                        )
+                        Passivbot._emit_candle_tail_projected_event(
+                            self,
+                            symbol=symbol,
+                            pside=pside,
+                            context=projection_context,
+                            reason_code="trailing_open_tail_projection",
+                            status="degraded",
+                        )
                 except Exception as e:
                     unavailable_reasons["bundle_compute_failed"].add(symbol)
                     unavailable_psides[symbol].add(pside)
@@ -9293,6 +9346,14 @@ class Passivbot:
             symbol: sorted(psides)
             for symbol, psides in sorted(unavailable_psides.items())
             if psides
+        }
+        self._trailing_tail_projection_counts = current_projection_counts
+        self._orchestrator_trailing_projection_contexts = {
+            symbol: {
+                pside: dict(context)
+                for pside, context in sorted(pside_contexts.items())
+            }
+            for symbol, pside_contexts in sorted(projection_contexts.items())
         }
 
     def symbol_is_eligible(self, symbol):

--- a/tests/ccxt_upgrade/test_order_contracts.py
+++ b/tests/ccxt_upgrade/test_order_contracts.py
@@ -1240,12 +1240,13 @@ def test_gateio_get_balance_reconstructs_stable_multi_currency_margin_balance():
                     "cross_available": "724.95615",
                     "cross_initial_margin": "12.5",
                     "cross_order_margin": "3.25",
+                    "cross_unrealised_pnl": "1.5",
                 }
             ],
         }
     )
 
-    assert balance == pytest.approx(740.70615)
+    assert balance == pytest.approx(739.20615)
     assert bot.uid == "16770081"
     assert bot.cca.uid == "16770081"
     assert bot.ccp.uid == "16770081"
@@ -1260,7 +1261,7 @@ def test_gateio_multi_currency_balance_is_stable_across_order_margin_reservation
     bot.ccp = None
     bot.log_once = lambda msg: None
 
-    def payload(available, order_margin):
+    def payload(available, order_margin, unrealised_pnl=0.0):
         return {
             "USDT": {"total": 0.0},
             "info": [
@@ -1270,12 +1271,14 @@ def test_gateio_multi_currency_balance_is_stable_across_order_margin_reservation
                     "cross_available": str(available),
                     "cross_initial_margin": "10.0",
                     "cross_order_margin": str(order_margin),
+                    "cross_unrealised_pnl": str(unrealised_pnl),
                 }
             ],
         }
 
     assert bot._get_balance(payload(677.0, 3.0)) == pytest.approx(690.0)
     assert bot._get_balance(payload(670.0, 10.0)) == pytest.approx(690.0)
+    assert bot._get_balance(payload(672.5, 10.0, 2.5)) == pytest.approx(690.0)
 
 
 @pytest.mark.parametrize(
@@ -1284,6 +1287,7 @@ def test_gateio_multi_currency_balance_is_stable_across_order_margin_reservation
         ("cross_available", "nan"),
         ("cross_initial_margin", "inf"),
         ("cross_order_margin", "-inf"),
+        ("cross_unrealised_pnl", "nan"),
     ],
 )
 def test_gateio_multi_currency_balance_rejects_non_finite_components(field, value):
@@ -1300,6 +1304,7 @@ def test_gateio_multi_currency_balance_rejects_non_finite_components(field, valu
         "cross_available": "680.0",
         "cross_initial_margin": "10.0",
         "cross_order_margin": "0.0",
+        "cross_unrealised_pnl": "0.0",
     }
     primary[field] = value
 

--- a/tests/ccxt_upgrade/test_order_contracts.py
+++ b/tests/ccxt_upgrade/test_order_contracts.py
@@ -1221,7 +1221,7 @@ async def test_gateio_updates_isolated_leverage_explicitly():
     ]
 
 
-def test_gateio_get_balance_uses_cross_available_for_multi_currency_margin():
+def test_gateio_get_balance_reconstructs_stable_multi_currency_margin_balance():
     bot = GateIOBot.__new__(GateIOBot)
     bot.exchange = "gateio"
     bot.quote = "USDT"
@@ -1238,15 +1238,73 @@ def test_gateio_get_balance_uses_cross_available_for_multi_currency_margin():
                     "user": 16770081,
                     "margin_mode_name": "multi_currency",
                     "cross_available": "724.95615",
+                    "cross_initial_margin": "12.5",
+                    "cross_order_margin": "3.25",
                 }
             ],
         }
     )
 
-    assert balance == 724.95615
+    assert balance == pytest.approx(740.70615)
     assert bot.uid == "16770081"
     assert bot.cca.uid == "16770081"
     assert bot.ccp.uid == "16770081"
+
+
+def test_gateio_multi_currency_balance_is_stable_across_order_margin_reservation():
+    bot = GateIOBot.__new__(GateIOBot)
+    bot.exchange = "gateio"
+    bot.quote = "USDT"
+    bot.uid = "existing"
+    bot.cca = SimpleNamespace(uid="existing")
+    bot.ccp = None
+    bot.log_once = lambda msg: None
+
+    def payload(available, order_margin):
+        return {
+            "USDT": {"total": 0.0},
+            "info": [
+                {
+                    "user": 16770081,
+                    "margin_mode_name": "multi_currency",
+                    "cross_available": str(available),
+                    "cross_initial_margin": "10.0",
+                    "cross_order_margin": str(order_margin),
+                }
+            ],
+        }
+
+    assert bot._get_balance(payload(677.0, 3.0)) == pytest.approx(690.0)
+    assert bot._get_balance(payload(670.0, 10.0)) == pytest.approx(690.0)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("cross_available", "nan"),
+        ("cross_initial_margin", "inf"),
+        ("cross_order_margin", "-inf"),
+    ],
+)
+def test_gateio_multi_currency_balance_rejects_non_finite_components(field, value):
+    bot = GateIOBot.__new__(GateIOBot)
+    bot.exchange = "gateio"
+    bot.quote = "USDT"
+    bot.uid = "existing"
+    bot.cca = SimpleNamespace(uid="existing")
+    bot.ccp = None
+    bot.log_once = lambda msg: None
+    primary = {
+        "user": 16770081,
+        "margin_mode_name": "multi_currency",
+        "cross_available": "680.0",
+        "cross_initial_margin": "10.0",
+        "cross_order_margin": "0.0",
+    }
+    primary[field] = value
+
+    with pytest.raises(ValueError, match="non-finite multi-currency margin balance"):
+        bot._get_balance({"USDT": {"total": 0.0}, "info": [primary]})
 
 
 def test_gateio_get_balance_uses_total_for_classic_margin():

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -19,6 +19,7 @@ from candlestick_manager import (
     CANDLE_DTYPE,
     GAP_REASON_FETCH_FAILED,
     GAP_REASON_NO_ARCHIVE,
+    GAP_REASON_NO_TRADES,
     ONE_MIN_MS,
     OhlcvFetchError,
     OhlcvTerminalEmptyPage,
@@ -4224,6 +4225,71 @@ def test_kucoin_between_page_holes_recorded_as_expiring_auto_gaps(tmp_path):
     assert between["reason"] == "auto_detected"
     assert int(between["retry_count"]) < _GAP_MAX_RETRIES
     assert cm._should_retry_gap(between)
+
+
+@pytest.mark.asyncio
+async def test_kucoin_contextual_retry_proves_persistent_sparse_gap(tmp_path, monkeypatch):
+    """A retry must include real rows on both sides of a sparse KuCoin gap.
+
+    Querying only the absent timestamps returns an empty payload and leaves the
+    gap as fetch_failed forever. One successful payload containing both bounds
+    proves the omitted interval as no-trade continuity.
+    """
+
+    now = 25 * ONE_MIN_MS + 1_000
+    monkeypatch.setattr("time.time", lambda: now / 1000.0)
+    calls = []
+
+    class _Ex:
+        id = "kucoinfutures"
+
+        async def fetch_ohlcv(
+            self, symbol, timeframe=None, since=None, limit=None, params=None
+        ):
+            calls.append((symbol, timeframe, since, limit, params))
+            return [
+                [0, 100.0, 101.0, 99.0, 100.0, 5.0],
+                [23 * ONE_MIN_MS, 110.0, 111.0, 109.0, 110.0, 7.0],
+            ]
+
+    cm = CandlestickManager(
+        exchange=_Ex(),
+        exchange_name="kucoin",
+        cache_dir=str(tmp_path / "caches"),
+    )
+    symbol = "SPARSE/USDT:USDT"
+    cm._cache[symbol] = np.array(
+        [
+            (0, 100.0, 101.0, 99.0, 100.0, 5.0),
+            (23 * ONE_MIN_MS, 110.0, 111.0, 109.0, 110.0, 7.0),
+            (24 * ONE_MIN_MS, 110.0, 112.0, 109.0, 111.0, 8.0),
+        ],
+        dtype=CANDLE_DTYPE,
+    )
+    cm._add_known_gap(
+        symbol,
+        ONE_MIN_MS,
+        22 * ONE_MIN_MS,
+        reason=GAP_REASON_FETCH_FAILED,
+        retry_count=_GAP_MAX_RETRIES,
+    )
+
+    result = await cm.get_candles(
+        symbol,
+        start_ts=0,
+        end_ts=24 * ONE_MIN_MS,
+        max_age_ms=None,
+    )
+
+    assert calls
+    assert calls[0][2] == 0
+    assert list(result["ts"]) == list(range(0, 25 * ONE_MIN_MS, ONE_MIN_MS))
+    gaps = cm._get_known_gaps_enhanced(symbol)
+    assert len(gaps) == 1
+    assert gaps[0]["reason"] == GAP_REASON_NO_TRADES
+    assert gaps[0]["start_ts"] == ONE_MIN_MS
+    assert gaps[0]["end_ts"] == 22 * ONE_MIN_MS
+    assert not cm._should_retry_gap(gaps[0])
 
 
 def test_kucoin_h1_payload_synthesizes_only_internally_bounded_no_trade_buckets(

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -24,6 +24,7 @@ from candlestick_manager import (
     OhlcvFetchError,
     OhlcvTerminalEmptyPage,
     _GAP_MAX_RETRIES,
+    _GAP_PERSISTENT_RETRY_MS,
     _GATEIO_RECENT_1M_LIMIT_CANDLES,
     _floor_minute,
     sanitize_remote_fetch_diagnostic,
@@ -4273,6 +4274,9 @@ async def test_kucoin_contextual_retry_proves_persistent_sparse_gap(tmp_path, mo
         reason=GAP_REASON_FETCH_FAILED,
         retry_count=_GAP_MAX_RETRIES,
     )
+    due_gaps = cm._get_known_gaps_enhanced(symbol)
+    due_gaps[0]["last_retry_at"] = now - _GAP_PERSISTENT_RETRY_MS - 1
+    cm._save_known_gaps_enhanced(symbol, due_gaps)
 
     result = await cm.get_candles(
         symbol,
@@ -4290,6 +4294,170 @@ async def test_kucoin_contextual_retry_proves_persistent_sparse_gap(tmp_path, mo
     assert gaps[0]["start_ts"] == ONE_MIN_MS
     assert gaps[0]["end_ts"] == 22 * ONE_MIN_MS
     assert not cm._should_retry_gap(gaps[0])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "returned_minutes",
+    [
+        (),
+        (0,),
+        (23,),
+        (0, 10),
+        (0, 10, 23),
+    ],
+    ids=(
+        "empty",
+        "left-only",
+        "right-only",
+        "left-plus-interior",
+        "both-bounds-plus-interior",
+    ),
+)
+async def test_kucoin_contextual_retry_requires_complete_single_payload_proof_and_cools_down(
+    tmp_path, monkeypatch, returned_minutes
+):
+    """Incomplete contextual proof must remain unavailable and respect cooldown."""
+
+    clock = {"now": 25 * ONE_MIN_MS + 1_000}
+    monkeypatch.setattr("time.time", lambda: clock["now"] / 1000.0)
+    calls = []
+
+    class _Ex:
+        id = "kucoinfutures"
+
+        async def fetch_ohlcv(
+            self, symbol, timeframe=None, since=None, limit=None, params=None
+        ):
+            calls.append((symbol, timeframe, since, limit, params))
+            return [
+                [
+                    minute * ONE_MIN_MS,
+                    100.0 + minute,
+                    101.0 + minute,
+                    99.0 + minute,
+                    100.0 + minute,
+                    5.0,
+                ]
+                for minute in returned_minutes
+            ]
+
+    cm = CandlestickManager(
+        exchange=_Ex(),
+        exchange_name="kucoin",
+        cache_dir=str(tmp_path / "caches"),
+    )
+    symbol = "SPARSE/USDT:USDT"
+    cm._cache[symbol] = np.array(
+        [
+            (0, 100.0, 101.0, 99.0, 100.0, 5.0),
+            (23 * ONE_MIN_MS, 110.0, 111.0, 109.0, 110.0, 7.0),
+            (24 * ONE_MIN_MS, 110.0, 112.0, 109.0, 111.0, 8.0),
+        ],
+        dtype=CANDLE_DTYPE,
+    )
+    cm._add_known_gap(
+        symbol,
+        ONE_MIN_MS,
+        22 * ONE_MIN_MS,
+        reason=GAP_REASON_FETCH_FAILED,
+        retry_count=_GAP_MAX_RETRIES,
+    )
+    gaps = cm._get_known_gaps_enhanced(symbol)
+    gaps[0]["last_retry_at"] = (
+        clock["now"] - _GAP_PERSISTENT_RETRY_MS - 1
+    )
+    cm._save_known_gaps_enhanced(symbol, gaps)
+
+    first = await cm.get_candles(
+        symbol,
+        start_ts=0,
+        end_ts=24 * ONE_MIN_MS,
+        max_age_ms=None,
+    )
+
+    assert len(calls) == 1
+    expected_real_timestamps = {
+        0,
+        23 * ONE_MIN_MS,
+        24 * ONE_MIN_MS,
+    } | {
+        int(minute) * ONE_MIN_MS
+        for minute in returned_minutes
+        if 1 <= int(minute) <= 22
+    }
+    assert set(int(ts) for ts in first["ts"]) == expected_real_timestamps
+    unresolved = cm._get_known_gaps_enhanced(symbol)
+    assert unresolved
+    assert all(gap["reason"] == GAP_REASON_FETCH_FAILED for gap in unresolved)
+    assert all(
+        int(gap["retry_count"]) >= _GAP_MAX_RETRIES
+        for gap in unresolved
+    )
+    assert all(
+        int(gap["last_retry_at"]) == clock["now"]
+        for gap in unresolved
+    )
+
+    await cm.get_candles(
+        symbol,
+        start_ts=0,
+        end_ts=24 * ONE_MIN_MS,
+        max_age_ms=None,
+    )
+    assert len(calls) == 1
+
+    due_again = cm._get_known_gaps_enhanced(symbol)
+    for gap in due_again:
+        gap["last_retry_at"] = (
+            clock["now"] - _GAP_PERSISTENT_RETRY_MS - 1
+        )
+    cm._save_known_gaps_enhanced(symbol, due_again)
+    await cm.get_candles(
+        symbol,
+        start_ts=0,
+        end_ts=24 * ONE_MIN_MS,
+        max_age_ms=None,
+    )
+    assert len(calls) == 1 + len(unresolved)
+
+
+@pytest.mark.asyncio
+async def test_kucoin_contextual_page_overlaps_exclusive_since_to_include_left_bound(
+    tmp_path,
+):
+    calls = []
+    left = 10 * ONE_MIN_MS
+    right = 13 * ONE_MIN_MS
+
+    class _Ex:
+        id = "kucoinfutures"
+
+        async def fetch_ohlcv(
+            self, symbol, timeframe=None, since=None, limit=None, params=None
+        ):
+            calls.append((symbol, timeframe, since, limit, params))
+            return [
+                [left, 100.0, 101.0, 99.0, 100.0, 5.0],
+                [right, 110.0, 111.0, 109.0, 110.0, 7.0],
+            ]
+
+    cm = CandlestickManager(
+        exchange=_Ex(),
+        exchange_name="kucoin",
+        cache_dir=str(tmp_path / "caches"),
+    )
+    rows, proof = await cm._fetch_kucoin_contextual_gap_page(
+        "SPARSE/USDT:USDT",
+        left_boundary_ts=left,
+        right_boundary_ts=right,
+        gap_start_ts=11 * ONE_MIN_MS,
+        gap_end_ts=12 * ONE_MIN_MS,
+    )
+
+    assert calls[0][2] == left - ONE_MIN_MS
+    assert list(rows["ts"]) == [left, right]
+    assert proof is True
 
 
 def test_kucoin_h1_payload_synthesizes_only_internally_bounded_no_trade_buckets(

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -685,8 +685,9 @@ async def test_forager_refresh_bounds_per_symbol_timeout_and_failure(monkeypatch
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("raise_terminal_empty", [False, True])
 async def test_forager_terminal_empty_page_uses_bounded_surface_backoff(
-    monkeypatch, caplog
+    monkeypatch, caplog, raise_terminal_empty
 ):
     import numpy as np
     import passivbot as pb_mod
@@ -727,16 +728,20 @@ async def test_forager_terminal_empty_page_uses_bounded_surface_backoff(
 
         def __init__(self):
             self.calls = 0
+            self.kwargs = []
 
         async def get_candles(self, symbol, **kwargs):
             self.calls += 1
-            raise pb_mod.OhlcvTerminalEmptyPage(
-                "bounded test failure",
-                partial_rows=np.empty((0,), dtype=pb_mod.CANDLE_DTYPE),
-                terminal_start_ts=0,
-                requested_end_ts=60_000,
-                pages=1,
-            )
+            self.kwargs.append(dict(kwargs))
+            if raise_terminal_empty:
+                raise pb_mod.OhlcvTerminalEmptyPage(
+                    "bounded test failure",
+                    partial_rows=np.empty((0,), dtype=pb_mod.CANDLE_DTYPE),
+                    terminal_start_ts=0,
+                    requested_end_ts=60_000,
+                    pages=1,
+                )
+            return np.empty((0,), dtype=pb_mod.CANDLE_DTYPE)
 
     class FakeBot:
         config = {
@@ -775,16 +780,22 @@ async def test_forager_terminal_empty_page_uses_bounded_surface_backoff(
         _shutdown_requested = pb_mod.Passivbot._shutdown_requested
 
     bot = FakeBot()
-    with caplog.at_level(logging.ERROR):
+    with caplog.at_level(logging.DEBUG):
         await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
         await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
 
     assert bot.cm.calls == 1
+    assert bot.cm.kwargs[0]["max_age_ms"] == 1
     assert (
         bot._forager_surface_failure_retry_after_ms[(symbol, "1m")]
         == now["ms"] + pb_mod._FORAGER_TERMINAL_EMPTY_RETRY_MS
     )
-    assert caplog.text.count("error_type=OhlcvTerminalEmptyPage") == 1
+    if raise_terminal_empty:
+        assert caplog.text.count("error_type=OhlcvTerminalEmptyPage") == 1
+        assert "reached terminal empty page" in caplog.text
+    else:
+        assert "forager refresh made no tail progress" in caplog.text
+    assert not any(record.levelno >= logging.ERROR for record in caplog.records)
 
 
 @pytest.mark.asyncio
@@ -3015,7 +3026,7 @@ async def test_forager_candidate_refresh_warms_required_native_h1_surface(monkey
     assert called_symbol == symbol
     assert kwargs["timeframe"] == "1h"
     assert kwargs["max_lookback_candles"] == 784
-    assert kwargs["max_age_ms"] == 0
+    assert kwargs["max_age_ms"] == 1
     assert kwargs["end_ts"] % (60 * 60_000) == 0
 
 

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -2859,7 +2859,6 @@ async def test_restart_accepts_matching_fill_before_bybit_position_update_time_a
     "rows",
     [
         [(240_000, 100.0, 102.0, 98.0, 101.0, 1.0)],
-        [(180_000, 100.0, 101.0, 99.0, 100.0, 1.0)],
     ],
 )
 async def test_trailing_extrema_reject_incomplete_post_fill_coverage(rows):
@@ -2876,6 +2875,72 @@ async def test_trailing_extrema_reject_incomplete_post_fill_coverage(rows):
         return _make_candles(rows)
 
     bot.cm.get_candles = partial_candles
+    await bot.update_trailing_data()
+
+    assert bot.trailing_prices[symbol]["long"] == _trailing_default()
+    assert bot._orchestrator_trailing_unavailable_reasons == {
+        symbol: ["incomplete_trailing_candle_coverage"]
+    }
+
+
+@pytest.mark.asyncio
+async def test_trailing_extrema_projects_bounded_open_tail_without_persisting():
+    cfg = _dummy_config()
+    cfg["live"]["max_active_candle_tail_gap_minutes"] = 10
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    bot._pnls_manager = _DummyPnlsManager(
+        [_DummyFillEvent(symbol, "long", 120_000, "fill-1")]
+    )
+    bot.is_trailing = lambda sym, pside=None: pside == "long"
+    bot.get_exchange_time = lambda: 301_000
+    returned = _make_candles(
+        [(180_000, 100.0, 101.0, 99.0, 100.0, 1.0)]
+    )
+
+    async def candles_with_open_tail(*args, **kwargs):
+        return returned
+
+    bot.cm.get_candles = candles_with_open_tail
+    await bot.update_trailing_data()
+
+    assert bot._orchestrator_trailing_unavailable_symbols == set()
+    assert bot.trailing_prices[symbol]["long"]["max_since_open"] == pytest.approx(
+        101.0
+    )
+    assert list(returned["ts"]) == [180_000]
+
+    # A delayed real candle replaces the prior projection on the next read.
+    returned = _make_candles(
+        [
+            (180_000, 100.0, 101.0, 99.0, 100.0, 1.0),
+            (240_000, 100.0, 120.0, 98.0, 110.0, 2.0),
+        ]
+    )
+    await bot.update_trailing_data()
+    assert bot.trailing_prices[symbol]["long"]["max_since_open"] == pytest.approx(
+        120.0
+    )
+
+
+@pytest.mark.asyncio
+async def test_trailing_extrema_rejects_open_tail_beyond_active_bound():
+    cfg = _dummy_config()
+    cfg["live"]["max_active_candle_tail_gap_minutes"] = 1
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    bot._pnls_manager = _DummyPnlsManager(
+        [_DummyFillEvent(symbol, "long", 120_000, "fill-1")]
+    )
+    bot.is_trailing = lambda sym, pside=None: pside == "long"
+    bot.get_exchange_time = lambda: 421_000
+
+    async def stale_candles(*args, **kwargs):
+        return _make_candles(
+            [(180_000, 100.0, 101.0, 99.0, 100.0, 1.0)]
+        )
+
+    bot.cm.get_candles = stale_candles
     await bot.update_trailing_data()
 
     assert bot.trailing_prices[symbol]["long"] == _trailing_default()

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -2894,6 +2894,10 @@ async def test_trailing_extrema_projects_bounded_open_tail_without_persisting():
     )
     bot.is_trailing = lambda sym, pside=None: pside == "long"
     bot.get_exchange_time = lambda: 301_000
+    emitted = []
+    bot._emit_live_event = lambda event_type, **kwargs: emitted.append(
+        (event_type, kwargs)
+    )
     returned = _make_candles(
         [(180_000, 100.0, 101.0, 99.0, 100.0, 1.0)]
     )
@@ -2909,6 +2913,23 @@ async def test_trailing_extrema_projects_bounded_open_tail_without_persisting():
         101.0
     )
     assert list(returned["ts"]) == [180_000]
+    assert bot._orchestrator_trailing_projection_contexts[symbol]["long"][
+        "consecutive_uses"
+    ] == 1
+    assert len(emitted) == 1
+    assert emitted[0][0] == "candle.tail_projected"
+    assert emitted[0][1]["pside"] == "long"
+    assert emitted[0][1]["status"] == "degraded"
+    assert emitted[0][1]["reason_code"] == "trailing_open_tail_projection"
+    assert emitted[0][1]["data"]["consumer"] == "trailing_extrema"
+    assert emitted[0][1]["data"]["tail_gap_candles"] == 1
+    assert emitted[0][1]["data"]["consecutive_uses"] == 1
+
+    await bot.update_trailing_data()
+    assert bot._orchestrator_trailing_projection_contexts[symbol]["long"][
+        "consecutive_uses"
+    ] == 2
+    assert emitted[-1][1]["data"]["consecutive_uses"] == 2
 
     # A delayed real candle replaces the prior projection on the next read.
     returned = _make_candles(
@@ -2921,6 +2942,9 @@ async def test_trailing_extrema_projects_bounded_open_tail_without_persisting():
     assert bot.trailing_prices[symbol]["long"]["max_since_open"] == pytest.approx(
         120.0
     )
+    assert bot._orchestrator_trailing_projection_contexts == {}
+    assert bot._trailing_tail_projection_counts == {}
+    assert len(emitted) == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- reconstruct Gate multi-currency futures wallet balance from available, position-margin, and order-margin components, excluding unrealized PnL, so resting-order reservations no longer resize Rust intent
- repair persistent sparse KuCoin 1m gaps only when one successful raw payload returns real candles on both sides and omits the interior timestamps
- back off expected empty/no-progress background forager surfaces without ERROR spam while leaving unexpected failures loud
- allow trailing extrema to use the same bounded, non-persistent open-tail projection as active EMA inputs after proving dense coverage from the post-fill reset boundary
- document Hyperliquid's 5,000-candle retention limit and the requirement to preserve exact 1m cache history when migrating older held trailing positions

## Contract notes

The trailing change does not bridge leading or internal gaps. Delayed real candles replace temporary projected rows on the next read. For Hyperliquid positions older than the venue's retained 1m window, an exact existing cache remains required; wider-timeframe candles and earliest-available resets are intentionally rejected as parity-unsafe.

Gate's futures account schema distinguishes available margin, order margin, position initial margin, and unrealized PnL. The normalized Passivbot balance remains wallet balance, because equity adds position PnL separately.

References:
- https://www.gate.com/docs/developers/apiv4/en/futures/
- https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint

## Validation

- full `pytest -q`
- `python -m compileall -q src tests`
- `python src/tools/check_ai_docs.py` (0 errors; 2 pre-existing size warnings)
- `pytest -q tests/test_ai_docs.py tests/test_live_event_registry_docs.py`
- public, unauthenticated KuCoin market-data replay against sparse 1m caches: persistent gaps converged only after bracketed raw-payload proof
- redacted live canaries on the affected connectors: Gate balance remained independent of order-margin reservation changes; KuCoin repaired sparse no-trade rows without terminal-empty/error spam; held-position trailing remained available once exact post-fill cache coverage was present; no ERROR/CRITICAL events were observed across the canary set
