### PR TITLE
Remove dead log silence watchdog

### DIFF
--- a/src/logging_setup.py
+++ b/src/logging_setup.py
@@ -17,7 +17,6 @@ TRACE_LEVEL_NAME = "TRACE"
 DEFAULT_FORMAT = "%(asctime)s %(levelname)-8s %(message)s"
 DEFAULT_FORMAT_WITH_PREFIX = "%(asctime)s %(levelname)-8s [%(log_prefix)s] %(message)s"
 DEFAULT_DATEFMT = "%Y-%m-%dT%H:%M:%SZ"
-_LAST_LOG_ACTIVITY_MONOTONIC = time.monotonic()
 DEFAULT_LOG_FILENAME_MAX_LEN = 100
 
 
@@ -31,23 +30,6 @@ class PrefixFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         record.log_prefix = self.prefix
         return True
-
-
-class ActivityFilter(logging.Filter):
-    """Filter that tracks the most recent emitted log record."""
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        mark_log_activity()
-        return True
-
-
-def mark_log_activity() -> None:
-    global _LAST_LOG_ACTIVITY_MONOTONIC
-    _LAST_LOG_ACTIVITY_MONOTONIC = time.monotonic()
-
-
-def get_last_log_activity_monotonic() -> float:
-    return _LAST_LOG_ACTIVITY_MONOTONIC
 
 
 _LOG_LEVEL_ALIASES = {
@@ -217,13 +199,11 @@ def configure_logging(
 
     # Create prefix filter if needed
     prefix_filter = PrefixFilter(prefix or "") if prefix else None
-    activity_filter = ActivityFilter()
 
     if stream:
         stream_handler = logging.StreamHandler()
         stream_handler.setFormatter(formatter)
         stream_handler.setLevel(numeric_level)
-        stream_handler.addFilter(activity_filter)
         if prefix_filter:
             stream_handler.addFilter(prefix_filter)
         handlers.append(stream_handler)
@@ -239,7 +219,6 @@ def configure_logging(
             file_handler = logging.FileHandler(path)
         file_handler.setFormatter(formatter)
         file_handler.setLevel(numeric_level)
-        file_handler.addFilter(activity_filter)
         if prefix_filter:
             file_handler.addFilter(prefix_filter)
         handlers.append(file_handler)

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -136,7 +136,6 @@ from risk_limits import (
 )
 from logging_setup import (
     configure_logging,
-    get_last_log_activity_monotonic,
     resolve_live_log_file_settings,
     resolve_log_level,
 )
@@ -1670,27 +1669,8 @@ class Passivbot:
         self._health_summary_interval_ms = 15 * 60 * 1000  # 15 minutes
         self._last_loop_duration_ms = 0
 
-        raw_silence_watchdog = get_optional_config_value(
-            config, "logging.silence_watchdog_seconds", 60.0
-        )
-        try:
-            silence_watchdog_seconds = float(raw_silence_watchdog)
-        except Exception:
-            logging.warning(
-                "Unable to parse logging.silence_watchdog_seconds=%r; using fallback 60",
-                raw_silence_watchdog,
-            )
-            silence_watchdog_seconds = 60.0
-        if silence_watchdog_seconds < 0:
-            logging.warning(
-                "logging.silence_watchdog_seconds=%r is negative; disabling",
-                raw_silence_watchdog,
-            )
-            silence_watchdog_seconds = 0.0
-        self._log_silence_watchdog_seconds = float(silence_watchdog_seconds)
         self._log_silence_watchdog_phase = "boot"
         self._log_silence_watchdog_stage = "idle"
-        self._log_silence_watchdog_task: Optional[asyncio.Task] = None
         self._bot_ready = False
 
         # Unstuck logging throttle
@@ -1872,71 +1852,6 @@ class Passivbot:
             self._log_silence_watchdog_phase = str(phase)
         if stage is not None:
             self._log_silence_watchdog_stage = str(stage)
-
-    def _maybe_log_silence_watchdog(
-        self, *, now_monotonic: Optional[float] = None
-    ) -> bool:
-        threshold = float(getattr(self, "_log_silence_watchdog_seconds", 0.0) or 0.0)
-        if threshold <= 0.0:
-            return False
-        if now_monotonic is None:
-            now_monotonic = time.monotonic()
-        silent_for_s = max(
-            0.0, now_monotonic - float(get_last_log_activity_monotonic())
-        )
-        if silent_for_s < threshold:
-            return False
-        phase = str(
-            getattr(self, "_log_silence_watchdog_phase", "runtime") or "runtime"
-        )
-        stage = str(
-            getattr(self, "_log_silence_watchdog_stage", "unknown") or "unknown"
-        )
-        uptime_ms = max(0, utc_ms() - int(getattr(self, "_health_start_ms", utc_ms())))
-        loop_ms = int(getattr(self, "_last_loop_duration_ms", 0) or 0)
-        loop_str = f"{loop_ms / 1000:.1f}s" if loop_ms > 0 else "n/a"
-        logging.info(
-            "[health] silence watchdog: no logs for %.0fs | phase=%s | stage=%s | uptime=%s | loop=%s",
-            silent_for_s,
-            phase,
-            stage,
-            self._format_duration(uptime_ms),
-            loop_str,
-        )
-        return True
-
-    async def _run_log_silence_watchdog(self) -> None:
-        threshold = float(getattr(self, "_log_silence_watchdog_seconds", 0.0) or 0.0)
-        if threshold <= 0.0:
-            return
-        poll_seconds = min(5.0, max(1.0, threshold / 4.0))
-        while not self.stop_signal_received:
-            await asyncio.sleep(poll_seconds)
-            if self.stop_signal_received:
-                break
-            self._maybe_log_silence_watchdog()
-
-    def _start_log_silence_watchdog(self) -> None:
-        threshold = float(getattr(self, "_log_silence_watchdog_seconds", 0.0) or 0.0)
-        if threshold <= 0.0:
-            return
-        task = getattr(self, "_log_silence_watchdog_task", None)
-        if task is not None and not task.done():
-            return
-        self._log_silence_watchdog_task = asyncio.create_task(
-            self._run_log_silence_watchdog()
-        )
-
-    async def _stop_log_silence_watchdog(self) -> None:
-        task = getattr(self, "_log_silence_watchdog_task", None)
-        self._log_silence_watchdog_task = None
-        if task is None:
-            return
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
 
     def _pnls_lookback_start_ms(self) -> Optional[int]:
         config = getattr(self, "config", None)

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -5939,8 +5939,6 @@ async def test_start_bot_records_startup_error_stop_and_early_snapshot(
         _monitor_emit_stop = pb_mod.Passivbot._monitor_emit_stop
         _emit_live_event = staticmethod(lambda *args, **kwargs: None)
         _set_log_silence_watchdog_context = pb_mod.Passivbot._set_log_silence_watchdog_context
-        _start_log_silence_watchdog = pb_mod.Passivbot._start_log_silence_watchdog
-        _stop_log_silence_watchdog = pb_mod.Passivbot._stop_log_silence_watchdog
         _shutdown_requested = pb_mod.Passivbot._shutdown_requested
         _raise_if_shutdown_requested = pb_mod.Passivbot._raise_if_shutdown_requested
         _sleep_unless_shutdown = pb_mod.Passivbot._sleep_unless_shutdown
@@ -5964,10 +5962,8 @@ async def test_start_bot_records_startup_error_stop_and_early_snapshot(
             self.debug_mode = False
             self.stop_signal_received = False
             self.snapshot_flushes = []
-            self._log_silence_watchdog_seconds = 0.0
             self._log_silence_watchdog_phase = "startup"
             self._log_silence_watchdog_stage = "idle"
-            self._log_silence_watchdog_task = None
             self._bot_ready = False
             self.live_event_console_enabled = structured_console
             self._live_event_pipeline = object() if structured_console else None
@@ -6034,32 +6030,6 @@ async def test_start_bot_records_startup_error_stop_and_early_snapshot(
         == incident_events[1]["payload"]["incident_id"]
     )
     assert incident_events[1]["payload"]["traceback"]["frame_count"] >= 1
-
-
-def test_maybe_log_silence_watchdog_emits_phase_and_stage(monkeypatch, caplog):
-    import passivbot as pb_mod
-
-    class FakeBot:
-        _maybe_log_silence_watchdog = pb_mod.Passivbot._maybe_log_silence_watchdog
-        _format_duration = pb_mod.Passivbot._format_duration
-
-        def __init__(self):
-            self._log_silence_watchdog_seconds = 60.0
-            self._log_silence_watchdog_phase = "startup"
-            self._log_silence_watchdog_stage = "equity_hard_stop_initialize_from_history"
-            self._health_start_ms = 0
-            self._last_loop_duration_ms = 0
-
-    monkeypatch.setattr(pb_mod, "get_last_log_activity_monotonic", lambda: 0.0)
-    monkeypatch.setattr(pb_mod, "utc_ms", lambda: 120_000)
-    caplog.set_level(logging.INFO)
-
-    bot = FakeBot()
-
-    assert bot._maybe_log_silence_watchdog(now_monotonic=61.0) is True
-    assert any("silence watchdog" in rec.message for rec in caplog.records)
-    assert any("phase=startup" in rec.message for rec in caplog.records)
-    assert any("stage=equity_hard_stop_initialize_from_history" in rec.message for rec in caplog.records)
 
 
 def test_log_new_fill_events_records_fill_history():


### PR DESCRIPTION
## Summary

- remove the unstarted log-silence watchdog task, threshold parsing, and direct-only test
- remove the per-handler activity filter and global monotonic timestamp that only fed that watchdog
- retain the existing runtime phase/stage context used by HSL, planning, and bounded incident diagnostics

## Why

Current master has no production caller for `_start_log_silence_watchdog` or `_stop_log_silence_watchdog`, so the watchdog task can never run. Despite that, every configured log handler updates a process-global activity timestamp, startup parses a hidden `logging.silence_watchdog_seconds` value, and tests directly exercise the otherwise unreachable helper.

This is patch sediment from an earlier logging integration rather than an active safety or observability contract. Removing it eliminates 136 lines and per-record filter work without changing emitted logs or trading behavior. The separately useful runtime stage context remains unchanged.

## Validation

- full Python test suite
- focused logging, monitor, execution-loop, HSL binding, and coin-HSL tests
- offline fake-live suite
- Python compile check for changed files
- exact Rust extension source-fingerprint verification after rebuild
- AI documentation check: 0 errors (2 pre-existing size warnings)
- `git diff --check`
