### PR TITLE
Fix live candle teardown and sparse refresh health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,10 @@ All notable user-facing changes will be documented in this file.
 - Dynamic candle WebSocket removal now lets the owning watcher consume CCXT
   Pro's unsubscribe wake-up before cancellation, avoiding orphaned-future error
   spam, and reconciliation retires a removed symbol batch with one supported
-  bulk unsubscribe. Watcher cancellation and post-cancellation waits are both
-  bounded; abandoned watchers remain marked retiring until they actually stop.
+  bulk unsubscribe. Bulk and singleton unsubscribe calls, watcher cancellation,
+  and post-cancellation waits are hard-bounded even when connector coroutines
+  suppress cancellation. Removed watchers remain owned until retirement returns,
+  and abandoned watchers remain marked retiring until they actually stop.
   Internal bot restarts await maintainer teardown and close event,
   monitor, and exchange-client resources before constructing the replacement
   bot; cancellation-resistant tasks cannot extend cleanup beyond the bounded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,14 +42,18 @@ All notable user-facing changes will be documented in this file.
   forager mode.
 - Dynamic candle WebSocket removal now lets the owning watcher consume CCXT
   Pro's unsubscribe wake-up before cancellation, avoiding orphaned-future error
-  spam. Internal bot restarts await maintainer teardown and close event,
+  spam, and reconciliation retires a removed symbol batch with one supported
+  bulk unsubscribe. Internal bot restarts await maintainer teardown and close event,
   monitor, and exchange-client resources before constructing the replacement
-  bot; bounded stage and source-location diagnostics identify future lifecycle
-  failures without exposing exchange response text. Background forager refresh
+  bot; cancellation-resistant tasks cannot extend cleanup beyond the bounded
+  grace deadline. Correlated private incident records retain bounded full frame
+  chains at normal log level while excluding exception text, locals, source
+  lines, and credentials. Background forager refresh
   also distinguishes currently fetchable missing candles from verified
   no-trade continuity and retry-deferred gaps, preventing sparse KuCoin markets
   from repeatedly consuming REST budget while raw coverage remains honestly
-  unavailable where proof is incomplete.
+  unavailable where proof is incomplete. Gap normalization preserves those
+  proof-specific ranges so adjacent unverified minutes remain refreshable.
 - Bitget UTA private order updates now use the native `holdSide` field for
   hedge position attribution. Hyperliquid briefly retries a sparse order-open
   event when a concurrent local create is still awaiting its exchange ID, then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,8 @@ All notable user-facing changes will be documented in this file.
   and post-cancellation waits are hard-bounded even when connector coroutines
   suppress cancellation. Removed watchers remain owned until retirement returns,
   and abandoned watchers remain marked retiring until they actually stop.
-  Internal bot restarts await maintainer teardown and close event,
+  Internal bot restarts delegate the single maintainer cancellation to outer cleanup,
+  then await teardown and close event,
   monitor, and exchange-client resources before constructing the replacement
   bot; cancellation-resistant tasks cannot extend cleanup beyond the bounded
   grace deadline, and an incomplete event-pipeline shutdown no longer permits a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,8 +60,9 @@ All notable user-facing changes will be documented in this file.
   no-trade continuity and retry-deferred gaps, preventing sparse KuCoin markets
   from repeatedly consuming REST budget while raw coverage remains honestly
   unavailable where proof is incomplete. Gap normalization preserves those
-  proof-specific ranges so adjacent unverified minutes remain refreshable, using
-  log-linear sweep normalization for large sparse histories.
+  proof- and retry-epoch-specific ranges so adjacent unverified or newly
+  finalized minutes remain refreshable, using log-linear sweep normalization
+  for large sparse histories.
 - Bitget UTA private order updates now use the native `holdSide` field for
   hedge position attribution. Hyperliquid briefly retries a sparse order-open
   event when a concurrent local create is still awaiting its exchange ID, then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,17 +43,23 @@ All notable user-facing changes will be documented in this file.
 - Dynamic candle WebSocket removal now lets the owning watcher consume CCXT
   Pro's unsubscribe wake-up before cancellation, avoiding orphaned-future error
   spam, and reconciliation retires a removed symbol batch with one supported
-  bulk unsubscribe. Internal bot restarts await maintainer teardown and close event,
+  bulk unsubscribe. Watcher cancellation and post-cancellation waits are both
+  bounded; abandoned watchers remain marked retiring until they actually stop.
+  Internal bot restarts await maintainer teardown and close event,
   monitor, and exchange-client resources before constructing the replacement
   bot; cancellation-resistant tasks cannot extend cleanup beyond the bounded
-  grace deadline. Correlated private incident records retain bounded full frame
-  chains at normal log level while excluding exception text, locals, source
-  lines, and credentials. Background forager refresh
+  grace deadline, and an incomplete event-pipeline shutdown no longer permits a
+  blocking monitor-publisher close to stall replacement. Correlated private
+  incident records retain bounded full frame chains at normal log level while
+  excluding exception text, locals, source lines, and credentials; hostile
+  traceback accessors degrade only the optional diagnostic projection.
+  Background forager refresh
   also distinguishes currently fetchable missing candles from verified
   no-trade continuity and retry-deferred gaps, preventing sparse KuCoin markets
   from repeatedly consuming REST budget while raw coverage remains honestly
   unavailable where proof is incomplete. Gap normalization preserves those
-  proof-specific ranges so adjacent unverified minutes remain refreshable.
+  proof-specific ranges so adjacent unverified minutes remain refreshable, using
+  log-linear sweep normalization for large sparse histories.
 - Bitget UTA private order updates now use the native `holdSide` field for
   hedge position attribution. Hyperliquid briefly retries a sparse order-open
   event when a concurrent local create is still awaiting its exchange ID, then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@ All notable user-facing changes will be documented in this file.
   streams cool down to REST-only maintenance before retrying automatically, and
   the subscription reconciler remains ready for runtime transitions into
   forager mode.
+- Dynamic candle WebSocket removal now lets the owning watcher consume CCXT
+  Pro's unsubscribe wake-up before cancellation, avoiding orphaned-future error
+  spam. Internal bot restarts await maintainer teardown and close event,
+  monitor, and exchange-client resources before constructing the replacement
+  bot; bounded stage and source-location diagnostics identify future lifecycle
+  failures without exposing exchange response text. Background forager refresh
+  also distinguishes currently fetchable missing candles from verified
+  no-trade continuity and retry-deferred gaps, preventing sparse KuCoin markets
+  from repeatedly consuming REST budget while raw coverage remains honestly
+  unavailable where proof is incomplete.
 - Bitget UTA private order updates now use the native `holdSide` field for
   hedge position attribution. Hyperliquid briefly retries a sparse order-open
   event when a concurrent local create is still awaiting its exchange ID, then

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -151,7 +151,10 @@
    enters the urgent active-candle universe. Removal requests the CCXT Pro unsubscribe while the
    watcher still owns its pending `watch_ohlcv` future, lets that watcher consume the transport's
    unsubscribe wake-up, and uses cancellation only as a bounded fallback. Restart cleanup awaits
-   this owner-managed teardown before closing exchange clients.
+   this owner-managed teardown before closing exchange clients. Both the graceful wait and the
+   post-cancellation wait are bounded. A cancellation-resistant watcher is abandoned without
+   blocking reconciliation and remains marked retiring until it actually terminates, preventing
+   it from resuming ingestion beside its replacement.
    A forced native higher-timeframe refresh bypasses in-memory range and complete-disk
    short-circuits so a partial cached range cannot consume budget without retrying the exchange.
    Fresh remote rows overwrite matching disk rows, but partial remote results retain any existing

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -119,7 +119,9 @@
    from raw coverage. Verified internal `no_trades` continuity and unresolved known gaps whose retry
    cooldown is active do not spend background REST budget. This scheduler classification never
    turns an unresolved gap into tradable coverage: raw `coverage_ok` remains false, and a newly
-   finalized suffix outside the deferred range remains refreshable. Refresh scheduling prioritizes
+   finalized suffix outside the deferred range remains refreshable. Adjacent missing ranges with
+   different retry epochs remain separate, even when their reason matches, so fresh evidence never
+   inherits an older range's retry cooldown. Refresh scheduling prioritizes
    never-attempted 1m fetches before native 1h backfills. Staleness targets count
    only surfaces handled by this background
    refresher, excluding urgent active symbols. A native 1h range with a fresh tail and only an

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -153,8 +153,10 @@
    enters the urgent active-candle universe. Removal requests the CCXT Pro unsubscribe while the
    watcher still owns its pending `watch_ohlcv` future, lets that watcher consume the transport's
    unsubscribe wake-up, and uses cancellation only as a bounded fallback. Restart cleanup awaits
-   this owner-managed teardown before closing exchange clients. Removed watchers remain in the
-   owner task map until retirement returns, so cancellation cannot detach them from outer cleanup.
+   this owner-managed teardown before closing exchange clients. An internal restart request only
+   unwinds to that cleanup owner; it does not pre-cancel maintainers and then cancel them again.
+   Removed watchers remain in the owner task map until retirement returns, so cancellation cannot
+   detach them from outer cleanup.
    Bulk and singleton unsubscribe calls, the graceful watcher wait, and the post-cancellation wait
    all use hard deadlines which do not await cancellation-resistant connector work. An uncooperative
    unsubscribe task is cancelled, retained for exception consumption, and abandoned without

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -114,15 +114,22 @@
    keep discovered-but-unfetched stale surfaces pending, and charge one token immediately before
    each actual fetch attempt rather than reserving tokens for a batch which may be cut short by
    the wall-time cap. A timed-out candidate surface receives a short in-memory retry delay so one
-   blocked symbol cannot monopolize successive refresh cycles,
-   and prioritize never-attempted 1m fetches before native 1h backfills. Staleness targets count
+   blocked symbol cannot monopolize successive refresh cycles. Completed-candle health reports
+   whether missing minutes are currently refreshable separately
+   from raw coverage. Verified internal `no_trades` continuity and unresolved known gaps whose retry
+   cooldown is active do not spend background REST budget. This scheduler classification never
+   turns an unresolved gap into tradable coverage: raw `coverage_ok` remains false, and a newly
+   finalized suffix outside the deferred range remains refreshable. Refresh scheduling prioritizes
+   never-attempted 1m fetches before native 1h backfills. Staleness targets count
    only surfaces handled by this background
    refresher, excluding urgent active symbols. A native 1h range with a fresh tail and only an
    unavailable leading prefix remains nontradable and is retried at most once per 24 hours after a
    successful nonempty fetch which still proves the same requested leading-prefix gap; changed
    requirements, empty results, partial pagination failures, and other failed fetches remain
-   eligible for normal retry. A zero OHLCV network budget disables candidate fetches even when
-   entry slots are open.
+   eligible for normal retry. Dense post-listing history which is shorter than the configured 1h
+   warmup remains unavailable until enough real buckets exist; pre-listing hours are never
+   synthesized. A zero OHLCV network budget disables candidate fetches even when entry slots are
+   open.
    When enabled and supported by CCXT Pro, proven-final public 1m WebSocket rows for flat forager
    candidates are persisted through the same canonical candle path as REST rows. Because CCXT may
    repeat a sliding cache, the first nonempty snapshot of each watcher session only primes
@@ -141,7 +148,10 @@
    reconciler remains alive when the transport is configured but no side is yet in forager mode, so
    runtime mode transitions are handled without restart. Dynamic subscriptions include only sides
    currently using forager mode, follow their flat approved universe, and are removed when a symbol
-   enters the urgent active-candle universe.
+   enters the urgent active-candle universe. Removal requests the CCXT Pro unsubscribe while the
+   watcher still owns its pending `watch_ohlcv` future, lets that watcher consume the transport's
+   unsubscribe wake-up, and uses cancellation only as a bounded fallback. Restart cleanup awaits
+   this owner-managed teardown before closing exchange clients.
    A forced native higher-timeframe refresh bypasses in-memory range and complete-disk
    short-circuits so a partial cached range cannot consume budget without retrying the exchange.
    Fresh remote rows overwrite matching disk rows, but partial remote results retain any existing

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -222,9 +222,11 @@
     extending a 1m gap invalidates cached 1m EMA and open-tail projection values. An overlap refresh
     which retries a due gap
     stamps every unresolved remainder before later repair stages run, preventing a
-    second attempt in the same request. Historical pagination
-    flushes deferred partial-page index writes before propagating terminal-empty
-    failure.
+    second attempt in the same request. Historical pagination flushes deferred
+    partial-page index writes before propagating terminal-empty failure.
+    Gap normalization also preserves proof-specific subranges: verified terminal
+    reasons never expand into adjacent retryable minutes, and an overlap gives
+    terminal evidence authority only over the timestamps it actually covers.
     Repeated terminal empty-page failures and successful refreshes which make no
     open-tail progress for a forager candle surface use a bounded in-memory retry
     delay without converting missing data into candles. Expected background

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -153,8 +153,12 @@
    enters the urgent active-candle universe. Removal requests the CCXT Pro unsubscribe while the
    watcher still owns its pending `watch_ohlcv` future, lets that watcher consume the transport's
    unsubscribe wake-up, and uses cancellation only as a bounded fallback. Restart cleanup awaits
-   this owner-managed teardown before closing exchange clients. Both the graceful wait and the
-   post-cancellation wait are bounded. A cancellation-resistant watcher is abandoned without
+   this owner-managed teardown before closing exchange clients. Removed watchers remain in the
+   owner task map until retirement returns, so cancellation cannot detach them from outer cleanup.
+   Bulk and singleton unsubscribe calls, the graceful watcher wait, and the post-cancellation wait
+   all use hard deadlines which do not await cancellation-resistant connector work. An uncooperative
+   unsubscribe task is cancelled, retained for exception consumption, and abandoned without
+   blocking teardown. A cancellation-resistant watcher is likewise abandoned without
    blocking reconciliation and remains marked retiring until it actually terminates, preventing
    it from resuming ingestion beside its replacement.
    A forced native higher-timeframe refresh bypasses in-memory range and complete-disk

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -518,10 +518,14 @@ helper apply the same type-only boundary.
 ## Execution-Loop Incidents
 
 An execution-loop failure publishes a bounded `error.bot` record and an equivalent first-occurrence
-operator signature. The stable diagnostic fields are operation/source, exception type, optional
-bounded status/code and endpoint, action, and cycle. This family excludes raw exception text,
-request URLs, response payloads, and traceback values. Stack frames may be retained only in the
-protected DEBUG text path and must not include the exception value.
+operator signature. The stable diagnostic fields are incident id, operation/source, exception
+type, optional bounded status/code and endpoint, stage, innermost origin, action, and cycle. A
+companion private `error.bot.detail` record uses the same incident id and retains the bounded full
+exception-chain frame sequence at normal logging levels so a rare failure remains diagnosable
+without a DEBUG restart. The detail contains normalized file/function/line values but no exception
+text, locals, source lines, request URLs, or response payloads. The normal console keeps only the
+compact operator signature; its omission of the frame chain is a readability and volume decision,
+not a public/privacy boundary.
 
 Equivalent repeats use `health.summary` with the execution-error-burst reason. Its latest-failure
 fields are `latest_error_type`, optional `latest_status`, `latest_code`, and `latest_endpoint`; it

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -525,7 +525,9 @@ exception-chain frame sequence at normal logging levels so a rare failure remain
 without a DEBUG restart. The detail contains normalized file/function/line values but no exception
 text, locals, source lines, request URLs, or response payloads. The normal console keeps only the
 compact operator signature; its omission of the frame chain is a readability and volume decision,
-not a public/privacy boundary.
+not a public/privacy boundary. Traceback projection is entirely observability-only: hostile or
+malformed exception accessors produce a bounded `projection_failed` detail instead of replacing the
+original error, its counter update, restart-threshold handling, or backoff.
 
 Equivalent repeats use `health.summary` with the execution-error-burst reason. Its latest-failure
 fields are `latest_error_type`, optional `latest_status`, `latest_code`, and `latest_endpoint`; it

--- a/docs/ai/features/monitor_persistence.md
+++ b/docs/ai/features/monitor_persistence.md
@@ -24,6 +24,11 @@ compact `error.bot` summary by incident id, while excluding exception text, loca
 URLs, payloads, and credentials. Existing rotation and retention limits bound this diagnostic data;
 its production does not depend on DEBUG logging.
 
+During an internal bot restart, a failed or timed-out event-pipeline close may leave its worker
+holding the publisher lock. The restart path therefore abandons that process-local publisher
+without calling its synchronous close; startup recovery owns any missing final checkpoint. This
+bounded observability fallback must not delay exchange-client closure or replacement-bot startup.
+
 Event sequences are monotonic within a monitor root, including across unclean restart. The startup
 watermark is the maximum of the manifest and checksummed segment recovery metadata. Never infer an
 envelope sequence from payload bytes or an invalid row.

--- a/docs/ai/features/monitor_persistence.md
+++ b/docs/ai/features/monitor_persistence.md
@@ -18,6 +18,12 @@ request URLs, responses, tracebacks, or caller-supplied raw diagnostic aliases. 
 incident context belongs in an explicitly sanitized event or protected developer path; persistence
 behavior and caller control flow remain unchanged.
 
+Private normal-run monitor history may retain an explicitly sanitized incident detail event. The
+execution-loop `error.bot.detail` schema stores a bounded normalized frame chain, correlated to its
+compact `error.bot` summary by incident id, while excluding exception text, locals, source lines,
+URLs, payloads, and credentials. Existing rotation and retention limits bound this diagnostic data;
+its production does not depend on DEBUG logging.
+
 Event sequences are monotonic within a monitor root, including across unclean restart. The startup
 watermark is the maximum of the manifest and checksummed segment recovery metadata. Never infer an
 envelope sequence from payload bytes or an invalid row.

--- a/docs/ai/logging_policy.md
+++ b/docs/ai/logging_policy.md
@@ -26,10 +26,21 @@ No sink may retain credentials, signatures, private keys, authorization headers,
 raw exchange/account payloads, or unbounded row collections. Treat exception messages and
 tracebacks as potentially containing request or account data.
 
