### PR TITLE
fix(gpu): harden long-horizon MPS drift validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ All notable user-facing changes will be documented in this file.
   ordering, and hedge/one-way initial-side semantics. Recursive trailing-martingale grid modes,
   other strategies, suites, multi-coin, HSL, auto-unstuck, collateral,
   minimum-effective-cost filtering, market-order execution, incomplete candle tails, non-inert
-  fixed runtime overrides, and unmodeled risk gates fail closed. Proxy/exact optimizer-limit
-  feasibility disagreement also halts immediately. Existing CPU bot, backtest, and optimizer paths
-  do not import or require the optional PyTorch dependency.
+  fixed runtime overrides, and unmodeled risk gates fail closed. Fused delta-form Metal EMA updates
+  reduce long-horizon float32 path drift. Proxy-front optimizer-limit feasibility disagreement
+  halts immediately; broad-probe disagreements feed a rolling constraint-agreement gate and persist
+  per-limit proxy/exact diagnostics. Existing CPU bot, backtest, and optimizer paths do not import
+  or require the optional PyTorch dependency.
 - Keep side-specific `approved_coins` authoritative in backtests and optimization so a coin
   approved only for long cannot open short entries, and a coin approved only for short cannot
   open long entries. Per-coin zero wallet-exposure overrides now retain the same entry-disable

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -136,9 +136,11 @@ The backend is hybrid rather than a replacement backtester:
    trailing, and position state with one shared balance and the exact Rust fill ordering.
 3. Diverse proxy-front candidates and broad drift probes are sent to the unchanged Rust backtester.
 4. Only exact Rust results enter `all_results.bin` and the persisted Pareto front.
-5. A rolling Spearman rank gate independently stops the run if broad proxy/exact probe agreement
-   falls below `drift_halt` after sufficient evidence, even when aggregate agreement remains high.
-   Any proxy/exact disagreement about optimizer-limit feasibility also stops immediately.
+5. Rolling rank and constraint-agreement gates independently stop the run if broad proxy/exact
+   probe agreement falls below `drift_halt` after sufficient evidence, even when aggregate
+   agreement remains high. A feasibility disagreement on a proxy-front candidate still stops
+   immediately; broad-probe disagreements are retained as rolling evidence because those probes
+   deliberately sample regions where the float32 screening path may be less representative.
 
 `optimize.iters` remains the number of exact Rust validations. GPU screening counts and throughput
 are reported separately in the log. `n_cpus` controls the exact-validation worker pool; MPS device
@@ -175,11 +177,13 @@ duplicate-elimination controls as the ordinary pymoo optimizer.
 - `drift_probes` reserves part of that validation budget for candidates away from the proxy front.
   A generation fails closed if its complete feasible proxy front leaves too few independent
   off-front candidates for the requested probe count.
-- `drift_window`, `drift_min_samples`, and `drift_halt` configure the rolling rank-safety gate. At
-  least eight broad probes are required before low correlation can halt a run, so `drift_window`
-  must be large enough to retain eight probes at the configured
-  `validate_per_generation / drift_probes` ratio. When probes are enabled, `optimize.iters` must
-  also be large enough to reach both that probe budget and `drift_min_samples`.
+- `drift_window`, `drift_min_samples`, and `drift_halt` configure the rolling rank and optimizer-
+  limit classification safety gates. Broad-probe Spearman correlation and constraint agreement
+  must each remain at or above `drift_halt`. At least eight broad probes are required before low
+  agreement can halt a run, so `drift_window` must be large enough to retain eight probes at the
+  configured `validate_per_generation / drift_probes` ratio. When probes are enabled,
+  `optimize.iters` must also be large enough to reach both that probe budget and
+  `drift_min_samples`.
 - `exact_workers: 0` inherits `optimize.n_cpus`; a positive value overrides it for this backend.
 - `max_pending_exact: 0` defaults to twice the exact-worker count.
 - `checkpoint_interval_seconds` bounds generation-level optimizer-state checkpoint writes. Exact

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -28,6 +28,8 @@ mod tests {
         assert!(source.contains("constant int SCALAR_COLS = 18"));
         assert!(source.contains("generate_short_orders"));
         assert!(source.contains("const bool hedge_mode"));
+        assert_eq!(source.matches("= fma(").count(), 5);
+        assert!(!source.contains("alpha0 * close +"));
     }
 
     #[test]
