### PR TITLE
Use historical candle ladder for trailing restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Reconstruct trailing extrema for positions older than an exchange's retained 1m candles with
+  the shared 1m, 5m, 15m, then 1h historical-resolution ladder. Coarser candles are limited to
+  the old leading prefix, their source counts and exact-1m boundary are logged, and a real recent
+  1m suffix remains mandatory; missing or internally sparse recent data still makes only the
+  affected trailing input unavailable.
 - Move live trailing-input availability into Rust's side-scoped planning contract. Missing
   trailing extrema now suppress only entry or close branches that actually consume them while the
   other branch, other position side, panic, and independent reducers remain available. Remove the

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -210,13 +210,21 @@
    bulk backtest-data download.
 10. Native higher-timeframe EMA windows require full requested coverage on every exchange. WEEX
     additionally requires exact aligned coverage for 1m EMA windows because its recent endpoint
-    silently tail-anchors responses. Exchange-independent trailing-extrema and HSL replay-cache
-    extension consumers also require exact aligned coverage; incomplete windows become unavailable
-    or fall back to authoritative replay. HSL restart reconstruction is the narrow exception: it
-    fetches 1m candles first, then may cover only the older leading prefix with 5m, 15m, and 1h
-    candles. The finest available source wins, source counts remain visible, and only coarse
-    buckets ending at or before the first available 1m candle are eligible, so later price action
-    cannot leak backward across the precision boundary.
+    silently tail-anchors responses. Exchange-independent HSL replay-cache extension consumers
+    require exact aligned coverage or authoritative replay. HSL restart and live trailing restart
+    reconstruction may instead fetch 1m candles first, then cover only the older leading prefix
+    with 5m, 15m, and 1h candles. The finest available source wins, source counts remain visible,
+    and only coarse buckets ending at or before the first available 1m candle are eligible, so
+    later price action cannot leak backward across the precision boundary.
+
+    Trailing still requires a nonempty exact 1m suffix and its existing dense post-fill coverage
+    and bounded open-tail checks. The first post-fill minute remains the exact reset boundary;
+    deterministic expansion may clip the beginning of a coarse bucket there but never emits an
+    earlier timestamp. Coarse OHLC preserves the old prefix's highs and lows, while the dependent
+    `min_since_max` and `max_since_min` values are explicitly approximate because a higher-timeframe
+    candle cannot prove whether its high or low occurred first. Failure to obtain the exact suffix
+    keeps the affected position side unavailable rather than treating an entirely coarse window as
+    current trailing state.
 11. Quote-volume EMA is derived from normalized CCXT base volume and typical price
     (`base_volume * (high + low + close) / 3`). It is an approximation when an exchange, including
     WEEX, does not expose raw quote turnover through unified OHLCV.

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -7464,6 +7464,60 @@ class CandlestickManager:
             }
         )
 