+Runtime console, text logs, and structured/monitor artifacts are private operator surfaces. They
+may retain account state and detailed operational diagnostics needed to investigate a normal bot
+run; console selection is about human readability and volume, not public-release privacy. Public
+issues, pull requests, commits, and other repository publications are a separate boundary and must
+never receive private runtime artifacts. The credential prohibition applies to every boundary:
+authentication material must not be copied from its configured credential store into any sink.
+
 - Connector-local and structured execution events retain stable classifications, bounded context,
   and exception type—not raw responses, exception text, or tracebacks.
 - Outer process/startup failure logs may include a traceback in the protected developer text log
   when needed for diagnosis, but should sanitize known request and credential material first.
+- Unexpected runtime incidents must retain a correlated, bounded frame chain in a private durable
+  diagnostic event at normal logging levels. Frame diagnostics exclude exception text, locals, and
+  source lines unless a producer has an explicitly reviewed sanitizer for those values; a rare
+  incident must not require reproducing the failure after restarting with DEBUG.
 - Structured event debug profiles add bounded shapes, counts, keys, correlation IDs, and samples;
   they do not enable raw-payload persistence.
 - Exchange-config response formatting permits only canonical status, finite numeric leverage,
@@ -100,9 +111,9 @@ The normal console projects an incident as a bounded signature, not a traceback:
    a bounded sanitized reason extracted from the exchange's structured error payload.
 2. Aggregate equivalent repeats and emit a compact count at most every five minutes. Emit recovery
    once when the condition clears.
-3. Keep sanitized tracebacks in the protected developer text/structured diagnostic path. A terminal
-   outer-process failure may tell the operator where that detail was retained, but must not dump it
-   into the normal console.
+3. Keep sanitized tracebacks in the protected developer text/structured diagnostic path at normal
+   logging levels. A terminal outer-process failure may tell the operator where that detail was
+   retained, but must not dump it into the normal console.
 
 Distinct safety transitions and distinct failed exchange writes are never coalesced merely to meet
 a volume target.

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -4169,42 +4169,73 @@ class CandlestickManager:
                 def intersect_missing(
                     masks: Iterable[Tuple[int, int]],
                 ) -> List[Tuple[int, int]]:
+                    missing_sorted = merge_spans(missing)
+                    masks_sorted = merge_spans(masks)
                     intersections: List[Tuple[int, int]] = []
-                    for missing_start, missing_end in missing:
-                        for mask_start, mask_end in masks:
-                            overlap_start = max(int(missing_start), int(mask_start))
-                            overlap_end = min(int(missing_end), int(mask_end))
-                            if overlap_start <= overlap_end:
-                                intersections.append((overlap_start, overlap_end))
-                    return merge_spans(intersections)
+                    missing_index = 0
+                    mask_index = 0
+                    while (
+                        missing_index < len(missing_sorted)
+                        and mask_index < len(masks_sorted)
+                    ):
+                        missing_start, missing_end = missing_sorted[missing_index]
+                        mask_start, mask_end = masks_sorted[mask_index]
+                        overlap_start = max(missing_start, mask_start)
+                        overlap_end = min(missing_end, mask_end)
+                        if overlap_start <= overlap_end:
+                            intersections.append((overlap_start, overlap_end))
+                        if missing_end < mask_end:
+                            missing_index += 1
+                        else:
+                            mask_index += 1
+                    return intersections
 
                 def subtract_spans(
                     source: Iterable[Tuple[int, int]],
                     masks: Iterable[Tuple[int, int]],
                 ) -> List[Tuple[int, int]]:
-                    remaining = list(source)
-                    for mask_start, mask_end in merge_spans(masks):
-                        next_remaining: List[Tuple[int, int]] = []
-                        for span_start, span_end in remaining:
-                            if mask_end < span_start or mask_start > span_end:
-                                next_remaining.append((span_start, span_end))
+                    source_sorted = merge_spans(source)
+                    masks_sorted = merge_spans(masks)
+                    remaining: List[Tuple[int, int]] = []
+                    mask_index = 0
+                    for span_start, span_end in source_sorted:
+                        while (
+                            mask_index < len(masks_sorted)
+                            and masks_sorted[mask_index][1] < span_start
+                        ):
+                            mask_index += 1
+                        cursor = span_start
+                        scan_index = mask_index
+                        while (
+                            scan_index < len(masks_sorted)
+                            and masks_sorted[scan_index][0] <= span_end
+                        ):
+                            mask_start, mask_end = masks_sorted[scan_index]
+                            if mask_end < cursor:
+                                scan_index += 1
                                 continue
-                            if span_start < mask_start:
-                                next_remaining.append(
-                                    (span_start, mask_start - ONE_MIN_MS)
+                            if mask_start > cursor:
+                                remaining.append(
+                                    (cursor, min(span_end, mask_start - ONE_MIN_MS))
                                 )
-                            if mask_end < span_end:
-                                next_remaining.append(
-                                    (mask_end + ONE_MIN_MS, span_end)
-                                )
-                        remaining = next_remaining
-                    return merge_spans(remaining)
+                            cursor = max(cursor, mask_end + ONE_MIN_MS)
+                            if cursor > span_end:
+                                break
+                            scan_index += 1
+                        if cursor <= span_end:
+                            remaining.append((cursor, span_end))
+                        mask_index = scan_index
+                    return remaining
 
                 verified_masks: List[Tuple[int, int]] = []
                 deferred_masks: List[Tuple[int, int]] = []
+                combined_ts = combined["ts"].astype(np.int64, copy=False)
                 for gap in known_gaps:
                     gap_start = int(gap["start_ts"])
                     gap_end = int(gap["end_ts"])
+                    if gap_end < start_ts or gap_start > end_ts:
+                        continue
+                    clipped_gap = (max(gap_start, start_ts), min(gap_end, end_ts))
                     reason = str(gap.get("reason", GAP_REASON_AUTO))
                     if reason == GAP_REASON_NO_TRADES:
                         # A continuity candle needs real price on both sides.
@@ -4212,16 +4243,20 @@ class CandlestickManager:
                         # candle can replace them authoritatively.
                         if gap_end >= end_ts:
                             continue
-                        prior = combined[combined["ts"] < gap_start]
-                        if prior.size == 0:
+                        prior_index = int(
+                            np.searchsorted(combined_ts, gap_start, side="left")
+                        )
+                        if prior_index == 0:
                             prior_ts = self._latest_cached_ts_before(
                                 symbol, gap_start, timeframe=tf_norm
                             )
                             if prior_ts is None:
                                 continue
-                        successor = combined[combined["ts"] > gap_end]
-                        if successor.size:
-                            verified_masks.append((gap_start, gap_end))
+                        successor_index = int(
+                            np.searchsorted(combined_ts, gap_end, side="right")
+                        )
+                        if successor_index < combined_ts.size:
+                            verified_masks.append(clipped_gap)
                         continue
 
                     retry_due = self._should_retry_gap(gap, now_ms=ts_now)
@@ -4234,7 +4269,7 @@ class CandlestickManager:
                     ):
                         retry_due = True
                     if not retry_due:
-                        deferred_masks.append((gap_start, gap_end))
+                        deferred_masks.append(clipped_gap)
 
                 verified_no_trade_spans = intersect_missing(verified_masks)
                 deferred_missing_spans = intersect_missing(deferred_masks)

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -3089,8 +3089,9 @@ class CandlestickManager:
         A terminal reason such as ``no_trades`` is evidence about an exact
         interval, not about an adjacent unresolved minute.  Normalize overlaps
         into disjoint segments and merge only segments carrying the same
-        reason.  Terminal evidence wins an actual overlap with retryable
-        metadata, but never expands across adjacency.
+        reason and retry epoch.  Terminal evidence wins an actual overlap with
+        retryable metadata, but neither proof nor cooldown state expands across
+        adjacency.
         """
         prepared = [
             dict(gap)
@@ -3150,15 +3151,32 @@ class CandlestickManager:
         gaps = sorted(normalized, key=lambda g: g["start_ts"])
         merged: List[GapEntry] = []
         for gap in gaps:
+            previous = merged[-1] if merged else None
             same_reason = bool(
-                merged
+                previous
                 and str(gap.get("reason", GAP_REASON_AUTO))
-                == str(merged[-1].get("reason", GAP_REASON_AUTO))
+                == str(previous.get("reason", GAP_REASON_AUTO))
+            )
+            same_retry_epoch = bool(
+                previous
+                and int(gap.get("retry_count", 0))
+                == int(previous.get("retry_count", 0))
+                and int(gap.get("added_at", 0))
+                == int(previous.get("added_at", 0))
+                and int(gap.get("last_retry_at", gap.get("added_at", 0)))
+                == int(
+                    previous.get(
+                        "last_retry_at", previous.get("added_at", 0)
+                    )
+                )
+                and int(gap.get("last_contextual_retry_at", 0))
+                == int(previous.get("last_contextual_retry_at", 0))
             )
             if (
                 not merged
                 or gap["start_ts"] > merged[-1]["end_ts"] + ONE_MIN_MS
                 or not same_reason
+                or not same_retry_epoch
             ):
                 merged.append(gap)
             else:
@@ -3284,10 +3302,9 @@ class CandlestickManager:
     ) -> None:
         """Add or update a known gap with enhanced metadata.
 
-        If a gap overlapping with [start_ts, end_ts] already exists:
-        - Extends the gap to cover the full range
-        - Increments retry_count if increment_retry is True (unless retry_count is specified)
-        - Updates reason if provided
+        Existing overlap receives the requested retry update, while previously
+        unseen prefix/suffix minutes start a fresh retry epoch. Adjacent ranges
+        remain separate unless normalization proves all metadata identical.
 
         If retry_count reaches _GAP_MAX_RETRIES, the gap is considered persistent
         and will not be re-fetched unless force_refetch_gaps is used.
