### PR TITLE
Add optimizer starting-config preselection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ All notable user-facing changes will be documented in this file.
   an omitted or null `scenario` keep using suite aggregation and their explicit `stat` or
   `backtest.aggregate` fallback. Named-scenario limits use that scenario's metric value and reject
   an accompanying `stat`.
+- Optimizer starting configs may now be pre-filtered from stored Pareto metrics with
+  `--filter-starting-configs` and optionally reduced with the same `anchors-farthest` selection as
+  `pareto-compress` via `--compress-starting-configs N` (`--starting-configs-max N`). The optimizer
+  warns that stored metrics are not verified against the new run and fails loudly when metric
+  artifacts are missing, malformed, or all rejected.
 - Live EMA preparation now batches compatible spans per symbol and metric family, including bounded
   cache-only fallbacks for stale forager candidates, and complete candle windows bypass redundant
   Python gap reconstruction. A failed combined read retries each span through its primary reader

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -96,6 +96,45 @@ passivbot tool pareto-compress optimize_results/.../pareto 8 --output-dir select
 passivbot tool merge-paretos optimize_results/run_a/pareto optimize_results/run_b/pareto
 ```
 
+## Optimizer starting-config preselection
+
+By default, `passivbot optimize -t/--start` accepts ordinary configs or Pareto artifacts, extracts
+their bot parameters, and re-evaluates every unique seed under the new run. Add
+`--filter-starting-configs` to filter metric-bearing Pareto artifacts before seed extraction using
+the optimizer's final effective limits, including config limits and CLI `--limits`, `--limit`, and
+`--clear-limits` changes:
+
+```shell
+passivbot optimize configs/examples/suite_example.json \
+  -t optimize_results/.../pareto \
+  --filter-starting-configs \
+  -l 'adg_strategy_eq>0.0' \
+  -l 'strategy_eq_recovery_days_max<100' \
+  -l '{"metric":"strategy_eq_recovery_days_max","penalize_if":"greater_than","stat":"max","value":120}'
+```
+
+Optionally add `--compress-starting-configs N` (alias `--starting-configs-max N`) to retain at most
+`N` filtered candidates using the same `anchors-farthest` objective-anchor and diversity selection
+as `passivbot tool pareto-compress N`. Compression may also be used without filtering:
+
+```shell
+passivbot optimize configs/examples/suite_example.json \
+  -t optimize_results/.../pareto \
+  --filter-starting-configs \
+  --compress-starting-configs 60 \
+  -l 'drawdown_worst_strategy_eq<0.5 scenario=base'
+```
+
+Both options trust the metrics and objectives stored in the seed artifacts. Passivbot cannot prove
+that their coin universe, exchanges, date range, scenarios, or other backtest settings match the
+new optimization, so it logs a warning whenever metric-based preselection is enabled. This workflow
+is best suited to restarting a comparable optimization with stricter limits. When seeds come from
+different runs or ordinary configs, omit these options so every seed is evaluated before selection.
+Metric-based preselection fails instead of guessing when JSON seeds lack usable Pareto metrics, a
+configured limit metric cannot be resolved, stored artifacts are malformed, or filtering rejects
+every candidate. Survivors are still quantized, deduplicated, and re-evaluated normally by the new
+optimization.
+
 ## Iterative backtester utilities
 
 `src/tools/iterative_backtester.py` and `iterative_history_plot.py` help replay slices of the backtester (or real fills) interactively so you can inspect order-by-order behaviour. Useful when tuning configs by hand.

--- a/src/limit_utils.py
+++ b/src/limit_utils.py
@@ -26,12 +26,16 @@ def resolve_auto_limit_entries(
     resolved: List[Dict[str, Any]] = []
     for raw_entry in limits:
         entry = deepcopy(raw_entry)
+        if not bool(entry.get("enabled", True)):
+            resolved.append(entry)
+            continue
         mode = entry.get("penalize_if") or "greater_than"
         if mode == "auto":
             metric = entry.get("metric")
             if not metric:
                 continue
             canonical_metric = canonical_metric_name(str(metric))
+            _validate_limit_metric(canonical_metric, raw_entry)
             weight = weights.get(canonical_metric)
             if weight is None:
                 continue

--- a/src/limit_utils.py
+++ b/src/limit_utils.py
@@ -17,6 +17,29 @@ _KNOWN_LIMIT_METRICS = (
 )
 
 
+def resolve_auto_limit_entries(
+    limits: Iterable[Dict[str, Any]],
+    scoring_weights: Dict[str, float],
+) -> List[Dict[str, Any]]:
+    """Resolve legacy ``penalize_if=auto`` entries using optimizer scoring directions."""
+    weights = scoring_weights or {}
+    resolved: List[Dict[str, Any]] = []
+    for raw_entry in limits:
+        entry = deepcopy(raw_entry)
+        mode = entry.get("penalize_if") or "greater_than"
+        if mode == "auto":
+            metric = entry.get("metric")
+            if not metric:
+                continue
+            canonical_metric = canonical_metric_name(str(metric))
+            weight = weights.get(canonical_metric)
+            if weight is None:
+                continue
+            entry["penalize_if"] = "less_than" if weight < 0 else "greater_than"
+        resolved.append(entry)
+    return resolved
+
+
 def expand_limit_checks(
     limits: Iterable[Dict[str, Any]],
     scoring_weights: Dict[str, float],
@@ -32,8 +55,8 @@ def expand_limit_checks(
         return []
     weights = scoring_weights or {}
     checks: List[Dict[str, Any]] = []
-    for raw_entry in limits:
-        entry = deepcopy(raw_entry)
+    for entry in resolve_auto_limit_entries(limits, weights):
+        raw_entry = entry
         if isinstance(entry, dict) and not bool(entry.get("enabled", True)):
             continue
         metric = entry.get("metric")
@@ -42,11 +65,6 @@ def expand_limit_checks(
         metric = canonical_metric_name(str(metric))
         _validate_limit_metric(metric, raw_entry)
         mode = entry.get("penalize_if") or "greater_than"
-        if mode == "auto":
-            weight = weights.get(metric)
-            if weight is None:
-                continue
-            mode = "less_than" if weight < 0 else "greater_than"
         if mode in {
             "greater_than",
             "greater_than_or_equal",

--- a/src/optimization/starting_config_selection.py
+++ b/src/optimization/starting_config_selection.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
-from config.scoring import ObjectiveSpec
+from config.scoring import ObjectiveSpec, default_scoring_weights
 from pareto_compress import compress_candidates
 from pareto_explorer import (
     ParetoCandidate,
@@ -29,11 +29,18 @@ class StartingConfigSelection:
 def _require_metric_bearing_artifacts(
     pareto_dir: Path,
     candidates: Sequence[ParetoCandidate],
+    source_path: str,
 ) -> None:
     candidate_paths = {candidate.path.resolve() for candidate in candidates}
+    raw_source = Path(source_path).expanduser()
+    json_paths = (
+        [raw_source.resolve()]
+        if raw_source.is_file()
+        else sorted(pareto_dir.glob("*.json"))
+    )
     unsupported = [
         path.name
-        for path in sorted(pareto_dir.glob("*.json"))
+        for path in json_paths
         if path.name not in _IGNORED_METADATA_FILENAMES
         and path.resolve() not in candidate_paths
     ]
@@ -73,7 +80,7 @@ def select_starting_config_artifacts(
             "Omit --filter-starting-configs and --compress-starting-configs to re-evaluate "
             "ordinary seed configs."
         ) from exc
-    _require_metric_bearing_artifacts(pareto_dir, loaded)
+    _require_metric_bearing_artifacts(pareto_dir, loaded, path)
 
     candidates = list(loaded)
     active_limits: list[dict[str, Any]] = []
@@ -82,6 +89,7 @@ def select_starting_config_artifacts(
             candidates,
             limits,
             aggregate_cfg=aggregate_cfg,
+            scoring_weights=default_scoring_weights(),
         )
         if not candidates:
             raise ValueError(

--- a/src/optimization/starting_config_selection.py
+++ b/src/optimization/starting_config_selection.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from config.scoring import ObjectiveSpec
+from pareto_compress import compress_candidates
+from pareto_explorer import (
+    ParetoCandidate,
+    filter_candidates_with_limits,
+    load_candidates,
+)
+
+_IGNORED_METADATA_FILENAMES = {"selection.json"}
+
+
+@dataclass(frozen=True)
+class StartingConfigSelection:
+    pareto_dir: Path
+    candidates: tuple[ParetoCandidate, ...]
+    scoring_specs: tuple[ObjectiveSpec, ...]
+    loaded_count: int
+    filtered_count: int
+    selected_count: int
+
+
+def _require_metric_bearing_artifacts(
+    pareto_dir: Path,
+    candidates: Sequence[ParetoCandidate],
+) -> None:
+    candidate_paths = {candidate.path.resolve() for candidate in candidates}
+    unsupported = [
+        path.name
+        for path in sorted(pareto_dir.glob("*.json"))
+        if path.name not in _IGNORED_METADATA_FILENAMES
+        and path.resolve() not in candidate_paths
+    ]
+    if unsupported:
+        preview = ", ".join(unsupported[:5])
+        suffix = (
+            "" if len(unsupported) <= 5 else f", ... (+{len(unsupported) - 5} more)"
+        )
+        raise ValueError(
+            "Starting-config metric preselection requires every JSON input to be a "
+            "metric-bearing Pareto artifact; unsupported files: "
+            f"{preview}{suffix}. Omit --filter-starting-configs and "
+            "--compress-starting-configs to re-evaluate ordinary seed configs."
+        )
+
+
+def select_starting_config_artifacts(
+    path: str,
+    *,
+    limits: Sequence[Mapping[str, Any]],
+    aggregate_cfg: Mapping[str, Any] | None,
+    filter_by_limits: bool,
+    max_count: int | None,
+) -> StartingConfigSelection:
+    logging.warning(
+        "Starting-config metric preselection trusts stored Pareto metrics and objectives "
+        "without verifying that their coins, exchanges, date range, scenarios, or backtest "
+        "settings match this optimization run. Use it only for comparable artifacts; omit "
+        "--filter-starting-configs and --compress-starting-configs to re-evaluate all seed configs."
+    )
+    try:
+        pareto_dir, loaded, scoring_specs = load_candidates(path)
+    except ValueError as exc:
+        raise ValueError(
+            "Starting-config metric preselection could not load complete metric-bearing "
+            f"Pareto artifacts: {exc}. "
+            "Omit --filter-starting-configs and --compress-starting-configs to re-evaluate "
+            "ordinary seed configs."
+        ) from exc
+    _require_metric_bearing_artifacts(pareto_dir, loaded)
+
+    candidates = list(loaded)
+    active_limits: list[dict[str, Any]] = []
+    if filter_by_limits:
+        candidates, active_limits = filter_candidates_with_limits(
+            candidates,
+            limits,
+            aggregate_cfg=aggregate_cfg,
+        )
+        if not candidates:
+            raise ValueError(
+                "No starting configs remained after applying the optimizer's effective limits."
+            )
+
+    filtered_count = len(candidates)
+    if max_count is not None and len(candidates) > int(max_count):
+        members, _objective_ranges, _truncated_anchors = compress_candidates(
+            candidates,
+            scoring_specs,
+            count=int(max_count),
+            method="anchors-farthest",
+        )
+        candidates = [member.candidate for member in members]
+
+    logging.info(
+        "Starting-config metric preselection | loaded=%d | retained_after_limits=%d "
+        "| selected=%d | active_limits=%d | max=%s",
+        len(loaded),
+        filtered_count,
+        len(candidates),
+        len(active_limits),
+        str(max_count) if max_count is not None else "none",
+    )
+    return StartingConfigSelection(
+        pareto_dir=pareto_dir,
+        candidates=tuple(candidates),
+        scoring_specs=tuple(scoring_specs),
+        loaded_count=len(loaded),
+        filtered_count=filtered_count,
+        selected_count=len(candidates),
+    )

--- a/src/optimization/starting_config_selection.py
+++ b/src/optimization/starting_config_selection.py
@@ -64,6 +64,7 @@ def select_starting_config_artifacts(
     aggregate_cfg: Mapping[str, Any] | None,
     filter_by_limits: bool,
     max_count: int | None,
+    scenario_labels: Sequence[str] | None = None,
 ) -> StartingConfigSelection:
     logging.warning(
         "Starting-config metric preselection trusts stored Pareto metrics and objectives "
@@ -89,6 +90,7 @@ def select_starting_config_artifacts(
             candidates,
             limits,
             aggregate_cfg=aggregate_cfg,
+            scenario_labels=scenario_labels,
             scoring_weights=default_scoring_weights(),
         )
         if not candidates:

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -183,6 +183,7 @@ from optimization.fine_tune_anchors import ANCHOR_GENE_KEY, ANCHOR_PLAN_KEY, get
 from optimization.backend_shared import cancel_pending_async_results, stream_async_results
 from optimization.backends import get_backend_runner
 from optimization.random_seed import seed_rngs
+from optimization.starting_config_selection import select_starting_config_artifacts
 from optimization.config_adapter import (
     extract_bounds_tuple_list_from_config,
     get_optimization_key_paths,
@@ -2224,9 +2225,8 @@ def add_extra_options(parser, *, help_all: bool):
         dest="starting_configs",
         default=None,
         help=(
-            "Start with given live configs. With --fine-tune-params, these configs are fixed-param anchors."
-            if help_all
-            else argparse.SUPPRESS
+            "Start with configs or Pareto artifacts from a JSON file or directory. "
+            "With --fine-tune-params, these configs are fixed-param anchors."
         ),
     )
     parser.add_argument(
@@ -2270,6 +2270,30 @@ def add_extra_options(parser, *, help_all: bool):
     )
 
 
+def add_starting_config_selection_options(parser) -> None:
+    parser.add_argument(
+        "--filter-starting-configs",
+        action="store_true",
+        dest="filter_starting_configs",
+        help=(
+            "Before optimization, filter metric-bearing -t/--start Pareto artifacts using "
+            "the final effective optimize limits. Stored metrics are not revalidated."
+        ),
+    )
+    parser.add_argument(
+        "--compress-starting-configs",
+        "--starting-configs-max",
+        type=int,
+        default=None,
+        metavar="N",
+        dest="starting_configs_max",
+        help=(
+            "Select at most N metric-bearing -t/--start artifacts with the same "
+            "anchors-farthest method as pareto-compress."
+        ),
+    )
+
+
 def _resolve_cli_limits_override(args, existing_limits=None) -> list[dict] | None:
     raw_limits_payload = getattr(args, "optimize.limits", None)
     raw_limit_entries = list(getattr(args, "limit_entries", []) or [])
@@ -2286,6 +2310,27 @@ def _resolve_cli_limits_override(args, existing_limits=None) -> list[dict] | Non
     if raw_limit_entries:
         replacement.extend(parse_limit_cli_entries(raw_limit_entries))
     return normalize_limit_entries(replacement)
+
+
+def _validate_starting_config_selection_args(
+    parser: argparse.ArgumentParser,
+    args: argparse.Namespace,
+) -> None:
+    filter_starting_configs = bool(getattr(args, "filter_starting_configs", False))
+    starting_configs_max = getattr(args, "starting_configs_max", None)
+    selection_requested = filter_starting_configs or starting_configs_max is not None
+    if not selection_requested:
+        return
+    if not getattr(args, "starting_configs", None):
+        parser.error(
+            "--filter-starting-configs and --compress-starting-configs require -t/--start"
+        )
+    if getattr(args, "resume", None):
+        parser.error(
+            "--filter-starting-configs and --compress-starting-configs cannot be used with --resume"
+        )
+    if starting_configs_max is not None and int(starting_configs_max) <= 0:
+        parser.error("--compress-starting-configs must be a positive integer")
 
 
 def _flat_optimize_bounds_for_config(config: dict) -> tuple[dict, bool]:
@@ -2557,6 +2602,8 @@ def install_anchored_fine_tune_plan(
     config: dict,
     fine_tune_params: list[str],
     starting_configs_path: str,
+    *,
+    starting_configs_override: Sequence[dict] | None = None,
 ) -> None:
     flat_bounds, fine_tune_set, config_fixed_params, effective_fixed_params = (
         _resolve_fine_tune_key_sets(config, fine_tune_params)
@@ -2583,7 +2630,12 @@ def install_anchored_fine_tune_plan(
     }
     sig_digits = config.get("optimize", {}).get("round_to_n_significant_digits", 6)
     clamp_collector = {}
-    for raw_anchor in iter_starting_configs(starting_configs_path):
+    starting_configs = (
+        iter(starting_configs_override)
+        if starting_configs_override is not None
+        else iter_starting_configs(starting_configs_path)
+    )
+    for raw_anchor in starting_configs:
         try:
             anchor_cfg = _build_starting_seed_config(raw_anchor)
             anchor_strategy_kind = normalize_strategy_kind(
@@ -2738,6 +2790,39 @@ def iter_starting_configs(starting_configs: str):
                 yield from iter_starting_configs(entry.path)
         return
     yield from iter_extract_configs(starting_configs)
+
+
+def preselect_starting_configs(
+    starting_configs_path: str,
+    config: Mapping[str, Any],
+    *,
+    filter_by_limits: bool,
+    max_count: int | None,
+) -> list[dict]:
+    backtest_cfg = config.get("backtest")
+    aggregate_cfg = backtest_cfg.get("aggregate") if isinstance(backtest_cfg, Mapping) else None
+    optimize_cfg = config.get("optimize")
+    limits = optimize_cfg.get("limits", []) if isinstance(optimize_cfg, Mapping) else []
+    selection = select_starting_config_artifacts(
+        starting_configs_path,
+        limits=limits,
+        aggregate_cfg=aggregate_cfg if isinstance(aggregate_cfg, Mapping) else None,
+        filter_by_limits=filter_by_limits,
+        max_count=max_count,
+    )
+    current_specs = extract_objective_specs(config)
+    if (
+        selection.selected_count < selection.filtered_count
+        and current_specs != list(selection.scoring_specs)
+    ):
+        logging.warning(
+            "Stored starting-config optimize.scoring differs from this optimization run; "
+            "anchors-farthest compression used the stored objectives."
+        )
+    return [
+        _extract_starting_config(candidate.entry, source=str(candidate.path))
+        for candidate in selection.candidates
+    ]
 
 
 def iter_anchored_fine_tune_seed_configs(config: dict):
@@ -2914,10 +2999,12 @@ async def main():
         dest="clear_limits",
         help="Replace optimize.limits with an empty list before applying any --limits/--limit entries.",
     )
+    add_starting_config_selection_options(optimize_common_group)
     add_extra_options(group_map["Advanced Overrides"], help_all=help_all)
     raw_args = merge_negative_cli_values(expand_help_all_argv(raw_argv))
     raw_args = _normalize_optional_bool_flag(raw_args, "--suite")
     args = parser.parse_args(raw_args)
+    _validate_starting_config_selection_args(parser, args)
     polish_bounds_pct = getattr(args, "polish_bounds_pct", None)
     polish_bounds_mode = getattr(args, "polish_bounds_mode", "clamp")
     if polish_bounds_pct is not None and (
@@ -2955,6 +3042,14 @@ async def main():
         TEMPLATE_CONFIG_MODE,
         ",".join(objective_metric_names(config)),
     )
+    preselected_starting_configs = None
+    if args.filter_starting_configs or args.starting_configs_max is not None:
+        preselected_starting_configs = preselect_starting_configs(
+            args.starting_configs,
+            config,
+            filter_by_limits=bool(args.filter_starting_configs),
+            max_count=args.starting_configs_max,
+        )
     fine_tune_params = (
         [p.strip() for p in (args.fine_tune_params or "").split(",") if p.strip()]
         if getattr(args, "fine_tune_params", "")
@@ -2968,7 +3063,12 @@ async def main():
     if polish_bounds_pct is not None:
         apply_polish_bounds(config, polish_bounds_pct, bounds_mode=polish_bounds_mode)
     if fine_tune_params and args.starting_configs:
-        install_anchored_fine_tune_plan(config, fine_tune_params, args.starting_configs)
+        install_anchored_fine_tune_plan(
+            config,
+            fine_tune_params,
+            args.starting_configs,
+            starting_configs_override=preselected_starting_configs,
+        )
     else:
         apply_fine_tune_bounds(config, fine_tune_params, cli_bounds_overrides)
     suite_override = None
@@ -3200,6 +3300,8 @@ async def main():
         logging.info("Selected optimizer backend: %s", backend_name)
         backend_runner = get_backend_runner(backend_name)
         starting_config_iter = iter_starting_configs
+        if preselected_starting_configs is not None:
+            starting_config_iter = lambda _path: iter(preselected_starting_configs)
         if get_anchor_plan(config) is not None:
             starting_config_iter = lambda _path: iter_anchored_fine_tune_seed_configs(config)
         backend_result = backend_runner(

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -2799,6 +2799,7 @@ def preselect_starting_configs(
     filter_by_limits: bool,
     max_count: int | None,
     aggregate_cfg: Mapping[str, Any] | None,
+    scenario_labels: Sequence[str] | None = None,
 ) -> list[dict]:
     optimize_cfg = config.get("optimize")
     limits = optimize_cfg.get("limits", []) if isinstance(optimize_cfg, Mapping) else []
@@ -2809,6 +2810,7 @@ def preselect_starting_configs(
         starting_configs_path,
         limits=limits,
         aggregate_cfg=effective_aggregate_cfg,
+        scenario_labels=scenario_labels,
         filter_by_limits=filter_by_limits,
         max_count=max_count,
     )
@@ -3082,6 +3084,15 @@ async def main():
             max_count=args.starting_configs_max,
             aggregate_cfg=(
                 suite_cfg.get("aggregate") if suite_cfg.get("enabled") else None
+            ),
+            scenario_labels=(
+                [
+                    str(scenario["label"])
+                    for scenario in suite_cfg.get("scenarios", [])
+                    if isinstance(scenario, Mapping) and "label" in scenario
+                ]
+                if suite_cfg.get("enabled")
+                else None
             ),
         )
     fine_tune_params = (

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -2798,9 +2798,14 @@ def preselect_starting_configs(
     *,
     filter_by_limits: bool,
     max_count: int | None,
+    aggregate_cfg_override: Mapping[str, Any] | None = None,
 ) -> list[dict]:
     backtest_cfg = config.get("backtest")
-    aggregate_cfg = backtest_cfg.get("aggregate") if isinstance(backtest_cfg, Mapping) else None
+    aggregate_cfg = (
+        backtest_cfg.get("aggregate") if isinstance(backtest_cfg, Mapping) else None
+    )
+    if aggregate_cfg_override is not None:
+        aggregate_cfg = aggregate_cfg_override
     optimize_cfg = config.get("optimize")
     limits = optimize_cfg.get("limits", []) if isinstance(optimize_cfg, Mapping) else []
     selection = select_starting_config_artifacts(
@@ -3042,6 +3047,15 @@ async def main():
         TEMPLATE_CONFIG_MODE,
         ",".join(objective_metric_names(config)),
     )
+    suite_override = None
+    if args.suite_config:
+        logging.info("loading suite config %s", args.suite_config)
+        suite_override = load_suite_override_config(args.suite_config)
+        if _suite_config_implies_suite_mode(args):
+            recursive_config_update(
+                config, "backtest.suite_enabled", True, verbose=True
+            )
+    suite_cfg = extract_suite_config(config, suite_override)
     preselected_starting_configs = None
     if args.filter_starting_configs or args.starting_configs_max is not None:
         preselected_starting_configs = preselect_starting_configs(
@@ -3049,6 +3063,7 @@ async def main():
             config,
             filter_by_limits=bool(args.filter_starting_configs),
             max_count=args.starting_configs_max,
+            aggregate_cfg_override=suite_cfg.get("aggregate"),
         )
     fine_tune_params = (
         [p.strip() for p in (args.fine_tune_params or "").split(",") if p.strip()]
@@ -3071,14 +3086,6 @@ async def main():
         )
     else:
         apply_fine_tune_bounds(config, fine_tune_params, cli_bounds_overrides)
-    suite_override = None
-    if args.suite_config:
-        logging.info("loading suite config %s", args.suite_config)
-        suite_override = load_suite_override_config(args.suite_config)
-        if _suite_config_implies_suite_mode(args):
-            recursive_config_update(config, "backtest.suite_enabled", True, verbose=True)
-    suite_cfg = extract_suite_config(config, suite_override)
-
     # Handle --scenarios filter (implies --suite y)
     scenario_filter = getattr(args, "scenarios", None)
     if scenario_filter:

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -171,6 +171,7 @@ from suite_runner import (
     filter_scenarios_by_label,
     load_suite_override_config,
     aggregate_metrics,
+    build_scenarios,
     build_suite_metrics_payload,
 )
 from metrics_schema import MetricAggregationError, build_scenario_metrics, flatten_metric_stats
@@ -2829,6 +2830,13 @@ def preselect_starting_configs(
     ]
 
 
+def _active_suite_scenario_labels(suite_cfg: Mapping[str, Any]) -> list[str] | None:
+    if not suite_cfg.get("enabled"):
+        return None
+    scenarios, _aggregate_cfg = build_scenarios(dict(suite_cfg))
+    return [scenario.label for scenario in scenarios]
+
+
 def iter_anchored_fine_tune_seed_configs(config: dict):
     anchor_plan = get_anchor_plan(config)
     if anchor_plan is None:
@@ -3085,15 +3093,7 @@ async def main():
             aggregate_cfg=(
                 suite_cfg.get("aggregate") if suite_cfg.get("enabled") else None
             ),
-            scenario_labels=(
-                [
-                    str(scenario["label"])
-                    for scenario in suite_cfg.get("scenarios", [])
-                    if isinstance(scenario, Mapping) and "label" in scenario
-                ]
-                if suite_cfg.get("enabled")
-                else None
-            ),
+            scenario_labels=_active_suite_scenario_labels(suite_cfg),
         )
     fine_tune_params = (
         [p.strip() for p in (args.fine_tune_params or "").split(",") if p.strip()]

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -2798,20 +2798,17 @@ def preselect_starting_configs(
     *,
     filter_by_limits: bool,
     max_count: int | None,
-    aggregate_cfg_override: Mapping[str, Any] | None = None,
+    aggregate_cfg: Mapping[str, Any] | None,
 ) -> list[dict]:
-    backtest_cfg = config.get("backtest")
-    aggregate_cfg = (
-        backtest_cfg.get("aggregate") if isinstance(backtest_cfg, Mapping) else None
-    )
-    if aggregate_cfg_override is not None:
-        aggregate_cfg = aggregate_cfg_override
     optimize_cfg = config.get("optimize")
     limits = optimize_cfg.get("limits", []) if isinstance(optimize_cfg, Mapping) else []
+    effective_aggregate_cfg = (
+        aggregate_cfg if isinstance(aggregate_cfg, Mapping) else {"default": "mean"}
+    )
     selection = select_starting_config_artifacts(
         starting_configs_path,
         limits=limits,
-        aggregate_cfg=aggregate_cfg if isinstance(aggregate_cfg, Mapping) else None,
+        aggregate_cfg=effective_aggregate_cfg,
         filter_by_limits=filter_by_limits,
         max_count=max_count,
     )
@@ -3056,6 +3053,26 @@ async def main():
                 config, "backtest.suite_enabled", True, verbose=True
             )
     suite_cfg = extract_suite_config(config, suite_override)
+
+    # Handle --scenarios filter (implies --suite y)
+    scenario_filter = getattr(args, "scenarios", None)
+    if scenario_filter:
+        labels = [
+            label.strip() for label in scenario_filter.split(",") if label.strip()
+        ]
+        suite_cfg["scenarios"] = filter_scenarios_by_label(
+            suite_cfg.get("scenarios", []), labels
+        )
+        suite_cfg["enabled"] = True  # --scenarios implies suite mode
+        logging.info("Filtered to %d scenario(s): %s", len(labels), ", ".join(labels))
+
+    # --suite CLI arg overrides config (applied after --scenarios so explicit --suite n wins)
+    if args.suite is not None:
+        recursive_config_update(
+            config, "backtest.suite_enabled", bool(args.suite), verbose=True
+        )
+        suite_cfg["enabled"] = bool(args.suite)
+
     preselected_starting_configs = None
     if args.filter_starting_configs or args.starting_configs_max is not None:
         preselected_starting_configs = preselect_starting_configs(
@@ -3063,7 +3080,9 @@ async def main():
             config,
             filter_by_limits=bool(args.filter_starting_configs),
             max_count=args.starting_configs_max,
-            aggregate_cfg_override=suite_cfg.get("aggregate"),
+            aggregate_cfg=(
+                suite_cfg.get("aggregate") if suite_cfg.get("enabled") else None
+            ),
         )
     fine_tune_params = (
         [p.strip() for p in (args.fine_tune_params or "").split(",") if p.strip()]
@@ -3086,18 +3105,6 @@ async def main():
         )
     else:
         apply_fine_tune_bounds(config, fine_tune_params, cli_bounds_overrides)
-    # Handle --scenarios filter (implies --suite y)
-    scenario_filter = getattr(args, "scenarios", None)
-    if scenario_filter:
-        labels = [label.strip() for label in scenario_filter.split(",") if label.strip()]
-        suite_cfg["scenarios"] = filter_scenarios_by_label(suite_cfg.get("scenarios", []), labels)
-        suite_cfg["enabled"] = True  # --scenarios implies suite mode
-        logging.info("Filtered to %d scenario(s): %s", len(labels), ", ".join(labels))
-
-    # --suite CLI arg overrides config (applied after --scenarios so explicit --suite n wins)
-    if args.suite is not None:
-        recursive_config_update(config, "backtest.suite_enabled", bool(args.suite), verbose=True)
-        suite_cfg["enabled"] = bool(args.suite)
     backtest_exchanges = require_config_value(config, "backtest.exchanges")
     await format_approved_ignored_coins(config, backtest_exchanges)
     interrupted = False

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -26,6 +26,7 @@ from config.scoring import (
     from_engine_value,
     objective_spec_by_metric,
 )
+from limit_utils import resolve_auto_limit_entries
 from metrics_schema import flatten_metric_stats
 from pareto_core import detect_latest_pareto_dir
 
@@ -636,8 +637,13 @@ def _extract_objectives(entry: Mapping[str, Any]) -> Dict[str, float]:
 
 
 def load_candidates(path: str | os.PathLike[str]) -> tuple[Path, List[ParetoCandidate], List[ObjectiveSpec]]:
-    pareto_dir = resolve_pareto_directory(path)
-    json_paths = sorted(pareto_dir.glob("*.json"))
+    raw_path = Path(path).expanduser()
+    if raw_path.is_file():
+        pareto_dir = raw_path.parent.resolve()
+        json_paths = [raw_path.resolve()]
+    else:
+        pareto_dir = resolve_pareto_directory(raw_path)
+        json_paths = sorted(pareto_dir.glob("*.json"))
     if not json_paths:
         raise ValueError(f"No Pareto JSON files found in {pareto_dir}")
 
@@ -951,7 +957,7 @@ def _limit_rejects(entry: Mapping[str, Any], value: float) -> bool:
         return value < float(low) or value > float(high)
     if mode == "inside_range":
         low, high = entry["range"]
-        return float(low) <= value <= float(high)
+        return float(low) < value < float(high)
     raise ValueError(f"Unsupported limit mode {mode!r}")
 
 
@@ -974,8 +980,14 @@ def filter_candidates_with_limits(
     limits: Sequence[Mapping[str, Any]],
     *,
     aggregate_cfg: Mapping[str, Any] | None = None,
+    scoring_weights: Mapping[str, float] | None = None,
 ) -> tuple[List[ParetoCandidate], List[Dict[str, Any]]]:
     normalized_limits = normalize_limit_entries(list(limits))
+    if scoring_weights is not None:
+        normalized_limits = resolve_auto_limit_entries(
+            normalized_limits,
+            dict(scoring_weights),
+        )
     enabled_limits = [entry for entry in normalized_limits if bool(entry.get("enabled", True))]
     if not enabled_limits:
         return list(candidates), enabled_limits

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -421,12 +421,18 @@ def build_parser() -> argparse.ArgumentParser:
 def _extract_suite_metrics(
     entry: Mapping[str, Any],
     aggregate_cfg: Mapping[str, Any] | None = None,
+    scenario_labels: Sequence[str] | None = None,
 ) -> tuple[Dict[str, float], Dict[str, float]]:
     aggregated_values: Dict[str, float] = {}
     stats_flat: Dict[str, float] = {}
     suite_metrics = entry.get("suite_metrics")
     if not isinstance(suite_metrics, Mapping):
         return stats_flat, aggregated_values
+    selected_labels = (
+        tuple(dict.fromkeys(str(label) for label in scenario_labels))
+        if scenario_labels is not None
+        else None
+    )
     effective_aggregate_cfg = (
         aggregate_cfg
         if aggregate_cfg is not None
@@ -441,7 +447,31 @@ def _extract_suite_metrics(
                 continue
             aggregated = payload.get("aggregated")
             stats = payload.get("stats") or {}
-            if aggregate_cfg is not None:
+            if selected_labels is not None:
+                scenarios = payload.get("scenarios")
+                selected_values: list[float] = []
+                if isinstance(scenarios, Mapping):
+                    for label in selected_labels:
+                        value = scenarios.get(label)
+                        if not isinstance(value, (int, float)) or not math.isfinite(
+                            float(value)
+                        ):
+                            selected_values = []
+                            break
+                        selected_values.append(float(value))
+                if len(selected_values) == len(selected_labels) and selected_values:
+                    values = np.asarray(selected_values, dtype=float)
+                    stats = {
+                        "mean": float(np.mean(values)),
+                        "min": float(np.min(values)),
+                        "max": float(np.max(values)),
+                        "std": float(np.std(values)),
+                        "median": float(np.median(values)),
+                    }
+                else:
+                    stats = {}
+                aggregated = None
+            if aggregate_cfg is not None or selected_labels is not None:
                 aggregated = None
                 if isinstance(stats, Mapping) and stats:
                     mode = resolve_aggregate_mode(str(metric), effective_aggregate_cfg)
@@ -451,8 +481,11 @@ def _extract_suite_metrics(
                 aggregated = stats.get(mode, stats.get("mean"))
             if isinstance(aggregated, (int, float)) and math.isfinite(float(aggregated)):
                 aggregated_values[str(metric)] = float(aggregated)
-            if isinstance(stats, Mapping):
+            if isinstance(stats, Mapping) and stats:
                 stats_flat.update(flatten_metric_stats({str(metric): dict(stats)}))
+        return stats_flat, aggregated_values
+
+    if selected_labels is not None:
         return stats_flat, aggregated_values
 
     aggregate = suite_metrics.get("aggregate") or {}
@@ -875,6 +908,7 @@ def _resolve_limit_value(
     candidate: ParetoCandidate,
     entry: Mapping[str, Any],
     aggregate_cfg: Mapping[str, Any] | None = None,
+    scenario_labels: Sequence[str] | None = None,
 ) -> Optional[float]:
     metric = str(entry.get("metric", "")).strip()
     if not metric:
@@ -901,15 +935,19 @@ def _resolve_limit_value(
     applies_current_suite_aggregate = aggregate_cfg is not None and isinstance(
         candidate.entry.get("suite_metrics"), Mapping
     )
+    applies_current_scenario_set = scenario_labels is not None and isinstance(
+        candidate.entry.get("suite_metrics"), Mapping
+    )
     stats_flat = candidate.stats_flat
     aggregated_values = candidate.aggregated_values
     if explicit_suite_basis or (
-        aggregate_cfg is not None
+        (aggregate_cfg is not None or scenario_labels is not None)
         and isinstance(candidate.entry.get("suite_metrics"), Mapping)
     ):
         stats_flat, aggregated_values = _extract_suite_metrics(
             candidate.entry,
             aggregate_cfg=aggregate_cfg,
+            scenario_labels=scenario_labels,
         )
     if candidate.scenario is not None and "stat" in entry and not explicit_suite_basis:
         requested_stat = str(entry.get("stat", "")).strip().lower()
@@ -931,6 +969,7 @@ def _resolve_limit_value(
         "stat" not in entry
         and not explicit_suite_basis
         and not applies_current_suite_aggregate
+        and not applies_current_scenario_set
     ):
         fallback = _resolve_candidate_metric_value(candidate, metric)
         if isinstance(fallback, (int, float)) and math.isfinite(float(fallback)):
@@ -991,6 +1030,7 @@ def filter_candidates_with_limits(
     limits: Sequence[Mapping[str, Any]],
     *,
     aggregate_cfg: Mapping[str, Any] | None = None,
+    scenario_labels: Sequence[str] | None = None,
     scoring_weights: Mapping[str, float] | None = None,
 ) -> tuple[List[ParetoCandidate], List[Dict[str, Any]]]:
     normalized_limits = normalize_limit_entries(list(limits))
@@ -1002,16 +1042,17 @@ def filter_candidates_with_limits(
     enabled_limits = [entry for entry in normalized_limits if bool(entry.get("enabled", True))]
     if not enabled_limits:
         return list(candidates), enabled_limits
-    if aggregate_cfg is None and candidates:
-        backtest_cfg = candidates[0].entry.get("backtest")
-        if isinstance(backtest_cfg, Mapping):
-            aggregate_cfg = backtest_cfg.get("aggregate")
 
     filtered: List[ParetoCandidate] = []
     for candidate in candidates:
         rejected = False
         for entry in enabled_limits:
-            value = _resolve_limit_value(candidate, entry, aggregate_cfg)
+            value = _resolve_limit_value(
+                candidate,
+                entry,
+                aggregate_cfg,
+                scenario_labels,
+            )
             if value is None:
                 metric = str(entry.get("metric", "")).strip() or "<missing>"
                 available = _format_available_limit_metrics(candidate)

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -441,9 +441,11 @@ def _extract_suite_metrics(
                 continue
             aggregated = payload.get("aggregated")
             stats = payload.get("stats") or {}
-            if aggregate_cfg is not None and isinstance(stats, Mapping) and stats:
-                mode = resolve_aggregate_mode(str(metric), effective_aggregate_cfg)
-                aggregated = stats.get(mode, stats.get("mean"))
+            if aggregate_cfg is not None:
+                aggregated = None
+                if isinstance(stats, Mapping) and stats:
+                    mode = resolve_aggregate_mode(str(metric), effective_aggregate_cfg)
+                    aggregated = stats.get(mode)
             elif aggregated is None and isinstance(stats, Mapping):
                 mode = resolve_aggregate_mode(str(metric), effective_aggregate_cfg)
                 aggregated = stats.get(mode, stats.get("mean"))
@@ -459,14 +461,15 @@ def _extract_suite_metrics(
         if isinstance(stats, Mapping):
             stats_flat.update(flatten_metric_stats(dict(stats)))
         aggregated = aggregate.get("aggregated") or {}
-        if aggregate_cfg is not None and isinstance(stats, Mapping) and stats:
-            for metric, metric_stats in stats.items():
-                if not isinstance(metric_stats, Mapping):
-                    continue
-                mode = resolve_aggregate_mode(str(metric), effective_aggregate_cfg)
-                value = metric_stats.get(mode, metric_stats.get("mean"))
-                if isinstance(value, (int, float)) and math.isfinite(float(value)):
-                    aggregated_values[str(metric)] = float(value)
+        if aggregate_cfg is not None:
+            if isinstance(stats, Mapping) and stats:
+                for metric, metric_stats in stats.items():
+                    if not isinstance(metric_stats, Mapping):
+                        continue
+                    mode = resolve_aggregate_mode(str(metric), effective_aggregate_cfg)
+                    value = metric_stats.get(mode)
+                    if isinstance(value, (int, float)) and math.isfinite(float(value)):
+                        aggregated_values[str(metric)] = float(value)
         elif isinstance(aggregated, Mapping):
             for metric, value in aggregated.items():
                 if isinstance(value, (int, float)) and math.isfinite(float(value)):
@@ -895,10 +898,14 @@ def _resolve_limit_value(
         and "scenario" in entry
         and entry.get("scenario") is None
     )
+    applies_current_suite_aggregate = aggregate_cfg is not None and isinstance(
+        candidate.entry.get("suite_metrics"), Mapping
+    )
     stats_flat = candidate.stats_flat
     aggregated_values = candidate.aggregated_values
     if explicit_suite_basis or (
-        aggregate_cfg is not None and isinstance(candidate.entry.get("suite_metrics"), Mapping)
+        aggregate_cfg is not None
+        and isinstance(candidate.entry.get("suite_metrics"), Mapping)
     ):
         stats_flat, aggregated_values = _extract_suite_metrics(
             candidate.entry,
@@ -920,7 +927,11 @@ def _resolve_limit_value(
     value = resolve_metric_value(stats_flat, key)
     if isinstance(value, (int, float)) and math.isfinite(float(value)):
         return float(value)
-    if "stat" not in entry and not explicit_suite_basis:
+    if (
+        "stat" not in entry
+        and not explicit_suite_basis
+        and not applies_current_suite_aggregate
+    ):
         fallback = _resolve_candidate_metric_value(candidate, metric)
         if isinstance(fallback, (int, float)) and math.isfinite(float(fallback)):
             return float(fallback)

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -440,7 +440,10 @@ def _extract_suite_metrics(
                 continue
             aggregated = payload.get("aggregated")
             stats = payload.get("stats") or {}
-            if aggregated is None and isinstance(stats, Mapping):
+            if aggregate_cfg is not None and isinstance(stats, Mapping) and stats:
+                mode = resolve_aggregate_mode(str(metric), effective_aggregate_cfg)
+                aggregated = stats.get(mode, stats.get("mean"))
+            elif aggregated is None and isinstance(stats, Mapping):
                 mode = resolve_aggregate_mode(str(metric), effective_aggregate_cfg)
                 aggregated = stats.get(mode, stats.get("mean"))
             if isinstance(aggregated, (int, float)) and math.isfinite(float(aggregated)):
@@ -455,7 +458,15 @@ def _extract_suite_metrics(
         if isinstance(stats, Mapping):
             stats_flat.update(flatten_metric_stats(dict(stats)))
         aggregated = aggregate.get("aggregated") or {}
-        if isinstance(aggregated, Mapping):
+        if aggregate_cfg is not None and isinstance(stats, Mapping) and stats:
+            for metric, metric_stats in stats.items():
+                if not isinstance(metric_stats, Mapping):
+                    continue
+                mode = resolve_aggregate_mode(str(metric), effective_aggregate_cfg)
+                value = metric_stats.get(mode, metric_stats.get("mean"))
+                if isinstance(value, (int, float)) and math.isfinite(float(value)):
+                    aggregated_values[str(metric)] = float(value)
+        elif isinstance(aggregated, Mapping):
             for metric, value in aggregated.items():
                 if isinstance(value, (int, float)) and math.isfinite(float(value)):
                     aggregated_values[str(metric)] = float(value)
@@ -880,7 +891,9 @@ def _resolve_limit_value(
     )
     stats_flat = candidate.stats_flat
     aggregated_values = candidate.aggregated_values
-    if explicit_suite_basis:
+    if explicit_suite_basis or (
+        aggregate_cfg is not None and isinstance(candidate.entry.get("suite_metrics"), Mapping)
+    ):
         stats_flat, aggregated_values = _extract_suite_metrics(
             candidate.entry,
             aggregate_cfg=aggregate_cfg,
@@ -953,12 +966,20 @@ def filter_candidates(
         normalized_limits.extend(normalize_limit_entries(limits_payload))
     if limit_entries:
         normalized_limits.extend(parse_limit_cli_entries(list(limit_entries)))
-    normalized_limits = normalize_limit_entries(normalized_limits)
+    return filter_candidates_with_limits(candidates, normalized_limits)
+
+
+def filter_candidates_with_limits(
+    candidates: Sequence[ParetoCandidate],
+    limits: Sequence[Mapping[str, Any]],
+    *,
+    aggregate_cfg: Mapping[str, Any] | None = None,
+) -> tuple[List[ParetoCandidate], List[Dict[str, Any]]]:
+    normalized_limits = normalize_limit_entries(list(limits))
     enabled_limits = [entry for entry in normalized_limits if bool(entry.get("enabled", True))]
     if not enabled_limits:
         return list(candidates), enabled_limits
-    aggregate_cfg = None
-    if candidates:
+    if aggregate_cfg is None and candidates:
         backtest_cfg = candidates[0].entry.get("backtest")
         if isinstance(backtest_cfg, Mapping):
             aggregate_cfg = backtest_cfg.get("aggregate")

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -780,6 +780,23 @@ def test_preselect_starting_configs_uses_effective_aggregate_basis(tmp_path):
     assert len(selected_non_suite) == 1
 
 
+def test_active_suite_scenario_labels_use_canonical_fallbacks():
+    assert optimize._active_suite_scenario_labels(
+        {
+            "enabled": True,
+            "scenarios": [
+                {},
+                {"label": "named"},
+                {"label": ""},
+                {"label": None},
+            ],
+        }
+    ) == ["scenario_01", "named", "scenario_03", "scenario_04"]
+    assert optimize._active_suite_scenario_labels(
+        {"enabled": False, "scenarios": [{}]}
+    ) is None
+
+
 def test_optimize_parser_accepts_short_limit_alias():
     parser = optimize.build_command_parser(
         prog="passivbot optimize",

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -34,10 +34,12 @@ from optimize import (
     _record_individual_result,
     _register_exchange_data,
     _resolve_cli_limits_override,
+    _validate_starting_config_selection_args,
     _set_candidate_metrics,
     _terminate_optimizer_pool,
     _suite_config_implies_suite_mode,
     _format_objectives,
+    add_starting_config_selection_options,
     ea_mu_plus_lambda_stream,
     individual_to_config,
     config_to_individual,
@@ -53,6 +55,7 @@ from optimize import (
     ConstraintAwareFitness,
     ResultRecorder,
     install_anchored_fine_tune_plan,
+    preselect_starting_configs,
 )
 from multiprocessing_utils import ignore_sigint_in_worker
 from optimization.bounds import Bound
@@ -591,6 +594,117 @@ class TestResolveCliLimitsOverride:
         ]
 
 
+class TestStartingConfigSelectionArgs:
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"filter_starting_configs": True, "starting_configs_max": None},
+            {"filter_starting_configs": False, "starting_configs_max": 60},
+        ],
+    )
+    def test_selection_requires_starting_configs(self, kwargs):
+        parser = argparse.ArgumentParser()
+        args = argparse.Namespace(starting_configs=None, resume=None, **kwargs)
+
+        with pytest.raises(SystemExit):
+            _validate_starting_config_selection_args(parser, args)
+
+    def test_selection_is_incompatible_with_resume(self):
+        parser = argparse.ArgumentParser()
+        args = argparse.Namespace(
+            starting_configs="pareto",
+            resume="optimize_results/run",
+            filter_starting_configs=True,
+            starting_configs_max=None,
+        )
+
+        with pytest.raises(SystemExit):
+            _validate_starting_config_selection_args(parser, args)
+
+    @pytest.mark.parametrize("value", [0, -1])
+    def test_starting_configs_max_must_be_positive(self, value):
+        parser = argparse.ArgumentParser()
+        args = argparse.Namespace(
+            starting_configs="pareto",
+            resume=None,
+            filter_starting_configs=False,
+            starting_configs_max=value,
+        )
+
+        with pytest.raises(SystemExit):
+            _validate_starting_config_selection_args(parser, args)
+
+    def test_valid_selection_arguments_are_accepted(self):
+        parser = argparse.ArgumentParser()
+        args = argparse.Namespace(
+            starting_configs="pareto",
+            resume=None,
+            filter_starting_configs=True,
+            starting_configs_max=60,
+        )
+
+        _validate_starting_config_selection_args(parser, args)
+
+
+def test_preselect_starting_configs_extracts_selected_pareto_configs(tmp_path):
+    config = get_template_config()
+    config["optimize"]["scoring"] = [
+        {"metric": "adg_strategy_eq", "goal": "max"},
+        {"metric": "drawdown_worst_strategy_eq", "goal": "min"},
+    ]
+    config["optimize"]["limits"] = [
+        {
+            "metric": "adg_strategy_eq",
+            "penalize_if": "less_than_or_equal",
+            "value": 0.0015,
+        }
+    ]
+    pareto_dir = tmp_path / "pareto"
+    pareto_dir.mkdir()
+    for idx, adg in enumerate((0.001, 0.002)):
+        artifact = deepcopy(config)
+        artifact["metrics"] = {
+            "objectives": {
+                "adg_strategy_eq": adg,
+                "drawdown_worst_strategy_eq": 0.3 - idx * 0.1,
+            },
+            "stats": {
+                "adg_strategy_eq": {
+                    "mean": adg,
+                    "min": adg,
+                    "max": adg,
+                    "std": 0.0,
+                    "median": adg,
+                },
+                "drawdown_worst_strategy_eq": {
+                    "mean": 0.3 - idx * 0.1,
+                    "min": 0.3 - idx * 0.1,
+                    "max": 0.3 - idx * 0.1,
+                    "std": 0.0,
+                    "median": 0.3 - idx * 0.1,
+                },
+            },
+        }
+        artifact["bot"]["long"]["risk"]["total_wallet_exposure_limit"] = 1.0 + adg
+        (pareto_dir / f"candidate_{idx}.json").write_text(
+            json.dumps(artifact),
+            encoding="utf-8",
+        )
+
+    selected = preselect_starting_configs(
+        str(pareto_dir),
+        config,
+        filter_by_limits=True,
+        max_count=None,
+    )
+
+    assert len(selected) == 1
+    assert selected[0]["_starting_config_source"].endswith("candidate_1.json")
+    assert selected[0]["bot"]["long"]["risk"]["total_wallet_exposure_limit"] == pytest.approx(
+        1.002
+    )
+
+
 def test_optimize_parser_accepts_short_limit_alias():
     parser = optimize.build_command_parser(
         prog="passivbot optimize",
@@ -641,6 +755,20 @@ def test_optimize_parser_accepts_short_limit_alias():
     args = parser.parse_args(["-l", "adg_strategy_pnl_rebased > 0.0"])
 
     assert args.limit_entries == ["adg_strategy_pnl_rebased > 0.0"]
+
+
+@pytest.mark.parametrize(
+    "flag",
+    ["--compress-starting-configs", "--starting-configs-max"],
+)
+def test_optimize_parser_accepts_starting_config_preselection_options(flag):
+    parser = argparse.ArgumentParser()
+    add_starting_config_selection_options(parser)
+
+    args = parser.parse_args(["--filter-starting-configs", flag, "60"])
+
+    assert args.filter_starting_configs is True
+    assert args.starting_configs_max == 60
 
 
 def test_optimize_parser_accepts_nested_bound_flags_alongside_limit_alias():
@@ -759,6 +887,14 @@ def test_optimize_parser_accepts_polish_bounds_mode():
 
     assert args.polish_bounds_pct == 0.2
     assert args.polish_bounds_mode == "override-all"
+
+
+def test_starting_configs_option_is_visible_in_default_help():
+    parser = argparse.ArgumentParser()
+    optimize.add_extra_options(parser, help_all=False)
+
+    assert "-t STARTING_CONFIGS" in parser.format_help()
+    assert "--start STARTING_CONFIGS" in parser.format_help()
 
 
 class TestFormatObjectives:

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -696,6 +696,7 @@ def test_preselect_starting_configs_extracts_selected_pareto_configs(tmp_path):
         config,
         filter_by_limits=True,
         max_count=None,
+        aggregate_cfg=config["backtest"]["aggregate"],
     )
 
     assert len(selected) == 1
@@ -705,7 +706,7 @@ def test_preselect_starting_configs_extracts_selected_pareto_configs(tmp_path):
     )
 
 
-def test_preselect_starting_configs_uses_effective_suite_aggregate_override(tmp_path):
+def test_preselect_starting_configs_uses_effective_aggregate_basis(tmp_path):
     config = get_template_config()
     config["backtest"]["aggregate"] = {"default": "max"}
     config["optimize"]["scoring"] = [
@@ -762,11 +763,21 @@ def test_preselect_starting_configs_uses_effective_suite_aggregate_override(tmp_
         config,
         filter_by_limits=True,
         max_count=None,
-        aggregate_cfg_override={"default": "mean"},
+        aggregate_cfg={"default": "mean"},
     )
 
     assert len(selected) == 1
     assert selected[0]["_starting_config_source"].endswith("candidate.json")
+
+    selected_non_suite = preselect_starting_configs(
+        str(artifact_path),
+        config,
+        filter_by_limits=True,
+        max_count=None,
+        aggregate_cfg=None,
+    )
+
+    assert len(selected_non_suite) == 1
 
 
 def test_optimize_parser_accepts_short_limit_alias():

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -705,6 +705,70 @@ def test_preselect_starting_configs_extracts_selected_pareto_configs(tmp_path):
     )
 
 
+def test_preselect_starting_configs_uses_effective_suite_aggregate_override(tmp_path):
+    config = get_template_config()
+    config["backtest"]["aggregate"] = {"default": "max"}
+    config["optimize"]["scoring"] = [
+        {"metric": "adg_strategy_eq", "goal": "max"},
+        {"metric": "drawdown_worst_strategy_eq", "goal": "min"},
+    ]
+    config["optimize"]["limits"] = [
+        {
+            "metric": "drawdown_worst_strategy_eq",
+            "penalize_if": "greater_than",
+            "value": 0.5,
+        }
+    ]
+    artifact = deepcopy(config)
+    artifact["metrics"] = {
+        "objectives": {
+            "adg_strategy_eq": 0.002,
+            "drawdown_worst_strategy_eq": 0.8,
+        },
+        "stats": {
+            "adg_strategy_eq": {
+                "mean": 0.002,
+                "min": 0.002,
+                "max": 0.002,
+                "std": 0.0,
+                "median": 0.002,
+            },
+            "drawdown_worst_strategy_eq": {
+                "mean": 0.2,
+                "min": 0.2,
+                "max": 0.8,
+                "std": 0.3,
+                "median": 0.2,
+            },
+        },
+    }
+    artifact["suite_metrics"] = {
+        "metrics": {
+            "adg_strategy_eq": {
+                "aggregated": 0.002,
+                "stats": artifact["metrics"]["stats"]["adg_strategy_eq"],
+            },
+            "drawdown_worst_strategy_eq": {
+                "aggregated": 0.8,
+                "stats": artifact["metrics"]["stats"]["drawdown_worst_strategy_eq"],
+            },
+        }
+    }
+    artifact_path = tmp_path / "candidate.json"
+    artifact_path.write_text(json.dumps(artifact), encoding="utf-8")
+
+    selected = preselect_starting_configs(
+        str(artifact_path),
+        config,
+        filter_by_limits=True,
+        max_count=None,
+        aggregate_cfg_override={"default": "mean"},
+    )
+
+    assert len(selected) == 1
+    assert selected[0]["_starting_config_source"].endswith("candidate.json")
+
+
 def test_optimize_parser_accepts_short_limit_alias():
     parser = optimize.build_command_parser(
         prog="passivbot optimize",

--- a/tests/optimization/test_starting_config_selection.py
+++ b/tests/optimization/test_starting_config_selection.py
@@ -178,6 +178,28 @@ def test_filtering_resolves_auto_limit_direction_like_optimizer(
     }
 
 
+def test_filtering_rejects_unknown_auto_limit_metric(
+    sample_pareto_dir: Path,
+):
+    with pytest.raises(
+        ValueError,
+        match="unknown optimizer limit metric 'adg_strategy_eqq'",
+    ):
+        select_starting_config_artifacts(
+            str(sample_pareto_dir),
+            limits=[
+                {
+                    "metric": "adg_strategy_eqq",
+                    "penalize_if": "auto",
+                    "value": 0.0015,
+                }
+            ],
+            aggregate_cfg={"default": "mean"},
+            filter_by_limits=True,
+            max_count=None,
+        )
+
+
 def test_inside_range_filter_preserves_boundary_candidates(
     sample_pareto_dir: Path,
 ):

--- a/tests/optimization/test_starting_config_selection.py
+++ b/tests/optimization/test_starting_config_selection.py
@@ -135,6 +135,73 @@ def test_compression_without_filtering_uses_all_metric_bearing_candidates(
     ]
 
 
+def test_metric_preselection_accepts_one_pareto_artifact_and_ignores_siblings(
+    sample_pareto_dir: Path,
+):
+    (sample_pareto_dir / "ordinary_config.json").write_text(
+        json.dumps({"bot": {"long": {}, "short": {}}}),
+        encoding="utf-8",
+    )
+
+    result = select_starting_config_artifacts(
+        str(sample_pareto_dir / "middle.json"),
+        limits=[],
+        aggregate_cfg={"default": "mean"},
+        filter_by_limits=False,
+        max_count=None,
+    )
+
+    assert result.loaded_count == 1
+    assert [candidate.path.name for candidate in result.candidates] == ["middle.json"]
+
+
+def test_filtering_resolves_auto_limit_direction_like_optimizer(
+    sample_pareto_dir: Path,
+):
+    result = select_starting_config_artifacts(
+        str(sample_pareto_dir),
+        limits=[
+            {
+                "metric": "adg_strategy_eq",
+                "penalize_if": "auto",
+                "value": 0.0015,
+            }
+        ],
+        aggregate_cfg={"default": "mean"},
+        filter_by_limits=True,
+        max_count=None,
+    )
+
+    assert result.filtered_count == 3
+    assert "low_drawdown_anchor.json" not in {
+        candidate.path.name for candidate in result.candidates
+    }
+
+
+def test_inside_range_filter_preserves_boundary_candidates(
+    sample_pareto_dir: Path,
+):
+    result = select_starting_config_artifacts(
+        str(sample_pareto_dir),
+        limits=[
+            {
+                "metric": "drawdown_worst_strategy_eq",
+                "penalize_if": "inside_range",
+                "range": [0.10, 0.25],
+            }
+        ],
+        aggregate_cfg={"default": "mean"},
+        filter_by_limits=True,
+        max_count=None,
+    )
+
+    assert {candidate.path.name for candidate in result.candidates} == {
+        "low_drawdown_anchor.json",
+        "middle.json",
+        "adg_anchor.json",
+    }
+
+
 def test_filtering_recomputes_suite_aggregate_with_current_optimizer_default(
     tmp_path: Path,
 ):

--- a/tests/optimization/test_starting_config_selection.py
+++ b/tests/optimization/test_starting_config_selection.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from optimization.starting_config_selection import select_starting_config_artifacts
+
+
+def _metric_stats(*, mean: float, max_value: float | None = None) -> dict:
+    maximum = mean if max_value is None else max_value
+    return {
+        "mean": mean,
+        "min": mean,
+        "max": maximum,
+        "std": 0.0,
+        "median": mean,
+    }
+
+
+def _write_candidate(
+    pareto_dir: Path,
+    name: str,
+    *,
+    adg: float,
+    drawdown_mean: float,
+    drawdown_max: float | None = None,
+) -> None:
+    payload = {
+        "config_version": "v8.0.0",
+        "backtest": {"aggregate": {"default": "max"}},
+        "bot": {"long": {"risk": {"total_wallet_exposure_limit": 1.0 + adg}}},
+        "optimize": {
+            "scoring": [
+                {"metric": "adg_strategy_eq", "goal": "max"},
+                {"metric": "drawdown_worst_strategy_eq", "goal": "min"},
+            ]
+        },
+        "metrics": {
+            "objectives": {
+                "adg_strategy_eq": adg,
+                "drawdown_worst_strategy_eq": drawdown_mean,
+            },
+            "stats": {
+                "adg_strategy_eq": _metric_stats(mean=adg),
+                "drawdown_worst_strategy_eq": _metric_stats(
+                    mean=drawdown_mean,
+                    max_value=drawdown_max,
+                ),
+            },
+        },
+    }
+    (pareto_dir / f"{name}.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+@pytest.fixture()
+def sample_pareto_dir(tmp_path: Path) -> Path:
+    pareto_dir = tmp_path / "run" / "pareto"
+    pareto_dir.mkdir(parents=True)
+    _write_candidate(
+        pareto_dir,
+        "low_drawdown_anchor",
+        adg=0.001,
+        drawdown_mean=0.10,
+        drawdown_max=0.20,
+    )
+    _write_candidate(
+        pareto_dir,
+        "adg_anchor",
+        adg=0.004,
+        drawdown_mean=0.40,
+        drawdown_max=0.80,
+    )
+    _write_candidate(
+        pareto_dir,
+        "middle",
+        adg=0.002,
+        drawdown_mean=0.25,
+        drawdown_max=0.60,
+    )
+    _write_candidate(
+        pareto_dir,
+        "diverse_fill",
+        adg=0.003,
+        drawdown_mean=0.15,
+        drawdown_max=0.30,
+    )
+    return pareto_dir
+
+
+def test_filters_with_effective_aggregate_then_compresses_with_anchors_farthest(
+    sample_pareto_dir: Path,
+):
+    result = select_starting_config_artifacts(
+        str(sample_pareto_dir),
+        limits=[
+            {
+                "metric": "drawdown_worst_strategy_eq",
+                "penalize_if": "greater_than",
+                "value": 0.30,
+            }
+        ],
+        aggregate_cfg={"default": "mean"},
+        filter_by_limits=True,
+        max_count=2,
+    )
+
+    assert result.loaded_count == 4
+    assert result.filtered_count == 3
+    assert result.selected_count == 2
+    assert [candidate.path.name for candidate in result.candidates] == [
+        "diverse_fill.json",
+        "low_drawdown_anchor.json",
+    ]
+
+
+def test_compression_without_filtering_uses_all_metric_bearing_candidates(
+    sample_pareto_dir: Path,
+):
+    result = select_starting_config_artifacts(
+        str(sample_pareto_dir),
+        limits=[],
+        aggregate_cfg={"default": "mean"},
+        filter_by_limits=False,
+        max_count=2,
+    )
+
+    assert result.filtered_count == 4
+    assert result.selected_count == 2
+    assert [candidate.path.name for candidate in result.candidates] == [
+        "diverse_fill.json",
+        "adg_anchor.json",
+    ]
+
+
+def test_filtering_recomputes_suite_aggregate_with_current_optimizer_default(
+    tmp_path: Path,
+):
+    pareto_dir = tmp_path / "run" / "pareto"
+    pareto_dir.mkdir(parents=True)
+    _write_candidate(
+        pareto_dir,
+        "suite_candidate",
+        adg=0.002,
+        drawdown_mean=0.20,
+        drawdown_max=0.80,
+    )
+    artifact_path = pareto_dir / "suite_candidate.json"
+    artifact = json.loads(artifact_path.read_text())
+    artifact["suite_metrics"] = {
+        "metrics": {
+            "adg_strategy_eq": {
+                "aggregated": 0.002,
+                "stats": _metric_stats(mean=0.002),
+            },
+            "drawdown_worst_strategy_eq": {
+                "aggregated": 0.80,
+                "stats": _metric_stats(mean=0.20, max_value=0.80),
+            },
+        }
+    }
+    artifact_path.write_text(json.dumps(artifact), encoding="utf-8")
+
+    result = select_starting_config_artifacts(
+        str(pareto_dir),
+        limits=[
+            {
+                "metric": "drawdown_worst_strategy_eq",
+                "penalize_if": "greater_than",
+                "value": 0.50,
+            }
+        ],
+        aggregate_cfg={"default": "mean"},
+        filter_by_limits=True,
+        max_count=None,
+    )
+
+    assert result.selected_count == 1
+
+
+def test_metric_preselection_warns_that_artifacts_are_not_verified(
+    sample_pareto_dir: Path,
+    caplog,
+):
+    caplog.set_level(logging.WARNING)
+
+    select_starting_config_artifacts(
+        str(sample_pareto_dir),
+        limits=[],
+        aggregate_cfg={"default": "mean"},
+        filter_by_limits=False,
+        max_count=2,
+    )
+
+    assert "trusts stored Pareto metrics and objectives" in caplog.text
+    assert (
+        "coins, exchanges, date range, scenarios, or backtest settings" in caplog.text
+    )
+
+
+def test_metric_preselection_rejects_ordinary_seed_configs(sample_pareto_dir: Path):
+    (sample_pareto_dir / "ordinary_config.json").write_text(
+        json.dumps({"bot": {"long": {}, "short": {}}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="metric-bearing Pareto artifact"):
+        select_starting_config_artifacts(
+            str(sample_pareto_dir),
+            limits=[],
+            aggregate_cfg={"default": "mean"},
+            filter_by_limits=False,
+            max_count=2,
+        )
+
+
+def test_metric_preselection_rejects_directory_with_only_ordinary_configs(
+    tmp_path: Path,
+):
+    seeds_dir = tmp_path / "seeds"
+    seeds_dir.mkdir()
+    (seeds_dir / "ordinary_config.json").write_text(
+        json.dumps({"bot": {"long": {}, "short": {}}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="could not load complete metric-bearing Pareto artifacts"):
+        select_starting_config_artifacts(
+            str(seeds_dir),
+            limits=[],
+            aggregate_cfg={"default": "mean"},
+            filter_by_limits=False,
+            max_count=2,
+        )
+
+
+def test_metric_preselection_allows_pareto_compress_manifest(sample_pareto_dir: Path):
+    (sample_pareto_dir / "selection.json").write_text(
+        json.dumps({"selected_count": 4}),
+        encoding="utf-8",
+    )
+
+    result = select_starting_config_artifacts(
+        str(sample_pareto_dir),
+        limits=[],
+        aggregate_cfg={"default": "mean"},
+        filter_by_limits=False,
+        max_count=2,
+    )
+
+    assert result.loaded_count == 4
+
+
+def test_metric_preselection_fails_when_all_candidates_are_filtered(
+    sample_pareto_dir: Path,
+):
+    with pytest.raises(ValueError, match="No starting configs remained"):
+        select_starting_config_artifacts(
+            str(sample_pareto_dir),
+            limits=[
+                {
+                    "metric": "adg_strategy_eq",
+                    "penalize_if": "less_than_or_equal",
+                    "value": 1.0,
+                }
+            ],
+            aggregate_cfg={"default": "mean"},
+            filter_by_limits=True,
+            max_count=None,
+        )
+
+
+def test_metric_preselection_fails_when_limit_metric_is_missing(
+    sample_pareto_dir: Path,
+):
+    with pytest.raises(
+        ValueError, match="Limit metric 'missing_metric' could not be resolved"
+    ):
+        select_starting_config_artifacts(
+            str(sample_pareto_dir),
+            limits=[
+                {
+                    "metric": "missing_metric",
+                    "penalize_if": "greater_than",
+                    "value": 1.0,
+                }
+            ],
+            aggregate_cfg={"default": "mean"},
+            filter_by_limits=True,
+            max_count=None,
+        )

--- a/tests/optimization/test_starting_config_selection.py
+++ b/tests/optimization/test_starting_config_selection.py
@@ -269,6 +269,102 @@ def test_filtering_recomputes_suite_aggregate_with_current_optimizer_default(
     assert result.selected_count == 1
 
 
+def test_filtering_recomputes_aggregate_from_active_scenarios(tmp_path: Path):
+    pareto_dir = tmp_path / "run" / "pareto"
+    pareto_dir.mkdir(parents=True)
+    _write_candidate(
+        pareto_dir,
+        "suite_candidate",
+        adg=0.002,
+        drawdown_mean=0.50,
+        drawdown_max=0.80,
+    )
+    artifact_path = pareto_dir / "suite_candidate.json"
+    artifact = json.loads(artifact_path.read_text())
+    artifact["suite_metrics"] = {
+        "scenario_labels": ["base", "stress"],
+        "metrics": {
+            "adg_strategy_eq": {
+                "aggregated": 0.002,
+                "stats": _metric_stats(mean=0.002),
+                "scenarios": {"base": 0.002, "stress": 0.002},
+            },
+            "drawdown_worst_strategy_eq": {
+                "aggregated": 0.80,
+                "stats": _metric_stats(mean=0.50, max_value=0.80),
+                "scenarios": {"base": 0.20, "stress": 0.80},
+            },
+        },
+    }
+    artifact_path.write_text(json.dumps(artifact), encoding="utf-8")
+
+    result = select_starting_config_artifacts(
+        str(pareto_dir),
+        limits=[
+            {
+                "metric": "drawdown_worst_strategy_eq",
+                "penalize_if": "greater_than",
+                "value": 0.50,
+            }
+        ],
+        aggregate_cfg={"default": "max"},
+        scenario_labels=["base"],
+        filter_by_limits=True,
+        max_count=None,
+    )
+
+    assert result.selected_count == 1
+
+
+def test_filtering_rejects_artifact_missing_active_scenario_values(tmp_path: Path):
+    pareto_dir = tmp_path / "run" / "pareto"
+    pareto_dir.mkdir(parents=True)
+    _write_candidate(
+        pareto_dir,
+        "suite_candidate",
+        adg=0.002,
+        drawdown_mean=0.20,
+        drawdown_max=0.20,
+    )
+    artifact_path = pareto_dir / "suite_candidate.json"
+    artifact = json.loads(artifact_path.read_text())
+    artifact["suite_metrics"] = {
+        "scenario_labels": ["base"],
+        "metrics": {
+            "adg_strategy_eq": {
+                "aggregated": 0.002,
+                "stats": _metric_stats(mean=0.002),
+                "scenarios": {"base": 0.002},
+            },
+            "drawdown_worst_strategy_eq": {
+                "aggregated": 0.20,
+                "stats": _metric_stats(mean=0.20),
+                "scenarios": {"base": 0.20},
+            },
+        },
+    }
+    artifact_path.write_text(json.dumps(artifact), encoding="utf-8")
+
+    with pytest.raises(
+        ValueError,
+        match="Limit metric 'drawdown_worst_strategy_eq' could not be resolved",
+    ):
+        select_starting_config_artifacts(
+            str(pareto_dir),
+            limits=[
+                {
+                    "metric": "drawdown_worst_strategy_eq",
+                    "penalize_if": "greater_than",
+                    "value": 0.50,
+                }
+            ],
+            aggregate_cfg={"default": "max"},
+            scenario_labels=["stress"],
+            filter_by_limits=True,
+            max_count=None,
+        )
+
+
 def test_filtering_rejects_suite_artifact_missing_effective_aggregate_stat(
     tmp_path: Path,
 ):

--- a/tests/optimization/test_starting_config_selection.py
+++ b/tests/optimization/test_starting_config_selection.py
@@ -247,6 +247,49 @@ def test_filtering_recomputes_suite_aggregate_with_current_optimizer_default(
     assert result.selected_count == 1
 
 
+def test_filtering_rejects_suite_artifact_missing_effective_aggregate_stat(
+    tmp_path: Path,
+):
+    pareto_dir = tmp_path / "run" / "pareto"
+    pareto_dir.mkdir(parents=True)
+    _write_candidate(
+        pareto_dir,
+        "incomplete_suite_candidate",
+        adg=0.002,
+        drawdown_mean=0.20,
+        drawdown_max=0.20,
+    )
+    artifact_path = pareto_dir / "incomplete_suite_candidate.json"
+    artifact = json.loads(artifact_path.read_text())
+    artifact["suite_metrics"] = {
+        "aggregate": {
+            "aggregated": {
+                "adg_strategy_eq": 0.002,
+                "drawdown_worst_strategy_eq": 0.20,
+            }
+        }
+    }
+    artifact_path.write_text(json.dumps(artifact), encoding="utf-8")
+
+    with pytest.raises(
+        ValueError,
+        match="Limit metric 'drawdown_worst_strategy_eq' could not be resolved",
+    ):
+        select_starting_config_artifacts(
+            str(pareto_dir),
+            limits=[
+                {
+                    "metric": "drawdown_worst_strategy_eq",
+                    "penalize_if": "greater_than",
+                    "value": 0.50,
+                }
+            ],
+            aggregate_cfg={"default": "max"},
+            filter_by_limits=True,
+            max_count=None,
+        )
+
+
 def test_metric_preselection_warns_that_artifacts_are_not_verified(
     sample_pareto_dir: Path,
     caplog,

--- a/tests/test_limit_utils.py
+++ b/tests/test_limit_utils.py
@@ -69,6 +69,28 @@ def test_auto_penalize_if_respects_scoring_weight_sign():
     assert violation == (0.0005 - 0.0001) * 3
 
 
+def test_auto_limit_without_scoring_weight_is_ignored_after_validation():
+    entry = {"metric": "adg", "penalize_if": "auto", "value": 0.0005}
+    assert expand_limit_checks([entry], {}, penalty_weight=1000.0) == []
+
+
+def test_unknown_auto_limit_metric_raises_before_weight_lookup():
+    entry = {"metric": "adgg", "penalize_if": "auto", "value": 0.0005}
+
+    with pytest.raises(ValueError, match="unknown optimizer limit metric 'adgg'"):
+        expand_limit_checks([entry], {}, penalty_weight=1000.0)
+
+
+def test_disabled_unknown_auto_limit_is_skipped():
+    entry = {
+        "metric": "adgg",
+        "penalize_if": "auto",
+        "value": 0.0005,
+        "enabled": False,
+    }
+    assert expand_limit_checks([entry], {}, penalty_weight=1000.0) == []
+
+
 def test_disabled_limit_entry_is_skipped():
     entry = {
         "metric": "drawdown_worst",

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -528,6 +528,38 @@ def test_limit_entry_can_select_scenario_without_projecting_candidates(
     assert limits[0]["scenario"] == "bull"
 
 
+def test_ordinary_filter_uses_stored_legacy_suite_aggregate(tmp_path: Path):
+    pareto_dir = tmp_path / "legacy_suite" / "pareto"
+    pareto_dir.mkdir(parents=True)
+    payload = {
+        "optimize": {
+            "scoring": [
+                {"metric": "metric_a", "goal": "max"},
+                {"metric": "metric_b", "goal": "min"},
+            ]
+        },
+        "backtest": {"aggregate": {"default": "max"}},
+        "suite_metrics": {
+            "aggregate": {
+                "aggregated": {
+                    "metric_a": 0.8,
+                    "metric_b": 0.4,
+                }
+            }
+        },
+    }
+    (pareto_dir / "candidate.json").write_text(json.dumps(payload), encoding="utf-8")
+    _pareto_dir, candidates, _specs = load_candidates(pareto_dir)
+
+    filtered, _limits = filter_candidates(
+        candidates,
+        limits_payload=None,
+        limit_entries=["metric_b<0.5"],
+    )
+
+    assert [candidate.path.name for candidate in filtered] == ["candidate.json"]
+
+
 def test_explicit_null_limit_keeps_suite_aggregate_after_scenario_projection(
     scenario_pareto_dir: Path,
 ):


### PR DESCRIPTION
## Summary

- add `--filter-starting-configs` to filter metric-bearing `-t/--start` Pareto artifacts with the optimizer's final effective limits before seed extraction
- add `--compress-starting-configs N` (alias `--starting-configs-max N`) to reuse the canonical `anchors-farthest` Pareto compression algorithm in memory
- warn that stored seed metrics and objectives are not verified against the new run's coins, exchanges, dates, scenarios, or backtest settings
- fail loudly for ordinary/malformed/mixed seed JSON, unresolved limit metrics, zero survivors, invalid flag combinations, and non-positive compression counts
- keep ordinary `-t/--start` behavior unchanged when neither preselection option is present
- feed selected configs through the existing quantization, deduplication, fine-tune-anchor, backend evaluation, and survival paths
- document the intended restart-with-stricter-limits workflow and its provenance caveat

## Behavior

```shell
passivbot optimize configs/canon_opt.json \
  -t optimize_results/.../pareto \
  --filter-starting-configs \
  --compress-starting-configs 60 \
  -l 'adg_strategy_eq>0.0' \
  -l 'strategy_eq_recovery_days_max<100' \
  -l '{"metric":"strategy_eq_recovery_days_max","penalize_if":"greater_than","stat":"max","value":120}'
