### PR TITLE
Fix Hyperliquid allMids market filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Prevent unrelated spot or unloaded-DEX rows in Hyperliquid's public `allMids` payload from
+  aborting live ticker snapshots. Unknown exchange-returned identifiers are filtered at the
+  connector boundary, while requested-market completeness and malformed known-market prices
+  remain fail-closed.
+
 - Allow the complete per-side HSL group in coin overrides when the global
   `live.hsl_signal_mode` is `"coin"`. Resolved per-coin HSL settings now drive both live
   supervision and Rust backtests; inline HSL patches fail in `pside` or `unified` mode, while HSL

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -17,7 +17,7 @@ from live.balance_composition import (
 )
 from passivbot import logging
 from passivbot_exceptions import FatalBotException
-from utils import symbol_to_coin, ts_to_date, utc_ms
+from utils import MarketIdentifierResolutionError, symbol_to_coin, ts_to_date, utc_ms
 from config.access import require_live_value
 from pure_funcs import calc_hash
 from procedures import print_async_exception, assert_correct_ccxt_version
@@ -1476,7 +1476,13 @@ class HyperliquidBot(CCXTBot):
         for coin, price_raw in fetched.items():
             symbol = self.symbol_ids_inv.get(coin)
             if symbol is None:
-                symbol = self.coin_to_symbol(coin, verbose=False)
+                try:
+                    symbol = self.coin_to_symbol(coin, verbose=False)
+                except MarketIdentifierResolutionError:
+                    # allMids includes spot and unloaded DEX rows outside this
+                    # bot's derivatives market universe. Requested-market
+                    # completeness is enforced by the snapshot caller.
+                    continue
             if symbol not in self.markets_dict:
                 continue
             price = float(price_raw)

--- a/tests/test_hyperliquid_tickers.py
+++ b/tests/test_hyperliquid_tickers.py
@@ -1,6 +1,55 @@
 import pytest
 
 from exchanges.hyperliquid import HyperliquidBot
+from utils import UnknownMarketIdentifier
+
+
+@pytest.mark.asyncio
+async def test_fetch_tickers_skips_unloaded_all_mids_market_identifiers():
+    bot = HyperliquidBot.__new__(HyperliquidBot)
+    bot.markets_dict = {"BTC/USDC:USDC": {}}
+    bot.symbol_ids_inv = {}
+
+    class FakeCCA:
+        async def fetch(self, url, method=None, headers=None, body=None):
+            return {"BTC": "100000.0", "PURR/USDC": "0.1"}
+
+    def resolve_coin(coin, verbose=True):
+        if coin == "BTC":
+            return "BTC/USDC:USDC"
+        raise UnknownMarketIdentifier(f"unavailable market identifier {coin!r}")
+
+    bot.cca = FakeCCA()
+    bot._hl_info_url = lambda: "https://example.invalid/info"
+    bot.coin_to_symbol = resolve_coin
+
+    out = await bot.fetch_tickers()
+
+    assert out == {
+        "BTC/USDC:USDC": {
+            "bid": 100_000.0,
+            "ask": 100_000.0,
+            "last": 100_000.0,
+            "source": "hyperliquid_all_mids",
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_fetch_tickers_propagates_malformed_loaded_market_price():
+    bot = HyperliquidBot.__new__(HyperliquidBot)
+    bot.markets_dict = {"BTC/USDC:USDC": {}}
+    bot.symbol_ids_inv = {"BTC": "BTC/USDC:USDC"}
+
+    class FakeCCA:
+        async def fetch(self, url, method=None, headers=None, body=None):
+            return {"BTC": "not-a-price"}
+
+    bot.cca = FakeCCA()
+    bot._hl_info_url = lambda: "https://example.invalid/info"
+
+    with pytest.raises(ValueError):
+        await bot.fetch_tickers()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- ignore Hyperliquid `allMids` rows whose exchange-returned identifiers are outside the bot's loaded derivatives market universe
- keep the generic exact-identifier resolver fail-closed for configured identifiers
- preserve requested-market completeness checks and malformed known-market price failures
- add focused regressions and an Unreleased changelog entry

## Root cause

Hyperliquid's public `allMids` response may include spot or unloaded-DEX identifiers alongside derivatives tickers. After exact market identifiers became fail-closed, one such unrelated row could raise `MarketIdentifierResolutionError` and abort the complete bulk ticker response before requested markets were returned. The connector now filters only those out-of-universe exchange rows; downstream snapshot completeness still rejects a missing requested market.

## Validation

- `pytest -q tests/test_hyperliquid_tickers.py tests/test_market_snapshot.py tests/test_hyperliquid_balance_cache.py tests/test_fill_events_hyperliquid_mapping.py tests/test_hyperliquid_probe_common.py tests/test_hyperliquid_probe_tools.py tests/test_utils_maps.py` (124 passed)
- `python -m compileall -q src/exchanges/hyperliquid.py tests/test_hyperliquid_tickers.py`
- `git diff --check`