@@ -3298,110 +3315,128 @@ class CandlestickManager:
         """
         now_ms = self._now_ms()
         gaps = self._get_known_gaps_enhanced(symbol)
+        requested_start = int(start_ts)
+        requested_end = int(end_ts)
+        covered: List[Tuple[int, int]] = []
+        updates: List[GapEntry] = []
+        persistent_transitions = 0
 
-        # Check if we have an overlapping gap with compatible evidence to update.
+        # Update only exact overlaps with compatible evidence. The original gap
+        # remains in the input; later update segments win their overlap during
+        # normalization while preserving the original metadata on either side.
         # Retryable reasons may evolve between auto/fetch classifications, but
-        # terminal proof must retain its exact range.
-        updated = False
-        previous_retry_count = 0
+        # terminal proof must retain its exact range. Adjacency alone is not an
+        # update: a newly finalized minute starts a fresh retry epoch and must
+        # not inherit a neighboring gap's cooldown.
         for gap in gaps:
             existing_reason = str(gap.get("reason", GAP_REASON_AUTO))
             compatible_reason = existing_reason == reason or (
                 existing_reason not in _GAP_NON_EXPIRING_REASONS
                 and reason not in _GAP_NON_EXPIRING_REASONS
             )
-            if (
-                compatible_reason
-                and gap["start_ts"] <= end_ts + ONE_MIN_MS
-                and gap["end_ts"] >= start_ts - ONE_MIN_MS
-            ):
-                # Overlapping - extend and optionally increment retry
-                gap["start_ts"] = min(gap["start_ts"], int(start_ts))
-                gap["end_ts"] = max(gap["end_ts"], int(end_ts))
-                previous_retry_count = gap.get("retry_count", 0)
-                retry_due = self._should_retry_gap(gap, now_ms=now_ms)
-                if retry_count is not None:
-                    gap["retry_count"] = retry_count
-                    gap["last_retry_at"] = now_ms
-                    if retry_count >= _GAP_MAX_RETRIES and previous_retry_count < _GAP_MAX_RETRIES:
-                        gap["added_at"] = now_ms
-                elif increment_retry and retry_due:
-                    # Cap retry_count at _GAP_MAX_RETRIES to prevent unbounded growth
-                    # without reverting a recent Hyperliquid gap to the ordinary
-                    # retry cadence. Other expired persistent gaps start a fresh
-                    # retry cycle under the existing retention contract.
-                    if previous_retry_count >= _GAP_MAX_RETRIES:
-                        new_retry_count = (
-                            _GAP_MAX_RETRIES
-                            if self._is_recent_hyperliquid_gap(
-                                gap, now_ms=now_ms
-                            )
-                            else 1
-                        )
-                    else:
-                        new_retry_count = previous_retry_count + 1
-                    gap["retry_count"] = min(new_retry_count, _GAP_MAX_RETRIES)
-                    gap["last_retry_at"] = now_ms
-                    if retry_due:
-                        gap["added_at"] = now_ms
-                    elif (
-                        gap["retry_count"] >= _GAP_MAX_RETRIES
-                        and previous_retry_count < _GAP_MAX_RETRIES
-                    ):
-                        gap["added_at"] = now_ms
-                if reason != GAP_REASON_AUTO:
-                    gap["reason"] = reason
-                updated = True
-                break
+            overlap_start = max(int(gap["start_ts"]), requested_start)
+            overlap_end = min(int(gap["end_ts"]), requested_end)
+            if not compatible_reason or overlap_start > overlap_end:
+                continue
+            covered.append((overlap_start, overlap_end))
 
-        if not updated:
-            initial_retry = retry_count if retry_count is not None else (1 if increment_retry else 0)
+            updated_gap: GapEntry = {
+                **gap,
+                "start_ts": overlap_start,
+                "end_ts": overlap_end,
+            }
+            previous_retry_count = int(gap.get("retry_count", 0))
+            retry_due = self._should_retry_gap(gap, now_ms=now_ms)
+            if retry_count is not None:
+                updated_gap["retry_count"] = retry_count
+                updated_gap["last_retry_at"] = now_ms
+                if (
+                    retry_count >= _GAP_MAX_RETRIES
+                    and previous_retry_count < _GAP_MAX_RETRIES
+                ):
+                    updated_gap["added_at"] = now_ms
+            elif increment_retry and retry_due:
+                # Cap retry_count at _GAP_MAX_RETRIES to prevent unbounded growth
+                # without reverting a recent Hyperliquid gap to the ordinary
+                # retry cadence. Other expired persistent gaps start a fresh
+                # retry cycle under the existing retention contract.
+                if previous_retry_count >= _GAP_MAX_RETRIES:
+                    new_retry_count = (
+                        _GAP_MAX_RETRIES
+                        if self._is_recent_hyperliquid_gap(
+                            gap, now_ms=now_ms
+                        )
+                        else 1
+                    )
+                else:
+                    new_retry_count = previous_retry_count + 1
+                updated_gap["retry_count"] = min(
+                    new_retry_count, _GAP_MAX_RETRIES
+                )
+                updated_gap["last_retry_at"] = now_ms
+                updated_gap["added_at"] = now_ms
+            if reason != GAP_REASON_AUTO:
+                updated_gap["reason"] = reason
+            if (
+                int(updated_gap.get("retry_count", 0)) >= _GAP_MAX_RETRIES
+                and previous_retry_count < _GAP_MAX_RETRIES
+                and str(updated_gap.get("reason", GAP_REASON_AUTO))
+                != "pre_inception"
+            ):
+                persistent_transitions += 1
+            updates.append(updated_gap)
+
+        uncovered: List[Tuple[int, int]] = []
+        cursor = requested_start
+        for covered_start, covered_end in sorted(covered):
+            if covered_end < cursor:
+                continue
+            if covered_start > cursor:
+                uncovered.append(
+                    (cursor, min(requested_end, covered_start - ONE_MIN_MS))
+                )
+            cursor = max(cursor, covered_end + ONE_MIN_MS)
+            if cursor > requested_end:
+                break
+        if cursor <= requested_end:
+            uncovered.append((cursor, requested_end))
+
+        initial_retry = (
+            retry_count
+            if retry_count is not None
+            else (1 if increment_retry else 0)
+        )
+        fresh_gaps: List[GapEntry] = []
+        for fresh_start, fresh_end in uncovered:
             new_gap: GapEntry = {
-                "start_ts": int(start_ts),
-                "end_ts": int(end_ts),
+                "start_ts": fresh_start,
+                "end_ts": fresh_end,
                 "retry_count": initial_retry,
                 "reason": reason,
                 "added_at": now_ms,
                 "last_retry_at": now_ms,
             }
-            gaps.append(new_gap)
+            fresh_gaps.append(new_gap)
             self._log(
                 "debug",
                 "gap_added",
                 symbol=symbol,
-                start_ts=start_ts,
-                end_ts=end_ts,
+                start_ts=fresh_start,
+                end_ts=fresh_end,
                 reason=reason,
                 retry_count=new_gap["retry_count"],
             )
-        else:
-            # Log warning only when gap transitions from retryable to persistent
-            # (retry_count goes from <max to >=max). Use throttling to prevent spam
-            # in edge cases where the same gap is processed multiple times.
-            updated_gap = next(
-                (
-                    g
-                    for g in gaps
-                    if g["start_ts"] <= end_ts + ONE_MIN_MS and g["end_ts"] >= start_ts - ONE_MIN_MS
-                ),
-                None,
+
+        gaps.extend(updates)
+        gaps.extend(fresh_gaps)
+        if persistent_transitions:
+            # Track transitions for the existing throttled summary logger.
+            if not hasattr(self, "_persistent_gap_summary"):
+                self._persistent_gap_summary: Dict[str, int] = {}
+            self._persistent_gap_summary[symbol] = (
+                self._persistent_gap_summary.get(symbol, 0)
+                + persistent_transitions
             )
-            if updated_gap:
-                current_retry_count = updated_gap.get("retry_count", 0)
-                gap_reason = updated_gap.get("reason", GAP_REASON_AUTO)
-                # Only warn on transition to persistent status (skip pre_inception - expected behavior)
-                if (
-                    current_retry_count >= _GAP_MAX_RETRIES
-                    and previous_retry_count < _GAP_MAX_RETRIES
-                    and gap_reason != "pre_inception"
-                ):
-                    gap_minutes = (updated_gap["end_ts"] - updated_gap["start_ts"]) // ONE_MIN_MS + 1
-                    # Track persistent gaps for summary logging
-                    if not hasattr(self, "_persistent_gap_summary"):
-                        self._persistent_gap_summary: Dict[str, int] = {}
-                    self._persistent_gap_summary[symbol] = (
-                        self._persistent_gap_summary.get(symbol, 0) + 1
-                    )
 
         self._save_known_gaps_enhanced(symbol, gaps)
         # A newly recorded or expanded 1m gap changes whether EMA inputs are

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import asyncio
 import calendar
 import hashlib
+import heapq
 import inspect
 import json
 import logging
@@ -3106,27 +3107,38 @@ class CandlestickManager:
                 )
             }
         )
+        starts = sorted(
+            (int(gap["start_ts"]), index)
+            for index, gap in enumerate(prepared)
+        )
+        active: list[tuple[int, int]] = []
+        start_index = 0
         normalized: List[GapEntry] = []
         for segment_start, next_start in zip(boundaries, boundaries[1:]):
             segment_end = int(next_start) - ONE_MIN_MS
             if segment_start > segment_end:
                 continue
-            active = [
-                (index, gap)
-                for index, gap in enumerate(prepared)
-                if int(gap["start_ts"]) <= segment_start
-                and int(gap["end_ts"]) >= segment_end
-            ]
+            while (
+                start_index < len(starts)
+                and starts[start_index][0] <= segment_start
+            ):
+                _start_ts, gap_index = starts[start_index]
+                terminal = int(
+                    str(prepared[gap_index].get("reason", GAP_REASON_AUTO))
+                    in _GAP_NON_EXPIRING_REASONS
+                )
+                # Highest proof class wins; within one class the later input
+                # retains the legacy last-write-wins behavior.
+                heapq.heappush(active, (-terminal, -gap_index))
+                start_index += 1
+            while active:
+                winner_index = -active[0][1]
+                if int(prepared[winner_index]["end_ts"]) >= segment_end:
+                    break
+                heapq.heappop(active)
             if not active:
                 continue
-            _index, winner = max(
-                active,
-                key=lambda item: (
-                    str(item[1].get("reason", GAP_REASON_AUTO))
-                    in _GAP_NON_EXPIRING_REASONS,
-                    item[0],
-                ),
-            )
+            winner = prepared[-active[0][1]]
             normalized.append(
                 {
                     **winner,

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -4062,6 +4062,115 @@ class CandlestickManager:
                 )
             )
             missing_candles = int(sum((e - s) // step_ms + 1 for s, e in missing))
+            verified_no_trade_spans: List[Tuple[int, int]] = []
+            deferred_missing_spans: List[Tuple[int, int]] = []
+            refreshable_missing_spans: List[Tuple[int, int]] = list(missing)
+            if step_ms == ONE_MIN_MS and missing:
+                known_gaps = self._get_known_gaps_enhanced(symbol)
+
+                def merge_spans(
+                    spans: Iterable[Tuple[int, int]],
+                ) -> List[Tuple[int, int]]:
+                    merged: List[Tuple[int, int]] = []
+                    for span_start, span_end in sorted(
+                        (int(a), int(b)) for a, b in spans if int(a) <= int(b)
+                    ):
+                        if merged and span_start <= merged[-1][1] + ONE_MIN_MS:
+                            merged[-1] = (
+                                merged[-1][0],
+                                max(merged[-1][1], span_end),
+                            )
+                        else:
+                            merged.append((span_start, span_end))
+                    return merged
+
+                def intersect_missing(
+                    masks: Iterable[Tuple[int, int]],
+                ) -> List[Tuple[int, int]]:
+                    intersections: List[Tuple[int, int]] = []
+                    for missing_start, missing_end in missing:
+                        for mask_start, mask_end in masks:
+                            overlap_start = max(int(missing_start), int(mask_start))
+                            overlap_end = min(int(missing_end), int(mask_end))
+                            if overlap_start <= overlap_end:
+                                intersections.append((overlap_start, overlap_end))
+                    return merge_spans(intersections)
+
+                def subtract_spans(
+                    source: Iterable[Tuple[int, int]],
+                    masks: Iterable[Tuple[int, int]],
+                ) -> List[Tuple[int, int]]:
+                    remaining = list(source)
+                    for mask_start, mask_end in merge_spans(masks):
+                        next_remaining: List[Tuple[int, int]] = []
+                        for span_start, span_end in remaining:
+                            if mask_end < span_start or mask_start > span_end:
+                                next_remaining.append((span_start, span_end))
+                                continue
+                            if span_start < mask_start:
+                                next_remaining.append(
+                                    (span_start, mask_start - ONE_MIN_MS)
+                                )
+                            if mask_end < span_end:
+                                next_remaining.append(
+                                    (mask_end + ONE_MIN_MS, span_end)
+                                )
+                        remaining = next_remaining
+                    return merge_spans(remaining)
+
+                verified_masks: List[Tuple[int, int]] = []
+                deferred_masks: List[Tuple[int, int]] = []
+                for gap in known_gaps:
+                    gap_start = int(gap["start_ts"])
+                    gap_end = int(gap["end_ts"])
+                    reason = str(gap.get("reason", GAP_REASON_AUTO))
+                    if reason == GAP_REASON_NO_TRADES:
+                        # A continuity candle needs real price on both sides.
+                        # Open tails remain unavailable so a delayed exchange
+                        # candle can replace them authoritatively.
+                        if gap_end >= end_ts:
+                            continue
+                        prior = combined[combined["ts"] < gap_start]
+                        if prior.size == 0:
+                            prior_ts = self._latest_cached_ts_before(
+                                symbol, gap_start, timeframe=tf_norm
+                            )
+                            if prior_ts is None:
+                                continue
+                        successor = combined[combined["ts"] > gap_end]
+                        if successor.size:
+                            verified_masks.append((gap_start, gap_end))
+                        continue
+
+                    retry_due = self._should_retry_gap(gap, now_ms=ts_now)
+                    if (
+                        not retry_due
+                        and isinstance(self._ex_id, str)
+                        and "kucoin" in self._ex_id.lower()
+                        and reason in {GAP_REASON_AUTO, GAP_REASON_FETCH_FAILED}
+                        and self._kucoin_contextual_retry_due(gap, now_ms=ts_now)
+                    ):
+                        retry_due = True
+                    if not retry_due:
+                        deferred_masks.append((gap_start, gap_end))
+
+                verified_no_trade_spans = intersect_missing(verified_masks)
+                deferred_missing_spans = intersect_missing(deferred_masks)
+                refreshable_missing_spans = subtract_spans(
+                    missing,
+                    [*verified_no_trade_spans, *deferred_missing_spans],
+                )
+
+            def span_candle_count(spans: Iterable[Tuple[int, int]]) -> int:
+                return int(sum((e - s) // step_ms + 1 for s, e in spans))
+
+            verified_no_trade_missing_candles = span_candle_count(
+                verified_no_trade_spans
+            )
+            deferred_missing_candles = span_candle_count(deferred_missing_spans)
+            refreshable_missing_candles = span_candle_count(
+                refreshable_missing_spans
+            )
             last_cached_ts: Optional[int] = None
             if combined.size:
                 last_cached_ts = int(np.max(combined["ts"].astype(np.int64)))
@@ -4153,6 +4262,14 @@ class CandlestickManager:
                 "missing_spans": missing,
                 "missing_spans_preview": top_spans,
                 "missing_candles": int(missing_candles),
+                "verified_no_trade_missing_candles": int(
+                    verified_no_trade_missing_candles
+                ),
+                "deferred_missing_candles": int(deferred_missing_candles),
+                "refreshable_missing_candles": int(
+                    refreshable_missing_candles
+                ),
+                "refresh_needed": bool(refreshable_missing_candles > 0),
                 "open_tail_gap": bool(open_tail_gap),
                 "tail_gap_candles": int(tail_gap_candles),
                 "tail_gap_age_ms": (

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -3083,12 +3083,71 @@ class CandlestickManager:
         *,
         defer_index: bool = False,
     ) -> None:
-        """Save gaps in enhanced format, merging overlapping ranges."""
-        # Sort by start_ts
-        gaps = sorted(gaps, key=lambda g: g["start_ts"])
+        """Save normalized gaps without broadening proof across reason boundaries.
+
+        A terminal reason such as ``no_trades`` is evidence about an exact
+        interval, not about an adjacent unresolved minute.  Normalize overlaps
+        into disjoint segments and merge only segments carrying the same
+        reason.  Terminal evidence wins an actual overlap with retryable
+        metadata, but never expands across adjacency.
+        """
+        prepared = [
+            dict(gap)
+            for gap in gaps
+            if int(gap.get("start_ts", 0)) <= int(gap.get("end_ts", -1))
+        ]
+        boundaries = sorted(
+            {
+                boundary
+                for gap in prepared
+                for boundary in (
+                    int(gap["start_ts"]),
+                    int(gap["end_ts"]) + ONE_MIN_MS,
+                )
+            }
+        )
+        normalized: List[GapEntry] = []
+        for segment_start, next_start in zip(boundaries, boundaries[1:]):
+            segment_end = int(next_start) - ONE_MIN_MS
+            if segment_start > segment_end:
+                continue
+            active = [
+                (index, gap)
+                for index, gap in enumerate(prepared)
+                if int(gap["start_ts"]) <= segment_start
+                and int(gap["end_ts"]) >= segment_end
+            ]
+            if not active:
+                continue
+            _index, winner = max(
+                active,
+                key=lambda item: (
+                    str(item[1].get("reason", GAP_REASON_AUTO))
+                    in _GAP_NON_EXPIRING_REASONS,
+                    item[0],
+                ),
+            )
+            normalized.append(
+                {
+                    **winner,
+                    "start_ts": int(segment_start),
+                    "end_ts": int(segment_end),
+                }
+            )
+
+        gaps = sorted(normalized, key=lambda g: g["start_ts"])
         merged: List[GapEntry] = []
         for gap in gaps:
-            if not merged or gap["start_ts"] > merged[-1]["end_ts"] + ONE_MIN_MS:
+            same_reason = bool(
+                merged
+                and str(gap.get("reason", GAP_REASON_AUTO))
+                == str(merged[-1].get("reason", GAP_REASON_AUTO))
+            )
+            if (
+                not merged
+                or gap["start_ts"] > merged[-1]["end_ts"] + ONE_MIN_MS
+                or not same_reason
+            ):
                 merged.append(gap)
             else:
                 # Merge overlapping gaps, keeping max retry count and earliest added_at
@@ -3097,7 +3156,7 @@ class CandlestickManager:
                     "start_ts": prev["start_ts"],
                     "end_ts": max(prev["end_ts"], gap["end_ts"]),
                     "retry_count": max(prev.get("retry_count", 0), gap.get("retry_count", 0)),
-                    "reason": prev.get("reason", GAP_REASON_AUTO),  # Keep original reason
+                    "reason": prev.get("reason", GAP_REASON_AUTO),
                     "added_at": min(prev.get("added_at", 0), gap.get("added_at", 0)),
                     "last_retry_at": max(
                         prev.get("last_retry_at", prev.get("added_at", 0)),
@@ -3228,11 +3287,22 @@ class CandlestickManager:
         now_ms = self._now_ms()
         gaps = self._get_known_gaps_enhanced(symbol)
 
-        # Check if we have an overlapping gap to update
+        # Check if we have an overlapping gap with compatible evidence to update.
+        # Retryable reasons may evolve between auto/fetch classifications, but
+        # terminal proof must retain its exact range.
         updated = False
         previous_retry_count = 0
         for gap in gaps:
-            if gap["start_ts"] <= end_ts + ONE_MIN_MS and gap["end_ts"] >= start_ts - ONE_MIN_MS:
+            existing_reason = str(gap.get("reason", GAP_REASON_AUTO))
+            compatible_reason = existing_reason == reason or (
+                existing_reason not in _GAP_NON_EXPIRING_REASONS
+                and reason not in _GAP_NON_EXPIRING_REASONS
+            )
+            if (
+                compatible_reason
+                and gap["start_ts"] <= end_ts + ONE_MIN_MS
+                and gap["end_ts"] >= start_ts - ONE_MIN_MS
+            ):
                 # Overlapping - extend and optionally increment retry
                 gap["start_ts"] = min(gap["start_ts"], int(start_ts))
                 gap["end_ts"] = max(gap["end_ts"], int(end_ts))

--- a/src/live/candle_ws.py
+++ b/src/live/candle_ws.py
@@ -21,6 +21,8 @@ _SUBSCRIPTION_RECONCILE_SECONDS = 5.0
 _MAX_RECONNECT_DELAY_SECONDS = 30.0
 _FAILURES_BEFORE_COOLDOWN = 5
 _UNSTABLE_COOLDOWN_SECONDS = 300.0
+_WATCHER_RETIRE_GRACE_SECONDS = 3.0
+_WATCHER_CANCEL_GRACE_SECONDS = 1.0
 
 
 def reconnect_delay_seconds(consecutive_failures: int) -> float:
@@ -158,6 +160,16 @@ async def _retire_watchers(bot: Any, tasks: dict[str, asyncio.Task]) -> None:
     symbols = sorted(active)
     retiring = _retiring_symbols(bot)
     retiring.update(symbols)
+    abandoned_symbols: set[str] = set()
+
+    def consume_done(done_tasks) -> None:
+        for done_task in done_tasks:
+            if done_task.done() and not done_task.cancelled():
+                try:
+                    done_task.exception()
+                except BaseException:
+                    pass
+
     try:
         unwatched = await _best_effort_unwatch_many(bot, symbols)
         if not unwatched:
@@ -165,14 +177,38 @@ async def _retire_watchers(bot: Any, tasks: dict[str, asyncio.Task]) -> None:
                 *(_best_effort_unwatch(bot, symbol) for symbol in symbols),
                 return_exceptions=True,
             )
+        consume_done(task for task in active.values() if task.done())
         pending = [task for task in active.values() if not task.done()]
         if pending:
-            _, still_pending = await asyncio.wait(pending, timeout=3.0)
+            done, still_pending = await asyncio.wait(
+                pending, timeout=_WATCHER_RETIRE_GRACE_SECONDS
+            )
+            consume_done(done)
             for task in still_pending:
                 task.cancel()
-        await asyncio.gather(*active.values(), return_exceptions=True)
+            if still_pending:
+                cancelled, resistant = await asyncio.wait(
+                    still_pending, timeout=_WATCHER_CANCEL_GRACE_SECONDS
+                )
+                consume_done(cancelled)
+                resistant_set = set(resistant)
+                abandoned_symbols = {
+                    symbol
+                    for symbol, task in active.items()
+                    if task in resistant_set
+                }
+                if abandoned_symbols:
+                    logging.warning(
+                        "[candle] websocket watcher cancellation grace expired "
+                        "| symbols=%d action=abandon_pending",
+                        len(abandoned_symbols),
+                    )
+                    for symbol in abandoned_symbols:
+                        active[symbol].add_done_callback(
+                            lambda _task, symbol=symbol: retiring.discard(symbol)
+                        )
     finally:
-        retiring.difference_update(symbols)
+        retiring.difference_update(set(symbols) - abandoned_symbols)
 
 
 async def watch_forager_ws_symbol(bot: Any, symbol: str) -> None:

--- a/src/live/candle_ws.py
+++ b/src/live/candle_ws.py
@@ -243,12 +243,9 @@ async def reconcile_forager_ws_tasks(
     existing = set(tasks)
     removed = existing - desired
     added = desired - existing
-    removed_tasks = []
-    for symbol in sorted(removed):
-        task = tasks.pop(symbol)
-        removed_tasks.append(_retire_watcher(bot, symbol, task))
+    removed_tasks = {symbol: tasks.pop(symbol) for symbol in sorted(removed)}
     if removed_tasks:
-        await asyncio.gather(*removed_tasks, return_exceptions=True)
+        await _retire_watchers(bot, removed_tasks)
     clear_state = getattr(bot.cm, "clear_live_ws_ohlcv_state", None)
     if callable(clear_state):
         for symbol in sorted(removed):

--- a/src/live/candle_ws.py
+++ b/src/live/candle_ws.py
@@ -99,17 +99,80 @@ async def _sleep_unless_shutdown(bot: Any, delay_s: float, *, stage: str) -> Non
         await asyncio.sleep(delay_s)
 
 
-async def _best_effort_unwatch(bot: Any, symbol: str) -> None:
+async def _best_effort_unwatch(bot: Any, symbol: str) -> bool:
     ccp = getattr(bot, "ccp", None)
     unwatch = getattr(ccp, "un_watch_ohlcv", None)
     if not callable(unwatch):
-        return
+        return False
     try:
         await asyncio.wait_for(unwatch(symbol, "1m"), timeout=2.0)
+        return True
     except (asyncio.CancelledError, TimeoutError):
-        return
+        return False
     except Exception:
+        return False
+
+
+async def _best_effort_unwatch_many(bot: Any, symbols: list[str]) -> bool:
+    ccp = getattr(bot, "ccp", None)
+    unwatch = getattr(ccp, "un_watch_ohlcv_for_symbols", None)
+    if not callable(unwatch) or not symbols:
+        return False
+    try:
+        subscriptions = [[symbol, "1m"] for symbol in symbols]
+        await asyncio.wait_for(unwatch(subscriptions), timeout=3.0)
+        return True
+    except (asyncio.CancelledError, TimeoutError):
+        return False
+    except Exception:
+        return False
+
+
+def _retiring_symbols(bot: Any) -> set[str]:
+    retiring = getattr(bot, "_forager_ws_retiring_symbols", None)
+    if not isinstance(retiring, set):
+        retiring = set()
+        bot._forager_ws_retiring_symbols = retiring
+    return retiring
+
+
+async def _retire_watcher(bot: Any, symbol: str, task: asyncio.Task) -> None:
+    """Unsubscribe while the watcher still owns CCXT's subscription future.
+
+    CCXT Pro uses ``UnsubscribeError`` to wake outstanding ``watch_ohlcv``
+    futures after an unsubscribe acknowledgement.  Cancelling Passivbot's
+    awaiting task first leaves that future orphaned, which asyncio later logs
+    as ``Future exception was never retrieved``.  Mark retirement first, ask
+    CCXT to unsubscribe, and let the watcher consume the wake-up exception.
+    Cancellation remains the bounded fallback for transports which do not wake
+    the watcher.
+    """
+    await _retire_watchers(bot, {symbol: task})
+
+
+async def _retire_watchers(bot: Any, tasks: dict[str, asyncio.Task]) -> None:
+    """Retire a watcher set through one bulk unsubscribe where available."""
+    active = {symbol: task for symbol, task in tasks.items() if task is not None}
+    if not active:
         return
+    symbols = sorted(active)
+    retiring = _retiring_symbols(bot)
+    retiring.update(symbols)
+    try:
+        unwatched = await _best_effort_unwatch_many(bot, symbols)
+        if not unwatched:
+            await asyncio.gather(
+                *(_best_effort_unwatch(bot, symbol) for symbol in symbols),
+                return_exceptions=True,
+            )
+        pending = [task for task in active.values() if not task.done()]
+        if pending:
+            _, still_pending = await asyncio.wait(pending, timeout=3.0)
+            for task in still_pending:
+                task.cancel()
+        await asyncio.gather(*active.values(), return_exceptions=True)
+    finally:
+        retiring.difference_update(symbols)
 
 
 async def watch_forager_ws_symbol(bot: Any, symbol: str) -> None:
@@ -119,6 +182,8 @@ async def watch_forager_ws_symbol(bot: Any, symbol: str) -> None:
         while not bool(getattr(bot, "stop_signal_received", False)):
             try:
                 rows = await bot.ccp.watch_ohlcv(symbol, "1m")
+                if symbol in _retiring_symbols(bot):
+                    break
                 ingest = getattr(bot.cm, "ingest_live_ws_ohlcv", None)
                 if callable(ingest):
                     # Some venues return hundreds of cached rows on every
@@ -133,6 +198,8 @@ async def watch_forager_ws_symbol(bot: Any, symbol: str) -> None:
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
+                if symbol in _retiring_symbols(bot):
+                    break
                 consecutive_failures += 1
                 delay_s = reconnect_delay_seconds(consecutive_failures)
                 clear_state = getattr(bot.cm, "clear_live_ws_ohlcv_state", None)
@@ -164,7 +231,8 @@ async def watch_forager_ws_symbol(bot: Any, symbol: str) -> None:
                     stage="forager_ws_candle_reconnect",
                 )
     finally:
-        await _best_effort_unwatch(bot, symbol)
+        if symbol not in _retiring_symbols(bot):
+            await _best_effort_unwatch(bot, symbol)
 
 
 async def reconcile_forager_ws_tasks(
@@ -178,8 +246,7 @@ async def reconcile_forager_ws_tasks(
     removed_tasks = []
     for symbol in sorted(removed):
         task = tasks.pop(symbol)
-        task.cancel()
-        removed_tasks.append(task)
+        removed_tasks.append(_retire_watcher(bot, symbol, task))
     if removed_tasks:
         await asyncio.gather(*removed_tasks, return_exceptions=True)
     clear_state = getattr(bot.cm, "clear_live_ws_ohlcv_state", None)
@@ -213,9 +280,5 @@ async def maintain_forager_ws_candles(bot: Any) -> None:
     except asyncio.CancelledError:
         raise
     finally:
-        pending = list(tasks.values())
-        for task in pending:
-            task.cancel()
-        if pending:
-            await asyncio.gather(*pending, return_exceptions=True)
+        await _retire_watchers(bot, dict(tasks))
         tasks.clear()

--- a/src/live/candle_ws.py
+++ b/src/live/candle_ws.py
@@ -130,12 +130,32 @@ async def _best_effort_unwatch_many(bot: Any, symbols: list[str]) -> bool:
         return False
 
 
-def _retiring_symbols(bot: Any) -> set[str]:
-    retiring = getattr(bot, "_forager_ws_retiring_symbols", None)
-    if not isinstance(retiring, set):
-        retiring = set()
-        bot._forager_ws_retiring_symbols = retiring
+def _retiring_watcher_tasks(bot: Any) -> dict[str, set[asyncio.Task]]:
+    retiring = getattr(bot, "_forager_ws_retiring_watchers", None)
+    if not isinstance(retiring, dict):
+        retiring = {}
+        bot._forager_ws_retiring_watchers = retiring
     return retiring
+
+
+def _watcher_is_retiring(bot: Any, symbol: str, task: asyncio.Task | None) -> bool:
+    if task is None:
+        return False
+    return task in _retiring_watcher_tasks(bot).get(symbol, set())
+
+
+def _mark_watcher_retiring(bot: Any, symbol: str, task: asyncio.Task) -> None:
+    _retiring_watcher_tasks(bot).setdefault(symbol, set()).add(task)
+
+
+def _clear_watcher_retiring(bot: Any, symbol: str, task: asyncio.Task) -> None:
+    retiring = _retiring_watcher_tasks(bot)
+    symbol_tasks = retiring.get(symbol)
+    if not symbol_tasks:
+        return
+    symbol_tasks.discard(task)
+    if not symbol_tasks:
+        retiring.pop(symbol, None)
 
 
 async def _retire_watcher(bot: Any, symbol: str, task: asyncio.Task) -> None:
@@ -158,9 +178,9 @@ async def _retire_watchers(bot: Any, tasks: dict[str, asyncio.Task]) -> None:
     if not active:
         return
     symbols = sorted(active)
-    retiring = _retiring_symbols(bot)
-    retiring.update(symbols)
-    abandoned_symbols: set[str] = set()
+    for symbol, task in active.items():
+        _mark_watcher_retiring(bot, symbol, task)
+    abandoned_tasks: dict[str, asyncio.Task] = {}
 
     def consume_done(done_tasks) -> None:
         for done_task in done_tasks:
@@ -192,33 +212,38 @@ async def _retire_watchers(bot: Any, tasks: dict[str, asyncio.Task]) -> None:
                 )
                 consume_done(cancelled)
                 resistant_set = set(resistant)
-                abandoned_symbols = {
-                    symbol
+                abandoned_tasks = {
+                    symbol: task
                     for symbol, task in active.items()
                     if task in resistant_set
                 }
-                if abandoned_symbols:
+                if abandoned_tasks:
                     logging.warning(
                         "[candle] websocket watcher cancellation grace expired "
                         "| symbols=%d action=abandon_pending",
-                        len(abandoned_symbols),
+                        len(abandoned_tasks),
                     )
-                    for symbol in abandoned_symbols:
-                        active[symbol].add_done_callback(
-                            lambda _task, symbol=symbol: retiring.discard(symbol)
+                    for symbol, task in abandoned_tasks.items():
+                        task.add_done_callback(
+                            lambda done_task, symbol=symbol: _clear_watcher_retiring(
+                                bot, symbol, done_task
+                            )
                         )
     finally:
-        retiring.difference_update(set(symbols) - abandoned_symbols)
+        for symbol, task in active.items():
+            if abandoned_tasks.get(symbol) is not task:
+                _clear_watcher_retiring(bot, symbol, task)
 
 
 async def watch_forager_ws_symbol(bot: Any, symbol: str) -> None:
     """Watch one symbol and pass only validated finalized rows to the manager."""
     consecutive_failures = 0
+    watcher_task = asyncio.current_task()
     try:
         while not bool(getattr(bot, "stop_signal_received", False)):
             try:
                 rows = await bot.ccp.watch_ohlcv(symbol, "1m")
-                if symbol in _retiring_symbols(bot):
+                if _watcher_is_retiring(bot, symbol, watcher_task):
                     break
                 ingest = getattr(bot.cm, "ingest_live_ws_ohlcv", None)
                 if callable(ingest):
@@ -234,7 +259,7 @@ async def watch_forager_ws_symbol(bot: Any, symbol: str) -> None:
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
-                if symbol in _retiring_symbols(bot):
+                if _watcher_is_retiring(bot, symbol, watcher_task):
                     break
                 consecutive_failures += 1
                 delay_s = reconnect_delay_seconds(consecutive_failures)
@@ -267,7 +292,7 @@ async def watch_forager_ws_symbol(bot: Any, symbol: str) -> None:
                     stage="forager_ws_candle_reconnect",
                 )
     finally:
-        if symbol not in _retiring_symbols(bot):
+        if not _watcher_is_retiring(bot, symbol, watcher_task):
             await _best_effort_unwatch(bot, symbol)
 
 

--- a/src/live/candle_ws.py
+++ b/src/live/candle_ws.py
@@ -21,6 +21,8 @@ _SUBSCRIPTION_RECONCILE_SECONDS = 5.0
 _MAX_RECONNECT_DELAY_SECONDS = 30.0
 _FAILURES_BEFORE_COOLDOWN = 5
 _UNSTABLE_COOLDOWN_SECONDS = 300.0
+_UNWATCH_TIMEOUT_SECONDS = 2.0
+_UNWATCH_MANY_TIMEOUT_SECONDS = 3.0
 _WATCHER_RETIRE_GRACE_SECONDS = 3.0
 _WATCHER_CANCEL_GRACE_SECONDS = 1.0
 
@@ -101,20 +103,75 @@ async def _sleep_unless_shutdown(bot: Any, delay_s: float, *, stage: str) -> Non
         await asyncio.sleep(delay_s)
 
 
+def _abandoned_unsubscribe_tasks(bot: Any) -> set[asyncio.Future]:
+    tasks = getattr(bot, "_forager_ws_abandoned_unsubscribe_tasks", None)
+    if not isinstance(tasks, set):
+        tasks = set()
+        bot._forager_ws_abandoned_unsubscribe_tasks = tasks
+    return tasks
+
+
+def _consume_abandoned_unsubscribe(bot: Any, task: asyncio.Future) -> None:
+    _abandoned_unsubscribe_tasks(bot).discard(task)
+    if task.done() and not task.cancelled():
+        try:
+            task.exception()
+        except BaseException:
+            pass
+
+
+def _cancel_and_track_unsubscribe(bot: Any, task: asyncio.Future) -> None:
+    task.cancel()
+    abandoned = _abandoned_unsubscribe_tasks(bot)
+    abandoned.add(task)
+    task.add_done_callback(
+        lambda done_task: _consume_abandoned_unsubscribe(bot, done_task)
+    )
+
+
+async def _run_unsubscribe_with_hard_timeout(
+    bot: Any, awaitable: Any, *, timeout: float
+) -> bool:
+    """Bound connector unsubscribe without awaiting cancellation-resistant work."""
+    try:
+        task = asyncio.ensure_future(awaitable)
+    except Exception:
+        return False
+    try:
+        done, _pending = await asyncio.wait(
+            {task}, timeout=max(0.0, float(timeout))
+        )
+    except asyncio.CancelledError:
+        _cancel_and_track_unsubscribe(bot, task)
+        raise
+    if task not in done:
+        _cancel_and_track_unsubscribe(bot, task)
+        return False
+    try:
+        task.result()
+        return True
+    except asyncio.CancelledError:
+        return False
+    except Exception:
+        return False
+
+
 async def _best_effort_unwatch(bot: Any, symbol: str) -> bool:
     ccp = getattr(bot, "ccp", None)
     unwatch = getattr(ccp, "un_watch_ohlcv", None)
     if not callable(unwatch):
         return False
     try:
-        await asyncio.wait_for(unwatch(symbol, "1m"), timeout=2.0)
-        return True
+        awaitable = unwatch(symbol, "1m")
     except asyncio.CancelledError:
         raise
-    except TimeoutError:
-        return False
     except Exception:
         return False
+    return await _run_unsubscribe_with_hard_timeout(
+        bot,
+        awaitable,
+        timeout=_UNWATCH_TIMEOUT_SECONDS,
+    )
 
 
 async def _best_effort_unwatch_many(bot: Any, symbols: list[str]) -> bool:
@@ -122,16 +179,18 @@ async def _best_effort_unwatch_many(bot: Any, symbols: list[str]) -> bool:
     unwatch = getattr(ccp, "un_watch_ohlcv_for_symbols", None)
     if not callable(unwatch) or not symbols:
         return False
+    subscriptions = [[symbol, "1m"] for symbol in symbols]
     try:
-        subscriptions = [[symbol, "1m"] for symbol in symbols]
-        await asyncio.wait_for(unwatch(subscriptions), timeout=3.0)
-        return True
+        awaitable = unwatch(subscriptions)
     except asyncio.CancelledError:
         raise
-    except TimeoutError:
-        return False
     except Exception:
         return False
+    return await _run_unsubscribe_with_hard_timeout(
+        bot,
+        awaitable,
+        timeout=_UNWATCH_MANY_TIMEOUT_SECONDS,
+    )
 
 
 def _retiring_watcher_tasks(bot: Any) -> dict[str, set[asyncio.Task]]:
@@ -308,9 +367,12 @@ async def reconcile_forager_ws_tasks(
     existing = set(tasks)
     removed = existing - desired
     added = desired - existing
-    removed_tasks = {symbol: tasks.pop(symbol) for symbol in sorted(removed)}
+    removed_tasks = {symbol: tasks[symbol] for symbol in sorted(removed)}
     if removed_tasks:
         await _retire_watchers(bot, removed_tasks)
+        for symbol, retired_task in removed_tasks.items():
+            if tasks.get(symbol) is retired_task:
+                tasks.pop(symbol, None)
     clear_state = getattr(bot.cm, "clear_live_ws_ohlcv_state", None)
     if callable(clear_state):
         for symbol in sorted(removed):

--- a/src/live/candle_ws.py
+++ b/src/live/candle_ws.py
@@ -109,7 +109,9 @@ async def _best_effort_unwatch(bot: Any, symbol: str) -> bool:
     try:
         await asyncio.wait_for(unwatch(symbol, "1m"), timeout=2.0)
         return True
-    except (asyncio.CancelledError, TimeoutError):
+    except asyncio.CancelledError:
+        raise
+    except TimeoutError:
         return False
     except Exception:
         return False
@@ -124,7 +126,9 @@ async def _best_effort_unwatch_many(bot: Any, symbols: list[str]) -> bool:
         subscriptions = [[symbol, "1m"] for symbol in symbols]
         await asyncio.wait_for(unwatch(subscriptions), timeout=3.0)
         return True
-    except (asyncio.CancelledError, TimeoutError):
+    except asyncio.CancelledError:
+        raise
+    except TimeoutError:
         return False
     except Exception:
         return False

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -522,7 +522,7 @@ def _bounded_traceback_origin(exc: BaseException) -> str:
         return "unknown"
 
 
-def _bounded_traceback_detail(exc: BaseException) -> dict[str, Any]:
+def _bounded_traceback_detail_inner(exc: BaseException) -> dict[str, Any]:
     """Return a durable frame chain without exception text, locals, or source lines."""
     exceptions: list[dict[str, Any]] = []
     visited: set[int] = set()
@@ -587,6 +587,21 @@ def _bounded_traceback_detail(exc: BaseException) -> dict[str, Any]:
         "includes_exception_text": False,
         "includes_locals": False,
     }
+
+
+def _bounded_traceback_detail(exc: BaseException) -> dict[str, Any]:
+    """Isolate optional traceback projection from the execution failure policy."""
+    try:
+        return _bounded_traceback_detail_inner(exc)
+    except BaseException:
+        return {
+            "exceptions": [],
+            "frame_count": 0,
+            "truncated": True,
+            "unavailable_reason": "projection_failed",
+            "includes_exception_text": False,
+            "includes_locals": False,
+        }
 
 
 def _bounded_runtime_stage(bot: Any) -> str:
@@ -8394,11 +8409,17 @@ class Passivbot:
             finally:
                 setattr(self, attr, None)
 
-        self._close_live_event_pipeline(timeout=2.0)
+        pipeline_closed = self._close_live_event_pipeline(timeout=2.0)
         publisher = getattr(self, "monitor_publisher", None)
         if publisher is not None:
             try:
-                publisher.close()
+                if pipeline_closed:
+                    publisher.close()
+                else:
+                    logging.warning(
+                        "[restart] monitor publisher close skipped "
+                        "| reason=event_pipeline_close_incomplete action=abandon_publisher"
+                    )
             except Exception as exc:
                 logging.warning(
                     "[restart] monitor publisher close failed | error_type=%s",

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -504,13 +504,45 @@ def order_has_match(order, orders, tolerance_qty=0.01, tolerance_price=0.002):
     return False
 
 
+def _bounded_traceback_origin(exc: BaseException) -> str:
+    """Return the innermost traceback location without exception text or paths."""
+    try:
+        tb = exc.__traceback__
+        if tb is None:
+            return "unknown"
+        while tb.tb_next is not None:
+            tb = tb.tb_next
+        filename = os.path.basename(str(tb.tb_frame.f_code.co_filename))
+        function = str(tb.tb_frame.f_code.co_name)
+        line = int(tb.tb_lineno)
+        if not re.fullmatch(r"[A-Za-z0-9_.-]{1,64}", filename):
+            return "unknown"
+        if not re.fullmatch(r"[A-Za-z0-9_<>.-]{1,64}", function):
+            return "unknown"
+        return f"{filename}:{function}:{line}"
+    except BaseException:
+        return "unknown"
+
+
+def _bounded_runtime_stage(bot: Any) -> str:
+    """Return the current lifecycle stage as a safe diagnostic token."""
+    try:
+        stage = str(getattr(bot, "_log_silence_watchdog_stage", "unknown"))
+    except BaseException:
+        return "unknown"
+    return stage if re.fullmatch(r"[A-Za-z0-9_.-]{1,64}", stage) else "unknown"
+
+
 def _log_process_failure(label: str, exc: BaseException) -> None:
+    current_bot = globals().get("bot")
     logging.error(
-        "%s | error_type=%s status=%s code=%s",
+        "%s | error_type=%s status=%s code=%s stage=%s origin=%s",
         label,
         bounded_exception_type(exc),
         bounded_exception_status(exc) or "-",
         bounded_exception_code(exc) or "-",
+        _bounded_runtime_stage(current_bot),
+        _bounded_traceback_origin(exc),
     )
 
 
@@ -5980,6 +6012,8 @@ class Passivbot:
             "status": bounded_exception_status(exc) or "-",
             "code": bounded_exception_code(exc) or "-",
             "endpoint": self._execution_loop_error_endpoint(exc),
+            "stage": _bounded_runtime_stage(self),
+            "origin": _bounded_traceback_origin(exc),
         }
 
     def _execution_loop_error_endpoint(self, exc: BaseException) -> str:
@@ -6094,11 +6128,13 @@ class Passivbot:
             },
         )
         logging.error(
-            "[error] operation=run_execution_loop error_type=%s status=%s code=%s endpoint=%s action=%s cycle=%s",
+            "[error] operation=run_execution_loop error_type=%s status=%s code=%s endpoint=%s stage=%s origin=%s action=%s cycle=%s",
             fields["error_type"],
             fields["status"],
             fields["code"],
             fields["endpoint"],
+            fields["stage"],
+            fields["origin"],
             incident_action,
             incident_cycle,
         )
@@ -7152,7 +7188,7 @@ class Passivbot:
             try:
                 try:
                     maintainer_grace = float(
-                        getattr(self, "_shutdown_maintainer_grace_seconds", 5.0)
+                        getattr(self, "_shutdown_maintainer_grace_seconds", 10.0)
                     )
                 except Exception:
                     maintainer_grace = 5.0
@@ -8175,6 +8211,12 @@ class Passivbot:
                 )
                 return {
                     "coverage_ok": bool(report.get("coverage_ok")),
+                    "refresh_needed": bool(
+                        report.get(
+                            "refresh_needed",
+                            not bool(report.get("coverage_ok")),
+                        )
+                    ),
                     "age_ms": (
                         int(now)
                         if no_basis
@@ -8186,6 +8228,16 @@ class Passivbot:
                         else int(last_cached_ts)
                     ),
                     "missing_candles": missing_candles,
+                    "verified_no_trade_missing_candles": int(
+                        report.get("verified_no_trade_missing_candles", 0) or 0
+                    ),
+                    "deferred_missing_candles": int(
+                        report.get("deferred_missing_candles", 0) or 0
+                    ),
+                    "refreshable_missing_candles": int(
+                        report.get("refreshable_missing_candles", missing_candles)
+                        or 0
+                    ),
                     "tail_gap_candles": tail_gap_candles,
                     "tail_only": bool(report.get("open_tail_gap"))
                     and missing_candles > 0
@@ -8207,6 +8259,7 @@ class Passivbot:
             if tf != "1m":
                 return {
                     "coverage_ok": False,
+                    "refresh_needed": True,
                     "age_ms": int(now),
                     "missing_candles": max(1, int(required_candles)),
                     "tail_gap_candles": max(1, int(required_candles)),
@@ -8218,6 +8271,7 @@ class Passivbot:
         age_ms = Passivbot._candle_staleness_ms(self, symbol, now_ms=now)
         return {
             "coverage_ok": age_ms <= 0,
+            "refresh_needed": age_ms > 0,
             "age_ms": int(age_ms),
             "missing_candles": 0 if age_ms <= 0 else 1,
             "tail_gap_candles": 0 if age_ms <= 0 else 1,
@@ -8308,7 +8362,12 @@ class Passivbot:
                     key,
                     bounded_exception_type(e),
                 )
-        if hasattr(self, "WS_ohlcvs_1m_tasks"):
+        ws_owner = self.maintainers.get("maintain_forager_ws_candles")
+        owner_done = getattr(ws_owner, "done", None)
+        ws_owner_active = ws_owner is not None and (
+            not callable(owner_done) or not owner_done()
+        )
+        if hasattr(self, "WS_ohlcvs_1m_tasks") and not ws_owner_active:
             res0s = {}
             for key in self.WS_ohlcvs_1m_tasks:
                 try:
@@ -8326,6 +8385,80 @@ class Passivbot:
         if verbose:
             logging.debug(f"stopped data maintainers: {res}")
         return res
+
+    async def cleanup_for_restart(self, *, timeout_seconds: float = 10.0) -> None:
+        """Close process-local resources before constructing a replacement bot."""
+        task_maps = (
+            getattr(self, "maintainers", None),
+            getattr(self, "WS_ohlcvs_1m_tasks", None),
+        )
+        self.stop_data_maintainers(verbose=False)
+        tasks: list[asyncio.Task] = []
+        seen: set[int] = set()
+        for task_map in task_maps:
+            if not isinstance(task_map, dict):
+                continue
+            for task in task_map.values():
+                if not isinstance(task, asyncio.Task) or id(task) in seen:
+                    continue
+                seen.add(id(task))
+                tasks.append(task)
+        if tasks:
+            gathered = asyncio.gather(*tasks, return_exceptions=True)
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(gathered), timeout=max(0.0, float(timeout_seconds))
+                )
+            except asyncio.TimeoutError:
+                logging.warning(
+                    "[restart] maintainer cleanup timed out | task_count=%d action=cancel_remaining",
+                    len(tasks),
+                )
+                for task in tasks:
+                    if not task.done():
+                        task.cancel()
+                try:
+                    await asyncio.wait_for(gathered, timeout=1.0)
+                except (asyncio.CancelledError, asyncio.TimeoutError):
+                    pass
+            except asyncio.CancelledError:
+                for task in tasks:
+                    if not task.done():
+                        task.cancel()
+                raise
+            except Exception as exc:
+                logging.warning(
+                    "[restart] maintainer cleanup failed | error_type=%s action=continue_cleanup",
+                    bounded_exception_type(exc),
+                )
+
+        for attr, label in (("ccp", "public"), ("cca", "private")):
+            client = getattr(self, attr, None)
+            if client is None:
+                continue
+            try:
+                await client.close()
+            except Exception as exc:
+                logging.warning(
+                    "[restart] %s session close failed | error_type=%s action=continue_cleanup",
+                    label,
+                    bounded_exception_type(exc),
+                )
+            finally:
+                setattr(self, attr, None)
+
+        self._close_live_event_pipeline(timeout=2.0)
+        publisher = getattr(self, "monitor_publisher", None)
+        if publisher is not None:
+            try:
+                publisher.close()
+            except Exception as exc:
+                logging.warning(
+                    "[restart] monitor publisher close failed | error_type=%s",
+                    bounded_exception_type(exc),
+                )
+            finally:
+                self.monitor_publisher = None
 
     def has_position(self, pside=None, symbol=None):
         """Return True if the bot currently holds a position for the given side and symbol."""
@@ -19832,15 +19965,12 @@ class Passivbot:
     # Legacy get_ohlcvs_1m_file_mods removed
 
     async def restart_bot(self):
-        """Stop all tasks and raise to trigger an external bot restart."""
+        """Request replacement by the outer lifecycle loop."""
         logging.info("Initiating bot restart...")
         # Note: Do NOT set stop_signal_received=True here - that would cause
         # the main loop to exit instead of restart. The flag is only for
         # user-initiated stops (SIGINT/SIGTERM).
         self.stop_data_maintainers()
-        await self.cca.close()
-        if self.ccp is not None:
-            await self.ccp.close()
         raise RestartBotException("Bot will restart.")
 
     def _forager_refresh_budget(
@@ -20322,6 +20452,15 @@ class Passivbot:
                 surface_health,
                 now_ms=now,
             )
+            refresh_needed = bool(
+                surface_health.get(
+                    "refresh_needed",
+                    not bool(surface_health.get("coverage_ok")),
+                )
+            )
+            if not refresh_needed and not ws_rest_audit_due:
+                surface_checks[surface_key] = checked_ms
+                continue
             if age_ms <= target_age_ms and (
                 bool(surface_health.get("coverage_ok")) or tail_only
             ) and not ws_rest_audit_due:
@@ -21814,15 +21953,9 @@ async def main():
                     else:
                         await bot.shutdown_gracefully()
                 else:
-                    bot.stop_data_maintainers()
-                if bot.ccp is not None:
-                    await bot.ccp.close()
-                    bot.ccp = None
-                if bot.cca is not None:
-                    await bot.cca.close()
-                    bot.cca = None
-            except:
-                pass
+                    await bot.cleanup_for_restart()
+            except Exception as exc:
+                _log_process_failure("passivbot cleanup error", exc)
             if bot is not None and getattr(bot, "_shutdown_in_progress", False):
                 logging.info(
                     "[%s] [shutdown] cleanup complete", getattr(bot, "exchange", "?")

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -522,6 +522,73 @@ def _bounded_traceback_origin(exc: BaseException) -> str:
         return "unknown"
 
 
+def _bounded_traceback_detail(exc: BaseException) -> dict[str, Any]:
+    """Return a durable frame chain without exception text, locals, or source lines."""
+    exceptions: list[dict[str, Any]] = []
+    visited: set[int] = set()
+    current: BaseException | None = exc
+    relation = "raised"
+    total_frames = 0
+    truncated = False
+    source_root = Path(__file__).resolve().parent.parent
+    while current is not None and id(current) not in visited:
+        if len(exceptions) >= 8:
+            truncated = True
+            break
+        visited.add(id(current))
+        frames: list[dict[str, Any]] = []
+        tb = current.__traceback__
+        while tb is not None:
+            if total_frames >= 64:
+                truncated = True
+                break
+            raw_filename = str(tb.tb_frame.f_code.co_filename)
+            try:
+                resolved = Path(raw_filename).resolve()
+                relative = resolved.relative_to(source_root)
+                filename = relative.as_posix()
+            except (OSError, RuntimeError, ValueError):
+                filename = os.path.basename(raw_filename)
+            if not re.fullmatch(r"[A-Za-z0-9_./<>-]{1,240}", filename):
+                filename = os.path.basename(raw_filename)
+            if not re.fullmatch(r"[A-Za-z0-9_./<>-]{1,240}", filename):
+                filename = "unknown"
+            function = str(tb.tb_frame.f_code.co_name)
+            if not re.fullmatch(r"[A-Za-z0-9_<>.-]{1,96}", function):
+                function = "unknown"
+            frames.append(
+                {
+                    "file": filename,
+                    "function": function,
+                    "line": max(0, int(tb.tb_lineno)),
+                }
+            )
+            total_frames += 1
+            tb = tb.tb_next
+        exceptions.append(
+            {
+                "relation": relation,
+                "error_type": bounded_exception_type(current),
+                "frames": frames,
+            }
+        )
+        if current.__cause__ is not None:
+            current = current.__cause__
+            relation = "cause"
+        elif current.__context__ is not None and not current.__suppress_context__:
+            current = current.__context__
+            relation = "context"
+        else:
+            current = None
+    return {
+        "exceptions": exceptions,
+        "frame_count": total_frames,
+        "truncated": truncated,
+        "includes_exception_text": False,
+        "includes_locals": False,
+    }
+
+
 def _bounded_runtime_stage(bot: Any) -> str:
     """Return the current lifecycle stage as a safe diagnostic token."""
     try:
@@ -5974,6 +6041,11 @@ class Passivbot:
             return True
         self._health_errors += 1
         fields = self._execution_loop_error_fields(exc)
+        incident_sequence = int(
+            getattr(self, "_execution_loop_incident_sequence", 0) or 0
+        ) + 1
+        self._execution_loop_incident_sequence = incident_sequence
+        incident_id = f"exec-{utc_ms()}-{incident_sequence}"
         incident_action = "record_error_restart_backoff"
         incident_cycle = "abandoned"
         self._monitor_record_event(
@@ -5981,13 +6053,27 @@ class Passivbot:
             ("error", "bot"),
             {
                 "source": "run_execution_loop",
+                "incident_id": incident_id,
                 **fields,
                 "action": incident_action,
                 "cycle": incident_cycle,
             },
         )
+        self._monitor_record_event(
+            "error.bot.detail",
+            ("error", "bot", "diagnostic"),
+            {
+                "source": "run_execution_loop",
+                "incident_id": incident_id,
+                **fields,
+                "action": incident_action,
+                "cycle": incident_cycle,
+                "traceback": _bounded_traceback_detail(exc),
+            },
+        )
         logging.error(
-            "[error] operation=run_execution_loop error_type=%s status=%s code=%s endpoint=%s stage=%s origin=%s action=%s cycle=%s",
+            "[error] operation=run_execution_loop incident=%s error_type=%s status=%s code=%s endpoint=%s stage=%s origin=%s action=%s cycle=%s",
+            incident_id,
             fields["error_type"],
             fields["status"],
             fields["code"],
@@ -5998,10 +6084,6 @@ class Passivbot:
             incident_cycle,
         )
         self._log_execution_loop_error_burst(fields)
-        if logging.getLogger().isEnabledFor(logging.DEBUG):
-            stack_frames = "".join(traceback.format_tb(exc.__traceback__))
-            if stack_frames:
-                logging.debug("[error] execution loop stack frames:\n%s", stack_frames)
         await self.restart_bot_on_too_many_errors()
         await asyncio.sleep(1.0)
         return True
@@ -8263,23 +8345,29 @@ class Passivbot:
                 seen.add(id(task))
                 tasks.append(task)
         if tasks:
-            gathered = asyncio.gather(*tasks, return_exceptions=True)
             try:
-                await asyncio.wait_for(
-                    asyncio.shield(gathered), timeout=max(0.0, float(timeout_seconds))
+                done, pending = await asyncio.wait(
+                    tasks, timeout=max(0.0, float(timeout_seconds))
                 )
-            except asyncio.TimeoutError:
-                logging.warning(
-                    "[restart] maintainer cleanup timed out | task_count=%d action=cancel_remaining",
-                    len(tasks),
-                )
-                for task in tasks:
-                    if not task.done():
+                for task in done:
+                    if not task.cancelled():
+                        task.exception()
+                if pending:
+                    logging.warning(
+                        "[restart] maintainer cleanup timed out | task_count=%d action=cancel_remaining",
+                        len(pending),
+                    )
+                    for task in pending:
                         task.cancel()
-                try:
-                    await asyncio.wait_for(gathered, timeout=1.0)
-                except (asyncio.CancelledError, asyncio.TimeoutError):
-                    pass
+                    cancelled, still_pending = await asyncio.wait(pending, timeout=1.0)
+                    for task in cancelled:
+                        if not task.cancelled():
+                            task.exception()
+                    if still_pending:
+                        logging.warning(
+                            "[restart] maintainer cancellation grace expired | task_count=%d action=abandon_pending",
+                            len(still_pending),
+                        )
             except asyncio.CancelledError:
                 for task in tasks:
                     if not task.done():

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -20072,7 +20072,10 @@ class Passivbot:
         # Note: Do NOT set stop_signal_received=True here - that would cause
         # the main loop to exit instead of restart. The flag is only for
         # user-initiated stops (SIGINT/SIGTERM).
-        self.stop_data_maintainers()
+        # The outer lifecycle finally block owns maintainer cancellation and
+        # awaits owner-managed teardown exactly once before closing clients.
+        # Cancelling here as well can inject a second CancelledError while the
+        # WebSocket owner is already retiring its child watchers.
         raise RestartBotException("Bot will restart.")
 
     def _forager_refresh_budget(

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -3062,6 +3062,101 @@ def test_known_gap_normalization_scales_to_large_sparse_history(tmp_path):
     assert elapsed < 2.0
 
 
+def test_completed_candle_health_scales_to_many_sparse_deferred_gaps(
+    tmp_path, monkeypatch
+):
+    cm = CandlestickManager(
+        exchange=None,
+        exchange_name="ex",
+        cache_dir=str(tmp_path / "caches"),
+    )
+    symbol = "MANYHEALTHGAPS/USDT:USDT"
+    gap_count = 5_000
+    end_ts = gap_count * 2 * ONE_MIN_MS
+    candles = np.array(
+        [
+            (ts, 1.0, 1.0, 1.0, 1.0, 1.0)
+            for ts in range(0, end_ts + 1, 2 * ONE_MIN_MS)
+        ],
+        dtype=CANDLE_DTYPE,
+    )
+    gaps = [
+        {
+            "start_ts": index * 2 * ONE_MIN_MS + ONE_MIN_MS,
+            "end_ts": index * 2 * ONE_MIN_MS + ONE_MIN_MS,
+            "retry_count": 1,
+            "reason": GAP_REASON_AUTO,
+            "added_at": 1,
+            "last_retry_at": 1,
+        }
+        for index in range(gap_count)
+    ]
+    monkeypatch.setattr(cm, "_load_from_disk", lambda *_args, **_kwargs: candles)
+    monkeypatch.setattr(cm, "_get_known_gaps_enhanced", lambda _symbol: gaps)
+    monkeypatch.setattr(cm, "_should_retry_gap", lambda *_args, **_kwargs: False)
+
+    started = time.perf_counter()
+    report = cm.get_completed_candle_health(
+        symbol,
+        {"1m": gap_count * 2 + 1},
+        now_ms=end_ts + ONE_MIN_MS,
+    )["timeframes"]["1m"]
+    elapsed = time.perf_counter() - started
+
+    assert report["missing_candles"] == gap_count
+    assert report["deferred_missing_candles"] == gap_count
+    assert report["refreshable_missing_candles"] == 0
+    assert report["refresh_needed"] is False
+    assert elapsed < 2.0
+
+
+def test_completed_candle_health_scales_to_many_verified_sparse_gaps(
+    tmp_path, monkeypatch
+):
+    cm = CandlestickManager(
+        exchange=None,
+        exchange_name="ex",
+        cache_dir=str(tmp_path / "caches"),
+    )
+    symbol = "MANYVERIFIEDGAPS/USDT:USDT"
+    gap_count = 5_000
+    end_ts = gap_count * 2 * ONE_MIN_MS
+    candles = np.array(
+        [
+            (ts, 1.0, 1.0, 1.0, 1.0, 1.0)
+            for ts in range(0, end_ts + 1, 2 * ONE_MIN_MS)
+        ],
+        dtype=CANDLE_DTYPE,
+    )
+    gaps = [
+        {
+            "start_ts": index * 2 * ONE_MIN_MS + ONE_MIN_MS,
+            "end_ts": index * 2 * ONE_MIN_MS + ONE_MIN_MS,
+            "retry_count": 0,
+            "reason": GAP_REASON_NO_TRADES,
+            "added_at": 1,
+            "last_retry_at": 1,
+        }
+        for index in range(gap_count)
+    ]
+    monkeypatch.setattr(cm, "_load_from_disk", lambda *_args, **_kwargs: candles)
+    monkeypatch.setattr(cm, "_get_known_gaps_enhanced", lambda _symbol: gaps)
+
+    started = time.perf_counter()
+    report = cm.get_completed_candle_health(
+        symbol,
+        {"1m": gap_count * 2 + 1},
+        now_ms=end_ts + ONE_MIN_MS,
+    )["timeframes"]["1m"]
+    elapsed = time.perf_counter() - started
+
+    assert report["missing_candles"] == gap_count
+    assert report["verified_no_trade_missing_candles"] == gap_count
+    assert report["refreshable_missing_candles"] == 0
+    assert report["refresh_needed"] is False
+    assert elapsed < 2.0
+
+
 def test_completed_candle_health_defers_unknown_gap_until_retry_is_due(tmp_path):
     class _Ex:
         id = "kucoinfutures"

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -3034,6 +3034,141 @@ def test_completed_candle_health_keeps_adjacent_unverified_minute_refreshable(tm
     assert report["refresh_needed"] is True
 
 
+def test_completed_candle_health_keeps_fresh_same_reason_suffix_refreshable(
+    tmp_path, monkeypatch
+):
+    now = {"ms": 7 * ONE_MIN_MS}
+    monkeypatch.setattr("time.time", lambda: now["ms"] / 1000.0)
+    cm = CandlestickManager(
+        exchange=None,
+        exchange_name="ex",
+        cache_dir=str(tmp_path / "caches"),
+    )
+    symbol = "FRESHEPOCH/USDT:USDT"
+    cm._persist_batch(
+        symbol,
+        np.array(
+            [
+                (2 * ONE_MIN_MS, 10.0, 10.0, 10.0, 10.0, 1.0),
+                (6 * ONE_MIN_MS, 11.0, 11.0, 11.0, 11.0, 2.0),
+            ],
+            dtype=CANDLE_DTYPE,
+        ),
+        timeframe="1m",
+        merge_cache=True,
+        last_refresh_ms=now["ms"],
+    )
+    cm._add_known_gap(
+        symbol,
+        3 * ONE_MIN_MS,
+        4 * ONE_MIN_MS,
+        reason=GAP_REASON_AUTO,
+        retry_count=_GAP_MAX_RETRIES,
+    )
+    now["ms"] += 1
+    cm._add_known_gap(
+        symbol,
+        3 * ONE_MIN_MS,
+        5 * ONE_MIN_MS,
+        reason=GAP_REASON_AUTO,
+    )
+
+    gaps = cm._get_known_gaps_enhanced(symbol)
+    assert [
+        (gap["start_ts"], gap["end_ts"], gap["retry_count"])
+        for gap in gaps
+    ] == [
+        (3 * ONE_MIN_MS, 4 * ONE_MIN_MS, _GAP_MAX_RETRIES),
+        (5 * ONE_MIN_MS, 5 * ONE_MIN_MS, 1),
+    ]
+    report = cm.get_completed_candle_health(
+        symbol, {"1m": 5}, now_ms=now["ms"]
+    )["timeframes"]["1m"]
+
+    assert report["missing_candles"] == 3
+    assert report["deferred_missing_candles"] == 2
+    assert report["refreshable_missing_candles"] == 1
+    assert report["refresh_needed"] is True
+
+
+def test_gap_normalization_merges_only_matching_retry_epochs(tmp_path):
+    cm = CandlestickManager(
+        exchange=None,
+        exchange_name="ex",
+        cache_dir=str(tmp_path / "caches"),
+    )
+    symbol = "RETRYEPISODES/USDT:USDT"
+    base_gap = {
+        "retry_count": _GAP_MAX_RETRIES,
+        "reason": GAP_REASON_AUTO,
+        "added_at": 1,
+        "last_retry_at": 1,
+        "last_contextual_retry_at": 0,
+    }
+    cm._save_known_gaps_enhanced(
+        symbol,
+        [
+            {
+                **base_gap,
+                "start_ts": ONE_MIN_MS,
+                "end_ts": ONE_MIN_MS,
+            },
+            {
+                **base_gap,
+                "start_ts": 2 * ONE_MIN_MS,
+                "end_ts": 2 * ONE_MIN_MS,
+            },
+            {
+                **base_gap,
+                "start_ts": 3 * ONE_MIN_MS,
+                "end_ts": 3 * ONE_MIN_MS,
+                "last_retry_at": 2,
+            },
+        ],
+    )
+
+    gaps = cm._get_known_gaps_enhanced(symbol)
+    assert [(gap["start_ts"], gap["end_ts"]) for gap in gaps] == [
+        (ONE_MIN_MS, 2 * ONE_MIN_MS),
+        (3 * ONE_MIN_MS, 3 * ONE_MIN_MS),
+    ]
+    assert [gap["last_retry_at"] for gap in gaps] == [1, 2]
+
+
+def test_gap_retry_update_is_scoped_to_attempted_overlap(tmp_path, monkeypatch):
+    now = {"ms": 10 * ONE_MIN_MS}
+    monkeypatch.setattr("time.time", lambda: now["ms"] / 1000.0)
+    cm = CandlestickManager(
+        exchange=None,
+        exchange_name="ex",
+        cache_dir=str(tmp_path / "caches"),
+    )
+    symbol = "PARTIALEPOCH/USDT:USDT"
+    cm._add_known_gap(
+        symbol,
+        ONE_MIN_MS,
+        3 * ONE_MIN_MS,
+        reason=GAP_REASON_AUTO,
+    )
+    now["ms"] += 1
+    cm._add_known_gap(
+        symbol,
+        2 * ONE_MIN_MS,
+        2 * ONE_MIN_MS,
+        reason=GAP_REASON_AUTO,
+    )
+
+    gaps = cm._get_known_gaps_enhanced(symbol)
+    assert [
+        (gap["start_ts"], gap["end_ts"], gap["retry_count"])
+        for gap in gaps
+    ] == [
+        (ONE_MIN_MS, ONE_MIN_MS, 1),
+        (2 * ONE_MIN_MS, 2 * ONE_MIN_MS, 2),
+        (3 * ONE_MIN_MS, 3 * ONE_MIN_MS, 1),
+    ]
+
+
 def test_known_gap_normalization_scales_to_large_sparse_history(tmp_path):
     cm = CandlestickManager(
         exchange=None,

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -2938,6 +2938,95 @@ def test_completed_candle_health_non_required_window_does_not_fail_overall(tmp_p
     assert report["timeframes"]["15m"]["missing_candles"] == 1
 
 
+def test_completed_candle_health_distinguishes_verified_sparse_continuity(tmp_path):
+    class _Ex:
+        id = "kucoinfutures"
+
+    cm = CandlestickManager(
+        exchange=_Ex(),
+        exchange_name="kucoin",
+        cache_dir=str(tmp_path / "caches"),
+    )
+    symbol = "SPARSE/USDT:USDT"
+    now_ms = 6 * ONE_MIN_MS
+    cm._persist_batch(
+        symbol,
+        np.array(
+            [
+                (2 * ONE_MIN_MS, 10.0, 10.0, 10.0, 10.0, 1.0),
+                (5 * ONE_MIN_MS, 11.0, 11.0, 11.0, 11.0, 2.0),
+            ],
+            dtype=CANDLE_DTYPE,
+        ),
+        timeframe="1m",
+        merge_cache=True,
+        last_refresh_ms=now_ms,
+    )
+    cm._record_verified_gap(
+        symbol,
+        3 * ONE_MIN_MS,
+        4 * ONE_MIN_MS,
+        reason=GAP_REASON_NO_TRADES,
+    )
+
+    report = cm.get_completed_candle_health(
+        symbol, {"1m": 4}, now_ms=now_ms
+    )["timeframes"]["1m"]
+
+    assert report["coverage_ok"] is False
+    assert report["missing_candles"] == 2
+    assert report["verified_no_trade_missing_candles"] == 2
+    assert report["deferred_missing_candles"] == 0
+    assert report["refreshable_missing_candles"] == 0
+    assert report["refresh_needed"] is False
+
+
+def test_completed_candle_health_defers_unknown_gap_until_retry_is_due(tmp_path):
+    class _Ex:
+        id = "kucoinfutures"
+
+    cm = CandlestickManager(
+        exchange=_Ex(),
+        exchange_name="kucoin",
+        cache_dir=str(tmp_path / "caches"),
+    )
+    symbol = "DEFERRED/USDT:USDT"
+    now_ms = 6 * ONE_MIN_MS
+    cm._persist_batch(
+        symbol,
+        np.array(
+            [
+                (2 * ONE_MIN_MS, 10.0, 10.0, 10.0, 10.0, 1.0),
+                (5 * ONE_MIN_MS, 11.0, 11.0, 11.0, 11.0, 2.0),
+            ],
+            dtype=CANDLE_DTYPE,
+        ),
+        timeframe="1m",
+        merge_cache=True,
+        last_refresh_ms=now_ms,
+    )
+    cm._add_known_gap(
+        symbol,
+        3 * ONE_MIN_MS,
+        4 * ONE_MIN_MS,
+        reason=GAP_REASON_FETCH_FAILED,
+        retry_count=_GAP_MAX_RETRIES,
+    )
+    gaps = cm._get_known_gaps_enhanced(symbol)
+    gaps[0]["last_contextual_retry_at"] = now_ms
+    cm._save_known_gaps_enhanced(symbol, gaps)
+
+    report = cm.get_completed_candle_health(
+        symbol, {"1m": 4}, now_ms=now_ms
+    )["timeframes"]["1m"]
+
+    assert report["coverage_ok"] is False
+    assert report["verified_no_trade_missing_candles"] == 0
+    assert report["deferred_missing_candles"] == 2
+    assert report["refreshable_missing_candles"] == 0
+    assert report["refresh_needed"] is False
+
+
 @pytest.mark.asyncio
 async def test_refresh_bounds_disk_load_range(monkeypatch, tmp_path):
     fixed_now_ms = 1725590400000  # 2024-09-06 00:00:00 UTC

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -17,6 +17,7 @@ import candlestick_manager
 from candlestick_manager import (
     CandlestickManager,
     CANDLE_DTYPE,
+    GAP_REASON_AUTO,
     GAP_REASON_FETCH_FAILED,
     GAP_REASON_NO_ARCHIVE,
     GAP_REASON_NO_TRADES,
@@ -2979,6 +2980,58 @@ def test_completed_candle_health_distinguishes_verified_sparse_continuity(tmp_pa
     assert report["deferred_missing_candles"] == 0
     assert report["refreshable_missing_candles"] == 0
     assert report["refresh_needed"] is False
+
+
+def test_completed_candle_health_keeps_adjacent_unverified_minute_refreshable(tmp_path):
+    cm = CandlestickManager(
+        exchange=None,
+        exchange_name="ex",
+        cache_dir=str(tmp_path / "caches"),
+    )
+    symbol = "PARTIALPROOF/USDT:USDT"
+    now_ms = 7 * ONE_MIN_MS
+    cm._persist_batch(
+        symbol,
+        np.array(
+            [
+                (2 * ONE_MIN_MS, 10.0, 10.0, 10.0, 10.0, 1.0),
+                (6 * ONE_MIN_MS, 11.0, 11.0, 11.0, 11.0, 2.0),
+            ],
+            dtype=CANDLE_DTYPE,
+        ),
+        timeframe="1m",
+        merge_cache=True,
+        last_refresh_ms=now_ms,
+    )
+    cm._record_verified_gap(
+        symbol,
+        3 * ONE_MIN_MS,
+        4 * ONE_MIN_MS,
+        reason=GAP_REASON_NO_TRADES,
+    )
+    cm._add_known_gap(
+        symbol,
+        5 * ONE_MIN_MS,
+        5 * ONE_MIN_MS,
+        reason=GAP_REASON_AUTO,
+        increment_retry=False,
+    )
+
+    gaps = cm._get_known_gaps_enhanced(symbol)
+    assert [
+        (gap["start_ts"], gap["end_ts"], gap["reason"]) for gap in gaps
+    ] == [
+        (3 * ONE_MIN_MS, 4 * ONE_MIN_MS, GAP_REASON_NO_TRADES),
+        (5 * ONE_MIN_MS, 5 * ONE_MIN_MS, GAP_REASON_AUTO),
+    ]
+    report = cm.get_completed_candle_health(
+        symbol, {"1m": 5}, now_ms=now_ms
+    )["timeframes"]["1m"]
+
+    assert report["missing_candles"] == 3
+    assert report["verified_no_trade_missing_candles"] == 2
+    assert report["refreshable_missing_candles"] == 1
+    assert report["refresh_needed"] is True
 
 
 def test_completed_candle_health_defers_unknown_gap_until_retry_is_due(tmp_path):

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -3034,6 +3034,34 @@ def test_completed_candle_health_keeps_adjacent_unverified_minute_refreshable(tm
     assert report["refresh_needed"] is True
 
 
+def test_known_gap_normalization_scales_to_large_sparse_history(tmp_path):
+    cm = CandlestickManager(
+        exchange=None,
+        exchange_name="ex",
+        cache_dir=str(tmp_path / "caches"),
+    )
+    symbol = "MANYGAPS/USDT:USDT"
+    gap_count = 5_000
+    gaps = [
+        {
+            "start_ts": index * 2 * ONE_MIN_MS,
+            "end_ts": index * 2 * ONE_MIN_MS,
+            "retry_count": 1,
+            "reason": GAP_REASON_AUTO,
+            "added_at": 1,
+            "last_retry_at": 1,
+        }
+        for index in range(gap_count)
+    ]
+
+    started = time.perf_counter()
+    cm._save_known_gaps_enhanced(symbol, gaps, defer_index=True)
+    elapsed = time.perf_counter() - started
+
+    assert len(cm._get_known_gaps_enhanced(symbol)) == gap_count
+    assert elapsed < 2.0
+
+
 def test_completed_candle_health_defers_unknown_gap_until_retry_is_due(tmp_path):
     class _Ex:
         id = "kucoinfutures"

--- a/tests/test_candlestick_manager_edge_cases.py
+++ b/tests/test_candlestick_manager_edge_cases.py
@@ -252,35 +252,51 @@ class TestGapHandlingEdgeCases:
         assert summary["persistent_gaps"] == 1
         assert summary["retryable_gaps"] == 0
 
-    def test_gap_merge_overlapping(self, tmp_cache_dir):
-        """Overlapping gaps should be merged."""
+    def test_gap_overlap_preserves_retried_subrange_epoch(
+        self, tmp_cache_dir, monkeypatch
+    ):
+        """A repeated overlap updates only the minutes attempted again."""
+        now = {"ms": 10 * ONE_MIN_MS}
+        monkeypatch.setattr(time, "time", lambda: now["ms"] / 1000.0)
         cm = CandlestickManager(exchange=None, exchange_name="test", cache_dir=tmp_cache_dir)
         symbol = "BTC/USDT:USDT"
 
-        # Add overlapping gaps
-        cm._add_known_gap(symbol, 1000000, 3000000)
-        cm._add_known_gap(symbol, 2000000, 4000000)
+        cm._add_known_gap(symbol, ONE_MIN_MS, 3 * ONE_MIN_MS)
+        now["ms"] += 1
+        cm._add_known_gap(symbol, 2 * ONE_MIN_MS, 4 * ONE_MIN_MS)
 
-        gaps = cm._get_known_gaps(symbol)
-        # Should be merged into one gap
-        assert len(gaps) == 1
-        assert gaps[0][0] == 1000000
-        assert gaps[0][1] == 4000000
+        gaps = cm._get_known_gaps_enhanced(symbol)
+        assert [
+            (gap["start_ts"], gap["end_ts"], gap["retry_count"])
+            for gap in gaps
+        ] == [
+            (ONE_MIN_MS, ONE_MIN_MS, 1),
+            (2 * ONE_MIN_MS, 3 * ONE_MIN_MS, 2),
+            (4 * ONE_MIN_MS, 4 * ONE_MIN_MS, 1),
+        ]
 
-    def test_gap_adjacent_merge(self, tmp_cache_dir):
-        """Adjacent gaps (touching at boundaries) should be merged."""
+    def test_gap_adjacent_distinct_retry_epochs_remain_separate(
+        self, tmp_cache_dir, monkeypatch
+    ):
+        """Later adjacent evidence must not inherit the first gap's epoch."""
+        now = {"ms": 10 * ONE_MIN_MS}
+        monkeypatch.setattr(time, "time", lambda: now["ms"] / 1000.0)
         cm = CandlestickManager(exchange=None, exchange_name="test", cache_dir=tmp_cache_dir)
         symbol = "BTC/USDT:USDT"
 
