### PR TITLE
Simplify monitor unstuck allowance calculation

### DIFF
--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -13616,49 +13616,6 @@ class Passivbot:
                 self._log_fill_event(event),
             )
 
-    def _calc_unstuck_allowances(self) -> dict[str, float]:
-        """Calculate unstuck allowances using FillEventsManager data.
-
-        Pure budget math from fill history; whether an unstuck order may be
-        emitted this cycle is a separate decision carried by the
-        auto_unstuck_allowed flag, which the Rust orchestrator consumes as
-        the sole emission gate.
-        """
-        if self._pnls_manager is None:
-            return {"long": 0.0, "short": 0.0}
-
-        start_ms = self._pnls_lookback_start_ms()
-        events = self._get_effective_pnl_events()
-        self._assert_pnl_history_safe_for_risk(
-            events,
-            context="unstuck allowance realized PnL",
-            start_ms=start_ms,
-        )
-        if not events:
-            return {"long": 0.0, "short": 0.0}
-
-        pnls_cumsum = np.array([fill_event_net_pnl(ev) for ev in events], dtype=float).cumsum()
-        pnls_cumsum_max, pnls_cumsum_last = max(0.0, float(pnls_cumsum.max())), pnls_cumsum[-1]
-        out = {}
-        balance_raw = self.get_raw_balance()
-        for pside in ["long", "short"]:
-            pct = float(self.bot_value(pside, "unstuck_loss_allowance_pct") or 0.0)
-            if pct > 0.0:
-                out[pside] = float(
-                    pbr.calc_auto_unstuck_allowance(
-                        balance_raw,
-                        pct
-                        * float(
-                            self.bot_value(pside, "total_wallet_exposure_limit") or 0.0
-                        ),
-                        float(pnls_cumsum_max),
-                        float(pnls_cumsum_last),
-                    )
-                )
-            else:
-                out[pside] = 0.0
-        return out
-
     def _get_realized_pnl_cumsum_stats(self) -> dict[str, float]:
         """Return net realized pnl cumsum peak/current from FillEventsManager history."""
         if getattr(self, "_pnls_manager", None) is None:
@@ -17008,10 +16965,6 @@ class Passivbot:
         }:
             return mode
         return self.PB_mode_stop[pside]
-
-    def _calc_unstuck_allowances_live(self) -> dict[str, float]:
-        """Calculate unstuck allowances using FillEventsManager."""
-        return self._calc_unstuck_allowances()
 
     def _auto_unstuck_configured_live(self) -> bool:
         """Whether configured Rust unstuck logic consumes validated PnL inputs."""

--- a/src/passivbot_monitor.py
+++ b/src/passivbot_monitor.py
@@ -1007,11 +1007,6 @@ def _build_monitor_unstuck_section(self) -> dict[str, Any]:
     # while an unstuck order is open. Disabled unstuck has no PnL-derived
     # allowance to report.
     unstuck_uses_realized_pnl = self._unstuck_uses_realized_pnl()
-    allowances_live = (
-        self._calc_unstuck_allowances_live()
-        if unstuck_uses_realized_pnl
-        else None
-    )
     out: dict[str, Any] = {
         "has_open_order": has_open,
         "open_orders": [],
@@ -1037,12 +1032,13 @@ def _build_monitor_unstuck_section(self) -> dict[str, Any]:
             if unstuck_uses_realized_pnl
             else {"status": "unstuck_disabled"}
         )
