### PR TITLE
Centralize live fill-history coverage ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live fill-history coverage now has one canonical verdict owned by
+  `FillEventsManager`. Refresh, staged readiness, HSL replay, and realized-PnL
+  consumers no longer duplicate cache/gap interpretation. Metadata that claims
+  missing cached rows and malformed known-gap bounds fail closed and trigger
+  repair or deferral, while confirmed empty windows remain valid.
 - Live fill readiness now separates proven structural fill history from realized-PnL
   quality. Pending or synthetic PnL continues to block and repair before enabled HSL,
   auto-unstuck, or realized-loss logic can run, but no longer defers all fill-dependent

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -67,6 +67,14 @@
     full authoritative amount without retaining fill-identity accounting state.
     Structured `cycle.degraded` diagnostics preserve bounded `pending_pnl_count` and
     `degraded_pnl_count` fields through the centralized payload sanitizer.
+11. `FillEventsManager` owns the canonical fill-history coverage verdict used by
+    refresh, staged readiness, HSL replay, and realized-PnL consumers. Orchestration
+    may choose retry timing or whether a proven-incomplete history is explicitly
+    allowed, but it must not reinterpret cache metadata or known gaps. Metadata
+    claiming cached rows when no rows loaded, and malformed known-gap bounds, are
+    contradictory cache evidence: they are unavailable rather than proof of
+    coverage. A window with no fills remains valid when zero oldest/newest metadata
+    and `covered_start_ms` prove that empty result.
 
 ## Runtime Provenance
 
@@ -161,6 +169,9 @@ merely because an auxiliary endpoint failed.
    authoritative-PnL consumer requires it, authoritative replacement is persisted, and
    unresolved rows defer those consumers without restarts. With every PnL consumer
    disabled, unresolved PnL does not block covered structural fill history.
+6. Coverage verdicts fail closed for contradictory metadata and malformed gaps,
+   while confirmed-legitimate gaps and proven empty windows retain their explicit
+   semantics.
 
 ## Key Code
 

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -5467,43 +5467,14 @@ class FillEventsManager:
 
         coverage_end_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
 
-        def gap_bounds(gap: KnownGap) -> Optional[Tuple[int, int]]:
-            try:
-                gap_start = int(gap["start_ts"])
-                gap_end = int(gap["end_ts"])
-            except (KeyError, TypeError, ValueError):
-                return None
-            if gap_end <= gap_start:
-                return None
-            return gap_start, gap_end
-
-        def gap_confirmed_legitimate(gap: KnownGap) -> bool:
-            reason = str(gap.get("reason", "") or "").lower()
-            try:
-                confidence = float(gap.get("confidence", 0.0) or 0.0)
-            except (TypeError, ValueError):
-                confidence = 0.0
-            return reason == GAP_REASON_CONFIRMED or confidence >= GAP_CONFIDENCE_CONFIRMED
-
-        def blocking_known_gaps() -> List[KnownGap]:
-            gaps: List[KnownGap] = []
-            for gap in self.cache.get_known_gaps():
-                if gap_confirmed_legitimate(gap):
-                    continue
-                bounds = gap_bounds(gap)
-                if bounds is None:
-                    gaps.append(gap)
-                    continue
-                gap_start, gap_end = bounds
-                if gap_start < coverage_end_ms and gap_end > start_ms:
-                    gaps.append(gap)
-            return gaps
-
-        blocking_gaps = blocking_known_gaps()
+        blocking_gaps = self._blocking_known_gaps(
+            start_ms=start_ms,
+            end_ms=coverage_end_ms,
+        )
         if blocking_gaps:
             retried_ranges: List[Tuple[int, int]] = []
             for gap in blocking_gaps:
-                bounds = gap_bounds(gap)
+                bounds = self._known_gap_bounds(gap)
                 if bounds is None:
                     continue
                 if not force_refetch_gaps and not self.cache.should_retry_gap(gap):
@@ -5522,7 +5493,10 @@ class FillEventsManager:
                 await self.refresh(start_ms=retry_start, end_ms=retry_end)
             if retried_ranges:
                 await self.refresh_latest(overlap=overlap)
-                blocking_gaps = blocking_known_gaps()
+                blocking_gaps = self._blocking_known_gaps(
+                    start_ms=start_ms,
+                    end_ms=coverage_end_ms,
+                )
             if blocking_gaps:
                 if not retried_ranges:
                     # Historical coverage may remain blocked after its bounded
@@ -5531,7 +5505,7 @@ class FillEventsManager:
                     # cache current without weakening the PnL coverage gate.
                     await self.refresh_latest(overlap=overlap)
                 gap = blocking_gaps[0]
-                bounds = gap_bounds(gap)
+                bounds = self._known_gap_bounds(gap)
                 range_label = (
                     f"{_format_ms(bounds[0])}..{_format_ms(bounds[1])}"
                     if bounds is not None
@@ -5547,29 +5521,13 @@ class FillEventsManager:
                 )
                 return True
 
-        metadata = self.cache.load_metadata()
-        covered_start_ms = int(metadata.get("covered_start_ms", 0) or 0)
+        coverage_status = self.get_coverage_status(
+            start_ms=start_ms,
+            end_ms=coverage_end_ms,
+        )
         oldest_event_ts = int(self._events[0].timestamp) if self._events else 0
