### PR TITLE
Add Pareto selected and filtered export options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Extend `passivbot tool pareto` with `--save-selected` for copying the method winner to a JSON
+  file and `--save-filtered` for copying the complete post-limit member set with a reproducible
+  selection manifest. Output writes protect source Pareto directories, require explicit overwrite
+  approval, and prevent stale or mixed filtered-directory contents.
 - Add `passivbot tool compose-coin-overrides` to validate and combine a directory of single-coin
   configs into a lean unified config with minimal inline per-coin patches. The tool canonicalizes
   parameters belonging only to features disabled in every input, reports account-wide conflicts,

--- a/docs/ai/runbooks/commands.md
+++ b/docs/ai/runbooks/commands.md
@@ -80,6 +80,8 @@ cd passivbot-rust && cargo check --tests && cd ..
 
 ```bash
 passivbot tool pareto optimize_results/.../pareto
+passivbot tool pareto optimize_results/.../pareto -s configs/promoted_candidate.json
+passivbot tool pareto optimize_results/.../pareto -l 'adg_strategy_eq>0.0' -f filtered_pareto
 passivbot tool pareto-compress optimize_results/.../pareto 8 --output-dir selected_pareto_8
 passivbot tool pareto-dash --data-root optimize_results
 passivbot tool verify-hlcvs-data

--- a/docs/ai/runbooks/commands.md
+++ b/docs/ai/runbooks/commands.md
@@ -80,8 +80,8 @@ cd passivbot-rust && cargo check --tests && cd ..
 
 ```bash
 passivbot tool pareto optimize_results/.../pareto
-passivbot tool pareto optimize_results/.../pareto -s configs/promoted_candidate.json
-passivbot tool pareto optimize_results/.../pareto -l 'adg_strategy_eq>0.0' -f filtered_pareto
+passivbot tool pareto optimize_results/.../pareto -s /path/to/private/passivbot/promoted_candidate.json
+passivbot tool pareto optimize_results/.../pareto -l 'adg_strategy_eq>0.0' -f /path/to/private/passivbot/filtered_pareto
 passivbot tool pareto-compress optimize_results/.../pareto 8 --output-dir selected_pareto_8
 passivbot tool pareto-dash --data-root optimize_results
 passivbot tool verify-hlcvs-data

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -33,7 +33,12 @@ passivbot tool pareto optimize_results/.../pareto -m reference \
   --target drawdown_worst_strategy_eq=0.25
 passivbot tool pareto optimize_results/.../pareto \
   -l 'drawdown_worst_strategy_eq<=0.35' \
-  -l 'adg_strategy_eq>0.0'
+  -l 'adg_strategy_eq>0.0' \
+  --save-selected configs/promoted_candidate.json
+passivbot tool pareto optimize_results/.../pareto \
+  -l 'drawdown_worst_strategy_eq<=0.35' \
+  -l 'adg_strategy_eq>0.0' \
+  --save-filtered filtered_pareto
 passivbot tool pareto -o sharpe_ratio_strategy_eq,adg_strategy_eq,strategy_eq_recovery_days_max \
   -m ideal
 passivbot tool pareto optimize_results/... -m utility \
@@ -70,6 +75,22 @@ recovered, so it is not the complete scenario Pareto front across all evaluated 
 
 The output also shows the retained front's ideal point: the best observed value for each active
 objective after any `--limit` filters are applied.
+
+Add `-s FILE` / `--save-selected FILE` to copy the selected member to an exact destination. The
+saved member is the winner of the active method after objectives, limits, weights, targets, and any
+scenario projection are applied; with the default method it is the ideal-point winner. The original
+Pareto JSON artifact is copied without reserialization. Add `-f DIR` / `--save-filtered DIR` to copy
+every member retained immediately after limits, preserving the source filenames, and write a
+`selection.json` manifest with the source, scenario, limits, counts, selected winner, and copied
+members. Without limits, `--save-filtered` copies the full loaded set. With `--scenario`, the
+exported set is filtered using that scenario's metrics before the scenario-specific nondominated
+front is rebuilt.
+
+Output destinations must be outside the source Pareto directory. Existing selected files and
+non-empty filtered directories fail by default. `--overwrite` replaces the selected file or clears
+existing JSON files from the filtered directory before writing the exact new set; filtered
+directories containing non-JSON entries are refused. Both save options may be used together when
+the selected file is outside the filtered directory.
 
 `-o` / `--objectives` is not limited to the original `optimize.scoring` list. You can also name
 other stored metrics such as `sharpe_ratio_strategy_eq` as long as the Pareto JSON

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -34,11 +34,11 @@ passivbot tool pareto optimize_results/.../pareto -m reference \
 passivbot tool pareto optimize_results/.../pareto \
   -l 'drawdown_worst_strategy_eq<=0.35' \
   -l 'adg_strategy_eq>0.0' \
-  --save-selected configs/promoted_candidate.json
+  --save-selected /path/to/private/passivbot/promoted_candidate.json
 passivbot tool pareto optimize_results/.../pareto \
   -l 'drawdown_worst_strategy_eq<=0.35' \
   -l 'adg_strategy_eq>0.0' \
-  --save-filtered filtered_pareto
+  --save-filtered /path/to/private/passivbot/filtered_pareto
 passivbot tool pareto -o sharpe_ratio_strategy_eq,adg_strategy_eq,strategy_eq_recovery_days_max \
   -m ideal
 passivbot tool pareto optimize_results/... -m utility \
@@ -81,8 +81,9 @@ saved member is the winner of the active method after objectives, limits, weight
 scenario projection are applied; with the default method it is the ideal-point winner. The original
 Pareto JSON artifact is copied without reserialization. Add `-f DIR` / `--save-filtered DIR` to copy
 every member retained immediately after limits, preserving the source filenames, and write a
-`selection.json` manifest with the source, scenario, limits, counts, selected winner, and copied
-members. Without limits, `--save-filtered` copies the full loaded set. With `--scenario`, the
+`selection.json` manifest with the source, scenario, limits, normalized method inputs, counts,
+selected winner, and copied members. Without limits, `--save-filtered` copies the full loaded set.
+With `--scenario`, the
 exported set is filtered using that scenario's metrics before the scenario-specific nondominated
 front is rebuilt.
 

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -1617,7 +1617,9 @@ def _validate_selected_output_not_source(
         for candidate in candidates
         for source in (candidate.path.resolve(), candidate.member_path)
     }
-    if output in sources:
+    if output in sources or any(
+        _same_existing_filesystem_object(output, source) for source in sources
+    ):
         raise ValueError(f"Refusing to overwrite a source Pareto member: {output}")
 
 