@@ -41,5 +43,7 @@ mod tests {
         assert!(source.contains("min_since_max"));
         assert!(source.contains("if (we_if <= s.twel * 1.01f) return qty"));
         assert!(source.contains("s.twel * balance - cost"));
+        assert_eq!(source.matches("= fma(").count(), 5);
+        assert!(!source.contains("alpha0 * close +"));
     }
 }

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -110,15 +110,14 @@ inline void update_indicators(
     bool hour_valid
 ) {
     if (hour_valid && side.alpha1h > 0.0f) {
-        side.vol1h = side.alpha1h * hour_lr + (1.0f - side.alpha1h) * side.vol1h;
+        side.vol1h = fma(side.alpha1h, hour_lr - side.vol1h, side.vol1h);
     }
     if (valid) {
-        side.ema0 = side.alpha0 * close + (1.0f - side.alpha0) * side.ema0;
-        side.ema1 = side.alpha1 * close + (1.0f - side.alpha1) * side.ema1;
-        side.ema2 = side.alpha2 * close + (1.0f - side.alpha2) * side.ema2;
+        side.ema0 = fma(side.alpha0, close - side.ema0, side.ema0);
+        side.ema1 = fma(side.alpha1, close - side.ema1, side.ema1);
+        side.ema2 = fma(side.alpha2, close - side.ema2, side.ema2);
         if (side.alpha1m > 0.0f) {
-            side.vol1m = side.alpha1m * log_range
-                + (1.0f - side.alpha1m) * side.vol1m;
+            side.vol1m = fma(side.alpha1m, log_range - side.vol1m, side.vol1m);
         }
     }
 }

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -100,13 +100,13 @@ inline void update_indicators(
     thread TmSide& s, float close, float lr, float hour_lr, bool valid, bool hour_valid
 ) {
     if (hour_valid && s.alpha1h > 0.0f)
-        s.vol1h = s.alpha1h * hour_lr + (1.0f - s.alpha1h) * s.vol1h;
+        s.vol1h = fma(s.alpha1h, hour_lr - s.vol1h, s.vol1h);
     if (valid) {
-        s.ema0 = s.alpha0 * close + (1.0f - s.alpha0) * s.ema0;
-        s.ema1 = s.alpha1 * close + (1.0f - s.alpha1) * s.ema1;
-        s.ema2 = s.alpha2 * close + (1.0f - s.alpha2) * s.ema2;
+        s.ema0 = fma(s.alpha0, close - s.ema0, s.ema0);
+        s.ema1 = fma(s.alpha1, close - s.ema1, s.ema1);
+        s.ema2 = fma(s.alpha2, close - s.ema2, s.ema2);
         if (s.alpha1m > 0.0f)
-            s.vol1m = s.alpha1m * lr + (1.0f - s.alpha1m) * s.vol1m;
+            s.vol1m = fma(s.alpha1m, lr - s.vol1m, s.vol1m);
     }
 }
 

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -15,6 +15,9 @@ from typing import Any
 
 import numpy as np
 
+from config.metrics import resolve_metric_value
+from limit_utils import compute_limit_violation
+from metrics_schema import flatten_metric_stats
 from optimization.backend_shared import load_starting_individuals
 from optimization.bounds import enforce_bounds
 from optimization.callback import build_pymoo_record_entry
@@ -444,10 +447,24 @@ class _DriftMonitor:
         self.window = int(options["drift_window"])
         self.minimum = int(options["drift_min_samples"])
         self.halt = float(options["drift_halt"])
-        self.pairs: deque[tuple[float, float, bool]] = deque(maxlen=self.window)
+        self.pairs: deque[tuple[float, float, bool, bool]] = deque(maxlen=self.window)
 
