### PR TITLE
Remove authoritative epoch mirror

### DIFF
--- a/docs/plans/live_logging_overhaul_plan.md
+++ b/docs/plans/live_logging_overhaul_plan.md
@@ -160,7 +160,8 @@ Compatibility mapping:
 - Current monitor `kind` maps to `event_type`.
 - Current monitor `payload` maps to `data`.
 - Current text tags map to `tags`.
-- `_authoritative_refresh_epoch` should become or feed `cycle_id`.
+- `FreshnessLedger.epoch` feeds authoritative cohort diagnostics; `cycle_id`
+  remains the separate execution-loop lifecycle correlation id.
 - `PlanningSnapshot.snapshot_id` should pass through unchanged.
 
 ## Event Registry

--- a/docs/plans/live_overengineering_audit_followup_plan.md
+++ b/docs/plans/live_overengineering_audit_followup_plan.md
@@ -47,6 +47,10 @@ verification and contract-specific regression coverage.
    and sets plus both unused generation counters were removed; pending
    post-write confirmation obligations and immutable planning snapshots remain
    separate because they represent distinct contracts.
+6. The scalar authoritative-refresh epoch mirror was removed. Refresh,
+   planning, reconciliation, snapshot stamping, and event diagnostics now read
+   the epoch directly from `FreshnessLedger`; execution-loop `cycle_id` remains
+   a separate observability lifecycle.
 
 ## Decision rules for further work
 
@@ -104,8 +108,8 @@ also removed after direct-caller and runtime analysis showed that the existing
 full-account `N+1` confirmation barrier always settled first in normal
 execution. The generic same-wave symbol latch remains because it also protects
 against late websocket changes and uncertain cancellation results. The scalar
-`_authoritative_refresh_epoch` compatibility alias remains a smaller follow-up
-candidate.
+authoritative-refresh epoch mirror was removed after verifying that it had no
+producer, invalidation rule, or consumer distinct from `FreshnessLedger.epoch`.
 
 ### 2. Fill and realized-PnL reconstruction
 

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -36,6 +36,11 @@ def current_live_event_cycle_id(bot: Any) -> str | None:
     return getattr(bot, "_live_event_current_cycle_id", None)
 
 
+def _freshness_epoch(bot: Any) -> int:
+    """Return the ledger epoch for diagnostics without creating trading state."""
+    return int(getattr(getattr(bot, "freshness_ledger", None), "epoch", 0) or 0)
+
+
 def set_live_event_context_ids(bot: Any, **kwargs: str | None) -> None:
     pipeline = getattr(bot, "_live_event_pipeline", None)
     if pipeline is None or not callable(getattr(pipeline, "with_context_ids", None)):
@@ -725,7 +730,7 @@ def _emit_authoritative_remote_call_event_unchecked(
     stage = str(stage or "").lower()
     surface = str(surface or "unknown")
     cycle_id = current_live_event_cycle_id(bot)
-    authoritative_epoch = int(getattr(bot, "_authoritative_refresh_epoch", 0) or 0)
+    authoritative_epoch = _freshness_epoch(bot)
     remote_call_group_id = (
         f"{cycle_id}:authoritative" if cycle_id else f"auth_{authoritative_epoch}:authoritative"
     )
@@ -1018,9 +1023,7 @@ def begin_live_event_cycle(bot: Any, *, loop_start_ms: int) -> str:
         status="started",
         data={
             "loop_start_ms": int(loop_start_ms),
-            "authoritative_epoch": int(
-                getattr(bot, "_authoritative_refresh_epoch", 0) or 0
-            ),
+            "authoritative_epoch": _freshness_epoch(bot),
         },
     )
     return cycle_id
@@ -1046,9 +1049,7 @@ def emit_live_cycle_completed(
         data={
             "elapsed_ms": elapsed_ms,
             "timings_ms": dict(timings_ms or {}),
-            "authoritative_epoch": int(
-                getattr(bot, "_authoritative_refresh_epoch", 0) or 0
-            ),
+            "authoritative_epoch": _freshness_epoch(bot),
             "orders_changed": bool(getattr(bot, "execution_scheduled", False)),
         },
     )
