### PR TITLE
Add WEEX broker attribution to order IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- WEEX Futures orders now carry Passivbot's registered broker ID in the required
+  `newClientOrderId` prefix while preserving Passivbot order-type markers for
+  reconciliation and fill diagnostics.
 - Retired the diagnostic-only Python planning-availability Cartesian product
   and its routine `planning.symbol_state` event. Snapshot provenance, actual
   planning deferrals, EMA degradation, Rust results, reconciliation, and

--- a/broker_codes.hjson
+++ b/broker_codes.hjson
@@ -22,7 +22,7 @@
 	// Supported exchanges without a broker-code payload in Passivbot.
 	// Keep these explicit so typos in exchange names fail loudly.
 	hyperliquid: null
-	weex: null
+	weex: "WEEX111164"
 	defx: null
 	paradex: null
 	fake: null

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -67,6 +67,16 @@ Handling in Passivbot:
 4. For each broker-agreement exchange, verify the actual signed CCXT/raw request includes the required broker field/header/tag.
 5. Add regression tests at the request-construction boundary when changing exchange sessions, signing, or order payload code.
 
+### WEEX broker client-order IDs
+
+WEEX attributes both Spot and Futures API volume when `newClientOrderId` starts with
+`b-{brokerId}-`. Passivbot's WEEX connector is Futures-only and the V3 Futures order endpoint
+limits this field to 36 characters, so every generated ID uses
+`b-{brokerId}-0xTTTT{random}` within that limit. The `0xTTTT` Passivbot order-type marker must
+remain intact for ownership, reconciliation, and fill-event diagnostics. Reject invalid or
+unattributed IDs before submission; do not rely on CCXT's WEEX `partner` default because CCXT
+ignores it when the caller supplies a client order ID.
+
 ## Exchange Hedge Mode Versus Strategy Hedge Mode
 
 `live.hedge_mode=false` disables simultaneous long and short strategy exposure; it does not put an

--- a/src/exchanges/weex.py
+++ b/src/exchanges/weex.py
@@ -82,6 +82,8 @@ class WeexBot(CCXTBot):
 
     MAX_OPEN_ORDERS = 100
     CLIENT_ORDER_ID_PATTERN = re.compile(r"^[.A-Z:/a-z0-9_-]{1,36}$")
+    BROKER_ID_PATTERN = re.compile(r"^WEEX[0-9]{6}$")
+    PASSIVBOT_TYPE_MARKER_PATTERN = re.compile(r"0x[0-9A-Fa-f]{4}")
 
     def __init__(self, config: dict):
         super().__init__(config)
@@ -90,6 +92,11 @@ class WeexBot(CCXTBot):
         self.hedge_mode = True
 
     def create_ccxt_sessions(self):
+        # WEEX attributes API volume from the client-order-id prefix, not a
+        # session header or CCXT option. Validate at startup so an invalid
+        # registry entry cannot leave an apparently healthy but unattributed
+        # trading session.
+        self._broker_client_order_id_prefix()
         ccxt_config = self._build_ccxt_config()
         user_options = self.user_info.get("options", {})
 
@@ -108,6 +115,27 @@ class WeexBot(CCXTBot):
         else:
             self.ccp = None
             logging.info("weex: WebSocket disabled, using REST polling")
