### PR TITLE
Add historical candle resolution ladder for HSL replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Make HSL restart price reconstruction portable across exchanges with limited candle retention.
+  Replay now uses the finest available historical resolution in a fixed 1m, 5m, 15m, then 1h
+  ladder for the older leading prefix, reports approximate source counts, and never uses coarser
+  candles to conceal gaps inside the available 1m era. Fill-based episode boundaries, realized
+  PnL, and fees remain exact.
 - Recognize repeated exclusive switching between complete order cohorts as live
   order-churn evidence. Alternating long/short or order-type intent can now use
   the existing account-wide far-order allowance without merging position-side

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -212,7 +212,10 @@
     additionally requires exact aligned coverage for 1m EMA windows because its recent endpoint
     silently tail-anchors responses. Exchange-independent trailing-extrema and HSL replay-cache
     extension consumers also require exact aligned coverage; incomplete windows become unavailable
-    or fall back to authoritative replay.
+    or fall back to authoritative replay. HSL restart reconstruction is the narrow exception: it
+    fetches 1m candles first, then may cover only the older leading prefix with 5m, 15m, and 1h
+    candles. The finest available source wins, source counts remain visible, and coarser candles
+    never patch a gap at or after the first available 1m candle.
 11. Quote-volume EMA is derived from normalized CCXT base volume and typical price
     (`base_volume * (high + low + close) / 3`). It is an approximation when an exchange, including
     WEEX, does not expose raw quote turnover through unified OHLCV.

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -214,8 +214,9 @@
     extension consumers also require exact aligned coverage; incomplete windows become unavailable
     or fall back to authoritative replay. HSL restart reconstruction is the narrow exception: it
     fetches 1m candles first, then may cover only the older leading prefix with 5m, 15m, and 1h
-    candles. The finest available source wins, source counts remain visible, and coarser candles
-    never patch a gap at or after the first available 1m candle.
+    candles. The finest available source wins, source counts remain visible, and only coarse
+    buckets ending at or before the first available 1m candle are eligible, so later price action
+    cannot leak backward across the precision boundary.
 11. Quote-volume EMA is derived from normalized CCXT base volume and typical price
     (`base_volume * (high + low + close) / 3`). It is an approximation when an exchange, including
     WEEX, does not expose raw quote turnover through unified OHLCV.

--- a/docs/ai/features/equity_hard_stop_loss.md
+++ b/docs/ai/features/equity_hard_stop_loss.md
@@ -39,6 +39,11 @@ HSL drawdown state is scoped by `live.hsl_signal_mode`:
    their gains, losses, and fees cannot affect the retained episode. Unavailable candles before the
    resulting boundary cannot strand an otherwise provable held episode; unavailable required
    candles at or after it still fail closed.
+9. Restart price reconstruction fetches 1m history first. When an exchange cannot provide the
+   older leading portion, it may use 5m, then 15m, then 1h candles for that prefix. This is an
+   explicitly approximate price path: the finest source wins and its contribution is reported.
+   Coarser candles never repair missing rows at or after the first available 1m candle. Fill-based
+   episode boundaries, realized PnL, and fees remain exact.
 
 ## Failure Semantics
 

--- a/docs/equity_hard_stop_loss.md
+++ b/docs/equity_hard_stop_loss.md
@@ -151,6 +151,12 @@ required. If the episode saw RED, its cooldown begins at that same flattening fi
 
 This contract applies both to live runtime and to restart-time history replay.
 
