### PR TITLE
Harden Gate multi-currency balance selection and diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Gate.io multi-currency futures balance events now publish bounded settle-currency
+  composition diagnostics (wallet amount, available margin, reserved IM/order
+  margin, unrealized PnL) and select the quote-matched futures-account row instead
+  of blindly using `info[0]`. Trading wallet balance continues to reconstruct from
+  available + position IM + order margin − unrealized PnL so resting-order
+  reservations do not resize risk inputs.
 - Refresh hardcoded schema defaults and the mirrored example config from the latest
   long-only trailing-martingale canon candidate: update `bot.long` parameters,
   `optimize.bounds`, and `live.approved_coins` (replace CRO with TON; reorder coin

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -324,8 +324,11 @@ such as `"None"` as durable subscription state.
 
 Gate's `cross_available` is spendable margin, not stable account equity. Resting
 orders move value between `cross_available` and `cross_order_margin`, while open
-positions use `cross_initial_margin`. For multi-currency margin accounts, derive
-the strategy balance from the same authoritative futures-account row as
+positions use `cross_initial_margin`. For multi-currency margin accounts, select
+the unique futures-account row whose settle `currency` matches the bot quote
+(CCXT wraps Gate's single-account response as `info=[account]`; never prefer an
+unrelated first row when currency-matched candidates exist). Derive the strategy
+wallet balance from that same authoritative row as
 `cross_available + cross_order_margin + cross_initial_margin -
 cross_unrealised_pnl`. Require all four finite fields. Removing unrealized PnL
 preserves wallet-balance semantics because Passivbot adds position PnL separately
@@ -333,6 +336,12 @@ when deriving equity. Do not feed `cross_available` alone to Rust, because
 ordinary order reservation would then resize ideal orders and create
 reconciliation churn. Classic accounts continue using CCXT's quote-currency
 total.
+
+Balance-change events may publish a bounded Gate composition diagnostic for the
+settle currency: reconstructed wallet amount, available margin
+(`cross_available`), reserved margin (`cross_initial_margin +
+cross_order_margin`), and unrealized PnL. Composition is observability-only and
+must not replace the trading wallet balance.
 
 ### Per-symbol leverage initializes the position risk limit
 

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -327,7 +327,9 @@ orders move value between `cross_available` and `cross_order_margin`, while open
 positions use `cross_initial_margin`. For multi-currency margin accounts, select
 the unique futures-account row whose settle `currency` matches the bot quote
 (CCXT wraps Gate's single-account response as `info=[account]`; never prefer an
-unrelated first row when currency-matched candidates exist). Derive the strategy
+unrelated first row when currency-matched candidates exist). A singleton row is
+accepted only when `currency` is omitted; an explicit mismatched currency fails
+closed. Derive the strategy
 wallet balance from that same authoritative row as
 `cross_available + cross_order_margin + cross_initial_margin -
 cross_unrealised_pnl`. Require all four finite fields. Removing unrealized PnL

--- a/src/exchanges/gateio.py
+++ b/src/exchanges/gateio.py
@@ -110,6 +110,101 @@ class GateIOBot(CCXTBot):
         balance_fetched = await self._do_fetch_balance()
         return self._get_balance(balance_fetched)
 