-        # Add adjacent gaps
-        cm._add_known_gap(symbol, 1000000, 2000000)
-        cm._add_known_gap(symbol, 2000000, 3000000)
+        cm._add_known_gap(symbol, ONE_MIN_MS, 2 * ONE_MIN_MS)
+        now["ms"] += 1
+        cm._add_known_gap(symbol, 3 * ONE_MIN_MS, 4 * ONE_MIN_MS)
 
-        gaps = cm._get_known_gaps(symbol)
-        # Should be merged
-        assert len(gaps) == 1
-        assert gaps[0][0] == 1000000
-        assert gaps[0][1] == 3000000
+        gaps = cm._get_known_gaps_enhanced(symbol)
+        assert [(gap["start_ts"], gap["end_ts"]) for gap in gaps] == [
+            (ONE_MIN_MS, 2 * ONE_MIN_MS),
+            (3 * ONE_MIN_MS, 4 * ONE_MIN_MS),
+        ]
+        assert [gap["added_at"] for gap in gaps] == [
+            10 * ONE_MIN_MS,
+            10 * ONE_MIN_MS + 1,
+        ]
 
 
 # ==============================================================================

--- a/tests/test_forager_ws_candles.py
+++ b/tests/test_forager_ws_candles.py
@@ -943,14 +943,76 @@ async def test_watcher_retirement_abandons_cancellation_resistant_task(
                 candle_ws._retire_watchers(bot, {symbol: task}), timeout=0.2
             )
         assert not task.done()
