### PR TITLE
Bound HSL history materialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Bound coin-mode HSL `always` restart reconstruction to its canonical fill-proven replay start.
+  Older sparse fills still seed exact balance and position state, but discarded closed episodes no
+  longer expand candle fetches, minute arrays, panic markers, or replay-event iteration;
+  ambiguous evidence and strict restart policies retain the full configured lookback.
 - Remove the persisted HSL replay cache and reconstruct every restart from authoritative fill/PnL
   history, candles, exchange state, config, and current time. Compact/sparse replay remains the
   performance path; obsolete replay-cache artifacts are ignored and no longer inspected by the

--- a/docs/ai/features/equity_hard_stop_loss.md
+++ b/docs/ai/features/equity_hard_stop_loss.md
@@ -42,6 +42,10 @@ HSL drawdown state is scoped by `live.hsl_signal_mode`:
    their gains, losses, and fees cannot affect the retained episode. Unavailable candles before the
    resulting boundary cannot strand an otherwise provable held episode; unavailable required
    candles at or after it still fail closed.
+   The same aggregate boundary limits candle fetches, minute-grid allocation, panic markers, and
+   replay events returned to the coin initializer. Sparse fills before the boundary remain input
+   only long enough to seed exact balance and position state at the boundary; they are not expanded
+   into replay rows or reconsidered as retained-episode events.
    Live fill-history readiness uses that same fill-derived boundary as its only held-episode owner
    and also proves every enabled side's flat-scope cooldown horizon. A recent fill for a currently
    flat pair may still own a RED cooldown and therefore preserves the full configured lookback.

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -136,8 +136,13 @@ slices.
 - [x] Do not persist HSL replay matrices or runtime checkpoints. Proving exact fill-set identity,
   late-fill stability, every ordinary flattened cooldown scope, config compatibility, and candle
   compatibility cost more complexity than the avoided compact replay.
-- [ ] Feed the canonical consumer-owned HSL replay boundary into fill and candle materialization so
+- [x] Feed the canonical consumer-owned HSL replay boundary into fill and candle materialization so
   the authoritative builder does not fetch or construct discarded history.
+  - Result: coin-mode initialization passes the aggregate required-start boundary to the compact
+    history builder. It fetches candles and allocates minute/pair arrays only at or after that
+    boundary, returns only retained replay fills and panic markers, and applies older sparse fills
+    once to seed exact boundary balance and position state. Strict and ambiguous scopes continue to
+    pass the full configured lookback.
 - [ ] Continue optimizing the compact/sparse replay itself with deterministic equivalence coverage.
 
 ### Goal 6: Make Warm Restart Fast But Proven
@@ -700,11 +705,11 @@ Trading-impact labels:
 
 ### P1: Authoritative HSL Replay Scope
 
-- [ ] Make the canonical HSL required-start boundary the single owner of fill and candle history
+- [x] Make the canonical HSL required-start boundary the single owner of fill and candle history
   materialization for that replay.
-- [ ] Preserve exact fill timestamps, realized PnL, fees, episode boundaries, and every relevant
+- [x] Preserve exact fill timestamps, realized PnL, fees, episode boundaries, and every relevant
   flat-scope cooldown while avoiding work before a proven disposable prefix.
-- [ ] Keep pside/unified and `threshold`/`never` full-lookback strict.
+- [x] Keep pside/unified and `threshold`/`never` full-lookback strict.
 - [ ] Measure cold and warm reconstruction through the same authoritative path; do not add a
   parallel persisted replay-state compatibility matrix.
 
@@ -958,9 +963,11 @@ Each slice should update this checklist with its result.
    - Acceptance: equivalence tests pass against the old replay contract and the
      benchmark shows a material rows/s improvement.
 
-5. [ ] HSL bounded-history materialization slice.
+5. [x] HSL bounded-history materialization slice.
    - Pass the canonical consumer-owned replay boundary into authoritative fill/candle preparation.
-   - Acceptance: discarded history is neither fetched nor materialized, while full-lookback modes,
+   - Result: candles and dense minute/pair structures begin at the canonical boundary. Earlier
+     authoritative sparse fills remain available only to prove the boundary and seed exact balance
+     and position state; they are not returned as active replay events. Full-lookback modes,
      cooldown scopes, and ambiguous evidence remain strict.
 
 6. [ ] Shutdown and restart latency slice.

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -14616,6 +14616,7 @@ class Passivbot:
         current_balance: Optional[float] = None,
         hsl_replay_signal_mode: Optional[str] = None,
         hsl_coin_compact_replay: bool = False,
