### PR TITLE
Move trailing availability into Rust planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Move live trailing-input availability into Rust's side-scoped planning contract. Missing
+  trailing extrema now suppress only entry or close branches that actually consume them while the
+  other branch, other position side, panic, and independent reducers remain available. Remove the
+  Python post-reconciliation exception matrix so stale orders absent from current Rust intent are
+  cancelled normally.
 - Make HSL restart price reconstruction portable across exchanges with limited candle retention.
   Replay now uses the finest available historical resolution in a fixed 1m, 5m, 15m, then 1h
   ladder for the older leading prefix, reports approximate source counts, and never uses coarser

--- a/docs/ai/error_contract.md
+++ b/docs/ai/error_contract.md
@@ -53,17 +53,19 @@ order classes whose strategy or risk decision consumes them. Stale flat-symbol c
 block protective management of held symbols.
 
 A failed urgent candle refresh is therefore an availability observation, not an account-wide
-planning barrier. Live Python may explicitly mark a symbol's known missing EMA inputs as
-unavailable and pass no invented values. Rust remains strict by default, including backtests, and
-may scope only that explicit live absence to forager selection, one-way arbitration, strategy, or
-unstuck consumers that need it.
+planning barrier. Live Python may explicitly mark a symbol's known missing EMA inputs or one
+position side's trailing extrema as unavailable. Rust remains strict by default, including
+backtests, and may scope only that explicit live absence to forager selection, one-way arbitration,
+strategy, or unstuck consumers that need it. A structurally required trailing bundle paired with
+`trailing_available=false` is inert transport data and must be rejected before any consuming
+strategy branch can read it.
 Missing ordinary strategy input produces no ideal orders for the entry or close branch that
 consumes it, so normal Rust-authoritative reconciliation removes any now-stale resting orders from
 that branch. The other strategy branch, independent Rust risk reducers, and panic actions continue
 when their own inputs are complete. Malformed or non-finite producer output is never covered by
 this degradation and remains fatal. Here, producer output means the Rust ideal-order/result
-envelope. A documented live input-reader availability sentinel is classified before that boundary,
-must never reach Rust, and retains only its explicitly bounded recovery and scoped-defer policies.
+envelope. A documented live input-reader availability sentinel must be classified before its
+strategy consumer and retains only its explicitly bounded recovery and scoped-defer policies.
 
 For candle-dependent actions, gate on canonical strategy-input readiness rather than raw REST
 candle arrival. A proven no-trade gap may use explicitly synthesized zero-volume continuity when

--- a/docs/ai/features/strategy_runtime.md
+++ b/docs/ai/features/strategy_runtime.md
@@ -76,8 +76,8 @@ Live health distinguishes three stages:
 1. The candidate universe contains approved, age-eligible, cost-eligible symbols.
 2. A rankable candidate has the required real-candle quote-volume and log-range
    features.
-3. A Rust-tradable symbol also has every strategy, trailing, and risk input
-   needed for its current mode.
+3. Each Rust-plannable action has the strategy, trailing, and risk inputs it
+   consumes; availability may differ by position side and entry/close branch.
 
 A flat candidate with unavailable ranking features remains visible as a forager
 candidate but is marked `forager.rankable=false`; this is distinct from an
@@ -104,6 +104,14 @@ Entries and closes use threshold/retracement fields.
 - `retracement_base_pct > 0.0`: threshold is the required excursion, retracement is the confirmation move.
 - Trailing extrema reset after any fill for the same coin+pside.
 - Passivbot tracks trailing state itself from candle inputs; exchange-native trailing order types are not part of the core contract.
