### PR TITLE
feat(gpu): support recursive martingale closes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ All notable user-facing changes will be documented in this file.
   feed feasible, diverse candidates into the unchanged exact Rust backtester; only exact results
   reach the Pareto store, and independent broad-probe rank checks halt on proxy drift. Dual-side
   screening preserves separate indicator/trailing/position state, a shared balance, Rust fill
-  ordering, and hedge/one-way initial-side semantics. Recursive trailing-martingale entry ladders
-  use immutable generation snapshots and fill every strictly crossed rung in Rust order. Recursive
-  trailing-martingale close grids, other strategies, suites, multi-coin, HSL, auto-unstuck,
+  ordering, and hedge/one-way initial-side semantics. Recursive trailing-martingale entry and close
+  ladders use immutable generation snapshots, merge equal-price closes, and fill every strictly
+  crossed rung in Rust's canonical order. Other strategies, suites, multi-coin, HSL, auto-unstuck,
   collateral, minimum-effective-cost filtering, market-order execution, incomplete candle tails,
   non-inert fixed runtime overrides, and unmodeled risk gates fail closed. Fused delta-form Metal
   EMA updates reduce long-horizon float32 path drift. Optimizer-limit feasibility disagreements

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -54,8 +54,8 @@ mod tests {
         assert_eq!(source.matches("const int fo = k * 11").count(), 1);
         assert_eq!(source.matches("const int touch_down_tick").count(), 1);
         assert_eq!(source.matches("const int touch_up_tick").count(), 1);
-        assert_eq!(source.matches("high_fill_max_tick").count(), 4);
-        assert_eq!(source.matches("low_nonfill_max_tick").count(), 4);
+        assert_eq!(source.matches("high_fill_max_tick").count(), 6);
+        assert_eq!(source.matches("low_nonfill_max_tick").count(), 6);
         assert!(!source.contains("nextafter("));
         assert!(source.contains("int cticks = touch_controls ? touch_nearest_ticks : target_ticks"));
         assert!(source.contains("remainder == mq && mq_relation > 0"));
@@ -68,6 +68,8 @@ mod tests {
         assert!(source.contains("touch_down_ticks >= raw_reentry_ticks"));
         assert!(source.contains("touch_up_ticks <= raw_reentry_ticks"));
         assert!(source.contains("entry_gen_balance"));
+        assert!(source.contains("close_gen_balance"));
+        assert!(source.contains("recursive_close_groups"));
         assert!(source.contains("for (int rung = 0; rung < 500; ++rung)"));
         assert!(source.contains("cooldown_min != 0.0f"));
         assert!(!source.contains("price_now > rounded_target"));

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -50,7 +50,18 @@ struct TmSide {
     float entry_price, close_price, entry_qty, close_qty;
     float entry_gen_balance, entry_gen_psize, entry_gen_pprice, entry_gen_kf;
     int entry_gen_touch_ticks;
+    float close_gen_balance, close_gen_psize, close_gen_pprice;
+    int close_gen_touch_down_ticks, close_gen_touch_up_ticks;
+    int close_gen_touch_nearest_ticks;
+    float close_gen_touch_min_qty;
+    int close_gen_touch_min_qty_relation;
     float min_since_open, max_since_min, max_since_open, min_since_max;
+};
+
+struct CloseGroup {
+    int ticks;
+    float price;
+    float qty;
 };
 
 inline TmSide load_side(constant float* p, int o, float seed) {
@@ -97,6 +108,12 @@ inline TmSide load_side(constant float* p, int o, float seed) {
     s.entry_gen_balance = 0.0f;
     s.entry_gen_psize = 0.0f; s.entry_gen_pprice = 0.0f;
     s.entry_gen_kf = -1.0f; s.entry_gen_touch_ticks = 0;
+    s.close_gen_balance = 0.0f;
+    s.close_gen_psize = 0.0f; s.close_gen_pprice = 0.0f;
+    s.close_gen_touch_down_ticks = 0; s.close_gen_touch_up_ticks = 0;
+    s.close_gen_touch_nearest_ticks = 0;
+    s.close_gen_touch_min_qty = 0.0f;
+    s.close_gen_touch_min_qty_relation = 0;
     s.min_since_open = INFINITY; s.max_since_min = 0.0f;
     s.max_since_open = 0.0f; s.min_since_max = INFINITY;
     return s;
@@ -192,6 +209,14 @@ inline void generate_orders(
     s.entry_gen_pprice = s.pprice;
     s.entry_gen_kf = kf;
     s.entry_gen_touch_ticks = entry_touch;
+    s.close_gen_balance = balance;
+    s.close_gen_psize = s.psize;
+    s.close_gen_pprice = s.pprice;
+    s.close_gen_touch_down_ticks = touch_down_ticks;
+    s.close_gen_touch_up_ticks = touch_up_ticks;
+    s.close_gen_touch_nearest_ticks = touch_nearest_ticks;
+    s.close_gen_touch_min_qty = touch_min_qty;
+    s.close_gen_touch_min_qty_relation = touch_min_qty_relation;
     int band_ticks = directional_ticks(
         band * (is_long ? 1.0f - s.initial_ema_dist
                         : 1.0f + s.initial_ema_dist),
@@ -389,6 +414,71 @@ inline void generate_short_orders(
     );
 }
 
+// Rebuild Rust's immutable recursive close grid and return its number of
+// duplicate-merged price groups. If wanted_group is present, also return that
+// group. Keeping only one requested group avoids a large per-GPU-thread array;
+// close grids are rebuilt only after a conservative fill-reachability check.
+inline int recursive_close_groups(
+    thread const TmSide& source, bool is_long, int wanted_group,
+    float qty_step, float price_step, float min_qty, float min_cost, float c_mult,
+    thread CloseGroup& selected
+) {
+    selected.ticks = 0;
+    selected.price = 0.0f;
+    selected.qty = 0.0f;
+    TmSide sim = source;
+    sim.psize = source.close_gen_psize;
+    sim.pprice = source.close_gen_pprice;
+    bool have_group = false;
+    int group_count = 0;
+    int group_ticks = 0;
+    float group_price = 0.0f;
+    float group_qty = 0.0f;
+
+    for (int rung = 0; rung < 500; ++rung) {
+        generate_orders(
+            sim, is_long, source.close_gen_balance, source.close_gen_pprice,
+            source.close_gen_touch_down_ticks, source.close_gen_touch_up_ticks,
+            source.close_gen_touch_nearest_ticks, source.close_gen_touch_min_qty,
+            source.close_gen_touch_min_qty_relation, qty_step, price_step,
+            min_qty, min_cost, c_mult, 0.0f, false
+        );
+        float qty = round_step(sim.close_qty, qty_step);
+        if (qty <= 0.0f || sim.close_ticks <= 0) break;
+
+        if (!have_group) {
+            have_group = true;
+            group_ticks = sim.close_ticks;
+            group_price = sim.close_price;
+            group_qty = qty;
+        } else if (sim.close_ticks == group_ticks) {
+            group_qty = round_step(group_qty + qty, qty_step);
+        } else {
+            if (group_count == wanted_group) {
+                selected.ticks = group_ticks;
+                selected.price = group_price;
+                selected.qty = group_qty;
+            }
+            ++group_count;
+            group_ticks = sim.close_ticks;
+            group_price = sim.close_price;
+            group_qty = qty;
+        }
+
+        sim.psize = fmax(round_step(sim.psize - qty, qty_step), 0.0f);
+        if (sim.psize <= 0.0f) break;
+    }
+    if (have_group) {
+        if (group_count == wanted_group) {
+            selected.ticks = group_ticks;
+            selected.price = group_price;
+            selected.qty = group_qty;
+        }
+        ++group_count;
+    }
+    return group_count;
+}
+
 inline void passivbot_single_coin_impl(
     constant float* bars,
     constant int* flags,
@@ -493,10 +583,66 @@ inline void passivbot_single_coin_impl(
             day_has_fill = 0.0f;
         }
 
-        bool long_close_fill = valid && alive && long_enabled
-            && long_side.close_qty > 0.0f && long_side.psize > 0.0f
+        bool long_close_fill = false;
+        bool long_close_ready = valid && alive && long_enabled
+            && long_side.close_qty > 0.0f && long_side.psize > 0.0f;
+        bool long_recursive_close = long_side.close_retracement_base <= 0.0f;
+        bool long_scan_close_grid = long_close_ready
             && long_side.close_ticks <= high_fill_max_tick;
-        if (long_close_fill) {
+        if (long_close_ready && long_recursive_close
+            && long_side.close_threshold_we > 0.0f) {
+            // Positive WE weight makes later generated long closes nearer.
+            // The zero-WE target is a conservative lower bound: reconstruct
+            // the sorted grid only if this candle can reach that bound.
+            float threshold_floor = long_side.close_threshold_base
+                + long_side.vol1h * long_side.close_threshold_v1h
+                + long_side.vol1m * long_side.close_threshold_v1m;
+            int target_ticks = directional_ticks(
+                long_side.close_gen_pprice * (1.0f + threshold_floor),
+                price_step, true
+            );
+            bool touch_controls = long_side.close_gen_touch_up_ticks > target_ticks;
+            int nearest_ticks = touch_controls
+                ? long_side.close_gen_touch_nearest_ticks : target_ticks;
+            long_scan_close_grid = nearest_ticks <= high_fill_max_tick;
+        }
+        if (long_scan_close_grid && long_recursive_close) {
+            CloseGroup group;
+            int group_count = recursive_close_groups(
+                long_side, true, -1, qty_step, price_step,
+                min_qty, min_cost, c_mult, group
+            );
+            bool reverse = long_side.close_threshold_we > 0.0f;
+            for (int rank = 0; rank < group_count; ++rank) {
+                int wanted = reverse ? group_count - rank - 1 : rank;
+                recursive_close_groups(
+                    long_side, true, wanted, qty_step, price_step,
+                    min_qty, min_cost, c_mult, group
+                );
+                if (group.qty <= 0.0f || group.ticks > high_fill_max_tick) break;
+                float adj = fmin(round_step(group.qty, qty_step), long_side.psize);
+                float pnl = adj * c_mult * (group.price - long_side.pprice);
+                balance += pnl - adj * group.price * c_mult * maker_fee;
+                float new_psize = fmax(
+                    round_step(long_side.psize - adj, qty_step), 0.0f
+                );
+                bool went_flat = new_psize <= 0.0f;
+                long_side.psize = new_psize;
+                day_volume += fabs(adj) * group.price / balance;
+                long_close_fill = true;
+                if (went_flat) {
+                    long_side.pprice = 0.0f;
+                    if (long_side.pos_open_k >= 0.0f) {
+                        held_max_min = fmax(
+                            held_max_min, kf - long_side.pos_open_k
+                        );
+                    }
+                    long_side.pos_open_k = -1.0f;
+                    break;
+                }
+            }
+            if (long_close_fill) long_side.close_qty = 0.0f;
+        } else if (long_scan_close_grid) {
             float cp = long_side.close_price;
             float adj = fmin(round_step(long_side.close_qty, qty_step), long_side.psize);
             float pnl = adj * c_mult * (cp - long_side.pprice);
@@ -513,6 +659,7 @@ inline void passivbot_single_coin_impl(
             }
             day_volume += fabs(adj) * cp / balance;
             long_side.close_qty = 0.0f;
+            long_close_fill = true;
         }
 
         bool long_entry_fill = valid && alive && long_enabled
@@ -571,10 +718,65 @@ inline void passivbot_single_coin_impl(
             long_side.entry_qty = 0.0f;
         }
 
-        bool short_close_fill = valid && alive && short_enabled
-            && short_side.close_qty > 0.0f && short_side.psize > 0.0f
+        bool short_close_fill = false;
+        bool short_close_ready = valid && alive && short_enabled
+            && short_side.close_qty > 0.0f && short_side.psize > 0.0f;
+        bool short_recursive_close = short_side.close_retracement_base <= 0.0f;
+        bool short_scan_close_grid = short_close_ready
             && short_side.close_ticks > low_nonfill_max_tick;
-        if (short_close_fill) {
+        if (short_close_ready && short_recursive_close
+            && short_side.close_threshold_we > 0.0f) {
+            // Positive WE weight makes later generated short closes nearer.
+            // The zero-WE target is a conservative upper bound.
+            float threshold_floor = short_side.close_threshold_base
+                + short_side.vol1h * short_side.close_threshold_v1h
+                + short_side.vol1m * short_side.close_threshold_v1m;
+            int target_ticks = directional_ticks(
+                short_side.close_gen_pprice * (1.0f - threshold_floor),
+                price_step, false
+            );
+            bool touch_controls = short_side.close_gen_touch_down_ticks < target_ticks;
+            int nearest_ticks = touch_controls
+                ? short_side.close_gen_touch_nearest_ticks : target_ticks;
+            short_scan_close_grid = nearest_ticks > low_nonfill_max_tick;
+        }
+        if (short_scan_close_grid && short_recursive_close) {
+            CloseGroup group;
+            int group_count = recursive_close_groups(
+                short_side, false, -1, qty_step, price_step,
+                min_qty, min_cost, c_mult, group
+            );
+            bool reverse = short_side.close_threshold_we > 0.0f;
+            for (int rank = 0; rank < group_count; ++rank) {
+                int wanted = reverse ? group_count - rank - 1 : rank;
+                recursive_close_groups(
+                    short_side, false, wanted, qty_step, price_step,
+                    min_qty, min_cost, c_mult, group
+                );
+                if (group.qty <= 0.0f || group.ticks <= low_nonfill_max_tick) break;
+                float adj = fmin(round_step(group.qty, qty_step), short_side.psize);
+                float pnl = adj * c_mult * (short_side.pprice - group.price);
+                balance += pnl - adj * group.price * c_mult * maker_fee;
+                float new_psize = fmax(
+                    round_step(short_side.psize - adj, qty_step), 0.0f
+                );
+                bool went_flat = new_psize <= 0.0f;
+                short_side.psize = new_psize;
+                day_volume += fabs(adj) * group.price / balance;
+                short_close_fill = true;
+                if (went_flat) {
+                    short_side.pprice = 0.0f;
+                    if (short_side.pos_open_k >= 0.0f) {
+                        held_max_min = fmax(
+                            held_max_min, kf - short_side.pos_open_k
+                        );
+                    }
+                    short_side.pos_open_k = -1.0f;
+                    break;
+                }
+            }
+            if (short_close_fill) short_side.close_qty = 0.0f;
+        } else if (short_scan_close_grid) {
             float cp = short_side.close_price;
             float adj = fmin(round_step(short_side.close_qty, qty_step), short_side.psize);
             float pnl = adj * c_mult * (short_side.pprice - cp);
@@ -591,6 +793,7 @@ inline void passivbot_single_coin_impl(
             }
             day_volume += fabs(adj) * cp / balance;
             short_side.close_qty = 0.0f;
+            short_close_fill = true;
         }
 
         bool short_entry_fill = valid && alive && short_enabled

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -116,22 +116,6 @@ def _minimum_rank_evidence_samples(halt: float) -> int:
     return math.floor((MIN_DRIFT_PROBES - 1) / float(halt)) + 1
 
 
-def _validate_trailing_martingale_mode_bounds(bound_by_key, enabled_sides) -> None:
-    """Reject recursive close grids until the proxy models their full ladders."""
-
-    for side in enabled_sides:
-        key = f"{side}_close_retracement_base_pct"
-        bound = bound_by_key[key]
-        if float(bound.low) <= 0.0:
-            raise ValueError(
-                "GPU trailing_martingale requires "
-                f"bot.{side}.strategy.trailing_martingale.close."
-                "retracement_base_pct bounds to stay strictly positive; "
-                "zero or negative values select recursive close grids that "
-                "the screening proxy does not model"
-            )
-
-
 def _build_gpu_nsga2(config, *, sampling, population_size: int, n_params: int):
     """Build GPU proposal evolution with the same variation controls as pymoo CPU."""
 
@@ -1326,8 +1310,6 @@ def run_backend(
         bound_key: float(base_vector[index])
         for index, (bound_key, _path) in enumerate(key_paths)
     }
-    if strategy_kind == "trailing_martingale":
-        _validate_trailing_martingale_mode_bounds(bound_by_key, enabled_sides)
     _validate_pinned_scope_bounds(bound_by_key, base_by_key, enabled_sides)
 
     _validate_directional_search_space(

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -35,7 +35,6 @@ from optimization.backends.gpu_backend import (
     _validate_resume_evidence_budget,
     _validate_seed_side_match,
     _validate_scope,
-    _validate_trailing_martingale_mode_bounds,
     TRAILING_MARTINGALE_BOUND_MAP,
 )
 
@@ -320,31 +319,6 @@ def test_trailing_martingale_bound_map_covers_both_directional_shapes():
     }
 
 
-def test_trailing_martingale_gpu_allows_recursive_entry_mode_bounds():
-    bounds = {
-        f"{side}_{mode}_retracement_base_pct": Bound(0.0001, 0.01, 0.0001)
-        for side in ("long", "short")
-        for mode in ("entry", "close")
-    }
-
-    bounds["long_entry_retracement_base_pct"] = Bound(0.0, 0.01, 0.0001)
-    bounds["short_entry_retracement_base_pct"] = Bound(-0.01, 0.01, 0.0001)
-    _validate_trailing_martingale_mode_bounds(bounds, {"long", "short"})
-
-
-def test_trailing_martingale_gpu_rejects_recursive_close_mode_bounds():
-    bounds = {
-        f"{side}_{mode}_retracement_base_pct": Bound(0.0001, 0.01, 0.0001)
-        for side in ("long", "short")
-        for mode in ("entry", "close")
-    }
-
-    bounds["short_close_retracement_base_pct"] = Bound(0.0, 0.01, 0.0001)
-
-    with pytest.raises(ValueError, match="recursive close grids"):
-        _validate_trailing_martingale_mode_bounds(bounds, {"long", "short"})
-
-
 def test_cpu_backend_registry_import_does_not_import_torch():
     script = (
         "import json, sys; import optimization.backends; "
@@ -517,12 +491,13 @@ def test_gpu_foundation_accepts_each_directional_trailing_martingale_mode(
     assert _validate_scope(config, _Evaluator()) == "bybit"
 
 
-def test_gpu_foundation_accepts_recursive_trailing_martingale_entry_bounds():
+def test_gpu_foundation_accepts_recursive_trailing_martingale_bounds():
     config = _directional_tm_config(long_enabled=True, short_enabled=True)
     for side in ("long", "short"):
-        config["optimize"]["bounds"][side]["strategy"]["trailing_martingale"][
-            "entry"
-        ]["retracement_base_pct"] = [-0.01, 0.01, 0.0001]
+        for mode in ("entry", "close"):
+            config["optimize"]["bounds"][side]["strategy"][
+                "trailing_martingale"
+            ][mode]["retracement_base_pct"] = [-0.01, 0.01, 0.0001]
 
     assert _validate_scope(config, _Evaluator()) == "bybit"
 

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -442,8 +442,10 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert "s.entry_retracement_base > 0.0f" in source
     assert "s.close_retracement_base > 0.0f" in source
     assert "entry_gen_balance" in source
+    assert "close_gen_balance" in source
     assert "for (int rung = 0; rung < 500; ++rung)" in source
     assert "ladder_side, ladder_balance" in source
+    assert "recursive_close_groups" in source
     assert "cooldown_min != 0.0f" in source
     assert "int entry_touch = is_long ? touch_down_ticks : touch_up_ticks" in source
     assert "int raw_reentry_ticks = reentry_target_is_touch" in source
@@ -584,6 +586,110 @@ def test_mps_trailing_martingale_fills_recursive_entry_ladders_in_hedge_mode():
 
     assert output["psize"].item() > 1.25
     assert output["short_psize"].item() > 1.25
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("is_long", [True, False])
+@pytest.mark.parametrize("close_threshold_we", [-0.005, 0.005])
+def test_mps_trailing_martingale_fills_sorted_recursive_close_grid(
+    is_long, close_threshold_we
+):
+    from optimization.gpu.mps_kernel import MpsTrailingMartingaleRunner
+
+    count = 7
+    close = np.full(count, 100.0)
+    high = np.full(count, 100.0)
+    low = np.full(count, 100.0)
+    if is_long:
+        low[3] = 99.0  # Fill the initial entry generated on the prior bar.
+        high[4] = 100.85 if close_threshold_we > 0.0 else 100.6
+    else:
+        high[3] = 101.0
+        low[4] = 99.15 if close_threshold_we > 0.0 else 99.4
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 5.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_row(initial_ema_dist=0.0, gate_initial=0.0, gate_reentry=0.0)
+    row[6] = 0.1  # Open a 1-unit position.
+    row[7] = 0.01  # Exposure cap prevents reentries in this fixture.
+    row[15] = 0.05  # Two recursive close rungs at the standard lower bound.
+    row[16] = 0.005 if close_threshold_we > 0.0 else 0.01
+    row[17] = close_threshold_we * 10.0
+    row[20] = 0.0  # Recursive close mode.
+
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=is_long,
+        short_enabled=not is_long,
+    ).run(np.array([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    position = output["psize" if is_long else "short_psize"].item()
+    # The candle strictly crosses one of two sorted 0.5-unit closes. With
+    # positive WE weight, the generated grid must be reversed before filling;
+    # its first generated (farthest) order is deliberately not crossed.
+    assert position == pytest.approx(0.5, abs=1e-6)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_trailing_martingale_fills_recursive_close_grids_in_hedge_mode():
+    from optimization.gpu.mps_kernel import MpsTrailingMartingaleRunner
+
+    count = 8
+    close = np.full(count, 100.0)
+    high = np.full(count, 100.0)
+    low = np.full(count, 100.0)
+    low[3], high[3] = 99.0, 101.0
+    low[4], high[4] = 99.15, 100.85
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 5.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_row(initial_ema_dist=0.0, gate_initial=0.0, gate_reentry=0.0)
+    row[6], row[7], row[15] = 1.0, 1.0, 0.2
+    row[16], row[17], row[20] = 0.005, 0.005, 0.0
+
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=True,
+        short_enabled=True,
+        hedge_mode=True,
+    ).run(np.array([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert output["psize"].item() == pytest.approx(4.0, abs=1e-6)
+    assert output["short_psize"].item() == pytest.approx(4.0, abs=1e-6)
 
 
 @pytest.mark.skipif(
@@ -856,8 +962,8 @@ def test_mps_trailing_sizes_raw_touch_close_before_price_finalization():
     data = build_mps_data(high, low, close, timestamps, run, market)
     row = _tm_row(gate_initial=0.0, gate_reentry=0.0)
     row[15] = 0.01
-    row[16] = 0.0
-    row[17] = 1e-6  # keep grid-close sizing on close_qty_pct
+    row[16] = 0.199
+    row[17] = -2.0  # keep later grid closes above this fixture's high
     row[20] = 0.0
 
     output = MpsTrailingMartingaleRunner(
@@ -899,8 +1005,8 @@ def test_mps_trailing_preserves_just_above_aligned_raw_touch_minimum():
     data = build_mps_data(high, low, close, timestamps, run, market)
     row = _tm_row(gate_initial=0.0, gate_reentry=0.0)
     row[15] = 0.05
-    row[16] = 0.0
-    row[17] = 1e-6  # keep grid-close sizing on close_qty_pct
+    row[16] = 0.299
+    row[17] = -3.0  # keep a possible second grid close above the high
     row[20] = 0.0
 
     rounded_only_data = dict(data)


### PR DESCRIPTION
## Summary

- add recursive trailing-martingale close-grid screening to the Apple MPS backend
- preserve the immutable generation snapshot used by exact Rust close construction
- merge equal-price rungs and execute long/short closes in Rust's canonical sorted order
- support positive and negative wallet-exposure weights, including the positive-weight case where the nearest close is generated last
- remove the fail-closed bounds rejection now that recursive close grids are modeled
- remain purely additive to GPU optimization; CPU bot, backtest, and optimizer paths are unchanged

This builds on #1500's recursive-entry snapshot foundation.

## Implementation notes

The Metal proxy reconstructs a close grid only when the current candle can reach it. Positive WE-weight grids use a conservative zero-WE reachability bound because their nearest rung is generated last. Once reachable, the kernel rebuilds the static grid from its saved balance/position/book snapshot, merges adjacent equal-price rungs like Rust, and replays groups in canonical long-ascending / short-descending order. Exact Rust remains authoritative for every persisted optimizer result.

## Validation

- 129 GPU Python tests, including all real Apple MPS tests: passed
- 259 Rust tests with `--no-default-features`: passed
- `cargo check --tests`: passed
- `cargo fmt --check`: passed
- `git diff --check`: passed
- rebuilt/stamped extension fingerprint verified against this source
- real MPS behavior covers long, short, hedge mode, positive/negative WE ordering, strict crossings, raw-touch minimum sizing, and duplicate-price semantics
- performance, 1,024 candidates x 30,000 minutes, five runs:
  - recursive closes median: 0.753 s
  - unchanged trailing closes median: 0.735 s
- bounded local ETH long-only recursive-close optimizer:
  - Jan-Jun 2024, bybit, no suite
  - 16 generations, 16,384 proxy evaluations, 128 exact Rust validations
  - completed without halt
  - rolling rank: rho 0.99797, broad-probe rho 0.99982, proxy-front rho 0.99766
  - constraint agreement: 1.0 overall, probes, and proxy front; zero mismatches
  - final Pareto: 36 positive-WE and 14 negative-WE recursive-close configs
