### PR TITLE
feat: add directional EMA MPS optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ All notable user-facing changes will be documented in this file.
 ## Unreleased
 
 - Add an experimental, purely additive Apple Silicon MPS optimizer backend for single-coin,
-  long-only EMA-anchor searches. Large NSGA-II populations run through a Rust-owned Metal screening
-  program and feed feasible, diverse candidates into the unchanged exact Rust backtester; only
-  exact results reach the Pareto store, and independent broad-probe rank checks halt on proxy
-  drift. Unsupported strategies, sides, suites, multi-coin, HSL, auto-unstuck, collateral,
+  EMA-anchor searches in long-only, short-only, and long+short modes. Large NSGA-II populations
+  run through a Rust-owned Metal screening program and feed feasible, diverse candidates into the
+  unchanged exact Rust backtester; only exact results reach the Pareto store, and independent
+  broad-probe rank checks halt on proxy drift. Dual-side screening preserves separate EMA/position
+  state, a shared balance, Rust fill ordering, and hedge/one-way initial-side semantics. Unsupported
+  strategies, suites, multi-coin, HSL, auto-unstuck, collateral,
   minimum-effective-cost filtering, market-order execution, incomplete candle tails, non-inert
   fixed runtime overrides, and unmodeled risk gates fail closed. Proxy/exact optimizer-limit
   feasibility disagreement also halts immediately. Existing CPU bot, backtest, and optimizer paths

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -101,8 +101,9 @@ The first supported slice is intentionally narrow:
 
 - Apple Silicon with `torch.backends.mps.is_available()`
 - one exchange and one coin, using one-minute candles
-- `strategy_kind: ema_anchor`, long-only
-- `bot.long.risk.n_positions` pinned to `1`
+- `strategy_kind: ema_anchor`, with long-only, short-only, or long+short enabled
+- each enabled side's `n_positions` pinned to `1` and wallet-exposure limit kept positive
+- hedge mode and one-way mode; one-way flat-side arbitration matches the Rust EMA-band rule
 - suite mode disabled
 - HSL and auto-unstuck disabled
 - BTC collateral, coin overrides, realized-loss gating, exposure enforcers, and non-inert fixed
@@ -111,9 +112,8 @@ The first supported slice is intentionally narrow:
 - `live.market_orders_allowed: false`
 - no invalid candle tail after the selected coin's final valid candle
 
-Unsupported combinations fail before optimization begins. Short-only, long+short,
-trailing-martingale, multi-coin, suites, HSL, auto-unstuck, and forager-dependent selection are not
-silently approximated by this foundation release.
+Unsupported combinations fail before optimization begins. Trailing-martingale, multi-coin, suites,
+HSL, auto-unstuck, and forager-dependent selection are not silently approximated by this release.
 
 Proxy scoring and limits are likewise fail-closed. This slice supports `adg_strategy_eq`,
 `adg_strategy_eq_w`, `mdg_strategy_eq`, `sharpe_ratio_strategy_eq`,
@@ -127,7 +127,8 @@ The backend is hybrid rather than a replacement backtester:
 
 1. pymoo NSGA-II proposes large normalized candidate batches.
 2. A Rust-owned Metal screening program evaluates every candidate against candle data resident on
-   MPS; Python only prepares buffers and dispatches the program.
+   MPS; Python only prepares buffers and dispatches the program. Directional runs use separate
+   long/short EMA and position state with one shared balance and the exact Rust fill ordering.
 3. Diverse proxy-front candidates and broad drift probes are sent to the unchanged Rust backtester.
 4. Only exact Rust results enter `all_results.bin` and the persisted Pareto front.
 5. A rolling Spearman rank gate independently stops the run if broad proxy/exact probe agreement

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -4,7 +4,7 @@
 //! still live behind the Rust ownership boundary. Python only compiles and
 //! dispatches this source through the optional Apple MPS backend.
 
-pub const MPS_EMA_ANCHOR_SOURCE: &str = include_str!("gpu/mps_ema_anchor.metal");
+pub const MPS_EMA_ANCHOR_SOURCE: &str = include_str!("gpu/mps_ema_anchor_directional.metal");
 
 pub fn mps_ema_anchor_source() -> &'static str {
     MPS_EMA_ANCHOR_SOURCE