-        assert symbol in candle_ws._retiring_symbols(bot)
+        assert candle_ws._watcher_is_retiring(bot, symbol, task)
         assert "websocket watcher cancellation grace expired" in caplog.text
     finally:
         release.set()
         await asyncio.wait_for(task, timeout=1.0)
         await asyncio.sleep(0)
 
-    assert symbol not in candle_ws._retiring_symbols(bot)
+    assert not candle_ws._watcher_is_retiring(bot, symbol, task)
+
+
+@pytest.mark.asyncio
+async def test_resistant_old_watcher_does_not_retire_replacement(monkeypatch):
+    monkeypatch.setattr(candle_ws, "_WATCHER_RETIRE_GRACE_SECONDS", 0.01)
+    monkeypatch.setattr(candle_ws, "_WATCHER_CANCEL_GRACE_SECONDS", 0.01)
+    release_old = asyncio.Event()
+    replacement_waiting = asyncio.Event()
+    ingested = asyncio.Event()
+
+    async def resistant_old_watcher():
+        while not release_old.is_set():
+            try:
+                await release_old.wait()
+            except asyncio.CancelledError:
+                continue
+
+    class _ReplacementCCP:
+        def __init__(self):
+            self.calls = 0
+
+        async def watch_ohlcv(self, _symbol, _timeframe):
+            self.calls += 1
+            if self.calls == 1:
+                return [[ONE_MIN_MS, 1.0, 1.0, 1.0, 1.0, 1.0]]
+            await replacement_waiting.wait()
+            return []
+
+        async def un_watch_ohlcv(self, _symbol, _timeframe):
+            return None
+
+    symbol = "REENTERED/USDT:USDT"
+    old_task = asyncio.create_task(resistant_old_watcher())
+    bot = SimpleNamespace(
+        ccp=_ReplacementCCP(),
+        cm=SimpleNamespace(
+            ingest_live_ws_ohlcv=lambda *_args: ingested.set(),
+            clear_live_ws_ohlcv_state=lambda _symbol: None,
+        ),
+        stop_signal_received=False,
+    )
+
+    try:
+        await candle_ws._retire_watchers(bot, {symbol: old_task})
+        replacement = asyncio.create_task(
+            candle_ws.watch_forager_ws_symbol(bot, symbol)
+        )
+        await asyncio.wait_for(ingested.wait(), timeout=1.0)
+        await asyncio.sleep(0)
+
+        assert candle_ws._watcher_is_retiring(bot, symbol, old_task)
+        assert not candle_ws._watcher_is_retiring(bot, symbol, replacement)
+        assert not replacement.done()
+    finally:
+        if "replacement" in locals():
+            replacement.cancel()
+            await asyncio.gather(replacement, return_exceptions=True)
+        release_old.set()
+        await asyncio.wait_for(old_task, timeout=1.0)
+        await asyncio.sleep(0)
+
+    assert not candle_ws._watcher_is_retiring(bot, symbol, old_task)
 
 
 @pytest.mark.asyncio