```

Filtering uses the final normalized `optimize.limits`, including config limits and CLI `--limits`, `--limit`, and `--clear-limits` changes. Omitted-stat suite limits use the new run's aggregate configuration and active scenario selection when the stored per-scenario statistics permit recomputation. Survivors are always re-evaluated normally.

The preselection flags intentionally reject ordinary seed configs. Operators should omit them when seed provenance is mixed or not comparable so every seed is evaluated before optimizer selection.

## Review follow-up

- load the effective `--suite-config` aggregate before starting-config filtering
- accept one metric-bearing Pareto JSON artifact as well as a directory, without validating unrelated sibling JSON files
- resolve legacy `penalize_if: auto` limits with the same scoring directions used by optimizer evaluation
- preserve `inside_range` boundary candidates because optimizer constraint violation is zero at either endpoint
- apply explicit `--suite` and `--scenarios` selection before preselection; when suite mode is disabled, use the non-suite evaluator's default `mean` basis instead of the configured suite aggregate
- require the requested effective suite statistic to be present when recomputing an omitted-stat limit, rather than silently substituting a stored aggregate or `mean`
- validate enabled `penalize_if: auto` metrics before an absent scoring weight may skip a valid unweighted limit, so unknown or misspelled metrics still fail loudly
- preserve stored aggregate-only legacy artifacts in ordinary `passivbot tool pareto` filtering instead of treating their own aggregate configuration as a caller-requested recomputation
- rebuild preselection aggregate statistics from the optimizer's active scenario labels, and fail loudly when an artifact cannot reproduce the selected scenario set
- derive active labels through the canonical suite builder so omitted, empty, and null labels use the same `scenario_NN` fallback during preselection and evaluation

## Dependency

This is a clean stacked PR targeting `codex/scenario-specific-optimize-limits` because the feature reuses PR #1423's canonical named-scenario/suite-stat limit resolver. Retarget to `master` after #1423 merges.

## Validation

- affected optimizer, backend, suite-limit, aggregation, Pareto, compression, dashboard, and config suite: 485 passed
- final preselection/Pareto compatibility slice after the original adjustment: 48 passed
- first review follow-up regression suite on the updated stacked base: 473 passed
- second review follow-up regression suite on the updated stacked base: 474 passed
- third review follow-up regression suite on the updated stacked base: 478 passed
- fourth review follow-up affected suite: 506 passed
- AI documentation and generated live-event registry checks passed (existing warning-only documentation size notices)
- Python compilation, CLI help, and `git diff --check` passed
- fail-loud CLI smoke rejected ordinary config seeds before data preparation with explicit re-evaluation guidance
- fail-loud CLI smoke rejected an unknown `auto` limit metric before data preparation and included metric-name suggestions
- real cached two-scenario optimizer smoke loaded 4 Pareto artifacts, retained 4 under effective limits, compressed to 2, re-evaluated exactly 2 starting configs, and completed all 4 evaluations
- real cached `--suite n` regression smoke supplied a suite override with `aggregate=max`, correctly filtered all 4 seeds using non-suite `mean`, re-evaluated all 4, and completed without network access
- real cached `--scenarios base` regression smoke used active-scenario `max` statistics, retained all 4 seeds where the stored all-scenario maximum would retain only 1, re-evaluated all 4, and completed all 4 evaluations

No private configs, optimizer results, credentials, or local artifacts are included.