### PR TITLE
Fix Bitunix cold-start live initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,10 @@ All notable user-facing changes will be documented in this file.
   WebSockets are explicitly disabled. The connector rejects invalid order quantities and
   case-insensitive authentication-header collisions, isolates malformed order-detail rows, retains
   synthetic ticker provenance, refreshes public ticker subscriptions as markets change, times
-  ticker-cache freshness locally, and reconciles malformed private-WebSocket rows.
+  ticker-cache freshness locally, reconciles malformed private-WebSocket rows, sends the venue's
+  JSON keepalive on idle private streams, supplies conservative documented VIP0 futures fees to
+  live planning, retries transient native market-discovery failures, and uses native public REST
+  market loading during cold-cache CLI startup instead of falling through to CCXT.
 - Fills sharing a single millisecond are now ordered by the position chain the exchange reports
   with each fill instead of by arbitrary response order. Hyperliquid executions retain their
   individual `startPosition` boundaries, and older coalesced cache rows are expanded back into those

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -371,7 +371,10 @@ candlestick-manager contract may bridge delayed current candles.
 Bitunix is not available in the pinned CCXT release, so the production connector is a narrow
 native async REST/WebSocket implementation rather than a generic `CCXTBot` exchange class.
 It retains the CCXT-compatible object boundary consumed by Passivbot while implementing only the
-futures operations required by live trading.
+futures operations required by live trading. Cold-cache standalone market preloads use this native
+public REST client as well; they must never fall through to CCXT before the bot is constructed.
+Native market records use Bitunix's documented VIP0 futures maker/taker fees as conservative
+planning inputs because the trading-pairs endpoint does not publish account fee tiers.
 
 Handling:
 
@@ -380,15 +383,18 @@ Handling:
 2. Supply `marginCoin=USDT` to account and symbol-configuration requests. Successful account data
    may be either an object or a singleton list; accept exactly those shapes.
 3. Map business error envelopes to CCXT exception classes and propagate unknown failures. Keep
-   request spacing below the venue's documented UID/IP rolling limit.
+   request spacing below the venue's documented UID/IP rolling limit. Treat the observed
+   `code=1, msg=Network Error` envelope like documented network error `10001`, and retry native
+   market discovery with bounded backoff so a transient cold-start response is not permanent.
 4. Authenticate the private WebSocket with its seconds-based signature, subscribe to `order`, and
-   enrich each notification from REST order detail before publishing it. The raw push lacks enough
-   durable close-only metadata for authoritative reconciliation. If REST reports that the order is
-   not found or returns semantically invalid order detail, publish only that raw row as untrusted so
-   the generic watcher requests an authoritative account-state refresh instead of silently
-   discarding the transition. Treat non-object pushes and rows without an order ID the same way
-   instead of dropping them before reconciliation. Transport failures still fail the batch and
-   reconnect.
+   send Bitunix's application-level JSON ping while idle; transport-level WebSocket heartbeats do
+   not replace the venue keepalive. Enrich each order notification from REST detail before
+   publishing it. The raw push lacks enough durable close-only metadata for authoritative
+   reconciliation. If REST reports that the order is not found or returns semantically invalid
+   order detail, publish only that raw row as untrusted so the generic watcher requests an
+   authoritative account-state refresh instead of silently discarding the transition. Treat
+   non-object pushes and rows without an order ID the same way instead of dropping them before
+   reconciliation. Transport failures still fail the batch and reconnect.
 5. Apply custom endpoint domain rewrites and `rest.url_overrides.api` to the native REST base, and
    merge `rest.extra_headers` into every request. Reject authentication header names
    case-insensitively in configured headers so proxy or user headers cannot collide with generated

--- a/src/exchanges/bitunix.py
+++ b/src/exchanges/bitunix.py
@@ -31,6 +31,30 @@ from passivbot import logging
 from utils import symbol_to_coin
 
 
