### PR TITLE
Add scenario-specific optimizer suite limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ All notable user-facing changes will be documented in this file.
   an omitted or null `scenario` keep using suite aggregation and their explicit `stat` or
   `backtest.aggregate` fallback. Named-scenario limits use that scenario's metric value and reject
   an accompanying `stat`.
+- Optimizer starting configs may now be pre-filtered from stored Pareto metrics with
+  `--filter-starting-configs` and optionally reduced with the same `anchors-farthest` selection as
+  `pareto-compress` via `--compress-starting-configs N` (`--starting-configs-max N`). The optimizer
+  warns that stored metrics are not verified against the new run and fails loudly when metric
+  artifacts are missing, malformed, or all rejected.
 - Live EMA preparation now batches compatible spans per symbol and metric family, including bounded
   cache-only fallbacks for stale forager candidates, and complete candle windows bypass redundant
   Python gap reconstruction. A failed combined read retries each span through its primary reader

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,11 @@ All notable user-facing changes will be documented in this file.
   entry may set `scenario` to a named suite scenario, set it explicitly to `null` to use suite
   aggregation, and optionally set `aggregate` to `mean`, `min`, `max`, `std`, or `median`.
   Omitting `scenario` inherits `optimize.objective_scenario`; aggregate objectives without an
-  explicit reducer inherit the metric-specific or default `backtest.aggregate` rule. Limits remain
-  suite-aggregated.
+  explicit reducer inherit the metric-specific or default `backtest.aggregate` rule.
+- Optimizer suite limits may now select a named `scenario` independently of scoring. Limits with
+  an omitted or null `scenario` keep using suite aggregation and their explicit `stat` or
+  `backtest.aggregate` fallback. Named-scenario limits use that scenario's metric value and reject
+  an accompanying `stat`.
 - Live EMA preparation now batches compatible spans per symbol and metric family, including bounded
   cache-only fallbacks for stale forager candidates, and complete candle windows bypass redundant
   Python gap reconstruction. A failed combined read retries each span through its primary reader

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,14 @@ All notable user-facing changes will be documented in this file.
 - Optimizer suite limits may now select a named `scenario` independently of scoring. Limits with
   an omitted or null `scenario` keep using suite aggregation and their explicit `stat` or
   `backtest.aggregate` fallback. Named-scenario limits use that scenario's metric value and reject
-  an accompanying `stat`.
+  an accompanying `stat`. Scenario labels are normalized consistently, and named-scenario limits
+  are rejected before data preparation when suite mode is disabled.
 - Optimizer starting configs may now be pre-filtered from stored Pareto metrics with
   `--filter-starting-configs` and optionally reduced with the same `anchors-farthest` selection as
   `pareto-compress` via `--compress-starting-configs N` (`--starting-configs-max N`). The optimizer
   warns that stored metrics are not verified against the new run and fails loudly when metric
-  artifacts are missing, malformed, or all rejected.
+  artifacts are missing, malformed, or all rejected. Active-scenario aggregate preselection matches
+  suite runtime behavior by aggregating each metric over the selected scenarios that emitted it.
 - Live EMA preparation now batches compatible spans per symbol and metric family, including bounded
   cache-only fallbacks for stale forager candidates, and complete candle windows bypass redundant
   Python gap reconstruction. A failed combined read retries each span through its primary reader

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable user-facing changes will be documented in this file.
   after filtering. Named-scenario limits are validated against the active labels before data
   preparation, including when suite mode is disabled. The Pareto dashboard also applies forbidden
   `inside_range` bands and optimizer-compatible `auto` directions to scenario-specific limit
-  columns.
+  columns, honors disabled limits, and parses generated not-equal filters.
 - Optimizer starting configs may now be pre-filtered from stored Pareto metrics with
   `--filter-starting-configs` and optionally reduced with the same `anchors-farthest` selection as
   `pareto-compress` via `--compress-starting-configs N` (`--starting-configs-max N`). The optimizer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,10 @@ All notable user-facing changes will be documented in this file.
   after filtering. Named-scenario limits are validated against the active labels before data
   preparation, including when suite mode is disabled. The Pareto dashboard also applies forbidden
   `inside_range` bands and optimizer-compatible `auto` directions to scenario-specific limit
-  columns, honors disabled limits, and parses generated not-equal filters. Pareto CLI filtering
-  likewise resolves `auto` limits with the optimizer's default metric directions.
+  columns, quotes scenario labels containing its boolean separator, honors disabled limits, and
+  parses generated not-equal filters. Pareto CLI filtering likewise resolves `auto` limits with
+  the optimizer's default metric directions. Iterative backtesting rejects unsupported
+  scenario-specific limits before loading markets or preparing datasets.
 - Optimizer starting configs may now be pre-filtered from stored Pareto metrics with
   `--filter-starting-configs` and optionally reduced with the same `anchors-farthest` selection as
   `pareto-compress` via `--compress-starting-configs N` (`--starting-configs-max N`). The optimizer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,10 @@ All notable user-facing changes will be documented in this file.
 - Optimizer suite limits may now select a named `scenario` independently of scoring. Limits with
   an omitted or null `scenario` keep using suite aggregation and their explicit `stat` or
   `backtest.aggregate` fallback. Named-scenario limits use that scenario's metric value and reject
-  an accompanying `stat`. Scenario labels are normalized consistently, and named-scenario limits
-  are rejected before data preparation when suite mode is disabled.
+  an accompanying `stat`. Scenario labels are normalized consistently and retain generated labels
+  after filtering. Named-scenario limits are validated against the active labels before data
+  preparation, including when suite mode is disabled. The Pareto dashboard also applies forbidden
+  `inside_range` bands to scenario-specific limit columns.
 - Optimizer starting configs may now be pre-filtered from stored Pareto metrics with
   `--filter-starting-configs` and optionally reduced with the same `anchors-farthest` selection as
   `pareto-compress` via `--compress-starting-configs N` (`--starting-configs-max N`). The optimizer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ All notable user-facing changes will be documented in this file.
   after filtering. Named-scenario limits are validated against the active labels before data
   preparation, including when suite mode is disabled. The Pareto dashboard also applies forbidden
   `inside_range` bands and optimizer-compatible `auto` directions to scenario-specific limit
-  columns, honors disabled limits, and parses generated not-equal filters.
+  columns, honors disabled limits, and parses generated not-equal filters. Pareto CLI filtering
+  likewise resolves `auto` limits with the optimizer's default metric directions.
 - Optimizer starting configs may now be pre-filtered from stored Pareto metrics with
   `--filter-starting-configs` and optionally reduced with the same `anchors-farthest` selection as
   `pareto-compress` via `--compress-starting-configs N` (`--starting-configs-max N`). The optimizer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ All notable user-facing changes will be documented in this file.
   an accompanying `stat`. Scenario labels are normalized consistently and retain generated labels
   after filtering. Named-scenario limits are validated against the active labels before data
   preparation, including when suite mode is disabled. The Pareto dashboard also applies forbidden
-  `inside_range` bands to scenario-specific limit columns.
+  `inside_range` bands and optimizer-compatible `auto` directions to scenario-specific limit
+  columns.
 - Optimizer starting configs may now be pre-filtered from stored Pareto metrics with
   `--filter-starting-configs` and optionally reduced with the same `anchors-farthest` selection as
   `pareto-compress` via `--compress-starting-configs N` (`--starting-configs-max N`). The optimizer

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -656,7 +656,8 @@ The optimizer reuses the backtest suite configuration when `--suite [y/n]` is en
   score objectives from that scenario by default, or to `null` to use suite aggregation by
   default. Individual `optimize.scoring` entries may override the default with a named `scenario`
   or explicit `scenario: null`, and aggregate-based entries may set their own `aggregate` reducer.
-  Limits remain suite-aggregated.
+  Individual `optimize.limits` entries independently select either a named scenario or a suite
+  aggregate statistic.
 
 Use `--suite-config path/to/file.json` to layer additional scenario definitions at runtime.
 
@@ -671,7 +672,12 @@ Any metric listed above can be used when defining limits. Currency-specific metr
 - `value`: numeric threshold for `<`/`>` modes.
 - `range`: two-value list `[low, high]` for the range modes.
 - Optional `enabled`: set to `false` to disable a default limit without deleting it. This prevents config normalization from re-adding that metric's default limit later.
-- Optional `stat`: when you want to compare against a specific statistic (`min`, `max`, `mean`, `std`). If omitted, Passivbot uses the metric's `backtest.aggregate` rule, then `backtest.aggregate.default`, then `mean`.
+- Optional `scenario`: a named suite scenario to evaluate for this limit. Omitted or explicit
+  `null` uses suite aggregation. A named scenario uses that scenario's metric value and cannot be
+  combined with `stat`; unknown labels and scenario limits outside suite optimization are rejected.
+- Optional `stat`: for suite-aggregate limits, the statistic to compare against (`min`, `max`,
+  `mean`, `std`, or `median`). If omitted, Passivbot uses the metric's `backtest.aggregate` rule,
+  then `backtest.aggregate.default`, then `mean`.
 
 #### Format
 
@@ -679,7 +685,18 @@ Define limits in `optimize.limits` as a list:
 
 ```json
 "limits": [
-  {"metric": "drawdown_worst_btc", "penalize_if": ">", "value": 0.3},
+  {
+    "metric": "drawdown_worst_strategy_eq",
+    "penalize_if": "greater_than",
+    "scenario": "base",
+    "value": 0.5
+  },
+  {
+    "metric": "drawdown_worst_strategy_eq",
+    "penalize_if": "greater_than",
+    "stat": "max",
+    "value": 0.7
+  },
   {"metric": "loss_profit_ratio", "penalize_if": "outside_range", "range": [0.05, 0.7]},
   {"metric": "adg_btc", "penalize_if": "<", "value": 0.0005, "stat": "mean"},
   {"metric": "hard_stop_time_in_red_pct", "penalize_if": ">", "value": 0.02},
@@ -706,6 +723,7 @@ written as keep conditions, matching `pareto_store.py` filtering:
 passivbot optimize \
   --clear-limits \
   --limit 'drawdown_worst <= 0.35' \
+  --limit 'drawdown_worst_strategy_eq <= 0.5 scenario=base' \
   --limit 'backtest_completion_ratio>=1.0' \
   --limit 'loss_profit_ratio outside_range [0.05,0.7]' \
   --limit 'adg > 0.0008 stat=mean'

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -405,7 +405,8 @@ Key fields (directly under `backtest`):
 `optimize.objective_scenario` sets the default scoring basis. Set it to a unique scenario label
 (commonly `base`) to read objectives from that scenario by default, or leave it `null` to use suite
 aggregation by default. The equivalent global CLI override is `--objective-scenario LABEL`.
-`optimize.limits` always continue to use suite aggregation and each limit's `stat`.
+Each `optimize.limits` entry independently uses suite aggregation by default or may select one
+named scenario.
 
 Each object-form `optimize.scoring` entry may override the default:
 
@@ -442,6 +443,31 @@ exclusive. This permits representative base-period performance objectives alongs
 worst-case stress objectives while limits retain their independent suite-wide contract.
 Each metric may still appear only once in `optimize.scoring`; scoring the same metric from multiple
 bases is not supported in this first version.
+
+Limits may combine a scenario-specific threshold with a separate suite-wide threshold for the same
+metric:
+
+```json
+"limits": [
+  {
+    "metric": "drawdown_worst_strategy_eq",
+    "penalize_if": "greater_than",
+    "scenario": "base",
+    "value": 0.5
+  },
+  {
+    "metric": "drawdown_worst_strategy_eq",
+    "penalize_if": "greater_than",
+    "stat": "max",
+    "value": 0.7
+  }
+]
+```
+
+The first limit reads only `base`; the second reads the maximum across scenarios. Their violations
+are evaluated independently and their penalties accumulate. A named `scenario` and `stat` are
+mutually exclusive. An omitted or null `scenario` uses suite aggregation; with no explicit `stat`,
+the limit falls back through the metric-specific and default `backtest.aggregate` rules.
 
 Suite mode is opt-in. The default schema/example config does not enable it automatically.
 
@@ -584,7 +610,10 @@ objects. Each object describes when to penalize a result:
   to keep a metric within `[low, high]`, or `inside_range` to forbid a band.
 - `value`: numeric threshold for `<`/`>` limits.
 - `range`: `[low, high]` for the range-based operators.
-- Optional `stat`: override the statistic to compare against (`min`, `max`, `mean`, `std`).
+- Optional `scenario`: select one named suite scenario. Omitted or explicit `null` uses suite
+  aggregation. Named scenarios cannot be combined with `stat`.
+- Optional `stat`: for suite aggregation, override the statistic to compare against (`min`, `max`,
+  `mean`, `std`, or `median`).
   Without `stat`, Passivbot resolves the metric through `backtest.aggregate`: first a
   metric-specific aggregate rule, then `backtest.aggregate.default`, then `mean`.
 
@@ -592,7 +621,18 @@ Example:
 
 ```json
 "limits": [
-  {"metric": "drawdown_worst_btc", "penalize_if": ">", "value": 0.3},
+  {
+    "metric": "drawdown_worst_strategy_eq",
+    "penalize_if": "greater_than",
+    "scenario": "base",
+    "value": 0.5
+  },
+  {
+    "metric": "drawdown_worst_strategy_eq",
+    "penalize_if": "greater_than",
+    "stat": "max",
+    "value": 0.7
+  },
   {"metric": "loss_profit_ratio", "penalize_if": "outside_range", "range": [0.05, 0.7]},
   {"metric": "adg", "penalize_if": "<", "value": 0.0008, "stat": "mean"}
 ]
@@ -613,6 +653,7 @@ in `--limit` are written as keep conditions, matching `pareto_store.py` filterin
 passivbot optimize \
   --clear-limits \
   --limit 'drawdown_worst <= 0.35' \
+  --limit 'drawdown_worst_strategy_eq <= 0.5 scenario=base' \
   --limit 'backtest_completion_ratio>=1.0' \
   --limit 'loss_profit_ratio outside_range [0.05,0.7]' \
   --limit 'adg > 0.0008 stat=mean'

--- a/docs/suite_examples.md
+++ b/docs/suite_examples.md
@@ -207,6 +207,32 @@ aggregation, and optionally set an objective-only `aggregate` reducer. For examp
 
 Here ADG uses `base`, while underwater percentage uses the configured suite aggregate.
 
