### PR TITLE
feat(optimize): support anchored GPU fine tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Extend the experimental Apple MPS optimizer to anchored fine-tuning with `--start` plus
+  `--fine-tune-params` for supported EMA-anchor and trailing-martingale scopes. The Metal proxy
+  evolves the same discrete anchor id as exact Rust, applies each anchor's fixed optimizer-bound
+  values before candidate tunables, and validates the full cross-anchor range so side enablement
+  or unsupported risk behavior cannot be introduced silently.
+
 - KuCoin private futures order websockets now discard the exact cached negotiated URL when the
   exchange expires its token, allowing `watch_orders` to obtain a fresh token instead of reusing
   the rejected URL indefinitely. The expected callback exception is reduced to a throttled warning

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -662,7 +662,8 @@ Risk should be constrained through canonical `*_strategy_eq` metrics instead. De
 - **population_size**: Size of population for genetic optimization algorithm. With the default `pymoo` backend, `null` means auto: NSGA-II resolves to `250`, while NSGA-III resolves to a default population budget of `500` and chooses the finest auto reference-direction grid that fits inside that budget. Set an explicit integer to change the NSGA-III per-generation evaluation budget and auto reference-direction coarseness.
 - **backend**: Optimizer backend. Default is `pymoo`. Supported values are `deap`, `pymoo`, and
   experimental `gpu`. The GPU backend currently supports Apple MPS, single-coin EMA-anchor and
-  trailing-martingale runs in long-only, short-only, and long+short modes; see
+  trailing-martingale runs in long-only, short-only, and long+short modes; single-side multi-coin
+  EMA-anchor runs; and anchored fine-tuning with `--start` plus `--fine-tune-params`. See
   `docs/optimizing.md` for its fail-closed scope and `optimize.gpu` settings.
   With the default `optimize.pymoo.algorithm: "auto"`, Passivbot uses `nsga2` for `3` or fewer
   objectives and `nsga3` for `4+`.

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -100,12 +100,15 @@ and the DEAP/pymoo CPU optimizers do not import or require PyTorch.
 The supported slice is intentionally narrow:
 
 - Apple Silicon with `torch.backends.mps.is_available()`
-- one exchange and one coin, using one-minute candles
+- one exchange using one-minute candles
 - `strategy_kind: ema_anchor` or `trailing_martingale`, with long-only, short-only, or
-  long+short enabled
-- trailing-martingale entry and close `retracement_base_pct` optimizer bounds strictly above zero;
-  zero or negative values select recursive grid ladders that this screening slice does not model
+  long+short enabled for one coin
+- long-only or short-only multi-coin EMA-anchor runs for up to 64 coins, with dynamic wallet-
+  exposure allocation and Forager selection; multi-coin runs require
+  `backtest.dynamic_wel_by_tradability: true` and `live.forager_score_hysteresis_pct: 0`
 - each enabled side's `n_positions` pinned to `1` and wallet-exposure limit kept positive
+  for single-coin runs; supported multi-coin bounds may vary `n_positions` between `1` and the
+  prepared coin count
 - hedge mode and one-way mode; one-way flat-side arbitration uses the active strategy's Rust rule
 - suite mode disabled
 - HSL and auto-unstuck disabled
@@ -115,9 +118,17 @@ The supported slice is intentionally narrow:
 - `live.market_orders_allowed: false`
 - no invalid candle tail after the selected coin's final valid candle
 