+        allowance_raw = info.get("allowance")
         side_payload: dict[str, Any] = {
             "status": info.get("status"),
             "allowance_live": (
-                float(allowances_live.get(pside, 0.0) or 0.0)
-                if allowances_live is not None
-                else None
+                max(0.0, float(allowance_raw))
+                if allowance_raw is not None
+                else (0.0 if unstuck_uses_realized_pnl else None)
             ),
             "configured_loss_allowance_pct": float(
                 self.bot_value(pside, "unstuck_loss_allowance_pct") or 0.0

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -8219,35 +8219,13 @@ async def test_update_effective_min_cost_uses_executable_min_qty():
     assert bot.effective_min_cost[symbol] == pytest.approx(88.165)
 
 
-def test_open_unstuck_order_does_not_gate_live_unstuck_emission(monkeypatch):
+def test_open_unstuck_order_does_not_gate_live_unstuck_configuration():
     # Rust owns auto-unstuck emission from the realized-PnL cumsum facts. A
     # resting unstuck order must not add a Python-only suppression path; any
     # duplicate-order risk rides normal order reconciliation.
-    import passivbot as pb_mod
-
     bot = Passivbot.__new__(Passivbot)
-    bot.balance = 100.0
-    bot.balance_raw = 200.0
-    get_events = MagicMock(
-        return_value=[
-            types.SimpleNamespace(pnl=10.0, fee_paid=-1.0),
-        ]
-    )
-    bot._pnls_manager = _with_fill_coverage_api(
-        types.SimpleNamespace(
-            get_events=get_events,
-            cache=_SafeRiskCache(),
-            get_history_scope=lambda: "all",
-        )
-    )
-    bot.bot_value = lambda pside, key: {
-        "unstuck_loss_allowance_pct": 0.2 if pside == "long" else 0.0,
-        "total_wallet_exposure_limit": 0.5,
-    }.get(key, 0.0)
+    bot._pnls_manager = object()
     bot._unstuck_uses_realized_pnl = lambda: True
-    monkeypatch.setattr(
-        pb_mod.pbr, "calc_auto_unstuck_allowance", lambda *a: 77.0
-    )
     # An unstuck order is live on the exchange.
     bot.open_orders = {
         "BTC/USDT:USDT": [
@@ -8256,14 +8234,7 @@ def test_open_unstuck_order_does_not_gate_live_unstuck_emission(monkeypatch):
     }
     assert bot.has_open_unstuck_order() is True
 
-    out = bot._calc_unstuck_allowances()
-    assert out["long"] == pytest.approx(77.0)
-
-    # The emission input stays available while the order is open, without a
-    # second fill scan after the cumsum/allowance history was validated.
-    get_events.reset_mock()
     assert bot._auto_unstuck_configured_live() is True
-    get_events.assert_not_called()
 
 
 def _make_unstuck_custom_id() -> str:
@@ -8275,143 +8246,6 @@ def _make_unstuck_custom_id() -> str:
     return bot.format_custom_id_single(
         pb_mod.pbr.get_order_id_type_from_string("close_unstuck_long")
     )
-
-
-def test_unstuck_allowance_routes_raw_balance_to_rust(monkeypatch):
-    import passivbot as pb_mod
-
-    bot = Passivbot.__new__(Passivbot)
-    bot.balance = 100.0
-    bot.balance_raw = 200.0
-    bot._pnls_manager = _with_fill_coverage_api(
-        types.SimpleNamespace(
-            get_events=lambda: [
-                types.SimpleNamespace(pnl=10.0, fee_paid=-1.0),
-                types.SimpleNamespace(pnl=-4.0, fee_paid=-0.5),
-            ],
-            cache=_SafeRiskCache(),
-            get_history_scope=lambda: "all",
-        )
-    )
-
-    def bot_value(pside, key):
-        if key == "unstuck_loss_allowance_pct":
-            return 0.2 if pside == "long" else 0.0
-        if key == "total_wallet_exposure_limit":
-            return 0.5
-        return 0.0
-
-    bot.bot_value = bot_value
-
-    calls = []
-
-    def fake_calc_auto_unstuck_allowance(
-        balance, loss_allowance_pct, pnl_cumsum_max, pnl_cumsum_last
-    ):
-        calls.append((balance, loss_allowance_pct, pnl_cumsum_max, pnl_cumsum_last))
-        return 123.45
-
-    monkeypatch.setattr(
-        pb_mod.pbr, "calc_auto_unstuck_allowance", fake_calc_auto_unstuck_allowance
-    )
-
-    out = bot._calc_unstuck_allowances()
-
-    assert out["long"] == pytest.approx(123.45)
-    assert out["short"] == pytest.approx(0.0)
-    assert len(calls) == 1
-    assert calls[0][0] == pytest.approx(200.0)  # raw balance
-    assert calls[0][2] == pytest.approx(9.0)
-    assert calls[0][3] == pytest.approx(4.5)
-
-
-def test_unstuck_allowance_uses_only_configured_pnl_lookback(monkeypatch):
-    import passivbot as pb_mod
-
-    now_ms = 10 * 86_400_000
-    bot = Passivbot.__new__(Passivbot)
-    bot.balance_raw = 1000.0
-    bot.get_raw_balance = lambda: float(bot.balance_raw)
-    _set_pnl_lookback(bot, lookback_days=1.0, now_ms=now_ms)
-    bot._pnls_manager = _with_fill_coverage_api(
-        types.SimpleNamespace(
-            get_events=lambda start_ms=None, end_ms=None, symbol=None: [
-                ev
-                for ev in [
-                    types.SimpleNamespace(pnl=100.0, timestamp=now_ms - 3 * 86_400_000),
-                    types.SimpleNamespace(
-                        pnl=-80.0, timestamp=now_ms - 3 * 86_400_000 + 1
-                    ),
-                    types.SimpleNamespace(pnl=10.0, timestamp=now_ms - 60_000),
-                ]
-                if start_ms is None or ev.timestamp >= start_ms
-            ],
-            cache=_SafeRiskCache(),
-            get_history_scope=lambda: "all",
-        )
-    )
-
-    def bot_value(pside, key):
-        if key == "unstuck_loss_allowance_pct":
-            return 0.01 if pside == "long" else 0.0
-        if key == "total_wallet_exposure_limit":
-            return 1.0
-        return 0.0
-
-    bot.bot_value = bot_value
-
-    calls = []
-
-    def fake_calc_auto_unstuck_allowance(
-        balance, loss_allowance_pct, pnl_cumsum_max, pnl_cumsum_last
-    ):
-        calls.append((balance, loss_allowance_pct, pnl_cumsum_max, pnl_cumsum_last))
-        return 10.0
-
-    monkeypatch.setattr(
-        pb_mod.pbr, "calc_auto_unstuck_allowance", fake_calc_auto_unstuck_allowance
-    )
-
-    out = bot._calc_unstuck_allowances()
-
-    assert out["long"] == pytest.approx(10.0)
-    assert len(calls) == 1
-    assert calls[0] == pytest.approx((1000.0, 0.01, 10.0, 10.0))
-
-
-def test_unstuck_allowance_blocks_degraded_synthetic_pnl():
-    bot = Passivbot.__new__(Passivbot)
-    bot._pnls_manager = types.SimpleNamespace(
-        get_events=lambda start_ms=None, end_ms=None, symbol=None: [
-            types.SimpleNamespace(
-                pnl=0.0,
-                fee_paid=0.0,
-                timestamp=1_000,
-                pnl_status="complete",
-                pnl_source="synthetic_fill_reconstruction_degraded",
-                id="degraded-close",
-                symbol="BTC/USDT:USDT",
-                position_side="long",
-                pb_order_type="close_grid_long",
-            )
-        ],
-        cache=None,
-    )
-
-    def bot_value(pside, key):
-        if key == "unstuck_loss_allowance_pct":
-            return 0.01
-        if key == "total_wallet_exposure_limit":
-            return 1.0
-        return 0.0
-
-    bot.bot_value = bot_value
-
-    with pytest.raises(RuntimeError, match="degraded realized PnL"):
-        bot._calc_unstuck_allowances()
-
-
-
 
 
 

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -3,7 +3,7 @@ import hashlib
 import json
 import logging
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import numpy as np
 
@@ -6455,9 +6455,6 @@ def test_monitor_unstuck_section_skips_pnl_math_when_unstuck_disabled():
     bot.open_orders = {}
     bot.has_open_unstuck_order = lambda: False
     bot._unstuck_uses_realized_pnl = lambda: False
-    bot._calc_unstuck_allowances_live = MagicMock(
-        side_effect=AssertionError("must not read nonauthoritative PnL")
-    )
     bot._calc_unstuck_allowance_for_logging = MagicMock(
         side_effect=AssertionError("must not read nonauthoritative PnL")
     )
@@ -6469,12 +6466,40 @@ def test_monitor_unstuck_section_skips_pnl_math_when_unstuck_disabled():
 
     section = bot._build_monitor_unstuck_section()
 
-    bot._calc_unstuck_allowances_live.assert_not_called()
     bot._calc_unstuck_allowance_for_logging.assert_not_called()
     assert section["sides"]["long"]["status"] == "unstuck_disabled"
     assert section["sides"]["long"]["allowance_live"] is None
     assert section["sides"]["short"]["status"] == "unstuck_disabled"
     assert section["sides"]["short"]["allowance_live"] is None
+
+
+def test_monitor_unstuck_section_derives_live_allowance_from_raw_diagnostic():
+    import passivbot as pb_mod
+
+    bot = pb_mod.Passivbot.__new__(pb_mod.Passivbot)
+    bot.open_orders = {}
+    bot.has_open_unstuck_order = lambda: False
+    bot._unstuck_uses_realized_pnl = lambda: True
+    bot._calc_unstuck_allowance_for_logging = MagicMock(
+        side_effect=[
+            {"status": "ok", "allowance": 12.5},
+            {"status": "ok", "allowance": -3.0},
+        ]
+    )
+    bot.bot_value = lambda pside, key: {
+        "unstuck_loss_allowance_pct": 0.01,
+        "unstuck_close_pct": 0.0,
+        "unstuck_threshold": 0.9,
+    }[key]
+
+    section = bot._build_monitor_unstuck_section()
+
+    assert bot._calc_unstuck_allowance_for_logging.call_args_list == [
+        call("long"),
+        call("short"),
+    ]
+    assert section["sides"]["long"]["allowance_live"] == pytest.approx(12.5)
+    assert section["sides"]["short"]["allowance_live"] == pytest.approx(0.0)
 
 
 @pytest.mark.asyncio
@@ -6832,10 +6857,6 @@ async def test_build_monitor_snapshot_includes_market_forager_unstuck_and_recent
                 }
             return {"status": "disabled"}
 
-        def _calc_unstuck_allowances_live(self):
-            # Allowances are pure budget facts, real even with an open unstuck order.
-            return {"long": 1.0, "short": 0.0}
-
         async def build_forager_candidate_payload(
             self,
             pside,
@@ -6955,6 +6976,8 @@ async def test_build_monitor_snapshot_includes_market_forager_unstuck_and_recent
     assert snapshot["forager"]["long"]["ranking"]["top_ema_readiness"]["symbol"] == "ETH/USDT:USDT"
     assert snapshot["unstuck"]["has_open_order"] is True
     assert snapshot["unstuck"]["sides"]["long"]["allowance"] == pytest.approx(-20.0)
+    assert snapshot["unstuck"]["sides"]["long"]["allowance_live"] == pytest.approx(0.0)
+    assert snapshot["unstuck"]["sides"]["short"]["allowance_live"] == pytest.approx(0.0)
     assert snapshot["unstuck"]["sides"]["long"]["override_loss_allowance_pcts"] == {
         "BTC/USDT:USDT": pytest.approx(0.005)
     }


### PR DESCRIPTION
## Summary

- remove the duplicate Python monitor-only unstuck allowance calculation and its live wrapper
- derive the existing `allowance_live` monitor field from the already-computed raw diagnostic allowance by applying the same zero clamp as Rust
- remove cache/risk tests that existed only for the duplicate path while retaining authoritative planner safeguards and the open-order configuration invariant

## Why

Rust already owns the production unstuck allowance and receives the validated realized-PnL cumulative facts used by live planning. The monitor independently rescanned fill history and called the same formula through PyO3, creating a second calculation and a second readiness boundary for an observability-only field.

The unclamped diagnostic formula is algebraically identical to Rust's allowance formula. Clamping that existing value at zero preserves the monitor payload without a second fill scan or a parallel Python risk path.

## Validation

- full Python test suite
- focused monitor, balance-split, and auto-unstuck tests
- offline fake-live, realized-loss, unstuck, unstuck-safeguard, and orchestrator integration tests
- Python compile check for changed files
- exact Rust extension source-fingerprint verification after rebuild
- AI documentation check: 0 errors (2 pre-existing size warnings)
- `git diff --check`
