### PR TITLE
Renew expired KuCoin websocket tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- KuCoin private futures order websockets now discard the exact cached negotiated URL when the
+  exchange expires its token, allowing `watch_orders` to obtain a fresh token instead of reusing
+  the rejected URL indefinitely. The expected callback exception is reduced to a throttled warning
+  while REST reconciliation continues normally.
+
 - Add `passivbot tool compose-coin-overrides` to validate and combine a directory of single-coin
   configs into a lean unified config with minimal inline per-coin patches. The tool canonicalizes
   parameters belonging only to features disabled in every input, reports account-wide conflicts,

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -181,6 +181,21 @@ whitelist authentication failure.
 Handling: Both KuCoin REST and WebSocket CCXT clients use IPv4-only network
 connectors. Keep the host's stable public IPv4 address in the API-key whitelist.
 
+### Private websocket token renewal
+
+Problem:
+
+1. KuCoin expires private futures websocket tokens during long-running sessions.
+2. Pinned CCXT classifies `connectId=privateFutures` as `private` when handling the expiry message,
+   so its cached futures URL keeps the rejected token and every reconnect reuses it.
+
+Handling:
+
+1. Clear the exact negotiated URL cache entry named by the websocket's `connectId` before CCXT
+   propagates the expiry error to the reconnect loop.
+2. Keep the expiry visible as a throttled websocket warning without emitting the dependency's raw
+   callback traceback. The next `watch_orders` attempt must negotiate a new futures token.
+
 ### KuCoin hedge-mode refresh
 
 Problem:

--- a/src/exchanges/kucoin.py
+++ b/src/exchanges/kucoin.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 import hmac
 import hashlib
 import base64
+from urllib.parse import parse_qs, urlsplit
 
 calc_order_price_diff = pbr.calc_order_price_diff
 
@@ -83,6 +84,30 @@ class ProKucoinBrokerFutures(IPv4TransportMixin, ccxt_pro.kucoinfutures):
         if api in {"private", "futuresPrivate", "broker"}:
             return _add_kucoin_broker_name_header(signed, self.options)
         return signed
+
+    def handle_error_message(self, client, message):
+        """Expire the exact negotiated websocket URL rejected by KuCoin.
+
+        Pinned CCXT clears ``private`` when a ``privateFutures`` token expires
+        because its substring check matches both connect IDs. Leaving the
+        futures URL future cached makes every reconnect reuse the rejected
+        token. Clear only the connect ID carried by the rejected URL before
+        delegating normal error classification to CCXT.
+        """
+        data = self.safe_string_2(message, "data", "reason", "")
+        if data == "token is expired":
+            query = parse_qs(urlsplit(str(getattr(client, "url", "") or "")).query)
+            connect_id_values = query.get("connectId", [])
+            connect_id = connect_id_values[0] if connect_id_values else None
+            urls = self.options.get("urls")
+            if connect_id in {
+                "private",
+                "privateFutures",
+                "public",
+                "publicFutures",
+            } and isinstance(urls, dict):
+                urls[connect_id] = None
+        return super().handle_error_message(client, message)
 
 
 assert_correct_ccxt_version(ccxt=ccxt_async)

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -6669,7 +6669,10 @@ class Passivbot:
         )
         if not callback_like:
             return False
