### PR TITLE
feat(gpu): support bot overrides in optimizer suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ All notable user-facing changes will be documented in this file.
   trailing-martingale scopes. Metal screens every candidate against each prepared scenario, while
   the canonical suite reducer, scenario-aware objectives, and limits select proxy candidates and
   unchanged exact Rust suite evaluations remain authoritative. This slice supports scenario date,
-  coin, ignored-coin, and single-exchange selection; scenario config overrides, multi-exchange
-  suites, multi-coin scenarios, and per-coin source assignments still fail closed. Effective
-  external suite definitions, scenario filters, and resolved date windows are persisted and
-  checked on resume.
+  coin, ignored-coin, and single-exchange selection. Scenario `bot.long`/`bot.short` overrides now
+  retain exact last-write precedence by shadowing affected Metal candidate parameters per scenario
+  and revalidating each effective scenario against the GPU scope; non-bot override paths,
+  multi-exchange suites, multi-coin scenarios, and per-coin source assignments still fail closed.
+  Effective external suite definitions, scenario filters, overrides, and resolved date windows are
+  persisted and checked on resume.
 
 - Apply `optimize.fixed_runtime_overrides` to experimental Apple MPS candidates in the same order
   as the exact CPU optimizer. Fixed values shadow corresponding Metal search genes, participate in

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -111,8 +111,8 @@ The supported slice is intentionally narrow:
   prepared coin count
 - hedge mode and one-way mode; one-way flat-side arbitration uses the active strategy's Rust rule
 - suite mode for single-coin scenarios on one shared exchange; scenario date, coin, ignored-coin,
-  and exchange selection are supported, while scenario config overrides and per-coin source
-  assignments remain unsupported
+  exchange selection, and fail-closed `bot.long`/`bot.short` config overrides are supported, while
+  non-bot override paths and per-coin source assignments remain unsupported
 - HSL and auto-unstuck disabled
 - BTC collateral, coin overrides, realized-loss gating, and exposure enforcers disabled
 - `backtest.filter_by_min_effective_cost: false`
@@ -120,7 +120,7 @@ The supported slice is intentionally narrow:
 - no invalid candle tail after the selected coin's final valid candle
 
 Unsupported combinations fail before optimization begins. Multi-coin trailing-martingale or
-long+short runs, multi-coin or multi-exchange suites, suite scenario config overrides or per-coin
+long+short runs, multi-coin or multi-exchange suites, non-bot suite scenario overrides, per-coin
 source assignments, HSL, and auto-unstuck are not silently approximated by this release.
 
 For a supported suite, each Metal candidate is dispatched across every prepared scenario. The GPU
@@ -129,8 +129,13 @@ for aggregate reducers, named-scenario objectives, and named-scenario or suite-r
 Every exact validation still runs the unchanged Rust backtest for every scenario; only those exact
 suite metrics enter `all_results.bin` and the Pareto front. A scenario may select a different
 single coin or date window, but every scenario must resolve to exactly one coin on the same
-exchange. Scenario `overrides` are rejected until their candidate-shadowing behavior is explicitly
-modeled by the proxy, and scenario `coin_sources` are rejected until per-coin source-exchange
+exchange. Scenario `overrides` require explicit candidate-shadowing behavior in the proxy. This
+slice models `bot.long` and `bot.short` overrides: the canonical exact
+suite evaluator still applies them last, after candidate materialization, while each scenario's
+Metal proxy shadows the corresponding candidate parameters with the same effective values. Every
+overridden scenario is rechecked against the directional GPU scope, so an override cannot silently
+enable HSL, auto-unstuck, an exposure enforcer, an invalid position count, or another unsupported
+behavior. Non-bot override paths and scenario `coin_sources` remain rejected until their proxy
 semantics are modeled. The effective external suite definition and any `--scenarios` filter are
 stored in the run contract and checkpoint identity, with dynamic scenario dates resolved to the
 prepared concrete dates, so resume fails closed if the definition or resolved window changes.

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -446,9 +446,14 @@ def _evaluate_gpu_suite_proxies(suite_evaluator, scenario_proxies, candidates) -
 
     from suite_runner import ScenarioResult, SuiteScenario
 
