### PR TITLE
feat(gpu): add short-only multicoin EMA MPS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ All notable user-facing changes will be documented in this file.
   remains unsupported by the GPU optimizer backend.
 - Add an experimental, purely additive Apple Silicon MPS optimizer backend for single-coin,
   EMA-anchor and trailing-martingale searches in long-only, short-only, and long+short modes.
-  Long-only multi-coin EMA-anchor searches are also supported for up to 64 coins with shared
-  balance, per-coin market and indicator state, dynamic wallet-exposure allocation, Forager
+  Single-side long-only or short-only multi-coin EMA-anchor searches are also supported for up to
+  64 coins with shared balance, per-coin market and indicator state, dynamic wallet-exposure
+  allocation, Forager
   selection, searchable Forager parameters and position count, strict tick-boundary fills, and
   compact unified-memory inputs guarded against excessive MPS allocation.
   Large NSGA-II populations run through strategy-specific Rust-owned Metal screening programs and
@@ -26,7 +27,7 @@ All notable user-facing changes will be documented in this file.
   validation and rolling drift gates remain authoritative for this screening approximation.
   Recursive trailing-martingale entry and close ladders use immutable generation snapshots, merge
   equal-price closes, and fill every strictly crossed rung in Rust's canonical order. Other
-  strategies, suites, multi-coin short/hedged or trailing-martingale runs, HSL, auto-unstuck,
+  strategies, suites, multi-coin hedged or trailing-martingale runs, HSL, auto-unstuck,
   collateral, minimum-effective-cost filtering, market-order execution, incomplete candle tails,
   non-inert fixed runtime overrides, and unmodeled risk gates fail closed. Fused delta-form Metal
   EMA updates reduce long-horizon float32 path drift. Optimizer-limit feasibility disagreements

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -5,13 +5,18 @@
 //! dispatches this source through the optional Apple MPS backend.
 
 pub const MPS_EMA_ANCHOR_SOURCE: &str = include_str!("gpu/mps_ema_anchor_directional.metal");
-pub const MPS_EMA_ANCHOR_MULTICOIN_LONG_SOURCE: &str =
+pub const MPS_EMA_ANCHOR_MULTICOIN_SOURCE: &str =
     include_str!("gpu/mps_ema_anchor_multicoin_long.metal");
+pub const MPS_EMA_ANCHOR_MULTICOIN_LONG_SOURCE: &str = MPS_EMA_ANCHOR_MULTICOIN_SOURCE;
 pub const MPS_TRAILING_MARTINGALE_SOURCE: &str =
     include_str!("gpu/mps_trailing_martingale_directional.metal");
 
 pub fn mps_ema_anchor_source() -> &'static str {
     MPS_EMA_ANCHOR_SOURCE
+}
+
+pub fn mps_ema_anchor_multicoin_source() -> &'static str {
+    MPS_EMA_ANCHOR_MULTICOIN_SOURCE
 }
 
 pub fn mps_ema_anchor_multicoin_long_source() -> &'static str {
@@ -45,9 +50,11 @@ mod tests {
     }
 
     #[test]
