### PR TITLE
Add trailing-martingale Apple MPS screening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@ All notable user-facing changes will be documented in this file.
 ## Unreleased
 
 - Add an experimental, purely additive Apple Silicon MPS optimizer backend for single-coin,
-  EMA-anchor searches in long-only, short-only, and long+short modes. Large NSGA-II populations
-  run through a Rust-owned Metal screening program and feed feasible, diverse candidates into the
-  unchanged exact Rust backtester; only exact results reach the Pareto store, and independent
-  broad-probe rank checks halt on proxy drift. Dual-side screening preserves separate EMA/position
-  state, a shared balance, Rust fill ordering, and hedge/one-way initial-side semantics. Unsupported
-  strategies, suites, multi-coin, HSL, auto-unstuck, collateral,
+  EMA-anchor and trailing-martingale searches in long-only, short-only, and long+short modes.
+  Large NSGA-II populations run through strategy-specific Rust-owned Metal screening programs and
+  feed feasible, diverse candidates into the unchanged exact Rust backtester; only exact results
+  reach the Pareto store, and independent broad-probe rank checks halt on proxy drift. Dual-side
+  screening preserves separate indicator/trailing/position state, a shared balance, Rust fill
+  ordering, and hedge/one-way initial-side semantics. Other strategies, suites, multi-coin, HSL,
+  auto-unstuck, collateral,
   minimum-effective-cost filtering, market-order execution, incomplete candle tails, non-inert
   fixed runtime overrides, and unmodeled risk gates fail closed. Proxy/exact optimizer-limit
   feasibility disagreement also halts immediately. Existing CPU bot, backtest, and optimizer paths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ All notable user-facing changes will be documented in this file.
   feed feasible, diverse candidates into the unchanged exact Rust backtester; only exact results
   reach the Pareto store, and independent broad-probe rank checks halt on proxy drift. Dual-side
   screening preserves separate indicator/trailing/position state, a shared balance, Rust fill
-  ordering, and hedge/one-way initial-side semantics. Other strategies, suites, multi-coin, HSL,
-  auto-unstuck, collateral,
+  ordering, and hedge/one-way initial-side semantics. Recursive trailing-martingale grid modes,
+  other strategies, suites, multi-coin, HSL, auto-unstuck, collateral,
   minimum-effective-cost filtering, market-order execution, incomplete candle tails, non-inert
   fixed runtime overrides, and unmodeled risk gates fail closed. Proxy/exact optimizer-limit
   feasibility disagreement also halts immediately. Existing CPU bot, backtest, and optimizer paths

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -661,8 +661,9 @@ Risk should be constrained through canonical `*_strategy_eq` metrics instead. De
 - **pareto_max_size**: Maximum number of Pareto-optimal configs kept on disk under `optimize_results/.../pareto/`. Members are pruned by crowding (least diverse removed first, while per-objective extremes are preserved), not by age. Default is `1000`.
 - **population_size**: Size of population for genetic optimization algorithm. With the default `pymoo` backend, `null` means auto: NSGA-II resolves to `250`, while NSGA-III resolves to a default population budget of `500` and chooses the finest auto reference-direction grid that fits inside that budget. Set an explicit integer to change the NSGA-III per-generation evaluation budget and auto reference-direction coarseness.
 - **backend**: Optimizer backend. Default is `pymoo`. Supported values are `deap`, `pymoo`, and
-  experimental `gpu`. The GPU backend currently supports Apple MPS, single-coin EMA-anchor
-  long-only runs; see `docs/optimizing.md` for its fail-closed scope and `optimize.gpu` settings.
+  experimental `gpu`. The GPU backend currently supports Apple MPS, single-coin EMA-anchor and
+  trailing-martingale runs in long-only, short-only, and long+short modes; see
+  `docs/optimizing.md` for its fail-closed scope and `optimize.gpu` settings.
   With the default `optimize.pymoo.algorithm: "auto"`, Passivbot uses `nsga2` for `3` or fewer
   objectives and `nsga3` for `4+`.
 - **round_to_n_significant_digits**: Quantization precision used when hashing configs, deduplicating candidates, and writing optimizer artifacts. Lower values collapse near-identical candidates more aggressively; higher values preserve more distinct variants.

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -103,6 +103,8 @@ The supported slice is intentionally narrow:
 - one exchange and one coin, using one-minute candles
 - `strategy_kind: ema_anchor` or `trailing_martingale`, with long-only, short-only, or
   long+short enabled
+- trailing-martingale entry and close `retracement_base_pct` optimizer bounds strictly above zero;
+  zero or negative values select recursive grid ladders that this screening slice does not model
 - each enabled side's `n_positions` pinned to `1` and wallet-exposure limit kept positive
 - hedge mode and one-way mode; one-way flat-side arbitration uses the active strategy's Rust rule
 - suite mode disabled
@@ -113,8 +115,9 @@ The supported slice is intentionally narrow:
 - `live.market_orders_allowed: false`
 - no invalid candle tail after the selected coin's final valid candle
 
-Unsupported combinations fail before optimization begins. Multi-coin, suites, HSL, auto-unstuck,
-and forager-dependent selection are not silently approximated by this release.
+Unsupported combinations fail before optimization begins. Recursive trailing-martingale grid
+modes, multi-coin, suites, HSL, auto-unstuck, and forager-dependent selection are not silently
+approximated by this release.
 
 Proxy scoring and limits are likewise fail-closed. This slice supports `adg_strategy_eq`,
 `adg_strategy_eq_w`, `mdg_strategy_eq`, `sharpe_ratio_strategy_eq`,

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -97,13 +97,14 @@ python3 -m pip install -e ".[full,gpu-mps]"
 Select it with `--backend gpu` or `optimize.backend: "gpu"`. Normal live operation, backtesting,
 and the DEAP/pymoo CPU optimizers do not import or require PyTorch.
 
-The first supported slice is intentionally narrow:
+The supported slice is intentionally narrow:
 
 - Apple Silicon with `torch.backends.mps.is_available()`
 - one exchange and one coin, using one-minute candles
-- `strategy_kind: ema_anchor`, with long-only, short-only, or long+short enabled
+- `strategy_kind: ema_anchor` or `trailing_martingale`, with long-only, short-only, or
+  long+short enabled
 - each enabled side's `n_positions` pinned to `1` and wallet-exposure limit kept positive
-- hedge mode and one-way mode; one-way flat-side arbitration matches the Rust EMA-band rule
+- hedge mode and one-way mode; one-way flat-side arbitration uses the active strategy's Rust rule
 - suite mode disabled
 - HSL and auto-unstuck disabled
 - BTC collateral, coin overrides, realized-loss gating, exposure enforcers, and non-inert fixed
@@ -112,8 +113,8 @@ The first supported slice is intentionally narrow:
 - `live.market_orders_allowed: false`
 - no invalid candle tail after the selected coin's final valid candle
 
-Unsupported combinations fail before optimization begins. Trailing-martingale, multi-coin, suites,
-HSL, auto-unstuck, and forager-dependent selection are not silently approximated by this release.
+Unsupported combinations fail before optimization begins. Multi-coin, suites, HSL, auto-unstuck,
+and forager-dependent selection are not silently approximated by this release.
 
 Proxy scoring and limits are likewise fail-closed. This slice supports `adg_strategy_eq`,
 `adg_strategy_eq_w`, `mdg_strategy_eq`, `sharpe_ratio_strategy_eq`,
@@ -127,8 +128,9 @@ The backend is hybrid rather than a replacement backtester:
 
 1. pymoo NSGA-II proposes large normalized candidate batches.
 2. A Rust-owned Metal screening program evaluates every candidate against candle data resident on
-   MPS; Python only prepares buffers and dispatches the program. Directional runs use separate
-   long/short EMA and position state with one shared balance and the exact Rust fill ordering.
+   MPS; Python only prepares buffers and dispatches the program. EMA-anchor and
+   trailing-martingale use separate kernels. Directional runs keep separate long/short indicator,
+   trailing, and position state with one shared balance and the exact Rust fill ordering.
 3. Diverse proxy-front candidates and broad drift probes are sent to the unchanged Rust backtester.
 4. Only exact Rust results enter `all_results.bin` and the persisted Pareto front.
 5. A rolling Spearman rank gate independently stops the run if broad proxy/exact probe agreement

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -5,9 +5,15 @@
 //! dispatches this source through the optional Apple MPS backend.
 
 pub const MPS_EMA_ANCHOR_SOURCE: &str = include_str!("gpu/mps_ema_anchor_directional.metal");
+pub const MPS_TRAILING_MARTINGALE_SOURCE: &str =
+    include_str!("gpu/mps_trailing_martingale_directional.metal");
 
 pub fn mps_ema_anchor_source() -> &'static str {
     MPS_EMA_ANCHOR_SOURCE
+}
+
+pub fn mps_trailing_martingale_source() -> &'static str {
+    MPS_TRAILING_MARTINGALE_SOURCE
 }
 
 #[cfg(test)]
