### PR TITLE
Recover Hyperliquid sparse order websocket semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,12 @@ All notable user-facing changes will be documented in this file.
   transport health: unnormalizable rows are discarded with a bounded warning and force an
   authoritative account-state refresh, while valid rows in the same message are processed without
   reconnecting. Bitget side-attribution failures now use this path without logging raw payloads.
+- Hyperliquid sparse private order updates now recover mandatory one-way position-side and
+  close-only semantics by exact exchange order ID from the current authoritative REST open-order
+  snapshot. Orders already resting at bot startup therefore avoid repeated semantic-rejection REST
+  refreshes. A bounded recent copy covers terminal updates arriving just after reconciliation
+  removes the order, while missing, ambiguous, stale, and contradictory identities remain
+  fail-closed.
 - Binance's explicit `MarginModeAlreadySet` response is now treated as a successful configuration
   no-op at DEBUG instead of an ERROR; unknown margin-mode failures retain their existing loud
   handling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,10 +228,10 @@ All notable user-facing changes will be documented in this file.
   close-only semantics by exact exchange order ID from the current authoritative REST open-order
   snapshot. Orders already resting at bot startup therefore avoid repeated semantic-rejection REST
   refreshes. A bounded recent copy covers terminal updates arriving just after reconciliation
-  removes the order. Client-ID aliases must agree, authoritative contradictions cannot fall back
-  to local acknowledgements, and snapshot-recovered rows still force account refresh because the
-  snapshot proves semantics rather than local ownership. Missing, ambiguous, stale, and
-  contradictory identities remain fail-closed.
+  removes the order. Exchange-ID and client-ID aliases must agree, authoritative contradictions
+  invalidate older cached semantics and cannot fall back to local acknowledgements, and
+  snapshot-recovered rows still force account refresh because the snapshot proves semantics rather
+  than local ownership. Missing, ambiguous, stale, and contradictory identities remain fail-closed.
 - Binance's explicit `MarginModeAlreadySet` response is now treated as a successful configuration
   no-op at DEBUG instead of an ERROR; unknown margin-mode failures retain their existing loud
   handling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,8 +226,10 @@ All notable user-facing changes will be documented in this file.
   close-only semantics by exact exchange order ID from the current authoritative REST open-order
   snapshot. Orders already resting at bot startup therefore avoid repeated semantic-rejection REST
   refreshes. A bounded recent copy covers terminal updates arriving just after reconciliation
-  removes the order, while missing, ambiguous, stale, and contradictory identities remain
-  fail-closed.
+  removes the order. Client-ID aliases must agree, authoritative contradictions cannot fall back
+  to local acknowledgements, and snapshot-recovered rows still force account refresh because the
+  snapshot proves semantics rather than local ownership. Missing, ambiguous, stale, and
+  contradictory identities remain fail-closed.
 - Binance's explicit `MarginModeAlreadySet` response is now treated as a successful configuration
   no-op at DEBUG instead of an ERROR; unknown margin-mode failures retain their existing loud
   handling.

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -50,7 +50,15 @@ an order-open websocket row before the concurrent create request returns its
 exchange order ID. While a create is still freshly submitted, the connector may
 briefly yield for that acknowledgement and retry the row, but recovery still
 requires the exact acknowledged exchange ID and all existing contradiction
-checks. Price, quantity, side, or order shape alone never prove ownership.
+checks. Sparse Hyperliquid rows for orders already resting at process startup may
+instead recover side, `position_side`, and close-only intent from one exact
+exchange-ID match in the current authoritative REST open-order snapshot. A
+bounded five-minute in-memory copy of those exact semantics covers terminal
+updates which arrive just after reconciliation removes the order; it is rebuilt
+from REST after restart and does not preserve ownership or trading intent.
+Missing, duplicate, expired, or contradictory matches remain rejected and
+trigger a fresh account-state read. Price, quantity, side, or order shape alone
+never prove ownership.
 
 A successful private-websocket read and a valid individual order row are separate health
 boundaries. When a supported CCXT connector receives a row whose mandatory side, position-side,

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -56,9 +56,11 @@ exchange-ID match in the current authoritative REST open-order snapshot. A
 bounded five-minute in-memory copy of those exact semantics covers terminal
 updates which arrive just after reconciliation removes the order; it is rebuilt
 from REST after restart and does not preserve ownership or trading intent.
-Every supplied client-ID alias must agree with the canonical client ID retained
-by the snapshot or its bounded copy. Missing, duplicate, expired, or
-contradictory matches remain rejected and trigger a fresh account-state read;
+Every supplied exchange-ID and client-ID alias must agree with the canonical
+identity retained by the snapshot or its bounded copy. A contradictory current
+snapshot row invalidates any older cached semantics for its exchange-ID aliases.
+Missing, duplicate, expired, or contradictory matches remain rejected and
+trigger a fresh account-state read;
 authoritative snapshot contradictions must not fall back to process-local
 acknowledgement evidence. A unified `reduceOnly` value of `false` or `null` is
 treated as a CCXT placeholder only when the native row omits that field; an

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -56,11 +56,16 @@ exchange-ID match in the current authoritative REST open-order snapshot. A
 bounded five-minute in-memory copy of those exact semantics covers terminal
 updates which arrive just after reconciliation removes the order; it is rebuilt
 from REST after restart and does not preserve ownership or trading intent.