-    fn ema_anchor_multicoin_long_mps_source_exposes_expected_kernel_contract() {
-        let source = mps_ema_anchor_multicoin_long_source();
+    fn ema_anchor_multicoin_mps_source_exposes_expected_kernel_contract() {
+        let source = mps_ema_anchor_multicoin_source();
+        assert!(source.contains("kernel void passivbot_ema_anchor_multicoin"));
         assert!(source.contains("kernel void passivbot_ema_anchor_multicoin_long"));
+        assert!(source.contains("const bool short_side"));
         assert!(source.contains("constant int MAX_COINS = 64"));
         assert!(source.contains("constant int PARAM_COLS = 19"));
         assert!(source.contains("constant int COIN_COLS = 11"));
@@ -61,6 +68,7 @@ mod tests {
         assert!(source.contains("= fma("));
         assert!(!source.contains("unstuck"));
         assert!(!source.contains("hard_stop"));
+        assert_eq!(source, mps_ema_anchor_multicoin_long_source());
     }
 
     #[test]

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -38,7 +38,7 @@ inline bool finite_positive(float value) {
     return isfinite(value) && value > 0.0f;
 }
 
-kernel void passivbot_ema_anchor_multicoin_long(
+inline void passivbot_ema_anchor_multicoin_impl(
     constant float* bars,
     constant int* fill_ticks,
     constant int* touch_ticks,
@@ -49,7 +49,8 @@ kernel void passivbot_ema_anchor_multicoin_long(
     device float* daily,
     device float* scalars,
     device int* gap_hist,
-    uint b [[thread_position_in_grid]]
+    uint b,
+    bool short_side
 ) {
     const int B = sizes[0];
     const int T = sizes[1];
@@ -236,11 +237,15 @@ kernel void passivbot_ema_anchor_multicoin_long(
             const float maker_fee = coin_settings[coin_offset + 5];
 
             bool filled_close = close_qty[c] > 0.0f && psize[c] > 0.0f
-                && close_tick[c] <= fill_ticks[tick_offset + 0];
+                && (short_side
+                    ? close_tick[c] > fill_ticks[tick_offset + 1]
+                    : close_tick[c] <= fill_ticks[tick_offset + 0]);
             if (filled_close) {
                 float fill_price = float(close_tick[c]) * price_step;
                 float adjusted = fmin(round_step(close_qty[c], qty_step), psize[c]);
-                float pnl = adjusted * c_mult * (fill_price - pprice[c]);
+                float pnl = adjusted * c_mult * (short_side
+                    ? pprice[c] - fill_price
+                    : fill_price - pprice[c]);
                 balance += pnl - adjusted * fill_price * c_mult * maker_fee;
                 float new_size = fmax(round_step(psize[c] - adjusted, qty_step), 0.0f);
                 bool went_flat = new_size <= 0.0f;
@@ -259,7 +264,9 @@ kernel void passivbot_ema_anchor_multicoin_long(
 
             bool was_flat = psize[c] <= 0.0f;
             bool filled_entry = entry_qty[c] > 0.0f
-                && entry_tick[c] > fill_ticks[tick_offset + 1];
+                && (short_side
+                    ? entry_tick[c] <= fill_ticks[tick_offset + 0]
+                    : entry_tick[c] > fill_ticks[tick_offset + 1]);
             if (filled_entry) {
                 float fill_price = float(entry_tick[c]) * price_step;
                 float adjusted = round_step(entry_qty[c], qty_step);
@@ -414,9 +421,13 @@ kernel void passivbot_ema_anchor_multicoin_long(
                     int bar_offset = (k * C + c) * 4;
                     float close = bars[bar_offset + 2];
                     float lower = fmin(ema0[c], fmin(ema1[c], ema2[c]));
-                    float threshold = lower * (1.0f - offset);
+                    float upper = fmax(ema0[c], fmax(ema1[c], ema2[c]));
+                    float threshold = short_side
+                        ? upper * (1.0f + offset)
+                        : lower * (1.0f - offset);
                     float readiness = threshold > 0.0f
-                        ? close / threshold - 1.0f : INFINITY;
+                        ? (short_side ? 1.0f - close / threshold : close / threshold - 1.0f)
+                        : INFINITY;
                     volume_min = fmin(volume_min, forager_volume[c]);
                     volume_max = fmax(volume_max, forager_volume[c]);
                     ready_min = fmin(ready_min, readiness);
@@ -430,9 +441,13 @@ kernel void passivbot_ema_anchor_multicoin_long(
                     int bar_offset = (k * C + c) * 4;
                     float close = bars[bar_offset + 2];
                     float lower = fmin(ema0[c], fmin(ema1[c], ema2[c]));
-                    float threshold = lower * (1.0f - offset);
+                    float upper = fmax(ema0[c], fmax(ema1[c], ema2[c]));
+                    float threshold = short_side
+                        ? upper * (1.0f + offset)
+                        : lower * (1.0f - offset);
                     float readiness = threshold > 0.0f
-                        ? close / threshold - 1.0f : INFINITY;
+                        ? (short_side ? 1.0f - close / threshold : close / threshold - 1.0f)
+                        : INFINITY;
                     float volume_component = volume_max > volume_min
                         ? (forager_volume[c] - volume_min) / (volume_max - volume_min) : 1.0f;
                     float ready_component = ready_max > ready_min
@@ -496,7 +511,8 @@ kernel void passivbot_ema_anchor_multicoin_long(
                 float wallet_ratio = psize[c] > 0.0f && balance > 0.0f
                     ? (psize[c] * price_now * c_mult / balance)
                         / fmax(effective_wel, 1.0e-12f) : 0.0f;
-                float inventory_shift = wallet_ratio * psize_weight;
+                float signed_wallet_ratio = short_side ? -wallet_ratio : wallet_ratio;
+                float inventory_shift = signed_wallet_ratio * psize_weight;
                 int bid_tick = min(
                     int(floor(
                         lower * (1.0f - offset * multiplier - inventory_shift)
@@ -513,8 +529,12 @@ kernel void passivbot_ema_anchor_multicoin_long(
                 );
                 float bid_price = float(bid_tick) * price_step;
                 float ask_price = float(ask_tick) * price_step;
+                int candidate_entry_tick = short_side ? ask_tick : bid_tick;
+                int candidate_close_tick = short_side ? bid_tick : ask_tick;
+                float entry_price = short_side ? ask_price : bid_price;
+                float close_price = short_side ? bid_price : ask_price;
                 float minimum = min_entry_qty(
-                    bid_price, qty_step, min_qty, min_cost, c_mult
+                    entry_price, qty_step, min_qty, min_cost, c_mult
                 );
                 minimum_entry[c] = minimum;
                 bool cooldown = cooldown_min > 0.0f && last_increase_k[c] > -1.0e19f
@@ -522,11 +542,11 @@ kernel void passivbot_ema_anchor_multicoin_long(
                 float cost_we = psize[c] > 0.0f && balance > 0.0f
                     ? psize[c] * pprice[c] * c_mult / balance : 0.0f;
                 float position_cap = effective_wel - 1.0e-7f;
-                if (selected[c] && !cooldown && bid_price > 0.0f && balance > 0.0f
+                if (selected[c] && !cooldown && entry_price > 0.0f && balance > 0.0f
                     && cost_we < position_cap && base_qty_pct > 0.0f) {
                     float base_qty = fmax(minimum, round_step(
                         balance * effective_wel * base_qty_pct
-                            / fmax(bid_price * c_mult, 1.0e-12f),
+                            / fmax(entry_price * c_mult, 1.0e-12f),
                         qty_step
                     ));
                     float quantity = round_step(
@@ -535,8 +555,8 @@ kernel void passivbot_ema_anchor_multicoin_long(
                     );
                     float headroom = (
                         position_cap * balance - psize[c] * pprice[c] * c_mult
-                    ) / fmax(bid_price * c_mult, 1.0e-12f);
-                    bool over = (psize[c] * pprice[c] + quantity * bid_price) * c_mult
+                    ) / fmax(entry_price * c_mult, 1.0e-12f);
+                    bool over = (psize[c] * pprice[c] + quantity * entry_price) * c_mult
                         / fmax(balance, 1.0e-9f) >= position_cap;
                     if (over) {
                         float capped = floor_step(headroom, qty_step);
@@ -544,23 +564,23 @@ kernel void passivbot_ema_anchor_multicoin_long(
                             ? capped : 0.0f;
                     }
                     entry_qty[c] = quantity;
-                    entry_tick[c] = bid_tick;
+                    entry_tick[c] = candidate_entry_tick;
                     entry_candidate[c] = quantity > 0.0f;
-                    contribution[c] = quantity * bid_price * c_mult / balance;
+                    contribution[c] = quantity * entry_price * c_mult / balance;
                 }
-                if (psize[c] > 0.0f && ask_price > 0.0f) {
+                if (psize[c] > 0.0f && close_price > 0.0f) {
                     float minimum_close = min_entry_qty(
-                        ask_price, qty_step, min_qty, min_cost, c_mult
+                        close_price, qty_step, min_qty, min_cost, c_mult
                     );
                     float clip = fmin(psize[c], fmax(minimum_close, round_step(
                         balance * effective_wel * base_qty_pct
-                            / fmax(ask_price * c_mult, 1.0e-12f),
+                            / fmax(close_price * c_mult, 1.0e-12f),
                         qty_step
                     )));
                     close_qty[c] = psize[c] <= minimum_close
                             || psize[c] - clip < minimum_close
                         ? psize[c] : clip;
-                    close_tick[c] = ask_tick;
+                    close_tick[c] = candidate_close_tick;
                 }
             }
 
@@ -584,9 +604,10 @@ kernel void passivbot_ema_anchor_multicoin_long(
                         int coin_offset = c * COIN_COLS;
                         float price_now = bars[bar_offset + 2];
                         float price_step = coin_settings[coin_offset + 1];
-                        float distance = (
-                            price_now - float(entry_tick[c]) * price_step
-                        ) / fmax(price_now, 1.0e-12f);
+                        float entry_price = float(entry_tick[c]) * price_step;
+                        float distance = (short_side
+                            ? entry_price - price_now
+                            : price_now - entry_price) / fmax(price_now, 1.0e-12f);
                         if (best < 0 || distance < best_distance
                             || (distance == best_distance && c < best)) {
                             best = c;
@@ -631,7 +652,7 @@ kernel void passivbot_ema_anchor_multicoin_long(
             }
             if (psize[c] > 0.0f) {
                 unrealized += psize[c] * coin_settings[coin_offset + 4]
-                    * (close - pprice[c]);
+                    * (short_side ? pprice[c] - close : close - pprice[c]);
             }
         }
         float equity = balance + unrealized;
@@ -703,8 +724,49 @@ kernel void passivbot_ema_anchor_multicoin_long(
         ? last_eq_k * interval_ms : -1.0f;
     scalars[scalar_offset + 9] = float(liquidation_day);
     scalars[scalar_offset + 10] = balance;
-    scalars[scalar_offset + 11] = total_size;
-    scalars[scalar_offset + 12] = total_cost;
+    scalars[scalar_offset + 11] = short_side ? 0.0f : total_size;
+    scalars[scalar_offset + 12] = short_side ? 0.0f : total_cost;
     scalars[scalar_offset + 13] = alive ? 1.0f : 0.0f;
     scalars[scalar_offset + 14] = float(open_positions);
+    scalars[scalar_offset + 15] = short_side ? total_size : 0.0f;
+    scalars[scalar_offset + 16] = short_side ? total_cost : 0.0f;
+}
+
+kernel void passivbot_ema_anchor_multicoin(
+    constant float* bars,
+    constant int* fill_ticks,
+    constant int* touch_ticks,
+    constant float* coin_settings,
+    constant float* params,
+    constant float* run_settings,
+    constant int* sizes,
+    device float* daily,
+    device float* scalars,
+    device int* gap_hist,
+    uint b [[thread_position_in_grid]]
+) {
+    const bool short_side = run_settings[3] > 0.5f;
+    passivbot_ema_anchor_multicoin_impl(
+        bars, fill_ticks, touch_ticks, coin_settings, params, run_settings,
+        sizes, daily, scalars, gap_hist, b, short_side
+    );
+}
+
+kernel void passivbot_ema_anchor_multicoin_long(
+    constant float* bars,
+    constant int* fill_ticks,
+    constant int* touch_ticks,
+    constant float* coin_settings,
+    constant float* params,
+    constant float* run_settings,
+    constant int* sizes,
+    device float* daily,
+    device float* scalars,
+    device int* gap_hist,
+    uint b [[thread_position_in_grid]]
+) {
+    passivbot_ema_anchor_multicoin_impl(
+        bars, fill_ticks, touch_ticks, coin_settings, params, run_settings,
+        sizes, daily, scalars, gap_hist, b, false
+    );
 }

--- a/passivbot-rust/src/lib.rs
+++ b/passivbot-rust/src/lib.rs
@@ -39,6 +39,11 @@ fn mps_ema_anchor_source_py() -> &'static str {
 }
 
 #[pyfunction]
+fn mps_ema_anchor_multicoin_source_py() -> &'static str {
+    gpu::mps_ema_anchor_multicoin_source()
+}
+
+#[pyfunction]
 fn mps_ema_anchor_multicoin_long_source_py() -> &'static str {
     gpu::mps_ema_anchor_multicoin_long_source()
 }
@@ -56,6 +61,7 @@ fn passivbot_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<EquityHardStopRuntimePy>()?;
     m.add_function(wrap_pyfunction!(runtime_build_info, m)?)?;
     m.add_function(wrap_pyfunction!(mps_ema_anchor_source_py, m)?)?;
+    m.add_function(wrap_pyfunction!(mps_ema_anchor_multicoin_source_py, m)?)?;
     m.add_function(wrap_pyfunction!(
         mps_ema_anchor_multicoin_long_source_py,
         m

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -68,21 +68,30 @@ EMA_BOUND_MAP = {
     for bound_suffix, parameter in _EMA_SIDE_BOUND_SUFFIXES.items()
 }
 
-EMA_MULTICOIN_LONG_BOUND_MAP = {
-    **EMA_BOUND_MAP,
-    **{
-        f"long_{suffix}": f"long_{parameter}"
-        for suffix, parameter in {
-            "forager_volume_ema_span_1m": "forager_volume_ema_span_1m",
-            "forager_volatility_ema_span_1m": "forager_volatility_ema_span_1m",
-            "forager_volume_drop_pct": "forager_volume_drop_pct",
-            "forager_score_weights_volume": "forager_score_weights_volume",
-            "forager_score_weights_ema_readiness": "forager_score_weights_ema_readiness",
-            "forager_score_weights_volatility": "forager_score_weights_volatility",
-            "n_positions": "n_positions",
-        }.items()
-    },
+_EMA_MULTICOIN_SIDE_BOUND_SUFFIXES = {
+    "forager_volume_ema_span_1m": "forager_volume_ema_span_1m",
+    "forager_volatility_ema_span_1m": "forager_volatility_ema_span_1m",
+    "forager_volume_drop_pct": "forager_volume_drop_pct",
+    "forager_score_weights_volume": "forager_score_weights_volume",
+    "forager_score_weights_ema_readiness": "forager_score_weights_ema_readiness",
+    "forager_score_weights_volatility": "forager_score_weights_volatility",
+    "n_positions": "n_positions",
 }
+
+EMA_MULTICOIN_BOUND_MAPS = {
+    side: {
+        **EMA_BOUND_MAP,
+        **{
+            f"{side}_{suffix}": f"{side}_{parameter}"
+            for suffix, parameter in _EMA_MULTICOIN_SIDE_BOUND_SUFFIXES.items()
+        },
+    }
+    for side in ("long", "short")
+}
+
+# Compatibility name for consumers of the first multicoin slice.
+EMA_MULTICOIN_LONG_BOUND_MAP = EMA_MULTICOIN_BOUND_MAPS["long"]
+EMA_MULTICOIN_SHORT_BOUND_MAP = EMA_MULTICOIN_BOUND_MAPS["short"]
 
 _TM_SIDE_BOUND_SUFFIXES = {
     "ema_span_0": "ema_span_0",
@@ -512,9 +521,9 @@ def _validate_scope(config: dict, evaluator) -> str:
             raise ValueError(
                 "GPU multicoin foundation currently supports strategy_kind=ema_anchor only"
             )
-        if enabled_sides != ["long"]:
+        if len(enabled_sides) != 1:
             raise ValueError(
-                "GPU multicoin foundation currently supports long-only enabledness"
+                "GPU multicoin foundation currently supports exactly one enabled side"
             )
         if not bool(config.get("backtest", {}).get("dynamic_wel_by_tradability")):
             raise ValueError(
@@ -1298,11 +1307,17 @@ def run_backend(
     base_vector = [float(value) for value in template_vectors[0]]
 
     strategy_kind = str(config["live"]["strategy_kind"]).strip().lower()
-    bound_map = (
-        EMA_MULTICOIN_LONG_BOUND_MAP
-        if strategy_kind == "ema_anchor" and coin_count > 1
-        else GPU_STRATEGY_BOUND_MAPS[strategy_kind]
-    )
+    if strategy_kind == "ema_anchor" and coin_count > 1:
+        multicoin_sides = [
+            side for side in ("long", "short") if gpu_side_enabled(config, side)
+        ]
+        if len(multicoin_sides) != 1:
+            raise ValueError(
+                "GPU multicoin foundation requires exactly one enabled side"
+            )
+        bound_map = EMA_MULTICOIN_BOUND_MAPS[multicoin_sides[0]]
+    else:
+        bound_map = GPU_STRATEGY_BOUND_MAPS[strategy_kind]
 
     mapped_all = {
         bound_map[bound_key]: (index, bounds[index])

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -41,13 +41,13 @@ def _trailing_martingale_shader_library():
 
 
 @lru_cache(maxsize=1)
-def _ema_anchor_multicoin_long_shader_library():
+def _ema_anchor_multicoin_shader_library():
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
     return torch.mps.compile_shader(
-        passivbot_rust.mps_ema_anchor_multicoin_long_source_py()
+        passivbot_rust.mps_ema_anchor_multicoin_source_py()
     )
 
 
@@ -294,10 +294,15 @@ class MpsEmaAnchorRunner:
         }
 
 
-class MpsEmaAnchorMulticoinLongRunner:
-    """Persistent long-only multi-coin EMA Anchor screening runner on MPS."""
+class MpsEmaAnchorMulticoinRunner:
+    """Persistent single-side multi-coin EMA Anchor screening runner on MPS."""
 
-    def __init__(self, run: ProxyRun, data: dict):
+    def __init__(self, run: ProxyRun, data: dict, *, side: str):
+        if side not in {"long", "short"}:
+            raise ValueError(
+                f"MPS multicoin EMA runner side must be long or short, got {side!r}"
+            )
+        self.side = side
         self.run_config = run
         self.n = int(data["n"])
         self.n_coins = int(data["n_coins"])
@@ -310,7 +315,7 @@ class MpsEmaAnchorMulticoinLongRunner:
             0.0, run.liquidation_threshold
         )
         self.settings = torch.tensor(
-            [run.starting_balance, liq_floor, run.interval_ms],
+            [run.starting_balance, liq_floor, run.interval_ms, float(side == "short")],
             dtype=torch.float32,
             device="mps",
         )
@@ -385,14 +390,14 @@ class MpsEmaAnchorMulticoinLongRunner:
                 device="mps",
             )
         prepared = time.perf_counter()
-        library = _ema_anchor_multicoin_long_shader_library()
+        library = _ema_anchor_multicoin_shader_library()
         compiled = time.perf_counter()
         if profile:
             torch.mps.synchronize()
             dispatched = time.perf_counter()
         else:
             dispatched = compiled
-        library.passivbot_ema_anchor_multicoin_long(
+        library.passivbot_ema_anchor_multicoin(
             self.bars,
             self.fill_ticks,
             self.touch_ticks,
@@ -416,6 +421,20 @@ class MpsEmaAnchorMulticoinLongRunner:
             "kernel_seconds": finished - dispatched,
         }
         return _decode_outputs(daily, scalars, gaps)
+
+
+class MpsEmaAnchorMulticoinLongRunner(MpsEmaAnchorMulticoinRunner):
+    """Compatibility wrapper for the original long-only multicoin runner."""
+
+    def __init__(self, run: ProxyRun, data: dict):
+        super().__init__(run, data, side="long")
+
+
+class MpsEmaAnchorMulticoinShortRunner(MpsEmaAnchorMulticoinRunner):
+    """Short-only multicoin EMA Anchor screening runner."""
+
+    def __init__(self, run: ProxyRun, data: dict):
+        super().__init__(run, data, side="short")
 
 
 class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -279,7 +279,7 @@ MpsEmaAnchorProxy = MpsSingleCoinProxy
 
 
 class MpsMulticoinEmaProxy:
-    """Batched long-only multi-coin EMA Anchor screening proxy."""
+    """Batched single-side multi-coin EMA Anchor screening proxy."""
 
     def __init__(
         self,
@@ -307,7 +307,7 @@ class MpsMulticoinEmaProxy:
 
         from backtest import build_backtest_payload
         from optimization.gpu.metrics import compute_objectives
-        from optimization.gpu.mps_kernel import MpsEmaAnchorMulticoinLongRunner
+        from optimization.gpu.mps_kernel import MpsEmaAnchorMulticoinRunner
 
         self._torch = torch
         self._compute_objectives = compute_objectives
@@ -334,8 +334,14 @@ class MpsMulticoinEmaProxy:
             != "ema_anchor"
         ):
             raise ValueError("MPS multicoin proxy currently supports ema_anchor only")
-        if not gpu_side_enabled(config, "long") or gpu_side_enabled(config, "short"):
-            raise ValueError("MPS multicoin proxy currently requires long-only enabledness")
+        enabled_sides = [
+            side for side in ("long", "short") if gpu_side_enabled(config, side)
+        ]
+        if len(enabled_sides) != 1:
+            raise ValueError(
+                "MPS multicoin proxy currently requires exactly one enabled side"
+            )
+        self.side = enabled_sides[0]
 
         payload = build_backtest_payload(
             np.ascontiguousarray(values),
@@ -376,10 +382,12 @@ class MpsMulticoinEmaProxy:
         for last_valid_idx in backtest_params["last_valid_indices"]:
             _require_complete_valid_tail(int(last_valid_idx), len(values))
 
-        first_bot = payload.bot_params_list[0]["long"]
-        first_strategy = dict(payload.strategy_params_list[0]["long"])
+        first_bot = payload.bot_params_list[0][self.side]
+        first_strategy = dict(payload.strategy_params_list[0][self.side])
         if bool(first_bot.get("unstuck_enabled")) or bool(first_bot.get("hsl_enabled")):
-            raise ValueError("MPS multicoin proxy requires long HSL and unstuck disabled")
+            raise ValueError(
+                f"MPS multicoin proxy requires {self.side} HSL and unstuck disabled"
+            )
         weights = first_bot.get("forager_score_weights", {}) or {}
         first_strategy.update(
             {
@@ -427,14 +435,14 @@ class MpsMulticoinEmaProxy:
             "hsl_enabled",
         )
         for coin in range(1, coin_count):
-            strategy = payload.strategy_params_list[coin]["long"]
-            bot = payload.bot_params_list[coin]["long"]
-            if strategy != payload.strategy_params_list[0]["long"] or any(
+            strategy = payload.strategy_params_list[coin][self.side]
+            bot = payload.bot_params_list[coin][self.side]
+            if strategy != payload.strategy_params_list[0][self.side] or any(
                 bot.get(key) != first_bot.get(key) for key in comparable_bot_keys
             ):
                 raise ValueError(
-                    "MPS multicoin proxy requires identical long strategy/forager "
-                    "settings across coins"
+                    "MPS multicoin proxy requires identical "
+                    f"{self.side} strategy/forager settings across coins"
                 )
 
         markets = [
@@ -485,7 +493,9 @@ class MpsMulticoinEmaProxy:
             values, timestamps, runs=runs, markets=markets
         )
         self.metrics_data = {"ts0": self.data["ts0"], "n": self.data["n"]}
-        self.runner = MpsEmaAnchorMulticoinLongRunner(self.run, self.data)
+        self.runner = MpsEmaAnchorMulticoinRunner(
+            self.run, self.data, side=self.side
+        )
 
     def _parameter_matrix(self, candidates: list[dict]) -> np.ndarray:
         rows = []
@@ -493,9 +503,9 @@ class MpsMulticoinEmaProxy:
             merged = dict(self.base_params)
             merged.update(
                 {
-                    key.removeprefix("long_"): value
+                    key.removeprefix(f"{self.side}_"): value
                     for key, value in candidate.items()
-                    if key.startswith("long_")
+                    if key.startswith(f"{self.side}_")
                 }
             )
             rows.append(

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -36,6 +36,7 @@ from optimization.backends.gpu_backend import (
     _validate_seed_side_match,
     _validate_scope,
     EMA_MULTICOIN_LONG_BOUND_MAP,
+    EMA_MULTICOIN_SHORT_BOUND_MAP,
     TRAILING_MARTINGALE_BOUND_MAP,
 )
 
@@ -469,12 +470,15 @@ def test_gpu_foundation_accepts_ema_long_single():
     assert _validate_scope(_long_only_ema_config(), _Evaluator()) == "bybit"
 
 
-def test_gpu_foundation_accepts_ema_long_multicoin():
-    config = _long_only_ema_config()
-    config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "SOL"]
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_gpu_foundation_accepts_ema_single_side_multicoin(side):
+    config = _directional_ema_config(
+        long_enabled=side == "long", short_enabled=side == "short"
+    )
+    config["live"]["approved_coins"][side] = ["BTC", "ETH", "SOL"]
     config["live"]["forager_score_hysteresis_pct"] = 0.0
     config["backtest"]["dynamic_wel_by_tradability"] = True
-    config["bot"]["long"]["risk"]["n_positions"] = 2
+    config["bot"][side]["risk"]["n_positions"] = 2
 
     assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
@@ -515,32 +519,39 @@ def test_gpu_multicoin_foundation_fails_closed_for_unsupported_scope(
         _validate_scope(config, _MulticoinEvaluator())
 
 
-def test_gpu_multicoin_foundation_rejects_short_and_hedge_modes():
-    for long_enabled, short_enabled in ((False, True), (True, True)):
-        config = _directional_ema_config(
-            long_enabled=long_enabled, short_enabled=short_enabled
-        )
-        config["live"]["approved_coins"] = {
-            "long": ["BTC", "ETH", "SOL"] if long_enabled else [],
-            "short": ["BTC", "ETH", "SOL"] if short_enabled else [],
-        }
-        config["live"]["forager_score_hysteresis_pct"] = 0.0
-        config["backtest"]["dynamic_wel_by_tradability"] = True
-        with pytest.raises(ValueError, match="long-only"):
-            _validate_scope(config, _MulticoinEvaluator())
+def test_gpu_multicoin_foundation_rejects_hedge_mode():
+    config = _directional_ema_config(long_enabled=True, short_enabled=True)
+    config["live"]["approved_coins"] = {
+        "long": ["BTC", "ETH", "SOL"],
+        "short": ["BTC", "ETH", "SOL"],
+    }
+    config["live"]["forager_score_hysteresis_pct"] = 0.0
+    config["backtest"]["dynamic_wel_by_tradability"] = True
+    with pytest.raises(ValueError, match="exactly one enabled side"):
+        _validate_scope(config, _MulticoinEvaluator())
 
 
-def test_gpu_multicoin_bound_map_exposes_forager_and_position_dimensions():
-    for key in (
-        "long_forager_volume_ema_span_1m",
-        "long_forager_volatility_ema_span_1m",
-        "long_forager_volume_drop_pct",
-        "long_forager_score_weights_volume",
-        "long_forager_score_weights_ema_readiness",
-        "long_forager_score_weights_volatility",
-        "long_n_positions",
+@pytest.mark.parametrize(
+    ("side", "bound_map"),
+    [
+        ("long", EMA_MULTICOIN_LONG_BOUND_MAP),
+        ("short", EMA_MULTICOIN_SHORT_BOUND_MAP),
+    ],
+)
+def test_gpu_multicoin_bound_map_exposes_forager_and_position_dimensions(
+    side, bound_map
+):
+    for suffix in (
+        "forager_volume_ema_span_1m",
+        "forager_volatility_ema_span_1m",
+        "forager_volume_drop_pct",
+        "forager_score_weights_volume",
+        "forager_score_weights_ema_readiness",
+        "forager_score_weights_volatility",
+        "n_positions",
     ):
-        assert EMA_MULTICOIN_LONG_BOUND_MAP[key] == key
+        key = f"{side}_{suffix}"
+        assert bound_map[key] == key
 
 
 @pytest.mark.parametrize(
@@ -1155,28 +1166,30 @@ def test_gpu_directional_search_space_keeps_side_enablement_fixed():
         _validate_directional_search_space(bounds, base, approved, {"long"})
 
 
-def test_gpu_multicoin_search_space_allows_bounded_n_positions():
-    approved = {"long": ["BTC", "ETH", "SOL"], "short": []}
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_gpu_multicoin_search_space_allows_bounded_n_positions(side):
+    other = "short" if side == "long" else "long"
+    approved = {side: ["BTC", "ETH", "SOL"], other: []}
     base = {
-        "long_total_wallet_exposure_limit": 1.0,
-        "long_n_positions": 2.0,
-        "short_total_wallet_exposure_limit": 0.0,
-        "short_n_positions": 0.0,
+        f"{side}_total_wallet_exposure_limit": 1.0,
+        f"{side}_n_positions": 2.0,
+        f"{other}_total_wallet_exposure_limit": 0.0,
+        f"{other}_n_positions": 0.0,
     }
     bounds = {
-        "long_total_wallet_exposure_limit": Bound(0.5, 1.5, None),
-        "long_n_positions": Bound(1.0, 3.0, 1.0),
-        "short_total_wallet_exposure_limit": Bound(0.0, 0.0, None),
-        "short_n_positions": Bound(0.0, 0.0, None),
+        f"{side}_total_wallet_exposure_limit": Bound(0.5, 1.5, None),
+        f"{side}_n_positions": Bound(1.0, 3.0, 1.0),
+        f"{other}_total_wallet_exposure_limit": Bound(0.0, 0.0, None),
+        f"{other}_n_positions": Bound(0.0, 0.0, None),
     }
 
     _validate_directional_search_space(
-        bounds, base, approved, {"long"}, coin_count=3
+        bounds, base, approved, {side}, coin_count=3
     )
-    bounds["long_n_positions"] = Bound(1.0, 4.0, 1.0)
+    bounds[f"{side}_n_positions"] = Bound(1.0, 4.0, 1.0)
     with pytest.raises(ValueError, match=r"within \[1, 3\]"):
         _validate_directional_search_space(
-            bounds, base, approved, {"long"}, coin_count=3
+            bounds, base, approved, {side}, coin_count=3
         )
 
 def test_gpu_directional_search_space_rejects_disabled_approved_side_activation():

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -47,6 +47,7 @@ def test_minimum_entry_qty_encoding_preserves_just_above_aligned_minimum():
 
 
 from optimization.gpu.mps_kernel import (
+    MpsEmaAnchorMulticoinRunner,
     MpsEmaAnchorMulticoinLongRunner,
     MpsEmaAnchorRunner,
 )
@@ -200,10 +201,12 @@ def test_mps_ema_anchor_shader_smoke():
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
-def test_mps_ema_anchor_multicoin_long_shader_smoke():
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
     import passivbot_rust
 
-    source = passivbot_rust.mps_ema_anchor_multicoin_long_source_py()
+    source = passivbot_rust.mps_ema_anchor_multicoin_source_py()
+    assert "kernel void passivbot_ema_anchor_multicoin" in source
     assert "kernel void passivbot_ema_anchor_multicoin_long" in source
     count = 512
     coin_count = 3
@@ -258,7 +261,7 @@ def test_mps_ema_anchor_multicoin_long_shader_smoke():
         2.0,
     ]
 
-    output = MpsEmaAnchorMulticoinLongRunner(runs[0], data).run(
+    output = MpsEmaAnchorMulticoinRunner(runs[0], data, side=side).run(
         np.array([row, row], dtype=np.float64)
     )
     torch.mps.synchronize()
@@ -268,6 +271,9 @@ def test_mps_ema_anchor_multicoin_long_shader_smoke():
     assert torch.isfinite(output["balance"]).all()
     assert output["day_has_fill"].sum().item() > 0
     assert (output["open_positions"] <= 2.0).all()
+
+    legacy_long = MpsEmaAnchorMulticoinLongRunner(runs[0], data)
+    assert legacy_long.side == "long"
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -1,12 +1,17 @@
 import pytest
 
 from optimization.gpu.model import (
+    EMA_ANCHOR_MULTICOIN_PARAM_KEYS,
     EMA_ANCHOR_PARAM_KEYS,
     TRAILING_MARTINGALE_PARAM_KEYS,
     flatten_trailing_martingale_params,
     gpu_side_enabled,
 )
-from optimization.gpu.service import MpsEmaAnchorProxy, _require_complete_valid_tail
+from optimization.gpu.service import (
+    MpsEmaAnchorProxy,
+    MpsMulticoinEmaProxy,
+    _require_complete_valid_tail,
+)
 
 
 def test_gpu_proxy_requires_complete_valid_tail():
@@ -32,6 +37,24 @@ def test_directional_parameter_matrix_keeps_side_values_separate():
     offset_index = EMA_ANCHOR_PARAM_KEYS.index("offset")
     assert matrix[0, offset_index] == 0.125
     assert matrix[0, len(EMA_ANCHOR_PARAM_KEYS) + offset_index] == 0.25
+
+
+@pytest.mark.parametrize(("side", "base"), [("long", 1.0), ("short", 2.0)])
+def test_multicoin_parameter_matrix_uses_only_enabled_side(side, base):
+    proxy = MpsMulticoinEmaProxy.__new__(MpsMulticoinEmaProxy)
+    proxy.side = side
+    proxy.base_params = {
+        key: base for key in EMA_ANCHOR_MULTICOIN_PARAM_KEYS
+    }
+
+    other_side = "short" if side == "long" else "long"
+    matrix = proxy._parameter_matrix(
+        [{f"{side}_offset": 0.125, f"{other_side}_offset": 9.0}]
+    )
+
+    assert matrix.shape == (1, len(EMA_ANCHOR_MULTICOIN_PARAM_KEYS))
+    offset_index = EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("offset")
+    assert matrix[0, offset_index] == 0.125
 
 
 def test_trailing_parameter_matrix_keeps_nested_flattened_sides_separate():


### PR DESCRIPTION
## Summary

- generalize the Apple MPS multicoin EMA Anchor proxy to support either long-only or short-only runs
- preserve the existing long-only runner and Metal entry point as compatibility wrappers
- route the enabled side's EMA, Forager, and position-count parameters while keeping dual-side multicoin runs fail-closed
- mirror short entry/close fills, PnL, unrealized equity, inventory skew, Forager readiness, and TWEL priority in the shared Metal kernel

This remains purely additive. CPU optimization, backtesting, and live bot behavior are unchanged. Multicoin hedged EMA, multicoin trailing martingale, suites, HSL, and auto-unstuck remain unsupported and fail closed.

## Validation

- `cargo fmt --check`
- `cargo test --offline --no-default-features` — 260 passed
- `cargo check --offline --tests`
- `pytest -q tests/optimization` — full suite passed (platform-only skips in sandbox)
- real Apple MPS directional multicoin shader smoke — long and short passed
- three-coin short-only MPS optimization: 4,096 proxy + 64 exact Rust evaluations, no halt
- sustained five-coin short-only optimization from 2022-05 through 2026-08: 4,096 proxy + 64 exact Rust evaluations, no halt; rank rho 0.794, broad-probe rho 0.721, exact Rust remained authoritative for constraint disagreements