@@ -22,5 +28,18 @@ mod tests {
         assert!(source.contains("constant int SCALAR_COLS = 18"));
         assert!(source.contains("generate_short_orders"));
         assert!(source.contains("const bool hedge_mode"));
+    }
+
+    #[test]
+    fn trailing_martingale_mps_source_exposes_expected_kernel_contract() {
+        let source = mps_trailing_martingale_source();
+        assert!(source.contains("kernel void passivbot_trailing_martingale"));
+        assert!(source.contains("constant int SIDE_PARAMS = 27"));
+        assert!(source.contains("min_since_open"));
+        assert!(source.contains("max_since_min"));
+        assert!(source.contains("max_since_open"));
+        assert!(source.contains("min_since_max"));
+        assert!(source.contains("if (we_if <= s.twel * 1.01f) return qty"));
+        assert!(source.contains("s.twel * balance - cost"));
     }
 }

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -1,0 +1,680 @@
+#include <metal_stdlib>
+using namespace metal;
+
+constant int DAILY_COLS = 5;
+constant int SCALAR_COLS = 18;
+constant int GAP_BINS = 128;
+constant int SIDE_PARAMS = 27;
+
+inline float round_step(float value, float step) {
+    return floor(value / step + 0.5f) * step;
+}
+
+inline float ceil_step(float value, float step) {
+    return ceil(value / step - 1.0e-6f) * step;
+}
+
+inline float floor_step(float value, float step) {
+    return floor(value / step + 1.0e-6f) * step;
+}
+
+inline float min_entry_qty(
+    float price, float qty_step, float min_qty, float min_cost, float c_mult
+) {
+    float raw_min = fmax(min_qty, min_cost / fmax(price, 1.0e-12f) / c_mult);
+    float raw_steps = raw_min / qty_step;
+    float nearest_count = floor(raw_steps + 0.5f);
+    float nearest = nearest_count * qty_step;
+    float representation_tolerance = 1.1920928955078125e-7f
+        * fmax(fabs(raw_min), fabs(nearest)) * 4.0f;
+    bool aligned = nearest_count > 0.0f && fabs(raw_steps - nearest_count) <= 1.0e-8f
+        && (nearest >= raw_min || raw_min - nearest <= representation_tolerance);
+    return aligned ? fmax(nearest, raw_min) : ceil(raw_steps) * qty_step;
+}
+
+struct TmSide {
+    float alpha0, alpha1, alpha2, alpha1m, alpha1h;
+    float ddf, initial_ema_dist, initial_qty_pct;
+    float entry_threshold_base, entry_threshold_we;
+    float entry_threshold_v1h, entry_threshold_v1m;
+    float entry_retracement_base, entry_retracement_we;
+    float entry_retracement_v1h, entry_retracement_v1m;
+    float close_qty_pct, close_threshold_base, close_threshold_we;
+    float close_threshold_v1h, close_threshold_v1m;
+    float close_retracement_base, close_retracement_v1h, close_retracement_v1m;
+    float cooldown_min, twel;
+    bool gate_initial, gate_reentry;
+    float ema0, ema1, ema2, vol1m, vol1h;
+    float psize, pprice, last_inc_k, pos_open_k;
+    int entry_ticks, close_ticks;
+    float entry_qty, close_qty;
+    float min_since_open, max_since_min, max_since_open, min_since_max;
+};
+
+inline TmSide load_side(constant float* p, int o, float seed) {
+    TmSide s;
+    float span0 = p[o + 0], span1 = p[o + 1], span2 = sqrt(span0 * span1);
+    float lo = fmin(span0, fmin(span1, span2));
+    float hi = fmax(span0, fmax(span1, span2));
+    float mid = span0 + span1 + span2 - lo - hi;
+    s.alpha0 = clamp(2.0f / (lo + 1.0f), 0.0f, 1.0f);
+    s.alpha1 = clamp(2.0f / (mid + 1.0f), 0.0f, 1.0f);
+    s.alpha2 = clamp(2.0f / (hi + 1.0f), 0.0f, 1.0f);
+    s.alpha1h = p[o + 2] > 0.0f ? 2.0f / (fmax(p[o + 2], 1.0f) + 1.0f) : 0.0f;
+    s.alpha1m = p[o + 3] > 0.0f ? clamp(2.0f / (p[o + 3] + 1.0f), 0.0f, 1.0f) : 0.0f;
+    s.ddf = p[o + 4];
+    s.initial_ema_dist = p[o + 5];
+    s.initial_qty_pct = p[o + 6];
+    s.entry_threshold_base = p[o + 7];
+    s.entry_threshold_we = p[o + 8];
+    s.entry_threshold_v1h = p[o + 9];
+    s.entry_threshold_v1m = p[o + 10];
+    s.entry_retracement_base = p[o + 11];
+    s.entry_retracement_we = p[o + 12];
+    s.entry_retracement_v1h = p[o + 13];
+    s.entry_retracement_v1m = p[o + 14];
+    s.close_qty_pct = p[o + 15];
+    s.close_threshold_base = p[o + 16];
+    s.close_threshold_we = p[o + 17];
+    s.close_threshold_v1h = p[o + 18];
+    s.close_threshold_v1m = p[o + 19];
+    s.close_retracement_base = p[o + 20];
+    s.close_retracement_v1h = p[o + 21];
+    s.close_retracement_v1m = p[o + 22];
+    s.cooldown_min = ceil(p[o + 23]);
+    s.twel = p[o + 24];
+    s.gate_initial = p[o + 25] > 0.5f;
+    s.gate_reentry = p[o + 26] > 0.5f;
+    s.ema0 = seed; s.ema1 = seed; s.ema2 = seed;
+    s.vol1m = 0.0f; s.vol1h = 0.0f;
+    s.psize = 0.0f; s.pprice = 0.0f;
+    s.last_inc_k = -1.0f; s.pos_open_k = -1.0f;
+    s.entry_ticks = 0; s.entry_qty = 0.0f;
+    s.close_ticks = 0; s.close_qty = 0.0f;
+    s.min_since_open = INFINITY; s.max_since_min = 0.0f;
+    s.max_since_open = 0.0f; s.min_since_max = INFINITY;
+    return s;
+}
+
+inline void update_indicators(
+    thread TmSide& s, float close, float lr, float hour_lr, bool valid, bool hour_valid
+) {
+    if (hour_valid && s.alpha1h > 0.0f)
+        s.vol1h = s.alpha1h * hour_lr + (1.0f - s.alpha1h) * s.vol1h;
+    if (valid) {
+        s.ema0 = s.alpha0 * close + (1.0f - s.alpha0) * s.ema0;
+        s.ema1 = s.alpha1 * close + (1.0f - s.alpha1) * s.ema1;
+        s.ema2 = s.alpha2 * close + (1.0f - s.alpha2) * s.ema2;
+        if (s.alpha1m > 0.0f)
+            s.vol1m = s.alpha1m * lr + (1.0f - s.alpha1m) * s.vol1m;
+    }
+}
+
+inline void update_trailing(
+    thread TmSide& s, float high, float low, float close, bool valid, bool filled
+) {
+    if (!valid || s.psize <= 0.0f) return;
+    if (filled) {
+        s.min_since_open = INFINITY; s.max_since_min = 0.0f;
+        s.max_since_open = 0.0f; s.min_since_max = INFINITY;
+    } else {
+        if (low < s.min_since_open) {
+            s.min_since_open = low; s.max_since_min = close;
+        } else s.max_since_min = fmax(s.max_since_min, high);
+        if (high > s.max_since_open) {
+            s.max_since_open = high; s.min_since_max = close;
+        } else s.min_since_max = fmin(s.min_since_max, low);
+    }
+}
+
+inline int directional_ticks(float price, float step, bool up) {
+    return up ? int(ceil(price / step - 1.0e-6f))
+              : int(floor(price / step + 1.0e-6f));
+}
+
+inline int touch_clamp(int target, int touch, bool up) {
+    return up ? max(target, touch) : min(target, touch);
+}
+
+inline float crop_entry(
+    thread TmSide& s, float balance, float price, float qty,
+    float qty_step, float min_qty, float min_cost, float c_mult
+) {
+    if (qty <= 0.0f) return 0.0f;
+    float cost = s.psize * s.pprice * c_mult;
+    float we_if = (cost + qty * price * c_mult) / fmax(balance, 1.0e-9f);
+    if (we_if <= s.twel * 1.01f) return qty;
+    float q = round_step(
+        (s.twel * balance - cost) / fmax(price * c_mult, 1.0e-12f), qty_step
+    );
+    float mq = min_entry_qty(price, qty_step, min_qty, min_cost, c_mult);
+    q = fmax(q, mq);
+    return q < qty ? q : qty;
+}
+
+inline float calc_close_qty(
+    thread TmSide& s, float balance, float price, float pct,
+    float qty_step, float min_qty, float min_cost, float c_mult
+) {
+    float mq = min_entry_qty(price, qty_step, min_qty, min_cost, c_mult);
+    float full = balance * s.twel / fmax(s.pprice * c_mult, 1.0e-12f);
+    float qty = fmin(
+        round_step(s.psize, qty_step),
+        fmax(mq, ceil_step(full * pct + fmax(s.psize - full, 0.0f), qty_step))
+    );
+    if (qty > 0.0f && qty < s.psize && s.psize - qty < mq) qty = s.psize;
+    if (s.psize < mq * (1.0f - 1.0e-6f) && qty > 0.0f) qty = s.psize;
+    else if (qty > 0.0f && qty * (1.0f + 1.0e-6f) < mq) qty = 0.0f;
+    return qty;
+}
+
+inline void generate_orders(
+    thread TmSide& s, bool is_long, float balance, float price_now,
+    float qty_step, float price_step, float min_qty, float min_cost, float c_mult,
+    float kf, bool block_initial
+) {
+    bool entry_up = !is_long;
+    bool close_up = is_long;
+    float band = is_long ? fmin(s.ema0, fmin(s.ema1, s.ema2))
+                         : fmax(s.ema0, fmax(s.ema1, s.ema2));
+    int entry_touch = directional_ticks(price_now, price_step, entry_up);
+    int band_ticks = directional_ticks(
+        band * (is_long ? 1.0f - s.initial_ema_dist
+                        : 1.0f + s.initial_ema_dist),
+        price_step, entry_up
+    );
+    int initial_ticks = s.gate_initial
+        ? touch_clamp(band_ticks, entry_touch, entry_up) : entry_touch;
+    float initial_price = float(initial_ticks) * price_step;
+    float min_iq = min_entry_qty(initial_price, qty_step, min_qty, min_cost, c_mult);
+    float iq = fmax(min_iq, round_step(
+        balance * s.twel * s.initial_qty_pct
+            / fmax(initial_price * c_mult, 1.0e-12f), qty_step
+    ));
+    bool flat = s.psize <= 0.0f;
+    bool partial = !flat && s.psize < iq * 0.8f;
+    float iq_partial = fmax(min_iq, floor_step(iq - s.psize, qty_step));
+    float iq_effective = !flat && s.psize < iq
+        ? fmax(round_step(s.psize, qty_step), min_iq) : iq;
+    float we = !flat && balance > 0.0f
+        ? s.psize * s.pprice * c_mult / balance : 0.0f;
+    float wer = we / fmax(s.twel, 1.0e-12f);
+    float tm = fmax(
+        1.0f + s.vol1h * s.entry_threshold_v1h
+            + s.vol1m * s.entry_threshold_v1m + wer * s.entry_threshold_we,
+        1.0f
+    );
+    float rm = fmax(
+        1.0f + s.vol1h * s.entry_retracement_v1h
+            + s.vol1m * s.entry_retracement_v1m + wer * s.entry_retracement_we,
+        1.0f
+    );
+    float threshold = fmax(s.entry_threshold_base, 0.0f) * tm;
+    float retracement = fmax(s.entry_retracement_base, 0.0f) * rm;
+    bool trailing_entry = s.entry_retracement_base > 0.0f;
+    bool retraced_entry = is_long
+        ? s.max_since_min > s.min_since_open * (1.0f + retracement)
+        : s.min_since_max < s.max_since_open * (1.0f - retracement);
+    bool crossed_entry = is_long
+        ? s.min_since_open < s.pprice * (1.0f - threshold)
+        : s.max_since_open > s.pprice * (1.0f + threshold);
+    bool entry_triggered = true;
+    float reentry_target = s.pprice * (
+        is_long ? 1.0f - s.entry_threshold_base * tm
+                : 1.0f + s.entry_threshold_base * tm
+    );
+    if (trailing_entry) {
+        if (threshold <= 0.0f) {
+            entry_triggered = retracement > 0.0f && retraced_entry;
+            reentry_target = price_now;
+        } else if (retracement <= 0.0f) {
+            reentry_target = s.pprice * (is_long ? 1.0f - threshold : 1.0f + threshold);
+        } else {
+            entry_triggered = crossed_entry && retraced_entry;
+            reentry_target = s.pprice * (
+                is_long ? 1.0f - threshold + retracement
+                        : 1.0f + threshold - retracement
+            );
+        }
+    }
+    int reentry_ticks = touch_clamp(
+        directional_ticks(reentry_target, price_step, entry_up), entry_touch, entry_up
+    );
+    if (s.gate_reentry)
+        reentry_ticks = touch_clamp(band_ticks, reentry_ticks, entry_up);
+    float reentry_price = float(reentry_ticks) * price_step;
+    float min_rq = min_entry_qty(reentry_price, qty_step, min_qty, min_cost, c_mult);
+    float rq = fmax(iq_effective, fmax(min_rq, round_step(
+        fmax(
+            s.psize * s.ddf,
+            balance * s.twel * s.initial_qty_pct
+                / fmax(reentry_price * c_mult, 1.0e-12f)
+        ), qty_step
+    )));
+    float we_if = (s.psize * s.pprice + rq * reentry_price)
+        * c_mult / fmax(balance, 1.0e-9f);
+    float crop_fraction = (s.twel - we) / fmax(we_if - we, 1.0e-12f);
+    float rq_crop = fmax(round_step(rq * crop_fraction, qty_step), min_rq);
+    if (we_if > s.twel * 1.01f && rq_crop < rq) rq = rq_crop;
+    bool cap_hit = trailing_entry ? we > s.twel * 0.999f : we >= s.twel * 0.999f;
+    bool reentry_ok = !flat && !partial && !cap_hit && reentry_ticks > 1
+        && (!trailing_entry || entry_triggered);
+    float eqty = flat ? iq : (partial ? iq_partial : (reentry_ok ? rq : 0.0f));
+    int eticks = flat || partial ? initial_ticks : reentry_ticks;
+    bool cooldown = s.cooldown_min > 0.0f && s.last_inc_k >= 0.0f
+        && kf < s.last_inc_k + s.cooldown_min;
+    if (cooldown || balance <= 0.0f || s.initial_qty_pct <= 0.0f
+        || s.twel <= 0.0f || eticks <= 1 || (block_initial && flat)) eqty = 0.0f;
+    s.entry_ticks = eticks;
+    s.entry_qty = crop_entry(
+        s, balance, float(eticks) * price_step, eqty,
+        qty_step, min_qty, min_cost, c_mult
+    );
+
+    float ct = s.close_threshold_base + wer * s.close_threshold_we
+        + s.vol1h * s.close_threshold_v1h + s.vol1m * s.close_threshold_v1m;
+    float cr = fmax(s.close_retracement_base, 0.0f) * fmax(
+        1.0f + s.vol1h * s.close_retracement_v1h
+            + s.vol1m * s.close_retracement_v1m,
+        1.0f
+    );
+    bool trailing_close = s.close_retracement_base > 0.0f;
+    bool retraced_close = is_long
+        ? s.min_since_max < s.max_since_open * (1.0f - cr)
+        : s.max_since_min > s.min_since_open * (1.0f + cr);
+    bool crossed_close = is_long
+        ? s.max_since_open > s.pprice * (1.0f + ct)
+        : s.min_since_open < s.pprice * (1.0f - ct);
+    bool close_triggered = true;
+    float close_target = s.pprice * (is_long ? 1.0f + ct : 1.0f - ct);
+    if (trailing_close) {
+        if (ct <= 0.0f) {
+            close_triggered = cr > 0.0f && retraced_close;
+            close_target = price_now;
+        } else if (cr > 0.0f) {
+            close_triggered = crossed_close && retraced_close;
+            close_target = s.pprice * (
+                is_long ? 1.0f + ct - cr : 1.0f - ct + cr
+            );
+        }
+    }
+    int close_touch = directional_ticks(price_now, price_step, close_up);
+    int cticks = touch_clamp(
+        directional_ticks(close_target, price_step, close_up), close_touch, close_up
+    );
+    float close_price = float(cticks) * price_step;
+    float pct = trailing_close ? s.close_qty_pct
+        : (s.close_threshold_we == 0.0f ? 1.0f : s.close_qty_pct);
+    s.close_ticks = cticks;
+    s.close_qty = s.psize > 0.0f && close_price > 0.0f
+            && (!trailing_close || close_triggered)
+        ? calc_close_qty(
+            s, balance, close_price, pct, qty_step, min_qty, min_cost, c_mult
+        ) : 0.0f;
+}
+
+inline void generate_long_orders(
+    thread TmSide& s, float balance, float price_now, float qty_step,
+    float price_step, float min_qty, float min_cost, float c_mult,
+    float kf, bool block_initial
+) {
+    generate_orders(
+        s, true, balance, price_now, qty_step, price_step, min_qty, min_cost,
+        c_mult, kf, block_initial
+    );
+}
+
+inline void generate_short_orders(
+    thread TmSide& s, float balance, float price_now, float qty_step,
+    float price_step, float min_qty, float min_cost, float c_mult,
+    float kf, bool block_initial
+) {
+    generate_orders(
+        s, false, balance, price_now, qty_step, price_step, min_qty, min_cost,
+        c_mult, kf, block_initial
+    );
+}
+
+inline void passivbot_single_coin_impl(
+    constant float* bars,
+    constant int* flags,
+    constant float* params,
+    constant float* settings,
+    constant int* sizes,
+    device float* daily,
+    device float* scalars,
+    device int* gap_hist,
+    uint b
+) {
+    const int B = sizes[0];
+    const int T = sizes[1];
+    const int D = sizes[2];
+    const int P = sizes[3];
+    const int first_valid = sizes[4];
+    if (b >= uint(B)) return;
+
+    const float qty_step = settings[0];
+    const float price_step = settings[1];
+    const float min_qty = settings[2];
+    const float min_cost = settings[3];
+    const float c_mult = settings[4];
+    const float maker_fee = settings[5];
+    const float starting_balance = settings[6];
+    const float liq_floor = settings[7];
+    const float interval_ms = settings[8];
+    const bool long_enabled = settings[9] > 0.5f;
+    const bool short_enabled = settings[10] > 0.5f;
+    const bool hedge_mode = settings[11] > 0.5f;
+    const float log_bin_scale = 127.0f / log(4000001.0f);
+
+    const int po = int(b) * P;
+    const int seed_k = clamp(first_valid, 0, T - 1);
+    const float seed_close = bars[seed_k * 5 + 2];
+    TmSide long_side = load_side(params, po, seed_close);
+    TmSide short_side = load_side(params, po + SIDE_PARAMS, seed_close);
+
+    float balance = starting_balance;
+    bool alive = true;
+    int liq_day = -1;
+    float held_max_min = 0.0f;
+    float last_fill_k = -1.0f;
+    float first_fill_k = -1.0f;
+    float gap_max_min = 0.0f;
+    float run_peak = -INFINITY;
+    float max_dd = 0.0f;
+    float last_high_k = -1.0f;
+    float recovery_max_min = 0.0f;
+    float first_eq_k = -1.0f;
+    float last_eq_k = -1.0f;
+    bool eq_started = false;
+
+    int cur_day = flags[2];
+    bool day_touched = false;
+    float day_end = 0.0f;
+    float day_min = INFINITY;
+    float day_dd = 0.0f;
+    float day_volume = 0.0f;
+    float day_has_fill = 0.0f;
+
+    for (int j = 0; j < GAP_BINS; ++j) {
+        gap_hist[int(b) * GAP_BINS + j] = 0;
+    }
+
+    for (int k = 1; k < T - 1; ++k) {
+        const int bo = k * 5;
+        const int fo = k * 4;
+        const float high = bars[bo + 0];
+        const float low = bars[bo + 1];
+        const float close = bars[bo + 2];
+        const float log_range = bars[bo + 3];
+        const float hour_lr = bars[bo + 4];
+        const bool valid = flags[fo + 0] != 0;
+        const bool can_gen = flags[fo + 1] != 0;
+        const int di = flags[fo + 2];
+        const bool hour_valid = flags[fo + 3] != 0;
+        const float kf = float(k);
+
+        if (di != cur_day) {
+            if (day_touched && cur_day >= 0 && cur_day < D) {
+                int o = (int(b) * D + cur_day) * DAILY_COLS;
+                daily[o + 0] = day_end;
+                daily[o + 1] = day_min;
+                daily[o + 2] = day_dd;
+                daily[o + 3] = day_volume;
+                daily[o + 4] = day_has_fill;
+            }
+            cur_day = di;
+            day_touched = false;
+            day_end = 0.0f;
+            day_min = INFINITY;
+            day_dd = 0.0f;
+            day_volume = 0.0f;
+            day_has_fill = 0.0f;
+        }
+
+        bool long_close_fill = valid && alive && long_enabled
+            && long_side.close_qty > 0.0f && long_side.psize > 0.0f
+            && high > float(long_side.close_ticks) * price_step;
+        if (long_close_fill) {
+            float cp = float(long_side.close_ticks) * price_step;
+            float adj = fmin(round_step(long_side.close_qty, qty_step), long_side.psize);
+            float pnl = adj * c_mult * (cp - long_side.pprice);
+            balance += pnl - adj * cp * c_mult * maker_fee;
+            float new_psize = fmax(round_step(long_side.psize - adj, qty_step), 0.0f);
+            bool went_flat = new_psize <= 0.0f;
+            long_side.psize = new_psize;
+            if (went_flat) {
+                long_side.pprice = 0.0f;
+                if (long_side.pos_open_k >= 0.0f) {
+                    held_max_min = fmax(held_max_min, kf - long_side.pos_open_k);
+                }
+                long_side.pos_open_k = -1.0f;
+            }
+            day_volume += fabs(adj) * cp / balance;
+            long_side.close_qty = 0.0f;
+        }
+
+        bool long_entry_fill = valid && alive && long_enabled
+            && long_side.entry_qty > 0.0f
+            && low < float(long_side.entry_ticks) * price_step;
+        if (long_entry_fill) {
+            float ep = float(long_side.entry_ticks) * price_step;
+            float eq = round_step(long_side.entry_qty, qty_step);
+            balance -= eq * ep * c_mult * maker_fee;
+            bool was_flat = long_side.psize <= 0.0f;
+            float new_psize = round_step(long_side.psize + eq, qty_step);
+            float new_pprice = was_flat ? ep
+                : long_side.pprice * (long_side.psize / fmax(new_psize, 1.0e-12f))
+                    + ep * (eq / fmax(new_psize, 1.0e-12f));
+            if (was_flat) long_side.pos_open_k = kf;
+            long_side.psize = new_psize;
+            long_side.pprice = new_pprice;
+            long_side.last_inc_k = kf;
+            day_volume += fabs(eq) * ep / balance;
+            long_side.entry_qty = 0.0f;
+        }
+
+        bool short_close_fill = valid && alive && short_enabled
+            && short_side.close_qty > 0.0f && short_side.psize > 0.0f
+            && low < float(short_side.close_ticks) * price_step;
+        if (short_close_fill) {
+            float cp = float(short_side.close_ticks) * price_step;
+            float adj = fmin(round_step(short_side.close_qty, qty_step), short_side.psize);
+            float pnl = adj * c_mult * (short_side.pprice - cp);
+            balance += pnl - adj * cp * c_mult * maker_fee;
+            float new_psize = fmax(round_step(short_side.psize - adj, qty_step), 0.0f);
+            bool went_flat = new_psize <= 0.0f;
+            short_side.psize = new_psize;
+            if (went_flat) {
+                short_side.pprice = 0.0f;
+                if (short_side.pos_open_k >= 0.0f) {
+                    held_max_min = fmax(held_max_min, kf - short_side.pos_open_k);
+                }
+                short_side.pos_open_k = -1.0f;
+            }
+            day_volume += fabs(adj) * cp / balance;
+            short_side.close_qty = 0.0f;
+        }
+
+        bool short_entry_fill = valid && alive && short_enabled
+            && short_side.entry_qty > 0.0f
+            && high > float(short_side.entry_ticks) * price_step;
+        if (short_entry_fill) {
+            float ep = float(short_side.entry_ticks) * price_step;
+            float eq = round_step(short_side.entry_qty, qty_step);
+            balance -= eq * ep * c_mult * maker_fee;
+            bool was_flat = short_side.psize <= 0.0f;
+            float new_psize = round_step(short_side.psize + eq, qty_step);
+            float new_pprice = was_flat ? ep
+                : short_side.pprice * (short_side.psize / fmax(new_psize, 1.0e-12f))
+                    + ep * (eq / fmax(new_psize, 1.0e-12f));
+            if (was_flat) short_side.pos_open_k = kf;
+            short_side.psize = new_psize;
+            short_side.pprice = new_pprice;
+            short_side.last_inc_k = kf;
+            day_volume += fabs(eq) * ep / balance;
+            short_side.entry_qty = 0.0f;
+        }
+
+        bool any_fill = long_close_fill || long_entry_fill
+            || short_close_fill || short_entry_fill;
+        if (any_fill) {
+            day_has_fill = 1.0f;
+            day_touched = true;
+            if (last_fill_k >= 0.0f) {
+                float gap = kf - last_fill_k;
+                int bin = clamp(
+                    int(log(fmax(gap, 0.0f) + 1.0f) * log_bin_scale), 0, 127
+                );
+                gap_hist[int(b) * GAP_BINS + bin] += 1;
+                gap_max_min = fmax(gap_max_min, gap);
+            }
+            if (first_fill_k < 0.0f) first_fill_k = kf;
+            last_fill_k = kf;
+        }
+
+        if (long_enabled) {
+            update_indicators(long_side, close, log_range, hour_lr, valid, hour_valid);
+        }
+        if (short_enabled) {
+            update_indicators(short_side, close, log_range, hour_lr, valid, hour_valid);
+        }
+        if (long_enabled) {
+            update_trailing(
+                long_side, high, low, close, valid,
+                long_close_fill || long_entry_fill
+            );
+        }
+        if (short_enabled) {
+            update_trailing(
+                short_side, high, low, close, valid,
+                short_close_fill || short_entry_fill
+            );
+        }
+
+        bool gen = can_gen && alive;
+        eq_started = eq_started || gen;
+        if (gen) {
+            bool block_long_initial = false;
+            bool block_short_initial = false;
+            if (long_enabled && short_enabled && !hedge_mode) {
+                if (long_side.psize > 0.0f) {
+                    block_short_initial = true;
+                } else if (short_side.psize > 0.0f) {
+                    block_long_initial = true;
+                } else {
+                    float long_lower = fmin(
+                        long_side.ema0, fmin(long_side.ema1, long_side.ema2)
+                    );
+                    float short_upper = fmax(
+                        short_side.ema0, fmax(short_side.ema1, short_side.ema2)
+                    );
+                    float dist_long = long_lower
+                        * (1.0f - long_side.initial_ema_dist) / close - 1.0f;
+                    float dist_short = 1.0f - short_upper
+                        * (1.0f + short_side.initial_ema_dist) / close;
+                    if (dist_long >= dist_short) {
+                        block_short_initial = true;
+                    } else {
+                        block_long_initial = true;
+                    }
+                }
+            }
+            if (long_enabled) {
+                generate_long_orders(
+                    long_side, balance, close, qty_step, price_step, min_qty,
+                    min_cost, c_mult, kf, block_long_initial
+                );
+            }
+            if (short_enabled) {
+                generate_short_orders(
+                    short_side, balance, close, qty_step, price_step, min_qty,
+                    min_cost, c_mult, kf, block_short_initial
+                );
+            }
+        }
+
+        float long_unreal = long_side.psize > 0.0f
+            ? long_side.psize * c_mult * (close - long_side.pprice) : 0.0f;
+        float short_unreal = short_side.psize > 0.0f
+            ? short_side.psize * c_mult * (short_side.pprice - close) : 0.0f;
+        float equity = balance + long_unreal + short_unreal;
+        bool active = eq_started && alive && valid;
+        if (active) {
+            if (first_eq_k < 0.0f) first_eq_k = kf;
+            last_eq_k = kf;
+            bool liq = balance <= 0.0f || equity <= liq_floor;
+            float eqf = liq ? liq_floor : equity;
+            if (eqf > run_peak) {
+                if (last_high_k >= 0.0f) {
+                    recovery_max_min = fmax(recovery_max_min, kf - last_high_k);
+                }
+                last_high_k = kf;
+                run_peak = eqf;
+            }
+            float dd = fmax(
+                (run_peak - eqf) / fmax(fabs(run_peak), 1.0e-12f), 0.0f
+            );
+            max_dd = fmax(max_dd, dd);
+            day_end = eqf;
+            day_min = fmin(day_min, eqf);
+            day_dd = fmax(day_dd, dd);
+            day_touched = true;
+            if (liq) {
+                liq_day = di;
+                alive = false;
+            }
+        }
+    }
+
+    if (day_touched && cur_day >= 0 && cur_day < D) {
+        int o = (int(b) * D + cur_day) * DAILY_COLS;
+        daily[o + 0] = day_end;
+        daily[o + 1] = day_min;
+        daily[o + 2] = day_dd;
+        daily[o + 3] = day_volume;
+        daily[o + 4] = day_has_fill;
+    }
+
+    if (long_side.pos_open_k >= 0.0f && last_eq_k >= 0.0f) {
+        held_max_min = fmax(held_max_min, last_eq_k - long_side.pos_open_k);
+    }
+    if (short_side.pos_open_k >= 0.0f && last_eq_k >= 0.0f) {
+        held_max_min = fmax(held_max_min, last_eq_k - short_side.pos_open_k);
+    }
+    int so = int(b) * SCALAR_COLS;
+    scalars[so + 0] = max_dd;
+    scalars[so + 1] = held_max_min * interval_ms;
+    scalars[so + 2] = gap_max_min * interval_ms;
+    scalars[so + 3] = first_fill_k >= 0.0f ? first_fill_k * interval_ms : -1.0f;
+    scalars[so + 4] = last_fill_k >= 0.0f ? last_fill_k * interval_ms : -1.0f;
+    scalars[so + 5] = recovery_max_min * interval_ms;
+    scalars[so + 6] = last_high_k >= 0.0f ? last_high_k * interval_ms : -1.0f;
+    scalars[so + 7] = first_eq_k >= 0.0f ? first_eq_k * interval_ms : -1.0f;
+    scalars[so + 8] = last_eq_k >= 0.0f ? last_eq_k * interval_ms : -1.0f;
+    scalars[so + 9] = float(liq_day);
+    scalars[so + 10] = balance;
+    scalars[so + 11] = long_side.psize;
+    scalars[so + 12] = long_side.pprice;
+    scalars[so + 13] = alive ? 1.0f : 0.0f;
+    scalars[so + 14] = long_side.psize > 0.0f || short_side.psize > 0.0f ? 1.0f : 0.0f;
+    scalars[so + 15] = short_side.psize;
+    scalars[so + 16] = short_side.pprice;
+    scalars[so + 17] = 0.0f;
+}
+
+kernel void passivbot_trailing_martingale(
+    constant float* bars,
+    constant int* flags,
+    constant float* params,
+    constant float* settings,
+    constant int* sizes,
+    device float* daily,
+    device float* scalars,
+    device int* gap_hist,
+    uint b [[thread_position_in_grid]]
+) {
+    passivbot_single_coin_impl(
+        bars, flags, params, settings, sizes, daily, scalars, gap_hist, b
+    );
+}

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -132,6 +132,10 @@ inline int directional_ticks(float price, float step, bool up) {
               : int(floor(price / step + 1.0e-6f));
 }
 
