### PR TITLE
Count only authoritative PnL in health summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live health-summary PnL now counts authoritative net realized PnL only.
+  Pending and synthetic fill estimates remain visible in fill diagnostics but
+  no longer create temporary fill-identity bookkeeping solely to correct the
+  uptime metric after enrichment.
 - Bitget UTA private order updates now use the native `holdSide` field for
   hedge position attribution. Hyperliquid briefly retries a sparse order-open
   event when a concurrent local create is still awaiting its exchange ID, then

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -60,12 +60,11 @@
     advancing windows while retaining the narrow execution lookup. Preserve ordinary
     recent-fill overlap for routine ingestion, and defer risk planning without consuming
     restart budget until every in-lookback row is authoritatively replaced. Report every
-    successful replacement before attempting later fallible fetches. Uptime health adds
-    the full authoritative net PnL when the previous cached value was not counted by this
-    process, and applies a delta against the exact net PnL previously counted for an
-    outstanding runtime synthetic row. Discard that temporary accounting after
-    enrichment; authoritative fills must not accumulate identity state. Structured
-    `cycle.degraded` diagnostics preserve bounded `pending_pnl_count` and
+    successful replacement before attempting later fallible fetches. Uptime health PnL
+    counts authoritative net realized PnL only: pending and synthetic values remain
+    visible in fill diagnostics but do not enter the health counter, and later enrichment
+    adds the full authoritative amount without retaining fill-identity accounting state.
+    Structured `cycle.degraded` diagnostics preserve bounded `pending_pnl_count` and
     `degraded_pnl_count` fields through the centralized payload sanitizer.
 
 ## Runtime Provenance

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -1512,8 +1512,8 @@ class Passivbot:
         self._health_orders_placed = 0
         self._health_orders_cancelled = 0
         self._health_fills = 0
-        self._health_pnl = 0.0  # sum of realized PnL from fills
-        self._health_counted_synthetic_pnl_by_key: dict[str, float] = {}
+        # Authoritative net realized PnL observed during this process.
+        self._health_pnl = 0.0
         self._health_errors = 0
         self._health_ws_reconnects = 0
         self._health_rate_limits = 0
@@ -12769,12 +12769,11 @@ class Passivbot:
         # Track fills and PnL for health summary
         self._health_fills += len(new_events)
         for event in new_events:
-            if fill_event_pnl_pending(event):
+            if fill_event_pnl_pending(event) or FillEventsManager.synthetic_pnl_events(
+                [event]
+            ):
                 continue
-            net_pnl = fill_event_net_pnl(event)
-            self._health_pnl += net_pnl
-            if FillEventsManager.synthetic_pnl_events([event]):
-                Passivbot._mark_health_fill_pnl_counted(self, event, net_pnl)
+            self._health_pnl += fill_event_net_pnl(event)
 
         batch_summary = len(new_events) > 20
         pending_count = 0
@@ -12835,48 +12834,6 @@ class Passivbot:
                     pending_pnl_count=pending_count,
                 )
 
-    @staticmethod
-    def _health_fill_identity_keys(event: object) -> set[str]:
-        keys: set[str] = set()
-        event_id = str(getattr(event, "id", "") or "")
-        if event_id:
-            keys.add(f"id:{event_id}")
-        for source_id in getattr(event, "source_ids", None) or ():
-            normalized = str(source_id or "")
-            if normalized:
-                keys.add(f"source:{normalized}")
-        return keys
-
-    def _health_fill_counted_net_pnl(self, event: object) -> float | None:
-        counted = getattr(self, "_health_counted_synthetic_pnl_by_key", {}) or {}
-        for key in Passivbot._health_fill_identity_keys(event):
-            if key in counted:
-                return float(counted[key])
-        return None
-
-    def _mark_health_fill_pnl_counted(
-        self, event: object, net_pnl: float | None = None
-    ) -> None:
-        counted = getattr(self, "_health_counted_synthetic_pnl_by_key", None)
-        if counted is None:
-            counted = {}
-            self._health_counted_synthetic_pnl_by_key = counted
-        amount = (
-            fill_event_net_pnl(event)
-            if net_pnl is None
-            else float(net_pnl)
-        )
-        for key in Passivbot._health_fill_identity_keys(event):
-            counted[key] = amount
-
-    def _forget_health_fill_pnl_counted(self, *events: object) -> None:
-        counted = getattr(self, "_health_counted_synthetic_pnl_by_key", None)
-        if not counted:
-            return
-        for event in events:
-            for key in Passivbot._health_fill_identity_keys(event):
-                counted.pop(key, None)
-
     def _log_enriched_fill_events(self, transitions: list[tuple[object, object]]) -> None:
         """Log authoritative PnL replacing pending or synthetic cached values."""
         if not transitions:
