### PR TITLE
Remove redundant disappeared-order symbol blocks

### DIFF
--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -357,7 +357,6 @@ Stable per-record reason-count values are:
 - `conversion_zero_or_duplicate`
 - `debug_mode`
 - `exact_reconciliation_match`
-- `freshness_creation_guardrail`
 - `hsl_replay_pending`
 - `account_cancel_first_barrier`
 - `limit_order_create_market_distance`

--- a/docs/plans/exchange_connector_event_contract_plan.md
+++ b/docs/plans/exchange_connector_event_contract_plan.md
@@ -50,7 +50,7 @@ Current code already has useful pieces to build on:
 - `src/live/executor.py`
   - order emit/cancel parent paths
 - `src/live/freshness.py`
-  - freshness surfaces and symbol blocks
+  - freshness surfaces and cohort epochs
 - `src/fill_events_manager.py`
   - canonical fill/PnL ingestion
 - `src/exchanges/fake.py`
@@ -270,7 +270,7 @@ Replay tests should assert:
 - structured event sequence
 - authoritative refresh barriers
 - no duplicate unsafe order creation
-- expected symbol blocks when state is ambiguous
+- expected same-wave symbol suppression when state changes after planning begins
 - expected recovery once authoritative surfaces refresh
 
 This gives better coverage for live bot behavior under synthetic data without requiring exchange

--- a/docs/plans/live_overengineering_audit_followup_plan.md
+++ b/docs/plans/live_overengineering_audit_followup_plan.md
@@ -99,10 +99,13 @@ consumers, and a deletion-first proposal. Do not implement until the
 account-wide versus scoped safety boundary is explicit.
 
 Current result: `FreshnessLedger` is the sole owner of per-surface freshness
-and change facts. Remaining candidates are the scalar
-`_authoritative_refresh_epoch` compatibility alias and the overlapping
-disappeared-self-order confirmation, symbol-block, and same-wave state-change
-representations. Audit their direct callers before further deletion.
+and change facts. The disappeared-self-order symbol-block state machine was
+also removed after direct-caller and runtime analysis showed that the existing
+full-account `N+1` confirmation barrier always settled first in normal
+execution. The generic same-wave symbol latch remains because it also protects
+against late websocket changes and uncertain cancellation results. The scalar
+`_authoritative_refresh_epoch` compatibility alias remains a smaller follow-up
+candidate.
 
 ### 2. Fill and realized-PnL reconstruction
 

--- a/docs/plans/staged_live_data_reconciliation_plan.md
+++ b/docs/plans/staged_live_data_reconciliation_plan.md
@@ -77,10 +77,9 @@ rules. Keep them narrow, visible, and test-covered.
 
 - [x] Define a formal freshness ledger for live inputs.
 - [x] Track freshness per surface: positions, fills, balance, open orders, completed candles, market snapshot.
-- [x] Track symbol-level freshness where relevant.
 - [x] Add planner precondition checks for required surfaces.
-- [x] Add execution precondition checks for disappeared self-order creation safety.
-- [x] Add DEBUG/INFO logs explaining disappeared-order freshness blocks.
+- [x] Route unexpected disappeared-order safety through the full-account confirmation barrier and
+  the existing same-wave symbol latch.
 - [x] Add tests for stale required inputs blocking order creation.
 
 ### 2. Market Snapshot Provider
@@ -266,14 +265,13 @@ rules. Keep them narrow, visible, and test-covered.
 
 ### 8. Duplicate-Order Guardrail
 
-- [x] Track known bot-emitted orders by exchange/client/order id with symbol, side, position side, qty, and price.
-- [x] Detect when a known bot-created order disappears from open orders.
-- [x] If a known bot-created order disappears, conservatively mark the symbol as suspect fill/stale position.
-- [x] Block order creations for suspect symbols until positions, fills, and open orders are refreshed coherently.
+- [x] Detect when a previously observed order disappears unexpectedly.
+- [x] Require a coherent next-epoch account refresh after an unexpected disappearance.
+- [x] Block same-wave creations for the affected symbol while that confirmation is pending.
 - [x] Prefer blocking creations over risking duplicate entries.
 - [x] Keep cancellation behavior conservative but avoid churn under ambiguous state.
-- [x] Add tests for bot cancel, unknown manual/exchange cancel, disappeared self-order with stale state,
-  full-refresh recovery, emitted-record matching, and restart/inherited-order recovery.
+- [x] Add tests for bot cancel, unknown manual/exchange disappearance, full-refresh recovery, and
+  restart/inherited-order recovery.
 
 ### 9. Websocket-Triggered Reconciliation
 
@@ -385,14 +383,11 @@ changing behavior during extraction commits.
 - [x] Verified Bybit Ctrl-C shutdown smoke on `ebybitsub03`: signal during warmup jitter
   aborted immediately, skipped further warmup/index rebuild work, closed sessions cleanly, and
   exited with code 0 without traceback.