-Missing, duplicate, expired, or contradictory matches remain rejected and
-trigger a fresh account-state read. A unified `reduceOnly` value of `false` or
-`null` is treated as a CCXT placeholder only when the native row omits that
-field; an explicit native value still must agree with the recovered semantics.
-Price, quantity, side, or order shape alone never prove ownership.
+Every supplied client-ID alias must agree with the canonical client ID retained
+by the snapshot or its bounded copy. Missing, duplicate, expired, or
+contradictory matches remain rejected and trigger a fresh account-state read;
+authoritative snapshot contradictions must not fall back to process-local
+acknowledgement evidence. A unified `reduceOnly` value of `false` or `null` is
+treated as a CCXT placeholder only when the native row omits that field; an
+explicit native value still must agree with the recovered semantics. All
+snapshot-recovered rows request authoritative refresh because an exact exchange
+ID proves semantics but not local ownership. Price, quantity, side, or order
+shape alone never prove ownership.
 
 A successful private-websocket read and a valid individual order row are separate health
 boundaries. When a supported CCXT connector receives a row whose mandatory side, position-side,

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -57,8 +57,10 @@ bounded five-minute in-memory copy of those exact semantics covers terminal
 updates which arrive just after reconciliation removes the order; it is rebuilt
 from REST after restart and does not preserve ownership or trading intent.
 Missing, duplicate, expired, or contradictory matches remain rejected and
-trigger a fresh account-state read. Price, quantity, side, or order shape alone
-never prove ownership.
+trigger a fresh account-state read. A unified `reduceOnly` value of `false` or
+`null` is treated as a CCXT placeholder only when the native row omits that
+field; an explicit native value still must agree with the recovered semantics.
+Price, quantity, side, or order shape alone never prove ownership.
 
 A successful private-websocket read and a valid individual order row are separate health
 boundaries. When a supported CCXT connector receives a row whose mandatory side, position-side,

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -987,10 +987,10 @@ class HyperliquidBot(CCXTBot):
                 if key not in order:
                     continue
                 value = order[key]
-                # CCXT may synthesize a unified False when the native payload
-                # omits reduceOnly. Preserve that compatibility, but never
-                # discard a supplied True or contradict native semantics.
-                if value is False and not raw_has_explicit_reduce_only:
+                # CCXT may synthesize a unified False or None when the native
+                # payload omits reduceOnly. Preserve those placeholders, but
+                # never discard a supplied True or contradict native semantics.
+                if value in (False, None) and not raw_has_explicit_reduce_only:
                     continue
                 websocket_reduce_only = self._strict_order_reduce_only_response(
                     {"info": {key: value}}

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -595,7 +595,10 @@ class HyperliquidBot(CCXTBot):
                         order["position_side"] = position_side
                         order["reduceOnly"] = reduce_only
                         order["_pb_order_semantics_source"] = semantics_source
-                        if self._hl_ws_order_has_fill_progress(order):
+                        if (
+                            semantics_source == "authoritative_open_order_snapshot"
+                            or self._hl_ws_order_has_fill_progress(order)
+                        ):
                             order[
                                 "_pb_order_update_requires_authoritative_refresh"
                             ] = True
@@ -622,7 +625,10 @@ class HyperliquidBot(CCXTBot):
                         order["position_side"] = position_side
                         order["reduceOnly"] = reduce_only
                         order["_pb_order_semantics_source"] = semantics_source
-                        if self._hl_ws_order_has_fill_progress(order):
+                        if (
+                            semantics_source == "authoritative_open_order_snapshot"
+                            or self._hl_ws_order_has_fill_progress(order)
+                        ):
                             order[
                                 "_pb_order_update_requires_authoritative_refresh"
                             ] = True
@@ -736,22 +742,7 @@ class HyperliquidBot(CCXTBot):
         if len(matches) != 1:
             return None
         record = matches[0]
-        client_id_keys = (
-            "custom_id",
-            "customId",
-            "client_order_id",
-            "clientOrderId",
-            "client_oid",
-            "clientOid",
-            "clOrdId",
-            "cloid",
-        )
-        client_ids = {
-            self._canonical_passivbot_custom_id(str(source.get(key)))
-            for source in (order, *raw_sources)
-            for key in client_id_keys
-            if source.get(key) not in (None, "")
-        }
+        client_ids = self._hl_ws_order_client_ids(order, raw_sources)
         record_client_id = str(record.get("canonical_custom_id") or "")
         if client_ids and (
             not record_client_id
@@ -785,9 +776,13 @@ class HyperliquidBot(CCXTBot):
         self, order: dict
     ) -> tuple[str, bool, str] | None:
         """Recover sparse semantics from exchange truth, then local create acknowledgement."""
-        recovered = self._hl_open_snapshot_ws_order_semantics(order)
+        snapshot_state, recovered = (
+            self._hl_open_snapshot_ws_order_semantics_evidence(order)
+        )
         if recovered is not None:
             return (*recovered, "authoritative_open_order_snapshot")
+        if snapshot_state == "invalid":
+            return None
         recovered = self._hl_acknowledged_ws_order_semantics(order)
         if recovered is not None:
             return (*recovered, "acknowledged_exchange_order_id")
@@ -820,22 +815,53 @@ class HyperliquidBot(CCXTBot):
             if source.get(key) not in (None, "")
         }
 
+    def _hl_ws_order_client_ids(
+        self, order: dict, raw_sources: tuple[dict, ...]
+    ) -> set[str]:
+        client_id_keys = (
+            "custom_id",
+            "customId",
+            "client_order_id",
+            "clientOrderId",
+            "client_oid",
+            "clientOid",
+            "clOrdId",
+            "cloid",
+        )
+        return {
+            self._canonical_passivbot_custom_id(str(source.get(key)))
+            for source in (order, *raw_sources)
+            for key in client_id_keys
+            if source.get(key) not in (None, "")
+        }
+
     def _hl_open_snapshot_ws_order_semantics(
         self, order: dict
     ) -> tuple[str, bool] | None:
