### PR TITLE
Restore Bitget UTA candle history and scope missing EMA inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,9 @@ All notable user-facing changes will be documented in this file.
   remain explicit and value-free; backtests and unannotated Rust inputs stay strict, stale resting
   strategy orders are cancelled through normal Rust-authoritative reconciliation, entry and close
   strategy branches remain independent when their input needs differ, and independent panic,
-  WEL, and TWEL reducers may continue when their own inputs are complete.
+  WEL, and TWEL reducers may continue when their own inputs are complete. A `NaN` returned by the
+  completed-candle EMA API now follows that unavailable-input path instead of restarting the whole
+  execution cycle; positive or negative infinity remains fatal.
 
 - Harden combined-exchange HLCV preparation across independently downloaded datasets: equivalent
   full-range sources now follow configured exchange priority instead of total volume, robust

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Route Bitget public OHLCV requests through the complete classic futures history endpoint even
+  when the authenticated account uses UTA/Elite v3, preventing older available candles from being
+  omitted from live EMA windows while retaining UTA routing for private account and order calls.
 - Recognize repeated exclusive switching between complete order cohorts as live
   order-churn evidence. Alternating long/short or order-type intent can now use
   the existing account-wide far-order allowance without merging position-side

--- a/docs/ai/error_contract.md
+++ b/docs/ai/error_contract.md
@@ -61,7 +61,9 @@ Missing ordinary strategy input produces no ideal orders for the entry or close 
 consumes it, so normal Rust-authoritative reconciliation removes any now-stale resting orders from
 that branch. The other strategy branch, independent Rust risk reducers, and panic actions continue
 when their own inputs are complete. Malformed or non-finite producer output is never covered by
-this degradation and remains fatal.
+this degradation and remains fatal. Here, producer output means the Rust ideal-order/result
+envelope. A documented live input-reader availability sentinel is classified before that boundary,
+must never reach Rust, and retains only its explicitly bounded recovery and scoped-defer policies.
 
 For candle-dependent actions, gate on canonical strategy-input readiness rather than raw REST
 candle arrival. A proven no-trade gap may use explicitly synthesized zero-volume continuity when

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -293,10 +293,12 @@
     gate the whole planner cycle. Canonical EMA consumers determine symbol/order-class readiness;
     unavailable values remain absent, never neutralized. Account surfaces and fresh market
     snapshots retain their separate execution barriers.
-16. A `NaN` returned by a completed-candle EMA API represents an empty or incomplete EMA window and
-    is translated by the live consumer into explicit symbol- or action-scoped unavailability. It is
-    never passed to Rust or replaced with a numeric value. Positive or negative infinity is not an
-    availability sentinel and remains a fatal invalid calculation result.
+16. A `NaN` returned by a completed-candle EMA API represents an empty or incomplete EMA window.
+    The live consumer may recover it only through the explicitly bounded open-tail projection or
+    carry-forward policies above; without such a recovery, it becomes symbol- or action-scoped
+    unavailability. It is never passed to Rust or replaced by an unbounded or fabricated value.
+    Positive or negative infinity is not an availability sentinel and remains a fatal invalid
+    calculation result before any fallback.
 
 Cache paths use `to_standard_exchange_name()` rather than raw CCXT identifiers such as
 `binanceusdm` or `kucoinfutures`.

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -293,6 +293,10 @@
     gate the whole planner cycle. Canonical EMA consumers determine symbol/order-class readiness;
     unavailable values remain absent, never neutralized. Account surfaces and fresh market
     snapshots retain their separate execution barriers.
+16. A `NaN` returned by a completed-candle EMA API represents an empty or incomplete EMA window and
+    is translated by the live consumer into explicit symbol- or action-scoped unavailability. It is
+    never passed to Rust or replaced with a numeric value. Positive or negative infinity is not an
+    availability sentinel and remains a fatal invalid calculation result.
 
 Cache paths use `to_standard_exchange_name()` rather than raw CCXT identifiers such as
 `binanceusdm` or `kucoinfutures`.

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -268,6 +268,14 @@ Handling in Passivbot:
    does not report that tuple, require an authoritative native `reduceOnly` value.
 4. Keep classic Bitget v2/mix `tradeSide`/`reduceOnly` handling separate.
 