-- [x] Added a `FreshnessLedger` for live surfaces and symbol-level blocks; staged refresh now
-  stamps account surfaces, market snapshots, and active completed-candle refreshes.
-- [x] Added a disappeared-self-order guardrail: when a bot-created order vanishes without a
-  known bot cancellation, new creations for that symbol are blocked until the next full account
-  freshness cohort confirms balance, positions, open orders, and fills.
-- [x] Added deterministic fake-cycle verification that the disappeared-self-order guardrail blocks
-  a real order-planner create for the affected symbol, logs the freshness block, and clears after
-  a full account freshness cohort.
+- [x] Added a `FreshnessLedger` for live surfaces; staged refresh stamps account surfaces, market
+  snapshots, and active completed-candle refreshes.
+- [x] Consolidated unexpected disappeared-order safety into the existing full-account next-epoch
+  confirmation barrier and same-wave symbol latch. The later symbol-block layer was removed after
+  proving it could not outlive the barrier into normal planning.
 - [x] Verified Bybit DEBUG smoke on `ebybitsub03` after freshness-ledger changes:
   three staged market-snapshot cycles, 27/27 symbols resolved from bulk `fetch_tickers()`,
   no `ERROR`, `Traceback`, `RecursionError`, or freshness guardrail block in the persisted log.
@@ -453,9 +448,8 @@ changing behavior during extraction commits.
   is missing, has non-market invalidation, or does not cover the creation symbol. Pure
   market-snapshot staleness is refreshed at the pre-create gate because ticker freshness is the
   intended final guard before order writes.
-- [x] Completed the duplicate-order guardrail test matrix for bot-cancel confirmation, unknown
-  manual/exchange disappearance, self-emitted order disappearance, full-refresh recovery, and
-  restart/inherited-order recovery.
+- [x] Completed the disappearance confirmation test matrix for bot-cancel confirmation, unknown
+  manual/exchange disappearance, full-refresh recovery, and restart/inherited-order recovery.
 - [x] Added startup readiness timing logs for account-ready, active-candle-ready, first
   market-ready, startup-ready, and full-warmup-ready milestones.
 - [x] Kept broad forager candidate candle refresh out of the order execution critical path.

--- a/src/freshness_ledger.py
+++ b/src/freshness_ledger.py
@@ -5,7 +5,6 @@ from live.freshness import (
     LIVE_STATE_SURFACES,
     FreshnessLedger,
     SurfaceState,
-    SymbolBlock,
 )
 
 __all__ = [
@@ -13,5 +12,4 @@ __all__ = [
     "LIVE_STATE_SURFACES",
     "FreshnessLedger",
     "SurfaceState",
-    "SymbolBlock",
 ]

--- a/src/live/freshness.py
+++ b/src/live/freshness.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 
@@ -17,25 +17,14 @@ class SurfaceState:
     changed_epoch: int = -1
 
 
-@dataclass
-class SymbolBlock:
-    symbol: str
-    reason: str
-    required_surfaces: frozenset[str]
-    min_epoch: int
-    detected_ms: int
-    details: dict[str, Any] = field(default_factory=dict)
-
-
 class FreshnessLedger:
-    """Track live data surface freshness and symbol-level execution safety blocks."""
+    """Track live data surface freshness."""
 
     def __init__(self, *, now_ms: int = 0) -> None:
         self.epoch = 0
         self.surfaces: dict[str, SurfaceState] = {
             surface: SurfaceState(name=surface) for surface in LIVE_STATE_SURFACES
         }
-        self.symbol_blocks: dict[str, SymbolBlock] = {}
         self.created_ms = int(now_ms or 0)
 
     def begin_epoch(self, *, now_ms: int | None = None) -> int:
@@ -59,7 +48,6 @@ class FreshnessLedger:
         state.epoch = int(self.epoch if epoch is None else epoch)
         if changed:
             state.changed_epoch = state.epoch
-        self._clear_satisfied_symbol_blocks()
         return changed
 
     def surface_epoch(self, surface: str) -> int:
@@ -90,42 +78,3 @@ class FreshnessLedger:
             for name, state in self.surfaces.items()
             if state.changed_epoch == target_epoch
         )
-
-    def surfaces_missing_after(self, surfaces: set[str] | frozenset[str], min_epoch: int) -> list[str]:
-        return sorted(surface for surface in surfaces if self.surface_epoch(surface) < int(min_epoch))
-
-    def flag_symbol_block(
-        self,
-        symbol: str,
-        *,
-        reason: str,
-        required_surfaces: set[str] | frozenset[str],
-        min_epoch: int,
-        detected_ms: int,
-        details: dict[str, Any] | None = None,
-    ) -> SymbolBlock:
-        block = SymbolBlock(
-            symbol=str(symbol),
-            reason=str(reason),
-            required_surfaces=frozenset(required_surfaces),
-            min_epoch=int(min_epoch),
-            detected_ms=int(detected_ms),
-            details=dict(details or {}),
-        )
-        self.symbol_blocks[block.symbol] = block
-        self._clear_satisfied_symbol_blocks()
-        return block
-
-    def blocked_symbols(self) -> dict[str, SymbolBlock]:
-        self._clear_satisfied_symbol_blocks()
-        return dict(self.symbol_blocks)
-
-    def clear_symbol(self, symbol: str) -> None:
-        self.symbol_blocks.pop(str(symbol), None)
-
-    def _clear_satisfied_symbol_blocks(self) -> None:
-        if not self.symbol_blocks:
-            return
-        for symbol, block in list(self.symbol_blocks.items()):
-            if not self.surfaces_missing_after(block.required_surfaces, block.min_epoch):
-                self.symbol_blocks.pop(symbol, None)