-    scenario_rows = [
-        (ctx, proxy.evaluate(candidates)) for ctx, proxy in scenario_proxies
-    ]
+    scenario_rows = []
+    for ctx, proxy, parameter_overrides in scenario_proxies:
+        scenario_candidates = (
+            [dict(candidate, **parameter_overrides) for candidate in candidates]
+            if parameter_overrides
+            else candidates
+        )
+        scenario_rows.append((ctx, proxy.evaluate(scenario_candidates)))
     results = []
     for index in range(len(candidates)):
         scenario_results = [
@@ -809,6 +814,8 @@ def _validate_scope(
 def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict]:
     """Materialize fail-closed single-coin suite inputs for MPS screening."""
 
+    from config.param_paths import require_existing_config_path
+
     contexts = getattr(suite_evaluator, "contexts", None)
     get_data = getattr(suite_evaluator, "get_prepared_context_data", None)
     build_config = getattr(suite_evaluator, "build_scenario_candidate_config", None)
@@ -820,11 +827,17 @@ def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict
     prepared = []
     expected_exchange = None
     for ctx in contexts:
-        if ctx.overrides:
-            raise ValueError(
-                f"GPU suite scenario {ctx.label!r} uses config overrides; this slice "
-                "supports scenario dates, coins, ignored coins, and exchange selection only"
-            )
+        overrides = getattr(ctx, "overrides", {}) or {}
+        for dotted_path in overrides:
+            resolved = require_existing_config_path(proxy_config, dotted_path)
+            if len(resolved) < 3 or resolved[0] != "bot" or resolved[1] not in {
+                "long",
+                "short",
+            }:
+                raise ValueError(
+                    f"GPU suite scenario {ctx.label!r} override {dotted_path!r} is "
+                    "outside the supported bot.long/bot.short scope"
+                )
         coin_sources = (
             getattr(ctx, "config", {}).get("backtest", {}).get("coin_sources") or {}
         )
@@ -874,6 +887,7 @@ def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict
             {
                 "ctx": ctx,
                 "config": scenario_config,
+                "overrides": deepcopy(overrides),
                 "exchange": exchange,
                 "hlcvs": values,
                 "mss": ctx.msss[exchange],
@@ -882,6 +896,73 @@ def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict
             }
         )
     return prepared
+
+
+def _gpu_suite_scenario_override_context(
+    base_config: dict,
+    scenario_config: dict,
+    overrides: dict,
+    bound_keys,
+    bound_map: dict[str, str],
+) -> tuple[dict[str, float], dict[str, float]]:
+    """Resolve exact-last scenario overrides into candidate and proxy shadows."""
+
+    if not overrides:
+        return {}, {}
+
+    from config.param_paths import (
+        require_existing_config_path,
+        resolve_optimizer_key_path,
+    )
+
+    override_paths = [
+        require_existing_config_path(base_config, dotted_path)
+        for dotted_path in overrides
+    ]
+
+    def is_shadowed(path: tuple[str, ...]) -> bool:
+        return any(
+            path[: len(override_path)] == override_path
+            for override_path in override_paths
+        )
+
+    def value_at(path: tuple[str, ...]):
+        value = scenario_config
+        for part in path:
+            value = value[part]
+        return value
+
+    fixed_bound_values: dict[str, float] = {}
+    fixed_parameters: dict[str, float] = {}
+    for bound_key in bound_keys:
+        path = resolve_optimizer_key_path(base_config, bound_key)
+        if path is None or not is_shadowed(path):
+            continue
+        try:
+            value = float(value_at(path))
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(
+                "GPU suite scenario override for optimizer bound "
+                f"{bound_key!r} must resolve to a numeric value"
+            ) from exc
+        if not math.isfinite(value):
+            raise ValueError(
+                "GPU suite scenario override for optimizer bound "
+                f"{bound_key!r} must resolve to a finite value"
+            )
+        fixed_bound_values[bound_key] = value
+        parameter = bound_map.get(bound_key)
+        if parameter is not None:
+            previous = fixed_parameters.get(parameter)
+            if previous is not None and not math.isclose(
+                previous, value, rel_tol=0.0, abs_tol=1.0e-12
+            ):
+                raise ValueError(
+                    "GPU suite scenario overrides resolve conflicting values for "
+                    f"proxy parameter {parameter!r}"
+                )
+            fixed_parameters[parameter] = value
+    return fixed_bound_values, fixed_parameters
 
 
 def _gpu_suite_enabled(config: dict, evaluator, evaluator_for_pool) -> bool:
@@ -2055,6 +2136,40 @@ def run_backend(
         coin_count=coin_count,
     )
 