+        """Compatibility wrapper returning only valid snapshot semantics."""
+        _snapshot_state, recovered = (
+            self._hl_open_snapshot_ws_order_semantics_evidence(order)
+        )
+        return recovered
+
+    def _hl_open_snapshot_ws_order_semantics_evidence(
+        self, order: dict
+    ) -> tuple[str, tuple[str, bool] | None]:
         """Recover sparse WS semantics from the exact authoritative REST order.
 
         The in-memory ``open_orders`` view is refreshed from exchange state and
         survives no process-local provenance assumptions.  This makes recovery
         reproducible after restart while still requiring one exact exchange ID
-        and rejecting ambiguous, missing, or contradictory payloads.
+        and rejecting ambiguous or contradictory payloads. The returned state
+        distinguishes absent evidence from invalid authoritative evidence so a
+        local acknowledgement can never override a snapshot contradiction.
         """
         if not isinstance(order, dict):
-            return None
+            return "invalid", None
         raw_sources = self._hl_ws_order_raw_sources(order)
         exchange_ids = self._hl_ws_order_exchange_ids(order, raw_sources)
         if len(exchange_ids) != 1:
-            return None
+            return "invalid", None
         exchange_id = next(iter(exchange_ids))
         matches = [
             existing
@@ -846,12 +872,18 @@ class HyperliquidBot(CCXTBot):
             and self._extract_order_exchange_id(existing) == exchange_id
         ]
         if len(matches) > 1:
-            return None
+            return "invalid", None
         if len(matches) == 1:
             existing = matches[0]
             side = str(existing.get("side") or "").lower()
             position_side = str(existing.get("position_side") or "").lower()
             reduce_only = self._canonical_open_order_reduce_only(existing)