+### UTA public candle history routing
+
+Bitget account-mode detection enables UTA routing for authenticated account and order calls. Public
+OHLCV history is account-independent and must explicitly use classic futures market-data routing;
+the UTA candle endpoint may expose a shorter history and return an empty prefix which is available
+from the public v2 futures history endpoint. Pass `uta=false` only on Bitget OHLCV requests. Do not
+disable UTA on the shared CCXT session or on private account/order requests.
+
 ### `since` is effectively exclusive for OHLCV paging
 
 Problem: naive paging can miss first candle in each page.

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -4994,6 +4994,14 @@ class CandlestickManager:
             try:
                 params: Dict[str, Any] = {}
                 request_limit = int(limit)
+                # Bitget account-mode detection enables UTA routing on the shared
+                # authenticated CCXT client. Public candle history is account-
+                # independent, and the UTA candle endpoint may expose a shorter
+                # history than the classic futures history endpoint. Override only
+                # this public request so live UTA accounts retain private v3 routing
+                # without losing older strategy candles.
+                if "bitget" in exid:
+                    params["uta"] = False
                 # Provide an end bound for exchanges that support it.
                 # Note: Avoid passing 'until' to Bitget due to API validation errors on non-1m tfs.
                 if is_weex and end_exclusive_ms is not None:

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -18301,6 +18301,11 @@ class Passivbot:
                         ema_type, symbol, span, "exception", ema_error_type(e)
                     )
                     continue
+                if math.isinf(val):
+                    raise RuntimeError(
+                        f"[ema] non-finite {ema_type} value {val} "
+                        f"for {symbol} span={span:.8g}"
+                    )
                 if math.isfinite(val):
                     out[span] = val
                 else:

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -18381,6 +18381,11 @@ class Passivbot:
                     if math.isfinite(val):
                         out[span] = val
                         continue
+                    if math.isinf(val):
+                        raise RuntimeError(
+                            f"[ema] non-finite {ema_type} value {val} "
+                            f"for {symbol} span={span:.8g}"
+                        )
                     reason = f"non-finite {ema_type} value {val}"
                 if metric_key is not None:
                     fallback = cached_fallbacks.get(span)
@@ -18433,10 +18438,6 @@ class Passivbot:
                 self.ema_type = ema_type
                 self.missing = list(missing)
                 self.detail = detail
-                self.contains_non_finite = any(
-                    "non-finite" in str(reason).lower()
-                    for _span, reason in self.missing
-                )
 
         class MissingCloseEma(RuntimeError):
             def __init__(
@@ -18452,10 +18453,6 @@ class Passivbot:
                 self.symbol = symbol
                 self.missing = list(missing)
                 self.detail = detail
-                self.contains_non_finite = any(
-                    "non-finite" in str(reason).lower()
-                    for _span, reason in self.missing
-                )
 
         def close_ema_reason_detail(reason: str) -> tuple[str, str]:
             if str(reason).startswith("non-finite close EMA value"):
@@ -18563,6 +18560,11 @@ class Passivbot:
                             )
                         self._orchestrator_close_ema_fallback_counts[key] = 0
                     else:
+                        if math.isinf(val):
+                            raise RuntimeError(
+                                f"[ema] non-finite close EMA value {val} "
+                                f"for {symbol} span={span:.8g}"
+                            )
                         reason = f"non-finite close EMA value {val}"
                 if reason is None:
                     continue
@@ -18849,56 +18851,61 @@ class Passivbot:
                     ),
                     "m1_log_range",
                 )
