### PR TITLE
Simplify bounded forager candle gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,9 @@ All notable user-facing changes will be documented in this file.
 - Skip forager ranking and its feature requirements when each side's exact remaining candidate
   universe fits its remaining position slots, including when ineligible held positions consume
   slots. Python now scopes missing ranking-only inputs to Rust selection instead of making the
-  whole symbol non-tradable. Freshly fetched forager candidates may also bridge bounded,
-  later-bracketed internal candle gaps under `live.max_active_candle_tail_gap_minutes`, with
-  per-symbol/metric consecutive-use and recovery diagnostics; cache-only stale candidates remain
-  strict.
+  whole symbol non-tradable. Current remote-enabled forager candidates may also bridge bounded,
+  later-bracketed internal candle gaps under `live.max_active_candle_tail_gap_minutes` without
+  depending on refresh timing inside one planning pass; cache-only stale candidates remain strict.
 - Standardize suite reduction configuration on `reducer` across `backtest`, optimizer scoring,
   limits, CLI parsing, examples, and serialized configs. The former `aggregate`, `stat`, and
   `scenario_stat` spellings remain accepted as input aliases (plus legacy limit `field`),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable user-facing changes will be documented in this file.
   slots. Python now scopes missing ranking-only inputs to Rust selection instead of making the
   whole symbol non-tradable. Current remote-enabled forager candidates may also bridge bounded,
   later-bracketed internal candle gaps under `live.max_active_candle_tail_gap_minutes` without
-  depending on refresh timing inside one planning pass; cache-only stale candidates remain strict.
+  depending on refresh timing inside one planning pass; compact transition diagnostics identify
+  ranking-input continuity use and authoritative recovery, while cache-only candidates remain strict.
 - Standardize suite reduction configuration on `reducer` across `backtest`, optimizer scoring,
   limits, CLI parsing, examples, and serialized configs. The former `aggregate`, `stat`, and
   `scenario_stat` spellings remain accepted as input aliases (plus legacy limit `field`),

--- a/docs/ai/error_contract.md
+++ b/docs/ai/error_contract.md
@@ -83,12 +83,13 @@ flat zero-volume rows for active strategy inputs while authoritative overlap rep
 Trailing-extrema reconstruction may use the same projection only for a still-open tail after dense
 post-fill coverage; it must not bridge a missing reset boundary or internal minute, and the
 projected rows must be discarded after that read so delayed authoritative highs and lows replace
-them immediately. Forager ranking quote-volume and log-range inputs may bridge a later-bounded
-internal gap only after the current planning bundle records a successful authoritative refresh for
-that symbol; remote fetch permission alone is not refresh provenance. The complete gap length must
-be within `live.max_active_candle_tail_gap_minutes`; cache-only candidates retain their narrower
-carry-forward contract. Each refreshed-symbol ranking metric records warning-visible gap count,
-age, source, and consecutive-use diagnostics, followed by an authoritative-recovery diagnostic.
+them immediately. Forager ranking quote-volume and log-range inputs for current, remote-enabled
+candidates may bridge a later-bounded internal gap when the complete gap length is within
+`live.max_active_candle_tail_gap_minutes`. This is an explicitly approximate ranking-continuity
+policy, not proof that the missing rows were fetched. The rows remain unresolved and retryable,
+are never persisted, and are replaced by delayed authoritative candles. Cache-only candidates
+remain strict across unresolved internal gaps. Existing known-gap and refresh diagnostics expose
+the underlying repair state; no parallel per-metric fallback state is required.
 
 Protective panic and reduce-only actions may proceed when their own account-critical and
 symbol-scoped requirements are fresh, even if unrelated strategy surfaces are unavailable.
@@ -97,9 +98,9 @@ symbol-scoped requirements are fresh, even if unrelated strategy surfaces are un
 
 Flat-symbol forager candidates may remain rankable within
 `live.max_forager_candle_staleness_minutes`. Close EMA readiness may use bounded flat-close
-projection. Quote-volume and log-range ranking inputs may use flat zero-volume continuity for
-later-bounded internal gaps within `live.max_active_candle_tail_gap_minutes` only after an
-authoritative refresh advances during the current planning bundle.
+projection. Quote-volume and log-range ranking inputs for current, remote-enabled candidates may
+use flat zero-volume continuity for later-bounded internal gaps within
+`live.max_active_candle_tail_gap_minutes`.
 Cache-only ranking inputs instead carry forward their latest known EMA with age/source metadata;
 they do not receive invented zero tails.
 When the forager setting is unset, its budget-derived acceptable age must not be shorter than

--- a/docs/ai/error_contract.md
+++ b/docs/ai/error_contract.md
@@ -89,7 +89,9 @@ candidates may bridge a later-bounded internal gap when the complete gap length 
 policy, not proof that the missing rows were fetched. The rows remain unresolved and retryable,
 are never persisted, and are replaced by delayed authoritative candles. Cache-only candidates
 remain strict across unresolved internal gaps. Existing known-gap and refresh diagnostics expose
-the underlying repair state; no parallel per-metric fallback state is required.
+the underlying repair state. A compact per-symbol/metric transition diagnostic additionally marks
+when ranking-input calculation consumes bounded continuity and later resumes from authoritative
+candles; it does not retain per-span contexts or consecutive-use counters.
 
 Protective panic and reduce-only actions may proceed when their own account-critical and
 symbol-scoped requirements are fresh, even if unrelated strategy surfaces are unavailable.

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -100,15 +100,12 @@
    do not permanently block strategy inputs. The timestamps remain unresolved and retryable;
    delayed authoritative rows replace the provisional values and invalidate affected EMA caches.
    This exception is selected explicitly by the consumer: completed-candle forager ranking metrics
