### PR TITLE
Simplify fill history coverage evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Stop inferring missing fill history from long periods without executions. Fill lookback
+  coverage is now proven by successful exchange-endpoint traversal; only actual failed bounded
+  fetches create unproven ranges, which remain retryable under the live execution loop's backoff
+  until a successful response (including an empty response) clears them.
 - Reconstruct trailing extrema for positions older than an exchange's retained 1m candles with
   the shared 1m, 5m, 15m, then 1h historical-resolution ladder. Coarser candles are limited to
   the old leading prefix, their source counts and exact-1m boundary are logged, and a real recent

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -77,7 +77,11 @@
     claiming cached rows when no rows loaded, and malformed known-gap bounds, are
     contradictory cache evidence: they are unavailable rather than proof of
     coverage. A window with no fills remains valid when zero oldest/newest metadata
-    and `covered_start_ms` prove that empty result.
+    and `covered_start_ms` prove that empty result. Fill spacing is never gap
+    evidence because executions are irregular. Only a failed bounded exchange
+    fetch records an unproven range; every such range remains retryable under the
+    execution loop's backoff regardless of attempt count, and a successful bounded
+    traversal clears it even when the response contains no fills.
 12. Live coverage requirements follow the enabled consumer. Realized-PnL risk
     features require the configured PnL lookback and authoritative PnL quality.
     Entry cooldown without a PnL consumer requires structural fill coverage only
@@ -169,11 +173,12 @@ quarantine, rebuild, or defer according to `../error_contract.md`; it must not a
 merely because an auxiliary endpoint failed.
 
 Unproven required coverage is a controlled live-planning deferral. The execution loop owns its
-bounded, reason-aware retry cadence, and persistent coverage gaps do not consume the generic
-process-restart budget. A change between coverage and PnL block reasons restarts that reason's
-backoff at its configured base. Already-latched HSL RED supervisors continue protective management
-without fills while coverage repair proceeds. Manager-owned known-gap state remains evidence about
-coverage, not a second orchestration timer.
+bounded, reason-aware retry cadence, and failed coverage ranges do not consume the generic
+process-restart budget or become terminal after an independent manager retry limit. A change
+between coverage and PnL block reasons restarts that reason's backoff at its configured base.
+Already-latched HSL RED supervisors continue protective management without fills while coverage
+repair proceeds. Manager-owned failed-range state remains evidence about coverage, not a second
+orchestration timer.
 
 ## Validation
 
@@ -186,9 +191,10 @@ coverage, not a second orchestration timer.
    authoritative-PnL consumer requires it, authoritative replacement is persisted, and
    unresolved rows defer those consumers without restarts. With every PnL consumer
    disabled, unresolved PnL does not block covered structural fill history.
-6. Coverage verdicts fail closed for contradictory metadata and malformed gaps,
-   while confirmed-legitimate gaps and proven empty windows retain their explicit
-   semantics.
+6. Coverage verdicts fail closed for contradictory metadata and malformed failed
+   ranges. Failed bounded fetches remain retryable, successful empty traversals
+   prove their ranges, fill spacing creates no gap, and legacy
+   confirmed-legitimate metadata retains its explicit semantics.
 
 ## Key Code
 

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -21,9 +21,10 @@
    or caused the exchange fill. Refresh and deduplication preserve an existing
    provenance record, including the absence of provenance on legacy cache rows.
    Historical rows are never retroactively attributed.
-8. `last_refresh_ms` records a completed exchange fetch, not local cache loading,
-   normalization, or doctor repair. Preserving that distinction ensures the first
-   incremental refresh after restart covers fills which occurred while the bot was
+8. `last_refresh_ms` records a completed tail-capable exchange fetch, not local cache
+   loading, normalization, doctor repair, or a bounded historical range repair.
+   Preserving that distinction ensures the next incremental refresh covers fills
+   after a repaired historical range and fills which occurred while the bot was
    offline.
 9. A position whose latest fill identity or reconstructed after-state does not
    match the authoritative exchange position remains nontradable. Live orchestration

