### PR TITLE
Harden combined HLCV preparation across environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ All notable user-facing changes will be documented in this file.
   strategy branches remain independent when their input needs differ, and independent panic,
   WEL, and TWEL reducers may continue when their own inputs are complete.
 
+- Harden combined-exchange HLCV preparation across independently downloaded datasets: equivalent
+  full-range sources now follow configured exchange priority instead of total volume, robust
+  complete-day median-log estimates replace arithmetic volume averaging, and underdetermined
+  normalization fails loudly. `backtest.volume_normalization` now controls scaling and cache
+  identity, while cache manifests and backtest dataset artifacts retain source-selection and
+  normalization provenance.
 - Reduce optimizer-suite startup time and peak memory by copying materialized candle datasets
   directly into shared memory instead of creating a redundant full-size intermediate array.
 - Speed up combined backtest and optimizer-suite candle materialization by writing bounded

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,8 +37,9 @@ For the recommended user workflow, examples, and best practices, see [Config Wor
   the median of per-coin median daily log-volume ratios over each coin/exchange pair's latest
   complete-overlap UTC days. Daily estimates require at least 95% common minute coverage, and
   underdetermined exchange links fail loudly instead of silently using an unstable factor. Forced
-  source exchanges contribute normalization-only overlap candidates without entering unrelated
-  source selection. Set to `false` to preserve each selected
+  source exchanges contribute normalization-only overlap candidates, bounded to the normalization
+  lookback, without entering unrelated source selection. `coin_sources` overrides outside the
+  effective coin universe do not trigger candle preparation. Set to `false` to preserve each selected
   exchange's native volume. The first selected exchange in `backtest.exchanges` is the stable
   normalization reference. Equivalent full-range candle sources are also selected by that
   configured order; total volume is never a source-selection tie-breaker. Cache manifests and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,9 +34,11 @@ For the recommended user workflow, examples, and best practices, see [Config Wor
   window clipped to the verified dataset. `dataset` adopts the dataset's
   effective coins and timestamp window for exact artifact replay.
 - **volume_normalization**: When `true` (default), normalize volume data across exchanges using
-  the median of per-coin median daily log-volume ratios over the latest complete UTC days. Daily
-  estimates require at least 95% common minute coverage, and underdetermined exchange links fail
-  loudly instead of silently using an unstable factor. Set to `false` to preserve each selected
+  the median of per-coin median daily log-volume ratios over each coin/exchange pair's latest
+  complete-overlap UTC days. Daily estimates require at least 95% common minute coverage, and
+  underdetermined exchange links fail loudly instead of silently using an unstable factor. Forced
+  source exchanges contribute normalization-only overlap candidates without entering unrelated
+  source selection. Set to `false` to preserve each selected
   exchange's native volume. The first selected exchange in `backtest.exchanges` is the stable
   normalization reference. Equivalent full-range candle sources are also selected by that
   configured order; total volume is never a source-selection tie-breaker. Cache manifests and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,7 +33,15 @@ For the recommended user workflow, examples, and best practices, see [Config Wor
   config. `intersection` (default) keeps the config's requested coins/date
   window clipped to the verified dataset. `dataset` adopts the dataset's
   effective coins and timestamp window for exact artifact replay.
-- **volume_normalization**: When `true` (default), normalize volume data across exchanges to make combined datasets comparable.
+- **volume_normalization**: When `true` (default), normalize volume data across exchanges using
+  the median of per-coin median daily log-volume ratios over the latest complete UTC days. Daily
+  estimates require at least 95% common minute coverage, and underdetermined exchange links fail
+  loudly instead of silently using an unstable factor. Set to `false` to preserve each selected
+  exchange's native volume. The first selected exchange in `backtest.exchanges` is the stable
+  normalization reference. Equivalent full-range candle sources are also selected by that
+  configured order; total volume is never a source-selection tie-breaker. Cache manifests and
+  backtest `dataset.json` artifacts record the chosen sources, reasons, estimation window,
+  contributors, dispersion, exclusions, reference exchange, and full-precision scale factors.
 - **start_date**: Start date of backtest.
 - **starting_balance**: Starting balance in USD at the beginning of the backtest.
 - **filter_by_min_effective_cost**: When `true`, skip coins whose projected initial entry

--- a/src/backtest.py
+++ b/src/backtest.py
@@ -102,6 +102,7 @@ from pure_funcs import (
 import pprint
 from copy import deepcopy
 from hlcv_preparation import (
+    HLCV_PREPARATION_ALGORITHM_VERSION,
     prepare_hlcvs,
     prepare_hlcvs_combined,
     try_prepare_hlcvs_v2_local,
@@ -1440,6 +1441,11 @@ def get_cache_hash(config, exchange):
         "coin_sources": coin_sources_sorted,
         "market_settings_sources": market_settings_sources_sorted,
     }
+    if exchange == "combined":
+        to_hash["volume_normalization"] = bool(
+            config.get("backtest", {}).get("volume_normalization", True)
+        )
+        to_hash["hlcv_preparation_algorithm_version"] = HLCV_PREPARATION_ALGORITHM_VERSION
     return calc_hash(to_hash)
 
 

--- a/src/backtest_dataset.py
+++ b/src/backtest_dataset.py
@@ -62,6 +62,7 @@ def build_backtest_dataset_metadata(config: dict, exchange: str) -> dict:
     manifest_schema_version = None
     materialization_schema_version = None
     content_hashes = {}
+    preparation = {}
     cache_build_side_membership = None
     manifest_missing = None
     coins_order = list(coins_from_config)
@@ -101,6 +102,9 @@ def build_backtest_dataset_metadata(config: dict, exchange: str) -> dict:
                     cache_build_side_membership = effective.get("build_side_membership")
                     if not isinstance(cache_build_side_membership, dict):
                         cache_build_side_membership = effective.get("side_membership")
+                manifest_preparation = manifest.get("preparation", {})
+                if isinstance(manifest_preparation, dict):
+                    preparation = manifest_preparation
         if coins_file:
             with open(coins_file) as f:
                 loaded_coins = json.load(f)
@@ -134,6 +138,7 @@ def build_backtest_dataset_metadata(config: dict, exchange: str) -> dict:
         "manifest_schema_version": manifest_schema_version,
         "materialization_schema_version": materialization_schema_version,
         "content_hashes": content_hashes,
+        "preparation": preparation,
         "side_membership": (
             runtime_side_membership
             if runtime_side_membership is not None

--- a/src/config_utils.py
+++ b/src/config_utils.py
@@ -1600,8 +1600,8 @@ CLI_HELP_OVERRIDES = {
     ),
     "backtest.base_dir": "Directory where standalone backtest results are written.",
     "backtest.volume_normalization": (
-        "Normalize volume across exchanges for combined datasets. Leave enabled "
-        "for comparable combined-exchange backtests."
+        "Normalize combined-exchange volume with robust complete-day, cross-coin "
+        "estimates. Disable to preserve each selected exchange's native volume."
     ),
     "backtest.liquidation_threshold": (
         "Early-stop equity floor as a fraction of starting balance. Must "

--- a/src/hlcv_preparation.py
+++ b/src/hlcv_preparation.py
@@ -106,7 +106,7 @@ from warmup_utils import compute_backtest_warmup_minutes, compute_per_coin_warmu
 from backtest_universe import effective_backtest_data_coins
 
 
-HLCV_PREPARATION_ALGORITHM_VERSION = 3
+HLCV_PREPARATION_ALGORITHM_VERSION = 4
 VOLUME_NORMALIZATION_LOOKBACK_DAYS = 60
 VOLUME_NORMALIZATION_MIN_COMMON_FRACTION = 0.95
 VOLUME_NORMALIZATION_MIN_ELIGIBLE_DAYS_FRACTION = 0.80
@@ -118,7 +118,7 @@ def _partition_combined_exchange_roles(
     forced_sources: Dict[str, str],
     market_settings_sources: Dict[str, str],
 ) -> tuple[list[str], list[str]]:
-    """Separate OHLCV candidates from exchanges needed only by per-coin overrides."""
+    """Separate source-selection exchanges from per-coin override managers."""
     candidate_exchanges = list(dict.fromkeys(configured_exchanges))
     candidate_exchange_set = set(candidate_exchanges)
     override_only_exchanges = sorted(
@@ -143,6 +143,7 @@ class CombinedCoinPlan:
     coin: str
     effective_start_ts: int
     forced_exchange: Optional[str]
+    selection_exchanges: tuple[str, ...]
     candidate_exchanges: tuple[str, ...]
 
 
@@ -4245,14 +4246,25 @@ async def prepare_hlcvs_combined(
         for coin, exchange in market_settings_sources.items()
         if exchange
     }
-    # Only configured exchanges are candidates for unforced coins. Exchanges used
-    # solely by a per-coin override still need managers, but must not leak into the
-    # candidate list. Sort those extras so mapping insertion order cannot affect work.
+    # Only configured exchanges may be selected for unforced coins. Exchanges used
+    # solely by a per-coin override still need managers and normalization overlap
+    # candidates, but must not enter unrelated source selection. Sort those extras
+    # so mapping insertion order cannot affect work.
     ohlcv_exchanges, extra_exchanges = _partition_combined_exchange_roles(
         exchanges_to_consider,
         normalized_forced_sources,
         normalized_mss_sources,
     )
+    normalization_candidate_exchanges = list(
+        dict.fromkeys(
+            [
+                *ohlcv_exchanges,
+                *sorted(set(normalized_forced_sources.values()) - set(ohlcv_exchanges)),
+            ]
+        )
+    )
+    if not bool(config.get("backtest", {}).get("volume_normalization", True)):
+        normalization_candidate_exchanges = []
 
     requested_start_date = require_config_value(config, "backtest.start_date")
     requested_start_ts = int(date_to_ts(requested_start_date))
@@ -4329,6 +4341,7 @@ async def prepare_hlcvs_combined(
             normalized_mss_sources,
             force_refetch_gaps=force_refetch_gaps,
             ohlcv_exchanges=ohlcv_exchanges,
+            normalization_candidate_exchanges=normalization_candidate_exchanges,
             catalog=catalog,
             store=store,
             legacy_root=legacy_root,
@@ -4423,6 +4436,7 @@ async def _prepare_hlcvs_combined_impl(
     *,
     force_refetch_gaps: bool,
     ohlcv_exchanges: Optional[Sequence[str]] = None,
+    normalization_candidate_exchanges: Optional[Sequence[str]] = None,
     catalog: OhlcvCatalog,
     store: OhlcvStore,
     legacy_root: Path | None,
@@ -4435,6 +4449,7 @@ async def _prepare_hlcvs_combined_impl(
         exchanges_to_consider = [ex for ex in ohlcv_exchanges if ex in om_dict]
     else:
         exchanges_to_consider = sorted(list(om_dict.keys()))
+    normalization_candidate_exchanges = list(normalization_candidate_exchanges or ())
     minimum_coin_age_days = float(require_live_value(config, "minimum_coin_age_days"))
     interval_ms = 60_000
     min_coin_age_ms = 1000 * 60 * 60 * 24 * minimum_coin_age_days
@@ -4477,6 +4492,7 @@ async def _prepare_hlcvs_combined_impl(
             forced_sources=forced_sources,
             market_settings_sources=market_settings_sources,
             exchanges_to_consider=exchanges_to_consider,
+            normalization_candidate_exchanges=normalization_candidate_exchanges,
             om_dict=om_dict,
             per_coin_warmups=per_coin_warmups,
             default_warm=default_warm,
@@ -4762,6 +4778,7 @@ def _plan_combined_coin(
     tradfi_for_stock_perps: bool,
     forced_sources: Dict[str, str],
     exchanges_to_consider: Sequence[str],
+    normalization_candidate_exchanges: Sequence[str] = (),
 ) -> Optional[CombinedCoinPlan]:
     is_stock_perp_coin = coin.startswith("xyz:")
     if coin not in first_timestamps_unified and not (is_stock_perp_coin and tradfi_for_stock_perps):
@@ -4796,13 +4813,17 @@ def _plan_combined_coin(
     forced_exchange = forced_sources.get(coin)
     if forced_exchange is None and coin.startswith("xyz:"):
         forced_exchange = forced_sources.get(coin[4:])
-    candidate_exchanges = (
+    selection_exchanges = (
         (forced_exchange,) if forced_exchange is not None else tuple(exchanges_to_consider)
+    )
+    candidate_exchanges = tuple(
+        dict.fromkeys([*selection_exchanges, *normalization_candidate_exchanges])
     )
     return CombinedCoinPlan(
         coin=coin,
         effective_start_ts=int(effective_start_ts),
         forced_exchange=forced_exchange,
+        selection_exchanges=tuple(selection_exchanges),
         candidate_exchanges=tuple(candidate_exchanges),
     )
 
@@ -5011,6 +5032,7 @@ async def _resolve_combined_coin(
     forced_sources: Dict[str, str],
     market_settings_sources: Dict[str, str],
     exchanges_to_consider: Sequence[str],
+    normalization_candidate_exchanges: Sequence[str],
     om_dict: Dict[str, HLCVManager],
     per_coin_warmups: dict,
     default_warm: int,
@@ -5032,6 +5054,7 @@ async def _resolve_combined_coin(
             tradfi_for_stock_perps=tradfi_for_stock_perps,
             forced_sources=forced_sources,
             exchanges_to_consider=exchanges_to_consider,
+            normalization_candidate_exchanges=normalization_candidate_exchanges,
         )
         if plan is None:
             return None
@@ -5052,7 +5075,13 @@ async def _resolve_combined_coin(
                 use_v2_local=use_v2_local,
                 candidate_report=candidate_report,
             )
-            if not candidates:
+            selection_exchange_set = set(plan.selection_exchanges)
+            selection_candidates = [
+                candidate
+                for candidate in candidates
+                if candidate.exchange in selection_exchange_set
+            ]
+            if not selection_candidates:
                 if plan.forced_exchange:
                     raise ValueError(
                         f"No exchange data found for coin {coin} on forced exchange {plan.forced_exchange}."
@@ -5063,14 +5092,15 @@ async def _resolve_combined_coin(
             best_candidate = _pick_best_combined_candidate(
                 coin,
                 plan.forced_exchange,
-                candidates,
-                exchange_priority=plan.candidate_exchanges,
+                selection_candidates,
+                exchange_priority=plan.selection_exchanges,
             )
             selection_reason = _combined_candidate_selection_reason(
-                best_candidate, plan.forced_exchange, candidates
+                best_candidate, plan.forced_exchange, selection_candidates
             )
             logging.info(
-                f"{coin} exchange preference: {[candidate.exchange for candidate in candidates]}"
+                f"{coin} exchange preference: "
+                f"{[candidate.exchange for candidate in selection_candidates]}"
             )
             market_settings = _resolve_combined_market_settings(
                 coin=coin,
@@ -5138,6 +5168,7 @@ async def _load_combined_coin_candidates(
             ) from forced_result
 
     candidates: list[CombinedExchangeCandidate] = []
+    selection_exchange_set = set(plan.selection_exchanges)
     for ex, result in zip(plan.candidate_exchanges, results):
         symbol = None
         try:
@@ -5145,7 +5176,26 @@ async def _load_combined_coin_candidates(
         except Exception:
             symbol = None
         if isinstance(result, Exception):
-            raise RuntimeError(f"Exchange {ex} failed for coin {plan.coin}") from result
+            if ex in selection_exchange_set:
+                raise RuntimeError(f"Exchange {ex} failed for coin {plan.coin}") from result
+            summary = _ineligible_combined_summary(
+                coin=plan.coin,
+                exchange=ex,
+                symbol=symbol,
+                reason=f"normalization_candidate_fetch_failed:{type(result).__name__}",
+                gap_class="unknown",
+                effective_start_ts=plan.effective_start_ts,
+                end_ts=end_ts,
+            )
+            if candidate_report is not None:
+                candidate_report.append(summary.to_dict())
+            logging.warning(
+                "%s: optional normalization candidate %s failed (%s)",
+                plan.coin,
+                ex,
+                type(result).__name__,
+            )
+            continue
         if result is None:
             summary = _ineligible_combined_summary(
                 coin=plan.coin,
@@ -5548,11 +5598,9 @@ def compute_exchange_volume_ratios_with_diagnostics(
     pair_coin_logs: dict[tuple[str, str], dict[str, float]] = defaultdict(dict)
     pair_daily_logs: dict[tuple[str, str], dict[str, list[float]]] = defaultdict(dict)
     pair_excluded: dict[tuple[str, str], dict[str, str]] = defaultdict(dict)
+    pair_overlap_windows: dict[tuple[str, str], dict[str, dict]] = defaultdict(dict)
     pair_potential_counts: dict[tuple[str, str], int] = defaultdict(int)
     minimum_common_rows = int(np.ceil(1440 * VOLUME_NORMALIZATION_MIN_COMMON_FRACTION))
-    minimum_eligible_days = max(
-        1, int(np.ceil(window_days * VOLUME_NORMALIZATION_MIN_ELIGIBLE_DAYS_FRACTION))
-    )
 
     for coin in coins:
         candidate_map = {
@@ -5585,6 +5633,49 @@ def compute_exchange_volume_ratios_with_diagnostics(
                 pair_excluded[pair][coin] = "no_common_valid_timestamps"
                 continue
 
+            pair_first_ts = max(
+                min(timestamp_volumes[ex0]),
+                min(timestamp_volumes[ex1]),
+                window_start_ts,
+            )
+            pair_last_ts = min(
+                max(timestamp_volumes[ex0]),
+                max(timestamp_volumes[ex1]),
+                window_end_ts_exclusive - minute_ms,
+            )
+            pair_window_start_ts = int(
+                (pair_first_ts + day_ms - 1) // day_ms * day_ms
+            )
+            pair_window_end_ts_exclusive = _complete_utc_day_window_end_exclusive(
+                pair_last_ts
+            )
+            pair_window_days = max(
+                0,
+                (pair_window_end_ts_exclusive - pair_window_start_ts) // day_ms,
+            )
+            minimum_eligible_days = (
+                max(
+                    1,
+                    int(
+                        np.ceil(
+                            pair_window_days
+                            * VOLUME_NORMALIZATION_MIN_ELIGIBLE_DAYS_FRACTION
+                        )
+                    ),
+                )
+                if pair_window_days > 0
+                else 0
+            )
+            pair_overlap_windows[pair][coin] = {
+                "window_start_ts": pair_window_start_ts,
+                "window_end_ts_exclusive": pair_window_end_ts_exclusive,
+                "window_days": int(pair_window_days),
+                "minimum_eligible_days": int(minimum_eligible_days),
+            }
+            if pair_window_days <= 0:
+                pair_excluded[pair][coin] = "no_complete_overlap_days"
+                continue
+
             daily: dict[int, list[float]] = defaultdict(lambda: [0.0, 0.0, 0.0])
             for timestamp in pair_common_timestamps:
                 day_start = int(timestamp // day_ms * day_ms)
@@ -5595,7 +5686,7 @@ def compute_exchange_volume_ratios_with_diagnostics(
 
             daily_logs = []
             for day_start in range(
-                window_start_ts, window_end_ts_exclusive, day_ms
+                pair_window_start_ts, pair_window_end_ts_exclusive, day_ms
             ):
                 common_count, sum0, sum1 = daily.get(day_start, [0.0, 0.0, 0.0])
                 if (
@@ -5630,6 +5721,7 @@ def compute_exchange_volume_ratios_with_diagnostics(
                 coin: {
                     "ratio": float(np.exp(log_ratio)),
                     "eligible_days": len(pair_daily_logs[pair][coin]),
+                    **pair_overlap_windows[pair][coin],
                     "daily_log_ratio_mad": float(
                         np.median(
                             np.abs(
@@ -5642,6 +5734,7 @@ def compute_exchange_volume_ratios_with_diagnostics(
                 for coin, log_ratio in sorted(contributor_logs.items())
             },
             "excluded": dict(sorted(pair_excluded.get(pair, {}).items())),
+            "overlap_windows": dict(sorted(pair_overlap_windows.get(pair, {}).items())),
         }
         if required_contributors > 0 and len(contributor_logs) >= required_contributors:
             logs = np.asarray(list(contributor_logs.values()), dtype=np.float64)
@@ -5673,8 +5766,8 @@ def compute_exchange_volume_ratios_with_diagnostics(
         "window_days": int(window_days),
         "minimum_daily_common_fraction": VOLUME_NORMALIZATION_MIN_COMMON_FRACTION,
         "minimum_eligible_days_fraction": VOLUME_NORMALIZATION_MIN_ELIGIBLE_DAYS_FRACTION,
+        "minimum_eligible_days_basis": "per_coin_exchange_pair_complete_overlap",
         "minimum_common_rows_per_day": minimum_common_rows,
-        "minimum_eligible_days": minimum_eligible_days,
         "pair_estimates": pair_estimates,
     }
     return ratios, diagnostics

--- a/src/hlcv_preparation.py
+++ b/src/hlcv_preparation.py
@@ -106,6 +106,13 @@ from warmup_utils import compute_backtest_warmup_minutes, compute_per_coin_warmu
 from backtest_universe import effective_backtest_data_coins
 
 
+HLCV_PREPARATION_ALGORITHM_VERSION = 2
+VOLUME_NORMALIZATION_LOOKBACK_DAYS = 60
+VOLUME_NORMALIZATION_MIN_COMMON_FRACTION = 0.95
+VOLUME_NORMALIZATION_MIN_ELIGIBLE_DAYS_FRACTION = 0.80
+VOLUME_NORMALIZATION_MIN_CONTRIBUTORS = 3
+
+
 @dataclass(frozen=True)
 class CombinedCoinPlan:
     coin: str
@@ -202,6 +209,7 @@ class CombinedCoinResolution:
     best_df: pd.DataFrame
     market_settings: dict
     candidates: tuple[CombinedExchangeCandidate, ...]
+    selection_reason: str
 
 
 def _has_tradfi_provider_config() -> bool:
@@ -4212,7 +4220,11 @@ async def prepare_hlcvs_combined(
         for coin, exchange in market_settings_sources.items()
         if exchange
     }
-    ohlcv_exchanges = sorted(set(exchanges_to_consider) | set(normalized_forced_sources.values()))
+    # Configuration order is the stable tie-break contract for equivalent full-range
+    # candidates. Preserve it through preparation instead of converting it to a set.
+    ohlcv_exchanges = list(
+        dict.fromkeys([*exchanges_to_consider, *normalized_forced_sources.values()])
+    )
 
     requested_start_date = require_config_value(config, "backtest.start_date")
     requested_start_ts = int(date_to_ts(requested_start_date))
@@ -4255,9 +4267,17 @@ async def prepare_hlcvs_combined(
             force_refetch_gaps=force_refetch_gaps,
             ohlcv_source_dir=config.get("backtest", {}).get("ohlcv_source_dir"),
         )
-    extra_forced = set(normalized_forced_sources.values()) - set(exchanges_to_consider)
-    extra_mss = set(normalized_mss_sources.values()) - set(exchanges_to_consider) - extra_forced
-    for ex in extra_forced | extra_mss:
+    extra_exchanges = list(
+        dict.fromkeys(
+            [
+                *normalized_forced_sources.values(),
+                *normalized_mss_sources.values(),
+            ]
+        )
+    )
+    for ex in extra_exchanges:
+        if ex in om_dict:
+            continue
         om_dict[ex] = HLCVManager(
             ex,
             effective_start_date,
@@ -4331,6 +4351,7 @@ async def prepare_hlcvs_combined(
 
         warmup_provided = max(0, int(max(0, requested_start_ts - int(timestamps[0])) // minute_ms))
         candidate_report = mss.pop("__candidate_report__", [])
+        preparation_meta = mss.pop("__preparation_meta__", {})
         mss["__meta__"] = {
             "requested_start_ts": int(requested_start_ts),
             "requested_start_date": ts_to_date(requested_start_ts),
@@ -4340,6 +4361,7 @@ async def prepare_hlcvs_combined(
             "warmup_minutes_provided": int(warmup_provided),
             "btc_source_exchange": btc_source_exchange,
             "candidate_report": candidate_report,
+            **preparation_meta,
         }
 
         run_id = f"combined_{uuid4().hex[:12]}"
@@ -4409,6 +4431,7 @@ async def _prepare_hlcvs_combined_impl(
     chosen_data_per_coin = {}
     chosen_mss_per_coin = {}
     chosen_candidates_per_coin: dict[str, tuple[CombinedExchangeCandidate, ...]] = {}
+    source_selection: dict[str, dict] = {}
     candidate_report: list[dict] = []
 
     # Preload markets
@@ -4463,6 +4486,30 @@ async def _prepare_hlcvs_combined_impl(
         chosen_data_per_coin[result.coin] = result.best_df
         chosen_mss_per_coin[result.coin] = result.market_settings
         chosen_candidates_per_coin[result.coin] = result.candidates
+        selected_candidate = next(
+            candidate
+            for candidate in result.candidates
+            if candidate.exchange == result.best_exchange
+        )
+        source_selection[result.coin] = {
+            "selected_exchange": to_standard_exchange_name(result.best_exchange),
+            "selection_reason": result.selection_reason,
+            "forced": result.selection_reason == "forced_exchange",
+            "configured_priority": [
+                to_standard_exchange_name(exchange) for exchange in exchanges_to_consider
+            ],
+            "selected_quality": {
+                "full_range": bool(selected_candidate.full_range),
+                "coverage_count": int(selected_candidate.coverage_count),
+                "gap_count": int(selected_candidate.gap_count),
+                "first_ts": (
+                    selected_candidate.summary.first_ts if selected_candidate.summary else None
+                ),
+                "last_ts": (
+                    selected_candidate.summary.last_ts if selected_candidate.summary else None
+                ),
+            },
+        }
         progress.update()
 
     progress.log_done()
@@ -4478,24 +4525,7 @@ async def _prepare_hlcvs_combined_impl(
     valid_coins = sorted(chosen_data_per_coin.keys())
     n_coins = len(valid_coins)
 
-    start_ts_for_volume_ratios = max(global_start_time, global_end_time - 1000 * 60 * 60 * 24 * 60)
-
     # Use OHLCV sources for volume ratio calculation, not market settings sources
-    exchanges_with_data = sorted(
-        set(
-            [
-                chosen_mss_per_coin[coin].get("ohlcv_source", chosen_mss_per_coin[coin]["exchange"])
-                for coin in valid_coins
-            ]
-        )
-    )
-    exchange_volume_ratios = compute_exchange_volume_ratios_from_candidates(
-        exchanges_with_data,
-        valid_coins,
-        chosen_candidates_per_coin,
-        int(start_ts_for_volume_ratios),
-        int(global_end_time),
-    )
     exchanges_counts = defaultdict(int)
     for coin in chosen_mss_per_coin:
         # Use OHLCV source for volume normalization, not market settings source
@@ -4503,16 +4533,76 @@ async def _prepare_hlcvs_combined_impl(
             "ohlcv_source", chosen_mss_per_coin[coin]["exchange"]
         )
         exchanges_counts[ohlcv_exchange] += 1
-    reference_exchange = sorted(exchanges_counts.items(), key=lambda x: x[1])[-1][0]
-    exchange_volume_ratios_mapped = _build_exchange_volume_ratio_map(
-        exchange_volume_ratios,
-        exchanges_counts.keys(),
-        reference_exchange,
-        valid_coins=valid_coins,
+
+    configured_exchange_priority = list(
+        dict.fromkeys(to_standard_exchange_name(exchange) for exchange in exchanges_to_consider)
+    )
+    exchanges_with_data = [
+        exchange for exchange in configured_exchange_priority if exchange in exchanges_counts
+    ]
+    exchanges_with_data.extend(
+        sorted(set(exchanges_counts).difference(exchanges_with_data))
+    )
+    reference_exchange = _select_volume_reference_exchange(
+        exchanges_counts, configured_exchange_priority
     )
 
+    normalization_enabled = bool(config.get("backtest", {}).get("volume_normalization", True))
+    day_ms = 24 * 60 * 60 * 1000
+    normalization_end_ts_exclusive = int(global_end_time // day_ms * day_ms)
+    if int(global_end_time) % day_ms:
+        normalization_end_ts_exclusive += day_ms
+    normalization_start_ts = max(
+        int(global_start_time),
+        normalization_end_ts_exclusive - VOLUME_NORMALIZATION_LOOKBACK_DAYS * day_ms,
+    )
+    normalization_start_ts = int((normalization_start_ts + day_ms - 1) // day_ms * day_ms)
+
+    if normalization_enabled and len(exchanges_counts) > 1:
+        exchange_volume_ratios, normalization_diagnostics = (
+            compute_exchange_volume_ratios_with_diagnostics(
+                exchanges_with_data,
+                valid_coins,
+                chosen_candidates_per_coin,
+                normalization_start_ts,
+                normalization_end_ts_exclusive,
+            )
+        )
+        exchange_volume_ratios_mapped = _build_exchange_volume_ratio_map(
+            exchange_volume_ratios,
+            exchanges_counts.keys(),
+            reference_exchange,
+            valid_coins=valid_coins,
+        )
+    else:
+        exchange_volume_ratios = {}
+        exchange_volume_ratios_mapped = defaultdict(dict)
+        for exchange in exchanges_counts:
+            exchange_volume_ratios_mapped[exchange][exchange] = 1.0
+            exchange_volume_ratios_mapped[exchange][reference_exchange] = 1.0
+        normalization_diagnostics = {
+            "method": "disabled" if not normalization_enabled else "single_exchange_identity",
+            "window_start_ts": normalization_start_ts,
+            "window_end_ts_exclusive": normalization_end_ts_exclusive,
+            "pair_estimates": {},
+        }
+
+    normalization_provenance = {
+        "enabled": normalization_enabled,
+        "reference_exchange": reference_exchange,
+        "reference_selection_reason": "configured_exchange_priority",
+        "exchange_counts": {
+            exchange: int(count) for exchange, count in sorted(exchanges_counts.items())
+        },
+        "scale_factors_to_reference": {
+            exchange: float(exchange_volume_ratios_mapped[exchange][reference_exchange])
+            for exchange in sorted(exchanges_counts)
+        },
+        **normalization_diagnostics,
+    }
+
     # Log volume normalization ratios (used to scale volumes when combining multi-exchange data)
-    if len(exchanges_counts) > 1:
+    if normalization_enabled and len(exchanges_counts) > 1:
         ratio_summary = ", ".join(
             f"{ex}={exchange_volume_ratios_mapped[ex][reference_exchange]:.3f}"
             for ex in sorted(exchanges_counts.keys())
@@ -4522,6 +4612,11 @@ async def _prepare_hlcvs_combined_impl(
             "volume normalization: reference=%s ratios=[%s] (coins per exchange: %s)",
             reference_exchange,
             ratio_summary,
+            ", ".join(f"{ex}={cnt}" for ex, cnt in sorted(exchanges_counts.items())),
+        )
+    elif len(exchanges_counts) > 1:
+        logging.info(
+            "volume normalization disabled; preserving native exchange volumes (%s)",
             ", ".join(f"{ex}={cnt}" for ex, cnt in sorted(exchanges_counts.items())),
         )
 
@@ -4576,6 +4671,18 @@ async def _prepare_hlcvs_combined_impl(
             trade_start_idx = last_idx
         chosen_mss_per_coin[coin]["trade_start_index"] = trade_start_idx
 
+    for item in candidate_report:
+        coin_selection = source_selection.get(str(item.get("coin")))
+        selected = bool(
+            coin_selection
+            and to_standard_exchange_name(str(item.get("exchange")))
+            == coin_selection["selected_exchange"]
+        )
+        item["selected"] = selected
+        item["selection_reason"] = (
+            coin_selection["selection_reason"] if selected and coin_selection else None
+        )
+
     chosen_mss_per_coin["__candidate_report__"] = sorted(
         candidate_report,
         key=lambda item: (
@@ -4584,6 +4691,11 @@ async def _prepare_hlcvs_combined_impl(
             str(item.get("status", "")),
         ),
     )
+    chosen_mss_per_coin["__preparation_meta__"] = {
+        "preparation_algorithm_version": HLCV_PREPARATION_ALGORITHM_VERSION,
+        "source_selection": source_selection,
+        "volume_normalization": normalization_provenance,
+    }
     return chosen_mss_per_coin, timestamps, aligned_values_by_coin
 
 
@@ -4681,6 +4793,7 @@ def _pick_best_combined_candidate(
     coin: str,
     forced_exchange: Optional[str],
     candidates: list[CombinedExchangeCandidate],
+    exchange_priority: Optional[Sequence[str]] = None,
 ) -> CombinedExchangeCandidate:
     if not candidates:
         raise ValueError(f"No exchange data found at all for coin {coin}. Skipping.")
@@ -4693,17 +4806,54 @@ def _pick_best_combined_candidate(
         return chosen[0]
     if len(candidates) == 1:
         return candidates[0]
-    ranked = sorted(
+    ordered_priority = list(exchange_priority or [candidate.exchange for candidate in candidates])
+    priority_rank = {
+        to_standard_exchange_name(exchange): rank
+        for rank, exchange in enumerate(ordered_priority)
+    }
+
+    full_range = [candidate for candidate in candidates if candidate.full_range]
+    if full_range:
+        return min(
+            full_range,
+            key=lambda candidate: priority_rank.get(
+                to_standard_exchange_name(candidate.exchange), len(priority_rank)
+            ),
+        )
+
+    # Partial candidates still compete on data integrity. Configuration order only
+    # breaks exact coverage/gap ties; volume must never choose the candle source.
+    return min(
         candidates,
         key=lambda candidate: (
-            1 if candidate.full_range else 0,
-            candidate.coverage_count,
-            -candidate.gap_count,
-            candidate.total_volume,
+            -int(candidate.coverage_count),
+            int(candidate.gap_count),
+            priority_rank.get(to_standard_exchange_name(candidate.exchange), len(priority_rank)),
         ),
-        reverse=True,
     )
-    return ranked[0]
+
+
+def _combined_candidate_selection_reason(
+    chosen: CombinedExchangeCandidate,
+    forced_exchange: Optional[str],
+    candidates: Sequence[CombinedExchangeCandidate],
+) -> str:
+    if forced_exchange:
+        return "forced_exchange"
+    if len(candidates) == 1:
+        return "only_usable_candidate"
+    if chosen.full_range:
+        return "configured_priority_among_full_range_candidates"
+    best_coverage = max(int(candidate.coverage_count) for candidate in candidates)
+    coverage_peers = [
+        candidate for candidate in candidates if int(candidate.coverage_count) == best_coverage
+    ]
+    if len(coverage_peers) == 1:
+        return "highest_partial_coverage"
+    best_gap_count = min(int(candidate.gap_count) for candidate in coverage_peers)
+    if sum(int(candidate.gap_count) == best_gap_count for candidate in coverage_peers) == 1:
+        return "fewest_gaps_at_best_partial_coverage"
+    return "configured_priority_after_partial_quality_tie"
 
 
 def _combined_summary_from_result(
@@ -4892,7 +5042,15 @@ async def _resolve_combined_coin(
                 logging.info(f"No exchange data found at all for coin {coin}. Skipping.")
                 return None
 
-            best_candidate = _pick_best_combined_candidate(coin, plan.forced_exchange, candidates)
+            best_candidate = _pick_best_combined_candidate(
+                coin,
+                plan.forced_exchange,
+                candidates,
+                exchange_priority=plan.candidate_exchanges,
+            )
+            selection_reason = _combined_candidate_selection_reason(
+                best_candidate, plan.forced_exchange, candidates
+            )
             logging.info(
                 f"{coin} exchange preference: {[candidate.exchange for candidate in candidates]}"
             )
@@ -4910,6 +5068,7 @@ async def _resolve_combined_coin(
                 best_df=best_candidate.df,
                 market_settings=market_settings,
                 candidates=tuple(candidates),
+                selection_reason=selection_reason,
             )
         except Exception as e:
             logging.error(f"Error processing coin {coin}: {e}")
@@ -5314,13 +5473,69 @@ def compute_exchange_volume_ratios_from_candidates(
     start_ts: int,
     end_ts: int,
 ) -> Dict[Tuple[str, str], float]:
+    """Compatibility wrapper whose ``end_ts`` remains inclusive."""
+    ratios, _diagnostics = compute_exchange_volume_ratios_with_diagnostics(
+        exchanges,
+        coins,
+        candidates_by_coin,
+        int(start_ts),
+        int(end_ts) + 60_000,
+    )
+    return ratios
+
+
+def _select_volume_reference_exchange(
+    exchange_counts: Dict[str, int], configured_priority: Sequence[str]
+) -> str:
+    selected = {to_standard_exchange_name(exchange) for exchange in exchange_counts}
+    for exchange in configured_priority:
+        normalized = to_standard_exchange_name(exchange)
+        if normalized in selected:
+            return normalized
+    if selected:
+        return sorted(selected)[0]
+    raise ValueError("cannot select volume normalization reference without a selected exchange")
+
+
+def compute_exchange_volume_ratios_with_diagnostics(
+    exchanges: Sequence[str],
+    coins: Sequence[str],
+    candidates_by_coin: Dict[str, Sequence[CombinedExchangeCandidate]],
+    start_ts: int,
+    end_ts_exclusive: int,
+) -> tuple[Dict[Tuple[str, str], float], dict]:
+    """Estimate exchange quote-volume ratios from robust complete-day overlap.
+
+    Each coin contributes the median of its eligible daily log ratios. The pair
+    estimate is the median across coin estimates, preventing one high-volume or
+    anomalous market from dominating the normalization factor.
+    """
+    minute_ms = 60_000
+    day_ms = 24 * 60 * minute_ms
+    window_start_ts = int((int(start_ts) + day_ms - 1) // day_ms * day_ms)
+    window_end_ts_exclusive = int(int(end_ts_exclusive) // day_ms * day_ms)
+    window_days = max(0, (window_end_ts_exclusive - window_start_ts) // day_ms)
+    if window_days <= 0:
+        raise ValueError(
+            "cannot normalize volumes: no complete UTC days in estimation window "
+            f"[{start_ts}, {end_ts_exclusive})"
+        )
+
     ordered_exchanges = sorted({to_standard_exchange_name(ex) for ex in exchanges})
     exchange_pairs: list[tuple[str, str]] = []
     for i, ex0 in enumerate(ordered_exchanges):
         for ex1 in ordered_exchanges[i + 1 :]:
             exchange_pairs.append((ex0, ex1))
 
-    all_data: dict[str, dict[tuple[str, str], float]] = {}
+    pair_coin_logs: dict[tuple[str, str], dict[str, float]] = defaultdict(dict)
+    pair_daily_logs: dict[tuple[str, str], dict[str, list[float]]] = defaultdict(dict)
+    pair_excluded: dict[tuple[str, str], dict[str, str]] = defaultdict(dict)
+    pair_potential_counts: dict[tuple[str, str], int] = defaultdict(int)
+    minimum_common_rows = int(np.ceil(1440 * VOLUME_NORMALIZATION_MIN_COMMON_FRACTION))
+    minimum_eligible_days = max(
+        1, int(np.ceil(window_days * VOLUME_NORMALIZATION_MIN_ELIGIBLE_DAYS_FRACTION))
+    )
+
     for coin in coins:
         candidate_map = {
             to_standard_exchange_name(candidate.exchange): candidate
@@ -5331,47 +5546,120 @@ def compute_exchange_volume_ratios_from_candidates(
         for ex in sorted(set(ordered_exchanges).intersection(candidate_map)):
             volume_by_timestamp = _timestamp_volume_dict_from_candidate_df(
                 candidate_map[ex].df,
-                start_ts=int(start_ts),
-                end_ts=int(end_ts),
+                start_ts=window_start_ts,
+                end_ts=window_end_ts_exclusive - minute_ms,
             )
             if volume_by_timestamp:
                 timestamp_volumes[ex] = volume_by_timestamp
 
-        coin_data = {}
         for ex0, ex1 in exchange_pairs:
+            pair = (ex0, ex1)
+            if ex0 in candidate_map and ex1 in candidate_map:
+                pair_potential_counts[pair] += 1
             if ex0 not in timestamp_volumes or ex1 not in timestamp_volumes:
+                if ex0 in candidate_map and ex1 in candidate_map:
+                    pair_excluded[pair][coin] = "no_valid_volume_in_window"
                 continue
             pair_common_timestamps = set(timestamp_volumes[ex0]).intersection(
                 timestamp_volumes[ex1]
             )
             if not pair_common_timestamps:
+                pair_excluded[pair][coin] = "no_common_valid_timestamps"
                 continue
-            sum0 = sum(timestamp_volumes[ex0][timestamp] for timestamp in pair_common_timestamps)
-            sum1 = sum(timestamp_volumes[ex1][timestamp] for timestamp in pair_common_timestamps)
-            if sum0 <= 0.0 or sum1 <= 0.0:
+
+            daily: dict[int, list[float]] = defaultdict(lambda: [0.0, 0.0, 0.0])
+            for timestamp in pair_common_timestamps:
+                day_start = int(timestamp // day_ms * day_ms)
+                bucket = daily[day_start]
+                bucket[0] += 1.0
+                bucket[1] += float(timestamp_volumes[ex0][timestamp])
+                bucket[2] += float(timestamp_volumes[ex1][timestamp])
+
+            daily_logs = []
+            for day_start in range(
+                window_start_ts, window_end_ts_exclusive, day_ms
+            ):
+                common_count, sum0, sum1 = daily.get(day_start, [0.0, 0.0, 0.0])
+                if (
+                    int(common_count) < minimum_common_rows
+                    or not np.isfinite(sum0)
+                    or not np.isfinite(sum1)
+                    or sum0 <= 0.0
+                    or sum1 <= 0.0
+                ):
+                    continue
+                daily_logs.append(float(np.log(sum0 / sum1)))
+
+            if len(daily_logs) < minimum_eligible_days:
+                pair_excluded[pair][coin] = (
+                    f"insufficient_complete_days:{len(daily_logs)}/{minimum_eligible_days}"
+                )
                 continue
-            coin_data[(ex0, ex1)] = sum0 / sum1
+            pair_coin_logs[pair][coin] = float(np.median(daily_logs))
+            pair_daily_logs[pair][coin] = daily_logs
 
-        if coin_data:
-            all_data[coin] = coin_data
+    ratios: Dict[Tuple[str, str], float] = {}
+    pair_estimates = {}
+    for pair in exchange_pairs:
+        potential_count = int(pair_potential_counts.get(pair, 0))
+        required_contributors = min(VOLUME_NORMALIZATION_MIN_CONTRIBUTORS, len(coins))
+        contributor_logs = pair_coin_logs.get(pair, {})
+        pair_key = f"{pair[0]}/{pair[1]}"
+        pair_payload = {
+            "potential_contributors": potential_count,
+            "required_contributors": required_contributors,
+            "contributors": {
+                coin: {
+                    "ratio": float(np.exp(log_ratio)),
+                    "eligible_days": len(pair_daily_logs[pair][coin]),
+                    "daily_log_ratio_mad": float(
+                        np.median(
+                            np.abs(
+                                np.asarray(pair_daily_logs[pair][coin], dtype=np.float64)
+                                - np.median(pair_daily_logs[pair][coin])
+                            )
+                        )
+                    ),
+                }
+                for coin, log_ratio in sorted(contributor_logs.items())
+            },
+            "excluded": dict(sorted(pair_excluded.get(pair, {}).items())),
+        }
+        if required_contributors > 0 and len(contributor_logs) >= required_contributors:
+            logs = np.asarray(list(contributor_logs.values()), dtype=np.float64)
+            pair_log_median = float(np.median(logs))
+            ratio = float(np.exp(pair_log_median))
+            ratios[pair] = ratio
+            pair_payload.update(
+                {
+                    "ratio": ratio,
+                    "coin_log_ratio_median": pair_log_median,
+                    "coin_log_ratio_mad": float(
+                        np.median(np.abs(logs - pair_log_median))
+                    ),
+                }
+            )
+        else:
+            pair_payload["rejection_reason"] = (
+                "no_shared_candidate_coins"
+                if potential_count == 0
+                else f"insufficient_contributors:{len(contributor_logs)}/{required_contributors}"
+            )
+        pair_estimates[pair_key] = pair_payload
 
-    averages = {}
-    if not all_data:
-        return averages
-
-    used_pairs = set()
-    for coin in all_data:
-        for pair in all_data[coin]:
-            used_pairs.add(pair)
-
-    for pair in used_pairs:
-        ratios_for_pair = []
-        for coin in all_data:
-            if pair in all_data[coin]:
-                ratios_for_pair.append(all_data[coin][pair])
-        averages[pair] = float(np.mean(ratios_for_pair)) if ratios_for_pair else 0.0
-
-    return averages
+    diagnostics = {
+        "method": "median_log_daily_quote_volume_ratio",
+        "lookback_days": VOLUME_NORMALIZATION_LOOKBACK_DAYS,
+        "window_start_ts": window_start_ts,
+        "window_end_ts_exclusive": window_end_ts_exclusive,
+        "window_days": int(window_days),
+        "minimum_daily_common_fraction": VOLUME_NORMALIZATION_MIN_COMMON_FRACTION,
+        "minimum_eligible_days_fraction": VOLUME_NORMALIZATION_MIN_ELIGIBLE_DAYS_FRACTION,
+        "minimum_common_rows_per_day": minimum_common_rows,
+        "minimum_eligible_days": minimum_eligible_days,
+        "pair_estimates": pair_estimates,
+    }
+    return ratios, diagnostics
 
 
 def _find_exchange_volume_scale_factor(
@@ -5446,9 +5734,11 @@ def _build_exchange_volume_ratio_map(
 
 
 __all__ = [
+    "HLCV_PREPARATION_ALGORITHM_VERSION",
     "HLCVManager",
     "prepare_hlcvs",
     "prepare_hlcvs_combined",
     "compute_exchange_volume_ratios",
     "compute_exchange_volume_ratios_from_candidates",
+    "compute_exchange_volume_ratios_with_diagnostics",
 ]

--- a/src/hlcv_preparation.py
+++ b/src/hlcv_preparation.py
@@ -106,11 +106,29 @@ from warmup_utils import compute_backtest_warmup_minutes, compute_per_coin_warmu
 from backtest_universe import effective_backtest_data_coins
 
 
-HLCV_PREPARATION_ALGORITHM_VERSION = 4
+HLCV_PREPARATION_ALGORITHM_VERSION = 5
 VOLUME_NORMALIZATION_LOOKBACK_DAYS = 60
 VOLUME_NORMALIZATION_MIN_COMMON_FRACTION = 0.95
 VOLUME_NORMALIZATION_MIN_ELIGIBLE_DAYS_FRACTION = 0.80
 VOLUME_NORMALIZATION_MIN_CONTRIBUTORS = 3
+
+
+def _filter_forced_sources_for_coins(
+    forced_sources: Dict[str, str], coins: Sequence[str]
+) -> Dict[str, str]:
+    active_aliases: set[str] = set()
+    for raw_coin in coins:
+        coin = str(raw_coin)
+        active_aliases.add(coin)
+        if coin.startswith("xyz:"):
+            active_aliases.add(coin[4:])
+        else:
+            active_aliases.add(f"xyz:{coin}")
+    return {
+        coin: forced_sources[coin]
+        for coin in sorted(forced_sources)
+        if coin in active_aliases
+    }
 
 
 def _partition_combined_exchange_roles(
@@ -136,6 +154,15 @@ def _complete_utc_day_window_end_exclusive(last_timestamp: int) -> int:
     if int(last_timestamp) >= day_start + day_ms - minute_ms:
         return day_start + day_ms
     return day_start
+
+
+def _normalization_candidate_start_ts(effective_start_ts: int, end_ts: int) -> int:
+    day_ms = 24 * 60 * 60 * 1000
+    latest_complete_day_end_exclusive = _complete_utc_day_window_end_exclusive(end_ts)
+    return max(
+        int(effective_start_ts),
+        latest_complete_day_end_exclusive - VOLUME_NORMALIZATION_LOOKBACK_DAYS * day_ms,
+    )
 
 
 @dataclass(frozen=True)
@@ -4240,6 +4267,10 @@ async def prepare_hlcvs_combined(
         for coin, exchange in forced_sources.items()
         if exchange
     }
+    normalized_forced_sources = _filter_forced_sources_for_coins(
+        normalized_forced_sources,
+        effective_backtest_data_coins(config),
+    )
     market_settings_sources = market_settings_sources or {}
     normalized_mss_sources = {
         str(coin): to_ccxt_exchange_id(exchange)
@@ -5155,6 +5186,19 @@ async def _load_combined_coin_candidates(
 ) -> list[CombinedExchangeCandidate]:
     tasks = []
     position_map = {ex0: (1 + i) for i, ex0 in enumerate(exchanges_to_consider)}
+    selection_exchange_set = set(plan.selection_exchanges)
+    normalization_start_ts = _normalization_candidate_start_ts(
+        plan.effective_start_ts,
+        end_ts,
+    )
+    start_ts_by_exchange = {
+        ex: (
+            plan.effective_start_ts
+            if ex in selection_exchange_set
+            else normalization_start_ts
+        )
+        for ex in plan.candidate_exchanges
+    }
     for ex in plan.candidate_exchanges:
         tasks.append(
             asyncio.create_task(
@@ -5162,7 +5206,7 @@ async def _load_combined_coin_candidates(
                     plan.coin,
                     ex,
                     om_dict[ex],
-                    plan.effective_start_ts,
+                    start_ts_by_exchange[ex],
                     end_ts,
                     progress_position=position_map.get(ex, 1),
                     catalog=catalog,
@@ -5182,7 +5226,6 @@ async def _load_combined_coin_candidates(
             ) from forced_result
 
     candidates: list[CombinedExchangeCandidate] = []
-    selection_exchange_set = set(plan.selection_exchanges)
     for ex, result in zip(plan.candidate_exchanges, results):
         symbol = None
         try:
@@ -5198,7 +5241,7 @@ async def _load_combined_coin_candidates(
                 symbol=symbol,
                 reason=f"normalization_candidate_fetch_failed:{type(result).__name__}",
                 gap_class="unknown",
-                effective_start_ts=plan.effective_start_ts,
+                effective_start_ts=start_ts_by_exchange[ex],
                 end_ts=end_ts,
             )
             if candidate_report is not None:
@@ -5217,7 +5260,7 @@ async def _load_combined_coin_candidates(
                 symbol=symbol,
                 reason="unavailable",
                 gap_class="unknown",
-                effective_start_ts=plan.effective_start_ts,
+                effective_start_ts=start_ts_by_exchange[ex],
                 end_ts=end_ts,
             )
             if candidate_report is not None:
@@ -5229,7 +5272,7 @@ async def _load_combined_coin_candidates(
             exchange=ex,
             symbol=symbol,
             result=result,
-            effective_start_ts=plan.effective_start_ts,
+            effective_start_ts=start_ts_by_exchange[ex],
             end_ts=end_ts,
             source_layer=source_layer,
         )

--- a/src/hlcv_preparation.py
+++ b/src/hlcv_preparation.py
@@ -106,11 +106,36 @@ from warmup_utils import compute_backtest_warmup_minutes, compute_per_coin_warmu
 from backtest_universe import effective_backtest_data_coins
 
 
-HLCV_PREPARATION_ALGORITHM_VERSION = 2
+HLCV_PREPARATION_ALGORITHM_VERSION = 3
 VOLUME_NORMALIZATION_LOOKBACK_DAYS = 60
 VOLUME_NORMALIZATION_MIN_COMMON_FRACTION = 0.95
 VOLUME_NORMALIZATION_MIN_ELIGIBLE_DAYS_FRACTION = 0.80
 VOLUME_NORMALIZATION_MIN_CONTRIBUTORS = 3
+
+
+def _partition_combined_exchange_roles(
+    configured_exchanges: Sequence[str],
+    forced_sources: Dict[str, str],
+    market_settings_sources: Dict[str, str],
+) -> tuple[list[str], list[str]]:
+    """Separate OHLCV candidates from exchanges needed only by per-coin overrides."""
+    candidate_exchanges = list(dict.fromkeys(configured_exchanges))
+    candidate_exchange_set = set(candidate_exchanges)
+    override_only_exchanges = sorted(
+        (set(forced_sources.values()) | set(market_settings_sources.values()))
+        - candidate_exchange_set
+    )
+    return candidate_exchanges, override_only_exchanges
+
+
+def _complete_utc_day_window_end_exclusive(last_timestamp: int) -> int:
+    """Return the exclusive end of the latest complete 1m UTC day."""
+    minute_ms = 60_000
+    day_ms = 24 * 60 * minute_ms
+    day_start = int(last_timestamp // day_ms * day_ms)
+    if int(last_timestamp) >= day_start + day_ms - minute_ms:
+        return day_start + day_ms
+    return day_start
 
 
 @dataclass(frozen=True)
@@ -4220,10 +4245,13 @@ async def prepare_hlcvs_combined(
         for coin, exchange in market_settings_sources.items()
         if exchange
     }
-    # Configuration order is the stable tie-break contract for equivalent full-range
-    # candidates. Preserve it through preparation instead of converting it to a set.
-    ohlcv_exchanges = list(
-        dict.fromkeys([*exchanges_to_consider, *normalized_forced_sources.values()])
+    # Only configured exchanges are candidates for unforced coins. Exchanges used
+    # solely by a per-coin override still need managers, but must not leak into the
+    # candidate list. Sort those extras so mapping insertion order cannot affect work.
+    ohlcv_exchanges, extra_exchanges = _partition_combined_exchange_roles(
+        exchanges_to_consider,
+        normalized_forced_sources,
+        normalized_mss_sources,
     )
 
     requested_start_date = require_config_value(config, "backtest.start_date")
@@ -4245,14 +4273,14 @@ async def prepare_hlcvs_combined(
         )
     logging.info(
         "combined starting v2-aware candle preparation across %d exchange(s) for %d candidate coin(s)",
-        len(set(ohlcv_exchanges)),
+        len(ohlcv_exchanges) + len(extra_exchanges),
         len(
             effective_backtest_data_coins(config)
         ),
     )
 
     om_dict: Dict[str, HLCVManager] = {}
-    for ex in exchanges_to_consider:
+    for ex in ohlcv_exchanges:
         om_dict[ex] = HLCVManager(
             ex,
             effective_start_date,
@@ -4267,17 +4295,7 @@ async def prepare_hlcvs_combined(
             force_refetch_gaps=force_refetch_gaps,
             ohlcv_source_dir=config.get("backtest", {}).get("ohlcv_source_dir"),
         )
-    extra_exchanges = list(
-        dict.fromkeys(
-            [
-                *normalized_forced_sources.values(),
-                *normalized_mss_sources.values(),
-            ]
-        )
-    )
     for ex in extra_exchanges:
-        if ex in om_dict:
-            continue
         om_dict[ex] = HLCVManager(
             ex,
             effective_start_date,
@@ -4549,9 +4567,9 @@ async def _prepare_hlcvs_combined_impl(
 
     normalization_enabled = bool(config.get("backtest", {}).get("volume_normalization", True))
     day_ms = 24 * 60 * 60 * 1000
-    normalization_end_ts_exclusive = int(global_end_time // day_ms * day_ms)
-    if int(global_end_time) % day_ms:
-        normalization_end_ts_exclusive += day_ms
+    normalization_end_ts_exclusive = _complete_utc_day_window_end_exclusive(
+        int(global_end_time)
+    )
     normalization_start_ts = max(
         int(global_start_time),
         normalization_end_ts_exclusive - VOLUME_NORMALIZATION_LOOKBACK_DAYS * day_ms,

--- a/src/hlcvs_manifest.py
+++ b/src/hlcvs_manifest.py
@@ -154,18 +154,21 @@ def build_hlcvs_manifest(
     if candidate_report is not None:
         files["candidate_report"] = _json_file_entry("candidate_report.json", candidate_report)
 
+    meta = mss.get("__meta__", {}) if isinstance(mss, dict) else {}
+    source_selection = meta.get("source_selection", {}) if isinstance(meta, dict) else {}
     sources = {}
     for coin in coins:
-        meta = mss.get(coin, {}) if isinstance(mss, dict) else {}
+        coin_meta = mss.get(coin, {}) if isinstance(mss, dict) else {}
+        selection = source_selection.get(coin, {}) if isinstance(source_selection, dict) else {}
         sources[coin] = {
-            "ohlcv_exchange": meta.get("ohlcv_source") or meta.get("exchange"),
-            "market_settings_exchange": meta.get("exchange"),
-            "symbol": meta.get("symbol"),
-            "first_valid_index": meta.get("first_valid_index"),
-            "last_valid_index": meta.get("last_valid_index"),
+            "ohlcv_exchange": coin_meta.get("ohlcv_source") or coin_meta.get("exchange"),
+            "market_settings_exchange": coin_meta.get("exchange"),
+            "symbol": coin_meta.get("symbol"),
+            "first_valid_index": coin_meta.get("first_valid_index"),
+            "last_valid_index": coin_meta.get("last_valid_index"),
+            "selection_reason": selection.get("selection_reason"),
         }
 
-    meta = mss.get("__meta__", {}) if isinstance(mss, dict) else {}
     build_side_membership = _side_membership(config, coins)
     manifest = {
         "schema_version": HLCVS_MANIFEST_SCHEMA_VERSION,
@@ -183,6 +186,12 @@ def build_hlcvs_manifest(
                 config, "backtest.gap_tolerance_ohlcvs_minutes"
             ),
             "ohlcv_source_dir": get_optional_config_value(config, "backtest.ohlcv_source_dir"),
+            "volume_normalization": bool(
+                get_optional_config_value(config, "backtest.volume_normalization", True)
+            ),
+            "hlcv_preparation_algorithm_version": meta.get(
+                "preparation_algorithm_version"
+            ),
         },
         "effective": {
             "coins": list(coins),
@@ -195,6 +204,10 @@ def build_hlcvs_manifest(
         },
         "files": files,
         "sources": sources,
+        "preparation": {
+            "source_selection": source_selection,
+            "volume_normalization": meta.get("volume_normalization", {}),
+        },
         "btc_benchmark": {
             "exchange": meta.get("btc_source_exchange"),
             "symbol": "BTC/USDT:USDT",

--- a/tests/test_backtest_dataset_metadata.py
+++ b/tests/test_backtest_dataset_metadata.py
@@ -20,6 +20,13 @@ def test_build_backtest_dataset_metadata_prefers_cache_coin_order_and_absolute_p
                 "materialization_schema_version": 1,
                 "files": {"hlcvs": {"sha256": "abc"}},
                 "effective": {"side_membership": {"long": ["BTC"], "short": ["ETH"]}},
+                "preparation": {
+                    "volume_normalization": {
+                        "enabled": True,
+                        "reference_exchange": "binance",
+                    },
+                    "source_selection": {"BTC": {"selected_exchange": "binance"}},
+                },
             }
         )
     )
@@ -53,6 +60,10 @@ def test_build_backtest_dataset_metadata_prefers_cache_coin_order_and_absolute_p
     assert metadata["manifest_schema_version"] == 1
     assert metadata["materialization_schema_version"] == 1
     assert metadata["content_hashes"] == {"hlcvs": "abc"}
+    assert metadata["preparation"]["volume_normalization"]["reference_exchange"] == "binance"
+    assert metadata["preparation"]["source_selection"]["BTC"]["selected_exchange"] == (
+        "binance"
+    )
     assert metadata["side_membership"] == {"long": ["BTC"], "short": ["ETH"]}
     assert metadata["cache_build_side_membership"] == {
         "long": ["BTC"],

--- a/tests/test_cache_warmup_reuse.py
+++ b/tests/test_cache_warmup_reuse.py
@@ -211,6 +211,16 @@ class TestCacheHashIndependence:
 
         assert hash_a != hash_b
 
+    def test_volume_normalization_mode_changes_hash(self):
+        cfg_enabled = _base_config()
+        cfg_disabled = copy.deepcopy(cfg_enabled)
+        cfg_enabled["backtest"]["volume_normalization"] = True
+        cfg_disabled["backtest"]["volume_normalization"] = False
+
+        assert get_cache_hash(cfg_enabled, "combined") != get_cache_hash(
+            cfg_disabled, "combined"
+        )
+
 
 # ============================================================================
 # Test Class: Warmup Sufficiency Gate

--- a/tests/test_config_coin_sources.py
+++ b/tests/test_config_coin_sources.py
@@ -65,6 +65,17 @@ def test_cache_hash_includes_coin_sources():
     assert hash_with != hash_without
 
 
+def test_cache_hash_is_independent_of_coin_sources_mapping_order():
+    cfg1 = _base_config()
+    cfg1["live"]["approved_coins"]["long"] = ["BTC/USDT:USDT", "ETH/USDT:USDT"]
+    cfg1["backtest"]["coin_sources"] = {"BTC": "okx", "ETH": "hyperliquid"}
+
+    cfg2 = copy.deepcopy(cfg1)
+    cfg2["backtest"]["coin_sources"] = {"ETH": "hyperliquid", "BTC": "okx"}
+
+    assert get_cache_hash(cfg1, "combined") == get_cache_hash(cfg2, "combined")
+
+
 def test_cache_hash_includes_market_settings_sources():
     """Verify market_settings_sources affects the cache hash."""
     cfg = _base_config()

--- a/tests/test_hlcv_preparation.py
+++ b/tests/test_hlcv_preparation.py
@@ -1770,7 +1770,7 @@ class TestPrepareHLCVSCombined:
         assert mss["__meta__"]["btc_source_exchange"] == "binanceusdm"
 
     @pytest.mark.asyncio
-    async def test_prepare_hlcvs_combined_volume_ratios_do_not_call_legacy_get_ohlcvs(
+    async def test_prepare_hlcvs_combined_stable_priority_does_not_call_legacy_get_ohlcvs(
         self, sample_config, monkeypatch, tmp_path
     ):
         monkeypatch.chdir(tmp_path)
@@ -1860,13 +1860,15 @@ class TestPrepareHLCVSCombined:
 
         np.testing.assert_array_equal(out_timestamps, timestamps)
         assert mss["ETH"]["exchange"] == "binance"
-        assert mss["SOL"]["exchange"] == "bybit"
-        ratio = ((100.0 / 10.0) + (5.0 / 50.0)) / 2.0
+        assert mss["SOL"]["exchange"] == "binance"
         valid_coins = sorted(["ETH", "SOL"])
         eth_index = valid_coins.index("ETH")
         sol_index = valid_coins.index("SOL")
-        assert hlcvs[0, eth_index, 3] == pytest.approx(100.0 / ratio)
-        assert hlcvs[0, sol_index, 3] == pytest.approx(50.0)
+        assert hlcvs[0, eth_index, 3] == pytest.approx(100.0)
+        assert hlcvs[0, sol_index, 3] == pytest.approx(5.0)
+        assert mss["__meta__"]["source_selection"]["SOL"]["selection_reason"] == (
+            "configured_priority_among_full_range_candidates"
+        )
         np.testing.assert_allclose(btc_usd_prices, np.array([50_000.0]))
 
 
@@ -2129,6 +2131,48 @@ def test_pick_best_combined_candidate_prefers_full_range_over_higher_volume_part
     assert chosen.exchange == "binance"
 
 
+def test_pick_best_combined_candidate_uses_config_order_not_volume_for_full_range_tie():
+    df = pd.DataFrame(
+        {
+            "timestamp": np.array([1, 2, 3], dtype=np.int64),
+            "high": [1.0, 1.0, 1.0],
+            "low": [1.0, 1.0, 1.0],
+            "close": [1.0, 1.0, 1.0],
+            "volume": [1.0, 1.0, 1.0],
+        }
+    )
+    binance = hp.CombinedExchangeCandidate(
+        exchange="binanceusdm",
+        df=df,
+        coverage_count=3,
+        gap_count=0,
+        total_volume=3.0,
+        full_range=True,
+    )
+    bybit = hp.CombinedExchangeCandidate(
+        exchange="bybit",
+        df=df,
+        coverage_count=3,
+        gap_count=0,
+        total_volume=1_000_000.0,
+        full_range=True,
+    )
+
+    chosen = hp._pick_best_combined_candidate(
+        "BTC", None, [bybit, binance], exchange_priority=["binanceusdm", "bybit"]
+    )
+
+    assert chosen.exchange == "binanceusdm"
+
+
+def test_volume_reference_exchange_uses_config_order_not_selected_coin_count():
+    chosen = hp._select_volume_reference_exchange(
+        {"binance": 1, "bybit": 20}, ["binanceusdm", "bybit"]
+    )
+
+    assert chosen == "binance"
+
+
 def test_combined_summary_treats_internal_gaps_as_partial():
     start_ts = month_start_ts(2026, 4)
     end_ts = start_ts + 2 * 60_000
@@ -2177,11 +2221,13 @@ def test_combined_valid_mask_conversion_avoids_pandas_downcast_warning():
 def test_exchange_volume_ratios_from_candidates_use_common_timestamps():
     day0 = month_start_ts(2026, 4)
     day1 = day0 + 86_400_000
-    day2 = day1 + 86_400_000
 
-    def candidate(exchange, volumes_by_ts):
-        timestamps = np.array(list(volumes_by_ts.keys()), dtype=np.int64)
-        volumes = np.array(list(volumes_by_ts.values()), dtype=np.float64)
+    def candidate(exchange, volume, extra=None):
+        timestamps = np.array(
+            [day0 + i * 60_000 for i in range(1440)] + ([day1] if extra else []),
+            dtype=np.int64,
+        )
+        volumes = np.array([volume] * 1440 + ([extra] if extra else []), dtype=np.float64)
         df = pd.DataFrame(
             {
                 "timestamp": timestamps,
@@ -2205,19 +2251,20 @@ def test_exchange_volume_ratios_from_candidates_use_common_timestamps():
         coins=["ETH", "SOL"],
         candidates_by_coin={
             "ETH": (
-                candidate("binanceusdm", {day0: 10.0, day1: 20.0, day2: 10_000.0}),
-                candidate("bybit", {day0: 30.0, day1: 30.0}),
+                candidate("binanceusdm", 1.0, extra=10_000.0),
+                candidate("bybit", 2.0),
             ),
             "SOL": (
-                candidate("binanceusdm", {day0: 100.0}),
-                candidate("bybit", {day0: 50.0, day2: 9_000.0}),
+                candidate("binanceusdm", 2.0),
+                candidate("bybit", 1.0, extra=9_000.0),
             ),
         },
         start_ts=day0,
-        end_ts=day1,
+        end_ts=day1 - 60_000,
     )
 
-    assert ratios[("binance", "bybit")] == pytest.approx(((30.0 / 60.0) + (100.0 / 50.0)) / 2.0)
+    # Median log aggregation gives the geometric midpoint of 0.5 and 2.0.
+    assert ratios[("binance", "bybit")] == pytest.approx(1.0)
 
 
 def test_exchange_volume_ratios_from_candidates_do_not_compare_partial_day_to_full_day():
@@ -2270,7 +2317,91 @@ def test_exchange_volume_ratios_from_candidates_do_not_compare_partial_day_to_fu
         end_ts=day0 + 1439 * 60_000,
     )
 
-    assert ratios[("binance", "bybit")] == pytest.approx(1.0)
+    assert ratios == {}
+
+
+def test_exchange_volume_ratios_use_median_coin_estimate_and_report_outlier_dispersion():
+    day0 = month_start_ts(2026, 4)
+    timestamps = np.array([day0 + i * 60_000 for i in range(1440)], dtype=np.int64)
+
+    def candidate(exchange, volume):
+        volumes = np.full(len(timestamps), volume, dtype=np.float64)
+        return hp.CombinedExchangeCandidate(
+            exchange=exchange,
+            df=pd.DataFrame(
+                {
+                    "timestamp": timestamps,
+                    "high": np.ones(len(timestamps)),
+                    "low": np.ones(len(timestamps)),
+                    "close": np.ones(len(timestamps)),
+                    "volume": volumes,
+                    "valid": np.ones(len(timestamps), dtype=bool),
+                }
+            ),
+            coverage_count=len(timestamps),
+            gap_count=0,
+            total_volume=float(volumes.sum()),
+        )
+
+    candidates = {
+        "BTC": (candidate("binance", 2.0), candidate("bybit", 1.0)),
+        "ETH": (candidate("binance", 2.2), candidate("bybit", 1.0)),
+        "OUTLIER": (candidate("binance", 100.0), candidate("bybit", 1.0)),
+    }
+
+    ratios, diagnostics = hp.compute_exchange_volume_ratios_with_diagnostics(
+        ["binance", "bybit"],
+        list(candidates),
+        candidates,
+        day0,
+        day0 + 86_400_000,
+    )
+
+    assert ratios[("binance", "bybit")] == pytest.approx(2.2)
+    estimate = diagnostics["pair_estimates"]["binance/bybit"]
+    assert sorted(estimate["contributors"]) == ["BTC", "ETH", "OUTLIER"]
+    assert estimate["coin_log_ratio_mad"] > 0.0
+
+
+def test_exchange_volume_ratios_reject_too_few_contributors_for_multi_coin_universe():
+    day0 = month_start_ts(2026, 4)
+    timestamps = np.array([day0 + i * 60_000 for i in range(1440)], dtype=np.int64)
+
+    def candidate(exchange, volume):
+        df = pd.DataFrame(
+            {
+                "timestamp": timestamps,
+                "high": np.ones(len(timestamps)),
+                "low": np.ones(len(timestamps)),
+                "close": np.ones(len(timestamps)),
+                "volume": np.full(len(timestamps), volume),
+                "valid": np.ones(len(timestamps), dtype=bool),
+            }
+        )
+        return hp.CombinedExchangeCandidate(
+            exchange=exchange,
+            df=df,
+            coverage_count=len(df),
+            gap_count=0,
+            total_volume=float(df["volume"].sum()),
+        )
+
+    ratios, diagnostics = hp.compute_exchange_volume_ratios_with_diagnostics(
+        ["binance", "bybit"],
+        ["BTC", "ETH", "SOL"],
+        {
+            "BTC": (candidate("binance", 2.0), candidate("bybit", 1.0)),
+            "ETH": (candidate("binance", 2.2), candidate("bybit", 1.0)),
+            "SOL": (candidate("binance", 2.4),),
+        },
+        day0,
+        day0 + 86_400_000,
+    )
+
+    assert ratios == {}
+    assert diagnostics["pair_estimates"]["binance/bybit"]["rejection_reason"] == (
+        "insufficient_contributors:2/3"
+    )
 
 
 def test_build_exchange_volume_ratio_map_fails_loudly_without_overlap_to_reference():

--- a/tests/test_hlcv_preparation.py
+++ b/tests/test_hlcv_preparation.py
@@ -2166,6 +2166,12 @@ def test_pick_best_combined_candidate_uses_config_order_not_volume_for_full_rang
 
 
 def test_forced_only_exchanges_are_normalization_only_for_unforced_coins():
+    filtered_forced_sources = hp._filter_forced_sources_for_coins(
+        {"BTC": "okx", "STALE": "hyperliquid", "xyz:TSLA": "hyperliquid"},
+        ["BTC", "xyz:TSLA"],
+    )
+    assert filtered_forced_sources == {"BTC": "okx", "xyz:TSLA": "hyperliquid"}
+
     configured, extras = hp._partition_combined_exchange_roles(
         ["binanceusdm", "bybit", "binanceusdm"],
         {"BTC": "okx", "ETH": "hyperliquid"},
@@ -2678,6 +2684,53 @@ async def test_load_combined_coin_candidates_tolerates_failed_normalization_only
 
     assert [candidate.exchange for candidate in candidates] == ["binanceusdm"]
     assert report[-1]["reason"] == "normalization_candidate_fetch_failed:RuntimeError"
+
+
+@pytest.mark.asyncio
+async def test_load_combined_coin_candidates_bounds_normalization_only_exchange_to_lookback(
+    monkeypatch, tmp_path
+):
+    day0 = month_start_ts(2026, 1)
+    day100 = day0 + 100 * 86_400_000
+    expected_normalization_start = day100 - hp.VOLUME_NORMALIZATION_LOOKBACK_DAYS * 86_400_000
+    plan = hp.CombinedCoinPlan(
+        coin="BTC",
+        effective_start_ts=day0,
+        forced_exchange=None,
+        selection_exchanges=("binanceusdm",),
+        candidate_exchanges=("binanceusdm", "okx"),
+    )
+
+    class FakeManager:
+        def has_coin(self, coin):
+            return True
+
+        def get_symbol(self, coin):
+            return f"{coin}/USDT:USDT"
+
+    calls = {}
+
+    async def fake_fetch(coin, ex, _om, start_ts, end_ts, **_kwargs):
+        calls[ex] = (start_ts, end_ts)
+        return None
+
+    monkeypatch.setattr(hp, "fetch_data_for_coin_and_exchange", fake_fetch)
+    catalog = OhlcvCatalog(tmp_path / "catalog.sqlite")
+    store = OhlcvStore(tmp_path / "ohlcvs", catalog)
+
+    await hp._load_combined_coin_candidates(
+        plan=plan,
+        om_dict={"binanceusdm": FakeManager(), "okx": FakeManager()},
+        end_ts=day100,
+        force_refetch_gaps=False,
+        catalog=catalog,
+        store=store,
+        legacy_root=None,
+        exchanges_to_consider=("binanceusdm",),
+    )
+
+    assert calls["binanceusdm"] == (day0, day100)
+    assert calls["okx"] == (expected_normalization_start, day100)
 
 
 @pytest.mark.asyncio

--- a/tests/test_hlcv_preparation.py
+++ b/tests/test_hlcv_preparation.py
@@ -2165,7 +2165,7 @@ def test_pick_best_combined_candidate_uses_config_order_not_volume_for_full_rang
     assert chosen.exchange == "binanceusdm"
 
 
-def test_forced_only_exchanges_do_not_leak_into_unforced_candidates():
+def test_forced_only_exchanges_are_normalization_only_for_unforced_coins():
     configured, extras = hp._partition_combined_exchange_roles(
         ["binanceusdm", "bybit", "binanceusdm"],
         {"BTC": "okx", "ETH": "hyperliquid"},
@@ -2179,6 +2179,7 @@ def test_forced_only_exchanges_do_not_leak_into_unforced_candidates():
 
     assert configured == configured_reordered == ["binanceusdm", "bybit"]
     assert extras == extras_reordered == ["gateio", "hyperliquid", "okx"]
+    normalization_exchanges = [*configured, "hyperliquid", "okx"]
 
     unforced = hp._plan_combined_coin(
         coin="SOL",
@@ -2190,6 +2191,7 @@ def test_forced_only_exchanges_do_not_leak_into_unforced_candidates():
         tradfi_for_stock_perps=False,
         forced_sources={"BTC": "okx"},
         exchanges_to_consider=configured,
+        normalization_candidate_exchanges=normalization_exchanges,
     )
     forced = hp._plan_combined_coin(
         coin="BTC",
@@ -2201,12 +2203,25 @@ def test_forced_only_exchanges_do_not_leak_into_unforced_candidates():
         tradfi_for_stock_perps=False,
         forced_sources={"BTC": "okx"},
         exchanges_to_consider=configured,
+        normalization_candidate_exchanges=normalization_exchanges,
     )
 
     assert unforced is not None
-    assert unforced.candidate_exchanges == ("binanceusdm", "bybit")
+    assert unforced.selection_exchanges == ("binanceusdm", "bybit")
+    assert unforced.candidate_exchanges == (
+        "binanceusdm",
+        "bybit",
+        "hyperliquid",
+        "okx",
+    )
     assert forced is not None
-    assert forced.candidate_exchanges == ("okx",)
+    assert forced.selection_exchanges == ("okx",)
+    assert forced.candidate_exchanges == (
+        "okx",
+        "binanceusdm",
+        "bybit",
+        "hyperliquid",
+    )
 
 
 def test_volume_reference_exchange_uses_config_order_not_selected_coin_count():
@@ -2402,7 +2417,58 @@ def test_volume_normalization_excludes_incomplete_final_utc_day_from_denominator
 
     assert window_end == day1
     assert diagnostics["window_days"] == 1
-    assert diagnostics["minimum_eligible_days"] == 1
+    assert diagnostics["minimum_eligible_days_basis"] == (
+        "per_coin_exchange_pair_complete_overlap"
+    )
+    contributor = diagnostics["pair_estimates"]["binance/bybit"]["contributors"]["BTC"]
+    assert contributor["window_days"] == 1
+    assert contributor["minimum_eligible_days"] == 1
+    assert ratios[("binance", "bybit")] == pytest.approx(2.0)
+
+
+def test_volume_normalization_excludes_pair_specific_partial_boundary_days():
+    day0 = month_start_ts(2026, 4)
+    day1 = day0 + 86_400_000
+    day2 = day1 + 86_400_000
+    full_timestamps = np.arange(day0, day2, 60_000, dtype=np.int64)
+    partial_timestamps = np.arange(day0, day1 + 12 * 60 * 60 * 1000, 60_000, dtype=np.int64)
+
+    def candidate(exchange, timestamps, volume):
+        volumes = np.full(len(timestamps), volume, dtype=np.float64)
+        return hp.CombinedExchangeCandidate(
+            exchange=exchange,
+            df=pd.DataFrame(
+                {
+                    "timestamp": timestamps,
+                    "high": np.ones(len(timestamps)),
+                    "low": np.ones(len(timestamps)),
+                    "close": np.ones(len(timestamps)),
+                    "volume": volumes,
+                    "valid": np.ones(len(timestamps), dtype=bool),
+                }
+            ),
+            coverage_count=len(timestamps),
+            gap_count=0,
+            total_volume=float(volumes.sum()),
+        )
+
+    ratios, diagnostics = hp.compute_exchange_volume_ratios_with_diagnostics(
+        ["binance", "bybit"],
+        ["BTC"],
+        {
+            "BTC": (
+                candidate("binance", full_timestamps, 2.0),
+                candidate("bybit", partial_timestamps, 1.0),
+            )
+        },
+        day0,
+        day2,
+    )
+
+    contributor = diagnostics["pair_estimates"]["binance/bybit"]["contributors"]["BTC"]
+    assert contributor["window_days"] == 1
+    assert contributor["minimum_eligible_days"] == 1
+    assert contributor["eligible_days"] == 1
     assert ratios[("binance", "bybit")] == pytest.approx(2.0)
 
 
@@ -2511,6 +2577,7 @@ async def test_load_combined_coin_candidates_raises_failed_non_forced_exchange(m
         coin="BTC",
         effective_start_ts=start_ts,
         forced_exchange=None,
+        selection_exchanges=("binanceusdm", "bybit"),
         candidate_exchanges=("binanceusdm", "bybit"),
     )
 
@@ -2558,6 +2625,62 @@ async def test_load_combined_coin_candidates_raises_failed_non_forced_exchange(m
 
 
 @pytest.mark.asyncio
+async def test_load_combined_coin_candidates_tolerates_failed_normalization_only_exchange(
+    monkeypatch, tmp_path
+):
+    start_ts = month_start_ts(2026, 4)
+    end_ts = start_ts + 60_000
+    plan = hp.CombinedCoinPlan(
+        coin="BTC",
+        effective_start_ts=start_ts,
+        forced_exchange=None,
+        selection_exchanges=("binanceusdm",),
+        candidate_exchanges=("binanceusdm", "okx"),
+    )
+
+    class FakeManager:
+        def has_coin(self, coin):
+            return True
+
+        def get_symbol(self, coin):
+            return f"{coin}/USDT:USDT"
+
+    async def fake_fetch(coin, ex, *_args, **_kwargs):
+        if ex == "okx":
+            raise RuntimeError("okx exploded")
+        df = pd.DataFrame(
+            {
+                "timestamp": np.array([start_ts, end_ts], dtype=np.int64),
+                "high": [1.0, 2.0],
+                "low": [1.0, 2.0],
+                "close": [1.0, 2.0],
+                "volume": [10.0, 11.0],
+            }
+        )
+        return ex, df, 2, 0, 21.0
+
+    monkeypatch.setattr(hp, "fetch_data_for_coin_and_exchange", fake_fetch)
+    catalog = OhlcvCatalog(tmp_path / "catalog.sqlite")
+    store = OhlcvStore(tmp_path / "ohlcvs", catalog)
+    report = []
+
+    candidates = await hp._load_combined_coin_candidates(
+        plan=plan,
+        om_dict={"binanceusdm": FakeManager(), "okx": FakeManager()},
+        end_ts=end_ts,
+        force_refetch_gaps=False,
+        catalog=catalog,
+        store=store,
+        legacy_root=None,
+        exchanges_to_consider=("binanceusdm",),
+        candidate_report=report,
+    )
+
+    assert [candidate.exchange for candidate in candidates] == ["binanceusdm"]
+    assert report[-1]["reason"] == "normalization_candidate_fetch_failed:RuntimeError"
+
+
+@pytest.mark.asyncio
 async def test_load_combined_coin_candidates_can_bypass_v2_for_source_dir(monkeypatch, tmp_path):
     start_ts = month_start_ts(2026, 4)
     end_ts = start_ts + 60_000
@@ -2565,6 +2688,7 @@ async def test_load_combined_coin_candidates_can_bypass_v2_for_source_dir(monkey
         coin="BTC",
         effective_start_ts=start_ts,
         forced_exchange=None,
+        selection_exchanges=("binanceusdm",),
         candidate_exchanges=("binanceusdm",),
     )
 
@@ -2625,6 +2749,7 @@ async def test_combined_force_refetch_uses_v2_resolver_for_large_internal_gap(
         coin="BTC",
         effective_start_ts=start_ts,
         forced_exchange=None,
+        selection_exchanges=("binanceusdm",),
         candidate_exchanges=("binanceusdm",),
     )
     catalog = OhlcvCatalog(tmp_path / "catalog.sqlite")

--- a/tests/test_hlcv_preparation.py
+++ b/tests/test_hlcv_preparation.py
@@ -2165,6 +2165,50 @@ def test_pick_best_combined_candidate_uses_config_order_not_volume_for_full_rang
     assert chosen.exchange == "binanceusdm"
 
 
+def test_forced_only_exchanges_do_not_leak_into_unforced_candidates():
+    configured, extras = hp._partition_combined_exchange_roles(
+        ["binanceusdm", "bybit", "binanceusdm"],
+        {"BTC": "okx", "ETH": "hyperliquid"},
+        {"SOL": "gateio"},
+    )
+    configured_reordered, extras_reordered = hp._partition_combined_exchange_roles(
+        ["binanceusdm", "bybit", "binanceusdm"],
+        {"ETH": "hyperliquid", "BTC": "okx"},
+        {"SOL": "gateio"},
+    )
+
+    assert configured == configured_reordered == ["binanceusdm", "bybit"]
+    assert extras == extras_reordered == ["gateio", "hyperliquid", "okx"]
+
+    unforced = hp._plan_combined_coin(
+        coin="SOL",
+        base_start_ts=0,
+        end_ts=1,
+        first_timestamps_unified={"SOL": 0},
+        minimum_coin_age_days=0.0,
+        min_coin_age_ms=0,
+        tradfi_for_stock_perps=False,
+        forced_sources={"BTC": "okx"},
+        exchanges_to_consider=configured,
+    )
+    forced = hp._plan_combined_coin(
+        coin="BTC",
+        base_start_ts=0,
+        end_ts=1,
+        first_timestamps_unified={"BTC": 0},
+        minimum_coin_age_days=0.0,
+        min_coin_age_ms=0,
+        tradfi_for_stock_perps=False,
+        forced_sources={"BTC": "okx"},
+        exchanges_to_consider=configured,
+    )
+
+    assert unforced is not None
+    assert unforced.candidate_exchanges == ("binanceusdm", "bybit")
+    assert forced is not None
+    assert forced.candidate_exchanges == ("okx",)
+
+
 def test_volume_reference_exchange_uses_config_order_not_selected_coin_count():
     chosen = hp._select_volume_reference_exchange(
         {"binance": 1, "bybit": 20}, ["binanceusdm", "bybit"]
@@ -2318,6 +2362,48 @@ def test_exchange_volume_ratios_from_candidates_do_not_compare_partial_day_to_fu
     )
 
     assert ratios == {}
+
+
+def test_volume_normalization_excludes_incomplete_final_utc_day_from_denominator():
+    day0 = month_start_ts(2026, 4)
+    day1 = day0 + 86_400_000
+    partial_final_timestamp = day1 + 12 * 60 * 60 * 1000
+    timestamps = np.array([day0 + i * 60_000 for i in range(1440)], dtype=np.int64)
+
+    def candidate(exchange, volume):
+        volumes = np.full(len(timestamps), volume, dtype=np.float64)
+        return hp.CombinedExchangeCandidate(
+            exchange=exchange,
+            df=pd.DataFrame(
+                {
+                    "timestamp": timestamps,
+                    "high": np.ones(len(timestamps)),
+                    "low": np.ones(len(timestamps)),
+                    "close": np.ones(len(timestamps)),
+                    "volume": volumes,
+                    "valid": np.ones(len(timestamps), dtype=bool),
+                }
+            ),
+            coverage_count=len(timestamps),
+            gap_count=0,
+            total_volume=float(volumes.sum()),
+        )
+
+    window_end = hp._complete_utc_day_window_end_exclusive(partial_final_timestamp)
+    assert hp._complete_utc_day_window_end_exclusive(day1 - 60_000) == day1
+    assert hp._complete_utc_day_window_end_exclusive(day1) == day1
+    ratios, diagnostics = hp.compute_exchange_volume_ratios_with_diagnostics(
+        ["binance", "bybit"],
+        ["BTC"],
+        {"BTC": (candidate("binance", 2.0), candidate("bybit", 1.0))},
+        day0,
+        window_end,
+    )
+
+    assert window_end == day1
+    assert diagnostics["window_days"] == 1
+    assert diagnostics["minimum_eligible_days"] == 1
+    assert ratios[("binance", "bybit")] == pytest.approx(2.0)
 
 
 def test_exchange_volume_ratios_use_median_coin_estimate_and_report_outlier_dispersion():

--- a/tests/test_hlcvs_manifest.py
+++ b/tests/test_hlcvs_manifest.py
@@ -49,7 +49,21 @@ def test_build_hlcvs_manifest_hashes_logical_arrays_and_side_membership(tmp_path
     mss = {
         "BTC": {"exchange": "binance", "first_valid_index": 0, "last_valid_index": 2},
         "ETH": {"exchange": "bybit", "first_valid_index": 0, "last_valid_index": 2},
-        "__meta__": {"btc_source_exchange": "binanceusdm"},
+        "__meta__": {
+            "btc_source_exchange": "binanceusdm",
+            "preparation_algorithm_version": 2,
+            "source_selection": {
+                "BTC": {
+                    "selected_exchange": "binance",
+                    "selection_reason": "configured_priority_among_full_range_candidates",
+                }
+            },
+            "volume_normalization": {
+                "enabled": True,
+                "reference_exchange": "binance",
+                "scale_factors_to_reference": {"binance": 1.0, "bybit": 1.23456789},
+            },
+        },
     }
     _write_cache_files(
         cache_dir,
@@ -84,6 +98,13 @@ def test_build_hlcvs_manifest_hashes_logical_arrays_and_side_membership(tmp_path
         "long": ["BTC", "ETH"],
         "short": ["BTC"],
     }
+    assert manifest["sources"]["BTC"]["selection_reason"] == (
+        "configured_priority_among_full_range_candidates"
+    )
+    assert manifest["preparation"]["volume_normalization"][
+        "scale_factors_to_reference"
+    ]["bybit"] == 1.23456789
+    assert manifest["requested"]["hlcv_preparation_algorithm_version"] == 2
     assert verify_hlcvs_manifest(cache_dir)["config_hash"] == "abc123"
 
     changed_btc = btc_usd_prices.copy()

--- a/tests/test_market_settings_sources_separation.py
+++ b/tests/test_market_settings_sources_separation.py
@@ -139,10 +139,10 @@ def test_coins_by_exchange_grouping():
 
 
 @pytest.mark.asyncio
-async def test_prepare_hlcvs_combined_impl_uses_ohlcv_source_for_volume_normalization(
+async def test_prepare_hlcvs_combined_impl_uses_ohlcv_source_for_normalization_provenance(
     monkeypatch, tmp_path
 ):
-    """Verify production combined flow uses ohlcv_source for volume normalization inputs."""
+    """Verify market-settings sources do not enter normalization provenance."""
     import hlcv_preparation as hp
 
     start_ts = 1_704_067_200_000  # 2024-01-01 00:00:00 UTC
@@ -184,27 +184,8 @@ async def test_prepare_hlcvs_combined_impl_uses_ohlcv_source_for_volume_normaliz
             return ex, candle_df.copy(), 2, 0, 500.0
         return None
 
-    def fake_compute_exchange_volume_ratios_from_candidates(
-        exchanges_with_data,
-        valid_coins,
-        candidates_by_coin,
-        _start_ts,
-        _end_ts,
-    ):
-        # This is the key behavior under test:
-        # market_settings_sources should not force bybit into normalization exchange set.
-        assert exchanges_with_data == ["binance"]
-        assert valid_coins == ["BTC"]
-        assert set(candidates_by_coin) == {"BTC"}
-        return {}
-
     monkeypatch.setattr(hp, "get_first_timestamps_unified", fake_get_first_timestamps_unified)
     monkeypatch.setattr(hp, "fetch_data_for_coin_and_exchange", fake_fetch_data_for_coin_and_exchange)
-    monkeypatch.setattr(
-        hp,
-        "compute_exchange_volume_ratios_from_candidates",
-        fake_compute_exchange_volume_ratios_from_candidates,
-    )
 
     config = {
         "backtest": {"gap_tolerance_ohlcvs_minutes": 120},
@@ -247,4 +228,101 @@ async def test_prepare_hlcvs_combined_impl_uses_ohlcv_source_for_volume_normaliz
 
     assert mss["BTC"]["exchange"] == "bybit"
     assert mss["BTC"]["ohlcv_source"] == "binance"
+    normalization = mss["__preparation_meta__"]["volume_normalization"]
+    assert normalization["exchange_counts"] == {"binance": 1}
+    assert normalization["reference_exchange"] == "binance"
     assert aligned_values_by_coin["BTC"][:, 3].sum() == pytest.approx(candle_df["volume"].sum())
+
+
+@pytest.mark.asyncio
+async def test_prepare_hlcvs_combined_impl_honors_disabled_volume_normalization(
+    monkeypatch, tmp_path
+):
+    import hlcv_preparation as hp
+
+    start_ts = 1_704_067_200_000
+    timestamps = [start_ts + i * 60_000 for i in range(3)]
+
+    class DummyOM:
+        async def load_markets(self):
+            return None
+
+        def get_symbol(self, coin):
+            return coin
+
+        def get_market_specific_settings(self, _coin):
+            return {"exchange": "unused", "min_cost": 1.0}
+
+    async def fake_get_first_timestamps_unified(_coins):
+        return {"BTC": start_ts, "ETH": start_ts}
+
+    async def fake_fetch(coin, exchange, *_args, **_kwargs):
+        volume = 10.0 if exchange == "binanceusdm" else 100.0
+        df = pd.DataFrame(
+            {
+                "timestamp": timestamps,
+                "high": [2.0] * 3,
+                "low": [0.5] * 3,
+                "close": [1.5] * 3,
+                "volume": [volume] * 3,
+            }
+        )
+        return exchange, df, 3, 0, float(df["volume"].sum())
+
+    monkeypatch.setattr(hp, "get_first_timestamps_unified", fake_get_first_timestamps_unified)
+    monkeypatch.setattr(hp, "fetch_data_for_coin_and_exchange", fake_fetch)
+    monkeypatch.setattr(
+        hp,
+        "compute_exchange_volume_ratios_with_diagnostics",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("normalization estimator must not run when disabled")
+        ),
+    )
+
+    config = {
+        "backtest": {
+            "gap_tolerance_ohlcvs_minutes": 120,
+            "volume_normalization": False,
+        },
+        "bot": {
+            "long": {
+                "n_positions": 2,
+                "total_wallet_exposure_limit": 1.0,
+                "wallet_exposure_limit": 0.5,
+            },
+            "short": {
+                "n_positions": 0,
+                "total_wallet_exposure_limit": 0.0,
+                "wallet_exposure_limit": 0.0,
+            },
+        },
+        "live": {
+            "approved_coins": {"long": ["BTC", "ETH"], "short": []},
+            "minimum_coin_age_days": 0,
+            "warmup_ratio": 0.0,
+            "max_warmup_minutes": 0.0,
+        },
+    }
+    om_dict = {"binanceusdm": DummyOM(), "bybit": DummyOM()}
+    catalog = OhlcvCatalog(tmp_path / "caches" / "ohlcvs" / "catalog.sqlite")
+    store = OhlcvStore(tmp_path / "caches" / "ohlcvs", catalog)
+
+    mss, _timestamps, values = await hp._prepare_hlcvs_combined_impl(
+        config=config,
+        om_dict=om_dict,
+        base_start_ts=start_ts,
+        _requested_start_ts=start_ts,
+        end_ts=timestamps[-1],
+        forced_sources={"BTC": "binanceusdm", "ETH": "bybit"},
+        force_refetch_gaps=False,
+        ohlcv_exchanges=["binanceusdm", "bybit"],
+        catalog=catalog,
+        store=store,
+        legacy_root=None,
+    )
+
+    assert values["BTC"][:, 3].sum() == pytest.approx(30.0)
+    assert values["ETH"][:, 3].sum() == pytest.approx(300.0)
+    normalization = mss["__preparation_meta__"]["volume_normalization"]
+    assert normalization["enabled"] is False
+    assert normalization["scale_factors_to_reference"] == {"binance": 1.0, "bybit": 1.0}

--- a/tests/test_market_settings_sources_separation.py
+++ b/tests/test_market_settings_sources_separation.py
@@ -326,3 +326,105 @@ async def test_prepare_hlcvs_combined_impl_honors_disabled_volume_normalization(
     normalization = mss["__preparation_meta__"]["volume_normalization"]
     assert normalization["enabled"] is False
     assert normalization["scale_factors_to_reference"] == {"binance": 1.0, "bybit": 1.0}
+
+
+@pytest.mark.asyncio
+async def test_prepare_hlcvs_combined_impl_normalizes_forced_override_only_exchange(
+    monkeypatch, tmp_path
+):
+    import hlcv_preparation as hp
+
+    start_ts = 1_704_067_200_000
+    timestamps = [start_ts + i * 60_000 for i in range(1440)]
+    coins = ["BTC", "ETH", "SOL"]
+
+    class DummyOM:
+        def __init__(self, exchange):
+            self.exchange = exchange
+
+        async def load_markets(self):
+            return None
+
+        def has_coin(self, coin):
+            return coin in coins
+
+        def get_symbol(self, coin):
+            return coin
+
+        def get_market_specific_settings(self, _coin):
+            return {"exchange": self.exchange, "min_cost": 1.0}
+
+    async def fake_get_first_timestamps_unified(_coins):
+        return {coin: start_ts for coin in coins}
+
+    async def fake_fetch(coin, exchange, *_args, **_kwargs):
+        volume = 2.0 if exchange == "binanceusdm" else 1.0
+        df = pd.DataFrame(
+            {
+                "timestamp": timestamps,
+                "high": [2.0] * len(timestamps),
+                "low": [0.5] * len(timestamps),
+                "close": [1.5] * len(timestamps),
+                "volume": [volume] * len(timestamps),
+            }
+        )
+        return exchange, df, len(df), 0, float(df["volume"].sum())
+
+    monkeypatch.setattr(hp, "get_first_timestamps_unified", fake_get_first_timestamps_unified)
+    monkeypatch.setattr(hp, "fetch_data_for_coin_and_exchange", fake_fetch)
+
+    config = {
+        "backtest": {
+            "gap_tolerance_ohlcvs_minutes": 120,
+            "volume_normalization": True,
+        },
+        "bot": {
+            "long": {
+                "n_positions": 3,
+                "total_wallet_exposure_limit": 1.0,
+                "wallet_exposure_limit": 1.0 / 3.0,
+            },
+            "short": {
+                "n_positions": 0,
+                "total_wallet_exposure_limit": 0.0,
+                "wallet_exposure_limit": 0.0,
+            },
+        },
+        "live": {
+            "approved_coins": {"long": coins, "short": []},
+            "minimum_coin_age_days": 0,
+            "warmup_ratio": 0.0,
+            "max_warmup_minutes": 0.0,
+        },
+    }
+    om_dict = {
+        "binanceusdm": DummyOM("binanceusdm"),
+        "bybit": DummyOM("bybit"),
+    }
+    catalog = OhlcvCatalog(tmp_path / "caches" / "ohlcvs" / "catalog.sqlite")
+    store = OhlcvStore(tmp_path / "caches" / "ohlcvs", catalog)
+
+    mss, _timestamps, values = await hp._prepare_hlcvs_combined_impl(
+        config=config,
+        om_dict=om_dict,
+        base_start_ts=start_ts,
+        _requested_start_ts=start_ts,
+        end_ts=timestamps[-1],
+        forced_sources={"BTC": "bybit"},
+        force_refetch_gaps=False,
+        ohlcv_exchanges=["binanceusdm"],
+        normalization_candidate_exchanges=["binanceusdm", "bybit"],
+        catalog=catalog,
+        store=store,
+        legacy_root=None,
+    )
+
+    assert mss["BTC"]["exchange"] == "bybit"
+    assert mss["ETH"]["exchange"] == "binance"
+    assert mss["SOL"]["exchange"] == "binance"
+    normalization = mss["__preparation_meta__"]["volume_normalization"]
+    assert normalization["scale_factors_to_reference"] == {
+        "binance": pytest.approx(1.0),
+        "bybit": pytest.approx(2.0),
+    }
+    assert values["BTC"][:, 3].sum() == pytest.approx(2880.0)


### PR DESCRIPTION
## Summary

- select equivalent full-range combined candle sources by configured exchange priority, never aggregate volume
- normalize cross-exchange volume from the latest 60 complete UTC days using per-coin daily log medians and a cross-coin median; require dense overlap and three contributors for universes of at least three coins
- use the first selected configured exchange as the stable reference and fail loudly when selected exchanges cannot be connected robustly
- honor `backtest.volume_normalization`, include it plus the preparation algorithm version in combined-cache identity, and preserve native volume when disabled
- persist full source-selection and normalization provenance in the cache manifest, candidate report, market settings metadata, and backtest `dataset.json`

## Validation

- full Python test suite: pass
- focused HLCV/config/suite/CLI slice after rebasing onto current `master`: pass (2 skipped)
- frozen prepared-dataset backtest before/after: all reported and persisted metrics identical
- fresh offline multi-exchange materialization smoke: stable 3/1 source split, three complete-day contributors with ratios 2.0/2.2/2.4 produced the expected robust factor 2.2, and manifest plus `dataset.json` retained the full estimator/source provenance
- Rust extension rebuilt and source-fingerprint verification passed after rebasing

No private configs, downloaded datasets, backtest artifacts, or generated smoke inputs are included.