### PR TITLE
Reduce sparse order websocket refresh churn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Bitget UTA private order updates now use the native `holdSide` field for
+  hedge position attribution. Hyperliquid briefly retries a sparse order-open
+  event when a concurrent local create is still awaiting its exchange ID, then
+  accepts it only through the existing exact acknowledged-ID contract. These
+  fixes avoid unnecessary authoritative REST refreshes without weakening
+  foreign or ambiguous order handling.
 - WEEX Futures orders now carry Passivbot's registered broker ID in the required
   `newClientOrderId` prefix while preserving Passivbot order-type markers for
   reconciliation and fill diagnostics.

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -43,6 +43,14 @@ even beyond the normal foreign-writer lookback. Recovered rows always force an
 authoritative account refresh. Sparse foreign, explicitly one-way,
 identity-conflicting, or unmarked notifications remain rejected.
 
+Bitget UTA websocket rows use the exchange-native `holdSide` field for hedge
+position attribution, while classic rows use `posSide`. Hyperliquid may deliver
+an order-open websocket row before the concurrent create request returns its
+exchange order ID. While a create is still freshly submitted, the connector may
+briefly yield for that acknowledgement and retry the row, but recovery still
+requires the exact acknowledged exchange ID and all existing contradiction
+checks. Price, quantity, side, or order shape alone never prove ownership.
+
 A successful private-websocket read and a valid individual order row are separate health
 boundaries. When a supported CCXT connector receives a row whose mandatory side, position-side,
 quantity, or close-only semantics cannot be normalized, it discards that row, requests an

--- a/src/exchanges/bitget.py
+++ b/src/exchanges/bitget.py
@@ -104,13 +104,18 @@ class BitgetBot(CCXTBot):
         """Bitget provides posSide in info."""
         if not bool(getattr(self, "hedge_mode", True)):
             return self._normalize_one_way_position_side(order)
-        position_side = str(
-            order.get("position_side")
-            or order.get("info", {}).get("posSide")
-            or ""
-        ).lower()
-        if position_side in {"long", "short"}:
-            return position_side
+        info = order.get("info") or {}
+        supplied = {
+            str(value).lower()
+            for value in (
+                order.get("position_side"),
+                info.get("posSide"),
+                info.get("holdSide"),
+            )
+            if value not in (None, "")
+        }
+        if len(supplied) == 1 and next(iter(supplied)) in {"long", "short"}:
+            return next(iter(supplied))
         raise ValueError("bitget order missing authoritative position-side semantics")
 
     def _canonical_open_order_reduce_only(self, order: dict) -> bool | None:

--- a/src/exchanges/bitget.py
+++ b/src/exchanges/bitget.py
@@ -173,6 +173,8 @@ class BitgetBot(CCXTBot):
         order["side"] = self._determine_side(order)
         order["position_side"] = self._get_position_side_for_order(order)
         order["qty"] = order["amount"]
+        if self._ws_order_update_has_fill_progress(order):
+            order["_pb_order_update_requires_authoritative_refresh"] = True
         return order
 
     def _determine_side(self, order: dict) -> str:

--- a/src/exchanges/ccxt_bot.py
+++ b/src/exchanges/ccxt_bot.py
@@ -144,6 +144,31 @@ class CCXTBot(Passivbot):
         order["qty"] = order["amount"]
         return order
 
