### PR TITLE
Add single-coin config composition tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ All notable user-facing changes will be documented in this file.
 - Add `passivbot tool compose-coin-overrides` to validate and combine a directory of single-coin
   configs into a lean unified config with minimal inline per-coin patches. The tool canonicalizes
   parameters belonging only to features disabled in every input, reports account-wide conflicts,
-  merges approved coins, supports selecting the master input, and can optionally retain that
-  input's backtest and optimizer sections for fixed-override fine-tuning.
+  merges approved coins without resolved-market alias collisions, supports selecting the master
+  input, and can optionally retain that input's backtest and optimizer sections for fixed-override
+  fine-tuning.
 - Add an experimental, purely additive Apple Silicon MPS optimizer backend for single-coin,
   EMA-anchor and trailing-martingale searches in long-only, short-only, and long+short modes.
   Large NSGA-II populations run through strategy-specific Rust-owned Metal screening programs and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ All notable user-facing changes will be documented in this file.
 - Add `passivbot tool compose-coin-overrides` to validate and combine a directory of single-coin
   configs into a lean unified config with minimal inline per-coin patches. The tool canonicalizes
   parameters belonging only to features disabled in every input, reports account-wide conflicts,
-  merges approved coins with fail-closed resolved-market identity validation, supports selecting
-  the master input, and can optionally retain that input's backtest and optimizer sections for
-  fixed-override fine-tuning. Full output rejects the single-coin-only GPU optimizer backend.
+  merges approved coins with fail-closed resolved-market and cross-venue contract identity
+  validation, supports selecting the master input, and can optionally retain that input's
+  backtest and optimizer sections for fixed-override fine-tuning. Full output rejects the
+  single-coin-only GPU optimizer backend.
 - Add an experimental, purely additive Apple Silicon MPS optimizer backend for single-coin,
   EMA-anchor and trailing-martingale searches in long-only, short-only, and long+short modes.
   Large NSGA-II populations run through strategy-specific Rust-owned Metal screening programs and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ All notable user-facing changes will be documented in this file.
 - Add `passivbot tool compose-coin-overrides` to validate and combine a directory of single-coin
   configs into a lean unified config with minimal inline per-coin patches. The tool canonicalizes
   parameters belonging only to features disabled in every input, reports account-wide conflicts,
-  merges approved coins without resolved-market alias collisions, supports selecting the master
-  input, and can optionally retain that input's backtest and optimizer sections for fixed-override
-  fine-tuning. Full output rejects the single-coin-only GPU optimizer backend.
+  merges approved coins with fail-closed resolved-market identity validation, supports selecting
+  the master input, and can optionally retain that input's backtest and optimizer sections for
+  fixed-override fine-tuning. Full output rejects the single-coin-only GPU optimizer backend.
 - Add an experimental, purely additive Apple Silicon MPS optimizer backend for single-coin,
   EMA-anchor and trailing-martingale searches in long-only, short-only, and long+short modes.
   Large NSGA-II populations run through strategy-specific Rust-owned Metal screening programs and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable user-facing changes will be documented in this file.
   parameters belonging only to features disabled in every input, reports account-wide conflicts,
   merges approved coins without resolved-market alias collisions, supports selecting the master
   input, and can optionally retain that input's backtest and optimizer sections for fixed-override
-  fine-tuning.
+  fine-tuning. Full output rejects the single-coin-only GPU optimizer backend.
 - Add an experimental, purely additive Apple Silicon MPS optimizer backend for single-coin,
   EMA-anchor and trailing-martingale searches in long-only, short-only, and long+short modes.
   Large NSGA-II populations run through strategy-specific Rust-owned Metal screening programs and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Add `passivbot tool compose-coin-overrides` to validate and combine a directory of single-coin
+  configs into a lean unified config with minimal inline per-coin patches. The tool canonicalizes
+  parameters belonging only to features disabled in every input, reports account-wide conflicts,
+  merges approved coins, supports selecting the master input, and can optionally retain that
+  input's backtest and optimizer sections for fixed-override fine-tuning.
 - Add an experimental, purely additive Apple Silicon MPS optimizer backend for single-coin,
   EMA-anchor and trailing-martingale searches in long-only, short-only, and long+short modes.
   Large NSGA-II populations run through strategy-specific Rust-owned Metal screening programs and

--- a/docs/ai/runbooks/commands.md
+++ b/docs/ai/runbooks/commands.md
@@ -85,6 +85,7 @@ passivbot tool pareto-dash --data-root optimize_results
 passivbot tool verify-hlcvs-data
 passivbot tool ohlcvs-doctor --repair-catalog
 passivbot tool streamline-json configs/examples/default_trailing_martingale_long.json
+passivbot tool compose-coin-overrides path/to/single_coins path/to/composed.json
 passivbot tool migrate-config-v7 config_v7.json config_v8.json
 passivbot tool compare-backtests path/to/v7/result path/to/v8/result
 ```

--- a/docs/coin_overrides.md
+++ b/docs/coin_overrides.md
@@ -205,10 +205,12 @@ passivbot tool compose-coin-overrides path/to/single_coins path/to/composed.json
 ```
 
 Each input must validate as a current config, approve exactly one coin across its long/short lists,
-and contain no existing `coin_overrides`. Files and coins are processed deterministically, with the
-alphabetically first filename supplying the master config by default. Pass `--master-config FILE`
-to select another input as the source of master/global values. The tool combines the per-side
-approved coin lists and expands `n_positions` to the approved-coin count on active sides. Legal
+reject the `all` sentinel, and contain no existing `coin_overrides`, including in nested-current
+input. Files and coins are processed deterministically, with the alphabetically first filename
+supplying the master config by default. Pass `--master-config FILE` to select another input as the
+source of master/global values. The tool rejects input aliases that resolve to the same configured
+venue market, combines the per-side approved coin lists, removes approved market aliases from the
+master's ignored lists, and expands `n_positions` to the approved-coin count on active sides. Legal
 per-coin differences become overrides only when they differ from the master; differing account-wide
 or otherwise non-overridable values retain the master value and are listed in the command output.
 

--- a/docs/coin_overrides.md
+++ b/docs/coin_overrides.md
@@ -214,8 +214,9 @@ master's ignored lists, and expands `n_positions` to the approved-coin count on 
 Exchange-qualified identifiers contribute their explicit venue to alias resolution. Legal per-coin
 differences become overrides only when they differ from the master; differing account-wide or
 otherwise non-overridable values retain the master value and are listed in the command output.
-Exact market identifiers must resolve through cached market metadata; unresolved exact approved or
-ignored identifiers fail validation instead of falling back to a lossy ticker guess.
+Exact market identifiers must resolve unambiguously through cached market metadata; unresolved
+exact approved or ignored identifiers, and identifiers resolving to different contracts across
+configured venues, fail validation instead of falling back to a lossy ticker guess.
 
 When HSL, auto unstuck, or a position/total-exposure enforcer is disabled in every input, parameters
 used only by that disabled feature are normalized before diffing. Optimized numeric fields use the

--- a/docs/coin_overrides.md
+++ b/docs/coin_overrides.md
@@ -195,6 +195,34 @@ Main config:
   only the selected `coin+side`, including enablement, tier thresholds, cooldown/restart policy,
   orange behavior, and panic execution type. Other coins inherit the main config.
 
+## Composing single-coin configs
+
+Use the offline composition tool to turn a directory of single-coin JSON/HJSON configs into one
+config with minimal inline patches:
+
+```bash
+passivbot tool compose-coin-overrides path/to/single_coins path/to/composed.json
+```
+
+Each input must validate as a current config, approve exactly one coin across its long/short lists,
+and contain no existing `coin_overrides`. Files and coins are processed deterministically, with the
+alphabetically first filename supplying the master config by default. Pass `--master-config FILE`
+to select another input as the source of master/global values. The tool combines the per-side
+approved coin lists and expands `n_positions` to the approved-coin count on active sides. Legal
+per-coin differences become overrides only when they differ from the master; differing account-wide
+or otherwise non-overridable values retain the master value and are listed in the command output.
+
+When HSL, auto unstuck, or a position/total-exposure enforcer is disabled in every input, parameters
+used only by that disabled feature are normalized before diffing. Optimized numeric fields use the
+lower bound from the master input and fixed fields use schema defaults, so inactive optimized values
+do not create noise in `coin_overrides`. The total-exposure threshold is shared by the TWEL entry
+gate and enforcer, so it is normalized only when both are disabled.
+
+By default the output omits `backtest` and `optimize`, producing a lean live config. Add
+`--include-backtest-optimize` to copy both sections from the master input, which makes the result
+directly usable for backtesting or fine-tuning inherited master parameters while the coin overrides
+remain fixed. Existing output files are protected unless `--overwrite` is supplied.
+
 ## Common pitfalls
 
 - Bad paths: a missing or unreadable `override_config_path` is fatal.

