### PR TITLE
fix(gpu): adapt scarce broad-probe validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,9 @@ All notable user-facing changes will be documented in this file.
   membership is persisted independently from off-front probe eligibility, with the safety window
   and exact budget sized for a one-member proxy front; a generation with no novel front candidate
   fails closed instead of silently consuming that evidence budget. Resume also proves that its
-  recovered evidence plus remaining exact budget can
-  still activate both class-specific gates; exact worker completions are durably consumed in
+  recovered evidence plus remaining exact budget can still activate the mandatory proxy-front
+  gate, while truthful broad-probe scarcity remains admissible across restart and recovered probes
+  continue feeding their independent gates; exact worker completions are durably consumed in
   submission order so that proof remains valid when workers finish out of order. Feasibility
   disagreements are evaluated by the independent constraint-agreement gates and excluded from rank
   correlation, preventing the same disagreement from being double-counted as arbitrary ordering of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,9 +52,12 @@ All notable user-facing changes will be documented in this file.
   disagreements are evaluated by the independent constraint-agreement gates and excluded from rank
   correlation, preventing the same disagreement from being double-counted as arbitrary ordering of
   otherwise exact near-ties. Window, exact-budget, and fresh/resumed suffix checks reserve enough
-  total broad probes to retain eight rank-comparable samples whenever their constraint gate has not
-  already failed. Existing CPU bot, backtest, and optimizer paths do not import or require the
-  optional PyTorch dependency.
+  broad-probe capacity to retain eight rank-comparable samples whenever the current generations
+  contain that many truthful off-front candidates. When a many-objective generation has fewer
+  off-front candidates than requested, all available probes keep their true classification and
+  diverse true-front candidates fill the unused exact slots; allocation shortfalls and recovery are
+  logged instead of aborting the run. Existing CPU bot, backtest, and optimizer paths do not import
+  or require the optional PyTorch dependency.
 - Keep side-specific `approved_coins` authoritative in backtests and optimization so a coin
   approved only for long cannot open short entries, and a coin approved only for short cannot
   open long entries. Per-coin zero wallet-exposure overrides now retain the same entry-disable

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -220,9 +220,11 @@ duplicate-elimination controls as the ordinary pymoo optimizer.
    evidence-budget check applies to fresh and resumed runs and includes recovered class membership,
    the rolling-window suffix, discarded pending work, and all full or partial validation batches.
    Exact worker results are consumed in submission order even if workers finish out of order,
-   preserving the modeled batch sequence; resume fails closed if either class-specific gate can no
-   longer reach its minimum sample count. A final checkpoint is always written on successful
-   completion.
+   preserving the modeled batch sequence. Resume fails closed if the mandatory proxy-front gate can
+   no longer reach its minimum sample count. Broad probes remain opportunistic across restart, just
+   as in an uninterrupted run: recovered truthful probes are retained, and their independent gates
+   activate only after enough off-front evidence exists. A final checkpoint is always written on
+   successful completion.
 
 The proxy is a float32 ranking model, not an authoritative simulator. Exact Rust metrics and configs
 remain the only stored optimization results. The screening source is owned and exported by the

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -189,8 +189,11 @@ duplicate-elimination controls as the ordinary pymoo optimizer.
 - `validate_per_generation` caps exact candidates selected from each proxy generation.
 - `drift_probes` reserves at least part of that validation budget for candidates away from the
   proxy front.
-  A generation fails closed if its complete feasible proxy front leaves too few independent
-  off-front candidates for the requested probe count.
+  If the complete feasible proxy front occupies nearly the whole population, the optimizer uses
+  every genuinely off-front candidate available and fills the remaining exact quota with diverse
+  true-front candidates. Front members are never relabeled as broad probes. The separate broad-
+  probe gates activate only after enough truthful off-front evidence has accumulated; allocation
+  shortfalls and recovery are logged.
 - `drift_window`, `drift_min_samples`, and `drift_halt` configure the rolling rank and optimizer-
   limit classification safety gates. Broad-probe Spearman correlation plus aggregate,
   proxy-front, and broad-probe constraint agreement must each remain at or above `drift_halt`.
@@ -198,14 +201,14 @@ duplicate-elimination controls as the ordinary pymoo optimizer.
   At least eight samples of a validation class are required before its independent low agreement
   can halt a run, so `drift_window` and `optimize.iters` must be large enough to retain and reach
   eight true proxy-front validations even when the complete feasible proxy front contributes only