-            nonfinite_close = [
+            infinite_close = [
                 span
                 for span in sorted(need_close_spans[sym])
-                if span in close and not math.isfinite(float(close[span]))
+                if span in close and math.isinf(float(close[span]))
             ]
-            if nonfinite_close:
+            if infinite_close:
                 raise RuntimeError(
                     "[ema] non-finite projected open-tail close EMA for "
-                    f"{sym}: spans={','.join(f'{span:.8g}' for span in nonfinite_close)}"
+                    f"{sym}: spans={','.join(f'{span:.8g}' for span in infinite_close)}"
                 )
-            missing_close = [
-                span for span in sorted(need_close_spans[sym]) if span not in close
-            ]
-            if missing_close:
-                missing = [
-                    (float(span), "projected close EMA missing")
-                    for span in missing_close
-                ]
+            missing = []
+            for span in sorted(need_close_spans[sym]):
+                if span not in close:
+                    missing.append((float(span), "projected close EMA missing"))
+                elif math.isnan(float(close[span])):
+                    missing.append(
+                        (
+                            float(span),
+                            "non-finite projected open-tail close EMA value nan",
+                        )
+                    )
+            if missing:
                 detail = "; ".join(
                     [f"span={span:.8g} reason={reason}" for span, reason in missing]
                 )
                 raise MissingCloseEma(sym, missing, detail)
             if not is_forager_mode() or project_strategy_log_range:
                 projected_lr1m = projected.get("log_range", {}) or {}
-                nonfinite_required_lr1m = [
+                infinite_required_lr1m = [
                     span
                     for span in required_m1_lr_for_symbol
                     if span in projected_lr1m
-                    and not math.isfinite(float(projected_lr1m[span]))
+                    and math.isinf(float(projected_lr1m[span]))
                 ]
-                if nonfinite_required_lr1m:
+                if infinite_required_lr1m:
                     raise RuntimeError(
                         "[ema] non-finite projected open-tail m1 log-range EMA for "
-                        f"{sym}: spans={','.join(f'{span:.8g}' for span in nonfinite_required_lr1m)}"
+                        f"{sym}: spans={','.join(f'{span:.8g}' for span in infinite_required_lr1m)}"
                     )
-                missing_required_lr1m = [
-                    span
-                    for span in required_m1_lr_for_symbol
-                    if span not in projected_lr1m
-                ]
-                if missing_required_lr1m:
-                    missing = [
-                        (float(span), "projected m1 log-range EMA missing")
-                        for span in missing_required_lr1m
-                    ]
+                missing = []
+                for span in required_m1_lr_for_symbol:
+                    if span not in projected_lr1m:
+                        missing.append(
+                            (float(span), "projected m1 log-range EMA missing")
+                        )
+                    elif math.isnan(float(projected_lr1m[span])):
+                        missing.append(
+                            (
+                                float(span),
+                                "non-finite projected open-tail m1_log_range value nan",
+                            )
+                        )
+                if missing:
                     detail = "; ".join(
-                        [
-                            f"span={span:.8g} reason={reason}"
-                            for span, reason in missing
-                        ]
+                        [f"span={span:.8g} reason={reason}" for span, reason in missing]
                     )
                     raise MissingRequiredEma(
                         sym, "m1_log_range", missing, detail
@@ -18957,8 +18964,6 @@ class Passivbot:
             def collect_input_unavailability(exc: Exception) -> bool:
                 if not isinstance(exc, (MissingCloseEma, MissingRequiredEma)):
                     return False
-                if exc.contains_non_finite:
-                    return False
                 input_unavailability.append(exc)
                 return True
 
@@ -18981,8 +18986,6 @@ class Passivbot:
                             sym, sorted(need_close_spans[sym]), log_on_missing=False
                         )
                     except MissingCloseEma as exc:
-                        if exc.contains_non_finite:
-                            raise
                         late_projection_ctx = projection_contexts.get(
                             sym
                         ) or refresh_open_tail_projection_context(sym)
@@ -19032,8 +19035,6 @@ class Passivbot:
                         )
                     except Exception as exc:
                         if not isinstance(exc, MissingRequiredEma):
-                            raise
-                        if exc.contains_non_finite:
                             raise
                         late_projection_ctx = refresh_open_tail_projection_context(sym)
                         if late_projection_ctx is None:
@@ -19106,8 +19107,6 @@ class Passivbot:
             except Exception as exc:
                 if not required_ema_can_mark_nontradable(sym):
                     if isinstance(exc, (MissingCloseEma, MissingRequiredEma)):
-                        if exc.contains_non_finite:
-                            raise
                         self._orchestrator_allow_missing_strategy_inputs_symbols.add(
                             sym
                         )

--- a/tests/test_ccxt_retry_policy.py
+++ b/tests/test_ccxt_retry_policy.py
@@ -193,6 +193,30 @@ async def test_gateio_fetch_ohlcv_omits_until_param(tmp_path):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("timeframe", ["1m", "1h"])
+async def test_bitget_public_ohlcv_bypasses_account_uta_routing(tmp_path, timeframe):
+    ex = CapturingExchange(exid="bitget")
+    ex.options = {"uta": True}
+    cm = CandlestickManager(
+        exchange=ex,
+        exchange_name="bitget",
+        cache_dir=str(tmp_path / "caches"),
+    )
+
+    rows = await cm._ccxt_fetch_ohlcv_once(
+        "XMR/USDT:USDT",
+        since_ms=1779332400000,
+        limit=200,
+        end_exclusive_ms=1780052400000,
+        timeframe=timeframe,
+    )
+
+    assert rows and len(rows) == 1
+    assert ex.options["uta"] is True
+    assert ex.params_seen == {"uta": False}
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(("timeframe", "row_count"), [("1m", 1400), ("1h", 1100)])
 async def test_weex_pagination_uses_bounded_history_then_recent_tail(
     tmp_path, timeframe, row_count

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -493,6 +493,8 @@ class _BundleReproBot:
                     raise TimeoutError("log range timeout")
                 if self.outer.lr1m_mode == "nan":
                     return float("nan")
+                if self.outer.lr1m_mode == "inf":
+                    return float("inf")
                 return 0.0015
 
             def get_completed_candle_health(self, symbol, windows=None, now_ms=None):
@@ -665,7 +667,8 @@ class _BundleReproBot:
 
 
 @pytest.mark.asyncio
-async def test_held_symbol_missing_ema_is_explicitly_scoped_for_rust():
+@pytest.mark.parametrize("close_mode", ["timeout", "nan"])
+async def test_held_symbol_missing_ema_is_explicitly_scoped_for_rust(close_mode):
     try:
         import passivbot as pb_mod
         import passivbot_rust as pbr
@@ -676,7 +679,7 @@ async def test_held_symbol_missing_ema_is_explicitly_scoped_for_rust():
         pytest.skip("requires real passivbot_rust extension")
 
     symbol = "AVAX/USDT:USDT"
-    bot = _BundleReproBot(symbol, close_mode="timeout")
+    bot = _BundleReproBot(symbol, close_mode=close_mode)
     (
         m1_close_emas,
         m1_volume_emas,
@@ -707,15 +710,55 @@ async def test_held_symbol_missing_ema_is_explicitly_scoped_for_rust():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("close_mode", ["nan", "inf"])
-async def test_held_symbol_nonfinite_close_ema_remains_fatal(close_mode):
+async def test_nan_close_ema_scopes_only_the_affected_symbol():
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    unavailable_symbol = "AVAX/USDT:USDT"
+    ready_symbol = "SOL/USDT:USDT"
+    symbols = [unavailable_symbol, ready_symbol]
+    bot = _BundleReproBot(unavailable_symbol, close_mode="value")
+    bot.PB_modes = {
+        "long": {symbol: "normal" for symbol in symbols},
+        "short": {symbol: "manual" for symbol in symbols},
+    }
+    bot.positions = {
+        symbol: {
+            "long": {"size": 0.0, "price": 0.0},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+        for symbol in symbols
+    }
+
+    async def symbol_close(symbol, span, **_kwargs):
+        del span
+        return float("nan") if symbol == unavailable_symbol else 123.0
+
+    bot.cm.get_latest_ema_close = symbol_close
+
+    result = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+        bot, symbols, bot.PB_modes
+    )
+
+    assert result[0][unavailable_symbol] == {}
+    assert result[0][ready_symbol]
+    assert set(result[0][ready_symbol].values()) == {123.0}
+    assert bot._orchestrator_allow_missing_strategy_inputs_symbols == {
+        unavailable_symbol
+    }
+
+
+@pytest.mark.asyncio
+async def test_held_symbol_infinite_close_ema_remains_fatal():
     try:
         import passivbot as pb_mod
     except ImportError:
         pytest.skip("passivbot module not importable in test environment")
 
     symbol = "AVAX/USDT:USDT"
-    bot = _BundleReproBot(symbol, close_mode=close_mode)
+    bot = _BundleReproBot(symbol, close_mode="inf")
 
     with pytest.raises(RuntimeError, match="non-finite close EMA value"):
         await pb_mod.Passivbot._load_orchestrator_ema_bundle(
@@ -2043,7 +2086,7 @@ async def test_open_tail_projection_precedes_previous_close_ema_fallback():
 
 
 @pytest.mark.asyncio
-async def test_late_open_tail_projection_does_not_mask_nonfinite_close_ema():
+async def test_late_open_tail_projection_recovers_nan_close_ema():
     try:
         import passivbot as pb_mod
     except ImportError:
@@ -2062,18 +2105,18 @@ async def test_late_open_tail_projection_does_not_mask_nonfinite_close_ema():
     )
     bot.projected_open_tail_called = False
 
-    with pytest.raises(RuntimeError, match="non-finite close EMA value"):
-        await pb_mod.Passivbot._load_orchestrator_ema_bundle(
-            bot, [symbol], bot.PB_modes
-        )
+    result = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+        bot, [symbol], bot.PB_modes
+    )
 
     assert bot.completed_candle_health_calls >= 2
-    assert bot.projected_open_tail_called is False
+    assert bot.projected_open_tail_called is True
+    assert result[0][symbol] == pytest.approx(projected)
     assert bot._orchestrator_close_ema_fallback_counts == {}
 
 
 @pytest.mark.asyncio
-async def test_nonfinite_close_ema_is_fatal_before_projection_or_previous_fallback():
+async def test_infinite_close_ema_is_fatal_before_projection_or_previous_fallback():
     try:
         import passivbot as pb_mod
     except ImportError:
@@ -2084,13 +2127,10 @@ async def test_nonfinite_close_ema_is_fatal_before_projection_or_previous_fallba
     span1 = 20.0
     span2 = (span0 * span1) ** 0.5
     prev = {span0: 100.04, span1: 100.03, span2: 100.02}
-    projected = {span0: 201.0, span1: 202.0, span2: 203.0}
     bot = _BundleReproBot(
         symbol,
-        close_mode="nan",
+        close_mode="inf",
         prev_close_ema=prev,
-        project_open_tail_after_health_calls=1,
-        projected_close_ema=projected,
     )
     bot.projected_open_tail_called = False
 
@@ -2099,13 +2139,12 @@ async def test_nonfinite_close_ema_is_fatal_before_projection_or_previous_fallba
             bot, [symbol], bot.PB_modes
         )
 
-    assert bot.completed_candle_health_calls >= 2
     assert bot.projected_open_tail_called is False
     assert bot._orchestrator_close_ema_fallback_counts == {}
 
 
 @pytest.mark.asyncio
-async def test_late_open_tail_projection_does_not_mask_nonfinite_m1_log_range():
+async def test_late_open_tail_projection_recovers_nan_m1_log_range():
     try:
         import passivbot as pb_mod
     except ImportError:
@@ -2126,13 +2165,35 @@ async def test_late_open_tail_projection_does_not_mask_nonfinite_m1_log_range():
     )
     bot.projected_open_tail_called = False
 
