### PR TITLE
Add per-objective optimizer suite scoring bases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Optimizer suites may now select the scoring basis independently for each objective. A scoring
+  entry may set `scenario` to a named suite scenario, set it explicitly to `null` to use suite
+  aggregation, and optionally set `aggregate` to `mean`, `min`, `max`, `std`, or `median`.
+  Omitting `scenario` inherits `optimize.objective_scenario`; aggregate objectives without an
+  explicit reducer inherit the metric-specific or default `backtest.aggregate` rule. Limits remain
+  suite-aggregated.
 - Gate multi-currency futures balance now remains stable while resting orders reserve and release
   margin, preventing balance-driven ideal-order resizing and reconciliation churn. Passivbot
   reconstructs account margin balance from Gate's available, position-margin, and order-margin

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -620,6 +620,11 @@ Risk should be constrained through canonical `*_strategy_eq` metrics instead. De
 - **round_to_n_significant_digits**: Quantization precision used when hashing configs, deduplicating candidates, and writing optimizer artifacts. Lower values collapse near-identical candidates more aggressively; higher values preserve more distinct variants.
 - **scoring**:
   - The optimizer minimizes the configured objective list and keeps the Pareto front.
+  - Each object-form scoring entry accepts `metric`, `goal`, and optional suite-only `scenario`
+    and `aggregate` selectors. An omitted `scenario` inherits `optimize.objective_scenario`; a
+    named value selects that scenario; explicit `null` selects suite aggregation. `aggregate`
+    overrides the reducer for that objective and supports `mean`, `min`, `max`, `std`, and
+    `median`. It is invalid when the objective resolves to a named scenario.
   - The current default profile uses:
     - `adg_strategy_eq`
     - `adg_strategy_eq_w`
@@ -647,9 +652,11 @@ The optimizer reuses the backtest suite configuration when `--suite [y/n]` is en
 - **backtest.suite_enabled**: Can be toggled for optimizer runs via `--suite [y/n]` on `passivbot optimize`.
 - **backtest.aggregate**: Per-metric aggregation rules applied to scenario results before feeding into `optimize.scoring` and `optimize.limits`.
 - **backtest.scenarios**: Scenario dictionaries. Each one may override `coins`, `ignored_coins`, `start_date`, `end_date`, `exchanges`, `coin_sources`, and `overrides` (arbitrary config path overrides).
-- **optimize.objective_scenario**: Optional unique scenario label used for objective scoring.
-  Limits remain suite-aggregated, so a common pattern is `base` performance scoring with
-  worst-case stress limits.
+- **optimize.objective_scenario**: Default scoring scenario. Set it to a unique scenario label to
+  score objectives from that scenario by default, or to `null` to use suite aggregation by
+  default. Individual `optimize.scoring` entries may override the default with a named `scenario`
+  or explicit `scenario: null`, and aggregate-based entries may set their own `aggregate` reducer.
+  Limits remain suite-aggregated.
 
 Use `--suite-config path/to/file.json` to layer additional scenario definitions at runtime.
 

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -399,14 +399,49 @@ Key fields (directly under `backtest`):
 
 - `backtest.suite_enabled`: master toggle for suite mode, can also be set with `--suite [y/n]`
 - `backtest.scenarios`: list of scenario dictionaries (same schema as backtest scenarios)
-- `backtest.aggregate`: how to combine per-scenario metrics (default: `{"default": "mean"}`)
+- `backtest.aggregate`: default per-metric reducers for combining scenario results (default:
+  `{"default": "mean"}`)
 
-Set `optimize.objective_scenario` to a unique scenario label (commonly `base`) when the suite
-exists primarily as a robustness gate. Objectives are then read from that scenario, while
-`optimize.limits` continue to use the suite aggregation and each limit's `stat`. This supports
-optimizing performance on a representative long period while enforcing worst-case drawdown,
-completion, and recovery constraints across shorter stress periods. The equivalent CLI override
-is `--objective-scenario LABEL`.
+`optimize.objective_scenario` sets the default scoring basis. Set it to a unique scenario label
+(commonly `base`) to read objectives from that scenario by default, or leave it `null` to use suite
+aggregation by default. The equivalent global CLI override is `--objective-scenario LABEL`.
+`optimize.limits` always continue to use suite aggregation and each limit's `stat`.
+
+Each object-form `optimize.scoring` entry may override the default:
+
+```json
+{
+  "backtest": {
+    "aggregate": {"default": "mean"}
+  },
+  "optimize": {
+    "objective_scenario": "base",
+    "scoring": [
+      {"metric": "adg_strategy_eq", "goal": "max"},
+      {
+        "metric": "strategy_eq_underwater_pct_mean",
+        "goal": "min",
+        "scenario": null
+      },
+      {
+        "metric": "strategy_eq_recovery_days_max",
+        "goal": "min",
+        "scenario": null,
+        "aggregate": "max"
+      }
+    ]
+  }
+}
+```
+
+An omitted `scenario` inherits `optimize.objective_scenario`, a named value selects that scenario,
+and explicit `null` selects suite aggregation. An aggregate objective without its own `aggregate`
+uses the metric-specific `backtest.aggregate` rule and then its `default`; an explicit `aggregate`
+may be `mean`, `min`, `max`, `std`, or `median`. A named scenario and `aggregate` are mutually
+exclusive. This permits representative base-period performance objectives alongside mean or
+worst-case stress objectives while limits retain their independent suite-wide contract.
+Each metric may still appear only once in `optimize.scoring`; scoring the same metric from multiple
+bases is not supported in this first version.
 
 Suite mode is opt-in. The default schema/example config does not enable it automatically.
 