+inline int nearest_ticks(float price, float step) {
+    return int(floor(price / step + 0.5f));
+}
+
 inline int touch_clamp(int target, int touch, bool up) {
     return up ? max(target, touch) : min(target, touch);
 }
@@ -298,10 +302,11 @@ inline void generate_orders(
             );
         }
     }
-    int close_touch = directional_ticks(price_now, price_step, close_up);
-    int cticks = touch_clamp(
-        directional_ticks(close_target, price_step, close_up), close_touch, close_up
-    );
+    int target_ticks = directional_ticks(close_target, price_step, close_up);
+    float rounded_target = float(target_ticks) * price_step;
+    bool touch_controls = (trailing_close && ct <= 0.0f) || (close_up
+        ? price_now > rounded_target : price_now < rounded_target);
+    int cticks = touch_controls ? nearest_ticks(price_now, price_step) : target_ticks;
     float close_price = float(cticks) * price_step;
     float pct = trailing_close ? s.close_qty_pct
         : (s.close_threshold_we == 0.0f ? 1.0f : s.close_qty_pct);

--- a/passivbot-rust/src/lib.rs
+++ b/passivbot-rust/src/lib.rs
@@ -38,6 +38,11 @@ fn mps_ema_anchor_source_py() -> &'static str {
     gpu::mps_ema_anchor_source()
 }
 