--- a/docs/fill_events_manager_spec.md
+++ b/docs/fill_events_manager_spec.md
@@ -336,40 +336,29 @@ raw = [
 
 ---
 
-## 11. Cache Self-Healing & Gap Detection
+## 11. Cache Coverage And Failed Ranges
 
-### Gap Classification Challenge
+Fill timestamps are irregular. Time between two fills is therefore not evidence
+of missing history and must not trigger a speculative refetch. Coverage comes
+from successful traversal of the exchange endpoint over the requested interval,
+including a successful response containing no fills.
 
-Unlike candlesticks (predictable 60-second intervals), fill events have irregular timing. A gap could be:
-- **Legitimate:** Bot was stopped, no trading occurred
-- **Illegitimate:** Data fetch failed, events are missing
-
-### Gap Detection Heuristics
-
-1. **Time threshold:** Gaps > 12 hours trigger investigation
-2. **Position discontinuity:** Position size jumps without fills → suspicious
-3. **PnL discontinuity:** Wallet balance change without recorded PnL → suspicious
-
-### Gap Metadata
+Only an actual failed bounded fetch creates an unproven range:
 
 ```python
 class KnownGap(TypedDict):
     start_ts: int           # Gap start timestamp (ms)
     end_ts: int             # Gap end timestamp (ms)
-    retry_count: int        # Fetch attempts (max 3)
-    reason: str             # auto_detected, fetch_failed, confirmed_legitimate, manual
+    retry_count: int        # Diagnostic fetch-attempt count
+    reason: str             # fetch_failed
     added_at: int           # When gap was first detected
-    confidence: float       # 0.0=unknown, 0.3=suspicious, 0.7=likely_ok, 1.0=confirmed
 ```
 
-### Gap Handling Strategy
-
-1. **Initial detection:** Mark with `confidence=0.0`, `retry_count=0`
-2. **Retry logic:** Up to 3 attempts with exponential backoff
-3. **Classification:** After retries:
-   - No new fills found → increase confidence toward legitimate
-   - New fills found → gap was real, filled successfully
-4. **Persistence:** After max retries, mark as known gap to avoid repeated fetches
+The execution loop owns retry timing. Failed ranges remain retryable under that
+bounded backoff regardless of prior attempt count; the fill manager does not
+create a second terminal retry state. A successful bounded fetch clears the
+range even when it returns no fills. Legacy `confirmed_legitimate` metadata
+remains readable but is no longer produced.
 
 ### Gap Metadata Storage
 
@@ -384,9 +373,8 @@ Add `metadata.json` to cache directory:
       "start_ts": 1705200000000,
       "end_ts": 1705250000000,
       "retry_count": 3,
-      "reason": "confirmed_legitimate",
-      "added_at": 1705300000000,
-      "confidence": 0.9
+      "reason": "fetch_failed",
+      "added_at": 1705300000000
     }
   ]
 }

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -1891,20 +1891,11 @@ def _is_close_payload(payload: Dict[str, object]) -> bool:
 # Cache
 # ---------------------------------------------------------------------------
 
-# Maximum retry attempts before marking gap as persistent
-_GAP_MAX_RETRIES = 3
-
-# Gap confidence levels
-GAP_CONFIDENCE_UNKNOWN = 0.0
-GAP_CONFIDENCE_SUSPICIOUS = 0.3
-GAP_CONFIDENCE_LIKELY_LEGITIMATE = 0.7
+# Legacy cache metadata may explicitly mark a range as proven legitimate.
 GAP_CONFIDENCE_CONFIRMED = 1.0
 
-# Gap reasons
-GAP_REASON_AUTO = "auto_detected"
 GAP_REASON_FETCH_FAILED = "fetch_failed"
 GAP_REASON_CONFIRMED = "confirmed_legitimate"
-GAP_REASON_MANUAL = "manual"
 PENDING_PNL_REFRESH_MARGIN_MS = 5 * 60 * 1000
 KUCOIN_POSITION_HISTORY_LOOKAHEAD_MS = 10 * 60 * 1000
 DEGRADED_PNL_REPAIR_MAX_INTERVALS_PER_CYCLE = 4
@@ -1912,14 +1903,14 @@ DEGRADED_PNL_REPAIR_MAX_INTERVAL_SPAN_MS = 24 * 60 * 60 * 1000
 
 
 class KnownGap(TypedDict, total=False):
-    """Gap metadata stored in metadata.json known_gaps."""
+    """Unproven bounded fetch range stored in metadata.json."""
 
     start_ts: int  # Gap start timestamp (ms)
     end_ts: int  # Gap end timestamp (ms)
-    retry_count: int  # Number of fetch attempts (max 3)
-    reason: str  # auto_detected, fetch_failed, confirmed_legitimate, manual
+    retry_count: int  # Diagnostic count; orchestration owns retry timing
+    reason: str  # fetch_failed or legacy confirmed_legitimate
     added_at: int  # Timestamp when gap was first detected
-    confidence: float  # 0.0=unknown, 0.3=suspicious, 0.7=likely_ok, 1.0=confirmed
+    confidence: float  # Legacy compatibility; 1.0 means confirmed legitimate
 
 
 class CacheMetadata(TypedDict, total=False):
@@ -2298,10 +2289,9 @@ class FillEventCache:
         start_ts: int,
         end_ts: int,
         *,
-        reason: str = GAP_REASON_AUTO,
-        confidence: float = GAP_CONFIDENCE_UNKNOWN,
+        reason: str = GAP_REASON_FETCH_FAILED,
     ) -> None:
-        """Add or update a known gap."""
+        """Record a bounded range whose exchange fetch failed."""
         metadata = self.load_metadata()
         gaps = metadata.get("known_gaps", [])
         now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
@@ -2313,10 +2303,6 @@ class FillEventCache:
                 gap["start_ts"] = min(gap["start_ts"], start_ts)
                 gap["end_ts"] = max(gap["end_ts"], end_ts)
                 gap["retry_count"] = gap.get("retry_count", 0) + 1
