### PR TITLE
Add Bitunix live exchange support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ All notable user-facing changes will be documented in this file.
   WebSocket connector, including complete market metadata and top-of-book coverage, live-candle
   pagination, hedge-mode order and position reconciliation, account configuration, realized-PnL
   fill events, long/short reduce-only order lifecycles, honest identifier-only market-order
-  acknowledgements, and bounded REST ticker snapshots when WebSockets are explicitly disabled.
+  acknowledgements, strict complete open-order pagination, and bounded REST ticker snapshots when
+  WebSockets are explicitly disabled.
 - WEEX Futures orders now carry Passivbot's registered broker ID in the required
   `newClientOrderId` prefix while preserving Passivbot order-type markers for
   reconciliation and fill diagnostics.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ All notable user-facing changes will be documented in this file.
   pagination, hedge-mode order and position reconciliation, account configuration, realized-PnL
   fill events, long/short reduce-only order lifecycles, honest identifier-only market-order
   acknowledgements, strict complete open-order pagination, and bounded REST ticker snapshots when
-  WebSockets are explicitly disabled.
+  WebSockets are explicitly disabled. The connector rejects invalid order quantities and
+  case-insensitive authentication-header collisions, isolates malformed order-detail rows, retains
+  synthetic ticker provenance, and refreshes public ticker subscriptions as markets change.
 - WEEX Futures orders now carry Passivbot's registered broker ID in the required
   `newClientOrderId` prefix while preserving Passivbot order-type markers for
   reconciliation and fill diagnostics.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable user-facing changes will be documented in this file.
   symbol/timeframe fetch instead of reserving a whole batch before execution.
   Wall-time or lock timeouts briefly defer only the affected surface, preventing
   one slow symbol from consuming the batch budget and starving other candidates.
+- Added production Bitunix USDT perpetual-futures support through a native signed REST and
+  WebSocket connector, including complete market metadata and top-of-book coverage, live-candle
+  pagination, hedge-mode order and position reconciliation, account configuration, realized-PnL
+  fill events, and long/short reduce-only order lifecycles.
 - WEEX Futures orders now carry Passivbot's registered broker ID in the required
   `newClientOrderId` prefix while preserving Passivbot order-type markers for
   reconciliation and fill diagnostics.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ All notable user-facing changes will be documented in this file.
 - Added production Bitunix USDT perpetual-futures support through a native signed REST and
   WebSocket connector, including complete market metadata and top-of-book coverage, live-candle
   pagination, hedge-mode order and position reconciliation, account configuration, realized-PnL
-  fill events, and long/short reduce-only order lifecycles.
+  fill events, long/short reduce-only order lifecycles, honest identifier-only market-order
+  acknowledgements, and bounded REST ticker snapshots when WebSockets are explicitly disabled.
 - WEEX Futures orders now carry Passivbot's registered broker ID in the required
   `newClientOrderId` prefix while preserving Passivbot order-type markers for
   reconciliation and fill diagnostics.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ All notable user-facing changes will be documented in this file.
   acknowledgements, strict complete open-order pagination, and bounded REST ticker snapshots when
   WebSockets are explicitly disabled. The connector rejects invalid order quantities and
   case-insensitive authentication-header collisions, isolates malformed order-detail rows, retains
-  synthetic ticker provenance, and refreshes public ticker subscriptions as markets change.
+  synthetic ticker provenance, refreshes public ticker subscriptions as markets change, times
+  ticker-cache freshness locally, and reconciles malformed private-WebSocket rows.
 - WEEX Futures orders now carry Passivbot's registered broker ID in the required
   `newClientOrderId` prefix while preserving Passivbot order-type markers for
   reconciliation and fill diagnostics.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Passivbot](docs/images/pbot_logo_full.svg)
 
-# Trading bot running on Bybit, OKX, Bitget, GateIO, Binance, Kucoin, Hyperliquid and WEEX
+# Trading bot running on Bybit, OKX, Bitget, Bitunix, GateIO, Binance, Kucoin, Hyperliquid and WEEX
 
 :warning: **Used at one's own risk** :warning:
 

--- a/api-keys.json.example
+++ b/api-keys.json.example
@@ -26,6 +26,11 @@
         "secret": "secret",
         "passphrase": "passphrase"
     },