-Unsupported combinations fail before optimization begins. Recursive trailing-martingale grid
-modes, multi-coin, suites, HSL, auto-unstuck, and forager-dependent selection are not silently
-approximated by this release.
+Unsupported combinations fail before optimization begins. Multi-coin trailing-martingale or
+long+short runs, suites, HSL, and auto-unstuck are not silently approximated by this release.
+
+Ordinary `-t/--start` seeding and fine-tuning with `-ft/--fine-tune-params` use the same optimizer
+shape as the CPU backends. When `-t` and `-ft` are combined, the GPU population includes the
+discrete anchor id alongside the selected tunable bounds. Anchor-fixed values are supplied to the
+screening proxy before each candidate's tunable values, while the unchanged exact Rust path
+materializes the same anchor and tunable vector. The complete range across all anchors is checked
+against the GPU scope: an anchor cannot change enabled sides or introduce unsupported risk
+behavior. Base-config runtime policy fields still win over anchor configs as described in
+[Fine-Tuning Specific Parameters](#fine-tuning-specific-parameters).
 
 Proxy scoring and limits are likewise fail-closed. This slice supports `adg_strategy_eq`,
 `adg_strategy_eq_w`, `mdg_strategy_eq`, `sharpe_ratio_strategy_eq`,

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -19,8 +19,9 @@ from config.metrics import resolve_metric_value
 from limit_utils import compute_limit_violation
 from metrics_schema import flatten_metric_stats
 from optimization.backend_shared import load_starting_individuals
-from optimization.bounds import enforce_bounds
+from optimization.bounds import Bound, enforce_bounds
 from optimization.callback import build_pymoo_record_entry
+from optimization.fine_tune_anchors import ANCHOR_GENE_KEY, get_anchor_plan
 from optimization.gpu.model import gpu_side_enabled
 from optimization.problem import (
     PymooAsyncRecordingRunner,
@@ -1033,23 +1034,107 @@ def _canonical_vector_hash(vector, bounds, sig_digits: int) -> str:
     return hashlib.sha256(json.dumps(canonical).encode()).hexdigest()
 
 
-def _build_proxy_parameter_dicts(base_vector, mapped, active, active_values) -> list[dict]:
+def _build_proxy_parameter_dicts(
+    base_vector,
+    mapped,
+    active,
+    active_values,
+    *,
+    anchor_parameter_overrides: list[dict[str, float]] | None = None,
+) -> list[dict]:
     """Include canonical pinned and active strategy values in each proxy candidate."""
 
     base_parameters = {
         name: float(base_vector[index]) for name, (index, _bound) in mapped.items()
     }
+    anchor_columns = [
+        column
+        for column, (name, _index, _bound) in enumerate(active)
+        if name == ANCHOR_GENE_KEY
+    ]
+    if len(anchor_columns) > 1:
+        raise ValueError("GPU anchored fine-tune has multiple anchor genes")
     result = []
     for row in active_values:
         parameters = dict(base_parameters)
+        if anchor_parameter_overrides is not None:
+            anchor_id = (
+                int(round(float(row[anchor_columns[0]]))) if anchor_columns else 0
+            )
+            if anchor_id < 0 or anchor_id >= len(anchor_parameter_overrides):
+                raise ValueError(
+                    "GPU anchored fine-tune selected invalid anchor id "
+                    f"{anchor_id}; available={len(anchor_parameter_overrides)}"
+                )
+            parameters.update(anchor_parameter_overrides[anchor_id])
+        elif anchor_columns:
+            raise ValueError("GPU anchor gene is present without an anchored fine-tune plan")
         parameters.update(
             {
                 name: float(row[column])
                 for column, (name, _index, _bound) in enumerate(active)
+                if name != ANCHOR_GENE_KEY
             }
         )
         result.append(parameters)
     return result
+
+
+def _build_anchor_parameter_context(
+    config: dict, bound_map: dict[str, str]
+) -> tuple[list[dict[str, float]] | None, dict[str, Bound]]:
+    """Resolve anchor-fixed optimizer values without materializing every candidate config."""
+
+    plan = get_anchor_plan(config)
+    if plan is None:
+        return None, {}
+    fixed_keys = set(plan.get("fixed_keys") or [])
+    parameter_overrides: list[dict[str, float]] = []
+    values_by_key: dict[str, list[float]] = {}
+    for anchor_index, anchor in enumerate(plan.get("anchors") or []):
+        seen = set()
+        overrides = {}
+        for item in anchor.get("fixed_values") or []:
+            key = item.get("key")
+            if not isinstance(key, str) or key not in fixed_keys:
+                raise ValueError(
+                    "GPU anchored fine-tune contains an invalid fixed optimizer key "
+                    f"for anchor {anchor_index}: {key!r}"
+                )
+            if key in seen:
+                raise ValueError(
+                    "GPU anchored fine-tune contains duplicate fixed optimizer key "
+                    f"{key!r} for anchor {anchor_index}"
+                )
+            seen.add(key)
+            try:
+                value = float(item["value"])
+            except (KeyError, TypeError, ValueError) as exc:
+                raise ValueError(
+                    "GPU anchored fine-tune contains a non-numeric fixed value "
+                    f"for {key!r} in anchor {anchor_index}"
+                ) from exc
+            if not math.isfinite(value):
+                raise ValueError(
+                    "GPU anchored fine-tune contains a non-finite fixed value "
+                    f"for {key!r} in anchor {anchor_index}"
+                )
+            values_by_key.setdefault(key, []).append(value)
+            if key in bound_map:
+                overrides[bound_map[key]] = value
+        missing = sorted(fixed_keys - seen)
+        if missing:
+            raise ValueError(
+                "GPU anchored fine-tune is missing fixed optimizer values for "
+                f"anchor {anchor_index}: {missing}"
+            )
+        parameter_overrides.append(overrides)
+    if not parameter_overrides:
+        raise ValueError("GPU anchored fine-tune requires at least one anchor")
+    fixed_bounds = {
+        key: Bound(min(values), max(values)) for key, values in values_by_key.items()
+    }
+    return parameter_overrides, fixed_bounds
 
 
 def _validate_pinned_scope_bounds(bound_by_key, base_by_key, enabled_sides=None) -> None:
@@ -1333,43 +1418,64 @@ def run_backend(
     else:
         bound_map = GPU_STRATEGY_BOUND_MAPS[strategy_kind]
 
+    anchor_parameter_overrides, anchor_fixed_bounds = (
+        _build_anchor_parameter_context(config, bound_map)
+    )
     mapped_all = {
         bound_map[bound_key]: (index, bounds[index])
         for index, (bound_key, _path) in enumerate(key_paths)
         if bound_key in bound_map
     }
     missing = sorted(set(bound_map.values()) - set(mapped_all))
-    if missing:
+    if anchor_parameter_overrides is None and missing:
         raise ValueError(
             f"GPU backend could not locate {strategy_kind} bounds for {missing}"
         )
+    if anchor_parameter_overrides is not None:
+        missing_from_anchors = sorted(
+            name
+            for name in missing
+            if any(name not in overrides for overrides in anchor_parameter_overrides)
+        )
+        if missing_from_anchors:
+            raise ValueError(
+                "GPU anchored fine-tune could not resolve fixed proxy parameters "
+                f"for {missing_from_anchors}"
+            )
     approved = config.get("live", {}).get("approved_coins", {})
 
     def side_approved(side: str) -> bool:
         return bool(approved.get(side, [])) if isinstance(approved, dict) else True
 
-    side_values = {}
-    for index, (bound_key, _path) in enumerate(key_paths):
-        if bound_key in {
-            "long_total_wallet_exposure_limit",
-            "long_n_positions",
-            "short_total_wallet_exposure_limit",
-            "short_n_positions",
-        }:
-            side_values[bound_key] = float(base_vector[index])
-
-    def vector_side_enabled(side: str) -> bool:
-        return (
-            side_approved(side)
-            and side_values.get(f"{side}_total_wallet_exposure_limit", 0.0) > 0.0
-            and side_values.get(f"{side}_n_positions", 0.0) > 0.0
-        )
-
-    enabled_sides = {side for side in ("long", "short") if vector_side_enabled(side)}
     config_enabled_sides = {
         side for side in ("long", "short") if gpu_side_enabled(config, side)
     }
-    _validate_seed_side_match(config_enabled_sides, enabled_sides)
+    if anchor_parameter_overrides is not None:
+        enabled_sides = set(config_enabled_sides)
+        side_values = {}
+    else:
+        side_values = {}
+        for index, (bound_key, _path) in enumerate(key_paths):
+            if bound_key in {
+                "long_total_wallet_exposure_limit",
+                "long_n_positions",
+                "short_total_wallet_exposure_limit",
+                "short_n_positions",
+            }:
+                side_values[bound_key] = float(base_vector[index])
+
+        def vector_side_enabled(side: str) -> bool:
+            return (
+                side_approved(side)
+                and side_values.get(f"{side}_total_wallet_exposure_limit", 0.0)
+                > 0.0
+                and side_values.get(f"{side}_n_positions", 0.0) > 0.0
+            )
+
+        enabled_sides = {
+            side for side in ("long", "short") if vector_side_enabled(side)
+        }
+        _validate_seed_side_match(config_enabled_sides, enabled_sides)
     if not enabled_sides:
         raise ValueError(
             "GPU bounds would disable both sides for exact validation; "
@@ -1385,6 +1491,12 @@ def run_backend(
         for name, (index, bound) in sorted(mapped.items(), key=lambda item: item[1][0])
         if bound.high > bound.low
     ]
+    active.extend(
+        (ANCHOR_GENE_KEY, index, bounds[index])
+        for index, (bound_key, _path) in enumerate(key_paths)
+        if bound_key == ANCHOR_GENE_KEY and bounds[index].high > bounds[index].low
+    )
+    active.sort(key=lambda item: item[1])
     if not active:
         raise ValueError(
             f"GPU backend found no free {strategy_kind} dimensions"
@@ -1393,6 +1505,13 @@ def run_backend(
     bound_by_key = {
         bound_key: bounds[index] for index, (bound_key, _path) in enumerate(key_paths)
     }
+    overlap = sorted(set(bound_by_key) & set(anchor_fixed_bounds))
+    if overlap:
+        raise ValueError(
+            "GPU anchored fine-tune marks optimizer keys as both tunable and fixed: "
+            f"{overlap}"
+        )
+    bound_by_key.update(anchor_fixed_bounds)
     base_by_key = {
         bound_key: float(base_vector[index])
         for index, (bound_key, _path) in enumerate(key_paths)
@@ -1407,8 +1526,8 @@ def run_backend(
         coin_count=coin_count,
     )
 
-    for index, (bound_key, _path) in enumerate(key_paths):
-        if bounds[index].high <= bounds[index].low:
+    for bound_key, bound in bound_by_key.items():
+        if bound_key == ANCHOR_GENE_KEY or bound.high <= bound.low:
             continue
         side = bound_key.split("_", 1)[0]
         if side in {"long", "short"} and side not in enabled_sides:
@@ -1480,7 +1599,13 @@ def run_backend(
 
     def parameter_dicts(rows: np.ndarray) -> list[dict]:
         values = normalized_to_values(rows)
-        return _build_proxy_parameter_dicts(base_vector, mapped, active, values)
+        return _build_proxy_parameter_dicts(
+            base_vector,
+            mapped,
+            active,
+            values,
+            anchor_parameter_overrides=anchor_parameter_overrides,
+        )
 
     def full_vector(row: np.ndarray) -> list[float]:
         result = list(base_vector)

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -178,7 +178,7 @@ PINNED_SCOPE_BOUND_VALUES = {
         "risk_position_exposure_enforcer_enabled": 0.0,
         "risk_total_exposure_enforcer_enabled": 0.0,
         "risk_total_exposure_entry_gate_enabled": 1.0,
-        "risk_total_exposure_enforcer_threshold": 1.0,
+        "risk_twel_enforcer_threshold": 1.0,
         "risk_we_excess_allowance_pct": 0.0,
     }.items()
 }

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -987,7 +987,7 @@ def _update_novelty_stall(
     return current
 
 
-def _checkpoint_signature(active, scoring) -> str:
+def _checkpoint_signature(active, scoring, *, anchor_plan=None) -> str:
     payload = {
         "active": [
             [name, int(index), float(bound.low), float(bound.high), bound.step]
@@ -996,6 +996,18 @@ def _checkpoint_signature(active, scoring) -> str:
         "scoring": scoring,
         "version": 2,
     }
+    if anchor_plan is not None:
+        payload["anchor_plan"] = {
+            "fixed_keys": sorted(anchor_plan.get("fixed_keys") or []),
+            "tunable_keys": sorted(anchor_plan.get("tunable_keys") or []),
+            "anchors": [
+                sorted(
+                    [str(item["key"]), float(item["value"])]
+                    for item in anchor.get("fixed_values") or []
+                )
+                for anchor in anchor_plan.get("anchors") or []
+            ],
+        }
     return hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()
 
 
@@ -1669,7 +1681,11 @@ def run_backend(
     objective_scale = _ObjectiveScale()
     drift_monitor = _DriftMonitor(options)
     persisted_halt_reason = None
-    signature = _checkpoint_signature(active, config["optimize"]["scoring"])
+    signature = _checkpoint_signature(
+        active,
+        config["optimize"]["scoring"],
+        anchor_plan=get_anchor_plan(config),
+    )
     budget = int(config["optimize"]["iters"])
     if budget <= 0:
         raise ValueError("optimize.iters must be greater than zero")

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -1293,6 +1293,8 @@ def config_to_individual(
 def _optimizer_anchor_id(config: dict) -> int | None:
     anchor_meta = config.get("_optimizer_anchor")
     if not isinstance(anchor_meta, dict):
+        anchor_meta = config.get("optimizer_anchor")
+    if not isinstance(anchor_meta, dict):
         return None
     try:
         return int(anchor_meta["id"])
@@ -2982,13 +2984,29 @@ def configs_to_individuals_streaming(
         raw_count += 1
         try:
             fcfg = _build_starting_seed_config(cfg)
+            resolved_anchor_id = None
+            if anchored_shape:
+                has_persisted_anchor = isinstance(cfg, dict) and any(
+                    key in cfg for key in ("_optimizer_anchor", "optimizer_anchor")
+                )
+                resolved_anchor_id = (
+                    _optimizer_anchor_id(cfg) if has_persisted_anchor else anchor_idx
+                )
+                if resolved_anchor_id is None:
+                    raise ValueError("invalid persisted optimizer anchor id")
+                anchor_high = int(bounds[0].high)
+                if not 0 <= resolved_anchor_id <= anchor_high:
+                    raise ValueError(
+                        "persisted optimizer anchor id is outside the optimization "
+                        f"shape: id={resolved_anchor_id}, allowed=0..{anchor_high}"
+                    )
             individual = config_to_individual(
                 fcfg,
                 bounds,
                 sig_digits,
                 key_paths=key_paths,
                 optimization_shape=optimization_shape,
-                anchor_id=anchor_idx if anchored_shape else None,
+                anchor_id=resolved_anchor_id,
                 clamp_context="starting config",
                 source=cfg.get("_starting_config_source", "<memory>")
                 if isinstance(cfg, dict)

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -1296,10 +1296,10 @@ def _optimizer_anchor_id(config: dict) -> int | None:
         anchor_meta = config.get("optimizer_anchor")
     if not isinstance(anchor_meta, dict):
         return None
-    try:
-        return int(anchor_meta["id"])
-    except (KeyError, TypeError, ValueError):
+    anchor_id = anchor_meta.get("id")
+    if isinstance(anchor_id, bool) or not isinstance(anchor_id, int):
         return None
+    return anchor_id
 
 
 def _canonicalize_optimizer_individual(

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -13,6 +13,7 @@ from optimization.bounds import Bound
 from optimization.backends.gpu_backend import (
     _canonical_candidate_values,
     _canonical_vector_hash,
+    _build_anchor_parameter_context,
     _build_gpu_nsga2,
     _build_proxy_parameter_dicts,
     _constraint_classification_mismatch,
@@ -40,6 +41,8 @@ from optimization.backends.gpu_backend import (
     EMA_MULTICOIN_SHORT_BOUND_MAP,
     TRAILING_MARTINGALE_BOUND_MAP,
 )
+from optimization.fine_tune_anchors import ANCHOR_GENE_KEY, ANCHOR_PLAN_KEY
+from optimization.warmup import build_optimizer_vector_config
 
 
 class _Evaluator:
@@ -1228,6 +1231,257 @@ def test_proxy_parameters_keep_directional_names_distinct():
     )
 
     assert parameters == [{"long_offset": 0.75, "short_offset": 0.125}]
+
+
+def test_gpu_anchor_context_maps_fixed_values_and_preserves_ranges():
+    config = {
+        ANCHOR_PLAN_KEY: {
+            "fixed_keys": [
+                "long_base_qty_pct",
+                "long_risk_we_excess_allowance_pct",
+            ],
+            "anchors": [
+                {
+                    "fixed_values": [
+                        {"key": "long_base_qty_pct", "value": 0.1},
+                        {
+                            "key": "long_risk_we_excess_allowance_pct",
+                            "value": 0.0,
+                        },
+                    ]
+                },
+                {
+                    "fixed_values": [
+                        {"key": "long_base_qty_pct", "value": 0.3},
+                        {
+                            "key": "long_risk_we_excess_allowance_pct",
+                            "value": 0.0,
+                        },
+                    ]
+                },
+            ],
+        }
+    }
+
+    overrides, fixed_bounds = _build_anchor_parameter_context(
+        config, {"long_base_qty_pct": "long_base_qty_pct"}
+    )
+
+    assert overrides == [
+        {"long_base_qty_pct": 0.1},
+        {"long_base_qty_pct": 0.3},
+    ]
+    assert fixed_bounds["long_base_qty_pct"] == Bound(0.1, 0.3)
+    assert fixed_bounds["long_risk_we_excess_allowance_pct"] == Bound(0.0, 0.0)
+
+
+def test_gpu_anchor_proxy_parameters_select_fixed_values_before_tunables():
+    mapped = {"long_offset": (1, Bound(0.0, 1.0))}
+    active = [
+        (ANCHOR_GENE_KEY, 0, Bound(0.0, 1.0, 1.0)),
+        ("long_offset", 1, mapped["long_offset"][1]),
+    ]
+
+    parameters = _build_proxy_parameter_dicts(
+        [0.0, 0.5],
+        mapped,
+        active,
+        np.array([[0.0, 0.75], [1.0, 0.125]]),
+        anchor_parameter_overrides=[
+            {"long_base_qty_pct": 0.1, "long_offset": 0.9},
+            {"long_base_qty_pct": 0.3, "long_offset": 0.8},
+        ],
+    )
+
+    assert parameters == [
+        {"long_base_qty_pct": 0.1, "long_offset": 0.75},
+        {"long_base_qty_pct": 0.3, "long_offset": 0.125},
+    ]
+
+
+@pytest.mark.parametrize(
+    ("strategy_kind", "fixed_key", "fixed_path", "tunable_key", "tunable_path"),
+    [
+        (
+            "ema_anchor",
+            "long_base_qty_pct",
+            ("bot", "long", "strategy", "ema_anchor", "base_qty_pct"),
+            "long_offset",
+            ("bot", "long", "strategy", "ema_anchor", "offset"),
+        ),
+        (
+            "trailing_martingale",
+            "long_entry_retracement_base_pct",
+            (
+                "bot",
+                "long",
+                "strategy",
+                "trailing_martingale",
+                "entry",
+                "retracement_base_pct",
+            ),
+            "long_entry_initial_qty_pct",
+            (
+                "bot",
+                "long",
+                "strategy",
+                "trailing_martingale",
+                "entry",
+                "initial_qty_pct",
+            ),
+        ),
+    ],
+)
+def test_gpu_anchor_proxy_values_match_exact_candidate_materialization(
+    strategy_kind, fixed_key, fixed_path, tunable_key, tunable_path
+):
+    config = (
+        _long_only_ema_config()
+        if strategy_kind == "ema_anchor"
+        else _directional_tm_config(long_enabled=True, short_enabled=False)
+    )
+    config[ANCHOR_PLAN_KEY] = {
+        "fixed_keys": [fixed_key],
+        "tunable_keys": [tunable_key],
+        "key_paths": [list(tunable_path)],
+        "anchors": [
+            {
+                "source": "anchor-a.json",
+                "fixed_values": [
+                    {"key": fixed_key, "path": list(fixed_path), "value": 0.1}
+                ],
+            },
+            {
+                "source": "anchor-b.json",
+                "fixed_values": [
+                    {"key": fixed_key, "path": list(fixed_path), "value": 0.3}
+                ],
+            },
+        ],
+    }
+    bound_map = (
+        EMA_MULTICOIN_LONG_BOUND_MAP
+        if strategy_kind == "ema_anchor"
+        else TRAILING_MARTINGALE_BOUND_MAP
+    )
+    anchor_overrides, _fixed_bounds = _build_anchor_parameter_context(
+        config, bound_map
+    )
+    proxy_tunable_key = bound_map[tunable_key]
+    active = [
+        (ANCHOR_GENE_KEY, 0, Bound(0.0, 1.0, 1.0)),
+        (proxy_tunable_key, 1, Bound(0.0, 1.0)),
+    ]
+    vectors = [[0.0, 0.75], [1.0, 0.125]]
+
+    proxy_parameters = _build_proxy_parameter_dicts(
+        [0.0, 0.0],
+        {proxy_tunable_key: (1, Bound(0.0, 1.0))},
+        active,
+        np.asarray(vectors),
+        anchor_parameter_overrides=anchor_overrides,
+    )
+    exact_configs = [build_optimizer_vector_config(vector, config) for vector in vectors]
+
+    for proxy, exact, expected_fixed, expected_tunable in zip(
+        proxy_parameters,
+        exact_configs,
+        (0.1, 0.3),
+        (0.75, 0.125),
+    ):
+        fixed = exact
+        for part in fixed_path:
+            fixed = fixed[part]
+        tunable = exact
+        for part in tunable_path:
+            tunable = tunable[part]
+        assert proxy[bound_map[fixed_key]] == fixed == expected_fixed
+        assert proxy[proxy_tunable_key] == tunable == expected_tunable
+
+
+def test_gpu_anchor_context_fails_closed_on_missing_fixed_values():
+    config = {
+        ANCHOR_PLAN_KEY: {
+            "fixed_keys": ["long_base_qty_pct", "long_offset"],
+            "anchors": [
+                {"fixed_values": [{"key": "long_base_qty_pct", "value": 0.1}]}
+            ],
+        }
+    }
+
+    with pytest.raises(ValueError, match="missing fixed optimizer values"):
+        _build_anchor_parameter_context(config, {})
+
+
+def test_gpu_anchor_ranges_preserve_pinned_scope_validation():
+    config = {
+        ANCHOR_PLAN_KEY: {
+            "fixed_keys": ["long_risk_we_excess_allowance_pct"],
+            "anchors": [
+                {
+                    "fixed_values": [
+                        {
+                            "key": "long_risk_we_excess_allowance_pct",
+                            "value": 0.0,
+                        }
+                    ]
+                },
+                {
+                    "fixed_values": [
+                        {
+                            "key": "long_risk_we_excess_allowance_pct",
+                            "value": 0.2,
+                        }
+                    ]
+                },
+            ],
+        }
+    }
+
+    _overrides, fixed_bounds = _build_anchor_parameter_context(config, {})
+
+    with pytest.raises(ValueError, match="we_excess_allowance_pct"):
+        _validate_pinned_scope_bounds(fixed_bounds, {}, {"long"})
+
+
+def test_gpu_anchor_ranges_cannot_change_side_enablement():
+    config = {
+        ANCHOR_PLAN_KEY: {
+            "fixed_keys": [
+                "long_n_positions",
+                "long_total_wallet_exposure_limit",
+            ],
+            "anchors": [
+                {
+                    "fixed_values": [
+                        {"key": "long_n_positions", "value": 1.0},
+                        {
+                            "key": "long_total_wallet_exposure_limit",
+                            "value": 1.0,
+                        },
+                    ]
+                },
+                {
+                    "fixed_values": [
+                        {"key": "long_n_positions", "value": 1.0},
+                        {
+                            "key": "long_total_wallet_exposure_limit",
+                            "value": 0.0,
+                        },
+                    ]
+                },
+            ],
+        }
+    }
+    _overrides, fixed_bounds = _build_anchor_parameter_context(config, {})
+
+    with pytest.raises(ValueError, match="remain positive"):
+        _validate_directional_search_space(
+            fixed_bounds,
+            {},
+            {"long": ["BTC"], "short": []},
+            {"long"},
+        )
 
 
 def test_gpu_rejects_pinned_unsupported_risk_behavior():

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -16,6 +16,7 @@ from optimization.backends.gpu_backend import (
     _build_anchor_parameter_context,
     _build_gpu_nsga2,
     _build_proxy_parameter_dicts,
+    _checkpoint_signature,
     _constraint_classification_mismatch,
     _constraint_diagnostics,
     _format_constraint_diagnostics,
@@ -1482,6 +1483,44 @@ def test_gpu_anchor_ranges_cannot_change_side_enablement():
             {"long": ["BTC"], "short": []},
             {"long"},
         )
+
+
+def test_gpu_anchor_checkpoint_signature_tracks_ordered_fixed_values():
+    active = [(ANCHOR_GENE_KEY, 0, Bound(0.0, 1.0, 1.0))]
+    scoring = [{"goal": "max", "metric": "adg_strategy_eq"}]
+    plan = {
+        "fixed_keys": ["long_base_qty_pct", "long_offset_psize_weight"],
+        "tunable_keys": ["long_offset"],
+        "anchors": [
+            {
+                "fixed_values": [
+                    {"key": "long_base_qty_pct", "value": 0.1},
+                    {"key": "long_offset_psize_weight", "value": 0.2},
+                ]
+            },
+            {
+                "fixed_values": [
+                    {"key": "long_base_qty_pct", "value": 0.3},
+                    {"key": "long_offset_psize_weight", "value": 0.4},
+                ]
+            },
+        ],
+    }
+    original = _checkpoint_signature(active, scoring, anchor_plan=plan)
+
+    edited = copy.deepcopy(plan)
+    edited["anchors"][1]["fixed_values"][0]["value"] = 0.31
+    reordered_anchors = copy.deepcopy(plan)
+    reordered_anchors["anchors"].reverse()
+    reordered_items = copy.deepcopy(plan)
+    reordered_items["anchors"][0]["fixed_values"].reverse()
+
+    assert _checkpoint_signature(active, scoring, anchor_plan=edited) != original
+    assert (
+        _checkpoint_signature(active, scoring, anchor_plan=reordered_anchors)
+        != original
+    )
+    assert _checkpoint_signature(active, scoring, anchor_plan=reordered_items) == original
 
 
 def test_gpu_rejects_pinned_unsupported_risk_behavior():

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1532,11 +1532,41 @@ def test_gpu_rejects_pinned_unsupported_risk_behavior():
             {"long_risk_we_excess_allowance_pct": 0.2},
         )
 
-    with pytest.raises(ValueError, match="total_exposure_enforcer_threshold"):
+    with pytest.raises(ValueError, match="twel_enforcer_threshold"):
         _validate_pinned_scope_bounds(
-            {"long_risk_total_exposure_enforcer_threshold": Bound(0.8, 0.8, None)},
-            {"long_risk_total_exposure_enforcer_threshold": 0.8},
+            {"long_risk_twel_enforcer_threshold": Bound(0.8, 0.8, None)},
+            {"long_risk_twel_enforcer_threshold": 0.8},
         )
+
+def test_gpu_anchor_constant_twel_threshold_fails_closed():
+    config = {
+        ANCHOR_PLAN_KEY: {
+            "fixed_keys": ["long_risk_twel_enforcer_threshold"],
+            "anchors": [
+                {
+                    "fixed_values": [
+                        {
+                            "key": "long_risk_twel_enforcer_threshold",
+                            "value": 0.8,
+                        }
+                    ]
+                },
+                {
+                    "fixed_values": [
+                        {
+                            "key": "long_risk_twel_enforcer_threshold",
+                            "value": 0.8,
+                        }
+                    ]
+                },
+            ],
+        }
+    }
+
+    _overrides, fixed_bounds = _build_anchor_parameter_context(config, {})
+
+    with pytest.raises(ValueError, match="twel_enforcer_threshold"):
+        _validate_pinned_scope_bounds(fixed_bounds, {}, {"long"})
 
 
 def test_gpu_directional_search_space_keeps_side_enablement_fixed():

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -3143,7 +3143,10 @@ class TestApplyFineTuneBounds:
         assert len(streamed) == 1
         assert streamed[0][0] == 1
 
-    def test_anchored_seed_stream_rejects_invalid_persisted_anchor_id(self, caplog):
+    @pytest.mark.parametrize("anchor_id", [2, 1.9, True, "1"])
+    def test_anchored_seed_stream_rejects_invalid_persisted_anchor_id(
+        self, caplog, anchor_id
+    ):
         config = {
             "live": {"strategy_kind": "trailing_martingale"},
             "optimize": {
@@ -3176,7 +3179,7 @@ class TestApplyFineTuneBounds:
         shape = build_optimization_shape(config)
         durable_result = deepcopy(config)
         durable_result.pop(ANCHOR_PLAN_KEY)
-        durable_result["optimizer_anchor"] = {"id": 2}
+        durable_result["optimizer_anchor"] = {"id": anchor_id}
 
         caplog.set_level(logging.WARNING)
         streamed, raw_count = configs_to_individuals_streaming(
@@ -3188,7 +3191,7 @@ class TestApplyFineTuneBounds:
 
         assert raw_count == 1
         assert streamed == []
-        assert "persisted optimizer anchor id is outside" in caplog.text
+        assert "optimizer anchor id" in caplog.text
 
     def test_starting_seed_values_are_clamped_to_base_bounds_with_logging(self, caplog):
         config = {

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -3094,6 +3094,102 @@ class TestApplyFineTuneBounds:
         assert sorted(individual[0] for individual in streamed) == [1, 2]
         assert "failed to use starting config as optimizer seed" in caplog.text
 
+    def test_anchored_seed_stream_preserves_persisted_result_anchor_id(self):
+        config = {
+            "live": {"strategy_kind": "trailing_martingale"},
+            "optimize": {
+                "bounds": {
+                    "long_n_positions": [1.0, 1.0],
+                    "long_param1": [0.0, 1.0],
+                    "long_total_wallet_exposure_limit": [1.0, 1.0],
+                    "short_n_positions": [0.0, 0.0],
+                    "short_total_wallet_exposure_limit": [0.0, 0.0],
+                },
+            },
+            "bot": {
+                "long": {
+                    "n_positions": 1.0,
+                    "param1": 0.1,
+                    "total_wallet_exposure_limit": 1.0,
+                },
+                "short": {"n_positions": 0.0, "total_wallet_exposure_limit": 0.0},
+            },
+            ANCHOR_PLAN_KEY: {
+                "anchors": [
+                    {"source": "anchor_0.json", "fixed_values": []},
+                    {"source": "anchor_1.json", "fixed_values": []},
+                ],
+                "fixed_keys": [],
+                "key_paths": [["bot", "long", "param1"]],
+                "tunable_keys": ["long_param1"],
+            },
+        }
+        shape = build_optimization_shape(config)
+        durable_result = deepcopy(config)
+        durable_result.pop(ANCHOR_PLAN_KEY)
+        durable_result["optimizer_anchor"] = {
+            "id": 1,
+            "source": "anchor_1.json",
+        }
+
+        streamed, raw_count = configs_to_individuals_streaming(
+            [durable_result],
+            shape.bounds,
+            6,
+            optimization_shape=shape,
+        )
+
+        assert raw_count == 1
+        assert len(streamed) == 1
+        assert streamed[0][0] == 1
+
+    def test_anchored_seed_stream_rejects_invalid_persisted_anchor_id(self, caplog):
+        config = {
+            "live": {"strategy_kind": "trailing_martingale"},
+            "optimize": {
+                "bounds": {
+                    "long_n_positions": [1.0, 1.0],
+                    "long_param1": [0.0, 1.0],
+                    "long_total_wallet_exposure_limit": [1.0, 1.0],
+                    "short_n_positions": [0.0, 0.0],
+                    "short_total_wallet_exposure_limit": [0.0, 0.0],
+                },
+            },
+            "bot": {
+                "long": {
+                    "n_positions": 1.0,
+                    "param1": 0.1,
+                    "total_wallet_exposure_limit": 1.0,
+                },
+                "short": {"n_positions": 0.0, "total_wallet_exposure_limit": 0.0},
+            },
+            ANCHOR_PLAN_KEY: {
+                "anchors": [
+                    {"source": "anchor_0.json", "fixed_values": []},
+                    {"source": "anchor_1.json", "fixed_values": []},
+                ],
+                "fixed_keys": [],
+                "key_paths": [["bot", "long", "param1"]],
+                "tunable_keys": ["long_param1"],
+            },
+        }
+        shape = build_optimization_shape(config)
+        durable_result = deepcopy(config)
+        durable_result.pop(ANCHOR_PLAN_KEY)
+        durable_result["optimizer_anchor"] = {"id": 2}
+
+        caplog.set_level(logging.WARNING)
+        streamed, raw_count = configs_to_individuals_streaming(
+            [durable_result],
+            shape.bounds,
+            6,
+            optimization_shape=shape,
+        )
+
+        assert raw_count == 1
+        assert streamed == []
+        assert "persisted optimizer anchor id is outside" in caplog.text
+
     def test_starting_seed_values_are_clamped_to_base_bounds_with_logging(self, caplog):
         config = {
             "live": {"strategy_kind": "trailing_martingale"},


### PR DESCRIPTION
## Summary

- add anchored fine-tuning support to the experimental Apple MPS optimizer for `-t/--start` plus `-ft/--fine-tune-params`
- evolve the discrete anchor id alongside tunable proxy parameters and supply each anchor's fixed optimizer-bound values to Metal screening
- validate the complete cross-anchor bound range so anchors cannot change enabled sides or introduce unsupported risk behavior
- keep exact Rust candidate materialization and persisted results authoritative
- document the supported single-coin and one-sided multi-coin EMA scope

## Validation

- `PYTHONPATH=src .../python -m pytest tests/optimization -q`
  - all passed; 32 existing optional tests skipped
- `py_compile` on the changed backend and tests
- `git diff --check`
- rebuilt and verified the Rust extension against this worktree's source fingerprint

### Apple M3 / MPS hardware

All runs used cached Bybit one-minute data from 2026-06-01 through 2026-07-30 and completed successfully:

- single-coin EMA anchor: 255 proxy / 32 exact; both anchors exact-validated (27/5), preserving fixed `base_qty_pct` values `0.06` and `0.04`
- single-coin trailing martingale: 511 proxy / 32 exact; both anchors exact-validated (10/22), preserving fixed entry/close retracements `0.0008/0.0005` and `0.0001/0.0001`
- two-coin BTC+SOL EMA anchor: 255 proxy / 32 exact; both anchors exact-validated (30/2), preserving the same distinct fixed values

The first intentionally degenerate smoke with identical anchors and only one tunable parameter halted fail-closed after exhausting novel proxy-front evidence.