@@ -1724,11 +1726,16 @@ def _prepare_filtered_output_dir(
     return output_dir
 
 
-def _write_candidate_snapshot(candidate: ParetoCandidate, destination: Path) -> None:
-    destination.write_bytes(candidate.source_bytes)
+def _write_candidate_snapshot_fd(
+    candidate: ParetoCandidate,
+    destination: Path,
+    file_descriptor: int,
+) -> None:
+    with os.fdopen(file_descriptor, "wb") as destination_file:
+        destination_file.write(candidate.source_bytes)
 
 
-def _create_selected_staging_file(parent: Path) -> Path:
+def _create_selected_staging_file(parent: Path) -> tuple[Path, int]:
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
     if hasattr(os, "O_CLOEXEC"):
         flags |= os.O_CLOEXEC
@@ -1738,8 +1745,7 @@ def _create_selected_staging_file(parent: Path) -> Path:
             file_descriptor = os.open(staging_path, flags, 0o666)
         except FileExistsError:
             continue
-        os.close(file_descriptor)
-        return staging_path
+        return staging_path, file_descriptor
     raise FileExistsError(f"Could not reserve selected staging file in {parent}")
 
 
@@ -1829,16 +1835,60 @@ def _install_selected_without_overwrite(
                 f"Selected output already exists: {output} "
                 "(use --overwrite to replace it)"
             ) from conflict
+        created_stat = os.fstat(file_descriptor)
+        created_identity = created_stat.st_dev, created_stat.st_ino
         try:
             with os.fdopen(file_descriptor, "wb") as output_file:
                 output_file.write(source_bytes)
             if metadata_source is not None:
+                output_stat = output.stat(follow_symlinks=False)
+                if (output_stat.st_dev, output_stat.st_ino) != created_identity:
+                    raise RuntimeError(
+                        f"Selected output changed concurrently; refusing metadata copy: "
+                        f"{output}"
+                    )
                 _copy_file_metadata(metadata_source, output)
-        except BaseException:
-            output.unlink(missing_ok=True)
+            output_stat = output.stat(follow_symlinks=False)
+            if (output_stat.st_dev, output_stat.st_ino) != created_identity:
+                raise RuntimeError(
+                    f"Selected output changed concurrently after metadata copy: {output}"
+                )
+        except BaseException as exc:
+            try:
+                output_stat = output.stat(follow_symlinks=False)
+            except FileNotFoundError:
+                output_stat = None
+            if output_stat is not None and (
+                output_stat.st_dev,
+                output_stat.st_ino,
+            ) == created_identity:
+                failed_descriptor, failed_name = tempfile.mkstemp(
+                    prefix=SELECTED_BACKUP_PREFIX,
+                    suffix=".failed",
+                    dir=output.parent,
+                )
+                os.close(failed_descriptor)
+                failed_path = Path(failed_name)
+                failed_path.unlink()
+                try:
+                    os.replace(output, failed_path)
+                except FileNotFoundError:
+                    pass
+                else:
+                    failed_stat = failed_path.stat(follow_symlinks=False)
+                    if (failed_stat.st_dev, failed_stat.st_ino) == created_identity:
+                        failed_path.unlink()
+                    else:
+                        raise RuntimeError(
+                            f"Selected output changed concurrently; moved file retained "
+                            f"at {failed_path}"
+                        ) from exc
+            elif output_stat is not None:
+                raise RuntimeError(
+                    f"Selected output changed concurrently; refusing cleanup: {output}"
+                ) from exc
             raise
-        output_stat = output.stat(follow_symlinks=False)
-        return output_stat.st_dev, output_stat.st_ino
+        return created_identity
     return staging_stat.st_dev, staging_stat.st_ino
 
 
@@ -1850,12 +1900,12 @@ def _write_selected_output(
     overwrite: bool,
 ) -> _SelectedOutputInstall:
     output.parent.mkdir(parents=True, exist_ok=True)
-    staging_path = _create_selected_staging_file(output.parent)
+    staging_path, staging_descriptor = _create_selected_staging_file(output.parent)
     backup_path: Path | None = None
     staging_cleanup_attempted = False
     installed_identity: tuple[int, int] | None = None
     try:
-        _write_candidate_snapshot(candidate, staging_path)
+        _write_candidate_snapshot_fd(candidate, staging_path, staging_descriptor)
         if not overwrite:
             staging_stat = staging_path.stat(follow_symlinks=False)
             installed_identity = staging_stat.st_dev, staging_stat.st_ino
@@ -2123,7 +2173,7 @@ def _remove_filtered_reservation(
         )
 
 
-def _reserve_filtered_output_file(destination: Path, *, label: str) -> None:
+def _reserve_filtered_output_file(destination: Path, *, label: str) -> int:
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
     if hasattr(os, "O_CLOEXEC"):
         flags |= os.O_CLOEXEC
@@ -2133,7 +2183,7 @@ def _reserve_filtered_output_file(destination: Path, *, label: str) -> None:
         raise ValueError(
             f"{label} collides on the destination filesystem: {destination.name}"
         ) from exc
-    os.close(file_descriptor)
+    return file_descriptor
 
 
 def _write_filtered_outputs(
@@ -2154,6 +2204,8 @@ def _write_filtered_outputs(
         overwrite=overwrite,
     )
     staging_dir: Path | None = None
+    staging_identity: tuple[int, int] | None = None
+    committed = False
     try:
         staging_dir = Path(
             tempfile.mkdtemp(
@@ -2166,14 +2218,18 @@ def _write_filtered_outputs(
         staging_dir.chmod(
             stat.S_IMODE(staging_dir.stat().st_mode) | stat.S_IWUSR | stat.S_IXUSR
         )
+        staging_stat = staging_dir.stat(follow_symlinks=False)
+        staging_identity = staging_stat.st_dev, staging_stat.st_ino
         members: List[Dict[str, Any]] = []
         for candidate in candidates:
             staged_destination = staging_dir / candidate.member_name
             final_destination = output_dir / candidate.member_name
-            _reserve_filtered_output_file(
+            member_descriptor = _reserve_filtered_output_file(
                 staged_destination, label="Filtered member filename"
             )
-            _write_candidate_snapshot(candidate, staged_destination)
+            _write_candidate_snapshot_fd(
+                candidate, staged_destination, member_descriptor
+            )
             members.append(
                 {
                     "file": candidate.member_name,
@@ -2207,22 +2263,48 @@ def _write_filtered_outputs(
             "members": members,
         }
         manifest_path = staging_dir / FILTERED_SELECTION_MANIFEST
-        _reserve_filtered_output_file(
+        manifest_descriptor = _reserve_filtered_output_file(
             manifest_path, label="Filtered selection manifest"
         )
-        manifest_path.write_text(
-            json.dumps(_json_ready(manifest), indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
-        )
+        with os.fdopen(manifest_descriptor, "w", encoding="utf-8") as manifest_file:
+            manifest_file.write(
+                json.dumps(_json_ready(manifest), indent=2, sort_keys=True) + "\n"
+            )
         _replace_filtered_output_dir(
             staging_dir,
             output_dir,
             overwrite=overwrite,
         )
+        committed = True
     finally:
-        if staging_dir is not None:
-            _remove_output_tree(staging_dir)
-        _remove_filtered_reservation(output_dir, reservation_identity)
+        if not committed and staging_identity is not None:
+            try:
+                output_stat = output_dir.stat(follow_symlinks=False)
+            except FileNotFoundError:
+                output_stat = None
+            if output_stat is not None and (
+                output_stat.st_dev,
+                output_stat.st_ino,
+            ) == staging_identity:
+                committed = True
+        if committed:
+            if staging_dir is not None:
+                try:
+                    _remove_output_tree(staging_dir)
+                except BaseException as exc:
+                    _warn_post_commit_cleanup_failure(
+                        "filtered output", staging_dir, exc
+                    )
+            try:
+                _remove_filtered_reservation(output_dir, reservation_identity)
+            except BaseException as exc:
+                _warn_post_commit_cleanup_failure(
+                    "filtered output reservation", output_dir, exc
+                )
+        else:
+            if staging_dir is not None:
+                _remove_output_tree(staging_dir)
+            _remove_filtered_reservation(output_dir, reservation_identity)
     return output_dir / FILTERED_SELECTION_MANIFEST
 
 

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import math
 import os
+import shutil
 import textwrap
 from dataclasses import dataclass
 from pathlib import Path
@@ -60,6 +61,9 @@ METHOD_DESCRIPTIONS = {
     "lexicographic": "Strict priority chooser. Sorts by objective priority order.",
     "outranking": "Simplified PROMETHEE-style chooser based on pairwise net preference flow.",
 }
+
+
+FILTERED_SELECTION_MANIFEST = "selection.json"
 
 
 @dataclass(frozen=True)
@@ -318,7 +322,10 @@ def parse_method_name(raw_method: str) -> str:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="passivbot tool pareto",
-        description="Select a single candidate from a Pareto front directory.",
+        description=(
+            "Select a single candidate from a Pareto front directory and optionally copy the "
+            "winner or filtered set."
+        ),
         formatter_class=argparse.RawTextHelpFormatter,
         epilog=(
             "Methods:\n"
@@ -331,7 +338,10 @@ def build_parser() -> argparse.ArgumentParser:
             "Limits are applied before selection. Repeat -l/--limit for multiple keep-conditions:\n"
             "  -l 'adg_strategy_eq>0.0'\n"
             "  -l 'drawdown_worst_strategy_eq<=0.35'\n"
-            "  --limits '[{\"metric\":\"drawdown_worst_strategy_eq\",\"penalize_if\":\">\",\"value\":0.35}]'\n"
+            "  --limits '[{\"metric\":\"drawdown_worst_strategy_eq\",\"penalize_if\":\">\",\"value\":0.35}]'\n\n"
+            "Outputs:\n"
+            "  -s selected.json      Copy the method winner.\n"
+            "  -f filtered_pareto    Copy every member retained after limits.\n"
         ),
     )
     parser.add_argument(
@@ -409,6 +419,33 @@ def build_parser() -> argparse.ArgumentParser:
         default=1,
         metavar="N",
         help="Show the top N ranked candidates instead of only the winner. Default: 1.",
+    )
+    parser.add_argument(
+        "-s",
+        "--save-selected",
+        type=str,
+        default=None,
+        metavar="FILE",
+        help="Copy the selected Pareto member to FILE.",
+    )
+    parser.add_argument(
+        "-f",
+        "--save-filtered",
+        type=str,
+        default=None,
+        metavar="DIR",
+        help=(
+            "Copy every member retained after limits to DIR and write selection.json. "
+            "Without limits, copies the full loaded set."
+        ),
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help=(
+            "Replace an existing selected FILE or JSON outputs in a filtered DIR. "
+            "A filtered DIR containing non-JSON entries is never replaced."
+        ),
     )
     parser.add_argument(
         "--json",
@@ -1515,6 +1552,153 @@ def format_selection_result(
     return "\n".join(lines)
 
 
+def _is_within(path: Path, directory: Path) -> bool:
+    try:
+        path.relative_to(directory)
+        return True
+    except ValueError:
+        return False
+
+
+def _validate_output_outside_source(path: Path, pareto_dir: Path, *, label: str) -> None:
+    if _is_within(path, pareto_dir.resolve()):
+        raise ValueError(
+            f"Refusing to write {label} inside the source Pareto directory: {path}"
+        )
+
+
+def _prepare_selected_output(
+    raw_path: str | os.PathLike[str] | None,
+    pareto_dir: Path,
+    *,
+    overwrite: bool,
+) -> Path | None:
+    if raw_path is None:
+        return None
+    output = Path(raw_path).expanduser().resolve()
+    _validate_output_outside_source(output, pareto_dir, label="selected output")
+    if output.suffix.lower() != ".json":
+        raise ValueError(f"Selected output must use a .json filename: {output}")
+    if output.exists():
+        if output.is_dir():
+            raise IsADirectoryError(f"Selected output path is a directory: {output}")
+        if not overwrite:
+            raise FileExistsError(
+                f"Selected output already exists: {output} (use --overwrite to replace it)"
+            )
+    if output.parent.exists() and not output.parent.is_dir():
+        raise NotADirectoryError(f"Selected output parent is not a directory: {output.parent}")
+    return output
+
+
+def _prepare_filtered_output_dir(
+    raw_path: str | os.PathLike[str] | None,
+    pareto_dir: Path,
+    candidates: Sequence[ParetoCandidate],
+    *,
+    overwrite: bool,
+) -> Path | None:
+    if raw_path is None:
+        return None
+    output_dir = Path(raw_path).expanduser().resolve()
+    _validate_output_outside_source(output_dir, pareto_dir, label="filtered output")
+    names = [candidate.path.name for candidate in candidates]
+    normalized_names = [name.casefold() for name in names]
+    if len(normalized_names) != len(set(normalized_names)):
+        raise ValueError("Filtered members contain duplicate filenames; cannot copy safely.")
+    if FILTERED_SELECTION_MANIFEST.casefold() in normalized_names:
+        raise ValueError(
+            f"Filtered member filename conflicts with reserved manifest name "
+            f"{FILTERED_SELECTION_MANIFEST!r}."
+        )
+    if output_dir.exists():
+        if not output_dir.is_dir():
+            raise NotADirectoryError(f"Filtered output path is not a directory: {output_dir}")
+        existing = sorted(
+            (path for path in output_dir.iterdir() if path.name != ".DS_Store"),
+            key=lambda path: path.name,
+        )
+        if existing and not overwrite:
+            raise FileExistsError(
+                f"Filtered output directory is not empty: {output_dir} "
+                "(use --overwrite to replace JSON outputs)"
+            )
+        invalid = [
+            path
+            for path in existing
+            if not path.is_file() or path.suffix.lower() != ".json"
+        ]
+        if invalid:
+            preview = ", ".join(path.name for path in invalid[:5])
+            raise FileExistsError(
+                f"Refusing to overwrite filtered output directory containing non-JSON "
+                f"entries: {preview}"
+            )
+    elif output_dir.parent.exists() and not output_dir.parent.is_dir():
+        raise NotADirectoryError(
+            f"Filtered output parent is not a directory: {output_dir.parent}"
+        )
+    return output_dir
+
+
+def _write_selected_output(candidate: ParetoCandidate, output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(candidate.path, output)
+
+
+def _write_filtered_outputs(
+    output_dir: Path,
+    pareto_dir: Path,
+    candidates: Sequence[ParetoCandidate],
+    *,
+    loaded_count: int,
+    active_limits: Sequence[Mapping[str, Any]],
+    scenario: str | None,
+    selected: ParetoCandidate,
+    overwrite: bool,
+) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if overwrite:
+        for path in output_dir.iterdir():
+            if path.name != ".DS_Store" and path.is_file() and path.suffix.lower() == ".json":
+                path.unlink()
+
+    members: List[Dict[str, Any]] = []
+    for candidate in candidates:
+        destination = output_dir / candidate.path.name
+        shutil.copy2(candidate.path, destination)
+        members.append(
+            {
+                "file": candidate.path.name,
+                "hash": candidate.path.stem,
+                "source_path": str(candidate.path),
+                "output_path": str(destination),
+            }
+        )
+
+    manifest_path = output_dir / FILTERED_SELECTION_MANIFEST
+    manifest = {
+        "tool": "passivbot tool pareto",
+        "mode": "filtered",
+        "pareto_dir": str(pareto_dir),
+        "loaded_count": int(loaded_count),
+        "retained_count": len(candidates),
+        "scenario": scenario,
+        "applied_limits": _json_ready(active_limits),
+        "selected_member": {
+            "file": selected.path.name,
+            "hash": selected.path.stem,
+            "source_path": str(selected.path),
+        },
+        "members": members,
+    }
+    manifest_path.write_text(
+        json.dumps(_json_ready(manifest), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
 def run_from_args(args: argparse.Namespace) -> SelectionResult:
     method = parse_method_name(args.method)
     raw_path = getattr(args, "path", None)
@@ -1557,6 +1741,42 @@ def run_from_args(args: argparse.Namespace) -> SelectionResult:
         target_pairs=getattr(args, "target", None),
         priority_arg=getattr(args, "priority", None),
     )
+    overwrite = bool(getattr(args, "overwrite", False))
+    selected_output = _prepare_selected_output(
+        getattr(args, "save_selected", None),
+        pareto_dir,
+        overwrite=overwrite,
+    )
+    filtered_output_dir = _prepare_filtered_output_dir(
+        getattr(args, "save_filtered", None),
+        pareto_dir,
+        filtered_candidates,
+        overwrite=overwrite,
+    )
+    if (
+        selected_output is not None
+        and filtered_output_dir is not None
+        and _is_within(selected_output, filtered_output_dir)
+    ):
+        raise ValueError(
+            "Selected output must be outside the filtered output directory when both are saved."
+        )
+    if selected_output is not None:
+        _write_selected_output(result.candidate, selected_output)
+    filtered_manifest = (
+        _write_filtered_outputs(
+            filtered_output_dir,
+            pareto_dir,
+            filtered_candidates,
+            loaded_count=len(candidates),
+            active_limits=active_limits,
+            scenario=scenario,
+            selected=result.candidate,
+            overwrite=overwrite,
+        )
+        if filtered_output_dir is not None
+        else None
+    )
     show_top = max(1, int(getattr(args, "show_top", 1) or 1))
     if getattr(args, "json_output", False):
         ranking_order = result.details.get("ranking_order") or [scenario_front.index(result.candidate)]
@@ -1596,21 +1816,44 @@ def run_from_args(args: argparse.Namespace) -> SelectionResult:
                     "scenario_front_complete": False,
                 }
             )
+        if selected_output is not None:
+            payload["selected"]["saved_path"] = str(selected_output)
+        if filtered_output_dir is not None and filtered_manifest is not None:
+            payload["saved_filtered"] = {
+                "directory": str(filtered_output_dir),
+                "manifest": str(filtered_manifest),
+                "count": len(filtered_candidates),
+                "stage": "post_limits",
+            }
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
-        print(
-            format_selection_result(
-                pareto_dir,
-                candidates=scenario_front,
-                loaded_count=len(candidates),
-                retained_count=len(filtered_candidates),
-                scenario=scenario,
-                scenario_front_count=len(scenario_front) if scenario is not None else None,
-                active_limits=active_limits,
-                result=result,
-                show_top=show_top,
-            )
+        output = format_selection_result(
+            pareto_dir,
+            candidates=scenario_front,
+            loaded_count=len(candidates),
+            retained_count=len(filtered_candidates),
+            scenario=scenario,
+            scenario_front_count=len(scenario_front) if scenario is not None else None,
+            active_limits=active_limits,
+            result=result,
+            show_top=show_top,
         )
+        saved_lines: List[str] = []
+        if selected_output is not None:
+            saved_lines.append(
+                f"Saved selected member: {_display_path(selected_output)}"
+            )
+        if filtered_output_dir is not None and filtered_manifest is not None:
+            saved_lines.extend(
+                [
+                    f"Saved filtered members: {len(filtered_candidates)} to "
+                    f"{_display_path(filtered_output_dir)}",
+                    f"Filtered manifest: {_display_path(filtered_manifest)}",
+                ]
+            )
+        if saved_lines:
+            output += "\n" + "\n".join(saved_lines)
+        print(output)
     return result
 
 

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -97,6 +97,12 @@ class _SelectedOutputInstall:
 
 
 @dataclass(frozen=True)
+class _FilteredOutputSnapshot:
+    identity: tuple[int, int]
+    members: tuple[tuple[str, bytes], ...]
+
+
+@dataclass(frozen=True)
 class SelectionResult:
     candidate: ParetoCandidate
     method: str
@@ -1898,7 +1904,13 @@ def _write_selected_output(
     *,
     keep_backup: bool,
     overwrite: bool,
+    install_sink: List[_SelectedOutputInstall] | None = None,
 ) -> _SelectedOutputInstall:
+    def record_install(install: _SelectedOutputInstall) -> _SelectedOutputInstall:
+        if install_sink is not None and not install_sink:
+            install_sink.append(install)
+        return install
+
     output.parent.mkdir(parents=True, exist_ok=True)
     staging_path, staging_descriptor = _create_selected_staging_file(output.parent)
     backup_path: Path | None = None
@@ -1919,15 +1931,17 @@ def _write_selected_output(
                 _warn_post_commit_cleanup_failure(
                     "selected output", staging_path, exc
                 )
-            return _SelectedOutputInstall(
-                None, installed_identity, candidate.source_bytes
+            return record_install(
+                _SelectedOutputInstall(None, installed_identity, candidate.source_bytes)
             )
         observed_identity: tuple[int, int] | None = None
+        observed_bytes: bytes | None = None
         if output.exists():
             if not output.is_file():
                 raise ValueError(f"Selected output must be a regular file: {output}")
             observed_stat = output.stat(follow_symlinks=False)
             observed_identity = observed_stat.st_dev, observed_stat.st_ino
+            observed_bytes = output.read_bytes()
             _copy_file_metadata(output, staging_path)
             backup_descriptor, backup_name = tempfile.mkstemp(
                 prefix=SELECTED_BACKUP_PREFIX,
@@ -1939,7 +1953,11 @@ def _write_selected_output(
             backup_path.unlink()
             os.replace(output, backup_path)
             moved_stat = backup_path.stat(follow_symlinks=False)
-            if (moved_stat.st_dev, moved_stat.st_ino) != observed_identity:
+            moved_bytes = backup_path.read_bytes()
+            if (
+                (moved_stat.st_dev, moved_stat.st_ino) != observed_identity
+                or moved_bytes != observed_bytes
+            ):
                 if output.exists():
                     raise RuntimeError(
                         f"Selected output changed concurrently; moved file retained at "
@@ -1966,8 +1984,10 @@ def _write_selected_output(
         if backup_path is not None and not keep_backup:
             _remove_selected_backup_after_commit(backup_path)
             backup_path = None
-        return _SelectedOutputInstall(
-            backup_path, installed_identity, candidate.source_bytes
+        return record_install(
+            _SelectedOutputInstall(
+                backup_path, installed_identity, candidate.source_bytes
+            )
         )
     except BaseException as exc:
         if installed_identity is not None:
@@ -1984,8 +2004,10 @@ def _write_selected_output(
                     f"keeping installed output: {output} ({exc})",
                     file=sys.stderr,
                 )
-                return _SelectedOutputInstall(
-                    backup_path, installed_identity, candidate.source_bytes
+                return record_install(
+                    _SelectedOutputInstall(
+                        backup_path, installed_identity, candidate.source_bytes
+                    )
                 )
         if backup_path is not None:
             if output.exists():
@@ -2002,13 +2024,43 @@ def _write_selected_output(
 
 
 def _restore_selected_output(output: Path, install: _SelectedOutputInstall) -> None:
+    rollback_descriptor, rollback_name = tempfile.mkstemp(
+        prefix=SELECTED_BACKUP_PREFIX,
+        suffix=".rollback",
+        dir=output.parent,
+    )
+    os.close(rollback_descriptor)
+    rollback_path = Path(rollback_name)
+    rollback_path.unlink()
     try:
-        output_stat = output.stat(follow_symlinks=False)
+        os.replace(output, rollback_path)
     except FileNotFoundError as exc:
         raise RuntimeError(
             f"Selected output changed concurrently; refusing rollback: {output}"
         ) from exc
-    if (output_stat.st_dev, output_stat.st_ino) != install.installed_identity:
+    rollback_stat = rollback_path.stat(follow_symlinks=False)
+    rollback_bytes = rollback_path.read_bytes()
+    if (
+        (rollback_stat.st_dev, rollback_stat.st_ino) != install.installed_identity
+        or rollback_bytes != install.installed_bytes
+    ):
+        try:
+            _install_selected_without_overwrite(
+                rollback_path,
+                output,
+                rollback_bytes,
+                metadata_source=rollback_path,
+            )
+        except BaseException as restore_exc:
+            backup_note = (
+                f" Original backup retained at {install.backup_path}."
+                if install.backup_path is not None
+                else ""
+            )
+            raise RuntimeError(
+                f"Selected output changed concurrently; moved file retained at "
+                f"{rollback_path}.{backup_note}"
+            ) from restore_exc
         backup_note = (
             f" Original backup retained at {install.backup_path}."
             if install.backup_path is not None
@@ -2016,28 +2068,20 @@ def _restore_selected_output(output: Path, install: _SelectedOutputInstall) -> N
         )
         raise RuntimeError(
             f"Selected output changed concurrently; refusing rollback: {output}."
-            f"{backup_note}"
-        )
-    try:
-        output_bytes = output.read_bytes()
-    except OSError as exc:
-        raise RuntimeError(
-            f"Selected output could not be verified; refusing rollback: {output}"
-        ) from exc
-    if output_bytes != install.installed_bytes:
-        backup_note = (
-            f" Original backup retained at {install.backup_path}."
-            if install.backup_path is not None
-            else ""
-        )
-        raise RuntimeError(
-            f"Selected output changed concurrently; refusing rollback: {output}."
-            f"{backup_note}"
+            f" Moved file retained at {rollback_path}.{backup_note}"
         )
     if install.backup_path is None:
-        output.unlink(missing_ok=True)
+        rollback_path.unlink()
     else:
-        os.replace(install.backup_path, output)
+        backup_bytes = install.backup_path.read_bytes()
+        _install_selected_without_overwrite(
+            install.backup_path,
+            output,
+            backup_bytes,
+            metadata_source=install.backup_path,
+        )
+        rollback_path.unlink()
+        install.backup_path.unlink()
 
 
 def _remove_selected_backup_after_commit(backup_path: Path) -> None:
@@ -2072,11 +2116,23 @@ def _copy_directory_metadata(source: Path, destination: Path) -> None:
     )
 
 
+def _snapshot_filtered_output_dir(output_dir: Path) -> _FilteredOutputSnapshot:
+    output_stat = output_dir.stat(follow_symlinks=False)
+    members = tuple(
+        (path.name, path.read_bytes())
+        for path in sorted(output_dir.iterdir(), key=lambda item: item.name)
+    )
+    return _FilteredOutputSnapshot(
+        (output_stat.st_dev, output_stat.st_ino), members
+    )
+
+
 def _replace_filtered_output_dir(
     staging_dir: Path,
     output_dir: Path,
     *,
     overwrite: bool,
+    observed_output: _FilteredOutputSnapshot,
 ) -> None:
     _validate_existing_filtered_output_dir(output_dir, overwrite=overwrite)
 
@@ -2090,6 +2146,17 @@ def _replace_filtered_output_dir(
     try:
         os.replace(output_dir, backup_dir)
         _validate_existing_filtered_output_dir(backup_dir, overwrite=overwrite)
+        moved_output = _snapshot_filtered_output_dir(backup_dir)
+        if moved_output != observed_output:
+            if output_dir.exists():
+                raise RuntimeError(
+                    f"Filtered output changed concurrently; moved directory retained at "
+                    f"{backup_dir}"
+                )
+            os.replace(backup_dir, output_dir)
+            raise RuntimeError(
+                f"Filtered output changed concurrently; refusing install: {output_dir}"
+            )
         _copy_directory_metadata(backup_dir, staging_dir)
         os.replace(staging_dir, output_dir)
     except BaseException as exc:
@@ -2138,17 +2205,18 @@ def _ensure_filtered_output_dir(
     output_dir: Path,
     *,
     overwrite: bool,
-) -> tuple[int, int] | None:
+) -> tuple[tuple[int, int] | None, _FilteredOutputSnapshot]:
     _validate_existing_filtered_output_dir(output_dir, overwrite=overwrite)
     if output_dir.exists():
-        return None
+        return None, _snapshot_filtered_output_dir(output_dir)
     try:
         output_dir.mkdir(mode=0o777)
     except FileExistsError:
         _validate_existing_filtered_output_dir(output_dir, overwrite=overwrite)
-        return None
+        return None, _snapshot_filtered_output_dir(output_dir)
     output_stat = output_dir.stat(follow_symlinks=False)
-    return output_stat.st_dev, output_stat.st_ino
+    identity = output_stat.st_dev, output_stat.st_ino
+    return identity, _FilteredOutputSnapshot(identity, ())
 
 
 def _remove_filtered_reservation(
@@ -2199,7 +2267,7 @@ def _write_filtered_outputs(
     overwrite: bool,
 ) -> Path:
     output_dir.parent.mkdir(parents=True, exist_ok=True)
-    reservation_identity = _ensure_filtered_output_dir(
+    reservation_identity, observed_output = _ensure_filtered_output_dir(
         output_dir,
         overwrite=overwrite,
     )
@@ -2274,6 +2342,7 @@ def _write_filtered_outputs(
             staging_dir,
             output_dir,
             overwrite=overwrite,
+            observed_output=observed_output,
         )
         committed = True
     finally:
@@ -2288,13 +2357,6 @@ def _write_filtered_outputs(
             ) == staging_identity:
                 committed = True
         if committed:
-            if staging_dir is not None:
-                try:
-                    _remove_output_tree(staging_dir)
-                except BaseException as exc:
-                    _warn_post_commit_cleanup_failure(
-                        "filtered output", staging_dir, exc
-                    )
             try:
                 _remove_filtered_reservation(output_dir, reservation_identity)
             except BaseException as exc:
@@ -2377,16 +2439,19 @@ def run_from_args(args: argparse.Namespace) -> SelectionResult:
         raise ValueError(
             "Selected and filtered output paths must not overlap when both are saved."
         )
+    selected_installs: List[_SelectedOutputInstall] = []
     selected_install: _SelectedOutputInstall | None = None
-    if selected_output is not None:
-        selected_install = _write_selected_output(
-            result.candidate,
-            selected_output,
-            keep_backup=filtered_output_dir is not None,
-            overwrite=overwrite,
-        )
     filtered_manifest: Path | None = None
     try:
+        if selected_output is not None:
+            _write_selected_output(
+                result.candidate,
+                selected_output,
+                keep_backup=filtered_output_dir is not None,
+                overwrite=overwrite,
+                install_sink=selected_installs,
+            )
+            selected_install = selected_installs[0]
         if filtered_output_dir is not None:
             filtered_manifest = _write_filtered_outputs(
                 filtered_output_dir,
@@ -2400,9 +2465,8 @@ def run_from_args(args: argparse.Namespace) -> SelectionResult:
                 overwrite=overwrite,
             )
     except BaseException:
-        if selected_output is not None:
-            assert selected_install is not None
-            _restore_selected_output(selected_output, selected_install)
+        if selected_output is not None and selected_installs:
+            _restore_selected_output(selected_output, selected_installs[0])
         raise
     else:
         if selected_install is not None and selected_install.backup_path is not None:

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -1636,6 +1636,7 @@ def _validate_output_outside_source(
     if protected_source_dir is not None and (
         _is_within(path, protected_source_dir.resolve())
         or _same_existing_filesystem_object(path, protected_source_dir)
+        or _paths_overlap_by_filesystem_identity(path, protected_source_dir)
     ):
         raise ValueError(
             f"Refusing to write {label} inside the source Pareto directory: {path}"
@@ -1849,7 +1850,13 @@ def _install_selected_without_overwrite(
     *,
     metadata_source: Path | None = None,
     preserve_metadata_timestamps: bool = False,
+    commit_identity_sink: List[tuple[int, int]] | None = None,
 ) -> tuple[int, int]:
+    def record_commit(identity: tuple[int, int]) -> tuple[int, int]:
+        if commit_identity_sink is not None and not commit_identity_sink:
+            commit_identity_sink.append(identity)
+        return identity
+
     staging_stat = staging_path.stat(follow_symlinks=False)
     try:
         os.link(staging_path, output)
@@ -1902,6 +1909,7 @@ def _install_selected_without_overwrite(
                 raise RuntimeError(
                     f"Selected output changed concurrently after metadata copy: {output}"
                 )
+            record_commit(created_identity)
         except BaseException as exc:
             try:
                 output_stat = output.stat(follow_symlinks=False)
@@ -1938,7 +1946,7 @@ def _install_selected_without_overwrite(
                 ) from exc
             raise
         return created_identity
-    return staging_stat.st_dev, staging_stat.st_ino
+    return record_commit((staging_stat.st_dev, staging_stat.st_ino))
 
 
 def _write_selected_output(
@@ -1959,13 +1967,17 @@ def _write_selected_output(
     backup_path: Path | None = None
     staging_cleanup_attempted = False
     installed_identity: tuple[int, int] | None = None
+    committed_identities: List[tuple[int, int]] = []
     try:
         _write_candidate_snapshot_fd(candidate, staging_path, staging_descriptor)
         if not overwrite:
             staging_stat = staging_path.stat(follow_symlinks=False)
             installed_identity = staging_stat.st_dev, staging_stat.st_ino
             installed_identity = _install_selected_without_overwrite(
-                staging_path, output, candidate.source_bytes
+                staging_path,
+                output,
+                candidate.source_bytes,
+                commit_identity_sink=committed_identities,
             )
             staging_cleanup_attempted = True
             try:
@@ -2018,6 +2030,7 @@ def _write_selected_output(
             output,
             candidate.source_bytes,
             metadata_source=backup_path,
+            commit_identity_sink=committed_identities,
         )
         staging_cleanup_attempted = True
         try:
@@ -2033,6 +2046,8 @@ def _write_selected_output(
             )
         )
     except BaseException as exc:
+        if committed_identities:
+            installed_identity = committed_identities[0]
         if installed_identity is not None:
             try:
                 output_stat = output.stat(follow_symlinks=False)

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -1599,6 +1599,34 @@ def _same_existing_filesystem_object(left: Path, right: Path) -> bool:
         return False
 
 
+def _existing_ancestors_with_suffix(path: Path) -> List[tuple[Path, tuple[str, ...]]]:
+    ancestors: List[tuple[Path, tuple[str, ...]]] = []
+    suffix: tuple[str, ...] = ()
+    current = path
+    while True:
+        if current.exists():
+            ancestors.append((current, suffix))
+        parent = current.parent
+        if parent == current:
+            break
+        suffix = (current.name, *suffix)
+        current = parent
+    return ancestors
+
+
+def _paths_overlap_by_filesystem_identity(left: Path, right: Path) -> bool:
+    for left_ancestor, left_suffix in _existing_ancestors_with_suffix(left):
+        for right_ancestor, right_suffix in _existing_ancestors_with_suffix(right):
+            if not _same_existing_filesystem_object(left_ancestor, right_ancestor):
+                continue
+            shorter, longer = sorted(
+                (left_suffix, right_suffix), key=lambda parts: len(parts)
+            )
+            if longer[: len(shorter)] == shorter:
+                return True
+    return False
+
+
 def _validate_output_outside_source(
     path: Path,
     protected_source_dir: Path | None,
@@ -1639,6 +1667,7 @@ def _validate_filtered_output_contains_no_sources(
             for candidate in candidates
             for source in (candidate.path.resolve(), candidate.member_path)
             if _is_within(source, output_dir)
+            or _paths_overlap_by_filesystem_identity(source, output_dir)
         },
         key=str,
     )
@@ -1778,7 +1807,12 @@ def _copy_platform_acl(source: Path, destination: Path) -> None:
         )
 
 
-def _copy_file_metadata(source: Path, destination: Path) -> None:
+def _copy_file_metadata(
+    source: Path,
+    destination: Path,
+    *,
+    preserve_timestamps: bool = False,
+) -> None:
     source_stat = source.stat(follow_symlinks=False)
     destination_stat = destination.stat(follow_symlinks=False)
     if hasattr(os, "chown"):
@@ -1790,11 +1824,12 @@ def _copy_file_metadata(source: Path, destination: Path) -> None:
         )
     shutil.copystat(source, destination, follow_symlinks=False)
     _copy_platform_acl(source, destination)
-    os.utime(
-        destination,
-        ns=(destination_stat.st_atime_ns, destination_stat.st_mtime_ns),
-        follow_symlinks=False,
-    )
+    if not preserve_timestamps:
+        os.utime(
+            destination,
+            ns=(destination_stat.st_atime_ns, destination_stat.st_mtime_ns),
+            follow_symlinks=False,
+        )
 
 
 def _warn_post_commit_cleanup_failure(
@@ -1813,6 +1848,7 @@ def _install_selected_without_overwrite(
     source_bytes: bytes,
     *,
     metadata_source: Path | None = None,
+    preserve_metadata_timestamps: bool = False,
 ) -> tuple[int, int]:
     staging_stat = staging_path.stat(follow_symlinks=False)
     try:
@@ -1853,7 +1889,14 @@ def _install_selected_without_overwrite(
                         f"Selected output changed concurrently; refusing metadata copy: "
                         f"{output}"
                     )
-                _copy_file_metadata(metadata_source, output)
+                if preserve_metadata_timestamps:
+                    _copy_file_metadata(
+                        metadata_source,
+                        output,
+                        preserve_timestamps=True,
+                    )
+                else:
+                    _copy_file_metadata(metadata_source, output)
             output_stat = output.stat(follow_symlinks=False)
             if (output_stat.st_dev, output_stat.st_ino) != created_identity:
                 raise RuntimeError(
@@ -2032,56 +2075,69 @@ def _restore_selected_output(output: Path, install: _SelectedOutputInstall) -> N
     os.close(rollback_descriptor)
     rollback_path = Path(rollback_name)
     rollback_path.unlink()
+    moved = False
     try:
-        os.replace(output, rollback_path)
-    except FileNotFoundError as exc:
-        raise RuntimeError(
-            f"Selected output changed concurrently; refusing rollback: {output}"
-        ) from exc
-    rollback_stat = rollback_path.stat(follow_symlinks=False)
-    rollback_bytes = rollback_path.read_bytes()
-    if (
-        (rollback_stat.st_dev, rollback_stat.st_ino) != install.installed_identity
-        or rollback_bytes != install.installed_bytes
-    ):
         try:
+            os.replace(output, rollback_path)
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"Selected output changed concurrently; refusing rollback: {output}"
+            ) from exc
+        finally:
+            moved = os.path.lexists(rollback_path)
+        rollback_stat = rollback_path.stat(follow_symlinks=False)
+        rollback_bytes = rollback_path.read_bytes()
+        if (
+            (rollback_stat.st_dev, rollback_stat.st_ino)
+            != install.installed_identity
+            or rollback_bytes != install.installed_bytes
+        ):
             _install_selected_without_overwrite(
                 rollback_path,
                 output,
                 rollback_bytes,
                 metadata_source=rollback_path,
+                preserve_metadata_timestamps=True,
             )
-        except BaseException as restore_exc:
             backup_note = (
                 f" Original backup retained at {install.backup_path}."
                 if install.backup_path is not None
                 else ""
             )
             raise RuntimeError(
-                f"Selected output changed concurrently; moved file retained at "
-                f"{rollback_path}.{backup_note}"
-            ) from restore_exc
-        backup_note = (
-            f" Original backup retained at {install.backup_path}."
-            if install.backup_path is not None
-            else ""
-        )
-        raise RuntimeError(
-            f"Selected output changed concurrently; refusing rollback: {output}."
-            f" Moved file retained at {rollback_path}.{backup_note}"
-        )
-    if install.backup_path is None:
-        rollback_path.unlink()
-    else:
-        backup_bytes = install.backup_path.read_bytes()
-        _install_selected_without_overwrite(
-            install.backup_path,
-            output,
-            backup_bytes,
-            metadata_source=install.backup_path,
-        )
-        rollback_path.unlink()
-        install.backup_path.unlink()
+                f"Selected output changed concurrently; refusing rollback: {output}."
+                f" Moved file retained at {rollback_path}.{backup_note}"
+            )
+        if install.backup_path is None:
+            rollback_path.unlink()
+        else:
+            backup_bytes = install.backup_path.read_bytes()
+            _install_selected_without_overwrite(
+                install.backup_path,
+                output,
+                backup_bytes,
+                metadata_source=install.backup_path,
+                preserve_metadata_timestamps=True,
+            )
+            rollback_path.unlink()
+            install.backup_path.unlink()
+    except BaseException as exc:
+        if moved and not output.exists() and os.path.lexists(rollback_path):
+            try:
+                rollback_bytes = rollback_path.read_bytes()
+                _install_selected_without_overwrite(
+                    rollback_path,
+                    output,
+                    rollback_bytes,
+                    metadata_source=rollback_path,
+                    preserve_metadata_timestamps=True,
+                )
+            except BaseException as restore_exc:
+                raise RuntimeError(
+                    f"Selected rollback was interrupted; moved file retained at "
+                    f"{rollback_path}"
+                ) from restore_exc
+        raise
 
 
 def _remove_selected_backup_after_commit(backup_path: Path) -> None:
@@ -2265,7 +2321,14 @@ def _write_filtered_outputs(
     selected: ParetoCandidate,
     result: SelectionResult,
     overwrite: bool,
+    commit_sink: List[Path] | None = None,
 ) -> Path:
+    manifest_output = output_dir / FILTERED_SELECTION_MANIFEST
+
+    def record_commit() -> None:
+        if commit_sink is not None and not commit_sink:
+            commit_sink.append(manifest_output)
+
     output_dir.parent.mkdir(parents=True, exist_ok=True)
     reservation_identity, observed_output = _ensure_filtered_output_dir(
         output_dir,
@@ -2345,6 +2408,7 @@ def _write_filtered_outputs(
             observed_output=observed_output,
         )
         committed = True
+        record_commit()
     finally:
         if not committed and staging_identity is not None:
             try:
@@ -2357,6 +2421,7 @@ def _write_filtered_outputs(
             ) == staging_identity:
                 committed = True
         if committed:
+            record_commit()
             try:
                 _remove_filtered_reservation(output_dir, reservation_identity)
             except BaseException as exc:
@@ -2367,7 +2432,7 @@ def _write_filtered_outputs(
             if staging_dir is not None:
                 _remove_output_tree(staging_dir)
             _remove_filtered_reservation(output_dir, reservation_identity)
-    return output_dir / FILTERED_SELECTION_MANIFEST
+    return manifest_output
 
 
 def run_from_args(args: argparse.Namespace) -> SelectionResult:
@@ -2434,12 +2499,16 @@ def run_from_args(args: argparse.Namespace) -> SelectionResult:
         and (
             _is_within(selected_output, filtered_output_dir)
             or _is_within(filtered_output_dir, selected_output)
+            or _paths_overlap_by_filesystem_identity(
+                selected_output, filtered_output_dir
+            )
         )
     ):
         raise ValueError(
             "Selected and filtered output paths must not overlap when both are saved."
         )
     selected_installs: List[_SelectedOutputInstall] = []
+    filtered_commits: List[Path] = []
     selected_install: _SelectedOutputInstall | None = None
     filtered_manifest: Path | None = None
     try:
@@ -2463,9 +2532,14 @@ def run_from_args(args: argparse.Namespace) -> SelectionResult:
                 selected=result.candidate,
                 result=result,
                 overwrite=overwrite,
+                commit_sink=filtered_commits,
             )
     except BaseException:
-        if selected_output is not None and selected_installs:
+        if (
+            selected_output is not None
+            and selected_installs
+            and not filtered_commits
+        ):
             _restore_selected_output(selected_output, selected_installs[0])
         raise
     else:

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -83,6 +83,12 @@ class ParetoCandidate:
 
 
 @dataclass(frozen=True)
+class _SelectedOutputInstall:
+    backup_path: Path | None
+    installed_identity: tuple[int, int]
+
+
+@dataclass(frozen=True)
 class SelectionResult:
     candidate: ParetoCandidate
     method: str
@@ -1724,7 +1730,9 @@ def _copy_file_metadata(source: Path, destination: Path) -> None:
     shutil.copystat(source, destination, follow_symlinks=False)
 
 
-def _warn_post_commit_cleanup_failure(label: str, path: Path, exc: OSError) -> None:
+def _warn_post_commit_cleanup_failure(
+    label: str, path: Path, exc: BaseException
+) -> None:
     print(
         f"Warning: {label} installed, but temporary path could not be removed: "
         f"{path} ({exc})",
@@ -1738,7 +1746,7 @@ def _write_selected_output(
     *,
     keep_backup: bool,
     overwrite: bool,
-) -> Path | None:
+) -> _SelectedOutputInstall:
     output.parent.mkdir(parents=True, exist_ok=True)
     file_descriptor, staging_name = tempfile.mkstemp(
         prefix=f".{output.name}.", suffix=".tmp", dir=output.parent
@@ -1751,6 +1759,8 @@ def _write_selected_output(
         _write_candidate_snapshot(candidate, staging_path)
         if not overwrite:
             staging_path.chmod(_default_file_mode())
+            staging_stat = staging_path.stat(follow_symlinks=False)
+            installed_identity = staging_stat.st_dev, staging_stat.st_ino
             try:
                 os.link(staging_path, output)
             except FileExistsError as exc:
@@ -1765,7 +1775,7 @@ def _write_selected_output(
                 _warn_post_commit_cleanup_failure(
                     "selected output", staging_path, exc
                 )
-            return None
+            return _SelectedOutputInstall(None, installed_identity)
         if output.exists():
             if not output.is_file():
                 raise ValueError(f"Selected output must be a regular file: {output}")
@@ -1780,11 +1790,13 @@ def _write_selected_output(
             _copy_file_metadata(output, staging_path)
         else:
             staging_path.chmod(_default_file_mode())
+        staging_stat = staging_path.stat(follow_symlinks=False)
+        installed_identity = staging_stat.st_dev, staging_stat.st_ino
         os.replace(staging_path, output)
         if backup_path is not None and not keep_backup:
             backup_path.unlink()
             backup_path = None
-        return backup_path
+        return _SelectedOutputInstall(backup_path, installed_identity)
     except BaseException:
         if backup_path is not None:
             backup_path.unlink(missing_ok=True)
@@ -1794,24 +1806,34 @@ def _write_selected_output(
             staging_path.unlink(missing_ok=True)
 
 
-def _restore_selected_output(output: Path, backup_path: Path | None) -> None:
-    if backup_path is None:
+def _restore_selected_output(output: Path, install: _SelectedOutputInstall) -> None:
+    try:
+        output_stat = output.stat(follow_symlinks=False)
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            f"Selected output changed concurrently; refusing rollback: {output}"
+        ) from exc
+    if (output_stat.st_dev, output_stat.st_ino) != install.installed_identity:
+        backup_note = (
+            f" Original backup retained at {install.backup_path}."
+            if install.backup_path is not None
+            else ""
+        )
+        raise RuntimeError(
+            f"Selected output changed concurrently; refusing rollback: {output}."
+            f"{backup_note}"
+        )
+    if install.backup_path is None:
         output.unlink(missing_ok=True)
     else:
-        os.replace(backup_path, output)
+        os.replace(install.backup_path, output)
 
 
 def _remove_selected_backup_after_commit(backup_path: Path) -> None:
     try:
         backup_path.unlink()
-    except OSError as exc:
+    except BaseException as exc:
         _warn_post_commit_cleanup_failure("selected output", backup_path, exc)
-
-
-def _default_directory_mode() -> int:
-    current_umask = os.umask(0)
-    os.umask(current_umask)
-    return 0o777 & ~current_umask
 
 
 def _remove_output_tree(path: Path) -> None:
@@ -1856,7 +1878,7 @@ def _replace_filtered_output_dir(
     else:
         try:
             _remove_output_tree(backup_dir)
-        except OSError as exc:
+        except BaseException as exc:
             print(
                 f"Warning: filtered output installed, but old backup could not be removed: "
                 f"{backup_dir} ({exc})",
@@ -1868,17 +1890,15 @@ def _ensure_filtered_output_dir(
     output_dir: Path,
     *,
     overwrite: bool,
-    new_output_mode: int,
 ) -> tuple[int, int] | None:
     _validate_existing_filtered_output_dir(output_dir, overwrite=overwrite)
     if output_dir.exists():
         return None
     try:
-        output_dir.mkdir(mode=new_output_mode)
+        output_dir.mkdir(mode=0o777)
     except FileExistsError:
         _validate_existing_filtered_output_dir(output_dir, overwrite=overwrite)
         return None
-    output_dir.chmod(new_output_mode)
     output_stat = output_dir.stat(follow_symlinks=False)
     return output_stat.st_dev, output_stat.st_ino
 
@@ -1918,11 +1938,9 @@ def _write_filtered_outputs(
     overwrite: bool,
 ) -> Path:
     output_dir.parent.mkdir(parents=True, exist_ok=True)
-    new_output_mode = _default_directory_mode()
     reservation_identity = _ensure_filtered_output_dir(
         output_dir,
         overwrite=overwrite,
-        new_output_mode=new_output_mode,
     )
     staging_dir: Path | None = None
     try:
@@ -2057,9 +2075,9 @@ def run_from_args(args: argparse.Namespace) -> SelectionResult:
         raise ValueError(
             "Selected and filtered output paths must not overlap when both are saved."
         )
-    selected_backup: Path | None = None
+    selected_install: _SelectedOutputInstall | None = None
     if selected_output is not None:
-        selected_backup = _write_selected_output(
+        selected_install = _write_selected_output(
             result.candidate,
             selected_output,
             keep_backup=filtered_output_dir is not None,
@@ -2081,11 +2099,12 @@ def run_from_args(args: argparse.Namespace) -> SelectionResult:
             )
     except BaseException:
         if selected_output is not None:
-            _restore_selected_output(selected_output, selected_backup)
+            assert selected_install is not None
+            _restore_selected_output(selected_output, selected_install)
         raise
     else:
-        if selected_backup is not None:
-            _remove_selected_backup_after_commit(selected_backup)
+        if selected_install is not None and selected_install.backup_path is not None:
+            _remove_selected_backup_after_commit(selected_install.backup_path)
     show_top = max(1, int(getattr(args, "show_top", 1) or 1))
     if getattr(args, "json_output", False):
         ranking_order = result.details.get("ranking_order") or [scenario_front.index(result.candidate)]

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -5,6 +5,7 @@ import json
 import math
 import os
 import shutil
+import stat
 import tempfile
 import textwrap
 from dataclasses import dataclass
@@ -1698,18 +1699,52 @@ def _prepare_filtered_output_dir(
     return output_dir
 
 
-def _write_selected_output(candidate: ParetoCandidate, output: Path) -> None:
+def _write_selected_output(
+    candidate: ParetoCandidate,
+    output: Path,
+    *,
+    keep_backup: bool,
+) -> Path | None:
     output.parent.mkdir(parents=True, exist_ok=True)
     file_descriptor, staging_name = tempfile.mkstemp(
         prefix=f".{output.name}.", suffix=".tmp", dir=output.parent
     )
     os.close(file_descriptor)
     staging_path = Path(staging_name)
+    backup_path: Path | None = None
     try:
         shutil.copy2(candidate.path, staging_path)
+        if output.exists():
+            backup_descriptor, backup_name = tempfile.mkstemp(
+                prefix=f".{output.name}.", suffix=".backup", dir=output.parent
+            )
+            os.close(backup_descriptor)
+            backup_path = Path(backup_name)
+            shutil.copy2(output, backup_path)
         os.replace(staging_path, output)
+        if backup_path is not None and not keep_backup:
+            backup_path.unlink()
+            backup_path = None
+        return backup_path
+    except Exception:
+        if backup_path is not None:
+            backup_path.unlink(missing_ok=True)
+        raise
     finally:
         staging_path.unlink(missing_ok=True)
+
+
+def _restore_selected_output(output: Path, backup_path: Path | None) -> None:
+    if backup_path is None:
+        output.unlink(missing_ok=True)
+    else:
+        os.replace(backup_path, output)
+
+
+def _default_directory_mode() -> int:
+    current_umask = os.umask(0)
+    os.umask(current_umask)
+    return 0o777 & ~current_umask
 
 
 def _replace_filtered_output_dir(
@@ -1751,10 +1786,16 @@ def _write_filtered_outputs(
     overwrite: bool,
 ) -> Path:
     output_dir.parent.mkdir(parents=True, exist_ok=True)
+    output_mode = (
+        stat.S_IMODE(output_dir.stat().st_mode)
+        if output_dir.exists()
+        else _default_directory_mode()
+    )
     staging_dir = Path(
         tempfile.mkdtemp(prefix=f".{output_dir.name}.", suffix=".tmp", dir=output_dir.parent)
     )
     try:
+        staging_dir.chmod(output_mode)
         members: List[Dict[str, Any]] = []
         for candidate in candidates:
             staged_destination = staging_dir / candidate.member_name
@@ -1872,23 +1913,34 @@ def run_from_args(args: argparse.Namespace) -> SelectionResult:
         raise ValueError(
             "Selected and filtered output paths must not overlap when both are saved."
         )
+    selected_backup: Path | None = None
     if selected_output is not None:
-        _write_selected_output(result.candidate, selected_output)
-    filtered_manifest = (
-        _write_filtered_outputs(
-            filtered_output_dir,
-            pareto_dir,
-            filtered_candidates,
-            loaded_count=len(candidates),
-            active_limits=active_limits,
-            scenario=scenario,
-            selected=result.candidate,
-            result=result,
-            overwrite=overwrite,
+        selected_backup = _write_selected_output(
+            result.candidate,
+            selected_output,
+            keep_backup=filtered_output_dir is not None,
         )
-        if filtered_output_dir is not None
-        else None
-    )
+    filtered_manifest: Path | None = None
+    try:
+        if filtered_output_dir is not None:
+            filtered_manifest = _write_filtered_outputs(
+                filtered_output_dir,
+                pareto_dir,
+                filtered_candidates,
+                loaded_count=len(candidates),
+                active_limits=active_limits,
+                scenario=scenario,
+                selected=result.candidate,
+                result=result,
+                overwrite=overwrite,
+            )
+    except Exception:
+        if selected_output is not None:
+            _restore_selected_output(selected_output, selected_backup)
+        raise
+    else:
+        if selected_backup is not None:
+            selected_backup.unlink()
     show_top = max(1, int(getattr(args, "show_top", 1) or 1))
     if getattr(args, "json_output", False):
         ranking_order = result.details.get("ranking_order") or [scenario_front.index(result.candidate)]

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -5,6 +5,7 @@ import json
 import math
 import os
 import shutil
+import tempfile
 import textwrap
 from dataclasses import dataclass
 from pathlib import Path
@@ -1567,9 +1568,36 @@ def _validate_output_outside_source(path: Path, pareto_dir: Path, *, label: str)
         )
 
 
+def _validate_selected_output_not_source(
+    output: Path,
+    candidates: Sequence[ParetoCandidate],
+) -> None:
+    sources = {candidate.path.resolve() for candidate in candidates}
+    if output in sources:
+        raise ValueError(f"Refusing to overwrite a source Pareto member: {output}")
+
+
+def _validate_filtered_output_contains_no_sources(
+    output_dir: Path,
+    candidates: Sequence[ParetoCandidate],
+) -> None:
+    contained = [
+        candidate.path.resolve()
+        for candidate in candidates
+        if _is_within(candidate.path.resolve(), output_dir)
+    ]
+    if contained:
+        preview = ", ".join(str(path) for path in contained[:5])
+        raise ValueError(
+            "Refusing to write filtered output over resolved source Pareto member(s): "
+            f"{preview}"
+        )
+
+
 def _prepare_selected_output(
     raw_path: str | os.PathLike[str] | None,
     pareto_dir: Path,
+    candidates: Sequence[ParetoCandidate],
     *,
     overwrite: bool,
 ) -> Path | None:
@@ -1577,6 +1605,7 @@ def _prepare_selected_output(
         return None
     output = Path(raw_path).expanduser().resolve()
     _validate_output_outside_source(output, pareto_dir, label="selected output")
+    _validate_selected_output_not_source(output, candidates)
     if output.suffix.lower() != ".json":
         raise ValueError(f"Selected output must use a .json filename: {output}")
     if output.exists():
@@ -1591,10 +1620,38 @@ def _prepare_selected_output(
     return output
 
 
+def _validate_existing_filtered_output_dir(output_dir: Path, *, overwrite: bool) -> None:
+    if not output_dir.exists():
+        return
+    if not output_dir.is_dir():
+        raise NotADirectoryError(f"Filtered output path is not a directory: {output_dir}")
+    existing = sorted(
+        (path for path in output_dir.iterdir() if path.name != ".DS_Store"),
+        key=lambda path: path.name,
+    )
+    if existing and not overwrite:
+        raise FileExistsError(
+            f"Filtered output directory is not empty: {output_dir} "
+            "(use --overwrite to replace JSON outputs)"
+        )
+    invalid = [
+        path
+        for path in existing
+        if not path.is_file() or path.suffix.lower() != ".json"
+    ]
+    if invalid:
+        preview = ", ".join(path.name for path in invalid[:5])
+        raise FileExistsError(
+            f"Refusing to overwrite filtered output directory containing non-JSON "
+            f"entries: {preview}"
+        )
+
+
 def _prepare_filtered_output_dir(
     raw_path: str | os.PathLike[str] | None,
     pareto_dir: Path,
     candidates: Sequence[ParetoCandidate],
+    source_candidates: Sequence[ParetoCandidate],
     *,
     overwrite: bool,
 ) -> Path | None:
@@ -1602,6 +1659,7 @@ def _prepare_filtered_output_dir(
         return None
     output_dir = Path(raw_path).expanduser().resolve()
     _validate_output_outside_source(output_dir, pareto_dir, label="filtered output")
+    _validate_filtered_output_contains_no_sources(output_dir, source_candidates)
     names = [candidate.path.name for candidate in candidates]
     normalized_names = [name.casefold() for name in names]
     if len(normalized_names) != len(set(normalized_names)):
@@ -1611,30 +1669,8 @@ def _prepare_filtered_output_dir(
             f"Filtered member filename conflicts with reserved manifest name "
             f"{FILTERED_SELECTION_MANIFEST!r}."
         )
-    if output_dir.exists():
-        if not output_dir.is_dir():
-            raise NotADirectoryError(f"Filtered output path is not a directory: {output_dir}")
-        existing = sorted(
-            (path for path in output_dir.iterdir() if path.name != ".DS_Store"),
-            key=lambda path: path.name,
-        )
-        if existing and not overwrite:
-            raise FileExistsError(
-                f"Filtered output directory is not empty: {output_dir} "
-                "(use --overwrite to replace JSON outputs)"
-            )
-        invalid = [
-            path
-            for path in existing
-            if not path.is_file() or path.suffix.lower() != ".json"
-        ]
-        if invalid:
-            preview = ", ".join(path.name for path in invalid[:5])
-            raise FileExistsError(
-                f"Refusing to overwrite filtered output directory containing non-JSON "
-                f"entries: {preview}"
-            )
-    elif output_dir.parent.exists() and not output_dir.parent.is_dir():
+    _validate_existing_filtered_output_dir(output_dir, overwrite=overwrite)
+    if not output_dir.exists() and output_dir.parent.exists() and not output_dir.parent.is_dir():
         raise NotADirectoryError(
             f"Filtered output parent is not a directory: {output_dir.parent}"
         )
@@ -1643,7 +1679,42 @@ def _prepare_filtered_output_dir(
 
 def _write_selected_output(candidate: ParetoCandidate, output: Path) -> None:
     output.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(candidate.path, output)
+    file_descriptor, staging_name = tempfile.mkstemp(
+        prefix=f".{output.name}.", suffix=".tmp", dir=output.parent
+    )
+    os.close(file_descriptor)
+    staging_path = Path(staging_name)
+    try:
+        shutil.copy2(candidate.path, staging_path)
+        os.replace(staging_path, output)
+    finally:
+        staging_path.unlink(missing_ok=True)
+
+
+def _replace_filtered_output_dir(
+    staging_dir: Path,
+    output_dir: Path,
+    *,
+    overwrite: bool,
+) -> None:
+    _validate_existing_filtered_output_dir(output_dir, overwrite=overwrite)
+    if not output_dir.exists():
+        os.replace(staging_dir, output_dir)
+        return
+
+    backup_name = tempfile.mkdtemp(
+        prefix=f".{output_dir.name}.backup-", dir=output_dir.parent
+    )
+    backup_dir = Path(backup_name)
+    backup_dir.rmdir()
+    os.replace(output_dir, backup_dir)
+    try:
+        os.replace(staging_dir, output_dir)
+    except Exception:
+        os.replace(backup_dir, output_dir)
+        raise
+    else:
+        shutil.rmtree(backup_dir)
 
 
 def _write_filtered_outputs(
@@ -1655,48 +1726,60 @@ def _write_filtered_outputs(
     active_limits: Sequence[Mapping[str, Any]],
     scenario: str | None,
     selected: ParetoCandidate,
+    result: SelectionResult,
     overwrite: bool,
 ) -> Path:
-    output_dir.mkdir(parents=True, exist_ok=True)
-    if overwrite:
-        for path in output_dir.iterdir():
-            if path.name != ".DS_Store" and path.is_file() and path.suffix.lower() == ".json":
-                path.unlink()
-
-    members: List[Dict[str, Any]] = []
-    for candidate in candidates:
-        destination = output_dir / candidate.path.name
-        shutil.copy2(candidate.path, destination)
-        members.append(
-            {
-                "file": candidate.path.name,
-                "hash": candidate.path.stem,
-                "source_path": str(candidate.path),
-                "output_path": str(destination),
-            }
-        )
-
-    manifest_path = output_dir / FILTERED_SELECTION_MANIFEST
-    manifest = {
-        "tool": "passivbot tool pareto",
-        "mode": "filtered",
-        "pareto_dir": str(pareto_dir),
-        "loaded_count": int(loaded_count),
-        "retained_count": len(candidates),
-        "scenario": scenario,
-        "applied_limits": _json_ready(active_limits),
-        "selected_member": {
-            "file": selected.path.name,
-            "hash": selected.path.stem,
-            "source_path": str(selected.path),
-        },
-        "members": members,
-    }
-    manifest_path.write_text(
-        json.dumps(_json_ready(manifest), indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
+    output_dir.parent.mkdir(parents=True, exist_ok=True)
+    staging_dir = Path(
+        tempfile.mkdtemp(prefix=f".{output_dir.name}.", suffix=".tmp", dir=output_dir.parent)
     )
-    return manifest_path
+    try:
+        members: List[Dict[str, Any]] = []
+        for candidate in candidates:
+            staged_destination = staging_dir / candidate.path.name
+            final_destination = output_dir / candidate.path.name
+            shutil.copy2(candidate.path, staged_destination)
+            members.append(
+                {
+                    "file": candidate.path.name,
+                    "hash": candidate.path.stem,
+                    "source_path": str(candidate.path),
+                    "output_path": str(final_destination),
+                }
+            )
+
+        active_metrics = result.details.get("active_metrics") or list(
+            result.objective_values
+        )
+        manifest = {
+            "tool": "passivbot tool pareto",
+            "mode": "filtered",
+            "pareto_dir": str(pareto_dir),
+            "loaded_count": int(loaded_count),
+            "retained_count": len(candidates),
+            "scenario": scenario,
+            "applied_limits": _json_ready(active_limits),
+            "method": result.method,
+            "objectives": _json_ready(active_metrics),
+            "weights": _json_ready(result.details.get("weights") or {}),
+            "targets": _json_ready(result.details.get("targets") or {}),
+            "priority": _json_ready(result.details.get("priority") or []),
+            "selected_member": {
+                "file": selected.path.name,
+                "hash": selected.path.stem,
+                "source_path": str(selected.path),
+            },
+            "members": members,
+        }
+        (staging_dir / FILTERED_SELECTION_MANIFEST).write_text(
+            json.dumps(_json_ready(manifest), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        _replace_filtered_output_dir(staging_dir, output_dir, overwrite=overwrite)
+    finally:
+        if staging_dir.exists():
+            shutil.rmtree(staging_dir)
+    return output_dir / FILTERED_SELECTION_MANIFEST
 
 
 def run_from_args(args: argparse.Namespace) -> SelectionResult:
@@ -1745,21 +1828,26 @@ def run_from_args(args: argparse.Namespace) -> SelectionResult:
     selected_output = _prepare_selected_output(
         getattr(args, "save_selected", None),
         pareto_dir,
+        candidates,
         overwrite=overwrite,
     )
     filtered_output_dir = _prepare_filtered_output_dir(
         getattr(args, "save_filtered", None),
         pareto_dir,
         filtered_candidates,
+        candidates,
         overwrite=overwrite,
     )
     if (
         selected_output is not None
         and filtered_output_dir is not None
-        and _is_within(selected_output, filtered_output_dir)
+        and (
+            _is_within(selected_output, filtered_output_dir)
+            or _is_within(filtered_output_dir, selected_output)
+        )
     ):
         raise ValueError(
-            "Selected output must be outside the filtered output directory when both are saved."
+            "Selected and filtered output paths must not overlap when both are saved."
         )
     if selected_output is not None:
         _write_selected_output(result.candidate, selected_output)
@@ -1772,6 +1860,7 @@ def run_from_args(args: argparse.Namespace) -> SelectionResult:
             active_limits=active_limits,
             scenario=scenario,
             selected=result.candidate,
+            result=result,
             overwrite=overwrite,
         )
         if filtered_output_dir is not None

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -11,6 +11,7 @@ import shutil
 import stat
 import sys
 import tempfile
+import unicodedata
 import textwrap
 from dataclasses import dataclass
 from pathlib import Path
@@ -1619,8 +1620,16 @@ def _paths_overlap_by_filesystem_identity(left: Path, right: Path) -> bool:
         for right_ancestor, right_suffix in _existing_ancestors_with_suffix(right):
             if not _same_existing_filesystem_object(left_ancestor, right_ancestor):
                 continue
+            normalized_left = tuple(
+                unicodedata.normalize("NFC", part).casefold()
+                for part in left_suffix
+            )
+            normalized_right = tuple(
+                unicodedata.normalize("NFC", part).casefold()
+                for part in right_suffix
+            )
             shorter, longer = sorted(
-                (left_suffix, right_suffix), key=lambda parts: len(parts)
+                (normalized_left, normalized_right), key=lambda parts: len(parts)
             )
             if longer[: len(shorter)] == shorter:
                 return True
@@ -1746,6 +1755,12 @@ def _prepare_filtered_output_dir(
     _validate_output_outside_source(output_dir, protected_source_dir, label="filtered output")
     _validate_filtered_output_contains_no_sources(output_dir, source_candidates)
     names = [candidate.member_name for candidate in candidates]
+    invalid_names = sorted(name for name in names if Path(name).suffix.lower() != ".json")
+    if invalid_names:
+        preview = ", ".join(invalid_names[:5])
+        raise ValueError(
+            f"Filtered members must use .json filenames; invalid member(s): {preview}"
+        )
     normalized_names = [name.casefold() for name in names]
     if len(normalized_names) != len(set(normalized_names)):
         raise ValueError("Filtered members contain duplicate filenames; cannot copy safely.")
@@ -1874,20 +1889,37 @@ def _install_selected_without_overwrite(
         windows_invalid_function = getattr(exc, "winerror", None) == 1
         if exc.errno not in unsupported and not windows_invalid_function:
             raise
-        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
-        if hasattr(os, "O_CLOEXEC"):
-            flags |= os.O_CLOEXEC
         try:
-            file_descriptor = os.open(output, flags, 0o666)
+            output_file = output.open("xb")
         except FileExistsError as conflict:
             raise FileExistsError(
                 f"Selected output already exists: {output} "
                 "(use --overwrite to replace it)"
             ) from conflict
-        created_stat = os.fstat(file_descriptor)
+        except BaseException as create_exc:
+            if os.path.lexists(output):
+                failed_descriptor, failed_name = tempfile.mkstemp(
+                    prefix=SELECTED_BACKUP_PREFIX,
+                    suffix=".failed",
+                    dir=output.parent,
+                )
+                os.close(failed_descriptor)
+                failed_path = Path(failed_name)
+                failed_path.unlink()
+                try:
+                    os.replace(output, failed_path)
+                except FileNotFoundError:
+                    pass
+                else:
+                    raise RuntimeError(
+                        f"Selected output creation was interrupted; unverified file "
+                        f"retained at {failed_path}"
+                    ) from create_exc
+            raise
+        created_stat = os.fstat(output_file.fileno())
         created_identity = created_stat.st_dev, created_stat.st_ino
         try:
-            with os.fdopen(file_descriptor, "wb") as output_file:
+            with output_file:
                 output_file.write(source_bytes)
             if metadata_source is not None:
                 output_stat = output.stat(follow_symlinks=False)
@@ -2276,6 +2308,7 @@ def _ensure_filtered_output_dir(
     output_dir: Path,
     *,
     overwrite: bool,
+    reservation_sink: List[tuple[int, int]] | None = None,
 ) -> tuple[tuple[int, int] | None, _FilteredOutputSnapshot]:
     _validate_existing_filtered_output_dir(output_dir, overwrite=overwrite)
     if output_dir.exists():
@@ -2287,6 +2320,8 @@ def _ensure_filtered_output_dir(
         return None, _snapshot_filtered_output_dir(output_dir)
     output_stat = output_dir.stat(follow_symlinks=False)
     identity = output_stat.st_dev, output_stat.st_ino
+    if reservation_sink is not None and not reservation_sink:
+        reservation_sink.append(identity)
     return identity, _FilteredOutputSnapshot(identity, ())
 
 
@@ -2345,14 +2380,18 @@ def _write_filtered_outputs(
             commit_sink.append(manifest_output)
 
     output_dir.parent.mkdir(parents=True, exist_ok=True)
-    reservation_identity, observed_output = _ensure_filtered_output_dir(
-        output_dir,
-        overwrite=overwrite,
-    )
+    reservation_identities: List[tuple[int, int]] = []
+    reservation_identity: tuple[int, int] | None = None
+    observed_output: _FilteredOutputSnapshot | None = None
     staging_dir: Path | None = None
     staging_identity: tuple[int, int] | None = None
     committed = False
     try:
+        reservation_identity, observed_output = _ensure_filtered_output_dir(
+            output_dir,
+            overwrite=overwrite,
+            reservation_sink=reservation_identities,
+        )
         staging_dir = Path(
             tempfile.mkdtemp(
                 prefix=FILTERED_STAGING_PREFIX,
@@ -2425,6 +2464,8 @@ def _write_filtered_outputs(
         committed = True
         record_commit()
     finally:
+        if reservation_identity is None and reservation_identities:
+            reservation_identity = reservation_identities[0]
         if not committed and staging_identity is not None:
             try:
                 output_stat = output_dir.stat(follow_symlinks=False)

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -70,6 +70,8 @@ FILTERED_SELECTION_MANIFEST = "selection.json"
 @dataclass(frozen=True)
 class ParetoCandidate:
     path: Path
+    member_path: Path
+    member_name: str
     entry: Dict[str, Any]
     objectives: Dict[str, float]
     stats_flat: Dict[str, float]
@@ -643,11 +645,13 @@ def project_candidates_to_scenario(
         if missing:
             raise ValueError(
                 f"Scenario {label!r} is missing scoring metric(s) {missing} "
-                f"in {candidate.path.name}."
+                f"in {candidate.member_name}."
             )
         projected.append(
             ParetoCandidate(
                 path=candidate.path,
+                member_path=candidate.member_path,
+                member_name=candidate.member_name,
                 entry=candidate.entry,
                 objectives=objectives,
                 stats_flat={f"{metric}_mean": value for metric, value in values.items()},
@@ -733,7 +737,7 @@ def load_candidates(path: str | os.PathLike[str]) -> tuple[Path, List[ParetoCand
     raw_path = Path(path).expanduser()
     if raw_path.is_file():
         pareto_dir = raw_path.parent.resolve()
-        json_paths = [raw_path.resolve()]
+        json_paths = [raw_path]
     else:
         pareto_dir = resolve_pareto_directory(raw_path)
         json_paths = sorted(pareto_dir.glob("*.json"))
@@ -780,6 +784,8 @@ def load_candidates(path: str | os.PathLike[str]) -> tuple[Path, List[ParetoCand
         candidates.append(
             ParetoCandidate(
                 path=entry_path.resolve(),
+                member_path=entry_path.absolute(),
+                member_name=entry_path.name,
                 entry=entry,
                 objectives=objectives,
                 stats_flat=stats_flat,
@@ -922,8 +928,8 @@ def _ranked_rows(
             {
                 "rank": rank,
                 "score": float(score_vector[int(idx)]),
-                "file": candidate.path.name,
-                "hash": candidate.path.stem,
+                "file": candidate.member_name,
+                "hash": Path(candidate.member_name).stem,
                 "path": str(candidate.path),
                 "objectives": {
                     metric: float(_resolve_candidate_metric_value(candidate, metric))
@@ -1011,7 +1017,7 @@ def _resolve_limit_value(
         if requested_reducer != "mean":
             raise ValueError(
                 f"Scenario {candidate.scenario!r} stores one mean value per metric; "
-                f"limit reducer={requested_reducer!r} is unavailable for {candidate.path.name}."
+                f"limit reducer={requested_reducer!r} is unavailable for {candidate.member_name}."
             )
     reducer = basis.reducer
     if "reducer" not in entry:
@@ -1119,7 +1125,7 @@ def filter_candidates_with_limits(
                 available = _format_available_limit_metrics(candidate)
                 raise ValueError(
                     f"Limit metric {metric!r} could not be resolved for "
-                    f"{candidate.path.name}. Available metrics: {available}"
+                    f"{candidate.member_name}. Available metrics: {available}"
                 )
             if _limit_rejects(entry, value):
                 rejected = True
@@ -1140,7 +1146,7 @@ def _select_knee(
         score = 0.0
         scores = np.array([score], dtype=float)
         mode = "single_candidate"
-        anchor_files: list[str] = [candidates[0].path.name]
+        anchor_files: list[str] = [candidates[0].member_name]
     else:
         anchor_indices = [int(np.argmax(utilities[:, j])) for j in range(n_obj)]
         unique_anchor_indices = list(dict.fromkeys(anchor_indices))
@@ -1162,7 +1168,7 @@ def _select_knee(
             idx = int(np.argmax(scores))
             score = float(scores[idx])
             mode = "maximin_fallback"
-        anchor_files = [candidates[i].path.name for i in unique_anchor_indices]
+        anchor_files = [candidates[i].member_name for i in unique_anchor_indices]
     ranking_order = list(np.argsort(-scores))
     candidate = candidates[idx]
     return SelectionResult(
@@ -1408,7 +1414,7 @@ def format_selection_result(
     result: SelectionResult,
     show_top: int = 1,
 ) -> str:
-    selected_filename = result.candidate.path.name
+    selected_filename = result.candidate.member_name
     score_label, score_value = _score_label_and_value(result)
     selected_display_path = _display_path(result.candidate.path)
     backtest_command = f"passivbot backtest {selected_display_path}"
@@ -1561,8 +1567,15 @@ def _is_within(path: Path, directory: Path) -> bool:
         return False
 
 
-def _validate_output_outside_source(path: Path, pareto_dir: Path, *, label: str) -> None:
-    if _is_within(path, pareto_dir.resolve()):
+def _validate_output_outside_source(
+    path: Path,
+    protected_source_dir: Path | None,
+    *,
+    label: str,
+) -> None:
+    if protected_source_dir is not None and _is_within(
+        path, protected_source_dir.resolve()
+    ):
         raise ValueError(
             f"Refusing to write {label} inside the source Pareto directory: {path}"
         )
@@ -1572,7 +1585,11 @@ def _validate_selected_output_not_source(
     output: Path,
     candidates: Sequence[ParetoCandidate],
 ) -> None:
-    sources = {candidate.path.resolve() for candidate in candidates}
+    sources = {
+        source
+        for candidate in candidates
+        for source in (candidate.path.resolve(), candidate.member_path)
+    }
     if output in sources:
         raise ValueError(f"Refusing to overwrite a source Pareto member: {output}")
 
@@ -1581,11 +1598,15 @@ def _validate_filtered_output_contains_no_sources(
     output_dir: Path,
     candidates: Sequence[ParetoCandidate],
 ) -> None:
-    contained = [
-        candidate.path.resolve()
-        for candidate in candidates
-        if _is_within(candidate.path.resolve(), output_dir)
-    ]
+    contained = sorted(
+        {
+            source
+            for candidate in candidates
+            for source in (candidate.path.resolve(), candidate.member_path)
+            if _is_within(source, output_dir)
+        },
+        key=str,
+    )
     if contained:
         preview = ", ".join(str(path) for path in contained[:5])
         raise ValueError(
@@ -1596,7 +1617,7 @@ def _validate_filtered_output_contains_no_sources(
 
 def _prepare_selected_output(
     raw_path: str | os.PathLike[str] | None,
-    pareto_dir: Path,
+    protected_source_dir: Path | None,
     candidates: Sequence[ParetoCandidate],
     *,
     overwrite: bool,
@@ -1604,7 +1625,7 @@ def _prepare_selected_output(
     if raw_path is None:
         return None
     output = Path(raw_path).expanduser().resolve()
-    _validate_output_outside_source(output, pareto_dir, label="selected output")
+    _validate_output_outside_source(output, protected_source_dir, label="selected output")
     _validate_selected_output_not_source(output, candidates)
     if output.suffix.lower() != ".json":
         raise ValueError(f"Selected output must use a .json filename: {output}")
@@ -1649,7 +1670,7 @@ def _validate_existing_filtered_output_dir(output_dir: Path, *, overwrite: bool)
 
 def _prepare_filtered_output_dir(
     raw_path: str | os.PathLike[str] | None,
-    pareto_dir: Path,
+    protected_source_dir: Path | None,
     candidates: Sequence[ParetoCandidate],
     source_candidates: Sequence[ParetoCandidate],
     *,
@@ -1658,9 +1679,9 @@ def _prepare_filtered_output_dir(
     if raw_path is None:
         return None
     output_dir = Path(raw_path).expanduser().resolve()
-    _validate_output_outside_source(output_dir, pareto_dir, label="filtered output")
+    _validate_output_outside_source(output_dir, protected_source_dir, label="filtered output")
     _validate_filtered_output_contains_no_sources(output_dir, source_candidates)
-    names = [candidate.path.name for candidate in candidates]
+    names = [candidate.member_name for candidate in candidates]
     normalized_names = [name.casefold() for name in names]
     if len(normalized_names) != len(set(normalized_names)):
         raise ValueError("Filtered members contain duplicate filenames; cannot copy safely.")
@@ -1736,13 +1757,13 @@ def _write_filtered_outputs(
     try:
         members: List[Dict[str, Any]] = []
         for candidate in candidates:
-            staged_destination = staging_dir / candidate.path.name
-            final_destination = output_dir / candidate.path.name
+            staged_destination = staging_dir / candidate.member_name
+            final_destination = output_dir / candidate.member_name
             shutil.copy2(candidate.path, staged_destination)
             members.append(
                 {
-                    "file": candidate.path.name,
-                    "hash": candidate.path.stem,
+                    "file": candidate.member_name,
+                    "hash": Path(candidate.member_name).stem,
                     "source_path": str(candidate.path),
                     "output_path": str(final_destination),
                 }
@@ -1765,8 +1786,8 @@ def _write_filtered_outputs(
             "targets": _json_ready(result.details.get("targets") or {}),
             "priority": _json_ready(result.details.get("priority") or []),
             "selected_member": {
-                "file": selected.path.name,
-                "hash": selected.path.stem,
+                "file": selected.member_name,
+                "hash": Path(selected.member_name).stem,
                 "source_path": str(selected.path),
             },
             "members": members,
@@ -1793,7 +1814,9 @@ def run_from_args(args: argparse.Namespace) -> SelectionResult:
                 "with at least one *.json candidate was found."
             )
         raw_path = str(latest)
+    input_is_single_file = Path(raw_path).expanduser().is_file()
     pareto_dir, candidates, scoring_specs = load_candidates(raw_path)
+    protected_source_dir = None if input_is_single_file else pareto_dir
     raw_scenario = getattr(args, "scenario", None)
     scenario = str(raw_scenario).strip() if raw_scenario is not None else None
     selection_candidates = (
@@ -1827,13 +1850,13 @@ def run_from_args(args: argparse.Namespace) -> SelectionResult:
     overwrite = bool(getattr(args, "overwrite", False))
     selected_output = _prepare_selected_output(
         getattr(args, "save_selected", None),
-        pareto_dir,
+        protected_source_dir,
         candidates,
         overwrite=overwrite,
     )
     filtered_output_dir = _prepare_filtered_output_dir(
         getattr(args, "save_filtered", None),
-        pareto_dir,
+        protected_source_dir,
         filtered_candidates,
         candidates,
         overwrite=overwrite,
@@ -1879,8 +1902,8 @@ def run_from_args(args: argparse.Namespace) -> SelectionResult:
             "method": result.method,
             "method_description": _method_explanation(result.method),
             "selected": {
-                "file": result.candidate.path.name,
-                "hash": result.candidate.path.stem,
+                "file": result.candidate.member_name,
+                "hash": Path(result.candidate.member_name).stem,
                 "path": str(result.candidate.path),
                 "score": float(result.score),
                 "objectives": _json_ready(result.objective_values),

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -15,7 +15,7 @@ import unicodedata
 import textwrap
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+from typing import Any, BinaryIO, Dict, Iterable, List, Mapping, Optional, Sequence
 
 import numpy as np
 
@@ -82,7 +82,7 @@ class ParetoCandidate:
     path: Path
     member_path: Path
     member_name: str
-    source_bytes: bytes
+    source_bytes: bytes | None
     entry: Dict[str, Any]
     objectives: Dict[str, float]
     stats_flat: Dict[str, float]
@@ -758,7 +758,11 @@ def _extract_objectives(entry: Mapping[str, Any]) -> Dict[str, float]:
     return objectives
 
 
-def load_candidates(path: str | os.PathLike[str]) -> tuple[Path, List[ParetoCandidate], List[ObjectiveSpec]]:
+def load_candidates(
+    path: str | os.PathLike[str],
+    *,
+    capture_source_bytes: bool = True,
+) -> tuple[Path, List[ParetoCandidate], List[ObjectiveSpec]]:
     raw_path = Path(path).expanduser()
     if raw_path.is_file():
         pareto_dir = raw_path.parent.resolve()
@@ -811,7 +815,7 @@ def load_candidates(path: str | os.PathLike[str]) -> tuple[Path, List[ParetoCand
                 path=entry_path.resolve(),
                 member_path=entry_path.parent.resolve() / entry_path.name,
                 member_name=entry_path.name,
-                source_bytes=source_bytes,
+                source_bytes=source_bytes if capture_source_bytes else None,
                 entry=entry,
                 objectives=objectives,
                 stats_flat=stats_flat,
@@ -1780,23 +1784,30 @@ def _prepare_filtered_output_dir(
 def _write_candidate_snapshot_fd(
     candidate: ParetoCandidate,
     destination: Path,
-    file_descriptor: int,
+    file_descriptor: int | BinaryIO,
 ) -> None:
-    with os.fdopen(file_descriptor, "wb") as destination_file:
+    if candidate.source_bytes is None:
+        raise RuntimeError("Pareto source snapshot was not captured for export.")
+    destination_file = (
+        os.fdopen(file_descriptor, "wb")
+        if isinstance(file_descriptor, int)
+        else file_descriptor
+    )
+    with destination_file:
         destination_file.write(candidate.source_bytes)
 
 
-def _create_selected_staging_file(parent: Path) -> tuple[Path, int]:
-    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
-    if hasattr(os, "O_CLOEXEC"):
-        flags |= os.O_CLOEXEC
+def _create_selected_staging_file(parent: Path) -> tuple[Path, BinaryIO]:
     for _ in range(100):
         staging_path = parent / f"{SELECTED_STAGING_PREFIX}{secrets.token_hex(8)}.tmp"
         try:
-            file_descriptor = os.open(staging_path, flags, 0o666)
+            staging_file = staging_path.open("xb")
         except FileExistsError:
             continue
-        return staging_path, file_descriptor
+        except BaseException:
+            staging_path.unlink(missing_ok=True)
+            raise
+        return staging_path, staging_file
     raise FileExistsError(f"Could not reserve selected staging file in {parent}")
 
 
@@ -1995,6 +2006,9 @@ def _write_selected_output(
         return install
 
     output.parent.mkdir(parents=True, exist_ok=True)
+    if candidate.source_bytes is None:
+        raise RuntimeError("Pareto source snapshot was not captured for export.")
+    source_bytes = candidate.source_bytes
     staging_path, staging_descriptor = _create_selected_staging_file(output.parent)
     backup_path: Path | None = None
     staging_cleanup_attempted = False
@@ -2008,7 +2022,7 @@ def _write_selected_output(
             installed_identity = _install_selected_without_overwrite(
                 staging_path,
                 output,
-                candidate.source_bytes,
+                source_bytes,
                 commit_identity_sink=committed_identities,
             )
             staging_cleanup_attempted = True
@@ -2019,7 +2033,7 @@ def _write_selected_output(
                     "selected output", staging_path, exc
                 )
             return record_install(
-                _SelectedOutputInstall(None, installed_identity, candidate.source_bytes)
+                _SelectedOutputInstall(None, installed_identity, source_bytes)
             )
         observed_identity: tuple[int, int] | None = None
         observed_bytes: bytes | None = None
@@ -2060,7 +2074,7 @@ def _write_selected_output(
         installed_identity = _install_selected_without_overwrite(
             staging_path,
             output,
-            candidate.source_bytes,
+            source_bytes,
             metadata_source=backup_path,
             commit_identity_sink=committed_identities,
         )
@@ -2074,7 +2088,7 @@ def _write_selected_output(
             backup_path = None
         return record_install(
             _SelectedOutputInstall(
-                backup_path, installed_identity, candidate.source_bytes
+                backup_path, installed_identity, source_bytes
             )
         )
     except BaseException as exc:
@@ -2096,7 +2110,7 @@ def _write_selected_output(
                 )
                 return record_install(
                     _SelectedOutputInstall(
-                        backup_path, installed_identity, candidate.source_bytes
+                        backup_path, installed_identity, source_bytes
                     )
                 )
         if backup_path is not None:
@@ -2313,16 +2327,24 @@ def _ensure_filtered_output_dir(
     _validate_existing_filtered_output_dir(output_dir, overwrite=overwrite)
     if output_dir.exists():
         return None, _snapshot_filtered_output_dir(output_dir)
+    already_existed = False
+    created_identity: tuple[int, int] | None = None
     try:
-        output_dir.mkdir(mode=0o777)
-    except FileExistsError:
+        try:
+            output_dir.mkdir(mode=0o777)
+        except FileExistsError:
+            already_existed = True
+    finally:
+        if not already_existed and output_dir.exists():
+            output_stat = output_dir.stat(follow_symlinks=False)
+            created_identity = output_stat.st_dev, output_stat.st_ino
+            if reservation_sink is not None and not reservation_sink:
+                reservation_sink.append(created_identity)
+    if already_existed:
         _validate_existing_filtered_output_dir(output_dir, overwrite=overwrite)
         return None, _snapshot_filtered_output_dir(output_dir)
-    output_stat = output_dir.stat(follow_symlinks=False)
-    identity = output_stat.st_dev, output_stat.st_ino
-    if reservation_sink is not None and not reservation_sink:
-        reservation_sink.append(identity)
-    return identity, _FilteredOutputSnapshot(identity, ())
+    assert created_identity is not None
+    return created_identity, _FilteredOutputSnapshot(created_identity, ())
 
 
 def _remove_filtered_reservation(
@@ -2503,7 +2525,13 @@ def run_from_args(args: argparse.Namespace) -> SelectionResult:
             )
         raw_path = str(latest)
     input_is_single_file = Path(raw_path).expanduser().is_file()
-    pareto_dir, candidates, scoring_specs = load_candidates(raw_path)
+    capture_source_bytes = bool(
+        getattr(args, "save_selected", None) or getattr(args, "save_filtered", None)
+    )
+    pareto_dir, candidates, scoring_specs = load_candidates(
+        raw_path,
+        capture_source_bytes=capture_source_bytes,
+    )
     protected_source_dir = None if input_is_single_file else pareto_dir
     raw_scenario = getattr(args, "scenario", None)
     scenario = str(raw_scenario).strip() if raw_scenario is not None else None

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import argparse
+import ctypes
+import errno
 import json
 import math
 import os
@@ -1584,14 +1586,22 @@ def _is_within(path: Path, directory: Path) -> bool:
         return False
 
 
+def _same_existing_filesystem_object(left: Path, right: Path) -> bool:
+    try:
+        return os.path.samefile(left, right)
+    except (FileNotFoundError, NotADirectoryError, OSError):
+        return False
+
+
 def _validate_output_outside_source(
     path: Path,
     protected_source_dir: Path | None,
     *,
     label: str,
 ) -> None:
-    if protected_source_dir is not None and _is_within(
-        path, protected_source_dir.resolve()
+    if protected_source_dir is not None and (
+        _is_within(path, protected_source_dir.resolve())
+        or _same_existing_filesystem_object(path, protected_source_dir)
     ):
         raise ValueError(
             f"Refusing to write {label} inside the source Pareto directory: {path}"
@@ -1733,6 +1743,29 @@ def _create_selected_staging_file(parent: Path) -> Path:
     raise FileExistsError(f"Could not reserve selected staging file in {parent}")
 
 
+def _copy_platform_acl(source: Path, destination: Path) -> None:
+    if sys.platform != "darwin":
+        return
+    copyfile = ctypes.CDLL("/usr/lib/libSystem.B.dylib", use_errno=True).copyfile
+    copyfile.argtypes = [
+        ctypes.c_char_p,
+        ctypes.c_char_p,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+    ]
+    copyfile.restype = ctypes.c_int
+    copyfile_acl = 0x00000001
+    if copyfile(
+        os.fsencode(source), os.fsencode(destination), None, copyfile_acl
+    ) != 0:
+        error_number = ctypes.get_errno()
+        raise OSError(
+            error_number,
+            f"Could not preserve ACL from {source} to {destination}: "
+            f"{os.strerror(error_number)}",
+        )
+
+
 def _copy_file_metadata(source: Path, destination: Path) -> None:
     source_stat = source.stat(follow_symlinks=False)
     destination_stat = destination.stat(follow_symlinks=False)
@@ -1744,6 +1777,7 @@ def _copy_file_metadata(source: Path, destination: Path) -> None:
             follow_symlinks=False,
         )
     shutil.copystat(source, destination, follow_symlinks=False)
+    _copy_platform_acl(source, destination)
     os.utime(
         destination,
         ns=(destination_stat.st_atime_ns, destination_stat.st_mtime_ns),
@@ -1759,6 +1793,52 @@ def _warn_post_commit_cleanup_failure(
         f"{path} ({exc})",
         file=sys.stderr,
     )
+
+
+def _install_selected_without_overwrite(
+    staging_path: Path,
+    output: Path,
+    source_bytes: bytes,
+    *,
+    metadata_source: Path | None = None,
+) -> tuple[int, int]:
+    staging_stat = staging_path.stat(follow_symlinks=False)
+    try:
+        os.link(staging_path, output)
+    except FileExistsError as exc:
+        raise FileExistsError(
+            f"Selected output already exists: {output} "
+            "(use --overwrite to replace it)"
+        ) from exc
+    except OSError as exc:
+        unsupported = {errno.EPERM, errno.ENOSYS, errno.EXDEV}
+        if hasattr(errno, "EOPNOTSUPP"):
+            unsupported.add(errno.EOPNOTSUPP)
+        if hasattr(errno, "ENOTSUP"):
+            unsupported.add(errno.ENOTSUP)
+        if exc.errno not in unsupported:
+            raise
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        if hasattr(os, "O_CLOEXEC"):
+            flags |= os.O_CLOEXEC
+        try:
+            file_descriptor = os.open(output, flags, 0o666)
+        except FileExistsError as conflict:
+            raise FileExistsError(
+                f"Selected output already exists: {output} "
+                "(use --overwrite to replace it)"
+            ) from conflict
+        try:
+            with os.fdopen(file_descriptor, "wb") as output_file:
+                output_file.write(source_bytes)
+            if metadata_source is not None:
+                _copy_file_metadata(metadata_source, output)
+        except BaseException:
+            output.unlink(missing_ok=True)
+            raise
+        output_stat = output.stat(follow_symlinks=False)
+        return output_stat.st_dev, output_stat.st_ino
+    return staging_stat.st_dev, staging_stat.st_ino
 
 
 def _write_selected_output(
@@ -1778,13 +1858,9 @@ def _write_selected_output(
         if not overwrite:
             staging_stat = staging_path.stat(follow_symlinks=False)
             installed_identity = staging_stat.st_dev, staging_stat.st_ino
-            try:
-                os.link(staging_path, output)
-            except FileExistsError as exc:
-                raise FileExistsError(
-                    f"Selected output already exists: {output} "
-                    "(use --overwrite to replace it)"
-                ) from exc
+            installed_identity = _install_selected_without_overwrite(
+                staging_path, output, candidate.source_bytes
+            )
             staging_cleanup_attempted = True
             try:
                 staging_path.unlink()
@@ -1795,25 +1871,49 @@ def _write_selected_output(
             return _SelectedOutputInstall(
                 None, installed_identity, candidate.source_bytes
             )
+        observed_identity: tuple[int, int] | None = None
         if output.exists():
             if not output.is_file():
                 raise ValueError(f"Selected output must be a regular file: {output}")
-            if keep_backup:
-                backup_descriptor, backup_name = tempfile.mkstemp(
-                    prefix=SELECTED_BACKUP_PREFIX,
-                    suffix=".backup",
-                    dir=output.parent,
-                )
-                os.close(backup_descriptor)
-                backup_path = Path(backup_name)
-                backup_path.unlink()
-                os.link(output, backup_path)
+            observed_stat = output.stat(follow_symlinks=False)
+            observed_identity = observed_stat.st_dev, observed_stat.st_ino
             _copy_file_metadata(output, staging_path)
+            backup_descriptor, backup_name = tempfile.mkstemp(
+                prefix=SELECTED_BACKUP_PREFIX,
+                suffix=".backup",
+                dir=output.parent,
+            )
+            os.close(backup_descriptor)
+            backup_path = Path(backup_name)
+            backup_path.unlink()
+            os.replace(output, backup_path)
+            moved_stat = backup_path.stat(follow_symlinks=False)
+            if (moved_stat.st_dev, moved_stat.st_ino) != observed_identity:
+                if output.exists():
+                    raise RuntimeError(
+                        f"Selected output changed concurrently; moved file retained at "
+                        f"{backup_path}"
+                    )
+                os.replace(backup_path, output)
+                backup_path = None
+                raise RuntimeError(
+                    f"Selected output changed concurrently; refusing install: {output}"
+                )
         staging_stat = staging_path.stat(follow_symlinks=False)
         installed_identity = staging_stat.st_dev, staging_stat.st_ino
-        os.replace(staging_path, output)
+        installed_identity = _install_selected_without_overwrite(
+            staging_path,
+            output,
+            candidate.source_bytes,
+            metadata_source=backup_path,
+        )
+        staging_cleanup_attempted = True
+        try:
+            staging_path.unlink()
+        except OSError as exc:
+            _warn_post_commit_cleanup_failure("selected output", staging_path, exc)
         if backup_path is not None and not keep_backup:
-            backup_path.unlink()
+            _remove_selected_backup_after_commit(backup_path)
             backup_path = None
         return _SelectedOutputInstall(
             backup_path, installed_identity, candidate.source_bytes
@@ -1837,7 +1937,13 @@ def _write_selected_output(
                     backup_path, installed_identity, candidate.source_bytes
                 )
         if backup_path is not None:
-            backup_path.unlink(missing_ok=True)
+            if output.exists():
+                raise RuntimeError(
+                    f"Selected output changed concurrently; original file retained at "
+                    f"{backup_path}"
+                ) from exc
+            os.replace(backup_path, output)
+            backup_path = None
         raise
     finally:
         if not staging_cleanup_attempted:
@@ -1907,6 +2013,7 @@ def _copy_directory_metadata(source: Path, destination: Path) -> None:
             follow_symlinks=False,
         )
     shutil.copystat(source, destination, follow_symlinks=False)
+    _copy_platform_acl(source, destination)
     os.utime(
         destination,
         ns=(destination_stat.st_atime_ns, destination_stat.st_mtime_ns),

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -1724,6 +1724,14 @@ def _copy_file_metadata(source: Path, destination: Path) -> None:
     shutil.copystat(source, destination, follow_symlinks=False)
 
 
+def _warn_post_commit_cleanup_failure(label: str, path: Path, exc: OSError) -> None:
+    print(
+        f"Warning: {label} installed, but temporary path could not be removed: "
+        f"{path} ({exc})",
+        file=sys.stderr,
+    )
+
+
 def _write_selected_output(
     candidate: ParetoCandidate,
     output: Path,
@@ -1738,6 +1746,7 @@ def _write_selected_output(
     os.close(file_descriptor)
     staging_path = Path(staging_name)
     backup_path: Path | None = None
+    staging_cleanup_attempted = False
     try:
         _write_candidate_snapshot(candidate, staging_path)
         if not overwrite:
@@ -1749,7 +1758,13 @@ def _write_selected_output(
                     f"Selected output already exists: {output} "
                     "(use --overwrite to replace it)"
                 ) from exc
-            staging_path.unlink()
+            staging_cleanup_attempted = True
+            try:
+                staging_path.unlink()
+            except OSError as exc:
+                _warn_post_commit_cleanup_failure(
+                    "selected output", staging_path, exc
+                )
             return None
         if output.exists():
             if not output.is_file():
@@ -1760,7 +1775,8 @@ def _write_selected_output(
                 )
                 os.close(backup_descriptor)
                 backup_path = Path(backup_name)
-                shutil.copy2(output, backup_path)
+                backup_path.unlink()
+                os.link(output, backup_path)
             _copy_file_metadata(output, staging_path)
         else:
             staging_path.chmod(_default_file_mode())
@@ -1769,12 +1785,13 @@ def _write_selected_output(
             backup_path.unlink()
             backup_path = None
         return backup_path
-    except Exception:
+    except BaseException:
         if backup_path is not None:
             backup_path.unlink(missing_ok=True)
         raise
     finally:
-        staging_path.unlink(missing_ok=True)
+        if not staging_cleanup_attempted:
+            staging_path.unlink(missing_ok=True)
 
 
 def _restore_selected_output(output: Path, backup_path: Path | None) -> None:
@@ -1788,11 +1805,7 @@ def _remove_selected_backup_after_commit(backup_path: Path) -> None:
     try:
         backup_path.unlink()
     except OSError as exc:
-        print(
-            f"Warning: selected output installed, but old backup could not be removed: "
-            f"{backup_path} ({exc})",
-            file=sys.stderr,
-        )
+        _warn_post_commit_cleanup_failure("selected output", backup_path, exc)
 
 
 def _default_directory_mode() -> int:
@@ -1824,13 +1837,8 @@ def _replace_filtered_output_dir(
     output_dir: Path,
     *,
     overwrite: bool,
-    new_output_mode: int,
 ) -> None:
     _validate_existing_filtered_output_dir(output_dir, overwrite=overwrite)
-    if not output_dir.exists():
-        staging_dir.chmod(new_output_mode)
-        os.replace(staging_dir, output_dir)
-        return
 
     backup_name = tempfile.mkdtemp(
         prefix=f".{output_dir.name}.backup-", dir=output_dir.parent
@@ -1842,7 +1850,7 @@ def _replace_filtered_output_dir(
         _validate_existing_filtered_output_dir(backup_dir, overwrite=overwrite)
         _copy_directory_metadata(backup_dir, staging_dir)
         os.replace(staging_dir, output_dir)
-    except Exception:
+    except BaseException:
         os.replace(backup_dir, output_dir)
         raise
     else:
@@ -1854,6 +1862,47 @@ def _replace_filtered_output_dir(
                 f"{backup_dir} ({exc})",
                 file=sys.stderr,
             )
+
+
+def _ensure_filtered_output_dir(
+    output_dir: Path,
+    *,
+    overwrite: bool,
+    new_output_mode: int,
+) -> tuple[int, int] | None:
+    _validate_existing_filtered_output_dir(output_dir, overwrite=overwrite)
+    if output_dir.exists():
+        return None
+    try:
+        output_dir.mkdir(mode=new_output_mode)
+    except FileExistsError:
+        _validate_existing_filtered_output_dir(output_dir, overwrite=overwrite)
+        return None
+    output_dir.chmod(new_output_mode)
+    output_stat = output_dir.stat(follow_symlinks=False)
+    return output_stat.st_dev, output_stat.st_ino
+
+
+def _remove_filtered_reservation(
+    output_dir: Path,
+    reservation_identity: tuple[int, int] | None,
+) -> None:
+    if reservation_identity is None:
+        return
+    try:
+        output_stat = output_dir.stat(follow_symlinks=False)
+    except FileNotFoundError:
+        return
+    if (output_stat.st_dev, output_stat.st_ino) != reservation_identity:
+        return
+    try:
+        output_dir.rmdir()
+    except OSError as exc:
+        print(
+            f"Warning: unused filtered output reservation could not be removed: "
+            f"{output_dir} ({exc})",
+            file=sys.stderr,
+        )
 
 
 def _write_filtered_outputs(
@@ -1870,10 +1919,22 @@ def _write_filtered_outputs(
 ) -> Path:
     output_dir.parent.mkdir(parents=True, exist_ok=True)
     new_output_mode = _default_directory_mode()
-    staging_dir = Path(
-        tempfile.mkdtemp(prefix=f".{output_dir.name}.", suffix=".tmp", dir=output_dir.parent)
+    reservation_identity = _ensure_filtered_output_dir(
+        output_dir,
+        overwrite=overwrite,
+        new_output_mode=new_output_mode,
     )
+    staging_dir: Path | None = None
     try:
+        staging_dir = Path(
+            tempfile.mkdtemp(
+                prefix=f".{output_dir.name}.", suffix=".tmp", dir=output_dir.parent
+            )
+        )
+        _copy_directory_metadata(output_dir, staging_dir)
+        staging_dir.chmod(
+            stat.S_IMODE(staging_dir.stat().st_mode) | stat.S_IWUSR | stat.S_IXUSR
+        )
         members: List[Dict[str, Any]] = []
         for candidate in candidates:
             staged_destination = staging_dir / candidate.member_name
@@ -1919,10 +1980,11 @@ def _write_filtered_outputs(
             staging_dir,
             output_dir,
             overwrite=overwrite,
-            new_output_mode=new_output_mode,
         )
     finally:
-        _remove_output_tree(staging_dir)
+        if staging_dir is not None:
+            _remove_output_tree(staging_dir)
+        _remove_filtered_reservation(output_dir, reservation_identity)
     return output_dir / FILTERED_SELECTION_MANIFEST
 
 
@@ -2017,7 +2079,7 @@ def run_from_args(args: argparse.Namespace) -> SelectionResult:
                 result=result,
                 overwrite=overwrite,
             )
-    except Exception:
+    except BaseException:
         if selected_output is not None:
             _restore_selected_output(selected_output, selected_backup)
         raise

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -75,6 +75,7 @@ SELECTED_STAGING_PREFIX = ".pareto-selected-"
 SELECTED_BACKUP_PREFIX = ".pareto-selected-backup-"
 FILTERED_STAGING_PREFIX = ".pareto-filtered-"
 FILTERED_BACKUP_PREFIX = ".pareto-filtered-backup-"
+FILTERED_RESERVATION_PREFIX = ".pareto-filtered-reservation-"
 
 
 @dataclass(frozen=True)
@@ -1797,7 +1798,9 @@ def _write_candidate_snapshot_fd(
         destination_file.write(candidate.source_bytes)
 
 
-def _create_selected_staging_file(parent: Path) -> tuple[Path, BinaryIO]:
+def _create_selected_staging_file(
+    parent: Path,
+) -> tuple[Path, BinaryIO, tuple[int, int]]:
     for _ in range(100):
         staging_path = parent / f"{SELECTED_STAGING_PREFIX}{secrets.token_hex(8)}.tmp"
         try:
@@ -1807,7 +1810,8 @@ def _create_selected_staging_file(parent: Path) -> tuple[Path, BinaryIO]:
         except BaseException:
             staging_path.unlink(missing_ok=True)
             raise
-        return staging_path, staging_file
+        staging_stat = os.fstat(staging_file.fileno())
+        return staging_path, staging_file, (staging_stat.st_dev, staging_stat.st_ino)
     raise FileExistsError(f"Could not reserve selected staging file in {parent}")
 
 
@@ -1877,6 +1881,7 @@ def _install_selected_without_overwrite(
     metadata_source: Path | None = None,
     preserve_metadata_timestamps: bool = False,
     commit_identity_sink: List[tuple[int, int]] | None = None,
+    expected_staging_identity: tuple[int, int] | None = None,
 ) -> tuple[int, int]:
     def record_commit(identity: tuple[int, int]) -> tuple[int, int]:
         if commit_identity_sink is not None and not commit_identity_sink:
@@ -1884,6 +1889,15 @@ def _install_selected_without_overwrite(
         return identity
 
     staging_stat = staging_path.stat(follow_symlinks=False)
+    staging_identity = staging_stat.st_dev, staging_stat.st_ino
+    if (
+        expected_staging_identity is not None
+        and staging_identity != expected_staging_identity
+    ):
+        raise RuntimeError(
+            f"Selected staging file changed concurrently; refusing install: "
+            f"{staging_path}"
+        )
     try:
         os.link(staging_path, output)
     except FileExistsError as exc:
@@ -1989,7 +2003,23 @@ def _install_selected_without_overwrite(
                 ) from exc
             raise
         return created_identity
-    return record_commit((staging_stat.st_dev, staging_stat.st_ino))
+    output_stat = output.stat(follow_symlinks=False)
+    output_identity = output_stat.st_dev, output_stat.st_ino
+    if output_identity != staging_identity or output.read_bytes() != source_bytes:
+        failed_descriptor, failed_name = tempfile.mkstemp(
+            prefix=SELECTED_BACKUP_PREFIX,
+            suffix=".failed",
+            dir=output.parent,
+        )
+        os.close(failed_descriptor)
+        failed_path = Path(failed_name)
+        failed_path.unlink()
+        os.replace(output, failed_path)
+        raise RuntimeError(
+            f"Selected staging file changed during install; installed object retained "
+            f"at {failed_path}"
+        )
+    return record_commit(staging_identity)
 
 
 def _write_selected_output(
@@ -1999,6 +2029,8 @@ def _write_selected_output(
     keep_backup: bool,
     overwrite: bool,
     install_sink: List[_SelectedOutputInstall] | None = None,
+    protected_source_dir: Path | None = None,
+    source_candidates: Sequence[ParetoCandidate] = (),
 ) -> _SelectedOutputInstall:
     def record_install(install: _SelectedOutputInstall) -> _SelectedOutputInstall:
         if install_sink is not None and not install_sink:
@@ -2006,24 +2038,40 @@ def _write_selected_output(
         return install
 
     output.parent.mkdir(parents=True, exist_ok=True)
+    _validate_output_outside_source(
+        output, protected_source_dir, label="selected output"
+    )
+    _validate_selected_output_not_source(output, source_candidates)
     if candidate.source_bytes is None:
         raise RuntimeError("Pareto source snapshot was not captured for export.")
     source_bytes = candidate.source_bytes
-    staging_path, staging_descriptor = _create_selected_staging_file(output.parent)
+    staging_path, staging_descriptor, staging_identity = (
+        _create_selected_staging_file(output.parent)
+    )
     backup_path: Path | None = None
     staging_cleanup_attempted = False
     installed_identity: tuple[int, int] | None = None
     committed_identities: List[tuple[int, int]] = []
     try:
         _write_candidate_snapshot_fd(candidate, staging_path, staging_descriptor)
+        staged_stat = staging_path.stat(follow_symlinks=False)
+        if (
+            (staged_stat.st_dev, staged_stat.st_ino) != staging_identity
+            or staging_path.read_bytes() != source_bytes
+        ):
+            staging_cleanup_attempted = True
+            raise RuntimeError(
+                f"Selected staging file changed concurrently; refusing install: "
+                f"{staging_path}"
+            )
         if not overwrite:
-            staging_stat = staging_path.stat(follow_symlinks=False)
-            installed_identity = staging_stat.st_dev, staging_stat.st_ino
+            installed_identity = staging_identity
             installed_identity = _install_selected_without_overwrite(
                 staging_path,
                 output,
                 source_bytes,
                 commit_identity_sink=committed_identities,
+                expected_staging_identity=staging_identity,
             )
             staging_cleanup_attempted = True
             try:
@@ -2043,7 +2091,6 @@ def _write_selected_output(
             observed_stat = output.stat(follow_symlinks=False)
             observed_identity = observed_stat.st_dev, observed_stat.st_ino
             observed_bytes = output.read_bytes()
-            _copy_file_metadata(output, staging_path)
             backup_descriptor, backup_name = tempfile.mkstemp(
                 prefix=SELECTED_BACKUP_PREFIX,
                 suffix=".backup",
@@ -2069,14 +2116,19 @@ def _write_selected_output(
                 raise RuntimeError(
                     f"Selected output changed concurrently; refusing install: {output}"
                 )
-        staging_stat = staging_path.stat(follow_symlinks=False)
-        installed_identity = staging_stat.st_dev, staging_stat.st_ino
+            _copy_file_metadata(backup_path, staging_path)
+        _validate_output_outside_source(
+            output, protected_source_dir, label="selected output"
+        )
+        _validate_selected_output_not_source(output, source_candidates)
+        installed_identity = staging_identity
         installed_identity = _install_selected_without_overwrite(
             staging_path,
             output,
             source_bytes,
             metadata_source=backup_path,
             commit_identity_sink=committed_identities,
+            expected_staging_identity=staging_identity,
         )
         staging_cleanup_attempted = True
         try:
@@ -2327,24 +2379,45 @@ def _ensure_filtered_output_dir(
     _validate_existing_filtered_output_dir(output_dir, overwrite=overwrite)
     if output_dir.exists():
         return None, _snapshot_filtered_output_dir(output_dir)
-    already_existed = False
-    created_identity: tuple[int, int] | None = None
-    try:
+    reservation_path: Path | None = None
+    for _ in range(100):
+        candidate_path = output_dir.parent / (
+            f"{FILTERED_RESERVATION_PREFIX}{secrets.token_hex(8)}.tmp"
+        )
         try:
-            output_dir.mkdir(mode=0o777)
+            candidate_path.mkdir(mode=0o777)
         except FileExistsError:
-            already_existed = True
-    finally:
-        if not already_existed and output_dir.exists():
-            output_stat = output_dir.stat(follow_symlinks=False)
-            created_identity = output_stat.st_dev, output_stat.st_ino
-            if reservation_sink is not None and not reservation_sink:
-                reservation_sink.append(created_identity)
-    if already_existed:
-        _validate_existing_filtered_output_dir(output_dir, overwrite=overwrite)
-        return None, _snapshot_filtered_output_dir(output_dir)
-    assert created_identity is not None
-    return created_identity, _FilteredOutputSnapshot(created_identity, ())
+            continue
+        except BaseException:
+            try:
+                candidate_path.rmdir()
+            except OSError:
+                pass
+            raise
+        reservation_path = candidate_path
+        break
+    if reservation_path is None:
+        raise FileExistsError(
+            f"Could not create filtered output reservation in {output_dir.parent}"
+        )
+    reservation_stat = reservation_path.stat(follow_symlinks=False)
+    reservation_identity = reservation_stat.st_dev, reservation_stat.st_ino
+    if reservation_sink is not None and not reservation_sink:
+        reservation_sink.append(reservation_identity)
+    try:
+        os.replace(reservation_path, output_dir)
+    except BaseException:
+        try:
+            reservation_path.rmdir()
+        except OSError:
+            pass
+        raise
+    output_stat = output_dir.stat(follow_symlinks=False)
+    if (output_stat.st_dev, output_stat.st_ino) != reservation_identity:
+        raise RuntimeError(
+            f"Filtered output reservation changed concurrently: {output_dir}"
+        )
+    return reservation_identity, _FilteredOutputSnapshot(reservation_identity, ())
 
 
 def _remove_filtered_reservation(
@@ -2353,20 +2426,36 @@ def _remove_filtered_reservation(
 ) -> None:
     if reservation_identity is None:
         return
+    cleanup_name = tempfile.mkdtemp(
+        prefix=FILTERED_RESERVATION_PREFIX,
+        suffix=".cleanup",
+        dir=output_dir.parent,
+    )
+    cleanup_path = Path(cleanup_name)
+    cleanup_path.rmdir()
     try:
-        output_stat = output_dir.stat(follow_symlinks=False)
+        os.replace(output_dir, cleanup_path)
     except FileNotFoundError:
         return
-    if (output_stat.st_dev, output_stat.st_ino) != reservation_identity:
+    cleanup_stat = cleanup_path.stat(follow_symlinks=False)
+    if (cleanup_stat.st_dev, cleanup_stat.st_ino) == reservation_identity:
+        try:
+            cleanup_path.rmdir()
+        except OSError as exc:
+            print(
+                f"Warning: unused filtered output reservation could not be removed: "
+                f"{cleanup_path} ({exc})",
+                file=sys.stderr,
+            )
         return
-    try:
-        output_dir.rmdir()
-    except OSError as exc:
+    if output_dir.exists():
         print(
-            f"Warning: unused filtered output reservation could not be removed: "
-            f"{output_dir} ({exc})",
+            f"Warning: filtered output reservation changed concurrently; moved directory "
+            f"retained at {cleanup_path}",
             file=sys.stderr,
         )
+        return
+    os.replace(cleanup_path, output_dir)
 
 
 def _reserve_filtered_output_file(destination: Path, *, label: str) -> int:
@@ -2394,6 +2483,8 @@ def _write_filtered_outputs(
     result: SelectionResult,
     overwrite: bool,
     commit_sink: List[Path] | None = None,
+    protected_source_dir: Path | None = None,
+    source_candidates: Sequence[ParetoCandidate] = (),
 ) -> Path:
     manifest_output = output_dir / FILTERED_SELECTION_MANIFEST
 
@@ -2402,6 +2493,12 @@ def _write_filtered_outputs(
             commit_sink.append(manifest_output)
 
     output_dir.parent.mkdir(parents=True, exist_ok=True)
+    _validate_output_outside_source(
+        output_dir, protected_source_dir, label="filtered output"
+    )
+    _validate_filtered_output_contains_no_sources(
+        output_dir, source_candidates
+    )
     reservation_identities: List[tuple[int, int]] = []
     reservation_identity: tuple[int, int] | None = None
     observed_output: _FilteredOutputSnapshot | None = None
@@ -2603,6 +2700,8 @@ def run_from_args(args: argparse.Namespace) -> SelectionResult:
                 keep_backup=filtered_output_dir is not None,
                 overwrite=overwrite,
                 install_sink=selected_installs,
+                protected_source_dir=protected_source_dir,
+                source_candidates=candidates,
             )
             selected_install = selected_installs[0]
         if filtered_output_dir is not None:
@@ -2617,6 +2716,8 @@ def run_from_args(args: argparse.Namespace) -> SelectionResult:
                 result=result,
                 overwrite=overwrite,
                 commit_sink=filtered_commits,
+                protected_source_dir=protected_source_dir,
+                source_candidates=candidates,
             )
     except BaseException:
         if (

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -86,6 +86,7 @@ class ParetoCandidate:
 class _SelectedOutputInstall:
     backup_path: Path | None
     installed_identity: tuple[int, int]
+    installed_bytes: bytes
 
 
 @dataclass(frozen=True)
@@ -1775,7 +1776,9 @@ def _write_selected_output(
                 _warn_post_commit_cleanup_failure(
                     "selected output", staging_path, exc
                 )
-            return _SelectedOutputInstall(None, installed_identity)
+            return _SelectedOutputInstall(
+                None, installed_identity, candidate.source_bytes
+            )
         if output.exists():
             if not output.is_file():
                 raise ValueError(f"Selected output must be a regular file: {output}")
@@ -1796,7 +1799,9 @@ def _write_selected_output(
         if backup_path is not None and not keep_backup:
             backup_path.unlink()
             backup_path = None
-        return _SelectedOutputInstall(backup_path, installed_identity)
+        return _SelectedOutputInstall(
+            backup_path, installed_identity, candidate.source_bytes
+        )
     except BaseException:
         if backup_path is not None:
             backup_path.unlink(missing_ok=True)
@@ -1814,6 +1819,22 @@ def _restore_selected_output(output: Path, install: _SelectedOutputInstall) -> N
             f"Selected output changed concurrently; refusing rollback: {output}"
         ) from exc
     if (output_stat.st_dev, output_stat.st_ino) != install.installed_identity:
+        backup_note = (
+            f" Original backup retained at {install.backup_path}."
+            if install.backup_path is not None
+            else ""
+        )
+        raise RuntimeError(
+            f"Selected output changed concurrently; refusing rollback: {output}."
+            f"{backup_note}"
+        )
+    try:
+        output_bytes = output.read_bytes()
+    except OSError as exc:
+        raise RuntimeError(
+            f"Selected output could not be verified; refusing rollback: {output}"
+        ) from exc
+    if output_bytes != install.installed_bytes:
         backup_note = (
             f" Original backup retained at {install.backup_path}."
             if install.backup_path is not None
@@ -1868,11 +1889,35 @@ def _replace_filtered_output_dir(
     backup_dir = Path(backup_name)
     backup_dir.rmdir()
     os.replace(output_dir, backup_dir)
+    staging_stat = staging_dir.stat(follow_symlinks=False)
+    staging_identity = staging_stat.st_dev, staging_stat.st_ino
     try:
         _validate_existing_filtered_output_dir(backup_dir, overwrite=overwrite)
         _copy_directory_metadata(backup_dir, staging_dir)
         os.replace(staging_dir, output_dir)
-    except BaseException:
+    except BaseException as exc:
+        try:
+            output_stat = output_dir.stat(follow_symlinks=False)
+        except FileNotFoundError:
+            output_stat = None
+        if output_stat is not None and (
+            output_stat.st_dev,
+            output_stat.st_ino,
+        ) == staging_identity:
+            print(
+                f"Warning: filtered output install committed before interruption; "
+                f"keeping installed output: {output_dir} ({exc})",
+                file=sys.stderr,
+            )
+            try:
+                _remove_output_tree(backup_dir)
+            except BaseException as cleanup_exc:
+                print(
+                    f"Warning: filtered output installed, but old backup could not be "
+                    f"removed: {backup_dir} ({cleanup_exc})",
+                    file=sys.stderr,
+                )
+            return
         os.replace(backup_dir, output_dir)
         raise
     else:

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import math
 import os
+import secrets
 import shutil
 import stat
 import sys
@@ -67,6 +68,10 @@ METHOD_DESCRIPTIONS = {
 
 
 FILTERED_SELECTION_MANIFEST = "selection.json"
+SELECTED_STAGING_PREFIX = ".pareto-selected-"
+SELECTED_BACKUP_PREFIX = ".pareto-selected-backup-"
+FILTERED_STAGING_PREFIX = ".pareto-filtered-"
+FILTERED_BACKUP_PREFIX = ".pareto-filtered-backup-"
 
 
 @dataclass(frozen=True)
@@ -1713,10 +1718,19 @@ def _write_candidate_snapshot(candidate: ParetoCandidate, destination: Path) -> 
     destination.write_bytes(candidate.source_bytes)
 
 
-def _default_file_mode() -> int:
-    current_umask = os.umask(0)
-    os.umask(current_umask)
-    return 0o666 & ~current_umask
+def _create_selected_staging_file(parent: Path) -> Path:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    for _ in range(100):
+        staging_path = parent / f"{SELECTED_STAGING_PREFIX}{secrets.token_hex(8)}.tmp"
+        try:
+            file_descriptor = os.open(staging_path, flags, 0o666)
+        except FileExistsError:
+            continue
+        os.close(file_descriptor)
+        return staging_path
+    raise FileExistsError(f"Could not reserve selected staging file in {parent}")
 
 
 def _copy_file_metadata(source: Path, destination: Path) -> None:
@@ -1755,18 +1769,13 @@ def _write_selected_output(
     overwrite: bool,
 ) -> _SelectedOutputInstall:
     output.parent.mkdir(parents=True, exist_ok=True)
-    file_descriptor, staging_name = tempfile.mkstemp(
-        prefix=f".{output.name}.", suffix=".tmp", dir=output.parent
-    )
-    os.close(file_descriptor)
-    staging_path = Path(staging_name)
+    staging_path = _create_selected_staging_file(output.parent)
     backup_path: Path | None = None
     staging_cleanup_attempted = False
     installed_identity: tuple[int, int] | None = None
     try:
         _write_candidate_snapshot(candidate, staging_path)
         if not overwrite:
-            staging_path.chmod(_default_file_mode())
             staging_stat = staging_path.stat(follow_symlinks=False)
             installed_identity = staging_stat.st_dev, staging_stat.st_ino
             try:
@@ -1791,15 +1800,15 @@ def _write_selected_output(
                 raise ValueError(f"Selected output must be a regular file: {output}")
             if keep_backup:
                 backup_descriptor, backup_name = tempfile.mkstemp(
-                    prefix=f".{output.name}.", suffix=".backup", dir=output.parent
+                    prefix=SELECTED_BACKUP_PREFIX,
+                    suffix=".backup",
+                    dir=output.parent,
                 )
                 os.close(backup_descriptor)
                 backup_path = Path(backup_name)
                 backup_path.unlink()
                 os.link(output, backup_path)
             _copy_file_metadata(output, staging_path)
-        else:
-            staging_path.chmod(_default_file_mode())
         staging_stat = staging_path.stat(follow_symlinks=False)
         installed_identity = staging_stat.st_dev, staging_stat.st_ino
         os.replace(staging_path, output)
@@ -1914,7 +1923,7 @@ def _replace_filtered_output_dir(
     _validate_existing_filtered_output_dir(output_dir, overwrite=overwrite)
 
     backup_name = tempfile.mkdtemp(
-        prefix=f".{output_dir.name}.backup-", dir=output_dir.parent
+        prefix=FILTERED_BACKUP_PREFIX, dir=output_dir.parent
     )
     backup_dir = Path(backup_name)
     backup_dir.rmdir()
@@ -2006,6 +2015,19 @@ def _remove_filtered_reservation(
         )
 
 
+def _reserve_filtered_output_file(destination: Path, *, label: str) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    try:
+        file_descriptor = os.open(destination, flags, 0o666)
+    except FileExistsError as exc:
+        raise ValueError(
+            f"{label} collides on the destination filesystem: {destination.name}"
+        ) from exc
+    os.close(file_descriptor)
+
+
 def _write_filtered_outputs(
     output_dir: Path,
     pareto_dir: Path,
@@ -2027,7 +2049,9 @@ def _write_filtered_outputs(
     try:
         staging_dir = Path(
             tempfile.mkdtemp(
-                prefix=f".{output_dir.name}.", suffix=".tmp", dir=output_dir.parent
+                prefix=FILTERED_STAGING_PREFIX,
+                suffix=".tmp",
+                dir=output_dir.parent,
             )
         )
         _copy_directory_metadata(output_dir, staging_dir)
@@ -2038,6 +2062,9 @@ def _write_filtered_outputs(
         for candidate in candidates:
             staged_destination = staging_dir / candidate.member_name
             final_destination = output_dir / candidate.member_name
+            _reserve_filtered_output_file(
+                staged_destination, label="Filtered member filename"
+            )
             _write_candidate_snapshot(candidate, staged_destination)
             members.append(
                 {
@@ -2071,7 +2098,11 @@ def _write_filtered_outputs(
             },
             "members": members,
         }
-        (staging_dir / FILTERED_SELECTION_MANIFEST).write_text(
+        manifest_path = staging_dir / FILTERED_SELECTION_MANIFEST
+        _reserve_filtered_output_file(
+            manifest_path, label="Filtered selection manifest"
+        )
+        manifest_path.write_text(
             json.dumps(_json_ready(manifest), indent=2, sort_keys=True) + "\n",
             encoding="utf-8",
         )

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -1706,6 +1706,24 @@ def _write_candidate_snapshot(candidate: ParetoCandidate, destination: Path) -> 
     destination.write_bytes(candidate.source_bytes)
 
 
+def _default_file_mode() -> int:
+    current_umask = os.umask(0)
+    os.umask(current_umask)
+    return 0o666 & ~current_umask
+
+
+def _copy_file_metadata(source: Path, destination: Path) -> None:
+    source_stat = source.stat(follow_symlinks=False)
+    if hasattr(os, "chown"):
+        os.chown(
+            destination,
+            source_stat.st_uid,
+            source_stat.st_gid,
+            follow_symlinks=False,
+        )
+    shutil.copystat(source, destination, follow_symlinks=False)
+
+
 def _write_selected_output(
     candidate: ParetoCandidate,
     output: Path,
@@ -1723,6 +1741,7 @@ def _write_selected_output(
     try:
         _write_candidate_snapshot(candidate, staging_path)
         if not overwrite:
+            staging_path.chmod(_default_file_mode())
             try:
                 os.link(staging_path, output)
             except FileExistsError as exc:
@@ -1732,15 +1751,19 @@ def _write_selected_output(
                 ) from exc
             staging_path.unlink()
             return None
-        if output.exists() and keep_backup:
+        if output.exists():
             if not output.is_file():
                 raise ValueError(f"Selected output must be a regular file: {output}")
-            backup_descriptor, backup_name = tempfile.mkstemp(
-                prefix=f".{output.name}.", suffix=".backup", dir=output.parent
-            )
-            os.close(backup_descriptor)
-            backup_path = Path(backup_name)
-            shutil.copy2(output, backup_path)
+            if keep_backup:
+                backup_descriptor, backup_name = tempfile.mkstemp(
+                    prefix=f".{output.name}.", suffix=".backup", dir=output.parent
+                )
+                os.close(backup_descriptor)
+                backup_path = Path(backup_name)
+                shutil.copy2(output, backup_path)
+            _copy_file_metadata(output, staging_path)
+        else:
+            staging_path.chmod(_default_file_mode())
         os.replace(staging_path, output)
         if backup_path is not None and not keep_backup:
             backup_path.unlink()
@@ -1759,6 +1782,17 @@ def _restore_selected_output(output: Path, backup_path: Path | None) -> None:
         output.unlink(missing_ok=True)
     else:
         os.replace(backup_path, output)
+
+
+def _remove_selected_backup_after_commit(backup_path: Path) -> None:
+    try:
+        backup_path.unlink()
+    except OSError as exc:
+        print(
+            f"Warning: selected output installed, but old backup could not be removed: "
+            f"{backup_path} ({exc})",
+            file=sys.stderr,
+        )
 
 
 def _default_directory_mode() -> int:
@@ -1989,7 +2023,7 @@ def run_from_args(args: argparse.Namespace) -> SelectionResult:
         raise
     else:
         if selected_backup is not None:
-            selected_backup.unlink()
+            _remove_selected_backup_after_commit(selected_backup)
     show_top = max(1, int(getattr(args, "show_top", 1) or 1))
     if getattr(args, "json_output", False):
         ranking_order = result.details.get("ranking_order") or [scenario_front.index(result.candidate)]

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -6,6 +6,7 @@ import math
 import os
 import shutil
 import stat
+import sys
 import tempfile
 import textwrap
 from dataclasses import dataclass
@@ -73,6 +74,7 @@ class ParetoCandidate:
     path: Path
     member_path: Path
     member_name: str
+    source_bytes: bytes
     entry: Dict[str, Any]
     objectives: Dict[str, float]
     stats_flat: Dict[str, float]
@@ -653,6 +655,7 @@ def project_candidates_to_scenario(
                 path=candidate.path,
                 member_path=candidate.member_path,
                 member_name=candidate.member_name,
+                source_bytes=candidate.source_bytes,
                 entry=candidate.entry,
                 objectives=objectives,
                 stats_flat={f"{metric}_mean": value for metric, value in values.items()},
@@ -750,8 +753,8 @@ def load_candidates(path: str | os.PathLike[str]) -> tuple[Path, List[ParetoCand
     baseline_metrics: Optional[List[str]] = None
 
     for entry_path in json_paths:
-        with open(entry_path) as f:
-            entry = json.load(f)
+        source_bytes = entry_path.read_bytes()
+        entry = json.loads(source_bytes)
         if not isinstance(entry, Mapping):
             continue
         specs = extract_objective_specs(entry)
@@ -787,6 +790,7 @@ def load_candidates(path: str | os.PathLike[str]) -> tuple[Path, List[ParetoCand
                 path=entry_path.resolve(),
                 member_path=entry_path.parent.resolve() / entry_path.name,
                 member_name=entry_path.name,
+                source_bytes=source_bytes,
                 entry=entry,
                 objectives=objectives,
                 stats_flat=stats_flat,
@@ -1649,15 +1653,7 @@ def _validate_existing_filtered_output_dir(output_dir: Path, *, overwrite: bool)
         return
     if not output_dir.is_dir():
         raise NotADirectoryError(f"Filtered output path is not a directory: {output_dir}")
-    existing = sorted(
-        (path for path in output_dir.iterdir() if path.name != ".DS_Store"),
-        key=lambda path: path.name,
-    )
-    if existing and not overwrite:
-        raise FileExistsError(
-            f"Filtered output directory is not empty: {output_dir} "
-            "(use --overwrite to replace JSON outputs)"
-        )
+    existing = sorted(output_dir.iterdir(), key=lambda path: path.name)
     invalid = [
         path
         for path in existing
@@ -1668,6 +1664,11 @@ def _validate_existing_filtered_output_dir(output_dir: Path, *, overwrite: bool)
         raise FileExistsError(
             f"Refusing to overwrite filtered output directory containing non-JSON "
             f"entries: {preview}"
+        )
+    if existing and not overwrite:
+        raise FileExistsError(
+            f"Filtered output directory is not empty: {output_dir} "
+            "(use --overwrite to replace JSON outputs)"
         )
 
 
@@ -1701,6 +1702,10 @@ def _prepare_filtered_output_dir(
     return output_dir
 
 
+def _write_candidate_snapshot(candidate: ParetoCandidate, destination: Path) -> None:
+    destination.write_bytes(candidate.source_bytes)
+
+
 def _write_selected_output(
     candidate: ParetoCandidate,
     output: Path,
@@ -1716,7 +1721,7 @@ def _write_selected_output(
     staging_path = Path(staging_name)
     backup_path: Path | None = None
     try:
-        shutil.copy2(candidate.path, staging_path)
+        _write_candidate_snapshot(candidate, staging_path)
         if not overwrite:
             try:
                 os.link(staging_path, output)
@@ -1768,14 +1773,28 @@ def _remove_output_tree(path: Path) -> None:
         shutil.rmtree(path)
 
 
+def _copy_directory_metadata(source: Path, destination: Path) -> None:
+    source_stat = source.stat(follow_symlinks=False)
+    if hasattr(os, "chown"):
+        os.chown(
+            destination,
+            source_stat.st_uid,
+            source_stat.st_gid,
+            follow_symlinks=False,
+        )
+    shutil.copystat(source, destination, follow_symlinks=False)
+
+
 def _replace_filtered_output_dir(
     staging_dir: Path,
     output_dir: Path,
     *,
     overwrite: bool,
+    new_output_mode: int,
 ) -> None:
     _validate_existing_filtered_output_dir(output_dir, overwrite=overwrite)
     if not output_dir.exists():
+        staging_dir.chmod(new_output_mode)
         os.replace(staging_dir, output_dir)
         return
 
@@ -1787,12 +1806,20 @@ def _replace_filtered_output_dir(
     os.replace(output_dir, backup_dir)
     try:
         _validate_existing_filtered_output_dir(backup_dir, overwrite=overwrite)
+        _copy_directory_metadata(backup_dir, staging_dir)
         os.replace(staging_dir, output_dir)
     except Exception:
         os.replace(backup_dir, output_dir)
         raise
     else:
-        _remove_output_tree(backup_dir)
+        try:
+            _remove_output_tree(backup_dir)
+        except OSError as exc:
+            print(
+                f"Warning: filtered output installed, but old backup could not be removed: "
+                f"{backup_dir} ({exc})",
+                file=sys.stderr,
+            )
 
 
 def _write_filtered_outputs(
@@ -1808,11 +1835,7 @@ def _write_filtered_outputs(
     overwrite: bool,
 ) -> Path:
     output_dir.parent.mkdir(parents=True, exist_ok=True)
-    output_mode = (
-        stat.S_IMODE(output_dir.stat().st_mode)
-        if output_dir.exists()
-        else _default_directory_mode()
-    )
+    new_output_mode = _default_directory_mode()
     staging_dir = Path(
         tempfile.mkdtemp(prefix=f".{output_dir.name}.", suffix=".tmp", dir=output_dir.parent)
     )
@@ -1821,7 +1844,7 @@ def _write_filtered_outputs(
         for candidate in candidates:
             staged_destination = staging_dir / candidate.member_name
             final_destination = output_dir / candidate.member_name
-            shutil.copy2(candidate.path, staged_destination)
+            _write_candidate_snapshot(candidate, staged_destination)
             members.append(
                 {
                     "file": candidate.member_name,
@@ -1858,8 +1881,12 @@ def _write_filtered_outputs(
             json.dumps(_json_ready(manifest), indent=2, sort_keys=True) + "\n",
             encoding="utf-8",
         )
-        staging_dir.chmod(output_mode)
-        _replace_filtered_output_dir(staging_dir, output_dir, overwrite=overwrite)
+        _replace_filtered_output_dir(
+            staging_dir,
+            output_dir,
+            overwrite=overwrite,
+            new_output_mode=new_output_mode,
+        )
     finally:
         _remove_output_tree(staging_dir)
     return output_dir / FILTERED_SELECTION_MANIFEST

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -1816,7 +1816,8 @@ def _install_selected_without_overwrite(
             unsupported.add(errno.EOPNOTSUPP)
         if hasattr(errno, "ENOTSUP"):
             unsupported.add(errno.ENOTSUP)
-        if exc.errno not in unsupported:
+        windows_invalid_function = getattr(exc, "winerror", None) == 1
+        if exc.errno not in unsupported and not windows_invalid_function:
             raise
         flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
         if hasattr(os, "O_CLOEXEC"):

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -1721,6 +1721,7 @@ def _default_file_mode() -> int:
 
 def _copy_file_metadata(source: Path, destination: Path) -> None:
     source_stat = source.stat(follow_symlinks=False)
+    destination_stat = destination.stat(follow_symlinks=False)
     if hasattr(os, "chown"):
         os.chown(
             destination,
@@ -1729,6 +1730,11 @@ def _copy_file_metadata(source: Path, destination: Path) -> None:
             follow_symlinks=False,
         )
     shutil.copystat(source, destination, follow_symlinks=False)
+    os.utime(
+        destination,
+        ns=(destination_stat.st_atime_ns, destination_stat.st_mtime_ns),
+        follow_symlinks=False,
+    )
 
 
 def _warn_post_commit_cleanup_failure(
@@ -1756,6 +1762,7 @@ def _write_selected_output(
     staging_path = Path(staging_name)
     backup_path: Path | None = None
     staging_cleanup_attempted = False
+    installed_identity: tuple[int, int] | None = None
     try:
         _write_candidate_snapshot(candidate, staging_path)
         if not overwrite:
@@ -1802,7 +1809,24 @@ def _write_selected_output(
         return _SelectedOutputInstall(
             backup_path, installed_identity, candidate.source_bytes
         )
-    except BaseException:
+    except BaseException as exc:
+        if installed_identity is not None:
+            try:
+                output_stat = output.stat(follow_symlinks=False)
+            except FileNotFoundError:
+                output_stat = None
+            if output_stat is not None and (
+                output_stat.st_dev,
+                output_stat.st_ino,
+            ) == installed_identity:
+                print(
+                    f"Warning: selected output install committed before interruption; "
+                    f"keeping installed output: {output} ({exc})",
+                    file=sys.stderr,
+                )
+                return _SelectedOutputInstall(
+                    backup_path, installed_identity, candidate.source_bytes
+                )
         if backup_path is not None:
             backup_path.unlink(missing_ok=True)
         raise
@@ -1865,6 +1889,7 @@ def _remove_output_tree(path: Path) -> None:
 
 def _copy_directory_metadata(source: Path, destination: Path) -> None:
     source_stat = source.stat(follow_symlinks=False)
+    destination_stat = destination.stat(follow_symlinks=False)
     if hasattr(os, "chown"):
         os.chown(
             destination,
@@ -1873,6 +1898,11 @@ def _copy_directory_metadata(source: Path, destination: Path) -> None:
             follow_symlinks=False,
         )
     shutil.copystat(source, destination, follow_symlinks=False)
+    os.utime(
+        destination,
+        ns=(destination_stat.st_atime_ns, destination_stat.st_mtime_ns),
+        follow_symlinks=False,
+    )
 
 
 def _replace_filtered_output_dir(
@@ -1888,10 +1918,10 @@ def _replace_filtered_output_dir(
     )
     backup_dir = Path(backup_name)
     backup_dir.rmdir()
-    os.replace(output_dir, backup_dir)
     staging_stat = staging_dir.stat(follow_symlinks=False)
     staging_identity = staging_stat.st_dev, staging_stat.st_ino
     try:
+        os.replace(output_dir, backup_dir)
         _validate_existing_filtered_output_dir(backup_dir, overwrite=overwrite)
         _copy_directory_metadata(backup_dir, staging_dir)
         os.replace(staging_dir, output_dir)
@@ -1918,7 +1948,13 @@ def _replace_filtered_output_dir(
                     file=sys.stderr,
                 )
             return
-        os.replace(backup_dir, output_dir)
+        if backup_dir.exists():
+            if output_dir.exists():
+                raise RuntimeError(
+                    f"Filtered output changed concurrently; original backup retained at "
+                    f"{backup_dir}"
+                ) from exc
+            os.replace(backup_dir, output_dir)
         raise
     else:
         try:

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -785,7 +785,7 @@ def load_candidates(path: str | os.PathLike[str]) -> tuple[Path, List[ParetoCand
         candidates.append(
             ParetoCandidate(
                 path=entry_path.resolve(),
-                member_path=entry_path.absolute(),
+                member_path=Path(os.path.abspath(entry_path)),
                 member_name=entry_path.name,
                 entry=entry,
                 objectives=objectives,
@@ -1633,6 +1633,8 @@ def _prepare_selected_output(
     if output.exists():
         if output.is_dir():
             raise IsADirectoryError(f"Selected output path is a directory: {output}")
+        if not output.is_file():
+            raise ValueError(f"Selected output must be a regular file: {output}")
         if not overwrite:
             raise FileExistsError(
                 f"Selected output already exists: {output} (use --overwrite to replace it)"
@@ -1704,6 +1706,7 @@ def _write_selected_output(
     output: Path,
     *,
     keep_backup: bool,
+    overwrite: bool,
 ) -> Path | None:
     output.parent.mkdir(parents=True, exist_ok=True)
     file_descriptor, staging_name = tempfile.mkstemp(
@@ -1714,7 +1717,19 @@ def _write_selected_output(
     backup_path: Path | None = None
     try:
         shutil.copy2(candidate.path, staging_path)
-        if output.exists():
+        if not overwrite:
+            try:
+                os.link(staging_path, output)
+            except FileExistsError as exc:
+                raise FileExistsError(
+                    f"Selected output already exists: {output} "
+                    "(use --overwrite to replace it)"
+                ) from exc
+            staging_path.unlink()
+            return None
+        if output.exists() and keep_backup:
+            if not output.is_file():
+                raise ValueError(f"Selected output must be a regular file: {output}")
             backup_descriptor, backup_name = tempfile.mkstemp(
                 prefix=f".{output.name}.", suffix=".backup", dir=output.parent
             )
@@ -1747,6 +1762,12 @@ def _default_directory_mode() -> int:
     return 0o777 & ~current_umask
 
 
+def _remove_output_tree(path: Path) -> None:
+    if path.exists():
+        path.chmod(stat.S_IMODE(path.stat().st_mode) | stat.S_IWUSR | stat.S_IXUSR)
+        shutil.rmtree(path)
+
+
 def _replace_filtered_output_dir(
     staging_dir: Path,
     output_dir: Path,
@@ -1770,7 +1791,7 @@ def _replace_filtered_output_dir(
         os.replace(backup_dir, output_dir)
         raise
     else:
-        shutil.rmtree(backup_dir)
+        _remove_output_tree(backup_dir)
 
 
 def _write_filtered_outputs(
@@ -1795,7 +1816,6 @@ def _write_filtered_outputs(
         tempfile.mkdtemp(prefix=f".{output_dir.name}.", suffix=".tmp", dir=output_dir.parent)
     )
     try:
-        staging_dir.chmod(output_mode)
         members: List[Dict[str, Any]] = []
         for candidate in candidates:
             staged_destination = staging_dir / candidate.member_name
@@ -1837,10 +1857,10 @@ def _write_filtered_outputs(
             json.dumps(_json_ready(manifest), indent=2, sort_keys=True) + "\n",
             encoding="utf-8",
         )
+        staging_dir.chmod(output_mode)
         _replace_filtered_output_dir(staging_dir, output_dir, overwrite=overwrite)
     finally:
-        if staging_dir.exists():
-            shutil.rmtree(staging_dir)
+        _remove_output_tree(staging_dir)
     return output_dir / FILTERED_SELECTION_MANIFEST
 
 
@@ -1919,6 +1939,7 @@ def run_from_args(args: argparse.Namespace) -> SelectionResult:
             result.candidate,
             selected_output,
             keep_backup=filtered_output_dir is not None,
+            overwrite=overwrite,
         )
     filtered_manifest: Path | None = None
     try:

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -785,7 +785,7 @@ def load_candidates(path: str | os.PathLike[str]) -> tuple[Path, List[ParetoCand
         candidates.append(
             ParetoCandidate(
                 path=entry_path.resolve(),
-                member_path=Path(os.path.abspath(entry_path)),
+                member_path=entry_path.parent.resolve() / entry_path.name,
                 member_name=entry_path.name,
                 entry=entry,
                 objectives=objectives,
@@ -1786,6 +1786,7 @@ def _replace_filtered_output_dir(
     backup_dir.rmdir()
     os.replace(output_dir, backup_dir)
     try:
+        _validate_existing_filtered_output_dir(backup_dir, overwrite=overwrite)
         os.replace(staging_dir, output_dir)
     except Exception:
         os.replace(backup_dir, output_dir)

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import os
 import shutil
+import stat
 from pathlib import Path
 
 import pytest
@@ -989,6 +990,80 @@ def test_filtered_overwrite_preserves_previous_set_when_staging_fails(
     assert json.loads(stale.read_text()) == {"stale": True}
     assert sorted(path.name for path in output_dir.iterdir()) == ["stale.json"]
     assert not [path for path in tmp_path.iterdir() if path.name.startswith(".filtered.")]
+
+
+@pytest.mark.parametrize("selected_exists", [False, True])
+def test_combined_outputs_restore_selected_when_filtered_staging_fails(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+    selected_exists: bool,
+):
+    selected_output = tmp_path / "selected.json"
+    if selected_exists:
+        selected_output.write_text('{"selected": "old"}\n')
+    filtered_output = tmp_path / "filtered"
+    filtered_output.mkdir()
+    stale = filtered_output / "stale.json"
+    stale.write_text('{"filtered": "old"}\n')
+    real_copy2 = shutil.copy2
+
+    def fail_during_filtered_staging(source, destination, *args, **kwargs):
+        destination = Path(destination)
+        if destination.name == "b_extreme.json" and destination.parent.name.startswith(
+            ".filtered."
+        ):
+            raise OSError("simulated filtered copy failure")
+        return real_copy2(source, destination, *args, **kwargs)
+
+    monkeypatch.setattr("pareto_explorer.shutil.copy2", fail_during_filtered_staging)
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_output),
+            "--overwrite",
+        ]
+    )
+
+    with pytest.raises(OSError, match="simulated filtered copy failure"):
+        run_from_args(args)
+
+    if selected_exists:
+        assert json.loads(selected_output.read_text()) == {"selected": "old"}
+    else:
+        assert not selected_output.exists()
+    assert json.loads(stale.read_text()) == {"filtered": "old"}
+    assert sorted(path.name for path in filtered_output.iterdir()) == ["stale.json"]
+    assert not [path for path in tmp_path.iterdir() if ".backup" in path.name]
+
+
+@pytest.mark.parametrize("output_exists", [False, True])
+def test_filtered_output_directory_uses_destination_permissions(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    capsys,
+    output_exists: bool,
+):
+    output_dir = tmp_path / "filtered"
+    if output_exists:
+        output_dir.mkdir()
+        output_dir.chmod(0o750)
+        (output_dir / "stale.json").write_text('{"stale": true}\n')
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-f", str(output_dir), "--overwrite"]
+    )
+
+    previous_umask = os.umask(0o027)
+    try:
+        run_from_args(args)
+    finally:
+        os.umask(previous_umask)
+    capsys.readouterr()
+
+    assert stat.S_IMODE(output_dir.stat().st_mode) == 0o750
 
 
 def test_save_filtered_refuses_directory_containing_resolved_source_member(

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -1040,6 +1040,48 @@ def test_selected_output_does_not_overwrite_racing_destination_without_permissio
     assert json.loads(selected_output.read_text()) == {"racing": True}
 
 
+def test_selected_output_continues_when_post_link_staging_cleanup_fails(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    selected_output = tmp_path / "selected.json"
+    filtered_output = tmp_path / "filtered"
+    real_unlink = Path.unlink
+
+    def fail_selected_staging_cleanup(path: Path, *args, **kwargs):
+        if path.name.startswith(".selected.json.") and path.suffix == ".tmp":
+            raise OSError("simulated selected staging cleanup failure")
+        return real_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_selected_staging_cleanup)
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_output),
+        ]
+    )
+
+    result = run_from_args(args)
+
+    assert selected_output.read_bytes() == result.candidate.source_bytes
+    assert (filtered_output / "selection.json").exists()
+    assert "selected output installed, but temporary path could not be removed" in (
+        capsys.readouterr().err
+    )
+    staging_paths = [
+        path
+        for path in tmp_path.iterdir()
+        if path.name.startswith(".selected.json.") and path.suffix == ".tmp"
+    ]
+    assert len(staging_paths) == 1
+    real_unlink(staging_paths[0])
+
+
 def test_filtered_overwrite_refuses_non_json_entries(
     sample_pareto_dir: Path,
     tmp_path: Path,
@@ -1155,8 +1197,10 @@ def test_combined_outputs_restore_selected_when_filtered_staging_fails(
     selected_exists: bool,
 ):
     selected_output = tmp_path / "selected.json"
+    original_inode = None
     if selected_exists:
         selected_output.write_text('{"selected": "old"}\n')
+        original_inode = selected_output.stat().st_ino
     filtered_output = tmp_path / "filtered"
     filtered_output.mkdir()
     stale = filtered_output / "stale.json"
@@ -1189,8 +1233,52 @@ def test_combined_outputs_restore_selected_when_filtered_staging_fails(
 
     if selected_exists:
         assert json.loads(selected_output.read_text()) == {"selected": "old"}
+        assert selected_output.stat().st_ino == original_inode
     else:
         assert not selected_output.exists()
+    assert json.loads(stale.read_text()) == {"filtered": "old"}
+    assert sorted(path.name for path in filtered_output.iterdir()) == ["stale.json"]
+    assert not [path for path in tmp_path.iterdir() if ".backup" in path.name]
+
+
+def test_combined_outputs_restore_both_destinations_when_interrupted(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"selected": "old"}\n')
+    selected_inode = selected_output.stat().st_ino
+    filtered_output = tmp_path / "filtered"
+    filtered_output.mkdir()
+    stale = filtered_output / "stale.json"
+    stale.write_text('{"filtered": "old"}\n')
+    real_copy_metadata = pareto_explorer._copy_directory_metadata
+
+    def interrupt_after_filtered_move(source: Path, destination: Path):
+        if ".backup-" in source.name:
+            raise KeyboardInterrupt()
+        real_copy_metadata(source, destination)
+
+    monkeypatch.setattr(
+        pareto_explorer, "_copy_directory_metadata", interrupt_after_filtered_move
+    )
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_output),
+            "--overwrite",
+        ]
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        run_from_args(args)
+
+    assert json.loads(selected_output.read_text()) == {"selected": "old"}
+    assert selected_output.stat().st_ino == selected_inode
     assert json.loads(stale.read_text()) == {"filtered": "old"}
     assert sorted(path.name for path in filtered_output.iterdir()) == ["stale.json"]
     assert not [path for path in tmp_path.iterdir() if ".backup" in path.name]
@@ -1247,10 +1335,14 @@ def test_combined_outputs_warn_when_selected_backup_cleanup_fails(
     selected_output.write_text('{"selected": "old"}\n')
     filtered_output = tmp_path / "filtered"
     real_unlink = Path.unlink
+    backup_unlinks = 0
 
     def fail_selected_backup_cleanup(path: Path, *args, **kwargs):
+        nonlocal backup_unlinks
         if path.suffix == ".backup":
-            raise OSError("simulated selected backup cleanup failure")
+            backup_unlinks += 1
+            if backup_unlinks == 2:
+                raise OSError("simulated selected backup cleanup failure")
         return real_unlink(path, *args, **kwargs)
 
     monkeypatch.setattr(Path, "unlink", fail_selected_backup_cleanup)
@@ -1269,7 +1361,7 @@ def test_combined_outputs_warn_when_selected_backup_cleanup_fails(
 
     assert selected_output.read_bytes() == result.candidate.source_bytes
     assert (filtered_output / "selection.json").exists()
-    assert "selected output installed, but old backup could not be removed" in (
+    assert "selected output installed, but temporary path could not be removed" in (
         capsys.readouterr().err
     )
     backups = [path for path in tmp_path.iterdir() if path.suffix == ".backup"]
@@ -1330,6 +1422,75 @@ def test_filtered_output_preserves_existing_directory_metadata(
     assert (after.st_uid, after.st_gid) == (before.st_uid, before.st_gid)
     if xattr_supported:
         assert os.getxattr(output_dir, xattr_name) == b"preserve"
+
+
+def test_filtered_output_applies_directory_metadata_before_writing_members(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    output_dir = tmp_path / "filtered"
+    output_dir.mkdir()
+    (output_dir / "stale.json").write_text('{"stale": true}\n')
+    real_copy_metadata = pareto_explorer._copy_directory_metadata
+    real_write_snapshot = pareto_explorer._write_candidate_snapshot
+    metadata_ready = False
+
+    def track_metadata(source: Path, destination: Path):
+        nonlocal metadata_ready
+        real_copy_metadata(source, destination)
+        if source == output_dir and destination.name.endswith(".tmp"):
+            metadata_ready = True
+
+    def require_metadata_before_write(candidate, destination):
+        assert metadata_ready
+        real_write_snapshot(candidate, destination)
+
+    monkeypatch.setattr(pareto_explorer, "_copy_directory_metadata", track_metadata)
+    monkeypatch.setattr(
+        pareto_explorer, "_write_candidate_snapshot", require_metadata_before_write
+    )
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-f", str(output_dir), "--overwrite"]
+    )
+
+    run_from_args(args)
+    capsys.readouterr()
+
+    assert metadata_ready
+    assert (output_dir / "selection.json").exists()
+
+
+def test_filtered_output_rechecks_directory_created_during_reservation(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    output_dir = tmp_path / "filtered"
+    real_mkdir = Path.mkdir
+    raced = False
+
+    def create_racing_destination(path: Path, *args, **kwargs):
+        nonlocal raced
+        if path == output_dir and not raced:
+            raced = True
+            os.mkdir(path, 0o750)
+            path.chmod(0o750)
+            raise FileExistsError(path)
+        return real_mkdir(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", create_racing_destination)
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-f", str(output_dir), "--overwrite"]
+    )
+
+    run_from_args(args)
+    capsys.readouterr()
+
+    assert raced
+    assert stat.S_IMODE(output_dir.stat().st_mode) == 0o750
 
 
 def test_filtered_output_builds_before_applying_read_only_destination_mode(

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 from pathlib import Path
 
 import pytest
@@ -837,6 +838,15 @@ def test_run_from_args_saves_filtered_members_and_manifest(
     assert manifest["loaded_count"] == 4
     assert manifest["retained_count"] == 2
     assert manifest["scenario"] is None
+    assert manifest["method"] == "ideal"
+    assert manifest["objectives"] == ["metric_a", "metric_b", "metric_c"]
+    assert manifest["weights"] == {
+        "metric_a": pytest.approx(1 / 3),
+        "metric_b": pytest.approx(1 / 3),
+        "metric_c": pytest.approx(1 / 3),
+    }
+    assert manifest["targets"] == {}
+    assert manifest["priority"] == []
     assert manifest["selected_member"]["file"] == "balanced.json"
     assert [member["file"] for member in manifest["members"]] == [
         "a_extreme.json",
@@ -949,6 +959,64 @@ def test_filtered_overwrite_refuses_non_json_entries(
     assert note.read_text() == "keep me\n"
 
 
+def test_filtered_overwrite_preserves_previous_set_when_staging_fails(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    output_dir = tmp_path / "filtered"
+    output_dir.mkdir()
+    stale = output_dir / "stale.json"
+    stale.write_text('{"stale": true}\n')
+    real_copy2 = shutil.copy2
+    copies = 0
+
+    def fail_on_second_copy(source, destination, *args, **kwargs):
+        nonlocal copies
+        copies += 1
+        if copies == 2:
+            raise OSError("simulated copy failure")
+        return real_copy2(source, destination, *args, **kwargs)
+
+    monkeypatch.setattr("pareto_explorer.shutil.copy2", fail_on_second_copy)
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-f", str(output_dir), "--overwrite"]
+    )
+
+    with pytest.raises(OSError, match="simulated copy failure"):
+        run_from_args(args)
+
+    assert json.loads(stale.read_text()) == {"stale": True}
+    assert sorted(path.name for path in output_dir.iterdir()) == ["stale.json"]
+    assert not [path for path in tmp_path.iterdir() if path.name.startswith(".filtered.")]
+
+
+def test_save_filtered_refuses_directory_containing_resolved_source_member(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+):
+    output_dir = tmp_path / "filtered"
+    output_dir.mkdir()
+    resolved_source = output_dir / "linked.json"
+    resolved_source.write_bytes((sample_pareto_dir / "balanced.json").read_bytes())
+    (sample_pareto_dir / "linked.json").symlink_to(resolved_source)
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-l",
+            "metric_a>0.8",
+            "-f",
+            str(output_dir),
+            "--overwrite",
+        ]
+    )
+
+    with pytest.raises(ValueError, match="resolved source Pareto member"):
+        run_from_args(args)
+
+    assert resolved_source.exists()
+
+
 def test_save_filtered_refuses_manifest_filename_collision(
     sample_pareto_dir: Path,
     tmp_path: Path,
@@ -984,6 +1052,109 @@ def test_save_outputs_refuse_source_pareto_directory(
     )
     with pytest.raises(ValueError, match="inside the source Pareto directory"):
         run_from_args(filtered_args)
+
+
+def test_save_outputs_refuse_both_overlap_directions(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+):
+    filtered_parent = tmp_path / "filtered"
+    selected_inside_args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-s",
+            str(filtered_parent / "selected.json"),
+            "-f",
+            str(filtered_parent),
+        ]
+    )
+    with pytest.raises(ValueError, match="must not overlap"):
+        run_from_args(selected_inside_args)
+
+    selected_parent = tmp_path / "selected.json"
+    filtered_inside_args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-s",
+            str(selected_parent),
+            "-f",
+            str(selected_parent / "filtered"),
+        ]
+    )
+    with pytest.raises(ValueError, match="must not overlap"):
+        run_from_args(filtered_inside_args)
+
+    assert not filtered_parent.exists()
+    assert not selected_parent.exists()
+
+
+def test_filtered_manifest_records_normalized_decision_inputs(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    capsys,
+):
+    utility_dir = tmp_path / "utility"
+    utility_args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-m",
+            "utility",
+            "-o",
+            "metric_b,metric_a",
+            "--weight",
+            "metric_b=5",
+            "-f",
+            str(utility_dir),
+        ]
+    )
+    run_from_args(utility_args)
+    capsys.readouterr()
+    utility_manifest = json.loads((utility_dir / "selection.json").read_text())
+    assert utility_manifest["method"] == "utility"
+    assert utility_manifest["objectives"] == ["metric_b", "metric_a"]
+    assert utility_manifest["weights"] == {
+        "metric_a": pytest.approx(1 / 6),
+        "metric_b": pytest.approx(5 / 6),
+    }
+    assert utility_manifest["targets"] == {}
+    assert utility_manifest["priority"] == []
+
+    reference_dir = tmp_path / "reference"
+    reference_args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-m",
+            "reference",
+            "--target",
+            "metric_a=0.75",
+            "-f",
+            str(reference_dir),
+        ]
+    )
+    run_from_args(reference_args)
+    capsys.readouterr()
+    reference_manifest = json.loads((reference_dir / "selection.json").read_text())
+    assert reference_manifest["method"] == "reference"
+    assert reference_manifest["targets"] == {"metric_a": 0.75}
+
+    priority_dir = tmp_path / "priority"
+    priority_args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-m",
+            "lexicographic",
+            "--priority",
+            "metric_c,metric_a",
+            "-f",
+            str(priority_dir),
+        ]
+    )
+    run_from_args(priority_args)
+    capsys.readouterr()
+    priority_manifest = json.loads((priority_dir / "selection.json").read_text())
+    assert priority_manifest["method"] == "lexicographic"
+    assert priority_manifest["objectives"] == ["metric_c", "metric_a"]
+    assert priority_manifest["priority"] == ["metric_c", "metric_a"]
 
 
 def test_save_filtered_with_scenario_exports_post_limit_set(

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -1017,6 +1017,42 @@ def test_save_filtered_refuses_directory_containing_resolved_source_member(
     assert resolved_source.exists()
 
 
+def test_save_filtered_preserves_symlink_member_name(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    capsys,
+):
+    external_dir = tmp_path / "external"
+    external_dir.mkdir()
+    resolved_source = external_dir / "balanced.json"
+    resolved_source.write_bytes((sample_pareto_dir / "balanced.json").read_bytes())
+    (sample_pareto_dir / "aliased_member.json").symlink_to(resolved_source)
+    output_dir = tmp_path / "filtered"
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-f", str(output_dir)]
+    )
+
+    run_from_args(args)
+    capsys.readouterr()
+
+    assert (output_dir / "aliased_member.json").read_bytes() == resolved_source.read_bytes()
+    assert sorted(path.name for path in output_dir.iterdir()) == [
+        "a_extreme.json",
+        "aliased_member.json",
+        "b_extreme.json",
+        "balanced.json",
+        "c_extreme.json",
+        "selection.json",
+    ]
+    manifest = json.loads((output_dir / "selection.json").read_text())
+    member = next(
+        entry for entry in manifest["members"] if entry["file"] == "aliased_member.json"
+    )
+    assert member["hash"] == "aliased_member"
+    assert member["source_path"] == str(resolved_source.resolve())
+    assert member["output_path"] == str((output_dir / "aliased_member.json").resolve())
+
+
 def test_save_filtered_refuses_manifest_filename_collision(
     sample_pareto_dir: Path,
     tmp_path: Path,
@@ -1052,6 +1088,34 @@ def test_save_outputs_refuse_source_pareto_directory(
     )
     with pytest.raises(ValueError, match="inside the source Pareto directory"):
         run_from_args(filtered_args)
+
+
+def test_single_file_input_allows_sibling_outputs(
+    sample_pareto_dir: Path,
+    capsys,
+):
+    source = sample_pareto_dir / "balanced.json"
+    selected_output = sample_pareto_dir / "promoted.json"
+    filtered_output = sample_pareto_dir / "single_filtered"
+    args = build_parser().parse_args(
+        [
+            str(source),
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_output),
+        ]
+    )
+
+    result = run_from_args(args)
+    capsys.readouterr()
+
+    assert result.candidate.path == source.resolve()
+    assert selected_output.read_bytes() == source.read_bytes()
+    assert sorted(path.name for path in filtered_output.iterdir()) == [
+        "balanced.json",
+        "selection.json",
+    ]
 
 
 def test_save_outputs_refuse_both_overlap_directions(

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -4,6 +4,7 @@ import argparse
 import errno
 import json
 import os
+import shutil
 import stat
 import subprocess
 import sys
@@ -1184,6 +1185,40 @@ def test_selected_overwrite_detects_replacement_before_commit(
     assert not [path for path in tmp_path.iterdir() if path.suffix == ".backup"]
 
 
+def test_selected_overwrite_detects_in_place_edit_before_commit(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"selected": "old"}\n')
+    original_inode = selected_output.stat().st_ino
+    real_replace = os.replace
+    edited = False
+
+    def edit_destination_before_move(source, destination):
+        nonlocal edited
+        source = Path(source)
+        destination = Path(destination)
+        if source == selected_output and destination.suffix == ".backup" and not edited:
+            selected_output.write_text('{"selected": "newer"}\n')
+            edited = True
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(os, "replace", edit_destination_before_move)
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-s", str(selected_output), "--overwrite"]
+    )
+
+    with pytest.raises(RuntimeError, match="changed concurrently; refusing install"):
+        run_from_args(args)
+
+    assert edited
+    assert selected_output.stat().st_ino == original_inode
+    assert json.loads(selected_output.read_text()) == {"selected": "newer"}
+    assert not [path for path in tmp_path.iterdir() if path.suffix == ".backup"]
+
+
 def test_selected_output_supports_name_max_destination(
     sample_pareto_dir: Path,
     tmp_path: Path,
@@ -1404,6 +1439,48 @@ def test_filtered_overwrite_revalidates_contents_after_move_aside(
     ]
 
 
+def test_filtered_overwrite_rejects_concurrent_directory_replacement(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    output_dir = tmp_path / "filtered"
+    output_dir.mkdir()
+    stale = output_dir / "stale.json"
+    stale.write_text('{"stale": true}\n')
+    detached_old = tmp_path / "detached-old"
+    real_replace = os.replace
+    replaced = False
+
+    def replace_destination_before_move_aside(source, destination):
+        nonlocal replaced
+        source = Path(source)
+        destination = Path(destination)
+        if (
+            source == output_dir
+            and destination.name.startswith(pareto_explorer.FILTERED_BACKUP_PREFIX)
+            and not replaced
+        ):
+            real_replace(output_dir, detached_old)
+            output_dir.mkdir()
+            (output_dir / "newer.json").write_text('{"newer": true}\n')
+            replaced = True
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(os, "replace", replace_destination_before_move_aside)
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-f", str(output_dir), "--overwrite"]
+    )
+
+    with pytest.raises(RuntimeError, match="changed concurrently; refusing install"):
+        run_from_args(args)
+
+    assert replaced
+    assert json.loads((output_dir / "newer.json").read_text()) == {"newer": True}
+    assert sorted(path.name for path in output_dir.iterdir()) == ["newer.json"]
+    assert json.loads((detached_old / "stale.json").read_text()) == {"stale": True}
+
+
 def test_filtered_overwrite_preserves_previous_set_when_staging_fails(
     sample_pareto_dir: Path,
     tmp_path: Path,
@@ -1536,6 +1613,52 @@ def test_combined_outputs_restore_both_destinations_when_interrupted(
     with pytest.raises(KeyboardInterrupt):
         run_from_args(args)
 
+    assert json.loads(selected_output.read_text()) == {"selected": "old"}
+    assert selected_output.stat().st_ino == selected_inode
+    assert json.loads(stale.read_text()) == {"filtered": "old"}
+    assert sorted(path.name for path in filtered_output.iterdir()) == ["stale.json"]
+    assert not [path for path in tmp_path.iterdir() if ".backup" in path.name]
+
+
+def test_combined_outputs_restore_selected_when_install_return_is_interrupted(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"selected": "old"}\n')
+    selected_inode = selected_output.stat().st_ino
+    filtered_output = tmp_path / "filtered"
+    filtered_output.mkdir()
+    stale = filtered_output / "stale.json"
+    stale.write_text('{"filtered": "old"}\n')
+    real_write_selected = pareto_explorer._write_selected_output
+    interrupted = False
+
+    def interrupt_after_selected_return(*args, **kwargs):
+        nonlocal interrupted
+        real_write_selected(*args, **kwargs)
+        interrupted = True
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr(
+        pareto_explorer, "_write_selected_output", interrupt_after_selected_return
+    )
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_output),
+            "--overwrite",
+        ]
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        run_from_args(args)
+
+    assert interrupted
     assert json.loads(selected_output.read_text()) == {"selected": "old"}
     assert selected_output.stat().st_ino == selected_inode
     assert json.loads(stale.read_text()) == {"filtered": "old"}
@@ -1682,30 +1805,34 @@ def test_combined_outputs_keep_committed_pair_when_filtered_rename_is_interrupte
     assert not [path for path in tmp_path.iterdir() if ".backup" in path.name]
 
 
-def test_combined_outputs_keep_committed_pair_when_filtered_staging_cleanup_is_interrupted(
+def test_combined_outputs_do_not_delete_reused_filtered_staging_path_after_commit(
     sample_pareto_dir: Path,
     tmp_path: Path,
     monkeypatch,
-    capsys,
 ):
     selected_output = tmp_path / "selected.json"
     selected_output.write_text('{"selected": "old"}\n')
     filtered_output = tmp_path / "filtered"
     filtered_output.mkdir()
     (filtered_output / "stale.json").write_text('{"filtered": "old"}\n')
-    real_remove = pareto_explorer._remove_output_tree
-    interrupted = False
+    real_replace = os.replace
+    reused_staging: Path | None = None
 
-    def interrupt_staging_cleanup(path: Path):
-        nonlocal interrupted
-        if path.name.startswith(pareto_explorer.FILTERED_STAGING_PREFIX):
-            interrupted = True
-            raise KeyboardInterrupt()
-        return real_remove(path)
+    def reuse_staging_path_after_commit(source, destination):
+        nonlocal reused_staging
+        source = Path(source)
+        destination = Path(destination)
+        result = real_replace(source, destination)
+        if (
+            source.name.startswith(pareto_explorer.FILTERED_STAGING_PREFIX)
+            and destination == filtered_output
+        ):
+            source.mkdir()
+            (source / "foreign.txt").write_text("preserve me\n")
+            reused_staging = source
+        return result
 
-    monkeypatch.setattr(
-        pareto_explorer, "_remove_output_tree", interrupt_staging_cleanup
-    )
+    monkeypatch.setattr(os, "replace", reuse_staging_path_after_commit)
     args = build_parser().parse_args(
         [
             str(sample_pareto_dir),
@@ -1719,13 +1846,12 @@ def test_combined_outputs_keep_committed_pair_when_filtered_staging_cleanup_is_i
 
     result = run_from_args(args)
 
-    assert interrupted
+    assert reused_staging is not None
     assert selected_output.read_bytes() == result.candidate.source_bytes
     assert not (filtered_output / "stale.json").exists()
     assert (filtered_output / "selection.json").exists()
-    assert "filtered output installed, but temporary path could not be removed" in (
-        capsys.readouterr().err
-    )
+    assert (reused_staging / "foreign.txt").read_text() == "preserve me\n"
+    shutil.rmtree(reused_staging)
 
 
 def test_combined_outputs_keep_committed_pair_when_selected_rename_is_interrupted(

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -719,6 +719,7 @@ def test_run_from_args_prints_summary(sample_pareto_dir: Path, capsys):
     assert "Target utilities:" not in captured
     assert "Top candidates:" in captured
     assert result.candidate.path.stem == "balanced"
+    assert result.candidate.source_bytes is None
 
 
 def test_run_from_args_uses_latest_pareto_dir_when_path_omitted(tmp_path: Path, monkeypatch, capsys):
@@ -1058,16 +1059,15 @@ def test_selected_staging_uses_normal_exclusive_file_creation(
     capsys,
 ):
     selected_output = tmp_path / "selected.json"
-    real_open = os.open
+    real_open = Path.open
     observed = []
 
-    def track_open(path, flags, mode=0o777, *args, **kwargs):
-        path = Path(path)
+    def track_open(path: Path, *args, **kwargs):
         if path.name.startswith(pareto_explorer.SELECTED_STAGING_PREFIX):
-            observed.append((flags, mode))
-        return real_open(path, flags, mode, *args, **kwargs)
+            observed.append(args[0] if args else kwargs.get("mode"))
+        return real_open(path, *args, **kwargs)
 
-    monkeypatch.setattr(os, "open", track_open)
+    monkeypatch.setattr(Path, "open", track_open)
     args = build_parser().parse_args(
         [str(sample_pareto_dir), "-s", str(selected_output)]
     )
@@ -1076,10 +1076,42 @@ def test_selected_staging_uses_normal_exclusive_file_creation(
     capsys.readouterr()
 
     assert observed
-    flags, mode = observed[0]
-    assert flags & os.O_CREAT
-    assert flags & os.O_EXCL
-    assert mode == 0o666
+    assert observed[0] == "xb"
+
+
+def test_selected_staging_creation_cleans_up_when_interrupted(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    selected_output = tmp_path / "selected.json"
+    real_open = Path.open
+    interrupted = False
+
+    def interrupt_after_staging_create(path: Path, *args, **kwargs):
+        nonlocal interrupted
+        staging_file = real_open(path, *args, **kwargs)
+        if path.name.startswith(pareto_explorer.SELECTED_STAGING_PREFIX):
+            interrupted = True
+            staging_file.close()
+            raise KeyboardInterrupt()
+        return staging_file
+
+    monkeypatch.setattr(Path, "open", interrupt_after_staging_create)
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-s", str(selected_output)]
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        run_from_args(args)
+
+    assert interrupted
+    assert not selected_output.exists()
+    assert not [
+        path
+        for path in tmp_path.iterdir()
+        if path.name.startswith(pareto_explorer.SELECTED_STAGING_PREFIX)
+    ]
 
 
 @pytest.mark.parametrize(
@@ -1307,6 +1339,7 @@ def test_selected_output_does_not_overwrite_racing_destination_without_permissio
 ):
     selected_output = tmp_path / "selected.json"
     destination_created = False
+    real_write_snapshot = pareto_explorer._write_candidate_snapshot_fd
 
     def create_destination_during_staging(candidate, destination, file_descriptor):
         nonlocal destination_created
@@ -1314,8 +1347,7 @@ def test_selected_output_does_not_overwrite_racing_destination_without_permissio
         if not destination_created and destination.suffix == ".tmp":
             selected_output.write_text('{"racing": true}\n')
             destination_created = True
-        with os.fdopen(file_descriptor, "wb") as destination_file:
-            destination_file.write(candidate.source_bytes)
+        real_write_snapshot(candidate, destination, file_descriptor)
 
     monkeypatch.setattr(
         "pareto_explorer._write_candidate_snapshot_fd",
@@ -1735,6 +1767,47 @@ def test_combined_outputs_cleanup_filtered_reservation_when_return_is_interrupte
     monkeypatch.setattr(
         pareto_explorer, "_ensure_filtered_output_dir", interrupt_after_reservation
     )
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_output),
+            "--overwrite",
+        ]
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        run_from_args(args)
+
+    assert interrupted
+    assert json.loads(selected_output.read_text()) == {"selected": "old"}
+    assert selected_output.stat().st_ino == selected_inode
+    assert not filtered_output.exists()
+
+
+def test_combined_outputs_record_filtered_reservation_at_mkdir_boundary(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"selected": "old"}\n')
+    selected_inode = selected_output.stat().st_ino
+    filtered_output = tmp_path / "filtered"
+    real_mkdir = Path.mkdir
+    interrupted = False
+
+    def interrupt_after_filtered_mkdir(path: Path, *args, **kwargs):
+        nonlocal interrupted
+        result = real_mkdir(path, *args, **kwargs)
+        if path == filtered_output and not interrupted:
+            interrupted = True
+            raise KeyboardInterrupt()
+        return result
+
+    monkeypatch.setattr(Path, "mkdir", interrupt_after_filtered_mkdir)
     args = build_parser().parse_args(
         [
             str(sample_pareto_dir),

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -1326,6 +1326,97 @@ def test_combined_outputs_refuse_rollback_over_newer_selected_file(
     backups[0].unlink()
 
 
+def test_combined_outputs_refuse_rollback_over_in_place_selected_edit(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"selected": "old"}\n')
+    filtered_output = tmp_path / "filtered"
+
+    def edit_selected_then_fail(candidate, destination):
+        destination = Path(destination)
+        if destination.parent.name.startswith(".filtered."):
+            selected_output.write_text('{"selected": "newer"}\n')
+            raise OSError("simulated filtered copy failure")
+        destination.write_bytes(candidate.source_bytes)
+
+    monkeypatch.setattr(
+        pareto_explorer, "_write_candidate_snapshot", edit_selected_then_fail
+    )
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_output),
+            "--overwrite",
+        ]
+    )
+
+    with pytest.raises(RuntimeError, match="changed concurrently; refusing rollback"):
+        run_from_args(args)
+
+    assert json.loads(selected_output.read_text()) == {"selected": "newer"}
+    backups = [path for path in tmp_path.iterdir() if path.suffix == ".backup"]
+    assert len(backups) == 1
+    assert json.loads(backups[0].read_text()) == {"selected": "old"}
+    backups[0].unlink()
+
+
+def test_combined_outputs_keep_committed_pair_when_filtered_rename_is_interrupted(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"selected": "old"}\n')
+    filtered_output = tmp_path / "filtered"
+    filtered_output.mkdir()
+    (filtered_output / "stale.json").write_text('{"filtered": "old"}\n')
+    real_replace = os.replace
+    interrupted = False
+
+    def interrupt_after_filtered_commit(source, destination):
+        nonlocal interrupted
+        source = Path(source)
+        destination = Path(destination)
+        result = real_replace(source, destination)
+        if (
+            not interrupted
+            and source.name.startswith(".filtered.")
+            and source.name.endswith(".tmp")
+            and destination == filtered_output
+        ):
+            interrupted = True
+            raise KeyboardInterrupt()
+        return result
+
+    monkeypatch.setattr(os, "replace", interrupt_after_filtered_commit)
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_output),
+            "--overwrite",
+        ]
+    )
+
+    result = run_from_args(args)
+
+    assert interrupted
+    assert selected_output.read_bytes() == result.candidate.source_bytes
+    assert not (filtered_output / "stale.json").exists()
+    assert (filtered_output / "selection.json").exists()
+    assert "install committed before interruption" in capsys.readouterr().err
+    assert not [path for path in tmp_path.iterdir() if ".backup" in path.name]
+
+
 def test_combined_outputs_remain_consistent_when_backup_cleanup_fails(
     sample_pareto_dir: Path,
     tmp_path: Path,

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -996,6 +996,25 @@ def test_selected_output_preserves_existing_file_metadata(
         assert os.getxattr(selected_output, xattr_name) == b"preserve"
 
 
+def test_selected_output_overwrite_uses_fresh_modification_time(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    capsys,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"old": true}\n')
+    old_timestamp_ns = 946684800_000_000_000
+    os.utime(selected_output, ns=(old_timestamp_ns, old_timestamp_ns))
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-s", str(selected_output), "--overwrite"]
+    )
+
+    run_from_args(args)
+    capsys.readouterr()
+
+    assert selected_output.stat().st_mtime_ns > old_timestamp_ns
+
+
 @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="requires POSIX FIFO support")
 def test_selected_output_refuses_existing_special_node(
     sample_pareto_dir: Path,
@@ -1417,6 +1436,108 @@ def test_combined_outputs_keep_committed_pair_when_filtered_rename_is_interrupte
     assert not [path for path in tmp_path.iterdir() if ".backup" in path.name]
 
 
+def test_combined_outputs_keep_committed_pair_when_selected_rename_is_interrupted(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"selected": "old"}\n')
+    filtered_output = tmp_path / "filtered"
+    real_replace = os.replace
+    interrupted = False
+
+    def interrupt_after_selected_commit(source, destination):
+        nonlocal interrupted
+        source = Path(source)
+        destination = Path(destination)
+        result = real_replace(source, destination)
+        if (
+            not interrupted
+            and source.name.startswith(".selected.json.")
+            and source.name.endswith(".tmp")
+            and destination == selected_output
+        ):
+            interrupted = True
+            raise KeyboardInterrupt()
+        return result
+
+    monkeypatch.setattr(os, "replace", interrupt_after_selected_commit)
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_output),
+            "--overwrite",
+        ]
+    )
+
+    result = run_from_args(args)
+
+    assert interrupted
+    assert selected_output.read_bytes() == result.candidate.source_bytes
+    assert (filtered_output / "selection.json").exists()
+    assert "selected output install committed before interruption" in (
+        capsys.readouterr().err
+    )
+    assert not [path for path in tmp_path.iterdir() if ".backup" in path.name]
+
+
+def test_combined_outputs_restore_both_when_filtered_move_aside_is_interrupted(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"selected": "old"}\n')
+    selected_inode = selected_output.stat().st_ino
+    filtered_output = tmp_path / "filtered"
+    filtered_output.mkdir()
+    stale = filtered_output / "stale.json"
+    stale.write_text('{"filtered": "old"}\n')
+    real_replace = os.replace
+    interrupted = False
+
+    def interrupt_after_filtered_move_aside(source, destination):
+        nonlocal interrupted
+        source = Path(source)
+        destination = Path(destination)
+        result = real_replace(source, destination)
+        if (
+            not interrupted
+            and source == filtered_output
+            and ".backup-" in destination.name
+        ):
+            interrupted = True
+            raise KeyboardInterrupt()
+        return result
+
+    monkeypatch.setattr(os, "replace", interrupt_after_filtered_move_aside)
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_output),
+            "--overwrite",
+        ]
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        run_from_args(args)
+
+    assert interrupted
+    assert json.loads(selected_output.read_text()) == {"selected": "old"}
+    assert selected_output.stat().st_ino == selected_inode
+    assert json.loads(stale.read_text()) == {"filtered": "old"}
+    assert sorted(path.name for path in filtered_output.iterdir()) == ["stale.json"]
+    assert not [path for path in tmp_path.iterdir() if ".backup" in path.name]
+
+
 def test_combined_outputs_remain_consistent_when_backup_cleanup_fails(
     sample_pareto_dir: Path,
     tmp_path: Path,
@@ -1598,6 +1719,26 @@ def test_filtered_output_preserves_existing_directory_metadata(
     assert (after.st_uid, after.st_gid) == (before.st_uid, before.st_gid)
     if xattr_supported:
         assert os.getxattr(output_dir, xattr_name) == b"preserve"
+
+
+def test_filtered_output_overwrite_uses_fresh_modification_time(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    capsys,
+):
+    output_dir = tmp_path / "filtered"
+    output_dir.mkdir()
+    (output_dir / "stale.json").write_text('{"stale": true}\n')
+    old_timestamp_ns = 946684800_000_000_000
+    os.utime(output_dir, ns=(old_timestamp_ns, old_timestamp_ns))
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-f", str(output_dir), "--overwrite"]
+    )
+
+    run_from_args(args)
+    capsys.readouterr()
+
+    assert output_dir.stat().st_mtime_ns > old_timestamp_ns
 
 
 def test_filtered_output_applies_directory_metadata_before_writing_members(

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -1666,6 +1666,55 @@ def test_combined_outputs_restore_selected_when_install_return_is_interrupted(
     assert not [path for path in tmp_path.iterdir() if ".backup" in path.name]
 
 
+def test_combined_outputs_record_no_hard_link_commit_before_nested_return(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"selected": "old"}\n')
+    filtered_output = tmp_path / "filtered"
+    real_install = pareto_explorer._install_selected_without_overwrite
+    interrupted = False
+
+    def reject_hard_link(*args, **kwargs):
+        raise OSError(errno.EOPNOTSUPP, "hard links unsupported")
+
+    def interrupt_after_nested_return(*args, **kwargs):
+        nonlocal interrupted
+        result = real_install(*args, **kwargs)
+        destination = Path(args[1])
+        if destination == selected_output and not interrupted:
+            interrupted = True
+            raise KeyboardInterrupt()
+        return result
+
+    monkeypatch.setattr(os, "link", reject_hard_link)
+    monkeypatch.setattr(
+        pareto_explorer,
+        "_install_selected_without_overwrite",
+        interrupt_after_nested_return,
+    )
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_output),
+            "--overwrite",
+        ]
+    )
+
+    result = run_from_args(args)
+
+    assert interrupted
+    assert selected_output.read_bytes() == result.candidate.source_bytes
+    assert (filtered_output / "selection.json").exists()
+    assert "install committed before interruption" in capsys.readouterr().err
+
+
 def test_combined_outputs_keep_committed_pair_when_filtered_return_is_interrupted(
     sample_pareto_dir: Path,
     tmp_path: Path,
@@ -2627,6 +2676,42 @@ def test_save_filtered_refuses_filesystem_identity_alias_of_source_directory(
 
     assert sorted(path.name for path in sample_pareto_dir.iterdir()) == source_files
     assert not list(output_alias.iterdir())
+
+
+@pytest.mark.parametrize("output_kind", ["selected", "filtered"])
+def test_save_outputs_refuse_descendants_of_source_directory_alias(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+    output_kind: str,
+):
+    output_alias = tmp_path / "source-alias"
+    output_alias.mkdir()
+    if output_kind == "selected":
+        output = output_alias / "notes.json"
+        output.write_text('{"unrelated": true}\n')
+        command = [str(sample_pareto_dir), "-s", str(output), "--overwrite"]
+    else:
+        output = output_alias / "nested"
+        output.mkdir()
+        (output / "notes.json").write_text('{"unrelated": true}\n')
+        command = [str(sample_pareto_dir), "-f", str(output), "--overwrite"]
+    real_samefile = os.path.samefile
+
+    def report_bind_mount_alias(left, right):
+        pair = {Path(left).resolve(), Path(right).resolve()}
+        if pair == {output_alias.resolve(), sample_pareto_dir.resolve()}:
+            return True
+        return real_samefile(left, right)
+
+    monkeypatch.setattr(os.path, "samefile", report_bind_mount_alias)
+    args = build_parser().parse_args(command)
+
+    with pytest.raises(ValueError, match="inside the source Pareto directory"):
+        run_from_args(args)
+
+    preserved = output / "notes.json" if output_kind == "filtered" else output
+    assert json.loads(preserved.read_text()) == {"unrelated": True}
 
 
 def test_single_file_input_allows_sibling_outputs(

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -942,6 +942,60 @@ def test_saved_outputs_require_explicit_overwrite(
     ]
 
 
+@pytest.mark.parametrize("output_exists", [False, True])
+def test_selected_output_uses_destination_permissions(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    capsys,
+    output_exists: bool,
+):
+    selected_output = tmp_path / "selected.json"
+    if output_exists:
+        selected_output.write_text('{"old": true}\n')
+        selected_output.chmod(0o750)
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-s", str(selected_output), "--overwrite"]
+    )
+
+    previous_umask = os.umask(0o027)
+    try:
+        run_from_args(args)
+    finally:
+        os.umask(previous_umask)
+    capsys.readouterr()
+
+    expected_mode = 0o750 if output_exists else 0o640
+    assert stat.S_IMODE(selected_output.stat().st_mode) == expected_mode
+
+
+def test_selected_output_preserves_existing_file_metadata(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    capsys,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"old": true}\n')
+    before = selected_output.stat()
+    xattr_name = b"user.passivbot_test"
+    xattr_supported = hasattr(os, "setxattr") and hasattr(os, "getxattr")
+    if xattr_supported:
+        try:
+            os.setxattr(selected_output, xattr_name, b"preserve")
+        except OSError:
+            xattr_supported = False
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-s", str(selected_output), "--overwrite"]
+    )
+
+    run_from_args(args)
+    capsys.readouterr()
+
+    after = selected_output.stat()
+    assert (after.st_uid, after.st_gid) == (before.st_uid, before.st_gid)
+    if xattr_supported:
+        assert os.getxattr(selected_output, xattr_name) == b"preserve"
+
+
 @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="requires POSIX FIFO support")
 def test_selected_output_refuses_existing_special_node(
     sample_pareto_dir: Path,
@@ -1181,6 +1235,46 @@ def test_combined_outputs_remain_consistent_when_backup_cleanup_fails(
     backups = [path for path in tmp_path.iterdir() if ".backup-" in path.name]
     assert len(backups) == 1
     real_remove(backups[0])
+
+
+def test_combined_outputs_warn_when_selected_backup_cleanup_fails(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"selected": "old"}\n')
+    filtered_output = tmp_path / "filtered"
+    real_unlink = Path.unlink
+
+    def fail_selected_backup_cleanup(path: Path, *args, **kwargs):
+        if path.suffix == ".backup":
+            raise OSError("simulated selected backup cleanup failure")
+        return real_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_selected_backup_cleanup)
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_output),
+            "--overwrite",
+        ]
+    )
+
+    result = run_from_args(args)
+
+    assert selected_output.read_bytes() == result.candidate.source_bytes
+    assert (filtered_output / "selection.json").exists()
+    assert "selected output installed, but old backup could not be removed" in (
+        capsys.readouterr().err
+    )
+    backups = [path for path in tmp_path.iterdir() if path.suffix == ".backup"]
+    assert len(backups) == 1
+    real_unlink(backups[0])
 
 
 @pytest.mark.parametrize("output_exists", [False, True])

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import argparse
+import errno
 import json
 import os
 import stat
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -996,6 +999,38 @@ def test_selected_output_preserves_existing_file_metadata(
         assert os.getxattr(selected_output, xattr_name) == b"preserve"
 
 
+@pytest.mark.skipif(sys.platform != "darwin", reason="requires macOS ACL tools")
+def test_selected_output_preserves_macos_access_acl(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    capsys,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"old": true}\n')
+    added = subprocess.run(
+        ["/bin/chmod", "+a", "everyone allow read", str(selected_output)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if added.returncode != 0:
+        pytest.skip(f"could not create test ACL: {added.stderr.strip()}")
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-s", str(selected_output), "--overwrite"]
+    )
+
+    run_from_args(args)
+    capsys.readouterr()
+    listed = subprocess.run(
+        ["/bin/ls", "-le", str(selected_output)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert " allow read" in listed.stdout
+
+
 def test_selected_output_overwrite_uses_fresh_modification_time(
     sample_pareto_dir: Path,
     tmp_path: Path,
@@ -1044,6 +1079,62 @@ def test_selected_staging_uses_normal_exclusive_file_creation(
     assert flags & os.O_CREAT
     assert flags & os.O_EXCL
     assert mode == 0o666
+
+
+def test_selected_output_falls_back_when_hard_links_are_unsupported(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    selected_output = tmp_path / "selected.json"
+
+    def reject_hard_link(*args, **kwargs):
+        raise OSError(errno.EOPNOTSUPP, "hard links unsupported")
+
+    monkeypatch.setattr(os, "link", reject_hard_link)
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-s", str(selected_output)]
+    )
+
+    result = run_from_args(args)
+    capsys.readouterr()
+
+    assert selected_output.read_bytes() == result.candidate.source_bytes
+
+
+def test_selected_overwrite_detects_replacement_before_commit(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"selected": "old"}\n')
+    real_replace = os.replace
+    raced = False
+
+    def replace_destination_before_move(source, destination):
+        nonlocal raced
+        source = Path(source)
+        destination = Path(destination)
+        if source == selected_output and destination.suffix == ".backup" and not raced:
+            newer = tmp_path / "newer.json"
+            newer.write_text('{"selected": "newer"}\n')
+            real_replace(newer, selected_output)
+            raced = True
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(os, "replace", replace_destination_before_move)
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-s", str(selected_output), "--overwrite"]
+    )
+
+    with pytest.raises(RuntimeError, match="changed concurrently; refusing install"):
+        run_from_args(args)
+
+    assert raced
+    assert json.loads(selected_output.read_text()) == {"selected": "newer"}
+    assert not [path for path in tmp_path.iterdir() if path.suffix == ".backup"]
 
 
 def test_selected_output_supports_name_max_destination(
@@ -1536,14 +1627,14 @@ def test_combined_outputs_keep_committed_pair_when_selected_rename_is_interrupte
     selected_output = tmp_path / "selected.json"
     selected_output.write_text('{"selected": "old"}\n')
     filtered_output = tmp_path / "filtered"
-    real_replace = os.replace
+    real_link = os.link
     interrupted = False
 
-    def interrupt_after_selected_commit(source, destination):
+    def interrupt_after_selected_commit(source, destination, *args, **kwargs):
         nonlocal interrupted
         source = Path(source)
         destination = Path(destination)
-        result = real_replace(source, destination)
+        result = real_link(source, destination, *args, **kwargs)
         if (
             not interrupted
             and source.name.startswith(pareto_explorer.SELECTED_STAGING_PREFIX)
@@ -1554,7 +1645,7 @@ def test_combined_outputs_keep_committed_pair_when_selected_rename_is_interrupte
             raise KeyboardInterrupt()
         return result
 
-    monkeypatch.setattr(os, "replace", interrupt_after_selected_commit)
+    monkeypatch.setattr(os, "link", interrupt_after_selected_commit)
     args = build_parser().parse_args(
         [
             str(sample_pareto_dir),
@@ -2111,6 +2202,34 @@ def test_save_outputs_refuse_source_pareto_directory(
     )
     with pytest.raises(ValueError, match="inside the source Pareto directory"):
         run_from_args(filtered_args)
+
+
+def test_save_filtered_refuses_filesystem_identity_alias_of_source_directory(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    output_alias = tmp_path / "source_alias"
+    output_alias.mkdir()
+    source_files = sorted(path.name for path in sample_pareto_dir.iterdir())
+    real_samefile = os.path.samefile
+
+    def report_bind_mount_alias(left, right):
+        pair = {Path(left).resolve(), Path(right).resolve()}
+        if pair == {output_alias.resolve(), sample_pareto_dir.resolve()}:
+            return True
+        return real_samefile(left, right)
+
+    monkeypatch.setattr(os.path, "samefile", report_bind_mount_alias)
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-f", str(output_alias), "--overwrite"]
+    )
+
+    with pytest.raises(ValueError, match="inside the source Pareto directory"):
+        run_from_args(args)
+
+    assert sorted(path.name for path in sample_pareto_dir.iterdir()) == source_files
+    assert not list(output_alias.iterdir())
 
 
 def test_single_file_input_allows_sibling_outputs(

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -942,6 +942,49 @@ def test_saved_outputs_require_explicit_overwrite(
     ]
 
 
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="requires POSIX FIFO support")
+def test_selected_output_refuses_existing_special_node(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+):
+    selected_output = tmp_path / "selected.json"
+    os.mkfifo(selected_output)
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-s", str(selected_output), "--overwrite"]
+    )
+
+    with pytest.raises(ValueError, match="must be a regular file"):
+        run_from_args(args)
+
+
+def test_selected_output_does_not_overwrite_racing_destination_without_permission(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    selected_output = tmp_path / "selected.json"
+    real_copy2 = shutil.copy2
+    destination_created = False
+
+    def create_destination_during_staging(source, destination, *args, **kwargs):
+        nonlocal destination_created
+        destination = Path(destination)
+        if not destination_created and destination.suffix == ".tmp":
+            selected_output.write_text('{"racing": true}\n')
+            destination_created = True
+        return real_copy2(source, destination, *args, **kwargs)
+
+    monkeypatch.setattr("pareto_explorer.shutil.copy2", create_destination_during_staging)
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-s", str(selected_output)]
+    )
+
+    with pytest.raises(FileExistsError, match="use --overwrite"):
+        run_from_args(args)
+
+    assert json.loads(selected_output.read_text()) == {"racing": True}
+
+
 def test_filtered_overwrite_refuses_non_json_entries(
     sample_pareto_dir: Path,
     tmp_path: Path,
@@ -1064,6 +1107,28 @@ def test_filtered_output_directory_uses_destination_permissions(
     capsys.readouterr()
 
     assert stat.S_IMODE(output_dir.stat().st_mode) == 0o750
+
+
+def test_filtered_output_builds_before_applying_read_only_destination_mode(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    capsys,
+):
+    output_dir = tmp_path / "filtered"
+    output_dir.mkdir()
+    (output_dir / "stale.json").write_text('{"stale": true}\n')
+    output_dir.chmod(0o555)
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-f", str(output_dir), "--overwrite"]
+    )
+
+    try:
+        run_from_args(args)
+        capsys.readouterr()
+        assert stat.S_IMODE(output_dir.stat().st_mode) == 0o555
+        assert (output_dir / "selection.json").exists()
+    finally:
+        output_dir.chmod(0o755)
 
 
 def test_save_filtered_refuses_directory_containing_resolved_source_member(
@@ -1191,6 +1256,34 @@ def test_single_file_input_allows_sibling_outputs(
         "balanced.json",
         "selection.json",
     ]
+
+
+def test_single_file_symlink_member_path_normalizes_dot_dot_without_dereferencing(
+    tmp_path: Path,
+):
+    run_dir = tmp_path / "run"
+    pareto_dir = run_dir / "pareto"
+    pareto_dir.mkdir(parents=True)
+    (run_dir / "other").mkdir()
+    external_dir = tmp_path / "external"
+    external_dir.mkdir()
+    resolved_source = external_dir / "target.json"
+    _write_candidate(
+        external_dir,
+        "target",
+        {"metric_a": 0.7, "metric_b": 0.7, "metric_c": 0.7},
+    )
+    member_path = pareto_dir / "member.json"
+    member_path.symlink_to(resolved_source)
+    spelled_path = run_dir / "other" / ".." / "pareto" / "member.json"
+    args = build_parser().parse_args(
+        [str(spelled_path), "-f", str(pareto_dir), "--overwrite"]
+    )
+
+    with pytest.raises(ValueError, match="resolved source Pareto member"):
+        run_from_args(args)
+
+    assert member_path.is_symlink()
 
 
 def test_save_outputs_refuse_both_overlap_directions(

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -1112,6 +1112,44 @@ def test_selected_output_falls_back_when_hard_links_are_unsupported(
     assert selected_output.read_bytes() == result.candidate.source_bytes
 
 
+def test_selected_fallback_refuses_to_remove_concurrent_replacement(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"selected": "old"}\n')
+    real_copy_metadata = pareto_explorer._copy_file_metadata
+
+    def reject_hard_link(*args, **kwargs):
+        raise OSError(errno.EOPNOTSUPP, "hard links unsupported")
+
+    def replace_during_metadata_copy(source: Path, destination: Path):
+        if destination == selected_output:
+            newer = tmp_path / "newer.json"
+            newer.write_text('{"selected": "newer"}\n')
+            os.replace(newer, selected_output)
+            raise OSError("simulated metadata copy failure")
+        real_copy_metadata(source, destination)
+
+    monkeypatch.setattr(os, "link", reject_hard_link)
+    monkeypatch.setattr(
+        pareto_explorer, "_copy_file_metadata", replace_during_metadata_copy
+    )
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-s", str(selected_output), "--overwrite"]
+    )
+
+    with pytest.raises(RuntimeError, match="changed concurrently"):
+        run_from_args(args)
+
+    assert json.loads(selected_output.read_text()) == {"selected": "newer"}
+    backups = [path for path in tmp_path.iterdir() if path.suffix == ".backup"]
+    assert len(backups) == 1
+    assert json.loads(backups[0].read_text()) == {"selected": "old"}
+    backups[0].unlink()
+
+
 def test_selected_overwrite_detects_replacement_before_commit(
     sample_pareto_dir: Path,
     tmp_path: Path,
@@ -1187,16 +1225,18 @@ def test_selected_output_does_not_overwrite_racing_destination_without_permissio
     selected_output = tmp_path / "selected.json"
     destination_created = False
 
-    def create_destination_during_staging(candidate, destination):
+    def create_destination_during_staging(candidate, destination, file_descriptor):
         nonlocal destination_created
         destination = Path(destination)
         if not destination_created and destination.suffix == ".tmp":
             selected_output.write_text('{"racing": true}\n')
             destination_created = True
-        destination.write_bytes(candidate.source_bytes)
+        with os.fdopen(file_descriptor, "wb") as destination_file:
+            destination_file.write(candidate.source_bytes)
 
     monkeypatch.setattr(
-        "pareto_explorer._write_candidate_snapshot", create_destination_during_staging
+        "pareto_explorer._write_candidate_snapshot_fd",
+        create_destination_during_staging,
     )
     args = build_parser().parse_args(
         [str(sample_pareto_dir), "-s", str(selected_output)]
@@ -1375,14 +1415,19 @@ def test_filtered_overwrite_preserves_previous_set_when_staging_fails(
     stale.write_text('{"stale": true}\n')
     copies = 0
 
-    def fail_on_second_copy(candidate, destination):
+    real_write_snapshot = pareto_explorer._write_candidate_snapshot_fd
+
+    def fail_on_second_copy(candidate, destination, file_descriptor):
         nonlocal copies
         copies += 1
         if copies == 2:
+            os.close(file_descriptor)
             raise OSError("simulated copy failure")
-        Path(destination).write_bytes(candidate.source_bytes)
+        real_write_snapshot(candidate, destination, file_descriptor)
 
-    monkeypatch.setattr("pareto_explorer._write_candidate_snapshot", fail_on_second_copy)
+    monkeypatch.setattr(
+        "pareto_explorer._write_candidate_snapshot_fd", fail_on_second_copy
+    )
     args = build_parser().parse_args(
         [str(sample_pareto_dir), "-f", str(output_dir), "--overwrite"]
     )
@@ -1416,16 +1461,20 @@ def test_combined_outputs_restore_selected_when_filtered_staging_fails(
     stale = filtered_output / "stale.json"
     stale.write_text('{"filtered": "old"}\n')
 
-    def fail_during_filtered_staging(candidate, destination):
+    real_write_snapshot = pareto_explorer._write_candidate_snapshot_fd
+
+    def fail_during_filtered_staging(candidate, destination, file_descriptor):
         destination = Path(destination)
         if destination.name == "b_extreme.json" and destination.parent.name.startswith(
             pareto_explorer.FILTERED_STAGING_PREFIX
         ):
+            os.close(file_descriptor)
             raise OSError("simulated filtered copy failure")
-        destination.write_bytes(candidate.source_bytes)
+        real_write_snapshot(candidate, destination, file_descriptor)
 
     monkeypatch.setattr(
-        "pareto_explorer._write_candidate_snapshot", fail_during_filtered_staging
+        "pareto_explorer._write_candidate_snapshot_fd",
+        fail_during_filtered_staging,
     )
     args = build_parser().parse_args(
         [
@@ -1503,17 +1552,20 @@ def test_combined_outputs_refuse_rollback_over_newer_selected_file(
     selected_output.write_text('{"selected": "old"}\n')
     filtered_output = tmp_path / "filtered"
 
-    def replace_selected_then_fail(candidate, destination):
+    real_write_snapshot = pareto_explorer._write_candidate_snapshot_fd
+
+    def replace_selected_then_fail(candidate, destination, file_descriptor):
         destination = Path(destination)
         if destination.parent.name.startswith(pareto_explorer.FILTERED_STAGING_PREFIX):
             newer = tmp_path / "newer.json"
             newer.write_text('{"selected": "newer"}\n')
             os.replace(newer, selected_output)
+            os.close(file_descriptor)
             raise OSError("simulated filtered copy failure")
-        destination.write_bytes(candidate.source_bytes)
+        real_write_snapshot(candidate, destination, file_descriptor)
 
     monkeypatch.setattr(
-        pareto_explorer, "_write_candidate_snapshot", replace_selected_then_fail
+        pareto_explorer, "_write_candidate_snapshot_fd", replace_selected_then_fail
     )
     args = build_parser().parse_args(
         [
@@ -1545,15 +1597,18 @@ def test_combined_outputs_refuse_rollback_over_in_place_selected_edit(
     selected_output.write_text('{"selected": "old"}\n')
     filtered_output = tmp_path / "filtered"
 
-    def edit_selected_then_fail(candidate, destination):
+    real_write_snapshot = pareto_explorer._write_candidate_snapshot_fd
+
+    def edit_selected_then_fail(candidate, destination, file_descriptor):
         destination = Path(destination)
         if destination.parent.name.startswith(pareto_explorer.FILTERED_STAGING_PREFIX):
             selected_output.write_text('{"selected": "newer"}\n')
+            os.close(file_descriptor)
             raise OSError("simulated filtered copy failure")
-        destination.write_bytes(candidate.source_bytes)
+        real_write_snapshot(candidate, destination, file_descriptor)
 
     monkeypatch.setattr(
-        pareto_explorer, "_write_candidate_snapshot", edit_selected_then_fail
+        pareto_explorer, "_write_candidate_snapshot_fd", edit_selected_then_fail
     )
     args = build_parser().parse_args(
         [
@@ -1625,6 +1680,52 @@ def test_combined_outputs_keep_committed_pair_when_filtered_rename_is_interrupte
     assert (filtered_output / "selection.json").exists()
     assert "install committed before interruption" in capsys.readouterr().err
     assert not [path for path in tmp_path.iterdir() if ".backup" in path.name]
+
+
+def test_combined_outputs_keep_committed_pair_when_filtered_staging_cleanup_is_interrupted(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"selected": "old"}\n')
+    filtered_output = tmp_path / "filtered"
+    filtered_output.mkdir()
+    (filtered_output / "stale.json").write_text('{"filtered": "old"}\n')
+    real_remove = pareto_explorer._remove_output_tree
+    interrupted = False
+
+    def interrupt_staging_cleanup(path: Path):
+        nonlocal interrupted
+        if path.name.startswith(pareto_explorer.FILTERED_STAGING_PREFIX):
+            interrupted = True
+            raise KeyboardInterrupt()
+        return real_remove(path)
+
+    monkeypatch.setattr(
+        pareto_explorer, "_remove_output_tree", interrupt_staging_cleanup
+    )
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_output),
+            "--overwrite",
+        ]
+    )
+
+    result = run_from_args(args)
+
+    assert interrupted
+    assert selected_output.read_bytes() == result.candidate.source_bytes
+    assert not (filtered_output / "stale.json").exists()
+    assert (filtered_output / "selection.json").exists()
+    assert "filtered output installed, but temporary path could not be removed" in (
+        capsys.readouterr().err
+    )
 
 
 def test_combined_outputs_keep_committed_pair_when_selected_rename_is_interrupted(
@@ -1950,7 +2051,7 @@ def test_filtered_output_applies_directory_metadata_before_writing_members(
     output_dir.mkdir()
     (output_dir / "stale.json").write_text('{"stale": true}\n')
     real_copy_metadata = pareto_explorer._copy_directory_metadata
-    real_write_snapshot = pareto_explorer._write_candidate_snapshot
+    real_write_snapshot = pareto_explorer._write_candidate_snapshot_fd
     metadata_ready = False
 
     def track_metadata(source: Path, destination: Path):
@@ -1959,13 +2060,13 @@ def test_filtered_output_applies_directory_metadata_before_writing_members(
         if source == output_dir and destination.name.endswith(".tmp"):
             metadata_ready = True
 
-    def require_metadata_before_write(candidate, destination):
+    def require_metadata_before_write(candidate, destination, file_descriptor):
         assert metadata_ready
-        real_write_snapshot(candidate, destination)
+        real_write_snapshot(candidate, destination, file_descriptor)
 
     monkeypatch.setattr(pareto_explorer, "_copy_directory_metadata", track_metadata)
     monkeypatch.setattr(
-        pareto_explorer, "_write_candidate_snapshot", require_metadata_before_write
+        pareto_explorer, "_write_candidate_snapshot_fd", require_metadata_before_write
     )
     args = build_parser().parse_args(
         [str(sample_pareto_dir), "-f", str(output_dir), "--overwrite"]
@@ -2145,18 +2246,18 @@ def test_saved_outputs_use_candidate_snapshot_from_selection_time(
     original_bytes = source.read_bytes()
     selected_output = tmp_path / "selected.json"
     filtered_output = tmp_path / "filtered"
-    real_write_snapshot = pareto_explorer._write_candidate_snapshot
+    real_write_snapshot = pareto_explorer._write_candidate_snapshot_fd
     source_changed = False
 
-    def change_source_before_export(candidate, destination):
+    def change_source_before_export(candidate, destination, file_descriptor):
         nonlocal source_changed
         if not source_changed:
             source.write_text('{"changed": true}\n')
             source_changed = True
-        return real_write_snapshot(candidate, destination)
+        return real_write_snapshot(candidate, destination, file_descriptor)
 
     monkeypatch.setattr(
-        pareto_explorer, "_write_candidate_snapshot", change_source_before_export
+        pareto_explorer, "_write_candidate_snapshot_fd", change_source_before_export
     )
     args = build_parser().parse_args(
         [
@@ -2211,6 +2312,25 @@ def test_save_outputs_refuse_source_pareto_directory(
     )
     with pytest.raises(ValueError, match="inside the source Pareto directory"):
         run_from_args(filtered_args)
+
+
+def test_save_selected_refuses_filesystem_identity_alias_of_source_member(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+):
+    source = sample_pareto_dir / "balanced.json"
+    output_alias = tmp_path / "selected.json"
+    os.link(source, output_alias)
+    original_bytes = source.read_bytes()
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-s", str(output_alias), "--overwrite"]
+    )
+
+    with pytest.raises(ValueError, match="source Pareto member"):
+        run_from_args(args)
+
+    assert source.read_bytes() == original_bytes
+    assert output_alias.read_bytes() == original_bytes
 
 
 def test_save_filtered_refuses_filesystem_identity_alias_of_source_directory(

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -1003,6 +1003,43 @@ def test_filtered_overwrite_refuses_non_json_entries(
     assert note.read_text() == "keep me\n"
 
 
+def test_filtered_overwrite_revalidates_contents_after_move_aside(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    output_dir = tmp_path / "filtered"
+    output_dir.mkdir()
+    stale = output_dir / "stale.json"
+    stale.write_text('{"stale": true}\n')
+    real_replace = os.replace
+    injected = False
+
+    def add_non_json_before_move_aside(source, destination):
+        nonlocal injected
+        source = Path(source)
+        destination = Path(destination)
+        if source == output_dir and ".backup-" in destination.name and not injected:
+            (output_dir / "notes.txt").write_text("preserve me\n")
+            injected = True
+        return real_replace(source, destination)
+
+    monkeypatch.setattr("pareto_explorer.os.replace", add_non_json_before_move_aside)
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-f", str(output_dir), "--overwrite"]
+    )
+
+    with pytest.raises(FileExistsError, match="non-JSON entries: notes.txt"):
+        run_from_args(args)
+
+    assert json.loads(stale.read_text()) == {"stale": True}
+    assert (output_dir / "notes.txt").read_text() == "preserve me\n"
+    assert sorted(path.name for path in output_dir.iterdir()) == [
+        "notes.txt",
+        "stale.json",
+    ]
+
+
 def test_filtered_overwrite_preserves_previous_set_when_staging_fails(
     sample_pareto_dir: Path,
     tmp_path: Path,
@@ -1278,6 +1315,38 @@ def test_single_file_symlink_member_path_normalizes_dot_dot_without_dereferencin
     spelled_path = run_dir / "other" / ".." / "pareto" / "member.json"
     args = build_parser().parse_args(
         [str(spelled_path), "-f", str(pareto_dir), "--overwrite"]
+    )
+
+    with pytest.raises(ValueError, match="resolved source Pareto member"):
+        run_from_args(args)
+
+    assert member_path.is_symlink()
+
+
+def test_single_file_member_path_canonicalizes_symlinked_parent(
+    tmp_path: Path,
+):
+    pareto_dir = tmp_path / "pareto"
+    pareto_dir.mkdir()
+    external_dir = tmp_path / "external"
+    external_dir.mkdir()
+    resolved_source = external_dir / "target.json"
+    _write_candidate(
+        external_dir,
+        "target",
+        {"metric_a": 0.7, "metric_b": 0.7, "metric_c": 0.7},
+    )
+    member_path = pareto_dir / "member.json"
+    member_path.symlink_to(resolved_source)
+    aliased_parent = tmp_path / "pareto_alias"
+    aliased_parent.symlink_to(pareto_dir, target_is_directory=True)
+    args = build_parser().parse_args(
+        [
+            str(aliased_parent / "member.json"),
+            "-f",
+            str(pareto_dir),
+            "--overwrite",
+        ]
     )
 
     with pytest.raises(ValueError, match="resolved source Pareto member"):

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -1015,6 +1015,55 @@ def test_selected_output_overwrite_uses_fresh_modification_time(
     assert selected_output.stat().st_mtime_ns > old_timestamp_ns
 
 
+def test_selected_staging_uses_normal_exclusive_file_creation(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    selected_output = tmp_path / "selected.json"
+    real_open = os.open
+    observed = []
+
+    def track_open(path, flags, mode=0o777, *args, **kwargs):
+        path = Path(path)
+        if path.name.startswith(pareto_explorer.SELECTED_STAGING_PREFIX):
+            observed.append((flags, mode))
+        return real_open(path, flags, mode, *args, **kwargs)
+
+    monkeypatch.setattr(os, "open", track_open)
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-s", str(selected_output)]
+    )
+
+    run_from_args(args)
+    capsys.readouterr()
+
+    assert observed
+    flags, mode = observed[0]
+    assert flags & os.O_CREAT
+    assert flags & os.O_EXCL
+    assert mode == 0o666
+
+
+def test_selected_output_supports_name_max_destination(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    capsys,
+):
+    name_max = os.pathconf(tmp_path, "PC_NAME_MAX")
+    suffix = ".json"
+    selected_output = tmp_path / ("x" * (name_max - len(suffix)) + suffix)
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-s", str(selected_output)]
+    )
+
+    result = run_from_args(args)
+    capsys.readouterr()
+
+    assert selected_output.read_bytes() == result.candidate.source_bytes
+
+
 @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="requires POSIX FIFO support")
 def test_selected_output_refuses_existing_special_node(
     sample_pareto_dir: Path,
@@ -1070,7 +1119,7 @@ def test_selected_output_continues_when_post_link_staging_cleanup_fails(
     real_unlink = Path.unlink
 
     def fail_selected_staging_cleanup(path: Path, *args, **kwargs):
-        if path.name.startswith(".selected.json.") and path.suffix == ".tmp":
+        if path.name.startswith(pareto_explorer.SELECTED_STAGING_PREFIX) and path.suffix == ".tmp":
             raise OSError("simulated selected staging cleanup failure")
         return real_unlink(path, *args, **kwargs)
 
@@ -1095,7 +1144,7 @@ def test_selected_output_continues_when_post_link_staging_cleanup_fails(
     staging_paths = [
         path
         for path in tmp_path.iterdir()
-        if path.name.startswith(".selected.json.") and path.suffix == ".tmp"
+        if path.name.startswith(pareto_explorer.SELECTED_STAGING_PREFIX) and path.suffix == ".tmp"
     ]
     assert len(staging_paths) == 1
     real_unlink(staging_paths[0])
@@ -1117,6 +1166,40 @@ def test_filtered_overwrite_refuses_non_json_entries(
         run_from_args(args)
 
     assert note.read_text() == "keep me\n"
+
+
+def test_filtered_output_detects_destination_filesystem_filename_collision(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    output_dir = tmp_path / "filtered"
+    real_open = os.open
+    member_creations = 0
+
+    def collide_on_second_member(path, flags, mode=0o777, *args, **kwargs):
+        nonlocal member_creations
+        path = Path(path)
+        if (
+            path.parent.name.startswith(pareto_explorer.FILTERED_STAGING_PREFIX)
+            and path.suffix == ".json"
+            and path.name != pareto_explorer.FILTERED_SELECTION_MANIFEST
+            and flags & os.O_EXCL
+        ):
+            member_creations += 1
+            if member_creations == 2:
+                raise FileExistsError(path)
+        return real_open(path, flags, mode, *args, **kwargs)
+
+    monkeypatch.setattr(os, "open", collide_on_second_member)
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-f", str(output_dir)]
+    )
+
+    with pytest.raises(ValueError, match="collides on the destination filesystem"):
+        run_from_args(args)
+
+    assert not output_dir.exists()
 
 
 @pytest.mark.parametrize("overwrite", [False, True])
@@ -1156,7 +1239,11 @@ def test_filtered_overwrite_revalidates_contents_after_move_aside(
         nonlocal injected
         source = Path(source)
         destination = Path(destination)
-        if source == output_dir and ".backup-" in destination.name and not injected:
+        if (
+            source == output_dir
+            and destination.name.startswith(pareto_explorer.FILTERED_BACKUP_PREFIX)
+            and not injected
+        ):
             (output_dir / "notes.txt").write_text("preserve me\n")
             injected = True
         return real_replace(source, destination)
@@ -1205,7 +1292,11 @@ def test_filtered_overwrite_preserves_previous_set_when_staging_fails(
 
     assert json.loads(stale.read_text()) == {"stale": True}
     assert sorted(path.name for path in output_dir.iterdir()) == ["stale.json"]
-    assert not [path for path in tmp_path.iterdir() if path.name.startswith(".filtered.")]
+    assert not [
+        path
+        for path in tmp_path.iterdir()
+        if path.name.startswith(pareto_explorer.FILTERED_STAGING_PREFIX)
+    ]
 
 
 @pytest.mark.parametrize("selected_exists", [False, True])
@@ -1228,7 +1319,7 @@ def test_combined_outputs_restore_selected_when_filtered_staging_fails(
     def fail_during_filtered_staging(candidate, destination):
         destination = Path(destination)
         if destination.name == "b_extreme.json" and destination.parent.name.startswith(
-            ".filtered."
+            pareto_explorer.FILTERED_STAGING_PREFIX
         ):
             raise OSError("simulated filtered copy failure")
         destination.write_bytes(candidate.source_bytes)
@@ -1275,7 +1366,7 @@ def test_combined_outputs_restore_both_destinations_when_interrupted(
     real_copy_metadata = pareto_explorer._copy_directory_metadata
 
     def interrupt_after_filtered_move(source: Path, destination: Path):
-        if ".backup-" in source.name:
+        if source.name.startswith(pareto_explorer.FILTERED_BACKUP_PREFIX):
             raise KeyboardInterrupt()
         real_copy_metadata(source, destination)
 
@@ -1314,7 +1405,7 @@ def test_combined_outputs_refuse_rollback_over_newer_selected_file(
 
     def replace_selected_then_fail(candidate, destination):
         destination = Path(destination)
-        if destination.parent.name.startswith(".filtered."):
+        if destination.parent.name.startswith(pareto_explorer.FILTERED_STAGING_PREFIX):
             newer = tmp_path / "newer.json"
             newer.write_text('{"selected": "newer"}\n')
             os.replace(newer, selected_output)
@@ -1356,7 +1447,7 @@ def test_combined_outputs_refuse_rollback_over_in_place_selected_edit(
 
     def edit_selected_then_fail(candidate, destination):
         destination = Path(destination)
-        if destination.parent.name.startswith(".filtered."):
+        if destination.parent.name.startswith(pareto_explorer.FILTERED_STAGING_PREFIX):
             selected_output.write_text('{"selected": "newer"}\n')
             raise OSError("simulated filtered copy failure")
         destination.write_bytes(candidate.source_bytes)
@@ -1406,7 +1497,7 @@ def test_combined_outputs_keep_committed_pair_when_filtered_rename_is_interrupte
         result = real_replace(source, destination)
         if (
             not interrupted
-            and source.name.startswith(".filtered.")
+            and source.name.startswith(pareto_explorer.FILTERED_STAGING_PREFIX)
             and source.name.endswith(".tmp")
             and destination == filtered_output
         ):
@@ -1455,7 +1546,7 @@ def test_combined_outputs_keep_committed_pair_when_selected_rename_is_interrupte
         result = real_replace(source, destination)
         if (
             not interrupted
-            and source.name.startswith(".selected.json.")
+            and source.name.startswith(pareto_explorer.SELECTED_STAGING_PREFIX)
             and source.name.endswith(".tmp")
             and destination == selected_output
         ):
@@ -1509,7 +1600,7 @@ def test_combined_outputs_restore_both_when_filtered_move_aside_is_interrupted(
         if (
             not interrupted
             and source == filtered_output
-            and ".backup-" in destination.name
+            and destination.name.startswith(pareto_explorer.FILTERED_BACKUP_PREFIX)
         ):
             interrupted = True
             raise KeyboardInterrupt()
@@ -1552,7 +1643,7 @@ def test_combined_outputs_remain_consistent_when_backup_cleanup_fails(
     real_remove = pareto_explorer._remove_output_tree
 
     def fail_backup_cleanup(path: Path):
-        if ".backup-" in path.name:
+        if path.name.startswith(pareto_explorer.FILTERED_BACKUP_PREFIX):
             raise OSError("simulated backup cleanup failure")
         return real_remove(path)
 
@@ -1574,7 +1665,11 @@ def test_combined_outputs_remain_consistent_when_backup_cleanup_fails(
     assert not (filtered_output / "stale.json").exists()
     assert (filtered_output / "selection.json").exists()
     assert "old backup could not be removed" in capsys.readouterr().err
-    backups = [path for path in tmp_path.iterdir() if ".backup-" in path.name]
+    backups = [
+        path
+        for path in tmp_path.iterdir()
+        if path.name.startswith(pareto_explorer.FILTERED_BACKUP_PREFIX)
+    ]
     assert len(backups) == 1
     real_remove(backups[0])
 
@@ -1593,7 +1688,7 @@ def test_combined_outputs_remain_consistent_when_backup_cleanup_is_interrupted(
     real_remove = pareto_explorer._remove_output_tree
 
     def interrupt_backup_cleanup(path: Path):
-        if ".backup-" in path.name:
+        if path.name.startswith(pareto_explorer.FILTERED_BACKUP_PREFIX):
             raise KeyboardInterrupt()
         return real_remove(path)
 
@@ -1617,7 +1712,11 @@ def test_combined_outputs_remain_consistent_when_backup_cleanup_is_interrupted(
     assert not (filtered_output / "stale.json").exists()
     assert (filtered_output / "selection.json").exists()
     assert "old backup could not be removed" in capsys.readouterr().err
-    backups = [path for path in tmp_path.iterdir() if ".backup-" in path.name]
+    backups = [
+        path
+        for path in tmp_path.iterdir()
+        if path.name.startswith(pareto_explorer.FILTERED_BACKUP_PREFIX)
+    ]
     assert len(backups) == 1
     real_remove(backups[0])
 
@@ -1833,6 +1932,23 @@ def test_new_filtered_output_retains_inherited_setgid_metadata(
     capsys.readouterr()
 
     assert output_dir.stat().st_mode & stat.S_ISGID
+
+
+def test_filtered_output_supports_name_max_destination(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    capsys,
+):
+    name_max = os.pathconf(tmp_path, "PC_NAME_MAX")
+    output_dir = tmp_path / ("x" * name_max)
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-f", str(output_dir)]
+    )
+
+    run_from_args(args)
+    capsys.readouterr()
+
+    assert (output_dir / "selection.json").exists()
 
 
 def test_filtered_output_builds_before_applying_read_only_destination_mode(

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -1284,6 +1284,48 @@ def test_combined_outputs_restore_both_destinations_when_interrupted(
     assert not [path for path in tmp_path.iterdir() if ".backup" in path.name]
 
 
+def test_combined_outputs_refuse_rollback_over_newer_selected_file(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"selected": "old"}\n')
+    filtered_output = tmp_path / "filtered"
+
+    def replace_selected_then_fail(candidate, destination):
+        destination = Path(destination)
+        if destination.parent.name.startswith(".filtered."):
+            newer = tmp_path / "newer.json"
+            newer.write_text('{"selected": "newer"}\n')
+            os.replace(newer, selected_output)
+            raise OSError("simulated filtered copy failure")
+        destination.write_bytes(candidate.source_bytes)
+
+    monkeypatch.setattr(
+        pareto_explorer, "_write_candidate_snapshot", replace_selected_then_fail
+    )
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_output),
+            "--overwrite",
+        ]
+    )
+
+    with pytest.raises(RuntimeError, match="changed concurrently; refusing rollback"):
+        run_from_args(args)
+
+    assert json.loads(selected_output.read_text()) == {"selected": "newer"}
+    backups = [path for path in tmp_path.iterdir() if path.suffix == ".backup"]
+    assert len(backups) == 1
+    assert json.loads(backups[0].read_text()) == {"selected": "old"}
+    backups[0].unlink()
+
+
 def test_combined_outputs_remain_consistent_when_backup_cleanup_fails(
     sample_pareto_dir: Path,
     tmp_path: Path,
@@ -1303,6 +1345,49 @@ def test_combined_outputs_remain_consistent_when_backup_cleanup_fails(
         return real_remove(path)
 
     monkeypatch.setattr(pareto_explorer, "_remove_output_tree", fail_backup_cleanup)
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_output),
+            "--overwrite",
+        ]
+    )
+
+    result = run_from_args(args)
+
+    assert selected_output.read_bytes() == result.candidate.source_bytes
+    assert not (filtered_output / "stale.json").exists()
+    assert (filtered_output / "selection.json").exists()
+    assert "old backup could not be removed" in capsys.readouterr().err
+    backups = [path for path in tmp_path.iterdir() if ".backup-" in path.name]
+    assert len(backups) == 1
+    real_remove(backups[0])
+
+
+def test_combined_outputs_remain_consistent_when_backup_cleanup_is_interrupted(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"selected": "old"}\n')
+    filtered_output = tmp_path / "filtered"
+    filtered_output.mkdir()
+    (filtered_output / "stale.json").write_text('{"filtered": "old"}\n')
+    real_remove = pareto_explorer._remove_output_tree
+
+    def interrupt_backup_cleanup(path: Path):
+        if ".backup-" in path.name:
+            raise KeyboardInterrupt()
+        return real_remove(path)
+
+    monkeypatch.setattr(
+        pareto_explorer, "_remove_output_tree", interrupt_backup_cleanup
+    )
     args = build_parser().parse_args(
         [
             str(sample_pareto_dir),
@@ -1491,6 +1576,31 @@ def test_filtered_output_rechecks_directory_created_during_reservation(
 
     assert raced
     assert stat.S_IMODE(output_dir.stat().st_mode) == 0o750
+
+
+def test_new_filtered_output_retains_inherited_setgid_metadata(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    capsys,
+):
+    output_parent = tmp_path / "exports"
+    output_parent.mkdir()
+    output_parent.chmod(stat.S_IMODE(output_parent.stat().st_mode) | stat.S_ISGID)
+    probe = output_parent / "probe"
+    probe.mkdir(mode=0o777)
+    inherited_setgid = bool(probe.stat().st_mode & stat.S_ISGID)
+    probe.rmdir()
+    if not inherited_setgid:
+        pytest.skip("filesystem does not inherit setgid on child directories")
+    output_dir = output_parent / "filtered"
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-f", str(output_dir)]
+    )
+
+    run_from_args(args)
+    capsys.readouterr()
+
+    assert output_dir.stat().st_mode & stat.S_ISGID
 
 
 def test_filtered_output_builds_before_applying_read_only_destination_mode(

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -440,6 +440,22 @@ def test_build_parser_accepts_scenario():
     assert args.scenario == "bull"
 
 
+def test_build_parser_accepts_save_outputs_and_overwrite():
+    args = build_parser().parse_args(
+        [
+            "-s",
+            "selected.json",
+            "-f",
+            "filtered",
+            "--overwrite",
+        ]
+    )
+
+    assert args.save_selected == "selected.json"
+    assert args.save_filtered == "filtered"
+    assert args.overwrite is True
+
+
 def test_project_and_rebuild_scenario_front(scenario_pareto_dir: Path):
     _pareto_dir, candidates, specs = load_candidates(scenario_pareto_dir)
 
@@ -761,6 +777,269 @@ def test_run_from_args_json_output(sample_pareto_dir: Path, capsys):
     assert "ranking_order" not in payload["selected"]["details"]
     assert "score_vector" not in payload["selected"]["details"]
     assert result.candidate.path.stem == "b_extreme"
+
+
+def test_run_from_args_saves_selected_member_exactly(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    capsys,
+):
+    output = tmp_path / "promoted" / "candidate.json"
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "--method",
+            "utility",
+            "--weight",
+            "metric_b=5",
+            "-s",
+            str(output),
+        ]
+    )
+
+    result = run_from_args(args)
+
+    assert result.candidate.path.name == "b_extreme.json"
+    assert output.read_bytes() == (sample_pareto_dir / "b_extreme.json").read_bytes()
+    assert "Saved selected member:" in capsys.readouterr().out
+
+
+def test_run_from_args_saves_filtered_members_and_manifest(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    capsys,
+):
+    output_dir = tmp_path / "filtered"
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-l",
+            "metric_a>0.6",
+            "-f",
+            str(output_dir),
+        ]
+    )
+
+    result = run_from_args(args)
+
+    assert result.candidate.path.name == "balanced.json"
+    assert sorted(path.name for path in output_dir.iterdir()) == [
+        "a_extreme.json",
+        "balanced.json",
+        "selection.json",
+    ]
+    assert (output_dir / "a_extreme.json").read_bytes() == (
+        sample_pareto_dir / "a_extreme.json"
+    ).read_bytes()
+    manifest = json.loads((output_dir / "selection.json").read_text())
+    assert manifest["tool"] == "passivbot tool pareto"
+    assert manifest["mode"] == "filtered"
+    assert manifest["loaded_count"] == 4
+    assert manifest["retained_count"] == 2
+    assert manifest["scenario"] is None
+    assert manifest["selected_member"]["file"] == "balanced.json"
+    assert [member["file"] for member in manifest["members"]] == [
+        "a_extreme.json",
+        "balanced.json",
+    ]
+    assert manifest["applied_limits"][0]["metric"] == "metric_a"
+    assert "Saved filtered members: 2" in capsys.readouterr().out
+
+
+def test_saved_outputs_are_reported_in_json(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    capsys,
+):
+    selected_output = tmp_path / "selected.json"
+    filtered_output = tmp_path / "filtered"
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-l",
+            "metric_a>0.6",
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_output),
+            "--json",
+        ]
+    )
+
+    run_from_args(args)
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["selected"]["saved_path"] == str(selected_output.resolve())
+    assert payload["saved_filtered"] == {
+        "count": 2,
+        "directory": str(filtered_output.resolve()),
+        "manifest": str((filtered_output / "selection.json").resolve()),
+        "stage": "post_limits",
+    }
+
+
+def test_saved_outputs_require_explicit_overwrite(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    capsys,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"old": true}\n')
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-s", str(selected_output)]
+    )
+
+    with pytest.raises(FileExistsError, match="use --overwrite"):
+        run_from_args(args)
+    assert json.loads(selected_output.read_text()) == {"old": True}
+
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-s", str(selected_output), "--overwrite"]
+    )
+    result = run_from_args(args)
+    capsys.readouterr()
+    assert selected_output.read_bytes() == result.candidate.path.read_bytes()
+
+    filtered_output = tmp_path / "filtered"
+    filtered_output.mkdir()
+    stale = filtered_output / "stale.json"
+    stale.write_text('{"stale": true}\n')
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-f", str(filtered_output)]
+    )
+    with pytest.raises(FileExistsError, match="use --overwrite"):
+        run_from_args(args)
+    assert stale.exists()
+
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-l",
+            "metric_a>0.6",
+            "-f",
+            str(filtered_output),
+            "--overwrite",
+        ]
+    )
+    run_from_args(args)
+    capsys.readouterr()
+    assert not stale.exists()
+    assert sorted(path.name for path in filtered_output.iterdir()) == [
+        "a_extreme.json",
+        "balanced.json",
+        "selection.json",
+    ]
+
+
+def test_filtered_overwrite_refuses_non_json_entries(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+):
+    output_dir = tmp_path / "filtered"
+    output_dir.mkdir()
+    note = output_dir / "notes.txt"
+    note.write_text("keep me\n")
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-f", str(output_dir), "--overwrite"]
+    )
+
+    with pytest.raises(FileExistsError, match="non-JSON entries: notes.txt"):
+        run_from_args(args)
+
+    assert note.read_text() == "keep me\n"
+
+
+def test_save_filtered_refuses_manifest_filename_collision(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+):
+    _write_candidate(
+        sample_pareto_dir,
+        "Selection",
+        {"metric_a": 0.5, "metric_b": 0.5, "metric_c": 0.5},
+    )
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-f", str(tmp_path / "filtered")]
+    )
+
+    with pytest.raises(ValueError, match="reserved manifest name 'selection.json'"):
+        run_from_args(args)
+
+
+def test_save_outputs_refuse_source_pareto_directory(
+    sample_pareto_dir: Path,
+):
+    selected_args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-s",
+            str(sample_pareto_dir / "promoted.json"),
+        ]
+    )
+    with pytest.raises(ValueError, match="inside the source Pareto directory"):
+        run_from_args(selected_args)
+
+    filtered_args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-f", str(sample_pareto_dir / "filtered")]
+    )
+    with pytest.raises(ValueError, match="inside the source Pareto directory"):
+        run_from_args(filtered_args)
+
+
+def test_save_filtered_with_scenario_exports_post_limit_set(
+    scenario_pareto_dir: Path,
+    tmp_path: Path,
+    capsys,
+):
+    output_dir = tmp_path / "bull_filtered"
+    args = build_parser().parse_args(
+        [
+            str(scenario_pareto_dir),
+            "--scenario",
+            "bull",
+            "-f",
+            str(output_dir),
+        ]
+    )
+
+    run_from_args(args)
+    capsys.readouterr()
+    manifest = json.loads((output_dir / "selection.json").read_text())
+
+    assert manifest["scenario"] == "bull"
+    assert manifest["retained_count"] == 4
+    assert sorted(member["file"] for member in manifest["members"]) == [
+        "a.json",
+        "b.json",
+        "c_dominated.json",
+        "d.json",
+    ]
+    assert (output_dir / "c_dominated.json").exists()
+
+
+def test_no_saved_output_is_written_when_limits_reject_all(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+):
+    selected_output = tmp_path / "selected.json"
+    filtered_output = tmp_path / "filtered"
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-l",
+            "metric_a>2",
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_output),
+        ]
+    )
+
+    with pytest.raises(ValueError, match="No Pareto candidates remained"):
+        run_from_args(args)
+
+    assert not selected_output.exists()
+    assert not filtered_output.exists()
 
 
 def test_select_candidate_accepts_non_scoring_metric_from_stats(sample_pareto_dir: Path):

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import shutil
 import stat
 from pathlib import Path
 
 import pytest
+import pareto_explorer
 
 from pareto_explorer import (
     build_scenario_front,
@@ -963,18 +963,19 @@ def test_selected_output_does_not_overwrite_racing_destination_without_permissio
     monkeypatch,
 ):
     selected_output = tmp_path / "selected.json"
-    real_copy2 = shutil.copy2
     destination_created = False
 
-    def create_destination_during_staging(source, destination, *args, **kwargs):
+    def create_destination_during_staging(candidate, destination):
         nonlocal destination_created
         destination = Path(destination)
         if not destination_created and destination.suffix == ".tmp":
             selected_output.write_text('{"racing": true}\n')
             destination_created = True
-        return real_copy2(source, destination, *args, **kwargs)
+        destination.write_bytes(candidate.source_bytes)
 
-    monkeypatch.setattr("pareto_explorer.shutil.copy2", create_destination_during_staging)
+    monkeypatch.setattr(
+        "pareto_explorer._write_candidate_snapshot", create_destination_during_staging
+    )
     args = build_parser().parse_args(
         [str(sample_pareto_dir), "-s", str(selected_output)]
     )
@@ -1001,6 +1002,27 @@ def test_filtered_overwrite_refuses_non_json_entries(
         run_from_args(args)
 
     assert note.read_text() == "keep me\n"
+
+
+@pytest.mark.parametrize("overwrite", [False, True])
+def test_save_filtered_refuses_ds_store(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    overwrite: bool,
+):
+    output_dir = tmp_path / "filtered"
+    output_dir.mkdir()
+    ds_store = output_dir / ".DS_Store"
+    ds_store.write_bytes(b"metadata")
+    command = [str(sample_pareto_dir), "-f", str(output_dir)]
+    if overwrite:
+        command.append("--overwrite")
+    args = build_parser().parse_args(command)
+
+    with pytest.raises(FileExistsError, match=r"non-JSON entries: \.DS_Store"):
+        run_from_args(args)
+
+    assert ds_store.read_bytes() == b"metadata"
 
 
 def test_filtered_overwrite_revalidates_contents_after_move_aside(
@@ -1049,17 +1071,16 @@ def test_filtered_overwrite_preserves_previous_set_when_staging_fails(
     output_dir.mkdir()
     stale = output_dir / "stale.json"
     stale.write_text('{"stale": true}\n')
-    real_copy2 = shutil.copy2
     copies = 0
 
-    def fail_on_second_copy(source, destination, *args, **kwargs):
+    def fail_on_second_copy(candidate, destination):
         nonlocal copies
         copies += 1
         if copies == 2:
             raise OSError("simulated copy failure")
-        return real_copy2(source, destination, *args, **kwargs)
+        Path(destination).write_bytes(candidate.source_bytes)
 
-    monkeypatch.setattr("pareto_explorer.shutil.copy2", fail_on_second_copy)
+    monkeypatch.setattr("pareto_explorer._write_candidate_snapshot", fail_on_second_copy)
     args = build_parser().parse_args(
         [str(sample_pareto_dir), "-f", str(output_dir), "--overwrite"]
     )
@@ -1086,17 +1107,18 @@ def test_combined_outputs_restore_selected_when_filtered_staging_fails(
     filtered_output.mkdir()
     stale = filtered_output / "stale.json"
     stale.write_text('{"filtered": "old"}\n')
-    real_copy2 = shutil.copy2
 
-    def fail_during_filtered_staging(source, destination, *args, **kwargs):
+    def fail_during_filtered_staging(candidate, destination):
         destination = Path(destination)
         if destination.name == "b_extreme.json" and destination.parent.name.startswith(
             ".filtered."
         ):
             raise OSError("simulated filtered copy failure")
-        return real_copy2(source, destination, *args, **kwargs)
+        destination.write_bytes(candidate.source_bytes)
 
-    monkeypatch.setattr("pareto_explorer.shutil.copy2", fail_during_filtered_staging)
+    monkeypatch.setattr(
+        "pareto_explorer._write_candidate_snapshot", fail_during_filtered_staging
+    )
     args = build_parser().parse_args(
         [
             str(sample_pareto_dir),
@@ -1118,6 +1140,47 @@ def test_combined_outputs_restore_selected_when_filtered_staging_fails(
     assert json.loads(stale.read_text()) == {"filtered": "old"}
     assert sorted(path.name for path in filtered_output.iterdir()) == ["stale.json"]
     assert not [path for path in tmp_path.iterdir() if ".backup" in path.name]
+
+
+def test_combined_outputs_remain_consistent_when_backup_cleanup_fails(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"selected": "old"}\n')
+    filtered_output = tmp_path / "filtered"
+    filtered_output.mkdir()
+    (filtered_output / "stale.json").write_text('{"filtered": "old"}\n')
+    real_remove = pareto_explorer._remove_output_tree
+
+    def fail_backup_cleanup(path: Path):
+        if ".backup-" in path.name:
+            raise OSError("simulated backup cleanup failure")
+        return real_remove(path)
+
+    monkeypatch.setattr(pareto_explorer, "_remove_output_tree", fail_backup_cleanup)
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_output),
+            "--overwrite",
+        ]
+    )
+
+    result = run_from_args(args)
+
+    assert selected_output.read_bytes() == result.candidate.source_bytes
+    assert not (filtered_output / "stale.json").exists()
+    assert (filtered_output / "selection.json").exists()
+    assert "old backup could not be removed" in capsys.readouterr().err
+    backups = [path for path in tmp_path.iterdir() if ".backup-" in path.name]
+    assert len(backups) == 1
+    real_remove(backups[0])
 
 
 @pytest.mark.parametrize("output_exists", [False, True])
@@ -1144,6 +1207,35 @@ def test_filtered_output_directory_uses_destination_permissions(
     capsys.readouterr()
 
     assert stat.S_IMODE(output_dir.stat().st_mode) == 0o750
+
+
+def test_filtered_output_preserves_existing_directory_metadata(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    capsys,
+):
+    output_dir = tmp_path / "filtered"
+    output_dir.mkdir()
+    (output_dir / "stale.json").write_text('{"stale": true}\n')
+    before = output_dir.stat()
+    xattr_name = b"user.passivbot_test"
+    xattr_supported = hasattr(os, "setxattr") and hasattr(os, "getxattr")
+    if xattr_supported:
+        try:
+            os.setxattr(output_dir, xattr_name, b"preserve")
+        except OSError:
+            xattr_supported = False
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-f", str(output_dir), "--overwrite"]
+    )
+
+    run_from_args(args)
+    capsys.readouterr()
+
+    after = output_dir.stat()
+    assert (after.st_uid, after.st_gid) == (before.st_uid, before.st_gid)
+    if xattr_supported:
+        assert os.getxattr(output_dir, xattr_name) == b"preserve"
 
 
 def test_filtered_output_builds_before_applying_read_only_destination_mode(
@@ -1228,6 +1320,47 @@ def test_save_filtered_preserves_symlink_member_name(
     assert member["hash"] == "aliased_member"
     assert member["source_path"] == str(resolved_source.resolve())
     assert member["output_path"] == str((output_dir / "aliased_member.json").resolve())
+
+
+def test_saved_outputs_use_candidate_snapshot_from_selection_time(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    source = sample_pareto_dir / "balanced.json"
+    original_bytes = source.read_bytes()
+    selected_output = tmp_path / "selected.json"
+    filtered_output = tmp_path / "filtered"
+    real_write_snapshot = pareto_explorer._write_candidate_snapshot
+    source_changed = False
+
+    def change_source_before_export(candidate, destination):
+        nonlocal source_changed
+        if not source_changed:
+            source.write_text('{"changed": true}\n')
+            source_changed = True
+        return real_write_snapshot(candidate, destination)
+
+    monkeypatch.setattr(
+        pareto_explorer, "_write_candidate_snapshot", change_source_before_export
+    )
+    args = build_parser().parse_args(
+        [
+            str(source),
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_output),
+        ]
+    )
+
+    run_from_args(args)
+    capsys.readouterr()
+
+    assert source.read_bytes() != original_bytes
+    assert selected_output.read_bytes() == original_bytes
+    assert (filtered_output / "balanced.json").read_bytes() == original_bytes
 
 
 def test_save_filtered_refuses_manifest_filename_collision(

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -1666,6 +1666,148 @@ def test_combined_outputs_restore_selected_when_install_return_is_interrupted(
     assert not [path for path in tmp_path.iterdir() if ".backup" in path.name]
 
 
+def test_combined_outputs_keep_committed_pair_when_filtered_return_is_interrupted(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"selected": "old"}\n')
+    filtered_output = tmp_path / "filtered"
+    filtered_output.mkdir()
+    (filtered_output / "stale.json").write_text('{"filtered": "old"}\n')
+    real_write_filtered = pareto_explorer._write_filtered_outputs
+    interrupted = False
+
+    def interrupt_after_filtered_return(*args, **kwargs):
+        nonlocal interrupted
+        real_write_filtered(*args, **kwargs)
+        interrupted = True
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr(
+        pareto_explorer, "_write_filtered_outputs", interrupt_after_filtered_return
+    )
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_output),
+            "--overwrite",
+        ]
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        run_from_args(args)
+
+    assert interrupted
+    assert selected_output.read_bytes() != b'{"selected": "old"}\n'
+    assert not (filtered_output / "stale.json").exists()
+    assert (filtered_output / "selection.json").exists()
+
+
+def test_selected_rollback_restores_path_when_verification_is_interrupted(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"selected": "old"}\n')
+    filtered_output = tmp_path / "filtered"
+    real_write_snapshot = pareto_explorer._write_candidate_snapshot_fd
+    real_stat = Path.stat
+    interrupted = False
+
+    def fail_filtered_staging(candidate, destination, file_descriptor):
+        destination = Path(destination)
+        if destination.parent.name.startswith(pareto_explorer.FILTERED_STAGING_PREFIX):
+            os.close(file_descriptor)
+            raise OSError("simulated filtered copy failure")
+        real_write_snapshot(candidate, destination, file_descriptor)
+
+    def interrupt_rollback_stat(path: Path, *args, **kwargs):
+        nonlocal interrupted
+        if path.suffix == ".rollback" and not interrupted:
+            interrupted = True
+            raise KeyboardInterrupt()
+        return real_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(
+        pareto_explorer, "_write_candidate_snapshot_fd", fail_filtered_staging
+    )
+    monkeypatch.setattr(Path, "stat", interrupt_rollback_stat)
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_output),
+            "--overwrite",
+        ]
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        run_from_args(args)
+
+    assert interrupted
+    assert selected_output.exists()
+    backups = [path for path in tmp_path.iterdir() if path.suffix == ".backup"]
+    rollbacks = [path for path in tmp_path.iterdir() if path.suffix == ".rollback"]
+    assert len(backups) == 1
+    assert len(rollbacks) == 1
+    assert json.loads(backups[0].read_text()) == {"selected": "old"}
+    assert selected_output.read_bytes() == rollbacks[0].read_bytes()
+    backups[0].unlink()
+    rollbacks[0].unlink()
+
+
+def test_selected_rollback_preserves_timestamps_without_hard_links(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"selected": "old"}\n')
+    old_timestamp_ns = 946684800_000_000_000
+    os.utime(selected_output, ns=(old_timestamp_ns, old_timestamp_ns))
+    filtered_output = tmp_path / "filtered"
+    real_write_snapshot = pareto_explorer._write_candidate_snapshot_fd
+
+    def reject_hard_link(*args, **kwargs):
+        raise OSError(errno.EOPNOTSUPP, "hard links unsupported")
+
+    def fail_filtered_staging(candidate, destination, file_descriptor):
+        destination = Path(destination)
+        if destination.parent.name.startswith(pareto_explorer.FILTERED_STAGING_PREFIX):
+            os.close(file_descriptor)
+            raise OSError("simulated filtered copy failure")
+        real_write_snapshot(candidate, destination, file_descriptor)
+
+    monkeypatch.setattr(os, "link", reject_hard_link)
+    monkeypatch.setattr(
+        pareto_explorer, "_write_candidate_snapshot_fd", fail_filtered_staging
+    )
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_output),
+            "--overwrite",
+        ]
+    )
+
+    with pytest.raises(OSError, match="simulated filtered copy failure"):
+        run_from_args(args)
+
+    assert json.loads(selected_output.read_text()) == {"selected": "old"}
+    assert selected_output.stat().st_mtime_ns == old_timestamp_ns
+
+
 def test_combined_outputs_refuse_rollback_over_newer_selected_file(
     sample_pareto_dir: Path,
     tmp_path: Path,
@@ -2515,6 +2657,34 @@ def test_single_file_input_allows_sibling_outputs(
     ]
 
 
+def test_single_file_input_rejects_filtered_parent_filesystem_alias(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    source = sample_pareto_dir / "balanced.json"
+    output_alias = tmp_path / "source-parent-alias"
+    output_alias.mkdir()
+    real_samefile = os.path.samefile
+
+    def report_bind_mount_alias(left, right):
+        pair = {Path(left).resolve(), Path(right).resolve()}
+        if pair == {output_alias.resolve(), sample_pareto_dir.resolve()}:
+            return True
+        return real_samefile(left, right)
+
+    monkeypatch.setattr(os.path, "samefile", report_bind_mount_alias)
+    args = build_parser().parse_args(
+        [str(source), "-f", str(output_alias), "--overwrite"]
+    )
+
+    with pytest.raises(ValueError, match="resolved source Pareto member"):
+        run_from_args(args)
+
+    assert source.exists()
+    assert not list(output_alias.iterdir())
+
+
 def test_single_file_symlink_member_path_normalizes_dot_dot_without_dereferencing(
     tmp_path: Path,
 ):
@@ -2607,6 +2777,44 @@ def test_save_outputs_refuse_both_overlap_directions(
 
     assert not filtered_parent.exists()
     assert not selected_parent.exists()
+
+
+def test_save_outputs_refuse_filesystem_alias_overlap(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    selected_parent = tmp_path / "selected-parent"
+    selected_parent.mkdir()
+    selected_output = selected_parent / "selected.json"
+    selected_output.write_text('{"selected": "old"}\n')
+    filtered_alias = tmp_path / "filtered-alias"
+    filtered_alias.mkdir()
+    real_samefile = os.path.samefile
+
+    def report_bind_mount_alias(left, right):
+        pair = {Path(left).resolve(), Path(right).resolve()}
+        if pair == {selected_parent.resolve(), filtered_alias.resolve()}:
+            return True
+        return real_samefile(left, right)
+
+    monkeypatch.setattr(os.path, "samefile", report_bind_mount_alias)
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_alias),
+            "--overwrite",
+        ]
+    )
+
+    with pytest.raises(ValueError, match="must not overlap"):
+        run_from_args(args)
+
+    assert json.loads(selected_output.read_text()) == {"selected": "old"}
+    assert not list(filtered_alias.iterdir())
 
 
 def test_filtered_manifest_records_normalized_decision_inputs(

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -1114,6 +1114,43 @@ def test_selected_staging_creation_cleans_up_when_interrupted(
     ]
 
 
+def test_selected_output_refuses_replaced_staging_inode(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    selected_output = tmp_path / "selected.json"
+    real_write_snapshot = pareto_explorer._write_candidate_snapshot_fd
+    replaced_staging: Path | None = None
+
+    def replace_staging_after_write(candidate, destination, file_descriptor):
+        nonlocal replaced_staging
+        destination = Path(destination)
+        real_write_snapshot(candidate, destination, file_descriptor)
+        if destination.name.startswith(pareto_explorer.SELECTED_STAGING_PREFIX):
+            attacker = tmp_path / "attacker.json"
+            attacker.write_text('{"attacker": true}\n')
+            os.replace(attacker, destination)
+            replaced_staging = destination
+
+    monkeypatch.setattr(
+        pareto_explorer,
+        "_write_candidate_snapshot_fd",
+        replace_staging_after_write,
+    )
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-s", str(selected_output)]
+    )
+
+    with pytest.raises(RuntimeError, match="staging file changed concurrently"):
+        run_from_args(args)
+
+    assert not selected_output.exists()
+    assert replaced_staging is not None
+    assert json.loads(replaced_staging.read_text()) == {"attacker": True}
+    replaced_staging.unlink()
+
+
 @pytest.mark.parametrize(
     ("error_number", "winerror"),
     [(errno.EOPNOTSUPP, None), (errno.EINVAL, 1)],
@@ -1297,6 +1334,39 @@ def test_selected_overwrite_detects_in_place_edit_before_commit(
     assert selected_output.stat().st_ino == original_inode
     assert json.loads(selected_output.read_text()) == {"selected": "newer"}
     assert not [path for path in tmp_path.iterdir() if path.suffix == ".backup"]
+
+
+def test_selected_overwrite_transfers_metadata_after_validated_move(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"selected": "old"}\n')
+    selected_output.chmod(0o644)
+    real_replace = os.replace
+    edited = False
+
+    def edit_metadata_before_move(source, destination):
+        nonlocal edited
+        source = Path(source)
+        destination = Path(destination)
+        if source == selected_output and destination.suffix == ".backup" and not edited:
+            selected_output.chmod(0o600)
+            edited = True
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(os, "replace", edit_metadata_before_move)
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-s", str(selected_output), "--overwrite"]
+    )
+
+    run_from_args(args)
+    capsys.readouterr()
+
+    assert edited
+    assert stat.S_IMODE(selected_output.stat().st_mode) == 0o600
 
 
 def test_selected_output_supports_name_max_destination(
@@ -1802,7 +1872,10 @@ def test_combined_outputs_record_filtered_reservation_at_mkdir_boundary(
     def interrupt_after_filtered_mkdir(path: Path, *args, **kwargs):
         nonlocal interrupted
         result = real_mkdir(path, *args, **kwargs)
-        if path == filtered_output and not interrupted:
+        if (
+            path.name.startswith(pareto_explorer.FILTERED_RESERVATION_PREFIX)
+            and not interrupted
+        ):
             interrupted = True
             raise KeyboardInterrupt()
         return result
@@ -2562,31 +2635,35 @@ def test_filtered_output_rechecks_directory_created_during_reservation(
     sample_pareto_dir: Path,
     tmp_path: Path,
     monkeypatch,
-    capsys,
 ):
     output_dir = tmp_path / "filtered"
-    real_mkdir = Path.mkdir
+    real_replace = os.replace
     raced = False
 
-    def create_racing_destination(path: Path, *args, **kwargs):
+    def create_racing_destination(source, destination):
         nonlocal raced
-        if path == output_dir and not raced:
+        source = Path(source)
+        destination = Path(destination)
+        if (
+            destination == output_dir
+            and source.name.startswith(pareto_explorer.FILTERED_RESERVATION_PREFIX)
+            and not raced
+        ):
             raced = True
-            os.mkdir(path, 0o750)
-            path.chmod(0o750)
-            raise FileExistsError(path)
-        return real_mkdir(path, *args, **kwargs)
+            output_dir.mkdir(mode=0o750)
+            (output_dir / "racing.json").write_text('{"racing": true}\n')
+        return real_replace(source, destination)
 
-    monkeypatch.setattr(Path, "mkdir", create_racing_destination)
+    monkeypatch.setattr(os, "replace", create_racing_destination)
     args = build_parser().parse_args(
         [str(sample_pareto_dir), "-f", str(output_dir), "--overwrite"]
     )
 
-    run_from_args(args)
-    capsys.readouterr()
+    with pytest.raises(OSError):
+        run_from_args(args)
 
     assert raced
-    assert stat.S_IMODE(output_dir.stat().st_mode) == 0o750
+    assert json.loads((output_dir / "racing.json").read_text()) == {"racing": True}
 
 
 def test_new_filtered_output_retains_inherited_setgid_metadata(
@@ -2874,6 +2951,38 @@ def test_save_outputs_refuse_descendants_of_source_directory_alias(
 
     preserved = output / "notes.json" if output_kind == "filtered" else output
     assert json.loads(preserved.read_text()) == {"unrelated": True}
+
+
+def test_selected_output_revalidates_parent_created_as_source_alias(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    output_parent = tmp_path / "late-parent"
+    selected_output = output_parent / "balanced.json"
+    source = sample_pareto_dir / "balanced.json"
+    original_bytes = source.read_bytes()
+    real_mkdir = Path.mkdir
+    aliased = False
+
+    def create_source_alias_parent(path: Path, *args, **kwargs):
+        nonlocal aliased
+        if path == output_parent and not aliased:
+            path.symlink_to(sample_pareto_dir, target_is_directory=True)
+            aliased = True
+            return None
+        return real_mkdir(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", create_source_alias_parent)
+    args = build_parser().parse_args(
+        [str(sample_pareto_dir), "-s", str(selected_output), "--overwrite"]
+    )
+
+    with pytest.raises(ValueError, match="source Pareto"):
+        run_from_args(args)
+
+    assert aliased
+    assert source.read_bytes() == original_bytes
 
 
 def test_single_file_input_allows_sibling_outputs(

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -1151,6 +1151,54 @@ def test_selected_fallback_refuses_to_remove_concurrent_replacement(
     backups[0].unlink()
 
 
+def test_selected_fallback_recovers_when_exclusive_creation_is_interrupted(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"selected": "old"}\n')
+    filtered_output = tmp_path / "filtered"
+    real_open = Path.open
+    interrupted = False
+
+    def reject_hard_link(*args, **kwargs):
+        raise OSError(errno.EOPNOTSUPP, "hard links unsupported")
+
+    def interrupt_after_exclusive_create(path: Path, *args, **kwargs):
+        nonlocal interrupted
+        output_file = real_open(path, *args, **kwargs)
+        if path == selected_output and args and args[0] == "xb" and not interrupted:
+            interrupted = True
+            output_file.close()
+            raise KeyboardInterrupt()
+        return output_file
+
+    monkeypatch.setattr(os, "link", reject_hard_link)
+    monkeypatch.setattr(Path, "open", interrupt_after_exclusive_create)
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_output),
+            "--overwrite",
+        ]
+    )
+
+    with pytest.raises(RuntimeError, match="unverified file retained"):
+        run_from_args(args)
+
+    assert interrupted
+    assert json.loads(selected_output.read_text()) == {"selected": "old"}
+    assert not filtered_output.exists()
+    failed = [path for path in tmp_path.iterdir() if path.suffix == ".failed"]
+    assert len(failed) == 1
+    assert failed[0].read_bytes() == b""
+    failed[0].unlink()
+
+
 def test_selected_overwrite_detects_replacement_before_commit(
     sample_pareto_dir: Path,
     tmp_path: Path,
@@ -1664,6 +1712,47 @@ def test_combined_outputs_restore_selected_when_install_return_is_interrupted(
     assert json.loads(stale.read_text()) == {"filtered": "old"}
     assert sorted(path.name for path in filtered_output.iterdir()) == ["stale.json"]
     assert not [path for path in tmp_path.iterdir() if ".backup" in path.name]
+
+
+def test_combined_outputs_cleanup_filtered_reservation_when_return_is_interrupted(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    selected_output = tmp_path / "selected.json"
+    selected_output.write_text('{"selected": "old"}\n')
+    selected_inode = selected_output.stat().st_ino
+    filtered_output = tmp_path / "filtered"
+    real_ensure = pareto_explorer._ensure_filtered_output_dir
+    interrupted = False
+
+    def interrupt_after_reservation(*args, **kwargs):
+        nonlocal interrupted
+        result = real_ensure(*args, **kwargs)
+        interrupted = True
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr(
+        pareto_explorer, "_ensure_filtered_output_dir", interrupt_after_reservation
+    )
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_output),
+            "--overwrite",
+        ]
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        run_from_args(args)
+
+    assert interrupted
+    assert json.loads(selected_output.read_text()) == {"selected": "old"}
+    assert selected_output.stat().st_ino == selected_inode
+    assert not filtered_output.exists()
 
 
 def test_combined_outputs_record_no_hard_link_commit_before_nested_return(
@@ -2742,6 +2831,23 @@ def test_single_file_input_allows_sibling_outputs(
     ]
 
 
+def test_single_file_input_rejects_non_json_filtered_member_name(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+):
+    json_source = sample_pareto_dir / "balanced.json"
+    source = tmp_path / "balanced.config"
+    source.write_bytes(json_source.read_bytes())
+    output_dir = tmp_path / "filtered"
+    args = build_parser().parse_args([str(source), "-f", str(output_dir)])
+
+    with pytest.raises(ValueError, match=r"must use \.json filenames"):
+        run_from_args(args)
+
+    assert source.exists()
+    assert not output_dir.exists()
+
+
 def test_single_file_input_rejects_filtered_parent_filesystem_alias(
     sample_pareto_dir: Path,
     tmp_path: Path,
@@ -2900,6 +3006,44 @@ def test_save_outputs_refuse_filesystem_alias_overlap(
 
     assert json.loads(selected_output.read_text()) == {"selected": "old"}
     assert not list(filtered_alias.iterdir())
+
+
+def test_save_outputs_conservatively_normalize_aliased_uncreated_suffixes(
+    sample_pareto_dir: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    selected_root = tmp_path / "selected-root"
+    selected_root.mkdir()
+    filtered_root = tmp_path / "filtered-root"
+    filtered_root.mkdir()
+    selected_output = selected_root / "New" / "selected.json"
+    filtered_output = filtered_root / "new"
+    real_samefile = os.path.samefile
+
+    def report_bind_mount_alias(left, right):
+        pair = {Path(left).resolve(), Path(right).resolve()}
+        if pair == {selected_root.resolve(), filtered_root.resolve()}:
+            return True
+        return real_samefile(left, right)
+
+    monkeypatch.setattr(os.path, "samefile", report_bind_mount_alias)
+    args = build_parser().parse_args(
+        [
+            str(sample_pareto_dir),
+            "-s",
+            str(selected_output),
+            "-f",
+            str(filtered_output),
+            "--overwrite",
+        ]
+    )
+
+    with pytest.raises(ValueError, match="must not overlap"):
+        run_from_args(args)
+
+    assert not selected_output.exists()
+    assert not filtered_output.exists()
 
 
 def test_filtered_manifest_records_normalized_decision_inputs(

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -1081,16 +1081,25 @@ def test_selected_staging_uses_normal_exclusive_file_creation(
     assert mode == 0o666
 
 
+@pytest.mark.parametrize(
+    ("error_number", "winerror"),
+    [(errno.EOPNOTSUPP, None), (errno.EINVAL, 1)],
+)
 def test_selected_output_falls_back_when_hard_links_are_unsupported(
     sample_pareto_dir: Path,
     tmp_path: Path,
     monkeypatch,
     capsys,
+    error_number: int,
+    winerror: int | None,
 ):
     selected_output = tmp_path / "selected.json"
 
     def reject_hard_link(*args, **kwargs):
-        raise OSError(errno.EOPNOTSUPP, "hard links unsupported")
+        error = OSError(error_number, "hard links unsupported")
+        if winerror is not None:
+            error.winerror = winerror
+        raise error
 
     monkeypatch.setattr(os, "link", reject_hard_link)
     args = build_parser().parse_args(


### PR DESCRIPTION
## Summary

- add `-s` / `--save-selected` to copy the selected Pareto member to an exact JSON destination
- add `-f` / `--save-filtered` to copy the complete post-limit member set with a `selection.json` manifest
- preserve original Pareto artifacts, report saved paths in text and JSON output, and document scenario-stage semantics
- fail closed on source-directory writes, implicit overwrites, mixed non-JSON output directories, filename collisions, and overlapping destinations

## Validation

- `pytest -q tests/test_pareto_explorer.py tests/test_pareto_compress.py tests/test_passivbot_cli.py tests/test_ai_docs.py tests/test_live_event_registry_docs.py`
- `pytest -q tests/test_pareto_*.py tests/test_merge_paretos_tool.py`
- `python -m compileall -q src/pareto_explorer.py tests/test_pareto_explorer.py`
- `PYTHONPATH=src python src/tools/check_ai_docs.py`
- `PYTHONPATH=src python src/tools/generate_live_event_registry.py --check`
- `git diff --check`