-        metadata_oldest_event_ts = int(metadata.get("oldest_event_ts", 0) or 0)
-        metadata_newest_event_ts = int(metadata.get("newest_event_ts", 0) or 0)
-        metadata_indicates_no_cached_fills = (
-            metadata_oldest_event_ts <= 0 and metadata_newest_event_ts <= 0
-        )
-        metadata_claims_history_without_events = (
-            not self._events
-            and (metadata_oldest_event_ts > 0 or metadata_newest_event_ts > 0)
-            and covered_start_ms > 0
-            and covered_start_ms <= start_ms
-        )
-        lookback_covered = (
-            covered_start_ms > 0 and covered_start_ms <= start_ms and bool(self._events)
-        ) or (
-            covered_start_ms > 0
-            and covered_start_ms <= start_ms
-            and metadata_indicates_no_cached_fills
-        )
-
-        if lookback_covered:
+        covered_start_ms = int(coverage_status.get("covered_start_ms", 0) or 0)
+        if bool(coverage_status.get("ready", False)):
             logger.debug(
                 "[fills] lookback already covered from %s (covered_start=%s oldest_event=%s); refreshing latest",
                 _format_ms(start_ms),
@@ -5579,7 +5537,7 @@ class FillEventsManager:
             await self.refresh_latest(overlap=overlap)
             return True
 
-        if metadata_claims_history_without_events:
+        if coverage_status.get("reason") == "cache_metadata_event_mismatch":
             logger.warning(
                 "[fills] cache metadata claims lookback coverage from %s, but no cached events were loaded; rebuilding from requested lookback",
                 _format_ms(covered_start_ms),
@@ -5612,6 +5570,117 @@ class FillEventsManager:
 
         self.cache.mark_covered_start(start_ms)
         return True
+
+    @staticmethod
+    def _known_gap_bounds(gap: KnownGap) -> Optional[Tuple[int, int]]:
+        try:
+            gap_start = int(gap["start_ts"])
+            gap_end = int(gap["end_ts"])
+        except (KeyError, TypeError, ValueError):
+            return None
+        if gap_end <= gap_start:
+            return None
+        return gap_start, gap_end
+
+    @staticmethod
+    def _known_gap_confirmed_legitimate(gap: KnownGap) -> bool:
+        reason = str(gap.get("reason", "") or "").lower()
+        try:
+            confidence = float(gap.get("confidence", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            confidence = 0.0
+        return reason == GAP_REASON_CONFIRMED or confidence >= GAP_CONFIDENCE_CONFIRMED
+
+    def _blocking_known_gaps(
+        self,
+        *,
+        start_ms: Optional[int],
+        end_ms: Optional[int],
+    ) -> List[KnownGap]:
+        window_start = 0 if start_ms is None else int(start_ms)
+        window_end = (2**63 - 1) if end_ms is None else int(end_ms)
+        blocking: List[KnownGap] = []
+        for gap in self.cache.get_known_gaps():
+            bounds = FillEventsManager._known_gap_bounds(gap)
+            if bounds is None:
+                blocking.append(gap)
+                continue
+            if FillEventsManager._known_gap_confirmed_legitimate(gap):
+                continue
+            gap_start, gap_end = bounds
+            if gap_start < window_end and gap_end > window_start:
+                blocking.append(gap)
+        return blocking
+
+    def get_coverage_status(
+        self,
+        *,
+        start_ms: Optional[int],
+        end_ms: Optional[int] = None,
+    ) -> Dict[str, object]:
+        """Return the canonical fill-history coverage verdict.
+
+        Callers must load the manager before asking it to judge coverage.
+        """
+        metadata = self.cache.load_metadata()
+        history_scope = self.get_history_scope()
+        covered_start_ms = int(metadata.get("covered_start_ms", 0) or 0)
+        metadata_oldest = int(metadata.get("oldest_event_ts", 0) or 0)
+        metadata_newest = int(metadata.get("newest_event_ts", 0) or 0)
+        status: Dict[str, object] = {
+            "ready": False,
+            "reason": "cache_not_loaded",
+            "history_scope": history_scope,
+            "covered_start_ms": covered_start_ms,
+            "oldest_event_ts": metadata_oldest,
+        }
+        if getattr(self, "_loaded", True) is False:
+            return status
+
+        blocking_gaps = FillEventsManager._blocking_known_gaps(
+            self,
+            start_ms=start_ms,
+            end_ms=end_ms,
+        )
+        if blocking_gaps:
+            gap = blocking_gaps[0]
+            bounds = FillEventsManager._known_gap_bounds(gap)
+            status.update(
+                {
+                    "reason": (
+                        "malformed_known_gap"
+                        if bounds is None
+                        else "known_gap_overlaps_lookback"
+                    ),
+                    "gap_start_ts": bounds[0] if bounds is not None else 0,
+                    "gap_end_ts": bounds[1] if bounds is not None else 0,
+                    "gap_reason": (
+                        str(gap.get("reason", "unknown"))
+                        if isinstance(gap, dict)
+                        else "malformed"
+                    ),
+                }
+            )
+            return status
+
+        if not self.get_events() and (metadata_oldest > 0 or metadata_newest > 0):
+            status["reason"] = "cache_metadata_event_mismatch"
+            return status
+
+        if history_scope == "all":
+            status.update({"ready": True, "reason": "full_history"})
+            return status
+
+        if start_ms is None:
+            status["reason"] = "full_history_scope_not_proven"
+            return status
+
+        if covered_start_ms > 0 and covered_start_ms <= int(start_ms):
+            status.update({"ready": True, "reason": "window_covered"})
+            return status
+
+        status["reason"] = "window_coverage_not_proven"
+        return status
 
     async def refresh_range(
         self,

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -2247,9 +2247,12 @@ class FillEventCache:
         metadata["pnl_contract"] = PNL_CONTRACT_CURRENT
         self.save_metadata(metadata)
 
-    def mark_refreshed(self) -> None:
+    def mark_refreshed(self, *, reset_event_bounds: bool = False) -> None:
         """Persist a successful refresh timestamp even if no events exist."""
         metadata = self.load_metadata()
+        if reset_event_bounds:
+            metadata["oldest_event_ts"] = 0
+            metadata["newest_event_ts"] = 0
         metadata["last_refresh_ms"] = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
         metadata["pnl_contract"] = PNL_CONTRACT_CURRENT
         self.save_metadata(metadata)
@@ -5160,7 +5163,10 @@ class FillEventsManager:
                 self._events, mark_refreshed=mark_refreshed
             )
         elif mark_refreshed:
-            self.cache.mark_refreshed()
+            # A successful empty fetch proves that metadata-only event bounds
+            # are stale. Keeping them would leave coverage permanently blocked
+            # by a cache_metadata_event_mismatch verdict.
+            self.cache.mark_refreshed(reset_event_bounds=True)
         if fetched_bounded_range:
             # A successful bounded fetch proves the retried range even when the
             # exchange returns no new fills or only duplicates.
@@ -5511,13 +5517,14 @@ class FillEventsManager:
                     if bounds is not None
                     else "unknown"
                 )
+                gap_info = gap if isinstance(gap, dict) else {}
                 logger.warning(
                     "[fills] lookback coverage remains unproven because known gap overlaps requested window | start=%s gap=%s reason=%s retry_count=%s confidence=%s",
                     _format_ms(start_ms),
                     range_label,
-                    str(gap.get("reason", "unknown")),
-                    str(gap.get("retry_count", "unknown")),
-                    str(gap.get("confidence", "unknown")),
+                    str(gap_info.get("reason", "malformed")),
+                    str(gap_info.get("retry_count", "unknown")),
+                    str(gap_info.get("confidence", "unknown")),
                 )
                 return True
 
@@ -5572,7 +5579,9 @@ class FillEventsManager:
         return True
 
     @staticmethod
-    def _known_gap_bounds(gap: KnownGap) -> Optional[Tuple[int, int]]:
+    def _known_gap_bounds(gap: object) -> Optional[Tuple[int, int]]:
+        if not isinstance(gap, dict):
+            return None
         try:
             gap_start = int(gap["start_ts"])
             gap_end = int(gap["end_ts"])
@@ -5583,7 +5592,9 @@ class FillEventsManager:
         return gap_start, gap_end
 
     @staticmethod
-    def _known_gap_confirmed_legitimate(gap: KnownGap) -> bool:
+    def _known_gap_confirmed_legitimate(gap: object) -> bool:
+        if not isinstance(gap, dict):
+            return False
         reason = str(gap.get("reason", "") or "").lower()
         try:
             confidence = float(gap.get("confidence", 0.0) or 0.0)
@@ -5596,11 +5607,14 @@ class FillEventsManager:
         *,
         start_ms: Optional[int],
         end_ms: Optional[int],
-    ) -> List[KnownGap]:
+    ) -> List[object]:
         window_start = 0 if start_ms is None else int(start_ms)
         window_end = (2**63 - 1) if end_ms is None else int(end_ms)
-        blocking: List[KnownGap] = []
-        for gap in self.cache.get_known_gaps():
+        known_gaps = self.cache.get_known_gaps()
+        if not isinstance(known_gaps, list):
+            return [None]
+        blocking: List[object] = []
+        for gap in known_gaps:
             bounds = FillEventsManager._known_gap_bounds(gap)
             if bounds is None:
                 blocking.append(gap)

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -5663,7 +5663,7 @@ class FillEventsManager:
             )
             return status
 
