### PR TITLE
Speed up frame candle materialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Speed up combined backtest and optimizer-suite candle materialization by writing bounded
+  time-major chunks instead of repeatedly sweeping the full memmap once per coin.
 - Prevent unproven fill-history coverage from consuming the generic live restart budget; one reason-aware execution-loop backoff owns fill retries while planning remains fail-closed, and already-latched HSL RED supervision continues during coverage repair.
 - Stop refetching every account surface when a known fill only gains authoritative PnL or revised fee evidence, while retaining confirmation for new source identities or structural fill changes; validate realized-PnL history once per Rust planning cycle instead of rescanning it for unstuck eligibility.
 - Scope live fill-history readiness to enabled consumers: PnL risk keeps its configured lookback, entry cooldown proves only its structural-fill horizon, and bots without historical consumers use bounded recent ingestion.

--- a/src/backtest_dataset_materializer.py
+++ b/src/backtest_dataset_materializer.py
@@ -14,6 +14,9 @@ from backtest_cancellation import raise_if_backtest_cancel_requested
 from ohlcv_store import OhlcvStore, timeframe_to_interval_ms
 
 
+_FRAME_MATERIALIZER_TARGET_CHUNK_BYTES = 64 * 1024 * 1024
+
+
 def _fill_sparse_hlcv_gaps(
     values: np.ndarray, valid_mask: np.ndarray, *, fill_edge_gaps: bool = False
 ) -> int:
@@ -142,6 +145,30 @@ def _close_memmap(array: np.memmap | None) -> None:
             mmap_obj.close()
         except (BufferError, OSError, ValueError):
             pass
