### PR TITLE
feat(optimize): support single-coin GPU suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Add experimental Apple MPS optimization suites for the existing single-coin EMA-anchor and
+  trailing-martingale scopes. Metal screens every candidate against each prepared scenario, while
+  the canonical suite reducer, scenario-aware objectives, and limits select proxy candidates and
+  unchanged exact Rust suite evaluations remain authoritative. This slice supports scenario date,
+  coin, ignored-coin, and single-exchange selection; scenario config overrides, multi-exchange
+  suites, and multi-coin scenarios still fail closed.
+
 - Apply `optimize.fixed_runtime_overrides` to experimental Apple MPS candidates in the same order
   as the exact CPU optimizer. Fixed values shadow corresponding Metal search genes, participate in
   durable candidate hashing, and remain subordinate to later `optimize.enable_overrides`; the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable user-facing changes will be documented in this file.
   unchanged exact Rust suite evaluations remain authoritative. This slice supports scenario date,
   coin, ignored-coin, and single-exchange selection; scenario config overrides, multi-exchange
   suites, multi-coin scenarios, and per-coin source assignments still fail closed. Effective
-  external suite definitions and scenario filters are persisted and checked on resume.
+  external suite definitions, scenario filters, and resolved date windows are persisted and
+  checked on resume.
 
 - Apply `optimize.fixed_runtime_overrides` to experimental Apple MPS candidates in the same order
   as the exact CPU optimizer. Fixed values shadow corresponding Metal search genes, participate in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable user-facing changes will be documented in this file.
   the canonical suite reducer, scenario-aware objectives, and limits select proxy candidates and
   unchanged exact Rust suite evaluations remain authoritative. This slice supports scenario date,
   coin, ignored-coin, and single-exchange selection; scenario config overrides, multi-exchange
-  suites, and multi-coin scenarios still fail closed.
+  suites, multi-coin scenarios, and per-coin source assignments still fail closed. Effective
+  external suite definitions and scenario filters are persisted and checked on resume.
 
 - Apply `optimize.fixed_runtime_overrides` to experimental Apple MPS candidates in the same order
   as the exact CPU optimizer. Fixed values shadow corresponding Metal search genes, participate in

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -111,7 +111,8 @@ The supported slice is intentionally narrow:
   prepared coin count
 - hedge mode and one-way mode; one-way flat-side arbitration uses the active strategy's Rust rule
 - suite mode for single-coin scenarios on one shared exchange; scenario date, coin, ignored-coin,
-  and exchange selection are supported, while scenario config overrides remain unsupported
+  and exchange selection are supported, while scenario config overrides and per-coin source
+  assignments remain unsupported
 - HSL and auto-unstuck disabled
 - BTC collateral, coin overrides, realized-loss gating, and exposure enforcers disabled
 - `backtest.filter_by_min_effective_cost: false`
@@ -119,8 +120,8 @@ The supported slice is intentionally narrow:
 - no invalid candle tail after the selected coin's final valid candle
 
 Unsupported combinations fail before optimization begins. Multi-coin trailing-martingale or
-long+short runs, multi-coin or multi-exchange suites, suite scenario config overrides, HSL, and
-auto-unstuck are not silently approximated by this release.
+long+short runs, multi-coin or multi-exchange suites, suite scenario config overrides or per-coin
+source assignments, HSL, and auto-unstuck are not silently approximated by this release.
 
 For a supported suite, each Metal candidate is dispatched across every prepared scenario. The GPU
 path then calls the same canonical suite reducer and scenario-selection logic as the CPU optimizer
@@ -129,7 +130,9 @@ Every exact validation still runs the unchanged Rust backtest for every scenario
 suite metrics enter `all_results.bin` and the Pareto front. A scenario may select a different
 single coin or date window, but every scenario must resolve to exactly one coin on the same
 exchange. Scenario `overrides` are rejected until their candidate-shadowing behavior is explicitly
-modeled by the proxy.
+modeled by the proxy, and scenario `coin_sources` are rejected until per-coin source-exchange
+semantics are modeled. The effective external suite definition and any `--scenarios` filter are
+stored in the run contract and checkpoint identity, so resume fails closed if either changes.
 
 Ordinary `-t/--start` seeding and fine-tuning with `-ft/--fine-tune-params` use the same optimizer
 shape as the CPU backends. When `-t` and `-ft` are combined, the GPU population includes the

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -110,16 +110,26 @@ The supported slice is intentionally narrow:
   for single-coin runs; supported multi-coin bounds may vary `n_positions` between `1` and the
   prepared coin count
 - hedge mode and one-way mode; one-way flat-side arbitration uses the active strategy's Rust rule
-- suite mode disabled
+- suite mode for single-coin scenarios on one shared exchange; scenario date, coin, ignored-coin,
+  and exchange selection are supported, while scenario config overrides remain unsupported
 - HSL and auto-unstuck disabled
-- BTC collateral, coin overrides, realized-loss gating, exposure enforcers, and non-inert fixed
-  runtime overrides disabled
+- BTC collateral, coin overrides, realized-loss gating, and exposure enforcers disabled
 - `backtest.filter_by_min_effective_cost: false`
 - `live.market_orders_allowed: false`
 - no invalid candle tail after the selected coin's final valid candle
 
 Unsupported combinations fail before optimization begins. Multi-coin trailing-martingale or
-long+short runs, suites, HSL, and auto-unstuck are not silently approximated by this release.
+long+short runs, multi-coin or multi-exchange suites, suite scenario config overrides, HSL, and
+auto-unstuck are not silently approximated by this release.
+
+For a supported suite, each Metal candidate is dispatched across every prepared scenario. The GPU
+path then calls the same canonical suite reducer and scenario-selection logic as the CPU optimizer
+for aggregate reducers, named-scenario objectives, and named-scenario or suite-reduced limits.
+Every exact validation still runs the unchanged Rust backtest for every scenario; only those exact
+suite metrics enter `all_results.bin` and the Pareto front. A scenario may select a different
+single coin or date window, but every scenario must resolve to exactly one coin on the same
+exchange. Scenario `overrides` are rejected until their candidate-shadowing behavior is explicitly
+modeled by the proxy.
 
 Ordinary `-t/--start` seeding and fine-tuning with `-ft/--fine-tune-params` use the same optimizer
 shape as the CPU backends. When `-t` and `-ft` are combined, the GPU population includes the
@@ -173,9 +183,11 @@ The backend is hybrid rather than a replacement backtester:
    price finalization, and their ordering relative to aligned quantity steps is retained across
    float32 transport. Tick-aligned computed targets remain on their exchange tick; residual
    float32 arithmetic drift is measured by exact validation.
-3. Diverse proxy-front candidates and broad drift probes are sent to the unchanged Rust backtester.
-4. Only exact Rust results enter `all_results.bin` and the persisted Pareto front.
-5. Rolling rank and constraint-agreement gates independently stop the run if proxy/exact agreement
+3. In suite mode, the same candidate batch is screened once per scenario and reduced with the
+   canonical suite scoring and limit contract.
+4. Diverse proxy-front candidates and broad drift probes are sent to the unchanged Rust backtester.
+5. Only exact Rust results enter `all_results.bin` and the persisted Pareto front.
+6. Rolling rank and constraint-agreement gates independently stop the run if proxy/exact agreement
    falls below `drift_halt` after sufficient evidence. Constraint classification is monitored over
    all validations and independently for proxy-front candidates and broad probes. An isolated
    disagreement is retained as drift evidence rather than aborting immediately; the exact Rust

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -132,7 +132,8 @@ single coin or date window, but every scenario must resolve to exactly one coin 
 exchange. Scenario `overrides` are rejected until their candidate-shadowing behavior is explicitly
 modeled by the proxy, and scenario `coin_sources` are rejected until per-coin source-exchange
 semantics are modeled. The effective external suite definition and any `--scenarios` filter are
-stored in the run contract and checkpoint identity, so resume fails closed if either changes.
+stored in the run contract and checkpoint identity, with dynamic scenario dates resolved to the
+prepared concrete dates, so resume fails closed if the definition or resolved window changes.
 
 Ordinary `-t/--start` seeding and fine-tuning with `-ft/--fine-tune-params` use the same optimizer
 shape as the CPU backends. When `-t` and `-ft` are combined, the GPU population includes the

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -423,6 +423,75 @@ def _single_scenario_metric_surface(metrics: dict) -> dict:
     return flattened
 
 