-        if not self.get_events() and (metadata_oldest > 0 or metadata_newest > 0):
+        if not self._events and (metadata_oldest > 0 or metadata_newest > 0):
             status["reason"] = "cache_metadata_event_mismatch"
             return status
 

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -2273,10 +2273,14 @@ class _StartupFillCacheProofAccumulator:
     _CACHE_REASONS = frozenset({"fill_cache_ready"})
     _COVERAGE_REASONS = frozenset(
         {
+            "cache_metadata_event_mismatch",
+            "cache_not_loaded",
             "full_history",
             "full_history_scope_not_proven",
             "known_gap_overlaps_lookback",
+            "malformed_known_gap",
             "missing_cache",
+            "missing_coverage_api",
             "missing_pnl_manager",
             "window_coverage_not_proven",
             "window_covered",

--- a/src/live/state_refresh.py
+++ b/src/live/state_refresh.py
@@ -220,7 +220,7 @@ def authoritative_staged_refresh_plan(bot) -> set[str]:
     plan = {"balance", "positions", "open_orders", "fills"}
     if "fills" not in pending:
         coverage_ready = True
-        coverage_ready_fn = getattr(bot, "_pnl_history_coverage_ready_for_risk", None)
+        coverage_ready_fn = getattr(bot, "_fill_history_coverage_ready", None)
         if callable(coverage_ready_fn):
             coverage_ready = bool(coverage_ready_fn())
         if not coverage_ready:

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -44,8 +44,6 @@ from candlestick_manager import (
 from fill_events_manager import (
     FillEventCacheContractError,
     FillEventsManager,
-    GAP_CONFIDENCE_CONFIRMED,
-    GAP_REASON_CONFIRMED,
     PNL_SOURCE_SYNTHETIC_DEGRADED,
     _build_fetcher_for_bot,
     _extract_symbol_pool,
@@ -1802,12 +1800,11 @@ class Passivbot:
         )
         return lookback.event_history_start_ms(self.get_exchange_time())
 
-    def _pnl_history_coverage_status(
+    def _fill_history_coverage_status(
         self,
         *,
         start_ms: Optional[int],
         end_ms: Optional[int] = None,
-        lookback=None,
     ) -> dict[str, object]:
         manager = getattr(self, "_pnls_manager", None)
         if manager is None:
@@ -1818,114 +1815,18 @@ class Passivbot:
                 "covered_start_ms": 0,
                 "oldest_event_ts": 0,
             }
-        cache = getattr(manager, "cache", None)
-        if cache is None:
-            get_history_scope = getattr(manager, "get_history_scope", None)
-            history_scope = (
-                str(get_history_scope() or "unknown").lower()
-                if callable(get_history_scope)
-                else "unknown"
-            )
-            if history_scope == "all":
-                return {
-                    "ready": True,
-                    "reason": "full_history",
-                    "history_scope": history_scope,
-                    "covered_start_ms": 0,
-                    "oldest_event_ts": 0,
-                }
+        get_coverage_status = getattr(manager, "get_coverage_status", None)
+        if not callable(get_coverage_status):
             return {
                 "ready": False,
-                "reason": "missing_cache",
+                "reason": "missing_coverage_api",
                 "history_scope": "unknown",
                 "covered_start_ms": 0,
                 "oldest_event_ts": 0,
             }
+        return dict(get_coverage_status(start_ms=start_ms, end_ms=end_ms))
 
-        metadata = {}
-        load_metadata = getattr(cache, "load_metadata", None)
-        if callable(load_metadata):
-            metadata = load_metadata() or {}
-
-        get_history_scope = getattr(manager, "get_history_scope", None)
-        if not callable(get_history_scope):
-            get_history_scope = getattr(cache, "get_history_scope", None)
-        raw_history_scope = (
-            get_history_scope()
-            if callable(get_history_scope)
-            else metadata.get("history_scope", "unknown")
-        )
-        history_scope = str(raw_history_scope or "unknown").lower()
-        if history_scope not in {"unknown", "window", "all"}:
-            history_scope = "unknown"
-
-        get_covered_start_ms = getattr(cache, "get_covered_start_ms", None)
-        if callable(get_covered_start_ms):
-            covered_start_ms = int(get_covered_start_ms() or 0)
-        else:
-            covered_start_ms = int(metadata.get("covered_start_ms", 0) or 0)
-        oldest_event_ts = int(metadata.get("oldest_event_ts", 0) or 0)
-
-        if end_ms is None:
-            try:
-                end_ms = int(self.get_exchange_time())
-            except (AttributeError, TypeError, ValueError):
-                end_ms = None
-        blocking_gaps = self._pnl_blocking_known_gaps(
-            cache,
-            metadata=metadata,
-            start_ms=start_ms,
-            end_ms=end_ms,
-        )
-        if blocking_gaps:
-            gap = blocking_gaps[0]
-            return {
-                "ready": False,
-                "reason": "known_gap_overlaps_lookback",
-                "history_scope": history_scope,
-                "covered_start_ms": covered_start_ms,
-                "oldest_event_ts": oldest_event_ts,
-                "gap_start_ts": int(gap.get("start_ts", 0) or 0),
-                "gap_end_ts": int(gap.get("end_ts", 0) or 0),
-                "gap_reason": str(gap.get("reason", "unknown")),
-            }
-
-        if history_scope == "all":
-            return {
-                "ready": True,
-                "reason": "full_history",
-                "history_scope": history_scope,
-                "covered_start_ms": covered_start_ms,
-                "oldest_event_ts": oldest_event_ts,
-            }
-
-        if start_ms is None or (lookback is not None and getattr(lookback, "is_all", False)):
-            return {
-                "ready": False,
-                "reason": "full_history_scope_not_proven",
-                "history_scope": history_scope,
-                "covered_start_ms": covered_start_ms,
-                "oldest_event_ts": oldest_event_ts,
-            }
-
-        if covered_start_ms > 0 and covered_start_ms <= int(start_ms):
-            return {
-                "ready": True,
-                "reason": "window_covered",
-                "history_scope": history_scope,
-                "covered_start_ms": covered_start_ms,
-                "oldest_event_ts": oldest_event_ts,
-            }
-
-        return {
-            "ready": False,
-            "reason": "window_coverage_not_proven",
-            "history_scope": history_scope,
-            "covered_start_ms": covered_start_ms,
-            "oldest_event_ts": oldest_event_ts,
-        }
-
-    def _pnl_history_coverage_ready_for_risk(self) -> bool:
+    def _fill_history_coverage_ready(self) -> bool:
         try:
             lookback = parse_pnls_max_lookback_days(
                 self.live_value("pnls_max_lookback_days"),
@@ -1935,10 +1836,9 @@ class Passivbot:
             start_ms = lookback.fill_cache_age_limit_ms(now_ms)
         except (AttributeError, KeyError, TypeError, ValueError):
             return False
-        status = self._pnl_history_coverage_status(
+        status = self._fill_history_coverage_status(
             start_ms=start_ms,
             end_ms=now_ms,
-            lookback=lookback,
         )
         return bool(status.get("ready", False))
 
@@ -2024,49 +1924,6 @@ class Passivbot:
         FillEventsManager.assert_no_pending_pnl(events, context=context)
 
     @staticmethod
-    def _pnl_gap_is_confirmed_legitimate(gap: dict) -> bool:
-        reason = str(gap.get("reason") or "").lower()
-        try:
-            confidence = float(gap.get("confidence", 0.0) or 0.0)
-        except (TypeError, ValueError):
-            confidence = 0.0
-        return reason == GAP_REASON_CONFIRMED or confidence >= GAP_CONFIDENCE_CONFIRMED
-
-    @staticmethod
-    def _pnl_gap_overlaps(gap: dict, start_ms: Optional[int], end_ms: Optional[int]) -> bool:
-        try:
-            gap_start = int(gap.get("start_ts", 0) or 0)
-            gap_end = int(gap.get("end_ts", 0) or 0)
-        except (TypeError, ValueError):
-            return True
-        if gap_end <= gap_start:
-            return False
-        start = 0 if start_ms is None else int(start_ms)
-        end = (2**63 - 1) if end_ms is None else int(end_ms)
-        return gap_start < end and gap_end > start
-
-    def _pnl_blocking_known_gaps(
-        self,
-        cache,
-        *,
-        metadata: Optional[dict] = None,
-        start_ms: Optional[int],
-        end_ms: Optional[int],
-    ) -> list[dict]:
-        get_known_gaps = getattr(cache, "get_known_gaps", None)
-        known_gaps = (
-            list(get_known_gaps() or [])
-            if callable(get_known_gaps)
-            else list((metadata or {}).get("known_gaps", []) or [])
-        )
-        return [
-            gap
-            for gap in known_gaps
-            if not self._pnl_gap_is_confirmed_legitimate(gap)
-            and self._pnl_gap_overlaps(gap, start_ms, end_ms)
-        ]
-
-    @staticmethod
     def _pnl_event_preview(events: Iterable[Any]) -> str:
         preview = ",".join(
             f"{str(getattr(ev, 'id', ''))[:12]}:{getattr(ev, 'symbol', '')}:"
@@ -2114,6 +1971,8 @@ class Passivbot:
             self._assert_pnl_history_coverage_for_risk(
                 context=context, start_ms=start_ms, end_ms=end_ms
             )
+        except FillEventCacheContractError:
+            raise
         except (RuntimeError, FillHistoryCoverageUnavailable) as exc:
             if not allow_incomplete:
                 raise
@@ -2131,34 +1990,34 @@ class Passivbot:
         start_ms: Optional[int],
         end_ms: Optional[int] = None,
     ) -> None:
-        cache = getattr(self._pnls_manager, "cache", None)
-        if cache is None:
-            raise RuntimeError(
-                f"{context}: fill history coverage unavailable; missing FillEventsManager cache"
-            )
-
         if end_ms is None:
             try:
                 end_ms = int(self.get_exchange_time())
             except (AttributeError, TypeError, ValueError):
                 end_ms = None
 
-        blocking_gaps = self._pnl_blocking_known_gaps(
-            cache,
-            start_ms=start_ms,
-            end_ms=end_ms,
-        )
-        if blocking_gaps:
-            gap = blocking_gaps[0]
+        status = self._fill_history_coverage_status(start_ms=start_ms, end_ms=end_ms)
+        reason = str(status.get("reason", "unknown"))
+        if reason in {"cache_metadata_event_mismatch", "malformed_known_gap"}:
+            raise FillEventCacheContractError(
+                f"{context}: fill history cache evidence is contradictory "
+                f"(reason={reason})"
+            )
+        if reason in {"missing_cache", "missing_coverage_api"}:
+            raise RuntimeError(
+                f"{context}: fill history coverage unavailable; "
+                f"missing FillEventsManager cache coverage API (reason={reason})"
+            )
+        if reason == "known_gap_overlaps_lookback":
             raise RuntimeError(
                 f"{context}: fill history gap overlaps risk lookback "
                 f"start={start_ms if start_ms is not None else 'all'} "
                 f"end={end_ms if end_ms is not None else 'latest'} "
-                f"gap={int(gap.get('start_ts', 0) or 0)}-{int(gap.get('end_ts', 0) or 0)} "
-                f"reason={gap.get('reason', 'unknown')}"
+                f"gap={int(status.get('gap_start_ts', 0) or 0)}-"
+                f"{int(status.get('gap_end_ts', 0) or 0)} "
+                f"reason={status.get('gap_reason', 'unknown')}"
             )
 
-        status = self._pnl_history_coverage_status(start_ms=start_ms, end_ms=end_ms)
         if bool(status.get("ready", False)):
             return
         history_scope = str(status.get("history_scope", "unknown"))
@@ -12486,10 +12345,9 @@ class Passivbot:
             # lookback before fill-dependent planning.
             events = self._pnls_manager.get_events()
             before_events_count = len(events)
-            coverage_status = self._pnl_history_coverage_status(
+            coverage_status = self._fill_history_coverage_status(
                 start_ms=age_limit,
                 end_ms=self.get_exchange_time(),
-                lookback=lookback,
             )
             coverage_ready = bool(coverage_status.get("ready", False))
             needs_full_refresh = lookback.is_all and not coverage_ready
@@ -12707,10 +12565,9 @@ class Passivbot:
             self._last_fill_refresh_pending_pnl_count = len(pending_pnl_events)
             self._last_fill_refresh_degraded_pnl_count = len(degraded_pnl_events)
             pnls_safe = not pending_pnl_events and not degraded_pnl_events
-            post_refresh_coverage_status = self._pnl_history_coverage_status(
+            post_refresh_coverage_status = self._fill_history_coverage_status(
                 start_ms=age_limit,
                 end_ms=self.get_exchange_time(),
-                lookback=lookback,
             )
             coverage_ready_after = bool(post_refresh_coverage_status.get("ready", False))
             fills_ready = coverage_ready_after and (
@@ -15096,10 +14953,9 @@ class Passivbot:
                 "history_scope": "unknown",
             }
         else:
-            fill_coverage_status = self._pnl_history_coverage_status(
+            fill_coverage_status = self._fill_history_coverage_status(
                 start_ms=None if lookback_start is None else int(record_start_ts),
                 end_ms=int(ts_now),
-                lookback=lookback,
             )
         result = {
             "panic_flatten_events": panic_flatten_events,

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -1967,10 +1967,9 @@ async def _hsl_replay_load_extend_and_reconcile_cache(
         field_name="live.pnls_max_lookback_days",
     )
     lookback_start = lookback.balance_history_start_ms(int(now_ms))
-    coverage_status = self._pnl_history_coverage_status(
+    coverage_status = self._fill_history_coverage_status(
         start_ms=None if lookback_start is None else int(lookback_start),
         end_ms=int(now_ms),
-        lookback=lookback,
     )
     if not bool(coverage_status.get("ready", False)):
         logging.info(

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -5651,6 +5651,131 @@ async def test_manager_refresh_for_lookback_rebuilds_when_metadata_claims_histor
 
 
 @pytest.mark.asyncio
+async def test_manager_coverage_rejects_metadata_claiming_missing_events(tmp_path: Path):
+    start_ms = 1_700_000_000_000
+    manager = FillEventsManager(
+        exchange="bybit",
+        user="default",
+        fetcher=MagicMock(),
+        cache_path=tmp_path / "fills_coverage_metadata_mismatch",
+    )
+    manager.cache.save_metadata(
+        {
+            "oldest_event_ts": start_ms + 60_000,
+            "newest_event_ts": start_ms + 120_000,
+            "covered_start_ms": start_ms,
+            "history_scope": "window",
+            "known_gaps": [],
+        }
+    )
+    await manager.ensure_loaded()
+
+    assert manager.get_coverage_status(start_ms=start_ms) == {
+        "ready": False,
+        "reason": "cache_metadata_event_mismatch",
+        "history_scope": "window",
+        "covered_start_ms": start_ms,
+        "oldest_event_ts": start_ms + 60_000,
+    }
+
+
+@pytest.mark.asyncio
+async def test_manager_coverage_accepts_proven_empty_window(tmp_path: Path):
+    start_ms = 1_700_000_000_000
+    manager = FillEventsManager(
+        exchange="bybit",
+        user="default",
+        fetcher=MagicMock(),
+        cache_path=tmp_path / "fills_coverage_empty_window",
+    )
+    manager.cache.save_metadata(
+        {
+            "oldest_event_ts": 0,
+            "newest_event_ts": 0,
+            "covered_start_ms": start_ms,
+            "history_scope": "window",
+            "known_gaps": [],
+        }
+    )
+    await manager.ensure_loaded()
+
+    assert manager.get_coverage_status(start_ms=start_ms)["reason"] == "window_covered"
+    assert manager.get_coverage_status(start_ms=start_ms)["ready"] is True
+
+
+@pytest.mark.asyncio
+async def test_manager_coverage_rejects_malformed_known_gap(tmp_path: Path):
+    start_ms = 1_700_000_000_000
+    manager = FillEventsManager(
+        exchange="bybit",
+        user="default",
+        fetcher=MagicMock(),
+        cache_path=tmp_path / "fills_coverage_malformed_gap",
+    )
+    manager.cache.save_metadata(
+        {
+            "oldest_event_ts": 0,
+            "newest_event_ts": 0,
+            "covered_start_ms": start_ms,
+            "history_scope": "window",
+            "known_gaps": [
+                {
+                    "start_ts": start_ms + 120_000,
+                    "end_ts": start_ms + 60_000,
+                    "reason": "fetch_failed",
+                    "confidence": 0.0,
+                }
+            ],
+        }
+    )
+    await manager.ensure_loaded()
+
+    status = manager.get_coverage_status(
+        start_ms=start_ms,
+        end_ms=start_ms + 180_000,
+    )
+
+    assert status["ready"] is False
+    assert status["reason"] == "malformed_known_gap"
+
+
+@pytest.mark.asyncio
+async def test_manager_coverage_allows_confirmed_legitimate_gap(tmp_path: Path):
+    start_ms = 1_700_000_000_000
+    manager = FillEventsManager(
+        exchange="bybit",
+        user="default",
+        fetcher=MagicMock(),
+        cache_path=tmp_path / "fills_coverage_confirmed_gap",
+    )
+    manager.cache.save_metadata(
+        {
+            "oldest_event_ts": 0,
+            "newest_event_ts": 0,
+            "covered_start_ms": start_ms,
+            "history_scope": "window",
+            "known_gaps": [
+                {
+                    "start_ts": start_ms + 60_000,
+                    "end_ts": start_ms + 120_000,
+                    "reason": "confirmed_legitimate",
+                    "confidence": 1.0,
+                }
+            ],
+        }
+    )
+    await manager.ensure_loaded()
+
+    status = manager.get_coverage_status(
+        start_ms=start_ms,
+        end_ms=start_ms + 180_000,
+    )
+
+    assert status["ready"] is True
+    assert status["reason"] == "window_covered"
+
+
+@pytest.mark.asyncio
 async def test_manager_refresh_for_lookback_preserves_metadata_only_no_fill_coverage(tmp_path: Path):
     cache_dir = tmp_path / "fills_lookback_no_fill_coverage"
     start_ms = 1_700_000_000_000

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -5669,6 +5669,7 @@ async def test_manager_coverage_rejects_metadata_claiming_missing_events(tmp_pat
         }
     )
     await manager.ensure_loaded()
+    manager.get_events = MagicMock(side_effect=AssertionError("coverage copied events"))
 
     assert manager.get_coverage_status(start_ms=start_ms) == {
         "ready": False,
@@ -5677,6 +5678,7 @@ async def test_manager_coverage_rejects_metadata_claiming_missing_events(tmp_pat
         "covered_start_ms": start_ms,
         "oldest_event_ts": start_ms + 60_000,
     }
+    manager.get_events.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -5648,6 +5648,16 @@ async def test_manager_refresh_for_lookback_rebuilds_when_metadata_claims_histor
     await manager.refresh_for_lookback(start_ms=start_ms)
 
     assert manager.fetcher.calls == [(start_ms, None)]
+    metadata = manager.cache.load_metadata()
+    assert metadata["oldest_event_ts"] == 0
+    assert metadata["newest_event_ts"] == 0
+    assert manager.get_coverage_status(start_ms=start_ms) == {
+        "ready": True,
+        "reason": "window_covered",
+        "history_scope": "unknown",
+        "covered_start_ms": start_ms,
+        "oldest_event_ts": 0,
+    }
 
 
 @pytest.mark.asyncio
@@ -5739,6 +5749,37 @@ async def test_manager_coverage_rejects_malformed_known_gap(tmp_path: Path):
 
     assert status["ready"] is False
     assert status["reason"] == "malformed_known_gap"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("known_gaps", [None, {"reason": "fetch_failed"}])
+async def test_manager_coverage_rejects_malformed_known_gap_container(
+    tmp_path: Path,
+    known_gaps: object,
+):
+    start_ms = 1_700_000_000_000
+    manager = FillEventsManager(
+        exchange="bybit",
+        user="default",
+        fetcher=MagicMock(),
+        cache_path=tmp_path / "fills_coverage_malformed_gap_container",
+    )
+    manager.cache.save_metadata(
+        {
+            "oldest_event_ts": 0,
+            "newest_event_ts": 0,
+            "covered_start_ms": start_ms,
+            "history_scope": "window",
+            "known_gaps": known_gaps,
+        }
+    )
+    await manager.ensure_loaded()
+
+    status = manager.get_coverage_status(start_ms=start_ms)
+
+    assert status["ready"] is False
+    assert status["reason"] == "malformed_known_gap"
+    assert status["gap_reason"] == "malformed"
 
 
 @pytest.mark.asyncio

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -5,7 +5,7 @@ from types import MethodType, SimpleNamespace
 
 import pytest
 
-from fill_events_manager import FillEvent
+from fill_events_manager import FillEvent, FillEventsManager
 from passivbot import Passivbot
 from passivbot_exceptions import RestartBotException
 from live.event_bus import ReasonCodes
@@ -193,9 +193,17 @@ def test_hsl_event_emitter_failure_logs_type_without_secret(caplog):
 
 
 class FakeRiskCache:
-    def __init__(self, covered_start_ms=1, history_scope="all"):
+    def __init__(
+        self,
+        covered_start_ms=1,
+        history_scope="all",
+        oldest_event_ts=0,
+        newest_event_ts=0,
+    ):
         self.covered_start_ms = covered_start_ms
         self.history_scope = history_scope
+        self.oldest_event_ts = oldest_event_ts
+        self.newest_event_ts = newest_event_ts
 
     def get_known_gaps(self):
         return []
@@ -211,18 +219,29 @@ class FakeRiskCache:
             "known_gaps": [],
             "covered_start_ms": self.covered_start_ms,
             "history_scope": self.history_scope,
-            "oldest_event_ts": self.covered_start_ms,
-            "newest_event_ts": 0,
+            "oldest_event_ts": self.oldest_event_ts,
+            "newest_event_ts": self.newest_event_ts,
         }
 
 
 def make_fake_pnls_manager(events, *, covered_start_ms=1, history_scope="all"):
-    cache = FakeRiskCache(covered_start_ms=covered_start_ms, history_scope=history_scope)
-    return SimpleNamespace(
+    timestamps = [int(getattr(event, "timestamp", 0) or 0) for event in events]
+    cache = FakeRiskCache(
+        covered_start_ms=covered_start_ms,
+        history_scope=history_scope,
+        oldest_event_ts=min(timestamps, default=0),
+        newest_event_ts=max(timestamps, default=0),
+    )
+    manager = SimpleNamespace(
         get_events=lambda: events,
         cache=cache,
         get_history_scope=cache.get_history_scope,
     )
+    manager.get_coverage_status = MethodType(
+        FillEventsManager.get_coverage_status,
+        manager,
+    )
+    return manager
 
 
 def test_hsl_signal_mode_requires_normalized_live_config():
@@ -2208,10 +2227,7 @@ def bind_hsl_methods(bot):
         setattr(bot, name, MethodType(getattr(hsl, name), bot))
     for name in (
         "_assert_no_pending_pnl_events",
-        "_pnl_history_coverage_status",
-        "_pnl_blocking_known_gaps",
-        "_pnl_gap_is_confirmed_legitimate",
-        "_pnl_gap_overlaps",
+        "_fill_history_coverage_status",
         "_pnl_event_preview",
         "_assert_pnl_history_safe_for_risk",
         "_assert_pnl_history_coverage_for_risk",
@@ -3711,12 +3727,9 @@ def _bind_reuse_support(bot, tmp_path, monkeypatch, *, fills, covered_start_ms=1
     bot.market_type = "swap"
     bot.qty_steps = {}
     bot.init_pnls = AsyncMock()
-    bot._pnl_history_coverage_status = MethodType(
-        Passivbot._pnl_history_coverage_status, bot
+    bot._fill_history_coverage_status = MethodType(
+        Passivbot._fill_history_coverage_status, bot
     )
-    bot._pnl_blocking_known_gaps = MethodType(Passivbot._pnl_blocking_known_gaps, bot)
-    bot._pnl_gap_is_confirmed_legitimate = Passivbot._pnl_gap_is_confirmed_legitimate
-    bot._pnl_gap_overlaps = Passivbot._pnl_gap_overlaps
     bot._hsl_extract_fill_events = MethodType(Passivbot._hsl_extract_fill_events, bot)
     bot._hsl_normalize_fill_symbol = MethodType(
         Passivbot._hsl_normalize_fill_symbol, bot
@@ -3734,6 +3747,9 @@ def _bind_reuse_support(bot, tmp_path, monkeypatch, *, fills, covered_start_ms=1
         def load_metadata(self):
             return {"covered_start_ms": covered_start_ms, "oldest_event_ts": 1}
 
+        def get_known_gaps(self):
+            return []
+
         def get_covered_start_ms(self):
             return covered_start_ms
 
@@ -3750,6 +3766,10 @@ def _bind_reuse_support(bot, tmp_path, monkeypatch, *, fills, covered_start_ms=1
             return "all"
 
     bot._pnls_manager = _StubPnlsManager()
+    bot._pnls_manager.get_coverage_status = MethodType(
+        FillEventsManager.get_coverage_status,
+        bot._pnls_manager,
+    )
     return bot
 
 
@@ -3835,6 +3855,9 @@ async def _reuse_collection_history(monkeypatch, *, n_minutes, fills, positions,
         def load_metadata(self):
             return {"covered_start_ms": 1, "oldest_event_ts": 1}
 
+        def get_known_gaps(self):
+            return []
+
         def get_covered_start_ms(self):
             return 1
 
@@ -3854,6 +3877,10 @@ async def _reuse_collection_history(monkeypatch, *, n_minutes, fills, positions,
             return "all"
 
     bot._pnls_manager = _StubPnlsManager(fills)
+    bot._pnls_manager.get_coverage_status = MethodType(
+        FillEventsManager.get_coverage_status,
+        bot._pnls_manager,
+    )
     history = await bot.get_balance_equity_history(
         current_balance=100.0,
         hsl_replay_signal_mode=signal_mode,

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -233,6 +233,7 @@ def make_fake_pnls_manager(events, *, covered_start_ms=1, history_scope="all"):
         newest_event_ts=max(timestamps, default=0),
     )
     manager = SimpleNamespace(
+        _events=list(events),
         get_events=lambda: events,
         cache=cache,
         get_history_scope=cache.get_history_scope,
@@ -3766,6 +3767,7 @@ def _bind_reuse_support(bot, tmp_path, monkeypatch, *, fills, covered_start_ms=1
             return "all"
 
     bot._pnls_manager = _StubPnlsManager()
+    bot._pnls_manager._events = bot._pnls_manager.get_events()
     bot._pnls_manager.get_coverage_status = MethodType(
         FillEventsManager.get_coverage_status,
         bot._pnls_manager,
@@ -3877,6 +3879,7 @@ async def _reuse_collection_history(monkeypatch, *, n_minutes, fills, positions,
             return "all"
 
     bot._pnls_manager = _StubPnlsManager(fills)
+    bot._pnls_manager._events = bot._pnls_manager.get_events()
     bot._pnls_manager.get_coverage_status = MethodType(
         FillEventsManager.get_coverage_status,
         bot._pnls_manager,

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -103,6 +103,72 @@ def _hostile_runtime_error(detail: str) -> RuntimeError:
     return error_cls(detail)
 
 
+def _with_fill_coverage_api(manager):
+    if getattr(manager, "cache", None) is None:
+
+        class _CoverageCache:
+            def load_metadata(self):
+                events = list(manager.get_events())
+                timestamps = [
+                    int(getattr(event, "timestamp", 0) or 0) for event in events
+                ]
+                return {
+                    "covered_start_ms": 0,
+                    "oldest_event_ts": min(timestamps, default=0),
+                    "newest_event_ts": max(timestamps, default=0),
+                    "history_scope": manager.get_history_scope(),
+                    "known_gaps": [],
+                }
+
+            def get_known_gaps(self):
+                return []
+
+        manager.cache = _CoverageCache()
+    manager.get_coverage_status = types.MethodType(
+        fem.FillEventsManager.get_coverage_status,
+        manager,
+    )
+    return manager
+
+
+def test_passivbot_fill_coverage_status_delegates_to_manager():
+    expected = {
+        "ready": False,
+        "reason": "cache_metadata_event_mismatch",
+        "history_scope": "window",
+        "covered_start_ms": 100,
+        "oldest_event_ts": 200,
+    }
+    get_coverage_status = MagicMock(return_value=expected)
+    bot = Passivbot.__new__(Passivbot)
+    bot._pnls_manager = SimpleNamespace(get_coverage_status=get_coverage_status)
+
+    assert bot._fill_history_coverage_status(start_ms=100, end_ms=300) == expected
+    get_coverage_status.assert_called_once_with(start_ms=100, end_ms=300)
+
+
+def test_incomplete_history_override_does_not_accept_contradictory_cache_evidence():
+    bot = Passivbot.__new__(Passivbot)
+    bot._pnls_manager = SimpleNamespace(
+        get_coverage_status=lambda **_kwargs: {
+            "ready": False,
+            "reason": "cache_metadata_event_mismatch",
+            "history_scope": "window",
+            "covered_start_ms": 100,
+            "oldest_event_ts": 200,
+        }
+    )
+
+    with pytest.raises(fem.FillEventCacheContractError):
+        bot._assert_pnl_history_safe_for_risk(
+            [],
+            context="test",
+            start_ms=100,
+            end_ms=300,
+            allow_incomplete=True,
+        )
+
+
 @pytest.mark.asyncio
 async def test_calc_upnl_sum_redacts_failure_and_returns_zero(caplog, capsys, monkeypatch):
     bot = Passivbot.__new__(Passivbot)
@@ -705,7 +771,7 @@ def _counted_staged_account_refresh_bot(
     bot._detect_foreign_passivbot_orders = AsyncMock()
     bot._reconcile_balance_after_positions_and_balance_refresh = lambda: False
     bot._reconcile_balance_after_open_orders_refresh = lambda: False
-    bot._pnl_history_coverage_ready_for_risk = lambda: True
+    bot._fill_history_coverage_ready = lambda: True
 
     counts = {
         "fetch_balance": 0,
@@ -2901,6 +2967,9 @@ async def test_balance_equity_history_records_pnls_manager_coverage_proof(monkey
         def get_history_scope(self):
             return "all"
 
+        def get_known_gaps(self):
+            return []
+
     class _StubPnlsManager:
         cache = _StubCache()
 
@@ -2910,7 +2979,7 @@ async def test_balance_equity_history_records_pnls_manager_coverage_proof(monkey
         def get_history_scope(self):
             return "all"
 
-    bot._pnls_manager = _StubPnlsManager()
+    bot._pnls_manager = _with_fill_coverage_api(_StubPnlsManager())
 
     history = await bot.get_balance_equity_history(
         current_balance=100.0,
@@ -4409,7 +4478,7 @@ async def test_update_pnls_routine_empty_refresh_timing_demoted_to_debug(
         }
     }
     bot._authoritative_pending_confirmations = {}
-    bot._pnls_manager = _Manager(cached_events)
+    bot._pnls_manager = _with_fill_coverage_api(_Manager(cached_events))
     bot.init_pnls = AsyncMock()
     bot.live_value = lambda key: "all" if key == "pnls_max_lookback_days" else None
     bot.get_exchange_time = lambda: 1_700_000_060_000
@@ -4487,7 +4556,7 @@ async def test_update_pnls_completed_refresh_timing_trigger_cases_stay_debug(
         }
     }
     bot._authoritative_pending_confirmations = {}
-    bot._pnls_manager = _Manager()
+    bot._pnls_manager = _with_fill_coverage_api(_Manager())
     bot.init_pnls = AsyncMock()
     bot.live_value = lambda key: "all" if key == "pnls_max_lookback_days" else None
     bot.get_exchange_time = lambda: 1_700_000_060_000
@@ -5763,7 +5832,9 @@ async def test_update_pnls_all_lookback_backfills_when_cache_scope_is_narrower()
             self.history_scope = scope
 
     bot.stop_signal_received = False
-    bot._pnls_manager = _Manager(cached_events, history_scope="window")
+    bot._pnls_manager = _with_fill_coverage_api(
+        _Manager(cached_events, history_scope="window")
+    )
     bot.init_pnls = AsyncMock()
     bot.live_value = lambda key: "all" if key == "pnls_max_lookback_days" else None
     bot.get_exchange_time = lambda: 1_700_000_060_000
@@ -5812,7 +5883,9 @@ async def test_update_pnls_all_lookback_uses_incremental_refresh_when_cache_is_f
             "pnls_max_lookback_days": "all",
         }
     }
-    bot._pnls_manager = _Manager(cached_events, history_scope="all")
+    bot._pnls_manager = _with_fill_coverage_api(
+        _Manager(cached_events, history_scope="all")
+    )
     bot.init_pnls = AsyncMock()
     bot.live_value = lambda key: "all" if key == "pnls_max_lookback_days" else None
     bot.get_exchange_time = lambda: 1_700_000_060_000
@@ -5873,7 +5946,7 @@ async def test_update_pnls_pending_enrichment_advances_only_trailing_fetch_gener
             "pnls_max_lookback_days": "all",
         }
     }
-    bot._pnls_manager = _Manager(cached_events)
+    bot._pnls_manager = _with_fill_coverage_api(_Manager(cached_events))
     bot.init_pnls = AsyncMock()
     bot.live_value = lambda key: bot.config["live"][key]
     bot.get_exchange_time = lambda: 1_700_000_060_000
@@ -5973,7 +6046,7 @@ async def test_update_pnls_window_lookback_bootstraps_when_coverage_unproven():
         }
     }
     bot._authoritative_pending_confirmations = {}
-    bot._pnls_manager = _Manager(cached_events)
+    bot._pnls_manager = _with_fill_coverage_api(_Manager(cached_events))
     bot.init_pnls = AsyncMock()
     bot.live_value = lambda key: bot.config["live"][key]
     bot.get_exchange_time = lambda: now_ms
@@ -6086,7 +6159,7 @@ async def test_update_pnls_window_lookback_stays_blocked_when_known_gap_persists
         "next_retry_ms": now_ms + 60_000,
     }
     bot._trailing_fill_fetch_generation = 7
-    bot._pnls_manager = _Manager(cached_events)
+    bot._pnls_manager = _with_fill_coverage_api(_Manager(cached_events))
     bot.init_pnls = AsyncMock()
     bot.live_value = lambda key: bot.config["live"][key]
     bot.get_exchange_time = lambda: now_ms
@@ -6208,7 +6281,7 @@ async def test_update_pnls_window_lookback_records_fills_after_known_gap_repair(
         }
     }
     bot._authoritative_pending_confirmations = {}
-    bot._pnls_manager = _Manager(cached_events)
+    bot._pnls_manager = _with_fill_coverage_api(_Manager(cached_events))
     bot.init_pnls = AsyncMock()
     bot.live_value = lambda key: bot.config["live"][key]
     bot.get_exchange_time = lambda: now_ms
@@ -6303,7 +6376,7 @@ async def test_update_pnls_window_lookback_uses_incremental_when_coverage_proven
         structured_sinks=[sink],
         monitor_sinks=[],
     )
-    bot._pnls_manager = _Manager(cached_events)
+    bot._pnls_manager = _with_fill_coverage_api(_Manager(cached_events))
     bot.init_pnls = AsyncMock()
     bot.live_value = lambda key: bot.config["live"][key]
     bot.get_exchange_time = lambda: now_ms
@@ -6435,7 +6508,7 @@ async def test_update_pnls_repairs_old_degraded_pnl_before_marking_fills_authori
         }
     }
     bot._authoritative_pending_confirmations = {}
-    bot._pnls_manager = _Manager()
+    bot._pnls_manager = _with_fill_coverage_api(_Manager())
     if failure_stage == "routine":
         bot._pnls_manager.refresh_latest.side_effect = RuntimeError(
             "routine refresh unavailable"
@@ -6564,7 +6637,7 @@ async def test_update_pnls_keeps_structural_fills_ready_when_pnl_consumers_disab
         }
     }
     bot._authoritative_pending_confirmations = {}
-    bot._pnls_manager = _Manager()
+    bot._pnls_manager = _with_fill_coverage_api(_Manager())
     bot._live_risk_uses_authoritative_pnl = lambda: False
     bot.init_pnls = AsyncMock()
     bot.live_value = lambda key: bot.config["live"][key]
@@ -6633,7 +6706,9 @@ async def test_update_pnls_uses_confirmation_overlap_when_fills_pending():
         }
     }
     bot._authoritative_pending_confirmations = {"fills": 2}
-    bot._pnls_manager = _Manager(cached_events, history_scope="all")
+    bot._pnls_manager = _with_fill_coverage_api(
+        _Manager(cached_events, history_scope="all")
+    )
     bot.init_pnls = AsyncMock()
     bot.live_value = lambda key: "all" if key == "pnls_max_lookback_days" else None
     bot.get_exchange_time = lambda: 1_700_000_060_000
@@ -6710,7 +6785,7 @@ async def test_update_pnls_widens_refresh_for_mismatched_trailing_fill_anchor(
         }
     }
     bot._authoritative_pending_confirmations = {"fills": 2}
-    bot._pnls_manager = _Manager()
+    bot._pnls_manager = _with_fill_coverage_api(_Manager())
     bot.init_pnls = AsyncMock()
     bot.live_value = lambda key: bot.config["live"][key]
     bot.get_exchange_time = lambda: now_ms
@@ -6793,7 +6868,7 @@ async def test_mandatory_fill_confirmation_does_not_widen_trailing_recovery(
         }
     }
     bot._authoritative_pending_confirmations = {"fills": 2}
-    bot._pnls_manager = _Manager()
+    bot._pnls_manager = _with_fill_coverage_api(_Manager())
     bot.init_pnls = AsyncMock()
     bot.live_value = lambda key: bot.config["live"][key]
     bot.get_exchange_time = lambda: now_ms
@@ -6870,7 +6945,9 @@ async def test_update_pnls_propagates_unexpected_refresh_errors_without_retainin
         structured_sinks=[sink],
         monitor_sinks=[],
     )
-    bot._pnls_manager = _Manager(cached_events, history_scope="all")
+    bot._pnls_manager = _with_fill_coverage_api(
+        _Manager(cached_events, history_scope="all")
+    )
     bot.init_pnls = AsyncMock()
     bot.live_value = lambda key: "all" if key == "pnls_max_lookback_days" else None
     bot.get_exchange_time = lambda: 1_700_000_060_000
@@ -6986,7 +7063,7 @@ async def test_update_pnls_failure_logs_only_bounded_status_and_code(caplog):
             "pnls_max_lookback_days": "all",
         }
     }
-    bot._pnls_manager = _Manager()
+    bot._pnls_manager = _with_fill_coverage_api(_Manager())
     bot.init_pnls = AsyncMock()
     bot.live_value = lambda key: "all" if key == "pnls_max_lookback_days" else None
     bot.get_exchange_time = lambda: 1_700_000_060_000
@@ -7040,7 +7117,7 @@ async def test_update_pnls_rate_limit_does_not_advance_trailing_fetch_generation
             "pnls_max_lookback_days": "all",
         }
     }
-    bot._pnls_manager = _Manager(cached_events)
+    bot._pnls_manager = _with_fill_coverage_api(_Manager(cached_events))
     bot.init_pnls = AsyncMock()
     bot.live_value = lambda key: bot.config["live"][key]
     bot.get_exchange_time = lambda: 1_700_000_060_000
@@ -7105,7 +7182,9 @@ async def test_update_pnls_emits_summary_when_exchange_time_resync_handles_error
         structured_sinks=[sink],
         monitor_sinks=[],
     )
-    bot._pnls_manager = _Manager(cached_events, history_scope="all")
+    bot._pnls_manager = _with_fill_coverage_api(
+        _Manager(cached_events, history_scope="all")
+    )
     bot.init_pnls = AsyncMock()
     bot.live_value = lambda key: "all" if key == "pnls_max_lookback_days" else None
     bot.get_exchange_time = lambda: 1_700_000_060_000
@@ -7174,7 +7253,7 @@ async def test_update_pnls_suppresses_inflight_shutdown_refresh_error(caplog):
             "pnls_max_lookback_days": "all",
         }
     }
-    bot._pnls_manager = _Manager(cached_events)
+    bot._pnls_manager = _with_fill_coverage_api(_Manager(cached_events))
     bot.init_pnls = AsyncMock()
     bot.live_value = lambda key: "all" if key == "pnls_max_lookback_days" else None
     bot.get_exchange_time = lambda: 1_700_000_060_000
@@ -8365,12 +8444,14 @@ def test_open_unstuck_order_does_not_gate_live_unstuck_emission(monkeypatch):
     bot = Passivbot.__new__(Passivbot)
     bot.balance = 100.0
     bot.balance_raw = 200.0
-    bot._pnls_manager = types.SimpleNamespace(
-        get_events=lambda: [
-            types.SimpleNamespace(pnl=10.0, fee_paid=-1.0),
-        ],
-        cache=_SafeRiskCache(),
-        get_history_scope=lambda: "all",
+    bot._pnls_manager = _with_fill_coverage_api(
+        types.SimpleNamespace(
+            get_events=lambda: [
+                types.SimpleNamespace(pnl=10.0, fee_paid=-1.0),
+            ],
+            cache=_SafeRiskCache(),
+            get_history_scope=lambda: "all",
+        )
     )
     bot.bot_value = lambda pside, key: {
         "unstuck_loss_allowance_pct": 0.2 if pside == "long" else 0.0,
@@ -8412,13 +8493,15 @@ def test_unstuck_allowance_routes_raw_balance_to_rust(monkeypatch):
     bot = Passivbot.__new__(Passivbot)
     bot.balance = 100.0
     bot.balance_raw = 200.0
-    bot._pnls_manager = types.SimpleNamespace(
-        get_events=lambda: [
-            types.SimpleNamespace(pnl=10.0, fee_paid=-1.0),
-            types.SimpleNamespace(pnl=-4.0, fee_paid=-0.5),
-        ],
-        cache=_SafeRiskCache(),
-        get_history_scope=lambda: "all",
+    bot._pnls_manager = _with_fill_coverage_api(
+        types.SimpleNamespace(
+            get_events=lambda: [
+                types.SimpleNamespace(pnl=10.0, fee_paid=-1.0),
+                types.SimpleNamespace(pnl=-4.0, fee_paid=-0.5),
+            ],
+            cache=_SafeRiskCache(),
+            get_history_scope=lambda: "all",
+        )
     )
 
     def bot_value(pside, key):
@@ -8460,18 +8543,22 @@ def test_unstuck_allowance_uses_only_configured_pnl_lookback(monkeypatch):
     bot.balance_raw = 1000.0
     bot.get_raw_balance = lambda: float(bot.balance_raw)
     _set_pnl_lookback(bot, lookback_days=1.0, now_ms=now_ms)
-    bot._pnls_manager = types.SimpleNamespace(
-        get_events=lambda start_ms=None, end_ms=None, symbol=None: [
-            ev
-            for ev in [
-                types.SimpleNamespace(pnl=100.0, timestamp=now_ms - 3 * 86_400_000),
-                types.SimpleNamespace(pnl=-80.0, timestamp=now_ms - 3 * 86_400_000 + 1),
-                types.SimpleNamespace(pnl=10.0, timestamp=now_ms - 60_000),
-            ]
-            if start_ms is None or ev.timestamp >= start_ms
-        ],
-        cache=_SafeRiskCache(),
-        get_history_scope=lambda: "all",
+    bot._pnls_manager = _with_fill_coverage_api(
+        types.SimpleNamespace(
+            get_events=lambda start_ms=None, end_ms=None, symbol=None: [
+                ev
+                for ev in [
+                    types.SimpleNamespace(pnl=100.0, timestamp=now_ms - 3 * 86_400_000),
+                    types.SimpleNamespace(
+                        pnl=-80.0, timestamp=now_ms - 3 * 86_400_000 + 1
+                    ),
+                    types.SimpleNamespace(pnl=10.0, timestamp=now_ms - 60_000),
+                ]
+                if start_ms is None or ev.timestamp >= start_ms
+            ],
+            cache=_SafeRiskCache(),
+            get_history_scope=lambda: "all",
+        )
     )
 
     def bot_value(pside, key):
@@ -9297,7 +9384,7 @@ def test_staged_refresh_plan_defers_fills_until_next_minute(monkeypatch):
     bot = Passivbot.__new__(Passivbot)
     bot.freshness_ledger = FreshnessLedger(now_ms=0)
     bot._authoritative_pending_confirmations = {}
-    bot._pnl_history_coverage_ready_for_risk = lambda: True
+    bot._fill_history_coverage_ready = lambda: True
     bot.freshness_ledger.stamp("fills", ("fills", "fresh"), now_ms=120_010, epoch=1)
 
     monkeypatch.setattr(passivbot_module, "utc_ms", lambda: 120_500)
@@ -9318,7 +9405,7 @@ def test_staged_refresh_plan_schedules_trailing_recovery_without_barrier(
     bot = Passivbot.__new__(Passivbot)
     bot.freshness_ledger = FreshnessLedger(now_ms=0)
     bot._authoritative_pending_confirmations = {}
-    bot._pnl_history_coverage_ready_for_risk = lambda: True
+    bot._fill_history_coverage_ready = lambda: True
     bot._trailing_fill_recovery_prefetch_due = lambda: True
     scheduled = []
     bot._schedule_routine_fill_refresh_prefetch = (
@@ -9342,7 +9429,7 @@ def test_staged_refresh_plan_keeps_stale_fills_during_trailing_recovery(
     bot = Passivbot.__new__(Passivbot)
     bot.freshness_ledger = FreshnessLedger(now_ms=0)
     bot._authoritative_pending_confirmations = {}
-    bot._pnl_history_coverage_ready_for_risk = lambda: True
+    bot._fill_history_coverage_ready = lambda: True
     bot._trailing_fill_recovery_prefetch_due = lambda: True
     scheduled = []
     bot._schedule_routine_fill_refresh_prefetch = (
@@ -9363,7 +9450,7 @@ def test_staged_refresh_plan_keeps_fills_when_risk_coverage_unproven(monkeypatch
     bot = Passivbot.__new__(Passivbot)
     bot.freshness_ledger = FreshnessLedger(now_ms=0)
     bot._authoritative_pending_confirmations = {}
-    bot._pnl_history_coverage_ready_for_risk = lambda: False
+    bot._fill_history_coverage_ready = lambda: False
     bot.freshness_ledger.stamp("fills", ("fills", "fresh"), now_ms=120_010, epoch=1)
 
     monkeypatch.setattr(passivbot_module, "utc_ms", lambda: 120_500)
@@ -9407,9 +9494,12 @@ def test_staged_refresh_plan_keeps_fills_when_known_gap_overlaps_lookback(monkey
     bot = Passivbot.__new__(Passivbot)
     bot.freshness_ledger = FreshnessLedger(now_ms=0)
     bot._authoritative_pending_confirmations = {}
-    bot._pnls_manager = SimpleNamespace(
-        cache=cache,
-        get_history_scope=lambda: "window",
+    bot._pnls_manager = _with_fill_coverage_api(
+        SimpleNamespace(
+            cache=cache,
+            get_events=lambda: [],
+            get_history_scope=lambda: "window",
+        )
     )
     bot.config = {"live": {"pnls_max_lookback_days": 1.0}}
     bot.live_value = lambda key: bot.config["live"][key]
@@ -9418,7 +9508,7 @@ def test_staged_refresh_plan_keeps_fills_when_known_gap_overlaps_lookback(monkey
 
     monkeypatch.setattr(passivbot_module, "utc_ms", lambda: 120_500)
 
-    assert bot._pnl_history_coverage_ready_for_risk() is False
+    assert bot._fill_history_coverage_ready() is False
     assert bot._authoritative_staged_refresh_plan() == {
         "balance",
         "positions",

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -124,6 +124,8 @@ def _with_fill_coverage_api(manager):
                 return []
 
         manager.cache = _CoverageCache()
+    if not hasattr(manager, "_events"):
+        manager._events = list(manager.get_events())
     manager.get_coverage_status = types.MethodType(
         fem.FillEventsManager.get_coverage_status,
         manager,

--- a/tests/test_realized_loss_gate.py
+++ b/tests/test_realized_loss_gate.py
@@ -97,6 +97,7 @@ def _make_bot_with_events(events, balance=10000.0, cache=_DEFAULT_RISK_CACHE):
         return out
 
     bot._pnls_manager.get_events.side_effect = _get_events
+    bot._pnls_manager._events = list(events)
     if cache is _DEFAULT_RISK_CACHE:
         oldest_event_ts = min(
             (int(getattr(ev, "timestamp", 0) or 0) for ev in events),

--- a/tests/test_realized_loss_gate.py
+++ b/tests/test_realized_loss_gate.py
@@ -11,6 +11,7 @@ import pytest
 
 from passivbot import Passivbot
 from backtest import prep_backtest_args
+from fill_events_manager import FillEventsManager
 from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
 
 # ---------------------------------------------------------------------------
@@ -99,17 +100,31 @@ def _make_bot_with_events(events, balance=10000.0, cache=_DEFAULT_RISK_CACHE):
     if cache is _DEFAULT_RISK_CACHE:
         oldest_event_ts = min(
             (int(getattr(ev, "timestamp", 0) or 0) for ev in events),
-            default=1,
+            default=0,
         )
         cache = _RiskCache(
             covered_start_ms=1,
             history_scope="all",
-            oldest_event_ts=max(1, oldest_event_ts),
+            oldest_event_ts=oldest_event_ts,
         )
     bot._pnls_manager.cache = cache
     if cache is not None:
         bot._pnls_manager.cache = cache
         bot._pnls_manager.get_history_scope.side_effect = cache.get_history_scope
+        bot._pnls_manager.get_coverage_status.side_effect = (
+            lambda **kwargs: FillEventsManager.get_coverage_status(
+                bot._pnls_manager,
+                **kwargs,
+            )
+        )
+    else:
+        bot._pnls_manager.get_coverage_status.return_value = {
+            "ready": False,
+            "reason": "missing_cache",
+            "history_scope": "unknown",
+            "covered_start_ms": 0,
+            "oldest_event_ts": 0,
+        }
     bot.balance = balance
     return bot
 


### PR DESCRIPTION
## Summary

- make `FillEventsManager` the single owner of fill-history coverage and known-gap classification
- reduce Passivbot coverage handling to a thin manager delegate and remove its duplicate gap helpers
- use the same verdict in lookback refresh, staged readiness, HSL replay, and realized-PnL safety checks
- fail closed when metadata claims cached events that did not load or when known-gap bounds are malformed
- preserve confirmed-legitimate gaps, proven empty windows, existing retry/backoff policy, and the explicit incomplete-history override for genuinely incomplete (not contradictory) evidence

## Why

The live layer and `FillEventsManager` had independently evolved coverage decision trees. They disagreed on contradictory metadata and malformed gaps, making the orchestration path able to accept evidence that the manager itself would rebuild or block. This PR removes the duplicate ownership instead of adding another reconciliation patch.

Production orchestration is reduced by roughly 144 net lines in `src/passivbot.py`; the canonical manager logic is then reused by both readiness and refresh.

## Validation

- rebuilt and source-fingerprint-verified the current Rust extension required by the risk tests (no Rust source changes)
- 842 tests passed across:
  - `tests/test_passivbot_balance_split.py`
  - `tests/test_hsl_coin_mode.py`
  - `tests/test_fill_events_manager.py`
  - `tests/test_live_performance_report.py`
  - `tests/test_realized_loss_gate.py`
- focused fill-history coverage tests in `tests/test_unstucking_safeguards.py` passed
- Python bytecode compilation passed for all changed runtime modules
- `git diff --check` passed

Base verified current at `691568107023be5c3067e7d297789532eb787b03`.