### PR TITLE
Bound held coin HSL replay to relevant episodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,12 @@ All notable user-facing changes will be documented in this file.
   proof- and retry-epoch-specific ranges so adjacent unverified or newly
   finalized minutes remain refreshable, using log-linear sweep normalization
   for large sparse histories.
+- Coin-mode HSL startup now bounds `always`-policy held-pair replay at a
+  fill-proven current episode plus any cooldown-linked predecessor episodes,
+  so exchanges with limited recent 1m history do not strand a protected open
+  position on irrelevant older closed episodes. Startup failures also retain a
+  correlated private bounded frame chain at normal log level while the console
+  remains compact.
 - Bitget UTA private order updates now use the native `holdSide` field for
   hedge position attribution. Hyperliquid briefly retries a sparse order-open
   event when a concurrent local create is still awaiting its exchange ID, then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,10 +68,12 @@ All notable user-facing changes will be documented in this file.
   proof- and retry-epoch-specific ranges so adjacent unverified or newly
   finalized minutes remain refreshable, using log-linear sweep normalization
   for large sparse histories.
-- Coin-mode HSL startup now bounds `always`-policy held-pair replay at a
-  fill-proven current episode plus any cooldown-linked predecessor episodes,
+- Coin-mode HSL startup now bounds and rebases `always`-policy held-pair
+  replay at a fill-proven current episode plus any cooldown-linked predecessor
+  episodes,
   so exchanges with limited recent 1m history do not strand a protected open
-  position on irrelevant older closed episodes. Startup failures also retain a
+  position on irrelevant older closed episodes without carrying their realized
+  PnL into the current episode. Startup failures also retain a
   correlated private bounded frame chain at normal log level while the console
   remains compact.
 - Bitget UTA private order updates now use the native `holdSide` field for

--- a/docs/ai/features/equity_hard_stop_loss.md
+++ b/docs/ai/features/equity_hard_stop_loss.md
@@ -35,8 +35,10 @@ HSL drawdown state is scoped by `live.hsl_signal_mode`:
    Replay retains preceding episodes while their cooldown horizons overlap the next episode, so a
    chain of possible cooldown interventions remains strict. An ambiguous fill sequence, a position
    size mismatch, `threshold`/`never`, or a missing current-episode boundary preserves full-lookback
-   replay. Unavailable candles before the resulting boundary cannot strand an otherwise provable
-   held episode; unavailable required candles at or after it still fail closed.
+   replay. The cumulative realized PnL of discarded episodes becomes the new replay baseline, so
+   their gains, losses, and fees cannot affect the retained episode. Unavailable candles before the
+   resulting boundary cannot strand an otherwise provable held episode; unavailable required
+   candles at or after it still fail closed.
 
 ## Failure Semantics
 

--- a/docs/ai/features/equity_hard_stop_loss.md
+++ b/docs/ai/features/equity_hard_stop_loss.md
@@ -30,6 +30,13 @@ HSL drawdown state is scoped by `live.hsl_signal_mode`:
    outcomes. They retain only a bounded exception type in diagnostics and fall back to authoritative
    replay when reuse is unavailable. Coin replay failures retain the same bounded classification
    without changing exception propagation or held-pair protection and flat-pair entry blocking.
+8. For an open coin scope using `restart_after_red_policy=always`, a fill-proven current episode
+   may discard older closed episodes after a flat gap longer than the configured RED cooldown.
+   Replay retains preceding episodes while their cooldown horizons overlap the next episode, so a
+   chain of possible cooldown interventions remains strict. An ambiguous fill sequence, a position
+   size mismatch, `threshold`/`never`, or a missing current-episode boundary preserves full-lookback
+   replay. Unavailable candles before the resulting boundary cannot strand an otherwise provable
+   held episode; unavailable required candles at or after it still fail closed.
 
 ## Failure Semantics
 

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -517,17 +517,19 @@ helper apply the same type-only boundary.
 
 ## Execution-Loop Incidents
 