+Limits choose their basis independently. This example applies a tighter drawdown threshold to the
+base scenario and a looser worst-scenario threshold across the whole suite:
+
+```json
+{
+  "optimize": {
+    "limits": [
+      {
+        "metric": "drawdown_worst_strategy_eq",
+        "penalize_if": "greater_than",
+        "scenario": "base",
+        "value": 0.5
+      },
+      {
+        "metric": "drawdown_worst_strategy_eq",
+        "penalize_if": "greater_than",
+        "stat": "max",
+        "value": 0.7
+      }
+    ]
+  }
+}
+```
+
+The two limits are independent and both penalties apply when both thresholds are exceeded.
+
 ## Recommended Workflow
 
 1. Start with a single backtest or optimize run.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -96,6 +96,45 @@ passivbot tool pareto-compress optimize_results/.../pareto 8 --output-dir select
 passivbot tool merge-paretos optimize_results/run_a/pareto optimize_results/run_b/pareto
 ```
 
+## Optimizer starting-config preselection
+
+By default, `passivbot optimize -t/--start` accepts ordinary configs or Pareto artifacts, extracts
+their bot parameters, and re-evaluates every unique seed under the new run. Add
+`--filter-starting-configs` to filter metric-bearing Pareto artifacts before seed extraction using
+the optimizer's final effective limits, including config limits and CLI `--limits`, `--limit`, and
+`--clear-limits` changes:
+
+```shell
+passivbot optimize configs/examples/suite_example.json \
+  -t optimize_results/.../pareto \
+  --filter-starting-configs \
+  -l 'adg_strategy_eq>0.0' \
+  -l 'strategy_eq_recovery_days_max<100' \
+  -l '{"metric":"strategy_eq_recovery_days_max","penalize_if":"greater_than","stat":"max","value":120}'
+```
+
+Optionally add `--compress-starting-configs N` (alias `--starting-configs-max N`) to retain at most
+`N` filtered candidates using the same `anchors-farthest` objective-anchor and diversity selection
+as `passivbot tool pareto-compress N`. Compression may also be used without filtering:
+
+```shell
+passivbot optimize configs/examples/suite_example.json \
+  -t optimize_results/.../pareto \
+  --filter-starting-configs \
+  --compress-starting-configs 60 \
+  -l 'drawdown_worst_strategy_eq<0.5 scenario=base'
+```
+
+Both options trust the metrics and objectives stored in the seed artifacts. Passivbot cannot prove
+that their coin universe, exchanges, date range, scenarios, or other backtest settings match the
+new optimization, so it logs a warning whenever metric-based preselection is enabled. This workflow
+is best suited to restarting a comparable optimization with stricter limits. When seeds come from
+different runs or ordinary configs, omit these options so every seed is evaluated before selection.
+Metric-based preselection fails instead of guessing when JSON seeds lack usable Pareto metrics, a
+configured limit metric cannot be resolved, stored artifacts are malformed, or filtering rejects
+every candidate. Survivors are still quantized, deduplicated, and re-evaluated normally by the new
+optimization.
+
 ## Iterative backtester utilities
 
 `src/tools/iterative_backtester.py` and `iterative_history_plot.py` help replay slices of the backtester (or real fills) interactively so you can inspect order-by-order behaviour. Useful when tuning configs by hand.

--- a/src/config/limits.py
+++ b/src/config/limits.py
@@ -169,7 +169,7 @@ def parse_limit_cli_entry(raw_entry: Union[str, Dict[str, Any]]) -> Dict[str, An
         if key == "stat":
             entry["stat"] = value
         elif key == "scenario":
-            entry["scenario"] = None if value.lower() in {"null", "none"} else value
+            entry["scenario"] = None if value.lower() == "null" else value
         elif key == "enabled":
             entry["enabled"] = _parse_cli_bool(value)
         else:

--- a/src/config/limits.py
+++ b/src/config/limits.py
@@ -94,7 +94,7 @@ _INLINE_LIMIT_OP_RE = re.compile(
 
 def _tokenize_cli_limit_entry(raw_entry: str) -> List[str]:
     tokens = shlex.split(raw_entry)
-    if len(tokens) >= 3:
+    if len(tokens) >= 3 and not _INLINE_LIMIT_OP_RE.match(tokens[0]):
         return tokens
 
     match = _INLINE_LIMIT_OP_RE.match(raw_entry)

--- a/src/config/limits.py
+++ b/src/config/limits.py
@@ -3,6 +3,7 @@ import json
 import re
 import shlex
 from copy import deepcopy
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import hjson
@@ -12,6 +13,12 @@ from .metrics import canonical_metric_name, canonicalize_limit_name, canonicaliz
 
 SUPPORTED_AGGREGATE_MODES = {"min", "max", "mean", "std", "median"}
 SUPPORTED_LIMIT_STATS = SUPPORTED_AGGREGATE_MODES
+
+
+@dataclass(frozen=True)
+class LimitBasis:
+    scenario: Optional[str]
+    stat: str
 
 
 def parse_limits_string(limits_str: Union[str, dict]) -> dict:
@@ -161,11 +168,14 @@ def parse_limit_cli_entry(raw_entry: Union[str, Dict[str, Any]]) -> Dict[str, An
         value = value.strip()
         if key == "stat":
             entry["stat"] = value
+        elif key == "scenario":
+            entry["scenario"] = None if value.lower() in {"null", "none"} else value
         elif key == "enabled":
             entry["enabled"] = _parse_cli_bool(value)
         else:
             raise ValueError(
-                f"Unsupported CLI --limit option {key!r}; supported extras are stat=... and enabled=..."
+                f"Unsupported CLI --limit option {key!r}; supported extras are "
+                "scenario=..., stat=..., and enabled=..."
             )
 
     return _normalize_limit_entry_preserve_extras(entry)
@@ -291,13 +301,31 @@ def _normalize_limit_entry(entry: Any) -> Dict[str, Any]:
     stat = payload.get("stat") or payload.get("field")
     normalized_stat: Optional[str] = None
     if stat is not None:
-        stat = str(stat).lower()
+        stat = str(stat).strip().lower()
         if stat not in SUPPORTED_LIMIT_STATS:
             raise ValueError(f"Unsupported stat '{stat}' for limit on {metric}.")
         normalized_stat = stat
+    scenario_present = "scenario" in payload
+    scenario = payload.get("scenario")
+    if scenario is not None:
+        if not isinstance(scenario, str):
+            raise ValueError(
+                f"Limit scenario for {metric} must be a scenario label string or null."
+            )
+        scenario = scenario.strip()
+        if not scenario:
+            raise ValueError(
+                f"Limit scenario for {metric} must be a non-empty scenario label or null."
+            )
+    if scenario is not None and normalized_stat is not None:
+        raise ValueError(
+            f"Limit on {metric} cannot set both a named scenario and stat."
+        )
     result: Dict[str, Any] = {"metric": metric, "penalize_if": penalize_if}
     if normalized_stat:
         result["stat"] = normalized_stat
+    if scenario_present:
+        result["scenario"] = scenario
     if penalize_if in {
         "greater_than",
         "greater_than_or_equal",
@@ -473,6 +501,28 @@ def resolve_limit_stat(
             )
         return resolved
     return resolve_aggregate_mode(metric, aggregate_cfg)
+
+
+def resolve_limit_basis(
+    entry: Dict[str, Any],
+    aggregate_cfg: Optional[Dict[str, Any]] = None,
+) -> LimitBasis:
+    metric = canonical_metric_name(str(entry.get("metric", "") or ""))
+    scenario = entry.get("scenario")
+    if scenario is not None:
+        if not isinstance(scenario, str) or not scenario.strip():
+            raise ValueError(
+                f"Limit scenario for {metric} must be a non-empty scenario label or null."
+            )
+        if entry.get("stat") is not None:
+            raise ValueError(
+                f"Limit on {metric} cannot set both a named scenario and stat."
+            )
+        return LimitBasis(scenario=scenario.strip(), stat="mean")
+    return LimitBasis(
+        scenario=None,
+        stat=resolve_limit_stat(entry, aggregate_cfg=aggregate_cfg),
+    )
 
 
 def _resolve_optimize_limits_for_load(

--- a/src/limit_utils.py
+++ b/src/limit_utils.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from difflib import get_close_matches
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
-from config.limits import resolve_limit_stat
+from config.limits import resolve_limit_basis
 from config.metrics import ANALYSIS_SHARED_KEYS, CURRENCY_METRICS, METRIC_ALIASES, canonical_metric_name
 
 _BOUNDARY_VIOLATION_EPSILON = 1e-12
@@ -180,15 +180,16 @@ def _build_single_bound_check(
     numeric_bound = _ensure_float(bound)
     if numeric_bound is None:
         return None
-    stat = resolve_limit_stat(entry, aggregate_cfg=aggregate_cfg)
-    metric_key = f"{metric}_{stat}"
+    basis = resolve_limit_basis(entry, aggregate_cfg=aggregate_cfg)
+    metric_key = f"{metric}_{basis.stat}"
     return {
         "metric": metric,
         "metric_key": metric_key,
         "mode": mode,
         "bound": numeric_bound,
         "penalty_weight": penalty_weight,
-        "stat": stat,
+        "stat": basis.stat,
+        "scenario": basis.scenario,
         "objective_indexes": list(objective_index_map.get(metric, [])) if objective_index_map else [],
     }
 
@@ -210,14 +211,15 @@ def _build_range_check(
         return None
     if low > high:
         low, high = high, low
-    stat = resolve_limit_stat(entry, aggregate_cfg=aggregate_cfg)
-    metric_key = f"{metric}_{stat}"
+    basis = resolve_limit_basis(entry, aggregate_cfg=aggregate_cfg)
+    metric_key = f"{metric}_{basis.stat}"
     return {
         "metric": metric,
         "metric_key": metric_key,
         "mode": mode,
         "range": (low, high),
         "penalty_weight": penalty_weight,
-        "stat": stat,
+        "stat": basis.stat,
+        "scenario": basis.scenario,
         "objective_indexes": list(objective_index_map.get(metric, [])) if objective_index_map else [],
     }

--- a/src/limit_utils.py
+++ b/src/limit_utils.py
@@ -26,12 +26,16 @@ def resolve_auto_limit_entries(
     resolved: List[Dict[str, Any]] = []
     for raw_entry in limits:
         entry = deepcopy(raw_entry)
+        if not bool(entry.get("enabled", True)):
+            resolved.append(entry)
+            continue
         mode = entry.get("penalize_if") or "greater_than"
         if mode == "auto":
             metric = entry.get("metric")
             if not metric:
                 continue
             canonical_metric = canonical_metric_name(str(metric))
+            _validate_limit_metric(canonical_metric, raw_entry)
             weight = weights.get(canonical_metric)
             if weight is None:
                 continue

--- a/src/limit_utils.py
+++ b/src/limit_utils.py
@@ -17,6 +17,29 @@ _KNOWN_LIMIT_METRICS = (
 )
 
 
+def resolve_auto_limit_entries(
+    limits: Iterable[Dict[str, Any]],
+    scoring_weights: Dict[str, float],
+) -> List[Dict[str, Any]]:
+    """Resolve legacy ``penalize_if=auto`` entries using optimizer scoring directions."""
+    weights = scoring_weights or {}
+    resolved: List[Dict[str, Any]] = []
+    for raw_entry in limits:
+        entry = deepcopy(raw_entry)
+        mode = entry.get("penalize_if") or "greater_than"
+        if mode == "auto":
+            metric = entry.get("metric")
+            if not metric:
+                continue
+            canonical_metric = canonical_metric_name(str(metric))
+            weight = weights.get(canonical_metric)
+            if weight is None:
+                continue
+            entry["penalize_if"] = "less_than" if weight < 0 else "greater_than"
+        resolved.append(entry)
+    return resolved
+
+
 def expand_limit_checks(
     limits: Iterable[Dict[str, Any]],
     scoring_weights: Dict[str, float],
@@ -32,8 +55,8 @@ def expand_limit_checks(
         return []
     weights = scoring_weights or {}
     checks: List[Dict[str, Any]] = []
-    for raw_entry in limits:
-        entry = deepcopy(raw_entry)
+    for entry in resolve_auto_limit_entries(limits, weights):
+        raw_entry = entry
         if isinstance(entry, dict) and not bool(entry.get("enabled", True)):
             continue
         metric = entry.get("metric")
@@ -42,11 +65,6 @@ def expand_limit_checks(
         metric = canonical_metric_name(str(metric))
         _validate_limit_metric(metric, raw_entry)
         mode = entry.get("penalize_if") or "greater_than"
-        if mode == "auto":
-            weight = weights.get(metric)
-            if weight is None:
-                continue
-            mode = "less_than" if weight < 0 else "greater_than"
         if mode in {
             "greater_than",
             "greater_than_or_equal",

--- a/src/optimization/starting_config_selection.py
+++ b/src/optimization/starting_config_selection.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
-from config.scoring import ObjectiveSpec
+from config.scoring import ObjectiveSpec, default_scoring_weights
 from pareto_compress import compress_candidates
 from pareto_explorer import (
     ParetoCandidate,
@@ -29,11 +29,18 @@ class StartingConfigSelection:
 def _require_metric_bearing_artifacts(
     pareto_dir: Path,
     candidates: Sequence[ParetoCandidate],
+    source_path: str,
 ) -> None:
     candidate_paths = {candidate.path.resolve() for candidate in candidates}
+    raw_source = Path(source_path).expanduser()
+    json_paths = (
+        [raw_source.resolve()]
+        if raw_source.is_file()
+        else sorted(pareto_dir.glob("*.json"))
+    )
     unsupported = [
         path.name
-        for path in sorted(pareto_dir.glob("*.json"))
+        for path in json_paths
         if path.name not in _IGNORED_METADATA_FILENAMES
         and path.resolve() not in candidate_paths
     ]
@@ -73,7 +80,7 @@ def select_starting_config_artifacts(
             "Omit --filter-starting-configs and --compress-starting-configs to re-evaluate "
             "ordinary seed configs."
         ) from exc
-    _require_metric_bearing_artifacts(pareto_dir, loaded)
+    _require_metric_bearing_artifacts(pareto_dir, loaded, path)
 
     candidates = list(loaded)
     active_limits: list[dict[str, Any]] = []
@@ -82,6 +89,7 @@ def select_starting_config_artifacts(
             candidates,
             limits,
             aggregate_cfg=aggregate_cfg,
+            scoring_weights=default_scoring_weights(),
         )
         if not candidates:
             raise ValueError(

--- a/src/optimization/starting_config_selection.py
+++ b/src/optimization/starting_config_selection.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from config.scoring import ObjectiveSpec
+from pareto_compress import compress_candidates
+from pareto_explorer import (
+    ParetoCandidate,
+    filter_candidates_with_limits,
+    load_candidates,
+)
+
+_IGNORED_METADATA_FILENAMES = {"selection.json"}
+
+
+@dataclass(frozen=True)
+class StartingConfigSelection:
+    pareto_dir: Path
+    candidates: tuple[ParetoCandidate, ...]
+    scoring_specs: tuple[ObjectiveSpec, ...]
+    loaded_count: int
+    filtered_count: int
+    selected_count: int
+
+
+def _require_metric_bearing_artifacts(
+    pareto_dir: Path,
+    candidates: Sequence[ParetoCandidate],
+) -> None:
+    candidate_paths = {candidate.path.resolve() for candidate in candidates}
+    unsupported = [
+        path.name
+        for path in sorted(pareto_dir.glob("*.json"))
+        if path.name not in _IGNORED_METADATA_FILENAMES
+        and path.resolve() not in candidate_paths
+    ]
+    if unsupported:
+        preview = ", ".join(unsupported[:5])
+        suffix = (
+            "" if len(unsupported) <= 5 else f", ... (+{len(unsupported) - 5} more)"
+        )
+        raise ValueError(
+            "Starting-config metric preselection requires every JSON input to be a "
+            "metric-bearing Pareto artifact; unsupported files: "
+            f"{preview}{suffix}. Omit --filter-starting-configs and "
+            "--compress-starting-configs to re-evaluate ordinary seed configs."
+        )
+
+
+def select_starting_config_artifacts(
+    path: str,
+    *,
+    limits: Sequence[Mapping[str, Any]],
+    aggregate_cfg: Mapping[str, Any] | None,
+    filter_by_limits: bool,
+    max_count: int | None,
+) -> StartingConfigSelection:
+    logging.warning(
+        "Starting-config metric preselection trusts stored Pareto metrics and objectives "
+        "without verifying that their coins, exchanges, date range, scenarios, or backtest "
+        "settings match this optimization run. Use it only for comparable artifacts; omit "
+        "--filter-starting-configs and --compress-starting-configs to re-evaluate all seed configs."
+    )
+    try:
+        pareto_dir, loaded, scoring_specs = load_candidates(path)
+    except ValueError as exc:
+        raise ValueError(
+            "Starting-config metric preselection could not load complete metric-bearing "
+            f"Pareto artifacts: {exc}. "
+            "Omit --filter-starting-configs and --compress-starting-configs to re-evaluate "
+            "ordinary seed configs."
+        ) from exc
+    _require_metric_bearing_artifacts(pareto_dir, loaded)
+
+    candidates = list(loaded)
+    active_limits: list[dict[str, Any]] = []
+    if filter_by_limits:
+        candidates, active_limits = filter_candidates_with_limits(
+            candidates,
+            limits,
+            aggregate_cfg=aggregate_cfg,
+        )
+        if not candidates:
+            raise ValueError(
+                "No starting configs remained after applying the optimizer's effective limits."
+            )
+
+    filtered_count = len(candidates)
+    if max_count is not None and len(candidates) > int(max_count):
+        members, _objective_ranges, _truncated_anchors = compress_candidates(
+            candidates,
+            scoring_specs,
+            count=int(max_count),
+            method="anchors-farthest",
+        )
+        candidates = [member.candidate for member in members]
+
+    logging.info(
+        "Starting-config metric preselection | loaded=%d | retained_after_limits=%d "
+        "| selected=%d | active_limits=%d | max=%s",
+        len(loaded),
+        filtered_count,
+        len(candidates),
+        len(active_limits),
+        str(max_count) if max_count is not None else "none",
+    )
+    return StartingConfigSelection(
+        pareto_dir=pareto_dir,
+        candidates=tuple(candidates),
+        scoring_specs=tuple(scoring_specs),
+        loaded_count=len(loaded),
+        filtered_count=filtered_count,
+        selected_count=len(candidates),
+    )

--- a/src/optimization/starting_config_selection.py
+++ b/src/optimization/starting_config_selection.py
@@ -64,6 +64,7 @@ def select_starting_config_artifacts(
     aggregate_cfg: Mapping[str, Any] | None,
     filter_by_limits: bool,
     max_count: int | None,
+    scenario_labels: Sequence[str] | None = None,
 ) -> StartingConfigSelection:
     logging.warning(
         "Starting-config metric preselection trusts stored Pareto metrics and objectives "
@@ -89,6 +90,7 @@ def select_starting_config_artifacts(
             candidates,
             limits,
             aggregate_cfg=aggregate_cfg,
+            scenario_labels=scenario_labels,
             scoring_weights=default_scoring_weights(),
         )
         if not candidates:

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -2837,6 +2837,28 @@ def _active_suite_scenario_labels(suite_cfg: Mapping[str, Any]) -> list[str] | N
     return [scenario.label for scenario in scenarios]
 
 
+def _validate_optimizer_limit_suite_mode(
+    config: Mapping[str, Any],
+    *,
+    suite_enabled: bool,
+) -> None:
+    if suite_enabled:
+        return
+    optimize_cfg = config.get("optimize")
+    limits = optimize_cfg.get("limits", []) if isinstance(optimize_cfg, Mapping) else []
+    for entry in limits:
+        if not isinstance(entry, Mapping) or not bool(entry.get("enabled", True)):
+            continue
+        scenario = entry.get("scenario")
+        if scenario is None:
+            continue
+        metric = str(entry.get("metric", "")).strip() or "<missing>"
+        raise ValueError(
+            f"scenario-specific optimizer limit on {metric!r} requires suite mode "
+            f"(scenario {scenario!r}); enable the optimizer suite or remove the scenario selector."
+        )
+
+
 def iter_anchored_fine_tune_seed_configs(config: dict):
     anchor_plan = get_anchor_plan(config)
     if anchor_plan is None:
@@ -3082,6 +3104,11 @@ async def main():
             config, "backtest.suite_enabled", bool(args.suite), verbose=True
         )
         suite_cfg["enabled"] = bool(args.suite)
+
+    _validate_optimizer_limit_suite_mode(
+        config,
+        suite_enabled=bool(suite_cfg.get("enabled")),
+    )
 
     preselected_starting_configs = None
     if args.filter_starting_configs or args.starting_configs_max is not None:

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -183,6 +183,7 @@ from optimization.fine_tune_anchors import ANCHOR_GENE_KEY, ANCHOR_PLAN_KEY, get
 from optimization.backend_shared import cancel_pending_async_results, stream_async_results
 from optimization.backends import get_backend_runner
 from optimization.random_seed import seed_rngs
+from optimization.starting_config_selection import select_starting_config_artifacts
 from optimization.config_adapter import (
     extract_bounds_tuple_list_from_config,
     get_optimization_key_paths,
@@ -2224,9 +2225,8 @@ def add_extra_options(parser, *, help_all: bool):
         dest="starting_configs",
         default=None,
         help=(
-            "Start with given live configs. With --fine-tune-params, these configs are fixed-param anchors."
-            if help_all
-            else argparse.SUPPRESS
+            "Start with configs or Pareto artifacts from a JSON file or directory. "
+            "With --fine-tune-params, these configs are fixed-param anchors."
         ),
     )
     parser.add_argument(
@@ -2270,6 +2270,30 @@ def add_extra_options(parser, *, help_all: bool):
     )
 
 
+def add_starting_config_selection_options(parser) -> None:
+    parser.add_argument(
+        "--filter-starting-configs",
+        action="store_true",
+        dest="filter_starting_configs",
+        help=(
+            "Before optimization, filter metric-bearing -t/--start Pareto artifacts using "
+            "the final effective optimize limits. Stored metrics are not revalidated."
+        ),
+    )
+    parser.add_argument(
+        "--compress-starting-configs",
+        "--starting-configs-max",
+        type=int,
+        default=None,
+        metavar="N",
+        dest="starting_configs_max",
+        help=(
+            "Select at most N metric-bearing -t/--start artifacts with the same "
+            "anchors-farthest method as pareto-compress."
+        ),
+    )
+
+
 def _resolve_cli_limits_override(args, existing_limits=None) -> list[dict] | None:
     raw_limits_payload = getattr(args, "optimize.limits", None)
     raw_limit_entries = list(getattr(args, "limit_entries", []) or [])
@@ -2286,6 +2310,27 @@ def _resolve_cli_limits_override(args, existing_limits=None) -> list[dict] | Non
     if raw_limit_entries:
         replacement.extend(parse_limit_cli_entries(raw_limit_entries))
     return normalize_limit_entries(replacement)
+
+
+def _validate_starting_config_selection_args(
+    parser: argparse.ArgumentParser,
+    args: argparse.Namespace,
+) -> None:
+    filter_starting_configs = bool(getattr(args, "filter_starting_configs", False))
+    starting_configs_max = getattr(args, "starting_configs_max", None)
+    selection_requested = filter_starting_configs or starting_configs_max is not None
+    if not selection_requested:
+        return
+    if not getattr(args, "starting_configs", None):
+        parser.error(
+            "--filter-starting-configs and --compress-starting-configs require -t/--start"
+        )
+    if getattr(args, "resume", None):
+        parser.error(
+            "--filter-starting-configs and --compress-starting-configs cannot be used with --resume"
+        )
+    if starting_configs_max is not None and int(starting_configs_max) <= 0:
+        parser.error("--compress-starting-configs must be a positive integer")
 
 
 def _flat_optimize_bounds_for_config(config: dict) -> tuple[dict, bool]:
@@ -2557,6 +2602,8 @@ def install_anchored_fine_tune_plan(
     config: dict,
     fine_tune_params: list[str],
     starting_configs_path: str,
+    *,
+    starting_configs_override: Sequence[dict] | None = None,
 ) -> None:
     flat_bounds, fine_tune_set, config_fixed_params, effective_fixed_params = (
         _resolve_fine_tune_key_sets(config, fine_tune_params)
@@ -2583,7 +2630,12 @@ def install_anchored_fine_tune_plan(
     }
     sig_digits = config.get("optimize", {}).get("round_to_n_significant_digits", 6)
     clamp_collector = {}
-    for raw_anchor in iter_starting_configs(starting_configs_path):
+    starting_configs = (
+        iter(starting_configs_override)
+        if starting_configs_override is not None
+        else iter_starting_configs(starting_configs_path)
+    )
+    for raw_anchor in starting_configs:
         try:
             anchor_cfg = _build_starting_seed_config(raw_anchor)
             anchor_strategy_kind = normalize_strategy_kind(
@@ -2738,6 +2790,39 @@ def iter_starting_configs(starting_configs: str):
                 yield from iter_starting_configs(entry.path)
         return
     yield from iter_extract_configs(starting_configs)
+
+
+def preselect_starting_configs(
+    starting_configs_path: str,
+    config: Mapping[str, Any],
+    *,
+    filter_by_limits: bool,
+    max_count: int | None,
+) -> list[dict]:
+    backtest_cfg = config.get("backtest")
+    aggregate_cfg = backtest_cfg.get("aggregate") if isinstance(backtest_cfg, Mapping) else None
+    optimize_cfg = config.get("optimize")
+    limits = optimize_cfg.get("limits", []) if isinstance(optimize_cfg, Mapping) else []
+    selection = select_starting_config_artifacts(
+        starting_configs_path,
+        limits=limits,
+        aggregate_cfg=aggregate_cfg if isinstance(aggregate_cfg, Mapping) else None,
+        filter_by_limits=filter_by_limits,
+        max_count=max_count,
+    )
+    current_specs = extract_objective_specs(config)
+    if (
+        selection.selected_count < selection.filtered_count
+        and current_specs != list(selection.scoring_specs)
+    ):
+        logging.warning(
+            "Stored starting-config optimize.scoring differs from this optimization run; "
+            "anchors-farthest compression used the stored objectives."
+        )
+    return [
+        _extract_starting_config(candidate.entry, source=str(candidate.path))
+        for candidate in selection.candidates
+    ]
 
 
 def iter_anchored_fine_tune_seed_configs(config: dict):
@@ -2914,10 +2999,12 @@ async def main():
         dest="clear_limits",
         help="Replace optimize.limits with an empty list before applying any --limits/--limit entries.",
     )
+    add_starting_config_selection_options(optimize_common_group)
     add_extra_options(group_map["Advanced Overrides"], help_all=help_all)
     raw_args = merge_negative_cli_values(expand_help_all_argv(raw_argv))
     raw_args = _normalize_optional_bool_flag(raw_args, "--suite")
     args = parser.parse_args(raw_args)
+    _validate_starting_config_selection_args(parser, args)
     polish_bounds_pct = getattr(args, "polish_bounds_pct", None)
     polish_bounds_mode = getattr(args, "polish_bounds_mode", "clamp")
     if polish_bounds_pct is not None and (
@@ -2955,6 +3042,14 @@ async def main():
         TEMPLATE_CONFIG_MODE,
         ",".join(objective_metric_names(config)),
     )
+    preselected_starting_configs = None
+    if args.filter_starting_configs or args.starting_configs_max is not None:
+        preselected_starting_configs = preselect_starting_configs(
+            args.starting_configs,
+            config,
+            filter_by_limits=bool(args.filter_starting_configs),
+            max_count=args.starting_configs_max,
+        )
     fine_tune_params = (
         [p.strip() for p in (args.fine_tune_params or "").split(",") if p.strip()]
         if getattr(args, "fine_tune_params", "")
@@ -2968,7 +3063,12 @@ async def main():
     if polish_bounds_pct is not None:
         apply_polish_bounds(config, polish_bounds_pct, bounds_mode=polish_bounds_mode)
     if fine_tune_params and args.starting_configs:
-        install_anchored_fine_tune_plan(config, fine_tune_params, args.starting_configs)
+        install_anchored_fine_tune_plan(
+            config,
+            fine_tune_params,
+            args.starting_configs,
+            starting_configs_override=preselected_starting_configs,
+        )
     else:
         apply_fine_tune_bounds(config, fine_tune_params, cli_bounds_overrides)
     suite_override = None
@@ -3200,6 +3300,8 @@ async def main():
         logging.info("Selected optimizer backend: %s", backend_name)
         backend_runner = get_backend_runner(backend_name)
         starting_config_iter = iter_starting_configs
+        if preselected_starting_configs is not None:
+            starting_config_iter = lambda _path: iter(preselected_starting_configs)
         if get_anchor_plan(config) is not None:
             starting_config_iter = lambda _path: iter_anchored_fine_tune_seed_configs(config)
         backend_result = backend_runner(

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -2841,11 +2841,15 @@ def _validate_optimizer_limit_suite_mode(
     config: Mapping[str, Any],
     *,
     suite_enabled: bool,
+    scenario_labels: Sequence[str] | None = None,
 ) -> None:
-    if suite_enabled:
-        return
     optimize_cfg = config.get("optimize")
     limits = optimize_cfg.get("limits", []) if isinstance(optimize_cfg, Mapping) else []
+    available_labels = (
+        {str(label).strip() for label in scenario_labels}
+        if scenario_labels is not None
+        else None
+    )
     for entry in limits:
         if not isinstance(entry, Mapping) or not bool(entry.get("enabled", True)):
             continue
@@ -2853,10 +2857,18 @@ def _validate_optimizer_limit_suite_mode(
         if scenario is None:
             continue
         metric = str(entry.get("metric", "")).strip() or "<missing>"
-        raise ValueError(
-            f"scenario-specific optimizer limit on {metric!r} requires suite mode "
-            f"(scenario {scenario!r}); enable the optimizer suite or remove the scenario selector."
-        )
+        normalized_scenario = str(scenario).strip()
+        if not suite_enabled:
+            raise ValueError(
+                f"scenario-specific optimizer limit on {metric!r} requires suite mode "
+                f"(scenario {scenario!r}); enable the optimizer suite or remove the scenario selector."
+            )
+        if available_labels is not None and normalized_scenario not in available_labels:
+            available = ", ".join(sorted(available_labels)) or "<none>"
+            raise ValueError(
+                f"optimizer limit on {metric!r} selects unknown scenario "
+                f"{normalized_scenario!r}; available labels: {available}"
+            )
 
 
 def iter_anchored_fine_tune_seed_configs(config: dict):
@@ -3105,9 +3117,11 @@ async def main():
         )
         suite_cfg["enabled"] = bool(args.suite)
 
+    active_suite_scenario_labels = _active_suite_scenario_labels(suite_cfg)
     _validate_optimizer_limit_suite_mode(
         config,
         suite_enabled=bool(suite_cfg.get("enabled")),
+        scenario_labels=active_suite_scenario_labels,
     )
 
     preselected_starting_configs = None
@@ -3120,7 +3134,7 @@ async def main():
             aggregate_cfg=(
                 suite_cfg.get("aggregate") if suite_cfg.get("enabled") else None
             ),
-            scenario_labels=_active_suite_scenario_labels(suite_cfg),
+            scenario_labels=active_suite_scenario_labels,
         )
     fine_tune_params = (
         [p.strip() for p in (args.fine_tune_params or "").split(",") if p.strip()]

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -2799,6 +2799,7 @@ def preselect_starting_configs(
     filter_by_limits: bool,
     max_count: int | None,
     aggregate_cfg: Mapping[str, Any] | None,
+    scenario_labels: Sequence[str] | None = None,
 ) -> list[dict]:
     optimize_cfg = config.get("optimize")
     limits = optimize_cfg.get("limits", []) if isinstance(optimize_cfg, Mapping) else []
@@ -2809,6 +2810,7 @@ def preselect_starting_configs(
         starting_configs_path,
         limits=limits,
         aggregate_cfg=effective_aggregate_cfg,
+        scenario_labels=scenario_labels,
         filter_by_limits=filter_by_limits,
         max_count=max_count,
     )
@@ -3082,6 +3084,15 @@ async def main():
             max_count=args.starting_configs_max,
             aggregate_cfg=(
                 suite_cfg.get("aggregate") if suite_cfg.get("enabled") else None
+            ),
+            scenario_labels=(
+                [
+                    str(scenario["label"])
+                    for scenario in suite_cfg.get("scenarios", [])
+                    if isinstance(scenario, Mapping) and "label" in scenario
+                ]
+                if suite_cfg.get("enabled")
+                else None
             ),
         )
     fine_tune_params = (

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -2798,9 +2798,14 @@ def preselect_starting_configs(
     *,
     filter_by_limits: bool,
     max_count: int | None,
+    aggregate_cfg_override: Mapping[str, Any] | None = None,
 ) -> list[dict]:
     backtest_cfg = config.get("backtest")
-    aggregate_cfg = backtest_cfg.get("aggregate") if isinstance(backtest_cfg, Mapping) else None
+    aggregate_cfg = (
+        backtest_cfg.get("aggregate") if isinstance(backtest_cfg, Mapping) else None
+    )
+    if aggregate_cfg_override is not None:
+        aggregate_cfg = aggregate_cfg_override
     optimize_cfg = config.get("optimize")
     limits = optimize_cfg.get("limits", []) if isinstance(optimize_cfg, Mapping) else []
     selection = select_starting_config_artifacts(
@@ -3042,6 +3047,15 @@ async def main():
         TEMPLATE_CONFIG_MODE,
         ",".join(objective_metric_names(config)),
     )
+    suite_override = None
+    if args.suite_config:
+        logging.info("loading suite config %s", args.suite_config)
+        suite_override = load_suite_override_config(args.suite_config)
+        if _suite_config_implies_suite_mode(args):
+            recursive_config_update(
+                config, "backtest.suite_enabled", True, verbose=True
+            )
+    suite_cfg = extract_suite_config(config, suite_override)
     preselected_starting_configs = None
     if args.filter_starting_configs or args.starting_configs_max is not None:
         preselected_starting_configs = preselect_starting_configs(
@@ -3049,6 +3063,7 @@ async def main():
             config,
             filter_by_limits=bool(args.filter_starting_configs),
             max_count=args.starting_configs_max,
+            aggregate_cfg_override=suite_cfg.get("aggregate"),
         )
     fine_tune_params = (
         [p.strip() for p in (args.fine_tune_params or "").split(",") if p.strip()]
@@ -3071,14 +3086,6 @@ async def main():
         )
     else:
         apply_fine_tune_bounds(config, fine_tune_params, cli_bounds_overrides)
-    suite_override = None
-    if args.suite_config:
-        logging.info("loading suite config %s", args.suite_config)
-        suite_override = load_suite_override_config(args.suite_config)
-        if _suite_config_implies_suite_mode(args):
-            recursive_config_update(config, "backtest.suite_enabled", True, verbose=True)
-    suite_cfg = extract_suite_config(config, suite_override)
-
     # Handle --scenarios filter (implies --suite y)
     scenario_filter = getattr(args, "scenarios", None)
     if scenario_filter:

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -157,7 +157,7 @@ from opt_utils import make_json_serializable, generate_incremental_diff, round_f
 from limit_utils import expand_limit_checks, compute_limit_violation
 from pareto_store import ParetoStore
 import msgpack
-from typing import Sequence, Tuple, List, Dict, Any, Optional
+from typing import Sequence, Tuple, List, Dict, Any, Mapping, Optional
 from shared_arrays import SharedArrayManager, attach_shared_array
 from ohlcv_utils import align_and_aggregate_hlcvs
 from optimize_suite import (
@@ -1605,6 +1605,7 @@ class Evaluator:
         analyses_combined,
         *,
         limit_metrics=None,
+        scenario_limit_metrics: Mapping[str, Mapping[str, float]] | None = None,
         objective_values: Sequence[float] | None = None,
         return_raw_objectives: bool = False,
     ):
@@ -1617,12 +1618,33 @@ class Evaluator:
         per_objective_modifier = [0.0] * len(self.scoring_specs)
         global_modifier = 0.0
         for check in self.limit_checks:
-            val = resolve_metric_value(limit_metrics, check["metric_key"])
+            scenario = check.get("scenario")
+            check_metrics = limit_metrics
+            if scenario is not None:
+                if scenario_limit_metrics is None:
+                    raise ValueError(
+                        f"scenario-specific optimizer limit on {check['metric']!r} "
+                        f"requires suite mode (scenario {scenario!r})"
+                    )
+                check_metrics = scenario_limit_metrics.get(scenario)
+                if check_metrics is None:
+                    available = ", ".join(sorted(scenario_limit_metrics)) or "<none>"
+                    raise ValueError(
+                        f"optimizer limit on {check['metric']!r} selects unknown scenario "
+                        f"{scenario!r}; available labels: {available}"
+                    )
+            val = resolve_metric_value(check_metrics, check["metric_key"])
             if val is None:
+                basis = (
+                    f"scenario {scenario!r}"
+                    if scenario is not None
+                    else f"suite stat {check['stat']!r}"
+                )
                 raise ValueError(
                     "missing optimizer limit metric "
-                    f"{check['metric_key']!r} for limit on {check['metric']!r}; "
-                    f"available metrics: {_format_available_metric_keys(limit_metrics)}"
+                    f"{check['metric_key']!r} for limit on {check['metric']!r} "
+                    f"from {basis}; "
+                    f"available metrics: {_format_available_metric_keys(check_metrics)}"
                 )
             penalty = compute_limit_violation(check, val)
             if not penalty:
@@ -1722,6 +1744,14 @@ class SuiteEvaluator:
                     f"available labels: {', '.join(labels)}"
                 )
         self.base.build_limit_checks(self.aggregate_cfg)
+        for check in self.base.limit_checks:
+            scenario = check.get("scenario")
+            if scenario is not None and scenario not in labels:
+                raise ValueError(
+                    f"optimizer limit on {check['metric']!r} selects scenario "
+                    f"{scenario!r}, which is not present in backtest.scenarios; "
+                    f"available labels: {', '.join(labels)}"
+                )
         # Cache for master dataset attachments (shared across scenarios)
         self._master_attachments: Dict[str, Dict[str, Any]] = {"hlcvs": {}, "btc": {}}
         self._master_arrays: Dict[str, Dict[str, np.ndarray]] = {"hlcvs": {}, "btc": {}}
@@ -2067,6 +2097,11 @@ class SuiteEvaluator:
         required_scenario_labels = {
             basis.scenario for basis in self.objective_bases if basis.scenario is not None
         }
+        required_scenario_labels.update(
+            check["scenario"]
+            for check in self.base.limit_checks
+            if check.get("scenario") is not None
+        )
         scenario_stats_by_label = {
             result.scenario.label: flatten_metric_stats(result.metrics.get("stats", {}))
             for result in scenario_results
@@ -2101,6 +2136,7 @@ class SuiteEvaluator:
         objectives, total_penalty = self.base.calc_fitness(
             flat_stats,
             limit_metrics=flat_stats,
+            scenario_limit_metrics=scenario_stats_by_label,
             objective_values=objective_values,
         )
         objectives_map = {f"w_{i}": val for i, val in enumerate(objectives)}
@@ -2868,7 +2904,8 @@ async def main():
         help=(
             "Repeatable optimize limit override. Example: "
             "\"drawdown_worst > 0.35\" or "
-            "\"loss_profit_ratio outside_range [0.05,0.7]\""
+            "\"drawdown_worst_strategy_eq <= 0.5 scenario=base\". "
+            "Aggregate limits may use stat=min|max|mean|std|median."
         ),
     )
     optimize_common_group.add_argument(

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -171,6 +171,7 @@ from suite_runner import (
     filter_scenarios_by_label,
     load_suite_override_config,
     aggregate_metrics,
+    build_scenarios,
     build_suite_metrics_payload,
 )
 from metrics_schema import MetricAggregationError, build_scenario_metrics, flatten_metric_stats
@@ -2829,6 +2830,13 @@ def preselect_starting_configs(
     ]
 
 
+def _active_suite_scenario_labels(suite_cfg: Mapping[str, Any]) -> list[str] | None:
+    if not suite_cfg.get("enabled"):
+        return None
+    scenarios, _aggregate_cfg = build_scenarios(dict(suite_cfg))
+    return [scenario.label for scenario in scenarios]
+
+
 def iter_anchored_fine_tune_seed_configs(config: dict):
     anchor_plan = get_anchor_plan(config)
     if anchor_plan is None:
@@ -3085,15 +3093,7 @@ async def main():
             aggregate_cfg=(
                 suite_cfg.get("aggregate") if suite_cfg.get("enabled") else None
             ),
-            scenario_labels=(
-                [
-                    str(scenario["label"])
-                    for scenario in suite_cfg.get("scenarios", [])
-                    if isinstance(scenario, Mapping) and "label" in scenario
-                ]
-                if suite_cfg.get("enabled")
-                else None
-            ),
+            scenario_labels=_active_suite_scenario_labels(suite_cfg),
         )
     fine_tune_params = (
         [p.strip() for p in (args.fine_tune_params or "").split(",") if p.strip()]

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -2798,20 +2798,17 @@ def preselect_starting_configs(
     *,
     filter_by_limits: bool,
     max_count: int | None,
-    aggregate_cfg_override: Mapping[str, Any] | None = None,
+    aggregate_cfg: Mapping[str, Any] | None,
 ) -> list[dict]:
-    backtest_cfg = config.get("backtest")
-    aggregate_cfg = (
-        backtest_cfg.get("aggregate") if isinstance(backtest_cfg, Mapping) else None
-    )
-    if aggregate_cfg_override is not None:
-        aggregate_cfg = aggregate_cfg_override
     optimize_cfg = config.get("optimize")
     limits = optimize_cfg.get("limits", []) if isinstance(optimize_cfg, Mapping) else []
+    effective_aggregate_cfg = (
+        aggregate_cfg if isinstance(aggregate_cfg, Mapping) else {"default": "mean"}
+    )
     selection = select_starting_config_artifacts(
         starting_configs_path,
         limits=limits,
-        aggregate_cfg=aggregate_cfg if isinstance(aggregate_cfg, Mapping) else None,
+        aggregate_cfg=effective_aggregate_cfg,
         filter_by_limits=filter_by_limits,
         max_count=max_count,
     )
@@ -3056,6 +3053,26 @@ async def main():
                 config, "backtest.suite_enabled", True, verbose=True
             )
     suite_cfg = extract_suite_config(config, suite_override)
+
+    # Handle --scenarios filter (implies --suite y)
+    scenario_filter = getattr(args, "scenarios", None)
+    if scenario_filter:
+        labels = [
+            label.strip() for label in scenario_filter.split(",") if label.strip()
+        ]
+        suite_cfg["scenarios"] = filter_scenarios_by_label(
+            suite_cfg.get("scenarios", []), labels
+        )
+        suite_cfg["enabled"] = True  # --scenarios implies suite mode
+        logging.info("Filtered to %d scenario(s): %s", len(labels), ", ".join(labels))
+
+    # --suite CLI arg overrides config (applied after --scenarios so explicit --suite n wins)
+    if args.suite is not None:
+        recursive_config_update(
+            config, "backtest.suite_enabled", bool(args.suite), verbose=True
+        )
+        suite_cfg["enabled"] = bool(args.suite)
+
     preselected_starting_configs = None
     if args.filter_starting_configs or args.starting_configs_max is not None:
         preselected_starting_configs = preselect_starting_configs(
@@ -3063,7 +3080,9 @@ async def main():
             config,
             filter_by_limits=bool(args.filter_starting_configs),
             max_count=args.starting_configs_max,
-            aggregate_cfg_override=suite_cfg.get("aggregate"),
+            aggregate_cfg=(
+                suite_cfg.get("aggregate") if suite_cfg.get("enabled") else None
+            ),
         )
     fine_tune_params = (
         [p.strip() for p in (args.fine_tune_params or "").split(",") if p.strip()]
@@ -3086,18 +3105,6 @@ async def main():
         )
     else:
         apply_fine_tune_bounds(config, fine_tune_params, cli_bounds_overrides)
-    # Handle --scenarios filter (implies --suite y)
-    scenario_filter = getattr(args, "scenarios", None)
-    if scenario_filter:
-        labels = [label.strip() for label in scenario_filter.split(",") if label.strip()]
-        suite_cfg["scenarios"] = filter_scenarios_by_label(suite_cfg.get("scenarios", []), labels)
-        suite_cfg["enabled"] = True  # --scenarios implies suite mode
-        logging.info("Filtered to %d scenario(s): %s", len(labels), ", ".join(labels))
-
-    # --suite CLI arg overrides config (applied after --scenarios so explicit --suite n wins)
-    if args.suite is not None:
-        recursive_config_update(config, "backtest.suite_enabled", bool(args.suite), verbose=True)
-        suite_cfg["enabled"] = bool(args.suite)
     backtest_exchanges = require_config_value(config, "backtest.exchanges")
     await format_approved_ignored_coins(config, backtest_exchanges)
     interrupted = False

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -26,6 +26,7 @@ from config.scoring import (
     from_engine_value,
     objective_spec_by_metric,
 )
+from limit_utils import resolve_auto_limit_entries
 from metrics_schema import flatten_metric_stats
 from pareto_core import detect_latest_pareto_dir
 
@@ -636,8 +637,13 @@ def _extract_objectives(entry: Mapping[str, Any]) -> Dict[str, float]:
 
 
 def load_candidates(path: str | os.PathLike[str]) -> tuple[Path, List[ParetoCandidate], List[ObjectiveSpec]]:
-    pareto_dir = resolve_pareto_directory(path)
-    json_paths = sorted(pareto_dir.glob("*.json"))
+    raw_path = Path(path).expanduser()
+    if raw_path.is_file():
+        pareto_dir = raw_path.parent.resolve()
+        json_paths = [raw_path.resolve()]
+    else:
+        pareto_dir = resolve_pareto_directory(raw_path)
+        json_paths = sorted(pareto_dir.glob("*.json"))
     if not json_paths:
         raise ValueError(f"No Pareto JSON files found in {pareto_dir}")
 
@@ -951,7 +957,7 @@ def _limit_rejects(entry: Mapping[str, Any], value: float) -> bool:
         return value < float(low) or value > float(high)
     if mode == "inside_range":
         low, high = entry["range"]
-        return float(low) <= value <= float(high)
+        return float(low) < value < float(high)
     raise ValueError(f"Unsupported limit mode {mode!r}")
 
 
@@ -974,8 +980,14 @@ def filter_candidates_with_limits(
     limits: Sequence[Mapping[str, Any]],
     *,
     aggregate_cfg: Mapping[str, Any] | None = None,
+    scoring_weights: Mapping[str, float] | None = None,
 ) -> tuple[List[ParetoCandidate], List[Dict[str, Any]]]:
     normalized_limits = normalize_limit_entries(list(limits))
+    if scoring_weights is not None:
+        normalized_limits = resolve_auto_limit_entries(
+            normalized_limits,
+            dict(scoring_weights),
+        )
     enabled_limits = [entry for entry in normalized_limits if bool(entry.get("enabled", True))]
     if not enabled_limits:
         return list(candidates), enabled_limits

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -21,6 +21,7 @@ from config.metrics import resolve_metric_value
 from config.scoring import (
     ObjectiveSpec,
     default_objective_goal,
+    default_scoring_weights,
     dominates_objectives,
     extract_objective_specs,
     from_engine_value,
@@ -1038,7 +1039,11 @@ def filter_candidates(
         normalized_limits.extend(normalize_limit_entries(limits_payload))
     if limit_entries:
         normalized_limits.extend(parse_limit_cli_entries(list(limit_entries)))
-    return filter_candidates_with_limits(candidates, normalized_limits)
+    return filter_candidates_with_limits(
+        candidates,
+        normalized_limits,
+        scoring_weights=default_scoring_weights(),
+    )
 
 
 def filter_candidates_with_limits(

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -421,12 +421,18 @@ def build_parser() -> argparse.ArgumentParser:
 def _extract_suite_metrics(
     entry: Mapping[str, Any],
     aggregate_cfg: Mapping[str, Any] | None = None,
+    scenario_labels: Sequence[str] | None = None,
 ) -> tuple[Dict[str, float], Dict[str, float]]:
     aggregated_values: Dict[str, float] = {}
     stats_flat: Dict[str, float] = {}
     suite_metrics = entry.get("suite_metrics")
     if not isinstance(suite_metrics, Mapping):
         return stats_flat, aggregated_values
+    selected_labels = (
+        tuple(dict.fromkeys(str(label) for label in scenario_labels))
+        if scenario_labels is not None
+        else None
+    )
     effective_aggregate_cfg = (
         aggregate_cfg
         if aggregate_cfg is not None
@@ -441,7 +447,31 @@ def _extract_suite_metrics(
                 continue
             aggregated = payload.get("aggregated")
             stats = payload.get("stats") or {}
-            if aggregate_cfg is not None:
+            if selected_labels is not None:
+                scenarios = payload.get("scenarios")
+                selected_values: list[float] = []
+                if isinstance(scenarios, Mapping):
+                    for label in selected_labels:
+                        value = scenarios.get(label)
+                        if not isinstance(value, (int, float)) or not math.isfinite(
+                            float(value)
+                        ):
+                            selected_values = []
+                            break
+                        selected_values.append(float(value))
+                if len(selected_values) == len(selected_labels) and selected_values:
+                    values = np.asarray(selected_values, dtype=float)
+                    stats = {
+                        "mean": float(np.mean(values)),
+                        "min": float(np.min(values)),
+                        "max": float(np.max(values)),
+                        "std": float(np.std(values)),
+                        "median": float(np.median(values)),
+                    }
+                else:
+                    stats = {}
+                aggregated = None
+            if aggregate_cfg is not None or selected_labels is not None:
                 aggregated = None
                 if isinstance(stats, Mapping) and stats:
                     mode = resolve_aggregate_mode(str(metric), effective_aggregate_cfg)
@@ -451,8 +481,11 @@ def _extract_suite_metrics(
                 aggregated = stats.get(mode, stats.get("mean"))
             if isinstance(aggregated, (int, float)) and math.isfinite(float(aggregated)):
                 aggregated_values[str(metric)] = float(aggregated)
-            if isinstance(stats, Mapping):
+            if isinstance(stats, Mapping) and stats:
                 stats_flat.update(flatten_metric_stats({str(metric): dict(stats)}))
+        return stats_flat, aggregated_values
+
+    if selected_labels is not None:
         return stats_flat, aggregated_values
 
     aggregate = suite_metrics.get("aggregate") or {}
@@ -875,6 +908,7 @@ def _resolve_limit_value(
     candidate: ParetoCandidate,
     entry: Mapping[str, Any],
     aggregate_cfg: Mapping[str, Any] | None = None,
+    scenario_labels: Sequence[str] | None = None,
 ) -> Optional[float]:
     metric = str(entry.get("metric", "")).strip()
     if not metric:
@@ -901,15 +935,19 @@ def _resolve_limit_value(
     applies_current_suite_aggregate = aggregate_cfg is not None and isinstance(
         candidate.entry.get("suite_metrics"), Mapping
     )
+    applies_current_scenario_set = scenario_labels is not None and isinstance(
+        candidate.entry.get("suite_metrics"), Mapping
+    )
     stats_flat = candidate.stats_flat
     aggregated_values = candidate.aggregated_values
     if explicit_suite_basis or (
-        aggregate_cfg is not None
+        (aggregate_cfg is not None or scenario_labels is not None)
         and isinstance(candidate.entry.get("suite_metrics"), Mapping)
     ):
         stats_flat, aggregated_values = _extract_suite_metrics(
             candidate.entry,
             aggregate_cfg=aggregate_cfg,
+            scenario_labels=scenario_labels,
         )
     if candidate.scenario is not None and "stat" in entry and not explicit_suite_basis:
         requested_stat = str(entry.get("stat", "")).strip().lower()
@@ -931,6 +969,7 @@ def _resolve_limit_value(
         "stat" not in entry
         and not explicit_suite_basis
         and not applies_current_suite_aggregate
+        and not applies_current_scenario_set
     ):
         fallback = _resolve_candidate_metric_value(candidate, metric)
         if isinstance(fallback, (int, float)) and math.isfinite(float(fallback)):
@@ -991,6 +1030,7 @@ def filter_candidates_with_limits(
     limits: Sequence[Mapping[str, Any]],
     *,
     aggregate_cfg: Mapping[str, Any] | None = None,
+    scenario_labels: Sequence[str] | None = None,
     scoring_weights: Mapping[str, float] | None = None,
 ) -> tuple[List[ParetoCandidate], List[Dict[str, Any]]]:
     normalized_limits = normalize_limit_entries(list(limits))
@@ -1002,16 +1042,17 @@ def filter_candidates_with_limits(
     enabled_limits = [entry for entry in normalized_limits if bool(entry.get("enabled", True))]
     if not enabled_limits:
         return list(candidates), enabled_limits
-    if aggregate_cfg is None and candidates:
-        backtest_cfg = candidates[0].entry.get("backtest")
-        if isinstance(backtest_cfg, Mapping):
-            aggregate_cfg = backtest_cfg.get("aggregate")
 
     filtered: List[ParetoCandidate] = []
     for candidate in candidates:
         rejected = False
         for entry in enabled_limits:
-            value = _resolve_limit_value(candidate, entry, aggregate_cfg)
+            value = _resolve_limit_value(
+                candidate,
+                entry,
+                aggregate_cfg,
+                scenario_labels,
+            )
             if value is None:
                 metric = str(entry.get("metric", "")).strip() or "<missing>"
                 available = _format_available_limit_metrics(candidate)

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -441,9 +441,11 @@ def _extract_suite_metrics(
                 continue
             aggregated = payload.get("aggregated")
             stats = payload.get("stats") or {}
-            if aggregate_cfg is not None and isinstance(stats, Mapping) and stats:
-                mode = resolve_aggregate_mode(str(metric), effective_aggregate_cfg)
-                aggregated = stats.get(mode, stats.get("mean"))
+            if aggregate_cfg is not None:
+                aggregated = None
+                if isinstance(stats, Mapping) and stats:
+                    mode = resolve_aggregate_mode(str(metric), effective_aggregate_cfg)
+                    aggregated = stats.get(mode)
             elif aggregated is None and isinstance(stats, Mapping):
                 mode = resolve_aggregate_mode(str(metric), effective_aggregate_cfg)
                 aggregated = stats.get(mode, stats.get("mean"))
@@ -459,14 +461,15 @@ def _extract_suite_metrics(
         if isinstance(stats, Mapping):
             stats_flat.update(flatten_metric_stats(dict(stats)))
         aggregated = aggregate.get("aggregated") or {}
-        if aggregate_cfg is not None and isinstance(stats, Mapping) and stats:
-            for metric, metric_stats in stats.items():
-                if not isinstance(metric_stats, Mapping):
-                    continue
-                mode = resolve_aggregate_mode(str(metric), effective_aggregate_cfg)
-                value = metric_stats.get(mode, metric_stats.get("mean"))
-                if isinstance(value, (int, float)) and math.isfinite(float(value)):
-                    aggregated_values[str(metric)] = float(value)
+        if aggregate_cfg is not None:
+            if isinstance(stats, Mapping) and stats:
+                for metric, metric_stats in stats.items():
+                    if not isinstance(metric_stats, Mapping):
+                        continue
+                    mode = resolve_aggregate_mode(str(metric), effective_aggregate_cfg)
+                    value = metric_stats.get(mode)
+                    if isinstance(value, (int, float)) and math.isfinite(float(value)):
+                        aggregated_values[str(metric)] = float(value)
         elif isinstance(aggregated, Mapping):
             for metric, value in aggregated.items():
                 if isinstance(value, (int, float)) and math.isfinite(float(value)):
@@ -895,10 +898,14 @@ def _resolve_limit_value(
         and "scenario" in entry
         and entry.get("scenario") is None
     )
+    applies_current_suite_aggregate = aggregate_cfg is not None and isinstance(
+        candidate.entry.get("suite_metrics"), Mapping
+    )
     stats_flat = candidate.stats_flat
     aggregated_values = candidate.aggregated_values
     if explicit_suite_basis or (
-        aggregate_cfg is not None and isinstance(candidate.entry.get("suite_metrics"), Mapping)
+        aggregate_cfg is not None
+        and isinstance(candidate.entry.get("suite_metrics"), Mapping)
     ):
         stats_flat, aggregated_values = _extract_suite_metrics(
             candidate.entry,
@@ -920,7 +927,11 @@ def _resolve_limit_value(
     value = resolve_metric_value(stats_flat, key)
     if isinstance(value, (int, float)) and math.isfinite(float(value)):
         return float(value)
-    if "stat" not in entry and not explicit_suite_basis:
+    if (
+        "stat" not in entry
+        and not explicit_suite_basis
+        and not applies_current_suite_aggregate
+    ):
         fallback = _resolve_candidate_metric_value(candidate, metric)
         if isinstance(fallback, (int, float)) and math.isfinite(float(fallback)):
             return float(fallback)

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -440,7 +440,10 @@ def _extract_suite_metrics(
                 continue
             aggregated = payload.get("aggregated")
             stats = payload.get("stats") or {}
-            if aggregated is None and isinstance(stats, Mapping):
+            if aggregate_cfg is not None and isinstance(stats, Mapping) and stats:
+                mode = resolve_aggregate_mode(str(metric), effective_aggregate_cfg)
+                aggregated = stats.get(mode, stats.get("mean"))
+            elif aggregated is None and isinstance(stats, Mapping):
                 mode = resolve_aggregate_mode(str(metric), effective_aggregate_cfg)
                 aggregated = stats.get(mode, stats.get("mean"))
             if isinstance(aggregated, (int, float)) and math.isfinite(float(aggregated)):
@@ -455,7 +458,15 @@ def _extract_suite_metrics(
         if isinstance(stats, Mapping):
             stats_flat.update(flatten_metric_stats(dict(stats)))
         aggregated = aggregate.get("aggregated") or {}
-        if isinstance(aggregated, Mapping):
+        if aggregate_cfg is not None and isinstance(stats, Mapping) and stats:
+            for metric, metric_stats in stats.items():
+                if not isinstance(metric_stats, Mapping):
+                    continue
+                mode = resolve_aggregate_mode(str(metric), effective_aggregate_cfg)
+                value = metric_stats.get(mode, metric_stats.get("mean"))
+                if isinstance(value, (int, float)) and math.isfinite(float(value)):
+                    aggregated_values[str(metric)] = float(value)
+        elif isinstance(aggregated, Mapping):
             for metric, value in aggregated.items():
                 if isinstance(value, (int, float)) and math.isfinite(float(value)):
                     aggregated_values[str(metric)] = float(value)
@@ -880,7 +891,9 @@ def _resolve_limit_value(
     )
     stats_flat = candidate.stats_flat
     aggregated_values = candidate.aggregated_values
-    if explicit_suite_basis:
+    if explicit_suite_basis or (
+        aggregate_cfg is not None and isinstance(candidate.entry.get("suite_metrics"), Mapping)
+    ):
         stats_flat, aggregated_values = _extract_suite_metrics(
             candidate.entry,
             aggregate_cfg=aggregate_cfg,
@@ -953,12 +966,20 @@ def filter_candidates(
         normalized_limits.extend(normalize_limit_entries(limits_payload))
     if limit_entries:
         normalized_limits.extend(parse_limit_cli_entries(list(limit_entries)))
-    normalized_limits = normalize_limit_entries(normalized_limits)
+    return filter_candidates_with_limits(candidates, normalized_limits)
+
+
+def filter_candidates_with_limits(
+    candidates: Sequence[ParetoCandidate],
+    limits: Sequence[Mapping[str, Any]],
+    *,
+    aggregate_cfg: Mapping[str, Any] | None = None,
+) -> tuple[List[ParetoCandidate], List[Dict[str, Any]]]:
+    normalized_limits = normalize_limit_entries(list(limits))
     enabled_limits = [entry for entry in normalized_limits if bool(entry.get("enabled", True))]
     if not enabled_limits:
         return list(candidates), enabled_limits
-    aggregate_cfg = None
-    if candidates:
+    if aggregate_cfg is None and candidates:
         backtest_cfg = candidates[0].entry.get("backtest")
         if isinstance(backtest_cfg, Mapping):
             aggregate_cfg = backtest_cfg.get("aggregate")

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -873,7 +873,19 @@ def _resolve_limit_value(
         if isinstance(value, (int, float)) and math.isfinite(float(value)):
             return float(value)
         return None
-    if candidate.scenario is not None and "stat" in entry:
+    explicit_suite_basis = (
+        candidate.scenario is not None
+        and "scenario" in entry
+        and entry.get("scenario") is None
+    )
+    stats_flat = candidate.stats_flat
+    aggregated_values = candidate.aggregated_values
+    if explicit_suite_basis:
+        stats_flat, aggregated_values = _extract_suite_metrics(
+            candidate.entry,
+            aggregate_cfg=aggregate_cfg,
+        )
+    if candidate.scenario is not None and "stat" in entry and not explicit_suite_basis:
         requested_stat = str(entry.get("stat", "")).strip().lower()
         if requested_stat != "mean":
             raise ValueError(
@@ -882,14 +894,14 @@ def _resolve_limit_value(
             )
     stat = basis.stat
     if "stat" not in entry:
-        value = resolve_metric_value(candidate.aggregated_values, metric)
+        value = resolve_metric_value(aggregated_values, metric)
         if isinstance(value, (int, float)) and math.isfinite(float(value)):
             return float(value)
     key = f"{metric}_{stat}"
-    value = resolve_metric_value(candidate.stats_flat, key)
+    value = resolve_metric_value(stats_flat, key)
     if isinstance(value, (int, float)) and math.isfinite(float(value)):
         return float(value)
-    if "stat" not in entry:
+    if "stat" not in entry and not explicit_suite_basis:
         fallback = _resolve_candidate_metric_value(candidate, metric)
         if isinstance(fallback, (int, float)) and math.isfinite(float(fallback)):
             return float(fallback)

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -15,7 +15,7 @@ from config.limits import (
     normalize_limit_entries,
     parse_limit_cli_entries,
     resolve_aggregate_mode,
-    resolve_limit_stat,
+    resolve_limit_basis,
 )
 from config.metrics import resolve_metric_value
 from config.scoring import (
@@ -859,6 +859,20 @@ def _resolve_limit_value(
     metric = str(entry.get("metric", "")).strip()
     if not metric:
         return None
+    basis = resolve_limit_basis(
+        dict(entry),
+        aggregate_cfg=dict(aggregate_cfg) if aggregate_cfg else None,
+    )
+    if basis.scenario is not None:
+        scenario_values = _scenario_metric_values(
+            candidate.entry,
+            basis.scenario,
+            source=candidate.path,
+        )
+        value = resolve_metric_value(scenario_values, metric)
+        if isinstance(value, (int, float)) and math.isfinite(float(value)):
+            return float(value)
+        return None
     if candidate.scenario is not None and "stat" in entry:
         requested_stat = str(entry.get("stat", "")).strip().lower()
         if requested_stat != "mean":
@@ -866,10 +880,7 @@ def _resolve_limit_value(
                 f"Scenario {candidate.scenario!r} stores one mean value per metric; "
                 f"limit stat={requested_stat!r} is unavailable for {candidate.path.name}."
             )
-    stat = resolve_limit_stat(
-        dict(entry),
-        aggregate_cfg=dict(aggregate_cfg) if aggregate_cfg else None,
-    )
+    stat = basis.stat
     if "stat" not in entry:
         value = resolve_metric_value(candidate.aggregated_values, metric)
         if isinstance(value, (int, float)) and math.isfinite(float(value)):

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -442,6 +442,24 @@ def _extract_suite_metrics(
     )
 
     if "metrics" in suite_metrics:
+        if selected_labels is not None:
+            raw_scenario_labels = suite_metrics.get("scenario_labels")
+            if isinstance(raw_scenario_labels, list):
+                available_scenario_labels = {
+                    str(label) for label in raw_scenario_labels
+                }
+            else:
+                available_scenario_labels = set()
+                for payload in suite_metrics["metrics"].values():
+                    if not isinstance(payload, Mapping):
+                        continue
+                    scenarios = payload.get("scenarios")
+                    if isinstance(scenarios, Mapping):
+                        available_scenario_labels.update(str(label) for label in scenarios)
+            if any(
+                label not in available_scenario_labels for label in selected_labels
+            ):
+                return stats_flat, aggregated_values
         for metric, payload in suite_metrics["metrics"].items():
             if not isinstance(payload, Mapping):
                 continue
@@ -453,13 +471,11 @@ def _extract_suite_metrics(
                 if isinstance(scenarios, Mapping):
                     for label in selected_labels:
                         value = scenarios.get(label)
-                        if not isinstance(value, (int, float)) or not math.isfinite(
+                        if isinstance(value, (int, float)) and math.isfinite(
                             float(value)
                         ):
-                            selected_values = []
-                            break
-                        selected_values.append(float(value))
-                if len(selected_values) == len(selected_labels) and selected_values:
+                            selected_values.append(float(value))
+                if selected_values:
                     values = np.asarray(selected_values, dtype=float)
                     stats = {
                         "mean": float(np.mean(values)),

--- a/src/suite_runner.py
+++ b/src/suite_runner.py
@@ -227,11 +227,14 @@ def filter_scenarios_by_label(
         return scenarios
 
     label_set = {str(label).strip() for label in labels}
-    filtered = [
-        scenario
-        for index, scenario in enumerate(scenarios, 1)
-        if _normalize_scenario_label(scenario.get("label"), index) in label_set
-    ]
+    filtered = []
+    for index, scenario in enumerate(scenarios, 1):
+        normalized_label = _normalize_scenario_label(scenario.get("label"), index)
+        if normalized_label not in label_set:
+            continue
+        normalized_scenario = dict(scenario)
+        normalized_scenario["label"] = normalized_label
+        filtered.append(normalized_scenario)
 
     if not filtered:
         available = [

--- a/src/suite_runner.py
+++ b/src/suite_runner.py
@@ -202,6 +202,11 @@ def load_suite_override_config(suite_config_path: str | Path) -> Dict[str, Any]:
     )
 
 
+def _normalize_scenario_label(raw_label: Any, index: int) -> str:
+    label = str(raw_label).strip() if raw_label else ""
+    return label or f"scenario_{index:02d}"
+
+
 def filter_scenarios_by_label(
     scenarios: List[Dict[str, Any]],
     labels: List[str],
@@ -221,11 +226,18 @@ def filter_scenarios_by_label(
     if not labels:
         return scenarios
 
-    label_set = set(labels)
-    filtered = [s for s in scenarios if s.get("label") in label_set]
+    label_set = {str(label).strip() for label in labels}
+    filtered = [
+        scenario
+        for index, scenario in enumerate(scenarios, 1)
+        if _normalize_scenario_label(scenario.get("label"), index) in label_set
+    ]
 
     if not filtered:
-        available = [s.get("label", f"<unnamed_{i}>") for i, s in enumerate(scenarios)]
+        available = [
+            _normalize_scenario_label(scenario.get("label"), index)
+            for index, scenario in enumerate(scenarios, 1)
+        ]
         raise ValueError(
             f"No scenarios match the requested labels {labels}. " f"Available labels: {available}"
         )
@@ -553,7 +565,7 @@ def build_scenarios(
         )
         scenarios.append(
             SuiteScenario(
-                label=str(raw.get("label") or f"scenario_{idx:02d}"),
+                label=_normalize_scenario_label(raw.get("label"), idx),
                 start_date=raw.get("start_date"),
                 end_date=raw.get("end_date"),
                 coins=scenario_coins,

--- a/src/tools/iterative_backtester.py
+++ b/src/tools/iterative_backtester.py
@@ -293,12 +293,20 @@ def build_limit_checks(
     scoring_index_map: Optional[Dict[str, List[int]]] = None,
 ) -> List[Dict[str, Any]]:
     normalized_limits = normalize_limit_entries(limits)
-    return expand_limit_checks(
+    checks = expand_limit_checks(
         normalized_limits,
         scoring_weights,
         penalty_weight=PENALTY_WEIGHT,
         objective_index_map=scoring_index_map,
     )
+    scenario_checks = [check for check in checks if check.get("scenario") is not None]
+    if scenario_checks:
+        labels = sorted({check["scenario"] for check in scenario_checks})
+        raise ValueError(
+            "Scenario-specific optimize limits require suite optimizer evaluation; "
+            f"iterative-backtester cannot resolve scenario label(s): {', '.join(labels)}"
+        )
+    return checks
 
 
 def resolve_metric_value(

--- a/src/tools/iterative_backtester.py
+++ b/src/tools/iterative_backtester.py
@@ -562,6 +562,12 @@ class IterativeBacktestSession:
         configure_logging(debug=level)
         config.setdefault("logging", {})
         config["logging"]["level"] = level
+        objective_specs = extract_objective_specs(config)
+        build_limit_checks(
+            config.get("optimize", {}).get("limits", []),
+            self.scoring_weights,
+            objective_index_map(objective_specs),
+        )
         # Ensure exchanges have markets loaded and live coin lists expanded
         for ex in require_config_value(config, "backtest.exchanges"):
             await load_markets(ex, verbose=False)

--- a/src/tools/pareto_dash.py
+++ b/src/tools/pareto_dash.py
@@ -341,6 +341,7 @@ LIMIT_PATTERNS = [
     (re.compile(r"^\s*(?P<key>.+?)\s*>=\s*(?P<val>[-+eE0-9.]+)\s*$"), np.greater_equal),
     (re.compile(r"^\s*(?P<key>.+?)\s*<\s*(?P<val>[-+eE0-9.]+)\s*$"), np.less),
     (re.compile(r"^\s*(?P<key>.+?)\s*>\s*(?P<val>[-+eE0-9.]+)\s*$"), np.greater),
+    (re.compile(r"^\s*(?P<key>.+?)\s*!=\s*(?P<val>[-+eE0-9.]+)\s*$"), np.not_equal),
     (re.compile(r"^\s*(?P<key>.+?)\s*==?\s*(?P<val>[-+eE0-9.]+)\s*$"), np.equal),
 ]
 
@@ -445,6 +446,8 @@ def _limits_to_exprs(limits_cfg: Any) -> List[str]:
     except Exception:
         return exprs
     for entry in normalized:
+        if not bool(entry.get("enabled", True)):
+            continue
         metric = entry.get("metric")
         mode = entry.get("penalize_if")
         if not metric or not mode:

--- a/src/tools/pareto_dash.py
+++ b/src/tools/pareto_dash.py
@@ -238,6 +238,7 @@ def load_pareto_dataframe(run_dir: str) -> RunData:
         raw_configs[config_id] = entry
         base = {"_id": config_id}
         suite_values, scenario_values, scenario_labels = _extract_suite_metrics(entry)
+        suite_aggregated_metric_names = _suite_aggregated_metric_names(entry)
         objective_values, objective_labels, objective_cols = _extract_objectives(entry)
         params = _flatten_numeric(entry.get("bot", {}), prefix="bot")
         row = {**base, **suite_values, **params}
@@ -245,7 +246,9 @@ def load_pareto_dataframe(run_dir: str) -> RunData:
         for key in row:
             if key.startswith("bot."):
                 param_cols.add(key)
-            elif key != "_id" and not _looks_like_stat_column(key):
+            elif key != "_id" and not _looks_like_stat_column(
+                key, suite_aggregated_metric_names
+            ):
                 aggregated_cols.add(key)
         for scenario, metric_values in scenario_values.items():
             for metric, value in metric_values.items():
@@ -383,7 +386,36 @@ def _apply_limits(df: pd.DataFrame, exprs: Optional[str]) -> pd.Series:
     return mask
 
 
-def _looks_like_stat_column(name: str) -> bool:
+def _suite_aggregated_metric_names(entry: dict) -> set[str]:
+    suite_metrics = entry.get("suite_metrics")
+    if not isinstance(suite_metrics, dict):
+        return set()
+    metrics = suite_metrics.get("metrics")
+    if isinstance(metrics, dict):
+        return {
+            str(metric)
+            for metric, payload in metrics.items()
+            if isinstance(payload, dict)
+            and _ensure_float(payload.get("aggregated")) is not None
+        }
+    aggregate = suite_metrics.get("aggregate")
+    if not isinstance(aggregate, dict):
+        return set()
+    aggregated = aggregate.get("aggregated")
+    if not isinstance(aggregated, dict):
+        return set()
+    return {
+        str(metric)
+        for metric, value in aggregated.items()
+        if _ensure_float(value) is not None
+    }
+
+
+def _looks_like_stat_column(
+    name: str, aggregated_metric_names: Iterable[str] = ()
+) -> bool:
+    if name in aggregated_metric_names:
+        return False
     lowered = name.lower()
     return lowered.endswith(("_mean", "_min", "_max", "_std", "_median"))
 

--- a/src/tools/pareto_dash.py
+++ b/src/tools/pareto_dash.py
@@ -355,8 +355,45 @@ def _parse_limit_term(term: str):
             value = float(match.group("val"))
         except ValueError:
             return None
-        return match.group("key"), op, value
+        key = match.group("key").strip()
+        if key.startswith('"') and key.endswith('"'):
+            try:
+                decoded = json.loads(key)
+            except (TypeError, ValueError):
+                return None
+            if not isinstance(decoded, str):
+                return None
+            key = decoded
+        return key, op, value
     return None
+
+
+def _split_limit_terms(line: str) -> List[str]:
+    terms: List[str] = []
+    start = 0
+    in_quotes = False
+    escaped = False
+    index = 0
+    while index < len(line):
+        char = line[index]
+        if in_quotes and escaped:
+            escaped = False
+        elif in_quotes and char == "\\":
+            escaped = True
+        elif char == '"':
+            in_quotes = not in_quotes
+        elif not in_quotes and line.startswith("||", index):
+            terms.append(line[start:index])
+            index += 2
+            start = index
+            continue
+        index += 1
+    terms.append(line[start:])
+    return terms
+
+
+def _encode_limit_key(key: str) -> str:
+    return json.dumps(key) if "||" in key or "\n" in key or "\r" in key else key
 
 
 def _extract_limit_metrics(exprs: Iterable[str]) -> List[str]:
@@ -366,7 +403,7 @@ def _extract_limit_metrics(exprs: Iterable[str]) -> List[str]:
     for line in exprs:
         if not line:
             continue
-        for term in str(line).split("||"):
+        for term in _split_limit_terms(str(line)):
             parsed = _parse_limit_term(term.strip())
             if parsed is None:
                 continue
@@ -384,7 +421,7 @@ def _apply_limits(df: pd.DataFrame, exprs: Optional[str]) -> pd.Series:
         line = line.strip()
         if not line:
             continue
-        raw_terms = [term.strip() for term in line.split("||") if term.strip()]
+        raw_terms = [term.strip() for term in _split_limit_terms(line) if term.strip()]
         parsed_terms = [_parse_limit_term(term) for term in raw_terms]
         if (
             not raw_terms
@@ -457,6 +494,7 @@ def _limits_to_exprs(limits_cfg: Any) -> List[str]:
             metric = f"{scenario}__{metric}"
         elif entry.get("stat") is not None:
             metric = f"{metric}_{entry['stat']}"
+        metric = _encode_limit_key(str(metric))
         if mode == "greater_than":
             num = _ensure_float(entry.get("value"))
             if num is not None:

--- a/src/tools/pareto_dash.py
+++ b/src/tools/pareto_dash.py
@@ -340,6 +340,19 @@ LIMIT_PATTERNS = [
 ]
 
 
+def _parse_limit_term(term: str):
+    for pattern, op in LIMIT_PATTERNS:
+        match = pattern.match(term)
+        if not match:
+            continue
+        try:
+            value = float(match.group("val"))
+        except ValueError:
+            return None
+        return match.group("key"), op, value
+    return None
+
+
 def _extract_limit_metrics(exprs: Iterable[str]) -> List[str]:
     metrics: List[str] = []
     if not exprs:
@@ -347,13 +360,13 @@ def _extract_limit_metrics(exprs: Iterable[str]) -> List[str]:
     for line in exprs:
         if not line:
             continue
-        for pattern, _ in LIMIT_PATTERNS:
-            m = pattern.match(line)
-            if m:
-                key = m.group("key")
-                if key not in metrics:
-                    metrics.append(key)
-                break
+        for term in str(line).split("||"):
+            parsed = _parse_limit_term(term.strip())
+            if parsed is None:
+                continue
+            key, _op, _value = parsed
+            if key not in metrics:
+                metrics.append(key)
     return metrics
 
 
@@ -365,24 +378,18 @@ def _apply_limits(df: pd.DataFrame, exprs: Optional[str]) -> pd.Series:
         line = line.strip()
         if not line:
             continue
-        matched = False
-        for pattern, op in LIMIT_PATTERNS:
-            m = pattern.match(line)
-            if not m:
-                continue
-            matched = True
-            key = m.group("key")
-            try:
-                val = float(m.group("val"))
-            except ValueError:
-                continue
-            if key not in df.columns:
-                continue
-            col = df[key]
-            mask &= op(col, val)
-            break
-        if not matched:
+        raw_terms = [term.strip() for term in line.split("||") if term.strip()]
+        parsed_terms = [_parse_limit_term(term) for term in raw_terms]
+        if (
+            not raw_terms
+            or any(parsed is None for parsed in parsed_terms)
+            or any(parsed[0] not in df.columns for parsed in parsed_terms)
+        ):
             continue
+        line_mask = pd.Series(False, index=df.index)
+        for key, op, val in parsed_terms:
+            line_mask |= op(df[key], val)
+        mask &= line_mask
     return mask
 
 
@@ -471,6 +478,13 @@ def _limits_to_exprs(limits_cfg: Any) -> List[str]:
                 if low is not None and high is not None:
                     exprs.append(f"{metric}>={low}")
                     exprs.append(f"{metric}<={high}")
+        elif mode == "inside_range":
+            rng = entry.get("range")
+            if isinstance(rng, (list, tuple)) and len(rng) == 2:
+                low = _ensure_float(rng[0])
+                high = _ensure_float(rng[1])
+                if low is not None and high is not None:
+                    exprs.append(f"{metric}<={low} || {metric}>={high}")
     return exprs
 
 

--- a/src/tools/pareto_dash.py
+++ b/src/tools/pareto_dash.py
@@ -329,11 +329,11 @@ def _select_closest_to_ideal(df: pd.DataFrame, metrics: List[str]) -> Optional[p
 
 
 LIMIT_PATTERNS = [
-    (re.compile(r"^\s*(?P<key>[A-Za-z0-9_.]+)\s*<=\s*(?P<val>[-+eE0-9.]+)\s*$"), np.less_equal),
-    (re.compile(r"^\s*(?P<key>[A-Za-z0-9_.]+)\s*>=\s*(?P<val>[-+eE0-9.]+)\s*$"), np.greater_equal),
-    (re.compile(r"^\s*(?P<key>[A-Za-z0-9_.]+)\s*<\s*(?P<val>[-+eE0-9.]+)\s*$"), np.less),
-    (re.compile(r"^\s*(?P<key>[A-Za-z0-9_.]+)\s*>\s*(?P<val>[-+eE0-9.]+)\s*$"), np.greater),
-    (re.compile(r"^\s*(?P<key>[A-Za-z0-9_.]+)\s*==?\s*(?P<val>[-+eE0-9.]+)\s*$"), np.equal),
+    (re.compile(r"^\s*(?P<key>.+?)\s*<=\s*(?P<val>[-+eE0-9.]+)\s*$"), np.less_equal),
+    (re.compile(r"^\s*(?P<key>.+?)\s*>=\s*(?P<val>[-+eE0-9.]+)\s*$"), np.greater_equal),
+    (re.compile(r"^\s*(?P<key>.+?)\s*<\s*(?P<val>[-+eE0-9.]+)\s*$"), np.less),
+    (re.compile(r"^\s*(?P<key>.+?)\s*>\s*(?P<val>[-+eE0-9.]+)\s*$"), np.greater),
+    (re.compile(r"^\s*(?P<key>.+?)\s*==?\s*(?P<val>[-+eE0-9.]+)\s*$"), np.equal),
 ]
 
 

--- a/src/tools/pareto_dash.py
+++ b/src/tools/pareto_dash.py
@@ -25,7 +25,12 @@ if str(SRC_ROOT) not in sys.path:
 
 from opt_utils import load_results
 from config.limits import normalize_limit_entries
-from config.scoring import extract_objective_specs, from_engine_value
+from config.scoring import (
+    default_scoring_weights,
+    extract_objective_specs,
+    from_engine_value,
+)
+from limit_utils import resolve_auto_limit_entries
 
 
 def discover_runs(root: str) -> List[str]:
@@ -433,7 +438,10 @@ def _limits_to_exprs(limits_cfg: Any) -> List[str]:
         exprs.append(limits_cfg)
         return exprs
     try:
-        normalized = normalize_limit_entries(limits_cfg)
+        normalized = resolve_auto_limit_entries(
+            normalize_limit_entries(limits_cfg),
+            default_scoring_weights(),
+        )
     except Exception:
         return exprs
     for entry in normalized:

--- a/src/tools/pareto_dash.py
+++ b/src/tools/pareto_dash.py
@@ -385,7 +385,7 @@ def _apply_limits(df: pd.DataFrame, exprs: Optional[str]) -> pd.Series:
 
 def _looks_like_stat_column(name: str) -> bool:
     lowered = name.lower()
-    return lowered.endswith(("_mean", "_min", "_max", "_std"))
+    return lowered.endswith(("_mean", "_min", "_max", "_std", "_median"))
 
 
 def _limits_to_exprs(limits_cfg: Any) -> List[str]:
@@ -402,6 +402,11 @@ def _limits_to_exprs(limits_cfg: Any) -> List[str]:
         mode = entry.get("penalize_if")
         if not metric or not mode:
             continue
+        scenario = entry.get("scenario")
+        if scenario is not None:
+            metric = f"{scenario}__{metric}"
+        elif entry.get("stat") is not None:
+            metric = f"{metric}_{entry['stat']}"
         if mode == "greater_than":
             num = _ensure_float(entry.get("value"))
             if num is not None:

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -780,6 +780,23 @@ def test_preselect_starting_configs_uses_effective_aggregate_basis(tmp_path):
     assert len(selected_non_suite) == 1
 
 
+def test_active_suite_scenario_labels_use_canonical_fallbacks():
+    assert optimize._active_suite_scenario_labels(
+        {
+            "enabled": True,
+            "scenarios": [
+                {},
+                {"label": "named"},
+                {"label": ""},
+                {"label": None},
+            ],
+        }
+    ) == ["scenario_01", "named", "scenario_03", "scenario_04"]
+    assert optimize._active_suite_scenario_labels(
+        {"enabled": False, "scenarios": [{}]}
+    ) is None
+
+
 def test_optimize_parser_accepts_short_limit_alias():
     parser = optimize.build_command_parser(
         prog="passivbot optimize",

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -797,6 +797,36 @@ def test_active_suite_scenario_labels_use_canonical_fallbacks():
     ) is None
 
 
+def test_validate_optimizer_limit_suite_mode_rejects_named_scenario_early():
+    config = optimize.get_template_config()
+    config["optimize"]["limits"] = [
+        {
+            "metric": "drawdown_worst_strategy_eq",
+            "penalize_if": "greater_than",
+            "scenario": "base",
+            "value": 0.50,
+        }
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match="scenario-specific optimizer limit.*requires suite mode",
+    ):
+        optimize._validate_optimizer_limit_suite_mode(
+            config,
+            suite_enabled=False,
+        )
+
+    optimize._validate_optimizer_limit_suite_mode(config, suite_enabled=True)
+
+    config["optimize"]["limits"][0]["enabled"] = False
+    optimize._validate_optimizer_limit_suite_mode(config, suite_enabled=False)
+
+    config["optimize"]["limits"][0]["enabled"] = True
+    config["optimize"]["limits"][0]["scenario"] = None
+    optimize._validate_optimizer_limit_suite_mode(config, suite_enabled=False)
+
+
 def test_optimize_parser_accepts_short_limit_alias():
     parser = optimize.build_command_parser(
         prog="passivbot optimize",

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -34,10 +34,12 @@ from optimize import (
     _record_individual_result,
     _register_exchange_data,
     _resolve_cli_limits_override,
+    _validate_starting_config_selection_args,
     _set_candidate_metrics,
     _terminate_optimizer_pool,
     _suite_config_implies_suite_mode,
     _format_objectives,
+    add_starting_config_selection_options,
     ea_mu_plus_lambda_stream,
     individual_to_config,
     config_to_individual,
@@ -53,6 +55,7 @@ from optimize import (
     ConstraintAwareFitness,
     ResultRecorder,
     install_anchored_fine_tune_plan,
+    preselect_starting_configs,
 )
 from multiprocessing_utils import ignore_sigint_in_worker
 from optimization.bounds import Bound
@@ -591,6 +594,117 @@ class TestResolveCliLimitsOverride:
         ]
 
 
+class TestStartingConfigSelectionArgs:
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"filter_starting_configs": True, "starting_configs_max": None},
+            {"filter_starting_configs": False, "starting_configs_max": 60},
+        ],
+    )
+    def test_selection_requires_starting_configs(self, kwargs):
+        parser = argparse.ArgumentParser()
+        args = argparse.Namespace(starting_configs=None, resume=None, **kwargs)
+
+        with pytest.raises(SystemExit):
+            _validate_starting_config_selection_args(parser, args)
+
+    def test_selection_is_incompatible_with_resume(self):
+        parser = argparse.ArgumentParser()
+        args = argparse.Namespace(
+            starting_configs="pareto",
+            resume="optimize_results/run",
+            filter_starting_configs=True,
+            starting_configs_max=None,
+        )
+
+        with pytest.raises(SystemExit):
+            _validate_starting_config_selection_args(parser, args)
+
+    @pytest.mark.parametrize("value", [0, -1])
+    def test_starting_configs_max_must_be_positive(self, value):
+        parser = argparse.ArgumentParser()
+        args = argparse.Namespace(
+            starting_configs="pareto",
+            resume=None,
+            filter_starting_configs=False,
+            starting_configs_max=value,
+        )
+
+        with pytest.raises(SystemExit):
+            _validate_starting_config_selection_args(parser, args)
+
+    def test_valid_selection_arguments_are_accepted(self):
+        parser = argparse.ArgumentParser()
+        args = argparse.Namespace(
+            starting_configs="pareto",
+            resume=None,
+            filter_starting_configs=True,
+            starting_configs_max=60,
+        )
+
+        _validate_starting_config_selection_args(parser, args)
+
+
+def test_preselect_starting_configs_extracts_selected_pareto_configs(tmp_path):
+    config = get_template_config()
+    config["optimize"]["scoring"] = [
+        {"metric": "adg_strategy_eq", "goal": "max"},
+        {"metric": "drawdown_worst_strategy_eq", "goal": "min"},
+    ]
+    config["optimize"]["limits"] = [
+        {
+            "metric": "adg_strategy_eq",
+            "penalize_if": "less_than_or_equal",
+            "value": 0.0015,
+        }
+    ]
+    pareto_dir = tmp_path / "pareto"
+    pareto_dir.mkdir()
+    for idx, adg in enumerate((0.001, 0.002)):
+        artifact = deepcopy(config)
+        artifact["metrics"] = {
+            "objectives": {
+                "adg_strategy_eq": adg,
+                "drawdown_worst_strategy_eq": 0.3 - idx * 0.1,
+            },
+            "stats": {
+                "adg_strategy_eq": {
+                    "mean": adg,
+                    "min": adg,
+                    "max": adg,
+                    "std": 0.0,
+                    "median": adg,
+                },
+                "drawdown_worst_strategy_eq": {
+                    "mean": 0.3 - idx * 0.1,
+                    "min": 0.3 - idx * 0.1,
+                    "max": 0.3 - idx * 0.1,
+                    "std": 0.0,
+                    "median": 0.3 - idx * 0.1,
+                },
+            },
+        }
+        artifact["bot"]["long"]["risk"]["total_wallet_exposure_limit"] = 1.0 + adg
+        (pareto_dir / f"candidate_{idx}.json").write_text(
+            json.dumps(artifact),
+            encoding="utf-8",
+        )
+
+    selected = preselect_starting_configs(
+        str(pareto_dir),
+        config,
+        filter_by_limits=True,
+        max_count=None,
+    )
+
+    assert len(selected) == 1
+    assert selected[0]["_starting_config_source"].endswith("candidate_1.json")
+    assert selected[0]["bot"]["long"]["risk"]["total_wallet_exposure_limit"] == pytest.approx(
+        1.002
+    )
+
+
 def test_optimize_parser_accepts_short_limit_alias():
     parser = optimize.build_command_parser(
         prog="passivbot optimize",
@@ -641,6 +755,20 @@ def test_optimize_parser_accepts_short_limit_alias():
     args = parser.parse_args(["-l", "adg_strategy_pnl_rebased > 0.0"])
 
     assert args.limit_entries == ["adg_strategy_pnl_rebased > 0.0"]
+
+
+@pytest.mark.parametrize(
+    "flag",
+    ["--compress-starting-configs", "--starting-configs-max"],
+)
+def test_optimize_parser_accepts_starting_config_preselection_options(flag):
+    parser = argparse.ArgumentParser()
+    add_starting_config_selection_options(parser)
+
+    args = parser.parse_args(["--filter-starting-configs", flag, "60"])
+
+    assert args.filter_starting_configs is True
+    assert args.starting_configs_max == 60
 
 
 def test_optimize_parser_accepts_nested_bound_flags_alongside_limit_alias():
@@ -759,6 +887,14 @@ def test_optimize_parser_accepts_polish_bounds_mode():
 
     assert args.polish_bounds_pct == 0.2
     assert args.polish_bounds_mode == "override-all"
+
+
+def test_starting_configs_option_is_visible_in_default_help():
+    parser = argparse.ArgumentParser()
+    optimize.add_extra_options(parser, help_all=False)
+
+    assert "-t STARTING_CONFIGS" in parser.format_help()
+    assert "--start STARTING_CONFIGS" in parser.format_help()
 
 
 class TestFormatObjectives:

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -3588,6 +3588,32 @@ class TestEvaluator:
         ):
             SuiteEvaluator(base, [], {"default": "mean"})
 
+    def test_suite_limit_scenario_must_match_context_label(self):
+        from optimize import Evaluator, SuiteEvaluator
+        from config_utils import get_template_config
+
+        mock_config = get_template_config()
+        mock_config["optimize"]["limits"] = [
+            {
+                "metric": "drawdown_worst_strategy_eq",
+                "penalize_if": "greater_than",
+                "scenario": "base",
+                "value": 0.5,
+            }
+        ]
+        base = Evaluator(
+            hlcvs_specs={},
+            btc_usd_specs={},
+            msss={},
+            config=mock_config,
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="optimizer limit.*selects scenario 'base'.*not present",
+        ):
+            SuiteEvaluator(base, [], {"default": "mean"})
+
     def test_suite_scoring_resolves_mixed_scenario_and_aggregate_bases(self):
         from optimize import Evaluator, SuiteEvaluator
         from config_utils import get_template_config

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -696,6 +696,7 @@ def test_preselect_starting_configs_extracts_selected_pareto_configs(tmp_path):
         config,
         filter_by_limits=True,
         max_count=None,
+        aggregate_cfg=config["backtest"]["aggregate"],
     )
 
     assert len(selected) == 1
@@ -705,7 +706,7 @@ def test_preselect_starting_configs_extracts_selected_pareto_configs(tmp_path):
     )
 
 
-def test_preselect_starting_configs_uses_effective_suite_aggregate_override(tmp_path):
+def test_preselect_starting_configs_uses_effective_aggregate_basis(tmp_path):
     config = get_template_config()
     config["backtest"]["aggregate"] = {"default": "max"}
     config["optimize"]["scoring"] = [
@@ -762,11 +763,21 @@ def test_preselect_starting_configs_uses_effective_suite_aggregate_override(tmp_
         config,
         filter_by_limits=True,
         max_count=None,
-        aggregate_cfg_override={"default": "mean"},
+        aggregate_cfg={"default": "mean"},
     )
 
     assert len(selected) == 1
     assert selected[0]["_starting_config_source"].endswith("candidate.json")
+
+    selected_non_suite = preselect_starting_configs(
+        str(artifact_path),
+        config,
+        filter_by_limits=True,
+        max_count=None,
+        aggregate_cfg=None,
+    )
+
+    assert len(selected_non_suite) == 1
 
 
 def test_optimize_parser_accepts_short_limit_alias():

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -827,6 +827,28 @@ def test_validate_optimizer_limit_suite_mode_rejects_named_scenario_early():
     optimize._validate_optimizer_limit_suite_mode(config, suite_enabled=False)
 
 
+def test_validate_optimizer_limit_suite_mode_rejects_unknown_scenario_early():
+    config = optimize.get_template_config()
+    config["optimize"]["limits"] = [
+        {
+            "metric": "drawdown_worst_strategy_eq",
+            "penalize_if": "greater_than",
+            "scenario": "stres",
+            "value": 0.50,
+        }
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match="selects unknown scenario 'stres'.*base, stress",
+    ):
+        optimize._validate_optimizer_limit_suite_mode(
+            config,
+            suite_enabled=True,
+            scenario_labels=["base", "stress"],
+        )
+
+
 def test_optimize_parser_accepts_short_limit_alias():
     parser = optimize.build_command_parser(
         prog="passivbot optimize",

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -705,6 +705,70 @@ def test_preselect_starting_configs_extracts_selected_pareto_configs(tmp_path):
     )
 
 
+def test_preselect_starting_configs_uses_effective_suite_aggregate_override(tmp_path):
+    config = get_template_config()
+    config["backtest"]["aggregate"] = {"default": "max"}
+    config["optimize"]["scoring"] = [
+        {"metric": "adg_strategy_eq", "goal": "max"},
+        {"metric": "drawdown_worst_strategy_eq", "goal": "min"},
+    ]
+    config["optimize"]["limits"] = [
+        {
+            "metric": "drawdown_worst_strategy_eq",
+            "penalize_if": "greater_than",
+            "value": 0.5,
+        }
+    ]
+    artifact = deepcopy(config)
+    artifact["metrics"] = {
+        "objectives": {
+            "adg_strategy_eq": 0.002,
+            "drawdown_worst_strategy_eq": 0.8,
+        },
+        "stats": {
+            "adg_strategy_eq": {
+                "mean": 0.002,
+                "min": 0.002,
+                "max": 0.002,
+                "std": 0.0,
+                "median": 0.002,
+            },
+            "drawdown_worst_strategy_eq": {
+                "mean": 0.2,
+                "min": 0.2,
+                "max": 0.8,
+                "std": 0.3,
+                "median": 0.2,
+            },
+        },
+    }
+    artifact["suite_metrics"] = {
+        "metrics": {
+            "adg_strategy_eq": {
+                "aggregated": 0.002,
+                "stats": artifact["metrics"]["stats"]["adg_strategy_eq"],
+            },
+            "drawdown_worst_strategy_eq": {
+                "aggregated": 0.8,
+                "stats": artifact["metrics"]["stats"]["drawdown_worst_strategy_eq"],
+            },
+        }
+    }
+    artifact_path = tmp_path / "candidate.json"
+    artifact_path.write_text(json.dumps(artifact), encoding="utf-8")
+
+    selected = preselect_starting_configs(
+        str(artifact_path),
+        config,
+        filter_by_limits=True,
+        max_count=None,
+        aggregate_cfg_override={"default": "mean"},
+    )
+
+    assert len(selected) == 1
+    assert selected[0]["_starting_config_source"].endswith("candidate.json")
+
+
 def test_optimize_parser_accepts_short_limit_alias():
     parser = optimize.build_command_parser(
         prog="passivbot optimize",

--- a/tests/optimization/test_starting_config_selection.py
+++ b/tests/optimization/test_starting_config_selection.py
@@ -178,6 +178,28 @@ def test_filtering_resolves_auto_limit_direction_like_optimizer(
     }
 
 
+def test_filtering_rejects_unknown_auto_limit_metric(
+    sample_pareto_dir: Path,
+):
+    with pytest.raises(
+        ValueError,
+        match="unknown optimizer limit metric 'adg_strategy_eqq'",
+    ):
+        select_starting_config_artifacts(
+            str(sample_pareto_dir),
+            limits=[
+                {
+                    "metric": "adg_strategy_eqq",
+                    "penalize_if": "auto",
+                    "value": 0.0015,
+                }
+            ],
+            aggregate_cfg={"default": "mean"},
+            filter_by_limits=True,
+            max_count=None,
+        )
+
+
 def test_inside_range_filter_preserves_boundary_candidates(
     sample_pareto_dir: Path,
 ):

--- a/tests/optimization/test_starting_config_selection.py
+++ b/tests/optimization/test_starting_config_selection.py
@@ -316,6 +316,55 @@ def test_filtering_recomputes_aggregate_from_active_scenarios(tmp_path: Path):
     assert result.selected_count == 1
 
 
+def test_filtering_aggregates_metric_from_available_active_scenarios(
+    tmp_path: Path,
+):
+    pareto_dir = tmp_path / "run" / "pareto"
+    pareto_dir.mkdir(parents=True)
+    _write_candidate(
+        pareto_dir,
+        "suite_candidate",
+        adg=0.002,
+        drawdown_mean=0.20,
+        drawdown_max=0.20,
+    )
+    artifact_path = pareto_dir / "suite_candidate.json"
+    artifact = json.loads(artifact_path.read_text())
+    artifact["suite_metrics"] = {
+        "scenario_labels": ["base", "stress"],
+        "metrics": {
+            "adg_strategy_eq": {
+                "aggregated": 0.002,
+                "stats": _metric_stats(mean=0.002),
+                "scenarios": {"base": 0.002, "stress": 0.002},
+            },
+            "drawdown_worst_strategy_eq": {
+                "aggregated": 0.20,
+                "stats": _metric_stats(mean=0.20),
+                "scenarios": {"base": 0.20},
+            },
+        },
+    }
+    artifact_path.write_text(json.dumps(artifact), encoding="utf-8")
+
+    result = select_starting_config_artifacts(
+        str(pareto_dir),
+        limits=[
+            {
+                "metric": "drawdown_worst_strategy_eq",
+                "penalize_if": "greater_than",
+                "value": 0.50,
+            }
+        ],
+        aggregate_cfg={"default": "max"},
+        scenario_labels=["base", "stress"],
+        filter_by_limits=True,
+        max_count=None,
+    )
+
+    assert result.selected_count == 1
+
+
 def test_filtering_rejects_artifact_missing_active_scenario_values(tmp_path: Path):
     pareto_dir = tmp_path / "run" / "pareto"
     pareto_dir.mkdir(parents=True)

--- a/tests/optimization/test_starting_config_selection.py
+++ b/tests/optimization/test_starting_config_selection.py
@@ -135,6 +135,73 @@ def test_compression_without_filtering_uses_all_metric_bearing_candidates(
     ]
 
 
+def test_metric_preselection_accepts_one_pareto_artifact_and_ignores_siblings(
+    sample_pareto_dir: Path,
+):
+    (sample_pareto_dir / "ordinary_config.json").write_text(
+        json.dumps({"bot": {"long": {}, "short": {}}}),
+        encoding="utf-8",
+    )
+
+    result = select_starting_config_artifacts(
+        str(sample_pareto_dir / "middle.json"),
+        limits=[],
+        aggregate_cfg={"default": "mean"},
+        filter_by_limits=False,
+        max_count=None,
+    )
+
+    assert result.loaded_count == 1
+    assert [candidate.path.name for candidate in result.candidates] == ["middle.json"]
+
+
+def test_filtering_resolves_auto_limit_direction_like_optimizer(
+    sample_pareto_dir: Path,
+):
+    result = select_starting_config_artifacts(
+        str(sample_pareto_dir),
+        limits=[
+            {
+                "metric": "adg_strategy_eq",
+                "penalize_if": "auto",
+                "value": 0.0015,
+            }
+        ],
+        aggregate_cfg={"default": "mean"},
+        filter_by_limits=True,
+        max_count=None,
+    )
+
+    assert result.filtered_count == 3
+    assert "low_drawdown_anchor.json" not in {
+        candidate.path.name for candidate in result.candidates
+    }
+
+
+def test_inside_range_filter_preserves_boundary_candidates(
+    sample_pareto_dir: Path,
+):
+    result = select_starting_config_artifacts(
+        str(sample_pareto_dir),
+        limits=[
+            {
+                "metric": "drawdown_worst_strategy_eq",
+                "penalize_if": "inside_range",
+                "range": [0.10, 0.25],
+            }
+        ],
+        aggregate_cfg={"default": "mean"},
+        filter_by_limits=True,
+        max_count=None,
+    )
+
+    assert {candidate.path.name for candidate in result.candidates} == {
+        "low_drawdown_anchor.json",
+        "middle.json",
+        "adg_anchor.json",
+    }
+
+
 def test_filtering_recomputes_suite_aggregate_with_current_optimizer_default(
     tmp_path: Path,
 ):

--- a/tests/optimization/test_starting_config_selection.py
+++ b/tests/optimization/test_starting_config_selection.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from optimization.starting_config_selection import select_starting_config_artifacts
+
+
+def _metric_stats(*, mean: float, max_value: float | None = None) -> dict:
+    maximum = mean if max_value is None else max_value
+    return {
+        "mean": mean,
+        "min": mean,
+        "max": maximum,
+        "std": 0.0,
+        "median": mean,
+    }
+
+
+def _write_candidate(
+    pareto_dir: Path,
+    name: str,
+    *,
+    adg: float,
+    drawdown_mean: float,
+    drawdown_max: float | None = None,
+) -> None:
+    payload = {
+        "config_version": "v8.0.0",
+        "backtest": {"aggregate": {"default": "max"}},
+        "bot": {"long": {"risk": {"total_wallet_exposure_limit": 1.0 + adg}}},
+        "optimize": {
+            "scoring": [
+                {"metric": "adg_strategy_eq", "goal": "max"},
+                {"metric": "drawdown_worst_strategy_eq", "goal": "min"},
+            ]
+        },
+        "metrics": {
+            "objectives": {
+                "adg_strategy_eq": adg,
+                "drawdown_worst_strategy_eq": drawdown_mean,
+            },
+            "stats": {
+                "adg_strategy_eq": _metric_stats(mean=adg),
+                "drawdown_worst_strategy_eq": _metric_stats(
+                    mean=drawdown_mean,
+                    max_value=drawdown_max,
+                ),
+            },
+        },
+    }
+    (pareto_dir / f"{name}.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+@pytest.fixture()
+def sample_pareto_dir(tmp_path: Path) -> Path:
+    pareto_dir = tmp_path / "run" / "pareto"
+    pareto_dir.mkdir(parents=True)
+    _write_candidate(
+        pareto_dir,
+        "low_drawdown_anchor",
+        adg=0.001,
+        drawdown_mean=0.10,
+        drawdown_max=0.20,
+    )
+    _write_candidate(
+        pareto_dir,
+        "adg_anchor",
+        adg=0.004,
+        drawdown_mean=0.40,
+        drawdown_max=0.80,
+    )
+    _write_candidate(
+        pareto_dir,
+        "middle",
+        adg=0.002,
+        drawdown_mean=0.25,
+        drawdown_max=0.60,
+    )
+    _write_candidate(
+        pareto_dir,
+        "diverse_fill",
+        adg=0.003,
+        drawdown_mean=0.15,
+        drawdown_max=0.30,
+    )
+    return pareto_dir
+
+
+def test_filters_with_effective_aggregate_then_compresses_with_anchors_farthest(
+    sample_pareto_dir: Path,
+):
+    result = select_starting_config_artifacts(
+        str(sample_pareto_dir),
+        limits=[
+            {
+                "metric": "drawdown_worst_strategy_eq",
+                "penalize_if": "greater_than",
+                "value": 0.30,
+            }
+        ],
+        aggregate_cfg={"default": "mean"},
+        filter_by_limits=True,
+        max_count=2,
+    )
+
+    assert result.loaded_count == 4
+    assert result.filtered_count == 3
+    assert result.selected_count == 2
+    assert [candidate.path.name for candidate in result.candidates] == [
+        "diverse_fill.json",
+        "low_drawdown_anchor.json",
+    ]
+
+
+def test_compression_without_filtering_uses_all_metric_bearing_candidates(
+    sample_pareto_dir: Path,
+):
+    result = select_starting_config_artifacts(
+        str(sample_pareto_dir),
+        limits=[],
+        aggregate_cfg={"default": "mean"},
+        filter_by_limits=False,
+        max_count=2,
+    )
+
+    assert result.filtered_count == 4
+    assert result.selected_count == 2
+    assert [candidate.path.name for candidate in result.candidates] == [
+        "diverse_fill.json",
+        "adg_anchor.json",
+    ]
+
+
+def test_filtering_recomputes_suite_aggregate_with_current_optimizer_default(
+    tmp_path: Path,
+):
+    pareto_dir = tmp_path / "run" / "pareto"
+    pareto_dir.mkdir(parents=True)
+    _write_candidate(
+        pareto_dir,
+        "suite_candidate",
+        adg=0.002,
+        drawdown_mean=0.20,
+        drawdown_max=0.80,
+    )
+    artifact_path = pareto_dir / "suite_candidate.json"
+    artifact = json.loads(artifact_path.read_text())
+    artifact["suite_metrics"] = {
+        "metrics": {
+            "adg_strategy_eq": {
+                "aggregated": 0.002,
+                "stats": _metric_stats(mean=0.002),
+            },
+            "drawdown_worst_strategy_eq": {
+                "aggregated": 0.80,
+                "stats": _metric_stats(mean=0.20, max_value=0.80),
+            },
+        }
+    }
+    artifact_path.write_text(json.dumps(artifact), encoding="utf-8")
+
+    result = select_starting_config_artifacts(
+        str(pareto_dir),
+        limits=[
+            {
+                "metric": "drawdown_worst_strategy_eq",
+                "penalize_if": "greater_than",
+                "value": 0.50,
+            }
+        ],
+        aggregate_cfg={"default": "mean"},
+        filter_by_limits=True,
+        max_count=None,
+    )
+
+    assert result.selected_count == 1
+
+
+def test_metric_preselection_warns_that_artifacts_are_not_verified(
+    sample_pareto_dir: Path,
+    caplog,
+):
+    caplog.set_level(logging.WARNING)
+
+    select_starting_config_artifacts(
+        str(sample_pareto_dir),
+        limits=[],
+        aggregate_cfg={"default": "mean"},
+        filter_by_limits=False,
+        max_count=2,
+    )
+
+    assert "trusts stored Pareto metrics and objectives" in caplog.text
+    assert (
+        "coins, exchanges, date range, scenarios, or backtest settings" in caplog.text
+    )
+
+
+def test_metric_preselection_rejects_ordinary_seed_configs(sample_pareto_dir: Path):
+    (sample_pareto_dir / "ordinary_config.json").write_text(
+        json.dumps({"bot": {"long": {}, "short": {}}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="metric-bearing Pareto artifact"):
+        select_starting_config_artifacts(
+            str(sample_pareto_dir),
+            limits=[],
+            aggregate_cfg={"default": "mean"},
+            filter_by_limits=False,
+            max_count=2,
+        )
+
+
+def test_metric_preselection_rejects_directory_with_only_ordinary_configs(
+    tmp_path: Path,
+):
+    seeds_dir = tmp_path / "seeds"
+    seeds_dir.mkdir()
+    (seeds_dir / "ordinary_config.json").write_text(
+        json.dumps({"bot": {"long": {}, "short": {}}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="could not load complete metric-bearing Pareto artifacts"):
+        select_starting_config_artifacts(
+            str(seeds_dir),
+            limits=[],
+            aggregate_cfg={"default": "mean"},
+            filter_by_limits=False,
+            max_count=2,
+        )
+
+
+def test_metric_preselection_allows_pareto_compress_manifest(sample_pareto_dir: Path):
+    (sample_pareto_dir / "selection.json").write_text(
+        json.dumps({"selected_count": 4}),
+        encoding="utf-8",
+    )
+
+    result = select_starting_config_artifacts(
+        str(sample_pareto_dir),
+        limits=[],
+        aggregate_cfg={"default": "mean"},
+        filter_by_limits=False,
+        max_count=2,
+    )
+
+    assert result.loaded_count == 4
+
+
+def test_metric_preselection_fails_when_all_candidates_are_filtered(
+    sample_pareto_dir: Path,
+):
+    with pytest.raises(ValueError, match="No starting configs remained"):
+        select_starting_config_artifacts(
+            str(sample_pareto_dir),
+            limits=[
+                {
+                    "metric": "adg_strategy_eq",
+                    "penalize_if": "less_than_or_equal",
+                    "value": 1.0,
+                }
+            ],
+            aggregate_cfg={"default": "mean"},
+            filter_by_limits=True,
+            max_count=None,
+        )
+
+
+def test_metric_preselection_fails_when_limit_metric_is_missing(
+    sample_pareto_dir: Path,
+):
+    with pytest.raises(
+        ValueError, match="Limit metric 'missing_metric' could not be resolved"
+    ):
+        select_starting_config_artifacts(
+            str(sample_pareto_dir),
+            limits=[
+                {
+                    "metric": "missing_metric",
+                    "penalize_if": "greater_than",
+                    "value": 1.0,
+                }
+            ],
+            aggregate_cfg={"default": "mean"},
+            filter_by_limits=True,
+            max_count=None,
+        )

--- a/tests/optimization/test_starting_config_selection.py
+++ b/tests/optimization/test_starting_config_selection.py
@@ -269,6 +269,102 @@ def test_filtering_recomputes_suite_aggregate_with_current_optimizer_default(
     assert result.selected_count == 1
 
 
+def test_filtering_recomputes_aggregate_from_active_scenarios(tmp_path: Path):
+    pareto_dir = tmp_path / "run" / "pareto"
+    pareto_dir.mkdir(parents=True)
+    _write_candidate(
+        pareto_dir,
+        "suite_candidate",
+        adg=0.002,
+        drawdown_mean=0.50,
+        drawdown_max=0.80,
+    )
+    artifact_path = pareto_dir / "suite_candidate.json"
+    artifact = json.loads(artifact_path.read_text())
+    artifact["suite_metrics"] = {
+        "scenario_labels": ["base", "stress"],
+        "metrics": {
+            "adg_strategy_eq": {
+                "aggregated": 0.002,
+                "stats": _metric_stats(mean=0.002),
+                "scenarios": {"base": 0.002, "stress": 0.002},
+            },
+            "drawdown_worst_strategy_eq": {
+                "aggregated": 0.80,
+                "stats": _metric_stats(mean=0.50, max_value=0.80),
+                "scenarios": {"base": 0.20, "stress": 0.80},
+            },
+        },
+    }
+    artifact_path.write_text(json.dumps(artifact), encoding="utf-8")
+
+    result = select_starting_config_artifacts(
+        str(pareto_dir),
+        limits=[
+            {
+                "metric": "drawdown_worst_strategy_eq",
+                "penalize_if": "greater_than",
+                "value": 0.50,
+            }
+        ],
+        aggregate_cfg={"default": "max"},
+        scenario_labels=["base"],
+        filter_by_limits=True,
+        max_count=None,
+    )
+
+    assert result.selected_count == 1
+
+
+def test_filtering_rejects_artifact_missing_active_scenario_values(tmp_path: Path):
+    pareto_dir = tmp_path / "run" / "pareto"
+    pareto_dir.mkdir(parents=True)
+    _write_candidate(
+        pareto_dir,
+        "suite_candidate",
+        adg=0.002,
+        drawdown_mean=0.20,
+        drawdown_max=0.20,
+    )
+    artifact_path = pareto_dir / "suite_candidate.json"
+    artifact = json.loads(artifact_path.read_text())
+    artifact["suite_metrics"] = {
+        "scenario_labels": ["base"],
+        "metrics": {
+            "adg_strategy_eq": {
+                "aggregated": 0.002,
+                "stats": _metric_stats(mean=0.002),
+                "scenarios": {"base": 0.002},
+            },
+            "drawdown_worst_strategy_eq": {
+                "aggregated": 0.20,
+                "stats": _metric_stats(mean=0.20),
+                "scenarios": {"base": 0.20},
+            },
+        },
+    }
+    artifact_path.write_text(json.dumps(artifact), encoding="utf-8")
+
+    with pytest.raises(
+        ValueError,
+        match="Limit metric 'drawdown_worst_strategy_eq' could not be resolved",
+    ):
+        select_starting_config_artifacts(
+            str(pareto_dir),
+            limits=[
+                {
+                    "metric": "drawdown_worst_strategy_eq",
+                    "penalize_if": "greater_than",
+                    "value": 0.50,
+                }
+            ],
+            aggregate_cfg={"default": "max"},
+            scenario_labels=["stress"],
+            filter_by_limits=True,
+            max_count=None,
+        )
+
+
 def test_filtering_rejects_suite_artifact_missing_effective_aggregate_stat(
     tmp_path: Path,
 ):

--- a/tests/optimization/test_starting_config_selection.py
+++ b/tests/optimization/test_starting_config_selection.py
@@ -247,6 +247,49 @@ def test_filtering_recomputes_suite_aggregate_with_current_optimizer_default(
     assert result.selected_count == 1
 
 
+def test_filtering_rejects_suite_artifact_missing_effective_aggregate_stat(
+    tmp_path: Path,
+):
+    pareto_dir = tmp_path / "run" / "pareto"
+    pareto_dir.mkdir(parents=True)
+    _write_candidate(
+        pareto_dir,
+        "incomplete_suite_candidate",
+        adg=0.002,
+        drawdown_mean=0.20,
+        drawdown_max=0.20,
+    )
+    artifact_path = pareto_dir / "incomplete_suite_candidate.json"
+    artifact = json.loads(artifact_path.read_text())
+    artifact["suite_metrics"] = {
+        "aggregate": {
+            "aggregated": {
+                "adg_strategy_eq": 0.002,
+                "drawdown_worst_strategy_eq": 0.20,
+            }
+        }
+    }
+    artifact_path.write_text(json.dumps(artifact), encoding="utf-8")
+
+    with pytest.raises(
+        ValueError,
+        match="Limit metric 'drawdown_worst_strategy_eq' could not be resolved",
+    ):
+        select_starting_config_artifacts(
+            str(pareto_dir),
+            limits=[
+                {
+                    "metric": "drawdown_worst_strategy_eq",
+                    "penalize_if": "greater_than",
+                    "value": 0.50,
+                }
+            ],
+            aggregate_cfg={"default": "max"},
+            filter_by_limits=True,
+            max_count=None,
+        )
+
+
 def test_metric_preselection_warns_that_artifacts_are_not_verified(
     sample_pareto_dir: Path,
     caplog,

--- a/tests/optimization/test_starting_config_selection.py
+++ b/tests/optimization/test_starting_config_selection.py
@@ -224,6 +224,30 @@ def test_inside_range_filter_preserves_boundary_candidates(
     }
 
 
+def test_filtering_normalizes_descending_range_bounds(
+    sample_pareto_dir: Path,
+):
+    result = select_starting_config_artifacts(
+        str(sample_pareto_dir),
+        limits=[
+            {
+                "metric": "drawdown_worst_strategy_eq",
+                "penalize_if": "outside_range",
+                "range": [0.30, 0.10],
+            }
+        ],
+        aggregate_cfg={"default": "mean"},
+        filter_by_limits=True,
+        max_count=None,
+    )
+
+    assert {candidate.path.name for candidate in result.candidates} == {
+        "low_drawdown_anchor.json",
+        "middle.json",
+        "diverse_fill.json",
+    }
+
+
 def test_filtering_recomputes_suite_aggregate_with_current_optimizer_default(
     tmp_path: Path,
 ):

--- a/tests/test_config_optimize_suite.py
+++ b/tests/test_config_optimize_suite.py
@@ -74,6 +74,30 @@ def test_optimizer_scoring_basis_round_trip_preserves_omitted_named_and_null_sce
     assert formatted["optimize"]["scoring"] == base["optimize"]["scoring"]
 
 
+def test_optimizer_limit_basis_round_trip_preserves_named_and_null_scenarios():
+    base = get_template_config()
+    base["_raw"] = deepcopy(base)
+    base["optimize"]["limits"] = [
+        {
+            "metric": "drawdown_worst_strategy_eq",
+            "penalize_if": "greater_than",
+            "scenario": "base",
+            "value": 0.5,
+        },
+        {
+            "metric": "drawdown_worst_strategy_eq",
+            "penalize_if": "greater_than",
+            "scenario": None,
+            "stat": "max",
+            "value": 0.7,
+        },
+    ]
+
+    formatted = format_config(deepcopy(base), verbose=False)
+
+    assert formatted["optimize"]["limits"] == base["optimize"]["limits"]
+
+
 def test_optimizer_preserves_explicit_hsl_aggregate_config():
     """Optimizer must not inherit template metric-specific aggregate overrides."""
     cfg = load_prepared_config("configs/examples/hsl_npos1.json", verbose=False)

--- a/tests/test_config_utils_helpers.py
+++ b/tests/test_config_utils_helpers.py
@@ -682,6 +682,78 @@ def test_normalize_limit_entries_preserves_optional_fields_on_canonical_entries(
     assert normalized[1]["enabled"] is False
 
 
+def test_normalize_limit_entries_supports_scenario_specific_limits():
+    raw = [
+        {
+            "metric": "drawdown_worst_strategy_eq",
+            "penalize_if": "greater_than",
+            "scenario": " base ",
+            "value": 0.5,
+        },
+        {
+            "metric": "drawdown_worst_strategy_eq",
+            "penalize_if": "greater_than",
+            "scenario": None,
+            "stat": "max",
+            "value": 0.7,
+        },
+    ]
+
+    assert config_utils.normalize_limit_entries(raw) == [
+        {
+            "metric": "drawdown_worst_strategy_eq",
+            "penalize_if": "greater_than",
+            "scenario": "base",
+            "value": 0.5,
+        },
+        {
+            "metric": "drawdown_worst_strategy_eq",
+            "penalize_if": "greater_than",
+            "scenario": None,
+            "stat": "max",
+            "value": 0.7,
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    ("entry", "match"),
+    [
+        (
+            {
+                "metric": "drawdown_worst_strategy_eq",
+                "penalize_if": "greater_than",
+                "scenario": "base",
+                "stat": "max",
+                "value": 0.5,
+            },
+            "cannot set both a named scenario and stat",
+        ),
+        (
+            {
+                "metric": "drawdown_worst_strategy_eq",
+                "penalize_if": "greater_than",
+                "scenario": "",
+                "value": 0.5,
+            },
+            "non-empty scenario label",
+        ),
+        (
+            {
+                "metric": "drawdown_worst_strategy_eq",
+                "penalize_if": "greater_than",
+                "scenario": 123,
+                "value": 0.5,
+            },
+            "scenario label string or null",
+        ),
+    ],
+)
+def test_normalize_limit_entries_rejects_invalid_scenario_basis(entry, match):
+    with pytest.raises(ValueError, match=match):
+        config_utils.normalize_limit_entries([entry])
+
+
 def test_load_config_preserves_canonical_optimize_limits(tmp_path):
     cfg = get_template_config()
     cfg["optimize"]["limits"] = [
@@ -791,6 +863,19 @@ def test_parse_limit_cli_entry_supports_range_and_extras():
         "range": [0.05, 0.7],
         "stat": "mean",
         "enabled": False,
+    }
+
+
+def test_parse_limit_cli_entry_supports_scenario_selector():
+    entry = config_utils.parse_limit_cli_entry(
+        "drawdown_worst_strategy_eq > 0.5 scenario=base"
+    )
+
+    assert entry == {
+        "metric": "drawdown_worst_strategy_eq",
+        "penalize_if": "less_than_or_equal",
+        "value": 0.5,
+        "scenario": "base",
     }
 
 

--- a/tests/test_config_utils_helpers.py
+++ b/tests/test_config_utils_helpers.py
@@ -879,6 +879,14 @@ def test_parse_limit_cli_entry_supports_scenario_selector():
     }
 
 
+def test_parse_limit_cli_entry_preserves_none_scenario_label():
+    entry = config_utils.parse_limit_cli_entry(
+        "drawdown_worst_strategy_eq > 0.5 scenario=none"
+    )
+
+    assert entry["scenario"] == "none"
+
+
 def test_parse_limit_cli_entry_supports_compact_operator_with_multiple_options():
     entry = config_utils.parse_limit_cli_entry(
         "drawdown_worst_strategy_eq<=0.7 scenario=null stat=max"

--- a/tests/test_config_utils_helpers.py
+++ b/tests/test_config_utils_helpers.py
@@ -879,6 +879,20 @@ def test_parse_limit_cli_entry_supports_scenario_selector():
     }
 
 
+def test_parse_limit_cli_entry_supports_compact_operator_with_multiple_options():
+    entry = config_utils.parse_limit_cli_entry(
+        "drawdown_worst_strategy_eq<=0.7 scenario=null stat=max"
+    )
+
+    assert entry == {
+        "metric": "drawdown_worst_strategy_eq",
+        "penalize_if": "greater_than",
+        "value": 0.7,
+        "scenario": None,
+        "stat": "max",
+    }
+
+
 def test_parse_limit_cli_entries_supports_json_object_strings():
     entries = config_utils.parse_limit_cli_entries(
         ['{"metric":"adg","penalize_if":"<","value":0.001,"stat":"mean"}']

--- a/tests/test_data_strategy_verification.py
+++ b/tests/test_data_strategy_verification.py
@@ -918,3 +918,10 @@ class TestScenarioFiltering:
         assert filtered[0]["exchanges"] == ["binance"]
         assert filtered[0]["coins"] == ["BTC", "ETH"]
         assert filtered[0]["overrides"]["bot.long.n_positions"] == 5
+
+    def test_filter_matches_normalized_scenario_label(self):
+        scenarios = [{"label": " stress ", "coins": ["BTC"]}]
+
+        filtered = filter_scenarios_by_label(scenarios, ["stress"])
+
+        assert filtered == scenarios

--- a/tests/test_data_strategy_verification.py
+++ b/tests/test_data_strategy_verification.py
@@ -924,4 +924,13 @@ class TestScenarioFiltering:
 
         filtered = filter_scenarios_by_label(scenarios, ["stress"])
 
-        assert filtered == scenarios
+        assert filtered == [{"label": "stress", "coins": ["BTC"]}]
+
+    def test_filter_preserves_generated_scenario_label(self):
+        scenarios = [{"label": "base"}, {"coins": ["BTC"]}]
+
+        filtered = filter_scenarios_by_label(scenarios, ["scenario_02"])
+        built, _aggregate_cfg = build_scenarios({"scenarios": filtered})
+
+        assert filtered == [{"label": "scenario_02", "coins": ["BTC"]}]
+        assert [scenario.label for scenario in built] == ["scenario_02"]

--- a/tests/test_iterative_backtester.py
+++ b/tests/test_iterative_backtester.py
@@ -265,3 +265,42 @@ def test_session_initialize_infers_combined_mode_from_exchange_count(monkeypatch
 
     assert session.backtest_exchanges == ["binance", "bybit"]
     assert session.combine_ohlcvs is True
+
+
+def test_load_config_rejects_scenario_limits_before_loading_markets(
+    monkeypatch, tmp_path
+):
+    config_path = tmp_path / "cfg.json"
+    config_path.write_text("{}", encoding="utf-8")
+    config = {
+        "backtest": {"exchanges": ["binance"]},
+        "optimize": {
+            "scoring": [{"metric": "adg_strategy_eq", "goal": "max"}],
+            "limits": [
+                {
+                    "metric": "drawdown_worst_strategy_eq",
+                    "penalize_if": "greater_than",
+                    "scenario": "base",
+                    "value": 0.5,
+                }
+            ],
+        },
+    }
+    market_loads = []
+
+    monkeypatch.setattr(ib, "load_prepared_config", lambda *args, **kwargs: config)
+    monkeypatch.setattr(ib, "parse_overrides", lambda loaded, **kwargs: loaded)
+
+    async def fake_load_markets(exchange, **kwargs):
+        market_loads.append(exchange)
+
+    monkeypatch.setattr(ib, "load_markets", fake_load_markets)
+
+    session = ib.IterativeBacktestSession(config_path, None, False)
+    with pytest.raises(
+        ValueError,
+        match="iterative-backtester cannot resolve scenario label\\(s\\): base",
+    ):
+        asyncio.run(session._load_config())
+
+    assert market_loads == []

--- a/tests/test_limit_utils.py
+++ b/tests/test_limit_utils.py
@@ -69,6 +69,28 @@ def test_auto_penalize_if_respects_scoring_weight_sign():
     assert violation == (0.0005 - 0.0001) * 3
 
 
+def test_auto_limit_without_scoring_weight_is_ignored_after_validation():
+    entry = {"metric": "adg", "penalize_if": "auto", "value": 0.0005}
+    assert expand_limit_checks([entry], {}, penalty_weight=1000.0) == []
+
+
+def test_unknown_auto_limit_metric_raises_before_weight_lookup():
+    entry = {"metric": "adgg", "penalize_if": "auto", "value": 0.0005}
+
+    with pytest.raises(ValueError, match="unknown optimizer limit metric 'adgg'"):
+        expand_limit_checks([entry], {}, penalty_weight=1000.0)
+
+
+def test_disabled_unknown_auto_limit_is_skipped():
+    entry = {
+        "metric": "adgg",
+        "penalize_if": "auto",
+        "value": 0.0005,
+        "enabled": False,
+    }
+    assert expand_limit_checks([entry], {}, penalty_weight=1000.0) == []
+
+
 def test_disabled_limit_entry_is_skipped():
     entry = {
         "metric": "drawdown_worst",

--- a/tests/test_limit_utils.py
+++ b/tests/test_limit_utils.py
@@ -148,3 +148,42 @@ def test_explicit_stat_overrides_aggregate_config():
     )
     assert checks[0]["stat"] == "min"
     assert checks[0]["metric_key"] == "adg_min"
+
+
+def test_named_scenario_limit_uses_scenario_mean():
+    entry = {
+        "metric": "drawdown_worst_strategy_eq",
+        "penalize_if": "greater_than",
+        "scenario": "base",
+        "value": 0.5,
+    }
+    checks = expand_limit_checks(
+        [entry],
+        {},
+        penalty_weight=1000.0,
+        aggregate_cfg={"default": "max"},
+    )
+
+    assert checks[0]["scenario"] == "base"
+    assert checks[0]["stat"] == "mean"
+    assert checks[0]["metric_key"] == "drawdown_worst_strategy_eq_mean"
+
+
+def test_explicit_null_scenario_uses_suite_stat():
+    entry = {
+        "metric": "drawdown_worst_strategy_eq",
+        "penalize_if": "greater_than",
+        "scenario": None,
+        "stat": "max",
+        "value": 0.7,
+    }
+    checks = expand_limit_checks(
+        [entry],
+        {},
+        penalty_weight=1000.0,
+        aggregate_cfg={"default": "mean"},
+    )
+
+    assert checks[0]["scenario"] is None
+    assert checks[0]["stat"] == "max"
+    assert checks[0]["metric_key"] == "drawdown_worst_strategy_eq_max"

--- a/tests/test_optimizer_limits_integration.py
+++ b/tests/test_optimizer_limits_integration.py
@@ -237,3 +237,72 @@ def test_limit_can_use_median_stat_emitted_by_metric_schema():
 
     assert pytest.approx(scores[0]) == (5.0 - 4.0) * 1e6
     assert pytest.approx(penalty) == (5.0 - 4.0) * 1e6
+
+
+def test_evaluator_combines_scenario_specific_and_suite_stat_limit_penalties():
+    limits = [
+        {
+            "metric": "drawdown_worst_strategy_eq",
+            "penalize_if": "greater_than",
+            "scenario": "base",
+            "value": 0.5,
+        },
+        {
+            "metric": "drawdown_worst_strategy_eq",
+            "penalize_if": "greater_than",
+            "stat": "max",
+            "value": 0.7,
+        },
+    ]
+    cfg = _make_config(limits, scoring=["adg_strategy_eq"])
+    evaluator = Evaluator({}, {}, {}, cfg)
+    evaluator.build_limit_checks({"default": "mean"})
+
+    scores, penalty = evaluator.calc_fitness(
+        {"adg_strategy_eq_mean": 0.002},
+        limit_metrics={"drawdown_worst_strategy_eq_max": 0.8},
+        scenario_limit_metrics={
+            "base": {"drawdown_worst_strategy_eq_mean": 0.6},
+        },
+    )
+
+    expected_penalty = ((0.6 - 0.5) + (0.8 - 0.7)) * 1e6
+    assert scores == pytest.approx((expected_penalty,))
+    assert penalty == pytest.approx(expected_penalty)
+
+
+def test_scenario_specific_limit_requires_suite_metrics():
+    limits = [
+        {
+            "metric": "drawdown_worst_strategy_eq",
+            "penalize_if": "greater_than",
+            "scenario": "base",
+            "value": 0.5,
+        },
+    ]
+    evaluator = Evaluator({}, {}, {}, _make_config(limits))
+
+    with pytest.raises(ValueError, match="requires suite mode"):
+        evaluator.calc_fitness(
+            {
+                "adg_mean": 0.001,
+                "drawdown_worst_strategy_eq_mean": 0.6,
+            }
+        )
+
+
+def test_iterative_backtester_rejects_scenario_specific_optimize_limits():
+    from tools.iterative_backtester import build_limit_checks
+
+    with pytest.raises(ValueError, match="require suite optimizer evaluation"):
+        build_limit_checks(
+            [
+                {
+                    "metric": "drawdown_worst_strategy_eq",
+                    "penalize_if": "greater_than",
+                    "scenario": "base",
+                    "value": 0.5,
+                }
+            ],
+            {},
+        )

--- a/tests/test_pareto_dash.py
+++ b/tests/test_pareto_dash.py
@@ -76,3 +76,24 @@ def test_load_history_dataframe_emits_iterations(tmp_path):
     assert "objective.w_0" in df.columns
     assert not df.empty
     assert np.isclose(df["adg"].iloc[0], 0.1)
+
+
+def test_default_limit_expressions_target_scenario_columns():
+    expressions = pareto_dash._limits_to_exprs(
+        [
+            {
+                "metric": "adg",
+                "penalize_if": "less_than",
+                "scenario": "base",
+                "value": 0.08,
+            },
+            {
+                "metric": "adg",
+                "penalize_if": "less_than",
+                "stat": "min",
+                "value": 0.05,
+            },
+        ]
+    )
+
+    assert expressions == ["base__adg_usd>=0.08", "adg_usd_min>=0.05"]

--- a/tests/test_pareto_dash.py
+++ b/tests/test_pareto_dash.py
@@ -169,3 +169,27 @@ def test_scenario_inside_range_limit_expression_preserves_outside_values():
         "stress__adg_usd<=0.05 || stress__adg_usd>=0.1"
     ]
     assert mask.tolist() == [True, True, False, True, True]
+
+
+def test_scenario_auto_limit_expressions_use_optimizer_directions():
+    expressions = pareto_dash._limits_to_exprs(
+        [
+            {
+                "metric": "adg",
+                "penalize_if": "auto",
+                "scenario": "base",
+                "value": 0.001,
+            },
+            {
+                "metric": "drawdown_worst_strategy_eq",
+                "penalize_if": "auto",
+                "scenario": "stress",
+                "value": 0.5,
+            },
+        ]
+    )
+
+    assert expressions == [
+        "base__adg_usd>=0.001",
+        "stress__drawdown_worst_strategy_eq<=0.5",
+    ]

--- a/tests/test_pareto_dash.py
+++ b/tests/test_pareto_dash.py
@@ -146,3 +146,26 @@ def test_scenario_limit_expression_supports_punctuation_in_label():
 
     assert expressions == ["bear-market__adg_usd<=0.08"]
     assert mask.tolist() == [True, False]
+
+
+def test_scenario_inside_range_limit_expression_preserves_outside_values():
+    expressions = pareto_dash._limits_to_exprs(
+        [
+            {
+                "metric": "adg",
+                "penalize_if": "inside_range",
+                "scenario": "stress",
+                "range": [0.05, 0.10],
+            }
+        ]
+    )
+    dataframe = pd.DataFrame(
+        {"stress__adg_usd": [0.04, 0.05, 0.075, 0.10, 0.11]}
+    )
+
+    mask = pareto_dash._apply_limits(dataframe, "\n".join(expressions))
+
+    assert expressions == [
+        "stress__adg_usd<=0.05 || stress__adg_usd>=0.1"
+    ]
+    assert mask.tolist() == [True, True, False, True, True]

--- a/tests/test_pareto_dash.py
+++ b/tests/test_pareto_dash.py
@@ -57,6 +57,35 @@ def test_load_pareto_dataframe_handles_suite_and_params(tmp_path):
     assert np.isclose(df["objective.adg_usd"].iloc[0], 1.0)
 
 
+def test_load_pareto_dataframe_keeps_median_named_aggregated_metric(tmp_path):
+    run_dir = tmp_path / "run"
+    pareto_dir = run_dir / "pareto"
+    entry = {
+        "suite_metrics": {
+            "metrics": {
+                "position_held_days_median": {
+                    "aggregated": 2.5,
+                    "stats": {
+                        "mean": 2.5,
+                        "min": 2.0,
+                        "max": 3.0,
+                        "std": 0.5,
+                        "median": 2.5,
+                    },
+                    "scenarios": {"base": 2.0, "stress": 3.0},
+                }
+            },
+            "scenario_labels": ["base", "stress"],
+        }
+    }
+    _write_pareto_entry(pareto_dir / "0001_hash.json", entry)
+
+    run_data = pareto_dash.load_pareto_dataframe(str(run_dir))
+
+    assert "position_held_days_median" in run_data.aggregated_metrics
+    assert "position_held_days_median_mean" not in run_data.aggregated_metrics
+
+
 def test_load_history_dataframe_emits_iterations(tmp_path):
     run_dir = tmp_path / "run"
     pareto_dir = run_dir / "pareto"

--- a/tests/test_pareto_dash.py
+++ b/tests/test_pareto_dash.py
@@ -148,6 +148,25 @@ def test_scenario_limit_expression_supports_punctuation_in_label():
     assert mask.tolist() == [True, False]
 
 
+def test_scenario_limit_expression_quotes_or_separator_in_label():
+    expressions = pareto_dash._limits_to_exprs(
+        [
+            {
+                "metric": "adg",
+                "penalize_if": "greater_than",
+                "scenario": "stress||base",
+                "value": 0.08,
+            }
+        ]
+    )
+    dataframe = pd.DataFrame({"stress||base__adg_usd": [0.07, 0.09]})
+
+    mask = pareto_dash._apply_limits(dataframe, "\n".join(expressions))
+
+    assert expressions == ['"stress||base__adg_usd"<=0.08']
+    assert mask.tolist() == [True, False]
+
+
 def test_scenario_inside_range_limit_expression_preserves_outside_values():
     expressions = pareto_dash._limits_to_exprs(
         [

--- a/tests/test_pareto_dash.py
+++ b/tests/test_pareto_dash.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import msgpack
 import numpy as np
+import pandas as pd
 
 from tools import pareto_dash
 
@@ -97,3 +98,22 @@ def test_default_limit_expressions_target_scenario_columns():
     )
 
     assert expressions == ["base__adg_usd>=0.08", "adg_usd_min>=0.05"]
+
+
+def test_scenario_limit_expression_supports_punctuation_in_label():
+    expressions = pareto_dash._limits_to_exprs(
+        [
+            {
+                "metric": "adg",
+                "penalize_if": "greater_than",
+                "scenario": "bear-market",
+                "value": 0.08,
+            }
+        ]
+    )
+    dataframe = pd.DataFrame({"bear-market__adg_usd": [0.07, 0.09]})
+
+    mask = pareto_dash._apply_limits(dataframe, "\n".join(expressions))
+
+    assert expressions == ["bear-market__adg_usd<=0.08"]
+    assert mask.tolist() == [True, False]

--- a/tests/test_pareto_dash.py
+++ b/tests/test_pareto_dash.py
@@ -193,3 +193,40 @@ def test_scenario_auto_limit_expressions_use_optimizer_directions():
         "base__adg_usd>=0.001",
         "stress__drawdown_worst_strategy_eq<=0.5",
     ]
+
+
+def test_scenario_equal_to_limit_expression_filters_equal_values():
+    expressions = pareto_dash._limits_to_exprs(
+        [
+            {
+                "metric": "drawdown_worst_strategy_eq",
+                "penalize_if": "equal_to",
+                "scenario": "stress",
+                "value": 0.5,
+            }
+        ]
+    )
+    dataframe = pd.DataFrame(
+        {"stress__drawdown_worst_strategy_eq": [0.4, 0.5, 0.6]}
+    )
+
+    mask = pareto_dash._apply_limits(dataframe, "\n".join(expressions))
+
+    assert expressions == ["stress__drawdown_worst_strategy_eq!=0.5"]
+    assert mask.tolist() == [True, False, True]
+
+
+def test_disabled_scenario_limit_is_not_a_dashboard_default():
+    expressions = pareto_dash._limits_to_exprs(
+        [
+            {
+                "enabled": False,
+                "metric": "drawdown_worst_strategy_eq",
+                "penalize_if": "greater_than",
+                "scenario": "stress",
+                "value": 0.5,
+            }
+        ]
+    )
+
+    assert expressions == []

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -528,6 +528,42 @@ def test_limit_entry_can_select_scenario_without_projecting_candidates(
     assert limits[0]["scenario"] == "bull"
 
 
+def test_explicit_null_limit_keeps_suite_aggregate_after_scenario_projection(
+    scenario_pareto_dir: Path,
+):
+    _pareto_dir, candidates, specs = load_candidates(scenario_pareto_dir)
+    projected = project_candidates_to_scenario(candidates, specs, "bull")
+
+    filtered, limits = filter_candidates(
+        projected,
+        limits_payload=None,
+        limit_entries=["metric_a<0.6 scenario=null"],
+    )
+
+    assert [candidate.path.stem for candidate in filtered] == [
+        "a",
+        "b",
+        "c_dominated",
+        "d",
+    ]
+    assert "scenario" in limits[0]
+    assert limits[0]["scenario"] is None
+
+    filtered_max, max_limits = filter_candidates(
+        projected,
+        limits_payload=None,
+        limit_entries=["metric_a<0.6 scenario=null stat=max"],
+    )
+
+    assert [candidate.path.stem for candidate in filtered_max] == [
+        "a",
+        "b",
+        "c_dominated",
+        "d",
+    ]
+    assert max_limits[0]["stat"] == "max"
+
+
 def test_run_from_args_scenario_json_reports_scope_and_uses_scenario_metrics(
     scenario_pareto_dir: Path,
     capsys,

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -528,6 +528,30 @@ def test_limit_entry_can_select_scenario_without_projecting_candidates(
     assert limits[0]["scenario"] == "bull"
 
 
+def test_filter_candidates_resolves_auto_limit_with_optimizer_direction(
+    scenario_pareto_dir: Path,
+):
+    _pareto_dir, candidates, _specs = load_candidates(scenario_pareto_dir)
+
+    filtered, limits = filter_candidates(
+        candidates,
+        limits_payload=json.dumps(
+            [
+                {
+                    "metric": "sharpe_ratio_strategy_eq",
+                    "penalize_if": "auto",
+                    "scenario": "bull",
+                    "value": 1.1,
+                }
+            ]
+        ),
+        limit_entries=None,
+    )
+
+    assert [candidate.path.stem for candidate in filtered] == ["a"]
+    assert limits[0]["penalize_if"] == "less_than"
+
+
 def test_ordinary_filter_uses_stored_legacy_suite_aggregate(tmp_path: Path):
     pareto_dir = tmp_path / "legacy_suite" / "pareto"
     pareto_dir.mkdir(parents=True)

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -513,6 +513,21 @@ def test_scenario_limit_uses_scalar_and_rejects_non_mean_stat(
         )
 
 
+def test_limit_entry_can_select_scenario_without_projecting_candidates(
+    scenario_pareto_dir: Path,
+):
+    _pareto_dir, candidates, _specs = load_candidates(scenario_pareto_dir)
+
+    filtered, limits = filter_candidates(
+        candidates,
+        limits_payload=None,
+        limit_entries=["metric_a>0.75 scenario=bull"],
+    )
+
+    assert [candidate.path.stem for candidate in filtered] == ["a", "b"]
+    assert limits[0]["scenario"] == "bull"
+
+
 def test_run_from_args_scenario_json_reports_scope_and_uses_scenario_metrics(
     scenario_pareto_dir: Path,
     capsys,

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -528,6 +528,38 @@ def test_limit_entry_can_select_scenario_without_projecting_candidates(
     assert limits[0]["scenario"] == "bull"
 
 
+def test_ordinary_filter_uses_stored_legacy_suite_aggregate(tmp_path: Path):
+    pareto_dir = tmp_path / "legacy_suite" / "pareto"
+    pareto_dir.mkdir(parents=True)
+    payload = {
+        "optimize": {
+            "scoring": [
+                {"metric": "metric_a", "goal": "max"},
+                {"metric": "metric_b", "goal": "min"},
+            ]
+        },
+        "backtest": {"aggregate": {"default": "max"}},
+        "suite_metrics": {
+            "aggregate": {
+                "aggregated": {
+                    "metric_a": 0.8,
+                    "metric_b": 0.4,
+                }
+            }
+        },
+    }
+    (pareto_dir / "candidate.json").write_text(json.dumps(payload), encoding="utf-8")
+    _pareto_dir, candidates, _specs = load_candidates(pareto_dir)
+
+    filtered, _limits = filter_candidates(
+        candidates,
+        limits_payload=None,
+        limit_entries=["metric_b<0.5"],
+    )
+
+    assert [candidate.path.name for candidate in filtered] == ["candidate.json"]
+
+
 def test_explicit_null_limit_keeps_suite_aggregate_after_scenario_projection(
     scenario_pareto_dir: Path,
 ):

--- a/tests/test_suite_runner.py
+++ b/tests/test_suite_runner.py
@@ -53,6 +53,14 @@ def test_build_scenarios_basic():
     assert scenarios[0].exchanges == ["binance"]
 
 
+def test_build_scenarios_normalizes_label_whitespace():
+    scenarios, _aggregate_cfg = build_scenarios(
+        {"scenarios": [{"label": " stress "}]}
+    )
+
+    assert scenarios[0].label == "stress"
+
+
 def test_build_scenarios_handles_exchanges_and_coin_sources():
     suite_cfg = {
         "scenarios": [


### PR DESCRIPTION
## Summary

- allow each `optimize.limits` entry to select a named suite `scenario`
- keep omitted or explicit-null scenarios on the existing suite aggregation path, with explicit `stat` or `backtest.aggregate` fallback
- reject named scenario plus `stat`, invalid labels, and scenario-specific limits outside suite-aware evaluation
- reject named-scenario limits before optimizer data preparation when suite mode is disabled or the selected active label is unknown
- normalize configured and requested scenario labels consistently, including surrounding whitespace
- preserve generated labels such as `scenario_02` across `--scenarios` filtering
- preserve duplicate limits for the same metric so base-only and suite-wide thresholds can accumulate independently
- extend repeatable `--limit` parsing with `scenario=...`
- keep Pareto filtering and dashboard columns consistent with scenario and suite-stat limit bases
- apply scenario-specific `inside_range` limits as outside-band default filters in the Pareto dashboard
- resolve scenario-specific `auto` limits with the optimizer's canonical metric-direction map before creating dashboard filters
- skip disabled limits and parse generated not-equal expressions in Pareto dashboard defaults
- resolve optimizer-style `auto` limits in Pareto CLI filtering with the canonical default metric directions
- quote dashboard scenario-limit columns whose labels contain the `||` boolean separator
- reject iterative-backtester scenario-specific limits before loading markets or preparing datasets
- make seed preselection aggregate each metric over the active scenarios that actually emitted it, matching runtime suite aggregation while still rejecting globally missing active scenarios
- document the contract and examples
- preserve explicit `scenario: null` suite aggregation after Pareto scenario projection
- support punctuation in scenario-specific Pareto dashboard limit columns
- reserve only `scenario=null` for aggregate scope so a suite scenario literally named `none` remains selectable
- preserve canonical aggregated metrics ending in `_median` in Pareto dashboard selectors

## Contract

```json
"limits": [
  {
    "metric": "drawdown_worst_strategy_eq",
    "penalize_if": "greater_than",
    "scenario": "base",
    "value": 0.5
  },
  {
    "metric": "drawdown_worst_strategy_eq",
    "penalize_if": "greater_than",
    "stat": "max",
    "value": 0.7
  }
]
```

The first threshold reads only the `base` scenario. The second reads the maximum across suite scenarios. Both violations contribute when both thresholds are exceeded.

## Validation

- affected config/limit/optimizer/Pareto regression suite: 418 passed
- final focused contract slice: 57 passed
- previous review follow-up optimizer/config/Pareto/dashboard matrix: 614 passed
- prior review follow-up affected matrix: 667 passed
- generated-label review follow-up affected matrix: 670 passed
- auto-limit review follow-up affected matrix: 671 passed
- latest dashboard edge-case review follow-up affected matrix: 674 passed
- Pareto CLI auto-limit review follow-up affected matrix: 675 passed
- final scenario-separator and iterative-validation review follow-up matrix: 686 passed
- latest focused dashboard/limit/preselection slice: 62 passed
- confirmed descending range bounds are already normalized canonically before starting-config filtering
- AI documentation and generated registry checks passed (warning-only existing documentation size notices)
- Python compilation, Pareto dashboard CLI help, and `git diff --check` passed
- rebuilt and verified the local Rust extension provenance required by merged `master`; no Rust sources changed in this PR
- real four-evaluation, two-scenario optimizer smoke passed using cached BTC data
- verified the persisted Pareto member retained both same-metric limits and that `constraint_violation` exactly equaled the sum of the base-only and suite-maximum violations
- real one-evaluation optimizer smoke passed with a suite scenario literally named `none`, with both scoring and limit selectors resolving to that label
- real one-evaluation optimizer smoke passed with surrounding whitespace in the configured scenario label, resolving both scoring and limits to the normalized label
- real one-evaluation optimizer smoke passed after filtering an unlabeled scenario by its generated `scenario_02` label, with scoring and limit selectors retaining that label
- non-suite and unknown-suite named-scenario CLI smokes failed immediately with deterministic configuration errors before market/data preparation

No private configs, optimization results, credentials, or local artifacts are included.