### PR TITLE
GPU: support dual-side multi-coin suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added Apple MPS optimizer suite support for dual-side hedge-mode multi-coin EMA Anchor scenarios
+  sharing one exchange and a consistent long/short topology.
+
 - Added Apple MPS multi-coin EMA Anchor optimizer support for Forager score hysteresis, retaining
   flat incumbent candidates when challenger scores are only marginally better.
 

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -115,7 +115,8 @@ The supported slice is intentionally narrow:
 - hedge mode and one-way mode; one-way flat-side arbitration uses the active strategy's Rust rule
 - suite mode on one shared exchange; single-coin EMA-anchor and trailing-martingale scenarios keep
   their existing directional support, while EMA-anchor suites may also use different multi-coin
-  subsets of up to 64 coins when every effective scenario shares exactly one enabled side;
+  subsets of up to 64 coins when every effective scenario shares the same one-side or dual-side
+  hedge-mode topology;
   scenario date, coin, ignored-coin, exchange selection, and fail-closed `bot.long`/`bot.short`
   config overrides are supported, while non-bot override paths and per-coin source assignments
   remain unsupported
@@ -132,7 +133,7 @@ Unsupported combinations fail before optimization begins. Dual-side multi-coin E
 long and one short Metal dispatch per candidate in hedge mode. Their directional surfaces form a
 conservative portfolio screening proxy; every accepted metric still comes from the unchanged exact
 Rust portfolio backtest, and classification, rank, and drift gates halt material disagreement.
-Dual-side one-way arbitration, dual-side multi-coin suites and coin overrides, multi-coin
+Dual-side one-way arbitration, dual-side multi-coin coin overrides, multi-coin
 trailing-martingale, multi-exchange suites, non-bot suite scenario overrides, per-coin source
 assignments, HSL, and auto-unstuck are not silently approximated by this release. Dual-side
 multi-coin screening also rejects `fills_gap_longest_days`,

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -994,8 +994,10 @@ def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict
     return prepared
 
 
-def _gpu_suite_search_context(suite_inputs: list[dict]) -> tuple[int, int, str | None]:
-    """Return the common candidate-space coin range and multicoin side."""
+def _gpu_suite_search_context(
+    suite_inputs: list[dict],
+) -> tuple[int, int, tuple[str, ...] | None]:
+    """Return the common candidate-space coin range and multicoin side topology."""
 
     if not suite_inputs:
         raise ValueError("GPU suite mode requires at least one prepared scenario")
@@ -1024,21 +1026,22 @@ def _gpu_suite_search_context(suite_inputs: list[dict]) -> tuple[int, int, str |
             if gpu_side_enabled(item["config"], side)
         )
         sides_by_label[item["ctx"].label] = sides
-        if len(sides) != 1:
+        if len(sides) not in (1, 2):
             raise ValueError(
-                "GPU multicoin suites require exactly one enabled side in every "
+                "GPU multicoin suites require one or two enabled sides in every "
                 f"scenario; {item['ctx'].label!r} has {list(sides)}"
             )
-    common_sides = {sides[0] for sides in sides_by_label.values()}
-    if len(common_sides) != 1:
+    common_topologies = set(sides_by_label.values())
+    if len(common_topologies) != 1:
         details = ", ".join(
-            f"{label}={sides[0]}" for label, sides in sides_by_label.items()
+            f"{label}={list(sides)}" for label, sides in sides_by_label.items()
         )
         raise ValueError(
-            "GPU multicoin suites require the same enabled side in every scenario; "
+            "GPU multicoin suites require the same enabled-side topology in every "
+            "scenario; "
             f"got {details}"
         )
