### PR TITLE
Share forager candle refresh time across surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@ All notable user-facing changes will be documented in this file.
   symbol/timeframe fetch instead of reserving a whole batch before execution.
   Wall-time or lock timeouts briefly defer only the affected surface, preventing
   one slow symbol from consuming the batch budget and starving other candidates.
+  The remaining cycle time is also shared across the remaining selected surfaces,
+  so sparse-history pagination cannot consume the entire wall-time allowance before
+  later candidates receive a refresh attempt.
 - Added production Bitunix USDT perpetual-futures support through a native signed REST and
   WebSocket connector, including complete market metadata and top-of-book coverage, live-candle
   pagination, hedge-mode order and position reconciliation, account configuration, realized-PnL

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -113,8 +113,12 @@
    candidate's 1m and native 1h health surfaces,
    keep discovered-but-unfetched stale surfaces pending, and charge one token immediately before
    each actual fetch attempt rather than reserving tokens for a batch which may be cut short by
-   the wall-time cap. A timed-out candidate surface receives a short in-memory retry delay so one
-   blocked symbol cannot monopolize successive refresh cycles. Completed-candle health reports
+   the wall-time cap. The remaining wall time is divided across the remaining selected surfaces;
+   a fast refresh leaves its unused share available to later work, while one slow sparse-history
+   refresh cannot consume the entire cycle and starve the rest of the batch. A timed-out candidate
+   surface receives a short in-memory retry delay so one blocked symbol cannot monopolize
+   successive refresh cycles. Exhausting an assigned scheduler time share is an expected DEBUG
+   yield; a timeout raised by the candle operation itself remains a warning. Completed-candle health reports
    whether missing minutes are currently refreshable separately
    from raw coverage. Verified internal `no_trades` continuity and unresolved known gaps whose retry
    cooldown is active do not spend background REST budget. This scheduler classification never

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -20702,6 +20702,7 @@ class Passivbot:
         for idx, (_priority, sym, timeframe, required_candles, pre_health) in enumerate(
             to_refresh, start=1
         ):
+            surface_time_slice_expired = False
             if Passivbot._shutdown_requested(self):
                 logging.debug("[shutdown] aborting forager candle refresh")
                 return
@@ -20764,13 +20765,37 @@ class Passivbot:
                         max_lookback_candles=int(required_candles),
                     )
                 if max_refresh_ms > 0:
+                    # Share the remaining cycle time across the remaining
+                    # selected surfaces. A sparse market may paginate or repair
+                    # gaps for much longer than a normal refresh; allowing it
+                    # to consume the whole remainder starves every later
+                    # candidate. Fast surfaces return early, so their unused
+                    # share naturally remains available to later work.
+                    elapsed_before_fetch_ms = int(
+                        max(0, utc_ms() - refresh_started_ms)
+                    )
+                    remaining_surface_count = max(
+                        1, len(to_refresh) - idx + 1
+                    )
                     remaining_s = max(
                         0.001,
-                        float(max_refresh_ms - elapsed_ms) / 1000.0,
+                        float(max_refresh_ms - elapsed_before_fetch_ms)
+                        / float(remaining_surface_count)
+                        / 1000.0,
                     )
-                    refreshed = await asyncio.wait_for(
-                        candle_task, timeout=remaining_s
+                    candle_fetch_task = asyncio.create_task(candle_task)
+                    completed_tasks, _pending_tasks = await asyncio.wait(
+                        {candle_fetch_task}, timeout=remaining_s
                     )
+                    if not completed_tasks:
+                        surface_time_slice_expired = True
+                        candle_fetch_task.cancel()
+                        try:
+                            await candle_fetch_task
+                        except asyncio.CancelledError:
+                            pass
+                        raise TimeoutError("forager surface time slice expired")
+                    refreshed = candle_fetch_task.result()
                 else:
                     refreshed = await candle_task
                 post_health = Passivbot._candidate_candle_surface_health(
@@ -20879,12 +20904,20 @@ class Passivbot:
                         total_count=len(to_refresh),
                     )
                     break
-                logging.warning(
-                    "Timed out acquiring candle lock for %s; forager refresh will retry "
-                    "| error_type=%s",
-                    Passivbot._log_symbol(sym),
-                    bounded_exception_type(exc),
-                )
+                if surface_time_slice_expired:
+                    logging.debug(
+                        "[candle] forager surface yielded after its fair time share | "
+                        "symbol=%s timeframe=%s action=defer_surface_retry",
+                        Passivbot._log_symbol(sym),
+                        timeframe,
+                    )
+                else:
+                    logging.warning(
+                        "Timed out refreshing candles for %s; forager refresh will retry "
+                        "| error_type=%s",
+                        Passivbot._log_symbol(sym),
+                        bounded_exception_type(exc),
+                    )
             except Exception as exc:
                 error_type = bounded_exception_type(exc)
                 if isinstance(exc, OhlcvTerminalEmptyPage):

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -20918,16 +20918,22 @@ class Passivbot:
                         / 1000.0,
                     )
                     candle_fetch_task = asyncio.create_task(candle_task)
