### PR TITLE
GPU: support cross-exchange suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added Apple MPS optimizer suites spanning exchanges, while retaining exactly one exchange per
+  scenario and rejecting combined or per-coin source datasets.
+
 - Added static per-coin EMA Anchor strategy, entry-cooldown, and wallet-exposure overrides to
   dual-side hedge-mode Apple MPS optimization, including compatible multi-coin suites.
 

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -100,7 +100,7 @@ and the DEAP/pymoo CPU optimizers do not import or require PyTorch.
 The supported slice is intentionally narrow:
 
 - Apple Silicon with `torch.backends.mps.is_available()`
-- one exchange using one-minute candles
+- one exchange per independent run or suite scenario, using one-minute candles
 - `strategy_kind: ema_anchor` or `trailing_martingale`, with long-only, short-only, or
   long+short enabled for one coin
 - long-only, short-only, or dual-side hedge-mode multi-coin EMA-anchor runs for up to 64 coins,
@@ -113,10 +113,10 @@ The supported slice is intentionally narrow:
   for single-coin runs; supported multi-coin bounds may vary `n_positions` between `1` and the
   prepared coin count
 - hedge mode and one-way mode; one-way flat-side arbitration uses the active strategy's Rust rule
-- suite mode on one shared exchange; single-coin EMA-anchor and trailing-martingale scenarios keep
-  their existing directional support, while EMA-anchor suites may also use different multi-coin
-  subsets of up to 64 coins when every effective scenario shares the same one-side or dual-side
-  hedge-mode topology;
+- suite mode with exactly one exchange per scenario, including suites spanning exchanges;
+  single-coin EMA-anchor and trailing-martingale scenarios keep their existing directional
+  support, while EMA-anchor suites may also use different multi-coin subsets of up to 64 coins when
+  every effective scenario shares the same one-side or dual-side hedge-mode topology;
   scenario date, coin, ignored-coin, exchange selection, and fail-closed `bot.long`/`bot.short`
   config overrides are supported, while non-bot override paths and per-coin source assignments
   remain unsupported
@@ -133,9 +133,9 @@ Unsupported combinations fail before optimization begins. Dual-side multi-coin E
 long and one short Metal dispatch per candidate in hedge mode. Their directional surfaces form a
 conservative portfolio screening proxy; every accepted metric still comes from the unchanged exact
 Rust portfolio backtest, and classification, rank, and drift gates halt material disagreement.
-Dual-side one-way arbitration, multi-coin trailing-martingale, multi-exchange suites, non-bot suite
-scenario overrides, per-coin source assignments, HSL, and auto-unstuck are not silently
-approximated by this release. Dual-side
+Dual-side one-way arbitration, multi-coin trailing-martingale, combined multi-exchange datasets,
+non-bot suite scenario overrides, per-coin source assignments, HSL, and auto-unstuck are not
+silently approximated by this release. Dual-side
 multi-coin screening also rejects `fills_gap_longest_days`,
 `strategy_eq_recovery_days_max`, and `volume_pct_per_day_avg`: the independent directional
 summaries cannot reconstruct cross-side-only fill gaps, alternating portfolio recovery periods,
@@ -146,7 +146,8 @@ path then calls the same canonical suite reducer and scenario-selection logic as
 for aggregate reducers, named-scenario objectives, and named-scenario or suite-reduced limits.
 Every exact validation still runs the unchanged Rust backtest for every scenario; only those exact
 suite metrics enter `all_results.bin` and the Pareto front. A scenario may select a different coin
-subset or date window, but every scenario must use the same exchange. Scenario `overrides` require
+subset, date window, or exchange, but each scenario must use exactly one exchange. Scenario
+`overrides` require
 explicit candidate-shadowing behavior in the proxy. This slice models `bot.long` and `bot.short`
 overrides: the canonical exact
 suite evaluator still applies them last, after candidate materialization, while each scenario's

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -921,7 +921,6 @@ def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict
         raise TypeError("GPU suite mode requires the canonical SuiteEvaluator")
 
     prepared = []
-    expected_exchange = None
     for ctx in contexts:
         overrides = getattr(ctx, "overrides", {}) or {}
         for dotted_path in overrides:
@@ -953,14 +952,6 @@ def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict
             raise ValueError(
                 "GPU suite scenarios do not support combined multi-exchange datasets"
             )
-        if expected_exchange is None:
-            expected_exchange = exchange
-        elif exchange != expected_exchange:
-            raise ValueError(
-                "GPU suite scenarios must use one shared exchange; "
-                f"expected {expected_exchange!r}, got {exchange!r} in {ctx.label!r}"
-            )
-
         hlcvs, btc, coin_indices = get_data(ctx, exchange)
         values = np.asarray(hlcvs)
         if coin_indices is not None:
@@ -2175,7 +2166,6 @@ def run_backend(
         else []
     )
     if suite_enabled:
-        exchange = suite_inputs[0]["exchange"]
         min_coin_count, max_coin_count, suite_multicoin_sides = (
             _gpu_suite_search_context(suite_inputs)
         )

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -777,7 +777,7 @@ def test_gpu_suite_inputs_reject_effective_coin_sources():
         _gpu_suite_scenario_inputs(config, Suite())
 
 
-def test_gpu_suite_inputs_require_one_shared_exchange_across_scenarios():
+def test_gpu_suite_inputs_accept_one_exchange_per_scenario():
     config = _long_only_ema_config()
     config["backtest"]["suite_enabled"] = True
     contexts = [
@@ -802,8 +802,9 @@ def test_gpu_suite_inputs_require_one_shared_exchange_across_scenarios():
 
     Suite.contexts = contexts
 
-    with pytest.raises(ValueError, match="one shared exchange"):
-        _gpu_suite_scenario_inputs(config, Suite())
+    prepared = _gpu_suite_scenario_inputs(config, Suite())
+
+    assert [item["exchange"] for item in prepared] == ["bybit", "binance"]
 
 
 def test_gpu_suite_proxy_rows_use_canonical_suite_scorer():


### PR DESCRIPTION
## Summary
- allow Apple MPS optimizer suites whose scenarios use different exchanges
- retain the fail-closed requirement that each individual scenario has exactly one exchange
- preserve rejection of combined datasets and per-coin source routing
- keep scenario-local market data, settings, fees, coin overrides, exact Rust validation, and checkpoint identity

## Validation
- focused GPU backend/service tests
- full Python test suite
- cargo test --offline --no-default-features: 260 passed
- Apple MPS integration tests: 38 passed
- real M3 MPS suite: dual-side BTC/ETH Bybit plus Binance scenarios, distinct coin overrides, 2,048 proxy plus 64 exact suite evaluations, 12.8s, no parity halt
- cargo fmt --check
- git diff --check

The smoke used the existing local v2 candle store; no authenticated exchange access occurred. Exact Rust backtests remain authoritative.