-                if gap["retry_count"] >= _GAP_MAX_RETRIES:
-                    gap["confidence"] = max(
-                        gap.get("confidence", 0), GAP_CONFIDENCE_LIKELY_LEGITIMATE
-                    )
                 logger.info(
                     "FillEventCache.add_known_gap: updated gap %s → %s (retry_count=%d)",
                     _format_ms(gap["start_ts"]),
@@ -2333,7 +2319,6 @@ class FillEventCache:
             "retry_count": 0,
             "reason": reason,
             "added_at": now_ms,
-            "confidence": confidence,
         }
         gaps.append(new_gap)
         metadata["known_gaps"] = gaps
@@ -2391,17 +2376,26 @@ class FillEventCache:
             return True
         return False
 
-    def should_retry_gap(self, gap: KnownGap) -> bool:
-        """Check if a gap should be retried (retry_count < max)."""
-        return gap.get("retry_count", 0) < _GAP_MAX_RETRIES
-
     def get_coverage_summary(self) -> Dict[str, object]:
         """Return a summary of cache coverage for debugging."""
         metadata = self.load_metadata()
         gaps = metadata.get("known_gaps", [])
 
-        persistent_gaps = [g for g in gaps if not self.should_retry_gap(g)]
-        retryable_gaps = [g for g in gaps if self.should_retry_gap(g)]
+        def is_confirmed_legacy_gap(gap: object) -> bool:
+            if not isinstance(gap, dict):
+                return False
+            try:
+                confidence = float(gap.get("confidence", 0.0) or 0.0)
+            except (TypeError, ValueError):
+                confidence = 0.0
+            return (
+                str(gap.get("reason", "") or "").lower() == GAP_REASON_CONFIRMED
+                or confidence >= GAP_CONFIDENCE_CONFIRMED
+            )
+
+        retryable_gaps = [
+            gap for gap in gaps if not is_confirmed_legacy_gap(gap)
+        ]
 
         total_gap_ms = sum(g["end_ts"] - g["start_ts"] for g in gaps)
 
@@ -2412,7 +2406,10 @@ class FillEventCache:
             "last_refresh_ms": metadata.get("last_refresh_ms", 0),
             "history_scope": self.get_history_scope(),
             "total_gaps": len(gaps),
-            "persistent_gaps": len(persistent_gaps),
+            # Compatibility fields retained for the fill dashboard. Unproven
+            # ranges no longer become terminal merely because a retry count is
+            # exhausted; orchestration owns indefinitely backed-off retries.
+            "persistent_gaps": 0,
             "retryable_gaps": len(retryable_gaps),
             "total_gap_hours": total_gap_ms / (1000 * 60 * 60) if total_gap_ms > 0 else 0,
             "gaps": [
@@ -5098,7 +5095,6 @@ class FillEventsManager:
                     start_ms,
                     end_ms,
                     reason=GAP_REASON_FETCH_FAILED,
-                    confidence=GAP_CONFIDENCE_UNKNOWN,
                 )
             raise
         finally:
@@ -5448,30 +5444,25 @@ class FillEventsManager:
         *,
         end_ms: Optional[int] = None,
         overlap: int = 20,
-        gap_hours: float = 12.0,
-        force_refetch_gaps: bool = False,
     ) -> bool:
-        """Refresh fills for a requested lookback window using cache-derived coverage.
+        """Prove a requested fill lookback through exchange traversal.
 
         Open-ended lookbacks are tracked in cache metadata so bots can avoid
         re-running the same expensive history bootstrap after restart when the