@@ -1068,9 +1069,7 @@ def emit_live_cycle_degraded(
     if not cycle_id:
         return
     payload = _sanitize_cycle_degraded_payload(dict(data or {}))
-    payload["authoritative_epoch"] = int(
-        getattr(bot, "_authoritative_refresh_epoch", 0) or 0
-    )
+    payload["authoritative_epoch"] = _freshness_epoch(bot)
     bot._emit_live_event(
         EventTypes.CYCLE_DEGRADED,
         level=level,
@@ -4437,7 +4436,7 @@ def emit_execution_confirmation_requested_event(
         data = {
             "surfaces": sorted(str(surface) for surface in surfaces),
             "target_epoch": int(target_epoch),
-            "current_epoch": int(getattr(bot, "_authoritative_refresh_epoch", 0) or 0),
+            "current_epoch": _freshness_epoch(bot),
             "min_epoch": int(min_epoch) if min_epoch is not None else None,
         }
         _add_execution_debug_profile(

--- a/src/live/market_data.py
+++ b/src/live/market_data.py
@@ -692,7 +692,6 @@ def record_market_snapshot_surface(
         "market_snapshot",
         bot._market_snapshot_signature(symbols, snapshots),
         now_ms=_utc_ms(),
-        epoch=int(getattr(bot, "_authoritative_refresh_epoch", 0) or 0),
     )
 
 

--- a/src/live/planning_gates.py
+++ b/src/live/planning_gates.py
@@ -35,7 +35,7 @@ def staged_planner_surface_min_epochs(
     bot, required: set[str] | frozenset[str]
 ) -> dict[str, int]:
     """Return minimum acceptable ledger epoch per staged planner input surface."""
-    current_epoch = int(getattr(bot, "_authoritative_refresh_epoch", 0) or 0)
+    current_epoch = int(bot._ensure_freshness_ledger().epoch)
     pending = dict(getattr(bot, "_authoritative_pending_confirmations", {}) or {})
     min_epochs: dict[str, int] = {}
     for surface in required:
@@ -110,7 +110,7 @@ def staged_planner_precondition_state(
     return not missing, {
         "missing": sorted(set(missing)),
         "required": sorted(required),
-        "epoch": int(getattr(bot, "_authoritative_refresh_epoch", 0) or 0),
+        "epoch": int(ledger.epoch),
         "min_epochs": min_epochs,
         "invalid": invalid,
     }
@@ -449,7 +449,7 @@ def build_protective_planning_snapshot(
     )
     required = frozenset({"balance", "positions", "open_orders", "market_snapshot"})
     ledger = bot._ensure_freshness_ledger()
-    current_epoch = int(getattr(bot, "_authoritative_refresh_epoch", 0) or 0)
+    current_epoch = int(ledger.epoch)
     required_epoch = max(1, current_epoch)
     min_epochs = {surface: required_epoch for surface in required}
     missing = sorted(

--- a/src/live/reconciler.py
+++ b/src/live/reconciler.py
@@ -897,7 +897,7 @@ def mark_account_critical_state_dirty(
     level: int = logging.DEBUG,
 ) -> None:
     """Force a coherent account-state refresh before the next execution cycle."""
-    min_epoch = int(getattr(bot, "_authoritative_refresh_epoch", 0) or 0) + 1
+    min_epoch = int(bot._ensure_freshness_ledger().epoch) + 1
     bot._request_authoritative_confirmation(ACCOUNT_SURFACES, min_epoch=min_epoch)
     bot.execution_scheduled = True
     normalized_symbols = sorted({str(symbol) for symbol in (symbols or []) if symbol})

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -1219,7 +1219,6 @@ class Passivbot:
         self.state_change_detected_by_symbol = set()
         self.recent_order_executions = []
         self.recent_order_cancellations = []
-        self._authoritative_refresh_epoch = 0
         self._authoritative_refresh_plan_surfaces = set()
         self._authoritative_pending_confirmations = {}
         self._trailing_fill_refresh_started_generation = 0
@@ -10338,8 +10337,7 @@ class Passivbot:
 
     def _begin_authoritative_refresh_epoch(self) -> None:
         """Start a new authoritative state refresh cohort for execution gating."""
-        ledger = self._ensure_freshness_ledger()
-        self._authoritative_refresh_epoch = ledger.begin_epoch(now_ms=utc_ms())
+        self._ensure_freshness_ledger().begin_epoch(now_ms=utc_ms())
 
     def _record_authoritative_surface(self, surface: str, signature) -> bool:
         """Record a fresh authoritative surface snapshot and whether it changed."""
@@ -10426,9 +10424,6 @@ class Passivbot:
         ledger = getattr(self, "freshness_ledger", None)
         if ledger is None:
             ledger = FreshnessLedger(now_ms=utc_ms())
-            ledger.epoch = int(
-                getattr(self, "_authoritative_refresh_epoch", 0) or 0
-            )
             self.freshness_ledger = ledger
         return ledger
 
@@ -10457,7 +10452,7 @@ class Passivbot:
         response_received_ts_ms: int,
     ) -> None:
         """Stage fetch metadata for account-critical packets without mutating trading state."""
-        cycle_hint = int(getattr(self, "_authoritative_refresh_epoch", 0) or 0)
+        cycle_hint = int(self._ensure_freshness_ledger().epoch)
         source = f"{getattr(self, 'exchange', '') or 'exchange'}.staged_refresh"
 
         def stage(kind: str, value, raw_payload=None) -> None:
@@ -10527,7 +10522,7 @@ class Passivbot:
                 kind=surface,
                 value=signature,
                 raw_payload=None,
-                cycle_hint=int(getattr(self, "_authoritative_refresh_epoch", 0) or 0),
+                cycle_hint=int(self._ensure_freshness_ledger().epoch),
                 response_received_ts_ms=utc_ms(),
                 source="authoritative_surface",
                 quality="ok",
@@ -10535,7 +10530,7 @@ class Passivbot:
             )
         packet = pending.with_revision(
             revision,
-            cycle_hint=int(getattr(self, "_authoritative_refresh_epoch", 0) or 0),
+            cycle_hint=int(self._ensure_freshness_ledger().epoch),
         )
         self._live_data_packets[surface] = packet
         emit_diagnostic_event(
@@ -10806,7 +10801,7 @@ class Passivbot:
         target_epoch = int(
             min_epoch
             if min_epoch is not None
-            else int(getattr(self, "_authoritative_refresh_epoch", 0) or 0) + 1
+            else int(self._ensure_freshness_ledger().epoch) + 1
         )
         current_wave = getattr(self, "_order_wave_in_progress", None)
         if isinstance(current_wave, dict):
@@ -20615,7 +20610,6 @@ class Passivbot:
                 "completed_candles",
                 signature,
                 now_ms=now,
-                epoch=int(getattr(self, "_authoritative_refresh_epoch", 0) or 0),
             )
             return True
         except Exception as e:

--- a/tests/test_exchange_config_updates.py
+++ b/tests/test_exchange_config_updates.py
@@ -734,6 +734,7 @@ async def test_execute_to_exchange_allows_cancellations_when_balance_too_low(
             pb_mod.Passivbot._emit_execution_create_filter_event
         )
         _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _ensure_freshness_ledger = pb_mod.Passivbot._ensure_freshness_ledger
         _live_event_console_available = pb_mod.Passivbot._live_event_console_available
         _shutdown_requested = pb_mod.Passivbot._shutdown_requested
 
@@ -830,6 +831,7 @@ async def test_low_balance_create_skip_uses_event_console_when_available(caplog)
             pb_mod.Passivbot._emit_execution_create_filter_event
         )
         _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _ensure_freshness_ledger = pb_mod.Passivbot._ensure_freshness_ledger
         _live_event_console_available = pb_mod.Passivbot._live_event_console_available
         _shutdown_requested = pb_mod.Passivbot._shutdown_requested
 

--- a/tests/test_foreign_passivbot_detection.py
+++ b/tests/test_foreign_passivbot_detection.py
@@ -25,6 +25,7 @@ async def test_execute_orders_parent_tracks_acknowledged_custom_id():
         _order_identity_fingerprint = pb_mod.Passivbot._order_identity_fingerprint
         _build_emitted_order_record = pb_mod.Passivbot._build_emitted_order_record
         _emitted_order_records = pb_mod.Passivbot._emitted_order_records
+        _ensure_freshness_ledger = pb_mod.Passivbot._ensure_freshness_ledger
         _is_market_execution_order = staticmethod(
             pb_mod.Passivbot._is_market_execution_order
         )

--- a/tests/test_fresh_entry_eligibility_integration.py
+++ b/tests/test_fresh_entry_eligibility_integration.py
@@ -195,6 +195,8 @@ async def test_malformed_open_order_snapshot_blocks_every_account_action():
 
 
 class _CreateBot:
+    _ensure_freshness_ledger = Passivbot._ensure_freshness_ledger
+
     def __init__(self, trace: FreshEntryEligibilityTrace):
         self._fresh_entry_eligibility_trace = trace
         self._order_wave_in_progress = {"event_id": "ow_1"}

--- a/tests/test_hyperliquid_balance_cache.py
+++ b/tests/test_hyperliquid_balance_cache.py
@@ -1335,7 +1335,6 @@ async def test_refresh_authoritative_state_staged_hyperliquid_publishes_final_ba
     bot.positions = {}
     bot.fetched_positions = []
     bot.fetched_open_orders = []
-    bot._authoritative_refresh_epoch = 0
     bot.state_change_detected_by_symbol = set()
     bot.execution_scheduled = False
     bot.recent_order_cancellations = []

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -95,7 +95,6 @@ def _set_authoritative_epoch_state(
         signature = (surface, "changed" if surface in changed else "baseline")
         ledger.stamp(surface, signature, now_ms=2, epoch=epoch)
     bot.freshness_ledger = ledger
-    bot._authoritative_refresh_epoch = int(epoch)
     return ledger
 
 
@@ -693,7 +692,6 @@ def _counted_staged_account_refresh_bot(
     bot.active_symbols = []
     bot.state_change_detected_by_symbol = set()
     bot.execution_scheduled = False
-    bot._authoritative_refresh_epoch = 0
     bot._authoritative_pending_confirmations = dict(pending_confirmations or {})
     bot.freshness_ledger = FreshnessLedger(now_ms=0)
     bot.recent_order_cancellations = []
@@ -845,7 +843,7 @@ async def test_data_packet_capture_failure_does_not_block_authoritative_fetch(ca
 def test_balance_data_packet_capture_accepts_legacy_raw_normalized_pair():
     bot = Passivbot.__new__(Passivbot)
     bot.exchange = "legacy"
-    bot._authoritative_refresh_epoch = 7
+    _set_authoritative_epoch_state(bot, epoch=7)
     raw_balance = {"total": {"USDT": 123.45}, "raw_revision": "legacy-pair"}
 
     bot._capture_live_data_packet_fetch_metadata(
@@ -890,15 +888,14 @@ def test_authoritative_surface_record_survives_data_packet_finalize_failure():
     assert bot.freshness_ledger.surface_epoch("balance") == 1
 
 
-def test_freshness_ledger_bootstraps_legacy_authoritative_epoch_alias():
+def test_freshness_ledger_is_only_authoritative_epoch_owner():
     bot = Passivbot.__new__(Passivbot)
-    bot._authoritative_refresh_epoch = 7
+    ledger = _set_authoritative_epoch_state(bot, epoch=7)
 
-    ledger = bot._ensure_freshness_ledger()
     bot._begin_authoritative_refresh_epoch()
 
     assert ledger.epoch == 8
-    assert bot._authoritative_refresh_epoch == 8
+    assert not hasattr(bot, "_authoritative_refresh_epoch")
 
 
 @pytest.mark.asyncio
@@ -933,7 +930,7 @@ async def test_staged_orchestrator_market_snapshot_fetch_uses_headroom_ttl():
     assert snapshots[symbol].last == 100.5
     assert (
         bot.freshness_ledger.surface_epoch("market_snapshot")
-        == bot._authoritative_refresh_epoch
+        == bot.freshness_ledger.epoch
     )
     assert bot._market_snapshot_signature_invalid([symbol]) == []
 
@@ -3835,7 +3832,7 @@ def _set_pnl_lookback(bot, *, lookback_days: float, now_ms: int) -> None:
 def test_handle_order_update_logs_summary_and_dedupes(caplog, monkeypatch):
     bot = Passivbot.__new__(Passivbot)
     bot.execution_scheduled = False
-    bot._authoritative_refresh_epoch = 0
+    _set_authoritative_epoch_state(bot, epoch=0)
     now = [1000.0]
 
     monkeypatch.setattr(time, "time", lambda: now[0])
@@ -3934,7 +3931,7 @@ def test_handle_order_update_cancel_hint_requests_full_confirmation(
 ):
     bot = Passivbot.__new__(Passivbot)
     bot.execution_scheduled = False
-    bot._authoritative_refresh_epoch = 7
+    _set_authoritative_epoch_state(bot, epoch=7)
     bot.state_change_detected_by_symbol = set()
     bot.recent_order_cancellations = []
 
@@ -3972,7 +3969,7 @@ def test_handle_order_update_fill_hint_requests_full_confirmation(caplog, monkey
     bot = Passivbot.__new__(Passivbot)
     bot.execution_scheduled = False
     bot._authoritative_pending_confirmations = {"open_orders": 1}
-    bot._authoritative_refresh_epoch = 4
+    _set_authoritative_epoch_state(bot, epoch=4)
     now = [1000.0]
 
     monkeypatch.setattr(time, "time", lambda: now[0])
@@ -4270,7 +4267,7 @@ def test_order_wave_settlement_logs_authoritative_confirmation(monkeypatch, capl
         [{"symbol": "BTC/USDT:USDT"}],
         [{"symbol": "ETH/USDT:USDT"}],
     )
-    bot._authoritative_refresh_epoch = 4
+    _set_authoritative_epoch_state(bot, epoch=4)
     bot._authoritative_pending_confirmations = {}
     bot._order_wave_in_progress = wave
     bot._request_authoritative_confirmation({"open_orders"})
@@ -4320,7 +4317,7 @@ def test_order_wave_settlement_uses_event_console_when_available(monkeypatch, ca
         [{"symbol": "BTC/USDT:USDT"}],
         [{"symbol": "ETH/USDT:USDT"}],
     )
-    bot._authoritative_refresh_epoch = 4
+    _set_authoritative_epoch_state(bot, epoch=4)
     bot._authoritative_pending_confirmations = {}
     bot._order_wave_in_progress = wave
     bot._request_authoritative_confirmation({"open_orders"})
@@ -7103,7 +7100,7 @@ async def test_refresh_authoritative_state_staged_applies_fake_snapshots():
     bot.active_symbols = []
     bot.state_change_detected_by_symbol = set()
     bot.execution_scheduled = False
-    bot._authoritative_refresh_epoch = 0
+    _set_authoritative_epoch_state(bot, epoch=0)
     bot.recent_order_cancellations = []
     bot.fetch_balance = AsyncMock(return_value=123.45)
     bot.fetch_positions = AsyncMock(
@@ -7303,7 +7300,7 @@ async def test_refresh_authoritative_state_staged_applies_bybit_snapshots():
     bot.active_symbols = []
     bot.state_change_detected_by_symbol = set()
     bot.execution_scheduled = False
-    bot._authoritative_refresh_epoch = 0
+    _set_authoritative_epoch_state(bot, epoch=0)
     bot.recent_order_cancellations = []
     seen = {}
 
@@ -7393,7 +7390,7 @@ async def test_refresh_authoritative_state_staged_uses_generic_staged_fetch_for_
     _disable_entry_cooldown_delta_guard_for_staged_refresh_test(bot)
     bot.exchange = "binance"
     bot.stop_signal_received = False
-    bot._authoritative_refresh_epoch = 0
+    _set_authoritative_epoch_state(bot, epoch=0)
     bot.fetch_balance = AsyncMock(return_value=100.0)
     bot.fetch_positions = AsyncMock(return_value=[])
     bot.fetch_open_orders = AsyncMock(return_value=[])
@@ -7432,7 +7429,7 @@ async def test_refresh_protective_authoritative_state_uses_account_critical_surf
     bot.stop_signal_received = False
     bot.positions = {}
     bot.open_orders = {}
-    bot._authoritative_refresh_epoch = 0
+    _set_authoritative_epoch_state(bot, epoch=0)
     bot.balance_override = None
     bot._balance_override_logged = False
     bot.previous_hysteresis_balance = None
@@ -7528,7 +7525,7 @@ def test_protective_planning_snapshot_requires_balance_not_fills_or_candles():
     bot = Passivbot.__new__(Passivbot)
     bot.exchange = "binance"
     bot.config_get = lambda keys: None
-    bot._authoritative_refresh_epoch = 1
+    _set_authoritative_epoch_state(bot, epoch=1)
     bot._authoritative_pending_confirmations = {
         "balance": 2,
         "positions": 2,
@@ -9525,7 +9522,7 @@ def test_completed_candle_signature_ignores_later_cache_improvements():
         "completed_candles",
         ((symbol, 60_000),),
         now_ms=stamp_ms,
-        epoch=bot._authoritative_refresh_epoch,
+        epoch=bot.freshness_ledger.epoch,
     )
 
     ok, details = bot._staged_planner_precondition_state(include_market_snapshot=False)
@@ -9582,7 +9579,7 @@ def test_staged_planner_preconditions_validate_candles_at_surface_stamp_time():
         "completed_candles",
         stamped_signature,
         now_ms=stamp_ms,
-        epoch=bot._authoritative_refresh_epoch,
+        epoch=bot.freshness_ledger.epoch,
     )
 
     ok, details = bot._staged_planner_precondition_state(include_market_snapshot=False)
@@ -9627,7 +9624,7 @@ def test_staged_planner_preconditions_allow_tail_fallback_shape_recovery():
         "completed_candles",
         stamped_signature,
         now_ms=stamp_ms,
-        epoch=bot._authoritative_refresh_epoch,
+        epoch=bot.freshness_ledger.epoch,
     )
 
     ok, details = bot._staged_planner_precondition_state(include_market_snapshot=False)
@@ -10102,7 +10099,7 @@ async def test_pre_create_snapshot_filter_blocks_stale_market_snapshots(caplog):
     bot.config = {"live": {}}
     bot.exchange = "bybit"
     bot.freshness_ledger = FreshnessLedger(now_ms=0)
-    bot._authoritative_refresh_epoch = 1
+    bot.freshness_ledger.epoch = 1
     sink = ListEventSink()
     monitor_sink = ListEventSink()
     console_sink = ListEventSink()
@@ -10205,7 +10202,7 @@ async def test_pre_create_snapshot_filter_emits_failed_refresh_skip_event(caplog
     bot.config = {"live": {}}
     bot.exchange = "bybit"
     bot.freshness_ledger = FreshnessLedger(now_ms=0)
-    bot._authoritative_refresh_epoch = 1
+    bot.freshness_ledger.epoch = 1
     sink = ListEventSink()
     monitor_sink = ListEventSink()
     console_sink = ListEventSink()
@@ -10302,7 +10299,7 @@ async def test_pre_create_snapshot_filter_refreshes_stale_planning_market_snapsh
     bot.config = {"live": {}}
     bot.exchange = "bybit"
     bot.freshness_ledger = FreshnessLedger(now_ms=0)
-    bot._authoritative_refresh_epoch = 1
+    bot.freshness_ledger.epoch = 1
     symbol = "BTC/USDT:USDT"
     now_ms = passivbot_module.utc_ms()
     bot._current_planning_snapshot = PlanningSnapshot(
@@ -10364,7 +10361,7 @@ def _make_pre_create_distance_guard_bot(
     bot.config = {"live": {"limit_order_create_max_market_dist_pct": threshold}}
     bot.exchange = "bybit"
     bot.freshness_ledger = FreshnessLedger(now_ms=0)
-    bot._authoritative_refresh_epoch = 1
+    bot.freshness_ledger.epoch = 1
     now_ms = passivbot_module.utc_ms()
     bot._current_planning_snapshot = PlanningSnapshot(
         ts_ms=now_ms,
@@ -10827,7 +10824,6 @@ def _make_open_order_snapshot_bot(*, epoch: int = 3):
     bot = Passivbot.__new__(Passivbot)
     bot.freshness_ledger = FreshnessLedger(now_ms=0)
     bot.freshness_ledger.epoch = epoch
-    bot._authoritative_refresh_epoch = epoch
     bot._authoritative_pending_confirmations = {}
     bot.execution_scheduled = False
     bot.state_change_detected_by_symbol = set()
@@ -11868,7 +11864,6 @@ async def test_run_execution_loop_retries_fill_history_coverage_without_restart(
     bot.positions = {}
     bot.open_orders = {}
     bot.PB_modes = {"long": {}, "short": {}}
-    bot._authoritative_refresh_epoch = 0
     bot._authoritative_pending_confirmations = {}
     bot.freshness_ledger = FreshnessLedger(now_ms=0)
     bot._equity_hard_stop_enabled = lambda *args, **kwargs: False
@@ -13220,7 +13215,7 @@ async def test_refresh_authoritative_state_staged_uses_open_orders_only_confirma
     bot.active_symbols = []
     bot.state_change_detected_by_symbol = set()
     bot.execution_scheduled = False
-    bot._authoritative_refresh_epoch = 0
+    _set_authoritative_epoch_state(bot, epoch=0)
     bot._authoritative_pending_confirmations = {"open_orders": 1}
     bot.recent_order_cancellations = []
     bot.recent_order_executions = [

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -268,7 +268,7 @@ def test_live_event_cycle_helpers_emit_structured_events():
             self.exchange = "okx"
             self.user = "okx_01"
             self.bot_id = "bot_1"
-            self._authoritative_refresh_epoch = 7
+            self.freshness_ledger = SimpleNamespace(epoch=7)
             self.execution_scheduled = True
             self._live_event_cycle_seq = 0
             self._live_event_pipeline = LiveEventPipeline(
@@ -3871,7 +3871,7 @@ async def test_authoritative_timed_fetch_emits_correlated_remote_call_events():
             self.user = "kucoin_01"
             self.bot_id = "bot_1"
             self._live_event_current_cycle_id = "cy_11"
-            self._authoritative_refresh_epoch = 17
+            self.freshness_ledger = SimpleNamespace(epoch=17)
             self._authoritative_pending_confirmations = {"open_orders": 18}
             self._live_event_remote_call_seq = 0
             self._live_event_pipeline = LiveEventPipeline(
@@ -3929,7 +3929,7 @@ async def test_remote_call_debug_profile_adds_authoritative_payload_shape():
             self.bot_id = "bot_1"
             self.live_event_debug_profiles = ("remote_calls",)
             self._live_event_current_cycle_id = "cy_12"
-            self._authoritative_refresh_epoch = 21
+            self.freshness_ledger = SimpleNamespace(epoch=21)
             self._authoritative_pending_confirmations = {"open_orders": 22}
             self._live_event_remote_call_seq = 0
             self._live_event_pipeline = LiveEventPipeline(
@@ -3978,7 +3978,7 @@ async def test_authoritative_timed_fetch_failure_emits_classification_only():
             self.user = "kucoin_01"
             self.bot_id = "bot_1"
             self._live_event_current_cycle_id = None
-            self._authoritative_refresh_epoch = 19
+            self.freshness_ledger = SimpleNamespace(epoch=19)
             self._authoritative_pending_confirmations = {}
             self._live_event_remote_call_seq = 0
             self._live_event_pipeline = LiveEventPipeline(
@@ -4021,7 +4021,7 @@ async def test_authoritative_timed_fetch_emit_failure_does_not_skip_fetch():
             self.user = "kucoin_01"
             self.bot_id = "bot_1"
             self._live_event_current_cycle_id = "cy_12"
-            self._authoritative_refresh_epoch = 20
+            self.freshness_ledger = SimpleNamespace(epoch=20)
             self._authoritative_pending_confirmations = {}
             self._live_event_remote_call_seq = 0
             self.fetch_called = False
@@ -4056,7 +4056,7 @@ async def test_authoritative_timed_fetch_emit_failure_preserves_fetch_exception(
             self.user = "kucoin_01"
             self.bot_id = "bot_1"
             self._live_event_current_cycle_id = "cy_13"
-            self._authoritative_refresh_epoch = 21
+            self.freshness_ledger = SimpleNamespace(epoch=21)
             self._authoritative_pending_confirmations = {}
             self._live_event_remote_call_seq = 0
 
@@ -5222,6 +5222,7 @@ async def test_execute_orders_parent_records_order_opened_event():
             pb_mod.Passivbot._is_market_execution_order
         )
         _log_market_execution_notice = pb_mod.Passivbot._log_market_execution_notice
+        _ensure_freshness_ledger = pb_mod.Passivbot._ensure_freshness_ledger
 
         def __init__(self):
             self.monitor_publisher = RecorderPublisher()
@@ -5232,6 +5233,8 @@ async def test_execute_orders_parent_records_order_opened_event():
             self.bot_id = "bot_1"
             self._live_event_current_cycle_id = "cy_11"
             self._order_wave_in_progress = {"id": 7, "event_id": "ow_7"}
+            self.freshness_ledger = SimpleNamespace(epoch=0)
+            self._authoritative_pending_confirmations = {}
             self._live_event_pipeline = LiveEventPipeline(
                 structured_sinks=[sink],
                 monitor_sinks=[],
@@ -5698,6 +5701,7 @@ async def test_execute_cancellations_parent_emits_ambiguous_confirmation_events(
         _request_authoritative_confirmation = (
             pb_mod.Passivbot._request_authoritative_confirmation
         )
+        _ensure_freshness_ledger = pb_mod.Passivbot._ensure_freshness_ledger
         _cancel_result_requires_full_authoritative_confirmation = (
             pb_mod.Passivbot._cancel_result_requires_full_authoritative_confirmation
         )
@@ -5709,7 +5713,7 @@ async def test_execute_cancellations_parent_emits_ambiguous_confirmation_events(
             self.live_event_debug_profiles = ("execution",)
             self._live_event_current_cycle_id = "cy_12"
             self._authoritative_pending_confirmations = {}
-            self._authoritative_refresh_epoch = 4
+            self.freshness_ledger = SimpleNamespace(epoch=4)
             self._order_wave_in_progress = {"id": 9, "event_id": "ow_9"}
             self._health_orders_cancelled = 0
             self.state_change_detected_by_symbol = set()


### PR DESCRIPTION
## Summary

- remove the duplicate `_authoritative_refresh_epoch` scalar mirror
- make `FreshnessLedger.epoch` the sole authoritative refresh-cohort owner across planning, reconciliation, packet stamping, and diagnostics
- keep execution-loop `cycle_id` separate and update the audit/logging plans to record that ownership
- migrate partial-bot fixtures to the canonical ledger contract

This is intended to preserve behavior while eliminating compatibility state that had no distinct producer, invalidation rule, or consumer.

## Validation

- `tests/test_passivbot_balance_split.py tests/test_passivbot_monitor.py tests/test_hyperliquid_balance_cache.py`
- `tests/test_freshness_ledger.py tests/test_fresh_entry_eligibility_integration.py tests/test_exchange_config_updates.py tests/test_order_orchestration.py tests/test_order_churn_cancel_first.py`
- `tests/test_unstucking_safeguards.py tests/test_live_candle_budget.py`
- `tests/test_foreign_passivbot_detection.py`
- `tests/test_ai_docs.py tests/test_live_event_registry_docs.py tests/test_maintainer_logging.py tests/test_logging_setup.py`
- `src/tools/check_ai_docs.py` (0 errors; two pre-existing documentation-size warnings)
- `src/tools/generate_live_event_registry.py --check`
- `git diff --check`

A full local pytest collection was also attempted, but the shared virtual environment's loaded Rust extension fingerprint does not match this isolated worktree's unchanged Rust source. The PR contains no Rust changes; affected Python suites pass and CI rebuilds in a clean environment.