### PR TITLE
Allow conditional per-coin HSL overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Allow the complete per-side HSL group in coin overrides when the global
+  `live.hsl_signal_mode` is `"coin"`. Resolved per-coin HSL settings now drive both live
+  supervision and Rust backtests; inline HSL patches fail in `pside` or `unified` mode, while HSL
+  fields from complete override files are warned about and ignored outside coin mode. The signal
+  mode remains global and cannot be changed by a coin override.
+
 - Refine the coin-override policy: allow per-coin
   `bot.<side>.risk.entry_cooldown_minutes` and
   `bot.<side>.unstuck.ema_gating_enabled`, retain

--- a/docs/coin_overrides.md
+++ b/docs/coin_overrides.md
@@ -12,6 +12,7 @@ Allowed fields are intentionally limited:
   (`entry_cooldown_minutes`, position-exposure enforcer settings, and
   `we_excess_allowance_pct`); selected unstuck fields (`close_pct`, `ema_dist`,
   `ema_gating_enabled`, `enabled`, `loss_allowance_pct`, and `threshold`); and
+  every HSL field when the global `live.hsl_signal_mode` is `"coin"`; and
   nested active strategy parameters under `bot.<side>.strategy.<strategy_kind>.*` (see the
   allowlist in `src/config/overrides.py:get_allowed_modifications()` for the full set).
 - **Live flags**: `forced_mode_long`, `forced_mode_short`, `leverage`.
@@ -26,6 +27,26 @@ nested v8 strategy path instead.
 patches that contain it fail with a migration message. A complete file used through
 `override_config_path` may contain the global field, but it is warned about and ignored for the
 coin patch; set the value in the main config instead.
+
+The complete conditional HSL override group is:
+
+- `hsl.enabled`
+- `hsl.red_threshold`
+- `hsl.ema_span_minutes`
+- `hsl.cooldown_minutes_after_red`
+- `hsl.no_restart_drawdown_threshold`
+- `hsl.restart_after_red_policy`
+- `hsl.tier_ratios.yellow`
+- `hsl.tier_ratios.orange`
+- `hsl.orange_tier_mode`
+- `hsl.panic_close_order_type`
+
+These fields are per `coin+side` only when the main config selects
+`live.hsl_signal_mode = "coin"`. The signal mode itself remains global and is not overridable.
+An inline HSL patch in `pside` or `unified` mode is rejected. HSL values in a complete override
+file are warned about and ignored in those modes, while other eligible fields in that file still
+apply. A `live.hsl_signal_mode` value inside an override file or inline patch cannot authorize the
+HSL patch; the main config's effective global mode always decides.
 
 ## How overrides are loaded
 
@@ -72,6 +93,17 @@ Coin keys that normalize to the same ticker are also rejected instead of overwri
           },
           "risk": {
             "entry_cooldown_minutes": 0.05
+          },
+          "hsl": {
+            "enabled": true,
+            "red_threshold": 0.08,
+            "ema_span_minutes": 10.0,
+            "cooldown_minutes_after_red": 60.0,
+            "no_restart_drawdown_threshold": 0.25,
+            "restart_after_red_policy": "threshold",
+            "tier_ratios": {"yellow": 0.5, "orange": 0.75},
+            "orange_tier_mode": "tp_only_with_active_entry_cancellation",
+            "panic_close_order_type": "market"
           },
           "wallet_exposure_limit": 0.18
         },
@@ -159,6 +191,9 @@ Main config:
 - A per-coin `risk.entry_cooldown_minutes` gates only position-increasing entries for the selected
   coin+side. A per-coin `unstuck.ema_gating_enabled=false` disables only that coin+side's unstuck
   EMA trigger/readiness gate; the other unstuck eligibility checks still apply.
+- In global `coin` signal mode, per-coin HSL values drive the live supervisor and Rust backtest for
+  only the selected `coin+side`, including enablement, tier thresholds, cooldown/restart policy,
+  orange behavior, and panic execution type. Other coins inherit the main config.
 
 ## Common pitfalls
 
@@ -170,3 +205,5 @@ Main config:
 - Mis-keyed coins: invalid coin names and normalized-name collisions are rejected.
 - Wrong types: strings such as `"false"`, nulls, and non-finite numbers are rejected rather than
   coerced into trading parameters.
+- Conditional HSL: setting HSL fields in a coin patch while the main config uses `pside` or
+  `unified` mode is invalid; changing `live.hsl_signal_mode` inside the patch does not change that.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -402,6 +402,16 @@ See [docs/forager.md](forager.md) for a full description of motivation, ranking 
         risk.position_exposure_enforcer_threshold,
         risk.entry_cooldown_minutes,
         risk.we_excess_allowance_pct,
+        hsl.cooldown_minutes_after_red,
+        hsl.ema_span_minutes,
+        hsl.enabled,
+        hsl.no_restart_drawdown_threshold,
+        hsl.orange_tier_mode,
+        hsl.panic_close_order_type,
+        hsl.red_threshold,
+        hsl.restart_after_red_policy,
+        hsl.tier_ratios.orange,
+        hsl.tier_ratios.yellow,
         unstuck.close_pct,
         unstuck.ema_dist,
         unstuck.ema_gating_enabled,
@@ -411,6 +421,8 @@ See [docs/forager.md](forager.md) for a full description of motivation, ranking 
         wallet_exposure_limit
       ]
       ```
+      The `hsl.*` entries are eligible only when the main config's global
+      `live.hsl_signal_mode` is `"coin"`. The signal mode is not itself overridable.
     - `config.live`:
     ```
     [forced_mode_long, forced_mode_short, leverage]

--- a/docs/equity_hard_stop_loss.md
+++ b/docs/equity_hard_stop_loss.md
@@ -59,6 +59,18 @@ Use `pside` when:
 
 Use `coin` when one symbol should be stopped because it has high adverse UPnL or has recently realized heavy losses through unstuck/WEL enforcement, while unrelated symbols should keep trading.
 
+### Per-coin HSL configuration
+
+When the main config uses `live.hsl_signal_mode = "coin"`, any field in
+`bot.<side>.hsl.*` may be overridden for an individual coin through `coin_overrides`. This includes
+enablement, red and tier thresholds, EMA span, cooldown and restart policy, orange-tier behavior,
+and panic-close execution type. Live supervision and Rust backtests both consume the resolved
+per-coin values. Coins without an HSL patch inherit the main side config.
+
+The signal mode remains one global setting. Per-coin HSL patches are rejected in `pside` and
+`unified` modes, and a signal-mode value inside an override cannot switch or authorize the patch.
+See [Coin Overrides](coin_overrides.md) for the full field list, precedence, and examples.
+
 This is separate from auto-unstuck and the realized-loss gate:
 
 1. Auto-unstuck gradually trims stuck positions while continuing to trade.

--- a/docs/plans/coin_overrides_overhaul.md
+++ b/docs/plans/coin_overrides_overhaul.md
@@ -139,7 +139,8 @@ instead of extending the current feature branch indefinitely.
 - [x] Rebuild and verify the Rust extension.
 - [x] Run real HSL backtests with public fixtures and compare expected behavior.
 - [x] Run deterministic offline fake-live HSL scenarios, including restart behavior.
-- [ ] Open a regular ready-for-review PR and request Codex review.
+- [x] Open a regular ready-for-review PR and request Codex review; first pass requested on
+  `d0a6e4a4976a1b18199cce27eeb0e1b55aa97230`.
 - [ ] Address findings and repeat review plus validation until the current head is green.
 - [ ] Merge the reviewed current head and mark this section complete.
 

--- a/docs/plans/coin_overrides_overhaul.md
+++ b/docs/plans/coin_overrides_overhaul.md
@@ -13,8 +13,8 @@ instead of extending the current feature branch indefinitely.
 - [x] Remove `bot.<pside>.risk.we_excess_allowance_mode` from the override surface.
 - [x] Add `bot.<pside>.unstuck.ema_gating_enabled` to the override surface.
 - [x] Add `bot.<pside>.risk.entry_cooldown_minutes` to the override surface.
-- [x] Make the complete `bot.<pside>.hsl.*` group overridable when that side's
-  `hsl_signal_mode` is `"coin"`.
+- [x] Make the complete `bot.<pside>.hsl.*` group overridable when the global
+  `live.hsl_signal_mode` is `"coin"`.
 - [x] Do not add any new `live.*` overrides in this series.
 
 ## Cross-PR invariants
@@ -113,31 +113,32 @@ instead of extending the current feature branch indefinitely.
 - [x] Run real backtest comparisons that exercise entry cooldown and unstuck EMA gating.
 - [x] Run deterministic offline fake-live scenarios that exercise the new parameters.
 - [x] Open a regular ready-for-review PR.
-- [ ] Request Codex review and record the reviewed head SHA.
-- [ ] Address findings and repeat review plus validation until the current head is green.
-- [ ] Merge the reviewed current head and mark this section complete.
+- [x] Request Codex review; clean pass reviewed
+  `145b497315e65934870d0aec381d2316403b803d`.
+- [x] Address findings and repeat review plus validation until the current head is green.
+- [x] Merge the reviewed current head and mark this section complete.
 
 ## PR 3: conditional per-coin HSL group
 
 ### Implementation
 
-- [ ] Branch from the merged PR 2 result.
-- [ ] Allow the complete `bot.<pside>.hsl.*` group only when that side's effective
-  `hsl_signal_mode` is `"coin"`.
-- [ ] Define and test precedence when the signal mode and HSL fields come from different
+- [x] Branch from the merged PR 2 result.
+- [x] Allow the complete `bot.<pside>.hsl.*` group only when the effective global
+  `live.hsl_signal_mode` is `"coin"`.
+- [x] Define and test precedence when the signal mode and HSL fields come from different
   sources.
-- [ ] Reject HSL coin patches in non-coin signal modes with actionable errors.
-- [ ] Validate every resolved HSL cross-field invariant.
-- [ ] Update HSL and coin-override documentation and the changelog.
+- [x] Reject HSL coin patches in non-coin signal modes with actionable errors.
+- [x] Validate every resolved HSL cross-field invariant.
+- [x] Update HSL and coin-override documentation and the changelog.
 
 ### Validation and release gate
 
-- [ ] Add table-driven coverage for every HSL field on both sides.
-- [ ] Cover global, file, and inline signal-mode transitions and invalid combinations.
-- [ ] Run focused and broader Python tests.
-- [ ] Rebuild and verify the Rust extension.
-- [ ] Run real HSL backtests with public fixtures and compare expected behavior.
-- [ ] Run deterministic offline fake-live HSL scenarios, including restart behavior.
+- [x] Add table-driven coverage for every HSL field on both sides.
+- [x] Cover global, file, and inline signal-mode transitions and invalid combinations.
+- [x] Run focused and broader Python tests.
+- [x] Rebuild and verify the Rust extension.
+- [x] Run real HSL backtests with public fixtures and compare expected behavior.
+- [x] Run deterministic offline fake-live HSL scenarios, including restart behavior.
 - [ ] Open a regular ready-for-review PR and request Codex review.
 - [ ] Address findings and repeat review plus validation until the current head is green.
 - [ ] Merge the reviewed current head and mark this section complete.
@@ -163,5 +164,5 @@ instead of extending the current feature branch indefinitely.
 - [x] PR 1 under review.
 - [x] PR 1 merged as `75116d1954c19e2bf54ef8313c18d332815a00e1`.
 - [x] PR 2 under review.
-- [ ] PR 2 merged.
+- [x] PR 2 merged as `9cc3cad58c566364d0ef5e01e9ef6457132246ea`.
 - [ ] PR 3 merged.

--- a/docs/plans/coin_overrides_overhaul.md
+++ b/docs/plans/coin_overrides_overhaul.md
@@ -139,8 +139,11 @@ instead of extending the current feature branch indefinitely.
 - [x] Rebuild and verify the Rust extension.
 - [x] Run real HSL backtests with public fixtures and compare expected behavior.
 - [x] Run deterministic offline fake-live HSL scenarios, including restart behavior.
-- [x] Open a regular ready-for-review PR and request Codex review; first pass requested on
-  `d0a6e4a4976a1b18199cce27eeb0e1b55aa97230`.
+- [x] Open a regular ready-for-review PR and request Codex review; first pass reviewed
+  `295abf6221006e8e1cbc0a73519438d670a6b57b`.
+- [x] Address the five first-pass findings in
+  `c151cbb44642228204dc8e47e765093d7d0f60f3`, add regressions, and rerun the full
+  Python suite, full Rust library suite, fake-live tests, and controlled HSL backtests.
 - [ ] Address findings and repeat review plus validation until the current head is green.
 - [ ] Merge the reviewed current head and mark this section complete.
 
@@ -166,4 +169,5 @@ instead of extending the current feature branch indefinitely.
 - [x] PR 1 merged as `75116d1954c19e2bf54ef8313c18d332815a00e1`.
 - [x] PR 2 under review.
 - [x] PR 2 merged as `9cc3cad58c566364d0ef5e01e9ef6457132246ea`.
+- [x] PR 3 first-pass findings addressed; current-head re-review pending.
 - [ ] PR 3 merged.

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -3204,13 +3204,16 @@ impl<'a> Backtest<'a> {
     }
 
     #[inline(always)]
