### PR TITLE
Scope fill history to enabled consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Scope live fill-history readiness to enabled consumers: PnL risk keeps its configured lookback, entry cooldown proves only its structural-fill horizon, and bots without historical consumers use bounded recent ingestion.
+
 - Live fill-history coverage now has one canonical verdict owned by
   `FillEventsManager`. Refresh, staged readiness, HSL replay, and realized-PnL
   consumers no longer duplicate cache/gap interpretation. Metadata that claims

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -75,6 +75,13 @@
     contradictory cache evidence: they are unavailable rather than proof of
     coverage. A window with no fills remains valid when zero oldest/newest metadata
     and `covered_start_ms` prove that empty result.
+12. Live coverage requirements follow the enabled consumer. Realized-PnL risk
+    features require the configured PnL lookback and authoritative PnL quality.
+    Entry cooldown without a PnL consumer requires structural fill coverage only
+    across its maximum configured cooldown horizon. Trailing reconstruction retains
+    its symbol/position-side confirmation and bounded recovery. With no historical
+    consumer enabled, routine ingestion starts from a bounded recent fetch rather
+    than proving an unrelated PnL window.
 
 ## Runtime Provenance
 

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -1833,14 +1833,47 @@ class Passivbot:
                 field_name="live.pnls_max_lookback_days",
             )
             now_ms = self.get_exchange_time()
-            start_ms = lookback.fill_cache_age_limit_ms(now_ms)
+            pnl_start_ms = lookback.fill_cache_age_limit_ms(now_ms)
+            coverage_required, start_ms = self._required_fill_history_start_ms(
+                now_ms, pnl_start_ms=pnl_start_ms
+            )
         except (AttributeError, KeyError, TypeError, ValueError):
             return False
+        if not coverage_required:
+            return True
         status = self._fill_history_coverage_status(
             start_ms=start_ms,
             end_ms=now_ms,
         )
         return bool(status.get("ready", False))
+
+    @staticmethod
+    def _entry_cooldown_fill_lookback_minutes(cooldown_minutes: float) -> int:
+        if cooldown_minutes <= 0.0:
+            return 0
+        return 1 if cooldown_minutes < 1.0 else int(math.ceil(cooldown_minutes)) + 1
+
+    def _max_configured_entry_cooldown_minutes(self) -> float:
+        symbols: list[Optional[str]] = [None]
+        symbols.extend(sorted((getattr(self, "coin_overrides", {}) or {}).keys()))
+        return max(
+            float(self.bp(pside, "risk_entry_cooldown_minutes", symbol) or 0.0)
+            for symbol in symbols
+            for pside in ("long", "short")
+        )
+
+    def _required_fill_history_start_ms(
+        self, now_ms: int, *, pnl_start_ms: Optional[int]
+    ) -> tuple[bool, Optional[int]]:
+        """Return whether planning needs historical coverage and its earliest timestamp."""
+        if self._live_risk_uses_authoritative_pnl():
+            return True, pnl_start_ms
+        cooldown_lookback_minutes = self._entry_cooldown_fill_lookback_minutes(
+            self._max_configured_entry_cooldown_minutes()
+        )
+        if cooldown_lookback_minutes <= 0:
+            return False, None
+        return True, max(0, int(now_ms) - cooldown_lookback_minutes * 60_000)
 
     def _fill_coverage_retry_delay_seconds(self, retry_count: int) -> float:
         try:
@@ -12271,7 +12304,12 @@ class Passivbot:
                 lookback_config_value,
                 field_name="live.pnls_max_lookback_days",
             )
-            age_limit = lookback.fill_cache_age_limit_ms(self.get_exchange_time())
+            exchange_time_ms = self.get_exchange_time()
+            pnl_age_limit = lookback.fill_cache_age_limit_ms(exchange_time_ms)
+            coverage_required, age_limit = self._required_fill_history_start_ms(
+                exchange_time_ms,
+                pnl_start_ms=pnl_age_limit,
+            )
 
             # Get existing event IDs and source IDs before refresh
             existing_ids: set[str] = set()
@@ -12345,20 +12383,35 @@ class Passivbot:
             # lookback before fill-dependent planning.
             events = self._pnls_manager.get_events()
             before_events_count = len(events)