--- a/tests/test_forager_ws_candles.py
+++ b/tests/test_forager_ws_candles.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -915,6 +916,41 @@ async def test_bulk_watcher_retirement_uses_one_supported_unsubscribe():
     ]
     assert ccp.single_calls == []
     assert all(task.done() and not task.cancelled() for task in tasks.values())
+
+
+@pytest.mark.asyncio
+async def test_watcher_retirement_abandons_cancellation_resistant_task(
+    caplog, monkeypatch
+):
+    monkeypatch.setattr(candle_ws, "_WATCHER_RETIRE_GRACE_SECONDS", 0.01)
+    monkeypatch.setattr(candle_ws, "_WATCHER_CANCEL_GRACE_SECONDS", 0.01)
+    release = asyncio.Event()
+
+    async def resistant_watcher():
+        while not release.is_set():
+            try:
+                await release.wait()
+            except asyncio.CancelledError:
+                continue
+
+    symbol = "RESISTANT/USDT:USDT"
+    task = asyncio.create_task(resistant_watcher())
+    bot = SimpleNamespace(ccp=SimpleNamespace())
+
+    try:
+        with caplog.at_level(logging.WARNING):
+            await asyncio.wait_for(
+                candle_ws._retire_watchers(bot, {symbol: task}), timeout=0.2
+            )
+        assert not task.done()
+        assert symbol in candle_ws._retiring_symbols(bot)
+        assert "websocket watcher cancellation grace expired" in caplog.text
+    finally:
+        release.set()
+        await asyncio.wait_for(task, timeout=1.0)
+        await asyncio.sleep(0)
+
+    assert symbol not in candle_ws._retiring_symbols(bot)
 
 
 @pytest.mark.asyncio