+For restart-time price reconstruction, Passivbot uses available 1m candles first. If the exchange
+does not retain the older part of the requested window at that resolution, Passivbot progressively
+uses 5m, 15m, and 1h candles for that older prefix. This deliberately trades old price-path
+precision for robust reconstruction; fill timestamps, realized PnL, fees, and episode boundaries
+remain exact. Coarser sources and their contributed minute counts are included in replay metadata.
+
 In practical terms, restart replay must recognize any historical fill that fully flattened the
 configured scope as an episode boundary even if:
 

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -437,8 +437,9 @@ async def fetch_candles_with_resolution_ladder(
     """Fetch exact 1m candles, then cover only older leading history coarsely.
 
     The first available 1m candle is the precision boundary. Higher-timeframe
-    candles may supply minutes before that boundary, but never patch gaps at or
-    after it. Within the older prefix, the finest successful source wins.
+    candles may supply minutes before that boundary only when their full bucket
+    ends there or earlier; they never patch gaps at or after it. Within the
+    older prefix, the finest successful source wins.
     """
     start_minute = _floor_minute(start_ts)
     end_minute = _floor_minute(end_ts)
@@ -480,11 +481,16 @@ async def fetch_candles_with_resolution_ladder(
 
         if fetched.size == 0:
             continue
-        candidates = (
-            fetched
-            if tf_minutes == 1
-            else synthesize_1m_from_higher_tf(fetched, tf_minutes)
-        )
+        if tf_minutes == 1:
+            candidates = fetched
+        else:
+            period_ms = tf_minutes * ONE_MIN_MS
+            complete_before_boundary = (
+                fetched["ts"].astype(np.int64) + period_ms <= precision_boundary
+            )
+            candidates = synthesize_1m_from_higher_tf(
+                fetched[complete_before_boundary], tf_minutes
+            )
         if index == 0:
             exact_timestamps = [
                 int(row["ts"])

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -49,7 +49,19 @@ import atexit
 from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, AsyncIterator, Callable, Dict, List, Optional, Tuple, TypedDict, TYPE_CHECKING
+from typing import (
+    Any,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    TypedDict,
+    TYPE_CHECKING,
+)
 import threading
 from collections import OrderedDict
 
@@ -283,6 +295,23 @@ CANDLE_DTYPE = np.dtype(
     ]
 )
 
+CANDLE_RESOLUTION_LADDER: tuple[tuple[str, int], ...] = (
+    ("1m", 1),
+    ("5m", 5),
+    ("15m", 15),
+    ("1h", 60),
+)
+
+
+@dataclass(frozen=True)
+class CandleResolutionResult:
+    """Candles assembled from the finest available historical resolutions."""
+
+    candles: np.ndarray
+    source_counts: Dict[str, int]
+    failures: Dict[str, Exception]
+
+
 _LIVE_WS_OBSERVATION_RETENTION_MS = 2 * 60 * ONE_MIN_MS
 
 EMA_SERIES_DTYPE = np.dtype(
@@ -390,15 +419,112 @@ def synthesize_1m_from_higher_tf(candles: np.ndarray, tf_minutes: int) -> np.nda
     arr = _ensure_dtype(candles)
     if arr.size == 0:
         return np.empty((0,), dtype=CANDLE_DTYPE)
-    if tf_minutes == 5:
-        expanded = [ohlcv_5m_to_1m(row) for row in arr]
-    elif tf_minutes == 15:
-        expanded = [ohlcv_15m_to_1m(row) for row in arr]
-    else:
-        raise ValueError(f"unsupported tf_minutes={tf_minutes}")
+    if tf_minutes <= 1:
+        raise ValueError(f"tf_minutes must be > 1, got {tf_minutes}")
+    expanded = [ohlcv_xm_to_1m(row, tf_minutes) for row in arr]
     if not expanded:
         return np.empty((0,), dtype=CANDLE_DTYPE)
     return np.sort(np.concatenate(expanded), order="ts")
+
+
+async def fetch_candles_with_resolution_ladder(
+    fetch_candles: Callable[..., Awaitable[np.ndarray]],
+    *,
+    start_ts: int,
+    end_ts: int,
+    supported_timeframes: Optional[Iterable[str]] = None,
+) -> CandleResolutionResult:
+    """Fetch exact 1m candles, then cover only older leading history coarsely.
+
+    The first available 1m candle is the precision boundary. Higher-timeframe
+    candles may supply minutes before that boundary, but never patch gaps at or
+    after it. Within the older prefix, the finest successful source wins.
+    """
+    start_minute = _floor_minute(start_ts)
+    end_minute = _floor_minute(end_ts)
+    if end_minute < start_minute:
+        return CandleResolutionResult(
+            candles=np.empty((0,), dtype=CANDLE_DTYPE),
+            source_counts={},
+            failures={},
+        )
+
+    supported = (
+        {str(timeframe).lower() for timeframe in supported_timeframes}
+        if supported_timeframes is not None
+        else None
+    )
+    rows_by_ts: Dict[int, np.void] = {}
+    sources_by_ts: Dict[int, str] = {}
+    failures: Dict[str, Exception] = {}
+    precision_boundary = end_minute + ONE_MIN_MS
+
+    for index, (timeframe, tf_minutes) in enumerate(CANDLE_RESOLUTION_LADDER):
+        timeframe = str(timeframe).lower()
+        if supported is not None and timeframe not in supported:
+            continue
+        fetch_end = end_minute if index == 0 else precision_boundary - ONE_MIN_MS
+        if fetch_end < start_minute:
+            break
+        try:
+            fetched = _ensure_dtype(
+                await fetch_candles(
+                    timeframe=timeframe,
+                    start_ts=start_minute,
+                    end_ts=fetch_end,
+                )
+            )
+        except Exception as exc:
+            failures[timeframe] = exc
+            continue
+
+        if fetched.size == 0:
+            continue
+        candidates = (
+            fetched
+            if tf_minutes == 1
+            else synthesize_1m_from_higher_tf(fetched, tf_minutes)
+        )
+        if index == 0:
+            exact_timestamps = [
+                int(row["ts"])
+                for row in candidates
+                if start_minute <= int(row["ts"]) <= end_minute
+            ]
+            if exact_timestamps:
+                precision_boundary = min(exact_timestamps)
+
+        for row in candidates:
+            ts = int(row["ts"])
+            if ts < start_minute or ts > end_minute:
+                continue
+            if index > 0 and ts >= precision_boundary:
+                continue
+            if ts in rows_by_ts:
+                continue
+            rows_by_ts[ts] = row
+            sources_by_ts[ts] = timeframe
+
+        if precision_boundary <= start_minute:
+            break
+        expected_prefix = range(start_minute, precision_boundary, ONE_MIN_MS)
+        if all(ts in rows_by_ts for ts in expected_prefix):
+            break
+
+    if not rows_by_ts:
+        candles = np.empty((0,), dtype=CANDLE_DTYPE)
+    else:
+        candles = np.empty((len(rows_by_ts),), dtype=CANDLE_DTYPE)
+        for index, ts in enumerate(sorted(rows_by_ts)):
+            candles[index] = rows_by_ts[ts]
+    source_counts: Dict[str, int] = {}
+    for source in sources_by_ts.values():
+        source_counts[source] = source_counts.get(source, 0) + 1
+    return CandleResolutionResult(
+        candles=candles,
+        source_counts=source_counts,
+        failures=failures,
+    )
 
 
 def get_caller_name(depth: int = 2, logger: Optional[logging.Logger] = None) -> str:

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -39,7 +39,7 @@ from candlestick_manager import (
     CANDLE_DTYPE,
     DEFAULT_NATIVE_SPARSE_GAP_TOLERANCE_MINUTES,
     OhlcvTerminalEmptyPage,
-    synthesize_1m_from_higher_tf,
+    fetch_candles_with_resolution_ladder,
 )
 from fill_events_manager import (
     FillEventCacheContractError,
@@ -14817,7 +14817,13 @@ class Passivbot:
                 reason_code=ReasonCodes.HSL_PRICE_HISTORY_FETCH_STARTED,
             )
 
-            async def fetch_replay_candles(sym: str, *, timeframe: str = "1m"):
+            async def fetch_replay_candles(
+                sym: str,
+                *,
+                timeframe: str,
+                start_ts: int,
+                end_ts: int,
+            ):
                 async with replay_sem:
                     symbol_fetch_started_s = time.monotonic()
                     symbol_payload = {
@@ -14826,8 +14832,8 @@ class Passivbot:
                         "price_replay_symbols": len(price_replay_symbols),
                         "history_minutes": history_minutes,
                         "timeframe": str(timeframe),
-                        "start_ts": int(start_minute),
-                        "end_ts": int(end_minute),
+                        "start_ts": int(start_ts),
+                        "end_ts": int(end_ts),
                     }
                     _emit_hsl_history_progress(
                         "price_history_symbol_fetch_started",
@@ -14838,8 +14844,8 @@ class Passivbot:
                     try:
                         arr = await self.cm.get_candles(
                             sym,
-                            start_ts=start_minute,
-                            end_ts=end_minute,
+                            start_ts=start_ts,
+                            end_ts=end_ts,
                             strict=False,
                             timeframe=timeframe,
                         )
@@ -14861,7 +14867,7 @@ class Passivbot:
                             status="succeeded",
                             reason_code=ReasonCodes.HSL_PRICE_HISTORY_SYMBOL_FETCH_COMPLETED,
                         )
-                        return sym, arr, None
+                        return arr
                     except Exception as exc:
                         _emit_hsl_history_progress(
                             "price_history_symbol_fetch_completed",
@@ -14881,76 +14887,64 @@ class Passivbot:
                             status="failed",
                             reason_code=ReasonCodes.HSL_PRICE_HISTORY_SYMBOL_FETCH_COMPLETED,
                         )
-                        return sym, None, exc
+                        raise
                     finally:
                         if replay_fetch_delay_s > 0.0:
                             await self._sleep_unless_shutdown(
                                 replay_fetch_delay_s, stage="history_replay_candles"
                             )
 
-            for sym, arr, exc in await asyncio.gather(
-                *(fetch_replay_candles(sym) for sym in sorted(price_replay_symbols))
+            exchange_timeframes = getattr(
+                getattr(self, "cca", None), "timeframes", None
+            )
+            supported_timeframes = (
+                set(exchange_timeframes)
+                if isinstance(exchange_timeframes, dict) and exchange_timeframes
+                else None
+            )
+
+            async def fetch_replay_history(sym: str):
+                async def fetch_timeframe(
+                    *, timeframe: str, start_ts: int, end_ts: int
+                ):
+                    return await fetch_replay_candles(
+                        sym,
+                        timeframe=timeframe,
+                        start_ts=start_ts,
+                        end_ts=end_ts,
+                    )
+
+                result = await fetch_candles_with_resolution_ladder(
+                    fetch_timeframe,
+                    start_ts=start_minute,
+                    end_ts=end_minute,
+                    supported_timeframes=supported_timeframes,
+                )
+                return sym, result
+
+            for sym, result in await asyncio.gather(
+                *(fetch_replay_history(sym) for sym in sorted(price_replay_symbols))
             ):
-                if exc is not None:
+                for timeframe, exc in result.failures.items():
                     logging.error(
-                        "error fetching candles for %s | error_type=%s",
+                        "error fetching %s candles for %s during equity history replay "
+                        "| error_type=%s",
+                        timeframe,
                         Passivbot._log_symbol(sym),
                         bounded_exception_type(exc),
                     )
-                    arr = np.empty((0,), dtype=CANDLE_DTYPE)
-                if arr is None:
-                    arr = np.empty((0,), dtype=CANDLE_DTYPE)
                 price_lookup[sym] = {
                     int(row["ts"]): float(row["c"])
-                    for row in arr
+                    for row in result.candles
                     if float(row["c"]) > 0.0
                 }
-            is_hyperliquid = str(getattr(self, "exchange", "")).lower() == "hyperliquid"
-            if is_hyperliquid:
-                lookback_minutes = (
-                    int(max(0, (end_minute - start_minute) // ONE_MIN_MS)) + 1
-                )
-                tf_plan: list[tuple[str, int]] = []
-                if lookback_minutes > 5000:
-                    tf_plan.append(("5m", 5))
-                if lookback_minutes > 5000 * 5:
-                    tf_plan.append(("15m", 15))
-                for timeframe, tf_minutes in tf_plan:
-                    for sym, arr, exc in await asyncio.gather(
-                        *(
-                            fetch_replay_candles(sym, timeframe=timeframe)
-                            for sym in sorted(price_replay_symbols)
-                        )
-                    ):
-                        if exc is not None:
-                            logging.error(
-                                "error fetching %s candles for %s during equity history replay "
-                                "| error_type=%s",
-                                timeframe,
-                                Passivbot._log_symbol(sym),
-                                bounded_exception_type(exc),
-                            )
-                            continue
-                        if arr is None or arr.size == 0:
-                            continue
-                        synth = synthesize_1m_from_higher_tf(arr, tf_minutes)
-                        if synth.size == 0:
-                            continue
-                        added = 0
-                        lookup = price_lookup.setdefault(sym, {})
-                        for row in synth:
-                            ts = int(row["ts"])
-                            close = float(row["c"])
-                            if ts < start_minute or ts > end_minute:
-                                continue
-                            if ts in lookup:
-                                continue
-                            lookup[ts] = float(close)
-                            added += 1
-                        if added > 0:
-                            approximate_price_sources.setdefault(sym, {})[
-                                timeframe
-                            ] = added
+                approximate_counts = {
+                    timeframe: count
+                    for timeframe, count in result.source_counts.items()
+                    if timeframe != "1m" and count > 0
+                }
+                if approximate_counts:
+                    approximate_price_sources[sym] = approximate_counts
             candle_fetch_elapsed_s = max(0.0, time.monotonic() - candle_fetch_started_s)
             _emit_hsl_history_progress(
                 "price_history_fetch_completed",

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -100,6 +100,30 @@ async def test_resolution_ladder_fills_only_prefix_before_exact_1m():
 
 
 @pytest.mark.asyncio
+async def test_resolution_ladder_rejects_coarse_bucket_crossing_1m_boundary():
+    async def fetch(*, timeframe, start_ts, end_ts):
+        if timeframe == "1m":
+            return _resolution_candles(12, 13)
+        if timeframe == "5m":
+            return _resolution_candles(5, 10, close_offset=500.0)
+        return _resolution_candles()
+
+    result = await fetch_candles_with_resolution_ladder(
+        fetch,
+        start_ts=5 * ONE_MIN_MS,
+        end_ts=13 * ONE_MIN_MS,
+    )
+
+    timestamps = set(result.candles["ts"])
+    expected_timestamps = {minute * ONE_MIN_MS for minute in range(5, 10)} | {
+        12 * ONE_MIN_MS,
+        13 * ONE_MIN_MS,
+    }
+    assert timestamps == expected_timestamps
+    assert result.source_counts == {"5m": 5, "1m": 2}
+
+
+@pytest.mark.asyncio
 async def test_resolution_ladder_uses_finer_sources_before_one_hour():
     calls = []
 
@@ -141,14 +165,14 @@ async def test_resolution_ladder_skips_unsupported_tier_and_records_failures():
     result = await fetch_candles_with_resolution_ladder(
         fetch,
         start_ts=0,
-        end_ts=4 * ONE_MIN_MS,
+        end_ts=59 * ONE_MIN_MS,
         supported_timeframes={"1m", "15m", "1h"},
     )
 
     assert calls == ["1m", "15m", "1h"]
     assert set(result.failures) == {"1m", "15m"}
-    assert result.source_counts == {"1h": 5}
-    assert result.candles.size == 5
+    assert result.source_counts == {"1h": 60}
+    assert result.candles.size == 60
 
 
 def test_synthesize_1m_from_one_hour_candle():

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -28,9 +28,137 @@ from candlestick_manager import (
     _GAP_PERSISTENT_RETRY_MS,
     _GATEIO_RECENT_1M_LIMIT_CANDLES,
     _floor_minute,
+    fetch_candles_with_resolution_ladder,
     sanitize_remote_fetch_diagnostic,
+    synthesize_1m_from_higher_tf,
 )
 from logging_setup import DEFAULT_DATEFMT, DEFAULT_FORMAT_WITH_PREFIX
+
+
+def _resolution_candles(*minutes, close_offset=0.0):
+    return np.array(
+        [
+            (
+                minute * ONE_MIN_MS,
+                100.0 + close_offset + minute,
+                101.0 + close_offset + minute,
+                99.0 + close_offset + minute,
+                100.0 + close_offset + minute,
+                1.0,
+            )
+            for minute in minutes
+        ],
+        dtype=CANDLE_DTYPE,
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolution_ladder_stops_when_exact_1m_reaches_start():
+    calls = []
+
+    async def fetch(*, timeframe, start_ts, end_ts):
+        calls.append((timeframe, start_ts, end_ts))
+        assert timeframe == "1m"
+        return _resolution_candles(0, 1, 2)
+
+    result = await fetch_candles_with_resolution_ladder(
+        fetch,
+        start_ts=0,
+        end_ts=2 * ONE_MIN_MS,
+    )
+
+    assert [call[0] for call in calls] == ["1m"]
+    assert result.source_counts == {"1m": 3}
+    assert result.failures == {}
+    assert result.candles["ts"].tolist() == [0, ONE_MIN_MS, 2 * ONE_MIN_MS]
+
+
+@pytest.mark.asyncio
+async def test_resolution_ladder_fills_only_prefix_before_exact_1m():
+    calls = []
+
+    async def fetch(*, timeframe, start_ts, end_ts):
+        calls.append((timeframe, start_ts, end_ts))
+        if timeframe == "1m":
+            return _resolution_candles(10, 11, 13)
+        if timeframe == "5m":
+            return _resolution_candles(0, 5, close_offset=1_000.0)
+        raise AssertionError(f"unexpected timeframe {timeframe}")
+
+    result = await fetch_candles_with_resolution_ladder(
+        fetch,
+        start_ts=0,
+        end_ts=13 * ONE_MIN_MS,
+    )
+
+    assert [call[0] for call in calls] == ["1m", "5m"]
+    assert calls[1][2] == 9 * ONE_MIN_MS
+    assert result.source_counts == {"5m": 10, "1m": 3}
+    assert 12 * ONE_MIN_MS not in set(result.candles["ts"])
+    exact_row = result.candles[result.candles["ts"] == 10 * ONE_MIN_MS][0]
+    assert float(exact_row["c"]) == pytest.approx(110.0)
+
+
+@pytest.mark.asyncio
+async def test_resolution_ladder_uses_finer_sources_before_one_hour():
+    calls = []
+
+    async def fetch(*, timeframe, start_ts, end_ts):
+        calls.append(timeframe)
+        if timeframe == "1m":
+            return _resolution_candles(*range(60, 75))
+        if timeframe == "5m":
+            return _resolution_candles(50, close_offset=500.0)
+        if timeframe == "15m":
+            return _resolution_candles(30, close_offset=1_500.0)
+        if timeframe == "1h":
+            return _resolution_candles(0, close_offset=6_000.0)
+        raise AssertionError(timeframe)
+
+    result = await fetch_candles_with_resolution_ladder(
+        fetch,
+        start_ts=0,
+        end_ts=74 * ONE_MIN_MS,
+    )
+
+    assert calls == ["1m", "5m", "15m", "1h"]
+    assert result.source_counts == {"1h": 40, "15m": 15, "5m": 5, "1m": 15}
+    assert result.candles.size == 75
+
+
+@pytest.mark.asyncio
+async def test_resolution_ladder_skips_unsupported_tier_and_records_failures():
+    calls = []
+
+    async def fetch(*, timeframe, start_ts, end_ts):
+        calls.append(timeframe)
+        if timeframe in {"1m", "15m"}:
+            raise RuntimeError(f"{timeframe} unavailable")
+        if timeframe == "1h":
+            return _resolution_candles(0)
+        raise AssertionError(timeframe)
+
+    result = await fetch_candles_with_resolution_ladder(
+        fetch,
+        start_ts=0,
+        end_ts=4 * ONE_MIN_MS,
+        supported_timeframes={"1m", "15m", "1h"},
+    )
+
+    assert calls == ["1m", "15m", "1h"]
+    assert set(result.failures) == {"1m", "15m"}
+    assert result.source_counts == {"1h": 5}
+    assert result.candles.size == 5
+
+
+def test_synthesize_1m_from_one_hour_candle():
+    result = synthesize_1m_from_higher_tf(_resolution_candles(0), 60)
+
+    assert result.size == 60
+    assert int(result[0]["ts"]) == 0
+    assert int(result[-1]["ts"]) == 59 * ONE_MIN_MS
+    with pytest.raises(ValueError, match="must be > 1"):
+        synthesize_1m_from_higher_tf(_resolution_candles(0), 1)
 
 
 def test_normalize_ccxt_ohlcv_filters_nonfinite_and_nonpositive_rows(tmp_path):

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -2100,6 +2100,7 @@ async def test_balance_equity_history_paces_replay_candle_fetches(monkeypatch):
     }
     bot._pnls_manager = None
     bot.inverse = False
+    bot.cca = SimpleNamespace(timeframes={"1m": "1m"})
     bot._candle_fetch_concurrency = lambda *, context="runtime": 2
     bot._get_fetch_delay_seconds = lambda: 0.0
     sink = ListEventSink()
@@ -2289,7 +2290,12 @@ async def test_balance_equity_history_redacts_failed_candle_fetch_diagnostics(mo
         if event.reason_code == ReasonCodes.HSL_PRICE_HISTORY_SYMBOL_FETCH_COMPLETED
         and event.status == "failed"
     ]
-    assert {event.data["timeframe"] for event in failed_events} == {"1m", "5m"}
+    assert {event.data["timeframe"] for event in failed_events} == {
+        "1m",
+        "5m",
+        "15m",
+        "1h",
+    }
     assert {event.data["error_type"] for event in failed_events} == {"RuntimeError"}
     assert all(
         event.data["stage"] == "price_history_symbol_fetch_completed"
@@ -3115,6 +3121,7 @@ async def test_balance_equity_history_skips_unsupported_closed_historical_symbol
     bot.positions = {}
     bot._pnls_manager = None
     bot.inverse = False
+    bot.cca = SimpleNamespace(timeframes={"1m": "1m"})
     bot._candle_fetch_concurrency = lambda *, context="runtime": 2
     bot._get_fetch_delay_seconds = lambda: 0.0
     bot.c_mults = {"BTC/USDT:USDT": 1.0}

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -6146,11 +6146,11 @@ async def test_hard_stop_initialize_from_history_preserves_no_restart_peak_acros
 
 
 @pytest.mark.asyncio
-async def test_get_balance_equity_history_hyperliquid_backfills_from_5m(monkeypatch):
+async def test_get_balance_equity_history_backfills_from_5m_on_any_exchange(monkeypatch):
     cfg = _dummy_config()
     cfg["live"]["pnls_max_lookback_days"] = 4.0
     bot = _make_dummy_bot(cfg)
-    bot.exchange = "hyperliquid"
+    bot.exchange = "gateio"
     bot._live_values["pnls_max_lookback_days"] = 4.0
     symbol = "BTC/USDT:USDT"
     bot.c_mults = {symbol: 1.0}
@@ -6183,7 +6183,7 @@ async def test_get_balance_equity_history_hyperliquid_backfills_from_5m(monkeypa
                         ),
                     ]
                 )
-            if timeframe == "15m":
+            if timeframe in {"15m", "1h"}:
                 return _make_candles([])
             raise AssertionError(f"unexpected timeframe {timeframe}")
 


### PR DESCRIPTION
## Summary
- add one reusable 1m -> 5m -> 15m -> 1h historical candle ladder
- restrict coarse reconstruction to the leading prefix before the first available 1m candle, with finer sources winning
- migrate HSL restart price replay from Hyperliquid-specific fallback logic to the exchange-independent ladder
- retain approximate source counts and exact fill, fee, realized-PnL, and episode-boundary semantics

## Deliberate scope
This PR migrates HSL only. EMA and trailing consumers can adopt the same primitive in separate reviewed changes. No exchange-specific caps, confidence model, or new configuration is added.

## Validation
- full tests/test_candlestick_manager.py
- full tests/test_unstucking_safeguards.py and tests/test_hsl_coin_mode.py
- offline fake-live tests in tests/test_run_fake_live.py with the fake_live marker
- Python compile checks and git diff --check