### PR TITLE
GPU: support recursive trailing-martingale entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,13 @@ All notable user-facing changes will be documented in this file.
   feed feasible, diverse candidates into the unchanged exact Rust backtester; only exact results
   reach the Pareto store, and independent broad-probe rank checks halt on proxy drift. Dual-side
   screening preserves separate indicator/trailing/position state, a shared balance, Rust fill
-  ordering, and hedge/one-way initial-side semantics. Recursive trailing-martingale grid modes,
-  other strategies, suites, multi-coin, HSL, auto-unstuck, collateral,
-  minimum-effective-cost filtering, market-order execution, incomplete candle tails, non-inert
-  fixed runtime overrides, and unmodeled risk gates fail closed. Fused delta-form Metal EMA updates
-  reduce long-horizon float32 path drift. Optimizer-limit feasibility disagreements feed aggregate,
-  proxy-front, and broad-probe rolling constraint-agreement gates, retain exact Rust as the only
+  ordering, and hedge/one-way initial-side semantics. Recursive trailing-martingale entry ladders
+  use immutable generation snapshots and fill every strictly crossed rung in Rust order. Recursive
+  trailing-martingale close grids, other strategies, suites, multi-coin, HSL, auto-unstuck,
+  collateral, minimum-effective-cost filtering, market-order execution, incomplete candle tails,
+  non-inert fixed runtime overrides, and unmodeled risk gates fail closed. Fused delta-form Metal
+  EMA updates reduce long-horizon float32 path drift. Optimizer-limit feasibility disagreements
+  feed aggregate, proxy-front, and broad-probe rolling constraint-agreement gates, retain exact Rust as the only
   authoritative classification, and persist per-limit proxy/exact diagnostics. Strict candle/order
   crossing comparisons are precomputed as
   integer price-tick boundaries, preventing float32 Metal prices from missing fills that exact Rust

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -54,8 +54,8 @@ mod tests {
         assert_eq!(source.matches("const int fo = k * 11").count(), 1);
         assert_eq!(source.matches("const int touch_down_tick").count(), 1);
         assert_eq!(source.matches("const int touch_up_tick").count(), 1);
-        assert_eq!(source.matches("high_fill_max_tick").count(), 3);
-        assert_eq!(source.matches("low_nonfill_max_tick").count(), 3);
+        assert_eq!(source.matches("high_fill_max_tick").count(), 4);
+        assert_eq!(source.matches("low_nonfill_max_tick").count(), 4);
         assert!(!source.contains("nextafter("));
         assert!(source.contains("int cticks = touch_controls ? touch_nearest_ticks : target_ticks"));
         assert!(source.contains("remainder == mq && mq_relation > 0"));
@@ -67,6 +67,9 @@ mod tests {
         assert!(source.contains("touch_up_ticks <= band_ticks"));
         assert!(source.contains("touch_down_ticks >= raw_reentry_ticks"));
         assert!(source.contains("touch_up_ticks <= raw_reentry_ticks"));
+        assert!(source.contains("entry_gen_balance"));
+        assert!(source.contains("for (int rung = 0; rung < 500; ++rung)"));
+        assert!(source.contains("cooldown_min != 0.0f"));
         assert!(!source.contains("price_now > rounded_target"));
         assert!(!source.contains("price_now < rounded_target"));
         assert!(!source.contains("nearest_ticks("));

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -48,6 +48,8 @@ struct TmSide {
     float psize, pprice, last_inc_k, pos_open_k;
     int entry_ticks, close_ticks;
     float entry_price, close_price, entry_qty, close_qty;
+    float entry_gen_balance, entry_gen_psize, entry_gen_pprice, entry_gen_kf;
+    int entry_gen_touch_ticks;
     float min_since_open, max_since_min, max_since_open, min_since_max;
 };
 
@@ -92,6 +94,9 @@ inline TmSide load_side(constant float* p, int o, float seed) {
     s.entry_ticks = 0; s.entry_qty = 0.0f;
     s.close_ticks = 0; s.close_qty = 0.0f;
     s.entry_price = 0.0f; s.close_price = 0.0f;
+    s.entry_gen_balance = 0.0f;
+    s.entry_gen_psize = 0.0f; s.entry_gen_pprice = 0.0f;
+    s.entry_gen_kf = -1.0f; s.entry_gen_touch_ticks = 0;
     s.min_since_open = INFINITY; s.max_since_min = 0.0f;
     s.max_since_open = 0.0f; s.min_since_max = INFINITY;
     return s;
@@ -179,6 +184,14 @@ inline void generate_orders(
     float band = is_long ? fmin(s.ema0, fmin(s.ema1, s.ema2))
                          : fmax(s.ema0, fmax(s.ema1, s.ema2));
     int entry_touch = is_long ? touch_down_ticks : touch_up_ticks;
+    // Exact Rust builds a recursive entry ladder from one immutable generation
+    // snapshot. Preserve that snapshot so all rungs touched by the next candle
+    // can be reconstructed without fee-adjusted sizing drift.
+    s.entry_gen_balance = balance;
+    s.entry_gen_psize = s.psize;
+    s.entry_gen_pprice = s.pprice;
+    s.entry_gen_kf = kf;
+    s.entry_gen_touch_ticks = entry_touch;
     int band_ticks = directional_ticks(
         band * (is_long ? 1.0f - s.initial_ema_dist
                         : 1.0f + s.initial_ema_dist),
@@ -506,19 +519,55 @@ inline void passivbot_single_coin_impl(
             && long_side.entry_qty > 0.0f
             && long_side.entry_ticks > low_nonfill_max_tick;
         if (long_entry_fill) {
-            float ep = long_side.entry_price;
-            float eq = round_step(long_side.entry_qty, qty_step);
-            balance -= eq * ep * c_mult * maker_fee;
-            bool was_flat = long_side.psize <= 0.0f;
-            float new_psize = round_step(long_side.psize + eq, qty_step);
-            float new_pprice = was_flat ? ep
-                : long_side.pprice * (long_side.psize / fmax(new_psize, 1.0e-12f))
-                    + ep * (eq / fmax(new_psize, 1.0e-12f));
-            if (was_flat) long_side.pos_open_k = kf;
-            long_side.psize = new_psize;
-            long_side.pprice = new_pprice;
-            long_side.last_inc_k = kf;
-            day_volume += fabs(eq) * ep / balance;
+            TmSide ladder_side = long_side;
+            ladder_side.psize = long_side.entry_gen_psize;
+            ladder_side.pprice = long_side.entry_gen_pprice;
+            const float ladder_balance = long_side.entry_gen_balance;
+            const float ladder_kf = long_side.entry_gen_kf;
+            int ladder_touch_ticks = long_side.entry_gen_touch_ticks;
+            int previous_ticks = 0;
+            for (int rung = 0; rung < 500; ++rung) {
+                int entry_ticks = rung == 0
+                    ? long_side.entry_ticks : ladder_side.entry_ticks;
+                float ep = rung == 0
+                    ? long_side.entry_price : ladder_side.entry_price;
+                float eq = round_step(
+                    rung == 0 ? long_side.entry_qty : ladder_side.entry_qty,
+                    qty_step
+                );
+                if (eq <= 0.0f || entry_ticks <= low_nonfill_max_tick
+                    || (rung > 0 && entry_ticks == previous_ticks)) break;
+
+                balance -= eq * ep * c_mult * maker_fee;
+                bool was_flat = long_side.psize <= 0.0f;
+                float new_psize = round_step(long_side.psize + eq, qty_step);
+                float new_pprice = was_flat ? ep
+                    : long_side.pprice * (long_side.psize / fmax(new_psize, 1.0e-12f))
+                        + ep * (eq / fmax(new_psize, 1.0e-12f));
+                if (was_flat) long_side.pos_open_k = kf;
+                long_side.psize = new_psize;
+                long_side.pprice = new_pprice;
+                long_side.last_inc_k = kf;
+                day_volume += fabs(eq) * ep / balance;
+
+                bool sim_flat = ladder_side.psize <= 0.0f;
+                float sim_psize = round_step(ladder_side.psize + eq, qty_step);
+                ladder_side.pprice = sim_flat ? ep
+                    : ladder_side.pprice
+                        * (ladder_side.psize / fmax(sim_psize, 1.0e-12f))
+                        + ep * (eq / fmax(sim_psize, 1.0e-12f));
+                ladder_side.psize = sim_psize;
+                previous_ticks = entry_ticks;
+                ladder_touch_ticks = min(ladder_touch_ticks, entry_ticks);
+                if (long_side.entry_retracement_base > 0.0f
+                    || long_side.cooldown_min != 0.0f) break;
+                generate_long_orders(
+                    ladder_side, ladder_balance, ep, qty_step,
+                    ladder_touch_ticks, ladder_touch_ticks, ladder_touch_ticks,
+                    touch_min_qty, touch_min_qty_relation, price_step, min_qty,
+                    min_cost, c_mult, ladder_kf, false
+                );
+            }
             long_side.entry_qty = 0.0f;
         }
 
@@ -548,19 +597,55 @@ inline void passivbot_single_coin_impl(
             && short_side.entry_qty > 0.0f
             && short_side.entry_ticks <= high_fill_max_tick;
         if (short_entry_fill) {
-            float ep = short_side.entry_price;
-            float eq = round_step(short_side.entry_qty, qty_step);
-            balance -= eq * ep * c_mult * maker_fee;
-            bool was_flat = short_side.psize <= 0.0f;
-            float new_psize = round_step(short_side.psize + eq, qty_step);
-            float new_pprice = was_flat ? ep
-                : short_side.pprice * (short_side.psize / fmax(new_psize, 1.0e-12f))
-                    + ep * (eq / fmax(new_psize, 1.0e-12f));
-            if (was_flat) short_side.pos_open_k = kf;
-            short_side.psize = new_psize;
-            short_side.pprice = new_pprice;
-            short_side.last_inc_k = kf;
-            day_volume += fabs(eq) * ep / balance;
+            TmSide ladder_side = short_side;
+            ladder_side.psize = short_side.entry_gen_psize;
+            ladder_side.pprice = short_side.entry_gen_pprice;
+            const float ladder_balance = short_side.entry_gen_balance;
+            const float ladder_kf = short_side.entry_gen_kf;
+            int ladder_touch_ticks = short_side.entry_gen_touch_ticks;
+            int previous_ticks = 0;
+            for (int rung = 0; rung < 500; ++rung) {
+                int entry_ticks = rung == 0
+                    ? short_side.entry_ticks : ladder_side.entry_ticks;
+                float ep = rung == 0
+                    ? short_side.entry_price : ladder_side.entry_price;
+                float eq = round_step(
+                    rung == 0 ? short_side.entry_qty : ladder_side.entry_qty,
+                    qty_step
+                );
+                if (eq <= 0.0f || entry_ticks > high_fill_max_tick
+                    || (rung > 0 && entry_ticks == previous_ticks)) break;
+
+                balance -= eq * ep * c_mult * maker_fee;
+                bool was_flat = short_side.psize <= 0.0f;
+                float new_psize = round_step(short_side.psize + eq, qty_step);
+                float new_pprice = was_flat ? ep
+                    : short_side.pprice * (short_side.psize / fmax(new_psize, 1.0e-12f))
+                        + ep * (eq / fmax(new_psize, 1.0e-12f));
+                if (was_flat) short_side.pos_open_k = kf;
+                short_side.psize = new_psize;
+                short_side.pprice = new_pprice;
+                short_side.last_inc_k = kf;
+                day_volume += fabs(eq) * ep / balance;
+
+                bool sim_flat = ladder_side.psize <= 0.0f;
+                float sim_psize = round_step(ladder_side.psize + eq, qty_step);
+                ladder_side.pprice = sim_flat ? ep
+                    : ladder_side.pprice
+                        * (ladder_side.psize / fmax(sim_psize, 1.0e-12f))
+                        + ep * (eq / fmax(sim_psize, 1.0e-12f));
+                ladder_side.psize = sim_psize;
+                previous_ticks = entry_ticks;
+                ladder_touch_ticks = max(ladder_touch_ticks, entry_ticks);
+                if (short_side.entry_retracement_base > 0.0f
+                    || short_side.cooldown_min != 0.0f) break;
+                generate_short_orders(
+                    ladder_side, ladder_balance, ep, qty_step,
+                    ladder_touch_ticks, ladder_touch_ticks, ladder_touch_ticks,
+                    touch_min_qty, touch_min_qty_relation, price_step, min_qty,
+                    min_cost, c_mult, ladder_kf, false
+                );
+            }
             short_side.entry_qty = 0.0f;
         }
 

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -117,20 +117,19 @@ def _minimum_rank_evidence_samples(halt: float) -> int:
 
 
 def _validate_trailing_martingale_mode_bounds(bound_by_key, enabled_sides) -> None:
-    """Reject recursive grid modes until the proxy models their full ladders."""
+    """Reject recursive close grids until the proxy models their full ladders."""
 
     for side in enabled_sides:
-        for mode in ("entry", "close"):
-            key = f"{side}_{mode}_retracement_base_pct"
-            bound = bound_by_key[key]
-            if float(bound.low) <= 0.0:
-                raise ValueError(
-                    "GPU trailing_martingale requires "
-                    f"bot.{side}.strategy.trailing_martingale.{mode}."
-                    "retracement_base_pct bounds to stay strictly positive; "
-                    "zero or negative values select recursive grid ladders that "
-                    "the screening proxy does not model"
-                )
+        key = f"{side}_close_retracement_base_pct"
+        bound = bound_by_key[key]
+        if float(bound.low) <= 0.0:
+            raise ValueError(
+                "GPU trailing_martingale requires "
+                f"bot.{side}.strategy.trailing_martingale.close."
+                "retracement_base_pct bounds to stay strictly positive; "
+                "zero or negative values select recursive close grids that "
+                "the screening proxy does not model"
+            )
 
 
 def _build_gpu_nsga2(config, *, sampling, population_size: int, n_params: int):

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -320,17 +320,28 @@ def test_trailing_martingale_bound_map_covers_both_directional_shapes():
     }
 
 
-def test_trailing_martingale_gpu_rejects_recursive_grid_mode_bounds():
+def test_trailing_martingale_gpu_allows_recursive_entry_mode_bounds():
     bounds = {
         f"{side}_{mode}_retracement_base_pct": Bound(0.0001, 0.01, 0.0001)
         for side in ("long", "short")
         for mode in ("entry", "close")
     }
 
+    bounds["long_entry_retracement_base_pct"] = Bound(0.0, 0.01, 0.0001)
+    bounds["short_entry_retracement_base_pct"] = Bound(-0.01, 0.01, 0.0001)
     _validate_trailing_martingale_mode_bounds(bounds, {"long", "short"})
+
+
+def test_trailing_martingale_gpu_rejects_recursive_close_mode_bounds():
+    bounds = {
+        f"{side}_{mode}_retracement_base_pct": Bound(0.0001, 0.01, 0.0001)
+        for side in ("long", "short")
+        for mode in ("entry", "close")
+    }
+
     bounds["short_close_retracement_base_pct"] = Bound(0.0, 0.01, 0.0001)
 
-    with pytest.raises(ValueError, match="recursive grid ladders"):
+    with pytest.raises(ValueError, match="recursive close grids"):
         _validate_trailing_martingale_mode_bounds(bounds, {"long", "short"})
 
 
@@ -502,6 +513,16 @@ def test_gpu_foundation_accepts_each_directional_trailing_martingale_mode(
     config = _directional_tm_config(
         long_enabled=long_enabled, short_enabled=short_enabled
     )
+
+    assert _validate_scope(config, _Evaluator()) == "bybit"
+
+
+def test_gpu_foundation_accepts_recursive_trailing_martingale_entry_bounds():
+    config = _directional_tm_config(long_enabled=True, short_enabled=True)
+    for side in ("long", "short"):
+        config["optimize"]["bounds"][side]["strategy"]["trailing_martingale"][
+            "entry"
+        ]["retracement_base_pct"] = [-0.01, 0.01, 0.0001]
 
     assert _validate_scope(config, _Evaluator()) == "bybit"
 

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -441,6 +441,10 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert "min_since_max" in source
     assert "s.entry_retracement_base > 0.0f" in source
     assert "s.close_retracement_base > 0.0f" in source
+    assert "entry_gen_balance" in source
+    assert "for (int rung = 0; rung < 500; ++rung)" in source
+    assert "ladder_side, ladder_balance" in source
+    assert "cooldown_min != 0.0f" in source
     assert "int entry_touch = is_long ? touch_down_ticks : touch_up_ticks" in source
     assert "int raw_reentry_ticks = reentry_target_is_touch" in source
     assert "int cticks = touch_controls ? touch_nearest_ticks : target_ticks" in source
@@ -482,6 +486,104 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert output["day_has_fill"].sum().item() > 0
     assert (output["psize"].item() > 0.0) is long_enabled
     assert (output["short_psize"].item() > 0.0) is short_enabled
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("is_long", [True, False])
+def test_mps_trailing_martingale_fills_recursive_entry_ladder(is_long):
+    from optimization.gpu.mps_kernel import MpsTrailingMartingaleRunner
+
+    count = 7
+    close = np.full(count, 100.0)
+    high = np.full(count, 100.0)
+    low = np.full(count, 100.0)
+    if is_long:
+        low[2] = 99.99  # Fill the initial entry generated on the prior bar.
+        low[3] = 90.0  # Strictly cross several pre-generated recursive rungs.
+    else:
+        high[2] = 100.01
+        high[3] = 110.0
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 5.0, 1.0, 0.0002)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_row(initial_ema_dist=0.0, gate_initial=0.0, gate_reentry=0.0)
+    row[4] = 1.5  # entry double-down factor
+    row[6] = 0.05  # initial entry uses 5% of the exposure budget
+    row[11] = 0.0  # recursive entry mode
+    row[16] = 1.0  # keep trailing closes unreachable in this fixture
+
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=is_long,
+        short_enabled=not is_long,
+    ).run(np.array([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    position = output["psize" if is_long else "short_psize"].item()
+    # Initial qty is 0.5 and the first reentry is 0.75. Crossing more than
+    # those two orders proves the recursive ladder, not merely one reentry,
+    # was filled in the same candle.
+    assert position > 1.25
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_trailing_martingale_fills_recursive_entry_ladders_in_hedge_mode():
+    from optimization.gpu.mps_kernel import MpsTrailingMartingaleRunner
+
+    count = 7
+    close = np.full(count, 100.0)
+    high = np.full(count, 100.0)
+    low = np.full(count, 100.0)
+    low[2], high[2] = 99.99, 100.01
+    low[3], high[3] = 90.0, 110.0
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 5.0, 1.0, 0.0002)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_row(initial_ema_dist=0.0, gate_initial=0.0, gate_reentry=0.0)
+    row[4], row[6], row[11], row[16] = 1.5, 0.05, 0.0, 1.0
+
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=True,
+        short_enabled=True,
+        hedge_mode=True,
+    ).run(np.array([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert output["psize"].item() > 1.25
+    assert output["short_psize"].item() > 1.25
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## What

- allow zero/negative trailing-martingale entry retracement bounds on the Apple MPS optimizer
- reconstruct Rust's full recursive entry ladder from an immutable generation snapshot
- fill every strictly crossed long/short rung in canonical order, including hedge-mode dual-side runs
- retain sequential one-order staging when entry cooldown is nonzero
- keep recursive close grids fail-closed for the next slice

## Why

Exact Rust builds the full passive entry grid one bar ahead using a fixed balance and simulated position. Recomputing each Metal rung from fee-adjusted live state would drift, so the proxy preserves the generation balance, position, price, time, and touch while applying actual fees and position updates per fill.

## Scope and safety

This is additive to the experimental Apple MPS optimizer only. Exact Rust remains authoritative, only exact validations enter the Pareto store, and all CPU/live/backtest paths remain unchanged. Unsupported recursive close grids still fail closed.

## Validation

- 116 GPU Python tests, including real Apple MPS long, short, and hedge-mode recursive ladder tests
- 259 Rust tests with no default features
- cargo check --tests
- cargo fmt --check and git diff --check
- rebuilt/stamped PyO3 extension with exact source fingerprint verification
- bounded ETH long-only recursive-entry optimizer: 2,048 proxy evaluations, 128 exact validations, completed without halt; final 64-sample rho=0.99995, broad-probe rho=1.0, front rho=0.99963, zero constraint mismatches
- interleaved positive-retracement MPS microbenchmark: branch median 0.750s vs master 0.965s for 1,024 candidates x 30,000 synthetic minutes