### PR TITLE
Harden market identifier resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,33 @@ All notable user-facing changes will be documented in this file.
   short entry quantities are re-cropped after directional price quantization.
 - Directionally quantize passive WEL auto-reducer prices away from off-tick executable touches so
   limit reducers cannot become crossing orders merely through price-step rounding.
+- Resolve exchange market identifiers without lossy pre-normalization: exact CCXT symbols,
+  native market IDs, multiplier-prefixed bases, and `exchange::<native-id>` identities now take
+  precedence on every exchange. Convenience aliases that match multiple markets fail closed with
+  their candidates instead of selecting an order-dependent first match, missing exact identifiers
+  and namespaced HIP-3 aliases fail closed instead of normalizing to another market,
+  suffix-bearing native IDs remain lossless,
+  contradictory qualified source mappings are rejected, unqualified native IDs that identify
+  different contracts across configured exchanges require venue scope, and the same scaled-contract
+  identity check applies to ordinary convenience aliases; suite scenario identifiers
+  are validated and reconciled after union, inception discovery is limited to requested/live
+  venues and uses the offline fake timeline locally,
+  source and approved-market aliases are coalesced before dataset preparation, conflicting
+  duplicate coin and market-settings overrides are rejected consistently, unresolved delisted
+  fill IDs preserve their raw historical symbol, resolver changes invalidate old HLCV and
+  first-timestamp/inception caches now retain and revalidate resolved-symbol provenance, prepared
+  HLCV cache keys track current resolved venue symbols
+  after refreshing configured and source-only venue metadata,
+  unknown combined-market inception cannot satisfy positive minimum-age rules,
+  backtest-only coin sources cannot rewrite live approvals,
+  invalid live identifiers disable only their own eligibility while unresolved ignored IDs retain
+  only their own prior restrictions, `approved_coins="all"`
+  unifies quote variants and equivalent `k`/`1000` scaled contracts while keeping scaled and
+  unscaled markets distinct, rejects unavailable exact source overrides for active coins,
+  emits exchange-scoped identities for remaining collisions, and generated symbol maps plus durable
+  per-exchange ambiguity tombstones remain deterministic across cache refresh order. Live coin
+  overrides are rebuilt atomically so a failed metadata refresh cannot expose a partial override map.
+
 - Reconstruct trailing extrema for positions older than an exchange's retained 1m candles with
   the shared 1m, 5m, 15m, then 1h historical-resolution ladder. Coarser candles are limited to
   the old leading prefix, their source counts and exact-1m boundary are logged, and a real recent

