### PR TITLE
Consolidate live PnL planning inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
-- Stop refetching every account surface when a known fill gains authoritative PnL, and validate realized-PnL history once per Rust planning cycle instead of rescanning it for unstuck eligibility.
+- Stop refetching every account surface when a known fill only gains authoritative PnL, while retaining confirmation for new source identities or structural fill changes; validate realized-PnL history once per Rust planning cycle instead of rescanning it for unstuck eligibility.
 - Scope live fill-history readiness to enabled consumers: PnL risk keeps its configured lookback, entry cooldown proves only its structural-fill horizon, and bots without historical consumers use bounded recent ingestion.
 
 - Live fill-history coverage now has one canonical verdict owned by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Stop refetching every account surface when a known fill gains authoritative PnL, and validate realized-PnL history once per Rust planning cycle instead of rescanning it for unstuck eligibility.
+
 - Live fill-history coverage now has one canonical verdict owned by
   `FillEventsManager`. Refresh, staged readiness, HSL replay, and realized-PnL
   consumers no longer duplicate cache/gap interpretation. Metadata that claims

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
-- Stop refetching every account surface when a known fill only gains authoritative PnL, while retaining confirmation for new source identities or structural fill changes; validate realized-PnL history once per Rust planning cycle instead of rescanning it for unstuck eligibility.
+- Stop refetching every account surface when a known fill only gains authoritative PnL or revised fee evidence, while retaining confirmation for new source identities or structural fill changes; validate realized-PnL history once per Rust planning cycle instead of rescanning it for unstuck eligibility.
 - Scope live fill-history readiness to enabled consumers: PnL risk keeps its configured lookback, entry cooldown proves only its structural-fill horizon, and bots without historical consumers use bounded recent ingestion.
 
 - Live fill-history coverage now has one canonical verdict owned by

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -65,9 +65,9 @@
     authoritative net realized PnL only: pending and synthetic values remain visible in
     fill diagnostics but do not enter the health counter, and later enrichment adds the
     full authoritative amount without retaining fill-identity accounting state.
-    PnL-only enrichment changes local accounting evidence and does not request another
-    account-wide confirmation. New source identities and structural fill changes still
-    confirm account surfaces because they may represent a new exchange-state transition.
+    PnL- or fee-only enrichment changes local accounting evidence and does not request
+    another account-wide confirmation. New source identities and structural fill changes
+    still confirm account surfaces because they may represent a new exchange-state transition.
     Structured `cycle.degraded` diagnostics preserve bounded `pending_pnl_count` and
     `degraded_pnl_count` fields through the centralized payload sanitizer.
 11. `FillEventsManager` owns the canonical fill-history coverage verdict used by

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -65,9 +65,9 @@
     authoritative net realized PnL only: pending and synthetic values remain visible in
     fill diagnostics but do not enter the health counter, and later enrichment adds the
     full authoritative amount without retaining fill-identity accounting state.
-    PnL enrichment changes local accounting evidence only and does not request another
-    account-wide confirmation; newly discovered fills still confirm account surfaces
-    because they may represent a new exchange-state transition.
+    PnL-only enrichment changes local accounting evidence and does not request another
+    account-wide confirmation. New source identities and structural fill changes still
+    confirm account surfaces because they may represent a new exchange-state transition.
     Structured `cycle.degraded` diagnostics preserve bounded `pending_pnl_count` and
     `degraded_pnl_count` fields through the centralized payload sanitizer.
 11. `FillEventsManager` owns the canonical fill-history coverage verdict used by

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -65,6 +65,9 @@
     authoritative net realized PnL only: pending and synthetic values remain visible in
     fill diagnostics but do not enter the health counter, and later enrichment adds the
     full authoritative amount without retaining fill-identity accounting state.
+    PnL enrichment changes local accounting evidence only and does not request another
+    account-wide confirmation; newly discovered fills still confirm account surfaces
+    because they may represent a new exchange-state transition.
     Structured `cycle.degraded` diagnostics preserve bounded `pending_pnl_count` and
     `degraded_pnl_count` fields through the centralized payload sanitizer.
 11. `FillEventsManager` owns the canonical fill-history coverage verdict used by

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -12287,7 +12287,14 @@ class Passivbot:
         post_refresh_coverage_status: dict[str, Any] = {}
         lookback_config_value = None
         enriched_events: list[tuple[object, object]] = []
