### PR TITLE
feat(optimize): apply GPU fixed runtime overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ All notable user-facing changes will be documented in this file.
   as the exact CPU optimizer. Fixed values shadow corresponding Metal search genes, participate in
   durable candidate hashing, and remain subordinate to later `optimize.enable_overrides`; the
   effective config still fails closed on unsupported GPU behavior. Config normalization now
-  preserves documented user-defined dotted override paths and rejects malformed or unknown paths
-  instead of silently replacing them with schema defaults.
+  preserves documented user-defined dotted leaf paths instead of silently replacing them with
+  schema defaults, rejects path aliases that collide or replace mappings, and validates exact
+  finalized boundary configs before either optimizer backend starts. Fixed values that disable
+  dependent trailing-martingale parameters remove and hash-canonicalize those dead GPU genes.
 
 - Apply the V8 `optimize.enable_overrides` candidate contract in the experimental Apple MPS
   optimizer. `mirror_short_from_long` now mirrors each proxy candidate after anchor and tunable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apply `optimize.fixed_runtime_overrides` to experimental Apple MPS candidates in the same order
+  as the exact CPU optimizer. Fixed values shadow corresponding Metal search genes, participate in
+  durable candidate hashing, and remain subordinate to later `optimize.enable_overrides`; the
+  effective config still fails closed on unsupported GPU behavior. Config normalization now
+  preserves documented user-defined dotted override paths and rejects malformed or unknown paths
+  instead of silently replacing them with schema defaults.
+
 - Apply the V8 `optimize.enable_overrides` candidate contract in the experimental Apple MPS
   optimizer. `mirror_short_from_long` now mirrors each proxy candidate after anchor and tunable
   values are resolved, and `lossless_close_trailing` raises each trailing-martingale close
@@ -47,7 +54,7 @@ All notable user-facing changes will be documented in this file.
   equal-price closes, and fill every strictly crossed rung in Rust's canonical order. Other
   strategies, suites, multi-coin hedged or trailing-martingale runs, HSL, auto-unstuck,
   collateral, minimum-effective-cost filtering, market-order execution, incomplete candle tails,
-  non-inert fixed runtime overrides, and unmodeled risk gates fail closed. Fused delta-form Metal
+  and unmodeled risk gates fail closed. Fused delta-form Metal
   EMA updates reduce long-horizon float32 path drift. Optimizer-limit feasibility disagreements
   feed aggregate, proxy-front, and broad-probe rolling constraint-agreement gates, retain exact
   Rust as the only authoritative classification, and persist per-limit proxy/exact diagnostics.

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -143,8 +143,11 @@ anchor and tunable values, and before `optimize.enable_overrides`. A fixed overr
 supported GPU optimizer bound removes that gene from the Metal search and supplies the fixed value
 to both proxy screening and exact Rust validation. The effective overridden config is checked
 against the same fail-closed GPU scope, so an override cannot silently enable unsupported behavior.
-Config normalization preserves user-defined dotted override paths and rejects malformed or unknown
-paths before optimization begins.
+Exact finalized boundary configs are validated before either optimizer backend starts. Config
+normalization preserves user-defined dotted leaf paths, rejects malformed or unknown paths,
+rejects aliases that resolve to the same setting, and rejects mapping-level replacements. When a
+fixed value disables dependent trailing-martingale parameters, the Metal search removes and
+hash-canonicalizes those dead genes using the same rule as exact candidate materialization.
 
 Proxy scoring and limits are likewise fail-closed. This slice supports `adg_strategy_eq`,
 `adg_strategy_eq_w`, `mdg_strategy_eq`, `sharpe_ratio_strategy_eq`,

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -138,6 +138,14 @@ genes that exact materialization overwrites are omitted from the proxy search di
 `forward_tp_grid` and `backward_tp_grid` values remain unsupported because the GPU backend does not
 support `trailing_grid_v7`.
 
+`optimize.fixed_runtime_overrides` is also applied in exact candidate-materialization order: after
+anchor and tunable values, and before `optimize.enable_overrides`. A fixed override that shadows a
+supported GPU optimizer bound removes that gene from the Metal search and supplies the fixed value
+to both proxy screening and exact Rust validation. The effective overridden config is checked
+against the same fail-closed GPU scope, so an override cannot silently enable unsupported behavior.
+Config normalization preserves user-defined dotted override paths and rejects malformed or unknown
+paths before optimization begins.
+
 Proxy scoring and limits are likewise fail-closed. This slice supports `adg_strategy_eq`,
 `adg_strategy_eq_w`, `mdg_strategy_eq`, `sharpe_ratio_strategy_eq`,
 `sortino_ratio_strategy_eq`, `volume_pct_per_day_avg`, `strategy_eq_recovery_days_max`,

