### PR TITLE
Tighten live candle and EMA readiness scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Scope live candle/EMA readiness to the Rust actions that consume it instead of deferring the
+  entire planner cycle when one active symbol lacks a completed candle. Known missing EMA inputs
+  remain explicit and value-free; backtests and unannotated Rust inputs stay strict, stale resting
+  strategy orders are cancelled through normal Rust-authoritative reconciliation, and independent
+  panic/TWEL reducers may continue when their own inputs are complete.
+
 - Prevent unproven fill-history coverage from consuming the generic live restart budget; one reason-aware execution-loop backoff owns fill retries while planning remains fail-closed, and already-latched HSL RED supervision continues during coverage repair.
 - Stop refetching every account surface when a known fill only gains authoritative PnL or revised fee evidence, while retaining confirmation for new source identities or structural fill changes; validate realized-PnL history once per Rust planning cycle instead of rescanning it for unstuck eligibility.
 - Scope live fill-history readiness to enabled consumers: PnL risk keeps its configured lookback, entry cooldown proves only its structural-fill horizon, and bots without historical consumers use bounded recent ingestion.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable user-facing changes will be documented in this file.
   entire planner cycle when one active symbol lacks a completed candle. Known missing EMA inputs
   remain explicit and value-free; backtests and unannotated Rust inputs stay strict, stale resting
   strategy orders are cancelled through normal Rust-authoritative reconciliation, and independent
-  panic/TWEL reducers may continue when their own inputs are complete.
+  panic/WEL/TWEL reducers may continue when their own inputs are complete.
 
 - Prevent unproven fill-history coverage from consuming the generic live restart budget; one reason-aware execution-loop backoff owns fill retries while planning remains fail-closed, and already-latched HSL RED supervision continues during coverage repair.
 - Stop refetching every account surface when a known fill only gains authoritative PnL or revised fee evidence, while retaining confirmation for new source identities or structural fill changes; validate realized-PnL history once per Rust planning cycle instead of rescanning it for unstuck eligibility.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ All notable user-facing changes will be documented in this file.
 - Scope live candle/EMA readiness to the Rust actions that consume it instead of deferring the
   entire planner cycle when one active symbol lacks a completed candle. Known missing EMA inputs
   remain explicit and value-free; backtests and unannotated Rust inputs stay strict, stale resting
-  strategy orders are cancelled through normal Rust-authoritative reconciliation, and independent
-  panic/WEL/TWEL reducers may continue when their own inputs are complete.
+  strategy orders are cancelled through normal Rust-authoritative reconciliation, entry and close
+  strategy branches remain independent when their input needs differ, and independent panic,
+  WEL, and TWEL reducers may continue when their own inputs are complete.
 
 - Prevent unproven fill-history coverage from consuming the generic live restart budget; one reason-aware execution-loop backoff owns fill retries while planning remains fail-closed, and already-latched HSL RED supervision continues during coverage repair.
 - Stop refetching every account surface when a known fill only gains authoritative PnL or revised fee evidence, while retaining confirmation for new source identities or structural fill changes; validate realized-PnL history once per Rust planning cycle instead of rescanning it for unstuck eligibility.

--- a/docs/ai/architecture.md
+++ b/docs/ai/architecture.md
@@ -49,6 +49,11 @@ Backtest loads config and OHLCV, invokes the Rust simulation, and emits results.
 candidate configs and evaluates them through the same Rust backtest contract. Differences between
 live and backtest runtime inputs require explicit parity tests rather than duplicated assumptions.
 
+Live may annotate a known missing symbol EMA bundle so Rust can scope only consumers that actually
+need it. The annotation is not a fallback value: backtest and unannotated inputs stay strict, Rust
+still owns the resulting ideal-order set, and reconciliation cancels resting orders absent from
+that set.
+
 ## Configuration Surfaces
 
 Use `config.live` only for behavior consumed by live and shared with backtest/optimizer.

--- a/docs/ai/error_contract.md
+++ b/docs/ai/error_contract.md
@@ -52,6 +52,15 @@ Market snapshots must be fresh for the symbols acted upon. Candles and EMAs are 
 order classes whose strategy or risk decision consumes them. Stale flat-symbol candles must not
 block protective management of held symbols.
 
+A failed urgent candle refresh is therefore an availability observation, not an account-wide
+planning barrier. Live Python may explicitly mark a symbol's known missing EMA inputs as
+unavailable and pass no invented values. Rust remains strict by default, including backtests, and
+may scope only that explicit live absence to the strategy or unstuck consumer that needs it.
+Missing ordinary strategy intent produces no ideal strategy order for that symbol/side, so normal
+Rust-authoritative reconciliation removes any now-stale resting strategy order. Independent Rust
+risk reducers and panic actions continue when their own inputs are complete. Malformed or
+non-finite producer output is never covered by this degradation and remains fatal.
+
 For candle-dependent actions, gate on canonical strategy-input readiness rather than raw REST
 candle arrival. A proven no-trade gap may use explicitly synthesized zero-volume continuity when
 the previous close is known, overlap repair is scheduled, and the gap is within policy. Unknown

--- a/docs/ai/error_contract.md
+++ b/docs/ai/error_contract.md
@@ -57,10 +57,11 @@ planning barrier. Live Python may explicitly mark a symbol's known missing EMA i
 unavailable and pass no invented values. Rust remains strict by default, including backtests, and
 may scope only that explicit live absence to forager selection, one-way arbitration, strategy, or
 unstuck consumers that need it.
-Missing ordinary strategy intent produces no ideal strategy order for that symbol/side, so normal
-Rust-authoritative reconciliation removes any now-stale resting strategy order. Independent Rust
-risk reducers and panic actions continue when their own inputs are complete. Malformed or
-non-finite producer output is never covered by this degradation and remains fatal.
+Missing ordinary strategy input produces no ideal orders for the entry or close branch that
+consumes it, so normal Rust-authoritative reconciliation removes any now-stale resting orders from
+that branch. The other strategy branch, independent Rust risk reducers, and panic actions continue
+when their own inputs are complete. Malformed or non-finite producer output is never covered by
+this degradation and remains fatal.
 
 For candle-dependent actions, gate on canonical strategy-input readiness rather than raw REST
 candle arrival. A proven no-trade gap may use explicitly synthesized zero-volume continuity when

--- a/docs/ai/error_contract.md
+++ b/docs/ai/error_contract.md
@@ -55,7 +55,8 @@ block protective management of held symbols.
 A failed urgent candle refresh is therefore an availability observation, not an account-wide
 planning barrier. Live Python may explicitly mark a symbol's known missing EMA inputs as
 unavailable and pass no invented values. Rust remains strict by default, including backtests, and
-may scope only that explicit live absence to the strategy or unstuck consumer that needs it.
+may scope only that explicit live absence to forager selection, one-way arbitration, strategy, or
+unstuck consumers that need it.
 Missing ordinary strategy intent produces no ideal strategy order for that symbol/side, so normal
 Rust-authoritative reconciliation removes any now-stale resting strategy order. Independent Rust
 risk reducers and panic actions continue when their own inputs are complete. Malformed or

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -285,6 +285,10 @@
     range be promoted to verified `no_trades` continuity. Empty, one-sided, terminal, or rejected
     payloads do not prove the gap and start a separate seven-day contextual-proof cooldown. Ordinary
     missing-range retries retain their existing independent schedule.
+15. Urgent active-candle refresh records and reports incomplete symbol coverage but does not itself
+    gate the whole planner cycle. Canonical EMA consumers determine symbol/order-class readiness;
+    unavailable values remain absent, never neutralized. Account surfaces and fresh market
+    snapshots retain their separate execution barriers.
 
 Cache paths use `to_standard_exchange_name()` rather than raw CCXT identifiers such as
 `binanceusdm` or `kucoinfutures`.

--- a/docs/plans/live_execution_gatekeeper_architecture_plan.md
+++ b/docs/plans/live_execution_gatekeeper_architecture_plan.md
@@ -17,7 +17,8 @@ surfaces plus the cycle's market snapshot, not blanket completed-candle freshnes
 identify known absent EMA inputs per symbol without fabricating values; Rust then records and
 scopes only consumers that encounter `MissingEma`, while backtest and unannotated calls remain
 strict. Ordinary ideals omitted by that scoped result are still authoritative, so reconciliation
-cancels stale resting strategy orders. Candle-independent panic and TWEL reducers remain eligible.
+cancels stale resting strategy orders. Candle-independent panic, WEL, and TWEL reducers remain
+eligible.
 
 ## Purpose
 

--- a/docs/plans/live_execution_gatekeeper_architecture_plan.md
+++ b/docs/plans/live_execution_gatekeeper_architecture_plan.md
@@ -12,6 +12,13 @@ build the event/data-packet spine and immutable per-cycle snapshot boundary firs
 enforcement should remain conditional until the Rust planning-completeness contract is explicit and
 tested.
 
+Implementation checkpoint (2026-08): the staged planner barrier covers authoritative account
+surfaces plus the cycle's market snapshot, not blanket completed-candle freshness. Live Python may
+identify known absent EMA inputs per symbol without fabricating values; Rust then records and
+scopes only consumers that encounter `MissingEma`, while backtest and unannotated calls remain
+strict. Ordinary ideals omitted by that scoped result are still authoritative, so reconciliation
+cancels stale resting strategy orders. Candle-independent panic and TWEL reducers remain eligible.
+
 ## Purpose
 
 Split the live bot into narrow components with explicit data contracts and structured decision
@@ -268,6 +275,8 @@ Policy:
 - Stale candles for flat symbols must not block protective management of held symbols.
 - Candle unavailability must be represented explicitly. Do not convert missing candle windows into
   neutral EMA inputs.
+- Do not require one completed-candle signature for the entire planner cycle. The Rust consumer
+  determines whether each strategy, unstuck, or independent risk action needs an unavailable EMA.
 
 ### Fill Events
 
@@ -359,8 +368,8 @@ Rules:
   positions, open orders, balance.
 - The snapshot may include stale/noncritical packets, but their status must be explicit.
 - Do not fabricate required Rust inputs with neutral values.
-- If a surface is unavailable for a symbol/order class, represent that as planning-unavailable
-  metadata.
+- If a surface is unavailable for a symbol/order class, represent that explicitly in the Rust
+  input/output contract; do not infer a hypothetical Python requirement matrix.
 - Background refresh tasks may be scheduled while building the snapshot, but their results belong
   to a later snapshot revision.
 

--- a/docs/plans/live_logging_overhaul_plan.md
+++ b/docs/plans/live_logging_overhaul_plan.md
@@ -569,8 +569,8 @@ After the event bus exists.
   captured with input digest.
 - Gatekeeper tests: stale market snapshot defers normal creates, panic close can
   use its reduced freshness contract, candidate-only stale EMA excludes the
-  candidate, and active/normal stale required EMA fails or defers loudly according
-  to its contract.
+  candidate, and active-symbol EMA absence is visible at the Rust consumer scope
+  without globally deferring independent actions.
 - Executor tests: partial create response emits an ambiguous event, terminal
   rejection emits a non-ambiguous rejected event, and confirmation requested is
   emitted before confirmation refresh.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -1012,6 +1012,11 @@ Related detailed plans:
       producer's existing structured-only feature-unavailability evidence in
       bounded smoke-report projections. It does not change readiness or the
       create-side handoff contract.
+    - 2026-08-01: Architecture-tightening work removes completed candles from
+      the global staged planner barrier and lets strict-by-default Rust scope
+      explicitly absent live EMA inputs to actual consumers. This addresses
+      held-symbol liveness and preserves stale-order cancellation, but does not
+      by itself settle flat-to-active forager ranking readiness.
 
 18. [ ] Binance hourly hedge-mode/config refresh traceback classification.
     Status: structured event, smoke projection, performance projection, and live

--- a/docs/plans/live_overengineering_audit_followup_plan.md
+++ b/docs/plans/live_overengineering_audit_followup_plan.md
@@ -51,6 +51,11 @@ verification and contract-specific regression coverage.
    planning, reconciliation, snapshot stamping, and event diagnostics now read
    the epoch directly from `FreshnessLedger`; execution-loop `cycle_id` remains
    a separate observability lifecycle.
