### PR TITLE
Reuse HLCV caches across position sides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Prepared HLCV caches now key direction-agnostic candle data by the effective
+  long/short coin union, allowing long-only, short-only, and both-side runs with
+  matching data inputs to reuse one verified cache. Backtest artifacts report
+  the current run's side membership separately from cache-build provenance, and
+  optimizer data preparation derives reachable sides from optimization bounds
+  so fixed-bound starts and Pareto restarts resolve consistently.
 - Live fill readiness now separates proven structural fill history from realized-PnL
   quality. Pending or synthetic PnL continues to block and repair before enabled HSL,
   auto-unstuck, or realized-loss logic can run, but no longer defers all fill-dependent

--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -93,6 +93,14 @@ Prepared final caches under `caches/hlcvs_data/` require a valid manifest. Old
 manifest-less final caches are rebuilt. Explicit `backtest.hlcvs_data_dir` override
 datasets also require valid manifests and checksums.
 
+Final cache identity follows the direction-agnostic data payload: the sorted union
+of enabled long and short coins, date window, exchanges, source assignments,
+minimum coin age, and gap tolerance. Long-only, short-only, and both-side runs
+therefore reuse the same prepared cache when their effective coin union and other
+data inputs match. Side membership remains run-specific; manifests retain the
+build request for provenance and explicit dataset replay. Warmup is checked
+separately, so a cache with greater warmup coverage may satisfy a smaller request.
+
 ### Override final HLCV datasets
 
 Use `backtest.hlcvs_data_dir` or `--hlcvs-data-dir` to replay a specific prepared

--- a/src/backtest.py
+++ b/src/backtest.py
@@ -1419,7 +1419,7 @@ def check_keys(dict0, dict1):
 
 def get_cache_hash(config, exchange):
     exchanges_cfg = require_config_value(config, "backtest.exchanges")
-    approved_coins = effective_backtest_approved_coins_by_side(config)
+    data_coins = effective_backtest_data_coins(config)
     minimum_coin_age = require_live_value(config, "minimum_coin_age_days")
     coin_sources = config.get("backtest", {}).get("coin_sources") or {}
     coin_sources_sorted = sorted((str(k), str(v)) for k, v in coin_sources.items())
@@ -1428,7 +1428,7 @@ def get_cache_hash(config, exchange):
         (str(k), str(v)) for k, v in market_settings_sources.items()
     )
     to_hash = {
-        "coins": approved_coins,
+        "coins": data_coins,
         "end_date": format_end_date(require_config_value(config, "backtest.end_date")),
         "start_date": require_config_value(config, "backtest.start_date"),
         "exchange": exchanges_cfg if exchange == "combined" else exchange,

--- a/src/backtest_dataset.py
+++ b/src/backtest_dataset.py
@@ -2,7 +2,9 @@ import json
 from pathlib import Path
 from typing import Sequence
 
+from backtest_universe import effective_backtest_approved_coins_by_side
 from config.access import get_optional_config_value
+from config.shared_bot import get_grouped_bot_value
 from hlcvs_manifest import manifest_has_required_schema
 
 HLCVS_CACHE_DIR_SEP = "__"
@@ -25,6 +27,25 @@ def _extract_cache_hash_from_dir(cache_dir: Path | None) -> str | None:
     return name.rsplit(HLCVS_CACHE_DIR_SEP, 1)[-1] or name
 
 
+def _runtime_side_membership(config: dict, coins: list[str]) -> dict[str, list[str]] | None:
+    bot = config.get("bot")
+    approved = config.get("live", {}).get("approved_coins")
+    if not isinstance(bot, dict) or not isinstance(approved, dict):
+        return None
+    for pside in ("long", "short"):
+        side = bot.get(pside)
+        if not isinstance(side, dict):
+            return None
+        for field in ("n_positions", "total_wallet_exposure_limit"):
+            if get_grouped_bot_value(side, field, default=None, prefer_flat=True) is None:
+                return None
+    coin_set = set(coins)
+    return {
+        pside: sorted(coin for coin in side_coins if coin in coin_set)
+        for pside, side_coins in effective_backtest_approved_coins_by_side(config).items()
+    }
+
+
 def build_backtest_dataset_metadata(config: dict, exchange: str) -> dict:
     cache_dir_raw = get_optional_config_value(config, f"backtest.cache_dir.{exchange}")
     cache_dir = Path(cache_dir_raw).resolve() if cache_dir_raw else None
@@ -41,7 +62,7 @@ def build_backtest_dataset_metadata(config: dict, exchange: str) -> dict:
     manifest_schema_version = None
     materialization_schema_version = None
     content_hashes = {}
-    side_membership = None
+    cache_build_side_membership = None
     manifest_missing = None
     coins_order = list(coins_from_config)
 
@@ -77,7 +98,9 @@ def build_backtest_dataset_metadata(config: dict, exchange: str) -> dict:
                     }
                 effective = manifest.get("effective", {})
                 if isinstance(effective, dict):