+    result = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+        bot, [symbol], bot.PB_modes
+    )
+
+    assert bot.completed_candle_health_calls >= 2
+    assert bot.projected_open_tail_called is True
+    assert result[0][symbol][span0] == pytest.approx(201.0)
+    assert result[2][symbol][60.0] == pytest.approx(0.0042)
+
+
+@pytest.mark.asyncio
+async def test_required_m1_log_range_infinite_output_remains_fatal():
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    symbol = "WLD/USDT:USDT"
+    bot = _BundleReproBot(
+        symbol,
+        close_mode="value",
+        lr1m_mode="inf",
+        entry_m1_weight=1.0,
+    )
+
     with pytest.raises(RuntimeError, match="non-finite m1_log_range value"):
         await pb_mod.Passivbot._load_orchestrator_ema_bundle(
             bot, [symbol], bot.PB_modes
         )
-
-    assert bot.completed_candle_health_calls == 1
-    assert bot.projected_open_tail_called is False
 
 
 @pytest.mark.asyncio
@@ -2221,7 +2282,7 @@ async def test_open_tail_projection_missing_close_span_scopes_only_its_consumers
 
 
 @pytest.mark.asyncio
-async def test_open_tail_projection_nonfinite_close_remains_fatal():
+async def test_open_tail_projection_nan_close_is_scoped_unavailable():
     try:
         import passivbot as pb_mod
     except ImportError:
@@ -2238,7 +2299,61 @@ async def test_open_tail_projection_nonfinite_close_remains_fatal():
         projected_close_ema={span0: float("nan"), span1: 202.0, span2: 203.0},
     )
 
+    result = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+        bot, [symbol], bot.PB_modes
+    )
+
+    assert result[0][symbol] == {}
+    assert bot._orchestrator_allow_missing_strategy_inputs_symbols == {symbol}
+
+
+@pytest.mark.asyncio
+async def test_open_tail_projection_infinite_close_remains_fatal():
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    symbol = "AVAX/USDT:USDT"
+    span0 = 10.0
+    span1 = 20.0
+    span2 = (span0 * span1) ** 0.5
+    bot = _BundleReproBot(
+        symbol,
+        close_mode="timeout",
+        project_open_tail=True,
+        projected_close_ema={span0: float("inf"), span1: 202.0, span2: 203.0},
+    )
+
     with pytest.raises(RuntimeError, match="non-finite projected open-tail close EMA"):
+        await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+            bot, [symbol], bot.PB_modes
+        )
+
+
+@pytest.mark.asyncio
+async def test_open_tail_projection_infinite_m1_log_range_remains_fatal():
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    symbol = "AVAX/USDT:USDT"
+    span0 = 10.0
+    span1 = 20.0
+    span2 = (span0 * span1) ** 0.5
+    bot = _BundleReproBot(
+        symbol,
+        close_mode="timeout",
+        entry_m1_weight=1.0,
+        project_open_tail=True,
+        projected_close_ema={span0: 201.0, span1: 202.0, span2: 203.0},
+        projected_log_range_ema={10.0: 0.0015, 60.0: float("inf")},
+    )
+
+    with pytest.raises(
+        RuntimeError, match="non-finite projected open-tail m1 log-range EMA"
+    ):
         await pb_mod.Passivbot._load_orchestrator_ema_bundle(
             bot, [symbol], bot.PB_modes
         )
