### PR TITLE
Speed up HLCV valid-window scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable user-facing changes will be documented in this file.
   Pareto/suite result artifacts remain readable without rewriting their historical payload keys.
 - Hash backtest cache arrays while writing their NPY artifacts, avoiding a second full-array read
   solely to build the cache manifest after multi-gigabyte cache publication.
+- Speed up multi-coin backtest HLCV validation with bounded time-major scans, and report frame
+  flush and valid-window validation timings separately during data preparation.
 - Preserve the full configured exchange pool for combined optimizer and backtest suite datasets
   when every selected coin happens to use the same venue, so single-coin multi-exchange suites no
   longer reject valid unselected candidate venues as unavailable.

--- a/src/backtest.py
+++ b/src/backtest.py
@@ -750,39 +750,91 @@ def _validate_hlcvs_valid_windows(
         end = min(n_rows - 1, end)
         valid_windows.append((col, start, end))
 
-    row_bytes = max(1, int(n_cols * 4 * hlcvs_arr.dtype.itemsize))
-    chunk_rows = max(1, int(target_chunk_bytes) // row_bytes)
+    column_events: dict[int, dict[int, int]] = {}
+    for col, start, end in valid_windows:
+        if start > end:
+            continue
+        for row, delta in ((start, 1), (end + 1, -1)):
+            row_events = column_events.setdefault(row, {})
+            row_events[col] = row_events.get(col, 0) + delta
+
+    scan_segments: list[tuple[int, int, tuple[int, ...]]] = []
+    active_column_counts: dict[int, int] = {}
+    event_rows = sorted(column_events)
+    for event_idx, segment_start in enumerate(event_rows[:-1]):
+        for col, delta in column_events[segment_start].items():
+            next_count = active_column_counts.get(col, 0) + delta
+            if next_count:
+                active_column_counts[col] = next_count
+            else:
+                active_column_counts.pop(col, None)
+        segment_end = event_rows[event_idx + 1]
+        if active_column_counts and segment_start < segment_end:
+            scan_segments.append(
+                (segment_start, segment_end, tuple(sorted(active_column_counts)))
+            )
+
+    itemsize = int(hlcvs_arr.dtype.itemsize)
+    planned_scan_bytes = sum(
+        (segment_end - segment_start) * len(segment_columns) * 4 * itemsize
+        for segment_start, segment_end, segment_columns in scan_segments
+    )
     chunk_count = 0
     first_bad_rows: list[int | None] = [None] * len(coins_order)
     validation_t0 = time.perf_counter()
     logging.info(
-        "[hlcvs] valid-window validation start rows=%d coins=%d bytes=%d chunk_rows=%d",
+        "[hlcvs] valid-window validation start rows=%d coins=%d segments=%d "
+        "scan_bytes=%d target_chunk_bytes=%d",
         n_rows,
         len(coins_order),
-        int(n_rows * n_cols * 4 * hlcvs_arr.dtype.itemsize),
-        chunk_rows,
+        len(scan_segments),
+        planned_scan_bytes,
+        int(target_chunk_bytes),
     )
-    for chunk_start in range(0, n_rows, chunk_rows):
-        chunk_end = min(n_rows, chunk_start + chunk_rows)
-        finite_by_row_coin = np.isfinite(
-            hlcvs_arr[chunk_start:chunk_end, :, :4]
-        ).all(axis=2)
-        chunk_count += 1
-        for payload_idx, (col, start, end) in enumerate(valid_windows):
-            if first_bad_rows[payload_idx] is not None or start > end:
-                continue
-            overlap_start = max(start, chunk_start)
-            overlap_end = min(end + 1, chunk_end)
-            if overlap_start >= overlap_end:
-                continue
-            finite = finite_by_row_coin[
-                overlap_start - chunk_start : overlap_end - chunk_start, col
-            ]
-            if finite.all():
-                continue
-            first_bad_rows[payload_idx] = overlap_start + int(
-                np.flatnonzero(~finite)[0]
-            )
+    for segment_start, segment_end, segment_columns in scan_segments:
+        row_bytes = max(1, int(len(segment_columns) * 4 * itemsize))
+        chunk_rows = max(1, int(target_chunk_bytes) // row_bytes)
+        first_column = segment_columns[0]
+        last_column = segment_columns[-1]
+        columns_are_contiguous = len(segment_columns) == last_column - first_column + 1
+        column_offsets = (
+            {col: col - first_column for col in segment_columns}
+            if columns_are_contiguous
+            else {col: offset for offset, col in enumerate(segment_columns)}
+        )
+        column_indices = (
+            None
+            if columns_are_contiguous
+            else np.asarray(segment_columns, dtype=np.intp)
+        )
+        for chunk_start in range(segment_start, segment_end, chunk_rows):
+            chunk_end = min(segment_end, chunk_start + chunk_rows)
+            if columns_are_contiguous:
+                chunk_values = hlcvs_arr[
+                    chunk_start:chunk_end, first_column : last_column + 1, :4
+                ]
+            else:
+                chunk_values = hlcvs_arr[chunk_start:chunk_end, :, :4][
+                    :, column_indices, :
+                ]
+            finite_by_row_coin = np.isfinite(chunk_values).all(axis=2)
+            chunk_count += 1
+            for payload_idx, (col, start, end) in enumerate(valid_windows):
+                if first_bad_rows[payload_idx] is not None or start > end:
+                    continue
+                overlap_start = max(start, chunk_start)
+                overlap_end = min(end + 1, chunk_end)
+                if overlap_start >= overlap_end:
+                    continue
+                finite = finite_by_row_coin[
+                    overlap_start - chunk_start : overlap_end - chunk_start,
+                    column_offsets[col],
+                ]
+                if finite.all():
+                    continue
+                first_bad_rows[payload_idx] = overlap_start + int(
+                    np.flatnonzero(~finite)[0]
+                )
 
     for payload_idx, coin in enumerate(coins_order):
         bad_row = first_bad_rows[payload_idx]
@@ -804,15 +856,17 @@ def _validate_hlcvs_valid_windows(
         )
 
     validation_elapsed = time.perf_counter() - validation_t0
-    validated_bytes = int(n_rows * n_cols * 4 * hlcvs_arr.dtype.itemsize)
     logging.info(
-        "[hlcvs] valid-window validation done rows=%d coins=%d chunks=%d elapsed_s=%.1f "
+        "[hlcvs] valid-window validation done rows=%d coins=%d segments=%d chunks=%d "
+        "scan_bytes=%d elapsed_s=%.1f "
         "throughput_mib_s=%.1f",
         n_rows,
         len(coins_order),
+        len(scan_segments),
         chunk_count,
+        planned_scan_bytes,
         validation_elapsed,
-        float(validated_bytes) / (1024.0**2) / max(validation_elapsed, 1e-9),
+        float(planned_scan_bytes) / (1024.0**2) / max(validation_elapsed, 1e-9),
     )
 
 

--- a/src/backtest.py
+++ b/src/backtest.py
@@ -39,6 +39,7 @@ import pandas as pd
 import json
 import asyncio
 import numbers
+import time
 from dataclasses import dataclass
 from typing import Any, Iterable, Sequence
 from cli_utils import (
@@ -699,6 +700,9 @@ def _build_hlcvs_bundle(
     return pbr.HlcvsBundle(hlcvs_arr, btc_arr, timestamps_arr, bundle_meta)
 
 
+_HLCVS_VALIDATION_TARGET_CHUNK_BYTES = 64 * 1024 * 1024
+
+
 def _validate_hlcvs_valid_windows(
     hlcvs,
     timestamps,
@@ -707,6 +711,7 @@ def _validate_hlcvs_valid_windows(
     last_valid_indices,
     *,
     coin_indices: list[int] | None = None,
+    target_chunk_bytes: int = _HLCVS_VALIDATION_TARGET_CHUNK_BYTES,
 ) -> None:
     hlcvs_arr = np.asarray(hlcvs)
     if hlcvs_arr.ndim != 3 or hlcvs_arr.shape[2] < 4:
@@ -726,6 +731,8 @@ def _validate_hlcvs_valid_windows(
         raise ValueError(
             f"coin_indices length ({len(active_columns)}) does not match coins ({len(coins_order)})"
         )
+
+    valid_windows: list[tuple[int, int, int]] = []
     for payload_idx, coin in enumerate(coins_order):
         if payload_idx >= len(first_valid_indices) or payload_idx >= len(last_valid_indices):
             raise ValueError(
@@ -737,16 +744,53 @@ def _validate_hlcvs_valid_windows(
         start = int(first_valid_indices[payload_idx])
         end = int(last_valid_indices[payload_idx])
         if start > end:
+            valid_windows.append((col, 1, 0))
             continue
         start = max(0, start)
         end = min(n_rows - 1, end)
-        if start > end:
+        valid_windows.append((col, start, end))
+
+    row_bytes = max(1, int(n_cols * 4 * hlcvs_arr.dtype.itemsize))
+    chunk_rows = max(1, int(target_chunk_bytes) // row_bytes)
+    chunk_count = 0
+    first_bad_rows: list[int | None] = [None] * len(coins_order)
+    validation_t0 = time.perf_counter()
+    logging.info(
+        "[hlcvs] valid-window validation start rows=%d coins=%d bytes=%d chunk_rows=%d",
+        n_rows,
+        len(coins_order),
+        int(n_rows * n_cols * 4 * hlcvs_arr.dtype.itemsize),
+        chunk_rows,
+    )
+    for chunk_start in range(0, n_rows, chunk_rows):
+        chunk_end = min(n_rows, chunk_start + chunk_rows)
+        finite_by_row_coin = np.isfinite(
+            hlcvs_arr[chunk_start:chunk_end, :, :4]
+        ).all(axis=2)
+        chunk_count += 1
+        for payload_idx, (col, start, end) in enumerate(valid_windows):
+            if first_bad_rows[payload_idx] is not None or start > end:
+                continue
+            overlap_start = max(start, chunk_start)
+            overlap_end = min(end + 1, chunk_end)
+            if overlap_start >= overlap_end:
+                continue
+            finite = finite_by_row_coin[
+                overlap_start - chunk_start : overlap_end - chunk_start, col
+            ]
+            if finite.all():
+                continue
+            first_bad_rows[payload_idx] = overlap_start + int(
+                np.flatnonzero(~finite)[0]
+            )
+
+    for payload_idx, coin in enumerate(coins_order):
+        bad_row = first_bad_rows[payload_idx]
+        if bad_row is None:
             continue
-        window = hlcvs_arr[start : end + 1, col, :4]
-        if np.isfinite(window).all():
-            continue
-        bad_rel_row, bad_field = np.argwhere(~np.isfinite(window))[0]
-        bad_row = start + int(bad_rel_row)
+        col, start, end = valid_windows[payload_idx]
+        bad_fields = np.flatnonzero(~np.isfinite(hlcvs_arr[bad_row, col, :4]))
+        bad_field = int(bad_fields[0])
         bad_value = float(hlcvs_arr[bad_row, col, int(bad_field)])
         if timestamps_arr is not None and bad_row < len(timestamps_arr):
             ts_context = f" timestamp_ms={int(timestamps_arr[bad_row])}"
@@ -758,6 +802,18 @@ def _validate_hlcvs_valid_windows(
             f"k={bad_row}{ts_context} field={hlcv_fields[int(bad_field)]} value={bad_value} "
             f"valid_window={start}..{end}"
         )
+
+    validation_elapsed = time.perf_counter() - validation_t0
+    validated_bytes = int(n_rows * n_cols * 4 * hlcvs_arr.dtype.itemsize)
+    logging.info(
+        "[hlcvs] valid-window validation done rows=%d coins=%d chunks=%d elapsed_s=%.1f "
+        "throughput_mib_s=%.1f",
+        n_rows,
+        len(coins_order),
+        chunk_count,
+        validation_elapsed,
+        float(validated_bytes) / (1024.0**2) / max(validation_elapsed, 1e-9),
+    )
 
 
 def _validate_hlcvs_valid_windows_from_mss(hlcvs, timestamps, coins, mss) -> None:

--- a/src/backtest_dataset_materializer.py
+++ b/src/backtest_dataset_materializer.py
@@ -529,9 +529,24 @@ def materialize_frames(
             float(hlcvs.nbytes) / (1024.0**2) / max(write_elapsed, 1e-9),
         )
         raise_if_backtest_cancel_requested("frame materializer close")
+        flush_t0 = time.monotonic()
+        logging.info(
+            "[materializer] frame flush start exchange=%s rows=%d coins=%d bytes=%d",
+            exchange,
+            n_steps,
+            len(coins),
+            int(hlcvs.nbytes),
+        )
         _close_memmap(hlcvs)
         _close_memmap(timestamps_mm)
         _close_memmap(btc_mm)
+        logging.info(
+            "[materializer] frame flush done exchange=%s rows=%d coins=%d elapsed_s=%.1f",
+            exchange,
+            n_steps,
+            len(coins),
+            time.monotonic() - flush_t0,
+        )
         hlcvs = None
         timestamps_mm = None
         btc_mm = None

--- a/tests/test_build_backtest_payload_purity.py
+++ b/tests/test_build_backtest_payload_purity.py
@@ -795,6 +795,57 @@ def test_hlcvs_valid_window_chunking_ignores_nonfinite_outside_each_coin_window(
     )
 
 
+def test_hlcvs_valid_window_chunking_scans_only_active_rows_and_columns(monkeypatch):
+    n_minutes = 10
+    hlcvs = np.empty((n_minutes, 4, 4), dtype=np.float64)
+    for col in range(4):
+        hlcvs[:, col, :] = float(col)
+    observed_chunks = []
+    original_isfinite = np.isfinite
+
+    def recording_isfinite(values):
+        arr = np.asarray(values)
+        observed_chunks.append((arr.shape, tuple(np.unique(arr[:, :, 0]))))
+        return original_isfinite(values)
+
+    monkeypatch.setattr(np, "isfinite", recording_isfinite)
+    _validate_hlcvs_valid_windows(
+        hlcvs,
+        None,
+        ["BTC", "EMPTY", "SOL"],
+        [2, n_minutes, 4],
+        [4, n_minutes - 1, 6],
+        coin_indices=[0, 1, 3],
+        target_chunk_bytes=1024,
+    )
+
+    # BTC covers rows 2..4 and SOL covers 4..6. The sweep therefore scans
+    # BTC alone, both columns for their one-row overlap, and SOL alone. The
+    # empty symbol, unused column 2, and rows outside the union are untouched.
+    assert observed_chunks == [
+        ((2, 1, 4), (0.0,)),
+        ((1, 2, 4), (0.0, 3.0)),
+        ((2, 1, 4), (3.0,)),
+    ]
+
+
+def test_hlcvs_valid_window_chunking_skips_scan_when_all_windows_are_empty(monkeypatch):
+    n_minutes = 10
+    hlcvs = np.full((n_minutes, 2, 4), np.nan, dtype=np.float64)
+
+    def fail_if_scanned(_values):
+        raise AssertionError("empty valid windows must not scan the HLCV payload")
+
+    monkeypatch.setattr(np, "isfinite", fail_if_scanned)
+    _validate_hlcvs_valid_windows(
+        hlcvs,
+        None,
+        ["BTC", "ETH"],
+        [n_minutes, n_minutes],
+        [n_minutes - 1, n_minutes - 1],
+    )
+
+
 def test_build_backtest_payload_aggregation_recomputes_effective_start_ts_over_stale_mss():
     """Pin that `build_backtest_payload` recomputes `effective_start_timestamp_ms`
     from the post-aggregation timestamps even when the caller pre-set a stale

--- a/tests/test_build_backtest_payload_purity.py
+++ b/tests/test_build_backtest_payload_purity.py
@@ -747,6 +747,54 @@ def test_build_backtest_payload_reports_active_source_column_for_nonfinite_price
         )
 
 
+def test_hlcvs_valid_window_chunking_preserves_coin_first_error_order():
+    start_ts = 1609459200000
+    n_minutes = 12
+    coins = ["BTC", "ETH"]
+    hlcvs = np.ones((n_minutes, len(coins), 4), dtype=np.float64)
+    timestamps = np.arange(
+        start_ts, start_ts + n_minutes * 60_000, 60_000, dtype=np.int64
+    )
+    # The legacy validator traverses coins first, so BTC's later bad row must
+    # still win over ETH's earlier bad row after switching to time-major chunks.
+    hlcvs[10, 0, 3] = np.nan
+    hlcvs[1, 1, 0] = np.inf
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"non-finite HLCV value inside valid backtest window: "
+            r"coin=BTC payload_index=0 source_column=0 k=10 .* field=volume"
+        ),
+    ):
+        _validate_hlcvs_valid_windows(
+            hlcvs,
+            timestamps,
+            coins,
+            [0, 0],
+            [n_minutes - 1, n_minutes - 1],
+            target_chunk_bytes=2 * len(coins) * 4 * np.dtype(np.float64).itemsize,
+        )
+
+
+def test_hlcvs_valid_window_chunking_ignores_nonfinite_outside_each_coin_window():
+    n_minutes = 12
+    hlcvs = np.ones((n_minutes, 2, 4), dtype=np.float64)
+    hlcvs[:3, 0, :] = np.nan
+    hlcvs[9:, 0, :] = np.nan
+    hlcvs[:5, 1, :] = np.nan
+    hlcvs[11:, 1, :] = np.nan
+
+    _validate_hlcvs_valid_windows(
+        hlcvs,
+        None,
+        ["BTC", "ETH"],
+        [3, 5],
+        [8, 10],
+        target_chunk_bytes=2 * 2 * 4 * np.dtype(np.float64).itemsize,
+    )
+
+
 def test_build_backtest_payload_aggregation_recomputes_effective_start_ts_over_stale_mss():
     """Pin that `build_backtest_payload` recomputes `effective_start_timestamp_ms`
     from the post-aggregation timestamps even when the caller pre-set a stale


### PR DESCRIPTION
## Summary

- validate multi-coin HLCV payloads in bounded time-major chunks instead of one strided pass per coin
- preserve valid-window semantics and coin-first non-finite error reporting
- log memmap flush and valid-window validation as separate preparation stages

## Root cause

The backtest payload is laid out as `(time, coin, field)`, but preflight validation traversed `hlcvs[:, coin, :4]` one coin at a time. On wide, multi-year datasets this creates poor locality across the multi-gigabyte mapping. The frame writer also logged completion before its explicit memmap flush, leaving flush time and validation time indistinguishable.

## Performance

A reproducible synthetic memmap benchmark using shape `(600000, 53, 4)` (`0.95 GiB`) measured:

- existing coin-major validator: `0.58-0.68s`
- new time-major chunked validator: `0.20s`
- best-run speedup: `2.9x`

The benchmark used the same float64 time-major layout as backtest preparation. The added stage timings will separate flush and validation cost on full production-sized builds.

## Validation

- rebuilt and verified the repository Rust extension source fingerprint
- `python -m pytest tests/test_build_backtest_payload_purity.py tests/test_hlcvs_valid_ranges.py tests/test_ohlcv_v2_foundation.py tests/test_materialized_cache.py tests/test_hlcvs_cache_roundtrip.py tests/test_ohlcv_v2_prepare.py::test_prepare_hlcvs_mss_prefers_local_v2_before_full_prepare tests/test_ohlcv_v2_prepare.py::test_prepare_hlcvs_mss_releases_payload_when_cache_save_interrupted -q`
  - 79 passed
- 250 randomized valid-window parity cases matched the previous validator's success/failure and exact error text
- `git diff --check`