-An execution-loop failure publishes a bounded `error.bot` record and an equivalent first-occurrence
+An execution-loop or startup failure publishes a bounded `error.bot` record and an equivalent
 operator signature. The stable diagnostic fields are incident id, operation/source, exception
 type, optional bounded status/code and endpoint, stage, innermost origin, action, and cycle. A
 companion private `error.bot.detail` record uses the same incident id and retains the bounded full
 exception-chain frame sequence at normal logging levels so a rare failure remains diagnosable
 without a DEBUG restart. The detail contains normalized file/function/line values but no exception
-text, locals, source lines, request URLs, or response payloads. The normal console keeps only the
-compact operator signature; its omission of the frame chain is a readability and volume decision,
-not a public/privacy boundary. Traceback projection is entirely observability-only: hostile or
-malformed exception accessors produce a bounded `projection_failed` detail instead of replacing the
-original error, its counter update, restart-threshold handling, or backoff.
+text, locals, source lines, request URLs, or response payloads. Startup records use the exact
+pre-wrapper exception, including deterministic validation failures later wrapped as fatal process
+errors. The normal console keeps only the compact operator signature; its omission of the frame
+chain is a readability and volume decision, not a public/privacy boundary. Traceback projection is
+entirely observability-only: hostile or malformed exception accessors produce a bounded
+`projection_failed` detail instead of replacing the original error, its counter update,
+restart-threshold handling, startup propagation, or backoff.
 
 Equivalent repeats use `health.summary` with the execution-error-burst reason. Its latest-failure
 fields are `latest_error_type`, optional `latest_status`, `latest_code`, and `latest_endpoint`; it

--- a/docs/ai/features/monitor_persistence.md
+++ b/docs/ai/features/monitor_persistence.md
@@ -19,10 +19,10 @@ incident context belongs in an explicitly sanitized event or protected developer
 behavior and caller control flow remain unchanged.
 
 Private normal-run monitor history may retain an explicitly sanitized incident detail event. The
-execution-loop `error.bot.detail` schema stores a bounded normalized frame chain, correlated to its
-compact `error.bot` summary by incident id, while excluding exception text, locals, source lines,
-URLs, payloads, and credentials. Existing rotation and retention limits bound this diagnostic data;
-its production does not depend on DEBUG logging.
+startup and execution-loop `error.bot.detail` schema stores a bounded normalized frame chain,
+correlated to its compact `error.bot` summary by incident id, while excluding exception text,
+locals, source lines, URLs, payloads, and credentials. Existing rotation and retention limits bound
+this diagnostic data; its production does not depend on DEBUG logging.
 
 During an internal bot restart, a failed or timed-out event-pipeline close may leave its worker
 holding the publisher lock. The restart path therefore abandons that process-local publisher

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -3589,11 +3589,37 @@ class Passivbot:
             error_type = bounded_exception_type(exc)
             error_status = bounded_exception_status(exc) or "-"
             error_code = bounded_exception_code(exc) or "-"
-            self._monitor_record_error(
+            incident_sequence = int(
+                getattr(self, "_startup_incident_sequence", 0) or 0
+            ) + 1
+            self._startup_incident_sequence = incident_sequence
+            incident_id = f"startup-{error_ts}-{incident_sequence}"
+            incident_action = "stop_startup"
+            incident_cycle = "not_started"
+            incident_fields = {
+                "source": "start_bot",
+                "stage": boot_stage,
+                "incident_id": incident_id,
+                "error_type": error_type,
+                "status": error_status,
+                "code": error_code,
+                "origin": _bounded_traceback_origin(exc),
+                "action": incident_action,
+                "cycle": incident_cycle,
+            }
+            self._monitor_record_event(
                 "error.bot",
-                exc,
-                tags=("error", "bot", "startup"),
-                payload={"source": "start_bot", "stage": boot_stage},
+                ("error", "bot", "startup"),
+                incident_fields,
+                ts=error_ts,
+            )
+            self._monitor_record_event(
+                "error.bot.detail",
+                ("error", "bot", "startup", "diagnostic"),
+                {
+                    **incident_fields,
+                    "traceback": _bounded_traceback_detail(exc),
+                },
                 ts=error_ts,
             )
             await self._monitor_flush_snapshot(force=True, ts=error_ts)

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -5943,6 +5943,19 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     symbol,
                     qty_step=qty_step,
                 )
