### PR TITLE
feat(gpu): support multicoin optimizer suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ All notable user-facing changes will be documented in this file.
   Effective external suite definitions, scenario filters, overrides, and resolved date windows are
   persisted and checked on resume.
 
+- Extend experimental Apple MPS EMA-anchor suites to multi-coin scenarios on one shared exchange.
+  Scenarios may select different coin subsets and independently dispatch to the single-coin or
+  multicoin Metal kernel, while the canonical suite reducer and exact Rust validations remain
+  authoritative. Multicoin suites require every effective scenario to share one enabled side, and
+  each scenario revalidates `n_positions` against its own prepared coin count.
+
 - Apply `optimize.fixed_runtime_overrides` to experimental Apple MPS candidates in the same order
   as the exact CPU optimizer. Fixed values shadow corresponding Metal search genes, participate in
   durable candidate hashing, and remain subordinate to later `optimize.enable_overrides`; the

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -110,9 +110,12 @@ The supported slice is intentionally narrow:
   for single-coin runs; supported multi-coin bounds may vary `n_positions` between `1` and the
   prepared coin count
 - hedge mode and one-way mode; one-way flat-side arbitration uses the active strategy's Rust rule
-- suite mode for single-coin scenarios on one shared exchange; scenario date, coin, ignored-coin,
-  exchange selection, and fail-closed `bot.long`/`bot.short` config overrides are supported, while
-  non-bot override paths and per-coin source assignments remain unsupported
+- suite mode on one shared exchange; single-coin EMA-anchor and trailing-martingale scenarios keep
+  their existing directional support, while EMA-anchor suites may also use different multi-coin
+  subsets of up to 64 coins when every effective scenario shares exactly one enabled side;
+  scenario date, coin, ignored-coin, exchange selection, and fail-closed `bot.long`/`bot.short`
+  config overrides are supported, while non-bot override paths and per-coin source assignments
+  remain unsupported
 - HSL and auto-unstuck disabled
 - BTC collateral, coin overrides, realized-loss gating, and exposure enforcers disabled
 - `backtest.filter_by_min_effective_cost: false`
@@ -120,8 +123,8 @@ The supported slice is intentionally narrow:
 - no invalid candle tail after the selected coin's final valid candle
 
 Unsupported combinations fail before optimization begins. Multi-coin trailing-martingale or
-long+short runs, multi-coin or multi-exchange suites, non-bot suite scenario overrides, per-coin
-source assignments, HSL, and auto-unstuck are not silently approximated by this release.
+long+short runs and suites, multi-exchange suites, non-bot suite scenario overrides, per-coin source
+assignments, HSL, and auto-unstuck are not silently approximated by this release.
 
 For a supported suite, each Metal candidate is dispatched across every prepared scenario. The GPU
 path then calls the same canonical suite reducer and scenario-selection logic as the CPU optimizer
@@ -135,8 +138,11 @@ suite evaluator still applies them last, after candidate materialization, while 
 Metal proxy shadows the corresponding candidate parameters with the same effective values. Every
 overridden scenario is rechecked against the directional GPU scope, so an override cannot silently
 enable HSL, auto-unstuck, an exposure enforcer, an invalid position count, or another unsupported
-behavior. Non-bot override paths and scenario `coin_sources` remain rejected until their proxy
-semantics are modeled. The effective external suite definition and any `--scenarios` filter are
+behavior. In a multicoin suite, a scenario with fewer coins must keep the effective `n_positions`
+range within that subset, either through common bounds or an explicit scenario override. Metal
+uses the single-coin or multicoin kernel independently for each scenario, then feeds all results to
+the same suite reducer. Non-bot override paths and scenario `coin_sources` remain rejected until
+their proxy semantics are modeled. The effective external suite definition and any `--scenarios` filter are
 stored in the run contract and checkpoint identity, with dynamic scenario dates resolved to the
 prepared concrete dates, so resume fails closed if the definition or resolved window changes.
 

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -130,10 +130,10 @@ For a supported suite, each Metal candidate is dispatched across every prepared 
 path then calls the same canonical suite reducer and scenario-selection logic as the CPU optimizer
 for aggregate reducers, named-scenario objectives, and named-scenario or suite-reduced limits.
 Every exact validation still runs the unchanged Rust backtest for every scenario; only those exact
