### PR TITLE
Disambiguate multiplier-prefixed markets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -617,6 +617,12 @@ All notable user-facing changes will be documented in this file.
   effect and close-only effect from position side in effective one-way mode. UTA orders with an
   explicit `posSide` now derive close-only effect directly from the authoritative `side` plus
   `posSide` tuple.
+- Fixed power-of-ten market aliases collapsing distinct contracts when an exchange lists both the
+  prefixed and unprefixed base, such as `1000CAT` and `CAT` on Binance or Bitget. Exact native and
+  CCXT symbols now resolve through distinct canonical names, map output is deterministic, and
+  ordinary single-contract aliases such as `1000SHIB -> SHIB` remain unchanged. Configs that
+  previously used bare `CAT` for Simon's Cat must use `1000CAT`; bare `CAT` now identifies the
+  unprefixed market.
 - Fixed live order-churn evidence treating the execution loop's normal 30-second scheduled wait as
   a provenance gap, which could prevent the account-wide churn gate from activating for slowly
   moving EMA-based orders.

--- a/src/utils.py
+++ b/src/utils.py
@@ -800,57 +800,85 @@ def _load_symbol_to_coin_map() -> dict:
         return {}
 
 
-def _build_coin_symbol_maps(markets, quote):
-    """
-    Build coin_to_symbol_map (as dict of lists) and symbol_to_coin_map from markets data.
-    This function is pure and performs no disk I/O.
-    """
+def _is_symbol_map_market(symbol: str, market: dict, quote: str) -> bool:
+    return (
+        bool(market.get("swap"))
+        and market.get("linear") is not False
+        and symbol.endswith(f":{quote}")
+    )
 
-    def _namespaced_aliases(base: str, market: dict) -> set[str]:
-        aliases = set()
-        if not isinstance(base, str) or not base:
-            return aliases
-        is_namespaced_hip3 = bool((market.get("info") or {}).get("hip3")) or base.startswith(
-            ("XYZ-", "xyz:")
-        )
-        if not is_namespaced_hip3:
-            return aliases
-        if ":" in base:
-            prefix, ticker = base.split(":", 1)
-            if prefix and ticker:
-                aliases.add(ticker)
-                aliases.add(f"{prefix.upper()}-{ticker}")
-        elif "-" in base:
-            prefix, ticker = base.split("-", 1)
-            if prefix and ticker:
-                aliases.add(ticker)
-                aliases.add(f"{prefix.lower()}:{ticker}")
+
+def _symbol_map_bases(market: dict) -> list[str]:
+    return [base for key in ("baseName", "base") if (base := market.get(key))]
+
+
+def _symbol_map_namespaced_aliases(base: str, market: dict) -> set[str]:
+    aliases = set()
+    if not isinstance(base, str) or not base:
         return aliases
+    is_namespaced_hip3 = bool((market.get("info") or {}).get("hip3")) or base.startswith(
+        ("XYZ-", "xyz:")
+    )
+    if not is_namespaced_hip3:
+        return aliases
+    if ":" in base:
+        prefix, ticker = base.split(":", 1)
+        if prefix and ticker:
+            aliases.add(ticker)
+            aliases.add(f"{prefix.upper()}-{ticker}")
+    elif "-" in base:
+        prefix, ticker = base.split("-", 1)
+        if prefix and ticker:
+            aliases.add(ticker)
+            aliases.add(f"{prefix.lower()}:{ticker}")
+    return aliases
 