-    def add(self, proxy_score: float, exact_score: float, *, probe: bool) -> None:
-        self.pairs.append((float(proxy_score), float(exact_score), bool(probe)))
+    def add(
+        self,
+        proxy_score: float,
+        exact_score: float,
+        *,
+        probe: bool,
+        constraint_mismatch: bool = False,
+    ) -> None:
+        self.pairs.append(
+            (
+                float(proxy_score),
+                float(exact_score),
+                bool(probe),
+                bool(constraint_mismatch),
+            )
+        )
 
     def evaluate(self) -> dict:
         result = {
@@ -456,6 +473,8 @@ class _DriftMonitor:
             "front_rho": float("nan"),
             "samples": len(self.pairs),
             "probes": 0,
+            "probe_constraint_agreement": float("nan"),
+            "probe_constraint_mismatches": 0,
             "halt_reason": None,
             "warn_reason": None,
         }
@@ -464,16 +483,34 @@ class _DriftMonitor:
         proxy = np.asarray([row[0] for row in self.pairs], dtype=np.float64)
         exact = np.asarray([row[1] for row in self.pairs], dtype=np.float64)
         probes = np.asarray([row[2] for row in self.pairs], dtype=bool)
+        constraint_mismatches = np.asarray(
+            [row[3] if len(row) > 3 else False for row in self.pairs], dtype=bool
+        )
         result["probes"] = int(probes.sum())
         result["rho"] = _spearman(proxy, exact)
         result["probe_rho"] = _spearman(proxy[probes], exact[probes])
         result["front_rho"] = _spearman(proxy[~probes], exact[~probes])
+        result["probe_constraint_mismatches"] = int(
+            (constraint_mismatches & probes).sum()
+        )
+        if result["probes"]:
+            result["probe_constraint_agreement"] = 1.0 - (
+                result["probe_constraint_mismatches"] / result["probes"]
+            )
         detail = (
             f"rho={result['rho']:.3f}, probe_rho={result['probe_rho']:.3f}, "
             f"front_rho={result['front_rho']:.3f}, samples={result['samples']}, "
-            f"probes={result['probes']}"
+            f"probes={result['probes']}, "
+            f"probe_constraint_agreement={result['probe_constraint_agreement']:.3f}"
         )
         if result["probes"] >= self.MIN_PROBES and (
+            result["probe_constraint_agreement"] < self.halt
+        ):
+            result["halt_reason"] = (
+                "GPU proxy/exact broad-probe constraint agreement fell below "
+                f"safety threshold ({detail})"
+            )
+        elif result["probes"] >= self.MIN_PROBES and (
             not np.isfinite(result["probe_rho"])
             or result["probe_rho"] < self.halt
         ):
