### PR TITLE
Fix optimizer suite scenario preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Preserve the full configured exchange pool for combined optimizer and backtest suite datasets
+  when every selected coin happens to use the same venue, so single-coin multi-exchange suites no
+  longer reject valid unselected candidate venues as unavailable.
+- Normalize nested suite scenario override documents to leaf config paths while keeping dynamic
+  `coin_overrides` mappings atomic, preventing partial `live` or `bot` overrides from replacing the
+  complete section during optimizer evaluation.
 - Bound coin-mode HSL `always` restart reconstruction to its canonical fill-proven replay start.
   Older sparse fills still seed exact balance and position state, but discarded closed episodes no
   longer expand candle fetches, minute arrays, panic markers, or replay-event iteration;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -690,6 +690,9 @@ The optimizer reuses the backtest suite configuration when `--suite [y/n]` is en
 - **backtest.suite_enabled**: Can be toggled for optimizer runs via `--suite [y/n]` on `passivbot optimize`.
 - **backtest.aggregate**: Per-metric aggregation rules applied to scenario results before feeding into `optimize.scoring` and `optimize.limits`.
 - **backtest.scenarios**: Scenario dictionaries. Each one may override `coins`, `ignored_coins`, `start_date`, `end_date`, `exchanges`, `coin_sources`, and `overrides` (arbitrary config path overrides).
+  `overrides` accepts either dotted config paths or nested config fragments; nested fragments are
+  flattened to leaf paths, while a top-level `coin_overrides` mapping remains an atomic scenario
+  replacement so scenarios may introduce coin-specific entries absent from the base config.
 - **optimize.objective_scenario**: Default scoring scenario. Set it to a unique scenario label to
   score objectives from that scenario by default, or to `null` to use suite aggregation by
   default. Individual `optimize.scoring` entries may override the default with a named `scenario`

--- a/src/suite_runner.py
+++ b/src/suite_runner.py
@@ -60,6 +60,7 @@ _SCENARIO_KEYS = frozenset(
         "overrides",
     }
 )
+_ATOMIC_SCENARIO_OVERRIDE_ROOTS = frozenset({"coin_overrides"})
 
 # --------------------------------------------------------------------------- #
 # Data containers
@@ -690,6 +691,7 @@ def build_scenarios(
         overrides = raw.get("overrides")
         if overrides is not None and not isinstance(overrides, dict):
             raise ValueError(f"Scenario overrides for '{raw.get('label')}' must be a mapping")
+        overrides = _normalize_scenario_overrides(overrides)
         scenario_coins = (
             _normalize_coin_list(raw.get("coins")) if raw.get("coins") is not None else None
         )
@@ -707,7 +709,7 @@ def build_scenarios(
                 ignored_coins=scenario_ignored,
                 exchanges=exchanges_list,
                 coin_sources=coin_source_map,
-                overrides=deepcopy(overrides) if overrides else None,
+                overrides=overrides or None,
             )
         )
 