-    return min_coin_count, max_coin_count, common_sides.pop()
+    return min_coin_count, max_coin_count, common_topologies.pop()
 
 
 def _gpu_suite_scenario_override_context(
@@ -2168,26 +2171,26 @@ def run_backend(
     )
     if suite_enabled:
         exchange = suite_inputs[0]["exchange"]
-        min_coin_count, max_coin_count, suite_multicoin_side = (
+        min_coin_count, max_coin_count, suite_multicoin_sides = (
             _gpu_suite_search_context(suite_inputs)
         )
         logging.info(
-            "GPU suite prepared %d scenarios | coins=%d..%d | multicoin_side=%s",
+            "GPU suite prepared %d scenarios | coins=%d..%d | multicoin_sides=%s",
             len(suite_inputs),
             min_coin_count,
             max_coin_count,
-            suite_multicoin_side or "n/a",
+            ",".join(suite_multicoin_sides or ()) or "n/a",
         )
     else:
         exchange = _validate_scope(proxy_config, evaluator)
         min_coin_count = max_coin_count = int(
             evaluator.shared_hlcvs_np[exchange].shape[1]
         )
-        suite_multicoin_side = None
+        suite_multicoin_sides = None
     if strategy_kind == "ema_anchor" and max_coin_count > 1:
         multicoin_sides = (
-            [suite_multicoin_side]
-            if suite_multicoin_side is not None
+            list(suite_multicoin_sides)
+            if suite_multicoin_sides is not None
             else [
                 side
                 for side in ("long", "short")
@@ -2248,8 +2251,8 @@ def run_backend(
         side for side in ("long", "short") if gpu_side_enabled(proxy_config, side)
     }
     config_enabled_sides = (
-        {suite_multicoin_side}
-        if suite_multicoin_side is not None
+        set(suite_multicoin_sides)
+        if suite_multicoin_sides is not None
         else base_config_enabled_sides
     )
     base_by_key = {
@@ -2284,13 +2287,13 @@ def run_backend(
         enabled_sides = {
             side for side in ("long", "short") if vector_side_enabled(side)
         }
-        if suite_multicoin_side is None:
+        if suite_multicoin_sides is None:
             _validate_seed_side_match(config_enabled_sides, enabled_sides)
         else:
             # CPU suite setup requires symmetric approved coin lists. Effective
-            # scenario overrides establish the common single-side topology and
+            # scenario overrides establish the common side topology and
             # are validated below after shadowing candidate bounds.
-            enabled_sides = {suite_multicoin_side}
+            enabled_sides = set(suite_multicoin_sides)
     if not enabled_sides:
         raise ValueError(
             "GPU bounds would disable both sides for exact validation; "
@@ -2345,7 +2348,7 @@ def run_backend(
         _mirror_short_mapping(bound_by_key)
     _validate_pinned_scope_bounds(bound_by_key, base_by_key, enabled_sides)
 
-    if suite_multicoin_side is None:
+    if suite_multicoin_sides is None:
         _validate_directional_search_space(
             bound_by_key,
             base_by_key,

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -490,6 +490,54 @@ def test_gpu_suite_inputs_materialize_multicoin_subset():
     assert np.array_equal(prepared[0]["hlcvs"][:, 1], master[:, 2])
 
 
+def test_gpu_suite_inputs_accept_dual_side_multicoin_hedge_scenario():
+    config = _directional_ema_config(long_enabled=True, short_enabled=True)
+    config["backtest"]["suite_enabled"] = True
+    config["backtest"]["dynamic_wel_by_tradability"] = True
+    config["live"]["hedge_mode"] = True
+    config["live"]["forager_score_hysteresis_pct"] = 0.02
+    config["live"]["approved_coins"] = {
+        "long": ["BTC", "ETH", "SOL"],
+        "short": ["BTC", "ETH", "SOL"],
+    }
+    config["bot"]["long"]["risk"]["n_positions"] = 2
+    config["bot"]["short"]["risk"]["n_positions"] = 2
+    master = np.zeros((10, 3, 4), dtype=np.float64)
+    ctx = SimpleNamespace(
+        label="dual",
+        overrides={},
+        exchanges=["bybit"],
+        msss={
+            "bybit": {
+                "BTC": {},
+                "ETH": {},
+                "SOL": {},
+                "__meta__": {},
+            }
+        },
+        timestamps={"bybit": np.arange(10, dtype=np.int64)},
+    )
+
+    class Suite:
+        contexts = [ctx]
+
+        @staticmethod
+        def get_prepared_context_data(_ctx, _exchange):
+            return master, np.ones(10), [0, 1, 2]
+
+        @staticmethod
+        def build_scenario_candidate_config(proxy_config, _ctx):
+            return copy.deepcopy(proxy_config)
+
+    prepared = _gpu_suite_scenario_inputs(config, Suite())
+
+    assert _gpu_suite_search_context(prepared) == (
+        3,
+        3,
+        ("long", "short"),
+    )
+
+
 @pytest.mark.parametrize(
     ("overrides", "exchanges", "coin_indices", "message"),
     [
@@ -542,7 +590,7 @@ def test_gpu_suite_search_context_reports_coin_count_range():
             _suite_search_input("broad", config, 4),
             _suite_search_input("narrow", config, 2),
         ]
-    ) == (2, 4, "long")
+    ) == (2, 4, ("long",))
 
 
 def test_gpu_suite_search_context_allows_legacy_single_coin_topologies():
@@ -563,22 +611,41 @@ def test_gpu_suite_search_context_rejects_multicoin_trailing_martingale():
         _gpu_suite_search_context([_suite_search_input("multi", config, 2)])
 
 
-def test_gpu_suite_search_context_rejects_multicoin_dual_side_scenario():
+def test_gpu_suite_search_context_accepts_multicoin_dual_side_scenarios():
     config = _directional_ema_config(long_enabled=True, short_enabled=True)
+    config["live"]["hedge_mode"] = True
 
-    with pytest.raises(ValueError, match="exactly one enabled side"):
-        _gpu_suite_search_context([_suite_search_input("multi", config, 2)])
+    assert _gpu_suite_search_context(
+        [
+            _suite_search_input("broad", config, 4),
+            _suite_search_input("narrow", config, 2),
+        ]
+    ) == (2, 4, ("long", "short"))
 
 
-def test_gpu_suite_search_context_rejects_different_sides():
+def test_gpu_suite_search_context_rejects_different_side_topologies():
     long_config = _directional_ema_config(long_enabled=True, short_enabled=False)
     short_config = _directional_ema_config(long_enabled=False, short_enabled=True)
 
-    with pytest.raises(ValueError, match="same enabled side"):
+    with pytest.raises(ValueError, match="same enabled-side topology"):
         _gpu_suite_search_context(
             [
                 _suite_search_input("long", long_config, 3),
                 _suite_search_input("short", short_config, 2),
+            ]
+        )
+
+
+def test_gpu_suite_search_context_rejects_single_vs_dual_side_topology():
+    long_config = _directional_ema_config(long_enabled=True, short_enabled=False)
+    dual_config = _directional_ema_config(long_enabled=True, short_enabled=True)
+    dual_config["live"]["hedge_mode"] = True
+
+    with pytest.raises(ValueError, match="same enabled-side topology"):
+        _gpu_suite_search_context(
+            [
+                _suite_search_input("long", long_config, 3),
+                _suite_search_input("dual", dual_config, 3),
             ]
         )
 


### PR DESCRIPTION
## Summary
- allow Apple MPS EMA Anchor suites whose effective scenarios share a dual-side hedge-mode topology
- build and validate both directional proxy parameter maps across every prepared scenario
- keep mismatched topologies and existing unsafe dual-side aggregate metrics fail-closed
- document the newly supported suite surface

## Validation
- full Python test suite
- cargo test --no-default-features: 260 passed
- Apple MPS integration tests: 38 passed
- real M3 MPS smoke: Bybit BTC/ETH/SOL base plus BTC/ETH narrow scenario, dual-side hedge mode, 64 exact suite evaluations, 26 Pareto members, no parity halt
- cargo fmt --check
- git diff --check

Exact Rust backtests remain authoritative; this only expands the additive Metal screening path.