### PR TITLE
feat(gpu): support Forager score hysteresis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added Apple MPS multi-coin EMA Anchor optimizer support for Forager score hysteresis, retaining
+  flat incumbent candidates when challenger scores are only marginally better.
+
 - Add dual-side hedge-mode multi-coin EMA-anchor optimization to the experimental Apple MPS
   backend. Metal screens long and short independently and combines their compact outputs into a
   conservative portfolio proxy, while unchanged exact Rust backtests remain authoritative and the

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -106,7 +106,9 @@ The supported slice is intentionally narrow:
 - long-only, short-only, or dual-side hedge-mode multi-coin EMA-anchor runs for up to 64 coins,
   with dynamic wallet-exposure allocation and independent per-side Forager selection; dual-side
   runs require matching long/short approved and ignored coin sets, and all multi-coin runs require
-  `backtest.dynamic_wel_by_tradability: true` and `live.forager_score_hysteresis_pct: 0`
+  `backtest.dynamic_wel_by_tradability: true`; `live.forager_score_hysteresis_pct` preserves flat
+  incumbent candidates when a challenger's normalized Forager-score lead is within the configured
+  gap
 - each enabled side's `n_positions` pinned to `1` and wallet-exposure limit kept positive
   for single-coin runs; supported multi-coin bounds may vary `n_positions` between `1` and the
   prepared coin count

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -67,6 +67,9 @@ mod tests {
         assert!(source.contains("entry_tick[c] > fill_ticks[tick_offset + 1]"));
         assert!(source.contains("const float volume_drop = clamp(params[po + 14]"));
         assert!(source.contains("effective_n_positions"));
+        assert!(source.contains("const float score_hysteresis = fmax(run_settings[4], 0.0f)"));
+        assert!(source.contains("incumbent[c] = selected[c] && psize[c] <= 0.0f"));
+        assert!(source.contains("score[challenger] - score[incumbent_coin]"));
         assert!(source.contains("float total_cap = twel - 1.0e-7f"));
         assert!(source.contains("= fma("));
         assert!(!source.contains("unstuck"));

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -69,6 +69,7 @@ mod tests {
         assert!(source.contains("effective_n_positions"));
         assert!(source.contains("const float score_hysteresis = fmax(run_settings[4], 0.0f)"));
         assert!(source.contains("incumbent[c] = selected[c] && psize[c] <= 0.0f"));
+        assert!(source.contains("if (!selected[c] || incumbent[c] || !survivor[c]) continue"));
         assert!(source.contains("score[challenger] - score[incumbent_coin]"));
         assert!(source.contains("float total_cap = twel - 1.0e-7f"));
         assert!(source.contains("= fma("));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -542,7 +542,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
 
                         int challenger = -1;
                         for (int c = 0; c < C; ++c) {
-                            if (!selected[c] || incumbent[c]) continue;
+                            if (!selected[c] || incumbent[c] || !survivor[c]) continue;
                             if (challenger < 0 || score[c] < score[challenger]
                                 || (score[c] == score[challenger] && c > challenger)) {
                                 challenger = c;

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -120,6 +120,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
     const float starting_balance = run_settings[0];
     const float liquidation_floor = run_settings[1];
     const float interval_ms = run_settings[2];
+    const float score_hysteresis = fmax(run_settings[4], 0.0f);
     const float log_bin_scale = 127.0f / log(4000001.0f);
 
     float ema0[MAX_COINS];
@@ -143,6 +144,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
     int entry_tick[MAX_COINS];
     int close_tick[MAX_COINS];
     bool selected[MAX_COINS];
+    bool incumbent[MAX_COINS];
     bool survivor[MAX_COINS];
     bool entry_candidate[MAX_COINS];
     float alpha0_coin[MAX_COINS];
@@ -179,6 +181,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
         entry_tick[c] = 0;
         close_tick[c] = 0;
         selected[c] = false;
+        incumbent[c] = false;
         survivor[c] = false;
         entry_candidate[c] = false;
         if (c < C) {
@@ -419,6 +422,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
             if (reselect) {
                 int active_count = 0;
                 for (int c = 0; c < C; ++c) {
+                    incumbent[c] = selected[c] && psize[c] <= 0.0f;
                     selected[c] = psize[c] > 0.0f;
                     if (selected[c]) active_count += 1;
                     survivor[c] = false;
@@ -518,6 +522,43 @@ inline void passivbot_ema_anchor_multicoin_impl(
                         }
                     }
                     if (best >= 0) selected[best] = true;
+                }
+                if (score_hysteresis > 0.0f) {
+                    // Match Rust's score hysteresis: consider incumbent flat
+                    // candidates from best to worst, then displace only the
+                    // weakest selected non-incumbent challenger when its
+                    // normalized-score lead is within the configured gap.
+                    for (int rank = 0; rank < C; ++rank) {
+                        int incumbent_coin = -1;
+                        for (int c = 0; c < C; ++c) {
+                            if (!survivor[c] || !incumbent[c] || selected[c]) continue;
+                            if (incumbent_coin < 0 || score[c] > score[incumbent_coin]
+                                || (score[c] == score[incumbent_coin]
+                                    && c < incumbent_coin)) {
+                                incumbent_coin = c;
+                            }
+                        }
+                        if (incumbent_coin < 0) break;
+
+                        int challenger = -1;
+                        for (int c = 0; c < C; ++c) {
+                            if (!selected[c] || incumbent[c]) continue;
+                            if (challenger < 0 || score[c] < score[challenger]
+                                || (score[c] == score[challenger] && c > challenger)) {
+                                challenger = c;
+                            }
+                        }
+                        if (challenger < 0) break;
+                        if (score[challenger] - score[incumbent_coin]
+                            <= score_hysteresis) {
+                            selected[challenger] = false;
+                            selected[incumbent_coin] = true;
+                        } else {
+                            // Rust continues to lower-scored incumbents, but
+                            // none can satisfy the gap once the best cannot.
+                            break;
+                        }
+                    }
                 }
                 selection_initialized = true;
                 previous_effective_n_positions = effective_n_positions;

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -767,17 +767,6 @@ def _validate_scope_config(
                 "GPU multicoin foundation requires "
                 "backtest.dynamic_wel_by_tradability=true"
             )
-        if (
-            float(
-                config.get("live", {}).get("forager_score_hysteresis_pct", 0.0)
-                or 0.0
-            )
-            != 0.0
-        ):
-            raise ValueError(
-                "GPU multicoin foundation requires "
-                "live.forager_score_hysteresis_pct=0"
-            )
     _validate_gpu_coin_overrides(
         config,
         strategy_kind=strategy_kind,

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -310,6 +310,7 @@ class MpsEmaAnchorMulticoinRunner:
         *,
         side: str,
         coin_overrides: np.ndarray | None = None,
+        forager_score_hysteresis_pct: float = 0.0,
     ):
         if side not in {"long", "short"}:
             raise ValueError(
@@ -335,11 +336,24 @@ class MpsEmaAnchorMulticoinRunner:
         self.coin_overrides = torch.as_tensor(
             np.ascontiguousarray(coin_overrides), device="mps"
         )
+        forager_score_hysteresis_pct = float(forager_score_hysteresis_pct)
+        if not np.isfinite(forager_score_hysteresis_pct) or (
+            forager_score_hysteresis_pct < 0.0
+        ):
+            raise ValueError(
+                "forager_score_hysteresis_pct must be finite and non-negative"
+            )
         liq_floor = max(0.0, run.starting_balance) * max(
             0.0, run.liquidation_threshold
         )
         self.settings = torch.tensor(
-            [run.starting_balance, liq_floor, run.interval_ms, float(side == "short")],
+            [
+                run.starting_balance,
+                liq_floor,
+                run.interval_ms,
+                float(side == "short"),
+                forager_score_hysteresis_pct,
+            ],
             dtype=torch.float32,
             device="mps",
         )

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -580,12 +580,15 @@ class MpsMulticoinEmaProxy:
             raise ValueError(
                 "MPS multicoin proxy requires backtest.dynamic_wel_by_tradability=true"
             )
-        if (
-            float(backtest_params.get("forager_score_hysteresis_pct", 0.0) or 0.0)
-            != 0.0
+        self.forager_score_hysteresis_pct = float(
+            backtest_params.get("forager_score_hysteresis_pct", 0.0) or 0.0
+        )
+        if not np.isfinite(self.forager_score_hysteresis_pct) or (
+            self.forager_score_hysteresis_pct < 0.0
         ):
             raise ValueError(
-                "MPS multicoin proxy requires live.forager_score_hysteresis_pct=0"
+                "MPS multicoin proxy requires a finite non-negative "
+                "live.forager_score_hysteresis_pct"
             )
         for last_valid_idx in backtest_params["last_valid_indices"]:
             _require_complete_valid_tail(int(last_valid_idx), len(values))
@@ -690,6 +693,9 @@ class MpsMulticoinEmaProxy:
                 "proxy_mode": "independent-side-hedge-v1",
             }
             per_side_coin_overrides = {side: None for side in self.sides}
+        self.coin_override_contract["forager_score_hysteresis_pct"] = (
+            self.forager_score_hysteresis_pct
+        )
 
         markets = [
             ProxyMarket(
@@ -745,6 +751,7 @@ class MpsMulticoinEmaProxy:
                 self.data,
                 side=side,
                 coin_overrides=per_side_coin_overrides[side],
+                forager_score_hysteresis_pct=self.forager_score_hysteresis_pct,
             )
             for side in self.sides
         }

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1024,12 +1024,6 @@ def test_gpu_coin_overrides_reject_single_coin_scope():
             ),
             "dynamic_wel_by_tradability",
         ),
-        (
-            lambda config: config["live"].__setitem__(
-                "forager_score_hysteresis_pct", 0.01
-            ),
-            "forager_score_hysteresis_pct",
-        ),
     ],
 )
 def test_gpu_multicoin_foundation_fails_closed_for_unsupported_scope(
@@ -1053,6 +1047,15 @@ def test_gpu_multicoin_foundation_accepts_dual_side_hedge_mode():
     }
     config["live"]["hedge_mode"] = True
     config["live"]["forager_score_hysteresis_pct"] = 0.0
+    config["backtest"]["dynamic_wel_by_tradability"] = True
+
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
+
+
+def test_gpu_multicoin_foundation_accepts_forager_score_hysteresis():
+    config = _long_only_ema_config()
+    config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "SOL"]
+    config["live"]["forager_score_hysteresis_pct"] = 0.02
     config["backtest"]["dynamic_wel_by_tradability"] = True
 
     assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
@@ -2653,6 +2656,14 @@ def test_gpu_checkpoint_signature_tracks_prepared_coin_override_contract():
     assert _checkpoint_signature(active, scoring) != original
     assert (
         _checkpoint_signature(active, scoring, runtime_contract=edited)
+        != original
+    )
+    hysteresis_edited = copy.deepcopy(contract)
+    hysteresis_edited["forager_score_hysteresis_pct"] = 0.02
+    assert (
+        _checkpoint_signature(
+            active, scoring, runtime_contract=hysteresis_edited
+        )
         != original
     )
 

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -214,6 +214,7 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
     assert "coin_override_or" in source
     assert "const float score_hysteresis = fmax(run_settings[4], 0.0f)" in source
     assert "incumbent[c] = selected[c] && psize[c] <= 0.0f" in source
+    assert "if (!selected[c] || incumbent[c] || !survivor[c]) continue" in source
     assert "score[challenger] - score[incumbent_coin]" in source
     count = 512
     coin_count = 3

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -212,6 +212,9 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
     assert "constant int DAILY_COLS = 6" in source
     assert "day_min_balance" in source
     assert "coin_override_or" in source
+    assert "const float score_hysteresis = fmax(run_settings[4], 0.0f)" in source
+    assert "incumbent[c] = selected[c] && psize[c] <= 0.0f" in source
+    assert "score[challenger] - score[incumbent_coin]" in source
     count = 512
     coin_count = 3
     phase = np.linspace(0.0, 12.0 * np.pi, count)
@@ -265,9 +268,11 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
         2.0,
     ]
 