--- a/docs/coin_overrides.md
+++ b/docs/coin_overrides.md
@@ -214,6 +214,8 @@ master's ignored lists, and expands `n_positions` to the approved-coin count on 
 Exchange-qualified identifiers contribute their explicit venue to alias resolution. Legal per-coin
 differences become overrides only when they differ from the master; differing account-wide or
 otherwise non-overridable values retain the master value and are listed in the command output.
+Exact market identifiers must resolve through cached market metadata; unresolved exact approved or
+ignored identifiers fail validation instead of falling back to a lossy ticker guess.
 
 When HSL, auto unstuck, or a position/total-exposure enforcer is disabled in every input, parameters
 used only by that disabled feature are normalized before diffing. Optimized numeric fields use the

--- a/docs/coin_overrides.md
+++ b/docs/coin_overrides.md
@@ -210,9 +210,10 @@ input. Files and coins are processed deterministically, with the alphabetically 
 supplying the master config by default. Pass `--master-config FILE` to select another input as the
 source of master/global values. The tool rejects input aliases that resolve to the same configured
 venue market, combines the per-side approved coin lists, removes approved market aliases from the
-master's ignored lists, and expands `n_positions` to the approved-coin count on active sides. Legal
-per-coin differences become overrides only when they differ from the master; differing account-wide
-or otherwise non-overridable values retain the master value and are listed in the command output.
+master's ignored lists, and expands `n_positions` to the approved-coin count on active sides.
+Exchange-qualified identifiers contribute their explicit venue to alias resolution. Legal per-coin
+differences become overrides only when they differ from the master; differing account-wide or
+otherwise non-overridable values retain the master value and are listed in the command output.
 
 When HSL, auto unstuck, or a position/total-exposure enforcer is disabled in every input, parameters
 used only by that disabled feature are normalized before diffing. Optimized numeric fields use the
@@ -223,7 +224,9 @@ gate and enforcer, so it is normalized only when both are disabled.
 By default the output omits `backtest` and `optimize`, producing a lean live config. Add
 `--include-backtest-optimize` to copy both sections from the master input, which makes the result
 directly usable for backtesting or fine-tuning inherited master parameters while the coin overrides
-remain fixed. Existing output files are protected unless `--overwrite` is supplied.
+remain fixed. A master using the single-coin-only `gpu` optimizer backend is rejected in this mode;
+select a CPU optimizer backend before composing. Existing output files are protected unless
+`--overwrite` is supplied.
 
 ## Common pitfalls
 

--- a/src/passivbot_cli/main.py
+++ b/src/passivbot_cli/main.py
@@ -62,6 +62,10 @@ TOOL_COMMANDS: dict[str, CommandSpec] = {
         "compare completed backtest artifacts (requires full install)",
         requires_full=True,
     ),
+    "compose-coin-overrides": CommandSpec(
+        "tools.compose_coin_overrides",
+        "compose single-coin configs with minimal inline overrides",
+    ),
     "fetch-balance": CommandSpec("tools.fetch_balance", "fetch exchange balances"),
     "hyperliquid-balance-probe": CommandSpec(
         "tools.probe_hyperliquid_balance",

--- a/src/tools/compose_coin_overrides.py
+++ b/src/tools/compose_coin_overrides.py
@@ -13,7 +13,14 @@ from config.overrides import get_allowed_modifications, parse_overrides
 from config.schema import get_template_config
 from config_utils import clean_config
 from pure_funcs import sort_dict_keys
-from utils import json_dumps_streamlined
+from utils import (
+    MarketIdentifierResolutionError,
+    coin_to_symbol,
+    heuristic_symbol_to_coin,
+    json_dumps_streamlined,
+    split_exchange_qualified_market_identifier,
+    to_standard_exchange_name,
+)
 
 
 CONFIG_SUFFIXES = frozenset({".json", ".hjson"})
@@ -133,6 +140,8 @@ def load_single_coin_config(path: Path) -> SingleCoinConfig:
         raw_snapshot=raw_snapshot,
     )
     config = clean_config(prepared)
+    if config.get("coin_overrides"):
+        raise ValueError(f"{path}: single-coin input must not contain coin_overrides")
     approved = _side_coin_lists(config, "approved_coins", path=path)
     ignored = _side_coin_lists(config, "ignored_coins", path=path)
     approved_union = {coin for coins in approved.values() for coin in coins}
@@ -142,6 +151,11 @@ def load_single_coin_config(path: Path) -> SingleCoinConfig:
             f"{path}: expected exactly one approved coin across long/short; found {formatted}"
         )
     coin = next(iter(approved_union))
+    if coin.strip().casefold() == "all":
+        raise ValueError(
+            f"{path}: live.approved_coins must name one coin; the 'all' sentinel is not valid "
+            "for a single-coin input"
+        )
     approved_sides = frozenset(side for side, coins in approved.items() if coin in coins)
     for side in POSITION_SIDES:
         if coin in ignored[side]:
@@ -155,6 +169,53 @@ def load_single_coin_config(path: Path) -> SingleCoinConfig:
                 + ", ".join(extra)
             )
     return SingleCoinConfig(path=path, coin=coin, approved_sides=approved_sides, config=config)
