### PR TITLE
Harden coin override resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Make coin overrides explicit, typed patches instead of hydrated config diffs. File values now
+  precede inline values without losing intentional resets to defaults, false, or zero; each resolved
+  per-coin config is validated before use; normalized symbol collisions and strategy-kind mismatches
+  are rejected; and configured override files fail closed when missing, unreadable, malformed, or
+  invalid. Live and backtest consumers now resolve canonical grouped bot fields consistently.
+
 - Refresh hardcoded schema defaults and the mirrored example config from the latest
   long-only trailing-martingale canon candidate: update `bot.long` parameters,
   `optimize.bounds`, and `live.approved_coins` (replace CRO with TON; reorder coin

--- a/docs/coin_overrides.md
+++ b/docs/coin_overrides.md
@@ -13,23 +13,31 @@ Allowed fields are intentionally limited:
   allowlist in `src/config/overrides.py:get_allowed_modifications()` for the full set).
 - **Live flags**: `forced_mode_long`, `forced_mode_short`, `leverage`.
 
-Not overrideable: approved/ignored coins, exchange settings, arbitrary new keys—anything outside the
-allowlist is ignored. Flat v7-style strategy keys such as `entry_grid_spacing_pct` are rejected;
-use the nested v8 strategy path instead.
+Not overrideable: approved/ignored coins, exchange settings, and arbitrary new keys. A disallowed or
+unknown inline override is rejected with its full path. A full override config file may contain
+ordinary non-override config fields; those fields are validated as part of that config and then
+filtered out. Flat v7-style strategy keys such as `entry_grid_spacing_pct` are rejected; use the
+nested v8 strategy path instead.
 
 ## How overrides are loaded
 
 1) `coin_overrides` is read from your main config. Keys should be coin tickers (e.g., `"XRP"`).
 2) If `override_config_path` is provided, the file is loaded. Relative paths are resolved against
    `live.base_config_path` (if set) or the current working directory.
-3) The override content is filtered to the allowed fields and diffed against the base config; only
-   differing allowed fields are kept.
-4) During live startup, override keys are remapped to exchange symbols via `coin_to_symbol`; config
+3) Explicit allowed values are extracted without hydrating omitted fields or diffing against the
+   base config. This preserves intentional resets to a global/default value, `false`, or zero.
+4) File values are applied first and inline values are applied second. Inline values therefore win
+   at the individual leaf they specify.
+5) The patch is type-checked, merged with the global config, and the resulting complete per-coin
+   config is validated before startup continues.
+6) During live startup, override keys are remapped to exchange symbols via `coin_to_symbol`; config
    lookups prefer these per-symbol values. In backtests, `prep_backtest_args` merges the override
-   bot diffs directly per coin.
+   bot patch directly per coin.
 
-If the file cannot be found or yields no allowed diffs, the override is effectively empty and the
-base values are used.
+Configured override files are required inputs. A missing, unreadable, malformed, or invalid file
+stops configuration loading with the coin and path identified. The file's `live.strategy_kind`, if
+present, must match the global strategy kind; per-coin strategy-kind changes are not supported.
+Coin keys that normalize to the same ticker are also rejected instead of overwriting each other.
 
 ## Inline override example
 
@@ -129,8 +137,8 @@ Main config:
 - Run with `--log-level debug` to see which overrides were initialized and when a per-symbol override
   value is used.
 - Ensure `live.base_config_path` is set so relative `override_config_path` values resolve.
-- Verify the override file changes *allowed* fields versus the base config; disallowed keys are
-  dropped unless they are rejected flat strategy keys.
+- Verify that inline patches contain only allowed fields. Non-override fields in a complete file are
+  filtered after the file is validated.
 - Don’t expect per-override approved coin lists to take effect; keep the master coin list in the
   main config.
 - A per-coin `unstuck.loss_allowance_pct` overrides only the selected coin+side's loss allowance
@@ -139,8 +147,11 @@ Main config:
 
 ## Common pitfalls
 
-- Bad paths: `override_config_path` not found → override silently empty.
-- Disallowed keys: fields outside the allowlist are ignored; flat strategy keys are rejected with an
-  error so stale v7-style overrides cannot disappear silently.
-- No diff: if the override matches the base on allowed fields, nothing is applied.
-- Mis-keyed coins: if a coin name cannot be mapped to an exchange symbol, the override is discarded.
+- Bad paths: a missing or unreadable `override_config_path` is fatal.
+- Disallowed inline keys: fields outside the allowlist are rejected; flat strategy keys are also
+  rejected so stale v7-style overrides cannot disappear silently.
+- Explicit reset: an allowed value equal to the global/default value is still retained and may
+  override a different value from `override_config_path`.
+- Mis-keyed coins: invalid coin names and normalized-name collisions are rejected.
+- Wrong types: strings such as `"false"`, nulls, and non-finite numbers are rejected rather than
+  coerced into trading parameters.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -395,10 +395,19 @@ See [docs/forager.md](forager.md) for a full description of motivation, ranking 
         close.retracement_volatility_1h_weight, close.retracement_volatility_1m_weight
       ]
       ```
-    - `config.bot.long/short` shared groups:
+    - `config.bot.long/short` shared fields:
       ```
       [
-        risk.*, forager.*, hsl.*, unstuck.*, wallet_exposure_limit
+        risk.position_exposure_enforcer_enabled,
+        risk.position_exposure_enforcer_threshold,
+        risk.we_excess_allowance_pct,
+        risk.we_excess_allowance_mode,
+        unstuck.close_pct,
+        unstuck.ema_dist,
+        unstuck.enabled,
+        unstuck.loss_allowance_pct,
+        unstuck.threshold,
+        wallet_exposure_limit
       ]
       ```
     - `config.live`:
@@ -406,7 +415,7 @@ See [docs/forager.md](forager.md) for a full description of motivation, ranking 
     [forced_mode_long, forced_mode_short, leverage]
     ```
   - Examples:
-    - `{"COIN1": {"override_config_path": "path/to/override_config.json"}}` -- Will attempt to load "path/to/override_config.json" and apply all eligible parameters from there for COIN1
+    - `{"COIN1": {"override_config_path": "path/to/override_config.json"}}` -- Loads the required file and applies all explicitly present eligible parameters from it for COIN1
     - `{"COIN2": {"override_config_path": "path/to/other_override_config.json", "bot": {"long": {"strategy": {"trailing_martingale": {"close": {"threshold_base_pct": 0.005}}}}}}}` -- Will attempt to load `"path/to/other_override_config.json"` first, and apply the given close threshold override after.
     - `{"COIN3": {"bot": {"short": {"strategy": {"trailing_martingale": {"entry": {"initial_qty_pct": 0.01}}}}}, "live": {"forced_mode_long": "panic"}}}` -- Will apply given overrides for COIN3.
 - **forced_modes**:

--- a/docs/plans/coin_overrides_overhaul.md
+++ b/docs/plans/coin_overrides_overhaul.md
@@ -83,7 +83,7 @@ instead of extending the current feature branch indefinitely.
 - [x] Run the deterministic offline fake-live harness with file and inline overrides,
   including a restart scenario.
 - [x] Inspect the exact diff and staged paths for public-repository safety.
-- [ ] Open a regular ready-for-review PR.
+- [x] Open a regular ready-for-review PR.
 - [ ] Request Codex review and record the reviewed head SHA.
 - [ ] Address actionable findings, add regressions, rerun proportional validation, and
   request re-review until no unresolved actionable findings remain.
@@ -159,7 +159,7 @@ instead of extending the current feature branch indefinitely.
 - [x] Foundation branch created from current `origin/master`.
 - [x] Execution checklist persisted.
 - [x] PR 1 implementation and author validation complete.
-- [ ] PR 1 under review.
+- [x] PR 1 under review.
 - [ ] PR 1 merged.
 - [ ] PR 2 merged.
 - [ ] PR 3 merged.

