### PR TITLE
GPU slice 8: dual-side multicoin EMA hedge mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Add dual-side hedge-mode multi-coin EMA-anchor optimization to the experimental Apple MPS
+  backend. Metal screens long and short independently and combines their compact outputs into a
+  conservative portfolio proxy, while unchanged exact Rust backtests remain authoritative and the
+  existing constraint, rank, and drift gates fail closed on disagreement. Dual-side one-way mode,
+  suites, and coin overrides remain explicitly unsupported in this slice.
+
 - Add static per-coin overrides to experimental Apple MPS multi-coin EMA-anchor optimization.
   The enabled side may override EMA-anchor parameters, entry cooldown, and an explicit per-coin
   wallet-exposure limit. Metal applies those values after every candidate gene, matching exact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ All notable user-facing changes will be documented in this file.
   backend. Metal screens long and short independently and combines their compact outputs into a
   conservative portfolio proxy, while unchanged exact Rust backtests remain authoritative and the
   existing constraint, rank, and drift gates fail closed on disagreement. Dual-side one-way mode,
-  suites, and coin overrides remain explicitly unsupported in this slice.
+  suites, coin overrides, and metrics requiring cross-side fill or recovery event streams remain
+  explicitly unsupported in this slice.
 
 - Add static per-coin overrides to experimental Apple MPS multi-coin EMA-anchor optimization.
   The enabled side may override EMA-anchor parameters, entry cooldown, and an explicit per-coin

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -662,8 +662,9 @@ Risk should be constrained through canonical `*_strategy_eq` metrics instead. De
 - **population_size**: Size of population for genetic optimization algorithm. With the default `pymoo` backend, `null` means auto: NSGA-II resolves to `250`, while NSGA-III resolves to a default population budget of `500` and chooses the finest auto reference-direction grid that fits inside that budget. Set an explicit integer to change the NSGA-III per-generation evaluation budget and auto reference-direction coarseness.
 - **backend**: Optimizer backend. Default is `pymoo`. Supported values are `deap`, `pymoo`, and
   experimental `gpu`. The GPU backend currently supports Apple MPS, single-coin EMA-anchor and
-  trailing-martingale runs in long-only, short-only, and long+short modes; single-side multi-coin
-  EMA-anchor runs; anchored fine-tuning with `--start` plus `--fine-tune-params`; and the V8
+  trailing-martingale runs in long-only, short-only, and long+short modes; single-side and
+  dual-side hedge-mode multi-coin EMA-anchor runs; anchored fine-tuning with `--start` plus
+  `--fine-tune-params`; and the V8
   `mirror_short_from_long` and `lossless_close_trailing` optimizer overrides. See
   `docs/optimizing.md` for its fail-closed scope and `optimize.gpu` settings.
   With the default `optimize.pymoo.algorithm: "auto"`, Passivbot uses `nsga2` for `3` or fewer

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -133,9 +133,10 @@ Rust portfolio backtest, and classification, rank, and drift gates halt material
 Dual-side one-way arbitration, dual-side multi-coin suites and coin overrides, multi-coin
 trailing-martingale, multi-exchange suites, non-bot suite scenario overrides, per-coin source
 assignments, HSL, and auto-unstuck are not silently approximated by this release. Dual-side
-multi-coin screening also rejects `fills_gap_longest_days` and
-`strategy_eq_recovery_days_max`: the independent directional summaries cannot reconstruct
-cross-side-only fill gaps or alternating portfolio recovery periods safely.
+multi-coin screening also rejects `fills_gap_longest_days`,
+`strategy_eq_recovery_days_max`, and `volume_pct_per_day_avg`: the independent directional
+summaries cannot reconstruct cross-side-only fill gaps, alternating portfolio recovery periods,
+or fill volume normalized by the shared balance safely.
 
 For a supported suite, each Metal candidate is dispatched across every prepared scenario. The GPU
 path then calls the same canonical suite reducer and scenario-selection logic as the CPU optimizer

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -103,8 +103,9 @@ The supported slice is intentionally narrow:
 - one exchange using one-minute candles
 - `strategy_kind: ema_anchor` or `trailing_martingale`, with long-only, short-only, or
   long+short enabled for one coin
-- long-only or short-only multi-coin EMA-anchor runs for up to 64 coins, with dynamic wallet-
-  exposure allocation and Forager selection; multi-coin runs require
+- long-only, short-only, or dual-side hedge-mode multi-coin EMA-anchor runs for up to 64 coins,
+  with dynamic wallet-exposure allocation and independent per-side Forager selection; dual-side
+  runs require matching long/short approved and ignored coin sets, and all multi-coin runs require
   `backtest.dynamic_wel_by_tradability: true` and `live.forager_score_hysteresis_pct: 0`
 - each enabled side's `n_positions` pinned to `1` and wallet-exposure limit kept positive
   for single-coin runs; supported multi-coin bounds may vary `n_positions` between `1` and the
@@ -125,8 +126,12 @@ The supported slice is intentionally narrow:
 - `live.market_orders_allowed: false`
 - no invalid candle tail after the selected coin's final valid candle
 
-Unsupported combinations fail before optimization begins. Multi-coin trailing-martingale or
-long+short runs and suites, multi-exchange suites, non-bot suite scenario overrides, per-coin source
+Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor uses one
+long and one short Metal dispatch per candidate in hedge mode. Their directional surfaces form a
+conservative portfolio screening proxy; every accepted metric still comes from the unchanged exact
+Rust portfolio backtest, and classification, rank, and drift gates halt material disagreement.
+Dual-side one-way arbitration, dual-side multi-coin suites and coin overrides, multi-coin
+trailing-martingale, multi-exchange suites, non-bot suite scenario overrides, per-coin source
 assignments, HSL, and auto-unstuck are not silently approximated by this release.
 
 For a supported suite, each Metal candidate is dispatched across every prepared scenario. The GPU

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -132,7 +132,10 @@ conservative portfolio screening proxy; every accepted metric still comes from t
 Rust portfolio backtest, and classification, rank, and drift gates halt material disagreement.
 Dual-side one-way arbitration, dual-side multi-coin suites and coin overrides, multi-coin
 trailing-martingale, multi-exchange suites, non-bot suite scenario overrides, per-coin source
