### PR TITLE
Fix directional approved coins in backtests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Keep side-specific `approved_coins` authoritative in backtests and optimization so a coin
+  approved only for long cannot open short entries, and a coin approved only for short cannot
+  open long entries. Per-coin zero wallet-exposure overrides now retain the same entry-disable
+  behavior after Rust derives runtime exposure budgets.
 - Skip forager ranking and its feature requirements when each side's exact remaining candidate
   universe fits its remaining position slots, including when ineligible held positions consume
   slots. Python now scopes missing ranking-only inputs to Rust selection instead of making the

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -1284,13 +1284,15 @@ impl<'a> Backtest<'a> {
         writer.write_record(&record);
     }
 
-    fn forced_normal_mode(&self, idx: usize, pside: usize) -> Option<orchestrator::TradingMode> {
+    fn configured_mode(&self, idx: usize, pside: usize) -> Option<orchestrator::TradingMode> {
         let side = match pside {
             LONG => &self.bot_params[idx].long,
             SHORT => &self.bot_params[idx].short,
             _ => return None,
         };
-        if side.is_forced_active {
+        if !side.entry_eligible {
+            Some(orchestrator::TradingMode::GracefulStop)
+        } else if side.is_forced_active {
             Some(orchestrator::TradingMode::Normal)
         } else {
             None
@@ -1377,9 +1379,9 @@ impl<'a> Backtest<'a> {
                 let pos_short = self.positions.short[idx];
 
                 let mut mode_long: Option<orchestrator::TradingMode> =
-                    self.forced_normal_mode(idx, LONG);
+                    self.configured_mode(idx, LONG);
                 let mut mode_short: Option<orchestrator::TradingMode> =
-                    self.forced_normal_mode(idx, SHORT);
+                    self.configured_mode(idx, SHORT);
 
                 if let Some(delist_timestamp) = self.last_valid_timestamps[idx] {
                     if k >= delist_timestamp {
@@ -1672,10 +1674,9 @@ impl<'a> Backtest<'a> {
             sym.short.runtime_budget = Some(self.runtime_budget[idx].short.clone());
 
             let valid_now = self.coin_is_valid_at(idx, k);
-            let mut mode_long: Option<orchestrator::TradingMode> =
-                self.forced_normal_mode(idx, LONG);
+            let mut mode_long: Option<orchestrator::TradingMode> = self.configured_mode(idx, LONG);
             let mut mode_short: Option<orchestrator::TradingMode> =
-                self.forced_normal_mode(idx, SHORT);
+                self.configured_mode(idx, SHORT);
 
             if let Some(delist_timestamp) = self.last_valid_timestamps[idx] {
                 if k >= delist_timestamp {
@@ -2159,11 +2160,11 @@ impl<'a> Backtest<'a> {
             trading_enabled: TradingEnabled {
                 long: bot_params
                     .iter()
-                    .any(|bp| bp.long.wallet_exposure_limit != 0.0)
+                    .any(|bp| bp.long.entry_eligible && bp.long.wallet_exposure_limit != 0.0)
                     && bot_params_master.long.n_positions > 0,
                 short: bot_params
                     .iter()
-                    .any(|bp| bp.short.wallet_exposure_limit != 0.0)
+                    .any(|bp| bp.short.entry_eligible && bp.short.wallet_exposure_limit != 0.0)
                     && bot_params_master.short.n_positions > 0,
             },
             trailing_enabled,
@@ -2425,12 +2426,18 @@ impl<'a> Backtest<'a> {
         let eligible_long: Vec<usize> = eligible
             .iter()
             .copied()
-            .filter(|&idx| self.bot_params_original[idx].long.wallet_exposure_limit != 0.0)
+            .filter(|&idx| {
+                self.bot_params_original[idx].long.entry_eligible
+                    && self.bot_params_original[idx].long.wallet_exposure_limit != 0.0
+            })
             .collect();
         let eligible_short: Vec<usize> = eligible
             .iter()
             .copied()
-            .filter(|&idx| self.bot_params_original[idx].short.wallet_exposure_limit != 0.0)
+            .filter(|&idx| {
+                self.bot_params_original[idx].short.entry_eligible
+                    && self.bot_params_original[idx].short.wallet_exposure_limit != 0.0
+            })
             .collect();
 
         let tradable_long_now = eligible_long.len();
@@ -10730,6 +10737,7 @@ mod tests {
         bp_pair.short.ema_span_1 = 20.0;
 
         let mut short_only = bp_pair.clone();
+        short_only.long.entry_eligible = false;
         short_only.long.n_positions = 0;
         short_only.long.total_wallet_exposure_limit = 0.0;
         short_only.long.wallet_exposure_limit = 0.0;
@@ -10792,6 +10800,12 @@ mod tests {
             bt.runtime_budget[3].long.effective_wallet_exposure_limit,
             0.0
         );
+        let input = bt.build_orchestrator_input_iter(0, None, None, 0..4);
+        assert_eq!(
+            input.symbols[3].long.mode,
+            Some(orchestrator::TradingMode::GracefulStop)
+        );
+        assert_eq!(input.symbols[3].short.mode, None);
     }
 
     #[test]

--- a/passivbot-rust/src/python.rs
+++ b/passivbot-rust/src/python.rs
@@ -2496,6 +2496,7 @@ fn bot_params_from_dict(dict: &PyDict) -> PyResult<BotParams> {
             .transpose()?
             .unwrap_or_default(),
         is_forced_active: extract_optional_bool(dict, "is_forced_active", false)?,
+        entry_eligible: extract_optional_bool(dict, "entry_eligible", true)?,
         ema_span_0: extract_optional_f64(dict, "ema_span_0")?,
         ema_span_1: extract_optional_f64(dict, "ema_span_1")?,
         hsl_enabled,

--- a/passivbot-rust/src/types.rs
+++ b/passivbot-rust/src/types.rs
@@ -570,6 +570,13 @@ pub struct BotParams {
     pub forager_score_weights: ForagerScoreWeights,
     #[serde(default)]
     pub is_forced_active: bool,
+    /// Whether this symbol+position-side may open new positions.
+    ///
+    /// Backtests set this from side-specific approved-coins membership.  Live
+    /// callers retain their existing mode-based eligibility contract through
+    /// the default value.
+    #[serde(default = "default_true")]
+    pub entry_eligible: bool,
     #[serde(default)]
     pub ema_span_0: f64,
     #[serde(default)]
@@ -649,6 +656,7 @@ impl Default for BotParams {
             forager_volume_drop_pct: 0.0,
             forager_score_weights: ForagerScoreWeights::default(),
             is_forced_active: false,
+            entry_eligible: true,
             ema_span_0: 0.0,
             ema_span_1: 0.0,
             hsl_enabled: default_hsl_enabled(),

--- a/src/backtest.py
+++ b/src/backtest.py
@@ -2444,6 +2444,9 @@ def prep_backtest_args(
                 coin_specific_bot_params[pside]["wallet_exposure_limit"] = 0.0
             elif "wallet_exposure_limit" not in coin_override_bot.get(pside, {}):
                 coin_specific_bot_params[pside]["wallet_exposure_limit"] = -1.0
+            coin_specific_bot_params[pside]["entry_eligible"] = (
+                coin_specific_bot_params[pside]["wallet_exposure_limit"] != 0.0
+            )
         bot_params_list.append(coin_specific_bot_params)
         strategy_params_list.append(coin_specific_strategy_params)
     maker_fee_override = get_optional_config_value(

--- a/tests/test_backtest_directional_eligibility.py
+++ b/tests/test_backtest_directional_eligibility.py
@@ -1,0 +1,171 @@
+from collections import Counter
+
+import numpy as np
+import pytest
+
+from backtest import run_backtest
+from config_utils import load_config
+
+
+@pytest.fixture(scope="module", autouse=True)
+def require_real_passivbot_rust_module():
+    import passivbot_rust as pbr
+
+    if getattr(pbr, "__is_stub__", False):
+        pytest.fail("directional eligibility requires the real passivbot_rust extension")
+
+
+def _ema_anchor_config(hedge_mode: bool) -> dict:
+    config = load_config("configs/examples/ema_anchor.json", verbose=False)
+    config["live"].update(
+        {
+            "approved_coins": {"long": ["LONGCOIN"], "short": ["SHORTCOIN"]},
+            "ignored_coins": {"long": [], "short": []},
+            "hedge_mode": hedge_mode,
+            "warmup_ratio": 1.0,
+            "max_warmup_minutes": 10,
+        }
+    )
+    config["backtest"].update(
+        {
+            "exchanges": ["binance"],
+            "coins": {"binance": ["LONGCOIN", "SHORTCOIN"]},
+            "start_date": "2024-01-01",
+            "end_date": "2024-01-02",
+            "starting_balance": 1_000.0,
+            "filter_by_min_effective_cost": False,
+            "dynamic_wel_by_tradability": True,
+            "candle_interval_minutes": 1,
+        }
+    )
+    for pside in ("long", "short"):
+        config["bot"][pside]["risk"].update(
+            {"n_positions": 1, "total_wallet_exposure_limit": 1.5}
+        )
+        config["bot"][pside]["forager"].update(
+            {
+                "volume_ema_span_1m": 2,
+                "volatility_ema_span_1m": 2,
+                "volume_drop_pct": 0.0,
+            }
+        )
+        config["bot"][pside]["strategy"]["ema_anchor"].update(
+            {
+                "ema_span_0": 2.0,
+                "ema_span_1": 3.0,
+                "base_qty_pct": 0.2,
+                "offset": 0.001,
+                "offset_psize_weight": 0.0,
+                "entry_double_down_factor": 0.0,
+                "offset_volatility_ema_span_1m": 2.0,
+                "offset_volatility_ema_span_1h": 2.0,
+                "offset_volatility_1m_weight": 0.0,
+                "offset_volatility_1h_weight": 0.0,
+            }
+        )
+    # Without side eligibility, these rankings intentionally prefer the coin
+    # approved only for the opposite side and reproduce the regression.
+    config["bot"]["long"]["forager"]["score_weights"] = {
+        "ema_readiness": 0.0,
+        "volatility": 1.0,
+        "volume": 0.0,
+    }
+    config["bot"]["short"]["forager"]["score_weights"] = {
+        "ema_readiness": 0.0,
+        "volatility": 0.0,
+        "volume": 1.0,
+    }
+    return config
+
+
+def _synthetic_inputs():
+    n_minutes = 60
+    start_ts = 1_704_067_200_000
+    timestamps = np.arange(
+        start_ts,
+        start_ts + n_minutes * 60_000,
+        60_000,
+        dtype=np.int64,
+    )
+    hlcvs = np.empty((n_minutes, 2, 4), dtype=np.float64)
+    for index in range(n_minutes):
+        hlcvs[index, 0] = [101.0, 99.0, 100.0, 10_000.0]
+        hlcvs[index, 1] = [220.0, 180.0, 200.0, 100.0]
+    market_settings = {
+        coin: {
+            "qty_step": 0.001,
+            "price_step": 0.01,
+            "min_qty": 0.001,
+            "min_cost": 1.0,
+            "c_mult": 1.0,
+            "maker": 0.0,
+            "taker": 0.0,
+            "exchange": "binance",
+            "first_valid_index": 0,
+            "last_valid_index": n_minutes - 1,
+            "warmup_minutes": 3,
+        }
+        for coin in ("LONGCOIN", "SHORTCOIN")
+    }
+    market_settings["__meta__"] = {
+        "requested_start_ts": start_ts,
+        "requested_start_date": "2024-01-01",
+        "warmup_minutes_requested": 3,
+    }
+    return hlcvs, market_settings, np.full(n_minutes, 50_000.0), timestamps
+
+
+@pytest.mark.parametrize("hedge_mode", [True, False])
+def test_ema_anchor_entries_obey_side_specific_approved_coins(hedge_mode):
+    config = _ema_anchor_config(hedge_mode)
+    hlcvs, market_settings, btc_prices, timestamps = _synthetic_inputs()
+
+    fills, _, _, payload = run_backtest(
+        hlcvs,
+        market_settings,
+        config,
+        "binance",
+        btc_prices,
+        timestamps,
+        return_payload=True,
+    )
+
+    entry_counts = Counter(
+        (str(row[2]), str(row[13]))
+        for row in fills
+        if str(row[13]).startswith("entry_")
+    )
+    assert set(entry_counts) == {
+        ("LONGCOIN", "entry_ema_anchor_long"),
+        ("SHORTCOIN", "entry_ema_anchor_short"),
+    }
+    params_by_coin = dict(zip(payload.backtest_params["coins"], payload.bot_params_list))
+    assert params_by_coin["LONGCOIN"]["short"]["entry_eligible"] is False
+    assert params_by_coin["SHORTCOIN"]["long"]["entry_eligible"] is False
+
+
+def test_zero_wel_coin_override_disables_approved_side_entries():
+    config = _ema_anchor_config(hedge_mode=True)
+    config["coin_overrides"] = {
+        "SHORTCOIN": {"bot": {"short": {"wallet_exposure_limit": 0.0}}}
+    }
+    hlcvs, market_settings, btc_prices, timestamps = _synthetic_inputs()
+
+    fills, _, _, payload = run_backtest(
+        hlcvs,
+        market_settings,
+        config,
+        "binance",
+        btc_prices,
+        timestamps,
+        return_payload=True,
+    )
+
+    entry_pairs = {
+        (str(row[2]), str(row[13]))
+        for row in fills
+        if str(row[13]).startswith("entry_")
+    }
+    assert entry_pairs == {("LONGCOIN", "entry_ema_anchor_long")}
+    params_by_coin = dict(zip(payload.backtest_params["coins"], payload.bot_params_list))
+    assert params_by_coin["SHORTCOIN"]["short"]["entry_eligible"] is False

--- a/tests/test_build_backtest_payload_purity.py
+++ b/tests/test_build_backtest_payload_purity.py
@@ -119,6 +119,8 @@ def test_build_backtest_payload_keeps_per_side_approved_coin_universe():
 
     assert payload.bot_params_list[coin4_idx]["long"]["wallet_exposure_limit"] == 0.0
     assert payload.bot_params_list[coin4_idx]["short"]["wallet_exposure_limit"] != 0.0
+    assert payload.bot_params_list[coin4_idx]["long"]["entry_eligible"] is False
+    assert payload.bot_params_list[coin4_idx]["short"]["entry_eligible"] is True
 
 
 def test_market_settings_overrides_match_exact_and_alias_keys(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- carry explicit per-symbol, per-position-side entry eligibility from the Python backtest/optimizer payload into Rust
- make ineligible sides use graceful-stop mode so existing positions may still close while new entries remain blocked
- exclude ineligible and zero-budget sides from runtime slot and exposure allocation
- add real-extension EMA-anchor regressions for hedge and one-way mode, plus explicit zero-WEL overrides
- document the corrected behavior in the changelog

## Root cause

The Python payload represented an unapproved side with a zero wallet-exposure limit. Rust later normalized zero limits from the total exposure budget and position count, unintentionally re-enabling that side. Eligibility is now an explicit boolean and is no longer inferred from the mutable runtime exposure budget.

## Validation

- `cd passivbot-rust && cargo test --no-default-features` (257 passed)
- `cd passivbot-rust && cargo check --tests`
- rebuilt and source-fingerprint-verified the real PyO3 extension
- `PYTHONPATH=src python -m pytest -q tests/test_backtest_directional_eligibility.py tests/test_build_backtest_payload_purity.py tests/test_backtest_universe.py tests/test_backtest_maker_fee_override.py` (75 passed)
