### PR TITLE
Avoid re-reading arrays for cache manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable user-facing changes will be documented in this file.
   `scenario_stat` spellings remain accepted as input aliases (plus legacy limit `field`),
   same-valued aliases collapse to `reducer`, conflicting aliases fail validation, and existing
   Pareto/suite result artifacts remain readable without rewriting their historical payload keys.
+- Hash backtest cache arrays while writing their NPY artifacts, avoiding a second full-array read
+  solely to build the cache manifest after multi-gigabyte cache publication.
 - Preserve the full configured exchange pool for combined optimizer and backtest suite datasets
   when every selected coin happens to use the same venue, so single-coin multi-exchange suites no
   longer reject valid unselected candidate venues as unavailable.

--- a/src/backtest.py
+++ b/src/backtest.py
@@ -121,6 +121,7 @@ from hlcvs_manifest import (
     build_hlcvs_manifest,
     load_hlcvs_manifest,
     manifest_has_required_schema,
+    save_numpy_artifact_with_hash,
     verify_hlcvs_manifest,
     write_hlcvs_manifest,
 )
@@ -1790,22 +1791,25 @@ def _save_coins_hlcvs_artifacts_to_cache_dir(
 ) -> None:
     uncompressed_size = hlcvs.nbytes
     sts = utc_ms()
+    array_hashes: dict[str, str] = {}
     if is_compressed:
         fpath = cache_dir / "hlcvs.npy.gz"
         logging.info(f"Attempting to save hlcvs data to cache {fpath}...")
         with gzip.open(fpath, "wb", compresslevel=1) as f:
-            np.save(f, hlcvs)
+            array_hashes["hlcvs"] = save_numpy_artifact_with_hash(f, hlcvs)
         raise_if_backtest_cancel_requested("hlcvs cache artifact")
         if timestamps is not None:
             ts_fpath = cache_dir / "timestamps.npy.gz"
             logging.info(f"Attempting to save timestamps to cache {ts_fpath}...")
             with gzip.open(ts_fpath, "wb", compresslevel=1) as f:
-                np.save(f, timestamps)
+                array_hashes["timestamps"] = save_numpy_artifact_with_hash(f, timestamps)
             raise_if_backtest_cancel_requested("timestamps cache artifact")
         btc_fpath = cache_dir / "btc_usd_prices.npy.gz"
         logging.info(f"Attempting to save BTC/USD prices to cache {btc_fpath}...")
         with gzip.open(btc_fpath, "wb", compresslevel=1) as f:
-            np.save(f, btc_usd_prices)
+            array_hashes["btc_usd_prices"] = save_numpy_artifact_with_hash(
+                f, btc_usd_prices
+            )
         raise_if_backtest_cancel_requested("btc cache artifact")
         compressed_size = (cache_dir / "hlcvs.npy.gz").stat().st_size
         btc_compressed_size = (cache_dir / "btc_usd_prices.npy.gz").stat().st_size
