### PR TITLE
Reduce combined candle candidate frame lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Reduce peak memory during combined candle preparation by releasing exchange-candidate frames
+  after volume normalization and consuming selected frames as dense arrays are materialized.
 - Scope live candle/EMA readiness to the Rust actions that consume it instead of deferring the
   entire planner cycle when one active symbol lacks a completed candle. Known missing EMA inputs
   remain explicit and value-free; backtests and unannotated Rust inputs stay strict, stale resting

--- a/src/hlcv_preparation.py
+++ b/src/hlcv_preparation.py
@@ -4467,6 +4467,15 @@ async def _prepare_hlcvs_combined_impl(
 
     progress.log_done()
 
+    # The gather result duplicates references already retained in the chosen
+    # data/settings/candidate maps. Drop it before allocating dense frames.
+    results.clear()
+    tasks.clear()
+    result = None
+    # Let asyncio discard completed gather/task result references before the
+    # normalization and dense-alignment allocations that follow.
+    await asyncio.sleep(0)
+
     if not chosen_data_per_coin:
         raise ValueError("No coin data found on any exchange for the requested date range.")
 
@@ -4543,10 +4552,15 @@ async def _prepare_hlcvs_combined_impl(
                 ", ".join(sorted(coins_list)),
             )
 
+    # Candidate frames are needed through normalization only. Candidate report
+    # entries contain summaries, so unselected source frames can now be freed.
+    chosen_candidates_per_coin.clear()
+
     aligned_values_by_coin = {}
 
     for i, coin in enumerate(valid_coins):
-        df = chosen_data_per_coin[coin].copy()
+        # Consume each selected frame as its dense replacement is materialized.
+        df = chosen_data_per_coin.pop(coin)
         df = df.set_index("timestamp").reindex(timestamps)
         # Use OHLCV source for volume normalization, not market settings source
         exchange_for_this_coin = chosen_mss_per_coin[coin].get(

--- a/tests/test_combined_candidate_frame_lifetime.py
+++ b/tests/test_combined_candidate_frame_lifetime.py
@@ -1,0 +1,151 @@
+import asyncio
+import gc
+import weakref
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import hlcv_preparation as hp
+
+
+@pytest.mark.asyncio
+async def test_combined_candidate_frames_are_released_after_normalization(monkeypatch):
+    coins = ["BTC", "ETH"]
+    timestamps = np.array([1_704_067_200_000, 1_704_067_260_000], dtype=np.int64)
+    candidate_refs = {}
+    selected_exchanges = {"BTC": "binance", "ETH": "bybit"}
+    normalization_finished = False
+    alignment_lifetime_checked = False
+
+    class DummyManager:
+        async def load_markets(self):
+            return None
+
+    class QuietProgress:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def maybe_log(self, *_args, **_kwargs):
+            pass
+
+        def update(self, *_args, **_kwargs):
+            pass
+
+        def log_done(self, *_args, **_kwargs):
+            pass
+
+    async def fake_resolve_combined_coin(**kwargs):
+        coin = kwargs["coin"]
+        candidates = []
+        selected_df = None
+        for exchange, volume in (("binance", 10.0), ("bybit", 20.0)):
+            df = pd.DataFrame(
+                {
+                    "timestamp": timestamps,
+                    "high": [2.0, 2.0],
+                    "low": [0.5, 0.5],
+                    "close": [1.5, 1.5],
+                    "volume": [volume, volume],
+                    "valid": [True, True],
+                }
+            )
+            candidate_refs[(coin, exchange)] = weakref.ref(df)
+            candidates.append(
+                hp.CombinedExchangeCandidate(
+                    exchange=exchange,
+                    df=df,
+                    coverage_count=2,
+                    gap_count=0,
+                    total_volume=volume * 2,
+                )
+            )
+            if exchange == selected_exchanges[coin]:
+                selected_df = df
+
+        resolution_kwargs = {
+            "coin": coin,
+            "best_exchange": selected_exchanges[coin],
+            "best_df": selected_df,
+            "market_settings": {
+                "exchange": selected_exchanges[coin],
+                "ohlcv_source": selected_exchanges[coin],
+                "warmup_minutes": 0,
+            },
+            "candidates": tuple(candidates),
+        }
+        if "selection_reason" in hp.CombinedCoinResolution.__dataclass_fields__:
+            resolution_kwargs["selection_reason"] = "configured_exchange_priority"
+        return hp.CombinedCoinResolution(**resolution_kwargs)
+
+    def record_normalization_inputs(*_args, **_kwargs):
+        nonlocal normalization_finished
+        assert len(candidate_refs) == 4
+        assert all(ref() is not None for ref in candidate_refs.values())
+        normalization_finished = True
+        return {("binance", "bybit"): 1.0}
+
+    def record_normalization_inputs_with_diagnostics(*_args, **_kwargs):
+        ratios = record_normalization_inputs()
+        return ratios, {
+            "method": "test",
+            "window_start_ts": int(timestamps[0]),
+            "window_end_ts_exclusive": int(timestamps[-1] + 60_000),
+            "pair_estimates": {},
+        }
+
+    original_set_index = pd.DataFrame.set_index
+
+    def assert_lifetime_at_alignment(self, keys, *args, **kwargs):
+        nonlocal alignment_lifetime_checked
+        if normalization_finished and not alignment_lifetime_checked and keys == "timestamp":
+            gc.collect()
+            for coin in coins:
+                unselected = "bybit" if selected_exchanges[coin] == "binance" else "binance"
+                assert candidate_refs[(coin, unselected)]() is None
+                assert candidate_refs[(coin, selected_exchanges[coin])]() is not None
+            alignment_lifetime_checked = True
+        return original_set_index(self, keys, *args, **kwargs)
+
+    monkeypatch.setattr(hp, "effective_backtest_data_coins", lambda _config: coins)
+    monkeypatch.setattr(hp, "compute_per_coin_warmup_minutes", lambda _config: {"__default__": 0})
+    monkeypatch.setattr(
+        hp,
+        "get_first_timestamps_unified",
+        lambda _coins: asyncio.sleep(0, result={}),
+    )
+    monkeypatch.setattr(hp, "_normalize_combined_coins", lambda values, *_args: list(values))
+    monkeypatch.setattr(hp, "_resolve_combined_coin", fake_resolve_combined_coin)
+    monkeypatch.setattr(hp, "ProgressTracker", QuietProgress)
+    monkeypatch.setattr(
+        hp,
+        "compute_exchange_volume_ratios_from_candidates",
+        record_normalization_inputs,
+    )
+    if hasattr(hp, "compute_exchange_volume_ratios_with_diagnostics"):
+        monkeypatch.setattr(
+            hp,
+            "compute_exchange_volume_ratios_with_diagnostics",
+            record_normalization_inputs_with_diagnostics,
+        )
+    monkeypatch.setattr(pd.DataFrame, "set_index", assert_lifetime_at_alignment)
+
+    config = {"backtest": {}, "live": {"minimum_coin_age_days": 0.0}}
+    _mss, output_timestamps, aligned = await hp._prepare_hlcvs_combined_impl(
+        config,
+        {"binance": DummyManager(), "bybit": DummyManager()},
+        base_start_ts=int(timestamps[0]),
+        _requested_start_ts=int(timestamps[0]),
+        end_ts=int(timestamps[-1]),
+        forced_sources={},
+        force_refetch_gaps=False,
+        catalog=None,
+        store=None,
+        legacy_root=None,
+        use_v2_local=False,
+    )
+
+    assert alignment_lifetime_checked
+    np.testing.assert_array_equal(output_timestamps, timestamps)
+    np.testing.assert_allclose(aligned["BTC"][:, 3], [10.0, 10.0])
+    np.testing.assert_allclose(aligned["ETH"][:, 3], [20.0, 20.0])


### PR DESCRIPTION
## Summary

- release completed gather/task result references before normalization and dense alignment
- retain exchange-candidate DataFrames through volume normalization, then release unselected frames
- consume each selected DataFrame as its dense HLCV array is materialized
- add a lifecycle regression proving normalization still sees all candidates and unselected frames are collectable before alignment

## Benchmark

Bounded synthetic combined-preparation workload: 52 coins × 80,000 rows × 2 exchange candidates.

- before: 639.4 MiB peak RSS, 0.100 s
- after: 483.9 MiB peak RSS, 0.095 s
- change: 155.5 MiB / 24.3% lower peak RSS
- output SHA-256 unchanged: `4418a02a6dbcced4381688a6b4b175dee3536a40052376805a1de4a17a0bc0c1`

The elapsed-time difference is small and should be treated as noise; this PR's measured benefit is reduced retained memory during combined preparation.

## Validation

- focused lifecycle and market-settings/normalization tests
- broader HLCV preparation, v2 preparation, dataset metadata, manifest, valid-range, and suite-runner test slice
- `compileall`
- `git diff --check`
- rebuilt and fingerprint-verified the shared Rust extension before the broader Python test slice

## PR #1446 compatibility

Reviewed current PR #1446 head `fef4fd10b3`. Its robust normalization estimator and provenance construction still finish before this PR releases candidate frames. Applied this patch on top of that head and passed the lifecycle, market-settings separation, and HLCV preparation tests there.