### PR TITLE
Consolidate authoritative freshness ownership

### DIFF
--- a/docs/plans/live_execution_gatekeeper_architecture_plan.md
+++ b/docs/plans/live_execution_gatekeeper_architecture_plan.md
@@ -9,7 +9,7 @@ safe migration path for making live execution easier to inspect, test, and reaso
 
 The first implementation commitment is intentionally narrower than the full target architecture:
 build the event/data-packet spine and immutable per-cycle snapshot boundary first. Gatekeeper
-enforcement should remain conditional until the planning-availability contract is explicit and
+enforcement should remain conditional until the Rust planning-completeness contract is explicit and
 tested.
 
 ## Purpose
@@ -44,9 +44,9 @@ front-loaded:
 The key unresolved safety gap is downstream gatekeeper visibility. A gatekeeper can only evaluate
 actions Rust emitted. If stale or missing snapshot inputs cause Rust not to emit an order it would
 have emitted with fresh data, the gatekeeper cannot recover that missing action. The mitigation is
-not gatekeeping alone; it is an explicit planning-availability contract before enforcement.
+not gatekeeping alone; it is an explicit Rust planning-completeness contract before enforcement.
 
-This means the first useful plateau is Phases 1-2 plus a planning-availability audit surface. The
+This means the first useful plateau is Phases 1-2 plus a Rust planning-completeness audit surface. The
 full gatekeeper should be built only after that plateau is reviewed and the stale-input policy is
 settled.
 
@@ -741,7 +741,7 @@ in JSONL artifacts or DEBUG/TRACE.
 
 - Add this plan and review with external agents.
 - Record the agreed scope split: Phases 1-2 are green-lit as a behavior-preserving plateau;
-  gatekeeper enforcement is conditional on planning-availability work.
+  gatekeeper enforcement is conditional on Rust planning-completeness work.
 - Identify current call sites for snapshot building, Rust input building, reconciliation, gates, and
   executor writes.
 - Define initial `DataPacket`, `LiveSnapshot`, `PlannedAction`, and `GateDecision` types in tests
@@ -896,8 +896,9 @@ The smallest valuable slice:
 5. Add tests proving the current cycle uses frozen packet revisions.
 6. Emit minimal `planning_unavailable` events for account-critical or obviously stale non-account
    surfaces without changing execution.
-7. Add passive planning-availability reporting and diagnostic-isolation tests before any
-   gatekeeper enforcement work.
+7. Add Rust-origin planning-completeness reporting for decisions Rust actually evaluated, plus
+   diagnostic-isolation tests, before any gatekeeper enforcement work. Do not recreate a
+   Python-side Cartesian product of hypothetical symbol, side, and order-class decisions.
 
 This creates the diagnostic spine without changing order behavior. Gatekeeper enforcement should
-wait until the event, snapshot, and planning-availability boundaries are visible and testable.
+wait until the event, snapshot, and Rust planning-completeness boundaries are visible and testable.

--- a/docs/plans/live_overengineering_audit_followup_plan.md
+++ b/docs/plans/live_overengineering_audit_followup_plan.md
@@ -42,6 +42,11 @@ verification and contract-specific regression coverage.
 4. The passive Python planning-availability Cartesian product and its routine
    per-snapshot event were removed. They duplicated readiness evidence, could
    not model actual Rust applicability, and were never enforcement inputs.
+5. Authoritative per-surface signature, freshness, and changed-this-cohort
+   ownership was consolidated in `FreshnessLedger`. Parallel `Passivbot` maps
+   and sets plus both unused generation counters were removed; pending
+   post-write confirmation obligations and immutable planning snapshots remain
+   separate because they represent distinct contracts.
 
 ## Decision rules for further work
 
@@ -92,6 +97,12 @@ Look for:
 Desired output: one owner for each readiness fact, a mapping of downstream
 consumers, and a deletion-first proposal. Do not implement until the
 account-wide versus scoped safety boundary is explicit.
+
+Current result: `FreshnessLedger` is the sole owner of per-surface freshness
+and change facts. Remaining candidates are the scalar
+`_authoritative_refresh_epoch` compatibility alias and the overlapping
+disappeared-self-order confirmation, symbol-block, and same-wave state-change
+representations. Audit their direct callers before further deletion.
 
 ### 2. Fill and realized-PnL reconstruction
 