+#[pyfunction]
+fn mps_trailing_martingale_source_py() -> &'static str {
+    gpu::mps_trailing_martingale_source()
+}
+
 /// A Python module implemented in Rust.
 #[pymodule]
 fn passivbot_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -46,6 +51,7 @@ fn passivbot_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<EquityHardStopRuntimePy>()?;
     m.add_function(wrap_pyfunction!(runtime_build_info, m)?)?;
     m.add_function(wrap_pyfunction!(mps_ema_anchor_source_py, m)?)?;
+    m.add_function(wrap_pyfunction!(mps_trailing_martingale_source_py, m)?)?;
     m.add_function(wrap_pyfunction!(round_, m)?)?;
     m.add_function(wrap_pyfunction!(round_up, m)?)?;
     m.add_function(wrap_pyfunction!(round_dn, m)?)?;

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -65,6 +65,45 @@ EMA_BOUND_MAP = {
     for bound_suffix, parameter in _EMA_SIDE_BOUND_SUFFIXES.items()
 }
 
+_TM_SIDE_BOUND_SUFFIXES = {
+    "ema_span_0": "ema_span_0",
+    "ema_span_1": "ema_span_1",
+    "volatility_ema_span_1h": "volatility_ema_span_1h",
+    "volatility_ema_span_1m": "volatility_ema_span_1m",
+    "entry_double_down_factor": "entry_double_down_factor",
+    "entry_initial_ema_dist": "entry_initial_ema_dist",
+    "entry_initial_qty_pct": "entry_initial_qty_pct",
+    "entry_threshold_base_pct": "entry_threshold_base_pct",
+    "entry_threshold_we_weight": "entry_threshold_we_weight",
+    "entry_threshold_volatility_1h_weight": "entry_threshold_volatility_1h_weight",
+    "entry_threshold_volatility_1m_weight": "entry_threshold_volatility_1m_weight",
+    "entry_retracement_base_pct": "entry_retracement_base_pct",
+    "entry_retracement_we_weight": "entry_retracement_we_weight",
+    "entry_retracement_volatility_1h_weight": "entry_retracement_volatility_1h_weight",
+    "entry_retracement_volatility_1m_weight": "entry_retracement_volatility_1m_weight",
+    "close_qty_pct": "close_qty_pct",
+    "close_threshold_base_pct": "close_threshold_base_pct",
+    "close_threshold_we_weight": "close_threshold_we_weight",
+    "close_threshold_volatility_1h_weight": "close_threshold_volatility_1h_weight",
+    "close_threshold_volatility_1m_weight": "close_threshold_volatility_1m_weight",
+    "close_retracement_base_pct": "close_retracement_base_pct",
+    "close_retracement_volatility_1h_weight": "close_retracement_volatility_1h_weight",
+    "close_retracement_volatility_1m_weight": "close_retracement_volatility_1m_weight",
+    "risk_entry_cooldown_minutes": "entry_cooldown_minutes",
+    "total_wallet_exposure_limit": "total_wallet_exposure_limit",
+}
+
+TRAILING_MARTINGALE_BOUND_MAP = {
+    f"{side}_{bound_suffix}": f"{side}_{parameter}"
+    for side in ("long", "short")
+    for bound_suffix, parameter in _TM_SIDE_BOUND_SUFFIXES.items()
+}
+
+GPU_STRATEGY_BOUND_MAPS = {
+    "ema_anchor": EMA_BOUND_MAP,
+    "trailing_martingale": TRAILING_MARTINGALE_BOUND_MAP,
+}
+
 
 def _build_gpu_nsga2(config, *, sampling, population_size: int, n_params: int):
     """Build GPU proposal evolution with the same variation controls as pymoo CPU."""