@@ -19,6 +19,8 @@ mod tests {
         let source = mps_ema_anchor_source();
         assert!(source.contains("kernel void passivbot_ema_anchor"));
         assert!(source.contains("constant int DAILY_COLS = 5"));
-        assert!(source.contains("constant int SCALAR_COLS = 15"));
+        assert!(source.contains("constant int SCALAR_COLS = 18"));
+        assert!(source.contains("generate_short_orders"));
+        assert!(source.contains("const bool hedge_mode"));
     }
 }

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -1,0 +1,599 @@
+#include <metal_stdlib>
+using namespace metal;
+
+constant int DAILY_COLS = 5;
+constant int SCALAR_COLS = 18;
+constant int GAP_BINS = 128;
+constant int SIDE_PARAMS = 12;
+
+inline float round_step(float value, float step) {
+    return floor(value / step + 0.5f) * step;
+}
+
+inline float ceil_step(float value, float step) {
+    return ceil(value / step - 1.0e-6f) * step;
+}
+
+inline float floor_step(float value, float step) {
+    return floor(value / step + 1.0e-6f) * step;
+}
+
+inline float min_entry_qty(
+    float price, float qty_step, float min_qty, float min_cost, float c_mult
+) {
+    float raw_min = fmax(min_qty, min_cost / fmax(price, 1.0e-12f) / c_mult);
+    float raw_steps = raw_min / qty_step;
+    float nearest_count = floor(raw_steps + 0.5f);
+    float nearest = nearest_count * qty_step;
+    float representation_tolerance = 1.1920928955078125e-7f
+        * fmax(fabs(raw_min), fabs(nearest)) * 4.0f;
+    bool aligned = nearest_count > 0.0f && fabs(raw_steps - nearest_count) <= 1.0e-8f
+        && (nearest >= raw_min || raw_min - nearest <= representation_tolerance);
+    return aligned ? fmax(nearest, raw_min) : ceil(raw_steps) * qty_step;
+}
+
+struct EmaSide {
+    float alpha0;
+    float alpha1;
+    float alpha2;
+    float alpha1m;
+    float alpha1h;
+    float base_qty_pct;
+    float ddf;
+    float offset;
+    float psize_weight;
+    float w1h;
+    float w1m;
+    float cooldown_min;
+    float twel;
+    float ema0;
+    float ema1;
+    float ema2;
+    float vol1m;
+    float vol1h;
+    float psize;
+    float pprice;
+    float last_inc_k;
+    float pos_open_k;
+    int entry_ticks;
+    float entry_qty;
+    int close_ticks;
+    float close_qty;
+};
+
+inline EmaSide load_side(constant float* params, int po, float seed_close) {
+    EmaSide side;
+    float span0 = params[po + 1];
+    float span1 = params[po + 2];
+    float span2 = sqrt(span0 * span1);
+    float lo_span = fmin(span0, fmin(span1, span2));
+    float hi_span = fmax(span0, fmax(span1, span2));
+    float mid_span = span0 + span1 + span2 - lo_span - hi_span;
+    side.alpha0 = clamp(2.0f / (lo_span + 1.0f), 0.0f, 1.0f);
+    side.alpha1 = clamp(2.0f / (mid_span + 1.0f), 0.0f, 1.0f);
+    side.alpha2 = clamp(2.0f / (hi_span + 1.0f), 0.0f, 1.0f);
+    float span_h = params[po + 8];
+    float span_m = params[po + 9];
+    side.alpha1h = span_h > 0.0f ? 2.0f / (fmax(span_h, 1.0f) + 1.0f) : 0.0f;
+    side.alpha1m = span_m > 0.0f
+        ? clamp(2.0f / (span_m + 1.0f), 0.0f, 1.0f) : 0.0f;
+    side.base_qty_pct = params[po + 0];
+    side.ddf = params[po + 3];
+    side.offset = params[po + 4];
+    side.psize_weight = params[po + 5];
+    side.w1h = params[po + 6];
+    side.w1m = params[po + 7];
+    side.cooldown_min = ceil(params[po + 10]);
+    side.twel = params[po + 11];
+    side.ema0 = seed_close;
+    side.ema1 = seed_close;
+    side.ema2 = seed_close;
+    side.vol1m = 0.0f;
+    side.vol1h = 0.0f;
+    side.psize = 0.0f;
+    side.pprice = 0.0f;
+    side.last_inc_k = -1.0f;
+    side.pos_open_k = -1.0f;
+    side.entry_ticks = 0;
+    side.entry_qty = 0.0f;
+    side.close_ticks = 0;
+    side.close_qty = 0.0f;
+    return side;
+}
+
+inline void update_indicators(
+    thread EmaSide& side,
+    float close,
+    float log_range,
+    float hour_lr,
+    bool valid,
+    bool hour_valid
+) {
+    if (hour_valid && side.alpha1h > 0.0f) {
+        side.vol1h = side.alpha1h * hour_lr + (1.0f - side.alpha1h) * side.vol1h;
+    }
+    if (valid) {
+        side.ema0 = side.alpha0 * close + (1.0f - side.alpha0) * side.ema0;
+        side.ema1 = side.alpha1 * close + (1.0f - side.alpha1) * side.ema1;
+        side.ema2 = side.alpha2 * close + (1.0f - side.alpha2) * side.ema2;
+        if (side.alpha1m > 0.0f) {
+            side.vol1m = side.alpha1m * log_range
+                + (1.0f - side.alpha1m) * side.vol1m;
+        }
+    }
+}
+
+inline void generate_long_orders(
+    thread EmaSide& side,
+    float balance,
+    float price_now,
+    float qty_step,
+    float price_step,
+    float min_qty,
+    float min_cost,
+    float c_mult,
+    float kf,
+    bool block_initial
+) {
+    float lower = fmin(side.ema0, fmin(side.ema1, side.ema2));
+    float upper = fmax(side.ema0, fmax(side.ema1, side.ema2));
+    float mult = fmax(1.0f + side.vol1h * side.w1h + side.vol1m * side.w1m, 1.0f);
+    float eff_off = side.offset * mult;
+    float current_we = side.psize > 0.0f && balance > 0.0f
+        ? side.psize * price_now * c_mult / balance : 0.0f;
+    float current_cost_we = side.psize > 0.0f && balance > 0.0f
+        ? side.psize * side.pprice * c_mult / balance : 0.0f;
+    float swer = side.psize > 0.0f && balance > 0.0f
+        ? current_we / fmax(side.twel, 1.0e-12f) : 0.0f;
+    float inv_shift = swer * side.psize_weight;
+
+    int bid_ticks = min(
+        int(floor(lower * (1.0f - eff_off - inv_shift) / price_step + 1.0e-6f)),
+        int(floor(price_now / price_step + 1.0e-6f))
+    );
+    float bid_price = float(bid_ticks) * price_step;
+    float min_q = min_entry_qty(bid_price, qty_step, min_qty, min_cost, c_mult);
+    float base_q = fmax(min_q, round_step(
+        balance * side.twel * side.base_qty_pct
+            / fmax(bid_price, 1.0e-12f) / c_mult,
+        qty_step
+    ));
+    float e_qty = round_step(
+        base_q * fmax(1.0f + fmax(swer, 0.0f) * side.ddf, 1.0f), qty_step
+    );
+    bool cooldown = side.cooldown_min > 0.0f && side.last_inc_k >= 0.0f
+        && kf < side.last_inc_k + side.cooldown_min;
+    float cap = side.twel - 1.0e-7f;
+    float headroom = (cap * balance - side.psize * side.pprice * c_mult)
+        / fmax(bid_price * c_mult, 1.0e-12f);
+    bool over = (side.psize * side.pprice + e_qty * bid_price) * c_mult
+        / fmax(balance, 1.0e-9f) >= cap;
+    float capped = floor_step(headroom, qty_step);
+    if (over) e_qty = capped > 0.0f && capped + 1.0e-6f >= min_q ? capped : 0.0f;
+    if (current_cost_we >= cap || cooldown || bid_price <= 0.0f || balance <= 0.0f
+        || side.base_qty_pct <= 0.0f || (block_initial && side.psize <= 0.0f)) {
+        e_qty = 0.0f;
+    }
+    side.entry_ticks = bid_ticks;
+    side.entry_qty = e_qty;
+
+    int ask_ticks = max(
+        int(ceil(upper * (1.0f + eff_off - inv_shift) / price_step - 1.0e-6f)),
+        int(ceil(price_now / price_step - 1.0e-6f))
+    );
+    float ask_price = float(ask_ticks) * price_step;
+    float min_cq = min_entry_qty(ask_price, qty_step, min_qty, min_cost, c_mult);
+    float clip = fmin(side.psize, fmax(min_cq, round_step(
+        balance * side.twel * side.base_qty_pct
+            / fmax(ask_price, 1.0e-12f) / c_mult,
+        qty_step
+    )));
+    float c_qty = side.psize <= min_cq || side.psize - clip < min_cq
+        ? side.psize : clip;
+    if (side.psize <= 0.0f || ask_price <= 0.0f) c_qty = 0.0f;
+    side.close_ticks = ask_ticks;
+    side.close_qty = c_qty;
+}
+
+inline void generate_short_orders(
+    thread EmaSide& side,
+    float balance,
+    float price_now,
+    float qty_step,
+    float price_step,
+    float min_qty,
+    float min_cost,
+    float c_mult,
+    float kf,
+    bool block_initial
+) {
+    float lower = fmin(side.ema0, fmin(side.ema1, side.ema2));
+    float upper = fmax(side.ema0, fmax(side.ema1, side.ema2));
+    float mult = fmax(1.0f + side.vol1h * side.w1h + side.vol1m * side.w1m, 1.0f);
+    float eff_off = side.offset * mult;
+    float swer = side.psize > 0.0f && balance > 0.0f
+        ? -side.psize * price_now * c_mult / balance / fmax(side.twel, 1.0e-12f)
+        : 0.0f;
+    float current_cost_we = side.psize > 0.0f && balance > 0.0f
+        ? side.psize * side.pprice * c_mult / balance : 0.0f;
+    float inv_shift = swer * side.psize_weight;
+
+    int ask_ticks = max(
+        int(ceil(upper * (1.0f + eff_off - inv_shift) / price_step - 1.0e-6f)),
+        int(ceil(price_now / price_step - 1.0e-6f))
+    );
+    float ask_price = float(ask_ticks) * price_step;
+    float min_q = min_entry_qty(ask_price, qty_step, min_qty, min_cost, c_mult);
+    float base_q = fmax(min_q, round_step(
+        balance * side.twel * side.base_qty_pct
+            / fmax(ask_price, 1.0e-12f) / c_mult,
+        qty_step
+    ));
+    float e_qty = round_step(
+        base_q * fmax(1.0f + fmax(-swer, 0.0f) * side.ddf, 1.0f), qty_step
+    );
+    bool cooldown = side.cooldown_min > 0.0f && side.last_inc_k >= 0.0f
+        && kf < side.last_inc_k + side.cooldown_min;
+    float cap = side.twel - 1.0e-7f;
+    float headroom = (cap * balance - side.psize * side.pprice * c_mult)
+        / fmax(ask_price * c_mult, 1.0e-12f);
+    bool over = (side.psize * side.pprice + e_qty * ask_price) * c_mult
+        / fmax(balance, 1.0e-9f) >= cap;
+    float capped = floor_step(headroom, qty_step);
+    if (over) e_qty = capped > 0.0f && capped + 1.0e-6f >= min_q ? capped : 0.0f;
+    if (current_cost_we >= cap || cooldown || ask_price <= 0.0f || balance <= 0.0f
+        || side.base_qty_pct <= 0.0f || (block_initial && side.psize <= 0.0f)) {
+        e_qty = 0.0f;
+    }
+    side.entry_ticks = ask_ticks;
+    side.entry_qty = e_qty;
+
+    int bid_ticks = min(
+        int(floor(lower * (1.0f - eff_off - inv_shift) / price_step + 1.0e-6f)),
+        int(floor(price_now / price_step + 1.0e-6f))
+    );
+    float bid_price = float(bid_ticks) * price_step;
+    float min_cq = min_entry_qty(bid_price, qty_step, min_qty, min_cost, c_mult);
+    float clip = fmin(side.psize, fmax(min_cq, round_step(
+        balance * side.twel * side.base_qty_pct
+            / fmax(bid_price, 1.0e-12f) / c_mult,
+        qty_step
+    )));
+    float c_qty = side.psize <= min_cq || side.psize - clip < min_cq
+        ? side.psize : clip;
+    if (side.psize <= 0.0f || bid_price <= 0.0f) c_qty = 0.0f;
+    side.close_ticks = bid_ticks;
+    side.close_qty = c_qty;
+}
+
+inline void passivbot_single_coin_impl(
+    constant float* bars,
+    constant int* flags,
+    constant float* params,
+    constant float* settings,
+    constant int* sizes,
+    device float* daily,
+    device float* scalars,
+    device int* gap_hist,
+    uint b
+) {
+    const int B = sizes[0];
+    const int T = sizes[1];
+    const int D = sizes[2];
+    const int P = sizes[3];
+    const int first_valid = sizes[4];
+    if (b >= uint(B)) return;
+
+    const float qty_step = settings[0];
+    const float price_step = settings[1];
+    const float min_qty = settings[2];
+    const float min_cost = settings[3];
+    const float c_mult = settings[4];
+    const float maker_fee = settings[5];
+    const float starting_balance = settings[6];
+    const float liq_floor = settings[7];
+    const float interval_ms = settings[8];
+    const bool long_enabled = settings[9] > 0.5f;
+    const bool short_enabled = settings[10] > 0.5f;
+    const bool hedge_mode = settings[11] > 0.5f;
+    const float log_bin_scale = 127.0f / log(4000001.0f);
+
+    const int po = int(b) * P;
+    const int seed_k = clamp(first_valid, 0, T - 1);
+    const float seed_close = bars[seed_k * 5 + 2];
+    EmaSide long_side = load_side(params, po, seed_close);
+    EmaSide short_side = load_side(params, po + SIDE_PARAMS, seed_close);
+
+    float balance = starting_balance;
+    bool alive = true;
+    int liq_day = -1;
+    float held_max_min = 0.0f;
+    float last_fill_k = -1.0f;
+    float first_fill_k = -1.0f;
+    float gap_max_min = 0.0f;
+    float run_peak = -INFINITY;
+    float max_dd = 0.0f;
+    float last_high_k = -1.0f;
+    float recovery_max_min = 0.0f;
+    float first_eq_k = -1.0f;
+    float last_eq_k = -1.0f;
+    bool eq_started = false;
+
+    int cur_day = flags[2];
+    bool day_touched = false;
+    float day_end = 0.0f;
+    float day_min = INFINITY;
+    float day_dd = 0.0f;
+    float day_volume = 0.0f;
+    float day_has_fill = 0.0f;
+
+    for (int j = 0; j < GAP_BINS; ++j) {
+        gap_hist[int(b) * GAP_BINS + j] = 0;
+    }
+
+    for (int k = 1; k < T - 1; ++k) {
+        const int bo = k * 5;
+        const int fo = k * 4;
+        const float high = bars[bo + 0];
+        const float low = bars[bo + 1];
+        const float close = bars[bo + 2];
+        const float log_range = bars[bo + 3];
+        const float hour_lr = bars[bo + 4];
+        const bool valid = flags[fo + 0] != 0;
+        const bool can_gen = flags[fo + 1] != 0;
+        const int di = flags[fo + 2];
+        const bool hour_valid = flags[fo + 3] != 0;
+        const float kf = float(k);
+
+        if (di != cur_day) {
+            if (day_touched && cur_day >= 0 && cur_day < D) {
+                int o = (int(b) * D + cur_day) * DAILY_COLS;
+                daily[o + 0] = day_end;
+                daily[o + 1] = day_min;
+                daily[o + 2] = day_dd;
+                daily[o + 3] = day_volume;
+                daily[o + 4] = day_has_fill;
+            }
+            cur_day = di;
+            day_touched = false;
+            day_end = 0.0f;
+            day_min = INFINITY;
+            day_dd = 0.0f;
+            day_volume = 0.0f;
+            day_has_fill = 0.0f;
+        }
+
+        bool long_close_fill = valid && alive && long_enabled
+            && long_side.close_qty > 0.0f && long_side.psize > 0.0f
+            && high > float(long_side.close_ticks) * price_step;
+        if (long_close_fill) {
+            float cp = float(long_side.close_ticks) * price_step;
+            float adj = fmin(round_step(long_side.close_qty, qty_step), long_side.psize);
+            float pnl = adj * c_mult * (cp - long_side.pprice);
+            balance += pnl - adj * cp * c_mult * maker_fee;
+            float new_psize = fmax(round_step(long_side.psize - adj, qty_step), 0.0f);
+            bool went_flat = new_psize <= 0.0f;
+            long_side.psize = new_psize;
+            if (went_flat) {
+                long_side.pprice = 0.0f;
+                if (long_side.pos_open_k >= 0.0f) {
+                    held_max_min = fmax(held_max_min, kf - long_side.pos_open_k);
+                }
+                long_side.pos_open_k = -1.0f;
+            }
+            day_volume += fabs(adj) * cp / balance;
+            long_side.close_qty = 0.0f;
+        }
+
+        bool long_entry_fill = valid && alive && long_enabled
+            && long_side.entry_qty > 0.0f
+            && low < float(long_side.entry_ticks) * price_step;
+        if (long_entry_fill) {
+            float ep = float(long_side.entry_ticks) * price_step;
+            float eq = round_step(long_side.entry_qty, qty_step);
+            balance -= eq * ep * c_mult * maker_fee;
+            bool was_flat = long_side.psize <= 0.0f;
+            float new_psize = round_step(long_side.psize + eq, qty_step);
+            float new_pprice = was_flat ? ep
+                : long_side.pprice * (long_side.psize / fmax(new_psize, 1.0e-12f))
+                    + ep * (eq / fmax(new_psize, 1.0e-12f));
+            if (was_flat) long_side.pos_open_k = kf;
+            long_side.psize = new_psize;
+            long_side.pprice = new_pprice;
+            long_side.last_inc_k = kf;
+            day_volume += fabs(eq) * ep / balance;
+            long_side.entry_qty = 0.0f;
+        }
+
+        bool short_close_fill = valid && alive && short_enabled
+            && short_side.close_qty > 0.0f && short_side.psize > 0.0f
+            && low < float(short_side.close_ticks) * price_step;
+        if (short_close_fill) {
+            float cp = float(short_side.close_ticks) * price_step;
+            float adj = fmin(round_step(short_side.close_qty, qty_step), short_side.psize);
+            float pnl = adj * c_mult * (short_side.pprice - cp);
+            balance += pnl - adj * cp * c_mult * maker_fee;
+            float new_psize = fmax(round_step(short_side.psize - adj, qty_step), 0.0f);
+            bool went_flat = new_psize <= 0.0f;
+            short_side.psize = new_psize;
+            if (went_flat) {
+                short_side.pprice = 0.0f;
+                if (short_side.pos_open_k >= 0.0f) {
+                    held_max_min = fmax(held_max_min, kf - short_side.pos_open_k);
+                }
+                short_side.pos_open_k = -1.0f;
+            }
+            day_volume += fabs(adj) * cp / balance;
+            short_side.close_qty = 0.0f;
+        }
+
+        bool short_entry_fill = valid && alive && short_enabled
+            && short_side.entry_qty > 0.0f
+            && high > float(short_side.entry_ticks) * price_step;
+        if (short_entry_fill) {
+            float ep = float(short_side.entry_ticks) * price_step;
+            float eq = round_step(short_side.entry_qty, qty_step);
+            balance -= eq * ep * c_mult * maker_fee;
+            bool was_flat = short_side.psize <= 0.0f;
+            float new_psize = round_step(short_side.psize + eq, qty_step);
+            float new_pprice = was_flat ? ep
+                : short_side.pprice * (short_side.psize / fmax(new_psize, 1.0e-12f))
+                    + ep * (eq / fmax(new_psize, 1.0e-12f));
+            if (was_flat) short_side.pos_open_k = kf;
+            short_side.psize = new_psize;
+            short_side.pprice = new_pprice;
+            short_side.last_inc_k = kf;
+            day_volume += fabs(eq) * ep / balance;
+            short_side.entry_qty = 0.0f;
+        }
+
+        bool any_fill = long_close_fill || long_entry_fill
+            || short_close_fill || short_entry_fill;
+        if (any_fill) {
+            day_has_fill = 1.0f;
+            day_touched = true;
+            if (last_fill_k >= 0.0f) {
+                float gap = kf - last_fill_k;
+                int bin = clamp(
+                    int(log(fmax(gap, 0.0f) + 1.0f) * log_bin_scale), 0, 127
+                );
+                gap_hist[int(b) * GAP_BINS + bin] += 1;
+                gap_max_min = fmax(gap_max_min, gap);
+            }
+            if (first_fill_k < 0.0f) first_fill_k = kf;
+            last_fill_k = kf;
+        }
+
+        if (long_enabled) {
+            update_indicators(long_side, close, log_range, hour_lr, valid, hour_valid);
+        }
+        if (short_enabled) {
+            update_indicators(short_side, close, log_range, hour_lr, valid, hour_valid);
+        }
+
+        bool gen = can_gen && alive;
+        eq_started = eq_started || gen;
+        if (gen) {
+            bool block_long_initial = false;
+            bool block_short_initial = false;
+            if (long_enabled && short_enabled && !hedge_mode) {
+                if (long_side.psize > 0.0f) {
+                    block_short_initial = true;
+                } else if (short_side.psize > 0.0f) {
+                    block_long_initial = true;
+                } else {
+                    float long_lower = fmin(
+                        long_side.ema0, fmin(long_side.ema1, long_side.ema2)
+                    );
+                    float short_upper = fmax(
+                        short_side.ema0, fmax(short_side.ema1, short_side.ema2)
+                    );
+                    float dist_long = long_lower * (1.0f - long_side.offset)
+                        / close - 1.0f;
+                    float dist_short = 1.0f
+                        - short_upper * (1.0f + short_side.offset) / close;
+                    if (dist_long >= dist_short) {
+                        block_short_initial = true;
+                    } else {
+                        block_long_initial = true;
+                    }
+                }
+            }
+            if (long_enabled) {
+                generate_long_orders(
+                    long_side, balance, close, qty_step, price_step, min_qty,
+                    min_cost, c_mult, kf, block_long_initial
+                );
+            }
+            if (short_enabled) {
+                generate_short_orders(
+                    short_side, balance, close, qty_step, price_step, min_qty,
+                    min_cost, c_mult, kf, block_short_initial
+                );
+            }
+        }
+
+        float long_unreal = long_side.psize > 0.0f
+            ? long_side.psize * c_mult * (close - long_side.pprice) : 0.0f;
+        float short_unreal = short_side.psize > 0.0f
+            ? short_side.psize * c_mult * (short_side.pprice - close) : 0.0f;
+        float equity = balance + long_unreal + short_unreal;
+        bool active = eq_started && alive && valid;
+        if (active) {
+            if (first_eq_k < 0.0f) first_eq_k = kf;
+            last_eq_k = kf;
+            bool liq = balance <= 0.0f || equity <= liq_floor;
+            float eqf = liq ? liq_floor : equity;
+            if (eqf > run_peak) {
+                if (last_high_k >= 0.0f) {
+                    recovery_max_min = fmax(recovery_max_min, kf - last_high_k);
+                }
+                last_high_k = kf;
+                run_peak = eqf;
+            }
+            float dd = fmax(
+                (run_peak - eqf) / fmax(fabs(run_peak), 1.0e-12f), 0.0f
+            );
+            max_dd = fmax(max_dd, dd);
+            day_end = eqf;
+            day_min = fmin(day_min, eqf);
+            day_dd = fmax(day_dd, dd);
+            day_touched = true;
+            if (liq) {
+                liq_day = di;
+                alive = false;
+            }
+        }
+    }
+
+    if (day_touched && cur_day >= 0 && cur_day < D) {
+        int o = (int(b) * D + cur_day) * DAILY_COLS;
+        daily[o + 0] = day_end;
+        daily[o + 1] = day_min;
+        daily[o + 2] = day_dd;
+        daily[o + 3] = day_volume;
+        daily[o + 4] = day_has_fill;
+    }
+
+    if (long_side.pos_open_k >= 0.0f && last_eq_k >= 0.0f) {
+        held_max_min = fmax(held_max_min, last_eq_k - long_side.pos_open_k);
+    }
+    if (short_side.pos_open_k >= 0.0f && last_eq_k >= 0.0f) {
+        held_max_min = fmax(held_max_min, last_eq_k - short_side.pos_open_k);
+    }
+    int so = int(b) * SCALAR_COLS;
+    scalars[so + 0] = max_dd;
+    scalars[so + 1] = held_max_min * interval_ms;
+    scalars[so + 2] = gap_max_min * interval_ms;
+    scalars[so + 3] = first_fill_k >= 0.0f ? first_fill_k * interval_ms : -1.0f;
+    scalars[so + 4] = last_fill_k >= 0.0f ? last_fill_k * interval_ms : -1.0f;
+    scalars[so + 5] = recovery_max_min * interval_ms;
+    scalars[so + 6] = last_high_k >= 0.0f ? last_high_k * interval_ms : -1.0f;
+    scalars[so + 7] = first_eq_k >= 0.0f ? first_eq_k * interval_ms : -1.0f;
+    scalars[so + 8] = last_eq_k >= 0.0f ? last_eq_k * interval_ms : -1.0f;
+    scalars[so + 9] = float(liq_day);
+    scalars[so + 10] = balance;
+    scalars[so + 11] = long_side.psize;
+    scalars[so + 12] = long_side.pprice;
+    scalars[so + 13] = alive ? 1.0f : 0.0f;
+    scalars[so + 14] = long_side.psize > 0.0f || short_side.psize > 0.0f ? 1.0f : 0.0f;
+    scalars[so + 15] = short_side.psize;
+    scalars[so + 16] = short_side.pprice;
+    scalars[so + 17] = 0.0f;
+}
+
+kernel void passivbot_ema_anchor(
+    constant float* bars,
+    constant int* flags,
+    constant float* params,
+    constant float* settings,
+    constant int* sizes,
+    device float* daily,
+    device float* scalars,
+    device int* gap_hist,
+    uint b [[thread_position_in_grid]]
+) {
+    passivbot_single_coin_impl(
+        bars, flags, params, settings, sizes, daily, scalars, gap_hist, b
+    );
+}

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -18,6 +18,7 @@ import numpy as np
 from optimization.backend_shared import load_starting_individuals
 from optimization.bounds import enforce_bounds
 from optimization.callback import build_pymoo_record_entry