--- a/docs/plans/coin_overrides_overhaul.md
+++ b/docs/plans/coin_overrides_overhaul.md
@@ -1,0 +1,165 @@
+# Coin Overrides Overhaul Plan
+
+## Objective
+
+Make per-coin configuration overrides deterministic, validated, and shared by live and
+backtest execution. Deliver the work in small, independently reviewable pull requests
+instead of extending the current feature branch indefinitely.
+
+## Agreed policy
+
+- [x] Pause further expansion of PR #1462 while the common override foundation is built.
+- [x] Keep `bot.<pside>.unstuck.loss_allowance_pct` overridable.
+- [x] Remove `bot.<pside>.risk.we_excess_allowance_mode` from the override surface.
+- [x] Add `bot.<pside>.unstuck.ema_gating_enabled` to the override surface.
+- [x] Add `bot.<pside>.entry_cooldown_minutes` to the override surface.
+- [x] Make the complete `bot.<pside>.hsl.*` group overridable when that side's
+  `hsl_signal_mode` is `"coin"`.
+- [x] Do not add any new `live.*` overrides in this series.
+
+## Cross-PR invariants
+
+- A coin override is an explicit, typed patch. Missing values never become overrides
+  through default hydration.
+- Precedence is deterministic: global configuration, then file-based coin patch, then
+  inline coin patch.
+- An explicitly supplied value remains meaningful even when it equals a schema default,
+  is false, or is zero.
+- Every effective per-coin configuration is validated before trading or simulation uses
+  it. Invalid overrides fail with the coin, source, and parameter path identified.
+- Live and backtest execution consume the same resolved per-coin configuration.
+- Coin-symbol normalization collisions are rejected rather than silently overwriting one
+  patch with another.
+- Strategy-kind mismatches are rejected until mixed per-coin strategy kinds are explicitly
+  designed and supported.
+- Missing, unreadable, malformed, or invalid configured override files fail closed.
+- Parsing and runtime compilation are idempotent; repeated preparation must not lose patch
+  provenance or change the result.
+- Documentation examples use only public repository fixtures under `configs/examples/`.
+
+## PR 1: canonical override-patch foundation
+
+### Design and implementation
+
+- [x] Inventory every current override producer and consumer in live, backtest, config
+  loading, and runtime compilation.
+- [x] Define one canonical internal representation for a per-coin patch, including source
+  metadata needed for actionable errors.
+- [x] Extract only explicitly present values from override inputs; do not infer patches by
+  diffing hydrated configurations.
+- [x] Canonicalize supported legacy input spellings exactly once at the parse boundary.
+- [x] Centralize file and inline precedence in one resolver.
+- [x] Validate patch types and values, then validate the fully resolved per-coin config.
+- [x] Reject normalized symbol collisions and strategy-kind mismatches.
+- [x] Make configured override-file failures fatal and actionable.
+- [x] Preserve the currently documented override allowlist in this PR; policy changes are
+  reserved for PR 2 and PR 3.
+- [x] Route live and backtest callers through the same resolver.
+- [x] Update `docs/coin_overrides.md` to describe the actual foundation contract.
+- [x] Add an `Unreleased` changelog entry for user-visible correctness changes.
+
+### Regression coverage
+
+- [x] Cover every currently allowed leaf for both long and short sides.
+- [x] Cover file-only, inline-only, and file-plus-inline precedence.
+- [x] Cover explicit resets to global/default values, `false`, and zero.
+- [x] Cover canonical and supported legacy input paths.
+- [x] Cover unknown and disallowed paths without silently accepting misspellings.
+- [x] Cover missing, unreadable, malformed, and structurally invalid files.
+- [x] Cover normalized-symbol collisions.
+- [x] Cover strategy-kind mismatches.
+- [x] Cover booleans supplied as strings, nulls, non-finite numbers, wrong scalar types,
+  and cross-field validation failures.
+- [x] Cover repeated preparation/compilation and confirm idempotence.
+- [x] Cover equivalent live and backtest resolution results.
+
+### Validation and release gate
+
+- [x] Run focused override and config tests.
+- [x] Run the broader Python test suite required by `docs/ai/validation.md`.
+- [x] Rebuild and verify the Rust extension before Rust-backed validation.
+- [x] Run at least one real backtest with no coin patch and one with a public coin patch;
+  verify unchanged baseline behavior and the intended per-coin delta.
+- [x] Run the deterministic offline fake-live harness with file and inline overrides,
+  including a restart scenario.
+- [x] Inspect the exact diff and staged paths for public-repository safety.
+- [ ] Open a regular ready-for-review PR.
+- [ ] Request Codex review and record the reviewed head SHA.
+- [ ] Address actionable findings, add regressions, rerun proportional validation, and
+  request re-review until no unresolved actionable findings remain.
+- [ ] Require all CI checks green on the current head.
+- [ ] Merge the reviewed current head and mark this section complete.
+
+## PR 2: override policy and entry cooldown
+
+### Implementation
+
+- [ ] Branch from the merged PR 1 result.
+- [ ] Express the allowlist as a maintainable parameter policy rather than scattered
+  conditionals.
+- [ ] Remove `bot.<pside>.risk.we_excess_allowance_mode` from allowed overrides with an
+  actionable migration error.
+- [ ] Keep `bot.<pside>.unstuck.loss_allowance_pct` allowed.
+- [ ] Add `bot.<pside>.unstuck.ema_gating_enabled`.
+- [ ] Add `bot.<pside>.entry_cooldown_minutes`.
+- [ ] Update reference documentation and the changelog.
+
+### Validation and release gate
+
+- [ ] Add table-driven policy tests for every added, retained, and removed parameter.
+- [ ] Prove independent long/short behavior and file/inline precedence.
+- [ ] Run focused and broader Python tests.
+- [ ] Rebuild and verify the Rust extension.
+- [ ] Run real backtest comparisons that exercise entry cooldown and unstuck EMA gating.
+- [ ] Run deterministic offline fake-live scenarios that exercise the new parameters.
+- [ ] Open a regular ready-for-review PR and request Codex review.
+- [ ] Address findings and repeat review plus validation until the current head is green.
+- [ ] Merge the reviewed current head and mark this section complete.
+
+## PR 3: conditional per-coin HSL group
+
+### Implementation
+
+- [ ] Branch from the merged PR 2 result.
+- [ ] Allow the complete `bot.<pside>.hsl.*` group only when that side's effective
+  `hsl_signal_mode` is `"coin"`.
+- [ ] Define and test precedence when the signal mode and HSL fields come from different
+  sources.
+- [ ] Reject HSL coin patches in non-coin signal modes with actionable errors.
+- [ ] Validate every resolved HSL cross-field invariant.
+- [ ] Update HSL and coin-override documentation and the changelog.
+
+### Validation and release gate
+
+- [ ] Add table-driven coverage for every HSL field on both sides.
+- [ ] Cover global, file, and inline signal-mode transitions and invalid combinations.
+- [ ] Run focused and broader Python tests.
+- [ ] Rebuild and verify the Rust extension.
+- [ ] Run real HSL backtests with public fixtures and compare expected behavior.
+- [ ] Run deterministic offline fake-live HSL scenarios, including restart behavior.
+- [ ] Open a regular ready-for-review PR and request Codex review.
+- [ ] Address findings and repeat review plus validation until the current head is green.
+- [ ] Merge the reviewed current head and mark this section complete.
+
+## Reviewer loop used for every PR
+
+1. [ ] Refresh the target branch and establish the exact target and head SHAs.
+2. [ ] Run author validation on the exact proposed head.
+3. [ ] Request Codex review and inspect thread-level resolution state.
+4. [ ] Classify each finding against code, tests, and the documented contract.
+5. [ ] Fix actionable findings and add regression coverage. If a finding is incorrect,
+   reply with evidence and leave it open for reviewer reconsideration.
+6. [ ] Rerun proportional validation and request another review on the new head.
+7. [ ] Repeat until CI is green and no actionable review thread remains unresolved.
+8. [ ] Merge only the reviewed head, then begin the next PR from the updated target branch.
+
+## Progress
+
+- [x] Audit completed and parameter-policy decisions confirmed.
+- [x] Foundation branch created from current `origin/master`.
+- [x] Execution checklist persisted.
+- [x] PR 1 implementation and author validation complete.
+- [ ] PR 1 under review.
+- [ ] PR 1 merged.
+- [ ] PR 2 merged.
+- [ ] PR 3 merged.

--- a/docs/plans/coin_overrides_overhaul.md
+++ b/docs/plans/coin_overrides_overhaul.md
@@ -84,7 +84,7 @@ instead of extending the current feature branch indefinitely.
   including a restart scenario.
 - [x] Inspect the exact diff and staged paths for public-repository safety.
 - [x] Open a regular ready-for-review PR.
-- [ ] Request Codex review and record the reviewed head SHA.
+- [x] Request Codex review; first pass reviewed `abb40a4840e64a834a50077540d0a2d5c2894313`.
 - [ ] Address actionable findings, add regressions, rerun proportional validation, and
   request re-review until no unresolved actionable findings remain.
 - [ ] Require all CI checks green on the current head.

--- a/src/config/overrides.py
+++ b/src/config/overrides.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import math
 import os
 from copy import deepcopy
 from typing import Callable
@@ -7,10 +8,15 @@ from typing import Callable
 from pure_funcs import sort_dict_keys
 from utils import symbol_to_coin
 
-from .load import load_prepared_config
+from .load import load_input_config, prepare_config
 from .log_output import log_config_message