+        hsl_replay_start_ms: Optional[int] = None,
     ) -> Dict[str, Any]:
         """Replay canonical fills into public curves or private compact coin-HSL input.
 
@@ -14627,6 +14628,17 @@ class Passivbot:
             raise ValueError(
                 "hsl_coin_compact_replay requires hsl_replay_signal_mode='coin'"
             )
+        if hsl_replay_start_ms is not None and not hsl_coin_compact_replay:
+            raise ValueError(
+                "hsl_replay_start_ms requires hsl_coin_compact_replay=True"
+            )
+        if hsl_replay_start_ms is not None:
+            try:
+                hsl_replay_start_ms = int(hsl_replay_start_ms)
+            except (TypeError, ValueError) as exc:
+                raise ValueError("hsl_replay_start_ms must be an integer timestamp") from exc
+            if hsl_replay_start_ms < 0:
+                raise ValueError("hsl_replay_start_ms must be nonnegative")
         history_started_s = time.monotonic()
         external_fill_events = fill_events is not None
         await self.init_pnls()
@@ -14717,6 +14729,9 @@ class Passivbot:
 
         events = self._hsl_extract_fill_events(fill_events)
         current_position_state = _current_position_state()
+        ts_now = self.get_exchange_time()
+        if hsl_replay_start_ms is not None and hsl_replay_start_ms > int(ts_now):
+            raise ValueError("hsl_replay_start_ms cannot be later than exchange time")
         _emit_hsl_history_progress(
             "history_inputs_loaded",
             {
@@ -14731,17 +14746,8 @@ class Passivbot:
             reason_code=ReasonCodes.HSL_HISTORY_INPUTS_LOADED,
         )
         if events:
-            try:
-                compute_psize_pprice(
-                    events,
-                    final_state=current_position_state,
-                    log_discrepancies=True,
-                    log_prefix=f"{self.exchange}:{self.user} balance-equity replay",
-                )
-            except TypeError:
-                compute_psize_pprice(events)
+            compute_psize_pprice(events)
         if not events:
-            ts_now = self.get_exchange_time()
             balance_now = (
                 float(current_balance)
                 if current_balance is not None
@@ -14790,6 +14796,10 @@ class Passivbot:
                         ).display_value,
                         "resolution_ms": ONE_MIN_MS,
                         "events_used": 0,
+                        "replay_events": 0,
+                        "pre_window_events_applied": 0,
+                        "materialized_start_ms": int(ts_now),
+                        "bounded_history": hsl_replay_start_ms is not None,
                         "symbols_covered": [],
                         "missing_price_symbols": [],
                         "history_format": "compact",
@@ -14824,8 +14834,13 @@ class Passivbot:
             self.live_value("pnls_max_lookback_days"),
             field_name="live.pnls_max_lookback_days",
         )
-        ts_now = self.get_exchange_time()
         lookback_start = lookback.balance_history_start_ms(ts_now)
+        if hsl_replay_start_ms is not None:
+            lookback_start = (
+                hsl_replay_start_ms
+                if lookback_start is None
+                else max(int(lookback_start), hsl_replay_start_ms)
+            )
 
         balance_now = (
             float(current_balance)
@@ -14854,6 +14869,15 @@ class Passivbot:
         end_minute = int(math.floor(ts_now / ONE_MIN_MS) * ONE_MIN_MS)
         if end_minute < record_start_minute:
             end_minute = record_start_minute
+        replay_fill_events = (
+            [
+                event
+                for event in events
+                if int(event["timestamp"]) >= int(record_start_ts)
+            ]
+            if hsl_replay_start_ms is not None
+            else events
+        )
 
         current_position_symbols = {
             symbol
@@ -14873,7 +14897,7 @@ class Passivbot:
         symbols.update(current_position_symbols)
         panic_event_symbols = {
             evt["symbol"]
-            for evt in events
+            for evt in replay_fill_events
             if evt["symbol"]
             and "panic" in str(evt.get("pb_order_type") or "").lower()
         }
@@ -15485,7 +15509,10 @@ class Passivbot:
             "lookback_days": lookback.display_value,
             "resolution_ms": ONE_MIN_MS,
             "events_used": len(events),
+            "replay_events": len(replay_fill_events),
             "pre_window_events_applied": int(pre_window_events_applied),
+            "materialized_start_ms": int(record_start_ts),
+            "bounded_history": hsl_replay_start_ms is not None,
             "symbols_covered": sorted(price_replay_symbols),
             "missing_price_symbols": sorted(missing_price_symbols),
             "approximate_price_sources": approximate_price_sources,
@@ -15514,7 +15541,7 @@ class Passivbot:
         )
         result = {
             "panic_flatten_events": panic_flatten_events,
-            "fill_events": events,
+            "fill_events": replay_fill_events,
             "metadata": metadata,
         }
         if compact_coin_replay:

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -3575,11 +3575,22 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             status="started",
             reason_code="coin_history_replay",
         )
+        now_ms = int(self.get_exchange_time())
+        configured_start_ms = lookback.balance_history_start_ms(now_ms)
+        history_required, replay_start_ms = (
+            self._equity_hard_stop_required_fill_history_start_ms(
+                now_ms,
+                pnl_start_ms=configured_start_ms,
+            )
+        )
+        if not history_required:
+            replay_start_ms = now_ms
         history_fetch_started_s = time.monotonic()
         history = await self.get_balance_equity_history(
             current_balance=self.get_raw_balance(),
             hsl_replay_signal_mode="coin",
             hsl_coin_compact_replay=True,
+            hsl_replay_start_ms=replay_start_ms,
         )
         history_loaded_s = time.monotonic()
         history_fetch_elapsed_s = max(0.0, history_loaded_s - history_fetch_started_s)

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -1302,6 +1302,39 @@ def test_passivbot_binds_coin_hsl_replay_support_helper():
     assert hasattr(Passivbot, "_equity_hard_stop_symbol_supported_for_coin_replay")
 
 
+@pytest.mark.asyncio
+async def test_coin_hsl_initializer_uses_canonical_required_history_start():
+    bot = make_coin_bot()
+    captured = {}
+    bot._equity_hard_stop_required_fill_history_start_ms = (
+        lambda now_ms, pnl_start_ms=None: (True, 120_000)
+    )
+
+    async def fake_history(**kwargs):
+        captured.update(kwargs)
+        return {
+            "timeline": [
+                {
+                    "timestamp": 120_000,
+                    "balance": 100.0,
+                    "realized_pnl": 0.0,
+                    "realized_pnl_by_coin_pside": {},
+                    "unrealized_pnl_by_coin_pside": {},
+                }
+            ],
+            "panic_flatten_events": [],
+            "fill_events": [],
+        }
+
+    bot.get_balance_equity_history = fake_history
+
+    await bot._equity_hard_stop_initialize_coin_from_history()
+
+    assert captured["hsl_replay_signal_mode"] == "coin"
+    assert captured["hsl_coin_compact_replay"] is True
+    assert captured["hsl_replay_start_ms"] == 120_000
+
+
 def test_coin_hsl_restart_reset_preserves_persistent_no_restart_peak():
     bot = make_coin_bot()
     state = bot._hsl_coin_state("long", "BTC/USDT:USDT")
@@ -2052,6 +2085,8 @@ async def _run_parity_history(
     *,
     compact: bool = False,
     fill_events_override: list[dict] | None = None,
+    hsl_replay_start_ms: int | None = None,
+    candle_calls: list[dict] | None = None,
 ):
     """Run the real coin-mode collection over a small two-close scenario."""
     import numpy as np
@@ -2095,6 +2130,8 @@ async def _run_parity_history(
 
     class _CM:
         async def get_candles(self, sym, **kwargs):
+            if candle_calls is not None:
+                candle_calls.append({"symbol": sym, **kwargs})
             return np.array(
                 [
                     (base_ts, 99.0, 101.0, 98.0, 100.0, 1.0),
@@ -2132,6 +2169,7 @@ async def _run_parity_history(
         current_balance=100.0,
         hsl_replay_signal_mode="coin",
         hsl_coin_compact_replay=compact,
+        hsl_replay_start_ms=hsl_replay_start_ms,
     )
     assert bot._live_event_pipeline.close(timeout=2.0) is True
     return history, symbol
@@ -2193,6 +2231,103 @@ async def test_hsl_compact_coin_history_zero_fill_shape(monkeypatch):
     assert compact["realized_pnl"].tolist() == [0.0]
     assert compact["pair_values"] == {}
     assert history["metadata"]["history_format"] == "compact"
+
+
+@pytest.mark.asyncio
+async def test_hsl_compact_coin_history_bounds_materialization_but_seeds_prior_fills(
+    monkeypatch,
+):
+    base_ts = 1_800_000_000_000
+    symbol = "BTC/USDT:USDT"
+    candle_calls = []
+    fill_events = [
+        {
+            "timestamp": base_ts - 120_000,
+            "symbol": symbol,
+            "position_side": "long",
+            "side": "buy",
+            "qty": 1.0,
+            "price": 100.0,
+            "pnl": 0.0,
+        },
+        {
+            "timestamp": base_ts - 60_000,
+            "symbol": symbol,
+            "position_side": "long",
+            "side": "sell",
+            "qty": 1.0,
+            "price": 95.0,
+            "pnl": -5.0,
+            "pb_order_type": "close_panic_long",
+        },
+        {
+            "timestamp": base_ts,
+            "symbol": symbol,
+            "position_side": "long",
+            "side": "buy",
+            "qty": 1.0,
+            "price": 100.0,
+            "pnl": 0.0,
+        },
+        {
+            "timestamp": base_ts + 90_000,
+            "symbol": symbol,
+            "position_side": "long",
+            "side": "sell",
+            "qty": 0.5,
+            "price": 101.0,
+            "pnl": 0.5,
+        },
+    ]
+
+    history, _symbol = await _run_parity_history(
+        monkeypatch,
+        compact=True,
+        fill_events_override=fill_events,
+        hsl_replay_start_ms=base_ts,
+        candle_calls=candle_calls,
+    )
+
+    compact = history["hsl_coin_compact_replay"]
+    assert compact["timestamps"].tolist() == [
+        base_ts,
+        base_ts + 60_000,
+        base_ts + 120_000,
+    ]
+    assert compact["balances"].tolist() == pytest.approx([99.5, 100.0, 100.0])
+    assert compact["realized_pnl"].tolist() == pytest.approx([0.0, 0.5, 0.5])
+    pair = compact["pair_values"][("long", symbol)]
+    assert pair["realized_pnl"].tolist() == pytest.approx([0.0, 0.5, 0.5])
+    assert [event["timestamp"] for event in history["fill_events"]] == [
+        base_ts,
+        base_ts + 90_000,
+    ]
+    assert history["panic_flatten_events"] == []
+    assert history["metadata"]["events_used"] == 4
+    assert history["metadata"]["replay_events"] == 2
+    assert history["metadata"]["pre_window_events_applied"] == 2
+    assert history["metadata"]["materialized_start_ms"] == base_ts
+    assert history["metadata"]["bounded_history"] is True
+    assert candle_calls
+    assert {call["start_ts"] for call in candle_calls} == {base_ts}
+
+
+@pytest.mark.asyncio
+async def test_hsl_replay_start_requires_compact_coin_mode_and_present_time(monkeypatch):
+    base_ts = 1_800_000_000_000
+
+    with pytest.raises(ValueError, match="requires hsl_coin_compact_replay"):
+        await _run_parity_history(
+            monkeypatch,
+            hsl_replay_start_ms=base_ts,
+        )
+
+    with pytest.raises(ValueError, match="cannot be later than exchange time"):
+        await _run_parity_history(
+            monkeypatch,
+            compact=True,
+            hsl_replay_start_ms=base_ts + 180_000,
+        )
 
 
 def test_calc_upnl_sum_strict_preserves_symbol_filter():


### PR DESCRIPTION
## Summary

- feed the existing canonical coin-HSL required-start boundary into compact history construction
- retain older authoritative sparse fills only to seed exact boundary balance and position state
- stop discarded episodes from expanding candle fetches, minute/pair arrays, panic markers, or returned replay fills
- keep ambiguous evidence and strict restart policies on the full configured lookback
- remove an obsolete `compute_psize_pprice()` compatibility call that always raised `TypeError` before invoking the actual signature

## Contract

This does not relax fill, PnL, fee, episode-boundary, or current-position correctness. Rust remains the risk source of truth. The existing boundary owner still falls back to the full configured lookback for `threshold`, `never`, pside/unified modes, recent flat-scope cooldown evidence, delayed or side-ambiguous fills, and held-position reconstruction mismatches.

## Validation

- full repository `pytest -q`
- complete coin-HSL suite
- balance split, HSL replay benchmark, HSL bindings, HSL metric regression, unstuck safeguards, fill-events manager, and AI-doc suites
- complete offline fake-live pytest matrix (`tests/test_run_fake_live.py -m fake_live`)
- canonical offline RED/restart fake-live scenario
- exact-source Rust extension rebuild and fingerprint verification (no Rust source changes)
- Python compile, AI-doc checker, and `git diff --check`