@@ -12884,21 +12841,16 @@ class Passivbot:
         for previous, event in sorted(
             transitions, key=lambda item: item[1].timestamp
         ):
-            counted_net_pnl = Passivbot._health_fill_counted_net_pnl(self, previous)
-            previous_counted = counted_net_pnl is not None
-            previous_net_pnl = float(counted_net_pnl or 0.0)
-            pnl_delta = fill_event_net_pnl(event) - previous_net_pnl
-            self._health_pnl += pnl_delta
-            Passivbot._forget_health_fill_pnl_counted(self, previous, event)
+            authoritative_net_pnl = fill_event_net_pnl(event)
+            self._health_pnl += authoritative_net_pnl
             previous_source = str(
                 getattr(previous, "pnl_source", "") or "pending"
             ).lower()
             logging.info(
                 "[fill] authoritative realized pnl replaced cached estimate | "
-                "previous_source=%s previous_counted=%s pnl_delta=%+.8g | %s",
+                "previous_source=%s authoritative_net_pnl=%+.8g | %s",
                 previous_source,
-                str(previous_counted).lower(),
-                pnl_delta,
+                authoritative_net_pnl,
                 self._log_fill_event(event),
             )
 

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -4562,7 +4562,6 @@ def test_log_new_fill_events_emits_fill_ingested_event():
             self.monitor_publisher = RecorderPublisher()
             self._health_fills = 0
             self._health_pnl = 0.0
-            self._health_counted_synthetic_pnl_by_key = {}
 
     source_ids = ["trade-a", "trade-b"]
     source_derived_fill_id = "+".join(source_ids)
@@ -4613,24 +4612,40 @@ def test_log_new_fill_events_emits_fill_ingested_event():
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
-def test_log_enriched_cached_fill_adds_full_authoritative_pnl_to_health(caplog):
+@pytest.mark.parametrize(
+    "pnl_source",
+    [
+        "synthetic_fill_reconstruction_exact",
+        "synthetic_fill_reconstruction_degraded",
+    ],
+)
+def test_synthetic_fill_waits_for_authoritative_pnl_before_health_count(
+    caplog, pnl_source
+):
     import passivbot as pb_mod
 
     class FakeBot:
+        _emit_fill_ingested_event = lambda self, event, **kwargs: None
+        _live_event_console_available = lambda self: True
+        _log_new_fill_events = pb_mod.Passivbot._log_new_fill_events
         _log_enriched_fill_events = pb_mod.Passivbot._log_enriched_fill_events
         _log_fill_event = lambda self, event: f"id={event.id}"
+        _monitor_fill_payload = lambda self, event: {}
+        _monitor_record_event = lambda self, *args, **kwargs: None
+        _monitor_record_fill_history = lambda self, event: None
 
         def __init__(self):
-            self._health_pnl = 100.0
-            self._health_counted_synthetic_pnl_by_key = {}
+            self._health_fills = 0
+            self._health_pnl = 0.0
 
     previous = SimpleNamespace(
         id="degraded-close",
+        source_ids=["trade-1"],
         timestamp=1_700_000_000_000,
         pnl=5.0,
         fee_paid=-0.1,
         pnl_status="complete",
-        pnl_source="synthetic_fill_reconstruction_degraded",
+        pnl_source=pnl_source,
     )
     authoritative = SimpleNamespace(
         id="degraded-close",
@@ -4642,60 +4657,17 @@ def test_log_enriched_cached_fill_adds_full_authoritative_pnl_to_health(caplog):
     )
     bot = FakeBot()
 
-    with caplog.at_level(logging.INFO):
-        bot._log_enriched_fill_events([(previous, authoritative)])
+    bot._log_new_fill_events([previous])
 