-suite metrics enter `all_results.bin` and the Pareto front. A scenario may select a different
-single coin or date window, but every scenario must resolve to exactly one coin on the same
-exchange. Scenario `overrides` require explicit candidate-shadowing behavior in the proxy. This
-slice models `bot.long` and `bot.short` overrides: the canonical exact
+suite metrics enter `all_results.bin` and the Pareto front. A scenario may select a different coin
+subset or date window, but every scenario must use the same exchange. Scenario `overrides` require
+explicit candidate-shadowing behavior in the proxy. This slice models `bot.long` and `bot.short`
+overrides: the canonical exact
 suite evaluator still applies them last, after candidate materialization, while each scenario's
 Metal proxy shadows the corresponding candidate parameters with the same effective values. Every
 overridden scenario is rechecked against the directional GPU scope, so an override cannot silently
@@ -144,7 +144,8 @@ uses the single-coin or multicoin kernel independently for each scenario, then f
 the same suite reducer. Non-bot override paths and scenario `coin_sources` remain rejected until
 their proxy semantics are modeled. The effective external suite definition and any `--scenarios` filter are
 stored in the run contract and checkpoint identity, with dynamic scenario dates resolved to the
-prepared concrete dates, so resume fails closed if the definition or resolved window changes.
+prepared concrete dates. The checkpoint signature also records each scenario's ordered effective
+coins, side topology, and prepared candle window, so resume fails closed if preparation changes.
 
 Ordinary `-t/--start` seeding and fine-tuning with `-ft/--fine-tune-params` use the same optimizer
 shape as the CPU backends. When `-t` and `-ft` are combined, the GPU population includes the

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -812,7 +812,7 @@ def _validate_scope(
 
 
 def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict]:
-    """Materialize fail-closed single-coin suite inputs for MPS screening."""
+    """Materialize fail-closed suite inputs for MPS screening."""
 
     from config.param_paths import require_existing_config_path
 
@@ -871,11 +871,6 @@ def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict
             values = np.take(values, list(coin_indices), axis=1)
         values = np.ascontiguousarray(values)
         coin_count = int(values.shape[1])
-        if coin_count != 1:
-            raise ValueError(
-                "GPU suite foundation currently requires exactly one prepared coin "
-                f"per scenario; {ctx.label!r} prepared {coin_count}"
-            )
         scenario_config = build_config(proxy_config, ctx)
         _validate_scope_config(
             scenario_config,
@@ -889,6 +884,7 @@ def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict
                 "config": scenario_config,
                 "overrides": deepcopy(overrides),
                 "exchange": exchange,
+                "coin_count": coin_count,
                 "hlcvs": values,
                 "mss": ctx.msss[exchange],
                 "btc": btc,
@@ -896,6 +892,53 @@ def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict
             }
         )
     return prepared