+    @staticmethod
+    def _ws_order_update_has_fill_progress(order: dict) -> bool:
+        """Return whether an order update proves that some quantity filled."""
+
+        def _number(key: str) -> float | None:
+            for source in (order, order.get("info", {})):
+                if not isinstance(source, dict) or source.get(key) in (None, ""):
+                    continue
+                try:
+                    value = float(source[key])
+                except (TypeError, ValueError, OverflowError):
+                    return None
+                return value if math.isfinite(value) and value >= 0.0 else None
+            return None
+
+        filled = _number("filled")
+        if filled is not None and filled > 0.0:
+            return True
+        amount = _number("amount")
+        remaining = _number("remaining")
+        if amount is None or remaining is None:
+            return False
+        tolerance = max(1e-12, amount * 1e-12)
+        return remaining < amount - tolerance
+
     def _sparse_ws_order_has_emitted_identity(self, order: dict) -> bool:
         """Return whether a sparse WS row identifies an order emitted by this process.
 

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -40,6 +40,8 @@ class HyperliquidBot(CCXTBot):
     # Full HIP-3 dex sweeps are safety sweeps. Startup and unknown-dex WS events still force
     # immediate full coverage, but steady-state refreshes should prefer active dexes.
     HIP3_FULL_DEX_SWEEP_INTERVAL_MS = 30 * 60_000
+    ORDER_WS_CREATE_ACK_GRACE_SECONDS = 1.0
+    ORDER_WS_SUBMITTED_LOOKBACK_MS = 5_000
 
     def __init__(self, config: dict):
         super().__init__(config)
@@ -604,6 +606,36 @@ class HyperliquidBot(CCXTBot):
                         untrusted.append((order, exc))
                         continue
                     normalized.append(order)
+                if untrusted and self._hl_recent_create_ack_pending():
+                    # Hyperliquid may publish the private WS open event before
+                    # the concurrent create request returns its exchange ID.
+                    # Yield briefly, then require the same exact acknowledged
+                    # ID contract as every other sparse update. Shape alone is
+                    # never used to attribute ownership or trading semantics.
+                    await asyncio.sleep(self.ORDER_WS_CREATE_ACK_GRACE_SECONDS)
+                    still_untrusted = []
+                    for order, exc in untrusted:
+                        recovered = self._hl_acknowledged_ws_order_semantics(order)
+                        if recovered is None:
+                            still_untrusted.append((order, exc))
+                            continue
+                        position_side, reduce_only = recovered
+                        order["position_side"] = position_side
+                        order["reduceOnly"] = reduce_only
+                        order["_pb_order_semantics_source"] = (
+                            "acknowledged_exchange_order_id"
+                        )
+                        if self._hl_ws_order_has_fill_progress(order):
+                            order[
+                                "_pb_order_update_requires_authoritative_refresh"
+                            ] = True
+                        try:
+                            order["qty"] = order["amount"]
+                        except (KeyError, TypeError, ValueError) as retry_exc:
+                            still_untrusted.append((order, retry_exc))
+                            continue
+                        normalized.append(order)
+                    untrusted = still_untrusted
                 if untrusted:
                     symbols = {
                         str(order.get("symbol") or "")
@@ -660,6 +692,22 @@ class HyperliquidBot(CCXTBot):
                 )
                 await asyncio.sleep(1)
                 logging.debug("[ws] %s: reconnecting...", self.exchange)
+
+    def _hl_recent_create_ack_pending(self) -> bool:
+        """Return whether a just-submitted create may still acquire its exchange ID."""
+        now_ms = (
+            int(self.get_exchange_time())
+            if callable(getattr(self, "get_exchange_time", None))
+            else utc_ms()
+        )
+        return any(
+            str(record.get("status") or "") == "submitted"
+            and 0
+            <= now_ms - int(record.get("timestamp", 0) or 0)
+            <= self.ORDER_WS_SUBMITTED_LOOKBACK_MS
+            for record in self._emitted_order_records()
+            if isinstance(record, dict)
+        )
 
     def _hl_acknowledged_ws_order_semantics(
         self, order: dict

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -895,30 +895,9 @@ class HyperliquidBot(CCXTBot):
                     return None
         return position_side, reduce_only
 
-    @staticmethod
-    def _hl_ws_order_has_fill_progress(order: dict) -> bool:
-        """Whether an open WS row proves that an acknowledged order has filled."""
-
-        def _number(key: str) -> float | None:
-            for source in (order, order.get("info", {})):
-                if not isinstance(source, dict) or source.get(key) in (None, ""):
-                    continue
-                try:
-                    value = float(source[key])
-                except (TypeError, ValueError, OverflowError):
-                    return None
-                return value if math.isfinite(value) and value >= 0.0 else None
-            return None
-
-        filled = _number("filled")
-        if filled is not None and filled > 0.0:
-            return True
-        amount = _number("amount")
-        remaining = _number("remaining")
-        if amount is None or remaining is None:
-            return False
-        tolerance = max(1e-12, amount * 1e-12)
-        return remaining < amount - tolerance
+    def _hl_ws_order_has_fill_progress(self, order: dict) -> bool:
+        """Compatibility wrapper for the shared CCXT fill-progress contract."""
+        return self._ws_order_update_has_fill_progress(order)
 
     def determine_pos_side(self, order):
         # Hyperliquid is one-way, but current position state must never label a
@@ -1574,8 +1553,19 @@ class HyperliquidBot(CCXTBot):
             # Could not recover - re-raise to trigger restart_bot_on_too_many_errors
             raise
 
+    async def _execute_order_and_record_ack(self, order: dict) -> dict:
+        """Publish each create acknowledgement before sibling batch tasks finish."""
+        executed = await self.execute_order(order)
+        if self.did_create_order(executed):
+            acknowledged = dict(executed)
+            for key, value in order.items():
+                if acknowledged.get(key) is None:
+                    acknowledged[key] = value
+            self._record_emitted_order_custom_id(acknowledged)
+        return executed
+
     async def execute_orders(self, orders: [dict]) -> [dict]:
-        return await self.execute_multiple(orders, "execute_order")
+        return await self.execute_multiple(orders, "_execute_order_and_record_ack")
 
     def did_create_order(self, executed) -> bool:
         did_create = super().did_create_order(executed)

--- a/tests/test_hyperliquid_balance_cache.py
+++ b/tests/test_hyperliquid_balance_cache.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib
 import logging as pylogging
 import sys
@@ -293,6 +294,73 @@ async def test_hyperliquid_ws_open_race_waits_for_exact_create_ack(
         "lacked authoritative order semantics" in rec.message
         for rec in caplog.records
     )
+
+
+@pytest.mark.asyncio
+async def test_hyperliquid_create_records_fast_ack_before_slow_sibling_finishes(
+    stubbed_modules,
+):
+    HyperliquidBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    bot = HyperliquidBot.__new__(HyperliquidBot)
+    slow_release = asyncio.Event()
+    fast_finished = asyncio.Event()
+    recorded = []
+
+    async def execute_order(order):
+        if order["symbol"] == "SLOW/USDC:USDC":
+            await slow_release.wait()
+        else:
+            fast_finished.set()
+        return {
+            "id": order["exchange_id"],
+            "status": "open",
+            "info": {"resting": {}},
+        }
+
+    async def handle_failures(_failures):
+        return None
+
+    bot.execute_order = execute_order
+    bot._handle_order_write_failures = handle_failures
+    bot._record_emitted_order_custom_id = lambda order, **_kwargs: recorded.append(
+        dict(order)
+    )
+    orders = [
+        {
+            "symbol": "SLOW/USDC:USDC",
+            "exchange_id": "1",
+            "side": "buy",
+            "position_side": "long",
+            "reduce_only": False,
+        },
+        {
+            "symbol": "FAST/USDC:USDC",
+            "exchange_id": "2",
+            "side": "buy",
+            "position_side": "long",
+            "reduce_only": False,
+        },
+    ]
+
+    batch = asyncio.create_task(bot.execute_orders(orders))
+    await fast_finished.wait()
+    await asyncio.sleep(0)
+
+    assert not batch.done()
+    assert recorded == [
+        {
+            "id": "2",
+            "status": "open",
+            "info": {"resting": {}},
+            **orders[1],
+        }
+    ]
+
+    slow_release.set()
+    results = await batch
+
+    assert [result["id"] for result in results] == ["1", "2"]
+    assert [order["id"] for order in recorded] == ["2", "1"]
 
 
 def test_hyperliquid_ws_order_rejects_ambiguous_acknowledged_id(stubbed_modules):

--- a/tests/test_hyperliquid_balance_cache.py
+++ b/tests/test_hyperliquid_balance_cache.py
@@ -227,6 +227,74 @@ async def test_hyperliquid_ws_order_recovers_semantics_from_exact_acknowledged_i
     )
 
 
+@pytest.mark.asyncio
+async def test_hyperliquid_ws_open_race_waits_for_exact_create_ack(
+    stubbed_modules, monkeypatch, caplog
+):
+    hyperliquid_module = importlib.import_module("exchanges.hyperliquid")
+    HyperliquidBot = hyperliquid_module.HyperliquidBot
+    caplog.set_level(pylogging.WARNING)
+    bot = HyperliquidBot.__new__(HyperliquidBot)
+    bot.stop_websocket = False
+    bot._health_ws_reconnects = 0
+    bot._health_rate_limits = 0
+    bot._log_symbols = lambda symbols, limit=8: ",".join(symbols[:limit])
+    bot._hl_note_ws_symbols_for_dex_scope = lambda _orders: None
+    bot.get_exchange_time = lambda: 1_000
+    submitted = {
+        "timestamp": 900,
+        "exchange_id": "",
+        "side": "buy",
+        "position_side": "long",
+        "reduce_only": False,
+        "pb_type": "entry_initial_normal_long",
+        "status": "submitted",
+    }
+    bot.orders_emitted_to_exchange = [submitted]
+    handled = []
+    dirty = []
+    bot.handle_order_update = lambda orders: handled.append(orders)
+    bot._mark_account_critical_state_dirty = lambda **kwargs: dirty.append(kwargs)
+    delays = []
+
+    async def acknowledge_during_grace(delay):
+        delays.append(delay)
+        submitted["exchange_id"] = "123"
+        submitted["status"] = "acknowledged"
+
+    monkeypatch.setattr(hyperliquid_module.asyncio, "sleep", acknowledge_during_grace)
+
+    async def watch_orders():
+        bot.stop_websocket = True
+        return [
+            {
+                "id": "123",
+                "symbol": "BTC/USDC:USDC",
+                "status": "open",
+                "side": "buy",
+                "amount": 0.01,
+                "info": {"oid": 123, "side": "B", "sz": "0.01"},
+            }
+        ]
+
+    bot.ccp = types.SimpleNamespace(watch_orders=watch_orders)
+
+    await bot.watch_orders()
+
+    assert delays == [bot.ORDER_WS_CREATE_ACK_GRACE_SECONDS]
+    assert dirty == []
+    assert len(handled) == 1
+    assert handled[0][0]["position_side"] == "long"
+    assert (
+        handled[0][0]["_pb_order_semantics_source"]
+        == "acknowledged_exchange_order_id"
+    )
+    assert not any(
+        "lacked authoritative order semantics" in rec.message
+        for rec in caplog.records
+    )
+
+
 def test_hyperliquid_ws_order_rejects_ambiguous_acknowledged_id(stubbed_modules):
     HyperliquidBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
     bot = HyperliquidBot.__new__(HyperliquidBot)
@@ -241,6 +309,29 @@ def test_hyperliquid_ws_order_rejects_ambiguous_acknowledged_id(stubbed_modules)
             "status": "acknowledged",
         }
         for timestamp in (1, 2)
+    ]
+
+    assert (
+        bot._hl_acknowledged_ws_order_semantics(
+            {"id": "123", "side": "buy", "amount": 0.01}
+        )
+        is None
+    )
+
+
+def test_hyperliquid_ws_order_rejects_unacknowledged_submitted_id(stubbed_modules):
+    HyperliquidBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    bot = HyperliquidBot.__new__(HyperliquidBot)
+    bot.orders_emitted_to_exchange = [
+        {
+            "timestamp": 1,
+            "exchange_id": "123",
+            "side": "buy",
+            "position_side": "long",
+            "reduce_only": False,
+            "pb_type": "entry_initial_normal_long",
+            "status": "submitted",
+        }
     ]
 
     assert (

--- a/tests/test_order_reconciliation_contract.py
+++ b/tests/test_order_reconciliation_contract.py
@@ -109,6 +109,52 @@ def test_bitget_uta_websocket_order_uses_native_hold_side():
     assert normalized["qty"] == 0.1
 
 
+@pytest.mark.parametrize(
+    "progress",
+    [
+        {"filled": 0.04, "remaining": 0.06},
+        {"filled": 0.0, "remaining": 0.06},
+    ],
+)
+def test_bitget_uta_websocket_partial_fill_requires_authoritative_refresh(progress):
+    bot = BitgetBot.__new__(BitgetBot)
+    bot._config_hedge_mode = True
+    bot.hedge_mode = True
+    bot.is_uta = True
+    order = {
+        "symbol": "BTC/USDT:USDT",
+        "status": "open",
+        "side": "buy",
+        "amount": 0.1,
+        **progress,
+        "info": {"holdSide": "long", "side": "buy"},
+    }
+
+    normalized = bot._normalize_order_update(order)
+
+    assert normalized["_pb_order_update_requires_authoritative_refresh"] is True
+
+
+def test_bitget_uta_websocket_unfilled_open_does_not_force_refresh():
+    bot = BitgetBot.__new__(BitgetBot)
+    bot._config_hedge_mode = True
+    bot.hedge_mode = True
+    bot.is_uta = True
+    order = {
+        "symbol": "BTC/USDT:USDT",
+        "status": "open",
+        "side": "buy",
+        "amount": 0.1,
+        "filled": 0.0,
+        "remaining": 0.1,
+        "info": {"holdSide": "long", "side": "buy"},
+    }
+
+    normalized = bot._normalize_order_update(order)
+
+    assert "_pb_order_update_requires_authoritative_refresh" not in normalized
+
+
 def test_bitget_uta_websocket_order_rejects_conflicting_native_psides():
     bot = BitgetBot.__new__(BitgetBot)
     bot.hedge_mode = True

--- a/tests/test_order_reconciliation_contract.py
+++ b/tests/test_order_reconciliation_contract.py
@@ -85,6 +85,41 @@ def test_supported_hedge_orders_do_not_fabricate_pside_from_client_id(bot_cls):
         bot._get_position_side_for_order(order)
 
 
+def test_bitget_uta_websocket_order_uses_native_hold_side():
+    bot = BitgetBot.__new__(BitgetBot)
+    bot._config_hedge_mode = True
+    bot.hedge_mode = True
+    bot.is_uta = True
+    order = {
+        "symbol": "BTC/USDT:USDT",
+        "side": "sell",
+        "amount": 0.1,
+        "info": {
+            "holdMode": "hedge_mode",
+            "holdSide": "long",
+            "side": "sell",
+            "tradeSide": "close",
+        },
+    }
+
+    normalized = bot._normalize_order_update(order)
+
+    assert normalized["side"] == "sell"
+    assert normalized["position_side"] == "long"
+    assert normalized["qty"] == 0.1
+
+
+def test_bitget_uta_websocket_order_rejects_conflicting_native_psides():
+    bot = BitgetBot.__new__(BitgetBot)
+    bot.hedge_mode = True
+    bot.is_uta = True
+
+    with pytest.raises(ValueError, match="authoritative position-side"):
+        bot._get_position_side_for_order(
+            {"info": {"posSide": "short", "holdSide": "long"}}
+        )
+
+
 @pytest.mark.parametrize("bot_cls", [BinanceBot, KucoinBot])
 def test_sparse_websocket_order_update_uses_passivbot_client_pside(bot_cls):
     bot = bot_cls.__new__(bot_cls)


### PR DESCRIPTION
## Summary

- normalize Bitget UTA hedge position side from its native private-WebSocket `holdSide` field
- reject contradictory Bitget `posSide`/`holdSide` values instead of selecting one
- give a just-submitted Hyperliquid create a one-second acknowledgement grace before treating its earlier sparse WS open event as untrusted
- retain the exact acknowledged exchange-order-ID and contradiction checks for Hyperliquid recovery

## Root causes

Bitget UTA order events use `holdSide`, while the connector only recognized classic `posSide`; valid UTA events therefore triggered the fail-closed authoritative REST fallback.

Hyperliquid can publish the private order-open event before the concurrent create request returns its exchange order ID. The submitted record initially lacks the ID, so the sparse event could not satisfy the existing exact-ID recovery contract and unnecessarily requested an account refresh.

## Safety contract

The Hyperliquid grace only yields while a create was submitted within the last five seconds. After the yield, the row is accepted only if the create record became acknowledged and its exact exchange ID and all existing side/status/client/reduce-only checks agree. Shape, price, quantity, and side alone never establish ownership. Ambiguous or foreign rows still fail closed to authoritative REST refresh.

## Validation

- `PYTHONPATH=/private/tmp/passivbot-4-ws-order-semantic-fixes/src /Users/eiriknarjord/repos/passivbot-4/venv/bin/python -m pytest -q tests/test_order_reconciliation_contract.py tests/test_hyperliquid_balance_cache.py tests/exchanges/test_ccxt_bot_hooks.py tests/ccxt_upgrade/test_order_contracts.py` (309 passed)
- `git diff --check`

Ready for review.