-   may bridge bounded internal gaps only after the current planning bundle observes that the symbol's
-   authoritative refresh timestamp advanced. Merely allowing a remote fetch is insufficient;
-   cache-only candidate reads remain strict. Synthetic replacement tracking follows the
-   manager's live/replay clock so delayed authoritative rows invalidate provisional replay EMAs
-   deterministically. Runtime provenance is retained per symbol, metric, span, and EMA window so
-   live orchestration can report gap count, age, synthetic source, consecutive uses, and recovery.
-   The live orchestrator requests forager quote-volume and log-range with bounded internal-gap
-   continuity only for symbols actually refreshed during that planner bundle; cache-only stale
-   candidates cannot invent zero-volume or zero-range observations.
+   for current, remote-enabled candidates may bridge bounded internal gaps, while cache-only
+   candidate reads remain strict. This is approximate ranking continuity, not evidence that the
+   missing rows were fetched. Synthetic replacement tracking follows the manager's live/replay
+   clock so delayed authoritative rows invalidate provisional replay EMAs deterministically.
+   Existing known-gap and refresh diagnostics expose repair state without a second per-span
+   provenance state machine.
    Open-ended tails use the separate bounded projection policy below.
    Refresh budgets count
    symbol/timeframe fetches, health scans are bounded and rotated across cycles, interleave each
@@ -246,9 +243,9 @@
     Missing rows remain unavailable to ordinary candle consumers until an authoritative row
     arrives. Live strategy EMA reads may provisionally bridge a later-bracketed internal gap with
     non-persistent flat zero-volume rows only when the gap is no wider than
-    `live.max_active_candle_tail_gap_minutes`; forager ranking reads use the same bounded internal-gap
-    rule only after an authoritative refresh advances during the current planning bundle, while
-    cache-only forager ranking carry-forward remains unavailable across an unresolved internal gap.
+    `live.max_active_candle_tail_gap_minutes`; current remote-enabled forager ranking reads use the
+    same bounded internal-gap rule, while cache-only forager ranking carry-forward remains
+    unavailable across an unresolved internal gap.
     Complete rows in the supplied EMA window remain
     authoritative even if stale known-gap metadata still names their timestamps. Recording or
     extending a 1m gap invalidates cached 1m EMA and open-tail projection values. An overlap refresh

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -104,8 +104,9 @@
    candidate reads remain strict. This is approximate ranking continuity, not evidence that the
    missing rows were fetched. Synthetic replacement tracking follows the manager's live/replay
    clock so delayed authoritative rows invalidate provisional replay EMAs deterministically.
-   Existing known-gap and refresh diagnostics expose repair state without a second per-span
-   provenance state machine.
+   Existing known-gap and refresh diagnostics expose repair state. Live orchestration derives
+   ranking-input consumption from canonical gap state and emits activation/recovery transitions
+   per symbol and metric without a second per-span provenance state machine or use counter.
    Open-ended tails use the separate bounded projection policy below.
    Refresh budgets count
    symbol/timeframe fetches, health scans are bounded and rotated across cycles, interleave each

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -9439,6 +9439,58 @@ class CandlestickManager:
             tf=tf,
         )
 
+    def ema_spans_use_provisional_internal_gap(
+        self,
+        symbol: str,
+        spans: Iterable[float],
+        *,
+        timeframe: Optional[str] = None,
+        tf: Optional[str] = None,
+    ) -> bool:
+        """Whether current EMA windows use bounded unresolved-gap continuity.
+
+        This derives consumption from canonical gap and candle state on demand;
+        it does not retain per-span fallback provenance.
+        """
+        period_ms = _tf_to_ms(timeframe if timeframe is not None else tf)
+        tolerance_ms = int(
+            self.provisional_internal_gap_tolerance_minutes * ONE_MIN_MS
+        )
+        if period_ms != ONE_MIN_MS or tolerance_ms <= 0:
+            return False
+        normalized_spans = {
+            float(span)
+            for span in spans
+            if math.isfinite(float(span)) and float(span) > 0.0
+        }
+        if not normalized_spans:
+            return False
+        end_ts = (
+            (int(self._now_ms()) // int(period_ms)) * int(period_ms)
+            - int(period_ms)
+        )
+        start_ts = int(
+            end_ts
+            - period_ms
+            * (max(1, int(math.ceil(max(normalized_spans)))) - 1)
+        )
+        last_final_ts = int(self.get_last_final_ts(symbol) or 0)
+        cached = self._cache.get(symbol)
+        if isinstance(cached, np.ndarray) and cached.size > 0:
+            last_final_ts = max(
+                last_final_ts,
+                int(np.max(np.asarray(cached["ts"], dtype=np.int64))),
+            )
+        for gap_start, gap_end in self._unverified_uncovered_gap_ranges(
+            symbol,
+            start_ts,
+            end_ts,
+        ):
+            gap_width_ms = int(gap_end) - int(gap_start) + ONE_MIN_MS
+            if gap_width_ms <= tolerance_ms and int(gap_end) < last_final_ts:
+                return True
+        return False
+
     async def get_latest_ema_close(
         self,
         symbol: str,

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -971,11 +971,6 @@ class CandlestickManager:
         ] = {}
         # Cache for EMA computations: per symbol -> {(metric, span, tf): (value, end_ts, computed_at_ms)}
         self._ema_cache: Dict[str, Dict[Tuple[str, int, str], Tuple[float, int, int]]] = {}
-        # Non-persistent provenance for EMA values computed with later-bounded
-        # internal zero-volume continuity rows. Keys mirror the EMA cache.
-        self._ema_provisional_internal_gap_context: Dict[
-            str, Dict[Tuple[str, float, str], Dict[str, int]]
-        ] = {}
         # Compatibility attribute retained for older monitor/tool code.  The
         # candlestick manager no longer owns current in-progress prices.
         self._current_close_cache: Dict[str, Tuple[float, int]] = {}
@@ -2979,24 +2974,6 @@ class CandlestickManager:
         self, symbol: str, *, timeframe: Optional[str] = None
     ) -> None:
         """Invalidate cached EMA values for a symbol, optionally for one timeframe."""