--- a/src/live/reconciler.py
+++ b/src/live/reconciler.py
@@ -888,94 +888,6 @@ async def detect_foreign_passivbot_orders(bot, open_orders: list[dict]) -> None:
         )
 
 
-def order_matches_known_self_emission(bot, order: dict, max_age_ms: int) -> bool:
-    """Return True when an open order is known to have been emitted by this process."""
-    if not isinstance(order, dict):
-        return False
-    if bot.order_matches_recent_execution(order, max_age_ms=max_age_ms):
-        return True
-    now_ts = (
-        int(bot.get_exchange_time()) if hasattr(bot, "get_exchange_time") else _utc_ms()
-    )
-    cutoff = now_ts - int(max_age_ms)
-    exchange_id = extract_order_exchange_id(order)
-    custom_id = extract_order_custom_id(order)
-    canonical_custom_id = canonical_passivbot_custom_id(custom_id)
-    pb_type = (
-        _pb_attr("custom_id_to_snake")(custom_id)
-        if custom_id
-        else bot._resolve_pb_order_type(order)
-    )
-    fingerprint = order_identity_fingerprint(order, pb_type)
-    for record in emitted_order_records(bot):
-        record_ts_raw = record.get("timestamp")
-        if record_ts_raw is None:
-            continue
-        try:
-            record_ts = int(record_ts_raw)
-        except (TypeError, ValueError):
-            continue
-        if record_ts < cutoff:
-            continue
-        record_exchange_id = str(record.get("exchange_id") or "")
-        if (
-            exchange_id
-            and record_exchange_id
-            and str(exchange_id) == record_exchange_id
-        ):
-            return True
-        record_custom_id = str(record.get("canonical_custom_id") or "")
-        if (
-            canonical_custom_id
-            and record_custom_id
-            and canonical_custom_id == record_custom_id
-        ):
-            return True
-        if (
-            fingerprint
-            and record.get("fingerprint")
-            and record.get("fingerprint") == fingerprint
-        ):
-            return True
-    return False
-
-
-def flag_disappeared_self_order_guardrail(bot, order: dict) -> None:
-    """Block creates for a symbol until account surfaces refresh after a self order vanishes."""
-    symbol = str(order.get("symbol") or "")
-    if not symbol:
-        return
-    ledger = bot._ensure_freshness_ledger()
-    min_epoch = int(getattr(bot, "_authoritative_refresh_epoch", 0) or 0) + 1
-    details = {
-        "order_id": str(order.get("id") or ""),
-        "side": str(order.get("side") or ""),
-        "position_side": str(order.get("position_side") or ""),
-        "price": order.get("price"),
-        "qty": order.get("qty", order.get("amount")),
-    }
-    ledger.flag_symbol_block(
-        symbol,
-        reason="self_order_disappeared_position_may_be_stale",
-        required_surfaces=ACCOUNT_SURFACES,
-        min_epoch=min_epoch,
-        detected_ms=_utc_ms(),
-        details=details,
-    )
-    bot.execution_scheduled = True
-    if not hasattr(bot, "state_change_detected_by_symbol"):
-        bot.state_change_detected_by_symbol = set()
-    bot.state_change_detected_by_symbol.add(symbol)
-    bot._request_authoritative_confirmation(ACCOUNT_SURFACES, min_epoch=min_epoch)
-    logging.debug(
-        "[state] freshness guardrail armed | symbol=%s | reason=self_order_disappeared_position_may_be_stale | required=%s | min_epoch=%s | order_id=%s",
-        _pb_attr("Passivbot")._log_symbol(symbol),
-        ",".join(sorted(ACCOUNT_SURFACES)),
-        min_epoch,
-        details["order_id"],
-    )
-
-
 def mark_account_critical_state_dirty(
     bot,
     *,
@@ -1251,7 +1163,6 @@ async def calc_orders_to_cancel_and_create_from_ideal(
     *,
     actual_symbols: Optional[Iterable[str]] = None,
     actual_psides_by_symbol: Optional[dict[str, Iterable[str]]] = None,
-    apply_creation_guardrails: bool = True,
     apply_mode_filters: bool = True,
     collect_fresh_entry_eligibility: bool = True,
 ):
@@ -1420,26 +1331,12 @@ async def calc_orders_to_cancel_and_create_from_ideal(
         )
     to_cancel = await bot._sort_orders_by_market_diff(to_cancel, "to_cancel")
     to_create = await bot._sort_orders_by_market_diff(to_create, "to_create")
-    if apply_creation_guardrails:
-        before_creation_guardrails = list(to_create)
-        to_create, freshness_skipped = bot._apply_freshness_creation_guardrails(to_create)
-        trace = _trace_record(
-            trace,
-            "record_blocked_orders",
-            _orders_removed_by_identity(before_creation_guardrails, to_create),
-            "freshness_creation_guardrail",
-        )
-    else:
-        freshness_skipped = 0
     if plan_summaries:
         total_pre_cancel = sum(p[1] for p in plan_summaries)
         total_cancel = sum(p[2] for p in plan_summaries)
         total_pre_create = sum(p[3] for p in plan_summaries)
         total_create = len(to_create)
-        total_skipped = (
-            sum(p[5] for p in plan_summaries)
-            + freshness_skipped
-        )
+        total_skipped = sum(p[5] for p in plan_summaries)
         detail_parts = []
         untouched_cancel = total_pre_cancel - total_cancel
         untouched_create = total_pre_create - total_create

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -10917,18 +10917,6 @@ class Passivbot:
                 {"balance", "positions", "open_orders", "fills"}
             )
 