@@ -1817,16 +1821,21 @@ def _save_coins_hlcvs_artifacts_to_cache_dir(
     else:
         fpath = cache_dir / "hlcvs.npy"
         logging.info(f"Attempting to save hlcvs data to cache {fpath}...")
-        np.save(fpath, hlcvs)
+        with fpath.open("wb") as f:
+            array_hashes["hlcvs"] = save_numpy_artifact_with_hash(f, hlcvs)
         raise_if_backtest_cancel_requested("hlcvs cache artifact")
         if timestamps is not None:
             ts_fpath = cache_dir / "timestamps.npy"
             logging.info(f"Attempting to save timestamps to cache {ts_fpath}...")
-            np.save(ts_fpath, timestamps)
+            with ts_fpath.open("wb") as f:
+                array_hashes["timestamps"] = save_numpy_artifact_with_hash(f, timestamps)
             raise_if_backtest_cancel_requested("timestamps cache artifact")
         btc_fpath = cache_dir / "btc_usd_prices.npy"
         logging.info(f"Attempting to save BTC/USD prices to cache {btc_fpath}...")
-        np.save(btc_fpath, btc_usd_prices)
+        with btc_fpath.open("wb") as f:
+            array_hashes["btc_usd_prices"] = save_numpy_artifact_with_hash(
+                f, btc_usd_prices
+            )
         raise_if_backtest_cancel_requested("btc cache artifact")
         line = ""
     logging.info(
@@ -1855,6 +1864,7 @@ def _save_coins_hlcvs_artifacts_to_cache_dir(
         timestamps=timestamps,
         warmup_minutes=warmup_minutes,
         compressed=is_compressed,
+        precomputed_array_hashes=array_hashes,
     )
     raise_if_backtest_cancel_requested("cache manifest write")
     write_hlcvs_manifest(cache_dir, manifest)

--- a/src/hlcvs_manifest.py
+++ b/src/hlcvs_manifest.py
@@ -37,17 +37,101 @@ def _sha256_bytes(payload: bytes) -> str:
     return hashlib.sha256(payload).hexdigest()
 
 
+def _new_logical_array_hasher(array: np.ndarray):
+    hasher = hashlib.sha256()
+    hasher.update(str(array.dtype).encode("utf-8"))
+    hasher.update(b"\0")
+    hasher.update(json.dumps(list(array.shape), separators=(",", ":")).encode("utf-8"))
+    hasher.update(b"\0")
+    return hasher
+
+
 def hash_logical_array(array: Any) -> str:
     arr = np.ascontiguousarray(np.asarray(array))
-    hasher = hashlib.sha256()
-    hasher.update(str(arr.dtype).encode("utf-8"))
-    hasher.update(b"\0")
-    hasher.update(json.dumps(list(arr.shape), separators=(",", ":")).encode("utf-8"))
-    hasher.update(b"\0")
+    hasher = _new_logical_array_hasher(arr)
     # arr is C-contiguous, so its buffer is byte-identical to tobytes(order="C")
     # without materializing a full copy.
     hasher.update(arr.data)
     return hasher.hexdigest()
+
+
+class _NpyDataHashingWriter:
+    """Forward an NPY stream while hashing only its logical array payload."""
+
+    def __init__(self, destination, array: np.ndarray):
+        self.destination = destination
+        self.hasher = _new_logical_array_hasher(array)
+        self.expected_data_bytes = int(array.nbytes)
+        self.hashed_data_bytes = 0
+        self.header_bytes = bytearray()
+        self.data_offset: int | None = None
+
+    def write(self, payload: bytes) -> int:
+        written = self.destination.write(payload)
+        if written is None:
+            written = len(payload)
+        if int(written) != len(payload):
+            raise OSError(
+                f"short NPY artifact write: expected {len(payload)} bytes, wrote {written}"
+            )
+        self._hash_npy_stream_bytes(payload)
+        return int(written)
+
+    def _hash_npy_stream_bytes(self, payload: bytes) -> None:
+        if self.data_offset is not None and not self.header_bytes:
+            self.hasher.update(payload)
+            self.hashed_data_bytes += len(payload)
+            return
+
+        self.header_bytes.extend(payload)
+        if len(self.header_bytes) < 8:
+            return
+        if self.header_bytes[:6] != b"\x93NUMPY":
+            raise HlcvsManifestError("invalid NPY magic while hashing cache artifact")
+        major_version = int(self.header_bytes[6])
+        if major_version == 1:
+            length_field_end = 10
+            length_field_start = 8
+        elif major_version in {2, 3}:
+            length_field_end = 12
+            length_field_start = 8
+        else:
+            raise HlcvsManifestError(
+                f"unsupported NPY version while hashing cache artifact: {major_version}"
+            )
+        if len(self.header_bytes) < length_field_end:
+            return
+        header_length = int.from_bytes(
+            self.header_bytes[length_field_start:length_field_end], "little"
+        )
+        if self.data_offset is None:
+            self.data_offset = length_field_end + header_length
+        if len(self.header_bytes) < self.data_offset:
+            return
+        data = self.header_bytes[self.data_offset :]
+        if data:
+            self.hasher.update(data)
+            self.hashed_data_bytes += len(data)
+        self.header_bytes.clear()
+
+    def hexdigest(self) -> str:
+        if self.data_offset is None or self.header_bytes:
+            raise HlcvsManifestError("incomplete NPY header while hashing cache artifact")
+        if self.hashed_data_bytes != self.expected_data_bytes:
+            raise HlcvsManifestError(
+                "incomplete NPY data while hashing cache artifact: "
+                f"expected {self.expected_data_bytes} bytes, hashed {self.hashed_data_bytes}"
+            )
+        return self.hasher.hexdigest()
+
+
+def save_numpy_artifact_with_hash(destination, array: Any) -> str:
+    """Write one numeric NPY artifact and return its unchanged logical-array hash."""
+
+    arr = np.ascontiguousarray(np.asarray(array))
+    writer = _NpyDataHashingWriter(destination, arr)
+    np.save(writer, arr, allow_pickle=False)
+    return writer.hexdigest()
 
 
 def hash_json_value(value: Any) -> str:
@@ -63,11 +147,13 @@ def load_numpy_artifact(path: Path) -> np.ndarray:
     return np.load(path)
 
 
-def _array_file_entry(path: str, array: Any) -> dict[str, Any]:
+def _array_file_entry(
+    path: str, array: Any, *, sha256: str | None = None
+) -> dict[str, Any]:
     arr = np.asarray(array)
     return {
         "path": path,
-        "sha256": hash_logical_array(arr),
+        "sha256": hash_logical_array(arr) if sha256 is None else str(sha256),
         "shape": [int(x) for x in arr.shape],
         "dtype": str(arr.dtype),
     }
@@ -127,6 +213,7 @@ def build_hlcvs_manifest(
     timestamps: Any | None,
     warmup_minutes: int,
     compressed: bool,
+    precomputed_array_hashes: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     if timestamps is None:
         raise HlcvsManifestError("HLCV manifests require timestamps artifact data")
@@ -135,11 +222,17 @@ def build_hlcvs_manifest(
     effective_end_ts = int(ts_arr[-1]) if ts_arr.size else None
 
     requested_end_date = format_end_date(require_config_value(config, "backtest.end_date"))
+    precomputed_array_hashes = precomputed_array_hashes or {}
     files = {
-        "hlcvs": _array_file_entry("hlcvs.npy.gz" if compressed else "hlcvs.npy", hlcvs),
+        "hlcvs": _array_file_entry(
+            "hlcvs.npy.gz" if compressed else "hlcvs.npy",
+            hlcvs,
+            sha256=precomputed_array_hashes.get("hlcvs"),
+        ),
         "btc_usd_prices": _array_file_entry(
             "btc_usd_prices.npy.gz" if compressed else "btc_usd_prices.npy",
             btc_usd_prices,
+            sha256=precomputed_array_hashes.get("btc_usd_prices"),
         ),
         "coins": _json_file_entry("coins.json", coins),
         "market_specific_settings": _json_file_entry("market_specific_settings.json", mss),
@@ -147,6 +240,7 @@ def build_hlcvs_manifest(
     files["timestamps"] = _array_file_entry(
         "timestamps.npy.gz" if compressed else "timestamps.npy",
         timestamps,
+        sha256=precomputed_array_hashes.get("timestamps"),
     )
     candidate_report = None
     if isinstance(mss, dict):

--- a/tests/test_hlcvs_manifest.py
+++ b/tests/test_hlcvs_manifest.py
@@ -1,3 +1,5 @@
+import gzip
+import io
 import json
 
 import numpy as np
@@ -5,8 +7,10 @@ import pytest
 
 from hlcvs_manifest import (
     HlcvsManifestError,
+    _NpyDataHashingWriter,
     build_hlcvs_manifest,
     hash_logical_array,
+    save_numpy_artifact_with_hash,
     verify_hlcvs_manifest,
     write_hlcvs_manifest,
 )
@@ -239,6 +243,80 @@ def test_hash_logical_array_matches_tobytes_reference():
     ]
     for arr in arrays:
         assert hash_logical_array(arr) == reference_hash(arr)
+
+
+@pytest.mark.parametrize("compressed", [False, True])
+@pytest.mark.parametrize(
+    "array",
+    [
+        np.arange(24, dtype=np.float64).reshape(2, 3, 4),
+        np.arange(24, dtype=np.float64).reshape(2, 3, 4)[:, :2, :],
+        np.asfortranarray(np.arange(6, dtype=np.float64).reshape(2, 3)),
+        np.array([1735689600000, 1735689660000], dtype=np.int64),
+        np.empty((0, 2, 4), dtype=np.float64),
+    ],
+)
+def test_save_numpy_artifact_with_hash_matches_logical_hash(tmp_path, compressed, array):
+    path = tmp_path / ("array.npy.gz" if compressed else "array.npy")
+    opener = gzip.open if compressed else open
+    with opener(path, "wb") as f:
+        digest = save_numpy_artifact_with_hash(f, array)
+
+    with opener(path, "rb") as f:
+        loaded = np.load(f)
+
+    np.testing.assert_array_equal(loaded, array)
+    assert digest == hash_logical_array(array)
+
+
+def test_npy_data_hashing_writer_handles_fragmented_header():
+    array = np.arange(24, dtype=np.float64).reshape(2, 3, 4)
+    encoded = io.BytesIO()
+    np.save(encoded, array, allow_pickle=False)
+
+    destination = io.BytesIO()
+    writer = _NpyDataHashingWriter(destination, array)
+    payload = encoded.getvalue()
+    for offset in range(0, len(payload), 3):
+        writer.write(payload[offset : offset + 3])
+
+    assert destination.getvalue() == payload
+    assert writer.hexdigest() == hash_logical_array(array)
+
+
+def test_build_hlcvs_manifest_uses_precomputed_array_hashes(monkeypatch):
+    coins = ["BTC"]
+    hlcvs = np.ones((2, 1, 4), dtype=np.float64)
+    timestamps = np.array([1735689600000, 1735689660000], dtype=np.int64)
+    btc_usd_prices = np.array([100.0, 101.0], dtype=np.float64)
+    mss = {"BTC": {"exchange": "binance"}, "__meta__": {}}
+    expected = {
+        "hlcvs": hash_logical_array(hlcvs),
+        "timestamps": hash_logical_array(timestamps),
+        "btc_usd_prices": hash_logical_array(btc_usd_prices),
+    }
+
+    def fail_if_rehashed(_array):
+        raise AssertionError("precomputed array hash must avoid a second array pass")
+
+    monkeypatch.setattr("hlcvs_manifest.hash_logical_array", fail_if_rehashed)
+    manifest = build_hlcvs_manifest(
+        config=_minimal_config(),
+        exchange="binance",
+        cache_hash="abc123",
+        coins=coins,
+        hlcvs=hlcvs,
+        mss=mss,
+        btc_usd_prices=btc_usd_prices,
+        timestamps=timestamps,
+        warmup_minutes=0,
+        compressed=False,
+        precomputed_array_hashes=expected,
+    )
+
+    assert manifest["files"]["hlcvs"]["sha256"] == expected["hlcvs"]
+    assert manifest["files"]["timestamps"]["sha256"] == expected["timestamps"]
+    assert manifest["files"]["btc_usd_prices"]["sha256"] == expected["btc_usd_prices"]
 
 
 def test_verify_hlcvs_manifest_returns_verified_arrays(tmp_path):


### PR DESCRIPTION
## Summary

- compute logical-array SHA-256 digests while NPY cache artifacts are written
- reuse those digests when building the HLCV cache manifest
- preserve the existing digest format and compressed/uncompressed artifact formats
- handle split NPY headers and reject incomplete/short artifact streams

## Why

Cache publication previously traversed each array once to write its NPY artifact and then traversed it again to build the manifest. For multi-gigabyte disk-backed arrays, that second pass can become an avoidable I/O-bound tail after artifact publication.

This keeps the write path and manifest integrity contract intact while reducing full source-array passes from two to one.

## Validation

- 52 focused tests passed:
  - `tests/test_hlcvs_manifest.py`
  - `tests/test_hlcvs_cache_roundtrip.py`
  - `tests/test_cache_warmup_reuse.py`
  - interrupted cache-save cleanup regression
- compressed and uncompressed round trips cover C-contiguous, non-contiguous, Fortran-order, integer, and empty arrays
- fragmented NPY-header regression verifies stream-boundary independence
- rebuilt and source-fingerprint-verified the real Rust extension before the final test run

## Performance check

A repeated synthetic gzip-level-1 benchmark on a 122 MiB in-memory array was neutral within noise: median 2.422s for write plus separate hash versus 2.431s for combined write/hash. The intended gain is avoiding the second source read when large materialized arrays are disk-backed or no longer resident, without adding a measurable in-memory-path cost.