+    async def get_candles_with_resolution_ladder(
+        self,
+        symbol: str,
+        *,
+        start_ts: int,
+        end_ts: Optional[int] = None,
+        strict: bool = False,
+    ) -> CandleResolutionResult:
+        """Return exact recent 1m candles with a coarser historical prefix.
+
+        Higher-timeframe candles are read through the same manager and may only
+        fill complete buckets ending inside the requested old-history prefix.
+        Callers remain responsible for requiring an exact recent 1m suffix when
+        their decision contract needs one.
+        """
+        self._raise_if_shutdown_requested("get_candles_with_resolution_ladder")
+        now = self._now_ms()
+        latest_finalized = _floor_minute(now) - ONE_MIN_MS
+        effective_end = (
+            latest_finalized
+            if end_ts is None
+            else min(_floor_minute(int(end_ts)), latest_finalized)
+        )
+        effective_start = _floor_minute(int(start_ts))
+        if effective_end < effective_start:
+            return CandleResolutionResult(
+                candles=np.empty((0,), dtype=CANDLE_DTYPE),
+                source_counts={},
+                failures={},
+            )
+
+        exchange_timeframes = getattr(self.exchange, "timeframes", None)
+        supported_timeframes = (
+            set(exchange_timeframes)
+            if isinstance(exchange_timeframes, dict) and exchange_timeframes
+            else None
+        )
+
+        async def fetch_resolution(*, timeframe: str, start_ts: int, end_ts: int):
+            return await self.get_candles(
+                symbol,
+                start_ts=start_ts,
+                end_ts=end_ts,
+                strict=strict,
+                timeframe=None if timeframe == "1m" else timeframe,
+            )
+
+        return await fetch_candles_with_resolution_ladder(
+            fetch_resolution,
+            start_ts=effective_start,
+            end_ts=effective_end,
+            supported_timeframes=supported_timeframes,
+        )
+
     async def get_candles(
         self,
         symbol: str,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -9559,7 +9559,7 @@ class Passivbot:
                 continue
             # Determine earliest start among sides to avoid duplicate fetches
             starts = [
-                pside_changes[pside]
+                (int(pside_changes[pside]) // ONE_MIN_MS + 1) * ONE_MIN_MS
                 for pside in pside_changes
                 if pside in required_trailing[symbol]
             ]
@@ -9570,7 +9570,9 @@ class Passivbot:
 
         tasks = {
             sym: asyncio.create_task(
-                self.cm.get_candles(sym, start_ts=st, end_ts=None, strict=False)
+                self.cm.get_candles_with_resolution_ladder(
+                    sym, start_ts=st, end_ts=None, strict=False
+                )
             )
             for sym, st in fetch_plan.items()
         }
@@ -9578,7 +9580,22 @@ class Passivbot:
         results = {}
         for sym, task in tasks.items():
             try:
-                results[sym] = await task
+                result = await task
+                if int(result.source_counts.get("1m", 0)) <= 0:
+                    if "1m" in result.failures:
+                        unavailable_reasons["candle_fetch_failed"].add(sym)
+                        logging.debug(
+                            "[trailing] exact candle fetch failed | symbol=%s "
+                            "reason=candle_fetch_failed action=mark_unavailable error_type=%s",
+                            Passivbot._log_symbol(sym),
+                            bounded_exception_type(result.failures["1m"]),
+                        )
+                    else:
+                        unavailable_reasons["missing_exact_trailing_candles"].add(sym)
+                    unavailable_psides[sym].update(required_trailing.get(sym, set()))
+                    results[sym] = None
+                    continue
+                results[sym] = result
             except Exception as e:
                 unavailable_reasons["candle_fetch_failed"].add(sym)
                 unavailable_psides[sym].update(required_trailing.get(sym, set()))
@@ -9590,13 +9607,40 @@ class Passivbot:
                 results[sym] = None
 
         # Compute trailing metrics per symbol/side
-        for symbol, arr in results.items():
-            if arr is None:
+        previous_resolution_contexts = dict(
+            getattr(self, "_trailing_historical_resolution_contexts", {}) or {}
+        )
+        current_resolution_contexts = {}
+        for symbol, result in results.items():
+            if result is None:
                 continue
+            arr = result.candles
             if arr.size == 0:
                 unavailable_reasons["missing_trailing_candles"].add(symbol)
                 unavailable_psides[symbol].update(required_trailing.get(symbol, set()))
                 continue
+            approximate_sources = {
+                timeframe: int(count)
+                for timeframe, count in result.source_counts.items()
+                if timeframe != "1m" and int(count) > 0
+            }
+            if approximate_sources:
+                approximate_count = sum(approximate_sources.values())
+                context = {
+                    "source_counts": approximate_sources,
+                    "approximate_until_ts": int(arr[approximate_count - 1]["ts"]),
+                    "exact_from_ts": int(arr[approximate_count]["ts"]),
+                }
+                current_resolution_contexts[symbol] = context
+                if previous_resolution_contexts.get(symbol) != context:
+                    logging.info(
+                        "[trailing] using approximate old candle prefix | symbol=%s "
+                        "sources=%s approximate_until_ts=%d exact_from_ts=%d",
+                        Passivbot._log_symbol(symbol),
+                        approximate_sources,
+                        context["approximate_until_ts"],
+                        context["exact_from_ts"],
+                    )
             if symbol not in last_position_changes:
                 continue
             arr = np.sort(arr, order="ts")
@@ -9657,6 +9701,7 @@ class Passivbot:
                         e,
                     )
 
+        self._trailing_historical_resolution_contexts = current_resolution_contexts
         unavailable_symbols = set()
         unavailable_by_symbol: dict[str, list[str]] = defaultdict(list)
         warning_signature_parts = [

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -124,6 +124,33 @@ async def test_resolution_ladder_rejects_coarse_bucket_crossing_1m_boundary():
 
 
 @pytest.mark.asyncio
+async def test_manager_resolution_ladder_reuses_canonical_candle_reads(tmp_path):
+    manager = CandlestickManager(exchange=None, cache_dir=str(tmp_path))
+    manager._now_ms_callback = lambda: 13 * ONE_MIN_MS
+    calls = []
+
+    async def fake_get_candles(
+        symbol, *, start_ts, end_ts, strict, timeframe=None, **_kwargs
+    ):
+        calls.append((symbol, timeframe or "1m", start_ts, end_ts, strict))
+        if timeframe is None:
+            return _resolution_candles(10, 11)
+        if timeframe == "5m":
+            return _resolution_candles(0, 5, close_offset=500.0)
+        return _resolution_candles()
+
+    manager.get_candles = fake_get_candles
+
+    result = await manager.get_candles_with_resolution_ladder(
+        "TEST/USDT", start_ts=0, end_ts=11 * ONE_MIN_MS, strict=False
+    )
+
+    assert [call[1] for call in calls] == ["1m", "5m"]
+    assert result.source_counts == {"5m": 10, "1m": 2}
+    assert result.candles.size == 12
+
+
+@pytest.mark.asyncio
 async def test_resolution_ladder_uses_finer_sources_before_one_hour():
     calls = []
 

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -766,6 +766,24 @@ def _make_dummy_bot(config, *, last_price=100.0):
                 },
             )
 