-  one novel candidate per generation. If that front is smaller than the non-probe quota, remaining
-  off-front validations stay truthfully classified as broad probes rather than being relabeled as
-  front evidence. Front membership is carried independently through exact-result persistence and
-  resume recovery. A generation fails closed if duplicate filtering leaves no novel proxy-front
-  candidate, so broad probes cannot silently consume the exact budget needed to activate the front
-  gate. `drift_probes` must remain below `validate_per_generation` so each generation requests
-  proxy-front safety evidence. A partial final validation batch scales its reserved probe count down
-  proportionally.
+  one novel candidate per generation. Off-front validations stay truthfully classified as broad
+  probes rather than being relabeled as front evidence, and scarce or duplicate probes give their
+  unused exact slots back to true-front candidates. Front membership is carried independently
+  through exact-result persistence and resume recovery. A generation still fails closed if
+  duplicate filtering leaves no novel proxy-front candidate, so broad probes cannot silently
+  consume the exact budget needed to activate the front gate. `drift_probes` must remain below
+  `validate_per_generation` so each generation requests proxy-front safety evidence. A partial
+  final validation batch scales its reserved probe count down proportionally.
 - `exact_workers: 0` inherits `optimize.n_cpus`; a positive value overrides it for this backend.
 - `max_pending_exact: 0` defaults to twice the exact-worker count.
   It must be at least `validate_per_generation` so throttling cannot change the configured

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -837,11 +837,6 @@ def _select_validation_indices(
     )
     front = primary[front_local]
     front_ids = {int(index) for index in front}