+    for item in suite_inputs:
+        fixed_scenario_bounds, parameter_overrides = (
+            _gpu_suite_scenario_override_context(
+                proxy_config,
+                item["config"],
+                item["overrides"],
+                bound_by_key,
+                bound_map,
+            )
+        )
+        scenario_bound_by_key = dict(bound_by_key)
+        scenario_base_by_key = dict(base_by_key)
+        for bound_key, value in fixed_scenario_bounds.items():
+            scenario_bound_by_key[bound_key] = Bound(value, value)
+            scenario_base_by_key[bound_key] = value
+        scenario_enabled_sides = {
+            side
+            for side in ("long", "short")
+            if gpu_side_enabled(item["config"], side)
+        }
+        _validate_pinned_scope_bounds(
+            scenario_bound_by_key,
+            scenario_base_by_key,
+            scenario_enabled_sides,
+        )
+        _validate_directional_search_space(
+            scenario_bound_by_key,
+            scenario_base_by_key,
+            item["config"].get("live", {}).get("approved_coins", {}),
+            scenario_enabled_sides,
+            coin_count=1,
+        )
+        item["parameter_overrides"] = parameter_overrides
+
     for bound_key, bound in bound_by_key.items():
         if bound_key == ANCHOR_GENE_KEY or bound.high <= bound.low:
             continue
@@ -2114,6 +2229,7 @@ def run_backend(
                     batch_size=int(options["batch_size"]),
                     needed_metrics=needed_metrics,
                 ),
