### PR TITLE
Refine coin override parameter policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Refine the coin-override policy: allow per-coin
+  `bot.<side>.risk.entry_cooldown_minutes` and
+  `bot.<side>.unstuck.ema_gating_enabled`, retain
+  `bot.<side>.unstuck.loss_allowance_pct`, and stop allowing per-coin
+  `bot.<side>.risk.we_excess_allowance_mode`. Configure the allowance mode globally.
+
 - Make coin overrides explicit, typed patches instead of hydrated config diffs. File values now
   precede inline values without losing intentional resets to defaults, false, or zero; each resolved
   per-coin config is validated before use; normalized symbol collisions and strategy-kind mismatches

--- a/docs/coin_overrides.md
+++ b/docs/coin_overrides.md
@@ -8,7 +8,10 @@ resolved, and shows examples for both inline and file-based overrides.
 
 Allowed fields are intentionally limited:
 
-- **Bot params** (per side): wallet exposure limits, unstuck settings, selected risk knobs, and
+- **Bot params** (per side): per-coin wallet exposure limits; selected risk fields
+  (`entry_cooldown_minutes`, position-exposure enforcer settings, and
+  `we_excess_allowance_pct`); selected unstuck fields (`close_pct`, `ema_dist`,
+  `ema_gating_enabled`, `enabled`, `loss_allowance_pct`, and `threshold`); and
   nested active strategy parameters under `bot.<side>.strategy.<strategy_kind>.*` (see the
   allowlist in `src/config/overrides.py:get_allowed_modifications()` for the full set).
 - **Live flags**: `forced_mode_long`, `forced_mode_short`, `leverage`.
@@ -18,6 +21,11 @@ unknown inline override is rejected with its full path. A full override config f
 ordinary non-override config fields; those fields are validated as part of that config and then
 filtered out. Flat v7-style strategy keys such as `entry_grid_spacing_pct` are rejected; use the
 nested v8 strategy path instead.
+
+`bot.<side>.risk.we_excess_allowance_mode` is global policy, not a per-coin knob. Inline coin
+patches that contain it fail with a migration message. A complete file used through
+`override_config_path` may contain the global field, but it is warned about and ignored for the
+coin patch; set the value in the main config instead.
 
 ## How overrides are loaded
 
@@ -59,7 +67,11 @@ Coin keys that normalize to the same ticker are also rejected instead of overwri
             }
           },
           "unstuck": {
+            "ema_gating_enabled": false,
             "loss_allowance_pct": 0.005
+          },
+          "risk": {
+            "entry_cooldown_minutes": 0.05
           },
           "wallet_exposure_limit": 0.18
         },
@@ -144,6 +156,9 @@ Main config:
 - A per-coin `unstuck.loss_allowance_pct` overrides only the selected coin+side's loss allowance
   percentage. It still uses the account-wide unstuck budget formula with `total_wallet_exposure_limit`;
   it does not create a separate per-coin realized-PnL tracker.
+- A per-coin `risk.entry_cooldown_minutes` gates only position-increasing entries for the selected
+  coin+side. A per-coin `unstuck.ema_gating_enabled=false` disables only that coin+side's unstuck
+  EMA trigger/readiness gate; the other unstuck eligibility checks still apply.
 
 ## Common pitfalls
 

--- a/docs/config.bot.md
+++ b/docs/config.bot.md
@@ -138,6 +138,7 @@ unstuck thresholds remain in the config but do not create orders.
 `bot.<side>.unstuck.ema_gating_enabled` controls only the EMA trigger/readiness check for
 auto-unstuck. It defaults to `true`. When false, auto-unstuck may trigger without EMA bands, but it
 still requires loss allowance, exposure threshold, close sizing, and valid market/exchange inputs.