+    def _select_futures_account_row(self, balance_fetched: dict) -> dict:
+        """Select the settle-currency futures account row from a CCXT balance payload.
+
+        CCXT wraps Gate's single futures-account object as ``info=[account]``. Prefer an
+        exact ``currency`` match to ``self.quote`` so a multi-row payload cannot silently
+        use the first unrelated row. When currency is absent, accept only a single row.
+        """
+        info = balance_fetched.get("info")
+        if not isinstance(info, list) or not info:
+            raise KeyError(f"{self.exchange}: fetch_balance response missing info list")
+        quote = str(self.quote).strip().upper()
+        if not quote:
+            raise ValueError(f"{self.exchange}: quote currency is required for balance parsing")
+
+        currency_matches: list[dict] = []
+        dict_rows: list[dict] = []
+        for row in info:
+            if not isinstance(row, dict):
+                continue
+            dict_rows.append(row)
+            raw_currency = row.get("currency")
+            if raw_currency is None:
+                continue
+            currency = str(raw_currency).strip().upper()
+            if currency == quote:
+                currency_matches.append(row)
+
+        if len(currency_matches) == 1:
+            return currency_matches[0]
+        if len(currency_matches) > 1:
+            raise ValueError(
+                f"{self.exchange}: fetch_balance response has multiple info rows "
+                f"for settle currency {quote}"
+            )
+        if len(dict_rows) == 1:
+            return dict_rows[0]
+        raise KeyError(
+            f"{self.exchange}: fetch_balance response missing unique info row "
+            f"for settle currency {quote}"
+        )
+
+    @staticmethod
+    def _require_finite_account_field(primary: dict, key: str, *, exchange: str) -> float:
+        if key not in primary:
+            raise KeyError(
+                f"{exchange}: fetch_balance response missing multi-currency field {key}"
+            )
+        try:
+            value = float(primary[key])
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(
+                f"{exchange}: fetch_balance response has non-numeric multi-currency "
+                f"field {key}"
+            ) from exc
+        if not math.isfinite(value):
+            raise ValueError(
+                f"{exchange}: fetch_balance response has non-finite multi-currency "
+                f"field {key}"
+            )
+        return value
+
+    def _multi_currency_wallet_balance(self, primary: dict) -> float:
+        """Stable wallet balance for multi-currency cross-margin accounts.
+
+        ``cross_available`` is spendable margin, not account equity: it falls when
+        resting orders reserve margin and rises when those orders are cancelled.
+        Reconstruct wallet balance from the same authoritative futures-account row:
+
+            cross_available + cross_initial_margin + cross_order_margin
+            - cross_unrealised_pnl
+
+        Unrealized PnL is removed because Passivbot adds position PnL separately when
+        deriving equity.
+        """
+        exchange = self.exchange
+        available = self._require_finite_account_field(
+            primary, "cross_available", exchange=exchange
+        )
+        initial_margin = self._require_finite_account_field(
+            primary, "cross_initial_margin", exchange=exchange
+        )
+        order_margin = self._require_finite_account_field(
+            primary, "cross_order_margin", exchange=exchange
+        )
+        unrealised_pnl = self._require_finite_account_field(
+            primary, "cross_unrealised_pnl", exchange=exchange
+        )
+        balance = available + initial_margin + order_margin - unrealised_pnl
+        if not math.isfinite(balance):
+            raise ValueError(
+                f"{exchange}: fetch_balance response has non-finite "
+                "multi-currency margin balance"
+            )
+        return balance
+
     def _get_balance(self, balance_fetched: dict) -> float:
         """Extract Gate.io futures balance for classic and multi-currency margin modes.
 
@@ -117,10 +212,7 @@ class GateIOBot(CCXTBot):
         fetch_balance() and calls this hook directly. Keep Gate.io's margin-mode
         specific parsing here so legacy and staged paths use the same balance.
         """
-        info = balance_fetched.get("info")
-        if not isinstance(info, list) or not info:
-            raise KeyError(f"{self.exchange}: fetch_balance response missing info[0]")
-        primary = info[0]
+        primary = self._select_futures_account_row(balance_fetched)
         if not hasattr(self, "uid") or not self.uid:
             # Gate's REST payload currently returns ``user`` as an integer,
             # while CCXT Pro's private futures subscription treats the UID as
@@ -128,12 +220,12 @@ class GateIOBot(CCXTBot):
             raw_uid = primary["user"]
             if isinstance(raw_uid, bool) or not isinstance(raw_uid, (str, int)):
                 raise ValueError(
-                    f"{self.exchange}: fetch_balance response has invalid info[0].user"
+                    f"{self.exchange}: fetch_balance response has invalid account user"
                 )
             uid = str(raw_uid).strip()
             if not uid:
                 raise ValueError(
-                    f"{self.exchange}: fetch_balance response has empty info[0].user"
+                    f"{self.exchange}: fetch_balance response has empty account user"
                 )
             self.uid = uid
             self.cca.uid = self.uid
@@ -144,32 +236,16 @@ class GateIOBot(CCXTBot):
         if margin_mode_name == "classic":
             balance = float(balance_fetched[self.quote]["total"])
         elif margin_mode_name == "multi_currency":