+from optimization.gpu.model import gpu_side_enabled
 from optimization.problem import (
     PymooAsyncRecordingRunner,
     PymooEvaluatorAdapter,
@@ -241,18 +242,6 @@ def _resolve_options(config: dict) -> dict:
     return options
 
 
-def _gpu_side_enabled(config: dict, side: str) -> bool:
-    risk = config.get("bot", {}).get(side, {}).get("risk", {})
-    total_exposure = float(risk.get("total_wallet_exposure_limit", 0.0) or 0.0)
-    n_positions = int(round(float(risk.get("n_positions", 0) or 0)))
-    if total_exposure <= 0.0 or n_positions <= 0:
-        return False
-    approved = config.get("live", {}).get("approved_coins", {})
-    if isinstance(approved, dict):
-        return bool(approved.get(side, []))
-    return True
-
-
 def _validate_scope(config: dict, evaluator) -> str:
     if bool(config.get("backtest", {}).get("suite_enabled")):
         raise ValueError("GPU foundation does not support suite mode")
@@ -304,7 +293,7 @@ def _validate_scope(config: dict, evaluator) -> str:
             "GPU foundation supports strategy_kind=ema_anchor only; "
             f"got {strategy_kind!r}"
         )
-    enabled_sides = [side for side in ("long", "short") if _gpu_side_enabled(config, side)]
+    enabled_sides = [side for side in ("long", "short") if gpu_side_enabled(config, side)]
     if not enabled_sides:
         raise ValueError("GPU foundation requires at least one enabled side")
     for side in enabled_sides:
