### PR TITLE
Unify fill coverage retry ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Prevent unproven fill-history coverage from consuming the generic live restart budget; one execution-loop backoff now owns coverage retries while planning remains fail-closed.
+
 - Live fill-history coverage now has one canonical verdict owned by
   `FillEventsManager`. Refresh, staged readiness, HSL replay, and realized-PnL
   consumers no longer duplicate cache/gap interpretation. Metadata that claims

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -158,6 +158,11 @@ Exchange fetch methods propagate endpoint failures. The manager or caller may re
 quarantine, rebuild, or defer according to `../error_contract.md`; it must not attach neutral PnL
 merely because an auxiliary endpoint failed.
 
+Unproven required coverage is a controlled live-planning deferral. The execution loop owns its
+bounded retry cadence, and persistent coverage gaps do not consume the generic process-restart
+budget. Manager-owned known-gap state remains evidence about coverage, not a second orchestration
+timer.
+
 ## Validation
 
 1. Deduplication correctness.

--- a/src/live/state_refresh.py
+++ b/src/live/state_refresh.py
@@ -109,7 +109,12 @@ async def refresh_authoritative_state_staged(bot) -> bool:
         bot._last_authoritative_degraded_pnl_count = int(
             snapshot.get("degraded_pnl_count", 0) or 0
         )
-        if bot._live_risk_uses_authoritative_pnl():
+        fill_refresh_block_reason = getattr(
+            bot, "_last_fill_refresh_block_reason", None
+        )
+        if fill_refresh_block_reason == "fill_history_coverage":
+            bot._last_authoritative_block_reason = fill_refresh_block_reason
+        elif bot._live_risk_uses_authoritative_pnl():
             if bot._last_authoritative_degraded_pnl_count:
                 bot._last_authoritative_block_reason = "degraded_pnl"
             elif bot._last_authoritative_pending_pnl_count:

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -239,6 +239,8 @@ FILL_EVENT_FETCH_OVERLAP_MAX_MS = 86_400_000  # 24 hours
 FILL_EVENT_FETCH_LIMIT_DEFAULT = 20
 PENDING_PNL_AUTHORITATIVE_RETRY_BASE_SECONDS = 1.0
 PENDING_PNL_AUTHORITATIVE_RETRY_MAX_SECONDS = 60.0
+FILL_COVERAGE_AUTHORITATIVE_RETRY_BASE_SECONDS = 30.0
+FILL_COVERAGE_AUTHORITATIVE_RETRY_MAX_SECONDS = 300.0
 
 
 # Match "...0xABCD..." anywhere (case-insensitive)
@@ -1841,76 +1843,6 @@ class Passivbot:
             end_ms=now_ms,
         )
         return bool(status.get("ready", False))
-
-    def _fill_coverage_retry_delay_seconds(self, retry_count: int) -> float:
-        try:
-            base_delay = float(
-                get_optional_live_value(
-                    self.config,
-                    "fills_coverage_retry_delay_seconds",
-                    30.0,
-                )
-            )
-        except Exception:
-            base_delay = 30.0
-        try:
-            max_delay = float(
-                get_optional_live_value(
-                    self.config,
-                    "fills_coverage_retry_max_delay_seconds",
-                    300.0,
-                )
-            )
-        except Exception:
-            max_delay = 300.0
-        base_delay = max(0.0, base_delay)
-        max_delay = max(base_delay, max_delay)
-        retry_count = max(1, int(retry_count or 1))
-        return min(max_delay, base_delay * (2 ** min(retry_count - 1, 6)))
-
-    @staticmethod
-    def _fill_coverage_retry_key(status: dict[str, object]) -> tuple:
-        return (
-            str(status.get("reason", "unknown")),
-            str(status.get("history_scope", "unknown")),
-            int(status.get("covered_start_ms", 0) or 0),
-            int(status.get("oldest_event_ts", 0) or 0),
-            int(status.get("gap_start_ts", 0) or 0),
-            int(status.get("gap_end_ts", 0) or 0),
-            str(status.get("gap_reason", "")),
-        )
-
-    def _fill_coverage_retry_deferred(self, status: dict[str, object], now_ms: int) -> bool:
-        state = getattr(self, "_fill_coverage_retry_state", None)
-        if not isinstance(state, dict):
-            return False
-        if state.get("key") != self._fill_coverage_retry_key(status):
-            return False
-        next_retry_ms = int(state.get("next_retry_ms", 0) or 0)
-        return next_retry_ms > int(now_ms)
-
-    def _record_fill_coverage_retry_defer(
-        self, status: dict[str, object], *, now_ms: Optional[int] = None
-    ) -> None:
-        now = utc_ms() if now_ms is None else int(now_ms)
-        key = self._fill_coverage_retry_key(status)
-        state = getattr(self, "_fill_coverage_retry_state", None)
-        previous_count = (
-            int(state.get("retry_count", 0) or 0)
-            if isinstance(state, dict) and state.get("key") == key
-            else 0
-        )
-        retry_count = previous_count + 1
-        delay_s = self._fill_coverage_retry_delay_seconds(retry_count)
-        self._fill_coverage_retry_state = {
-            "key": key,
-            "retry_count": retry_count,
-            "next_retry_ms": now + int(delay_s * 1000.0),
-        }
-
-    def _clear_fill_coverage_retry_defer(self) -> None:
-        if hasattr(self, "_fill_coverage_retry_state"):
-            self._fill_coverage_retry_state = {}
 
     def _get_effective_pnl_events(self) -> list:
         if self._pnls_manager is None:
@@ -5978,7 +5910,7 @@ class Passivbot:
         self._execution_loop_task_is_inline = True
         self._execution_loop_stopped = execution_loop_stopped
         failed_update_pos_oos_pnls_ohlcvs_count = 0
-        unsafe_pnl_authoritative_retry_count = 0
+        authoritative_fill_retry_count = 0
         max_n_fails = 10
         if self._equity_hard_stop_enabled():
             if self._equity_hard_stop_signal_mode() == "coin":
@@ -6035,32 +5967,39 @@ class Passivbot:
                             data={"timings_ms": dict(loop_timings_ms)},
                         )
                         break
-                    if getattr(self, "_last_authoritative_block_reason", None) in {
+                    authoritative_block_reason = getattr(
+                        self, "_last_authoritative_block_reason", None
+                    )
+                    if authoritative_block_reason in {
                         "pending_pnl",
                         "degraded_pnl",
+                        "fill_history_coverage",
                     }:
-                        unsafe_pnl_authoritative_retry_count += 1
+                        authoritative_fill_retry_count += 1
                         failed_update_pos_oos_pnls_ohlcvs_count = 0
                         retry_delay_seconds = (
-                            self._pending_pnl_authoritative_retry_delay_seconds(
-                                unsafe_pnl_authoritative_retry_count
+                            self._authoritative_fill_retry_delay_seconds(
+                                authoritative_fill_retry_count,
+                                block_reason=authoritative_block_reason,
                             )
                         )
-                        self._maybe_log_pnl_authoritative_block(
+                        self._maybe_log_authoritative_fill_block(
                             retry_delay_seconds=retry_delay_seconds
+                        )
+                        coverage_blocked = (
+                            authoritative_block_reason == "fill_history_coverage"
                         )
                         self._emit_live_cycle_degraded(
                             cycle_id=cycle_id,
                             reason_code=(
-                                "degraded_pnl_authoritative_refresh"
-                                if getattr(
-                                    self, "_last_authoritative_block_reason", None
-                                )
-                                == "degraded_pnl"
+                                "fill_history_coverage_unavailable"
+                                if coverage_blocked
+                                else "degraded_pnl_authoritative_refresh"
+                                if authoritative_block_reason == "degraded_pnl"
                                 else "pending_pnl_authoritative_refresh"
                             ),
                             data={
-                                "retry_count": unsafe_pnl_authoritative_retry_count,
+                                "retry_count": authoritative_fill_retry_count,
                                 "retry_delay_seconds": retry_delay_seconds,
                                 "pending_pnl_count": int(
                                     getattr(
@@ -6084,16 +6023,15 @@ class Passivbot:
                         await self._sleep_unless_shutdown(
                             retry_delay_seconds,
                             stage=(
-                                "degraded_pnl_authoritative_retry"
-                                if getattr(
-                                    self, "_last_authoritative_block_reason", None
-                                )
-                                == "degraded_pnl"
+                                "fill_history_coverage_retry"
+                                if coverage_blocked
+                                else "degraded_pnl_authoritative_retry"
+                                if authoritative_block_reason == "degraded_pnl"
                                 else "pending_pnl_authoritative_retry"
                             ),
                         )
                     else:
-                        unsafe_pnl_authoritative_retry_count = 0
+                        authoritative_fill_retry_count = 0
                         failed_update_pos_oos_pnls_ohlcvs_count += 1
                         self._emit_live_cycle_degraded(
                             cycle_id=cycle_id,
@@ -6112,7 +6050,7 @@ class Passivbot:
                         if failed_update_pos_oos_pnls_ohlcvs_count > max_n_fails:
                             await self.restart_bot_on_too_many_errors()
                     continue
-                unsafe_pnl_authoritative_retry_count = 0
+                authoritative_fill_retry_count = 0
                 failed_update_pos_oos_pnls_ohlcvs_count = 0
                 if self.stop_signal_received:
                     self._emit_live_cycle_degraded(
@@ -6478,12 +6416,20 @@ class Passivbot:
         return max(1, int(getattr(self, "max_n_concurrent_ohlcvs_1m_updates", 4) or 4))
 
     @staticmethod
-    def _pending_pnl_authoritative_retry_delay_seconds(retry_count: int) -> float:
+    def _authoritative_fill_retry_delay_seconds(
+        retry_count: int, *, block_reason: str
+    ) -> float:
         retry_index = max(0, int(retry_count) - 1)
-        delay = PENDING_PNL_AUTHORITATIVE_RETRY_BASE_SECONDS * (2**retry_index)
-        return float(min(PENDING_PNL_AUTHORITATIVE_RETRY_MAX_SECONDS, delay))
+        if block_reason == "fill_history_coverage":
+            base_seconds = FILL_COVERAGE_AUTHORITATIVE_RETRY_BASE_SECONDS
+            max_seconds = FILL_COVERAGE_AUTHORITATIVE_RETRY_MAX_SECONDS
+        else:
+            base_seconds = PENDING_PNL_AUTHORITATIVE_RETRY_BASE_SECONDS
+            max_seconds = PENDING_PNL_AUTHORITATIVE_RETRY_MAX_SECONDS
+        delay = base_seconds * (2**retry_index)
+        return float(min(max_seconds, delay))
 
-    def _maybe_log_pnl_authoritative_block(
+    def _maybe_log_authoritative_fill_block(
         self, *, retry_delay_seconds: float
     ) -> None:
         pending_count = int(getattr(self, "_last_authoritative_pending_pnl_count", 0) or 0)
@@ -6491,17 +6437,24 @@ class Passivbot:
             getattr(self, "_last_authoritative_degraded_pnl_count", 0) or 0
         )
         now = utc_ms()
-        last_log = int(getattr(self, "_pending_pnl_authoritative_block_log_ms", 0) or 0)
+        last_log = int(getattr(self, "_authoritative_fill_block_log_ms", 0) or 0)
         if now - last_log < 60_000:
             return
-        self._pending_pnl_authoritative_block_log_ms = now
-        logging.info(
-            "[fills] authoritative refresh waiting for realized PnL enrichment | "
-            "pending_pnl=%d degraded_pnl=%d action=retry_without_restart retry_in=%.1fs",
-            pending_count,
-            degraded_count,
-            float(retry_delay_seconds),
-        )
+        self._authoritative_fill_block_log_ms = now
+        if getattr(self, "_last_authoritative_block_reason", None) == "fill_history_coverage":
+            logging.info(
+                "[fills] authoritative refresh waiting for fill-history coverage | "
+                "action=retry_without_restart retry_in=%.1fs",
+                float(retry_delay_seconds),
+            )
+        else:
+            logging.info(
+                "[fills] authoritative refresh waiting for realized PnL enrichment | "
+                "pending_pnl=%d degraded_pnl=%d action=retry_without_restart retry_in=%.1fs",
+                pending_count,
+                degraded_count,
+                float(retry_delay_seconds),
+            )
 
     def _install_asyncio_runtime_exception_handler(self) -> None:
         """Install a narrow asyncio callback exception classifier for noisy WS libraries."""
@@ -12229,6 +12182,7 @@ class Passivbot:
         """Fetch latest fills while holding the fill-cache single-flight lock."""
         if self.stop_signal_received:
             return False
+        self._last_fill_refresh_block_reason = None
 
         fill_refresh_attempt_generation = (
             max(
@@ -12377,35 +12331,6 @@ class Passivbot:
                     )
                 finally:
                     flush_enriched_events()
-            if not coverage_ready:
-                now_ms = utc_ms()
-                if self._fill_coverage_retry_deferred(coverage_status, now_ms):
-                    state = getattr(self, "_fill_coverage_retry_state", {}) or {}
-                    next_retry_ms = int(state.get("next_retry_ms", 0) or 0)
-                    refresh_mode = "coverage_retry_backoff"
-                    next_retry_in_ms = max(0, next_retry_ms - now_ms)
-                    logging.debug(
-                        "[fills] fill-history lookback proof deferred by retry backoff | "
-                        "reason=%s scope=%s next_retry_in_ms=%d",
-                        str(coverage_status.get("reason", "unknown")),
-                        history_scope,
-                        next_retry_in_ms,
-                    )
-                    self._emit_fills_refresh_summary_event(
-                        source=source,
-                        refresh_mode=refresh_mode,
-                        status="deferred",
-                        reason_code="fill_history_coverage_retry_backoff",
-                        elapsed_ms=int(max(0, utc_ms() - refresh_started_ms)),
-                        lookback=lookback_config_value,
-                        history_scope=history_scope,
-                        event_count_before=before_events_count,
-                        coverage_before=coverage_status,
-                        next_retry_in_ms=next_retry_in_ms,
-                        retry_count=int(state.get("retry_count", 0) or 0),
-                        level="debug",
-                    )
-                    return False
             if needs_full_refresh:
                 cache_key = "_fills_full_refresh_logged"
                 if not getattr(self, cache_key, False):
@@ -12574,7 +12499,6 @@ class Passivbot:
                 pnls_safe or not authoritative_pnl_required
             )
             if fills_ready:
-                self._clear_fill_coverage_retry_defer()
                 self._record_authoritative_surface(
                     "fills", self._fill_events_signature(all_events)
                 )
@@ -12582,16 +12506,13 @@ class Passivbot:
                     fill_refresh_attempt_generation
                 )
             elif not coverage_ready_after:
-                self._record_fill_coverage_retry_defer(post_refresh_coverage_status)
-                state = getattr(self, "_fill_coverage_retry_state", {}) or {}
-                next_retry_ms = int(state.get("next_retry_ms", 0) or 0)
+                self._last_fill_refresh_block_reason = "fill_history_coverage"
                 logging.warning(
                     "[fills] fill-history lookback still unproven after refresh; "
-                    "deferring authoritative fills | reason=%s scope=%s covered_start=%s next_retry_in_ms=%d",
+                    "deferring authoritative fills | reason=%s scope=%s covered_start=%s",
                     str(post_refresh_coverage_status.get("reason", "unknown")),
                     str(post_refresh_coverage_status.get("history_scope", "unknown")),
                     int(post_refresh_coverage_status.get("covered_start_ms", 0) or 0),
-                    max(0, next_retry_ms - utc_ms()),
                 )
             elapsed_ms = int(max(0, utc_ms() - refresh_started_ms))
             blocking_or_confirmation_refresh = (

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -6069,14 +6069,10 @@ async def test_update_pnls_window_lookback_bootstraps_when_coverage_unproven():
 
 
 @pytest.mark.asyncio
-async def test_update_pnls_window_lookback_stays_blocked_when_known_gap_persists(
-    monkeypatch,
-):
+async def test_update_pnls_window_lookback_stays_blocked_when_known_gap_persists():
     bot = Passivbot.__new__(Passivbot)
     bot._live_risk_uses_authoritative_pnl = lambda: True
     now_ms = 1_800_000_000_000
-    wall_ms = {"value": now_ms}
-    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: wall_ms["value"])
     lookback_days = 30.0
     start_ms = now_ms - int(lookback_days * 86_400_000)
     cached_events = [
@@ -6155,11 +6151,6 @@ async def test_update_pnls_window_lookback_stays_blocked_when_known_gap_persists
         }
     }
     bot._authoritative_pending_confirmations = {}
-    bot._fill_coverage_retry_state = {
-        "key": ("stale",),
-        "retry_count": 3,
-        "next_retry_ms": now_ms + 60_000,
-    }
     bot._trailing_fill_fetch_generation = 7
     bot._pnls_manager = _with_fill_coverage_api(_Manager(cached_events))
     bot.init_pnls = AsyncMock()
@@ -6178,19 +6169,11 @@ async def test_update_pnls_window_lookback_stays_blocked_when_known_gap_persists
     bot._pnls_manager.refresh.assert_not_awaited()
     bot._pnls_manager.refresh_latest.assert_not_awaited()
     assert bot._last_fill_refresh_pending_pnl_count == 0
+    assert bot._last_fill_refresh_block_reason == "fill_history_coverage"
     ledger = getattr(bot, "freshness_ledger", None)
     assert ledger is None or ledger.surface_signature("fills") is None
     assert bot._trailing_fill_fetch_generation == 7
-    retry_state = getattr(bot, "_fill_coverage_retry_state", {})
-    assert retry_state["next_retry_ms"] > wall_ms["value"]
 
-    result = await bot.update_pnls(source="staged_blocking")
-
-    assert result is False
-    bot._pnls_manager.refresh_for_lookback.assert_awaited_once_with(start_ms=start_ms)
-    assert bot._trailing_fill_fetch_generation == 7
-
-    wall_ms["value"] = int(retry_state["next_retry_ms"]) + 1
     result = await bot.update_pnls(source="staged_blocking")
 
     assert result is False
@@ -6300,7 +6283,7 @@ async def test_update_pnls_window_lookback_records_fills_after_known_gap_repair(
     bot._pnls_manager.refresh.assert_not_awaited()
     bot._pnls_manager.refresh_latest.assert_not_awaited()
     assert bot.freshness_ledger.surface_signature("fills") is not None
-    assert getattr(bot, "_fill_coverage_retry_state", {}) == {}
+    assert bot._last_fill_refresh_block_reason is None
 
 
 @pytest.mark.asyncio
@@ -7904,6 +7887,36 @@ async def test_refresh_authoritative_state_staged_does_not_blame_nonblocking_pnl
     assert bot._last_authoritative_block_reason is None
     assert bot._last_authoritative_pending_pnl_count == 1
     assert bot._last_authoritative_degraded_pnl_count == 1
+
+
+@pytest.mark.asyncio
+async def test_refresh_authoritative_state_staged_classifies_unproven_fill_coverage():
+    bot = Passivbot.__new__(Passivbot)
+    bot._live_risk_uses_authoritative_pnl = lambda: False
+    bot._last_fill_refresh_block_reason = "fill_history_coverage"
+    bot._authoritative_staged_refresh_plan = lambda: {
+        "balance",
+        "positions",
+        "open_orders",
+        "fills",
+    }
+    bot._fetch_authoritative_state_staged_snapshot = AsyncMock(
+        return_value={
+            "balance": 100.0,
+            "positions": [{"symbol": "BTC/USDT:USDT"}],
+            "open_orders": [],
+            "pnls_ok": False,
+            "pending_pnl_count": 0,
+            "degraded_pnl_count": 0,
+        }
+    )
+
+    result = await bot._refresh_authoritative_state_staged()
+
+    assert result is False
+    assert bot._last_authoritative_block_reason == "fill_history_coverage"
+    assert bot._last_authoritative_pending_pnl_count == 0
+    assert bot._last_authoritative_degraded_pnl_count == 0
 
 
 @pytest.mark.asyncio
@@ -12093,6 +12106,79 @@ async def test_run_execution_loop_waits_on_degraded_pnl_without_restart():
     ]
     assert len(degraded_events) == 3
     assert all(event["data"]["degraded_pnl_count"] == 1 for event in degraded_events)
+
+
+@pytest.mark.asyncio
+async def test_run_execution_loop_waits_on_fill_coverage_without_restart():
+    bot = Passivbot.__new__(Passivbot)
+    cycle = {"n": 0}
+    sleeps = []
+
+    async def fake_sleep_unless_shutdown(seconds, *, stage):
+        sleeps.append((seconds, stage))
+
+    bot.stop_signal_received = False
+    bot.execution_scheduled = False
+    bot.state_change_detected_by_symbol = set()
+    bot.debug_mode = True
+    bot._equity_hard_stop_enabled = lambda *args, **kwargs: False
+    bot._set_log_silence_watchdog_context = lambda *args, **kwargs: None
+    bot._maybe_log_health_summary = lambda: None
+    bot._maybe_log_unstuck_status = lambda: None
+    bot._monitor_flush_snapshot = AsyncMock()
+    bot.restart_bot_on_too_many_errors = AsyncMock()
+    bot._sleep_unless_shutdown = fake_sleep_unless_shutdown
+    bot._emit_live_cycle_degraded = MagicMock()
+    bot.live_value = lambda key: 0.0 if key == "execution_delay_seconds" else False
+
+    async def fake_refresh_authoritative_state():
+        cycle["n"] += 1
+        if cycle["n"] <= 12:
+            bot._last_authoritative_block_reason = "fill_history_coverage"
+            bot._last_authoritative_pending_pnl_count = 0
+            bot._last_authoritative_degraded_pnl_count = 0
+            return False
+        bot._begin_authoritative_refresh_epoch()
+        for surface, sig in (
+            ("balance", ("b", 1)),
+            ("positions", ("p", 1)),
+            ("open_orders", ("o", 1)),
+            ("fills", ("f", 1)),
+            ("completed_candles", tuple()),
+        ):
+            bot._record_authoritative_surface(surface, sig)
+        return True
+
+    bot.refresh_authoritative_state = fake_refresh_authoritative_state
+    bot.prepare_planning_universe = AsyncMock()
+    bot.refresh_market_state_if_needed = AsyncMock(return_value=True)
+    bot.execute_to_exchange = AsyncMock(return_value={"executed_cycle": 13})
+
+    result = await bot.run_execution_loop()
+
+    assert result == {"executed_cycle": 13}
+    bot.restart_bot_on_too_many_errors.assert_not_awaited()
+    assert [seconds for seconds, _stage in sleeps] == [
+        30.0,
+        60.0,
+        120.0,
+        240.0,
+        300.0,
+        300.0,
+        300.0,
+        300.0,
+        300.0,
+        300.0,
+        300.0,
+        300.0,
+    ]
+    assert {stage for _seconds, stage in sleeps} == {"fill_history_coverage_retry"}
+    coverage_events = [
+        call.kwargs
+        for call in bot._emit_live_cycle_degraded.call_args_list
+        if call.kwargs["reason_code"] == "fill_history_coverage_unavailable"
+    ]
+    assert len(coverage_events) == 12
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- classify unproven fill-history coverage as a controlled authoritative-state block
- move coverage retry cadence to the execution loop and keep it out of generic restart accounting
- remove Passivbot's duplicate coverage timer, status key, and undocumented retry config knobs
- retain `FillEventsManager` as the canonical owner of coverage and known-gap evidence

## Why

The previous inner coverage backoff returned `False`, but staged refresh did not preserve why. The execution loop therefore treated the deliberate wait as a generic authoritative-refresh failure and could restart the bot after eleven deferred cycles. It also left retry policy split between the manager, Passivbot, and the execution loop.

This change keeps planning fail-closed while making the execution loop the single retry-cadence owner. Coverage retries use the existing 30-to-300-second bounds and never consume restart budget. Pending/degraded PnL retries retain their 1-to-60-second behavior.

## Validation

- rebuilt and fingerprint-verified the current Rust extension
- `PYTHONPATH=src .../python -m pytest -q tests/test_passivbot_balance_split.py tests/test_fill_events_manager.py tests/test_realized_loss_gate.py tests/test_unstucking_safeguards.py tests/test_ai_docs.py`
- `PYTHONPATH=src .../python src/tools/check_ai_docs.py`
- `PYTHONPATH=src .../python src/tools/generate_live_event_registry.py --check`
- `git diff --check`