-            # ``cross_available`` is spendable margin, not account equity. It
-            # falls when resting orders reserve margin and rises again when
-            # those orders are cancelled, which would make Passivbot resize its
-            # ideal orders on every reconciliation cycle. Reconstruct the
-            # stable cross-margin balance from the same authoritative account
-            # payload by adding back position and resting-order initial margin.
-            margin_balance = sum(
-                float(primary[key])
-                for key in (
-                    "cross_available",
-                    "cross_initial_margin",
-                    "cross_order_margin",
-                )
-            )
-            # Margin balance includes unrealized cross-position PnL. Passivbot
-            # adds position PnL separately when deriving equity, so remove it
-            # here to retain wallet-balance semantics and avoid double-counting.
-            balance = margin_balance - float(primary["cross_unrealised_pnl"])
-            if not math.isfinite(balance):
-                raise ValueError(
-                    f"{self.exchange}: fetch_balance response has non-finite "
-                    "multi-currency margin balance"
-                )
+            balance = self._multi_currency_wallet_balance(primary)
         else:
             raise Exception(f"unknown margin_mode_name {balance_fetched}")
         return balance
+
+    def _normalize_balance_diagnostics(self, fetched: object) -> dict:
+        """Expose Gate settle-currency margin components for balance events only."""
+        from live.balance_composition import normalize_gateio_balance_composition
+
+        return normalize_gateio_balance_composition(fetched, quote=self.quote)
 
     async def fetch_pnls(
         self,

--- a/src/exchanges/gateio.py
+++ b/src/exchanges/gateio.py
@@ -144,7 +144,9 @@ class GateIOBot(CCXTBot):
                 f"{self.exchange}: fetch_balance response has multiple info rows "
                 f"for settle currency {quote}"
             )