-        if symbol in self._ema_provisional_internal_gap_context:
-            if timeframe is None:
-                self._ema_provisional_internal_gap_context.pop(symbol, None)
-            else:
-                tf_key = str(_tf_to_ms(timeframe))
-                retained_context = {
-                    key: value
-                    for key, value in self._ema_provisional_internal_gap_context[
-                        symbol
-                    ].items()
-                    if len(key) < 3 or str(key[2]) != tf_key
-                }
-                if retained_context:
-                    self._ema_provisional_internal_gap_context[symbol] = (
-                        retained_context
-                    )
-                else:
-                    self._ema_provisional_internal_gap_context.pop(symbol, None)
         if symbol not in self._ema_cache:
             return
         if timeframe is None:
@@ -9462,83 +9439,6 @@ class CandlestickManager:
             tf=tf,
         )
 
-    def _record_ema_provisional_internal_gap_context(
-        self,
-        symbol: str,
-        metric_key: str,
-        span: float,
-        period_ms: int,
-        start_ts: int,
-        end_ts: int,
-    ) -> None:
-        key = (str(metric_key), float(span), str(period_ms))
-        contexts = self._ema_provisional_internal_gap_context.setdefault(symbol, {})
-        if period_ms != ONE_MIN_MS:
-            contexts.pop(key, None)
-            return
-        tolerance_ms = int(
-            self.provisional_internal_gap_tolerance_minutes * ONE_MIN_MS
-        )
-        if tolerance_ms <= 0:
-            contexts.pop(key, None)
-            return
-        last_final_ts = int(self.get_last_final_ts(symbol) or 0)
-        cached = self._cache.get(symbol)
-        if isinstance(cached, np.ndarray) and cached.size > 0:
-            last_final_ts = max(
-                last_final_ts, int(np.max(np.asarray(cached["ts"], dtype=np.int64)))
-            )
-        used_ranges: List[Tuple[int, int]] = []
-        for full_gap_start, full_gap_end in self._unverified_uncovered_gap_ranges(
-            symbol, int(start_ts), int(end_ts)
-        ):
-            gap_width_ms = int(full_gap_end) - int(full_gap_start) + ONE_MIN_MS
-            overlap_start = max(int(start_ts), int(full_gap_start))
-            overlap_end = min(int(end_ts), int(full_gap_end))
-            if (
-                overlap_start <= overlap_end
-                and gap_width_ms <= tolerance_ms
-                and int(full_gap_end) < last_final_ts
-            ):
-                used_ranges.append((overlap_start, overlap_end))
-        if not used_ranges:
-            contexts.pop(key, None)
-            if not contexts:
-                self._ema_provisional_internal_gap_context.pop(symbol, None)
-            return
-        gap_candles = sum(
-            (gap_end - gap_start) // ONE_MIN_MS + 1
-            for gap_start, gap_end in used_ranges
-        )
-        max_gap_candles = max(
-            (gap_end - gap_start) // ONE_MIN_MS + 1
-            for gap_start, gap_end in used_ranges
-        )
-        oldest_gap_start = min(gap_start for gap_start, _gap_end in used_ranges)
-        contexts[key] = {
-            "gap_count": int(len(used_ranges)),
-            "gap_candles": int(gap_candles),
-            "max_gap_candles": int(max_gap_candles),
-            "oldest_gap_age_ms": max(0, int(self._now_ms()) - oldest_gap_start),
-            "window_start_ts": int(start_ts),
-            "window_end_ts": int(end_ts),
-        }
-
-    def get_ema_provisional_internal_gap_context(
-        self,
-        symbol: str,
-        metric_key: str,
-        span: float,
-        *,
-        timeframe: Optional[str] = None,
-        tf: Optional[str] = None,
-    ) -> Optional[Dict[str, int]]:
-        period_ms = _tf_to_ms(timeframe if timeframe is not None else tf)
-        context = self._ema_provisional_internal_gap_context.get(symbol, {}).get(
-            (str(metric_key), float(span), str(period_ms))
-        )
-        return None if context is None else dict(context)
-
     async def get_latest_ema_close(
         self,
         symbol: str,
@@ -9587,15 +9487,6 @@ class CandlestickManager:
             return float("nan")
         closes = np.asarray(arr["c"], dtype=np.float64)
         res = float(self._ema(closes, span))
-        if allow_provisional_internal_gaps:
-            self._record_ema_provisional_internal_gap_context(
-                symbol,
-                "close",
-                span,
-                period_ms,
-                start_ts,
-                end_ts,
-            )
         # Store in cache
         cache[key] = (res, int(end_ts), int(now))
         return res
@@ -9851,20 +9742,6 @@ class CandlestickManager:
             return float("nan")
         series = series_fn(arr)
         res = float(self._ema(series, span))
-        if allow_provisional_internal_gaps:
-            if math.isfinite(res):
-                self._record_ema_provisional_internal_gap_context(
-                    symbol,
-                    metric_key,
-                    span,
-                    period_ms,
-                    start_ts,
-                    end_ts,
-                )
-            else:
-                self._ema_provisional_internal_gap_context.get(symbol, {}).pop(
-                    (str(metric_key), float(span), str(period_ms)), None
-                )
         cache[key] = (res, int(end_ts), int(now))
         return res
 
@@ -10120,20 +9997,7 @@ class CandlestickManager:
                 value = float(self._ema(self._ema_metric_series(metric_key, tail), span))
                 out[metric_key][span] = value
                 if not math.isfinite(value):
-                    if allow_provisional_internal_gaps:
-                        self._ema_provisional_internal_gap_context.get(symbol, {}).pop(
-                            (str(metric_key), float(span), str(period_ms)), None
-                        )
                     continue
-                if allow_provisional_internal_gaps:
-                    self._record_ema_provisional_internal_gap_context(
-                        symbol,
-                        metric_key,
-                        span,
-                        period_ms,
-                        metric_start_ts,
-                        end_ts,
-                    )
                 cache[(cache_metric_key, float(span), tf_key)] = (
                     value,
                     int(end_ts),

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -17023,6 +17023,8 @@ class Passivbot:
             self._orchestrator_close_ema_fallback_counts = {}
         if not hasattr(self, "_orchestrator_ema_issue_last_log_ms"):
             self._orchestrator_ema_issue_last_log_ms = {}
+        if not hasattr(self, "_orchestrator_forager_provisional_gap_inputs_active"):
+            self._orchestrator_forager_provisional_gap_inputs_active = set()
         m1_max_age_by_symbol = {s: 60_000 for s in symbols}
         h1_max_age_by_symbol = {s: 600_000 for s in symbols}
         cache_only_symbols: set[str] = set()
@@ -17034,6 +17036,9 @@ class Passivbot:
         optional_ema_drops: dict[tuple[str, str, str], list[tuple[str, float]]] = {}
         close_ema_recoveries: dict[str, list[tuple[float, int]]] = {}
         close_ema_fallbacks: dict[str, list[tuple[float, int, int, str, str]]] = {}
+        forager_gap_inputs_evaluated: set[tuple[str, str]] = set()
+        forager_gap_inputs_consumed: set[tuple[str, str]] = set()
+
         def log_ema_issue(
             key: tuple,
             level: int,
@@ -17060,6 +17065,35 @@ class Passivbot:
             optional_ema_drops.setdefault((ema_type, reason_code, error_type), []).append(
                 (symbol, span)
             )
+
+        def record_forager_gap_consumption(
+            symbol: str,
+            ema_type: str,
+            primary_spans: set[float],
+        ) -> None:
+            if (
+                not primary_spans
+                or symbol in cache_only_symbols
+                or not bool(is_forager_mode())
+                or ema_type not in {"m1_volume", "forager_m1_log_range"}
+            ):
+                return
+            metric = "quote_volume" if ema_type == "m1_volume" else "log_range"
+            key = (symbol, metric)
+            getter = getattr(
+                self.cm,
+                "ema_spans_use_provisional_internal_gap",
+                None,
+            )
+            if not callable(getter):
+                return
+            forager_gap_inputs_evaluated.add(key)
+            if getter(
+                symbol,
+                primary_spans,
+                timeframe="1m",
+            ):
+                forager_gap_inputs_consumed.add(key)
 
         def ema_error_type(exc: Exception) -> str:
             name = type(exc).__name__
@@ -17620,6 +17654,7 @@ class Passivbot:
 
         async def fetch_map(symbol: str, spans: list[float], fn, ema_type: str):
             out: dict[float, float] = {}
+            primary_spans: set[float] = set()
             if not spans:
                 return out
             metric_key = {
@@ -17683,6 +17718,7 @@ class Passivbot:
                     )
                 if math.isfinite(val):
                     out[span] = val
+                    primary_spans.add(span)
                 else:
                     if metric_key is not None:
                         fallback = cached_fallbacks.get(span)
@@ -17699,6 +17735,7 @@ class Passivbot:
                     record_optional_ema_drop(
                         ema_type, symbol, span, "non_finite_value", "NonFiniteValue"
                     )
+            record_forager_gap_consumption(symbol, ema_type, primary_spans)
             return out
 
         async def fetch_required_map(
@@ -18847,6 +18884,35 @@ class Passivbot:
                     type(err).__name__,
                 )
             raise errors[0][1]
+        previous_gap_inputs = {
+            (str(symbol), str(metric))
+            for symbol, metric in set(
+                self._orchestrator_forager_provisional_gap_inputs_active
+            )
+            if symbol in symbols and bool(is_forager_mode())
+        }
+        current_gap_inputs = set(forager_gap_inputs_consumed)
+        activated_gap_inputs = current_gap_inputs - previous_gap_inputs
+        recovered_gap_inputs = (
+            previous_gap_inputs & forager_gap_inputs_evaluated
+        ) - current_gap_inputs
+        for symbol, metric in sorted(activated_gap_inputs):
+            logging.warning(
+                "[ema] forager ranking input using bounded internal-gap continuity "
+                "%s metric=%s source=synthetic_zero_volume_continuity",
+                Passivbot._log_symbol(symbol),
+                metric,
+            )
+        for symbol, metric in sorted(recovered_gap_inputs):
+            logging.info(
+                "[ema] forager ranking input resumed authoritative candles "
+                "%s metric=%s",
+                Passivbot._log_symbol(symbol),
+                metric,
+            )
+        self._orchestrator_forager_provisional_gap_inputs_active = (
+            previous_gap_inputs - forager_gap_inputs_evaluated
+        ) | current_gap_inputs
         if ema_unavailable_reasons:
             parts = []
             all_unavailable: set[str] = set()

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -17023,8 +17023,6 @@ class Passivbot:
             self._orchestrator_close_ema_fallback_counts = {}
         if not hasattr(self, "_orchestrator_ema_issue_last_log_ms"):
             self._orchestrator_ema_issue_last_log_ms = {}
-        if not hasattr(self, "_orchestrator_forager_gap_fallback_counts"):
-            self._orchestrator_forager_gap_fallback_counts = {}
         m1_max_age_by_symbol = {s: 60_000 for s in symbols}
         h1_max_age_by_symbol = {s: 600_000 for s in symbols}
         cache_only_symbols: set[str] = set()
@@ -17036,33 +17034,6 @@ class Passivbot:
         optional_ema_drops: dict[tuple[str, str, str], list[tuple[str, float]]] = {}
         close_ema_recoveries: dict[str, list[tuple[float, int]]] = {}
         close_ema_fallbacks: dict[str, list[tuple[float, int, int, str, str]]] = {}
-        refresh_baseline_by_symbol: dict[str, int] = {}
-        forager_provisional_primary_spans: dict[
-            tuple[str, str], set[float]
-        ] = {}
-        refresh_getter = getattr(self.cm, "get_last_refresh_ms", None)
-
-        def last_refresh_ms(symbol: str) -> int:
-            if not callable(refresh_getter):
-                return 0
-            try:
-                return int(refresh_getter(symbol) or 0)
-            except Exception as exc:
-                logging.debug(
-                    "[forager] failed to read candle refresh provenance | "
-                    "symbol=%s error_type=%s",
-                    symbol,
-                    type(exc).__name__,
-                )
-                return 0
-
-        for symbol in symbols:
-            refresh_baseline_by_symbol[symbol] = last_refresh_ms(symbol)
-
-        def refreshed_during_bundle(symbol: str) -> bool:
-            current = last_refresh_ms(symbol)
-            return current > int(refresh_baseline_by_symbol.get(symbol, 0))
-
         def log_ema_issue(
             key: tuple,
             level: int,
@@ -17088,89 +17059,6 @@ class Passivbot:
         ) -> None:
             optional_ema_drops.setdefault((ema_type, reason_code, error_type), []).append(
                 (symbol, span)
-            )
-
-        def record_forager_gap_fallback_diagnostics(
-            symbol: str,
-            ema_type: str,
-            primary_spans: set[float],
-        ) -> None:
-            if (
-                not primary_spans
-                or symbol in cache_only_symbols
-                or not bool(is_forager_mode())
-                or ema_type not in {"m1_volume", "forager_m1_log_range"}
-            ):
-                return
-            metric_key = "qv" if ema_type == "m1_volume" else "log_range"
-            diagnostic_metric = (
-                "quote_volume" if ema_type == "m1_volume" else "log_range"
-            )
-            key = (symbol, diagnostic_metric)
-            previous_count = int(
-                self._orchestrator_forager_gap_fallback_counts.get(key, 0) or 0
-            )
-
-            def record_recovery() -> None:
-                if previous_count > 0:
-                    self._orchestrator_forager_gap_fallback_counts[key] = 0
-                    logging.info(
-                        "[ema] forager ranking provisional internal-gap fallback recovered "
-                        "%s metric=%s after_consecutive_uses=%d source=authoritative_candles",
-                        Passivbot._log_symbol(symbol),
-                        diagnostic_metric,
-                        previous_count,
-                    )
-
-            provisional_spans = set(primary_spans) & set(
-                forager_provisional_primary_spans.get((symbol, ema_type), set())
-            )
-            if not provisional_spans:
-                record_recovery()
-                return
-            getter = getattr(
-                self.cm, "get_ema_provisional_internal_gap_context", None
-            )
-            if not callable(getter):
-                return
-            contexts = []
-            for span in sorted(provisional_spans):
-                context = getter(symbol, metric_key, span, timeframe="1m")
-                if context:
-                    contexts.append((float(span), dict(context)))
-            if not contexts:
-                record_recovery()
-                return
-            consecutive_uses = previous_count + 1
-            self._orchestrator_forager_gap_fallback_counts[key] = consecutive_uses
-            gap_count = max(int(ctx.get("gap_count", 0) or 0) for _span, ctx in contexts)
-            gap_candles = max(
-                int(ctx.get("gap_candles", 0) or 0) for _span, ctx in contexts
-            )
-            max_gap_candles = max(
-                int(ctx.get("max_gap_candles", 0) or 0)
-                for _span, ctx in contexts
-            )
-            oldest_gap_age_ms = max(
-                int(ctx.get("oldest_gap_age_ms", 0) or 0)
-                for _span, ctx in contexts
-            )
-            log_ema_issue(
-                ("forager_provisional_internal_gap", symbol, diagnostic_metric),
-                logging.WARNING,
-                "[ema] forager ranking provisional internal-gap fallback %s "
-                "metric=%s spans=%s reason=later_bounded_internal_gap "
-                "source=synthetic_zero_volume_continuity gap_count=%d "
-                "gap_candles=%d max_gap_candles=%d age_ms=%d consecutive_uses=%d",
-                Passivbot._log_symbol(symbol),
-                diagnostic_metric,
-                ",".join(f"{span:.8g}" for span, _ctx in contexts),
-                gap_count,
-                gap_candles,
-                max_gap_candles,
-                oldest_gap_age_ms,
-                consecutive_uses,
-                interval_ms=15 * 60 * 1000,
             )
 
         def ema_error_type(exc: Exception) -> str:
@@ -17732,7 +17620,6 @@ class Passivbot:
 
         async def fetch_map(symbol: str, spans: list[float], fn, ema_type: str):
             out: dict[float, float] = {}
-            primary_spans: set[float] = set()
             if not spans:
                 return out
             metric_key = {
@@ -17796,7 +17683,6 @@ class Passivbot:
                     )
                 if math.isfinite(val):
                     out[span] = val
-                    primary_spans.add(span)
                 else:
                     if metric_key is not None:
                         fallback = cached_fallbacks.get(span)
@@ -17813,9 +17699,6 @@ class Passivbot:
                     record_optional_ema_drop(
                         ema_type, symbol, span, "non_finite_value", "NonFiniteValue"
                     )
-            record_forager_gap_fallback_diagnostics(
-                symbol, ema_type, primary_spans
-            )
             return out
 
         async def fetch_required_map(
@@ -18180,40 +18063,17 @@ class Passivbot:
             )
 
         async def ema_qv(symbol: str, span: float) -> float:
-            async def read(allow_provisional: bool) -> float:
-                return float(
-                    await self.cm.get_latest_ema_quote_volume(
-                        symbol,
-                        span=span,
-                        max_age_ms=m1_max_age_by_symbol.get(symbol, 60_000),
-                        allow_remote_fetch=symbol not in cache_only_symbols,
-                        allow_provisional_internal_gaps=allow_provisional,
-                    )
+            return float(
+                await self.cm.get_latest_ema_quote_volume(
+                    symbol,
+                    span=span,
+                    max_age_ms=m1_max_age_by_symbol.get(symbol, 60_000),
+                    allow_remote_fetch=symbol not in cache_only_symbols,
+                    allow_provisional_internal_gaps=(
+                        symbol not in cache_only_symbols
+                    ),
                 )
-
-            try:
-                value = await read(False)
-            except Exception:
-                if symbol in cache_only_symbols or not refreshed_during_bundle(symbol):
-                    raise
-                value = await read(True)
-                if math.isfinite(value):
-                    forager_provisional_primary_spans.setdefault(
-                        (symbol, "m1_volume"), set()
-                    ).add(float(span))
-                return value
-            if (
-                math.isfinite(value)
-                or symbol in cache_only_symbols
-                or not refreshed_during_bundle(symbol)
-            ):
-                return value
-            value = await read(True)
-            if math.isfinite(value):
-                forager_provisional_primary_spans.setdefault(
-                    (symbol, "m1_volume"), set()
-                ).add(float(span))
-            return value
+            )
 
         async def ema_lr_1m(symbol: str, span: float) -> float:
             return float(
@@ -18226,40 +18086,17 @@ class Passivbot:
             )
 
         async def ema_forager_lr_1m(symbol: str, span: float) -> float:
-            async def read(allow_provisional: bool) -> float:
-                return float(
-                    await self.cm.get_latest_ema_log_range(
-                        symbol,
-                        span=span,
-                        max_age_ms=m1_max_age_by_symbol.get(symbol, 60_000),
-                        allow_remote_fetch=symbol not in cache_only_symbols,
-                        allow_provisional_internal_gaps=allow_provisional,
-                    )
+            return float(
+                await self.cm.get_latest_ema_log_range(
+                    symbol,
+                    span=span,
+                    max_age_ms=m1_max_age_by_symbol.get(symbol, 60_000),
+                    allow_remote_fetch=symbol not in cache_only_symbols,
+                    allow_provisional_internal_gaps=(
+                        symbol not in cache_only_symbols
+                    ),
                 )
-
-            try:
-                value = await read(False)
-            except Exception:
-                if symbol in cache_only_symbols or not refreshed_during_bundle(symbol):
-                    raise
-                value = await read(True)
-                if math.isfinite(value):
-                    forager_provisional_primary_spans.setdefault(
-                        (symbol, "forager_m1_log_range"), set()
-                    ).add(float(span))
-                return value
-            if (
-                math.isfinite(value)
-                or symbol in cache_only_symbols
-                or not refreshed_during_bundle(symbol)
-            ):
-                return value
-            value = await read(True)
-            if math.isfinite(value):
-                forager_provisional_primary_spans.setdefault(
-                    (symbol, "forager_m1_log_range"), set()
-                ).add(float(span))
-            return value
+            )
 
         async def ema_lr_1h(symbol: str, span: float) -> float:
             return float(
@@ -18294,10 +18131,6 @@ class Passivbot:
             if metric_key is None:
                 return None
             timeframe = "1h" if ema_type == "h1_log_range" else "1m"
-            ranking_ema_type = ema_type in {
-                "m1_volume",
-                "forager_m1_log_range",
-            }
             call_kwargs = dict(
                 max_age_ms=(
                     h1_max_age_by_symbol.get(symbol, 600_000)
@@ -18312,42 +18145,12 @@ class Passivbot:
                 {metric_key: [float(span) for span in spans]},
                 **call_kwargs,
                 allow_provisional_internal_gaps=(
-                    symbol not in cache_only_symbols and not ranking_ema_type
+                    symbol not in cache_only_symbols
                 ),
             )
-            metric_values = dict(values.get(metric_key, {}))
-            missing_spans = {
-                float(span)
-                for span in spans
-                if float(span) not in metric_values
-                or not math.isfinite(
-                    float(metric_values.get(float(span), float("nan")))
-                )
-            }
-            if (
-                ranking_ema_type
-                and missing_spans
-                and symbol not in cache_only_symbols
-                and refreshed_during_bundle(symbol)
-            ):
-                retry_values = await method(
-                    symbol,
-                    {metric_key: [float(span) for span in spans]},
-                    **call_kwargs,
-                    allow_provisional_internal_gaps=True,
-                )
-                retry_metric_values = retry_values.get(metric_key, {})
-                for span in missing_spans:
-                    retry_value = retry_metric_values.get(span)
-                    if retry_value is None or not math.isfinite(float(retry_value)):
-                        continue
-                    metric_values[span] = retry_value
-                    forager_provisional_primary_spans.setdefault(
-                        (symbol, ema_type), set()
-                    ).add(span)
             return {
                 float(span): float(value)
-                for span, value in metric_values.items()
+                for span, value in values.get(metric_key, {}).items()
             }
 
         async def load_projected_open_tail_bundle(

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -4298,7 +4298,7 @@ async def test_live_ema_provisionally_fills_bounded_unknown_gap_and_recomputes(
 
 
 @pytest.mark.asyncio
-async def test_refreshed_forager_metrics_bridge_bounded_internal_gap(
+async def test_forager_metrics_bridge_bounded_internal_gap_without_persistence(
     monkeypatch, tmp_path
 ):
     now = 11 * ONE_MIN_MS
@@ -4351,17 +4351,6 @@ async def test_refreshed_forager_metrics_bridge_bounded_internal_gap(
     )
     assert refreshed["qv"][3.0] == pytest.approx(expected_qv)
     assert refreshed["log_range"][3.0] == pytest.approx(expected_log_range)
-    qv_context = cm.get_ema_provisional_internal_gap_context(
-        symbol, "qv", 3.0, timeframe="1m"
-    )
-    log_range_context = cm.get_ema_provisional_internal_gap_context(
-        symbol, "log_range", 3.0, timeframe="1m"
-    )
-    assert qv_context == log_range_context
-    assert qv_context["gap_count"] == 1
-    assert qv_context["gap_candles"] == 1
-    assert qv_context["max_gap_candles"] == 1
-    assert qv_context["oldest_gap_age_ms"] == 2 * ONE_MIN_MS
     assert np.array_equal(
         cm._cache[symbol]["ts"],
         np.asarray([start, end], dtype=np.int64),

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -4351,9 +4351,26 @@ async def test_forager_metrics_bridge_bounded_internal_gap_without_persistence(
     )
     assert refreshed["qv"][3.0] == pytest.approx(expected_qv)
     assert refreshed["log_range"][3.0] == pytest.approx(expected_log_range)
+    assert cm.ema_spans_use_provisional_internal_gap(
+        symbol, [3.0], timeframe="1m"
+    )
     assert np.array_equal(
         cm._cache[symbol]["ts"],
         np.asarray([start, end], dtype=np.int64),
+    )
+
+    cm._persist_batch(
+        symbol,
+        np.array(
+            [(missing, 110.0, 110.0, 110.0, 110.0, 2.0)],
+            dtype=CANDLE_DTYPE,
+        ),
+        timeframe="1m",
+        merge_cache=True,
+        last_refresh_ms=now,
+    )
+    assert not cm.ema_spans_use_provisional_internal_gap(
+        symbol, [3.0], timeframe="1m"
     )
 
 

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -1609,7 +1609,7 @@ async def test_explicit_normal_missing_required_forager_features_are_scoped_to_r
 
 
 @pytest.mark.asyncio
-async def test_forager_internal_gap_retry_requires_actual_refresh_provenance():
+async def test_current_forager_ranking_uses_bounded_internal_gap_policy_directly():
     try:
         import passivbot as pb_mod
     except ImportError:
@@ -1648,172 +1648,14 @@ async def test_forager_internal_gap_retry_requires_actual_refresh_provenance():
         bot, [symbol], bot.PB_modes
     )
 
-    assert result[1][symbol] == {}
-    assert bot._orchestrator_forager_m1_log_range_emas[symbol] == {}
-    assert bot.qv_provisional_flags == [False]
-    assert [flag for _tf, flag in bot.lr_provisional_flags if flag is not None] == [
-        False
-    ]
-
-
-@pytest.mark.asyncio
-async def test_forager_internal_gap_retry_follows_successful_bundle_refresh():
-    try:
-        import passivbot as pb_mod
-    except ImportError:
-        pytest.skip("passivbot module not importable in test environment")
-
-    symbol = "HYPE/USDT:USDT"
-    bot = _BundleReproBot(symbol, close_mode="value")
-    _enable_forager_required_ranking(bot)
-    refresh = {"value": 100}
-    bot.cm.get_last_refresh_ms = lambda _symbol: refresh["value"]
-
-    async def quote_volume(
-        _symbol,
-        span,
-        max_age_ms=60_000,
-        allow_remote_fetch=True,
-        allow_provisional_internal_gaps=None,
-    ):
-        bot.qv_provisional_flags.append(allow_provisional_internal_gaps)
-        if not allow_provisional_internal_gaps:
-            refresh["value"] += 1
-            return float("nan")
-        return 250000.0
-
-    async def log_range(
-        _symbol,
-        span,
-        tf=None,
-        max_age_ms=60_000,
-        allow_remote_fetch=True,
-        allow_provisional_internal_gaps=None,
-    ):
-        bot.lr_provisional_flags.append((tf or "1m", allow_provisional_internal_gaps))
-        if not allow_provisional_internal_gaps:
-            refresh["value"] += 1
-            return float("nan")
-        return 0.0015
-
-    bot.cm.get_latest_ema_quote_volume = quote_volume
-    bot.cm.get_latest_ema_log_range = log_range
-
-    result = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
-        bot, [symbol], bot.PB_modes
-    )
-
     assert result[1][symbol][10.0] == pytest.approx(250000.0)
     assert bot._orchestrator_forager_m1_log_range_emas[symbol][10.0] == pytest.approx(
         0.0015
     )
-    assert bot.qv_provisional_flags == [False, True]
+    assert bot.qv_provisional_flags == [True]
     assert [flag for _tf, flag in bot.lr_provisional_flags if flag is not None] == [
-        False,
-        True,
+        True
     ]
-
-
-@pytest.mark.asyncio
-async def test_forager_provisional_internal_gap_logs_use_count_and_recovery(caplog):
-    try:
-        import passivbot as pb_mod
-    except ImportError:
-        pytest.skip("passivbot module not importable in test environment")
-
-    symbol = "HYPE/USDT:USDT"
-    bot = _BundleReproBot(symbol, close_mode="value")
-    _enable_forager_required_ranking(bot)
-    context = {
-        "gap_count": 1,
-        "gap_candles": 2,
-        "max_gap_candles": 2,
-        "oldest_gap_age_ms": 180_000,
-    }
-    current_context = {"value": context}
-    refresh = {"value": 100}
-    authoritative = {"value": False}
-    bot.cm.get_last_refresh_ms = lambda _symbol: refresh["value"]
-
-    async def quote_volume(
-        _symbol,
-        span,
-        max_age_ms=60_000,
-        allow_remote_fetch=True,
-        allow_provisional_internal_gaps=None,
-    ):
-        if not allow_provisional_internal_gaps:
-            if authoritative["value"]:
-                return 250000.0
-            refresh["value"] += 1
-            return float("nan")
-        return 250000.0
-
-    async def log_range(
-        _symbol,
-        span,
-        tf=None,
-        max_age_ms=60_000,
-        allow_remote_fetch=True,
-        allow_provisional_internal_gaps=None,
-    ):
-        if not allow_provisional_internal_gaps:
-            if authoritative["value"]:
-                return 0.0015
-            refresh["value"] += 1
-            return float("nan")
-        return 0.0015
-
-    bot.cm.get_latest_ema_quote_volume = quote_volume
-    bot.cm.get_latest_ema_log_range = log_range
-    bot.cm.get_ema_provisional_internal_gap_context = (
-        lambda _symbol, _metric, _span, **_kwargs: current_context["value"]
-    )
-
-    with caplog.at_level(logging.DEBUG):
-        await pb_mod.Passivbot._load_orchestrator_ema_bundle(
-            bot, [symbol], bot.PB_modes
-        )
-        await pb_mod.Passivbot._load_orchestrator_ema_bundle(
-            bot, [symbol], bot.PB_modes
-        )
-
-    assert bot._orchestrator_forager_gap_fallback_counts == {
-        (symbol, "quote_volume"): 2,
-        (symbol, "log_range"): 2,
-    }
-    fallback_logs = [
-        record
-        for record in caplog.records
-        if "forager ranking provisional internal-gap fallback" in record.message
-        and "recovered" not in record.message
-    ]
-    assert fallback_logs
-    assert any(record.levelno == logging.WARNING for record in fallback_logs)
-    assert any(
-        "source=synthetic_zero_volume_continuity" in record.message
-        for record in fallback_logs
-    )
-    assert any("consecutive_uses=2" in record.message for record in fallback_logs)
-
-    authoritative["value"] = True
-    caplog.clear()
-    with caplog.at_level(logging.INFO):
-        await pb_mod.Passivbot._load_orchestrator_ema_bundle(
-            bot, [symbol], bot.PB_modes
-        )
-
-    assert bot._orchestrator_forager_gap_fallback_counts == {
-        (symbol, "quote_volume"): 0,
-        (symbol, "log_range"): 0,
-    }
-    recoveries = [
-        record.message
-        for record in caplog.records
-        if "provisional internal-gap fallback recovered" in record.message
-    ]
-    assert len(recoveries) == 2
-    assert all("after_consecutive_uses=2" in message for message in recoveries)
 
 
 @pytest.mark.asyncio
@@ -2009,8 +1851,8 @@ async def test_active_forager_open_tail_projects_strategy_required_log_range():
     assert m1_volume_emas[symbol][span0] == pytest.approx(250000.0)
     assert volumes_long[symbol] == pytest.approx(250000.0)
     assert _log_ranges_long[symbol] == pytest.approx(0.0015)
-    assert bot.qv_provisional_flags == [False]
-    assert bot.lr_provisional_flags == [("1m", False)]
+    assert bot.qv_provisional_flags == [True]
+    assert bot.lr_provisional_flags == [("1m", True)]
     assert bot._orchestrator_ema_projection_symbols == {symbol}
 
 
@@ -2732,7 +2574,8 @@ async def test_batched_ema_failure_retries_each_span_before_carry_forward(monkey
         for request, allow_provisional in batch_requests
     ]
     assert ("close", True) in request_flags
-    assert ("qv", False) in request_flags
+    assert ("qv", True) in request_flags
+    assert ("log_range", True) in request_flags
 
 
 @pytest.mark.asyncio

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -1659,6 +1659,63 @@ async def test_current_forager_ranking_uses_bounded_internal_gap_policy_directly
 
 
 @pytest.mark.asyncio
+async def test_forager_gap_consumption_logs_only_activation_and_recovery(caplog):
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    symbol = "HYPE/USDT:USDT"
+    bot = _BundleReproBot(symbol, close_mode="value")
+    _enable_forager_required_ranking(bot)
+    usage = {"value": True}
+    bot.cm.ema_spans_use_provisional_internal_gap = (
+        lambda _symbol, _spans, **_kwargs: usage["value"]
+    )
+
+    with caplog.at_level(logging.INFO):
+        await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+            bot, [symbol], bot.PB_modes
+        )
+        await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+            bot, [symbol], bot.PB_modes
+        )
+
+    activation_logs = [
+        record.message
+        for record in caplog.records
+        if "forager ranking input using bounded internal-gap continuity"
+        in record.message
+    ]
+    assert len(activation_logs) == 2
+    assert all(
+        "source=synthetic_zero_volume_continuity" in msg
+        for msg in activation_logs
+    )
+    assert bot._orchestrator_forager_provisional_gap_inputs_active == {
+        (symbol, "quote_volume"),
+        (symbol, "log_range"),
+    }
+
+    usage["value"] = False
+    caplog.clear()
+    with caplog.at_level(logging.INFO):
+        await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+            bot, [symbol], bot.PB_modes
+        )
+
+    recovery_logs = [
+        record.message
+        for record in caplog.records
+        if "forager ranking input resumed authoritative candles"
+        in record.message
+    ]
+    assert len(recovery_logs) == 2
+    assert bot._orchestrator_forager_provisional_gap_inputs_active == set()
+    assert not hasattr(bot, "_orchestrator_forager_gap_fallback_counts")
+
+
+@pytest.mark.asyncio
 async def test_active_forager_required_features_use_bounded_cached_carry_forward():
     try:
         import passivbot as pb_mod


### PR DESCRIPTION
## Summary

- let current, remote-enabled forager ranking reads use the existing later-bounded internal-gap policy directly
- keep cache-only candidates strict across unresolved internal gaps
- remove planning-pass refresh timestamp comparison, duplicate strict/retry reads, and the parallel per-symbol/metric/span diagnostic state machine
- preserve bounded gap width, non-persistence, retryability, and authoritative candle replacement invalidation

The previous refresh-timing check did not prove that the relevant gap was fetched: any successful symbol refresh could advance the timestamp. It also made identical candle state rankable or unavailable depending on whether a refresh happened inside that planning pass. The simplified contract treats bounded continuity as an explicitly approximate ranking policy and leaves repair visibility with the candlestick manager's existing known-gap and refresh diagnostics.

Net change: 52 insertions, 556 deletions.

## Validation

- rebuilt and fingerprint-verified the Python Rust extension from this branch
- `python -m py_compile` for the changed implementation and tests
- full `test_candlestick_manager.py`, `test_missing_ema_fix.py`, `test_live_candle_budget.py`, `test_orchestrator_json_api.py`, and `test_passivbot_monitor.py` suites
- `pytest -q tests/test_run_fake_live.py -m fake_live` (27 passed)
- deterministic offline `run_fake_live.py` HSL red/restart scenario completed successfully
- AI documentation checks and generated live-event registry check
- `pytest -q tests/test_ai_docs.py tests/test_live_event_registry_docs.py`
- `git diff --check`

No VPS access, authenticated exchange calls, or live bot operations were used.
