### PR TITLE
Fix forager candle refresh starvation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Background forager candle refresh now charges its REST budget per attempted
+  symbol/timeframe fetch instead of reserving a whole batch before execution.
+  Wall-time or lock timeouts briefly defer only the affected surface, preventing
+  one slow symbol from consuming the batch budget and starving other candidates.
 - WEEX Futures orders now carry Passivbot's registered broker ID in the required
   `newClientOrderId` prefix while preserving Passivbot order-type markers for
   reconciliation and fill diagnostics.

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -111,7 +111,10 @@
    Refresh budgets count
    symbol/timeframe fetches, health scans are bounded and rotated across cycles, interleave each
    candidate's 1m and native 1h health surfaces,
-   keep discovered-but-unfetched stale surfaces pending, charge tokens only for selected fetches,
+   keep discovered-but-unfetched stale surfaces pending, and charge one token immediately before
+   each actual fetch attempt rather than reserving tokens for a batch which may be cut short by
+   the wall-time cap. A timed-out candidate surface receives a short in-memory retry delay so one
+   blocked symbol cannot monopolize successive refresh cycles,
    and prioritize never-attempted 1m fetches before native 1h backfills. Staleness targets count
    only surfaces handled by this background
    refresher, excluding urgent active symbols. A native 1h range with a fresh tail and only an

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -395,6 +395,7 @@ from pure_funcs import (
 
 ONE_MIN_MS = 60_000
 _FORAGER_TERMINAL_EMPTY_RETRY_MS = 15 * ONE_MIN_MS
+_FORAGER_TRANSIENT_FAILURE_RETRY_MS = ONE_MIN_MS
 _COMPLETED_CANDLE_SYMBOL_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9:/._-]{0,159}")
 bot = None
 
@@ -20288,15 +20289,11 @@ class Passivbot:
             and utc_ms() - refresh_started_ms >= max_refresh_ms
         ):
             return
-        budget = self._forager_refresh_budget(
-            max_calls,
-            max_cycle_budget=min(cycle_cap, len(stale)),
-            initial_tokens=cycle_cap,
-            consume=True,
-        )
-        if budget <= 0:
-            return
-        to_refresh = stale[:budget]
+        # The earlier non-consuming peek bounds this cycle. Consume one token
+        # immediately before each actual REST attempt below. Reserving the
+        # whole selected batch here lets one slow surface exhaust the wall-time
+        # cap while charging unattempted surfaces against the account budget.
+        to_refresh = stale[: min(int(budget), int(cycle_cap), len(stale))]
         if not to_refresh:
             return
         stale_by_surface = {
@@ -20374,6 +20371,14 @@ class Passivbot:
                     refreshed_count=int(refreshed_count),
                     total_count=len(to_refresh),
                 )
+                break
+            attempt_budget = self._forager_refresh_budget(
+                max_calls,
+                max_cycle_budget=1,
+                initial_tokens=cycle_cap,
+                consume=True,
+            )
+            if attempt_budget <= 0:
                 break
             try:
                 period_ms = ONE_MIN_MS if timeframe == "1m" else 60 * ONE_MIN_MS
@@ -20491,6 +20496,12 @@ class Passivbot:
                     )
                     last_progress_ms = now_ms
             except TimeoutError as exc:
+                surface_failure_retry_after[(sym, timeframe)] = int(
+                    utc_ms() + _FORAGER_TRANSIENT_FAILURE_RETRY_MS
+                )
+                self._forager_surface_failure_retry_after_ms = (
+                    surface_failure_retry_after
+                )
                 paused_by_cap = bool(
                     max_refresh_ms > 0
                     and utc_ms() - refresh_started_ms >= max_refresh_ms

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -682,6 +682,10 @@ async def test_forager_refresh_bounds_per_symbol_timeout_and_failure(monkeypatch
     assert caplog.text.count("error_type=RuntimeError") == 1
     assert secret not in caplog.text
     assert "Traceback" not in caplog.text
+    assert (
+        bot._forager_surface_failure_retry_after_ms[("TIMEOUT/USDT:USDT", "1m")]
+        == now_ms + pb_mod._FORAGER_TRANSIENT_FAILURE_RETRY_MS
+    )
 
 
 @pytest.mark.asyncio
@@ -4375,6 +4379,11 @@ async def test_forager_candidate_refresh_yields_after_wall_time_cap(
         def _get_fetch_delay_seconds(self):
             return 0.0
 
+        def _forager_refresh_budget(self, *args, **kwargs):
+            self.budget_calls = getattr(self, "budget_calls", [])
+            self.budget_calls.append(dict(kwargs))
+            return pb_mod.Passivbot._forager_refresh_budget(self, *args, **kwargs)
+
         def bp(self, pside, key, symbol):
             if key == "forager_volume_ema_span_1m":
                 return 10.0
@@ -4383,7 +4392,6 @@ async def test_forager_candidate_refresh_yields_after_wall_time_cap(
             return 0.0
 
         _urgent_active_candle_symbols = pb_mod.Passivbot._urgent_active_candle_symbols
-        _forager_refresh_budget = pb_mod.Passivbot._forager_refresh_budget
         _token_bucket_budget = pb_mod.Passivbot._token_bucket_budget
         _forager_target_staleness_ms = pb_mod.Passivbot._forager_target_staleness_ms
         _candle_staleness_ms = pb_mod.Passivbot._candle_staleness_ms
@@ -4393,6 +4401,11 @@ async def test_forager_candidate_refresh_yields_after_wall_time_cap(
         await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
 
     assert len(bot.cm.calls) == 2
+    assert [
+        call.get("max_cycle_budget")
+        for call in bot.budget_calls
+        if call.get("consume", True)
+    ] == [1, 1]
     assert "forager refresh paused by wall-time cap" in caplog.text
 
 


### PR DESCRIPTION
## Summary

- charge the forager OHLCV token bucket immediately before each actual symbol/timeframe fetch instead of reserving an entire batch
- briefly defer only a surface which times out, allowing other stale candidates to advance
- document the per-attempt budget and retry contract

## Root cause

The refresher consumed tokens for every selected batch item before starting network work. If an early candle request consumed the wall-time cap, later items were never attempted but their REST budget was already charged. A repeatedly blocked surface could therefore reduce throughput and starve unrelated candidates.

## Behavior

The non-consuming budget peek still bounds each cycle. One token is now consumed immediately before each actual REST attempt. A lock or wall-time timeout gives only that surface a one-minute in-memory retry delay; missing data remains unavailable and retryable, and no candles are fabricated.

## Validation

- `PYTHONPATH=/private/tmp/passivbot-4-live-candle-readiness/src /Users/eiriknarjord/repos/passivbot-4/venv/bin/python -m pytest -q tests/test_live_candle_budget.py` (79 passed)
- `git diff --check`

Ready for review.