-                    completed_tasks, _pending_tasks = await asyncio.wait(
-                        {candle_fetch_task}, timeout=remaining_s
-                    )
+                    try:
+                        completed_tasks, _pending_tasks = await asyncio.wait(
+                            {candle_fetch_task}, timeout=remaining_s
+                        )
+                    except asyncio.CancelledError:
+                        candle_fetch_task.cancel()
+                        await asyncio.gather(
+                            candle_fetch_task, return_exceptions=True
+                        )
+                        raise
                     if not completed_tasks:
                         surface_time_slice_expired = True
                         candle_fetch_task.cancel()
-                        try:
-                            await candle_fetch_task
-                        except asyncio.CancelledError:
-                            pass
+                        await asyncio.gather(
+                            candle_fetch_task, return_exceptions=True
+                        )
                         raise TimeoutError("forager surface time slice expired")
                     refreshed = candle_fetch_task.result()
                 else:

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 import pytest
@@ -4531,6 +4532,97 @@ async def test_forager_candidate_refresh_shares_wall_time_across_surfaces(
         bot._forager_surface_failure_retry_after_ms[(symbols[0], "1m")]
         == now_ms + pb_mod._FORAGER_TRANSIENT_FAILURE_RETRY_MS
     )
+
+
+@pytest.mark.asyncio
+async def test_forager_candidate_refresh_cancels_child_fetch_with_parent(
+    monkeypatch,
+):
+    import passivbot as pb_mod
+
+    now_ms = 10_000_000
+    symbol = "SLOW/USDT:USDT"
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: now_ms)
+    monkeypatch.setattr(
+        pb_mod,
+        "compute_live_warmup_windows",
+        lambda *args, **kwargs: ({symbol: 10}, {symbol: 0}, {symbol: True}),
+    )
+    monkeypatch.setattr(
+        pb_mod.Passivbot, "_urgent_active_candle_symbols", lambda _bot: []
+    )
+    monkeypatch.setattr(
+        pb_mod.Passivbot,
+        "_candidate_candle_surface_health",
+        lambda _bot, *args, **kwargs: {
+            "age_ms": 60_000,
+            "coverage_ok": False,
+            "no_basis": True,
+        },
+    )
+
+    spawned_tasks = []
+
+    async def cancelled_wait(tasks, *, timeout):
+        del timeout
+        spawned_tasks.extend(tasks)
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(pb_mod.asyncio, "wait", cancelled_wait)
+
+    class FakeCM:
+        default_window_candles = 120
+
+        def get_candles(self, symbol, **kwargs):
+            del symbol, kwargs
+
+            async def blocked_fetch():
+                await asyncio.Event().wait()
+
+            return blocked_fetch()
+
+    class FakeBot:
+        config = {
+            "live": {
+                "max_ohlcv_fetches_per_minute": 1,
+                "max_forager_candle_refresh_seconds": 1.0,
+            }
+        }
+        approved_coins_minus_ignored_coins = {"long": {symbol}, "short": set()}
+        stop_signal_received = False
+        _shutdown_in_progress = False
+        start_time_ms = now_ms
+        cm = FakeCM()
+
+        def is_forager_mode(self, pside=None):
+            return pside in (None, "long")
+
+        def get_max_n_positions(self, pside):
+            return 1 if pside == "long" else 0
+
+        def get_current_n_positions(self, pside):
+            return 0
+
+        def bp(self, *args, **kwargs):
+            return 0.0
+
+        def _get_fetch_delay_seconds(self):
+            return 0.0
+
+        def _forager_refresh_budget(self, *args, **kwargs):
+            return 1
+
+        def _forager_target_staleness_ms(self, *args, **kwargs):
+            return 0
+
+        _shutdown_requested = pb_mod.Passivbot._shutdown_requested
+
+    with pytest.raises(asyncio.CancelledError):
+        await pb_mod.Passivbot._refresh_forager_candidate_candles(FakeBot())
+
+    assert len(spawned_tasks) == 1
+    assert spawned_tasks[0].done()
+    assert spawned_tasks[0].cancelled()
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -674,7 +674,7 @@ async def test_forager_refresh_bounds_per_symbol_timeout_and_failure(monkeypatch
 
     assert bot.cm.calls == sorted(symbols)
     assert (
-        "Timed out acquiring candle lock for TIMEOUT; "
+        "Timed out refreshing candles for TIMEOUT; "
         "forager refresh will retry | error_type=TimeoutError"
     ) in caplog.text
     assert "error refreshing forager candles for BROKEN" in caplog.text
@@ -4407,6 +4407,120 @@ async def test_forager_candidate_refresh_yields_after_wall_time_cap(
         if call.get("consume", True)
     ] == [1, 1]
     assert "forager refresh paused by wall-time cap" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_forager_candidate_refresh_shares_wall_time_across_surfaces(
+    monkeypatch,
+    caplog,
+):
+    import passivbot as pb_mod
+
+    now_ms = 10_000_000
+    symbols = ["A_SLOW/USDT:USDT", "B_FAST/USDT:USDT"]
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: now_ms)
+    monkeypatch.setattr(
+        pb_mod,
+        "compute_live_warmup_windows",
+        lambda *args, **kwargs: (
+            {symbol: 10 for symbol in symbols},
+            {symbol: 0 for symbol in symbols},
+            {symbol: True for symbol in symbols},
+        ),
+    )
+    monkeypatch.setattr(
+        pb_mod.Passivbot, "_urgent_active_candle_symbols", lambda _bot: []
+    )
+    monkeypatch.setattr(
+        pb_mod.Passivbot,
+        "_candidate_candle_surface_health",
+        lambda _bot, *args, **kwargs: {
+            "age_ms": 60_000,
+            "coverage_ok": False,
+            "no_basis": True,
+        },
+    )
+
+    timeout_calls = []
+
+    async def fake_wait(tasks, *, timeout):
+        timeout_calls.append(float(timeout))
+        task = next(iter(tasks))
+        if len(timeout_calls) == 1:
+            return set(), {task}
+        await task
+        return {task}, set()
+
+    monkeypatch.setattr(pb_mod.asyncio, "wait", fake_wait)
+
+    class FakeCM:
+        default_window_candles = 120
+
+        def __init__(self):
+            self.calls = []
+
+        def get_candles(self, symbol, **kwargs):
+            self.calls.append(symbol)
+
+            async def completed_fetch():
+                return []
+
+            return completed_fetch()
+
+    class FakeBot:
+        config = {
+            "live": {
+                "max_ohlcv_fetches_per_minute": 8,
+                "max_forager_candle_refresh_seconds": 0.1,
+            }
+        }
+        approved_coins_minus_ignored_coins = {"long": set(symbols), "short": set()}
+        stop_signal_received = False
+        _shutdown_in_progress = False
+        start_time_ms = now_ms
+
+        def __init__(self):
+            self.cm = FakeCM()
+
+        def is_forager_mode(self, pside=None):
+            return pside in (None, "long")
+
+        def get_max_n_positions(self, pside):
+            return 2 if pside == "long" else 0
+
+        def get_current_n_positions(self, pside):
+            return 0
+
+        def bp(self, *args, **kwargs):
+            return 0.0
+
+        def _get_fetch_delay_seconds(self):
+            return 0.0
+
+        def _forager_refresh_budget(self, *args, **kwargs):
+            return 2
+
+        def _forager_target_staleness_ms(self, *args, **kwargs):
+            return 0
+
+        _shutdown_requested = pb_mod.Passivbot._shutdown_requested
+
+    bot = FakeBot()
+    with caplog.at_level(logging.DEBUG):
+        await pb_mod.Passivbot._refresh_forager_candidate_candles(bot)
+
+    assert bot.cm.calls == symbols
+    assert timeout_calls == pytest.approx([0.05, 0.1])
+    assert "forager surface yielded after its fair time share" in caplog.text
+    assert not any(
+        record.levelno >= logging.WARNING
+        and "A_SLOW" in record.message
+        for record in caplog.records
+    )
+    assert (
+        bot._forager_surface_failure_retry_after_ms[(symbols[0], "1m")]
+        == now_ms + pb_mod._FORAGER_TRANSIENT_FAILURE_RETRY_MS
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- share each forager candle-refresh cycle's remaining wall time across the remaining selected surfaces
- cancel and briefly defer a surface that exhausts its fair scheduler slice so later candidates still receive attempts
- distinguish expected scheduler yields at DEBUG from genuine candle-operation timeouts at WARNING

## Root cause

The scheduler bounded a selected batch with a wall-time cap, but each individual candle operation could consume the entire remaining allowance while paginating or repairing sparse history. One slow surface could therefore starve every later candidate even though their REST budget tokens had not been consumed.

## Validation

- `python -m pytest -q tests/test_live_candle_budget.py tests/test_candlestick_manager.py tests/test_ai_docs.py`
- `python -m py_compile src/passivbot.py`
- `python src/tools/check_ai_docs.py` (0 errors; existing documentation-size warnings only)
- live smoke test on KuCoin: full warmup completed, subsequent cycles reached up to all eight selected surfaces, and the prior scheduler-timeout warning spam did not recur