-from .shared_bot import BOT_GROUP_FIELD_MAP
-from .strategy import TRAILING_GRID_V7_FLAT_ONLY_KEYS, get_strategy_param_keys
+from .schema import get_template_config
+from .shared_bot import BOT_GROUP_FIELD_MAP, canonicalize_shared_bot_side
+from .strategy import (
+    TRAILING_GRID_V7_FLAT_ONLY_KEYS,
+    get_strategy_param_keys,
+    normalize_strategy_kind,
+)
 from .strategy_spec import get_supported_strategy_kinds
 from .transform_log import record_transform
 from risk_limits import normalize_we_excess_allowance_mode
@@ -32,7 +38,7 @@ def apply_allowed_modifications(src, modifications, allowed_overrides, return_fu
                 return True
         return False
 
-    def _apply_recursive(target_dict, mod_dict, allowed_dict, src_dict=None):
+    def _apply_recursive(target_dict, mod_dict, allowed_dict):
         for key, mod_value in mod_dict.items():
             if key not in allowed_dict:
                 continue
@@ -46,7 +52,6 @@ def apply_allowed_modifications(src, modifications, allowed_overrides, return_fu
                     target_dict[key],
                     mod_value,
                     allowed_value,
-                    src_dict[key] if src_dict and key in src_dict else None,
                 )
                 if not return_full and not target_dict[key]:
                     target_dict.pop(key, None)
@@ -56,11 +61,9 @@ def apply_allowed_modifications(src, modifications, allowed_overrides, return_fu
                 if return_full:
                     target_dict[key] = deepcopy(mod_value)
                 else:
-                    src_val = src_dict.get(key) if src_dict else None
-                    if src_val != mod_value:
-                        target_dict[key] = deepcopy(mod_value)
+                    target_dict[key] = deepcopy(mod_value)
 
-    _apply_recursive(target, modifications, allowed_overrides, src if return_full else src)
+    _apply_recursive(target, modifications, allowed_overrides)
     return result
 
 
@@ -99,6 +102,13 @@ _UNSUPPORTED_FLAT_STRATEGY_OVERRIDE_KEYS = {
     "entry_weight_volatility_1m",
     "entry_we_weight",
 } | TRAILING_GRID_V7_FLAT_ONLY_KEYS
+
+_RUNTIME_GENERATED_OVERRIDE_KEYS = {
+    "filter_volatility_drop_pct",
+    "filter_volatility_ema_span_1m",
+    "filter_volume_drop_pct",
+    "filter_volume_ema_span_1m",
+}
 
 
 def _reject_flat_strategy_coin_overrides(overrides: dict, *, coin: str) -> None:
@@ -205,27 +215,303 @@ def nested_update(base_dict, update_dict):
     return base_dict
 
 
+def _unwrap_override_document(document: dict, *, source: str) -> dict:
+    if not isinstance(document, dict):
+        raise TypeError(f"{source} must contain a configuration object")
+    nested = document.get("config")
+    if isinstance(nested, dict) and ("bot" in nested or "live" in nested):
+        return deepcopy(nested)
+    return deepcopy(document)
+
+
+def _format_override_path(coin: str, parts: tuple[str, ...]) -> str:
+    return ".".join(("coin_overrides", coin, *parts))
+
+
+def _extract_allowed_patch(
+    document: dict,
+    *,
+    coin: str,
+    source: str,
+    strict: bool,
+    strategy_kind: str,
+    strip_runtime_aliases: bool = False,
+) -> dict:
+    """Extract explicitly supplied allowed leaves without hydrating defaults."""
+
+    source_doc = _unwrap_override_document(document, source=source)
+    _reject_flat_strategy_coin_overrides(source_doc, coin=coin)
+    source_live = source_doc.get("live")
+    if isinstance(source_live, dict) and "strategy_kind" in source_live:
+        source_strategy_kind = normalize_strategy_kind(source_live["strategy_kind"])
+        if source_strategy_kind != strategy_kind:
+            raise ValueError(
+                f"{source}.live.strategy_kind {source_strategy_kind!r} does not match "
+                f"the global strategy_kind {strategy_kind!r}"
+            )
+    bot = source_doc.get("bot")
+    if bot is not None and not isinstance(bot, dict):
+        raise TypeError(f"{source}.bot must be a dict")
+    if isinstance(bot, dict):
+        for pside in ("long", "short"):
+            side = bot.get(pside)
+            if side is None:
+                continue
+            if not isinstance(side, dict):
+                raise TypeError(f"{source}.bot.{pside} must be a dict")
+            if strip_runtime_aliases:
+                for generated_key in _RUNTIME_GENERATED_OVERRIDE_KEYS:
+                    side.pop(generated_key, None)
+            canonicalize_shared_bot_side(
+                side,
+                path_prefix=(source, "bot", pside),
+                seed_missing_groups=False,
+            )
+            strategy = side.get("strategy")
+            if strategy is None:
+                continue
+            if not isinstance(strategy, dict):
+                raise TypeError(f"{source}.bot.{pside}.strategy must be a dict")
+            unsupported = sorted(set(strategy) - set(get_supported_strategy_kinds()))
+            if unsupported:
+                raise ValueError(
+                    f"{source}.bot.{pside}.strategy has unsupported strategy kind(s): "
+                    + ", ".join(unsupported)
+                )
+            mismatched = sorted(kind for kind in strategy if kind != strategy_kind)
+            if mismatched:
+                declares_strategy_kind = (
+                    isinstance(source_live, dict) and "strategy_kind" in source_live
+                )
+                if strict or not declares_strategy_kind:
+                    raise ValueError(
+                        f"{source}.bot.{pside}.strategy.{mismatched[0]} cannot override active "
+                        f"strategy_kind {strategy_kind!r}"
+                    )
+                for kind in mismatched:
+                    strategy.pop(kind, None)
+
+    allowed = get_allowed_modifications()
+
+    def visit(value, policy, path: tuple[str, ...]):
+        if policy is True:
+            if value is None:
+                raise TypeError(f"{_format_override_path(coin, path)} may not be null")
+            return deepcopy(value)
+        if not isinstance(policy, dict):
+            if strict:
+                raise ValueError(f"{_format_override_path(coin, path)} is not overridable")
+            return None
+        if not isinstance(value, dict):
+            raise TypeError(f"{_format_override_path(coin, path)} must be a dict")
+        result = {}
+        for key, child in value.items():
+            if key not in policy:
+                if strict:
+                    raise ValueError(
+                        f"{_format_override_path(coin, path + (key,))} is not overridable"
+                    )
+                continue
+            child_value = visit(child, policy[key], path + (key,))
+            if child_value is not None and (not isinstance(child_value, dict) or child_value):
+                result[key] = child_value
+        return result
+
+    patch = {}
+    for root in ("bot", "live"):
+        if root not in source_doc:
+            continue
+        root_patch = visit(source_doc[root], allowed[root], (root,))
+        if root_patch:
+            patch[root] = root_patch
+    if strict:
+        unknown_roots = sorted(set(source_doc) - {"bot", "live", "override_config_path"})
+        if unknown_roots:
+            raise ValueError(
+                f"coin_overrides.{coin} has unsupported key(s): " + ", ".join(unknown_roots)
+            )
+    return patch
+
+
+def _iter_patch_leaves(value, path=()):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            yield from _iter_patch_leaves(child, path + (key,))
+        return
+    yield path, value
+
+
+def _get_nested_value(config: dict, path: tuple[str, ...]):
+    current = config
+    for key in path:
+        if not isinstance(current, dict) or key not in current:
+            return None
+        current = current[key]
+    return current
+
+
+def _validate_patch_leaf_types(
+    config: dict, patch: dict, *, coin: str, origin: str
+) -> None:
+    template = get_template_config()
+    for path, value in _iter_patch_leaves(patch):
+        display_path = f"{_format_override_path(coin, path)} ({origin})"
+        reference = _get_nested_value(config, path)
+        if reference is None:
+            reference = _get_nested_value(template, path)
+        if isinstance(value, bool):
+            if not isinstance(reference, bool):
+                raise TypeError(f"{display_path} must be numeric, not a boolean")
+            continue
+        if isinstance(value, (int, float)):
+            if isinstance(reference, (bool, str)):
+                expected = "boolean" if isinstance(reference, bool) else "string"
+                raise TypeError(f"{display_path} must be a {expected}, not numeric")
+            if not math.isfinite(float(value)):
+                raise ValueError(f"{display_path} must be finite")
+            continue
+        if isinstance(value, str):
+            if path in {
+                ("live", "forced_mode_long"),
+                ("live", "forced_mode_short"),
+            }:
+                if value:
+                    try:
+                        expand_PB_mode(value)
+                    except Exception as exc:
+                        raise ValueError(f"{display_path} has invalid mode {value!r}") from exc
+            elif not isinstance(reference, str):
+                raise TypeError(f"{display_path} must be numeric or boolean, not a string")
+            continue
+        raise TypeError(
+            f"{display_path} must be a scalar value; got {type(value).__name__}"
+        )
+
+    for pside in ("long", "short"):
+        side_patch = patch.get("bot", {}).get(pside, {})
+        if "wallet_exposure_limit" in side_patch:
+            value = side_patch["wallet_exposure_limit"]
+            display_path = (
+                f"coin_overrides.{coin}.bot.{pside}.wallet_exposure_limit ({origin})"
+            )
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"{display_path} must be numeric")
+            if not math.isfinite(float(value)) or float(value) < 0.0:
+                raise ValueError(
+                    f"{display_path} must be finite and >= 0.0"
+                )
+    leverage = patch.get("live", {}).get("leverage")
+    if leverage is not None and float(leverage) <= 0.0:
+        raise ValueError(
+            f"coin_overrides.{coin}.live.leverage ({origin}) must be > 0.0"
+        )
+
+
+def _normalize_patch_values(patch: dict, *, coin: str) -> None:
+    for pside in ("long", "short"):
+        risk = patch.get("bot", {}).get(pside, {}).get("risk", {})
+        if isinstance(risk, dict) and "we_excess_allowance_mode" in risk:
+            risk["we_excess_allowance_mode"] = normalize_we_excess_allowance_mode(
+                risk["we_excess_allowance_mode"],
+                path=(
+                    f"coin_overrides.{coin}.bot.{pside}.risk."
+                    "we_excess_allowance_mode"
+                ),
+            )
+
+
+def _validate_effective_coin_config(
+    config: dict, patch: dict, *, coin: str, origin: str
+) -> None:
+    effective = deepcopy(config)
+    for metadata_key in (
+        "_coins_sources",
+        "_raw",
+        "_raw_effective",
+        "_transform_log",
+    ):
+        effective.pop(metadata_key, None)
+    effective["coin_overrides"] = {}
+    validation_input = get_template_config()
+    nested_update(validation_input, effective)
+    effective = validation_input
+    for root in ("bot", "live"):
+        if root in patch:
+            nested_update(effective[root], deepcopy(patch[root]))
+    try:
+        prepare_config(
+            effective,
+            base_config_path=str(effective.get("live", {}).get("base_config_path") or ""),
+            live_only=False,
+            verbose=False,
+            log_config_transforms=False,
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise type(exc)(
+            f"coin_overrides.{coin} produces an invalid config after {origin}: {exc}"
+        ) from exc
+
+
 def load_override_config(
     config,
     coin,
     *,
     config_loader: Callable[[str], dict] | None = None,
 ):
-    if config_loader is None:
-        config_loader = lambda path: load_prepared_config(path, verbose=False, log_info=False)
-    path = None
-    try:
-        path = config.get("coin_overrides", {}).get(coin, {}).get("override_config_path")
-        if path and os.path.exists(path):
-            return config_loader(path)
+    path = config.get("coin_overrides", {}).get(coin, {}).get("override_config_path")
+    if path is None:
+        return {}
+    if not isinstance(path, str) or not path.strip():
+        raise TypeError(f"coin_overrides.{coin}.override_config_path must be a non-empty string")
+    path = path.strip()
+    candidates = []
+    if os.path.isabs(path):
+        candidates.append(path)
+    else:
         base_config_path = config.get("live", {}).get("base_config_path")
-        if path and base_config_path:
-            npath = os.path.join(os.path.dirname(base_config_path), path)
-            if os.path.exists(npath):
-                return config_loader(npath)
+        if base_config_path:
+            candidates.append(os.path.join(os.path.dirname(base_config_path), path))
+        candidates.append(path)
+    resolved_path = next((candidate for candidate in candidates if os.path.isfile(candidate)), None)
+    if resolved_path is None:
+        attempted = ", ".join(os.path.abspath(candidate) for candidate in candidates)
+        raise FileNotFoundError(
+            f"coin_overrides.{coin}.override_config_path not found; tried: {attempted}"
+        )
+    if config_loader is not None:
+        return config_loader(resolved_path)
+    # Validate the document as a configuration, but return its raw explicit values.
+    try:
+        source, base_config_path, raw_snapshot = load_input_config(
+            resolved_path, log_info=False
+        )
+        if not isinstance(source, dict):
+            raise TypeError("configuration root must be an object")
+        validation_source = get_template_config()
+        nested_update(
+            validation_source,
+            _unwrap_override_document(
+                source,
+                source=f"coin_overrides.{coin}.override_config_path",
+            ),
+        )
+        prepare_config(
+            validation_source,
+            base_config_path=base_config_path,
+            verbose=False,
+            log_config_transforms=False,
+            raw_snapshot=validation_source,
+        )
+    except OSError as exc:
+        raise type(exc)(
+            f"coin_overrides.{coin}.override_config_path {resolved_path!r} "
+            f"could not be read: {exc}"
+        ) from exc
     except Exception as exc:
-        logging.exception("error loading config %s: %s", path, exc)
-    return {}
+        raise ValueError(
+            f"coin_overrides.{coin}.override_config_path {resolved_path!r} is invalid: {exc}"
+        ) from exc
+    return raw_snapshot
 
 
 def parse_old_coin_flags(config) -> dict:
@@ -273,6 +559,8 @@ def parse_overrides(
     if symbol_normalizer is None:
         symbol_normalizer = symbol_to_coin
     result = deepcopy(config)
+    if "coin_overrides" in result and not isinstance(result["coin_overrides"], dict):
+        raise TypeError("coin_overrides must be a dict")
     if not result.get("coin_overrides", {}):
         result["coin_overrides"] = parse_old_coin_flags(config)
         if verbose and result["coin_overrides"]:
@@ -286,40 +574,85 @@ def parse_overrides(
     if "live" in result:
         result["live"].pop("coin_flags", None)
         result["live"].setdefault("coin_flags", {})
-    for coin in sorted(result["coin_overrides"]):
+    normalized_overrides = {}
+    normalized_sources = {}
+    for coin, overrides in result["coin_overrides"].items():
+        if not isinstance(coin, str):
+            raise TypeError("coin_overrides keys must be strings")
         formatted_coin = symbol_normalizer(coin)
+        if not formatted_coin:
+            raise ValueError(f"coin_overrides.{coin} is not a valid coin or symbol")
+        if formatted_coin in normalized_overrides:
+            prior = normalized_sources[formatted_coin]
+            raise ValueError(
+                f"coin_overrides keys {prior!r} and {coin!r} both normalize to "
+                f"{formatted_coin!r}"
+            )
+        normalized_overrides[formatted_coin] = deepcopy(overrides)
+        normalized_sources[formatted_coin] = coin
         if formatted_coin != coin:
-            if formatted_coin:
-                result["coin_overrides"][formatted_coin] = deepcopy(result["coin_overrides"][coin])
-                log_config_message(
-                    verbose,
-                    logging.INFO,
-                    "Renamed %s -> %s for coin_overrides",
-                    coin,
-                    formatted_coin,
-                )
-            else:
-                log_config_message(
-                    verbose,
-                    logging.INFO,
-                    "Failed to format %s; removed from coin_overrides",
-                    coin,
-                )
-            del result["coin_overrides"][coin]
+            log_config_message(
+                verbose,
+                logging.INFO,
+                "Renamed %s -> %s for coin_overrides",
+                coin,
+                formatted_coin,
+            )
+    result["coin_overrides"] = normalized_overrides
+    strategy_kind = normalize_strategy_kind(result.get("live", {}).get("strategy_kind"))
+    runtime_compiled = any(
+        isinstance(item, dict) and item.get("step") == "compile_runtime_config"
+        for item in result.get("_transform_log", [])
+    )
     for coin, overrides in result["coin_overrides"].items():
         parsed_overrides = {}
         loaded = override_loader(result, coin)
         if loaded:
-            _reject_flat_strategy_coin_overrides(loaded, coin=coin)
-            parsed_overrides = apply_allowed_modifications(
-                result, loaded, get_allowed_modifications(), return_full=False
+            parsed_overrides = _extract_allowed_patch(
+                loaded,
+                coin=coin,
+                source=f"coin_overrides.{coin}.override_config_path",
+                strict=False,
+                strategy_kind=strategy_kind,
             )
-        _reject_flat_strategy_coin_overrides(overrides, coin=coin)
+            _normalize_patch_values(parsed_overrides, coin=coin)
+            _validate_patch_leaf_types(
+                result,
+                parsed_overrides,
+                coin=coin,
+                origin="override_config_path",
+            )
+            _validate_effective_coin_config(
+                result,
+                parsed_overrides,
+                coin=coin,
+                origin="override_config_path",
+            )
+        inline_patch = _extract_allowed_patch(
+            overrides,
+            coin=coin,
+            source=f"coin_overrides.{coin}",
+            strict=True,
+            strategy_kind=strategy_kind,
+            strip_runtime_aliases=runtime_compiled,
+        )
+        _normalize_patch_values(inline_patch, coin=coin)
+        _validate_patch_leaf_types(
+            result,
+            inline_patch,
+            coin=coin,
+            origin="inline override",
+        )
         nested_update(
             parsed_overrides,
-            apply_allowed_modifications(
-                result, overrides, get_allowed_modifications(), return_full=False
-            ),
+            inline_patch,
+        )
+        _normalize_patch_values(parsed_overrides, coin=coin)
+        _validate_effective_coin_config(
+            result,
+            parsed_overrides,
+            coin=coin,
+            origin="file and inline precedence resolution",
         )
         result.setdefault("coin_overrides", {})[coin] = parsed_overrides
         log_config_message(

--- a/src/config/overrides.py
+++ b/src/config/overrides.py
@@ -103,14 +103,6 @@ _UNSUPPORTED_FLAT_STRATEGY_OVERRIDE_KEYS = {
     "entry_we_weight",
 } | TRAILING_GRID_V7_FLAT_ONLY_KEYS
 
-_RUNTIME_GENERATED_OVERRIDE_KEYS = {
-    "filter_volatility_drop_pct",
-    "filter_volatility_ema_span_1m",
-    "filter_volume_drop_pct",
-    "filter_volume_ema_span_1m",
-}
-
-
 def _reject_flat_strategy_coin_overrides(overrides: dict, *, coin: str) -> None:
     if not isinstance(overrides, dict):
         return
@@ -235,7 +227,6 @@ def _extract_allowed_patch(
     source: str,
     strict: bool,
     strategy_kind: str,
-    strip_runtime_aliases: bool = False,
 ) -> dict:
     """Extract explicitly supplied allowed leaves without hydrating defaults."""
 
@@ -259,9 +250,6 @@ def _extract_allowed_patch(
                 continue
             if not isinstance(side, dict):
                 raise TypeError(f"{source}.bot.{pside} must be a dict")
-            if strip_runtime_aliases:
-                for generated_key in _RUNTIME_GENERATED_OVERRIDE_KEYS:
-                    side.pop(generated_key, None)
             canonicalize_shared_bot_side(
                 side,
                 path_prefix=(source, "bot", pside),
@@ -422,7 +410,7 @@ def _normalize_patch_values(patch: dict, *, coin: str) -> None:
 
 def _validate_effective_coin_config(
     config: dict, patch: dict, *, coin: str, origin: str
-) -> None:
+) -> dict:
     effective = deepcopy(config)
     for metadata_key in (
         "_coins_sources",
@@ -432,6 +420,12 @@ def _validate_effective_coin_config(
     ):
         effective.pop(metadata_key, None)
     effective["coin_overrides"] = {}
+    for pside in ("long", "short"):
+        canonicalize_shared_bot_side(
+            effective.get("bot", {}).get(pside),
+            path_prefix=("bot", pside),
+            seed_missing_groups=False,
+        )
     validation_input = get_template_config()
     nested_update(validation_input, effective)
     effective = validation_input
@@ -439,7 +433,7 @@ def _validate_effective_coin_config(
         if root in patch:
             nested_update(effective[root], deepcopy(patch[root]))
     try:
-        prepare_config(
+        prepared = prepare_config(
             effective,
             base_config_path=str(effective.get("live", {}).get("base_config_path") or ""),
             live_only=False,
@@ -450,6 +444,25 @@ def _validate_effective_coin_config(
         raise type(exc)(
             f"coin_overrides.{coin} produces an invalid config after {origin}: {exc}"
         ) from exc
+    normalized_patch = {}
+    for path, original_value in _iter_patch_leaves(patch):
+        normalized_value = _get_nested_value(prepared, path)
+        if normalized_value is None:
+            # wallet_exposure_limit is a per-coin runtime value calculated after
+            # canonical config preparation, so it has no canonical global leaf.
+            if len(path) == 3 and path[0] == "bot" and path[2] == "wallet_exposure_limit":
+                normalized_value = original_value
+            else:
+                raise ValueError(
+                    f"coin_overrides.{coin} normalization lost {'.'.join(path)} after {origin}"
+                )
+        set_nested_value_safe(
+            normalized_patch,
+            list(path),
+            deepcopy(normalized_value),
+            create_missing=True,
+        )
+    return normalized_patch
 
 
 def load_override_config(
@@ -559,6 +572,15 @@ def parse_overrides(
     if symbol_normalizer is None:
         symbol_normalizer = symbol_to_coin
     result = deepcopy(config)
+    runtime_compiled = any(
+        isinstance(item, dict) and item.get("step") == "compile_runtime_config"
+        for item in result.get("_transform_log", [])
+    )
+    if runtime_compiled:
+        raise ValueError(
+            "parse_overrides must run before compile_runtime_config so explicit coin "
+            "override keys remain distinguishable from generated runtime aliases"
+        )
     if "coin_overrides" in result and not isinstance(result["coin_overrides"], dict):
         raise TypeError("coin_overrides must be a dict")
     if not result.get("coin_overrides", {}):
@@ -600,10 +622,6 @@ def parse_overrides(
             )
     result["coin_overrides"] = normalized_overrides
     strategy_kind = normalize_strategy_kind(result.get("live", {}).get("strategy_kind"))
-    runtime_compiled = any(
-        isinstance(item, dict) and item.get("step") == "compile_runtime_config"
-        for item in result.get("_transform_log", [])
-    )
     for coin, overrides in result["coin_overrides"].items():
         parsed_overrides = {}
         loaded = override_loader(result, coin)
@@ -622,7 +640,7 @@ def parse_overrides(
                 coin=coin,
                 origin="override_config_path",
             )
-            _validate_effective_coin_config(
+            parsed_overrides = _validate_effective_coin_config(
                 result,
                 parsed_overrides,
                 coin=coin,
@@ -634,7 +652,6 @@ def parse_overrides(
             source=f"coin_overrides.{coin}",
             strict=True,
             strategy_kind=strategy_kind,
-            strip_runtime_aliases=runtime_compiled,
         )
         _normalize_patch_values(inline_patch, coin=coin)
         _validate_patch_leaf_types(
@@ -648,7 +665,7 @@ def parse_overrides(
             inline_patch,
         )
         _normalize_patch_values(parsed_overrides, coin=coin)
-        _validate_effective_coin_config(
+        parsed_overrides = _validate_effective_coin_config(
             result,
             parsed_overrides,
             coin=coin,

--- a/src/config/strategy.py
+++ b/src/config/strategy.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 from typing import Optional
 
-from .shared_bot import BOT_SHARED_GROUPS
+from .shared_bot import BOT_SHARED_GROUPS, flatten_shared_bot_side
 from .strategy_spec import (
     BOT_POSITION_SIDES,
     DEFAULT_STRATEGY_KIND,
@@ -354,7 +354,7 @@ def merge_runtime_bot_side(
         if key in strategy_keys:
             merged.pop(key)
     if isinstance(override_side, dict):
-        for key, value in override_side.items():
+        for key, value in flatten_shared_bot_side(override_side).items():
             if key == "strategy":
                 continue
             if key in strategy_keys:

--- a/src/config_utils.py
+++ b/src/config_utils.py
@@ -590,9 +590,7 @@ def parse_overrides(config, verbose=True):
 
 
 def load_override_config(config, coin):
-    return staged_load_override_config(
-        config, coin, config_loader=lambda path: load_config(path, verbose=False)
-    )
+    return staged_load_override_config(config, coin)
 
 
 def parse_old_coin_flags(config) -> dict:

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -129,6 +129,7 @@ from config.shared_bot import get_grouped_bot_value
 from config.schema import MAX_EXCHANGE_SYMBOL_UNAVAILABLE_COOLDOWN_HOURS
 from config.pnl_lookback import parse_pnls_max_lookback_days
 from config.overrides import parse_overrides
+from config.runtime_compile import compile_runtime_config
 from risk_limits import (
     effective_we_excess_allowance_pct,
     normalize_we_excess_allowance_mode,
@@ -22329,7 +22330,6 @@ async def main():
         live_only=True,
         verbose=True,
         target="live",
-        runtime="live",
         raw_snapshot=raw_snapshot,
     )
     config_logging_value = get_optional_config_value(config, "logging.level", None)
@@ -22420,6 +22420,7 @@ async def main():
     await load_markets(user_info["exchange"], verbose=True)
 
     config = parse_overrides(config, verbose=True)
+    config = compile_runtime_config(config, runtime="live")
     cooldown_secs = 60
     restarts = []
     while True:

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -4456,6 +4456,12 @@ class Passivbot:
         log_key = None
         if symbol and symbol in self.coin_overrides:
             d = self.coin_overrides[symbol]
+            if len(path) == 3 and path[0] == "bot" and path[1] in {"long", "short"}:
+                side = d.get("bot", {}).get(path[1], {})
+                sentinel = object()
+                grouped_value = get_grouped_bot_value(side, path[2], default=sentinel)
+                if grouped_value is not sentinel:
+                    return grouped_value
             for p in path:
                 if isinstance(d, dict) and p in d:
                     d = d[p]

--- a/src/tools/run_fake_live.py
+++ b/src/tools/run_fake_live.py
@@ -19,6 +19,7 @@ from candlestick_manager import CANDLE_DTYPE, sanitize_remote_fetch_diagnostic
 from config import load_prepared_config
 from config.overrides import parse_overrides
 from config.pnl_lookback import parse_pnls_max_lookback_days
+from config.runtime_compile import compile_runtime_config
 from exchanges.fake import FakeCCXTClient, load_fake_scenario
 from fill_events_manager import FillEvent, FillEventCache
 from live.event_bus import LiveEvent, LiveEventContext, LiveEventPipeline
@@ -880,9 +881,9 @@ async def _run_fake_case(
         config_path,
         verbose=False,
         target="live",
-        runtime="live",
     )
     config = parse_overrides(config, verbose=False)
+    config = compile_runtime_config(config, runtime="live")
     config.setdefault("live", {})
     config["live"]["fake_scenario_path"] = scenario_path
 

--- a/src/tools/run_fake_live.py
+++ b/src/tools/run_fake_live.py
@@ -17,6 +17,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from candlestick_manager import CANDLE_DTYPE, sanitize_remote_fetch_diagnostic
 from config import load_prepared_config
+from config.overrides import parse_overrides
 from config.pnl_lookback import parse_pnls_max_lookback_days
 from exchanges.fake import FakeCCXTClient, load_fake_scenario
 from fill_events_manager import FillEvent, FillEventCache
@@ -881,6 +882,7 @@ async def _run_fake_case(
         target="live",
         runtime="live",
     )
+    config = parse_overrides(config, verbose=False)
     config.setdefault("live", {})
     config["live"]["fake_scenario_path"] = scenario_path
 

--- a/tests/test_coin_overrides_foundation.py
+++ b/tests/test_coin_overrides_foundation.py
@@ -1,0 +1,363 @@
+from copy import deepcopy
+
+import pytest
+
+from config.load import prepare_config
+from config.overrides import parse_overrides
+from config.schema import get_template_config
+from config.strategy import merge_runtime_bot_side
+from passivbot import Passivbot
+
+
+def _prepared_config(overrides):
+    source = get_template_config()
+    source["live"]["user"] = "tester"
+    source["coin_overrides"] = deepcopy(overrides)
+    return prepare_config(source, verbose=False, log_config_transforms=False)
+
+
+def _parse(overrides, *, loaded=None, symbol_normalizer=lambda coin: coin):
+    prepared = _prepared_config(overrides)
+    return parse_overrides(
+        prepared,
+        verbose=False,
+        override_loader=lambda config, coin: deepcopy(loaded or {}),
+        symbol_normalizer=symbol_normalizer,
+    )
+
+
+def test_explicit_inline_values_equal_to_global_are_retained():
+    template = get_template_config()
+    threshold = template["bot"]["long"]["strategy"]["trailing_martingale"]["entry"][
+        "threshold_base_pct"
+    ]
+    enabled = template["bot"]["long"]["unstuck"]["enabled"]
+    parsed = _parse(
+        {
+            "BTC": {
+                "bot": {
+                    "long": {
+                        "strategy": {
+                            "trailing_martingale": {
+                                "entry": {"threshold_base_pct": threshold}
+                            }
+                        },
+                        "unstuck": {"enabled": enabled},
+                    }
+                }
+            }
+        }
+    )
+
+    override = parsed["coin_overrides"]["BTC"]["bot"]["long"]
+    assert (
+        override["strategy"]["trailing_martingale"]["entry"]["threshold_base_pct"]
+        == threshold
+    )
+    assert override["unstuck"]["enabled"] is enabled
+
+
+def test_partial_file_extracts_only_explicit_values_and_inline_wins():
+    parsed = _parse(
+        {
+            "BTC": {
+                "override_config_path": "unused-by-test.json",
+                "bot": {"long": {"unstuck": {"enabled": False}}},
+            }
+        },
+        loaded={
+            "bot": {
+                "long": {
+                    "unstuck": {
+                        "enabled": True,
+                        "loss_allowance_pct": 0.02,
+                    }
+                }
+            }
+        },
+    )
+
+    override = parsed["coin_overrides"]["BTC"]
+    assert override == {
+        "bot": {
+            "long": {
+                "unstuck": {
+                    "enabled": False,
+                    "loss_allowance_pct": 0.02,
+                }
+            }
+        }
+    }
+
+
+@pytest.mark.parametrize(
+    ("value", "error", "message"),
+    [
+        ("false", TypeError, "must be numeric or boolean, not a string"),
+        (None, TypeError, "may not be null"),
+    ],
+)
+def test_invalid_boolean_override_types_fail(value, error, message):
+    with pytest.raises(error, match=message):
+        _parse({"BTC": {"bot": {"long": {"unstuck": {"enabled": value}}}}})
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_override_values_fail(value):
+    with pytest.raises(ValueError, match="must be finite"):
+        _parse(
+            {
+                "BTC": {
+                    "bot": {
+                        "long": {
+                            "strategy": {
+                                "trailing_martingale": {
+                                    "entry": {"threshold_base_pct": value}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        )
+
+
+def test_effective_config_cross_field_validation_fails_with_coin_context():
+    with pytest.raises(
+        ValueError,
+        match=r"coin_overrides\.BTC produces an invalid config after .*threshold.*> 0",
+    ):
+        _parse(
+            {
+                "BTC": {
+                    "bot": {
+                        "long": {
+                            "risk": {
+                                "position_exposure_enforcer_enabled": True,
+                                "position_exposure_enforcer_threshold": 0.0,
+                            }
+                        }
+                    }
+                }
+            }
+        )
+
+
+def test_unstuck_ema_distance_validation_applies_to_effective_config():
+    with pytest.raises(
+        ValueError,
+        match=r"coin_overrides\.BTC produces an invalid config after file and inline precedence resolution",
+    ):
+        _parse({"BTC": {"bot": {"long": {"unstuck": {"ema_dist": -1.0}}}}})
+
+
+def test_unknown_and_disallowed_inline_paths_fail():
+    with pytest.raises(ValueError, match=r"coin_overrides\.BTC\.bot\.long\.mystery"):
+        _parse({"BTC": {"bot": {"long": {"mystery": 1.0}}}})
+    with pytest.raises(
+        ValueError, match=r"total_wallet_exposure_limit.*not overridable"
+    ):
+        _parse(
+            {"BTC": {"bot": {"long": {"risk": {"total_wallet_exposure_limit": 1.0}}}}}
+        )
+
+
+def test_strategy_kind_mismatch_fails_in_inline_patch():
+    with pytest.raises(
+        ValueError, match=r"ema_anchor cannot override active strategy_kind"
+    ):
+        _parse(
+            {
+                "BTC": {
+                    "bot": {
+                        "long": {
+                            "strategy": {"ema_anchor": {"entry": {"ema_dist": -0.01}}}
+                        }
+                    }
+                }
+            }
+        )
+
+
+def test_inactive_strategy_subtrees_in_full_override_file_are_ignored():
+    loaded = get_template_config()
+    loaded["bot"]["long"]["strategy"]["trailing_martingale"]["entry"][
+        "threshold_base_pct"
+    ] = 0.123
+    parsed = _parse(
+        {"BTC": {"override_config_path": "unused-by-test.json"}},
+        loaded=loaded,
+    )
+
+    strategy = parsed["coin_overrides"]["BTC"]["bot"]["long"]["strategy"]
+    assert set(strategy) == {"trailing_martingale"}
+    assert strategy["trailing_martingale"]["entry"]["threshold_base_pct"] == 0.123
+
+
+def test_override_file_strategy_kind_mismatch_fails():
+    loaded = get_template_config()
+    loaded["live"]["strategy_kind"] = "ema_anchor"
+    with pytest.raises(ValueError, match=r"live\.strategy_kind.*does not match"):
+        _parse(
+            {"BTC": {"override_config_path": "unused-by-test.json"}},
+            loaded=loaded,
+        )
+
+    with pytest.raises(
+        ValueError, match=r"ema_anchor cannot override active strategy_kind"
+    ):
+        _parse(
+            {"BTC": {"override_config_path": "unused-by-test.json"}},
+            loaded={
+                "bot": {
+                    "long": {"strategy": {"ema_anchor": {"entry": {"ema_dist": -0.01}}}}
+                }
+            },
+        )
+
+
+@pytest.mark.parametrize("value", [0, -1.0])
+def test_non_positive_leverage_override_fails(value):
+    with pytest.raises(ValueError, match=r"live\.leverage .*must be > 0\.0"):
+        _parse({"BTC": {"live": {"leverage": value}}})
+
+
+def test_normalized_coin_collision_fails():
+    with pytest.raises(ValueError, match=r"both normalize to 'BTC'"):
+        _parse(
+            {"BTC": {}, "BTCUSDT": {}},
+            symbol_normalizer=lambda coin: "BTC",
+        )
+
+
+def test_invalid_normalized_coin_fails():
+    with pytest.raises(ValueError, match="not a valid coin or symbol"):
+        _parse({"???": {}}, symbol_normalizer=lambda coin: "")
+
+
+def test_wallet_exposure_limit_from_partial_file_is_retained_and_validated():
+    parsed = _parse(
+        {"BTC": {"override_config_path": "unused-by-test.json"}},
+        loaded={"bot": {"short": {"wallet_exposure_limit": 0.125}}},
+    )
+    assert (
+        parsed["coin_overrides"]["BTC"]["bot"]["short"]["wallet_exposure_limit"]
+        == 0.125
+    )
+
+    with pytest.raises(
+        ValueError, match=r"wallet_exposure_limit .*must be finite and >= 0\.0"
+    ):
+        _parse(
+            {"BTC": {"override_config_path": "unused-by-test.json"}},
+            loaded={"bot": {"short": {"wallet_exposure_limit": -0.1}}},
+        )
+
+
+def test_parse_overrides_is_idempotent():
+    parsed_once = _parse(
+        {"BTC": {"bot": {"long": {"unstuck": {"loss_allowance_pct": 0.02}}}}}
+    )
+    parsed_twice = parse_overrides(
+        parsed_once,
+        verbose=False,
+        override_loader=lambda config, coin: {},
+        symbol_normalizer=lambda coin: coin,
+    )
+    assert parsed_twice["coin_overrides"] == parsed_once["coin_overrides"]
+
+
+def test_programmatic_override_added_after_prepare_is_retained():
+    prepared = _prepared_config({})
+    assert prepared["_raw"]["coin_overrides"] == {}
+    prepared["coin_overrides"] = {
+        "BTC": {"bot": {"long": {"unstuck": {"loss_allowance_pct": 0.027}}}}
+    }
+
+    parsed = parse_overrides(
+        prepared,
+        verbose=False,
+        override_loader=lambda config, coin: {},
+        symbol_normalizer=lambda coin: coin,
+    )
+
+    assert (
+        parsed["coin_overrides"]["BTC"]["bot"]["long"]["unstuck"]["loss_allowance_pct"]
+        == 0.027
+    )
+
+
+def test_canonical_grouped_patch_has_live_and_backtest_consumer_parity():
+    parsed = _parse(
+        {"BTC": {"bot": {"long": {"unstuck": {"loss_allowance_pct": 0.031}}}}}
+    )
+    override_side = parsed["coin_overrides"]["BTC"]["bot"]["long"]
+    merged = merge_runtime_bot_side(
+        parsed["bot"]["long"],
+        pside="long",
+        override_side=override_side,
+        strategy_kind=parsed["live"]["strategy_kind"],
+    )
+
+    bot = Passivbot.__new__(Passivbot)
+    bot.config = parsed
+    bot.coin_overrides = {"BTC/USDT:USDT": parsed["coin_overrides"]["BTC"]}
+
+    assert merged["unstuck_loss_allowance_pct"] == 0.031
+    assert (
+        bot.config_get(
+            ["bot", "long", "unstuck_loss_allowance_pct"],
+            "BTC/USDT:USDT",
+        )
+        == 0.031
+    )
+
+
+@pytest.mark.parametrize("pside", ["long", "short"])
+def test_complete_current_active_strategy_and_shared_allowlist_is_accepted(pside):
+    template = get_template_config()
+    side = template["bot"][pside]
+    parsed = _parse(
+        {
+            "BTC": {
+                "bot": {
+                    pside: {
+                        "strategy": {
+                            "trailing_martingale": deepcopy(
+                                side["strategy"]["trailing_martingale"]
+                            )
+                        },
+                        "risk": {
+                            "position_exposure_enforcer_enabled": side["risk"][
+                                "position_exposure_enforcer_enabled"
+                            ],
+                            "position_exposure_enforcer_threshold": side["risk"][
+                                "position_exposure_enforcer_threshold"
+                            ],
+                            "we_excess_allowance_pct": side["risk"][
+                                "we_excess_allowance_pct"
+                            ],
+                            "we_excess_allowance_mode": side["risk"][
+                                "we_excess_allowance_mode"
+                            ],
+                        },
+                        "unstuck": {
+                            "close_pct": side["unstuck"]["close_pct"],
+                            "ema_dist": side["unstuck"]["ema_dist"],
+                            "enabled": side["unstuck"]["enabled"],
+                            "loss_allowance_pct": side["unstuck"]["loss_allowance_pct"],
+                            "threshold": side["unstuck"]["threshold"],
+                        },
+                        "wallet_exposure_limit": 0.1,
+                    }
+                },
+                "live": {
+                    "forced_mode_long": "",
+                    "forced_mode_short": "normal",
+                    "leverage": template["live"]["leverage"],
+                },
+            }
+        }
+    )
+
+    assert parsed["coin_overrides"]["BTC"]["bot"][pside]["wallet_exposure_limit"] == 0.1

--- a/tests/test_coin_overrides_foundation.py
+++ b/tests/test_coin_overrides_foundation.py
@@ -4,6 +4,7 @@ import pytest
 
 from config.load import prepare_config
 from config.overrides import parse_overrides
+from config.runtime_compile import compile_runtime_config
 from config.schema import get_template_config
 from config.strategy import merge_runtime_bot_side
 from passivbot import Passivbot
@@ -149,6 +150,52 @@ def test_unstuck_ema_distance_validation_applies_to_effective_config():
         match=r"coin_overrides\.BTC produces an invalid config after file and inline precedence resolution",
     ):
         _parse({"BTC": {"bot": {"long": {"unstuck": {"ema_dist": -1.0}}}}})
+
+
+def test_effective_validation_normalization_is_retained_in_patch():
+    parsed = _parse({"BTC": {"bot": {"long": {"unstuck": {"threshold": 1e-12}}}}})
+
+    assert parsed["coin_overrides"]["BTC"]["bot"]["long"]["unstuck"]["threshold"] == 0.0
+
+
+def test_runtime_compilation_must_follow_override_parsing():
+    source = get_template_config()
+    source["coin_overrides"] = {
+        "BTC": {"bot": {"long": {"filter_volume_drop_pct": 0.25}}}
+    }
+    runtime_config = prepare_config(
+        source,
+        verbose=False,
+        log_config_transforms=False,
+        target="live",
+        runtime="live",
+    )
+
+    with pytest.raises(ValueError, match=r"must run before compile_runtime_config"):
+        parse_overrides(runtime_config, verbose=False)
+
+    canonical_config = prepare_config(
+        source,
+        verbose=False,
+        log_config_transforms=False,
+        target="live",
+    )
+    with pytest.raises(
+        ValueError,
+        match=r"coin_overrides\.BTC\.bot\.long\.filter_volume_drop_pct is not overridable",
+    ):
+        parse_overrides(canonical_config, verbose=False)
+
+
+def test_runtime_compilation_after_parsing_preserves_normalized_patch():
+    parsed = _parse({"BTC": {"bot": {"long": {"unstuck": {"threshold": 1e-12}}}}})
+
+    runtime_config = compile_runtime_config(parsed, runtime="live")
+
+    assert (
+        runtime_config["coin_overrides"]["BTC"]["bot"]["long"]["unstuck"]["threshold"]
+        == 0.0
+    )
 
 
 def test_unknown_and_disallowed_inline_paths_fail():

--- a/tests/test_coin_overrides_paths.py
+++ b/tests/test_coin_overrides_paths.py
@@ -6,6 +6,7 @@ import os
 import pytest
 
 import config_utils
+from config.overrides import load_override_config
 
 
 def _write_config(path, cfg):
@@ -66,17 +67,70 @@ def test_override_path_resolves_relative_to_base_config(tmp_path):
     assert "disallowed_root" not in xrp_ov
 
 
-def test_override_file_not_found_yields_empty_override(tmp_path, monkeypatch):
+def test_override_file_not_found_fails_closed(tmp_path):
     base_cfg = config_utils.get_template_config()
     base_cfg["live"]["user"] = "tester"
     base_cfg["live"]["base_config_path"] = str(tmp_path / "base.json")
-    base_cfg["coin_overrides"] = {"DOGE": {"override_config_path": "overrides/missing.json"}}
+    base_cfg["coin_overrides"] = {
+        "DOGE": {"override_config_path": "overrides/missing.json"}
+    }
     base_path = tmp_path / "base.json"
     _write_config(base_path, base_cfg)
 
     loaded = config_utils.load_config(str(base_path), verbose=False)
-    parsed = config_utils.parse_overrides(deepcopy(loaded), verbose=False)
+    with pytest.raises(
+        FileNotFoundError,
+        match=r"coin_overrides\.DOGE\.override_config_path not found",
+    ):
+        config_utils.parse_overrides(deepcopy(loaded), verbose=False)
 
-    # override exists but has no allowed diff because the file was missing
-    assert "DOGE" in parsed["coin_overrides"]
-    assert parsed["coin_overrides"]["DOGE"] == {}
+
+def test_malformed_override_file_fails_closed(tmp_path):
+    base_cfg = config_utils.get_template_config()
+    base_cfg["live"]["user"] = "tester"
+    base_path = tmp_path / "base.json"
+    override_path = tmp_path / "broken.json"
+    override_path.write_text('{"bot": ', encoding="utf-8")
+    base_cfg["live"]["base_config_path"] = str(base_path)
+    base_cfg["coin_overrides"] = {"DOGE": {"override_config_path": override_path.name}}
+    _write_config(base_path, base_cfg)
+
+    loaded = config_utils.load_config(str(base_path), verbose=False)
+    with pytest.raises(
+        ValueError,
+        match=r"coin_overrides\.DOGE\.override_config_path .* is invalid",
+    ):
+        config_utils.parse_overrides(deepcopy(loaded), verbose=False)
+
+
+def test_structurally_invalid_override_file_fails_closed(tmp_path):
+    base_cfg = config_utils.get_template_config()
+    base_cfg["live"]["user"] = "tester"
+    base_path = tmp_path / "base.json"
+    override_path = tmp_path / "invalid.json"
+    override_path.write_text("[]", encoding="utf-8")
+    base_cfg["live"]["base_config_path"] = str(base_path)
+    base_cfg["coin_overrides"] = {"DOGE": {"override_config_path": override_path.name}}
+    _write_config(base_path, base_cfg)
+
+    loaded = config_utils.load_config(str(base_path), verbose=False)
+    with pytest.raises(
+        ValueError,
+        match=r"coin_overrides\.DOGE\.override_config_path .* is invalid",
+    ):
+        config_utils.parse_overrides(deepcopy(loaded), verbose=False)
+
+
+def test_unreadable_override_file_error_propagates(tmp_path):
+    override_path = tmp_path / "override.json"
+    override_path.write_text("{}", encoding="utf-8")
+    config = {
+        "live": {"base_config_path": str(tmp_path / "base.json")},
+        "coin_overrides": {"DOGE": {"override_config_path": override_path.name}},
+    }
+
+    def raise_permission_error(path):
+        raise PermissionError(f"cannot read {path}")
+
+    with pytest.raises(PermissionError, match="cannot read"):
+        load_override_config(config, "DOGE", config_loader=raise_permission_error)

--- a/tests/test_run_fake_live.py
+++ b/tests/test_run_fake_live.py
@@ -1146,6 +1146,10 @@ async def test_coin_overrides_resolve_in_offline_restart_harness(tmp_path, monke
         assert override["bot"]["long"]["strategy"]["trailing_martingale"][
             "entry"
         ]["threshold_base_pct"] == global_threshold
+        transform_steps = [item["step"] for item in bot.config["_transform_log"]]
+        assert transform_steps.index("parse_overrides") < transform_steps.index(
+            "compile_runtime_config"
+        )
     finally:
         _cleanup_fake_user_state(user)
 

--- a/tests/test_run_fake_live.py
+++ b/tests/test_run_fake_live.py
@@ -1070,6 +1070,88 @@ async def test_documented_hsl_restart_scenario_runs_unmodified(tmp_path):
 
 @pytest.mark.asyncio
 @pytest.mark.fake_live
+async def test_coin_overrides_resolve_in_offline_restart_harness(tmp_path, monkeypatch):
+    """Exercise file and inline coin patches through a real fake-live restart scenario."""
+    import passivbot_rust as pbr
+
+    if getattr(pbr, "__is_stub__", False):
+        pytest.skip("requires real passivbot_rust extension")
+
+    user = f"fake_coin_overrides_{tmp_path.name}"
+    _cleanup_fake_user_state(user)
+    base_config = hjson.loads(
+        (REPO_ROOT / "configs" / "fake_live_hsl_btc.hjson").read_text(
+            encoding="utf-8"
+        )
+    )
+    global_threshold = base_config["bot"]["long"]["strategy"][
+        "trailing_martingale"
+    ]["entry"]["threshold_base_pct"]
+    override_path = tmp_path / "btc_override.hjson"
+    override_path.write_text(
+        hjson.dumps(
+            {
+                "bot": {
+                    "long": {
+                        "unstuck": {"loss_allowance_pct": 0.1},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    base_config["coin_overrides"] = {
+        "BTC": {
+            "override_config_path": override_path.name,
+            "bot": {
+                "long": {
+                    "strategy": {
+                        "trailing_martingale": {
+                            "entry": {"threshold_base_pct": global_threshold}
+                        }
+                    }
+                }
+            },
+        }
+    }
+    config_path = tmp_path / "fake_live_coin_overrides.hjson"
+    config_path.write_text(hjson.dumps(base_config), encoding="utf-8")
+
+    captured = {}
+    real_setup_bot = run_fake_live_module.setup_bot
+
+    def capture_setup_bot(config):
+        bot = real_setup_bot(config)
+        captured["bot"] = bot
+        return bot
+
+    monkeypatch.setattr(run_fake_live_module, "setup_bot", capture_setup_bot)
+    try:
+        args = argparse.Namespace(
+            config=str(config_path),
+            scenario=str(
+                REPO_ROOT / "scenarios" / "fake_live" / "hsl_long_red_restart.hjson"
+            ),
+            user=user,
+            max_steps=None,
+            output_dir=str(tmp_path / "artifacts"),
+            log_level=1,
+            snapshot_each_step=False,
+        )
+        assert await _async_main(args) == 0
+
+        bot = captured["bot"]
+        override = bot.coin_overrides["BTC/USDT:USDT"]
+        assert override["bot"]["long"]["unstuck"]["loss_allowance_pct"] == 0.1
+        assert override["bot"]["long"]["strategy"]["trailing_martingale"][
+            "entry"
+        ]["threshold_base_pct"] == global_threshold
+    finally:
+        _cleanup_fake_user_state(user)
+
+
+@pytest.mark.asyncio
+@pytest.mark.fake_live
 async def test_coin_hsl_restart_scenario_uses_protective_supervisor(tmp_path):
     """Coin-mode RED must not fall through normal planning with confirmations pending."""
     import passivbot_rust as pbr


### PR DESCRIPTION
## Summary

- replace hydrated config diffs with explicit, typed per-coin patches
- make file then inline precedence preserve intentional resets to defaults, false, and zero
- validate every resolved per-coin config and fail closed on missing or invalid configured files
- reject normalized-symbol collisions and per-coin strategy-kind mismatches
- make canonical grouped bot overrides resolve consistently in live, backtest, and the offline fake-live harness
- document the staged follow-up plan for parameter-policy and conditional coin-mode HSL work

## Root cause

File overrides were hydrated before allowed values were extracted, which could invent omitted overrides. Inline values were then diffed against the global config, which discarded explicit resets. Most override values also bypassed effective-config validation, and several failure and normalization paths silently fell back or overwrote another patch.

## Validation

- `python -m pytest -q`: 5,609 passed, 122 skipped
- focused config, override, warmup, backtest-payload, and fake-live suites passed
- Rust extension rebuilt and its source fingerprint verified before Rust-backed tests
- deterministic offline fake-live restart scenario passed with both file and inline coin patches
- paired real Binance BTC backtests on 2024-12-10 through 2025-01-02 completed from the public `configs/examples/btc_long.json` configuration; the override case applied `initial_qty_pct=0.0138`, `unstuck.enabled=false`, and `wallet_exposure_limit=0.5`, producing the expected material behavior delta