@@ -2466,7 +2581,8 @@ async def test_batched_ema_failure_retries_each_span_before_carry_forward(monkey
 
 
 @pytest.mark.asyncio
-async def test_required_h1_log_range_ema_is_scoped_when_missing():
+@pytest.mark.parametrize("h1_mode", ["timeout", "nan"])
+async def test_required_h1_log_range_ema_is_scoped_when_missing(h1_mode):
     try:
         import passivbot as pb_mod
     except ImportError:
@@ -2476,7 +2592,7 @@ async def test_required_h1_log_range_ema_is_scoped_when_missing():
     bot = _BundleReproBot(
         symbol,
         close_mode="value",
-        h1_mode="timeout",
+        h1_mode=h1_mode,
         entry_h1_span_hours=4.0,
         entry_m1_weight=1.0,
     )
@@ -2492,8 +2608,7 @@ async def test_required_h1_log_range_ema_is_scoped_when_missing():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("h1_mode", ["nan", "inf"])
-async def test_required_h1_log_range_nonfinite_output_remains_fatal(h1_mode):
+async def test_required_h1_log_range_infinite_output_remains_fatal():
     try:
         import passivbot as pb_mod
     except ImportError:
@@ -2503,7 +2618,7 @@ async def test_required_h1_log_range_nonfinite_output_remains_fatal(h1_mode):
     bot = _BundleReproBot(
         symbol,
         close_mode="value",
-        h1_mode=h1_mode,
+        h1_mode="inf",
         entry_h1_span_hours=4.0,
     )
 

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -467,6 +467,8 @@ class _BundleReproBot:
                     raise TimeoutError("quote volume timeout")
                 if self.outer.qv_mode == "nan":
                     return float("nan")
+                if self.outer.qv_mode == "inf":
+                    return float("inf")
                 return 250000.0
 
             async def get_latest_ema_log_range(
@@ -1339,7 +1341,10 @@ def test_trailing_grid_v7_py_orchestrator_rejects_incomplete_strategy_params():
 
 
 @pytest.mark.asyncio
-async def test_kucoin_avax_close_ema_fallback_uses_previous_ema_not_price(caplog):
+@pytest.mark.parametrize("close_mode", ["timeout", "nan"])
+async def test_kucoin_avax_close_ema_fallback_uses_previous_ema_not_price(
+    caplog, close_mode
+):
     try:
         import passivbot as pb_mod
     except ImportError:
@@ -1350,7 +1355,12 @@ async def test_kucoin_avax_close_ema_fallback_uses_previous_ema_not_price(caplog
     span1 = 20.0
     span2 = (span0 * span1) ** 0.5
     prev = {span0: 100.04, span1: 100.03, span2: 100.02}
-    bot = _BundleReproBot(symbol, close_mode="timeout", close_value=110.37, prev_close_ema=prev)
+    bot = _BundleReproBot(
+        symbol,
+        close_mode=close_mode,
+        close_value=110.37,
+        prev_close_ema=prev,
+    )
 
     with caplog.at_level(logging.WARNING):
         (
@@ -1755,6 +1765,42 @@ async def test_active_forager_required_features_use_bounded_cached_carry_forward
         int(call["max_staleness_ms"]) >= 60_000
         for call in bot.cached_metric_calls
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("qv_mode", "lr1m_mode", "error_match"),
+    [
+        ("inf", "value", "non-finite m1_volume value"),
+        ("value", "inf", "non-finite m1_log_range value"),
+    ],
+)
+async def test_required_forager_infinity_is_fatal_before_cached_carry_forward(
+    qv_mode, lr1m_mode, error_match
+):
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    symbol = "AAVE/USDT:USDT"
+    bot = _BundleReproBot(
+        symbol,
+        close_mode="value",
+        qv_mode=qv_mode,
+        lr1m_mode=lr1m_mode,
+        cached_qv_ema={10.0: 250000.0},
+        cached_log_range_ema={10.0: 0.0015},
+    )
+    _enable_forager_required_ranking(bot)
+    mode_overrides = {"long": {symbol: "normal"}, "short": {symbol: "manual"}}
+
+    with pytest.raises(RuntimeError, match=error_match):
+        await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+            bot, [symbol], mode_overrides
+        )
+
+    assert bot.cached_metric_calls == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- route Bitget public OHLCV requests through classic futures market data even when the authenticated account uses UTA/Elite v3
- treat unrecovered `NaN` from completed-candle EMA reads as explicit symbol/action-scoped input unavailability
- preserve bounded open-tail projection and prior-close recovery before scoping affected consumers
- keep positive and negative infinity fatal before projection or cached fallback

## Root cause

Bitget account-mode detection enables CCXT UTA routing on the authenticated client shared with the candlestick manager. Bitget's public v3 UTA candle endpoint exposes a shorter XMR history than the account-independent v2 futures history endpoint. The live 1h cache therefore began on 2026-06-12 while an 1,814-hour EMA window required data from 2026-05-21, leaving a 531-candle historical prefix absent even though Bitget v2 had the data.

Bitget OHLCV requests now explicitly pass `uta=false` without changing the client's account-level UTA option or any private account/order routing. Existing cache merging can persist the recovered prefix without deleting newer shards.

The completed-candle EMA API still reports genuinely empty or incomplete windows as `NaN`. The live caller keeps those values absent rather than fabricating a number or passing `NaN` into Rust. Other ready symbols and independent Rust-authoritative consumers may continue under the existing scoped-readiness contract. Infinity remains an invalid calculation result and still fails the cycle.

## Validation

- 73 focused retry-policy and missing-EMA regressions passed
- full candlestick-manager coverage: 151 passed, 7 skipped
- public unauthenticated Bitget probe through the modified manager recovered exactly 531 unique continuous XMR 1h candles from 2026-05-21 03:00 through 2026-06-12 05:00 UTC
- the same probe retained the CCXT client's account-level `uta=true` option
- `git diff --check`
