### PR TITLE
GPU: support dual-side multi-coin overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added static per-coin EMA Anchor strategy, entry-cooldown, and wallet-exposure overrides to
+  dual-side hedge-mode Apple MPS optimization, including compatible multi-coin suites.
+
 - Added Apple MPS optimizer suite support for dual-side hedge-mode multi-coin EMA Anchor scenarios
   sharing one exchange and a consistent long/short topology.
 

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -120,9 +120,9 @@ The supported slice is intentionally narrow:
   scenario date, coin, ignored-coin, exchange selection, and fail-closed `bot.long`/`bot.short`
   config overrides are supported, while non-bot override paths and per-coin source assignments
   remain unsupported
-- static `coin_overrides` for the enabled side of multi-coin EMA-anchor runs: EMA-anchor strategy
+- static `coin_overrides` for each enabled side of multi-coin EMA-anchor runs: EMA-anchor strategy
   parameters, `risk.entry_cooldown_minutes`, and explicit `wallet_exposure_limit` are supported;
-  other sides and override leaves fail closed
+  disabled sides and other override leaves fail closed
 - HSL and auto-unstuck disabled
 - BTC collateral, realized-loss gating, and exposure enforcers disabled
 - `backtest.filter_by_min_effective_cost: false`
@@ -133,9 +133,9 @@ Unsupported combinations fail before optimization begins. Dual-side multi-coin E
 long and one short Metal dispatch per candidate in hedge mode. Their directional surfaces form a
 conservative portfolio screening proxy; every accepted metric still comes from the unchanged exact
 Rust portfolio backtest, and classification, rank, and drift gates halt material disagreement.