+The field may be overridden for an individual coin+side through `coin_overrides`.
 
 When aggregated realised PnL falls below the peak by more than
 `unstuck_loss_allowance_pct * total_wallet_exposure_limit`, one position at a time is

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -400,10 +400,11 @@ See [docs/forager.md](forager.md) for a full description of motivation, ranking 
       [
         risk.position_exposure_enforcer_enabled,
         risk.position_exposure_enforcer_threshold,
+        risk.entry_cooldown_minutes,
         risk.we_excess_allowance_pct,
-        risk.we_excess_allowance_mode,
         unstuck.close_pct,
         unstuck.ema_dist,
+        unstuck.ema_gating_enabled,
         unstuck.enabled,
         unstuck.loss_allowance_pct,
         unstuck.threshold,
@@ -529,6 +530,8 @@ See [docs/forager.md](forager.md) for a full description of motivation, ranking 
   - Live and backtest use the same contract for realized-PnL risk windows: filter realized fill events to the active lookback window, then recompute cumulative PnL, current value, and peak from only that filtered sequence.
 - **position_exposure_enforcer_threshold**: Per-position multiplier that triggers the position exposure enforcer. When a bot-managed position’s exposure exceeds `wallet_exposure_limit * (1 + effective_we_excess_allowance_pct) * position_exposure_enforcer_threshold`, the bot emits a reduce-only order to bring it back under control. Set <1.0 for continual trimming or `1.0` for a hard cap; use `position_exposure_enforcer_enabled = false` to disable.
 - **entry_cooldown_minutes**: Time-based cooldown after the last position-increasing fill for that coin+pside. Full simultaneous entry ladders are emitted only when `entry_cooldown_minutes = 0.0` and entry retracement is disabled. The deprecated `trailing_grid_v7` compatibility strategy is the exception: at zero cooldown it preserves v7's internally bounded simultaneous grid leg, whose generator stops before stacking retracement-dependent trailing orders. Any positive value enforces a cooldown of that many minutes and limits staged position-adding entries to one order, including fractional values such as `0.05` for roughly three seconds. Backtests evaluate entries on one-minute steps, so any positive sub-minute cooldown prevents a same-minute replacement/add and effectively waits until the next backtest decision minute; live trading enforces the actual millisecond duration between intra-minute checks.
+  This field may be overridden per coin+side as
+  `coin_overrides.<coin>.bot.<side>.risk.entry_cooldown_minutes`.
 - **total_exposure_entry_gate_enabled**: Enables the TWEL entry cap for bot-generated entries. When enabled, entries are blocked or cropped before projected snapped-balance TWE, including existing same-side exchange positions, can exceed `min(total_wallet_exposure_limit, total_wallet_exposure_limit * total_exposure_enforcer_threshold)`. When disabled, excess allowance may let entries push same-side TWE above raw TWEL.
 - **total_exposure_enforcer_enabled**: Enables TWEL auto-reduce repair for already-over-target same-side exchange exposure. Manual and panic exposure counts toward the trigger, but only managed positions can receive TWEL auto-reduce orders. Disable this independently from the TWEL entry gate when you want entry capping without repair closes, or repair closes without entry capping.
 - **total_exposure_enforcer_policy**: TWEL auto-reduce candidate policy. `reduce_overweight` trims managed positions whose WE is above `total_wallet_exposure_limit * total_exposure_enforcer_threshold / effective_n_positions`, where live `effective_n_positions` follows the current dynamic tradable-slot count and falls back to the current held-position count when no symbols are entry-eligible. `reduce_portfolio` can trim any managed open position on that side. Both policies prefer profitable/breakeven reductions before shallow adverse-loss reductions and stop once projected TWE reaches the repair target. Default: `reduce_overweight`.

--- a/docs/plans/coin_overrides_overhaul.md
+++ b/docs/plans/coin_overrides_overhaul.md
@@ -112,7 +112,8 @@ instead of extending the current feature branch indefinitely.
 - [x] Rebuild and verify the Rust extension.
 - [x] Run real backtest comparisons that exercise entry cooldown and unstuck EMA gating.
 - [x] Run deterministic offline fake-live scenarios that exercise the new parameters.
-- [ ] Open a regular ready-for-review PR and request Codex review.
+- [x] Open a regular ready-for-review PR.
+- [ ] Request Codex review and record the reviewed head SHA.
 - [ ] Address findings and repeat review plus validation until the current head is green.
 - [ ] Merge the reviewed current head and mark this section complete.
 
@@ -161,5 +162,6 @@ instead of extending the current feature branch indefinitely.
 - [x] PR 1 implementation and author validation complete.
 - [x] PR 1 under review.
 - [x] PR 1 merged as `75116d1954c19e2bf54ef8313c18d332815a00e1`.
+- [x] PR 2 under review.
 - [ ] PR 2 merged.
 - [ ] PR 3 merged.

--- a/docs/plans/coin_overrides_overhaul.md
+++ b/docs/plans/coin_overrides_overhaul.md
@@ -12,7 +12,7 @@ instead of extending the current feature branch indefinitely.
 - [x] Keep `bot.<pside>.unstuck.loss_allowance_pct` overridable.
 - [x] Remove `bot.<pside>.risk.we_excess_allowance_mode` from the override surface.
 - [x] Add `bot.<pside>.unstuck.ema_gating_enabled` to the override surface.
-- [x] Add `bot.<pside>.entry_cooldown_minutes` to the override surface.
+- [x] Add `bot.<pside>.risk.entry_cooldown_minutes` to the override surface.
 - [x] Make the complete `bot.<pside>.hsl.*` group overridable when that side's
   `hsl_signal_mode` is `"coin"`.
 - [x] Do not add any new `live.*` overrides in this series.
@@ -85,33 +85,33 @@ instead of extending the current feature branch indefinitely.
 - [x] Inspect the exact diff and staged paths for public-repository safety.
 - [x] Open a regular ready-for-review PR.
 - [x] Request Codex review; first pass reviewed `abb40a4840e64a834a50077540d0a2d5c2894313`.
-- [ ] Address actionable findings, add regressions, rerun proportional validation, and
+- [x] Address actionable findings, add regressions, rerun proportional validation, and
   request re-review until no unresolved actionable findings remain.
-- [ ] Require all CI checks green on the current head.
-- [ ] Merge the reviewed current head and mark this section complete.
+- [x] Require all CI checks green on the current head.
+- [x] Merge the reviewed current head and mark this section complete.
 
 ## PR 2: override policy and entry cooldown
 
 ### Implementation
 
-- [ ] Branch from the merged PR 1 result.
-- [ ] Express the allowlist as a maintainable parameter policy rather than scattered
+- [x] Branch from the merged PR 1 result.
+- [x] Express the allowlist as a maintainable parameter policy rather than scattered
   conditionals.
-- [ ] Remove `bot.<pside>.risk.we_excess_allowance_mode` from allowed overrides with an
+- [x] Remove `bot.<pside>.risk.we_excess_allowance_mode` from allowed overrides with an
   actionable migration error.
-- [ ] Keep `bot.<pside>.unstuck.loss_allowance_pct` allowed.
-- [ ] Add `bot.<pside>.unstuck.ema_gating_enabled`.
-- [ ] Add `bot.<pside>.entry_cooldown_minutes`.
-- [ ] Update reference documentation and the changelog.
+- [x] Keep `bot.<pside>.unstuck.loss_allowance_pct` allowed.
+- [x] Add `bot.<pside>.unstuck.ema_gating_enabled`.
+- [x] Add `bot.<pside>.risk.entry_cooldown_minutes`.
+- [x] Update reference documentation and the changelog.
 
 ### Validation and release gate
 
-- [ ] Add table-driven policy tests for every added, retained, and removed parameter.
-- [ ] Prove independent long/short behavior and file/inline precedence.
-- [ ] Run focused and broader Python tests.
-- [ ] Rebuild and verify the Rust extension.
-- [ ] Run real backtest comparisons that exercise entry cooldown and unstuck EMA gating.
-- [ ] Run deterministic offline fake-live scenarios that exercise the new parameters.
+- [x] Add table-driven policy tests for every added, retained, and removed parameter.
+- [x] Prove independent long/short behavior and file/inline precedence.
+- [x] Run focused and broader Python tests.
+- [x] Rebuild and verify the Rust extension.
+- [x] Run real backtest comparisons that exercise entry cooldown and unstuck EMA gating.
+- [x] Run deterministic offline fake-live scenarios that exercise the new parameters.
 - [ ] Open a regular ready-for-review PR and request Codex review.
 - [ ] Address findings and repeat review plus validation until the current head is green.
 - [ ] Merge the reviewed current head and mark this section complete.
@@ -160,6 +160,6 @@ instead of extending the current feature branch indefinitely.
 - [x] Execution checklist persisted.
 - [x] PR 1 implementation and author validation complete.
 - [x] PR 1 under review.
-- [ ] PR 1 merged.
+- [x] PR 1 merged as `75116d1954c19e2bf54ef8313c18d332815a00e1`.
 - [ ] PR 2 merged.
 - [ ] PR 3 merged.

--- a/src/config/overrides.py
+++ b/src/config/overrides.py
@@ -19,7 +19,6 @@ from .strategy import (
 )
 from .strategy_spec import get_supported_strategy_kinds
 from .transform_log import record_transform
-from risk_limits import normalize_we_excess_allowance_mode
 
 
 def apply_allowed_modifications(src, modifications, allowed_overrides, return_full=True):
@@ -56,8 +55,6 @@ def apply_allowed_modifications(src, modifications, allowed_overrides, return_fu
                 if not return_full and not target_dict[key]:
                     target_dict.pop(key, None)
             elif allowed_value is True:
-                if key in {"risk_we_excess_allowance_mode", "we_excess_allowance_mode"}:
-                    mod_value = normalize_we_excess_allowance_mode(mod_value)
                 if return_full:
                     target_dict[key] = deepcopy(mod_value)
                 else:
@@ -67,27 +64,39 @@ def apply_allowed_modifications(src, modifications, allowed_overrides, return_fu
     return result
 
 
-_ALLOWED_FLAT_BOT_SIDE_MODIFICATIONS = {
-    "unstuck_close_pct": True,
-    "unstuck_ema_dist": True,
-    "unstuck_enabled": True,
-    "unstuck_loss_allowance_pct": True,
-    "unstuck_threshold": True,
-    "wallet_exposure_limit": True,
-    "risk_twel_entry_gate_enabled": False,
-    "risk_wel_enforcer_enabled": True,
-    "risk_wel_enforcer_threshold": True,
-    "risk_we_excess_allowance_pct": True,
-    "risk_we_excess_allowance_mode": True,
-    "risk_twel_enforcer_enabled": False,
-    "risk_twel_enforcer_policy": False,
-    "risk_twel_enforcer_threshold": False,
-}
+OVERRIDABLE_SHARED_BOT_PATHS = frozenset(
+    {
+        "risk.entry_cooldown_minutes",
+        "risk.position_exposure_enforcer_enabled",
+        "risk.position_exposure_enforcer_threshold",
+        "risk.we_excess_allowance_pct",
+        "unstuck.close_pct",
+        "unstuck.ema_dist",
+        "unstuck.ema_gating_enabled",
+        "unstuck.enabled",
+        "unstuck.loss_allowance_pct",
+        "unstuck.threshold",
+    }
+)
+OVERRIDABLE_STANDALONE_BOT_KEYS = frozenset({"wallet_exposure_limit"})
+REMOVED_COIN_OVERRIDE_PATHS = frozenset({"risk.we_excess_allowance_mode"})
+
+
+def _flat_bot_side_modification_policy() -> dict[str, bool]:
+    policy = {
+        flat_key: f"{group_name}.{local_key}" in OVERRIDABLE_SHARED_BOT_PATHS
+        for group_name, field_map in BOT_GROUP_FIELD_MAP.items()
+        for local_key, flat_key in field_map.items()
+    }
+    policy.update({key: True for key in OVERRIDABLE_STANDALONE_BOT_KEYS})
+    return policy
 
 
 def allowed_flat_bot_side_modification_keys() -> frozenset[str]:
     return frozenset(
-        key for key, allowed in _ALLOWED_FLAT_BOT_SIDE_MODIFICATIONS.items() if allowed is True
+        key
+        for key, allowed in _flat_bot_side_modification_policy().items()
+        if allowed is True
     )
 
 
@@ -142,7 +151,7 @@ def _allowed_bot_side_modifications() -> dict:
             current[parts[-1]] = True
         return result
 
-    side = deepcopy(_ALLOWED_FLAT_BOT_SIDE_MODIFICATIONS)
+    side = _flat_bot_side_modification_policy()
     side["strategy"] = {
         strategy_kind: _allow_dotted_paths(keys)
         for strategy_kind in get_supported_strategy_kinds()
@@ -150,8 +159,8 @@ def _allowed_bot_side_modifications() -> dict:
     }
     for group_name, field_map in BOT_GROUP_FIELD_MAP.items():
         grouped_allowed = {
-            local_key: _ALLOWED_FLAT_BOT_SIDE_MODIFICATIONS.get(flat_key, False)
-            for local_key, flat_key in field_map.items()
+            local_key: f"{group_name}.{local_key}" in OVERRIDABLE_SHARED_BOT_PATHS
+            for local_key in field_map
         }
         if any(grouped_allowed.values()):
             side[group_name] = grouped_allowed
@@ -250,6 +259,23 @@ def _extract_allowed_patch(
                 continue
             if not isinstance(side, dict):
                 raise TypeError(f"{source}.bot.{pside} must be a dict")
+            for removed_path in REMOVED_COIN_OVERRIDE_PATHS:
+                group_name, local_key = removed_path.split(".", 1)
+                flat_key = BOT_GROUP_FIELD_MAP[group_name][local_key]
+                group = side.get(group_name)
+                if flat_key in side or (
+                    isinstance(group, dict) and local_key in group
+                ):
+                    path = _format_override_path(
+                        coin, ("bot", pside, group_name, local_key)
+                    )
+                    message = (
+                        f"{path} is no longer overridable; configure "
+                        f"bot.{pside}.{removed_path} globally and remove it from {source}"
+                    )
+                    if strict:
+                        raise ValueError(message)
+                    logging.warning("%s; the file value is ignored", message)
             canonicalize_shared_bot_side(
                 side,
                 path_prefix=(source, "bot", pside),
@@ -393,19 +419,6 @@ def _validate_patch_leaf_types(
         raise ValueError(
             f"coin_overrides.{coin}.live.leverage ({origin}) must be > 0.0"
         )
-
-
-def _normalize_patch_values(patch: dict, *, coin: str) -> None:
-    for pside in ("long", "short"):
-        risk = patch.get("bot", {}).get(pside, {}).get("risk", {})
-        if isinstance(risk, dict) and "we_excess_allowance_mode" in risk:
-            risk["we_excess_allowance_mode"] = normalize_we_excess_allowance_mode(
-                risk["we_excess_allowance_mode"],
-                path=(
-                    f"coin_overrides.{coin}.bot.{pside}.risk."
-                    "we_excess_allowance_mode"
-                ),
-            )
 
 
 def _validate_effective_coin_config(
@@ -633,7 +646,6 @@ def parse_overrides(
                 strict=False,
                 strategy_kind=strategy_kind,
             )
-            _normalize_patch_values(parsed_overrides, coin=coin)
             _validate_patch_leaf_types(
                 result,
                 parsed_overrides,
@@ -653,7 +665,6 @@ def parse_overrides(
             strict=True,
             strategy_kind=strategy_kind,
         )
-        _normalize_patch_values(inline_patch, coin=coin)
         _validate_patch_leaf_types(
             result,
             inline_patch,
@@ -664,7 +675,6 @@ def parse_overrides(
             parsed_overrides,
             inline_patch,
         )
-        _normalize_patch_values(parsed_overrides, coin=coin)
         parsed_overrides = _validate_effective_coin_config(
             result,
             parsed_overrides,

--- a/tests/test_coin_overrides_foundation.py
+++ b/tests/test_coin_overrides_foundation.py
@@ -375,6 +375,9 @@ def test_complete_current_active_strategy_and_shared_allowlist_is_accepted(pside
                             )
                         },
                         "risk": {
+                            "entry_cooldown_minutes": side["risk"][
+                                "entry_cooldown_minutes"
+                            ],
                             "position_exposure_enforcer_enabled": side["risk"][
                                 "position_exposure_enforcer_enabled"
                             ],
@@ -384,13 +387,11 @@ def test_complete_current_active_strategy_and_shared_allowlist_is_accepted(pside
                             "we_excess_allowance_pct": side["risk"][
                                 "we_excess_allowance_pct"
                             ],
-                            "we_excess_allowance_mode": side["risk"][
-                                "we_excess_allowance_mode"
-                            ],
                         },
                         "unstuck": {
                             "close_pct": side["unstuck"]["close_pct"],
                             "ema_dist": side["unstuck"]["ema_dist"],
+                            "ema_gating_enabled": side["unstuck"]["ema_gating_enabled"],
                             "enabled": side["unstuck"]["enabled"],
                             "loss_allowance_pct": side["unstuck"]["loss_allowance_pct"],
                             "threshold": side["unstuck"]["threshold"],

--- a/tests/test_coin_overrides_policy.py
+++ b/tests/test_coin_overrides_policy.py
@@ -1,0 +1,149 @@
+from copy import deepcopy
+
+import pytest
+
+from config.load import prepare_config
+from config.overrides import (
+    OVERRIDABLE_SHARED_BOT_PATHS,
+    allowed_flat_bot_side_modification_keys,
+    parse_overrides,
+)
+from config.schema import get_template_config
+
+
+def _parse(overrides, *, loaded=None):
+    source = get_template_config()
+    source["live"]["user"] = "tester"
+    source["coin_overrides"] = deepcopy(overrides)
+    prepared = prepare_config(source, verbose=False, log_config_transforms=False)
+    return parse_overrides(
+        prepared,
+        verbose=False,
+        override_loader=lambda config, coin: deepcopy(loaded or {}),
+        symbol_normalizer=lambda coin: coin,
+    )
+
+
+@pytest.mark.parametrize("pside", ["long", "short"])
+@pytest.mark.parametrize(
+    ("group", "key", "value"),
+    [
+        ("risk", "entry_cooldown_minutes", 2.5),
+        ("unstuck", "ema_gating_enabled", False),
+        ("unstuck", "loss_allowance_pct", 0.027),
+    ],
+)
+def test_added_and_retained_canonical_policy_paths_are_allowed(
+    pside, group, key, value
+):
+    parsed = _parse({"BTC": {"bot": {pside: {group: {key: value}}}}})
+
+    assert parsed["coin_overrides"]["BTC"]["bot"][pside][group][key] == value
+
+
+def test_policy_registry_and_legacy_aliases_are_derived_consistently():
+    assert "risk.entry_cooldown_minutes" in OVERRIDABLE_SHARED_BOT_PATHS
+    assert "unstuck.ema_gating_enabled" in OVERRIDABLE_SHARED_BOT_PATHS
+    assert "unstuck.loss_allowance_pct" in OVERRIDABLE_SHARED_BOT_PATHS
+    assert "risk.we_excess_allowance_mode" not in OVERRIDABLE_SHARED_BOT_PATHS
+
+    flat = allowed_flat_bot_side_modification_keys()
+    assert "risk_entry_cooldown_minutes" in flat
+    assert "unstuck_ema_gating_enabled" in flat
+    assert "unstuck_loss_allowance_pct" in flat
+    assert "risk_we_excess_allowance_mode" not in flat
+
+
+@pytest.mark.parametrize("pside", ["long", "short"])
+@pytest.mark.parametrize("spelling", ["grouped", "flat"])
+def test_removed_allowance_mode_has_actionable_inline_error(pside, spelling):
+    side = (
+        {"risk": {"we_excess_allowance_mode": "legacy_raw"}}
+        if spelling == "grouped"
+        else {"risk_we_excess_allowance_mode": "legacy_raw"}
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            rf"coin_overrides\.BTC\.bot\.{pside}\.risk\.we_excess_allowance_mode "
+            rf"is no longer overridable.*configure bot\.{pside}\.risk\."
+            r"we_excess_allowance_mode globally"
+        ),
+    ):
+        _parse({"BTC": {"bot": {pside: side}}})
+
+
+def test_removed_allowance_mode_in_full_file_is_warned_and_ignored(caplog):
+    parsed = _parse(
+        {"BTC": {"override_config_path": "unused-by-test.json"}},
+        loaded={
+            "bot": {
+                "long": {
+                    "risk": {
+                        "entry_cooldown_minutes": 1.5,
+                        "we_excess_allowance_mode": "legacy_raw",
+                    }
+                }
+            }
+        },
+    )
+
+    risk = parsed["coin_overrides"]["BTC"]["bot"]["long"]["risk"]
+    assert risk == {"entry_cooldown_minutes": 1.5}
+    assert "is no longer overridable" in caplog.text
+    assert "the file value is ignored" in caplog.text
+
+
+def test_file_then_inline_precedence_and_long_short_independence():
+    parsed = _parse(
+        {
+            "BTC": {
+                "override_config_path": "unused-by-test.json",
+                "bot": {
+                    "long": {"risk_entry_cooldown_minutes": 0.05},
+                    "short": {
+                        "unstuck": {
+                            "ema_gating_enabled": True,
+                            "loss_allowance_pct": 0.031,
+                        }
+                    },
+                },
+            }
+        },
+        loaded={
+            "bot": {
+                "long": {
+                    "risk": {"entry_cooldown_minutes": 3.0},
+                    "unstuck": {"ema_gating_enabled": False},
+                },
+                "short": {
+                    "risk": {"entry_cooldown_minutes": 7.0},
+                    "unstuck": {
+                        "ema_gating_enabled": False,
+                        "loss_allowance_pct": 0.029,
+                    },
+                },
+            }
+        },
+    )
+
+    bot = parsed["coin_overrides"]["BTC"]["bot"]
+    assert bot["long"]["risk"]["entry_cooldown_minutes"] == 0.05
+    assert bot["long"]["unstuck"]["ema_gating_enabled"] is False
+    assert bot["short"]["risk"]["entry_cooldown_minutes"] == 7.0
+    assert bot["short"]["unstuck"]["ema_gating_enabled"] is True
+    assert bot["short"]["unstuck"]["loss_allowance_pct"] == 0.031
+
+
+def test_new_policy_fields_use_effective_config_and_type_validation():
+    with pytest.raises(
+        ValueError,
+        match=r"coin_overrides\.BTC produces an invalid config.*entry_cooldown_minutes",
+    ):
+        _parse({"BTC": {"bot": {"long": {"risk": {"entry_cooldown_minutes": -0.1}}}}})
+
+    with pytest.raises(TypeError, match=r"ema_gating_enabled.*numeric or boolean"):
+        _parse(
+            {"BTC": {"bot": {"short": {"unstuck": {"ema_gating_enabled": "false"}}}}}
+        )

--- a/tests/test_config_pipeline.py
+++ b/tests/test_config_pipeline.py
@@ -684,7 +684,7 @@ def test_migrated_v7_trailing_grid_config_prepares_and_validates():
     assert set(prepared["optimize"]["bounds"]["long"]["strategy"]) == {"trailing_grid_v7"}
 
 
-def test_migrate_v7_trailing_grid_coin_override_preserves_wallet_exposure_limit():
+def test_migrate_v7_coin_override_preserves_supported_fields_and_reports_removed_mode():
     source = _minimal_v7_trailing_grid_config()
     source["coin_overrides"]["BTC"] = {
         "bot": {
@@ -702,18 +702,22 @@ def test_migrate_v7_trailing_grid_coin_override_preserves_wallet_exposure_limit(
     long_override = migrated["coin_overrides"]["BTC"]["bot"]["long"]
     assert long_override["wallet_exposure_limit"] == pytest.approx(0.25)
     assert long_override["risk"]["we_excess_allowance_pct"] == pytest.approx(0.2)
-    assert long_override["risk"]["we_excess_allowance_mode"] == "LEGACY_RAW"
+    assert "we_excess_allowance_mode" not in long_override["risk"]
     assert long_override["strategy"]["trailing_grid_v7"]["ema_span_0"] == pytest.approx(3.0)
     assert (
         "coin_overrides.BTC.bot.long.wallet_exposure_limit -> "
         "coin_overrides.BTC.bot.long.wallet_exposure_limit"
     ) in report["moved_fields"]
+    assert (
+        "coin_overrides.BTC.bot.long.risk_we_excess_allowance_mode"
+        in report["manual_review_fields"]
+    )
     prepared = prepare_config(migrated, verbose=False, target="canonical", runtime=None)
     parsed = parse_overrides(prepared, verbose=False)
     parsed_override = parsed["coin_overrides"]["BTC"]["bot"]["long"]
     assert parsed_override["wallet_exposure_limit"] == pytest.approx(0.25)
     assert parsed_override["risk"]["we_excess_allowance_pct"] == pytest.approx(0.2)
-    assert parsed_override["risk"]["we_excess_allowance_mode"] == "legacy_raw"
+    assert "we_excess_allowance_mode" not in parsed_override["risk"]
 
 
 def test_migrate_v7_trailing_grid_coin_override_reports_runtime_unsupported_risk_fields():
@@ -1712,7 +1716,7 @@ def test_prepare_config_normalizes_coin_override_we_excess_allowance_mode():
     )
 
 
-def test_parse_overrides_normalizes_coin_override_we_excess_allowance_mode():
+def test_parse_overrides_rejects_coin_override_we_excess_allowance_mode():
     source = get_template_config()
     source["coin_overrides"] = {
         "BTC": {
@@ -1726,11 +1730,12 @@ def test_parse_overrides_normalizes_coin_override_we_excess_allowance_mode():
         }
     }
 
-    parsed = parse_overrides(source, verbose=False)
-
-    assert parsed["coin_overrides"]["BTC"]["bot"]["long"]["risk"][
-        "we_excess_allowance_mode"
-    ] == "legacy_raw"
+    with pytest.raises(
+        ValueError,
+        match=r"coin_overrides\.BTC\.bot\.long\.risk\.we_excess_allowance_mode "
+        r"is no longer overridable.*configure bot\.long\.risk\.we_excess_allowance_mode globally",
+    ):
+        parse_overrides(source, verbose=False)
 
 
 def test_prepare_config_rejects_invalid_we_excess_allowance_mode():

--- a/tests/test_run_fake_live.py
+++ b/tests/test_run_fake_live.py
@@ -1093,7 +1093,11 @@ async def test_coin_overrides_resolve_in_offline_restart_harness(tmp_path, monke
             {
                 "bot": {
                     "long": {
-                        "unstuck": {"loss_allowance_pct": 0.1},
+                        "risk": {"entry_cooldown_minutes": 3.0},
+                        "unstuck": {
+                            "ema_gating_enabled": False,
+                            "loss_allowance_pct": 0.1,
+                        },
                     }
                 }
             }
@@ -1105,6 +1109,7 @@ async def test_coin_overrides_resolve_in_offline_restart_harness(tmp_path, monke
             "override_config_path": override_path.name,
             "bot": {
                 "long": {
+                    "risk": {"entry_cooldown_minutes": 0.05},
                     "strategy": {
                         "trailing_martingale": {
                             "entry": {"threshold_base_pct": global_threshold}
@@ -1142,6 +1147,10 @@ async def test_coin_overrides_resolve_in_offline_restart_harness(tmp_path, monke
 
         bot = captured["bot"]
         override = bot.coin_overrides["BTC/USDT:USDT"]
+        assert override["bot"]["long"]["risk"]["entry_cooldown_minutes"] == 0.05
+        assert override["bot"]["long"]["risk_entry_cooldown_minutes"] == 0.05
+        assert override["bot"]["long"]["unstuck"]["ema_gating_enabled"] is False
+        assert override["bot"]["long"]["unstuck_ema_gating_enabled"] is False
         assert override["bot"]["long"]["unstuck"]["loss_allowance_pct"] == 0.1
         assert override["bot"]["long"]["strategy"]["trailing_martingale"][
             "entry"


### PR DESCRIPTION
## Summary

- derive the per-side shared-field allowlist from one canonical parameter policy
- allow per-coin `risk.entry_cooldown_minutes` and `unstuck.ema_gating_enabled`
- retain per-coin `unstuck.loss_allowance_pct`
- remove per-coin `risk.we_excess_allowance_mode`; inline use now fails with a global-config migration message, while complete override files warn and ignore the field
- update v7 migration coverage, reference docs, changelog, and the staged rollout checklist

## Validation

- full Python test suite passed
- focused coin-override, config-pipeline, migration, and complete fake-live suites passed
- Rust extension rebuilt and its loaded source fingerprint matched the current Rust source
- CI-style AI docs and generated live-event registry checks passed
- deterministic offline fake-live restart scenario passed with file and inline cooldown/unstuck EMA-gating overrides
- paired real Binance BTC backtests on public cached data completed for 2024-12-10 through 2025-01-02; the per-coin 1,440-minute cooldown plus unstuck EMA-gate case changed worst BTC drawdown from 0.01371 to 0.00391 and produced the expected material behavior delta