### PR TITLE
fix(gpu): preserve exact candle fill boundaries on MPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@ All notable user-facing changes will be documented in this file.
   fixed runtime overrides, and unmodeled risk gates fail closed. Fused delta-form Metal EMA updates
   reduce long-horizon float32 path drift. Proxy-front optimizer-limit feasibility disagreement
   halts immediately; broad-probe disagreements feed a rolling constraint-agreement gate and persist
-  per-limit proxy/exact diagnostics. Existing CPU bot, backtest, and optimizer paths do not import
-  or require the optional PyTorch dependency.
+  per-limit proxy/exact diagnostics. Strict candle/order crossing comparisons are precomputed as
+  integer price-tick boundaries, preventing float32 Metal prices from missing fills that exact Rust
+  sees just beyond a decimal tick. Existing CPU bot, backtest, and optimizer paths do not import or
+  require the optional PyTorch dependency.
 - Keep side-specific `approved_coins` authoritative in backtests and optimization so a coin
   approved only for long cannot open short entries, and a coin approved only for short cannot
   open long entries. Per-coin zero wallet-exposure overrides now retain the same entry-disable

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -133,7 +133,9 @@ The backend is hybrid rather than a replacement backtester:
 2. A Rust-owned Metal screening program evaluates every candidate against candle data resident on
    MPS; Python only prepares buffers and dispatches the program. EMA-anchor and
    trailing-martingale use separate kernels. Directional runs keep separate long/short indicator,
-   trailing, and position state with one shared balance and the exact Rust fill ordering.
+   trailing, and position state with one shared balance and the exact Rust fill ordering. Python
+   also precomputes strict high/low crossing boundaries as integer price ticks so float32 Metal
+   comparisons preserve Rust's decimal-tick fill decisions.
 3. Diverse proxy-front candidates and broad drift probes are sent to the unchanged Rust backtester.
 4. Only exact Rust results enter `all_results.bin` and the persisted Pareto front.
 5. Rolling rank and constraint-agreement gates independently stop the run if broad proxy/exact

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -30,6 +30,9 @@ mod tests {
         assert!(source.contains("const bool hedge_mode"));
         assert_eq!(source.matches("= fma(").count(), 5);
         assert!(!source.contains("alpha0 * close +"));
+        assert_eq!(source.matches("const int fo = k * 6").count(), 1);
+        assert_eq!(source.matches("high_fill_max_tick").count(), 3);
+        assert_eq!(source.matches("low_nonfill_max_tick").count(), 3);
     }
 
     #[test]
