### PR TITLE
Fix single-coin forager readiness and bounded candle gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Skip forager ranking and its feature requirements when each side's eligible universe already
+  fits its configured position slots. Freshly fetched forager candidates may also bridge bounded,
+  later-bracketed internal candle gaps under `live.max_active_candle_tail_gap_minutes`; cache-only
+  stale candidates remain strict.
 - Standardize suite reduction configuration on `reducer` across `backtest`, optimizer scoring,
   limits, CLI parsing, examples, and serialized configs. The former `aggregate`, `stat`, and
   `scenario_stat` spellings remain accepted as input aliases (plus legacy limit `field`),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
-- Skip forager ranking and its feature requirements when each side's eligible universe already
-  fits its configured position slots. Freshly fetched forager candidates may also bridge bounded,
-  later-bracketed internal candle gaps under `live.max_active_candle_tail_gap_minutes`; cache-only
-  stale candidates remain strict.
+- Skip forager ranking and its feature requirements when each side's exact remaining candidate
+  universe fits its remaining position slots, including when ineligible held positions consume
+  slots. Python now scopes missing ranking-only inputs to Rust selection instead of making the
+  whole symbol non-tradable. Freshly fetched forager candidates may also bridge bounded,
+  later-bracketed internal candle gaps under `live.max_active_candle_tail_gap_minutes`, with
+  per-symbol/metric consecutive-use and recovery diagnostics; cache-only stale candidates remain
+  strict.
 - Standardize suite reduction configuration on `reducer` across `backtest`, optimizer scoring,
   limits, CLI parsing, examples, and serialized configs. The former `aggregate`, `stat`, and
   `scenario_stat` spellings remain accepted as input aliases (plus legacy limit `field`),

--- a/docs/ai/error_contract.md
+++ b/docs/ai/error_contract.md
@@ -86,7 +86,8 @@ projected rows must be discarded after that read so delayed authoritative highs 
 them immediately. Freshly fetched forager ranking quote-volume and log-range inputs may bridge a
 later-bounded internal gap when its complete length is within
 `live.max_active_candle_tail_gap_minutes`; cache-only candidates retain their narrower
-carry-forward contract.
+carry-forward contract. Each refreshed-symbol ranking metric records warning-visible gap count,
+age, source, and consecutive-use diagnostics, followed by an authoritative-recovery diagnostic.
 
 Protective panic and reduce-only actions may proceed when their own account-critical and
 symbol-scoped requirements are fresh, even if unrelated strategy surfaces are unavailable.
@@ -105,6 +106,9 @@ tail grace period. An explicit positive forager cap is an operator override.
 
 Candidates with no prior feature basis, non-finite carried values, or excessive feature age are
 unavailable for new entries. Do not silently rank only the subset that happened to refresh first.
+Ranking-feature absence must remain scoped to forager selection: when the exact remaining eligible
+candidate count fits the remaining slots, Rust may select those candidates without ranking and
+must not let Python turn that unused input absence into symbol-wide non-tradability.
 
 Approved and ignored coin state is an entry-eligibility input. Stale or unreadable eligibility
 blocks affected initial entries but not protective management. With `auto_gs=true`, removal of a

--- a/docs/ai/error_contract.md
+++ b/docs/ai/error_contract.md
@@ -83,7 +83,9 @@ flat zero-volume rows for active strategy inputs while authoritative overlap rep
 Trailing-extrema reconstruction may use the same projection only for a still-open tail after dense
 post-fill coverage; it must not bridge a missing reset boundary or internal minute, and the
 projected rows must be discarded after that read so delayed authoritative highs and lows replace
-them immediately. Forager ranking quote-volume and log-range inputs retain their narrower
+them immediately. Freshly fetched forager ranking quote-volume and log-range inputs may bridge a
+later-bounded internal gap when its complete length is within
+`live.max_active_candle_tail_gap_minutes`; cache-only candidates retain their narrower
 carry-forward contract.
 
 Protective panic and reduce-only actions may proceed when their own account-critical and
@@ -93,8 +95,10 @@ symbol-scoped requirements are fresh, even if unrelated strategy surfaces are un
 
 Flat-symbol forager candidates may remain rankable within
 `live.max_forager_candle_staleness_minutes`. Close EMA readiness may use bounded flat-close
-projection. Quote-volume and log-range ranking inputs carry forward their latest known EMA with
-age/source metadata; they do not receive invented zero tails.
+projection. Freshly fetched quote-volume and log-range ranking inputs may use flat zero-volume
+continuity for later-bounded internal gaps within `live.max_active_candle_tail_gap_minutes`.
+Cache-only ranking inputs instead carry forward their latest known EMA with age/source metadata;
+they do not receive invented zero tails.
 When the forager setting is unset, its budget-derived acceptable age must not be shorter than
 `live.max_active_candle_tail_gap_minutes`; the refresh budget must not silently reduce the active
 tail grace period. An explicit positive forager cap is an operator override.

--- a/docs/ai/error_contract.md
+++ b/docs/ai/error_contract.md
@@ -83,9 +83,10 @@ flat zero-volume rows for active strategy inputs while authoritative overlap rep
 Trailing-extrema reconstruction may use the same projection only for a still-open tail after dense
 post-fill coverage; it must not bridge a missing reset boundary or internal minute, and the
 projected rows must be discarded after that read so delayed authoritative highs and lows replace
-them immediately. Freshly fetched forager ranking quote-volume and log-range inputs may bridge a
-later-bounded internal gap when its complete length is within
-`live.max_active_candle_tail_gap_minutes`; cache-only candidates retain their narrower
+them immediately. Forager ranking quote-volume and log-range inputs may bridge a later-bounded
+internal gap only after the current planning bundle records a successful authoritative refresh for
+that symbol; remote fetch permission alone is not refresh provenance. The complete gap length must
+be within `live.max_active_candle_tail_gap_minutes`; cache-only candidates retain their narrower
 carry-forward contract. Each refreshed-symbol ranking metric records warning-visible gap count,
 age, source, and consecutive-use diagnostics, followed by an authoritative-recovery diagnostic.
 
@@ -96,8 +97,9 @@ symbol-scoped requirements are fresh, even if unrelated strategy surfaces are un
 
 Flat-symbol forager candidates may remain rankable within
 `live.max_forager_candle_staleness_minutes`. Close EMA readiness may use bounded flat-close
-projection. Freshly fetched quote-volume and log-range ranking inputs may use flat zero-volume
-continuity for later-bounded internal gaps within `live.max_active_candle_tail_gap_minutes`.
+projection. Quote-volume and log-range ranking inputs may use flat zero-volume continuity for
+later-bounded internal gaps within `live.max_active_candle_tail_gap_minutes` only after an
+authoritative refresh advances during the current planning bundle.
 Cache-only ranking inputs instead carry forward their latest known EMA with age/source metadata;
 they do not receive invented zero tails.
 When the forager setting is unset, its budget-derived acceptable age must not be shorter than
@@ -108,7 +110,9 @@ Candidates with no prior feature basis, non-finite carried values, or excessive 
 unavailable for new entries. Do not silently rank only the subset that happened to refresh first.
 Ranking-feature absence must remain scoped to forager selection: when the exact remaining eligible
 candidate count fits the remaining slots, Rust may select those candidates without ranking and
-must not let Python turn that unused input absence into symbol-wide non-tradability.
+must not let Python turn that unused input absence into symbol-wide non-tradability or a current
+ranking-unavailable alert. Diagnostics may retain the gap as conditional until Rust reports that
+ranking was required for that side.
 
 Approved and ignored coin state is an entry-eligibility input. Stale or unreadable eligibility
 blocks affected initial entries but not protective management. With `auto_gs=true`, removal of a

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -99,15 +99,16 @@
    candles: they may use non-persistent zero-volume continuity rows so sparse no-trade intervals
    do not permanently block strategy inputs. The timestamps remain unresolved and retryable;
    delayed authoritative rows replace the provisional values and invalidate affected EMA caches.
-   This exception is selected explicitly by the consumer: freshly fetched completed-candle
-   forager ranking metrics may bridge bounded internal gaps, while cache-only candidate reads
-   remain strict. Synthetic replacement tracking follows the
+   This exception is selected explicitly by the consumer: completed-candle forager ranking metrics
+   may bridge bounded internal gaps only after the current planning bundle observes that the symbol's
+   authoritative refresh timestamp advanced. Merely allowing a remote fetch is insufficient;
+   cache-only candidate reads remain strict. Synthetic replacement tracking follows the
    manager's live/replay clock so delayed authoritative rows invalidate provisional replay EMAs
    deterministically. Runtime provenance is retained per symbol, metric, span, and EMA window so
    live orchestration can report gap count, age, synthetic source, consecutive uses, and recovery.
    The live orchestrator requests forager quote-volume and log-range with bounded internal-gap
-   continuity only for refreshed symbols; cache-only stale candidates cannot invent zero-volume
-   or zero-range observations.
+   continuity only for symbols actually refreshed during that planner bundle; cache-only stale
+   candidates cannot invent zero-volume or zero-range observations.
    Open-ended tails use the separate bounded projection policy below.
    Refresh budgets count
    symbol/timeframe fetches, health scans are bounded and rotated across cycles, interleave each
@@ -186,7 +187,9 @@
    nevertheless symbol-scoped: once every normal side is proven dynamically managed, any missing
    required strategy EMA degrades the whole flat symbol rather than fabricating a partial bundle.
    Missing forager ranking features remain side-scoped because their affected side is authoritative
-   and carried separately from strategy EMA maps. Dynamic-management eligibility is retained in
+   and carried separately from strategy EMA maps. They remain conditional diagnostics, rather than
+   symbol-wide EMA-unavailable state, until Rust reports that ranking was required for that side.
+   Dynamic-management eligibility is retained in
    memory independently of side-scoped cancellation permission when Rust's symbol-level
    nontradable result changes both sides to the configured manual stop mode. This lets the next
    identical missing-ranking cycle remain degraded without authorizing cancellation of an
@@ -243,9 +246,10 @@
     Missing rows remain unavailable to ordinary candle consumers until an authoritative row
     arrives. Live strategy EMA reads may provisionally bridge a later-bracketed internal gap with
     non-persistent flat zero-volume rows only when the gap is no wider than
-    `live.max_active_candle_tail_gap_minutes`; freshly fetched forager ranking reads use the same
-    bounded internal-gap rule, while cache-only forager ranking carry-forward remains unavailable
-    across an unresolved internal gap. Complete rows in the supplied EMA window remain
+    `live.max_active_candle_tail_gap_minutes`; forager ranking reads use the same bounded internal-gap
+    rule only after an authoritative refresh advances during the current planning bundle, while
+    cache-only forager ranking carry-forward remains unavailable across an unresolved internal gap.
+    Complete rows in the supplied EMA window remain
     authoritative even if stale known-gap metadata still names their timestamps. Recording or
     extending a 1m gap invalidates cached 1m EMA and open-tail projection values. An overlap refresh
     which retries a due gap

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -103,7 +103,8 @@
    forager ranking metrics may bridge bounded internal gaps, while cache-only candidate reads
    remain strict. Synthetic replacement tracking follows the
    manager's live/replay clock so delayed authoritative rows invalidate provisional replay EMAs
-   deterministically.
+   deterministically. Runtime provenance is retained per symbol, metric, span, and EMA window so
+   live orchestration can report gap count, age, synthetic source, consecutive uses, and recovery.
    The live orchestrator requests forager quote-volume and log-range with bounded internal-gap
    continuity only for refreshed symbols; cache-only stale candidates cannot invent zero-volume
    or zero-range observations.

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -99,14 +99,14 @@
    candles: they may use non-persistent zero-volume continuity rows so sparse no-trade intervals
    do not permanently block strategy inputs. The timestamps remain unresolved and retryable;
    delayed authoritative rows replace the provisional values and invalidate affected EMA caches.