-    fn hard_stop_orange_target_mode_pside(&self, pside: usize) -> orchestrator::TradingMode {
-        if self
-            .hard_stop_cfg_pside(pside)
-            .hsl_orange_tier_mode
-            .as_str()
-            == "graceful_stop"
-        {
+    fn hard_stop_orange_target_mode(
+        &self,
+        pside: usize,
+        coin_idx: Option<usize>,
+    ) -> orchestrator::TradingMode {
+        let cfg = coin_idx.map_or_else(
+            || self.hard_stop_cfg_pside(pside),
+            |idx| self.hard_stop_cfg_coin(pside, idx),
+        );
+        if cfg.hsl_orange_tier_mode.as_str() == "graceful_stop" {
             orchestrator::TradingMode::GracefulStop
         } else {
             orchestrator::TradingMode::TpOnly
@@ -3266,7 +3269,7 @@ impl<'a> Backtest<'a> {
                 }
             }
             ehsl::HardStopTier::Orange => {
-                let target = self.hard_stop_orange_target_mode_pside(pside);
+                let target = self.hard_stop_orange_target_mode(pside, None);
                 Self::apply_orange_override(mode, target);
             }
             _ => {}
@@ -3280,7 +3283,7 @@ impl<'a> Backtest<'a> {
         idx: usize,
         pside: usize,
     ) {
-        let cfg = self.hard_stop_cfg_pside(pside);
+        let cfg = self.hard_stop_cfg_coin(pside, idx);
         if !cfg.hsl_enabled || cfg.total_wallet_exposure_limit == 0.0 {
             return;
         }
@@ -3306,7 +3309,7 @@ impl<'a> Backtest<'a> {
                 }
             }
             ehsl::HardStopTier::Orange => {
-                let target = self.hard_stop_orange_target_mode_pside(pside);
+                let target = self.hard_stop_orange_target_mode(pside, Some(idx));
                 Self::apply_orange_override(mode, target);
             }
             _ => {}
@@ -3351,7 +3354,9 @@ impl<'a> Backtest<'a> {
                 }
                 self.record_hard_stop_pside_strategy_equity_sample(k, pside)?;
                 for idx in 0..self.n_coins {
-                    self.update_hard_stop_state_coin(k, idx, pside)?;
+                    if self.hard_stop_coin_should_update(pside, idx)? {
+                        self.update_hard_stop_state_coin(k, idx, pside)?;
+                    }
                 }
                 self.record_hard_stop_coin_drawdown_sample(pside);
             }
@@ -3463,8 +3468,10 @@ impl<'a> Backtest<'a> {
     }
 
     fn record_hard_stop_coin_drawdown_sample(&mut self, pside: usize) {
-        let cfg = self.hard_stop_cfg_pside(pside);
-        if !cfg.hsl_enabled || cfg.total_wallet_exposure_limit == 0.0 {
+        if !self
+            .hard_stop_coin_should_update_pside(pside)
+            .unwrap_or(false)
+        {
             return;
         }
         let Some(&timestamp_ms) = self.equities.timestamps_ms.last() else {
@@ -3708,8 +3715,7 @@ impl<'a> Backtest<'a> {
         idx: usize,
         pside: usize,
     ) -> Result<(), String> {
-        if !self.hard_stop_coin_should_update_pside(pside)?
-            || self.hard_stop_coin[pside][idx].halted
+        if !self.hard_stop_coin_should_update(pside, idx)? || self.hard_stop_coin[pside][idx].halted
         {
             return Ok(());
         }
@@ -3727,7 +3733,7 @@ impl<'a> Backtest<'a> {
                     k, idx, pside, e
                 )
             })?;
-        let cfg = self.hard_stop_cfg_pside(pside);
+        let cfg = self.hard_stop_cfg_coin(pside, idx);
         let hsl_red_threshold = cfg.hsl_red_threshold;
         let hsl_ema_span_minutes = cfg.hsl_ema_span_minutes;
         let hsl_tier_ratio_yellow = cfg.hsl_tier_ratio_yellow;
@@ -4687,12 +4693,30 @@ impl<'a> Backtest<'a> {
     }
 
     #[inline(always)]
+    fn hard_stop_cfg_coin(&self, pside: usize, idx: usize) -> &BotParams {
+        match pside {
+            LONG => &self.bot_params[idx].long,
+            SHORT => &self.bot_params[idx].short,
+            _ => unreachable!("invalid pside"),
+        }
+    }
+
+    #[inline(always)]
     fn hard_stop_enabled_pside(&self, pside: usize) -> bool {
         self.hard_stop_cfg_pside(pside).hsl_enabled
     }
 
     fn hard_stop_coin_should_update_pside(&self, pside: usize) -> Result<bool, String> {
-        let cfg = self.hard_stop_cfg_pside(pside);
+        for idx in 0..self.n_coins {
+            if self.hard_stop_coin_should_update(pside, idx)? {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    fn hard_stop_coin_should_update(&self, pside: usize, idx: usize) -> Result<bool, String> {
+        let cfg = self.hard_stop_cfg_coin(pside, idx);
         if !cfg.hsl_enabled {
             return Ok(false);
         }
@@ -4717,6 +4741,12 @@ impl<'a> Backtest<'a> {
 
     #[inline(always)]
     fn hard_stop_reporting_enabled_pside(&self, pside: usize) -> bool {
+        if self.hard_stop_signal_mode() == "coin" {
+            return (0..self.n_coins).any(|idx| {
+                let cfg = self.hard_stop_cfg_coin(pside, idx);
+                cfg.hsl_enabled && cfg.n_positions > 0 && cfg.total_wallet_exposure_limit > 0.0
+            });
+        }
         let cfg = self.hard_stop_cfg_pside(pside);
         cfg.hsl_enabled && cfg.n_positions > 0 && cfg.total_wallet_exposure_limit > 0.0
     }
@@ -4777,7 +4807,7 @@ impl<'a> Backtest<'a> {
         idx: usize,
         pside: usize,
     ) -> Result<(f64, f64, f64, f64, f64), String> {
-        let cfg = self.hard_stop_cfg_pside(pside);
+        let cfg = self.hard_stop_cfg_coin(pside, idx);
         let n_positions = self.hard_stop_coin_slot_n_positions(pside);
         let total_wallet_exposure_limit = cfg.total_wallet_exposure_limit;
         if n_positions == 0 {
@@ -4936,13 +4966,23 @@ impl<'a> Backtest<'a> {
         self.market_fill_price_for_qty(k, idx, order.qty)
     }
 
-    fn order_uses_market_execution(&self, order: &BacktestOrder) -> bool {
+    fn order_uses_market_execution(&self, idx: usize, order: &BacktestOrder) -> bool {
         match order.order.order_type {
             OrderType::ClosePanicLong => {
-                return self.bot_params_master.long.hsl_panic_close_order_type == "market";
+                let cfg = if self.hard_stop_signal_mode() == "coin" {
+                    &self.bot_params[idx].long
+                } else {
+                    &self.bot_params_master.long
+                };
+                return cfg.hsl_panic_close_order_type == "market";
             }
             OrderType::ClosePanicShort => {
-                return self.bot_params_master.short.hsl_panic_close_order_type == "market";
+                let cfg = if self.hard_stop_signal_mode() == "coin" {
+                    &self.bot_params[idx].short
+                } else {
+                    &self.bot_params_master.short
+                };
+                return cfg.hsl_panic_close_order_type == "market";
             }
             _ => {}
         }
@@ -4955,7 +4995,7 @@ impl<'a> Backtest<'a> {
         idx: usize,
         order: &BacktestOrder,
     ) -> Option<OrderFillExecution> {
-        if self.order_uses_market_execution(order) {
+        if self.order_uses_market_execution(idx, order) {
             return self
                 .market_fill_price(k, idx, &order.order)
                 .map(|price| OrderFillExecution {

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -1999,10 +1999,12 @@ impl<'a> Backtest<'a> {
                 bp.short.wallet_exposure_limit =
                     bp.short.total_wallet_exposure_limit / bp.short.n_positions as f64;
             }
-            Self::apply_common_hsl_config_to_bot_params_pair(
-                bp,
-                &backtest_params.equity_hard_stop_loss,
-            );
+            if backtest_params.equity_hard_stop_loss.signal_mode != "coin" {
+                Self::apply_common_hsl_config_to_bot_params_pair(
+                    bp,
+                    &backtest_params.equity_hard_stop_loss,
+                );
+            }
         }
         let strategy_params_parsed: Vec<StrategyParamsPair> = strategy_params
             .iter()
@@ -3433,7 +3435,11 @@ impl<'a> Backtest<'a> {
         k: usize,
         pside: usize,
     ) -> Result<(), String> {
-        if !self.hard_stop_enabled_pside(pside) {
+        if self.hard_stop_signal_mode() == "coin" {
+            if !self.hard_stop_coin_should_update_pside(pside)? {
+                return Ok(());
+            }
+        } else if !self.hard_stop_enabled_pside(pside) {
             return Ok(());
         }
         let Some(&timestamp_ms) = self.equities.timestamps_ms.last() else {
@@ -8355,7 +8361,7 @@ mod tests {
     }
 
     #[test]
-    fn common_hsl_does_not_enable_disabled_side_when_other_side_is_explicit() {
+    fn coin_mode_preserves_explicit_hsl_enablement_by_side() {
         let hlcvs = Array3::from_shape_vec((1, 1, 4), vec![100.0; 1 * 1 * 4]).unwrap();
         let btc_usd_prices = Array1::from_vec(vec![20_000.0]);
 
@@ -8415,6 +8421,9 @@ mod tests {
             candle_interval_minutes: 1,
         };
 
+        let mut all_disabled = bp_pair.clone();
+        all_disabled.long.hsl_enabled = false;
+
         let mut bt = Backtest::new(
             hlcvs.view(),
             btc_usd_prices.view(),
@@ -8424,6 +8433,16 @@ mod tests {
         );
         assert!(bt.bot_params_master.long.hsl_enabled);
         assert!(!bt.bot_params_master.short.hsl_enabled);
+
+        let disabled_bt = Backtest::new(
+            hlcvs.view(),
+            btc_usd_prices.view(),
+            vec![all_disabled],
+            vec![ExchangeParams::default()],
+            &backtest_params,
+        );
+        assert!(!disabled_bt.bot_params_master.long.hsl_enabled);
+        assert!(!disabled_bt.bot_params_master.short.hsl_enabled);
 
         assert!(bt.update_n_positions_and_wallet_exposure_limits(0));
         assert_eq!(bt.effective_n_positions.long, 1);
@@ -8440,14 +8459,14 @@ mod tests {
         let hlcvs = Array3::from_shape_vec((2, 2, 4), vec![100.0; 2 * 2 * 4]).unwrap();
         let btc_usd_prices = Array1::from_vec(vec![20_000.0, 20_000.0]);
 
-        let make_bp = || {
+        let make_bp = |hsl_enabled| {
             let mut bp_pair = BotParamsPair::default();
             bp_pair.long.n_positions = 2;
             bp_pair.long.total_wallet_exposure_limit = 2.0;
             bp_pair.long.wallet_exposure_limit = 1.0;
             bp_pair.long.ema_span_0 = 10.0;
             bp_pair.long.ema_span_1 = 20.0;
-            bp_pair.long.hsl_enabled = true;
+            bp_pair.long.hsl_enabled = hsl_enabled;
             bp_pair.long.hsl_red_threshold = 0.5;
             bp_pair.long.hsl_ema_span_minutes = 1.0;
             bp_pair.long.hsl_tier_ratio_yellow = 0.5;
@@ -8456,7 +8475,7 @@ mod tests {
         };
 
         let mut hs = EquityHardStopLossConfig::default();
-        hs.enabled = true;
+        hs.enabled = false;
         hs.signal_mode = "coin".to_string();
         hs.red_threshold = 0.5;
         hs.ema_span_minutes = 1.0;
@@ -8495,18 +8514,18 @@ mod tests {
         let mut bt = Backtest::new(
             hlcvs.view(),
             btc_usd_prices.view(),
-            vec![make_bp(), make_bp()],
+            vec![make_bp(false), make_bp(true)],
             vec![ExchangeParams::default(), ExchangeParams::default()],
             &backtest_params,
         );
         bt.balance.usd_total_balance = 100.0;
 
-        bt.record_coin_rolling_pnl(0, 0, LONG, 50.0);
+        bt.record_coin_rolling_pnl(0, 1, LONG, 50.0);
         bt.equities.timestamps_ms.push(0);
         bt.equities.usd_total_equity.push(100.0);
         bt.update_hard_stop_state(0).unwrap();
 
-        bt.record_coin_rolling_pnl(1, 0, LONG, -80.0);
+        bt.record_coin_rolling_pnl(1, 1, LONG, -80.0);
         bt.equities.timestamps_ms.push(60_000);
         bt.equities.usd_total_equity.push(100.0);
         bt.update_hard_stop_state(1).unwrap();

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -750,18 +750,14 @@ mod core {
         order: &IdealOrder,
         global: &OrchestratorGlobal,
         order_book: &OrderBook,
+        symbol_bot_params: Option<&BotParams>,
     ) -> bool {
         if is_panic_close_order_type(order.order_type) {
-            let pside_market = match order.pside {
-                PositionSide::Long => {
-                    global.global_bot_params.long.hsl_enabled
-                        && global.global_bot_params.long.hsl_panic_close_order_type == "market"
-                }
-                PositionSide::Short => {
-                    global.global_bot_params.short.hsl_enabled
-                        && global.global_bot_params.short.hsl_panic_close_order_type == "market"
-                }
-            };
+            let params = symbol_bot_params.unwrap_or(match order.pside {
+                PositionSide::Long => &global.global_bot_params.long,
+                PositionSide::Short => &global.global_bot_params.short,
+            });
+            let pside_market = params.hsl_enabled && params.hsl_panic_close_order_type == "market";
             return pside_market || global.panic_close_market;
         }
         if !global.market_orders_allowed {
@@ -791,8 +787,11 @@ mod core {
         order_book: &OrderBook,
         exchange: &ExchangeParams,
         position: &Position,
+        bot_params: &BotParams,
     ) {
-        if !order.order_type.is_close() || !should_use_market_execution(order, global, order_book) {
+        if !order.order_type.is_close()
+            || !should_use_market_execution(order, global, order_book, Some(bot_params))
+        {
             return;
         }
 
@@ -822,11 +821,12 @@ mod core {
         global: &OrchestratorGlobal,
         order_book: &OrderBook,
         exchange: &ExchangeParams,
+        bot_params: &BotParams,
     ) {
         if order.pside != PositionSide::Short
             || !order.order_type.is_entry()
             || order.qty >= 0.0
-            || !should_use_market_execution(order, global, order_book)
+            || !should_use_market_execution(order, global, order_book, Some(bot_params))
         {
             return;
         }
@@ -854,7 +854,12 @@ mod core {
             let Some(symbol) = symbols.get(order.symbol_idx) else {
                 return false;
             };
-            if !should_use_market_execution(order, global, &symbol.order_book) {
+            if !should_use_market_execution(
+                order,
+                global,
+                &symbol.order_book,
+                Some(&symbol.short.bot_params),
+            ) {
                 return true;
             }
             let minimum_qty = calc_min_entry_qty(symbol.order_book.bid, &symbol.exchange);
@@ -869,12 +874,14 @@ mod core {
         global: &OrchestratorGlobal,
         order_book: &OrderBook,
         mode: TradingMode,
+        bot_params: &BotParams,
     ) -> ExecutableOrder {
-        let execution_type = if should_use_market_execution(&order, global, order_book) {
-            ExecutionType::Market
-        } else {
-            ExecutionType::Limit
-        };
+        let execution_type =
+            if should_use_market_execution(&order, global, order_book, Some(bot_params)) {
+                ExecutionType::Market
+            } else {
+                ExecutionType::Limit
+            };
         let execution_priority = if is_protective_close_reducer(order.order_type, order.pside)
             || (mode == TradingMode::GracefulStop && order.order_type.is_close())
         {
@@ -1344,6 +1351,7 @@ mod core {
         ob: &OrderBook,
         exchange: &ExchangeParams,
         global: Option<&OrchestratorGlobal>,
+        bot_params: Option<&BotParams>,
     ) {
         const EPS: f64 = 1e-12;
         if closes.is_empty() {
@@ -1361,7 +1369,9 @@ mod core {
         // when the authoritative position is below every candidate's effective minimum. In a mixed
         // ladder, drop each below-min leg before the remaining close wave is trimmed.
         let minimum_price = |order: &IdealOrder| {
-            if global.is_some_and(|policy| should_use_market_execution(order, policy, ob)) {
+            if global
+                .is_some_and(|policy| should_use_market_execution(order, policy, ob, bot_params))
+            {
                 executable_touch_for_order_side(ob, order.qty)
             } else {
                 order.price
@@ -1569,9 +1579,11 @@ mod core {
         exchange: &ExchangeParams,
         global: &OrchestratorGlobal,
         order_book: &OrderBook,
+        bot_params: &BotParams,
     ) -> Option<f64> {
         const EPS: f64 = 1e-12;
-        let market_execution = should_use_market_execution(order, global, order_book);
+        let market_execution =
+            should_use_market_execution(order, global, order_book, Some(bot_params));
         let execution_price = if market_execution {
             projected_market_fill_price(order, global, order_book, exchange)?
         } else {
@@ -1709,6 +1721,7 @@ mod core {
             &symbol.exchange,
             &input.global,
             &symbol.order_book,
+            &symbol_side_input(symbol, order.pside).bot_params,
         ) else {
             return true;
         };
@@ -1766,6 +1779,7 @@ mod core {
             &symbol.order_book,
             &symbol.exchange,
             Some(global),
+            Some(&symbol_side_input(symbol, pside).bot_params),
         );
         finalized
     }
@@ -2924,7 +2938,12 @@ mod core {
             };
             let ob = &sym.order_book;
             let exch = &sym.exchange;
-            let fill_price = if should_use_market_execution(o, global, ob) {
+            let fill_price = if should_use_market_execution(
+                o,
+                global,
+                ob,
+                Some(&symbol_side_input(sym, o.pside).bot_params),
+            ) {
                 executable_touch_for_order_side(ob, o.qty)
             } else {
                 o.price
@@ -3127,7 +3146,12 @@ mod core {
                 Some(v) => v,
                 None => continue,
             };
-            let minimum_price = if should_use_market_execution(&o, global, &sym.order_book) {
+            let minimum_price = if should_use_market_execution(
+                &o,
+                global,
+                &sym.order_book,
+                Some(&symbol_side_input(sym, o.pside).bot_params),
+            ) {
                 executable_touch_for_order_side(&sym.order_book, o.qty)
             } else {
                 o.price
@@ -4098,6 +4122,7 @@ mod core {
                     &symbol.order_book,
                     &symbol.exchange,
                     &side.pos,
+                    &symbol.long.bot_params,
                 );
             }
         }
@@ -4109,6 +4134,7 @@ mod core {
                     &input.global,
                     &symbol.order_book,
                     &symbol.exchange,
+                    &symbol.short.bot_params,
                 );
             }
             for close in &mut side.closes {
@@ -4118,6 +4144,7 @@ mod core {
                     &symbol.order_book,
                     &symbol.exchange,
                     &side.pos,
+                    &symbol.short.bot_params,
                 );
             }
         }
@@ -4361,7 +4388,13 @@ mod core {
                 // normal so it can emit closes, but those closes remain risk-critical
                 // for live execution priority.
                 let mode = side.mode.unwrap_or(TradingMode::Normal);
-                to_executable_order(order, &input.global, &symbol.order_book, mode)
+                to_executable_order(
+                    order,
+                    &input.global,
+                    &symbol.order_book,
+                    mode,
+                    &side.bot_params,
+                )
             })
             .collect();
 
@@ -4766,8 +4799,19 @@ mod core {
                 price: 100.05,
                 order_type: OrderType::CloseGridLong,
             };
-            assert!(should_use_market_execution(&order, &global, &order_book));
-            let executable = to_executable_order(order, &global, &order_book, TradingMode::Normal);
+            assert!(should_use_market_execution(
+                &order,
+                &global,
+                &order_book,
+                Some(&global.global_bot_params.long),
+            ));
+            let executable = to_executable_order(
+                order,
+                &global,
+                &order_book,
+                TradingMode::Normal,
+                &global.global_bot_params.long,
+            );
             assert_eq!(executable.execution_type, ExecutionType::Market);
         }
 
@@ -4814,6 +4858,7 @@ mod core {
                     &order_book,
                     &exchange,
                     &position,
+                    &global.global_bot_params.long,
                 );
 
                 assert!((order.qty + 1.001).abs() <= f64::EPSILON * 8.0);
@@ -4850,6 +4895,7 @@ mod core {
                 &global,
                 &order_book,
                 &exchange,
+                &global.global_bot_params.short,
             );
 
             assert!((order.qty + 1.001).abs() <= f64::EPSILON * 8.0);
@@ -5070,6 +5116,7 @@ mod core {
                         &global,
                         &order_book,
                         TradingMode::Normal,
+                        &global.global_bot_params.long,
                     )
                     .execution_priority,
                     ExecutionPriority::RiskCritical,
@@ -5082,6 +5129,7 @@ mod core {
                     &global,
                     &order_book,
                     TradingMode::GracefulStop,
+                    &global.global_bot_params.long,
                 )
                 .execution_priority,
                 ExecutionPriority::RiskCritical
@@ -5091,8 +5139,14 @@ mod core {
                 make(OrderType::EntryGridNormalLong, 1.0),
             ] {
                 assert_eq!(
-                    to_executable_order(order, &global, &order_book, TradingMode::Normal,)
-                        .execution_priority,
+                    to_executable_order(
+                        order,
+                        &global,
+                        &order_book,
+                        TradingMode::Normal,
+                        &global.global_bot_params.long,
+                    )
+                    .execution_priority,
                     ExecutionPriority::Ordinary
                 );
             }
@@ -5170,14 +5224,38 @@ mod core {
                 price: 100.0,
                 order_type: OrderType::CloseGridLong,
             };
-            assert!(should_use_market_execution(&buy, &global, &order_book));
-            assert!(should_use_market_execution(&sell, &global, &order_book));
+            assert!(should_use_market_execution(
+                &buy,
+                &global,
+                &order_book,
+                Some(&global.global_bot_params.long),
+            ));
+            assert!(should_use_market_execution(
+                &sell,
+                &global,
+                &order_book,
+                Some(&global.global_bot_params.long),
+            ));
             assert_eq!(
-                to_executable_order(buy, &global, &order_book, TradingMode::Normal).execution_type,
+                to_executable_order(
+                    buy,
+                    &global,
+                    &order_book,
+                    TradingMode::Normal,
+                    &global.global_bot_params.long,
+                )
+                .execution_type,
                 ExecutionType::Market
             );
             assert_eq!(
-                to_executable_order(sell, &global, &order_book, TradingMode::Normal).execution_type,
+                to_executable_order(
+                    sell,
+                    &global,
+                    &order_book,
+                    TradingMode::Normal,
+                    &global.global_bot_params.long,
+                )
+                .execution_type,
                 ExecutionType::Market
             );
         }
@@ -5196,10 +5274,21 @@ mod core {
                 price: 100.0,
                 order_type: OrderType::CloseGridLong,
             };
-            assert!(!should_use_market_execution(&order, &global, &order_book));
+            assert!(!should_use_market_execution(
+                &order,
+                &global,
+                &order_book,
+                Some(&global.global_bot_params.long),
+            ));
             assert_eq!(
-                to_executable_order(order, &global, &order_book, TradingMode::Normal)
-                    .execution_type,
+                to_executable_order(
+                    order,
+                    &global,
+                    &order_book,
+                    TradingMode::Normal,
+                    &global.global_bot_params.long,
+                )
+                .execution_type,
                 ExecutionType::Limit
             );
         }
@@ -5411,12 +5500,17 @@ mod core {
         }
 
         #[test]
-        fn panic_close_respects_side_local_hsl_order_type() {
+        fn panic_close_respects_symbol_side_hsl_order_type() {
             let mut global = make_basic_global();
-            global.global_bot_params.long.hsl_enabled = true;
-            global.global_bot_params.long.hsl_panic_close_order_type = "market".to_string();
+            global.global_bot_params.long.hsl_enabled = false;
+            global.global_bot_params.long.hsl_panic_close_order_type = "limit".to_string();
             global.global_bot_params.short.hsl_enabled = true;
-            global.global_bot_params.short.hsl_panic_close_order_type = "limit".to_string();
+            global.global_bot_params.short.hsl_panic_close_order_type = "market".to_string();
+            let mut symbol_long = global.global_bot_params.long.clone();
+            symbol_long.hsl_enabled = true;
+            symbol_long.hsl_panic_close_order_type = "market".to_string();
+            let mut symbol_short = global.global_bot_params.short.clone();
+            symbol_short.hsl_panic_close_order_type = "limit".to_string();
             let order_book = OrderBook {
                 bid: 100.0,
                 ask: 100.0,
@@ -5441,6 +5535,7 @@ mod core {
                     &global,
                     &order_book,
                     TradingMode::Normal,
+                    &symbol_long,
                 )
                 .execution_type,
                 ExecutionType::Market
@@ -5451,14 +5546,21 @@ mod core {
                     &global,
                     &order_book,
                     TradingMode::Normal,
+                    &symbol_short,
                 )
                 .execution_type,
                 ExecutionType::Limit
             );
             global.panic_close_market = true;
             assert_eq!(
-                to_executable_order(short_order, &global, &order_book, TradingMode::Normal,)
-                    .execution_type,
+                to_executable_order(
+                    short_order,
+                    &global,
+                    &order_book,
+                    TradingMode::Normal,
+                    &symbol_short,
+                )
+                .execution_type,
                 ExecutionType::Market
             );
         }
@@ -6230,7 +6332,15 @@ mod core {
                     order_type: OrderType::CloseGridLong,
                 },
             ];
-            trim_closes_to_position(PositionSide::Long, &mut closes, 1.5, &ob, &exchange, None);
+            trim_closes_to_position(
+                PositionSide::Long,
+                &mut closes,
+                1.5,
+                &ob,
+                &exchange,
+                None,
+                None,
+            );
             let total: f64 = closes.iter().map(|o| o.qty.abs()).sum();
             assert!(total <= 1.5 + 1e-9);
             assert_eq!(closes.len(), 2);
@@ -6284,6 +6394,7 @@ mod core {
                 &ob,
                 &exchange,
                 None,
+                None,
             );
 
             let total: f64 = closes.iter().map(|order| order.qty.abs()).sum();
@@ -6322,7 +6433,15 @@ mod core {
                 },
             ];
 
-            trim_closes_to_position(PositionSide::Long, &mut closes, 1.5, &ob, &exchange, None);
+            trim_closes_to_position(
+                PositionSide::Long,
+                &mut closes,
+                1.5,
+                &ob,
+                &exchange,
+                None,
+                None,
+            );
 
             let reducer = closes
                 .iter()
@@ -6951,7 +7070,15 @@ mod core {
                 price: 101.0,
                 order_type: OrderType::CloseGridLong,
             }];
-            trim_closes_to_position(PositionSide::Long, &mut closes, 100.0, &ob, &exchange, None);
+            trim_closes_to_position(
+                PositionSide::Long,
+                &mut closes,
+                100.0,
+                &ob,
+                &exchange,
+                None,
+                None,
+            );
             assert!(closes.is_empty());
 
             // pos smaller than effective min => allow full close of tiny pos
@@ -6962,7 +7089,15 @@ mod core {
                 price: 101.0,
                 order_type: OrderType::CloseGridLong,
             }];
-            trim_closes_to_position(PositionSide::Long, &mut closes, 5.0, &ob, &exchange, None);
+            trim_closes_to_position(
+                PositionSide::Long,
+                &mut closes,
+                5.0,
+                &ob,
+                &exchange,
+                None,
+                None,
+            );
             assert_eq!(closes.len(), 1);
             assert!((closes[0].qty + 5.0).abs() < 1e-9);
         }
@@ -6989,7 +7124,15 @@ mod core {
                 order_type: OrderType::CloseGridShort,
             }];
 
-            trim_closes_to_position(PositionSide::Short, &mut closes, -1.0, &ob, &exchange, None);
+            trim_closes_to_position(
+                PositionSide::Short,
+                &mut closes,
+                -1.0,
+                &ob,
+                &exchange,
+                None,
+                None,
+            );
 
             assert_eq!(closes.len(), 1);
             assert!((closes[0].qty - 1.0).abs() < 1e-12);
@@ -7027,7 +7170,15 @@ mod core {
                 },
             ];
 
-            trim_closes_to_position(PositionSide::Short, &mut closes, -5.0, &ob, &exchange, None);
+            trim_closes_to_position(
+                PositionSide::Short,
+                &mut closes,
+                -5.0,
+                &ob,
+                &exchange,
+                None,
+                None,
+            );
 
             assert_eq!(closes.len(), 1);
             assert!((closes[0].qty - 5.0).abs() < 1e-12);
@@ -7066,6 +7217,7 @@ mod core {
                 &ob,
                 &exchange,
                 Some(&global),
+                Some(&global.global_bot_params.short),
             );
 
             assert_eq!(closes.len(), 1);
@@ -7717,8 +7869,15 @@ mod core {
                 price: 101.0,
             };
 
-            let projected =
-                projected_close_pnl(&order, &pos, &exchange, &global, &order_book).unwrap();
+            let projected = projected_close_pnl(
+                &order,
+                &pos,
+                &exchange,
+                &global,
+                &order_book,
+                &global.global_bot_params.long,
+            )
+            .unwrap();
 
             assert!((projected - -2.0).abs() < 1e-12);
         }

--- a/passivbot-rust/src/python.rs
+++ b/passivbot-rust/src/python.rs
@@ -2636,6 +2636,15 @@ fn validate_hsl_risk_unstuck_bot_params(
     pside: &str,
     params: &BotParams,
 ) -> PyResult<()> {
+    match params.hsl_panic_close_order_type.as_str() {
+        "market" | "limit" => {}
+        raw => {
+            return Err(PyValueError::new_err(format!(
+                "{path_prefix}.hsl_panic_close_order_type must be one of: market, limit; got {:?}",
+                raw
+            )));
+        }
+    }
     validate_finite_range(
         &format!("{path_prefix}.hsl_ema_span_minutes"),
         params.hsl_ema_span_minutes,
@@ -2683,18 +2692,20 @@ fn validate_hsl_risk_unstuck_bot_params(
         params.hsl_tier_ratio_yellow,
         0.0,
         Some(1.0),
-        true,
+        false,
     )?;
     validate_finite_range(
         &format!("{path_prefix}.hsl_tier_ratio_orange"),
         params.hsl_tier_ratio_orange,
         0.0,
         Some(1.0),
-        true,
+        false,
     )?;
-    if params.hsl_tier_ratio_yellow > params.hsl_tier_ratio_orange {
+    if !(params.hsl_tier_ratio_yellow < params.hsl_tier_ratio_orange
+        && params.hsl_tier_ratio_orange < 1.0)
+    {
         return Err(PyValueError::new_err(format!(
-            "{path_prefix}.hsl_tier_ratio_yellow must be <= {path_prefix}.hsl_tier_ratio_orange"
+            "{path_prefix}.hsl tier ratios must satisfy 0 < yellow < orange < 1"
         )));
     }
     validate_finite_range(

--- a/src/config/bot.py
+++ b/src/config/bot.py
@@ -32,6 +32,10 @@ CLIFF_EDGE_THRESHOLD_KEYS = (
     "unstuck_threshold",
 )
 TWEL_ENFORCER_POLICIES = frozenset({"reduce_overweight", "reduce_portfolio"})
+HSL_ORANGE_TIER_MODES = frozenset(
+    {"graceful_stop", "tp_only_with_active_entry_cancellation"}
+)
+HSL_PANIC_CLOSE_ORDER_TYPES = frozenset({"limit", "market"})
 CLIFF_EDGE_DUST_EPS = 1e-9
 CLIFF_EDGE_WARNING_THRESHOLD = 0.1
 FORAGER_CANONICAL_TO_INTERNAL_BOT_KEYS = {
@@ -73,6 +77,15 @@ def _validate_bool(value, *, path: str) -> bool:
     if isinstance(value, bool):
         return value
     raise TypeError(f"{path} must be a boolean")
+
+
+def _validate_string_choice(value, *, path: str, allowed: frozenset[str]) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{path} must be a string")
+    if value not in allowed:
+        choices = ", ".join(sorted(allowed))
+        raise ValueError(f"{path} must be one of {{{choices}}}, got {value!r}")
+    return value
 
 
 def _validate_positive_ratio_when_enabled(
@@ -478,6 +491,20 @@ def normalize_hsl_risk_unstuck_numerics(
             path=f"{hsl_path}.ema_span_minutes",
             verbose=verbose,
             tracker=tracker,
+        )
+        _validate_bool(
+            get_grouped_bot_value(bot_side, "hsl_enabled"),
+            path=f"{hsl_path}.enabled",
+        )
+        _validate_string_choice(
+            get_grouped_bot_value(bot_side, "hsl_orange_tier_mode"),
+            path=f"{hsl_path}.orange_tier_mode",
+            allowed=HSL_ORANGE_TIER_MODES,
+        )
+        _validate_string_choice(
+            get_grouped_bot_value(bot_side, "hsl_panic_close_order_type"),
+            path=f"{hsl_path}.panic_close_order_type",
+            allowed=HSL_PANIC_CLOSE_ORDER_TYPES,
         )
         red_threshold = _validate_ratio(
             get_grouped_bot_value(bot_side, "hsl_red_threshold"),

--- a/src/config/bot.py
+++ b/src/config/bot.py
@@ -552,15 +552,17 @@ def normalize_hsl_risk_unstuck_numerics(
             tier_ratios.get("yellow"),
             path=f"{hsl_path}.tier_ratios.yellow",
             max_value=1.0,
+            min_inclusive=False,
         )
         orange = _validate_ratio(
             tier_ratios.get("orange"),
             path=f"{hsl_path}.tier_ratios.orange",
             max_value=1.0,
+            min_inclusive=False,
         )
-        if yellow > orange:
+        if not yellow < orange or orange >= 1.0:
             raise ValueError(
-                f"{hsl_path}.tier_ratios.yellow must be <= {hsl_path}.tier_ratios.orange"
+                f"{hsl_path}.tier_ratios must satisfy 0 < yellow < orange < 1"
             )
         restart_after_red_policy = normalize_hsl_restart_after_red_policy(
             get_grouped_bot_value(bot_side, "hsl_restart_after_red_policy"),

--- a/src/config/migrations/trailing_grid_v7.py
+++ b/src/config/migrations/trailing_grid_v7.py
@@ -108,8 +108,6 @@ MANUAL_REVIEW_BOUND_KEYS = {
 COIN_OVERRIDE_SIDE_PASSTHROUGH_KEYS = {
     "wallet_exposure_limit",
 }
-COIN_OVERRIDE_SUPPORTED_SHARED_FLAT_KEYS = allowed_flat_bot_side_modification_keys()
-
 V7_ABSENT_RISK_DEFAULTS = {
     "risk_entry_cooldown_minutes": 0.0,
     "risk_we_excess_allowance_mode": WE_EXCESS_ALLOWANCE_MODE_BOUNDED,
@@ -1260,6 +1258,9 @@ def _migrate_coin_overrides(source: dict, target: dict, report: dict) -> None:
     if not isinstance(coin_overrides, dict):
         return
     allowed_live_keys = set(target.get("live", {}))
+    allowed_shared_flat_keys = allowed_flat_bot_side_modification_keys(
+        hsl_signal_mode=target.get("live", {}).get("hsl_signal_mode", "pside")
+    )
     result = {}
     for coin, override in coin_overrides.items():
         if not isinstance(override, dict):
@@ -1299,7 +1300,7 @@ def _migrate_coin_overrides(source: dict, target: dict, report: dict) -> None:
                     report,
                     source_prefix=prefix,
                     target_prefix=prefix,
-                    allowed_flat_keys=COIN_OVERRIDE_SUPPORTED_SHARED_FLAT_KEYS,
+                    allowed_flat_keys=allowed_shared_flat_keys,
                 )
                 _move_strategy_side_fields(
                     side,

--- a/src/config/overrides.py
+++ b/src/config/overrides.py
@@ -11,6 +11,7 @@ from utils import symbol_to_coin
 from .load import load_input_config, prepare_config
 from .log_output import log_config_message
 from .schema import get_template_config
+from .coerce import normalize_hsl_signal_mode
 from .shared_bot import BOT_GROUP_FIELD_MAP, canonicalize_shared_bot_side
 from .strategy import (
     TRAILING_GRID_V7_FLAT_ONLY_KEYS,
@@ -64,6 +65,20 @@ def apply_allowed_modifications(src, modifications, allowed_overrides, return_fu
     return result
 
 
+CONDITIONAL_HSL_OVERRIDE_PATHS = frozenset(
+    {
+        "hsl.cooldown_minutes_after_red",
+        "hsl.ema_span_minutes",
+        "hsl.enabled",
+        "hsl.no_restart_drawdown_threshold",
+        "hsl.orange_tier_mode",
+        "hsl.panic_close_order_type",
+        "hsl.red_threshold",
+        "hsl.restart_after_red_policy",
+        "hsl.tier_ratios.orange",
+        "hsl.tier_ratios.yellow",
+    }
+)
 OVERRIDABLE_SHARED_BOT_PATHS = frozenset(
     {
         "risk.entry_cooldown_minutes",
@@ -77,14 +92,30 @@ OVERRIDABLE_SHARED_BOT_PATHS = frozenset(
         "unstuck.loss_allowance_pct",
         "unstuck.threshold",
     }
+    | CONDITIONAL_HSL_OVERRIDE_PATHS
 )
 OVERRIDABLE_STANDALONE_BOT_KEYS = frozenset({"wallet_exposure_limit"})
 REMOVED_COIN_OVERRIDE_PATHS = frozenset({"risk.we_excess_allowance_mode"})
 
 
-def _flat_bot_side_modification_policy() -> dict[str, bool]:
+def _active_shared_bot_override_paths(hsl_signal_mode: str) -> frozenset[str]:
+    if normalize_hsl_signal_mode(hsl_signal_mode) == "coin":
+        return OVERRIDABLE_SHARED_BOT_PATHS
+    return OVERRIDABLE_SHARED_BOT_PATHS - CONDITIONAL_HSL_OVERRIDE_PATHS
+
+
+def _flat_bot_side_modification_policy(
+    *, hsl_signal_mode: str = "coin"
+) -> dict[str, bool]:
+    active_paths = _active_shared_bot_override_paths(hsl_signal_mode)
     policy = {
-        flat_key: f"{group_name}.{local_key}" in OVERRIDABLE_SHARED_BOT_PATHS
+        flat_key: (
+            f"{group_name}.{local_key}" in active_paths
+            or any(
+                path.startswith(f"{group_name}.{local_key}.")
+                for path in active_paths
+            )
+        )
         for group_name, field_map in BOT_GROUP_FIELD_MAP.items()
         for local_key, flat_key in field_map.items()
     }
@@ -92,10 +123,14 @@ def _flat_bot_side_modification_policy() -> dict[str, bool]:
     return policy
 
 
-def allowed_flat_bot_side_modification_keys() -> frozenset[str]:
+def allowed_flat_bot_side_modification_keys(
+    *, hsl_signal_mode: str = "coin"
+) -> frozenset[str]:
     return frozenset(
         key
-        for key, allowed in _flat_bot_side_modification_policy().items()
+        for key, allowed in _flat_bot_side_modification_policy(
+            hsl_signal_mode=hsl_signal_mode
+        ).items()
         if allowed is True
     )
 
@@ -140,7 +175,7 @@ def _reject_flat_strategy_coin_overrides(overrides: dict, *, coin: str) -> None:
             )
 
 
-def _allowed_bot_side_modifications() -> dict:
+def _allowed_bot_side_modifications(*, hsl_signal_mode: str = "coin") -> dict:
     def _allow_dotted_paths(keys: tuple[str, ...]) -> dict:
         result = {}
         for key in keys:
@@ -151,27 +186,30 @@ def _allowed_bot_side_modifications() -> dict:
             current[parts[-1]] = True
         return result
 
-    side = _flat_bot_side_modification_policy()
+    active_paths = _active_shared_bot_override_paths(hsl_signal_mode)
+    side = _flat_bot_side_modification_policy(hsl_signal_mode=hsl_signal_mode)
     side["strategy"] = {
         strategy_kind: _allow_dotted_paths(keys)
         for strategy_kind in get_supported_strategy_kinds()
         for keys in (get_strategy_param_keys(strategy_kind),)
     }
-    for group_name, field_map in BOT_GROUP_FIELD_MAP.items():
-        grouped_allowed = {
-            local_key: f"{group_name}.{local_key}" in OVERRIDABLE_SHARED_BOT_PATHS
-            for local_key in field_map
-        }
-        if any(grouped_allowed.values()):
+    for group_name in BOT_GROUP_FIELD_MAP:
+        relative_paths = tuple(
+            path.removeprefix(f"{group_name}.")
+            for path in active_paths
+            if path.startswith(f"{group_name}.")
+        )
+        if relative_paths:
+            grouped_allowed = _allow_dotted_paths(relative_paths)
             side[group_name] = grouped_allowed
     return side
 
 
-def get_allowed_modifications():
+def get_allowed_modifications(*, hsl_signal_mode: str = "coin"):
     return {
         "bot": {
-            "long": _allowed_bot_side_modifications(),
-            "short": _allowed_bot_side_modifications(),
+            "long": _allowed_bot_side_modifications(hsl_signal_mode=hsl_signal_mode),
+            "short": _allowed_bot_side_modifications(hsl_signal_mode=hsl_signal_mode),
         },
         "live": {
             "forced_mode_long": True,
@@ -236,6 +274,7 @@ def _extract_allowed_patch(
     source: str,
     strict: bool,
     strategy_kind: str,
+    hsl_signal_mode: str,
 ) -> dict:
     """Extract explicitly supplied allowed leaves without hydrating defaults."""
 
@@ -259,6 +298,20 @@ def _extract_allowed_patch(
                 continue
             if not isinstance(side, dict):
                 raise TypeError(f"{source}.bot.{pside} must be a dict")
+            hsl_group = side.get("hsl")
+            hsl_flat_keys = set(BOT_GROUP_FIELD_MAP["hsl"].values())
+            has_hsl_patch = (
+                isinstance(hsl_group, dict) and bool(hsl_group)
+            ) or any(key in side for key in hsl_flat_keys)
+            if has_hsl_patch and hsl_signal_mode != "coin":
+                path = _format_override_path(coin, ("bot", pside, "hsl"))
+                message = (
+                    f"{path} is overridable only when the effective global "
+                    f"live.hsl_signal_mode is 'coin'; got {hsl_signal_mode!r}"
+                )
+                if strict:
+                    raise ValueError(message)
+                logging.warning("%s; the file HSL values are ignored", message)
             for removed_path in REMOVED_COIN_OVERRIDE_PATHS:
                 group_name, local_key = removed_path.split(".", 1)
                 flat_key = BOT_GROUP_FIELD_MAP[group_name][local_key]
@@ -305,7 +358,7 @@ def _extract_allowed_patch(
                 for kind in mismatched:
                     strategy.pop(kind, None)
 
-    allowed = get_allowed_modifications()
+    allowed = get_allowed_modifications(hsl_signal_mode=hsl_signal_mode)
 
     def visit(value, policy, path: tuple[str, ...]):
         if policy is True:
@@ -442,6 +495,7 @@ def _validate_effective_coin_config(
     validation_input = get_template_config()
     nested_update(validation_input, effective)
     effective = validation_input
+    canonical_base = deepcopy(effective)
     for root in ("bot", "live"):
         if root in patch:
             nested_update(effective[root], deepcopy(patch[root]))
@@ -475,6 +529,25 @@ def _validate_effective_coin_config(
             deepcopy(normalized_value),
             create_missing=True,
         )
+    for pside in ("long", "short"):
+        hsl_patch = patch.get("bot", {}).get(pside, {}).get("hsl")
+        if not isinstance(hsl_patch, dict) or not hsl_patch:
+            continue
+        dependent_path = (
+            "bot",
+            pside,
+            "hsl",
+            "no_restart_drawdown_threshold",
+        )
+        normalized_value = _get_nested_value(prepared, dependent_path)
+        base_value = _get_nested_value(canonical_base, dependent_path)
+        if normalized_value != base_value:
+            set_nested_value_safe(
+                normalized_patch,
+                list(dependent_path),
+                deepcopy(normalized_value),
+                create_missing=True,
+            )
     return normalized_patch
 
 
@@ -635,6 +708,10 @@ def parse_overrides(
             )
     result["coin_overrides"] = normalized_overrides
     strategy_kind = normalize_strategy_kind(result.get("live", {}).get("strategy_kind"))
+    live_config = result.get("live", {})
+    hsl_signal_mode = normalize_hsl_signal_mode(
+        live_config["hsl_signal_mode"] if "hsl_signal_mode" in live_config else "coin"
+    )
     for coin, overrides in result["coin_overrides"].items():
         parsed_overrides = {}
         loaded = override_loader(result, coin)
@@ -645,6 +722,7 @@ def parse_overrides(
                 source=f"coin_overrides.{coin}.override_config_path",
                 strict=False,
                 strategy_kind=strategy_kind,
+                hsl_signal_mode=hsl_signal_mode,
             )
             _validate_patch_leaf_types(
                 result,
@@ -664,6 +742,7 @@ def parse_overrides(
             source=f"coin_overrides.{coin}",
             strict=True,
             strategy_kind=strategy_kind,
+            hsl_signal_mode=hsl_signal_mode,
         )
         _validate_patch_leaf_types(
             result,

--- a/src/config/overrides.py
+++ b/src/config/overrides.py
@@ -475,7 +475,12 @@ def _validate_patch_leaf_types(
 
 
 def _validate_effective_coin_config(
-    config: dict, patch: dict, *, coin: str, origin: str
+    config: dict,
+    patch: dict,
+    *,
+    coin: str,
+    origin: str,
+    retain_derived_hsl_dependents: bool = False,
 ) -> dict:
     effective = deepcopy(config)
     for metadata_key in (
@@ -529,7 +534,7 @@ def _validate_effective_coin_config(
             deepcopy(normalized_value),
             create_missing=True,
         )
-    for pside in ("long", "short"):
+    for pside in ("long", "short") if retain_derived_hsl_dependents else ():
         hsl_patch = patch.get("bot", {}).get(pside, {}).get("hsl")
         if not isinstance(hsl_patch, dict) or not hsl_patch:
             continue
@@ -759,6 +764,7 @@ def parse_overrides(
             parsed_overrides,
             coin=coin,
             origin="file and inline precedence resolution",
+            retain_derived_hsl_dependents=True,
         )
         result.setdefault("coin_overrides", {})[coin] = parsed_overrides
         log_config_message(

--- a/src/config/strategy.py
+++ b/src/config/strategy.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 from typing import Optional
 
-from .shared_bot import BOT_SHARED_GROUPS, flatten_shared_bot_side
+from .shared_bot import flatten_shared_bot_side
 from .strategy_spec import (
     BOT_POSITION_SIDES,
     DEFAULT_STRATEGY_KIND,
@@ -344,12 +344,20 @@ def merge_runtime_bot_side(
     override_side: dict | None = None,
     strategy_kind: str = DEFAULT_STRATEGY_KIND,
 ) -> dict:
+    def merge_patch(base: dict, patch: dict) -> dict:
+        result = deepcopy(base)
+        for patch_key, patch_value in patch.items():
+            if isinstance(result.get(patch_key), dict) and isinstance(
+                patch_value, dict
+            ):
+                result[patch_key] = merge_patch(result[patch_key], patch_value)
+            else:
+                result[patch_key] = deepcopy(patch_value)
+        return result
+
     normalized_kind = normalize_strategy_kind(strategy_kind)
     strategy_keys = set(get_strategy_param_keys(normalized_kind))
-    merged = deepcopy(bot_side) if isinstance(bot_side, dict) else {}
-    merged.pop("strategy", None)
-    for group_name in BOT_SHARED_GROUPS:
-        merged.pop(group_name, None)
+    merged = flatten_shared_bot_side(bot_side)
     for key in list(merged):
         if key in strategy_keys:
             merged.pop(key)
@@ -359,5 +367,8 @@ def merge_runtime_bot_side(
                 continue
             if key in strategy_keys:
                 continue
-            merged[key] = deepcopy(value)
+            if isinstance(merged.get(key), dict) and isinstance(value, dict):
+                merged[key] = merge_patch(merged[key], value)
+            else:
+                merged[key] = deepcopy(value)
     return merged

--- a/src/live/reconciler.py
+++ b/src/live/reconciler.py
@@ -1397,7 +1397,9 @@ def _expected_rust_effective_mode(
 
 
 def _expected_rust_panic_execution_type(
-    global_input: dict, order_type: str, pside: str
+    global_input: dict,
+    symbol_side_hsl_execution: tuple[bool, str],
+    order_type: str,
 ) -> str | None:
     if order_type.rsplit("_", 1)[0] != "close_panic":
         return None
@@ -1405,32 +1407,24 @@ def _expected_rust_panic_execution_type(
     # this before market_orders_allowed, so Python must preserve the same rule.
     if global_input.get("panic_close_market", False) is True:
         return "market"
-    global_bot_params = global_input.get("global_bot_params")
-    if not isinstance(global_bot_params, dict):
-        return "limit"
-    side_params = global_bot_params.get(pside)
-    if not isinstance(side_params, dict):
-        return "limit"
+    hsl_enabled, panic_close_order_type = symbol_side_hsl_execution
     return (
         "market"
-        if (
-            side_params.get("hsl_enabled", False) is True
-            and side_params.get("hsl_panic_close_order_type", "market") == "market"
-        )
+        if hsl_enabled and panic_close_order_type == "market"
         else "limit"
     )
 
 
 def _expected_rust_execution_type(
     global_input: dict,
+    symbol_side_hsl_execution: tuple[bool, str],
     order_book: tuple[float, float],
     order_type: str,
-    pside: str,
     qty: float,
     price: float,
 ) -> str:
     panic_execution_type = _expected_rust_panic_execution_type(
-        global_input, order_type, pside
+        global_input, symbol_side_hsl_execution, order_type
     )
     if panic_execution_type is not None:
         return panic_execution_type
@@ -1468,6 +1462,7 @@ def _submitted_rust_input_context(
     dict[tuple[int, str], bool],
     dict[tuple[int, str], bool],
     dict[tuple[int, str], bool],
+    dict[tuple[int, str], tuple[bool, str]],
 ]:
     symbols = orchestrator_input.get("symbols")
     if not isinstance(symbols, list):
@@ -1484,6 +1479,7 @@ def _submitted_rust_input_context(
     entry_cooldown_positive: dict[tuple[int, str], bool] = {}
     entry_sequential_staging: dict[tuple[int, str], bool] = {}
     close_retracement_enabled: dict[tuple[int, str], bool] = {}
+    hsl_execution_policy: dict[tuple[int, str], tuple[bool, str]] = {}
     timestamp_ms = _validated_rust_u64(
         orchestrator_input.get("timestamp_ms", 0), "input has invalid timestamp_ms"
     )
@@ -1658,6 +1654,21 @@ def _submitted_rust_input_context(
                 raise FatalBotException(
                     f"Rust orchestrator symbol input {input_idx} has invalid {pside} bot_params"
                 )
+            hsl_enabled = bot_params.get("hsl_enabled", False)
+            panic_close_order_type = bot_params.get(
+                "hsl_panic_close_order_type", "market"
+            )
+            if not isinstance(hsl_enabled, bool) or panic_close_order_type not in {
+                "limit",
+                "market",
+            }:
+                raise FatalBotException(
+                    f"Rust orchestrator symbol input {input_idx} has invalid {pside} HSL execution policy"
+                )
+            hsl_execution_policy[(symbol_idx, pside)] = (
+                hsl_enabled,
+                panic_close_order_type,
+            )
             cooldown_minutes = _validated_rust_finite_number(
                 bot_params.get("risk_entry_cooldown_minutes", 0.0),
                 f"symbol input {input_idx} has invalid {pside} risk_entry_cooldown_minutes",
@@ -1775,6 +1786,7 @@ def _submitted_rust_input_context(
         entry_cooldown_positive,
         entry_sequential_staging,
         close_retracement_enabled,
+        hsl_execution_policy,
     )
 
 
@@ -1856,6 +1868,7 @@ def validate_rust_orchestrator_output(
         submitted_entry_cooldown_positive,
         submitted_entry_sequential_staging,
         submitted_close_retracement_enabled,
+        submitted_hsl_execution_policy,
     ) = _submitted_rust_input_context(orchestrator_input, expected_symbol_idxs)
     seen_conversion_identities: dict[tuple[object, float, float, str], int] = {}
     aggregate_close_qty: dict[tuple[int, str], float] = {}
@@ -2056,9 +2069,9 @@ def validate_rust_orchestrator_output(
             )
         expected_execution_type = _expected_rust_execution_type(
             global_input,
+            submitted_hsl_execution_policy[pair],
             submitted_order_books[symbol_idx],
             order_type,
-            pside,
             qty,
             price,
         )
@@ -2575,9 +2588,9 @@ def validate_rust_orchestrator_output(
             )
         block_execution_type = _expected_rust_execution_type(
             global_input,
+            submitted_hsl_execution_policy[pair],
             submitted_order_books[symbol_idx],
             order_type,
-            pside,
             qty,
             finite_values["price"],
         )

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -2169,6 +2169,7 @@ class Passivbot:
     _hsl_psides = pb_hsl._hsl_psides
     _hsl_state = pb_hsl._hsl_state
     _parse_hsl_config = pb_hsl._parse_hsl_config
+    _equity_hard_stop_config = pb_hsl._equity_hard_stop_config
     _equity_hard_stop_enabled = pb_hsl._equity_hard_stop_enabled
     _equity_hard_stop_signal_mode = pb_hsl._equity_hard_stop_signal_mode
     _equity_hard_stop_balance_override_active = (
@@ -16688,35 +16689,63 @@ class Passivbot:
                     )
             else:
                 out[out_key] = float(val or 0.0)
-        out.update(
-            {
-                "hsl_enabled": bool(self.bot_value(pside, "hsl_enabled")),
-                "hsl_red_threshold": float(self.bot_value(pside, "hsl_red_threshold")),
-                "hsl_ema_span_minutes": float(
+        hsl_cfg = (
+            self._equity_hard_stop_config(pside, symbol)
+            if symbol is not None and hasattr(self, "_equity_hard_stop_config")
+            else {
+                "enabled": bool(self.bot_value(pside, "hsl_enabled")),
+                "red_threshold": float(self.bot_value(pside, "hsl_red_threshold")),
+                "ema_span_minutes": float(
                     self.bot_value(pside, "hsl_ema_span_minutes")
                 ),
-                "hsl_cooldown_minutes_after_red": float(
+                "cooldown_minutes_after_red": float(
                     self.bot_value(pside, "hsl_cooldown_minutes_after_red")
                 ),
-                "hsl_no_restart_drawdown_threshold": float(
+                "no_restart_drawdown_threshold": float(
                     self.bot_value(pside, "hsl_no_restart_drawdown_threshold")
                 ),
+                "restart_after_red_policy": self.bot_value(
+                    pside, "hsl_restart_after_red_policy"
+                ),
+                "tier_ratios": {
+                    "yellow": float(
+                        self.bot_value(pside, "hsl_tier_ratios.yellow")
+                    ),
+                    "orange": float(
+                        self.bot_value(pside, "hsl_tier_ratios.orange")
+                    ),
+                },
+                "orange_tier_mode": str(
+                    self.bot_value(pside, "hsl_orange_tier_mode")
+                ),
+                "panic_close_order_type": str(
+                    self.bot_value(pside, "hsl_panic_close_order_type")
+                ),
+            }
+        )
+        out.update(
+            {
+                "hsl_enabled": bool(hsl_cfg["enabled"]),
+                "hsl_red_threshold": float(hsl_cfg["red_threshold"]),
+                "hsl_ema_span_minutes": float(hsl_cfg["ema_span_minutes"]),
+                "hsl_cooldown_minutes_after_red": float(
+                    hsl_cfg["cooldown_minutes_after_red"]
+                ),
+                "hsl_no_restart_drawdown_threshold": float(
+                    hsl_cfg["no_restart_drawdown_threshold"]
+                ),
                 "hsl_restart_after_red_policy": normalize_hsl_restart_after_red_policy(
-                    self.bot_value(pside, "hsl_restart_after_red_policy"),
+                    hsl_cfg["restart_after_red_policy"],
                     path=f"bot.{pside}.hsl_restart_after_red_policy",
                 ),
                 "hsl_tier_ratio_yellow": float(
-                    self.bot_value(pside, "hsl_tier_ratios.yellow")
+                    hsl_cfg["tier_ratios"]["yellow"]
                 ),
                 "hsl_tier_ratio_orange": float(
-                    self.bot_value(pside, "hsl_tier_ratios.orange")
+                    hsl_cfg["tier_ratios"]["orange"]
                 ),
-                "hsl_orange_tier_mode": str(
-                    self.bot_value(pside, "hsl_orange_tier_mode")
-                ),
-                "hsl_panic_close_order_type": str(
-                    self.bot_value(pside, "hsl_panic_close_order_type")
-                ),
+                "hsl_orange_tier_mode": str(hsl_cfg["orange_tier_mode"]),
+                "hsl_panic_close_order_type": str(hsl_cfg["panic_close_order_type"]),
             }
         )
         return out

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -1893,7 +1893,7 @@ async def _equity_hard_stop_try_reuse_replay_cache(
         if not isinstance(slots, dict):
             continue
         for pside in self._hsl_psides():
-            if not self._equity_hard_stop_coin_active_pside(pside):
+            if not self._equity_hard_stop_coin_active_pside(pside, str(symbol)):
                 continue
             if self._equity_hard_stop_has_open_position_symbol(pside, str(symbol)):
                 if not self._equity_hard_stop_symbol_supported_for_coin_replay(
@@ -2468,8 +2468,10 @@ def _hsl_coin_state(self, pside: str, symbol: str) -> dict[str, Any]:
     return pside_states[symbol]
 
 
-def _equity_hard_stop_coin_active_pside(self, pside: str) -> bool:
-    if not self._equity_hard_stop_enabled(pside):
+def _equity_hard_stop_coin_active_pside(
+    self, pside: str, symbol: Optional[str] = None
+) -> bool:
+    if not self._equity_hard_stop_enabled(pside, symbol=symbol):
         return False
     n_positions_raw = float(self.bot_value(pside, "n_positions"))
     if not math.isfinite(n_positions_raw) or n_positions_raw < 0.0:
@@ -2643,16 +2645,77 @@ def _equity_hard_stop_no_restart_latched(
     )
 
 
-def _equity_hard_stop_enabled(self, pside: Optional[str] = None) -> bool:
+def _equity_hard_stop_config(
+    self, pside: str, symbol: Optional[str] = None
+) -> dict[str, Any]:
+    global_cfg = self.hsl[pside]
+    if symbol is None:
+        return global_cfg
+    coin_overrides = getattr(self, "coin_overrides", {}) or {}
+    if symbol not in coin_overrides or not callable(getattr(self, "bp", None)):
+        return global_cfg
+    if self._equity_hard_stop_signal_mode() != "coin":
+        return global_cfg
+    tier_ratios = dict(global_cfg["tier_ratios"])
+    override_ratios = self.bp(pside, "hsl_tier_ratios", symbol)
+    if isinstance(override_ratios, dict):
+        tier_ratios.update(override_ratios)
+    return {
+        "cooldown_minutes_after_red": float(
+            self.bp(pside, "hsl_cooldown_minutes_after_red", symbol)
+        ),
+        "ema_span_minutes": float(self.bp(pside, "hsl_ema_span_minutes", symbol)),
+        "enabled": bool(self.bp(pside, "hsl_enabled", symbol)),
+        "no_restart_drawdown_threshold": float(
+            self.bp(pside, "hsl_no_restart_drawdown_threshold", symbol)
+        ),
+        "orange_tier_mode": str(self.bp(pside, "hsl_orange_tier_mode", symbol)),
+        "panic_close_order_type": str(
+            self.bp(pside, "hsl_panic_close_order_type", symbol)
+        ),
+        "red_threshold": float(self.bp(pside, "hsl_red_threshold", symbol)),
+        "restart_after_red_policy": normalize_hsl_restart_after_red_policy(
+            self.bp(pside, "hsl_restart_after_red_policy", symbol),
+            path=f"coin HSL {symbol} {pside}.restart_after_red_policy",
+        ),
+        "tier_ratios": tier_ratios,
+    }
+
+
+def _equity_hard_stop_enabled(
+    self, pside: Optional[str] = None, *, symbol: Optional[str] = None
+) -> bool:
     if not hasattr(self, "hsl") or not isinstance(self.hsl, dict):
         legacy_cfg = getattr(self, "equity_hard_stop_loss", None)
         enabled = bool(isinstance(legacy_cfg, dict) and legacy_cfg.get("enabled", False))
         if pside is None:
             return enabled
         return enabled
+    if self._equity_hard_stop_signal_mode() != "coin":
+        if pside is None:
+            return any(bool(self.hsl[x]["enabled"]) for x in ("long", "short"))
+        return bool(self.hsl[pside]["enabled"])
+    if symbol is not None:
+        if pside is None:
+            return any(
+                bool(_equity_hard_stop_config(self, side, symbol)["enabled"])
+                for side in ("long", "short")
+            )
+        return bool(_equity_hard_stop_config(self, pside, symbol)["enabled"])
+    symbols = tuple((getattr(self, "coin_overrides", {}) or {}).keys())
     if pside is None:
-        return any(bool(self.hsl[x]["enabled"]) for x in ("long", "short"))
-    return bool(self.hsl[pside]["enabled"])
+        return any(
+            bool(self.hsl[side]["enabled"])
+            or any(
+                bool(_equity_hard_stop_config(self, side, coin)["enabled"])
+                for coin in symbols
+            )
+            for side in ("long", "short")
+        )
+    return bool(self.hsl[pside]["enabled"]) or any(
+        bool(_equity_hard_stop_config(self, pside, coin)["enabled"])
+        for coin in symbols
+    )
 
 
 def _equity_hard_stop_signal_mode(self) -> str:
@@ -2800,7 +2863,9 @@ def _equity_hard_stop_infer_coin_replay_contract(
     self, pside: str, symbol: str, fill_events: list[dict], now_ms: int
 ) -> dict[str, Any]:
     policy = self._equity_hard_stop_cooldown_position_policy()
-    cooldown_minutes = float(self.hsl[pside]["cooldown_minutes_after_red"])
+    cooldown_minutes = float(
+        _equity_hard_stop_config(self, pside, symbol)["cooldown_minutes_after_red"]
+    )
     cooldown_ms = int(round(cooldown_minutes * 60_000.0)) if cooldown_minutes > 0.0 else 0
     pos_now = self._equity_hard_stop_has_open_position_symbol(pside, symbol)
     panic_events = [
@@ -2875,10 +2940,16 @@ def _equity_hard_stop_halted_mode(self, pside: str, symbol: str | None) -> str:
     return "graceful_stop"
 
 
-def _equity_hard_stop_panic_close_order_type(self, pside: str) -> str:
+def _equity_hard_stop_panic_close_order_type(
+    self, pside: str, symbol: Optional[str] = None
+) -> str:
     hsl_cfg = getattr(self, "hsl", None)
     if isinstance(hsl_cfg, dict) and pside in hsl_cfg and isinstance(hsl_cfg[pside], dict):
-        return str(hsl_cfg[pside].get("panic_close_order_type", "market"))
+        return str(
+            _equity_hard_stop_config(self, pside, symbol).get(
+                "panic_close_order_type", "market"
+            )
+        )
     legacy_cfg = getattr(self, "equity_hard_stop_loss", None)
     if isinstance(legacy_cfg, dict):
         return str(legacy_cfg.get("panic_close_order_type", "market"))
@@ -3384,8 +3455,9 @@ def _equity_hard_stop_coverage_allow_incomplete(
     hsl_cfg = getattr(self, "hsl", None)
     if not isinstance(hsl_cfg, dict) or pside not in hsl_cfg:
         return False
+    effective_hsl_cfg = _equity_hard_stop_config(self, pside, symbol)
     policy = normalize_hsl_restart_after_red_policy(
-        hsl_cfg[pside].get("restart_after_red_policy", "threshold"),
+        effective_hsl_cfg.get("restart_after_red_policy", "threshold"),
         path="hsl.restart_after_red_policy",
     )
     if policy != "always":
@@ -3635,7 +3707,7 @@ def _equity_hard_stop_apply_coin_metrics_sample(
     state = self._hsl_coin_state(pside, symbol)
     last_metrics = state["last_metrics"]
     current_minute = int(timestamp_ms) // 60_000
-    cfg = self.hsl[pside]
+    cfg = _equity_hard_stop_config(self, pside, symbol)
     red_threshold = float(cfg["red_threshold"])
     ratio_yellow = float(cfg["tier_ratios"]["yellow"])
     ratio_orange = float(cfg["tier_ratios"]["orange"])
@@ -3725,6 +3797,8 @@ def _equity_hard_stop_apply_coin_metrics_sample(
         "drawdown_ema": float(step["drawdown_ema"]),
         "drawdown_score": float(step["drawdown_score"]),
         "red_threshold": red_threshold,
+        "tier_ratio_yellow": ratio_yellow,
+        "tier_ratio_orange": ratio_orange,
         "tier": str(step["tier"]),
         "red_active_now": bool(step["red_active_now"]),
         "red_seen_in_episode": bool(step["red_seen_in_episode"]),
@@ -4036,7 +4110,9 @@ def _equity_hard_stop_coin_bounded_required_replay_start_ts(
         return None
 
     required_start_ts = int(episode_start_ts)
-    cooldown_minutes = float(self.hsl[pside]["cooldown_minutes_after_red"])
+    cooldown_minutes = float(
+        _equity_hard_stop_config(self, pside, symbol)["cooldown_minutes_after_red"]
+    )
     cooldown_ms = (
         int(round(cooldown_minutes * 60_000.0))
         if cooldown_minutes > 0.0
@@ -4101,7 +4177,7 @@ def _equity_hard_stop_prime_coin_runtime_for_replay(
     state = self._hsl_coin_state(pside, symbol)
     if state["runtime"].initialized():
         return
-    cfg = self.hsl[pside]
+    cfg = _equity_hard_stop_config(self, pside, symbol)
     baseline_ts_ms = max(0, int(first_sample_ts_ms) - 60_000)
     step = state["runtime"].apply_sample(
         timestamp_ms=baseline_ts_ms,
@@ -4123,6 +4199,7 @@ def _equity_hard_stop_log_transition(self, pside: str, metrics: dict, prev_tier:
     label = pside
     if metrics["signal_mode"] == "coin":
         label = f"{pside}:{metrics['symbol']}"
+    cfg = _equity_hard_stop_config(self, pside, metrics.get("symbol"))
     logging.info(
         "[risk] HSL[%s] tier transition %s -> %s | balance=%.6f strategy_equity=%.6f "
         "peak_strategy_equity=%.6f drawdown_raw=%.6f drawdown_ema=%.6f drawdown_score=%.6f "
@@ -4140,8 +4217,8 @@ def _equity_hard_stop_log_transition(self, pside: str, metrics: dict, prev_tier:
         metrics["strategy_pnl"],
         metrics["peak_strategy_pnl"],
         metrics["red_threshold"],
-        float(self.hsl[pside]["tier_ratios"]["yellow"]),
-        float(self.hsl[pside]["tier_ratios"]["orange"]),
+        float(metrics.get("tier_ratio_yellow", cfg["tier_ratios"]["yellow"])),
+        float(metrics.get("tier_ratio_orange", cfg["tier_ratios"]["orange"])),
     )
     _emit_hsl_event(
         self,
@@ -4250,7 +4327,7 @@ def _equity_hard_stop_build_latch_payload(
     no_restart_peak_strategy_equity: Optional[float] = None,
     no_restart_drawdown_raw: Optional[float] = None,
 ) -> dict:
-    cfg = self.hsl[pside]
+    cfg = _equity_hard_stop_config(self, pside, symbol)
     return {
         "triggered_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "exchange": str(self.exchange),
@@ -4309,7 +4386,7 @@ def _equity_hard_stop_red_episode_finalization(
 ) -> dict[str, Any]:
     """Apply Rust-owned post-episode restart/cooldown policy math."""
     state = self._hsl_coin_state(pside, symbol) if symbol else self._hsl_state(pside)
-    cfg = self.hsl[pside]
+    cfg = _equity_hard_stop_config(self, pside, symbol)
     policy = normalize_hsl_restart_after_red_policy(
         cfg.get("restart_after_red_policy", "threshold"),
         path="hsl.restart_after_red_policy",
@@ -4549,7 +4626,9 @@ async def _equity_hard_stop_refresh_coin_cooldown_after_repanic(
     self, pside: str, symbol: str, now_ms: int
 ) -> bool:
     state = self._hsl_coin_state(pside, symbol)
-    cooldown_minutes = float(self.hsl[pside]["cooldown_minutes_after_red"])
+    cooldown_minutes = float(
+        _equity_hard_stop_config(self, pside, symbol)["cooldown_minutes_after_red"]
+    )
     cooldown_ms = max(0, int(round(cooldown_minutes * 60_000.0))) if cooldown_minutes > 0.0 else 0
     repanic_since_ms = state.get("cooldown_repanic_since_ms")
     stop_ts_ms = await self._equity_hard_stop_flatten_fill_timestamp_with_refresh(
@@ -5581,7 +5660,9 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
         for pside, symbol in sorted(current_position_pairs):
             pair_fill_events = fill_events_by_pair.get((pside, symbol), [])
             restart_policy = normalize_hsl_restart_after_red_policy(
-                self.hsl[pside].get("restart_after_red_policy", "threshold"),
+                _equity_hard_stop_config(self, pside, symbol).get(
+                    "restart_after_red_policy", "threshold"
+                ),
                 path=f"hsl.{pside}.restart_after_red_policy",
             )
             bounded_start_ts = None
@@ -5705,8 +5786,8 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
         active_pairs = tuple(
             (pside, symbol)
             for pside in self._hsl_psides()
-            if self._equity_hard_stop_coin_active_pside(pside)
             for symbol in sorted(replay_symbols)
+            if self._equity_hard_stop_coin_active_pside(pside, symbol)
         )
         active_pair_set = set(active_pairs)
         active_held_pairs = active_pair_set.intersection(current_position_pairs)
@@ -5897,7 +5978,9 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     )
                 state = self._hsl_coin_state(pside, symbol)
                 cooldown_minutes = float(
-                    self.hsl[pside]["cooldown_minutes_after_red"]
+                    _equity_hard_stop_config(self, pside, symbol)[
+                        "cooldown_minutes_after_red"
+                    ]
                 )
                 cooldown_ms = (
                     int(round(cooldown_minutes * 60_000.0))
@@ -7204,6 +7287,8 @@ async def _equity_hard_stop_check_coin(self) -> Optional[dict]:
         if not self._equity_hard_stop_coin_active_pside(pside):
             continue
         for symbol in symbols:
+            if not self._equity_hard_stop_coin_active_pside(pside, symbol):
+                continue
             if partial_replay and (pside, symbol) not in ready_pairs:
                 continue
             state = self._hsl_coin_state(pside, symbol)
@@ -7293,7 +7378,9 @@ async def _equity_hard_stop_check_coin(self) -> Optional[dict]:
                 if not state["halted"]:
                     self._equity_hard_stop_clear_coin_runtime_forced_mode(pside, symbol)
             if metrics["tier"] == "orange":
-                target = str(self.hsl[pside]["orange_tier_mode"])
+                target = str(
+                    _equity_hard_stop_config(self, pside, symbol)["orange_tier_mode"]
+                )
                 if target == "graceful_stop":
                     self._equity_hard_stop_set_coin_runtime_forced_mode(
                         pside, symbol, "graceful_stop"
@@ -7360,7 +7447,7 @@ async def _equity_hard_stop_check_coin(self) -> Optional[dict]:
 def _equity_hard_stop_coin_needs_panic_supervision(
     self, pside: str, symbol: str, state: dict[str, Any]
 ) -> bool:
-    if not self._equity_hard_stop_enabled(pside):
+    if not self._equity_hard_stop_enabled(pside, symbol=symbol):
         return False
     if state["runtime"].red_latched() and not state["halted"]:
         # B2.1 contract (clarified 2026-07-06): only the CURRENT sample being

--- a/tests/test_backtest_maker_fee_override.py
+++ b/tests/test_backtest_maker_fee_override.py
@@ -216,6 +216,45 @@ def test_prep_backtest_args_preserves_explicit_coin_wallet_exposure_override():
     assert bot_params_list[0]["short"]["wallet_exposure_limit"] == 0.5
 
 
+def test_prep_backtest_args_merges_conditional_hsl_override_per_coin():
+    config = _multi_coin_config()
+    config["live"]["hsl_signal_mode"] = "coin"
+    config["bot"]["long"]["hsl"]["enabled"] = False
+    config["bot"]["long"]["hsl"]["red_threshold"] = 0.2
+    config["coin_overrides"] = {
+        "BTC/USDT:USDT": {
+            "bot": {
+                "long": {
+                    "hsl": {
+                        "enabled": True,
+                        "red_threshold": 0.01,
+                        "tier_ratios": {"yellow": 0.4},
+                    }
+                }
+            }
+        }
+    }
+
+    bot_params_list, _, _, _ = prep_backtest_args(
+        config, _multi_coin_mss(), "binance"
+    )
+
+    btc_long = bot_params_list[0]["long"]
+    eth_long = bot_params_list[1]["long"]
+    assert btc_long["hsl_enabled"] is True
+    assert btc_long["hsl_red_threshold"] == pytest.approx(0.01)
+    assert btc_long["hsl_tier_ratios"] == {
+        "yellow": pytest.approx(0.4),
+        "orange": pytest.approx(0.75),
+    }
+    assert eth_long["hsl_enabled"] is False
+    assert eth_long["hsl_red_threshold"] == pytest.approx(0.2)
+    assert eth_long["hsl_tier_ratios"] == {
+        "yellow": pytest.approx(0.5),
+        "orange": pytest.approx(0.75),
+    }
+
+
 def test_prep_backtest_args_uses_canonical_strategy_params_for_runtime_payload():
     config = _base_config()
     config["bot"]["long"]["strategy"]["trailing_martingale"]["ema_span_0"] = 321.0

--- a/tests/test_coin_overrides_hsl.py
+++ b/tests/test_coin_overrides_hsl.py
@@ -201,9 +201,33 @@ def test_hsl_dependent_normalization_is_retained_in_resolved_patch():
     assert hsl["no_restart_drawdown_threshold"] == 0.2
 
 
+def test_hsl_dependent_normalization_runs_after_file_inline_precedence():
+    def configure(source):
+        source["bot"]["long"]["hsl"]["red_threshold"] = 0.05
+        source["bot"]["long"]["hsl"]["no_restart_drawdown_threshold"] = 0.1
+
+    parsed = _parse(
+        {
+            "BTC": {
+                "override_config_path": "unused-by-test.json",
+                "bot": {"long": {"hsl": {"red_threshold": 0.05}}},
+            }
+        },
+        loaded={"bot": {"long": {"hsl": {"red_threshold": 0.2}}}},
+        configure_source=configure,
+    )
+
+    hsl = parsed["coin_overrides"]["BTC"]["bot"]["long"]["hsl"]
+    assert hsl["red_threshold"] == 0.05
+    assert "no_restart_drawdown_threshold" not in hsl
+
+
 @pytest.mark.parametrize(
     "hsl_patch",
     [
+        {"tier_ratios": {"yellow": 0.0, "orange": 0.8}},
+        {"tier_ratios": {"yellow": 0.8, "orange": 0.8}},
+        {"tier_ratios": {"yellow": 0.8, "orange": 1.0}},
         {"tier_ratios": {"yellow": 0.9, "orange": 0.8}},
         {"orange_tier_mode": "invalid"},
         {"panic_close_order_type": "invalid"},

--- a/tests/test_coin_overrides_hsl.py
+++ b/tests/test_coin_overrides_hsl.py
@@ -1,0 +1,225 @@
+from copy import deepcopy
+
+import pytest
+
+from config.load import prepare_config
+from config.overrides import CONDITIONAL_HSL_OVERRIDE_PATHS, parse_overrides
+from config.schema import get_template_config
+
+
+def _parse(overrides, *, mode="coin", loaded=None, configure_source=None):
+    source = get_template_config()
+    source["live"]["user"] = "tester"
+    source["live"]["hsl_signal_mode"] = mode
+    if configure_source is not None:
+        configure_source(source)
+    source["coin_overrides"] = deepcopy(overrides)
+    prepared = prepare_config(source, verbose=False, log_config_transforms=False)
+    return parse_overrides(
+        prepared,
+        verbose=False,
+        override_loader=lambda config, coin: deepcopy(loaded or {}),
+        symbol_normalizer=lambda coin: coin,
+    )
+
+
+HSL_LEAF_CASES = [
+    (("cooldown_minutes_after_red",), 12.5),
+    (("ema_span_minutes",), 5.5),
+    (("enabled",), False),
+    (("no_restart_drawdown_threshold",), 0.8),
+    (("orange_tier_mode",), "graceful_stop"),
+    (("panic_close_order_type",), "market"),
+    (("red_threshold",), 0.2),
+    (("restart_after_red_policy",), "always"),
+    (("tier_ratios", "orange"), 0.8),
+    (("tier_ratios", "yellow"), 0.4),
+]
+
+
+def _nested_hsl_patch(path, value):
+    result = current = {}
+    for part in path[:-1]:
+        current[part] = {}
+        current = current[part]
+    current[path[-1]] = value
+    return result
+
+
+def _get_path(value, path):
+    current = value
+    for part in path:
+        current = current[part]
+    return current
+
+
+@pytest.mark.parametrize("pside", ["long", "short"])
+@pytest.mark.parametrize(("path", "value"), HSL_LEAF_CASES)
+def test_complete_hsl_group_is_allowed_for_coin_signal_mode(pside, path, value):
+    parsed = _parse({"BTC": {"bot": {pside: {"hsl": _nested_hsl_patch(path, value)}}}})
+
+    hsl = parsed["coin_overrides"]["BTC"]["bot"][pside]["hsl"]
+    assert _get_path(hsl, path) == value
+
+
+def test_hsl_policy_registry_covers_every_canonical_leaf():
+    assert CONDITIONAL_HSL_OVERRIDE_PATHS == {
+        "hsl.cooldown_minutes_after_red",
+        "hsl.ema_span_minutes",
+        "hsl.enabled",
+        "hsl.no_restart_drawdown_threshold",
+        "hsl.orange_tier_mode",
+        "hsl.panic_close_order_type",
+        "hsl.red_threshold",
+        "hsl.restart_after_red_policy",
+        "hsl.tier_ratios.orange",
+        "hsl.tier_ratios.yellow",
+    }
+
+
+@pytest.mark.parametrize("mode", ["pside", "unified"])
+@pytest.mark.parametrize("spelling", ["grouped", "flat"])
+def test_inline_hsl_patch_is_rejected_outside_coin_mode(mode, spelling):
+    side = (
+        {"hsl": {"red_threshold": 0.2}}
+        if spelling == "grouped"
+        else {"hsl_red_threshold": 0.2}
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=rf"coin_overrides\.BTC\.bot\.long\.hsl.*only when.*got '{mode}'",
+    ):
+        _parse({"BTC": {"bot": {"long": side}}}, mode=mode)
+
+
+def test_full_file_hsl_patch_is_warned_and_ignored_outside_coin_mode(caplog):
+    parsed = _parse(
+        {"BTC": {"override_config_path": "unused-by-test.json"}},
+        mode="pside",
+        loaded={
+            "bot": {
+                "long": {
+                    "hsl": {"red_threshold": 0.2},
+                    "unstuck": {"loss_allowance_pct": 0.023},
+                }
+            }
+        },
+    )
+
+    side = parsed["coin_overrides"]["BTC"]["bot"]["long"]
+    assert "hsl" not in side
+    assert side["unstuck"]["loss_allowance_pct"] == 0.023
+    assert "file HSL values are ignored" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("global_mode", "file_mode", "accepted"),
+    [("coin", "unified", True), ("pside", "coin", False)],
+)
+def test_global_signal_mode_wins_over_override_file_mode(
+    global_mode, file_mode, accepted, caplog
+):
+    parsed = _parse(
+        {"BTC": {"override_config_path": "unused-by-test.json"}},
+        mode=global_mode,
+        loaded={
+            "live": {"hsl_signal_mode": file_mode},
+            "bot": {"short": {"hsl": {"panic_close_order_type": "market"}}},
+        },
+    )
+
+    short = parsed["coin_overrides"]["BTC"].get("bot", {}).get("short", {})
+    assert ("hsl" in short) is accepted
+    if accepted:
+        assert short["hsl"]["panic_close_order_type"] == "market"
+    else:
+        assert "file HSL values are ignored" in caplog.text
+
+
+def test_inline_cannot_switch_signal_mode_to_authorize_hsl_patch():
+    with pytest.raises(ValueError, match=r"effective global.*got 'pside'"):
+        _parse(
+            {
+                "BTC": {
+                    "live": {"hsl_signal_mode": "coin"},
+                    "bot": {"long": {"hsl": {"enabled": False}}},
+                }
+            },
+            mode="pside",
+        )
+
+
+def test_file_then_inline_hsl_precedence_is_independent_by_side():
+    parsed = _parse(
+        {
+            "BTC": {
+                "override_config_path": "unused-by-test.json",
+                "bot": {
+                    "long": {"hsl": {"red_threshold": 0.25}},
+                    "short": {"hsl_panic_close_order_type": "market"},
+                },
+            }
+        },
+        loaded={
+            "bot": {
+                "long": {
+                    "hsl": {
+                        "red_threshold": 0.15,
+                        "tier_ratios": {"yellow": 0.4},
+                    }
+                },
+                "short": {
+                    "hsl": {
+                        "panic_close_order_type": "limit",
+                        "restart_after_red_policy": "always",
+                    }
+                },
+            }
+        },
+    )
+
+    bot = parsed["coin_overrides"]["BTC"]["bot"]
+    assert bot["long"]["hsl"]["red_threshold"] == 0.25
+    assert bot["long"]["hsl"]["tier_ratios"]["yellow"] == 0.4
+    assert bot["short"]["hsl"]["panic_close_order_type"] == "market"
+    assert bot["short"]["hsl"]["restart_after_red_policy"] == "always"
+
+
+def test_hsl_dependent_normalization_is_retained_in_resolved_patch():
+    def configure(source):
+        source["bot"]["long"]["hsl"]["red_threshold"] = 0.05
+        source["bot"]["long"]["hsl"]["no_restart_drawdown_threshold"] = 0.1
+
+    parsed = _parse(
+        {"BTC": {"bot": {"long": {"hsl": {"red_threshold": 0.2}}}}},
+        configure_source=configure,
+    )
+
+    hsl = parsed["coin_overrides"]["BTC"]["bot"]["long"]["hsl"]
+    assert hsl["red_threshold"] == 0.2
+    assert hsl["no_restart_drawdown_threshold"] == 0.2
+
+
+@pytest.mark.parametrize(
+    "hsl_patch",
+    [
+        {"tier_ratios": {"yellow": 0.9, "orange": 0.8}},
+        {"orange_tier_mode": "invalid"},
+        {"panic_close_order_type": "invalid"},
+        {"red_threshold": 1.1},
+    ],
+)
+def test_invalid_hsl_combinations_fail_effective_validation(hsl_patch):
+    with pytest.raises(
+        ValueError, match=r"coin_overrides\.BTC produces an invalid config"
+    ):
+        _parse({"BTC": {"bot": {"long": {"hsl": hsl_patch}}}})
+
+
+def test_unknown_hsl_tier_ratio_is_rejected_at_patch_boundary():
+    with pytest.raises(
+        ValueError,
+        match=r"coin_overrides\.BTC\.bot\.long\.hsl\.tier_ratios\.red is not overridable",
+    ):
+        _parse({"BTC": {"bot": {"long": {"hsl": {"tier_ratios": {"red": 1.0}}}}}})

--- a/tests/test_config_pipeline.py
+++ b/tests/test_config_pipeline.py
@@ -751,8 +751,9 @@ def test_migrate_v7_trailing_grid_coin_override_reports_runtime_unsupported_risk
     assert "total_wallet_exposure_limit" not in parsed_override.get("risk", {})
 
 
-def test_migrate_v7_trailing_grid_coin_override_reports_unsupported_shared_alias_fields():
+def test_migrate_v7_trailing_grid_coin_override_migrates_conditional_hsl_aliases():
     source = _minimal_v7_trailing_grid_config()
+    source["live"]["hsl_signal_mode"] = "coin"
     source["coin_overrides"]["BTC"] = {
         "bot": {
             "long": {
@@ -773,11 +774,12 @@ def test_migrate_v7_trailing_grid_coin_override_reports_unsupported_shared_alias
     migrated, report = migrate_v7_trailing_grid_config(source)
 
     long_override = migrated["coin_overrides"]["BTC"]["bot"]["long"]
-    assert "hsl" not in long_override
+    assert long_override["hsl"]["tier_ratios"] == {
+        "yellow": pytest.approx(0.45),
+        "orange": pytest.approx(0.75),
+    }
     assert "forager" not in long_override
     for key in (
-        "hsl_tier_ratio_yellow",
-        "hsl_tier_ratio_orange",
         "forager_score_weights",
         "forager_volatility_ema_span",
         "filter_volume_ema_span",
@@ -785,6 +787,15 @@ def test_migrate_v7_trailing_grid_coin_override_reports_unsupported_shared_alias
         source_path = f"coin_overrides.BTC.bot.long.{key}"
         assert source_path in report["manual_review_fields"]
         assert not any(moved.startswith(f"{source_path} ->") for moved in report["moved_fields"])
+    for source_key, target_path in (
+        ("hsl_tier_ratio_yellow", "hsl.tier_ratios.yellow"),
+        ("hsl_tier_ratio_orange", "hsl.tier_ratios.orange"),
+    ):
+        source_path = f"coin_overrides.BTC.bot.long.{source_key}"
+        assert (
+            f"{source_path} -> coin_overrides.BTC.bot.long.{target_path}"
+            in report["moved_fields"]
+        )
 
     prepared = prepare_config(migrated, verbose=False, target="canonical", runtime=None)
     parsed = parse_overrides(
@@ -793,8 +804,34 @@ def test_migrate_v7_trailing_grid_coin_override_reports_unsupported_shared_alias
         symbol_normalizer=lambda coin: coin,
     )
     parsed_override = parsed["coin_overrides"]["BTC"]["bot"]["long"]
-    assert "hsl" not in parsed_override
+    assert parsed_override["hsl"]["tier_ratios"] == {
+        "yellow": pytest.approx(0.45),
+        "orange": pytest.approx(0.75),
+    }
     assert "forager" not in parsed_override
+
+
+def test_migrate_v7_trailing_grid_coin_override_rejects_hsl_aliases_outside_coin_mode():
+    source = _minimal_v7_trailing_grid_config()
+    source["live"]["hsl_signal_mode"] = "pside"
+    source["coin_overrides"]["BTC"] = {
+        "bot": {
+            "long": {
+                "hsl_tier_ratio_yellow": 0.45,
+                "hsl_tier_ratio_orange": 0.75,
+            }
+        }
+    }
+
+    migrated, report = migrate_v7_trailing_grid_config(source)
+
+    assert "hsl" not in migrated["coin_overrides"]["BTC"]["bot"]["long"]
+    for key in ("hsl_tier_ratio_yellow", "hsl_tier_ratio_orange"):
+        source_path = f"coin_overrides.BTC.bot.long.{key}"
+        assert source_path in report["manual_review_fields"]
+        assert not any(
+            moved.startswith(f"{source_path} ->") for moved in report["moved_fields"]
+        )
 
 
 def test_migrate_v7_trailing_grid_coin_override_reports_unsupported_fields():

--- a/tests/test_config_pipeline.py
+++ b/tests/test_config_pipeline.py
@@ -2178,7 +2178,7 @@ def test_prepare_config_clamps_hsl_no_restart_threshold_to_red_threshold():
             "hsl",
             "tier_ratios",
             {"yellow": 0.9, "orange": 0.8},
-            r"bot\.long\.hsl\.tier_ratios\.yellow must be <= bot\.long\.hsl\.tier_ratios\.orange",
+            r"bot\.long\.hsl\.tier_ratios must satisfy 0 < yellow < orange < 1",
         ),
         (
             "risk",

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -3128,10 +3128,10 @@ def test_panic_close_order_type_is_side_local():
     import passivbot_rust as pbr
 
     global_bp = bot_params_pair(
-        long_overrides={"hsl_enabled": True, "hsl_panic_close_order_type": "market"},
+        long_overrides={"hsl_enabled": False, "hsl_panic_close_order_type": "limit"},
         short_overrides={
             "hsl_enabled": True,
-            "hsl_panic_close_order_type": "limit",
+            "hsl_panic_close_order_type": "market",
             "n_positions": 1,
             "total_wallet_exposure_limit": 1.0,
         },
@@ -3150,6 +3150,11 @@ def test_panic_close_order_type_is_side_local():
                 long_pos_price=100.0,
                 short_pos_size=-1.5,
                 short_pos_price=100.0,
+                long_bp={"hsl_enabled": True, "hsl_panic_close_order_type": "market"},
+                short_bp={
+                    "hsl_enabled": True,
+                    "hsl_panic_close_order_type": "limit",
+                },
             )
         ],
     )
@@ -3176,6 +3181,27 @@ def test_panic_close_order_type_rejects_invalid_values():
     inp = make_input(balance=1_000.0, global_bp=global_bp, symbols=[])
 
     with pytest.raises(ValueError, match="hsl_panic_close_order_type"):
+        compute(pbr, inp)
+
+
+def test_panic_close_order_type_rejects_invalid_symbol_value():
+    import passivbot_rust as pbr
+
+    inp = make_input(
+        balance=1_000.0,
+        symbols=[
+            make_symbol(
+                0,
+                bid=100.0,
+                ask=100.0,
+                long_bp={"hsl_panic_close_order_type": "iceberg"},
+            )
+        ],
+    )
+
+    with pytest.raises(
+        ValueError, match=r"symbols\[0\]\.long\.bot_params\.hsl_panic_close_order_type"
+    ):
         compute(pbr, inp)
 
 

--- a/tests/test_order_churn_gate.py
+++ b/tests/test_order_churn_gate.py
@@ -108,6 +108,10 @@ def _raw_rust_input(
     short_entry_retracement_base_pct=0.0,
     long_close_retracement_base_pct=0.0,
     short_close_retracement_base_pct=0.0,
+    long_hsl_enabled=False,
+    short_hsl_enabled=False,
+    long_hsl_panic_close_order_type="market",
+    short_hsl_panic_close_order_type="market",
     **global_overrides,
 ) -> dict:
     global_input = {
@@ -174,6 +178,8 @@ def _raw_rust_input(
                         }
                     },
                     "bot_params": {
+                        "hsl_enabled": long_hsl_enabled,
+                        "hsl_panic_close_order_type": long_hsl_panic_close_order_type,
                         "wallet_exposure_limit": long_wallet_exposure_limit,
                         "risk_entry_cooldown_minutes": long_entry_cooldown_minutes,
                         "risk_wel_enforcer_enabled": True,
@@ -199,6 +205,8 @@ def _raw_rust_input(
                         }
                     },
                     "bot_params": {
+                        "hsl_enabled": short_hsl_enabled,
+                        "hsl_panic_close_order_type": short_hsl_panic_close_order_type,
                         "wallet_exposure_limit": short_wallet_exposure_limit,
                         "risk_entry_cooldown_minutes": short_entry_cooldown_minutes,
                         "risk_wel_enforcer_enabled": True,
@@ -1177,26 +1185,18 @@ def test_raw_rust_output_rejects_non_panic_execution_type_mismatch(
 
 
 @pytest.mark.parametrize(
-    "global_overrides",
+    "input_overrides",
     [
         {
-            "global_bot_params": {
-                "long": {
-                    "hsl_enabled": True,
-                    "hsl_panic_close_order_type": "market",
-                },
-                "short": {
-                    "hsl_enabled": False,
-                    "hsl_panic_close_order_type": "market",
-                },
-            }
+            "long_hsl_enabled": True,
+            "long_hsl_panic_close_order_type": "market",
         },
         {"panic_close_market": True},
     ],
-    ids=["side-local-hsl-market", "global-panic-market"],
+    ids=["symbol-side-hsl-market", "global-panic-market"],
 )
 def test_raw_rust_output_allows_configured_market_panic_close_when_markets_disabled(
-    global_overrides,
+    input_overrides,
 ):
     order = _raw_rust_order(
         qty=-1.0,
@@ -1211,7 +1211,7 @@ def test_raw_rust_output_allows_configured_market_panic_close_when_markets_disab
         _raw_rust_input(
             long_mode="panic",
             market_orders_allowed=False,
-            **global_overrides,
+            **input_overrides,
         ),
     ) == [order]
 
@@ -1382,26 +1382,18 @@ def test_raw_rust_output_accepts_panic_limit_price_derived_from_book(
 
 
 @pytest.mark.parametrize(
-    "global_overrides",
+    "input_overrides",
     [
         {
-            "global_bot_params": {
-                "long": {
-                    "hsl_enabled": True,
-                    "hsl_panic_close_order_type": "market",
-                },
-                "short": {
-                    "hsl_enabled": False,
-                    "hsl_panic_close_order_type": "market",
-                },
-            }
+            "long_hsl_enabled": True,
+            "long_hsl_panic_close_order_type": "market",
         },
         {"panic_close_market": True},
     ],
-    ids=["side-local-hsl-market", "global-panic-market"],
+    ids=["symbol-side-hsl-market", "global-panic-market"],
 )
 def test_raw_rust_output_rejects_limit_panic_close_when_market_is_configured(
-    global_overrides,
+    input_overrides,
 ):
     order = _raw_rust_order(
         qty=-1.0,
@@ -1419,7 +1411,7 @@ def test_raw_rust_output_rejects_limit_panic_close_when_market_is_configured(
             _raw_rust_input(
                 long_mode="panic",
                 market_orders_allowed=False,
-                **global_overrides,
+                **input_overrides,
             ),
         )
 
@@ -1431,17 +1423,6 @@ def test_raw_rust_output_rejects_market_panic_close_when_limit_is_configured():
         execution_type="market",
         execution_priority="risk_critical",
     )
-    global_bot_params = {
-        "long": {
-            "hsl_enabled": True,
-            "hsl_panic_close_order_type": "limit",
-        },
-        "short": {
-            "hsl_enabled": False,
-            "hsl_panic_close_order_type": "market",
-        },
-    }
-
     with pytest.raises(
         FatalBotException, match="inconsistent with its submitted input"
     ):
@@ -1451,31 +1432,24 @@ def test_raw_rust_output_rejects_market_panic_close_when_limit_is_configured():
             _raw_rust_input(
                 long_mode="panic",
                 market_orders_allowed=True,
-                global_bot_params=global_bot_params,
+                long_hsl_enabled=True,
+                long_hsl_panic_close_order_type="limit",
             ),
         )
 
 
 @pytest.mark.parametrize(
-    "global_overrides",
+    "input_overrides",
     [
         {},
         {
-            "global_bot_params": {
-                "long": {
-                    "hsl_enabled": True,
-                    "hsl_panic_close_order_type": "limit",
-                },
-                "short": {
-                    "hsl_enabled": False,
-                    "hsl_panic_close_order_type": "market",
-                },
-            }
+            "long_hsl_enabled": True,
+            "long_hsl_panic_close_order_type": "limit",
         },
     ],
     ids=["hsl-disabled", "hsl-limit"],
 )
-def test_raw_rust_output_rejects_unconfigured_market_panic_close(global_overrides):
+def test_raw_rust_output_rejects_unconfigured_market_panic_close(input_overrides):
     order = _raw_rust_order(
         qty=-1.0,
         order_type="close_panic_long",
@@ -1492,7 +1466,7 @@ def test_raw_rust_output_rejects_unconfigured_market_panic_close(global_override
             _raw_rust_input(
                 long_mode="panic",
                 market_orders_allowed=False,
-                **global_overrides,
+                **input_overrides,
             ),
         )
 

--- a/tests/test_run_fake_live.py
+++ b/tests/test_run_fake_live.py
@@ -1165,8 +1165,10 @@ async def test_coin_overrides_resolve_in_offline_restart_harness(tmp_path, monke
 
 @pytest.mark.asyncio
 @pytest.mark.fake_live
-async def test_coin_hsl_restart_scenario_uses_protective_supervisor(tmp_path):
-    """Coin-mode RED must not fall through normal planning with confirmations pending."""
+async def test_coin_hsl_restart_scenario_uses_protective_supervisor(
+    tmp_path, monkeypatch
+):
+    """A per-coin HSL patch must drive RED handling when global HSL is disabled."""
     import passivbot_rust as pbr
 
     if getattr(pbr, "__is_stub__", False):
@@ -1178,6 +1180,26 @@ async def test_coin_hsl_restart_scenario_uses_protective_supervisor(tmp_path):
         str(REPO_ROOT / "configs" / "fake_live_hsl_btc.hjson"), verbose=False
     )
     cfg["live"]["hsl_signal_mode"] = "coin"
+    cfg["bot"]["long"]["hsl_enabled"] = False
+    cfg["coin_overrides"] = {
+        "BTC": {
+            "bot": {
+                "long": {
+                    "hsl": {
+                        "cooldown_minutes_after_red": 1.0,
+                        "ema_span_minutes": 1.0,
+                        "enabled": True,
+                        "no_restart_drawdown_threshold": 0.9,
+                        "orange_tier_mode": "tp_only_with_active_entry_cancellation",
+                        "panic_close_order_type": "market",
+                        "red_threshold": 0.05,
+                        "restart_after_red_policy": "threshold",
+                        "tier_ratios": {"yellow": 0.5, "orange": 0.75},
+                    }
+                }
+            }
+        }
+    }
     config_path = tmp_path / "fake_live_hsl_btc_coin.json"
     config_path.write_text(json.dumps(cfg), encoding="utf-8")
     scenario = hjson.loads(
@@ -1188,6 +1210,16 @@ async def test_coin_hsl_restart_scenario_uses_protective_supervisor(tmp_path):
     scenario.pop("assertions", None)
     scenario_path = tmp_path / "hsl_long_red_restart_coin.hjson"
     scenario_path.write_text(hjson.dumps(scenario), encoding="utf-8")
+
+    captured = {}
+    real_setup_bot = run_fake_live_module.setup_bot
+
+    def capture_setup_bot(config):
+        bot = real_setup_bot(config)
+        captured["bot"] = bot
+        return bot
+
+    monkeypatch.setattr(run_fake_live_module, "setup_bot", capture_setup_bot)
 
     try:
         args = argparse.Namespace(
@@ -1200,6 +1232,28 @@ async def test_coin_hsl_restart_scenario_uses_protective_supervisor(tmp_path):
             snapshot_each_step=False,
         )
         assert await _async_main(args) == 0
+
+        bot = captured["bot"]
+        override = bot.coin_overrides["BTC/USDT:USDT"]["bot"]["long"]
+        assert bot.config["bot"]["long"]["hsl_enabled"] is False
+        assert override["hsl"]["enabled"] is True
+        assert override["hsl_enabled"] is True
+        assert override["hsl"]["panic_close_order_type"] == "market"
+        assert override["hsl_panic_close_order_type"] == "market"
+        rust_params = bot._bot_params_to_rust_dict("long", "BTC/USDT:USDT")
+        assert rust_params["hsl_enabled"] is True
+        assert rust_params["hsl_red_threshold"] == pytest.approx(0.05)
+        assert rust_params["hsl_ema_span_minutes"] == pytest.approx(1.0)
+        assert rust_params["hsl_cooldown_minutes_after_red"] == pytest.approx(1.0)
+        assert rust_params["hsl_no_restart_drawdown_threshold"] == pytest.approx(0.9)
+        assert rust_params["hsl_restart_after_red_policy"] == "threshold"
+        assert rust_params["hsl_tier_ratio_yellow"] == pytest.approx(0.5)
+        assert rust_params["hsl_tier_ratio_orange"] == pytest.approx(0.75)
+        assert (
+            rust_params["hsl_orange_tier_mode"]
+            == "tp_only_with_active_entry_cancellation"
+        )
+        assert rust_params["hsl_panic_close_order_type"] == "market"
 
         run_dirs = sorted(
             path

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -797,6 +797,7 @@ def _make_dummy_bot(config, *, last_price=100.0):
                 "ema_span_minutes": 60.0,
                 "cooldown_minutes_after_red": 0.0,
                 "no_restart_drawdown_threshold": 1.0,
+                "restart_after_red_policy": "threshold",
                 "tier_ratios": {"yellow": 0.5, "orange": 0.75},
                 "orange_tier_mode": "tp_only_with_active_entry_cancellation",
                 "panic_close_order_type": "market",


### PR DESCRIPTION
## Summary

- allow the complete `bot.<side>.hsl.*` group in coin overrides only when the global `live.hsl_signal_mode` is `coin`
- validate conditional HSL patches and resolved cross-field invariants at the config boundary
- make live supervision, Rust orchestrator inputs, and Rust backtests consume the resolved coin+side HSL configuration
- preserve global signal-mode authority and reject or ignore HSL patches outside coin mode according to inline/file strictness
- document the conditional policy and update the staged rollout checklist

## Validation

- `./venv/bin/python -m pytest -q`
- focused config, override, HSL, backtest, orchestrator, and fake-live test suites
- `PYO3_PYTHON=./venv/bin/python cargo test --manifest-path passivbot-rust/Cargo.toml --no-default-features --features abi3-py312 --lib` (255 passed)
- `cargo check --manifest-path passivbot-rust/Cargo.toml --tests`
- `cargo fmt --manifest-path passivbot-rust/Cargo.toml --all -- --check`
- rebuilt and verified the PyO3 extension against the current Rust source fingerprint
- deterministic offline fake-live HSL restart scenario with global HSL disabled and a BTC HSL override enabled
- bounded cached-data BTC backtest comparison: the disabled-HSL baseline produced no HSL trigger; the per-coin override produced the expected RED trigger and restart

No authenticated exchange requests or live bot processes were used.