-        known_transport_error = any(
+        kucoin_token_expired = (
+            "token is expired" in combined and "kucoin" in combined
+        )
+        known_transport_error = kucoin_token_expired or any(
             needle in combined
             for needle in (
                 "ping timeout",
@@ -6700,7 +6703,11 @@ class Passivbot:
             self._asyncio_ws_callback_last_log_ms = now_ms
             level = logging.DEBUG if self._shutdown_requested() else logging.WARNING
             reason = (
-                "ping timeout" if "ping timeout" in combined else type(exc).__name__
+                "token expired"
+                if kucoin_token_expired
+                else "ping timeout"
+                if "ping timeout" in combined
+                else type(exc).__name__
             )
             if not reason:
                 reason = "transport error"

--- a/tests/test_kucoin_exchange_config.py
+++ b/tests/test_kucoin_exchange_config.py
@@ -5,6 +5,7 @@ import socket
 import types
 
 import pytest
+import ccxt.pro as ccxt_pro
 
 from exchanges.kucoin import (
     AsyncKucoinBrokerFutures,
@@ -39,6 +40,62 @@ class DummyCCA:
     async def set_leverage(self, **params):
         self.leverage_calls.append(params)
         return {"symbol": params["symbol"], "leverage": params["leverage"]}
+
+
+def test_kucoin_futures_expired_ws_token_invalidates_exact_negotiated_url(monkeypatch):
+    client = ProKucoinBrokerFutures({})
+    private_url = object()
+    private_futures_url = object()
+    client.options["urls"] = {
+        "private": private_url,
+        "privateFutures": private_futures_url,
+    }
+    delegated = []
+
+    def handle_error_message(_self, ws_client, message):
+        delegated.append((ws_client, message))
+        return False
+
+    monkeypatch.setattr(
+        ccxt_pro.kucoinfutures,
+        "handle_error_message",
+        handle_error_message,
+    )
+    ws_client = types.SimpleNamespace(
+        url="wss://push-private.kucoin.example/endpoint?token=redacted&connectId=privateFutures"
+    )
+    message = {"type": "error", "data": "token is expired"}
+
+    assert client.handle_error_message(ws_client, message) is False
+
+    assert client.options["urls"]["privateFutures"] is None
+    assert client.options["urls"]["private"] is private_url
+    assert delegated == [(ws_client, message)]
+
+
+def test_kucoin_ws_non_expiry_error_preserves_negotiated_url(monkeypatch):
+    client = ProKucoinBrokerFutures({})
+    private_futures_url = object()
+    client.options["urls"] = {"privateFutures": private_futures_url}
+
+    monkeypatch.setattr(
+        ccxt_pro.kucoinfutures,
+        "handle_error_message",
+        lambda _self, _ws_client, _message: False,
+    )
+    ws_client = types.SimpleNamespace(
+        url="wss://push-private.kucoin.example/endpoint?token=redacted&connectId=privateFutures"
+    )
+
+    assert (
+        client.handle_error_message(
+            ws_client,
+            {"type": "error", "data": "type is not supported"},
+        )
+        is False
+    )
+
+    assert client.options["urls"]["privateFutures"] is private_futures_url
 
 
 @pytest.mark.asyncio

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -2023,6 +2023,38 @@ def test_asyncio_runtime_exception_handler_suppresses_ccxt_transport_callback(ca
     )
 
 
+def test_asyncio_runtime_exception_handler_suppresses_kucoin_token_expiry_callback(caplog):
+    class AuthenticationError(Exception):
+        pass
+
+    bot = Passivbot.__new__(Passivbot)
+    bot.exchange = "kucoin"
+    bot._shutdown_in_progress = False
+    bot.stop_signal_received = False
+    bot._asyncio_ws_callback_last_log_ms = 0
+
+    with caplog.at_level(logging.WARNING):
+        handled = bot._handle_asyncio_runtime_exception(
+            {
+                "message": "Exception in callback Client.receive_loop",
+                "exception": AuthenticationError("kucoinfutures token is expired"),
+            }
+        )
+
+    assert handled is True
+    assert any("websocket callback token expired" in r.message for r in caplog.records)
+
+    assert (
+        bot._handle_asyncio_runtime_exception(
+            {
+                "message": "Exception in callback Client.receive_loop",
+                "exception": AuthenticationError("invalid api key"),
+            }
+        )
+        is False
+    )
+
+
 def test_asyncio_runtime_exception_handler_suppresses_unretrieved_transport_future(caplog):
     class RequestTimeout(Exception):
         pass


### PR DESCRIPTION
## Summary

- invalidate the exact cached KuCoin websocket URL when CCXT reports an expired token
- suppress only the known asyncio callback traceback for that token-lifecycle event while preserving unrelated authentication failures
- document the KuCoin renewal contract and add focused regression coverage

## Root cause

CCXT caches separate `private` and `privateFutures` websocket URLs. Its current error handler classifies `connectId=privateFutures` with a substring check for `connectId=private`, so an expired futures token clears the wrong cache entry. Every reconnect then reuses the rejected `privateFutures` URL indefinitely.

The Passivbot broker now parses the exact `connectId` from the rejected URL and invalidates only that cached endpoint before delegating to CCXT's normal error handling. The next `watch_orders` attempt therefore negotiates a fresh token.

## Operational evidence

A long-running KuCoin futures bot was otherwise healthy through REST reconciliation but had accumulated more than 5,000 failed private-websocket reconnects and repeated raw callback tracebacks after token expiry.

The branch was deployed to that affected bot using its unchanged command and config. It rebuilt the Rust extension, restored account and candle readiness, completed history reconstruction, started the private order watch, and resumed normal order execution. The new run had zero token-expiry errors, raw tracebacks, degraded cycles, or error-budget events during the bounded verification window.

No private configuration, account, order, or host data is included in this PR.

## Validation

- `pytest -q tests/test_kucoin_exchange_config.py tests/exchanges/test_ccxt_bot_hooks.py tests/test_passivbot_balance_split.py -k 'kucoin or websocket or asyncio_runtime_exception_handler or watch_orders'` — 38 passed
- focused failure-first renewal and callback-handler regressions — 3 passed
- `python -m py_compile` for changed Python modules/tests
- `git diff --check`
- `python src/tools/check_ai_docs.py` — 0 errors (2 pre-existing word-count warnings)
- `python src/tools/generate_live_event_registry.py --check`
- `pytest -q tests/test_ai_docs.py tests/test_live_event_registry_docs.py` — 6 passed