+def apply_bitunix_endpoint_override(
+    config: dict, endpoint_override: Any | None
+) -> dict:
+    """Apply the native Bitunix REST override contract to a client config."""
+    resolved = dict(config)
+    if endpoint_override is None:
+        return resolved
+    unsupported_keys = set(endpoint_override.rest_url_overrides) - {"api"}
+    if unsupported_keys:
+        raise CustomEndpointConfigError(
+            "bitunix: unsupported REST URL override key(s): "
+            + ", ".join(sorted(unsupported_keys))
+            + "; use 'api' for the native REST base"
+        )
+    rest_urls = endpoint_override.apply_to_api_urls(
+        {"api": BitunixClient.REST_URL}
+    )
+    resolved["restUrl"] = rest_urls["api"]
+    headers = dict(resolved.get("headers") or {})
+    headers.update(endpoint_override.rest_extra_headers)
+    resolved["headers"] = headers
+    return resolved
+
+
 def _float(value: Any, *, field: str, default: float | None = None) -> float:
     if value in (None, ""):
         if default is not None:
@@ -86,6 +110,11 @@ class BitunixClient:
     TICKER_MAX_AGE_MS = 30_000
     TICKER_WAIT_SECONDS = 8.0
     MAX_DEPTH_FALLBACK_SYMBOLS = 8