-        early portion of the lookback legitimately contains no fills.
+        early portion of the lookback legitimately contains no fills. Fill
+        density is not coverage evidence: only a completed exchange fetch may
+        prove an interval, and only a failed bounded fetch creates a known gap.
 
         Returns True only after at least one exchange fill fetch completes.
         """
         await self.ensure_loaded()
         start_ms = int(start_ms)
         if end_ms is not None:
-            await self.refresh_range(
-                start_ms=start_ms,
-                end_ms=end_ms,
-                gap_hours=gap_hours,
-                overlap=overlap,
-                force_refetch_gaps=force_refetch_gaps,
-            )
+            await self.refresh(start_ms=start_ms, end_ms=int(end_ms))
             return True
 
         coverage_end_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+        latest_refreshed = False
 
         blocking_gaps = self._blocking_known_gaps(
             start_ms=start_ms,
@@ -5482,8 +5473,6 @@ class FillEventsManager:
             for gap in blocking_gaps:
                 bounds = self._known_gap_bounds(gap)
                 if bounds is None:
-                    continue
-                if not force_refetch_gaps and not self.cache.should_retry_gap(gap):
                     continue
                 gap_start, gap_end = bounds
                 retry_start = max(start_ms, gap_start)
@@ -5499,17 +5488,18 @@ class FillEventsManager:
                 await self.refresh(start_ms=retry_start, end_ms=retry_end)
             if retried_ranges:
                 await self.refresh_latest(overlap=overlap)
+                latest_refreshed = True
                 blocking_gaps = self._blocking_known_gaps(
                     start_ms=start_ms,
                     end_ms=coverage_end_ms,
                 )
             if blocking_gaps:
                 if not retried_ranges:
-                    # Historical coverage may remain blocked after its bounded
-                    # retry budget is exhausted. A recent refresh is still
-                    # required so trailing confirmation can prove its fill
-                    # cache current without weakening the PnL coverage gate.
+                    # Malformed legacy evidence cannot identify a bounded retry
+                    # range. Keep recent structural confirmation current while
+                    # the coverage verdict remains fail-closed.
                     await self.refresh_latest(overlap=overlap)
+                    latest_refreshed = True
                 gap = blocking_gaps[0]
                 bounds = self._known_gap_bounds(gap)
                 range_label = (
@@ -5519,12 +5509,11 @@ class FillEventsManager:
                 )
                 gap_info = gap if isinstance(gap, dict) else {}
                 logger.warning(
-                    "[fills] lookback coverage remains unproven because known gap overlaps requested window | start=%s gap=%s reason=%s retry_count=%s confidence=%s",
+                    "[fills] lookback coverage remains unproven because failed fetch range overlaps requested window | start=%s gap=%s reason=%s retry_count=%s",
                     _format_ms(start_ms),
                     range_label,
                     str(gap_info.get("reason", "malformed")),
                     str(gap_info.get("retry_count", "unknown")),
-                    str(gap_info.get("confidence", "unknown")),
                 )
                 return True
 
@@ -5541,7 +5530,8 @@ class FillEventsManager:
                 _format_ms(covered_start_ms) if covered_start_ms else "None",
                 _format_ms(oldest_event_ts) if oldest_event_ts else "None",
             )
-            await self.refresh_latest(overlap=overlap)
+            if not latest_refreshed:
+                await self.refresh_latest(overlap=overlap)
             return True
 
         if coverage_status.get("reason") == "cache_metadata_event_mismatch":
@@ -5550,30 +5540,11 @@ class FillEventsManager:
                 _format_ms(covered_start_ms),
             )
 
-        if self._events:
-            if oldest_event_ts > 0 and oldest_event_ts <= start_ms:
-                logger.info(
-                    "[fills] lookback coverage unproven from %s despite older cached fill at %s; refreshing full lookback",
-                    _format_ms(start_ms),
-                    _format_ms(oldest_event_ts),
-                )
-                await self.refresh(start_ms=start_ms, end_ms=None)
-                await self.refresh_latest(overlap=overlap)
-            else:
-                logger.info(
-                    "[fills] lookback uncovered from %s; refreshing missing range before latest",
-                    _format_ms(start_ms),
-                )
-                await self.refresh_range(
-                    start_ms=start_ms,
-                    end_ms=None,
-                    gap_hours=gap_hours,
-                    overlap=overlap,
-                    force_refetch_gaps=force_refetch_gaps,
-                )
-        else:
-            logger.info("[fills] cache empty; refreshing full lookback from %s", _format_ms(start_ms))
-            await self.refresh(start_ms=start_ms, end_ms=None)
+        logger.info(
+            "[fills] lookback coverage unproven from %s; traversing the full requested window",
+            _format_ms(start_ms),
+        )
+        await self.refresh(start_ms=start_ms, end_ms=None)
 
         self.cache.mark_covered_start(start_ms)
         return True
@@ -5700,101 +5671,18 @@ class FillEventsManager:
         self,
         start_ms: int,
         end_ms: Optional[int],
-        *,
-        gap_hours: float = 12.0,
-        overlap: int = 20,
-        force_refetch_gaps: bool = False,
     ) -> None:
-        """Fill missing data between `start_ms` and `end_ms` using gap heuristics.
+        """Refresh the exact requested interval.
 
-        Args:
-            start_ms: Start timestamp in milliseconds
-            end_ms: End timestamp in milliseconds (or None for now)
-            gap_hours: Threshold for detecting gaps (default 12 hours)
-            overlap: Number of events to overlap when fetching latest
-            force_refetch_gaps: If True, retry even persistent gaps
+        Fill timestamps are irregular, so spacing between cached events is not
+        evidence of missing history. The exchange fetcher owns complete
+        traversal of this interval.
         """
         await self.ensure_loaded()