--- a/tests/test_forager_ws_candles.py
+++ b/tests/test_forager_ws_candles.py
@@ -918,6 +918,58 @@ async def test_bulk_watcher_retirement_uses_one_supported_unsubscribe():
 
 
 @pytest.mark.asyncio
+async def test_reconcile_retires_removed_watchers_in_one_bulk_unsubscribe():
+    class _BulkWakeupCCP:
+        def __init__(self):
+            self.futures = {}
+            self.bulk_calls = []
+            self.single_calls = []
+
+        async def watch_ohlcv(self, symbol, _timeframe):
+            future = asyncio.get_running_loop().create_future()
+            self.futures[symbol] = future
+            return await future
+
+        async def un_watch_ohlcv_for_symbols(self, subscriptions):
+            self.bulk_calls.append(subscriptions)
+            for symbol, _timeframe in subscriptions:
+                self.futures[symbol].set_exception(RuntimeError("unsubscribe wakeup"))
+
+        async def un_watch_ohlcv(self, symbol, _timeframe):
+            self.single_calls.append(symbol)
+
+    ccp = _BulkWakeupCCP()
+    bot = SimpleNamespace(
+        config={"live": {"enable_forager_ws_candles": True}},
+        ws_enabled=True,
+        ccp=ccp,
+        cm=SimpleNamespace(
+            ingest_live_ws_ohlcv=lambda *_args: 0,
+            clear_live_ws_ohlcv_state=lambda _symbol: None,
+        ),
+        stop_signal_received=False,
+        approved_coins_minus_ignored_coins={"long": set(), "short": set()},
+        is_forager_mode=lambda pside=None: pside in {None, "long"},
+        _urgent_active_candle_symbols=lambda: [],
+    )
+    tasks = {
+        symbol: asyncio.create_task(candle_ws.watch_forager_ws_symbol(bot, symbol))
+        for symbol in ("A/USDT:USDT", "B/USDT:USDT")
+    }
+    await asyncio.sleep(0)
+
+    added, removed = await candle_ws.reconcile_forager_ws_tasks(bot, tasks)
+
+    assert added == set()
+    assert removed == {"A/USDT:USDT", "B/USDT:USDT"}
+    assert tasks == {}
+    assert ccp.bulk_calls == [
+        [["A/USDT:USDT", "1m"], ["B/USDT:USDT", "1m"]]
+    ]
+    assert ccp.single_calls == []
+
+
+@pytest.mark.asyncio
 async def test_ws_maintainer_starts_before_forager_mode_becomes_active():
     bot = Passivbot.__new__(Passivbot)
     bot.config = {

--- a/tests/test_forager_ws_candles.py
+++ b/tests/test_forager_ws_candles.py
@@ -843,6 +843,54 @@ async def test_dynamic_subscriptions_follow_flat_forager_universe():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("bulk_supported", [False, True])
+async def test_watcher_retirement_propagates_owner_cancellation(bulk_supported):
+    unsubscribe_started = asyncio.Event()
+
+    class _CancellationBlockingCCP:
+        def __init__(self):
+            self.single_calls = 0
+            self.bulk_calls = 0
+            if not bulk_supported:
+                self.un_watch_ohlcv_for_symbols = None
+
+        async def un_watch_ohlcv(self, _symbol, _timeframe):
+            self.single_calls += 1
+            unsubscribe_started.set()
+            await asyncio.Event().wait()
+
+        async def un_watch_ohlcv_for_symbols(self, _subscriptions):
+            self.bulk_calls += 1
+            unsubscribe_started.set()
+            await asyncio.Event().wait()
+
+    symbol = "CANCEL/USDT:USDT"
+    watcher = asyncio.create_task(asyncio.Event().wait())
+    bot = SimpleNamespace(ccp=_CancellationBlockingCCP())
+    retirement = asyncio.create_task(
+        candle_ws._retire_watchers(bot, {symbol: watcher})
+    )
+
+    try:
+        await asyncio.wait_for(unsubscribe_started.wait(), timeout=1.0)
+        retirement.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await retirement
+
+        assert not watcher.done()
+        assert not candle_ws._watcher_is_retiring(bot, symbol, watcher)
+        if bulk_supported:
+            assert bot.ccp.bulk_calls == 1
+            assert bot.ccp.single_calls == 0
+        else:
+            assert bot.ccp.bulk_calls == 0
+            assert bot.ccp.single_calls == 1
+    finally:
+        watcher.cancel()
+        await asyncio.gather(watcher, return_exceptions=True)
+
+
+@pytest.mark.asyncio
 async def test_unsubscribe_wakeup_exception_is_consumed_before_watcher_retirement():
     class _UnsubscribeWakeupCCP:
         has = {"watchOHLCV": True}

--- a/tests/test_forager_ws_candles.py
+++ b/tests/test_forager_ws_candles.py
@@ -674,6 +674,7 @@ class _BlockingCCP:
     async def un_watch_ohlcv(self, symbol, timeframe):
         assert timeframe == "1m"
         self.unwatched.append(symbol)
+        self.events.setdefault(symbol, asyncio.Event()).set()
 
 
 @pytest.mark.asyncio
@@ -838,6 +839,82 @@ async def test_dynamic_subscriptions_follow_flat_forager_universe():
     for task in tasks.values():
         task.cancel()
     await asyncio.gather(*tasks.values(), return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_wakeup_exception_is_consumed_before_watcher_retirement():
+    class _UnsubscribeWakeupCCP:
+        has = {"watchOHLCV": True}
+
+        def __init__(self):
+            self.future = None
+
+        async def watch_ohlcv(self, _symbol, _timeframe):
+            self.future = asyncio.get_running_loop().create_future()
+            return await self.future
+
+        async def un_watch_ohlcv(self, _symbol, _timeframe):
+            self.future.set_exception(RuntimeError("unsubscribe wakeup"))
+
+    ccp = _UnsubscribeWakeupCCP()
+    bot = SimpleNamespace(
+        ccp=ccp,
+        cm=SimpleNamespace(ingest_live_ws_ohlcv=lambda *_args: 0),
+        stop_signal_received=False,
+    )
+    task = asyncio.create_task(
+        candle_ws.watch_forager_ws_symbol(bot, "BTC/USDT:USDT")
+    )
+    await asyncio.sleep(0)
+
+    await candle_ws._retire_watcher(bot, "BTC/USDT:USDT", task)
+
+    assert task.done()
+    assert task.cancelled() is False
+    assert ccp.future.done()
+    assert ccp.future.exception() is not None
+
+
+@pytest.mark.asyncio
+async def test_bulk_watcher_retirement_uses_one_supported_unsubscribe():
+    class _BulkWakeupCCP:
+        def __init__(self):
+            self.futures = {}
+            self.bulk_calls = []
+            self.single_calls = []
+
+        async def watch_ohlcv(self, symbol, _timeframe):
+            future = asyncio.get_running_loop().create_future()
+            self.futures[symbol] = future
+            return await future
+
+        async def un_watch_ohlcv_for_symbols(self, subscriptions):
+            self.bulk_calls.append(subscriptions)
+            for symbol, _timeframe in subscriptions:
+                self.futures[symbol].set_exception(RuntimeError("unsubscribe wakeup"))
+
+        async def un_watch_ohlcv(self, symbol, _timeframe):
+            self.single_calls.append(symbol)
+
+    ccp = _BulkWakeupCCP()
+    bot = SimpleNamespace(
+        ccp=ccp,
+        cm=SimpleNamespace(ingest_live_ws_ohlcv=lambda *_args: 0),
+        stop_signal_received=False,
+    )
+    tasks = {
+        symbol: asyncio.create_task(candle_ws.watch_forager_ws_symbol(bot, symbol))
+        for symbol in ("A/USDT:USDT", "B/USDT:USDT")
+    }
+    await asyncio.sleep(0)
+
+    await candle_ws._retire_watchers(bot, tasks)
+
+    assert ccp.bulk_calls == [
+        [["A/USDT:USDT", "1m"], ["B/USDT:USDT", "1m"]]
+    ]
+    assert ccp.single_calls == []
+    assert all(task.done() and not task.cancelled() for task in tasks.values())
 
 
 @pytest.mark.asyncio

--- a/tests/test_forager_ws_candles.py
+++ b/tests/test_forager_ws_candles.py
@@ -891,6 +891,92 @@ async def test_watcher_retirement_propagates_owner_cancellation(bulk_supported):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("bulk_supported", [False, True])
+async def test_unsubscribe_timeout_is_hard_when_connector_suppresses_cancellation(
+    bulk_supported, monkeypatch
+):
+    monkeypatch.setattr(candle_ws, "_UNWATCH_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(candle_ws, "_UNWATCH_MANY_TIMEOUT_SECONDS", 0.01)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def cancellation_resistant_unsubscribe(*_args):
+        started.set()
+        while not release.is_set():
+            try:
+                await release.wait()
+            except asyncio.CancelledError:
+                continue
+
+    ccp = SimpleNamespace(un_watch_ohlcv=cancellation_resistant_unsubscribe)
+    if bulk_supported:
+        ccp.un_watch_ohlcv_for_symbols = cancellation_resistant_unsubscribe
+    bot = SimpleNamespace(ccp=ccp)
+
+    if bulk_supported:
+        result = await asyncio.wait_for(
+            candle_ws._best_effort_unwatch_many(bot, ["A/USDT:USDT"]),
+            timeout=0.2,
+        )
+    else:
+        result = await asyncio.wait_for(
+            candle_ws._best_effort_unwatch(bot, "A/USDT:USDT"),
+            timeout=0.2,
+        )
+
+    assert result is False
+    await asyncio.wait_for(started.wait(), timeout=0.2)
+    abandoned = candle_ws._abandoned_unsubscribe_tasks(bot)
+    assert len(abandoned) == 1
+    abandoned_task = next(iter(abandoned))
+    release.set()
+    await asyncio.wait_for(abandoned_task, timeout=1.0)
+    await asyncio.sleep(0)
+    assert candle_ws._abandoned_unsubscribe_tasks(bot) == set()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_cancellation_keeps_removed_watcher_owned():
+    unsubscribe_started = asyncio.Event()
+
+    class _BlockingBulkCCP:
+        async def un_watch_ohlcv_for_symbols(self, _subscriptions):
+            unsubscribe_started.set()
+            await asyncio.Event().wait()
+
+        async def un_watch_ohlcv(self, _symbol, _timeframe):
+            raise AssertionError("single fallback must not start after owner cancellation")
+
+    symbol = "OWNED/USDT:USDT"
+    watcher = asyncio.create_task(asyncio.Event().wait())
+    tasks = {symbol: watcher}
+    bot = SimpleNamespace(
+        config={"live": {"enable_forager_ws_candles": True}},
+        ws_enabled=True,
+        ccp=_BlockingBulkCCP(),
+        cm=SimpleNamespace(clear_live_ws_ohlcv_state=lambda _symbol: None),
+        approved_coins_minus_ignored_coins={"long": set(), "short": set()},
+        is_forager_mode=lambda pside=None: pside in {None, "long"},
+        _urgent_active_candle_symbols=lambda: [],
+    )
+    reconciliation = asyncio.create_task(
+        candle_ws.reconcile_forager_ws_tasks(bot, tasks)
+    )
+
+    try:
+        await asyncio.wait_for(unsubscribe_started.wait(), timeout=1.0)
+        reconciliation.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await reconciliation
+
+        assert tasks == {symbol: watcher}
+        assert not watcher.done()
+    finally:
+        watcher.cancel()
+        await asyncio.gather(watcher, return_exceptions=True)
+
+
+@pytest.mark.asyncio
 async def test_unsubscribe_wakeup_exception_is_consumed_before_watcher_retirement():
     class _UnsubscribeWakeupCCP:
         has = {"watchOHLCV": True}

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -4558,6 +4558,89 @@ async def test_forager_candidate_refresh_skips_latest_final_candles(monkeypatch)
     assert bot.cm.calls == []
 
 
+@pytest.mark.asyncio
+async def test_forager_candidate_refresh_skips_non_refreshable_sparse_gap(monkeypatch):
+    import passivbot as pb_mod
+
+    now_ms = 10_000_000
+    latest_final = (now_ms // 60_000) * 60_000 - 60_000
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: now_ms)
+
+    class FakeCM:
+        default_window_candles = 120
+
+        def __init__(self):
+            self.calls = []
+
+        def get_completed_candle_health(self, _symbol, windows, *, now_ms=None):
+            required = int(windows["1m"])
+            return {
+                "timeframes": {
+                    "1m": {
+                        "coverage_ok": False,
+                        "refresh_needed": False,
+                        "loaded_rows": required - 2,
+                        "last_cached_ts": latest_final,
+                        "last_cached_age_ms": 0,
+                        "missing_candles": 2,
+                        "verified_no_trade_missing_candles": 2,
+                        "refreshable_missing_candles": 0,
+                        "tail_gap_candles": 0,
+                        "missing_spans": [(latest_final - 180_000, latest_final - 120_000)],
+                    }
+                }
+            }
+
+        async def get_candles(self, symbol, **kwargs):
+            self.calls.append((symbol, kwargs))
+            return []
+
+    class FakeBot:
+        config = {"live": {"max_ohlcv_fetches_per_minute": 30}}
+        approved_coins_minus_ignored_coins = {
+            "long": {"SPARSE/USDT:USDT"},
+            "short": set(),
+        }
+        active_symbols = []
+        positions = {}
+        open_orders = {}
+        inactive_coin_candle_ttl_ms = 600_000
+        stop_signal_received = False
+        start_time_ms = 0
+        cm = FakeCM()
+
+        def is_forager_mode(self, pside=None):
+            return pside in (None, "long")
+
+        def get_max_n_positions(self, pside):
+            return 1 if pside == "long" else 0
+
+        def get_current_n_positions(self, _pside):
+            return 0
+
+        def _get_fetch_delay_seconds(self):
+            return 0.0
+
+        def bp(self, _pside, key, _symbol):
+            if key in {
+                "forager_volume_ema_span_1m",
+                "forager_volatility_ema_span_1m",
+            }:
+                return 10.0
+            return 0.0
+
+        _urgent_active_candle_symbols = pb_mod.Passivbot._urgent_active_candle_symbols
+        _forager_refresh_budget = pb_mod.Passivbot._forager_refresh_budget
+        _token_bucket_budget = pb_mod.Passivbot._token_bucket_budget
+        _forager_target_staleness_ms = pb_mod.Passivbot._forager_target_staleness_ms
+        _candle_staleness_ms = pb_mod.Passivbot._candle_staleness_ms
+
+    bot = FakeBot()
+    await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
+
+    assert bot.cm.calls == []
+
+
 def test_completed_candle_freshness_allows_bounded_active_tail_gap(monkeypatch, caplog):
     import logging
     import passivbot as pb_mod

--- a/tests/test_maintainer_logging.py
+++ b/tests/test_maintainer_logging.py
@@ -130,6 +130,47 @@ async def test_restart_cleanup_awaits_ws_owner_before_closing_resources():
 
 
 @pytest.mark.asyncio
+async def test_restart_cleanup_abandons_cancellation_resistant_maintainer(caplog):
+    bot = Passivbot.__new__(Passivbot)
+    release = asyncio.Event()
+    cancellation_count = 0
+
+    async def resistant_maintainer():
+        nonlocal cancellation_count
+        while not release.is_set():
+            try:
+                await release.wait()
+            except asyncio.CancelledError:
+                cancellation_count += 1
+
+    class _Client:
+        async def close(self):
+            return None
+
+    task = asyncio.create_task(resistant_maintainer())
+    await asyncio.sleep(0)
+    bot.maintainers = {"resistant": task}
+    bot.WS_ohlcvs_1m_tasks = {}
+    bot.ccp = _Client()
+    bot.cca = _Client()
+    bot.monitor_publisher = None
+    bot._close_live_event_pipeline = lambda **_kwargs: True
+
+    try:
+        with caplog.at_level(logging.WARNING):
+            await asyncio.wait_for(
+                bot.cleanup_for_restart(timeout_seconds=0.0), timeout=1.5
+            )
+        assert cancellation_count >= 1
+        assert "maintainer cancellation grace expired" in caplog.text
+        assert bot.ccp is None
+        assert bot.cca is None
+    finally:
+        release.set()
+        await asyncio.wait_for(task, timeout=1.0)
+
+
+@pytest.mark.asyncio
 async def test_shutdown_bot_redacts_close_failure_text(capsys):
     class _FailingBot:
         def stop_data_maintainers(self):

--- a/tests/test_maintainer_logging.py
+++ b/tests/test_maintainer_logging.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -70,6 +71,62 @@ def test_stop_data_maintainers_keeps_cancellation_failures_at_error(caplog):
     assert "websocket-secret" not in caplog.text
     assert "private.invalid" not in caplog.text
     assert any(record.levelno == logging.ERROR for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_restart_cleanup_awaits_ws_owner_before_closing_resources():
+    bot = Passivbot.__new__(Passivbot)
+    calls = []
+    child = None
+
+    async def child_watcher():
+        try:
+            await asyncio.Event().wait()
+        finally:
+            calls.append("watcher_stopped")
+
+    async def ws_owner():
+        try:
+            await asyncio.Event().wait()
+        finally:
+            child.cancel()
+            await asyncio.gather(child, return_exceptions=True)
+            calls.append("owner_stopped")
+
+    class _Client:
+        def __init__(self, label):
+            self.label = label
+
+        async def close(self):
+            calls.append(self.label)
+
+    class _Publisher:
+        def close(self):
+            calls.append("publisher")
+
+    child = asyncio.create_task(child_watcher())
+    owner = asyncio.create_task(ws_owner())
+    await asyncio.sleep(0)
+    bot.maintainers = {"maintain_forager_ws_candles": owner}
+    bot.WS_ohlcvs_1m_tasks = {"BTC": child}
+    bot.ccp = _Client("public")
+    bot.cca = _Client("private")
+    bot.monitor_publisher = _Publisher()
+    bot._close_live_event_pipeline = lambda **_kwargs: calls.append("pipeline") or True
+
+    await bot.cleanup_for_restart(timeout_seconds=1.0)
+
+    assert calls == [
+        "watcher_stopped",
+        "owner_stopped",
+        "public",
+        "private",
+        "pipeline",
+        "publisher",
+    ]
+    assert bot.ccp is None
+    assert bot.cca is None
+    assert bot.monitor_publisher is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_maintainer_logging.py
+++ b/tests/test_maintainer_logging.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from passivbot import Passivbot, shutdown_bot
+from passivbot_exceptions import RestartBotException
 
 
 class _Task:
@@ -71,6 +72,18 @@ def test_stop_data_maintainers_keeps_cancellation_failures_at_error(caplog):
     assert "websocket-secret" not in caplog.text
     assert "private.invalid" not in caplog.text
     assert any(record.levelno == logging.ERROR for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_restart_request_defers_maintainer_cancellation_to_outer_cleanup():
+    bot = Passivbot.__new__(Passivbot)
+    stop_calls = []
+    bot.stop_data_maintainers = lambda: stop_calls.append("stop")
+
+    with pytest.raises(RestartBotException, match="Bot will restart"):
+        await bot.restart_bot()
+
+    assert stop_calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_maintainer_logging.py
+++ b/tests/test_maintainer_logging.py
@@ -171,6 +171,37 @@ async def test_restart_cleanup_abandons_cancellation_resistant_maintainer(caplog
 
 
 @pytest.mark.asyncio
+async def test_restart_cleanup_skips_publisher_close_after_pipeline_timeout(caplog):
+    bot = Passivbot.__new__(Passivbot)
+    closed_clients = []
+
+    class _Client:
+        def __init__(self, label):
+            self.label = label
+
+        async def close(self):
+            closed_clients.append(self.label)
+
+    class _Publisher:
+        def close(self):
+            raise AssertionError("publisher close must be skipped")
+
+    bot.maintainers = {}
+    bot.WS_ohlcvs_1m_tasks = {}
+    bot.ccp = _Client("public")
+    bot.cca = _Client("private")
+    bot.monitor_publisher = _Publisher()
+    bot._close_live_event_pipeline = lambda **_kwargs: False
+
+    with caplog.at_level(logging.WARNING):
+        await bot.cleanup_for_restart()
+
+    assert closed_clients == ["public", "private"]
+    assert bot.monitor_publisher is None
+    assert "monitor publisher close skipped" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_shutdown_bot_redacts_close_failure_text(capsys):
     class _FailingBot:
         def stop_data_maintainers(self):

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -12940,6 +12940,44 @@ def test_bounded_traceback_detail_retains_exception_chain_without_values_or_loca
     assert "raise_cause" in str(detail)
 
 
+@pytest.mark.asyncio
+async def test_hostile_traceback_projection_does_not_replace_execution_failure(
+    monkeypatch,
+):
+    class HostileError(RuntimeError):
+        def __getattribute__(self, name):
+            if name in {"__traceback__", "__cause__", "__context__"}:
+                raise KeyboardInterrupt("projection trap")
+            return super().__getattribute__(name)
+
+    bot = Passivbot.__new__(Passivbot)
+    bot.stop_signal_received = False
+    bot._health_errors = 0
+    bot.error_counts = []
+    bot._maybe_recover_exchange_time_sync = AsyncMock(return_value=False)
+    monitor_events = []
+    bot._monitor_record_event = lambda *args, **kwargs: monitor_events.append(
+        (args, kwargs)
+    )
+    bot.restart_bot = AsyncMock()
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+
+    assert await bot._handle_execution_loop_failure(
+        HostileError("token=SECRET"), allow_time_sync_recovery=False
+    ) is True
+
+    assert bot._health_errors == 1
+    assert len(bot.error_counts) == 1
+    assert [event[0][0] for event in monitor_events] == [
+        "error.bot",
+        "error.bot.detail",
+    ]
+    detail = monitor_events[1][0][2]["traceback"]
+    assert detail["unavailable_reason"] == "projection_failed"
+    assert detail["truncated"] is True
+    assert "SECRET" not in str(monitor_events)
+
+
 def test_execution_loop_error_fields_are_bounded_and_classify_unknown_endpoint():
     bot = Passivbot.__new__(Passivbot)
 

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -12265,12 +12265,17 @@ async def test_run_execution_loop_records_nonshutdown_cancelled_error(
                 "status": "-",
                 "code": "-",
                 "endpoint": "unknown",
+                "stage": "unknown",
+                "origin": monitor_events[0][0][2]["origin"],
                 "action": "record_error_restart_backoff",
                 "cycle": "abandoned",
             }),
             {},
         )
     ]
+    assert monitor_events[0][0][2]["origin"].startswith(
+        "test_passivbot_balance_split.py:fake_refresh_authoritative_state:"
+    )
     bot.restart_bot_on_too_many_errors.assert_awaited_once()
     bot.execute_to_exchange.assert_not_awaited()
     messages = [record.message for record in caplog.records]
@@ -12728,12 +12733,17 @@ async def test_run_execution_loop_error_log_includes_type_status_and_action(capl
                 "status": "500",
                 "code": "500000",
                 "endpoint": "account-overview",
+                "stage": "unknown",
+                "origin": monitor_events[0][0][2]["origin"],
                 "action": "record_error_restart_backoff",
                 "cycle": "abandoned",
             }),
             {},
         )
     ]