@@ -723,6 +725,36 @@ def build_scenarios(
 
     aggregate_cfg = deepcopy(suite_cfg.get("aggregate", {"default": "mean"}))
     return scenarios, aggregate_cfg
+
+
+def _normalize_scenario_overrides(overrides: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Flatten nested override documents while preserving atomic dynamic mappings."""
+    normalized: Dict[str, Any] = {}
+
+    def visit(mapping: Dict[str, Any], prefix: tuple[str, ...] = ()) -> None:
+        for raw_key, value in mapping.items():
+            if not isinstance(raw_key, str):
+                raise ValueError("Scenario override keys must be strings")
+            key = raw_key.strip()
+            if not key:
+                raise ValueError("Scenario override keys must not be empty")
+            path = (*prefix, key)
+            root = path[0].split(".", 1)[0]
+            if (
+                isinstance(value, dict)
+                and "." not in key
+                and root not in _ATOMIC_SCENARIO_OVERRIDE_ROOTS
+            ):
+                visit(value, path)
+                continue
+            dotted_path = ".".join(path)
+            if dotted_path in normalized:
+                raise ValueError(f"Scenario override path {dotted_path!r} is defined more than once")
+            normalized[dotted_path] = deepcopy(value)
+
+    if overrides:
+        visit(overrides)
+    return normalized
 
 
 def collect_suite_coin_sources(
@@ -876,12 +908,17 @@ async def prepare_master_datasets(
         cache_dir: str,
         btc_usd_prices: np.ndarray,
         timestamps: Optional[np.ndarray],
+        source_exchanges: Optional[Iterable[str]] = None,
     ) -> ExchangeDataset:
         coin_index = {coin: idx for idx, coin in enumerate(coins)}
         coin_exchange = {
             coin: str(mss.get(coin, {}).get("exchange", exchange_name)) for coin in coins
         }
-        available_exchanges = sorted(set(coin_exchange.values())) or [exchange_name]
+        available_exchanges = sorted(
+            {str(exchange) for exchange in source_exchanges}
+            if source_exchanges is not None
+            else set(coin_exchange.values())
+        ) or [exchange_name]
         timestamps_array = (
             None
             if timestamps is None
@@ -973,6 +1010,7 @@ async def prepare_master_datasets(
             cache_dir,
             btc_usd_prices,
             timestamps,
+            source_exchanges=require_config_value(combined_config, "backtest.exchanges"),
         )
         # Free original arrays after copying to SharedMemory (can save ~5GB+ RAM)
         del hlcvs, btc_usd_prices

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -4521,6 +4521,62 @@ class TestEvaluator:
         assert mock_config["backtest"]["start_date"] == "2023-01-01"
         assert mock_config["live"]["approved_coins"] == {"long": ["BTC"], "short": []}
 
+    def test_suite_scenario_nested_overrides_preserve_candidate_config_sections(self):
+        from optimize import Evaluator, SuiteEvaluator
+        from config_utils import get_template_config
+        from suite_runner import build_scenarios
+
+        candidate_config = get_template_config()
+        candidate_config["bot"]["long"]["risk"]["n_positions"] = 7
+        candidate_config["live"]["approved_coins"] = {"long": ["ETH"], "short": ["ETH"]}
+        candidate_config["live"]["ignored_coins"] = {"long": [], "short": []}
+        scenario = build_scenarios(
+            {
+                "scenarios": [
+                    {
+                        "label": "nested",
+                        "overrides": {
+                            "live": {"hedge_mode": True},
+                            "bot": {
+                                "short": {"risk": {"total_wallet_exposure_limit": 0.0}}
+                            },
+                        },
+                    }
+                ]
+            },
+            base_exchanges=["binance"],
+        )[0][0]
+        ctx_config = deepcopy(candidate_config)
+        ctx = ScenarioEvalContext(
+            label=scenario.label,
+            config=ctx_config,
+            exchanges=["binance"],
+            hlcvs_specs={},
+            btc_usd_specs={},
+            msss={"binance": {}},
+            timestamps={"binance": None},
+            shared_hlcvs_np={"binance": np.zeros((1, 1, 5))},
+            shared_btc_np={},
+            attachments={"hlcvs": {}, "btc": {}},
+            coin_indices={"binance": None},
+            overrides=scenario.overrides,
+        )
+        evaluator = SuiteEvaluator(
+            Evaluator({}, {}, {}, candidate_config),
+            [ctx],
+            {},
+        )
+
+        scenario_config = evaluator._build_scenario_candidate_config(candidate_config, ctx)
+
+        assert scenario_config["live"]["approved_coins"] == {
+            "long": ["ETH"],
+            "short": ["ETH"],
+        }
+        assert scenario_config["live"]["hedge_mode"] is True
+        assert scenario_config["bot"]["long"]["risk"]["n_positions"] == 7
+        assert scenario_config["bot"]["short"]["risk"]["total_wallet_exposure_limit"] == 0.0
+
 
 def _remove_nested_path(mapping, path):
     target = mapping

--- a/tests/test_suite_runner.py
+++ b/tests/test_suite_runner.py
@@ -80,6 +80,34 @@ def test_build_scenarios_handles_exchanges_and_coin_sources():
     assert scenario.coin_sources == {"BTC": "binance"}
 
 
+def test_build_scenarios_flattens_nested_overrides_but_keeps_coin_overrides_atomic():
+    scenarios, _ = build_scenarios(
+        {
+            "scenarios": [
+                {
+                    "label": "nested",
+                    "overrides": {
+                        "live": {"hedge_mode": True},
+                        "bot": {
+                            "short": {"risk": {"total_wallet_exposure_limit": 0.0}}
+                        },
+                        "coin_overrides": {
+                            "ETH": {"live": {"forced_mode_long": "normal"}}
+                        },
+                    },
+                }
+            ]
+        },
+        base_exchanges=["binance"],
+    )
+
+    assert scenarios[0].overrides == {
+        "live.hedge_mode": True,
+        "bot.short.risk.total_wallet_exposure_limit": 0.0,
+        "coin_overrides": {"ETH": {"live": {"forced_mode_long": "normal"}}},
+    }
+
+
 def test_build_scenarios_preserves_exact_coins_and_coin_sources():
     suite_cfg = {
         "scenarios": [
@@ -793,6 +821,59 @@ async def test_prepare_master_datasets_uses_scenario_windows_for_individual_exch
         in rec.message
         for rec in caplog.records
     )
+
+
+@pytest.mark.asyncio
+async def test_prepare_master_datasets_preserves_combined_source_exchanges(monkeypatch):
+    async def fake_prepare_hlcvs_mss(config, exchange, *, force_refetch_gaps=False):
+        assert exchange == "combined"
+        timestamps = np.array([0, 60_000], dtype=np.int64)
+        return (
+            ["ETH"],
+            np.ones((2, 1, 4), dtype=np.float64),
+            {"ETH": {"exchange": "binance"}, "__meta__": {}},
+            "",
+            "/tmp/combined",
+            np.ones(2, dtype=np.float64),
+            timestamps,
+        )
+
+    monkeypatch.setitem(
+        sys.modules,
+        "backtest",
+        SimpleNamespace(prepare_hlcvs_mss=fake_prepare_hlcvs_mss),
+    )
+    base_config = {
+        "backtest": {
+            "start_date": "1970-01-01T00:00:00",
+            "end_date": "1970-01-01T00:02:00",
+            "exchanges": ["binance", "bybit"],
+            "coins": {},
+        },
+        "live": {
+            "approved_coins": {"long": ["ETH"], "short": ["ETH"]},
+            "ignored_coins": {"long": [], "short": []},
+        },
+    }
+    scenarios = [
+        SuiteScenario(
+            label="base",
+            start_date=None,
+            end_date=None,
+            coins=None,
+            ignored_coins=None,
+            exchanges=["binance", "bybit"],
+        )
+    ]
+
+    datasets = await prepare_master_datasets(
+        base_config,
+        ["binance", "bybit"],
+        scenarios=scenarios,
+    )
+
+    assert datasets["combined"].coin_exchange == {"ETH": "binance"}
+    assert datasets["combined"].available_exchanges == ["binance", "bybit"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- preserve the full configured source-exchange pool for combined suite datasets, independently of the winning per-coin venue assignments
- normalize nested suite scenario override fragments to leaf config paths while preserving `coin_overrides` as an atomic mapping
- add regression coverage plus optimizer-suite documentation and changelog entries

## Root cause

A combined single-coin dataset derived its advertised exchange availability only from the selected venue for that coin. Valid configured alternatives could therefore be rejected as unavailable. Separately, nested scenario override fragments such as partial `live` or `bot` mappings were reapplied as whole-section replacements during evaluation, which removed required candidate configuration fields.

## Validation

- `./venv/bin/python -m pytest -q tests/optimization tests/test_suite_runner.py tests/test_data_strategy_verification.py` (435 passed)
- `./venv/bin/python -m compileall -q src/suite_runner.py src/optimize_suite.py src/optimize.py`
- cached single-coin, two-exchange, four-scenario Pymoo optimizer smoke completed successfully
- `git diff --check origin/master...HEAD`