+
+def _collect_symbol_map_markets(markets: dict, quote: str) -> tuple[dict, dict]:
+    eligible_markets = {}
+    available_bases = defaultdict(set)
+    for symbol, market in markets.items():
+        try:
+            if not _is_symbol_map_market(symbol, market, quote):
+                continue
+            eligible_markets[symbol] = market
+            for base in _symbol_map_bases(market):
+                available_bases[base.replace("k", "")].add(symbol)
+        except Exception:
+            continue
+    return eligible_markets, available_bases
+
+
+def _symbol_map_coin_and_variants(
+    symbol: str, market: dict, available_bases: dict
+) -> tuple[str, set[str]]:
+    coin = ""
+    variants = set()
+    for base in _symbol_map_bases(market):
+        variants.add(base)
+        raw_cleaned = base.replace("k", "")
+        variants.add(raw_cleaned)
+        cleaned = remove_powers_of_ten(raw_cleaned)
+        preserve_multiplier = cleaned != raw_cleaned and any(
+            other_symbol != symbol for other_symbol in available_bases.get(cleaned, set())
+        )
+        if not preserve_multiplier:
+            variants.add(remove_powers_of_ten(base))
+            variants.add(cleaned)
+        if not coin:
+            coin = raw_cleaned if preserve_multiplier else cleaned
+        variants.update(_symbol_map_namespaced_aliases(base, market))
+    return coin, variants
+
+
+def _build_coin_symbol_maps(markets, quote):
+    """Build coin-to-symbol and symbol-to-coin maps without disk I/O."""
+    eligible_markets, available_bases = _collect_symbol_map_markets(markets, quote)
     coin_to_symbol_map = defaultdict(set)
     symbol_to_coin_map = {}
-    for k, v in markets.items():
+    for k, v in eligible_markets.items():
         try:
-            # Only include swap markets with the right quote.
-            if not v.get("swap"):
-                continue
-            # If "linear" is explicitly False, skip; otherwise treat missing as acceptable.
-            if v.get("linear") is False:
-                continue
-            if not k.endswith(f":{quote}"):
-                continue
-            coin = ""
-            variants = set()
-            for k0 in ["baseName", "base"]:
-                if base := v.get(k0):
-                    variants.add(base)
-                    variants.add(base.replace("k", ""))
-                    variants.add(remove_powers_of_ten(base))
-                    cleaned = remove_powers_of_ten(base.replace("k", ""))
-                    variants.add(cleaned)
-                    if not coin:
-                        coin = cleaned
-                    variants.update(_namespaced_aliases(base, v))
+            coin, variants = _symbol_map_coin_and_variants(k, v, available_bases)
             symbol_to_coin_map[k] = coin
             for variant in variants:
                 existing = symbol_to_coin_map.get(variant)
@@ -865,8 +893,19 @@ def _build_coin_symbol_maps(markets, quote):
             continue
 
     # Convert sets to lists for JSON serialisation / on-disk storage
-    coin_to_symbol_map = {k: list(v) for k, v in coin_to_symbol_map.items()}
+    coin_to_symbol_map = {k: sorted(v) for k, v in coin_to_symbol_map.items()}
     return coin_to_symbol_map, symbol_to_coin_map