+
+
+def _gpu_suite_search_context(suite_inputs: list[dict]) -> tuple[int, int, str | None]:
+    """Return the common candidate-space coin range and multicoin side."""
+
+    if not suite_inputs:
+        raise ValueError("GPU suite mode requires at least one prepared scenario")
+    coin_counts = [int(item["coin_count"]) for item in suite_inputs]
+    min_coin_count = min(coin_counts)
+    max_coin_count = max(coin_counts)
+    if max_coin_count == 1:
+        return min_coin_count, max_coin_count, None
+
+    strategy_kinds = {
+        str(item["config"].get("live", {}).get("strategy_kind", ""))
+        .strip()
+        .lower()
+        for item in suite_inputs
+    }
+    if strategy_kinds != {"ema_anchor"}:
+        raise ValueError(
+            "GPU multicoin suites currently require strategy_kind=ema_anchor in "
+            f"every scenario; got {sorted(strategy_kinds)}"
+        )
+    sides_by_label = {}
+    for item in suite_inputs:
+        sides = tuple(
+            side
+            for side in ("long", "short")
+            if gpu_side_enabled(item["config"], side)
+        )
+        sides_by_label[item["ctx"].label] = sides
+        if len(sides) != 1:
+            raise ValueError(
+                "GPU multicoin suites require exactly one enabled side in every "
+                f"scenario; {item['ctx'].label!r} has {list(sides)}"
+            )
+    common_sides = {sides[0] for sides in sides_by_label.values()}
+    if len(common_sides) != 1:
+        details = ", ".join(
+            f"{label}={sides[0]}" for label, sides in sides_by_label.items()
+        )
+        raise ValueError(
+            "GPU multicoin suites require the same enabled side in every scenario; "
+            f"got {details}"
+        )
+    return min_coin_count, max_coin_count, common_sides.pop()
 
 
 def _gpu_suite_scenario_override_context(
@@ -1982,16 +2025,32 @@ def run_backend(
     )
     if suite_enabled:
         exchange = suite_inputs[0]["exchange"]
-        coin_count = 1
+        min_coin_count, max_coin_count, suite_multicoin_side = (
+            _gpu_suite_search_context(suite_inputs)
+        )
+        logging.info(
+            "GPU suite prepared %d scenarios | coins=%d..%d | multicoin_side=%s",
+            len(suite_inputs),
+            min_coin_count,
+            max_coin_count,
+            suite_multicoin_side or "n/a",
+        )
     else:
         exchange = _validate_scope(proxy_config, evaluator)
-        coin_count = int(evaluator.shared_hlcvs_np[exchange].shape[1])
-    if strategy_kind == "ema_anchor" and coin_count > 1:
-        multicoin_sides = [
-            side
-            for side in ("long", "short")
-            if gpu_side_enabled(proxy_config, side)
-        ]
+        min_coin_count = max_coin_count = int(
+            evaluator.shared_hlcvs_np[exchange].shape[1]
+        )
+        suite_multicoin_side = None
+    if strategy_kind == "ema_anchor" and max_coin_count > 1:
+        multicoin_sides = (
+            [suite_multicoin_side]
+            if suite_multicoin_side is not None
+            else [
+                side
+                for side in ("long", "short")
+                if gpu_side_enabled(proxy_config, side)
+            ]
+        )
         if len(multicoin_sides) != 1:
             raise ValueError(
                 "GPU multicoin foundation requires exactly one enabled side"
@@ -2038,9 +2097,14 @@ def run_backend(
     def side_approved(side: str) -> bool:
         return bool(approved.get(side, [])) if isinstance(approved, dict) else True
 
-    config_enabled_sides = {
+    base_config_enabled_sides = {
         side for side in ("long", "short") if gpu_side_enabled(proxy_config, side)
     }
+    config_enabled_sides = (
+        {suite_multicoin_side}
+        if suite_multicoin_side is not None
+        else base_config_enabled_sides
+    )
     base_by_key = {
         bound_key: float(base_vector[index])
         for index, (bound_key, _path) in enumerate(key_paths)
@@ -2073,7 +2137,13 @@ def run_backend(
         enabled_sides = {
             side for side in ("long", "short") if vector_side_enabled(side)
         }
-        _validate_seed_side_match(config_enabled_sides, enabled_sides)
+        if suite_multicoin_side is None:
+            _validate_seed_side_match(config_enabled_sides, enabled_sides)
+        else:
+            # CPU suite setup requires symmetric approved coin lists. Effective
+            # scenario overrides establish the common single-side topology and
+            # are validated below after shadowing candidate bounds.
+            enabled_sides = {suite_multicoin_side}
     if not enabled_sides:
         raise ValueError(
             "GPU bounds would disable both sides for exact validation; "
@@ -2128,13 +2198,14 @@ def run_backend(
         _mirror_short_mapping(bound_by_key)
     _validate_pinned_scope_bounds(bound_by_key, base_by_key, enabled_sides)
 
-    _validate_directional_search_space(
-        bound_by_key,
-        base_by_key,
-        approved,
-        enabled_sides,
-        coin_count=coin_count,
-    )
+    if suite_multicoin_side is None:
+        _validate_directional_search_space(
+            bound_by_key,
+            base_by_key,
+            approved,
+            enabled_sides,
+            coin_count=max_coin_count,
+        )
 
     for item in suite_inputs:
         fixed_scenario_bounds, parameter_overrides = (
@@ -2166,7 +2237,7 @@ def run_backend(
             scenario_base_by_key,
             item["config"].get("live", {}).get("approved_coins", {}),
             scenario_enabled_sides,
-            coin_count=1,
+            coin_count=item["coin_count"],
         )
         item["parameter_overrides"] = parameter_overrides
 
@@ -2176,7 +2247,7 @@ def run_backend(
         side = bound_key.split("_", 1)[0]
         if side in {"long", "short"} and side not in enabled_sides:
             continue
-        if coin_count == 1 and any(
+        if max_coin_count == 1 and any(
             bound_key.startswith(f"{side}_forager_") for side in enabled_sides
         ):
             # Forager ranking cannot affect a one-coin backtest.
@@ -2191,7 +2262,7 @@ def run_backend(
             # either the exact Rust backtest or the proxy.
             continue
         if (
-            coin_count == 1
+            max_coin_count == 1
             and bound_key in {f"{side}_n_positions" for side in enabled_sides}
         ):
             continue
@@ -2219,7 +2290,7 @@ def run_backend(
         scenario_proxies = [
             (
                 item["ctx"],
-                MpsSingleCoinProxy(
+                (MpsMulticoinEmaProxy if item["coin_count"] > 1 else MpsSingleCoinProxy)(
                     config=item["config"],
                     hlcvs=item["hlcvs"],
                     mss=item["mss"],
@@ -2242,7 +2313,7 @@ def run_backend(
             )
 
     else:
-        proxy_cls = MpsMulticoinEmaProxy if coin_count > 1 else MpsSingleCoinProxy
+        proxy_cls = MpsMulticoinEmaProxy if max_coin_count > 1 else MpsSingleCoinProxy
         proxy = proxy_cls(
             config=proxy_config,
             hlcvs=evaluator.shared_hlcvs_np[exchange],

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -878,6 +878,14 @@ def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict
             coin_count=coin_count,
             allow_suite=True,
         )
+        effective_coins = [
+            str(coin) for coin in ctx.msss[exchange] if coin != "__meta__"
+        ]
+        if len(effective_coins) != coin_count:
+            raise ValueError(
+                f"GPU suite scenario {ctx.label!r} prepared coin identity "
+                f"mismatch: hlcvs={coin_count}, market_settings={effective_coins}"
+            )
         prepared.append(
             {
                 "ctx": ctx,
@@ -885,6 +893,7 @@ def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict
                 "overrides": deepcopy(overrides),
                 "exchange": exchange,
                 "coin_count": coin_count,
+                "coins": effective_coins,
                 "hlcvs": values,
                 "mss": ctx.msss[exchange],
                 "btc": btc,
@@ -1446,9 +1455,9 @@ def _update_novelty_stall(
     return current
 
 
-def _gpu_suite_checkpoint_contract(config: dict) -> dict:
+def _gpu_suite_checkpoint_contract(config: dict, suite_inputs=None) -> dict:
     backtest = config.get("backtest", {})
-    return {
+    contract = {
         key: deepcopy(backtest.get(key))
         for key in (
             "suite_enabled",
@@ -1458,6 +1467,42 @@ def _gpu_suite_checkpoint_contract(config: dict) -> dict:
             "volume_normalization",
         )
     }
+    if suite_inputs is not None:
+        prepared_scenarios = []
+        for item in suite_inputs:
+            timestamps = np.asarray(item["timestamps"]).reshape(-1)
+            if len(timestamps) != len(item["hlcvs"]):
+                raise ValueError(
+                    f"GPU suite scenario {item['ctx'].label!r} timestamp identity "
+                    f"mismatch: timestamps={len(timestamps)}, hlcvs={len(item['hlcvs'])}"
+                )
+            prepared_scenarios.append(
+                {
+                    "label": item["ctx"].label,
+                    "exchange": item["exchange"],
+                    "coins": list(item["coins"]),
+                    "coin_count": int(item["coin_count"]),
+                    "strategy_kind": str(
+                        item["config"].get("live", {}).get("strategy_kind", "")
+                    )
+                    .strip()
+                    .lower(),
+                    "enabled_sides": [
+                        side
+                        for side in ("long", "short")
+                        if gpu_side_enabled(item["config"], side)
+                    ],
+                    "candle_count": int(len(item["hlcvs"])),
+                    "first_timestamp": (
+                        int(timestamps[0]) if len(timestamps) else None
+                    ),
+                    "last_timestamp": (
+                        int(timestamps[-1]) if len(timestamps) else None
+                    ),
+                }
+            )
+        contract["prepared_scenarios"] = prepared_scenarios
+    return contract
 
 
 def _checkpoint_signature(
@@ -2430,7 +2475,9 @@ def run_backend(
         config["optimize"]["scoring"],
         anchor_plan=get_anchor_plan(config),
         suite_contract=(
-            _gpu_suite_checkpoint_contract(config) if suite_enabled else None
+            _gpu_suite_checkpoint_contract(config, suite_inputs)
+            if suite_enabled
+            else None
         ),
     )
     budget = int(config["optimize"]["iters"])

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -30,6 +30,7 @@ from optimization.backends.gpu_backend import (
     _gpu_fixed_bound_context,
     _gpu_candidate_source_sides,
     _gpu_suite_enabled,
+    _gpu_suite_checkpoint_contract,
     _gpu_suite_scenario_override_context,
     _gpu_suite_scenario_inputs,
     _gpu_suite_search_context,
@@ -2502,6 +2503,58 @@ def test_gpu_checkpoint_signature_tracks_effective_suite_contract():
         _checkpoint_signature(active, scoring, suite_contract=changed_date)
         != original
     )
+
+
+def test_gpu_suite_checkpoint_contract_tracks_prepared_scenario_identity():
+    config = _directional_ema_config(long_enabled=True, short_enabled=False)
+    item = {
+        "ctx": SimpleNamespace(label="stress"),
+        "exchange": "bybit",
+        "coins": ["BTC", "ETH"],
+        "coin_count": 2,
+        "config": config,
+        "hlcvs": np.zeros((3, 2, 4)),
+        "timestamps": np.array([1000, 2000, 3000]),
+    }
+    original = _gpu_suite_checkpoint_contract(config, [item])
+
+    assert original["prepared_scenarios"] == [
+        {
+            "label": "stress",
+            "exchange": "bybit",
+            "coins": ["BTC", "ETH"],
+            "coin_count": 2,
+            "strategy_kind": "ema_anchor",
+            "enabled_sides": ["long"],
+            "candle_count": 3,
+            "first_timestamp": 1000,
+            "last_timestamp": 3000,
+        }
+    ]
+
+    changed_coins = copy.deepcopy(item)
+    changed_coins["coins"] = ["BTC", "SOL"]
+    changed_window = copy.deepcopy(item)
+    changed_window["timestamps"] = np.array([1000, 2000, 4000])
+
+    assert _gpu_suite_checkpoint_contract(config, [changed_coins]) != original
+    assert _gpu_suite_checkpoint_contract(config, [changed_window]) != original
+
+
+def test_gpu_suite_checkpoint_contract_rejects_timestamp_shape_mismatch():
+    config = _directional_ema_config(long_enabled=True, short_enabled=False)
+    item = {
+        "ctx": SimpleNamespace(label="stress"),
+        "exchange": "bybit",
+        "coins": ["BTC", "ETH"],
+        "coin_count": 2,
+        "config": config,
+        "hlcvs": np.zeros((3, 2, 4)),
+        "timestamps": np.array([1000, 2000]),
+    }
+
+    with pytest.raises(ValueError, match="timestamp identity mismatch"):
+        _gpu_suite_checkpoint_contract(config, [item])
 
 
 def test_gpu_rejects_pinned_unsupported_risk_behavior():

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -32,6 +32,7 @@ from optimization.backends.gpu_backend import (
     _gpu_suite_enabled,
     _gpu_suite_scenario_override_context,
     _gpu_suite_scenario_inputs,
+    _gpu_suite_search_context,
     _materialize_gpu_override_template,
     _DriftMonitor,
     _ObjectiveScale,
@@ -450,6 +451,40 @@ def test_gpu_suite_inputs_materialize_one_selected_coin():
     assert len(prepared) == 1
     assert prepared[0]["hlcvs"].shape == (10, 1, 4)
     assert np.array_equal(prepared[0]["hlcvs"][:, 0], master[:, 1])
+    assert prepared[0]["coin_count"] == 1
+
+
+def test_gpu_suite_inputs_materialize_multicoin_subset():
+    config = _long_only_ema_config()
+    config["backtest"]["suite_enabled"] = True
+    config["live"]["forager_score_hysteresis_pct"] = 0.0
+    config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "SOL"]
+    config["bot"]["long"]["risk"]["n_positions"] = 2
+    master = np.arange(10 * 4 * 4, dtype=np.float64).reshape(10, 4, 4)
+    ctx = SimpleNamespace(
+        label="three_coins",
+        overrides={},
+        exchanges=["bybit"],
+        msss={"bybit": {coin: {} for coin in ("BTC", "ETH", "SOL")}},
+        timestamps={"bybit": np.arange(10, dtype=np.int64)},
+    )
+
+    class Suite:
+        contexts = [ctx]
+
+        @staticmethod
+        def get_prepared_context_data(_ctx, _exchange):
+            return master, np.ones(10), [0, 2, 3]
+
+        @staticmethod
+        def build_scenario_candidate_config(proxy_config, _ctx):
+            return copy.deepcopy(proxy_config)
+
+    prepared = _gpu_suite_scenario_inputs(config, Suite())
+
+    assert prepared[0]["coin_count"] == 3
+    assert prepared[0]["hlcvs"].shape == (10, 3, 4)
+    assert np.array_equal(prepared[0]["hlcvs"][:, 1], master[:, 2])
 
 
 @pytest.mark.parametrize(
@@ -458,7 +493,6 @@ def test_gpu_suite_inputs_materialize_one_selected_coin():
         ({"backtest.starting_balance": 1_000}, ["bybit"], [0], "outside the supported"),
         ({}, ["bybit", "binance"], [0], "exactly one exchange"),
         ({}, ["combined"], [0], "combined multi-exchange"),
-        ({}, ["bybit"], [0, 1], "exactly one prepared coin"),
     ],
 )
 def test_gpu_suite_inputs_reject_unsupported_scenario_scope(
@@ -487,6 +521,63 @@ def test_gpu_suite_inputs_reject_unsupported_scenario_scope(
 
     with pytest.raises(ValueError, match=message):
         _gpu_suite_scenario_inputs(config, Suite())
+
+
+def _suite_search_input(label, config, coin_count):
+    return {
+        "ctx": SimpleNamespace(label=label),
+        "config": config,
+        "coin_count": coin_count,
+    }
+
+
+def test_gpu_suite_search_context_reports_coin_count_range():
+    config = _directional_ema_config(long_enabled=True, short_enabled=False)
+
+    assert _gpu_suite_search_context(
+        [
+            _suite_search_input("broad", config, 4),
+            _suite_search_input("narrow", config, 2),
+        ]
+    ) == (2, 4, "long")
+
+
+def test_gpu_suite_search_context_allows_legacy_single_coin_topologies():
+    config = _directional_tm_config(long_enabled=True, short_enabled=True)
+
+    assert _gpu_suite_search_context(
+        [
+            _suite_search_input("base", config, 1),
+            _suite_search_input("stress", config, 1),
+        ]
+    ) == (1, 1, None)
+
+
+def test_gpu_suite_search_context_rejects_multicoin_trailing_martingale():
+    config = _directional_tm_config(long_enabled=True, short_enabled=False)
+
+    with pytest.raises(ValueError, match="strategy_kind=ema_anchor"):
+        _gpu_suite_search_context([_suite_search_input("multi", config, 2)])
+
+
+def test_gpu_suite_search_context_rejects_multicoin_dual_side_scenario():
+    config = _directional_ema_config(long_enabled=True, short_enabled=True)
+
+    with pytest.raises(ValueError, match="exactly one enabled side"):
+        _gpu_suite_search_context([_suite_search_input("multi", config, 2)])
+
+
+def test_gpu_suite_search_context_rejects_different_sides():
+    long_config = _directional_ema_config(long_enabled=True, short_enabled=False)
+    short_config = _directional_ema_config(long_enabled=False, short_enabled=True)
+
+    with pytest.raises(ValueError, match="same enabled side"):
+        _gpu_suite_search_context(
+            [
+                _suite_search_input("long", long_config, 3),
+                _suite_search_input("short", short_config, 2),
+            ]
+        )
 
 
 def test_gpu_suite_scenario_overrides_shadow_candidate_parameters_last():


### PR DESCRIPTION
## Summary

- extend experimental Apple MPS EMA-anchor suites to multi-coin scenarios on one shared exchange
- allow different scenario coin subsets, dispatching each scenario to the single-coin or multicoin Metal proxy as appropriate
- require one common enabled side across effective multicoin scenarios and revalidate each scenario's search space against its own coin count
- retain canonical suite reduction, exact Rust authority, drift checks, persistence, and fail-closed handling for unsupported topologies

## Validation

- full Python test suite: passed
- focused GPU and optimizer-suite tests: passed
- Python compile check: passed
- AI docs checker: 0 errors, 2 pre-existing size warnings
- real Apple MPS long-only EMA suite, 3-coin and 2-coin scenarios: 4,096 proxy evaluations and 64 exact validations in 25.6s, no halt or constraint-classification mismatch
- real Apple MPS long-only EMA suite, mixed 3-coin and 1-coin scenarios: 2,048 proxy evaluations and 64 exact validations in 18.6s, no halt
- real Apple MPS short-only EMA suite, mixed 3-coin and 1-coin scenarios: 2,048 proxy evaluations and 64 exact validations in 18.3s, no halt

## Scope

This remains additive and experimental. Multi-coin trailing-martingale, dual-side multi-coin, multi-exchange suites, per-coin source assignments, HSL, and auto-unstuck continue to fail closed.