-    output = MpsEmaAnchorMulticoinRunner(runs[0], data, side=side).run(
-        np.array([row, row], dtype=np.float64)
+    runner = MpsEmaAnchorMulticoinRunner(
+        runs[0], data, side=side, forager_score_hysteresis_pct=0.02
     )
+    assert runner.settings.cpu()[4].item() == pytest.approx(0.02)
+    output = runner.run(np.array([row, row], dtype=np.float64))
     torch.mps.synchronize()
 
     assert output["balance"].device.type == "mps"
@@ -279,6 +284,14 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
     ).all()
     assert output["day_has_fill"].sum().item() > 0
     assert (output["open_positions"] <= 2.0).all()
+
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        MpsEmaAnchorMulticoinRunner(
+            runs[0],
+            data,
+            side=side,
+            forager_score_hysteresis_pct=-0.01,
+        )
 
     legacy_long = MpsEmaAnchorMulticoinLongRunner(runs[0], data)
     assert legacy_long.side == "long"


### PR DESCRIPTION
## Summary

- allow nonzero `live.forager_score_hysteresis_pct` in Apple MPS multi-coin EMA Anchor optimization
- preserve previously selected flat candidates and apply the canonical Rust weakest-challenger replacement/tie-breaking semantics in Metal
- carry hysteresis through the MPS runner and checkpoint runtime identity, with finite/non-negative validation
- keep the zero-hysteresis path behaviorally unchanged and exact Rust validation authoritative

## Validation

- `cargo test --no-default-features` — 260 passed
- full Python suite — passed
- `tests/optimization/test_gpu_mps.py` on Apple M3/MPS — 38 passed
- real dual-side hedge-mode BTC/ETH/SOL optimization, Bybit cached data, 2024-01 through 2024-03, hysteresis 0.02 — 4,096 proxy evaluations + 64 exact Rust validations in 30.2s, drift gates enabled, no halt
- `cargo fmt --check` and `git diff --check`

## Scope

This remains additive and experimental. Exact Rust backtests remain authoritative; existing unsupported GPU settings still fail closed.