### PR TITLE
Reduce suite dataset copy overhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Reduce optimizer-suite startup time and peak memory by copying materialized candle datasets
+  directly into shared memory instead of creating a redundant full-size intermediate array.
 - Speed up combined backtest and optimizer-suite candle materialization by writing bounded
   time-major chunks instead of repeatedly sweeping the full memmap once per coin.
 - Prevent unproven fill-history coverage from consuming the generic live restart budget; one reason-aware execution-loop backoff owns fill retries while planning remains fail-closed, and already-latched HSL RED supervision continues during coverage repair.

--- a/src/suite_runner.py
+++ b/src/suite_runner.py
@@ -750,8 +750,6 @@ async def prepare_master_datasets(
             coin: str(mss.get(coin, {}).get("exchange", exchange_name)) for coin in coins
         }
         available_exchanges = sorted(set(coin_exchange.values())) or [exchange_name]
-        hlcvs_array = np.array(hlcvs, dtype=np.float64, copy=True, order="C")
-        btc_array = np.array(btc_usd_prices, dtype=np.float64, copy=True, order="C")
         timestamps_array = (
             None
             if timestamps is None
@@ -759,14 +757,19 @@ async def prepare_master_datasets(
         )
         hlcvs_spec = None
         btc_spec = None
-        if shared_array_manager is not None:
-            # Copy to SharedMemory, then reassign to view (frees intermediate copy)
-            hlcvs_spec, hlcvs_view = shared_array_manager.create_from(hlcvs_array)
-            del hlcvs_array  # Free intermediate contiguous array
-            hlcvs_array = hlcvs_view
-            btc_spec, btc_view = shared_array_manager.create_from(btc_array)
-            del btc_array  # Free intermediate contiguous array
-            btc_array = btc_view
+        if shared_array_manager is None:
+            hlcvs_array = np.array(hlcvs, dtype=np.float64, copy=True, order="C")
+            btc_array = np.array(btc_usd_prices, dtype=np.float64, copy=True, order="C")
+        else:
+            # The materialized arrays are already float64 and contiguous in the normal
+            # suite path. Copy them directly into SharedMemory instead of first making
+            # another full-size process-local array.
+            hlcvs_spec, hlcvs_array = shared_array_manager.create_from(
+                np.ascontiguousarray(hlcvs, dtype=np.float64)
+            )
+            btc_spec, btc_array = shared_array_manager.create_from(
+                np.ascontiguousarray(btc_usd_prices, dtype=np.float64)
+            )
         release_materialized_payload(hlcvs)
         return ExchangeDataset(
             exchange=exchange_label,

--- a/tests/test_suite_runner.py
+++ b/tests/test_suite_runner.py
@@ -563,6 +563,75 @@ async def test_prepare_master_datasets_uses_scenario_windows_for_individual_exch
     )
 
 
+@pytest.mark.asyncio
+async def test_prepare_master_datasets_copies_materialized_arrays_directly_to_shared_memory(
+    monkeypatch,
+):
+    source_hlcvs = np.arange(24, dtype=np.float64).reshape(3, 2, 4)
+    source_btc = np.array([10.0, 11.0, 12.0], dtype=np.float64)
+    timestamps = np.array([0, 60_000, 120_000], dtype=np.int64)
+
+    async def fake_prepare_hlcvs_mss(config, exchange, *, force_refetch_gaps=False):
+        return (
+            ["BTC", "ETH"],
+            source_hlcvs,
+            {
+                "BTC": {"exchange": exchange},
+                "ETH": {"exchange": exchange},
+                "__meta__": {},
+            },
+            "",
+            f"/tmp/{exchange}",
+            source_btc,
+            timestamps,
+        )
+
+    class RecordingSharedArrayManager:
+        def __init__(self):
+            self.sources = []
+
+        def create_from(self, array):
+            self.sources.append(array)
+            copied = np.array(array, copy=True, order="C")
+            spec = SimpleNamespace(
+                name=f"test-{len(self.sources)}",
+                shape=copied.shape,
+                dtype=copied.dtype.str,
+            )
+            return spec, copied
+
+    monkeypatch.setitem(
+        sys.modules,
+        "backtest",
+        SimpleNamespace(prepare_hlcvs_mss=fake_prepare_hlcvs_mss),
+    )
+    manager = RecordingSharedArrayManager()
+    base_config = {
+        "backtest": {
+            "start_date": "1970-01-01T00:00:00",
+            "end_date": "1970-01-01T00:02:00",
+            "exchanges": ["binance"],
+            "coins": {},
+        },
+        "live": {
+            "approved_coins": {"long": ["BTC", "ETH"], "short": []},
+            "ignored_coins": {"long": [], "short": []},
+        },
+    }
+
+    datasets = await prepare_master_datasets(
+        base_config,
+        ["binance"],
+        shared_array_manager=manager,
+    )
+
+    assert len(manager.sources) == 2
+    assert np.shares_memory(manager.sources[0], source_hlcvs)
+    assert np.shares_memory(manager.sources[1], source_btc)
+    np.testing.assert_array_equal(datasets["binance"].hlcvs, source_hlcvs)
+    np.testing.assert_array_equal(datasets["binance"].btc_usd_prices, source_btc)
+
+
 def test_aggregate_metrics_computes_stats():
     scenario_results = [
         ScenarioResult(


### PR DESCRIPTION
## Summary

- copy materialized HLCV and BTC arrays directly into optimizer-suite shared memory
- retain the existing owned contiguous-copy behavior when no shared-memory manager is present
- add regression coverage proving the shared-memory path consumes the original materialized buffers and preserves values

## Root cause

Suite preparation first copied the complete materialized candle memmap into a process-local NumPy array. `SharedArrayManager.create_from()` then copied that intermediate into its shared-memory segment. The intermediate was redundant for the normal float64 contiguous materialized payload.

## Performance

Offline handoff benchmark using a 250,000 × 52 × 4 float64 candle payload (396.7 MiB):

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Handoff time | 0.290 s | 0.096 s | 3.02x faster |
| Peak RSS | 1,227 MiB | 830 MiB | 397 MiB lower |

The before/after shared-memory payload SHA-256 was identical: `093ee6103f7028c0ddd8af022e6fdc50c6ae6b5122937aad1264cf3a691eab3c`.

For the observed 3,423,168 × 52 payload, this removes a redundant approximately 5.30 GiB intermediate allocation.

## Validation

- `49 passed`: suite runner, optimizer suite contexts, suite config, and suite config sources
- focused regression proves direct buffer sharing at the handoff boundary and exact copied values
- rebuilt and fingerprint-verified the current compiled Rust extension before optimizer-context tests
- `compileall` passed for changed Python files
- `git diff --check` passed