+    "bitunix_01" : {
+        "exchange": "bitunix",
+        "key": "key",
+        "secret": "secret"
+    },
     "okx_01" : {
         "exchange": "okx",
         "key": "key",

--- a/broker_codes.hjson
+++ b/broker_codes.hjson
@@ -22,6 +22,7 @@
 	// Supported exchanges without a broker-code payload in Passivbot.
 	// Keep these explicit so typos in exchange names fail loudly.
 	hyperliquid: null
+	bitunix: null
 	weex: "WEEX111164"
 	defx: null
 	paradex: null

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -388,7 +388,8 @@ Handling:
    account-state refresh instead of silently discarding the transition.
 5. Apply custom endpoint domain rewrites and `rest.url_overrides.api` to the native REST base, and
    merge `rest.extra_headers` into every request without allowing them to replace authentication
-   headers. Honor `disable_ws` by using REST order polling.
+   headers. Honor `disable_ws` for both private orders and public tickers: use REST order polling
+   and request only explicit, bounded symbol sets through REST depth.
 6. Keep `bitunix: null` explicit in `broker_codes.hjson`; there is no Passivbot broker payload for
    this connector.
 
@@ -438,7 +439,10 @@ authoritative top-of-book and last price, splitting the active market set across
 because Bitunix permits at most 300 subscriptions per connection. A targeted ticker request may
 use one-row REST depth for at most eight missing symbols as a bounded startup fallback, with the
 bid/ask midpoint labeled as its synthetic last. Broad operation must fail instead of fanning out
-one depth request per market or substituting bid/ask for a last trade.
+one depth request per market or substituting bid/ask for a last trade. When WebSockets are
+explicitly disabled, live market snapshots select this targeted REST path directly without opening
+or waiting for a public ticker socket; unbounded bulk requests and requests above the eight-symbol
+limit fail closed.
 
 Bitunix klines return at most 200 rows. The live field names are inverted relative to their units:
 `quoteVol` is base quantity and `baseVol` is quote notional; normalize `quoteVol` as CCXT base

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -412,13 +412,17 @@ Handling:
    `reduceOnly`; never reuse placement-side semantics while parsing a response.
 3. Accept both documented `LONG`/`SHORT` and observed `BUY`/`SELL` aliases on position rows. Keep
    all other position-side values invalid.
-4. Bitunix has emitted `NEW_` on live order detail although its schema documents `NEW`. Normalize
+4. Require a positive finite request price for every limit order and every open order. Only
+   terminal market-order detail may omit the request price.
+5. Bitunix has emitted `NEW_` on live order detail although its schema documents `NEW`. Normalize
    only trailing underscore padding before applying the closed order-status allowlist.
-5. Page trade history by `skip` to the reported total under one fixed `endTime` snapshot,
-   deduplicate by `tradeId`, preserve `realizedPNL` and fees, and enrich empty fill `clientId`
-   values through order detail. This is the canonical fill source for realized PnL, unstuck
-   accounting, and HSL replay.
-6. Reconstruct realized wallet balance as
+6. Page trade history by `skip` to the required, stable reported total under one fixed `endTime`
+   snapshot. Reject missing, changing, truncated, or duplicate pagination results. Preserve
+   `realizedPNL` and the fee sign so maker rebates remain positive balance impacts. Enrich empty
+   fill `clientId` values through order detail, but retain the exchange-truth fill with unknown
+   attribution when terminal order detail has expired. This is the canonical fill source for
+   realized PnL, unstuck accounting, and HSL replay.
+7. Reconstruct realized wallet balance as
    `available + frozen + margin - crossUnrealizedPNL - isolationUnrealizedPNL`; do not feed
    mark-to-market equity into Rust sizing.
 

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -5,8 +5,9 @@ requires explicit user approval; prefer offline request-construction tests.
 
 ## Supported Live-Exchange Boundary
 
-The supported production live connectors are Binance, Bybit, Bitget, OKX, Gate.io, KuCoin,
-Hyperliquid, and WEEX. The fake connector is an offline deterministic test harness, not an exchange.
+The supported production live connectors are Binance, Bybit, Bitget, Bitunix, OKX, Gate.io,
+KuCoin, Hyperliquid, and WEEX. The fake connector is an offline deterministic test harness, not an
+exchange.
 
 Defx is deliberately unsupported. `src/exchanges/defx.py` and the `setup_bot()` routing branch are
 stale legacy placeholders retained only until a separate cleanup removes them. Their presence does
@@ -362,6 +363,84 @@ after the fill is not locally present; wider-timeframe candles or an
 earliest-available reset are not parity-safe substitutes. Once that range is
 dense, only the bounded non-persistent open-tail projection described in the
 candlestick-manager contract may bridge delayed current candles.
+
+## Bitunix Futures
+
+### Native connector and authentication
+
+Bitunix is not available in the pinned CCXT release, so the production connector is a narrow
+native async REST/WebSocket implementation rather than a generic `CCXTBot` exchange class.
+It retains the CCXT-compatible object boundary consumed by Passivbot while implementing only the
+futures operations required by live trading.
+
+Handling:
+
+1. Sign private REST requests with Bitunix's documented double SHA-256 scheme. Sort query keys for
+   signing, and sign the exact compact JSON body bytes sent on POST.
+2. Supply `marginCoin=USDT` to account and symbol-configuration requests. Successful account data
+   may be either an object or a singleton list; accept exactly those shapes.
+3. Map business error envelopes to CCXT exception classes and propagate unknown failures. Keep
+   request spacing below the venue's documented UID/IP rolling limit.
+4. Authenticate the private WebSocket with its seconds-based signature, subscribe to `order`, and
+   enrich each notification from REST order detail before publishing it. The raw push lacks enough
+   durable close-only metadata for authoritative reconciliation.
+5. Keep `bitunix: null` explicit in `broker_codes.hjson`; there is no Passivbot broker payload for
+   this connector.
+
+Primary references: [Bitunix REST authentication](https://www.bitunix.com/api-docs/futures/common/sign.html),
+[WebSocket login](https://www.bitunix.com/api-docs/futures/websocket/prepare/WebSocket.html), and
+[order channel](https://www.bitunix.com/api-docs/futures/websocket/private/Order%20Channel.html).
+
+### Hedge orders, positions, and fills
+
+Bitunix's hedge placement request uses a venue-specific side contract:
+`BUY + OPEN` opens long, `SELL + OPEN` opens short, `BUY + CLOSE` closes long, and
+`SELL + CLOSE` closes short. A close additionally requires the live `positionId`. Order-detail and
+fill responses instead expose the actual buy/sell action.
+
+Handling:
+
+1. Keep the exchange account in `HEDGE` mode. Translate Passivbot's explicit `position_side` into
+   the placement-side tuple and send `reduceOnly=true` plus the cached authoritative `positionId`
+   on every close.
+2. Treat response `side` as the actual action. Derive long/short from action plus the boolean
+   `reduceOnly`; never reuse placement-side semantics while parsing a response.
+3. Accept both documented `LONG`/`SHORT` and observed `BUY`/`SELL` aliases on position rows. Keep
+   all other position-side values invalid.
+4. Bitunix has emitted `NEW_` on live order detail although its schema documents `NEW`. Normalize
+   only trailing underscore padding before applying the closed order-status allowlist.
+5. Page trade history by `skip` to the reported total, deduplicate by `tradeId`, preserve
+   `realizedPNL` and fees, and enrich empty fill `clientId` values through order detail. This is the
+   canonical fill source for realized PnL, unstuck accounting, and HSL replay.
+6. Reconstruct realized wallet balance as
+   `available + frozen + margin - crossUnrealizedPNL - isolationUnrealizedPNL`; do not feed
+   mark-to-market equity into Rust sizing.
+
+Primary references: [place order](https://www.bitunix.com/api-docs/futures/trade/place_order.html),
+[pending positions](https://www.bitunix.com/api-docs/futures/position/get_pending_positions.html),
+[order detail](https://www.bitunix.com/api-docs/futures/trade/get_order_detail.html), and
+[history trades](https://www.bitunix.com/api-docs/futures/trade/get_history_trades.html).
+
+### Live quotes and candles
+
+The bulk REST ticker omits bid and ask. Use the official public `tickers` WebSocket for
+authoritative top-of-book and last price, splitting the active market set across connections
+because Bitunix permits at most 300 subscriptions per connection. A targeted ticker request may
+use one-row REST depth as a bounded startup fallback; broad operation must not fan out one depth
+request per market or substitute last trade for bid/ask.
+
+Bitunix klines return at most 200 rows. The live field names are inverted relative to their units:
+`quoteVol` is base quantity and `baseVol` is quote notional; normalize `quoteVol` as CCXT base
+volume so Passivbot's generic quote-volume calculation remains dimensionally correct. In live
+behavior, `startTime` does not anchor a response; the venue tail-anchors at `endTime`. Derive each
+forward page's `endTime` from `since + limit * timeframe`, filter to the requested bounds, sort
+ascending, and deduplicate. This pagination supports live warmup, restart reconstruction, and
+runtime indicators only. Bulk historical Bitunix data for backtesting or optimization is not a
+supported source.
+
+Primary references: [ticker WebSocket](https://www.bitunix.com/api-docs/futures/websocket/public/Tickers%20Channel.html),
+[REST depth](https://www.bitunix.com/api-docs/futures/market/get_depth.html), and
+[kline API](https://www.bitunix.com/api-docs/futures/market/get_kline.html).
 
 ## WEEX Futures
 

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -386,7 +386,9 @@ Handling:
    durable close-only metadata for authoritative reconciliation. If REST reports that the order is
    not found or returns semantically invalid order detail, publish only that raw row as untrusted so
    the generic watcher requests an authoritative account-state refresh instead of silently
-   discarding the transition. Transport failures still fail the batch and reconnect.
+   discarding the transition. Treat non-object pushes and rows without an order ID the same way
+   instead of dropping them before reconciliation. Transport failures still fail the batch and
+   reconnect.
 5. Apply custom endpoint domain rewrites and `rest.url_overrides.api` to the native REST base, and
    merge `rest.extra_headers` into every request. Reject authentication header names
    case-insensitively in configured headers so proxy or user headers cannot collide with generated
@@ -443,13 +445,15 @@ Primary references: [place order](https://www.bitunix.com/api-docs/futures/trade
 The bulk REST ticker omits bid and ask. Use the official public `tickers` WebSocket for
 authoritative top-of-book and last price, splitting the active market set across connections
 because Bitunix permits at most 300 subscriptions per connection. Refresh those subscriptions when
-the active market-ID set changes. A targeted ticker request may use one-row REST depth for at most
-eight missing symbols as a bounded startup fallback, with the bid/ask midpoint labeled as its
-synthetic last through ticker normalization and into snapshot provenance. Broad operation must fail
-instead of fanning out one depth request per market or substituting bid/ask for a last trade. When
-WebSockets are explicitly disabled, live market snapshots select this targeted REST path directly
-without opening or waiting for a public ticker socket; unbounded bulk requests and requests above
-the eight-symbol limit fail closed.
+the active market-ID set changes. Determine cache freshness from the bounded local receipt time;
+retain exchange timestamps only as quote provenance so future-skewed venue timestamps cannot keep a
+stale quote eligible. A targeted ticker request may use one-row REST depth for at most eight missing
+symbols as a bounded startup fallback, with the bid/ask midpoint labeled as its synthetic last
+through ticker normalization and into snapshot provenance. Broad operation must fail instead of
+fanning out one depth request per market or substituting bid/ask for a last trade. When WebSockets
+are explicitly disabled, live market snapshots select this targeted REST path directly without
+opening or waiting for a public ticker socket; unbounded bulk requests and requests above the
+eight-symbol limit fail closed.
 
 Bitunix klines return at most 200 rows. The live field names are inverted relative to their units:
 `quoteVol` is base quantity and `baseVol` is quote notional; normalize `quoteVol` as CCXT base

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -384,12 +384,14 @@ Handling:
 4. Authenticate the private WebSocket with its seconds-based signature, subscribe to `order`, and
    enrich each notification from REST order detail before publishing it. The raw push lacks enough
    durable close-only metadata for authoritative reconciliation. If REST reports that the order is
-   not found, publish the raw row as untrusted so the generic watcher requests an authoritative
-   account-state refresh instead of silently discarding the transition.
+   not found or returns semantically invalid order detail, publish only that raw row as untrusted so
+   the generic watcher requests an authoritative account-state refresh instead of silently
+   discarding the transition. Transport failures still fail the batch and reconnect.
 5. Apply custom endpoint domain rewrites and `rest.url_overrides.api` to the native REST base, and
-   merge `rest.extra_headers` into every request without allowing them to replace authentication
-   headers. Honor `disable_ws` for both private orders and public tickers: use REST order polling
-   and request only explicit, bounded symbol sets through REST depth.
+   merge `rest.extra_headers` into every request. Reject authentication header names
+   case-insensitively in configured headers so proxy or user headers cannot collide with generated
+   signatures. Honor `disable_ws` for both private orders and public tickers: use REST order
+   polling and request only explicit, bounded symbol sets through REST depth.
 6. Keep `bitunix: null` explicit in `broker_codes.hjson`; there is no Passivbot broker payload for
    this connector.
 
@@ -413,8 +415,9 @@ Handling:
    `reduceOnly`; never reuse placement-side semantics while parsing a response.
 3. Accept both documented `LONG`/`SHORT` and observed `BUY`/`SELL` aliases on position rows. Keep
    all other position-side values invalid.
-4. Require a positive finite request price for every limit order and every open order. Only
-   terminal market-order detail may omit the request price.
+4. Require a positive finite quantity on every normalized order and a positive finite request
+   price for every limit order and every open order. Only terminal market-order detail may omit the
+   request price.
 5. Bitunix has emitted `NEW_` on live order detail although its schema documents `NEW`. Normalize
    only trailing underscore padding before applying the closed order-status allowlist.
 6. Page pending orders by `skip` to the required, stable reported total under one fixed `endTime`
@@ -439,13 +442,14 @@ Primary references: [place order](https://www.bitunix.com/api-docs/futures/trade
 
 The bulk REST ticker omits bid and ask. Use the official public `tickers` WebSocket for
 authoritative top-of-book and last price, splitting the active market set across connections
-because Bitunix permits at most 300 subscriptions per connection. A targeted ticker request may
-use one-row REST depth for at most eight missing symbols as a bounded startup fallback, with the
-bid/ask midpoint labeled as its synthetic last. Broad operation must fail instead of fanning out
-one depth request per market or substituting bid/ask for a last trade. When WebSockets are
-explicitly disabled, live market snapshots select this targeted REST path directly without opening
-or waiting for a public ticker socket; unbounded bulk requests and requests above the eight-symbol
-limit fail closed.
+because Bitunix permits at most 300 subscriptions per connection. Refresh those subscriptions when
+the active market-ID set changes. A targeted ticker request may use one-row REST depth for at most
+eight missing symbols as a bounded startup fallback, with the bid/ask midpoint labeled as its
+synthetic last through ticker normalization and into snapshot provenance. Broad operation must fail
+instead of fanning out one depth request per market or substituting bid/ask for a last trade. When
+WebSockets are explicitly disabled, live market snapshots select this targeted REST path directly
+without opening or waiting for a public ticker socket; unbounded bulk requests and requests above
+the eight-symbol limit fail closed.
 
 Bitunix klines return at most 200 rows. The live field names are inverted relative to their units:
 `quoteVol` is base quantity and `baseVol` is quote notional; normalize `quoteVol` as CCXT base

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -383,8 +383,13 @@ Handling:
    request spacing below the venue's documented UID/IP rolling limit.
 4. Authenticate the private WebSocket with its seconds-based signature, subscribe to `order`, and
    enrich each notification from REST order detail before publishing it. The raw push lacks enough
-   durable close-only metadata for authoritative reconciliation.
-5. Keep `bitunix: null` explicit in `broker_codes.hjson`; there is no Passivbot broker payload for
+   durable close-only metadata for authoritative reconciliation. If REST reports that the order is
+   not found, publish the raw row as untrusted so the generic watcher requests an authoritative
+   account-state refresh instead of silently discarding the transition.
+5. Apply custom endpoint domain rewrites and `rest.url_overrides.api` to the native REST base, and
+   merge `rest.extra_headers` into every request without allowing them to replace authentication
+   headers. Honor `disable_ws` by using REST order polling.
+6. Keep `bitunix: null` explicit in `broker_codes.hjson`; there is no Passivbot broker payload for
    this connector.
 
 Primary references: [Bitunix REST authentication](https://www.bitunix.com/api-docs/futures/common/sign.html),
@@ -409,9 +414,10 @@ Handling:
    all other position-side values invalid.
 4. Bitunix has emitted `NEW_` on live order detail although its schema documents `NEW`. Normalize
    only trailing underscore padding before applying the closed order-status allowlist.
-5. Page trade history by `skip` to the reported total, deduplicate by `tradeId`, preserve
-   `realizedPNL` and fees, and enrich empty fill `clientId` values through order detail. This is the
-   canonical fill source for realized PnL, unstuck accounting, and HSL replay.
+5. Page trade history by `skip` to the reported total under one fixed `endTime` snapshot,
+   deduplicate by `tradeId`, preserve `realizedPNL` and fees, and enrich empty fill `clientId`
+   values through order detail. This is the canonical fill source for realized PnL, unstuck
+   accounting, and HSL replay.
 6. Reconstruct realized wallet balance as
    `available + frozen + margin - crossUnrealizedPNL - isolationUnrealizedPNL`; do not feed
    mark-to-market equity into Rust sizing.
@@ -426,17 +432,19 @@ Primary references: [place order](https://www.bitunix.com/api-docs/futures/trade
 The bulk REST ticker omits bid and ask. Use the official public `tickers` WebSocket for
 authoritative top-of-book and last price, splitting the active market set across connections
 because Bitunix permits at most 300 subscriptions per connection. A targeted ticker request may
-use one-row REST depth as a bounded startup fallback; broad operation must not fan out one depth
-request per market or substitute last trade for bid/ask.
+use one-row REST depth for at most eight missing symbols as a bounded startup fallback, with the
+bid/ask midpoint labeled as its synthetic last. Broad operation must fail instead of fanning out
+one depth request per market or substituting bid/ask for a last trade.
 
 Bitunix klines return at most 200 rows. The live field names are inverted relative to their units:
 `quoteVol` is base quantity and `baseVol` is quote notional; normalize `quoteVol` as CCXT base
-volume so Passivbot's generic quote-volume calculation remains dimensionally correct. In live
-behavior, `startTime` does not anchor a response; the venue tail-anchors at `endTime`. Derive each
-forward page's `endTime` from `since + limit * timeframe`, filter to the requested bounds, sort
-ascending, and deduplicate. This pagination supports live warmup, restart reconstruction, and
-runtime indicators only. Bulk historical Bitunix data for backtesting or optimization is not a
-supported source.
+volume so Passivbot's generic quote-volume calculation remains dimensionally correct. Missing,
+non-finite, or negative base volume is invalid; an explicit zero remains valid. In live behavior,
+`startTime` does not anchor a response; the venue tail-anchors at `endTime`. Derive each forward
+page's `endTime` from `since + limit * timeframe`, filter to the requested bounds, sort ascending,
+and deduplicate. This pagination supports live warmup, restart reconstruction, and runtime
+indicators only. Bulk historical Bitunix data for backtesting or optimization is not a supported
+source.
 
 Primary references: [ticker WebSocket](https://www.bitunix.com/api-docs/futures/websocket/public/Tickers%20Channel.html),
 [REST depth](https://www.bitunix.com/api-docs/futures/market/get_depth.html), and

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -417,13 +417,16 @@ Handling:
    terminal market-order detail may omit the request price.
 5. Bitunix has emitted `NEW_` on live order detail although its schema documents `NEW`. Normalize
    only trailing underscore padding before applying the closed order-status allowlist.
-6. Page trade history by `skip` to the required, stable reported total under one fixed `endTime`
+6. Page pending orders by `skip` to the required, stable reported total under one fixed `endTime`
+   snapshot. Reject missing, changing, truncated, or duplicate pagination results before treating
+   the account-critical open-order set as authoritative.
+7. Page trade history by `skip` to the required, stable reported total under one fixed `endTime`
    snapshot. Reject missing, changing, truncated, or duplicate pagination results. Preserve
    `realizedPNL` and the fee sign so maker rebates remain positive balance impacts. Enrich empty
    fill `clientId` values through order detail, but retain the exchange-truth fill with unknown
    attribution when terminal order detail has expired. This is the canonical fill source for
    realized PnL, unstuck accounting, and HSL replay.
-7. Reconstruct realized wallet balance as
+8. Reconstruct realized wallet balance as
    `available + frozen + margin - crossUnrealizedPNL - isolationUnrealizedPNL`; do not feed
    mark-to-market equity into Rust sizing.
 

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -996,6 +996,9 @@ class CandlestickManager:
             self._record_payload_gaps_as_known = True
             # KuCoin since behaves as exclusive for 1m OHLCV.
             self._ccxt_since_exclusive = True
+        if isinstance(self._ex_id, str) and "bitunix" in self._ex_id.lower():
+            # Bitunix futures caps every kline response at 200 rows.
+            self._ccxt_limit_default = 200
 
         # Optional per-page range logging for selected symbols (debug pagination)
         self._page_debug_all = False

--- a/src/ccxt_contracts.py
+++ b/src/ccxt_contracts.py
@@ -97,6 +97,10 @@ def get_bot_class(exchange: str):
         from exchanges.bitget import BitgetBot
 
         return BitgetBot
+    if exchange == "bitunix":
+        from exchanges.bitunix import BitunixBot
+
+        return BitunixBot
     if exchange == "bybit":
         from exchanges.bybit import BybitBot
 
@@ -148,6 +152,7 @@ def build_contract_bot(exchange: str, quote: str = "USDT"):
             "hedge_mode": True,
         }
     }
+    bot.coin_overrides = {}
     bot.user_info = {"exchange": bot.exchange}
     bot.cca = SimpleNamespace(has={}, options={})
     bot.ccp = None

--- a/src/exchanges/bitunix.py
+++ b/src/exchanges/bitunix.py
@@ -81,6 +81,7 @@ class BitunixClient:
     PRIVATE_WS_URL = "wss://fapi.bitunix.com/private/"
     MAX_PAGE_SIZE = 100
     MAX_KLINE_PAGE_SIZE = 200
+    MAX_OPEN_ORDER_PAGES = 1000
     MAX_FILL_PAGES = 1000
     TICKER_MAX_AGE_MS = 30_000
     TICKER_WAIT_SECONDS = 8.0
@@ -640,10 +641,14 @@ class BitunixClient:
         }
 
     async def _fetch_order_page(
-        self, symbol: str | None, skip: int, limit: int
+        self, symbol: str | None, skip: int, limit: int, end_time: int
     ) -> tuple[list[dict], int]:
         await self._ensure_markets()
-        params: dict[str, Any] = {"skip": skip, "limit": limit}
+        params: dict[str, Any] = {
+            "skip": skip,
+            "limit": limit,
+            "endTime": end_time,
+        }
         if symbol:
             params["symbol"] = self.market(symbol)["id"]
         data = await self._request(
@@ -654,7 +659,15 @@ class BitunixClient:
         )
         if not isinstance(data, dict) or not isinstance(data.get("orderList"), list):
             raise ValueError("Bitunix open-orders response has invalid shape")
-        return data["orderList"], int(data.get("total") or 0)
+        try:
+            total = _int(data.get("total"), field="open-orders total")
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(
+                "Bitunix response has invalid open-orders total"
+            ) from exc
+        if total < 0:
+            raise ValueError("Bitunix response has negative open-orders total")
+        return data["orderList"], total
 
     async def fetch_open_orders(
         self,
@@ -664,15 +677,52 @@ class BitunixClient:
         params: dict | None = None,
     ) -> list[dict]:
         page_size = min(self.MAX_PAGE_SIZE, max(1, int(limit or self.MAX_PAGE_SIZE)))
-        rows: list[dict] = []
+        snapshot_end = self.milliseconds()
+        rows: dict[str, dict] = {}
         skip = 0
-        while True:
-            page, total = await self._fetch_order_page(symbol, skip, page_size)
-            rows.extend(page)
+        expected_total: int | None = None
+        for _ in range(self.MAX_OPEN_ORDER_PAGES):
+            page, total = await self._fetch_order_page(
+                symbol, skip, page_size, snapshot_end
+            )
+            if expected_total is None:
+                expected_total = total
+            elif total != expected_total:
+                raise ValueError(
+                    "Bitunix open-orders total changed during pagination"
+                )
+            for row in page:
+                if not isinstance(row, dict):
+                    raise ValueError(
+                        "Bitunix open-orders response contains a non-object row"
+                    )
+                order_id = str(row.get("orderId") or "")
+                if not order_id:
+                    raise ValueError("Bitunix open-orders row missing orderId")
+                rows[order_id] = row
             skip += len(page)
-            if not page or skip >= total or len(page) < page_size:
+            if skip > total:
+                raise ValueError(
+                    "Bitunix open-orders total is smaller than returned rows"
+                )
+            if not page and skip < total:
+                raise ValueError(
+                    "Bitunix open-orders pagination ended before total"
+                )
+            if skip == total:
                 break
-        return sorted((self._normalize_order(row) for row in rows), key=lambda x: x["timestamp"])
+        else:
+            raise RuntimeError(
+                "Bitunix open-orders pagination exceeded safety limit"
+            )
+        if expected_total is None or len(rows) != expected_total:
+            raise ValueError(
+                "Bitunix open-orders pagination returned duplicate or incomplete rows"
+            )
+        return sorted(
+            (self._normalize_order(row) for row in rows.values()),
+            key=lambda order: order["timestamp"],
+        )
 
     async def fetch_order(
         self, order_id: str, symbol: str | None = None, params: dict | None = None

--- a/src/exchanges/bitunix.py
+++ b/src/exchanges/bitunix.py
@@ -171,6 +171,7 @@ class BitunixClient:
         self._last_request_monotonic = 0.0
         self._position_ids: dict[tuple[str, str], str] = {}
         self._ticker_cache: dict[str, dict] = {}
+        self._ticker_received_monotonic: dict[str, float] = {}
         self._ticker_tasks: list[asyncio.Task] = []
         self._ticker_subscription_ids: tuple[str, ...] = ()
         self._ticker_ready = asyncio.Event()
@@ -1172,7 +1173,9 @@ class BitunixClient:
                                 continue
                             data = payload.get("data")
                             rows = data if isinstance(data, list) else [data]
-                            timestamp = int(payload.get("ts") or self.milliseconds())
+                            received_at = self.milliseconds()
+                            received_monotonic = time.monotonic()
+                            timestamp = int(payload.get("ts") or received_at)
                             for row in rows:
                                 if not isinstance(row, dict):
                                     continue
@@ -1193,6 +1196,9 @@ class BitunixClient:
                                     "timestamp": timestamp,
                                     "info": deepcopy(row),
                                 }
+                                self._ticker_received_monotonic[
+                                    market["symbol"]
+                                ] = received_monotonic
                             if self._ticker_cache:
                                 self._ticker_ready.set()
                         elif message.type in {
@@ -1238,6 +1244,17 @@ class BitunixClient:
                 )
             )
 
+    def _ticker_is_fresh(
+        self, symbol: str, now_monotonic: float
+    ) -> bool:
+        if symbol not in self._ticker_cache:
+            return False
+        received_monotonic = self._ticker_received_monotonic.get(symbol)
+        if received_monotonic is None:
+            return False
+        age_ms = (now_monotonic - received_monotonic) * 1000.0
+        return 0.0 <= age_ms <= self.TICKER_MAX_AGE_MS
+
     async def fetch_tickers(
         self, symbols: list[str] | None = None, params: dict | None = None
     ) -> dict[str, dict]:
@@ -1272,11 +1289,9 @@ class BitunixClient:
         self._ensure_ticker_tasks()
         deadline = time.monotonic() + self.TICKER_WAIT_SECONDS
         while time.monotonic() < deadline:
-            now = self.milliseconds()
+            now_monotonic = time.monotonic()
             if all(
-                symbol in self._ticker_cache
-                and now - int(self._ticker_cache[symbol]["timestamp"])
-                <= self.TICKER_MAX_AGE_MS
+                self._ticker_is_fresh(symbol, now_monotonic)
                 for symbol in desired
             ):
                 break
@@ -1288,13 +1303,11 @@ class BitunixClient:
                 self._ticker_ready.clear()
             except asyncio.TimeoutError:
                 pass
-        now = self.milliseconds()
+        now_monotonic = time.monotonic()
         result = {
             symbol: deepcopy(self._ticker_cache[symbol])
             for symbol in desired
-            if symbol in self._ticker_cache
-            and now - int(self._ticker_cache[symbol]["timestamp"])
-            <= self.TICKER_MAX_AGE_MS
+            if self._ticker_is_fresh(symbol, now_monotonic)
         }
         if symbols:
             missing = [symbol for symbol in desired if symbol not in result]
@@ -1465,6 +1478,12 @@ class BitunixOrderStream:
                 enriched = []
                 for row in rows:
                     if not isinstance(row, dict) or not row.get("orderId"):
+                        fallback = {"info": {"raw": deepcopy(row)}}
+                        if isinstance(row, dict) and row.get("symbol"):
+                            fallback["symbol"] = self.rest.safe_symbol(
+                                str(row["symbol"])
+                            )
+                        enriched.append(fallback)
                         continue
                     try:
                         enriched.append(

--- a/src/exchanges/bitunix.py
+++ b/src/exchanges/bitunix.py
@@ -86,6 +86,7 @@ class BitunixClient:
     TICKER_MAX_AGE_MS = 30_000
     TICKER_WAIT_SECONDS = 8.0
     MAX_DEPTH_FALLBACK_SYMBOLS = 8
+    RESERVED_AUTH_HEADERS = frozenset({"api-key", "nonce", "timestamp", "sign"})
 
     has = {
         "cancelOrder": True,
@@ -143,10 +144,21 @@ class BitunixClient:
         self.apiKey = str(config.get("apiKey") or config.get("key") or "")
         self.secret = str(config.get("secret") or "")
         self.rest_url = str(config.get("restUrl") or self.REST_URL).rstrip("/")
-        self.headers = {
+        configured_headers = {
             str(key): str(value)
             for key, value in dict(config.get("headers") or {}).items()
         }
+        reserved_headers = sorted(
+            key
+            for key in configured_headers
+            if key.lower() in self.RESERVED_AUTH_HEADERS
+        )
+        if reserved_headers:
+            raise ValueError(
+                "Bitunix headers may not override reserved authentication header(s): "
+                + ", ".join(reserved_headers)
+            )
+        self.headers = configured_headers
         self.timeout = int(config.get("timeout") or 30_000)
         self.enableRateLimit = bool(config.get("enableRateLimit", True))
         self.ws_enabled = bool(config.get("wsEnabled", True))
@@ -160,6 +172,7 @@ class BitunixClient:
         self._position_ids: dict[tuple[str, str], str] = {}
         self._ticker_cache: dict[str, dict] = {}
         self._ticker_tasks: list[asyncio.Task] = []
+        self._ticker_subscription_ids: tuple[str, ...] = ()
         self._ticker_ready = asyncio.Event()
         self._closed = False
 
@@ -574,7 +587,9 @@ class BitunixClient:
                 if reduce_only
                 else ("long" if action_side == "buy" else "short")
             )
-        qty = abs(_float(row.get("qty"), field="order.qty"))
+        qty = _float(row.get("qty"), field="order.qty")
+        if qty <= 0.0:
+            raise ValueError("Bitunix response has non-positive order.qty")
         filled = abs(
             _float(
                 row.get("tradeQty") or row.get("dealAmount"),
@@ -1198,19 +1213,22 @@ class BitunixClient:
     def _ensure_ticker_tasks(self) -> None:
         if not self.ws_enabled:
             return
+        market_ids = tuple(
+            sorted(
+                str(market["id"])
+                for market in self.markets.values()
+                if market.get("active")
+            )
+        )
         if self._ticker_tasks and all(
             not task.done() for task in self._ticker_tasks
-        ):
+        ) and market_ids == self._ticker_subscription_ids:
             return
         for task in self._ticker_tasks:
             task.cancel()
         self._ticker_tasks = []
+        self._ticker_subscription_ids = market_ids
         self._ticker_ready.clear()
-        market_ids = [
-            str(market["id"])
-            for market in self.markets.values()
-            if market.get("active")
-        ]
         for index in range(0, len(market_ids), 300):
             chunk = tuple(market_ids[index : index + 300])
             self._ticker_tasks.append(
@@ -1455,7 +1473,7 @@ class BitunixOrderStream:
                                 self.rest.safe_symbol(str(row.get("symbol") or "")),
                             )
                         )
-                    except OrderNotFound:
+                    except (OrderNotFound, ValueError):
                         fallback = deepcopy(row)
                         fallback["symbol"] = self.rest.safe_symbol(
                             str(row.get("symbol") or "")
@@ -1519,6 +1537,17 @@ class BitunixBot(CCXTBot):
         if not self.ws_enabled:
             return "symbols"
         return super()._market_snapshot_ticker_strategy()
+
+    def _normalize_tickers(self, fetched: dict) -> dict:
+        tickers = super()._normalize_tickers(fetched)
+        for symbol, ticker in tickers.items():
+            raw = fetched[symbol]
+            if raw.get("timestamp") is not None:
+                ticker["timestamp"] = int(raw["timestamp"])
+            source = raw.get("source")
+            if isinstance(source, str) and source.strip():
+                ticker["source"] = source.strip()
+        return tickers
 
     async def update_exchange_config(self) -> None:
         current = await self.cca.fetch_position_mode()

--- a/src/exchanges/bitunix.py
+++ b/src/exchanges/bitunix.py
@@ -25,6 +25,7 @@ from ccxt.base.errors import (
 )
 
 from config.access import require_live_value
+from custom_endpoint_overrides import CustomEndpointConfigError
 from exchanges.ccxt_bot import CCXTBot, format_exchange_config_response
 from passivbot import logging
 from utils import symbol_to_coin
@@ -82,6 +83,8 @@ class BitunixClient:
     MAX_KLINE_PAGE_SIZE = 200
     MAX_FILL_PAGES = 1000
     TICKER_MAX_AGE_MS = 30_000
+    TICKER_WAIT_SECONDS = 8.0
+    MAX_DEPTH_FALLBACK_SYMBOLS = 8
 
     has = {
         "cancelOrder": True,
@@ -138,6 +141,11 @@ class BitunixClient:
         config = config or {}
         self.apiKey = str(config.get("apiKey") or config.get("key") or "")
         self.secret = str(config.get("secret") or "")
+        self.rest_url = str(config.get("restUrl") or self.REST_URL).rstrip("/")
+        self.headers = {
+            str(key): str(value)
+            for key, value in dict(config.get("headers") or {}).items()
+        }
         self.timeout = int(config.get("timeout") or 30_000)
         self.enableRateLimit = bool(config.get("enableRateLimit", True))
         self.options: dict[str, Any] = {}
@@ -239,13 +247,13 @@ class BitunixClient:
             if body is not None
             else ""
         )
-        headers = (
-            self._signed_headers(params, body_text)
-            if private
-            else {"Content-Type": "application/json"}
-        )
+        headers = dict(self.headers)
+        if private:
+            headers.update(self._signed_headers(params, body_text))
+        else:
+            headers["Content-Type"] = "application/json"
         query = urlencode(sorted(params.items()))
-        url = f"{self.REST_URL}{path}" + (f"?{query}" if query else "")
+        url = f"{self.rest_url}{path}" + (f"?{query}" if query else "")
         await self._throttle(cancel=cancel)
         session = await self._get_session()
         try:
@@ -452,6 +460,15 @@ class BitunixClient:
                 raise ValueError("Bitunix open position missing positionId")
             fresh_ids[(symbol, pside)] = position_id
             contracts = abs(_float(row.get("qty"), field="position.qty"))
+            entry_price = _float(
+                row.get("avgOpenPrice") or row.get("entryPrice"),
+                field="position entry price",
+                default=0.0 if contracts == 0.0 else None,
+            )
+            if contracts != 0.0 and entry_price <= 0.0:
+                raise ValueError(
+                    "Bitunix response has non-positive position entry price"
+                )
             raw_margin_mode = str(row.get("marginMode") or "").upper()
             if raw_margin_mode not in {"CROSS", "ISOLATION"}:
                 raise ValueError(
@@ -471,11 +488,7 @@ class BitunixClient:
                     "side": pside,
                     "contracts": contracts,
                     "contractSize": 1.0,
-                    "entryPrice": _float(
-                        row.get("avgOpenPrice") or row.get("entryPrice"),
-                        field="position.avgOpenPrice",
-                        default=0.0,
-                    ),
+                    "entryPrice": entry_price,
                     "markPrice": None,
                     "notional": _float(
                         row.get("entryValue"),
@@ -859,14 +872,24 @@ class BitunixClient:
         await self._ensure_markets()
         params = dict(params or {})
         until = params.pop("until", None)
+        explicit_end_time = params.pop("endTime", None)
+        snapshot_end = int(
+            until
+            if until is not None
+            else explicit_end_time
+            if explicit_end_time is not None
+            else self.milliseconds()
+        )
         page_size = min(self.MAX_PAGE_SIZE, max(1, int(limit or self.MAX_PAGE_SIZE)))
-        query: dict[str, Any] = {"skip": 0, "limit": page_size}
+        query: dict[str, Any] = {
+            "skip": 0,
+            "limit": page_size,
+            "endTime": snapshot_end,
+        }
         if symbol:
             query["symbol"] = self.market(symbol)["id"]
         if since is not None:
             query["startTime"] = int(since)
-        if until is not None:
-            query["endTime"] = int(until)
         query.update(params)
         rows: dict[str, dict] = {}
         for _ in range(self.MAX_FILL_PAGES):
@@ -959,8 +982,10 @@ class BitunixClient:
                 # Bitunix's live payload names are inverted relative to their
                 # units: quoteVol is base quantity, while baseVol is quote
                 # notional (baseVol / quoteVol is approximately price).
-                _float(row.get("quoteVol"), field="kline.quoteVol", default=0.0),
+                _float(row.get("quoteVol"), field="kline.quoteVol"),
             ]
+            if normalized[timestamp][5] < 0.0:
+                raise ValueError("Bitunix response has negative kline.quoteVol")
         return [normalized[key] for key in sorted(normalized)]
 
     async def _fetch_depth_ticker(self, symbol: str) -> dict:
@@ -985,6 +1010,7 @@ class BitunixClient:
             "ask": ask,
             "last": (bid + ask) / 2.0,
             "timestamp": self.milliseconds(),
+            "source": "bitunix_depth_mid",
             "info": data,
         }
 
@@ -1094,7 +1120,7 @@ class BitunixClient:
         for symbol in desired:
             self.market(symbol)
         self._ensure_ticker_tasks()
-        deadline = time.monotonic() + 8.0
+        deadline = time.monotonic() + self.TICKER_WAIT_SECONDS
         while time.monotonic() < deadline:
             now = self.milliseconds()
             if all(
@@ -1121,9 +1147,15 @@ class BitunixClient:
             <= self.TICKER_MAX_AGE_MS
         }
         if symbols:
-            for symbol in desired:
-                if symbol not in result:
-                    result[symbol] = await self._fetch_depth_ticker(symbol)
+            missing = [symbol for symbol in desired if symbol not in result]
+            if len(missing) > self.MAX_DEPTH_FALLBACK_SYMBOLS:
+                raise NetworkError(
+                    "Bitunix ticker websocket missing "
+                    f"{len(missing)} symbols; REST depth fallback limited to "
+                    f"{self.MAX_DEPTH_FALLBACK_SYMBOLS}"
+                )
+            for symbol in missing:
+                result[symbol] = await self._fetch_depth_ticker(symbol)
         if not result:
             raise NetworkError("Bitunix ticker websocket produced no current quotes")
         return result
@@ -1292,7 +1324,11 @@ class BitunixOrderStream:
                             )
                         )
                     except OrderNotFound:
-                        continue
+                        fallback = deepcopy(row)
+                        fallback["symbol"] = self.rest.safe_symbol(
+                            str(row.get("symbol") or "")
+                        )
+                        enriched.append(fallback)
                 if enriched:
                     return enriched
             elif message.type in {
@@ -1322,6 +1358,22 @@ class BitunixBot(CCXTBot):
 
     def create_ccxt_sessions(self) -> None:
         ccxt_config = self._build_ccxt_config()
+        endpoint_override = getattr(self, "endpoint_override", None)
+        if endpoint_override is not None:
+            unsupported_keys = set(endpoint_override.rest_url_overrides) - {"api"}
+            if unsupported_keys:
+                raise CustomEndpointConfigError(
+                    "bitunix: unsupported REST URL override key(s): "
+                    + ", ".join(sorted(unsupported_keys))
+                    + "; use 'api' for the native REST base"
+                )
+            rest_urls = endpoint_override.apply_to_api_urls(
+                {"api": BitunixClient.REST_URL}
+            )
+            ccxt_config["restUrl"] = rest_urls["api"]
+            headers = dict(ccxt_config.get("headers") or {})
+            headers.update(endpoint_override.rest_extra_headers)
+            ccxt_config["headers"] = headers
         self.cca = BitunixClient(ccxt_config)
         self.cca.options.update(self.user_info.get("options", {}))
         if self.ws_enabled:

--- a/src/exchanges/bitunix.py
+++ b/src/exchanges/bitunix.py
@@ -148,6 +148,7 @@ class BitunixClient:
         }
         self.timeout = int(config.get("timeout") or 30_000)
         self.enableRateLimit = bool(config.get("enableRateLimit", True))
+        self.ws_enabled = bool(config.get("wsEnabled", True))
         self.options: dict[str, Any] = {}
         self.markets: dict[str, dict] = {}
         self.markets_by_id: dict[str, dict] = {}
@@ -758,6 +759,29 @@ class BitunixClient:
         order_id = str(data.get("orderId") or "")
         if not order_id:
             raise ExchangeError("Bitunix place-order response missing orderId")
+        if order_type == "MARKET":
+            # Bitunix acknowledges placement with identifiers only. A market
+            # order may already be terminal when the response arrives, so do
+            # not fabricate an unpriced open-order row from the request.
+            return {
+                "info": {
+                    **data,
+                    "positionSide": pside.upper(),
+                    "reduceOnly": reduce_only,
+                },
+                "id": order_id,
+                "clientOrderId": str(data.get("clientId") or client_id),
+                "timestamp": self.milliseconds(),
+                "symbol": symbol,
+                "type": "market",
+                "side": str(side).lower(),
+                "price": None,
+                "amount": abs(float(amount)),
+                "filled": None,
+                "remaining": None,
+                "status": None,
+                "reduceOnly": reduce_only,
+            }
         raw = {
             **body,
             **data,
@@ -1122,6 +1146,8 @@ class BitunixClient:
                 reconnect_delay = min(30.0, reconnect_delay * 2.0)
 
     def _ensure_ticker_tasks(self) -> None:
+        if not self.ws_enabled:
+            return
         if self._ticker_tasks and all(
             not task.done() for task in self._ticker_tasks
         ):
@@ -1160,6 +1186,21 @@ class BitunixClient:
         )
         for symbol in desired:
             self.market(symbol)
+        if not self.ws_enabled:
+            if symbols is None:
+                raise NetworkError(
+                    "Bitunix REST-only ticker mode requires explicit symbols"
+                )
+            if len(desired) > self.MAX_DEPTH_FALLBACK_SYMBOLS:
+                raise NetworkError(
+                    "Bitunix REST-only ticker request has "
+                    f"{len(desired)} symbols; depth requests limited to "
+                    f"{self.MAX_DEPTH_FALLBACK_SYMBOLS}"
+                )
+            return {
+                symbol: await self._fetch_depth_ticker(symbol)
+                for symbol in desired
+            }
         self._ensure_ticker_tasks()
         deadline = time.monotonic() + self.TICKER_WAIT_SECONDS
         while time.monotonic() < deadline:
@@ -1399,6 +1440,7 @@ class BitunixBot(CCXTBot):
 
     def create_ccxt_sessions(self) -> None:
         ccxt_config = self._build_ccxt_config()
+        ccxt_config["wsEnabled"] = bool(self.ws_enabled)
         endpoint_override = getattr(self, "endpoint_override", None)
         if endpoint_override is not None:
             unsupported_keys = set(endpoint_override.rest_url_overrides) - {"api"}
@@ -1422,6 +1464,11 @@ class BitunixBot(CCXTBot):
         else:
             self.ccp = None
             logging.info("bitunix: WebSocket disabled, using REST polling")
+
+    def _market_snapshot_ticker_strategy(self) -> str:
+        if not self.ws_enabled:
+            return "symbols"
+        return super()._market_snapshot_ticker_strategy()
 
     async def update_exchange_config(self) -> None:
         current = await self.cca.fetch_position_mode()

--- a/src/exchanges/bitunix.py
+++ b/src/exchanges/bitunix.py
@@ -1,0 +1,1439 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import math
+import re
+import time
+import uuid
+from copy import deepcopy
+from decimal import Decimal
+from typing import Any, Iterable
+from urllib.parse import urlencode
+
+import aiohttp
+from ccxt.base.errors import (
+    AuthenticationError,
+    BadRequest,
+    ExchangeError,
+    InsufficientFunds,
+    InvalidOrder,
+    NetworkError,
+    OrderNotFound,
+    RateLimitExceeded,
+)
+
+from config.access import require_live_value
+from exchanges.ccxt_bot import CCXTBot, format_exchange_config_response
+from passivbot import logging
+from utils import symbol_to_coin
+
+
+def _float(value: Any, *, field: str, default: float | None = None) -> float:
+    if value in (None, ""):
+        if default is not None:
+            return default
+        raise ValueError(f"Bitunix response missing {field}")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"Bitunix response has non-finite {field}")
+    return result
+
+
+def _int(value: Any, *, field: str, default: int | None = None) -> int:
+    if value in (None, ""):
+        if default is not None:
+            return default
+        raise ValueError(f"Bitunix response missing {field}")
+    return int(value)
+
+
+def _decimal_string(value: Any) -> str:
+    decimal = Decimal(str(value))
+    if not decimal.is_finite():
+        raise ValueError("Bitunix request contains a non-finite number")
+    return format(decimal, "f")
+
+
+def _singleton_or_mapping(data: Any, *, endpoint: str) -> dict:
+    if isinstance(data, dict):
+        return data
+    if isinstance(data, list) and len(data) == 1 and isinstance(data[0], dict):
+        return data[0]
+    raise ValueError(f"Bitunix {endpoint} response has invalid data shape")
+
+
+class BitunixClient:
+    """Minimal async Bitunix futures client with a CCXT-compatible live boundary."""
+
+    id = "bitunix"
+    name = "Bitunix"
+    precisionMode = 4  # ccxt.TICK_SIZE
+    # The venue documents 10 requests/sec per UID and IP. Keep headroom for
+    # rolling-window enforcement and other Passivbot account-state consumers.
+    rateLimit = 160
+    version = "v1"
+
+    REST_URL = "https://fapi.bitunix.com"
+    PUBLIC_WS_URL = "wss://fapi.bitunix.com/public/"
+    PRIVATE_WS_URL = "wss://fapi.bitunix.com/private/"
+    MAX_PAGE_SIZE = 100
+    MAX_KLINE_PAGE_SIZE = 200
+    MAX_FILL_PAGES = 1000
+    TICKER_MAX_AGE_MS = 30_000
+
+    has = {
+        "cancelOrder": True,
+        "createOrder": True,
+        "fetchBalance": True,
+        "fetchMyTrades": True,
+        "fetchOHLCV": True,
+        "fetchOpenOrders": True,
+        "fetchOrder": True,
+        "fetchPositions": True,
+        "fetchTickers": True,
+        "setLeverage": True,
+        "setMarginMode": True,
+        "setPositionMode": True,
+        "watchOrders": False,
+    }
+
+    timeframes = {
+        "1m": "1m",
+        "3m": "3m",
+        "5m": "5m",
+        "15m": "15m",
+        "30m": "30m",
+        "1h": "1h",
+        "2h": "2h",
+        "4h": "4h",
+        "6h": "6h",
+        "8h": "8h",
+        "12h": "12h",
+        "1d": "1d",
+        "3d": "3d",
+        "1w": "1w",
+        "1M": "1M",
+    }
+    timeframe_milliseconds = {
+        "1m": 60_000,
+        "3m": 3 * 60_000,
+        "5m": 5 * 60_000,
+        "15m": 15 * 60_000,
+        "30m": 30 * 60_000,
+        "1h": 60 * 60_000,
+        "2h": 2 * 60 * 60_000,
+        "4h": 4 * 60 * 60_000,
+        "6h": 6 * 60 * 60_000,
+        "8h": 8 * 60 * 60_000,
+        "12h": 12 * 60 * 60_000,
+        "1d": 24 * 60 * 60_000,
+        "3d": 3 * 24 * 60 * 60_000,
+        "1w": 7 * 24 * 60 * 60_000,
+        "1M": 30 * 24 * 60 * 60_000,
+    }
+
+    def __init__(self, config: dict | None = None):
+        config = config or {}
+        self.apiKey = str(config.get("apiKey") or config.get("key") or "")
+        self.secret = str(config.get("secret") or "")
+        self.timeout = int(config.get("timeout") or 30_000)
+        self.enableRateLimit = bool(config.get("enableRateLimit", True))
+        self.options: dict[str, Any] = {}
+        self.markets: dict[str, dict] = {}
+        self.markets_by_id: dict[str, dict] = {}
+        self.symbols: list[str] = []
+        self._session: aiohttp.ClientSession | None = None
+        self._rate_lock = asyncio.Lock()
+        self._last_request_monotonic = 0.0
+        self._position_ids: dict[tuple[str, str], str] = {}
+        self._ticker_cache: dict[str, dict] = {}
+        self._ticker_tasks: list[asyncio.Task] = []
+        self._ticker_ready = asyncio.Event()
+        self._closed = False
+
+    def milliseconds(self) -> int:
+        return int(time.time() * 1000)
+
+    def nonce(self) -> int:
+        return self.milliseconds()
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            timeout = aiohttp.ClientTimeout(total=self.timeout / 1000.0)
+            self._session = aiohttp.ClientSession(timeout=timeout)
+        return self._session
+
+    async def _throttle(self, *, cancel: bool = False) -> None:
+        if not self.enableRateLimit:
+            return
+        minimum_spacing = 0.21 if cancel else self.rateLimit / 1000.0
+        async with self._rate_lock:
+            now = time.monotonic()
+            delay = self._last_request_monotonic + minimum_spacing - now
+            if delay > 0.0:
+                await asyncio.sleep(delay)
+            self._last_request_monotonic = time.monotonic()
+
+    def _signed_headers(
+        self,
+        params: dict[str, Any] | None,
+        body_text: str,
+    ) -> dict[str, str]:
+        if not self.apiKey or not self.secret:
+            raise AuthenticationError("Bitunix API key and secret are required")
+        nonce = uuid.uuid4().hex
+        timestamp = str(self.milliseconds())
+        query_text = "".join(
+            f"{key}{value}"
+            for key, value in sorted((params or {}).items())
+            if value is not None
+        )
+        digest = hashlib.sha256(
+            f"{nonce}{timestamp}{self.apiKey}{query_text}{body_text}".encode()
+        ).hexdigest()
+        signature = hashlib.sha256(f"{digest}{self.secret}".encode()).hexdigest()
+        return {
+            "api-key": self.apiKey,
+            "nonce": nonce,
+            "timestamp": timestamp,
+            "sign": signature,
+            "Content-Type": "application/json",
+        }
+
+    @staticmethod
+    def _raise_api_error(code: Any, message: Any) -> None:
+        code_text = str(code)
+        safe_message = str(message or "Bitunix API error")[:240]
+        text = f"Bitunix error {code_text}: {safe_message}"
+        if code_text in {"403", "10003", "10004", "10007"}:
+            raise AuthenticationError(text)
+        if code_text == "10001":
+            raise NetworkError(text)
+        if code_text in {"10005", "10006", "429"}:
+            raise RateLimitExceeded(text)
+        if code_text == "20007":
+            raise OrderNotFound(text)
+        if code_text in {"20003", "20004"}:
+            raise InsufficientFunds(text)
+        if code_text.startswith("3"):
+            raise InvalidOrder(text)
+        if code_text.startswith("2") or code_text.startswith("1"):
+            raise BadRequest(text)
+        raise ExchangeError(text)
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        body: dict[str, Any] | None = None,
+        private: bool = False,
+        cancel: bool = False,
+    ) -> Any:
+        params = {key: value for key, value in (params or {}).items() if value is not None}
+        body_text = (
+            json.dumps(body, separators=(",", ":"), ensure_ascii=False)
+            if body is not None
+            else ""
+        )
+        headers = (
+            self._signed_headers(params, body_text)
+            if private
+            else {"Content-Type": "application/json"}
+        )
+        query = urlencode(sorted(params.items()))
+        url = f"{self.REST_URL}{path}" + (f"?{query}" if query else "")
+        await self._throttle(cancel=cancel)
+        session = await self._get_session()
+        try:
+            async with session.request(
+                method,
+                url,
+                headers=headers,
+                data=body_text if body is not None else None,
+            ) as response:
+                response_text = await response.text()
+                if response.status == 429:
+                    raise RateLimitExceeded("Bitunix HTTP 429")
+                if response.status in {401, 403}:
+                    raise AuthenticationError(f"Bitunix HTTP {response.status}")
+                if response.status >= 400:
+                    raise NetworkError(f"Bitunix HTTP {response.status}")
+        except asyncio.CancelledError:
+            raise
+        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            raise NetworkError(f"Bitunix request failed: {type(exc).__name__}") from exc
+        try:
+            payload = json.loads(response_text)
+        except json.JSONDecodeError as exc:
+            raise NetworkError("Bitunix returned invalid JSON") from exc
+        if not isinstance(payload, dict):
+            raise ExchangeError("Bitunix returned a non-object response")
+        code = payload.get("code")
+        if code not in (0, "0"):
+            self._raise_api_error(code, payload.get("msg"))
+        if "data" not in payload:
+            raise ExchangeError("Bitunix success response missing data")
+        return payload["data"]
+
+    async def load_markets(self, reload: bool = False) -> dict[str, dict]:
+        if self.markets and not reload:
+            return self.markets
+        rows = await self._request(
+            "GET", "/api/v1/futures/market/trading_pairs"
+        )
+        if not isinstance(rows, list):
+            raise ValueError("Bitunix trading-pairs response is not a list")
+        markets: dict[str, dict] = {}
+        markets_by_id: dict[str, dict] = {}
+        for row in rows:
+            if not isinstance(row, dict):
+                raise ValueError("Bitunix trading-pairs response contains a non-object row")
+            market_id = str(row.get("symbol") or "")
+            base = str(row.get("base") or "")
+            quote = str(row.get("quote") or "")
+            if not market_id or not base or not quote:
+                raise ValueError("Bitunix market metadata missing symbol/base/quote")
+            symbol = f"{base}/{quote}:{quote}"
+            amount_precision = _int(
+                row.get("basePrecision"), field=f"{market_id}.basePrecision"
+            )
+            price_precision = _int(
+                row.get("quotePrecision"), field=f"{market_id}.quotePrecision"
+            )
+            amount_step = float(Decimal(1).scaleb(-amount_precision))
+            price_step = float(Decimal(1).scaleb(-price_precision))
+            min_amount = _float(
+                row.get("minTradeVolume"),
+                field=f"{market_id}.minTradeVolume",
+            )
+            max_leverage = _float(
+                row.get("maxLeverage"), field=f"{market_id}.maxLeverage"
+            )
+            min_leverage = _float(
+                row.get("minLeverage"),
+                field=f"{market_id}.minLeverage",
+                default=1.0,
+            )
+            market = {
+                "id": market_id,
+                "symbol": symbol,
+                "base": base,
+                "quote": quote,
+                "settle": quote,
+                "baseId": base,
+                "quoteId": quote,
+                "settleId": quote,
+                "type": "swap",
+                "spot": False,
+                "margin": False,
+                "swap": True,
+                "future": False,
+                "option": False,
+                "contract": True,
+                "linear": True,
+                "inverse": False,
+                "active": (
+                    str(row.get("symbolStatus") or "").upper() == "OPEN"
+                    and row.get("isApiSupported") is True
+                ),
+                "contractSize": 1.0,
+                "precision": {
+                    "amount": amount_step,
+                    "price": price_step,
+                },
+                "limits": {
+                    "amount": {"min": min_amount, "max": None},
+                    "price": {"min": price_step, "max": None},
+                    "cost": {"min": None, "max": None},
+                    "leverage": {"min": min_leverage, "max": max_leverage},
+                },
+                "marginModes": {"cross": True, "isolated": True},
+                "info": deepcopy(row),
+            }
+            markets[symbol] = market
+            markets_by_id[market_id] = market
+        self.markets = markets
+        self.markets_by_id = markets_by_id
+        self.symbols = sorted(markets)
+        return markets
+
+    async def _ensure_markets(self) -> None:
+        if not self.markets:
+            await self.load_markets()
+
+    def market(self, symbol: str) -> dict:
+        if symbol in self.markets:
+            return self.markets[symbol]
+        if symbol in self.markets_by_id:
+            return self.markets_by_id[symbol]
+        raise BadRequest(f"Unknown Bitunix symbol {symbol!r}")
+
+    def safe_symbol(self, market_id: str) -> str:
+        market = self.markets_by_id.get(str(market_id))
+        if market is None:
+            raise ValueError(f"Unknown Bitunix market id {market_id!r}")
+        return str(market["symbol"])
+
+    async def fetch_balance(self, params: dict | None = None) -> dict:
+        raw = _singleton_or_mapping(
+            await self._request(
+                "GET",
+                "/api/v1/futures/account",
+                params={"marginCoin": "USDT"},
+                private=True,
+            ),
+            endpoint="account",
+        )
+        available = _float(raw.get("available"), field="account.available")
+        frozen = _float(raw.get("frozen"), field="account.frozen")
+        margin = _float(raw.get("margin"), field="account.margin")
+        cross_upnl = _float(
+            raw.get("crossUnrealizedPNL"),
+            field="account.crossUnrealizedPNL",
+        )
+        isolated_upnl = _float(
+            raw.get("isolationUnrealizedPNL"),
+            field="account.isolationUnrealizedPNL",
+        )
+        wallet = available + frozen + margin - cross_upnl - isolated_upnl
+        if not math.isfinite(wallet) or wallet < 0.0:
+            raise ValueError("Bitunix account response produced invalid wallet balance")
+        return {
+            "info": raw,
+            "USDT": {"free": available, "used": frozen + margin, "total": wallet},
+            "free": {"USDT": available},
+            "used": {"USDT": frozen + margin},
+            "total": {"USDT": wallet},
+        }
+
+    async def fetch_positions(
+        self, symbols: list[str] | None = None, params: dict | None = None
+    ) -> list[dict]:
+        await self._ensure_markets()
+        requested_ids = (
+            {self.market(symbol)["id"] for symbol in symbols} if symbols else None
+        )
+        query = dict(params or {})
+        if requested_ids and len(requested_ids) == 1:
+            query["symbol"] = next(iter(requested_ids))
+        rows = await self._request(
+            "GET",
+            "/api/v1/futures/position/get_pending_positions",
+            params=query,
+            private=True,
+        )
+        if not isinstance(rows, list):
+            raise ValueError("Bitunix positions response is not a list")
+        positions = []
+        fresh_ids: dict[tuple[str, str], str] = {}
+        for row in rows:
+            market_id = str(row.get("symbol") or "")
+            if requested_ids and market_id not in requested_ids:
+                continue
+            raw_side = str(row.get("side") or "").upper().rstrip("_")
+            side_aliases = {
+                "LONG": "long",
+                "BUY": "long",
+                "SHORT": "short",
+                "SELL": "short",
+            }
+            pside = side_aliases.get(raw_side)
+            if pside is None:
+                raise ValueError(
+                    "Bitunix position missing LONG/SHORT or BUY/SELL side"
+                )
+            symbol = self.safe_symbol(market_id)
+            position_id = str(row.get("positionId") or "")
+            if not position_id:
+                raise ValueError("Bitunix open position missing positionId")
+            fresh_ids[(symbol, pside)] = position_id
+            contracts = abs(_float(row.get("qty"), field="position.qty"))
+            raw_margin_mode = str(row.get("marginMode") or "").upper()
+            if raw_margin_mode not in {"CROSS", "ISOLATION"}:
+                raise ValueError(
+                    "Bitunix position missing CROSS/ISOLATION margin mode"
+                )
+            positions.append(
+                {
+                    "info": deepcopy(row),
+                    "id": position_id,
+                    "symbol": symbol,
+                    "timestamp": _int(
+                        row.get("ctime"), field="position.ctime", default=0
+                    ),
+                    "lastUpdateTimestamp": _int(
+                        row.get("mtime"), field="position.mtime", default=0
+                    ),
+                    "side": pside,
+                    "contracts": contracts,
+                    "contractSize": 1.0,
+                    "entryPrice": _float(
+                        row.get("avgOpenPrice") or row.get("entryPrice"),
+                        field="position.avgOpenPrice",
+                        default=0.0,
+                    ),
+                    "markPrice": None,
+                    "notional": _float(
+                        row.get("entryValue"),
+                        field="position.entryValue",
+                        default=0.0,
+                    ),
+                    "leverage": _float(
+                        row.get("leverage"), field="position.leverage", default=0.0
+                    ),
+                    "unrealizedPnl": _float(
+                        row.get("unrealizedPNL"),
+                        field="position.unrealizedPNL",
+                        default=0.0,
+                    ),
+                    "realizedPnl": _float(
+                        row.get("realizedPNL"),
+                        field="position.realizedPNL",
+                        default=0.0,
+                    ),
+                    "marginMode": (
+                        "isolated"
+                        if raw_margin_mode == "ISOLATION"
+                        else "cross"
+                    ),
+                }
+            )
+        if requested_ids is None:
+            self._position_ids = fresh_ids
+        else:
+            for key in [
+                key
+                for key in self._position_ids
+                if self.market(key[0])["id"] in requested_ids
+            ]:
+                self._position_ids.pop(key, None)
+            self._position_ids.update(fresh_ids)
+        return positions
+
+    @staticmethod
+    def _order_status(raw_status: Any) -> str:
+        # Live REST currently emits ``NEW_`` although the public schema says
+        # ``NEW``.  Treat only trailing enum padding as equivalent.
+        status = str(raw_status or "").upper().rstrip("_")
+        mapping = {
+            "INIT": "open",
+            "NEW": "open",
+            "PART_FILLED": "open",
+            "FILLED": "closed",
+            "CANCELED": "canceled",
+            "PART_FILLED_CANCELED": "canceled",
+        }
+        if status not in mapping:
+            raise ValueError(f"Unknown Bitunix order status {status!r}")
+        return mapping[status]
+
+    def _normalize_order(self, row: dict) -> dict:
+        market_id = str(row.get("symbol") or "")
+        symbol = self.safe_symbol(market_id)
+        raw_side = str(row.get("side") or "").upper()
+        position_mode = str(row.get("positionMode") or "").upper()
+        if position_mode not in {"HEDGE", "ONE_WAY"}:
+            raise ValueError("Bitunix order missing HEDGE/ONE_WAY position mode")
+        reduce_only = row.get("reduceOnly")
+        if not isinstance(reduce_only, bool):
+            raise ValueError("Bitunix order missing boolean reduceOnly")
+        if position_mode == "HEDGE":
+            if raw_side not in {"BUY", "SELL"}:
+                raise ValueError("Bitunix hedge order missing BUY/SELL action side")
+            action_side = raw_side.lower()
+            pside = (
+                ("short" if action_side == "buy" else "long")
+                if reduce_only
+                else ("long" if action_side == "buy" else "short")
+            )
+        else:
+            action_side = raw_side.lower()
+            if action_side not in {"buy", "sell"}:
+                raise ValueError("Bitunix order missing buy/sell side")
+            pside = (
+                ("short" if action_side == "buy" else "long")
+                if reduce_only
+                else ("long" if action_side == "buy" else "short")
+            )
+        qty = abs(_float(row.get("qty"), field="order.qty"))
+        filled = abs(
+            _float(
+                row.get("tradeQty") or row.get("dealAmount"),
+                field="order.tradeQty",
+                default=0.0,
+            )
+        )
+        price = _float(row.get("price"), field="order.price", default=0.0)
+        timestamp = _int(row.get("ctime"), field="order.ctime")
+        order_id = str(row.get("orderId") or "")
+        if not order_id:
+            raise ValueError("Bitunix order missing orderId")
+        order_type = str(
+            row.get("orderType") or row.get("type") or ""
+        ).lower()
+        if order_type not in {"limit", "market"}:
+            raise ValueError("Bitunix order missing LIMIT/MARKET order type")
+        info = deepcopy(row)
+        info["positionSide"] = pside.upper()
+        info["reduceOnly"] = reduce_only
+        return {
+            "info": info,
+            "id": order_id,
+            "clientOrderId": str(row.get("clientId") or ""),
+            "timestamp": timestamp,
+            "lastTradeTimestamp": _int(
+                row.get("mtime"), field="order.mtime", default=timestamp
+            ),
+            "symbol": symbol,
+            "type": order_type,
+            "timeInForce": str(row.get("effect") or "").upper() or None,
+            "postOnly": str(row.get("effect") or "").upper() == "POST_ONLY",
+            "reduceOnly": reduce_only,
+            "side": action_side,
+            "price": price,
+            "amount": qty,
+            "filled": filled,
+            "remaining": max(0.0, qty - filled),
+            "average": _float(
+                row.get("averagePrice"),
+                field="order.averagePrice",
+                default=0.0,
+            )
+            or None,
+            "status": self._order_status(row.get("status") or row.get("orderStatus")),
+            "fee": (
+                {
+                    "currency": "USDT",
+                    "cost": abs(_float(row.get("fee"), field="order.fee")),
+                }
+                if row.get("fee") not in (None, "")
+                else None
+            ),
+        }
+
+    async def _fetch_order_page(
+        self, symbol: str | None, skip: int, limit: int
+    ) -> tuple[list[dict], int]:
+        await self._ensure_markets()
+        params: dict[str, Any] = {"skip": skip, "limit": limit}
+        if symbol:
+            params["symbol"] = self.market(symbol)["id"]
+        data = await self._request(
+            "GET",
+            "/api/v1/futures/trade/get_pending_orders",
+            params=params,
+            private=True,
+        )
+        if not isinstance(data, dict) or not isinstance(data.get("orderList"), list):
+            raise ValueError("Bitunix open-orders response has invalid shape")
+        return data["orderList"], int(data.get("total") or 0)
+
+    async def fetch_open_orders(
+        self,
+        symbol: str | None = None,
+        since: int | None = None,
+        limit: int | None = None,
+        params: dict | None = None,
+    ) -> list[dict]:
+        page_size = min(self.MAX_PAGE_SIZE, max(1, int(limit or self.MAX_PAGE_SIZE)))
+        rows: list[dict] = []
+        skip = 0
+        while True:
+            page, total = await self._fetch_order_page(symbol, skip, page_size)
+            rows.extend(page)
+            skip += len(page)
+            if not page or skip >= total or len(page) < page_size:
+                break
+        return sorted((self._normalize_order(row) for row in rows), key=lambda x: x["timestamp"])
+
+    async def fetch_order(
+        self, order_id: str, symbol: str | None = None, params: dict | None = None
+    ) -> dict:
+        query = {"orderId": str(order_id)}
+        if not order_id and params and params.get("clientId"):
+            query = {"clientId": str(params["clientId"])}
+        row = await self._request(
+            "GET",
+            "/api/v1/futures/trade/get_order_detail",
+            params=query,
+            private=True,
+        )
+        return self._normalize_order(_singleton_or_mapping(row, endpoint="order detail"))
+
+    async def _position_id(self, symbol: str, pside: str) -> str:
+        position_id = self._position_ids.get((symbol, pside))
+        if position_id:
+            return position_id
+        await self.fetch_positions([symbol])
+        position_id = self._position_ids.get((symbol, pside))
+        if not position_id:
+            raise InvalidOrder(
+                f"Bitunix close for {symbol} {pside} has no live positionId"
+            )
+        return position_id
+
+    async def create_order(
+        self,
+        symbol: str,
+        type: str,
+        side: str,
+        amount: float,
+        price: float | None = None,
+        params: dict | None = None,
+    ) -> dict:
+        await self._ensure_markets()
+        params = dict(params or {})
+        pside = str(params.pop("positionSide", "")).lower()
+        if pside not in {"long", "short"}:
+            raise InvalidOrder("Bitunix order requires LONG/SHORT positionSide")
+        reduce_only = bool(params.pop("reduceOnly", False))
+        trade_side = "CLOSE" if reduce_only else "OPEN"
+        raw_side = "BUY" if pside == "long" else "SELL"
+        order_type = str(type).upper()
+        if order_type not in {"LIMIT", "MARKET"}:
+            raise InvalidOrder(f"Unsupported Bitunix order type {type!r}")
+        body: dict[str, Any] = {
+            "symbol": self.market(symbol)["id"],
+            "qty": _decimal_string(abs(amount)),
+            "side": raw_side,
+            "tradeSide": trade_side,
+            "orderType": order_type,
+            "reduceOnly": reduce_only,
+        }
+        if order_type == "LIMIT":
+            if price is None or float(price) <= 0.0:
+                raise InvalidOrder("Bitunix limit order requires a positive price")
+            body["price"] = _decimal_string(price)
+            body["effect"] = str(
+                params.pop("effect", params.pop("timeInForce", "GTC"))
+            ).upper()
+        client_id = str(params.pop("clientOrderId", params.pop("clientId", "")))
+        if client_id:
+            body["clientId"] = client_id
+        if reduce_only:
+            body["positionId"] = str(
+                params.pop("positionId", "")
+                or await self._position_id(symbol, pside)
+            )
+        if params:
+            raise InvalidOrder(
+                f"Unsupported Bitunix order params: {','.join(sorted(params))}"
+            )
+        data = _singleton_or_mapping(
+            await self._request(
+                "POST",
+                "/api/v1/futures/trade/place_order",
+                body=body,
+                private=True,
+            ),
+            endpoint="place order",
+        )
+        order_id = str(data.get("orderId") or "")
+        if not order_id:
+            raise ExchangeError("Bitunix place-order response missing orderId")
+        raw = {
+            **body,
+            **data,
+            # The placement request uses Bitunix's hedge-position side, while
+            # order responses expose the actual buy/sell action.
+            "side": str(side).upper(),
+            "positionMode": "HEDGE",
+            "marginMode": "",
+            "status": "NEW",
+            "ctime": self.milliseconds(),
+            "tradeQty": "0",
+        }
+        return self._normalize_order(raw)
+
+    async def cancel_order(
+        self, order_id: str, symbol: str | None = None, params: dict | None = None
+    ) -> dict:
+        if not symbol:
+            raise BadRequest("Bitunix cancel_order requires symbol")
+        body = {
+            "symbol": self.market(symbol)["id"],
+            "orderList": [{"orderId": str(order_id)}],
+        }
+        data = await self._request(
+            "POST",
+            "/api/v1/futures/trade/cancel_orders",
+            body=body,
+            private=True,
+            cancel=True,
+        )
+        if not isinstance(data, dict):
+            raise ExchangeError("Bitunix cancel response has invalid shape")
+        success = data.get("successList") or []
+        failures = data.get("failureList") or []
+        succeeded = any(
+            str(row.get("orderId") or "") == str(order_id)
+            for row in success
+            if isinstance(row, dict)
+        )
+        if not succeeded:
+            failure = next(
+                (
+                    row
+                    for row in failures
+                    if isinstance(row, dict)
+                    and str(row.get("orderId") or "") == str(order_id)
+                ),
+                {},
+            )
+            code = failure.get("errorCode") or failure.get("code") or "20007"
+            self._raise_api_error(code, failure.get("errorMsg") or failure.get("msg"))
+        return {
+            "id": str(order_id),
+            "symbol": symbol,
+            "status": "canceled",
+            "info": deepcopy(data),
+        }
+
+    def _normalize_trade(self, row: dict) -> dict:
+        market_id = str(row.get("symbol") or "")
+        symbol = self.safe_symbol(market_id)
+        raw_side = str(row.get("side") or "").upper()
+        position_mode = str(row.get("positionMode") or "").upper()
+        if position_mode not in {"HEDGE", "ONE_WAY"}:
+            raise ValueError("Bitunix fill missing HEDGE/ONE_WAY position mode")
+        reduce_only = row.get("reduceOnly")
+        if not isinstance(reduce_only, bool):
+            raise ValueError("Bitunix fill missing boolean reduceOnly")
+        if position_mode == "HEDGE":
+            if raw_side not in {"BUY", "SELL"}:
+                raise ValueError("Bitunix fill missing BUY/SELL action side")
+            action_side = raw_side.lower()
+            pside = (
+                ("short" if action_side == "buy" else "long")
+                if reduce_only
+                else ("long" if action_side == "buy" else "short")
+            )
+        else:
+            action_side = raw_side.lower()
+            if action_side not in {"buy", "sell"}:
+                raise ValueError("Bitunix fill missing buy/sell side")
+            pside = (
+                ("short" if action_side == "buy" else "long")
+                if reduce_only
+                else ("long" if action_side == "buy" else "short")
+            )
+        trade_id = str(row.get("tradeId") or "")
+        order_id = str(row.get("orderId") or "")
+        if not trade_id or not order_id:
+            raise ValueError("Bitunix fill missing tradeId/orderId")
+        qty = abs(_float(row.get("qty"), field="fill.qty"))
+        price = _float(row.get("price"), field="fill.price")
+        timestamp = _int(row.get("ctime"), field="fill.ctime")
+        fee = _float(row.get("fee"), field="fill.fee", default=0.0)
+        info = deepcopy(row)
+        info["positionSide"] = pside.upper()
+        info["reduceOnly"] = reduce_only
+        return {
+            "info": info,
+            "id": trade_id,
+            "order": order_id,
+            "timestamp": timestamp,
+            "symbol": symbol,
+            "type": str(row.get("orderType") or row.get("type") or "").lower(),
+            "side": action_side,
+            "takerOrMaker": str(row.get("roleType") or "").lower() or None,
+            "price": price,
+            "amount": qty,
+            "cost": qty * price,
+            "fee": {"currency": "USDT", "cost": abs(fee)},
+            "fees": [{"currency": "USDT", "cost": abs(fee)}],
+            "clientOrderId": str(row.get("clientId") or ""),
+        }
+
+    async def fetch_my_trades(
+        self,
+        symbol: str | None = None,
+        since: int | None = None,
+        limit: int | None = None,
+        params: dict | None = None,
+    ) -> list[dict]:
+        await self._ensure_markets()
+        params = dict(params or {})
+        until = params.pop("until", None)
+        page_size = min(self.MAX_PAGE_SIZE, max(1, int(limit or self.MAX_PAGE_SIZE)))
+        query: dict[str, Any] = {"skip": 0, "limit": page_size}
+        if symbol:
+            query["symbol"] = self.market(symbol)["id"]
+        if since is not None:
+            query["startTime"] = int(since)
+        if until is not None:
+            query["endTime"] = int(until)
+        query.update(params)
+        rows: dict[str, dict] = {}
+        for _ in range(self.MAX_FILL_PAGES):
+            data = await self._request(
+                "GET",
+                "/api/v1/futures/trade/get_history_trades",
+                params=dict(query),
+                private=True,
+            )
+            if not isinstance(data, dict) or not isinstance(data.get("tradeList"), list):
+                raise ValueError("Bitunix fill-history response has invalid shape")
+            page = data["tradeList"]
+            for row in page:
+                trade_id = str(row.get("tradeId") or "")
+                if not trade_id:
+                    raise ValueError("Bitunix fill-history row missing tradeId")
+                rows[trade_id] = row
+            query["skip"] += len(page)
+            total = int(data.get("total") or 0)
+            if not page or query["skip"] >= total or len(page) < page_size:
+                break
+        else:
+            raise RuntimeError("Bitunix fill-history pagination exceeded safety limit")
+        return sorted(
+            (self._normalize_trade(row) for row in rows.values()),
+            key=lambda trade: trade["timestamp"],
+        )
+
+    async def fetch_ohlcv(
+        self,
+        symbol: str,
+        timeframe: str = "1m",
+        since: int | None = None,
+        limit: int | None = None,
+        params: dict | None = None,
+    ) -> list[list[float]]:
+        await self._ensure_markets()
+        if timeframe not in self.timeframes:
+            raise BadRequest(f"Unsupported Bitunix OHLCV timeframe {timeframe!r}")
+        request_limit = min(
+            self.MAX_KLINE_PAGE_SIZE,
+            max(1, int(limit or self.MAX_KLINE_PAGE_SIZE)),
+        )
+        query: dict[str, Any] = {
+            "symbol": self.market(symbol)["id"],
+            "interval": self.timeframes[timeframe],
+            "limit": request_limit,
+            "type": "LAST_PRICE",
+        }
+        if since is not None:
+            query["startTime"] = int(since)
+        params = dict(params or {})
+        requested_until = params.pop("until", None)
+        if since is not None:
+            # Bitunix ignores startTime for page anchoring and always returns
+            # the rows immediately preceding endTime. Derive an end bound from
+            # CCXT's forward-page contract so live pagination cannot skip to
+            # the newest tail.
+            derived_until = (
+                int(since)
+                + request_limit * self.timeframe_milliseconds[timeframe]
+            )
+            query["endTime"] = min(
+                derived_until,
+                int(requested_until)
+                if requested_until is not None
+                else derived_until,
+            )
+        elif requested_until is not None:
+            query["endTime"] = int(requested_until)
+        query.update(params)
+        rows = await self._request(
+            "GET", "/api/v1/futures/market/kline", params=query
+        )
+        if not isinstance(rows, list):
+            raise ValueError("Bitunix kline response is not a list")
+        normalized: dict[int, list[float]] = {}
+        for row in rows:
+            timestamp = _int(row.get("time"), field="kline.time")
+            if since is not None and timestamp < int(since):
+                continue
+            if query.get("endTime") is not None and timestamp > int(query["endTime"]):
+                continue
+            normalized[timestamp] = [
+                timestamp,
+                _float(row.get("open"), field="kline.open"),
+                _float(row.get("high"), field="kline.high"),
+                _float(row.get("low"), field="kline.low"),
+                _float(row.get("close"), field="kline.close"),
+                # Bitunix's live payload names are inverted relative to their
+                # units: quoteVol is base quantity, while baseVol is quote
+                # notional (baseVol / quoteVol is approximately price).
+                _float(row.get("quoteVol"), field="kline.quoteVol", default=0.0),
+            ]
+        return [normalized[key] for key in sorted(normalized)]
+
+    async def _fetch_depth_ticker(self, symbol: str) -> dict:
+        data = await self._request(
+            "GET",
+            "/api/v1/futures/market/depth",
+            params={"symbol": self.market(symbol)["id"], "limit": 1},
+        )
+        if not isinstance(data, dict):
+            raise ValueError("Bitunix depth response has invalid shape")
+        bids = data.get("bids") or []
+        asks = data.get("asks") or []
+        if not bids or not asks:
+            raise ValueError(f"Bitunix depth missing top of book for {symbol}")
+        bid = _float(bids[0][0], field="depth.bid")
+        ask = _float(asks[0][0], field="depth.ask")
+        if bid <= 0.0 or ask <= 0.0 or bid > ask:
+            raise ValueError(f"Bitunix depth returned invalid top of book for {symbol}")
+        return {
+            "symbol": symbol,
+            "bid": bid,
+            "ask": ask,
+            "last": (bid + ask) / 2.0,
+            "timestamp": self.milliseconds(),
+            "info": data,
+        }
+
+    async def _ticker_loop(self, market_ids: tuple[str, ...]) -> None:
+        reconnect_delay = 1.0
+        while not self._closed:
+            try:
+                await self._ensure_markets()
+                if not market_ids:
+                    raise ValueError("Bitunix has no active websocket ticker symbols")
+                session = await self._get_session()
+                async with session.ws_connect(
+                    self.PUBLIC_WS_URL, heartbeat=20.0, receive_timeout=45.0
+                ) as ws:
+                    await ws.send_json(
+                        {
+                            "op": "subscribe",
+                            "args": [
+                                {"symbol": market_id, "ch": "tickers"}
+                                for market_id in market_ids
+                            ],
+                        }
+                    )
+                    reconnect_delay = 1.0
+                    async for message in ws:
+                        if message.type == aiohttp.WSMsgType.TEXT:
+                            payload = json.loads(message.data)
+                            if payload.get("ch") != "tickers":
+                                continue
+                            data = payload.get("data")
+                            rows = data if isinstance(data, list) else [data]
+                            timestamp = int(payload.get("ts") or self.milliseconds())
+                            for row in rows:
+                                if not isinstance(row, dict):
+                                    continue
+                                market_id = str(row.get("s") or "")
+                                market = self.markets_by_id.get(market_id)
+                                if market is None:
+                                    continue
+                                bid = _float(row.get("bd"), field="ticker.bd")
+                                ask = _float(row.get("ak"), field="ticker.ak")
+                                last = _float(row.get("la"), field="ticker.la")
+                                if bid <= 0.0 or ask <= 0.0 or last <= 0.0 or bid > ask:
+                                    continue
+                                self._ticker_cache[market["symbol"]] = {
+                                    "symbol": market["symbol"],
+                                    "bid": bid,
+                                    "ask": ask,
+                                    "last": last,
+                                    "timestamp": timestamp,
+                                    "info": deepcopy(row),
+                                }
+                            if self._ticker_cache:
+                                self._ticker_ready.set()
+                        elif message.type in {
+                            aiohttp.WSMsgType.CLOSED,
+                            aiohttp.WSMsgType.ERROR,
+                        }:
+                            break
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logging.debug(
+                    "[ws] bitunix public ticker reconnect | error_type=%s",
+                    type(exc).__name__,
+                )
+                await asyncio.sleep(reconnect_delay)
+                reconnect_delay = min(30.0, reconnect_delay * 2.0)
+
+    def _ensure_ticker_tasks(self) -> None:
+        if self._ticker_tasks and all(
+            not task.done() for task in self._ticker_tasks
+        ):
+            return
+        for task in self._ticker_tasks:
+            task.cancel()
+        self._ticker_tasks = []
+        self._ticker_ready.clear()
+        market_ids = [
+            str(market["id"])
+            for market in self.markets.values()
+            if market.get("active")
+        ]
+        for index in range(0, len(market_ids), 300):
+            chunk = tuple(market_ids[index : index + 300])
+            self._ticker_tasks.append(
+                asyncio.create_task(
+                    self._ticker_loop(chunk),
+                    name=f"bitunix-public-tickers-{index // 300 + 1}",
+                )
+            )
+
+    async def fetch_tickers(
+        self, symbols: list[str] | None = None, params: dict | None = None
+    ) -> dict[str, dict]:
+        await self._ensure_markets()
+        desired = list(
+            dict.fromkeys(
+                symbols
+                or [
+                    symbol
+                    for symbol, market in self.markets.items()
+                    if market.get("active")
+                ]
+            )
+        )
+        for symbol in desired:
+            self.market(symbol)
+        self._ensure_ticker_tasks()
+        deadline = time.monotonic() + 8.0
+        while time.monotonic() < deadline:
+            now = self.milliseconds()
+            if all(
+                symbol in self._ticker_cache
+                and now - int(self._ticker_cache[symbol]["timestamp"])
+                <= self.TICKER_MAX_AGE_MS
+                for symbol in desired
+            ):
+                break
+            try:
+                await asyncio.wait_for(
+                    self._ticker_ready.wait(),
+                    timeout=min(0.25, max(0.0, deadline - time.monotonic())),
+                )
+                self._ticker_ready.clear()
+            except asyncio.TimeoutError:
+                pass
+        now = self.milliseconds()
+        result = {
+            symbol: deepcopy(self._ticker_cache[symbol])
+            for symbol in desired
+            if symbol in self._ticker_cache
+            and now - int(self._ticker_cache[symbol]["timestamp"])
+            <= self.TICKER_MAX_AGE_MS
+        }
+        if symbols:
+            for symbol in desired:
+                if symbol not in result:
+                    result[symbol] = await self._fetch_depth_ticker(symbol)
+        if not result:
+            raise NetworkError("Bitunix ticker websocket produced no current quotes")
+        return result
+
+    async def fetch_position_mode(self) -> dict:
+        raw = _singleton_or_mapping(
+            await self._request(
+                "GET",
+                "/api/v1/futures/account",
+                params={"marginCoin": "USDT"},
+                private=True,
+            ),
+            endpoint="account",
+        )
+        mode = str(raw.get("positionMode") or "").upper()
+        if mode not in {"HEDGE", "ONE_WAY"}:
+            raise ValueError("Bitunix account response missing positionMode")
+        return {"hedged": mode == "HEDGE", "info": raw}
+
+    async def set_position_mode(
+        self, hedged: bool, symbol: str | None = None, params: dict | None = None
+    ) -> dict:
+        mode = "HEDGE" if hedged else "ONE_WAY"
+        data = await self._request(
+            "POST",
+            "/api/v1/futures/account/change_position_mode",
+            body={"positionMode": mode},
+            private=True,
+        )
+        return {"code": 0, "positionMode": mode, "info": data}
+
+    async def fetch_leverage_margin_mode(self, symbol: str) -> dict:
+        data = await self._request(
+            "GET",
+            "/api/v1/futures/account/get_leverage_margin_mode",
+            params={"symbol": self.market(symbol)["id"], "marginCoin": "USDT"},
+            private=True,
+        )
+        return _singleton_or_mapping(data, endpoint="leverage/margin mode")
+
+    async def set_margin_mode(
+        self, margin_mode: str, symbol: str | None = None, params: dict | None = None
+    ) -> dict:
+        if not symbol:
+            raise BadRequest("Bitunix set_margin_mode requires symbol")
+        normalized = str(margin_mode).lower()
+        if normalized not in {"cross", "isolated", "isolation"}:
+            raise BadRequest(f"Invalid Bitunix margin mode {margin_mode!r}")
+        raw_mode = "CROSS" if normalized == "cross" else "ISOLATION"
+        data = await self._request(
+            "POST",
+            "/api/v1/futures/account/change_margin_mode",
+            body={
+                "symbol": self.market(symbol)["id"],
+                "marginCoin": "USDT",
+                "marginMode": raw_mode,
+            },
+            private=True,
+        )
+        return {"code": 0, "marginMode": raw_mode, "info": data}
+
+    async def set_leverage(
+        self, leverage: int, symbol: str | None = None, params: dict | None = None
+    ) -> dict:
+        if not symbol:
+            raise BadRequest("Bitunix set_leverage requires symbol")
+        leverage_int = int(leverage)
+        data = await self._request(
+            "POST",
+            "/api/v1/futures/account/change_leverage",
+            body={
+                "symbol": self.market(symbol)["id"],
+                "marginCoin": "USDT",
+                "leverage": leverage_int,
+            },
+            private=True,
+        )
+        return {"code": 0, "leverage": leverage_int, "info": data}
+
+    async def close(self) -> None:
+        self._closed = True
+        for task in self._ticker_tasks:
+            task.cancel()
+        if self._ticker_tasks:
+            await asyncio.gather(*self._ticker_tasks, return_exceptions=True)
+        if self._session is not None and not self._session.closed:
+            await self._session.close()
+
+
+class BitunixOrderStream:
+    """Private Bitunix order websocket enriched through authoritative REST detail."""
+
+    id = "bitunix"
+    has = {"watchOrders": True}
+
+    def __init__(self, rest: BitunixClient):
+        self.rest = rest
+        self.options: dict[str, Any] = {}
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+
+    def _login_payload(self) -> dict:
+        if not self.rest.apiKey or not self.rest.secret:
+            raise AuthenticationError("Bitunix API key and secret are required")
+        nonce = uuid.uuid4().hex
+        timestamp = int(time.time())
+        digest = hashlib.sha256(
+            f"{nonce}{timestamp}{self.rest.apiKey}".encode()
+        ).hexdigest()
+        signature = hashlib.sha256(
+            f"{digest}{self.rest.secret}".encode()
+        ).hexdigest()
+        return {
+            "op": "login",
+            "args": [
+                {
+                    "apiKey": self.rest.apiKey,
+                    "timestamp": timestamp,
+                    "nonce": nonce,
+                    "sign": signature,
+                }
+            ],
+        }
+
+    async def _connect(self) -> aiohttp.ClientWebSocketResponse:
+        session = await self.rest._get_session()
+        ws = await session.ws_connect(
+            self.rest.PRIVATE_WS_URL, heartbeat=20.0, receive_timeout=45.0
+        )
+        await ws.send_json(self._login_payload())
+        while True:
+            message = await ws.receive()
+            if message.type != aiohttp.WSMsgType.TEXT:
+                await ws.close()
+                raise NetworkError("Bitunix private websocket closed during login")
+            payload = json.loads(message.data)
+            if payload.get("op") == "login":
+                if payload.get("code") not in (None, 0, "0") or payload.get("success") is False:
+                    await ws.close()
+                    raise AuthenticationError("Bitunix private websocket login failed")
+                break
+        await ws.send_json({"op": "subscribe", "args": [{"ch": "order"}]})
+        self._ws = ws
+        return ws
+
+    async def watch_orders(self) -> list[dict]:
+        ws = self._ws
+        if ws is None or ws.closed:
+            ws = await self._connect()
+        while True:
+            message = await ws.receive()
+            if message.type == aiohttp.WSMsgType.TEXT:
+                payload = json.loads(message.data)
+                if payload.get("ch") != "order":
+                    continue
+                data = payload.get("data")
+                rows = data if isinstance(data, list) else [data]
+                enriched = []
+                for row in rows:
+                    if not isinstance(row, dict) or not row.get("orderId"):
+                        continue
+                    try:
+                        enriched.append(
+                            await self.rest.fetch_order(
+                                str(row["orderId"]),
+                                self.rest.safe_symbol(str(row.get("symbol") or "")),
+                            )
+                        )
+                    except OrderNotFound:
+                        continue
+                if enriched:
+                    return enriched
+            elif message.type in {
+                aiohttp.WSMsgType.CLOSED,
+                aiohttp.WSMsgType.ERROR,
+            }:
+                self._ws = None
+                raise NetworkError("Bitunix private order websocket disconnected")
+
+    async def close(self) -> None:
+        if self._ws is not None and not self._ws.closed:
+            await self._ws.close()
+        self._ws = None
+
+
+class BitunixBot(CCXTBot):
+    """Bitunix USDT-margined perpetual-futures connector."""
+
+    MAX_OPEN_ORDERS = 100
+    CLIENT_ORDER_ID_PATTERN = re.compile(r"^[.A-Z:/a-z0-9_-]{1,36}$")
+
+    def __init__(self, config: dict):
+        super().__init__(config)
+        self.custom_id_max_length = 36
+        self.quote = "USDT"
+        self.hedge_mode = True
+
+    def create_ccxt_sessions(self) -> None:
+        ccxt_config = self._build_ccxt_config()
+        self.cca = BitunixClient(ccxt_config)
+        self.cca.options.update(self.user_info.get("options", {}))
+        if self.ws_enabled:
+            self.ccp = BitunixOrderStream(self.cca)
+        else:
+            self.ccp = None
+            logging.info("bitunix: WebSocket disabled, using REST polling")
+
+    async def update_exchange_config(self) -> None:
+        current = await self.cca.fetch_position_mode()
+        if current.get("hedged") is True:
+            logging.debug("[config] bitunix account already uses HEDGE position mode")
+            return
+        result = await self.cca.set_position_mode(True)
+        logging.info(
+            "[config] bitunix set HEDGE position mode result=%s",
+            format_exchange_config_response(result),
+        )
+
+    async def update_exchange_config_by_symbols(self, symbols: Iterable[str]) -> None:
+        for symbol in symbols:
+            current = await self.cca.fetch_leverage_margin_mode(symbol)
+            current_mode = str(current.get("marginMode") or "").upper()
+            desired_mode = self._get_margin_mode_for_symbol(symbol)
+            desired_raw_mode = "CROSS" if desired_mode == "cross" else "ISOLATION"
+            log_symbol = symbol_to_coin(symbol, verbose=False) or symbol
+            margin_mode_changed = current_mode != desired_raw_mode
+            if margin_mode_changed:
+                result = await self.cca.set_margin_mode(desired_mode, symbol)
+                logging.info(
+                    "[config] %s set Bitunix %s margin result=%s",
+                    log_symbol,
+                    desired_mode,
+                    format_exchange_config_response(result),
+                )
+            leverage = self._calc_leverage_for_symbol(symbol)
+            raw_leverages = [
+                current.get("leverage"),
+                current.get("longLeverage"),
+                current.get("shortLeverage"),
+            ]
+            known = {
+                int(float(value))
+                for value in raw_leverages
+                if value not in (None, "")
+            }
+            if margin_mode_changed or known != {leverage}:
+                result = await self.cca.set_leverage(leverage, symbol)
+                logging.info(
+                    "[config] %s set Bitunix leverage=%sx result=%s",
+                    log_symbol,
+                    leverage,
+                    format_exchange_config_response(result),
+                )
+
+    def set_market_specific_settings(self) -> None:
+        super().set_market_specific_settings()
+        for symbol in sorted(self.symbols_requiring_market_sizing()):
+            raw = self.markets_dict[symbol].get("info") or {}
+            max_leverage = _float(
+                raw.get("maxLeverage"), field=f"{symbol}.maxLeverage"
+            )
+            self.max_leverage[symbol] = int(max_leverage)
+
+    def _build_order_params(self, order: dict) -> dict:
+        position_side = str(order.get("position_side") or "").lower()
+        if position_side not in {"long", "short"}:
+            raise ValueError(
+                f"Bitunix order has invalid position_side: {position_side!r}"
+            )
+        client_order_id = str(order.get("custom_id") or "")
+        if not self.CLIENT_ORDER_ID_PATTERN.fullmatch(client_order_id):
+            raise ValueError(
+                "Bitunix client order id must match ^[.A-Z:/a-z0-9_-]{1,36}$"
+            )
+        params = {
+            "positionSide": position_side.upper(),
+            "clientOrderId": client_order_id,
+            "reduceOnly": bool(order.get("reduce_only")),
+        }
+        if order.get("type", "limit") == "limit":
+            params["effect"] = (
+                "POST_ONLY"
+                if require_live_value(self.config, "time_in_force") == "post_only"
+                else "GTC"
+            )
+        return params
+
+    def _get_position_side_for_order(self, order: dict) -> str:
+        info = order.get("info") or {}
+        position_side = str(info.get("positionSide") or "").lower()
+        if position_side not in {"long", "short"}:
+            raise ValueError("Bitunix order missing explicit LONG/SHORT positionSide")
+        return position_side
+
+    def _canonical_open_order_reduce_only(self, order: dict) -> bool:
+        raw = (order.get("info") or {}).get("reduceOnly")
+        if not isinstance(raw, bool):
+            raise ValueError("Bitunix open order missing boolean reduceOnly")
+        return raw
+
+    def _get_position_side_from_trade(self, trade: dict) -> str:
+        position_side = str(
+            (trade.get("info") or {}).get("positionSide") or ""
+        ).lower()
+        if position_side not in {"long", "short"}:
+            raise ValueError("Bitunix fill missing explicit LONG/SHORT positionSide")
+        return position_side
+
+    async def close(self) -> None:
+        self.stop_data_maintainers()
+        if self.ccp is not None:
+            await self.ccp.close()
+        await self.cca.close()
+        self._close_live_event_pipeline(timeout=2.0)

--- a/src/exchanges/bitunix.py
+++ b/src/exchanges/bitunix.py
@@ -580,7 +580,6 @@ class BitunixClient:
                 default=0.0,
             )
         )
-        price = _float(row.get("price"), field="order.price", default=0.0)
         timestamp = _int(row.get("ctime"), field="order.ctime")
         order_id = str(row.get("orderId") or "")
         if not order_id:
@@ -590,6 +589,17 @@ class BitunixClient:
         ).lower()
         if order_type not in {"limit", "market"}:
             raise ValueError("Bitunix order missing LIMIT/MARKET order type")
+        status = self._order_status(
+            row.get("status") or row.get("orderStatus")
+        )
+        price_required = order_type == "limit" or status == "open"
+        price = _float(
+            row.get("price"),
+            field="order.price",
+            default=0.0 if not price_required else None,
+        )
+        if price_required and price <= 0.0:
+            raise ValueError("Bitunix response has non-positive order.price")
         info = deepcopy(row)
         info["positionSide"] = pside.upper()
         info["reduceOnly"] = reduce_only
@@ -617,11 +627,11 @@ class BitunixClient:
                 default=0.0,
             )
             or None,
-            "status": self._order_status(row.get("status") or row.get("orderStatus")),
+            "status": status,
             "fee": (
                 {
                     "currency": "USDT",
-                    "cost": abs(_float(row.get("fee"), field="order.fee")),
+                    "cost": _float(row.get("fee"), field="order.fee"),
                 }
                 if row.get("fee") not in (None, "")
                 else None
@@ -857,8 +867,8 @@ class BitunixClient:
             "price": price,
             "amount": qty,
             "cost": qty * price,
-            "fee": {"currency": "USDT", "cost": abs(fee)},
-            "fees": [{"currency": "USDT", "cost": abs(fee)}],
+            "fee": {"currency": "USDT", "cost": fee},
+            "fees": [{"currency": "USDT", "cost": fee}],
             "clientOrderId": str(row.get("clientId") or ""),
         }
 
@@ -892,6 +902,7 @@ class BitunixClient:
             query["startTime"] = int(since)
         query.update(params)
         rows: dict[str, dict] = {}
+        expected_total: int | None = None
         for _ in range(self.MAX_FILL_PAGES):
             data = await self._request(
                 "GET",
@@ -902,17 +913,47 @@ class BitunixClient:
             if not isinstance(data, dict) or not isinstance(data.get("tradeList"), list):
                 raise ValueError("Bitunix fill-history response has invalid shape")
             page = data["tradeList"]
+            try:
+                total = _int(
+                    data.get("total"),
+                    field="fill-history total",
+                )
+            except (TypeError, ValueError, OverflowError) as exc:
+                raise ValueError(
+                    "Bitunix response has invalid fill-history total"
+                ) from exc
+            if total < 0:
+                raise ValueError(
+                    "Bitunix response has negative fill-history total"
+                )
+            if expected_total is None:
+                expected_total = total
+            elif total != expected_total:
+                raise ValueError(
+                    "Bitunix fill-history total changed during pagination"
+                )
             for row in page:
                 trade_id = str(row.get("tradeId") or "")
                 if not trade_id:
                     raise ValueError("Bitunix fill-history row missing tradeId")
                 rows[trade_id] = row
             query["skip"] += len(page)
-            total = int(data.get("total") or 0)
-            if not page or query["skip"] >= total or len(page) < page_size:
+            if query["skip"] > total:
+                raise ValueError(
+                    "Bitunix fill-history total is smaller than returned rows"
+                )
+            if not page and query["skip"] < total:
+                raise ValueError(
+                    "Bitunix fill-history pagination ended before total"
+                )
+            if query["skip"] == total:
                 break
         else:
             raise RuntimeError("Bitunix fill-history pagination exceeded safety limit")
+        if expected_total is None or len(rows) != expected_total:
+            raise ValueError(
+                "Bitunix fill-history pagination returned duplicate or incomplete rows"
+            )
         return sorted(
             (self._normalize_trade(row) for row in rows.values()),
             key=lambda trade: trade["timestamp"],

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -6033,6 +6033,145 @@ class HyperliquidFetcher(BaseFetcher):
         }
 
 
+class BitunixFetcher(BaseFetcher):
+    """Fetch canonical Bitunix futures fills from its native trade history."""
+
+    def __init__(self, api, *, trade_limit: int = 100) -> None:
+        self.api = api
+        self.trade_limit = max(1, min(100, int(trade_limit)))
+
+    async def fetch(
+        self,
+        since_ms: Optional[int],
+        until_ms: Optional[int],
+        detail_cache: Dict[str, Tuple[str, str]],
+        on_batch: Optional[Callable[[List[Dict[str, object]]], None]] = None,
+    ) -> List[Dict[str, object]]:
+        params = {}
+        if until_ms is not None:
+            params["until"] = int(until_ms)
+        trades = await self.api.fetch_my_trades(
+            symbol=None,
+            since=int(since_ms) if since_ms is not None else None,
+            limit=self.trade_limit,
+            params=params,
+        )
+        events = [self._normalize_trade(trade) for trade in trades]
+        events.sort(key=lambda event: event["timestamp"])
+        await self._enrich_client_order_ids(events, detail_cache)
+        if on_batch and events:
+            on_batch(events)
+        for event in events:
+            detail_cache[str(event["id"])] = (
+                str(event.get("client_order_id") or ""),
+                str(event.get("pb_order_type") or "unknown"),
+            )
+        return events
+
+    async def _enrich_client_order_ids(
+        self,
+        events: List[Dict[str, object]],
+        detail_cache: Dict[str, Tuple[str, str]],
+    ) -> None:
+        missing_by_order: Dict[
+            Tuple[str, str], List[Dict[str, object]]
+        ] = defaultdict(list)
+        for event in events:
+            cached = detail_cache.get(str(event["id"]))
+            if cached:
+                event["client_order_id"], event["pb_order_type"] = cached
+            elif not event.get("client_order_id"):
+                missing_by_order[
+                    (str(event["order_id"]), str(event["symbol"]))
+                ].append(event)
+
+        semaphore = asyncio.Semaphore(4)
+
+        async def fetch_detail(key: Tuple[str, str]):
+            order_id, symbol = key
+            async with semaphore:
+                order = await self.api.fetch_order(order_id, symbol)
+            info = order.get("info") if isinstance(order, dict) else {}
+            client_order_id = (
+                str(order.get("clientOrderId") or "")
+                if isinstance(order, dict)
+                else ""
+            )
+            if not client_order_id and isinstance(info, dict):
+                client_order_id = str(info.get("clientId") or "")
+            return key, client_order_id
+
+        if missing_by_order:
+            results = await asyncio.gather(
+                *(fetch_detail(key) for key in missing_by_order)
+            )
+            for key, client_order_id in results:
+                pb_order_type = (
+                    custom_id_to_snake(client_order_id)
+                    if client_order_id
+                    else "unknown"
+                )
+                for event in missing_by_order[key]:
+                    event["client_order_id"] = client_order_id
+                    event["pb_order_type"] = pb_order_type
+
+        for event in events:
+            if not event.get("pb_order_type"):
+                event["pb_order_type"] = "unknown"
+
+    @staticmethod
+    def _normalize_trade(trade: Dict[str, object]) -> Dict[str, object]:
+        info = trade.get("info") or {}
+        trade_id = str(trade.get("id") or info.get("tradeId") or "")
+        order_id = str(trade.get("order") or info.get("orderId") or "")
+        timestamp = int(trade.get("timestamp") or info.get("ctime") or 0)
+        symbol = str(trade.get("symbol") or "")
+        side = str(trade.get("side") or "").lower()
+        position_side = str(info.get("positionSide") or "").lower()
+        if not trade_id or not order_id or timestamp <= 0 or not symbol:
+            raise ValueError(
+                "Bitunix fill is missing id, order id, timestamp, or symbol"
+            )
+        if side not in {"buy", "sell"}:
+            raise ValueError(f"Bitunix fill has invalid side: {side!r}")
+        if position_side not in {"long", "short"}:
+            raise ValueError(
+                f"Bitunix fill has invalid positionSide: {position_side!r}"
+            )
+        qty = abs(float(trade.get("amount") or info.get("qty") or 0.0))
+        price = float(trade.get("price") or info.get("price") or 0.0)
+        if "realizedPNL" not in info:
+            raise ValueError("Bitunix fill is missing realizedPNL")
+        pnl = float(info["realizedPNL"])
+        if not all(math.isfinite(value) for value in (qty, price, pnl)):
+            raise ValueError("Bitunix fill has non-finite qty, price, or realizedPNL")
+        if qty <= 0.0 or price <= 0.0:
+            raise ValueError("Bitunix fill has non-positive qty or price")
+        client_order_id = str(
+            trade.get("clientOrderId") or info.get("clientId") or ""
+        )
+        pb_order_type = (
+            custom_id_to_snake(client_order_id) if client_order_id else "unknown"
+        )
+        return {
+            "id": trade_id,
+            "order_id": order_id,
+            "timestamp": timestamp,
+            "datetime": ts_to_date(timestamp),
+            "symbol": symbol,
+            "side": side,
+            "qty": qty,
+            "price": price,
+            "pnl": pnl,
+            "fees": trade.get("fees") or trade.get("fee"),
+            "pb_order_type": pb_order_type,
+            "position_side": position_side,
+            "client_order_id": client_order_id,
+            "raw": [{"source": "fetch_my_trades", "data": dict(trade)}],
+            "c_mult": 1.0,
+        }
+
+
 class WeexFetcher(BaseFetcher):
     """Fetch canonical WEEX V3 futures fills through CCXT.
 
@@ -7610,6 +7749,7 @@ def normalize_uta_fill_payload(
 EXCHANGE_BOT_CLASSES: Dict[str, Tuple[str, str]] = {
     "binance": ("exchanges.binance", "BinanceBot"),
     "bitget": ("exchanges.bitget", "BitgetBot"),
+    "bitunix": ("exchanges.bitunix", "BitunixBot"),
     "bybit": ("exchanges.bybit", "BybitBot"),
     "fake": ("exchanges.fake", "FakeBot"),
     "hyperliquid": ("exchanges.hyperliquid", "HyperliquidBot"),
@@ -7759,6 +7899,8 @@ def _build_fetcher_for_bot(bot, symbols: List[str]) -> BaseFetcher:
             api=bot.cca,
             symbol_resolver=lambda value: resolver(value),
         )
+    if exchange == "bitunix":
+        return BitunixFetcher(api=bot.cca)
     if exchange == "bybit":
         return BybitFetcher(api=bot.cca)
     if exchange == "fake":
@@ -7778,7 +7920,9 @@ def _build_fetcher_for_bot(bot, symbols: List[str]) -> BaseFetcher:
         return OkxFetcher(api=bot.cca)
     if exchange == "weex":
         return WeexFetcher(api=bot.cca)
-    supported = "binance, bitget, bybit, fake, gateio, hyperliquid, kucoin, okx, weex"
+    supported = (
+        "binance, bitget, bitunix, bybit, fake, gateio, hyperliquid, kucoin, okx, weex"
+    )
     raise ValueError(
         f"Unsupported exchange '{exchange}' for live fill events; realized PnL, "
         f"unstuck accounting, and HSL replay require an exchange-specific fetcher. "

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -33,7 +33,7 @@ from pathlib import Path
 from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple, TypedDict
 
 import passivbot_rust as pbr
-from ccxt.base.errors import RateLimitExceeded
+from ccxt.base.errors import OrderNotFound, RateLimitExceeded
 from bitget_normalization import (
     deduce_side_pside,
     deduce_uta_side_pside as _deduce_uta_side_pside,
@@ -6089,8 +6089,11 @@ class BitunixFetcher(BaseFetcher):
 
         async def fetch_detail(key: Tuple[str, str]):
             order_id, symbol = key
-            async with semaphore:
-                order = await self.api.fetch_order(order_id, symbol)
+            try:
+                async with semaphore:
+                    order = await self.api.fetch_order(order_id, symbol)
+            except OrderNotFound:
+                return key, ""
             info = order.get("info") if isinstance(order, dict) else {}
             client_order_id = (
                 str(order.get("clientOrderId") or "")

--- a/src/live/order_churn_gate.py
+++ b/src/live/order_churn_gate.py
@@ -10,6 +10,7 @@ ORDER_CHURN_GATE_SUPPORTED_EXCHANGES = frozenset(
     {
         "binance",
         "bitget",
+        "bitunix",
         "bybit",
         "fake",
         "gateio",

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -21375,6 +21375,10 @@ def setup_bot(config):
         from exchanges.bitget import BitgetBot
 
         bot = BitgetBot(config)
+    elif user_info["exchange"] == "bitunix":
+        from exchanges.bitunix import BitunixBot
+
+        bot = BitunixBot(config)
     elif user_info["exchange"] == "binance":
         from exchanges.binance import BinanceBot
 

--- a/tests/exchanges/test_bitunix.py
+++ b/tests/exchanges/test_bitunix.py
@@ -22,7 +22,11 @@ from custom_endpoint_overrides import (
     ResolvedEndpointOverride,
 )
 from exchanges.bitunix import BitunixBot, BitunixClient, BitunixOrderStream
-from fill_events_manager import BitunixFetcher, _build_fetcher_for_bot
+from fill_events_manager import (
+    BitunixFetcher,
+    _build_fetcher_for_bot,
+    signed_fee_paid_from_payload,
+)
 from candlestick_manager import CandlestickManager
 
 
@@ -273,6 +277,34 @@ def test_order_status_accepts_live_trailing_enum_padding():
     assert client._normalize_order(_order_row(status="NEW_"))["status"] == "open"
 
 
+@pytest.mark.parametrize("price", [None, "", "0", "-1", "nan"])
+def test_limit_order_requires_positive_finite_price(price):
+    client = _prepared_client()
+
+    with pytest.raises(ValueError, match="order.price"):
+        client._normalize_order(_order_row(price=price))
+
+
+def test_terminal_market_order_allows_missing_request_price():
+    client = _prepared_client()
+
+    order = client._normalize_order(
+        _order_row(orderType="MARKET", price=None, status="FILLED")
+    )
+
+    assert order["type"] == "market"
+    assert order["price"] == 0.0
+
+
+def test_open_market_order_requires_positive_price_for_reconciliation():
+    client = _prepared_client()
+
+    with pytest.raises(ValueError, match="order.price"):
+        client._normalize_order(
+            _order_row(orderType="MARKET", price=None, status="NEW")
+        )
+
+
 @pytest.mark.asyncio
 async def test_create_close_order_uses_hedge_side_and_position_id():
     client = _prepared_client()
@@ -422,6 +454,49 @@ async def test_fill_history_freezes_end_time_when_until_is_omitted(monkeypatch):
         call.kwargs["params"]["endTime"]
         for call in client._request.await_args_list
     } == {1_700_001_000_000}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"tradeList": [_trade_row()]},
+        {"tradeList": [_trade_row()], "total": None},
+        {"tradeList": [_trade_row()], "total": 0},
+        {"tradeList": [_trade_row()], "total": -1},
+    ],
+)
+async def test_fill_history_rejects_missing_or_inconsistent_total(payload):
+    client = _prepared_client()
+    client._request = AsyncMock(return_value=payload)
+
+    with pytest.raises(ValueError, match="fill-history total"):
+        await client.fetch_my_trades(limit=1)
+
+
+@pytest.mark.asyncio
+async def test_fill_history_rejects_total_changes_between_pages():
+    client = _prepared_client()
+    client._request = AsyncMock(
+        side_effect=[
+            {"tradeList": [_trade_row(tradeId="trade-2")], "total": 2},
+            {"tradeList": [_trade_row()], "total": 3},
+        ]
+    )
+
+    with pytest.raises(ValueError, match="fill-history total changed"):
+        await client.fetch_my_trades(limit=1)
+
+
+def test_trade_normalization_preserves_fee_rebate_sign():
+    client = _prepared_client()
+
+    trade = client._normalize_trade(_trade_row(fee="-0.01"))
+    event = BitunixFetcher._normalize_trade(trade)
+
+    assert trade["fee"]["cost"] == -0.01
+    assert trade["fees"][0]["cost"] == -0.01
+    assert signed_fee_paid_from_payload(event) == pytest.approx(0.01)
 
 
 @pytest.mark.asyncio
@@ -815,6 +890,7 @@ async def test_bitunix_fetcher_normalizes_accounting_fields():
     assert events[0]["side"] == "buy"
     assert events[0]["pnl"] == 0.0
     assert events[0]["c_mult"] == 1.0
+    assert signed_fee_paid_from_payload(events[0]) == pytest.approx(-0.01)
     assert cache["trade-1"][0] == "clock_entry_long_1"
 
 
@@ -837,6 +913,23 @@ async def test_bitunix_fetcher_enriches_missing_fill_client_id_from_order_detail
     assert events[0]["client_order_id"] == "clock_entry_long_1"
     assert events[0]["pb_order_type"]
     assert cache["trade-1"][0] == "clock_entry_long_1"
+
+
+@pytest.mark.asyncio
+async def test_bitunix_fetcher_retains_fill_when_order_detail_expired():
+    client = _prepared_client()
+    trade = client._normalize_trade(_trade_row(clientId=""))
+    client.fetch_my_trades = AsyncMock(return_value=[trade])
+    client.fetch_order = AsyncMock(side_effect=OrderNotFound("expired"))
+    fetcher = BitunixFetcher(client)
+    cache = {}
+
+    events = await fetcher.fetch(None, None, cache)
+
+    assert [event["id"] for event in events] == ["trade-1"]
+    assert events[0]["client_order_id"] == ""
+    assert events[0]["pb_order_type"] == "unknown"
+    assert cache["trade-1"] == ("", "unknown")
 
 
 def test_build_fetcher_for_bitunix():

--- a/tests/exchanges/test_bitunix.py
+++ b/tests/exchanges/test_bitunix.py
@@ -346,6 +346,54 @@ async def test_create_close_order_uses_hedge_side_and_position_id():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    "side,position_side,reduce_only",
+    [
+        ("buy", "LONG", False),
+        ("sell", "LONG", True),
+    ],
+)
+async def test_create_market_order_returns_identifier_acknowledgement(
+    side, position_side, reduce_only
+):
+    client = _prepared_client()
+    if reduce_only:
+        client._position_ids[("BTC/USDT:USDT", "long")] = "position-1"
+    client._request = AsyncMock(
+        return_value={"orderId": "order-1", "clientId": "clock_market_long_1"}
+    )
+
+    result = await client.create_order(
+        "BTC/USDT:USDT",
+        "market",
+        side,
+        0.001,
+        None,
+        {
+            "positionSide": position_side,
+            "clientOrderId": "clock_market_long_1",
+            "reduceOnly": reduce_only,
+        },
+    )
+
+    assert result["id"] == "order-1"
+    assert result["clientOrderId"] == "clock_market_long_1"
+    assert result["type"] == "market"
+    assert result["side"] == side
+    assert result["price"] is None
+    assert result["status"] is None
+    assert result["info"]["positionSide"] == position_side
+    assert result["reduceOnly"] is reduce_only
+    assert build_contract_bot("bitunix").did_create_order(result) is True
+    body = client._request.await_args.kwargs["body"]
+    assert body["orderType"] == "MARKET"
+    assert "price" not in body
+    assert "effect" not in body
+    if reduce_only:
+        assert body["positionId"] == "position-1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     "raw_side,expected",
     [("LONG", "long"), ("BUY", "long"), ("SHORT", "short"), ("SELL", "short")],
 )
@@ -690,6 +738,41 @@ async def test_ticker_depth_fallback_is_capped_before_any_rest_fanout():
 
 
 @pytest.mark.asyncio
+async def test_rest_only_tickers_skip_public_websocket_and_use_depth():
+    client = _prepared_client()
+    client.ws_enabled = False
+    client._ensure_ticker_tasks = MagicMock(
+        side_effect=AssertionError("public websocket must stay disabled")
+    )
+    expected = {
+        "symbol": "BTC/USDT:USDT",
+        "bid": 99.0,
+        "ask": 101.0,
+        "last": 100.0,
+        "timestamp": 1_700_000_000_000,
+    }
+    client._fetch_depth_ticker = AsyncMock(return_value=expected)
+
+    result = await client.fetch_tickers(["BTC/USDT:USDT"])
+
+    assert result == {"BTC/USDT:USDT": expected}
+    client._ensure_ticker_tasks.assert_not_called()
+    client._fetch_depth_ticker.assert_awaited_once_with("BTC/USDT:USDT")
+
+
+@pytest.mark.asyncio
+async def test_rest_only_tickers_reject_unbounded_bulk_request():
+    client = _prepared_client()
+    client.ws_enabled = False
+    client._fetch_depth_ticker = AsyncMock()
+
+    with pytest.raises(NetworkError, match="requires explicit symbols"):
+        await client.fetch_tickers()
+
+    client._fetch_depth_ticker.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_depth_ticker_uses_midpoint_as_synthetic_last():
     client = _prepared_client()
     client._request = AsyncMock(
@@ -773,7 +856,9 @@ def test_native_session_applies_bitunix_endpoint_override():
         "Existing": "header",
         "X-Proxy": "enabled",
     }
+    assert bot.cca.ws_enabled is False
     assert bot.ccp is None
+    assert bot._market_snapshot_ticker_strategy() == "symbols"
 
 
 def test_native_session_applies_bitunix_domain_rewrite():

--- a/tests/exchanges/test_bitunix.py
+++ b/tests/exchanges/test_bitunix.py
@@ -285,6 +285,14 @@ def test_limit_order_requires_positive_finite_price(price):
         client._normalize_order(_order_row(price=price))
 
 
+@pytest.mark.parametrize("qty", [None, "", "0", "-1", "nan"])
+def test_order_requires_positive_finite_quantity(qty):
+    client = _prepared_client()
+
+    with pytest.raises(ValueError, match="order.qty"):
+        client._normalize_order(_order_row(qty=qty))
+
+
 def test_terminal_market_order_allows_missing_request_price():
     client = _prepared_client()
 
@@ -764,6 +772,78 @@ async def test_order_stream_surfaces_unenriched_row_when_detail_is_not_found():
 
 
 @pytest.mark.asyncio
+async def test_order_stream_isolates_malformed_rest_detail_to_its_row():
+    client = _prepared_client()
+    valid_order = client._normalize_order(_order_row(orderId="order-2"))
+    client.fetch_order = AsyncMock(
+        side_effect=[ValueError("malformed order detail"), valid_order]
+    )
+    stream = BitunixOrderStream(client)
+    stream._ws = SimpleNamespace(
+        closed=False,
+        receive=AsyncMock(
+            return_value=SimpleNamespace(
+                type=aiohttp.WSMsgType.TEXT,
+                data=json.dumps(
+                    {
+                        "ch": "order",
+                        "data": [
+                            {
+                                "orderId": "order-1",
+                                "symbol": "BTCUSDT",
+                                "status": "FILLED",
+                            },
+                            {
+                                "orderId": "order-2",
+                                "symbol": "BTCUSDT",
+                                "status": "FILLED",
+                            },
+                        ],
+                    }
+                ),
+            )
+        ),
+    )
+
+    rows = await stream.watch_orders()
+
+    assert rows[0] == {
+        "orderId": "order-1",
+        "symbol": "BTC/USDT:USDT",
+        "status": "FILLED",
+    }
+    assert rows[1] == valid_order
+
+
+@pytest.mark.asyncio
+async def test_order_stream_propagates_rest_transport_failure():
+    client = _prepared_client()
+    client.fetch_order = AsyncMock(side_effect=NetworkError("unavailable"))
+    stream = BitunixOrderStream(client)
+    stream._ws = SimpleNamespace(
+        closed=False,
+        receive=AsyncMock(
+            return_value=SimpleNamespace(
+                type=aiohttp.WSMsgType.TEXT,
+                data=json.dumps(
+                    {
+                        "ch": "order",
+                        "data": {
+                            "orderId": "order-1",
+                            "symbol": "BTCUSDT",
+                            "status": "FILLED",
+                        },
+                    }
+                ),
+            )
+        ),
+    )
+
+    with pytest.raises(NetworkError, match="unavailable"):
+        await stream.watch_orders()
+
+
+@pytest.mark.asyncio
 async def test_unenriched_order_row_requests_account_state_refresh():
     bot = build_contract_bot("bitunix")
     bot.ccp = SimpleNamespace(has={"watchOrders": True})
@@ -865,6 +945,72 @@ async def test_depth_ticker_uses_midpoint_as_synthetic_last():
     assert ticker["source"] == "bitunix_depth_mid"
 
 
+@pytest.mark.asyncio
+async def test_bot_ticker_normalization_preserves_source_and_timestamp():
+    bot = build_contract_bot("bitunix")
+    symbol = "BTC/USDT:USDT"
+    bot.markets_dict = {symbol: _market()}
+    bot.cca = SimpleNamespace(
+        fetch_tickers=AsyncMock(
+            return_value={
+                symbol: {
+                    "bid": 99.0,
+                    "ask": 101.0,
+                    "last": 100.0,
+                    "timestamp": 1_700_000_000_000,
+                    "source": "bitunix_depth_mid",
+                }
+            }
+        )
+    )
+
+    tickers = await bot.fetch_tickers_for_symbols([symbol])
+
+    assert tickers[symbol] == {
+        "bid": 99.0,
+        "ask": 101.0,
+        "last": 100.0,
+        "timestamp": 1_700_000_000_000,
+        "source": "bitunix_depth_mid",
+    }
+
+
+def test_ticker_tasks_restart_when_active_market_ids_change():
+    client = _prepared_client()
+    existing_task = MagicMock()
+    existing_task.done.return_value = False
+    client._ticker_tasks = [existing_task]
+    client._ticker_subscription_ids = ("BTCUSDT",)
+    created_tasks = []
+
+    def fake_create_task(coroutine, *, name):
+        coroutine.close()
+        task = MagicMock()
+        task.done.return_value = False
+        created_tasks.append((task, name))
+        return task
+
+    with patch(
+        "exchanges.bitunix.asyncio.create_task", side_effect=fake_create_task
+    ) as create_task:
+        client._ensure_ticker_tasks()
+        create_task.assert_not_called()
+        existing_task.cancel.assert_not_called()
+
+        eth_market = {
+            **_market(),
+            "id": "ETHUSDT",
+            "symbol": "ETH/USDT:USDT",
+        }
+        client.markets[eth_market["symbol"]] = eth_market
+        client._ensure_ticker_tasks()
+
+    existing_task.cancel.assert_called_once_with()
+    assert client._ticker_subscription_ids == ("BTCUSDT", "ETHUSDT")
+    assert len(created_tasks) == 1
+    assert client._ticker_tasks == [created_tasks[0][0]]
+
+
 class _ResponseContext:
     def __init__(self, response):
         self.response = response
@@ -893,7 +1039,7 @@ async def test_native_request_uses_configured_rest_base_and_extra_headers():
             "apiKey": "key",
             "secret": "secret",
             "restUrl": "https://proxy.example/base/",
-            "headers": {"X-Proxy": "enabled", "api-key": "must-not-win"},
+            "headers": {"X-Proxy": "enabled"},
         }
     )
     response = SimpleNamespace(
@@ -910,6 +1056,22 @@ async def test_native_request_uses_configured_rest_base_and_extra_headers():
     assert args[:2] == ("GET", "https://proxy.example/base/private")
     assert kwargs["headers"]["X-Proxy"] == "enabled"
     assert kwargs["headers"]["api-key"] == "key"
+
+
+@pytest.mark.parametrize(
+    "header_name", ["api-key", "Api-Key", "NONCE", "Timestamp", "sIgN"]
+)
+def test_native_session_rejects_case_insensitive_auth_header_collision(
+    header_name,
+):
+    with pytest.raises(ValueError, match="reserved authentication header"):
+        BitunixClient(
+            {
+                "apiKey": "key",
+                "secret": "secret",
+                "headers": {header_name: "must-not-win"},
+            }
+        )
 
 
 def test_native_session_applies_bitunix_endpoint_override():

--- a/tests/exchanges/test_bitunix.py
+++ b/tests/exchanges/test_bitunix.py
@@ -1,17 +1,26 @@
+import asyncio
 import hashlib
+import json
+import logging
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import pytest
 from ccxt.base.errors import (
     AuthenticationError,
     InsufficientFunds,
     InvalidOrder,
     NetworkError,
+    OrderNotFound,
     RateLimitExceeded,
 )
 
 from ccxt_contracts import build_contract_bot, get_bot_class
+from custom_endpoint_overrides import (
+    CustomEndpointConfigError,
+    ResolvedEndpointOverride,
+)
 from exchanges.bitunix import BitunixBot, BitunixClient, BitunixOrderStream
 from fill_events_manager import BitunixFetcher, _build_fetcher_for_bot
 from candlestick_manager import CandlestickManager
@@ -92,6 +101,26 @@ def _trade_row(**overrides):
         "realizedPNL": "0",
         "ctime": 1_700_000_000_000,
         "roleType": "TAKER",
+    }
+    row.update(overrides)
+    return row
+
+
+def _position_row(**overrides):
+    row = {
+        "positionId": "position-1",
+        "symbol": "BTCUSDT",
+        "qty": "0.001",
+        "entryValue": "50",
+        "side": "LONG",
+        "positionMode": "HEDGE",
+        "marginMode": "CROSS",
+        "leverage": 3,
+        "unrealizedPNL": "0",
+        "realizedPNL": "0",
+        "avgOpenPrice": "50000",
+        "ctime": 1_700_000_000_000,
+        "mtime": 1_700_000_000_001,
     }
     row.update(overrides)
     return row
@@ -292,30 +321,24 @@ async def test_positions_accept_documented_and_live_hedge_side_aliases(
     raw_side, expected
 ):
     client = _prepared_client()
-    client._request = AsyncMock(
-        return_value=[
-            {
-                "positionId": "position-1",
-                "symbol": "BTCUSDT",
-                "qty": "0.001",
-                "entryValue": "50",
-                "side": raw_side,
-                "positionMode": "HEDGE",
-                "marginMode": "CROSS",
-                "leverage": 3,
-                "unrealizedPNL": "0",
-                "realizedPNL": "0",
-                "avgOpenPrice": "50000",
-                "ctime": 1_700_000_000_000,
-                "mtime": 1_700_000_000_001,
-            }
-        ]
-    )
+    client._request = AsyncMock(return_value=[_position_row(side=raw_side)])
 
     positions = await client.fetch_positions(["BTC/USDT:USDT"])
 
     assert positions[0]["side"] == expected
     assert client._position_ids[("BTC/USDT:USDT", expected)] == "position-1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("entry_price", [None, "", "0", "-1", "nan"])
+async def test_nonzero_position_requires_positive_finite_entry_price(entry_price):
+    client = _prepared_client()
+    client._request = AsyncMock(
+        return_value=[_position_row(avgOpenPrice=entry_price)]
+    )
+
+    with pytest.raises(ValueError, match="entry price"):
+        await client.fetch_positions(["BTC/USDT:USDT"])
 
 
 @pytest.mark.asyncio
@@ -373,6 +396,32 @@ async def test_fill_history_paginates_and_normalizes_hedge_actions():
     assert trades[1]["side"] == "sell"
     assert trades[1]["info"]["positionSide"] == "LONG"
     assert client._request.await_args_list[1].kwargs["params"]["skip"] == 1
+    assert {
+        call.kwargs["params"]["endTime"]
+        for call in client._request.await_args_list
+    } == {1_700_001_000_000}
+
+
+@pytest.mark.asyncio
+async def test_fill_history_freezes_end_time_when_until_is_omitted(monkeypatch):
+    client = _prepared_client()
+    monkeypatch.setattr(client, "milliseconds", lambda: 1_700_001_000_000)
+    client._request = AsyncMock(
+        side_effect=[
+            {"tradeList": [_trade_row(tradeId="trade-2")], "total": 2},
+            {"tradeList": [_trade_row()], "total": 2},
+        ]
+    )
+
+    await client.fetch_my_trades(limit=1)
+
+    assert [
+        call.kwargs["params"]["skip"] for call in client._request.await_args_list
+    ] == [0, 1]
+    assert {
+        call.kwargs["params"]["endTime"]
+        for call in client._request.await_args_list
+    } == {1_700_001_000_000}
 
 
 @pytest.mark.asyncio
@@ -431,6 +480,252 @@ async def test_ohlcv_derives_forward_page_end_from_since_when_venue_ignores_star
     query = client._request.await_args.kwargs["params"]
     assert query["startTime"] == 60_000
     assert query["endTime"] == 60_000 + 200 * 60_000
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("volume", [None, "", "nan", "-1"])
+async def test_ohlcv_rejects_missing_or_invalid_base_volume(volume):
+    client = _prepared_client()
+    client._request = AsyncMock(
+        return_value=[
+            {
+                "time": 60_000,
+                "open": "1",
+                "high": "2",
+                "low": "0.5",
+                "close": "1.5",
+                "quoteVol": volume,
+            }
+        ]
+    )
+
+    with pytest.raises(ValueError, match="kline.quoteVol"):
+        await client.fetch_ohlcv("BTC/USDT:USDT", "1m", since=60_000)
+
+
+@pytest.mark.asyncio
+async def test_ohlcv_accepts_explicit_zero_base_volume():
+    client = _prepared_client()
+    client._request = AsyncMock(
+        return_value=[
+            {
+                "time": 60_000,
+                "open": "1",
+                "high": "2",
+                "low": "0.5",
+                "close": "1.5",
+                "quoteVol": "0",
+            }
+        ]
+    )
+
+    candles = await client.fetch_ohlcv(
+        "BTC/USDT:USDT", "1m", since=60_000
+    )
+
+    assert candles[0][5] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_order_stream_surfaces_unenriched_row_when_detail_is_not_found():
+    client = _prepared_client()
+    client.fetch_order = AsyncMock(side_effect=OrderNotFound("not found"))
+    stream = BitunixOrderStream(client)
+    stream._ws = SimpleNamespace(
+        closed=False,
+        receive=AsyncMock(
+            return_value=SimpleNamespace(
+                type=aiohttp.WSMsgType.TEXT,
+                data=json.dumps(
+                    {
+                        "ch": "order",
+                        "data": {
+                            "orderId": "order-1",
+                            "symbol": "BTCUSDT",
+                            "status": "FILLED",
+                        },
+                    }
+                ),
+            )
+        ),
+    )
+
+    rows = await stream.watch_orders()
+
+    assert rows == [
+        {
+            "orderId": "order-1",
+            "symbol": "BTC/USDT:USDT",
+            "status": "FILLED",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_unenriched_order_row_requests_account_state_refresh():
+    bot = build_contract_bot("bitunix")
+    bot.ccp = SimpleNamespace(has={"watchOrders": True})
+    bot.stop_websocket = False
+    bot._do_watch_orders = AsyncMock(
+        side_effect=[
+            [
+                {
+                    "orderId": "order-1",
+                    "symbol": "BTC/USDT:USDT",
+                    "status": "FILLED",
+                }
+            ],
+            asyncio.CancelledError,
+        ]
+    )
+    bot._mark_account_critical_state_dirty = MagicMock()
+    bot.handle_order_update = MagicMock()
+
+    await bot.watch_orders()
+
+    bot._mark_account_critical_state_dirty.assert_called_once_with(
+        reason="order_ws_semantics_unavailable",
+        symbols={"BTC/USDT:USDT"},
+        source="bitunix_order_ws",
+        level=logging.DEBUG,
+    )
+    bot.handle_order_update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ticker_depth_fallback_is_capped_before_any_rest_fanout():
+    client = _prepared_client()
+    eth_market = {
+        **_market(),
+        "id": "ETHUSDT",
+        "symbol": "ETH/USDT:USDT",
+    }
+    client.markets[eth_market["symbol"]] = eth_market
+    client.markets_by_id[eth_market["id"]] = eth_market
+    client.symbols.append(eth_market["symbol"])
+    client.TICKER_WAIT_SECONDS = 0.0
+    client.MAX_DEPTH_FALLBACK_SYMBOLS = 1
+    client._ensure_ticker_tasks = lambda: None
+    client._fetch_depth_ticker = AsyncMock()
+
+    with pytest.raises(NetworkError, match="fallback limited"):
+        await client.fetch_tickers(client.symbols)
+
+    client._fetch_depth_ticker.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_depth_ticker_uses_midpoint_as_synthetic_last():
+    client = _prepared_client()
+    client._request = AsyncMock(
+        return_value={"bids": [["99", "1"]], "asks": [["101", "1"]]}
+    )
+    client.milliseconds = lambda: 1_700_000_000_000
+
+    ticker = await client._fetch_depth_ticker("BTC/USDT:USDT")
+
+    assert ticker["last"] == 100.0
+    assert ticker["source"] == "bitunix_depth_mid"
+
+
+class _ResponseContext:
+    def __init__(self, response):
+        self.response = response
+
+    async def __aenter__(self):
+        return self.response
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+class _RecordingSession:
+    def __init__(self, response):
+        self.response = response
+        self.call = None
+
+    def request(self, *args, **kwargs):
+        self.call = (args, kwargs)
+        return _ResponseContext(self.response)
+
+
+@pytest.mark.asyncio
+async def test_native_request_uses_configured_rest_base_and_extra_headers():
+    client = BitunixClient(
+        {
+            "apiKey": "key",
+            "secret": "secret",
+            "restUrl": "https://proxy.example/base/",
+            "headers": {"X-Proxy": "enabled", "api-key": "must-not-win"},
+        }
+    )
+    response = SimpleNamespace(
+        status=200,
+        text=AsyncMock(return_value='{"code": 0, "data": []}'),
+    )
+    session = _RecordingSession(response)
+    client._get_session = AsyncMock(return_value=session)
+    client._throttle = AsyncMock()
+
+    await client._request("GET", "/private", private=True)
+
+    args, kwargs = session.call
+    assert args[:2] == ("GET", "https://proxy.example/base/private")
+    assert kwargs["headers"]["X-Proxy"] == "enabled"
+    assert kwargs["headers"]["api-key"] == "key"
+
+
+def test_native_session_applies_bitunix_endpoint_override():
+    bot = build_contract_bot("bitunix")
+    bot.user_info = {
+        "exchange": "bitunix",
+        "key": "key",
+        "secret": "secret",
+        "headers": {"Existing": "header"},
+    }
+    bot.endpoint_override = ResolvedEndpointOverride(
+        exchange_id="bitunix",
+        rest_url_overrides={"api": "https://proxy.example/bitunix"},
+        rest_extra_headers={"X-Proxy": "enabled"},
+        disable_ws=True,
+    )
+    bot.ws_enabled = False
+
+    bot.create_ccxt_sessions()
+
+    assert bot.cca.rest_url == "https://proxy.example/bitunix"
+    assert bot.cca.headers == {
+        "Existing": "header",
+        "X-Proxy": "enabled",
+    }
+    assert bot.ccp is None
+
+
+def test_native_session_applies_bitunix_domain_rewrite():
+    bot = build_contract_bot("bitunix")
+    bot.endpoint_override = ResolvedEndpointOverride(
+        exchange_id="bitunix",
+        rest_domain_rewrites={
+            "https://fapi.bitunix.com": "https://proxy.example"
+        },
+    )
+    bot.ws_enabled = False
+
+    bot.create_ccxt_sessions()
+
+    assert bot.cca.rest_url == "https://proxy.example"
+
+
+def test_native_session_rejects_unsupported_endpoint_url_keys():
+    bot = build_contract_bot("bitunix")
+    bot.endpoint_override = ResolvedEndpointOverride(
+        exchange_id="bitunix",
+        rest_url_overrides={"private": "https://proxy.example"},
+    )
+    bot.ws_enabled = False
+
+    with pytest.raises(CustomEndpointConfigError, match="unsupported REST URL override"):
+        bot.create_ccxt_sessions()
 
 
 def test_bot_order_params_require_durable_hedge_semantics():

--- a/tests/exchanges/test_bitunix.py
+++ b/tests/exchanges/test_bitunix.py
@@ -306,6 +306,85 @@ def test_open_market_order_requires_positive_price_for_reconciliation():
 
 
 @pytest.mark.asyncio
+async def test_open_orders_paginate_to_stable_reported_total():
+    client = _prepared_client()
+    client.milliseconds = lambda: 1_700_001_000_000
+    client._request = AsyncMock(
+        side_effect=[
+            {
+                "orderList": [
+                    _order_row(
+                        orderId="order-2",
+                        ctime=1_700_000_000_002,
+                        mtime=1_700_000_000_002,
+                    )
+                ],
+                "total": 2,
+            },
+            {"orderList": [_order_row()], "total": 2},
+        ]
+    )
+
+    orders = await client.fetch_open_orders(limit=1)
+
+    assert [order["id"] for order in orders] == ["order-1", "order-2"]
+    assert [
+        call.kwargs["params"]["skip"]
+        for call in client._request.await_args_list
+    ] == [0, 1]
+    assert {
+        call.kwargs["params"]["endTime"]
+        for call in client._request.await_args_list
+    } == {1_700_001_000_000}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"orderList": [_order_row()]},
+        {"orderList": [_order_row()], "total": None},
+        {"orderList": [_order_row()], "total": 0},
+        {"orderList": [], "total": -1},
+    ],
+)
+async def test_open_orders_reject_missing_or_inconsistent_total(payload):
+    client = _prepared_client()
+    client._request = AsyncMock(return_value=payload)
+
+    with pytest.raises(ValueError, match="open-orders total"):
+        await client.fetch_open_orders(limit=1)
+
+
+@pytest.mark.asyncio
+async def test_open_orders_reject_total_changes_between_pages():
+    client = _prepared_client()
+    client._request = AsyncMock(
+        side_effect=[
+            {"orderList": [_order_row(orderId="order-2")], "total": 2},
+            {"orderList": [_order_row()], "total": 3},
+        ]
+    )
+
+    with pytest.raises(ValueError, match="open-orders total changed"):
+        await client.fetch_open_orders(limit=1)
+
+
+@pytest.mark.asyncio
+async def test_open_orders_reject_duplicate_or_incomplete_pagination():
+    client = _prepared_client()
+    client._request = AsyncMock(
+        side_effect=[
+            {"orderList": [_order_row()], "total": 2},
+            {"orderList": [_order_row()], "total": 2},
+        ]
+    )
+
+    with pytest.raises(ValueError, match="duplicate or incomplete"):
+        await client.fetch_open_orders(limit=1)
+
+
+@pytest.mark.asyncio
 async def test_create_close_order_uses_hedge_side_and_position_id():
     client = _prepared_client()
     client._position_ids[("BTC/USDT:USDT", "long")] = "position-1"

--- a/tests/exchanges/test_bitunix.py
+++ b/tests/exchanges/test_bitunix.py
@@ -1,0 +1,565 @@
+import hashlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from ccxt.base.errors import (
+    AuthenticationError,
+    InsufficientFunds,
+    InvalidOrder,
+    NetworkError,
+    RateLimitExceeded,
+)
+
+from ccxt_contracts import build_contract_bot, get_bot_class
+from exchanges.bitunix import BitunixBot, BitunixClient, BitunixOrderStream
+from fill_events_manager import BitunixFetcher, _build_fetcher_for_bot
+from candlestick_manager import CandlestickManager
+
+
+MARKET_ROW = {
+    "symbol": "BTCUSDT",
+    "base": "BTC",
+    "quote": "USDT",
+    "minTradeVolume": "0.0001",
+    "basePrecision": 4,
+    "quotePrecision": 1,
+    "minLeverage": 1,
+    "maxLeverage": 125,
+    "defaultLeverage": 20,
+    "defaultMarginMode": "CROSS",
+    "symbolStatus": "OPEN",
+    "isApiSupported": True,
+}
+
+
+def _market():
+    return {
+        "id": "BTCUSDT",
+        "symbol": "BTC/USDT:USDT",
+        "active": True,
+        "info": MARKET_ROW,
+    }
+
+
+def _prepared_client() -> BitunixClient:
+    client = BitunixClient({"apiKey": "key", "secret": "secret"})
+    client.markets = {"BTC/USDT:USDT": _market()}
+    client.markets_by_id = {"BTCUSDT": client.markets["BTC/USDT:USDT"]}
+    client.symbols = ["BTC/USDT:USDT"]
+    return client
+
+
+def _order_row(**overrides):
+    row = {
+        "orderId": "order-1",
+        "symbol": "BTCUSDT",
+        "qty": "0.001",
+        "tradeQty": "0",
+        "positionMode": "HEDGE",
+        "marginMode": "CROSS",
+        "leverage": 3,
+        "price": "50000",
+        "side": "BUY",
+        "orderType": "LIMIT",
+        "effect": "POST_ONLY",
+        "clientId": "clock_entry_long_1",
+        "reduceOnly": False,
+        "status": "NEW",
+        "ctime": 1_700_000_000_000,
+        "mtime": 1_700_000_000_001,
+    }
+    row.update(overrides)
+    return row
+
+
+def _trade_row(**overrides):
+    row = {
+        "tradeId": "trade-1",
+        "orderId": "order-1",
+        "symbol": "BTCUSDT",
+        "qty": "0.001",
+        "positionMode": "HEDGE",
+        "marginMode": "CROSS",
+        "leverage": 3,
+        "price": "50000",
+        "side": "BUY",
+        "orderType": "MARKET",
+        "effect": "",
+        "clientId": "clock_entry_long_1",
+        "reduceOnly": False,
+        "fee": "0.01",
+        "realizedPNL": "0",
+        "ctime": 1_700_000_000_000,
+        "roleType": "TAKER",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_ccxt_contract_registry_uses_bitunix_adapter():
+    assert get_bot_class("bitunix") is BitunixBot
+
+
+def test_candlestick_manager_uses_bitunix_kline_page_limit(tmp_path):
+    client = _prepared_client()
+    manager = CandlestickManager(
+        exchange=client,
+        exchange_name="bitunix",
+        cache_dir=str(tmp_path / "caches"),
+    )
+    assert manager._ccxt_limit_default == 200
+
+
+def test_rest_signature_matches_documented_double_sha256(monkeypatch):
+    client = BitunixClient({"apiKey": "api", "secret": "secret"})
+    monkeypatch.setattr("exchanges.bitunix.uuid.uuid4", lambda: SimpleNamespace(hex="nonce"))
+    monkeypatch.setattr(client, "milliseconds", lambda: 1_700_000_000_000)
+
+    headers = client._signed_headers({"symbol": "BTCUSDT", "limit": 10}, "")
+
+    first = hashlib.sha256(
+        b"nonce1700000000000apilimit10symbolBTCUSDT"
+    ).hexdigest()
+    expected = hashlib.sha256(f"{first}secret".encode()).hexdigest()
+    assert headers == {
+        "api-key": "api",
+        "nonce": "nonce",
+        "timestamp": "1700000000000",
+        "sign": expected,
+        "Content-Type": "application/json",
+    }
+
+
+def test_private_websocket_signature_uses_seconds(monkeypatch):
+    client = BitunixClient({"apiKey": "api", "secret": "secret"})
+    stream = BitunixOrderStream(client)
+    monkeypatch.setattr("exchanges.bitunix.uuid.uuid4", lambda: SimpleNamespace(hex="nonce"))
+    monkeypatch.setattr("exchanges.bitunix.time.time", lambda: 1_700_000_000.9)
+
+    payload = stream._login_payload()
+
+    first = hashlib.sha256(b"nonce1700000000api").hexdigest()
+    expected = hashlib.sha256(f"{first}secret".encode()).hexdigest()
+    assert payload["args"][0] == {
+        "apiKey": "api",
+        "timestamp": 1_700_000_000,
+        "nonce": "nonce",
+        "sign": expected,
+    }
+
+
+@pytest.mark.parametrize(
+    "code,error_type",
+    [
+        (10004, AuthenticationError),
+        (10001, NetworkError),
+        (10006, RateLimitExceeded),
+        (20003, InsufficientFunds),
+        (30042, InvalidOrder),
+    ],
+)
+def test_api_errors_map_to_ccxt_exception_contract(code, error_type):
+    with pytest.raises(error_type):
+        BitunixClient._raise_api_error(code, "test")
+
+
+@pytest.mark.asyncio
+async def test_load_markets_maps_base_quantity_and_tick_sizes():
+    client = BitunixClient()
+    client._request = AsyncMock(return_value=[MARKET_ROW])
+
+    markets = await client.load_markets(True)
+
+    market = markets["BTC/USDT:USDT"]
+    assert market["id"] == "BTCUSDT"
+    assert market["swap"] is True
+    assert market["linear"] is True
+    assert market["active"] is True
+    assert market["contractSize"] == 1.0
+    assert market["precision"] == {"amount": 0.0001, "price": 0.1}
+    assert market["limits"]["amount"]["min"] == pytest.approx(0.0001)
+    assert market["limits"]["leverage"]["max"] == pytest.approx(125)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("as_list", [False, True])
+async def test_balance_reconstructs_wallet_and_accepts_both_account_shapes(as_list):
+    client = _prepared_client()
+    raw = {
+        "marginCoin": "USDT",
+        "available": "1000",
+        "frozen": "4",
+        "margin": "10",
+        "positionMode": "HEDGE",
+        "crossUnrealizedPNL": "2",
+        "isolationUnrealizedPNL": "-1",
+    }
+    client._request = AsyncMock(return_value=[raw] if as_list else raw)
+
+    balance = await client.fetch_balance()
+
+    assert balance["free"]["USDT"] == 1000.0
+    assert balance["used"]["USDT"] == 14.0
+    assert balance["total"]["USDT"] == 1013.0
+    assert client._request.await_args.kwargs["params"] == {"marginCoin": "USDT"}
+
+
+def test_hedge_order_normalization_preserves_position_and_action_side():
+    client = _prepared_client()
+
+    entry = client._normalize_order(_order_row())
+    close = client._normalize_order(
+        _order_row(
+            side="SELL", reduceOnly=True, clientId="clock_close_long_1"
+        )
+    )
+    short_close = client._normalize_order(
+        _order_row(
+            side="BUY",
+            reduceOnly=True,
+            clientId="clock_close_short_1",
+        )
+    )
+
+    assert (entry["side"], entry["info"]["positionSide"], entry["reduceOnly"]) == (
+        "buy",
+        "LONG",
+        False,
+    )
+    assert (close["side"], close["info"]["positionSide"], close["reduceOnly"]) == (
+        "sell",
+        "LONG",
+        True,
+    )
+    assert (
+        short_close["side"],
+        short_close["info"]["positionSide"],
+        short_close["reduceOnly"],
+    ) == ("buy", "SHORT", True)
+
+
+def test_order_status_accepts_live_trailing_enum_padding():
+    client = _prepared_client()
+    assert client._normalize_order(_order_row(status="NEW_"))["status"] == "open"
+
+
+@pytest.mark.asyncio
+async def test_create_close_order_uses_hedge_side_and_position_id():
+    client = _prepared_client()
+    client._position_ids[("BTC/USDT:USDT", "long")] = "position-1"
+    client._request = AsyncMock(
+        return_value={"orderId": "order-1", "clientId": "clock_close_long_1"}
+    )
+
+    result = await client.create_order(
+        "BTC/USDT:USDT",
+        "limit",
+        "sell",
+        0.001,
+        50_000,
+        {
+            "positionSide": "LONG",
+            "clientOrderId": "clock_close_long_1",
+            "reduceOnly": True,
+            "effect": "POST_ONLY",
+        },
+    )
+
+    body = client._request.await_args.kwargs["body"]
+    assert body == {
+        "symbol": "BTCUSDT",
+        "qty": "0.001",
+        "side": "BUY",
+        "tradeSide": "CLOSE",
+        "orderType": "LIMIT",
+        "reduceOnly": True,
+        "price": "50000",
+        "effect": "POST_ONLY",
+        "clientId": "clock_close_long_1",
+        "positionId": "position-1",
+    }
+    assert result["side"] == "sell"
+    assert result["reduceOnly"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "raw_side,expected",
+    [("LONG", "long"), ("BUY", "long"), ("SHORT", "short"), ("SELL", "short")],
+)
+async def test_positions_accept_documented_and_live_hedge_side_aliases(
+    raw_side, expected
+):
+    client = _prepared_client()
+    client._request = AsyncMock(
+        return_value=[
+            {
+                "positionId": "position-1",
+                "symbol": "BTCUSDT",
+                "qty": "0.001",
+                "entryValue": "50",
+                "side": raw_side,
+                "positionMode": "HEDGE",
+                "marginMode": "CROSS",
+                "leverage": 3,
+                "unrealizedPNL": "0",
+                "realizedPNL": "0",
+                "avgOpenPrice": "50000",
+                "ctime": 1_700_000_000_000,
+                "mtime": 1_700_000_000_001,
+            }
+        ]
+    )
+
+    positions = await client.fetch_positions(["BTC/USDT:USDT"])
+
+    assert positions[0]["side"] == expected
+    assert client._position_ids[("BTC/USDT:USDT", expected)] == "position-1"
+
+
+@pytest.mark.asyncio
+async def test_create_close_order_rejects_missing_live_position():
+    client = _prepared_client()
+    client.fetch_positions = AsyncMock(return_value=[])
+    with pytest.raises(InvalidOrder, match="no live positionId"):
+        await client.create_order(
+            "BTC/USDT:USDT",
+            "market",
+            "sell",
+            0.001,
+            None,
+            {
+                "positionSide": "LONG",
+                "clientOrderId": "clock_close_long_1",
+                "reduceOnly": True,
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_fill_history_paginates_and_normalizes_hedge_actions():
+    client = _prepared_client()
+    client._request = AsyncMock(
+        side_effect=[
+            {
+                "tradeList": [
+                    _trade_row(
+                        tradeId="trade-2",
+                        side="SELL",
+                        reduceOnly=True,
+                        realizedPNL="0.5",
+                        ctime=1_700_000_000_002,
+                    )
+                ],
+                "total": 2,
+            },
+            {
+                "tradeList": [_trade_row()],
+                "total": 2,
+            },
+        ]
+    )
+
+    trades = await client.fetch_my_trades(
+        since=1_699_999_000_000,
+        limit=1,
+        params={"until": 1_700_001_000_000},
+    )
+
+    assert [trade["id"] for trade in trades] == ["trade-1", "trade-2"]
+    assert trades[0]["side"] == "buy"
+    assert trades[0]["info"]["positionSide"] == "LONG"
+    assert trades[1]["side"] == "sell"
+    assert trades[1]["info"]["positionSide"] == "LONG"
+    assert client._request.await_args_list[1].kwargs["params"]["skip"] == 1
+
+
+@pytest.mark.asyncio
+async def test_ohlcv_is_clamped_reversed_and_deduplicated():
+    client = _prepared_client()
+    client._request = AsyncMock(
+        return_value=[
+            {
+                "time": 120_000,
+                "open": "2",
+                "high": "3",
+                "low": "1",
+                "close": "2.5",
+                "quoteVol": "4",
+                "baseVol": "10",
+            },
+            {
+                "time": 60_000,
+                "open": "1",
+                "high": "2",
+                "low": "0.5",
+                "close": "1.5",
+                "quoteVol": "3",
+                "baseVol": "4.5",
+            },
+        ]
+    )
+
+    candles = await client.fetch_ohlcv(
+        "BTC/USDT:USDT",
+        "1m",
+        since=60_000,
+        limit=1000,
+        params={"until": 180_000},
+    )
+
+    assert candles == [
+        [60_000, 1.0, 2.0, 0.5, 1.5, 3.0],
+        [120_000, 2.0, 3.0, 1.0, 2.5, 4.0],
+    ]
+    query = client._request.await_args.kwargs["params"]
+    assert query["limit"] == 200
+    assert query["startTime"] == 60_000
+    assert query["endTime"] == 180_000
+
+
+@pytest.mark.asyncio
+async def test_ohlcv_derives_forward_page_end_from_since_when_venue_ignores_start():
+    client = _prepared_client()
+    client._request = AsyncMock(return_value=[])
+
+    await client.fetch_ohlcv(
+        "BTC/USDT:USDT", "1m", since=60_000, limit=200
+    )
+
+    query = client._request.await_args.kwargs["params"]
+    assert query["startTime"] == 60_000
+    assert query["endTime"] == 60_000 + 200 * 60_000
+
+
+def test_bot_order_params_require_durable_hedge_semantics():
+    bot = build_contract_bot("bitunix")
+
+    params = bot._build_order_params(
+        {
+            "position_side": "short",
+            "custom_id": "clock_close_short_1",
+            "reduce_only": True,
+            "type": "limit",
+        }
+    )
+
+    assert params == {
+        "positionSide": "SHORT",
+        "clientOrderId": "clock_close_short_1",
+        "reduceOnly": True,
+        "effect": "GTC",
+    }
+    with pytest.raises(ValueError, match="invalid position_side"):
+        bot._build_order_params(
+            {
+                "position_side": "",
+                "custom_id": "clock_entry_long_1",
+                "type": "limit",
+            }
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "current_mode,current_leverage,expect_margin,expect_leverage",
+    [
+        ("CROSS", 3, False, False),
+        ("CROSS", 5, False, True),
+        # A margin-mode change may reset venue leverage, so set it again even
+        # when the pre-mutation leverage happened to match.
+        ("ISOLATION", 3, True, True),
+    ],
+)
+async def test_symbol_config_mutates_only_needed_state_and_reapplies_leverage(
+    current_mode,
+    current_leverage,
+    expect_margin,
+    expect_leverage,
+):
+    bot = build_contract_bot("bitunix")
+    symbol = "BTC/USDT:USDT"
+    bot.max_leverage = {symbol: 125}
+    bot.markets_dict = {symbol: _market()}
+    bot.cca = SimpleNamespace(
+        fetch_leverage_margin_mode=AsyncMock(
+            return_value={
+                "marginMode": current_mode,
+                "leverage": current_leverage,
+            }
+        ),
+        set_margin_mode=AsyncMock(return_value={"code": 0}),
+        set_leverage=AsyncMock(return_value={"code": 0}),
+    )
+
+    await bot.update_exchange_config_by_symbols([symbol])
+
+    assert bot.cca.set_margin_mode.await_count == int(expect_margin)
+    assert bot.cca.set_leverage.await_count == int(expect_leverage)
+    if expect_leverage:
+        bot.cca.set_leverage.assert_awaited_once_with(3, symbol)
+
+
+@pytest.mark.asyncio
+async def test_bitunix_fetcher_normalizes_accounting_fields():
+    client = _prepared_client()
+    client.fetch_my_trades = AsyncMock(
+        return_value=[client._normalize_trade(_trade_row())]
+    )
+    fetcher = BitunixFetcher(client)
+    cache = {}
+
+    events = await fetcher.fetch(
+        1_699_999_000_000, 1_700_001_000_000, cache
+    )
+
+    assert len(events) == 1
+    assert events[0]["id"] == "trade-1"
+    assert events[0]["position_side"] == "long"
+    assert events[0]["side"] == "buy"
+    assert events[0]["pnl"] == 0.0
+    assert events[0]["c_mult"] == 1.0
+    assert cache["trade-1"][0] == "clock_entry_long_1"
+
+
+@pytest.mark.asyncio
+async def test_bitunix_fetcher_enriches_missing_fill_client_id_from_order_detail():
+    client = _prepared_client()
+    trade = client._normalize_trade(_trade_row(clientId=""))
+    client.fetch_my_trades = AsyncMock(return_value=[trade])
+    client.fetch_order = AsyncMock(
+        return_value={
+            "clientOrderId": "clock_entry_long_1",
+            "info": {"clientId": "clock_entry_long_1"},
+        }
+    )
+    fetcher = BitunixFetcher(client)
+    cache = {}
+
+    events = await fetcher.fetch(None, None, cache)
+
+    assert events[0]["client_order_id"] == "clock_entry_long_1"
+    assert events[0]["pb_order_type"]
+    assert cache["trade-1"][0] == "clock_entry_long_1"
+
+
+def test_build_fetcher_for_bitunix():
+    bot = SimpleNamespace(
+        exchange="bitunix",
+        cca=object(),
+        user="bitunix_user",
+        config={"live": {}},
+    )
+    assert isinstance(_build_fetcher_for_bot(bot, []), BitunixFetcher)
+
+
+def test_setup_bot_bitunix_uses_native_adapter():
+    from passivbot import setup_bot
+
+    config = {"live": {"user": "bitunix_01"}}
+    with patch("passivbot.load_user_info", return_value={"exchange": "bitunix"}):
+        with patch("exchanges.bitunix.BitunixBot") as mock_cls:
+            result = setup_bot(config)
+    assert result is mock_cls.return_value
+    mock_cls.assert_called_once_with(config)

--- a/tests/exchanges/test_bitunix.py
+++ b/tests/exchanges/test_bitunix.py
@@ -844,6 +844,62 @@ async def test_order_stream_propagates_rest_transport_failure():
 
 
 @pytest.mark.asyncio
+async def test_order_stream_forwards_malformed_rows_for_account_refresh():
+    client = _prepared_client()
+    client.fetch_order = AsyncMock()
+    stream = BitunixOrderStream(client)
+    stream._ws = SimpleNamespace(
+        closed=False,
+        receive=AsyncMock(
+            return_value=SimpleNamespace(
+                type=aiohttp.WSMsgType.TEXT,
+                data=json.dumps(
+                    {
+                        "ch": "order",
+                        "data": [
+                            {"symbol": "BTCUSDT", "status": "FILLED"},
+                            "malformed",
+                        ],
+                    }
+                ),
+            )
+        ),
+    )
+
+    rows = await stream.watch_orders()
+
+    assert rows == [
+        {
+            "symbol": "BTC/USDT:USDT",
+            "info": {
+                "raw": {"symbol": "BTCUSDT", "status": "FILLED"}
+            },
+        },
+        {"info": {"raw": "malformed"}},
+    ]
+    client.fetch_order.assert_not_awaited()
+
+    bot = build_contract_bot("bitunix")
+    bot.ccp = SimpleNamespace(has={"watchOrders": True})
+    bot.stop_websocket = False
+    bot._do_watch_orders = AsyncMock(
+        side_effect=[rows, asyncio.CancelledError]
+    )
+    bot._mark_account_critical_state_dirty = MagicMock()
+    bot.handle_order_update = MagicMock()
+
+    await bot.watch_orders()
+
+    bot._mark_account_critical_state_dirty.assert_called_once_with(
+        reason="order_ws_semantics_unavailable",
+        symbols={"BTC/USDT:USDT"},
+        source="bitunix_order_ws",
+        level=logging.DEBUG,
+    )
+    bot.handle_order_update.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_unenriched_order_row_requests_account_state_refresh():
     bot = build_contract_bot("bitunix")
     bot.ccp = SimpleNamespace(has={"watchOrders": True})
@@ -943,6 +999,38 @@ async def test_depth_ticker_uses_midpoint_as_synthetic_last():
 
     assert ticker["last"] == 100.0
     assert ticker["source"] == "bitunix_depth_mid"
+
+
+@pytest.mark.asyncio
+async def test_future_exchange_timestamp_does_not_extend_cache_freshness():
+    client = _prepared_client()
+    symbol = "BTC/USDT:USDT"
+    client.TICKER_WAIT_SECONDS = 0.0
+    client._ensure_ticker_tasks = lambda: None
+    client.milliseconds = lambda: 100_000
+    client._ticker_cache[symbol] = {
+        "symbol": symbol,
+        "bid": 99.0,
+        "ask": 101.0,
+        "last": 100.0,
+        "timestamp": 10**15,
+    }
+    client._ticker_received_monotonic[symbol] = 60.0
+    fallback = {
+        "symbol": symbol,
+        "bid": 98.0,
+        "ask": 102.0,
+        "last": 100.0,
+        "timestamp": 100_000,
+        "source": "bitunix_depth_mid",
+    }
+    client._fetch_depth_ticker = AsyncMock(return_value=fallback)
+
+    with patch("exchanges.bitunix.time.monotonic", return_value=100.0):
+        tickers = await client.fetch_tickers([symbol])
+
+    assert tickers == {symbol: fallback}
+    client._fetch_depth_ticker.assert_awaited_once_with(symbol)
 
 
 @pytest.mark.asyncio

--- a/tests/test_setup_bot_fallback.py
+++ b/tests/test_setup_bot_fallback.py
@@ -15,6 +15,7 @@ def test_order_churn_rollout_allowlist_matches_supported_connector_contract():
     assert ORDER_CHURN_GATE_SUPPORTED_EXCHANGES == {
         "binance",
         "bitget",
+        "bitunix",
         "bybit",
         "fake",
         "gateio",
@@ -24,6 +25,7 @@ def test_order_churn_rollout_allowlist_matches_supported_connector_contract():
         "weex",
     }
     assert connector_supports_order_churn_gate(SimpleNamespace(exchange="weex")) is True
+    assert connector_supports_order_churn_gate(SimpleNamespace(exchange="bitunix")) is True
     assert connector_supports_order_churn_gate(SimpleNamespace(exchange="kraken")) is False
 
 


### PR DESCRIPTION
## Summary

- add a native async Bitunix USDT perpetual-futures connector because Bitunix is not available in CCXT
- implement signed REST, public ticker WebSocket fanout, authenticated private order WebSocket handling, market metadata, top-of-book quotes, live OHLCV pagination, balances, positions, hedge-mode order handling, account configuration, and realized-PnL fill ingestion
- route Bitunix through Passivbot startup, reconciliation, candlestick, fill-event, and order-churn contracts
- document the exchange-specific request/response semantics and add the public API-key template entry

Bulk Bitunix historical data for backtesting/optimization is intentionally out of scope; the candle implementation covers live startup, warmup, restart reconstruction, and runtime indicators.

## Why

Bitunix is absent from both the pinned CCXT release and CCXT's current supported-exchange list. The official repository provides API demos rather than a packaged production client, while the available PyPI client is an unofficial alpha without WebSocket support. A narrow native connector against Bitunix's official futures REST and WebSocket APIs is therefore the smallest production-capable path while retaining Passivbot's existing CCXT-compatible internal boundary.

## Validation

- full repository test suite: `python -m pytest -q`
- focused Bitunix and integration regression suites
- Python compile checks, JSON/HJSON parsing, and `git diff --check`
- public live market/depth/candle checks against the official Bitunix API
- end-to-end live order, position, fill, balance, configuration, and WebSocket contract checks

Private credentials, account data, balances, logs, caches, monitor output, network details, and other local artifacts are excluded.