+7. The current architecture-tightening slice removes completed candles from the
+   account-wide staged planning barrier. Known live EMA absence is passed to
+   strict-by-default Rust as symbol-scoped availability metadata, so only actual
+   EMA consumers are suppressed, stale strategy orders remain cancellable, and
+   candle-independent reducers can still run.
 
 ## Decision rules for further work
 

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -1514,6 +1514,7 @@ impl<'a> Backtest<'a> {
                     order_book,
                     exchange,
                     tradable,
+                    allow_missing_strategy_inputs: false,
                     next_candle,
                     effective_min_cost,
                     emas,

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -2324,13 +2324,14 @@ mod core {
         if symbol.allow_missing_strategy_inputs
             && matches!(err, OrchestratorError::MissingEma { .. })
         {
-            diagnostics
-                .warnings
-                .push(OrchestratorWarning::StrategyInputUnavailable {
-                    symbol_idx: symbol.symbol_idx,
-                    pside,
-                    scope,
-                });
+            let warning = OrchestratorWarning::StrategyInputUnavailable {
+                symbol_idx: symbol.symbol_idx,
+                pside,
+                scope,
+            };
+            if !diagnostics.warnings.contains(&warning) {
+                diagnostics.warnings.push(warning);
+            }
             Ok(())
         } else {
             Err(err)
@@ -2588,6 +2589,56 @@ mod core {
         let mut closes = Vec::new();
         append_strategy_orders_as_ideal(&mut closes, generated.closes, symbol.symbol_idx, pside);
         Ok((entries, closes))
+    }
+
+    fn generate_available_strategy_ideal_orders(
+        input: &OrchestratorInput,
+        symbol: &SymbolInput,
+        pside: PositionSide,
+        cache: &mut [CachedSideDerived],
+        runtime_budget: RuntimeBudgetState,
+        wants_entries: bool,
+        wants_closes: bool,
+        diagnostics: &mut OrchestratorDiagnostics,
+    ) -> Result<(Vec<IdealOrder>, Vec<IdealOrder>, bool), OrchestratorError> {
+        let requests = if symbol.allow_missing_strategy_inputs && wants_entries && wants_closes {
+            [(true, false), (false, true)]
+        } else {
+            [(wants_entries, wants_closes), (false, false)]
+        };
+        let mut entries = Vec::new();
+        let mut closes = Vec::new();
+        let mut close_inputs_unavailable = false;
+        for (request_entries, request_closes) in requests {
+            if !request_entries && !request_closes {
+                continue;
+            }
+            match generate_strategy_ideal_orders(
+                input,
+                symbol,
+                pside,
+                cache,
+                runtime_budget,
+                request_entries,
+                request_closes,
+            ) {
+                Ok((generated_entries, generated_closes)) => {
+                    entries.extend(generated_entries);
+                    closes.extend(generated_closes);
+                }
+                Err(err) => {
+                    handle_strategy_input_error(
+                        err,
+                        symbol,
+                        pside,
+                        StrategyInputScope::StrategyOrders,
+                        diagnostics,
+                    )?;
+                    close_inputs_unavailable |= request_closes;
+                }
+            }
+        }
+        Ok((entries, closes, close_inputs_unavailable))
     }
 
     #[derive(Clone)]
@@ -3412,34 +3463,26 @@ mod core {
                     let wants_entries = should_generate_entries(mode, has_pos, allow_initial);
                     let wants_closes = should_generate_closes(mode, has_pos);
                     if wants_entries || wants_closes {
-                        match generate_strategy_ideal_orders(
-                            input,
-                            s,
-                            PositionSide::Long,
-                            &mut workspace.derived_long,
-                            workspace.runtime_budget_long[s.symbol_idx],
-                            wants_entries,
-                            wants_closes,
-                        ) {
-                            Ok(generated) => (entries, closes) = generated,
-                            Err(err) => {
-                                handle_strategy_input_error(
-                                    err,
-                                    s,
-                                    PositionSide::Long,
-                                    StrategyInputScope::StrategyOrders,
-                                    &mut diagnostics,
-                                )?;
-                                if wants_closes {
-                                    if let Some(order) = calc_independent_wel_ideal_order(
-                                        input,
-                                        s,
-                                        PositionSide::Long,
-                                        workspace.runtime_budget_long[s.symbol_idx],
-                                    ) {
-                                        closes.push(order);
-                                    }
-                                }
+                        let (generated_entries, generated_closes, close_inputs_unavailable) =
+                            generate_available_strategy_ideal_orders(
+                                input,
+                                s,
+                                PositionSide::Long,
+                                &mut workspace.derived_long,
+                                workspace.runtime_budget_long[s.symbol_idx],
+                                wants_entries,
+                                wants_closes,
+                                &mut diagnostics,
+                            )?;
+                        (entries, closes) = (generated_entries, generated_closes);
+                        if close_inputs_unavailable {
+                            if let Some(order) = calc_independent_wel_ideal_order(
+                                input,
+                                s,
+                                PositionSide::Long,
+                                workspace.runtime_budget_long[s.symbol_idx],
+                            ) {
+                                closes.push(order);
                             }
                         }
                     }
@@ -3516,34 +3559,26 @@ mod core {
                     let wants_entries = should_generate_entries(mode, has_pos, allow_initial);
                     let wants_closes = should_generate_closes(mode, has_pos);
                     if wants_entries || wants_closes {
-                        match generate_strategy_ideal_orders(
-                            input,
-                            s,
-                            PositionSide::Short,
-                            &mut workspace.derived_short,
-                            workspace.runtime_budget_short[s.symbol_idx],
-                            wants_entries,
-                            wants_closes,
-                        ) {
-                            Ok(generated) => (entries, closes) = generated,
-                            Err(err) => {
-                                handle_strategy_input_error(
-                                    err,
-                                    s,
-                                    PositionSide::Short,
-                                    StrategyInputScope::StrategyOrders,
-                                    &mut diagnostics,
-                                )?;
-                                if wants_closes {
-                                    if let Some(order) = calc_independent_wel_ideal_order(
-                                        input,
-                                        s,
-                                        PositionSide::Short,
-                                        workspace.runtime_budget_short[s.symbol_idx],
-                                    ) {
-                                        closes.push(order);
-                                    }
-                                }
+                        let (generated_entries, generated_closes, close_inputs_unavailable) =
+                            generate_available_strategy_ideal_orders(
+                                input,
+                                s,
+                                PositionSide::Short,
+                                &mut workspace.derived_short,
+                                workspace.runtime_budget_short[s.symbol_idx],
+                                wants_entries,
+                                wants_closes,
+                                &mut diagnostics,
+                            )?;
+                        (entries, closes) = (generated_entries, generated_closes);
+                        if close_inputs_unavailable {
+                            if let Some(order) = calc_independent_wel_ideal_order(
+                                input,
+                                s,
+                                PositionSide::Short,
+                                workspace.runtime_budget_short[s.symbol_idx],
+                            ) {
+                                closes.push(order);
                             }
                         }
                     }

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -104,6 +104,13 @@ mod core {
         RiskCritical,
     }
 
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(rename_all = "snake_case")]
+    pub enum StrategyInputScope {
+        StrategyOrders,
+        Unstuck,
+    }
+
     #[derive(Debug, Clone, Serialize, Deserialize)]
     #[serde(deny_unknown_fields)]
     pub struct IdealOrder {
@@ -137,6 +144,11 @@ mod core {
         NonTradableHasPosition {
             symbol_idx: usize,
             pside: PositionSide,
+        },
+        StrategyInputUnavailable {
+            symbol_idx: usize,
+            pside: PositionSide,
+            scope: StrategyInputScope,
         },
         TwelRepairBlockedByLossGate {
             pside: PositionSide,
@@ -389,6 +401,11 @@ mod core {
         pub order_book: OrderBook, // must have bid>0 and ask>0
         pub exchange: ExchangeParams,
         pub tradable: bool,
+        /// Live-only authorization to scope absent EMA inputs to the strategy
+        /// actions that consume them. Defaults to strict for backtests and all
+        /// callers that do not explicitly establish live data unavailability.
+        #[serde(default)]
+        pub allow_missing_strategy_inputs: bool,
         /// Backtest-only hint: next candle range for "peek fill" decisions.
         /// `None` => unknown (live mode), default to full-grid expansion.
         pub next_candle: Option<NextCandle>,
@@ -2291,6 +2308,29 @@ mod core {
         }
     }
 
+    fn handle_strategy_input_error(
+        err: OrchestratorError,
+        symbol: &SymbolInput,
+        pside: PositionSide,
+        scope: StrategyInputScope,
+        diagnostics: &mut OrchestratorDiagnostics,
+    ) -> Result<(), OrchestratorError> {
+        if symbol.allow_missing_strategy_inputs
+            && matches!(err, OrchestratorError::MissingEma { .. })
+        {
+            diagnostics
+                .warnings
+                .push(OrchestratorWarning::StrategyInputUnavailable {
+                    symbol_idx: symbol.symbol_idx,
+                    pside,
+                    scope,
+                });
+            Ok(())
+        } else {
+            Err(err)
+        }
+    }
+
     fn strategy_order_generation_needs_ema_for_symbol_side(
         params: &StrategyParams,
         pside: PositionSide,
@@ -2374,6 +2414,100 @@ mod core {
                 order_type: order.order_type,
             });
         }
+    }
+
+    fn generate_strategy_ideal_orders(
+        input: &OrchestratorInput,
+        symbol: &SymbolInput,
+        pside: PositionSide,
+        cache: &mut [CachedSideDerived],
+        runtime_budget: RuntimeBudgetState,
+        wants_entries: bool,
+        wants_closes: bool,
+    ) -> Result<(Vec<IdealOrder>, Vec<IdealOrder>), OrchestratorError> {
+        let (strategy_side, side) = match pside {
+            PositionSide::Long => (StrategySide::Long, &symbol.long),
+            PositionSide::Short => (StrategySide::Short, &symbol.short),
+        };
+        let strategy_params = cached_strategy_params_for_symbol_side(
+            cache,
+            symbol.symbol_idx,
+            input.global.strategy_kind,
+            strategy_side,
+            side,
+        )?;
+        let ema_bands = if strategy_order_generation_needs_ema_for_symbol_side(
+            &strategy_params,
+            pside,
+            wants_entries,
+            wants_closes,
+            &side.position,
+            &symbol.exchange,
+            &symbol.order_book,
+            &side.bot_params,
+            runtime_budget,
+            input.balance,
+        ) {
+            cached_ema_bands(cache, symbol.symbol_idx, &symbol.emas, &strategy_params)?
+        } else {
+            EMABands::default()
+        };
+        let volatility_ema_1h =
+            cached_volatility_ema_1h(cache, symbol.symbol_idx, &symbol.emas, &strategy_params)?;
+        let volatility_ema_1m =
+            cached_volatility_ema_1m(cache, symbol.symbol_idx, &symbol.emas, &strategy_params)?;
+        let state = StateParams {
+            balance: input.balance,
+            order_book: symbol.order_book,
+            ema_bands,
+            volatility_ema_1m,
+            volatility_ema_1h,
+        };
+        let generated = generate_strategy_orders(
+            strategy_kind_for_symbol_side(&input.global),
+            strategy_side,
+            StrategyRequest {
+                wants_entries,
+                wants_closes,
+                exchange: &symbol.exchange,
+                state: &state,
+                bot_params: &side.bot_params,
+                strategy_params: &strategy_params,
+                runtime_budget,
+                position: &side.position,
+                trailing: &side.trailing,
+                next_candle: symbol.next_candle.as_ref().map(|candle| NextStepHint {
+                    low: candle.low,
+                    high: candle.high,
+                    tradable: candle.tradable,
+                }),
+                peek: input.peek_hints.as_ref().map(|hints| PeekBehavior {
+                    expand_entries: match pside {
+                        PositionSide::Long => hints.expand_grid_long.contains(&symbol.symbol_idx),
+                        PositionSide::Short => hints.expand_grid_short.contains(&symbol.symbol_idx),
+                    },
+                    expand_closes: match pside {
+                        PositionSide::Long => hints.expand_close_long.contains(&symbol.symbol_idx),
+                        PositionSide::Short => {
+                            hints.expand_close_short.contains(&symbol.symbol_idx)
+                        }
+                    },
+                }),
+            },
+        );
+        let mut entries = Vec::new();
+        append_strategy_orders_as_ideal(&mut entries, generated.entries, symbol.symbol_idx, pside);
+        apply_add_order_gates(
+            &mut entries,
+            pside,
+            input.timestamp_ms,
+            side.last_increase_fill_timestamp_ms,
+            side.bot_params.risk_entry_cooldown_minutes,
+            strategy_requires_sequential_entry_staging(&strategy_params),
+        );
+        let mut closes = Vec::new();
+        append_strategy_orders_as_ideal(&mut closes, generated.closes, symbol.symbol_idx, pside);
+        Ok((entries, closes))
     }
 
     #[derive(Clone)]
@@ -3166,98 +3300,24 @@ mod core {
                     let wants_entries = should_generate_entries(mode, has_pos, allow_initial);
                     let wants_closes = should_generate_closes(mode, has_pos);
                     if wants_entries || wants_closes {
-                        let strategy_params = cached_strategy_params_for_symbol_side(
-                            &mut workspace.derived_long,
-                            s.symbol_idx,
-                            input.global.strategy_kind,
-                            StrategySide::Long,
-                            &s.long,
-                        )?;
-                        let runtime_budget = workspace.runtime_budget_long[s.symbol_idx];
-                        let ema_bands = if strategy_order_generation_needs_ema_for_symbol_side(
-                            &strategy_params,
+                        match generate_strategy_ideal_orders(
+                            input,
+                            s,
                             PositionSide::Long,
+                            &mut workspace.derived_long,
+                            workspace.runtime_budget_long[s.symbol_idx],
                             wants_entries,
                             wants_closes,
-                            &s.long.position,
-                            &s.exchange,
-                            &s.order_book,
-                            &s.long.bot_params,
-                            runtime_budget,
-                            input.balance,
                         ) {
-                            cached_ema_bands(
-                                &mut workspace.derived_long,
-                                s.symbol_idx,
-                                &s.emas,
-                                &strategy_params,
-                            )?
-                        } else {
-                            EMABands::default()
-                        };
-                        let volatility_ema_1h = cached_volatility_ema_1h(
-                            &mut workspace.derived_long,
-                            s.symbol_idx,
-                            &s.emas,
-                            &strategy_params,
-                        )?;
-                        let volatility_ema_1m = cached_volatility_ema_1m(
-                            &mut workspace.derived_long,
-                            s.symbol_idx,
-                            &s.emas,
-                            &strategy_params,
-                        )?;
-                        let state = StateParams {
-                            balance: input.balance,
-                            order_book: s.order_book,
-                            ema_bands,
-                            volatility_ema_1m,
-                            volatility_ema_1h,
-                        };
-                        let generated = generate_strategy_orders(
-                            strategy_kind_for_symbol_side(&input.global),
-                            StrategySide::Long,
-                            StrategyRequest {
-                                wants_entries,
-                                wants_closes,
-                                exchange: &s.exchange,
-                                state: &state,
-                                bot_params: &s.long.bot_params,
-                                strategy_params: &strategy_params,
-                                runtime_budget,
-                                position: &s.long.position,
-                                trailing: &s.long.trailing,
-                                next_candle: s.next_candle.as_ref().map(|nc| NextStepHint {
-                                    low: nc.low,
-                                    high: nc.high,
-                                    tradable: nc.tradable,
-                                }),
-                                peek: input.peek_hints.as_ref().map(|hints| PeekBehavior {
-                                    expand_entries: hints.expand_grid_long.contains(&s.symbol_idx),
-                                    expand_closes: hints.expand_close_long.contains(&s.symbol_idx),
-                                }),
-                            },
-                        );
-                        append_strategy_orders_as_ideal(
-                            &mut entries,
-                            generated.entries,
-                            s.symbol_idx,
-                            PositionSide::Long,
-                        );
-                        apply_add_order_gates(
-                            &mut entries,
-                            PositionSide::Long,
-                            input.timestamp_ms,
-                            s.long.last_increase_fill_timestamp_ms,
-                            s.long.bot_params.risk_entry_cooldown_minutes,
-                            strategy_requires_sequential_entry_staging(&strategy_params),
-                        );
-                        append_strategy_orders_as_ideal(
-                            &mut closes,
-                            generated.closes,
-                            s.symbol_idx,
-                            PositionSide::Long,
-                        );
+                            Ok(generated) => (entries, closes) = generated,
+                            Err(err) => handle_strategy_input_error(
+                                err,
+                                s,
+                                PositionSide::Long,
+                                StrategyInputScope::StrategyOrders,
+                                &mut diagnostics,
+                            )?,
+                        }
                     }
                 }
 
@@ -3332,98 +3392,24 @@ mod core {
                     let wants_entries = should_generate_entries(mode, has_pos, allow_initial);
                     let wants_closes = should_generate_closes(mode, has_pos);
                     if wants_entries || wants_closes {
-                        let strategy_params = cached_strategy_params_for_symbol_side(
-                            &mut workspace.derived_short,
-                            s.symbol_idx,
-                            input.global.strategy_kind,
-                            StrategySide::Short,
-                            &s.short,
-                        )?;
-                        let runtime_budget = workspace.runtime_budget_short[s.symbol_idx];
-                        let ema_bands = if strategy_order_generation_needs_ema_for_symbol_side(
-                            &strategy_params,
+                        match generate_strategy_ideal_orders(
+                            input,
+                            s,
                             PositionSide::Short,
+                            &mut workspace.derived_short,
+                            workspace.runtime_budget_short[s.symbol_idx],
                             wants_entries,
                             wants_closes,
-                            &s.short.position,
-                            &s.exchange,
-                            &s.order_book,
-                            &s.short.bot_params,
-                            runtime_budget,
-                            input.balance,
                         ) {
-                            cached_ema_bands(
-                                &mut workspace.derived_short,
-                                s.symbol_idx,
-                                &s.emas,
-                                &strategy_params,
-                            )?
-                        } else {
-                            EMABands::default()
-                        };
-                        let volatility_ema_1h = cached_volatility_ema_1h(
-                            &mut workspace.derived_short,
-                            s.symbol_idx,
-                            &s.emas,
-                            &strategy_params,
-                        )?;
-                        let volatility_ema_1m = cached_volatility_ema_1m(
-                            &mut workspace.derived_short,
-                            s.symbol_idx,
-                            &s.emas,
-                            &strategy_params,
-                        )?;
-                        let state = StateParams {
-                            balance: input.balance,
-                            order_book: s.order_book,
-                            ema_bands,
-                            volatility_ema_1m,
-                            volatility_ema_1h,
-                        };
-                        let generated = generate_strategy_orders(
-                            strategy_kind_for_symbol_side(&input.global),
-                            StrategySide::Short,
-                            StrategyRequest {
-                                wants_entries,
-                                wants_closes,
-                                exchange: &s.exchange,
-                                state: &state,
-                                bot_params: &s.short.bot_params,
-                                strategy_params: &strategy_params,
-                                runtime_budget,
-                                position: &s.short.position,
-                                trailing: &s.short.trailing,
-                                next_candle: s.next_candle.as_ref().map(|nc| NextStepHint {
-                                    low: nc.low,
-                                    high: nc.high,
-                                    tradable: nc.tradable,
-                                }),
-                                peek: input.peek_hints.as_ref().map(|hints| PeekBehavior {
-                                    expand_entries: hints.expand_grid_short.contains(&s.symbol_idx),
-                                    expand_closes: hints.expand_close_short.contains(&s.symbol_idx),
-                                }),
-                            },
-                        );
-                        append_strategy_orders_as_ideal(
-                            &mut entries,
-                            generated.entries,
-                            s.symbol_idx,
-                            PositionSide::Short,
-                        );
-                        apply_add_order_gates(
-                            &mut entries,
-                            PositionSide::Short,
-                            input.timestamp_ms,
-                            s.short.last_increase_fill_timestamp_ms,
-                            s.short.bot_params.risk_entry_cooldown_minutes,
-                            strategy_requires_sequential_entry_staging(&strategy_params),
-                        );
-                        append_strategy_orders_as_ideal(
-                            &mut closes,
-                            generated.closes,
-                            s.symbol_idx,
-                            PositionSide::Short,
-                        );
+                            Ok(generated) => (entries, closes) = generated,
+                            Err(err) => handle_strategy_input_error(
+                                err,
+                                s,
+                                PositionSide::Short,
+                                StrategyInputScope::StrategyOrders,
+                                &mut diagnostics,
+                            )?,
+                        }
                     }
                 }
 
@@ -3461,12 +3447,24 @@ mod core {
                     StrategySide::Long,
                     &sym.long,
                 )?;
-                cached_ema_bands(
+                match cached_ema_bands(
                     &mut workspace.derived_long,
                     s.symbol_idx,
                     &sym.emas,
                     &strategy_params,
-                )?
+                ) {
+                    Ok(value) => value,
+                    Err(err) => {
+                        handle_strategy_input_error(
+                            err,
+                            sym,
+                            PositionSide::Long,
+                            StrategyInputScope::Unstuck,
+                            &mut diagnostics,
+                        )?;
+                        continue;
+                    }
+                }
             } else {
                 EMABands::default()
             };
@@ -3518,12 +3516,24 @@ mod core {
                     StrategySide::Short,
                     &sym.short,
                 )?;
-                cached_ema_bands(
+                match cached_ema_bands(
                     &mut workspace.derived_short,
                     s.symbol_idx,
                     &sym.emas,
                     &strategy_params,
-                )?
+                ) {
+                    Ok(value) => value,
+                    Err(err) => {
+                        handle_strategy_input_error(
+                            err,
+                            sym,
+                            PositionSide::Short,
+                            StrategyInputScope::Unstuck,
+                            &mut diagnostics,
+                        )?;
+                        continue;
+                    }
+                }
             } else {
                 EMABands::default()
             };
@@ -4150,6 +4160,7 @@ mod core {
                     ..Default::default()
                 },
                 tradable: true,
+                allow_missing_strategy_inputs: false,
                 next_candle: None,
                 effective_min_cost: 0.0,
                 emas,

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -2389,7 +2389,7 @@ mod core {
                 }
             }
             StrategyParams::EmaAnchor(_) => wants_entries || wants_closes,
-            StrategyParams::TrailingGridV7(_) => wants_entries || wants_closes,
+            StrategyParams::TrailingGridV7(_) => wants_entries,
         }
     }
 

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -45,10 +45,11 @@ mod core {
     use crate::strategies::{
         generate_orders as generate_strategy_orders, parse_strategy_params, strategy_ema_spans,
         strategy_entry_volatility_span_hours, strategy_initial_entry_offset,
-        strategy_initial_qty_pct, strategy_needs_log_range_1h, strategy_needs_log_range_1m,
-        strategy_offset_volatility_span_minutes, strategy_requires_sequential_entry_staging,
-        EmaGateMode, NextStepHint, PeekBehavior, StrategyKind, StrategyParams, StrategyRequest,
-        StrategySide,
+        strategy_initial_qty_pct, strategy_needs_log_range_1h,
+        strategy_needs_log_range_1h_for_request, strategy_needs_log_range_1m,
+        strategy_needs_log_range_1m_for_request, strategy_offset_volatility_span_minutes,
+        strategy_requires_sequential_entry_staging, EmaGateMode, NextStepHint, PeekBehavior,
+        StrategyKind, StrategyParams, StrategyRequest, StrategySide,
     };
     use crate::types::{
         BotParams, BotParamsPair, EMABands, ExchangeParams, OrderBook, OrderType, Position,
@@ -2517,10 +2518,24 @@ mod core {
         } else {
             EMABands::default()
         };
-        let volatility_ema_1h =
-            cached_volatility_ema_1h(cache, symbol.symbol_idx, &symbol.emas, &strategy_params)?;
-        let volatility_ema_1m =
-            cached_volatility_ema_1m(cache, symbol.symbol_idx, &symbol.emas, &strategy_params)?;
+        let volatility_ema_1h = if strategy_needs_log_range_1h_for_request(
+            &strategy_params,
+            wants_entries,
+            wants_closes,
+        ) {
+            cached_volatility_ema_1h(cache, symbol.symbol_idx, &symbol.emas, &strategy_params)?
+        } else {
+            0.0
+        };
+        let volatility_ema_1m = if strategy_needs_log_range_1m_for_request(
+            &strategy_params,
+            wants_entries,
+            wants_closes,
+        ) {
+            cached_volatility_ema_1m(cache, symbol.symbol_idx, &symbol.emas, &strategy_params)?
+        } else {
+            0.0
+        };
         let state = StateParams {
             balance: input.balance,
             order_book: symbol.order_book,

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -28,6 +28,7 @@ pub struct ForagerHysteresisState {
 }
 
 mod core {
+    use crate::closes::{calc_wel_auto_reduce_long, calc_wel_auto_reduce_short};
     use crate::coin_selection::{
         select_forager_candidates_with_diagnostics, ForagerCandidate, ForagerPositionSide,
         ForagerSelectionConfig, ForagerSelectionError, ForagerSelectionResult,
@@ -107,6 +108,8 @@ mod core {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(rename_all = "snake_case")]
     pub enum StrategyInputScope {
+        ForagerSelection,
+        OneWayArbitration,
         StrategyOrders,
         Unstuck,
     }
@@ -2054,6 +2057,20 @@ mod core {
         }
     }
 
+    fn unavailable_forager_candidate(index: usize) -> ForagerCandidate {
+        ForagerCandidate {
+            index,
+            enabled: false,
+            volume_score: 0.0,
+            volatility_score: 0.0,
+            bid: 0.0,
+            ask: 0.0,
+            ema_lower: 0.0,
+            ema_upper: 0.0,
+            entry_initial_ema_dist: 0.0,
+        }
+    }
+
     fn build_forager_candidates_into(
         symbols: &[SymbolInput],
         pside: PositionSide,
@@ -2137,46 +2154,54 @@ mod core {
                         strategy_initial_qty_pct(&strategy_params),
                     );
                 }
-                out.push(ForagerCandidate {
-                    index: s.symbol_idx,
-                    enabled: false,
-                    volume_score: 0.0,
-                    volatility_score: 0.0,
-                    bid: 0.0,
-                    ask: 0.0,
-                    ema_lower: 0.0,
-                    ema_upper: 0.0,
-                    entry_initial_ema_dist: 0.0,
-                });
+                out.push(unavailable_forager_candidate(s.symbol_idx));
                 continue;
             }
             let volume_score = if volume_required {
-                require_forager_input(
-                    s.symbol_idx,
-                    "forager_volume_score",
-                    ema_lookup(
-                        &forager_m1.volume,
-                        side.bot_params.filter_volume_ema_span_1m,
-                    )
-                    .ok_or(OrchestratorError::MissingEma {
-                        symbol_idx: s.symbol_idx,
-                    })?,
-                )?
+                let value = match ema_lookup(
+                    &forager_m1.volume,
+                    side.bot_params.filter_volume_ema_span_1m,
+                ) {
+                    Some(value) => value,
+                    None => {
+                        handle_strategy_input_error(
+                            OrchestratorError::MissingEma {
+                                symbol_idx: s.symbol_idx,
+                            },
+                            s,
+                            pside,
+                            StrategyInputScope::ForagerSelection,
+                            diagnostics,
+                        )?;
+                        out.push(unavailable_forager_candidate(s.symbol_idx));
+                        continue;
+                    }
+                };
+                require_forager_input(s.symbol_idx, "forager_volume_score", value)?
             } else {
                 0.0
             };
             let volatility_score = if volatility_required {
-                require_forager_input(
-                    s.symbol_idx,
-                    "forager_volatility_score",
-                    ema_lookup(
-                        &forager_m1.log_range,
-                        side.bot_params.filter_volatility_ema_span_1m,
-                    )
-                    .ok_or(OrchestratorError::MissingEma {
-                        symbol_idx: s.symbol_idx,
-                    })?,
-                )?
+                let value = match ema_lookup(
+                    &forager_m1.log_range,
+                    side.bot_params.filter_volatility_ema_span_1m,
+                ) {
+                    Some(value) => value,
+                    None => {
+                        handle_strategy_input_error(
+                            OrchestratorError::MissingEma {
+                                symbol_idx: s.symbol_idx,
+                            },
+                            s,
+                            pside,
+                            StrategyInputScope::ForagerSelection,
+                            diagnostics,
+                        )?;
+                        out.push(unavailable_forager_candidate(s.symbol_idx));
+                        continue;
+                    }
+                };
+                require_forager_input(s.symbol_idx, "forager_volatility_score", value)?
             } else {
                 0.0
             };
@@ -2193,17 +2218,7 @@ mod core {
                     | Err(OrchestratorError::NonFiniteInput {
                         field: "ema_bands", ..
                     }) => {
-                        out.push(ForagerCandidate {
-                            index: s.symbol_idx,
-                            enabled: false,
-                            volume_score: 0.0,
-                            volatility_score: 0.0,
-                            bid: 0.0,
-                            ask: 0.0,
-                            ema_lower: 0.0,
-                            ema_upper: 0.0,
-                            entry_initial_ema_dist: 0.0,
-                        });
+                        out.push(unavailable_forager_candidate(s.symbol_idx));
                         continue;
                     }
                     Err(err) => return Err(err),
@@ -2216,17 +2231,7 @@ mod core {
                 ) {
                     Ok(v) => v,
                     Err(_) => {
-                        out.push(ForagerCandidate {
-                            index: s.symbol_idx,
-                            enabled: false,
-                            volume_score: 0.0,
-                            volatility_score: 0.0,
-                            bid: 0.0,
-                            ask: 0.0,
-                            ema_lower: 0.0,
-                            ema_upper: 0.0,
-                            entry_initial_ema_dist: 0.0,
-                        });
+                        out.push(unavailable_forager_candidate(s.symbol_idx));
                         continue;
                     }
                 };
@@ -2414,6 +2419,66 @@ mod core {
                 order_type: order.order_type,
             });
         }
+    }
+
+    fn calc_independent_wel_ideal_order(
+        input: &OrchestratorInput,
+        symbol: &SymbolInput,
+        pside: PositionSide,
+        runtime_budget: RuntimeBudgetState,
+    ) -> Option<IdealOrder> {
+        if !matches!(
+            input.global.strategy_kind,
+            StrategyKind::TrailingMartingale | StrategyKind::TrailingGridV7
+        ) {
+            return None;
+        }
+        let side = match pside {
+            PositionSide::Long => &symbol.long,
+            PositionSide::Short => &symbol.short,
+        };
+        if side.position.size == 0.0 {
+            return None;
+        }
+        let state = StateParams {
+            balance: input.balance,
+            order_book: symbol.order_book,
+            ..Default::default()
+        };
+        let runtime_context = RuntimeOrderContext {
+            effective_wallet_exposure_limit: runtime_budget.effective_wallet_exposure_limit,
+        };
+        let wallet_exposure = calc_wallet_exposure(
+            symbol.exchange.c_mult,
+            input.balance,
+            side.position.size.abs(),
+            side.position.price,
+        );
+        let order = match pside {
+            PositionSide::Long => calc_wel_auto_reduce_long(
+                &symbol.exchange,
+                &state,
+                &side.bot_params,
+                &runtime_context,
+                &side.position,
+                wallet_exposure,
+            ),
+            PositionSide::Short => calc_wel_auto_reduce_short(
+                &symbol.exchange,
+                &state,
+                &side.bot_params,
+                &runtime_context,
+                &side.position,
+                wallet_exposure,
+            ),
+        }?;
+        Some(IdealOrder {
+            symbol_idx: symbol.symbol_idx,
+            pside,
+            qty: order.qty,
+            price: order.price,
+            order_type: order.order_type,
+        })
     }
 
     fn generate_strategy_ideal_orders(
@@ -3197,14 +3262,46 @@ mod core {
                     );
                     let params_long = strategy_params_long?;
                     let params_short = strategy_params_short?;
-                    let bands_long =
-                        cached_ema_bands(&mut workspace.derived_long, idx, &s.emas, &params_long)?;
-                    let bands_short = cached_ema_bands(
+                    let bands_long = match cached_ema_bands(
+                        &mut workspace.derived_long,
+                        idx,
+                        &s.emas,
+                        &params_long,
+                    ) {
+                        Ok(value) => value,
+                        Err(err) => {
+                            handle_strategy_input_error(
+                                err,
+                                s,
+                                PositionSide::Long,
+                                StrategyInputScope::OneWayArbitration,
+                                &mut diagnostics,
+                            )?;
+                            workspace.one_way_block_initial_long[idx] = true;
+                            workspace.one_way_block_initial_short[idx] = true;
+                            continue;
+                        }
+                    };
+                    let bands_short = match cached_ema_bands(
                         &mut workspace.derived_short,
                         idx,
                         &s.emas,
                         &params_short,
-                    )?;
+                    ) {
+                        Ok(value) => value,
+                        Err(err) => {
+                            handle_strategy_input_error(
+                                err,
+                                s,
+                                PositionSide::Short,
+                                StrategyInputScope::OneWayArbitration,
+                                &mut diagnostics,
+                            )?;
+                            workspace.one_way_block_initial_long[idx] = true;
+                            workspace.one_way_block_initial_short[idx] = true;
+                            continue;
+                        }
+                    };
 
                     let entry_threshold_long =
                         bands_long.lower * (1.0 - strategy_initial_entry_offset(&params_long));
@@ -3310,13 +3407,25 @@ mod core {
                             wants_closes,
                         ) {
                             Ok(generated) => (entries, closes) = generated,
-                            Err(err) => handle_strategy_input_error(
-                                err,
-                                s,
-                                PositionSide::Long,
-                                StrategyInputScope::StrategyOrders,
-                                &mut diagnostics,
-                            )?,
+                            Err(err) => {
+                                handle_strategy_input_error(
+                                    err,
+                                    s,
+                                    PositionSide::Long,
+                                    StrategyInputScope::StrategyOrders,
+                                    &mut diagnostics,
+                                )?;
+                                if wants_closes {
+                                    if let Some(order) = calc_independent_wel_ideal_order(
+                                        input,
+                                        s,
+                                        PositionSide::Long,
+                                        workspace.runtime_budget_long[s.symbol_idx],
+                                    ) {
+                                        closes.push(order);
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -3402,13 +3511,25 @@ mod core {
                             wants_closes,
                         ) {
                             Ok(generated) => (entries, closes) = generated,
-                            Err(err) => handle_strategy_input_error(
-                                err,
-                                s,
-                                PositionSide::Short,
-                                StrategyInputScope::StrategyOrders,
-                                &mut diagnostics,
-                            )?,
+                            Err(err) => {
+                                handle_strategy_input_error(
+                                    err,
+                                    s,
+                                    PositionSide::Short,
+                                    StrategyInputScope::StrategyOrders,
+                                    &mut diagnostics,
+                                )?;
+                                if wants_closes {
+                                    if let Some(order) = calc_independent_wel_ideal_order(
+                                        input,
+                                        s,
+                                        PositionSide::Short,
+                                        workspace.runtime_budget_short[s.symbol_idx],
+                                    ) {
+                                        closes.push(order);
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/passivbot-rust/src/strategies/mod.rs
+++ b/passivbot-rust/src/strategies/mod.rs
@@ -315,37 +315,62 @@ pub fn strategy_requires_sequential_entry_staging(params: &StrategyParams) -> bo
 }
 
 pub fn strategy_needs_log_range_1m(params: &StrategyParams) -> bool {
+    strategy_needs_log_range_1m_for_request(params, true, true)
+}
+
+pub fn strategy_needs_log_range_1m_for_request(
+    params: &StrategyParams,
+    wants_entries: bool,
+    wants_closes: bool,
+) -> bool {
     match params {
         StrategyParams::TrailingMartingale(params) => {
-            (params.entry.threshold_volatility_1m_weight != 0.0
-                || params.entry.retracement_volatility_1m_weight != 0.0
-                || params.close.threshold_volatility_1m_weight != 0.0
-                || params.close.retracement_volatility_1m_weight != 0.0)
+            ((wants_entries
+                && (params.entry.threshold_volatility_1m_weight != 0.0
+                    || params.entry.retracement_volatility_1m_weight != 0.0))
+                || (wants_closes
+                    && (params.close.threshold_volatility_1m_weight != 0.0
+                        || params.close.retracement_volatility_1m_weight != 0.0)))
                 && params.volatility_ema_span_1m > 0.0
         }
         StrategyParams::EmaAnchor(params) => {
-            params.offset_volatility_1m_weight != 0.0 && params.offset_volatility_ema_span_1m > 0.0
+            (wants_entries || wants_closes)
+                && params.offset_volatility_1m_weight != 0.0
+                && params.offset_volatility_ema_span_1m > 0.0
         }
         StrategyParams::TrailingGridV7(_) => false,
     }
 }
 
 pub fn strategy_needs_log_range_1h(params: &StrategyParams) -> bool {
+    strategy_needs_log_range_1h_for_request(params, true, true)
+}
+
+pub fn strategy_needs_log_range_1h_for_request(
+    params: &StrategyParams,
+    wants_entries: bool,
+    wants_closes: bool,
+) -> bool {
     match params {
         StrategyParams::TrailingMartingale(params) => {
-            (params.entry.threshold_volatility_1h_weight != 0.0
-                || params.entry.retracement_volatility_1h_weight != 0.0
-                || params.close.threshold_volatility_1h_weight != 0.0
-                || params.close.retracement_volatility_1h_weight != 0.0)
+            ((wants_entries
+                && (params.entry.threshold_volatility_1h_weight != 0.0
+                    || params.entry.retracement_volatility_1h_weight != 0.0))
+                || (wants_closes
+                    && (params.close.threshold_volatility_1h_weight != 0.0
+                        || params.close.retracement_volatility_1h_weight != 0.0)))
                 && params.volatility_ema_span_1h > 0.0
         }
         StrategyParams::EmaAnchor(params) => {
-            params.offset_volatility_1h_weight != 0.0 && params.offset_volatility_ema_span_1h > 0.0
+            (wants_entries || wants_closes)
+                && params.offset_volatility_1h_weight != 0.0
+                && params.offset_volatility_ema_span_1h > 0.0
         }
         StrategyParams::TrailingGridV7(params) => {
-            (params.entry.grid_spacing_volatility_weight != 0.0
-                || params.entry.trailing_threshold_volatility_weight != 0.0
-                || params.entry.trailing_retracement_volatility_weight != 0.0)
+            wants_entries
+                && (params.entry.grid_spacing_volatility_weight != 0.0
+                    || params.entry.trailing_threshold_volatility_weight != 0.0
+                    || params.entry.trailing_retracement_volatility_weight != 0.0)
                 && params.entry.volatility_ema_span_hours > 0.0
         }
     }
@@ -377,7 +402,11 @@ pub fn generate_orders(
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_strategy_params, StrategyKind, StrategySide};
+    use super::{
+        parse_strategy_params, strategy_needs_log_range_1h,
+        strategy_needs_log_range_1h_for_request, StrategyKind, StrategyParams, StrategySide,
+        TrailingGridV7Params,
+    };
     use crate::types::BotParams;
     use serde_json::json;
 
@@ -422,5 +451,21 @@ mod tests {
         .expect_err("missing close.trailing_threshold_pct must fail");
 
         assert!(err.contains("trailing_threshold_pct"), "{err}");
+    }
+
+    #[test]
+    fn trailing_grid_v7_entry_volatility_is_not_required_for_close_only_request() {
+        let mut params = TrailingGridV7Params::default();
+        params.entry.grid_spacing_volatility_weight = 1.0;
+        params.entry.volatility_ema_span_hours = 4.0;
+        let params = StrategyParams::TrailingGridV7(params);
+
+        assert!(strategy_needs_log_range_1h(&params));
+        assert!(strategy_needs_log_range_1h_for_request(
+            &params, true, false
+        ));
+        assert!(!strategy_needs_log_range_1h_for_request(
+            &params, false, true
+        ));
     }
 }

--- a/src/live/planning_gates.py
+++ b/src/live/planning_gates.py
@@ -5,7 +5,7 @@ import logging
 import sys
 from typing import Iterable
 
-from live.freshness import ACCOUNT_SURFACES, LIVE_STATE_SURFACES
+from live.freshness import ACCOUNT_SURFACES
 from live.market_snapshot import MarketSnapshot
 from live.events import run_diagnostic_step
 from live.planning_snapshot import PlanningSnapshot
@@ -25,9 +25,9 @@ def staged_planner_required_surfaces(
 ) -> frozenset[str]:
     """Return live input surfaces required before staged order planning may proceed."""
     del bot
-    surfaces = set(LIVE_STATE_SURFACES)
-    if not include_market_snapshot:
-        surfaces.discard("market_snapshot")
+    surfaces = set(ACCOUNT_SURFACES)
+    if include_market_snapshot:
+        surfaces.add("market_snapshot")
     return frozenset(surfaces)
 
 
@@ -41,8 +41,6 @@ def staged_planner_surface_min_epochs(
     for surface in required:
         if surface in ACCOUNT_SURFACES:
             min_epochs[surface] = max(1, int(pending.get(surface, 0) or 0))
-        elif surface in {"completed_candles", "market_snapshot"}:
-            min_epochs[surface] = current_epoch
         else:
             min_epochs[surface] = current_epoch
     return min_epochs
@@ -66,32 +64,6 @@ def staged_planner_precondition_state(
         if ledger.surface_epoch(surface) < int(min_epochs.get(surface, 0) or 0)
     )
     invalid: dict[str, list] = {}
-    if "completed_candles" in required and "completed_candles" not in missing:
-        expected_symbols = tuple(bot._urgent_active_candle_symbols())
-        candle_check_ms = ledger.surface_updated_ms(
-            "completed_candles"
-        ) or bot._completed_candle_health_now_ms()
-        signature, candle_missing = bot._completed_candle_freshness_signature(
-            expected_symbols, now_ms=candle_check_ms
-        )
-        stamped_signature = ledger.surface_signature("completed_candles")
-        equivalent = (
-            bot._completed_candle_signatures_equivalent(
-                signature,
-                stamped_signature,
-            )
-            if hasattr(bot, "_completed_candle_signatures_equivalent")
-            else stamped_signature == signature
-        )
-        if candle_missing or not equivalent:
-            missing.append("completed_candles")
-            invalid["completed_candles"] = candle_missing or (
-                bot._completed_candle_signature_mismatch_details(
-                    expected_symbols=expected_symbols,
-                    expected_signature=signature,
-                    stamped_signature=stamped_signature,
-                )
-            )
     if (
         include_market_snapshot
         and "market_snapshot" in required

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -18599,6 +18599,15 @@ class Passivbot:
                     type(exc).__name__,
                     interval_ms=15 * 60 * 1000,
                 )
+                if isinstance(exc, (TimeoutError, RuntimeError)):
+                    missing = [
+                        (float(span), f"{type(exc).__name__}: projection unavailable")
+                        for span in sorted(need_close_spans[sym])
+                    ]
+                    detail = "; ".join(
+                        [f"span={span:.8g} reason={reason}" for span, reason in missing]
+                    )
+                    raise MissingCloseEma(sym, missing, detail) from exc
                 raise
             close = dict(projected.get("close", {}))
             if is_forager_mode() and not project_strategy_log_range:
@@ -18623,26 +18632,59 @@ class Passivbot:
                     ),
                     "m1_log_range",
                 )
-            missing_close = [
+            nonfinite_close = [
                 span
                 for span in sorted(need_close_spans[sym])
-                if span not in close or not math.isfinite(float(close[span]))
+                if span in close and not math.isfinite(float(close[span]))
+            ]
+            if nonfinite_close:
+                raise RuntimeError(
+                    "[ema] non-finite projected open-tail close EMA for "
+                    f"{sym}: spans={','.join(f'{span:.8g}' for span in nonfinite_close)}"
+                )
+            missing_close = [
+                span for span in sorted(need_close_spans[sym]) if span not in close
             ]
             if missing_close:
-                raise RuntimeError(
-                    "[ema] projected open-tail close EMA incomplete for "
-                    f"{sym}: spans={','.join(f'{span:.8g}' for span in missing_close)}"
+                missing = [
+                    (float(span), "projected close EMA missing")
+                    for span in missing_close
+                ]
+                detail = "; ".join(
+                    [f"span={span:.8g} reason={reason}" for span, reason in missing]
                 )
+                raise MissingCloseEma(sym, missing, detail)
             if not is_forager_mode() or project_strategy_log_range:
+                projected_lr1m = projected.get("log_range", {}) or {}
+                nonfinite_required_lr1m = [
+                    span
+                    for span in required_m1_lr_for_symbol
+                    if span in projected_lr1m
+                    and not math.isfinite(float(projected_lr1m[span]))
+                ]
+                if nonfinite_required_lr1m:
+                    raise RuntimeError(
+                        "[ema] non-finite projected open-tail m1 log-range EMA for "
+                        f"{sym}: spans={','.join(f'{span:.8g}' for span in nonfinite_required_lr1m)}"
+                    )
                 missing_required_lr1m = [
                     span
                     for span in required_m1_lr_for_symbol
-                    if span not in lr1m or not math.isfinite(float(lr1m[span]))
+                    if span not in projected_lr1m
                 ]
                 if missing_required_lr1m:
-                    raise RuntimeError(
-                        "[ema] projected open-tail m1 log-range EMA incomplete for "
-                        f"{sym}: spans={','.join(f'{span:.8g}' for span in missing_required_lr1m)}"
+                    missing = [
+                        (float(span), "projected m1 log-range EMA missing")
+                        for span in missing_required_lr1m
+                    ]
+                    detail = "; ".join(
+                        [
+                            f"span={span:.8g} reason={reason}"
+                            for span, reason in missing
+                        ]
+                    )
+                    raise MissingRequiredEma(
+                        sym, "m1_log_range", missing, detail
                     )
             self._orchestrator_ema_projection_symbols.add(sym)
             self._orchestrator_ema_projection_details[sym] = dict(projection_ctx)
@@ -18693,15 +18735,29 @@ class Passivbot:
             lr1m: Optional[dict[float, float]] = None
             h1: dict[float, float] = {}
             forager_lr1m: Optional[dict[float, float]] = None
+            input_unavailability: list[Exception] = []
+
+            def collect_input_unavailability(exc: Exception) -> bool:
+                if not isinstance(exc, (MissingCloseEma, MissingRequiredEma)):
+                    return False
+                if exc.contains_non_finite:
+                    return False
+                input_unavailability.append(exc)
+                return True
+
             try:
                 projection_ctx = projection_contexts.get(sym)
                 if projection_ctx is not None:
-                    close, vol, lr1m = await load_projected_open_tail_bundle(
-                        sym,
-                        projection_ctx,
-                        required_m1_lr_for_symbol,
-                        requested_m1_lr_spans,
-                    )
+                    try:
+                        close, vol, lr1m = await load_projected_open_tail_bundle(
+                            sym,
+                            projection_ctx,
+                            required_m1_lr_for_symbol,
+                            requested_m1_lr_spans,
+                        )
+                    except Exception as exc:
+                        if not collect_input_unavailability(exc):
+                            raise
                 else:
                     try:
                         close = await fetch_close_map(
@@ -18713,20 +18769,35 @@ class Passivbot:
                         ) or refresh_open_tail_projection_context(sym)
                         if late_projection_ctx is None:
                             log_missing_close_ema(sym, exc.missing)
-                            raise
-                        close, vol, lr1m = await load_projected_open_tail_bundle(
-                            sym,
-                            late_projection_ctx,
-                            required_m1_lr_for_symbol,
-                            requested_m1_lr_spans,
-                        )
+                            if not collect_input_unavailability(exc):
+                                raise
+                        else:
+                            try:
+                                close, vol, lr1m = (
+                                    await load_projected_open_tail_bundle(
+                                        sym,
+                                        late_projection_ctx,
+                                        required_m1_lr_for_symbol,
+                                        requested_m1_lr_spans,
+                                    )
+                                )
+                            except Exception as projection_exc:
+                                if not collect_input_unavailability(projection_exc):
+                                    raise
                     else:
                         vol = None
                         lr1m = None
                 Passivbot._raise_if_shutdown_requested(self, "orchestrator_ema_bundle")
-                h1 = await fetch_required_map(
-                    sym, sorted(need_h1_lr_spans[sym]), ema_lr_1h, "h1_log_range"
-                )
+                try:
+                    h1 = await fetch_required_map(
+                        sym,
+                        sorted(need_h1_lr_spans[sym]),
+                        ema_lr_1h,
+                        "h1_log_range",
+                    )
+                except Exception as exc:
+                    if not collect_input_unavailability(exc):
+                        raise
                 Passivbot._raise_if_shutdown_requested(self, "orchestrator_ema_bundle")
                 if vol is None:
                     vol = await fetch_map(sym, m1_volume_spans, ema_qv, "m1_volume")
@@ -18740,9 +18811,13 @@ class Passivbot:
                             "m1_log_range",
                             log_on_missing=False,
                         )
-                    except Exception:
+                    except Exception as exc:
+                        if not isinstance(exc, MissingRequiredEma):
+                            raise
                         late_projection_ctx = refresh_open_tail_projection_context(sym)
                         if late_projection_ctx is None:
+                            if exc.contains_non_finite:
+                                raise
                             log_ema_issue(
                                 ("required_missing", sym, "m1_log_range"),
                                 required_ema_log_level(sym),
@@ -18756,22 +18831,32 @@ class Passivbot:
                                     sym, "m1_log_range", required_m1_lr_for_symbol
                                 ),
                             )
-                            raise
-                        projected_close, projected_vol, projected_lr1m = (
-                            await load_projected_open_tail_bundle(
-                                sym,
-                                late_projection_ctx,
-                                required_m1_lr_for_symbol,
-                                requested_m1_lr_spans,
-                            )
-                        )
-                        close = projected_close
-                        if projected_vol is not None:
-                            vol = projected_vol
-                        if projected_lr1m is not None:
-                            lr1m = projected_lr1m
-                        else:
+                            collect_input_unavailability(exc)
                             lr1m = {}
+                        else:
+                            try:
+                                projected_close, projected_vol, projected_lr1m = (
+                                    await load_projected_open_tail_bundle(
+                                        sym,
+                                        late_projection_ctx,
+                                        required_m1_lr_for_symbol,
+                                        requested_m1_lr_spans,
+                                    )
+                                )
+                            except Exception as projection_exc:
+                                if exc.contains_non_finite:
+                                    raise exc
+                                if not collect_input_unavailability(projection_exc):
+                                    raise
+                                lr1m = {}
+                            else:
+                                close = projected_close
+                                if projected_vol is not None:
+                                    vol = projected_vol
+                                if projected_lr1m is not None:
+                                    lr1m = projected_lr1m
+                                else:
+                                    lr1m = {}
                     else:
                         optional_lr1m = await fetch_map(
                             sym,
@@ -18799,6 +18884,8 @@ class Passivbot:
                     }
                 if forager_lr1m is None:
                     forager_lr1m = {}
+                if input_unavailability:
+                    raise input_unavailability[0]
             except Exception as exc:
                 if not required_ema_can_mark_nontradable(sym):
                     if isinstance(exc, (MissingCloseEma, MissingRequiredEma)):

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -18764,6 +18764,8 @@ class Passivbot:
                             sym, sorted(need_close_spans[sym]), log_on_missing=False
                         )
                     except MissingCloseEma as exc:
+                        if exc.contains_non_finite:
+                            raise
                         late_projection_ctx = projection_contexts.get(
                             sym
                         ) or refresh_open_tail_projection_context(sym)
@@ -18814,10 +18816,10 @@ class Passivbot:
                     except Exception as exc:
                         if not isinstance(exc, MissingRequiredEma):
                             raise
+                        if exc.contains_non_finite:
+                            raise
                         late_projection_ctx = refresh_open_tail_projection_context(sym)
                         if late_projection_ctx is None:
-                            if exc.contains_non_finite:
-                                raise
                             log_ema_issue(
                                 ("required_missing", sym, "m1_log_range"),
                                 required_ema_log_level(sym),
@@ -18844,8 +18846,6 @@ class Passivbot:
                                     )
                                 )
                             except Exception as projection_exc:
-                                if exc.contains_non_finite:
-                                    raise exc
                                 if not collect_input_unavailability(projection_exc):
                                     raise
                                 lr1m = {}

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -18216,6 +18216,10 @@ class Passivbot:
                 self.ema_type = ema_type
                 self.missing = list(missing)
                 self.detail = detail
+                self.contains_non_finite = any(
+                    "non-finite" in str(reason).lower()
+                    for _span, reason in self.missing
+                )
 
         class MissingCloseEma(RuntimeError):
             def __init__(
@@ -18231,6 +18235,10 @@ class Passivbot:
                 self.symbol = symbol
                 self.missing = list(missing)
                 self.detail = detail
+                self.contains_non_finite = any(
+                    "non-finite" in str(reason).lower()
+                    for _span, reason in self.missing
+                )
 
         def close_ema_reason_detail(reason: str) -> tuple[str, str]:
             if str(reason).startswith("non-finite close EMA value"):
@@ -18794,6 +18802,8 @@ class Passivbot:
             except Exception as exc:
                 if not required_ema_can_mark_nontradable(sym):
                     if isinstance(exc, (MissingCloseEma, MissingRequiredEma)):
+                        if exc.contains_non_finite:
+                            raise
                         self._orchestrator_allow_missing_strategy_inputs_symbols.add(
                             sym
                         )
@@ -19536,7 +19546,9 @@ class Passivbot:
             input_hash=input_hash,
             symbol_count=len(input_dict["symbols"]),
             tradable_count=int(tradable_count),
-            ema_unavailable_count=len(ema_unavailable_symbols),
+            ema_unavailable_count=len(
+                ema_unavailable_symbols | allow_missing_strategy_inputs_symbols
+            ),
             trailing_unavailable_count=len(trailing_unavailable_symbols),
             hedge_mode=bool(effective_hedge_mode),
             strategy_kind=strategy_kind,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -17163,6 +17163,7 @@ class Passivbot:
         self._orchestrator_ema_bundle_symbols = set()
         self._orchestrator_forager_m1_log_range_emas = {}
         self._orchestrator_ema_unavailable_symbols = set()
+        self._orchestrator_allow_missing_strategy_inputs_symbols = set()
         self._orchestrator_candidate_ema_unavailable_symbols = set()
         self._orchestrator_ema_unavailable_reasons = {}
         previous_ema_entry_cancellation_order_keys = set(
@@ -18679,6 +18680,10 @@ class Passivbot:
             requested_m1_lr_spans = sorted(
                 set(m1_lr_spans) | set(required_m1_lr_for_symbol)
             )
+            close: dict[float, float] = {}
+            vol: Optional[dict[float, float]] = None
+            lr1m: Optional[dict[float, float]] = None
+            h1: dict[float, float] = {}
             forager_lr1m: Optional[dict[float, float]] = None
             try:
                 projection_ctx = projection_contexts.get(sym)
@@ -18788,6 +18793,26 @@ class Passivbot:
                     forager_lr1m = {}
             except Exception as exc:
                 if not required_ema_can_mark_nontradable(sym):
+                    if isinstance(exc, (MissingCloseEma, MissingRequiredEma)):
+                        self._orchestrator_allow_missing_strategy_inputs_symbols.add(
+                            sym
+                        )
+                        log_ema_issue(
+                            ("strategy_inputs_unavailable", sym),
+                            logging.WARNING,
+                            "[ema] strategy inputs unavailable %s action=scope_consumers_in_rust error_type=%s | %s",
+                            Passivbot._log_symbol(sym),
+                            ema_error_type(exc),
+                            ema_candle_health_context(sym),
+                            interval_ms=15 * 60 * 1000,
+                        )
+                        return (
+                            close,
+                            vol or {},
+                            lr1m or {},
+                            h1,
+                            forager_lr1m or {},
+                        )
                     raise
                 if sym in cache_only_symbols:
                     reason = "cache_only_fetch_failed"
@@ -19304,6 +19329,13 @@ class Passivbot:
         ema_unavailable_symbols = set(
             getattr(self, "_orchestrator_ema_unavailable_symbols", set())
         )
+        allow_missing_strategy_inputs_symbols = set(
+            getattr(
+                self,
+                "_orchestrator_allow_missing_strategy_inputs_symbols",
+                set(),
+            )
+        )
         forager_m1_log_range_emas = getattr(
             self, "_orchestrator_forager_m1_log_range_emas", {}
         )
@@ -19469,6 +19501,9 @@ class Passivbot:
                     "order_book": {"bid": bid, "ask": ask},
                     "exchange": Passivbot._orchestrator_exchange_params(self, symbol),
                     "tradable": tradable,
+                    "allow_missing_strategy_inputs": (
+                        symbol in allow_missing_strategy_inputs_symbols
+                    ),
                     "next_candle": None,
                     "effective_min_cost": float(effective_min_cost),
                     "emas": {
@@ -21031,7 +21066,7 @@ class Passivbot:
                 Passivbot._log_active_candle_refresh_incomplete(
                     self, ordered_symbols, missing
                 )
-                return False
+                return True
             self._ensure_freshness_ledger().stamp(
                 "completed_candles",
                 signature,

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -1357,7 +1357,7 @@ async def test_orchestrator_ema_bundle_projection_context_summary_is_debug(
         ):
             if tf == "1h":
                 return 0.01
-            return float("nan")
+            raise TimeoutError("m1 log range unavailable")
 
         async def get_latest_cached_ema_metrics(
             self,

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -270,7 +270,7 @@ async def test_active_candle_refresh_ignores_broad_graceful_stop_universe(monkey
 
 
 @pytest.mark.asyncio
-async def test_active_candle_refresh_does_not_stamp_when_rate_limited(monkeypatch):
+async def test_active_candle_refresh_does_not_block_planning_when_rate_limited(monkeypatch):
     import passivbot as pb_mod
 
     now_ms = 10_000_000
@@ -330,7 +330,7 @@ async def test_active_candle_refresh_does_not_stamp_when_rate_limited(monkeypatc
 
     bot = FakeBot()
 
-    assert await pb_mod.Passivbot.update_ohlcvs_1m_for_actives(bot) is False
+    assert await pb_mod.Passivbot.update_ohlcvs_1m_for_actives(bot) is True
     assert stamps == []
 
 
@@ -1274,19 +1274,23 @@ async def test_orchestrator_ema_bundle_marks_flat_forager_candidate_required_m1_
     bot_active = FakeBot()
     bot_active.PB_modes = {"long": {symbol: "normal"}, "short": {}}
     bot_active.active_symbols = [symbol]
-    with pytest.raises(RuntimeError, match="missing required m1_log_range EMA"):
-        await pb_mod.Passivbot._load_orchestrator_ema_bundle(
-            bot_active, [symbol], modes=bot_active.PB_modes
-        )
+    active_result = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+        bot_active, [symbol], modes=bot_active.PB_modes
+    )
+    assert active_result[2][symbol] == {}
+    assert bot_active._orchestrator_allow_missing_strategy_inputs_symbols == {symbol}
 
     bot_with_position = FakeBot()
     bot_with_position.positions = {
         symbol: {"long": {"size": 1.0}, "short": {"size": 0.0}}
     }
-    with pytest.raises(RuntimeError, match="missing required m1_log_range EMA"):
-        await pb_mod.Passivbot._load_orchestrator_ema_bundle(
-            bot_with_position, [symbol], modes=bot_with_position.PB_modes
-        )
+    held_result = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+        bot_with_position, [symbol], modes=bot_with_position.PB_modes
+    )
+    assert held_result[2][symbol] == {}
+    assert bot_with_position._orchestrator_allow_missing_strategy_inputs_symbols == {
+        symbol
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -1274,6 +1274,11 @@ async def test_orchestrator_ema_bundle_marks_flat_forager_candidate_required_m1_
     bot_active = FakeBot()
     bot_active.PB_modes = {"long": {symbol: "normal"}, "short": {}}
     bot_active.active_symbols = [symbol]
+
+    async def unavailable_log_range(*args, **kwargs):
+        raise TimeoutError("log range unavailable")
+
+    bot_active.cm.get_latest_ema_log_range = unavailable_log_range
     active_result = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
         bot_active, [symbol], modes=bot_active.PB_modes
     )
@@ -1284,6 +1289,7 @@ async def test_orchestrator_ema_bundle_marks_flat_forager_candidate_required_m1_
     bot_with_position.positions = {
         symbol: {"long": {"size": 1.0}, "short": {"size": 0.0}}
     }
+    bot_with_position.cm.get_latest_ema_log_range = unavailable_log_range
     held_result = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
         bot_with_position, [symbol], modes=bot_with_position.PB_modes
     )

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -448,6 +448,8 @@ class _BundleReproBot:
                     raise TimeoutError("kucoinfutures GET ... RequestTimeout")
                 if self.outer.close_mode == "nan":
                     return float("nan")
+                if self.outer.close_mode == "inf":
+                    return float("inf")
                 return float(self.outer.close_value)
 
             async def get_latest_ema_quote_volume(
@@ -484,6 +486,8 @@ class _BundleReproBot:
                         raise TimeoutError("kucoinfutures GET ... RequestTimeout")
                     if self.outer.h1_mode == "nan":
                         return float("nan")
+                    if self.outer.h1_mode == "inf":
+                        return float("inf")
                     return float(self.outer.h1_log_range_value)
                 if self.outer.lr1m_mode == "timeout":
                     raise TimeoutError("log range timeout")
@@ -661,8 +665,7 @@ class _BundleReproBot:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("close_mode", ["timeout", "nan"])
-async def test_held_symbol_missing_ema_is_explicitly_scoped_for_rust(close_mode):
+async def test_held_symbol_missing_ema_is_explicitly_scoped_for_rust():
     try:
         import passivbot as pb_mod
         import passivbot_rust as pbr
@@ -673,7 +676,7 @@ async def test_held_symbol_missing_ema_is_explicitly_scoped_for_rust(close_mode)
         pytest.skip("requires real passivbot_rust extension")
 
     symbol = "AVAX/USDT:USDT"
-    bot = _BundleReproBot(symbol, close_mode=close_mode)
+    bot = _BundleReproBot(symbol, close_mode="timeout")
     (
         m1_close_emas,
         m1_volume_emas,
@@ -701,6 +704,23 @@ async def test_held_symbol_missing_ema_is_explicitly_scoped_for_rust(close_mode)
 
     with pytest.raises(ValueError, match=r"orchestrator compute_ideal_orders failed: MissingEma \{ symbol_idx: 0 \}"):
         pbr.compute_ideal_orders_json(json.dumps(payload))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("close_mode", ["nan", "inf"])
+async def test_held_symbol_nonfinite_close_ema_remains_fatal(close_mode):
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    symbol = "AVAX/USDT:USDT"
+    bot = _BundleReproBot(symbol, close_mode=close_mode)
+
+    with pytest.raises(RuntimeError, match="non-finite close EMA value"):
+        await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+            bot, [symbol], bot.PB_modes
+        )
 
 
 @pytest.mark.asyncio
@@ -795,7 +815,7 @@ async def test_mixed_forager_fixed_normal_side_missing_ema_is_scoped_in_rust():
         pytest.skip("passivbot module not importable in test environment")
 
     symbol = "BTC/USDT:USDT"
-    bot = _BundleReproBot(symbol, close_mode="nan")
+    bot = _BundleReproBot(symbol, close_mode="timeout")
     bot.PB_modes = {"long": {symbol: "normal"}, "short": {symbol: "normal"}}
     bot.active_symbols = [symbol]
     bot.open_orders = {
@@ -2442,8 +2462,31 @@ async def test_batched_ema_failure_retries_each_span_before_carry_forward(monkey
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("h1_mode", ["timeout", "nan"])
-async def test_required_h1_log_range_ema_is_scoped_when_missing(h1_mode):
+async def test_required_h1_log_range_ema_is_scoped_when_missing():
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    symbol = "AVAX/USDT:USDT"
+    bot = _BundleReproBot(
+        symbol,
+        close_mode="value",
+        h1_mode="timeout",
+        entry_h1_span_hours=4.0,
+    )
+    result = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+        bot, [symbol], bot.PB_modes
+    )
+
+    assert result[0][symbol]
+    assert result[3][symbol] == {}
+    assert bot._orchestrator_allow_missing_strategy_inputs_symbols == {symbol}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("h1_mode", ["nan", "inf"])
+async def test_required_h1_log_range_nonfinite_output_remains_fatal(h1_mode):
     try:
         import passivbot as pb_mod
     except ImportError:
@@ -2456,13 +2499,11 @@ async def test_required_h1_log_range_ema_is_scoped_when_missing(h1_mode):
         h1_mode=h1_mode,
         entry_h1_span_hours=4.0,
     )
-    result = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
-        bot, [symbol], bot.PB_modes
-    )
 
-    assert result[0][symbol]
-    assert result[3][symbol] == {}
-    assert bot._orchestrator_allow_missing_strategy_inputs_symbols == {symbol}
+    with pytest.raises(RuntimeError, match="non-finite h1_log_range value"):
+        await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+            bot, [symbol], bot.PB_modes
+        )
 
 
 @pytest.mark.asyncio
@@ -2637,7 +2678,7 @@ async def test_trailing_grid_v7_grid_spacing_h1_missing_is_scoped_in_rust():
     bot = _BundleReproBot(
         symbol,
         close_mode="value",
-        h1_mode="nan",
+        h1_mode="timeout",
         entry_h1_span_hours=0.0,
     )
     bot.config = {

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -2043,7 +2043,7 @@ async def test_open_tail_projection_precedes_previous_close_ema_fallback():
 
 
 @pytest.mark.asyncio
-async def test_late_open_tail_projection_recovers_required_close_ema(caplog):
+async def test_late_open_tail_projection_does_not_mask_nonfinite_close_ema():
     try:
         import passivbot as pb_mod
     except ImportError:
@@ -2062,38 +2062,18 @@ async def test_late_open_tail_projection_recovers_required_close_ema(caplog):
     )
     bot.projected_open_tail_called = False
 
-    with caplog.at_level(logging.WARNING):
-        (
-            m1_close_emas,
-            m1_volume_emas,
-            m1_log_range_emas,
-            _h1_log_range_emas,
-            volumes_long,
-            log_ranges_long,
-        ) = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+    with pytest.raises(RuntimeError, match="non-finite close EMA value"):
+        await pb_mod.Passivbot._load_orchestrator_ema_bundle(
             bot, [symbol], bot.PB_modes
         )
 
     assert bot.completed_candle_health_calls >= 2
-    assert bot.projected_open_tail_called is True
-    got = m1_close_emas[symbol]
-    assert got[span0] == pytest.approx(projected[span0])
-    assert got[span1] == pytest.approx(projected[span1])
-    assert got[span2] == pytest.approx(projected[span2])
-    assert m1_volume_emas[symbol][10.0] == pytest.approx(250000.0)
-    assert m1_log_range_emas[symbol][10.0] == pytest.approx(0.0015)
-    assert volumes_long[symbol] == pytest.approx(250000.0)
-    assert log_ranges_long[symbol] == pytest.approx(0.0015)
+    assert bot.projected_open_tail_called is False
     assert bot._orchestrator_close_ema_fallback_counts == {}
-    assert bot._orchestrator_ema_projection_details[symbol]["tail_gap_age_ms"] == 60_000
-    warning_messages = [
-        record.message for record in caplog.records if record.levelno >= logging.WARNING
-    ]
-    assert not any("missing required close EMA" in message for message in warning_messages)
 
 
 @pytest.mark.asyncio
-async def test_late_open_tail_projection_precedes_available_previous_close_ema():
+async def test_nonfinite_close_ema_is_fatal_before_projection_or_previous_fallback():
     try:
         import passivbot as pb_mod
     except ImportError:
@@ -2114,25 +2094,18 @@ async def test_late_open_tail_projection_precedes_available_previous_close_ema()
     )
     bot.projected_open_tail_called = False
 
-    (
-        m1_close_emas,
-        _m1_volume_emas,
-        _m1_log_range_emas,
-        _h1_log_range_emas,
-        _volumes_long,
-        _log_ranges_long,
-    ) = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
-        bot, [symbol], bot.PB_modes
-    )
+    with pytest.raises(RuntimeError, match="non-finite close EMA value"):
+        await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+            bot, [symbol], bot.PB_modes
+        )
 
     assert bot.completed_candle_health_calls >= 2
-    assert bot.projected_open_tail_called is True
-    assert m1_close_emas[symbol] == pytest.approx(projected)
+    assert bot.projected_open_tail_called is False
     assert bot._orchestrator_close_ema_fallback_counts == {}
 
 
 @pytest.mark.asyncio
-async def test_late_open_tail_projection_recovers_required_m1_log_range():
+async def test_late_open_tail_projection_does_not_mask_nonfinite_m1_log_range():
     try:
         import passivbot as pb_mod
     except ImportError:
@@ -2153,21 +2126,13 @@ async def test_late_open_tail_projection_recovers_required_m1_log_range():
     )
     bot.projected_open_tail_called = False
 
-    (
-        m1_close_emas,
-        _m1_volume_emas,
-        m1_log_range_emas,
-        _h1_log_range_emas,
-        _volumes_long,
-        log_ranges_long,
-    ) = await pb_mod.Passivbot._load_orchestrator_ema_bundle(bot, [symbol], bot.PB_modes)
+    with pytest.raises(RuntimeError, match="non-finite m1_log_range value"):
+        await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+            bot, [symbol], bot.PB_modes
+        )
 
-    assert bot.completed_candle_health_calls >= 2
-    assert bot.projected_open_tail_called is True
-    assert m1_close_emas[symbol][span0] == pytest.approx(201.0)
-    assert m1_log_range_emas[symbol][60.0] == pytest.approx(0.0042)
-    assert log_ranges_long[symbol] == pytest.approx(0.0015)
-    assert bot._orchestrator_ema_projection_details[symbol]["tail_gap_age_ms"] == 60_000
+    assert bot.completed_candle_health_calls == 1
+    assert bot.projected_open_tail_called is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -689,8 +689,8 @@ async def test_held_symbol_missing_ema_is_explicitly_scoped_for_rust():
     )
 
     assert m1_close_emas[symbol] == {}
-    assert m1_volume_emas[symbol] == {}
-    assert m1_log_range_emas[symbol] == {}
+    assert m1_volume_emas[symbol][10.0] == pytest.approx(250000.0)
+    assert m1_log_range_emas[symbol][10.0] == pytest.approx(0.0015)
     assert h1_log_range_emas[symbol] == {}
     assert bot._orchestrator_allow_missing_strategy_inputs_symbols == {symbol}
     assert bot._orchestrator_ema_unavailable_symbols == set()
@@ -2213,7 +2213,7 @@ async def test_open_tail_projection_missing_optional_metrics_are_diagnostic(capl
 
 
 @pytest.mark.asyncio
-async def test_open_tail_projection_missing_close_span_fails_loudly():
+async def test_open_tail_projection_missing_close_span_scopes_only_its_consumers():
     try:
         import passivbot as pb_mod
     except ImportError:
@@ -2234,13 +2234,49 @@ async def test_open_tail_projection_missing_close_span_fails_loudly():
     }
     bot._orchestrator_ema_bundle_completed = True
 
-    with pytest.raises(RuntimeError, match="projected open-tail close EMA incomplete"):
-        await pb_mod.Passivbot._load_orchestrator_ema_bundle(bot, [symbol], bot.PB_modes)
+    (
+        m1_close_emas,
+        m1_volume_emas,
+        m1_log_range_emas,
+        _h1_log_range_emas,
+        _volumes_long,
+        _log_ranges_long,
+    ) = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+        bot, [symbol], bot.PB_modes
+    )
 
     assert bot._orchestrator_candidate_ema_unavailable_symbols == set()
     assert bot._orchestrator_ema_unavailable_symbols == set()
     assert bot._orchestrator_ema_unavailable_reasons == {}
-    assert bot._orchestrator_ema_bundle_completed is False
+    assert bot._orchestrator_ema_bundle_completed is True
+    assert bot._orchestrator_allow_missing_strategy_inputs_symbols == {symbol}
+    assert m1_close_emas[symbol] == {}
+    assert m1_volume_emas[symbol][10.0] == pytest.approx(250000.0)
+    assert m1_log_range_emas[symbol][10.0] == pytest.approx(0.0015)
+
+
+@pytest.mark.asyncio
+async def test_open_tail_projection_nonfinite_close_remains_fatal():
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    symbol = "AVAX/USDT:USDT"
+    span0 = 10.0
+    span1 = 20.0
+    span2 = (span0 * span1) ** 0.5
+    bot = _BundleReproBot(
+        symbol,
+        close_mode="timeout",
+        project_open_tail=True,
+        projected_close_ema={span0: float("nan"), span1: 202.0, span2: 203.0},
+    )
+
+    with pytest.raises(RuntimeError, match="non-finite projected open-tail close EMA"):
+        await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+            bot, [symbol], bot.PB_modes
+        )
 
 
 @pytest.mark.asyncio
@@ -2260,10 +2296,9 @@ async def test_open_tail_projection_failure_log_omits_exception_text(caplog):
     )
 
     with caplog.at_level(logging.WARNING):
-        with pytest.raises(TimeoutError, match="private.example"):
-            await pb_mod.Passivbot._load_orchestrator_ema_bundle(
-                bot, [symbol], bot.PB_modes
-            )
+        result = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+            bot, [symbol], bot.PB_modes
+        )
 
     messages = [record.message for record in caplog.records]
     assert any(
@@ -2273,6 +2308,10 @@ async def test_open_tail_projection_failure_log_omits_exception_text(caplog):
     )
     assert all(secret not in message for message in messages)
     assert all("projection-secret" not in message for message in messages)
+    assert result[0][symbol] == {}
+    assert result[1][symbol][10.0] == pytest.approx(250000.0)
+    assert result[2][symbol][10.0] == pytest.approx(0.0015)
+    assert bot._orchestrator_allow_missing_strategy_inputs_symbols == {symbol}
 
 
 @pytest.mark.asyncio
@@ -2474,12 +2513,15 @@ async def test_required_h1_log_range_ema_is_scoped_when_missing():
         close_mode="value",
         h1_mode="timeout",
         entry_h1_span_hours=4.0,
+        entry_m1_weight=1.0,
     )
     result = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
         bot, [symbol], bot.PB_modes
     )
 
     assert result[0][symbol]
+    assert result[1][symbol][10.0] == pytest.approx(250000.0)
+    assert result[2][symbol][10.0] == pytest.approx(0.0015)
     assert result[3][symbol] == {}
     assert bot._orchestrator_allow_missing_strategy_inputs_symbols == {symbol}
 

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -662,7 +662,7 @@ class _BundleReproBot:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("close_mode", ["timeout", "nan"])
-async def test_kucoin_avax_bundle_drop_reproduces_missing_ema_symbol_idx_0(close_mode):
+async def test_held_symbol_missing_ema_is_explicitly_scoped_for_rust(close_mode):
     try:
         import passivbot as pb_mod
         import passivbot_rust as pbr
@@ -674,10 +674,23 @@ async def test_kucoin_avax_bundle_drop_reproduces_missing_ema_symbol_idx_0(close
 
     symbol = "AVAX/USDT:USDT"
     bot = _BundleReproBot(symbol, close_mode=close_mode)
-    with pytest.raises(
-        RuntimeError, match=r"missing required close EMA for AVAX/USDT:USDT"
-    ):
-        await pb_mod.Passivbot._load_orchestrator_ema_bundle(bot, [symbol], bot.PB_modes)
+    (
+        m1_close_emas,
+        m1_volume_emas,
+        m1_log_range_emas,
+        h1_log_range_emas,
+        _volumes_long,
+        _log_ranges_long,
+    ) = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+        bot, [symbol], bot.PB_modes
+    )
+
+    assert m1_close_emas[symbol] == {}
+    assert m1_volume_emas[symbol] == {}
+    assert m1_log_range_emas[symbol] == {}
+    assert h1_log_range_emas[symbol] == {}
+    assert bot._orchestrator_allow_missing_strategy_inputs_symbols == {symbol}
+    assert bot._orchestrator_ema_unavailable_symbols == set()
 
     payload = _make_orchestrator_payload(
         symbol,
@@ -775,7 +788,7 @@ async def test_forager_eligible_flat_normal_missing_close_ema_marks_unavailable(
 
 
 @pytest.mark.asyncio
-async def test_mixed_forager_fixed_normal_side_missing_ema_remains_strict():
+async def test_mixed_forager_fixed_normal_side_missing_ema_is_scoped_in_rust():
     try:
         import passivbot as pb_mod
     except ImportError:
@@ -804,13 +817,13 @@ async def test_mixed_forager_fixed_normal_side_missing_ema_remains_strict():
     bot.is_forager_mode = lambda pside=None: pside in {None, "long"}
     mode_overrides = {"long": {symbol: None}, "short": {symbol: None}}
 
-    with pytest.raises(
-        RuntimeError, match=r"missing required close EMA for BTC/USDT:USDT"
-    ):
-        await pb_mod.Passivbot._load_orchestrator_ema_bundle(
-            bot, [symbol], mode_overrides
-        )
+    result = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+        bot, [symbol], mode_overrides
+    )
 
+    assert result[0][symbol] == {}
+    assert bot._orchestrator_allow_missing_strategy_inputs_symbols == {symbol}
+    assert bot._orchestrator_ema_unavailable_symbols == set()
     assert bot._orchestrator_ema_entry_cancellation_order_keys == set()
 
 
@@ -2277,7 +2290,7 @@ async def test_cached_forager_ema_failure_log_omits_exception_text(caplog):
 
 
 @pytest.mark.asyncio
-async def test_close_ema_fallback_raises_when_previous_ema_is_stale(caplog):
+async def test_close_ema_fallback_scopes_symbol_when_previous_ema_is_stale(caplog):
     try:
         import passivbot as pb_mod
     except ImportError:
@@ -2297,9 +2310,12 @@ async def test_close_ema_fallback_raises_when_previous_ema_is_stale(caplog):
     bot.config = {"live": {"max_forager_candle_staleness_minutes": 10}}
 
     with caplog.at_level(logging.WARNING):
-        with pytest.raises(RuntimeError, match="previous close EMA stale"):
-            await pb_mod.Passivbot._load_orchestrator_ema_bundle(bot, [symbol], bot.PB_modes)
+        result = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+            bot, [symbol], bot.PB_modes
+        )
 
+    assert result[0][symbol] == {}
+    assert bot._orchestrator_allow_missing_strategy_inputs_symbols == {symbol}
     stale_warnings = [
         record.message
         for record in caplog.records
@@ -2427,7 +2443,7 @@ async def test_batched_ema_failure_retries_each_span_before_carry_forward(monkey
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("h1_mode", ["timeout", "nan"])
-async def test_required_h1_log_range_ema_raises_when_missing(h1_mode):
+async def test_required_h1_log_range_ema_is_scoped_when_missing(h1_mode):
     try:
         import passivbot as pb_mod
     except ImportError:
@@ -2440,8 +2456,13 @@ async def test_required_h1_log_range_ema_raises_when_missing(h1_mode):
         h1_mode=h1_mode,
         entry_h1_span_hours=4.0,
     )
-    with pytest.raises(RuntimeError, match=r"missing required h1_log_range EMA for AVAX/USDT:USDT"):
-        await pb_mod.Passivbot._load_orchestrator_ema_bundle(bot, [symbol], bot.PB_modes)
+    result = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+        bot, [symbol], bot.PB_modes
+    )
+
+    assert result[0][symbol]
+    assert result[3][symbol] == {}
+    assert bot._orchestrator_allow_missing_strategy_inputs_symbols == {symbol}
 
 
 @pytest.mark.asyncio
@@ -2606,7 +2627,7 @@ async def test_trailing_grid_v7_grid_spacing_volatility_requires_h1_log_range():
 
 
 @pytest.mark.asyncio
-async def test_trailing_grid_v7_grid_spacing_h1_log_range_missing_fails_loudly():
+async def test_trailing_grid_v7_grid_spacing_h1_missing_is_scoped_in_rust():
     try:
         import passivbot as pb_mod
     except ImportError:
@@ -2641,8 +2662,13 @@ async def test_trailing_grid_v7_grid_spacing_h1_log_range_missing_fails_loudly()
 
     bot._strategy_params_to_rust_dict = trailing_grid_v7_params
 
-    with pytest.raises(RuntimeError, match=r"missing required h1_log_range EMA for AVAX/USDT:USDT"):
-        await pb_mod.Passivbot._load_orchestrator_ema_bundle(bot, [symbol], bot.PB_modes)
+    result = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+        bot, [symbol], bot.PB_modes
+    )
+
+    assert result[0][symbol]
+    assert result[3][symbol] == {}
+    assert bot._orchestrator_allow_missing_strategy_inputs_symbols == {symbol}
 
 
 @pytest.mark.asyncio

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -565,6 +565,38 @@ def test_live_authorized_missing_ema_does_not_scope_unaffected_pside():
     ]
 
 
