### PR TITLE
feat(gpu): support multicoin EMA coin overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Add static per-coin overrides to experimental Apple MPS multi-coin EMA-anchor optimization.
+  The enabled side may override EMA-anchor parameters, entry cooldown, and an explicit per-coin
+  wallet-exposure limit. Metal applies those values after every candidate gene, matching exact
+  Rust precedence; unsupported override leaves still fail closed, and checkpoint identity now
+  includes the prepared effective override table.
+
 - Add experimental Apple MPS optimization suites for the existing single-coin EMA-anchor and
   trailing-martingale scopes. Metal screens every candidate against each prepared scenario, while
   the canonical suite reducer, scenario-aware objectives, and limits select proxy candidates and

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -116,8 +116,11 @@ The supported slice is intentionally narrow:
   scenario date, coin, ignored-coin, exchange selection, and fail-closed `bot.long`/`bot.short`
   config overrides are supported, while non-bot override paths and per-coin source assignments
   remain unsupported
+- static `coin_overrides` for the enabled side of multi-coin EMA-anchor runs: EMA-anchor strategy
+  parameters, `risk.entry_cooldown_minutes`, and explicit `wallet_exposure_limit` are supported;
+  other sides and override leaves fail closed
 - HSL and auto-unstuck disabled
-- BTC collateral, coin overrides, realized-loss gating, and exposure enforcers disabled
+- BTC collateral, realized-loss gating, and exposure enforcers disabled
 - `backtest.filter_by_min_effective_cost: false`
 - `live.market_orders_allowed: false`
 - no invalid candle tail after the selected coin's final valid candle

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -57,6 +57,8 @@ mod tests {
         assert!(source.contains("const bool short_side"));
         assert!(source.contains("constant int MAX_COINS = 64"));
         assert!(source.contains("constant int PARAM_COLS = 19"));
+        assert!(source.contains("constant int OVERRIDE_COLS = 12"));
+        assert!(source.contains("coin_override_or"));
         assert!(source.contains("constant int COIN_COLS = 11"));
         assert!(source.contains("constant int DAILY_COLS = 5"));
         assert!(source.contains("constant int SCALAR_COLS = 18"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -4,6 +4,7 @@ using namespace metal;
 constant int MAX_COINS = 64;
 constant int PARAM_COLS = 19;
 constant int COIN_COLS = 11;
+constant int OVERRIDE_COLS = 12;
 constant int DAILY_COLS = 5;
 constant int SCALAR_COLS = 18;
 constant int GAP_BINS = 128;
@@ -38,11 +39,19 @@ inline bool finite_positive(float value) {
     return isfinite(value) && value > 0.0f;
 }
 
+inline float coin_override_or(
+    constant float* coin_overrides, int coin, int column, float fallback
+) {
+    float value = coin_overrides[coin * OVERRIDE_COLS + column];
+    return isfinite(value) ? value : fallback;
+}
+
 inline void passivbot_ema_anchor_multicoin_impl(
     constant float* bars,
     constant int* fill_ticks,
     constant int* touch_ticks,
     constant float* coin_settings,
+    constant float* coin_overrides,
     constant float* params,
     constant float* run_settings,
     constant int* sizes,
@@ -136,6 +145,11 @@ inline void passivbot_ema_anchor_multicoin_impl(
     bool selected[MAX_COINS];
     bool survivor[MAX_COINS];
     bool entry_candidate[MAX_COINS];
+    float alpha0_coin[MAX_COINS];
+    float alpha1_coin[MAX_COINS];
+    float alpha2_coin[MAX_COINS];
+    float alpha_1h_coin[MAX_COINS];
+    float alpha_1m_coin[MAX_COINS];
 
     for (int c = 0; c < MAX_COINS; ++c) {
         float seed_close = c < C ? coin_settings[c * COIN_COLS + 9] : 0.0f;
@@ -167,6 +181,30 @@ inline void passivbot_ema_anchor_multicoin_impl(
         selected[c] = false;
         survivor[c] = false;
         entry_candidate[c] = false;
+        if (c < C) {
+            float coin_span_a = coin_override_or(coin_overrides, c, 1, span_a);
+            float coin_span_b = coin_override_or(coin_overrides, c, 2, span_b);
+            float coin_span_c = sqrt(fmax(coin_span_a * coin_span_b, 1.0f));
+            float coin_span_lo = fmin(coin_span_a, fmin(coin_span_b, coin_span_c));
+            float coin_span_hi = fmax(coin_span_a, fmax(coin_span_b, coin_span_c));
+            float coin_span_mid = coin_span_a + coin_span_b + coin_span_c
+                - coin_span_lo - coin_span_hi;
+            alpha0_coin[c] = clamp(2.0f / (coin_span_lo + 1.0f), 0.0f, 1.0f);
+            alpha1_coin[c] = clamp(2.0f / (coin_span_mid + 1.0f), 0.0f, 1.0f);
+            alpha2_coin[c] = clamp(2.0f / (coin_span_hi + 1.0f), 0.0f, 1.0f);
+            float coin_span_1h = coin_override_or(coin_overrides, c, 8, span_1h);
+            float coin_span_1m = coin_override_or(coin_overrides, c, 9, span_1m);
+            alpha_1h_coin[c] = coin_span_1h > 0.0f
+                ? 2.0f / (fmax(coin_span_1h, 1.0f) + 1.0f) : 0.0f;
+            alpha_1m_coin[c] = coin_span_1m > 0.0f
+                ? clamp(2.0f / (coin_span_1m + 1.0f), 0.0f, 1.0f) : 0.0f;
+        } else {
+            alpha0_coin[c] = alpha0;
+            alpha1_coin[c] = alpha1;
+            alpha2_coin[c] = alpha2;
+            alpha_1h_coin[c] = alpha_1h;
+            alpha_1m_coin[c] = alpha_1m;
+        }
     }
     for (int j = 0; j < GAP_BINS; ++j) {
         gap_hist[int(b) * GAP_BINS + j] = 0;
@@ -312,10 +350,10 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 && finite_positive(high) && finite_positive(low) && finite_positive(close);
             if (hour_boundary) {
                 if (hour_high[c] > 0.0f && isfinite(hour_low[c]) && hour_low[c] > 0.0f
-                    && alpha_1h > 0.0f) {
+                    && alpha_1h_coin[c] > 0.0f) {
                     float hour_range = log(hour_high[c] / hour_low[c]);
                     volatility_1h[c] = fma(
-                        alpha_1h, hour_range - volatility_1h[c], volatility_1h[c]
+                        alpha_1h_coin[c], hour_range - volatility_1h[c], volatility_1h[c]
                     );
                 }
                 hour_high[c] = -INFINITY;
@@ -325,12 +363,12 @@ inline void passivbot_ema_anchor_multicoin_impl(
             hour_high[c] = fmax(hour_high[c], high);
             hour_low[c] = fmin(hour_low[c], low);
             float log_range = log(high / low);
-            ema0[c] = fma(alpha0, close - ema0[c], ema0[c]);
-            ema1[c] = fma(alpha1, close - ema1[c], ema1[c]);
-            ema2[c] = fma(alpha2, close - ema2[c], ema2[c]);
-            if (alpha_1m > 0.0f) {
+            ema0[c] = fma(alpha0_coin[c], close - ema0[c], ema0[c]);
+            ema1[c] = fma(alpha1_coin[c], close - ema1[c], ema1[c]);
+            ema2[c] = fma(alpha2_coin[c], close - ema2[c], ema2[c]);
+            if (alpha_1m_coin[c] > 0.0f) {
                 volatility_1m[c] = fma(
-                    alpha_1m, log_range - volatility_1m[c], volatility_1m[c]
+                    alpha_1m_coin[c], log_range - volatility_1m[c], volatility_1m[c]
                 );
             }
             if (alpha_forager_volatility > 0.0f) {
@@ -356,9 +394,10 @@ inline void passivbot_ema_anchor_multicoin_impl(
             int coin_offset = c * COIN_COLS;
             int bar_offset = (k * C + c) * 4;
             float close = bars[bar_offset + 2];
+            float coin_wel = coin_override_or(coin_overrides, c, 11, -1.0f);
             if (k >= int(coin_settings[coin_offset + 8])
                 && k <= int(coin_settings[coin_offset + 7])
-                && finite_positive(close)) {
+                && finite_positive(close) && coin_wel != 0.0f) {
                 tradable_count += 1;
             }
         }
@@ -386,10 +425,11 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 for (int c = 0; c < C; ++c) {
                     int coin_offset = c * COIN_COLS;
                     int bar_offset = (k * C + c) * 4;
+                    float coin_wel = coin_override_or(coin_overrides, c, 11, -1.0f);
                     bool enabled = !selected[c]
                         && k >= int(coin_settings[coin_offset + 8])
                         && k <= int(coin_settings[coin_offset + 7])
-                        && finite_positive(bars[bar_offset + 2]);
+                        && finite_positive(bars[bar_offset + 2]) && coin_wel != 0.0f;
                     survivor[c] = enabled;
                     if (enabled) enabled_count += 1;
                 }
@@ -422,9 +462,12 @@ inline void passivbot_ema_anchor_multicoin_impl(
                     float close = bars[bar_offset + 2];
                     float lower = fmin(ema0[c], fmin(ema1[c], ema2[c]));
                     float upper = fmax(ema0[c], fmax(ema1[c], ema2[c]));
+                    float coin_offset_pct = coin_override_or(
+                        coin_overrides, c, 4, offset
+                    );
                     float threshold = short_side
-                        ? upper * (1.0f + offset)
-                        : lower * (1.0f - offset);
+                        ? upper * (1.0f + coin_offset_pct)
+                        : lower * (1.0f - coin_offset_pct);
                     float readiness = threshold > 0.0f
                         ? (short_side ? 1.0f - close / threshold : close / threshold - 1.0f)
                         : INFINITY;
@@ -442,9 +485,12 @@ inline void passivbot_ema_anchor_multicoin_impl(
                     float close = bars[bar_offset + 2];
                     float lower = fmin(ema0[c], fmin(ema1[c], ema2[c]));
                     float upper = fmax(ema0[c], fmax(ema1[c], ema2[c]));
+                    float coin_offset_pct = coin_override_or(
+                        coin_overrides, c, 4, offset
+                    );
                     float threshold = short_side
-                        ? upper * (1.0f + offset)
-                        : lower * (1.0f - offset);
+                        ? upper * (1.0f + coin_offset_pct)
+                        : lower * (1.0f - coin_offset_pct);
                     float readiness = threshold > 0.0f
                         ? (short_side ? 1.0f - close / threshold : close / threshold - 1.0f)
                         : INFINITY;
@@ -492,9 +538,14 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 int bar_offset = (k * C + c) * 4;
                 int tick_offset = (k * C + c) * 2;
                 float price_now = bars[bar_offset + 2];
+                float fixed_coin_wel = coin_override_or(
+                    coin_overrides, c, 11, -1.0f
+                );
+                float coin_wel = fixed_coin_wel >= 0.0f
+                    ? fixed_coin_wel : effective_wel;
                 bool tradable = k >= int(coin_settings[coin_offset + 8])
                     && k <= int(coin_settings[coin_offset + 7])
-                    && finite_positive(price_now);
+                    && finite_positive(price_now) && coin_wel > 0.0f;
                 if (!tradable) continue;
                 float qty_step = coin_settings[coin_offset + 0];
                 float price_step = coin_settings[coin_offset + 1];
@@ -503,26 +554,38 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 float c_mult = coin_settings[coin_offset + 4];
                 float lower = fmin(ema0[c], fmin(ema1[c], ema2[c]));
                 float upper = fmax(ema0[c], fmax(ema1[c], ema2[c]));
+                float coin_weight_1h = coin_override_or(
+                    coin_overrides, c, 6, weight_1h
+                );
+                float coin_weight_1m = coin_override_or(
+                    coin_overrides, c, 7, weight_1m
+                );
                 float multiplier = fmax(
-                    1.0f + volatility_1h[c] * weight_1h
-                        + volatility_1m[c] * weight_1m,
+                    1.0f + volatility_1h[c] * coin_weight_1h
+                        + volatility_1m[c] * coin_weight_1m,
                     1.0f
                 );
                 float wallet_ratio = psize[c] > 0.0f && balance > 0.0f
                     ? (psize[c] * price_now * c_mult / balance)
-                        / fmax(effective_wel, 1.0e-12f) : 0.0f;
+                        / fmax(coin_wel, 1.0e-12f) : 0.0f;
                 float signed_wallet_ratio = short_side ? -wallet_ratio : wallet_ratio;
-                float inventory_shift = signed_wallet_ratio * psize_weight;
+                float coin_psize_weight = coin_override_or(
+                    coin_overrides, c, 5, psize_weight
+                );
+                float coin_offset_pct = coin_override_or(
+                    coin_overrides, c, 4, offset
+                );
+                float inventory_shift = signed_wallet_ratio * coin_psize_weight;
                 int bid_tick = min(
                     int(floor(
-                        lower * (1.0f - offset * multiplier - inventory_shift)
+                        lower * (1.0f - coin_offset_pct * multiplier - inventory_shift)
                             / price_step + 1.0e-6f
                     )),
                     touch_ticks[tick_offset + 0]
                 );
                 int ask_tick = max(
                     int(ceil(
-                        upper * (1.0f + offset * multiplier - inventory_shift)
+                        upper * (1.0f + coin_offset_pct * multiplier - inventory_shift)
                             / price_step - 1.0e-6f
                     )),
                     touch_ticks[tick_offset + 1]
@@ -537,20 +600,27 @@ inline void passivbot_ema_anchor_multicoin_impl(
                     entry_price, qty_step, min_qty, min_cost, c_mult
                 );
                 minimum_entry[c] = minimum;
-                bool cooldown = cooldown_min > 0.0f && last_increase_k[c] > -1.0e19f
-                    && float(k) < last_increase_k[c] + cooldown_min;
+                float coin_cooldown_min = ceil(coin_override_or(
+                    coin_overrides, c, 10, cooldown_min
+                ));
+                bool cooldown = coin_cooldown_min > 0.0f && last_increase_k[c] > -1.0e19f
+                    && float(k) < last_increase_k[c] + coin_cooldown_min;
                 float cost_we = psize[c] > 0.0f && balance > 0.0f
                     ? psize[c] * pprice[c] * c_mult / balance : 0.0f;
-                float position_cap = effective_wel - 1.0e-7f;
+                float position_cap = coin_wel - 1.0e-7f;
+                float coin_base_qty_pct = coin_override_or(
+                    coin_overrides, c, 0, base_qty_pct
+                );
+                float coin_ddf = coin_override_or(coin_overrides, c, 3, ddf);
                 if (selected[c] && !cooldown && entry_price > 0.0f && balance > 0.0f
-                    && cost_we < position_cap && base_qty_pct > 0.0f) {
+                    && cost_we < position_cap && coin_base_qty_pct > 0.0f) {
                     float base_qty = fmax(minimum, round_step(
-                        balance * effective_wel * base_qty_pct
+                        balance * coin_wel * coin_base_qty_pct
                             / fmax(entry_price * c_mult, 1.0e-12f),
                         qty_step
                     ));
                     float quantity = round_step(
-                        base_qty * fmax(1.0f + fmax(wallet_ratio, 0.0f) * ddf, 1.0f),
+                        base_qty * fmax(1.0f + fmax(wallet_ratio, 0.0f) * coin_ddf, 1.0f),
                         qty_step
                     );
                     float headroom = (
@@ -573,7 +643,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
                         close_price, qty_step, min_qty, min_cost, c_mult
                     );
                     float clip = fmin(psize[c], fmax(minimum_close, round_step(
-                        balance * effective_wel * base_qty_pct
+                        balance * coin_wel * coin_base_qty_pct
                             / fmax(close_price * c_mult, 1.0e-12f),
                         qty_step
                     )));
@@ -737,6 +807,7 @@ kernel void passivbot_ema_anchor_multicoin(
     constant int* fill_ticks,
     constant int* touch_ticks,
     constant float* coin_settings,
+    constant float* coin_overrides,
     constant float* params,
     constant float* run_settings,
     constant int* sizes,
@@ -747,7 +818,7 @@ kernel void passivbot_ema_anchor_multicoin(
 ) {
     const bool short_side = run_settings[3] > 0.5f;
     passivbot_ema_anchor_multicoin_impl(
-        bars, fill_ticks, touch_ticks, coin_settings, params, run_settings,
+        bars, fill_ticks, touch_ticks, coin_settings, coin_overrides, params, run_settings,
         sizes, daily, scalars, gap_hist, b, short_side
     );
 }
@@ -757,6 +828,7 @@ kernel void passivbot_ema_anchor_multicoin_long(
     constant int* fill_ticks,
     constant int* touch_ticks,
     constant float* coin_settings,
+    constant float* coin_overrides,
     constant float* params,
     constant float* run_settings,
     constant int* sizes,
@@ -766,7 +838,7 @@ kernel void passivbot_ema_anchor_multicoin_long(
     uint b [[thread_position_in_grid]]
 ) {
     passivbot_ema_anchor_multicoin_impl(
-        bars, fill_ticks, touch_ticks, coin_settings, params, run_settings,
+        bars, fill_ticks, touch_ticks, coin_settings, coin_overrides, params, run_settings,
         sizes, daily, scalars, gap_hist, b, false
     );
 }

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -702,8 +702,6 @@ def _validate_scope_config(
         )
     if float(config.get("backtest", {}).get("btc_collateral_cap", 0.0) or 0.0) > 0.0:
         raise ValueError("GPU foundation does not support backtest.btc_collateral_cap")
-    if config.get("coin_overrides"):
-        raise ValueError("GPU foundation does not support coin_overrides")
     if float(config.get("live", {}).get("max_realized_loss_pct", 1.0)) != 1.0:
         raise ValueError(
             "GPU foundation requires live.max_realized_loss_pct=1.0 because the "
@@ -762,6 +760,12 @@ def _validate_scope_config(
                 "GPU multicoin foundation requires "
                 "live.forager_score_hysteresis_pct=0"
             )
+    _validate_gpu_coin_overrides(
+        config,
+        strategy_kind=strategy_kind,
+        enabled_sides=enabled_sides,
+        coin_count=coin_count,
+    )
     for side in enabled_sides:
         side_config = config["bot"][side]
         if bool(side_config.get("hsl", {}).get("enabled")):
@@ -785,6 +789,63 @@ def _validate_scope_config(
                 f"GPU foundation requires bot.{side}.risk.we_excess_allowance_pct=0.0"
             )
     return exchange
+
+
+def _validate_gpu_coin_overrides(
+    config: dict,
+    *,
+    strategy_kind: str,
+    enabled_sides,
+    coin_count: int,
+) -> None:
+    """Accept only the static per-coin leaves modeled by the MPS proxy."""
+
+    overrides = config.get("coin_overrides") or {}
+    if not overrides:
+        return
+    if coin_count <= 1 or strategy_kind != "ema_anchor" or len(enabled_sides) != 1:
+        raise ValueError(
+            "GPU coin_overrides currently require multi-coin EMA Anchor with "
+            "exactly one enabled side"
+        )
+    enabled_side = next(iter(enabled_sides))
+    from optimization.gpu.model import EMA_ANCHOR_PARAM_KEYS
+
+    strategy_keys = set(EMA_ANCHOR_PARAM_KEYS) - {
+        "entry_cooldown_minutes",
+        "total_wallet_exposure_limit",
+    }
+
+    def leaves(value, prefix=()):
+        if isinstance(value, dict):
+            for key, child in value.items():
+                yield from leaves(child, (*prefix, str(key)))
+        else:
+            yield prefix
+
+    allowed = {
+        ("bot", enabled_side, "risk", "entry_cooldown_minutes"),
+        ("bot", enabled_side, "wallet_exposure_limit"),
+    } | {
+        ("bot", enabled_side, "strategy", "ema_anchor", key)
+        for key in strategy_keys
+    }
+    unsupported = []
+    for coin, patch in overrides.items():
+        if not isinstance(patch, dict):
+            unsupported.append(f"coin_overrides.{coin}")
+            continue
+        unsupported.extend(
+            ".".join(("coin_overrides", str(coin), *path))
+            for path in leaves(patch)
+            if path not in allowed
+        )
+    if unsupported:
+        raise ValueError(
+            "GPU coin_overrides do not model these paths yet: "
+            f"{sorted(unsupported)}; supported leaves are enabled-side EMA Anchor "
+            "parameters, risk.entry_cooldown_minutes, and wallet_exposure_limit"
+        )
 
 
 def _validate_scope(
@@ -1499,6 +1560,10 @@ def _gpu_suite_checkpoint_contract(config: dict, suite_inputs=None) -> dict:
                     "last_timestamp": (
                         int(timestamps[-1]) if len(timestamps) else None
                     ),
+                    "coin_overrides": deepcopy(
+                        item.get("coin_override_contract")
+                        or item["config"].get("coin_overrides", {})
+                    ),
                 }
             )
         contract["prepared_scenarios"] = prepared_scenarios
@@ -1511,6 +1576,7 @@ def _checkpoint_signature(
     *,
     anchor_plan=None,
     suite_contract=None,
+    runtime_contract=None,
 ) -> str:
     payload = {
         "active": [
@@ -1534,6 +1600,8 @@ def _checkpoint_signature(
         }
     if suite_contract is not None:
         payload["suite_contract"] = suite_contract
+    if runtime_contract is not None:
+        payload["runtime_contract"] = runtime_contract
     return hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()
 
 
@@ -2332,23 +2400,28 @@ def run_backend(
         )
 
     if suite_enabled:
-        scenario_proxies = [
-            (
-                item["ctx"],
-                (MpsMulticoinEmaProxy if item["coin_count"] > 1 else MpsSingleCoinProxy)(
-                    config=item["config"],
-                    hlcvs=item["hlcvs"],
-                    mss=item["mss"],
-                    btc=item["btc"],
-                    timestamps=item["timestamps"],
-                    exchange=item["exchange"],
-                    batch_size=int(options["batch_size"]),
-                    needed_metrics=needed_metrics,
-                ),
-                item["parameter_overrides"],
+        scenario_proxies = []
+        for item in suite_inputs:
+            scenario_proxy = (
+                MpsMulticoinEmaProxy
+                if item["coin_count"] > 1
+                else MpsSingleCoinProxy
+            )(
+                config=item["config"],
+                hlcvs=item["hlcvs"],
+                mss=item["mss"],
+                btc=item["btc"],
+                timestamps=item["timestamps"],
+                exchange=item["exchange"],
+                batch_size=int(options["batch_size"]),
+                needed_metrics=needed_metrics,
             )
-            for item in suite_inputs
-        ]
+            item["coin_override_contract"] = getattr(
+                scenario_proxy, "coin_override_contract", {}
+            )
+            scenario_proxies.append(
+                (item["ctx"], scenario_proxy, item["parameter_overrides"])
+            )
 
         def evaluate_proxy(candidates):
             return _evaluate_gpu_suite_proxies(
@@ -2478,6 +2551,11 @@ def run_backend(
             _gpu_suite_checkpoint_contract(config, suite_inputs)
             if suite_enabled
             else None
+        ),
+        runtime_contract=(
+            None
+            if suite_enabled
+            else getattr(proxy, "coin_override_contract", None)
         ),
     )
     budget = int(config["optimize"]["iters"])

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -297,7 +297,14 @@ class MpsEmaAnchorRunner:
 class MpsEmaAnchorMulticoinRunner:
     """Persistent single-side multi-coin EMA Anchor screening runner on MPS."""
 
-    def __init__(self, run: ProxyRun, data: dict, *, side: str):
+    def __init__(
+        self,
+        run: ProxyRun,
+        data: dict,
+        *,
+        side: str,
+        coin_overrides: np.ndarray | None = None,
+    ):
         if side not in {"long", "short"}:
             raise ValueError(
                 f"MPS multicoin EMA runner side must be long or short, got {side!r}"
@@ -311,6 +318,17 @@ class MpsEmaAnchorMulticoinRunner:
         self.fill_ticks = data["fill_ticks"]
         self.touch_ticks = data["touch_ticks"]
         self.coin_settings = data["coin_settings"]
+        if coin_overrides is None:
+            coin_overrides = np.full((self.n_coins, 12), np.nan, dtype=np.float32)
+        coin_overrides = np.asarray(coin_overrides, dtype=np.float32)
+        if coin_overrides.shape != (self.n_coins, 12):
+            raise ValueError(
+                "expected multicoin EMA override matrix shaped "
+                f"({self.n_coins}, 12), got {coin_overrides.shape}"
+            )
+        self.coin_overrides = torch.as_tensor(
+            np.ascontiguousarray(coin_overrides), device="mps"
+        )
         liq_floor = max(0.0, run.starting_balance) * max(
             0.0, run.liquidation_threshold
         )
@@ -402,6 +420,7 @@ class MpsEmaAnchorMulticoinRunner:
             self.fill_ticks,
             self.touch_ticks,
             self.coin_settings,
+            self.coin_overrides,
             params_mps,
             self.settings,
             self._sizes[sizes_key],

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -7,6 +7,7 @@ import os
 import numpy as np
 
 from optimization.gpu.model import (
+    EMA_ANCHOR_PARAM_KEYS,
     EMA_ANCHOR_MULTICOIN_PARAM_KEYS,
     GPU_STRATEGY_PARAM_KEYS,
     MPS_MULTICOIN_MAX_COINS,
@@ -278,6 +279,52 @@ class MpsSingleCoinProxy:
 MpsEmaAnchorProxy = MpsSingleCoinProxy
 
 
+def _build_multicoin_ema_coin_overrides(
+    *,
+    config: dict,
+    mss: dict,
+    exchange: str,
+    coins: list[str],
+    payload,
+    side: str,
+    resolve_override=None,
+) -> tuple[np.ndarray, dict]:
+    """Pack exact-last static coin overrides for the Metal EMA proxy."""
+
+    if resolve_override is None:
+        from backtest import _get_backtest_coin_override
+
+        resolve_override = _get_backtest_coin_override
+
+    override_keys = tuple(EMA_ANCHOR_PARAM_KEYS[:-2])
+    matrix = np.full((len(coins), 12), np.nan, dtype=np.float32)
+    for coin_index, coin in enumerate(coins):
+        patch = resolve_override(config, mss, exchange, coin) or {}
+        side_patch = patch.get("bot", {}).get(side, {})
+        strategy_patch = side_patch.get("strategy", {}).get("ema_anchor", {}) or {}
+        effective_strategy = payload.strategy_params_list[coin_index][side]
+        effective_bot = payload.bot_params_list[coin_index][side]
+        for column, key in enumerate(override_keys):
+            if key in strategy_patch:
+                matrix[coin_index, column] = float(effective_strategy[key])
+        if "entry_cooldown_minutes" in (side_patch.get("risk", {}) or {}):
+            matrix[coin_index, 10] = float(
+                effective_bot.get("entry_cooldown_minutes", 0.0) or 0.0
+            )
+        if "wallet_exposure_limit" in side_patch:
+            matrix[coin_index, 11] = float(effective_bot["wallet_exposure_limit"])
+    contract = {
+        "exchange": exchange,
+        "coins": coins,
+        "side": side,
+        "values": [
+            [None if not np.isfinite(value) else float(value) for value in row]
+            for row in matrix
+        ],
+    }
+    return matrix, contract
+
+
 class MpsMulticoinEmaProxy:
     """Batched single-side multi-coin EMA Anchor screening proxy."""
 
@@ -424,7 +471,6 @@ class MpsMulticoinEmaProxy:
         self.base_params = first_strategy
 
         comparable_bot_keys = (
-            "entry_cooldown_minutes",
             "total_wallet_exposure_limit",
             "filter_volume_ema_span_1m",
             "filter_volatility_ema_span_1m",
@@ -437,13 +483,30 @@ class MpsMulticoinEmaProxy:
         for coin in range(1, coin_count):
             strategy = payload.strategy_params_list[coin][self.side]
             bot = payload.bot_params_list[coin][self.side]
-            if strategy != payload.strategy_params_list[0][self.side] or any(
+            if any(
                 bot.get(key) != first_bot.get(key) for key in comparable_bot_keys
             ):
                 raise ValueError(
-                    "MPS multicoin proxy requires identical "
-                    f"{self.side} strategy/forager settings across coins"
+                    "MPS multicoin proxy requires identical global "
+                    f"{self.side} forager/risk settings across coins"
                 )
+
+        coins = list(backtest_params.get("coins") or [])
+        if len(coins) != coin_count:
+            raise ValueError(
+                "MPS multicoin payload coin identity disagrees with prepared data: "
+                f"coins={coins}, prepared={coin_count}"
+            )
+        per_coin_overrides, self.coin_override_contract = (
+            _build_multicoin_ema_coin_overrides(
+                config=config,
+                mss=mss,
+                exchange=exchange,
+                coins=coins,
+                payload=payload,
+                side=self.side,
+            )
+        )
 
         markets = [
             ProxyMarket(
@@ -494,7 +557,10 @@ class MpsMulticoinEmaProxy:
         )
         self.metrics_data = {"ts0": self.data["ts0"], "n": self.data["n"]}
         self.runner = MpsEmaAnchorMulticoinRunner(
-            self.run, self.data, side=self.side
+            self.run,
+            self.data,
+            side=self.side,
+            coin_overrides=per_coin_overrides,
         )
 
     def _parameter_matrix(self, candidates: list[dict]) -> np.ndarray:

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -51,6 +51,7 @@ from optimization.backends.gpu_backend import (
     _update_probe_shortfall_log,
     _validate_directional_search_space,
     _validate_gpu_optimizer_overrides,
+    _validate_gpu_coin_overrides,
     _validate_pinned_scope_bounds,
     _validate_resume_evidence_budget,
     _validate_seed_side_match,
@@ -952,6 +953,59 @@ def test_gpu_foundation_accepts_ema_single_side_multicoin(side):
     config["bot"][side]["risk"]["n_positions"] = 2
 
     assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
+
+
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_gpu_multicoin_accepts_static_ema_coin_overrides(side):
+    config = _directional_ema_config(
+        long_enabled=side == "long", short_enabled=side == "short"
+    )
+    config["live"]["forager_score_hysteresis_pct"] = 0.0
+    config["coin_overrides"] = {
+        "ETH": {
+            "bot": {
+                side: {
+                    "strategy": {"ema_anchor": {"offset": 0.02, "ema_span_0": 90}},
+                    "risk": {"entry_cooldown_minutes": 15},
+                    "wallet_exposure_limit": 0.4,
+                }
+            }
+        }
+    }
+
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
+
+
+@pytest.mark.parametrize(
+    "patch",
+    [
+        {"live": {"leverage": 3}},
+        {"bot": {"long": {"risk": {"n_positions": 2}}}},
+        {"bot": {"long": {"unstuck": {"enabled": True}}}},
+        {"bot": {"short": {"strategy": {"ema_anchor": {"offset": 0.02}}}}},
+    ],
+)
+def test_gpu_multicoin_coin_overrides_reject_unmodeled_leaves(patch):
+    config = _directional_ema_config(long_enabled=True, short_enabled=False)
+    config["coin_overrides"] = {"ETH": patch}
+
+    with pytest.raises(ValueError, match="do not model these paths yet"):
+        _validate_gpu_coin_overrides(
+            config,
+            strategy_kind="ema_anchor",
+            enabled_sides=["long"],
+            coin_count=3,
+        )
+
+
+def test_gpu_coin_overrides_reject_single_coin_scope():
+    config = _long_only_ema_config()
+    config["coin_overrides"] = {
+        "BTC": {"bot": {"long": {"wallet_exposure_limit": 0.5}}}
+    }
+
+    with pytest.raises(ValueError, match="require multi-coin EMA Anchor"):
+        _validate_scope(config, _Evaluator())
 
 
 @pytest.mark.parametrize(
@@ -2505,6 +2559,28 @@ def test_gpu_checkpoint_signature_tracks_effective_suite_contract():
     )
 
 
+def test_gpu_checkpoint_signature_tracks_prepared_coin_override_contract():
+    active = [("long_offset", 0, Bound(0.01, 0.1, 0.01))]
+    scoring = [{"goal": "max", "metric": "adg_strategy_eq"}]
+    contract = {
+        "exchange": "bybit",
+        "coins": ["BTC", "ETH"],
+        "side": "long",
+        "values": [[None] * 12, [None] * 11 + [0.4]],
+    }
+    original = _checkpoint_signature(
+        active, scoring, runtime_contract=contract
+    )
+    edited = copy.deepcopy(contract)
+    edited["values"][1][11] = 0.5
+
+    assert _checkpoint_signature(active, scoring) != original
+    assert (
+        _checkpoint_signature(active, scoring, runtime_contract=edited)
+        != original
+    )
+
+
 def test_gpu_suite_checkpoint_contract_tracks_prepared_scenario_identity():
     config = _directional_ema_config(long_enabled=True, short_enabled=False)
     item = {
@@ -2529,6 +2605,7 @@ def test_gpu_suite_checkpoint_contract_tracks_prepared_scenario_identity():
             "candle_count": 3,
             "first_timestamp": 1000,
             "last_timestamp": 3000,
+            "coin_overrides": {},
         }
     ]
 

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -208,6 +208,8 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
     source = passivbot_rust.mps_ema_anchor_multicoin_source_py()
     assert "kernel void passivbot_ema_anchor_multicoin" in source
     assert "kernel void passivbot_ema_anchor_multicoin_long" in source
+    assert "constant int OVERRIDE_COLS = 12" in source
+    assert "coin_override_or" in source
     count = 512
     coin_count = 3
     phase = np.linspace(0.0, 12.0 * np.pi, count)
@@ -274,6 +276,42 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
 
     legacy_long = MpsEmaAnchorMulticoinLongRunner(runs[0], data)
     assert legacy_long.side == "long"
+
+    disabled = np.full((coin_count, 12), np.nan, dtype=np.float32)
+    disabled[:, 11] = 0.0
+    disabled_output = MpsEmaAnchorMulticoinRunner(
+        runs[0], data, side=side, coin_overrides=disabled
+    ).run(np.array([row], dtype=np.float64))
+    torch.mps.synchronize()
+    assert disabled_output["day_has_fill"].sum().item() == 0
+    assert disabled_output["open_positions"].item() == 0.0
+
+    exact_last = np.full((coin_count, 12), np.nan, dtype=np.float32)
+    exact_last[:, :11] = np.asarray(row[:11], dtype=np.float32)
+    changed_candidate = list(row)
+    changed_candidate[:11] = [
+        0.01,
+        200.0,
+        400.0,
+        0.0,
+        0.05,
+        2.0,
+        5.0,
+        5.0,
+        10.0,
+        10.0,
+        30.0,
+    ]
+    exact_last_output = MpsEmaAnchorMulticoinRunner(
+        runs[0], data, side=side, coin_overrides=exact_last
+    ).run(np.array([row, changed_candidate], dtype=np.float64))
+    torch.mps.synchronize()
+    assert torch.equal(
+        exact_last_output["day_has_fill"][0], exact_last_output["day_has_fill"][1]
+    )
+    assert torch.equal(
+        exact_last_output["day_end_eq"][0], exact_last_output["day_end_eq"][1]
+    )
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -1,3 +1,6 @@
+from types import SimpleNamespace
+
+import numpy as np
 import pytest
 
 from optimization.gpu.model import (
@@ -10,6 +13,7 @@ from optimization.gpu.model import (
 from optimization.gpu.service import (
     MpsEmaAnchorProxy,
     MpsMulticoinEmaProxy,
+    _build_multicoin_ema_coin_overrides,
     _require_complete_valid_tail,
 )
 
@@ -55,6 +59,57 @@ def test_multicoin_parameter_matrix_uses_only_enabled_side(side, base):
     assert matrix.shape == (1, len(EMA_ANCHOR_MULTICOIN_PARAM_KEYS))
     offset_index = EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("offset")
     assert matrix[0, offset_index] == 0.125
+
+
+def test_multicoin_coin_overrides_pack_only_explicit_exact_values():
+    strategy_base = {key: 1.0 for key in EMA_ANCHOR_PARAM_KEYS[:-2]}
+    strategy_override = dict(strategy_base, offset=0.25, ema_span_0=90.0)
+    payload = SimpleNamespace(
+        strategy_params_list=[
+            {"long": strategy_base},
+            {"long": strategy_override},
+        ],
+        bot_params_list=[
+            {"long": {"entry_cooldown_minutes": 0.0, "wallet_exposure_limit": -1.0}},
+            {"long": {"entry_cooldown_minutes": 15.0, "wallet_exposure_limit": 0.4}},
+        ],
+    )
+    config = {
+        "coin_overrides": {
+            "ETH": {
+                "bot": {
+                    "long": {
+                        "strategy": {
+                            "ema_anchor": {"offset": 0.25, "ema_span_0": 90.0}
+                        },
+                        "risk": {"entry_cooldown_minutes": 15.0},
+                        "wallet_exposure_limit": 0.4,
+                    }
+                }
+            }
+        }
+    }
+
+    matrix, contract = _build_multicoin_ema_coin_overrides(
+        config=config,
+        mss={"BTC": {}, "ETH": {}},
+        exchange="bybit",
+        coins=["BTC", "ETH"],
+        payload=payload,
+        side="long",
+        resolve_override=lambda config, _mss, _exchange, coin: config[
+            "coin_overrides"
+        ].get(coin, {}),
+    )
+
+    assert matrix.shape == (2, 12)
+    assert np.isnan(matrix[0]).all()
+    assert matrix[1, EMA_ANCHOR_PARAM_KEYS.index("offset")] == pytest.approx(0.25)
+    assert matrix[1, EMA_ANCHOR_PARAM_KEYS.index("ema_span_0")] == pytest.approx(90.0)
+    assert matrix[1, 10] == pytest.approx(15.0)
+    assert matrix[1, 11] == pytest.approx(0.4)
+    assert contract["coins"] == ["BTC", "ETH"]
+    assert contract["values"][0] == [None] * 12
 
 
 def test_trailing_parameter_matrix_keeps_nested_flattened_sides_separate():


### PR DESCRIPTION
## Summary
- support exact-last per-coin EMA Anchor, entry cooldown, and wallet exposure overrides in the Apple MPS multicoin proxy
- keep every unmodeled coin override path fail-closed and bind resume checkpoints to the prepared effective override table
- document the supported scope and add backend, packing, Metal precedence, disabled-coin, and checkpoint regression coverage

## Validation
- `python -m pytest -q`
- `cargo test --no-default-features` (260 passed)
- `cargo check --tests`
- `python -m pytest -q tests/optimization/test_gpu_mps.py` on Apple M3/MPS (38 passed)
- fingerprint-aware release rebuild and runtime source-stamp verification
- bounded cached three-coin MPS optimize: 512 proxy + 64 exact Rust evaluations, no drift or classification halt
- AI documentation checks: 0 errors, 2 pre-existing size warnings