@@ -746,6 +735,18 @@ def _validate_directional_search_space(
             )
 
 
+def _validate_seed_side_match(config_enabled_sides, seed_enabled_sides) -> None:
+    config_enabled_sides = set(config_enabled_sides)
+    seed_enabled_sides = set(seed_enabled_sides)
+    if config_enabled_sides != seed_enabled_sides:
+        raise ValueError(
+            "GPU foundation does not allow optimizer bounds to activate or disable "
+            "a side relative to the input config; "
+            f"config={sorted(config_enabled_sides)}, "
+            f"bounds_clamped_seed={sorted(seed_enabled_sides)}"
+        )
+
+
 def _constraint_classification_mismatch(proxy_violation: float, exact_payload: dict) -> bool:
     if "G" not in exact_payload:
         return False
@@ -910,6 +911,10 @@ def run_backend(
         )
 
     enabled_sides = {side for side in ("long", "short") if vector_side_enabled(side)}
+    config_enabled_sides = {
+        side for side in ("long", "short") if gpu_side_enabled(config, side)
+    }
+    _validate_seed_side_match(config_enabled_sides, enabled_sides)
     if not enabled_sides:
         raise ValueError(
             "GPU bounds would disable both sides for exact validation; "

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -43,19 +43,25 @@ MIN_DRIFT_PROBES = 8
 
 MAX_NOVELTY_STALL_GENERATIONS = 8
 
+_EMA_SIDE_BOUND_SUFFIXES = {
+    "base_qty_pct": "base_qty_pct",
+    "ema_span_0": "ema_span_0",
+    "ema_span_1": "ema_span_1",
+    "entry_double_down_factor": "entry_double_down_factor",
+    "offset": "offset",
+    "offset_psize_weight": "offset_psize_weight",
+    "offset_volatility_1h_weight": "offset_volatility_1h_weight",
+    "offset_volatility_1m_weight": "offset_volatility_1m_weight",
+    "offset_volatility_ema_span_1h": "offset_volatility_ema_span_1h",
+    "offset_volatility_ema_span_1m": "offset_volatility_ema_span_1m",
+    "risk_entry_cooldown_minutes": "entry_cooldown_minutes",
+    "total_wallet_exposure_limit": "total_wallet_exposure_limit",
+}
+
 EMA_BOUND_MAP = {
-    "long_base_qty_pct": "base_qty_pct",
-    "long_ema_span_0": "ema_span_0",
-    "long_ema_span_1": "ema_span_1",
-    "long_entry_double_down_factor": "entry_double_down_factor",
-    "long_offset": "offset",
-    "long_offset_psize_weight": "offset_psize_weight",
-    "long_offset_volatility_1h_weight": "offset_volatility_1h_weight",
-    "long_offset_volatility_1m_weight": "offset_volatility_1m_weight",
-    "long_offset_volatility_ema_span_1h": "offset_volatility_ema_span_1h",
-    "long_offset_volatility_ema_span_1m": "offset_volatility_ema_span_1m",
-    "long_risk_entry_cooldown_minutes": "entry_cooldown_minutes",
-    "long_total_wallet_exposure_limit": "total_wallet_exposure_limit",
+    f"{side}_{bound_suffix}": f"{side}_{parameter}"
+    for side in ("long", "short")
+    for bound_suffix, parameter in _EMA_SIDE_BOUND_SUFFIXES.items()
 }
 
 
@@ -87,13 +93,17 @@ def _build_gpu_nsga2(config, *, sampling, population_size: int, n_params: int):
     )
 
 PINNED_SCOPE_BOUND_VALUES = {
-    "long_hsl_enabled": 0.0,
-    "long_unstuck_enabled": 0.0,
-    "long_risk_position_exposure_enforcer_enabled": 0.0,
-    "long_risk_total_exposure_enforcer_enabled": 0.0,
-    "long_risk_total_exposure_entry_gate_enabled": 1.0,
-    "long_risk_total_exposure_enforcer_threshold": 1.0,
-    "long_risk_we_excess_allowance_pct": 0.0,
+    f"{side}_{suffix}": expected
+    for side in ("long", "short")
+    for suffix, expected in {
+        "hsl_enabled": 0.0,
+        "unstuck_enabled": 0.0,
+        "risk_position_exposure_enforcer_enabled": 0.0,
+        "risk_total_exposure_enforcer_enabled": 0.0,
+        "risk_total_exposure_entry_gate_enabled": 1.0,
+        "risk_total_exposure_enforcer_threshold": 1.0,
+        "risk_we_excess_allowance_pct": 0.0,
+    }.items()
 }
 
 GPU_RESULT_BACKTEST_CONTRACT_KEYS = {
@@ -294,35 +304,31 @@ def _validate_scope(config: dict, evaluator) -> str:
             "GPU foundation supports strategy_kind=ema_anchor only; "
             f"got {strategy_kind!r}"
         )