+                if (
+                    replay_start_boundary_ts is not None
+                    and (pside, symbol) in bounded_held_replay_starts
+                ):
+                    # Pair realized values are cumulative across the replay
+                    # record window. Discarded closed episodes must therefore
+                    # become the current episode's baseline rather than leaking
+                    # their gains/losses into its drawdown state.
+                    reset_baseline_realized = sum(
+                        float(realized_delta)
+                        for event_ts, _action, _qty, realized_delta in replay_events
+                        if int(event_ts) < int(replay_start_boundary_ts)
+                    )
                 pair_uses_dense_replay = (
                     compact_replay is None
                     or replay_ambiguous

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -3973,6 +3973,89 @@ def _equity_hard_stop_coin_replay_events(
     return replay_events, ambiguous
 
 
+def _equity_hard_stop_coin_bounded_required_replay_start_ts(
+    self,
+    pside: str,
+    symbol: str,
+    fill_events: list[Any],
+) -> Optional[int]:
+    """Return the earliest episode still relevant to an open ``always`` scope.
+
+    Coin HSL resets at every proven flatten. With ``restart_after_red_policy=always``,
+    episodes before the current one matter only while a possible RED cooldown can
+    chain across the intervening flat periods. Walk proven fill-derived episodes
+    backward from the authoritative current position and retain preceding episodes
+    only while each flatten falls inside the next episode's cooldown horizon.
+
+    ``None`` means the current episode boundary is not provable. Callers must then
+    preserve the strict full-lookback replay rather than guessing a boundary.
+    """
+    qty_step = _hsl_qty_step_for_symbol(self, symbol)
+    flat_epsilon = _hsl_flat_epsilon(qty_step)
+    current_size = abs(
+        float(
+            (self.positions or {})
+            .get(symbol, {})
+            .get(pside, {})
+            .get("size", 0.0)
+            or 0.0
+        )
+    )
+    if current_size <= flat_epsilon:
+        return None
+    replay_events, ambiguous = _equity_hard_stop_coin_replay_events(
+        fill_events,
+        pside,
+        symbol,
+        qty_step=qty_step,
+    )
+    if ambiguous:
+        return None
+
+    episodes: list[tuple[int, Optional[int]]] = []
+    replay_size = 0.0
+    episode_start_ts: Optional[int] = None
+    for event_ts, action, qty, _realized_delta in replay_events:
+        was_flat = replay_size <= flat_epsilon
+        if action == "increase":
+            replay_size += qty
+            if was_flat and replay_size > flat_epsilon:
+                episode_start_ts = int(event_ts)
+        else:
+            replay_size = max(0.0, replay_size - qty)
+            if not was_flat and replay_size <= flat_epsilon:
+                if episode_start_ts is None:
+                    return None
+                episodes.append((int(episode_start_ts), int(event_ts)))
+                episode_start_ts = None
+
+    size_tolerance = max(flat_epsilon, abs(current_size) * 1e-12, 1e-12)
+    if abs(replay_size - current_size) > size_tolerance:
+        return None
+    if episode_start_ts is None:
+        return None
+
+    required_start_ts = int(episode_start_ts)
+    cooldown_minutes = float(self.hsl[pside]["cooldown_minutes_after_red"])
+    cooldown_ms = (
+        int(round(cooldown_minutes * 60_000.0))
+        if cooldown_minutes > 0.0
+        else 0
+    )
+    if cooldown_ms <= 0:
+        return required_start_ts
+
+    next_episode_start_ts = required_start_ts
+    for previous_start_ts, previous_flatten_ts in reversed(episodes):
+        if previous_flatten_ts is None:
+            return None
+        if int(previous_flatten_ts) + cooldown_ms <= next_episode_start_ts:
+            break
+        required_start_ts = int(previous_start_ts)
+        next_episode_start_ts = int(previous_start_ts)
+    return required_start_ts
+
+
 def _equity_hard_stop_coin_replay_size_at(
     replay_events: list[tuple[int, str, float, float]], row_ts_ms: int
 ) -> float:
@@ -5494,9 +5577,36 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     continue
                 pside = _equity_hard_stop_fill_pside(event)
                 symbols.add(symbol)
-                if (pside, symbol) in current_position_pairs:
-                    required_replay_pairs.add((pside, symbol))
-                    remember_required_replay_start(pside, symbol, ts)
+        bounded_held_replay_starts: dict[tuple[str, str], int] = {}
+        for pside, symbol in sorted(current_position_pairs):
+            pair_fill_events = fill_events_by_pair.get((pside, symbol), [])
+            restart_policy = normalize_hsl_restart_after_red_policy(
+                self.hsl[pside].get("restart_after_red_policy", "threshold"),
+                path=f"hsl.{pside}.restart_after_red_policy",
+            )
+            bounded_start_ts = None
+            if restart_policy == "always":
+                bounded_start_ts = (
+                    _equity_hard_stop_coin_bounded_required_replay_start_ts(
+                        self,
+                        pside,
+                        symbol,
+                        pair_fill_events,
+                    )
+                )
+            if bounded_start_ts is not None:
+                replay_ts = int(
+                    math.floor(int(bounded_start_ts) / 60_000) * 60_000
+                )
+                required_replay_start_ts[(pside, symbol)] = replay_ts
+                bounded_held_replay_starts[(pside, symbol)] = replay_ts
+            else:
+                for event in pair_fill_events:
+                    remember_required_replay_start(
+                        pside,
+                        symbol,
+                        _equity_hard_stop_fill_timestamp_ms(event),
+                    )
         if compact_replay is not None:
             for _pside, symbol in compact_pair_values:
                 if not self._equity_hard_stop_symbol_supported_for_coin_replay(symbol):
@@ -5549,7 +5659,9 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             symbols.add(symbol)
             panic_replay_pairs.add((pside, symbol))
             required_replay_pairs.add((pside, symbol))
-            remember_required_replay_start(pside, symbol, minute_ts)
+            bounded_start_ts = bounded_held_replay_starts.get((pside, symbol))
+            if bounded_start_ts is None or minute_ts >= bounded_start_ts:
+                remember_required_replay_start(pside, symbol, minute_ts)
             key = (pside, symbol, minute_ts)
             prev = latest_panic_by_coin_minute.get(key)
             if prev is None or stop_ts >= int(prev["timestamp"]):
@@ -5796,9 +5908,16 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 contract = self._equity_hard_stop_infer_coin_replay_contract(
                     pside, symbol, pair_fill_events, now_ms
                 )
-                replay_start_boundary_ts = None
+                replay_start_boundary_ts = bounded_held_replay_starts.get(
+                    (pside, symbol)
+                )
                 if contract["intervention_entry_ts"] is not None and contract["policy"] == "normal":
-                    replay_start_boundary_ts = int(contract["intervention_entry_ts"])
+                    intervention_boundary_ts = int(contract["intervention_entry_ts"])
+                    replay_start_boundary_ts = (
+                        intervention_boundary_ts
+                        if replay_start_boundary_ts is None
+                        else max(replay_start_boundary_ts, intervention_boundary_ts)
+                    )
                     self._equity_hard_stop_reset_coin_after_restart(pside, symbol)
                     self._equity_hard_stop_remove_latch_file(pside, symbol=symbol)
                     state = self._hsl_coin_state(pside, symbol)
@@ -6113,6 +6232,9 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                             pair_started_s,
                         )
                     if replay_start_boundary_ts is not None and ts < replay_start_boundary_ts:
+                        # Advance fill-derived size state while intentionally
+                        # discarding pre-boundary episode transitions.
+                        replay_transitions_at(ts)
                         continue
                     if state["halted"]:
                         cooldown_until_ms = state["cooldown_until_ms"]

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -5176,6 +5176,116 @@ async def test_compact_replay_resets_flat_episode_when_historical_upnl_is_omitte
     assert symbol not in bot._runtime_forced_modes["long"]
 
 
+@pytest.mark.parametrize(
+    ("restart_policy", "cooldown_minutes", "should_raise"),
+    [
+        ("always", 5.0, False),
+        ("always", 20.0, True),
+        ("threshold", 5.0, True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_held_coin_replay_bounds_missing_prices_only_after_proven_cooldown_gap(
+    restart_policy, cooldown_minutes, should_raise
+):
+    """Old closed episodes must not strand an ``always`` held position.
+
+    GateIO exposes only a recent 1m window.  A held pair may therefore have
+    fill/PnL history for an old closed episode whose candles are no longer
+    fetchable, while its current episode has complete price history.  The old
+    episode is irrelevant only when a proven flat gap exceeds every possible
+    cooldown bridge.
+    """
+    import numpy as np
+
+    symbol = "UNI/USDT:USDT"
+    timestamps = np.arange(1, 21, dtype=np.int64) * 60_000
+    old_entry_ts = 60_001
+    old_flatten_ts = 120_001
+    current_entry_ts = 900_001
+    unrealized = np.zeros(len(timestamps), dtype=np.float64)
+    unrealized[0] = np.nan
+    unrealized[14:] = -1.0
+    history = {
+        "hsl_coin_compact_replay": {
+            "timestamps": timestamps,
+            "balances": np.full(len(timestamps), 100.0, dtype=np.float64),
+            "realized_pnl": np.zeros(len(timestamps), dtype=np.float64),
+            "pair_values": {
+                ("long", symbol): {
+                    "realized_pnl": np.zeros(
+                        len(timestamps), dtype=np.float64
+                    ),
+                    "unrealized_pnl": unrealized,
+                }
+            },
+        },
+        "panic_flatten_events": [],
+        "fill_events": [
+            {
+                "timestamp": old_entry_ts,
+                "symbol": symbol,
+                "pside": "long",
+                "action": "increase",
+                "qty": 1.0,
+                "pnl": 0.0,
+            },
+            {
+                "timestamp": old_flatten_ts,
+                "symbol": symbol,
+                "pside": "long",
+                "action": "decrease",
+                "qty": 1.0,
+                "pnl": 0.0,
+            },
+            {
+                "timestamp": current_entry_ts,
+                "symbol": symbol,
+                "pside": "long",
+                "action": "increase",
+                "qty": 1.0,
+                "pnl": 0.0,
+            },
+        ],
+    }
+    bot = make_coin_bot()
+    bot.positions = {
+        symbol: {
+            "long": {"size": 1.0, "price": 100.0},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+    }
+    bot.hsl["long"]["restart_after_red_policy"] = restart_policy
+    bot.hsl["long"]["cooldown_minutes_after_red"] = cooldown_minutes
+    bot.get_exchange_time = lambda: int(timestamps[-1])
+
+    async def current_upnl(pside=None, symbol=None):
+        return -1.0 if pside == "long" and symbol == "UNI/USDT:USDT" else 0.0
+
+    bot._calc_upnl_sum_strict = current_upnl
+
+    async def fake_history(current_balance=None, **kwargs):
+        return history
+
+    bot.get_balance_equity_history = fake_history
+
+    if should_raise:
+        with pytest.raises(
+            ValueError,
+            match="missing required unrealized_pnl_by_coin_pside value",
+        ):
+            await bot._equity_hard_stop_initialize_coin_from_history()
+        return
+
+    await bot._equity_hard_stop_initialize_coin_from_history()
+
+    state = bot._hsl_coin_state("long", symbol)
+    assert state["halted"] is False
+    assert state["last_metrics"]["timestamp_ms"] == int(timestamps[-1])
+    assert state["last_metrics"]["unrealized_pnl"] == pytest.approx(-1.0)
+    assert state["pnl_reset_timestamp_ms"] is None
+
+
 @pytest.mark.asyncio
 async def test_compact_replay_keeps_held_and_ambiguous_pairs_dense():
     import numpy as np

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -5203,19 +5203,25 @@ async def test_held_coin_replay_bounds_missing_prices_only_after_proven_cooldown
     old_entry_ts = 60_001
     old_flatten_ts = 120_001
     current_entry_ts = 900_001
+    old_entry_fee = -5.0
+    old_close_pnl = -55.0
+    old_realized_pnl = -60.0
+    realized = np.zeros(len(timestamps), dtype=np.float64)
+    realized[0] = old_entry_fee
+    realized[1:] = old_realized_pnl
+    balances = np.full(len(timestamps), 100.0, dtype=np.float64)
+    balances[0] = 100.0 - old_close_pnl
     unrealized = np.zeros(len(timestamps), dtype=np.float64)
     unrealized[0] = np.nan
     unrealized[14:] = -1.0
     history = {
         "hsl_coin_compact_replay": {
             "timestamps": timestamps,
-            "balances": np.full(len(timestamps), 100.0, dtype=np.float64),
-            "realized_pnl": np.zeros(len(timestamps), dtype=np.float64),
+            "balances": balances,
+            "realized_pnl": realized,
             "pair_values": {
                 ("long", symbol): {
-                    "realized_pnl": np.zeros(
-                        len(timestamps), dtype=np.float64
-                    ),
+                    "realized_pnl": realized,
                     "unrealized_pnl": unrealized,
                 }
             },
@@ -5229,6 +5235,7 @@ async def test_held_coin_replay_bounds_missing_prices_only_after_proven_cooldown
                 "action": "increase",
                 "qty": 1.0,
                 "pnl": 0.0,
+                "fee_paid": old_entry_fee,
             },
             {
                 "timestamp": old_flatten_ts,
@@ -5236,7 +5243,7 @@ async def test_held_coin_replay_bounds_missing_prices_only_after_proven_cooldown
                 "pside": "long",
                 "action": "decrease",
                 "qty": 1.0,
-                "pnl": 0.0,
+                "pnl": old_close_pnl,
             },
             {
                 "timestamp": current_entry_ts,
@@ -5282,7 +5289,9 @@ async def test_held_coin_replay_bounds_missing_prices_only_after_proven_cooldown
     state = bot._hsl_coin_state("long", symbol)
     assert state["halted"] is False
     assert state["last_metrics"]["timestamp_ms"] == int(timestamps[-1])
+    assert state["last_metrics"]["realized_pnl"] == pytest.approx(0.0)
     assert state["last_metrics"]["unrealized_pnl"] == pytest.approx(-1.0)
+    assert state["last_metrics"]["tier"] == "green"
     assert state["pnl_reset_timestamp_ms"] is None
 
 

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -3366,10 +3366,12 @@ async def test_start_bot_treats_hsl_value_error_as_terminal_startup_failure(
     bot._bot_ready = False
     bot.user_info = {"exchange": "gateio"}
     bot._log_startup_banner = lambda: None
-    monitor_errors = []
+    monitor_events = []
     stop_events = []
-    bot._monitor_record_event = lambda *args, **kwargs: None
-    bot._monitor_record_error = lambda *args, **kwargs: monitor_errors.append((args, kwargs))
+    bot._monitor_record_event = lambda *args, **kwargs: monitor_events.append(
+        (args, kwargs)
+    )
+    bot._monitor_record_error = MagicMock()
     bot._monitor_flush_snapshot = AsyncMock()
     bot._monitor_emit_stop = lambda *args, **kwargs: stop_events.append((args, kwargs))
     bot.init_markets = AsyncMock()
@@ -3393,11 +3395,21 @@ async def test_start_bot_treats_hsl_value_error_as_terminal_startup_failure(
         ) as exc_info:
             await bot.start_bot()
 
-    assert monitor_errors
-    assert (
-        monitor_errors[-1][1]["payload"]["stage"]
-        == "equity_hard_stop_initialize_coin_from_history"
-    )
+    incident_events = [
+        item for item in monitor_events if item[0][0] in {"error.bot", "error.bot.detail"}
+    ]
+    assert [item[0][0] for item in incident_events] == [
+        "error.bot",
+        "error.bot.detail",
+    ]
+    summary = incident_events[0][0][2]
+    detail = incident_events[1][0][2]
+    assert summary["stage"] == "equity_hard_stop_initialize_coin_from_history"
+    assert summary["incident_id"] == detail["incident_id"]
+    assert summary["origin"] != "unknown"
+    assert detail["traceback"]["frame_count"] >= 1
+    assert detail["traceback"]["includes_exception_text"] is False
+    bot._monitor_record_error.assert_not_called()
     assert stop_events[-1][0][0] == "startup_error"
     assert stop_events[-1][1]["payload"] == {
         "stage": "equity_hard_stop_initialize_coin_from_history",

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -6019,9 +6019,22 @@ async def test_start_bot_records_startup_error_stop_and_early_snapshot(
     assert bot.monitor_publisher.events[-1]["kind"] == "bot.stop"
     assert bot.monitor_publisher.events[-1]["payload"]["reason"] == "startup_error"
     assert bot.monitor_publisher.events[-1]["payload"]["stage"] == "start_data_maintainers"
-    assert bot.monitor_publisher.errors[-1]["kind"] == "error.bot"
-    assert bot.monitor_publisher.errors[-1]["payload"]["source"] == "start_bot"
-    assert bot.monitor_publisher.errors[-1]["payload"]["stage"] == "start_data_maintainers"
+    incident_events = [
+        event
+        for event in bot.monitor_publisher.events
+        if event["kind"] in {"error.bot", "error.bot.detail"}
+    ]
+    assert [event["kind"] for event in incident_events] == [
+        "error.bot",
+        "error.bot.detail",
+    ]
+    assert incident_events[0]["payload"]["source"] == "start_bot"
+    assert incident_events[0]["payload"]["stage"] == "start_data_maintainers"
+    assert (
+        incident_events[0]["payload"]["incident_id"]
+        == incident_events[1]["payload"]["incident_id"]
+    )
+    assert incident_events[1]["payload"]["traceback"]["frame_count"] >= 1
 
 
 def test_maybe_log_silence_watchdog_emits_phase_and_stage(monkeypatch, caplog):


### PR DESCRIPTION
## Summary

- bound coin-mode HSL startup replay to the fill-proven current episode, plus any predecessor episodes still connected by the configured restart cooldown, when `restart_after_red_policy=always`
- rebase cumulative realized PnL at that boundary so gains, losses, and fees from discarded episodes cannot affect current-episode drawdown
- preserve strict full-lookback requirements for threshold/never policies and for ambiguous, incomplete, or position-size-inconsistent fill histories
- emit a correlated durable `error.bot.detail` event with a bounded exception-frame chain when startup fails, while keeping the normal console error compact and free of exception text
- document the replay-boundary and startup-incident contracts

## Root cause

Gate exposes only a recent public 1m OHLCV window. Coin HSL startup nevertheless selected the earliest held-pair fill from the complete configured lookback, including already-flat historical episodes that could no longer influence an `always` restart-policy current episode. That required unavailable old candle/uPnL history and failed startup even though the current held episode had complete fill and candle coverage.

## Behavior

For `restart_after_red_policy=always`, a held pair may start replay at its proven current episode. The boundary walks backward only across predecessor episodes whose flat-to-next-entry gaps are shorter than the configured cooldown, because those episodes can still affect current cooldown state. A cooldown-breaking flat gap ends the dependency chain.

Pair realized PnL is cumulative across the replay record window. The boundary therefore carries the discarded episodes' cumulative realized value into the new episode baseline before evaluating retained rows.

The optimization is fail-closed: missing episode boundaries, replayed-size disagreement with the authoritative current position, ambiguous fill attribution, and stricter restart policies retain the existing full-lookback requirement.

## Validation

- `python -m py_compile src/passivbot_hsl.py`
- focused Gate-like compact-replay regression matrix: 3 passed
- `pytest tests/test_hsl_coin_mode.py`
- `pytest tests/test_passivbot_balance_split.py tests/test_passivbot_monitor.py tests/test_monitor_publisher.py tests/test_live_event_bus.py`
- `PYTHONPATH=src python src/tools/check_ai_docs.py`
- generated live-event registry check
- `pytest tests/test_ai_docs.py tests/test_live_event_registry_docs.py`
- `git diff --check origin/master...HEAD`

An approved authenticated Gate live smoke test used the existing private bot configuration and cache/fill history. The previously failing held-position startup reached HSL ready, startup ready, market ready, and full warmup ready; the held position was classified green, protective and entry orders reconciled through the cancel-first barrier, websocket order/candle ingestion started, and the current run reported zero errors or dropped events. No private runtime artifacts are included in this PR.

## Review focus

Please pay particular attention to the proof of the current-episode boundary, backward cooldown chaining, preservation of fill-derived transition state while skipping older rows, and the strict fallbacks for non-`always` policies and ambiguous histories.