-    front_count = max(0, total - probes)
-    elite_local = _normalized_farthest_indices(objectives[front], front_count)
-    selected = [(int(front[index]), False, True) for index in elite_local]
-    selected_ids = {index for index, _probe, _front in selected}
-
     broad_pool = np.asarray(
         [
             int(index)
@@ -850,13 +845,17 @@ def _select_validation_indices(
         ],
         dtype=np.int64,
     )
-    requested_probes = min(max(0, probes), max(0, total - len(selected)))
+    requested_probes = min(max(0, probes), max(0, total - 1))
     # With several competing objectives the complete feasible proxy Pareto
     # front may legitimately contain nearly the entire population. Use every
     # truthful off-front probe available, then let diverse true-front members
     # fill the remaining exact quota. Never relabel a front member as a broad
     # probe merely to satisfy the configured per-generation target.
     probe_count = min(requested_probes, len(broad_pool))
+    front_count = max(0, total - probe_count)
+    elite_local = _normalized_farthest_indices(objectives[front], front_count)
+    selected = [(int(front[index]), False, True) for index in elite_local]
+    selected_ids = {index for index, _probe, _front in selected}
     if probe_count:
         positions = np.round(
             np.linspace(0, len(broad_pool) - 1, num=probe_count)
@@ -912,7 +911,11 @@ def _select_novel_validations(
     novel_probe_count = 0
     novel_front_count = 0
     target_probe_count = min(
-        probes, sum(bool(is_probe) for _index, is_probe, _is_front in selections)
+        probes,
+        sum(
+            bool(is_probe)
+            for _index, is_probe, _is_front in selections[:total]
+        ),
     )
     for index, is_probe, is_front in selections:
         candidate = candidate_for_index(index)

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -889,7 +889,6 @@ def _select_novel_validations(
     selections,
     *,
     total: int,
-    probes: int,
     candidate_for_index,
     digest_for_candidate,
     completed_hashes,
@@ -899,13 +898,16 @@ def _select_novel_validations(
     seen = set()
     novel_probe_count = 0
     novel_front_count = 0
+    # The first ``total`` preferences are the selector's truthful allocation.
+    # Later items replace duplicate hashes but must not change that class mix.
     target_probe_count = min(
-        probes,
+        max(0, total - 1),
         sum(
             bool(is_probe)
             for _index, is_probe, _is_front in selections[:total]
         ),
     )
+    target_front_count = max(1, total - target_probe_count)
     for index, is_probe, is_front in selections:
         candidate = candidate_for_index(index)
         digest = digest_for_candidate(candidate)
@@ -917,9 +919,8 @@ def _select_novel_validations(
         novel_probe_count += int(bool(is_probe))
         novel_front_count += int(bool(is_front))
         if (
-            len(novel) >= total
-            and novel_probe_count >= target_probe_count
-            and novel_front_count > 0
+            novel_probe_count >= target_probe_count
+            and novel_front_count >= target_front_count
         ):
             break
 
@@ -930,13 +931,9 @@ def _select_novel_validations(
             "GPU validation cannot provide novel proxy-front safety evidence; "
             "the current proxy front was already evaluated or submitted"
         )
-    chosen = probe_items[:probes]
+    chosen = probe_items[:target_probe_count]
     chosen_digests = {item[4] for item in chosen}
-    first_front = front_items[0]
-    if first_front[4] not in chosen_digests:
-        chosen.append(first_front)
-        chosen_digests.add(first_front[4])
-    for item in novel:
+    for item in front_items:
         if len(chosen) >= total:
             break
         if item[4] not in chosen_digests:
@@ -1849,7 +1846,6 @@ def run_backend(
             novel_selections = _select_novel_validations(
                 selections,
                 total=validation_count,
-                probes=probe_count,
                 candidate_for_index=lambda index: full_vector(rows[index]),
                 digest_for_candidate=vector_hash,
                 completed_hashes=completed_hashes,

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -396,46 +396,42 @@ def _validate_resume_evidence_budget(
     context: str = "resume",
     error_type: type[Exception] = RuntimeError,
 ) -> None:
-    """Fail closed if a resumed run cannot still activate each drift gate."""
+    """Fail closed if a resumed run cannot retain mandatory front evidence.
+
+    Broad probes are opportunistic because a complete feasible proxy front can
+    truthfully leave no off-front candidates. An uninterrupted run accepts
+    that geometry and keeps its independent broad-probe gates inactive until
+    enough evidence exists, so resume must not invent a stronger guarantee for
+    future generations. Durable probe evidence remains in ``pairs`` and is
+    evaluated by ``_DriftMonitor`` exactly as it is without a restart.
+    """
 
     remaining = max(0, int(exact_budget) - int(exact_done))
     window = int(options["drift_window"])
     validations = int(options["validate_per_generation"])
-    configured_probes = int(options["drift_probes"])
-    required_probes = _minimum_rank_evidence_samples(
-        float(options.get("drift_halt", GPU_DEFAULTS["drift_halt"]))
-    )
 
     # Recovered samples already have a durable order. Future exact results are
     # consumed strictly in submission order, so each validation generation is
-    # a contiguous segment. A partially retained future segment may lose any
-    # evidence samples first, which is the conservative within-batch order.
-    segments = [
-        (1, int(bool(row[4])), int(bool(row[2])))
-        for row in pairs
-    ]
+    # a contiguous segment. Each future generation requests at least one true-
+    # front validation, while broad probes depend on the population geometry
+    # and therefore cannot be guaranteed before selection. A partially retained
+    # future segment may lose its front sample first, which is the conservative
+    # within-batch order.
+    segments = [(1, int(bool(row[4]))) for row in pairs]
     future = remaining
     while future > 0:
         count = min(validations, future)
-        segments.append(
-            (
-                count,
-                1,
-                _validation_probe_count(count, validations, configured_probes),
-            )
-        )
+        segments.append((count, 1))
         future -= count
 
     kept = 0
     guaranteed_front = 0
-    guaranteed_probes = 0
-    for length, front_count, probe_count in reversed(segments):
+    for length, front_count in reversed(segments):
         if kept >= window:
             break
         included = min(length, window - kept)
         excluded = length - included
         guaranteed_front += max(0, front_count - excluded)
-        guaranteed_probes += max(0, probe_count - excluded)
         kept += included
 
     if guaranteed_front < MIN_DRIFT_PROBES:
@@ -443,13 +439,6 @@ def _validate_resume_evidence_budget(
             f"GPU {context} has insufficient exact budget to retain "
             f"{MIN_DRIFT_PROBES} proxy-front safety samples in the drift window: "
             f"guaranteed={guaranteed_front}, exact_done={exact_done}, "
-            f"remaining={remaining}"
-        )
-    if configured_probes > 0 and guaranteed_probes < required_probes:
-        raise error_type(
-            f"GPU {context} has insufficient exact budget to retain "
-            f"{required_probes} broad-probe safety samples in the drift window: "
-            f"guaranteed={guaranteed_probes}, exact_done={exact_done}, "
             f"remaining={remaining}"
         )
 

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -851,13 +851,12 @@ def _select_validation_indices(
         dtype=np.int64,
     )
     requested_probes = min(max(0, probes), max(0, total - len(selected)))
-    if len(broad_pool) < requested_probes:
-        raise RuntimeError(
-            "GPU validation cannot provide the requested independent broad-probe "
-            f"evidence: requested {requested_probes}, available {len(broad_pool)} "
-            "outside the complete feasible proxy Pareto front"
-        )
-    probe_count = requested_probes
+    # With several competing objectives the complete feasible proxy Pareto
+    # front may legitimately contain nearly the entire population. Use every
+    # truthful off-front probe available, then let diverse true-front members
+    # fill the remaining exact quota. Never relabel a front member as a broad
+    # probe merely to satisfy the configured per-generation target.
+    probe_count = min(requested_probes, len(broad_pool))
     if probe_count:
         positions = np.round(
             np.linspace(0, len(broad_pool) - 1, num=probe_count)
@@ -912,6 +911,9 @@ def _select_novel_validations(
     seen = set()
     novel_probe_count = 0
     novel_front_count = 0
+    target_probe_count = min(
+        probes, sum(bool(is_probe) for _index, is_probe, _is_front in selections)
+    )
     for index, is_probe, is_front in selections:
         candidate = candidate_for_index(index)
         digest = digest_for_candidate(candidate)
@@ -924,18 +926,12 @@ def _select_novel_validations(
         novel_front_count += int(bool(is_front))
         if (
             len(novel) >= total
-            and novel_probe_count >= probes
+            and novel_probe_count >= target_probe_count
             and novel_front_count > 0
         ):
             break
 
     probe_items = [item for item in novel if item[1]]
-    if len(probe_items) < probes:
-        raise RuntimeError(
-            "GPU validation cannot replace duplicate broad probes with novel "
-            "candidates outside the complete feasible proxy Pareto front: "
-            f"requested {probes}, available {len(probe_items)}"
-        )
     front_items = [item for item in novel if item[2]]
     if not front_items:
         raise RuntimeError(
@@ -955,6 +951,35 @@ def _select_novel_validations(
             chosen.append(item)
             chosen_digests.add(item[4])
     return chosen
+
+
+def _update_probe_shortfall_log(
+    previous: tuple[int, int] | None,
+    *,
+    requested: int,
+    actual: int,
+) -> tuple[int, int] | None:
+    current = (requested, actual) if actual < requested else None
+    if current == previous:
+        return previous
+    if current is None:
+        if previous is not None:
+            logging.info(
+                "GPU validation broad-probe allocation recovered | "
+                "requested=%d available=%d",
+                requested,
+                actual,
+            )
+    else:
+        logging.warning(
+            "GPU validation has fewer novel candidates outside the complete feasible "
+            "proxy Pareto front than requested | requested=%d available=%d | "
+            "filling the exact quota with diverse true-front candidates; broad-probe "
+            "gates use only truthful accumulated off-front evidence",
+            requested,
+            actual,
+        )
+    return current
 
 
 def _update_novelty_stall(
@@ -1644,6 +1669,7 @@ def run_backend(
     proxy_evaluations = 0
     novelty_stall_generations = 0
     last_warning = None
+    last_probe_shortfall = None
     last_checkpoint_at = 0.0
     last_checkpoint_exact = exact_done
 
@@ -1836,6 +1862,12 @@ def run_backend(
                 digest_for_candidate=vector_hash,
                 completed_hashes=completed_hashes,
                 submitted_hashes=submitted_hashes,
+            )
+            actual_probe_count = sum(bool(item[1]) for item in novel_selections)
+            last_probe_shortfall = _update_probe_shortfall_log(
+                last_probe_shortfall,
+                requested=probe_count,
+                actual=actual_probe_count,
             )
             submitted_this_generation = 0
             for index, is_probe, is_proxy_front, vector, digest in novel_selections:

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -647,9 +647,13 @@ def test_validation_selection_uses_true_front_when_no_off_front_evidence_exists(
     scores = objectives.mean(axis=1)
 
     selected = _select_validation_indices(objectives, scores, total=3, probes=1)
+    diversity_baseline = _select_validation_indices(
+        objectives, scores, total=3, probes=0
+    )
 
     assert len(selected) == len(objectives)
     assert all(not is_probe and is_front for _index, is_probe, is_front in selected)
+    assert selected[:3] == diversity_baseline[:3]
 
 
 def test_validation_selection_uses_all_available_off_front_probes():
@@ -670,6 +674,9 @@ def test_validation_selection_uses_all_available_off_front_probes():
     scores = objectives.mean(axis=1)
 
     selected = _select_validation_indices(objectives, scores, total=8, probes=4)
+    diversity_baseline = _select_validation_indices(
+        objectives, scores, total=6, probes=0
+    )
 
     chosen = selected[:8]
     assert sum(is_probe for _index, is_probe, _front in chosen) == 2
@@ -677,6 +684,9 @@ def test_validation_selection_uses_all_available_off_front_probes():
     assert {
         index for index, is_probe, _front in chosen if is_probe
     } == {8, 9}
+    assert {
+        index for index, _is_probe, is_front in chosen if is_front
+    } == {index for index, _is_probe, _front in diversity_baseline[:6]}
 
 
 def test_validation_selection_prefers_feasible_candidates():
@@ -756,6 +766,40 @@ def test_duplicate_broad_probe_falls_back_to_novel_true_front_candidates():
         not is_probe and is_front
         for _index, is_probe, is_front, *_rest in chosen
     )
+
+
+def test_unallocated_infeasible_fallback_does_not_restore_probe_quota():
+    objectives = np.array(
+        [
+            [0.0, 3.0],
+            [1.0, 2.0],
+            [2.0, 1.0],
+            [3.0, 0.0],
+            [8.0, 8.0],
+        ]
+    )
+    scores = objectives.mean(axis=1)
+    selections = _select_validation_indices(
+        objectives,
+        scores,
+        violations=np.array([0.0, 0.0, 0.0, 0.0, 1.0]),
+        total=3,
+        probes=1,
+    )
+
+    assert selections[-1] == (4, True, False)
+    chosen = _select_novel_validations(
+        selections,
+        total=3,
+        probes=1,
+        candidate_for_index=lambda index: [index],
+        digest_for_candidate=lambda candidate: f"hash-{candidate[0]}",
+        completed_hashes=set(),
+        submitted_hashes=set(),
+    )
+
+    assert len(chosen) == 3
+    assert all(not is_probe and is_front for _index, is_probe, is_front, *_ in chosen)
 
 
 def test_probe_shortfall_logging_is_bounded_and_reports_recovery(caplog):

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -178,15 +178,16 @@ def test_gpu_options_are_additive_and_validate_ranges():
         _resolve_options(config)
 
 
-def test_fresh_run_rejects_partial_suffix_without_rank_probe_budget():
+def test_fresh_run_accepts_partial_suffix_with_opportunistic_probes():
     config = _long_only_ema_config()
     config["optimize"]["gpu"]["validate_per_generation"] = 8
     config["optimize"]["gpu"]["drift_probes"] = 1
     config["optimize"]["gpu"]["drift_window"] = 96
     config["optimize"]["iters"] = 97
 
-    with pytest.raises(ValueError, match="GPU fresh run.*broad-probe"):
-        _resolve_options(config)
+    options = _resolve_options(config)
+
+    assert options["drift_probes"] == 1
 
 
 def test_partial_validation_batch_preserves_front_evidence_ratio():
@@ -252,20 +253,19 @@ def test_resume_budget_accepts_sufficient_recovered_and_future_evidence():
     )
 
 
-def test_resume_budget_rejects_too_few_remaining_broad_probes():
-    pairs = [_drift_pair(front=index >= 3) for index in range(57)]
+def test_resume_budget_accepts_truthful_broad_probe_scarcity():
+    pairs = [_drift_pair(front=True) for _ in range(57)]
 
-    with pytest.raises(RuntimeError, match="broad-probe safety samples"):
-        _validate_resume_evidence_budget(
-            pairs,
-            exact_done=57,
-            exact_budget=64,
-            options={
-                "drift_window": 128,
-                "validate_per_generation": 8,
-                "drift_probes": 4,
-            },
-        )
+    _validate_resume_evidence_budget(
+        pairs,
+        exact_done=57,
+        exact_budget=64,
+        options={
+            "drift_window": 128,
+            "validate_per_generation": 8,
+            "drift_probes": 4,
+        },
+    )
 
 
 def test_gpu_nsga2_uses_configured_pymoo_variation_operators():

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -735,7 +735,6 @@ def test_duplicate_broad_probe_is_replaced_by_novel_off_front_candidate():
     chosen = _select_novel_validations(
         selections,
         total=2,
-        probes=1,
         candidate_for_index=lambda index: [index],
         digest_for_candidate=lambda candidate: f"hash-{candidate[0]}",
         completed_hashes={"hash-1"},
@@ -754,7 +753,6 @@ def test_duplicate_broad_probe_falls_back_to_novel_true_front_candidates():
     chosen = _select_novel_validations(
         [(0, False, True), (1, True, False), (2, False, True)],
         total=2,
-        probes=1,
         candidate_for_index=lambda index: [index],
         digest_for_candidate=lambda candidate: f"hash-{candidate[0]}",
         completed_hashes={"hash-1"},
@@ -791,7 +789,6 @@ def test_unallocated_infeasible_fallback_does_not_restore_probe_quota():
     chosen = _select_novel_validations(
         selections,
         total=3,
-        probes=1,
         candidate_for_index=lambda index: [index],
         digest_for_candidate=lambda candidate: f"hash-{candidate[0]}",
         completed_hashes=set(),
@@ -800,6 +797,30 @@ def test_unallocated_infeasible_fallback_does_not_restore_probe_quota():
 
     assert len(chosen) == 3
     assert all(not is_probe and is_front for _index, is_probe, is_front, *_ in chosen)
+
+
+def test_duplicate_fronts_do_not_expand_adaptive_probe_allocation():
+    selections = [
+        *((index, False, True) for index in range(6)),
+        (6, True, False),
+        (7, True, False),
+        *((index, True, False) for index in range(8, 12)),
+        *((index, False, True) for index in range(12, 17)),
+    ]
+
+    chosen = _select_novel_validations(
+        selections,
+        total=8,
+        candidate_for_index=lambda index: [index],
+        digest_for_candidate=lambda candidate: f"hash-{candidate[0]}",
+        completed_hashes={f"hash-{index}" for index in range(1, 6)},
+        submitted_hashes=set(),
+    )
+
+    assert len(chosen) == 8
+    assert sum(is_probe for _index, is_probe, _front, *_rest in chosen) == 2
+    assert sum(is_front for _index, _is_probe, is_front, *_rest in chosen) == 6
+    assert {item[0] for item in chosen if item[2]} == {0, 12, 13, 14, 15, 16}
 
 
 def test_probe_shortfall_logging_is_bounded_and_reports_recovery(caplog):
@@ -828,7 +849,6 @@ def test_validation_batch_preserves_true_front_and_off_front_classification():
     chosen = _select_novel_validations(
         selections,
         total=8,
-        probes=4,
         candidate_for_index=lambda index: [index],
         digest_for_candidate=lambda candidate: f"hash-{candidate[0]}",
         completed_hashes=set(),
@@ -867,7 +887,6 @@ def test_validation_fails_closed_without_novel_proxy_front_evidence():
         _select_novel_validations(
             [(0, False, True), (1, True, False), (2, True, False)],
             total=2,
-            probes=1,
             candidate_for_index=lambda index: [index],
             digest_for_candidate=lambda candidate: f"hash-{candidate[0]}",
             completed_hashes={"hash-0"},
@@ -884,7 +903,6 @@ def test_validation_scans_fallbacks_for_novel_proxy_front_before_failing():
             (3, False, True),
         ],
         total=2,
-        probes=1,
         candidate_for_index=lambda index: [index],
         digest_for_candidate=lambda candidate: f"hash-{candidate[0]}",
         completed_hashes={"hash-0"},

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -30,6 +30,7 @@ from optimization.backends.gpu_backend import (
     _single_scenario_metric_surface,
     _select_novel_validations,
     _select_validation_indices,
+    _update_probe_shortfall_log,
     _validate_directional_search_space,
     _validate_pinned_scope_bounds,
     _validate_resume_evidence_budget,
@@ -639,14 +640,43 @@ def test_validation_selection_includes_front_and_broad_probes():
     assert len({index for index, _is_probe, _front in selected}) == len(objectives)
 
 
-def test_validation_selection_fails_without_requested_off_front_evidence():
+def test_validation_selection_uses_true_front_when_no_off_front_evidence_exists():
     objectives = np.array(
         [[0.0, 3.0], [1.0, 2.0], [2.0, 1.0], [3.0, 0.0]]
     )
     scores = objectives.mean(axis=1)
 
-    with pytest.raises(RuntimeError, match="independent broad-probe evidence"):
-        _select_validation_indices(objectives, scores, total=3, probes=1)
+    selected = _select_validation_indices(objectives, scores, total=3, probes=1)
+
+    assert len(selected) == len(objectives)
+    assert all(not is_probe and is_front for _index, is_probe, is_front in selected)
+
+
+def test_validation_selection_uses_all_available_off_front_probes():
+    objectives = np.array(
+        [
+            [0.0, 7.0],
+            [1.0, 6.0],
+            [2.0, 5.0],
+            [3.0, 4.0],
+            [4.0, 3.0],
+            [5.0, 2.0],
+            [6.0, 1.0],
+            [7.0, 0.0],
+            [8.0, 8.0],
+            [9.0, 9.0],
+        ]
+    )
+    scores = objectives.mean(axis=1)
+
+    selected = _select_validation_indices(objectives, scores, total=8, probes=4)
+
+    chosen = selected[:8]
+    assert sum(is_probe for _index, is_probe, _front in chosen) == 2
+    assert sum(is_front for _index, _probe, is_front in chosen) == 6
+    assert {
+        index for index, is_probe, _front in chosen if is_probe
+    } == {8, 9}
 
 
 def test_validation_selection_prefers_feasible_candidates():
@@ -710,17 +740,34 @@ def test_duplicate_broad_probe_is_replaced_by_novel_off_front_candidate():
     assert chosen[0][0] == 3
 
 
-def test_duplicate_broad_probes_fail_closed_when_no_novel_replacement_exists():
-    with pytest.raises(RuntimeError, match="replace duplicate broad probes"):
-        _select_novel_validations(
-            [(0, False, True), (1, True, False)],
-            total=2,
-            probes=1,
-            candidate_for_index=lambda index: [index],
-            digest_for_candidate=lambda candidate: f"hash-{candidate[0]}",
-            completed_hashes={"hash-1"},
-            submitted_hashes=set(),
-        )
+def test_duplicate_broad_probe_falls_back_to_novel_true_front_candidates():
+    chosen = _select_novel_validations(
+        [(0, False, True), (1, True, False), (2, False, True)],
+        total=2,
+        probes=1,
+        candidate_for_index=lambda index: [index],
+        digest_for_candidate=lambda candidate: f"hash-{candidate[0]}",
+        completed_hashes={"hash-1"},
+        submitted_hashes=set(),
+    )
+
+    assert [item[0] for item in chosen] == [0, 2]
+    assert all(
+        not is_probe and is_front
+        for _index, is_probe, is_front, *_rest in chosen
+    )
+
+
+def test_probe_shortfall_logging_is_bounded_and_reports_recovery(caplog):
+    with caplog.at_level("INFO"):
+        state = _update_probe_shortfall_log(None, requested=4, actual=2)
+        state = _update_probe_shortfall_log(state, requested=4, actual=2)
+        state = _update_probe_shortfall_log(state, requested=4, actual=4)
+
+    assert state is None
+    assert caplog.text.count("fewer novel candidates") == 1
+    assert "requested=4 available=2" in caplog.text
+    assert caplog.text.count("allocation recovered") == 1
 
 
 def test_validation_batch_preserves_true_front_and_off_front_classification():


### PR DESCRIPTION
## Summary

- keep GPU validation running when a many-objective generation has fewer genuine off-front candidates than its configured broad-probe quota
- use every available off-front probe and fill unused exact slots with diverse true-front candidates
- preserve truthful, mutually exclusive front/probe classification and exact-Rust authority
- log allocation shortfalls once per state change and log recovery
- document the adaptive allocation contract

## Root cause

With several competing objectives, the complete feasible proxy Pareto front can contain nearly the entire population. The validator previously aborted immediately if fewer off-front candidates existed than the per-generation probe target, even though it could still collect all available independent probes and broaden exact coverage of the true front.

## Validation

- focused GPU backend regression suite
- full `tests/optimization` suite
- Python compile and `git diff --check`
- AI documentation checks
- bounded single-coin Apple MPS optimization: 32,768 proxy evaluations and 64 exact Rust validations completed without a selector or drift halt

The regression matrix covers eight exact slots, four requested probes, and only two genuine off-front candidates, asserting two truthful probes plus six true-front validations. It also covers duplicate-probe fallback and bounded shortfall/recovery logging.