-                    side_membership = effective.get("side_membership")
+                    cache_build_side_membership = effective.get("build_side_membership")
+                    if not isinstance(cache_build_side_membership, dict):
+                        cache_build_side_membership = effective.get("side_membership")
         if coins_file:
             with open(coins_file) as f:
                 loaded_coins = json.load(f)
@@ -86,6 +109,7 @@ def build_backtest_dataset_metadata(config: dict, exchange: str) -> dict:
             ):
                 raise TypeError(f"cache coins file must contain a list[str], got {type(loaded_coins)}")
             coins_order = loaded_coins
+    runtime_side_membership = _runtime_side_membership(config, coins_order)
 
     return {
         "exchange": exchange,
@@ -110,7 +134,12 @@ def build_backtest_dataset_metadata(config: dict, exchange: str) -> dict:
         "manifest_schema_version": manifest_schema_version,
         "materialization_schema_version": materialization_schema_version,
         "content_hashes": content_hashes,
-        "side_membership": side_membership,
+        "side_membership": (
+            runtime_side_membership
+            if runtime_side_membership is not None
+            else cache_build_side_membership
+        ),
+        "cache_build_side_membership": cache_build_side_membership,
         "coins": coins_order,
         "coin_index": {coin: idx for idx, coin in enumerate(coins_order)},
         "requested_start_date": get_optional_config_value(config, "backtest.start_date"),

--- a/src/hlcvs_manifest.py
+++ b/src/hlcvs_manifest.py
@@ -166,6 +166,7 @@ def build_hlcvs_manifest(
         }
 
     meta = mss.get("__meta__", {}) if isinstance(mss, dict) else {}
+    build_side_membership = _side_membership(config, coins)
     manifest = {
         "schema_version": HLCVS_MANIFEST_SCHEMA_VERSION,
         "materialization_schema_version": HLCVS_MATERIALIZATION_SCHEMA_VERSION,
@@ -185,7 +186,10 @@ def build_hlcvs_manifest(
         },
         "effective": {
             "coins": list(coins),
-            "side_membership": _side_membership(config, coins),
+            # Side eligibility is run-specific and is not part of the content-cache key.
+            # Keep the build request for explicit dataset replay and provenance.
+            "build_side_membership": build_side_membership,
+            "side_membership": build_side_membership,
             "start_ts": effective_start_ts,
             "end_ts": effective_end_ts,
         },

--- a/src/hlcvs_override.py
+++ b/src/hlcvs_override.py
@@ -110,7 +110,9 @@ def _side_membership_for_override(config: dict, dataset_coins: list[str], manife
     if manifest_has_required_schema(manifest):
         effective = manifest.get("effective", {})
         if isinstance(effective, dict):
-            manifest_sides = effective.get("side_membership")
+            manifest_sides = effective.get("build_side_membership")
+            if not isinstance(manifest_sides, dict):
+                manifest_sides = effective.get("side_membership")
     if isinstance(manifest_sides, dict):
         return {
             pside: sorted([normalize_backtest_coin(coin) for coin in manifest_sides.get(pside, [])])

--- a/src/optimization/warmup.py
+++ b/src/optimization/warmup.py
@@ -4,13 +4,18 @@ from collections import Counter
 from copy import deepcopy
 from typing import Sequence
 
+from backtest_universe import backtest_side_enabled
 from config.bot import normalize_forager_score_weights
 from config.optimize_bounds import flatten_optimize_bounds
 from config.param_paths import require_existing_config_path, resolve_dotted_config_path
 from config.shared_bot import flatten_shared_bot_side
 from optimizer_overrides import optimizer_overrides
 from optimization.bounds import Bound, enforce_bounds
-from optimization.config_adapter import extract_bounds_tuple_list_from_config, get_optimization_key_paths
+from optimization.config_adapter import (
+    extract_bounds_tuple_list_from_config,
+    get_optimization_key_paths,
+    resolve_optimization_bound_path,
+)
 from optimization.fine_tune_anchors import ANCHOR_PLAN_KEY, get_anchor_plan
 from optimization.shape import build_optimization_shape
 from warmup_utils import compute_per_coin_warmup_minutes
@@ -229,24 +234,62 @@ def build_optimizer_max_config(config: dict) -> dict:
     )
 
 
-def compute_optimizer_per_coin_warmup_minutes(config: dict) -> dict:
+def _build_optimizer_boundary_configs(config: dict) -> list[dict]:
     anchor_plan = get_anchor_plan(config)
-    if anchor_plan is not None:
-        shape = build_optimization_shape(config)
-        overrides_list = config.get("optimize", {}).get("enable_overrides", []) or []
-        tunable_max_vector = [bound.high for bound in shape.bounds[1:]]
+    if anchor_plan is None:
+        return [build_optimizer_max_config(config)]
+    shape = build_optimization_shape(config)
+    overrides_list = config.get("optimize", {}).get("enable_overrides", []) or []
+    tunable_max_vector = [bound.high for bound in shape.bounds[1:]]
+    return [
+        build_optimizer_vector_config(
+            [float(anchor_id), *tunable_max_vector],
+            config,
+            key_paths=shape.key_paths,
+            overrides_list=overrides_list,
+        )
+        for anchor_id in range(len(anchor_plan.get("anchors") or []))
+    ]
+
+
+def build_optimizer_data_config(config: dict) -> dict:
+    """Return a copy whose side gates cover every optimizer-reachable side."""
+    boundary_configs = _build_optimizer_boundary_configs(config)
+    if not boundary_configs:
+        return deepcopy(config)
+    data_config = deepcopy(config)
+    for pside in ("long", "short"):
+        source = next(
+            (
+                candidate
+                for candidate in boundary_configs
+                if backtest_side_enabled(candidate, pside)
+            ),
+            boundary_configs[0],
+        )
+        for field in ("n_positions", "total_wallet_exposure_limit"):
+            path = resolve_optimization_bound_path(data_config, f"{pside}_{field}")
+            if path is None:
+                raise KeyError(f"optimizer data side gate does not resolve: {pside}_{field}")
+            value = _try_get_path(source, path)
+            if value is None:
+                raise KeyError(
+                    f"optimizer data side gate is missing from boundary config: {'.'.join(path)}"
+                )
+            _set_path(data_config, path, deepcopy(value))
+    _refresh_shared_bot_runtime_aliases(data_config)
+    return data_config
+
+
+def compute_optimizer_per_coin_warmup_minutes(config: dict) -> dict:
+    boundary_configs = _build_optimizer_boundary_configs(config)
+    if len(boundary_configs) > 1:
         merged: dict[str, int] = {}
-        for anchor_id in range(len(anchor_plan.get("anchors") or [])):
-            anchor_config = build_optimizer_vector_config(
-                [float(anchor_id), *tunable_max_vector],
-                config,
-                key_paths=shape.key_paths,
-                overrides_list=overrides_list,
-            )
-            for key, value in compute_per_coin_warmup_minutes(anchor_config).items():
+        for boundary_config in boundary_configs:
+            for key, value in compute_per_coin_warmup_minutes(boundary_config).items():
                 merged[key] = max(int(value), int(merged.get(key, 0)))
         return merged
-    return compute_per_coin_warmup_minutes(build_optimizer_max_config(config))
+    return compute_per_coin_warmup_minutes(boundary_configs[0])
 
 
 def compute_optimizer_backtest_warmup_minutes(config: dict) -> int:
@@ -275,6 +318,7 @@ def stamp_warmup_metadata(mss: dict, coins: Sequence[str], warmup_map: dict) -> 
 
 
 __all__ = [
+    "build_optimizer_data_config",
     "build_optimizer_max_config",
     "build_optimizer_vector_config",
     "canonicalize_dead_optimizer_params",

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -192,6 +192,7 @@ from optimization.config_adapter import (
 )
 from optimization.evaluation_payload import apply_evaluation_payload, build_evaluation_payload
 from optimization.warmup import (
+    build_optimizer_data_config,
     build_optimizer_vector_config,
     compute_optimizer_per_coin_warmup_minutes,
     stamp_warmup_metadata,
@@ -3159,6 +3160,7 @@ async def main():
         apply_fine_tune_bounds(config, fine_tune_params, cli_bounds_overrides)
     backtest_exchanges = require_config_value(config, "backtest.exchanges")
     await format_approved_ignored_coins(config, backtest_exchanges)
+    data_config = build_optimizer_data_config(config)
     interrupted = False
     failed = False
     pool = None
@@ -3177,7 +3179,7 @@ async def main():
 
         if suite_enabled:
             scenario_contexts, aggregate_cfg = await prepare_suite_contexts(
-                config,
+                data_config,
                 suite_cfg,
                 shared_array_manager=array_manager,
             )
@@ -3252,7 +3254,7 @@ async def main():
                 exchange = "combined"
                 coins, mss = _register_exchange_data(
                     exchange,
-                    await prepare_hlcvs_mss(config, exchange),
+                    await prepare_hlcvs_mss(data_config, exchange),
                     config,
                     msss=msss,
                     hlcvs_specs=hlcvs_specs,
@@ -3267,7 +3269,7 @@ async def main():
                     logging.info(f"chose {ex} for {','.join(exchange_preference[ex])}")
             else:
                 tasks = {
-                    exchange: asyncio.create_task(prepare_hlcvs_mss(config, exchange))
+                    exchange: asyncio.create_task(prepare_hlcvs_mss(data_config, exchange))
                     for exchange in backtest_exchanges
                 }
                 for exchange, task in tasks.items():

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -322,6 +322,51 @@ def _stamp_optimizer_warmup(config: dict, mss: dict, coins: list[str]) -> None:
         )
 
 
+def _propagate_optimizer_dataset_override(
+    config: dict,
+    exchange: str,
+    coins: list[str],
+    cache_dir,
+    mss: dict,
+) -> None:
+    """Apply a prepared dataset override's replay policy to the evaluator config.
+
+    Optimizer data preparation uses a bounds-derived config copy so every
+    reachable side is loaded. Dataset-mode overrides also mutate that copy
+    with the manifest's replay policy. Copy only those override-owned values
+    back here; optimizer-reachable bot side gates remain owned by ``config``.
+    """
+    meta = mss.get("__meta__")
+    if not isinstance(meta, dict) or not meta.get("dataset_override"):
+        return
+    side_membership = meta.get("effective_side_membership")
+    if not isinstance(side_membership, dict):
+        raise ValueError("HLCV dataset override metadata missing effective_side_membership")
+    missing_sides = [
+        pside for pside in ("long", "short") if not isinstance(side_membership.get(pside), list)
+    ]
+    if missing_sides:
+        raise ValueError(
+            "HLCV dataset override metadata has invalid side membership for: "
+            + ", ".join(missing_sides)
+        )
+    if cache_dir is None:
+        raise ValueError("HLCV dataset override result missing cache directory")
+    try:
+        effective_start_ts = int(meta["effective_requested_start_ts"])
+        effective_end_ts = int(meta["effective_end_ts"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("HLCV dataset override metadata missing effective date range") from exc
+
+    config.setdefault("live", {})["approved_coins"] = deepcopy(side_membership)
+    backtest = config.setdefault("backtest", {})
+    backtest["start_date"] = ts_to_date(effective_start_ts)
+    backtest["end_date"] = ts_to_date(effective_end_ts)
+    backtest.setdefault("cache_dir", {})[exchange] = str(cache_dir)
+    backtest.setdefault("coins", {})[exchange] = list(coins)
+    config["_hlcvs_dataset_override_meta"] = deepcopy(meta)
+
+
 def _register_exchange_data(
     exchange: str,
     prepare_result: tuple,
@@ -335,12 +380,10 @@ def _register_exchange_data(
 ) -> tuple[list[str], dict]:
     """
     Register one exchange's prepared data into the optimizer's shared-memory
-    pools. Consolidates the previously-duplicated setup logic for the
-    combined and per-exchange branches. No behavioral change from the
-    original inline code; see commit history for the fix that later hooks
-    into this helper.
+    pools and preserve any dataset replay policy on the evaluator config.
     """
-    coins, hlcvs, mss, _results_path, _cache_dir, btc_usd_prices, timestamps = prepare_result
+    coins, hlcvs, mss, _results_path, cache_dir, btc_usd_prices, timestamps = prepare_result
+    _propagate_optimizer_dataset_override(config, exchange, coins, cache_dir, mss)
     prepared_hlcvs = hlcvs
     hlcvs, timestamps, btc_usd_prices = _maybe_aggregate_backtest_data(
         hlcvs, timestamps, btc_usd_prices, mss, config

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -2036,6 +2036,77 @@ class TestValidateArray:
         assert manager.arrays[0] is hlcvs
         assert manager.arrays[1] is btc_usd_prices
 
+    def test_register_exchange_data_propagates_dataset_replay_policy_without_bot_gates(self):
+        class RecordingArrayManager:
+            def create_from(self, array):
+                return object(), array
+
+        hlcvs = np.zeros((3, 2, 5), dtype=np.float64)
+        btc_usd_prices = np.ones(3, dtype=np.float64)
+        timestamps = np.array(
+            [1735689600000, 1735776000000, 1735862400000], dtype=np.int64
+        )
+        override_meta = {
+            "dataset_override": True,
+            "dataset_override_mode": "dataset",
+            "effective_side_membership": {
+                "long": ["BTC", "ETH"],
+                "short": ["ETH"],
+            },
+            "effective_requested_start_ts": 1735776000000,
+            "effective_end_ts": 1735862400000,
+        }
+        mss = {
+            "BTC": {"first_valid_index": 0, "last_valid_index": 2},
+            "ETH": {"first_valid_index": 0, "last_valid_index": 2},
+            "__meta__": override_meta,
+        }
+        original_bot = {
+            "long": {"n_positions": 0, "total_wallet_exposure_limit": 0.0},
+            "short": {"n_positions": 1, "total_wallet_exposure_limit": 1.0},
+        }
+        config = {
+            "backtest": {
+                "cache_dir": {},
+                "candle_interval_minutes": 1,
+                "coins": {},
+                "end_date": "2025-12-31",
+                "start_date": "2024-01-01",
+            },
+            "bot": deepcopy(original_bot),
+            "live": {"approved_coins": {"long": ["BTC"], "short": []}},
+        }
+        cache_dir = Path("/prepared/dataset")
+
+        with patch("optimize._stamp_optimizer_warmup"):
+            _register_exchange_data(
+                "binance",
+                (
+                    ["BTC", "ETH"],
+                    hlcvs,
+                    mss,
+                    None,
+                    cache_dir,
+                    btc_usd_prices,
+                    timestamps,
+                ),
+                config,
+                msss={},
+                hlcvs_specs={},
+                btc_usd_specs={},
+                timestamps_dict={},
+                array_manager=RecordingArrayManager(),
+            )
+
+        assert config["live"]["approved_coins"] == override_meta["effective_side_membership"]
+        assert config["backtest"]["start_date"] == "2025-01-02T00:00:00"
+        assert config["backtest"]["end_date"] == "2025-01-03T00:00:00"
+        assert config["backtest"]["cache_dir"]["binance"] == str(cache_dir)
+        assert config["backtest"]["coins"]["binance"] == ["BTC", "ETH"]
+        assert config["_hlcvs_dataset_override_meta"] == override_meta
+        assert config["_hlcvs_dataset_override_meta"] is not override_meta
+        assert config["bot"] == original_bot
+
 
 class TestApplyPolishBounds:
     """Test apply_polish_bounds function."""

--- a/tests/optimization/test_optimizer_warmup.py
+++ b/tests/optimization/test_optimizer_warmup.py
@@ -9,9 +9,11 @@ from pathlib import Path
 
 import pytest
 
+from backtest_universe import effective_backtest_data_coins
 from config_utils import get_template_config
 from optimization.warmup import (
     _apply_config_overrides,
+    build_optimizer_data_config,
     compute_optimizer_backtest_warmup_minutes,
     compute_optimizer_per_coin_warmup_minutes,
     stamp_warmup_metadata,
@@ -101,6 +103,34 @@ def test_shared_optimizer_warmup_helper_uses_bounds_when_template_bot_exceeds_th
     assert warmup_map["__default__"] == 30
     assert "HYPE" not in warmup_map
     assert compute_optimizer_backtest_warmup_minutes(config) == 30
+
+
+def test_optimizer_data_config_uses_reachable_side_gates_from_bounds():
+    config = get_template_config()
+    config["live"]["approved_coins"] = {"long": ["BTC"], "short": ["ETH"]}
+    config["bot"]["long"]["risk"]["total_wallet_exposure_limit"] = 1.0
+    config["bot"]["short"]["risk"]["total_wallet_exposure_limit"] = 1.0
+    config["optimize"]["bounds"]["long_n_positions"] = [1, 3, 1]
+    config["optimize"]["bounds"]["long_total_wallet_exposure_limit"] = [0.5, 1.5, 0.01]
+    config["optimize"]["bounds"]["short_n_positions"] = [1, 3, 1]
+    config["optimize"]["bounds"]["short_total_wallet_exposure_limit"] = [0.0]
+
+    data_config = build_optimizer_data_config(config)
+
+    assert data_config["bot"]["long"]["risk"]["total_wallet_exposure_limit"] > 0.0
+    assert data_config["bot"]["short"]["risk"]["total_wallet_exposure_limit"] == 0.0
+    assert effective_backtest_data_coins(data_config) == ["BTC"]
+
+
+def test_optimizer_data_config_enables_template_disabled_side_when_bounds_reach_it():
+    config = get_template_config()
+    config["bot"]["short"]["risk"]["total_wallet_exposure_limit"] = 0.0
+    config["optimize"]["bounds"]["short_n_positions"] = [1, 3, 1]
+    config["optimize"]["bounds"]["short_total_wallet_exposure_limit"] = [0.5, 1.5, 0.01]
+
+    data_config = build_optimizer_data_config(config)
+
+    assert data_config["bot"]["short"]["risk"]["total_wallet_exposure_limit"] == 1.5
 
 
 def test_optimizer_warmup_fixed_runtime_override_rejects_unknown_path():

--- a/tests/test_backtest_dataset_metadata.py
+++ b/tests/test_backtest_dataset_metadata.py
@@ -54,6 +54,50 @@ def test_build_backtest_dataset_metadata_prefers_cache_coin_order_and_absolute_p
     assert metadata["materialization_schema_version"] == 1
     assert metadata["content_hashes"] == {"hlcvs": "abc"}
     assert metadata["side_membership"] == {"long": ["BTC"], "short": ["ETH"]}
+    assert metadata["cache_build_side_membership"] == {
+        "long": ["BTC"],
+        "short": ["ETH"],
+    }
+
+
+def test_build_backtest_dataset_metadata_separates_runtime_and_cache_build_sides(tmp_path):
+    cache_dir = tmp_path / "caches" / "hlcvs_data" / "combined__BTC__abc123"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "coins.json").write_text(json.dumps(["BTC"]))
+    (cache_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "materialization_schema_version": 1,
+                "files": {},
+                "effective": {
+                    "build_side_membership": {"long": ["BTC"], "short": ["BTC"]},
+                    "side_membership": {"long": ["BTC"], "short": ["BTC"]},
+                },
+            }
+        )
+    )
+    config = {
+        "backtest": {
+            "cache_dir": {"combined": str(cache_dir)},
+            "coins": {"combined": ["BTC"]},
+            "start_date": "2025-01-01",
+            "end_date": "2025-02-01",
+        },
+        "bot": {
+            "long": {"n_positions": 0, "total_wallet_exposure_limit": 0.0},
+            "short": {"n_positions": 1, "total_wallet_exposure_limit": 1.0},
+        },
+        "live": {"approved_coins": {"long": ["BTC"], "short": ["BTC"]}},
+    }
+
+    metadata = build_backtest_dataset_metadata(config, "combined")
+
+    assert metadata["side_membership"] == {"long": [], "short": ["BTC"]}
+    assert metadata["cache_build_side_membership"] == {
+        "long": ["BTC"],
+        "short": ["BTC"],
+    }
 
 
 def test_dump_backtest_dataset_metadata_writes_dataset_json(tmp_path):

--- a/tests/test_cache_warmup_reuse.py
+++ b/tests/test_cache_warmup_reuse.py
@@ -187,6 +187,19 @@ class TestCacheHashIndependence:
 
         assert hash_a != hash_b
 
+    def test_same_coin_union_across_sides_has_same_hash(self):
+        cfg_long = _base_config()
+        cfg_short = copy.deepcopy(cfg_long)
+        cfg_short["bot"]["long"]["total_wallet_exposure_limit"] = 0.0
+        cfg_short["bot"]["short"]["total_wallet_exposure_limit"] = 1.0
+        cfg_short["bot"]["short"]["n_positions"] = 1
+        cfg_short["live"]["approved_coins"] = {
+            "long": [],
+            "short": ["BTC/USDT:USDT"],
+        }
+
+        assert get_cache_hash(cfg_long, "binance") == get_cache_hash(cfg_short, "binance")
+
     def test_different_dates_different_hash(self):
         """Changing start_date still produces a different hash."""
         cfg_a = _base_config()

--- a/tests/test_hlcvs_manifest.py
+++ b/tests/test_hlcvs_manifest.py
@@ -80,6 +80,10 @@ def test_build_hlcvs_manifest_hashes_logical_arrays_and_side_membership(tmp_path
         "long": ["BTC", "ETH"],
         "short": ["BTC"],
     }
+    assert manifest["effective"]["build_side_membership"] == {
+        "long": ["BTC", "ETH"],
+        "short": ["BTC"],
+    }
     assert verify_hlcvs_manifest(cache_dir)["config_hash"] == "abc123"
 
     changed_btc = btc_usd_prices.copy()


### PR DESCRIPTION
## Summary

- key prepared HLCV caches by the effective long/short coin union rather than per-side membership
- keep cache-build side membership as manifest provenance while recording the current run's side membership in `dataset.json`
- derive optimizer data-preparation side gates from the maximum reachable optimization bounds, including anchored fine-tune configurations
- preserve explicit dataset replay by preferring `build_side_membership` with fallback support for existing manifests

## Root cause

Prepared HLCV arrays are direction-agnostic, but the cache hash included `{long: [...], short: [...]}`. A fixed-bound optimizer start could therefore resolve a both-side cache identity from its template while a Pareto restart resolved a short-only identity from its embedded bot values, even when both requested the same coin union and candle window.

## Impact

Long-only, short-only, and both-side runs now reuse one verified prepared cache whenever their effective coin union and all other data inputs match. Warmup remains a separate sufficiency check. Existing side-keyed cache directories have a different hash, so the first run for an existing dataset may build the new union-key cache once; subsequent direction variants reuse it.

## Validation

- rebuilt and stamped the Rust extension against the exact branch head
- 67 focused cache/manifest/override/optimizer tests passed
- 467 broader optimizer, suite, HLCV, and backtest tests passed; 2 intentionally skipped
- `git diff --check` passed