-   This exception is selected explicitly by the consumer: cache-only candidate close EMAs and
-   completed-candle forager ranking metrics remain strict, use policy-separated cache entries, and
-   cannot reuse a provisional active-strategy result. Synthetic replacement tracking follows the
+   This exception is selected explicitly by the consumer: freshly fetched completed-candle
+   forager ranking metrics may bridge bounded internal gaps, while cache-only candidate reads
+   remain strict. Synthetic replacement tracking follows the
    manager's live/replay clock so delayed authoritative rows invalidate provisional replay EMAs
    deterministically.
-   The live orchestrator likewise requests forager quote-volume and log-range through the strict
-   policy even for active symbols. A coincident strategy log-range span may use provisional
-   continuity without leaking that value into the separate `forager_m1` ranking bundle.
+   The live orchestrator requests forager quote-volume and log-range with bounded internal-gap
+   continuity only for refreshed symbols; cache-only stale candidates cannot invent zero-volume
+   or zero-range observations.
    Open-ended tails use the separate bounded projection policy below.
    Refresh budgets count
    symbol/timeframe fetches, health scans are bounded and rotated across cycles, interleave each
@@ -242,8 +242,9 @@
     Missing rows remain unavailable to ordinary candle consumers until an authoritative row
     arrives. Live strategy EMA reads may provisionally bridge a later-bracketed internal gap with
     non-persistent flat zero-volume rows only when the gap is no wider than
-    `live.max_active_candle_tail_gap_minutes`; cache-only forager ranking carry-forward remains
-    unavailable across an unresolved internal gap. Complete rows in the supplied EMA window remain
+    `live.max_active_candle_tail_gap_minutes`; freshly fetched forager ranking reads use the same
+    bounded internal-gap rule, while cache-only forager ranking carry-forward remains unavailable
+    across an unresolved internal gap. Complete rows in the supplied EMA window remain
     authoritative even if stale known-gap metadata still names their timestamps. Recording or
     extending a 1m gap invalidates cached 1m EMA and open-tail projection values. An overlap refresh
     which retries a due gap

--- a/passivbot-rust/src/coin_selection.rs
+++ b/passivbot-rust/src/coin_selection.rs
@@ -114,15 +114,15 @@ impl ForagerSelectionConfig {
     }
 
     fn volume_required(&self) -> Result<bool, ForagerSelectionError> {
-        Ok(self.volume_drop()? > 0.0 || self.weights.volume != 0.0)
+        Ok(self.require_forager && (self.volume_drop()? > 0.0 || self.weights.volume != 0.0))
     }
 
     fn volatility_required(&self) -> bool {
-        self.weights.volatility != 0.0
+        self.require_forager && self.weights.volatility != 0.0
     }
 
     fn ema_readiness_required(&self) -> bool {
-        self.weights.ema_readiness != 0.0
+        self.require_forager && self.weights.ema_readiness != 0.0
     }
 
     fn score_hysteresis(&self) -> Result<f64, ForagerSelectionError> {
@@ -860,6 +860,27 @@ mod tests {
             ..default_config()
         };
         assert_eq!(select_coins(&features, &cfg), vec![0, 2]);
+    }
+
+    #[test]
+    fn non_forager_candidate_selection_does_not_require_ranking_inputs() {
+        let mut enabled = make_candidate(0, f64::NAN, f64::NAN, f64::NAN, f64::NAN);
+        enabled.ema_lower = f64::NAN;
+        enabled.ema_upper = f64::NAN;
+        enabled.entry_initial_ema_dist = f64::NAN;
+        let mut disabled = make_candidate(1, f64::NAN, f64::NAN, f64::NAN, f64::NAN);
+        disabled.enabled = false;
+        let cfg = ForagerSelectionConfig {
+            require_forager: false,
+            ..default_forager_config(ForagerPositionSide::Long)
+        };
+
+        let selection =
+            select_forager_candidates_with_diagnostics(&[enabled, disabled], &cfg).unwrap();
+
+        assert_eq!(selection.selected_indices, vec![0]);
+        assert!(selection.scored.is_empty());
+        assert!(selection.hysteresis_events.is_empty());
     }
 
     #[test]

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -2222,6 +2222,59 @@ mod core {
         }
     }
 