-    assert bot._health_pnl == pytest.approx(102.9)
-    assert "previous_source=synthetic_fill_reconstruction_degraded" in caplog.text
-    assert "previous_counted=false" in caplog.text
-    assert "pnl_delta=+2.9" in caplog.text
-
-
-def test_log_enriched_runtime_fill_applies_authoritative_pnl_delta(caplog):
-    import passivbot as pb_mod
-
-    class FakeBot:
-        _log_enriched_fill_events = pb_mod.Passivbot._log_enriched_fill_events
-        _log_fill_event = lambda self, event: f"id={event.id}"
-
-        def __init__(self):
-            self._health_pnl = 100.0
-            self._health_counted_synthetic_pnl_by_key = {}
-
-    previous = SimpleNamespace(
-        id="degraded-close",
-        source_ids=["trade-1"],
-        timestamp=1_700_000_000_000,
-        pnl=5.0,
-        fee_paid=-0.1,
-        pnl_status="complete",
-        pnl_source="synthetic_fill_reconstruction_degraded",
-    )
-    authoritative = SimpleNamespace(
-        id="authoritative-close",
-        source_ids=["trade-1"],
-        timestamp=previous.timestamp,
-        pnl=3.0,
-        fee_paid=-0.1,
-        pnl_status="complete",
-        pnl_source="authoritative",
-    )
-    bot = FakeBot()
-    pb_mod.Passivbot._mark_health_fill_pnl_counted(bot, previous)
-    assert bot._health_counted_synthetic_pnl_by_key
-    assert all(
-        value == pytest.approx(4.9)
-        for value in bot._health_counted_synthetic_pnl_by_key.values()
-    )
-    previous.pnl = 50.0
+    assert bot._health_fills == 1
+    assert bot._health_pnl == 0.0
 
     with caplog.at_level(logging.INFO):
         bot._log_enriched_fill_events([(previous, authoritative)])
 
-    assert bot._health_pnl == pytest.approx(98.0)
-    assert "previous_counted=true" in caplog.text
-    assert "pnl_delta=-2" in caplog.text
-    assert bot._health_counted_synthetic_pnl_by_key == {}
+    assert bot._health_pnl == pytest.approx(2.9)
+    assert f"previous_source={pnl_source}" in caplog.text
+    assert "authoritative_net_pnl=+2.9" in caplog.text
 
 
 def test_log_new_fill_events_uses_structured_console_without_legacy_duplicate(caplog):
@@ -4734,7 +4706,6 @@ def test_log_new_fill_events_uses_structured_console_without_legacy_duplicate(ca
             self.monitor_publisher = RecorderPublisher()
             self._health_fills = 0
             self._health_pnl = 0.0
-            self._health_counted_synthetic_pnl_by_key = {}
 
     event = SimpleNamespace(
         id="fill-1",
@@ -4757,7 +4728,6 @@ def test_log_new_fill_events_uses_structured_console_without_legacy_duplicate(ca
     with caplog.at_level(logging.INFO):
         bot._log_new_fill_events([event])
 
-    assert bot._health_counted_synthetic_pnl_by_key == {}
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
     assert [event.event_type for event in structured.events] == [EventTypes.FILL_INGESTED]
     assert [event.event_type for event in console.events] == [EventTypes.FILL_INGESTED]


### PR DESCRIPTION
## Summary

- count only authoritative net realized PnL in the uptime health summary
- keep pending and synthetic PnL visible in fill diagnostics without adding them to the health counter
- add the full authoritative amount when a pending or synthetic fill is later enriched
- remove the temporary fill-identity alias map and delta-correction bookkeeping
- update the fill/PnL contract and changelog

## Why

The health counter is diagnostic-only, but making it exactly track provisional synthetic PnL required persistent identity aliases and correction deltas. Defining the metric as authoritative-only makes its meaning clearer and removes patch sediment without changing fill ingestion, PnL enrichment, risk readiness, planning, reconciliation, or exchange behavior.

The production and test diff is deletion-positive: 45 insertions and 120 deletions overall.

## Validation

- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-3/venv/bin/python -m pytest -q tests/test_passivbot_monitor.py`
- focused degraded-repair integration and exact/degraded synthetic enrichment tests
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-3/venv/bin/python src/tools/check_ai_docs.py` (0 errors; existing word-count warnings only)
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-3/venv/bin/python src/tools/generate_live_event_registry.py --check`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-3/venv/bin/python -m pytest -q tests/test_ai_docs.py tests/test_live_event_registry_docs.py`
- Python compilation for changed Python files
- `git diff --check`