+                item["parameter_overrides"],
             )
             for item in suite_inputs
         ]

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -30,6 +30,7 @@ from optimization.backends.gpu_backend import (
     _gpu_fixed_bound_context,
     _gpu_candidate_source_sides,
     _gpu_suite_enabled,
+    _gpu_suite_scenario_override_context,
     _gpu_suite_scenario_inputs,
     _materialize_gpu_override_template,
     _DriftMonitor,
@@ -454,7 +455,7 @@ def test_gpu_suite_inputs_materialize_one_selected_coin():
 @pytest.mark.parametrize(
     ("overrides", "exchanges", "coin_indices", "message"),
     [
-        ({"bot.long.risk.n_positions": 1}, ["bybit"], [0], "config overrides"),
+        ({"backtest.starting_balance": 1_000}, ["bybit"], [0], "outside the supported"),
         ({}, ["bybit", "binance"], [0], "exactly one exchange"),
         ({}, ["combined"], [0], "combined multi-exchange"),
         ({}, ["bybit"], [0, 1], "exactly one prepared coin"),
@@ -485,6 +486,106 @@ def test_gpu_suite_inputs_reject_unsupported_scenario_scope(
             return copy.deepcopy(proxy_config)
 
     with pytest.raises(ValueError, match=message):
+        _gpu_suite_scenario_inputs(config, Suite())
+
+
+def test_gpu_suite_scenario_overrides_shadow_candidate_parameters_last():
+    config = _long_only_ema_config()
+    scenario = copy.deepcopy(config)
+    scenario["bot"]["long"]["strategy"]["ema_anchor"]["base_qty_pct"] = 0.025
+    scenario["bot"]["long"]["risk"]["total_wallet_exposure_limit"] = 0.75
+
+    fixed_bounds, fixed_parameters = _gpu_suite_scenario_override_context(
+        config,
+        scenario,
+        {
+            "bot.long.strategy.ema_anchor.base_qty_pct": 0.025,
+            "bot.long.total_wallet_exposure_limit": 0.75,
+        },
+        {
+            "long_base_qty_pct",
+            "long_total_wallet_exposure_limit",
+            "long_n_positions",
+        },
+        {
+            "long_base_qty_pct": "long_base_qty_pct",
+            "long_total_wallet_exposure_limit": "long_total_wallet_exposure_limit",
+        },
+    )
+
+    assert fixed_bounds == {
+        "long_base_qty_pct": 0.025,
+        "long_total_wallet_exposure_limit": 0.75,
+    }
+    assert fixed_parameters == {
+        "long_base_qty_pct": 0.025,
+        "long_total_wallet_exposure_limit": 0.75,
+    }
+
+
+def test_gpu_suite_inputs_accept_and_preserve_bot_override_scope():
+    config = _long_only_ema_config()
+    config["backtest"]["suite_enabled"] = True
+    overrides = {"bot.long.strategy.ema_anchor.base_qty_pct": 0.025}
+    ctx = SimpleNamespace(
+        label="fixed_qty",
+        overrides=overrides,
+        exchanges=["bybit"],
+        msss={"bybit": {"BTC": {}, "__meta__": {}}},
+        timestamps={"bybit": np.arange(10, dtype=np.int64)},
+    )
+
+    class Suite:
+        contexts = [ctx]
+
+        @staticmethod
+        def get_prepared_context_data(_ctx, _exchange):
+            return np.zeros((10, 1, 4)), np.ones(10), [0]
+
+        @staticmethod
+        def build_scenario_candidate_config(proxy_config, _ctx):
+            scenario = copy.deepcopy(proxy_config)
+            scenario["bot"]["long"]["strategy"]["ema_anchor"]["base_qty_pct"] = 0.025
+            return scenario
+
+    prepared = _gpu_suite_scenario_inputs(config, Suite())
+
+    assert prepared[0]["overrides"] == overrides
+    assert (
+        prepared[0]["config"]["bot"]["long"]["strategy"]["ema_anchor"][
+            "base_qty_pct"
+        ]
+        == 0.025
+    )
+
+
+def test_gpu_suite_inputs_revalidate_effective_bot_override_scope():
+    config = _long_only_ema_config()
+    config["backtest"]["suite_enabled"] = True
+    ctx = SimpleNamespace(
+        label="unsupported_risk",
+        overrides={"bot.long.risk.total_exposure_enforcer_enabled": True},
+        exchanges=["bybit"],
+        msss={"bybit": {"BTC": {}, "__meta__": {}}},
+        timestamps={"bybit": np.arange(10, dtype=np.int64)},
+    )
+
+    class Suite:
+        contexts = [ctx]
+
+        @staticmethod
+        def get_prepared_context_data(_ctx, _exchange):
+            return np.zeros((10, 1, 4)), np.ones(10), [0]
+
+        @staticmethod
+        def build_scenario_candidate_config(proxy_config, _ctx):
+            scenario = copy.deepcopy(proxy_config)
+            scenario["bot"]["long"]["risk"][
+                "total_exposure_enforcer_enabled"
+            ] = True
+            return scenario
+
+    with pytest.raises(ValueError, match="total_exposure_enforcer_enabled=false"):
         _gpu_suite_scenario_inputs(config, Suite())
 
 
@@ -571,8 +672,8 @@ def test_gpu_suite_proxy_rows_use_canonical_suite_scorer():
     rows = _evaluate_gpu_suite_proxies(
         Suite(),
         [
-            (contexts[0], Proxy([0.10, 0.20])),
-            (contexts[1], Proxy([0.01, 0.02])),
+            (contexts[0], Proxy([0.10, 0.20]), {}),
+            (contexts[1], Proxy([0.01, 0.02]), {}),
         ],
         [{"x": 1}, {"x": 2}],
     )
@@ -589,6 +690,47 @@ def test_gpu_suite_proxy_rows_use_canonical_suite_scorer():
             _GPU_SUITE_METRICS_KEY: {"values": [0.20, 0.02]},
         },
     ]
+
+
+def test_gpu_suite_proxy_applies_scenario_parameter_overrides_without_mutating_candidates():
+    seen = []
+
+    class Proxy:
+        def evaluate(self, candidates):
+            seen.append(copy.deepcopy(candidates))
+            return [
+                {"adg_strategy_eq": candidate["long_base_qty_pct"]}
+                for candidate in candidates
+            ]
+
+    class Suite:
+        @staticmethod
+        def score_scenario_results(results):
+            return {
+                "objectives": (0.0,),
+                "constraint_violation": 0.0,
+                "suite_metrics": {},
+            }
+
+    candidates = [{"long_base_qty_pct": 0.01}]
+    _evaluate_gpu_suite_proxies(
+        Suite(),
+        [
+            (
+                SimpleNamespace(label="fixed"),
+                Proxy(),
+                {"long_base_qty_pct": 0.025},
+            ),
+            (SimpleNamespace(label="candidate"), Proxy(), {}),
+        ],
+        candidates,
+    )
+
+    assert seen == [
+        [{"long_base_qty_pct": 0.025}],
+        [{"long_base_qty_pct": 0.01}],
+    ]
+    assert candidates == [{"long_base_qty_pct": 0.01}]
 
 
 def test_suite_limit_metric_value_respects_reducer_and_scenario():


### PR DESCRIPTION
## Summary

- support `bot.long` and `bot.short` scenario overrides in single-coin Apple MPS optimizer suites
- preserve exact suite last-write precedence by shadowing affected Metal candidate parameters per scenario
- revalidate each effective scenario against the existing GPU scope; non-bot overrides remain fail-closed
- document the supported contract and persistence/resume behavior

## Validation

- `pytest -q tests/optimization/test_gpu_backend.py tests/optimization/test_optimize_suite_contexts.py tests/optimization/test_optimize.py` (368 passed)
- full repository `pytest -q` (passed)
- `PYTHONPATH=src python src/tools/check_ai_docs.py` (0 errors; existing size warnings only)
- Apple M3/MPS EMA-anchor suite smoke: 4,096 proxy evaluations, 64 exact Rust validations, no drift or constraint halt
- Apple M3/MPS trailing-martingale suite smoke: 4,096 proxy evaluations, 64 exact Rust validations, no drift or constraint halt

## Scope

This remains purely additive. CPU optimizers and normal bot/backtest paths are unchanged. Multi-coin suites, non-bot scenario override paths, multi-exchange suites, and per-coin source assignments still fail closed.