+def test_trailing_grid_v7_close_only_ignores_entry_only_h1_volatility():
+    import passivbot_rust as pbr
+
+    strategy = trailing_grid_v7_strategy_params(
+        grid_spacing_volatility_weight=1.0,
+        volatility_ema_span_hours=4.0,
+    )
+    symbol = make_symbol(
+        0,
+        bid=100.0,
+        ask=100.0,
+        long_mode="tp_only",
+        long_pos_size=1.0,
+        long_pos_price=100.0,
+        long_strategy=strategy,
+        short_strategy=strategy,
+        emas=ema_bundle(h1_log_range=[]),
+    )
+    inp = make_input(
+        balance=1_000.0,
+        strategy_kind="trailing_grid_v7",
+        symbols=[symbol],
+    )
+
+    out = compute(pbr, inp)
+
+    assert any(
+        order["pside"] == "long" and order["order_type"] == "close_grid_long"
+        for order in out["orders"]
+    )
+
+
 def test_live_authorization_does_not_tolerate_malformed_ema_values():
     import passivbot_rust as pbr
 

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -458,6 +458,63 @@ def test_live_authorized_missing_ema_still_emits_twel_reducer():
     assert {order["symbol_idx"] for order in twel_orders} == {1}
 
 
+def test_live_authorized_missing_ema_still_emits_wel_reducer():
+    import passivbot_rust as pbr
+
+    long_bp = {
+        "wallet_exposure_limit": 0.4,
+        "risk_wel_enforcer_threshold": 1.0,
+        "risk_twel_enforcer_enabled": False,
+        "total_wallet_exposure_limit": 1.0,
+        "n_positions": 1,
+    }
+    symbol = make_symbol(
+        0,
+        bid=100.0,
+        ask=100.0,
+        long_pos_size=6.0,
+        long_pos_price=100.0,
+        long_bp=long_bp,
+        emas=ema_bundle(m1_close=[]),
+    )
+    symbol["allow_missing_strategy_inputs"] = True
+    inp = make_input(
+        balance=1_000.0,
+        global_bp=bot_params_pair(long_overrides=long_bp),
+        symbols=[symbol],
+    )
+    inp["global"]["hedge_mode"] = True
+
+    out = compute(pbr, inp)
+    complete_inp = copy.deepcopy(inp)
+    complete_inp["symbols"][0]["emas"] = ema_bundle()
+    complete_inp["symbols"][0]["allow_missing_strategy_inputs"] = False
+    complete_out = compute(pbr, complete_inp)
+
+    wel_orders = [
+        order
+        for order in out["orders"]
+        if order["order_type"] == "close_auto_reduce_wel_long"
+    ]
+    complete_wel_orders = [
+        order
+        for order in complete_out["orders"]
+        if order["order_type"] == "close_auto_reduce_wel_long"
+    ]
+    assert len(wel_orders) == 1
+    assert wel_orders == complete_wel_orders
+    assert wel_orders[0]["symbol_idx"] == 0
+    assert not any(
+        order["pside"] == "long"
+        and (
+            order["order_type"].startswith("entry_")
+            or order["order_type"].startswith("close_grid")
+            or order["order_type"].startswith("close_trailing")
+        )
+        for order in out["orders"]
+    )
+
+
 def test_live_authorized_missing_ema_does_not_scope_unaffected_pside():
     import passivbot_rust as pbr
 
