### PR TITLE
Scope live PnL readiness to enabled consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live fill readiness now separates proven structural fill history from realized-PnL
+  quality. Pending or synthetic PnL continues to block and repair before enabled HSL,
+  auto-unstuck, or realized-loss logic can run, but no longer defers all fill-dependent
+  planning when every authoritative-PnL consumer is disabled.
 - Live health-summary PnL now counts authoritative net realized PnL only.
   Pending and synthetic fill estimates remain visible in fill diagnostics but
   no longer create temporary fill-identity bookkeeping solely to correct the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ All notable user-facing changes will be documented in this file.
 - Live fill readiness now separates proven structural fill history from realized-PnL
   quality. Pending or synthetic PnL continues to block and repair before enabled HSL,
   auto-unstuck, or realized-loss logic can run, but no longer defers all fill-dependent
-  planning when every authoritative-PnL consumer is disabled.
+  planning when every authoritative-PnL consumer is disabled. Zero-exposure unstuck
+  configurations follow Rust's disabled behavior, monitor snapshots leave disabled
+  unstuck allowances unavailable instead of reading unsafe PnL, and coverage failures
+  retain their coverage-specific diagnostics and retry classification.
 - Live health-summary PnL now counts authoritative net realized PnL only.
   Pending and synthetic fill estimates remain visible in fill diagnostics but
   no longer create temporary fill-identity bookkeeping solely to correct the

--- a/docs/ai/error_contract.md
+++ b/docs/ai/error_contract.md
@@ -86,9 +86,16 @@ held coin is handled as graceful stop.
 
 ## Fill And PnL Inputs
 
-Risk consumers may use a fill/PnL lookback only when the cache proves `history_scope=all` or a
+Structural fill history and realized-PnL quality are separate readiness facts. Fill-dependent
+planning may use the configured lookback only when the cache proves `history_scope=all` or a
 `covered_start_ms` at or before the configured lookback start. Unknown coverage triggers observable
-refresh or deferral, never neutral PnL.
+refresh or deferral, never a neutral history.
+
+Pending or degraded realized PnL blocks only enabled consumers that require authoritative PnL, such
+as HSL, auto-unstuck, or the realized-loss gate. When every such consumer is disabled, proven fill
+history may remain ready for structural consumers such as fill timestamps; PnL defects remain
+observable and repairable but do not globally defer planning. Enabling a PnL consumer restores the
+strict requirement without a neutral PnL fallback.
 
 Corrupt or unavailable fills use bounded repair/retry and explicit degraded decisions. Valid
 manual or external exchange fills without Passivbot client IDs are exchange truth unless they

