### PR TITLE
Fix disapproved symbols entering live forager selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Prevent symbols retained for existing positions or open-order reconciliation from becoming live
+  forager candidates after removal from a side's approved set. Disapproved symbols now remain in
+  graceful-stop or manual mode according to `live.auto_gs` while their existing state is managed.
 - Reduce peak memory during combined candle preparation by releasing exchange-candidate frames
   after volume normalization and consuming selected frames as dense arrays are materialized.
 - Scope live candle/EMA readiness to the Rust actions that consume it instead of deferring the

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -16760,10 +16760,10 @@ class Passivbot:
                 if configured_mode:
                     expanded_mode = expand_PB_mode(configured_mode)
                     if expanded_mode != "normal":
-                        return self._apply_ignored_coin_mode(
+                        return self._apply_entry_eligibility_mode(
                             pside, symbol, expanded_mode
                         )
-                return self._apply_ignored_coin_mode(
+                return self._apply_entry_eligibility_mode(
                     pside, symbol, "graceful_stop"
                 )
 
@@ -16771,11 +16771,13 @@ class Passivbot:
             getattr(self, "_runtime_forced_modes", {}).get(pside, {}).get(symbol)
         )
         if runtime_forced:
-            return self._apply_ignored_coin_mode(pside, symbol, str(runtime_forced))
+            return self._apply_entry_eligibility_mode(
+                pside, symbol, str(runtime_forced)
+            )
 
         forced_mode = self.config_get(["live", f"forced_mode_{pside}"], symbol)
         if forced_mode:
-            return self._apply_ignored_coin_mode(
+            return self._apply_entry_eligibility_mode(
                 pside, symbol, expand_PB_mode(forced_mode)
             )
         if not self.markets_dict.get(symbol, {}).get("active", True):
@@ -16783,7 +16785,7 @@ class Passivbot:
         ineligible_reason = getattr(self, "ineligible_symbols", {}).get(symbol)
         if ineligible_reason is not None:
             return "tp_only" if ineligible_reason == "not active" else "manual"
-        return self._apply_ignored_coin_mode(pside, symbol)
+        return self._apply_entry_eligibility_mode(pside, symbol)
 
     def _build_orchestrator_mode_overrides(
         self, symbols: Iterable[str]
@@ -16812,20 +16814,21 @@ class Passivbot:
                 )
         return overrides
 
-    def _apply_ignored_coin_mode(
+    def _apply_entry_eligibility_mode(
         self, pside: str, symbol: str, mode: Optional[str] = None
     ) -> Optional[str]:
-        ignored = getattr(self, "ignored_coins", {}).get(pside, set())
-        if symbol not in ignored:
+        """Block initials for managed symbols outside the current entry universe."""
+        if self.is_approved(pside, symbol):
             return mode
         if str(mode or "").strip().lower() in {
             "manual",
             "panic",
+            "graceful_stop",
             "tp_only",
             "tp_only_with_active_entry_cancellation",
         }:
             return mode
-        return "graceful_stop"
+        return self.PB_mode_stop[pside]
 
     def _calc_unstuck_allowances_live(self) -> dict[str, float]:
         """Calculate unstuck allowances using FillEventsManager."""

--- a/tests/test_live_coin_lists.py
+++ b/tests/test_live_coin_lists.py
@@ -6,12 +6,12 @@ from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline, ReasonC
 from passivbot import Passivbot
 
 
-def _make_mode_override_bot():
-    ignored_symbol = "DOGE/USDT:USDT"
+def _make_mode_override_bot(auto_gs=True):
+    disapproved_symbol = "DOGE/USDT:USDT"
     approved_symbol = "BTC/USDT:USDT"
     bot = Passivbot.__new__(Passivbot)
     bot.positions = {
-        ignored_symbol: {
+        disapproved_symbol: {
             "long": {"size": 0.0, "price": 0.0},
             "short": {"size": 0.0, "price": 0.0},
         }
@@ -22,9 +22,9 @@ def _make_mode_override_bot():
         "long": {approved_symbol},
         "short": set(),
     }
-    bot.ignored_coins = {"long": {ignored_symbol}, "short": set()}
+    bot.ignored_coins = {"long": {disapproved_symbol}, "short": set()}
     bot.markets_dict = {
-        ignored_symbol: {"active": True},
+        disapproved_symbol: {"active": True},
         approved_symbol: {"active": True},
     }
     bot.ineligible_symbols = {}
@@ -32,44 +32,93 @@ def _make_mode_override_bot():
     bot._equity_hard_stop_enabled = lambda pside: False
     bot.config_get = lambda path, symbol=None: ""
     bot.is_old_enough = lambda pside, symbol: True
-    return bot, ignored_symbol, approved_symbol
+    bot.PB_mode_stop = {
+        "long": "graceful_stop" if auto_gs else "manual",
+        "short": "graceful_stop" if auto_gs else "manual",
+    }
+    return bot, disapproved_symbol, approved_symbol
 
 
-def test_ignored_coin_retained_flat_position_gets_graceful_stop_override():
-    bot, ignored_symbol, approved_symbol = _make_mode_override_bot()
+def test_disapproved_coin_retained_flat_position_gets_graceful_stop_override():
+    bot, disapproved_symbol, approved_symbol = _make_mode_override_bot()
 
     universe = bot._build_live_symbol_universe()
-    assert ignored_symbol in universe
-    assert ignored_symbol not in bot.approved_coins_minus_ignored_coins["long"]
+    assert disapproved_symbol in universe
+    assert disapproved_symbol not in bot.approved_coins_minus_ignored_coins["long"]
 
     overrides = bot._build_orchestrator_mode_overrides(universe)
 
-    assert overrides["long"][ignored_symbol] == "graceful_stop"
-    assert overrides["short"][ignored_symbol] is None
+    assert overrides["long"][disapproved_symbol] == "graceful_stop"
+    assert overrides["short"][disapproved_symbol] == "graceful_stop"
     assert overrides["long"][approved_symbol] is None
+    assert overrides["short"][approved_symbol] == "graceful_stop"
 
 
-@pytest.mark.parametrize("forced_mode", ["manual", "panic", "tp_only"])
-def test_ignored_coin_preserves_stricter_forced_modes(forced_mode):
-    bot, ignored_symbol, _approved_symbol = _make_mode_override_bot()
+@pytest.mark.parametrize(
+    "forced_mode", ["manual", "panic", "graceful_stop", "tp_only"]
+)
+def test_ignored_coin_preserves_entry_blocking_forced_modes(forced_mode):
+    bot, disapproved_symbol, _approved_symbol = _make_mode_override_bot()
     bot.config_get = (
         lambda path, symbol=None: forced_mode
-        if path == ["live", "forced_mode_long"] and symbol == ignored_symbol
+        if path == ["live", "forced_mode_long"] and symbol == disapproved_symbol
         else ""
     )
 
-    assert bot._orchestrator_mode_override("long", ignored_symbol) == forced_mode
+    assert bot._orchestrator_mode_override("long", disapproved_symbol) == forced_mode
 
 
 def test_ignored_coin_overrides_forced_normal_to_graceful_stop():
-    bot, ignored_symbol, _approved_symbol = _make_mode_override_bot()
+    bot, disapproved_symbol, _approved_symbol = _make_mode_override_bot()
     bot.config_get = (
         lambda path, symbol=None: "normal"
-        if path == ["live", "forced_mode_long"] and symbol == ignored_symbol
+        if path == ["live", "forced_mode_long"] and symbol == disapproved_symbol
         else ""
     )
 
-    assert bot._orchestrator_mode_override("long", ignored_symbol) == "graceful_stop"
+    assert (
+        bot._orchestrator_mode_override("long", disapproved_symbol)
+        == "graceful_stop"
+    )
+
+
+def test_disapproved_coin_uses_manual_mode_when_auto_gs_is_disabled():
+    bot, disapproved_symbol, _approved_symbol = _make_mode_override_bot(auto_gs=False)
+
+    assert bot._orchestrator_mode_override("long", disapproved_symbol) == "manual"
+
+
+def test_retained_order_and_position_do_not_expand_forager_eligibility():
+    bot, _disapproved_symbol, approved_symbol = _make_mode_override_bot()
+    retained_order_symbol = "ETH/USDT:USDT"
+    held_symbol = "UNI/USDT:USDT"
+    bot.positions = {
+        held_symbol: {
+            "long": {"size": 1.0, "price": 1.0},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+    }
+    bot.open_orders = {retained_order_symbol: [{"symbol": retained_order_symbol}]}
+    bot.approved_coins_minus_ignored_coins = {
+        "long": {approved_symbol},
+        "short": {approved_symbol},
+    }
+    bot.ignored_coins = {"long": set(), "short": set()}
+    bot.markets_dict.update(
+        {
+            retained_order_symbol: {"active": True},
+            held_symbol: {"active": True},
+        }
+    )
+
+    universe = bot._build_live_symbol_universe()
+    overrides = bot._build_orchestrator_mode_overrides(universe)
+
+    assert universe == [approved_symbol, retained_order_symbol, held_symbol]
+    for pside in ("long", "short"):
+        assert overrides[pside][approved_symbol] is None
+        assert overrides[pside][retained_order_symbol] == "graceful_stop"
+        assert overrides[pside][held_symbol] == "graceful_stop"
 
 
 def test_add_to_coins_lists_skips_symbols_not_in_eligible_markets(caplog):

--- a/tests/test_order_orchestration.py
+++ b/tests/test_order_orchestration.py
@@ -204,7 +204,7 @@ def test_coin_hsl_pending_replay_mode_override_is_pair_scoped():
         "MANUAL/USDT:USDT": {"active": True},
     }
     bot.ineligible_symbols = {}
-    bot._apply_ignored_coin_mode = lambda pside, symbol, mode=None: mode
+    bot._apply_entry_eligibility_mode = lambda pside, symbol, mode=None: mode
 
     assert (
         bot._orchestrator_mode_override("long", "BTC/USDT:USDT")

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -626,6 +626,11 @@ def _make_dummy_bot(config, *, last_price=100.0):
             self.ineligible_symbols = {}
             self.approved_coins_minus_ignored_coins = {"long": [], "short": []}
             self.PB_modes = {"long": {}, "short": {}}
+            auto_gs = bool(cfg["live"]["auto_gs"])
+            self.PB_mode_stop = {
+                "long": "graceful_stop" if auto_gs else "manual",
+                "short": "graceful_stop" if auto_gs else "manual",
+            }
             self._runtime_forced_modes = {"long": {}, "short": {}}
             self.inactive_coin_candle_ttl_ms = 60_000
             self.trailing_prices = {}


### PR DESCRIPTION
## Summary

- apply the canonical side-specific entry-eligibility predicate when assigning Rust orchestrator modes
- keep disapproved symbols in the live management universe for position and open-order handling, while assigning `graceful_stop` or `manual` according to `live.auto_gs`
- preserve explicit entry-blocking safety modes and prevent forced `normal` from bypassing disapproval
- add regression coverage for side-scoped approvals, retained open orders, held positions, ignored symbols, and `auto_gs=false`

## Root cause

The live management universe intentionally includes symbols with positions and open orders even when they are no longer approved. Its mode guard checked only explicit ignored-coin membership, so a retained symbol merely absent from the approved set received `mode=None`. Rust correctly interprets `None` as the forager-eligible default, allowing the retained symbol to occupy an initial-entry slot.

The fix reuses `is_approved()`, the same predicate used when admitting ordinary candidates to the universe. A retained symbol that fails that predicate remains visible for reconciliation and protective management but receives the configured stop mode instead of the forager default.

## Validation

- `PYTHONPATH=src .../venv/bin/python -m pytest -q tests/test_live_coin_lists.py tests/test_order_orchestration.py tests/test_unstucking_safeguards.py tests/test_run_fake_live.py`
- `PYTHONPATH=src .../venv/bin/python -m compileall -q src/passivbot.py tests/test_live_coin_lists.py tests/test_order_orchestration.py tests/test_unstucking_safeguards.py`
- `cargo test --no-default-features graceful_stop_blocks_only_initial_entries`
- `git diff --check`