+
+Live trailing availability is a Rust planning input, not a Python reconciliation policy. Python
+sets `trailing_available=false` only for the affected coin+position-side while retaining a
+structurally valid but inert bundle. Rust omits only an entry or close branch whose active strategy
+configuration actually consumes trailing extrema. The other branch, the other position side,
+panic, and independent risk reducers continue when their own inputs are complete. The resulting
+Rust ideal set remains authoritative: reconciliation cancels resting orders absent from that set
+and never preserves them merely because trailing reconstruction is pending.
 
 Entry thresholds and retracements are multiplicative distances. Positive volatility or wallet
 exposure weights widen them.

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -1523,6 +1523,7 @@ impl<'a> Backtest<'a> {
                         mode: mode_long,
                         position: pos_long,
                         trailing: trailing_long,
+                        trailing_available: true,
                         last_increase_fill_timestamp_ms: self.last_increase_fill_timestamp_long
                             [idx],
                         bot_params: self.bot_params[idx].long.clone(),
@@ -1534,6 +1535,7 @@ impl<'a> Backtest<'a> {
                         mode: mode_short,
                         position: pos_short,
                         trailing: trailing_short,
+                        trailing_available: true,
                         last_increase_fill_timestamp_ms: self.last_increase_fill_timestamp_short
                             [idx],
                         bot_params: self.bot_params[idx].short.clone(),

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -47,9 +47,10 @@ mod core {
         strategy_entry_volatility_span_hours, strategy_initial_entry_offset,
         strategy_initial_qty_pct, strategy_needs_log_range_1h,
         strategy_needs_log_range_1h_for_request, strategy_needs_log_range_1m,
-        strategy_needs_log_range_1m_for_request, strategy_offset_volatility_span_minutes,
-        strategy_requires_sequential_entry_staging, EmaGateMode, NextStepHint, PeekBehavior,
-        StrategyKind, StrategyParams, StrategyRequest, StrategySide,
+        strategy_needs_log_range_1m_for_request, strategy_needs_trailing_for_request,
+        strategy_offset_volatility_span_minutes, strategy_requires_sequential_entry_staging,
+        EmaGateMode, NextStepHint, PeekBehavior, StrategyKind, StrategyParams, StrategyRequest,
+        StrategySide,
     };
     use crate::types::{
         BotParams, BotParamsPair, EMABands, ExchangeParams, OrderBook, OrderType, Position,
@@ -255,6 +256,9 @@ mod core {
         MissingEma {
             symbol_idx: usize,
         },
+        MissingTrailing {
+            symbol_idx: usize,
+        },
     }
 
     #[derive(Debug, Default, Clone, Serialize, Deserialize)]
@@ -366,6 +370,10 @@ mod core {
         true
     }
 
+    fn default_trailing_available() -> bool {
+        true
+    }
+
     fn default_market_order_near_touch_threshold() -> f64 {
         0.001
     }
@@ -378,6 +386,11 @@ mod core {
         pub mode: Option<TradingMode>,
         pub position: Position,
         pub trailing: TrailingPriceBundle,
+        /// Explicit live availability for this side's trailing extrema. The
+        /// structurally required bundle is ignored by consuming strategy
+        /// branches while this is false.
+        #[serde(default = "default_trailing_available")]
+        pub trailing_available: bool,
         #[serde(default)]
         pub last_increase_fill_timestamp_ms: Option<u64>,
         /// Per-symbol/per-pside params after applying coin_overrides.
@@ -2321,9 +2334,14 @@ mod core {
         scope: StrategyInputScope,
         diagnostics: &mut OrchestratorDiagnostics,
     ) -> Result<(), OrchestratorError> {
-        if symbol.allow_missing_strategy_inputs
-            && matches!(err, OrchestratorError::MissingEma { .. })
-        {
+        let explicitly_unavailable = match &err {
+            OrchestratorError::MissingEma { .. } => symbol.allow_missing_strategy_inputs,
+            OrchestratorError::MissingTrailing { .. } => {
+                !symbol_side_input(symbol, pside).trailing_available
+            }
+            _ => false,
+        };
+        if explicitly_unavailable {
             let warning = OrchestratorWarning::StrategyInputUnavailable {
                 symbol_idx: symbol.symbol_idx,
                 pside,
@@ -2503,6 +2521,13 @@ mod core {
             strategy_side,
             side,
         )?;
+        if !side.trailing_available
+            && strategy_needs_trailing_for_request(&strategy_params, wants_entries, wants_closes)
+        {
+            return Err(OrchestratorError::MissingTrailing {
+                symbol_idx: symbol.symbol_idx,
+            });
+        }
         let ema_bands = if strategy_order_generation_needs_ema_for_symbol_side(
             &strategy_params,
             pside,
@@ -2601,7 +2626,11 @@ mod core {
         wants_closes: bool,
         diagnostics: &mut OrchestratorDiagnostics,
     ) -> Result<(Vec<IdealOrder>, Vec<IdealOrder>, bool), OrchestratorError> {
-        let requests = if symbol.allow_missing_strategy_inputs && wants_entries && wants_closes {
+        let side = symbol_side_input(symbol, pside);
+        let requests = if (symbol.allow_missing_strategy_inputs || !side.trailing_available)
+            && wants_entries
+            && wants_closes
+        {
             [(true, false), (false, true)]
         } else {
             [(wants_entries, wants_closes), (false, false)]
@@ -4340,6 +4369,7 @@ mod core {
                     mode: None,
                     position: Position::default(),
                     trailing: TrailingPriceBundle::default(),
+                    trailing_available: true,
                     bot_params: bp.clone(),
                     strategy_params: None,
                     parsed_strategy_params: None,
@@ -4350,6 +4380,7 @@ mod core {
                     mode: None,
                     position: Position::default(),
                     trailing: TrailingPriceBundle::default(),
+                    trailing_available: true,
                     bot_params: bp,
                     strategy_params: None,
                     parsed_strategy_params: None,

--- a/passivbot-rust/src/strategies/mod.rs
+++ b/passivbot-rust/src/strategies/mod.rs
@@ -377,13 +377,23 @@ pub fn strategy_needs_log_range_1h_for_request(
 }
 
 pub fn strategy_has_trailing(params: &StrategyParams) -> bool {
+    strategy_needs_trailing_for_request(params, true, true)
+}
+
+pub fn strategy_needs_trailing_for_request(
+    params: &StrategyParams,
+    wants_entries: bool,
+    wants_closes: bool,
+) -> bool {
     match params {
         StrategyParams::TrailingMartingale(params) => {
-            params.entry.retracement_base_pct > 0.0 || params.close.retracement_base_pct > 0.0
+            (wants_entries && params.entry.retracement_base_pct > 0.0)
+                || (wants_closes && params.close.retracement_base_pct > 0.0)
         }
         StrategyParams::EmaAnchor(_) => false,
         StrategyParams::TrailingGridV7(params) => {
-            params.entry.trailing_grid_ratio != 0.0 || params.close.trailing_grid_ratio != 0.0
+            (wants_entries && params.entry.trailing_grid_ratio != 0.0)
+                || (wants_closes && params.close.trailing_grid_ratio != 0.0)
         }
     }
 }
@@ -404,11 +414,42 @@ pub fn generate_orders(
 mod tests {
     use super::{
         parse_strategy_params, strategy_needs_log_range_1h,
-        strategy_needs_log_range_1h_for_request, StrategyKind, StrategyParams, StrategySide,
-        TrailingGridV7Params,
+        strategy_needs_log_range_1h_for_request, strategy_needs_trailing_for_request,
+        EmaAnchorParams, StrategyKind, StrategyParams, StrategySide, TrailingGridV7Params,
+        TrailingMartingaleParams,
     };
     use crate::types::BotParams;
     use serde_json::json;
+
+    #[test]
+    fn trailing_input_needs_are_request_scoped_for_all_strategy_kinds() {
+        let mut martingale = TrailingMartingaleParams::default();
+        martingale.entry.retracement_base_pct = 0.01;
+        let martingale = StrategyParams::TrailingMartingale(martingale);
+        assert!(strategy_needs_trailing_for_request(
+            &martingale,
+            true,
+            false
+        ));
+        assert!(!strategy_needs_trailing_for_request(
+            &martingale,
+            false,
+            true
+        ));
+
+        let mut v7 = TrailingGridV7Params::default();
+        v7.close.trailing_grid_ratio = 0.5;
+        let v7 = StrategyParams::TrailingGridV7(v7);
+        assert!(!strategy_needs_trailing_for_request(&v7, true, false));
+        assert!(strategy_needs_trailing_for_request(&v7, false, true));
+
+        let ema_anchor = StrategyParams::EmaAnchor(EmaAnchorParams::default());
+        assert!(!strategy_needs_trailing_for_request(
+            &ema_anchor,
+            true,
+            true
+        ));
+    }
 
     #[test]
     fn trailing_grid_v7_parse_rejects_missing_required_leaf() {

--- a/src/live/reconciler.py
+++ b/src/live/reconciler.py
@@ -1190,9 +1190,6 @@ async def calc_orders_to_cancel_and_create_from_ideal(
     malformed_actual_symbols = set(
         getattr(bot, "_malformed_actual_order_symbols", set()) or set()
     )
-    trailing_unavailable_symbols = set(
-        getattr(bot, "_orchestrator_trailing_unavailable_symbols", set()) or set()
-    )
     malformed_actual_counts = dict(
         getattr(bot, "_malformed_actual_order_counts", {}) or {}
     )
@@ -1269,33 +1266,6 @@ async def calc_orders_to_cancel_and_create_from_ideal(
             )
         pre_cancel = len(cancel_)
         pre_create = len(create_)
-        trailing_skipped = 0
-        if symbol in trailing_unavailable_symbols:
-            before_trailing_create = list(create_)
-            cancel_, create_, trailing_skipped, fully_blocked = (
-                filter_trailing_unavailable_reconciliation(
-                    bot, symbol, cancel_, create_, ideal_list
-                )
-            )
-            trace = _trace_record(
-                trace,
-                "record_blocked_orders",
-                _orders_removed_by_identity(before_trailing_create, create_),
-                "trailing_unavailable",
-            )
-            if fully_blocked:
-                blocked_total = len(symbol_orders) + len(ideal_list)
-                plan_summaries.append(
-                    (
-                        symbol,
-                        len(symbol_orders),
-                        0,
-                        len(ideal_list),
-                        0,
-                        blocked_total,
-                    )
-                )
-                continue
         cancel_, create_ = bot._annotate_order_deltas(cancel_, create_)
         before_tolerance_create = list(create_)
         cancel_, create_, skipped = bot._apply_order_match_tolerance(cancel_, create_)
@@ -1305,7 +1275,6 @@ async def calc_orders_to_cancel_and_create_from_ideal(
             _orders_removed_by_identity(before_tolerance_create, create_),
             "order_match_tolerance",
         )
-        skipped += trailing_skipped
         plan_summaries.append(
             (symbol, pre_cancel, len(cancel_), pre_create, len(create_), skipped)
         )
@@ -1740,124 +1709,6 @@ _PROTECTIVE_REDUCE_ONLY_FAMILIES = frozenset(
 def _order_is_protective_reducer(order: dict) -> bool:
     family = _reduce_only_order_family(order)
     return family is not None and family[1] in _PROTECTIVE_REDUCE_ONLY_FAMILIES
-
-
-def _trailing_unavailable_reasons(bot, symbol: str) -> set[str]:
-    by_symbol = getattr(bot, "_orchestrator_trailing_unavailable_reasons", {}) or {}
-    reasons = by_symbol.get(symbol, []) if isinstance(by_symbol, dict) else []
-    if isinstance(reasons, str):
-        return {reasons}
-    return {str(reason) for reason in reasons if reason}
-
-
-def _trailing_unavailable_psides(bot, symbol: str) -> set[str]:
-    by_symbol = getattr(bot, "_orchestrator_trailing_unavailable_psides", {}) or {}
-    if isinstance(by_symbol, dict) and symbol in by_symbol:
-        psides = by_symbol.get(symbol, [])
-        if isinstance(psides, str):
-            return {psides}
-        return {str(pside).lower() for pside in psides if pside}
-    # Compatibility for callers/tests that only expose the older symbol-level state.
-    return {"long", "short"}
-
-
-def _order_is_unavailable_trailing_close(order: dict, unavailable_psides: set[str]) -> bool:
-    family = _reduce_only_order_family(order)
-    if family is None:
-        return False
-    pside, order_family = family
-    return order_family == "close_trailing" and (
-        not pside or pside in unavailable_psides
-    )
-
-
-def _order_position_side(order: dict) -> str:
-    pside = str(
-        order.get("position_side") or order.get("positionSide") or ""
-    ).lower()
-    if not pside:
-        family = _reduce_only_order_family(order)
-        pside = "" if family is None else family[0]
-    return pside
-
-
-def _order_targets_unavailable_pside(
-    order: dict, unavailable_psides: set[str]
-) -> bool:
-    pside = _order_position_side(order)
-    return not pside or pside in unavailable_psides
-
-
-def filter_trailing_unavailable_reconciliation(
-    bot,
-    symbol: str,
-    to_cancel: list[dict],
-    to_create: list[dict],
-    ideal_orders: list[dict],
-) -> tuple[list[dict], list[dict], int, bool]:
-    """Constrain reconciliation when trailing data is unavailable.
-
-    Ordinary trailing closes require post-fill extrema. Suppress their creation and
-    retire existing trailing orders while preserving independent reduce-only and panic
-    exits. Missing anchors/fetch failures otherwise preserve the symbol.
-    """
-    reasons = _trailing_unavailable_reasons(bot, symbol)
-    unavailable_psides = _trailing_unavailable_psides(bot, symbol)
-    panic_psides = {
-        pside
-        for order in [*ideal_orders, *to_create]
-        if _order_is_panic(order) and (pside := _order_position_side(order))
-    }
-    soft_missing_candles_only = reasons == {"missing_trailing_candles"}
-    if not soft_missing_candles_only:
-        filtered_cancel = [
-            order
-            for order in to_cancel
-            if _order_position_side(order) in panic_psides
-            or not _order_targets_unavailable_pside(order, unavailable_psides)
-            or _order_is_unavailable_trailing_close(order, unavailable_psides)
-        ]
-        filtered_create = [
-            order
-            for order in to_create
-            if _order_is_panic(order)
-            or not _order_targets_unavailable_pside(order, unavailable_psides)
-        ]
-        dropped = (len(to_cancel) - len(filtered_cancel)) + (
-            len(to_create) - len(filtered_create)
-        )
-        fully_blocked = not filtered_cancel and not filtered_create
-        return filtered_cancel, filtered_create, dropped, fully_blocked
-
-    filtered_create = [
-        order
-        for order in to_create
-        if (_order_is_reduce_only(order) or _order_is_panic(order))
-        and not _order_is_unavailable_trailing_close(order, unavailable_psides)
-    ]
-    dropped_create = len(to_create) - len(filtered_create)
-
-    ideal_reduce_only_families = {
-        family
-        for order in ideal_orders
-        if (family := _reduce_only_order_family(order)) is not None
-    }
-    filtered_cancel = []
-    dropped_cancel = 0
-    for order in to_cancel:
-        if _order_position_side(order) in panic_psides:
-            filtered_cancel.append(order)
-            continue
-        if _order_is_reduce_only(order):
-            if _order_is_unavailable_trailing_close(order, unavailable_psides):
-                filtered_cancel.append(order)
-                continue
-            family = _reduce_only_order_family(order)
-            if family is None or family not in ideal_reduce_only_families:
-                dropped_cancel += 1
-                continue
-        filtered_cancel.append(order)
-    return filtered_cancel, filtered_create, dropped_cancel + dropped_create, False
 
 
 def annotate_order_deltas(

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -348,6 +348,25 @@ def _trailing_bundle_default_dict() -> dict:
     return _trailing_bundle_tuple_to_dict(pbr.trailing_bundle_default_py())
 
 
+def _orchestrator_trailing_input(bot, symbol: str, pside: str) -> tuple[dict, bool]:
+    unavailable_psides = getattr(
+        bot, "_orchestrator_trailing_unavailable_psides", {}
+    ) or {}
+    available = pside not in set(unavailable_psides.get(symbol, []))
+    trailing = getattr(bot, "trailing_prices", {}).get(symbol, {}).get(pside)
+    if not trailing:
+        trailing = _trailing_bundle_default_dict()
+    return (
+        {
+            "min_since_open": float(trailing.get("min_since_open", 0.0)),
+            "max_since_min": float(trailing.get("max_since_min", 0.0)),
+            "max_since_open": float(trailing.get("max_since_open", 0.0)),
+            "min_since_max": float(trailing.get("min_since_max", 0.0)),
+        },
+        available,
+    )
+
+
 def _trailing_bundle_from_arrays(
     highs: np.ndarray, lows: np.ndarray, closes: np.ndarray
 ) -> dict:
@@ -9709,7 +9728,7 @@ class Passivbot:
                         )
                 logging.warning(
                     "[trailing] trailing state unavailable reason=%s symbols=%s "
-                    "action=mark_nontradable_until_fresh%s",
+                    "action=mark_trailing_branches_unavailable_until_fresh%s",
                     reason,
                     Passivbot._log_symbols(sorted(reason_symbols), limit=12),
                     confirmation_detail,
@@ -17063,10 +17082,6 @@ class Passivbot:
             "forager_m1_log_range_emas", m1_log_range_emas
         )
         h1_log_range_emas = snapshot["h1_log_range_emas"]
-        trailing_unavailable_symbols = set(
-            getattr(self, "_orchestrator_trailing_unavailable_symbols", set())
-        )
-
         unstuck_allowances = snapshot.get("unstuck_allowances", {"long": 0.0, "short": 0.0})
         auto_unstuck_allowed = bool(
             snapshot.get(
@@ -17169,23 +17184,17 @@ class Passivbot:
                 pos = self.positions.get(symbol, {}).get(
                     pside, {"size": 0.0, "price": 0.0}
                 )
-                trailing = self.trailing_prices.get(symbol, {}).get(pside)
-                if not trailing:
-                    trailing = _trailing_bundle_default_dict()
-                else:
-                    trailing = dict(trailing)
+                trailing, trailing_available = _orchestrator_trailing_input(
+                    self, symbol, pside
+                )
                 return {
                     "mode": mode,
                     "position": {
                         "size": float(pos["size"]),
                         "price": float(pos["price"]),
                     },
-                    "trailing": {
-                        "min_since_open": float(trailing.get("min_since_open", 0.0)),
-                        "max_since_min": float(trailing.get("max_since_min", 0.0)),
-                        "max_since_open": float(trailing.get("max_since_open", 0.0)),
-                        "min_since_max": float(trailing.get("min_since_max", 0.0)),
-                    },
+                    "trailing": trailing,
+                    "trailing_available": trailing_available,
                     "last_increase_fill_timestamp_ms": last_increase_fill_timestamps.get(symbol, {}).get(pside),
                     "bot_params": self._bot_params_to_rust_dict(pside, symbol),
                     "strategy_params": self._strategy_params_to_rust_dict(pside, symbol),
@@ -17217,11 +17226,7 @@ class Passivbot:
                     "symbol_idx": int(idx),
                     "order_book": {"bid": mprice, "ask": mprice},
                     "exchange": Passivbot._orchestrator_exchange_params(self, symbol),
-                    "tradable": bool(
-                        active
-                        and symbol not in trailing_unavailable_symbols
-                        and not exchange_cooldown_blocks_symbol
-                    ),
+                    "tradable": bool(active and not exchange_cooldown_blocks_symbol),
                     "next_candle": None,
                     "effective_min_cost": float(effective_min_cost),
                     "emas": {
@@ -19659,7 +19664,6 @@ class Passivbot:
         trailing_unavailable_symbols = set(
             getattr(self, "_orchestrator_trailing_unavailable_symbols", set())
         )
-
         market_snapshots = await self._get_orchestrator_market_snapshots(symbols)
         self._assert_staged_planner_preconditions(
             include_market_snapshot=True,
@@ -19758,7 +19762,6 @@ class Passivbot:
             tradable = bool(
                 active
                 and symbol not in ema_unavailable_symbols
-                and symbol not in trailing_unavailable_symbols
                 and not exchange_cooldown_blocks_symbol
             )
             effective_min_cost = float(self.effective_min_cost.get(symbol, 0.0) or 0.0)
@@ -19774,23 +19777,17 @@ class Passivbot:
                 pos = self.positions.get(symbol, {}).get(
                     pside, {"size": 0.0, "price": 0.0}
                 )
-                trailing = self.trailing_prices.get(symbol, {}).get(pside)
-                if not trailing:
-                    trailing = _trailing_bundle_default_dict()
-                else:
-                    trailing = dict(trailing)
+                trailing, trailing_available = _orchestrator_trailing_input(
+                    self, symbol, pside
+                )
                 return {
                     "mode": mode,
                     "position": {
                         "size": float(pos["size"]),
                         "price": float(pos["price"]),
                     },
-                    "trailing": {
-                        "min_since_open": float(trailing.get("min_since_open", 0.0)),
-                        "max_since_min": float(trailing.get("max_since_min", 0.0)),
-                        "max_since_open": float(trailing.get("max_since_open", 0.0)),
-                        "min_since_max": float(trailing.get("min_since_max", 0.0)),
-                    },
+                    "trailing": trailing,
+                    "trailing_available": trailing_available,
                     "last_increase_fill_timestamp_ms": last_increase_fill_timestamps.get(symbol, {}).get(pside),
                     "bot_params": self._bot_params_to_rust_dict(pside, symbol),
                     "strategy_params": self._strategy_params_to_rust_dict(pside, symbol),

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -377,6 +377,135 @@ def test_json_rejects_missing_ema():
         compute(pbr, inp)
 
 
+def test_trailing_unavailable_does_not_hide_malformed_bundle():
+    import passivbot_rust as pbr
+
+    symbol = make_symbol(0, bid=100.0, ask=100.0)
+    symbol["long"]["trailing_available"] = False
+    del symbol["long"]["trailing"]["max_since_open"]
+    inp = make_input(balance=1_000.0, symbols=[symbol])
+
+    with pytest.raises(ValueError, match="missing field `max_since_open`"):
+        compute(pbr, inp)
+
+
+def test_live_missing_entry_trailing_preserves_close_and_other_side():
+    import passivbot_rust as pbr
+
+    enabled_short = {"n_positions": 1, "total_wallet_exposure_limit": 1.0}
+    strategy = adaptive_strategy_params(
+        entry={"retracement_base_pct": 0.01},
+        close={"retracement_base_pct": 0.0},
+    )
+    symbol = make_symbol(
+        0,
+        bid=100.0,
+        ask=100.0,
+        long_pos_size=1.0,
+        long_pos_price=100.0,
+        short_pos_size=-1.0,
+        short_pos_price=100.0,
+        short_bp=enabled_short,
+        long_strategy=strategy,
+        short_strategy=strategy,
+    )
+    symbol["long"]["trailing_available"] = False
+    inp = make_input(
+        balance=1_000.0,
+        global_bp=bot_params_pair(short_overrides=enabled_short),
+        symbols=[symbol],
+    )
+    inp["global"]["hedge_mode"] = True
+
+    out = compute(pbr, inp)
+
+    assert not any(
+        order["pside"] == "long" and order["order_type"].startswith("entry_")
+        for order in out["orders"]
+    )
+    assert any(
+        order["pside"] == "long" and order["order_type"].startswith("close_")
+        for order in out["orders"]
+    )
+    assert any(order["pside"] == "short" for order in out["orders"])
+    assert {
+        "strategy_input_unavailable": {
+            "symbol_idx": 0,
+            "pside": "long",
+            "scope": "strategy_orders",
+        }
+    } in out["diagnostics"]["warnings"]
+
+
+def test_live_missing_close_trailing_still_emits_wel_reducer():
+    import passivbot_rust as pbr
+
+    long_bp = {
+        "wallet_exposure_limit": 0.4,
+        "risk_wel_enforcer_threshold": 1.0,
+        "risk_twel_enforcer_enabled": False,
+        "total_wallet_exposure_limit": 1.0,
+        "n_positions": 1,
+    }
+    strategy = adaptive_strategy_params(
+        entry={"retracement_base_pct": 0.0},
+        close={"retracement_base_pct": 0.01},
+    )
+    symbol = make_symbol(
+        0,
+        bid=100.0,
+        ask=100.0,
+        long_pos_size=6.0,
+        long_pos_price=100.0,
+        long_bp=long_bp,
+        long_strategy=strategy,
+    )
+    symbol["long"]["trailing_available"] = False
+    inp = make_input(
+        balance=1_000.0,
+        global_bp=bot_params_pair(long_overrides=long_bp),
+        symbols=[symbol],
+    )
+    inp["global"]["hedge_mode"] = True
+
+    out = compute(pbr, inp)
+
+    assert any(
+        order["order_type"] == "close_auto_reduce_wel_long"
+        for order in out["orders"]
+    )
+    assert not any(
+        order["pside"] == "long"
+        and order["order_type"] in {"close_grid_long", "close_trailing_long"}
+        for order in out["orders"]
+    )
+
+
+def test_trailing_unavailable_is_inert_when_strategy_does_not_consume_it():
+    import passivbot_rust as pbr
+
+    symbol = make_symbol(
+        0,
+        bid=100.0,
+        ask=100.0,
+        long_pos_size=1.0,
+        long_pos_price=100.0,
+    )
+    symbol["long"]["trailing_available"] = False
+    inp = make_input(balance=1_000.0, symbols=[symbol])
+    available_inp = copy.deepcopy(inp)
+    available_inp["symbols"][0]["long"]["trailing_available"] = True
+
+    out = compute(pbr, inp)
+    available_out = compute(pbr, available_inp)
+
+    assert out["orders"] == available_out["orders"]
+    assert not any(
+        "strategy_input_unavailable" in warning
+        for warning in out["diagnostics"]["warnings"]
+    )
+
+
 def test_live_authorized_missing_entry_ema_preserves_independent_closes():
     import passivbot_rust as pbr
 

--- a/tests/test_order_orchestration.py
+++ b/tests/test_order_orchestration.py
@@ -408,21 +408,23 @@ async def test_calc_orders_to_cancel_and_create_reconciles_orders(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_calc_orders_preserves_orders_when_trailing_anchor_unavailable():
+async def test_calc_orders_obeys_rust_ideal_when_trailing_anchor_unavailable():
     symbol = "BTC/USDT"
     bot = OrchestrationBot({symbol: 100.0})
     bot.register_symbol(symbol)
     bot._orchestrator_trailing_unavailable_symbols = {symbol}
 
     bot.open_orders[symbol] = [
-        {
-            "symbol": symbol,
-            "side": "sell",
-            "position_side": "long",
-            "qty": 1.0,
-            "price": 101.0,
-            "custom_id": "order-0x0004",
-        }
+        _make_order(
+            symbol,
+            "sell",
+            "long",
+            1.0,
+            101.0,
+            "close_grid_long",
+            reduce_only=True,
+            exchange_id="stale-close-long",
+        )
     ]
 
     async def fake_calc_ideal_orders(self):
@@ -444,8 +446,12 @@ async def test_calc_orders_preserves_orders_when_trailing_anchor_unavailable():
 
     to_cancel, to_create = await bot.calc_orders_to_cancel_and_create()
 
-    assert to_cancel == []
-    assert to_create == []
+    assert [(order["position_side"], order["price"]) for order in to_cancel] == [
+        ("long", 101.0)
+    ]
+    assert [(order["position_side"], order["price"]) for order in to_create] == [
+        ("long", 103.0)
+    ]
 
 
 @pytest.mark.asyncio
@@ -1082,62 +1088,6 @@ async def test_coin_red_supervisor_refreshes_late_cooldown_repanic_fill():
 
 
 @pytest.mark.asyncio
-async def test_calc_orders_blocks_entry_creates_when_trailing_candles_pending():
-    symbol = "BTC/USDT"
-    bot = OrchestrationBot({symbol: 100.0})
-    bot.register_symbol(symbol)
-    bot._orchestrator_trailing_unavailable_symbols = {symbol}
-    bot._orchestrator_trailing_unavailable_reasons = {
-        symbol: ["missing_trailing_candles"]
-    }
-
-    bot.open_orders[symbol] = [
-        _make_order(
-            symbol,
-            "buy",
-            "long",
-            1.0,
-            99.0,
-            "entry_grid_normal_long",
-            exchange_id="pending-entry-long",
-        ),
-        _make_order(
-            symbol,
-            "sell",
-            "long",
-            1.0,
-            101.0,
-            "close_grid_long",
-            reduce_only=True,
-            exchange_id="pending-close-long",
-        ),
-    ]
-
-    async def fake_calc_ideal_orders(self):
-        return {
-            symbol: [
-                _make_order(
-                    symbol,
-                    "buy",
-                    "long",
-                    1.0,
-                    98.0,
-                    "entry_grid_normal_long",
-                )
-            ]
-        }
-
-    bot.calc_ideal_orders = types.MethodType(fake_calc_ideal_orders, bot)
-
-    to_cancel, to_create = await bot.calc_orders_to_cancel_and_create()
-
-    assert [(order["side"], order["position_side"], order["price"]) for order in to_cancel] == [
-        ("buy", "long", 99.0)
-    ]
-    assert to_create == []
-
-
-@pytest.mark.asyncio
 async def test_calc_orders_retires_stale_trailing_close_when_trailing_candles_pending():
     symbol = "BTC/USDT"
     bot = OrchestrationBot({symbol: 100.0})
@@ -1183,83 +1133,6 @@ async def test_calc_orders_retires_stale_trailing_close_when_trailing_candles_pe
         "close_trailing_long"
     ]
     assert [order["pb_order_type"] for order in to_create] == ["close_grid_long"]
-
-
-@pytest.mark.asyncio
-async def test_calc_orders_blocks_new_trailing_close_when_trailing_candles_pending():
-    symbol = "BTC/USDT"
-    bot = OrchestrationBot({symbol: 100.0})
-    bot.register_symbol(symbol)
-    bot._orchestrator_trailing_unavailable_symbols = {symbol}
-    bot._orchestrator_trailing_unavailable_reasons = {
-        symbol: ["missing_trailing_candles"]
-    }
-    bot._orchestrator_trailing_unavailable_psides = {symbol: ["long"]}
-
-    async def fake_calc_ideal_orders(self):
-        return {
-            symbol: [
-                _make_order(
-                    symbol,
-                    "sell",
-                    "long",
-                    1.0,
-                    99.0,
-                    "close_trailing_long",
-                    reduce_only=True,
-                )
-            ]
-        }
-
-    bot.calc_ideal_orders = types.MethodType(fake_calc_ideal_orders, bot)
-
-    to_cancel, to_create = await bot.calc_orders_to_cancel_and_create()
-
-    assert to_cancel == []
-    assert to_create == []
-
-
-@pytest.mark.asyncio
-async def test_calc_orders_trailing_unavailable_is_position_side_scoped():
-    symbol = "BTC/USDT"
-    bot = OrchestrationBot({symbol: 100.0})
-    bot.register_symbol(symbol)
-    bot._orchestrator_trailing_unavailable_symbols = {symbol}
-    bot._orchestrator_trailing_unavailable_reasons = {
-        symbol: ["missing_trailing_candles"]
-    }
-    bot._orchestrator_trailing_unavailable_psides = {symbol: ["long"]}
-
-    async def fake_calc_ideal_orders(self):
-        return {
-            symbol: [
-                _make_order(
-                    symbol,
-                    "sell",
-                    "long",
-                    1.0,
-                    99.0,
-                    "close_trailing_long",
-                    reduce_only=True,
-                ),
-                _make_order(
-                    symbol,
-                    "buy",
-                    "short",
-                    1.0,
-                    101.0,
-                    "close_trailing_short",
-                    reduce_only=True,
-                ),
-            ]
-        }
-
-    bot.calc_ideal_orders = types.MethodType(fake_calc_ideal_orders, bot)
-
-    to_cancel, to_create = await bot.calc_orders_to_cancel_and_create()
-
-    assert to_cancel == []
-    assert [order["pb_order_type"] for order in to_create] == ["close_trailing_short"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -3012,7 +3012,7 @@ async def test_trailing_extrema_accept_dense_zero_volume_gap_continuity():
 
 
 @pytest.mark.asyncio
-async def test_orchestrator_marks_trailing_unavailable_symbols_non_tradable(monkeypatch):
+async def test_orchestrator_passes_trailing_unavailability_to_rust_per_side(monkeypatch):
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
     symbol = _set_basic_state(bot)
@@ -3037,6 +3037,7 @@ async def test_orchestrator_marks_trailing_unavailable_symbols_non_tradable(monk
         }
     }
     bot._orchestrator_trailing_unavailable_symbols = {symbol}
+    bot._orchestrator_trailing_unavailable_psides = {symbol: ["long"]}
 
     async def fake_load_bundle(self, symbols, modes):
         m1_close = {symbol: {1.0: 100.0, 2.0: 100.0}}
@@ -3060,7 +3061,10 @@ async def test_orchestrator_marks_trailing_unavailable_symbols_non_tradable(monk
 
     await bot.calc_ideal_orders_orchestrator()
 
-    assert captured["input"]["symbols"][0]["tradable"] is False
+    rust_symbol = captured["input"]["symbols"][0]
+    assert rust_symbol["tradable"] is True
+    assert rust_symbol["long"]["trailing_available"] is False
+    assert rust_symbol["short"]["trailing_available"] is True
 
 
 def _stamp_staged_account_and_candles(bot):


### PR DESCRIPTION
## Summary

- represent live trailing readiness as a side-scoped Rust planning input
- suppress only entry or close requests whose active strategy consumes unavailable trailing extrema
- keep the other branch, other position side, panic, WEL, and TWEL paths independent
- delete the Python post-reconciliation exception matrix so current Rust ideal orders remain authoritative
- retain strict structural validation for supplied trailing bundles

The production and regression diff is net-negative: 291 insertions and 348 deletions, including removal of 149 reconciler lines.

## Validation

- cargo test --manifest-path passivbot-rust/Cargo.toml --no-default-features (226 passed)
- cargo check --manifest-path passivbot-rust/Cargo.toml --tests
- cargo fmt --manifest-path passivbot-rust/Cargo.toml -- --check
- rebuilt and verified the real Python extension; source fingerprint matched
- affected orchestrator, EMA-readiness, reconciliation, restart, unstuck, fresh-entry, and offline fake-live suites (486 passed)
- src/tools/check_ai_docs.py (0 errors; existing size warnings only)
- tests/test_ai_docs.py (3 passed)
- Python compile checks and git diff --check