-        if len(dict_rows) == 1:
+        # No currency match: accept a singleton only when currency is omitted.
+        # An explicit mismatched currency must fail closed (wrong denomination).
+        if len(dict_rows) == 1 and dict_rows[0].get("currency") is None:
             return dict_rows[0]
         raise KeyError(
             f"{self.exchange}: fetch_balance response missing unique info row "

--- a/src/live/balance_composition.py
+++ b/src/live/balance_composition.py
@@ -271,7 +271,11 @@ def normalize_hyperliquid_unified_balance_composition(fetched: Any) -> dict[str,
 
 
 def _select_gateio_account_row(fetched: Mapping[str, Any], quote: str) -> Mapping[str, Any] | None:
-    """Pick the unique Gate futures-account row for the settle currency when possible."""
+    """Pick the unique Gate futures-account row for the settle currency when possible.
+
+    Prefer an exact currency match to ``quote``. A singleton is accepted only when
+    ``currency`` is omitted; an explicit mismatched currency is rejected.
+    """
     info = fetched.get("info")
     if not isinstance(info, list) or not info:
         return None
@@ -289,7 +293,7 @@ def _select_gateio_account_row(fetched: Mapping[str, Any], quote: str) -> Mappin
         return currency_matches[0]
     if len(currency_matches) > 1:
         return None
-    if len(dict_rows) == 1:
+    if len(dict_rows) == 1 and dict_rows[0].get("currency") is None:
         return dict_rows[0]
     return None
 

--- a/src/live/balance_composition.py
+++ b/src/live/balance_composition.py
@@ -315,8 +315,16 @@ def normalize_gateio_balance_composition(
     if primary is None:
         return malformed_balance_composition(source=source, reason="missing_account")
 
-    asset = _asset_name(primary.get("currency")) or _asset_name(quote)
-    if asset is None:
+    payload_asset = _asset_name(primary.get("currency"))
+    quote_asset = _asset_name(quote)
+    if payload_asset is not None:
+        asset = payload_asset
+        asset_provenance = "currency"
+    elif quote_asset is not None:
+        # Singleton form may omit currency; label asset as config quote, not payload.
+        asset = quote_asset
+        asset_provenance = "quote"
+    else:
         return malformed_balance_composition(source=source, reason="missing_currency")
 
     margin_mode = primary.get("margin_mode_name")
@@ -341,7 +349,7 @@ def normalize_gateio_balance_composition(
             "used_amount": initial_margin + order_margin,
             "unrealized_pnl": unrealized_pnl,
             "field_provenance": {
-                "asset": "currency",
+                "asset": asset_provenance,
                 "amount": "wallet_balance",
                 "free_amount": "cross_available",
                 "used_amount": "cross_margin",
@@ -365,7 +373,7 @@ def normalize_gateio_balance_composition(
             "asset": asset,
             "amount": amount,
             "field_provenance": {
-                "asset": "currency",
+                "asset": asset_provenance,
                 "amount": "total",
             },
         }
@@ -427,7 +435,7 @@ def public_balance_composition(value: Any) -> dict[str, Any] | None:
         provenance = item.get("field_provenance")
         if isinstance(provenance, Mapping):
             allowed_sources = {
-                "asset": {"ccy", "coin", "currency", "currency_map_key"},
+                "asset": {"ccy", "coin", "currency", "currency_map_key", "quote"},
                 "amount": {"cashBal", "total", "wallet_balance"},
                 "free_amount": {"free", "available", "cross_available"},
                 "used_amount": {"used", "cross_margin"},

--- a/src/live/balance_composition.py
+++ b/src/live/balance_composition.py
@@ -270,6 +270,110 @@ def normalize_hyperliquid_unified_balance_composition(fetched: Any) -> dict[str,
     )
 
 
+def _select_gateio_account_row(fetched: Mapping[str, Any], quote: str) -> Mapping[str, Any] | None:
+    """Pick the unique Gate futures-account row for the settle currency when possible."""
+    info = fetched.get("info")
+    if not isinstance(info, list) or not info:
+        return None
+    quote_name = _asset_name(quote)
+    currency_matches: list[Mapping[str, Any]] = []
+    dict_rows: list[Mapping[str, Any]] = []
+    for row in info:
+        if not isinstance(row, Mapping):
+            continue
+        dict_rows.append(row)
+        asset = _asset_name(row.get("currency"))
+        if quote_name is not None and asset == quote_name:
+            currency_matches.append(row)
+    if len(currency_matches) == 1:
+        return currency_matches[0]
+    if len(currency_matches) > 1:
+        return None
+    if len(dict_rows) == 1:
+        return dict_rows[0]
+    return None
+
+
+def normalize_gateio_balance_composition(
+    fetched: Any, *, quote: str | None = None
+) -> dict[str, Any]:
+    """Normalize Gate futures-account margin components for observability only.
+
+    Multi-currency accounts expose available margin, position IM, order margin, and
+    unrealized PnL on the settle-currency futures-account row. Trading balance continues
+    to use the connector's wallet reconstruction; this helper only publishes a bounded
+    diagnostic view of those components.
+    """
+    source = "gateio.info.futures_account"
+    if not isinstance(fetched, Mapping):
+        return malformed_balance_composition(source=source, reason="invalid_payload")
+    primary = _select_gateio_account_row(fetched, quote or "")
+    if primary is None:
+        return malformed_balance_composition(source=source, reason="missing_account")
+
+    asset = _asset_name(primary.get("currency")) or _asset_name(quote)
+    if asset is None:
+        return malformed_balance_composition(source=source, reason="missing_currency")
+
+    margin_mode = primary.get("margin_mode_name")
+    if margin_mode == "multi_currency":
+        available = _finite_number(primary.get("cross_available"))
+        initial_margin = _finite_number(primary.get("cross_initial_margin"))
+        order_margin = _finite_number(primary.get("cross_order_margin"))
+        unrealized_pnl = _finite_number(primary.get("cross_unrealised_pnl"))
+        if None in (available, initial_margin, order_margin, unrealized_pnl):
+            return malformed_balance_composition(
+                source=source, reason="missing_cross_fields"
+            )
+        wallet_balance = available + initial_margin + order_margin - unrealized_pnl
+        if not math.isfinite(wallet_balance):
+            return malformed_balance_composition(
+                source=source, reason="non_finite_wallet"
+            )
+        row = {
+            "asset": asset,
+            "amount": wallet_balance,
+            "free_amount": available,
+            "used_amount": initial_margin + order_margin,
+            "unrealized_pnl": unrealized_pnl,
+            "field_provenance": {
+                "asset": "currency",
+                "amount": "wallet_balance",
+                "free_amount": "cross_available",
+                "used_amount": "cross_margin",
+                "unrealized_pnl": "cross_unrealised_pnl",
+            },
+        }
+        return _finalize_snapshot(status="available", source=source, assets=[row])
+
+    if margin_mode == "classic":
+        total_map = fetched.get("total")
+        amount = None
+        if isinstance(total_map, Mapping):
+            amount = _finite_number(total_map.get(asset))
+            if amount is None and quote is not None:
+                amount = _finite_number(total_map.get(quote))
+        if amount is None:
+            amount = _finite_number(primary.get("total"))
+        if amount is None:
+            return malformed_balance_composition(source=source, reason="missing_total")
+        row: dict[str, Any] = {
+            "asset": asset,
+            "amount": amount,
+            "field_provenance": {
+                "asset": "currency",
+                "amount": "total",
+            },
+        }
+        available = _finite_number(primary.get("available"))
+        if available is not None:
+            row["free_amount"] = available
+            row["field_provenance"]["free_amount"] = "available"
+        return _finalize_snapshot(status="available", source=source, assets=[row])
+
+    return malformed_balance_composition(source=source, reason="unknown_margin_mode")
+
+
 def public_balance_composition(value: Any) -> dict[str, Any] | None:
     """Copy only the bounded event contract; never publish an internal signature."""
     if not isinstance(value, Mapping):
@@ -287,6 +391,7 @@ def public_balance_composition(value: Any) -> dict[str, Any] | None:
             "unsupported",
             "normalizer",
             "ccxt.unified_balance",
+            "gateio.info.futures_account",
             "hyperliquid.info.balances",
             "okx.info.data[0].details",
         }
@@ -318,12 +423,12 @@ def public_balance_composition(value: Any) -> dict[str, Any] | None:
         provenance = item.get("field_provenance")
         if isinstance(provenance, Mapping):
             allowed_sources = {
-                "asset": {"ccy", "coin", "currency_map_key"},
-                "amount": {"cashBal", "total"},
-                "free_amount": {"free"},
-                "used_amount": {"used"},
+                "asset": {"ccy", "coin", "currency", "currency_map_key"},
+                "amount": {"cashBal", "total", "wallet_balance"},
+                "free_amount": {"free", "available", "cross_available"},
+                "used_amount": {"used", "cross_margin"},
                 "usd_value": "eqUsd",
-                "unrealized_pnl": "upl",
+                "unrealized_pnl": {"upl", "cross_unrealised_pnl"},
                 "liability": {"debt", "liab"},
                 "collateral_enabled": "collateralEnabled",
             }

--- a/tests/ccxt_upgrade/test_order_contracts.py
+++ b/tests/ccxt_upgrade/test_order_contracts.py
@@ -1321,6 +1321,62 @@ def test_gateio_selects_quote_matched_account_row_not_first_info_entry():
     assert balance == pytest.approx(693.0)
 
 
+def test_gateio_rejects_singleton_account_row_with_mismatched_currency():
+    bot = GateIOBot.__new__(GateIOBot)
+    bot.exchange = "gateio"
+    bot.quote = "USDT"
+    bot.uid = "existing"
+    bot.cca = SimpleNamespace(uid="existing")
+    bot.ccp = None
+    bot.log_once = lambda msg: None
+
+    with pytest.raises(KeyError, match="settle currency USDT"):
+        bot._get_balance(
+            {
+                "USDT": {"total": 0.0},
+                "info": [
+                    {
+                        "user": 1,
+                        "currency": "BTC",
+                        "margin_mode_name": "multi_currency",
+                        "cross_available": "1.0",
+                        "cross_initial_margin": "0.0",
+                        "cross_order_margin": "0.0",
+                        "cross_unrealised_pnl": "0.0",
+                    }
+                ],
+            }
+        )
+
+
+def test_gateio_accepts_singleton_account_row_when_currency_omitted():
+    bot = GateIOBot.__new__(GateIOBot)
+    bot.exchange = "gateio"
+    bot.quote = "USDT"
+    bot.uid = "existing"
+    bot.cca = SimpleNamespace(uid="existing")
+    bot.ccp = None
+    bot.log_once = lambda msg: None
+
+    balance = bot._get_balance(
+        {
+            "USDT": {"total": 0.0},
+            "info": [
+                {
+                    "user": 1,
+                    "margin_mode_name": "multi_currency",
+                    "cross_available": "680.0",
+                    "cross_initial_margin": "10.0",
+                    "cross_order_margin": "5.0",
+                    "cross_unrealised_pnl": "2.0",
+                }
+            ],
+        }
+    )
+
+    assert balance == pytest.approx(693.0)
+
+
 @pytest.mark.parametrize(
     "field,value",
     [

--- a/tests/ccxt_upgrade/test_order_contracts.py
+++ b/tests/ccxt_upgrade/test_order_contracts.py
@@ -1236,6 +1236,7 @@ def test_gateio_get_balance_reconstructs_stable_multi_currency_margin_balance():
             "info": [
                 {
                     "user": 16770081,
+                    "currency": "USDT",
                     "margin_mode_name": "multi_currency",
                     "cross_available": "724.95615",
                     "cross_initial_margin": "12.5",
@@ -1267,6 +1268,7 @@ def test_gateio_multi_currency_balance_is_stable_across_order_margin_reservation
             "info": [
                 {
                     "user": 16770081,
+                    "currency": "USDT",
                     "margin_mode_name": "multi_currency",
                     "cross_available": str(available),
                     "cross_initial_margin": "10.0",
@@ -1279,6 +1281,44 @@ def test_gateio_multi_currency_balance_is_stable_across_order_margin_reservation
     assert bot._get_balance(payload(677.0, 3.0)) == pytest.approx(690.0)
     assert bot._get_balance(payload(670.0, 10.0)) == pytest.approx(690.0)
     assert bot._get_balance(payload(672.5, 10.0, 2.5)) == pytest.approx(690.0)
+
+
+def test_gateio_selects_quote_matched_account_row_not_first_info_entry():
+    bot = GateIOBot.__new__(GateIOBot)
+    bot.exchange = "gateio"
+    bot.quote = "USDT"
+    bot.uid = "existing"
+    bot.cca = SimpleNamespace(uid="existing")
+    bot.ccp = None
+    bot.log_once = lambda msg: None
+
+    balance = bot._get_balance(
+        {
+            "USDT": {"total": 0.0},
+            "info": [
+                {
+                    "user": 1,
+                    "currency": "BTC",
+                    "margin_mode_name": "multi_currency",
+                    "cross_available": "1.0",
+                    "cross_initial_margin": "0.0",
+                    "cross_order_margin": "0.0",
+                    "cross_unrealised_pnl": "0.0",
+                },
+                {
+                    "user": 2,
+                    "currency": "USDT",
+                    "margin_mode_name": "multi_currency",
+                    "cross_available": "680.0",
+                    "cross_initial_margin": "10.0",
+                    "cross_order_margin": "5.0",
+                    "cross_unrealised_pnl": "2.0",
+                },
+            ],
+        }
+    )
+
+    assert balance == pytest.approx(693.0)
 
 
 @pytest.mark.parametrize(
@@ -1300,6 +1340,7 @@ def test_gateio_multi_currency_balance_rejects_non_finite_components(field, valu
     bot.log_once = lambda msg: None
     primary = {
         "user": 16770081,
+        "currency": "USDT",
         "margin_mode_name": "multi_currency",
         "cross_available": "680.0",
         "cross_initial_margin": "10.0",
@@ -1308,8 +1349,35 @@ def test_gateio_multi_currency_balance_rejects_non_finite_components(field, valu
     }
     primary[field] = value
 
-    with pytest.raises(ValueError, match="non-finite multi-currency margin balance"):
+    with pytest.raises(ValueError, match="non-finite multi-currency field"):
         bot._get_balance({"USDT": {"total": 0.0}, "info": [primary]})
+
+
+def test_gateio_multi_currency_balance_rejects_missing_required_fields():
+    bot = GateIOBot.__new__(GateIOBot)
+    bot.exchange = "gateio"
+    bot.quote = "USDT"
+    bot.uid = "existing"
+    bot.cca = SimpleNamespace(uid="existing")
+    bot.ccp = None
+    bot.log_once = lambda msg: None
+
+    with pytest.raises(KeyError, match="cross_order_margin"):
+        bot._get_balance(
+            {
+                "USDT": {"total": 0.0},
+                "info": [
+                    {
+                        "user": 16770081,
+                        "currency": "USDT",
+                        "margin_mode_name": "multi_currency",
+                        "cross_available": "680.0",
+                        "cross_initial_margin": "10.0",
+                        "cross_unrealised_pnl": "0.0",
+                    }
+                ],
+            }
+        )
 
 
 def test_gateio_get_balance_uses_total_for_classic_margin():
@@ -1327,6 +1395,7 @@ def test_gateio_get_balance_uses_total_for_classic_margin():
             "info": [
                 {
                     "user": "16770081",
+                    "currency": "USDT",
                     "margin_mode_name": "classic",
                     "cross_available": "724.95615",
                 }
@@ -1347,13 +1416,14 @@ def test_gateio_get_balance_rejects_invalid_uid_before_caching(raw_uid):
     bot.ccp = SimpleNamespace()
     bot.log_once = lambda msg: None
 
-    with pytest.raises(ValueError, match=r"info\[0\]\.user"):
+    with pytest.raises(ValueError, match="account user"):
         bot._get_balance(
             {
                 "USDT": {"total": 543.21},
                 "info": [
                     {
                         "user": raw_uid,
+                        "currency": "USDT",
                         "margin_mode_name": "classic",
                         "cross_available": "724.95615",
                     }

--- a/tests/test_balance_composition.py
+++ b/tests/test_balance_composition.py
@@ -303,6 +303,29 @@ def test_gateio_balance_composition_rejects_singleton_mismatched_currency():
     )
 
 
+def test_gateio_balance_composition_labels_quote_derived_asset_provenance():
+    snapshot = normalize_gateio_balance_composition(
+        {
+            "info": [
+                {
+                    "margin_mode_name": "multi_currency",
+                    "cross_available": "670.0",
+                    "cross_initial_margin": "10.0",
+                    "cross_order_margin": "12.5",
+                    "cross_unrealised_pnl": "2.5",
+                }
+            ]
+        },
+        quote="USDT",
+    )
+
+    row = snapshot["asset_balances"][0]
+    assert row["asset"] == "USDT"
+    assert row["field_provenance"]["asset"] == "quote"
+    public = public_balance_composition(snapshot)
+    assert public["asset_balances"][0]["field_provenance"]["asset"] == "quote"
+
+
 def test_ccxt_balance_composition_public_contract_keeps_bounded_provenance():
     public = public_balance_composition(
         normalize_ccxt_balance_composition(

--- a/tests/test_balance_composition.py
+++ b/tests/test_balance_composition.py
@@ -11,6 +11,7 @@ from live.balance_composition import (
     format_balance_composition_sample,
     malformed_balance_composition,
     normalize_ccxt_balance_composition,
+    normalize_gateio_balance_composition,
     normalize_hyperliquid_unified_balance_composition,
     normalize_okx_balance_composition,
     public_balance_composition,
@@ -204,6 +205,80 @@ def test_ccxt_balance_composition_is_explicit_for_missing_or_partial_fields():
             "amount": 0.0,
         },
     ]
+
+
+def test_gateio_balance_composition_exposes_multi_currency_margin_components():
+    snapshot = normalize_gateio_balance_composition(
+        {
+            "total": {"USDT": 0.0},
+            "info": [
+                {
+                    "currency": "BTC",
+                    "margin_mode_name": "multi_currency",
+                    "cross_available": "1",
+                    "cross_initial_margin": "0",
+                    "cross_order_margin": "0",
+                    "cross_unrealised_pnl": "0",
+                },
+                {
+                    "currency": "USDT",
+                    "margin_mode_name": "multi_currency",
+                    "cross_available": "670.0",
+                    "cross_initial_margin": "10.0",
+                    "cross_order_margin": "12.5",
+                    "cross_unrealised_pnl": "2.5",
+                    "secret": "must-not-leak",
+                },
+            ],
+        },
+        quote="USDT",
+    )
+
+    assert snapshot["status"] == "available"
+    assert snapshot["source"] == "gateio.info.futures_account"
+    assert snapshot["count"] == 1
+    row = snapshot["asset_balances"][0]
+    assert row == {
+        "asset": "USDT",
+        "amount": 690.0,
+        "free_amount": 670.0,
+        "used_amount": 22.5,
+        "unrealized_pnl": 2.5,
+        "field_provenance": {
+            "asset": "currency",
+            "amount": "wallet_balance",
+            "free_amount": "cross_available",
+            "used_amount": "cross_margin",
+            "unrealized_pnl": "cross_unrealised_pnl",
+        },
+    }
+    assert "secret" not in str(snapshot)
+    public = public_balance_composition(snapshot)
+    assert public["source"] == "gateio.info.futures_account"
+    assert public["asset_balances"][0]["free_amount"] == 670.0
+    assert public["asset_balances"][0]["used_amount"] == 22.5
+
+
+def test_gateio_balance_composition_marks_malformed_multi_currency_fields():
+    snapshot = normalize_gateio_balance_composition(
+        {
+            "info": [
+                {
+                    "currency": "USDT",
+                    "margin_mode_name": "multi_currency",
+                    "cross_available": "670.0",
+                    "cross_initial_margin": "nan",
+                    "cross_order_margin": "0",
+                    "cross_unrealised_pnl": "0",
+                }
+            ]
+        },
+        quote="USDT",
+    )
+
+    assert snapshot == malformed_balance_composition(
+        source="gateio.info.futures_account", reason="missing_cross_fields"
+    )
 
 
 def test_ccxt_balance_composition_public_contract_keeps_bounded_provenance():

--- a/tests/test_balance_composition.py
+++ b/tests/test_balance_composition.py
@@ -281,6 +281,28 @@ def test_gateio_balance_composition_marks_malformed_multi_currency_fields():
     )
 
 
+def test_gateio_balance_composition_rejects_singleton_mismatched_currency():
+    snapshot = normalize_gateio_balance_composition(
+        {
+            "info": [
+                {
+                    "currency": "BTC",
+                    "margin_mode_name": "multi_currency",
+                    "cross_available": "1.0",
+                    "cross_initial_margin": "0.0",
+                    "cross_order_margin": "0.0",
+                    "cross_unrealised_pnl": "0.0",
+                }
+            ]
+        },
+        quote="USDT",
+    )
+
+    assert snapshot == malformed_balance_composition(
+        source="gateio.info.futures_account", reason="missing_account"
+    )
+
+
 def test_ccxt_balance_composition_public_contract_keeps_bounded_provenance():
     public = public_balance_composition(
         normalize_ccxt_balance_composition(


### PR DESCRIPTION
## Summary

- Multi-currency Gate futures balance must not treat `cross_available` as wallet equity: that field is spendable margin and moves with order-margin reservation/release.
- Master already reconstructs the trading wallet as `cross_available + cross_initial_margin + cross_order_margin - cross_unrealised_pnl` (PR #1414). That remains the risk/sizing source of truth.
- This PR completes the remaining hardening around that contract:
  - select the unique settle-currency futures-account row (`currency` == quote) instead of blindly using `info[0]`
  - fail closed on missing/non-finite multi-currency margin fields
  - publish bounded Gate balance-composition diagnostics (wallet amount, available margin, reserved IM+order margin, unrealized PnL) so `balance.changed` events no longer report `unsupported_connector`
  - document the contract and add regression coverage for row selection and composition

Composition remains observability-only and never replaces the trading wallet balance.

## Verification

- Offline code review of the Gate multi-currency parser and Gate futures account schema (`cross_available` is available cross-margin balance, distinct from margin/equity components): [Gate futures accounts](https://www.gate.com/docs/developers/apiv4/en/futures/).
- No authenticated Gate probes were used.

## Validation

```bash
PYTHONPATH=src python -m pytest -q \
  tests/test_balance_composition.py \
  tests/ccxt_upgrade/test_order_contracts.py -k gateio
PYTHONPATH=src python -m compileall -q src/exchanges/gateio.py src/live/balance_composition.py
PYTHONPATH=src python src/tools/check_ai_docs.py
```

## Test plan

- [x] Multi-currency wallet balance stays stable across order-margin reservation swaps
- [x] Quote-matched account row is preferred over a leading unrelated row
- [x] Missing/non-finite cross-margin fields fail closed
- [x] Gate composition publishes free/used/wallet/UPL components without leaking raw secrets
- [ ] After merge/deploy to multi-currency Gate bots, confirm `balance.changed` composition is available and raw balance no longer jumps with pure create/cancel churn