--- a/src/config/hydrate.py
+++ b/src/config/hydrate.py
@@ -23,6 +23,7 @@ Path = tuple[str, ...]
 PARTIALLY_OPEN_CONFIG_PATHS: set[Path] = {
     ("backtest", "reducer"),
     ("live", "startup_phase_budgets"),
+    ("optimize", "fixed_runtime_overrides"),
 }
 BACKTEST_INHERITED_LIVE_KEYS: tuple[str, ...] = (
     "fee_pct_fallback",

--- a/src/config/validate.py
+++ b/src/config/validate.py
@@ -26,12 +26,29 @@ def _validate_fixed_runtime_overrides(config: dict) -> None:
     overrides = config.get("optimize", {}).get("fixed_runtime_overrides")
     if not isinstance(overrides, dict):
         raise TypeError("config.optimize.fixed_runtime_overrides must be a dict")
+    resolved_sources: dict[tuple[str, ...], str] = {}
     for dotted_path in overrides:
         if not isinstance(dotted_path, str):
             raise TypeError(
                 "config.optimize.fixed_runtime_overrides keys must be dotted strings"
             )
-        require_existing_config_path(config, dotted_path)
+        resolved = require_existing_config_path(config, dotted_path)
+        prior = resolved_sources.get(resolved)
+        if prior is not None:
+            raise ValueError(
+                "config.optimize.fixed_runtime_overrides paths "
+                f"{prior!r} and {dotted_path!r} resolve to the same setting "
+                f"{'.'.join(resolved)!r}"
+            )
+        resolved_sources[resolved] = dotted_path
+        target = config
+        for part in resolved:
+            target = target[part]
+        if isinstance(target, dict):
+            raise TypeError(
+                "config.optimize.fixed_runtime_overrides must target leaf settings; "
+                f"{dotted_path!r} resolves to a mapping"
+            )
 
 
 def _validate_startup_phase_budgets(live_config: dict) -> None:

--- a/src/config/validate.py
+++ b/src/config/validate.py
@@ -10,6 +10,7 @@ from .bot import (
     validate_forager_config,
 )
 from .coerce import normalize_hsl_cooldown_position_policy, normalize_hsl_signal_mode
+from .param_paths import require_existing_config_path
 from .shared_bot import get_grouped_bot_value
 from .schema import MAX_EXCHANGE_SYMBOL_UNAVAILABLE_COOLDOWN_HOURS
 from .strategy import (
@@ -19,6 +20,18 @@ from .strategy import (
 )
 
 _STARTUP_BUDGET_KEYS = frozenset({"elapsed_ms", "since_previous_ms"})
+
+
+def _validate_fixed_runtime_overrides(config: dict) -> None:
+    overrides = config.get("optimize", {}).get("fixed_runtime_overrides")
+    if not isinstance(overrides, dict):
+        raise TypeError("config.optimize.fixed_runtime_overrides must be a dict")
+    for dotted_path in overrides:
+        if not isinstance(dotted_path, str):
+            raise TypeError(
+                "config.optimize.fixed_runtime_overrides keys must be dotted strings"
+            )
+        require_existing_config_path(config, dotted_path)
 
 
 def _validate_startup_phase_budgets(live_config: dict) -> None:
@@ -54,6 +67,7 @@ def validate_config(
     from optimization.config_adapter import validate_optimize_bounds_against_bot_config
 
     require_config_dict(config, "monitor")
+    _validate_fixed_runtime_overrides(config)
     strategy_kind = normalize_strategy_kind(config["live"].get("strategy_kind"))
     optimize_bounds = (
         raw_optimize.get("bounds")

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -162,10 +162,31 @@ def _materialize_gpu_override_template(
     config: dict,
     overrides_list,
     overrides_fn,
+    *,
+    fixed_overrides_fn=None,
 ) -> dict:
-    """Apply the exact candidate override contract to the proxy's base config."""
+    """Apply exact runtime-finalization overrides to the proxy base config."""
 
     proxy_config = deepcopy(config)
+    fixed_overrides = (
+        proxy_config.get("optimize", {}).get("fixed_runtime_overrides", {}) or {}
+    )
+    if fixed_overrides:
+        if not callable(fixed_overrides_fn):
+            from optimization.warmup import _apply_config_overrides
+
+            fixed_overrides_fn = _apply_config_overrides
+        fixed_overrides_fn(proxy_config, fixed_overrides)
+    source_strategy_kind = str(config.get("live", {}).get("strategy_kind", "")).strip().lower()
+    effective_strategy_kind = (
+        str(proxy_config.get("live", {}).get("strategy_kind", "")).strip().lower()
+    )
+    if effective_strategy_kind != source_strategy_kind:
+        raise ValueError(
+            "GPU optimize.fixed_runtime_overrides may not change live.strategy_kind; "
+            "configure the strategy kind before optimization so the search shape and "
+            "Metal kernel remain aligned"
+        )
     if not overrides_list:
         return proxy_config
     if not callable(overrides_fn):
@@ -176,6 +197,57 @@ def _materialize_gpu_override_template(
     for side in ("long", "short"):
         proxy_config = overrides_fn(overrides_list, proxy_config, side)
     return proxy_config
+
+
+def _gpu_fixed_bound_context(
+    config: dict,
+    effective_config: dict,
+    key_paths,
+    bound_map: dict[str, str],
+) -> tuple[dict[str, float], dict[str, float]]:
+    """Resolve runtime-fixed optimizer bounds and their proxy parameter names."""
+
+    from config.param_paths import (
+        require_existing_config_path,
+        resolve_optimizer_key_path,
+    )
+
+    path_to_bound_key = {
+        tuple(path): bound_key for bound_key, path in key_paths
+    }
+    for bound_key in bound_map:
+        path = resolve_optimizer_key_path(config, bound_key)
+        if path is not None:
+            path_to_bound_key[tuple(path)] = bound_key
+    fixed_bound_values: dict[str, float] = {}
+    fixed_parameters: dict[str, float] = {}
+    fixed_overrides = (
+        config.get("optimize", {}).get("fixed_runtime_overrides", {}) or {}
+    )
+    for dotted_path in fixed_overrides:
+        resolved = require_existing_config_path(config, dotted_path)
+        bound_key = path_to_bound_key.get(tuple(resolved))
+        if bound_key is None:
+            continue
+        target = effective_config
+        for part in resolved:
+            target = target[part]
+        try:
+            value = float(target)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "GPU fixed runtime override for optimizer bound "
+                f"{bound_key!r} must resolve to a numeric value"
+            ) from exc
+        if not math.isfinite(value):
+            raise ValueError(
+                "GPU fixed runtime override for optimizer bound "
+                f"{bound_key!r} must resolve to a finite value"
+            )
+        fixed_bound_values[bound_key] = value
+        if bound_key in bound_map:
+            fixed_parameters[bound_map[bound_key]] = value
+    return fixed_bound_values, fixed_parameters
 
 
 def _mirror_short_mapping(mapping: dict) -> None:
@@ -556,17 +628,6 @@ def _validate_scope(config: dict, evaluator) -> str:
         raise ValueError("GPU foundation does not support backtest.btc_collateral_cap")
     if config.get("coin_overrides"):
         raise ValueError("GPU foundation does not support coin_overrides")
-    fixed_overrides = config.get("optimize", {}).get("fixed_runtime_overrides", {}) or {}
-    inert_hsl_policy_overrides = {
-        "bot.long.hsl.restart_after_red_policy",
-        "bot.short.hsl.restart_after_red_policy",
-    }
-    unsupported_overrides = sorted(set(fixed_overrides) - inert_hsl_policy_overrides)
-    if unsupported_overrides:
-        raise ValueError(
-            "GPU foundation does not support optimize.fixed_runtime_overrides for "
-            f"{unsupported_overrides}; apply the values directly to the config"
-        )
     if float(config.get("live", {}).get("max_realized_loss_pct", 1.0)) != 1.0:
         raise ValueError(
             "GPU foundation requires live.max_realized_loss_pct=1.0 because the "
@@ -1162,6 +1223,8 @@ def _canonicalize_optimizer_override_hash_vector(
     overrides: set[str],
     *,
     anchor_parameter_overrides: list[dict[str, float]] | None = None,
+    fixed_bound_values: dict[str, float] | None = None,
+    fixed_parameter_overrides: dict[str, float] | None = None,
 ) -> list[float]:
     """Hash the effective candidate while neutralizing mirrored shadow genes."""
 
@@ -1169,6 +1232,9 @@ def _canonicalize_optimizer_override_hash_vector(
     index_by_key = {
         bound_key: index for index, (bound_key, _path) in enumerate(key_paths)
     }
+    for bound_key, value in (fixed_bound_values or {}).items():
+        if bound_key in index_by_key:
+            canonical[index_by_key[bound_key]] = float(value)
     parameters = {}
     if anchor_parameter_overrides is not None:
         anchor_index = index_by_key.get(ANCHOR_GENE_KEY)
@@ -1184,6 +1250,7 @@ def _canonicalize_optimizer_override_hash_vector(
     parameters.update(
         {bound_key: canonical[index] for bound_key, index in index_by_key.items()}
     )
+    parameters.update(fixed_parameter_overrides or {})
     _apply_gpu_optimizer_overrides(parameters, overrides)
     for bound_key, value in parameters.items():
         if bound_key in index_by_key:
@@ -1204,6 +1271,7 @@ def _build_proxy_parameter_dicts(
     active_values,
     *,
     anchor_parameter_overrides: list[dict[str, float]] | None = None,
+    fixed_parameter_overrides: dict[str, float] | None = None,
     optimizer_overrides: set[str] | None = None,
 ) -> list[dict]:
     """Include canonical pinned and active strategy values in each proxy candidate."""
@@ -1240,6 +1308,7 @@ def _build_proxy_parameter_dicts(
                 if name != ANCHOR_GENE_KEY
             }
         )
+        parameters.update(fixed_parameter_overrides or {})
         result.append(
             _apply_gpu_optimizer_overrides(parameters, optimizer_overrides or set())
         )
@@ -1545,6 +1614,7 @@ def run_backend(
     from config.scoring import extract_objective_specs
     from optimization.gpu.metrics import SUPPORTED_METRICS
     from optimization.gpu.service import MpsMulticoinEmaProxy, MpsSingleCoinProxy
+    from optimization.warmup import _apply_config_overrides
 
     options = _resolve_options(config)
     logging.info("GPU optimizer options: %s", options)
@@ -1577,6 +1647,7 @@ def run_backend(
         config,
         overrides_list,
         overrides_fn,
+        fixed_overrides_fn=_apply_config_overrides,
     )
     exchange = _validate_scope(proxy_config, evaluator)
     coin_count = int(evaluator.shared_hlcvs_np[exchange].shape[1])
@@ -1595,6 +1666,13 @@ def run_backend(
         )
     else:
         bound_map = GPU_STRATEGY_BOUND_MAPS[strategy_kind]
+
+    fixed_bound_values, fixed_parameter_overrides = _gpu_fixed_bound_context(
+        config,
+        proxy_config,
+        key_paths,
+        bound_map,
+    )
 
     anchor_parameter_overrides, anchor_fixed_bounds = (
         _build_anchor_parameter_context(config, bound_map)
@@ -1632,6 +1710,7 @@ def run_backend(
         bound_key: float(base_vector[index])
         for index, (bound_key, _path) in enumerate(key_paths)
     }
+    base_by_key.update(fixed_bound_values)
     if "mirror_short_from_long" in gpu_optimizer_overrides:
         _mirror_short_mapping(base_by_key)
     if anchor_parameter_overrides is not None:
@@ -1677,6 +1756,7 @@ def run_backend(
         (name, index, bound)
         for name, (index, bound) in sorted(mapped.items(), key=lambda item: item[1][0])
         if bound.high > bound.low
+        and name not in fixed_parameter_overrides
         and not (
             "mirror_short_from_long" in gpu_optimizer_overrides
             and name.startswith("short_")
@@ -1703,6 +1783,12 @@ def run_backend(
             f"{overlap}"
         )
     bound_by_key.update(anchor_fixed_bounds)
+    bound_by_key.update(
+        {
+            bound_key: Bound(value, value)
+            for bound_key, value in fixed_bound_values.items()
+        }
+    )
     if "mirror_short_from_long" in gpu_optimizer_overrides:
         _mirror_short_mapping(bound_by_key)
     _validate_pinned_scope_bounds(bound_by_key, base_by_key, enabled_sides)
@@ -1794,6 +1880,7 @@ def run_backend(
             active,
             values,
             anchor_parameter_overrides=anchor_parameter_overrides,
+            fixed_parameter_overrides=fixed_parameter_overrides,
             optimizer_overrides=gpu_optimizer_overrides,
         )
 
@@ -1817,6 +1904,8 @@ def run_backend(
             key_paths,
             gpu_optimizer_overrides,
             anchor_parameter_overrides=anchor_parameter_overrides,
+            fixed_bound_values=fixed_bound_values,
+            fixed_parameter_overrides=fixed_parameter_overrides,
         )
         return _canonical_vector_hash(vector, bounds, sig_digits)
 

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -161,22 +161,19 @@ def _validate_gpu_optimizer_overrides(overrides_list, strategy_kind: str) -> set
 def _materialize_gpu_override_template(
     config: dict,
     overrides_list,
-    overrides_fn,
     *,
-    fixed_overrides_fn=None,
+    finalize_fn=None,
 ) -> dict:
     """Apply exact runtime-finalization overrides to the proxy base config."""
 
-    proxy_config = deepcopy(config)
-    fixed_overrides = (
-        proxy_config.get("optimize", {}).get("fixed_runtime_overrides", {}) or {}
-    )
-    if fixed_overrides:
-        if not callable(fixed_overrides_fn):
-            from optimization.warmup import _apply_config_overrides
+    if not callable(finalize_fn):
+        from optimization.warmup import _finalize_optimizer_vector_config
 
-            fixed_overrides_fn = _apply_config_overrides
-        fixed_overrides_fn(proxy_config, fixed_overrides)
+        finalize_fn = _finalize_optimizer_vector_config
+    proxy_config = finalize_fn(
+        deepcopy(config),
+        overrides_list=overrides_list,
+    )
     source_strategy_kind = str(config.get("live", {}).get("strategy_kind", "")).strip().lower()
     effective_strategy_kind = (
         str(proxy_config.get("live", {}).get("strategy_kind", "")).strip().lower()
@@ -187,15 +184,6 @@ def _materialize_gpu_override_template(
             "configure the strategy kind before optimization so the search shape and "
             "Metal kernel remain aligned"
         )
-    if not overrides_list:
-        return proxy_config
-    if not callable(overrides_fn):
-        raise ValueError(
-            "GPU optimizer requires the exact optimizer override materializer"
-        )
-    proxy_config = overrides_fn(overrides_list, proxy_config, None)
-    for side in ("long", "short"):
-        proxy_config = overrides_fn(overrides_list, proxy_config, side)
     return proxy_config
 
 
@@ -211,6 +199,7 @@ def _gpu_fixed_bound_context(
         require_existing_config_path,
         resolve_optimizer_key_path,
     )
+    from optimization.warmup import optimizer_dead_param_values
 
     path_to_bound_key = {
         tuple(path): bound_key for bound_key, path in key_paths
@@ -244,6 +233,13 @@ def _gpu_fixed_bound_context(
                 "GPU fixed runtime override for optimizer bound "
                 f"{bound_key!r} must resolve to a finite value"
             )
+        fixed_bound_values[bound_key] = value
+        if bound_key in bound_map:
+            fixed_parameters[bound_map[bound_key]] = value
+    for bound_key, value in optimizer_dead_param_values(
+        effective_config,
+        globally_dead_only=True,
+    ).items():
         fixed_bound_values[bound_key] = value
         if bound_key in bound_map:
             fixed_parameters[bound_map[bound_key]] = value
@@ -1614,10 +1610,14 @@ def run_backend(
     from config.scoring import extract_objective_specs
     from optimization.gpu.metrics import SUPPORTED_METRICS
     from optimization.gpu.service import MpsMulticoinEmaProxy, MpsSingleCoinProxy
-    from optimization.warmup import _apply_config_overrides
+    from optimization.warmup import (
+        _finalize_optimizer_vector_config,
+        validate_optimizer_effective_configs,
+    )
 
     options = _resolve_options(config)
     logging.info("GPU optimizer options: %s", options)
+    validate_optimizer_effective_configs(config)
 
     shape = (
         optimization_shape
@@ -1646,8 +1646,7 @@ def run_backend(
     proxy_config = _materialize_gpu_override_template(
         config,
         overrides_list,
-        overrides_fn,
-        fixed_overrides_fn=_apply_config_overrides,
+        finalize_fn=_finalize_optimizer_vector_config,
     )
     exchange = _validate_scope(proxy_config, evaluator)
     coin_count = int(evaluator.shared_hlcvs_np[exchange].shape[1])

--- a/src/optimization/warmup.py
+++ b/src/optimization/warmup.py
@@ -72,32 +72,28 @@ def _canonical_dead_value(flat_bounds: dict, bound_key: str, canonical_value: fl
     return enforce_bounds([canonical_value], [bound], sig_digits=None)[0]
 
 
-def _canonicalize_path_value(
+def optimizer_dead_param_values(
     config: dict,
-    flat_bounds: dict,
     *,
-    bound_key: str,
-    path: Sequence[str],
-    canonical_value: float,
-) -> None:
-    if _try_get_path(config, path) is None:
-        return
-    _set_path(
-        config,
-        path,
-        _canonical_dead_value(flat_bounds, bound_key, canonical_value),
-    )
+    globally_dead_only: bool = False,
+) -> dict[str, float]:
+    """Return exact canonical values for optimizer genes made semantically dead."""
 
-
-def canonicalize_dead_optimizer_params(config: dict) -> None:
     live_cfg = config.get("live", {})
     strategy_kind = str(live_cfg.get("strategy_kind") or "trailing_martingale").strip().lower()
     if strategy_kind != "trailing_martingale":
-        return
+        return {}
     flat_bounds = flatten_optimize_bounds(
         config.get("optimize", {}).get("bounds", {}),
         strategy_kind=strategy_kind,
     )
+    result: dict[str, float] = {}
+    fixed_paths = set()
+    if globally_dead_only:
+        for dotted_path in (
+            config.get("optimize", {}).get("fixed_runtime_overrides", {}) or {}
+        ):
+            fixed_paths.add(tuple(require_existing_config_path(config, dotted_path)))
     for pside in ("long", "short"):
         close_root = ("bot", pside, "strategy", strategy_kind, "close")
         retracement_base_path = (*close_root, "retracement_base_pct")
@@ -107,25 +103,50 @@ def canonicalize_dead_optimizer_params(config: dict) -> None:
             continue
         if retracement_base > 0.0:
             continue
+        raw_base_bound = flat_bounds.get(f"{pside}_close_retracement_base_pct")
+        base_bound = (
+            None
+            if raw_base_bound is None
+            else Bound.from_config(
+                f"{pside}_close_retracement_base_pct", raw_base_bound
+            )
+        )
+        if (
+            globally_dead_only
+            and tuple(retracement_base_path) not in fixed_paths
+            and (base_bound is None or base_bound.high > 0.0)
+        ):
+            continue
         canonical_base = _canonical_dead_value(
             flat_bounds,
             f"{pside}_close_retracement_base_pct",
             0.0,
         )
         if float(canonical_base) > 0.0:
-            continue
-        _set_path(config, retracement_base_path, canonical_base)
+            # A fixed runtime override may intentionally disable retracement
+            # outside a positive-only search bound. The exact effective value,
+            # not the inactive gene bound, owns that case.
+            canonical_base = retracement_base
+        result[f"{pside}_close_retracement_base_pct"] = float(canonical_base)
         for field in (
             "retracement_volatility_1h_weight",
             "retracement_volatility_1m_weight",
         ):
-            _canonicalize_path_value(
-                config,
-                flat_bounds,
-                bound_key=f"{pside}_close_{field}",
-                path=(*close_root, field),
-                canonical_value=0.0,
+            path = (*close_root, field)
+            if _try_get_path(config, path) is None:
+                continue
+            bound_key = f"{pside}_close_{field}"
+            result[bound_key] = float(
+                _canonical_dead_value(flat_bounds, bound_key, 0.0)
             )
+    return result
+
+
+def canonicalize_dead_optimizer_params(config: dict) -> None:
+    for bound_key, value in optimizer_dead_param_values(config).items():
+        path = resolve_optimization_bound_path(config, bound_key)
+        if path is not None:
+            _set_path(config, path, value)
 
 
 def _finalize_optimizer_vector_config(config: dict, overrides_list=None) -> dict:
@@ -144,17 +165,25 @@ def _finalize_optimizer_vector_config(config: dict, overrides_list=None) -> dict
         no_restart = pside_cfg.get("hsl_no_restart_drawdown_threshold")
         if red_threshold is not None and no_restart is not None:
             if float(no_restart) < float(red_threshold):
-                pside_cfg["hsl_no_restart_drawdown_threshold"] = float(red_threshold)
+                clamped = float(red_threshold)
+                pside_cfg["hsl_no_restart_drawdown_threshold"] = clamped
+                hsl_cfg = pside_cfg.get("hsl")
+                if isinstance(hsl_cfg, dict):
+                    hsl_cfg["no_restart_drawdown_threshold"] = clamped
     for pside in sorted(config.get("bot", {})):
         config = optimizer_overrides(overrides_list or [], config, pside)
     for pside in ("long", "short"):
         pside_cfg = config.get("bot", {}).get(pside, {})
         if not isinstance(pside_cfg, dict) or "forager_score_weights" not in pside_cfg:
             continue
-        pside_cfg["forager_score_weights"] = normalize_forager_score_weights(
+        normalized = normalize_forager_score_weights(
             pside_cfg["forager_score_weights"],
             path=f"bot.{pside}.forager_score_weights",
         )
+        pside_cfg["forager_score_weights"] = normalized
+        forager_cfg = pside_cfg.get("forager")
+        if isinstance(forager_cfg, dict):
+            forager_cfg["score_weights"] = deepcopy(normalized)
     canonicalize_dead_optimizer_params(config)
     return config
 
@@ -222,7 +251,10 @@ def build_optimizer_vector_config(
 def build_optimizer_max_config(config: dict) -> dict:
     bounds = extract_bounds_tuple_list_from_config(config)
     if not bounds:
-        return deepcopy(config)
+        return _finalize_optimizer_vector_config(
+            deepcopy(config),
+            overrides_list=config.get("optimize", {}).get("enable_overrides", []) or [],
+        )
     overrides_list = config.get("optimize", {}).get("enable_overrides", []) or []
     shape = build_optimization_shape(config)
     max_vector = [bound.high for bound in shape.bounds]
@@ -250,6 +282,22 @@ def _build_optimizer_boundary_configs(config: dict) -> list[dict]:
         )
         for anchor_id in range(len(anchor_plan.get("anchors") or []))
     ]
+
+
+def validate_optimizer_effective_configs(config: dict) -> None:
+    """Validate exact finalized optimizer boundary configs before backend work."""
+
+    from config.validate import validate_config
+
+    for candidate in _build_optimizer_boundary_configs(config):
+        effective = deepcopy(candidate)
+        effective.setdefault("optimize", {})["fixed_runtime_overrides"] = {}
+        validate_config(
+            effective,
+            raw_optimize=effective.get("optimize", {}),
+            verbose=False,
+            tracker=None,
+        )
 
 
 def build_optimizer_data_config(config: dict) -> dict:
@@ -324,5 +372,7 @@ __all__ = [
     "canonicalize_dead_optimizer_params",
     "compute_optimizer_backtest_warmup_minutes",
     "compute_optimizer_per_coin_warmup_minutes",
+    "optimizer_dead_param_values",
     "stamp_warmup_metadata",
+    "validate_optimizer_effective_configs",
 ]

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -197,6 +197,7 @@ from optimization.warmup import (
     build_optimizer_vector_config,
     compute_optimizer_per_coin_warmup_minutes,
     stamp_warmup_metadata,
+    validate_optimizer_effective_configs,
 )
 from optimization.shape import OptimizationShape, build_optimization_shape
 from config.strategy import normalize_strategy_kind, sync_canonical_strategy_config
@@ -3236,6 +3237,7 @@ async def main():
         )
     else:
         apply_fine_tune_bounds(config, fine_tune_params, cli_bounds_overrides)
+    validate_optimizer_effective_configs(config)
     backtest_exchanges = require_config_value(config, "backtest.exchanges")
     await format_approved_ignored_coins(
         config, backtest_exchanges, prefer_backtest_coin_source_keys=True

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1558,7 +1558,6 @@ def test_gpu_optimizer_override_template_uses_exact_materializer():
     proxy_config = _materialize_gpu_override_template(
         config,
         ["mirror_short_from_long"],
-        optimizer_overrides,
     )
 
     assert (
@@ -1569,8 +1568,6 @@ def test_gpu_optimizer_override_template_uses_exact_materializer():
 
 
 def test_gpu_runtime_template_applies_fixed_values_before_optimizer_overrides():
-    from optimization.warmup import _apply_config_overrides
-
     config = _directional_ema_config(long_enabled=True, short_enabled=True)
     config["optimize"]["fixed_runtime_overrides"] = {
         "bot.long.strategy.ema_anchor.base_qty_pct": 0.321
@@ -1579,8 +1576,6 @@ def test_gpu_runtime_template_applies_fixed_values_before_optimizer_overrides():
     proxy_config = _materialize_gpu_override_template(
         config,
         ["mirror_short_from_long"],
-        optimizer_overrides,
-        fixed_overrides_fn=_apply_config_overrides,
     )
 
     assert (
@@ -1594,8 +1589,6 @@ def test_gpu_runtime_template_applies_fixed_values_before_optimizer_overrides():
 
 
 def test_gpu_runtime_template_rejects_fixed_strategy_kind_change():
-    from optimization.warmup import _apply_config_overrides
-
     config = _long_only_ema_config()
     config["optimize"]["fixed_runtime_overrides"] = {
         "live.strategy_kind": "trailing_martingale"
@@ -1605,8 +1598,6 @@ def test_gpu_runtime_template_rejects_fixed_strategy_kind_change():
         _materialize_gpu_override_template(
             config,
             [],
-            optimizer_overrides,
-            fixed_overrides_fn=_apply_config_overrides,
         )
 
 
@@ -1642,9 +1633,64 @@ def test_gpu_fixed_bound_context_maps_effective_candidate_shadows():
     }
 
 
-def test_gpu_materialized_fixed_runtime_scope_still_fails_closed():
-    from optimization.warmup import _apply_config_overrides
+def test_gpu_fixed_disabled_retracement_canonicalizes_dead_weight_genes():
+    config = _directional_tm_config(long_enabled=True, short_enabled=False)
+    config["optimize"]["fixed_runtime_overrides"] = {
+        "bot.long.strategy.trailing_martingale.close.retracement_base_pct": 0.0
+    }
+    close_path = (
+        "bot",
+        "long",
+        "strategy",
+        "trailing_martingale",
+        "close",
+    )
+    key_paths = [
+        ("long_close_retracement_base_pct", (*close_path, "retracement_base_pct")),
+        (
+            "long_close_retracement_volatility_1h_weight",
+            (*close_path, "retracement_volatility_1h_weight"),
+        ),
+        (
+            "long_close_retracement_volatility_1m_weight",
+            (*close_path, "retracement_volatility_1m_weight"),
+        ),
+    ]
+    bound_map = {key: key for key, _path in key_paths}
+    effective = _materialize_gpu_override_template(config, [])
 
+    bound_values, parameters = _gpu_fixed_bound_context(
+        config,
+        effective,
+        key_paths,
+        bound_map,
+    )
+
+    assert bound_values == {
+        "long_close_retracement_base_pct": 0.0,
+        "long_close_retracement_volatility_1h_weight": 0.01,
+        "long_close_retracement_volatility_1m_weight": 0.01,
+    }
+    assert parameters == bound_values
+    assert _canonicalize_optimizer_override_hash_vector(
+        [0.0, 37.0, 38.0],
+        [0.0, 1.0, 1.0],
+        key_paths,
+        set(),
+        fixed_bound_values=bound_values,
+        fixed_parameter_overrides=parameters,
+    ) == [0.0, 0.01, 0.01]
+
+    materialized = _materialize_gpu_override_template(config, [])
+    close = materialized["bot"]["long"]["strategy"]["trailing_martingale"][
+        "close"
+    ]
+    assert close["retracement_base_pct"] == 0.0
+    assert close["retracement_volatility_1h_weight"] == 0.01
+    assert close["retracement_volatility_1m_weight"] == 0.01
+
+
+def test_gpu_materialized_fixed_runtime_scope_still_fails_closed():
     config = _long_only_ema_config()
     config["optimize"]["fixed_runtime_overrides"] = {
         "bot.long.unstuck.enabled": True
@@ -1652,8 +1698,6 @@ def test_gpu_materialized_fixed_runtime_scope_still_fails_closed():
     proxy_config = _materialize_gpu_override_template(
         config,
         [],
-        optimizer_overrides,
-        fixed_overrides_fn=_apply_config_overrides,
     )
 
     with pytest.raises(ValueError, match=r"bot\.long\.unstuck"):

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -25,6 +25,7 @@ from optimization.backends.gpu_backend import (
     _constraint_diagnostics,
     _ema_multicoin_bound_map,
     _format_constraint_diagnostics,
+    _gpu_fixed_bound_context,
     _gpu_candidate_source_sides,
     _materialize_gpu_override_template,
     _DriftMonitor,
@@ -432,12 +433,6 @@ def test_single_scenario_metric_surface_supports_all_reducers():
                 "coin_overrides", {"BTC": {"bot.long.risk.n_positions": 2}}
             ),
             "coin_overrides",
-        ),
-        (
-            lambda config: config["optimize"]["fixed_runtime_overrides"].__setitem__(
-                "bot.long.unstuck.enabled", True
-            ),
-            "fixed_runtime_overrides",
         ),
         (
             lambda config: config["live"].__setitem__(
@@ -1370,6 +1365,53 @@ def test_gpu_lossless_hash_uses_selected_anchor_fixed_retracement():
     assert submitted == recovered == [1.0, 0.06]
 
 
+def test_gpu_hash_uses_runtime_fixed_value_before_lossless_override():
+    key_paths = [
+        (
+            "long_close_threshold_base_pct",
+            (
+                "bot",
+                "long",
+                "strategy",
+                "trailing_martingale",
+                "close",
+                "threshold_base_pct",
+            ),
+        ),
+        (
+            "long_close_retracement_base_pct",
+            (
+                "bot",
+                "long",
+                "strategy",
+                "trailing_martingale",
+                "close",
+                "retracement_base_pct",
+            ),
+        ),
+    ]
+    base_vector = [0.01, 0.02]
+
+    submitted = _canonicalize_optimizer_override_hash_vector(
+        [0.01, 0.02],
+        base_vector,
+        key_paths,
+        {"lossless_close_trailing"},
+        fixed_bound_values={"long_close_retracement_base_pct": 0.06},
+        fixed_parameter_overrides={"long_close_retracement_base_pct": 0.06},
+    )
+    recovered = _canonicalize_optimizer_override_hash_vector(
+        [0.06, 0.06],
+        base_vector,
+        key_paths,
+        {"lossless_close_trailing"},
+        fixed_bound_values={"long_close_retracement_base_pct": 0.06},
+        fixed_parameter_overrides={"long_close_retracement_base_pct": 0.06},
+    )
+
+    assert submitted == recovered == [0.06, 0.06]
+
+
 def test_gpu_short_only_mirror_keeps_long_source_genes_active():
     assert _gpu_candidate_source_sides(
         {"short"}, {"mirror_short_from_long"}
@@ -1475,6 +1517,37 @@ def test_gpu_proxy_parameter_builder_applies_optimizer_overrides_after_anchors()
     ]
 
 
+def test_gpu_proxy_parameter_builder_applies_fixed_runtime_after_tunables():
+    mapped = {
+        "long_close_threshold_base_pct": (0, Bound(0.0, 1.0)),
+        "long_close_retracement_base_pct": (1, Bound(0.0, 1.0)),
+    }
+    active = [
+        ("long_close_threshold_base_pct", 0, mapped["long_close_threshold_base_pct"][1]),
+        (
+            "long_close_retracement_base_pct",
+            1,
+            mapped["long_close_retracement_base_pct"][1],
+        ),
+    ]
+
+    parameters = _build_proxy_parameter_dicts(
+        [0.01, 0.02],
+        mapped,
+        active,
+        np.asarray([[0.03, 0.04]]),
+        fixed_parameter_overrides={"long_close_retracement_base_pct": 0.06},
+        optimizer_overrides={"lossless_close_trailing"},
+    )
+
+    assert parameters == [
+        {
+            "long_close_threshold_base_pct": pytest.approx(0.06),
+            "long_close_retracement_base_pct": pytest.approx(0.06),
+        }
+    ]
+
+
 def test_gpu_optimizer_override_template_uses_exact_materializer():
     config = _directional_ema_config(long_enabled=True, short_enabled=True)
     long_strategy = config["bot"]["long"]["strategy"]["ema_anchor"]
@@ -1493,6 +1566,98 @@ def test_gpu_optimizer_override_template_uses_exact_materializer():
         == pytest.approx(0.123)
     )
     assert short_strategy["base_qty_pct"] == pytest.approx(0.456)
+
+
+def test_gpu_runtime_template_applies_fixed_values_before_optimizer_overrides():
+    from optimization.warmup import _apply_config_overrides
+
+    config = _directional_ema_config(long_enabled=True, short_enabled=True)
+    config["optimize"]["fixed_runtime_overrides"] = {
+        "bot.long.strategy.ema_anchor.base_qty_pct": 0.321
+    }
+
+    proxy_config = _materialize_gpu_override_template(
+        config,
+        ["mirror_short_from_long"],
+        optimizer_overrides,
+        fixed_overrides_fn=_apply_config_overrides,
+    )
+
+    assert (
+        proxy_config["bot"]["long"]["strategy"]["ema_anchor"]["base_qty_pct"]
+        == pytest.approx(0.321)
+    )
+    assert (
+        proxy_config["bot"]["short"]["strategy"]["ema_anchor"]["base_qty_pct"]
+        == pytest.approx(0.321)
+    )
+
+
+def test_gpu_runtime_template_rejects_fixed_strategy_kind_change():
+    from optimization.warmup import _apply_config_overrides
+
+    config = _long_only_ema_config()
+    config["optimize"]["fixed_runtime_overrides"] = {
+        "live.strategy_kind": "trailing_martingale"
+    }
+
+    with pytest.raises(ValueError, match="may not change live.strategy_kind"):
+        _materialize_gpu_override_template(
+            config,
+            [],
+            optimizer_overrides,
+            fixed_overrides_fn=_apply_config_overrides,
+        )
+
+
+def test_gpu_fixed_bound_context_maps_effective_candidate_shadows():
+    config = _long_only_ema_config()
+    path = ("bot", "long", "strategy", "ema_anchor", "offset")
+    fixed_only_path = ("bot", "long", "risk", "entry_cooldown_minutes")
+    config["optimize"]["fixed_runtime_overrides"] = {
+        ".".join(path): 0.123,
+        ".".join(fixed_only_path): 17.0,
+    }
+    effective = copy.deepcopy(config)
+    effective["bot"]["long"]["strategy"]["ema_anchor"]["offset"] = 0.123
+    effective["bot"]["long"]["risk"]["entry_cooldown_minutes"] = 17.0
+
+    bound_values, parameters = _gpu_fixed_bound_context(
+        config,
+        effective,
+        [("long_offset", path)],
+        {
+            "long_offset": "long_offset",
+            "long_risk_entry_cooldown_minutes": "long_entry_cooldown_minutes",
+        },
+    )
+
+    assert bound_values == {
+        "long_offset": 0.123,
+        "long_risk_entry_cooldown_minutes": 17.0,
+    }
+    assert parameters == {
+        "long_offset": 0.123,
+        "long_entry_cooldown_minutes": 17.0,
+    }
+
+
+def test_gpu_materialized_fixed_runtime_scope_still_fails_closed():
+    from optimization.warmup import _apply_config_overrides
+
+    config = _long_only_ema_config()
+    config["optimize"]["fixed_runtime_overrides"] = {
+        "bot.long.unstuck.enabled": True
+    }
+    proxy_config = _materialize_gpu_override_template(
+        config,
+        [],
+        optimizer_overrides,
+        fixed_overrides_fn=_apply_config_overrides,
+    )
+
+    with pytest.raises(ValueError, match=r"bot\.long\.unstuck"):
+        _validate_scope(proxy_config, _Evaluator())
 
 
 def test_gpu_optimizer_override_scope_fails_closed():

--- a/tests/optimization/test_optimizer_warmup.py
+++ b/tests/optimization/test_optimizer_warmup.py
@@ -17,6 +17,7 @@ from optimization.warmup import (
     compute_optimizer_backtest_warmup_minutes,
     compute_optimizer_per_coin_warmup_minutes,
     stamp_warmup_metadata,
+    validate_optimizer_effective_configs,
 )
 from warmup_utils import compute_per_coin_warmup_minutes
 
@@ -140,6 +141,16 @@ def test_optimizer_warmup_fixed_runtime_override_rejects_unknown_path():
         _apply_config_overrides(config, {"bot.long.risk.n_positons": 7})
 
     assert "n_positons" not in config["bot"]["long"]["risk"]
+
+
+def test_optimizer_rejects_invalid_effective_fixed_runtime_value_before_backend():
+    config = get_template_config()
+    config["optimize"]["fixed_runtime_overrides"] = {
+        "bot.long.forager.score_weights.volatility": -1.0
+    }
+
+    with pytest.raises(ValueError, match="score_weights.*non-negative"):
+        validate_optimizer_effective_configs(config)
 
 
 def test_stamp_optimizer_warmup_respects_last_valid_index_cap():

--- a/tests/test_config_pipeline.py
+++ b/tests/test_config_pipeline.py
@@ -89,6 +89,19 @@ def test_prepare_config_preserves_fixed_runtime_override_mapping():
         ([], TypeError, "fixed_runtime_overrides must be a dict"),
         ({1: 2}, TypeError, "keys must be dotted strings"),
         ({"bot.long.not_a_setting": 1}, KeyError, "Unknown override path"),
+        (
+            {
+                "bot.long.risk.total_wallet_exposure_limit": 1.0,
+                "bot.long.total_wallet_exposure_limit": 2.0,
+            },
+            ValueError,
+            "resolve to the same setting",
+        ),
+        (
+            {"bot.long.strategy.trailing_martingale": {}},
+            TypeError,
+            "must target leaf settings",
+        ),
     ],
 )
 def test_prepare_config_rejects_invalid_fixed_runtime_overrides(

--- a/tests/test_config_pipeline.py
+++ b/tests/test_config_pipeline.py
@@ -69,6 +69,38 @@ def test_startup_phase_budgets_validate_and_roundtrip():
     ]
 
 
+def test_prepare_config_preserves_fixed_runtime_override_mapping():
+    source = get_template_config()
+    source["optimize"]["fixed_runtime_overrides"] = {
+        "bot.long.strategy.trailing_martingale.entry.threshold_base_pct": 0.123,
+        "bot.short.hsl.no_restart_drawdown_threshold": 1.0,
+    }
+
+    prepared = prepare_config(source, verbose=False, target="canonical", runtime=None)
+
+    assert prepared["optimize"]["fixed_runtime_overrides"] == source["optimize"][
+        "fixed_runtime_overrides"
+    ]
+
+
+@pytest.mark.parametrize(
+    "overrides,error_type,error_match",
+    [
+        ([], TypeError, "fixed_runtime_overrides must be a dict"),
+        ({1: 2}, TypeError, "keys must be dotted strings"),
+        ({"bot.long.not_a_setting": 1}, KeyError, "Unknown override path"),
+    ],
+)
+def test_prepare_config_rejects_invalid_fixed_runtime_overrides(
+    overrides, error_type, error_match
+):
+    source = get_template_config()
+    source["optimize"]["fixed_runtime_overrides"] = overrides
+
+    with pytest.raises(error_type, match=error_match):
+        prepare_config(source, verbose=False, target="canonical", runtime=None)
+
+
 @pytest.mark.parametrize(
     "budgets,error_type,error_match",
     [


### PR DESCRIPTION
## Summary

- apply `optimize.fixed_runtime_overrides` to the experimental Apple MPS proxy in exact candidate-materialization order: anchor, tunables, fixed runtime values, then `optimize.enable_overrides`
- remove fixed-shadowed and dependent dead GPU genes, canonicalize their durable candidate hashes, and keep exact Rust authoritative
- validate the effective overridden GPU scope fail-closed, including rejecting strategy-kind changes that would desynchronize the search shape and Metal kernel
- preserve documented user-defined dotted leaf paths through shared config normalization; reject malformed, unknown, colliding-alias, and mapping-level paths early
- validate exact finalized boundary configs before either CPU or GPU optimization starts

## Validation

- full Python test suite: passed
- focused config/GPU tests: passed (287 tests)
- `py_compile`: passed
- `git diff --check`: passed

## Apple M3/MPS evidence

EMA-anchor, long+short with `mirror_short_from_long`, Bybit SOL, 2024-01 through available present data:

- 32,768 Metal proxy evaluations; 64 exact Rust validations; 8 generations
- all 64 persisted exact candidates had long offset `0.007` and short offset `0.007`
- zero mirror mismatches; all 64 records included GPU validation metadata

Trailing-martingale long-only with `lossless_close_trailing`, Bybit ETH, 2026-06-01 through 2026-07-30:

- 16,384 Metal proxy evaluations; 64 exact Rust validations; 8 generations; 22.6 seconds
- all 64 exact candidates fixed close retracement at `0.03`; lossless close threshold was `0.03` for every candidate
- `n_positions=1` and excess allowance `0` were fixed through runtime overrides; all 64 records included GPU validation metadata

Review-fix regression on the same ETH window with fixed close retracement `0`:

- 16,384 Metal proxy evaluations; 64 exact Rust validations; 8 generations; 23.6 seconds
- every persisted exact candidate had retracement base `0` and both now-dead retracement-volatility weights canonicalized to `0.01`
- fixed `n_positions=1` and excess allowance `0`; all 64 records included GPU validation metadata

GPU support remains additive; CPU bot, backtest, and optimizer paths do not import or require PyTorch.