-            coverage_status = self._fill_history_coverage_status(
-                start_ms=age_limit,
-                end_ms=self.get_exchange_time(),
+            if coverage_required:
+                coverage_status = self._fill_history_coverage_status(
+                    start_ms=age_limit,
+                    end_ms=exchange_time_ms,
+                )
+                coverage_ready = bool(coverage_status.get("ready", False))
+            else:
+                coverage_status = {
+                    "ready": True,
+                    "reason": "historical_coverage_not_required",
+                    "history_scope": "recent",
+                    "covered_start_ms": 0,
+                    "oldest_event_ts": 0,
+                }
+                coverage_ready = True
+            needs_full_refresh = (
+                coverage_required and age_limit is None and not coverage_ready
             )
-            coverage_ready = bool(coverage_status.get("ready", False))
-            needs_full_refresh = lookback.is_all and not coverage_ready
-            needs_lookback_refresh = (not lookback.is_all) and not coverage_ready
+            needs_lookback_refresh = (
+                coverage_required and age_limit is not None and not coverage_ready
+            )
             fill_fetch_completed = False
             degraded_repair_attempted = False
             history_scope = str(coverage_status.get("history_scope", "unknown"))
             degraded_before = [
                 event
                 for event in FillEventsManager.degraded_pnl_events(events)
-                if age_limit is None or int(event.timestamp) >= int(age_limit)
+                if pnl_age_limit is None
+                or int(event.timestamp) >= int(pnl_age_limit)
             ]
             repair_degraded = getattr(
                 self._pnls_manager, "refresh_degraded_pnl_events", None
@@ -12372,7 +12425,9 @@ class Passivbot:
                 degraded_repair_attempted = True
                 try:
                     await repair_degraded(
-                        start_ms=None if age_limit is None else int(age_limit),
+                        start_ms=(
+                            None if pnl_age_limit is None else int(pnl_age_limit)
+                        ),
                         end_ms=int(self.get_exchange_time()),
                     )
                 finally:
@@ -12495,7 +12550,7 @@ class Passivbot:
                     # widening is reserved for the nonblocking trailing
                     # recovery prefetch.
                     recovery_start_ms = (
-                        self._trailing_fill_history_recovery_start_ms(age_limit)
+                        self._trailing_fill_history_recovery_start_ms(pnl_age_limit)
                         if trailing_recovery_refresh
                         else None
                     )
@@ -12518,6 +12573,22 @@ class Passivbot:
                             start_ms=int(recovery_start_ms),
                             end_ms=None,
                         )
+                    elif not coverage_required and before_events_count == 0:
+                        refresh_mode = "incremental_bounded"
+                        bounded_start_ms = max(
+                            0,
+                            int(exchange_time_ms)
+                            - int(overlap_minutes * 60 * 1000),
+                        )
+                        await self._pnls_manager.refresh(
+                            start_ms=bounded_start_ms,
+                            end_ms=None,
+                        )
+                        cache = getattr(self._pnls_manager, "cache", None)
+                        mark_covered_start = getattr(cache, "mark_covered_start", None)
+                        if callable(mark_covered_start):
+                            mark_covered_start(bounded_start_ms)
+                        self._pnls_manager.set_history_scope("window")
                     else:
                         await self._pnls_manager.refresh_latest(
                             overlap=20,
@@ -12560,16 +12631,23 @@ class Passivbot:
             degraded_pnl_events = [
                 event
                 for event in FillEventsManager.degraded_pnl_events(all_events)
-                if age_limit is None or int(event.timestamp) >= int(age_limit)
+                if pnl_age_limit is None
+                or int(event.timestamp) >= int(pnl_age_limit)
             ]
             self._last_fill_refresh_pending_pnl_count = len(pending_pnl_events)
             self._last_fill_refresh_degraded_pnl_count = len(degraded_pnl_events)
             pnls_safe = not pending_pnl_events and not degraded_pnl_events
-            post_refresh_coverage_status = self._fill_history_coverage_status(
-                start_ms=age_limit,
-                end_ms=self.get_exchange_time(),
-            )
-            coverage_ready_after = bool(post_refresh_coverage_status.get("ready", False))
+            if coverage_required:
+                post_refresh_coverage_status = self._fill_history_coverage_status(
+                    start_ms=age_limit,
+                    end_ms=self.get_exchange_time(),
+                )
+                coverage_ready_after = bool(
+                    post_refresh_coverage_status.get("ready", False)
+                )
+            else:
+                post_refresh_coverage_status = dict(coverage_status)
+                coverage_ready_after = True
             fills_ready = coverage_ready_after and (
                 pnls_safe or not authoritative_pnl_required
             )
@@ -12984,8 +13062,8 @@ class Passivbot:
 
         if now_ms is None:
             now_ms = int(self.get_exchange_time())
-        lookback_minutes = (
-            1 if max_cooldown_minutes < 1.0 else int(math.ceil(max_cooldown_minutes)) + 1
+        lookback_minutes = self._entry_cooldown_fill_lookback_minutes(
+            max_cooldown_minutes
         )
         start_ms = max(0, int(now_ms) - lookback_minutes * 60_000)
         events = self._pnls_manager.get_events(start_ms=start_ms)

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -5973,12 +5973,23 @@ async def test_update_pnls_pending_enrichment_advances_only_trailing_fetch_gener
 
 
 @pytest.mark.asyncio
-async def test_update_pnls_window_lookback_bootstraps_when_coverage_unproven():
+@pytest.mark.parametrize(
+    ("pnl_required", "cooldown_minutes", "expected_lookback_minutes"),
+    [
+        (True, 0.0, 30 * 24 * 60),
+        (False, 2.5, 4),
+    ],
+    ids=["pnl_risk", "entry_cooldown"],
+)
+async def test_update_pnls_bootstraps_required_consumer_lookback(
+    pnl_required, cooldown_minutes, expected_lookback_minutes
+):
     bot = Passivbot.__new__(Passivbot)
-    bot._live_risk_uses_authoritative_pnl = lambda: True
+    bot._live_risk_uses_authoritative_pnl = lambda: pnl_required
+    bot._max_configured_entry_cooldown_minutes = lambda: cooldown_minutes
     now_ms = 1_800_000_000_000
     lookback_days = 30.0
-    start_ms = now_ms - int(lookback_days * 86_400_000)
+    start_ms = now_ms - int(expected_lookback_minutes * 60_000)
     cached_events = [
         SimpleNamespace(
             timestamp=start_ms - 60_000,
@@ -6065,6 +6076,68 @@ async def test_update_pnls_window_lookback_bootstraps_when_coverage_unproven():
     bot._pnls_manager.refresh.assert_not_awaited()
     bot._pnls_manager.refresh_latest.assert_not_awaited()
     assert bot._pnls_manager.cache.get_covered_start_ms() == start_ms
+    assert bot._pnls_manager.history_scope == "window"
+
+
+@pytest.mark.asyncio
+async def test_update_pnls_empty_cache_uses_bounded_recent_fetch_without_history_consumer():
+    bot = Passivbot.__new__(Passivbot)
+    bot._live_risk_uses_authoritative_pnl = lambda: False
+    bot._max_configured_entry_cooldown_minutes = lambda: 0.0
+    now_ms = 1_800_000_000_000
+
+    class _Cache:
+        def __init__(self):
+            self.covered_start_ms = 0
+
+        def mark_covered_start(self, value):
+            self.covered_start_ms = int(value)
+
+    class _Manager:
+        def __init__(self):
+            self._events = []
+            self.cache = _Cache()
+            self.refresh = AsyncMock()
+            self.refresh_latest = AsyncMock()
+            self.history_scope = "unknown"
+
+        def get_events(self, start_ms=None):
+            return list(self._events)
+
+        def get_history_scope(self):
+            return self.history_scope
+
+        def set_history_scope(self, scope):
+            self.history_scope = scope
+
+    bot.stop_signal_received = False
+    bot.config = {
+        "live": {
+            "fills_recent_overlap_minutes": 10.0,
+            "pnls_max_lookback_days": "all",
+        }
+    }
+    bot._authoritative_pending_confirmations = {}
+    bot._pnls_manager = _with_fill_coverage_api(_Manager())
+    bot.init_pnls = AsyncMock()
+    bot.live_value = lambda key: bot.config["live"][key]
+    bot.get_exchange_time = lambda: now_ms
+    bot._log_new_fill_events = lambda new_events: None
+    bot._monitor_record_event = lambda *args, **kwargs: None
+    bot._monitor_record_error = lambda *args, **kwargs: None
+    bot.logging_level = 0
+    bot._health_rate_limits = 0
+
+    result = await bot.update_pnls(source="staged_blocking")
+
+    bounded_start_ms = now_ms - 10 * 60_000
+    assert result is True
+    bot._pnls_manager.refresh.assert_awaited_once_with(
+        start_ms=bounded_start_ms,
+        end_ms=None,
+    )
+    bot._pnls_manager.refresh_latest.assert_not_awaited()
+    assert bot._pnls_manager.cache.covered_start_ms == bounded_start_ms
     assert bot._pnls_manager.history_scope == "window"
 
 
@@ -6641,6 +6714,7 @@ async def test_update_pnls_keeps_structural_fills_ready_when_pnl_consumers_disab
     bot._authoritative_pending_confirmations = {}
     bot._pnls_manager = _with_fill_coverage_api(_Manager())
     bot._live_risk_uses_authoritative_pnl = lambda: False
+    bot._max_configured_entry_cooldown_minutes = lambda: 0.0
     bot.init_pnls = AsyncMock()
     bot.live_value = lambda key: bot.config["live"][key]
     bot.get_exchange_time = lambda: now_ms
@@ -6654,23 +6728,18 @@ async def test_update_pnls_keeps_structural_fills_ready_when_pnl_consumers_disab
 
     result = await bot.update_pnls(source="staged_blocking")
 
-    assert result is coverage_ready
+    assert result is True
     bot._pnls_manager.refresh_degraded_pnl_events.assert_not_awaited()
-    if coverage_ready:
-        bot._record_authoritative_surface.assert_called_once()
-    else:
-        bot._record_authoritative_surface.assert_not_called()
+    bot._pnls_manager.refresh_for_lookback.assert_not_awaited()
+    bot._pnls_manager.refresh_latest.assert_awaited_once()
+    bot._record_authoritative_surface.assert_called_once()
     expected_pending = 1 if pnl_status == "pending" else 0
     expected_degraded = 1 if pnl_source == fem.PNL_SOURCE_SYNTHETIC_DEGRADED else 0
     assert bot._last_fill_refresh_pending_pnl_count == expected_pending
     assert bot._last_fill_refresh_degraded_pnl_count == expected_degraded
     summary = bot._emit_fills_refresh_summary_event.call_args.kwargs
-    assert summary["status"] == ("succeeded" if coverage_ready else "deferred")
-    assert summary["reason_code"] == (
-        "fills_refresh_succeeded"
-        if coverage_ready
-        else "fill_history_coverage_unavailable"
-    )
+    assert summary["status"] == "succeeded"
+    assert summary["reason_code"] == "fills_refresh_succeeded"
     assert summary["pending_pnl_count"] == expected_pending
     assert summary["degraded_pnl_count"] == expected_degraded
 
@@ -9380,6 +9449,32 @@ def test_authoritative_barrier_waits_for_next_epoch_confirmation():
     assert details["missing"] == []
     assert getattr(bot, "_authoritative_pending_confirmations", {}) == {}
     assert bot.freshness_ledger.surface_epoch("open_orders") == 2
+
+
+@pytest.mark.parametrize(
+    ("pnl_required", "cooldown_minutes", "pnl_start_ms", "expected"),
+    [
+        (True, 720.0, None, (True, None)),
+        (True, 720.0, 1_000_000, (True, 1_000_000)),
+        (False, 2.5, 1_000_000, (True, 9_760_000)),
+        (False, 0.0, 1_000_000, (False, None)),
+    ],
+    ids=["pnl_all", "pnl_window", "cooldown_only", "routine_only"],
+)
+def test_required_fill_history_start_follows_enabled_consumer(
+    pnl_required, cooldown_minutes, pnl_start_ms, expected
+):
+    bot = Passivbot.__new__(Passivbot)
+    bot._live_risk_uses_authoritative_pnl = lambda: pnl_required
+    bot._max_configured_entry_cooldown_minutes = lambda: cooldown_minutes
+
+    assert (
+        bot._required_fill_history_start_ms(
+            10_000_000,
+            pnl_start_ms=pnl_start_ms,
+        )
+        == expected
+    )
 
 
 def test_staged_refresh_plan_defers_fills_until_next_minute(monkeypatch):


### PR DESCRIPTION
## Summary

- derive required live fill-history coverage from enabled consumers
- retain the configured PnL lookback and authoritative PnL quality for realized-loss, unstuck, and HSL consumers
- require only the maximum configured entry-cooldown horizon when cooldown is the sole historical consumer
- use a bounded recent fetch for an empty cache when no historical consumer is enabled
- keep trailing reconstruction on its existing symbol/position-side confirmation and recovery path

## Why

Live orchestration currently proves `live.pnls_max_lookback_days` before planning even when no enabled feature consumes realized PnL. That applies accounting-grade historical correctness to structural fill consumers and can turn an unrelated 30-day history gap into a global planning block.

This change preserves strict evidence at each real consumer boundary. PnL-dependent risk still receives exactly the configured window. Entry cooldown receives enough structural history to find any fill that could still activate the gate. Trailing remains fail-closed and scoped. Routine-only bots ingest recent fills without pretending that bounded data proves a larger history window.

This is the second audit PR and should merge after #1438; both target `master` as required.

## Validation

- rebuilt and fingerprint-verified the current Rust extension from this worktree
- fill, state-refresh, HSL, realized-loss, unstuck, and documentation suites passed
- offline fake-live and order-orchestration suites passed
- AI documentation and generated live-event registry checks passed
- Python compilation and `git diff --check` passed