@@ -287,10 +326,13 @@ def _validate_scope(config: dict, evaluator) -> str:
             "GPU foundation supports exactly one coin; "
             f"prepared {int(hlcvs.shape[1])}"
         )
-    strategy_kind = str(config.get("live", {}).get("strategy_kind", "")).lower()
-    if "ema_anchor" not in strategy_kind:
+    strategy_kind = (
+        str(config.get("live", {}).get("strategy_kind", "")).strip().lower()
+    )
+    if strategy_kind not in GPU_STRATEGY_BOUND_MAPS:
         raise ValueError(
-            "GPU foundation supports strategy_kind=ema_anchor only; "
+            "GPU foundation supports strategy_kind=ema_anchor or "
+            "trailing_martingale only; "
             f"got {strategy_kind!r}"
         )
     enabled_sides = [side for side in ("long", "short") if gpu_side_enabled(config, side)]
@@ -652,7 +694,7 @@ def _canonical_vector_hash(vector, bounds, sig_digits: int) -> str:
 
 
 def _build_proxy_parameter_dicts(base_vector, mapped, active, active_values) -> list[dict]:
-    """Include canonical pinned and active EMA values in every proxy candidate."""
+    """Include canonical pinned and active strategy values in each proxy candidate."""
 
     base_parameters = {
         name: float(base_vector[index]) for name, (index, _bound) in mapped.items()
@@ -854,7 +896,7 @@ def run_backend(
     from config.metrics import canonicalize_metric_name
     from config.scoring import extract_objective_specs
     from optimization.gpu.metrics import SUPPORTED_METRICS
-    from optimization.gpu.service import MpsEmaAnchorProxy
+    from optimization.gpu.service import MpsSingleCoinProxy
 
     exchange = _validate_scope(config, evaluator)
     options = _resolve_options(config)
@@ -880,14 +922,19 @@ def run_backend(
         )
     base_vector = [float(value) for value in template_vectors[0]]
 
+    strategy_kind = str(config["live"]["strategy_kind"]).strip().lower()
+    bound_map = GPU_STRATEGY_BOUND_MAPS[strategy_kind]
+
     mapped_all = {
-        EMA_BOUND_MAP[bound_key]: (index, bounds[index])
+        bound_map[bound_key]: (index, bounds[index])
         for index, (bound_key, _path) in enumerate(key_paths)
-        if bound_key in EMA_BOUND_MAP
+        if bound_key in bound_map
     }
-    missing = sorted(set(EMA_BOUND_MAP.values()) - set(mapped_all))
+    missing = sorted(set(bound_map.values()) - set(mapped_all))
     if missing:
-        raise ValueError(f"GPU backend could not locate EMA bounds for {missing}")
+        raise ValueError(
+            f"GPU backend could not locate {strategy_kind} bounds for {missing}"
+        )
     approved = config.get("live", {}).get("approved_coins", {})
 
     def side_approved(side: str) -> bool:
@@ -931,7 +978,9 @@ def run_backend(
         if bound.high > bound.low
     ]
     if not active:
-        raise ValueError("GPU backend found no free EMA-anchor dimensions")
+        raise ValueError(
+            f"GPU backend found no free {strategy_kind} dimensions"
+        )
 
     bound_by_key = {
         bound_key: bounds[index] for index, (bound_key, _path) in enumerate(key_paths)
@@ -966,7 +1015,7 @@ def run_backend(
             continue
         if bound_key in {f"{side}_n_positions" for side in enabled_sides}:
             continue
-        if bound_key not in EMA_BOUND_MAP:
+        if bound_key not in bound_map:
             raise ValueError(
                 "GPU foundation cannot optimize active bound "
                 f"{bound_key!r}; pin it or use the CPU optimizer"
@@ -986,7 +1035,7 @@ def run_backend(
             "use supported metrics or the CPU optimizer"
         )
 
-    proxy = MpsEmaAnchorProxy(
+    proxy = MpsSingleCoinProxy(
         config=config,
         hlcvs=evaluator.shared_hlcvs_np[exchange],
         mss=evaluator.msss[exchange],

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -105,6 +105,23 @@ GPU_STRATEGY_BOUND_MAPS = {
 }
 
 
+def _validate_trailing_martingale_mode_bounds(bound_by_key, enabled_sides) -> None:
+    """Reject recursive grid modes until the proxy models their full ladders."""
+
+    for side in enabled_sides:
+        for mode in ("entry", "close"):
+            key = f"{side}_{mode}_retracement_base_pct"
+            bound = bound_by_key[key]
+            if float(bound.low) <= 0.0:
+                raise ValueError(
+                    "GPU trailing_martingale requires "
+                    f"bot.{side}.strategy.trailing_martingale.{mode}."
+                    "retracement_base_pct bounds to stay strictly positive; "
+                    "zero or negative values select recursive grid ladders that "
+                    "the screening proxy does not model"
+                )
+
+
 def _build_gpu_nsga2(config, *, sampling, population_size: int, n_params: int):
     """Build GPU proposal evolution with the same variation controls as pymoo CPU."""
 
@@ -989,6 +1006,8 @@ def run_backend(
         bound_key: float(base_vector[index])
         for index, (bound_key, _path) in enumerate(key_paths)
     }
+    if strategy_kind == "trailing_martingale":
+        _validate_trailing_martingale_mode_bounds(bound_by_key, enabled_sides)
     _validate_pinned_scope_bounds(bound_by_key, base_by_key, enabled_sides)
 
     _validate_directional_search_space(

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -24,6 +24,101 @@ EMA_ANCHOR_PARAM_KEYS = (
     "total_wallet_exposure_limit",
 )
 
+TRAILING_MARTINGALE_PARAM_KEYS = (
+    "ema_span_0",
+    "ema_span_1",
+    "volatility_ema_span_1h",
+    "volatility_ema_span_1m",
+    "entry_double_down_factor",
+    "entry_initial_ema_dist",
+    "entry_initial_qty_pct",
+    "entry_threshold_base_pct",
+    "entry_threshold_we_weight",
+    "entry_threshold_volatility_1h_weight",
+    "entry_threshold_volatility_1m_weight",
+    "entry_retracement_base_pct",
+    "entry_retracement_we_weight",
+    "entry_retracement_volatility_1h_weight",
+    "entry_retracement_volatility_1m_weight",
+    "close_qty_pct",
+    "close_threshold_base_pct",
+    "close_threshold_we_weight",
+    "close_threshold_volatility_1h_weight",
+    "close_threshold_volatility_1m_weight",
+    "close_retracement_base_pct",
+    "close_retracement_volatility_1h_weight",
+    "close_retracement_volatility_1m_weight",
+    "entry_cooldown_minutes",
+    "total_wallet_exposure_limit",
+    "gate_initial",
+    "gate_reentry",
+)
+
+GPU_STRATEGY_PARAM_KEYS = {
+    "ema_anchor": EMA_ANCHOR_PARAM_KEYS,
+    "trailing_martingale": TRAILING_MARTINGALE_PARAM_KEYS,
+}
+
+
+def flatten_trailing_martingale_params(strategy: dict, risk: dict) -> dict:
+    """Flatten Rust's nested TM payload into the Metal row contract."""
+
+    entry = strategy.get("entry", {})
+    close = strategy.get("close", {})
+    mode = str(entry.get("ema_gate_mode", "all")).strip().lower()
+    if mode not in {"disabled", "all", "initial", "reentry"}:
+        raise ValueError(f"unsupported trailing_martingale entry.ema_gate_mode={mode!r}")
+    flattened = {
+        "ema_span_0": strategy.get("ema_span_0"),
+        "ema_span_1": strategy.get("ema_span_1"),
+        "volatility_ema_span_1h": strategy.get("volatility_ema_span_1h"),
+        "volatility_ema_span_1m": strategy.get("volatility_ema_span_1m"),
+        "entry_cooldown_minutes": float(
+            risk.get("entry_cooldown_minutes", 0.0) or 0.0
+        ),
+        "total_wallet_exposure_limit": float(
+            risk["total_wallet_exposure_limit"]
+        ),
+        "gate_initial": float(mode in {"all", "initial"}),
+        "gate_reentry": float(mode in {"all", "reentry"}),
+    }
+    for prefix, values, keys in (
+        (
+            "entry",
+            entry,
+            (
+                "double_down_factor",
+                "initial_ema_dist",
+                "initial_qty_pct",
+                "threshold_base_pct",
+                "threshold_we_weight",
+                "threshold_volatility_1h_weight",
+                "threshold_volatility_1m_weight",
+                "retracement_base_pct",
+                "retracement_we_weight",
+                "retracement_volatility_1h_weight",
+                "retracement_volatility_1m_weight",
+            ),
+        ),
+        (
+            "close",
+            close,
+            (
+                "qty_pct",
+                "threshold_base_pct",
+                "threshold_we_weight",
+                "threshold_volatility_1h_weight",
+                "threshold_volatility_1m_weight",
+                "retracement_base_pct",
+                "retracement_volatility_1h_weight",
+                "retracement_volatility_1m_weight",
+            ),
+        ),
+    ):
+        for key in keys:
+            flattened[f"{prefix}_{key}"] = values.get(key)
+    return {key: flattened[key] for key in TRAILING_MARTINGALE_PARAM_KEYS}
+
 
 def gpu_side_enabled(config: dict, side: str) -> bool:
     """Match Rust/backtest global side eligibility, including approved coins."""

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -11,6 +11,7 @@ from optimization.gpu.model import (
     GAP_BINS,
     ProxyMarket,
     ProxyRun,
+    TRAILING_MARTINGALE_PARAM_KEYS,
 )
 
 
@@ -25,6 +26,17 @@ def _shader_library():
     import passivbot_rust
 
     return torch.mps.compile_shader(passivbot_rust.mps_ema_anchor_source_py())
+
+
+@lru_cache(maxsize=1)
+def _trailing_martingale_shader_library():
+    if not torch.backends.mps.is_available():
+        raise RuntimeError("Apple MPS is not available in this process")
+    import passivbot_rust
+
+    return torch.mps.compile_shader(
+        passivbot_rust.mps_trailing_martingale_source_py()
+    )
 
 
 class MpsEmaAnchorRunner:
@@ -186,6 +198,108 @@ class MpsEmaAnchorRunner:
             "kernel_seconds": finished - dispatched,
         }
         active_days = torch.isfinite(daily[:, :, 1]) & (daily[:, :, 1] < float("inf"))
+
+        def timestamp_column(index: int):
+            values = scalars[:, index]
+            return torch.where(
+                values >= 0.0, values, torch.full_like(values, float("nan"))
+            )
+
+        return {
+            "day_end_eq": daily[:, :, 0],
+            "day_min_eq": torch.where(
+                active_days,
+                daily[:, :, 1],
+                torch.full_like(daily[:, :, 1], float("inf")),
+            ),
+            "day_max_dd": daily[:, :, 2],
+            "day_volume": daily[:, :, 3],
+            "day_has_fill": daily[:, :, 4] > 0.0,
+            "max_dd": scalars[:, 0],
+            "held_max_ms": scalars[:, 1],
+            "gap_hist": gaps,
+            "gap_max_ms": scalars[:, 2],
+            "first_fill_ts": timestamp_column(3),
+            "last_fill_ts": timestamp_column(4),
+            "recovery_max_ms": scalars[:, 5],
+            "last_high_ts": timestamp_column(6),
+            "first_eq_ts": timestamp_column(7),
+            "last_eq_ts": timestamp_column(8),
+            "liq_step": scalars[:, 9].to(torch.int64),
+            "balance": scalars[:, 10],
+            "psize": scalars[:, 11],
+            "pprice": scalars[:, 12],
+            "alive": scalars[:, 13] > 0.0,
+            "short_psize": scalars[:, 15],
+            "short_pprice": scalars[:, 16],
+        }
+
+
+class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
+    """Persistent single-coin trailing-martingale runner on Apple MPS."""
+
+    def _pack_params(self, params: np.ndarray) -> np.ndarray:
+        expected = len(TRAILING_MARTINGALE_PARAM_KEYS) * 2
+        if params.ndim != 2 or params.shape[1] != expected:
+            got = params.shape[1] if params.ndim == 2 else params.shape
+            raise ValueError(
+                "expected directional trailing-martingale parameter matrix with "
+                f"{expected} columns, got {got}"
+            )
+        return np.ascontiguousarray(params, dtype=np.float32)
+
+    def run(self, params: np.ndarray, *, profile: bool = False) -> dict:
+        started = time.perf_counter()
+        matrix = self._pack_params(params)
+        packed = time.perf_counter()
+        params_mps = torch.as_tensor(matrix, device="mps")
+        batch_size = int(matrix.shape[0])
+        daily, scalars, gaps = self._output_buffers(batch_size)
+        sizes_key = (batch_size, int(matrix.shape[1]))
+        if sizes_key not in self._sizes:
+            self._sizes[sizes_key] = torch.tensor(
+                [
+                    batch_size,
+                    self.n,
+                    self.n_days,
+                    matrix.shape[1],
+                    self.run_config.first_valid_idx,
+                ],
+                dtype=torch.int32,
+                device="mps",
+            )
+        prepared = time.perf_counter()
+        library = _trailing_martingale_shader_library()
+        compiled = time.perf_counter()
+        if profile:
+            torch.mps.synchronize()
+            dispatched = time.perf_counter()
+        else:
+            dispatched = compiled
+        library.passivbot_trailing_martingale(
+            self.bars,
+            self.flags,
+            params_mps,
+            self.settings,
+            self._sizes[sizes_key],
+            daily,
+            scalars,
+            gaps,
+            threads=(batch_size, 1, 1),
+        )
+        if profile:
+            torch.mps.synchronize()
+        finished = time.perf_counter()
+        self.last_profile = {
+            "cpu_pack_seconds": packed - started,
+            "upload_and_zero_seconds": prepared - packed,
+            "compile_seconds": compiled - prepared,
+            "pre_dispatch_sync_seconds": dispatched - compiled,
+            "kernel_seconds": finished - dispatched,
+        }
+        active_days = torch.isfinite(daily[:, :, 1]) & (
+            daily[:, :, 1] < float("inf")
+        )
 
         def timestamp_column(index: int):
             values = scalars[:, index]

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -6,10 +6,11 @@ import os
 import numpy as np
 
 from optimization.gpu.model import (
-    EMA_ANCHOR_PARAM_KEYS,
+    GPU_STRATEGY_PARAM_KEYS,
     ProxyMarket,
     ProxyRun,
     build_mps_data,
+    flatten_trailing_martingale_params,
     gpu_side_enabled,
 )
 
@@ -43,8 +44,8 @@ def _require_complete_valid_tail(last_valid_idx: int, candle_count: int) -> None
         )
 
 
-class MpsEmaAnchorProxy:
-    """Batched single-coin directional EMA-anchor screening proxy."""
+class MpsSingleCoinProxy:
+    """Batched directional screening proxy for supported single-coin strategies."""
 
     def __init__(
         self,
@@ -74,7 +75,10 @@ class MpsEmaAnchorProxy:
 
         from backtest import build_backtest_payload
         from optimization.gpu.metrics import compute_objectives
-        from optimization.gpu.mps_kernel import MpsEmaAnchorRunner
+        from optimization.gpu.mps_kernel import (
+            MpsEmaAnchorRunner,
+            MpsTrailingMartingaleRunner,
+        )
 
         self._torch = torch
         self._compute_objectives = compute_objectives
@@ -88,6 +92,15 @@ class MpsEmaAnchorProxy:
             "yes",
             "y",
         }
+        self.strategy_kind = str(
+            config.get("live", {}).get("strategy_kind", "")
+        ).strip().lower()
+        if self.strategy_kind not in GPU_STRATEGY_PARAM_KEYS:
+            raise ValueError(
+                "MPS single-coin proxy supports ema_anchor or "
+                f"trailing_martingale, got {self.strategy_kind!r}"
+            )
+        self.param_keys = GPU_STRATEGY_PARAM_KEYS[self.strategy_kind]
 
         payload = build_backtest_payload(
             np.ascontiguousarray(hlcvs),
@@ -130,16 +143,20 @@ class MpsEmaAnchorProxy:
                 raise ValueError(f"GPU foundation requires bot.{side}.hsl.enabled=false")
             strategy = dict(payload.strategy_params_list[0][side])
             risk = config["bot"][side]["risk"]
-            strategy["entry_cooldown_minutes"] = float(
-                risk.get("entry_cooldown_minutes", 0.0) or 0.0
-            )
-            strategy["total_wallet_exposure_limit"] = float(
-                risk["total_wallet_exposure_limit"]
-            )
-            missing = [key for key in EMA_ANCHOR_PARAM_KEYS if key not in strategy]
+            if self.strategy_kind == "trailing_martingale":
+                strategy = flatten_trailing_martingale_params(strategy, risk)
+            else:
+                strategy["entry_cooldown_minutes"] = float(
+                    risk.get("entry_cooldown_minutes", 0.0) or 0.0
+                )
+                strategy["total_wallet_exposure_limit"] = float(
+                    risk["total_wallet_exposure_limit"]
+                )
+            missing = [key for key in self.param_keys if key not in strategy]
             if missing:
                 raise ValueError(
-                    f"GPU EMA payload for {side} is missing parameters: {missing}"
+                    f"GPU {self.strategy_kind} payload for {side} is missing "
+                    f"parameters: {missing}"
                 )
             self.base_params[side] = strategy
 
@@ -180,7 +197,12 @@ class MpsEmaAnchorProxy:
         close = hlcvs[:, 0, 2].astype(np.float64)
         self.data = build_mps_data(high, low, close, timestamps, self.run, self.market)
         self.metrics_data = {"ts0": self.data["ts0"], "n": self.data["n"]}
-        self.runner = MpsEmaAnchorRunner(
+        runner_cls = (
+            MpsTrailingMartingaleRunner
+            if self.strategy_kind == "trailing_martingale"
+            else MpsEmaAnchorRunner
+        )
+        self.runner = runner_cls(
             self.market,
             self.run,
             self.data,
@@ -202,7 +224,7 @@ class MpsEmaAnchorProxy:
                         if key.startswith(f"{side}_")
                     }
                 )
-                row.extend(float(merged[key]) for key in EMA_ANCHOR_PARAM_KEYS)
+                row.extend(float(merged[key]) for key in self.param_keys)
             rows.append(row)
         return np.asarray(rows, dtype=np.float64)
 
@@ -246,3 +268,7 @@ class MpsEmaAnchorProxy:
                 for index in range(len(chunk))
             )
         return results
+
+
+# Compatibility name retained for downstream imports from the EMA foundation PR.
+MpsEmaAnchorProxy = MpsSingleCoinProxy

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -29,6 +29,7 @@ from optimization.backends.gpu_backend import (
     _validate_pinned_scope_bounds,
     _validate_seed_side_match,
     _validate_scope,
+    TRAILING_MARTINGALE_BOUND_MAP,
 )
 
 
@@ -72,6 +73,14 @@ def _directional_ema_config(*, long_enabled: bool, short_enabled: bool):
         config["bot"][side]["risk"]["total_exposure_enforcer_enabled"] = False
         config["bot"][side]["risk"]["total_exposure_entry_gate_enabled"] = True
         config["bot"][side]["risk"]["we_excess_allowance_pct"] = 0.0
+    return config
+
+
+def _directional_tm_config(*, long_enabled: bool, short_enabled: bool):
+    config = _directional_ema_config(
+        long_enabled=long_enabled, short_enabled=short_enabled
+    )
+    config["live"]["strategy_kind"] = "trailing_martingale"
     return config
 
 
@@ -153,6 +162,42 @@ def test_gpu_nsga2_uses_configured_pymoo_variation_operators():
     assert type(algorithm.eliminate_duplicates).__name__ == "NoDuplicateElimination"
 
 
+def test_trailing_martingale_bound_map_covers_both_directional_shapes():
+    expected_suffixes = {
+        "ema_span_0",
+        "ema_span_1",
+        "volatility_ema_span_1h",
+        "volatility_ema_span_1m",
+        "entry_double_down_factor",
+        "entry_initial_ema_dist",
+        "entry_initial_qty_pct",
+        "entry_threshold_base_pct",
+        "entry_threshold_we_weight",
+        "entry_threshold_volatility_1h_weight",
+        "entry_threshold_volatility_1m_weight",
+        "entry_retracement_base_pct",
+        "entry_retracement_we_weight",
+        "entry_retracement_volatility_1h_weight",
+        "entry_retracement_volatility_1m_weight",
+        "close_qty_pct",
+        "close_threshold_base_pct",
+        "close_threshold_we_weight",
+        "close_threshold_volatility_1h_weight",
+        "close_threshold_volatility_1m_weight",
+        "close_retracement_base_pct",
+        "close_retracement_volatility_1h_weight",
+        "close_retracement_volatility_1m_weight",
+        "risk_entry_cooldown_minutes",
+        "total_wallet_exposure_limit",
+    }
+
+    assert set(TRAILING_MARTINGALE_BOUND_MAP) == {
+        f"{side}_{suffix}"
+        for side in ("long", "short")
+        for suffix in expected_suffixes
+    }
+
+
 def test_cpu_backend_registry_import_does_not_import_torch():
     script = (
         "import json, sys; import optimization.backends; "
@@ -221,9 +266,9 @@ def test_single_scenario_metric_surface_supports_all_reducers():
         ),
         (
             lambda config: config["live"].__setitem__(
-                "strategy_kind", "trailing_martingale"
+                "strategy_kind", "trailing_grid_v7"
             ),
-            "ema_anchor",
+            "trailing_martingale",
         ),
         (
             lambda config: config["bot"]["long"]["hsl"].__setitem__("enabled", True),
@@ -305,6 +350,20 @@ def test_gpu_foundation_accepts_each_directional_ema_mode(
     long_enabled, short_enabled
 ):
     config = _directional_ema_config(
+        long_enabled=long_enabled, short_enabled=short_enabled
+    )
+
+    assert _validate_scope(config, _Evaluator()) == "bybit"
+
+
+@pytest.mark.parametrize(
+    ("long_enabled", "short_enabled"),
+    [(True, False), (False, True), (True, True)],
+)
+def test_gpu_foundation_accepts_each_directional_trailing_martingale_mode(
+    long_enabled, short_enabled
+):
+    config = _directional_tm_config(
         long_enabled=long_enabled, short_enabled=short_enabled
     )
 

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 
 from config.schema import get_template_config
+from optimization.bounds import Bound
 from optimization.backends.gpu_backend import (
     _canonical_candidate_values,
     _canonical_vector_hash,
@@ -29,6 +30,7 @@ from optimization.backends.gpu_backend import (
     _validate_pinned_scope_bounds,
     _validate_seed_side_match,
     _validate_scope,
+    _validate_trailing_martingale_mode_bounds,
     TRAILING_MARTINGALE_BOUND_MAP,
 )
 
@@ -196,6 +198,20 @@ def test_trailing_martingale_bound_map_covers_both_directional_shapes():
         for side in ("long", "short")
         for suffix in expected_suffixes
     }
+
+
+def test_trailing_martingale_gpu_rejects_recursive_grid_mode_bounds():
+    bounds = {
+        f"{side}_{mode}_retracement_base_pct": Bound(0.0001, 0.01, 0.0001)
+        for side in ("long", "short")
+        for mode in ("entry", "close")
+    }
+
+    _validate_trailing_martingale_mode_bounds(bounds, {"long", "short"})
+    bounds["short_close_retracement_base_pct"] = Bound(0.0, 0.01, 0.0001)
+
+    with pytest.raises(ValueError, match="recursive grid ladders"):
+        _validate_trailing_martingale_mode_bounds(bounds, {"long", "short"})
 
 
 def test_cpu_backend_registry_import_does_not_import_torch():

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -245,3 +245,183 @@ def test_mps_short_only_opens_short_position():
 
     assert output["psize"].item() == 0.0
     assert output["short_psize"].item() > 0.0
+
+
+def _tm_row(*, initial_ema_dist=0.01, gate_initial=1.0, gate_reentry=1.0):
+    return [
+        2.0,  # ema_span_0
+        3.0,  # ema_span_1
+        2.0,  # volatility_ema_span_1h
+        2.0,  # volatility_ema_span_1m
+        1.0,  # entry_double_down_factor
+        initial_ema_dist,
+        0.1,  # entry_initial_qty_pct
+        0.01,  # entry_threshold_base_pct
+        0.0,  # entry_threshold_we_weight
+        0.0,  # entry_threshold_volatility_1h_weight
+        0.0,  # entry_threshold_volatility_1m_weight
+        0.001,  # entry_retracement_base_pct
+        0.0,  # entry_retracement_we_weight
+        0.0,  # entry_retracement_volatility_1h_weight
+        0.0,  # entry_retracement_volatility_1m_weight
+        1.0,  # close_qty_pct
+        0.01,  # close_threshold_base_pct
+        0.0,  # close_threshold_we_weight
+        0.0,  # close_threshold_volatility_1h_weight
+        0.0,  # close_threshold_volatility_1m_weight
+        0.001,  # close_retracement_base_pct
+        0.0,  # close_retracement_volatility_1h_weight
+        0.0,  # close_retracement_volatility_1m_weight
+        0.0,  # entry_cooldown_minutes
+        1.0,  # total_wallet_exposure_limit
+        gate_initial,
+        gate_reentry,
+    ]
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize(
+    ("long_enabled", "short_enabled"),
+    [(True, False), (False, True), (True, True)],
+)
+def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
+    long_enabled, short_enabled
+):
+    import passivbot_rust
+    from optimization.gpu.mps_kernel import MpsTrailingMartingaleRunner
+
+    source = passivbot_rust.mps_trailing_martingale_source_py()
+    assert "kernel void passivbot_trailing_martingale" in source
+    assert "constant int SIDE_PARAMS = 27" in source
+    assert "min_since_open" in source
+    assert "max_since_min" in source
+    assert "max_since_open" in source
+    assert "min_since_max" in source
+    assert "s.entry_retracement_base > 0.0f" in source
+    assert "s.close_retracement_base > 0.0f" in source
+
+    count = 8
+    close = np.full(count, 100.0)
+    high = np.array([100.0, 100.0, 100.0, 102.0, 102.0, 103.0, 102.0, 100.0])
+    low = np.array([100.0, 100.0, 100.0, 98.0, 98.0, 97.0, 98.0, 100.0])
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 5.0, 1.0, 0.0002)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_row()
+
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=long_enabled,
+        short_enabled=short_enabled,
+        hedge_mode=True,
+    ).run(np.array([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert output["day_has_fill"].sum().item() > 0
+    assert (output["psize"].item() > 0.0) is long_enabled
+    assert (output["short_psize"].item() > 0.0) is short_enabled
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_trailing_martingale_one_way_arbitrates_initial_entry():
+    from optimization.gpu.mps_kernel import MpsTrailingMartingaleRunner
+
+    count = 5
+    close = np.full(count, 100.0)
+    high = np.array([100.0, 100.0, 100.0, 102.0, 100.0])
+    low = np.array([100.0, 100.0, 100.0, 98.0, 100.0])
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 5.0, 1.0, 0.0002)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_row()
+
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=True,
+        short_enabled=True,
+        hedge_mode=False,
+    ).run(np.array([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert output["psize"].item() > 0.0
+    assert output["short_psize"].item() == 0.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_trailing_martingale_entry_cap_uses_rust_nearest_step_rounding():
+    """Guard the one-quantity divergence that can split a later trailing path."""
+
+    from optimization.gpu.mps_kernel import MpsTrailingMartingaleRunner
+
+    count = 8
+    close = np.full(count, 100.0)
+    high = np.full(count, 100.0)
+    low = np.array([100.0, 100.0, 100.0, 99.0, 100.0, 100.0, 100.0, 100.0])
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 5.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_row(initial_ema_dist=0.0, gate_initial=0.0, gate_reentry=0.0)
+    row[6] = 2.0  # Oversize the initial order so the exposure cap crops it.
+    row[7] = 0.5  # Keep any subsequent reentry far below the fixture market.
+    row[16] = 0.5  # Keep the close above the fixture market.
+    row[20] = 0.0
+    row[24] = 0.24036  # Exact cap quantity is 2.4036 at price 100.
+
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=True,
+        short_enabled=False,
+    ).run(np.array([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    # Rust finalization rounds the cap to the nearest quantity step. Flooring
+    # this to 2.403 was enough to change a later close/reentry decision.
+    assert output["psize"].item() == pytest.approx(2.404, abs=1.0e-6)

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -425,3 +425,55 @@ def test_mps_trailing_martingale_entry_cap_uses_rust_nearest_step_rounding():
     # Rust finalization rounds the cap to the nearest quantity step. Flooring
     # this to 2.403 was enough to change a later close/reentry decision.
     assert output["psize"].item() == pytest.approx(2.404, abs=1.0e-6)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_trailing_martingale_touch_close_uses_nearest_tick():
+    """Match Rust finalization when an off-tick market touch controls a close."""
+
+    from optimization.gpu.mps_kernel import MpsTrailingMartingaleRunner
+
+    count = 9
+    close = np.array(
+        [100.0, 100.0, 100.004, 100.004, 100.004, 100.004, 100.004, 100.004, 100.0]
+    )
+    high = np.array(
+        [100.0, 100.0, 100.004, 100.005, 100.005, 100.005, 100.005, 100.005, 100.0]
+    )
+    low = np.array(
+        [100.0, 100.0, 99.0, 100.003, 100.003, 100.003, 100.003, 100.003, 100.0]
+    )
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 5.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_row(initial_ema_dist=0.0, gate_initial=0.0, gate_reentry=0.0)
+    row[7] = 0.5  # Prevent another entry in this fixture.
+    row[16] = 0.0  # Use the current touch after the close trail retraces.
+    row[20] = 0.000001
+
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=True,
+        short_enabled=False,
+    ).run(np.array([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    # The 100.004 touch rounds to 100.00 and fills at the next 100.005 high.
+    # Directionally rounding the touch up to 100.01 would leave the position open.
+    assert output["psize"].item() == 0.0

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -1,6 +1,11 @@
 import pytest
 
-from optimization.gpu.model import EMA_ANCHOR_PARAM_KEYS, gpu_side_enabled
+from optimization.gpu.model import (
+    EMA_ANCHOR_PARAM_KEYS,
+    TRAILING_MARTINGALE_PARAM_KEYS,
+    flatten_trailing_martingale_params,
+    gpu_side_enabled,
+)
 from optimization.gpu.service import MpsEmaAnchorProxy, _require_complete_valid_tail
 
 
@@ -17,6 +22,7 @@ def test_directional_parameter_matrix_keeps_side_values_separate():
         "long": {key: 1.0 for key in EMA_ANCHOR_PARAM_KEYS},
         "short": {key: 2.0 for key in EMA_ANCHOR_PARAM_KEYS},
     }
+    proxy.param_keys = EMA_ANCHOR_PARAM_KEYS
 
     matrix = proxy._parameter_matrix(
         [{"long_offset": 0.125, "short_offset": 0.25}]
@@ -26,6 +32,34 @@ def test_directional_parameter_matrix_keeps_side_values_separate():
     offset_index = EMA_ANCHOR_PARAM_KEYS.index("offset")
     assert matrix[0, offset_index] == 0.125
     assert matrix[0, len(EMA_ANCHOR_PARAM_KEYS) + offset_index] == 0.25
+
+
+def test_trailing_parameter_matrix_keeps_nested_flattened_sides_separate():
+    proxy = MpsEmaAnchorProxy.__new__(MpsEmaAnchorProxy)
+    proxy.param_keys = TRAILING_MARTINGALE_PARAM_KEYS
+    proxy.base_params = {
+        "long": {key: 1.0 for key in TRAILING_MARTINGALE_PARAM_KEYS},
+        "short": {key: 2.0 for key in TRAILING_MARTINGALE_PARAM_KEYS},
+    }
+
+    matrix = proxy._parameter_matrix(
+        [
+            {
+                "long_entry_threshold_base_pct": 0.125,
+                "short_close_qty_pct": 0.25,
+            }
+        ]
+    )
+
+    assert matrix.shape == (1, 2 * len(TRAILING_MARTINGALE_PARAM_KEYS))
+    entry_index = TRAILING_MARTINGALE_PARAM_KEYS.index(
+        "entry_threshold_base_pct"
+    )
+    close_index = TRAILING_MARTINGALE_PARAM_KEYS.index("close_qty_pct")
+    assert matrix[0, entry_index] == 0.125
+    assert (
+        matrix[0, len(TRAILING_MARTINGALE_PARAM_KEYS) + close_index] == 0.25
+    )
 
 
 def test_gpu_side_enablement_uses_config_risk_not_per_coin_sentinel():
@@ -43,3 +77,67 @@ def test_gpu_side_enablement_uses_config_risk_not_per_coin_sentinel():
 
     assert gpu_side_enabled(config, "long")
     assert not gpu_side_enabled(config, "short")
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [
+        ("disabled", (0.0, 0.0)),
+        ("all", (1.0, 1.0)),
+        ("initial", (1.0, 0.0)),
+        ("reentry", (0.0, 1.0)),
+    ],
+)
+def test_trailing_martingale_flattening_preserves_nested_params_and_gates(
+    mode, expected
+):
+    strategy = {
+        "ema_span_0": 10.0,
+        "ema_span_1": 20.0,
+        "volatility_ema_span_1h": 30.0,
+        "volatility_ema_span_1m": 40.0,
+        "entry": {
+            "ema_gate_mode": mode,
+            "double_down_factor": 1.1,
+            "initial_ema_dist": 0.01,
+            "initial_qty_pct": 0.02,
+            "threshold_base_pct": 0.03,
+            "threshold_we_weight": 0.04,
+            "threshold_volatility_1h_weight": 0.05,
+            "threshold_volatility_1m_weight": 0.06,
+            "retracement_base_pct": 0.007,
+            "retracement_we_weight": 0.08,
+            "retracement_volatility_1h_weight": 0.09,
+            "retracement_volatility_1m_weight": 0.1,
+        },
+        "close": {
+            "qty_pct": 0.2,
+            "threshold_base_pct": 0.03,
+            "threshold_we_weight": 0.04,
+            "threshold_volatility_1h_weight": 0.05,
+            "threshold_volatility_1m_weight": 0.06,
+            "retracement_base_pct": 0.007,
+            "retracement_volatility_1h_weight": 0.09,
+            "retracement_volatility_1m_weight": 0.1,
+        },
+    }
+    flattened = flatten_trailing_martingale_params(
+        strategy,
+        {"entry_cooldown_minutes": 7.0, "total_wallet_exposure_limit": 1.5},
+    )
+
+    assert tuple(flattened) == TRAILING_MARTINGALE_PARAM_KEYS
+    assert flattened["entry_double_down_factor"] == 1.1
+    assert flattened["close_qty_pct"] == 0.2
+    assert (flattened["gate_initial"], flattened["gate_reentry"]) == expected
+
+
+def test_trailing_martingale_flattening_rejects_unknown_gate_mode():
+    with pytest.raises(ValueError, match="ema_gate_mode"):
+        flatten_trailing_martingale_params(
+            {
+                "entry": {"ema_gate_mode": "mystery"},
+                "close": {},
+            },
+            {"total_wallet_exposure_limit": 1.0},
+        )


### PR DESCRIPTION
## Summary

- add a separate Rust-owned Metal screening kernel for single-coin `trailing_martingale`
- support long-only, short-only, and long+short searches in both hedge and one-way modes
- map the trailing-mode parameter surface, including all EMA gate modes, volatility weights, cooldown, wallet-exposure cap, trailing extrema, entries, and closes
- keep the unchanged Rust backtester authoritative: Metal only ranks candidates, while exact Rust results alone enter `all_results.bin` and the Pareto store
- retain the existing fail-closed boundary for suites, multi-coin, HSL, auto-unstuck, forager-dependent selection, unmodeled risk gates, and unsupported strategies

This is additive to the EMA-anchor MPS foundation in #1494. Normal live operation, backtesting, and CPU optimization still do not import or require PyTorch.

## Parity and safety evidence

Validation used the local M3 MacBook Air, one-minute Bybit BTC candles from 2026-05-06 through 2026-07-30 (121,249 rows), and the final kernel source at `5258a9ac6`.

| Mode | rolling rho | broad-probe rho | front rho | feasibility mismatches |
|---|---:|---:|---:|---:|
| long-only | 1.000 | 1.000 | 1.000 | 0 |
| short-only | 1.000 | 1.000 | 1.000 | 0 |
| long+short hedge | 0.935 | 1.000 | 0.738 | 0 |
| long+short one-way | 0.991 | 1.000 | 1.000 | 0 |

All runs cleared the fail-closed `0.6` rank threshold. One-quantity drift found during testing was traced to exposure-cap cropping: Metal had floored a cap quantity that Rust finalization rounds to the nearest quantity step. The kernel now matches the Rust `1.01 * TWEL` tolerance and nearest-step crop rule, with a dedicated MPS regression proving `2.4036 -> 2.404` rather than `2.403`.

Codex's first-head review identified two additional parity boundaries. The update now rejects entry or close retracement bounds that can select recursive grid ladders, and touch-controlled closes use Rust's nearest-tick finalization while strategy-controlled targets retain directional rounding. Both behaviors have dedicated regression tests.

## Performance evidence

Warm kernels and warm exact workers evaluated the same 256 candidate configs over the same BTC window. Each number is the median sustained throughput across repeated complete passes; shader compilation, data loading, and worker startup are excluded from both sides.

| Workload | Metal proxy | 4 exact Rust workers | speedup |
|---|---:|---:|---:|
| long-only | 258.4 candidates/s | 41.0 candidates/s | 6.31x |
| long+short hedge | 88.6 candidates/s | 37.3 candidates/s | 2.38x |

The hybrid optimizer additionally completed drift-gated 1,984-proxy/32-exact runs in 9.0 seconds for long-only and 23.5 seconds for dual-side hedge mode.

## Validation

- `PYTHONPATH=src python -m pytest -q tests/optimization --ignore=tests/optimization/test_gpu_mps.py` (425 passed)
- `PYTHONPATH=src python -m pytest -q tests/optimization/test_gpu_mps.py` on Apple MPS (12 passed)
- `cargo test --no-default-features` (259 passed)
- `cargo check --tests`
- `cargo fmt --check`
- `git diff --check`
- rebuilt the worktree-local PyO3 extension and verified its source stamp equals the final Rust source fingerprint (`c8f1a368...`)

## Deferred scope

Recursive trailing-martingale grid modes, multi-coin, suites, HSL, auto-unstuck, forager-dependent selection, and additional strategies remain intentionally rejected before GPU optimization begins. They will be separate follow-up slices after this head passes Codex review.