+
+
+def _merge_symbol_to_coin_maps(existing: dict, discovered: dict) -> dict:
+    """Merge symbol maps without downgrading a multiplier-specific canonical name."""
+    merged = dict(existing)
+    for symbol, coin in discovered.items():
+        previous = merged.get(symbol)
+        if previous and previous != coin and remove_powers_of_ten(previous) == coin:
+            continue
+        merged[symbol] = coin
+    return merged
 
 
 def _write_coin_symbol_maps(
@@ -962,8 +1001,11 @@ def create_coin_symbol_map_cache(exchange: str, markets, quote=None, verbose=Tru
                 # Build fresh maps from provided markets (pure logic)
                 coin_to_symbol_map, new_symbol_to_coin_map = _build_coin_symbol_maps(markets, quote)
 
-                # Merge: prefer new discovered mappings while retaining others
-                symbol_to_coin_map.update(new_symbol_to_coin_map)
+                # Preserve a more specific multiplier-prefixed name discovered on
+                # another exchange, regardless of market-cache refresh order.
+                symbol_to_coin_map = _merge_symbol_to_coin_maps(
+                    symbol_to_coin_map, new_symbol_to_coin_map
+                )
 
                 # Write symbol_to_coin_map atomically while still holding lock
                 if verbose:

--- a/tests/test_utils_maps.py
+++ b/tests/test_utils_maps.py
@@ -242,6 +242,152 @@ def test_coin_to_symbol_multiple_candidates(tmp_path, monkeypatch, caplog):
     assert any("Multiple candidates" in rec.message for rec in caplog.records)
 
 
+@pytest.mark.parametrize("reverse_order", [False, True])
+def test_coin_symbol_maps_preserve_multiplier_when_unprefixed_market_exists(reverse_order):
+    market_rows = [
+        (
+            "1000CAT/USDT:USDT",
+            {
+                "id": "1000CATUSDT",
+                "swap": True,
+                "linear": True,
+                "base": "1000CAT",
+            },
+        ),
+        (
+            "CAT/USDT:USDT",
+            {
+                "id": "CATUSDT",
+                "swap": True,
+                "linear": True,
+                "base": "CAT",
+            },
+        ),
+    ]
+    if reverse_order:
+        market_rows.reverse()
+
+    coin_to_symbol_map, symbol_to_coin_map = utils._build_coin_symbol_maps(
+        dict(market_rows), "USDT"
+    )
+
+    assert coin_to_symbol_map["1000CAT"] == ["1000CAT/USDT:USDT"]
+    assert coin_to_symbol_map["CAT"] == ["CAT/USDT:USDT"]
+    assert symbol_to_coin_map["1000CATUSDT"] == "1000CAT"
+    assert symbol_to_coin_map["CATUSDT"] == "CAT"
+
+
+def test_coin_symbol_maps_still_shorten_single_multiplier_market():
+    markets = {
+        "1000SHIB/USDT:USDT": {
+            "id": "1000SHIBUSDT",
+            "swap": True,
+            "linear": True,
+            "base": "1000SHIB",
+        }
+    }
+
+    coin_to_symbol_map, symbol_to_coin_map = utils._build_coin_symbol_maps(markets, "USDT")
+
+    assert coin_to_symbol_map["SHIB"] == ["1000SHIB/USDT:USDT"]
+    assert coin_to_symbol_map["1000SHIB"] == ["1000SHIB/USDT:USDT"]
+    assert symbol_to_coin_map["1000SHIBUSDT"] == "SHIB"
+
+
+def test_coin_symbol_maps_do_not_treat_same_market_base_name_as_collision():
+    markets = {
+        "1000SHIB/USDT:USDT": {
+            "id": "1000SHIBUSDT",
+            "swap": True,
+            "linear": True,
+            "base": "1000SHIB",
+            "baseName": "SHIB",
+        }
+    }
+
+    coin_to_symbol_map, symbol_to_coin_map = utils._build_coin_symbol_maps(markets, "USDT")
+
+    assert coin_to_symbol_map["SHIB"] == ["1000SHIB/USDT:USDT"]
+    assert symbol_to_coin_map["1000SHIBUSDT"] == "SHIB"
+
+
+def test_coin_to_symbol_resolves_exact_market_symbols_after_normalization(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    os.makedirs(os.path.join("caches", "binance"), exist_ok=True)
+    json.dump(
+        {
+            "CAT": ["CAT/USDT:USDT"],
+            "1000CAT": ["1000CAT/USDT:USDT"],
+        },
+        open(os.path.join("caches", "binance", "coin_to_symbol_map.json"), "w"),
+    )
+    json.dump(
+        {
+            "CAT": "CAT",
+            "1000CAT": "1000CAT",
+            "CATUSDT": "CAT",
+            "1000CATUSDT": "1000CAT",
+            "CAT/USDT:USDT": "CAT",
+            "1000CAT/USDT:USDT": "1000CAT",
+        },
+        open(os.path.join("caches", "symbol_to_coin_map.json"), "w"),
+    )
+
+    assert utils.coin_to_symbol("CAT", "binance") == "CAT/USDT:USDT"
+    assert utils.coin_to_symbol("1000CAT", "binance") == "1000CAT/USDT:USDT"
+    assert utils.coin_to_symbol("CATUSDT", "binance") == "CAT/USDT:USDT"
+    assert utils.coin_to_symbol("1000CATUSDT", "binance") == "1000CAT/USDT:USDT"
+    assert utils.coin_to_symbol("CAT/USDT:USDT", "binance") == "CAT/USDT:USDT"
+    assert (
+        utils.coin_to_symbol("1000CAT/USDT:USDT", "binance")
+        == "1000CAT/USDT:USDT"
+    )
+
+
+@pytest.mark.parametrize(
+    "existing,discovered",
+    [
+        ({"1000CAT": "CAT"}, {"1000CAT": "1000CAT"}),
+        ({"1000CAT": "1000CAT"}, {"1000CAT": "CAT"}),
+    ],
+)
+def test_symbol_map_merge_keeps_multiplier_specific_canonical_name(existing, discovered):
+    assert utils._merge_symbol_to_coin_maps(existing, discovered)["1000CAT"] == "1000CAT"
+
+
+def test_cache_refresh_order_does_not_downgrade_multiplier_specific_name(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    multiplier_only = {
+        "1000CAT/USDT:USDT": {
+            "id": "1000CATUSDT",
+            "swap": True,
+            "linear": True,
+            "base": "1000CAT",
+        }
+    }
+    colliding_markets = {
+        **multiplier_only,
+        "CAT/USDT:USDT": {
+            "id": "CATUSDT",
+            "swap": True,
+            "linear": True,
+            "base": "CAT",
+        },
+    }
+
+    assert utils.create_coin_symbol_map_cache("bybit", multiplier_only, verbose=False)
+    assert utils.symbol_to_coin("1000CATUSDT") == "CAT"
+
+    assert utils.create_coin_symbol_map_cache("binance", colliding_markets, verbose=False)
+    assert utils.symbol_to_coin("1000CATUSDT") == "1000CAT"
+    assert utils.coin_to_symbol("CAT", "binance") == "CAT/USDT:USDT"
+    assert utils.coin_to_symbol("1000CAT", "binance") == "1000CAT/USDT:USDT"
+
+    assert utils.create_coin_symbol_map_cache("bybit", multiplier_only, verbose=False)
+    assert utils.symbol_to_coin("1000CATUSDT") == "1000CAT"
+    assert utils.coin_to_symbol("1000CAT", "bybit") == "1000CAT/USDT:USDT"
+
+
 def test_symbol_to_coin_in_memory_reload_and_heuristics(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     s2c_path = os.path.join("caches", "symbol_to_coin_map.json")


### PR DESCRIPTION
## Summary

- build coin/symbol maps in two passes so multiplier prefixes are preserved when the unprefixed base is a separate market in the same exchange/quote universe
- keep ordinary aliases such as `1000SHIB -> SHIB`, while mapping Binance/Bitget `1000CAT` and `CAT` to distinct contracts
- make candidate lists deterministic and prevent later single-market cache refreshes from downgrading a previously discovered multiplier-specific canonical name
- preserve exact native and CCXT symbol round trips through the corrected canonical maps

## Behavior

When both bases exist:

```text
1000CAT -> 1000CAT/USDT:USDT
CAT     -> CAT/USDT:USDT
```

When only the multiplier contract exists:

```text
1000SHIB -> SHIB -> 1000SHIB/USDT:USDT
```

This does not change RWA eligibility, margin handling, or order execution. It only disambiguates market identity. Existing configs that used bare `CAT` for Simon's Cat must change that entry to `1000CAT`; bare `CAT` now refers to the unprefixed contract.

Fixes #1456

## Testing

- `python -m pytest tests/test_utils_maps.py tests/ccxt_upgrade/test_market_contracts.py tests/test_live_coins_reload.py tests/test_live_coin_lists.py tests/test_coin_overrides.py tests/test_backtest_universe.py tests/test_suite_runner.py` (`104 passed`)
- `python -m pytest` (`5250 passed, 121 skipped`)
- rebuilt and fingerprint-verified the local Rust extension after rebasing onto current `master`
- `python -m compileall -q src/utils.py tests/test_utils_maps.py`
- `git diff --check`

The regression coverage includes reversed market order, a same-market `baseName` alias, cache refresh order across exchanges, exact native/CCXT symbols, and the unchanged single-multiplier behavior.