+    # Bitunix does not expose fee rates through the trading-pairs endpoint.
+    # Use the documented VIP0 futures rates as conservative live-planning
+    # inputs; higher VIP tiers pay equal or lower fees.
+    DEFAULT_MAKER_FEE = 0.0002
+    DEFAULT_TAKER_FEE = 0.0006
     RESERVED_AUTH_HEADERS = frozenset({"api-key", "nonce", "timestamp", "sign"})
 
     has = {
@@ -233,7 +262,12 @@ class BitunixClient:
         text = f"Bitunix error {code_text}: {safe_message}"
         if code_text in {"403", "10003", "10004", "10007"}:
             raise AuthenticationError(text)
-        if code_text == "10001":
+        # The documented transport code is 10001. The live trading-pairs
+        # endpoint also emits code 1 with the same message; classify both as
+        # retryable network failures instead of permanent bad requests.
+        if code_text == "10001" or (
+            code_text == "1" and safe_message.strip().lower() == "network error"
+        ):
             raise NetworkError(text)
         if code_text in {"10005", "10006", "429"}:
             raise RateLimitExceeded(text)
@@ -306,9 +340,17 @@ class BitunixClient:
     async def load_markets(self, reload: bool = False) -> dict[str, dict]:
         if self.markets and not reload:
             return self.markets
-        rows = await self._request(
-            "GET", "/api/v1/futures/market/trading_pairs"
-        )
+        rows = None
+        for attempt in range(3):
+            try:
+                rows = await self._request(
+                    "GET", "/api/v1/futures/market/trading_pairs"
+                )
+                break
+            except NetworkError:
+                if attempt == 2:
+                    raise
+                await asyncio.sleep(0.5 * (2**attempt))
         if not isinstance(rows, list):
             raise ValueError("Bitunix trading-pairs response is not a list")
         markets: dict[str, dict] = {}
@@ -360,6 +402,8 @@ class BitunixClient:
                 "contract": True,
                 "linear": True,
                 "inverse": False,
+                "maker": self.DEFAULT_MAKER_FEE,
+                "taker": self.DEFAULT_TAKER_FEE,
                 "active": (
                     str(row.get("symbolStatus") or "").upper() == "OPEN"
                     and row.get("isApiSupported") is True
@@ -1413,11 +1457,27 @@ class BitunixOrderStream:
 
     id = "bitunix"
     has = {"watchOrders": True}
+    PING_INTERVAL_SECONDS = 15.0
 
     def __init__(self, rest: BitunixClient):
         self.rest = rest
         self.options: dict[str, Any] = {}
         self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._last_ping_monotonic = time.monotonic()
+
+    async def _receive_with_keepalive(
+        self, ws: aiohttp.ClientWebSocketResponse
+    ) -> aiohttp.WSMessage:
+        """Receive one frame while satisfying Bitunix's JSON ping contract."""
+        while True:
+            elapsed = time.monotonic() - self._last_ping_monotonic
+            timeout = max(0.0, self.PING_INTERVAL_SECONDS - elapsed)
+            try:
+                return await asyncio.wait_for(ws.receive(), timeout=timeout)
+            except asyncio.TimeoutError:
+                ping_timestamp = int(time.time())
+                await ws.send_json({"op": "ping", "ping": ping_timestamp})
+                self._last_ping_monotonic = time.monotonic()
 
     def _login_payload(self) -> dict:
         if not self.rest.apiKey or not self.rest.secret:
@@ -1460,6 +1520,7 @@ class BitunixOrderStream:
                     raise AuthenticationError("Bitunix private websocket login failed")
                 break
         await ws.send_json({"op": "subscribe", "args": [{"ch": "order"}]})
+        self._last_ping_monotonic = time.monotonic()
         self._ws = ws
         return ws
 
@@ -1468,7 +1529,7 @@ class BitunixOrderStream:
         if ws is None or ws.closed:
             ws = await self._connect()
         while True:
-            message = await ws.receive()
+            message = await self._receive_with_keepalive(ws)
             if message.type == aiohttp.WSMsgType.TEXT:
                 payload = json.loads(message.data)
                 if payload.get("ch") != "order":
@@ -1528,22 +1589,9 @@ class BitunixBot(CCXTBot):
     def create_ccxt_sessions(self) -> None:
         ccxt_config = self._build_ccxt_config()
         ccxt_config["wsEnabled"] = bool(self.ws_enabled)
-        endpoint_override = getattr(self, "endpoint_override", None)
-        if endpoint_override is not None:
-            unsupported_keys = set(endpoint_override.rest_url_overrides) - {"api"}
-            if unsupported_keys:
-                raise CustomEndpointConfigError(
-                    "bitunix: unsupported REST URL override key(s): "
-                    + ", ".join(sorted(unsupported_keys))
-                    + "; use 'api' for the native REST base"
-                )
-            rest_urls = endpoint_override.apply_to_api_urls(
-                {"api": BitunixClient.REST_URL}
-            )
-            ccxt_config["restUrl"] = rest_urls["api"]
-            headers = dict(ccxt_config.get("headers") or {})
-            headers.update(endpoint_override.rest_extra_headers)
-            ccxt_config["headers"] = headers
+        ccxt_config = apply_bitunix_endpoint_override(
+            ccxt_config, getattr(self, "endpoint_override", None)
+        )
         self.cca = BitunixClient(ccxt_config)
         self.cca.options.update(self.user_info.get("options", {}))
         if self.ws_enabled:
@@ -1616,8 +1664,21 @@ class BitunixBot(CCXTBot):
                 )
 
     def set_market_specific_settings(self) -> None:
+        sizing_symbols = sorted(self.symbols_requiring_market_sizing())
+        for symbol in sizing_symbols:
+            market = self.markets_dict[symbol]
+            # Caches written by the initial native connector release predate
+            # fee metadata. Upgrade those records in memory so existing users
+            # do not need to delete a fresh markets cache manually.
+            if market.get("maker_fee") is None and market.get("maker") is None:
+                market["maker"] = BitunixClient.DEFAULT_MAKER_FEE
+            if market.get("taker_fee") is None and market.get("taker") is None:
+                market["taker"] = BitunixClient.DEFAULT_TAKER_FEE
         super().set_market_specific_settings()
-        for symbol in sorted(self.symbols_requiring_market_sizing()):
+        for symbol in sizing_symbols:
+            # Fail during initialization, before entering the execution loop,
+            # if native metadata ever stops providing mandatory planning fees.
+            self._get_exchange_fee_rates(symbol)
             raw = self.markets_dict[symbol].get("info") or {}
             max_leverage = _float(
                 raw.get("maxLeverage"), field=f"{symbol}.maxLeverage"

--- a/src/utils.py
+++ b/src/utils.py
@@ -489,12 +489,12 @@ async def load_markets(
     quote=None,
 ) -> dict:
     """
-    Standalone helper to load and cache CCXT markets for a given exchange.
+    Standalone helper to load and cache markets for a given exchange.
 
     - Reads from caches/{exchange}/markets.json if fresh
-    - Otherwise fetches via ccxt, writes cache, and returns the markets dict
+    - Otherwise fetches through the exchange client, writes cache, and returns the markets dict
 
-    Returns a markets dictionary as provided by ccxt.
+    Returns a CCXT-compatible markets dictionary.
 
     Note: Uses the exchange name as-is (e.g., "binance" not "binanceusdm") for
     consistency with other cache paths (pnls, ohlcv, fill_events).
@@ -517,10 +517,29 @@ async def load_markets(
     except Exception as e:
         logging.error("Error loading %s: %s", markets_path, e)
 
-    # Fetch from exchange via ccxt
+    # Fetch from the exchange client.
     owned_cc = cc is None
     if owned_cc:
-        cc = load_ccxt_instance(ex, enable_rate_limit=True)
+        if ex == "bitunix":
+            # Bitunix is intentionally native because it is absent from CCXT.
+            # Standalone market preloads must use the same public REST client as
+            # the live bot so a cold cache cannot fall through to CCXT.
+            from exchanges.bitunix import (
+                BitunixClient,
+                apply_bitunix_endpoint_override,
+            )
+
+            client_config = apply_bitunix_endpoint_override(
+                {
+                    "enableRateLimit": True,
+                    "timeout": 60_000,
+                    "wsEnabled": False,
+                },
+                resolve_custom_endpoint_override(ex),
+            )
+            cc = BitunixClient(client_config)
+        else:
+            cc = load_ccxt_instance(ex, enable_rate_limit=True)
     try:
         markets = await cc.load_markets(True)
     except Exception as e:

--- a/tests/exchanges/test_bitunix.py
+++ b/tests/exchanges/test_bitunix.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -51,6 +52,8 @@ def _market():
         "id": "BTCUSDT",
         "symbol": "BTC/USDT:USDT",
         "active": True,
+        "maker": BitunixClient.DEFAULT_MAKER_FEE,
+        "taker": BitunixClient.DEFAULT_TAKER_FEE,
         "info": MARKET_ROW,
     }
 
@@ -197,6 +200,11 @@ def test_api_errors_map_to_ccxt_exception_contract(code, error_type):
         BitunixClient._raise_api_error(code, "test")
 
 
+def test_observed_code_one_network_envelope_is_retryable():
+    with pytest.raises(NetworkError, match="Network Error"):
+        BitunixClient._raise_api_error(1, "Network Error")
+
+
 @pytest.mark.asyncio
 async def test_load_markets_maps_base_quantity_and_tick_sizes():
     client = BitunixClient()
@@ -210,9 +218,27 @@ async def test_load_markets_maps_base_quantity_and_tick_sizes():
     assert market["linear"] is True
     assert market["active"] is True
     assert market["contractSize"] == 1.0
+    assert market["maker"] == pytest.approx(0.0002)
+    assert market["taker"] == pytest.approx(0.0006)
     assert market["precision"] == {"amount": 0.0001, "price": 0.1}
     assert market["limits"]["amount"]["min"] == pytest.approx(0.0001)
     assert market["limits"]["leverage"]["max"] == pytest.approx(125)
+
+
+@pytest.mark.asyncio
+async def test_load_markets_retries_observed_network_error(monkeypatch):
+    client = BitunixClient()
+    client._request = AsyncMock(
+        side_effect=[NetworkError("transient"), [MARKET_ROW]]
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr("exchanges.bitunix.asyncio.sleep", sleep)
+
+    markets = await client.load_markets(True)
+
+    assert "BTC/USDT:USDT" in markets
+    assert client._request.await_count == 2
+    sleep.assert_awaited_once_with(0.5)
 
 
 @pytest.mark.asyncio
@@ -772,6 +798,45 @@ async def test_order_stream_surfaces_unenriched_row_when_detail_is_not_found():
 
 
 @pytest.mark.asyncio
+async def test_order_stream_sends_documented_json_ping_when_idle(monkeypatch):
+    client = _prepared_client()
+    stream = BitunixOrderStream(client)
+    stream._last_ping_monotonic = (
+        time.monotonic() - stream.PING_INTERVAL_SECONDS - 1.0
+    )
+    monkeypatch.setattr("exchanges.bitunix.time.time", lambda: 1_700_000_000.9)
+    order_message = SimpleNamespace(
+        type=aiohttp.WSMsgType.TEXT,
+        data=json.dumps(
+            {
+                "ch": "order",
+                "data": {
+                    "orderId": "order-1",
+                    "symbol": "BTCUSDT",
+                    "status": "FILLED",
+                },
+            }
+        ),
+    )
+    ws = SimpleNamespace(
+        closed=False,
+        receive=AsyncMock(return_value=order_message),
+        send_json=AsyncMock(),
+    )
+    stream._ws = ws
+    client.fetch_order = AsyncMock(
+        return_value={"id": "order-1", "symbol": "BTC/USDT:USDT"}
+    )
+
+    rows = await stream.watch_orders()
+
+    ws.send_json.assert_awaited_once_with(
+        {"op": "ping", "ping": 1_700_000_000}
+    )
+    assert rows == [{"id": "order-1", "symbol": "BTC/USDT:USDT"}]
+
+
+@pytest.mark.asyncio
 async def test_order_stream_isolates_malformed_rest_detail_to_its_row():
     client = _prepared_client()
     valid_order = client._normalize_order(_order_row(orderId="order-2"))
@@ -1215,6 +1280,30 @@ def test_native_session_rejects_unsupported_endpoint_url_keys():
 
     with pytest.raises(CustomEndpointConfigError, match="unsupported REST URL override"):
         bot.create_ccxt_sessions()
+
+
+def test_market_settings_upgrade_legacy_cache_with_conservative_fees():
+    bot = build_contract_bot("bitunix")
+    symbol = "BTC/USDT:USDT"
+    market = {
+        **_market(),
+        "precision": {"amount": 0.0001, "price": 0.1},
+        "limits": {
+            "amount": {"min": 0.0001, "max": None},
+            "price": {"min": 0.1, "max": None},
+            "cost": {"min": None, "max": None},
+        },
+        "contractSize": 1.0,
+    }
+    market.pop("maker")
+    market.pop("taker")
+    bot.markets_dict = {symbol: market}
+    bot.eligible_symbols = {symbol}
+
+    bot.set_market_specific_settings()
+
+    assert bot.markets_dict[symbol]["maker"] == pytest.approx(0.0002)
+    assert bot.markets_dict[symbol]["taker"] == pytest.approx(0.0006)
 
 
 def test_bot_order_params_require_durable_hedge_semantics():

--- a/tests/test_utils_maps.py
+++ b/tests/test_utils_maps.py
@@ -111,6 +111,63 @@ async def test_load_markets_fetch_and_cache_creates_maps(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_load_markets_uses_native_bitunix_client_on_cold_cache(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    markets = {
+        "BTC/USDT:USDT": {
+            "swap": True,
+            "baseName": "BTC",
+            "base": "BTC",
+        }
+    }
+    observed = {}
+
+    class DummyBitunixClient:
+        def __init__(self, config):
+            observed["config"] = config
+
+        async def load_markets(self, reload):
+            observed["reload"] = reload
+            return markets
+
+        async def close(self):
+            observed["closed"] = True
+
+    import exchanges.bitunix as bitunix
+
+    def unexpected_ccxt(*_args, **_kwargs):
+        raise AssertionError("Bitunix cold start must not use CCXT")
+
+    monkeypatch.setattr(bitunix, "BitunixClient", DummyBitunixClient)
+    monkeypatch.setattr(
+        utils,
+        "resolve_custom_endpoint_override",
+        lambda _exchange: None,
+    )
+    monkeypatch.setattr(
+        utils,
+        "load_ccxt_instance",
+        unexpected_ccxt,
+    )
+
+    result = await utils.load_markets("bitunix")
+
+    assert result == markets
+    assert observed == {
+        "config": {
+            "enableRateLimit": True,
+            "timeout": 60_000,
+            "wsEnabled": False,
+        },
+        "reload": True,
+        "closed": True,
+    }
+    assert os.path.exists("caches/bitunix/markets.json")
+
+
+@pytest.mark.asyncio
 async def test_load_markets_uses_fresh_cache(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     ex = "binance"


### PR DESCRIPTION
## Summary

- route cold-cache Bitunix market discovery through the native client instead of the unavailable CCXT exchange
- preserve custom endpoint overrides and retry observed transient market-discovery network envelopes
- provide conservative documented VIP0 futures fees, including transparent in-memory upgrades for legacy market caches
- keep private order WebSockets alive with Bitunix's required JSON ping

## Root cause

The live CLI preloads markets before constructing the exchange bot. On an empty cache that standalone path attempted to instantiate `ccxt.bitunix`, which does not exist. Once routed through the native client, live validation also exposed missing fee metadata in native market records and an application-level WebSocket keepalive requirement.

## Validation

- full repository `pytest -q`
- focused Bitunix, market-cache, setup-routing, and documentation tests
- exact live CLI startup with both a legacy cache and an isolated empty market/candle cache
- live market discovery, authenticated account initialization, ticker/candle readiness, leverage updates, order create/cancel/replacement, and private order-event reconciliation
- bounded market-order entry/close round trip with REST order details, private WebSocket events, trade-history visibility, and final confirmation of no open orders or positions

Private credentials, configuration, account state, balances, logs, caches, and local test artifacts are excluded from this PR.