@@ -415,8 +450,7 @@ During evaluation the optimizer records:
 - Per-scenario combined metrics (the same mean/min/max/std set produced by standalone
   backtests). These are exposed on each individual as `<label>__{metric}`.
 - Aggregated metrics computed with the `backtest.aggregate` rules (default `mean`).
-  These aggregated values feed `optimize.limits` and, unless `optimize.objective_scenario` is set,
-  `optimize.scoring`.
+  These values feed `optimize.limits` and aggregate-based `optimize.scoring` entries.
 
 See [Suite Examples](suite_examples.md) for practical scenario configurations including exchange
 comparisons, date range testing, and parameter sensitivity analysis.

--- a/docs/suite_examples.md
+++ b/docs/suite_examples.md
@@ -185,6 +185,28 @@ Interpretation:
 - use `mean` for general performance metrics
 - use `max` for risk and recovery metrics where the worst scenario matters more than the average
 
+`optimize.objective_scenario` sets the default source for scoring objectives. Individual scoring
+entries may select a named `scenario`, set `scenario` explicitly to `null` to use suite
+aggregation, and optionally set an objective-only `aggregate` reducer. For example:
+
+```json
+{
+  "optimize": {
+    "objective_scenario": "base",
+    "scoring": [
+      {"metric": "adg_strategy_eq", "goal": "max"},
+      {
+        "metric": "strategy_eq_underwater_pct_mean",
+        "goal": "min",
+        "scenario": null
+      }
+    ]
+  }
+}
+```
+
+Here ADG uses `base`, while underwater percentage uses the configured suite aggregate.
+
 ## Recommended Workflow
 
 1. Start with a single backtest or optimize run.

--- a/src/config/limits.py
+++ b/src/config/limits.py
@@ -10,7 +10,8 @@ import hjson
 from .metrics import canonical_metric_name, canonicalize_limit_name, canonicalize_metric_name
 
 
-SUPPORTED_LIMIT_STATS = {"min", "max", "mean", "std", "median"}
+SUPPORTED_AGGREGATE_MODES = {"min", "max", "mean", "std", "median"}
+SUPPORTED_LIMIT_STATS = SUPPORTED_AGGREGATE_MODES
 
 
 def parse_limits_string(limits_str: Union[str, dict]) -> dict:

--- a/src/config/scoring.py
+++ b/src/config/scoring.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Iterable, Sequence
 
 from .access import require_config_dict
+from .limits import SUPPORTED_AGGREGATE_MODES, resolve_aggregate_mode
 from .log_output import log_config_message
 from .metrics import canonicalize_metric_name
 
 OBJECTIVE_GOALS = ("min", "max")