-Dual-side one-way arbitration, dual-side multi-coin coin overrides, multi-coin
-trailing-martingale, multi-exchange suites, non-bot suite scenario overrides, per-coin source
-assignments, HSL, and auto-unstuck are not silently approximated by this release. Dual-side
+Dual-side one-way arbitration, multi-coin trailing-martingale, multi-exchange suites, non-bot suite
+scenario overrides, per-coin source assignments, HSL, and auto-unstuck are not silently
+approximated by this release. Dual-side
 multi-coin screening also rejects `fills_gap_longest_days`,
 `strategy_eq_recovery_days_max`, and `volume_pct_per_day_avg`: the independent directional
 summaries cannot reconstruct cross-side-only fill gaps, alternating portfolio recovery periods,

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -833,12 +833,12 @@ def _validate_gpu_coin_overrides(
     overrides = config.get("coin_overrides") or {}
     if not overrides:
         return
-    if coin_count <= 1 or strategy_kind != "ema_anchor" or len(enabled_sides) != 1:
+    if coin_count <= 1 or strategy_kind != "ema_anchor" or not enabled_sides:
         raise ValueError(
-            "GPU coin_overrides currently require multi-coin EMA Anchor with "
-            "exactly one enabled side"
+            "GPU coin_overrides currently require multi-coin EMA Anchor with at "
+            "least one enabled side"
         )
-    enabled_side = next(iter(enabled_sides))
+    enabled_sides = set(enabled_sides)
     from optimization.gpu.model import EMA_ANCHOR_PARAM_KEYS
 
     strategy_keys = set(EMA_ANCHOR_PARAM_KEYS) - {
@@ -853,13 +853,18 @@ def _validate_gpu_coin_overrides(
         else:
             yield prefix
 
-    allowed = {
-        ("bot", enabled_side, "risk", "entry_cooldown_minutes"),
-        ("bot", enabled_side, "wallet_exposure_limit"),
-    } | {
-        ("bot", enabled_side, "strategy", "ema_anchor", key)
-        for key in strategy_keys
-    }
+    allowed = set()
+    for enabled_side in enabled_sides:
+        allowed.update(
+            {
+                ("bot", enabled_side, "risk", "entry_cooldown_minutes"),
+                ("bot", enabled_side, "wallet_exposure_limit"),
+            }
+        )
+        allowed.update(
+            ("bot", enabled_side, "strategy", "ema_anchor", key)
+            for key in strategy_keys
+        )
     unsupported = []
     for coin, patch in overrides.items():
         if not isinstance(patch, dict):

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -532,10 +532,6 @@ class MpsMulticoinEmaProxy:
                 "MPS dual-side multicoin proxy currently requires live.hedge_mode=true; "
                 "one-way arbitration is not modeled"
             )
-        if len(enabled_sides) == 2 and (config.get("coin_overrides") or {}):
-            raise ValueError(
-                "MPS dual-side multicoin proxy does not yet support coin_overrides"
-            )
         if len(enabled_sides) == 2:
             approved = config.get("live", {}).get("approved_coins", {}) or {}
             ignored = config.get("live", {}).get("ignored_coins", {}) or {}
@@ -672,27 +668,31 @@ class MpsMulticoinEmaProxy:
                 f"coins={coins}, prepared={coin_count}"
             )
         per_side_coin_overrides = {}
-        if len(self.sides) == 1:
-            side = self.sides[0]
-            overrides, self.coin_override_contract = (
-                _build_multicoin_ema_coin_overrides(
-                    config=config,
-                    mss=mss,
-                    exchange=exchange,
-                    coins=coins,
-                    payload=payload,
-                    side=side,
-                )
+        per_side_override_contracts = {}
+        for side in self.sides:
+            overrides, contract = _build_multicoin_ema_coin_overrides(
+                config=config,
+                mss=mss,
+                exchange=exchange,
+                coins=coins,
+                payload=payload,
+                side=side,
             )
             per_side_coin_overrides[side] = overrides
+            per_side_override_contracts[side] = contract
+        if len(self.sides) == 1:
+            self.coin_override_contract = per_side_override_contracts[self.sides[0]]
         else:
             self.coin_override_contract = {
                 "exchange": exchange,
                 "coins": coins,
                 "sides": list(self.sides),
+                "values_by_side": {
+                    side: per_side_override_contracts[side]["values"]
+                    for side in self.sides
+                },
                 "proxy_mode": "independent-side-hedge-v1",
             }
-            per_side_coin_overrides = {side: None for side in self.sides}
         self.coin_override_contract["forager_score_hysteresis_pct"] = (
             self.forager_score_hysteresis_pct
         )

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1142,7 +1142,7 @@ def test_gpu_multicoin_foundation_rejects_dual_side_one_way_mode():
         _validate_scope(config, _MulticoinEvaluator())
 
 
-def test_gpu_multicoin_foundation_rejects_dual_side_coin_overrides():
+def test_gpu_multicoin_foundation_accepts_dual_side_coin_overrides():
     config = _directional_ema_config(long_enabled=True, short_enabled=True)
     config["live"]["approved_coins"] = {
         "long": ["BTC", "ETH", "SOL"],
@@ -1152,11 +1152,21 @@ def test_gpu_multicoin_foundation_rejects_dual_side_coin_overrides():
     config["live"]["forager_score_hysteresis_pct"] = 0.0
     config["backtest"]["dynamic_wel_by_tradability"] = True
     config["coin_overrides"] = {
-        "ETH": {"bot": {"long": {"wallet_exposure_limit": 0.5}}}
+        "ETH": {
+            "bot": {
+                "long": {
+                    "strategy": {"ema_anchor": {"offset": 0.02}},
+                    "wallet_exposure_limit": 0.5,
+                },
+                "short": {
+                    "strategy": {"ema_anchor": {"offset": 0.03}},
+                    "risk": {"entry_cooldown_minutes": 15},
+                },
+            }
+        }
     }
 
-    with pytest.raises(ValueError, match="exactly one enabled side"):
-        _validate_scope(config, _MulticoinEvaluator())
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
 def test_gpu_multicoin_foundation_rejects_asymmetric_dual_side_coins():
@@ -2731,6 +2741,32 @@ def test_gpu_checkpoint_signature_tracks_prepared_coin_override_contract():
         _checkpoint_signature(
             active, scoring, runtime_contract=hysteresis_edited
         )
+        != original
+    )
+
+
+def test_gpu_checkpoint_signature_tracks_dual_side_coin_override_contract():
+    active = [
+        ("long_offset", 0, Bound(0.01, 0.1, 0.01)),
+        ("short_offset", 1, Bound(0.01, 0.1, 0.01)),
+    ]
+    scoring = [{"goal": "max", "metric": "adg_strategy_eq"}]
+    contract = {
+        "exchange": "bybit",
+        "coins": ["BTC", "ETH"],
+        "sides": ["long", "short"],
+        "values_by_side": {
+            "long": [[None] * 12, [None] * 11 + [0.4]],
+            "short": [[None] * 12, [None] * 10 + [30.0, None]],
+        },
+        "proxy_mode": "independent-side-hedge-v1",
+    }
+    original = _checkpoint_signature(active, scoring, runtime_contract=contract)
+    edited = copy.deepcopy(contract)
+    edited["values_by_side"]["short"][1][10] = 45.0
+
+    assert (
+        _checkpoint_signature(active, scoring, runtime_contract=edited)
         != original
     )
 

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -287,6 +287,74 @@ def test_multicoin_coin_overrides_pack_only_explicit_exact_values():
     assert contract["values"][0] == [None] * 12
 
 
+def test_multicoin_coin_overrides_pack_dual_sides_independently():
+    strategy_base = {key: 1.0 for key in EMA_ANCHOR_PARAM_KEYS[:-2]}
+    payload = SimpleNamespace(
+        strategy_params_list=[
+            {"long": strategy_base, "short": strategy_base},
+            {
+                "long": dict(strategy_base, offset=0.25),
+                "short": dict(strategy_base, offset=0.5),
+            },
+        ],
+        bot_params_list=[
+            {
+                "long": {"entry_cooldown_minutes": 0.0, "wallet_exposure_limit": -1.0},
+                "short": {"entry_cooldown_minutes": 0.0, "wallet_exposure_limit": -1.0},
+            },
+            {
+                "long": {"entry_cooldown_minutes": 0.0, "wallet_exposure_limit": 0.4},
+                "short": {"entry_cooldown_minutes": 30.0, "wallet_exposure_limit": -1.0},
+            },
+        ],
+    )
+    config = {
+        "coin_overrides": {
+            "ETH": {
+                "bot": {
+                    "long": {
+                        "strategy": {"ema_anchor": {"offset": 0.25}},
+                        "wallet_exposure_limit": 0.4,
+                    },
+                    "short": {
+                        "strategy": {"ema_anchor": {"offset": 0.5}},
+                        "risk": {"entry_cooldown_minutes": 30.0},
+                    },
+                }
+            }
+        }
+    }
+    def resolver(config, _mss, _exchange, coin):
+        return config["coin_overrides"].get(coin, {})
+
+    long_matrix, _ = _build_multicoin_ema_coin_overrides(
+        config=config,
+        mss={"BTC": {}, "ETH": {}},
+        exchange="bybit",
+        coins=["BTC", "ETH"],
+        payload=payload,
+        side="long",
+        resolve_override=resolver,
+    )
+    short_matrix, _ = _build_multicoin_ema_coin_overrides(
+        config=config,
+        mss={"BTC": {}, "ETH": {}},
+        exchange="bybit",
+        coins=["BTC", "ETH"],
+        payload=payload,
+        side="short",
+        resolve_override=resolver,
+    )
+
+    offset_index = EMA_ANCHOR_PARAM_KEYS.index("offset")
+    assert long_matrix[1, offset_index] == pytest.approx(0.25)
+    assert long_matrix[1, 11] == pytest.approx(0.4)
+    assert np.isnan(long_matrix[1, 10])
+    assert short_matrix[1, offset_index] == pytest.approx(0.5)
+    assert short_matrix[1, 10] == pytest.approx(30.0)
+    assert np.isnan(short_matrix[1, 11])
+
+
 def test_trailing_parameter_matrix_keeps_nested_flattened_sides_separate():
     proxy = MpsEmaAnchorProxy.__new__(MpsEmaAnchorProxy)
     proxy.param_keys = TRAILING_MARTINGALE_PARAM_KEYS


### PR DESCRIPTION
## Summary
- allow static per-coin EMA Anchor, entry-cooldown, and wallet-exposure overrides on both enabled hedge-mode sides
- pack exact-last long and short override matrices independently for their Metal runners
- include both effective matrices in the checkpoint/runtime identity
- compose the same contract through dual-side multi-coin suites while keeping disabled sides and unsupported leaves fail-closed

## Validation
- full Python test suite
- cargo test --no-default-features: 260 passed
- Apple MPS integration tests: 38 passed
- real M3 MPS single run: Bybit BTC/ETH/SOL, distinct ETH long/short overrides, 2,048 proxy plus 64 exact evaluations, 24.2s, no parity halt
- real M3 MPS suite: 3-coin base plus 2-coin narrow scenario, same overrides, 2,048 proxy plus 64 exact suite evaluations, 33.5s, no parity halt
- cargo fmt --check
- git diff --check

Exact Rust backtests remain authoritative; this only expands the additive Metal screening path.