+_GPU_SUITE_OBJECTIVES_KEY = "__gpu_suite_objectives__"
+_GPU_SUITE_VIOLATION_KEY = "__gpu_suite_constraint_violation__"
+_GPU_SUITE_METRICS_KEY = "__gpu_suite_metrics__"
+
+
+def _scalar_metric_stats(metrics: dict) -> dict:
+    return {
+        key: {
+            "mean": float(value),
+            "min": float(value),
+            "max": float(value),
+            "std": 0.0,
+            "median": float(value),
+        }
+        for key, value in metrics.items()
+    }
+
+
+def _evaluate_gpu_suite_proxies(suite_evaluator, scenario_proxies, candidates) -> list[dict]:
+    """Screen one candidate batch across suite scenarios with canonical reducers."""
+
+    from suite_runner import ScenarioResult, SuiteScenario
+
+    scenario_rows = [
+        (ctx, proxy.evaluate(candidates)) for ctx, proxy in scenario_proxies
+    ]
+    results = []
+    for index in range(len(candidates)):
+        scenario_results = [
+            ScenarioResult(
+                scenario=SuiteScenario(
+                    label=ctx.label,
+                    start_date=None,
+                    end_date=None,
+                    coins=None,
+                    ignored_coins=None,
+                ),
+                per_exchange={},
+                metrics={"stats": _scalar_metric_stats(rows[index])},
+                elapsed_seconds=0.0,
+                output_path=None,
+            )
+            for ctx, rows in scenario_rows
+        ]
+        scored = suite_evaluator.score_scenario_results(scenario_results)
+        results.append(
+            {
+                _GPU_SUITE_OBJECTIVES_KEY: tuple(scored["objectives"]),
+                _GPU_SUITE_VIOLATION_KEY: float(scored["constraint_violation"]),
+                _GPU_SUITE_METRICS_KEY: scored["suite_metrics"],
+            }
+        )
+    return results
+
+
+def _suite_limit_metric_value(suite_payload: dict, check: dict):
+    metrics = suite_payload.get("metrics", {}) if isinstance(suite_payload, dict) else {}
+    metric = check["metric"]
+    entry = metrics.get(metric)
+    if entry is None and metric.endswith(("_usd", "_btc")):
+        entry = metrics.get(metric.rsplit("_", 1)[0])
+    if not isinstance(entry, dict):
+        return None
+    scenario = check.get("scenario")
+    if scenario is not None:
+        return (entry.get("scenarios") or {}).get(scenario)
+    return (entry.get("stats") or {}).get(check.get("reducer") or "mean")
+
+
 def _resolve_options(config: dict) -> dict:
     options = dict(GPU_DEFAULTS)
     configured = config.get("optimize", {}).get("gpu", {})
@@ -607,8 +676,14 @@ def _validate_resume_evidence_budget(
         )
 
 
-def _validate_scope(config: dict, evaluator) -> str:
-    if bool(config.get("backtest", {}).get("suite_enabled")):
+def _validate_scope_config(
+    config: dict,
+    *,
+    exchanges,
+    coin_count: int,
+    allow_suite: bool = False,
+) -> str:
+    if bool(config.get("backtest", {}).get("suite_enabled")) and not allow_suite:
         raise ValueError("GPU foundation does not support suite mode")
     if bool(config.get("backtest", {}).get("filter_by_min_effective_cost")):
         raise ValueError(
@@ -629,14 +704,13 @@ def _validate_scope(config: dict, evaluator) -> str:
             "GPU foundation requires live.max_realized_loss_pct=1.0 because the "
             "screening proxy does not model the realized-loss gate"
         )
-    exchanges = list(getattr(evaluator, "exchanges", []))
+    exchanges = list(exchanges)
     if len(exchanges) != 1:
         raise ValueError(
             f"GPU foundation requires exactly one exchange, got {exchanges}"
         )
     exchange = exchanges[0]
-    hlcvs = evaluator.shared_hlcvs_np[exchange]
-    coin_count = int(hlcvs.shape[1])
+    coin_count = int(coin_count)
     if coin_count < 1:
         raise ValueError("GPU foundation requires at least one prepared coin")
     strategy_kind = (
@@ -706,6 +780,100 @@ def _validate_scope(config: dict, evaluator) -> str:
                 f"GPU foundation requires bot.{side}.risk.we_excess_allowance_pct=0.0"
             )
     return exchange
+
+
+def _validate_scope(
+    config: dict,
+    evaluator,
+    *,
+    allow_suite: bool = False,
+) -> str:
+    exchanges = list(getattr(evaluator, "exchanges", []))
+    if len(exchanges) != 1:
+        return _validate_scope_config(
+            config,
+            exchanges=exchanges,
+            coin_count=0,
+            allow_suite=allow_suite,
+        )
+    exchange = exchanges[0]
+    hlcvs = evaluator.shared_hlcvs_np[exchange]
+    return _validate_scope_config(
+        config,
+        exchanges=exchanges,
+        coin_count=int(hlcvs.shape[1]),
+        allow_suite=allow_suite,
+    )
+
+
+def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict]:
+    """Materialize fail-closed single-coin suite inputs for MPS screening."""
+
+    contexts = getattr(suite_evaluator, "contexts", None)
+    get_data = getattr(suite_evaluator, "get_prepared_context_data", None)
+    build_config = getattr(suite_evaluator, "build_scenario_candidate_config", None)
+    if not isinstance(contexts, list) or not contexts:
+        raise ValueError("GPU suite mode requires prepared optimizer scenario contexts")
+    if not callable(get_data) or not callable(build_config):
+        raise TypeError("GPU suite mode requires the canonical SuiteEvaluator")
+
+    prepared = []
+    expected_exchange = None
+    for ctx in contexts:
+        if ctx.overrides:
+            raise ValueError(
+                f"GPU suite scenario {ctx.label!r} uses config overrides; this slice "
+                "supports scenario dates, coins, ignored coins, and exchange selection only"
+            )
+        exchanges = list(ctx.exchanges)
+        if len(exchanges) != 1:
+            raise ValueError(
+                f"GPU suite scenario {ctx.label!r} requires exactly one exchange, "
+                f"got {exchanges}"
+            )
+        exchange = exchanges[0]
+        if exchange == "combined":
+            raise ValueError(
+                "GPU suite scenarios do not support combined multi-exchange datasets"
+            )
+        if expected_exchange is None:
+            expected_exchange = exchange
+        elif exchange != expected_exchange:
+            raise ValueError(
+                "GPU suite scenarios must use one shared exchange; "
+                f"expected {expected_exchange!r}, got {exchange!r} in {ctx.label!r}"
+            )
+
+        hlcvs, btc, coin_indices = get_data(ctx, exchange)
+        values = np.asarray(hlcvs)
+        if coin_indices is not None:
+            values = np.take(values, list(coin_indices), axis=1)
+        values = np.ascontiguousarray(values)
+        coin_count = int(values.shape[1])
+        if coin_count != 1:
+            raise ValueError(
+                "GPU suite foundation currently requires exactly one prepared coin "
+                f"per scenario; {ctx.label!r} prepared {coin_count}"
+            )
+        scenario_config = build_config(proxy_config, ctx)
+        _validate_scope_config(
+            scenario_config,
+            exchanges=exchanges,
+            coin_count=coin_count,
+            allow_suite=True,
+        )
+        prepared.append(
+            {
+                "ctx": ctx,
+                "config": scenario_config,
+                "exchange": exchange,
+                "hlcvs": values,
+                "mss": ctx.msss[exchange],
+                "btc": btc,
+                "timestamps": ctx.timestamps.get(exchange),
+            }
+        )
+    return prepared
 
 
 def _average_ranks(values: np.ndarray) -> np.ndarray:
@@ -1464,13 +1632,29 @@ def _constraint_classification_mismatch(proxy_violation: float, exact_payload: d
 def _constraint_diagnostics(evaluator, proxy_metrics: dict, exact_payload: dict) -> list[dict]:
     """Describe proxy/exact values for every active optimizer limit."""
 
-    proxy_surface = _single_scenario_metric_surface(proxy_metrics)
-    exact_stats = (exact_payload.get("metrics") or {}).get("stats") or {}
-    exact_surface = flatten_metric_stats(exact_stats)
+    proxy_suite = proxy_metrics.get(_GPU_SUITE_METRICS_KEY)
+    exact_metrics = exact_payload.get("metrics") or {}
+    exact_suite = exact_metrics.get("suite_metrics")
+    proxy_surface = (
+        None if proxy_suite is not None else _single_scenario_metric_surface(proxy_metrics)
+    )
+    exact_surface = (
+        None
+        if exact_suite is not None
+        else flatten_metric_stats(exact_metrics.get("stats") or {})
+    )
     diagnostics = []
     for check in getattr(evaluator, "limit_checks", []):
-        proxy_value = resolve_metric_value(proxy_surface, check["metric_key"])
-        exact_value = resolve_metric_value(exact_surface, check["metric_key"])
+        proxy_value = (
+            _suite_limit_metric_value(proxy_suite, check)
+            if proxy_suite is not None
+            else resolve_metric_value(proxy_surface, check["metric_key"])
+        )
+        exact_value = (
+            _suite_limit_metric_value(exact_suite, check)
+            if exact_suite is not None
+            else resolve_metric_value(exact_surface, check["metric_key"])
+        )
         entry = {
             "metric": check["metric"],
             "metric_key": check["metric_key"],
@@ -1648,8 +1832,18 @@ def run_backend(
         overrides_list,
         finalize_fn=_finalize_optimizer_vector_config,
     )
-    exchange = _validate_scope(proxy_config, evaluator)
-    coin_count = int(evaluator.shared_hlcvs_np[exchange].shape[1])
+    suite_enabled = bool(config.get("backtest", {}).get("suite_enabled"))
+    suite_inputs = (
+        _gpu_suite_scenario_inputs(proxy_config, evaluator_for_pool)
+        if suite_enabled
+        else []
+    )
+    if suite_enabled:
+        exchange = suite_inputs[0]["exchange"]
+        coin_count = 1
+    else:
+        exchange = _validate_scope(proxy_config, evaluator)
+        coin_count = int(evaluator.shared_hlcvs_np[exchange].shape[1])
     if strategy_kind == "ema_anchor" and coin_count > 1:
         multicoin_sides = [
             side
@@ -1845,17 +2039,46 @@ def run_backend(
             "use supported metrics or the CPU optimizer"
         )
 
-    proxy_cls = MpsMulticoinEmaProxy if coin_count > 1 else MpsSingleCoinProxy
-    proxy = proxy_cls(
-        config=proxy_config,
-        hlcvs=evaluator.shared_hlcvs_np[exchange],
-        mss=evaluator.msss[exchange],
-        btc=evaluator.shared_btc_np[exchange],
-        timestamps=evaluator.timestamps.get(exchange),
-        exchange=exchange,
-        batch_size=int(options["batch_size"]),
-        needed_metrics=needed_metrics,
-    )
+    if suite_enabled:
+        scenario_proxies = [
+            (
+                item["ctx"],
+                MpsSingleCoinProxy(
+                    config=item["config"],
+                    hlcvs=item["hlcvs"],
+                    mss=item["mss"],
+                    btc=item["btc"],
+                    timestamps=item["timestamps"],
+                    exchange=item["exchange"],
+                    batch_size=int(options["batch_size"]),
+                    needed_metrics=needed_metrics,
+                ),
+            )
+            for item in suite_inputs
+        ]
+
+        def evaluate_proxy(candidates):
+            return _evaluate_gpu_suite_proxies(
+                evaluator_for_pool,
+                scenario_proxies,
+                candidates,
+            )
+
+    else:
+        proxy_cls = MpsMulticoinEmaProxy if coin_count > 1 else MpsSingleCoinProxy
+        proxy = proxy_cls(
+            config=proxy_config,
+            hlcvs=evaluator.shared_hlcvs_np[exchange],
+            mss=evaluator.msss[exchange],
+            btc=evaluator.shared_btc_np[exchange],
+            timestamps=evaluator.timestamps.get(exchange),
+            exchange=exchange,
+            batch_size=int(options["batch_size"]),
+            needed_metrics=needed_metrics,
+        )
+
+        def evaluate_proxy(candidates):
+            return proxy.evaluate(candidates)
 
     active_low = np.asarray(
         [bound.low for _name, _index, bound in active], dtype=np.float64
@@ -2104,6 +2327,18 @@ def run_backend(
         objectives = np.empty((len(metric_rows), len(specs)), dtype=np.float64)
         violations = np.empty(len(metric_rows), dtype=np.float64)
         for row, metrics in enumerate(metric_rows):
+            if _GPU_SUITE_OBJECTIVES_KEY in metrics:
+                objective_values = np.asarray(
+                    metrics[_GPU_SUITE_OBJECTIVES_KEY], dtype=np.float64
+                )
+                if len(objective_values) != len(specs):
+                    raise ValueError(
+                        "GPU suite proxy objective length mismatch: "
+                        f"expected {len(specs)}, got {len(objective_values)}"
+                    )
+                objectives[row] = objective_values
+                violations[row] = float(metrics[_GPU_SUITE_VIOLATION_KEY])
+                continue
             flattened = _single_scenario_metric_surface(metrics)
             objective_values = [
                 metrics[canonicalize_metric_name(spec.metric)] for spec in specs
@@ -2227,7 +2462,7 @@ def run_backend(
 
             population = algorithm.ask()
             rows = np.asarray(population.get("X"), dtype=np.float64)
-            metric_rows = proxy.evaluate(parameter_dicts(rows))
+            metric_rows = evaluate_proxy(parameter_dicts(rows))
             proxy_objectives, proxy_violations = proxy_fitness(metric_rows)
             proxy_evaluations += len(rows)
             if objective_scale.median is None:

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -825,6 +825,14 @@ def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict
                 f"GPU suite scenario {ctx.label!r} uses config overrides; this slice "
                 "supports scenario dates, coins, ignored coins, and exchange selection only"
             )
+        coin_sources = (
+            getattr(ctx, "config", {}).get("backtest", {}).get("coin_sources") or {}
+        )
+        if coin_sources:
+            raise ValueError(
+                f"GPU suite scenario {ctx.label!r} uses coin_sources; this slice "
+                "does not model per-coin source exchanges"
+            )
         exchanges = list(ctx.exchanges)
         if len(exchanges) != 1:
             raise ValueError(
@@ -874,6 +882,13 @@ def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict
             }
         )
     return prepared
+
+
+def _gpu_suite_enabled(config: dict, evaluator, evaluator_for_pool) -> bool:
+    enabled = evaluator_for_pool is not evaluator
+    if bool(config.get("backtest", {}).get("suite_enabled")) and not enabled:
+        raise TypeError("GPU suite mode requires the canonical SuiteEvaluator")
+    return enabled
 
 
 def _average_ranks(values: np.ndarray) -> np.ndarray:
@@ -1307,7 +1322,27 @@ def _update_novelty_stall(
     return current
 
 
-def _checkpoint_signature(active, scoring, *, anchor_plan=None) -> str:
+def _gpu_suite_checkpoint_contract(config: dict) -> dict:
+    backtest = config.get("backtest", {})
+    return {
+        key: deepcopy(backtest.get(key))
+        for key in (
+            "suite_enabled",
+            "scenarios",
+            "reducer",
+            "exchanges",
+            "volume_normalization",
+        )
+    }
+
+
+def _checkpoint_signature(
+    active,
+    scoring,
+    *,
+    anchor_plan=None,
+    suite_contract=None,
+) -> str:
     payload = {
         "active": [
             [name, int(index), float(bound.low), float(bound.high), bound.step]
@@ -1328,6 +1363,8 @@ def _checkpoint_signature(active, scoring, *, anchor_plan=None) -> str:
                 for anchor in anchor_plan.get("anchors") or []
             ],
         }
+    if suite_contract is not None:
+        payload["suite_contract"] = suite_contract
     return hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()
 
 
@@ -1635,6 +1672,14 @@ def _constraint_diagnostics(evaluator, proxy_metrics: dict, exact_payload: dict)
     proxy_suite = proxy_metrics.get(_GPU_SUITE_METRICS_KEY)
     exact_metrics = exact_payload.get("metrics") or {}
     exact_suite = exact_metrics.get("suite_metrics")
+    exact_constraint_violation = float(
+        exact_metrics.get("constraint_violation", 0.0) or 0.0
+    )
+    exact_failure_penalty = (
+        exact_constraint_violation
+        if exact_metrics.get("error") and exact_constraint_violation > 0.0
+        else None
+    )
     proxy_surface = (
         None if proxy_suite is not None else _single_scenario_metric_surface(proxy_metrics)
     )
@@ -1655,15 +1700,24 @@ def _constraint_diagnostics(evaluator, proxy_metrics: dict, exact_payload: dict)
             if exact_suite is not None
             else resolve_metric_value(exact_surface, check["metric_key"])
         )
+        exact_limit_violation = (
+            None
+            if exact_value is None and exact_failure_penalty is not None
+            else float(compute_limit_violation(check, exact_value))
+        )
         entry = {
             "metric": check["metric"],
             "metric_key": check["metric_key"],
+            "scenario": check.get("scenario"),
+            "reducer": check.get("reducer"),
             "mode": check["mode"],
             "proxy_value": None if proxy_value is None else float(proxy_value),
             "exact_value": None if exact_value is None else float(exact_value),
             "proxy_violation": float(compute_limit_violation(check, proxy_value)),
-            "exact_violation": float(compute_limit_violation(check, exact_value)),
+            "exact_violation": exact_limit_violation,
         }
+        if exact_limit_violation is None:
+            entry["exact_failure_penalty"] = exact_failure_penalty
         if "bound" in check:
             entry["bound"] = float(check["bound"])
         if "range" in check:
@@ -1676,13 +1730,20 @@ def _format_constraint_diagnostics(diagnostics: list[dict]) -> str:
     differing = [
         item
         for item in diagnostics
-        if (item["proxy_violation"] > 0.0) != (item["exact_violation"] > 0.0)
+        if item["exact_violation"] is None
+        or (item["proxy_violation"] > 0.0) != (item["exact_violation"] > 0.0)
     ]
     selected = differing or diagnostics
     return "; ".join(
         f"{item['metric_key']}: proxy={item['proxy_value']} "
         f"exact={item['exact_value']} mode={item['mode']} "
-        f"bound={item.get('bound', item.get('range'))}"
+        f"bound={item.get('bound', item.get('range'))} "
+        f"scenario={item.get('scenario')} reducer={item.get('reducer')}"
+        + (
+            f" exact_failure_penalty={item['exact_failure_penalty']}"
+            if item.get("exact_failure_penalty") is not None
+            else ""
+        )
         for item in selected
     )
 
@@ -1832,7 +1893,7 @@ def run_backend(
         overrides_list,
         finalize_fn=_finalize_optimizer_vector_config,
     )
-    suite_enabled = bool(config.get("backtest", {}).get("suite_enabled"))
+    suite_enabled = _gpu_suite_enabled(config, evaluator, evaluator_for_pool)
     suite_inputs = (
         _gpu_suite_scenario_inputs(proxy_config, evaluator_for_pool)
         if suite_enabled
@@ -2181,6 +2242,9 @@ def run_backend(
         active,
         config["optimize"]["scoring"],
         anchor_plan=get_anchor_plan(config),
+        suite_contract=(
+            _gpu_suite_checkpoint_contract(config) if suite_enabled else None
+        ),
     )
     budget = int(config["optimize"]["iters"])
     if budget <= 0:
@@ -2192,7 +2256,9 @@ def run_backend(
         with open(checkpoint_path, "rb") as file:
             checkpoint = pickle.load(file)
         if checkpoint.get("signature") != signature:
-            raise ValueError("GPU checkpoint does not match current bounds and scoring")
+            raise ValueError(
+                "GPU checkpoint does not match current bounds, scoring, or suite contract"
+            )
         algorithm = checkpoint["algorithm"]
         seed = int(checkpoint.get("seed", seed))
         generation = int(checkpoint["generation"])

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -2988,14 +2988,23 @@ def _materialize_resolved_gpu_suite_dates(
     for scenario, ctx in zip(scenarios, scenario_contexts):
         resolved = deepcopy(scenario)
         resolved["label"] = ctx.label
-        context_backtest = ctx.config.get("backtest", {})
         for key in ("start_date", "end_date"):
-            value = context_backtest.get(key)
-            if value is None:
+            meta_key = f"requested_{key}"
+            prepared_values = {
+                str(mss.get("__meta__", {}).get(meta_key))
+                for mss in ctx.msss.values()
+                if mss.get("__meta__", {}).get(meta_key) is not None
+            }
+            if not prepared_values:
                 raise RuntimeError(
-                    f"GPU suite scenario {ctx.label!r} has no prepared {key}"
+                    f"GPU suite scenario {ctx.label!r} has no prepared {meta_key}"
                 )
-            resolved[key] = value
+            if len(prepared_values) != 1:
+                raise RuntimeError(
+                    f"GPU suite scenario {ctx.label!r} has inconsistent prepared "
+                    f"{meta_key} values: {sorted(prepared_values)}"
+                )
+            resolved[key] = prepared_values.pop()
         resolved_scenarios.append(resolved)
     config["backtest"]["scenarios"] = resolved_scenarios
 

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -117,6 +117,7 @@ from utils import date_to_ts, ts_to_date, utc_ms, make_get_filepath, format_appr
 from logging_setup import configure_logging, resolve_log_level
 from materialized_cache import release_materialized_payload
 from copy import deepcopy
+from dataclasses import replace
 import gc
 import numpy as np
 from uuid import uuid4
@@ -2282,6 +2283,26 @@ class SuiteEvaluator:
             self.base.seen_hashes[actual_hash] = (tuple(objectives), total_penalty)
         return build_evaluation_payload(objectives, total_penalty, metrics_payload, individual)
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["contexts"] = [
+            replace(
+                ctx,
+                shared_hlcvs_np={},
+                shared_btc_np={},
+                attachments={"hlcvs": {}, "btc": {}},
+            )
+            for ctx in self.contexts
+        ]
+        state["_master_attachments"] = {"hlcvs": {}, "btc": {}}
+        state["_master_arrays"] = {"hlcvs": {}, "btc": {}}
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._master_attachments = {"hlcvs": {}, "btc": {}}
+        self._master_arrays = {"hlcvs": {}, "btc": {}}
+
     def __del__(self):
         self.close()
 
@@ -2932,6 +2953,22 @@ def _active_suite_scenario_labels(suite_cfg: Mapping[str, Any]) -> list[str] | N
     return [scenario.label for scenario in scenarios]
 
 
+def _materialize_gpu_suite_run_contract(
+    config: Dict[str, Any], suite_cfg: Mapping[str, Any]
+) -> None:
+    """Persist the effective external/filterable suite in the GPU run config."""
+
+    if config.get("optimize", {}).get("backend") != "gpu" or not suite_cfg.get(
+        "enabled"
+    ):
+        return
+    backtest = config.setdefault("backtest", {})
+    backtest["suite_enabled"] = True
+    for key in ("scenarios", "reducer", "exchanges", "volume_normalization"):
+        if key in suite_cfg:
+            backtest[key] = deepcopy(suite_cfg[key])
+
+
 def _validate_optimizer_limit_suite_mode(
     config: Mapping[str, Any],
     *,
@@ -3228,6 +3265,7 @@ async def main():
         )
         suite_cfg["enabled"] = bool(args.suite)
 
+    _materialize_gpu_suite_run_contract(config, suite_cfg)
     active_suite_scenario_labels = _active_suite_scenario_labels(suite_cfg)
     _validate_optimizer_limit_suite_mode(
         config,

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -1893,7 +1893,21 @@ class SuiteEvaluator:
                 ctx.attachments["btc"][exchange] = attachment
                 ctx.shared_btc_np[exchange] = attachment.array
 
-    def _build_scenario_candidate_config(self, config: Dict[str, Any], ctx: ScenarioEvalContext):
+    def get_prepared_context_data(
+        self, ctx: ScenarioEvalContext, exchange: str
+    ) -> tuple[np.ndarray, np.ndarray | None, list[int] | None]:
+        """Return the exact prepared arrays and active coin indices for a scenario."""
+
+        if self._uses_lazy_slicing(ctx, exchange):
+            return self._get_lazy_slice_data(ctx, exchange)
+        self._ensure_context_attachment(ctx, exchange)
+        return (
+            ctx.shared_hlcvs_np[exchange],
+            ctx.shared_btc_np.get(exchange),
+            ctx.coin_indices.get(exchange),
+        )
+
+    def build_scenario_candidate_config(self, config: Dict[str, Any], ctx: ScenarioEvalContext):
         scenario_config = dict(config)
         scenario_backtest = ctx.config.get("backtest", {})
         backtest_cfg = dict(config.get("backtest", {}))
@@ -1914,6 +1928,83 @@ class SuiteEvaluator:
             scenario_config = deepcopy(scenario_config)
             _apply_config_overrides(scenario_config, ctx.overrides)
         return scenario_config
+
+    def _build_scenario_candidate_config(
+        self, config: Dict[str, Any], ctx: ScenarioEvalContext
+    ):
+        """Compatibility wrapper for callers predating the public suite helper."""
+
+        return self.build_scenario_candidate_config(config, ctx)
+
+    def score_scenario_results(self, scenario_results: List[ScenarioResult]) -> Dict[str, Any]:
+        """Apply the canonical suite reducers, objectives, and limits to scenario stats."""
+
+        reduce_started = time.perf_counter()
+        reduced_summary = reduce_metrics(scenario_results, self.reducer_cfg)
+        reduce_metrics_ms = (time.perf_counter() - reduce_started) * 1000.0
+        fitness_started = time.perf_counter()
+        suite_payload = build_suite_metrics_payload(scenario_results, reduced_summary)
+        reduced_stats = reduced_summary.get("stats", {})
+
+        reduced_stats_flat = flatten_metric_stats(reduced_stats)
+        flat_stats = dict(reduced_stats_flat)
+        # Override _mean with correctly aggregated values so calc_fitness
+        # and limit defaults respect the reducer config (e.g. "max" instead of "mean").
+        aggregated_values = reduced_summary.get("aggregated", {})
+        for metric, agg_value in aggregated_values.items():
+            flat_stats[f"{metric}_mean"] = agg_value
+        required_scenario_labels = {
+            basis.scenario for basis in self.objective_bases if basis.scenario is not None
+        }
+        required_scenario_labels.update(
+            check["scenario"]
+            for check in self.base.limit_checks
+            if check.get("scenario") is not None
+        )
+        scenario_stats_by_label = {
+            result.scenario.label: flatten_metric_stats(result.metrics.get("stats", {}))
+            for result in scenario_results
+            if result.scenario.label in required_scenario_labels
+        }
+        objective_values: List[float] = []
+        for spec, basis in zip(self.base.scoring_specs, self.objective_bases):
+            if basis.scenario is not None:
+                source_stats = scenario_stats_by_label[basis.scenario]
+                reducer = "mean"
+            else:
+                source_stats = reduced_stats_flat
+                reducer = basis.reducer or "mean"
+            value = resolve_metric_value(source_stats, f"{spec.metric}_{reducer}")
+            if value is None and spec.metric.endswith(("_usd", "_btc")):
+                value = resolve_metric_value(
+                    source_stats,
+                    f"{spec.metric.rsplit('_', 1)[0]}_{reducer}",
+                )
+            if value is None:
+                basis_label = (
+                    f"scenario {basis.scenario!r}"
+                    if basis.scenario is not None
+                    else f"reducer {reducer!r}"
+                )
+                raise ValueError(
+                    "missing optimizer scoring metric "
+                    f"{spec.metric!r} for {basis_label}; "
+                    f"available metrics: {_format_available_metric_keys(source_stats)}"
+                )
+            objective_values.append(float(value))
+        objectives, total_penalty = self.base.calc_fitness(
+            flat_stats,
+            limit_metrics=flat_stats,
+            scenario_limit_metrics=scenario_stats_by_label,
+            objective_values=objective_values,
+        )
+        return {
+            "objectives": tuple(objectives),
+            "constraint_violation": float(total_penalty),
+            "suite_metrics": suite_payload,
+            "reduce_metrics_ms": reduce_metrics_ms,
+            "fitness_payload_ms": (time.perf_counter() - fitness_started) * 1000.0,
+        }
 
     def evaluate(self, individual, overrides_list):
         profile_enabled = _optimize_profile_enabled()
@@ -1985,7 +2076,7 @@ class SuiteEvaluator:
 
         for ctx in self.contexts:
             phase_start = _profile_start(profile_enabled)
-            scenario_config = self._build_scenario_candidate_config(config, ctx)
+            scenario_config = self.build_scenario_candidate_config(config, ctx)
             skip_btc_analysis = _optimizer_can_skip_btc_analysis(
                 scenario_config,
                 self.base.scoring_specs,
@@ -2013,16 +2104,9 @@ class SuiteEvaluator:
 
             analyses = {}
             for exchange in ctx.exchanges:
-                # Get data arrays - either from lazy slicing or cached SharedMemory
-                if self._uses_lazy_slicing(ctx, exchange):
-                    # Get time-sliced VIEW (O(1) memory) + coin indices
-                    # Coin subsetting is passed to Rust as active indices.
-                    hlcvs_data, btc_data, coin_indices = self._get_lazy_slice_data(ctx, exchange)
-                else:
-                    self._ensure_context_attachment(ctx, exchange)
-                    hlcvs_data = ctx.shared_hlcvs_np[exchange]
-                    btc_data = ctx.shared_btc_np.get(exchange)
-                    coin_indices = ctx.coin_indices.get(exchange)
+                hlcvs_data, btc_data, coin_indices = self.get_prepared_context_data(
+                    ctx, exchange
+                )
 
                 phase_start = _profile_start(profile_enabled)
                 payload = build_backtest_payload(
@@ -2146,67 +2230,14 @@ class SuiteEvaluator:
                 )
             )
 
-        phase_start = _profile_start(profile_enabled)
-        reduced_summary = reduce_metrics(scenario_results, self.reducer_cfg)
-        _profile_add(timings, "reduce_metrics_ms", phase_start)
-        phase_start = _profile_start(profile_enabled)
-        suite_payload = build_suite_metrics_payload(scenario_results, reduced_summary)
-        reduced_stats = reduced_summary.get("stats", {})
-
-        reduced_stats_flat = flatten_metric_stats(reduced_stats)
-        flat_stats = dict(reduced_stats_flat)
-        # Override _mean with correctly aggregated values so calc_fitness
-        # and limit defaults respect the reducer config (e.g. "max" instead of "mean").
-        aggregated_values = reduced_summary.get("aggregated", {})
-        for metric, agg_value in aggregated_values.items():
-            flat_stats[f"{metric}_mean"] = agg_value
-        required_scenario_labels = {
-            basis.scenario for basis in self.objective_bases if basis.scenario is not None
-        }
-        required_scenario_labels.update(
-            check["scenario"]
-            for check in self.base.limit_checks
-            if check.get("scenario") is not None
-        )
-        scenario_stats_by_label = {
-            result.scenario.label: flatten_metric_stats(result.metrics.get("stats", {}))
-            for result in scenario_results
-            if result.scenario.label in required_scenario_labels
-        }
-        objective_values: List[float] = []
-        for spec, basis in zip(self.base.scoring_specs, self.objective_bases):
-            if basis.scenario is not None:
-                source_stats = scenario_stats_by_label[basis.scenario]
-                reducer = "mean"
-            else:
-                source_stats = reduced_stats_flat
-                reducer = basis.reducer or "mean"
-            value = resolve_metric_value(source_stats, f"{spec.metric}_{reducer}")
-            if value is None and spec.metric.endswith(("_usd", "_btc")):
-                value = resolve_metric_value(
-                    source_stats,
-                    f"{spec.metric.rsplit('_', 1)[0]}_{reducer}",
-                )
-            if value is None:
-                basis_label = (
-                    f"scenario {basis.scenario!r}"
-                    if basis.scenario is not None
-                    else f"reducer {reducer!r}"
-                )
-                raise ValueError(
-                    "missing optimizer scoring metric "
-                    f"{spec.metric!r} for {basis_label}; "
-                    f"available metrics: {_format_available_metric_keys(source_stats)}"
-                )
-            objective_values.append(float(value))
-        objectives, total_penalty = self.base.calc_fitness(
-            flat_stats,
-            limit_metrics=flat_stats,
-            scenario_limit_metrics=scenario_stats_by_label,
-            objective_values=objective_values,
-        )
+        suite_fitness = self.score_scenario_results(scenario_results)
+        objectives = suite_fitness["objectives"]
+        total_penalty = suite_fitness["constraint_violation"]
+        suite_payload = suite_fitness["suite_metrics"]
+        if timings is not None:
+            timings["reduce_metrics_ms"] = suite_fitness["reduce_metrics_ms"]
+            timings["fitness_payload_ms"] = suite_fitness["fitness_payload_ms"]
         objectives_map = {f"w_{i}": val for i, val in enumerate(objectives)}
-        _profile_add(timings, "fitness_payload_ms", phase_start)
 
         metrics_payload = {
             "objectives": objectives_map,

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -2969,6 +2969,37 @@ def _materialize_gpu_suite_run_contract(
             backtest[key] = deepcopy(suite_cfg[key])
 
 
+def _materialize_resolved_gpu_suite_dates(
+    config: Dict[str, Any], scenario_contexts: Sequence[ScenarioEvalContext]
+) -> None:
+    """Replace dynamic suite date tokens with the prepared concrete dates."""
+
+    if config.get("optimize", {}).get("backend") != "gpu" or not config.get(
+        "backtest", {}
+    ).get("suite_enabled"):
+        return
+    scenarios = config["backtest"].get("scenarios") or []
+    if len(scenarios) != len(scenario_contexts):
+        raise RuntimeError(
+            "GPU suite run contract does not match prepared scenario count: "
+            f"{len(scenarios)} != {len(scenario_contexts)}"
+        )
+    resolved_scenarios = []
+    for scenario, ctx in zip(scenarios, scenario_contexts):
+        resolved = deepcopy(scenario)
+        resolved["label"] = ctx.label
+        context_backtest = ctx.config.get("backtest", {})
+        for key in ("start_date", "end_date"):
+            value = context_backtest.get(key)
+            if value is None:
+                raise RuntimeError(
+                    f"GPU suite scenario {ctx.label!r} has no prepared {key}"
+                )
+            resolved[key] = value
+        resolved_scenarios.append(resolved)
+    config["backtest"]["scenarios"] = resolved_scenarios
+
+
 def _validate_optimizer_limit_suite_mode(
     config: Mapping[str, Any],
     *,
@@ -3336,6 +3367,7 @@ async def main():
             )
             if not scenario_contexts:
                 raise ValueError("Suite configuration produced no scenarios.")
+            _materialize_resolved_gpu_suite_dates(config, scenario_contexts)
             logging.info("Optimizer suite enabled with %d scenario(s)", len(scenario_contexts))
             first_ctx = scenario_contexts[0]
             hlcvs_specs = first_ctx.hlcvs_specs

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -2253,6 +2253,8 @@ def test_gpu_checkpoint_signature_tracks_effective_suite_contract():
     changed_scenario["scenarios"][0]["coins"] = ["ETH"]
     changed_reducer = copy.deepcopy(suite)
     changed_reducer["reducer"]["default"] = "min"
+    changed_date = copy.deepcopy(suite)
+    changed_date["scenarios"][0]["end_date"] = "2026-08-19"
 
     assert _checkpoint_signature(active, scoring) != original
     assert (
@@ -2261,6 +2263,10 @@ def test_gpu_checkpoint_signature_tracks_effective_suite_contract():
     )
     assert (
         _checkpoint_signature(active, scoring, suite_contract=changed_reducer)
+        != original
+    )
+    assert (
+        _checkpoint_signature(active, scoring, suite_contract=changed_date)
         != original
     )
 

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -24,9 +25,11 @@ from optimization.backends.gpu_backend import (
     _constraint_classification_mismatch,
     _constraint_diagnostics,
     _ema_multicoin_bound_map,
+    _evaluate_gpu_suite_proxies,
     _format_constraint_diagnostics,
     _gpu_fixed_bound_context,
     _gpu_candidate_source_sides,
+    _gpu_suite_scenario_inputs,
     _materialize_gpu_override_template,
     _DriftMonitor,
     _ObjectiveScale,
@@ -38,6 +41,7 @@ from optimization.backends.gpu_backend import (
     _resolve_options,
     _restore_gpu_result_run_contract,
     _single_scenario_metric_surface,
+    _suite_limit_metric_value,
     _select_novel_validations,
     _select_validation_indices,
     _update_probe_shortfall_log,
@@ -47,6 +51,9 @@ from optimization.backends.gpu_backend import (
     _validate_resume_evidence_budget,
     _validate_seed_side_match,
     _validate_scope,
+    _GPU_SUITE_METRICS_KEY,
+    _GPU_SUITE_OBJECTIVES_KEY,
+    _GPU_SUITE_VIOLATION_KEY,
     EMA_MULTICOIN_LONG_BOUND_MAP,
     EMA_MULTICOIN_SHORT_BOUND_MAP,
     TRAILING_MARTINGALE_BOUND_MAP,
@@ -388,6 +395,187 @@ def test_single_scenario_metric_surface_supports_all_reducers():
         "drawdown_median": 0.25,
         "drawdown_std": 0.0,
     }
+
+
+def test_gpu_scope_allows_suite_only_when_explicitly_requested():
+    config = _long_only_ema_config()
+    config["backtest"]["suite_enabled"] = True
+
+    with pytest.raises(ValueError, match="suite"):
+        _validate_scope(config, _Evaluator())
+
+    assert _validate_scope(config, _Evaluator(), allow_suite=True) == "bybit"
+
+
+def test_gpu_suite_inputs_materialize_one_selected_coin():
+    config = _long_only_ema_config()
+    config["backtest"]["suite_enabled"] = True
+    master = np.arange(10 * 3 * 4, dtype=np.float64).reshape(10, 3, 4)
+    ctx = SimpleNamespace(
+        label="stress",
+        overrides={},
+        exchanges=["bybit"],
+        msss={"bybit": {"BTC": {}, "__meta__": {}}},
+        timestamps={"bybit": np.arange(10, dtype=np.int64)},
+    )
+
+    class Suite:
+        contexts = [ctx]
+
+        @staticmethod
+        def get_prepared_context_data(_ctx, _exchange):
+            return master, np.ones(10), [1]
+
+        @staticmethod
+        def build_scenario_candidate_config(proxy_config, _ctx):
+            return copy.deepcopy(proxy_config)
+
+    prepared = _gpu_suite_scenario_inputs(config, Suite())
+
+    assert len(prepared) == 1
+    assert prepared[0]["hlcvs"].shape == (10, 1, 4)
+    assert np.array_equal(prepared[0]["hlcvs"][:, 0], master[:, 1])
+
+
+@pytest.mark.parametrize(
+    ("overrides", "exchanges", "coin_indices", "message"),
+    [
+        ({"bot.long.risk.n_positions": 1}, ["bybit"], [0], "config overrides"),
+        ({}, ["bybit", "binance"], [0], "exactly one exchange"),
+        ({}, ["combined"], [0], "combined multi-exchange"),
+        ({}, ["bybit"], [0, 1], "exactly one prepared coin"),
+    ],
+)
+def test_gpu_suite_inputs_reject_unsupported_scenario_scope(
+    overrides, exchanges, coin_indices, message
+):
+    config = _long_only_ema_config()
+    config["backtest"]["suite_enabled"] = True
+    ctx = SimpleNamespace(
+        label="stress",
+        overrides=overrides,
+        exchanges=exchanges,
+        msss={exchange: {"BTC": {}, "__meta__": {}} for exchange in exchanges},
+        timestamps={exchange: np.arange(10, dtype=np.int64) for exchange in exchanges},
+    )
+
+    class Suite:
+        contexts = [ctx]
+
+        @staticmethod
+        def get_prepared_context_data(_ctx, _exchange):
+            return np.zeros((10, 2, 4)), np.ones(10), coin_indices
+
+        @staticmethod
+        def build_scenario_candidate_config(proxy_config, _ctx):
+            return copy.deepcopy(proxy_config)
+
+    with pytest.raises(ValueError, match=message):
+        _gpu_suite_scenario_inputs(config, Suite())
+
+
+def test_gpu_suite_inputs_require_one_shared_exchange_across_scenarios():
+    config = _long_only_ema_config()
+    config["backtest"]["suite_enabled"] = True
+    contexts = [
+        SimpleNamespace(
+            label=exchange,
+            overrides={},
+            exchanges=[exchange],
+            msss={exchange: {"BTC": {}, "__meta__": {}}},
+            timestamps={exchange: np.arange(10, dtype=np.int64)},
+        )
+        for exchange in ("bybit", "binance")
+    ]
+
+    class Suite:
+        @staticmethod
+        def get_prepared_context_data(_ctx, _exchange):
+            return np.zeros((10, 1, 4)), np.ones(10), [0]
+
+        @staticmethod
+        def build_scenario_candidate_config(proxy_config, _ctx):
+            return copy.deepcopy(proxy_config)
+
+    Suite.contexts = contexts
+
+    with pytest.raises(ValueError, match="one shared exchange"):
+        _gpu_suite_scenario_inputs(config, Suite())
+
+
+def test_gpu_suite_proxy_rows_use_canonical_suite_scorer():
+    contexts = [SimpleNamespace(label="base"), SimpleNamespace(label="stress")]
+
+    class Proxy:
+        def __init__(self, values):
+            self.values = values
+
+        def evaluate(self, candidates):
+            assert len(candidates) == 2
+            return [{"adg_strategy_eq": value} for value in self.values]
+
+    class Suite:
+        @staticmethod
+        def score_scenario_results(results):
+            values = [
+                result.metrics["stats"]["adg_strategy_eq"]["mean"]
+                for result in results
+            ]
+            return {
+                "objectives": (-min(values),),
+                "constraint_violation": max(values),
+                "suite_metrics": {"values": values},
+            }
+
+    rows = _evaluate_gpu_suite_proxies(
+        Suite(),
+        [
+            (contexts[0], Proxy([0.10, 0.20])),
+            (contexts[1], Proxy([0.01, 0.02])),
+        ],
+        [{"x": 1}, {"x": 2}],
+    )
+
+    assert rows == [
+        {
+            _GPU_SUITE_OBJECTIVES_KEY: (-0.01,),
+            _GPU_SUITE_VIOLATION_KEY: 0.10,
+            _GPU_SUITE_METRICS_KEY: {"values": [0.10, 0.01]},
+        },
+        {
+            _GPU_SUITE_OBJECTIVES_KEY: (-0.02,),
+            _GPU_SUITE_VIOLATION_KEY: 0.20,
+            _GPU_SUITE_METRICS_KEY: {"values": [0.20, 0.02]},
+        },
+    ]
+
+
+def test_suite_limit_metric_value_respects_reducer_and_scenario():
+    payload = {
+        "metrics": {
+            "drawdown_worst_strategy_eq": {
+                "stats": {"mean": 0.2, "max": 0.4},
+                "scenarios": {"base": 0.1, "stress": 0.4},
+            }
+        }
+    }
+
+    assert _suite_limit_metric_value(
+        payload,
+        {
+            "metric": "drawdown_worst_strategy_eq",
+            "reducer": "max",
+            "scenario": None,
+        },
+    ) == 0.4
+    assert _suite_limit_metric_value(
+        payload,
+        {
+            "metric": "drawdown_worst_strategy_eq",
+            "reducer": "mean",
+            "scenario": "stress",
+        },
+    ) == 0.4
 
 
 @pytest.mark.parametrize(
@@ -2192,6 +2380,68 @@ def test_constraint_diagnostics_name_disagreeing_limit_values():
     assert "position_held_days_max_max" in detail
     assert "proxy=24.0 exact=195.0" in detail
     assert "bound=60.0" in detail
+
+
+def test_constraint_diagnostics_reads_suite_reducers_and_scenarios():
+    checks = [
+        {
+            "metric": "drawdown_worst_strategy_eq",
+            "metric_key": "drawdown_worst_strategy_eq_max",
+            "mode": "greater_than",
+            "bound": 0.3,
+            "penalty_weight": 1.0,
+            "reducer": "max",
+            "scenario": None,
+        },
+        {
+            "metric": "adg_strategy_eq",
+            "metric_key": "adg_strategy_eq_mean",
+            "mode": "less_than",
+            "bound": 0.002,
+            "penalty_weight": 1.0,
+            "reducer": "mean",
+            "scenario": "stress",
+        },
+    ]
+    evaluator = type("Evaluator", (), {"limit_checks": checks})()
+    proxy_suite = {
+        "metrics": {
+            "drawdown_worst_strategy_eq": {
+                "stats": {"max": 0.2},
+                "scenarios": {"stress": 0.2},
+            },
+            "adg_strategy_eq": {
+                "stats": {"mean": 0.003},
+                "scenarios": {"stress": 0.003},
+            },
+        }
+    }
+    exact_suite = {
+        "metrics": {
+            "drawdown_worst_strategy_eq": {
+                "stats": {"max": 0.4},
+                "scenarios": {"stress": 0.4},
+            },
+            "adg_strategy_eq": {
+                "stats": {"mean": 0.001},
+                "scenarios": {"stress": 0.001},
+            },
+        }
+    }
+
+    diagnostics = _constraint_diagnostics(
+        evaluator,
+        {_GPU_SUITE_METRICS_KEY: proxy_suite},
+        {"metrics": {"suite_metrics": exact_suite}},
+    )
+
+    assert [(item["proxy_value"], item["exact_value"]) for item in diagnostics] == [
+        (0.2, 0.4),
+        (0.003, 0.001),
+    ]
+    assert [item["exact_violation"] for item in diagnostics] == pytest.approx(
+        [0.1, 0.001]
+    )
 
 
 def test_resume_recovers_hashes_and_drift_for_results_ahead_of_checkpoint():

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -29,6 +29,7 @@ from optimization.backends.gpu_backend import (
     _format_constraint_diagnostics,
     _gpu_fixed_bound_context,
     _gpu_candidate_source_sides,
+    _gpu_suite_enabled,
     _gpu_suite_scenario_inputs,
     _materialize_gpu_override_template,
     _DriftMonitor,
@@ -407,6 +408,19 @@ def test_gpu_scope_allows_suite_only_when_explicitly_requested():
     assert _validate_scope(config, _Evaluator(), allow_suite=True) == "bybit"
 
 
+def test_gpu_suite_activation_comes_from_exact_evaluator_wrapper():
+    config = _long_only_ema_config()
+    base = object()
+    suite = object()
+
+    assert _gpu_suite_enabled(config, base, suite) is True
+    assert _gpu_suite_enabled(config, base, base) is False
+
+    config["backtest"]["suite_enabled"] = True
+    with pytest.raises(TypeError, match="canonical SuiteEvaluator"):
+        _gpu_suite_enabled(config, base, base)
+
+
 def test_gpu_suite_inputs_materialize_one_selected_coin():
     config = _long_only_ema_config()
     config["backtest"]["suite_enabled"] = True
@@ -471,6 +485,33 @@ def test_gpu_suite_inputs_reject_unsupported_scenario_scope(
             return copy.deepcopy(proxy_config)
 
     with pytest.raises(ValueError, match=message):
+        _gpu_suite_scenario_inputs(config, Suite())
+
+
+def test_gpu_suite_inputs_reject_effective_coin_sources():
+    config = _long_only_ema_config()
+    config["backtest"]["suite_enabled"] = True
+    ctx = SimpleNamespace(
+        label="stress",
+        config={"backtest": {"coin_sources": {"BTC": "binance"}}},
+        overrides={},
+        exchanges=["bybit"],
+        msss={"bybit": {"BTC": {}, "__meta__": {}}},
+        timestamps={"bybit": np.arange(10, dtype=np.int64)},
+    )
+
+    class Suite:
+        contexts = [ctx]
+
+        @staticmethod
+        def get_prepared_context_data(_ctx, _exchange):
+            return np.zeros((10, 1, 4)), np.ones(10), [0]
+
+        @staticmethod
+        def build_scenario_candidate_config(proxy_config, _ctx):
+            return copy.deepcopy(proxy_config)
+
+    with pytest.raises(ValueError, match="coin_sources"):
         _gpu_suite_scenario_inputs(config, Suite())
 
 
@@ -2197,6 +2238,33 @@ def test_gpu_anchor_checkpoint_signature_tracks_ordered_fixed_values():
     assert _checkpoint_signature(active, scoring, anchor_plan=reordered_items) == original
 
 
+def test_gpu_checkpoint_signature_tracks_effective_suite_contract():
+    active = [("long_base_qty_pct", 0, Bound(0.01, 0.1, 0.01))]
+    scoring = [{"goal": "max", "metric": "adg_strategy_eq"}]
+    suite = {
+        "suite_enabled": True,
+        "scenarios": [{"label": "base", "coins": ["BTC"]}],
+        "reducer": {"default": "mean"},
+        "exchanges": ["bybit"],
+        "volume_normalization": True,
+    }
+    original = _checkpoint_signature(active, scoring, suite_contract=suite)
+    changed_scenario = copy.deepcopy(suite)
+    changed_scenario["scenarios"][0]["coins"] = ["ETH"]
+    changed_reducer = copy.deepcopy(suite)
+    changed_reducer["reducer"]["default"] = "min"
+
+    assert _checkpoint_signature(active, scoring) != original
+    assert (
+        _checkpoint_signature(active, scoring, suite_contract=changed_scenario)
+        != original
+    )
+    assert (
+        _checkpoint_signature(active, scoring, suite_contract=changed_reducer)
+        != original
+    )
+
+
 def test_gpu_rejects_pinned_unsupported_risk_behavior():
     from optimization.bounds import Bound
 
@@ -2368,6 +2436,8 @@ def test_constraint_diagnostics_name_disagreeing_limit_values():
         {
             "metric": "position_held_days_max",
             "metric_key": "position_held_days_max_max",
+            "scenario": None,
+            "reducer": None,
             "mode": "greater_than",
             "proxy_value": 24.0,
             "exact_value": 195.0,
@@ -2380,6 +2450,7 @@ def test_constraint_diagnostics_name_disagreeing_limit_values():
     assert "position_held_days_max_max" in detail
     assert "proxy=24.0 exact=195.0" in detail
     assert "bound=60.0" in detail
+    assert "scenario=None reducer=None" in detail
 
 
 def test_constraint_diagnostics_reads_suite_reducers_and_scenarios():
@@ -2441,6 +2512,50 @@ def test_constraint_diagnostics_reads_suite_reducers_and_scenarios():
     ]
     assert [item["exact_violation"] for item in diagnostics] == pytest.approx(
         [0.1, 0.001]
+    )
+    detail = _format_constraint_diagnostics(diagnostics)
+    assert "scenario=None reducer=max" in detail
+    assert "scenario=stress reducer=mean" in detail
+
+
+def test_constraint_diagnostics_preserve_invalid_exact_suite_penalty():
+    check = {
+        "metric": "backtest_completion_ratio",
+        "metric_key": "backtest_completion_ratio_min",
+        "mode": "less_than",
+        "bound": 0.99,
+        "penalty_weight": 1.0,
+        "reducer": "min",
+        "scenario": None,
+    }
+    evaluator = type("Evaluator", (), {"limit_checks": [check]})()
+    diagnostics = _constraint_diagnostics(
+        evaluator,
+        {
+            _GPU_SUITE_METRICS_KEY: {
+                "metrics": {
+                    "backtest_completion_ratio": {
+                        "stats": {"min": 1.0},
+                        "scenarios": {"base": 1.0},
+                    }
+                }
+            }
+        },
+        {
+            "metrics": {
+                "suite_metrics": {},
+                "constraint_violation": 1.0e18,
+                "error": "recoverable Rust failure",
+            },
+            "G": np.asarray([1.0e18]),
+        },
+    )
+
+    assert diagnostics[0]["exact_value"] is None
+    assert diagnostics[0]["exact_violation"] is None
+    assert diagnostics[0]["exact_failure_penalty"] == 1.0e18
+    assert "exact_failure_penalty=1e+18" in _format_constraint_diagnostics(
+        diagnostics
     )
 
 

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -839,6 +839,44 @@ def test_materialize_gpu_suite_run_contract_does_not_change_cpu_config():
     assert config["backtest"] == before
 
 
+def test_materialize_resolved_gpu_suite_dates_replaces_dynamic_tokens():
+    config = optimize.get_template_config()
+    config["optimize"]["backend"] = "gpu"
+    config["backtest"]["suite_enabled"] = True
+    config["backtest"]["scenarios"] = [
+        {"label": "rolling", "start_date": "2026-01-01", "end_date": "now"}
+    ]
+    context = Mock(
+        label="rolling",
+        config={
+            "backtest": {
+                "start_date": "2026-01-01",
+                "end_date": "2026-08-18",
+            }
+        },
+    )
+
+    optimize._materialize_resolved_gpu_suite_dates(config, [context])
+
+    assert config["backtest"]["scenarios"] == [
+        {
+            "label": "rolling",
+            "start_date": "2026-01-01",
+            "end_date": "2026-08-18",
+        }
+    ]
+
+
+def test_materialize_resolved_gpu_suite_dates_rejects_context_count_mismatch():
+    config = optimize.get_template_config()
+    config["optimize"]["backend"] = "gpu"
+    config["backtest"]["suite_enabled"] = True
+    config["backtest"]["scenarios"] = [{"label": "base"}]
+
+    with pytest.raises(RuntimeError, match="prepared scenario count"):
+        optimize._materialize_resolved_gpu_suite_dates(config, [])
+
+
 def test_validate_optimizer_limit_suite_mode_rejects_named_scenario_early():
     config = optimize.get_template_config()
     config["optimize"]["limits"] = [

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -850,8 +850,16 @@ def test_materialize_resolved_gpu_suite_dates_replaces_dynamic_tokens():
         label="rolling",
         config={
             "backtest": {
-                "start_date": "2026-01-01",
-                "end_date": "2026-08-18",
+                "start_date": "now",
+                "end_date": "today",
+            }
+        },
+        msss={
+            "bybit": {
+                "__meta__": {
+                    "requested_start_date": "2026-08-17T00:00:00",
+                    "requested_end_date": "2026-08-18T00:00:00",
+                }
             }
         },
     )
@@ -861,10 +869,72 @@ def test_materialize_resolved_gpu_suite_dates_replaces_dynamic_tokens():
     assert config["backtest"]["scenarios"] == [
         {
             "label": "rolling",
-            "start_date": "2026-01-01",
-            "end_date": "2026-08-18",
+            "start_date": "2026-08-17T00:00:00",
+            "end_date": "2026-08-18T00:00:00",
         }
     ]
+
+
+def test_materialize_resolved_gpu_suite_dates_rejects_inconsistent_prepared_dates():
+    config = optimize.get_template_config()
+    config["optimize"]["backend"] = "gpu"
+    config["backtest"]["suite_enabled"] = True
+    config["backtest"]["scenarios"] = [{"label": "rolling"}]
+    context = Mock(
+        label="rolling",
+        msss={
+            "bybit": {
+                "__meta__": {
+                    "requested_start_date": "2026-08-16T00:00:00",
+                    "requested_end_date": "2026-08-18T00:00:00",
+                }
+            },
+            "binance": {
+                "__meta__": {
+                    "requested_start_date": "2026-08-17T00:00:00",
+                    "requested_end_date": "2026-08-18T00:00:00",
+                }
+            },
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="inconsistent prepared requested_start_date"):
+        optimize._materialize_resolved_gpu_suite_dates(config, [context])
+
+
+def test_materialized_gpu_suite_dates_make_rollover_resume_incompatible():
+    previous = optimize.get_template_config()
+    previous["optimize"]["backend"] = "gpu"
+    previous["backtest"]["suite_enabled"] = True
+    previous["backtest"]["scenarios"] = [
+        {"label": "rolling", "start_date": "now", "end_date": "2026-08-20"}
+    ]
+    current = deepcopy(previous)
+
+    def prepared_context(requested_start_date):
+        return Mock(
+            label="rolling",
+            msss={
+                "bybit": {
+                    "__meta__": {
+                        "requested_start_date": requested_start_date,
+                        "requested_end_date": "2026-08-20T00:00:00",
+                    }
+                }
+            },
+        )
+
+    optimize._materialize_resolved_gpu_suite_dates(
+        previous, [prepared_context("2026-08-17T00:00:00")]
+    )
+    optimize._materialize_resolved_gpu_suite_dates(
+        current, [prepared_context("2026-08-18T00:00:00")]
+    )
+    previous["suite_metrics"] = {"scenario_labels": ["rolling"]}
+
+    mismatches = optimize._resume_config_mismatches(previous, current)
+
+    assert any("backtest.scenarios" in mismatch for mismatch in mismatches)
 
 
 def test_materialize_resolved_gpu_suite_dates_rejects_context_count_mismatch():

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -797,6 +797,48 @@ def test_active_suite_scenario_labels_use_canonical_fallbacks():
     ) is None
 
 
+def test_materialize_gpu_suite_run_contract_persists_external_and_filtered_suite():
+    config = optimize.get_template_config()
+    config["optimize"]["backend"] = "gpu"
+    config["backtest"]["suite_enabled"] = False
+    suite_cfg = {
+        "enabled": True,
+        "scenarios": [{"label": "stress", "coins": ["ETH"]}],
+        "reducer": {"default": "max"},
+        "exchanges": ["bybit"],
+        "volume_normalization": False,
+    }
+
+    optimize._materialize_gpu_suite_run_contract(config, suite_cfg)
+
+    assert config["backtest"]["suite_enabled"] is True
+    assert config["backtest"]["scenarios"] == suite_cfg["scenarios"]
+    assert config["backtest"]["reducer"] == suite_cfg["reducer"]
+    assert config["backtest"]["exchanges"] == ["bybit"]
+    assert config["backtest"]["volume_normalization"] is False
+    suite_cfg["scenarios"][0]["coins"] = ["BTC"]
+    assert config["backtest"]["scenarios"][0]["coins"] == ["ETH"]
+
+
+def test_materialize_gpu_suite_run_contract_does_not_change_cpu_config():
+    config = optimize.get_template_config()
+    config["optimize"]["backend"] = "pymoo"
+    before = deepcopy(config["backtest"])
+
+    optimize._materialize_gpu_suite_run_contract(
+        config,
+        {
+            "enabled": True,
+            "scenarios": [{"label": "stress", "coins": ["ETH"]}],
+            "reducer": {"default": "max"},
+            "exchanges": ["bybit"],
+            "volume_normalization": False,
+        },
+    )
+
+    assert config["backtest"] == before
+
+
 def test_validate_optimizer_limit_suite_mode_rejects_named_scenario_early():
     config = optimize.get_template_config()
     config["optimize"]["limits"] = [

--- a/tests/optimization/test_optimize_suite_contexts.py
+++ b/tests/optimization/test_optimize_suite_contexts.py
@@ -1,3 +1,4 @@
+import pickle
 from types import SimpleNamespace
 
 import numpy as np
@@ -162,6 +163,46 @@ def test_suite_evaluator_close_releases_context_and_master_attachments():
     assert evaluator.contexts[0].attachments == {"hlcvs": {}, "btc": {}}
     assert evaluator._master_attachments == {"hlcvs": {}, "btc": {}}
     assert evaluator._master_arrays == {"hlcvs": {}, "btc": {}}
+
+
+def test_suite_evaluator_pickle_strips_attached_and_cached_arrays():
+    from optimize import SuiteEvaluator
+
+    large = np.ones((1024, 1024), dtype=np.float64)
+    context = optimize_suite.ScenarioEvalContext(
+        label="base",
+        config={},
+        exchanges=["bybit"],
+        hlcvs_specs={},
+        btc_usd_specs={},
+        msss={"bybit": {}},
+        timestamps={"bybit": None},
+        shared_hlcvs_np={"bybit": large},
+        shared_btc_np={"bybit": large[:, 0]},
+        attachments={"hlcvs": {"bybit": _FakeAttachment()}, "btc": {}},
+        coin_indices={"bybit": [0]},
+        overrides={},
+    )
+    evaluator = object.__new__(SuiteEvaluator)
+    evaluator.base = None
+    evaluator.contexts = [context]
+    evaluator.reducer_cfg = {"default": "mean"}
+    evaluator._master_attachments = {
+        "hlcvs": {"master": _FakeAttachment()},
+        "btc": {},
+    }
+    evaluator._master_arrays = {"hlcvs": {"master": large}, "btc": {}}
+
+    payload = pickle.dumps(evaluator)
+    restored = pickle.loads(payload)
+
+    assert len(payload) < 100_000
+    assert context.shared_hlcvs_np["bybit"] is large
+    assert restored.contexts[0].shared_hlcvs_np == {}
+    assert restored.contexts[0].shared_btc_np == {}
+    assert restored.contexts[0].attachments == {"hlcvs": {}, "btc": {}}
+    assert restored._master_arrays == {"hlcvs": {}, "btc": {}}
+    assert restored._master_attachments == {"hlcvs": {}, "btc": {}}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- enable experimental Apple MPS optimization for suites whose scenarios each prepare exactly one coin on one shared exchange
- dispatch every GPU candidate through every scenario proxy, then reuse the canonical suite reducer, named-scenario scoring, and limit implementation
- keep unchanged exact Rust suite evaluation authoritative for persistence, Pareto membership, constraint classification, and drift monitoring
- fail closed for scenario config overrides, combined or multiple exchanges, and multi-coin scenarios
- expose narrow canonical SuiteEvaluator helpers while preserving the prior private scenario-config helper contract
- document the supported suite slice and add an Unreleased changelog entry

## Validation

- `PYTHONPATH=src python -m pytest -q tests/optimization/test_gpu_backend.py tests/optimization/test_optimize_suite_contexts.py tests/optimization/test_optimize.py`
- `PYTHONPATH=src python -m pytest -q` (full repository suite, isolated test cache)
- `python -m py_compile src/optimize.py src/optimization/backends/gpu_backend.py tests/optimization/test_gpu_backend.py`
- `git diff --check`
- verified the rebuilt runtime extension source fingerprint matches this worktree

## Apple M3/MPS evidence

- two ETH date-window scenarios: 8,192 proxy evaluations, 64 exact Rust suite validations, 24.2 seconds
- named-scenario objective plus aggregate reducer and scenario/reduced limits: 4,096 proxy evaluations, 64 exact validations, 11.0 seconds; resumed from 64 to 72 exact validations with one additional 512-candidate generation in 1.5 seconds
- BTC and ETH as two separate single-coin scenarios on Bybit: 4,096 proxy evaluations, 64 exact validations, 9.6 seconds; all 64 durable rows contained canonical suite payloads, both scenario labels, and GPU validation evidence

All MPS runs used existing local historical data. No private configs or result artifacts are included in this PR.