+    assert monitor_events[0][0][2]["origin"].startswith(
+        "test_passivbot_balance_split.py:fake_refresh_authoritative_state:"
+    )
     messages = [record.message for record in caplog.records]
     assert not any("error with run_execution_loop" in message for message in messages)
     assert any(
@@ -12825,6 +12835,8 @@ def test_execution_loop_error_fields_are_bounded_and_classify_unknown_endpoint()
         "status": "429",
         "code": "10006",
         "endpoint": "unknown",
+        "stage": "unknown",
+        "origin": "unknown",
     }
     assert "SECRET" not in str(fields)
     assert "SIG" not in str(fields)
@@ -12841,6 +12853,25 @@ def test_execution_loop_error_fields_reject_credential_shaped_endpoint():
 
     assert fields["endpoint"] == "unknown"
     assert secret not in str(fields)
+
+
+def test_execution_loop_error_fields_include_bounded_stage_and_origin():
+    bot = Passivbot.__new__(Passivbot)
+    bot._log_silence_watchdog_stage = "refresh_authoritative_state"
+
+    def fail_in_test():
+        raise RuntimeError("api_key=must-not-be-projected")
+
+    try:
+        fail_in_test()
+    except RuntimeError as exc:
+        fields = bot._execution_loop_error_fields(exc)
+
+    assert fields["stage"] == "refresh_authoritative_state"
+    assert fields["origin"].startswith(
+        "test_passivbot_balance_split.py:fail_in_test:"
+    )
+    assert "must-not-be-projected" not in str(fields)
 
 
 def test_execution_loop_error_fields_contain_hostile_exception_metadata():
@@ -12870,6 +12901,8 @@ def test_execution_loop_error_fields_contain_hostile_exception_metadata():
         "status": "-",
         "code": "-",
         "endpoint": "unknown",
+        "stage": "unknown",
+        "origin": "unknown",
     }
 
 

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -12349,25 +12349,19 @@ async def test_run_execution_loop_records_nonshutdown_cancelled_error(
     assert result is None
     assert bot._health_errors == 1
     bot._monitor_record_error.assert_not_called()
-    assert monitor_events == [
-        (
-            ("error.bot", ("error", "bot"), {
-                "source": "run_execution_loop",
-                "error_type": "CancelledError",
-                "status": "-",
-                "code": "-",
-                "endpoint": "unknown",
-                "stage": "unknown",
-                "origin": monitor_events[0][0][2]["origin"],
-                "action": "record_error_restart_backoff",
-                "cycle": "abandoned",
-            }),
-            {},
-        )
+    assert [event[0][0] for event in monitor_events] == [
+        "error.bot",
+        "error.bot.detail",
     ]
-    assert monitor_events[0][0][2]["origin"].startswith(
+    summary = monitor_events[0][0][2]
+    detail = monitor_events[1][0][2]
+    assert summary["error_type"] == "CancelledError"
+    assert summary["incident_id"] == detail["incident_id"]
+    assert summary["origin"].startswith(
         "test_passivbot_balance_split.py:fake_refresh_authoritative_state:"
     )
+    assert detail["traceback"]["frame_count"] >= 1
+    assert detail["traceback"]["includes_exception_text"] is False
     bot.restart_bot_on_too_many_errors.assert_awaited_once()
     bot.execute_to_exchange.assert_not_awaited()
     messages = [record.message for record in caplog.records]
@@ -12817,25 +12811,22 @@ async def test_run_execution_loop_error_log_includes_type_status_and_action(capl
     assert bot._health_errors == 1
     bot.restart_bot_on_too_many_errors.assert_awaited_once()
     bot._monitor_record_error.assert_not_called()
-    assert monitor_events == [
-        (
-            ("error.bot", ("error", "bot"), {
-                "source": "run_execution_loop",
-                "error_type": "RuntimeError",
-                "status": "500",
-                "code": "500000",
-                "endpoint": "account-overview",
-                "stage": "unknown",
-                "origin": monitor_events[0][0][2]["origin"],
-                "action": "record_error_restart_backoff",
-                "cycle": "abandoned",
-            }),
-            {},
-        )
+    assert [event[0][0] for event in monitor_events] == [
+        "error.bot",
+        "error.bot.detail",
     ]
-    assert monitor_events[0][0][2]["origin"].startswith(
+    summary = monitor_events[0][0][2]
+    detail = monitor_events[1][0][2]
+    assert summary["status"] == "500"
+    assert summary["code"] == "500000"
+    assert summary["endpoint"] == "account-overview"
+    assert summary["incident_id"] == detail["incident_id"]
+    assert summary["origin"].startswith(
         "test_passivbot_balance_split.py:fake_refresh_authoritative_state:"
     )
+    assert detail["traceback"]["frame_count"] >= 1
+    assert raw_error not in str(detail)
+    assert "SECRET" not in str(detail)
     messages = [record.message for record in caplog.records]
     assert not any("error with run_execution_loop" in message for message in messages)
     assert any(
@@ -12857,18 +12848,15 @@ async def test_run_execution_loop_error_log_includes_type_status_and_action(capl
     assert "error" not in degraded_event["data"]
     assert raw_error not in str(degraded_event)
     assert "SECRET" not in str(degraded_event)
-    debug_stack_messages = [
-        record.message
+    assert not [
+        record
         for record in caplog.records
         if record.levelno == logging.DEBUG and "stack frames" in record.message
     ]
-    assert len(debug_stack_messages) == 1
-    assert raw_error not in debug_stack_messages[0]
-    assert "FakeExchangeError" not in debug_stack_messages[0]
 
 
 @pytest.mark.asyncio
-async def test_execution_loop_error_normal_info_is_bounded_and_skips_nondebug_frames(
+async def test_execution_loop_error_normal_info_persists_bounded_traceback_detail(
     caplog, monkeypatch
 ):
     bot = Passivbot.__new__(Passivbot)
@@ -12876,15 +12864,16 @@ async def test_execution_loop_error_normal_info_is_bounded_and_skips_nondebug_fr
     bot._health_errors = 0
     bot.error_counts = []
     bot._maybe_recover_exchange_time_sync = AsyncMock(return_value=False)
-    bot._monitor_record_event = MagicMock()
+    monitor_events = []
+    bot._monitor_record_event = lambda *args, **kwargs: monitor_events.append(
+        (args, kwargs)
+    )
     bot.restart_bot = AsyncMock()
 
     async def fake_sleep(_seconds):
         return None
 
     monkeypatch.setattr(asyncio, "sleep", fake_sleep)
-    format_tb = MagicMock()
-    monkeypatch.setattr(passivbot_module.traceback, "format_tb", format_tb)
     raw_error = "raw-message https://example.invalid/private?api_key=SECRET"
 
     try:
@@ -12898,13 +12887,57 @@ async def test_execution_loop_error_normal_info_is_bounded_and_skips_nondebug_fr
     assert bot._health_errors == 1
     assert len(bot.error_counts) == 1
     bot.restart_bot.assert_not_awaited()
-    format_tb.assert_not_called()
+    assert [event[0][0] for event in monitor_events] == [
+        "error.bot",
+        "error.bot.detail",
+    ]
+    summary = monitor_events[0][0][2]
+    detail = monitor_events[1][0][2]
+    assert summary["incident_id"] == detail["incident_id"]
+    assert detail["traceback"]["frame_count"] >= 1
+    assert detail["traceback"]["includes_exception_text"] is False
+    assert detail["traceback"]["includes_locals"] is False
+    assert raw_error not in str(detail)
+    assert "SECRET" not in str(detail)
     normal_messages = [
         record.message for record in caplog.records if record.levelno >= logging.INFO
     ]
     assert "[health] error_budget count=1 limit=10 window=1h action=continue" in normal_messages
     assert all(raw_error not in message for message in normal_messages)
     assert all("SECRET" not in message for message in normal_messages)
+
+
+def test_bounded_traceback_detail_retains_exception_chain_without_values_or_locals():
+    secret = "api_key=TOP-SECRET"
+
+    def raise_cause():
+        raise ValueError(secret)
+
+    def raise_outer():
+        try:
+            raise_cause()
+        except ValueError as cause:
+            raise RuntimeError(secret) from cause
+
+    try:
+        raise_outer()
+    except RuntimeError as exc:
+        detail = passivbot_module._bounded_traceback_detail(exc)
+
+    assert [item["relation"] for item in detail["exceptions"]] == [
+        "raised",
+        "cause",
+    ]
+    assert [item["error_type"] for item in detail["exceptions"]] == [
+        "RuntimeError",
+        "ValueError",
+    ]
+    assert detail["frame_count"] >= 3
+    assert detail["includes_exception_text"] is False
+    assert detail["includes_locals"] is False
+    assert secret not in str(detail)
+    assert "raise_outer" in str(detail)
+    assert "raise_cause" in str(detail)
 
 
 def test_execution_loop_error_fields_are_bounded_and_classify_unknown_endpoint():


### PR DESCRIPTION
## Summary

- retire dynamic CCXT Pro OHLCV subscriptions through their owning watcher tasks, using bulk unsubscribe where available and bounded cancellation only as fallback
- make internal restarts await maintainer teardown and close exchange, event-pipeline, and monitor resources before constructing a replacement bot; add bounded lifecycle stage/origin diagnostics without exchange response text
- distinguish fetchable 1m gaps from verified no-trade continuity and retry-deferred gaps so sparse markets do not repeatedly consume candidate candle REST budget
- document that short, dense post-listing Hyperliquid TradFi history remains unavailable until genuine 1h warmup exists; pre-listing buckets are never fabricated

Raw candle coverage remains conservative: verified/deferred gaps can suppress redundant background REST work but never become tradable coverage.

## Validation

- `python -m pytest -q tests/test_passivbot_monitor.py tests/test_hsl_coin_mode.py tests/test_maintainer_logging.py tests/test_forager_ws_candles.py tests/test_live_candle_budget.py tests/test_candlestick_manager.py tests/test_passivbot_balance_split.py`
- `python -m compileall -q src tests`
- `git diff --check origin/master...HEAD`
- live smoke on WEEX, Bybit, Binance, KuCoin, and Hyperliquid TradFi with their existing configurations:
  - repeated dynamic forager rotations produced no orphaned-future or unsubscribe errors
  - graceful high-fanout WEEX teardown completed cleanly and subsequent runtime resource use remained bounded
  - KuCoin made one due sparse-gap proof attempt after startup, then crossed the next ten-minute refresh boundary without repeating the prior wall-time/lock backlog
  - all observed bot error budgets remained `0/10`; Hyperliquid continued safely rejecting candidates whose genuine post-listing 1h history is too short
- no probe intended to create a fill was run

The repository-wide suite was not used as the author check because the shared development environment currently has a Rust-extension source-fingerprint mismatch from parallel work. This PR changes no Rust; the complete directly affected Python suite above passes on the current head.