-        structural_confirmation_required = False
+        account_confirmation_requested = False
+
+        def request_account_confirmation() -> None:
+            nonlocal account_confirmation_requested
+            if account_confirmation_requested:
+                return
+            self._request_authoritative_confirmation(ACCOUNT_SURFACES)
+            account_confirmation_requested = True
 
         def flush_enriched_events() -> list[tuple[object, object]]:
             return []
@@ -12373,8 +12380,8 @@ class Passivbot:
                 )
 
             def collect_enriched_events() -> list[tuple[object, object]]:
-                nonlocal structural_confirmation_required
                 transitions: list[tuple[object, object]] = []
+                structural_transition = False
                 for current in self._pnls_manager.get_events():
                     current_keys = event_identity_keys(current)
                     if current_keys & handled_enrichment_keys:
@@ -12402,11 +12409,13 @@ class Passivbot:
                     if previous_needs_enrichment and current_is_authoritative:
                         transitions.append((previous, current))
                         if event_structure(previous) != event_structure(current):
-                            structural_confirmation_required = True
+                            structural_transition = True
                         handled_enrichment_keys.update(current_keys)
                 if transitions:
                     self._log_enriched_fill_events(transitions)
                     enriched_events.extend(transitions)
+                if structural_transition:
+                    request_account_confirmation()
                 return transitions
 
             flush_enriched_events = collect_enriched_events
@@ -12642,6 +12651,7 @@ class Passivbot:
                 self._trailing_fill_fetch_generation = fill_refresh_attempt_generation
             new_events = []
             seen_new_source_ids: set[str] = set()
+            mixed_source_confirmation_required = False
             for ev in all_events:
                 src_ids = getattr(ev, "source_ids", None)
                 if src_ids:
@@ -12658,12 +12668,19 @@ class Passivbot:
                 ]
                 if not unseen_source_ids:
                     continue
-                new_events.append(ev)
+                has_known_source = any(
+                    src_id in existing_source_ids or src_id in seen_new_source_ids
+                    for src_id in src_ids
+                )
                 seen_new_source_ids.update(unseen_source_ids)
+                if has_known_source:
+                    mixed_source_confirmation_required = True
+                    continue
+                new_events.append(ev)
             if new_events:
                 self._log_new_fill_events(new_events)
-            if new_events or structural_confirmation_required:
-                self._request_authoritative_confirmation(ACCOUNT_SURFACES)
+            if new_events or mixed_source_confirmation_required:
+                request_account_confirmation()
             pending_pnl_events = FillEventsManager.pending_pnl_events(all_events)
             degraded_pnl_events = [
                 event

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -12287,6 +12287,7 @@ class Passivbot:
         post_refresh_coverage_status: dict[str, Any] = {}
         lookback_config_value = None
         enriched_events: list[tuple[object, object]] = []
+        structural_confirmation_required = False
 
         def flush_enriched_events() -> list[tuple[object, object]]:
             return []
@@ -12342,7 +12343,37 @@ class Passivbot:
                     keys.add(f"id:{event_id}")
                 return keys
 
+            def event_structure(event: object) -> tuple[object, ...]:
+                source_ids = tuple(
+                    sorted(
+                        str(value)
+                        for value in getattr(event, "source_ids", None) or ()
+                        if value
+                    )
+                )
+                if not source_ids:
+                    event_id = str(getattr(event, "id", "") or "")
+                    source_ids = (event_id,) if event_id else ()
+                structural_fields = (
+                    "timestamp",
+                    "symbol",
+                    "side",
+                    "qty",
+                    "price",
+                    "fee_paid",
+                    "pb_order_type",
+                    "position_side",
+                    "client_order_id",
+                    "psize",
+                    "pprice",
+                    "c_mult",
+                )
+                return (source_ids,) + tuple(
+                    getattr(event, field, None) for field in structural_fields
+                )
+
             def collect_enriched_events() -> list[tuple[object, object]]:
+                nonlocal structural_confirmation_required
                 transitions: list[tuple[object, object]] = []
                 for current in self._pnls_manager.get_events():
                     current_keys = event_identity_keys(current)
@@ -12370,6 +12401,8 @@ class Passivbot:
                     )
                     if previous_needs_enrichment and current_is_authoritative:
                         transitions.append((previous, current))
+                        if event_structure(previous) != event_structure(current):
+                            structural_confirmation_required = True
                         handled_enrichment_keys.update(current_keys)
                 if transitions:
                     self._log_enriched_fill_events(transitions)