-assignments, HSL, and auto-unstuck are not silently approximated by this release.
+assignments, HSL, and auto-unstuck are not silently approximated by this release. Dual-side
+multi-coin screening also rejects `fills_gap_longest_days` and
+`strategy_eq_recovery_days_max`: the independent directional summaries cannot reconstruct
+cross-side-only fill gaps or alternating portfolio recovery periods safely.
 
 For a supported suite, each Metal candidate is dispatched across every prepared scenario. The GPU
 path then calls the same canonical suite reducer and scenario-selection logic as the CPU optimizer

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -60,7 +60,8 @@ mod tests {
         assert!(source.contains("constant int OVERRIDE_COLS = 12"));
         assert!(source.contains("coin_override_or"));
         assert!(source.contains("constant int COIN_COLS = 11"));
-        assert!(source.contains("constant int DAILY_COLS = 5"));
+        assert!(source.contains("constant int DAILY_COLS = 6"));
+        assert!(source.contains("day_min_balance"));
         assert!(source.contains("constant int SCALAR_COLS = 18"));
         assert!(source.contains("close_tick[c] <= fill_ticks[tick_offset + 0]"));
         assert!(source.contains("entry_tick[c] > fill_ticks[tick_offset + 1]"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -5,7 +5,7 @@ constant int MAX_COINS = 64;
 constant int PARAM_COLS = 19;
 constant int COIN_COLS = 11;
 constant int OVERRIDE_COLS = 12;
-constant int DAILY_COLS = 5;
+constant int DAILY_COLS = 6;
 constant int SCALAR_COLS = 18;
 constant int GAP_BINS = 128;
 
@@ -235,6 +235,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
     float day_dd = 0.0f;
     float day_volume = 0.0f;
     float day_has_fill = 0.0f;
+    float day_min_balance = INFINITY;
 
     for (int k = 1; k < T - 1; ++k) {
         const int day_index = (start_day_minute + k) / 1440;
@@ -246,6 +247,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 daily[output + 2] = day_dd;
                 daily[output + 3] = day_volume;
                 daily[output + 4] = day_has_fill;
+                daily[output + 5] = day_min_balance;
             }
             current_day = day_index;
             day_touched = false;
@@ -254,6 +256,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
             day_dd = 0.0f;
             day_volume = 0.0f;
             day_has_fill = 0.0f;
+            day_min_balance = INFINITY;
         }
 
         bool any_fill = false;
@@ -747,6 +750,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
             max_dd = fmax(max_dd, drawdown);
             day_end = effective_equity;
             day_min = fmin(day_min, effective_equity);
+            day_min_balance = fmin(day_min_balance, balance);
             day_dd = fmax(day_dd, drawdown);
             day_touched = true;
             if (liquidated) {
@@ -763,6 +767,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
         daily[output + 2] = day_dd;
         daily[output + 3] = day_volume;
         daily[output + 4] = day_has_fill;
+        daily[output + 5] = day_min_balance;
     }
 
     float total_size = 0.0f;

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -818,7 +818,11 @@ def _validate_dual_multicoin_metrics(
         return
     unsupported = sorted(
         set(needed_metrics)
-        & {"fills_gap_longest_days", "strategy_eq_recovery_days_max"}
+        & {
+            "fills_gap_longest_days",
+            "strategy_eq_recovery_days_max",
+            "volume_pct_per_day_avg",
+        }
     )
     if unsupported:
         raise ValueError(

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -740,10 +740,28 @@ def _validate_scope_config(
             raise ValueError(
                 "GPU multicoin foundation currently supports strategy_kind=ema_anchor only"
             )
-        if len(enabled_sides) != 1:
+        if len(enabled_sides) not in (1, 2):
             raise ValueError(
-                "GPU multicoin foundation currently supports exactly one enabled side"
+                "GPU multicoin foundation requires one or two enabled sides"
             )
+        if len(enabled_sides) == 2 and not bool(
+            config.get("live", {}).get("hedge_mode")
+        ):
+            raise ValueError(
+                "GPU dual-side multicoin EMA Anchor currently requires "
+                "live.hedge_mode=true; one-way arbitration is not modeled"
+            )
+        if len(enabled_sides) == 2:
+            approved = config.get("live", {}).get("approved_coins", {}) or {}
+            ignored = config.get("live", {}).get("ignored_coins", {}) or {}
+            for label, values in (("approved", approved), ("ignored", ignored)):
+                if set(values.get("long", []) or []) != set(
+                    values.get("short", []) or []
+                ):
+                    raise ValueError(
+                        "GPU dual-side multicoin EMA Anchor currently requires "
+                        f"matching long/short {label}_coins"
+                    )
         if not bool(config.get("backtest", {}).get("dynamic_wel_by_tradability")):
             raise ValueError(
                 "GPU multicoin foundation requires "
@@ -2164,13 +2182,17 @@ def run_backend(
                 if gpu_side_enabled(proxy_config, side)
             ]
         )
-        if len(multicoin_sides) != 1:
+        if len(multicoin_sides) not in (1, 2):
             raise ValueError(
-                "GPU multicoin foundation requires exactly one enabled side"
+                "GPU multicoin foundation requires one or two enabled sides"
             )
-        bound_map = _ema_multicoin_bound_map(
-            multicoin_sides[0], gpu_optimizer_overrides
-        )
+        bound_map = {}
+        for multicoin_side in multicoin_sides:
+            bound_map.update(
+                _ema_multicoin_bound_map(
+                    multicoin_side, gpu_optimizer_overrides
+                )
+            )
     else:
         bound_map = GPU_STRATEGY_BOUND_MAPS[strategy_kind]
 

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -809,6 +809,25 @@ def _validate_scope_config(
     return exchange
 
 
+def _validate_dual_multicoin_metrics(
+    needed_metrics, *, coin_count: int, enabled_sides
+) -> None:
+    """Reject metrics which cannot be reconstructed from directional summaries."""
+
+    if int(coin_count) <= 1 or len(set(enabled_sides)) != 2:
+        return
+    unsupported = sorted(
+        set(needed_metrics)
+        & {"fills_gap_longest_days", "strategy_eq_recovery_days_max"}
+    )
+    if unsupported:
+        raise ValueError(
+            "GPU dual-side multicoin EMA Anchor cannot safely reconstruct proxy "
+            f"metrics {unsupported} from independent directional summaries; "
+            "use other metrics or the CPU optimizer"
+        )
+
+
 def _validate_gpu_coin_overrides(
     config: dict,
     *,
@@ -2420,6 +2439,11 @@ def run_backend(
             f"GPU foundation does not implement optimizer metrics {unsupported}; "
             "use supported metrics or the CPU optimizer"
         )
+    _validate_dual_multicoin_metrics(
+        needed_metrics,
+        coin_count=max_coin_count,
+        enabled_sides=enabled_sides,
+    )
 
     if suite_enabled:
         scenario_proxies = []

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -17,6 +17,7 @@ from optimization.gpu.model import (
 
 
 MPS_DAILY_COLS = 5
+MPS_MULTICOIN_DAILY_COLS = 6
 MPS_SCALAR_COLS = 18
 
 
@@ -70,6 +71,11 @@ def _decode_outputs(daily, scalars, gaps) -> dict:
         "day_max_dd": daily[:, :, 2],
         "day_volume": daily[:, :, 3],
         "day_has_fill": daily[:, :, 4] > 0.0,
+        "day_min_balance": torch.where(
+            active_days,
+            daily[:, :, 5],
+            torch.full_like(daily[:, :, 5], float("inf")),
+        ),
         "max_dd": scalars[:, 0],
         "held_max_ms": scalars[:, 1],
         "gap_hist": gaps,
@@ -364,7 +370,7 @@ class MpsEmaAnchorMulticoinRunner:
             self._buffers = {
                 batch_size: (
                     torch.zeros(
-                        (batch_size, self.n_days, MPS_DAILY_COLS),
+                        (batch_size, self.n_days, MPS_MULTICOIN_DAILY_COLS),
                         dtype=torch.float32,
                         device="mps",
                     ),
@@ -382,6 +388,7 @@ class MpsEmaAnchorMulticoinRunner:
             for buffer in self._buffers[batch_size]:
                 buffer.zero_()
         self._buffers[batch_size][0][:, :, 1].fill_(float("inf"))
+        self._buffers[batch_size][0][:, :, 5].fill_(float("inf"))
         return self._buffers[batch_size]
 
     def run(self, params: np.ndarray, *, profile: bool = False) -> dict:

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -71,7 +71,13 @@ def _nan_max(left, right):
     )
 
 
-def _combine_hedged_multicoin_outputs(long: dict, short: dict, starting_balance: float):
+def _combine_hedged_multicoin_outputs(
+    long: dict,
+    short: dict,
+    starting_balance: float,
+    first_ts_ms: int,
+    interval_ms: int,
+):
     """Build a conservative portfolio surface from independent directional screens.
 
     This is deliberately only a ranking proxy. The unchanged Rust backtest remains
@@ -79,9 +85,25 @@ def _combine_hedged_multicoin_outputs(long: dict, short: dict, starting_balance:
     material disagreement.
     """
 
-    long_active = long["day_min_eq"].isfinite()
-    short_active = short["day_min_eq"].isfinite()
-    active = long_active & short_active
+    long_liquidated = long["liq_step"] >= 0
+    short_liquidated = short["liq_step"] >= 0
+    liq_step = long["liq_step"].where(
+        long_liquidated & ~short_liquidated,
+        short["liq_step"].where(
+            short_liquidated & ~long_liquidated,
+            long["liq_step"].minimum(short["liq_step"]),
+        ),
+    )
+    active = long["day_min_eq"].isfinite() & short["day_min_eq"].isfinite()
+    day_count = int(active.shape[1])
+    day_ids = active.new_tensor(range(day_count), dtype=long["liq_step"].dtype)
+    first_day = int(first_ts_ms) // 86_400_000
+    terminal_day = (
+        (int(first_ts_ms) + liq_step * int(interval_ms)) // 86_400_000
+    ) - first_day
+    active &= (~(long_liquidated | short_liquidated)).unsqueeze(1) | (
+        day_ids.unsqueeze(0) < terminal_day.unsqueeze(1)
+    )
 
     combined = {}
     for key in ("day_end_eq", "day_min_eq"):
@@ -123,15 +145,7 @@ def _combine_hedged_multicoin_outputs(long: dict, short: dict, starting_balance:
     )
     combined["last_eq_ts"] = _nan_min(long["last_eq_ts"], short["last_eq_ts"])
 
-    long_liquidated = long["liq_step"] >= 0
-    short_liquidated = short["liq_step"] >= 0
-    combined["liq_step"] = long["liq_step"].where(
-        long_liquidated & ~short_liquidated,
-        short["liq_step"].where(
-            short_liquidated & ~long_liquidated,
-            long["liq_step"].minimum(short["liq_step"]),
-        ),
-    )
+    combined["liq_step"] = liq_step
     return combined
 
 
@@ -748,6 +762,8 @@ class MpsMulticoinEmaProxy:
                     side_outputs["long"],
                     side_outputs["short"],
                     self.run.starting_balance,
+                    self.metrics_data["ts0"],
+                    self.run.interval_ms,
                 )
             timestamp_origin = float(self.metrics_data["ts0"])
             for key in (

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -75,6 +75,9 @@ def _combine_hedged_multicoin_outputs(
     long: dict,
     short: dict,
     starting_balance: float,
+    liquidation_threshold: float,
+    start_minute_of_day: int,
+    interval_ms: int,
 ):
     """Build a conservative portfolio surface from independent directional screens.
 
@@ -83,25 +86,41 @@ def _combine_hedged_multicoin_outputs(
     material disagreement.
     """
 
-    long_liquidated = long["liq_step"] >= 0
-    short_liquidated = short["liq_step"] >= 0
-    liquidation_day = long["liq_step"].where(
-        long_liquidated & ~short_liquidated,
-        short["liq_step"].where(
-            short_liquidated & ~long_liquidated,
-            long["liq_step"].minimum(short["liq_step"]),
-        ),
-    )
     active = long["day_min_eq"].isfinite() & short["day_min_eq"].isfinite()
     day_count = int(active.shape[1])
     day_ids = active.new_tensor(range(day_count), dtype=long["liq_step"].dtype)
-    active &= (~(long_liquidated | short_liquidated)).unsqueeze(1) | (
-        day_ids.unsqueeze(0) < liquidation_day.unsqueeze(1)
+    no_liquidation = long["liq_step"].new_full(long["liq_step"].shape, day_count)
+    directional_liquidation_day = long["liq_step"].where(
+        long["liq_step"] >= 0, no_liquidation
+    ).minimum(
+        short["liq_step"].where(short["liq_step"] >= 0, no_liquidation)
+    )
+    raw_combined_min = (
+        long["day_min_eq"] + short["day_min_eq"] - float(starting_balance)
+    )
+    portfolio_floor = max(0.0, float(starting_balance)) * max(
+        0.0, float(liquidation_threshold)
+    )
+    portfolio_breach = active & (raw_combined_min <= portfolio_floor)
+    portfolio_liquidation_day = portfolio_breach.to(
+        dtype=long["liq_step"].dtype
+    ).argmax(dim=1).where(
+        portfolio_breach.any(dim=1), no_liquidation
+    )
+    terminal_day = directional_liquidation_day.minimum(portfolio_liquidation_day)
+    liquidated = terminal_day < day_count
+    liquidation_day = terminal_day.where(
+        liquidated, -no_liquidation.new_ones(())
+    )
+    active &= (~liquidated).unsqueeze(1) | (
+        day_ids.unsqueeze(0) < terminal_day.unsqueeze(1)
     )
 
     combined = {}
     for key in ("day_end_eq", "day_min_eq"):
-        values = long[key] + short[key] - float(starting_balance)
+        values = raw_combined_min if key == "day_min_eq" else (
+            long[key] + short[key] - float(starting_balance)
+        )
         if key == "day_min_eq":
             values = values.where(active, values.new_full((), float("inf")))
         else:
@@ -137,7 +156,22 @@ def _combine_hedged_multicoin_outputs(
     combined["first_eq_ts"] = _nan_max(
         long["first_eq_ts"], short["first_eq_ts"]
     )
-    combined["last_eq_ts"] = _nan_min(long["last_eq_ts"], short["last_eq_ts"])
+    last_eq_ts = _nan_min(long["last_eq_ts"], short["last_eq_ts"])
+    # Daily summaries do not reveal the exact intra-day portfolio breach. Stop at
+    # the final complete candle before that UTC day so completion cannot imply
+    # coverage beyond the conservative combined-equity liquidation surface.
+    terminal_day_start_ms = (
+        terminal_day.to(last_eq_ts.dtype) * 86_400_000.0
+        - float(start_minute_of_day) * 60_000.0
+    ).clamp(min=0.0)
+    complete_tail_ms = (terminal_day_start_ms - float(interval_ms)).clamp(min=0.0)
+    first_eq_ts = combined["first_eq_ts"]
+    complete_tail_ms = complete_tail_ms.maximum(first_eq_ts).where(
+        first_eq_ts.isfinite(), complete_tail_ms
+    )
+    combined["last_eq_ts"] = last_eq_ts.minimum(complete_tail_ms).where(
+        liquidated, last_eq_ts
+    )
 
     combined["liq_step"] = liquidation_day
     return combined
@@ -756,6 +790,9 @@ class MpsMulticoinEmaProxy:
                     side_outputs["long"],
                     side_outputs["short"],
                     self.run.starting_balance,
+                    self.run.liquidation_threshold,
+                    self.runners["long"].start_minute_of_day,
+                    self.run.interval_ms,
                 )
             timestamp_origin = float(self.metrics_data["ts0"])
             for key in (

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -26,6 +26,7 @@ CORE_OUTPUT_KEYS = {
     "day_max_dd",
     "day_volume",
     "day_has_fill",
+    "day_min_balance",
     "max_dd",
     "held_max_ms",
     "gap_hist",
@@ -98,10 +99,17 @@ def _combine_hedged_multicoin_outputs(
     raw_combined_min = (
         long["day_min_eq"] + short["day_min_eq"] - float(starting_balance)
     )
+    raw_combined_min_balance = (
+        long["day_min_balance"]
+        + short["day_min_balance"]
+        - float(starting_balance)
+    )
     portfolio_floor = max(0.0, float(starting_balance)) * max(
         0.0, float(liquidation_threshold)
     )
-    portfolio_breach = active & (raw_combined_min <= portfolio_floor)
+    portfolio_breach = active & (
+        (raw_combined_min <= portfolio_floor) | (raw_combined_min_balance <= 0.0)
+    )
     portfolio_liquidation_day = portfolio_breach.to(
         dtype=long["liq_step"].dtype
     ).argmax(dim=1).where(

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -75,8 +75,6 @@ def _combine_hedged_multicoin_outputs(
     long: dict,
     short: dict,
     starting_balance: float,
-    first_ts_ms: int,
-    interval_ms: int,
 ):
     """Build a conservative portfolio surface from independent directional screens.
 
@@ -87,7 +85,7 @@ def _combine_hedged_multicoin_outputs(
 
     long_liquidated = long["liq_step"] >= 0
     short_liquidated = short["liq_step"] >= 0
-    liq_step = long["liq_step"].where(
+    liquidation_day = long["liq_step"].where(
         long_liquidated & ~short_liquidated,
         short["liq_step"].where(
             short_liquidated & ~long_liquidated,
@@ -97,12 +95,8 @@ def _combine_hedged_multicoin_outputs(
     active = long["day_min_eq"].isfinite() & short["day_min_eq"].isfinite()
     day_count = int(active.shape[1])
     day_ids = active.new_tensor(range(day_count), dtype=long["liq_step"].dtype)
-    first_day = int(first_ts_ms) // 86_400_000
-    terminal_day = (
-        (int(first_ts_ms) + liq_step * int(interval_ms)) // 86_400_000
-    ) - first_day
     active &= (~(long_liquidated | short_liquidated)).unsqueeze(1) | (
-        day_ids.unsqueeze(0) < terminal_day.unsqueeze(1)
+        day_ids.unsqueeze(0) < liquidation_day.unsqueeze(1)
     )
 
     combined = {}
@@ -145,7 +139,7 @@ def _combine_hedged_multicoin_outputs(
     )
     combined["last_eq_ts"] = _nan_min(long["last_eq_ts"], short["last_eq_ts"])
 
-    combined["liq_step"] = liq_step
+    combined["liq_step"] = liquidation_day
     return combined
 
 
@@ -762,8 +756,6 @@ class MpsMulticoinEmaProxy:
                     side_outputs["long"],
                     side_outputs["short"],
                     self.run.starting_balance,
-                    self.metrics_data["ts0"],
-                    self.run.interval_ms,
                 )
             timestamp_origin = float(self.metrics_data["ts0"])
             for key in (

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -92,16 +92,16 @@ def _combine_hedged_multicoin_outputs(long: dict, short: dict, starting_balance:
             values = values.where(active, values.new_zeros(()))
         combined[key] = values
 
-    combined["day_max_dd"] = long["day_max_dd"].maximum(
-        short["day_max_dd"]
-    ).where(active, long["day_max_dd"].new_zeros(()))
+    combined["day_max_dd"] = (
+        long["day_max_dd"] + short["day_max_dd"]
+    ).clamp(max=1.0).where(active, long["day_max_dd"].new_zeros(()))
     combined["day_volume"] = (long["day_volume"] + short["day_volume"]).where(
         active, long["day_volume"].new_zeros(())
     )
     combined["day_has_fill"] = (
         long["day_has_fill"] | short["day_has_fill"]
     ) & active
-    combined["max_dd"] = long["max_dd"].maximum(short["max_dd"])
+    combined["max_dd"] = (long["max_dd"] + short["max_dd"]).clamp(max=1.0)
     combined["held_max_ms"] = long["held_max_ms"].maximum(short["held_max_ms"])
     combined["gap_hist"] = long["gap_hist"] + short["gap_hist"]
     combined["gap_max_ms"] = long["gap_max_ms"].maximum(short["gap_max_ms"])

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -49,6 +49,92 @@ def _require_complete_valid_tail(last_valid_idx: int, candle_count: int) -> None
         )
 
 
+def _nan_min(left, right):
+    """Elementwise minimum which preserves the finite operand when only one exists."""
+
+    left_finite = left.isfinite()
+    right_finite = right.isfinite()
+    return left.where(
+        left_finite & ~right_finite,
+        right.where(right_finite & ~left_finite, left.minimum(right)),
+    )
+
+
+def _nan_max(left, right):
+    """Elementwise maximum which preserves the finite operand when only one exists."""
+
+    left_finite = left.isfinite()
+    right_finite = right.isfinite()
+    return left.where(
+        left_finite & ~right_finite,
+        right.where(right_finite & ~left_finite, left.maximum(right)),
+    )
+
+
+def _combine_hedged_multicoin_outputs(long: dict, short: dict, starting_balance: float):
+    """Build a conservative portfolio surface from independent directional screens.
+
+    This is deliberately only a ranking proxy. The unchanged Rust backtest remains
+    authoritative for every accepted result and the optimizer's drift gates halt on
+    material disagreement.
+    """
+
+    long_active = long["day_min_eq"].isfinite()
+    short_active = short["day_min_eq"].isfinite()
+    active = long_active & short_active
+
+    combined = {}
+    for key in ("day_end_eq", "day_min_eq"):
+        values = long[key] + short[key] - float(starting_balance)
+        if key == "day_min_eq":
+            values = values.where(active, values.new_full((), float("inf")))
+        else:
+            values = values.where(active, values.new_zeros(()))
+        combined[key] = values
+
+    combined["day_max_dd"] = long["day_max_dd"].maximum(
+        short["day_max_dd"]
+    ).where(active, long["day_max_dd"].new_zeros(()))
+    combined["day_volume"] = (long["day_volume"] + short["day_volume"]).where(
+        active, long["day_volume"].new_zeros(())
+    )
+    combined["day_has_fill"] = (
+        long["day_has_fill"] | short["day_has_fill"]
+    ) & active
+    combined["max_dd"] = long["max_dd"].maximum(short["max_dd"])
+    combined["held_max_ms"] = long["held_max_ms"].maximum(short["held_max_ms"])
+    combined["gap_hist"] = long["gap_hist"] + short["gap_hist"]
+    combined["gap_max_ms"] = long["gap_max_ms"].maximum(short["gap_max_ms"])
+    combined["first_fill_ts"] = _nan_min(
+        long["first_fill_ts"], short["first_fill_ts"]
+    )
+    combined["last_fill_ts"] = _nan_max(
+        long["last_fill_ts"], short["last_fill_ts"]
+    )
+    combined["recovery_max_ms"] = long["recovery_max_ms"].maximum(
+        short["recovery_max_ms"]
+    )
+    # The earlier directional high produces the longer, safer final-recovery estimate.
+    combined["last_high_ts"] = _nan_min(
+        long["last_high_ts"], short["last_high_ts"]
+    )
+    combined["first_eq_ts"] = _nan_max(
+        long["first_eq_ts"], short["first_eq_ts"]
+    )
+    combined["last_eq_ts"] = _nan_min(long["last_eq_ts"], short["last_eq_ts"])
+
+    long_liquidated = long["liq_step"] >= 0
+    short_liquidated = short["liq_step"] >= 0
+    combined["liq_step"] = long["liq_step"].where(
+        long_liquidated & ~short_liquidated,
+        short["liq_step"].where(
+            short_liquidated & ~long_liquidated,
+            long["liq_step"].minimum(short["liq_step"]),
+        ),
+    )
+    return combined
+
+
 class MpsSingleCoinProxy:
     """Batched directional screening proxy for supported single-coin strategies."""
 
@@ -326,7 +412,7 @@ def _build_multicoin_ema_coin_overrides(
 
 
 class MpsMulticoinEmaProxy:
-    """Batched single-side multi-coin EMA Anchor screening proxy."""
+    """Batched multi-coin EMA Anchor screening proxy for one or two sides."""
 
     def __init__(
         self,
@@ -384,11 +470,36 @@ class MpsMulticoinEmaProxy:
         enabled_sides = [
             side for side in ("long", "short") if gpu_side_enabled(config, side)
         ]
-        if len(enabled_sides) != 1:
+        if len(enabled_sides) not in (1, 2):
             raise ValueError(
-                "MPS multicoin proxy currently requires exactly one enabled side"
+                "MPS multicoin proxy requires one or two enabled sides"
             )
-        self.side = enabled_sides[0]
+        self.sides = enabled_sides
+        if len(enabled_sides) == 2 and not bool(
+            config.get("live", {}).get("hedge_mode")
+        ):
+            raise ValueError(
+                "MPS dual-side multicoin proxy currently requires live.hedge_mode=true; "
+                "one-way arbitration is not modeled"
+            )
+        if len(enabled_sides) == 2 and (config.get("coin_overrides") or {}):
+            raise ValueError(
+                "MPS dual-side multicoin proxy does not yet support coin_overrides"
+            )
+        if len(enabled_sides) == 2:
+            approved = config.get("live", {}).get("approved_coins", {}) or {}
+            ignored = config.get("live", {}).get("ignored_coins", {}) or {}
+            for label, values_by_side in (
+                ("approved", approved),
+                ("ignored", ignored),
+            ):
+                if set(values_by_side.get("long", []) or []) != set(
+                    values_by_side.get("short", []) or []
+                ):
+                    raise ValueError(
+                        "MPS dual-side multicoin proxy requires matching "
+                        f"long/short {label}_coins"
+                    )
 
         payload = build_backtest_payload(
             np.ascontiguousarray(values),
@@ -429,47 +540,6 @@ class MpsMulticoinEmaProxy:
         for last_valid_idx in backtest_params["last_valid_indices"]:
             _require_complete_valid_tail(int(last_valid_idx), len(values))
 
-        first_bot = payload.bot_params_list[0][self.side]
-        first_strategy = dict(payload.strategy_params_list[0][self.side])
-        if bool(first_bot.get("unstuck_enabled")) or bool(first_bot.get("hsl_enabled")):
-            raise ValueError(
-                f"MPS multicoin proxy requires {self.side} HSL and unstuck disabled"
-            )
-        weights = first_bot.get("forager_score_weights", {}) or {}
-        first_strategy.update(
-            {
-                "entry_cooldown_minutes": float(
-                    first_bot.get("entry_cooldown_minutes", 0.0) or 0.0
-                ),
-                "total_wallet_exposure_limit": float(
-                    first_bot["total_wallet_exposure_limit"]
-                ),
-                "forager_volume_ema_span_1m": float(
-                    first_bot.get("filter_volume_ema_span_1m", 0.0) or 0.0
-                ),
-                "forager_volatility_ema_span_1m": float(
-                    first_bot.get("filter_volatility_ema_span_1m", 0.0) or 0.0
-                ),
-                "forager_volume_drop_pct": float(
-                    first_bot.get("filter_volume_drop_pct", 0.0) or 0.0
-                ),
-                "forager_score_weights_volume": float(weights.get("volume", 0.0)),
-                "forager_score_weights_ema_readiness": float(
-                    weights.get("ema_readiness", 0.0)
-                ),
-                "forager_score_weights_volatility": float(
-                    weights.get("volatility", 0.0)
-                ),
-                "n_positions": float(first_bot["n_positions"]),
-            }
-        )
-        missing = [
-            key for key in EMA_ANCHOR_MULTICOIN_PARAM_KEYS if key not in first_strategy
-        ]
-        if missing:
-            raise ValueError(f"MPS multicoin EMA payload is missing parameters: {missing}")
-        self.base_params = first_strategy
-
         comparable_bot_keys = (
             "total_wallet_exposure_limit",
             "filter_volume_ema_span_1m",
@@ -480,16 +550,67 @@ class MpsMulticoinEmaProxy:
             "unstuck_enabled",
             "hsl_enabled",
         )
-        for coin in range(1, coin_count):
-            strategy = payload.strategy_params_list[coin][self.side]
-            bot = payload.bot_params_list[coin][self.side]
-            if any(
-                bot.get(key) != first_bot.get(key) for key in comparable_bot_keys
+        self.base_params = {}
+        for side in self.sides:
+            first_bot = payload.bot_params_list[0][side]
+            first_strategy = dict(payload.strategy_params_list[0][side])
+            if bool(first_bot.get("unstuck_enabled")) or bool(
+                first_bot.get("hsl_enabled")
             ):
                 raise ValueError(
-                    "MPS multicoin proxy requires identical global "
-                    f"{self.side} forager/risk settings across coins"
+                    f"MPS multicoin proxy requires {side} HSL and unstuck disabled"
                 )
+            weights = first_bot.get("forager_score_weights", {}) or {}
+            first_strategy.update(
+                {
+                    "entry_cooldown_minutes": float(
+                        first_bot.get("entry_cooldown_minutes", 0.0) or 0.0
+                    ),
+                    "total_wallet_exposure_limit": float(
+                        first_bot["total_wallet_exposure_limit"]
+                    ),
+                    "forager_volume_ema_span_1m": float(
+                        first_bot.get("filter_volume_ema_span_1m", 0.0) or 0.0
+                    ),
+                    "forager_volatility_ema_span_1m": float(
+                        first_bot.get("filter_volatility_ema_span_1m", 0.0) or 0.0
+                    ),
+                    "forager_volume_drop_pct": float(
+                        first_bot.get("filter_volume_drop_pct", 0.0) or 0.0
+                    ),
+                    "forager_score_weights_volume": float(
+                        weights.get("volume", 0.0)
+                    ),
+                    "forager_score_weights_ema_readiness": float(
+                        weights.get("ema_readiness", 0.0)
+                    ),
+                    "forager_score_weights_volatility": float(
+                        weights.get("volatility", 0.0)
+                    ),
+                    "n_positions": float(first_bot["n_positions"]),
+                }
+            )
+            missing = [
+                key
+                for key in EMA_ANCHOR_MULTICOIN_PARAM_KEYS
+                if key not in first_strategy
+            ]
+            if missing:
+                raise ValueError(
+                    f"MPS multicoin EMA {side} payload is missing parameters: {missing}"
+                )
+            self.base_params[side] = first_strategy
+
+            for coin in range(1, coin_count):
+                bot = payload.bot_params_list[coin][side]
+                if any(
+                    bot.get(key) != first_bot.get(key)
+                    for key in comparable_bot_keys
+                ):
+                    raise ValueError(
+                        "MPS multicoin proxy requires identical global "
+                        f"{side} forager/risk settings across coins"
+                    )
 
         coins = list(backtest_params.get("coins") or [])
         if len(coins) != coin_count:
@@ -497,16 +618,28 @@ class MpsMulticoinEmaProxy:
                 "MPS multicoin payload coin identity disagrees with prepared data: "
                 f"coins={coins}, prepared={coin_count}"
             )
-        per_coin_overrides, self.coin_override_contract = (
-            _build_multicoin_ema_coin_overrides(
-                config=config,
-                mss=mss,
-                exchange=exchange,
-                coins=coins,
-                payload=payload,
-                side=self.side,
+        per_side_coin_overrides = {}
+        if len(self.sides) == 1:
+            side = self.sides[0]
+            overrides, self.coin_override_contract = (
+                _build_multicoin_ema_coin_overrides(
+                    config=config,
+                    mss=mss,
+                    exchange=exchange,
+                    coins=coins,
+                    payload=payload,
+                    side=side,
+                )
             )
-        )
+            per_side_coin_overrides[side] = overrides
+        else:
+            self.coin_override_contract = {
+                "exchange": exchange,
+                "coins": coins,
+                "sides": list(self.sides),
+                "proxy_mode": "independent-side-hedge-v1",
+            }
+            per_side_coin_overrides = {side: None for side in self.sides}
 
         markets = [
             ProxyMarket(
@@ -556,22 +689,31 @@ class MpsMulticoinEmaProxy:
             values, timestamps, runs=runs, markets=markets
         )
         self.metrics_data = {"ts0": self.data["ts0"], "n": self.data["n"]}
-        self.runner = MpsEmaAnchorMulticoinRunner(
-            self.run,
-            self.data,
-            side=self.side,
-            coin_overrides=per_coin_overrides,
-        )
+        self.runners = {
+            side: MpsEmaAnchorMulticoinRunner(
+                self.run,
+                self.data,
+                side=side,
+                coin_overrides=per_side_coin_overrides[side],
+            )
+            for side in self.sides
+        }
 
-    def _parameter_matrix(self, candidates: list[dict]) -> np.ndarray:
+    def _parameter_matrix(
+        self, candidates: list[dict], side: str | None = None
+    ) -> np.ndarray:
+        if side is None:
+            if len(self.sides) != 1:
+                raise ValueError("side is required for dual-side multicoin parameters")
+            side = self.sides[0]
         rows = []
         for candidate in candidates:
-            merged = dict(self.base_params)
+            merged = dict(self.base_params[side])
             merged.update(
                 {
-                    key.removeprefix(f"{self.side}_"): value
+                    key.removeprefix(f"{side}_"): value
                     for key, value in candidate.items()
-                    if key.startswith(f"{self.side}_")
+                    if key.startswith(f"{side}_")
                 }
             )
             rows.append(
@@ -584,14 +726,29 @@ class MpsMulticoinEmaProxy:
         torch = self._torch
         for start in range(0, len(candidates), self.batch_size):
             chunk = candidates[start : start + self.batch_size]
-            output = self.runner.run(
-                self._parameter_matrix(chunk), profile=self.profile_enabled
-            )
-            output = {
-                key: value.cpu()
-                for key, value in output.items()
-                if key in CORE_OUTPUT_KEYS
+            raw_side_outputs = {
+                side: self.runners[side].run(
+                    self._parameter_matrix(chunk, side),
+                    profile=self.profile_enabled,
+                )
+                for side in self.sides
             }
+            side_outputs = {
+                side: {
+                    key: value.cpu()
+                    for key, value in raw_side_outputs[side].items()
+                    if key in CORE_OUTPUT_KEYS
+                }
+                for side in self.sides
+            }
+            if len(self.sides) == 1:
+                output = side_outputs[self.sides[0]]
+            else:
+                output = _combine_hedged_multicoin_outputs(
+                    side_outputs["long"],
+                    side_outputs["short"],
+                    self.run.starting_balance,
+                )
             timestamp_origin = float(self.metrics_data["ts0"])
             for key in (
                 "first_fill_ts",

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -50,6 +50,7 @@ from optimization.backends.gpu_backend import (
     _select_validation_indices,
     _update_probe_shortfall_log,
     _validate_directional_search_space,
+    _validate_dual_multicoin_metrics,
     _validate_gpu_optimizer_overrides,
     _validate_gpu_coin_overrides,
     _validate_pinned_scope_bounds,
@@ -1100,6 +1101,26 @@ def test_gpu_multicoin_foundation_rejects_asymmetric_dual_side_coins():
 
     with pytest.raises(ValueError, match="matching long/short approved_coins"):
         _validate_scope(config, _MulticoinEvaluator())
+
+
+@pytest.mark.parametrize(
+    "metric", ["fills_gap_longest_days", "strategy_eq_recovery_days_max"]
+)
+def test_gpu_dual_multicoin_rejects_unreconstructable_metrics(metric):
+    with pytest.raises(ValueError, match=metric):
+        _validate_dual_multicoin_metrics(
+            {metric, "adg_strategy_eq"},
+            coin_count=3,
+            enabled_sides={"long", "short"},
+        )
+
+
+def test_gpu_dual_multicoin_metric_gate_does_not_narrow_single_side():
+    _validate_dual_multicoin_metrics(
+        {"fills_gap_longest_days", "strategy_eq_recovery_days_max"},
+        coin_count=3,
+        enabled_sides={"long"},
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1104,7 +1104,12 @@ def test_gpu_multicoin_foundation_rejects_asymmetric_dual_side_coins():
 
 
 @pytest.mark.parametrize(
-    "metric", ["fills_gap_longest_days", "strategy_eq_recovery_days_max"]
+    "metric",
+    [
+        "fills_gap_longest_days",
+        "strategy_eq_recovery_days_max",
+        "volume_pct_per_day_avg",
+    ],
 )
 def test_gpu_dual_multicoin_rejects_unreconstructable_metrics(metric):
     with pytest.raises(ValueError, match=metric):
@@ -1117,7 +1122,11 @@ def test_gpu_dual_multicoin_rejects_unreconstructable_metrics(metric):
 
 def test_gpu_dual_multicoin_metric_gate_does_not_narrow_single_side():
     _validate_dual_multicoin_metrics(
-        {"fills_gap_longest_days", "strategy_eq_recovery_days_max"},
+        {
+            "fills_gap_longest_days",
+            "strategy_eq_recovery_days_max",
+            "volume_pct_per_day_avg",
+        },
         coin_count=3,
         enabled_sides={"long"},
     )

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1044,15 +1044,61 @@ def test_gpu_multicoin_foundation_fails_closed_for_unsupported_scope(
         _validate_scope(config, _MulticoinEvaluator())
 
 
-def test_gpu_multicoin_foundation_rejects_hedge_mode():
+def test_gpu_multicoin_foundation_accepts_dual_side_hedge_mode():
     config = _directional_ema_config(long_enabled=True, short_enabled=True)
     config["live"]["approved_coins"] = {
         "long": ["BTC", "ETH", "SOL"],
         "short": ["BTC", "ETH", "SOL"],
     }
+    config["live"]["hedge_mode"] = True
     config["live"]["forager_score_hysteresis_pct"] = 0.0
     config["backtest"]["dynamic_wel_by_tradability"] = True
+
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
+
+
+def test_gpu_multicoin_foundation_rejects_dual_side_one_way_mode():
+    config = _directional_ema_config(long_enabled=True, short_enabled=True)
+    config["live"]["approved_coins"] = {
+        "long": ["BTC", "ETH", "SOL"],
+        "short": ["BTC", "ETH", "SOL"],
+    }
+    config["live"]["hedge_mode"] = False
+    config["live"]["forager_score_hysteresis_pct"] = 0.0
+    config["backtest"]["dynamic_wel_by_tradability"] = True
+
+    with pytest.raises(ValueError, match="one-way arbitration is not modeled"):
+        _validate_scope(config, _MulticoinEvaluator())
+
+
+def test_gpu_multicoin_foundation_rejects_dual_side_coin_overrides():
+    config = _directional_ema_config(long_enabled=True, short_enabled=True)
+    config["live"]["approved_coins"] = {
+        "long": ["BTC", "ETH", "SOL"],
+        "short": ["BTC", "ETH", "SOL"],
+    }
+    config["live"]["hedge_mode"] = True
+    config["live"]["forager_score_hysteresis_pct"] = 0.0
+    config["backtest"]["dynamic_wel_by_tradability"] = True
+    config["coin_overrides"] = {
+        "ETH": {"bot": {"long": {"wallet_exposure_limit": 0.5}}}
+    }
+
     with pytest.raises(ValueError, match="exactly one enabled side"):
+        _validate_scope(config, _MulticoinEvaluator())
+
+
+def test_gpu_multicoin_foundation_rejects_asymmetric_dual_side_coins():
+    config = _directional_ema_config(long_enabled=True, short_enabled=True)
+    config["live"]["approved_coins"] = {
+        "long": ["BTC", "ETH", "SOL"],
+        "short": ["BTC", "ETH"],
+    }
+    config["live"]["hedge_mode"] = True
+    config["live"]["forager_score_hysteresis_pct"] = 0.0
+    config["backtest"]["dynamic_wel_by_tradability"] = True
+
+    with pytest.raises(ValueError, match="matching long/short approved_coins"):
         _validate_scope(config, _MulticoinEvaluator())
 
 

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -209,6 +209,8 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
     assert "kernel void passivbot_ema_anchor_multicoin" in source
     assert "kernel void passivbot_ema_anchor_multicoin_long" in source
     assert "constant int OVERRIDE_COLS = 12" in source
+    assert "constant int DAILY_COLS = 6" in source
+    assert "day_min_balance" in source
     assert "coin_override_or" in source
     count = 512
     coin_count = 3
@@ -271,6 +273,10 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
     assert output["balance"].device.type == "mps"
     assert output["balance"].shape == (2,)
     assert torch.isfinite(output["balance"]).all()
+    assert output["day_min_balance"].shape == output["day_min_eq"].shape
+    assert torch.isfinite(
+        output["day_min_balance"][output["day_min_eq"].isfinite()]
+    ).all()
     assert output["day_has_fill"].sum().item() > 0
     assert (output["open_positions"] <= 2.0).all()
 

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -126,7 +126,9 @@ def test_combine_hedged_multicoin_outputs_uses_conservative_surface():
     short["recovery_max_ms"] = torch.tensor([500.0])
     short["last_high_ts"] = torch.tensor([800.0])
 
-    combined = _combine_hedged_multicoin_outputs(long, short, 1_000.0)
+    combined = _combine_hedged_multicoin_outputs(
+        long, short, 1_000.0, 0.05, 0, 60_000
+    )
 
     assert combined["day_end_eq"].tolist() == [[1_050.0, 1_100.0]]
     assert combined["day_min_eq"].tolist() == [[975.0, 950.0]]
@@ -141,7 +143,9 @@ def test_combine_hedged_multicoin_outputs_uses_conservative_surface():
 
     short["day_min_eq"][0, 1] = float("inf")
     short["last_eq_ts"] = torch.tensor([800.0])
-    truncated = _combine_hedged_multicoin_outputs(long, short, 1_000.0)
+    truncated = _combine_hedged_multicoin_outputs(
+        long, short, 1_000.0, 0.05, 0, 60_000
+    )
     assert truncated["day_end_eq"][0, 1].item() == 0.0
     assert torch.isinf(truncated["day_min_eq"][0, 1])
     assert truncated["day_volume"][0, 1].item() == 0.0
@@ -150,11 +154,48 @@ def test_combine_hedged_multicoin_outputs_uses_conservative_surface():
 
     short["day_min_eq"][0, 1] = 850.0
     long["liq_step"] = torch.tensor([1])
-    liquidated = _combine_hedged_multicoin_outputs(long, short, 1_000.0)
+    liquidated = _combine_hedged_multicoin_outputs(
+        long, short, 1_000.0, 0.05, 0, 60_000
+    )
     assert torch.isfinite(liquidated["day_min_eq"][0, 0])
     assert torch.isinf(liquidated["day_min_eq"][0, 1])
     assert liquidated["day_end_eq"][0, 1].item() == 0.0
     assert liquidated["liq_step"].item() == 1
+
+
+def test_combine_hedged_multicoin_outputs_detects_shared_equity_liquidation():
+    torch = pytest.importorskip("torch")
+
+    def side_output():
+        return {
+            "day_end_eq": torch.tensor([[1_000.0, 520.0, 900.0]]),
+            "day_min_eq": torch.tensor([[900.0, 520.0, 800.0]]),
+            "day_max_dd": torch.tensor([[0.10, 0.48, 0.20]]),
+            "day_volume": torch.tensor([[0.1, 0.1, 0.1]]),
+            "day_has_fill": torch.tensor([[True, True, True]]),
+            "max_dd": torch.tensor([0.48]),
+            "held_max_ms": torch.tensor([100.0]),
+            "gap_hist": torch.tensor([[1, 2]]),
+            "gap_max_ms": torch.tensor([300.0]),
+            "first_fill_ts": torch.tensor([100.0]),
+            "last_fill_ts": torch.tensor([200_000_000.0]),
+            "recovery_max_ms": torch.tensor([400.0]),
+            "last_high_ts": torch.tensor([1_000.0]),
+            "first_eq_ts": torch.tensor([0.0]),
+            "last_eq_ts": torch.tensor([200_000_000.0]),
+            "liq_step": torch.tensor([-1]),
+        }
+
+    combined = _combine_hedged_multicoin_outputs(
+        side_output(), side_output(), 1_000.0, 0.05, 0, 60_000
+    )
+
+    assert combined["liq_step"].item() == 1
+    assert torch.isfinite(combined["day_min_eq"][0, 0])
+    assert torch.isinf(combined["day_min_eq"][0, 1])
+    assert torch.isinf(combined["day_min_eq"][0, 2])
+    assert combined["day_end_eq"][0, 1].item() == 0.0
+    assert combined["last_eq_ts"].item() == 86_340_000.0
 
 
 def test_multicoin_coin_overrides_pack_only_explicit_exact_values():

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -89,6 +89,7 @@ def test_combine_hedged_multicoin_outputs_uses_conservative_surface():
             "day_max_dd": torch.tensor([[0.10, 0.20]]),
             "day_volume": torch.tensor([[0.4, 0.5]]),
             "day_has_fill": torch.tensor([fill]),
+            "day_min_balance": torch.tensor([[1_000.0, 1_000.0]]),
             "max_dd": torch.tensor([0.20]),
             "held_max_ms": torch.tensor([100.0]),
             "gap_hist": torch.tensor([[1, 2]]),
@@ -173,6 +174,7 @@ def test_combine_hedged_multicoin_outputs_detects_shared_equity_liquidation():
             "day_max_dd": torch.tensor([[0.10, 0.48, 0.20]]),
             "day_volume": torch.tensor([[0.1, 0.1, 0.1]]),
             "day_has_fill": torch.tensor([[True, True, True]]),
+            "day_min_balance": torch.tensor([[900.0, 900.0, 900.0]]),
             "max_dd": torch.tensor([0.48]),
             "held_max_ms": torch.tensor([100.0]),
             "gap_hist": torch.tensor([[1, 2]]),
@@ -195,6 +197,42 @@ def test_combine_hedged_multicoin_outputs_detects_shared_equity_liquidation():
     assert torch.isinf(combined["day_min_eq"][0, 1])
     assert torch.isinf(combined["day_min_eq"][0, 2])
     assert combined["day_end_eq"][0, 1].item() == 0.0
+    assert combined["last_eq_ts"].item() == 86_340_000.0
+
+
+def test_combine_hedged_multicoin_outputs_detects_shared_balance_depletion():
+    torch = pytest.importorskip("torch")
+
+    def side_output():
+        return {
+            "day_end_eq": torch.tensor([[900.0, 600.0, 800.0]]),
+            "day_min_eq": torch.tensor([[800.0, 600.0, 700.0]]),
+            "day_max_dd": torch.tensor([[0.10, 0.40, 0.30]]),
+            "day_volume": torch.tensor([[0.1, 0.1, 0.1]]),
+            "day_has_fill": torch.tensor([[True, True, True]]),
+            "day_min_balance": torch.tensor([[900.0, 450.0, 700.0]]),
+            "max_dd": torch.tensor([0.40]),
+            "held_max_ms": torch.tensor([100.0]),
+            "gap_hist": torch.tensor([[1, 2]]),
+            "gap_max_ms": torch.tensor([300.0]),
+            "first_fill_ts": torch.tensor([100.0]),
+            "last_fill_ts": torch.tensor([200_000_000.0]),
+            "recovery_max_ms": torch.tensor([400.0]),
+            "last_high_ts": torch.tensor([1_000.0]),
+            "first_eq_ts": torch.tensor([0.0]),
+            "last_eq_ts": torch.tensor([200_000_000.0]),
+            "liq_step": torch.tensor([-1]),
+        }
+
+    combined = _combine_hedged_multicoin_outputs(
+        side_output(), side_output(), 1_000.0, 0.05, 0, 60_000
+    )
+
+    # Combined equity remains 200, above the 50 floor, while conservative
+    # combined realized balance is -100 and must terminate the screen.
+    assert combined["liq_step"].item() == 1
+    assert torch.isfinite(combined["day_min_eq"][0, 0])
+    assert torch.isinf(combined["day_min_eq"][0, 1])
     assert combined["last_eq_ts"].item() == 86_340_000.0
 
 

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -126,9 +126,7 @@ def test_combine_hedged_multicoin_outputs_uses_conservative_surface():
     short["recovery_max_ms"] = torch.tensor([500.0])
     short["last_high_ts"] = torch.tensor([800.0])
 
-    combined = _combine_hedged_multicoin_outputs(
-        long, short, 1_000.0, 0, 60_000
-    )
+    combined = _combine_hedged_multicoin_outputs(long, short, 1_000.0)
 
     assert combined["day_end_eq"].tolist() == [[1_050.0, 1_100.0]]
     assert combined["day_min_eq"].tolist() == [[975.0, 950.0]]
@@ -143,9 +141,7 @@ def test_combine_hedged_multicoin_outputs_uses_conservative_surface():
 
     short["day_min_eq"][0, 1] = float("inf")
     short["last_eq_ts"] = torch.tensor([800.0])
-    truncated = _combine_hedged_multicoin_outputs(
-        long, short, 1_000.0, 0, 60_000
-    )
+    truncated = _combine_hedged_multicoin_outputs(long, short, 1_000.0)
     assert truncated["day_end_eq"][0, 1].item() == 0.0
     assert torch.isinf(truncated["day_min_eq"][0, 1])
     assert truncated["day_volume"][0, 1].item() == 0.0
@@ -153,14 +149,12 @@ def test_combine_hedged_multicoin_outputs_uses_conservative_surface():
     assert truncated["last_eq_ts"].item() == 800.0
 
     short["day_min_eq"][0, 1] = 850.0
-    long["liq_step"] = torch.tensor([1_500])
-    liquidated = _combine_hedged_multicoin_outputs(
-        long, short, 1_000.0, 0, 60_000
-    )
+    long["liq_step"] = torch.tensor([1])
+    liquidated = _combine_hedged_multicoin_outputs(long, short, 1_000.0)
     assert torch.isfinite(liquidated["day_min_eq"][0, 0])
     assert torch.isinf(liquidated["day_min_eq"][0, 1])
     assert liquidated["day_end_eq"][0, 1].item() == 0.0
-    assert liquidated["liq_step"].item() == 1_500
+    assert liquidated["liq_step"].item() == 1
 
 
 def test_multicoin_coin_overrides_pack_only_explicit_exact_values():

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -130,7 +130,8 @@ def test_combine_hedged_multicoin_outputs_uses_conservative_surface():
 
     assert combined["day_end_eq"].tolist() == [[1_050.0, 1_100.0]]
     assert combined["day_min_eq"].tolist() == [[975.0, 950.0]]
-    np.testing.assert_allclose(combined["day_max_dd"].numpy(), [[0.10, 0.30]])
+    np.testing.assert_allclose(combined["day_max_dd"].numpy(), [[0.15, 0.50]])
+    assert combined["max_dd"].item() == pytest.approx(0.50)
     np.testing.assert_allclose(combined["day_volume"].numpy(), [[0.5, 0.7]])
     assert combined["day_has_fill"].tolist() == [[True, True]]
     assert combined["first_fill_ts"].item() == 300.0

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -108,7 +108,7 @@ def test_combine_hedged_multicoin_outputs_uses_conservative_surface():
         fill=[True, False],
         first_fill=float("nan"),
         last_fill=700.0,
-        liq=25,
+        liq=-1,
     )
     short = side_output(
         end=[950.0, 900.0],
@@ -116,7 +116,7 @@ def test_combine_hedged_multicoin_outputs_uses_conservative_surface():
         fill=[False, True],
         first_fill=300.0,
         last_fill=float("nan"),
-        liq=10,
+        liq=-1,
     )
     short["day_max_dd"] = torch.tensor([[0.05, 0.30]])
     short["day_volume"] = torch.tensor([[0.1, 0.2]])
@@ -126,7 +126,9 @@ def test_combine_hedged_multicoin_outputs_uses_conservative_surface():
     short["recovery_max_ms"] = torch.tensor([500.0])
     short["last_high_ts"] = torch.tensor([800.0])
 
-    combined = _combine_hedged_multicoin_outputs(long, short, 1_000.0)
+    combined = _combine_hedged_multicoin_outputs(
+        long, short, 1_000.0, 0, 60_000
+    )
 
     assert combined["day_end_eq"].tolist() == [[1_050.0, 1_100.0]]
     assert combined["day_min_eq"].tolist() == [[975.0, 950.0]]
@@ -137,16 +139,28 @@ def test_combine_hedged_multicoin_outputs_uses_conservative_surface():
     assert combined["first_fill_ts"].item() == 300.0
     assert combined["last_fill_ts"].item() == 700.0
     assert combined["last_high_ts"].item() == 800.0
-    assert combined["liq_step"].item() == 10
+    assert combined["liq_step"].item() == -1
 
     short["day_min_eq"][0, 1] = float("inf")
     short["last_eq_ts"] = torch.tensor([800.0])
-    truncated = _combine_hedged_multicoin_outputs(long, short, 1_000.0)
+    truncated = _combine_hedged_multicoin_outputs(
+        long, short, 1_000.0, 0, 60_000
+    )
     assert truncated["day_end_eq"][0, 1].item() == 0.0
     assert torch.isinf(truncated["day_min_eq"][0, 1])
     assert truncated["day_volume"][0, 1].item() == 0.0
     assert not truncated["day_has_fill"][0, 1].item()
     assert truncated["last_eq_ts"].item() == 800.0
+
+    short["day_min_eq"][0, 1] = 850.0
+    long["liq_step"] = torch.tensor([1_500])
+    liquidated = _combine_hedged_multicoin_outputs(
+        long, short, 1_000.0, 0, 60_000
+    )
+    assert torch.isfinite(liquidated["day_min_eq"][0, 0])
+    assert torch.isinf(liquidated["day_min_eq"][0, 1])
+    assert liquidated["day_end_eq"][0, 1].item() == 0.0
+    assert liquidated["liq_step"].item() == 1_500
 
 
 def test_multicoin_coin_overrides_pack_only_explicit_exact_values():

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -14,6 +14,7 @@ from optimization.gpu.service import (
     MpsEmaAnchorProxy,
     MpsMulticoinEmaProxy,
     _build_multicoin_ema_coin_overrides,
+    _combine_hedged_multicoin_outputs,
     _require_complete_valid_tail,
 )
 
@@ -46,9 +47,9 @@ def test_directional_parameter_matrix_keeps_side_values_separate():
 @pytest.mark.parametrize(("side", "base"), [("long", 1.0), ("short", 2.0)])
 def test_multicoin_parameter_matrix_uses_only_enabled_side(side, base):
     proxy = MpsMulticoinEmaProxy.__new__(MpsMulticoinEmaProxy)
-    proxy.side = side
+    proxy.sides = [side]
     proxy.base_params = {
-        key: base for key in EMA_ANCHOR_MULTICOIN_PARAM_KEYS
+        side: {key: base for key in EMA_ANCHOR_MULTICOIN_PARAM_KEYS}
     }
 
     other_side = "short" if side == "long" else "long"
@@ -59,6 +60,92 @@ def test_multicoin_parameter_matrix_uses_only_enabled_side(side, base):
     assert matrix.shape == (1, len(EMA_ANCHOR_MULTICOIN_PARAM_KEYS))
     offset_index = EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("offset")
     assert matrix[0, offset_index] == 0.125
+
+
+def test_multicoin_parameter_matrix_keeps_dual_side_values_separate():
+    proxy = MpsMulticoinEmaProxy.__new__(MpsMulticoinEmaProxy)
+    proxy.sides = ["long", "short"]
+    proxy.base_params = {
+        "long": {key: 1.0 for key in EMA_ANCHOR_MULTICOIN_PARAM_KEYS},
+        "short": {key: 2.0 for key in EMA_ANCHOR_MULTICOIN_PARAM_KEYS},
+    }
+    candidate = {"long_offset": 0.125, "short_offset": 0.25}
+
+    long_matrix = proxy._parameter_matrix([candidate], "long")
+    short_matrix = proxy._parameter_matrix([candidate], "short")
+
+    offset_index = EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("offset")
+    assert long_matrix[0, offset_index] == 0.125
+    assert short_matrix[0, offset_index] == 0.25
+
+
+def test_combine_hedged_multicoin_outputs_uses_conservative_surface():
+    torch = pytest.importorskip("torch")
+
+    def side_output(*, end, minimum, fill, first_fill, last_fill, liq):
+        return {
+            "day_end_eq": torch.tensor([end], dtype=torch.float64),
+            "day_min_eq": torch.tensor([minimum], dtype=torch.float64),
+            "day_max_dd": torch.tensor([[0.10, 0.20]]),
+            "day_volume": torch.tensor([[0.4, 0.5]]),
+            "day_has_fill": torch.tensor([fill]),
+            "max_dd": torch.tensor([0.20]),
+            "held_max_ms": torch.tensor([100.0]),
+            "gap_hist": torch.tensor([[1, 2]]),
+            "gap_max_ms": torch.tensor([300.0]),
+            "first_fill_ts": torch.tensor([first_fill]),
+            "last_fill_ts": torch.tensor([last_fill]),
+            "recovery_max_ms": torch.tensor([400.0]),
+            "last_high_ts": torch.tensor([900.0]),
+            "first_eq_ts": torch.tensor([100.0]),
+            "last_eq_ts": torch.tensor([1_000.0]),
+            "liq_step": torch.tensor([liq]),
+        }
+
+    long = side_output(
+        end=[1_100.0, 1_200.0],
+        minimum=[1_050.0, 1_100.0],
+        fill=[True, False],
+        first_fill=float("nan"),
+        last_fill=700.0,
+        liq=25,
+    )
+    short = side_output(
+        end=[950.0, 900.0],
+        minimum=[925.0, 850.0],
+        fill=[False, True],
+        first_fill=300.0,
+        last_fill=float("nan"),
+        liq=10,
+    )
+    short["day_max_dd"] = torch.tensor([[0.05, 0.30]])
+    short["day_volume"] = torch.tensor([[0.1, 0.2]])
+    short["max_dd"] = torch.tensor([0.30])
+    short["held_max_ms"] = torch.tensor([200.0])
+    short["gap_max_ms"] = torch.tensor([250.0])
+    short["recovery_max_ms"] = torch.tensor([500.0])
+    short["last_high_ts"] = torch.tensor([800.0])
+
+    combined = _combine_hedged_multicoin_outputs(long, short, 1_000.0)
+
+    assert combined["day_end_eq"].tolist() == [[1_050.0, 1_100.0]]
+    assert combined["day_min_eq"].tolist() == [[975.0, 950.0]]
+    np.testing.assert_allclose(combined["day_max_dd"].numpy(), [[0.10, 0.30]])
+    np.testing.assert_allclose(combined["day_volume"].numpy(), [[0.5, 0.7]])
+    assert combined["day_has_fill"].tolist() == [[True, True]]
+    assert combined["first_fill_ts"].item() == 300.0
+    assert combined["last_fill_ts"].item() == 700.0
+    assert combined["last_high_ts"].item() == 800.0
+    assert combined["liq_step"].item() == 10
+
+    short["day_min_eq"][0, 1] = float("inf")
+    short["last_eq_ts"] = torch.tensor([800.0])
+    truncated = _combine_hedged_multicoin_outputs(long, short, 1_000.0)
+    assert truncated["day_end_eq"][0, 1].item() == 0.0
+    assert torch.isinf(truncated["day_min_eq"][0, 1])
+    assert truncated["day_volume"][0, 1].item() == 0.0
+    assert not truncated["day_has_fill"][0, 1].item()
+    assert truncated["last_eq_ts"].item() == 800.0
 
 
 def test_multicoin_coin_overrides_pack_only_explicit_exact_values():


### PR DESCRIPTION
## Summary
- support experimental Apple MPS multi-coin EMA Anchor screening with both long and short enabled in hedge mode
- dispatch the established directional Metal kernel once per side and combine compact outputs conservatively while exact Rust remains authoritative
- fail closed for one-way arbitration, asymmetric directional coin universes, dual-side suites, and dual-side coin overrides
- include the proxy topology in checkpoint identity and document the additive scope

## Safety model
- exact Rust metrics remain the only persisted/Pareto results
- existing constraint-classification, rank, and drift gates remain mandatory
- early termination on either directional screen truncates the combined proxy at their common valid span
- normal CPU optimization, backtesting, and bot operation are unchanged

## Validation
- full Python test suite
- 52 targeted GPU service and real Apple MPS tests
- `cargo test --no-default-features` (260 passed)
- `cargo check --tests`
- AI documentation contract check (0 errors; 2 pre-existing size warnings)
- real M3 end-to-end BTC/ETH/SOL dual-side hedge-mode smoke: 2,048 paired Metal proxy evaluations plus 64 exact Rust validations, completed in 14.1 seconds without a safety halt