+            async def _get_candles_with_resolution_ladder(
+                symbol, *, start_ts, end_ts=None, strict=False
+            ):
+                from candlestick_manager import CandleResolutionResult
+
+                candles = await self.cm.get_candles(
+                    symbol, start_ts=start_ts, end_ts=end_ts, strict=strict
+                )
+                return CandleResolutionResult(
+                    candles=candles,
+                    source_counts={"1m": int(candles.size)} if candles.size else {},
+                    failures={},
+                )
+
+            self.cm.get_candles_with_resolution_ladder = (
+                _get_candles_with_resolution_ladder
+            )
+
         def bp(self, pside: str, key: str, symbol: str | None = None):
             return self._bp_defaults.get(key, 0.0)
 
@@ -1453,7 +1471,7 @@ async def test_trailing_anchor_uses_position_timestamp_when_fill_history_is_out_
 
     await bot.update_trailing_data()
 
-    assert candle_calls == [(symbol, 120_000, None, False)]
+    assert candle_calls == [(symbol, 180_000, None, False)]
     assert bot._orchestrator_trailing_unavailable_symbols == set()
     assert bot.trailing_prices[symbol]["long"]["max_since_open"] == pytest.approx(101.0)
 
@@ -2890,6 +2908,88 @@ async def test_trailing_extrema_reject_incomplete_post_fill_coverage(rows):
     assert bot.trailing_prices[symbol]["long"] == _trailing_default()
     assert bot._orchestrator_trailing_unavailable_reasons == {
         symbol: ["incomplete_trailing_candle_coverage"]
+    }
+
+
+@pytest.mark.asyncio
+async def test_trailing_extrema_accepts_coarse_old_prefix_with_exact_1m_suffix(caplog):
+    from candlestick_manager import CandleResolutionResult
+
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    bot._pnls_manager = _DummyPnlsManager(
+        [_DummyFillEvent(symbol, "long", 120_000, "fill-1")]
+    )
+    bot.is_trailing = lambda sym, pside=None: pside == "long"
+    bot.get_exchange_time = lambda: 361_000
+    requested = []
+
+    async def mixed_resolution_candles(sym, *, start_ts, end_ts=None, strict=False):
+        requested.append((sym, start_ts, end_ts, strict))
+        return CandleResolutionResult(
+            candles=_make_candles(
+                [
+                    (180_000, 100.0, 101.0, 99.0, 100.0, 1.0),
+                    (240_000, 100.0, 102.0, 98.0, 101.0, 1.0),
+                    (300_000, 101.0, 103.0, 100.0, 102.0, 1.0),
+                ]
+            ),
+            source_counts={"5m": 2, "1m": 1},
+            failures={},
+        )
+
+    bot.cm.get_candles_with_resolution_ladder = mixed_resolution_candles
+    caplog.set_level(logging.INFO)
+
+    await bot.update_trailing_data()
+
+    assert requested == [(symbol, 180_000, None, False)]
+    assert bot._orchestrator_trailing_unavailable_symbols == set()
+    assert bot.trailing_prices[symbol]["long"]["max_since_open"] == pytest.approx(103.0)
+    assert bot._trailing_historical_resolution_contexts == {
+        symbol: {
+            "source_counts": {"5m": 2},
+            "approximate_until_ts": 240_000,
+            "exact_from_ts": 300_000,
+        }
+    }
+    assert "using approximate old candle prefix" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_trailing_extrema_rejects_coarse_history_without_exact_1m_suffix():
+    from candlestick_manager import CandleResolutionResult
+
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    bot._pnls_manager = _DummyPnlsManager(
+        [_DummyFillEvent(symbol, "long", 120_000, "fill-1")]
+    )
+    bot.is_trailing = lambda sym, pside=None: pside == "long"
+    bot.get_exchange_time = lambda: 361_000
+
+    async def coarse_only(*_args, **_kwargs):
+        return CandleResolutionResult(
+            candles=_make_candles(
+                [
+                    (180_000, 100.0, 101.0, 99.0, 100.0, 1.0),
+                    (240_000, 100.0, 102.0, 98.0, 101.0, 1.0),
+                    (300_000, 101.0, 103.0, 100.0, 102.0, 1.0),
+                ]
+            ),
+            source_counts={"5m": 3},
+            failures={},
+        )
+
+    bot.cm.get_candles_with_resolution_ladder = coarse_only
+
+    await bot.update_trailing_data()
+
+    assert bot.trailing_prices[symbol]["long"] == _trailing_default()
+    assert bot._orchestrator_trailing_unavailable_reasons == {
+        symbol: ["missing_exact_trailing_candles"]
     }
 
 