+SCORING_ENTRY_FIELDS = {"metric", "goal", "scenario", "aggregate"}
+
+
+class ScenarioSelection(Enum):
+    INHERIT = "inherit"
+
 
 DEFAULT_OBJECTIVE_GOALS = {
     "positions_held_per_day": "min",
@@ -147,13 +155,26 @@ DEFAULT_OBJECTIVE_GOALS = {
 class ObjectiveSpec:
     metric: str
     goal: str
+    scenario: str | None | ScenarioSelection = ScenarioSelection.INHERIT
+    aggregate: str | None = None
 
     @property
     def engine_sign(self) -> float:
         return -1.0 if self.goal == "max" else 1.0
 
-    def to_config(self) -> dict[str, str]:
-        return {"metric": self.metric, "goal": self.goal}
+    def to_config(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {"metric": self.metric, "goal": self.goal}
+        if self.scenario is not ScenarioSelection.INHERIT:
+            payload["scenario"] = self.scenario
+        if self.aggregate is not None:
+            payload["aggregate"] = self.aggregate
+        return payload
+
+
+@dataclass(frozen=True)
+class ObjectiveBasis:
+    scenario: str | None
+    aggregate: str | None
 
 
 def _normalize_goal(value: Any, *, path: str) -> str:
@@ -162,6 +183,28 @@ def _normalize_goal(value: Any, *, path: str) -> str:
         allowed = ", ".join(OBJECTIVE_GOALS)
         raise ValueError(f"{path} must be one of {{{allowed}}}, got {value!r}")
     return goal
+
+
+def _normalize_scenario(value: Any, *, path: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{path} must be a scenario label string or null, got {value!r}")
+    scenario = value.strip()
+    if not scenario:
+        raise ValueError(f"{path} must be a non-empty scenario label or null")
+    return scenario
+
+
+def _normalize_aggregate(value: Any, *, path: str) -> str | None:
+    if value is None:
+        return None
+    aggregate = str(value).strip().lower()
+    if aggregate not in SUPPORTED_AGGREGATE_MODES:
+        raise ValueError(
+            f"{path} must be one of {sorted(SUPPORTED_AGGREGATE_MODES)}, got {value!r}"
+        )
+    return aggregate
 
 
 def default_objective_goal(metric: str) -> str | None:
@@ -184,10 +227,26 @@ def _normalize_spec(
     unknown_goal: str,
 ) -> tuple[ObjectiveSpec, bool]:
     if isinstance(item, ObjectiveSpec):
+        scenario = item.scenario
+        if scenario is not ScenarioSelection.INHERIT:
+            scenario = _normalize_scenario(
+                scenario,
+                path=f"config.optimize.scoring[{index}].scenario",
+            )
         spec = ObjectiveSpec(
             metric=canonicalize_metric_name(item.metric),
             goal=_normalize_goal(item.goal, path=f"config.optimize.scoring[{index}].goal"),
+            scenario=scenario,
+            aggregate=_normalize_aggregate(
+                item.aggregate,
+                path=f"config.optimize.scoring[{index}].aggregate",
+            ),
         )
+        if isinstance(spec.scenario, str) and spec.aggregate is not None:
+            raise ValueError(
+                f"config.optimize.scoring[{index}] cannot set both a named scenario "
+                "and aggregate"
+            )
         return spec, False
 
     if isinstance(item, str):
@@ -205,6 +264,12 @@ def _normalize_spec(
         return ObjectiveSpec(metric=metric, goal=goal), True
 
     if isinstance(item, dict):
+        unknown_fields = sorted(set(item) - SCORING_ENTRY_FIELDS)
+        if unknown_fields:
+            raise ValueError(
+                f"config.optimize.scoring[{index}] has unknown field(s): "
+                f"{', '.join(unknown_fields)}"
+            )
         metric = canonicalize_metric_name(str(item.get("metric", "")).strip())
         if not metric:
             raise ValueError(f"config.optimize.scoring[{index}].metric must be a non-empty string")
@@ -219,11 +284,33 @@ def _normalize_spec(
                 goal = unknown_goal
         else:
             goal = _normalize_goal(raw_goal, path=f"config.optimize.scoring[{index}].goal")
-        return ObjectiveSpec(metric=metric, goal=goal), False
+        scenario = (
+            _normalize_scenario(
+                item.get("scenario"),
+                path=f"config.optimize.scoring[{index}].scenario",
+            )
+            if "scenario" in item
+            else ScenarioSelection.INHERIT
+        )
+        aggregate = _normalize_aggregate(
+            item.get("aggregate"),
+            path=f"config.optimize.scoring[{index}].aggregate",
+        )
+        if isinstance(scenario, str) and aggregate is not None:
+            raise ValueError(
+                f"config.optimize.scoring[{index}] cannot set both a named scenario "
+                "and aggregate"
+            )
+        return ObjectiveSpec(
+            metric=metric,
+            goal=goal,
+            scenario=scenario,
+            aggregate=aggregate,
+        ), False
 
     raise ValueError(
         "config.optimize.scoring entries must be strings or objects like "
-        "{metric: ..., goal: min|max}"
+        "{metric: ..., goal: min|max, scenario: label|null, aggregate: mean|min|max|std|median}"
     )
 
 
@@ -297,6 +384,25 @@ def objective_spec_by_metric(config_or_scoring: Any) -> dict[str, ObjectiveSpec]
     return {spec.metric: spec for spec in extract_objective_specs(config_or_scoring)}
 
 
+def resolve_objective_basis(
+    spec: ObjectiveSpec,
+    *,
+    default_scenario: str | None,
+    aggregate_cfg: dict[str, Any] | None,
+) -> ObjectiveBasis:
+    scenario = default_scenario if spec.scenario is ScenarioSelection.INHERIT else spec.scenario
+    if scenario is not None:
+        if spec.aggregate is not None:
+            raise ValueError(
+                f"scoring objective {spec.metric!r} resolves to scenario {scenario!r} "
+                f"and cannot also use aggregate {spec.aggregate!r}; set scenario to null "
+                "to use suite aggregation"
+            )
+        return ObjectiveBasis(scenario=scenario, aggregate=None)
+    aggregate = spec.aggregate or resolve_aggregate_mode(spec.metric, aggregate_cfg)
+    return ObjectiveBasis(scenario=None, aggregate=aggregate)
+
+
 def to_engine_value(spec: ObjectiveSpec, raw_value: float) -> float:
     return float(raw_value) * spec.engine_sign
 
@@ -336,7 +442,14 @@ def dominates_objectives(
 
 
 def objective_display_name(spec: ObjectiveSpec) -> str:
-    return f"{spec.metric} ({spec.goal})"
+    basis = ""
+    if isinstance(spec.scenario, str):
+        basis = f", scenario={spec.scenario}"
+    elif spec.scenario is None:
+        basis = ", aggregate"
+    if spec.aggregate is not None:
+        basis += f"={spec.aggregate}"
+    return f"{spec.metric} ({spec.goal}{basis})"
 
 
 def default_scoring_weights() -> dict[str, float]:

--- a/src/config_utils.py
+++ b/src/config_utils.py
@@ -1423,8 +1423,8 @@ RESERVED_CLI_ARGS = {
         "commands": {"optimize"},
         "group": {"optimize": "Optimizer"},
         "help": (
-            "Use one suite scenario for scoring objectives while keeping optimize.limits "
-            "evaluated against suite aggregates."
+            "Default suite scenario for scoring objectives. Per-objective scenario selectors "
+            "may override it; optimize.limits remain suite-aggregated."
         ),
     },
     "optimize.population_size": {

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -89,6 +89,7 @@ from config.scoring import (
     extract_objective_specs,
     objective_index_map,
     objective_metric_names,
+    resolve_objective_basis,
     to_engine_value,
 )
 from config.parse import load_raw_config as load_hjson_config
@@ -1604,9 +1605,15 @@ class Evaluator:
         analyses_combined,
         *,
         limit_metrics=None,
+        objective_values: Sequence[float] | None = None,
         return_raw_objectives: bool = False,
     ):
         limit_metrics = analyses_combined if limit_metrics is None else limit_metrics
+        if objective_values is not None and len(objective_values) != len(self.scoring_specs):
+            raise ValueError(
+                "optimizer objective value count does not match optimize.scoring: "
+                f"{len(objective_values)} != {len(self.scoring_specs)}"
+            )
         per_objective_modifier = [0.0] * len(self.scoring_specs)
         global_modifier = 0.0
         for check in self.limit_checks:
@@ -1632,9 +1639,15 @@ class Evaluator:
         engine_scores = []
         raw_objectives: Dict[str, float] = {}
         for idx, spec in enumerate(self.scoring_specs):
-            val = resolve_metric_value(analyses_combined, f"{spec.metric}_mean")
-            if val is None and spec.metric.endswith(("_usd", "_btc")):
-                val = resolve_metric_value(analyses_combined, f"{spec.metric.rsplit('_', 1)[0]}_mean")
+            if objective_values is None:
+                val = resolve_metric_value(analyses_combined, f"{spec.metric}_mean")
+                if val is None and spec.metric.endswith(("_usd", "_btc")):
+                    val = resolve_metric_value(
+                        analyses_combined,
+                        f"{spec.metric.rsplit('_', 1)[0]}_mean",
+                    )
+            else:
+                val = objective_values[idx]
 
             if val is None:
                 raise ValueError(
@@ -1692,12 +1705,20 @@ class SuiteEvaluator:
         )
         if not self.objective_scenario:
             self.objective_scenario = None
-        if self.objective_scenario is not None:
-            labels = [ctx.label for ctx in self.contexts]
-            if self.objective_scenario not in labels:
+        labels = [ctx.label for ctx in self.contexts]
+        self.objective_bases = [
+            resolve_objective_basis(
+                spec,
+                default_scenario=self.objective_scenario,
+                aggregate_cfg=self.aggregate_cfg,
+            )
+            for spec in self.base.scoring_specs
+        ]
+        for spec, basis in zip(self.base.scoring_specs, self.objective_bases):
+            if basis.scenario is not None and basis.scenario not in labels:
                 raise ValueError(
-                    "optimize.objective_scenario "
-                    f"{self.objective_scenario!r} is not present in backtest.scenarios; "
+                    f"scoring objective {spec.metric!r} selects scenario "
+                    f"{basis.scenario!r}, which is not present in backtest.scenarios; "
                     f"available labels: {', '.join(labels)}"
                 )
         self.base.build_limit_checks(self.aggregate_cfg)
@@ -2036,23 +2057,51 @@ class SuiteEvaluator:
         suite_payload = build_suite_metrics_payload(scenario_results, aggregate_summary)
         aggregate_stats = aggregate_summary.get("stats", {})
 
-        flat_stats = flatten_metric_stats(aggregate_stats)
+        aggregate_stats_flat = flatten_metric_stats(aggregate_stats)
+        flat_stats = dict(aggregate_stats_flat)
         # Override _mean with correctly aggregated values so calc_fitness
-        # respects the aggregate config (e.g. "max" instead of "mean").
+        # and limit defaults respect the aggregate config (e.g. "max" instead of "mean").
         aggregated_values = aggregate_summary.get("aggregated", {})
         for metric, agg_value in aggregated_values.items():
             flat_stats[f"{metric}_mean"] = agg_value
-        objective_stats = flat_stats
-        if self.objective_scenario is not None:
-            objective_result = next(
-                result
-                for result in scenario_results
-                if result.scenario.label == self.objective_scenario
-            )
-            objective_stats = flatten_metric_stats(objective_result.metrics.get("stats", {}))
+        required_scenario_labels = {
+            basis.scenario for basis in self.objective_bases if basis.scenario is not None
+        }
+        scenario_stats_by_label = {
+            result.scenario.label: flatten_metric_stats(result.metrics.get("stats", {}))
+            for result in scenario_results
+            if result.scenario.label in required_scenario_labels
+        }
+        objective_values: List[float] = []
+        for spec, basis in zip(self.base.scoring_specs, self.objective_bases):
+            if basis.scenario is not None:
+                source_stats = scenario_stats_by_label[basis.scenario]
+                stat = "mean"
+            else:
+                source_stats = aggregate_stats_flat
+                stat = basis.aggregate or "mean"
+            value = resolve_metric_value(source_stats, f"{spec.metric}_{stat}")
+            if value is None and spec.metric.endswith(("_usd", "_btc")):
+                value = resolve_metric_value(
+                    source_stats,
+                    f"{spec.metric.rsplit('_', 1)[0]}_{stat}",
+                )
+            if value is None:
+                basis_label = (
+                    f"scenario {basis.scenario!r}"
+                    if basis.scenario is not None
+                    else f"aggregate {stat!r}"
+                )
+                raise ValueError(
+                    "missing optimizer scoring metric "
+                    f"{spec.metric!r} for {basis_label}; "
+                    f"available metrics: {_format_available_metric_keys(source_stats)}"
+                )
+            objective_values.append(float(value))
         objectives, total_penalty = self.base.calc_fitness(
-            objective_stats,
+            flat_stats,
             limit_metrics=flat_stats,
+            objective_values=objective_values,
         )
         objectives_map = {f"w_{i}": val for i, val in enumerate(objectives)}
         _profile_add(timings, "fitness_payload_ms", phase_start)

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -646,9 +646,11 @@ def load_candidates(path: str | os.PathLike[str]) -> tuple[Path, List[ParetoCand
         if baseline_specs is None:
             baseline_specs = specs
             baseline_metrics = metrics
-        elif metrics != baseline_metrics:
+        elif specs != baseline_specs:
             raise ValueError(
-                f"Inconsistent optimize.scoring in {entry_path}; expected {baseline_metrics}, got {metrics}"
+                f"Inconsistent optimize.scoring in {entry_path}; expected "
+                f"{[spec.to_config() for spec in baseline_specs]}, got "
+                f"{[spec.to_config() for spec in specs]}"
             )
 
         metrics_block = entry.get("metrics") or {}

--- a/src/pareto_store.py
+++ b/src/pareto_store.py
@@ -196,8 +196,16 @@ class ParetoStore:
         self._bootstrap_from_disk()
 
     @staticmethod
-    def _scoring_signature(specs: Sequence[Any]) -> tuple[tuple[str, str], ...]:
-        return tuple((spec.metric, spec.goal) for spec in specs)
+    def _scoring_signature(specs: Sequence[Any]) -> tuple[tuple[Any, ...], ...]:
+        return tuple(
+            (
+                spec.metric,
+                spec.goal,
+                spec.to_config().get("scenario", "<inherit>"),
+                spec.aggregate,
+            )
+            for spec in specs
+        )
 
     def _apply_entry_scoring_specs(self, entry: dict) -> None:
         entry_specs = extract_objective_specs(entry)

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -3584,9 +3584,125 @@ class TestEvaluator:
 
         with pytest.raises(
             ValueError,
-            match="optimize.objective_scenario 'base' is not present",
+            match="selects scenario 'base'.*not present",
         ):
             SuiteEvaluator(base, [], {"default": "mean"})
+
+    def test_suite_scoring_resolves_mixed_scenario_and_aggregate_bases(self):
+        from optimize import Evaluator, SuiteEvaluator
+        from config_utils import get_template_config
+
+        class DummyIndividual(list):
+            pass
+
+        mock_config = get_template_config()
+        mock_config["optimize"]["limits"] = []
+        mock_config["optimize"]["objective_scenario"] = "base"
+        mock_config["optimize"]["scoring"] = [
+            {"metric": "adg_strategy_eq", "goal": "max"},
+            {
+                "metric": "strategy_eq_underwater_pct_mean",
+                "goal": "min",
+                "scenario": None,
+            },
+            {
+                "metric": "strategy_eq_recovery_days_max",
+                "goal": "min",
+                "scenario": None,
+                "aggregate": "max",
+            },
+            {
+                "metric": "position_held_days_max",
+                "goal": "min",
+                "scenario": "stress",
+            },
+        ]
+        mock_config["backtest"]["start_date"] = "2023-01-01"
+        mock_config["backtest"]["end_date"] = "2023-01-02"
+        mock_config["backtest"]["coins"] = {"binance": ["BTC/USDT:USDT"]}
+        mock_config["live"]["approved_coins"] = {"long": ["BTC"], "short": []}
+        mock_config["live"]["ignored_coins"] = {"long": [], "short": []}
+
+        base = Evaluator(
+            hlcvs_specs={},
+            btc_usd_specs={},
+            msss={},
+            config=mock_config,
+        )
+
+        def make_context(label):
+            return ScenarioEvalContext(
+                label=label,
+                config=deepcopy(mock_config),
+                exchanges=["binance"],
+                hlcvs_specs={},
+                btc_usd_specs={},
+                msss={"binance": {}},
+                timestamps={"binance": None},
+                shared_hlcvs_np={"binance": np.zeros((1, 1, 5))},
+                shared_btc_np={},
+                attachments={"hlcvs": {}, "btc": {}},
+                coin_indices={"binance": None},
+                overrides={},
+            )
+
+        evaluator = SuiteEvaluator(
+            base,
+            [make_context("base"), make_context("stress")],
+            {"default": "mean"},
+        )
+        individual = DummyIndividual(
+            config_to_individual(mock_config, base.bounds, base.sig_digits)
+        )
+
+        def metric_stats(value):
+            return {
+                "mean": value,
+                "min": value,
+                "max": value,
+                "std": 0.0,
+                "median": value,
+            }
+
+        scenario_metric_payloads = [
+            {
+                "stats": {
+                    "adg_strategy_eq": metric_stats(0.01),
+                    "strategy_eq_underwater_pct_mean": metric_stats(0.1),
+                    "strategy_eq_recovery_days_max": metric_stats(10.0),
+                    "position_held_days_max": metric_stats(5.0),
+                }
+            },
+            {
+                "stats": {
+                    "adg_strategy_eq": metric_stats(0.002),
+                    "strategy_eq_underwater_pct_mean": metric_stats(0.5),
+                    "strategy_eq_recovery_days_max": metric_stats(50.0),
+                    "position_held_days_max": metric_stats(20.0),
+                }
+            },
+        ]
+
+        with patch("optimize.build_backtest_payload", return_value=object()), patch(
+            "optimize.execute_backtest",
+            return_value=(None, None, {"liquidated": False}),
+        ), patch(
+            "tools.iterative_backtester.combine_analyses",
+            side_effect=scenario_metric_payloads,
+        ):
+            objectives, penalty, metrics, _ = unpack_evaluation_payload(
+                evaluator.evaluate(individual, [])
+            )
+
+        assert objectives == pytest.approx((-0.01, 0.3, 50.0, 20.0))
+        assert penalty == 0.0
+        assert metrics["objectives"] == pytest.approx(
+            {"w_0": -0.01, "w_1": 0.3, "w_2": 50.0, "w_3": 20.0}
+        )
+        assert metrics["suite_metrics"]["metrics"]["adg_strategy_eq"]["scenarios"] == {
+            "base": 0.01,
+            "stress": 0.002,
+        }
 
     def test_evaluate_converts_recoverable_backtest_panic_to_penalty(self):
         from optimize import Evaluator, INVALID_BACKTEST_CANDIDATE_PENALTY

--- a/tests/test_config_optimize_suite.py
+++ b/tests/test_config_optimize_suite.py
@@ -45,6 +45,35 @@ def test_optimizer_objective_scenario_is_preserved():
     assert formatted["optimize"]["objective_scenario"] == "base"
 
 
+def test_optimizer_scoring_basis_round_trip_preserves_omitted_named_and_null_scenarios():
+    base = get_template_config()
+    base["_raw"] = deepcopy(base)
+    base["optimize"]["objective_scenario"] = "base"
+    base["optimize"]["scoring"] = [
+        {"metric": "adg_strategy_eq", "goal": "max"},
+        {
+            "metric": "strategy_eq_underwater_pct_mean",
+            "goal": "min",
+            "scenario": None,
+        },
+        {
+            "metric": "strategy_eq_recovery_days_max",
+            "goal": "min",
+            "scenario": "stress",
+        },
+        {
+            "metric": "position_held_days_max",
+            "goal": "min",
+            "scenario": None,
+            "aggregate": "max",
+        },
+    ]
+
+    formatted = format_config(deepcopy(base), verbose=False)
+
+    assert formatted["optimize"]["scoring"] == base["optimize"]["scoring"]
+
+
 def test_optimizer_preserves_explicit_hsl_aggregate_config():
     """Optimizer must not inherit template metric-specific aggregate overrides."""
     cfg = load_prepared_config("configs/examples/hsl_npos1.json", verbose=False)

--- a/tests/test_config_scoring.py
+++ b/tests/test_config_scoring.py
@@ -1,5 +1,12 @@
+import pytest
+
 from config.metrics import canonicalize_metric_name, resolve_metric_value
-from config.scoring import default_objective_goal, normalize_scoring_entries
+from config.scoring import (
+    ScenarioSelection,
+    default_objective_goal,
+    normalize_scoring_entries,
+    resolve_objective_basis,
+)
 
 
 def test_default_objective_goal_recognizes_new_ratio_metrics():
@@ -94,3 +101,145 @@ def test_strategy_eq_recovery_max_resolves_legacy_peak_metric_value():
 
     assert resolve_metric_value(metrics, "strategy_eq_recovery_days_max") == 12.5
     assert resolve_metric_value(metrics, "strategy_eq_recovery_days_max_mean") == 9.0
+
+
+def test_scoring_basis_preserves_inherit_named_and_explicit_aggregate_scenarios():
+    specs, _ = normalize_scoring_entries(
+        [
+            {"metric": "adg_strategy_eq", "goal": "max"},
+            {
+                "metric": "strategy_eq_underwater_pct_mean",
+                "goal": "min",
+                "scenario": " stress ",
+            },
+            {
+                "metric": "strategy_eq_recovery_days_max",
+                "goal": "min",
+                "scenario": None,
+                "aggregate": " MAX ",
+            },
+        ]
+    )
+
+    assert specs[0].scenario is ScenarioSelection.INHERIT
+    assert specs[0].to_config() == {
+        "metric": "adg_strategy_eq",
+        "goal": "max",
+    }
+    assert specs[1].to_config() == {
+        "metric": "strategy_eq_underwater_pct_mean",
+        "goal": "min",
+        "scenario": "stress",
+    }
+    assert specs[2].to_config() == {
+        "metric": "strategy_eq_recovery_days_max",
+        "goal": "min",
+        "scenario": None,
+        "aggregate": "max",
+    }
+
+
+def test_scoring_basis_resolves_omitted_and_null_scenario_in_both_default_directions():
+    aggregate_cfg = {
+        "default": "mean",
+        "strategy_eq_recovery_days_max": "max",
+    }
+    specs, _ = normalize_scoring_entries(
+        [
+            {"metric": "adg_strategy_eq", "goal": "max"},
+            {
+                "metric": "strategy_eq_underwater_pct_mean",
+                "goal": "min",
+                "scenario": None,
+            },
+            {
+                "metric": "strategy_eq_recovery_days_max",
+                "goal": "min",
+                "scenario": None,
+            },
+            {
+                "metric": "position_held_days_max",
+                "goal": "min",
+                "scenario": "stress",
+            },
+        ]
+    )
+
+    assert resolve_objective_basis(
+        specs[0],
+        default_scenario="base",
+        aggregate_cfg=aggregate_cfg,
+    ).scenario == "base"
+    underwater_basis = resolve_objective_basis(
+        specs[1],
+        default_scenario="base",
+        aggregate_cfg=aggregate_cfg,
+    )
+    assert underwater_basis.scenario is None
+    assert underwater_basis.aggregate == "mean"
+    recovery_basis = resolve_objective_basis(
+        specs[2],
+        default_scenario="base",
+        aggregate_cfg=aggregate_cfg,
+    )
+    assert recovery_basis.scenario is None
+    assert recovery_basis.aggregate == "max"
+
+    inherited_aggregate = resolve_objective_basis(
+        specs[0],
+        default_scenario=None,
+        aggregate_cfg=aggregate_cfg,
+    )
+    assert inherited_aggregate.scenario is None
+    assert inherited_aggregate.aggregate == "mean"
+    named_override = resolve_objective_basis(
+        specs[3],
+        default_scenario=None,
+        aggregate_cfg=aggregate_cfg,
+    )
+    assert named_override.scenario == "stress"
+    assert named_override.aggregate is None
+
+
+@pytest.mark.parametrize(
+    ("entry", "match"),
+    [
+        (
+            {"metric": "adg_strategy_eq", "goal": "max", "stat": "mean"},
+            "unknown field",
+        ),
+        (
+            {
+                "metric": "adg_strategy_eq",
+                "goal": "max",
+                "scenario": "base",
+                "aggregate": "mean",
+            },
+            "cannot set both",
+        ),
+        (
+            {"metric": "adg_strategy_eq", "goal": "max", "scenario": ""},
+            "non-empty scenario",
+        ),
+        (
+            {"metric": "adg_strategy_eq", "goal": "max", "aggregate": "p95"},
+            "must be one of",
+        ),
+    ],
+)
+def test_scoring_basis_rejects_ambiguous_or_unknown_fields(entry, match):
+    with pytest.raises(ValueError, match=match):
+        normalize_scoring_entries([entry])
+
+
+def test_scoring_aggregate_override_requires_effective_aggregate_scenario():
+    specs, _ = normalize_scoring_entries(
+        [{"metric": "adg_strategy_eq", "goal": "max", "aggregate": "max"}]
+    )
+
+    with pytest.raises(ValueError, match="set scenario to null"):
+        resolve_objective_basis(
+            specs[0],
+            default_scenario="base",
+            aggregate_cfg={"default": "mean"},
+        )

--- a/tests/test_pareto_extremes.py
+++ b/tests/test_pareto_extremes.py
@@ -184,6 +184,19 @@ def test_pareto_store_rejects_scored_entry_after_unscored_front(tmp_path):
         store.add_entry(_make_adg_candidate(2.0, include_scoring=True))
 
 
+def test_pareto_store_rejects_scoring_basis_mismatch(tmp_path):
+    first = _make_adg_candidate(1.0)
+    first["optimize"]["scoring"][0]["scenario"] = "base"
+    second = _make_adg_candidate(2.0)
+    second["optimize"]["scoring"][0]["scenario"] = None
+    second["optimize"]["scoring"][0]["aggregate"] = "mean"
+    store = ParetoStore(directory=str(tmp_path), sig_digits=6, flush_interval=10_000, max_size=50)
+
+    assert store.add_entry(first)
+    with pytest.raises(ValueError, match="optimize.scoring differs"):
+        store.add_entry(second)
+
+
 def test_pareto_store_rejects_missing_objective_values(tmp_path):
     entry = {
         "metrics": {


### PR DESCRIPTION
## Summary

- add tri-state per-objective `scenario` selection: omitted inherits `optimize.objective_scenario`, a label selects that suite scenario, and explicit `null` selects suite aggregation
- add per-objective `aggregate` overrides (`mean`, `min`, `max`, `std`, `median`) with fallback to metric-specific/default `backtest.aggregate`
- preserve the existing suite-aggregated limit contract and reject ambiguous named-scenario-plus-aggregate entries
- include scoring bases in Pareto compatibility checks and document the new configuration contract

Repeated use of the same metric with different scoring bases remains intentionally out of scope for this first version.

## Validation

- affected optimizer/config/Pareto regression suite passed
- focused post-review regression: 24 passed
- AI docs checks, live event registry check, Python compilation, and `git diff --check` passed
- rebuilt and verified the local Rust extension provenance (no Rust sources changed)
- ran two real optimizer suite smokes covering both default directions:
  - global named scenario with per-objective aggregate and named-scenario overrides
  - global aggregate mode with per-objective named-scenario and aggregate overrides
- verified persisted Pareto objective values against their selected scenario/aggregate sources

The optimizer smokes used public unauthenticated Binance market metadata and a temporary local smoke config; no private configs, results, credentials, or local artifacts are included in this PR.