-    if not _gpu_side_enabled(config, "long") or _gpu_side_enabled(config, "short"):
-        raise ValueError(
-            "GPU foundation supports long-only configs; enable long and disable short"
-        )
-    long_config = config["bot"]["long"]
-    if bool(long_config.get("hsl", {}).get("enabled")):
-        raise ValueError("GPU foundation requires bot.long.hsl.enabled=false")
-    if bool(long_config.get("unstuck", {}).get("enabled")):
-        raise ValueError("GPU foundation requires bot.long.unstuck.enabled=false")
-    risk = long_config.get("risk", {})
-    if bool(risk.get("position_exposure_enforcer_enabled")):
-        raise ValueError(
-            "GPU foundation requires "
-            "bot.long.risk.position_exposure_enforcer_enabled=false"
-        )
-    if bool(risk.get("total_exposure_enforcer_enabled")):
-        raise ValueError(
-            "GPU foundation requires "
-            "bot.long.risk.total_exposure_enforcer_enabled=false"
-        )
-    if float(risk.get("we_excess_allowance_pct", 0.0) or 0.0) != 0.0:
-        raise ValueError(
-            "GPU foundation requires bot.long.risk.we_excess_allowance_pct=0.0"
-        )
-    if not bool(risk.get("total_exposure_entry_gate_enabled", True)):
-        raise ValueError(
-            "GPU foundation requires "
-            "bot.long.risk.total_exposure_entry_gate_enabled=true"
-        )
+    enabled_sides = [side for side in ("long", "short") if _gpu_side_enabled(config, side)]
+    if not enabled_sides:
+        raise ValueError("GPU foundation requires at least one enabled side")
+    for side in enabled_sides:
+        side_config = config["bot"][side]
+        if bool(side_config.get("hsl", {}).get("enabled")):
+            raise ValueError(f"GPU foundation requires bot.{side}.hsl.enabled=false")
+        if bool(side_config.get("unstuck", {}).get("enabled")):
+            raise ValueError(
+                f"GPU foundation requires bot.{side}.unstuck.enabled=false"
+            )
+        risk = side_config.get("risk", {})
+        for key, expected in (
+            ("position_exposure_enforcer_enabled", False),
+            ("total_exposure_enforcer_enabled", False),
+            ("total_exposure_entry_gate_enabled", True),
+        ):
+            if bool(risk.get(key, expected)) != expected:
+                raise ValueError(
+                    f"GPU foundation requires bot.{side}.risk.{key}={str(expected).lower()}"
+                )
+        if float(risk.get("we_excess_allowance_pct", 0.0) or 0.0) != 0.0:
+            raise ValueError(
+                f"GPU foundation requires bot.{side}.risk.we_excess_allowance_pct=0.0"
+            )
     return exchange
 
 
@@ -675,8 +681,11 @@ def _build_proxy_parameter_dicts(base_vector, mapped, active, active_values) -> 
     return result
 
 
-def _validate_pinned_scope_bounds(bound_by_key, base_by_key) -> None:
+def _validate_pinned_scope_bounds(bound_by_key, base_by_key, enabled_sides=None) -> None:
+    enabled_sides = set(enabled_sides or ("long", "short"))
     for key, expected in PINNED_SCOPE_BOUND_VALUES.items():