@@ -45,5 +48,8 @@ mod tests {
         assert!(source.contains("s.twel * balance - cost"));
         assert_eq!(source.matches("= fma(").count(), 5);
         assert!(!source.contains("alpha0 * close +"));
+        assert_eq!(source.matches("const int fo = k * 6").count(), 1);
+        assert_eq!(source.matches("high_fill_max_tick").count(), 3);
+        assert_eq!(source.matches("low_nonfill_max_tick").count(), 3);
     }
 }

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -332,7 +332,7 @@ inline void passivbot_single_coin_impl(
 
     for (int k = 1; k < T - 1; ++k) {
         const int bo = k * 5;
-        const int fo = k * 4;
+        const int fo = k * 6;
         const float high = bars[bo + 0];
         const float low = bars[bo + 1];
         const float close = bars[bo + 2];
@@ -342,6 +342,8 @@ inline void passivbot_single_coin_impl(
         const bool can_gen = flags[fo + 1] != 0;
         const int di = flags[fo + 2];
         const bool hour_valid = flags[fo + 3] != 0;
+        const int high_fill_max_tick = flags[fo + 4];
+        const int low_nonfill_max_tick = flags[fo + 5];
         const float kf = float(k);
 
         if (di != cur_day) {
@@ -364,7 +366,7 @@ inline void passivbot_single_coin_impl(
 
         bool long_close_fill = valid && alive && long_enabled
             && long_side.close_qty > 0.0f && long_side.psize > 0.0f
-            && high > float(long_side.close_ticks) * price_step;
+            && long_side.close_ticks <= high_fill_max_tick;
         if (long_close_fill) {
             float cp = float(long_side.close_ticks) * price_step;
             float adj = fmin(round_step(long_side.close_qty, qty_step), long_side.psize);
@@ -386,7 +388,7 @@ inline void passivbot_single_coin_impl(
 
         bool long_entry_fill = valid && alive && long_enabled
             && long_side.entry_qty > 0.0f
-            && low < float(long_side.entry_ticks) * price_step;
+            && long_side.entry_ticks > low_nonfill_max_tick;
         if (long_entry_fill) {
             float ep = float(long_side.entry_ticks) * price_step;
             float eq = round_step(long_side.entry_qty, qty_step);
@@ -406,7 +408,7 @@ inline void passivbot_single_coin_impl(
 
         bool short_close_fill = valid && alive && short_enabled
             && short_side.close_qty > 0.0f && short_side.psize > 0.0f
-            && low < float(short_side.close_ticks) * price_step;
+            && short_side.close_ticks > low_nonfill_max_tick;
         if (short_close_fill) {
             float cp = float(short_side.close_ticks) * price_step;
             float adj = fmin(round_step(short_side.close_qty, qty_step), short_side.psize);
@@ -428,7 +430,7 @@ inline void passivbot_single_coin_impl(
 
         bool short_entry_fill = valid && alive && short_enabled
             && short_side.entry_qty > 0.0f
-            && high > float(short_side.entry_ticks) * price_step;
+            && short_side.entry_ticks <= high_fill_max_tick;
         if (short_entry_fill) {
             float ep = float(short_side.entry_ticks) * price_step;
             float eq = round_step(short_side.entry_qty, qty_step);

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -407,7 +407,7 @@ inline void passivbot_single_coin_impl(
 
     for (int k = 1; k < T - 1; ++k) {
         const int bo = k * 5;
-        const int fo = k * 4;
+        const int fo = k * 6;
         const float high = bars[bo + 0];
         const float low = bars[bo + 1];
         const float close = bars[bo + 2];
@@ -417,6 +417,8 @@ inline void passivbot_single_coin_impl(
         const bool can_gen = flags[fo + 1] != 0;
         const int di = flags[fo + 2];
         const bool hour_valid = flags[fo + 3] != 0;
+        const int high_fill_max_tick = flags[fo + 4];
+        const int low_nonfill_max_tick = flags[fo + 5];
         const float kf = float(k);
 
         if (di != cur_day) {
@@ -439,7 +441,7 @@ inline void passivbot_single_coin_impl(
 
         bool long_close_fill = valid && alive && long_enabled
             && long_side.close_qty > 0.0f && long_side.psize > 0.0f
-            && high > float(long_side.close_ticks) * price_step;
+            && long_side.close_ticks <= high_fill_max_tick;
         if (long_close_fill) {
             float cp = float(long_side.close_ticks) * price_step;
             float adj = fmin(round_step(long_side.close_qty, qty_step), long_side.psize);
@@ -461,7 +463,7 @@ inline void passivbot_single_coin_impl(
 
         bool long_entry_fill = valid && alive && long_enabled
             && long_side.entry_qty > 0.0f
-            && low < float(long_side.entry_ticks) * price_step;
+            && long_side.entry_ticks > low_nonfill_max_tick;
         if (long_entry_fill) {
             float ep = float(long_side.entry_ticks) * price_step;
             float eq = round_step(long_side.entry_qty, qty_step);
@@ -481,7 +483,7 @@ inline void passivbot_single_coin_impl(
 
         bool short_close_fill = valid && alive && short_enabled
             && short_side.close_qty > 0.0f && short_side.psize > 0.0f
-            && low < float(short_side.close_ticks) * price_step;
+            && short_side.close_ticks > low_nonfill_max_tick;
         if (short_close_fill) {
             float cp = float(short_side.close_ticks) * price_step;
             float adj = fmin(round_step(short_side.close_qty, qty_step), short_side.psize);
@@ -503,7 +505,7 @@ inline void passivbot_single_coin_impl(
 
         bool short_entry_fill = valid && alive && short_enabled
             && short_side.entry_qty > 0.0f
-            && high > float(short_side.entry_ticks) * price_step;
+            && short_side.entry_ticks <= high_fill_max_tick;
         if (short_entry_fill) {
             float ep = float(short_side.entry_ticks) * price_step;
             float eq = round_step(short_side.entry_qty, qty_step);

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -219,20 +219,42 @@ def _strict_fill_tick_boundaries(
     high_fill_max = np.floor(safe_high / price_step).astype(np.int64)
     low_nonfill_max = np.floor(safe_low / price_step).astype(np.int64)
 
+    decimal_multiplier = None
+    multiplier = 1.0
+    for places in range(16):
+        scaled_step = abs(price_step) * multiplier
+        rounded_step = np.floor(scaled_step + 0.5)
+        if rounded_step >= 1.0 and abs(scaled_step - rounded_step) <= max(
+            abs(scaled_step), 1.0
+        ) * 1e-12:
+            decimal_multiplier = 10.0 ** max(places, 10)
+            break
+        multiplier *= 10.0
+
+    def rust_tick_prices(ticks):
+        prices = ticks.astype(np.float64) * price_step
+        if decimal_multiplier is None:
+            return prices
+        scaled = prices * decimal_multiplier
+        return (
+            np.copysign(np.floor(np.abs(scaled) + 0.5), scaled)
+            / decimal_multiplier
+        )
+
     # Division can land one tick to either side near an exact boundary. Repair
-    # against the same float64 multiplication used by Rust order prices.
+    # against Rust's step-decimal-preserving order-price rounding contract.
     for _ in range(2):
-        high_fill_max -= (
-            high_fill_max.astype(np.float64) * price_step >= safe_high
-        ).astype(np.int64)
-        high_fill_max += (
-            (high_fill_max + 1).astype(np.float64) * price_step < safe_high
-        ).astype(np.int64)
-        low_nonfill_max -= (
-            low_nonfill_max.astype(np.float64) * price_step > safe_low
-        ).astype(np.int64)
+        high_fill_max -= (rust_tick_prices(high_fill_max) >= safe_high).astype(
+            np.int64
+        )
+        high_fill_max += (rust_tick_prices(high_fill_max + 1) < safe_high).astype(
+            np.int64
+        )
+        low_nonfill_max -= (rust_tick_prices(low_nonfill_max) > safe_low).astype(
+            np.int64
+        )
         low_nonfill_max += (
-            (low_nonfill_max + 1).astype(np.float64) * price_step <= safe_low
+            rust_tick_prices(low_nonfill_max + 1) <= safe_low
         ).astype(np.int64)
 
     high_fill_max[~finite] = 0

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -202,6 +202,52 @@ def _build_hourly_log_range(high, low, timestamps, run: ProxyRun):
     return hour_log_range, hour_valid
 
 
+def _strict_fill_tick_boundaries(
+    high, low, price_step: float
+) -> tuple[np.ndarray, np.ndarray]:
+    """Encode Rust's strict candle/order comparisons as integer tick boundaries."""
+
+    if not np.isfinite(price_step) or price_step <= 0.0:
+        raise ValueError(
+            f"MPS proxy requires a positive finite price_step, got {price_step}"
+        )
+    high = np.asarray(high, dtype=np.float64)
+    low = np.asarray(low, dtype=np.float64)
+    finite = np.isfinite(high) & np.isfinite(low)
+    safe_high = np.where(finite, high, 0.0)
+    safe_low = np.where(finite, low, 0.0)
+    high_fill_max = np.floor(safe_high / price_step).astype(np.int64)
+    low_nonfill_max = np.floor(safe_low / price_step).astype(np.int64)
+
+    # Division can land one tick to either side near an exact boundary. Repair
+    # against the same float64 multiplication used by Rust order prices.
+    for _ in range(2):
+        high_fill_max -= (
+            high_fill_max.astype(np.float64) * price_step >= safe_high
+        ).astype(np.int64)
+        high_fill_max += (
+            (high_fill_max + 1).astype(np.float64) * price_step < safe_high
+        ).astype(np.int64)
+        low_nonfill_max -= (
+            low_nonfill_max.astype(np.float64) * price_step > safe_low
+        ).astype(np.int64)
+        low_nonfill_max += (
+            (low_nonfill_max + 1).astype(np.float64) * price_step <= safe_low
+        ).astype(np.int64)
+
+    high_fill_max[~finite] = 0
+    low_nonfill_max[~finite] = 0
+    i32 = np.iinfo(np.int32)
+    if (
+        high_fill_max.min(initial=0) < i32.min
+        or high_fill_max.max(initial=0) > i32.max
+        or low_nonfill_max.min(initial=0) < i32.min
+        or low_nonfill_max.max(initial=0) > i32.max
+    ):
+        raise ValueError("MPS proxy candle price ticks exceed signed 32-bit range")
+    return high_fill_max.astype(np.int32), low_nonfill_max.astype(np.int32)
+
+
 def build_mps_data(high, low, close, timestamps_ms, run: ProxyRun, market: ProxyMarket):
     """Prepare immutable minute data and keep it resident on Apple MPS.
 
@@ -257,6 +303,9 @@ def build_mps_data(high, low, close, timestamps_ms, run: ProxyRun, market: Proxy
         & (indices >= run.trade_start_idx)
         & valid
     )
+    high_fill_max_tick, low_nonfill_max_tick = _strict_fill_tick_boundaries(
+        high, low, market.price_step
+    )
 
     def tensor(values, *, dtype=None):
         return torch.as_tensor(values, dtype=dtype, device="mps")
@@ -271,6 +320,8 @@ def build_mps_data(high, low, close, timestamps_ms, run: ProxyRun, market: Proxy
         "valid": tensor(valid),
         "can_gen": tensor(can_generate),
         "day_idx": tensor(day_idx),
+        "high_fill_max_tick": tensor(high_fill_max_tick),
+        "low_nonfill_max_tick": tensor(low_nonfill_max_tick),
         "n_days": int(day_idx[-1]) + 1,
         "ts0": int(timestamps[0]),
         "times_relative": True,

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -82,6 +82,8 @@ class MpsEmaAnchorRunner:
                     data["can_gen"].to(torch.int32),
                     data["day_idx"].to(torch.int32),
                     data["hour_valid"].to(torch.int32),
+                    data["high_fill_max_tick"].to(torch.int32),
+                    data["low_nonfill_max_tick"].to(torch.int32),
                 ],
                 dim=1,
             )

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -8,9 +8,27 @@ from optimization.gpu.model import (
     ProxyMarket,
     ProxyRun,
     _build_hourly_log_range,
+    _strict_fill_tick_boundaries,
     build_mps_data,
 )
 from optimization.gpu.mps_kernel import MpsEmaAnchorRunner
+
+
+def test_strict_fill_tick_boundaries_preserve_float32_candle_crossing():
+    step = 0.01
+    order_tick = 371_177
+    exact_order_price = order_tick * step
+    represented_above = float(np.float32(exact_order_price))
+    assert represented_above > exact_order_price
+
+    high_fill_max, low_nonfill_max = _strict_fill_tick_boundaries(
+        np.array([represented_above, exact_order_price]),
+        np.array([exact_order_price, represented_above]),
+        step,
+    )
+
+    assert high_fill_max.tolist() == [order_tick, order_tick - 1]
+    assert low_nonfill_max.tolist() == [order_tick, order_tick]
 
 
 def test_initial_single_candle_hour_bucket_matches_rust_skip_contract():

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -31,6 +31,22 @@ def test_strict_fill_tick_boundaries_preserve_float32_candle_crossing():
     assert low_nonfill_max.tolist() == [order_tick, order_tick]
 
 
+def test_strict_fill_tick_boundaries_preserve_rust_step_decimal_rounding():
+    step = 0.1
+    order_tick = 371_177
+    rust_order_price = 37_117.7
+    assert order_tick * step > rust_order_price
+
+    high_fill_max, low_nonfill_max = _strict_fill_tick_boundaries(
+        np.array([rust_order_price]),
+        np.array([rust_order_price]),
+        step,
+    )
+
+    assert high_fill_max.tolist() == [order_tick - 1]
+    assert low_nonfill_max.tolist() == [order_tick]
+
+
 def test_initial_single_candle_hour_bucket_matches_rust_skip_contract():
     timestamps = 3_540_000 + np.arange(62, dtype=np.int64) * 60_000
     high = np.full(62, 105.0)


### PR DESCRIPTION
## Summary

- preserve Rust's strict candle/order fill comparisons in the Apple MPS proxy by precomputing integer price-tick crossing boundaries
- pass those boundaries to both EMA-anchor and trailing-martingale Metal kernels
- add regression and kernel-contract coverage, plus user-facing documentation

## Root cause

Market candles are stored as float32 for Metal. An order at the exact decimal tick `3711.77` is represented as `3711.77001953125` in float32. Rust compares the candle high as float64 against the exact decimal-tick order price and fills, while Metal previously compared two equal float32 values and missed the strict `high > order_price` crossing. That delayed later fills and could change optimizer-limit feasibility.

The host now computes the highest tick strictly below each candle high and the highest tick at or below each candle low using float64 tick-price semantics. Metal compares integer order ticks to those boundaries, avoiding float32 equality ambiguity.

The immediate proxy/exact front-mismatch halt remains unchanged and fail-closed.

## Validation

- replayed the reported 956-day ETH trailing-martingale candidate: recovery-days proxy moved from `132.461807` to `273.690287`, versus exact Rust `273.689583`; fill count matches at `2238`
- `13 passed` in the full Apple MPS test file
- `69 passed` in GPU backend/service tests
- `259 passed` from `cargo test --no-default-features`
- BTC throughput check: 61,440 proxy evaluations plus 64 exact validations in 41.6 s; generation throughput approximately 1,487/s; rank correlation 0.99959; constraint agreement 1.0 with zero mismatches

Existing CPU bot, backtest, and optimizer paths are unchanged.