-    def _order_matches_known_self_emission(
-        self, order: dict, max_age_ms=FOREIGN_PASSIVBOT_LOOKBACK_MS
-    ) -> bool:
-        """Return True when an open order is known to have been emitted by this process."""
-        return reconciler.order_matches_known_self_emission(
-            self, order, max_age_ms=max_age_ms
-        )
-
-    def _flag_disappeared_self_order_guardrail(self, order: dict) -> None:
-        """Block creates for a symbol until account surfaces refresh after a self order vanishes."""
-        return reconciler.flag_disappeared_self_order_guardrail(self, order)
-
     def _mark_account_critical_state_dirty(
         self,
         *,
@@ -10941,12 +10929,6 @@ class Passivbot:
         return reconciler.mark_account_critical_state_dirty(
             self, reason=reason, symbols=symbols, source=source, level=level
         )
-
-    def _freshness_creation_blocked_symbols(self) -> dict[str, object]:
-        ledger = getattr(self, "freshness_ledger", None)
-        if ledger is None:
-            return {}
-        return ledger.blocked_symbols()
 
     def _staged_planner_required_surfaces(
         self, *, include_market_snapshot: bool = True
@@ -11476,39 +11458,6 @@ class Passivbot:
         return planning_gates.current_planning_snapshot_invalid_for_creations(
             self, symbols
         )
-
-    def _apply_freshness_creation_guardrails(
-        self, orders: list[dict]
-    ) -> tuple[list[dict], int]:
-        blocked = self._freshness_creation_blocked_symbols()
-        if not blocked:
-            return orders, 0
-        kept = []
-        skipped = 0
-        logged_symbols = set()
-        for order in orders:
-            symbol = str(order.get("symbol") or "")
-            block = blocked.get(symbol)
-            if block is None:
-                kept.append(order)
-                continue
-            skipped += 1
-            if symbol not in logged_symbols:
-                missing = []
-                ledger = getattr(self, "freshness_ledger", None)
-                if ledger is not None:
-                    missing = ledger.surfaces_missing_after(
-                        block.required_surfaces, block.min_epoch
-                    )
-                logging.info(
-                    "[state] freshness guardrail blocking order creation | symbol=%s | reason=%s | missing=%s | min_epoch=%s",
-                    Passivbot._log_symbol(symbol),
-                    block.reason,
-                    ",".join(missing) if missing else "unknown",
-                    block.min_epoch,
-                )
-                logged_symbols.add(symbol)
-        return kept, skipped
 
     def add_new_order(self, order, source="WS"):
         """No-op placeholder; subclasses update open orders through REST synchronisation."""
@@ -15549,8 +15498,6 @@ class Passivbot:
                 unexpected_open_orders_change = True
                 schedule_update_positions = True
                 unexpected_removed_symbols.add(order["symbol"])
-                if self._order_matches_known_self_emission(order):
-                    self._flag_disappeared_self_order_guardrail(order)
                 if len(removed_orders) <= 20:
                     self.log_order_action(
                         order, "missing order", "fetch_open_orders", level=logging.INFO
@@ -19558,7 +19505,6 @@ class Passivbot:
             ideal_orders,
             actual_symbols=actual_symbols,
             actual_psides_by_symbol=actual_psides_by_symbol,
-            apply_creation_guardrails=False,
             apply_mode_filters=False,
             collect_fresh_entry_eligibility=False,
         )

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -15540,19 +15540,14 @@ class Passivbot:
         if balance_reconciled:
             await self.handle_balance_update(source="REST+open_orders")
         if schedule_update_positions:
+            self.execution_scheduled = True
+            self.state_change_detected_by_symbol.update(unexpected_removed_symbols)
+            self._request_authoritative_confirmation(ACCOUNT_SURFACES)
             if allow_followup_positions_refresh:
                 await asyncio.sleep(1.5)
                 await self.update_positions_and_balance()
-            else:
-                self.execution_scheduled = True
-                self.state_change_detected_by_symbol.update(unexpected_removed_symbols)
-                self._request_authoritative_confirmation(
-                    {"balance", "positions", "open_orders", "fills"}
-                )
         elif unexpected_open_orders_change and not allow_followup_positions_refresh:
-            self._request_authoritative_confirmation(
-                {"balance", "positions", "open_orders", "fills"}
-            )
+            self._request_authoritative_confirmation(ACCOUNT_SURFACES)
         return True
 
     async def _fetch_and_apply_positions(self):

--- a/tests/test_fresh_entry_eligibility_integration.py
+++ b/tests/test_fresh_entry_eligibility_integration.py
@@ -113,7 +113,6 @@ def _reconciliation_bot(symbol: str, actual_orders: list[dict]) -> Passivbot:
     bot.is_pside_enabled = lambda pside: pside == "long"
     bot._annotate_order_deltas = lambda cancel, create: (cancel, create)
     bot._apply_order_match_tolerance = lambda cancel, create: (cancel, create, 0)
-    bot._apply_freshness_creation_guardrails = lambda create: (create, 0)
     bot._order_plan_summary_is_interesting = lambda **kwargs: False
 
     async def keep_sort(self, orders, _label):

--- a/tests/test_freshness_ledger.py
+++ b/tests/test_freshness_ledger.py
@@ -1,4 +1,4 @@
-from freshness_ledger import ACCOUNT_SURFACES, FreshnessLedger
+from freshness_ledger import FreshnessLedger
 
 
 def test_freshness_ledger_tracks_current_epoch_surface_changes():
@@ -32,36 +32,3 @@ def test_freshness_ledger_tracks_current_epoch_surface_changes():
 
     assert ledger.surfaces_at_epoch() == {"positions"}
     assert ledger.changed_surfaces_at_epoch() == {"positions"}
-
-
-def test_symbol_block_clears_only_after_required_surfaces_reach_min_epoch():
-    ledger = FreshnessLedger(now_ms=1000)
-    ledger.begin_epoch(now_ms=1100)
-    ledger.stamp("positions", ("old",), now_ms=1200)
-
-    ledger.flag_symbol_block(
-        "BTC/USDT:USDT",
-        reason="self_order_disappeared_position_may_be_stale",
-        required_surfaces=ACCOUNT_SURFACES,
-        min_epoch=2,
-        detected_ms=1300,
-    )
-
-    assert set(ledger.blocked_symbols()) == {"BTC/USDT:USDT"}
-    assert ledger.surfaces_missing_after(ACCOUNT_SURFACES, 2) == [
-        "balance",
-        "fills",
-        "open_orders",
-        "positions",
-    ]
-
-    ledger.begin_epoch(now_ms=1400)
-    for surface in ("balance", "positions", "open_orders"):
-        ledger.stamp(surface, surface, now_ms=1500)
-
-    assert set(ledger.blocked_symbols()) == {"BTC/USDT:USDT"}
-    assert ledger.surfaces_missing_after(ACCOUNT_SURFACES, 2) == ["fills"]
-
-    ledger.stamp("fills", "fills", now_ms=1600)
-
-    assert ledger.blocked_symbols() == {}

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -11099,6 +11099,39 @@ async def test_unexpected_order_disappearance_waits_for_full_confirmation():
 
 
 @pytest.mark.asyncio
+async def test_default_open_order_refresh_preserves_disappearance_confirmation(
+    monkeypatch,
+):
+    bot = _make_open_order_snapshot_bot(epoch=3)
+    order = _snapshot_order()
+    bot.open_orders = {"BTC/USDT:USDT": [order]}
+    bot.fetched_open_orders = [order]
+    bot.order_matches_recent_execution = lambda _order, max_age_ms=None: True
+    bot.order_matches_bot_cancellation = lambda _order: False
+    bot.order_was_recently_cancelled = lambda _order: 0.0
+    bot.stop_signal_received = False
+    bot.fetch_open_orders = AsyncMock(return_value=[])
+    bot.update_positions_and_balance = AsyncMock(return_value=(True, True))
+    sleep = AsyncMock()
+    monkeypatch.setattr(passivbot_module.asyncio, "sleep", sleep)
+
+    ok = await Passivbot.update_open_orders(bot)
+
+    assert ok is True
+    bot.fetch_open_orders.assert_awaited_once_with()
+    sleep.assert_awaited_once_with(1.5)
+    bot.update_positions_and_balance.assert_awaited_once_with()
+    assert bot.execution_scheduled is True
+    assert bot.state_change_detected_by_symbol == {"BTC/USDT:USDT"}
+    assert bot._authoritative_pending_confirmations == {
+        surface: 4 for surface in ACCOUNT_SURFACES
+    }
+    blocked, details = bot._authoritative_execution_barrier_state()
+    assert blocked is True
+    assert set(details["missing"]) == set(ACCOUNT_SURFACES)
+
+
+@pytest.mark.asyncio
 async def test_bot_cancelled_order_disappearance_does_not_request_confirmation():
     bot = _make_open_order_snapshot_bot(epoch=5)
     order = _snapshot_order()

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -10823,7 +10823,7 @@ async def test_pre_create_snapshot_diagnostic_failures_are_redacted(caplog):
     assert "secret-trace" not in messages
 
 
-def _make_open_order_guardrail_bot(*, epoch: int = 3):
+def _make_open_order_snapshot_bot(*, epoch: int = 3):
     bot = Passivbot.__new__(Passivbot)
     bot.freshness_ledger = FreshnessLedger(now_ms=0)
     bot.freshness_ledger.epoch = epoch
@@ -10840,7 +10840,7 @@ def _make_open_order_guardrail_bot(*, epoch: int = 3):
     return bot
 
 
-def _guardrail_order(**overrides):
+def _snapshot_order(**overrides):
     order = {
         "id": "created-1",
         "symbol": "BTC/USDT:USDT",
@@ -10856,7 +10856,7 @@ def _guardrail_order(**overrides):
 
 
 def _open_orders_snapshot_orders(prefix: str, count: int) -> list[dict]:
-    return [_guardrail_order(id=f"{prefix}-{index}") for index in range(count)]
+    return [_snapshot_order(id=f"{prefix}-{index}") for index in range(count)]
 
 
 @pytest.mark.asyncio
@@ -10867,7 +10867,7 @@ async def test_large_added_open_orders_snapshot_delta_event_is_bounded_and_opera
     monitor_sink = ListEventSink()
     console_sink = ListEventSink()
     text_sink = ListEventSink()
-    bot = _make_open_order_guardrail_bot()
+    bot = _make_open_order_snapshot_bot()
     bot.exchange = "bybit"
     bot.user = "user_01"
     bot.bot_id = "bot_01"
@@ -10920,7 +10920,7 @@ async def test_large_added_open_orders_snapshot_delta_event_is_bounded_and_opera
 @pytest.mark.asyncio
 async def test_large_removed_open_orders_snapshot_delta_event_preserves_guardrails():
     structured_sink = ListEventSink()
-    bot = _make_open_order_guardrail_bot(epoch=5)
+    bot = _make_open_order_snapshot_bot(epoch=5)
     bot._live_event_pipeline = LiveEventPipeline(
         structured_sinks=[structured_sink], monitor_sinks=[]
     )
@@ -10959,7 +10959,7 @@ async def test_large_removed_open_orders_snapshot_delta_event_preserves_guardrai
 async def test_open_orders_snapshot_delta_uses_strictly_greater_than_twenty_threshold(
     direction,
 ):
-    bot = _make_open_order_guardrail_bot()
+    bot = _make_open_order_snapshot_bot()
     emitted = []
     logged_orders = []
     bot._emit_open_orders_snapshot_delta_event = lambda **kwargs: emitted.append(kwargs)
@@ -10982,7 +10982,7 @@ async def test_open_orders_snapshot_delta_uses_strictly_greater_than_twenty_thre
 
 
 def test_open_orders_snapshot_delta_emitter_failure_is_bounded_and_keeps_fallback(caplog):
-    bot = _make_open_order_guardrail_bot()
+    bot = _make_open_order_snapshot_bot()
 
     def fail_emit_delta(**_kwargs):
         raise RuntimeError(
@@ -11015,7 +11015,7 @@ async def test_open_orders_snapshot_delta_console_sink_failure_does_not_change_r
         def write(self, _event):
             raise OSError("console unavailable")
 
-    bot = _make_open_order_guardrail_bot(epoch=7)
+    bot = _make_open_order_snapshot_bot(epoch=7)
     bot.live_event_console_enabled = True
     bot._live_event_pipeline = LiveEventPipeline(
         structured_sinks=[],
@@ -11047,7 +11047,7 @@ async def test_open_orders_snapshot_delta_console_sink_failure_does_not_change_r
 
 @pytest.mark.asyncio
 async def test_large_open_orders_snapshot_delta_keeps_legacy_console_without_pipeline(caplog):
-    bot = _make_open_order_guardrail_bot()
+    bot = _make_open_order_snapshot_bot()
     bot.live_event_console_enabled = False
     bot._live_event_pipeline = None
     bot.open_orders = {}
@@ -11062,9 +11062,9 @@ async def test_large_open_orders_snapshot_delta_keeps_legacy_console_without_pip
 
 
 @pytest.mark.asyncio
-async def test_disappeared_self_order_blocks_creations_until_full_freshness():
-    bot = _make_open_order_guardrail_bot(epoch=3)
-    order = _guardrail_order()
+async def test_unexpected_order_disappearance_waits_for_full_confirmation():
+    bot = _make_open_order_snapshot_bot(epoch=3)
+    order = _snapshot_order()
     bot.open_orders = {"BTC/USDT:USDT": [order]}
     bot.fetched_open_orders = [order]
     bot.order_matches_recent_execution = lambda _order, max_age_ms=None: True
@@ -11080,34 +11080,28 @@ async def test_disappeared_self_order_blocks_creations_until_full_freshness():
     assert ok is True
     assert bot.execution_scheduled is True
     assert bot.state_change_detected_by_symbol == {"BTC/USDT:USDT"}
-    assert set(bot.freshness_ledger.blocked_symbols()) == {"BTC/USDT:USDT"}
-    assert bot.freshness_ledger.blocked_symbols()["BTC/USDT:USDT"].min_epoch == 4
     assert bot._authoritative_pending_confirmations == {
         surface: 4 for surface in ACCOUNT_SURFACES
     }
 
-    to_create, skipped = Passivbot._apply_freshness_creation_guardrails(
-        bot,
-        [
-            {"symbol": "BTC/USDT:USDT", "side": "buy", "position_side": "long"},
-            {"symbol": "ETH/USDT:USDT", "side": "buy", "position_side": "long"},
-        ],
-    )
-
-    assert skipped == 1
-    assert [order["symbol"] for order in to_create] == ["ETH/USDT:USDT"]
+    blocked, details = bot._authoritative_execution_barrier_state()
+    assert blocked is True
+    assert set(details["missing"]) == set(ACCOUNT_SURFACES)
 
     bot._begin_authoritative_refresh_epoch()
     for surface in ACCOUNT_SURFACES:
         bot._record_authoritative_surface(surface, (surface, "fresh"))
 
-    assert bot.freshness_ledger.blocked_symbols() == {}
+    blocked, details = bot._authoritative_execution_barrier_state()
+    assert blocked is False
+    assert details["missing"] == []
+    assert bot._authoritative_pending_confirmations == {}
 
 
 @pytest.mark.asyncio
-async def test_bot_cancelled_order_disappearance_does_not_arm_duplicate_guardrail():
-    bot = _make_open_order_guardrail_bot(epoch=5)
-    order = _guardrail_order()
+async def test_bot_cancelled_order_disappearance_does_not_request_confirmation():
+    bot = _make_open_order_snapshot_bot(epoch=5)
+    order = _snapshot_order()
     bot.open_orders = {"BTC/USDT:USDT": [order]}
     bot.fetched_open_orders = [order]
     bot.order_matches_bot_cancellation = lambda _order: True
@@ -11121,15 +11115,14 @@ async def test_bot_cancelled_order_disappearance_does_not_arm_duplicate_guardrai
     )
 
     assert ok is True
-    assert bot.freshness_ledger.blocked_symbols() == {}
     assert bot._authoritative_pending_confirmations == {}
     assert bot.state_change_detected_by_symbol == set()
 
 
 @pytest.mark.asyncio
-async def test_unknown_manual_or_exchange_cancel_requests_confirmation_without_symbol_block():
-    bot = _make_open_order_guardrail_bot(epoch=5)
-    order = _guardrail_order(id="manual-or-exchange-cancel")
+async def test_unknown_manual_or_exchange_cancel_requests_confirmation():
+    bot = _make_open_order_snapshot_bot(epoch=5)
+    order = _snapshot_order(id="manual-or-exchange-cancel")
     bot.open_orders = {"BTC/USDT:USDT": [order]}
     bot.fetched_open_orders = [order]
     bot.order_matches_bot_cancellation = lambda _order: False
@@ -11143,7 +11136,6 @@ async def test_unknown_manual_or_exchange_cancel_requests_confirmation_without_s
     )
 
     assert ok is True
-    assert bot.freshness_ledger.blocked_symbols() == {}
     assert bot.state_change_detected_by_symbol == {"BTC/USDT:USDT"}
     assert bot._authoritative_pending_confirmations == {
         surface: 6 for surface in ACCOUNT_SURFACES
@@ -11151,38 +11143,9 @@ async def test_unknown_manual_or_exchange_cancel_requests_confirmation_without_s
 
 
 @pytest.mark.asyncio
-async def test_disappeared_emitted_order_record_arms_duplicate_guardrail_without_recent_execution():
-    bot = _make_open_order_guardrail_bot(epoch=8)
-    order = _guardrail_order(
-        custom_id="entry_grid_normal_long",
-        info={"clientOrderId": "entry_grid_normal_long"},
-    )
-    bot.get_exchange_time = lambda: 10_000
-    bot.open_orders = {"BTC/USDT:USDT": [order]}
-    bot.fetched_open_orders = [order]
-    bot.order_matches_bot_cancellation = lambda _order: False
-    bot.order_was_recently_cancelled = lambda _order: 0.0
-    bot.order_matches_recent_execution = lambda _order, max_age_ms=None: False
-    Passivbot._record_emitted_order_custom_id(bot, order, emitted_ts=9_000)
-
-    ok = await Passivbot._apply_open_orders_snapshot(
-        bot,
-        [],
-        allow_followup_positions_refresh=False,
-    )
-
-    assert ok is True
-    assert set(bot.freshness_ledger.blocked_symbols()) == {"BTC/USDT:USDT"}
-    assert bot.freshness_ledger.blocked_symbols()["BTC/USDT:USDT"].min_epoch == 9
-    assert bot._authoritative_pending_confirmations == {
-        surface: 9 for surface in ACCOUNT_SURFACES
-    }
-
-
-@pytest.mark.asyncio
-async def test_restarted_inherited_order_disappearance_uses_confirmation_not_symbol_block():
-    bot = _make_open_order_guardrail_bot(epoch=8)
-    order = _guardrail_order(
+async def test_restarted_inherited_order_disappearance_uses_confirmation():
+    bot = _make_open_order_snapshot_bot(epoch=8)
+    order = _snapshot_order(
         id="inherited-after-restart",
         custom_id="entry_grid_normal_long",
         info={"clientOrderId": "entry_grid_normal_long"},
@@ -11201,7 +11164,6 @@ async def test_restarted_inherited_order_disappearance_uses_confirmation_not_sym
     )
 
     assert ok is True
-    assert bot.freshness_ledger.blocked_symbols() == {}
     assert bot.state_change_detected_by_symbol == {"BTC/USDT:USDT"}
     assert bot._authoritative_pending_confirmations == {
         surface: 9 for surface in ACCOUNT_SURFACES
@@ -11209,94 +11171,8 @@ async def test_restarted_inherited_order_disappearance_uses_confirmation_not_sym
 
 
 @pytest.mark.asyncio
-async def test_disappeared_self_order_guardrail_blocks_real_plan_create_until_refresh(
-    caplog,
-):
-    bot = _make_open_order_guardrail_bot(epoch=7)
-    bot._last_plan_detail = {}
-    bot._order_plan_summary_is_interesting = lambda **kwargs: False
-    bot.PB_modes = {"long": {}, "short": {}}
-    bot.active_symbols = ["BTC/USDT:USDT", "ETH/USDT:USDT"]
-
-    class _CM:
-        def get_current_close(self, symbol, max_age_ms=None):
-            return 100.0
-
-    bot.cm = _CM()
-
-    async def fake_get_live_last_prices(symbols, **kwargs):
-        return {symbol: 100.0 for symbol in symbols}
-
-    bot._get_live_last_prices = fake_get_live_last_prices
-    bot.live_value = lambda key: 0.0 if key == "order_match_tolerance_pct" else 0.0
-
-    disappeared_order = _guardrail_order()
-    bot.open_orders = {"BTC/USDT:USDT": [disappeared_order], "ETH/USDT:USDT": []}
-    bot.fetched_open_orders = [disappeared_order]
-    bot.order_matches_recent_execution = lambda _order, max_age_ms=None: True
-    bot.order_matches_bot_cancellation = lambda _order: False
-    bot.order_was_recently_cancelled = lambda _order: 0.0
-
-    await Passivbot._apply_open_orders_snapshot(
-        bot,
-        [],
-        allow_followup_positions_refresh=False,
-    )
-    bot.state_change_detected_by_symbol = set()
-
-    ideal_orders = {
-        "BTC/USDT:USDT": [
-            {
-                "symbol": "BTC/USDT:USDT",
-                "side": "buy",
-                "position_side": "long",
-                "qty": 0.01,
-                "price": 99_000.0,
-                "reduce_only": False,
-                "type": "limit",
-                "pb_order_type": "entry_grid_normal_long",
-            }
-        ],
-        "ETH/USDT:USDT": [
-            {
-                "symbol": "ETH/USDT:USDT",
-                "side": "buy",
-                "position_side": "long",
-                "qty": 0.1,
-                "price": 3_000.0,
-                "reduce_only": False,
-                "type": "limit",
-                "pb_order_type": "entry_grid_normal_long",
-            }
-        ],
-    }
-
-    async def fake_calc_ideal_orders():
-        return ideal_orders
-
-    bot.calc_ideal_orders = fake_calc_ideal_orders
-
-    with caplog.at_level(logging.INFO):
-        _to_cancel, to_create = await Passivbot.calc_orders_to_cancel_and_create(bot)
-
-    assert [order["symbol"] for order in to_create] == ["ETH/USDT:USDT"]
-    assert "freshness guardrail blocking order creation" in caplog.text
-
-    bot._begin_authoritative_refresh_epoch()
-    for surface in ACCOUNT_SURFACES:
-        bot._record_authoritative_surface(surface, (surface, "fresh"))
-
-    _to_cancel, to_create = await Passivbot.calc_orders_to_cancel_and_create(bot)
-
-    assert sorted(order["symbol"] for order in to_create) == [
-        "BTC/USDT:USDT",
-        "ETH/USDT:USDT",
-    ]
-
-
-@pytest.mark.asyncio
 async def test_malformed_actual_open_order_blocks_account_wide_creates(caplog):
-    bot = _make_open_order_guardrail_bot(epoch=11)
+    bot = _make_open_order_snapshot_bot(epoch=11)
     bot._last_plan_detail = {}
     bot._order_plan_summary_is_interesting = lambda **kwargs: False
     bot.PB_modes = {"long": {}, "short": {}}
@@ -11322,7 +11198,7 @@ async def test_malformed_actual_open_order_blocks_account_wide_creates(caplog):
         def __float__(self):
             raise hostile_error(secret)
 
-    malformed_order = _guardrail_order(id=unsafe_order_id)
+    malformed_order = _snapshot_order(id=unsafe_order_id)
     malformed_order["price"] = HostilePrice()
     bot.open_orders = {"BTC/USDT:USDT": [malformed_order], "ETH/USDT:USDT": []}
     ideal_orders = {


### PR DESCRIPTION
## Summary

- remove the disappeared-self-order `SymbolBlock` state machine and its sole self-emission classifier
- preserve the existing full-account next-epoch confirmation and same-wave symbol latch for every unexpected order disappearance
- simplify `FreshnessLedger`, reconciliation, and the HSL protective-plan call by removing the now-unused creation-guardrail switch
- replace planner-only symbol-block tests with the real authoritative confirmation lifecycle and update the affected architecture/event documentation

## Why

The symbol block required the same account surfaces at the same target epoch as `_authoritative_pending_confirmations`. In the normal live loop, the authoritative execution barrier is evaluated before planning and blocks the current cycle until that next full cohort settles. Stamping the final required surface then cleared the symbol block before reconciliation could consume it.

The layer therefore had no independent production safety role. Its direct planner test only exercised it after bypassing the outer barrier and manually clearing the same-wave latch.

## Safety contract retained

- any unexpected disappearance still schedules execution, marks the affected symbol in `state_change_detected_by_symbol`, and requests balance, positions, open orders, and fills at epoch `N+1`
- the normal loop still cannot plan or write until the authoritative barrier settles
- known bot cancellations still avoid the unexpected-disappearance path
- late websocket changes and uncertain cancellation results still use the same-wave symbol latch
- protective HSL market-panic behavior is unchanged

## Validation

- focused reconciliation/readiness tests: 45 passed
- complete affected suites: freshness ledger, balance/snapshot reconciliation, fresh-entry eligibility, cancel-first behavior, exchange config execution, foreign-order detection, and unstucking safeguards
- full Python test suite: passed
- `PYTHONPATH=src python src/tools/check_ai_docs.py` (0 errors; existing word-count warnings only)
- `PYTHONPATH=src python src/tools/generate_live_event_registry.py --check`
- `pytest tests/test_ai_docs.py tests/test_live_event_registry_docs.py -q`
- `git diff --check`