+        if key.split("_", 1)[0] not in enabled_sides:
+            continue
         bound = bound_by_key.get(key)
         values = (
             (float(bound.low), float(bound.high))
@@ -687,6 +696,53 @@ def _validate_pinned_scope_bounds(bound_by_key, base_by_key) -> None:
             raise ValueError(
                 "GPU foundation requires "
                 f"{key} to remain pinned at {expected}; got bounds {values}"
+            )
+
+
+def _validate_directional_search_space(
+    bound_by_key, base_by_key, approved, enabled_sides
+) -> None:
+    """Keep candidate-side eligibility identical to the proxy runner's flags."""
+
+    enabled_sides = set(enabled_sides)
+
+    def side_approved(side: str) -> bool:
+        return bool(approved.get(side, [])) if isinstance(approved, dict) else True
+
+    def bound_edge(key: str, edge: str) -> float:
+        bound = bound_by_key.get(key)
+        return (
+            float(getattr(bound, edge))
+            if bound is not None
+            else float(base_by_key.get(key, 0.0))
+        )
+
+    for side in ("long", "short"):
+        can_activate = (
+            side_approved(side)
+            and bound_edge(f"{side}_total_wallet_exposure_limit", "high") > 0.0
+            and bound_edge(f"{side}_n_positions", "high") > 0.0
+        )
+        if can_activate != (side in enabled_sides):
+            raise ValueError(
+                f"GPU foundation requires {side} enabledness to remain fixed across "
+                "the full search space; pin exposure/positions or approved coins"
+            )
+        if side not in enabled_sides:
+            continue
+        if bound_edge(f"{side}_total_wallet_exposure_limit", "low") <= 0.0:
+            raise ValueError(
+                f"GPU foundation requires {side} total_wallet_exposure_limit "
+                "to remain positive across the full search space"
+            )
+        n_positions = (
+            bound_edge(f"{side}_n_positions", "low"),
+            bound_edge(f"{side}_n_positions", "high"),
+        )
+        if n_positions != (1.0, 1.0):
+            raise ValueError(
+                f"GPU foundation requires {side}_n_positions pinned at 1; "
+                f"got bounds {n_positions}"
             )
 
 
@@ -823,89 +879,18 @@ def run_backend(
         )
     base_vector = [float(value) for value in template_vectors[0]]
 
-    mapped = {
+    mapped_all = {
         EMA_BOUND_MAP[bound_key]: (index, bounds[index])
         for index, (bound_key, _path) in enumerate(key_paths)
         if bound_key in EMA_BOUND_MAP
     }
-    missing = sorted(set(EMA_BOUND_MAP.values()) - set(mapped))
+    missing = sorted(set(EMA_BOUND_MAP.values()) - set(mapped_all))
     if missing:
         raise ValueError(f"GPU backend could not locate EMA bounds for {missing}")
-    active = [
-        (name, index, bound)
-        for name, (index, bound) in sorted(mapped.items(), key=lambda item: item[1][0])
-        if bound.high > bound.low
-    ]
-    if not active:
-        raise ValueError("GPU backend found no free EMA-anchor dimensions")
-
-    bound_by_key = {
-        bound_key: bounds[index] for index, (bound_key, _path) in enumerate(key_paths)
-    }
-    base_by_key = {
-        bound_key: float(base_vector[index])
-        for index, (bound_key, _path) in enumerate(key_paths)
-    }
-    _validate_pinned_scope_bounds(bound_by_key, base_by_key)
     approved = config.get("live", {}).get("approved_coins", {})
 
     def side_approved(side: str) -> bool:
         return bool(approved.get(side, [])) if isinstance(approved, dict) else True
-
-    def maximum_bound_value(key: str) -> float:
-        bound = bound_by_key.get(key)
-        return (
-            float(bound.high) if bound is not None else float(base_by_key.get(key, 0.0))
-        )
-
-    short_can_activate = (
-        side_approved("short")
-        and maximum_bound_value("short_total_wallet_exposure_limit") > 0.0
-        and maximum_bound_value("short_n_positions") > 0.0
-    )
-    if short_can_activate:
-        raise ValueError(
-            "GPU foundation requires short to remain disabled across the full search space; "
-            "clear live.approved_coins.short or pin short exposure/positions off"
-        )
-
-    long_n_positions_bound = bound_by_key.get("long_n_positions")
-    if long_n_positions_bound is None:
-        long_n_positions_values = (
-            base_by_key.get("long_n_positions", 0.0),
-            base_by_key.get("long_n_positions", 0.0),
-        )
-    else:
-        long_n_positions_values = (
-            float(long_n_positions_bound.low),
-            float(long_n_positions_bound.high),
-        )
-    if long_n_positions_values != (1.0, 1.0):
-        raise ValueError(
-            "GPU foundation requires long_n_positions to remain pinned at 1; "
-            f"got bounds {long_n_positions_values}"
-        )
-
-    for index, (bound_key, _path) in enumerate(key_paths):
-        if bounds[index].high <= bounds[index].low:
-            continue
-        if bound_key.startswith("short_"):
-            continue
-        if bound_key.startswith("long_forager_"):
-            # Forager ranking cannot affect a one-coin backtest.
-            continue
-        if bound_key.startswith("long_hsl_") or bound_key.startswith("long_unstuck_"):
-            # The enabling flags are not optimizer bounds. Scope validation
-            # requires both features off, so these dormant values cannot affect
-            # either the exact Rust backtest or the proxy.
-            continue
-        if bound_key == "long_n_positions":
-            continue
-        if bound_key not in EMA_BOUND_MAP:
-            raise ValueError(
-                "GPU foundation cannot optimize active bound "
-                f"{bound_key!r}; pin it or use the CPU optimizer"
-            )
 
     side_values = {}
     for index, (bound_key, _path) in enumerate(key_paths):
@@ -924,14 +909,63 @@ def run_backend(
             and side_values.get(f"{side}_n_positions", 0.0) > 0.0
         )
 
-    vector_long = vector_side_enabled("long")
-    vector_short = vector_side_enabled("short")
-    if not vector_long or vector_short:
+    enabled_sides = {side for side in ("long", "short") if vector_side_enabled(side)}
+    if not enabled_sides:
         raise ValueError(
-            "GPU bounds would make exact validation disagree with the long-only proxy; "
-            "pin long exposure/positions on and short exposure/positions off "
-            f"(effective seed values: {side_values})"
+            "GPU bounds would disable both sides for exact validation; "
+            f"effective seed values: {side_values}"
         )
+    mapped = {
+        name: value
+        for name, value in mapped_all.items()
+        if name.split("_", 1)[0] in enabled_sides
+    }
+    active = [
+        (name, index, bound)
+        for name, (index, bound) in sorted(mapped.items(), key=lambda item: item[1][0])
+        if bound.high > bound.low
+    ]
+    if not active:
+        raise ValueError("GPU backend found no free EMA-anchor dimensions")
+
+    bound_by_key = {
+        bound_key: bounds[index] for index, (bound_key, _path) in enumerate(key_paths)
+    }
+    base_by_key = {
+        bound_key: float(base_vector[index])
+        for index, (bound_key, _path) in enumerate(key_paths)
+    }
+    _validate_pinned_scope_bounds(bound_by_key, base_by_key, enabled_sides)
+
+    _validate_directional_search_space(
+        bound_by_key, base_by_key, approved, enabled_sides
+    )
+
+    for index, (bound_key, _path) in enumerate(key_paths):
+        if bounds[index].high <= bounds[index].low:
+            continue
+        side = bound_key.split("_", 1)[0]
+        if side in {"long", "short"} and side not in enabled_sides:
+            continue
+        if any(bound_key.startswith(f"{side}_forager_") for side in enabled_sides):
+            # Forager ranking cannot affect a one-coin backtest.
+            continue
+        if any(
+            bound_key.startswith(f"{side}_hsl_")
+            or bound_key.startswith(f"{side}_unstuck_")
+            for side in enabled_sides
+        ):
+            # The enabling flags are not optimizer bounds. Scope validation
+            # requires both features off, so these dormant values cannot affect
+            # either the exact Rust backtest or the proxy.
+            continue
+        if bound_key in {f"{side}_n_positions" for side in enabled_sides}:
+            continue
+        if bound_key not in EMA_BOUND_MAP:
+            raise ValueError(
+                "GPU foundation cannot optimize active bound "
+                f"{bound_key!r}; pin it or use the CPU optimizer"
+            )
 
     specs = extract_objective_specs(config)
     metric_names = [canonicalize_metric_name(spec.metric) for spec in specs]

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -25,6 +25,25 @@ EMA_ANCHOR_PARAM_KEYS = (
 )
 
 
+def gpu_side_enabled(config: dict, side: str) -> bool:
+    """Match Rust/backtest global side eligibility, including approved coins."""
+
+    risk = config.get("bot", {}).get(side, {}).get("risk", {})
+    total_exposure = float(risk.get("total_wallet_exposure_limit", 0.0) or 0.0)
+    n_positions_raw = float(risk.get("n_positions", 0) or 0)
+    if (
+        not math.isfinite(total_exposure)
+        or not math.isfinite(n_positions_raw)
+        or total_exposure <= 0.0
+        or int(round(n_positions_raw)) <= 0
+    ):
+        return False
+    approved = config.get("live", {}).get("approved_coins", {})
+    if isinstance(approved, dict):
+        return bool(approved.get(side, []))
+    return True
+
+
 @dataclass(frozen=True)
 class ProxyMarket:
     qty_step: float

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -15,7 +15,7 @@ from optimization.gpu.model import (
 
 
 MPS_DAILY_COLS = 5
-MPS_SCALAR_COLS = 15
+MPS_SCALAR_COLS = 18
 
 
 @lru_cache(maxsize=1)
@@ -35,9 +35,18 @@ class MpsEmaAnchorRunner:
         market: ProxyMarket,
         run: ProxyRun,
         data: dict,
+        *,
+        long_enabled: bool = True,
+        short_enabled: bool = False,
+        hedge_mode: bool = True,
     ):
         self.market = market
         self.run_config = run
+        self.long_enabled = bool(long_enabled)
+        self.short_enabled = bool(short_enabled)
+        self.hedge_mode = bool(hedge_mode)
+        if not self.long_enabled and not self.short_enabled:
+            raise ValueError("MPS EMA proxy requires at least one enabled side")
         self.n = int(data["n"])
         self.n_days = int(data["n_days"])
         self.bars = (
@@ -79,6 +88,9 @@ class MpsEmaAnchorRunner:
                 run.starting_balance,
                 liq_floor,
                 run.interval_ms,
+                float(self.long_enabled),
+                float(self.short_enabled),
+                float(self.hedge_mode),
             ],
             dtype=torch.float32,
             device="mps",
@@ -88,10 +100,11 @@ class MpsEmaAnchorRunner:
         self.last_profile: dict[str, float] = {}
 
     def _pack_params(self, params: np.ndarray) -> np.ndarray:
-        if params.ndim != 2 or params.shape[1] != len(EMA_ANCHOR_PARAM_KEYS):
+        expected = len(EMA_ANCHOR_PARAM_KEYS) * 2
+        if params.ndim != 2 or params.shape[1] != expected:
             got = params.shape[1] if params.ndim == 2 else params.shape
             raise ValueError(
-                f"expected EMA parameter matrix with {len(EMA_ANCHOR_PARAM_KEYS)} columns, got {got}"
+                f"expected directional EMA parameter matrix with {expected} columns, got {got}"
             )
         return np.ascontiguousarray(params, dtype=np.float32)
 
@@ -205,4 +218,6 @@ class MpsEmaAnchorRunner:
             "psize": scalars[:, 11],
             "pprice": scalars[:, 12],
             "alive": scalars[:, 13] > 0.0,
+            "short_psize": scalars[:, 15],
+            "short_pprice": scalars[:, 16],
         }

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -50,7 +50,7 @@ def _require_complete_valid_tail(last_valid_idx: int, candle_count: int) -> None
 
 
 class MpsEmaAnchorProxy:
-    """Batched single-coin, long-only EMA-anchor screening proxy."""
+    """Batched single-coin directional EMA-anchor screening proxy."""
 
     def __init__(
         self,
@@ -121,28 +121,34 @@ class MpsEmaAnchorProxy:
 
         long_bot = payload.bot_params_list[0]["long"]
         short_bot = payload.bot_params_list[0]["short"]
-        if not _side_enabled(long_bot) or _side_enabled(short_bot):
-            raise ValueError(
-                "GPU foundation currently supports long-only configs; "
-                "enable long and disable short"
+        self.enabled = {
+            "long": _side_enabled(long_bot),
+            "short": _side_enabled(short_bot),
+        }
+        if not any(self.enabled.values()):
+            raise ValueError("GPU foundation requires at least one enabled side")
+        self.base_params = {}
+        for side, bot in (("long", long_bot), ("short", short_bot)):
+            if self.enabled[side] and bool(bot.get("unstuck_enabled")):
+                raise ValueError(
+                    f"GPU foundation requires bot.{side}.unstuck.enabled=false"
+                )
+            if self.enabled[side] and bool(bot.get("hsl_enabled")):
+                raise ValueError(f"GPU foundation requires bot.{side}.hsl.enabled=false")
+            strategy = dict(payload.strategy_params_list[0][side])
+            risk = config["bot"][side]["risk"]
+            strategy["entry_cooldown_minutes"] = float(
+                risk.get("entry_cooldown_minutes", 0.0) or 0.0
             )
-        if bool(long_bot.get("unstuck_enabled")):
-            raise ValueError("GPU foundation requires bot.long.unstuck.enabled=false")
-        if bool(long_bot.get("hsl_enabled")):
-            raise ValueError("GPU foundation requires bot.long.hsl.enabled=false")
-
-        strategy = dict(payload.strategy_params_list[0]["long"])
-        risk = config["bot"]["long"]["risk"]
-        strategy["entry_cooldown_minutes"] = float(
-            risk.get("entry_cooldown_minutes", 0.0) or 0.0
-        )
-        strategy["total_wallet_exposure_limit"] = float(
-            risk["total_wallet_exposure_limit"]
-        )
-        missing = [key for key in EMA_ANCHOR_PARAM_KEYS if key not in strategy]
-        if missing:
-            raise ValueError(f"GPU EMA payload is missing parameters: {missing}")
-        self.base_params = strategy
+            strategy["total_wallet_exposure_limit"] = float(
+                risk["total_wallet_exposure_limit"]
+            )
+            missing = [key for key in EMA_ANCHOR_PARAM_KEYS if key not in strategy]
+            if missing:
+                raise ValueError(
+                    f"GPU EMA payload for {side} is missing parameters: {missing}"
+                )
+            self.base_params[side] = strategy
 
         market_params = payload.exchange_params[0]
         self.market = ProxyMarket(
@@ -185,14 +191,26 @@ class MpsEmaAnchorProxy:
             self.market,
             self.run,
             self.data,
+            long_enabled=self.enabled["long"],
+            short_enabled=self.enabled["short"],
+            hedge_mode=bool(backtest_params["hedge_mode"]),
         )
 
     def _parameter_matrix(self, candidates: list[dict]) -> np.ndarray:
         rows = []
         for candidate in candidates:
-            merged = dict(self.base_params)
-            merged.update(candidate)
-            rows.append([float(merged[key]) for key in EMA_ANCHOR_PARAM_KEYS])
+            row = []
+            for side in ("long", "short"):
+                merged = dict(self.base_params[side])
+                merged.update(
+                    {
+                        key.removeprefix(f"{side}_"): value
+                        for key, value in candidate.items()
+                        if key.startswith(f"{side}_")
+                    }
+                )
+                row.extend(float(merged[key]) for key in EMA_ANCHOR_PARAM_KEYS)
+            rows.append(row)
         return np.asarray(rows, dtype=np.float64)
 
     def evaluate(self, candidates: list[dict]) -> list[dict]:

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -10,6 +10,7 @@ from optimization.gpu.model import (
     ProxyMarket,
     ProxyRun,
     build_mps_data,
+    gpu_side_enabled,
 )
 
 
@@ -31,13 +32,6 @@ CORE_OUTPUT_KEYS = {
     "last_eq_ts",
     "liq_step",
 }
-
-
-def _side_enabled(bot_params: dict) -> bool:
-    return (
-        bool(bot_params.get("entry_eligible", True))
-        and float(bot_params.get("wallet_exposure_limit", 0.0) or 0.0) != 0.0
-    )
 
 
 def _require_complete_valid_tail(last_valid_idx: int, candle_count: int) -> None:
@@ -122,8 +116,7 @@ class MpsEmaAnchorProxy:
         long_bot = payload.bot_params_list[0]["long"]
         short_bot = payload.bot_params_list[0]["short"]
         self.enabled = {
-            "long": _side_enabled(long_bot),
-            "short": _side_enabled(short_bot),
+            side: gpu_side_enabled(config, side) for side in ("long", "short")
         }
         if not any(self.enabled.values()):
             raise ValueError("GPU foundation requires at least one enabled side")

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -27,6 +27,7 @@ from optimization.backends.gpu_backend import (
     _select_validation_indices,
     _validate_directional_search_space,
     _validate_pinned_scope_bounds,
+    _validate_seed_side_match,
     _validate_scope,
 )
 
@@ -638,6 +639,17 @@ def test_gpu_directional_search_space_rejects_disabled_approved_side_activation(
             {"long": ["BTC"], "short": ["BTC"]},
             {"long"},
         )
+
+
+def test_gpu_rejects_optimizer_bounds_that_change_config_side_enablement():
+    _validate_seed_side_match({"long"}, {"long"})
+
+    with pytest.raises(ValueError, match="activate or disable"):
+        _validate_seed_side_match({"long"}, {"long", "short"})
+
+    with pytest.raises(ValueError, match="activate or disable"):
+        _validate_seed_side_match({"long", "short"}, {"long"})
+
 
 def test_constraint_classification_drift_detects_feasibility_disagreement():
     assert _constraint_classification_mismatch(0.0, {"G": np.array([0.1])})

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -25,6 +25,7 @@ from optimization.backends.gpu_backend import (
     _single_scenario_metric_surface,
     _select_novel_validations,
     _select_validation_indices,
+    _validate_directional_search_space,
     _validate_pinned_scope_bounds,
     _validate_scope,
 )
@@ -50,6 +51,26 @@ def _long_only_ema_config():
     config["bot"]["long"]["risk"]["total_exposure_entry_gate_enabled"] = True
     config["bot"]["long"]["risk"]["we_excess_allowance_pct"] = 0.0
     config["backtest"]["suite_enabled"] = False
+    return config
+
+
+def _directional_ema_config(*, long_enabled: bool, short_enabled: bool):
+    config = _long_only_ema_config()
+    config["live"]["approved_coins"] = {
+        "long": ["BTC"] if long_enabled else [],
+        "short": ["BTC"] if short_enabled else [],
+    }
+    for side, enabled in (("long", long_enabled), ("short", short_enabled)):
+        config["bot"][side]["risk"]["total_wallet_exposure_limit"] = (
+            1.0 if enabled else 0.0
+        )
+        config["bot"][side]["risk"]["n_positions"] = 1 if enabled else 0
+        config["bot"][side]["hsl"]["enabled"] = False
+        config["bot"][side]["unstuck"]["enabled"] = False
+        config["bot"][side]["risk"]["position_exposure_enforcer_enabled"] = False
+        config["bot"][side]["risk"]["total_exposure_enforcer_enabled"] = False
+        config["bot"][side]["risk"]["total_exposure_entry_gate_enabled"] = True
+        config["bot"][side]["risk"]["we_excess_allowance_pct"] = 0.0
     return config
 
 
@@ -273,6 +294,35 @@ def test_gpu_foundation_fails_closed_for_unsupported_scope(mutate, message):
 
 def test_gpu_foundation_accepts_ema_long_single():
     assert _validate_scope(_long_only_ema_config(), _Evaluator()) == "bybit"
+
+
+@pytest.mark.parametrize(
+    ("long_enabled", "short_enabled"),
+    [(True, False), (False, True), (True, True)],
+)
+def test_gpu_foundation_accepts_each_directional_ema_mode(
+    long_enabled, short_enabled
+):
+    config = _directional_ema_config(
+        long_enabled=long_enabled, short_enabled=short_enabled
+    )
+
+    assert _validate_scope(config, _Evaluator()) == "bybit"
+
+
+def test_gpu_foundation_checks_unsupported_behavior_on_short_side():
+    config = _directional_ema_config(long_enabled=False, short_enabled=True)
+    config["bot"]["short"]["unstuck"]["enabled"] = True
+
+    with pytest.raises(ValueError, match=r"bot\.short\.unstuck"):
+        _validate_scope(config, _Evaluator())
+
+
+def test_gpu_foundation_rejects_both_sides_disabled():
+    config = _directional_ema_config(long_enabled=False, short_enabled=False)
+
+    with pytest.raises(ValueError, match="at least one enabled side"):
+        _validate_scope(config, _Evaluator())
 
 
 def test_gpu_foundation_honors_approved_coins_when_disabled_side_risk_is_nonzero():
@@ -507,6 +557,25 @@ def test_proxy_parameters_include_canonical_pinned_ema_values():
     assert parameters == [{"base_qty_pct": 0.25, "offset": 0.75}]
 
 
+def test_proxy_parameters_keep_directional_names_distinct():
+    from optimization.bounds import Bound
+
+    mapped = {
+        "long_offset": (0, Bound(0.0, 1.0, None)),
+        "short_offset": (1, Bound(0.0, 1.0, None)),
+    }
+    active = [
+        ("long_offset", 0, mapped["long_offset"][1]),
+        ("short_offset", 1, mapped["short_offset"][1]),
+    ]
+
+    parameters = _build_proxy_parameter_dicts(
+        [0.25, 0.5], mapped, active, np.array([[0.75, 0.125]])
+    )
+
+    assert parameters == [{"long_offset": 0.75, "short_offset": 0.125}]
+
+
 def test_gpu_rejects_pinned_unsupported_risk_behavior():
     from optimization.bounds import Bound
 
@@ -522,6 +591,53 @@ def test_gpu_rejects_pinned_unsupported_risk_behavior():
             {"long_risk_total_exposure_enforcer_threshold": 0.8},
         )
 
+
+def test_gpu_directional_search_space_keeps_side_enablement_fixed():
+    from optimization.bounds import Bound
+
+    approved = {"long": ["BTC"], "short": []}
+    base = {
+        "long_total_wallet_exposure_limit": 1.0,
+        "long_n_positions": 1.0,
+        "short_total_wallet_exposure_limit": 0.0,
+        "short_n_positions": 0.0,
+    }
+    bounds = {
+        "long_total_wallet_exposure_limit": Bound(0.5, 1.5, None),
+        "long_n_positions": Bound(1.0, 1.0, None),
+        "short_total_wallet_exposure_limit": Bound(0.0, 2.0, None),
+        "short_n_positions": Bound(0.0, 1.0, None),
+    }
+
+    _validate_directional_search_space(bounds, base, approved, {"long"})
+
+    bounds["long_total_wallet_exposure_limit"] = Bound(0.0, 1.5, None)
+    with pytest.raises(ValueError, match="remain positive"):
+        _validate_directional_search_space(bounds, base, approved, {"long"})
+
+    bounds["long_total_wallet_exposure_limit"] = Bound(0.5, 1.5, None)
+    bounds["long_n_positions"] = Bound(1.0, 2.0, None)
+    with pytest.raises(ValueError, match="pinned at 1"):
+        _validate_directional_search_space(bounds, base, approved, {"long"})
+
+
+def test_gpu_directional_search_space_rejects_disabled_approved_side_activation():
+    from optimization.bounds import Bound
+
+    bounds = {
+        "long_total_wallet_exposure_limit": Bound(0.5, 1.5, None),
+        "long_n_positions": Bound(1.0, 1.0, None),
+        "short_total_wallet_exposure_limit": Bound(0.0, 1.5, None),
+        "short_n_positions": Bound(0.0, 1.0, None),
+    }
+
+    with pytest.raises(ValueError, match="short enabledness"):
+        _validate_directional_search_space(
+            bounds,
+            {},
+            {"long": ["BTC"], "short": ["BTC"]},
+            {"long"},
+        )
 
 def test_constraint_classification_drift_detects_feasibility_disagreement():
     assert _constraint_classification_mismatch(0.0, {"G": np.array([0.1])})

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -51,8 +51,11 @@ def test_mps_ema_anchor_shader_smoke():
 
     source = passivbot_rust.mps_ema_anchor_source_py()
     assert "kernel void passivbot_ema_anchor" in source
-    assert "constant int SCALAR_COLS = 15" in source
-    assert "psize * price_now * c_mult / balance" in source
+    assert "constant int SCALAR_COLS = 18" in source
+    assert "side.psize * price_now * c_mult / balance" in source
+    assert "short_side.psize * c_mult * (short_side.pprice - close)" in source
+    assert "long_close_fill || long_entry_fill" in source
+    assert "short_close_fill || short_entry_fill" in source
     assert "fabs(adj) * cp * c_mult /" not in source
     assert "fabs(eq) * ep * c_mult /" not in source
     assert "fabs(adj) * cp / balance" in source
@@ -61,11 +64,11 @@ def test_mps_ema_anchor_shader_smoke():
     assert "rint(value / step)" not in source
     assert "int(ceil(price_now / price_step - 1.0e-6f))" in source
     assert "int(floor(price_now / price_step + 1.0e-6f))" in source
-    assert "float dd = fmax((run_peak - eqf)" in source
+    assert "(run_peak - eqf) / fmax(fabs(run_peak)" in source
     assert "fabs(raw_steps - nearest_count) <= 1.0e-8f" in source
     assert "if (current_cost_we >= cap" in source
     assert source.index("float eqf = liq ? liq_floor : equity") < source.index(
-        "float dd = fmax((run_peak - eqf)"
+        "(run_peak - eqf) / fmax(fabs(run_peak)"
     )
 
     count = 512
@@ -109,7 +112,7 @@ def test_mps_ema_anchor_shader_smoke():
         0.0,
         1.0,
     ]
-    parameters = np.array([row, row], dtype=np.float64)
+    parameters = np.array([row + row, row + row], dtype=np.float64)
 
     output = MpsEmaAnchorRunner(market, run, data).run(parameters)
     torch.mps.synchronize()
@@ -150,8 +153,9 @@ def test_mps_volume_uses_raw_non_positive_post_fill_balance():
         last_valid_idx=count - 1,
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
+    row = [1.0, 2.0, 3.0, 0.0, 0.0001, 0.0, 0.0, 0.0, 2.0, 2.0, 0.0, 1.0]
     parameters = np.array(
-        [[1.0, 2.0, 3.0, 0.0, 0.0001, 0.0, 0.0, 0.0, 2.0, 2.0, 0.0, 1.0]],
+        [row + row],
         dtype=np.float64,
     )
 
@@ -160,3 +164,84 @@ def test_mps_volume_uses_raw_non_positive_post_fill_balance():
 
     assert output["day_has_fill"].sum().item() > 0
     assert output["day_volume"].sum().item() < 0.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("hedge_mode", [False, True])
+def test_mps_dual_side_respects_one_way_initial_arbitration(hedge_mode):
+    count = 5
+    close = np.full(count, 100.0)
+    high = np.array([100.0, 100.0, 100.0, 102.0, 100.0])
+    low = np.array([100.0, 100.0, 100.0, 98.0, 100.0])
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(
+        qty_step=0.001,
+        price_step=0.01,
+        min_qty=0.001,
+        min_cost=5.0,
+        c_mult=1.0,
+        maker_fee=0.0002,
+    )
+    run = ProxyRun(
+        starting_balance=1_000.0,
+        warmup_bars=1,
+        trade_start_idx=1,
+        requested_start_ts_ms=int(timestamps[0]),
+        guard_ts_ms=int(timestamps[0]),
+        first_ts_ms=int(timestamps[0]),
+        interval_ms=60_000,
+        liquidation_threshold=0.05,
+        first_valid_idx=0,
+        last_valid_idx=count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = [0.1, 2.0, 3.0, 0.0, 0.01, 0.0, 0.0, 0.0, 2.0, 2.0, 0.0, 1.0]
+
+    output = MpsEmaAnchorRunner(
+        market,
+        run,
+        data,
+        long_enabled=True,
+        short_enabled=True,
+        hedge_mode=hedge_mode,
+    ).run(np.array([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert output["psize"].item() > 0.0
+    assert (output["short_psize"].item() > 0.0) is hedge_mode
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_short_only_opens_short_position():
+    count = 5
+    close = np.full(count, 100.0)
+    high = np.array([100.0, 100.0, 100.0, 102.0, 100.0])
+    low = np.full(count, 100.0)
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 5.0, 1.0, 0.0002)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = [0.1, 2.0, 3.0, 0.0, 0.01, 0.0, 0.0, 0.0, 2.0, 2.0, 0.0, 1.0]
+
+    output = MpsEmaAnchorRunner(
+        market, run, data, long_enabled=False, short_enabled=True
+    ).run(np.array([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert output["psize"].item() == 0.0
+    assert output["short_psize"].item() > 0.0

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -1,6 +1,6 @@
 import pytest
 
-from optimization.gpu.model import EMA_ANCHOR_PARAM_KEYS
+from optimization.gpu.model import EMA_ANCHOR_PARAM_KEYS, gpu_side_enabled
 from optimization.gpu.service import MpsEmaAnchorProxy, _require_complete_valid_tail
 
 
@@ -26,3 +26,20 @@ def test_directional_parameter_matrix_keeps_side_values_separate():
     offset_index = EMA_ANCHOR_PARAM_KEYS.index("offset")
     assert matrix[0, offset_index] == 0.125
     assert matrix[0, len(EMA_ANCHOR_PARAM_KEYS) + offset_index] == 0.25
+
+
+def test_gpu_side_enablement_uses_config_risk_not_per_coin_sentinel():
+    config = {
+        "bot": {
+            "long": {
+                "risk": {"total_wallet_exposure_limit": 1.0, "n_positions": 1}
+            },
+            "short": {
+                "risk": {"total_wallet_exposure_limit": 0.0, "n_positions": 0}
+            },
+        },
+        "live": {"approved_coins": {"long": ["BTC"], "short": ["BTC"]}},
+    }
+
+    assert gpu_side_enabled(config, "long")
+    assert not gpu_side_enabled(config, "short")

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -1,6 +1,7 @@
 import pytest
 
-from optimization.gpu.service import _require_complete_valid_tail
+from optimization.gpu.model import EMA_ANCHOR_PARAM_KEYS
+from optimization.gpu.service import MpsEmaAnchorProxy, _require_complete_valid_tail
 
 
 def test_gpu_proxy_requires_complete_valid_tail():
@@ -8,3 +9,20 @@ def test_gpu_proxy_requires_complete_valid_tail():
 
     with pytest.raises(ValueError, match="force-realizes open positions"):
         _require_complete_valid_tail(98, 100)
+
+
+def test_directional_parameter_matrix_keeps_side_values_separate():
+    proxy = MpsEmaAnchorProxy.__new__(MpsEmaAnchorProxy)
+    proxy.base_params = {
+        "long": {key: 1.0 for key in EMA_ANCHOR_PARAM_KEYS},
+        "short": {key: 2.0 for key in EMA_ANCHOR_PARAM_KEYS},
+    }
+
+    matrix = proxy._parameter_matrix(
+        [{"long_offset": 0.125, "short_offset": 0.25}]
+    )
+
+    assert matrix.shape == (1, 2 * len(EMA_ANCHOR_PARAM_KEYS))
+    offset_index = EMA_ANCHOR_PARAM_KEYS.index("offset")
+    assert matrix[0, offset_index] == 0.125
+    assert matrix[0, len(EMA_ANCHOR_PARAM_KEYS) + offset_index] == 0.25


### PR DESCRIPTION
## Summary

- extend the Apple MPS EMA-anchor screening proxy from long-only to short-only and long+short single-coin searches
- keep separate long/short EMA, volatility, position, order, and cooldown state while sharing the exact backtest balance/equity surface
- preserve Rust fill ordering (long close, long entry, short close, short entry) and both hedge-mode and one-way initial-side arbitration
- generalize directional bound packing and fail closed if either side can activate/deactivate inside the search space
- retain the unchanged exact Rust validator, durable result/Pareto path, feasibility gate, and broad-probe drift halt from #1493

This is PR 2 in the staged Apple M3 MPS series and builds on merged PR #1493. Trailing martingale, multi-coin, suites, HSL, unstuck, and forager-dependent selection remain explicitly unsupported.

## Validation

- `cargo test --no-default-features`: 258 passed
- `cargo check --tests` and `cargo fmt --check`
- Rust extension rebuilt through the stamped repository utility; runtime and source fingerprints matched
- selected optimizer/config suite: 475 passed, 5 skipped
- active M3 MPS tests: 6 passed
- cached BTC end-to-end exact-validation smokes:
  - short-only: 224 proxy screens, 4 exact validations, completed
  - dual one-way: 224 proxy screens, 4 exact validations, completed
  - dual hedge: 96 proxy screens, 2 exact validations, completed
- drift-gated cached BTC runs, each with 16 exact checks and 8 independent probes:
  - short-only Spearman: 0.997 overall, 1.000 probes
  - dual one-way Spearman: 0.982 overall, 1.000 probes
  - no drift or feasibility halt

## Safety boundary

Normal CPU bot, backtest, and optimizer paths remain unchanged and do not import Torch. Only exact Rust results are persisted; GPU output remains a screening signal.