+            existing_client_ids = self._hl_ws_order_client_ids(
+                existing, self._hl_ws_order_raw_sources(existing)
+            )
+            if len(existing_client_ids) > 1:
+                return "invalid", None
+            client_id = next(iter(existing_client_ids), "")
         else:
             now_ms = utc_ms()
             semantics_cache = getattr(
@@ -869,29 +901,38 @@ class HyperliquidBot(CCXTBot):
             self._hl_open_order_semantics_by_exchange_id = semantics_cache
             existing = semantics_cache.get(exchange_id)
             if not isinstance(existing, dict):
-                return None
+                return "absent", None
             side = str(existing.get("side") or "").lower()
             position_side = str(existing.get("position_side") or "").lower()
             reduce_only = existing.get("reduce_only")
+            client_id = str(existing.get("client_id") or "")
         if (
             side not in {"buy", "sell"}
             or position_side not in {"long", "short"}
             or not isinstance(reduce_only, bool)
         ):
-            return None
+            return "invalid", None
         if str(order.get("side") or "").lower() != side:
-            return None
+            return "invalid", None
+        websocket_client_ids = self._hl_ws_order_client_ids(order, raw_sources)
+        if websocket_client_ids and (
+            not client_id
+            or len(websocket_client_ids) != 1
+            or next(iter(websocket_client_ids)) != client_id
+        ):
+            return "invalid", None
         action_side = self._derive_one_way_position_side(
             {"side": side, "reduceOnly": reduce_only}
         )
         if action_side != position_side:
-            return None
-        return self._hl_validate_recovered_ws_order_semantics(
+            return "invalid", None
+        recovered = self._hl_validate_recovered_ws_order_semantics(
             order,
             raw_sources=raw_sources,
             position_side=position_side,
             reduce_only=reduce_only,
         )
+        return ("valid", recovered) if recovered is not None else ("invalid", None)
 
     def _hl_validate_recovered_ws_order_semantics(
         self,
@@ -1099,17 +1140,22 @@ class HyperliquidBot(CCXTBot):
             side = str(order.get("side") or "").lower()
             position_side = str(order.get("position_side") or "").lower()
             reduce_only = self._canonical_open_order_reduce_only(order)
+            client_ids = self._hl_ws_order_client_ids(
+                order, self._hl_ws_order_raw_sources(order)
+            )
             if (
                 not exchange_id
                 or side not in {"buy", "sell"}
                 or position_side not in {"long", "short"}
                 or not isinstance(reduce_only, bool)
+                or len(client_ids) > 1
             ):
                 continue
             cache[exchange_id] = {
                 "side": side,
                 "position_side": position_side,
                 "reduce_only": reduce_only,
+                "client_id": next(iter(client_ids), ""),
                 "last_seen_ms": now_ms,
             }
         self._hl_open_order_semantics_by_exchange_id = cache

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -863,14 +863,21 @@ class HyperliquidBot(CCXTBot):
         if len(exchange_ids) != 1:
             return "invalid", None
         exchange_id = next(iter(exchange_ids))
-        matches = [
-            existing
-            for orders in (getattr(self, "open_orders", {}) or {}).values()
-            if isinstance(orders, list)
-            for existing in orders
-            if isinstance(existing, dict)
-            and self._extract_order_exchange_id(existing) == exchange_id
-        ]
+        matches = []
+        for orders in (getattr(self, "open_orders", {}) or {}).values():
+            if not isinstance(orders, list):
+                continue
+            for existing in orders:
+                if not isinstance(existing, dict):
+                    continue
+                existing_exchange_ids = self._hl_ws_order_exchange_ids(
+                    existing, self._hl_ws_order_raw_sources(existing)
+                )
+                if exchange_id not in existing_exchange_ids:
+                    continue
+                if existing_exchange_ids != {exchange_id}:
+                    return "invalid", None
+                matches.append(existing)
         if len(matches) > 1:
             return "invalid", None
         if len(matches) == 1:
@@ -1136,7 +1143,14 @@ class HyperliquidBot(CCXTBot):
             and int(value.get("last_seen_ms", 0) or 0) >= cutoff_ms
         }
         for order in orders:
-            exchange_id = self._extract_order_exchange_id(order)
+            exchange_ids = self._hl_ws_order_exchange_ids(
+                order, self._hl_ws_order_raw_sources(order)
+            )
+            if len(exchange_ids) != 1:
+                for exchange_id in exchange_ids:
+                    cache.pop(exchange_id, None)
+                continue
+            exchange_id = next(iter(exchange_ids))
             side = str(order.get("side") or "").lower()
             position_side = str(order.get("position_side") or "").lower()
             reduce_only = self._canonical_open_order_reduce_only(order)
@@ -1150,6 +1164,7 @@ class HyperliquidBot(CCXTBot):
                 or not isinstance(reduce_only, bool)
                 or len(client_ids) > 1
             ):
+                cache.pop(exchange_id, None)
                 continue
             cache[exchange_id] = {
                 "side": side,

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -42,6 +42,7 @@ class HyperliquidBot(CCXTBot):
     HIP3_FULL_DEX_SWEEP_INTERVAL_MS = 30 * 60_000
     ORDER_WS_CREATE_ACK_GRACE_SECONDS = 1.0
     ORDER_WS_SUBMITTED_LOOKBACK_MS = 5_000
+    ORDER_WS_OPEN_SNAPSHOT_SEMANTICS_TTL_MS = 5 * 60_000
 
     def __init__(self, config: dict):
         super().__init__(config)
@@ -586,16 +587,14 @@ class HyperliquidBot(CCXTBot):
                     try:
                         order["position_side"] = self.determine_pos_side(order)
                     except (KeyError, TypeError, ValueError) as exc:
-                        recovered = self._hl_acknowledged_ws_order_semantics(order)
+                        recovered = self._hl_recover_ws_order_semantics(order)
                         if recovered is None:
                             untrusted.append((order, exc))
                             continue
-                        position_side, reduce_only = recovered
+                        position_side, reduce_only, semantics_source = recovered
                         order["position_side"] = position_side
                         order["reduceOnly"] = reduce_only
-                        order["_pb_order_semantics_source"] = (
-                            "acknowledged_exchange_order_id"
-                        )
+                        order["_pb_order_semantics_source"] = semantics_source
                         if self._hl_ws_order_has_fill_progress(order):
                             order[
                                 "_pb_order_update_requires_authoritative_refresh"
@@ -615,16 +614,14 @@ class HyperliquidBot(CCXTBot):
                     await asyncio.sleep(self.ORDER_WS_CREATE_ACK_GRACE_SECONDS)
                     still_untrusted = []
                     for order, exc in untrusted:
-                        recovered = self._hl_acknowledged_ws_order_semantics(order)
+                        recovered = self._hl_recover_ws_order_semantics(order)
                         if recovered is None:
                             still_untrusted.append((order, exc))
                             continue
-                        position_side, reduce_only = recovered
+                        position_side, reduce_only, semantics_source = recovered
                         order["position_side"] = position_side
                         order["reduceOnly"] = reduce_only
-                        order["_pb_order_semantics_source"] = (
-                            "acknowledged_exchange_order_id"
-                        )
+                        order["_pb_order_semantics_source"] = semantics_source
                         if self._hl_ws_order_has_fill_progress(order):
                             order[
                                 "_pb_order_update_requires_authoritative_refresh"
@@ -723,27 +720,8 @@ class HyperliquidBot(CCXTBot):
         """
         if not isinstance(order, dict):
             return None
-        info = order.get("info")
-        info_wrapper = info if isinstance(info, dict) else {}
-        nested_order = info_wrapper.get("order")
-        raw_info = nested_order if isinstance(nested_order, dict) else info_wrapper
-        raw_source_candidates = (info_wrapper, raw_info)
-        raw_sources = tuple(
-            source
-            for index, source in enumerate(raw_source_candidates)
-            if source
-            and all(
-                source is not prior for prior in raw_source_candidates[:index]
-            )
-        )
-
-        exchange_id_keys = ("id", "order_id", "orderId", "orderID", "ordId", "oid")
-        exchange_ids = {
-            str(source.get(key))
-            for source in (order, *raw_sources)
-            for key in exchange_id_keys
-            if source.get(key) not in (None, "")
-        }
+        raw_sources = self._hl_ws_order_raw_sources(order)
+        exchange_ids = self._hl_ws_order_exchange_ids(order, raw_sources)
         if len(exchange_ids) != 1:
             return None
         exchange_id = next(iter(exchange_ids))
@@ -796,6 +774,135 @@ class HyperliquidBot(CCXTBot):
         )
         if action_side != position_side:
             return None
+        return self._hl_validate_recovered_ws_order_semantics(
+            order,
+            raw_sources=raw_sources,
+            position_side=position_side,
+            reduce_only=reduce_only,
+        )
+
+    def _hl_recover_ws_order_semantics(
+        self, order: dict
+    ) -> tuple[str, bool, str] | None:
+        """Recover sparse semantics from exchange truth, then local create acknowledgement."""
+        recovered = self._hl_open_snapshot_ws_order_semantics(order)
+        if recovered is not None:
+            return (*recovered, "authoritative_open_order_snapshot")
+        recovered = self._hl_acknowledged_ws_order_semantics(order)
+        if recovered is not None:
+            return (*recovered, "acknowledged_exchange_order_id")
+        return None
+
+    @staticmethod
+    def _hl_ws_order_raw_sources(order: dict) -> tuple[dict, ...]:
+        """Return distinct native websocket payload wrappers for validation."""
+        info = order.get("info")
+        info_wrapper = info if isinstance(info, dict) else {}
+        nested_order = info_wrapper.get("order")
+        raw_info = nested_order if isinstance(nested_order, dict) else info_wrapper
+        raw_source_candidates = (info_wrapper, raw_info)
+        return tuple(
+            source
+            for index, source in enumerate(raw_source_candidates)
+            if source
+            and all(source is not prior for prior in raw_source_candidates[:index])
+        )
+
+    @staticmethod
+    def _hl_ws_order_exchange_ids(
+        order: dict, raw_sources: tuple[dict, ...]
+    ) -> set[str]:
+        exchange_id_keys = ("id", "order_id", "orderId", "orderID", "ordId", "oid")
+        return {
+            str(source.get(key))
+            for source in (order, *raw_sources)
+            for key in exchange_id_keys
+            if source.get(key) not in (None, "")
+        }
+
+    def _hl_open_snapshot_ws_order_semantics(
+        self, order: dict
+    ) -> tuple[str, bool] | None:
+        """Recover sparse WS semantics from the exact authoritative REST order.
+
+        The in-memory ``open_orders`` view is refreshed from exchange state and
+        survives no process-local provenance assumptions.  This makes recovery
+        reproducible after restart while still requiring one exact exchange ID
+        and rejecting ambiguous, missing, or contradictory payloads.
+        """
+        if not isinstance(order, dict):
+            return None
+        raw_sources = self._hl_ws_order_raw_sources(order)
+        exchange_ids = self._hl_ws_order_exchange_ids(order, raw_sources)
+        if len(exchange_ids) != 1:
+            return None
+        exchange_id = next(iter(exchange_ids))
+        matches = [
+            existing
+            for orders in (getattr(self, "open_orders", {}) or {}).values()
+            if isinstance(orders, list)
+            for existing in orders
+            if isinstance(existing, dict)
+            and self._extract_order_exchange_id(existing) == exchange_id
+        ]
+        if len(matches) > 1:
+            return None
+        if len(matches) == 1:
+            existing = matches[0]
+            side = str(existing.get("side") or "").lower()
+            position_side = str(existing.get("position_side") or "").lower()
+            reduce_only = self._canonical_open_order_reduce_only(existing)
+        else:
+            now_ms = utc_ms()
+            semantics_cache = getattr(
+                self, "_hl_open_order_semantics_by_exchange_id", {}
+            )
+            if not isinstance(semantics_cache, dict):
+                semantics_cache = {}
+            cutoff_ms = now_ms - self.ORDER_WS_OPEN_SNAPSHOT_SEMANTICS_TTL_MS
+            semantics_cache = {
+                key: value
+                for key, value in semantics_cache.items()
+                if isinstance(value, dict)
+                and int(value.get("last_seen_ms", 0) or 0) >= cutoff_ms
+            }
+            self._hl_open_order_semantics_by_exchange_id = semantics_cache
+            existing = semantics_cache.get(exchange_id)
+            if not isinstance(existing, dict):
+                return None
+            side = str(existing.get("side") or "").lower()
+            position_side = str(existing.get("position_side") or "").lower()
+            reduce_only = existing.get("reduce_only")
+        if (
+            side not in {"buy", "sell"}
+            or position_side not in {"long", "short"}
+            or not isinstance(reduce_only, bool)
+        ):
+            return None
+        if str(order.get("side") or "").lower() != side:
+            return None
+        action_side = self._derive_one_way_position_side(
+            {"side": side, "reduceOnly": reduce_only}
+        )
+        if action_side != position_side:
+            return None
+        return self._hl_validate_recovered_ws_order_semantics(
+            order,
+            raw_sources=raw_sources,
+            position_side=position_side,
+            reduce_only=reduce_only,
+        )
+
+    def _hl_validate_recovered_ws_order_semantics(
+        self,
+        order: dict,
+        *,
+        raw_sources: tuple[dict, ...],
+        position_side: str,
+        reduce_only: bool,
+    ) -> tuple[str, bool] | None:
+        """Reject any websocket field contradicting recovered semantics."""
+        side = str(order.get("side") or "").lower()
         raw_side_values = [
             source.get("side")
             for source in raw_sources
@@ -964,7 +1071,48 @@ class HyperliquidBot(CCXTBot):
         for elm in fetched:
             elm["position_side"] = self.determine_pos_side(elm)
             elm["qty"] = elm["amount"]
-        return sorted(fetched, key=lambda x: x["timestamp"])
+        normalized = sorted(fetched, key=lambda x: x["timestamp"])
+        self._hl_note_authoritative_open_order_semantics(normalized)
+        return normalized
+
+    def _hl_note_authoritative_open_order_semantics(self, orders: list[dict]) -> None:
+        """Retain a bounded exact-ID semantic hint for terminal WS updates.
+
+        Reconciliation may remove a canceled or filled order from ``open_orders``
+        before its sparse websocket update arrives. This cache retains only
+        semantics already proven by a REST open-order snapshot and is rebuilt
+        after every process restart.
+        """
+        now_ms = utc_ms()
+        cutoff_ms = now_ms - self.ORDER_WS_OPEN_SNAPSHOT_SEMANTICS_TTL_MS
+        cache = getattr(self, "_hl_open_order_semantics_by_exchange_id", {})
+        if not isinstance(cache, dict):
+            cache = {}
+        cache = {
+            key: value
+            for key, value in cache.items()
+            if isinstance(value, dict)
+            and int(value.get("last_seen_ms", 0) or 0) >= cutoff_ms
+        }
+        for order in orders:
+            exchange_id = self._extract_order_exchange_id(order)
+            side = str(order.get("side") or "").lower()
+            position_side = str(order.get("position_side") or "").lower()
+            reduce_only = self._canonical_open_order_reduce_only(order)
+            if (
+                not exchange_id
+                or side not in {"buy", "sell"}
+                or position_side not in {"long", "short"}
+                or not isinstance(reduce_only, bool)
+            ):
+                continue
+            cache[exchange_id] = {
+                "side": side,
+                "position_side": position_side,
+                "reduce_only": reduce_only,
+                "last_seen_ms": now_ms,
+            }
+        self._hl_open_order_semantics_by_exchange_id = cache
 
     async def fetch_open_orders(self, symbol: str = None):
         fetched = await self._do_fetch_open_orders(symbol=symbol)

--- a/tests/test_hyperliquid_balance_cache.py
+++ b/tests/test_hyperliquid_balance_cache.py
@@ -437,6 +437,83 @@ async def test_hyperliquid_ws_order_rejects_snapshot_client_id_contradiction(
 
 
 @pytest.mark.asyncio
+async def test_hyperliquid_ws_order_rejects_snapshot_exchange_id_contradiction(
+    stubbed_modules,
+):
+    HyperliquidBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    bot = HyperliquidBot.__new__(HyperliquidBot)
+    bot.open_orders = {
+        "BTC/USDC:USDC": [
+            {
+                "id": "123",
+                "side": "buy",
+                "position_side": "long",
+                "info": {"oid": 456, "side": "B", "reduceOnly": False},
+            }
+        ]
+    }
+    bot._hl_open_order_semantics_by_exchange_id = {
+        "123": {
+            "side": "buy",
+            "position_side": "long",
+            "reduce_only": False,
+            "client_id": "",
+            "last_seen_ms": 1,
+        }
+    }
+    bot.orders_emitted_to_exchange = [
+        {
+            "exchange_id": "123",
+            "side": "buy",
+            "position_side": "long",
+            "reduce_only": False,
+            "status": "acknowledged",
+        }
+    ]
+    sparse = {
+        "id": "123",
+        "side": "buy",
+        "info": {"oid": 123, "side": "B"},
+    }
+
+    snapshot_state, recovered = (
+        bot._hl_open_snapshot_ws_order_semantics_evidence(sparse)
+    )
+
+    assert snapshot_state == "invalid"
+    assert recovered is None
+    assert bot._hl_recover_ws_order_semantics(sparse) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("contradiction", ["client_id", "exchange_id"])
+async def test_hyperliquid_authoritative_snapshot_contradiction_invalidates_cache(
+    stubbed_modules,
+    contradiction,
+):
+    HyperliquidBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    bot = HyperliquidBot.__new__(HyperliquidBot)
+    valid = {
+        "id": "123",
+        "side": "buy",
+        "position_side": "long",
+        "clientOrderId": "entry_initial_normal_long_local",
+        "info": {"oid": 123, "side": "B", "reduceOnly": False},
+    }
+    bot._hl_note_authoritative_open_order_semantics([valid])
+    contradictory = dict(valid)
+    contradictory["info"] = dict(valid["info"])
+    if contradiction == "client_id":
+        contradictory["info"]["cloid"] = "entry_initial_normal_long_different"
+    else:
+        contradictory["info"]["oid"] = 456
+
+    bot._hl_note_authoritative_open_order_semantics([contradictory])
+
+    assert "123" not in bot._hl_open_order_semantics_by_exchange_id
+
+
+@pytest.mark.asyncio
 async def test_hyperliquid_ws_order_rejects_expired_open_snapshot_semantics(
     stubbed_modules,
     monkeypatch,

--- a/tests/test_hyperliquid_balance_cache.py
+++ b/tests/test_hyperliquid_balance_cache.py
@@ -21,12 +21,18 @@ def stubbed_modules(monkeypatch):
     pr_module.order_type_id_to_snake = lambda *args, **kwargs: "unknown"
     pr_module.calc_min_entry_qty_py = lambda *args, **kwargs: 0.0
     pr_module.calc_min_close_qty_py = lambda *args, **kwargs: 0.0
+    pr_module.get_strategy_kinds = lambda: ["trailing_martingale", "ema_anchor"]
+    pr_module.get_strategy_spec = lambda _kind: {
+        "parameters": [],
+        "fixed_parameters": [],
+    }
     pr_module.__getattr__ = lambda name: (lambda *args, **kwargs: 0)
     monkeypatch.setitem(sys.modules, "passivbot_rust", pr_module)
 
     # Stub ccxt modules
     errors_module = types.ModuleType("ccxt.base.errors")
     errors_module.NetworkError = Exception
+    errors_module.OrderNotFound = Exception
     errors_module.RateLimitExceeded = Exception
     monkeypatch.setitem(sys.modules, "ccxt.base.errors", errors_module)
 
@@ -226,6 +232,178 @@ async def test_hyperliquid_ws_order_recovers_semantics_from_exact_acknowledged_i
         "lacked authoritative order semantics" in rec.message
         for rec in caplog.records
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("side", "raw_side", "position_side", "reduce_only"),
+    [
+        ("buy", "B", "long", False),
+        ("sell", "A", "long", True),
+    ],
+)
+async def test_hyperliquid_ws_order_recovers_semantics_from_open_snapshot_after_restart(
+    stubbed_modules,
+    monkeypatch,
+    caplog,
+    side,
+    raw_side,
+    position_side,
+    reduce_only,
+):
+    hyperliquid_module = importlib.import_module("exchanges.hyperliquid")
+    HyperliquidBot = hyperliquid_module.HyperliquidBot
+    monkeypatch.setattr(hyperliquid_module.time, "monotonic", lambda: 100.0)
+    caplog.set_level(pylogging.WARNING)
+    bot = HyperliquidBot.__new__(HyperliquidBot)
+    bot.stop_websocket = False
+    bot._health_ws_reconnects = 0
+    bot._health_rate_limits = 0
+    bot._log_symbols = lambda symbols, limit=8: ",".join(symbols[:limit])
+    bot._hl_note_ws_symbols_for_dex_scope = lambda _orders: None
+    bot.orders_emitted_to_exchange = []
+    bot.open_orders = {
+        "BTC/USDC:USDC": [
+            {
+                "id": "123",
+                "symbol": "BTC/USDC:USDC",
+                "side": side,
+                "position_side": position_side,
+                "amount": 0.01,
+                "info": {"oid": 123, "side": raw_side, "reduceOnly": reduce_only},
+            }
+        ]
+    }
+    bot._hl_note_authoritative_open_order_semantics(
+        bot.open_orders["BTC/USDC:USDC"]
+    )
+    # Reconciliation may remove the order before its terminal WS row arrives.
+    bot.open_orders = {}
+    handled = []
+    dirty = []
+    bot.handle_order_update = lambda orders: handled.append(orders)
+    bot._mark_account_critical_state_dirty = lambda **kwargs: dirty.append(kwargs)
+
+    watch_calls = 0
+
+    async def watch_orders():
+        nonlocal watch_calls
+        watch_calls += 1
+        if watch_calls == 2:
+            bot.stop_websocket = True
+        return [
+            {
+                "id": "123",
+                "symbol": "BTC/USDC:USDC",
+                "side": side,
+                "amount": 0.01,
+                # Native WS omits reduceOnly; CCXT synthesizes False.
+                "reduceOnly": False,
+                "info": {"oid": 123, "side": raw_side, "sz": "0.01"},
+            }
+        ]
+
+    bot.ccp = types.SimpleNamespace(watch_orders=watch_orders)
+
+    await bot.watch_orders()
+
+    assert dirty == []
+    assert len(handled) == 2
+    for [order] in handled:
+        assert order["position_side"] == position_side
+        assert order["reduceOnly"] is reduce_only
+        assert order["_pb_order_semantics_source"] == "authoritative_open_order_snapshot"
+    assert not any(
+        "lacked authoritative order semantics" in rec.message
+        for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_hyperliquid_ws_order_rejects_ambiguous_open_snapshot_identity(
+    stubbed_modules,
+):
+    HyperliquidBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    bot = HyperliquidBot.__new__(HyperliquidBot)
+    bot.open_orders = {
+        "BTC/USDC:USDC": [
+            {
+                "id": "123",
+                "side": "buy",
+                "position_side": "long",
+                "info": {"reduceOnly": False},
+            },
+            {
+                "id": "123",
+                "side": "buy",
+                "position_side": "long",
+                "info": {"reduceOnly": False},
+            },
+        ]
+    }
+    sparse = {
+        "id": "123",
+        "side": "buy",
+        "info": {"oid": 123, "side": "B"},
+    }
+
+    assert bot._hl_open_snapshot_ws_order_semantics(sparse) is None
+
+
+@pytest.mark.asyncio
+async def test_hyperliquid_ws_order_rejects_open_snapshot_semantic_contradiction(
+    stubbed_modules,
+):
+    HyperliquidBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    bot = HyperliquidBot.__new__(HyperliquidBot)
+    bot.open_orders = {
+        "BTC/USDC:USDC": [
+            {
+                "id": "123",
+                "side": "buy",
+                "position_side": "long",
+                "info": {"reduceOnly": False},
+            }
+        ]
+    }
+    sparse = {
+        "id": "123",
+        "side": "buy",
+        "info": {"oid": 123, "side": "B", "reduceOnly": True},
+    }
+
+    assert bot._hl_open_snapshot_ws_order_semantics(sparse) is None
+
+
+@pytest.mark.asyncio
+async def test_hyperliquid_ws_order_rejects_expired_open_snapshot_semantics(
+    stubbed_modules,
+    monkeypatch,
+):
+    hyperliquid_module = importlib.import_module("exchanges.hyperliquid")
+    HyperliquidBot = hyperliquid_module.HyperliquidBot
+    now = {"ms": 1_000_000}
+    monkeypatch.setattr(hyperliquid_module, "utc_ms", lambda: now["ms"])
+    bot = HyperliquidBot.__new__(HyperliquidBot)
+    bot.open_orders = {}
+    bot._hl_note_authoritative_open_order_semantics(
+        [
+            {
+                "id": "123",
+                "side": "buy",
+                "position_side": "long",
+                "info": {"reduceOnly": False},
+            }
+        ]
+    )
+    now["ms"] += bot.ORDER_WS_OPEN_SNAPSHOT_SEMANTICS_TTL_MS + 1
+    sparse = {
+        "id": "123",
+        "side": "buy",
+        "info": {"oid": 123, "side": "B"},
+    }
+
+    assert bot._hl_open_snapshot_ws_order_semantics(sparse) is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_hyperliquid_balance_cache.py
+++ b/tests/test_hyperliquid_balance_cache.py
@@ -297,8 +297,8 @@ async def test_hyperliquid_ws_order_recovers_semantics_from_open_snapshot_after_
                 "symbol": "BTC/USDC:USDC",
                 "side": side,
                 "amount": 0.01,
-                # Native WS omits reduceOnly; CCXT synthesizes False.
-                "reduceOnly": False,
+                # Native WS omits reduceOnly; current CCXT synthesizes None.
+                "reduceOnly": None,
                 "info": {"oid": 123, "side": raw_side, "sz": "0.01"},
             }
         ]

--- a/tests/test_hyperliquid_balance_cache.py
+++ b/tests/test_hyperliquid_balance_cache.py
@@ -270,6 +270,7 @@ async def test_hyperliquid_ws_order_recovers_semantics_from_open_snapshot_after_
                 "side": side,
                 "position_side": position_side,
                 "amount": 0.01,
+                "clientOrderId": "entry_initial_normal_long_local",
                 "info": {"oid": 123, "side": raw_side, "reduceOnly": reduce_only},
             }
         ]
@@ -297,6 +298,7 @@ async def test_hyperliquid_ws_order_recovers_semantics_from_open_snapshot_after_
                 "symbol": "BTC/USDC:USDC",
                 "side": side,
                 "amount": 0.01,
+                "clientOrderId": "entry_initial_normal_long_local",
                 # Native WS omits reduceOnly; current CCXT synthesizes None.
                 "reduceOnly": None,
                 "info": {"oid": 123, "side": raw_side, "sz": "0.01"},
@@ -313,6 +315,11 @@ async def test_hyperliquid_ws_order_recovers_semantics_from_open_snapshot_after_
         assert order["position_side"] == position_side
         assert order["reduceOnly"] is reduce_only
         assert order["_pb_order_semantics_source"] == "authoritative_open_order_snapshot"
+        assert order["_pb_order_update_requires_authoritative_refresh"] is True
+    bot.order_matches_recent_execution = lambda _order: True
+    bot.order_matches_bot_cancellation = lambda _order: True
+    for batch in handled:
+        assert bot._ws_order_update_is_self_echo(batch) is False
     assert not any(
         "lacked authoritative order semantics" in rec.message
         for rec in caplog.records
@@ -346,8 +353,18 @@ async def test_hyperliquid_ws_order_rejects_ambiguous_open_snapshot_identity(
         "side": "buy",
         "info": {"oid": 123, "side": "B"},
     }
+    bot.orders_emitted_to_exchange = [
+        {
+            "exchange_id": "123",
+            "side": "buy",
+            "position_side": "long",
+            "reduce_only": False,
+            "status": "acknowledged",
+        }
+    ]
 
     assert bot._hl_open_snapshot_ws_order_semantics(sparse) is None
+    assert bot._hl_recover_ws_order_semantics(sparse) is None
 
 
 @pytest.mark.asyncio
@@ -371,8 +388,52 @@ async def test_hyperliquid_ws_order_rejects_open_snapshot_semantic_contradiction
         "side": "buy",
         "info": {"oid": 123, "side": "B", "reduceOnly": True},
     }
+    bot.orders_emitted_to_exchange = [
+        {
+            "exchange_id": "123",
+            "side": "buy",
+            "position_side": "long",
+            "reduce_only": False,
+            "status": "acknowledged",
+        }
+    ]
 
     assert bot._hl_open_snapshot_ws_order_semantics(sparse) is None
+    assert bot._hl_recover_ws_order_semantics(sparse) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_recent_cache", [False, True])
+async def test_hyperliquid_ws_order_rejects_snapshot_client_id_contradiction(
+    stubbed_modules,
+    use_recent_cache,
+):
+    HyperliquidBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    bot = HyperliquidBot.__new__(HyperliquidBot)
+    existing = {
+        "id": "123",
+        "side": "buy",
+        "position_side": "long",
+        "clientOrderId": "entry_initial_normal_long_local",
+        "info": {"oid": 123, "side": "B", "reduceOnly": False},
+    }
+    bot.open_orders = {"BTC/USDC:USDC": [existing]}
+    if use_recent_cache:
+        bot._hl_note_authoritative_open_order_semantics([existing])
+        bot.open_orders = {}
+    sparse = {
+        "id": "123",
+        "side": "buy",
+        "clientOrderId": "entry_initial_normal_long_different",
+        "info": {"oid": 123, "side": "B"},
+    }
+
+    snapshot_state, recovered = (
+        bot._hl_open_snapshot_ws_order_semantics_evidence(sparse)
+    )
+
+    assert snapshot_state == "invalid"
+    assert recovered is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- recover sparse Hyperliquid private-order websocket semantics from an exact exchange-order-ID match in the current authoritative REST open-order snapshot
- retain a bounded five-minute RAM-only semantics cache for terminal updates arriving just after reconciliation removes an order
- accept CCXT's unified `reduceOnly: false` or `null` placeholder only when the native payload omits the field, while retaining fail-closed contradiction checks

## Root cause

Hyperliquid private order updates omit one-way position-side and reduce-only metadata. Process-local create acknowledgements could recover newly created orders, but not orders already resting at restart, and current CCXT emits `reduceOnly: null` when the native row has no such field. Those rows were discarded and forced repeated authoritative account refreshes.

## Safety contract

Recovery requires one exact exchange order ID. Missing, duplicate, expired, or contradictory identities remain rejected. Native side, status, position-side, client-ID, and reduce-only contradictions still fail closed; price, quantity, and order shape never prove identity or ownership.

## Validation

- `python -m pytest -q tests/test_hyperliquid_balance_cache.py`
- `python -m pytest -q tests/exchanges/test_ccxt_bot_hooks.py`
- `python -m pytest -q tests/test_foreign_passivbot_detection.py`
- `python -m pytest -q tests/test_ai_docs.py`
- `python -m py_compile src/exchanges/hyperliquid.py`
- `python src/tools/check_ai_docs.py` (0 errors; existing documentation-size warnings only)
- authenticated read-only payload-shape probe confirmed the native omission and CCXT `null` placeholder
- live smoke test processed multiple cancel/open replacement waves with zero semantic-rejection warnings