### PR DESCRIPTION
## Summary

- add a CandlestickManager entry point that reuses the shared 1m -> 5m -> 15m -> 1h historical-resolution ladder through canonical candle reads
- use that path when reconstructing live trailing extrema after restart
- require a nonempty exact recent 1m suffix and retain existing dense post-fill and bounded open-tail checks
- expose coarse source counts and the exact/coarse boundary in transition-only logging
- document the deliberately approximate old-history contract

## Why

A position may remain open longer than an exchange retains 1m candles. The previous trailing path requested exact 1m history only, so restart reconstruction could remain unavailable even when sufficient older 5m, 15m, or 1h history existed.

The ladder is limited to the old leading prefix. It never patches a gap inside the available 1m era, and an entirely coarse window is rejected. Rust remains authoritative for the resulting side-scoped trailing availability and ideal orders.

Higher-timeframe OHLC cannot prove whether its high or low occurred first. Global old-prefix highs and lows are preserved, while min_since_max and max_since_min are explicitly approximate when their decisive extrema share one coarse bucket. This is confined to history older than the exact 1m boundary.

## Experiment

A local offline differential run compared exact 1m trailing bundles with a simulated Hyperliquid-style 30-day ladder: newest 5,000 minutes exact, preceding history from up to 5,000 5m buckets, then 15m. All four final bundle fields matched exactly across 30 representative random-walk, trend, wick, and jump samples.

An adversarial path placing the decisive high and low in one old 15m bucket confirmed the documented ordering ambiguity in the two dependent extrema. The implementation does not add heuristics or configurable tolerances for that unknowable path.

## Validation

- `python -m py_compile src/candlestick_manager.py src/passivbot.py tests/test_candlestick_manager.py tests/test_unstucking_safeguards.py`
- `pytest tests/test_candlestick_manager.py -q`
- `pytest tests/test_unstucking_safeguards.py -q`
- `pytest tests/test_order_orchestration.py tests/test_orchestrator_integration.py -q`
- `pytest tests/test_run_fake_live.py -m fake_live -q`
- `PYTHONPATH=src python src/tools/check_ai_docs.py`
- `PYTHONPATH=src python src/tools/generate_live_event_registry.py --check`
- `pytest tests/test_ai_docs.py tests/test_live_event_registry_docs.py -q`
- `git diff --check`