+    fn count_enabled_forager_candidates(
+        symbols: &[SymbolInput],
+        pside: PositionSide,
+        strategy_kind: StrategyKind,
+        hedge_mode: bool,
+        filter_enabled: bool,
+        balance: f64,
+        runtime_budgets: &[RuntimeBudgetState],
+        active_flags: Option<&[bool]>,
+        derived_cache: &mut [CachedSideDerived],
+    ) -> Result<usize, OrchestratorError> {
+        let mut enabled_count = 0usize;
+        for s in symbols {
+            let side = match pside {
+                PositionSide::Long => &s.long,
+                PositionSide::Short => &s.short,
+            };
+            let strategy_params = cached_strategy_params_for_symbol_side(
+                derived_cache,
+                s.symbol_idx,
+                strategy_kind,
+                match pside {
+                    PositionSide::Long => StrategySide::Long,
+                    PositionSide::Short => StrategySide::Short,
+                },
+                side,
+            )?;
+            let already_active = active_flags
+                .and_then(|flags| flags.get(s.symbol_idx))
+                .copied()
+                .unwrap_or(false);
+            let can_open_initial =
+                should_generate_entries(effective_mode(side.mode, false), false, true);
+            let min_cost_ok = effective_min_cost_is_low_enough(
+                balance,
+                filter_enabled,
+                s.effective_min_cost,
+                &side.bot_params,
+                &runtime_budgets[s.symbol_idx],
+                strategy_initial_qty_pct(&strategy_params),
+            );
+            if symbol_side_eligible(s, pside)
+                && !already_active
+                && one_way_allows_initial_slot(symbols, s.symbol_idx, pside, hedge_mode)
+                && can_open_initial
+                && min_cost_ok
+            {
+                enabled_count += 1;
+            }
+        }
+        Ok(enabled_count)
+    }
+
     fn build_forager_candidates_into(
         symbols: &[SymbolInput],
         pside: PositionSide,
@@ -3314,8 +3367,20 @@ mod core {
                 }
             }
             if actives_long_count < enp_long {
+                let slots_to_fill = enp_long.saturating_sub(actives_long_count);
+                let remaining_candidate_count = count_enabled_forager_candidates(
+                    &input.symbols,
+                    PositionSide::Long,
+                    input.global.strategy_kind,
+                    input.global.hedge_mode,
+                    input.global.filter_by_min_effective_cost,
+                    input.balance,
+                    &workspace.runtime_budget_long,
+                    Some(actives_long),
+                    &mut workspace.derived_long,
+                )?;
                 let cfg = ForagerSelectionConfig {
-                    slots_to_fill: enp_long.saturating_sub(actives_long_count),
+                    slots_to_fill,
                     volume_drop_pct: input.global.global_bot_params.long.forager_volume_drop_pct,
                     weights: input
                         .global
@@ -3323,7 +3388,7 @@ mod core {
                         .long
                         .forager_score_weights
                         .clone(),
-                    require_forager: enp_long < eligible_long,
+                    require_forager: remaining_candidate_count > slots_to_fill,
                     position_side: ForagerPositionSide::Long,
                     score_hysteresis_pct: input
                         .forager_hysteresis
@@ -3400,8 +3465,20 @@ mod core {
                 }
             }
             if actives_short_count < enp_short {
+                let slots_to_fill = enp_short.saturating_sub(actives_short_count);
+                let remaining_candidate_count = count_enabled_forager_candidates(
+                    &input.symbols,
+                    PositionSide::Short,
+                    input.global.strategy_kind,
+                    input.global.hedge_mode,
+                    input.global.filter_by_min_effective_cost,
+                    input.balance,
+                    &workspace.runtime_budget_short,
+                    Some(actives_short),
+                    &mut workspace.derived_short,
+                )?;
                 let cfg = ForagerSelectionConfig {
-                    slots_to_fill: enp_short.saturating_sub(actives_short_count),
+                    slots_to_fill,
                     volume_drop_pct: input.global.global_bot_params.short.forager_volume_drop_pct,
                     weights: input
                         .global
@@ -3409,7 +3486,7 @@ mod core {
                         .short
                         .forager_score_weights
                         .clone(),
-                    require_forager: enp_short < eligible_short,
+                    require_forager: remaining_candidate_count > slots_to_fill,
                     position_side: ForagerPositionSide::Short,
                     score_hysteresis_pct: input
                         .forager_hysteresis

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -223,6 +223,7 @@ mod core {
     pub struct ForagerSelectionDiagnostic {
         pub pside: PositionSide,
         pub slots_to_fill: usize,
+        pub ranking_required: bool,
         pub score_hysteresis_pct: f64,
         pub selected_symbol_indices: Vec<usize>,
         pub incumbent_symbol_indices: Vec<usize>,
@@ -1043,6 +1044,7 @@ mod core {
             .push(ForagerSelectionDiagnostic {
                 pside,
                 slots_to_fill: cfg.slots_to_fill,
+                ranking_required: cfg.require_forager,
                 score_hysteresis_pct: cfg.score_hysteresis_pct,
                 selected_symbol_indices: result.selected_indices.clone(),
                 incumbent_symbol_indices,
@@ -5318,6 +5320,7 @@ mod core {
                 .find(|selection| selection.pside == PositionSide::Long)
                 .unwrap();
             assert_eq!(selection.selected_symbol_indices, vec![0]);
+            assert!(!selection.ranking_required);
             assert!(selection.top_scores.is_empty());
         }
 

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -2243,9 +2243,10 @@ mod core {
                     field: "forager_score_weights",
                     symbol_idx: None,
                 })?;
-        let volume_required = cfg.volume_drop_pct > 0.0 || normalized_weights.volume != 0.0;
-        let volatility_required = normalized_weights.volatility != 0.0;
-        let ema_readiness_required = normalized_weights.ema_readiness != 0.0;
+        let volume_required =
+            cfg.require_forager && (cfg.volume_drop_pct > 0.0 || normalized_weights.volume != 0.0);
+        let volatility_required = cfg.require_forager && normalized_weights.volatility != 0.0;
+        let ema_readiness_required = cfg.require_forager && normalized_weights.ema_readiness != 0.0;
         out.clear();
         out.reserve(symbols.len());
         for s in symbols {
@@ -3322,7 +3323,7 @@ mod core {
                         .long
                         .forager_score_weights
                         .clone(),
-                    require_forager: true,
+                    require_forager: enp_long < eligible_long,
                     position_side: ForagerPositionSide::Long,
                     score_hysteresis_pct: input
                         .forager_hysteresis
@@ -3408,7 +3409,7 @@ mod core {
                         .short
                         .forager_score_weights
                         .clone(),
-                    require_forager: true,
+                    require_forager: enp_short < eligible_short,
                     position_side: ForagerPositionSide::Short,
                     score_hysteresis_pct: input
                         .forager_hysteresis
@@ -5199,6 +5200,48 @@ mod core {
             assert!((block.effective_limit - 1.5).abs() < 1e-12);
             assert!((block.projected_initial_cost - 1.4732627616).abs() < 1e-9);
             assert!((block.effective_min_cost - 10.1).abs() < 1e-12);
+        }
+
+        #[test]
+        fn single_eligible_coin_skips_forager_feature_requirements() {
+            let mut symbol = make_basic_symbol(0);
+            symbol.forager_m1 = Some(EmaTimeframeBundle::default());
+
+            let mut global = make_basic_global();
+            global.global_bot_params.long.n_positions = 1;
+            global.global_bot_params.long.total_wallet_exposure_limit = 1.0;
+            global.global_bot_params.long.forager_volume_drop_pct = 0.5;
+            global.global_bot_params.long.forager_score_weights =
+                crate::types::ForagerScoreWeights {
+                    volume: 1.0,
+                    ema_readiness: 1.0,
+                    volatility: 1.0,
+                };
+            global.global_bot_params.short.n_positions = 0;
+            global.global_bot_params.short.total_wallet_exposure_limit = 0.0;
+
+            let input = OrchestratorInput {
+                timestamp_ms: 0,
+                balance: 1_000.0,
+                balance_raw: 1_000.0,
+                global,
+                symbols: vec![symbol],
+                peek_hints: None,
+                forager_hysteresis: None,
+            };
+
+            let out = compute_ideal_orders_for_test(&input).unwrap();
+            assert!(out.orders.iter().any(|order| {
+                order.symbol_idx == 0 && order.pside == PositionSide::Long && order.qty > 0.0
+            }));
+            let selection = out
+                .diagnostics
+                .forager_selections
+                .iter()
+                .find(|selection| selection.pside == PositionSide::Long)
+                .unwrap();
+            assert_eq!(selection.selected_symbol_indices, vec![0]);
+            assert!(selection.top_scores.is_empty());
         }
 
         #[test]

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -971,6 +971,11 @@ class CandlestickManager:
         ] = {}
         # Cache for EMA computations: per symbol -> {(metric, span, tf): (value, end_ts, computed_at_ms)}
         self._ema_cache: Dict[str, Dict[Tuple[str, int, str], Tuple[float, int, int]]] = {}
+        # Non-persistent provenance for EMA values computed with later-bounded
+        # internal zero-volume continuity rows. Keys mirror the EMA cache.
+        self._ema_provisional_internal_gap_context: Dict[
+            str, Dict[Tuple[str, float, str], Dict[str, int]]
+        ] = {}
         # Compatibility attribute retained for older monitor/tool code.  The
         # candlestick manager no longer owns current in-progress prices.
         self._current_close_cache: Dict[str, Tuple[float, int]] = {}
@@ -2974,6 +2979,24 @@ class CandlestickManager:
         self, symbol: str, *, timeframe: Optional[str] = None
     ) -> None:
         """Invalidate cached EMA values for a symbol, optionally for one timeframe."""
+        if symbol in self._ema_provisional_internal_gap_context:
+            if timeframe is None:
+                self._ema_provisional_internal_gap_context.pop(symbol, None)
+            else:
+                tf_key = str(_tf_to_ms(timeframe))
+                retained_context = {
+                    key: value
+                    for key, value in self._ema_provisional_internal_gap_context[
+                        symbol
+                    ].items()
+                    if len(key) < 3 or str(key[2]) != tf_key
+                }
+                if retained_context:
+                    self._ema_provisional_internal_gap_context[symbol] = (
+                        retained_context
+                    )
+                else:
+                    self._ema_provisional_internal_gap_context.pop(symbol, None)
         if symbol not in self._ema_cache:
             return
         if timeframe is None:
@@ -9439,6 +9462,83 @@ class CandlestickManager:
             tf=tf,
         )
 
+    def _record_ema_provisional_internal_gap_context(
+        self,
+        symbol: str,
+        metric_key: str,
+        span: float,
+        period_ms: int,
+        start_ts: int,
+        end_ts: int,
+    ) -> None:
+        key = (str(metric_key), float(span), str(period_ms))
+        contexts = self._ema_provisional_internal_gap_context.setdefault(symbol, {})
+        if period_ms != ONE_MIN_MS:
+            contexts.pop(key, None)
+            return
+        tolerance_ms = int(
+            self.provisional_internal_gap_tolerance_minutes * ONE_MIN_MS
+        )
+        if tolerance_ms <= 0:
+            contexts.pop(key, None)
+            return
+        last_final_ts = int(self.get_last_final_ts(symbol) or 0)
+        cached = self._cache.get(symbol)
+        if isinstance(cached, np.ndarray) and cached.size > 0:
+            last_final_ts = max(
+                last_final_ts, int(np.max(np.asarray(cached["ts"], dtype=np.int64)))
+            )
+        used_ranges: List[Tuple[int, int]] = []
+        for full_gap_start, full_gap_end in self._unverified_uncovered_gap_ranges(
+            symbol, int(start_ts), int(end_ts)
+        ):
+            gap_width_ms = int(full_gap_end) - int(full_gap_start) + ONE_MIN_MS
+            overlap_start = max(int(start_ts), int(full_gap_start))
+            overlap_end = min(int(end_ts), int(full_gap_end))
+            if (
+                overlap_start <= overlap_end
+                and gap_width_ms <= tolerance_ms
+                and int(full_gap_end) < last_final_ts
+            ):
+                used_ranges.append((overlap_start, overlap_end))
+        if not used_ranges:
+            contexts.pop(key, None)
+            if not contexts:
+                self._ema_provisional_internal_gap_context.pop(symbol, None)
+            return
+        gap_candles = sum(
+            (gap_end - gap_start) // ONE_MIN_MS + 1
+            for gap_start, gap_end in used_ranges
+        )
+        max_gap_candles = max(
+            (gap_end - gap_start) // ONE_MIN_MS + 1
+            for gap_start, gap_end in used_ranges
+        )
+        oldest_gap_start = min(gap_start for gap_start, _gap_end in used_ranges)
+        contexts[key] = {
+            "gap_count": int(len(used_ranges)),
+            "gap_candles": int(gap_candles),
+            "max_gap_candles": int(max_gap_candles),
+            "oldest_gap_age_ms": max(0, int(self._now_ms()) - oldest_gap_start),
+            "window_start_ts": int(start_ts),
+            "window_end_ts": int(end_ts),
+        }
+
+    def get_ema_provisional_internal_gap_context(
+        self,
+        symbol: str,
+        metric_key: str,
+        span: float,
+        *,
+        timeframe: Optional[str] = None,
+        tf: Optional[str] = None,
+    ) -> Optional[Dict[str, int]]:
+        period_ms = _tf_to_ms(timeframe if timeframe is not None else tf)
+        context = self._ema_provisional_internal_gap_context.get(symbol, {}).get(
+            (str(metric_key), float(span), str(period_ms))
+        )
+        return None if context is None else dict(context)
+
     async def get_latest_ema_close(
         self,
         symbol: str,
@@ -9487,6 +9587,15 @@ class CandlestickManager:
             return float("nan")
         closes = np.asarray(arr["c"], dtype=np.float64)
         res = float(self._ema(closes, span))
+        if allow_provisional_internal_gaps:
+            self._record_ema_provisional_internal_gap_context(
+                symbol,
+                "close",
+                span,
+                period_ms,
+                start_ts,
+                end_ts,
+            )
         # Store in cache
         cache[key] = (res, int(end_ts), int(now))
         return res
@@ -9742,6 +9851,20 @@ class CandlestickManager:
             return float("nan")
         series = series_fn(arr)
         res = float(self._ema(series, span))
+        if allow_provisional_internal_gaps:
+            if math.isfinite(res):
+                self._record_ema_provisional_internal_gap_context(
+                    symbol,
+                    metric_key,
+                    span,
+                    period_ms,
+                    start_ts,
+                    end_ts,
+                )
+            else:
+                self._ema_provisional_internal_gap_context.get(symbol, {}).pop(
+                    (str(metric_key), float(span), str(period_ms)), None
+                )
         cache[key] = (res, int(end_ts), int(now))
         return res
 
@@ -9997,7 +10120,20 @@ class CandlestickManager:
                 value = float(self._ema(self._ema_metric_series(metric_key, tail), span))
                 out[metric_key][span] = value
                 if not math.isfinite(value):
+                    if allow_provisional_internal_gaps:
+                        self._ema_provisional_internal_gap_context.get(symbol, {}).pop(
+                            (str(metric_key), float(span), str(period_ms)), None
+                        )
                     continue
+                if allow_provisional_internal_gaps:
+                    self._record_ema_provisional_internal_gap_context(
+                        symbol,
+                        metric_key,
+                        span,
+                        period_ms,
+                        metric_start_ts,
+                        end_ts,
+                    )
                 cache[(cache_metric_key, float(span), tf_key)] = (
                     value,
                     int(end_ts),

--- a/src/live/reconciler.py
+++ b/src/live/reconciler.py
@@ -2745,6 +2745,10 @@ def validate_rust_orchestrator_output(
             raise FatalBotException(
                 f"Rust orchestrator {context} has invalid slots_to_fill"
             )
+        if not isinstance(selection.get("ranking_required"), bool):
+            raise FatalBotException(
+                f"Rust orchestrator {context} has invalid ranking_required"
+            )
         validate_diagnostic_finite_fields(selection, ("score_hysteresis_pct",), context)
         for field in ("selected_symbol_indices", "incumbent_symbol_indices"):
             validate_diagnostic_symbol_idx_list(

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -18066,9 +18066,13 @@ class Passivbot:
                     span=span,
                     max_age_ms=m1_max_age_by_symbol.get(symbol, 60_000),
                     allow_remote_fetch=symbol not in cache_only_symbols,
-                    # Quote volume is consumed only by forager ranking today.
-                    # Unknown internal gaps must not become invented zero volume.
-                    allow_provisional_internal_gaps=False,
+                    # Freshly fetched candidates may bridge later-bounded gaps
+                    # within the configured tolerance. Cache-only candidates
+                    # remain strict because an unknown stale tail is not
+                    # continuity evidence.
+                    allow_provisional_internal_gaps=(
+                        symbol not in cache_only_symbols
+                    ),
                 )
             )
 
@@ -18089,9 +18093,11 @@ class Passivbot:
                     span=span,
                     max_age_ms=m1_max_age_by_symbol.get(symbol, 60_000),
                     allow_remote_fetch=symbol not in cache_only_symbols,
-                    # Ranking is stricter than active strategy volatility and
-                    # owns a policy-separated EMA cache entry.
-                    allow_provisional_internal_gaps=False,
+                    # Match quote-volume continuity policy: only refreshed
+                    # candidates may bridge bounded internal gaps.
+                    allow_provisional_internal_gaps=(
+                        symbol not in cache_only_symbols
+                    ),
                 )
             )
 
@@ -18128,7 +18134,6 @@ class Passivbot:
             if metric_key is None:
                 return None
             timeframe = "1h" if ema_type == "h1_log_range" else "1m"
-            strict = ema_type in {"m1_volume", "forager_m1_log_range"}
             values = await method(
                 symbol,
                 {metric_key: [float(span) for span in spans]},
@@ -18140,7 +18145,7 @@ class Passivbot:
                 timeframe=timeframe,
                 allow_remote_fetch=symbol not in cache_only_symbols,
                 allow_provisional_internal_gaps=(
-                    False if strict else symbol not in cache_only_symbols
+                    symbol not in cache_only_symbols
                 ),
             )
             metric_values = values.get(metric_key, {})

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -13920,6 +13920,7 @@ class Passivbot:
         """Emit throttled Rust-owned forager score and hysteresis diagnostics."""
         diagnostics = out.get("diagnostics", {}) if isinstance(out, dict) else {}
         selections = diagnostics.get("forager_selections", [])
+        self._forager_ranking_required_by_side = {"long": False, "short": False}
         if not isinstance(selections, list) or not selections:
             return
         if not hasattr(self, "_forager_selection_log_state"):
@@ -13992,6 +13993,10 @@ class Passivbot:
             if not isinstance(selection, dict):
                 continue
             pside = str(selection.get("pside") or "unknown")
+            if pside in self._forager_ranking_required_by_side:
+                self._forager_ranking_required_by_side[pside] = bool(
+                    selection.get("ranking_required", False)
+                )
             top_scores = [
                 item
                 for item in selection.get("top_scores", [])
@@ -14183,7 +14188,6 @@ class Passivbot:
                 )
                 state["debug_key"] = debug_key
                 state["debug_last_ms"] = now_ms
-
     # Legacy init_fill_events, update_fill_events, etc. removed - using FillEventsManager
 
     @staticmethod
@@ -17032,6 +17036,32 @@ class Passivbot:
         optional_ema_drops: dict[tuple[str, str, str], list[tuple[str, float]]] = {}
         close_ema_recoveries: dict[str, list[tuple[float, int]]] = {}
         close_ema_fallbacks: dict[str, list[tuple[float, int, int, str, str]]] = {}
+        refresh_baseline_by_symbol: dict[str, int] = {}
+        forager_provisional_primary_spans: dict[
+            tuple[str, str], set[float]
+        ] = {}
+        refresh_getter = getattr(self.cm, "get_last_refresh_ms", None)
+
+        def last_refresh_ms(symbol: str) -> int:
+            if not callable(refresh_getter):
+                return 0
+            try:
+                return int(refresh_getter(symbol) or 0)
+            except Exception as exc:
+                logging.debug(
+                    "[forager] failed to read candle refresh provenance | "
+                    "symbol=%s error_type=%s",
+                    symbol,
+                    type(exc).__name__,
+                )
+                return 0
+
+        for symbol in symbols:
+            refresh_baseline_by_symbol[symbol] = last_refresh_ms(symbol)
+
+        def refreshed_during_bundle(symbol: str) -> bool:
+            current = last_refresh_ms(symbol)
+            return current > int(refresh_baseline_by_symbol.get(symbol, 0))
 
         def log_ema_issue(
             key: tuple,
@@ -17071,6 +17101,11 @@ class Passivbot:
                 or not bool(is_forager_mode())
                 or ema_type not in {"m1_volume", "forager_m1_log_range"}
             ):
+                return
+            primary_spans = set(primary_spans) & set(
+                forager_provisional_primary_spans.get((symbol, ema_type), set())
+            )
+            if not primary_spans:
                 return
             getter = getattr(
                 self.cm, "get_ema_provisional_internal_gap_context", None
@@ -18140,21 +18175,40 @@ class Passivbot:
             )
 
         async def ema_qv(symbol: str, span: float) -> float:
-            return float(
-                await self.cm.get_latest_ema_quote_volume(
-                    symbol,
-                    span=span,
-                    max_age_ms=m1_max_age_by_symbol.get(symbol, 60_000),
-                    allow_remote_fetch=symbol not in cache_only_symbols,
-                    # Freshly fetched candidates may bridge later-bounded gaps
-                    # within the configured tolerance. Cache-only candidates
-                    # remain strict because an unknown stale tail is not
-                    # continuity evidence.
-                    allow_provisional_internal_gaps=(
-                        symbol not in cache_only_symbols
-                    ),
+            async def read(allow_provisional: bool) -> float:
+                return float(
+                    await self.cm.get_latest_ema_quote_volume(
+                        symbol,
+                        span=span,
+                        max_age_ms=m1_max_age_by_symbol.get(symbol, 60_000),
+                        allow_remote_fetch=symbol not in cache_only_symbols,
+                        allow_provisional_internal_gaps=allow_provisional,
+                    )
                 )
-            )
+
+            try:
+                value = await read(False)
+            except Exception:
+                if symbol in cache_only_symbols or not refreshed_during_bundle(symbol):
+                    raise
+                value = await read(True)
+                if math.isfinite(value):
+                    forager_provisional_primary_spans.setdefault(
+                        (symbol, "m1_volume"), set()
+                    ).add(float(span))
+                return value
+            if (
+                math.isfinite(value)
+                or symbol in cache_only_symbols
+                or not refreshed_during_bundle(symbol)
+            ):
+                return value
+            value = await read(True)
+            if math.isfinite(value):
+                forager_provisional_primary_spans.setdefault(
+                    (symbol, "m1_volume"), set()
+                ).add(float(span))
+            return value
 
         async def ema_lr_1m(symbol: str, span: float) -> float:
             return float(
@@ -18167,19 +18221,40 @@ class Passivbot:
             )
 
         async def ema_forager_lr_1m(symbol: str, span: float) -> float:
-            return float(
-                await self.cm.get_latest_ema_log_range(
-                    symbol,
-                    span=span,
-                    max_age_ms=m1_max_age_by_symbol.get(symbol, 60_000),
-                    allow_remote_fetch=symbol not in cache_only_symbols,
-                    # Match quote-volume continuity policy: only refreshed
-                    # candidates may bridge bounded internal gaps.
-                    allow_provisional_internal_gaps=(
-                        symbol not in cache_only_symbols
-                    ),
+            async def read(allow_provisional: bool) -> float:
+                return float(
+                    await self.cm.get_latest_ema_log_range(
+                        symbol,
+                        span=span,
+                        max_age_ms=m1_max_age_by_symbol.get(symbol, 60_000),
+                        allow_remote_fetch=symbol not in cache_only_symbols,
+                        allow_provisional_internal_gaps=allow_provisional,
+                    )
                 )
-            )
+
+            try:
+                value = await read(False)
+            except Exception:
+                if symbol in cache_only_symbols or not refreshed_during_bundle(symbol):
+                    raise
+                value = await read(True)
+                if math.isfinite(value):
+                    forager_provisional_primary_spans.setdefault(
+                        (symbol, "forager_m1_log_range"), set()
+                    ).add(float(span))
+                return value
+            if (
+                math.isfinite(value)
+                or symbol in cache_only_symbols
+                or not refreshed_during_bundle(symbol)
+            ):
+                return value
+            value = await read(True)
+            if math.isfinite(value):
+                forager_provisional_primary_spans.setdefault(
+                    (symbol, "forager_m1_log_range"), set()
+                ).add(float(span))
+            return value
 
         async def ema_lr_1h(symbol: str, span: float) -> float:
             return float(
@@ -18214,9 +18289,11 @@ class Passivbot:
             if metric_key is None:
                 return None
             timeframe = "1h" if ema_type == "h1_log_range" else "1m"
-            values = await method(
-                symbol,
-                {metric_key: [float(span) for span in spans]},
+            ranking_ema_type = ema_type in {
+                "m1_volume",
+                "forager_m1_log_range",
+            }
+            call_kwargs = dict(
                 max_age_ms=(
                     h1_max_age_by_symbol.get(symbol, 600_000)
                     if timeframe == "1h"
@@ -18224,11 +18301,45 @@ class Passivbot:
                 ),
                 timeframe=timeframe,
                 allow_remote_fetch=symbol not in cache_only_symbols,
+            )
+            values = await method(
+                symbol,
+                {metric_key: [float(span) for span in spans]},
+                **call_kwargs,
                 allow_provisional_internal_gaps=(
-                    symbol not in cache_only_symbols
+                    symbol not in cache_only_symbols and not ranking_ema_type
                 ),
             )
-            metric_values = values.get(metric_key, {})
+            metric_values = dict(values.get(metric_key, {}))
+            missing_spans = {
+                float(span)
+                for span in spans
+                if float(span) not in metric_values
+                or not math.isfinite(
+                    float(metric_values.get(float(span), float("nan")))
+                )
+            }
+            if (
+                ranking_ema_type
+                and missing_spans
+                and symbol not in cache_only_symbols
+                and refreshed_during_bundle(symbol)
+            ):
+                retry_values = await method(
+                    symbol,
+                    {metric_key: [float(span) for span in spans]},
+                    **call_kwargs,
+                    allow_provisional_internal_gaps=True,
+                )
+                retry_metric_values = retry_values.get(metric_key, {})
+                for span in missing_spans:
+                    retry_value = retry_metric_values.get(span)
+                    if retry_value is None or not math.isfinite(float(retry_value)):
+                        continue
+                    metric_values[span] = retry_value
+                    forager_provisional_primary_spans.setdefault(
+                        (symbol, ema_type), set()
+                    ).add(span)
             return {
                 float(span): float(value)
                 for span, value in metric_values.items()
@@ -18635,28 +18746,6 @@ class Passivbot:
                 # explicit missing-input flag makes only that candidate/side
                 # unavailable instead of disabling the whole symbol.
                 self._orchestrator_allow_missing_strategy_inputs_symbols.add(sym)
-                candidate_ema_unavailable_details.setdefault(reason, []).append(
-                    (
-                        sym,
-                        "MissingForagerRankingEma",
-                        tuple(
-                            sorted(
-                                ({"m1_volume"} if missing_required_volume else set())
-                                | (
-                                    {"forager_m1_log_range"}
-                                    if missing_required_forager_lr1m
-                                    else set()
-                                )
-                            )
-                        ),
-                        tuple(
-                            sorted(
-                                set(missing_required_volume)
-                                | set(missing_required_forager_lr1m)
-                            )
-                        ),
-                    )
-                )
                 log_ema_issue(
                     ("required_forager_missing", sym),
                     (
@@ -18865,10 +18954,29 @@ class Passivbot:
                 "; ".join(examples),
                 interval_ms=15 * 60 * 1000,
             )
+        alerting_optional_ema_drops: dict[
+            tuple[str, str, str], list[tuple[str, float]]
+        ] = {}
+        for key, items in optional_ema_drops.items():
+            ema_type, _reason_code, _error_type = key
+            conditional_spans = (
+                required_forager_volume_spans
+                if ema_type == "m1_volume"
+                else required_forager_m1_lr_spans
+                if ema_type == "forager_m1_log_range"
+                else set()
+            )
+            alerting_items = [
+                (symbol, span)
+                for symbol, span in items
+                if float(span) not in conditional_spans
+            ]
+            if alerting_items:
+                alerting_optional_ema_drops[key] = alerting_items
         ema_unavailable_event_emitted = bool(
             Passivbot._emit_ema_unavailable_event(
                 self,
-                optional_ema_drops=optional_ema_drops,
+                optional_ema_drops=alerting_optional_ema_drops,
                 candidate_ema_unavailable_details=candidate_ema_unavailable_details,
                 ema_unavailable_reasons=ema_unavailable_reasons,
             )
@@ -19029,12 +19137,9 @@ class Passivbot:
             cancellation_psides_by_symbol[str(symbol)] = (
                 dynamic_forager_managed_entry_psides(symbol)
             )
-        ranking_reason_symbols = {
-            str(symbol)
-            for reason, items in candidate_ema_unavailable_details.items()
-            if str(reason).startswith("missing_required_forager_")
-            for symbol, _error_type, _ema_types, _spans in items
-        }
+        ranking_reason_symbols = set().union(
+            *(set(symbols) for symbols in rank_feature_unavailable_by_side.values())
+        )
         for pside, unavailable_symbols in rank_feature_unavailable_by_side.items():
             for symbol in ranking_reason_symbols & set(unavailable_symbols):
                 if pside in dynamic_forager_managed_entry_psides(symbol):

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -17019,6 +17019,8 @@ class Passivbot:
             self._orchestrator_close_ema_fallback_counts = {}
         if not hasattr(self, "_orchestrator_ema_issue_last_log_ms"):
             self._orchestrator_ema_issue_last_log_ms = {}
+        if not hasattr(self, "_orchestrator_forager_gap_fallback_counts"):
+            self._orchestrator_forager_gap_fallback_counts = {}
         m1_max_age_by_symbol = {s: 60_000 for s in symbols}
         h1_max_age_by_symbol = {s: 600_000 for s in symbols}
         cache_only_symbols: set[str] = set()
@@ -17056,6 +17058,79 @@ class Passivbot:
         ) -> None:
             optional_ema_drops.setdefault((ema_type, reason_code, error_type), []).append(
                 (symbol, span)
+            )
+
+        def record_forager_gap_fallback_diagnostics(
+            symbol: str,
+            ema_type: str,
+            primary_spans: set[float],
+        ) -> None:
+            if (
+                not primary_spans
+                or symbol in cache_only_symbols
+                or not bool(is_forager_mode())
+                or ema_type not in {"m1_volume", "forager_m1_log_range"}
+            ):
+                return
+            getter = getattr(
+                self.cm, "get_ema_provisional_internal_gap_context", None
+            )
+            if not callable(getter):
+                return
+            metric_key = "qv" if ema_type == "m1_volume" else "log_range"
+            diagnostic_metric = (
+                "quote_volume" if ema_type == "m1_volume" else "log_range"
+            )
+            contexts = []
+            for span in sorted(primary_spans):
+                context = getter(symbol, metric_key, span, timeframe="1m")
+                if context:
+                    contexts.append((float(span), dict(context)))
+            key = (symbol, diagnostic_metric)
+            previous_count = int(
+                self._orchestrator_forager_gap_fallback_counts.get(key, 0) or 0
+            )
+            if not contexts:
+                if previous_count > 0:
+                    self._orchestrator_forager_gap_fallback_counts[key] = 0
+                    logging.info(
+                        "[ema] forager ranking provisional internal-gap fallback recovered "
+                        "%s metric=%s after_consecutive_uses=%d source=authoritative_candles",
+                        Passivbot._log_symbol(symbol),
+                        diagnostic_metric,
+                        previous_count,
+                    )
+                return
+            consecutive_uses = previous_count + 1
+            self._orchestrator_forager_gap_fallback_counts[key] = consecutive_uses
+            gap_count = max(int(ctx.get("gap_count", 0) or 0) for _span, ctx in contexts)
+            gap_candles = max(
+                int(ctx.get("gap_candles", 0) or 0) for _span, ctx in contexts
+            )
+            max_gap_candles = max(
+                int(ctx.get("max_gap_candles", 0) or 0)
+                for _span, ctx in contexts
+            )
+            oldest_gap_age_ms = max(
+                int(ctx.get("oldest_gap_age_ms", 0) or 0)
+                for _span, ctx in contexts
+            )
+            log_ema_issue(
+                ("forager_provisional_internal_gap", symbol, diagnostic_metric),
+                logging.WARNING,
+                "[ema] forager ranking provisional internal-gap fallback %s "
+                "metric=%s spans=%s reason=later_bounded_internal_gap "
+                "source=synthetic_zero_volume_continuity gap_count=%d "
+                "gap_candles=%d max_gap_candles=%d age_ms=%d consecutive_uses=%d",
+                Passivbot._log_symbol(symbol),
+                diagnostic_metric,
+                ",".join(f"{span:.8g}" for span, _ctx in contexts),
+                gap_count,
+                gap_candles,
+                max_gap_candles,
+                oldest_gap_age_ms,
+                consecutive_uses,
+                interval_ms=15 * 60 * 1000,
             )
 
         def ema_error_type(exc: Exception) -> str:
@@ -17617,6 +17692,7 @@ class Passivbot:
 
         async def fetch_map(symbol: str, spans: list[float], fn, ema_type: str):
             out: dict[float, float] = {}
+            primary_spans: set[float] = set()
             if not spans:
                 return out
             metric_key = {
@@ -17680,6 +17756,7 @@ class Passivbot:
                     )
                 if math.isfinite(val):
                     out[span] = val
+                    primary_spans.add(span)
                 else:
                     if metric_key is not None:
                         fallback = cached_fallbacks.get(span)
@@ -17696,6 +17773,9 @@ class Passivbot:
                     record_optional_ema_drop(
                         ema_type, symbol, span, "non_finite_value", "NonFiniteValue"
                     )
+            record_forager_gap_fallback_diagnostics(
+                symbol, ema_type, primary_spans
+            )
             return out
 
         async def fetch_required_map(
@@ -18549,31 +18629,51 @@ class Passivbot:
                     f"volume_spans={','.join(f'{span:.8g}' for span in missing_required_volume)} "
                     f"log_range_spans={','.join(f'{span:.8g}' for span in missing_required_forager_lr1m)}"
                 )
-                if not required_ema_can_mark_nontradable(sym):
-                    log_ema_issue(
-                        ("required_forager_missing_active", sym),
-                        logging.WARNING,
-                        "[ema] missing required forager EMA %s %s action=raise | %s",
-                        Passivbot._log_symbol(sym),
-                        detail,
-                        ema_candle_health_context(sym),
-                        interval_ms=15 * 60 * 1000,
+                # Ranking inputs are side- and selection-scope data. Keep the
+                # symbol tradable and let Rust decide whether the remaining
+                # candidate set actually requires ranking. If it does, the
+                # explicit missing-input flag makes only that candidate/side
+                # unavailable instead of disabling the whole symbol.
+                self._orchestrator_allow_missing_strategy_inputs_symbols.add(sym)
+                candidate_ema_unavailable_details.setdefault(reason, []).append(
+                    (
+                        sym,
+                        "MissingForagerRankingEma",
+                        tuple(
+                            sorted(
+                                ({"m1_volume"} if missing_required_volume else set())
+                                | (
+                                    {"forager_m1_log_range"}
+                                    if missing_required_forager_lr1m
+                                    else set()
+                                )
+                            )
+                        ),
+                        tuple(
+                            sorted(
+                                set(missing_required_volume)
+                                | set(missing_required_forager_lr1m)
+                            )
+                        ),
                     )
-                    raise RuntimeError(
-                        f"[ema] missing required forager EMA for active/normal symbol {sym}: {detail}"
-                    )
-                mark_ema_unavailable(sym, reason)
+                )
                 log_ema_issue(
                     ("required_forager_missing", sym),
-                    logging.DEBUG,
-                    "[ema] missing required forager EMA %s volume_spans=%s log_range_spans=%s action=mark_nontradable_until_fresh | %s",
+                    (
+                        logging.DEBUG
+                        if required_ema_can_mark_nontradable(sym)
+                        else logging.WARNING
+                    ),
+                    "[ema] missing required forager EMA %s volume_spans=%s log_range_spans=%s action=scope_forager_selection_in_rust | %s",
                     Passivbot._log_symbol(sym),
                     ",".join(f"{span:.8g}" for span in missing_required_volume),
                     ",".join(f"{span:.8g}" for span in missing_required_forager_lr1m),
                     ema_candle_health_context(sym),
                     interval_ms=15 * 60 * 1000,
                 )
-            if sym in cache_only_symbols:
+            if sym in cache_only_symbols and not (
+                missing_required_volume or missing_required_forager_lr1m
+            ):
                 missing_volume = [span for span in m1_volume_spans if span not in vol]
                 missing_lr1m = [
                     span for span in m1_lr_spans if span not in forager_lr1m
@@ -18812,7 +18912,7 @@ class Passivbot:
             log_ema_issue(
                 ("required_ema_unavailable_summary",),
                 logging.WARNING,
-                "[ema] required EMA unavailable summary | unavailable=%d groups=%d action=mark_nontradable_until_fresh | %s",
+                "[ema] required EMA unavailable summary | unavailable=%d groups=%d action=scope_unavailable_inputs | %s",
                 len(all_symbols),
                 len(candidate_ema_unavailable_details),
                 "; ".join(parts[:4]),
@@ -18891,7 +18991,9 @@ class Passivbot:
         self._orchestrator_ema_unavailable_symbols = set(ema_unavailable_symbols)
         candidate_reason_names = {
             reason
-            for reason in ema_unavailable_reasons
+            for reason in (
+                set(ema_unavailable_reasons) | set(candidate_ema_unavailable_details)
+            )
             if reason
             in {
                 "cache_only_fetch_failed",
@@ -18929,9 +19031,9 @@ class Passivbot:
             )
         ranking_reason_symbols = {
             str(symbol)
-            for reason, reason_symbols in self._orchestrator_ema_unavailable_reasons.items()
+            for reason, items in candidate_ema_unavailable_details.items()
             if str(reason).startswith("missing_required_forager_")
-            for symbol in reason_symbols
+            for symbol, _error_type, _ema_types, _spans in items
         }
         for pside, unavailable_symbols in rank_feature_unavailable_by_side.items():
             for symbol in ranking_reason_symbols & set(unavailable_symbols):

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -17102,30 +17102,16 @@ class Passivbot:
                 or ema_type not in {"m1_volume", "forager_m1_log_range"}
             ):
                 return
-            primary_spans = set(primary_spans) & set(
-                forager_provisional_primary_spans.get((symbol, ema_type), set())
-            )
-            if not primary_spans:
-                return
-            getter = getattr(
-                self.cm, "get_ema_provisional_internal_gap_context", None
-            )
-            if not callable(getter):
-                return
             metric_key = "qv" if ema_type == "m1_volume" else "log_range"
             diagnostic_metric = (
                 "quote_volume" if ema_type == "m1_volume" else "log_range"
             )
-            contexts = []
-            for span in sorted(primary_spans):
-                context = getter(symbol, metric_key, span, timeframe="1m")
-                if context:
-                    contexts.append((float(span), dict(context)))
             key = (symbol, diagnostic_metric)
             previous_count = int(
                 self._orchestrator_forager_gap_fallback_counts.get(key, 0) or 0
             )
-            if not contexts:
+
+            def record_recovery() -> None:
                 if previous_count > 0:
                     self._orchestrator_forager_gap_fallback_counts[key] = 0
                     logging.info(
@@ -17135,6 +17121,25 @@ class Passivbot:
                         diagnostic_metric,
                         previous_count,
                     )
+
+            provisional_spans = set(primary_spans) & set(
+                forager_provisional_primary_spans.get((symbol, ema_type), set())
+            )
+            if not provisional_spans:
+                record_recovery()
+                return
+            getter = getattr(
+                self.cm, "get_ema_provisional_internal_gap_context", None
+            )
+            if not callable(getter):
+                return
+            contexts = []
+            for span in sorted(provisional_spans):
+                context = getter(symbol, metric_key, span, timeframe="1m")
+                if context:
+                    contexts.append((float(span), dict(context)))
+            if not contexts:
+                record_recovery()
                 return
             consecutive_uses = previous_count + 1
             self._orchestrator_forager_gap_fallback_counts[key] = consecutive_uses

--- a/src/passivbot_monitor.py
+++ b/src/passivbot_monitor.py
@@ -603,6 +603,9 @@ def _build_monitor_market_section(self) -> dict[str, dict]:
     rank_feature_unavailable_by_side = getattr(
         self, "_forager_rank_feature_unavailable_by_side", {}
     ) or {}
+    ranking_required_by_side = getattr(
+        self, "_forager_ranking_required_by_side", {}
+    ) or {}
     ema_bundle_completed = bool(
         getattr(self, "_orchestrator_ema_bundle_completed", False)
     )
@@ -715,11 +718,19 @@ def _build_monitor_market_section(self) -> dict[str, dict]:
             if forager_side and age_eligible_approved and min_cost_eligible:
                 forager_candidate_psides.append(pside)
         if forager_candidate_psides:
-            rank_feature_psides = sorted(
+            raw_rank_feature_psides = sorted(
                 pside
                 for pside in forager_candidate_psides
                 if symbol
                 in set(rank_feature_unavailable_by_side.get(pside, set()) or set())
+            )
+            rank_feature_psides = sorted(
+                pside
+                for pside in raw_rank_feature_psides
+                if bool(ranking_required_by_side.get(pside, False))
+            )
+            conditional_rank_feature_psides = sorted(
+                set(raw_rank_feature_psides) - set(rank_feature_psides)
             )
             rankability_reasons = []
             if not ema_bundle_completed or symbol not in ema_bundle_symbols:
@@ -740,6 +751,14 @@ def _build_monitor_market_section(self) -> dict[str, dict]:
                 "rankable": not rankability_reasons,
                 "rankability_reasons": sorted(set(rankability_reasons)),
                 "ranking_feature_unavailable_psides": rank_feature_psides,
+                "conditional_ranking_feature_unavailable_psides": (
+                    conditional_rank_feature_psides
+                ),
+                "ranking_required_psides": sorted(
+                    pside
+                    for pside in forager_candidate_psides
+                    if bool(ranking_required_by_side.get(pside, False))
+                ),
                 "ema_unavailable_reasons": matching_ema_reasons,
             }
         if symbol in trailing_unavailable_symbols:

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -4297,6 +4297,66 @@ async def test_live_ema_provisionally_fills_bounded_unknown_gap_and_recomputes(
     assert authoritative_ema != pytest.approx(provisional)
 
 
+@pytest.mark.asyncio
+async def test_refreshed_forager_metrics_bridge_bounded_internal_gap(
+    monkeypatch, tmp_path
+):
+    now = 11 * ONE_MIN_MS
+    monkeypatch.setattr("time.time", lambda: now / 1000.0)
+    cm = CandlestickManager(
+        exchange=None,
+        exchange_name="kucoinfutures",
+        cache_dir=str(tmp_path / "caches"),
+        provisional_internal_gap_tolerance_minutes=10,
+    )
+    cm._now_ms_callback = lambda: now
+    symbol = "SPARSE/USDT:USDT"
+    start = 8 * ONE_MIN_MS
+    missing = 9 * ONE_MIN_MS
+    end = 10 * ONE_MIN_MS
+    cm._cache[symbol] = np.array(
+        [
+            (start, 100.0, 101.0, 99.0, 100.0, 1.0),
+            (end, 120.0, 121.0, 119.0, 120.0, 1.0),
+        ],
+        dtype=CANDLE_DTYPE,
+    )
+    cm._add_known_gap(
+        symbol,
+        missing,
+        missing,
+        reason=GAP_REASON_FETCH_FAILED,
+    )
+    spans = {"qv": [3.0], "log_range": [3.0]}
+
+    strict = await cm.get_latest_ema_metric_spans(
+        symbol,
+        spans,
+        allow_remote_fetch=False,
+        allow_provisional_internal_gaps=False,
+    )
+    assert math.isnan(strict["qv"][3.0])
+    assert math.isnan(strict["log_range"][3.0])
+
+    refreshed = await cm.get_latest_ema_metric_spans(
+        symbol,
+        spans,
+        allow_remote_fetch=False,
+        allow_provisional_internal_gaps=True,
+    )
+    expected_qv = cm._ema(np.asarray([100.0, 0.0, 120.0]), 3.0)
+    expected_log_range = cm._ema(
+        np.log(np.asarray([101.0 / 99.0, 1.0, 121.0 / 119.0])),
+        3.0,
+    )
+    assert refreshed["qv"][3.0] == pytest.approx(expected_qv)
+    assert refreshed["log_range"][3.0] == pytest.approx(expected_log_range)
+    assert np.array_equal(
+        cm._cache[symbol]["ts"],
+        np.asarray([start, end], dtype=np.int64),
+    )
+
+
 def test_synthetic_timestamp_retention_uses_replay_clock(monkeypatch, tmp_path):
     wall_now = 10_000 * ONE_MIN_MS
     replay_now = 100 * ONE_MIN_MS

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -4351,6 +4351,17 @@ async def test_refreshed_forager_metrics_bridge_bounded_internal_gap(
     )
     assert refreshed["qv"][3.0] == pytest.approx(expected_qv)
     assert refreshed["log_range"][3.0] == pytest.approx(expected_log_range)
+    qv_context = cm.get_ema_provisional_internal_gap_context(
+        symbol, "qv", 3.0, timeframe="1m"
+    )
+    log_range_context = cm.get_ema_provisional_internal_gap_context(
+        symbol, "log_range", 3.0, timeframe="1m"
+    )
+    assert qv_context == log_range_context
+    assert qv_context["gap_count"] == 1
+    assert qv_context["gap_candles"] == 1
+    assert qv_context["max_gap_candles"] == 1
+    assert qv_context["oldest_gap_age_ms"] == 2 * ONE_MIN_MS
     assert np.array_equal(
         cm._cache[symbol]["ts"],
         np.asarray([start, end], dtype=np.int64),

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -1027,7 +1027,7 @@ async def test_orchestrator_ema_bundle_fetches_flat_default_normal_planning_symb
 
 
 @pytest.mark.asyncio
-async def test_orchestrator_ema_bundle_marks_missing_required_forager_ema_unavailable(
+async def test_orchestrator_ema_bundle_tracks_missing_required_forager_ema_by_side(
     monkeypatch,
 ):
     import passivbot as pb_mod
@@ -1143,7 +1143,11 @@ async def test_orchestrator_ema_bundle_marks_missing_required_forager_ema_unavai
 
     assert m1_close_emas[symbol]
     assert m1_volume_emas[symbol] == {}
-    assert bot._orchestrator_ema_unavailable_symbols == {symbol}
+    assert bot._orchestrator_ema_unavailable_symbols == set()
+    assert bot._forager_rank_feature_unavailable_by_side == {
+        "long": {symbol},
+        "short": set(),
+    }
 
 
 @pytest.mark.asyncio
@@ -1512,7 +1516,11 @@ async def test_orchestrator_ema_bundle_projection_context_summary_is_debug(
             == 60_000
         )
     assert bot._orchestrator_ema_projection_symbols == set(symbols)
-    assert bot._orchestrator_ema_unavailable_symbols == set(symbols)
+    assert bot._orchestrator_ema_unavailable_symbols == set()
+    assert bot._forager_rank_feature_unavailable_by_side == {
+        "long": set(symbols),
+        "short": set(),
+    }
     assert not any(
         "late open-tail EMA projection context" in record.message
         and record.levelno >= logging.INFO
@@ -2045,7 +2053,7 @@ async def test_orchestrator_ema_bundle_disables_remote_fetch_for_cache_only_seco
 
 
 @pytest.mark.asyncio
-async def test_orchestrator_ema_bundle_marks_incomplete_cache_only_symbol_unavailable(
+async def test_orchestrator_ema_bundle_scopes_incomplete_cache_only_ranking_by_side(
     monkeypatch,
 ):
     import passivbot as pb_mod
@@ -2152,9 +2160,10 @@ async def test_orchestrator_ema_bundle_marks_incomplete_cache_only_symbol_unavai
     assert isinstance(h1_log_range_emas["CACHE/USDT:USDT"], dict)
     assert "CACHE/USDT:USDT" not in volumes_long
     assert isinstance(log_ranges_long["CACHE/USDT:USDT"], float)
-    assert bot._orchestrator_ema_unavailable_symbols == {
-        "CACHE/USDT:USDT",
-        "FETCH/USDT:USDT",
+    assert bot._orchestrator_ema_unavailable_symbols == {"FETCH/USDT:USDT"}
+    assert bot._forager_rank_feature_unavailable_by_side == {
+        "long": {"CACHE/USDT:USDT", "FETCH/USDT:USDT"},
+        "short": set(),
     }
 
 

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -1805,8 +1805,8 @@ async def test_active_forager_open_tail_projects_strategy_required_log_range():
     assert m1_volume_emas[symbol][span0] == pytest.approx(250000.0)
     assert volumes_long[symbol] == pytest.approx(250000.0)
     assert _log_ranges_long[symbol] == pytest.approx(0.0015)
-    assert bot.qv_provisional_flags == [False]
-    assert bot.lr_provisional_flags == [("1m", False)]
+    assert bot.qv_provisional_flags == [True]
+    assert bot.lr_provisional_flags == [("1m", True)]
     assert bot._orchestrator_ema_projection_symbols == {symbol}
 
 
@@ -2475,9 +2475,14 @@ async def test_batched_ema_failure_retries_each_span_before_carry_forward(monkey
         _cm,
         _symbol,
         spans_by_metric,
-        **_kwargs,
+        **kwargs,
     ):
-        batch_requests.append(dict(spans_by_metric))
+        batch_requests.append(
+            (
+                dict(spans_by_metric),
+                kwargs.get("allow_provisional_internal_gaps"),
+            )
+        )
         raise RuntimeError("widest EMA window unavailable")
 
     original_close = bot.cm.get_latest_ema_close
@@ -2511,11 +2516,12 @@ async def test_batched_ema_failure_retries_each_span_before_carry_forward(monkey
     )
     assert m1_volume_emas[symbol][10.0] == pytest.approx(250000.0)
     assert m1_log_range_emas[symbol][10.0] == pytest.approx(0.0015)
-    assert {next(iter(request)) for request in batch_requests} >= {
+    assert {next(iter(request)) for request, _allow_provisional in batch_requests} >= {
         "close",
         "qv",
         "log_range",
     }
+    assert all(allow_provisional is True for _request, allow_provisional in batch_requests)
 
 
 @pytest.mark.asyncio

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -1601,7 +1601,117 @@ async def test_explicit_normal_missing_required_forager_features_are_scoped_to_r
     assert result[1][symbol] == {}
     assert bot._orchestrator_ema_unavailable_symbols == set()
     assert bot._orchestrator_allow_missing_strategy_inputs_symbols == {symbol}
-    assert bot._orchestrator_candidate_ema_unavailable_symbols == {symbol}
+    assert bot._orchestrator_candidate_ema_unavailable_symbols == set()
+    assert bot._forager_rank_feature_unavailable_by_side == {
+        "long": {symbol},
+        "short": {symbol},
+    }
+
+
+@pytest.mark.asyncio
+async def test_forager_internal_gap_retry_requires_actual_refresh_provenance():
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    symbol = "HYPE/USDT:USDT"
+    bot = _BundleReproBot(symbol, close_mode="value")
+    _enable_forager_required_ranking(bot)
+    bot.cm.get_last_refresh_ms = lambda _symbol: 100
+
+    async def quote_volume(
+        _symbol,
+        span,
+        max_age_ms=60_000,
+        allow_remote_fetch=True,
+        allow_provisional_internal_gaps=None,
+    ):
+        bot.qv_provisional_flags.append(allow_provisional_internal_gaps)
+        return 250000.0 if allow_provisional_internal_gaps else float("nan")
+
+    async def log_range(
+        _symbol,
+        span,
+        tf=None,
+        max_age_ms=60_000,
+        allow_remote_fetch=True,
+        allow_provisional_internal_gaps=None,
+    ):
+        bot.lr_provisional_flags.append((tf or "1m", allow_provisional_internal_gaps))
+        return 0.0015 if allow_provisional_internal_gaps else float("nan")
+
+    bot.cm.get_latest_ema_quote_volume = quote_volume
+    bot.cm.get_latest_ema_log_range = log_range
+
+    result = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+        bot, [symbol], bot.PB_modes
+    )
+
+    assert result[1][symbol] == {}
+    assert bot._orchestrator_forager_m1_log_range_emas[symbol] == {}
+    assert bot.qv_provisional_flags == [False]
+    assert [flag for _tf, flag in bot.lr_provisional_flags if flag is not None] == [
+        False
+    ]
+
+
+@pytest.mark.asyncio
+async def test_forager_internal_gap_retry_follows_successful_bundle_refresh():
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    symbol = "HYPE/USDT:USDT"
+    bot = _BundleReproBot(symbol, close_mode="value")
+    _enable_forager_required_ranking(bot)
+    refresh = {"value": 100}
+    bot.cm.get_last_refresh_ms = lambda _symbol: refresh["value"]
+
+    async def quote_volume(
+        _symbol,
+        span,
+        max_age_ms=60_000,
+        allow_remote_fetch=True,
+        allow_provisional_internal_gaps=None,
+    ):
+        bot.qv_provisional_flags.append(allow_provisional_internal_gaps)
+        if not allow_provisional_internal_gaps:
+            refresh["value"] += 1
+            return float("nan")
+        return 250000.0
+
+    async def log_range(
+        _symbol,
+        span,
+        tf=None,
+        max_age_ms=60_000,
+        allow_remote_fetch=True,
+        allow_provisional_internal_gaps=None,
+    ):
+        bot.lr_provisional_flags.append((tf or "1m", allow_provisional_internal_gaps))
+        if not allow_provisional_internal_gaps:
+            refresh["value"] += 1
+            return float("nan")
+        return 0.0015
+
+    bot.cm.get_latest_ema_quote_volume = quote_volume
+    bot.cm.get_latest_ema_log_range = log_range
+
+    result = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+        bot, [symbol], bot.PB_modes
+    )
+
+    assert result[1][symbol][10.0] == pytest.approx(250000.0)
+    assert bot._orchestrator_forager_m1_log_range_emas[symbol][10.0] == pytest.approx(
+        0.0015
+    )
+    assert bot.qv_provisional_flags == [False, True]
+    assert [flag for _tf, flag in bot.lr_provisional_flags if flag is not None] == [
+        False,
+        True,
+    ]
 
 
 @pytest.mark.asyncio
@@ -1621,6 +1731,36 @@ async def test_forager_provisional_internal_gap_logs_use_count_and_recovery(capl
         "oldest_gap_age_ms": 180_000,
     }
     current_context = {"value": context}
+    refresh = {"value": 100}
+    bot.cm.get_last_refresh_ms = lambda _symbol: refresh["value"]
+
+    async def quote_volume(
+        _symbol,
+        span,
+        max_age_ms=60_000,
+        allow_remote_fetch=True,
+        allow_provisional_internal_gaps=None,
+    ):
+        if not allow_provisional_internal_gaps:
+            refresh["value"] += 1
+            return float("nan")
+        return 250000.0
+
+    async def log_range(
+        _symbol,
+        span,
+        tf=None,
+        max_age_ms=60_000,
+        allow_remote_fetch=True,
+        allow_provisional_internal_gaps=None,
+    ):
+        if not allow_provisional_internal_gaps:
+            refresh["value"] += 1
+            return float("nan")
+        return 0.0015
+
+    bot.cm.get_latest_ema_quote_volume = quote_volume
+    bot.cm.get_latest_ema_log_range = log_range
     bot.cm.get_ema_provisional_internal_gap_context = (
         lambda _symbol, _metric, _span, **_kwargs: current_context["value"]
     )
@@ -1864,13 +2004,13 @@ async def test_active_forager_open_tail_projects_strategy_required_log_range():
     assert m1_volume_emas[symbol][span0] == pytest.approx(250000.0)
     assert volumes_long[symbol] == pytest.approx(250000.0)
     assert _log_ranges_long[symbol] == pytest.approx(0.0015)
-    assert bot.qv_provisional_flags == [True]
-    assert bot.lr_provisional_flags == [("1m", True)]
+    assert bot.qv_provisional_flags == [False]
+    assert bot.lr_provisional_flags == [("1m", False)]
     assert bot._orchestrator_ema_projection_symbols == {symbol}
 
 
 @pytest.mark.asyncio
-async def test_candidate_only_missing_required_forager_features_marks_unavailable(caplog):
+async def test_candidate_only_missing_required_forager_features_stays_conditional(caplog):
     try:
         import passivbot as pb_mod
         from live.event_bus import EventTypes
@@ -1889,8 +2029,9 @@ async def test_candidate_only_missing_required_forager_features_marks_unavailabl
         lr1m_mode="nan",
     )
     bot.PB_modes = {"long": {}, "short": {}}
-    bot.cm.get_last_refresh_ms = lambda _symbol: int(time.time() * 1000)
-    bot.cm.get_last_final_ts = lambda _symbol: int(time.time() * 1000)
+    now_ms = int(time.time() * 1000)
+    bot.cm.get_last_refresh_ms = lambda _symbol: now_ms
+    bot.cm.get_last_final_ts = lambda _symbol: now_ms
     bot._candle_staleness_ms = lambda _symbol, now_ms=None: 0
     _enable_forager_required_ranking(bot)
     events = []
@@ -1920,7 +2061,11 @@ async def test_candidate_only_missing_required_forager_features_marks_unavailabl
     assert symbol not in log_ranges_long
     assert bot._orchestrator_ema_unavailable_symbols == set()
     assert bot._orchestrator_allow_missing_strategy_inputs_symbols == {symbol}
-    assert bot._orchestrator_candidate_ema_unavailable_symbols == {symbol}
+    assert bot._orchestrator_candidate_ema_unavailable_symbols == set()
+    assert bot._forager_rank_feature_unavailable_by_side == {
+        "long": {symbol},
+        "short": {symbol},
+    }
     assert not any(
         "missing required forager EMA HYPE" in record.message
         and "action=mark_nontradable_until_fresh" in record.message
@@ -1933,9 +2078,9 @@ async def test_candidate_only_missing_required_forager_features_marks_unavailabl
         if event_type == EventTypes.EMA_UNAVAILABLE
     ]
     assert len(unavailable_events) == 1
+    assert unavailable_events[0]["level"] == "debug"
     event_data = unavailable_events[0]["data"]
-    assert event_data["candidate_unavailable"]["count"] == 1
-    assert event_data["candidate_unavailable"]["sample"] == [symbol]
+    assert event_data["candidate_unavailable"]["count"] == 0
     assert event_data["unavailable"]["count"] == 0
 
 
@@ -2577,7 +2722,12 @@ async def test_batched_ema_failure_retries_each_span_before_carry_forward(monkey
         "qv",
         "log_range",
     }
-    assert all(allow_provisional is True for _request, allow_provisional in batch_requests)
+    request_flags = [
+        (next(iter(request)), allow_provisional)
+        for request, allow_provisional in batch_requests
+    ]
+    assert ("close", True) in request_flags
+    assert ("qv", False) in request_flags
 
 
 @pytest.mark.asyncio

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -1732,6 +1732,7 @@ async def test_forager_provisional_internal_gap_logs_use_count_and_recovery(capl
     }
     current_context = {"value": context}
     refresh = {"value": 100}
+    authoritative = {"value": False}
     bot.cm.get_last_refresh_ms = lambda _symbol: refresh["value"]
 
     async def quote_volume(
@@ -1742,6 +1743,8 @@ async def test_forager_provisional_internal_gap_logs_use_count_and_recovery(capl
         allow_provisional_internal_gaps=None,
     ):
         if not allow_provisional_internal_gaps:
+            if authoritative["value"]:
+                return 250000.0
             refresh["value"] += 1
             return float("nan")
         return 250000.0
@@ -1755,6 +1758,8 @@ async def test_forager_provisional_internal_gap_logs_use_count_and_recovery(capl
         allow_provisional_internal_gaps=None,
     ):
         if not allow_provisional_internal_gaps:
+            if authoritative["value"]:
+                return 0.0015
             refresh["value"] += 1
             return float("nan")
         return 0.0015
@@ -1791,7 +1796,7 @@ async def test_forager_provisional_internal_gap_logs_use_count_and_recovery(capl
     )
     assert any("consecutive_uses=2" in record.message for record in fallback_logs)
 
-    current_context["value"] = None
+    authoritative["value"] = True
     caplog.clear()
     with caplog.at_level(logging.INFO):
         await pb_mod.Passivbot._load_orchestrator_ema_bundle(

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -954,12 +954,9 @@ async def test_disabled_opposite_side_does_not_block_flat_forager_degradation():
         {"long": {symbol: None}, "short": {symbol: None}},
     )
 
-    assert bot._orchestrator_ema_unavailable_symbols == {symbol}
-    assert bot._orchestrator_ema_unavailable_reasons == {
-        "missing_required_forager_volume+missing_required_forager_log_range": {
-            symbol
-        }
-    }
+    assert bot._orchestrator_ema_unavailable_symbols == set()
+    assert bot._orchestrator_ema_unavailable_reasons == {}
+    assert bot._orchestrator_allow_missing_strategy_inputs_symbols == {symbol}
     assert bot._orchestrator_ema_entry_cancellation_order_keys == {
         (symbol, "long", "exchange_id", "ondo-forager-entry")
     }
@@ -1066,9 +1063,7 @@ async def test_forager_ranking_ema_degradation_authorizes_resting_entry_cancel()
         bot, [symbol], mode_overrides
     )
 
-    assert bot._orchestrator_ema_unavailable_reasons == {
-        "missing_required_forager_volume": {symbol}
-    }
+    assert bot._orchestrator_ema_unavailable_reasons == {}
     assert bot._orchestrator_ema_entry_cancellation_order_keys == {
         (
             symbol,
@@ -1150,11 +1145,8 @@ async def test_forager_ranking_degradation_authorizes_only_affected_side():
         symbol: {"long", "short"}
     }
 
-    # Rust's symbol-level tradable=false result may move both sides to manual
-    # even though only the long ranking feature was missing. Preserve dynamic
-    # eligibility independently of cancellation scope: the remaining short
-    # entry must not turn the next identical gap into an account-fatal error,
-    # and it must not become cancellable.
+    # Preserve dynamic eligibility independently of cancellation scope: the
+    # remaining short entry must not become cancellable.
     bot.PB_modes = {
         "long": {symbol: "manual"},
         "short": {symbol: "manual"},
@@ -1169,9 +1161,7 @@ async def test_forager_ranking_degradation_authorizes_only_affected_side():
         [symbol],
         {"long": {symbol: None}, "short": {symbol: None}},
     )
-    assert bot._orchestrator_ema_unavailable_reasons == {
-        "missing_required_forager_volume": {symbol}
-    }
+    assert bot._orchestrator_ema_unavailable_reasons == {}
     assert bot._orchestrator_ema_entry_cancellation_order_keys == set()
     assert bot._orchestrator_dynamic_forager_eligibility_psides_by_symbol == {
         symbol: {"long", "short"}
@@ -1583,7 +1573,7 @@ def _enable_forager_required_ranking(bot):
 
 
 @pytest.mark.asyncio
-async def test_explicit_normal_missing_required_forager_features_fails_loudly():
+async def test_explicit_normal_missing_required_forager_features_are_scoped_to_rust():
     try:
         import passivbot as pb_mod
     except ImportError:
@@ -1603,13 +1593,82 @@ async def test_explicit_normal_missing_required_forager_features_fails_loudly():
     _enable_forager_required_ranking(bot)
     mode_overrides = {"long": {symbol: "normal"}, "short": {symbol: "manual"}}
 
-    with pytest.raises(
-        RuntimeError,
-        match=r"missing required forager EMA for active/normal symbol HYPE/USDT:USDT",
-    ):
+    result = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+        bot, [symbol], mode_overrides
+    )
+
+    assert result[0][symbol]
+    assert result[1][symbol] == {}
+    assert bot._orchestrator_ema_unavailable_symbols == set()
+    assert bot._orchestrator_allow_missing_strategy_inputs_symbols == {symbol}
+    assert bot._orchestrator_candidate_ema_unavailable_symbols == {symbol}
+
+
+@pytest.mark.asyncio
+async def test_forager_provisional_internal_gap_logs_use_count_and_recovery(caplog):
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    symbol = "HYPE/USDT:USDT"
+    bot = _BundleReproBot(symbol, close_mode="value")
+    _enable_forager_required_ranking(bot)
+    context = {
+        "gap_count": 1,
+        "gap_candles": 2,
+        "max_gap_candles": 2,
+        "oldest_gap_age_ms": 180_000,
+    }
+    current_context = {"value": context}
+    bot.cm.get_ema_provisional_internal_gap_context = (
+        lambda _symbol, _metric, _span, **_kwargs: current_context["value"]
+    )
+
+    with caplog.at_level(logging.DEBUG):
         await pb_mod.Passivbot._load_orchestrator_ema_bundle(
-            bot, [symbol], mode_overrides
+            bot, [symbol], bot.PB_modes
         )
+        await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+            bot, [symbol], bot.PB_modes
+        )
+
+    assert bot._orchestrator_forager_gap_fallback_counts == {
+        (symbol, "quote_volume"): 2,
+        (symbol, "log_range"): 2,
+    }
+    fallback_logs = [
+        record
+        for record in caplog.records
+        if "forager ranking provisional internal-gap fallback" in record.message
+        and "recovered" not in record.message
+    ]
+    assert fallback_logs
+    assert any(record.levelno == logging.WARNING for record in fallback_logs)
+    assert any(
+        "source=synthetic_zero_volume_continuity" in record.message
+        for record in fallback_logs
+    )
+    assert any("consecutive_uses=2" in record.message for record in fallback_logs)
+
+    current_context["value"] = None
+    caplog.clear()
+    with caplog.at_level(logging.INFO):
+        await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+            bot, [symbol], bot.PB_modes
+        )
+
+    assert bot._orchestrator_forager_gap_fallback_counts == {
+        (symbol, "quote_volume"): 0,
+        (symbol, "log_range"): 0,
+    }
+    recoveries = [
+        record.message
+        for record in caplog.records
+        if "provisional internal-gap fallback recovered" in record.message
+    ]
+    assert len(recoveries) == 2
+    assert all("after_consecutive_uses=2" in message for message in recoveries)
 
 
 @pytest.mark.asyncio
@@ -1859,7 +1918,8 @@ async def test_candidate_only_missing_required_forager_features_marks_unavailabl
     assert m1_log_range_emas[symbol] == {}
     assert symbol not in volumes_long
     assert symbol not in log_ranges_long
-    assert bot._orchestrator_ema_unavailable_symbols == {symbol}
+    assert bot._orchestrator_ema_unavailable_symbols == set()
+    assert bot._orchestrator_allow_missing_strategy_inputs_symbols == {symbol}
     assert bot._orchestrator_candidate_ema_unavailable_symbols == {symbol}
     assert not any(
         "missing required forager EMA HYPE" in record.message
@@ -1874,13 +1934,9 @@ async def test_candidate_only_missing_required_forager_features_marks_unavailabl
     ]
     assert len(unavailable_events) == 1
     event_data = unavailable_events[0]["data"]
-    assert event_data["candidate_unavailable"]["count"] == 0
-    assert event_data["unavailable"]["sample"] == [symbol]
-    assert any(
-        group["reason"] == "missing_required_forager_volume+missing_required_forager_log_range"
-        and group["symbols"]["sample"] == [symbol]
-        for group in event_data["unavailable_reasons"]
-    )
+    assert event_data["candidate_unavailable"]["count"] == 1
+    assert event_data["candidate_unavailable"]["sample"] == [symbol]
+    assert event_data["unavailable"]["count"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -3402,6 +3402,7 @@ def test_forager_respects_n_positions_selects_one_coin():
     assert {o["symbol_idx"] for o in out["orders"]} == {1}
     selection = out["diagnostics"]["forager_selections"][0]
     assert selection["pside"] == "long"
+    assert selection["ranking_required"] is True
     assert selection["selected_symbol_indices"] == [1]
     assert selection["top_scores"][0]["symbol_idx"] == 1
     assert selection["top_scores"][0]["selected"] is True
@@ -3443,6 +3444,7 @@ def test_single_eligible_coin_does_not_require_forager_feature_bundle():
         if item["pside"] == "long"
     )
     assert selection["selected_symbol_indices"] == [0]
+    assert selection["ranking_required"] is False
     assert selection["top_scores"] == []
 
 

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -3446,6 +3446,65 @@ def test_single_eligible_coin_does_not_require_forager_feature_bundle():
     assert selection["top_scores"] == []
 
 
+def test_forager_ranks_remaining_candidates_after_ineligible_position_consumes_slot():
+    import passivbot_rust as pbr
+
+    side_params = {
+        "n_positions": 2,
+        "total_wallet_exposure_limit": 1.0,
+        "filter_volume_drop_pct": 0.5,
+        "filter_volatility_drop_pct": 0.0,
+        "filter_volume_ema_span_1m": 10.0,
+        "filter_volatility_ema_span_1m": 10.0,
+    }
+    held_ineligible = make_symbol(
+        0,
+        bid=100.0,
+        ask=100.0,
+        tradable=False,
+        long_pos_size=1.0,
+        long_pos_price=100.0,
+        long_bp=side_params,
+    )
+    lower_ranked = make_symbol(
+        1,
+        bid=100.0,
+        ask=100.0,
+        long_bp=side_params,
+        emas=ema_bundle(m1_volume=[[10.0, 10.0]]),
+    )
+    higher_ranked = make_symbol(
+        2,
+        bid=100.0,
+        ask=100.0,
+        long_bp=side_params,
+        emas=ema_bundle(m1_volume=[[10.0, 20.0]]),
+    )
+    inp = make_input(
+        balance=1_000.0,
+        global_bp=bot_params_pair(long_overrides=side_params),
+        symbols=[held_ineligible, lower_ranked, higher_ranked],
+    )
+
+    out = compute(pbr, inp)
+
+    selection = next(
+        item
+        for item in out["diagnostics"]["forager_selections"]
+        if item["pside"] == "long"
+    )
+    assert selection["slots_to_fill"] == 1
+    assert selection["selected_symbol_indices"] == [2]
+    assert not any(
+        order["symbol_idx"] == 1 and order["order_type"].startswith("entry_")
+        for order in out["orders"]
+    )
+    assert any(
+        order["symbol_idx"] == 2 and order["order_type"].startswith("entry_")
+        for order in out["orders"]
+    )
+
+
 def test_live_authorized_missing_forager_feature_scopes_only_candidate_side():
     import passivbot_rust as pbr
 

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -3407,6 +3407,45 @@ def test_forager_respects_n_positions_selects_one_coin():
     assert selection["top_scores"][0]["selected"] is True
 
 
+def test_single_eligible_coin_does_not_require_forager_feature_bundle():
+    import passivbot_rust as pbr
+
+    side_params = {
+        "n_positions": 1,
+        "total_wallet_exposure_limit": 1.0,
+        "filter_volume_drop_pct": 0.5,
+        "filter_volume_ema_span_1m": 10.0,
+    }
+    symbol = make_symbol(
+        0,
+        bid=100.0,
+        ask=100.0,
+        long_bp=side_params,
+    )
+    symbol["forager_m1"] = {
+        "close": [],
+        "volume": [],
+        "log_range": [],
+    }
+    inp = make_input(
+        balance=1_000.0,
+        global_bp=bot_params_pair(long_overrides=side_params),
+        symbols=[symbol],
+    )
+
+    out = compute(pbr, inp)
+
+    assert out["orders"]
+    assert {order["symbol_idx"] for order in out["orders"]} == {0}
+    selection = next(
+        item
+        for item in out["diagnostics"]["forager_selections"]
+        if item["pside"] == "long"
+    )
+    assert selection["selected_symbol_indices"] == [0]
+    assert selection["top_scores"] == []
+
+
 def test_live_authorized_missing_forager_feature_scopes_only_candidate_side():
     import passivbot_rust as pbr
 

--- a/tests/test_order_churn_gate.py
+++ b/tests/test_order_churn_gate.py
@@ -322,6 +322,7 @@ def _raw_forager_selection(**overrides) -> dict:
     selection = {
         "pside": "long",
         "slots_to_fill": 1,
+        "ranking_required": True,
         "score_hysteresis_pct": 0.1,
         "selected_symbol_indices": [0],
         "incumbent_symbol_indices": [0],
@@ -3257,6 +3258,14 @@ def test_raw_rust_output_rejects_impossible_loss_gate_block(overrides, error):
         (
             {"forager_selections": [_raw_forager_selection(slots_to_fill="1")]},
             "invalid slots_to_fill",
+        ),
+        (
+            {"forager_selections": [_raw_forager_selection(ranking_required=None)]},
+            "invalid ranking_required",
+        ),
+        (
+            {"forager_selections": [_raw_forager_selection(ranking_required=1)]},
+            "invalid ranking_required",
         ),
         (
             {

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -6499,6 +6499,7 @@ async def test_build_monitor_snapshot_includes_market_forager_unstuck_and_recent
             self._forager_rank_feature_unavailable_by_side = {
                 "long": {"ETH/USDT:USDT"}
             }
+            self._forager_ranking_required_by_side = {"long": True, "short": False}
             self._orchestrator_trailing_unavailable_symbols = {"BTC/USDT:USDT"}
             self._orchestrator_trailing_unavailable_reasons = {
                 "BTC/USDT:USDT": ["position_fill_confirmation_pending"]
@@ -6815,6 +6816,8 @@ async def test_build_monitor_snapshot_includes_market_forager_unstuck_and_recent
         "rankable": True,
         "rankability_reasons": [],
         "ranking_feature_unavailable_psides": [],
+        "conditional_ranking_feature_unavailable_psides": [],
+        "ranking_required_psides": ["long"],
         "ema_unavailable_reasons": [],
     }
     assert snapshot["market"]["ETH/USDT:USDT"]["forager"] == {
@@ -6822,6 +6825,8 @@ async def test_build_monitor_snapshot_includes_market_forager_unstuck_and_recent
         "rankable": False,
         "rankability_reasons": ["ranking_features_unavailable"],
         "ranking_feature_unavailable_psides": ["long"],
+        "conditional_ranking_feature_unavailable_psides": [],
+        "ranking_required_psides": ["long"],
         "ema_unavailable_reasons": [],
     }
     assert snapshot["market"]["BTC/USDT:USDT"]["c_mult"] == pytest.approx(1.0)
@@ -6920,6 +6925,70 @@ def test_monitor_forager_candidates_use_live_age_eligibility():
 
     assert market[old_symbol]["forager"]["candidate_psides"] == ["long"]
     assert "forager" not in market[young_symbol]
+
+
+def test_monitor_forager_ranking_gap_blocks_only_when_rust_required_ranking():
+    import passivbot as pb_mod
+
+    symbol = "HYPE/USDT:USDT"
+
+    class FakeBot:
+        _build_monitor_market_section = pb_mod.Passivbot._build_monitor_market_section
+
+        def __init__(self):
+            self.active_symbols = []
+            self.positions = {}
+            self.open_orders = {}
+            self.trailing_prices = {}
+            self.effective_min_cost = {}
+            self.approved_coins = {"long": {symbol}, "short": set()}
+            self.ignored_coins = {"long": set(), "short": set()}
+            self.approved_coins_minus_ignored_coins = {
+                "long": {symbol},
+                "short": set(),
+            }
+            self.markets_dict = {symbol: {"active": True}}
+            self._orchestrator_ema_bundle_completed = True
+            self._orchestrator_ema_bundle_symbols = {symbol}
+            self._forager_rank_feature_unavailable_by_side = {
+                "long": {symbol},
+                "short": set(),
+            }
+            self._forager_ranking_required_by_side = {
+                "long": False,
+                "short": False,
+            }
+
+        def is_forager_mode(self, pside):
+            return pside == "long"
+
+        def is_approved(self, pside, candidate):
+            return pside == "long" and candidate == symbol
+
+        def effective_min_cost_is_low_enough(self, pside, candidate):
+            return pside == "long" and candidate == symbol
+
+        def has_position(self, pside=None, symbol=None):
+            return False
+
+    bot = FakeBot()
+    conditional = bot._build_monitor_market_section()[symbol]["forager"]
+
+    assert conditional["rankable"] is True
+    assert conditional["ranking_feature_unavailable_psides"] == []
+    assert conditional["conditional_ranking_feature_unavailable_psides"] == [
+        "long"
+    ]
+    assert conditional["ranking_required_psides"] == []
+
+    bot._forager_ranking_required_by_side["long"] = True
+    blocking = bot._build_monitor_market_section()[symbol]["forager"]
+
+    assert blocking["rankable"] is False
+    assert blocking["rankability_reasons"] == ["ranking_features_unavailable"]
+    assert blocking["ranking_feature_unavailable_psides"] == ["long"]
+    assert blocking["conditional_ranking_feature_unavailable_psides"] == []
+    assert blocking["ranking_required_psides"] == ["long"]
 
 
 def test_monitor_forager_candidates_use_live_min_cost_eligibility():

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -3350,6 +3350,7 @@ async def test_orchestrator_passes_trailing_unavailability_to_rust_per_side(monk
                     {
                         "pside": "long",
                         "slots_to_fill": 1,
+                        "ranking_required": True,
                         "score_hysteresis_pct": 0.1,
                         "selected_symbol_indices": ["0"],
                         "incumbent_symbol_indices": [],


### PR DESCRIPTION
## What changed

- Skip forager scoring and ranking-feature requirements when a side's complete eligible universe already fits its configured position slots.
- Let freshly fetched forager quote-volume and log-range EMAs bridge later-bounded internal candle gaps within `live.max_active_candle_tail_gap_minutes`.
- Keep cache-only stale candidates strict; they still cannot invent zero-volume or zero-range tails.
- Document the clarified readiness contract and add the user-facing changelog entry.

## Root cause

Python correctly reported that a one-approved-coin, one-slot side was not in forager mode, but Rust always constructed selection with `require_forager=true`. Once the sole KuCoin position became flat, Rust therefore required forager volume inputs that were irrelevant to selection.

Separately, live orchestration forced provisional internal gaps off for all forager quote-volume and log-range reads. A single later-bracketed `fetch_failed` minute therefore invalidated an otherwise usable 1,440-minute XMR window, even though the configured tolerance was ten minutes.

## Impact

Single-coin bots no longer fail because of unused ranking features. Freshly refreshed candidates tolerate short, bounded sparse-candle intervals under the existing configured limit, while long gaps, open tails, and cache-only unknown data remain unavailable.

## Validation

- `cargo fmt --all`
- `cargo test --no-default-features` — 257 passed
- `cargo check --tests`
- rebuilt and fingerprint-verified the real PyO3 extension
- `pytest tests/test_candlestick_manager.py tests/test_missing_ema_fix.py -q`
- `pytest tests/test_orchestrator_json_api.py -q`
- post-rebase high-signal Rust, candle-gap, EMA-bundle, and full JSON API regression rerun