@@ -149,6 +160,12 @@ Map every revision or epoch to:
 Delete any token which has no unique invalidation semantics. Keep the
 gatekeeper passive until its ownership boundary is narrower than the existing
 authoritative guards and its removal plan is known.
+
+Current result: the unused authoritative surface generations were deleted.
+Data-packet revisions remain diagnostics-only provenance, pending
+confirmations remain cross-wave execution obligations, and planning snapshots
+remain immutable handoff proofs; these are not interchangeable with freshness
+epochs.
 
 ### 5. Create/cancel safeguard pipeline
 

--- a/src/live/freshness.py
+++ b/src/live/freshness.py
@@ -12,10 +12,9 @@ LIVE_STATE_SURFACES = ACCOUNT_SURFACES | frozenset({"completed_candles", "market
 class SurfaceState:
     name: str
     updated_ms: int = 0
-    epoch: int = 0
-    generation: int = 0
+    epoch: int = -1
     signature: Any = None
-    changed: bool = False
+    changed_epoch: int = -1
 
 
 @dataclass
@@ -58,20 +57,39 @@ class FreshnessLedger:
         state.signature = signature
         state.updated_ms = int(now_ms)
         state.epoch = int(self.epoch if epoch is None else epoch)
-        state.changed = changed
         if changed:
-            state.generation += 1
+            state.changed_epoch = state.epoch
         self._clear_satisfied_symbol_blocks()
         return changed
 
     def surface_epoch(self, surface: str) -> int:
-        return int(self.surfaces.get(surface, SurfaceState(surface)).epoch or 0)
+        return max(
+            0, int(self.surfaces.get(surface, SurfaceState(surface)).epoch)
+        )
 
     def surface_signature(self, surface: str) -> Any:
         return self.surfaces.get(surface, SurfaceState(surface)).signature
 
     def surface_updated_ms(self, surface: str) -> int:
         return int(self.surfaces.get(surface, SurfaceState(surface)).updated_ms or 0)
+
+    def surfaces_at_epoch(self, epoch: int | None = None) -> frozenset[str]:
+        """Return surfaces stamped in the requested refresh cohort."""
+        target_epoch = int(self.epoch if epoch is None else epoch)
+        return frozenset(
+            name
+            for name, state in self.surfaces.items()
+            if state.epoch == target_epoch
+        )
+
+    def changed_surfaces_at_epoch(self, epoch: int | None = None) -> frozenset[str]:
+        """Return surfaces whose signature changed in the requested refresh cohort."""
+        target_epoch = int(self.epoch if epoch is None else epoch)
+        return frozenset(
+            name
+            for name, state in self.surfaces.items()
+            if state.changed_epoch == target_epoch
+        )
 
     def surfaces_missing_after(self, surfaces: set[str] | frozenset[str], min_epoch: int) -> list[str]:
         return sorted(surface for surface in surfaces if self.surface_epoch(surface) < int(min_epoch))

--- a/src/live/state_refresh.py
+++ b/src/live/state_refresh.py
@@ -391,7 +391,9 @@ def log_staged_refresh_timings(
     routine_without_fills = {"balance", "open_orders", "positions"}
     plan_set = set(plan)
     unusual_plan = plan_set not in (full_plan, routine_without_fills)
-    epoch_changed = set(getattr(bot, "_authoritative_refresh_epoch_changed", set()) or set())
+    epoch_changed = set(
+        bot._ensure_freshness_ledger().changed_surfaces_at_epoch()
+    )
     meaningful_surfaces = epoch_changed - {"balance"}
     if pending_confirmations and plan_set == {"open_orders"} and wall_ms < 2_000:
         meaningful_surfaces -= {"open_orders"}

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -1218,11 +1218,7 @@ class Passivbot:
         self.state_change_detected_by_symbol = set()
         self.recent_order_executions = []
         self.recent_order_cancellations = []
-        self._authoritative_surface_signatures = {}
-        self._authoritative_surface_generations = {}
         self._authoritative_refresh_epoch = 0
-        self._authoritative_refresh_epoch_fresh = set()
-        self._authoritative_refresh_epoch_changed = set()
         self._authoritative_refresh_plan_surfaces = set()
         self._authoritative_pending_confirmations = {}
         self._trailing_fill_refresh_started_generation = 0
@@ -10341,44 +10337,13 @@ class Passivbot:
 
     def _begin_authoritative_refresh_epoch(self) -> None:
         """Start a new authoritative state refresh cohort for execution gating."""
-        self._authoritative_refresh_epoch = (
-            int(getattr(self, "_authoritative_refresh_epoch", 0) or 0) + 1
-        )
-        self._authoritative_refresh_epoch_fresh = set()
-        self._authoritative_refresh_epoch_changed = set()
-        ledger = getattr(self, "freshness_ledger", None)
-        if ledger is None:
-            ledger = FreshnessLedger(now_ms=utc_ms())
-            self.freshness_ledger = ledger
-        ledger.begin_epoch(now_ms=utc_ms())
+        ledger = self._ensure_freshness_ledger()
+        self._authoritative_refresh_epoch = ledger.begin_epoch(now_ms=utc_ms())
 
     def _record_authoritative_surface(self, surface: str, signature) -> bool:
         """Record a fresh authoritative surface snapshot and whether it changed."""
-        if not hasattr(self, "_authoritative_surface_signatures"):
-            self._authoritative_surface_signatures = {}
-        if not hasattr(self, "_authoritative_surface_generations"):
-            self._authoritative_surface_generations = {}
-        if not hasattr(self, "_authoritative_refresh_epoch_fresh"):
-            self._authoritative_refresh_epoch_fresh = set()
-        if not hasattr(self, "_authoritative_refresh_epoch_changed"):
-            self._authoritative_refresh_epoch_changed = set()
-        prev = self._authoritative_surface_signatures.get(surface)
-        changed = prev != signature
-        self._authoritative_surface_signatures[surface] = signature
-        self._authoritative_refresh_epoch_fresh.add(surface)
-        ledger = getattr(self, "freshness_ledger", None)
-        if ledger is not None:
-            ledger.stamp(
-                surface,
-                signature,
-                now_ms=utc_ms(),
-                epoch=int(getattr(self, "_authoritative_refresh_epoch", 0) or 0),
-            )
-        if changed:
-            self._authoritative_surface_generations[surface] = (
-                int(self._authoritative_surface_generations.get(surface, 0) or 0) + 1
-            )
-            self._authoritative_refresh_epoch_changed.add(surface)
+        ledger = self._ensure_freshness_ledger()
+        changed = ledger.stamp(surface, signature, now_ms=utc_ms())
         if surface in ACCOUNT_PACKET_KINDS:
             self._finalize_live_data_packet_metadata(surface, signature=signature)
         return changed
@@ -10460,6 +10425,9 @@ class Passivbot:
         ledger = getattr(self, "freshness_ledger", None)
         if ledger is None:
             ledger = FreshnessLedger(now_ms=utc_ms())
+            ledger.epoch = int(
+                getattr(self, "_authoritative_refresh_epoch", 0) or 0
+            )
             self.freshness_ledger = ledger
         return ledger
 
@@ -10868,13 +10836,12 @@ class Passivbot:
     def _authoritative_execution_barrier_state(self) -> tuple[bool, dict]:
         """Return whether execution must be skipped until authoritative state settles."""
         required = self._authoritative_required_surfaces()
-        fresh = set(getattr(self, "_authoritative_refresh_epoch_fresh", set()) or set())
-        changed_all = set(
-            getattr(self, "_authoritative_refresh_epoch_changed", set()) or set()
-        )
+        ledger = self._ensure_freshness_ledger()
+        current_epoch = int(ledger.epoch)
+        fresh = set(ledger.surfaces_at_epoch(current_epoch))
+        changed_all = set(ledger.changed_surfaces_at_epoch(current_epoch))
         changed = sorted(changed_all & {"positions", "open_orders", "fills"})
         pending = dict(getattr(self, "_authoritative_pending_confirmations", {}) or {})
-        current_epoch = int(getattr(self, "_authoritative_refresh_epoch", 0) or 0)
         missing = sorted(
             surface
             for surface in required
@@ -10934,7 +10901,7 @@ class Passivbot:
         """Escalate follow-up confirmations only when the current refresh cohort was insufficient."""
         refreshed_surfaces = set(refreshed_surfaces or set())
         changed_all = set(
-            getattr(self, "_authoritative_refresh_epoch_changed", set()) or set()
+            self._ensure_freshness_ledger().changed_surfaces_at_epoch()
         )
         if (
             refreshed_surfaces == {"open_orders"}

--- a/tests/test_freshness_ledger.py
+++ b/tests/test_freshness_ledger.py
@@ -1,7 +1,7 @@
 from freshness_ledger import ACCOUNT_SURFACES, FreshnessLedger
 
 
-def test_freshness_ledger_tracks_surface_generations():
+def test_freshness_ledger_tracks_current_epoch_surface_changes():
     ledger = FreshnessLedger(now_ms=1000)
 
     ledger.begin_epoch(now_ms=1100)
@@ -13,9 +13,25 @@ def test_freshness_ledger_tracks_surface_generations():
     assert changed is True
     assert unchanged is False
     assert changed_again is True
-    assert state.generation == 2
     assert state.updated_ms == 1400
     assert state.epoch == 1
+    assert ledger.surfaces_at_epoch() == {"positions"}
+    assert ledger.changed_surfaces_at_epoch() == {"positions"}
+
+    ledger.begin_epoch(now_ms=1500)
+    ledger.stamp("positions", (("BTC", "long", 0.2),), now_ms=1600)
+    ledger.stamp("open_orders", (), now_ms=1700)
+
+    assert ledger.surfaces_at_epoch() == {"positions", "open_orders"}
+    assert ledger.changed_surfaces_at_epoch() == {"open_orders"}
+    assert ledger.changed_surfaces_at_epoch(1) == {"positions"}
+
+    ledger.begin_epoch(now_ms=1800)
+    ledger.stamp("positions", (("BTC", "long", 0.3),), now_ms=1900)
+    ledger.stamp("positions", (("BTC", "long", 0.3),), now_ms=2000)
+
+    assert ledger.surfaces_at_epoch() == {"positions"}
+    assert ledger.changed_surfaces_at_epoch() == {"positions"}
 
 
 def test_symbol_block_clears_only_after_required_surfaces_reach_min_epoch():

--- a/tests/test_hyperliquid_balance_cache.py
+++ b/tests/test_hyperliquid_balance_cache.py
@@ -1335,11 +1335,7 @@ async def test_refresh_authoritative_state_staged_hyperliquid_publishes_final_ba
     bot.positions = {}
     bot.fetched_positions = []
     bot.fetched_open_orders = []
-    bot._authoritative_surface_signatures = {}
-    bot._authoritative_surface_generations = {}
     bot._authoritative_refresh_epoch = 0
-    bot._authoritative_refresh_epoch_fresh = set()
-    bot._authoritative_refresh_epoch_changed = set()
     bot.state_change_detected_by_symbol = set()
     bot.execution_scheduled = False
     bot.recent_order_cancellations = []

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -71,6 +71,34 @@ TEST_RUNTIME_IDENTITY = RuntimeIdentity(
 )
 
 
+def _set_authoritative_epoch_state(
+    bot,
+    *,
+    epoch: int = 1,
+    fresh: set[str] | frozenset[str] = frozenset(),
+    changed: set[str] | frozenset[str] = frozenset(),
+) -> FreshnessLedger:
+    """Seed one internally consistent authoritative cohort for focused tests."""
+    fresh_surfaces = set(fresh) | set(changed)
+    ledger = FreshnessLedger(now_ms=0)
+    previous_epoch = max(0, int(epoch) - 1)
+    ledger.epoch = previous_epoch
+    for surface in fresh_surfaces:
+        ledger.stamp(
+            surface,
+            (surface, "baseline"),
+            now_ms=1,
+            epoch=previous_epoch,
+        )
+    ledger.epoch = int(epoch)
+    for surface in fresh_surfaces:
+        signature = (surface, "changed" if surface in changed else "baseline")
+        ledger.stamp(surface, signature, now_ms=2, epoch=epoch)
+    bot.freshness_ledger = ledger
+    bot._authoritative_refresh_epoch = int(epoch)
+    return ledger
+
+
 def _hostile_runtime_error(detail: str) -> RuntimeError:
     error_cls = type("ApiKeySecretError", (RuntimeError,), {})
     return error_cls(detail)
@@ -665,11 +693,7 @@ def _counted_staged_account_refresh_bot(
     bot.active_symbols = []
     bot.state_change_detected_by_symbol = set()
     bot.execution_scheduled = False
-    bot._authoritative_surface_signatures = {}
-    bot._authoritative_surface_generations = {}
     bot._authoritative_refresh_epoch = 0
-    bot._authoritative_refresh_epoch_fresh = set()
-    bot._authoritative_refresh_epoch_changed = set()
     bot._authoritative_pending_confirmations = dict(pending_confirmations or {})
     bot.freshness_ledger = FreshnessLedger(now_ms=0)
     bot.recent_order_cancellations = []
@@ -714,14 +738,16 @@ def _counted_staged_account_refresh_bot(
     bot.fetch_open_orders = counted_fetch_open_orders
     bot.update_pnls = counted_update_pnls
 
-    # Seed the previous signatures so steady-state request-count tests do not
+    # Seed the previous ledger signatures so steady-state request-count tests do not
     # create follow-up confirmations just because the fake bot has no history.
-    bot._authoritative_surface_signatures = {
+    signatures = {
         "balance": round(float(balance), 12),
         "positions": Passivbot._positions_signature(bot, list(positions or [])),
         "open_orders": Passivbot._open_orders_signature(bot, list(open_orders or [])),
         "fills": (),
     }
+    for surface, signature in signatures.items():
+        bot.freshness_ledger.stamp(surface, signature, now_ms=1, epoch=0)
     return bot, counts
 
 
@@ -852,12 +878,7 @@ def test_diagnostic_event_emit_failure_is_noncritical():
 
 def test_authoritative_surface_record_survives_data_packet_finalize_failure():
     bot = Passivbot.__new__(Passivbot)
-    bot.freshness_ledger = FreshnessLedger(now_ms=0)
-    bot._authoritative_refresh_epoch = 1
-    bot._authoritative_surface_signatures = {}
-    bot._authoritative_surface_generations = {}
-    bot._authoritative_refresh_epoch_fresh = set()
-    bot._authoritative_refresh_epoch_changed = set()
+    _set_authoritative_epoch_state(bot)
 
     def failing_finalize(*_args, **_kwargs):
         raise RuntimeError("diagnostic finalize failed")
@@ -865,8 +886,19 @@ def test_authoritative_surface_record_survives_data_packet_finalize_failure():
     bot._finalize_live_data_packet_metadata_inner = failing_finalize
 
     assert bot._record_authoritative_surface("balance", ("balance", "fresh")) is True
-    assert bot._authoritative_surface_signatures["balance"] == ("balance", "fresh")
+    assert bot.freshness_ledger.surface_signature("balance") == ("balance", "fresh")
     assert bot.freshness_ledger.surface_epoch("balance") == 1
+
+
+def test_freshness_ledger_bootstraps_legacy_authoritative_epoch_alias():
+    bot = Passivbot.__new__(Passivbot)
+    bot._authoritative_refresh_epoch = 7
+
+    ledger = bot._ensure_freshness_ledger()
+    bot._begin_authoritative_refresh_epoch()
+
+    assert ledger.epoch == 8
+    assert bot._authoritative_refresh_epoch == 8
 
 
 @pytest.mark.asyncio
@@ -3963,7 +3995,7 @@ def test_handle_order_update_fill_hint_requests_full_confirmation(caplog, monkey
 def test_log_staged_refresh_timings_logs_only_for_slow_refreshes(caplog):
     bot = Passivbot.__new__(Passivbot)
     bot._authoritative_pending_confirmations = {}
-    bot._authoritative_refresh_epoch_changed = set()
+    _set_authoritative_epoch_state(bot)
 
     with caplog.at_level(logging.DEBUG):
         bot._log_staged_refresh_timings({"open_orders"}, {"open_orders": 250}, 250)
@@ -3982,13 +4014,13 @@ def test_log_staged_refresh_timings_logs_only_for_slow_refreshes(caplog):
             {"balance": 2500, "positions": 3000, "open_orders": 2000, "fills": 4000},
             8500,
         )
-        bot._authoritative_refresh_epoch_changed = {"positions"}
+        _set_authoritative_epoch_state(bot, changed={"positions"})
         bot._log_staged_refresh_timings(
             {"balance", "positions", "open_orders", "fills"},
             {"balance": 1200, "positions": 1700, "open_orders": 900, "fills": 1300},
             4100,
         )
-        bot._authoritative_refresh_epoch_changed = set()
+        _set_authoritative_epoch_state(bot)
         bot._log_staged_refresh_timings(
             {"balance", "positions", "open_orders", "fills"},
             {"balance": 2500, "positions": 3000, "open_orders": 2000, "fills": 4000},
@@ -4030,7 +4062,7 @@ def test_log_staged_refresh_timings_keeps_meaningful_change_structured_at_info(c
     bot._live_event_current_cycle_id = "cy_refresh"
     bot._live_event_pipeline = LiveEventPipeline(structured_sinks=[sink], monitor_sinks=[])
     bot._authoritative_pending_confirmations = {}
-    bot._authoritative_refresh_epoch_changed = {"positions"}
+    _set_authoritative_epoch_state(bot, changed={"positions"})
 
     with caplog.at_level(logging.DEBUG):
         bot._log_staged_refresh_timings(
@@ -4077,7 +4109,7 @@ def test_log_staged_refresh_timings_skips_structured_debug_sample():
     bot._live_event_current_cycle_id = "cy_refresh_debug"
     bot._live_event_pipeline = LiveEventPipeline(structured_sinks=[sink], monitor_sinks=[])
     bot._authoritative_pending_confirmations = {}
-    bot._authoritative_refresh_epoch_changed = set()
+    _set_authoritative_epoch_state(bot)
 
     bot._log_staged_refresh_timings(
         {"balance", "positions", "open_orders", "fills"},
@@ -4247,9 +4279,12 @@ def test_order_wave_settlement_logs_authoritative_confirmation(monkeypatch, capl
     wave["create_posted"] = 1
     bot._track_order_wave_confirmation(wave)
 
-    bot._authoritative_refresh_epoch = 5
-    bot._authoritative_refresh_epoch_fresh = {"open_orders"}
-    bot._authoritative_refresh_epoch_changed = {"open_orders", "positions"}
+    _set_authoritative_epoch_state(
+        bot,
+        epoch=5,
+        fresh={"open_orders"},
+        changed={"open_orders", "positions"},
+    )
 
     with caplog.at_level(logging.INFO):
         blocked, details = bot._authoritative_execution_barrier_state()
@@ -6064,7 +6099,8 @@ async def test_update_pnls_window_lookback_stays_blocked_when_known_gap_persists
     bot._pnls_manager.refresh.assert_not_awaited()
     bot._pnls_manager.refresh_latest.assert_not_awaited()
     assert bot._last_fill_refresh_pending_pnl_count == 0
-    assert "fills" not in getattr(bot, "_authoritative_surface_signatures", {})
+    ledger = getattr(bot, "freshness_ledger", None)
+    assert ledger is None or ledger.surface_signature("fills") is None
     assert bot._trailing_fill_fetch_generation == 7
     retry_state = getattr(bot, "_fill_coverage_retry_state", {})
     assert retry_state["next_retry_ms"] > wall_ms["value"]
@@ -6183,7 +6219,7 @@ async def test_update_pnls_window_lookback_records_fills_after_known_gap_repair(
     bot._pnls_manager.refresh_for_lookback.assert_awaited_once_with(start_ms=start_ms)
     bot._pnls_manager.refresh.assert_not_awaited()
     bot._pnls_manager.refresh_latest.assert_not_awaited()
-    assert "fills" in getattr(bot, "_authoritative_surface_signatures", {})
+    assert bot.freshness_ledger.surface_signature("fills") is not None
     assert getattr(bot, "_fill_coverage_retry_state", {}) == {}
 
 
@@ -7067,11 +7103,7 @@ async def test_refresh_authoritative_state_staged_applies_fake_snapshots():
     bot.active_symbols = []
     bot.state_change_detected_by_symbol = set()
     bot.execution_scheduled = False
-    bot._authoritative_surface_signatures = {}
-    bot._authoritative_surface_generations = {}
     bot._authoritative_refresh_epoch = 0
-    bot._authoritative_refresh_epoch_fresh = set()
-    bot._authoritative_refresh_epoch_changed = set()
     bot.recent_order_cancellations = []
     bot.fetch_balance = AsyncMock(return_value=123.45)
     bot.fetch_positions = AsyncMock(
@@ -7271,11 +7303,7 @@ async def test_refresh_authoritative_state_staged_applies_bybit_snapshots():
     bot.active_symbols = []
     bot.state_change_detected_by_symbol = set()
     bot.execution_scheduled = False
-    bot._authoritative_surface_signatures = {}
-    bot._authoritative_surface_generations = {}
     bot._authoritative_refresh_epoch = 0
-    bot._authoritative_refresh_epoch_fresh = set()
-    bot._authoritative_refresh_epoch_changed = set()
     bot.recent_order_cancellations = []
     seen = {}
 
@@ -7366,10 +7394,6 @@ async def test_refresh_authoritative_state_staged_uses_generic_staged_fetch_for_
     bot.exchange = "binance"
     bot.stop_signal_received = False
     bot._authoritative_refresh_epoch = 0
-    bot._authoritative_refresh_epoch_fresh = set()
-    bot._authoritative_refresh_epoch_changed = set()
-    bot._authoritative_surface_signatures = {}
-    bot._authoritative_surface_generations = {}
     bot.fetch_balance = AsyncMock(return_value=100.0)
     bot.fetch_positions = AsyncMock(return_value=[])
     bot.fetch_open_orders = AsyncMock(return_value=[])
@@ -7409,10 +7433,6 @@ async def test_refresh_protective_authoritative_state_uses_account_critical_surf
     bot.positions = {}
     bot.open_orders = {}
     bot._authoritative_refresh_epoch = 0
-    bot._authoritative_refresh_epoch_fresh = set()
-    bot._authoritative_refresh_epoch_changed = set()
-    bot._authoritative_surface_signatures = {}
-    bot._authoritative_surface_generations = {}
     bot.balance_override = None
     bot._balance_override_logged = False
     bot.previous_hysteresis_balance = None
@@ -10806,11 +10826,8 @@ async def test_pre_create_snapshot_diagnostic_failures_are_redacted(caplog):
 def _make_open_order_guardrail_bot(*, epoch: int = 3):
     bot = Passivbot.__new__(Passivbot)
     bot.freshness_ledger = FreshnessLedger(now_ms=0)
-    bot._authoritative_surface_signatures = {}
-    bot._authoritative_surface_generations = {}
+    bot.freshness_ledger.epoch = epoch
     bot._authoritative_refresh_epoch = epoch
-    bot._authoritative_refresh_epoch_fresh = set()
-    bot._authoritative_refresh_epoch_changed = set()
     bot._authoritative_pending_confirmations = {}
     bot.execution_scheduled = False
     bot.state_change_detected_by_symbol = set()
@@ -11942,8 +11959,6 @@ async def test_run_execution_loop_retries_fill_history_coverage_without_restart(
     bot.positions = {}
     bot.open_orders = {}
     bot.PB_modes = {"long": {}, "short": {}}
-    bot._authoritative_surface_signatures = {}
-    bot._authoritative_surface_generations = {}
     bot._authoritative_refresh_epoch = 0
     bot._authoritative_pending_confirmations = {}
     bot.freshness_ledger = FreshnessLedger(now_ms=0)
@@ -13056,7 +13071,7 @@ def test_staged_refresh_timing_summary_aggregates_routine_fast_refreshes(
     now = {"value": 1_000_000}
     monkeypatch.setattr(passivbot_module, "utc_ms", lambda: now["value"])
     bot._authoritative_pending_confirmations = {}
-    bot._authoritative_refresh_epoch_changed = set()
+    _set_authoritative_epoch_state(bot)
 
     with caplog.at_level(logging.INFO):
         for i in range(60):
@@ -13082,7 +13097,7 @@ def test_staged_refresh_timing_summary_emits_structured_event(monkeypatch):
     bot._live_event_current_cycle_id = "cy_refresh_summary"
     bot._live_event_pipeline = LiveEventPipeline(structured_sinks=[sink], monitor_sinks=[])
     bot._authoritative_pending_confirmations = {}
-    bot._authoritative_refresh_epoch_changed = set()
+    _set_authoritative_epoch_state(bot)
 
     for i in range(60):
         bot._log_staged_refresh_timings(
@@ -13136,7 +13151,7 @@ def test_staged_refresh_timing_threshold_uses_structured_console_owner(caplog, m
         text_sink=text_sink,
     )
     bot._authoritative_pending_confirmations = {}
-    bot._authoritative_refresh_epoch_changed = set()
+    _set_authoritative_epoch_state(bot)
     monkeypatch.setattr(passivbot_module, "utc_ms", lambda: 1_000_000)
 
     with caplog.at_level(logging.DEBUG):
@@ -13190,7 +13205,7 @@ def test_staged_refresh_timing_uses_exact_legacy_fallback_without_console(caplog
         console_sink=None,
     )
     bot._authoritative_pending_confirmations = {}
-    bot._authoritative_refresh_epoch_changed = set()
+    _set_authoritative_epoch_state(bot)
     monkeypatch.setattr(passivbot_module, "utc_ms", lambda: 1_000_000)
 
     with caplog.at_level(logging.INFO):
@@ -13222,7 +13237,7 @@ def test_staged_refresh_timing_summary_uses_structured_console_owner(caplog, mon
         console_sink=console_sink,
     )
     bot._authoritative_pending_confirmations = {}
-    bot._authoritative_refresh_epoch_changed = set()
+    _set_authoritative_epoch_state(bot)
     monkeypatch.setattr(passivbot_module, "utc_ms", lambda: 1_000_000)
 
     with caplog.at_level(logging.INFO):
@@ -13253,7 +13268,7 @@ def test_staged_refresh_timing_summary_includes_debug_moderate_refreshes(
     now = {"value": 2_000_000}
     monkeypatch.setattr(passivbot_module, "utc_ms", lambda: now["value"])
     bot._authoritative_pending_confirmations = {}
-    bot._authoritative_refresh_epoch_changed = set()
+    _set_authoritative_epoch_state(bot)
 
     with caplog.at_level(logging.INFO):
         for _ in range(60):
@@ -13296,11 +13311,7 @@ async def test_refresh_authoritative_state_staged_uses_open_orders_only_confirma
     bot.active_symbols = []
     bot.state_change_detected_by_symbol = set()
     bot.execution_scheduled = False
-    bot._authoritative_surface_signatures = {}
-    bot._authoritative_surface_generations = {}
     bot._authoritative_refresh_epoch = 0
-    bot._authoritative_refresh_epoch_fresh = set()
-    bot._authoritative_refresh_epoch_changed = set()
     bot._authoritative_pending_confirmations = {"open_orders": 1}
     bot.recent_order_cancellations = []
     bot.recent_order_executions = [
@@ -13478,8 +13489,11 @@ async def test_staged_account_refresh_request_counts_missing_self_order_escalate
         pending_confirmations={"open_orders": 1},
     )
     bot.open_orders = {"BTC/USDT:USDT": [dict(stale_order)]}
-    bot._authoritative_surface_signatures["open_orders"] = (
-        Passivbot._open_orders_signature(bot, [stale_order])
+    bot.freshness_ledger.stamp(
+        "open_orders",
+        Passivbot._open_orders_signature(bot, [stale_order]),
+        now_ms=2,
+        epoch=0,
     )
 
     result = await bot.refresh_authoritative_state()


### PR DESCRIPTION
## Summary

- make `FreshnessLedger` the sole owner of authoritative per-surface signatures, current-cohort freshness, and changed-this-cohort state
- remove the parallel `Passivbot` signature/fresh/changed containers and both unused surface-generation counters
- preserve post-write confirmation obligations, symbol freshness blocks, immutable planning snapshots, and all existing barrier outcomes
- update the overengineering checkpoint and gatekeeper plan to record the ownership decision and avoid reintroducing the retired hypothetical planning-availability matrix

## Why

The live bot recorded the same authoritative surface facts in both `Passivbot` and `FreshnessLedger`. Every refresh had to update two independent representations, while the generation counters had no production consumers. This made the safety boundary harder to reason about without protecting a distinct invariant.

`SurfaceState.changed_epoch` preserves the previous sticky cohort behavior: if a surface changes and is then stamped unchanged again during the same cohort, it still counts as changed for confirmation settlement and refresh diagnostics.

Pending confirmations remain separate because they represent future exchange-state obligations. Planning snapshots remain separate because they freeze the exact Rust handoff.

## Validation

- full Python test suite: passed
- focused freshness, authoritative-refresh, HSL/unstuck, reconciliation, orchestration, and Hyperliquid balance-cache suites: passed
- Python compile check for changed runtime modules: passed
- `src/tools/check_ai_docs.py`: passed with the two pre-existing documentation-size warnings
- generated live-event registry check: passed
- AI documentation tests: passed
- `git diff --check`: passed
- rebuilt and verified the current-master Rust extension source fingerprint before the full Python suite