@@ -12617,14 +12650,19 @@ class Passivbot:
                     src_ids = [ev.id] if getattr(ev, "id", None) else []
                 if not src_ids:
                     continue
-                if any(src_id in existing_source_ids for src_id in src_ids):
-                    continue
-                if any(src_id in seen_new_source_ids for src_id in src_ids):
+                unseen_source_ids = [
+                    src_id
+                    for src_id in src_ids
+                    if src_id not in existing_source_ids
+                    and src_id not in seen_new_source_ids
+                ]
+                if not unseen_source_ids:
                     continue
                 new_events.append(ev)
-                seen_new_source_ids.update(src_ids)
+                seen_new_source_ids.update(unseen_source_ids)
             if new_events:
                 self._log_new_fill_events(new_events)
+            if new_events or structural_confirmation_required:
                 self._request_authoritative_confirmation(ACCOUNT_SURFACES)
             pending_pnl_events = FillEventsManager.pending_pnl_events(all_events)
             degraded_pnl_events = [

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -12367,7 +12367,6 @@ class Passivbot:
                     "side",
                     "qty",
                     "price",
-                    "fee_paid",
                     "pb_order_type",
                     "position_side",
                     "client_order_id",

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -12335,7 +12335,6 @@ class Passivbot:
                         handled_enrichment_keys.update(current_keys)
                 if transitions:
                     self._log_enriched_fill_events(transitions)
-                    self._request_authoritative_confirmation(ACCOUNT_SURFACES)
                     enriched_events.extend(transitions)
                 return transitions
 
@@ -12942,7 +12941,7 @@ class Passivbot:
         events = self._get_effective_pnl_events()
         self._assert_pnl_history_safe_for_risk(
             events,
-            context="realized loss gate PnL cumsum",
+            context="orchestrator realized PnL cumsum",
             start_ms=start_ms,
         )
         if not events:
@@ -16416,19 +16415,9 @@ class Passivbot:
         """Calculate unstuck allowances using FillEventsManager."""
         return self._calc_unstuck_allowances()
 
-    def _auto_unstuck_allowed_live(self) -> bool:
-        if self._pnls_manager is None:
-            return False
-        if not self._unstuck_uses_realized_pnl():
-            return False
-        start_ms = self._pnls_lookback_start_ms()
-        events = self._get_effective_pnl_events()
-        self._assert_pnl_history_safe_for_risk(
-            events,
-            context="auto unstuck realized PnL",
-            start_ms=start_ms,
-        )
-        return True
+    def _auto_unstuck_configured_live(self) -> bool:
+        """Whether configured Rust unstuck logic consumes validated PnL inputs."""
+        return self._pnls_manager is not None and self._unstuck_uses_realized_pnl()
 
     def _calc_orchestrator_unstuck_allowance_for_symbol(
         self, pside: str, symbol: str, realized_pnl_cumsum: dict
@@ -18925,8 +18914,8 @@ class Passivbot:
         # Python only proves the realized-PnL inputs are safe to expose; Rust
         # owns unstuck emission from the cumsum facts below, and duplicate
         # order risk rides normal live reconciliation like any other order.
-        auto_unstuck_allowed = self._auto_unstuck_allowed_live()
         realized_pnl_cumsum = self._get_realized_pnl_cumsum_stats()
+        auto_unstuck_allowed = self._auto_unstuck_configured_live()
         now_ms = int(self.get_exchange_time())
         fill_increase_timestamps = self._get_last_increase_fill_timestamps(
             symbols, now_ms=now_ms

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -4563,6 +4563,7 @@ async def test_update_pnls_completed_refresh_timing_trigger_cases_stay_debug(
     bot.live_value = lambda key: "all" if key == "pnls_max_lookback_days" else None
     bot.get_exchange_time = lambda: 1_700_000_060_000
     bot._log_new_fill_events = lambda new_events: None
+    bot._request_authoritative_confirmation = MagicMock()
     bot._monitor_record_event = lambda *args, **kwargs: None
     bot._monitor_record_error = lambda *args, **kwargs: None
     refresh_summaries = []
@@ -4585,6 +4586,12 @@ async def test_update_pnls_completed_refresh_timing_trigger_cases_stay_debug(
     assert f"new={int(add_new_fill)}" in fill_timing_records[0].message
     assert len(refresh_summaries) == 1
     assert refresh_summaries[0]["level"] == "info"
+    if add_new_fill:
+        bot._request_authoritative_confirmation.assert_called_once_with(
+            ACCOUNT_SURFACES
+        )
+    else:
+        bot._request_authoritative_confirmation.assert_not_called()
 
 
 def test_min_effective_cost_blocks_are_aggregated(caplog):
@@ -6554,6 +6561,7 @@ async def test_update_pnls_repairs_old_degraded_pnl_before_marking_fills_authori
     previous, current = bot._log_enriched_fill_events.call_args.args[0][0]
     assert previous is degraded
     assert current is authoritative
+    bot._request_authoritative_confirmation.assert_not_called()
     if failure_stage is not None:
         return
     summary = bot._emit_fills_refresh_summary_event.call_args.kwargs
@@ -8446,11 +8454,14 @@ def test_open_unstuck_order_does_not_gate_live_unstuck_emission(monkeypatch):
     bot = Passivbot.__new__(Passivbot)
     bot.balance = 100.0
     bot.balance_raw = 200.0
+    get_events = MagicMock(
+        return_value=[
+            types.SimpleNamespace(pnl=10.0, fee_paid=-1.0),
+        ]
+    )
     bot._pnls_manager = _with_fill_coverage_api(
         types.SimpleNamespace(
-            get_events=lambda: [
-                types.SimpleNamespace(pnl=10.0, fee_paid=-1.0),
-            ],
+            get_events=get_events,
             cache=_SafeRiskCache(),
             get_history_scope=lambda: "all",
         )
@@ -8474,8 +8485,11 @@ def test_open_unstuck_order_does_not_gate_live_unstuck_emission(monkeypatch):
     out = bot._calc_unstuck_allowances()
     assert out["long"] == pytest.approx(77.0)
 
-    # The emission input stays available while the order is open.
-    assert bot._auto_unstuck_allowed_live() is True
+    # The emission input stays available while the order is open, without a
+    # second fill scan after the cumsum/allowance history was validated.
+    get_events.reset_mock()
+    assert bot._auto_unstuck_configured_live() is True
+    get_events.assert_not_called()
 
 
 def _make_unstuck_custom_id() -> str:

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -4596,15 +4596,15 @@ async def test_update_pnls_completed_refresh_timing_trigger_cases_stay_debug(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("current_source_ids", "current_id", "expect_new_event"),
+    ("current_source_ids", "current_id"),
     [
-        (["fill-a", "fill-b"], "fill-a+fill-b", True),
-        (["fill-a"], "fill-a", False),
+        (["fill-a", "fill-b"], "fill-a+fill-b"),
+        (["fill-a"], "fill-a"),
     ],
     ids=["mixed_new_source", "same_source_structural_change"],
 )
 async def test_update_pnls_confirms_non_pnl_only_enrichment(
-    current_source_ids, current_id, expect_new_event
+    current_source_ids, current_id
 ):
     bot = Passivbot.__new__(Passivbot)
     bot._live_risk_uses_authoritative_pnl = lambda: True
@@ -4676,10 +4676,9 @@ async def test_update_pnls_confirms_non_pnl_only_enrichment(
     assert await bot.update_pnls(source="staged_blocking") is True
 
     bot._log_enriched_fill_events.assert_called_once_with([(previous, current)])
-    if expect_new_event:
-        bot._log_new_fill_events.assert_called_once_with([current])
-    else:
-        bot._log_new_fill_events.assert_not_called()
+    # A mixed aggregate is already accounted by the enrichment path, so it
+    # requests confirmation without counting the aggregate as a second fill.
+    bot._log_new_fill_events.assert_not_called()
     bot._request_authoritative_confirmation.assert_called_once_with(ACCOUNT_SURFACES)
 
 
@@ -6588,7 +6587,9 @@ async def test_update_pnls_window_lookback_uses_incremental_when_coverage_proven
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("failure_stage", [None, "repair", "routine"])
+@pytest.mark.parametrize(
+    "failure_stage", [None, "repair", "repair_structural", "routine"]
+)
 async def test_update_pnls_repairs_old_degraded_pnl_before_marking_fills_authoritative(
     failure_stage,
 ):
@@ -6614,6 +6615,12 @@ async def test_update_pnls_repairs_old_degraded_pnl_before_marking_fills_authori
     authoritative = SimpleNamespace(
         **{
             **vars(degraded),
+            "source_ids": (
+                ["degraded-close", "new-close"]
+                if failure_stage == "repair_structural"
+                else ["degraded-close"]
+            ),
+            "qty": -5.0 if failure_stage == "repair_structural" else -4.0,
             "pnl": 3.0,
             "pnl_source": fem.PNL_SOURCE_AUTHORITATIVE,
         }
@@ -6647,7 +6654,7 @@ async def test_update_pnls_repairs_old_degraded_pnl_before_marking_fills_authori
 
         async def _repair_degraded(self, **_kwargs):
             self._events = [authoritative]
-            if failure_stage == "repair":
+            if failure_stage in {"repair", "repair_structural"}:
                 raise RuntimeError("later repair range unavailable")
             return {
                 "attempted": True,
@@ -6712,7 +6719,7 @@ async def test_update_pnls_repairs_old_degraded_pnl_before_marking_fills_authori
         start_ms=start_ms,
         end_ms=now_ms,
     )
-    if failure_stage == "repair":
+    if failure_stage in {"repair", "repair_structural"}:
         bot._pnls_manager.refresh_latest.assert_not_awaited()
     else:
         bot._pnls_manager.refresh_latest.assert_awaited_once_with(
@@ -6723,7 +6730,12 @@ async def test_update_pnls_repairs_old_degraded_pnl_before_marking_fills_authori
     previous, current = bot._log_enriched_fill_events.call_args.args[0][0]
     assert previous is degraded
     assert current is authoritative
-    bot._request_authoritative_confirmation.assert_not_called()
+    if failure_stage == "repair_structural":
+        bot._request_authoritative_confirmation.assert_called_once_with(
+            ACCOUNT_SURFACES
+        )
+    else:
+        bot._request_authoritative_confirmation.assert_not_called()
     if failure_stage is not None:
         return
     summary = bot._emit_fills_refresh_summary_event.call_args.kwargs

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -4594,6 +4594,95 @@ async def test_update_pnls_completed_refresh_timing_trigger_cases_stay_debug(
         bot._request_authoritative_confirmation.assert_not_called()
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("current_source_ids", "current_id", "expect_new_event"),
+    [
+        (["fill-a", "fill-b"], "fill-a+fill-b", True),
+        (["fill-a"], "fill-a", False),
+    ],
+    ids=["mixed_new_source", "same_source_structural_change"],
+)
+async def test_update_pnls_confirms_non_pnl_only_enrichment(
+    current_source_ids, current_id, expect_new_event
+):
+    bot = Passivbot.__new__(Passivbot)
+    bot._live_risk_uses_authoritative_pnl = lambda: True
+    previous = SimpleNamespace(
+        timestamp=1_700_000_000_000,
+        id="fill-a",
+        source_ids=["fill-a"],
+        symbol="BTC/USDT:USDT",
+        side="sell",
+        qty=-1.0,
+        price=100.0,
+        fee_paid=-0.01,
+        pb_order_type="close",
+        position_side="long",
+        client_order_id="pb-close",
+        pnl=0.0,
+        pnl_status="pending",
+        pnl_source=fem.PNL_SOURCE_PENDING,
+    )
+    current = SimpleNamespace(
+        **{
+            **vars(previous),
+            "id": current_id,
+            "source_ids": current_source_ids,
+            "qty": -2.0,
+            "pnl": 1.0,
+            "pnl_status": "complete",
+            "pnl_source": fem.PNL_SOURCE_AUTHORITATIVE,
+        }
+    )
+
+    class _Manager:
+        def __init__(self):
+            self._events = [previous]
+
+        async def refresh_latest(self, **_kwargs):
+            self._events = [current]
+
+        def get_events(self):
+            return list(self._events)
+
+        def get_history_scope(self):
+            return "all"
+
+        def set_history_scope(self, _scope):
+            pass
+
+    bot.stop_signal_received = False
+    bot.config = {
+        "live": {
+            "fills_recent_overlap_minutes": 10.0,
+            "pnls_max_lookback_days": "all",
+        }
+    }
+    bot._authoritative_pending_confirmations = {}
+    bot._pnls_manager = _with_fill_coverage_api(_Manager())
+    bot.init_pnls = AsyncMock()
+    bot.live_value = lambda key: bot.config["live"][key]
+    bot.get_exchange_time = lambda: 1_700_000_060_000
+    bot._log_new_fill_events = MagicMock()
+    bot._log_enriched_fill_events = MagicMock()
+    bot._request_authoritative_confirmation = MagicMock()
+    bot._monitor_record_event = lambda *args, **kwargs: None
+    bot._monitor_record_error = lambda *args, **kwargs: None
+    bot._emit_fills_refresh_summary_event = MagicMock()
+    bot.logging_level = 0
+    bot._health_rate_limits = 0
+
+    assert await bot.update_pnls(source="staged_blocking") is True
+
+    bot._log_enriched_fill_events.assert_called_once_with([(previous, current)])
+    if expect_new_event:
+        bot._log_new_fill_events.assert_called_once_with([current])
+    else:
+        bot._log_new_fill_events.assert_not_called()
+    bot._request_authoritative_confirmation.assert_called_once_with(ACCOUNT_SURFACES)
+
+
 def test_min_effective_cost_blocks_are_aggregated(caplog):
     bot = Passivbot.__new__(Passivbot)
     bot._min_effective_cost_last_log_ms = {}

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -4596,15 +4596,26 @@ async def test_update_pnls_completed_refresh_timing_trigger_cases_stay_debug(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("current_source_ids", "current_id"),
+    (
+        "current_source_ids",
+        "current_id",
+        "current_qty",
+        "current_fee_paid",
+        "expect_confirmation",
+    ),
     [
-        (["fill-a", "fill-b"], "fill-a+fill-b"),
-        (["fill-a"], "fill-a"),
+        (["fill-a", "fill-b"], "fill-a+fill-b", -2.0, -0.01, True),
+        (["fill-a"], "fill-a", -2.0, -0.01, True),
+        (["fill-a"], "fill-a", -1.0, -0.02, False),
     ],
-    ids=["mixed_new_source", "same_source_structural_change"],
+    ids=["mixed_new_source", "same_source_structural_change", "fee_only_change"],
 )
-async def test_update_pnls_confirms_non_pnl_only_enrichment(
-    current_source_ids, current_id
+async def test_update_pnls_confirms_only_structural_enrichment(
+    current_source_ids,
+    current_id,
+    current_qty,
+    current_fee_paid,
+    expect_confirmation,
 ):
     bot = Passivbot.__new__(Passivbot)
     bot._live_risk_uses_authoritative_pnl = lambda: True
@@ -4629,7 +4640,8 @@ async def test_update_pnls_confirms_non_pnl_only_enrichment(
             **vars(previous),
             "id": current_id,
             "source_ids": current_source_ids,
-            "qty": -2.0,
+            "qty": current_qty,
+            "fee_paid": current_fee_paid,
             "pnl": 1.0,
             "pnl_status": "complete",
             "pnl_source": fem.PNL_SOURCE_AUTHORITATIVE,
@@ -4679,7 +4691,12 @@ async def test_update_pnls_confirms_non_pnl_only_enrichment(
     # A mixed aggregate is already accounted by the enrichment path, so it
     # requests confirmation without counting the aggregate as a second fill.
     bot._log_new_fill_events.assert_not_called()
-    bot._request_authoritative_confirmation.assert_called_once_with(ACCOUNT_SURFACES)
+    if expect_confirmation:
+        bot._request_authoritative_confirmation.assert_called_once_with(
+            ACCOUNT_SURFACES
+        )
+    else:
+        bot._request_authoritative_confirmation.assert_not_called()
 
 
 def test_min_effective_cost_blocks_are_aggregated(caplog):


### PR DESCRIPTION
## Summary

- stop requesting an account-wide confirmation when a known fill is enriched from pending/synthetic to authoritative PnL
- retain account-wide confirmation for genuinely newly discovered fills
- validate and accumulate realized-PnL history once before deriving the Rust auto-unstuck configuration flag
- remove the duplicate auto-unstuck fill scan and safety assertion

## Why

PnL enrichment changes local accounting evidence but does not represent a new exchange-state transition. Treating it like a new fill caused an unnecessary follow-up fetch of balance, positions, open orders, and fills.

Live planning also read and safety-validated the same realized-PnL events once for unstuck eligibility and immediately again for the cumsum values passed to Rust. The cumsum path is now the single validation point; the following configuration check does not reread fills. Rust remains the source of truth for unstuck emission.

This is the third audit PR and should merge after #1438 and #1439; all three independently target `master`.

## Validation

- rebuilt and fingerprint-verified the current Rust extension from this worktree
- fill, state-refresh, HSL, realized-loss, unstuck, order-orchestration, and documentation suites passed
- regression tests prove enrichment requests no account confirmation while a newly discovered fill still requests all account surfaces
- AI documentation and generated live-event registry checks passed
- Python compilation and `git diff --check` passed