+
+
+def _write_time_major_frame_chunks(
+    destination: np.ndarray,
+    frames: list[np.ndarray],
+    *,
+    target_chunk_bytes: int = _FRAME_MATERIALIZER_TARGET_CHUNK_BYTES,
+) -> int:
+    """Write coin-major source frames into a time-major destination in bounded chunks."""
+    if not frames:
+        return 0
+    n_steps = int(destination.shape[0])
+    row_bytes = int(len(frames) * destination.shape[2] * destination.dtype.itemsize)
+    chunk_rows = max(1, int(target_chunk_bytes) // max(1, row_bytes))
+    chunk_count = 0
+    for start in range(0, n_steps, chunk_rows):
+        raise_if_backtest_cancel_requested("frame materializer chunk write")
+        end = min(n_steps, start + chunk_rows)
+        destination[start:end, :, :] = np.stack(
+            [frame[start:end, :] for frame in frames],
+            axis=1,
+        )
+        chunk_count += 1
+    return chunk_count
 
 
 @dataclass(frozen=True)
@@ -401,8 +428,6 @@ def materialize_frames(
     try:
         raise_if_backtest_cancel_requested("frame materializer memmap allocation")
         hlcvs = np.memmap(hlcvs_path, mode="w+", dtype=np.float64, shape=(n_steps, len(coins), 4))
-        hlcvs[:] = np.nan
-        raise_if_backtest_cancel_requested("frame materializer hlcvs initialization")
         timestamps_mm = np.memmap(timestamps_path, mode="w+", dtype=np.int64, shape=(n_steps,))
         timestamps_mm[:] = ts_arr
         btc_mm = np.memmap(btc_path, mode="w+", dtype=np.float64, shape=(n_steps,))
@@ -410,17 +435,18 @@ def materialize_frames(
         raise_if_backtest_cancel_requested("frame materializer static arrays")
 
         enriched_mss = deepcopy(mss)
+        prepared_frames: list[np.ndarray] = []
         for coin_idx, coin in enumerate(coins):
             raise_if_backtest_cancel_requested("frame materializer coin loop")
             coin_t0 = time.monotonic()
             logging.info(
-                "[materializer] frame coin start %d/%d exchange=%s coin=%s",
+                "[materializer] frame coin prepare start %d/%d exchange=%s coin=%s",
                 coin_idx + 1,
                 len(coins),
                 exchange,
                 coin,
             )
-            aligned = np.array(aligned_values_by_coin[coin], dtype=np.float64, copy=True)
+            aligned = np.asarray(aligned_values_by_coin[coin], dtype=np.float64)
             if aligned.shape != (n_steps, 4):
                 raise ValueError(
                     f"aligned_values_by_coin[{coin!r}] must have shape ({n_steps}, 4), got {aligned.shape}"
@@ -439,12 +465,23 @@ def materialize_frames(
                 start_ts=int(ts_arr[0]) if n_steps else 0,
                 interval_ms=60_000 if n_steps < 2 else int(ts_arr[1] - ts_arr[0]),
             )
-            synthetic_gap_fill_count = _fill_sparse_hlcv_gaps(aligned, valid_mask)
+            has_internal_gaps = (
+                source_valid_count > 0
+                and source_valid_count
+                < source_last_valid_index - source_first_valid_index + 1
+            )
+            if has_internal_gaps:
+                # Preserve the caller-owned aligned frame while applying the same
+                # synthetic-gap policy to the materialized payload.
+                aligned = np.array(aligned, dtype=np.float64, copy=True)
+                synthetic_gap_fill_count = _fill_sparse_hlcv_gaps(aligned, valid_mask)
+            else:
+                synthetic_gap_fill_count = 0
             if synthetic_gaps_tradable:
                 tradable_first_index, tradable_last_index, _tradable_count = (
                     _longest_contiguous_valid_span(valid_mask)
                 )
-            hlcvs[:, coin_idx, :] = aligned
+            prepared_frames.append(aligned)
             meta = enriched_mss.setdefault(coin, {})
             meta["first_valid_index"] = tradable_first_index
             meta["last_valid_index"] = tradable_last_index
@@ -457,7 +494,7 @@ def materialize_frames(
                 if synthetic_gaps_tradable:
                     meta["synthetic_gap_fill_tradable"] = True
             logging.info(
-                "[materializer] frame coin done %d/%d exchange=%s coin=%s source_first_valid=%d "
+                "[materializer] frame coin prepare done %d/%d exchange=%s coin=%s source_first_valid=%d "
                 "source_last_valid=%d invalid_rows=%d synthetic_filled=%d elapsed_s=%.1f",
                 coin_idx + 1,
                 len(coins),
@@ -471,6 +508,26 @@ def materialize_frames(
             )
             raise_if_backtest_cancel_requested("frame materializer coin finalize")
 
+        write_t0 = time.monotonic()
+        logging.info(
+            "[materializer] frame write start exchange=%s rows=%d coins=%d bytes=%d",
+            exchange,
+            n_steps,
+            len(coins),
+            int(hlcvs.nbytes),
+        )
+        chunk_count = _write_time_major_frame_chunks(hlcvs, prepared_frames)
+        write_elapsed = time.monotonic() - write_t0
+        logging.info(
+            "[materializer] frame write done exchange=%s rows=%d coins=%d chunks=%d "
+            "elapsed_s=%.1f throughput_mib_s=%.1f",
+            exchange,
+            n_steps,
+            len(coins),
+            chunk_count,
+            write_elapsed,
+            float(hlcvs.nbytes) / (1024.0**2) / max(write_elapsed, 1e-9),
+        )
         raise_if_backtest_cancel_requested("frame materializer close")
         _close_memmap(hlcvs)
         _close_memmap(timestamps_mm)

--- a/tests/test_ohlcv_v2_foundation.py
+++ b/tests/test_ohlcv_v2_foundation.py
@@ -3,7 +3,11 @@ import sqlite3
 import numpy as np
 import pytest
 
-from backtest_dataset_materializer import BacktestDatasetMaterializer, materialize_frames
+from backtest_dataset_materializer import (
+    BacktestDatasetMaterializer,
+    _write_time_major_frame_chunks,
+    materialize_frames,
+)
 from ohlcv_catalog import OhlcvCatalog
 from ohlcv_planner import plan_local_symbol_range
 from ohlcv_store import OhlcvStore, month_offset, month_start_ts, rows_in_month
@@ -772,6 +776,7 @@ def test_materialize_frames_fills_internal_sparse_gaps(tmp_path):
             dtype=np.float64,
         ),
     }
+    original_aligned = aligned_values_by_coin["ETH"].copy()
 
     handle = materialize_frames(
         output_root=tmp_path / "caches" / "ohlcvs" / "materialized",
@@ -791,6 +796,27 @@ def test_materialize_frames_fills_internal_sparse_gaps(tmp_path):
     assert handle.mss["ETH"]["source_first_valid_index"] == 0
     assert handle.mss["ETH"]["source_last_valid_index"] == 2
     assert handle.mss["ETH"]["synthetic_gap_fill_count"] == 1
+    np.testing.assert_array_equal(
+        aligned_values_by_coin["ETH"],
+        original_aligned,
+    )
+
+
+def test_write_time_major_frame_chunks_matches_direct_stack():
+    frames = [
+        np.arange(28, dtype=np.float64).reshape(7, 4) + coin_idx * 100.0
+        for coin_idx in range(3)
+    ]
+    destination = np.full((7, 3, 4), np.nan, dtype=np.float64)
+
+    chunk_count = _write_time_major_frame_chunks(
+        destination,
+        frames,
+        target_chunk_bytes=2 * 3 * 4 * np.dtype(np.float64).itemsize,
+    )
+
+    assert chunk_count == 4
+    np.testing.assert_array_equal(destination, np.stack(frames, axis=1))
 
 
 def test_chunk_checksum_matches_tobytes_reference(tmp_path):


### PR DESCRIPTION
## Summary

- write prepared candle frames to the time-major memmap in bounded 64 MiB chunks
- avoid the separate full-memmap NaN initialization pass
- avoid unconditional per-coin copies when no internal gaps need synthetic filling
- preserve cancellation checkpoints, metadata, sparse-gap behavior, and caller-owned input arrays

## Performance

Synthetic 52-coin materialization benchmark:

| Rows | Dataset | Before | After | Speedup |
| ---: | ---: | ---: | ---: | ---: |
| 250,000 | 0.39 GiB | 2.0475 s | 1.6115 s | 1.27x |
| 1,000,000 | 1.55 GiB | 7.2292 s | 5.6074 s | 1.29x |

The pre/post 250,000-row candle payload and materialized metadata files were SHA-256 identical.

## Validation

- 171 focused materializer, cache, preparation, and optimizer-suite tests passed
- real compiled-Rust backtest smoke passed with a 2,000-row materialized frame
- `git diff --check` passed