+
+    def _broker_client_order_id_prefix(self) -> str:
+        broker_id = str(self.broker_code or "")
+        if not self.BROKER_ID_PATTERN.fullmatch(broker_id):
+            raise ValueError(
+                "WEEX broker code must match WEEX followed by six digits"
+            )
+        return f"b-{broker_id}-"
+
+    def format_custom_id_single(self, order_type_id: int) -> str:
+        """Build WEEX's broker-prefixed ID while retaining Passivbot diagnostics."""
+        prefix = self._broker_client_order_id_prefix()
+        formatted = super().format_custom_id_single(order_type_id)
+        custom_id = (prefix + formatted)[: self.custom_id_max_length]
+        if not self.CLIENT_ORDER_ID_PATTERN.fullmatch(custom_id):
+            raise ValueError("generated invalid WEEX client order id")
+        if not self.PASSIVBOT_TYPE_MARKER_PATTERN.search(custom_id):
+            raise ValueError(
+                "WEEX client order id has no Passivbot order-type marker"
+            )
+        return custom_id
 
     async def update_exchange_config(self):
         """WEEX has no account-wide position-mode endpoint.
@@ -219,6 +247,14 @@ class WeexBot(CCXTBot):
         if not self.CLIENT_ORDER_ID_PATTERN.fullmatch(client_order_id):
             raise ValueError(
                 "WEEX client order id must match ^[.A-Z:/a-z0-9_-]{1,36}$"
+            )
+        if not client_order_id.startswith(self._broker_client_order_id_prefix()):
+            raise ValueError(
+                "WEEX client order id must start with the configured broker prefix"
+            )
+        if not self.PASSIVBOT_TYPE_MARKER_PATTERN.search(client_order_id):
+            raise ValueError(
+                "WEEX client order id must retain the Passivbot order-type marker"
             )
         params = {
             "positionSide": position_side.upper(),

--- a/tests/exchanges/test_weex.py
+++ b/tests/exchanges/test_weex.py
@@ -12,6 +12,7 @@ from ccxt_contracts import build_contract_bot, get_bot_class
 from exchanges.weex import AsyncWeex, ProWeex, WeexBot
 from fill_events_manager import WeexFetcher, _build_fetcher_for_bot
 from market_snapshot import MarketSnapshotProvider
+from passivbot import custom_id_has_explicit_passivbot_marker, custom_id_to_snake
 
 
 SYMBOL = "BTC/USDT:USDT"
@@ -58,6 +59,8 @@ def _ccxt_exchange() -> ccxt.weex:
 def _bot(*, time_in_force: str = "gtc") -> WeexBot:
     bot = build_contract_bot("weex")
     bot.config["live"]["time_in_force"] = time_in_force
+    bot.broker_code = "WEEX111164"
+    bot.custom_id_max_length = 36
     return bot
 
 
@@ -192,19 +195,20 @@ def test_weex_order_websocket_does_not_hide_malformed_order_event():
 
 def test_weex_order_params_match_v3_hedge_contract():
     bot = _bot(time_in_force="post_only")
+    custom_id = "b-WEEX111164-0x0007abc123"
     params = bot._build_order_params(
         {
             "symbol": SYMBOL,
             "type": "limit",
             "position_side": "long",
             "reduce_only": True,
-            "custom_id": "close_grid_long_01",
+            "custom_id": custom_id,
         }
     )
 
     assert params == {
         "positionSide": "LONG",
-        "clientOrderId": "close_grid_long_01",
+        "clientOrderId": custom_id,
         "timeInForce": "POST_ONLY",
     }
     assert "reduceOnly" not in params
@@ -219,6 +223,9 @@ def test_weex_order_params_match_v3_hedge_contract():
         ("custom_id", ""),
         ("custom_id", "x" * 37),
         ("custom_id", "invalid id"),
+        ("custom_id", "0x0004validbutunattributed"),
+        ("custom_id", "b-WEEX999999-0x0004wrongbroker"),
+        ("custom_id", "b-WEEX111164-without-marker"),
     ],
 )
 def test_weex_order_params_reject_ambiguous_side_or_invalid_client_id(field, value):
@@ -228,7 +235,7 @@ def test_weex_order_params_reject_ambiguous_side_or_invalid_client_id(field, val
         "type": "limit",
         "position_side": "long",
         "reduce_only": False,
-        "custom_id": "entry_grid_long_01",
+        "custom_id": "b-WEEX111164-0x0004abc123",
     }
     order[field] = value
 
@@ -249,13 +256,14 @@ def test_weex_order_params_survive_ccxt_request_construction(
     side: str, position_side: str, reduce_only: bool
 ):
     bot = _bot(time_in_force="post_only")
+    custom_id = f"b-WEEX111164-0x0007{position_side}{int(reduce_only)}"
     params = bot._build_order_params(
         {
             "symbol": SYMBOL,
             "type": "limit",
             "position_side": position_side,
             "reduce_only": reduce_only,
-            "custom_id": f"pb_{position_side}_{int(reduce_only)}",
+            "custom_id": custom_id,
         }
     )
     exchange = _ccxt_exchange()
@@ -269,9 +277,57 @@ def test_weex_order_params_survive_ccxt_request_construction(
     assert request["positionSide"] == position_side.upper()
     assert "positionId" not in request
     assert request["timeInForce"] == "POST_ONLY"
-    assert request["newClientOrderId"] == f"pb_{position_side}_{int(reduce_only)}"
+    assert request["newClientOrderId"] == custom_id
     assert "reduceOnly" not in request
     assert "postOnly" not in request
+
+
+def test_weex_generated_client_id_attributes_broker_and_preserves_diagnostics():
+    bot = _bot()
+
+    first = bot.format_custom_id_single(0x0007)
+    second = bot.format_custom_id_single(0x0007)
+
+    assert first.startswith("b-WEEX111164-0x0007")
+    assert len(first) == 36
+    assert first != second
+    assert bot.CLIENT_ORDER_ID_PATTERN.fullmatch(first)
+    assert custom_id_has_explicit_passivbot_marker(first)
+    assert custom_id_to_snake(first) == "close_grid_long"
+
+
+def test_weex_market_order_keeps_broker_client_id_without_limit_fields():
+    bot = _bot()
+    custom_id = bot.format_custom_id_single(0x0007)
+    params = bot._build_order_params(
+        {
+            "symbol": SYMBOL,
+            "type": "market",
+            "position_side": "long",
+            "reduce_only": True,
+            "custom_id": custom_id,
+        }
+    )
+    request = _ccxt_exchange().create_contract_order_request(
+        SYMBOL, "market", "sell", 0.0001, None, params
+    )
+
+    assert request["newClientOrderId"] == custom_id
+    assert request["positionSide"] == "LONG"
+    assert "timeInForce" not in request
+    assert "price" not in request
+    assert "reduceOnly" not in request
+
+
+@pytest.mark.parametrize(
+    "broker_code", ["", "WEEX11116", "WEEX1111640", "weex111164"]
+)
+def test_weex_rejects_invalid_broker_code_before_session_creation(broker_code):
+    bot = _bot()
+    bot.broker_code = broker_code
+
+    with pytest.raises(ValueError, match="WEEX broker code"):
+        bot.create_ccxt_sessions()
 
 
 @pytest.mark.parametrize(
@@ -307,13 +363,14 @@ def test_weex_open_order_rejects_missing_or_ambiguous_position_side(raw_info):
 def test_weex_signed_order_contains_required_auth_and_no_reduce_only():
     bot = _bot(time_in_force="gtc")
     exchange = _ccxt_exchange()
+    custom_id = "b-WEEX111164-0x0007signed01"
     params = bot._build_order_params(
         {
             "symbol": SYMBOL,
             "type": "limit",
             "position_side": "short",
             "reduce_only": True,
-            "custom_id": "close_grid_short_01",
+            "custom_id": custom_id,
         }
     )
     request = exchange.create_contract_order_request(
@@ -327,6 +384,7 @@ def test_weex_signed_order_contains_required_auth_and_no_reduce_only():
 
     assert body["positionSide"] == "SHORT"
     assert body["timeInForce"] == "GTC"
+    assert body["newClientOrderId"] == custom_id
     assert "reduceOnly" not in body
     assert signed["headers"]["ACCESS-KEY"] == "key"
     assert signed["headers"]["ACCESS-PASSPHRASE"] == "passphrase"
@@ -567,7 +625,10 @@ class _FakeWeexApi:
 
     async def fetch_order(self, order_id, symbol):
         self.order_calls.append((order_id, symbol))
-        return {"clientOrderId": f"entry_grid_long_{order_id}", "info": {}}
+        return {
+            "clientOrderId": f"b-WEEX111164-0x0004{order_id}",
+            "info": {},
+        }
 
 
 def _trade(trade_id: str, order_id: str, timestamp: int, *, position_side="LONG"):
@@ -612,7 +673,11 @@ async def test_weex_fetcher_windows_paginates_normalizes_and_enriches():
     assert all(event["position_side"] == "long" for event in events)
     assert all(event["pnl"] == pytest.approx(1.25) for event in events)
     assert all(event["c_mult"] == 1.0 for event in events)
-    assert all(event["client_order_id"].startswith("entry_grid_long_") for event in events)
+    assert all(
+        event["client_order_id"].startswith("b-WEEX111164-0x0004")
+        for event in events
+    )
+    assert all(event["pb_order_type"] == "entry_grid_normal_long" for event in events)
     assert len(api.order_calls) == 4
     assert all(call["params"]["type"] == "swap" for call in api.trade_calls)
     assert all(

--- a/tests/test_broker_codes.py
+++ b/tests/test_broker_codes.py
@@ -8,6 +8,7 @@ def test_load_broker_code_independent_of_cwd(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
 
     assert load_broker_code("bybit") == "passivbotbybit"
+    assert load_broker_code("weex") == "WEEX111164"
 
 
 def test_load_broker_code_uses_env_override(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- register Passivbot's WEEX broker ID in `broker_codes.hjson`
- generate WEEX Futures `newClientOrderId` values as `b-{brokerId}-0xTTTT{random}` within the V3 endpoint's 36-character limit
- preserve Passivbot order-type decoding for reconciliation and fill diagnostics
- reject missing, malformed, unattributed, or markerless WEEX client IDs before submission
- document the WEEX-specific broker contract and add request/signing, market-order, registry, and fill-enrichment regression coverage

## Why

[WEEX's broker integration documentation](https://www.weex.com/api-doc/broker/intro) requires Spot and Futures `newClientOrderId` values to begin with `b-{brokerId}`. Passivbot's WEEX connector is Futures-only, and the [V3 Futures order endpoint](https://www.weex.com/api-doc/contract/Transaction_API/PlaceOrder) limits the identifier to 36 characters. Pinned CCXT only uses its `partner` fallback when the caller omits a client ID, while Passivbot always supplies one, so attribution must be encoded in Passivbot's generated ID at the real request boundary.

## Validation

- `PYTHONPATH=src .../python -m pytest -q` — full Python suite passed
- focused WEEX, broker registry, CCXT order-contract, reconciliation, retry-policy, CLI, and exchange-normalization suites passed
- `PYTHONPATH=src .../python src/tools/check_ai_docs.py` — passed with pre-existing word-count warnings only
- `PYTHONPATH=src .../python src/tools/generate_live_event_registry.py --check` — current
- rebuilt and fingerprint-verified the Python Rust extension against the current worktree
- bounded authenticated Futures entry/close verification on an isolated inactive symbol: broker-prefixed IDs were echoed by WEEX, both fills appeared in trade history, Passivbot entry/close types decoded correctly, and no test position or open order remained