+
+
+def _market_resolution_exchanges(configs: list[SingleCoinConfig]) -> tuple[str, ...]:
+    exchanges = set()
+    for item in configs:
+        backtest = item.config.get("backtest", {})
+        configured = backtest.get("exchanges", [])
+        if isinstance(configured, str):
+            configured = [configured]
+        coin_sources = backtest.get("coin_sources", {})
+        source_exchanges = coin_sources.values() if isinstance(coin_sources, dict) else []
+        for exchange in [*configured, *source_exchanges]:
+            normalized = to_standard_exchange_name(str(exchange))
+            if normalized and normalized != "fake":
+                exchanges.add(normalized)
+    return tuple(sorted(exchanges))
+
+
+def _market_identity(
+    identifier: str, exchanges: tuple[str, ...]
+) -> tuple[frozenset[tuple[str, str]], str]:
+    resolved = set()
+    for exchange in exchanges:
+        try:
+            symbol = coin_to_symbol(identifier, exchange, verbose=False)
+        except MarketIdentifierResolutionError:
+            continue
+        resolved.add((exchange, symbol))
+    _qualified_exchange, unqualified = split_exchange_qualified_market_identifier(identifier)
+    fallback = heuristic_symbol_to_coin(unqualified).strip().casefold()
+    return frozenset(resolved), fallback
+
+
+def _identifiers_refer_to_same_market(
+    left: str, right: str, exchanges: tuple[str, ...]
+) -> bool:
+    if left == right:
+        return True
+    left_resolved, left_fallback = _market_identity(left, exchanges)
+    right_resolved, right_fallback = _market_identity(right, exchanges)
+    if left_resolved & right_resolved:
+        return True
+    # When cached venue metadata cannot resolve one or both identifiers, fail closed
+    # on the deterministic underlying-name fallback instead of permitting a duplicate.
+    return (
+        not left_resolved or not right_resolved
+    ) and left_fallback == right_fallback
 
 
 def _resolve_master_path(
@@ -193,6 +254,16 @@ def load_single_coin_directory(
                 f"{by_coin[item.coin]} and {item.path}"
             )
         by_coin[item.coin] = item.path
+    resolution_exchanges = _market_resolution_exchanges(configs)
+    for index, item in enumerate(configs):
+        for previous in configs[:index]:
+            if _identifiers_refer_to_same_market(
+                previous.coin, item.coin, resolution_exchanges
+            ):
+                raise ValueError(
+                    "duplicate single-coin configs resolve to the same market: "
+                    f"{previous.coin} ({previous.path}) and {item.coin} ({item.path})"
+                )
     strategy_kinds = {
         str(item.config.get("live", {}).get("strategy_kind")) for item in configs
     }
@@ -412,9 +483,15 @@ def compose_configs(
         for side in POSITION_SIDES
     }
     master["live"]["approved_coins"] = approved
+    resolution_exchanges = _market_resolution_exchanges(configs)
     for side in POSITION_SIDES:
         master["live"]["ignored_coins"][side] = sorted(
-            set(master["live"]["ignored_coins"][side]) - set(approved[side])
+            ignored
+            for ignored in set(master["live"]["ignored_coins"][side])
+            if not any(
+                _identifiers_refer_to_same_market(ignored, coin, resolution_exchanges)
+                for coin in approved[side]
+            )
         )
         if approved[side] and float(master["bot"][side]["risk"]["total_wallet_exposure_limit"]) > 0:
             master["bot"][side]["risk"]["n_positions"] = float(len(approved[side]))

--- a/src/tools/compose_coin_overrides.py
+++ b/src/tools/compose_coin_overrides.py
@@ -26,6 +26,7 @@ from utils import (
 CONFIG_SUFFIXES = frozenset({".json", ".hjson"})
 POSITION_SIDES = ("long", "short")
 OUTPUT_ROOTS = ("config_version", "bot", "coin_overrides", "live", "logging", "monitor")
+HYPERLIQUID_MARKET_PREFIXES = ("xyz:", "xyz-", "xyz_")
 
 
 @dataclass
@@ -184,6 +185,18 @@ def _market_resolution_exchanges(configs: list[SingleCoinConfig]) -> tuple[str, 
             normalized = to_standard_exchange_name(str(exchange))
             if normalized and normalized != "fake":
                 exchanges.add(normalized)
+        for key in ("approved_coins", "ignored_coins"):
+            for identifiers in item.config.get("live", {}).get(key, {}).values():
+                for identifier in identifiers:
+                    qualified_exchange, _unqualified = (
+                        split_exchange_qualified_market_identifier(identifier)
+                    )
+                    if qualified_exchange and qualified_exchange != "fake":
+                        exchanges.add(qualified_exchange)
+                    if str(identifier).strip().casefold().startswith(
+                        HYPERLIQUID_MARKET_PREFIXES
+                    ):
+                        exchanges.add("hyperliquid")
     return tuple(sorted(exchanges))
 
 
@@ -474,6 +487,16 @@ def compose_configs(
 ) -> tuple[dict, CompositionReport]:
     if len(configs) < 2:
         raise ValueError("at least two single-coin configs are required")
+    if (
+        include_backtest_optimize
+        and str(configs[0].config.get("optimize", {}).get("backend", "")).casefold()
+        == "gpu"
+    ):
+        raise ValueError(
+            "--include-backtest-optimize cannot retain optimize.backend='gpu': the GPU "
+            "optimizer supports neither multi-coin datasets nor coin_overrides; select a "
+            "CPU optimizer backend in the master input"
+        )
     canonicalized_features = canonicalize_inactive_features(configs)
     master_source = configs[0]
     master = deepcopy(master_source.config)

--- a/src/tools/compose_coin_overrides.py
+++ b/src/tools/compose_coin_overrides.py
@@ -19,6 +19,7 @@ from utils import (
     heuristic_symbol_to_coin,
     json_dumps_streamlined,
     looks_like_exact_market_identifier,
+    market_denomination_identity,
     split_exchange_qualified_market_identifier,
     to_standard_exchange_name,
 )
@@ -211,12 +212,27 @@ def _market_identity(
         except MarketIdentifierResolutionError:
             continue
         resolved.add((exchange, symbol))
-    if looks_like_exact_market_identifier(identifier) and not resolved:
-        formatted_exchanges = ", ".join(exchanges) or "none"
-        raise ValueError(
-            f"could not resolve exact market identifier {identifier!r} on configured "
-            f"venue(s): {formatted_exchanges}; refresh market metadata before composing"
-        )
+    if looks_like_exact_market_identifier(identifier):
+        if not resolved:
+            formatted_exchanges = ", ".join(exchanges) or "none"
+            raise ValueError(
+                f"could not resolve exact market identifier {identifier!r} on configured "
+                f"venue(s): {formatted_exchanges}; refresh market metadata before composing"
+            )
+        resolved_contracts = {
+            market_denomination_identity(symbol, exchange=exchange)
+            for exchange, symbol in resolved
+        }
+        if len(resolved_contracts) > 1:
+            formatted_resolutions = ", ".join(
+                f"{exchange}={symbol}"
+                for exchange, symbol in sorted(resolved)
+            )
+            raise ValueError(
+                f"exact market identifier {identifier!r} resolves to different contracts "
+                f"across configured venues ({formatted_resolutions}); use "
+                "exchange::<native-id>"
+            )
     _qualified_exchange, unqualified = split_exchange_qualified_market_identifier(identifier)
     fallback = heuristic_symbol_to_coin(unqualified).strip().casefold()
     return frozenset(resolved), fallback

--- a/src/tools/compose_coin_overrides.py
+++ b/src/tools/compose_coin_overrides.py
@@ -1,0 +1,565 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+from config.load import load_input_config, prepare_config
+from config.overrides import get_allowed_modifications, parse_overrides
+from config.schema import get_template_config
+from config_utils import clean_config
+from pure_funcs import sort_dict_keys
+from utils import json_dumps_streamlined
+
+
+CONFIG_SUFFIXES = frozenset({".json", ".hjson"})
+POSITION_SIDES = ("long", "short")
+OUTPUT_ROOTS = ("config_version", "bot", "coin_overrides", "live", "logging", "monitor")
+
+
+@dataclass
+class SingleCoinConfig:
+    path: Path
+    coin: str
+    approved_sides: frozenset[str]
+    config: dict
+
+
+@dataclass
+class CompositionReport:
+    source_paths: list[Path]
+    master_path: Path
+    master_was_selected: bool
+    coins: list[str]
+    canonicalized_features: list[str]
+    account_wide_conflicts: dict[str, list[str]]
+    override_leaf_counts: dict[str, int]
+    included_backtest_optimize: bool
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="passivbot tool compose-coin-overrides",
+        description=(
+            "Compose a directory of single-coin configs into one config with minimal inline "
+            "coin_overrides."
+        ),
+    )
+    parser.add_argument(
+        "input_directory",
+        type=Path,
+        help="Directory containing the single-coin JSON/HJSON configs",
+    )
+    parser.add_argument("output_config", type=Path, help="Path for the composed JSON config")
+    parser.add_argument(
+        "--master-config",
+        type=Path,
+        default=None,
+        help=(
+            "Input config to use for master/global values. May be a filename in input_directory "
+            "or its path. Defaults to the alphabetically first input."
+        ),
+    )
+    parser.add_argument(
+        "--include-backtest-optimize",
+        action="store_true",
+        help=(
+            "Include backtest and optimize sections from the master input. They are omitted by "
+            "default for a lean live config."
+        ),
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace output_config if it already exists",
+    )
+    return parser
+
+
+def discover_config_paths(
+    input_directory: Path, *, output_config: Path | None = None
+) -> list[Path]:
+    directory = input_directory.expanduser().resolve()
+    if not directory.is_dir():
+        raise NotADirectoryError(
+            f"input directory does not exist or is not a directory: {directory}"
+        )
+    output_resolved = output_config.expanduser().resolve() if output_config is not None else None
+    paths = sorted(
+        (
+            path.resolve()
+            for path in directory.iterdir()
+            if path.is_file()
+            and path.suffix.lower() in CONFIG_SUFFIXES
+            and path.resolve() != output_resolved
+        ),
+        key=lambda path: (path.name.casefold(), path.name),
+    )
+    if len(paths) < 2:
+        raise ValueError(
+            f"expected at least two JSON/HJSON configs in {directory}; found {len(paths)}"
+        )
+    return paths
+
+
+def _side_coin_lists(config: dict, key: str, *, path: Path) -> dict[str, list[str]]:
+    value = config.get("live", {}).get(key)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: live.{key} must be a per-side mapping")
+    result = {}
+    for side in POSITION_SIDES:
+        coins = value.get(side)
+        if not isinstance(coins, list) or not all(isinstance(coin, str) for coin in coins):
+            raise ValueError(f"{path}: live.{key}.{side} must be a list of coin names")
+        result[side] = coins
+    return result
+
+
+def load_single_coin_config(path: Path) -> SingleCoinConfig:
+    source, base_config_path, raw_snapshot = load_input_config(str(path), log_info=False)
+    if not isinstance(source, dict):
+        raise TypeError(f"{path}: configuration root must be an object")
+    if source.get("coin_overrides"):
+        raise ValueError(f"{path}: single-coin input must not contain coin_overrides")
+    prepared = prepare_config(
+        source,
+        base_config_path=base_config_path,
+        verbose=False,
+        log_config_transforms=False,
+        raw_snapshot=raw_snapshot,
+    )
+    config = clean_config(prepared)
+    approved = _side_coin_lists(config, "approved_coins", path=path)
+    ignored = _side_coin_lists(config, "ignored_coins", path=path)
+    approved_union = {coin for coins in approved.values() for coin in coins}
+    if len(approved_union) != 1:
+        formatted = ", ".join(sorted(approved_union)) or "none"
+        raise ValueError(
+            f"{path}: expected exactly one approved coin across long/short; found {formatted}"
+        )
+    coin = next(iter(approved_union))
+    approved_sides = frozenset(side for side, coins in approved.items() if coin in coins)
+    for side in POSITION_SIDES:
+        if coin in ignored[side]:
+            raise ValueError(
+                f"{path}: single approved coin {coin} is also present in live.ignored_coins.{side}"
+            )
+        extra = sorted(set(approved[side]) - {coin})
+        if extra:
+            raise ValueError(
+                f"{path}: live.approved_coins.{side} contains additional coin(s): "
+                + ", ".join(extra)
+            )
+    return SingleCoinConfig(path=path, coin=coin, approved_sides=approved_sides, config=config)
+
+
+def _resolve_master_path(
+    input_directory: Path, paths: list[Path], master_config: Path | None
+) -> tuple[Path, bool]:
+    if master_config is None:
+        return paths[0], False
+    selected = master_config.expanduser()
+    if not selected.is_absolute():
+        directory_candidate = input_directory.expanduser().resolve() / selected
+        selected = directory_candidate if directory_candidate.exists() else selected.resolve()
+    selected = selected.resolve()
+    if selected not in paths:
+        raise ValueError(
+            f"selected master config is not a JSON/HJSON input in {input_directory}: {selected}"
+        )
+    return selected, True
+
+
+def load_single_coin_directory(
+    input_directory: Path,
+    *,
+    output_config: Path | None = None,
+    master_config: Path | None = None,
+) -> tuple[list[SingleCoinConfig], bool]:
+    paths = discover_config_paths(input_directory, output_config=output_config)
+    master_path, master_was_selected = _resolve_master_path(
+        input_directory, paths, master_config
+    )
+    configs = [load_single_coin_config(path) for path in paths]
+    by_coin: dict[str, Path] = {}
+    for item in configs:
+        if item.coin in by_coin:
+            raise ValueError(
+                f"duplicate single-coin config for {item.coin}: "
+                f"{by_coin[item.coin]} and {item.path}"
+            )
+        by_coin[item.coin] = item.path
+    strategy_kinds = {
+        str(item.config.get("live", {}).get("strategy_kind")) for item in configs
+    }
+    if len(strategy_kinds) != 1:
+        raise ValueError(
+            "all single-coin configs must use the same live.strategy_kind; found "
+            + ", ".join(sorted(strategy_kinds))
+        )
+    signal_modes = {
+        str(item.config.get("live", {}).get("hsl_signal_mode")) for item in configs
+    }
+    if len(signal_modes) != 1:
+        raise ValueError(
+            "all single-coin configs must use the same live.hsl_signal_mode; found "
+            + ", ".join(sorted(signal_modes))
+        )
+    master = next(item for item in configs if item.path == master_path)
+    ordered = [master, *(item for item in configs if item.path != master_path)]
+    return ordered, master_was_selected
+
+
+def _get_path(config: dict, path: Iterable[str]) -> Any:
+    current: Any = config
+    parts = tuple(path)
+    for key in parts:
+        if not isinstance(current, dict) or key not in current:
+            raise KeyError(".".join(parts))
+        current = current[key]
+    return current
+
+
+def _set_path(config: dict, path: tuple[str, ...], value: Any) -> None:
+    current = config
+    for key in path[:-1]:
+        current = current.setdefault(key, {})
+    current[path[-1]] = deepcopy(value)
+
+
+def _bound_lower(config: dict, side: str, group: str, key: str) -> float | int:
+    raw = _get_path(config, ("optimize", "bounds", side, group, key))
+    if isinstance(raw, (list, tuple)) and raw:
+        candidates = raw[:2] if len(raw) >= 2 else raw
+        if all(
+            isinstance(value, (int, float)) and not isinstance(value, bool)
+            for value in candidates
+        ):
+            return min(candidates)
+    if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+        return raw
+    raise ValueError(
+        f"optimize.bounds.{side}.{group}.{key} must contain a numeric lower bound"
+    )
+
+
+def _canonical_disabled_group(master: dict, side: str, group: str) -> dict:
+    result = deepcopy(get_template_config()["bot"][side][group])
+    bounds = master["optimize"]["bounds"][side].get(group, {})
+    for key in bounds:
+        if key in result:
+            result[key] = _bound_lower(master, side, group, key)
+    result["enabled"] = False
+    return result
+
+
+def canonicalize_inactive_features(configs: list[SingleCoinConfig]) -> list[str]:
+    master = configs[0].config
+    actions: list[str] = []
+    schema = get_template_config()
+    for side in POSITION_SIDES:
+        hsl_disabled = [
+            not bool(item.config["bot"][side]["hsl"]["enabled"]) for item in configs
+        ]
+        if all(hsl_disabled):
+            canonical = _canonical_disabled_group(master, side, "hsl")
+            for item in configs:
+                item.config["bot"][side]["hsl"] = deepcopy(canonical)
+            actions.append(f"bot.{side}.hsl (disabled in every input)")
+        else:
+            master_hsl = master["bot"][side]["hsl"]
+            for item, disabled in zip(configs, hsl_disabled):
+                if disabled:
+                    item.config["bot"][side]["hsl"] = {
+                        **deepcopy(master_hsl),
+                        "enabled": False,
+                    }
+
+        unstuck_disabled = [
+            not bool(item.config["bot"][side]["unstuck"]["enabled"]) for item in configs
+        ]
+        unstuck_all_disabled = all(unstuck_disabled)
+        if unstuck_all_disabled:
+            canonical = _canonical_disabled_group(master, side, "unstuck")
+            for item in configs:
+                item.config["bot"][side]["unstuck"] = deepcopy(canonical)
+            actions.append(f"bot.{side}.unstuck (disabled in every input)")
+        else:
+            master_unstuck = master["bot"][side]["unstuck"]
+            for item, disabled in zip(configs, unstuck_disabled):
+                if disabled:
+                    item.config["bot"][side]["unstuck"] = {
+                        **deepcopy(master_unstuck),
+                        "enabled": False,
+                    }
+            ema_gating_disabled = [
+                not bool(item.config["bot"][side]["unstuck"]["ema_gating_enabled"])
+                for item in configs
+            ]
+            if all(ema_gating_disabled):
+                lower = _bound_lower(master, side, "unstuck", "ema_dist")
+                for item in configs:
+                    item.config["bot"][side]["unstuck"]["ema_dist"] = lower
+                actions.append(
+                    f"bot.{side}.unstuck.ema_dist (EMA gating disabled in every input)"
+                )
+            else:
+                master_ema_dist = master["bot"][side]["unstuck"]["ema_dist"]
+                for item, disabled in zip(configs, ema_gating_disabled):
+                    if disabled:
+                        item.config["bot"][side]["unstuck"]["ema_dist"] = master_ema_dist
+
+        wel_enforcer_disabled = [
+            not bool(
+                item.config["bot"][side]["risk"][
+                    "position_exposure_enforcer_enabled"
+                ]
+            )
+            for item in configs
+        ]
+        if all(wel_enforcer_disabled):
+            lower = _bound_lower(master, side, "risk", "position_exposure_enforcer_threshold")
+            for item in configs:
+                risk = item.config["bot"][side]["risk"]
+                risk["position_exposure_enforcer_enabled"] = False
+                risk["position_exposure_enforcer_threshold"] = lower
+            actions.append(f"bot.{side}.risk.position_exposure_enforcer (disabled in every input)")
+        else:
+            master_threshold = master["bot"][side]["risk"][
+                "position_exposure_enforcer_threshold"
+            ]
+            for item, disabled in zip(configs, wel_enforcer_disabled):
+                if disabled:
+                    item.config["bot"][side]["risk"][
+                        "position_exposure_enforcer_threshold"
+                    ] = master_threshold
+
+        twel_enforcer_disabled = all(
+            not bool(item.config["bot"][side]["risk"]["total_exposure_enforcer_enabled"])
+            for item in configs
+        )
+        twel_entry_gate_disabled = all(
+            not bool(item.config["bot"][side]["risk"]["total_exposure_entry_gate_enabled"])
+            for item in configs
+        )
+        if twel_enforcer_disabled:
+            policy_default = schema["bot"][side]["risk"]["total_exposure_enforcer_policy"]
+            for item in configs:
+                risk = item.config["bot"][side]["risk"]
+                risk["total_exposure_enforcer_enabled"] = False
+                risk["total_exposure_enforcer_policy"] = policy_default
+            actions.append(f"bot.{side}.risk.total_exposure_enforcer (disabled in every input)")
+            if twel_entry_gate_disabled:
+                lower = _bound_lower(
+                    master, side, "risk", "total_exposure_enforcer_threshold"
+                )
+                for item in configs:
+                    item.config["bot"][side]["risk"][
+                        "total_exposure_enforcer_threshold"
+                    ] = lower
+                actions.append(
+                    f"bot.{side}.risk.total_exposure_enforcer_threshold "
+                    "(entry gate and enforcer disabled in every input)"
+                )
+    return actions
+
+
+def _iter_leaves(value: Any, path: tuple[str, ...] = ()):
+    if isinstance(value, dict):
+        for key in sorted(value):
+            yield from _iter_leaves(value[key], (*path, key))
+        return
+    yield path, value
+
+
+def _policy_allows(policy: dict, path: tuple[str, ...]) -> bool:
+    current: Any = policy
+    for key in path:
+        if current is True:
+            return True
+        if not isinstance(current, dict) or key not in current:
+            return False
+        current = current[key]
+    return current is True
+
+
+def _count_leaves(value: Any) -> int:
+    return sum(1 for _path, _value in _iter_leaves(value))
+
+
+def _format_value(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def compose_configs(
+    configs: list[SingleCoinConfig],
+    *,
+    include_backtest_optimize: bool = False,
+    master_was_selected: bool = False,
+) -> tuple[dict, CompositionReport]:
+    if len(configs) < 2:
+        raise ValueError("at least two single-coin configs are required")
+    canonicalized_features = canonicalize_inactive_features(configs)
+    master_source = configs[0]
+    master = deepcopy(master_source.config)
+
+    approved = {
+        side: sorted(item.coin for item in configs if side in item.approved_sides)
+        for side in POSITION_SIDES
+    }
+    master["live"]["approved_coins"] = approved
+    for side in POSITION_SIDES:
+        master["live"]["ignored_coins"][side] = sorted(
+            set(master["live"]["ignored_coins"][side]) - set(approved[side])
+        )
+        if approved[side] and float(master["bot"][side]["risk"]["total_wallet_exposure_limit"]) > 0:
+            master["bot"][side]["risk"]["n_positions"] = float(len(approved[side]))
+
+    if not include_backtest_optimize:
+        master.pop("backtest", None)
+        master.pop("optimize", None)
+    master["coin_overrides"] = {}
+
+    policy = get_allowed_modifications(hsl_signal_mode=master["live"]["hsl_signal_mode"])
+    conflicts: dict[str, list[str]] = {}
+    skip_paths = {
+        ("live", "approved_coins", "long"),
+        ("live", "approved_coins", "short"),
+        ("bot", "long", "risk", "n_positions"),
+        ("bot", "short", "risk", "n_positions"),
+    }
+    comparable_master = master_source.config
+    for item in configs:
+        patch: dict = {}
+        for root in ("bot", "live", "logging", "monitor"):
+            master_leaves = dict(_iter_leaves(comparable_master[root], (root,)))
+            source_leaves = dict(_iter_leaves(item.config[root], (root,)))
+            for path in sorted(set(master_leaves) | set(source_leaves)):
+                if path in skip_paths or master_leaves.get(path) == source_leaves.get(path):
+                    continue
+                source_value = source_leaves.get(path)
+                if _policy_allows(policy, path):
+                    _set_path(patch, path, source_value)
+                else:
+                    description = (
+                        f"{item.path.name}={_format_value(source_value)}; "
+                        f"master={_format_value(master_leaves.get(path))}"
+                    )
+                    conflicts.setdefault(".".join(path), []).append(description)
+        if patch:
+            master["coin_overrides"][item.coin] = patch
+
+    expected_roots = set(OUTPUT_ROOTS)
+    if include_backtest_optimize:
+        expected_roots.update({"backtest", "optimize"})
+    master = sort_dict_keys({key: master[key] for key in expected_roots})
+
+    validated = prepare_config(
+        master,
+        verbose=False,
+        log_config_transforms=False,
+        raw_snapshot=master,
+    )
+    parse_overrides(validated, verbose=False)
+
+    report = CompositionReport(
+        source_paths=sorted((item.path for item in configs), key=lambda path: path.name.casefold()),
+        master_path=master_source.path,
+        master_was_selected=master_was_selected,
+        coins=sorted(item.coin for item in configs),
+        canonicalized_features=canonicalized_features,
+        account_wide_conflicts=conflicts,
+        override_leaf_counts={
+            coin: _count_leaves(patch) for coin, patch in master["coin_overrides"].items()
+        },
+        included_backtest_optimize=include_backtest_optimize,
+    )
+    return master, report
+
+
+def compose_directory(
+    input_directory: Path,
+    *,
+    output_config: Path | None = None,
+    master_config: Path | None = None,
+    include_backtest_optimize: bool = False,
+) -> tuple[dict, CompositionReport]:
+    configs, master_was_selected = load_single_coin_directory(
+        input_directory,
+        output_config=output_config,
+        master_config=master_config,
+    )
+    return compose_configs(
+        configs,
+        include_backtest_optimize=include_backtest_optimize,
+        master_was_selected=master_was_selected,
+    )
+
+
+def write_config(config: dict, output_config: Path, *, overwrite: bool = False) -> None:
+    output = output_config.expanduser()
+    if output.exists() and not overwrite:
+        raise FileExistsError(
+            f"output config already exists: {output}; pass --overwrite to replace it"
+        )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json_dumps_streamlined(config, indent=4, max_inline=72, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def print_report(report: CompositionReport, output_config: Path) -> None:
+    print(
+        f"Validated {len(report.source_paths)} single-coin configs: "
+        + ", ".join(report.coins)
+    )
+    selection = "selected" if report.master_was_selected else "alphabetically first"
+    print(f"Master source ({selection}): {report.master_path}")
+    if report.included_backtest_optimize:
+        print(f"Included backtest and optimize sections from: {report.master_path}")
+    else:
+        print("Omitted backtest and optimize sections for a lean live config")
+    for description in report.canonicalized_features:
+        print(f"Canonicalized inactive feature: {description}")
+    if report.account_wide_conflicts:
+        print("Kept master values for differing non-overridable/account-wide parameters:")
+        for path, descriptions in sorted(report.account_wide_conflicts.items()):
+            print(f"  {path}")
+            for description in descriptions:
+                print(f"    {description}")
+    else:
+        print("No differing non-overridable/account-wide parameters")
+    if report.override_leaf_counts:
+        rendered = ", ".join(
+            f"{coin}={count}" for coin, count in sorted(report.override_leaf_counts.items())
+        )
+        print(f"Coin override leaves: {rendered}")
+    else:
+        print("Coin override leaves: none")
+    print(f"Wrote composed config: {output_config}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        config, report = compose_directory(
+            args.input_directory,
+            output_config=args.output_config,
+            master_config=args.master_config,
+            include_backtest_optimize=args.include_backtest_optimize,
+        )
+        write_config(config, args.output_config, overwrite=args.overwrite)
+    except (OSError, TypeError, ValueError, KeyError) as exc:
+        print(f"compose-coin-overrides: {exc}", file=sys.stderr)
+        return 2
+    print_report(report, args.output_config)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tools/compose_coin_overrides.py
+++ b/src/tools/compose_coin_overrides.py
@@ -18,6 +18,7 @@ from utils import (
     coin_to_symbol,
     heuristic_symbol_to_coin,
     json_dumps_streamlined,
+    looks_like_exact_market_identifier,
     split_exchange_qualified_market_identifier,
     to_standard_exchange_name,
 )
@@ -210,6 +211,12 @@ def _market_identity(
         except MarketIdentifierResolutionError:
             continue
         resolved.add((exchange, symbol))
+    if looks_like_exact_market_identifier(identifier) and not resolved:
+        formatted_exchanges = ", ".join(exchanges) or "none"
+        raise ValueError(
+            f"could not resolve exact market identifier {identifier!r} on configured "
+            f"venue(s): {formatted_exchanges}; refresh market metadata before composing"
+        )
     _qualified_exchange, unqualified = split_exchange_qualified_market_identifier(identifier)
     fallback = heuristic_symbol_to_coin(unqualified).strip().casefold()
     return frozenset(resolved), fallback
@@ -229,6 +236,21 @@ def _identifiers_refer_to_same_market(
     return (
         not left_resolved or not right_resolved
     ) and left_fallback == right_fallback
+
+
+def _validate_market_identifiers(
+    configs: list[SingleCoinConfig], exchanges: tuple[str, ...]
+) -> None:
+    for item in configs:
+        for key in ("approved_coins", "ignored_coins"):
+            for side, identifiers in item.config.get("live", {}).get(key, {}).items():
+                for identifier in identifiers:
+                    try:
+                        _market_identity(identifier, exchanges)
+                    except ValueError as exc:
+                        raise ValueError(
+                            f"{item.path}: live.{key}.{side}: {exc}"
+                        ) from exc
 
 
 def _resolve_master_path(
@@ -268,6 +290,7 @@ def load_single_coin_directory(
             )
         by_coin[item.coin] = item.path
     resolution_exchanges = _market_resolution_exchanges(configs)
+    _validate_market_identifiers(configs, resolution_exchanges)
     for index, item in enumerate(configs):
         for previous in configs[:index]:
             if _identifiers_refer_to_same_market(

--- a/tests/test_compose_coin_overrides_tool.py
+++ b/tests/test_compose_coin_overrides_tool.py
@@ -175,6 +175,26 @@ def test_rejects_non_single_and_precomposed_inputs(tmp_path: Path):
         compose_directory(tmp_path)
 
 
+def test_rejects_nested_precomposed_input(tmp_path: Path):
+    _write(tmp_path / "a.json", _single_coin_config("BTC"))
+    nested = _single_coin_config("ETH")
+    nested["coin_overrides"] = {"ETH": {"live": {"leverage": 4}}}
+    _write(tmp_path / "b.json", {"config": nested})
+
+    with pytest.raises(ValueError, match="must not contain coin_overrides"):
+        compose_directory(tmp_path)
+
+
+def test_rejects_all_as_single_coin(tmp_path: Path):
+    _write(tmp_path / "a.json", _single_coin_config("BTC"))
+    wildcard = _single_coin_config("ETH")
+    wildcard["live"]["approved_coins"] = "all"
+    _write(tmp_path / "b.json", wildcard)
+
+    with pytest.raises(ValueError, match="'all' sentinel"):
+        compose_directory(tmp_path)
+
+
 def test_rejects_duplicate_coin_and_master_outside_directory(tmp_path: Path):
     _write(tmp_path / "a.json", _single_coin_config("BTC"))
     _write(tmp_path / "b.json", _single_coin_config("BTC"))
@@ -183,6 +203,25 @@ def test_rejects_duplicate_coin_and_master_outside_directory(tmp_path: Path):
         compose_directory(tmp_path)
     with pytest.raises(ValueError, match="selected master config is not"):
         compose_directory(tmp_path, master_config=tmp_path / "missing.json")
+
+
+def test_rejects_duplicate_resolved_market_aliases(tmp_path: Path):
+    _write(tmp_path / "a.json", _single_coin_config("BTC"))
+    _write(tmp_path / "b.json", _single_coin_config("BTCUSDT"))
+
+    with pytest.raises(ValueError, match="resolve to the same market"):
+        compose_directory(tmp_path)
+
+
+def test_removes_ignored_alias_of_approved_market(tmp_path: Path):
+    master = _single_coin_config("ETH")
+    master["live"]["ignored_coins"]["long"] = ["BTCUSDT", "DOGE"]
+    _write(tmp_path / "a.json", master)
+    _write(tmp_path / "b.json", _single_coin_config("BTC"))
+
+    composed, _report = compose_directory(tmp_path)
+
+    assert composed["live"]["ignored_coins"]["long"] == ["DOGE"]
 
 
 def test_cli_writes_sorted_config_and_protects_existing_output(tmp_path: Path, capsys):

--- a/tests/test_compose_coin_overrides_tool.py
+++ b/tests/test_compose_coin_overrides_tool.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from config.load import prepare_config
+from config.overrides import parse_overrides
+from config.schema import get_template_config
+from tools.compose_coin_overrides import compose_directory, main
+
+
+def _single_coin_config(coin: str) -> dict:
+    config = get_template_config()
+    config["live"]["approved_coins"] = {"long": [coin], "short": [coin]}
+    config["live"]["ignored_coins"] = {"long": [], "short": []}
+    config["live"]["user"] = "test_user"
+    config["coin_overrides"] = {}
+    for side in ("long", "short"):
+        risk = config["bot"][side]["risk"]
+        risk["n_positions"] = 1.0
+        risk["position_exposure_enforcer_enabled"] = False
+        risk["total_exposure_enforcer_enabled"] = False
+        config["bot"][side]["hsl"]["enabled"] = False
+    config["bot"]["long"]["risk"]["total_wallet_exposure_limit"] = 1.0
+    config["bot"]["short"]["risk"]["total_wallet_exposure_limit"] = 0.0
+    return config
+
+
+def _write(path: Path, config: dict) -> None:
+    path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+
+
+def test_composes_minimal_overrides_and_canonicalizes_disabled_features(tmp_path: Path):
+    first = _single_coin_config("BTC")
+    second = _single_coin_config("ETH")
+
+    first["bot"]["long"]["strategy"]["trailing_martingale"]["entry"][
+        "initial_qty_pct"
+    ] = 0.01
+    second["bot"]["long"]["strategy"]["trailing_martingale"]["entry"][
+        "initial_qty_pct"
+    ] = 0.02
+    first["bot"]["long"]["risk"]["entry_cooldown_minutes"] = 1.0
+    second["bot"]["long"]["risk"]["entry_cooldown_minutes"] = 2.0
+    first["bot"]["long"]["forager"]["volatility_ema_span_1m"] = 100.0
+    second["bot"]["long"]["forager"]["volatility_ema_span_1m"] = 200.0
+    first["live"]["leverage"] = 3
+    second["live"]["leverage"] = 5
+
+    first["bot"]["long"]["hsl"]["red_threshold"] = 0.21
+    second["bot"]["long"]["hsl"]["red_threshold"] = 0.11
+    first["optimize"]["bounds"]["long"]["hsl"]["red_threshold"] = [0.03, 0.25, 0.01]
+    first["bot"]["long"]["risk"]["position_exposure_enforcer_threshold"] = 0.9
+    second["bot"]["long"]["risk"]["position_exposure_enforcer_threshold"] = 0.8
+    first["optimize"]["bounds"]["long"]["risk"][
+        "position_exposure_enforcer_threshold"
+    ] = [0.7, 1.0, 0.01]
+
+    _write(tmp_path / "a_btc.json", first)
+    _write(tmp_path / "b_eth.json", second)
+
+    composed, report = compose_directory(tmp_path)
+
+    assert set(composed) == {
+        "bot",
+        "coin_overrides",
+        "config_version",
+        "live",
+        "logging",
+        "monitor",
+    }
+    assert composed["live"]["approved_coins"] == {
+        "long": ["BTC", "ETH"],
+        "short": ["BTC", "ETH"],
+    }
+    assert composed["bot"]["long"]["risk"]["n_positions"] == 2.0
+    assert composed["bot"]["short"]["risk"]["n_positions"] == 1.0
+    assert composed["bot"]["long"]["hsl"]["enabled"] is False
+    assert composed["bot"]["long"]["hsl"]["red_threshold"] == 0.03
+    assert (
+        composed["bot"]["long"]["risk"]["position_exposure_enforcer_threshold"]
+        == 0.7
+    )
+
+    assert "BTC" not in composed["coin_overrides"]
+    eth = composed["coin_overrides"]["ETH"]
+    assert (
+        eth["bot"]["long"]["strategy"]["trailing_martingale"]["entry"][
+            "initial_qty_pct"
+        ]
+        == 0.02
+    )
+    assert eth["bot"]["long"]["risk"]["entry_cooldown_minutes"] == 2.0
+    assert eth["live"]["leverage"] == 5
+    assert "hsl" not in eth["bot"]["long"]
+    assert "position_exposure_enforcer_threshold" not in eth["bot"]["long"]["risk"]
+    assert "bot.long.forager.volatility_ema_span_1m" in report.account_wide_conflicts
+
+    prepared = prepare_config(composed, verbose=False, log_config_transforms=False)
+    parse_overrides(prepared, verbose=False)
+
+
+def test_selected_master_supplies_globals_and_optional_sections(tmp_path: Path):
+    first = _single_coin_config("BTC")
+    selected = _single_coin_config("ETH")
+    first["bot"]["long"]["forager"]["volume_ema_span_1m"] = 300.0
+    selected["bot"]["long"]["forager"]["volume_ema_span_1m"] = 600.0
+    first["backtest"]["start_date"] = "2020-01-01"
+    selected["backtest"]["start_date"] = "2021-01-01"
+    first["optimize"]["iters"] = 100
+    selected["optimize"]["iters"] = 200
+    _write(tmp_path / "a_btc.json", first)
+    selected_path = tmp_path / "b_eth.json"
+    _write(selected_path, selected)
+
+    composed, report = compose_directory(
+        tmp_path,
+        master_config=Path("b_eth.json"),
+        include_backtest_optimize=True,
+    )
+
+    assert report.master_path == selected_path.resolve()
+    assert report.master_was_selected is True
+    assert composed["bot"]["long"]["forager"]["volume_ema_span_1m"] == 600.0
+    assert composed["backtest"]["start_date"] == "2021-01-01"
+    assert composed["optimize"]["iters"] == 200
+
+
+def test_mixed_feature_enablement_omits_inert_dependent_overrides(tmp_path: Path):
+    master = _single_coin_config("BTC")
+    disabled = _single_coin_config("ETH")
+    for config in (master, disabled):
+        config["bot"]["long"]["hsl"]["enabled"] = True
+        config["bot"]["long"]["unstuck"]["enabled"] = True
+        config["bot"]["long"]["risk"]["position_exposure_enforcer_enabled"] = True
+    disabled["bot"]["long"]["hsl"].update(
+        {"enabled": False, "red_threshold": 0.24, "ema_span_minutes": 12.0}
+    )
+    disabled["bot"]["long"]["unstuck"].update(
+        {"enabled": False, "threshold": 0.88, "close_pct": 0.11}
+    )
+    disabled["bot"]["long"]["risk"].update(
+        {
+            "position_exposure_enforcer_enabled": False,
+            "position_exposure_enforcer_threshold": 0.75,
+        }
+    )
+    _write(tmp_path / "a_btc.json", master)
+    _write(tmp_path / "b_eth.json", disabled)
+
+    composed, _report = compose_directory(tmp_path)
+
+    eth_long = composed["coin_overrides"]["ETH"]["bot"]["long"]
+    assert eth_long["hsl"] == {"enabled": False}
+    assert eth_long["unstuck"] == {"enabled": False}
+    assert eth_long["risk"] == {"position_exposure_enforcer_enabled": False}
+
+
+def test_rejects_non_single_and_precomposed_inputs(tmp_path: Path):
+    valid = _single_coin_config("BTC")
+    invalid = _single_coin_config("ETH")
+    invalid["live"]["approved_coins"]["long"].append("XRP")
+    _write(tmp_path / "a.json", valid)
+    _write(tmp_path / "b.json", invalid)
+
+    with pytest.raises(ValueError, match="expected exactly one approved coin"):
+        compose_directory(tmp_path)
+
+    invalid = _single_coin_config("ETH")
+    invalid["coin_overrides"] = {"ETH": {"live": {"leverage": 4}}}
+    _write(tmp_path / "b.json", invalid)
+    with pytest.raises(ValueError, match="must not contain coin_overrides"):
+        compose_directory(tmp_path)
+
+
+def test_rejects_duplicate_coin_and_master_outside_directory(tmp_path: Path):
+    _write(tmp_path / "a.json", _single_coin_config("BTC"))
+    _write(tmp_path / "b.json", _single_coin_config("BTC"))
+
+    with pytest.raises(ValueError, match="duplicate single-coin config for BTC"):
+        compose_directory(tmp_path)
+    with pytest.raises(ValueError, match="selected master config is not"):
+        compose_directory(tmp_path, master_config=tmp_path / "missing.json")
+
+
+def test_cli_writes_sorted_config_and_protects_existing_output(tmp_path: Path, capsys):
+    inputs = tmp_path / "inputs"
+    inputs.mkdir()
+    _write(inputs / "a.json", _single_coin_config("BTC"))
+    _write(inputs / "b.json", _single_coin_config("ETH"))
+    output = tmp_path / "composed.json"
+
+    assert main([str(inputs), str(output)]) == 0
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert list(payload) == sorted(payload)
+    assert "Master source (alphabetically first)" in capsys.readouterr().out
+
+    assert main([str(inputs), str(output)]) == 2
+    assert "pass --overwrite" in capsys.readouterr().err

--- a/tests/test_compose_coin_overrides_tool.py
+++ b/tests/test_compose_coin_overrides_tool.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import pytest
+import tools.compose_coin_overrides as compose_tool
 
 from config.load import prepare_config
 from config.overrides import parse_overrides
@@ -222,6 +223,59 @@ def test_removes_ignored_alias_of_approved_market(tmp_path: Path):
     composed, _report = compose_directory(tmp_path)
 
     assert composed["live"]["ignored_coins"]["long"] == ["DOGE"]
+
+
+def test_qualified_identifier_venue_participates_in_alias_resolution(
+    tmp_path: Path, monkeypatch
+):
+    def fake_coin_to_symbol(identifier, exchange, **_kwargs):
+        if exchange == "hyperliquid" and identifier in {
+            "hyperliquid::12345",
+            "xyz:TSLA",
+        }:
+            return "xyz:TSLA/USDC:USDC"
+        raise compose_tool.MarketIdentifierResolutionError("unavailable")
+
+    monkeypatch.setattr(compose_tool, "coin_to_symbol", fake_coin_to_symbol)
+    _write(tmp_path / "a.json", _single_coin_config("hyperliquid::12345"))
+    _write(tmp_path / "b.json", _single_coin_config("xyz:TSLA"))
+
+    with pytest.raises(ValueError, match="resolve to the same market"):
+        compose_directory(tmp_path)
+
+
+def test_qualified_identifier_venue_removes_ignored_alias(tmp_path: Path, monkeypatch):
+    def fake_coin_to_symbol(identifier, exchange, **_kwargs):
+        if exchange == "hyperliquid" and identifier in {
+            "hyperliquid::12345",
+            "xyz:TSLA",
+        }:
+            return "xyz:TSLA/USDC:USDC"
+        if identifier == "ETH":
+            return "ETH/USDC:USDC"
+        raise compose_tool.MarketIdentifierResolutionError("unavailable")
+
+    monkeypatch.setattr(compose_tool, "coin_to_symbol", fake_coin_to_symbol)
+    master = _single_coin_config("ETH")
+    master["live"]["ignored_coins"]["long"] = ["hyperliquid::12345"]
+    _write(tmp_path / "a.json", master)
+    _write(tmp_path / "b.json", _single_coin_config("xyz:TSLA"))
+
+    composed, _report = compose_directory(tmp_path)
+
+    assert composed["live"]["ignored_coins"]["long"] == []
+
+
+def test_rejects_retaining_gpu_optimizer_for_composed_config(tmp_path: Path):
+    master = _single_coin_config("BTC")
+    master["optimize"]["backend"] = "gpu"
+    _write(tmp_path / "a.json", master)
+    _write(tmp_path / "b.json", _single_coin_config("ETH"))
+
+    lean, _report = compose_directory(tmp_path)
+    assert "optimize" not in lean
+    with pytest.raises(ValueError, match="optimize.backend='gpu'"):
+        compose_directory(tmp_path, include_backtest_optimize=True)
 
 
 def test_cli_writes_sorted_config_and_protects_existing_output(tmp_path: Path, capsys):

--- a/tests/test_compose_coin_overrides_tool.py
+++ b/tests/test_compose_coin_overrides_tool.py
@@ -206,7 +206,13 @@ def test_rejects_duplicate_coin_and_master_outside_directory(tmp_path: Path):
         compose_directory(tmp_path, master_config=tmp_path / "missing.json")
 
 
-def test_rejects_duplicate_resolved_market_aliases(tmp_path: Path):
+def test_rejects_duplicate_resolved_market_aliases(tmp_path: Path, monkeypatch):
+    def fake_coin_to_symbol(identifier, exchange, **_kwargs):
+        if exchange == "binance" and identifier in {"BTC", "BTCUSDT"}:
+            return "BTC/USDT:USDT"
+        raise compose_tool.MarketIdentifierResolutionError("unavailable")
+
+    monkeypatch.setattr(compose_tool, "coin_to_symbol", fake_coin_to_symbol)
     _write(tmp_path / "a.json", _single_coin_config("BTC"))
     _write(tmp_path / "b.json", _single_coin_config("BTCUSDT"))
 
@@ -214,7 +220,15 @@ def test_rejects_duplicate_resolved_market_aliases(tmp_path: Path):
         compose_directory(tmp_path)
 
 
-def test_removes_ignored_alias_of_approved_market(tmp_path: Path):
+def test_removes_ignored_alias_of_approved_market(tmp_path: Path, monkeypatch):
+    def fake_coin_to_symbol(identifier, exchange, **_kwargs):
+        if exchange == "binance" and identifier in {"BTC", "BTCUSDT"}:
+            return "BTC/USDT:USDT"
+        if identifier in {"ETH", "DOGE"}:
+            return f"{identifier}/USDT:USDT"
+        raise compose_tool.MarketIdentifierResolutionError("unavailable")
+
+    monkeypatch.setattr(compose_tool, "coin_to_symbol", fake_coin_to_symbol)
     master = _single_coin_config("ETH")
     master["live"]["ignored_coins"]["long"] = ["BTCUSDT", "DOGE"]
     _write(tmp_path / "a.json", master)
@@ -223,6 +237,30 @@ def test_removes_ignored_alias_of_approved_market(tmp_path: Path):
     composed, _report = compose_directory(tmp_path)
 
     assert composed["live"]["ignored_coins"]["long"] == ["DOGE"]
+
+
+@pytest.mark.parametrize("field", ["approved", "ignored"])
+def test_rejects_unresolved_exact_market_identifiers(
+    tmp_path: Path, monkeypatch, field: str
+):
+    def unavailable_market(*_args, **_kwargs):
+        raise compose_tool.MarketIdentifierResolutionError("unavailable")
+
+    monkeypatch.setattr(compose_tool, "coin_to_symbol", unavailable_market)
+    first = _single_coin_config("ETH")
+    second = _single_coin_config("BTC")
+    if field == "approved":
+        second["live"]["approved_coins"] = {
+            "long": ["hyperliquid::12345"],
+            "short": ["hyperliquid::12345"],
+        }
+    else:
+        first["live"]["ignored_coins"]["long"] = ["hyperliquid::12345"]
+    _write(tmp_path / "a.json", first)
+    _write(tmp_path / "b.json", second)
+
+    with pytest.raises(ValueError, match="could not resolve exact market identifier"):
+        compose_directory(tmp_path)
 
 
 def test_qualified_identifier_venue_participates_in_alias_resolution(

--- a/tests/test_compose_coin_overrides_tool.py
+++ b/tests/test_compose_coin_overrides_tool.py
@@ -263,6 +263,30 @@ def test_rejects_unresolved_exact_market_identifiers(
         compose_directory(tmp_path)
 
 
+@pytest.mark.parametrize("field", ["approved", "ignored"])
+def test_rejects_exact_identifier_resolving_to_different_venue_markets(
+    tmp_path: Path, monkeypatch, field: str
+):
+    def fake_coin_to_symbol(identifier, exchange, **_kwargs):
+        if identifier == "12345":
+            return {
+                "binance": "ABC/USDT:USDT",
+                "bybit": "OTHER/USDT:USDT",
+            }[exchange]
+        raise compose_tool.MarketIdentifierResolutionError("unavailable")
+
+    monkeypatch.setattr(compose_tool, "coin_to_symbol", fake_coin_to_symbol)
+    first = _single_coin_config("ETH")
+    second = _single_coin_config("12345" if field == "approved" else "BTC")
+    if field == "ignored":
+        first["live"]["ignored_coins"]["long"] = ["12345"]
+    _write(tmp_path / "a.json", first)
+    _write(tmp_path / "b.json", second)
+
+    with pytest.raises(ValueError, match="resolves to different contracts"):
+        compose_directory(tmp_path)
+
+
 def test_qualified_identifier_venue_participates_in_alias_resolution(
     tmp_path: Path, monkeypatch
 ):

--- a/tests/test_passivbot_cli.py
+++ b/tests/test_passivbot_cli.py
@@ -159,6 +159,7 @@ def test_tool_help_lists_supported_tools(capsys):
     assert "streamline-json" in out
     assert "trailing-inspect" in out
     assert "compare-backtests" in out
+    assert "compose-coin-overrides" in out
     assert "verify-hlcvs-data" in out
     assert "requires full install" in out
 


### PR DESCRIPTION
## Summary
- add `passivbot tool compose-coin-overrides` for validating and combining single-coin configs into a minimal unified config
- support deterministic alphabetical master selection or `--master-config`, lean live output by default, and optional master backtest/optimize sections
- canonicalize inactive HSL/unstuck/enforcer parameters and report account-wide conflicts while emitting only legal differing overrides

## Validation
- `pytest -q tests/test_compose_coin_overrides_tool.py tests/test_passivbot_cli.py tests/test_coin_overrides.py tests/test_coin_overrides_foundation.py tests/test_coin_overrides_policy.py tests/test_coin_overrides_hsl.py tests/test_config_preserve_coin_overrides.py`
- `pytest -q tests/test_ai_docs.py tests/test_live_event_registry_docs.py tests/test_config_pipeline.py tests/test_config_cleaning.py tests/test_format_config.py`
- `PYTHONPATH=src python src/tools/check_ai_docs.py`
- `PYTHONPATH=src python src/tools/generate_live_event_registry.py --check`
- bounded multi-coin backtest and master-only fine-tune optimizer smoke using generated inline overrides