@@ -695,6 +752,37 @@ def test_one_way_flat_tie_break_requires_ema_even_when_entry_gate_disabled():
 
     with pytest.raises(ValueError, match="MissingEma"):
         compute(pbr, inp)
+
+
+def test_live_authorized_missing_ema_blocks_both_one_way_initial_sides():
+    import passivbot_rust as pbr
+
+    side_enabled = {"n_positions": 1, "total_wallet_exposure_limit": 1.0}
+    symbol = make_symbol(
+        0,
+        bid=100.0,
+        ask=101.0,
+        short_bp=side_enabled,
+        emas=ema_bundle(m1_close=[]),
+    )
+    symbol["allow_missing_strategy_inputs"] = True
+    inp = make_input(
+        balance=1_000.0,
+        global_bp=bot_params_pair(short_overrides=side_enabled),
+        symbols=[symbol],
+    )
+    inp["global"]["hedge_mode"] = False
+
+    out = compute(pbr, inp)
+
+    assert not any(order["order_type"].startswith("entry_") for order in out["orders"])
+    assert {
+        "strategy_input_unavailable": {
+            "symbol_idx": 0,
+            "pside": "long",
+            "scope": "one_way_arbitration",
+        }
+    } in out["diagnostics"]["warnings"]
 
 
 @pytest.mark.parametrize(
@@ -2015,6 +2103,64 @@ def test_forager_respects_n_positions_selects_one_coin():
     assert selection["selected_symbol_indices"] == [1]
     assert selection["top_scores"][0]["symbol_idx"] == 1
     assert selection["top_scores"][0]["selected"] is True
+
+
+def test_live_authorized_missing_forager_feature_scopes_only_candidate_side():
+    import passivbot_rust as pbr
+
+    side_params = {
+        "n_positions": 1,
+        "total_wallet_exposure_limit": 1.0,
+        "filter_volume_drop_pct": 0.5,
+        "filter_volatility_drop_pct": 0.0,
+        "filter_volume_ema_span_1m": 10.0,
+        "filter_volatility_ema_span_1m": 10.0,
+    }
+    global_bp = bot_params_pair(long_overrides=side_params)
+    unavailable = make_symbol(
+        0,
+        bid=100.0,
+        ask=100.0,
+        long_bp=side_params,
+        emas=ema_bundle(m1_volume=[]),
+    )
+    unavailable["allow_missing_strategy_inputs"] = True
+    available = make_symbol(
+        1,
+        bid=100.0,
+        ask=100.0,
+        long_bp=side_params,
+        emas=ema_bundle(m1_volume=[[10.0, 11.0]]),
+    )
+
+    inp = make_input(
+        balance=1_000.0,
+        global_bp=global_bp,
+        symbols=[unavailable, available],
+    )
+    strict_inp = copy.deepcopy(inp)
+    strict_inp["symbols"][0]["allow_missing_strategy_inputs"] = False
+
+    with pytest.raises(ValueError, match="MissingEma"):
+        compute(pbr, strict_inp)
+
+    out = compute(pbr, inp)
+
+    assert any(
+        order["symbol_idx"] == 1 and order["order_type"].startswith("entry_")
+        for order in out["orders"]
+    )
+    assert not any(
+        order["symbol_idx"] == 0 and order["order_type"].startswith("entry_")
+        for order in out["orders"]
+    )
+    assert {
+        "strategy_input_unavailable": {
+            "symbol_idx": 0,
+            "pside": "long",
+            "scope": "forager_selection",
+        }
+    } in out["diagnostics"]["warnings"]
 
 
 def test_json_rejects_invalid_forager_hysteresis_pct():

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -377,7 +377,7 @@ def test_json_rejects_missing_ema():
         compute(pbr, inp)
 
 
-def test_live_authorized_missing_ema_scopes_strategy_orders_atomically():
+def test_live_authorized_missing_entry_ema_preserves_independent_closes():
     import passivbot_rust as pbr
 
     symbol = make_symbol(
@@ -396,11 +396,11 @@ def test_live_authorized_missing_ema_scopes_strategy_orders_atomically():
 
     assert not any(
         order["pside"] == "long"
-        and (
-            order["order_type"].startswith("entry_")
-            or order["order_type"].startswith("close_grid")
-            or order["order_type"].startswith("close_trailing")
-        )
+        and order["order_type"].startswith("entry_")
+        for order in out["orders"]
+    )
+    assert any(
+        order["pside"] == "long" and order["order_type"].startswith("close_")
         for order in out["orders"]
     )
     assert {
@@ -410,6 +410,59 @@ def test_live_authorized_missing_ema_scopes_strategy_orders_atomically():
             "scope": "strategy_orders",
         }
     } in out["diagnostics"]["warnings"]
+
+
+def test_live_authorized_missing_entry_volatility_preserves_independent_closes():
+    import passivbot_rust as pbr
+
+    strategy = adaptive_strategy_params(
+        entry_volatility_ema_span_1h=4.0,
+        entry_weight_volatility_1h=1.0,
+    )
+    symbol = make_symbol(
+        0,
+        bid=100.0,
+        ask=100.0,
+        long_pos_size=1.0,
+        long_pos_price=100.0,
+        long_strategy=strategy,
+        emas=ema_bundle(h1_log_range=[]),
+    )
+    symbol["allow_missing_strategy_inputs"] = True
+    inp = make_input(balance=1_000.0, symbols=[symbol])
+    inp["global"]["hedge_mode"] = True
+
+    out = compute(pbr, inp)
+    complete_inp = copy.deepcopy(inp)
+    complete_inp["symbols"][0]["emas"] = ema_bundle(h1_log_range=[[4.0, 0.01]])
+    complete_inp["symbols"][0]["allow_missing_strategy_inputs"] = False
+    complete_out = compute(pbr, complete_inp)
+
+    assert not any(
+        order["pside"] == "long" and order["order_type"].startswith("entry_")
+        for order in out["orders"]
+    )
+    scoped_closes = [
+        order
+        for order in out["orders"]
+        if order["pside"] == "long" and order["order_type"].startswith("close_")
+    ]
+    complete_closes = [
+        order
+        for order in complete_out["orders"]
+        if order["pside"] == "long" and order["order_type"].startswith("close_")
+    ]
+    assert scoped_closes
+    assert scoped_closes == complete_closes
+    assert out["diagnostics"]["warnings"].count(
+        {
+            "strategy_input_unavailable": {
+                "symbol_idx": 0,
+                "pside": "long",
+                "scope": "strategy_orders",
+            }
+        }
+    ) == 1
 
 
 def test_live_authorized_missing_ema_still_emits_twel_reducer():
@@ -506,9 +559,13 @@ def test_live_authorized_missing_ema_still_emits_wel_reducer():
     assert wel_orders[0]["symbol_idx"] == 0
     assert not any(
         order["pside"] == "long"
+        and order["order_type"].startswith("entry_")
+        for order in out["orders"]
+    )
+    assert any(
+        order["pside"] == "long"
         and (
-            order["order_type"].startswith("entry_")
-            or order["order_type"].startswith("close_grid")
+            order["order_type"].startswith("close_grid")
             or order["order_type"].startswith("close_trailing")
         )
         for order in out["orders"]
@@ -547,10 +604,13 @@ def test_live_authorized_missing_ema_does_not_scope_unaffected_pside():
 
     assert any(order["pside"] == "short" for order in out["orders"])
     assert not any(
+        order["pside"] == "long" and order["order_type"].startswith("entry_")
+        for order in out["orders"]
+    )
+    assert any(
         order["pside"] == "long"
         and (
-            order["order_type"].startswith("entry_")
-            or order["order_type"].startswith("close_grid")
+            order["order_type"].startswith("close_grid")
             or order["order_type"].startswith("close_trailing")
         )
         for order in out["orders"]

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -565,7 +565,7 @@ def test_live_authorized_missing_ema_does_not_scope_unaffected_pside():
     ]
 
 
-def test_trailing_grid_v7_close_only_ignores_entry_only_h1_volatility():
+def test_trailing_grid_v7_close_only_ignores_entry_only_emas():
     import passivbot_rust as pbr
 
     strategy = trailing_grid_v7_strategy_params(
@@ -581,7 +581,7 @@ def test_trailing_grid_v7_close_only_ignores_entry_only_h1_volatility():
         long_pos_price=100.0,
         long_strategy=strategy,
         short_strategy=strategy,
-        emas=ema_bundle(h1_log_range=[]),
+        emas=ema_bundle(m1_close=[], h1_log_range=[]),
     )
     inp = make_input(
         balance=1_000.0,

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -377,6 +377,162 @@ def test_json_rejects_missing_ema():
         compute(pbr, inp)
 
 
+def test_live_authorized_missing_ema_scopes_strategy_orders_atomically():
+    import passivbot_rust as pbr
+
+    symbol = make_symbol(
+        0,
+        bid=100.0,
+        ask=100.0,
+        long_pos_size=1.0,
+        long_pos_price=100.0,
+        emas=ema_bundle(m1_close=[]),
+    )
+    symbol["allow_missing_strategy_inputs"] = True
+    inp = make_input(balance=1_000.0, symbols=[symbol])
+    inp["global"]["hedge_mode"] = True
+
+    out = compute(pbr, inp)
+
+    assert not any(
+        order["pside"] == "long"
+        and (
+            order["order_type"].startswith("entry_")
+            or order["order_type"].startswith("close_grid")
+            or order["order_type"].startswith("close_trailing")
+        )
+        for order in out["orders"]
+    )
+    assert {
+        "strategy_input_unavailable": {
+            "symbol_idx": 0,
+            "pside": "long",
+            "scope": "strategy_orders",
+        }
+    } in out["diagnostics"]["warnings"]
+
+
+def test_live_authorized_missing_ema_still_emits_twel_reducer():
+    import passivbot_rust as pbr
+
+    long_bp = {
+        "wallet_exposure_limit": 0.4,
+        "total_wallet_exposure_limit": 0.9,
+        "risk_twel_enforcer_threshold": 1.0,
+        "n_positions": 2,
+    }
+    global_bp = bot_params_pair(long_overrides=long_bp)
+    symbols = [
+        make_symbol(
+            0,
+            bid=50.0,
+            ask=50.0,
+            long_pos_size=8.0,
+            long_pos_price=50.0,
+            long_bp=long_bp,
+            emas=ema_bundle(m1_close=[]),
+        ),
+        make_symbol(
+            1,
+            bid=50.0,
+            ask=50.0,
+            long_pos_size=12.0,
+            long_pos_price=50.0,
+            long_bp=long_bp,
+            emas=ema_bundle(m1_close=[]),
+        ),
+    ]
+    for symbol in symbols:
+        symbol["allow_missing_strategy_inputs"] = True
+    inp = make_input(balance=1_000.0, global_bp=global_bp, symbols=symbols)
+    inp["global"]["hedge_mode"] = True
+
+    out = compute(pbr, inp)
+
+    twel_orders = [
+        order
+        for order in out["orders"]
+        if order["order_type"] == "close_auto_reduce_twel_long"
+    ]
+    assert twel_orders
+    assert {order["symbol_idx"] for order in twel_orders} == {1}
+
+
+def test_live_authorized_missing_ema_does_not_scope_unaffected_pside():
+    import passivbot_rust as pbr
+
+    enabled_short = {"n_positions": 1, "total_wallet_exposure_limit": 1.0}
+    symbol = make_symbol(
+        0,
+        bid=100.0,
+        ask=100.0,
+        long_pos_size=1.0,
+        long_pos_price=100.0,
+        short_pos_size=-1.0,
+        short_pos_price=100.0,
+        short_bp=enabled_short,
+        long_strategy=adaptive_strategy_params(
+            entry_volatility_ema_span_1h=4.0,
+            entry_weight_volatility_1h=1.0,
+        ),
+        short_strategy=adaptive_strategy_params(),
+        emas=ema_bundle(h1_log_range=[]),
+    )
+    symbol["allow_missing_strategy_inputs"] = True
+    inp = make_input(
+        balance=1_000.0,
+        global_bp=bot_params_pair(short_overrides=enabled_short),
+        symbols=[symbol],
+    )
+    inp["global"]["hedge_mode"] = True
+
+    out = compute(pbr, inp)
+
+    assert any(order["pside"] == "short" for order in out["orders"])
+    assert not any(
+        order["pside"] == "long"
+        and (
+            order["order_type"].startswith("entry_")
+            or order["order_type"].startswith("close_grid")
+            or order["order_type"].startswith("close_trailing")
+        )
+        for order in out["orders"]
+    )
+    scoped_warnings = [
+        warning["strategy_input_unavailable"]
+        for warning in out["diagnostics"]["warnings"]
+        if "strategy_input_unavailable" in warning
+    ]
+    assert scoped_warnings == [
+        {"symbol_idx": 0, "pside": "long", "scope": "strategy_orders"}
+    ]
+
+
+def test_live_authorization_does_not_tolerate_malformed_ema_values():
+    import passivbot_rust as pbr
+
+    symbol = make_symbol(
+        0,
+        bid=100.0,
+        ask=100.0,
+        long_pos_size=1.0,
+        long_pos_price=100.0,
+        emas=ema_bundle(
+            m1_close=[
+                [10.0, 0.0],
+                [20.0, 0.0],
+                [math.sqrt(10.0 * 20.0), 0.0],
+            ]
+        ),
+    )
+    symbol["allow_missing_strategy_inputs"] = True
+    inp = make_input(balance=1_000.0, symbols=[symbol])
+    inp["global"]["hedge_mode"] = True
+
+    with pytest.raises(ValueError, match="NonFiniteInput"):
+        compute(pbr, inp)
+
+
 def test_ema_gate_mode_disabled_initial_long_uses_best_bid_without_ema():
     import passivbot_rust as pbr
 

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -40,7 +40,7 @@ from passivbot import Passivbot
 import passivbot as passivbot_module
 import fill_events_manager as fem
 from config import get_template_config, prepare_config
-from freshness_ledger import ACCOUNT_SURFACES, LIVE_STATE_SURFACES, FreshnessLedger
+from freshness_ledger import ACCOUNT_SURFACES, FreshnessLedger
 from logging_setup import DEFAULT_DATEFMT, DEFAULT_FORMAT_WITH_PREFIX
 from market_snapshot import MarketSnapshot
 from planning_snapshot import (
@@ -9836,7 +9836,7 @@ def test_staged_planner_preconditions_require_current_epoch_surfaces():
     bot._begin_authoritative_refresh_epoch()
     ok, details = bot._staged_planner_precondition_state(include_market_snapshot=False)
     assert ok is False
-    assert details["missing"] == sorted(ACCOUNT_SURFACES | {"completed_candles"})
+    assert details["missing"] == sorted(ACCOUNT_SURFACES)
 
     for surface in ACCOUNT_SURFACES:
         bot._record_authoritative_surface(surface, (surface, "fresh"))
@@ -9853,7 +9853,7 @@ def test_staged_planner_preconditions_require_current_epoch_surfaces():
     bot._record_authoritative_surface("market_snapshot", ("market", "fresh"))
     ok, details = bot._staged_planner_precondition_state(include_market_snapshot=True)
     assert ok is True
-    assert set(details["required"]) == set(LIVE_STATE_SURFACES)
+    assert set(details["required"]) == set(ACCOUNT_SURFACES) | {"market_snapshot"}
 
 
 def test_staged_planner_preconditions_allow_open_orders_only_confirmation_epoch():
@@ -9913,7 +9913,7 @@ def test_staged_planner_preconditions_raise_before_rust_planning():
         )
 
 
-def test_staged_planner_preconditions_reject_stale_completed_candle_signature():
+def test_staged_planner_preconditions_do_not_gate_on_stale_completed_candles():
     bot = Passivbot.__new__(Passivbot)
     bot.config = {"live": {}}
     bot.exchange = "bybit"
@@ -9942,12 +9942,13 @@ def test_staged_planner_preconditions_reject_stale_completed_candle_signature():
 
     ok, details = bot._staged_planner_precondition_state(include_market_snapshot=False)
 
-    assert ok is False
-    assert "completed_candles" in details["missing"]
-    assert details["invalid"]["completed_candles"][0]["symbol"] == "BTC/USDT:USDT"
+    assert ok is True
+    assert details["missing"] == []
+    assert "completed_candles" not in details["required"]
+    assert details["invalid"] == {}
 
 
-def test_staged_planner_preconditions_explain_completed_candle_signature_mismatch():
+def test_staged_planner_preconditions_ignore_completed_candle_universe_changes():
     bot = Passivbot.__new__(Passivbot)
     bot.config = {"live": {}}
     bot.exchange = "bybit"
@@ -9983,14 +9984,10 @@ def test_staged_planner_preconditions_explain_completed_candle_signature_mismatc
 
     ok, details = bot._staged_planner_precondition_state(include_market_snapshot=False)
 
-    assert ok is False
-    mismatch = details["invalid"]["completed_candles"][0]
-    assert mismatch["reason"] == "signature_mismatch"
-    assert mismatch["mismatch_type"] == "planning_universe_changed"
-    assert mismatch["expected_count"] == 2
-    assert mismatch["stamped_count"] == 1
-    assert mismatch["missing_symbols"] == ["ETH/USDT:USDT"]
-    assert mismatch["changed_symbols"] == ["BTC/USDT:USDT"]
+    assert ok is True
+    assert details["missing"] == []
+    assert "completed_candles" not in details["required"]
+    assert details["invalid"] == {}
 
 
 def test_completed_candle_signature_ignores_later_cache_improvements():
@@ -10189,7 +10186,9 @@ def test_build_staged_planning_snapshot_captures_exact_surface_contract():
     assert planning_snapshot.symbols == (symbol,)
     assert planning_snapshot.last_prices() == {symbol: 100.5}
     assert planning_snapshot.completed_candle_signature == candle_signature
-    assert set(planning_snapshot.required_surfaces) == set(LIVE_STATE_SURFACES)
+    assert set(planning_snapshot.required_surfaces) == set(ACCOUNT_SURFACES) | {
+        "market_snapshot"
+    }
     assert planning_snapshot.invalid_details(now_ms=passivbot_module.utc_ms()) == []
 
 
@@ -10451,9 +10450,8 @@ async def test_planning_snapshot_freezes_data_packet_revisions_through_cycle(mon
     assert diagnostic_build_calls[-1][1]["cycle_id"] == "cy_snapshot"
     assert diagnostic_build_calls[-1][1]["snapshot_id"] == planning_snapshot.snapshot_id
     surface_age_names = {item["name"] for item in snapshot_payload["surface_ages"]}
-    assert {"balance", "positions", "open_orders", "completed_candles", "market_snapshot"} <= (
-        surface_age_names
-    )
+    assert {"balance", "positions", "open_orders", "market_snapshot"} <= surface_age_names
+    assert "completed_candles" not in surface_age_names
     market_summary = snapshot_payload["market_snapshot_summary"]
     assert market_summary["count"] == 1
     assert market_summary["symbol_count"] == 1
@@ -12150,7 +12148,7 @@ async def test_run_execution_loop_does_not_reinitialize_coin_hsl_after_startup()
 
 
 @pytest.mark.asyncio
-async def test_run_execution_loop_defers_staged_precondition_without_error_count():
+async def test_run_execution_loop_does_not_defer_for_completed_candles():
     bot = Passivbot.__new__(Passivbot)
     cycle = {"n": 0}
     executes = []
@@ -12206,13 +12204,11 @@ async def test_run_execution_loop_defers_staged_precondition_without_error_count
 
     result = await bot.run_execution_loop()
 
-    assert result == {"executed_cycle": 2}
+    assert result == {"executed_cycle": 1}
     assert executes == [
         ("universe", 1),
         ("market", 1),
-        ("universe", 2),
-        ("market", 2),
-        ("execute", False, 2),
+        ("execute", False, 1),
     ]
     bot.restart_bot_on_too_many_errors.assert_not_called()
 

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -1015,6 +1015,7 @@ async def test_live_orchestrator_passes_merged_entry_cooldown_delta_anchor(monke
     captured = {}
 
     async def fake_load_bundle(self, symbols, modes):
+        self._orchestrator_allow_missing_strategy_inputs_symbols = {symbol}
         m1_close = {symbol: {1.0: 100.0, 2.0: 100.0}}
         m1_volume = {symbol: {10.0: 1_000.0}}
         m1_log_range = {symbol: {10.0: 0.01}}
@@ -1035,6 +1036,7 @@ async def test_live_orchestrator_passes_merged_entry_cooldown_delta_anchor(monke
 
     rust_symbol = captured["input"]["symbols"][0]
     assert rust_symbol["long"]["last_increase_fill_timestamp_ms"] == 121_000
+    assert rust_symbol["allow_missing_strategy_inputs"] is True
     assert snapshot["last_increase_fill_timestamps"][symbol]["long"] == 121_000
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
     rust_events = [

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -1055,6 +1055,7 @@ async def test_live_orchestrator_passes_merged_entry_cooldown_delta_anchor(monke
     assert {event.cycle_id for event in rust_events} == {"cy_live"}
     assert rust_events[0].remote_call_id == rust_events[1].remote_call_id
     assert rust_events[0].data["input_hash"] == rust_events[1].data["input_hash"]
+    assert rust_events[0].data["ema_unavailable_count"] == 1
     assert rust_events[1].data["order_count"] == 0
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 


### PR DESCRIPTION
## Summary

- remove completed-candle freshness from the account-wide staged planner barrier while retaining authoritative account and market-snapshot barriers
- pass known absent live EMA inputs to strict-by-default Rust without fabricating values, then scope only forager selection, one-way arbitration, strategy, or unstuck consumers that actually encounter `MissingEma`
- keep Rust ideals authoritative: omitted ordinary ideals cancel stale resting strategy orders through normal reconciliation, while independent panic, WEL, and TWEL reducers remain eligible when their own inputs are complete
- consolidate duplicated long/short strategy generation and update the architecture, error contract, logging plan, operations backlog, audit plan, and changelog

## Safety contract

- backtests and unannotated Rust inputs remain strict
- only explicit live `MissingEma` availability is scoped; malformed, non-finite, or invalid producer input remains fatal
- no neutral or synthetic strategy values are introduced
- account surfaces and the current market snapshot remain mandatory planner barriers

## Validation

- `pytest -q` (full Python suite)
- targeted readiness, EMA, reconciliation, live-loop, and real-extension regression suites
- `cargo fmt --all -- --check`
- `cargo check --tests`
- `cargo test --no-default-features` (224 passed)
- rebuilt the Python Rust extension and verified its source fingerprint before final real-extension tests
- `pytest -q tests/test_ai_docs.py tests/test_live_event_registry_docs.py`