--- a/src/backtest.py
+++ b/src/backtest.py
@@ -86,12 +86,20 @@ from config_utils import (
 from backtest_dataset import dump_backtest_dataset_metadata
 from analysis_visibility import filter_analysis_for_visibility
 from utils import (
+    MarketIdentifierResolutionError,
+    MarketIdentifierExchangeMismatch,
+    UnknownMarketIdentifier,
+    coin_to_symbol,
+    heuristic_symbol_to_coin,
+    looks_like_exact_market_identifier,
     utc_ms,
     make_get_filepath,
     load_markets,
     format_end_date,
     format_approved_ignored_coins,
     date_to_ts,
+    to_standard_exchange_name,
+    to_ccxt_exchange_id,
 )
 from pure_funcs import (
     ts_to_date,
@@ -103,6 +111,7 @@ import pprint
 from copy import deepcopy
 from hlcv_preparation import (
     HLCV_PREPARATION_ALGORITHM_VERSION,
+    _load_and_reconcile_combined_sources,
     prepare_hlcvs,
     prepare_hlcvs_combined,
     try_prepare_hlcvs_v2_local,
@@ -384,16 +393,60 @@ def _apply_market_settings_override(
     market_settings: dict,
     overrides: dict,
 ) -> dict:
+    def find_override(mapping: dict, venue: str, field_name: str):
+        direct_override = mapping.get(coin_key)
+        if venue == "combined" or not (
+            looks_like_exact_market_identifier(coin_key)
+            or any(looks_like_exact_market_identifier(key) for key in mapping)
+        ):
+            return direct_override
+        try:
+            target_symbol = coin_to_symbol(coin_key, venue, verbose=False)
+        except (MarketIdentifierExchangeMismatch, UnknownMarketIdentifier):
+            return direct_override
+        matches = (
+            [(coin_key, direct_override)] if direct_override is not None else []
+        )
+        for identifier, override in mapping.items():
+            if identifier == coin_key:
+                continue
+            try:
+                override_symbol = coin_to_symbol(identifier, venue, verbose=False)
+            except (MarketIdentifierExchangeMismatch, UnknownMarketIdentifier):
+                continue
+            if override_symbol == target_symbol:
+                matches.append((identifier, override))
+        if len(matches) > 1:
+            first_override = matches[0][1]
+            if any(override != first_override for _, override in matches[1:]):
+                raise ValueError(
+                    f"conflicting {field_name} keys resolve to {coin!r} on {venue}: "
+                    f"{sorted(identifier for identifier, _ in matches)}"
+                )
+            return first_override
+        return matches[0][1] if matches else None
+
     result = dict(market_settings)
     coin_key = normalize_backtest_coin(coin)
-    global_override = overrides.get("global", {}).get(coin_key)
+    entry_exchange = str(result.get("exchange") or exchange)
+    global_override = find_override(
+        overrides.get("global", {}),
+        entry_exchange,
+        "backtest.market_settings.overrides",
+    )
     if global_override:
         result.update(deepcopy(global_override))
-    entry_exchange = str(result.get("exchange") or exchange)
-    exchange_override = (
-        overrides.get("by_exchange", {}).get(entry_exchange, {}).get(coin_key)
-        or overrides.get("by_exchange", {}).get(str(exchange), {}).get(coin_key)
+    exchange_override = find_override(
+        overrides.get("by_exchange", {}).get(entry_exchange, {}),
+        entry_exchange,
+        f"backtest.market_settings.overrides_by_exchange.{entry_exchange}",
     )
+    if exchange_override is None and str(exchange) != entry_exchange:
+        exchange_override = find_override(
+            overrides.get("by_exchange", {}).get(str(exchange), {}),
+            str(exchange),
+            f"backtest.market_settings.overrides_by_exchange.{exchange}",
+        )
     if exchange_override:
         result.update(deepcopy(exchange_override))
     return result
@@ -1428,6 +1481,30 @@ def get_cache_hash(config, exchange):
     market_settings_sources_sorted = sorted(
         (str(k), str(v)) for k, v in market_settings_sources.items()
     )
+    identity_exchanges = (
+        [
+            *exchanges_cfg,
+            *coin_sources.values(),
+            *market_settings_sources.values(),
+        ]
+        if exchange == "combined"
+        else [exchange]
+    )
+    identity_exchanges = sorted(
+        {
+            to_standard_exchange_name(str(venue))
+            for venue in identity_exchanges
+            if str(venue).strip()
+        }
+    )
+    resolved_market_identities = []
+    for venue in identity_exchanges:
+        for coin in data_coins:
+            try:
+                symbol = coin_to_symbol(coin, venue, verbose=False)
+            except MarketIdentifierResolutionError:
+                symbol = None
+            resolved_market_identities.append((venue, str(coin), symbol))
     to_hash = {
         "coins": data_coins,
         "end_date": format_end_date(require_config_value(config, "backtest.end_date")),
@@ -1440,12 +1517,13 @@ def get_cache_hash(config, exchange):
         "ohlcv_source_dir": config.get("backtest", {}).get("ohlcv_source_dir"),
         "coin_sources": coin_sources_sorted,
         "market_settings_sources": market_settings_sources_sorted,
+        "resolved_market_identities": resolved_market_identities,
+        "hlcv_preparation_algorithm_version": HLCV_PREPARATION_ALGORITHM_VERSION,
     }
     if exchange == "combined":
         to_hash["volume_normalization"] = bool(
             config.get("backtest", {}).get("volume_normalization", True)
         )
-        to_hash["hlcv_preparation_algorithm_version"] = HLCV_PREPARATION_ALGORITHM_VERSION
     return calc_hash(to_hash)
 
 
@@ -1929,6 +2007,34 @@ async def prepare_hlcvs_mss(config, exchange, *, force_refetch_gaps: bool = Fals
     warmup_map = compute_per_coin_warmup_minutes(config)
     default_warm = int(warmup_map.get("__default__", 0))
     backtest_warmup_minutes = compute_backtest_warmup_minutes(config)
+    if exchange == "combined":
+        backtest_cfg = config.setdefault("backtest", {})
+        configured_exchanges = [
+            to_ccxt_exchange_id(value)
+            for value in require_config_value(config, "backtest.exchanges")
+        ]
+        forced_sources = {
+            str(coin): to_ccxt_exchange_id(source_exchange)
+            for coin, source_exchange in (backtest_cfg.get("coin_sources") or {}).items()
+            if source_exchange
+        }
+        market_settings_sources = {
+            str(coin): to_ccxt_exchange_id(source_exchange)
+            for coin, source_exchange in (
+                backtest_cfg.get("market_settings_sources") or {}
+            ).items()
+            if source_exchange
+        }
+        forced_sources, market_settings_sources = (
+            await _load_and_reconcile_combined_sources(
+                forced_sources,
+                market_settings_sources,
+                effective_backtest_data_coins(config),
+                configured_exchanges,
+            )
+        )
+        backtest_cfg["coin_sources"] = forced_sources
+        backtest_cfg["market_settings_sources"] = market_settings_sources
     override_result = load_hlcvs_data_override(config, exchange)
     if override_result is not None:
         cache_dir, coins, hlcvs, mss, results_path, btc_usd_prices, timestamps = override_result
@@ -2115,6 +2221,45 @@ def log_backtest_execution_settings(
     )
 
 
+def _get_backtest_coin_override(config, mss, exchange, coin):
+    overrides = config.get("coin_overrides", {})
+    direct_override = overrides.get(coin)
+    market_settings = mss.get(coin, {})
+    venue = market_settings.get("exchange") or exchange
+    if venue == "combined":
+        return {}
+    target_symbol = market_settings.get("symbol")
+    if not target_symbol:
+        try:
+            target_symbol = coin_to_symbol(coin, venue, verbose=False)
+        except (MarketIdentifierExchangeMismatch, UnknownMarketIdentifier):
+            return direct_override or {}
+    matches = [(coin, direct_override)] if direct_override is not None else []
+    for identifier, override in overrides.items():
+        if identifier == coin:
+            continue
+        if not (
+            looks_like_exact_market_identifier(identifier)
+            or looks_like_exact_market_identifier(coin)
+        ):
+            continue
+        try:
+            override_symbol = coin_to_symbol(identifier, venue, verbose=False)
+        except (MarketIdentifierExchangeMismatch, UnknownMarketIdentifier):
+            continue
+        if override_symbol == target_symbol:
+            matches.append((identifier, override))
+    if len(matches) > 1:
+        first_override = matches[0][1]
+        if any(override != first_override for _, override in matches[1:]):
+            raise ValueError(
+                f"conflicting coin_overrides resolve to {coin!r} on {venue}: "
+                f"{sorted(identifier for identifier, _ in matches)}"
+            )
+        return first_override
+    return matches[0][1] if matches else {}
+
+
 def prep_backtest_args(
     config,
     mss,
@@ -2146,7 +2291,7 @@ def prep_backtest_args(
     for coin in coins:
         coin_specific_bot_params = {}
         coin_specific_strategy_params = {}
-        coin_override = config.get("coin_overrides", {}).get(coin, {})
+        coin_override = _get_backtest_coin_override(config, mss, exchange, coin)
         coin_override_bot = coin_override.get("bot", {})
         for pside in ["long", "short"]:
             override_side = coin_override_bot.get(pside, {})
@@ -2167,8 +2312,15 @@ def prep_backtest_args(
                 coin_override.get("live", {}).get(f"forced_mode_{pside}", "") == "normal"
             )
         coin_key = normalize_backtest_coin(coin)
+        coin_canonical = heuristic_symbol_to_coin(coin_key)
         for pside in POSITION_SIDES:
-            if coin_key not in approved_by_side[pside]:
+            approved_exact = approved_by_side[pside]
+            approved_by_alias = any(
+                not looks_like_exact_market_identifier(identifier)
+                and heuristic_symbol_to_coin(identifier) == coin_canonical
+                for identifier in approved_exact
+            )
+            if coin_key not in approved_exact and not approved_by_alias:
                 coin_specific_bot_params[pside]["wallet_exposure_limit"] = 0.0
             elif "wallet_exposure_limit" not in coin_override_bot.get(pside, {}):
                 coin_specific_bot_params[pside]["wallet_exposure_limit"] = -1.0
@@ -2848,7 +3000,9 @@ async def main():
 
     for ex in backtest_exchanges:
         await load_markets(ex)
-    await format_approved_ignored_coins(config, backtest_exchanges)
+    await format_approved_ignored_coins(
+        config, backtest_exchanges, prefer_backtest_coin_source_keys=True
+    )
     config["disable_plotting"] = (
         args.disable_plotting if args.disable_plotting is not None else False
     )

--- a/src/backtest_universe.py
+++ b/src/backtest_universe.py
@@ -5,7 +5,8 @@ from typing import Any
 
 from config.access import require_config_value, require_live_value
 from config.shared_bot import require_grouped_bot_value
-from utils import symbol_to_coin
+from utils import heuristic_symbol_to_coin, looks_like_exact_market_identifier
+
 
 POSITION_SIDES = ("long", "short")
 
@@ -30,7 +31,11 @@ def backtest_side_enabled(config: dict, pside: str) -> bool:
 
 
 def normalize_backtest_coin(coin: Any) -> str:
-    return symbol_to_coin(str(coin), verbose=False)
+    raw = str(coin).strip()
+    # Keep explicitly exchange-scoped identities and exact CCXT symbols
+    # lossless.  Other unqualified inputs retain the established canonical
+    # coin keys used by datasets, overrides, and Rust payloads.
+    return raw if looks_like_exact_market_identifier(raw) else heuristic_symbol_to_coin(raw)
 
 
 def _normalize_coin_list(coins: Any) -> list[str]:

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -89,7 +89,11 @@ from legacy_data_migrator import (
     normalize_ccxt_volume_to_base,
 )
 from live.diagnostic_safety import bounded_exception_type
-from utils import symbol_to_coin
+from utils import (
+    FIRST_OHLCV_TIMESTAMPS_CACHE_VERSION,
+    exchange_name_aliases,
+    symbol_to_coin,
+)
 
 # Suppress portalocker's "timeout has no effect in blocking mode" warning
 warnings.filterwarnings(
@@ -4857,23 +4861,76 @@ class CandlestickManager:
     def _first_ohlcv_cache_path(self) -> Path:
         return Path(self.cache_dir) / "first_ohlcv_timestamps_unified_exchange_specific.json"
 
+    def _first_ohlcv_cache_version_path(self) -> Path:
+        return Path(self.cache_dir) / "first_ohlcv_timestamps_unified.version"
+
+    def _first_ohlcv_cache_symbols_path(self) -> Path:
+        return (
+            Path(self.cache_dir)
+            / "first_ohlcv_timestamps_unified_exchange_specific_symbols.json"
+        )
+
     def _first_ohlcv_cache_exchange_name(self) -> str:
         exchange_name = str(self.exchange_name or self._ex_id or "").lower()
         return _FIRST_OHLCV_EXCHANGE_CACHE_ALIASES.get(exchange_name, exchange_name)
 
     def _lookup_cached_authoritative_start_ts(self, symbol: str) -> Optional[int]:
         cache_path = self._first_ohlcv_cache_path()
-        if not cache_path.exists():
+        symbols_path = self._first_ohlcv_cache_symbols_path()
+        if not cache_path.exists() or not symbols_path.exists():
             return None
         try:
+            with open(self._first_ohlcv_cache_version_path(), "r", encoding="utf-8") as f:
+                if int(f.read().strip()) != FIRST_OHLCV_TIMESTAMPS_CACHE_VERSION:
+                    return None
             with open(cache_path, "r", encoding="utf-8") as f:
                 data = json.load(f)
-            if not isinstance(data, dict):
+            with open(symbols_path, "r", encoding="utf-8") as f:
+                cached_symbols = json.load(f)
+            if not isinstance(data, dict) or not isinstance(cached_symbols, dict):
                 return None
-            coin = symbol.split("/")[0].strip()
             exchange_name = self._first_ohlcv_cache_exchange_name()
-            value = data.get(coin, {}).get(exchange_name)
-            return int(value) if value is not None and float(value) > 0.0 else None
+            cache_keys = [symbol]
+            markets = getattr(self.exchange, "markets", {}) if self.exchange is not None else {}
+            if isinstance(markets, dict):
+                for market_symbol, market in markets.items():
+                    if not isinstance(market, dict):
+                        continue
+                    resolved_symbol = str(market.get("symbol") or market_symbol)
+                    if resolved_symbol != symbol:
+                        continue
+                    native_id = str(market.get("id") or "").strip()
+                    if native_id and native_id not in cache_keys:
+                        cache_keys.append(native_id)
+                    if native_id:
+                        qualifiers = set(exchange_name_aliases(exchange_name))
+                        qualifiers.update(exchange_name_aliases(self.exchange_name))
+                        qualifiers.update(exchange_name_aliases(self._ex_id))
+                        for qualifier in sorted(qualifiers):
+                            qualified_id = f"{qualifier}::{native_id}"
+                            if qualified_id not in cache_keys:
+                                cache_keys.append(qualified_id)
+            base_coin = symbol.split("/")[0].strip()
+            if base_coin != symbol:
+                cache_keys.append(base_coin)
+            for cache_key in cache_keys:
+                exchange_values = data.get(cache_key, {})
+                if not isinstance(exchange_values, dict):
+                    continue
+                value = exchange_values.get(exchange_name)
+                provenance_values = cached_symbols.get(cache_key, {})
+                cached_symbol = (
+                    provenance_values.get(exchange_name)
+                    if isinstance(provenance_values, dict)
+                    else None
+                )
+                if (
+                    value is not None
+                    and float(value) > 0.0
+                    and cached_symbol == symbol
+                ):
+                    return int(value)
+            return None
         except Exception:
             return None
 

--- a/src/config/hydrate.py
+++ b/src/config/hydrate.py
@@ -2,7 +2,12 @@ import logging
 from copy import deepcopy
 from typing import Any, Dict, Iterable, Optional
 
-from utils import format_end_date, normalize_coins_source, symbol_to_coin
+from utils import (
+    format_end_date,
+    looks_like_exact_market_identifier,
+    normalize_coins_source,
+    symbol_to_coin,
+)
 from optimization.random_seed import normalize_optional_seed
 
 from .limits import _resolve_optimize_limits_for_load
@@ -152,7 +157,12 @@ def _normalize_coin_sources(raw: Any) -> Dict[str, str]:
     for coin, exchange in raw.items():
         if exchange is None:
             continue
-        coin_key = symbol_to_coin(str(coin), verbose=False)
+        raw_coin = str(coin).strip()
+        coin_key = (
+            raw_coin
+            if looks_like_exact_market_identifier(raw_coin)
+            else symbol_to_coin(raw_coin, verbose=False)
+        )
         if not coin_key:
             continue
         exchange_value = str(exchange)

--- a/src/config/overrides.py
+++ b/src/config/overrides.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 from typing import Callable
 
 from pure_funcs import sort_dict_keys
-from utils import symbol_to_coin
+from utils import looks_like_exact_market_identifier, symbol_to_coin
 
 from .load import load_input_config, prepare_config
 from .log_output import log_config_message
@@ -692,7 +692,9 @@ def parse_overrides(
     for coin, overrides in result["coin_overrides"].items():
         if not isinstance(coin, str):
             raise TypeError("coin_overrides keys must be strings")
-        formatted_coin = symbol_normalizer(coin)
+        formatted_coin = (
+            coin if looks_like_exact_market_identifier(coin) else symbol_normalizer(coin)
+        )
         if not formatted_coin:
             raise ValueError(f"coin_overrides.{coin} is not a valid coin or symbol")
         if formatted_coin in normalized_overrides:

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -44,9 +44,21 @@ from config import load_input_config, prepare_config
 from live.diagnostic_safety import bounded_exception_type, exception_text_contains
 
 try:
-    from utils import ts_to_date  # type: ignore
+    from utils import (  # type: ignore
+        AmbiguousMarketIdentifier,
+        MarketIdentifierResolutionError,
+        MarketIdentifierExchangeMismatch,
+        UnknownMarketIdentifier,
+        ts_to_date,
+    )
 except ImportError:  # pragma: no cover - fallback for package-relative execution
-    from .utils import ts_to_date
+    from .utils import (
+        AmbiguousMarketIdentifier,
+        MarketIdentifierResolutionError,
+        MarketIdentifierExchangeMismatch,
+        UnknownMarketIdentifier,
+        ts_to_date,
+    )
 
 from logging_setup import configure_logging
 from procedures import load_user_info
@@ -2973,6 +2985,15 @@ class BitgetFetcher(BaseFetcher):
             return ""
         try:
             resolved = self._symbol_resolver(market_symbol)
+        except UnknownMarketIdentifier:
+            logger.warning(
+                "BitgetFetcher._resolve_symbol: historical symbol '%s' is absent from "
+                "current markets; preserving raw value",
+                market_symbol,
+            )
+            return str(market_symbol)
+        except (AmbiguousMarketIdentifier, MarketIdentifierExchangeMismatch):
+            raise
         except Exception as exc:
             logger.warning(
                 "BitgetFetcher._resolve_symbol: resolver failed for %s error_type=%s; using fallback",
@@ -3611,6 +3632,15 @@ class BinanceFetcher(BaseFetcher):
             resolved = self._symbol_resolver(value)
             if resolved:
                 return resolved
+        except UnknownMarketIdentifier:
+            logger.warning(
+                "BinanceFetcher._resolve_symbol: historical symbol '%s' is absent from "
+                "current markets; preserving raw value",
+                value,
+            )
+            return str(value)
+        except (AmbiguousMarketIdentifier, MarketIdentifierExchangeMismatch):
+            raise
         except Exception as exc:
             logger.warning(
                 "BinanceFetcher._resolve_symbol: resolver failed for %s error_type=%s",
@@ -8306,6 +8336,8 @@ def _symbol_resolver(bot) -> Callable[[Optional[str]], str]:
             mapped = bot.coin_to_symbol(value, verbose=False)
             if mapped:
                 return mapped
+        except MarketIdentifierResolutionError:
+            raise
         except Exception:
             pass
         upper = value.upper()

--- a/src/hlcv_preparation.py
+++ b/src/hlcv_preparation.py
@@ -89,13 +89,18 @@ from config.access import require_config_value, require_live_value
 from ohlcv_utils import get_days_in_between, load_ohlcv_data
 from procedures import get_first_timestamps_unified
 from utils import (
+    MarketIdentifierExchangeMismatch,
+    UnknownMarketIdentifier,
     coin_to_symbol,
+    heuristic_symbol_to_coin,
+    looks_like_exact_market_identifier,
     to_standard_exchange_name,
     format_end_date,
     get_quote,
     load_ccxt_instance,
     load_markets,
     make_get_filepath,
+    split_exchange_qualified_market_identifier,
     to_ccxt_exchange_id,
     symbol_to_coin,
     ts_to_date,
@@ -106,16 +111,36 @@ from warmup_utils import compute_backtest_warmup_minutes, compute_per_coin_warmu
 from backtest_universe import effective_backtest_data_coins
 
 
-HLCV_PREPARATION_ALGORITHM_VERSION = 5
+HLCV_PREPARATION_ALGORITHM_VERSION = 6
 VOLUME_NORMALIZATION_LOOKBACK_DAYS = 60
 VOLUME_NORMALIZATION_MIN_COMMON_FRACTION = 0.95
 VOLUME_NORMALIZATION_MIN_ELIGIBLE_DAYS_FRACTION = 0.80
 VOLUME_NORMALIZATION_MIN_CONTRIBUTORS = 3
 
 
-def _filter_forced_sources_for_coins(
-    forced_sources: Dict[str, str], coins: Sequence[str]
+def _reconcile_exchange_sources_for_coins(
+    sources: Dict[str, str],
+    coins: Sequence[str],
+    *,
+    field_name: str,
+    defer_unavailable: bool = False,
 ) -> Dict[str, str]:
+    def canonical_alias(identifier: str) -> str:
+        _qualified_exchange, unqualified = split_exchange_qualified_market_identifier(
+            str(identifier)
+        )
+        return heuristic_symbol_to_coin(unqualified)
+
+    for source_coin, exchange in sources.items():
+        qualified_exchange, _ = split_exchange_qualified_market_identifier(source_coin)
+        if (
+            qualified_exchange is not None
+            and qualified_exchange != to_standard_exchange_name(exchange)
+        ):
+            raise MarketIdentifierExchangeMismatch(
+                f"market identifier {source_coin!r} targets {qualified_exchange}, "
+                f"not {to_standard_exchange_name(exchange)}"
+            )
     active_aliases: set[str] = set()
     for raw_coin in coins:
         coin = str(raw_coin)
@@ -124,11 +149,105 @@ def _filter_forced_sources_for_coins(
             active_aliases.add(coin[4:])
         else:
             active_aliases.add(f"xyz:{coin}")
-    return {
-        coin: forced_sources[coin]
-        for coin in sorted(forced_sources)
+    filtered = {
+        coin: sources[coin]
+        for coin in sorted(sources)
         if coin in active_aliases
     }
+    active_coins = [str(coin) for coin in coins]
+    for source_coin in sorted(sources):
+        if source_coin in active_aliases:
+            continue
+        exchange = sources[source_coin]
+        if not (
+            looks_like_exact_market_identifier(source_coin)
+            or any(looks_like_exact_market_identifier(coin) for coin in active_coins)
+        ):
+            continue
+        try:
+            source_symbol = coin_to_symbol(source_coin, exchange, verbose=False)
+        except UnknownMarketIdentifier as exc:
+            if defer_unavailable:
+                filtered[source_coin] = exchange
+            elif canonical_alias(source_coin) in {
+                canonical_alias(active_coin) for active_coin in active_coins
+            }:
+                raise UnknownMarketIdentifier(
+                    f"{field_name} key {source_coin!r} is unavailable on {exchange} "
+                    "but corresponds to an active backtest coin"
+                ) from exc
+            continue
+        matches = []
+        for active_coin in active_coins:
+            try:
+                if coin_to_symbol(active_coin, exchange, verbose=False) == source_symbol:
+                    matches.append(active_coin)
+            except (MarketIdentifierExchangeMismatch, UnknownMarketIdentifier):
+                continue
+        if len(matches) > 1:
+            raise ValueError(
+                f"{field_name} key {source_coin!r} matches multiple active coins "
+                f"on {exchange}: {sorted(matches)}"
+            )
+        if not matches:
+            continue
+        active_coin = matches[0]
+        existing = filtered.get(active_coin)
+        if existing is not None and existing != exchange:
+            raise ValueError(
+                f"{field_name} maps conflicting exchanges for {active_coin}: "
+                f"{existing} and {exchange}"
+            )
+        filtered[active_coin] = exchange
+    return {coin: filtered[coin] for coin in sorted(filtered)}
+
+
+def _filter_forced_sources_for_coins(
+    forced_sources: Dict[str, str],
+    coins: Sequence[str],
+    *,
+    defer_unavailable: bool = False,
+) -> Dict[str, str]:
+    return _reconcile_exchange_sources_for_coins(
+        forced_sources,
+        coins,
+        field_name="backtest.coin_sources",
+        defer_unavailable=defer_unavailable,
+    )
+
+
+def _filter_market_settings_sources_for_coins(
+    market_settings_sources: Dict[str, str],
+    coins: Sequence[str],
+    *,
+    defer_unavailable: bool = False,
+) -> Dict[str, str]:
+    return _reconcile_exchange_sources_for_coins(
+        market_settings_sources,
+        coins,
+        field_name="backtest.market_settings_sources",
+        defer_unavailable=defer_unavailable,
+    )
+
+
+async def _load_and_reconcile_combined_sources(
+    forced_sources: Dict[str, str],
+    market_settings_sources: Dict[str, str],
+    coins: Sequence[str],
+    configured_exchanges: Sequence[str] = (),
+) -> tuple[Dict[str, str], Dict[str, str]]:
+    """Load override venues before deciding which ones participate in preparation."""
+    source_exchanges = sorted(
+        (set(forced_sources.values()) | set(market_settings_sources.values()))
+        - set(configured_exchanges)
+    )
+    await asyncio.gather(
+        *[load_markets(exchange, verbose=False) for exchange in source_exchanges]
+    )
+    return (
+        _filter_forced_sources_for_coins(forced_sources, coins),
+        _filter_market_settings_sources_for_coins(market_settings_sources, coins),
+    )
 
 
 def _partition_combined_exchange_roles(
@@ -573,7 +692,16 @@ class HLCVManager:
 
     def get_symbol(self, coin: str) -> str:
         assert self.markets, "needs to call load_markets() first"
-        symbol = coin_to_symbol(coin, self.exchange)
+        try:
+            symbol = coin_to_symbol(coin, self.exchange)
+        except MarketIdentifierExchangeMismatch:
+            # Exchange-qualified identities are intentionally unavailable on
+            # every other source in combined-exchange preparation.
+            return ""
+        except UnknownMarketIdentifier:
+            # The manager's in-memory market metadata is authoritative even
+            # when a disk-backed symbol map has not yet been generated.
+            symbol = ""
         if symbol in self.markets:
             return symbol
 
@@ -1255,7 +1383,9 @@ async def try_prepare_hlcvs_v2_local(
 
     try:
         await om.load_markets()
-        first_timestamps_unified = await get_first_timestamps_unified(coins)
+        first_timestamps_unified = await get_first_timestamps_unified(
+            coins, exchange=exchange
+        )
         catalog = OhlcvCatalog(Path("caches") / "ohlcvs" / "catalog.sqlite")
         store = OhlcvStore(Path("caches") / "ohlcvs", catalog)
         mss = {}
@@ -1269,6 +1399,11 @@ async def try_prepare_hlcvs_v2_local(
                 continue
             if coin not in first_timestamps_unified:
                 logging.info("[%s] v2 local skip missing unified inception %s", exchange, coin)
+                continue
+            if minimum_coin_age_days > 0.0 and not _coerce_positive_ts(
+                first_timestamps_unified.get(coin)
+            ):
+                logging.info("[%s] v2 local skip unknown inception %s", exchange, coin)
                 continue
 
             first_ts_guess = om.load_first_timestamp(coin)
@@ -4043,7 +4178,9 @@ async def prepare_hlcvs_internal(
     minimum_coin_age_days = float(require_live_value(config, "minimum_coin_age_days"))
     interval_ms = 60_000
 
-    first_timestamps_unified = await get_first_timestamps_unified(coins)
+    first_timestamps_unified = await get_first_timestamps_unified(
+        coins, exchange=exchange
+    )
     per_coin_warmups = compute_per_coin_warmup_minutes(config)
     default_warm = int(per_coin_warmups.get("__default__", 0))
 
@@ -4087,6 +4224,16 @@ async def prepare_hlcvs_internal(
                 if minimum_coin_age_days > 0.0 and not (
                     is_stock_perp_coin and tradfi_for_stock_perps
                 ):
+                    unified_first_ts = _coerce_positive_ts(
+                        first_timestamps_unified.get(coin)
+                    )
+                    if unified_first_ts is None:
+                        _pct_log(
+                            "info",
+                            progress.pct(),
+                            f"{exchange} coin {coin} has no authoritative inception; skipping",
+                        )
+                        return None
                     fetch_stage = "get_first_timestamp"
                     first_ts = await om.get_first_timestamp(coin)
 
@@ -4099,7 +4246,7 @@ async def prepare_hlcvs_internal(
                         return None
 
                     coin_age_days = int(
-                        round(utc_ms() - first_timestamps_unified[coin]) / (1000 * 60 * 60 * 24)
+                        round(utc_ms() - unified_first_ts) / (1000 * 60 * 60 * 24)
                     )
                     if coin_age_days < minimum_coin_age_days:
                         _pct_log(
@@ -4111,7 +4258,7 @@ async def prepare_hlcvs_internal(
                         return None
 
                     new_adjusted_start_ts = max(
-                        first_timestamps_unified[coin] + min_coin_age_ms, first_ts
+                        unified_first_ts + min_coin_age_ms, first_ts
                     )
                     if new_adjusted_start_ts > adjusted_start_ts:
                         _pct_log(
@@ -4267,16 +4414,20 @@ async def prepare_hlcvs_combined(
         for coin, exchange in forced_sources.items()
         if exchange
     }
-    normalized_forced_sources = _filter_forced_sources_for_coins(
-        normalized_forced_sources,
-        effective_backtest_data_coins(config),
-    )
     market_settings_sources = market_settings_sources or {}
     normalized_mss_sources = {
         str(coin): to_ccxt_exchange_id(exchange)
         for coin, exchange in market_settings_sources.items()
         if exchange
     }
+    normalized_forced_sources, normalized_mss_sources = (
+        await _load_and_reconcile_combined_sources(
+            normalized_forced_sources,
+            normalized_mss_sources,
+            effective_backtest_data_coins(config),
+            exchanges_to_consider,
+        )
+    )
     # Only configured exchanges may be selected for unforced coins. Exchanges used
     # solely by a per-coin override still need managers and normalization overlap
     # candidates, but must not enter unrelated source selection. Sort those extras
@@ -4487,7 +4638,12 @@ async def _prepare_hlcvs_combined_impl(
     tradfi_for_stock_perps = _has_stock_perp_calendar_context(
         config.get("backtest", {}).get("ohlcv_source_dir")
     )
-    first_timestamps_unified = await get_first_timestamps_unified(coins)
+    timestamp_exchanges = list(
+        dict.fromkeys([*exchanges_to_consider, *forced_sources.values()])
+    )
+    first_timestamps_unified = await get_first_timestamps_unified(
+        coins, exchanges=timestamp_exchanges
+    )
 
     per_coin_warmups = compute_per_coin_warmup_minutes(config)
     default_warm = int(per_coin_warmups.get("__default__", 0))
@@ -4500,6 +4656,10 @@ async def _prepare_hlcvs_combined_impl(
 
     # Preload markets
     await asyncio.gather(*[om.load_markets() for om in om_dict.values()])
+    forced_sources = _filter_forced_sources_for_coins(forced_sources, coins)
+    market_settings_sources = _filter_market_settings_sources_for_coins(
+        market_settings_sources, coins
+    )
     coins = _normalize_combined_coins(coins, forced_sources, om_dict, first_timestamps_unified)
 
     progress = ProgressTracker(len(coins), "combined fetching candles")
@@ -4833,7 +4993,15 @@ def _plan_combined_coin(
         effective_start_ts = int(base_start_ts)
         coin_fts = None
     else:
-        coin_fts = int(first_timestamps_unified[coin])
+        coin_fts = _coerce_positive_ts(first_timestamps_unified[coin])
+        if minimum_coin_age_days > 0.0 and coin_fts is None:
+            logging.info(
+                "%s: skipping - no authoritative inception for min_age=%d days",
+                coin,
+                int(minimum_coin_age_days),
+            )
+            return None
+        coin_fts = int(coin_fts or 0)
         effective_start_ts = max(int(base_start_ts), coin_fts + int(min_coin_age_ms))
     if effective_start_ts > end_ts:
         logging.info(
@@ -5047,8 +5215,13 @@ def _resolve_combined_market_settings(
             settings_exchange = best_exchange
         else:
             try:
-                settings_om.get_symbol(coin)
-            except Exception:
+                if not settings_om.has_coin(coin):
+                    raise LookupError("market identifier unavailable on settings source")
+            except (
+                LookupError,
+                MarketIdentifierExchangeMismatch,
+                UnknownMarketIdentifier,
+            ):
                 logging.warning(
                     f"{coin}: not listed on market_settings_sources exchange '{settings_exchange}', "
                     f"falling back to OHLCV source '{best_exchange}'"

--- a/src/hlcvs_override.py
+++ b/src/hlcvs_override.py
@@ -21,7 +21,14 @@ from hlcvs_manifest import (
     manifest_has_required_schema,
     verify_hlcvs_manifest,
 )
-from utils import date_to_ts, format_end_date, ts_to_date
+from utils import (
+    MarketIdentifierExchangeMismatch,
+    UnknownMarketIdentifier,
+    coin_to_symbol,
+    date_to_ts,
+    format_end_date,
+    ts_to_date,
+)
 from warmup_utils import compute_backtest_warmup_minutes
 
 
@@ -97,8 +104,47 @@ def _load_hlcvs_cache_arrays(cache_dir: Path, manifest, preloaded_arrays=None):
     return coins, hlcvs, mss, btc_usd_prices, timestamps
 
 
-def _side_membership_for_override(config: dict, dataset_coins: list[str], manifest, mode: str) -> dict:
-    input_sides = effective_backtest_approved_coins_by_side(config)
+def _reconcile_override_identifiers(
+    identifiers, dataset_coins: list[str], exchange: str
+) -> list[str]:
+    dataset_by_symbol = {}
+    for dataset_coin in dataset_coins:
+        try:
+            symbol = coin_to_symbol(dataset_coin, exchange, verbose=False)
+        except (MarketIdentifierExchangeMismatch, UnknownMarketIdentifier):
+            continue
+        existing = dataset_by_symbol.get(symbol)
+        if existing is not None and existing != dataset_coin:
+            raise ValueError(
+                f"HLCV dataset coins {existing!r} and {dataset_coin!r} resolve "
+                f"to the same {exchange} market {symbol!r}"
+            )
+        dataset_by_symbol[symbol] = dataset_coin
+
+    reconciled = []
+    dataset_coin_set = set(dataset_coins)
+    for identifier in identifiers:
+        if identifier in dataset_coin_set:
+            resolved = identifier
+        else:
+            try:
+                symbol = coin_to_symbol(identifier, exchange, verbose=False)
+            except (MarketIdentifierExchangeMismatch, UnknownMarketIdentifier):
+                resolved = identifier
+            else:
+                resolved = dataset_by_symbol.get(symbol, identifier)
+        if resolved not in reconciled:
+            reconciled.append(resolved)
+    return reconciled
+
+
+def _side_membership_for_override(
+    config: dict, dataset_coins: list[str], manifest, mode: str, exchange: str
+) -> dict:
+    input_sides = {
+        pside: _reconcile_override_identifiers(coins, dataset_coins, exchange)
+        for pside, coins in effective_backtest_approved_coins_by_side(config).items()
+    }
     dataset_coin_set = set(dataset_coins)
     if mode == "intersection":
         return {
@@ -206,7 +252,9 @@ def load_hlcvs_data_override(config, exchange):
         cache_dir, manifest, preloaded_arrays=verified_arrays
     )
     dataset_coins = [normalize_backtest_coin(coin) for coin in dataset_coins]
-    requested_coins = effective_backtest_data_coins(config)
+    requested_coins = _reconcile_override_identifiers(
+        effective_backtest_data_coins(config), dataset_coins, exchange
+    )
     if mode == "intersection":
         selected_coins = [coin for coin in dataset_coins if coin in set(requested_coins)]
     else:
@@ -259,7 +307,9 @@ def load_hlcvs_data_override(config, exchange):
         meta = deepcopy(mss.get(coin, {}))
         _slice_valid_window_metadata(meta, row_start=row_start, row_end=row_end)
         selected_mss[coin] = meta
-    side_membership = _side_membership_for_override(config, selected_coins, manifest, mode)
+    side_membership = _side_membership_for_override(
+        config, selected_coins, manifest, mode, exchange
+    )
     side_membership = {
         pside: sorted([coin for coin in side_membership.get(pside, []) if coin in selected_coins])
         for pside in POSITION_SIDES

--- a/src/ohlcv_download.py
+++ b/src/ohlcv_download.py
@@ -13,7 +13,9 @@ from utils import format_approved_ignored_coins
 
 async def warm_ohlcv_caches(config: dict, *, force_refetch_gaps: bool = False) -> None:
     exchanges = require_config_value(config, "backtest.exchanges")
-    await format_approved_ignored_coins(config, exchanges)
+    await format_approved_ignored_coins(
+        config, exchanges, prefer_backtest_coin_source_keys=True
+    )
     config.setdefault("backtest", {})
     config["backtest"]["cache_dir"] = {}
     config["backtest"]["coins"] = {}

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -3202,7 +3202,9 @@ async def main():
     else:
         apply_fine_tune_bounds(config, fine_tune_params, cli_bounds_overrides)
     backtest_exchanges = require_config_value(config, "backtest.exchanges")
-    await format_approved_ignored_coins(config, backtest_exchanges)
+    await format_approved_ignored_coins(
+        config, backtest_exchanges, prefer_backtest_coin_source_keys=True
+    )
     data_config = build_optimizer_data_config(config)
     interrupted = False
     failed = False

--- a/src/optimize_suite.py
+++ b/src/optimize_suite.py
@@ -36,8 +36,15 @@ from suite_runner import (
     _compute_slice_indices,
     _normalize_date_to_ts,
     _determine_needed_individual_exchanges,
+    _coalesce_master_coins,
 )
-from utils import format_approved_ignored_coins, load_markets, ts_to_date, utc_ms
+from utils import (
+    format_approved_ignored_coins,
+    load_markets,
+    reject_cross_exchange_market_identifier_collisions,
+    ts_to_date,
+    utc_ms,
+)
 
 
 @dataclass
@@ -84,10 +91,19 @@ async def prepare_suite_contexts(
             sorted(added_exchanges),
         )
 
-    for exchange in exchanges_list:
+    suite_coin_sources = collect_suite_coin_sources(config, scenarios)
+    identity_exchanges = sorted(
+        set(exchanges_list) | set(suite_coin_sources.values())
+    )
+    for exchange in identity_exchanges:
         await load_markets(exchange, verbose=False)
-    await format_approved_ignored_coins(config, exchanges_list, verbose=False)
-    validate_suite_side_coin_lists(config)
+    await format_approved_ignored_coins(
+        config,
+        exchanges_list,
+        verbose=False,
+        prefer_backtest_coin_source_keys=True,
+    )
+    validate_suite_side_coin_lists(config, exchanges_list)
 
     base_start = require_config_value(config, "backtest.start_date")
     base_end = require_config_value(config, "backtest.end_date")
@@ -109,8 +125,6 @@ async def prepare_suite_contexts(
     else:
         base_ignored_list = []
 
-    suite_coin_sources = collect_suite_coin_sources(config, scenarios)
-
     # Match suite_runner: scenario-specific coins extend the base universe, they do not replace it.
     master_coins = set(base_coins_list)
     master_ignored = set(base_ignored_list)
@@ -119,10 +133,15 @@ async def prepare_suite_contexts(
             master_coins.update(scenario.coins)
         if scenario.ignored_coins:
             master_ignored.update(scenario.ignored_coins)
-    master_coins.update(suite_coin_sources.keys())
-
-    master_coins_list = sorted(master_coins)
+    master_coins_list = _coalesce_master_coins(
+        sorted(master_coins), suite_coin_sources, identity_exchanges
+    )
     master_ignored_list = sorted(master_ignored)
+    await reject_cross_exchange_market_identifier_collisions(
+        [*master_coins_list, *master_ignored_list, *suite_coin_sources.keys()],
+        identity_exchanges,
+        verbose=False,
+    )
 
     base_config = deepcopy(config)
     if isinstance(base_config["live"]["approved_coins"], dict):

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -141,6 +141,7 @@ from logging_setup import (
     resolve_log_level,
 )
 from utils import (
+    MarketIdentifierResolutionError,
     load_markets,
     coin_to_symbol,
     symbol_to_coin,
@@ -4440,11 +4441,20 @@ class Passivbot:
 
     def init_coin_overrides(self):
         """Populate coin override map keyed by symbols for quick lookup."""
-        self.coin_overrides = {
-            s: v
-            for k, v in self.config.get("coin_overrides", {}).items()
-            if (s := self.coin_to_symbol(k))
-        }
+        resolved_coin_overrides = {}
+        override_keys_by_symbol = {}
+        for key, value in self.config.get("coin_overrides", {}).items():
+            symbol = self.coin_to_symbol(key)
+            if not symbol:
+                continue
+            if symbol in resolved_coin_overrides and resolved_coin_overrides[symbol] != value:
+                raise ValueError(
+                    f"conflicting coin_overrides keys resolve to {symbol}: "
+                    f"{override_keys_by_symbol[symbol]!r} and {key!r}"
+                )
+            resolved_coin_overrides[symbol] = value
+            override_keys_by_symbol.setdefault(symbol, key)
+        self.coin_overrides = resolved_coin_overrides
         if self.coin_overrides:
             logging.debug(
                 "Initialized coin overrides for %s",
@@ -5315,7 +5325,28 @@ class Passivbot:
         )
         if all([s in self.first_timestamps for s in symbols]):
             return
-        first_timestamps = await get_first_timestamps_unified(symbols)
+        if self.exchange == "fake":
+            first_timestamps = {}
+            for symbol in symbols:
+                symbolf = self.coin_to_symbol(symbol, verbose=False)
+                try:
+                    candles = await self.cca.fetch_ohlcv(
+                        symbolf, timeframe="1m", since=1
+                    )
+                except Exception as e:
+                    logging.warning(
+                        "fake: unable to derive first timestamp for %s: %s",
+                        symbolf,
+                        e,
+                    )
+                    candles = []
+                first_timestamps[symbol] = (
+                    int(candles[0][0]) if candles else 0.0
+                )
+        else:
+            first_timestamps = await get_first_timestamps_unified(
+                symbols, exchange=self.exchange
+            )
         self.first_timestamps.update(first_timestamps)
         for symbol in sorted(self.first_timestamps):
             symbolf = self.coin_to_symbol(symbol, verbose=False)
@@ -5922,17 +5953,9 @@ class Passivbot:
         """Map a coin identifier to the exchange-specific trading symbol."""
         if coin == "":
             return ""
-        if not hasattr(self, "coin_to_symbol_map"):
-            self.coin_to_symbol_map = {}
-        if coin in self.coin_to_symbol_map:
-            return self.coin_to_symbol_map[coin]
-        coinf = symbol_to_coin(coin, verbose=verbose)
-        if coinf in self.coin_to_symbol_map:
-            self.coin_to_symbol_map[coin] = self.coin_to_symbol_map[coinf]
-            return self.coin_to_symbol_map[coinf]
-        result = coin_to_symbol(coin, self.exchange, quote=self.quote, verbose=verbose)
-        self.coin_to_symbol_map[coin] = result
-        return result
+        # The shared resolver already caches maps with file-change detection.
+        # A second bot-level result cache would hide newly ambiguous aliases.
+        return coin_to_symbol(coin, self.exchange, quote=self.quote, verbose=verbose)
 
     def order_to_order_tuple(self, order):
         """Convert an order dictionary into a normalized tuple for comparisons."""
@@ -21889,13 +21912,23 @@ class Passivbot:
         if log_psides is None:
             log_psides = set(content.keys())
         symbols = None
+        resolved_identifier_symbols = None
+        resolution_error_identifiers = None
+        identifier_symbol_cache = getattr(self, "_coin_list_identifier_symbols", None)
+        if not isinstance(identifier_symbol_cache, dict):
+            identifier_symbol_cache = {}
+            self._coin_list_identifier_symbols = identifier_symbol_cache
+        list_identifier_symbol_cache = identifier_symbol_cache.setdefault(k_coins, {})
         result = {"added": {}, "removed": {}}
         psides_equal = content["long"] == content["short"]
         for pside in content:
+            symbols_already = getattr(self, k_coins)[pside]
             if not psides_equal or symbols is None:
                 coins = content[pside]
                 if k_coins == "approved_coins" and _coins_source_side_is_all(coins):
                     symbols = set(getattr(self, "eligible_symbols", set()))
+                    resolved_identifier_symbols = {}
+                    resolution_error_identifiers = set()
                 else:
                     # Check if coins is a single string that needs to be split
                     if isinstance(coins, str):
@@ -21910,11 +21943,29 @@ class Passivbot:
                                 expanded_coins.append(item)
                         coins = expanded_coins
 
-                    symbols = [
-                        self.coin_to_symbol(coin, verbose=False)
-                        for coin in coins
-                        if coin
-                    ]
+                    symbols = []
+                    resolved_identifier_symbols = {}
+                    resolution_error_identifiers = set()
+                    for coin in coins:
+                        if not coin:
+                            continue
+                        identifier = str(coin).strip()
+                        try:
+                            symbol = self.coin_to_symbol(coin, verbose=False)
+                        except MarketIdentifierResolutionError as e:
+                            resolution_error_identifiers.add(identifier)
+                            logging.error(
+                                "[forager] market identifier unavailable | "
+                                "list_kind=%s pside=%s error_type=%s "
+                                "action=skip_identifier",
+                                k_coins,
+                                pside,
+                                bounded_exception_type(e),
+                            )
+                            continue
+                        if symbol:
+                            symbols.append(symbol)
+                            resolved_identifier_symbols[identifier] = symbol
                     symbols = {s for s in symbols if s}
                     eligible = getattr(self, "eligible_symbols", None)
                     if eligible:
@@ -21971,15 +22022,28 @@ class Passivbot:
                                     if emitted:
                                         event_keys.add(event_key)
                             symbols = symbols - set(skipped)
-            symbols_already = getattr(self, k_coins)[pside]
-            if symbols_already != symbols:
-                added = symbols - symbols_already
-                removed = symbols_already - symbols
+            symbols_for_pside = set(symbols)
+            identifier_symbols_for_pside = dict(resolved_identifier_symbols or {})
+            if k_coins == "ignored_coins":
+                previous_identifier_symbols = list_identifier_symbol_cache.get(pside, {})
+                for identifier in resolution_error_identifiers or ():
+                    previous_symbol = previous_identifier_symbols.get(identifier)
+                    if previous_symbol in symbols_already:
+                        symbols_for_pside.add(previous_symbol)
+                        identifier_symbols_for_pside[identifier] = previous_symbol
+            list_identifier_symbol_cache[pside] = {
+                identifier: symbol
+                for identifier, symbol in identifier_symbols_for_pside.items()
+                if symbol in symbols_for_pside
+            }
+            if symbols_already != symbols_for_pside:
+                added = symbols_for_pside - symbols_already
+                removed = symbols_already - symbols_for_pside
                 if added and pside in log_psides:
                     result["added"][pside] = added
                 if removed and pside in log_psides:
                     result["removed"][pside] = removed
-                getattr(self, k_coins)[pside] = symbols
+                getattr(self, k_coins)[pside] = symbols_for_pside
         return result
 
     def refresh_approved_ignored_coins_lists(self):
@@ -22100,6 +22164,17 @@ class Passivbot:
             except Exception:
                 pass
             self._log_coin_symbol_fallback_summary()
+        except MarketIdentifierResolutionError as e:
+            psides = set(getattr(self, "approved_coins", {})) | {"long", "short"}
+            self.approved_coins = {pside: set() for pside in psides}
+            self.approved_coins_minus_ignored_coins = {
+                pside: set() for pside in psides
+            }
+            logging.error(
+                "[forager] approved/ignored coin refresh failed closed | "
+                "error_type=%s action=clear_approved_eligibility",
+                bounded_exception_type(e),
+            )
         except Exception as e:
             logging.error(
                 "[forager] approved/ignored coin refresh failed | "

--- a/src/procedures.py
+++ b/src/procedures.py
@@ -13,19 +13,25 @@ import re
 from collections import defaultdict
 from collections.abc import Sized
 from utils import (
+    FIRST_OHLCV_TIMESTAMPS_CACHE_VERSION,
+    MarketIdentifierResolutionError,
+    UnknownMarketIdentifier,
     coin_to_symbol,
     symbol_to_coin,
     make_get_filepath,
     load_markets,
     get_file_mod_ms,
+    get_quote,
     date_to_ts,
     get_first_ohlcv_iteratively,
     load_ccxt_instance,
+    split_exchange_qualified_market_identifier,
+    to_ccxt_exchange_id,
     to_standard_exchange_name,
 )
 import sys
 import passivbot_rust as pbr
-from typing import Union, Optional, Set, Any, List
+from typing import Union, Optional, Set, Any, List, Sequence
 from pathlib import Path
 import ccxt.async_support as ccxta
 
@@ -307,10 +313,15 @@ def print_async_exception(coro):
         pass
 
 
-async def get_first_timestamps_unified(coins: List[str], exchange: str = None):
+async def get_first_timestamps_unified(
+    coins: List[str],
+    exchange: str = None,
+    exchanges: Optional[Sequence[str]] = None,
+):
     """
     Returns earliest timestamp each coin was found on any exchange by default.
     If 'exchange' is specified, returns earliest timestamps specifically for that exchange.
+    If 'exchanges' is specified, returns the earliest timestamp across only those venues.
 
     Batches requests in groups of 10 coins at a time, and dumps results to disk
     immediately after each batch is processed.
@@ -343,27 +354,82 @@ async def get_first_timestamps_unified(coins: List[str], exchange: str = None):
             # Monthly timeframe; data since 2018
             return await cc.fetch_ohlcv(symbol, since=int(date_to_ts("2018-01-01")), timeframe="1M")
 
-        elif exchange_name == "bitget":
+        elif exchange_name in {"bitget", "bitunix"}:
             first_candle = await get_first_ohlcv_iteratively(cc, symbol)
             return [first_candle] if first_candle else []
 
-        else:  # e.g., 'hyperliquid'
+        elif exchange_name == "hyperliquid":
             # Weekly timeframe; data since 2021
             return await cc.fetch_ohlcv(symbol, since=int(date_to_ts("2021-01-01")), timeframe="1w")
 
-    # Remove duplicates and sort the input coins for consistency
-    coins = sorted(set(symbol_to_coin(coin) for coin in coins))
+        else:
+            # Dynamic CCXT venues must not inherit another exchange's listing
+            # horizon. Ask for the first daily candle from the epoch instead.
+            return await cc.fetch_ohlcv(symbol, since=1, timeframe="1d", limit=1)
+
+    # Preserve exact market identifiers until each exchange-specific resolver
+    # sees them.  Eager canonicalization can collapse unrelated contracts.
+    coins = sorted({str(coin).strip() for coin in coins if str(coin).strip()})
+
+    if exchange is not None and exchanges is not None:
+        raise ValueError("pass either exchange or exchanges, not both")
+    if exchanges is not None:
+        selected_exchanges = list(
+            dict.fromkeys(str(item).strip() for item in exchanges if str(item).strip())
+        )
+        if not selected_exchanges:
+            raise ValueError("exchanges must contain at least one venue")
+        scoped_results = []
+        for selected_exchange in selected_exchanges:
+            scoped_results.append(
+                await get_first_timestamps_unified(coins, exchange=selected_exchange)
+            )
+        return {
+            coin: min(
+                (
+                    float(result[coin])
+                    for result in scoped_results
+                    if coin in result and float(result[coin]) > 0.0
+                ),
+                default=0.0,
+            )
+            for coin in coins
+        }
 
     # Paths to the cache files
     cache_fpath = make_get_filepath("caches/first_ohlcv_timestamps_unified.json")
     cache_fpath_exchange_specific = "caches/first_ohlcv_timestamps_unified_exchange_specific.json"
+    cache_symbols_fpath_exchange_specific = (
+        "caches/first_ohlcv_timestamps_unified_exchange_specific_symbols.json"
+    )
+    cache_version_fpath = make_get_filepath(
+        "caches/first_ohlcv_timestamps_unified.version"
+    )
 
     # In-memory dictionaries for storing timestamps
     ftss = {}  # coin -> earliest timestamp across all exchanges
     ftss_exchange_specific = {}  # coin -> {exchange -> earliest timestamp}
+    fts_symbols_exchange_specific = {}  # coin -> {exchange -> resolved symbol}
 
-    # Load main cache if it exists
-    if os.path.exists(cache_fpath):
+    cache_version_is_current = False
+    if os.path.exists(cache_version_fpath):
+        try:
+            with open(cache_version_fpath, "r", encoding="utf-8") as f:
+                cache_version_is_current = (
+                    int(f.read().strip()) == FIRST_OHLCV_TIMESTAMPS_CACHE_VERSION
+                )
+        except Exception as e:
+            logging.warning("error reading %s: %s", cache_version_fpath, e)
+    if not cache_version_is_current and (
+        os.path.exists(cache_fpath) or os.path.exists(cache_fpath_exchange_specific)
+    ):
+        logging.info(
+            "ignoring legacy first-OHLCV timestamp caches without resolver version %s",
+            FIRST_OHLCV_TIMESTAMPS_CACHE_VERSION,
+        )
+
+    # Load caches only when they match the current resolver semantics.
+    if cache_version_is_current and os.path.exists(cache_fpath):
         try:
             with open(cache_fpath, "r") as f:
                 ftss = json.load(f)
@@ -372,7 +438,7 @@ async def get_first_timestamps_unified(coins: List[str], exchange: str = None):
             logging.warning("error reading %s: %s", cache_fpath, e)
 
     # Load exchange-specific cache if it exists
-    if os.path.exists(cache_fpath_exchange_specific):
+    if cache_version_is_current and os.path.exists(cache_fpath_exchange_specific):
         try:
             with open(cache_fpath_exchange_specific, "r") as f:
                 ftss_exchange_specific = json.load(f)
@@ -384,9 +450,21 @@ async def get_first_timestamps_unified(coins: List[str], exchange: str = None):
         except Exception as e:
             logging.warning("error reading %s: %s", cache_fpath_exchange_specific, e)
 
-    # If an exchange is specified, handle "binance" alias
-    if exchange == "binance":
-        exchange = "binanceusdm"
+    if cache_version_is_current and os.path.exists(cache_symbols_fpath_exchange_specific):
+        try:
+            with open(cache_symbols_fpath_exchange_specific, "r") as f:
+                fts_symbols_exchange_specific = json.load(f)
+            if not isinstance(fts_symbols_exchange_specific, dict):
+                fts_symbols_exchange_specific = {}
+        except Exception as e:
+            logging.warning("error reading %s: %s", cache_symbols_fpath_exchange_specific, e)
+
+    # Exchange-specific cache keys use canonical names, except for the legacy
+    # Binance key retained for compatibility with existing caches/readers.
+    if exchange is not None:
+        exchange = to_standard_exchange_name(exchange)
+        if exchange == "binance":
+            exchange = "binanceusdm"
 
     def _valid_first_timestamp(value: Any) -> bool:
         try:
@@ -394,23 +472,53 @@ async def get_first_timestamps_unified(coins: List[str], exchange: str = None):
         except Exception:
             return False
 
+    resolved_symbol_cache = {}
+
+    def _current_resolved_symbol(coin: str, exchange_name: str):
+        key = (coin, exchange_name)
+        if key not in resolved_symbol_cache:
+            try:
+                resolved_symbol_cache[key] = coin_to_symbol(coin, exchange_name)
+            except MarketIdentifierResolutionError:
+                resolved_symbol_cache[key] = None
+        return resolved_symbol_cache[key]
+
+    def _valid_exchange_cache_entry(coin: str, exchange_name: str) -> bool:
+        value = ftss_exchange_specific.get(coin, {}).get(exchange_name)
+        cached_symbol = fts_symbols_exchange_specific.get(coin, {}).get(exchange_name)
+        return (
+            _valid_first_timestamp(value)
+            and bool(cached_symbol)
+            and cached_symbol == _current_resolved_symbol(coin, exchange_name)
+        )
+
+    def _valid_unified_cache_entry(coin: str) -> bool:
+        value = ftss.get(coin)
+        if not _valid_first_timestamp(value):
+            return False
+        return any(
+            _valid_exchange_cache_entry(coin, exchange_name)
+            and float(exchange_value) == float(value)
+            for exchange_name, exchange_value in ftss_exchange_specific.get(coin, {}).items()
+        )
+
     # 1) If no exchange is specified and all coins have valid cached timestamps, just return ftss
     if exchange is None:
-        if all(_valid_first_timestamp(ftss.get(coin)) for coin in coins):
-            return ftss
+        if all(_valid_unified_cache_entry(coin) for coin in coins):
+            return {coin: ftss[coin] for coin in coins}
 
     # 2) If a specific exchange is requested:
     else:
         # If all coins exist in the exchange-specific cache for that exchange, return them
-        if all(_valid_first_timestamp(ftss_exchange_specific.get(coin, {}).get(exchange)) for coin in coins):
+        if all(_valid_exchange_cache_entry(coin, exchange) for coin in coins):
             return {c: ftss_exchange_specific[c][exchange] for c in coins}
 
     # Figure out which coins are missing from the relevant cache or have invalid cached timestamps
     if exchange is None:
-        missing_coins = {c for c in coins if not _valid_first_timestamp(ftss.get(c))}
+        missing_coins = {c for c in coins if not _valid_unified_cache_entry(c)}
     else:
         missing_coins = {
-            c for c in coins if not _valid_first_timestamp(ftss_exchange_specific.get(c, {}).get(exchange))
+            c for c in coins if not _valid_exchange_cache_entry(c, exchange)
         }
     if not missing_coins:
         if exchange is not None:
@@ -428,12 +536,46 @@ async def get_first_timestamps_unified(coins: List[str], exchange: str = None):
         "bitget": "USDT",
         "hyperliquid": "USDC",
     }
+    qualified_only_exchanges = set()
+    if exchange is not None:
+        target_exchange = to_standard_exchange_name(exchange)
+        exchange_map = {
+            ex_name: quote
+            for ex_name, quote in exchange_map.items()
+            if to_standard_exchange_name(ex_name) == target_exchange
+        }
+        if not exchange_map:
+            exchange_map = {exchange: get_quote(exchange)}
+    else:
+        for coin in coins:
+            qualified_exchange, _ = split_exchange_qualified_market_identifier(coin)
+            if qualified_exchange is None or any(
+                to_standard_exchange_name(ex_name) == qualified_exchange
+                for ex_name in exchange_map
+            ):
+                continue
+            exchange_map[qualified_exchange] = get_quote(qualified_exchange)
+            qualified_only_exchanges.add(qualified_exchange)
 
     # Initialize ccxt clients for each exchange
     ccxt_clients = {}
     for ex_name in sorted(exchange_map):
         try:
-            ccxt_clients[ex_name] = load_ccxt_instance(ex_name)
+            if ex_name == "bitunix":
+                from exchanges.bitunix import BitunixClient, apply_bitunix_endpoint_override
+                from custom_endpoint_overrides import resolve_custom_endpoint_override
+
+                client_config = apply_bitunix_endpoint_override(
+                    {
+                        "enableRateLimit": True,
+                        "timeout": 60_000,
+                        "wsEnabled": False,
+                    },
+                    resolve_custom_endpoint_override(ex_name),
+                )
+                ccxt_clients[ex_name] = BitunixClient(client_config)
+            else:
+                ccxt_clients[ex_name] = load_ccxt_instance(to_ccxt_exchange_id(ex_name))
         except Exception as e:
             print(f"Error loading {ex_name} from ccxt. Skipping. {e}")
             del exchange_map[ex_name]
@@ -471,13 +613,30 @@ async def get_first_timestamps_unified(coins: List[str], exchange: str = None):
             # Create tasks for every coin/exchange pair in this batch
             tasks = {}
             bitget_symbols = {}
+            attempted_exchanges = {}
+            resolved_symbols = {}
             for coin in batch:
                 tasks[coin] = {}
+                attempted_exchanges[coin] = set()
+                resolved_symbols[coin] = {}
+                qualified_exchange, _ = split_exchange_qualified_market_identifier(coin)
                 for ex_name, quote in exchange_map.items():
+                    if (
+                        qualified_exchange is not None
+                        and qualified_exchange != to_standard_exchange_name(ex_name)
+                    ):
+                        continue
+                    if qualified_exchange is None and ex_name in qualified_only_exchanges:
+                        continue
+                    attempted_exchanges[coin].add(ex_name)
                     # Convert coin to a symbol recognized by the exchange, e.g. "BTC/USDT:USDT"
-                    symbol = coin_to_symbol(coin, ex_name)
+                    try:
+                        symbol = coin_to_symbol(coin, ex_name)
+                    except UnknownMarketIdentifier:
+                        continue
                     if not symbol:
                         continue
+                    resolved_symbols[coin][ex_name] = symbol
                     if ex_name == "bitget":
                         bitget_symbols[coin] = symbol
                         continue
@@ -529,8 +688,44 @@ async def get_first_timestamps_unified(coins: List[str], exchange: str = None):
             # Process results for each coin in this batch
             for coin in batch:
                 exchange_data = batch_results.get(coin, {})
-                fts_for_this_coin = {ex: 0.0 for ex in exchange_map}  # default 0.0 for all
-                earliest_candidates = []
+                cached_exchange_data = ftss_exchange_specific.get(coin, {})
+                if not isinstance(cached_exchange_data, dict):
+                    fts_for_this_coin = {}
+                elif exchange is not None:
+                    fts_for_this_coin = dict(cached_exchange_data)
+                else:
+                    fts_for_this_coin = {
+                        ex_name: value
+                        for ex_name, value in cached_exchange_data.items()
+                        if _valid_exchange_cache_entry(coin, ex_name)
+                    }
+                cached_symbol_data = fts_symbols_exchange_specific.get(coin, {})
+                symbols_for_this_coin = (
+                    {
+                        ex_name: value
+                        for ex_name, value in cached_symbol_data.items()
+                        if ex_name in fts_for_this_coin
+                    }
+                    if isinstance(cached_symbol_data, dict)
+                    else {}
+                )
+                for ex_name in attempted_exchanges[coin]:
+                    fts_for_this_coin[ex_name] = 0.0
+                    if ex_name in resolved_symbols[coin]:
+                        symbols_for_this_coin[ex_name] = resolved_symbols[coin][ex_name]
+                    else:
+                        symbols_for_this_coin.pop(ex_name, None)
+                earliest_candidates = [
+                    value
+                    for value in fts_for_this_coin.values()
+                    if _valid_first_timestamp(value) and float(value) > 1262304000000.0
+                ]
+                if (
+                    exchange is not None
+                    and _valid_unified_cache_entry(coin)
+                    and float(ftss[coin]) > 1262304000000.0
+                ):
+                    earliest_candidates.append(ftss[coin])
 
                 for ex_name, arr in exchange_data.items():
                     if arr and len(arr) > 0:
@@ -549,6 +744,7 @@ async def get_first_timestamps_unified(coins: List[str], exchange: str = None):
 
                 # Update the exchange-specific dictionary
                 ftss_exchange_specific[coin] = fts_for_this_coin
+                fts_symbols_exchange_specific[coin] = symbols_for_this_coin
 
             # Immediately dump updated dictionaries to disk after each batch
             with open(cache_fpath, "w") as f:
@@ -556,6 +752,12 @@ async def get_first_timestamps_unified(coins: List[str], exchange: str = None):
 
             with open(cache_fpath_exchange_specific, "w") as f:
                 json.dump(ftss_exchange_specific, f, indent=4, sort_keys=True)
+
+            with open(cache_symbols_fpath_exchange_specific, "w") as f:
+                json.dump(fts_symbols_exchange_specific, f, indent=4, sort_keys=True)
+
+            with open(cache_version_fpath, "w", encoding="utf-8") as f:
+                f.write(str(FIRST_OHLCV_TIMESTAMPS_CACHE_VERSION))
 
             print(f"Finished batch {batch}. Caches updated.")
 
@@ -566,7 +768,7 @@ async def get_first_timestamps_unified(coins: List[str], exchange: str = None):
             return {coin: ftss_exchange_specific.get(coin, {}).get(exchange, 0.0) for coin in coins}
 
         # Otherwise, return earliest cross-exchange timestamps
-        return ftss
+        return {coin: ftss.get(coin, 0.0) for coin in coins}
     finally:
         await asyncio.gather(
             *(ccxt_clients[e].close() for e in ccxt_clients if hasattr(ccxt_clients[e], "close"))

--- a/src/repro_harness.py
+++ b/src/repro_harness.py
@@ -107,7 +107,12 @@ async def run_optimizer_replay(config: Dict[str, Any]) -> Dict[str, Any]:
 
     cfg = deepcopy(config)
     backtest_exchanges = require_config_value(cfg, "backtest.exchanges")
-    await format_approved_ignored_coins(cfg, backtest_exchanges, verbose=False)
+    await format_approved_ignored_coins(
+        cfg,
+        backtest_exchanges,
+        verbose=False,
+        prefer_backtest_coin_source_keys=True,
+    )
     cfg["backtest"]["coins"] = {}
     suite_cfg = extract_suite_config(cfg, None)
     suite_enabled = bool(suite_cfg.get("enabled"))
@@ -186,7 +191,12 @@ async def run_backtest_replay(config: Dict[str, Any]) -> Dict[str, Any]:
 
     cfg = deepcopy(config)
     backtest_exchanges = require_config_value(cfg, "backtest.exchanges")
-    await format_approved_ignored_coins(cfg, backtest_exchanges, verbose=False)
+    await format_approved_ignored_coins(
+        cfg,
+        backtest_exchanges,
+        verbose=False,
+        prefer_backtest_coin_source_keys=True,
+    )
     cfg["backtest"]["coins"] = {}
     cfg["backtest"]["cache_dir"] = {}
     suite_cfg = extract_suite_config(cfg, None)

--- a/src/suite_runner.py
+++ b/src/suite_runner.py
@@ -28,11 +28,17 @@ from config.shared_bot import canonicalize_shared_bot_side
 from config_transform import ConfigTransformTracker, record_transform
 from logging_setup import configure_logging
 from materialized_cache import release_materialized_payload
+from backtest_universe import normalize_backtest_coin
 from utils import (
+    MarketIdentifierExchangeMismatch,
+    UnknownMarketIdentifier,
+    coin_to_symbol,
     format_approved_ignored_coins,
     format_end_date,
     load_markets,
-    symbol_to_coin,
+    reject_cross_exchange_market_identifier_collisions,
+    split_exchange_qualified_market_identifier,
+    to_standard_exchange_name,
     ts_to_date,
     utc_ms,
     date_to_ts,
@@ -259,18 +265,144 @@ def _flatten_coin_list(value: Any) -> List[str]:
     return []
 
 
-def _normalized_coin_set(value: Any) -> set[str]:
+def _normalized_coin_set(value: Any, exchanges: Sequence[str] = ()) -> set[str]:
     out: set[str] = set()
     if isinstance(value, str):
         value = [value]
     for entry in value or []:
-        coin = symbol_to_coin(str(entry), verbose=False)
-        if coin:
-            out.add(coin)
+        coin = normalize_backtest_coin(entry)
+        if not coin:
+            continue
+        qualified_exchange, _ = split_exchange_qualified_market_identifier(coin)
+        resolved_symbols = set()
+        for exchange in exchanges:
+            try:
+                symbol = coin_to_symbol(coin, exchange, verbose=False)
+                resolved_symbols.add(
+                    f"{qualified_exchange}::{symbol}"
+                    if qualified_exchange is not None
+                    else symbol
+                )
+            except (MarketIdentifierExchangeMismatch, UnknownMarketIdentifier):
+                continue
+        out.update(resolved_symbols or {coin})
     return out
 
 
-def validate_suite_side_coin_lists(config: Dict[str, Any]) -> None:
+def _reconcile_suite_identifiers_to_available(
+    identifiers: Sequence[str],
+    available_coins: set[str],
+    exchanges: Sequence[str],
+) -> list[str]:
+    """Match exact/alias scenario identifiers to prepared dataset coin keys."""
+    reconciled = []
+    for identifier in identifiers:
+        raw = str(identifier)
+        if raw in available_coins:
+            reconciled.append(raw)
+            continue
+        matches = set()
+        for exchange in exchanges:
+            try:
+                target_symbol = coin_to_symbol(raw, exchange, verbose=False)
+            except (MarketIdentifierExchangeMismatch, UnknownMarketIdentifier):
+                continue
+            for available_coin in available_coins:
+                try:
+                    if (
+                        coin_to_symbol(available_coin, exchange, verbose=False)
+                        == target_symbol
+                    ):
+                        matches.add(available_coin)
+                except (MarketIdentifierExchangeMismatch, UnknownMarketIdentifier):
+                    continue
+        if len(matches) > 1:
+            raise ValueError(
+                f"suite identifier {raw!r} matches multiple prepared coins: "
+                f"{sorted(matches)}"
+            )
+        reconciled.append(next(iter(matches)) if matches else raw)
+    return list(dict.fromkeys(reconciled))
+
+
+def _reconcile_suite_coin_sources(
+    sources: Dict[str, str], coins: Sequence[str]
+) -> Dict[str, str]:
+    available_coins = set(coins)
+    reconciled = {}
+    for source_coin, exchange in sorted(sources.items()):
+        mapped = _reconcile_suite_identifiers_to_available(
+            [source_coin], available_coins, [exchange]
+        )[0]
+        target_coin = mapped if mapped in available_coins else source_coin
+        existing = reconciled.get(target_coin)
+        if existing is not None and existing != exchange:
+            raise ValueError(
+                f"suite coin_sources maps conflicting exchanges for {target_coin}: "
+                f"{existing} and {exchange}"
+            )
+        reconciled[target_coin] = exchange
+    return reconciled
+
+
+def _coalesce_master_coins(
+    coins: Sequence[str], sources: Dict[str, str], exchanges: Sequence[str]
+) -> list[str]:
+    """Use one dataset identity per resolved market, preferring forced-source keys."""
+    source_assignments = {}
+    for source_coin, exchange in sorted(sources.items()):
+        exchange = to_standard_exchange_name(str(exchange))
+        try:
+            source_symbol = coin_to_symbol(source_coin, exchange, verbose=False)
+        except UnknownMarketIdentifier:
+            continue
+        qualified_exchange, _ = split_exchange_qualified_market_identifier(source_coin)
+        if qualified_exchange is not None:
+            continue
+        existing = source_assignments.get(source_symbol)
+        if existing is not None and existing[1] != exchange:
+            raise ValueError(
+                "suite coin_sources maps equivalent identifiers "
+                f"{existing[0]!r} and {source_coin!r} to conflicting exchanges: "
+                f"{existing[1]} and {exchange}"
+            )
+        source_assignments[source_symbol] = (source_coin, exchange)
+
+    coalesced = set(str(coin) for coin in coins)
+    for source_coin, exchange in sorted(sources.items()):
+        try:
+            source_symbol = coin_to_symbol(source_coin, exchange, verbose=False)
+        except UnknownMarketIdentifier:
+            coalesced.add(source_coin)
+            continue
+        equivalent = set()
+        for coin in coalesced:
+            try:
+                if coin_to_symbol(coin, exchange, verbose=False) == source_symbol:
+                    equivalent.add(coin)
+            except (MarketIdentifierExchangeMismatch, UnknownMarketIdentifier):
+                continue
+        coalesced.difference_update(equivalent)
+        coalesced.add(source_coin)
+
+    representatives = {}
+    for coin in sorted(coalesced):
+        resolved = []
+        for exchange in exchanges:
+            try:
+                resolved.append(
+                    (exchange, coin_to_symbol(coin, exchange, verbose=False))
+                )
+            except (MarketIdentifierExchangeMismatch, UnknownMarketIdentifier):
+                continue
+        identity = ("resolved", tuple(resolved)) if resolved else ("raw", coin)
+        representatives.setdefault(identity, coin)
+    return sorted(representatives.values())
+
+
+def validate_suite_side_coin_lists(
+    config: Dict[str, Any], exchanges: Sequence[str] = ()
+) -> None:
     live = config.get("live", {}) if isinstance(config, dict) else {}
     if not isinstance(live, dict):
         return
@@ -278,8 +410,8 @@ def validate_suite_side_coin_lists(config: Dict[str, Any]) -> None:
         value = live.get(field)
         if not isinstance(value, dict):
             continue
-        long_coins = _normalized_coin_set(value.get("long", []))
-        short_coins = _normalized_coin_set(value.get("short", []))
+        long_coins = _normalized_coin_set(value.get("long", []), exchanges)
+        short_coins = _normalized_coin_set(value.get("short", []), exchanges)
         if long_coins == short_coins:
             continue
         long_only = sorted(long_coins - short_coins)
@@ -311,7 +443,7 @@ def _coerce_coin_source_dict(value: Any) -> Optional[Dict[str, str]]:
     for coin, exchange in value.items():
         if exchange is None:
             continue
-        coin_key = symbol_to_coin(str(coin), verbose=False)
+        coin_key = normalize_backtest_coin(coin)
         if not coin_key:
             continue
         exchange_value = str(exchange)
@@ -333,7 +465,7 @@ def _normalize_coin_list(value: Any) -> Optional[List[str]]:
     normalized: List[str] = []
     seen: set[str] = set()
     for entry in coins_raw:
-        coin = symbol_to_coin(str(entry), verbose=False)
+        coin = normalize_backtest_coin(entry)
         if not coin or coin in seen:
             continue
         seen.add(coin)
@@ -976,7 +1108,7 @@ def apply_scenario(
         )
     backtest_section = cfg.setdefault("backtest", {})
     live_section = cfg.setdefault("live", {})
-    validate_suite_side_coin_lists(cfg)
+    validate_suite_side_coin_lists(cfg, backtest_section.get("exchanges", []))
 
     new_start = scenario.start_date or backtest_section.get("start_date")
     if new_start != backtest_section.get("start_date"):
@@ -993,6 +1125,16 @@ def apply_scenario(
     scenario_coins = list(scenario.coins) if scenario.coins is not None else list(default_coins)
     scenario_ignored = (
         list(scenario.ignored_coins) if scenario.ignored_coins is not None else list(default_ignored)
+    )
+    available_exchange_list = list(available_exchanges)
+    scenario_exchanges = (
+        list(scenario.exchanges) if scenario.exchanges else available_exchange_list
+    )
+    scenario_coins = _reconcile_suite_identifiers_to_available(
+        scenario_coins, available_coins, scenario_exchanges
+    )
+    scenario_ignored = _reconcile_suite_identifiers_to_available(
+        scenario_ignored, available_coins, scenario_exchanges
     )
 
     filtered_coins = [coin for coin in scenario_coins if coin in available_coins]
@@ -1011,7 +1153,6 @@ def apply_scenario(
     filtered_ignored = [coin for coin in scenario_ignored if coin in available_coins]
     filtered_ignored = sorted(dict.fromkeys(filtered_ignored))
 
-    scenario_exchanges = list(scenario.exchanges) if scenario.exchanges else list(available_exchanges)
     if scenario_exchanges != backtest_section.get("exchanges"):
         tracker.update(
             ["backtest", "exchanges"], backtest_section.get("exchanges"), scenario_exchanges
@@ -1068,6 +1209,7 @@ def apply_scenario(
         base_coin_sources or {},
         scenario.coin_sources,
     )
+    resolved_sources = _reconcile_suite_coin_sources(resolved_sources, filtered_coins)
     if resolved_sources != backtest_section.get("coin_sources"):
         tracker.update(
             ["backtest", "coin_sources"],
@@ -1760,7 +1902,6 @@ async def run_backtest_suite_async(
     suite_output_root: Optional[Path] = None,
 ) -> SuiteSummary:
     base_exchanges = require_config_value(config, "backtest.exchanges")
-    validate_suite_side_coin_lists(config)
 
     base_coins = _flatten_coin_list(require_live_value(config, "approved_coins"))
     base_ignored = _flatten_coin_list(require_live_value(config, "ignored_coins"))
@@ -1781,16 +1922,30 @@ async def run_backtest_suite_async(
             sorted(added_exchanges),
         )
 
-    for exchange in exchanges_list:
-        await load_markets(exchange, verbose=False)
-    await format_approved_ignored_coins(config, exchanges_list, verbose=False)
-
     suite_coin_sources = collect_suite_coin_sources(config, scenarios)
+    identity_exchanges = sorted(
+        set(exchanges_list) | set(suite_coin_sources.values())
+    )
+    for exchange in identity_exchanges:
+        await load_markets(exchange, verbose=False)
+    await format_approved_ignored_coins(
+        config,
+        exchanges_list,
+        verbose=False,
+        prefer_backtest_coin_source_keys=True,
+    )
+    validate_suite_side_coin_lists(config, exchanges_list)
 
     master_coins = _collect_union((s.coins for s in scenarios), base_coins)
-    if suite_coin_sources:
-        master_coins = sorted(dict.fromkeys([*master_coins, *suite_coin_sources.keys()]))
+    master_coins = _coalesce_master_coins(
+        master_coins, suite_coin_sources, identity_exchanges
+    )
     master_ignored = _collect_union((s.ignored_coins for s in scenarios), base_ignored)
+    await reject_cross_exchange_market_identifier_collisions(
+        [*master_coins, *master_ignored, *suite_coin_sources.keys()],
+        identity_exchanges,
+        verbose=False,
+    )
 
     base_config = deepcopy(config)
     base_config.setdefault("backtest", {})

--- a/src/tools/iterative_backtester.py
+++ b/src/tools/iterative_backtester.py
@@ -572,7 +572,10 @@ class IterativeBacktestSession:
         for ex in require_config_value(config, "backtest.exchanges"):
             await load_markets(ex, verbose=False)
         await format_approved_ignored_coins(
-            config, require_config_value(config, "backtest.exchanges"), verbose=False
+            config,
+            require_config_value(config, "backtest.exchanges"),
+            verbose=False,
+            prefer_backtest_coin_source_keys=True,
         )
         config.setdefault("backtest", {})
         config["backtest"].setdefault("cache_dir", {})

--- a/src/utils.py
+++ b/src/utils.py
@@ -37,16 +37,34 @@ _COIN_TO_SYMBOL_CACHE = {}  # {exchange: {"map": dict, "mtime_ns": int, "size": 
 _SYMBOL_TO_COIN_CACHE = {"map": None, "mtime_ns": None, "size": None}
 _SYMBOL_TO_COIN_WARNINGS: set[str] = set()
 _COIN_TO_SYMBOL_FALLBACKS: set[tuple[str, str]] = set()
+_KNOWN_EXCHANGE_QUALIFIERS: Optional[frozenset[str]] = None
 
 # File locking constants for symbol/coin map files
 _SYMBOL_MAP_LOCK_STALE_SECONDS = 180  # Remove locks older than 3 minutes
 _SYMBOL_MAP_LOCK_TIMEOUT = 5  # Seconds to wait for lock acquisition
 _SYMBOL_MAP_STALE_CLEANUP_DONE = False  # Track if cleanup has run this session
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
+FIRST_OHLCV_TIMESTAMPS_CACHE_VERSION = 2
 LEGACY_COINS_FILE_ALIASES = {
     "approved_coins_topmcap.json": Path("configs/approved_coins.json"),
     "approved_coins_topmcap.txt": Path("configs/approved_coins.json"),
 }
+
+
+class MarketIdentifierResolutionError(ValueError):
+    """Base class for fail-closed exchange market identifier errors."""
+
+
+class AmbiguousMarketIdentifier(MarketIdentifierResolutionError):
+    """Raised when a convenience alias matches multiple exchange markets."""
+
+
+class MarketIdentifierExchangeMismatch(MarketIdentifierResolutionError):
+    """Raised when an exchange-qualified identifier targets another exchange."""
+
+
+class UnknownMarketIdentifier(MarketIdentifierResolutionError):
+    """Raised when an exact market identifier is absent from a loaded exchange map."""
 
 
 def _atomic_write_json(path: str, data: dict, indent=None, sort_keys=False) -> None:
@@ -605,6 +623,19 @@ def to_ccxt_client_id(exchange: str) -> str:
     return "gate" if exchange_id == "gateio" else exchange_id
 
 
+def exchange_name_aliases(exchange: str) -> tuple[str, ...]:
+    """Return accepted canonical, connector, and CCXT names for one venue."""
+    raw = str(exchange or "").lower()
+    canonical = to_standard_exchange_name(raw)
+    aliases = {
+        raw,
+        canonical,
+        to_ccxt_exchange_id(canonical),
+        to_ccxt_client_id(canonical),
+    }
+    return tuple(sorted(alias for alias in aliases if alias))
+
+
 def to_standard_exchange_name(exchange: str) -> str:
     """
     Convert a ccxt exchange id to the canonical short form used in configs, caches, and logs.
@@ -827,8 +858,10 @@ def _build_coin_symbol_maps(markets, quote):
                 aliases.add(f"{prefix.lower()}:{ticker}")
         return aliases
 
-    coin_to_symbol_map = defaultdict(set)
-    symbol_to_coin_map = {}
+    alias_to_symbols = defaultdict(set)
+    exact_alias_to_symbols = defaultdict(set)
+    alias_to_coins = defaultdict(set)
+    exact_alias_to_coins = defaultdict(set)
     for k, v in markets.items():
         try:
             # Only include swap markets with the right quote.
@@ -839,8 +872,10 @@ def _build_coin_symbol_maps(markets, quote):
                 continue
             if not k.endswith(f":{quote}"):
                 continue
+            active = v.get("active") is not False
             coin = ""
             variants = set()
+            namespaced_full_aliases = set()
             for k0 in ["baseName", "base"]:
                 if base := v.get(k0):
                     variants.add(base)
@@ -850,22 +885,56 @@ def _build_coin_symbol_maps(markets, quote):
                     variants.add(cleaned)
                     if not coin:
                         coin = cleaned
-                    variants.update(_namespaced_aliases(base, v))
-            symbol_to_coin_map[k] = coin
-            for variant in variants:
-                existing = symbol_to_coin_map.get(variant)
-                if existing and existing != coin:
-                    continue
-                symbol_to_coin_map[variant] = coin
-                coin_to_symbol_map[variant].add(k)
+                    namespaced_aliases = _namespaced_aliases(base, v)
+                    variants.update(namespaced_aliases)
+                    if "/" in k:
+                        suffix = k[k.find("/") :]
+                        for alias in {base, *namespaced_aliases}:
+                            if ":" in alias or "-" in alias:
+                                namespaced_full_aliases.add(f"{alias}{suffix}")
+            # Exact exchange identifiers are lossless routing aliases.  They
+            # must be available before any convenience normalization such as
+            # removing a 1000/k contract multiplier.
+            exact_alias_to_symbols[k].add(k)
+            exact_alias_to_coins[k].add(coin)
+            for alias in namespaced_full_aliases:
+                exact_alias_to_symbols[alias].add(k)
+                exact_alias_to_coins[alias].add(coin)
+            if active:
+                for variant in variants:
+                    alias_to_coins[variant].add(coin)
+                    alias_to_symbols[variant].add(k)
             if symbol_id := v.get("id"):
-                symbol_to_coin_map[symbol_id] = coin
+                symbol_id = str(symbol_id)
+                exact_alias_to_coins[symbol_id].add(coin)
+                exact_alias_to_symbols[symbol_id].add(k)
         except Exception:
             # Skip malformed market entries but continue processing others
             continue
 
-    # Convert sets to lists for JSON serialisation / on-disk storage
-    coin_to_symbol_map = {k: list(v) for k, v in coin_to_symbol_map.items()}
+    # Exact aliases outrank convenience aliases even if exchange metadata
+    # happens to make their text collide.  All remaining multi-market aliases
+    # stay visible so the resolver can reject them rather than guess.
+    alias_to_symbols.update(exact_alias_to_symbols)
+    coin_to_symbol_map = {
+        alias: sorted(symbols) for alias, symbols in sorted(alias_to_symbols.items())
+    }
+
+    # The global symbol-to-coin map is used only for canonical labels.  Omit
+    # ambiguous convenience aliases instead of choosing whichever market CCXT
+    # happened to return first, then overlay unique exact identifiers.
+    symbol_to_coin_map = {
+        alias: next(iter(alias_to_coins[alias]))
+        for alias, symbols in sorted(alias_to_symbols.items())
+        if len(symbols) == 1 and len(alias_to_coins[alias]) == 1
+    }
+    symbol_to_coin_map.update(
+        {
+            alias: next(iter(coins))
+            for alias, coins in sorted(exact_alias_to_coins.items())
+            if len(coins) == 1
+        }
+    )
     return coin_to_symbol_map, symbol_to_coin_map
 
 
@@ -945,6 +1014,9 @@ def create_coin_symbol_map_cache(exchange: str, markets, quote=None, verbose=Tru
         quote = get_quote(exchange, quote)
 
         symbol_to_coin_map_path = make_get_filepath(os.path.join("caches", "symbol_to_coin_map.json"))
+        ambiguity_map_path = make_get_filepath(
+            os.path.join("caches", "symbol_to_coin_ambiguities.json")
+        )
         s2c_lock_path = symbol_to_coin_map_path + ".lock"
 
         # Lock the symbol_to_coin_map for the entire read-modify-write cycle
@@ -962,13 +1034,47 @@ def create_coin_symbol_map_cache(exchange: str, markets, quote=None, verbose=Tru
                 # Build fresh maps from provided markets (pure logic)
                 coin_to_symbol_map, new_symbol_to_coin_map = _build_coin_symbol_maps(markets, quote)
 
-                # Merge: prefer new discovered mappings while retaining others
-                symbol_to_coin_map.update(new_symbol_to_coin_map)
+                # Persist ambiguity ownership per exchange.  The global label
+                # map cannot represent an alias which is ambiguous on any
+                # loaded exchange, so tombstone the union regardless of cache
+                # refresh order.  Replacing this exchange's entry lets a
+                # delisted collision become usable again after refresh.
+                ambiguity_map = {}
+                try:
+                    if os.path.exists(ambiguity_map_path):
+                        with open(ambiguity_map_path, "r") as f:
+                            loaded_ambiguities = json.load(f)
+                        if isinstance(loaded_ambiguities, dict):
+                            ambiguity_map = loaded_ambiguities
+                except Exception as e:
+                    logging.error("failed to load symbol ambiguity map %s", e)
+                ambiguity_map[exchange] = sorted(
+                    alias
+                    for alias, candidates in coin_to_symbol_map.items()
+                    if len(candidates) > 1
+                )
+                ambiguous_aliases = {
+                    alias
+                    for aliases in ambiguity_map.values()
+                    if isinstance(aliases, list)
+                    for alias in aliases
+                }
+
+                for alias in ambiguous_aliases:
+                    symbol_to_coin_map.pop(alias, None)
+                symbol_to_coin_map.update(
+                    {
+                        alias: coin
+                        for alias, coin in new_symbol_to_coin_map.items()
+                        if alias not in ambiguous_aliases
+                    }
+                )
 
                 # Write symbol_to_coin_map atomically while still holding lock
                 if verbose:
                     logging.debug("dumping symbol_to_coin_map %s", symbol_to_coin_map_path)
                 _atomic_write_json(symbol_to_coin_map_path, symbol_to_coin_map)
+                _atomic_write_json(ambiguity_map_path, ambiguity_map, sort_keys=True)
 
                 # Update in-memory cache
                 try:
@@ -1016,6 +1122,77 @@ def create_coin_symbol_map_cache(exchange: str, markets, quote=None, verbose=Tru
         return False
 
 
+def split_exchange_qualified_market_identifier(identifier: str):
+    """Return ``(exchange, value)`` for a recognized ``exchange::value`` identifier."""
+    if not isinstance(identifier, str) or "::" not in identifier:
+        return None, identifier
+    prefix, value = identifier.split("::", 1)
+    if not prefix or not value or "/" in prefix:
+        return None, identifier
+    global _KNOWN_EXCHANGE_QUALIFIERS
+    if _KNOWN_EXCHANGE_QUALIFIERS is None:
+        known = set(getattr(ccxt, "exchanges", []))
+        known.update(to_standard_exchange_name(exchange) for exchange in tuple(known))
+        known.update(
+            {
+                "binance",
+                "binanceusdm",
+                "bitget",
+                "bitunix",
+                "bybit",
+                "defx",
+                "fake",
+                "gate",
+                "gateio",
+                "hyperliquid",
+                "kucoin",
+                "kucoinfutures",
+                "okx",
+                "paradex",
+                "weex",
+            }
+        )
+        _KNOWN_EXCHANGE_QUALIFIERS = frozenset(known)
+    if prefix.lower() not in _KNOWN_EXCHANGE_QUALIFIERS:
+        return None, identifier
+    return to_standard_exchange_name(prefix), value
+
+
+def looks_like_exact_market_identifier(identifier: str) -> bool:
+    """Return whether an identifier should reach an exchange map losslessly."""
+    raw = str(identifier).strip()
+    qualified_exchange, _ = split_exchange_qualified_market_identifier(raw)
+    if (
+        qualified_exchange is not None
+        or "/" in raw
+        or raw.isdigit()
+        or (":" in raw and all(raw.split(":", 1)))
+    ):
+        return True
+    if raw != raw.upper():
+        return False
+    if "-" in raw:
+        return True
+    for quote in ("USDT", "USDC", "BUSD", "USD"):
+        match = re.search(rf"{quote}[A-Z0-9_-]*$", raw)
+        if match is not None and match.start() >= 1:
+            return True
+    return False
+
+
+def _resolve_market_candidates(raw, candidates, exchange):
+    candidates = sorted(set(candidates or []))
+    if len(candidates) == 1:
+        return candidates[0]
+    if len(candidates) > 1:
+        raise AmbiguousMarketIdentifier(
+            f"ambiguous market identifier {raw!r} on {exchange}: matches {candidates}; "
+            "use an exact CCXT symbol, native market ID, or "
+            f"{exchange}::<native-id>"
+        )
+    return None
+
+
 def coin_to_symbol(coin, exchange, quote=None, verbose=True):
     # caches coin_to_symbol_map in memory and reloads if file changes
     if coin == "":
@@ -1023,22 +1200,37 @@ def coin_to_symbol(coin, exchange, quote=None, verbose=True):
     # Denormalize to use canonical form for cache paths (e.g., "binance" not "binanceusdm")
     ex = to_standard_exchange_name(exchange or "")
     quote = get_quote(ex, quote)
-    coin_sanitized = symbol_to_coin(coin, verbose=verbose)
-    fallback = f"{coin_sanitized}/{quote}:{quote}"
+    raw = str(coin).strip()
+    qualified_exchange, unqualified = split_exchange_qualified_market_identifier(raw)
+    if qualified_exchange is not None and qualified_exchange != ex:
+        raise MarketIdentifierExchangeMismatch(
+            f"market identifier {raw!r} targets {qualified_exchange}, not {ex}"
+        )
+    lookup_raw = unqualified if qualified_exchange is not None else raw
     try:
         loaded = _load_coin_to_symbol_map(ex)
-        candidates = loaded.get(coin_sanitized, []) if loaded else []
-        if len(candidates) == 1:
-            return candidates[0]
-        if len(candidates) > 1:
-            if verbose:
-                logging.info(
-                    "Multiple candidates for %s (raw=%s): %s",
-                    coin_sanitized,
-                    coin,
-                    candidates,
-                )
-            return candidates[0]
+        if loaded:
+            # Exact identifiers and base aliases take precedence over lossy
+            # canonicalization.  Ambiguous aliases fail closed.
+            if resolved := _resolve_market_candidates(
+                raw, loaded.get(lookup_raw, []), ex
+            ):
+                return resolved
+
+        coin_sanitized = symbol_to_coin(lookup_raw, verbose=verbose)
+        if looks_like_exact_market_identifier(raw) or (
+            loaded and lookup_raw != coin_sanitized
+        ):
+            raise UnknownMarketIdentifier(
+                f"exact market identifier {raw!r} is unavailable on {ex}; "
+                "refresh exchange market metadata or use a valid exact identifier"
+            )
+        fallback = f"{coin_sanitized}/{quote}:{quote}"
+        if loaded:
+            if resolved := _resolve_market_candidates(
+                raw, loaded.get(coin_sanitized, []), ex
+            ):
+                return resolved
         if loaded:
             # map present but coin missing
             warn_key = (ex, coin_sanitized)
@@ -1064,7 +1256,11 @@ def coin_to_symbol(coin, exchange, quote=None, verbose=True):
                         fallback,
                     )
                 _COIN_TO_SYMBOL_FALLBACKS.add(warn_key)
+    except MarketIdentifierResolutionError:
+        raise
     except Exception as e:
+        coin_sanitized = symbol_to_coin(lookup_raw, verbose=verbose)
+        fallback = f"{coin_sanitized}/{quote}:{quote}"
         if verbose:
             logging.error(
                 "error with coin_to_symbol %s (raw=%s) %s: %s", coin_sanitized, coin, exchange, e
@@ -1076,16 +1272,8 @@ def get_caller_name():
     return inspect.currentframe().f_back.f_back.f_code.co_name
 
 
-def symbol_to_coin(symbol, verbose=True):
-    # caches symbol_to_coin_map in memory and reloads if file changes
-    try:
-        loaded = _load_symbol_to_coin_map()
-        if symbol in loaded:
-            return loaded[symbol]
-        msg = f"failed to convert {symbol} to its coin with symbol_to_coin_map. Caller: {get_caller_name()}"
-    except Exception:
-        msg = f"failed to convert {symbol} to its coin with symbol_to_coin_map. Caller: {get_caller_name()}"
-
+def heuristic_symbol_to_coin(symbol):
+    """Return the legacy deterministic coin heuristic without consulting caches."""
     if symbol == "":
         return ""
     if "/" in symbol:
@@ -1107,6 +1295,24 @@ def symbol_to_coin(symbol, verbose=True):
     if coin.startswith("k") and coin[1:].isupper():
         # hyperliquid uses e.g. kSHIB instead of 1000SHIB
         coin = coin[1:]
+    return coin
+
+
+def symbol_to_coin(symbol, verbose=True):
+    # caches symbol_to_coin_map in memory and reloads if file changes
+    raw = str(symbol).strip()
+    qualified_exchange, _ = split_exchange_qualified_market_identifier(raw)
+    if qualified_exchange is not None:
+        return raw
+    try:
+        loaded = _load_symbol_to_coin_map()
+        if raw in loaded:
+            return loaded[raw]
+        msg = f"failed to convert {symbol} to its coin with symbol_to_coin_map. Caller: {get_caller_name()}"
+    except Exception:
+        msg = f"failed to convert {symbol} to its coin with symbol_to_coin_map. Caller: {get_caller_name()}"
+
+    coin = heuristic_symbol_to_coin(raw)
     if coin:
         msg += f". Using heuristics to guess coin: {coin}"
     if verbose:
@@ -1175,7 +1381,289 @@ def _load_fake_approved_coins(config, *, quote=None):
     return sorted(set(approved_coins))
 
 
-async def format_approved_ignored_coins(config, exchanges: [str], quote=None, verbose=True):
+def _approved_all_market_identifiers(exchange_markets_quotes) -> set[str]:
+    """Return identifiers whose collision scope is safe across all exchanges."""
+    records = []
+    collision_canonicals = set()
+    canonical_symbols = defaultdict(set)
+    for exchange, markets, quote in exchange_markets_quotes:
+        coin_to_symbol_map, symbol_to_coin_map = _build_coin_symbol_maps(markets, quote)
+        canonical_groups = defaultdict(list)
+        for symbol, market in markets.items():
+            if (market or {}).get("active") is False:
+                continue
+            canonical = symbol_to_coin_map.get(symbol) or heuristic_symbol_to_coin(symbol)
+            if canonical:
+                canonical_groups[canonical].append(symbol)
+
+        exchange_name = to_standard_exchange_name(exchange)
+        for canonical, symbols in canonical_groups.items():
+            canonical_symbols[canonical].update(
+                _quote_agnostic_market_identity(symbol) for symbol in symbols
+            )
+            candidates = coin_to_symbol_map.get(canonical, [])
+            if len(symbols) > 1 or len(candidates) > 1:
+                collision_canonicals.add(canonical)
+            for symbol in symbols:
+                market = markets.get(symbol) or {}
+                exact_identifier = str(market.get("id") or symbol)
+                records.append((exchange_name, canonical, exact_identifier))
+
+    collision_canonicals.update(
+        canonical
+        for canonical, symbols in canonical_symbols.items()
+        if len(symbols) > 1
+    )
+
+    return {
+        f"{exchange}::{exact_identifier}" if canonical in collision_canonicals else canonical
+        for exchange, canonical, exact_identifier in records
+    }
+
+
+def _quote_agnostic_market_identity(symbol: str) -> str:
+    """Identify an underlying contract without collapsing scaled base tokens."""
+    base = str(symbol).split("/", 1)[0].strip()
+    if base.startswith("k") and base[1:].isupper():
+        base = f"1000{base[1:]}"
+    return base.upper()
+
+
+def _preserve_market_identifiers(values) -> list[str]:
+    """Strip configured identifiers without collapsing exchange market identity."""
+    return [raw for value in values if (raw := str(value).strip())]
+
+
+async def reject_cross_exchange_market_identifier_collisions(
+    identifiers, exchanges, *, quote=None, verbose=True
+) -> None:
+    """Require venue scope when one native ID names different configured contracts."""
+    standard_exchanges = list(
+        dict.fromkeys(
+            to_standard_exchange_name(str(exchange))
+            for exchange in exchanges
+            if str(exchange).lower() != "fake"
+        )
+    )
+    if len(standard_exchanges) < 2:
+        return
+
+    identifiers = {
+        str(identifier).strip()
+        for identifier in identifiers
+        if str(identifier).strip()
+    }
+    candidates = sorted(
+        identifier
+        for identifier in identifiers
+        if split_exchange_qualified_market_identifier(identifier)[0] is None
+    )
+    if not candidates:
+        return
+
+    await asyncio.gather(
+        *[load_markets(exchange, verbose=False, quote=quote) for exchange in standard_exchanges]
+    )
+    for identifier in candidates:
+        resolved = {}
+        for exchange in standard_exchanges:
+            try:
+                symbol = coin_to_symbol(
+                    identifier, exchange, quote=quote, verbose=verbose
+                )
+            except (MarketIdentifierExchangeMismatch, UnknownMarketIdentifier):
+                continue
+            resolved[exchange] = {
+                "coin": heuristic_symbol_to_coin(symbol),
+                "symbol": symbol,
+                "identity": _quote_agnostic_market_identity(symbol),
+            }
+        if len({item["identity"] for item in resolved.values()}) > 1:
+            raise AmbiguousMarketIdentifier(
+                f"market identifier {identifier!r} resolves to different contracts across "
+                f"configured exchanges: {resolved}; use exchange::<native-id>"
+            )
+
+
+async def _remove_resolved_ignored_markets(
+    config,
+    exchanges,
+    *,
+    quote=None,
+    verbose=True,
+    include_backtest_coin_source_venues=False,
+) -> None:
+    """Subtract ignored aliases resolving to the same venue market."""
+    approved_by_side = config["live"]["approved_coins"]
+    ignored_by_side = config["live"]["ignored_coins"]
+    potentially_overlapping_sides = [
+        pside
+        for pside in ("long", "short")
+        if any(
+            approved != ignored
+            and (
+                looks_like_exact_market_identifier(approved)
+                or looks_like_exact_market_identifier(ignored)
+                or heuristic_symbol_to_coin(approved) == heuristic_symbol_to_coin(ignored)
+            )
+            for approved in approved_by_side[pside]
+            for ignored in ignored_by_side[pside]
+        )
+    ]
+    if not potentially_overlapping_sides:
+        return
+
+    source_exchanges = (
+        (config.get("backtest", {}).get("coin_sources") or {}).values()
+        if include_backtest_coin_source_venues
+        else []
+    )
+    standard_exchanges = list(
+        dict.fromkeys(
+            to_standard_exchange_name(str(exchange))
+            for exchange in [*exchanges, *source_exchanges]
+            if str(exchange).lower() != "fake"
+        )
+    )
+    if not standard_exchanges:
+        return
+    await asyncio.gather(
+        *[load_markets(ex, verbose=False, quote=quote) for ex in standard_exchanges]
+    )
+
+    def resolve_if_available(identifier, exchange):
+        try:
+            return coin_to_symbol(identifier, exchange, quote=quote, verbose=verbose)
+        except (MarketIdentifierExchangeMismatch, UnknownMarketIdentifier):
+            return None
+
+    for pside in potentially_overlapping_sides:
+        ignored_symbols_by_exchange = {
+            exchange: {
+                symbol
+                for identifier in ignored_by_side[pside]
+                if (symbol := resolve_if_available(identifier, exchange)) is not None
+            }
+            for exchange in standard_exchanges
+        }
+        approved_by_side[pside] = [
+            identifier
+            for identifier in approved_by_side[pside]
+            if not any(
+                (symbol := resolve_if_available(identifier, exchange)) is not None
+                and symbol in ignored_symbols_by_exchange[exchange]
+                for exchange in standard_exchanges
+            )
+        ]
+
+
+async def _coalesce_resolved_approved_markets(
+    config,
+    exchanges,
+    *,
+    quote=None,
+    verbose=True,
+    prefer_backtest_coin_source_keys=False,
+) -> None:
+    """Keep one approved dataset key for each resolved venue-market identity."""
+    coin_sources = (
+        config.get("backtest", {}).get("coin_sources") or {}
+        if prefer_backtest_coin_source_keys
+        else {}
+    )
+    standard_exchanges = list(
+        dict.fromkeys(
+            to_standard_exchange_name(str(exchange))
+            for exchange in [*exchanges, *coin_sources.values()]
+            if str(exchange).lower() != "fake"
+        )
+    )
+    approved_identifiers = [
+        identifier
+        for pside in ("long", "short")
+        for identifier in config["live"]["approved_coins"][pside]
+    ]
+    identifiers_by_canonical = defaultdict(set)
+    for identifier in approved_identifiers:
+        identifiers_by_canonical[heuristic_symbol_to_coin(identifier)].add(identifier)
+    needs_resolved_coalescing = bool(coin_sources) or any(
+        len(identifiers) > 1 for identifiers in identifiers_by_canonical.values()
+    )
+    if needs_resolved_coalescing:
+        missing_map_exchanges = [
+            exchange
+            for exchange in standard_exchanges
+            if not _load_coin_to_symbol_map(exchange)
+        ]
+        await asyncio.gather(
+            *[
+                load_markets(exchange, verbose=False, quote=quote)
+                for exchange in missing_map_exchanges
+            ]
+        )
+
+    source_identities = []
+    for source_identifier, exchange in sorted(coin_sources.items()):
+        exchange = to_standard_exchange_name(str(exchange))
+        try:
+            source_symbol = coin_to_symbol(
+                source_identifier, exchange, quote=quote, verbose=verbose
+            )
+        except UnknownMarketIdentifier:
+            continue
+        source_identities.append(
+            (source_identifier, exchange, source_symbol)
+        )
+
+    def identity(identifier):
+        for _source_identifier, exchange, source_symbol in source_identities:
+            try:
+                identifier_symbol = coin_to_symbol(
+                    identifier, exchange, quote=quote, verbose=verbose
+                )
+            except (MarketIdentifierExchangeMismatch, UnknownMarketIdentifier):
+                continue
+            if identifier_symbol == source_symbol:
+                return ("source", exchange, source_symbol)
+        resolved = []
+        for exchange in standard_exchanges:
+            try:
+                symbol = coin_to_symbol(
+                    identifier, exchange, quote=quote, verbose=verbose
+                )
+            except (MarketIdentifierExchangeMismatch, UnknownMarketIdentifier):
+                continue
+            resolved.append((exchange, symbol))
+        return ("resolved", tuple(resolved)) if resolved else ("raw", identifier)
+
+    representatives = {
+        ("source", exchange, source_symbol): source_identifier
+        for source_identifier, exchange, source_symbol in source_identities
+    }
+    for pside in ("long", "short"):
+        for identifier in config["live"]["approved_coins"][pside]:
+            representatives.setdefault(identity(identifier), identifier)
+
+    for pside in ("long", "short"):
+        seen = set()
+        coalesced = []
+        for identifier in config["live"]["approved_coins"][pside]:
+            market_identity = identity(identifier)
+            if market_identity in seen:
+                continue
+            seen.add(market_identity)
+            coalesced.append(representatives[market_identity])
+        config["live"]["approved_coins"][pside] = coalesced
+
+
+async def format_approved_ignored_coins(
+    config,
+    exchanges: [str],
+    quote=None,
+    verbose=True,
+    *,
+    prefer_backtest_coin_source_keys=False,
+):
     if isinstance(exchanges, str):
         exchanges = [exchanges]
     before_approved = deepcopy(config.get("live", {}).get("approved_coins"))
@@ -1207,9 +1695,14 @@ async def format_approved_ignored_coins(config, exchanges: [str], quote=None, ve
             marketss = [
                 filter_markets(m, ex, quote=quote)[0] for m, ex in zip(marketss, standard_exchanges)
             ]
-            for markets in marketss:
-                for symbol in markets:
-                    approved_coins.add(symbol_to_coin(symbol, verbose=verbose))
+            approved_coins.update(
+                _approved_all_market_identifiers(
+                    [
+                        (exchange, markets, get_quote(exchange, quote))
+                        for exchange, markets in zip(standard_exchanges, marketss)
+                    ]
+                )
+            )
         approved_coins_sorted = sorted([x for x in approved_coins if x])
 
     config["live"]["approved_coins"] = {}
@@ -1217,9 +1710,7 @@ async def format_approved_ignored_coins(config, exchanges: [str], quote=None, ve
         if _coins_source_side_is_all(ac[pside]):
             config["live"]["approved_coins"][pside] = list(approved_coins_sorted or [])
         else:
-            config["live"]["approved_coins"][pside] = [
-                cf for x in ac[pside] if (cf := symbol_to_coin(x))
-            ]
+            config["live"]["approved_coins"][pside] = _preserve_market_identifiers(ac[pside])
 
     ignored_source = coin_sources.get("ignored_coins", config.get("live", {}).get("ignored_coins"))
     if ignored_source is None:
@@ -1227,8 +1718,33 @@ async def format_approved_ignored_coins(config, exchanges: [str], quote=None, ve
     coin_sources["ignored_coins"] = deepcopy(ignored_source)
     ic = normalize_coins_source(ignored_source, allow_all=False)
     config["live"]["ignored_coins"] = {
-        pside: [cf for x in ic[pside] if (cf := symbol_to_coin(x))] for pside in ic
+        pside: _preserve_market_identifiers(ic[pside]) for pside in ic
     }
+    await reject_cross_exchange_market_identifier_collisions(
+        [
+            identifier
+            for field in ("approved_coins", "ignored_coins")
+            for side in ("long", "short")
+            for identifier in config["live"][field][side]
+        ],
+        exchanges,
+        quote=quote,
+        verbose=verbose,
+    )
+    await _coalesce_resolved_approved_markets(
+        config,
+        exchanges,
+        quote=quote,
+        verbose=verbose,
+        prefer_backtest_coin_source_keys=prefer_backtest_coin_source_keys,
+    )
+    await _remove_resolved_ignored_markets(
+        config,
+        exchanges,
+        quote=quote,
+        verbose=verbose,
+        include_backtest_coin_source_venues=prefer_backtest_coin_source_keys,
+    )
 
     approved_diff = _diff_snapshot(before_approved, config["live"]["approved_coins"])
     ignored_diff = _diff_snapshot(before_ignored, config["live"]["ignored_coins"])
@@ -1437,15 +1953,15 @@ def read_external_coins_lists(filepath) -> dict:
 
 
 async def get_first_ohlcv_iteratively(cc, symbol):
-    """Return the earliest OHLCV candle for a Bitget market.
+    """Return the earliest OHLCV candle for a backward-paginated native market.
 
-    Bitget does not accept a conventional ``since`` parameter for swap OHLCV
-    queries. Instead we page backwards using ``params={"until": ms}``, where an
-    empty response indicates that ``until`` predates the instrument listing.  We
-    leverage that behaviour to binary-search over monthly candles and then
-    refine the result with a daily fetch.  The returned value is the first full
-    candle ``[timestamp, open, high, low, close, volume]`` if available, else
-    ``None``."""
+    Native Bitget and Bitunix clients page backwards using
+    ``params={"until": ms}``, where an empty response indicates that ``until``
+    predates the instrument listing. We leverage that behaviour to binary-search
+    over monthly candles and then refine the result with a daily fetch. The
+    returned value is the first full candle
+    ``[timestamp, open, high, low, close, volume]`` if available, else ``None``.
+    """
 
     DAY_MS = 86_400_000
     MONTH_MS = 30 * DAY_MS

--- a/tests/fixtures/ccxt_contracts/hyperliquid_namespaced_hip3_markets.json
+++ b/tests/fixtures/ccxt_contracts/hyperliquid_namespaced_hip3_markets.json
@@ -87,7 +87,16 @@
     },
     "summary": {
       "coin_to_symbol_map": {
-        "ABCD-USA500": [
+        "160000": [
+          "ABCD-USA500/USDC:USDC"
+        ],
+        "180001": [
+          "PARA-OTHERS/USDC:USDC"
+        ],
+        "180002": [
+          "PARA-BTCD/USDC:USDC"
+        ],
+        "ABCD-USA500/USDC:USDC": [
           "ABCD-USA500/USDC:USDC"
         ],
         "BTCD": [
@@ -99,19 +108,28 @@
         "PARA-BTCD": [
           "PARA-BTCD/USDC:USDC"
         ],
+        "PARA-BTCD/USDC:USDC": [
+          "PARA-BTCD/USDC:USDC"
+        ],
         "PARA-OTHERS": [
           "PARA-OTHERS/USDC:USDC"
         ],
-        "USA500": [
-          "ABCD-USA500/USDC:USDC"
+        "PARA-OTHERS/USDC:USDC": [
+          "PARA-OTHERS/USDC:USDC"
         ],
-        "abcd:USA500": [
+        "abcd:USA500/USDC:USDC": [
           "ABCD-USA500/USDC:USDC"
         ],
         "para:BTCD": [
           "PARA-BTCD/USDC:USDC"
         ],
+        "para:BTCD/USDC:USDC": [
+          "PARA-BTCD/USDC:USDC"
+        ],
         "para:OTHERS": [
+          "PARA-OTHERS/USDC:USDC"
+        ],
+        "para:OTHERS/USDC:USDC": [
           "PARA-OTHERS/USDC:USDC"
         ]
       },
@@ -164,7 +182,6 @@
         "160000": "abcd:USA500",
         "180001": "para:OTHERS",
         "180002": "para:BTCD",
-        "ABCD-USA500": "abcd:USA500",
         "ABCD-USA500/USDC:USDC": "abcd:USA500",
         "BTCD": "para:BTCD",
         "OTHERS": "para:OTHERS",
@@ -172,10 +189,11 @@
         "PARA-BTCD/USDC:USDC": "para:BTCD",
         "PARA-OTHERS": "para:OTHERS",
         "PARA-OTHERS/USDC:USDC": "para:OTHERS",
-        "USA500": "abcd:USA500",
-        "abcd:USA500": "abcd:USA500",
+        "abcd:USA500/USDC:USDC": "abcd:USA500",
         "para:BTCD": "para:BTCD",
-        "para:OTHERS": "para:OTHERS"
+        "para:BTCD/USDC:USDC": "para:BTCD",
+        "para:OTHERS": "para:OTHERS",
+        "para:OTHERS/USDC:USDC": "para:OTHERS"
       }
     }
   }

--- a/tests/fixtures/ccxt_contracts/kucoin_symbol_aliases.json
+++ b/tests/fixtures/ccxt_contracts/kucoin_symbol_aliases.json
@@ -57,7 +57,19 @@
         "EDGE": [
           "EDGE/USDT:USDT"
         ],
+        "EDGE/USDT:USDT": [
+          "EDGE/USDT:USDT"
+        ],
+        "EDGEUSDTM": [
+          "EDGE/USDT:USDT"
+        ],
         "HOT": [
+          "HOT/USDT:USDT"
+        ],
+        "HOT/USDT:USDT": [
+          "HOT/USDT:USDT"
+        ],
+        "HOTUSDTM": [
           "HOT/USDT:USDT"
         ]
       },

--- a/tests/optimization/test_optimize_suite_contexts.py
+++ b/tests/optimization/test_optimize_suite_contexts.py
@@ -21,6 +21,19 @@ class _FakeAttachment:
         self.closed += 1
 
 
+def _stub_market_identity_validation(monkeypatch):
+    async def fake_reject_cross_exchange_market_identifier_collisions(
+        _identifiers, _exchanges, **_kwargs
+    ):
+        return None
+
+    monkeypatch.setattr(
+        optimize_suite,
+        "reject_cross_exchange_market_identifier_collisions",
+        fake_reject_cross_exchange_market_identifier_collisions,
+    )
+
+
 def _make_lazy_dataset(
     *,
     exchange="combined",
@@ -61,6 +74,7 @@ def _make_lazy_dataset(
 async def test_prepare_suite_contexts_keeps_directional_scenarios_with_default_short_disabled(
     monkeypatch,
 ):
+    _stub_market_identity_validation(monkeypatch)
     config = get_template_config()
     config["backtest"]["start_date"] = "2024-01-01"
     config["backtest"]["end_date"] = "2024-01-02"
@@ -80,7 +94,9 @@ async def test_prepare_suite_contexts_keeps_directional_scenarios_with_default_s
     async def fake_load_markets(_exchange, verbose=False):
         return {}
 
-    async def fake_format_approved_ignored_coins(_config, _exchanges, verbose=False):
+    async def fake_format_approved_ignored_coins(
+        _config, _exchanges, verbose=False, **_kwargs
+    ):
         return None
 
     async def fake_prepare_master_datasets(*_args, **_kwargs):
@@ -166,7 +182,9 @@ async def test_prepare_suite_contexts_master_universe_keeps_base_and_scenario_co
     async def fake_load_markets(_exchange, verbose=False):
         return {}
 
-    async def fake_format_approved_ignored_coins(_config, _exchanges, verbose=False):
+    async def fake_format_approved_ignored_coins(
+        _config, _exchanges, verbose=False, **_kwargs
+    ):
         return None
 
     async def fake_prepare_master_datasets(base_config, exchanges, *_args, **_kwargs):
@@ -202,6 +220,7 @@ async def test_prepare_suite_contexts_master_universe_keeps_base_and_scenario_co
 
 @pytest.mark.asyncio
 async def test_prepare_suite_contexts_expands_scenario_required_exchanges(monkeypatch):
+    _stub_market_identity_validation(monkeypatch)
     config = get_template_config()
     config["backtest"]["start_date"] = "2024-01-01"
     config["backtest"]["end_date"] = "2024-01-02"
@@ -219,7 +238,9 @@ async def test_prepare_suite_contexts_expands_scenario_required_exchanges(monkey
         loaded_exchanges.append(exchange)
         return {}
 
-    async def fake_format_approved_ignored_coins(_config, exchanges, verbose=False):
+    async def fake_format_approved_ignored_coins(
+        _config, exchanges, verbose=False, **_kwargs
+    ):
         captured["formatted_exchanges"] = list(exchanges)
         return None
 
@@ -252,6 +273,7 @@ async def test_prepare_suite_contexts_expands_scenario_required_exchanges(monkey
 
 @pytest.mark.asyncio
 async def test_prepare_suite_contexts_rejects_unavailable_scenario_exchange(monkeypatch):
+    _stub_market_identity_validation(monkeypatch)
     config = get_template_config()
     config["backtest"]["start_date"] = "2024-01-01"
     config["backtest"]["end_date"] = "2024-01-02"
@@ -266,7 +288,9 @@ async def test_prepare_suite_contexts_rejects_unavailable_scenario_exchange(monk
     async def fake_load_markets(_exchange, verbose=False):
         return {}
 
-    async def fake_format_approved_ignored_coins(_config, _exchanges, verbose=False):
+    async def fake_format_approved_ignored_coins(
+        _config, _exchanges, verbose=False, **_kwargs
+    ):
         return None
 
     async def fake_prepare_master_datasets(*_args, **_kwargs):
@@ -303,7 +327,9 @@ async def test_prepare_suite_contexts_rejects_scenario_with_no_usable_coins(monk
     async def fake_load_markets(_exchange, verbose=False):
         return {}
 
-    async def fake_format_approved_ignored_coins(_config, _exchanges, verbose=False):
+    async def fake_format_approved_ignored_coins(
+        _config, _exchanges, verbose=False, **_kwargs
+    ):
         return None
 
     async def fake_prepare_master_datasets(*_args, **_kwargs):
@@ -340,7 +366,9 @@ async def test_prepare_suite_contexts_rejects_asymmetric_side_coin_lists(monkeyp
     async def fake_load_markets(_exchange, verbose=False):
         return {}
 
-    async def fake_format_approved_ignored_coins(_config, _exchanges, verbose=False):
+    async def fake_format_approved_ignored_coins(
+        _config, _exchanges, verbose=False, **_kwargs
+    ):
         return None
 
     monkeypatch.setattr(optimize_suite, "load_markets", fake_load_markets)

--- a/tests/test_backtest_maker_fee_override.py
+++ b/tests/test_backtest_maker_fee_override.py
@@ -2,6 +2,7 @@ import logging
 
 import numpy as np
 import pytest
+import utils
 
 import backtest as backtest_module
 from config_utils import get_template_config
@@ -196,6 +197,37 @@ def test_prep_backtest_args_injects_dynamic_wallet_exposure_sentinel_without_coi
     assert bot_params_list[0]["short"]["wallet_exposure_limit"] == -1.0
 
 
+def test_prep_backtest_args_does_not_alias_exact_native_ids_across_sides():
+    config = _base_config()
+    config["backtest"]["coins"] = {"binance": ["1000ABCUSDT", "ABCUSDT"]}
+    config["live"]["approved_coins"] = {
+        "long": ["1000ABCUSDT"],
+        "short": ["ABCUSDT"],
+    }
+    config["bot"]["short"]["n_positions"] = 1
+    config["bot"]["short"]["total_wallet_exposure_limit"] = 1.0
+    market_settings = {
+        coin: {
+            "maker": 0.0001,
+            "taker": 0.0005,
+            "qty_step": 1.0,
+            "price_step": 0.0001,
+            "min_qty": 1.0,
+            "min_cost": 1.0,
+            "c_mult": 1.0,
+        }
+        for coin in config["backtest"]["coins"]["binance"]
+    }
+
+    bot_params_list, _, _, _ = prep_backtest_args(config, market_settings, "binance")
+
+    params_by_coin = dict(zip(sorted(market_settings), bot_params_list))
+    assert params_by_coin["1000ABCUSDT"]["long"]["wallet_exposure_limit"] == -1.0
+    assert params_by_coin["1000ABCUSDT"]["short"]["wallet_exposure_limit"] == 0.0
+    assert params_by_coin["ABCUSDT"]["long"]["wallet_exposure_limit"] == 0.0
+    assert params_by_coin["ABCUSDT"]["short"]["wallet_exposure_limit"] == -1.0
+
+
 def test_prep_backtest_args_preserves_explicit_coin_wallet_exposure_override():
     config = _base_config()
     config["bot"]["short"]["total_wallet_exposure_limit"] = 1.0
@@ -253,6 +285,37 @@ def test_prep_backtest_args_merges_conditional_hsl_override_per_coin():
         "yellow": pytest.approx(0.5),
         "orange": pytest.approx(0.75),
     }
+
+
+def test_prep_backtest_args_matches_exact_override_to_active_alias(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    markets = {
+        "BTC/USDT:USDT": {
+            "id": "BTCUSDT",
+            "swap": True,
+            "linear": True,
+            "active": True,
+            "base": "BTC",
+        }
+    }
+    utils.create_coin_symbol_map_cache("binance", markets, verbose=False)
+    config = _base_config()
+    config["backtest"]["coins"] = {"binance": ["BTC"]}
+    config["live"]["approved_coins"] = {"long": ["BTC"], "short": []}
+    config["coin_overrides"] = {
+        "BTCUSDT": {"bot": {"long": {"wallet_exposure_limit": 0.25}}}
+    }
+    market_settings = {
+        "BTC": {
+            **_base_mss()["BTC/USDT:USDT"],
+            "exchange": "binance",
+            "symbol": "BTC/USDT:USDT",
+        }
+    }
+
+    bot_params_list, _, _, _ = prep_backtest_args(config, market_settings, "binance")
+
+    assert bot_params_list[0]["long"]["wallet_exposure_limit"] == 0.25
 
 
 def test_prep_backtest_args_uses_canonical_strategy_params_for_runtime_payload():

--- a/tests/test_backtest_universe.py
+++ b/tests/test_backtest_universe.py
@@ -2,8 +2,9 @@ from copy import deepcopy
 
 import pytest
 
+import backtest
 from backtest import get_cache_hash
-from backtest_universe import effective_backtest_data_coins
+from backtest_universe import effective_backtest_data_coins, normalize_backtest_coin
 from config import prepare_config
 from config_utils import get_template_config
 
@@ -31,6 +32,43 @@ def test_effective_backtest_data_coins_ignores_disabled_side():
     assert effective_backtest_data_coins(cfg) == ["A"]
 
 
+def test_backtest_universe_preserves_exchange_qualified_market_identity():
+    assert normalize_backtest_coin("bitget::ABCUSDT") == "bitget::ABCUSDT"
+
+
+def test_backtest_universe_preserves_exact_ccxt_market_identity():
+    assert normalize_backtest_coin("1000ABC/USDT:USDT") == "1000ABC/USDT:USDT"
+
+
+def test_backtest_universe_preserves_native_market_id():
+    assert normalize_backtest_coin("1000ABCUSDT") == "1000ABCUSDT"
+
+
+def test_backtest_universe_preserves_hyphenated_native_market_id():
+    assert normalize_backtest_coin("BTC-USDT-SWAP") == "BTC-USDT-SWAP"
+
+
+def test_backtest_universe_preserves_suffix_bearing_native_market_id():
+    assert normalize_backtest_coin("HOTUSDTM") == "HOTUSDTM"
+    assert normalize_backtest_coin("XUSDTM") == "XUSDTM"
+
+
+@pytest.mark.parametrize("identifier", ["1000ABC"])
+def test_backtest_universe_retains_legacy_unqualified_canonical_keys(identifier):
+    assert normalize_backtest_coin(identifier) == "ABC"
+
+
+def test_backtest_universe_does_not_use_global_symbol_label_cache(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    cache_dir = tmp_path / "caches"
+    cache_dir.mkdir()
+    (cache_dir / "symbol_to_coin_map.json").write_text(
+        '{"ABC": "venue:ABC"}', encoding="utf-8"
+    )
+
+    assert normalize_backtest_coin("ABC") == "ABC"
+
+
 def test_effective_backtest_data_coins_supports_canonical_grouped_bot_config():
     cfg = prepare_config(
         _base_config(),
@@ -54,6 +92,73 @@ def test_hlcvs_cache_hash_changes_when_disabled_side_becomes_enabled():
     assert effective_backtest_data_coins(disabled_long) == ["A"]
     assert effective_backtest_data_coins(enabled_long) == ["A", "B", "C"]
     assert get_cache_hash(disabled_long, "binance") != get_cache_hash(enabled_long, "binance")
+
+
+def test_single_exchange_cache_hash_tracks_preparation_algorithm(monkeypatch):
+    cfg = _base_config()
+    first = get_cache_hash(cfg, "binance")
+    monkeypatch.setattr(
+        backtest,
+        "HLCV_PREPARATION_ALGORITHM_VERSION",
+        backtest.HLCV_PREPARATION_ALGORITHM_VERSION + 1,
+    )
+
+    assert get_cache_hash(cfg, "binance") != first
+
+
+def test_hlcvs_cache_hash_tracks_resolved_market_identity(monkeypatch):
+    cfg = _base_config()
+    resolved_symbol = {"value": "A/USDT:USDT"}
+
+    monkeypatch.setattr(
+        backtest,
+        "coin_to_symbol",
+        lambda coin, exchange, verbose=False: resolved_symbol["value"],
+    )
+    first = get_cache_hash(cfg, "binance")
+    resolved_symbol["value"] = "1000A/USDT:USDT"
+
+    assert get_cache_hash(cfg, "binance") != first
+
+
+@pytest.mark.asyncio
+async def test_combined_sources_refresh_before_hlcvs_cache_lookup(monkeypatch):
+    cfg = _base_config()
+    cfg["backtest"]["exchanges"] = ["binance", "bybit"]
+    cfg["backtest"]["coin_sources"] = {"AUSDT": "bitget"}
+    cfg["backtest"]["market_settings_sources"] = {"AUSDT": "kucoin"}
+    refreshed = False
+
+    async def refresh_sources(forced, settings, coins, configured):
+        nonlocal refreshed
+        assert forced == {"AUSDT": "bitget"}
+        assert settings == {"AUSDT": "kucoinfutures"}
+        assert coins == ["A"]
+        assert configured == ["binanceusdm", "bybit"]
+        refreshed = True
+        return {"A": "bitget"}, {"A": "kucoinfutures"}
+
+    def cache_lookup(config, exchange, warmup_minutes):
+        assert refreshed
+        assert config["backtest"]["coin_sources"] == {"A": "bitget"}
+        assert config["backtest"]["market_settings_sources"] == {
+            "A": "kucoinfutures"
+        }
+        return None
+
+    class PreparationReached(Exception):
+        pass
+
+    async def stop_after_cache_gate(*args, **kwargs):
+        raise PreparationReached
+
+    monkeypatch.setattr(backtest, "_load_and_reconcile_combined_sources", refresh_sources)
+    monkeypatch.setattr(backtest, "load_hlcvs_data_override", lambda *args: None)
+    monkeypatch.setattr(backtest, "load_coins_hlcvs_from_cache", cache_lookup)
+    monkeypatch.setattr(backtest, "prepare_hlcvs_combined", stop_after_cache_gate)
+
+    with pytest.raises(PreparationReached):
+        await backtest.prepare_hlcvs_mss(cfg, "combined")
 
 
 def test_hlcvs_cache_hash_changes_for_canonical_grouped_side_enablement():

--- a/tests/test_build_backtest_payload_purity.py
+++ b/tests/test_build_backtest_payload_purity.py
@@ -14,8 +14,13 @@ from copy import deepcopy
 import numpy as np
 import pytest
 
-from backtest import _validate_hlcvs_valid_windows, build_backtest_payload
+from backtest import (
+    _apply_market_settings_override,
+    _validate_hlcvs_valid_windows,
+    build_backtest_payload,
+)
 from config_utils import get_template_config
+import utils
 
 
 def _base_config(candle_interval_minutes: int = 1) -> dict:
@@ -114,6 +119,87 @@ def test_build_backtest_payload_keeps_per_side_approved_coin_universe():
 
     assert payload.bot_params_list[coin4_idx]["long"]["wallet_exposure_limit"] == 0.0
     assert payload.bot_params_list[coin4_idx]["short"]["wallet_exposure_limit"] != 0.0
+
+
+def test_market_settings_overrides_match_exact_and_alias_keys(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    markets = {
+        "BTC/USDT:USDT": {
+            "id": "BTCUSDT",
+            "swap": True,
+            "linear": True,
+            "active": True,
+            "base": "BTC",
+        }
+    }
+    utils.create_coin_symbol_map_cache("bitget", markets, verbose=False)
+    overrides = {
+        "global": {"BTCUSDT": {"c_mult": 2.0}},
+        "by_exchange": {"bitget": {"BTCUSDT": {"maker": 0.001}}},
+    }
+
+    result = _apply_market_settings_override(
+        "BTC",
+        "bitget",
+        {"exchange": "bitget", "c_mult": 1.0, "maker": 0.0002},
+        overrides,
+    )
+
+    assert result["c_mult"] == 2.0
+    assert result["maker"] == 0.001
+
+
+def test_market_settings_override_alias_matches_active_exact_key(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    markets = {
+        "BTC/USDT:USDT": {
+            "id": "BTCUSDT",
+            "swap": True,
+            "linear": True,
+            "active": True,
+            "base": "BTC",
+        }
+    }
+    utils.create_coin_symbol_map_cache("bitget", markets, verbose=False)
+
+    result = _apply_market_settings_override(
+        "BTCUSDT",
+        "bitget",
+        {"exchange": "bitget", "c_mult": 1.0},
+        {"global": {"BTC": {"c_mult": 3.0}}, "by_exchange": {}},
+    )
+
+    assert result["c_mult"] == 3.0
+
+
+def test_market_settings_override_rejects_conflicting_direct_aliases(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    markets = {
+        "BTC/USDT:USDT": {
+            "id": "BTCUSDT",
+            "swap": True,
+            "linear": True,
+            "active": True,
+            "base": "BTC",
+        }
+    }
+    utils.create_coin_symbol_map_cache("bitget", markets, verbose=False)
+
+    with pytest.raises(ValueError, match="conflicting backtest.market_settings.overrides"):
+        _apply_market_settings_override(
+            "BTC",
+            "bitget",
+            {"exchange": "bitget", "c_mult": 1.0},
+            {
+                "global": {
+                    "BTC": {"c_mult": 2.0},
+                    "BTCUSDT": {"c_mult": 3.0},
+                },
+                "by_exchange": {},
+            },
+        )
 
 
 def test_build_backtest_payload_marks_normal_forced_coin_active():

--- a/tests/test_coin_overrides.py
+++ b/tests/test_coin_overrides.py
@@ -1,5 +1,8 @@
 from copy import deepcopy
 
+import pytest
+import passivbot
+from backtest import _get_backtest_coin_override
 from config_utils import parse_overrides
 from passivbot import Passivbot
 
@@ -22,7 +25,7 @@ def test_coin_override_forced_mode_manual(monkeypatch):
     }
 
     config = parse_overrides(deepcopy(base_config), verbose=False)
-    assert "DOGE" in config["coin_overrides"]
+    assert "DOGEUSDT" in config["coin_overrides"]
 
     bot = Passivbot.__new__(Passivbot)
     bot.config = config
@@ -39,6 +42,67 @@ def test_coin_override_forced_mode_manual(monkeypatch):
 
     assert "DOGE/USDT:USDT" in bot.coin_overrides
     assert bot.get_forced_PB_mode("long", "DOGE/USDT:USDT") == "manual"
+
+
+def test_live_coin_overrides_reject_conflicting_aliases_for_one_market():
+    bot = Passivbot.__new__(Passivbot)
+    bot.config = {
+        "coin_overrides": {
+            "BTC": {"live": {"forced_mode_long": "manual"}},
+            "BTCUSDT": {"live": {"forced_mode_long": "panic"}},
+        }
+    }
+    bot.coin_to_symbol = lambda _coin: "BTC/USDT:USDT"
+
+    with pytest.raises(ValueError, match="conflicting coin_overrides keys"):
+        bot.init_coin_overrides()
+
+
+def test_live_coin_overrides_refresh_is_atomic_on_resolution_failure():
+    bot = Passivbot.__new__(Passivbot)
+    prior = {"OLD/USDT:USDT": {"live": {"forced_mode_long": "manual"}}}
+    bot.coin_overrides = deepcopy(prior)
+    bot.config = {
+        "coin_overrides": {
+            "BTC": {"live": {"forced_mode_long": "panic"}},
+            "BROKEN": {"live": {"forced_mode_long": "manual"}},
+        }
+    }
+
+    def resolve(coin):
+        if coin == "BTC":
+            return "BTC/USDT:USDT"
+        raise ValueError("unavailable override market")
+
+    bot.coin_to_symbol = resolve
+
+    with pytest.raises(ValueError, match="unavailable override market"):
+        bot.init_coin_overrides()
+
+    assert bot.coin_overrides == prior
+
+
+def test_backtest_coin_overrides_reject_conflicting_aliases_for_one_market(
+    monkeypatch,
+):
+    config = {
+        "coin_overrides": {
+            "BTC": {"live": {"forced_mode_long": "manual"}},
+            "BTCUSDT": {"live": {"forced_mode_long": "panic"}},
+        }
+    }
+    monkeypatch.setattr(
+        "backtest.coin_to_symbol",
+        lambda _identifier, _venue, verbose=False: "BTC/USDT:USDT",
+    )
+
+    with pytest.raises(ValueError, match="conflicting coin_overrides resolve"):
+        _get_backtest_coin_override(
+            config,
+            {"BTC": {"exchange": "bitget", "symbol": "BTC/USDT:USDT"}},
+            "bitget",
+            "BTC",
+        )
 
 
 def test_forced_mode_shorthand_expansion(monkeypatch):
@@ -65,3 +129,36 @@ def test_forced_mode_shorthand_expansion(monkeypatch):
     assert bot.get_forced_PB_mode("long", "ETH/USDT:USDT") == "panic"
     # Shorthand "gs" should expand to "graceful_stop"
     assert bot.get_forced_PB_mode("short", "ETH/USDT:USDT") == "graceful_stop"
+
+
+def test_bot_symbol_cache_does_not_reuse_lossy_canonical_alias(monkeypatch):
+    bot = Passivbot.__new__(Passivbot)
+    bot.exchange = "testexchange"
+    bot.quote = "USDT"
+    bot.coin_to_symbol_map = {"ABC": "ABC/USDT:USDT"}
+    calls = []
+
+    def exact_resolver(identifier, exchange, quote=None, verbose=True):
+        calls.append((identifier, exchange, quote))
+        return "1000ABC/USDT:USDT"
+
+    monkeypatch.setattr(passivbot, "coin_to_symbol", exact_resolver)
+    monkeypatch.setattr(passivbot, "symbol_to_coin", lambda *_args, **_kwargs: "ABC")
+
+    assert bot.coin_to_symbol("1000ABC/USDT:USDT") == "1000ABC/USDT:USDT"
+    assert calls == [("1000ABC/USDT:USDT", "testexchange", "USDT")]
+
+
+def test_bot_symbol_cache_revalidates_previously_cached_alias(monkeypatch):
+    bot = Passivbot.__new__(Passivbot)
+    bot.exchange = "testexchange"
+    bot.quote = "USDT"
+    bot.coin_to_symbol_map = {"ABC": "STALE/USDT:USDT"}
+
+    monkeypatch.setattr(
+        passivbot,
+        "coin_to_symbol",
+        lambda identifier, exchange, quote=None, verbose=True: "CURRENT/USDT:USDT",
+    )
+
+    assert bot.coin_to_symbol("ABC") == "CURRENT/USDT:USDT"

--- a/tests/test_coin_overrides_foundation.py
+++ b/tests/test_coin_overrides_foundation.py
@@ -272,7 +272,7 @@ def test_non_positive_leverage_override_fails(value):
 def test_normalized_coin_collision_fails():
     with pytest.raises(ValueError, match=r"both normalize to 'BTC'"):
         _parse(
-            {"BTC": {}, "BTCUSDT": {}},
+            {"BTC": {}, "XBT": {}},
             symbol_normalizer=lambda coin: "BTC",
         )
 

--- a/tests/test_combined_candidate_frame_lifetime.py
+++ b/tests/test_combined_candidate_frame_lifetime.py
@@ -112,7 +112,7 @@ async def test_combined_candidate_frames_are_released_after_normalization(monkey
     monkeypatch.setattr(
         hp,
         "get_first_timestamps_unified",
-        lambda _coins: asyncio.sleep(0, result={}),
+        lambda _coins, **_kwargs: asyncio.sleep(0, result={}),
     )
     monkeypatch.setattr(hp, "_normalize_combined_coins", lambda values, *_args: list(values))
     monkeypatch.setattr(hp, "_resolve_combined_coin", fake_resolve_combined_coin)

--- a/tests/test_config_coin_sources.py
+++ b/tests/test_config_coin_sources.py
@@ -53,6 +53,20 @@ def test_format_config_normalizes_coin_sources():
     assert out["backtest"]["coin_sources"] == {"BTC": "binance"}
 
 
+def test_format_config_preserves_exact_coin_source_identifiers():
+    cfg = _base_config()
+    cfg["backtest"]["coin_sources"] = {
+        "1000ABCUSDT": "bitget",
+        "ABC/USDT:USDT": "bybit",
+        "bitget::ABCUSDT": "bitget",
+        "BTC-USDT-SWAP": "okx",
+    }
+
+    out = format_config(copy.deepcopy(cfg), verbose=False)
+
+    assert out["backtest"]["coin_sources"] == cfg["backtest"]["coin_sources"]
+
+
 def test_cache_hash_includes_coin_sources():
     cfg = _base_config()
     cfg["live"]["approved_coins"]["long"] = ["BTC/USDT:USDT"]

--- a/tests/test_config_utils_parse_overrides.py
+++ b/tests/test_config_utils_parse_overrides.py
@@ -67,6 +67,20 @@ def test_parse_overrides_keeps_nested_strategy_mods(monkeypatch):
     }
 
 
+@pytest.mark.parametrize("identifier", ["1000ABCUSDT", "1000ABC/USDT:USDT"])
+def test_parse_overrides_preserves_exact_market_identifier(identifier, monkeypatch):
+    cfg = _base_config_with_override(
+        identifier, {"live": {"forced_mode_long": "manual"}}
+    )
+    monkeypatch.setattr(config_utils, "symbol_to_coin", lambda _value: "ABC")
+    monkeypatch.setattr(config_utils, "load_override_config", lambda c, coin: {})
+
+    parsed = config_utils.parse_overrides(deepcopy(cfg), verbose=False)
+
+    assert identifier in parsed["coin_overrides"]
+    assert "ABC" not in parsed["coin_overrides"]
+
+
 def test_parse_overrides_retains_coin_flags_key(monkeypatch):
     cfg = _base_config_with_override("BTC", {"live": {"forced_mode_long": "manual"}})
     cfg["live"]["coin_flags"] = None

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -58,6 +58,62 @@ class _Clock:
         self._now += delta_ms
 
 
+def test_bot_symbol_resolver_propagates_market_ambiguity():
+    class _Bot:
+        def coin_to_symbol(self, _value, verbose=False):
+            raise fem.AmbiguousMarketIdentifier("ambiguous test market")
+
+    resolver = fem._symbol_resolver(_Bot())
+
+    with pytest.raises(fem.AmbiguousMarketIdentifier, match="ambiguous test market"):
+        resolver("ABCUSDT")
+
+
+@pytest.mark.parametrize(
+    "error_cls", [fem.AmbiguousMarketIdentifier, fem.MarketIdentifierExchangeMismatch]
+)
+@pytest.mark.parametrize("fetcher_cls", [BitgetFetcher, BinanceFetcher])
+def test_exchange_fetcher_symbol_resolver_propagates_market_resolution_errors(
+    fetcher_cls, error_cls
+):
+    def ambiguous(_value):
+        raise error_cls("unresolvable test market")
+
+    kwargs = {"symbol_resolver": ambiguous}
+    if fetcher_cls is BinanceFetcher:
+        kwargs.update(positions_provider=lambda: (), open_orders_provider=lambda: ())
+    fetcher = fetcher_cls(object(), **kwargs)
+
+    with pytest.raises(error_cls, match="unresolvable test market"):
+        fetcher._resolve_symbol("ABCUSDT")
+
+
+@pytest.mark.parametrize("fetcher_cls", [BitgetFetcher, BinanceFetcher])
+def test_exchange_fetcher_preserves_unknown_historical_symbol(fetcher_cls):
+    def unknown(_value):
+        raise fem.UnknownMarketIdentifier("delisted test market")
+
+    kwargs = {"symbol_resolver": unknown}
+    if fetcher_cls is BinanceFetcher:
+        kwargs.update(positions_provider=lambda: (), open_orders_provider=lambda: ())
+    fetcher = fetcher_cls(object(), **kwargs)
+
+    assert fetcher._resolve_symbol("OLDUSDT") == "OLDUSDT"
+
+
+@pytest.mark.parametrize("fetcher_cls", [BitgetFetcher, BinanceFetcher])
+def test_exchange_fetcher_symbol_resolver_keeps_generic_fallback(fetcher_cls):
+    def unavailable(_value):
+        raise RuntimeError("resolver unavailable")
+
+    kwargs = {"symbol_resolver": unavailable}
+    if fetcher_cls is BinanceFetcher:
+        kwargs.update(positions_provider=lambda: (), open_orders_provider=lambda: ())
+    fetcher = fetcher_cls(object(), **kwargs)
+
+    assert fetcher._resolve_symbol("ABCUSDT") == "ABCUSDT"
+
+
 class _FakeBitgetAPI:
     def __init__(
         self,

--- a/tests/test_hlcv_preparation.py
+++ b/tests/test_hlcv_preparation.py
@@ -32,6 +32,7 @@ import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 import hlcv_preparation as hp
+import utils
 from hlcv_preparation import HLCVManager, prepare_hlcvs, prepare_hlcvs_combined
 from candlestick_manager import CandlestickManager, CANDLE_DTYPE
 from ohlcv_catalog import OhlcvCatalog
@@ -47,6 +48,29 @@ LEGACY_DTYPE = np.dtype(
         ("bv", "float32"),
     ]
 )
+
+
+def test_combined_market_settings_propagates_ambiguous_source_identifier():
+    class AmbiguousSettingsManager:
+        def has_coin(self, _coin):
+            raise utils.AmbiguousMarketIdentifier("ambiguous market identifier")
+
+    class BestSourceManager:
+        def get_market_specific_settings(self, _coin):
+            return {}
+
+    with pytest.raises(utils.AmbiguousMarketIdentifier):
+        hp._resolve_combined_market_settings(
+            coin="ABC",
+            best_exchange="bybit",
+            market_settings_sources={"ABC": "bitget"},
+            om_dict={
+                "bybit": BestSourceManager(),
+                "bitget": AmbiguousSettingsManager(),
+            },
+            per_coin_warmups={},
+            default_warm=0,
+        )
 
 # ============================================================================
 # Fixtures
@@ -719,11 +743,8 @@ async def test_prepare_hlcvs_internal_raises_on_coin_fetch_failure(
         def get_market_specific_settings(self, coin):
             return {"exchange": "binance", "symbol": f"{coin}/USDT:USDT"}
 
-    monkeypatch.setattr(
-        hp,
-        "get_first_timestamps_unified",
-        AsyncMock(return_value={"BAD": 0, "GOOD": 0}),
-    )
+    first_timestamps_mock = AsyncMock(return_value={"BAD": 0, "GOOD": 0})
+    monkeypatch.setattr(hp, "get_first_timestamps_unified", first_timestamps_mock)
 
     with pytest.raises(RuntimeError, match="get_ohlcvs failed for BAD"):
         await hp.prepare_hlcvs_internal(
@@ -735,6 +756,9 @@ async def test_prepare_hlcvs_internal_raises_on_coin_fetch_failure(
             60_000,
             FakeManager(),
         )
+    first_timestamps_mock.assert_awaited_once_with(
+        ["BAD", "GOOD"], exchange="binance"
+    )
 
 
 @pytest.mark.asyncio
@@ -765,7 +789,7 @@ async def test_prepare_hlcvs_internal_raises_on_first_timestamp_failure(
     monkeypatch.setattr(
         hp,
         "get_first_timestamps_unified",
-        AsyncMock(return_value={"BAD": 0, "GOOD": 0}),
+        AsyncMock(return_value={"BAD": 1, "GOOD": 1}),
     )
 
     with pytest.raises(RuntimeError, match="get_first_timestamp failed for BAD"):
@@ -773,6 +797,41 @@ async def test_prepare_hlcvs_internal_raises_on_first_timestamp_failure(
             sample_config,
             ["BAD", "GOOD"],
             "binance",
+            0,
+            0,
+            60_000,
+            FakeManager(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_prepare_hlcvs_internal_rejects_zero_inception_when_age_filter_enabled(
+    sample_config, monkeypatch
+):
+    sample_config["live"]["minimum_coin_age_days"] = 30.0
+
+    class FakeManager:
+        async def load_markets(self):
+            return None
+
+        def has_coin(self, _coin):
+            return True
+
+        async def get_first_timestamp(self, _coin):
+            pytest.fail("zero unified inception must fail before exchange age lookup")
+
+        async def get_ohlcvs(self, _coin):
+            pytest.fail("coin with unknown inception must not fetch tradable candles")
+
+    monkeypatch.setattr(
+        hp, "get_first_timestamps_unified", AsyncMock(return_value={"NEW": 0.0})
+    )
+
+    with pytest.raises(ValueError, match="No valid coins found with data"):
+        await hp.prepare_hlcvs_internal(
+            sample_config,
+            ["NEW"],
+            "kucoinfutures",
             0,
             0,
             60_000,
@@ -2167,10 +2226,19 @@ def test_pick_best_combined_candidate_uses_config_order_not_volume_for_full_rang
 
 def test_forced_only_exchanges_are_normalization_only_for_unforced_coins():
     filtered_forced_sources = hp._filter_forced_sources_for_coins(
-        {"BTC": "okx", "STALE": "hyperliquid", "xyz:TSLA": "hyperliquid"},
-        ["BTC", "xyz:TSLA"],
+        {
+            "BTC": "okx",
+            "1000ABCUSDT": "bitget",
+            "STALE": "hyperliquid",
+            "xyz:TSLA": "hyperliquid",
+        },
+        ["BTC", "1000ABCUSDT", "xyz:TSLA"],
     )
-    assert filtered_forced_sources == {"BTC": "okx", "xyz:TSLA": "hyperliquid"}
+    assert filtered_forced_sources == {
+        "1000ABCUSDT": "bitget",
+        "BTC": "okx",
+        "xyz:TSLA": "hyperliquid",
+    }
 
     configured, extras = hp._partition_combined_exchange_roles(
         ["binanceusdm", "bybit", "binanceusdm"],
@@ -2228,6 +2296,169 @@ def test_forced_only_exchanges_are_normalization_only_for_unforced_coins():
         "bybit",
         "hyperliquid",
     )
+
+
+def test_plan_combined_coin_rejects_unknown_inception_when_minimum_age_enabled():
+    assert (
+        hp._plan_combined_coin(
+            coin="NEW",
+            base_start_ts=1_700_000_000_000,
+            end_ts=1_800_000_000_000,
+            first_timestamps_unified={"NEW": 0.0},
+            minimum_coin_age_days=30.0,
+            min_coin_age_ms=30 * 24 * 60 * 60 * 1000,
+            tradfi_for_stock_perps=False,
+            forced_sources={},
+            exchanges_to_consider=["bybit", "hyperliquid"],
+        )
+        is None
+    )
+
+
+def test_exact_forced_source_key_matches_active_alias(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    markets = {
+        "BTC/USDT:USDT": {
+            "id": "BTCUSDT",
+            "swap": True,
+            "linear": True,
+            "active": True,
+            "base": "BTC",
+        }
+    }
+    utils.create_coin_symbol_map_cache("bitget", markets, verbose=False)
+
+    assert hp._filter_forced_sources_for_coins(
+        {"BTCUSDT": "bitget"}, ["BTC"]
+    ) == {"BTC": "bitget"}
+
+
+def test_exact_forced_source_is_deferred_until_override_exchange_is_loaded(monkeypatch):
+    loaded = False
+
+    def resolve(identifier, exchange, verbose=False):
+        assert exchange == "bitget"
+        if not loaded:
+            raise utils.UnknownMarketIdentifier(identifier)
+        if identifier in {"BTC", "BTCUSDT"}:
+            return "BTC/USDT:USDT"
+        raise utils.UnknownMarketIdentifier(identifier)
+
+    monkeypatch.setattr(hp, "coin_to_symbol", resolve)
+
+    deferred = hp._filter_forced_sources_for_coins(
+        {"BTCUSDT": "bitget"}, ["BTC"], defer_unavailable=True
+    )
+    assert deferred == {"BTCUSDT": "bitget"}
+
+    loaded = True
+    assert hp._filter_forced_sources_for_coins(deferred, ["BTC"]) == {
+        "BTC": "bitget"
+    }
+
+
+@pytest.mark.parametrize(
+    ("filter_sources", "field_name"),
+    [
+        (hp._filter_forced_sources_for_coins, "backtest.coin_sources"),
+        (
+            hp._filter_market_settings_sources_for_coins,
+            "backtest.market_settings_sources",
+        ),
+    ],
+)
+def test_unknown_exact_source_for_active_canonical_coin_fails_closed(
+    monkeypatch, filter_sources, field_name
+):
+    def resolve(identifier, exchange, verbose=False):
+        if identifier == "BTCUSDT":
+            raise utils.UnknownMarketIdentifier(identifier)
+        return "BTC/USDT:USDT"
+
+    monkeypatch.setattr(hp, "coin_to_symbol", resolve)
+
+    with pytest.raises(
+        utils.UnknownMarketIdentifier,
+        match=rf"{field_name} key 'BTCUSDT' is unavailable on bitget",
+    ):
+        filter_sources({"BTCUSDT": "bitget"}, ["BTC"])
+
+
+def test_unknown_exact_source_outside_active_universe_is_dropped(monkeypatch):
+    def resolve(identifier, exchange, verbose=False):
+        raise utils.UnknownMarketIdentifier(identifier)
+
+    monkeypatch.setattr(hp, "coin_to_symbol", resolve)
+
+    assert hp._filter_forced_sources_for_coins(
+        {"OLDUSDTM": "kucoin"}, ["BTC"]
+    ) == {}
+
+
+@pytest.mark.asyncio
+async def test_combined_source_roles_drop_inactive_deferred_keys_after_loading(
+    monkeypatch,
+):
+    loaded = False
+
+    async def fake_load_markets(exchange, verbose=False):
+        nonlocal loaded
+        assert exchange == "kucoin"
+        loaded = True
+        return {}
+
+    def resolve(identifier, exchange, verbose=False):
+        assert loaded
+        assert exchange == "kucoin"
+        if identifier == "OLDUSDTM":
+            return "OLD/USDT:USDT"
+        if identifier == "BTC":
+            return "BTC/USDT:USDT"
+        raise utils.UnknownMarketIdentifier(identifier)
+
+    monkeypatch.setattr(hp, "load_markets", fake_load_markets)
+    monkeypatch.setattr(hp, "coin_to_symbol", resolve)
+
+    forced, market_settings = await hp._load_and_reconcile_combined_sources(
+        {"OLDUSDTM": "kucoin"}, {}, ["BTC"]
+    )
+
+    assert forced == {}
+    assert market_settings == {}
+
+
+@pytest.mark.parametrize(
+    "filter_sources",
+    [
+        hp._filter_forced_sources_for_coins,
+        hp._filter_market_settings_sources_for_coins,
+    ],
+)
+@pytest.mark.parametrize("active_coin", ["BTC", "bitget::BTCUSDT"])
+def test_qualified_source_rejects_contradictory_exchange(filter_sources, active_coin):
+    with pytest.raises(
+        utils.MarketIdentifierExchangeMismatch,
+        match="targets bitget, not bybit",
+    ):
+        filter_sources(
+            {"bitget::BTCUSDT": "bybit"},
+            [active_coin],
+            defer_unavailable=True,
+        )
+
+
+def test_market_settings_source_key_matches_active_exact_identifier(monkeypatch):
+    def resolve(identifier, exchange, verbose=False):
+        assert exchange == "bybit"
+        if identifier in {"BTC", "BTCUSDT"}:
+            return "BTC/USDT:USDT"
+        raise utils.UnknownMarketIdentifier(identifier)
+
+    monkeypatch.setattr(hp, "coin_to_symbol", resolve)
+
+    assert hp._filter_market_settings_sources_for_coins(
+        {"BTC": "bybit"}, ["BTCUSDT"]
+    ) == {"BTCUSDT": "bybit"}
 
 
 def test_volume_reference_exchange_uses_config_order_not_selected_coin_count():

--- a/tests/test_hlcvs_dataset_override.py
+++ b/tests/test_hlcvs_dataset_override.py
@@ -2,6 +2,7 @@ import json
 
 import numpy as np
 import pytest
+import utils
 
 from backtest import build_backtest_payload, ensure_valid_index_metadata
 from config_utils import get_template_config
@@ -117,6 +118,36 @@ def test_hlcvs_dataset_override_intersection_mode_preserves_input_side_membershi
     cache_dir = tmp_path / "hlcvs_data" / "custom__abc123"
     _write_dataset(cache_dir)
     config = _base_config(cache_dir, mode="intersection")
+
+    _cache_dir, coins, _hlcvs, _mss, _results_path, _btc, _timestamps = (
+        load_hlcvs_data_override(config, "binance")
+    )
+
+    assert coins == ["BTC"]
+    assert config["live"]["approved_coins"] == {"long": ["BTC"], "short": []}
+
+
+def test_hlcvs_dataset_override_reconciles_exact_identifier_to_dataset_key(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    cache_dir = tmp_path / "hlcvs_data" / "custom__abc123"
+    _write_dataset(cache_dir)
+    assert utils.create_coin_symbol_map_cache(
+        "binance",
+        {
+            "BTC/USDT:USDT": {
+                "id": "BTCUSDT",
+                "swap": True,
+                "linear": True,
+                "active": True,
+                "base": "BTC",
+            }
+        },
+        verbose=False,
+    )
+    config = _base_config(cache_dir, mode="intersection")
+    config["live"]["approved_coins"] = {"long": ["BTCUSDT"], "short": []}
 
     _cache_dir, coins, _hlcvs, _mss, _results_path, _btc, _timestamps = (
         load_hlcvs_data_override(config, "binance")

--- a/tests/test_inception_date.py
+++ b/tests/test_inception_date.py
@@ -8,6 +8,7 @@ import tempfile
 import shutil
 
 from candlestick_manager import CandlestickManager, CANDLE_DTYPE, ONE_MIN_MS
+from utils import FIRST_OHLCV_TIMESTAMPS_CACHE_VERSION
 
 
 @pytest.fixture
@@ -16,6 +17,27 @@ def tmp_cache_dir():
     d = tempfile.mkdtemp()
     yield d
     shutil.rmtree(d, ignore_errors=True)
+
+
+def mark_first_ohlcv_cache_current(cache_dir):
+    with open(
+        os.path.join(cache_dir, "first_ohlcv_timestamps_unified.version"),
+        "w",
+        encoding="utf-8",
+    ) as f:
+        f.write(str(FIRST_OHLCV_TIMESTAMPS_CACHE_VERSION))
+
+
+def write_first_ohlcv_cache_provenance(cache_dir, cache_key, exchange_name, symbol):
+    with open(
+        os.path.join(
+            cache_dir,
+            "first_ohlcv_timestamps_unified_exchange_specific_symbols.json",
+        ),
+        "w",
+        encoding="utf-8",
+    ) as f:
+        json.dump({cache_key: {exchange_name: symbol}}, f)
 
 
 def make_candles(timestamps: list[int]) -> np.ndarray:
@@ -292,8 +314,12 @@ class TestInceptionDateTracking:
         day2_end = day2 + 1439 * ONE_MIN_MS
 
         cache_path = os.path.join(tmp_cache_dir, "first_ohlcv_timestamps_unified_exchange_specific.json")
+        mark_first_ohlcv_cache_current(tmp_cache_dir)
         with open(cache_path, "w", encoding="utf-8") as f:
             json.dump({"ETH": {"binanceusdm": authoritative_ts}}, f)
+        write_first_ohlcv_cache_provenance(
+            tmp_cache_dir, "ETH", "binanceusdm", symbol
+        )
 
         calls = []
 
@@ -316,3 +342,169 @@ class TestInceptionDateTracking:
             g["start_ts"] == day1 and g["end_ts"] == day2 - ONE_MIN_MS and g["reason"] == "pre_inception"
             for g in gaps
         )
+
+    def test_exact_symbol_key_in_exchange_specific_cache_is_authoritative(self, tmp_cache_dir):
+        cm = CandlestickManager(exchange=None, exchange_name="binance", cache_dir=tmp_cache_dir)
+        symbol = "ETH/USDT:USDT"
+        authoritative_ts = 1672617600000
+        cache_path = os.path.join(
+            tmp_cache_dir, "first_ohlcv_timestamps_unified_exchange_specific.json"
+        )
+        mark_first_ohlcv_cache_current(tmp_cache_dir)
+        with open(cache_path, "w", encoding="utf-8") as f:
+            json.dump({symbol: {"binanceusdm": authoritative_ts}}, f)
+        write_first_ohlcv_cache_provenance(
+            tmp_cache_dir, symbol, "binanceusdm", symbol
+        )
+
+        assert cm._lookup_cached_authoritative_start_ts(symbol) == authoritative_ts
+
+    def test_mismatched_market_provenance_is_not_authoritative(self, tmp_cache_dir):
+        cm = CandlestickManager(exchange=None, exchange_name="binance", cache_dir=tmp_cache_dir)
+        symbol = "1000ABC/USDT:USDT"
+        authoritative_ts = 1672617600000
+        cache_path = os.path.join(
+            tmp_cache_dir, "first_ohlcv_timestamps_unified_exchange_specific.json"
+        )
+        mark_first_ohlcv_cache_current(tmp_cache_dir)
+        with open(cache_path, "w", encoding="utf-8") as f:
+            json.dump({"ABC": {"binanceusdm": authoritative_ts}}, f)
+        write_first_ohlcv_cache_provenance(
+            tmp_cache_dir, "ABC", "binanceusdm", "ABC/USDT:USDT"
+        )
+
+        assert cm._lookup_cached_authoritative_start_ts(symbol) is None
+
+    def test_unversioned_exchange_specific_cache_is_not_authoritative(self, tmp_cache_dir):
+        cm = CandlestickManager(exchange=None, exchange_name="binance", cache_dir=tmp_cache_dir)
+        symbol = "ETH/USDT:USDT"
+        cache_path = os.path.join(
+            tmp_cache_dir, "first_ohlcv_timestamps_unified_exchange_specific.json"
+        )
+        with open(cache_path, "w", encoding="utf-8") as f:
+            json.dump({symbol: {"binanceusdm": 1672617600000}}, f)
+
+        assert cm._lookup_cached_authoritative_start_ts(symbol) is None
+
+    def test_native_market_id_key_in_exchange_specific_cache_is_authoritative(
+        self, tmp_cache_dir
+    ):
+        symbol = "1000ABC/USDT:USDT"
+        native_id = "1000ABCUSDT"
+        authoritative_ts = 1672617600000
+        exchange = type(
+            "FakeExchange",
+            (),
+            {
+                "id": "bitget",
+                "markets": {
+                    symbol: {
+                        "symbol": symbol,
+                        "id": native_id,
+                    }
+                },
+            },
+        )()
+        cm = CandlestickManager(
+            exchange=exchange, exchange_name="bitget", cache_dir=tmp_cache_dir
+        )
+        cache_path = os.path.join(
+            tmp_cache_dir, "first_ohlcv_timestamps_unified_exchange_specific.json"
+        )
+        mark_first_ohlcv_cache_current(tmp_cache_dir)
+        with open(cache_path, "w", encoding="utf-8") as f:
+            json.dump({native_id: {"bitget": authoritative_ts}}, f)
+        write_first_ohlcv_cache_provenance(
+            tmp_cache_dir, native_id, "bitget", symbol
+        )
+
+        assert cm._lookup_cached_authoritative_start_ts(symbol) == authoritative_ts
+
+    def test_qualified_native_market_id_cache_key_is_authoritative(self, tmp_cache_dir):
+        symbol = "ABC/USDT:USDT"
+        native_id = "ABCUSDT"
+        authoritative_ts = 1672617600000
+        exchange = type(
+            "FakeExchange",
+            (),
+            {
+                "id": "bitget",
+                "markets": {
+                    symbol: {
+                        "symbol": symbol,
+                        "id": native_id,
+                    }
+                },
+            },
+        )()
+        cm = CandlestickManager(
+            exchange=exchange, exchange_name="bitget", cache_dir=tmp_cache_dir
+        )
+        cache_path = os.path.join(
+            tmp_cache_dir, "first_ohlcv_timestamps_unified_exchange_specific.json"
+        )
+        mark_first_ohlcv_cache_current(tmp_cache_dir)
+        with open(cache_path, "w", encoding="utf-8") as f:
+            json.dump(
+                {f"bitget::{native_id}": {"bitget": authoritative_ts}},
+                f,
+            )
+        write_first_ohlcv_cache_provenance(
+            tmp_cache_dir, f"bitget::{native_id}", "bitget", symbol
+        )
+
+        assert cm._lookup_cached_authoritative_start_ts(symbol) == authoritative_ts
+
+    @pytest.mark.parametrize(
+        ("exchange_name", "exchange_id", "qualified_prefix", "cache_exchange"),
+        [
+            ("binance", "binanceusdm", "binance", "binanceusdm"),
+            ("gateio", "gate", "gate", "gateio"),
+        ],
+    )
+    def test_qualified_native_cache_lookup_accepts_exchange_aliases(
+        self,
+        tmp_cache_dir,
+        exchange_name,
+        exchange_id,
+        qualified_prefix,
+        cache_exchange,
+    ):
+        symbol = "ABC/USDT:USDT"
+        native_id = "ABCUSDT"
+        authoritative_ts = 1672617600000
+        exchange = type(
+            "FakeExchange",
+            (),
+            {
+                "id": exchange_id,
+                "markets": {
+                    symbol: {
+                        "symbol": symbol,
+                        "id": native_id,
+                    }
+                },
+            },
+        )()
+        cm = CandlestickManager(
+            exchange=exchange,
+            exchange_name=exchange_name,
+            cache_dir=tmp_cache_dir,
+        )
+        cache_path = os.path.join(
+            tmp_cache_dir, "first_ohlcv_timestamps_unified_exchange_specific.json"
+        )
+        mark_first_ohlcv_cache_current(tmp_cache_dir)
+        with open(cache_path, "w", encoding="utf-8") as f:
+            json.dump(
+                {f"{qualified_prefix}::{native_id}": {cache_exchange: authoritative_ts}},
+                f,
+            )
+        write_first_ohlcv_cache_provenance(
+            tmp_cache_dir,
+            f"{qualified_prefix}::{native_id}",
+            cache_exchange,
+            symbol,
+        )
+
+        assert cm._lookup_cached_authoritative_start_ts(symbol) == authoritative_ts

--- a/tests/test_live_coin_lists.py
+++ b/tests/test_live_coin_lists.py
@@ -1,9 +1,75 @@
 import logging
 
 import pytest
+import passivbot as passivbot_module
 
 from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline, ReasonCodes
 from passivbot import Passivbot
+from utils import AmbiguousMarketIdentifier, UnknownMarketIdentifier
+
+
+@pytest.mark.asyncio
+async def test_update_first_timestamps_scopes_discovery_to_live_exchange(monkeypatch):
+    captured = {}
+
+    async def fake_get_first_timestamps(symbols, exchange=None, exchanges=None):
+        captured["symbols"] = list(symbols)
+        captured["exchange"] = exchange
+        captured["exchanges"] = exchanges
+        return {symbol: 1710115200000 for symbol in symbols}
+
+    monkeypatch.setattr(
+        passivbot_module,
+        "get_first_timestamps_unified",
+        fake_get_first_timestamps,
+    )
+    symbol = "EDGE/USDT:USDT"
+    bot = Passivbot.__new__(Passivbot)
+    bot.exchange = "kucoin"
+    bot.approved_coins_minus_ignored_coins = {"long": {symbol}, "short": set()}
+    bot.markets_dict = {symbol: {}}
+    bot.coin_to_symbol = lambda value, verbose=False: value
+
+    await bot.update_first_timestamps()
+
+    assert captured == {
+        "symbols": [symbol],
+        "exchange": "kucoin",
+        "exchanges": None,
+    }
+    assert bot.first_timestamps[symbol] == 1710115200000
+
+
+@pytest.mark.asyncio
+async def test_update_first_timestamps_uses_fake_harness_ohlcv(monkeypatch):
+    async def unexpected_discovery(*_args, **_kwargs):
+        pytest.fail("fake inception must not route through CCXT discovery")
+
+    class FakeClient:
+        def __init__(self):
+            self.calls = []
+
+        async def fetch_ohlcv(self, symbol, timeframe="1m", since=None):
+            self.calls.append((symbol, timeframe, since))
+            return [[1700000000000, 1.0, 1.0, 1.0, 1.0, 1.0]]
+
+    monkeypatch.setattr(
+        passivbot_module,
+        "get_first_timestamps_unified",
+        unexpected_discovery,
+    )
+    symbol = "FAKE/USDT:USDT"
+    bot = Passivbot.__new__(Passivbot)
+    bot.exchange = "fake"
+    bot.cca = FakeClient()
+    bot.approved_coins_minus_ignored_coins = {"long": {symbol}, "short": set()}
+    bot.markets_dict = {symbol: {}}
+    bot.coin_to_symbol = lambda value, verbose=False: value
+
+    await bot.update_first_timestamps()
+
+    assert bot.cca.calls == [(symbol, "1m", 1)]
+    assert bot.first_timestamps[symbol] == 1700000000000
 
 
 def _make_mode_override_bot(auto_gs=True):
@@ -479,6 +545,159 @@ def test_refresh_approved_ignored_coin_lists_supports_migrated_global_all():
 
     assert bot.approved_coins["long"] == {"AAA/USDT:USDT", "BBB/USDT:USDT"}
     assert bot.approved_coins["short"] == {"AAA/USDT:USDT", "BBB/USDT:USDT"}
+
+
+@pytest.mark.parametrize(
+    "error_cls", [AmbiguousMarketIdentifier, UnknownMarketIdentifier]
+)
+def test_refresh_market_resolution_error_skips_affected_identifier(
+    error_cls, caplog
+):
+    bot = _make_eligibility_event_bot()
+    bot.approved_coins_minus_ignored_coins = {
+        "long": {"STALE/USDT:USDT"},
+        "short": {"STALE/USDT:USDT"},
+    }
+
+    def fail_closed(_coin, verbose=True):
+        raise error_cls("unresolvable test market")
+
+    bot.coin_to_symbol = fail_closed
+
+    with caplog.at_level(logging.ERROR):
+        bot.refresh_approved_ignored_coins_lists()
+
+    assert bot.approved_coins == {"long": set(), "short": set()}
+    assert bot.approved_coins_minus_ignored_coins == {
+        "long": set(),
+        "short": set(),
+    }
+    assert any(
+        "action=skip_identifier" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_refresh_market_resolution_error_retains_other_valid_markets(caplog):
+    bot = _make_eligibility_event_bot()
+    bot.config["_coins_sources"]["approved_coins"] = {
+        "long": ["BTC", "OLDUSDT"],
+        "short": ["BTC", "OLDUSDT"],
+    }
+    bot.config["_coins_sources"]["ignored_coins"] = {"long": [], "short": []}
+    bot.eligible_symbols.add("BTC/USDT:USDT")
+
+    def resolve(coin, verbose=True):
+        if coin == "BTC":
+            return "BTC/USDT:USDT"
+        raise UnknownMarketIdentifier("unresolvable test market")
+
+    bot.coin_to_symbol = resolve
+
+    with caplog.at_level(logging.ERROR):
+        bot.refresh_approved_ignored_coins_lists()
+
+    assert bot.approved_coins == {
+        "long": {"BTC/USDT:USDT"},
+        "short": {"BTC/USDT:USDT"},
+    }
+    assert bot.approved_coins_minus_ignored_coins == bot.approved_coins
+    assert any(
+        "action=skip_identifier" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_refresh_ignored_resolution_error_retains_prior_restriction(caplog):
+    bot = _make_eligibility_event_bot()
+    bot.config["_coins_sources"]["approved_coins"] = {
+        "long": ["BTC", "ETH"],
+        "short": ["BTC", "ETH"],
+    }
+    bot.config["_coins_sources"]["ignored_coins"] = {
+        "long": ["OLDUSDT"],
+        "short": ["OLDUSDT"],
+    }
+    bot.eligible_symbols.update({"BTC/USDT:USDT", "ETH/USDT:USDT"})
+    bot.ignored_coins = {
+        "long": {"BTC/USDT:USDT"},
+        "short": {"ETH/USDT:USDT"},
+    }
+    bot._coin_list_identifier_symbols = {
+        "ignored_coins": {
+            "long": {"OLDUSDT": "BTC/USDT:USDT"},
+            "short": {"OLDUSDT": "ETH/USDT:USDT"},
+        }
+    }
+
+    def resolve(coin, verbose=True):
+        if coin in {"BTC", "ETH"}:
+            return f"{coin}/USDT:USDT"
+        raise AmbiguousMarketIdentifier("ambiguous ignored test market")
+
+    bot.coin_to_symbol = resolve
+
+    with caplog.at_level(logging.ERROR):
+        bot.refresh_approved_ignored_coins_lists()
+
+    assert bot.ignored_coins == {
+        "long": {"BTC/USDT:USDT"},
+        "short": {"ETH/USDT:USDT"},
+    }
+    assert bot.approved_coins_minus_ignored_coins == {
+        "long": {"ETH/USDT:USDT"},
+        "short": {"BTC/USDT:USDT"},
+    }
+    assert any(
+        "list_kind=ignored_coins" in record.getMessage()
+        and "action=skip_identifier" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_refresh_ignored_resolution_error_does_not_restore_unrelated_removals(caplog):
+    bot = _make_eligibility_event_bot()
+    bot.config["_coins_sources"]["approved_coins"] = {
+        "long": ["BTC", "DOGE", "ETH"],
+        "short": ["BTC", "DOGE", "ETH"],
+    }
+    bot.config["_coins_sources"]["ignored_coins"] = {
+        "long": ["ETH", "DOGE"],
+        "short": ["ETH", "DOGE"],
+    }
+    bot.eligible_symbols.update(
+        {"BTC/USDT:USDT", "DOGE/USDT:USDT", "ETH/USDT:USDT"}
+    )
+    bot.ignored_coins = {
+        "long": {"BTC/USDT:USDT", "DOGE/USDT:USDT"},
+        "short": {"BTC/USDT:USDT", "DOGE/USDT:USDT"},
+    }
+    bot._coin_list_identifier_symbols = {
+        "ignored_coins": {
+            "long": {
+                "BTC": "BTC/USDT:USDT",
+                "DOGE": "DOGE/USDT:USDT",
+            },
+            "short": {
+                "BTC": "BTC/USDT:USDT",
+                "DOGE": "DOGE/USDT:USDT",
+            },
+        }
+    }
+
+    def resolve(coin, verbose=True):
+        if coin == "DOGE":
+            raise AmbiguousMarketIdentifier("ambiguous ignored test market")
+        return f"{coin}/USDT:USDT"
+
+    bot.coin_to_symbol = resolve
+
+    with caplog.at_level(logging.ERROR):
+        bot.refresh_approved_ignored_coins_lists()
+
+    expected = {"DOGE/USDT:USDT", "ETH/USDT:USDT"}
+    assert bot.ignored_coins == {"long": expected, "short": expected}
+    assert "BTC/USDT:USDT" not in bot.ignored_coins["long"]
 
 
 def _make_eligibility_event_bot():

--- a/tests/test_live_coins_reload.py
+++ b/tests/test_live_coins_reload.py
@@ -61,6 +61,467 @@ async def test_external_ignored_coins_reload(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_unqualified_native_id_collision_across_exchanges_requires_scope(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    markets_by_exchange = {
+        "bitget": {
+            "ABC/USDT:USDT": {
+                "id": "12345",
+                "swap": True,
+                "linear": True,
+                "active": True,
+                "base": "ABC",
+            }
+        },
+        "bybit": {
+            "OTHER/USDT:USDT": {
+                "id": "12345",
+                "swap": True,
+                "linear": True,
+                "active": True,
+                "base": "OTHER",
+            }
+        },
+    }
+
+    async def fake_load_markets(exchange, verbose=False, quote=None):
+        markets = markets_by_exchange[exchange]
+        assert utils.create_coin_symbol_map_cache(
+            exchange, markets, quote=quote, verbose=False
+        )
+        return markets
+
+    monkeypatch.setattr(utils, "load_markets", fake_load_markets)
+    config = {
+        "live": {
+            "approved_coins": {"long": ["12345"], "short": ["12345"]},
+            "ignored_coins": {"long": [], "short": []},
+        }
+    }
+
+    with pytest.raises(
+        utils.AmbiguousMarketIdentifier,
+        match="different contracts across configured exchanges",
+    ):
+        await format_approved_ignored_coins(config, ["bitget", "bybit"])
+
+
+@pytest.mark.asyncio
+async def test_cross_exchange_native_id_collision_preserves_multiplier_identity(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    markets_by_exchange = {
+        "bitget": {
+            "ABC/USDT:USDT": {
+                "id": "SAME-ID",
+                "swap": True,
+                "linear": True,
+                "active": True,
+                "base": "ABC",
+            }
+        },
+        "bybit": {
+            "1000ABC/USDT:USDT": {
+                "id": "SAME-ID",
+                "swap": True,
+                "linear": True,
+                "active": True,
+                "base": "1000ABC",
+            }
+        },
+    }
+
+    async def fake_load_markets(exchange, verbose=False, quote=None):
+        markets = markets_by_exchange[exchange]
+        assert utils.create_coin_symbol_map_cache(
+            exchange, markets, quote=quote, verbose=False
+        )
+        return markets
+
+    monkeypatch.setattr(utils, "load_markets", fake_load_markets)
+
+    with pytest.raises(
+        utils.AmbiguousMarketIdentifier,
+        match="different contracts across configured exchanges",
+    ):
+        await utils.reject_cross_exchange_market_identifier_collisions(
+            ["SAME-ID"], ["bitget", "bybit"]
+        )
+
+
+@pytest.mark.asyncio
+async def test_cross_exchange_convenience_alias_preserves_multiplier_identity(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    markets_by_exchange = {
+        "bitget": {
+            "ABC/USDT:USDT": {
+                "id": "ABCUSDT",
+                "swap": True,
+                "linear": True,
+                "active": True,
+                "base": "ABC",
+            }
+        },
+        "bybit": {
+            "1000ABC/USDT:USDT": {
+                "id": "1000ABCUSDT",
+                "swap": True,
+                "linear": True,
+                "active": True,
+                "base": "1000ABC",
+            }
+        },
+    }
+
+    async def fake_load_markets(exchange, verbose=False, quote=None):
+        markets = markets_by_exchange[exchange]
+        assert utils.create_coin_symbol_map_cache(
+            exchange, markets, quote=quote, verbose=False
+        )
+        return markets
+
+    monkeypatch.setattr(utils, "load_markets", fake_load_markets)
+
+    with pytest.raises(
+        utils.AmbiguousMarketIdentifier,
+        match="different contracts across configured exchanges",
+    ):
+        await utils.reject_cross_exchange_market_identifier_collisions(
+            ["ABC"], ["bitget", "bybit"]
+        )
+
+
+@pytest.mark.asyncio
+async def test_cross_exchange_native_id_allows_quote_variants_of_same_underlying(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    markets_by_exchange = {
+        "bybit": {
+            "BTC/USDT:USDT": {
+                "id": "SAME-ID",
+                "swap": True,
+                "linear": True,
+                "active": True,
+                "base": "BTC",
+            }
+        },
+        "hyperliquid": {
+            "BTC/USDC:USDC": {
+                "id": "SAME-ID",
+                "swap": True,
+                "linear": True,
+                "active": True,
+                "base": "BTC",
+            }
+        },
+    }
+
+    async def fake_load_markets(exchange, verbose=False, quote=None):
+        markets = markets_by_exchange[exchange]
+        assert utils.create_coin_symbol_map_cache(
+            exchange, markets, quote=quote, verbose=False
+        )
+        return markets
+
+    monkeypatch.setattr(utils, "load_markets", fake_load_markets)
+
+    await utils.reject_cross_exchange_market_identifier_collisions(
+        ["SAME-ID"], ["bybit", "hyperliquid"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_approved_aliases_for_one_market_are_coalesced(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    markets = {
+        "BTC/USDT:USDT": {
+            "id": "BTCUSDT",
+            "swap": True,
+            "linear": True,
+            "active": True,
+            "base": "BTC",
+        }
+    }
+
+    assert utils.create_coin_symbol_map_cache("bitget", markets, verbose=False)
+    config = {
+        "live": {
+            "approved_coins": {
+                "long": ["BTC", "BTCUSDT"],
+                "short": ["BTCUSDT", "BTC"],
+            },
+            "ignored_coins": {"long": [], "short": []},
+        }
+    }
+
+    await format_approved_ignored_coins(config, ["bitget"])
+
+    assert config["live"]["approved_coins"] == {
+        "long": ["BTC"],
+        "short": ["BTC"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_backtest_approved_aliases_use_source_key_from_override_only_venue(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    markets_by_exchange = {
+        "bybit": {
+            "EDGE/USDT:USDT": {
+                "id": "EDGEUSDT",
+                "swap": True,
+                "linear": True,
+                "active": True,
+                "base": "EDGE",
+            }
+        },
+        "kucoin": {
+            "EDGE/USDT:USDT": {
+                "id": "EDGEUSDTM",
+                "swap": True,
+                "linear": True,
+                "active": True,
+                "base": "EDGE",
+            }
+        },
+    }
+
+    async def fake_load_markets(exchange, verbose=False, quote=None):
+        markets = markets_by_exchange[exchange]
+        assert utils.create_coin_symbol_map_cache(
+            exchange, markets, quote=quote, verbose=False
+        )
+        return markets
+
+    monkeypatch.setattr(utils, "load_markets", fake_load_markets)
+    config = {
+        "backtest": {"coin_sources": {"EDGEUSDTM": "kucoin"}},
+        "live": {
+            "approved_coins": {
+                "long": ["EDGE"],
+                "short": ["EDGEUSDTM"],
+            },
+            "ignored_coins": {"long": [], "short": []},
+        },
+    }
+
+    await format_approved_ignored_coins(
+        config, ["bybit"], prefer_backtest_coin_source_keys=True
+    )
+
+    assert config["live"]["approved_coins"] == {
+        "long": ["EDGEUSDTM"],
+        "short": ["EDGEUSDTM"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_live_approved_alias_ignores_backtest_coin_source(monkeypatch):
+    async def unexpected_load_markets(exchange, verbose=False, quote=None):
+        pytest.fail(f"live formatting must not load backtest-only source venue {exchange}")
+
+    monkeypatch.setattr(utils, "load_markets", unexpected_load_markets)
+    config = {
+        "backtest": {"coin_sources": {"EDGEUSDTM": "kucoin"}},
+        "live": {
+            "approved_coins": {"long": ["EDGE"], "short": ["EDGE"]},
+            "ignored_coins": {"long": [], "short": []},
+        },
+    }
+
+    await format_approved_ignored_coins(config, ["bybit"])
+
+    assert config["live"]["approved_coins"] == {
+        "long": ["EDGE"],
+        "short": ["EDGE"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_backtest_ignored_alias_resolves_on_source_only_venue(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    markets_by_exchange = {
+        "bybit": {},
+        "kucoin": {
+            "EDGE/USDT:USDT": {
+                "id": "EDGEUSDTM",
+                "swap": True,
+                "linear": True,
+                "active": True,
+                "base": "EDGE",
+            }
+        },
+    }
+
+    async def fake_load_markets(exchange, verbose=False, quote=None):
+        markets = markets_by_exchange[exchange]
+        assert utils.create_coin_symbol_map_cache(
+            exchange, markets, quote=quote, verbose=False
+        )
+        return markets
+
+    monkeypatch.setattr(utils, "load_markets", fake_load_markets)
+    config = {
+        "backtest": {"coin_sources": {"EDGEUSDTM": "kucoin"}},
+        "live": {
+            "approved_coins": {
+                "long": ["EDGEUSDTM"],
+                "short": ["EDGEUSDTM"],
+            },
+            "ignored_coins": {"long": ["EDGE"], "short": ["EDGE"]},
+        },
+    }
+
+    await format_approved_ignored_coins(
+        config, ["bybit"], prefer_backtest_coin_source_keys=True
+    )
+
+    assert config["live"]["approved_coins"] == {"long": [], "short": []}
+
+
+@pytest.mark.asyncio
+async def test_exact_ignored_identifier_removes_matching_approved_alias(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    markets = {
+        "BTC/USDT:USDT": {
+            "id": "BTCUSDT",
+            "swap": True,
+            "linear": True,
+            "active": True,
+            "base": "BTC",
+        }
+    }
+    utils.create_coin_symbol_map_cache("bitget", markets, verbose=False)
+
+    async def fake_load_markets(_exchange, verbose=False, quote=None):
+        return markets
+
+    monkeypatch.setattr(utils, "load_markets", fake_load_markets)
+    config = {
+        "live": {
+            "approved_coins": {"long": ["BTC"], "short": ["BTC"]},
+            "ignored_coins": {"long": ["BTCUSDT"], "short": []},
+        }
+    }
+
+    await format_approved_ignored_coins(config, ["bitget"])
+
+    assert config["live"]["approved_coins"] == {"long": [], "short": ["BTC"]}
+    assert config["live"]["ignored_coins"] == {"long": ["BTCUSDT"], "short": []}
+
+
+@pytest.mark.asyncio
+async def test_ignored_alias_removes_matching_exact_approval(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    markets = {
+        "BTC/USDT:USDT": {
+            "id": "BTCUSDT",
+            "swap": True,
+            "linear": True,
+            "active": True,
+            "base": "BTC",
+        }
+    }
+    utils.create_coin_symbol_map_cache("bitget", markets, verbose=False)
+
+    async def fake_load_markets(_exchange, verbose=False, quote=None):
+        return markets
+
+    monkeypatch.setattr(utils, "load_markets", fake_load_markets)
+    config = {
+        "live": {
+            "approved_coins": {"long": ["BTCUSDT"], "short": []},
+            "ignored_coins": {"long": ["BTC"], "short": []},
+        }
+    }
+
+    await format_approved_ignored_coins(config, ["bitget"])
+
+    assert config["live"]["approved_coins"]["long"] == []
+
+
+@pytest.mark.asyncio
+async def test_ignored_multiplier_alias_removes_matching_canonical_approval(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    markets = {
+        "1000SHIB/USDT:USDT": {
+            "id": "1000SHIBUSDT",
+            "swap": True,
+            "linear": True,
+            "active": True,
+            "base": "1000SHIB",
+        }
+    }
+    utils.create_coin_symbol_map_cache("bitget", markets, verbose=False)
+
+    async def fake_load_markets(_exchange, verbose=False, quote=None):
+        return markets
+
+    monkeypatch.setattr(utils, "load_markets", fake_load_markets)
+    config = {
+        "live": {
+            "approved_coins": {"long": ["SHIB"], "short": []},
+            "ignored_coins": {"long": ["1000SHIB"], "short": []},
+        }
+    }
+
+    await format_approved_ignored_coins(config, ["bitget"])
+
+    assert config["live"]["approved_coins"]["long"] == []
+
+
+@pytest.mark.asyncio
+async def test_exact_ignored_identifier_does_not_remove_distinct_multiplier_market(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    markets = {
+        "ABC/USDT:USDT": {
+            "id": "ABCUSDT",
+            "swap": True,
+            "linear": True,
+            "active": True,
+            "base": "ABC",
+        },
+        "1000ABC/USDT:USDT": {
+            "id": "1000ABCUSDT",
+            "swap": True,
+            "linear": True,
+            "active": True,
+            "base": "1000ABC",
+        },
+    }
+    utils.create_coin_symbol_map_cache("bitget", markets, verbose=False)
+
+    async def fake_load_markets(_exchange, verbose=False, quote=None):
+        return markets
+
+    monkeypatch.setattr(utils, "load_markets", fake_load_markets)
+    config = {
+        "live": {
+            "approved_coins": {"long": ["ABC/USDT:USDT"], "short": []},
+            "ignored_coins": {"long": ["1000ABCUSDT"], "short": []},
+        }
+    }
+
+    await format_approved_ignored_coins(config, ["bitget"])
+
+    assert config["live"]["approved_coins"]["long"] == ["ABC/USDT:USDT"]
+
+
+@pytest.mark.asyncio
 async def test_format_approved_ignored_coins_records_transform():
     config = {
         "live": {
@@ -162,6 +623,302 @@ async def test_format_approved_ignored_coins_supports_migrated_all(monkeypatch):
     assert config["live"]["approved_coins"] == {
         "long": ["BTC", "ETH"],
         "short": ["BTC", "ETH"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_format_approved_all_uses_scoped_ids_for_colliding_markets(monkeypatch):
+    markets = {
+        "ABC/USDT:USDT": {
+            "swap": True,
+            "linear": True,
+            "base": "ABC",
+            "id": "ABCUSDT",
+        },
+        "1000ABC/USDT:USDT": {
+            "swap": True,
+            "linear": True,
+            "base": "1000ABC",
+            "id": "1000ABCUSDT",
+        },
+        "BTC/USDT:USDT": {
+            "swap": True,
+            "linear": True,
+            "base": "BTC",
+            "id": "BTCUSDT",
+        },
+    }
+
+    async def fake_load_markets(exchange, verbose=False, quote=None):
+        return markets
+
+    def fake_filter_markets(loaded_markets, exchange, quote=None):
+        return loaded_markets, None
+
+    monkeypatch.setattr(utils, "load_markets", fake_load_markets)
+    monkeypatch.setattr(utils, "filter_markets", fake_filter_markets)
+
+    config = {
+        "live": {
+            "approved_coins": "all",
+            "ignored_coins": {"long": [], "short": []},
+        }
+    }
+
+    await format_approved_ignored_coins(config, ["bitget"])
+
+    expected = ["BTC", "bitget::1000ABCUSDT", "bitget::ABCUSDT"]
+    assert config["live"]["approved_coins"] == {
+        "long": expected,
+        "short": expected,
+    }
+
+
+@pytest.mark.asyncio
+async def test_format_coin_lists_preserves_distinct_exact_identifiers_and_coalesces_aliases(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    markets = {
+        "ABC/USDT:USDT": {
+            "id": "ABCUSDT",
+            "swap": True,
+            "linear": True,
+            "active": True,
+            "base": "ABC",
+        },
+        "1000ABC/USDT:USDT": {
+            "id": "1000ABCUSDT",
+            "swap": True,
+            "linear": True,
+            "active": True,
+            "base": "1000ABC",
+        },
+    }
+
+    async def fake_load_markets(exchange, verbose=False, quote=None):
+        assert exchange == "bitget"
+        assert utils.create_coin_symbol_map_cache(
+            exchange, markets, quote=quote, verbose=False
+        )
+        return markets
+
+    monkeypatch.setattr(utils, "load_markets", fake_load_markets)
+    identifiers = ["bitget::ABCUSDT", "1000ABC/USDT:USDT", "ABCUSDT"]
+    config = {
+        "live": {
+            "approved_coins": {"long": identifiers, "short": []},
+            "ignored_coins": {"long": [], "short": identifiers},
+        }
+    }
+
+    await format_approved_ignored_coins(config, ["bitget"])
+
+    assert config["live"]["approved_coins"]["long"] == identifiers[:2]
+    assert config["live"]["ignored_coins"]["short"] == identifiers
+
+
+@pytest.mark.asyncio
+async def test_format_approved_all_scopes_collision_on_every_exchange(monkeypatch):
+    markets_by_exchange = {
+        "bitget": {
+            "ABC/USDT:USDT": {
+                "swap": True,
+                "linear": True,
+                "base": "ABC",
+                "id": "ABCUSDT",
+            },
+            "1000ABC/USDT:USDT": {
+                "swap": True,
+                "linear": True,
+                "base": "1000ABC",
+                "id": "1000ABCUSDT",
+            },
+            "BTC/USDT:USDT": {
+                "swap": True,
+                "linear": True,
+                "base": "BTC",
+                "id": "BTCUSDT",
+            },
+        },
+        "bybit": {
+            "ABC/USDT:USDT": {
+                "swap": True,
+                "linear": True,
+                "base": "ABC",
+                "id": "ABCUSDT",
+            },
+            "BTC/USDT:USDT": {
+                "swap": True,
+                "linear": True,
+                "base": "BTC",
+                "id": "BTCUSDT",
+            },
+        },
+    }
+
+    async def fake_load_markets(exchange, verbose=False, quote=None):
+        return markets_by_exchange[exchange]
+
+    monkeypatch.setattr(utils, "load_markets", fake_load_markets)
+    monkeypatch.setattr(
+        utils, "filter_markets", lambda markets, exchange, quote=None: (markets, None)
+    )
+    config = {
+        "live": {
+            "approved_coins": "all",
+            "ignored_coins": {"long": [], "short": []},
+        }
+    }
+
+    await format_approved_ignored_coins(config, ["bitget", "bybit"])
+
+    expected = [
+        "BTC",
+        "bitget::1000ABCUSDT",
+        "bitget::ABCUSDT",
+        "bybit::ABCUSDT",
+    ]
+    assert config["live"]["approved_coins"] == {
+        "long": expected,
+        "short": expected,
+    }
+
+
+@pytest.mark.asyncio
+async def test_format_approved_all_scopes_cross_exchange_scaled_contracts(monkeypatch):
+    markets_by_exchange = {
+        "bybit": {
+            "ABC/USDT:USDT": {
+                "swap": True,
+                "linear": True,
+                "base": "ABC",
+                "id": "ABCUSDT",
+            }
+        },
+        "bitget": {
+            "1000ABC/USDT:USDT": {
+                "swap": True,
+                "linear": True,
+                "base": "1000ABC",
+                "id": "1000ABCUSDT",
+            }
+        },
+    }
+
+    async def fake_load_markets(exchange, verbose=False, quote=None):
+        return markets_by_exchange[exchange]
+
+    monkeypatch.setattr(utils, "load_markets", fake_load_markets)
+    monkeypatch.setattr(
+        utils, "filter_markets", lambda markets, exchange, quote=None: (markets, None)
+    )
+    config = {
+        "live": {
+            "approved_coins": "all",
+            "ignored_coins": {"long": [], "short": []},
+        }
+    }
+
+    await format_approved_ignored_coins(config, ["bybit", "bitget"])
+
+    expected = ["bitget::1000ABCUSDT", "bybit::ABCUSDT"]
+    assert config["live"]["approved_coins"] == {
+        "long": expected,
+        "short": expected,
+    }
+
+
+@pytest.mark.asyncio
+async def test_format_approved_all_unifies_cross_exchange_quote_variants(monkeypatch):
+    markets_by_exchange = {
+        "bybit": {
+            "BTC/USDT:USDT": {
+                "swap": True,
+                "linear": True,
+                "base": "BTC",
+                "id": "BTCUSDT",
+            }
+        },
+        "hyperliquid": {
+            "BTC/USDC:USDC": {
+                "swap": True,
+                "linear": True,
+                "base": "BTC",
+                "id": "BTC",
+            }
+        },
+    }
+
+    async def fake_load_markets(exchange, verbose=False, quote=None):
+        return markets_by_exchange[exchange]
+
+    monkeypatch.setattr(utils, "load_markets", fake_load_markets)
+    monkeypatch.setattr(
+        utils, "filter_markets", lambda markets, exchange, quote=None: (markets, None)
+    )
+    config = {
+        "live": {
+            "approved_coins": "all",
+            "ignored_coins": {"long": [], "short": []},
+        }
+    }
+
+    await format_approved_ignored_coins(config, ["bybit", "hyperliquid"])
+
+    assert config["live"]["approved_coins"] == {
+        "long": ["BTC"],
+        "short": ["BTC"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_format_approved_all_unifies_equivalent_k_and_1000_contracts(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    markets_by_exchange = {
+        "bybit": {
+            "1000SHIB/USDT:USDT": {
+                "swap": True,
+                "linear": True,
+                "base": "1000SHIB",
+                "id": "1000SHIBUSDT",
+            }
+        },
+        "hyperliquid": {
+            "kSHIB/USDC:USDC": {
+                "swap": True,
+                "linear": True,
+                "base": "kSHIB",
+                "id": "kSHIB",
+            }
+        },
+    }
+
+    async def fake_load_markets(exchange, verbose=False, quote=None):
+        markets = markets_by_exchange[exchange]
+        assert utils.create_coin_symbol_map_cache(
+            exchange, markets, quote=quote, verbose=False
+        )
+        return markets
+
+    monkeypatch.setattr(utils, "load_markets", fake_load_markets)
+    monkeypatch.setattr(
+        utils, "filter_markets", lambda markets, exchange, quote=None: (markets, None)
+    )
+    config = {
+        "live": {
+            "approved_coins": "all",
+            "ignored_coins": {"long": [], "short": []},
+        }
+    }
+
+    await format_approved_ignored_coins(config, ["bybit", "hyperliquid"])
+
+    assert config["live"]["approved_coins"] == {
+        "long": ["SHIB"],
+        "short": ["SHIB"],
     }
 
 

--- a/tests/test_market_settings_sources_separation.py
+++ b/tests/test_market_settings_sources_separation.py
@@ -138,6 +138,37 @@ def test_coins_by_exchange_grouping():
     assert "hyperliquid" not in coins_by_exchange
 
 
+def test_scoped_market_settings_miss_falls_back_to_ohlcv_source():
+    import hlcv_preparation as hp
+
+    class StubOM:
+        def __init__(self, exchange, available):
+            self.exchange = exchange
+            self.available = available
+
+        def has_coin(self, _coin):
+            return self.available
+
+        def get_market_specific_settings(self, _coin):
+            if not self.available:
+                raise AssertionError("unavailable settings source must not be used")
+            return {"exchange": self.exchange, "min_cost": 1.0}
+
+    result = hp._resolve_combined_market_settings(
+        coin="bitget::ABCUSDT",
+        best_exchange="bitget",
+        market_settings_sources={"bitget::ABCUSDT": "bybit"},
+        om_dict={
+            "bitget": StubOM("bitget", True),
+            "bybit": StubOM("bybit", False),
+        },
+        per_coin_warmups={},
+        default_warm=0,
+    )
+
+    assert result["exchange"] == "bitget"
+
+
 @pytest.mark.asyncio
 async def test_prepare_hlcvs_combined_impl_uses_ohlcv_source_for_normalization_provenance(
     monkeypatch, tmp_path
@@ -167,16 +198,22 @@ async def test_prepare_hlcvs_combined_impl_uses_ohlcv_source_for_normalization_p
         def get_symbol(self, coin):
             return coin
 
+        def has_coin(self, _coin):
+            return True
+
         def get_market_specific_settings(self, _coin):
             return {"exchange": self.exchange_id, "min_cost": 1.0}
 
     om_dict = {"binanceusdm": DummyOM("binanceusdm"), "bybit": DummyOM("bybit")}
 
-    async def fake_get_first_timestamps_unified(_coins):
-        return {"BTC": start_ts}
+    exact_coin = "BTC/USDT:USDT"
+
+    async def fake_get_first_timestamps_unified(_coins, **_kwargs):
+        assert _kwargs == {"exchanges": ["binanceusdm", "bybit"]}
+        return {exact_coin: start_ts}
 
     async def fake_fetch_data_for_coin_and_exchange(coin, ex, *_args, **_kwargs):
-        if coin != "BTC":
+        if coin != exact_coin:
             return None
         if ex == "binanceusdm":
             return ex, candle_df.copy(), 3, 0, 1_000.0
@@ -219,19 +256,21 @@ async def test_prepare_hlcvs_combined_impl_uses_ohlcv_source_for_normalization_p
         _requested_start_ts=start_ts,
         end_ts=start_ts + 180_000,
         forced_sources={},
-        market_settings_sources={"BTC": "bybit"},
+        market_settings_sources={exact_coin: "bybit"},
         force_refetch_gaps=False,
         catalog=catalog,
         store=store,
         legacy_root=None,
     )
 
-    assert mss["BTC"]["exchange"] == "bybit"
-    assert mss["BTC"]["ohlcv_source"] == "binance"
+    assert mss[exact_coin]["exchange"] == "bybit"
+    assert mss[exact_coin]["ohlcv_source"] == "binance"
     normalization = mss["__preparation_meta__"]["volume_normalization"]
     assert normalization["exchange_counts"] == {"binance": 1}
     assert normalization["reference_exchange"] == "binance"
-    assert aligned_values_by_coin["BTC"][:, 3].sum() == pytest.approx(candle_df["volume"].sum())
+    assert aligned_values_by_coin[exact_coin][:, 3].sum() == pytest.approx(
+        candle_df["volume"].sum()
+    )
 
 
 @pytest.mark.asyncio
@@ -253,7 +292,7 @@ async def test_prepare_hlcvs_combined_impl_honors_disabled_volume_normalization(
         def get_market_specific_settings(self, _coin):
             return {"exchange": "unused", "min_cost": 1.0}
 
-    async def fake_get_first_timestamps_unified(_coins):
+    async def fake_get_first_timestamps_unified(_coins, **_kwargs):
         return {"BTC": start_ts, "ETH": start_ts}
 
     async def fake_fetch(coin, exchange, *_args, **_kwargs):
@@ -354,7 +393,7 @@ async def test_prepare_hlcvs_combined_impl_normalizes_forced_override_only_excha
         def get_market_specific_settings(self, _coin):
             return {"exchange": self.exchange, "min_cost": 1.0}
 
-    async def fake_get_first_timestamps_unified(_coins):
+    async def fake_get_first_timestamps_unified(_coins, **_kwargs):
         return {coin: start_ts for coin in coins}
 
     async def fake_fetch(coin, exchange, *_args, **_kwargs):

--- a/tests/test_ohlcv_v2_prepare.py
+++ b/tests/test_ohlcv_v2_prepare.py
@@ -2858,7 +2858,8 @@ async def test_prepare_hlcvs_mss_stock_perp_source_dir_loads_real_values(
     )
     monkeypatch.setattr(hp, "_has_tradfi_provider_config", lambda: True)
 
-    async def fake_first_timestamps(_coins):
+    async def fake_first_timestamps(_coins, exchange=None):
+        assert exchange == "hyperliquid"
         return {}
 
     monkeypatch.setattr(hp, "get_first_timestamps_unified", fake_first_timestamps)
@@ -2951,7 +2952,8 @@ async def test_prepare_hlcvs_internal_masks_invalid_direct_fetch_rows(monkeypatc
     start_ts = month_start_ts(2026, 4)
     end_ts = start_ts + 2 * 60_000
 
-    async def fake_first_timestamps(coins):
+    async def fake_first_timestamps(coins, exchange=None):
+        assert exchange == "binance"
         return {"ETH": start_ts}
 
     monkeypatch.setattr(hp, "get_first_timestamps_unified", fake_first_timestamps)

--- a/tests/test_ohlcvs_downloader.py
+++ b/tests/test_ohlcvs_downloader.py
@@ -140,7 +140,7 @@ def test_attempt_gap_fix_ohlcvs_raises_on_huge_gap():
 async def test_download_uses_backtest_materialization_path(monkeypatch, tmp_path):
     calls = []
 
-    async def fake_format_approved_ignored_coins(config, exchanges):
+    async def fake_format_approved_ignored_coins(config, exchanges, **_kwargs):
         calls.append(("format", tuple(exchanges)))
 
     async def fake_prepare_hlcvs_mss(config, exchange, *, force_refetch_gaps=False):

--- a/tests/test_procedures_first_timestamps.py
+++ b/tests/test_procedures_first_timestamps.py
@@ -11,8 +11,18 @@ class _DummyCC:
     def __init__(self, exchange_name: str, first_ts: int):
         self.exchange_name = exchange_name
         self.first_ts = first_ts
+        self.fetch_calls = []
 
-    async def fetch_ohlcv(self, symbol, since=None, timeframe=None):
+    async def fetch_ohlcv(self, symbol, since=None, timeframe=None, limit=None, **kwargs):
+        self.fetch_calls.append(
+            {
+                "symbol": symbol,
+                "since": since,
+                "timeframe": timeframe,
+                "limit": limit,
+                **kwargs,
+            }
+        )
         if self.exchange_name == "binanceusdm" and symbol == "HYPE/USDT:USDT":
             return [[self.first_ts, 1.0, 1.0, 1.0, 1.0, 1.0]]
         return []
@@ -21,10 +31,140 @@ class _DummyCC:
         return None
 
 
+def _mark_first_ohlcv_cache_current(cache_dir):
+    (cache_dir / "first_ohlcv_timestamps_unified.version").write_text(
+        str(procedures.FIRST_OHLCV_TIMESTAMPS_CACHE_VERSION), encoding="utf-8"
+    )
+
+
+def _write_first_ohlcv_provenance(cache_dir, data):
+    (cache_dir / "first_ohlcv_timestamps_unified_exchange_specific_symbols.json").write_text(
+        json.dumps(data), encoding="utf-8"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_first_timestamps_preserves_exact_market_identifiers(monkeypatch, tmp_path):
+    cache_dir = tmp_path / "caches"
+    cache_dir.mkdir()
+    _mark_first_ohlcv_cache_current(cache_dir)
+    exact_identifiers = {
+        "1000ABC": 1710115200000,
+        "ABC/USDT:USDT": 1710115260000,
+        "bitget::ABCUSDT": 1710115320000,
+    }
+    (cache_dir / "first_ohlcv_timestamps_unified.json").write_text(
+        json.dumps(exact_identifiers), encoding="utf-8"
+    )
+    (cache_dir / "first_ohlcv_timestamps_unified_exchange_specific.json").write_text(
+        json.dumps({key: {"bitget": value} for key, value in exact_identifiers.items()}),
+        encoding="utf-8",
+    )
+    _write_first_ohlcv_provenance(
+        cache_dir,
+        {key: {"bitget": key} for key in exact_identifiers},
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(procedures, "make_get_filepath", lambda p: str(tmp_path / p))
+    monkeypatch.setattr(
+        procedures,
+        "load_ccxt_instance",
+        lambda *_args, **_kwargs: pytest.fail("valid exact cache keys must not fetch markets"),
+    )
+    monkeypatch.setattr(procedures, "coin_to_symbol", lambda coin, _exchange: coin)
+
+    result = await procedures.get_first_timestamps_unified(list(exact_identifiers))
+
+    assert result == exact_identifiers
+
+
+@pytest.mark.asyncio
+async def test_get_first_timestamps_returns_only_requested_cache_keys(monkeypatch, tmp_path):
+    cache_dir = tmp_path / "caches"
+    cache_dir.mkdir()
+    _mark_first_ohlcv_cache_current(cache_dir)
+    (cache_dir / "first_ohlcv_timestamps_unified.json").write_text(
+        json.dumps(
+            {
+                "BTC": 1710115200000,
+                "bybit::ABCUSDT": 1710115260000,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (cache_dir / "first_ohlcv_timestamps_unified_exchange_specific.json").write_text(
+        json.dumps({"BTC": {"binanceusdm": 1710115200000}}), encoding="utf-8"
+    )
+    _write_first_ohlcv_provenance(
+        cache_dir, {"BTC": {"binanceusdm": "BTC/USDT:USDT"}}
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(procedures, "make_get_filepath", lambda p: str(tmp_path / p))
+    monkeypatch.setattr(
+        procedures,
+        "load_ccxt_instance",
+        lambda *_args, **_kwargs: pytest.fail("valid requested cache key must not fetch markets"),
+    )
+    monkeypatch.setattr(
+        procedures, "coin_to_symbol", lambda _coin, _exchange: "BTC/USDT:USDT"
+    )
+
+    result = await procedures.get_first_timestamps_unified(["BTC"])
+
+    assert result == {"BTC": 1710115200000}
+
+
+@pytest.mark.asyncio
+async def test_exchange_timestamp_cache_rebind_refetches_current_market(monkeypatch, tmp_path):
+    cache_dir = tmp_path / "caches"
+    cache_dir.mkdir()
+    _mark_first_ohlcv_cache_current(cache_dir)
+    old_ts = 1609459200000
+    new_ts = 1710115200000
+    (cache_dir / "first_ohlcv_timestamps_unified.json").write_text(
+        json.dumps({"ABC": old_ts}), encoding="utf-8"
+    )
+    (cache_dir / "first_ohlcv_timestamps_unified_exchange_specific.json").write_text(
+        json.dumps({"ABC": {"bybit": old_ts}}), encoding="utf-8"
+    )
+    _write_first_ohlcv_provenance(
+        cache_dir, {"ABC": {"bybit": "ABC/USDT:USDT"}}
+    )
+
+    class ReboundClient(_DummyCC):
+        async def fetch_ohlcv(self, symbol, since=None, timeframe=None, limit=None, **kwargs):
+            self.fetch_calls.append({"symbol": symbol, "since": since, "timeframe": timeframe})
+            return [[new_ts, 1.0, 1.0, 1.0, 1.0, 1.0]]
+
+    client = ReboundClient("bybit", new_ts)
+
+    async def fake_load_markets(_exchange):
+        return {}
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(procedures, "make_get_filepath", lambda p: str(tmp_path / p))
+    monkeypatch.setattr(procedures, "coin_to_symbol", lambda *_args: "1000ABC/USDT:USDT")
+    monkeypatch.setattr(procedures, "load_ccxt_instance", lambda _exchange: client)
+    monkeypatch.setattr(procedures, "load_markets", fake_load_markets)
+
+    result = await procedures.get_first_timestamps_unified(["ABC"], exchange="bybit")
+
+    assert result == {"ABC": new_ts}
+    assert client.fetch_calls
+    provenance = json.loads(
+        (cache_dir / "first_ohlcv_timestamps_unified_exchange_specific_symbols.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert provenance["ABC"]["bybit"] == "1000ABC/USDT:USDT"
+
+
 @pytest.mark.asyncio
 async def test_get_first_timestamps_unified_refreshes_zero_cached_entries(monkeypatch, tmp_path):
     cache_dir = tmp_path / "caches"
     cache_dir.mkdir()
+    _mark_first_ohlcv_cache_current(cache_dir)
     unified_cache = cache_dir / "first_ohlcv_timestamps_unified.json"
     exchange_cache = cache_dir / "first_ohlcv_timestamps_unified_exchange_specific.json"
     unified_cache.write_text(json.dumps({"HYPE": 0.0}), encoding="utf-8")
@@ -66,3 +206,314 @@ async def test_get_first_timestamps_unified_refreshes_zero_cached_entries(monkey
         json.loads(exchange_cache.read_text(encoding="utf-8"))["HYPE"]["binanceusdm"]
         == 1710115200000
     )
+
+
+@pytest.mark.asyncio
+async def test_get_first_timestamps_ignores_unversioned_legacy_cache(monkeypatch, tmp_path):
+    cache_dir = tmp_path / "caches"
+    cache_dir.mkdir()
+    unified_cache = cache_dir / "first_ohlcv_timestamps_unified.json"
+    exchange_cache = cache_dir / "first_ohlcv_timestamps_unified_exchange_specific.json"
+    unified_cache.write_text(json.dumps({"HYPE": 1609459200000}), encoding="utf-8")
+    exchange_cache.write_text(
+        json.dumps({"HYPE": {"binanceusdm": 1609459200000}}), encoding="utf-8"
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(procedures, "make_get_filepath", lambda p: str(tmp_path / p))
+    monkeypatch.setattr(procedures, "coin_to_symbol", lambda coin, ex: "HYPE/USDT:USDT")
+    monkeypatch.setattr(
+        procedures,
+        "load_ccxt_instance",
+        lambda ex_name: _DummyCC(ex_name, 1710115200000),
+    )
+
+    async def _fake_load_markets(_exchange_name):
+        return {}
+
+    monkeypatch.setattr(procedures, "load_markets", _fake_load_markets)
+
+    result = await procedures.get_first_timestamps_unified(["HYPE"])
+
+    assert result["HYPE"] == 1710115200000
+    assert (
+        cache_dir / "first_ohlcv_timestamps_unified.version"
+    ).read_text(encoding="utf-8") == str(
+        procedures.FIRST_OHLCV_TIMESTAMPS_CACHE_VERSION
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_first_timestamps_scoped_identifier_skips_other_exchanges(monkeypatch, tmp_path):
+    cache_dir = tmp_path / "caches"
+    cache_dir.mkdir()
+    _mark_first_ohlcv_cache_current(cache_dir)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(procedures, "make_get_filepath", lambda p: str(tmp_path / p))
+    monkeypatch.setattr(
+        procedures,
+        "load_ccxt_instance",
+        lambda ex_name: _DummyCC(ex_name, 1710115200000),
+    )
+
+    async def _fake_load_markets(_exchange_name):
+        return {}
+
+    monkeypatch.setattr(procedures, "load_markets", _fake_load_markets)
+    resolved_on = []
+
+    def _coin_to_symbol(coin, exchange):
+        resolved_on.append((coin, exchange))
+        return "ABC/USDT:USDT"
+
+    monkeypatch.setattr(procedures, "coin_to_symbol", _coin_to_symbol)
+
+    result = await procedures.get_first_timestamps_unified(["bybit::ABCUSDT"])
+
+    assert resolved_on == [("bybit::ABCUSDT", "bybit")]
+    assert result["bybit::ABCUSDT"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_exchange_specific_first_timestamps_skips_other_exchanges(monkeypatch, tmp_path):
+    cache_dir = tmp_path / "caches"
+    cache_dir.mkdir()
+    _mark_first_ohlcv_cache_current(cache_dir)
+    unified_cache = cache_dir / "first_ohlcv_timestamps_unified.json"
+    unified_cache.write_text(json.dumps({"ABC": 1710115200000}), encoding="utf-8")
+    exchange_cache = cache_dir / "first_ohlcv_timestamps_unified_exchange_specific.json"
+    exchange_cache.write_text(
+        json.dumps({"ABC": {"binanceusdm": 1710115200000, "bybit": 0.0}}),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(procedures, "make_get_filepath", lambda p: str(tmp_path / p))
+    loaded_exchanges = []
+
+    def _load_ccxt(exchange_name):
+        loaded_exchanges.append(exchange_name)
+        return _DummyCC(exchange_name, 1710115200000)
+
+    monkeypatch.setattr(procedures, "load_ccxt_instance", _load_ccxt)
+
+    async def _load_markets(_exchange):
+        return {}
+
+    monkeypatch.setattr(procedures, "load_markets", _load_markets)
+
+    def _coin_to_symbol(coin, exchange):
+        assert exchange == "bybit"
+        return "ABC/USDT:USDT"
+
+    monkeypatch.setattr(procedures, "coin_to_symbol", _coin_to_symbol)
+
+    result = await procedures.get_first_timestamps_unified(["ABC"], exchange="bybit")
+
+    assert loaded_exchanges == ["bybit"]
+    assert result == {"ABC": 0.0}
+    assert json.loads(unified_cache.read_text(encoding="utf-8"))["ABC"] == 1710115200000
+    assert json.loads(exchange_cache.read_text(encoding="utf-8"))["ABC"] == {
+        "binanceusdm": 1710115200000,
+        "bybit": 0.0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_exchange_specific_first_timestamps_supports_non_default_exchange(
+    monkeypatch, tmp_path
+):
+    cache_dir = tmp_path / "caches"
+    cache_dir.mkdir()
+    _mark_first_ohlcv_cache_current(cache_dir)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(procedures, "make_get_filepath", lambda p: str(tmp_path / p))
+    loaded_exchanges = []
+    loaded_clients = []
+
+    def _load_ccxt(exchange_name):
+        loaded_exchanges.append(exchange_name)
+        client = _DummyCC(exchange_name, 1710115200000)
+        loaded_clients.append(client)
+        return client
+
+    monkeypatch.setattr(procedures, "load_ccxt_instance", _load_ccxt)
+
+    async def _load_markets(_exchange):
+        return {}
+
+    monkeypatch.setattr(procedures, "load_markets", _load_markets)
+
+    def _coin_to_symbol(_coin, exchange):
+        assert exchange == "kucoin"
+        return "ABC/USDT:USDT"
+
+    monkeypatch.setattr(procedures, "coin_to_symbol", _coin_to_symbol)
+
+    result = await procedures.get_first_timestamps_unified(
+        ["ABC"], exchange="kucoinfutures"
+    )
+
+    assert loaded_exchanges == ["kucoinfutures"]
+    assert result == {"ABC": 0.0}
+    assert loaded_clients[0].fetch_calls == [
+        {
+            "symbol": "ABC/USDT:USDT",
+            "since": 1,
+            "timeframe": "1d",
+            "limit": 1,
+        }
+    ]
+    exchange_cache = cache_dir / "first_ohlcv_timestamps_unified_exchange_specific.json"
+    assert json.loads(exchange_cache.read_text(encoding="utf-8"))["ABC"] == {
+        "kucoin": 0.0
+    }
+
+
+@pytest.mark.asyncio
+async def test_qualified_dynamic_exchange_is_discovered_without_exchange_argument(
+    monkeypatch, tmp_path
+):
+    cache_dir = tmp_path / "caches"
+    cache_dir.mkdir()
+    _mark_first_ohlcv_cache_current(cache_dir)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(procedures, "make_get_filepath", lambda p: str(tmp_path / p))
+    loaded_clients = {}
+
+    def _load_ccxt(exchange_name):
+        client = _DummyCC(exchange_name, 1710115200000)
+        loaded_clients[exchange_name] = client
+        return client
+
+    monkeypatch.setattr(procedures, "load_ccxt_instance", _load_ccxt)
+
+    async def _load_markets(_exchange):
+        return {}
+
+    monkeypatch.setattr(procedures, "load_markets", _load_markets)
+    resolved_on = []
+
+    def _coin_to_symbol(coin, exchange):
+        resolved_on.append((coin, exchange))
+        return "ABC/USDT:USDT"
+
+    monkeypatch.setattr(procedures, "coin_to_symbol", _coin_to_symbol)
+
+    result = await procedures.get_first_timestamps_unified(["kucoin::ABCUSDT"])
+
+    assert resolved_on == [("kucoin::ABCUSDT", "kucoin")]
+    assert result == {"kucoin::ABCUSDT": 0.0}
+    assert loaded_clients["kucoinfutures"].fetch_calls == [
+        {
+            "symbol": "ABC/USDT:USDT",
+            "since": 1,
+            "timeframe": "1d",
+            "limit": 1,
+        }
+    ]
+    exchange_cache = cache_dir / "first_ohlcv_timestamps_unified_exchange_specific.json"
+    assert json.loads(exchange_cache.read_text(encoding="utf-8"))["kucoin::ABCUSDT"] == {
+        "kucoin": 0.0
+    }
+
+
+@pytest.mark.asyncio
+async def test_configured_dynamic_exchange_scopes_unqualified_discovery(monkeypatch, tmp_path):
+    cache_dir = tmp_path / "caches"
+    cache_dir.mkdir()
+    _mark_first_ohlcv_cache_current(cache_dir)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(procedures, "make_get_filepath", lambda p: str(tmp_path / p))
+    loaded_clients = {}
+
+    def _load_ccxt(exchange_name):
+        client = _DummyCC(exchange_name, 1710115200000)
+        loaded_clients[exchange_name] = client
+        return client
+
+    monkeypatch.setattr(procedures, "load_ccxt_instance", _load_ccxt)
+
+    async def _load_markets(_exchange):
+        return {}
+
+    monkeypatch.setattr(procedures, "load_markets", _load_markets)
+
+    resolved_on = []
+
+    def _coin_to_symbol(coin, exchange):
+        resolved_on.append((coin, exchange))
+        return "EDGE/USDT:USDT"
+
+    monkeypatch.setattr(procedures, "coin_to_symbol", _coin_to_symbol)
+
+    result = await procedures.get_first_timestamps_unified(
+        ["EDGE"], exchanges=["kucoin"]
+    )
+
+    assert result == {"EDGE": 0.0}
+    assert set(loaded_clients) == {"kucoinfutures"}
+    assert resolved_on == [("EDGE", "kucoin")]
+    assert loaded_clients["kucoinfutures"].fetch_calls == [
+        {
+            "symbol": "EDGE/USDT:USDT",
+            "since": 1,
+            "timeframe": "1d",
+            "limit": 1,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_exchange_specific_first_timestamps_uses_native_bitunix_client(
+    monkeypatch, tmp_path
+):
+    import custom_endpoint_overrides
+    import exchanges.bitunix as bitunix
+
+    cache_dir = tmp_path / "caches"
+    cache_dir.mkdir()
+    _mark_first_ohlcv_cache_current(cache_dir)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(procedures, "make_get_filepath", lambda p: str(tmp_path / p))
+    dummy = _DummyCC("bitunix", 1710115200000)
+    observed_configs = []
+
+    def _bitunix_client(config):
+        observed_configs.append(config)
+        return dummy
+
+    monkeypatch.setattr(bitunix, "BitunixClient", _bitunix_client)
+    monkeypatch.setattr(
+        bitunix,
+        "apply_bitunix_endpoint_override",
+        lambda config, _override: config,
+    )
+    monkeypatch.setattr(
+        custom_endpoint_overrides,
+        "resolve_custom_endpoint_override",
+        lambda _exchange: None,
+    )
+    monkeypatch.setattr(
+        procedures,
+        "load_ccxt_instance",
+        lambda *_args, **_kwargs: pytest.fail("Bitunix must not use a CCXT client"),
+    )
+
+    async def _load_markets(exchange):
+        assert exchange == "bitunix"
+        return {}
+
+    monkeypatch.setattr(procedures, "load_markets", _load_markets)
+
+    def _coin_to_symbol(_coin, exchange):
+        assert exchange == "bitunix"
+        return "ABC/USDT:USDT"
+
+    monkeypatch.setattr(procedures, "coin_to_symbol", _coin_to_symbol)
+
+    result = await procedures.get_first_timestamps_unified(["ABC"], exchange="bitunix")
+
+    assert result == {"ABC": 0.0}
+    assert observed_configs == [
+        {"enableRateLimit": True, "timeout": 60_000, "wsEnabled": False}
+    ]

--- a/tests/test_suite_runner.py
+++ b/tests/test_suite_runner.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import numpy as np
 import pytest
+import utils
 
 from suite_runner import (
     SuiteScenario,
@@ -19,9 +20,11 @@ from suite_runner import (
     prepare_master_datasets,
     resolve_coin_sources,
     _collect_union,
+    _coalesce_master_coins,
     _prepare_dataset_subset,
     _run_combined_dataset,
     summarize_scenario_metrics,
+    validate_suite_side_coin_lists,
 )
 
 
@@ -77,22 +80,30 @@ def test_build_scenarios_handles_exchanges_and_coin_sources():
     assert scenario.coin_sources == {"BTC": "binance"}
 
 
-def test_build_scenarios_normalizes_coins_and_coin_sources():
+def test_build_scenarios_preserves_exact_coins_and_coin_sources():
     suite_cfg = {
         "scenarios": [
             {
                 "label": "X",
-                "coins": ["BTC/USDT:USDT", "ETHUSDT"],
-                "ignored_coins": ["SOL/USDT:USDT"],
-                "coin_sources": {"BTC/USDT:USDT": "binance", "ETHUSDT": "bybit"},
+                "coins": ["BTC/USDT:USDT", "ETHUSDT", "BTC-USDT-SWAP"],
+                "ignored_coins": ["SOL/USDT:USDT", "1000ABCUSDT"],
+                "coin_sources": {
+                    "BTC/USDT:USDT": "binance",
+                    "ETHUSDT": "bybit",
+                    "BTC-USDT-SWAP": "okx",
+                },
             }
         ],
     }
     scenarios, _ = build_scenarios(suite_cfg)
     scenario = scenarios[0]
-    assert scenario.coins == ["BTC", "ETH"]
-    assert scenario.ignored_coins == ["SOL"]
-    assert scenario.coin_sources == {"BTC": "binance", "ETH": "bybit"}
+    assert scenario.coins == ["BTC/USDT:USDT", "ETHUSDT", "BTC-USDT-SWAP"]
+    assert scenario.ignored_coins == ["SOL/USDT:USDT", "1000ABCUSDT"]
+    assert scenario.coin_sources == {
+        "BTC/USDT:USDT": "binance",
+        "ETHUSDT": "bybit",
+        "BTC-USDT-SWAP": "okx",
+    }
 
 
 def test_build_scenarios_inherits_exchanges_from_defaults():
@@ -300,6 +311,227 @@ def test_apply_scenario_rejects_asymmetric_side_coin_lists():
             available_exchanges=["binance"],
             available_coins={"BTC", "ETH"},
         )
+
+
+def test_apply_scenario_rejects_asymmetric_exact_side_coin_lists():
+    base_config = {
+        "backtest": {
+            "coins": {},
+            "cache_dir": {},
+            "exchanges": ["bitget"],
+        },
+        "live": {
+            "approved_coins": {
+                "long": ["1000ABCUSDT"],
+                "short": ["ABCUSDT"],
+            },
+            "ignored_coins": {"long": [], "short": []},
+        },
+    }
+    scenario = SuiteScenario(
+        label="scenario_a",
+        start_date=None,
+        end_date=None,
+        coins=["1000ABCUSDT", "ABCUSDT"],
+        ignored_coins=[],
+    )
+
+    with pytest.raises(ValueError, match="asymmetric live.approved_coins"):
+        apply_scenario(
+            base_config,
+            scenario,
+            master_coins=["1000ABCUSDT", "ABCUSDT"],
+            master_ignored=[],
+            available_exchanges=["bitget"],
+            available_coins={"1000ABCUSDT", "ABCUSDT"},
+        )
+
+
+def test_apply_scenario_reconciles_exact_ignored_id_to_available_alias(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    markets = {
+        "BTC/USDT:USDT": {
+            "id": "BTCUSDT",
+            "swap": True,
+            "linear": True,
+            "active": True,
+            "base": "BTC",
+        }
+    }
+    assert utils.create_coin_symbol_map_cache("bitget", markets, verbose=False)
+    base_config = {
+        "backtest": {"coins": {}, "cache_dir": {}, "exchanges": ["bitget"]},
+        "live": {
+            "approved_coins": {"long": ["BTC"], "short": ["BTC"]},
+            "ignored_coins": {"long": [], "short": []},
+        },
+    }
+    scenario = SuiteScenario(
+        label="scenario_a",
+        start_date=None,
+        end_date=None,
+        coins=["BTC"],
+        ignored_coins=["BTCUSDT"],
+    )
+
+    cfg, coins = apply_scenario(
+        base_config,
+        scenario,
+        master_coins=["BTC"],
+        master_ignored=["BTCUSDT"],
+        available_exchanges=["bitget"],
+        available_coins={"BTC"},
+    )
+
+    assert coins == ["BTC"]
+    assert cfg["live"]["ignored_coins"] == {
+        "long": ["BTC"],
+        "short": ["BTC"],
+    }
+
+
+def test_suite_side_validation_compares_resolved_market_identity(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    markets = {
+        "BTC/USDT:USDT": {
+            "id": "BTCUSDT",
+            "swap": True,
+            "linear": True,
+            "active": True,
+            "base": "BTC",
+        }
+    }
+    assert utils.create_coin_symbol_map_cache("bitget", markets, verbose=False)
+    config = {
+        "live": {
+            "approved_coins": {"long": ["BTC"], "short": ["BTCUSDT"]},
+            "ignored_coins": {"long": [], "short": []},
+        }
+    }
+
+    validate_suite_side_coin_lists(config, ["bitget"])
+
+
+def test_suite_coin_sources_coalesce_master_aliases_to_forced_key(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    markets = {
+        "BTC/USDT:USDT": {
+            "id": "BTCUSDT",
+            "swap": True,
+            "linear": True,
+            "active": True,
+            "base": "BTC",
+        }
+    }
+    assert utils.create_coin_symbol_map_cache("bitget", markets, verbose=False)
+
+    assert _coalesce_master_coins(
+        ["BTC", "BTCUSDT"], {"BTCUSDT": "bitget"}, ["bitget"]
+    ) == ["BTCUSDT"]
+
+
+def test_suite_master_coins_coalesce_resolved_aliases_without_forced_source(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    markets = {
+        "BTC/USDT:USDT": {
+            "id": "BTCUSDT",
+            "swap": True,
+            "linear": True,
+            "active": True,
+            "base": "BTC",
+        }
+    }
+    assert utils.create_coin_symbol_map_cache("bitget", markets, verbose=False)
+
+    assert _coalesce_master_coins(
+        ["BTC", "BTCUSDT"], {}, ["bitget"]
+    ) == ["BTC"]
+
+
+def test_suite_master_coins_reject_conflicting_source_aliases(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    markets_by_exchange = {
+        "bybit": {
+            "EDGE/USDT:USDT": {
+                "id": "EDGEUSDT",
+                "swap": True,
+                "linear": True,
+                "active": True,
+                "base": "EDGE",
+            }
+        },
+        "kucoin": {
+            "EDGE/USDT:USDT": {
+                "id": "EDGEUSDTM",
+                "swap": True,
+                "linear": True,
+                "active": True,
+                "base": "EDGE",
+            }
+        },
+    }
+    for exchange, markets in markets_by_exchange.items():
+        assert utils.create_coin_symbol_map_cache(exchange, markets, verbose=False)
+
+    with pytest.raises(ValueError, match="equivalent identifiers.*conflicting exchanges"):
+        _coalesce_master_coins(
+            ["EDGE", "EDGEUSDTM"],
+            {"EDGE": "bybit", "EDGEUSDTM": "kucoin"},
+            ["bybit", "kucoin"],
+        )
+
+
+def test_suite_master_coins_preserve_distinct_qualified_sources(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    markets = {
+        "BTC/USDT:USDT": {
+            "id": "BTCUSDT",
+            "swap": True,
+            "linear": True,
+            "active": True,
+            "base": "BTC",
+        }
+    }
+    for exchange in ("bitget", "bybit"):
+        assert utils.create_coin_symbol_map_cache(exchange, markets, verbose=False)
+
+    identifiers = ["bitget::BTCUSDT", "bybit::BTCUSDT"]
+    assert _coalesce_master_coins(
+        identifiers,
+        {"bitget::BTCUSDT": "bitget", "bybit::BTCUSDT": "bybit"},
+        ["bitget", "bybit"],
+    ) == identifiers
+
+
+def test_suite_side_validation_retains_qualified_venue_scope(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    markets = {
+        "BTC/USDT:USDT": {
+            "id": "BTCUSDT",
+            "swap": True,
+            "linear": True,
+            "active": True,
+            "base": "BTC",
+        }
+    }
+    for exchange in ("bitget", "bybit"):
+        assert utils.create_coin_symbol_map_cache(exchange, markets, verbose=False)
+    config = {
+        "live": {
+            "approved_coins": {
+                "long": ["bitget::BTCUSDT"],
+                "short": ["bybit::BTCUSDT"],
+            },
+            "ignored_coins": {"long": [], "short": []},
+        }
+    }
+
+    with pytest.raises(ValueError, match="asymmetric live.approved_coins"):
+        validate_suite_side_coin_lists(config, ["bitget", "bybit"])
 
 
 def test_apply_scenario_overrides_update_config():

--- a/tests/test_utils_maps.py
+++ b/tests/test_utils_maps.py
@@ -57,6 +57,20 @@ def test_load_ccxt_instance_defaults_okx_to_swap_only_markets(monkeypatch):
     assert cc.options["fetchMarkets"] == {"types": ["swap"]}
 
 
+def test_defx_exchange_qualified_identifier_is_recognized():
+    assert utils.split_exchange_qualified_market_identifier("defx::ABCUSDC") == (
+        "defx",
+        "ABCUSDC",
+    )
+
+
+@pytest.mark.parametrize(
+    "identifier", ["BTC-USDT-SWAP", "HOTUSDTM", "EDGEUSDTM", "XUSDT", "XUSDTM"]
+)
+def test_native_market_id_is_exact(identifier):
+    assert utils.looks_like_exact_market_identifier(identifier)
+
+
 @pytest.mark.asyncio
 async def test_load_markets_fetch_and_cache_creates_maps(tmp_path, monkeypatch):
     # Work inside an isolated temp directory
@@ -96,6 +110,9 @@ async def test_load_markets_fetch_and_cache_creates_maps(tmp_path, monkeypatch):
     assert set(c2s["BTC"]) == {"BTC/USDT:USDT"}
     # SHIB should be derived from "1000SHIB"
     assert set(c2s["SHIB"]) == {"1000SHIB/USDT:USDT"}
+    # Exact bases and CCXT symbols remain lossless aliases.
+    assert c2s["1000SHIB"] == ["1000SHIB/USDT:USDT"]
+    assert c2s["1000SHIB/USDT:USDT"] == ["1000SHIB/USDT:USDT"]
     # FOO comes from base without baseName
     assert set(c2s["FOO"]) == {"FOO/USDT:USDT"}
 
@@ -224,22 +241,326 @@ def test_coin_to_symbol_fallback_and_logging(tmp_path, monkeypatch, caplog):
     path = os.path.join("caches", ex, "coin_to_symbol_map.json")
     os.makedirs(os.path.dirname(path), exist_ok=True)
     json.dump({}, open(path, "w"))
-    # sanitize a noisy input
     caplog.set_level(logging.INFO)
-    sym = utils.coin_to_symbol("BTCUSDC", ex)
+    sym = utils.coin_to_symbol("BTC", ex)
     assert sym == "BTC/USDC:USDC"
-    assert any("BTCUSDC" in rec.message for rec in caplog.records)
+    assert any("BTC" in rec.message for rec in caplog.records)
 
 
-def test_coin_to_symbol_multiple_candidates(tmp_path, monkeypatch, caplog):
+@pytest.mark.parametrize("identifier", ["bitget::1000ABCUSDT", "1000ABCUSDT"])
+def test_exact_identifier_without_market_map_fails_closed(identifier, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(utils.UnknownMarketIdentifier, match="is unavailable on bitget"):
+        utils.coin_to_symbol(identifier, "bitget")
+
+
+def test_unknown_namespaced_hip3_identifier_fails_closed(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    assert utils.looks_like_exact_market_identifier("xyz:UNKNOWN")
+    with pytest.raises(utils.UnknownMarketIdentifier, match="is unavailable on hyperliquid"):
+        utils.coin_to_symbol("xyz:UNKNOWN", "hyperliquid")
+
+
+def test_coin_to_symbol_rejects_multiple_candidates(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     ex = "binance"
     path = os.path.join("caches", ex, "coin_to_symbol_map.json")
     os.makedirs(os.path.dirname(path), exist_ok=True)
     json.dump({"BTC": ["A", "B"]}, open(path, "w"))
-    caplog.set_level(logging.INFO)
-    assert utils.coin_to_symbol("BTC", ex) == "A"
-    assert any("Multiple candidates" in rec.message for rec in caplog.records)
+    with pytest.raises(utils.AmbiguousMarketIdentifier, match="matches \['A', 'B'\]"):
+        utils.coin_to_symbol("BTC", ex)
+
+
+def test_collision_aware_maps_preserve_exact_market_identifiers(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    ex = "testexchange"
+    markets = {
+        "ABC/USDT:USDT": {
+            "swap": True,
+            "linear": True,
+            "base": "ABC",
+            "baseName": "ABC",
+            "id": "ABCUSDT",
+        },
+        "1000ABC/USDT:USDT": {
+            "swap": True,
+            "linear": True,
+            "base": "1000ABC",
+            "baseName": "1000ABC",
+            "id": "1000ABCUSDT",
+        },
+    }
+
+    c2s, s2c = utils._build_coin_symbol_maps(markets, "USDT")
+    reverse_c2s, reverse_s2c = utils._build_coin_symbol_maps(
+        dict(reversed(list(markets.items()))), "USDT"
+    )
+    assert c2s == reverse_c2s
+    assert s2c == reverse_s2c
+    assert c2s["ABC"] == ["1000ABC/USDT:USDT", "ABC/USDT:USDT"]
+    assert c2s["1000ABC"] == ["1000ABC/USDT:USDT"]
+    assert c2s["ABCUSDT"] == ["ABC/USDT:USDT"]
+    assert c2s["1000ABCUSDT"] == ["1000ABC/USDT:USDT"]
+    assert c2s["ABC/USDT:USDT"] == ["ABC/USDT:USDT"]
+    assert c2s["1000ABC/USDT:USDT"] == ["1000ABC/USDT:USDT"]
+
+    path = os.path.join("caches", ex, "coin_to_symbol_map.json")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    json.dump(c2s, open(path, "w"))
+
+    assert utils.coin_to_symbol("1000ABC", ex) == "1000ABC/USDT:USDT"
+    assert utils.coin_to_symbol("ABCUSDT", ex) == "ABC/USDT:USDT"
+    assert utils.coin_to_symbol("1000ABCUSDT", ex) == "1000ABC/USDT:USDT"
+    assert utils.coin_to_symbol("ABC/USDT:USDT", ex) == "ABC/USDT:USDT"
+    assert utils.coin_to_symbol("1000ABC/USDT:USDT", ex) == "1000ABC/USDT:USDT"
+    with pytest.raises(utils.AmbiguousMarketIdentifier, match="ambiguous market identifier 'ABC'"):
+        utils.coin_to_symbol("ABC", ex)
+
+
+def test_single_multiplier_market_keeps_legacy_convenience_alias():
+    markets = {
+        "1000SHIB/USDT:USDT": {
+            "id": "1000SHIBUSDT",
+            "swap": True,
+            "linear": True,
+            "base": "1000SHIB",
+            "baseName": "SHIB",
+        }
+    }
+
+    coin_to_symbol_map, symbol_to_coin_map = utils._build_coin_symbol_maps(markets, "USDT")
+
+    assert coin_to_symbol_map["SHIB"] == ["1000SHIB/USDT:USDT"]
+    assert coin_to_symbol_map["1000SHIB"] == ["1000SHIB/USDT:USDT"]
+    assert symbol_to_coin_map["1000SHIBUSDT"] == "SHIB"
+
+
+def test_inactive_multiplier_market_does_not_pollute_convenience_alias():
+    markets = {
+        "ABC/USDT:USDT": {
+            "id": "ABCUSDT",
+            "swap": True,
+            "linear": True,
+            "active": True,
+            "base": "ABC",
+        },
+        "1000ABC/USDT:USDT": {
+            "id": "1000ABCUSDT",
+            "swap": True,
+            "linear": True,
+            "active": False,
+            "base": "1000ABC",
+        },
+    }
+
+    coin_to_symbol_map, _ = utils._build_coin_symbol_maps(markets, "USDT")
+
+    assert coin_to_symbol_map["ABC"] == ["ABC/USDT:USDT"]
+    assert coin_to_symbol_map["1000ABCUSDT"] == ["1000ABC/USDT:USDT"]
+    assert coin_to_symbol_map["1000ABC/USDT:USDT"] == ["1000ABC/USDT:USDT"]
+
+
+def test_map_builder_omits_ambiguous_canonical_label_deterministically():
+    markets = {
+        "ABC/USDC:USDC": {
+            "swap": True,
+            "linear": True,
+            "base": "ABC",
+            "id": "ABC-USDC",
+        },
+        "VENUE-ABC/USDC:USDC": {
+            "swap": True,
+            "linear": True,
+            "baseName": "venue:ABC",
+            "id": "12345",
+            "info": {"hip3": True},
+        },
+    }
+
+    c2s, s2c = utils._build_coin_symbol_maps(markets, "USDC")
+    reverse_c2s, reverse_s2c = utils._build_coin_symbol_maps(
+        dict(reversed(list(markets.items()))), "USDC"
+    )
+
+    assert c2s == reverse_c2s
+    assert s2c == reverse_s2c
+    assert c2s["ABC"] == ["ABC/USDC:USDC", "VENUE-ABC/USDC:USDC"]
+    assert "ABC" not in s2c
+    assert s2c["ABC-USDC"] == "ABC"
+    assert s2c["12345"] == "venue:ABC"
+
+
+def test_ambiguity_tombstones_survive_other_exchange_refreshes(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    colliding_markets = {
+        "ABC/USDC:USDC": {
+            "swap": True,
+            "linear": True,
+            "base": "ABC",
+            "id": "ABC-USDC",
+        },
+        "VENUE-ABC/USDC:USDC": {
+            "swap": True,
+            "linear": True,
+            "baseName": "venue:ABC",
+            "id": "12345",
+            "info": {"hip3": True},
+        },
+    }
+    unambiguous_markets = {
+        "ABC/USDT:USDT": {
+            "swap": True,
+            "linear": True,
+            "base": "ABC",
+            "id": "ABCUSDT",
+        }
+    }
+
+    assert utils.create_coin_symbol_map_cache(
+        "hyperliquid", colliding_markets, quote="USDC", verbose=False
+    )
+    assert utils.create_coin_symbol_map_cache("bybit", unambiguous_markets, verbose=False)
+
+    symbol_map = json.loads((tmp_path / "caches" / "symbol_to_coin_map.json").read_text())
+    ambiguities = json.loads(
+        (tmp_path / "caches" / "symbol_to_coin_ambiguities.json").read_text()
+    )
+    assert "ABC" not in symbol_map
+    assert ambiguities["hyperliquid"] == ["ABC"]
+    assert utils.coin_to_symbol("ABC", "bybit") == "ABC/USDT:USDT"
+    with pytest.raises(utils.AmbiguousMarketIdentifier):
+        utils.coin_to_symbol("ABC", "hyperliquid")
+
+
+def test_ambiguity_tombstone_is_released_after_collision_disappears(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    colliding_markets = {
+        "ABC/USDT:USDT": {
+            "swap": True,
+            "linear": True,
+            "base": "ABC",
+            "id": "ABCUSDT",
+        },
+        "1000ABC/USDT:USDT": {
+            "swap": True,
+            "linear": True,
+            "base": "1000ABC",
+            "id": "1000ABCUSDT",
+        },
+    }
+    remaining_market = {"ABC/USDT:USDT": colliding_markets["ABC/USDT:USDT"]}
+
+    assert utils.create_coin_symbol_map_cache("bitget", colliding_markets, verbose=False)
+    assert "ABC" not in utils._load_symbol_to_coin_map()
+
+    assert utils.create_coin_symbol_map_cache("bitget", remaining_market, verbose=False)
+    assert utils.symbol_to_coin("ABC", verbose=False) == "ABC"
+    assert json.loads(
+        (tmp_path / "caches" / "symbol_to_coin_ambiguities.json").read_text()
+    )["bitget"] == []
+
+
+def test_exact_native_id_resolution_is_exchange_local(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    bitget_markets = {
+        "ABC/USDT:USDT": {
+            "swap": True,
+            "linear": True,
+            "base": "ABC",
+            "id": "12345",
+        }
+    }
+    bybit_markets = {
+        "OTHER/USDT:USDT": {
+            "swap": True,
+            "linear": True,
+            "base": "OTHER",
+            "id": "12345",
+        }
+    }
+
+    assert utils.create_coin_symbol_map_cache("bitget", bitget_markets, verbose=False)
+    assert utils.create_coin_symbol_map_cache("bybit", bybit_markets, verbose=False)
+
+    assert utils.coin_to_symbol("12345", "bitget") == "ABC/USDT:USDT"
+    assert utils.coin_to_symbol("12345", "bybit") == "OTHER/USDT:USDT"
+
+
+def test_exchange_qualified_native_id_is_scoped(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    path = os.path.join("caches", "bitget", "coin_to_symbol_map.json")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    json.dump({"ABCUSDT": ["ABC/USDT:USDT"]}, open(path, "w"))
+
+    assert utils.coin_to_symbol("bitget::ABCUSDT", "bitget") == "ABC/USDT:USDT"
+    with pytest.raises(utils.MarketIdentifierExchangeMismatch, match="targets bitget, not bybit"):
+        utils.coin_to_symbol("bitget::ABCUSDT", "bybit")
+
+
+@pytest.mark.parametrize("identifier", ["bitget::1000ABCUSDT", "1000ABCUSDT"])
+def test_exact_identifier_miss_does_not_fall_back_to_normalized_market(
+    identifier, tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    path = os.path.join("caches", "bitget", "coin_to_symbol_map.json")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    json.dump({"ABC": ["ABC/USDT:USDT"]}, open(path, "w"))
+
+    with pytest.raises(utils.UnknownMarketIdentifier, match="is unavailable on bitget"):
+        utils.coin_to_symbol(identifier, "bitget")
+
+
+def test_symbol_to_coin_preserves_exchange_qualified_identifier(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    assert utils.symbol_to_coin("bitget::ABCUSDT", verbose=False) == "bitget::ABCUSDT"
+
+
+def test_namespaced_non_exchange_alias_is_not_treated_as_qualification(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    path = os.path.join("caches", "hyperliquid", "coin_to_symbol_map.json")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    json.dump({"xyz:TSLA": ["XYZ-TSLA/USDC:USDC"]}, open(path, "w"))
+
+    assert utils.coin_to_symbol("xyz:TSLA", "hyperliquid") == "XYZ-TSLA/USDC:USDC"
+
+
+def test_namespaced_full_symbol_alias_resolves_losslessly(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    markets = {
+        "XYZ-TSLA/USDC:USDC": {
+            "id": "12345",
+            "swap": True,
+            "linear": True,
+            "active": True,
+            "base": "XYZ-TSLA",
+            "baseName": "xyz:TSLA",
+            "info": {"hip3": True},
+        }
+    }
+    assert utils.create_coin_symbol_map_cache(
+        "hyperliquid", markets, quote="USDC", verbose=False
+    )
+
+    assert (
+        utils.coin_to_symbol("xyz:TSLA/USDC:USDC", "hyperliquid")
+        == "XYZ-TSLA/USDC:USDC"
+    )
+
+
+def test_hip3_namespace_matching_exchange_name_is_not_qualification(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    path = os.path.join("caches", "hyperliquid", "coin_to_symbol_map.json")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    json.dump({"bitget:FOO": ["BITGET-FOO/USDC:USDC"]}, open(path, "w"))
+
+    assert (
+        utils.coin_to_symbol("bitget:FOO", "hyperliquid")
+        == "BITGET-FOO/USDC:USDC"
+    )
 
 
 def test_symbol_to_coin_in_memory_reload_and_heuristics(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- build deterministic exchange symbol maps with lossless aliases for complete CCXT symbols and native market IDs
- resolve raw and explicitly qualified `exchange::<native-id>` identifiers before convenience normalization without colliding with HIP-3 `namespace:ticker` aliases
- reject ambiguous aliases and missing exact identifiers instead of guessing or normalizing to another market
- exclude inactive markets from convenience-alias ambiguity while retaining their exact symbol/native-ID routes
- preserve exact identifiers through live caches, configured coin lists, coin overrides, fill normalization, first-timestamp discovery, backtest data selection, and combined HLCV source selection
- recognize native-ID-shaped backtest and override inputs as exact identities while retaining legacy canonical alias compatibility
- scope every exchange's identity for a canonical coin when `approved_coins="all"` finds a collision on any configured exchange
- return only requested first-timestamp cache keys and restrict exchange-specific timestamp lookups to their target venue
- remove the stale bot-level result cache and rely on the shared file-aware market-map cache
- fail closed by clearing stale entry eligibility when a live coin-list refresh encounters any market-identifier resolution error
- propagate mapping resolution errors through Bitget and Binance fill fetchers instead of falling back to the raw symbol
- make combined market-settings overrides fall back safely when a scoped identity is unavailable on the requested settings venue
- persist per-exchange ambiguity tombstones so cache refresh order cannot resurrect unsafe global aliases
- retain legacy single-multiplier convenience aliases and add the useful ordering, baseName, refresh-order, and exact-round-trip regressions from #1459
- update sanitized CCXT contract fixtures and the changelog

## Root cause

The existing map builder used normalized coin aliases as market identities. Multiplier removal and exchange-specific aliases could therefore collapse unrelated contracts onto one alias. Candidate symbols were collected in a set, serialized without sorting, and the resolver selected the first candidate. Exact native IDs and CCXT symbols were normalized before the exchange-specific map could preserve them.

The new resolver separates exact routing aliases from convenience aliases. Exact identifiers take precedence, generated maps are deterministic, convenience collisions and exact misses fail closed, inactive listings cannot pollute convenience aliases, and ambiguity ownership is retained across cache refreshes. Explicit exchange scoping uses a double-colon separator so valid HIP-3 namespaces remain unambiguous. A shared market-resolution error base keeps future mapping failures fail-closed across eligibility and fill consumers.

Closes #1456.

## Validation

- full offline Python test suite on final rebased head after each review round
- focused market-map, CCXT fixture replay, config override, coin-list, first-timestamp, backtest-universe, HLCV preparation, coin-override, and fill-event suites
- rebuilt and fingerprint-verified the repository Rust extension; no Rust source changed in later review rounds
- `cargo test --no-default-features` (255 passed)
- `cargo check --tests`
- offline fake-live HSL restart smoke
- AI documentation and generated live-event registry checks
- `python -m compileall -q`
- `git diff --check`