-        intervals: List[Tuple[int, int]] = []
-
-        # Get known gaps from cache metadata
-        known_gaps = self.cache.get_known_gaps()
-
-        def is_in_persistent_gap(ts_start: int, ts_end: int) -> bool:
-            """Check if interval is fully within a persistent (max retries) gap."""
-            if force_refetch_gaps:
-                return False
-            for gap in known_gaps:
-                if ts_start >= gap["start_ts"] and ts_end <= gap["end_ts"]:
-                    if not self.cache.should_retry_gap(gap):
-                        return True
-            return False
-
-        if not self._events:
-            logger.debug("[fills] refresh_range: cache empty, refreshing entire interval")
-            await self.refresh(start_ms=start_ms, end_ms=end_ms)
-            if self._events:
-                await self.refresh_latest(overlap=overlap)
-            return
-
-        events_sorted = self._events
-        earliest = events_sorted[0].timestamp
-        latest = events_sorted[-1].timestamp
-        gap_ms = max(1, int(gap_hours * 60.0 * 60.0 * 1000.0))
-
-        # Fetch older data before earliest cached if requested
-        if start_ms < earliest:
-            upper = earliest if end_ms is None else min(earliest, end_ms)
-            if start_ms < upper and not is_in_persistent_gap(start_ms, upper):
-                intervals.append((start_ms, upper))
-
-        # Detect large gaps in cached data
-        prev_ts = earliest
-        for ev in events_sorted[1:]:
-            cur_ts = ev.timestamp
-            if end_ms is not None and cur_ts > end_ms:
-                break
-            if cur_ts - prev_ts >= gap_ms:
-                gap_start = max(prev_ts, start_ms)
-                gap_end = cur_ts
-                if gap_start < gap_end:
-                    if is_in_persistent_gap(gap_start, gap_end):
-                        logger.debug(
-                            "FillEventsManager.refresh_range: skipping persistent gap %s → %s",
-                            _format_ms(gap_start),
-                            _format_ms(gap_end),
-                        )
-                    else:
-                        intervals.append((gap_start, gap_end))
-                        # Record as potential gap for tracking
-                        self.cache.add_known_gap(
-                            gap_start,
-                            gap_end,
-                            reason=GAP_REASON_AUTO,
-                            confidence=GAP_CONFIDENCE_SUSPICIOUS,
-                        )
-            prev_ts = cur_ts
-
-        # Fetch newer data after latest cached if requested (if not already covered)
-        if end_ms is not None and end_ms > latest and (not intervals or intervals[-1][1] != end_ms):
-            lower = max(latest, start_ms)
-            if lower < end_ms and not is_in_persistent_gap(lower, end_ms):
-                intervals.append((lower, end_ms))
-
-        merged = self._merge_intervals(intervals)
-        if merged:
-            logger.debug(
-                "[fills] refresh_range: refreshing %d intervals: %s",
-                len(merged),
-                ", ".join(f"{_format_ms(start)} → {_format_ms(end)}" for start, end in merged),
-            )
-        else:
-            logger.debug("[fills] refresh_range: no gaps detected in requested interval")
-
-        for start, end in merged:
-            await self.refresh(start_ms=start, end_ms=end)
-
-        await self.refresh_latest(overlap=overlap)
+        await self.refresh(
+            start_ms=int(start_ms),
+            end_ms=None if end_ms is None else int(end_ms),
+        )
 
     def get_events(
         self,

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -2303,6 +2303,12 @@ class FillEventCache:
                 gap["start_ts"] = min(gap["start_ts"], start_ts)
                 gap["end_ts"] = max(gap["end_ts"], end_ts)
                 gap["retry_count"] = gap.get("retry_count", 0) + 1
+                # A current failed traversal is stronger evidence than a
+                # legacy operator classification. Conservatively retry the
+                # merged range instead of letting confirmed metadata hide a
+                # newly unproven extension.
+                gap["reason"] = reason
+                gap.pop("confidence", None)
                 logger.info(
                     "FillEventCache.add_known_gap: updated gap %s → %s (retry_count=%d)",
                     _format_ms(gap["start_ts"]),
@@ -5464,7 +5470,11 @@ class FillEventsManager:
         await self.ensure_loaded()
         start_ms = int(start_ms)
         if end_ms is not None:
-            await self.refresh(start_ms=start_ms, end_ms=int(end_ms))
+            await self.refresh(
+                start_ms=start_ms,
+                end_ms=int(end_ms),
+                mark_refreshed=False,
+            )
             return True
 
         coverage_end_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -5501,7 +5501,14 @@ class FillEventsManager:
                     _format_ms(retry_start),
                     _format_ms(retry_end),
                 )
-                await self.refresh(start_ms=retry_start, end_ms=retry_end)
+                await self.refresh(
+                    start_ms=retry_start,
+                    end_ms=retry_end,
+                    # A bounded historical retry does not prove the recent
+                    # tail. Let the subsequent tail refresh advance the
+                    # incremental checkpoint only after it succeeds.
+                    mark_refreshed=False,
+                )
             if retried_ranges:
                 await self.refresh_latest(overlap=overlap)
                 latest_refreshed = True

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -5087,10 +5087,16 @@ class FillEventsManager:
                 fetched_events = await self.fetcher.fetch(
                     start_ms, end_ms, detail_cache, on_batch=collect_batch
                 )
-        except RateLimitExceeded:
-            # Preserve bounded-range failures as known gaps so retry logic can
-            # revisit them.  We still re-raise to fail loudly on critical input.
-            if start_ms is not None and end_ms is not None:
+        except Exception:
+            # Preserve failed bounded fill traversals as unproven ranges so
+            # coverage retry can revisit them. PnL-only enrichment does not
+            # invalidate already-proven structural fill coverage. Re-raise so
+            # the caller still owns failure policy.
+            if (
+                degraded_pnl_aux_range is None
+                and start_ms is not None
+                and end_ms is not None
+            ):
                 self.cache.add_known_gap(
                     start_ms,
                     end_ms,
@@ -5682,6 +5688,9 @@ class FillEventsManager:
         await self.refresh(
             start_ms=int(start_ms),
             end_ms=None if end_ms is None else int(end_ms),
+            # A bounded historical repair does not prove the recent tail and
+            # must not advance the incremental refresh checkpoint.
+            mark_refreshed=end_ms is None,
         )
 
     def get_events(

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -1733,6 +1733,27 @@ async def test_refresh_range_bounded_history_preserves_refresh_checkpoint_with_f
     assert metadata["newest_event_ts"] == 1_500
 
 
+@pytest.mark.asyncio
+async def test_refresh_for_lookback_bounded_history_preserves_refresh_checkpoint(
+    tmp_path: Path,
+):
+    checkpoint_ms = 777
+    cache = FillEventCache(tmp_path)
+    cache.save_metadata({"last_refresh_ms": checkpoint_ms})
+    manager = FillEventsManager(
+        exchange="hyperliquid",
+        user="user",
+        fetcher=_StaticFetcher([]),
+        cache_path=tmp_path,
+    )
+
+    completed = await manager.refresh_for_lookback(start_ms=1_000, end_ms=2_000)
+
+    assert completed is True
+    assert manager.fetcher.calls == [(1_000, 2_000)]
+    assert manager.cache.load_metadata()["last_refresh_ms"] == checkpoint_ms
+
+
 # ---------------------------------------------------------------------------
 # Cache tests
 # ---------------------------------------------------------------------------
@@ -6078,6 +6099,34 @@ def test_clear_gap_persists_partial_trim_and_middle_split(tmp_path: Path):
         },
     ]
     assert cache.load_metadata()["known_gaps"] == cache.get_known_gaps()
+
+
+def test_failed_range_downgrades_overlapping_legacy_confirmed_gap(tmp_path: Path):
+    cache = FillEventCache(tmp_path / "fills_legacy_confirmed_overlap")
+    cache.save_metadata(
+        {
+            "known_gaps": [
+                {
+                    "start_ts": 1_000,
+                    "end_ts": 2_000,
+                    "retry_count": 0,
+                    "reason": "confirmed_legitimate",
+                    "confidence": 1.0,
+                }
+            ]
+        }
+    )
+
+    cache.add_known_gap(1_500, 2_500, reason=GAP_REASON_FETCH_FAILED)
+
+    assert cache.get_known_gaps() == [
+        {
+            "start_ts": 1_000,
+            "end_ts": 2_500,
+            "retry_count": 1,
+            "reason": GAP_REASON_FETCH_FAILED,
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -6049,6 +6049,78 @@ async def test_manager_refresh_for_lookback_retries_failed_range_regardless_of_a
     assert manager.cache.get_known_gaps() == []
 
 
+@pytest.mark.asyncio
+async def test_manager_known_gap_retry_preserves_checkpoint_when_tail_refresh_fails(
+    tmp_path: Path,
+):
+    cache_dir = tmp_path / "fills_lookback_gap_tail_failure"
+    cache = FillEventCache(cache_dir)
+    start_ms = int((datetime.now(timezone.utc) - timedelta(days=2)).timestamp() * 1000)
+    gap_start = start_ms + 60 * 60 * 1000
+    gap_end = start_ms + 2 * 60 * 60 * 1000
+    event_ts = start_ms + 3 * 60 * 60 * 1000
+    event = FillEvent.from_dict(
+        dict(
+            id="post-gap-fill",
+            timestamp=event_ts,
+            datetime="",
+            symbol="BTC/USDT",
+            side="buy",
+            qty=0.1,
+            price=10,
+            pnl=0.0,
+            pb_order_type="entry",
+            position_side="long",
+            client_order_id="cid-post-gap-fill",
+        )
+    )
+    cache.save([event])
+    cache.save_metadata(
+        {
+            "last_refresh_ms": event_ts,
+            "oldest_event_ts": event_ts,
+            "newest_event_ts": event_ts,
+            "covered_start_ms": start_ms,
+            "history_scope": "window",
+            "known_gaps": [
+                {
+                    "start_ts": gap_start,
+                    "end_ts": gap_end,
+                    "retry_count": 3,
+                    "reason": GAP_REASON_FETCH_FAILED,
+                    "confidence": 0.0,
+                }
+            ],
+        }
+    )
+
+    class _TailFailureFetcher(BaseFetcher):
+        def __init__(self):
+            self.calls: List[Tuple[Optional[int], Optional[int]]] = []
+
+        async def fetch(self, since_ms, until_ms, detail_cache, on_batch=None):
+            self.calls.append((since_ms, until_ms))
+            if until_ms is None:
+                raise RuntimeError("tail unavailable")
+            if on_batch:
+                on_batch([])
+            return []
+
+    fetcher = _TailFailureFetcher()
+    manager = FillEventsManager(
+        exchange="bybit",
+        user="default",
+        fetcher=fetcher,
+        cache_path=cache_dir,
+    )
+
+    with pytest.raises(RuntimeError, match="tail unavailable"):
+        await manager.refresh_for_lookback(start_ms=start_ms)
+
+    assert fetcher.calls == [(gap_start, gap_end), (event_ts, None)]
+    assert manager.cache.load_metadata()["last_refresh_ms"] == event_ts
+
+
 def test_clear_gap_persists_partial_trim_and_middle_split(tmp_path: Path):
     cache = FillEventCache(tmp_path / "fills_clear_gap")
     cache.save_metadata(

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -5921,7 +5921,7 @@ async def test_manager_refresh_for_lookback_retries_known_gap_before_latest(tmp_
 
 
 @pytest.mark.asyncio
-async def test_manager_refresh_for_lookback_refreshes_latest_when_gap_retries_exhausted(
+async def test_manager_refresh_for_lookback_retries_failed_range_regardless_of_attempt_count(
     tmp_path: Path,
 ):
     cache_dir = tmp_path / "fills_lookback_exhausted_gap"
@@ -5986,8 +5986,8 @@ async def test_manager_refresh_for_lookback_refreshes_latest_when_gap_retries_ex
     completed = await manager.refresh_for_lookback(start_ms=start_ms)
 
     assert completed is True
-    assert fetcher.calls == [(event_ts, None)]
-    assert manager.cache.get_known_gaps()[0]["retry_count"] == 3
+    assert fetcher.calls == [(gap_start, gap_end), (event_ts, None)]
+    assert manager.cache.get_known_gaps() == []
 
 
 def test_clear_gap_persists_partial_trim_and_middle_split(tmp_path: Path):
@@ -6043,7 +6043,7 @@ def test_clear_gap_persists_partial_trim_and_middle_split(tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_manager_refresh_range_detects_gaps(tmp_path: Path):
+async def test_manager_refresh_range_does_not_infer_gaps_from_fill_spacing(tmp_path: Path):
     cache_dir = tmp_path / "fills_range"
     cache = FillEventCache(cache_dir)
     base = int((datetime.now(timezone.utc) - timedelta(hours=48)).timestamp() * 1000)
@@ -6119,12 +6119,10 @@ async def test_manager_refresh_range_detects_gaps(tmp_path: Path):
     start_ms = base - int(6 * 60 * 60 * 1000)
     end_ms = base + int(24 * 60 * 60 * 1000)
 
-    await manager.refresh_range(start_ms=start_ms, end_ms=end_ms, gap_hours=12, overlap=1)
+    await manager.refresh_range(start_ms=start_ms, end_ms=end_ms)
 
-    assert len(fetcher.calls) == 3
-    assert fetcher.calls[0] == (start_ms, events[0].timestamp)
-    assert fetcher.calls[1] == (events[1].timestamp, end_ms)
-    assert fetcher.calls[2] == (events[2].timestamp, None)
+    assert fetcher.calls == [(start_ms, end_ms)]
+    assert manager.cache.get_known_gaps() == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -1658,6 +1658,7 @@ async def test_refresh_rejects_malformed_fetcher_rows_without_partial_persist(tm
 
     assert FillEventCache(tmp_path).load() == []
     assert FillEventCache(tmp_path).load_metadata()["last_refresh_ms"] == 0
+    assert FillEventCache(tmp_path).get_known_gaps() == []
 
 
 @pytest.mark.asyncio
@@ -1693,6 +1694,43 @@ async def test_refresh_range_empty_bounded_window_does_not_fetch_unbounded_lates
 
     assert fetcher.calls == [(1_000, 2_000)]
     assert FillEventCache(tmp_path).load() == []
+    assert FillEventCache(tmp_path).load_metadata()["last_refresh_ms"] == 0
+
+
+@pytest.mark.asyncio
+async def test_refresh_range_bounded_history_preserves_refresh_checkpoint_with_fills(
+    tmp_path: Path,
+):
+    checkpoint_ms = 777
+    event = {
+        "id": "historical",
+        "timestamp": 1_500,
+        "datetime": "",
+        "symbol": "BTC/USDC:USDC",
+        "side": "buy",
+        "qty": 1.0,
+        "price": 100.0,
+        "pnl": 0.0,
+        "fees": {"currency": "USDC", "cost": 0.01},
+        "pb_order_type": "entry_grid_normal_long",
+        "position_side": "long",
+        "client_order_id": "cid-historical",
+    }
+    cache = FillEventCache(tmp_path)
+    cache.save_metadata({"last_refresh_ms": checkpoint_ms})
+    manager = FillEventsManager(
+        exchange="hyperliquid",
+        user="user",
+        fetcher=_StaticFetcher([event]),
+        cache_path=tmp_path,
+    )
+
+    await manager.refresh_range(start_ms=1_000, end_ms=2_000)
+
+    assert [item.id for item in cache.load()] == ["historical"]
+    metadata = manager.cache.load_metadata()
+    assert metadata["last_refresh_ms"] == checkpoint_ms
+    assert metadata["newest_event_ts"] == 1_500
 
 
 # ---------------------------------------------------------------------------
@@ -6186,23 +6224,31 @@ async def test_hyperliquid_fetcher_raises_after_max_rate_limit_retries(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_manager_refresh_registers_gap_and_reraises_rate_limit(tmp_path: Path):
-    cache_dir = tmp_path / "fills_rate_limit_gap"
+@pytest.mark.parametrize(
+    "fetch_error",
+    [RateLimitExceeded("rate limited"), RuntimeError("exchange unavailable")],
+    ids=["rate_limit", "exchange_error"],
+)
+async def test_manager_refresh_registers_gap_and_reraises_fetch_failure(
+    tmp_path: Path,
+    fetch_error: Exception,
+):
+    cache_dir = tmp_path / "fills_fetch_failure_gap"
 
-    class _RateLimitedFetcher(BaseFetcher):
+    class _FailingFetcher(BaseFetcher):
         async def fetch(self, since_ms, until_ms, detail_cache, on_batch=None):
-            raise RateLimitExceeded("rate limited")
+            raise fetch_error
 
     manager = FillEventsManager(
         exchange="hyperliquid",
         user="default",
-        fetcher=_RateLimitedFetcher(),
+        fetcher=_FailingFetcher(),
         cache_path=cache_dir,
     )
 
     start_ms = 1_700_000_000_000
     end_ms = start_ms + 60_000
-    with pytest.raises(RateLimitExceeded):
+    with pytest.raises(type(fetch_error), match=str(fetch_error)):
         await manager.refresh(start_ms=start_ms, end_ms=end_ms)
 
     gaps = manager.cache.get_known_gaps()
@@ -6210,6 +6256,43 @@ async def test_manager_refresh_registers_gap_and_reraises_rate_limit(tmp_path: P
     assert gaps[0]["start_ts"] == start_ms
     assert gaps[0]["end_ts"] == end_ms
     assert gaps[0]["reason"] == GAP_REASON_FETCH_FAILED
+
+
+@pytest.mark.asyncio
+async def test_manager_pnl_repair_failure_does_not_invalidate_fill_coverage(
+    tmp_path: Path,
+):
+    class _FailingPnlRepairFetcher(BaseFetcher):
+        async def fetch(self, since_ms, until_ms, detail_cache, on_batch=None):
+            return []
+
+        async def fetch_degraded_pnl_repair(
+            self,
+            since_ms,
+            until_ms,
+            aux_start_ms,
+            aux_end_ms,
+            detail_cache,
+            on_batch=None,
+        ):
+            raise RuntimeError("PnL endpoint unavailable")
+
+    manager = FillEventsManager(
+        exchange="bybit",
+        user="default",
+        fetcher=_FailingPnlRepairFetcher(),
+        cache_path=tmp_path,
+    )
+
+    with pytest.raises(RuntimeError, match="PnL endpoint unavailable"):
+        await manager.refresh(
+            start_ms=1_000,
+            end_ms=2_000,
+            mark_refreshed=False,
+            degraded_pnl_aux_range=(3_000, 4_000),
+        )
+
+    assert manager.cache.get_known_gaps() == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Fill executions are irregular, so a long interval between cached fills is not evidence that exchange history is missing. The existing heuristic split requested windows around fill spacing, manufactured `known_gaps`, promoted them through a second retry/confidence state machine, and then left them blocking forever after three attempts.

## What changed

- prove fill-history coverage through successful endpoint traversal, including empty responses
- create unproven ranges when a bounded fill traversal actually fails, while keeping PnL-only enrichment failures separate
- keep failed ranges retryable under the execution loop's existing reason-aware backoff instead of a manager-owned terminal retry limit
- replace heuristic `refresh_range` subdivision with one exact requested traversal
- preserve the live incremental checkpoint after bounded historical repairs and lookbacks
- downgrade an overlapping legacy confirmed range when a current failed traversal makes any part unproven
- avoid a duplicate latest-fill request after successfully repairing a failed range
- update the feature contract, manager spec, changelog, and regression coverage

The production implementation is 93 lines smaller, with one fewer retry state machine and a stronger evidence boundary.

## Validation

- `python -m py_compile src/fill_events_manager.py`
- full `tests/test_fill_events_manager.py` suite (211 tests)
- focused live fill-coverage/PnL retry integration tests (9 tests)
- `PYTHONPATH=src python src/tools/check_ai_docs.py` (0 errors; pre-existing size warnings only)
- `pytest tests/test_ai_docs.py`
- `git diff --check`