--- a/docs/ai/error_contract.md
+++ b/docs/ai/error_contract.md
@@ -92,10 +92,10 @@ planning may use the configured lookback only when the cache proves `history_sco
 refresh or deferral, never a neutral history.
 
 Pending or degraded realized PnL blocks only enabled consumers that require authoritative PnL, such
-as HSL, auto-unstuck, or the realized-loss gate. When every such consumer is disabled, proven fill
-history may remain ready for structural consumers such as fill timestamps; PnL defects remain
-observable and repairable but do not globally defer planning. Enabling a PnL consumer restores the
-strict requirement without a neutral PnL fallback.
+as HSL, operational auto-unstuck with positive total exposure, or the realized-loss gate. When
+every such consumer is disabled, proven fill history may remain ready for structural consumers
+such as fill timestamps; PnL defects remain observable and repairable but do not globally defer
+planning. Enabling a PnL consumer restores the strict requirement without a neutral PnL fallback.
 
 Corrupt or unavailable fills use bounded repair/retry and explicit degraded decisions. Valid
 manual or external exchange fills without Passivbot client IDs are exchange truth unless they

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -58,12 +58,13 @@
     starve the others. Connectors whose authoritative PnL endpoint uses a timestamp
     different from execution time must search that timestamp independently in bounded,
     advancing windows while retaining the narrow execution lookup. Preserve ordinary
-    recent-fill overlap for routine ingestion, and defer risk planning without consuming
-    restart budget until every in-lookback row is authoritatively replaced. Report every
-    successful replacement before attempting later fallible fetches. Uptime health PnL
-    counts authoritative net realized PnL only: pending and synthetic values remain
-    visible in fill diagnostics but do not enter the health counter, and later enrichment
-    adds the full authoritative amount without retaining fill-identity accounting state.
+    recent-fill overlap for routine ingestion. When an enabled PnL consumer requires
+    authoritative history, defer that planning without consuming restart budget until
+    every in-lookback row is authoritatively replaced. Report every successful
+    replacement before attempting later fallible fetches. Uptime health PnL counts
+    authoritative net realized PnL only: pending and synthetic values remain visible in
+    fill diagnostics but do not enter the health counter, and later enrichment adds the
+    full authoritative amount without retaining fill-identity accounting state.
     Structured `cycle.degraded` diagnostics preserve bounded `pending_pnl_count` and
     `degraded_pnl_count` fields through the centralized payload sanitizer.
 
@@ -108,8 +109,10 @@ logs, runtime windows, and immutable manifests.
    rather than silently treated as complete.
 5. Old synthetic rows remain outside ordinary recent-fill overlap to avoid repeatedly
    widening every routine refresh. Risk-blocking degraded rows use a separate bounded
-   repair path so proven coverage cannot strand an otherwise recoverable authoritative
-   exchange record. Repair-only calls do not advance `last_refresh_ms`; the subsequent
+   repair path when an enabled HSL, auto-unstuck, or realized-loss consumer requires
+   authoritative PnL. With all such consumers disabled, covered structural fill history
+   remains ready while degraded rows stay visible for later repair. Repair-only calls do
+   not advance `last_refresh_ms`; the subsequent
    ordinary recent refresh must still cover downtime from the prior successful
    checkpoint. Bybit keeps the execution-time range narrow while rotating a separate
    closed-PnL `updatedTime` range toward the present; each auxiliary range spans at most
@@ -136,8 +139,10 @@ merely because an auxiliary endpoint failed.
 3. PnL attachment behavior when auxiliary endpoints fail.
 4. Provenance round-trip, preservation during refresh/deduplication, and legacy
    rows remaining unattributed.
-5. Old degraded synthetic PnL is refetched in bounded windows, authoritative
-   replacement is persisted, and unresolved rows defer live planning without restarts.
+5. Old degraded synthetic PnL is refetched in bounded windows when an enabled
+   authoritative-PnL consumer requires it, authoritative replacement is persisted, and
+   unresolved rows defer those consumers without restarts. With every PnL consumer
+   disabled, unresolved PnL does not block covered structural fill history.
 
 ## Key Code
 

--- a/src/live/state_refresh.py
+++ b/src/live/state_refresh.py
@@ -109,11 +109,11 @@ async def refresh_authoritative_state_staged(bot) -> bool:
         bot._last_authoritative_degraded_pnl_count = int(
             snapshot.get("degraded_pnl_count", 0) or 0
         )
-        bot._last_authoritative_block_reason = (
-            "degraded_pnl"
-            if bot._last_authoritative_degraded_pnl_count
-            else "pending_pnl"
-        )
+        if bot._live_risk_uses_authoritative_pnl():
+            if bot._last_authoritative_degraded_pnl_count:
+                bot._last_authoritative_block_reason = "degraded_pnl"
+            elif bot._last_authoritative_pending_pnl_count:
+                bot._last_authoritative_block_reason = "pending_pnl"
         return False
     prepared_balance_snapshot = None
     if "balance" in plan:

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -1666,6 +1666,37 @@ class Passivbot:
         value = self.live_value("max_realized_loss_pct")
         return 1.0 if value is None else float(value)
 
+    def _unstuck_uses_realized_pnl(self) -> bool:
+        symbols: list[Optional[str]] = [None]
+        symbols.extend(sorted((getattr(self, "coin_overrides", {}) or {}).keys()))
+        for symbol in symbols:
+            for pside in ("long", "short"):
+                if (
+                    bool(self.bp(pside, "unstuck_enabled", symbol))
+                    and float(
+                        self.bp(pside, "unstuck_loss_allowance_pct", symbol) or 0.0
+                    )
+                    > 0.0
+                    and float(self.bp(pside, "unstuck_close_pct", symbol) or 0.0)
+                    > 0.0
+                    and float(self.bp(pside, "unstuck_threshold", symbol) or 0.0)
+                    > 0.0
+                ):
+                    return True
+        return False
+
+    def _orchestrator_uses_realized_pnl(self) -> bool:
+        return (
+            self._live_max_realized_loss_pct() < 1.0
+            or self._unstuck_uses_realized_pnl()
+        )
+
+    def _live_risk_uses_authoritative_pnl(self) -> bool:
+        return (
+            self._orchestrator_uses_realized_pnl()
+            or self._equity_hard_stop_enabled()
+        )
+
     def bot_value(self, pside: str, key: str):
         bot_side = self.config.get("bot", {}).get(pside, {})
         sentinel = object()
@@ -12237,6 +12268,7 @@ class Passivbot:
             return False
 
         try:
+            authoritative_pnl_required = self._live_risk_uses_authoritative_pnl()
             # Use the same lookback window
             lookback_config_value = self.live_value("pnls_max_lookback_days")
             lookback = parse_pnls_max_lookback_days(
@@ -12314,7 +12346,7 @@ class Passivbot:
             flush_enriched_events = collect_enriched_events
 
             # Check whether the cache proves the configured fill-history
-            # lookback before risk gates consume realized PnL.
+            # lookback before fill-dependent planning.
             events = self._pnls_manager.get_events()
             before_events_count = len(events)
             coverage_status = self._pnl_history_coverage_status(
@@ -12336,7 +12368,12 @@ class Passivbot:
             repair_degraded = getattr(
                 self._pnls_manager, "refresh_degraded_pnl_events", None
             )
-            if coverage_ready and degraded_before and callable(repair_degraded):
+            if (
+                authoritative_pnl_required
+                and coverage_ready
+                and degraded_before
+                and callable(repair_degraded)
+            ):
                 degraded_repair_attempted = True
                 try:
                     await repair_degraded(
@@ -12411,7 +12448,7 @@ class Passivbot:
             elif needs_lookback_refresh:
                 refresh_mode = "lookback_bootstrap"
                 logging.info(
-                    "[fills] proving fill-history lookback before risk planning | "
+                    "[fills] proving fill-history lookback before fill-dependent planning | "
                     "start=%s scope=%s covered_start=%s reason=%s",
                     ts_to_date(age_limit)[:19] if age_limit is not None else "all",
                     history_scope,
@@ -12500,8 +12537,9 @@ class Passivbot:
             flush_enriched_events()
             # Trailing fill confirmation only needs proof that a fill-cache
             # refresh completed after the position snapshot. Keep this
-            # separate from the risk-authoritative fills generation below,
-            # which must still wait for PnL enrichment and history coverage.
+            # separate from the planning-authoritative fills generation below.
+            # Coverage is always required; PnL enrichment is required only
+            # when an enabled live risk feature consumes realized PnL.
             if fill_fetch_completed:
                 self._trailing_fill_fetch_generation = fill_refresh_attempt_generation
             new_events = []
@@ -12538,7 +12576,10 @@ class Passivbot:
                 lookback=lookback,
             )
             coverage_ready_after = bool(post_refresh_coverage_status.get("ready", False))
-            if pnls_safe and coverage_ready_after:
+            fills_ready = coverage_ready_after and (
+                pnls_safe or not authoritative_pnl_required
+            )
+            if fills_ready:
                 self._clear_fill_coverage_retry_defer()
                 self._record_authoritative_surface(
                     "fills", self._fill_events_signature(all_events)
@@ -12546,7 +12587,7 @@ class Passivbot:
                 self._trailing_fill_refresh_generation = (
                     fill_refresh_attempt_generation
                 )
-            elif pnls_safe and not coverage_ready_after:
+            elif not coverage_ready_after:
                 self._record_fill_coverage_retry_defer(post_refresh_coverage_status)
                 state = getattr(self, "_fill_coverage_retry_state", {}) or {}
                 next_retry_ms = int(state.get("next_retry_ms", 0) or 0)
@@ -12597,10 +12638,10 @@ class Passivbot:
             self._emit_fills_refresh_summary_event(
                 source=source,
                 refresh_mode=refresh_mode,
-                status="succeeded" if pnls_safe and coverage_ready_after else "deferred",
+                status="succeeded" if fills_ready else "deferred",
                 reason_code=(
                     "fills_refresh_succeeded"
-                    if pnls_safe and coverage_ready_after
+                    if fills_ready
                     else (
                         "pending_pnl_enrichment"
                         if pending_pnl_events
@@ -12626,7 +12667,7 @@ class Passivbot:
                 level=logging.getLevelName(structured_event_level).lower(),
             )
 
-            return pnls_safe and coverage_ready_after
+            return fills_ready
 
         except RateLimitExceeded as e:
             flush_enriched_events()
@@ -12900,6 +12941,8 @@ class Passivbot:
     def _get_realized_pnl_cumsum_stats(self) -> dict[str, float]:
         """Return net realized pnl cumsum peak/current from FillEventsManager history."""
         if getattr(self, "_pnls_manager", None) is None:
+            return {"max": 0.0, "last": 0.0}
+        if not self._orchestrator_uses_realized_pnl():
             return {"max": 0.0, "last": 0.0}
         start_ms = self._pnls_lookback_start_ms()
         events = self._get_effective_pnl_events()
@@ -16382,6 +16425,8 @@ class Passivbot:
 
     def _auto_unstuck_allowed_live(self) -> bool:
         if self._pnls_manager is None:
+            return False
+        if not self._unstuck_uses_realized_pnl():
             return False
         start_ms = self._pnls_lookback_start_ms()
         events = self._get_effective_pnl_events()

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -1669,8 +1669,15 @@ class Passivbot:
     def _unstuck_uses_realized_pnl(self) -> bool:
         symbols: list[Optional[str]] = [None]
         symbols.extend(sorted((getattr(self, "coin_overrides", {}) or {}).keys()))
-        for symbol in symbols:
-            for pside in ("long", "short"):
+        for pside in ("long", "short"):
+            if (
+                float(
+                    self.bot_value(pside, "total_wallet_exposure_limit") or 0.0
+                )
+                <= 0.0
+            ):
+                continue
+            for symbol in symbols:
                 if (
                     bool(self.bp(pside, "unstuck_enabled", symbol))
                     and float(
@@ -12644,10 +12651,10 @@ class Passivbot:
                     if fills_ready
                     else (
                         "pending_pnl_enrichment"
-                        if pending_pnl_events
+                        if authoritative_pnl_required and pending_pnl_events
                         else (
                             "degraded_pnl_enrichment"
-                            if degraded_pnl_events
+                            if authoritative_pnl_required and degraded_pnl_events
                             else "fill_history_coverage_unavailable"
                         )
                     )

--- a/src/passivbot_monitor.py
+++ b/src/passivbot_monitor.py
@@ -973,9 +973,15 @@ async def _build_monitor_forager_section(self) -> dict[str, dict]:
 
 def _build_monitor_unstuck_section(self) -> dict[str, Any]:
     has_open = bool(self.has_open_unstuck_order())
-    # Allowances are pure budget facts and stay real while an unstuck order
-    # is open; has_open is reported alongside so the monitor shows both.
-    allowances_live = self._calc_unstuck_allowances_live()
+    # When unstuck is enabled, allowances are pure budget facts and stay real
+    # while an unstuck order is open. Disabled unstuck has no PnL-derived
+    # allowance to report.
+    unstuck_uses_realized_pnl = self._unstuck_uses_realized_pnl()
+    allowances_live = (
+        self._calc_unstuck_allowances_live()
+        if unstuck_uses_realized_pnl
+        else None
+    )
     out: dict[str, Any] = {
         "has_open_order": has_open,
         "open_orders": [],
@@ -996,10 +1002,18 @@ def _build_monitor_unstuck_section(self) -> dict[str, Any]:
             payload["symbol"] = symbol
             out["open_orders"].append(payload)
     for pside in ("long", "short"):
-        info = self._calc_unstuck_allowance_for_logging(pside)
+        info = (
+            self._calc_unstuck_allowance_for_logging(pside)
+            if unstuck_uses_realized_pnl
+            else {"status": "unstuck_disabled"}
+        )
         side_payload: dict[str, Any] = {
             "status": info.get("status"),
-            "allowance_live": float(allowances_live.get(pside, 0.0) or 0.0),
+            "allowance_live": (
+                float(allowances_live.get(pside, 0.0) or 0.0)
+                if allowances_live is not None
+                else None
+            ),
             "configured_loss_allowance_pct": float(
                 self.bot_value(pside, "unstuck_loss_allowance_pct") or 0.0
             ),

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -6497,8 +6497,9 @@ async def test_update_pnls_repairs_old_degraded_pnl_before_marking_fills_authori
         ("complete", fem.PNL_SOURCE_SYNTHETIC_DEGRADED),
     ],
 )
+@pytest.mark.parametrize("coverage_ready", [True, False])
 async def test_update_pnls_keeps_structural_fills_ready_when_pnl_consumers_disabled(
-    pnl_status, pnl_source
+    pnl_status, pnl_source, coverage_ready
 ):
     bot = Passivbot.__new__(Passivbot)
     now_ms = 1_800_000_000_000
@@ -6522,7 +6523,7 @@ async def test_update_pnls_keeps_structural_fills_ready_when_pnl_consumers_disab
     class _Cache:
         def load_metadata(self):
             return {
-                "covered_start_ms": start_ms,
+                "covered_start_ms": start_ms if coverage_ready else start_ms + 1,
                 "oldest_event_ts": event.timestamp,
                 "history_scope": "window",
                 "known_gaps": [],
@@ -6532,12 +6533,13 @@ async def test_update_pnls_keeps_structural_fills_ready_when_pnl_consumers_disab
             return []
 
         def get_covered_start_ms(self):
-            return start_ms
+            return start_ms if coverage_ready else start_ms + 1
 
     class _Manager:
         def __init__(self):
             self.cache = _Cache()
             self.refresh_latest = AsyncMock()
+            self.refresh_for_lookback = AsyncMock(return_value=False)
             self.refresh_degraded_pnl_events = AsyncMock()
 
         def get_events(self, start_ms=None, end_ms=None):
@@ -6577,16 +6579,23 @@ async def test_update_pnls_keeps_structural_fills_ready_when_pnl_consumers_disab
 
     result = await bot.update_pnls(source="staged_blocking")
 
-    assert result is True
+    assert result is coverage_ready
     bot._pnls_manager.refresh_degraded_pnl_events.assert_not_awaited()
-    bot._record_authoritative_surface.assert_called_once()
+    if coverage_ready:
+        bot._record_authoritative_surface.assert_called_once()
+    else:
+        bot._record_authoritative_surface.assert_not_called()
     expected_pending = 1 if pnl_status == "pending" else 0
     expected_degraded = 1 if pnl_source == fem.PNL_SOURCE_SYNTHETIC_DEGRADED else 0
     assert bot._last_fill_refresh_pending_pnl_count == expected_pending
     assert bot._last_fill_refresh_degraded_pnl_count == expected_degraded
     summary = bot._emit_fills_refresh_summary_event.call_args.kwargs
-    assert summary["status"] == "succeeded"
-    assert summary["reason_code"] == "fills_refresh_succeeded"
+    assert summary["status"] == ("succeeded" if coverage_ready else "deferred")
+    assert summary["reason_code"] == (
+        "fills_refresh_succeeded"
+        if coverage_ready
+        else "fill_history_coverage_unavailable"
+    )
     assert summary["pending_pnl_count"] == expected_pending
     assert summary["degraded_pnl_count"] == expected_degraded
 
@@ -7755,6 +7764,7 @@ async def test_fetch_authoritative_state_staged_snapshot_cleans_up_on_cancelled_
 @pytest.mark.asyncio
 async def test_refresh_authoritative_state_staged_does_not_publish_when_fills_fail():
     bot = Passivbot.__new__(Passivbot)
+    bot._live_risk_uses_authoritative_pnl = lambda: True
     plan = {"balance", "positions", "open_orders", "fills"}
     bot._authoritative_staged_refresh_plan = lambda: set(plan)
     bot._fetch_authoritative_state_staged_snapshot = AsyncMock(
@@ -7783,6 +7793,35 @@ async def test_refresh_authoritative_state_staged_does_not_publish_when_fills_fa
     bot._finalize_authoritative_refresh_consistency.assert_not_called()
     assert bot._last_authoritative_block_reason == "degraded_pnl"
     assert bot._last_authoritative_pending_pnl_count == 0
+    assert bot._last_authoritative_degraded_pnl_count == 1
+
+
+@pytest.mark.asyncio
+async def test_refresh_authoritative_state_staged_does_not_blame_nonblocking_pnl():
+    bot = Passivbot.__new__(Passivbot)
+    bot._live_risk_uses_authoritative_pnl = lambda: False
+    bot._authoritative_staged_refresh_plan = lambda: {
+        "balance",
+        "positions",
+        "open_orders",
+        "fills",
+    }
+    bot._fetch_authoritative_state_staged_snapshot = AsyncMock(
+        return_value={
+            "balance": 100.0,
+            "positions": [{"symbol": "BTC/USDT:USDT"}],
+            "open_orders": [],
+            "pnls_ok": False,
+            "pending_pnl_count": 1,
+            "degraded_pnl_count": 1,
+        }
+    )
+
+    result = await bot._refresh_authoritative_state_staged()
+
+    assert result is False
+    assert bot._last_authoritative_block_reason is None
+    assert bot._last_authoritative_pending_pnl_count == 1
     assert bot._last_authoritative_degraded_pnl_count == 1
 
 

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -4378,6 +4378,7 @@ async def test_update_pnls_routine_empty_refresh_timing_demoted_to_debug(
     monkeypatch, caplog
 ):
     bot = Passivbot.__new__(Passivbot)
+    bot._live_risk_uses_authoritative_pnl = lambda: True
     cached_events = [
         SimpleNamespace(timestamp=1_700_000_000_000, id="fill-1", source_ids=["fill-1"])
     ]
@@ -4443,6 +4444,7 @@ async def test_update_pnls_completed_refresh_timing_trigger_cases_stay_debug(
     monkeypatch, caplog, source, add_new_fill
 ):
     bot = Passivbot.__new__(Passivbot)
+    bot._live_risk_uses_authoritative_pnl = lambda: True
     cached_event = SimpleNamespace(
         timestamp=1_700_000_000_000,
         id="fill-1",
@@ -5739,6 +5741,7 @@ def test_trailing_status_reappearing_item_is_operator_visible(monkeypatch):
 @pytest.mark.asyncio
 async def test_update_pnls_all_lookback_backfills_when_cache_scope_is_narrower():
     bot = Passivbot.__new__(Passivbot)
+    bot._live_risk_uses_authoritative_pnl = lambda: True
     cached_events = [
         SimpleNamespace(timestamp=1_700_000_000_000, id="fill-1", source_ids=["fill-1"])
     ]
@@ -5781,6 +5784,7 @@ async def test_update_pnls_all_lookback_backfills_when_cache_scope_is_narrower()
 @pytest.mark.asyncio
 async def test_update_pnls_all_lookback_uses_incremental_refresh_when_cache_is_full_history():
     bot = Passivbot.__new__(Passivbot)
+    bot._live_risk_uses_authoritative_pnl = lambda: True
     cached_events = [
         SimpleNamespace(timestamp=1_700_000_000_000, id="fill-1", source_ids=["fill-1"])
     ]
@@ -5837,6 +5841,7 @@ async def test_update_pnls_all_lookback_uses_incremental_refresh_when_cache_is_f
 @pytest.mark.asyncio
 async def test_update_pnls_pending_enrichment_advances_only_trailing_fetch_generation():
     bot = Passivbot.__new__(Passivbot)
+    bot._live_risk_uses_authoritative_pnl = lambda: True
     cached_events = [
         SimpleNamespace(
             timestamp=1_700_000_000_000,
@@ -5895,6 +5900,7 @@ async def test_update_pnls_pending_enrichment_advances_only_trailing_fetch_gener
 @pytest.mark.asyncio
 async def test_update_pnls_window_lookback_bootstraps_when_coverage_unproven():
     bot = Passivbot.__new__(Passivbot)
+    bot._live_risk_uses_authoritative_pnl = lambda: True
     now_ms = 1_800_000_000_000
     lookback_days = 30.0
     start_ms = now_ms - int(lookback_days * 86_400_000)
@@ -5992,6 +5998,7 @@ async def test_update_pnls_window_lookback_stays_blocked_when_known_gap_persists
     monkeypatch,
 ):
     bot = Passivbot.__new__(Passivbot)
+    bot._live_risk_uses_authoritative_pnl = lambda: True
     now_ms = 1_800_000_000_000
     wall_ms = {"value": now_ms}
     monkeypatch.setattr(passivbot_module, "utc_ms", lambda: wall_ms["value"])
@@ -6119,6 +6126,7 @@ async def test_update_pnls_window_lookback_stays_blocked_when_known_gap_persists
 @pytest.mark.asyncio
 async def test_update_pnls_window_lookback_records_fills_after_known_gap_repair():
     bot = Passivbot.__new__(Passivbot)
+    bot._live_risk_uses_authoritative_pnl = lambda: True
     now_ms = 1_800_000_000_000
     lookback_days = 30.0
     start_ms = now_ms - int(lookback_days * 86_400_000)
@@ -6223,6 +6231,7 @@ async def test_update_pnls_window_lookback_records_fills_after_known_gap_repair(
 @pytest.mark.asyncio
 async def test_update_pnls_window_lookback_uses_incremental_when_coverage_proven():
     bot = Passivbot.__new__(Passivbot)
+    bot._live_risk_uses_authoritative_pnl = lambda: True
     now_ms = 1_800_000_000_000
     lookback_days = 30.0
     start_ms = now_ms - int(lookback_days * 86_400_000)
@@ -6340,6 +6349,7 @@ async def test_update_pnls_repairs_old_degraded_pnl_before_marking_fills_authori
     failure_stage,
 ):
     bot = Passivbot.__new__(Passivbot)
+    bot._live_risk_uses_authoritative_pnl = lambda: True
     now_ms = 1_800_000_000_000
     lookback_days = 30.0
     start_ms = now_ms - int(lookback_days * 86_400_000)
@@ -6480,8 +6490,111 @@ async def test_update_pnls_repairs_old_degraded_pnl_before_marking_fills_authori
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "pnl_status,pnl_source",
+    [
+        ("pending", "unknown"),
+        ("complete", fem.PNL_SOURCE_SYNTHETIC_DEGRADED),
+    ],
+)
+async def test_update_pnls_keeps_structural_fills_ready_when_pnl_consumers_disabled(
+    pnl_status, pnl_source
+):
+    bot = Passivbot.__new__(Passivbot)
+    now_ms = 1_800_000_000_000
+    lookback_days = 30.0
+    start_ms = now_ms - int(lookback_days * 86_400_000)
+    event = SimpleNamespace(
+        timestamp=start_ms + 60_000,
+        id="degraded-close",
+        source_ids=["degraded-close"],
+        symbol="SOL/USDT:USDT",
+        position_side="long",
+        side="sell",
+        qty=-4.0,
+        price=103.0,
+        pnl=5.0,
+        fee_paid=-0.1,
+        pnl_status=pnl_status,
+        pnl_source=pnl_source,
+    )
+
+    class _Cache:
+        def load_metadata(self):
+            return {
+                "covered_start_ms": start_ms,
+                "oldest_event_ts": event.timestamp,
+                "history_scope": "window",
+                "known_gaps": [],
+            }
+
+        def get_known_gaps(self):
+            return []
+
+        def get_covered_start_ms(self):
+            return start_ms
+
+    class _Manager:
+        def __init__(self):
+            self.cache = _Cache()
+            self.refresh_latest = AsyncMock()
+            self.refresh_degraded_pnl_events = AsyncMock()
+
+        def get_events(self, start_ms=None, end_ms=None):
+            events = [event]
+            if start_ms is not None:
+                events = [event for event in events if event.timestamp >= start_ms]
+            if end_ms is not None:
+                events = [event for event in events if event.timestamp <= end_ms]
+            return events
+
+        def get_history_scope(self):
+            return "window"
+
+        def set_history_scope(self, _scope):
+            pass
+
+    bot.stop_signal_received = False
+    bot.config = {
+        "live": {
+            "fills_recent_overlap_minutes": 10.0,
+            "pnls_max_lookback_days": lookback_days,
+        }
+    }
+    bot._authoritative_pending_confirmations = {}
+    bot._pnls_manager = _Manager()
+    bot._live_risk_uses_authoritative_pnl = lambda: False
+    bot.init_pnls = AsyncMock()
+    bot.live_value = lambda key: bot.config["live"][key]
+    bot.get_exchange_time = lambda: now_ms
+    bot._log_new_fill_events = MagicMock()
+    bot._record_authoritative_surface = MagicMock()
+    bot._monitor_record_event = lambda *args, **kwargs: None
+    bot._monitor_record_error = lambda *args, **kwargs: None
+    bot._emit_fills_refresh_summary_event = MagicMock()
+    bot.logging_level = 0
+    bot._health_rate_limits = 0
+
+    result = await bot.update_pnls(source="staged_blocking")
+
+    assert result is True
+    bot._pnls_manager.refresh_degraded_pnl_events.assert_not_awaited()
+    bot._record_authoritative_surface.assert_called_once()
+    expected_pending = 1 if pnl_status == "pending" else 0
+    expected_degraded = 1 if pnl_source == fem.PNL_SOURCE_SYNTHETIC_DEGRADED else 0
+    assert bot._last_fill_refresh_pending_pnl_count == expected_pending
+    assert bot._last_fill_refresh_degraded_pnl_count == expected_degraded
+    summary = bot._emit_fills_refresh_summary_event.call_args.kwargs
+    assert summary["status"] == "succeeded"
+    assert summary["reason_code"] == "fills_refresh_succeeded"
+    assert summary["pending_pnl_count"] == expected_pending
+    assert summary["degraded_pnl_count"] == expected_degraded
+
+
+@pytest.mark.asyncio
 async def test_update_pnls_uses_confirmation_overlap_when_fills_pending():
     bot = Passivbot.__new__(Passivbot)
+    bot._live_risk_uses_authoritative_pnl = lambda: True
     cached_events = [
         SimpleNamespace(timestamp=1_700_000_000_000, id="fill-1", source_ids=["fill-1"])
     ]
@@ -6536,6 +6649,7 @@ async def test_update_pnls_widens_refresh_for_mismatched_trailing_fill_anchor(
     monkeypatch,
 ):
     bot = Passivbot.__new__(Passivbot)
+    bot._live_risk_uses_authoritative_pnl = lambda: True
     now_ms = 1_800_000_000_000
     position_anchor_ms = now_ms - 2 * 60 * 60 * 1000
     monkeypatch.setattr(passivbot_module, "utc_ms", lambda: now_ms)
@@ -6617,6 +6731,7 @@ async def test_mandatory_fill_confirmation_does_not_widen_trailing_recovery(
     monkeypatch,
 ):
     bot = Passivbot.__new__(Passivbot)
+    bot._live_risk_uses_authoritative_pnl = lambda: True
     now_ms = 1_800_000_000_000
     position_anchor_ms = now_ms - 180 * 24 * 60 * 60 * 1000
     monkeypatch.setattr(passivbot_module, "utc_ms", lambda: now_ms)
@@ -6696,6 +6811,7 @@ async def test_update_pnls_propagates_unexpected_refresh_errors_without_retainin
     caplog, capsys, shutdown_requested
 ):
     bot = Passivbot.__new__(Passivbot)
+    bot._live_risk_uses_authoritative_pnl = lambda: True
     secret = "api_key=fill-refresh-secret https://private.example.invalid/fills"
 
     class HostileKey:
@@ -6826,6 +6942,7 @@ async def test_routine_fill_prefetch_failure_logs_only_exception_type(
 @pytest.mark.asyncio
 async def test_update_pnls_failure_logs_only_bounded_status_and_code(caplog):
     bot = Passivbot.__new__(Passivbot)
+    bot._live_risk_uses_authoritative_pnl = lambda: True
     cached_events = [
         SimpleNamespace(timestamp=1_700_000_000_000, id="fill-1", source_ids=["fill-1"])
     ]
@@ -6885,6 +7002,7 @@ async def test_update_pnls_failure_logs_only_bounded_status_and_code(caplog):
 @pytest.mark.asyncio
 async def test_update_pnls_rate_limit_does_not_advance_trailing_fetch_generation():
     bot = Passivbot.__new__(Passivbot)
+    bot._live_risk_uses_authoritative_pnl = lambda: True
     cached_events = [
         SimpleNamespace(timestamp=1_700_000_000_000, id="fill-1", source_ids=["fill-1"])
     ]
@@ -6939,6 +7057,7 @@ async def test_update_pnls_rate_limit_does_not_advance_trailing_fetch_generation
 @pytest.mark.asyncio
 async def test_update_pnls_emits_summary_when_exchange_time_resync_handles_error():
     bot = Passivbot.__new__(Passivbot)
+    bot._live_risk_uses_authoritative_pnl = lambda: True
     cached_events = [
         SimpleNamespace(timestamp=1_700_000_000_000, id="fill-1", source_ids=["fill-1"])
     ]
@@ -7013,6 +7132,7 @@ async def test_update_pnls_emits_summary_when_exchange_time_resync_handles_error
 @pytest.mark.asyncio
 async def test_update_pnls_suppresses_inflight_shutdown_refresh_error(caplog):
     bot = Passivbot.__new__(Passivbot)
+    bot._live_risk_uses_authoritative_pnl = lambda: True
     cached_events = [
         SimpleNamespace(timestamp=1_700_000_000_000, id="fill-1", source_ids=["fill-1"])
     ]
@@ -8217,6 +8337,7 @@ def test_open_unstuck_order_does_not_gate_live_unstuck_emission(monkeypatch):
         "unstuck_loss_allowance_pct": 0.2 if pside == "long" else 0.0,
         "total_wallet_exposure_limit": 0.5,
     }.get(key, 0.0)
+    bot._unstuck_uses_realized_pnl = lambda: True
     monkeypatch.setattr(
         pb_mod.pbr, "calc_auto_unstuck_allowance", lambda *a: 77.0
     )

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -3,7 +3,7 @@ import hashlib
 import json
 import logging
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import numpy as np
 
@@ -6436,6 +6436,35 @@ async def test_shutdown_gracefully_closes_event_pipeline_before_monitor_publishe
     assert bot._live_event_pipeline is None
 
 
+def test_monitor_unstuck_section_skips_pnl_math_when_unstuck_disabled():
+    import passivbot as pb_mod
+
+    bot = pb_mod.Passivbot.__new__(pb_mod.Passivbot)
+    bot.open_orders = {}
+    bot.has_open_unstuck_order = lambda: False
+    bot._unstuck_uses_realized_pnl = lambda: False
+    bot._calc_unstuck_allowances_live = MagicMock(
+        side_effect=AssertionError("must not read nonauthoritative PnL")
+    )
+    bot._calc_unstuck_allowance_for_logging = MagicMock(
+        side_effect=AssertionError("must not read nonauthoritative PnL")
+    )
+    bot.bot_value = lambda pside, key: {
+        "unstuck_loss_allowance_pct": 0.01,
+        "unstuck_close_pct": 0.0,
+        "unstuck_threshold": 0.9,
+    }[key]
+
+    section = bot._build_monitor_unstuck_section()
+
+    bot._calc_unstuck_allowances_live.assert_not_called()
+    bot._calc_unstuck_allowance_for_logging.assert_not_called()
+    assert section["sides"]["long"]["status"] == "unstuck_disabled"
+    assert section["sides"]["long"]["allowance_live"] is None
+    assert section["sides"]["short"]["status"] == "unstuck_disabled"
+    assert section["sides"]["short"]["allowance_live"] is None
+
+
 @pytest.mark.asyncio
 async def test_build_monitor_snapshot_includes_market_forager_unstuck_and_recent():
     import passivbot as pb_mod
@@ -6773,6 +6802,9 @@ async def test_build_monitor_snapshot_includes_market_forager_unstuck_and_recent
             return self._coin_bot_values[(pside, key)]
 
         def has_open_unstuck_order(self):
+            return True
+
+        def _unstuck_uses_realized_pnl(self):
             return True
 
         def _calc_unstuck_allowance_for_logging(self, pside):

--- a/tests/test_realized_loss_gate.py
+++ b/tests/test_realized_loss_gate.py
@@ -180,11 +180,22 @@ class _FailingConsoleSink:
 
 class TestRealizedPnlConsumers:
     @staticmethod
-    def _make_bot(*, max_realized_loss_pct=1.0, hsl_enabled=False, values=None):
+    def _make_bot(
+        *,
+        max_realized_loss_pct=1.0,
+        hsl_enabled=False,
+        total_wallet_exposure_limit=1.0,
+        values=None,
+    ):
         bot = object.__new__(Passivbot)
         bot.coin_overrides = {}
         bot._live_max_realized_loss_pct = lambda: max_realized_loss_pct
         bot._equity_hard_stop_enabled = lambda: hsl_enabled
+        bot.bot_value = lambda pside, key: (
+            total_wallet_exposure_limit
+            if key == "total_wallet_exposure_limit"
+            else 0.0
+        )
         values = values or {}
         bot.bp = lambda pside, key, symbol=None: values.get(
             (symbol, pside, key),
@@ -224,6 +235,20 @@ class TestRealizedPnlConsumers:
             bot.coin_overrides = {symbol: {}}
 
         assert bot._live_risk_uses_authoritative_pnl() is True
+
+    def test_unstuck_with_zero_total_exposure_does_not_require_pnl(self):
+        values = {
+            (None, "long", "unstuck_enabled"): True,
+            (None, "long", "unstuck_loss_allowance_pct"): 0.01,
+            (None, "long", "unstuck_close_pct"): 0.1,
+            (None, "long", "unstuck_threshold"): 0.9,
+        }
+        bot = self._make_bot(
+            total_wallet_exposure_limit=0.0,
+            values=values,
+        )
+
+        assert bot._live_risk_uses_authoritative_pnl() is False
 
 
 class TestGetRealizedPnlCumsumStats:

--- a/tests/test_realized_loss_gate.py
+++ b/tests/test_realized_loss_gate.py
@@ -83,6 +83,7 @@ _DEFAULT_RISK_CACHE = object()
 def _make_bot_with_events(events, balance=10000.0, cache=_DEFAULT_RISK_CACHE):
     """Return a Passivbot instance with a mocked FillEventsManager."""
     bot = object.__new__(Passivbot)
+    bot._orchestrator_uses_realized_pnl = lambda: True
     bot._pnls_manager = MagicMock()
     def _get_events(start_ms=None, end_ms=None, symbol=None):
         out = list(events)
@@ -177,6 +178,54 @@ class _FailingConsoleSink:
 # ---------------------------------------------------------------------------
 
 
+class TestRealizedPnlConsumers:
+    @staticmethod
+    def _make_bot(*, max_realized_loss_pct=1.0, hsl_enabled=False, values=None):
+        bot = object.__new__(Passivbot)
+        bot.coin_overrides = {}
+        bot._live_max_realized_loss_pct = lambda: max_realized_loss_pct
+        bot._equity_hard_stop_enabled = lambda: hsl_enabled
+        values = values or {}
+        bot.bp = lambda pside, key, symbol=None: values.get(
+            (symbol, pside, key),
+            values.get((None, pside, key), False if key == "unstuck_enabled" else 0.0),
+        )
+        return bot
+
+    def test_disabled_risk_features_do_not_require_authoritative_pnl(self):
+        bot = self._make_bot()
+
+        assert bot._live_risk_uses_authoritative_pnl() is False
+
+    @pytest.mark.parametrize(
+        "max_realized_loss_pct,hsl_enabled",
+        [(0.99, False), (1.0, True)],
+    )
+    def test_realized_loss_gate_or_hsl_requires_authoritative_pnl(
+        self, max_realized_loss_pct, hsl_enabled
+    ):
+        bot = self._make_bot(
+            max_realized_loss_pct=max_realized_loss_pct,
+            hsl_enabled=hsl_enabled,
+        )
+
+        assert bot._live_risk_uses_authoritative_pnl() is True
+
+    @pytest.mark.parametrize("symbol", [None, "SOL/USDT:USDT"])
+    def test_enabled_unstuck_requires_authoritative_pnl(self, symbol):
+        values = {
+            (symbol, "long", "unstuck_enabled"): True,
+            (symbol, "long", "unstuck_loss_allowance_pct"): 0.01,
+            (symbol, "long", "unstuck_close_pct"): 0.1,
+            (symbol, "long", "unstuck_threshold"): 0.9,
+        }
+        bot = self._make_bot(values=values)
+        if symbol is not None:
+            bot.coin_overrides = {symbol: {}}
+
+        assert bot._live_risk_uses_authoritative_pnl() is True
+
+
 class TestGetRealizedPnlCumsumStats:
     def test_no_manager_returns_zeros(self):
         bot = object.__new__(Passivbot)
@@ -188,6 +237,26 @@ class TestGetRealizedPnlCumsumStats:
         bot = _make_bot_with_events([])
         result = bot._get_realized_pnl_cumsum_stats()
         assert result == {"max": 0.0, "last": 0.0}
+
+    @pytest.mark.parametrize(
+        "pnl_status,pnl_source",
+        [("pending", "unknown"), ("complete", "synthetic_degraded")],
+    )
+    def test_disabled_consumers_do_not_read_unsafe_pnl(
+        self, pnl_status, pnl_source
+    ):
+        bot = _make_bot_with_events(
+            [
+                _make_fill_event(
+                    -10.0,
+                    pnl_status=pnl_status,
+                    pnl_source=pnl_source,
+                )
+            ]
+        )
+        bot._orchestrator_uses_realized_pnl = lambda: False
+
+        assert bot._get_realized_pnl_cumsum_stats() == {"max": 0.0, "last": 0.0}
 
     def test_single_positive_event(self):
         bot = _make_bot_with_events([_make_fill_event(50.0)])

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -3270,6 +3270,14 @@ def _make_order(
 async def test_existing_unstuck_order_does_not_block_rust_emission(monkeypatch):
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
+    bot._bp_defaults.update(
+        {
+            "unstuck_enabled": True,
+            "unstuck_loss_allowance_pct": 0.01,
+            "unstuck_close_pct": 0.1,
+            "unstuck_threshold": 0.5,
+        }
+    )
     symbol = _set_basic_state(bot)
     import passivbot_rust as pbr
 

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -3278,6 +3278,7 @@ async def test_existing_unstuck_order_does_not_block_rust_emission(monkeypatch):
             "unstuck_threshold": 0.5,
         }
     )
+    bot._bot_value_defaults["total_wallet_exposure_limit"] = 0.5
     symbol = _set_basic_state(bot)
     import passivbot_rust as pbr
 


### PR DESCRIPTION
## Summary
- separate structural fill-history readiness from realized-PnL quality
- require authoritative PnL only when HSL, auto-unstuck, or the realized-loss gate is enabled
- keep fill-history coverage strict and retain pending/degraded PnL diagnostics
- skip degraded-PnL repair when no enabled consumer can use it
- document the consumer-scoped readiness contract

## Safety boundary
Enabled PnL consumers remain fail-closed. Auto-unstuck detection mirrors the four Rust enabling conditions and includes per-coin overrides. This does not add a fallback PnL value, relax fill-history coverage, or change Rust trading policy.

## Validation
- rebuilt the Rust extension against current `master` and verified source fingerprint on test import
- `pytest -q tests/test_realized_loss_gate.py tests/test_passivbot_balance_split.py`
- `pytest -q tests/test_auto_unstuck_allowance.py tests/test_unstucking.py tests/test_unstucking_safeguards.py tests/test_passivbot_hsl_bindings.py tests/test_hsl_incomplete_history_override.py`
- `pytest -q tests/test_hsl_coin_mode.py tests/test_hsl_metric_regression.py`
- `pytest -q tests/test_run_fake_live.py -m fake_live`
- `git diff --check origin/master...HEAD`