### PR TITLE
feat(optimize): apply GPU candidate overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apply the V8 `optimize.enable_overrides` candidate contract in the experimental Apple MPS
+  optimizer. `mirror_short_from_long` now mirrors each proxy candidate after anchor and tunable
+  values are resolved, and `lossless_close_trailing` raises each trailing-martingale close
+  threshold to its candidate retracement before Metal screening. Exact Rust remains authoritative;
+  legacy trailing-grid override modes fail closed because their strategy is not supported by the
+  GPU backend.
+
 - Extend the experimental Apple MPS optimizer to anchored fine-tuning with `--start` plus
   `--fine-tune-params` for supported EMA-anchor and trailing-martingale scopes. The Metal proxy
   evolves the same discrete anchor id as exact Rust, applies each anchor's fixed optimizer-bound

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -663,7 +663,8 @@ Risk should be constrained through canonical `*_strategy_eq` metrics instead. De
 - **backend**: Optimizer backend. Default is `pymoo`. Supported values are `deap`, `pymoo`, and
   experimental `gpu`. The GPU backend currently supports Apple MPS, single-coin EMA-anchor and
   trailing-martingale runs in long-only, short-only, and long+short modes; single-side multi-coin
-  EMA-anchor runs; and anchored fine-tuning with `--start` plus `--fine-tune-params`. See
+  EMA-anchor runs; anchored fine-tuning with `--start` plus `--fine-tune-params`; and the V8
+  `mirror_short_from_long` and `lossless_close_trailing` optimizer overrides. See
   `docs/optimizing.md` for its fail-closed scope and `optimize.gpu` settings.
   With the default `optimize.pymoo.algorithm: "auto"`, Passivbot uses `nsga2` for `3` or fewer
   objectives and `nsga3` for `4+`.

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -130,6 +130,14 @@ against the GPU scope: an anchor cannot change enabled sides or introduce unsupp
 behavior. Base-config runtime policy fields still win over anchor configs as described in
 [Fine-Tuning Specific Parameters](#fine-tuning-specific-parameters).
 
+The V8 `optimize.enable_overrides` values `mirror_short_from_long` and
+`lossless_close_trailing` are applied to Metal candidates in the same order as exact candidate
+materialization. Mirroring may be used with the supported single-coin directional scopes; short
+genes that exact materialization overwrites are omitted from the proxy search dimensions.
+`lossless_close_trailing` is available only with `strategy_kind: trailing_martingale`. The legacy
+`forward_tp_grid` and `backward_tp_grid` values remain unsupported because the GPU backend does not
+support `trailing_grid_v7`.
+
 Proxy scoring and limits are likewise fail-closed. This slice supports `adg_strategy_eq`,
 `adg_strategy_eq_w`, `mdg_strategy_eq`, `sharpe_ratio_strategy_eq`,
 `sortino_ratio_strategy_eq`, `volume_pct_per_day_avg`, `strategy_eq_recovery_days_max`,

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -1160,6 +1160,8 @@ def _canonicalize_optimizer_override_hash_vector(
     base_vector,
     key_paths,
     overrides: set[str],
+    *,
+    anchor_parameter_overrides: list[dict[str, float]] | None = None,
 ) -> list[float]:
     """Hash the effective candidate while neutralizing mirrored shadow genes."""
 
@@ -1167,12 +1169,25 @@ def _canonicalize_optimizer_override_hash_vector(
     index_by_key = {
         bound_key: index for index, (bound_key, _path) in enumerate(key_paths)
     }
-    parameters = {
-        bound_key: canonical[index] for bound_key, index in index_by_key.items()
-    }
+    parameters = {}
+    if anchor_parameter_overrides is not None:
+        anchor_index = index_by_key.get(ANCHOR_GENE_KEY)
+        anchor_id = (
+            int(round(canonical[anchor_index])) if anchor_index is not None else 0
+        )
+        if anchor_id < 0 or anchor_id >= len(anchor_parameter_overrides):
+            raise ValueError(
+                "GPU anchored fine-tune selected invalid anchor id while hashing "
+                f"{anchor_id}; available={len(anchor_parameter_overrides)}"
+            )
+        parameters.update(anchor_parameter_overrides[anchor_id])
+    parameters.update(
+        {bound_key: canonical[index] for bound_key, index in index_by_key.items()}
+    )
     _apply_gpu_optimizer_overrides(parameters, overrides)
     for bound_key, value in parameters.items():
-        canonical[index_by_key[bound_key]] = float(value)
+        if bound_key in index_by_key:
+            canonical[index_by_key[bound_key]] = float(value)
     if "mirror_short_from_long" in overrides:
         canonical = _canonicalize_mirrored_hash_vector(
             canonical,
@@ -1801,6 +1816,7 @@ def run_backend(
             base_vector,
             key_paths,
             gpu_optimizer_overrides,
+            anchor_parameter_overrides=anchor_parameter_overrides,
         )
         return _canonical_vector_hash(vector, bounds, sig_digits)
 

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -220,6 +220,15 @@ def _gpu_candidate_source_sides(
     return source_sides
 
 
+def _ema_multicoin_bound_map(target_side: str, overrides: set[str]) -> dict:
+    """Include all bound families that can feed the enabled multicoin side."""
+
+    bound_map = dict(EMA_MULTICOIN_BOUND_MAPS[target_side])
+    if "mirror_short_from_long" in overrides and target_side == "short":
+        bound_map.update(EMA_MULTICOIN_BOUND_MAPS["long"])
+    return bound_map
+
+
 def _minimum_rank_evidence_samples(halt: float) -> int:
     """Total samples needed to guarantee eight comparable at agreement >= halt."""
 
@@ -1142,9 +1151,7 @@ def _canonicalize_mirrored_hash_vector(vector, base_vector, key_paths) -> list[f
     for short_key, short_index in index_by_key.items():
         if not short_key.startswith("short_"):
             continue
-        long_key = f"long_{short_key[len('short_') :]}"
-        if long_key in index_by_key:
-            canonical[short_index] = float(base_vector[short_index])
+        canonical[short_index] = float(base_vector[short_index])
     return canonical
 
 
@@ -1568,7 +1575,9 @@ def run_backend(
             raise ValueError(
                 "GPU multicoin foundation requires exactly one enabled side"
             )
-        bound_map = EMA_MULTICOIN_BOUND_MAPS[multicoin_sides[0]]
+        bound_map = _ema_multicoin_bound_map(
+            multicoin_sides[0], gpu_optimizer_overrides
+        )
     else:
         bound_map = GPU_STRATEGY_BOUND_MAPS[strategy_kind]
 

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -209,6 +209,17 @@ def _apply_gpu_optimizer_overrides(
     return parameters
 
 
+def _gpu_candidate_source_sides(
+    enabled_sides: set[str], overrides: set[str]
+) -> set[str]:
+    """Return sides whose genes can affect an enabled exact-trading side."""
+
+    source_sides = set(enabled_sides)
+    if "mirror_short_from_long" in overrides and "short" in enabled_sides:
+        source_sides.add("long")
+    return source_sides
+
+
 def _minimum_rank_evidence_samples(halt: float) -> int:
     """Total samples needed to guarantee eight comparable at agreement >= halt."""
 
@@ -1137,6 +1148,33 @@ def _canonicalize_mirrored_hash_vector(vector, base_vector, key_paths) -> list[f
     return canonical
 
 
+def _canonicalize_optimizer_override_hash_vector(
+    vector,
+    base_vector,
+    key_paths,
+    overrides: set[str],
+) -> list[float]:
+    """Hash the effective candidate while neutralizing mirrored shadow genes."""
+
+    canonical = [float(value) for value in vector]
+    index_by_key = {
+        bound_key: index for index, (bound_key, _path) in enumerate(key_paths)
+    }
+    parameters = {
+        bound_key: canonical[index] for bound_key, index in index_by_key.items()
+    }
+    _apply_gpu_optimizer_overrides(parameters, overrides)
+    for bound_key, value in parameters.items():
+        canonical[index_by_key[bound_key]] = float(value)
+    if "mirror_short_from_long" in overrides:
+        canonical = _canonicalize_mirrored_hash_vector(
+            canonical,
+            base_vector,
+            key_paths,
+        )
+    return canonical
+
+
 def _build_proxy_parameter_dicts(
     base_vector,
     mapped,
@@ -1603,10 +1641,13 @@ def run_backend(
             "GPU bounds would disable both sides for exact validation; "
             f"effective seed values: {side_values}"
         )
+    candidate_source_sides = _gpu_candidate_source_sides(
+        enabled_sides, gpu_optimizer_overrides
+    )
     mapped = {
         name: value
         for name, value in mapped_all.items()
-        if name.split("_", 1)[0] in enabled_sides
+        if name.split("_", 1)[0] in candidate_source_sides
     }
     active = [
         (name, index, bound)
@@ -1746,12 +1787,12 @@ def run_backend(
         return np.clip((values - active_low) / active_span, 0.0, 1.0)
 
     def vector_hash(vector) -> str:
-        if "mirror_short_from_long" in gpu_optimizer_overrides:
-            vector = _canonicalize_mirrored_hash_vector(
-                vector,
-                base_vector,
-                key_paths,
-            )
+        vector = _canonicalize_optimizer_override_hash_vector(
+            vector,
+            base_vector,
+            key_paths,
+            gpu_optimizer_overrides,
+        )
         return _canonical_vector_hash(vector, bounds, sig_digits)
 
     from pymoo.core.problem import Problem

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -133,6 +133,81 @@ GPU_STRATEGY_BOUND_MAPS = {
     "trailing_martingale": TRAILING_MARTINGALE_BOUND_MAP,
 }
 
+GPU_SUPPORTED_OPTIMIZER_OVERRIDES = {
+    "lossless_close_trailing",
+    "mirror_short_from_long",
+}
+
+
+def _validate_gpu_optimizer_overrides(overrides_list, strategy_kind: str) -> set[str]:
+    overrides = set(overrides_list or [])
+    unsupported = sorted(overrides - GPU_SUPPORTED_OPTIMIZER_OVERRIDES)
+    if unsupported:
+        raise ValueError(
+            "GPU optimizer does not support optimize.enable_overrides values "
+            f"{unsupported}"
+        )
+    if (
+        "lossless_close_trailing" in overrides
+        and strategy_kind != "trailing_martingale"
+    ):
+        raise ValueError(
+            "GPU optimizer override lossless_close_trailing requires "
+            "live.strategy_kind='trailing_martingale'"
+        )
+    return overrides
+
+
+def _materialize_gpu_override_template(
+    config: dict,
+    overrides_list,
+    overrides_fn,
+) -> dict:
+    """Apply the exact candidate override contract to the proxy's base config."""
+
+    proxy_config = deepcopy(config)
+    if not overrides_list:
+        return proxy_config
+    if not callable(overrides_fn):
+        raise ValueError(
+            "GPU optimizer requires the exact optimizer override materializer"
+        )
+    proxy_config = overrides_fn(overrides_list, proxy_config, None)
+    for side in ("long", "short"):
+        proxy_config = overrides_fn(overrides_list, proxy_config, side)
+    return proxy_config
+
+
+def _mirror_short_mapping(mapping: dict) -> None:
+    """Mirror effective long values/bounds into existing short-side keys."""
+
+    for long_key, value in list(mapping.items()):
+        if not long_key.startswith("long_"):
+            continue
+        short_key = f"short_{long_key[len('long_') :]}"
+        if short_key in mapping:
+            mapping[short_key] = value
+
+
+def _apply_gpu_optimizer_overrides(
+    parameters: dict[str, float],
+    overrides: set[str],
+) -> dict[str, float]:
+    """Apply candidate-dependent V8 overrides without materializing Python configs."""
+
+    if "mirror_short_from_long" in overrides:
+        _mirror_short_mapping(parameters)
+    if "lossless_close_trailing" in overrides:
+        for side in ("long", "short"):
+            threshold_key = f"{side}_close_threshold_base_pct"
+            retracement_key = f"{side}_close_retracement_base_pct"
+            if threshold_key in parameters and retracement_key in parameters:
+                parameters[threshold_key] = max(
+                    float(parameters[threshold_key]),
+                    float(parameters[retracement_key]),
+                )
+    return parameters
+
 
 def _minimum_rank_evidence_samples(halt: float) -> int:
     """Total samples needed to guarantee eight comparable at agreement >= halt."""
@@ -1046,6 +1121,22 @@ def _canonical_vector_hash(vector, bounds, sig_digits: int) -> str:
     return hashlib.sha256(json.dumps(canonical).encode()).hexdigest()
 
 
+def _canonicalize_mirrored_hash_vector(vector, base_vector, key_paths) -> list[float]:
+    """Erase short genes whose exact values are overwritten by mirroring."""
+
+    canonical = [float(value) for value in vector]
+    index_by_key = {
+        bound_key: index for index, (bound_key, _path) in enumerate(key_paths)
+    }
+    for short_key, short_index in index_by_key.items():
+        if not short_key.startswith("short_"):
+            continue
+        long_key = f"long_{short_key[len('short_') :]}"
+        if long_key in index_by_key:
+            canonical[short_index] = float(base_vector[short_index])
+    return canonical
+
+
 def _build_proxy_parameter_dicts(
     base_vector,
     mapped,
@@ -1053,6 +1144,7 @@ def _build_proxy_parameter_dicts(
     active_values,
     *,
     anchor_parameter_overrides: list[dict[str, float]] | None = None,
+    optimizer_overrides: set[str] | None = None,
 ) -> list[dict]:
     """Include canonical pinned and active strategy values in each proxy candidate."""
 
@@ -1088,7 +1180,9 @@ def _build_proxy_parameter_dicts(
                 if name != ANCHOR_GENE_KEY
             }
         )
-        result.append(parameters)
+        result.append(
+            _apply_gpu_optimizer_overrides(parameters, optimizer_overrides or set())
+        )
     return result
 
 
@@ -1392,8 +1486,6 @@ def run_backend(
     from optimization.gpu.metrics import SUPPORTED_METRICS
     from optimization.gpu.service import MpsMulticoinEmaProxy, MpsSingleCoinProxy
 
-    exchange = _validate_scope(config, evaluator)
-    coin_count = int(evaluator.shared_hlcvs_np[exchange].shape[1])
     options = _resolve_options(config)
     logging.info("GPU optimizer options: %s", options)
 
@@ -1418,9 +1510,21 @@ def run_backend(
     base_vector = [float(value) for value in template_vectors[0]]
 
     strategy_kind = str(config["live"]["strategy_kind"]).strip().lower()
+    gpu_optimizer_overrides = _validate_gpu_optimizer_overrides(
+        overrides_list, strategy_kind
+    )
+    proxy_config = _materialize_gpu_override_template(
+        config,
+        overrides_list,
+        overrides_fn,
+    )
+    exchange = _validate_scope(proxy_config, evaluator)
+    coin_count = int(evaluator.shared_hlcvs_np[exchange].shape[1])
     if strategy_kind == "ema_anchor" and coin_count > 1:
         multicoin_sides = [
-            side for side in ("long", "short") if gpu_side_enabled(config, side)
+            side
+            for side in ("long", "short")
+            if gpu_side_enabled(proxy_config, side)
         ]
         if len(multicoin_sides) != 1:
             raise ValueError(
@@ -1454,27 +1558,33 @@ def run_backend(
                 "GPU anchored fine-tune could not resolve fixed proxy parameters "
                 f"for {missing_from_anchors}"
             )
-    approved = config.get("live", {}).get("approved_coins", {})
+    approved = proxy_config.get("live", {}).get("approved_coins", {})
 
     def side_approved(side: str) -> bool:
         return bool(approved.get(side, [])) if isinstance(approved, dict) else True
 
     config_enabled_sides = {
-        side for side in ("long", "short") if gpu_side_enabled(config, side)
+        side for side in ("long", "short") if gpu_side_enabled(proxy_config, side)
     }
+    base_by_key = {
+        bound_key: float(base_vector[index])
+        for index, (bound_key, _path) in enumerate(key_paths)
+    }
+    if "mirror_short_from_long" in gpu_optimizer_overrides:
+        _mirror_short_mapping(base_by_key)
     if anchor_parameter_overrides is not None:
         enabled_sides = set(config_enabled_sides)
         side_values = {}
     else:
         side_values = {}
-        for index, (bound_key, _path) in enumerate(key_paths):
+        for bound_key, value in base_by_key.items():
             if bound_key in {
                 "long_total_wallet_exposure_limit",
                 "long_n_positions",
                 "short_total_wallet_exposure_limit",
                 "short_n_positions",
             }:
-                side_values[bound_key] = float(base_vector[index])
+                side_values[bound_key] = value
 
         def vector_side_enabled(side: str) -> bool:
             return (
@@ -1502,6 +1612,10 @@ def run_backend(
         (name, index, bound)
         for name, (index, bound) in sorted(mapped.items(), key=lambda item: item[1][0])
         if bound.high > bound.low
+        and not (
+            "mirror_short_from_long" in gpu_optimizer_overrides
+            and name.startswith("short_")
+        )
     ]
     active.extend(
         (ANCHOR_GENE_KEY, index, bounds[index])
@@ -1524,10 +1638,8 @@ def run_backend(
             f"{overlap}"
         )
     bound_by_key.update(anchor_fixed_bounds)
-    base_by_key = {
-        bound_key: float(base_vector[index])
-        for index, (bound_key, _path) in enumerate(key_paths)
-    }
+    if "mirror_short_from_long" in gpu_optimizer_overrides:
+        _mirror_short_mapping(bound_by_key)
     _validate_pinned_scope_bounds(bound_by_key, base_by_key, enabled_sides)
 
     _validate_directional_search_space(
@@ -1585,7 +1697,7 @@ def run_backend(
 
     proxy_cls = MpsMulticoinEmaProxy if coin_count > 1 else MpsSingleCoinProxy
     proxy = proxy_cls(
-        config=config,
+        config=proxy_config,
         hlcvs=evaluator.shared_hlcvs_np[exchange],
         mss=evaluator.msss[exchange],
         btc=evaluator.shared_btc_np[exchange],
@@ -1617,6 +1729,7 @@ def run_backend(
             active,
             values,
             anchor_parameter_overrides=anchor_parameter_overrides,
+            optimizer_overrides=gpu_optimizer_overrides,
         )
 
     def full_vector(row: np.ndarray) -> list[float]:
@@ -1633,6 +1746,12 @@ def run_backend(
         return np.clip((values - active_low) / active_span, 0.0, 1.0)
 
     def vector_hash(vector) -> str:
+        if "mirror_short_from_long" in gpu_optimizer_overrides:
+            vector = _canonicalize_mirrored_hash_vector(
+                vector,
+                base_vector,
+                key_paths,
+            )
         return _canonical_vector_hash(vector, bounds, sig_digits)
 
     from pymoo.core.problem import Problem

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1331,6 +1331,45 @@ def test_gpu_lossless_hash_uses_effective_threshold_and_mirror_ordering():
     assert submitted == recovered == [0.04, 0.04, 0.7, 0.8]
 
 
+def test_gpu_lossless_hash_uses_selected_anchor_fixed_retracement():
+    key_paths = [
+        (ANCHOR_GENE_KEY, ("optimize", "fine_tune_anchor_index")),
+        (
+            "long_close_threshold_base_pct",
+            (
+                "bot",
+                "long",
+                "strategy",
+                "trailing_martingale",
+                "close",
+                "threshold_base_pct",
+            ),
+        ),
+    ]
+    base_vector = [0.0, 0.01]
+    anchors = [
+        {"long_close_retracement_base_pct": 0.02},
+        {"long_close_retracement_base_pct": 0.06},
+    ]
+
+    submitted = _canonicalize_optimizer_override_hash_vector(
+        [1.0, 0.01],
+        base_vector,
+        key_paths,
+        {"lossless_close_trailing"},
+        anchor_parameter_overrides=anchors,
+    )
+    recovered = _canonicalize_optimizer_override_hash_vector(
+        [1.0, 0.06],
+        base_vector,
+        key_paths,
+        {"lossless_close_trailing"},
+        anchor_parameter_overrides=anchors,
+    )
+
+    assert submitted == recovered == [1.0, 0.06]
+
+
 def test_gpu_short_only_mirror_keeps_long_source_genes_active():
     assert _gpu_candidate_source_sides(
         {"short"}, {"mirror_short_from_long"}

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -23,6 +23,7 @@ from optimization.backends.gpu_backend import (
     _checkpoint_signature,
     _constraint_classification_mismatch,
     _constraint_diagnostics,
+    _ema_multicoin_bound_map,
     _format_constraint_diagnostics,
     _gpu_candidate_source_sides,
     _materialize_gpu_override_template,
@@ -564,6 +565,24 @@ def test_gpu_multicoin_bound_map_exposes_forager_and_position_dimensions(
     ):
         key = f"{side}_{suffix}"
         assert bound_map[key] == key
+
+
+def test_gpu_short_multicoin_mirror_includes_long_forager_source_dimensions():
+    bound_map = _ema_multicoin_bound_map(
+        "short", {"mirror_short_from_long"}
+    )
+
+    for suffix in (
+        "forager_volume_ema_span_1m",
+        "forager_volatility_ema_span_1m",
+        "forager_volume_drop_pct",
+        "forager_score_weights_volume",
+        "forager_score_weights_ema_readiness",
+        "forager_score_weights_volatility",
+        "n_positions",
+    ):
+        assert f"long_{suffix}" in bound_map
+        assert f"short_{suffix}" in bound_map
 
 
 @pytest.mark.parametrize(
@@ -1231,6 +1250,23 @@ def test_gpu_mirror_hash_ignores_shadowed_short_genes_during_recovery():
     assert _canonical_vector_hash(submitted, bounds, 6) == _canonical_vector_hash(
         recovered, bounds, 6
     )
+
+
+def test_gpu_mirror_hash_neutralizes_anchor_shadow_without_long_shape_key():
+    key_paths = [
+        ("anchor_index", ("optimize", "fine_tune_anchor_index")),
+        ("short_offset", ("bot", "short", "offset")),
+    ]
+    base_vector = [0.0, 0.7]
+
+    submitted = _canonicalize_mirrored_hash_vector(
+        [1.0, 0.7], base_vector, key_paths
+    )
+    recovered = _canonicalize_mirrored_hash_vector(
+        [1.0, 0.2], base_vector, key_paths
+    )
+
+    assert submitted == recovered == [1.0, 0.7]
 
 
 def test_gpu_lossless_hash_uses_effective_threshold_and_mirror_ordering():

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -15,6 +15,7 @@ from optimization.backends.gpu_backend import (
     _apply_gpu_optimizer_overrides,
     _canonical_candidate_values,
     _canonicalize_mirrored_hash_vector,
+    _canonicalize_optimizer_override_hash_vector,
     _canonical_vector_hash,
     _build_anchor_parameter_context,
     _build_gpu_nsga2,
@@ -23,6 +24,7 @@ from optimization.backends.gpu_backend import (
     _constraint_classification_mismatch,
     _constraint_diagnostics,
     _format_constraint_diagnostics,
+    _gpu_candidate_source_sides,
     _materialize_gpu_override_template,
     _DriftMonitor,
     _ObjectiveScale,
@@ -1229,6 +1231,77 @@ def test_gpu_mirror_hash_ignores_shadowed_short_genes_during_recovery():
     assert _canonical_vector_hash(submitted, bounds, 6) == _canonical_vector_hash(
         recovered, bounds, 6
     )
+
+
+def test_gpu_lossless_hash_uses_effective_threshold_and_mirror_ordering():
+    key_paths = [
+        (
+            "long_close_threshold_base_pct",
+            (
+                "bot",
+                "long",
+                "strategy",
+                "trailing_martingale",
+                "close",
+                "threshold_base_pct",
+            ),
+        ),
+        (
+            "long_close_retracement_base_pct",
+            (
+                "bot",
+                "long",
+                "strategy",
+                "trailing_martingale",
+                "close",
+                "retracement_base_pct",
+            ),
+        ),
+        (
+            "short_close_threshold_base_pct",
+            (
+                "bot",
+                "short",
+                "strategy",
+                "trailing_martingale",
+                "close",
+                "threshold_base_pct",
+            ),
+        ),
+        (
+            "short_close_retracement_base_pct",
+            (
+                "bot",
+                "short",
+                "strategy",
+                "trailing_martingale",
+                "close",
+                "retracement_base_pct",
+            ),
+        ),
+    ]
+    base_vector = [0.01, 0.02, 0.7, 0.8]
+    submitted = [0.01, 0.04, 0.6, 0.9]
+    recovered = [0.04, 0.04, 0.04, 0.04]
+    overrides = {"mirror_short_from_long", "lossless_close_trailing"}
+
+    submitted = _canonicalize_optimizer_override_hash_vector(
+        submitted, base_vector, key_paths, overrides
+    )
+    recovered = _canonicalize_optimizer_override_hash_vector(
+        recovered, base_vector, key_paths, overrides
+    )
+
+    assert submitted == recovered == [0.04, 0.04, 0.7, 0.8]
+
+
+def test_gpu_short_only_mirror_keeps_long_source_genes_active():
+    assert _gpu_candidate_source_sides(
+        {"short"}, {"mirror_short_from_long"}
+    ) == {"long", "short"}
+    assert _gpu_candidate_source_sides(
+        {"long"}, {"mirror_short_from_long"}
+    ) == {"long"}
 
 
 def test_proxy_parameters_include_canonical_pinned_ema_values():

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -9,9 +9,12 @@ import numpy as np
 import pytest
 
 from config.schema import get_template_config
+from optimizer_overrides import optimizer_overrides
 from optimization.bounds import Bound
 from optimization.backends.gpu_backend import (
+    _apply_gpu_optimizer_overrides,
     _canonical_candidate_values,
+    _canonicalize_mirrored_hash_vector,
     _canonical_vector_hash,
     _build_anchor_parameter_context,
     _build_gpu_nsga2,
@@ -20,6 +23,7 @@ from optimization.backends.gpu_backend import (
     _constraint_classification_mismatch,
     _constraint_diagnostics,
     _format_constraint_diagnostics,
+    _materialize_gpu_override_template,
     _DriftMonitor,
     _ObjectiveScale,
     _recover_durable_validations,
@@ -34,6 +38,7 @@ from optimization.backends.gpu_backend import (
     _select_validation_indices,
     _update_probe_shortfall_log,
     _validate_directional_search_space,
+    _validate_gpu_optimizer_overrides,
     _validate_pinned_scope_bounds,
     _validate_resume_evidence_budget,
     _validate_seed_side_match,
@@ -1199,6 +1204,33 @@ def test_gpu_candidate_hash_uses_exact_significant_digit_quantization():
     )
 
 
+def test_gpu_mirror_hash_ignores_shadowed_short_genes_during_recovery():
+    key_paths = [
+        ("long_offset", ("bot", "long", "offset")),
+        ("short_offset", ("bot", "short", "offset")),
+        ("long_total_wallet_exposure_limit", ("bot", "long", "wel")),
+        ("short_total_wallet_exposure_limit", ("bot", "short", "wel")),
+    ]
+    base_vector = [0.2, 0.7, 1.0, 0.0]
+    submitted = [0.9, 0.7, 1.0, 0.0]
+    recovered_from_mirrored_result = [0.9, 0.9, 1.0, 1.0]
+
+    submitted = _canonicalize_mirrored_hash_vector(
+        submitted, base_vector, key_paths
+    )
+    recovered = _canonicalize_mirrored_hash_vector(
+        recovered_from_mirrored_result,
+        base_vector,
+        key_paths,
+    )
+
+    assert submitted == recovered == [0.9, 0.7, 1.0, 0.0]
+    bounds = [Bound(0.0, 1.0) for _ in key_paths]
+    assert _canonical_vector_hash(submitted, bounds, 6) == _canonical_vector_hash(
+        recovered, bounds, 6
+    )
+
+
 def test_proxy_parameters_include_canonical_pinned_ema_values():
     from optimization.bounds import Bound
 
@@ -1232,6 +1264,103 @@ def test_proxy_parameters_keep_directional_names_distinct():
     )
 
     assert parameters == [{"long_offset": 0.75, "short_offset": 0.125}]
+
+
+def test_gpu_proxy_applies_mirror_before_lossless_close_override():
+    parameters = {
+        "long_close_threshold_base_pct": 0.01,
+        "long_close_retracement_base_pct": 0.02,
+        "long_entry_initial_qty_pct": 0.03,
+        "short_close_threshold_base_pct": 0.08,
+        "short_close_retracement_base_pct": 0.09,
+        "short_entry_initial_qty_pct": 0.10,
+    }
+
+    result = _apply_gpu_optimizer_overrides(
+        parameters,
+        {"mirror_short_from_long", "lossless_close_trailing"},
+    )
+
+    assert result["long_close_threshold_base_pct"] == pytest.approx(0.02)
+    assert result["short_close_threshold_base_pct"] == pytest.approx(0.02)
+    assert result["short_close_retracement_base_pct"] == pytest.approx(0.02)
+    assert result["short_entry_initial_qty_pct"] == pytest.approx(0.03)
+
+
+def test_gpu_proxy_parameter_builder_applies_optimizer_overrides_after_anchors():
+    mapped = {
+        "long_close_threshold_base_pct": (1, Bound(0.0, 1.0)),
+        "long_close_retracement_base_pct": (2, Bound(0.0, 1.0)),
+        "short_close_threshold_base_pct": (3, Bound(0.0, 1.0)),
+        "short_close_retracement_base_pct": (4, Bound(0.0, 1.0)),
+    }
+    active = [(ANCHOR_GENE_KEY, 0, Bound(0.0, 1.0, 1.0))]
+
+    parameters = _build_proxy_parameter_dicts(
+        [0.0, 0.01, 0.02, 0.4, 0.5],
+        mapped,
+        active,
+        np.asarray([[1.0]]),
+        anchor_parameter_overrides=[
+            {
+                "long_close_threshold_base_pct": 0.03,
+                "long_close_retracement_base_pct": 0.04,
+            },
+            {
+                "long_close_threshold_base_pct": 0.05,
+                "long_close_retracement_base_pct": 0.06,
+            },
+        ],
+        optimizer_overrides={
+            "mirror_short_from_long",
+            "lossless_close_trailing",
+        },
+    )
+
+    assert parameters == [
+        {
+            "long_close_threshold_base_pct": pytest.approx(0.06),
+            "long_close_retracement_base_pct": pytest.approx(0.06),
+            "short_close_threshold_base_pct": pytest.approx(0.06),
+            "short_close_retracement_base_pct": pytest.approx(0.06),
+        }
+    ]
+
+
+def test_gpu_optimizer_override_template_uses_exact_materializer():
+    config = _directional_ema_config(long_enabled=True, short_enabled=True)
+    long_strategy = config["bot"]["long"]["strategy"]["ema_anchor"]
+    short_strategy = config["bot"]["short"]["strategy"]["ema_anchor"]
+    long_strategy["base_qty_pct"] = 0.123
+    short_strategy["base_qty_pct"] = 0.456
+
+    proxy_config = _materialize_gpu_override_template(
+        config,
+        ["mirror_short_from_long"],
+        optimizer_overrides,
+    )
+
+    assert (
+        proxy_config["bot"]["short"]["strategy"]["ema_anchor"]["base_qty_pct"]
+        == pytest.approx(0.123)
+    )
+    assert short_strategy["base_qty_pct"] == pytest.approx(0.456)
+
+
+def test_gpu_optimizer_override_scope_fails_closed():
+    assert _validate_gpu_optimizer_overrides(
+        ["mirror_short_from_long"], "ema_anchor"
+    ) == {"mirror_short_from_long"}
+    assert _validate_gpu_optimizer_overrides(
+        ["lossless_close_trailing"], "trailing_martingale"
+    ) == {"lossless_close_trailing"}
+
+    with pytest.raises(ValueError, match="forward_tp_grid"):
+        _validate_gpu_optimizer_overrides(["forward_tp_grid"], "ema_anchor")
+    with pytest.raises(ValueError, match="requires.*trailing_martingale"):
+        _validate_gpu_optimizer_overrides(
+            ["lossless_close_trailing"], "ema_anchor"
+        )
 
 
 def test_gpu_anchor_context_maps_fixed_values_and_preserves_ranges():


### PR DESCRIPTION
## Summary

- apply `mirror_short_from_long` to Metal proxy candidates after anchor-fixed and tunable values resolve, using the same exact materializer for the proxy template
- apply `lossless_close_trailing` to candidate close thresholds before Metal screening
- remove mirrored short genes from effective proxy evolution and canonicalize them out of durable resume hashes
- fail closed for optimizer overrides outside the supported V8 strategy contract
- document the supported override scope

Exact Rust remains authoritative and only exact results enter the durable result/Pareto stores. CPU optimization, backtesting, and bot operation are unchanged.

## Validation

- full `tests/optimization` suite passes (32 existing optional skips)
- focused candidate ordering, anchor interaction, exact-template, fail-closed, and mirrored resume-hash regressions pass
- `py_compile` and `git diff --check` pass
- real Apple M3/MPS dual-side EMA mirror run: 1,024 proxy / 64 exact, 8 generations, no halt; all 64 durable exact records have identical mirrored long/short groups
- real Apple M3/MPS trailing-martingale lossless run: 1,024 proxy / 64 exact, no halt; zero durable threshold/retracement violations
- final combined mirror + lossless MPS run on exact PR code: 1,024 proxy / 64 exact in 8.7s, all 64 validation records present, zero mirror mismatches, zero lossless violations, and six active long-side threshold raises