@@ -815,6 +852,48 @@ def _constraint_classification_mismatch(proxy_violation: float, exact_payload: d
     return proxy_feasible != exact_feasible
 
 
+def _constraint_diagnostics(evaluator, proxy_metrics: dict, exact_payload: dict) -> list[dict]:
+    """Describe proxy/exact values for every active optimizer limit."""
+
+    proxy_surface = _single_scenario_metric_surface(proxy_metrics)
+    exact_stats = (exact_payload.get("metrics") or {}).get("stats") or {}
+    exact_surface = flatten_metric_stats(exact_stats)
+    diagnostics = []
+    for check in getattr(evaluator, "limit_checks", []):
+        proxy_value = resolve_metric_value(proxy_surface, check["metric_key"])
+        exact_value = resolve_metric_value(exact_surface, check["metric_key"])
+        entry = {
+            "metric": check["metric"],
+            "metric_key": check["metric_key"],
+            "mode": check["mode"],
+            "proxy_value": None if proxy_value is None else float(proxy_value),
+            "exact_value": None if exact_value is None else float(exact_value),
+            "proxy_violation": float(compute_limit_violation(check, proxy_value)),
+            "exact_violation": float(compute_limit_violation(check, exact_value)),
+        }
+        if "bound" in check:
+            entry["bound"] = float(check["bound"])
+        if "range" in check:
+            entry["range"] = [float(value) for value in check["range"]]
+        diagnostics.append(entry)
+    return diagnostics
+
+
+def _format_constraint_diagnostics(diagnostics: list[dict]) -> str:
+    differing = [
+        item
+        for item in diagnostics
+        if (item["proxy_violation"] > 0.0) != (item["exact_violation"] > 0.0)
+    ]
+    selected = differing or diagnostics
+    return "; ".join(
+        f"{item['metric_key']}: proxy={item['proxy_value']} "
+        f"exact={item['exact_value']} mode={item['mode']} "
+        f"bound={item.get('bound', item.get('range'))}"
+        for item in selected
+    )
+
+
 def _recover_durable_validations(
     entries,
     *,
@@ -822,11 +901,11 @@ def _recover_durable_validations(
     stop_index: int,
     vector_from_entry,
     hash_vector,
-) -> tuple[set[str], list[tuple[float, float, bool]], str | None]:
+) -> tuple[set[str], list[tuple[float, float, bool, bool]], str | None]:
     """Recover candidate identities and safety evidence after a stale checkpoint."""
 
     recovered: set[str] = set()
-    drift_pairs: list[tuple[float, float, bool]] = []
+    drift_pairs: list[tuple[float, float, bool, bool]] = []
     mismatch_reason = None
     consumed = 0
     for index, entry in enumerate(entries):
@@ -866,8 +945,8 @@ def _recover_durable_validations(
                 "GPU resume found non-finite proxy/exact safety evidence in "
                 f"durable result {index}"
             )
-        drift_pairs.append((proxy_score, exact_score, probe))
-        if classification_mismatch:
+        drift_pairs.append((proxy_score, exact_score, probe, classification_mismatch))
+        if classification_mismatch and not probe:
             mismatch_reason = (
                 "GPU proxy/exact constraint classification disagreed for a "
                 "durably recorded exact validation"
@@ -1328,7 +1407,14 @@ def run_backend(
             PymooAsyncRecordingRunner._raise_if_pool_workers_exited(pool_workers)
             time.sleep(0.05)
         for result in ready:
-            vector, proxy_score, proxy_violation, is_probe, digest = pending.pop(result)
+            (
+                vector,
+                proxy_score,
+                proxy_violation,
+                proxy_metrics,
+                is_probe,
+                digest,
+            ) = pending.pop(result)
             payload = result.get()
             PymooAsyncRecordingRunner._raise_if_worker_failure(payload, exact_done)
             exact_score = float(
@@ -1336,6 +1422,9 @@ def run_backend(
             )
             classification_mismatch = _constraint_classification_mismatch(
                 proxy_violation, payload
+            )
+            constraint_diagnostics = _constraint_diagnostics(
+                evaluator, proxy_metrics, payload
             )
             record_exact(
                 vector,
@@ -1346,19 +1435,32 @@ def run_backend(
                     "exact_score": exact_score,
                     "probe": bool(is_probe),
                     "constraint_classification_mismatch": classification_mismatch,
+                    "constraint_diagnostics": constraint_diagnostics,
                 },
             )
             exact_done += 1
             completed_hashes.add(digest)
-            if classification_mismatch:
+            if classification_mismatch and not is_probe:
                 persisted_halt_reason = (
                     "GPU proxy/exact constraint classification disagreed for an exact "
                     f"validation: proxy_violation={proxy_violation}, "
-                    f"exact_G={np.asarray(payload['G']).tolist()}"
+                    f"exact_G={np.asarray(payload['G']).tolist()}; "
+                    f"limits=[{_format_constraint_diagnostics(constraint_diagnostics)}]"
                 )
                 maybe_save_checkpoint(force=True)
                 raise RuntimeError(persisted_halt_reason)
-            drift_monitor.add(proxy_score, exact_score, probe=is_probe)
+            if classification_mismatch:
+                logging.warning(
+                    "GPU broad-probe proxy/exact constraint classification disagreed; "
+                    "recording rolling drift evidence: %s",
+                    _format_constraint_diagnostics(constraint_diagnostics),
+                )
+            drift_monitor.add(
+                proxy_score,
+                exact_score,
+                probe=is_probe,
+                constraint_mismatch=classification_mismatch,
+            )
             status = drift_monitor.evaluate()
             if status["warn_reason"] and status["warn_reason"] != last_warning:
                 logging.warning(status["warn_reason"])
@@ -1433,6 +1535,7 @@ def run_backend(
                     vector,
                     float(proxy_scores[index]),
                     float(proxy_violations[index]),
+                    dict(metric_rows[index]),
                     bool(is_probe),
                     digest,
                 )

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -16,6 +16,8 @@ from optimization.backends.gpu_backend import (
     _build_gpu_nsga2,
     _build_proxy_parameter_dicts,
     _constraint_classification_mismatch,
+    _constraint_diagnostics,
+    _format_constraint_diagnostics,
     _DriftMonitor,
     _ObjectiveScale,
     _recover_durable_validations,
@@ -565,6 +567,53 @@ def test_drift_monitor_probe_failure_cannot_be_masked_by_high_aggregate_rho():
     assert status["halt_reason"]
 
 
+def test_drift_monitor_allows_isolated_broad_probe_constraint_mismatches():
+    monitor = _DriftMonitor(
+        {
+            "drift_window": 64,
+            "drift_min_samples": 16,
+            "drift_halt": 0.6,
+        }
+    )
+    for index in range(16):
+        probe = index < 8
+        monitor.add(
+            index,
+            index,
+            probe=probe,
+            constraint_mismatch=probe and index < 3,
+        )
+
+    status = monitor.evaluate()
+
+    assert status["probe_constraint_agreement"] == pytest.approx(0.625)
+    assert status["probe_constraint_mismatches"] == 3
+    assert status["halt_reason"] is None
+
+
+def test_drift_monitor_halts_on_low_broad_probe_constraint_agreement():
+    monitor = _DriftMonitor(
+        {
+            "drift_window": 64,
+            "drift_min_samples": 16,
+            "drift_halt": 0.6,
+        }
+    )
+    for index in range(16):
+        probe = index < 8
+        monitor.add(
+            index,
+            index,
+            probe=probe,
+            constraint_mismatch=probe and index < 4,
+        )
+
+    status = monitor.evaluate()
+
+    assert status["probe_constraint_agreement"] == pytest.approx(0.5)
+    assert "constraint agreement fell below" in status["halt_reason"]
+
+
 def test_novelty_stall_terminates_and_resets_on_progress():
     stall = 0
     for _ in range(7):
@@ -734,6 +783,53 @@ def test_constraint_classification_drift_detects_feasibility_disagreement():
     assert not _constraint_classification_mismatch(0.1, {})
 
 
+def test_constraint_diagnostics_name_disagreeing_limit_values():
+    check = {
+        "metric": "position_held_days_max",
+        "metric_key": "position_held_days_max_max",
+        "mode": "greater_than",
+        "bound": 60.0,
+        "penalty_weight": 1.0e6,
+    }
+    evaluator = type("Evaluator", (), {"limit_checks": [check]})()
+    exact_payload = {
+        "metrics": {
+            "stats": {
+                "position_held_days_max": {
+                    "mean": 195.0,
+                    "min": 195.0,
+                    "max": 195.0,
+                    "std": 0.0,
+                    "median": 195.0,
+                }
+            }
+        }
+    }
+
+    diagnostics = _constraint_diagnostics(
+        evaluator,
+        {"position_held_days_max": 24.0},
+        exact_payload,
+    )
+
+    assert diagnostics == [
+        {
+            "metric": "position_held_days_max",
+            "metric_key": "position_held_days_max_max",
+            "mode": "greater_than",
+            "proxy_value": 24.0,
+            "exact_value": 195.0,
+            "proxy_violation": 0.0,
+            "exact_violation": 135_000_000.0,
+            "bound": 60.0,
+        }
+    ]
+    detail = _format_constraint_diagnostics(diagnostics)
+    assert "position_held_days_max_max" in detail
+    assert "proxy=24.0 exact=195.0" in detail
+    assert "bound=60.0" in detail
+
+
 def test_resume_recovers_hashes_and_drift_for_results_ahead_of_checkpoint():
     entries = [
         {
@@ -760,7 +856,10 @@ def test_resume_recovers_hashes_and_drift_for_results_ahead_of_checkpoint():
     )
 
     assert recovered == {"hash-2.0", "hash-3.0"}
-    assert drift_pairs == [(2.0, 2.5, False), (3.0, 3.5, True)]
+    assert drift_pairs == [
+        (2.0, 2.5, False, False),
+        (3.0, 3.5, True, False),
+    ]
     assert mismatch is None
 
 
@@ -800,7 +899,33 @@ def test_resume_fails_closed_when_durable_tail_lacks_drift_evidence():
         )
 
 
-def test_resume_recovers_durable_constraint_disagreement():
+def test_resume_recovers_durable_front_constraint_disagreement():
+    _hashes, pairs, mismatch = _recover_durable_validations(
+        [
+            {
+                "id": 0,
+                "metrics": {
+                    "gpu_validation": {
+                        "schema_version": 1,
+                        "proxy_score": 0.1,
+                        "exact_score": 0.2,
+                        "probe": False,
+                        "constraint_classification_mismatch": True,
+                    }
+                },
+            }
+        ],
+        start_index=0,
+        stop_index=1,
+        vector_from_entry=lambda entry: [float(entry["id"])],
+        hash_vector=lambda vector: f"hash-{vector[0]}",
+    )
+
+    assert pairs == [(0.1, 0.2, False, True)]
+    assert "constraint classification disagreed" in mismatch
+
+
+def test_resume_records_broad_probe_constraint_disagreement_without_immediate_halt():
     _hashes, pairs, mismatch = _recover_durable_validations(
         [
             {
@@ -822,5 +947,5 @@ def test_resume_recovers_durable_constraint_disagreement():
         hash_vector=lambda vector: f"hash-{vector[0]}",
     )
 
-    assert pairs == [(0.1, 0.2, True)]
-    assert "constraint classification disagreed" in mismatch
+    assert pairs == [(0.1, 0.2, True, True)]
+    assert mismatch is None


### PR DESCRIPTION
## Summary

- reduce long-horizon Metal float32 EMA drift with fused delta-form updates in both supported directional kernels
- keep immediate fail-closed behavior for proxy-front constraint classification disagreements
- retain broad-probe disagreements as rolling constraint-agreement evidence, with the existing drift threshold and an eight-probe minimum
- persist per-limit proxy/exact values and violations for actionable diagnostics

## Root cause

The Metal kernels updated EMAs as two weighted products plus an addition. Over long histories, float32 rounding drift could move duration metrics across optimizer-limit boundaries. Broad drift probes intentionally sample less representative regions, so treating any isolated broad-probe classification disagreement as an unconditional halt made healthy long runs stop despite strong rank agreement. Exact Rust remains authoritative: only exact results enter Pareto/storage.

## Safety

- front-selected classification disagreement still halts immediately
- broad-probe constraint agreement must remain at or above `drift_halt`
- rank-correlation gates remain active
- unsupported strategy/runtime surfaces remain fail-closed
- CPU bot, backtest, and optimizer paths are unchanged

## Validation

- `PYTHONPATH=src ./venv/bin/pytest -q tests/optimization/test_gpu_backend.py tests/optimization/test_gpu_service.py` (69 passed)
- `cargo test --no-default-features` (259 passed)
- `PYTHONPATH=src ./venv/bin/pytest -q tests/optimization/test_gpu_mps.py` (12 passed)
- deterministic 955-day ETH run: 61,440 proxy + 64 exact validations; overall rho 0.9996; broad-probe constraint agreement 31/32; no front mismatch
- fresh 59-day BTC run: 61,440 proxy + 64 exact validations in 42.0s; overall rho 0.9976; probe rho 0.9989; front rho 0.9941; constraint agreement 32/32
- Rust extension fingerprint matched the expected source stamp
- `git diff --check`
