### PR TITLE
feat(gpu): support modeled suite overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Expanded Apple MPS optimizer suites with fail-closed scenario-local overrides for modeled
+  runtime inputs: `coin_overrides`, starting balance, maker fee, liquidation threshold, Forager
+  hysteresis, and hedge mode. Other non-bot overrides and per-coin source routing remain rejected.
+
 - Added Apple MPS optimizer suites spanning exchanges, while retaining exactly one exchange per
   scenario and rejecting combined or per-coin source datasets.
 

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -118,8 +118,9 @@ The supported slice is intentionally narrow:
   support, while EMA-anchor suites may also use different multi-coin subsets of up to 64 coins when
   every effective scenario shares the same one-side or dual-side hedge-mode topology;
   scenario date, coin, ignored-coin, exchange selection, and fail-closed `bot.long`/`bot.short`
-  config overrides are supported, while non-bot override paths and per-coin source assignments
-  remain unsupported
+  config overrides are supported; scenario-local `coin_overrides`, starting balance, maker fee,
+  liquidation threshold, Forager hysteresis, and hedge mode are also supported, while other
+  non-bot override paths and per-coin source assignments remain unsupported
 - static `coin_overrides` for each enabled side of multi-coin EMA-anchor runs: EMA-anchor strategy
   parameters, `risk.entry_cooldown_minutes`, and explicit `wallet_exposure_limit` are supported;
   disabled sides and other override leaves fail closed
@@ -134,8 +135,8 @@ long and one short Metal dispatch per candidate in hedge mode. Their directional
 conservative portfolio screening proxy; every accepted metric still comes from the unchanged exact
 Rust portfolio backtest, and classification, rank, and drift gates halt material disagreement.
 Dual-side one-way arbitration, multi-coin trailing-martingale, combined multi-exchange datasets,
-non-bot suite scenario overrides, per-coin source assignments, HSL, and auto-unstuck are not
-silently approximated by this release. Dual-side
+unmodeled non-bot suite scenario overrides, per-coin source assignments, HSL, and auto-unstuck are
+not silently approximated by this release. Dual-side
 multi-coin screening also rejects `fills_gap_longest_days`,
 `strategy_eq_recovery_days_max`, and `volume_pct_per_day_avg`: the independent directional
 summaries cannot reconstruct cross-side-only fill gaps, alternating portfolio recovery periods,
@@ -157,8 +158,12 @@ enable HSL, auto-unstuck, an exposure enforcer, an invalid position count, or an
 behavior. In a multicoin suite, a scenario with fewer coins must keep the effective `n_positions`
 range within that subset, either through common bounds or an explicit scenario override. Metal
 uses the single-coin or multicoin kernel independently for each scenario, then feeds all results to
-the same suite reducer. Non-bot override paths and scenario `coin_sources` remain rejected until
-their proxy semantics are modeled. The effective external suite definition and any `--scenarios` filter are
+the same suite reducer. Scenario-local `coin_overrides`, `backtest.starting_balance`,
+`backtest.maker_fee_override`, `backtest.liquidation_threshold`,
+`live.forager_score_hysteresis_pct`, and `live.hedge_mode` are accepted because every scenario
+proxy consumes them through the canonical backtest payload and then passes the same fail-closed
+scope checks. Other non-bot paths and scenario `coin_sources` remain rejected until their proxy
+semantics are modeled. The effective external suite definition and any `--scenarios` filter are
 stored in the run contract and checkpoint identity, with dynamic scenario dates resolved to the
 prepared concrete dates. The checkpoint signature also records each scenario's ordered effective
 coins, side topology, and prepared candle window, so resume fails closed if preparation changes.

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -138,6 +138,19 @@ GPU_SUPPORTED_OPTIMIZER_OVERRIDES = {
     "mirror_short_from_long",
 }
 
+# These scenario-local values are consumed when each MPS proxy builds the same
+# canonical backtest payload as exact Rust. Keep this allowlist explicit: data
+# selection and unsupported execution/risk behavior must continue to fail
+# closed instead of being accepted merely because the config path exists.
+GPU_SUPPORTED_SUITE_NON_BOT_OVERRIDE_PATHS = {
+    ("backtest", "liquidation_threshold"),
+    ("backtest", "maker_fee_override"),
+    ("backtest", "starting_balance"),
+    ("coin_overrides",),
+    ("live", "forager_score_hysteresis_pct"),
+    ("live", "hedge_mode"),
+}
+
 
 def _validate_gpu_optimizer_overrides(overrides_list, strategy_kind: str) -> set[str]:
     overrides = set(overrides_list or [])
@@ -925,13 +938,18 @@ def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict
         overrides = getattr(ctx, "overrides", {}) or {}
         for dotted_path in overrides:
             resolved = require_existing_config_path(proxy_config, dotted_path)
-            if len(resolved) < 3 or resolved[0] != "bot" or resolved[1] not in {
-                "long",
-                "short",
-            }:
+            bot_side_override = (
+                len(resolved) >= 3
+                and resolved[0] == "bot"
+                and resolved[1] in {"long", "short"}
+            )
+            if (
+                not bot_side_override
+                and resolved not in GPU_SUPPORTED_SUITE_NON_BOT_OVERRIDE_PATHS
+            ):
                 raise ValueError(
                     f"GPU suite scenario {ctx.label!r} override {dotted_path!r} is "
-                    "outside the supported bot.long/bot.short scope"
+                    "outside the supported modeled scenario scope"
                 )
         coin_sources = (
             getattr(ctx, "config", {}).get("backtest", {}).get("coin_sources") or {}

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -541,7 +541,7 @@ def test_gpu_suite_inputs_accept_dual_side_multicoin_hedge_scenario():
 @pytest.mark.parametrize(
     ("overrides", "exchanges", "coin_indices", "message"),
     [
-        ({"backtest.starting_balance": 1_000}, ["bybit"], [0], "outside the supported"),
+        ({"live.strategy_kind": "trailing_martingale"}, ["bybit"], [0], "outside the supported"),
         ({}, ["bybit", "binance"], [0], "exactly one exchange"),
         ({}, ["combined"], [0], "combined multi-exchange"),
     ],
@@ -571,6 +571,175 @@ def test_gpu_suite_inputs_reject_unsupported_scenario_scope(
             return copy.deepcopy(proxy_config)
 
     with pytest.raises(ValueError, match=message):
+        _gpu_suite_scenario_inputs(config, Suite())
+
+
+@pytest.mark.parametrize(
+    ("dotted_path", "value", "resolved_path"),
+    [
+        ("backtest.starting_balance", 12_345.0, ("backtest", "starting_balance")),
+        ("backtest.maker_fee_override", 0.0002, ("backtest", "maker_fee_override")),
+        (
+            "backtest.liquidation_threshold",
+            0.1,
+            ("backtest", "liquidation_threshold"),
+        ),
+        (
+            "live.forager_score_hysteresis_pct",
+            0.03,
+            ("live", "forager_score_hysteresis_pct"),
+        ),
+        ("live.hedge_mode", True, ("live", "hedge_mode")),
+    ],
+)
+def test_gpu_suite_inputs_accept_modeled_non_bot_overrides(
+    dotted_path, value, resolved_path
+):
+    config = _long_only_ema_config()
+    config["backtest"]["suite_enabled"] = True
+    ctx = SimpleNamespace(
+        label="modeled_runtime",
+        overrides={dotted_path: value},
+        exchanges=["bybit"],
+        msss={"bybit": {"BTC": {}, "__meta__": {}}},
+        timestamps={"bybit": np.arange(10, dtype=np.int64)},
+    )
+
+    class Suite:
+        contexts = [ctx]
+
+        @staticmethod
+        def get_prepared_context_data(_ctx, _exchange):
+            return np.zeros((10, 1, 4)), np.ones(10), [0]
+
+        @staticmethod
+        def build_scenario_candidate_config(proxy_config, _ctx):
+            scenario = copy.deepcopy(proxy_config)
+            target = scenario
+            for part in resolved_path[:-1]:
+                target = target[part]
+            target[resolved_path[-1]] = value
+            return scenario
+
+    prepared = _gpu_suite_scenario_inputs(config, Suite())
+    target = prepared[0]["config"]
+    for part in resolved_path:
+        target = target[part]
+    assert target == value
+
+
+def test_gpu_suite_inputs_accept_scenario_local_modeled_coin_overrides():
+    config = _long_only_ema_config()
+    config["backtest"]["suite_enabled"] = True
+    config["live"]["approved_coins"]["long"] = ["BTC", "ETH"]
+    config["bot"]["long"]["risk"]["n_positions"] = 2
+    overrides = {
+        "coin_overrides": {
+            "ETH": {
+                "bot": {
+                    "long": {
+                        "strategy": {"ema_anchor": {"offset": 0.012}},
+                        "risk": {"entry_cooldown_minutes": 15.0},
+                    }
+                }
+            }
+        }
+    }
+    ctx = SimpleNamespace(
+        label="eth_override",
+        overrides=overrides,
+        exchanges=["bybit"],
+        msss={"bybit": {"BTC": {}, "ETH": {}, "__meta__": {}}},
+        timestamps={"bybit": np.arange(10, dtype=np.int64)},
+    )
+
+    class Suite:
+        contexts = [ctx]
+
+        @staticmethod
+        def get_prepared_context_data(_ctx, _exchange):
+            return np.zeros((10, 2, 4)), np.ones(10), [0, 1]
+
+        @staticmethod
+        def build_scenario_candidate_config(proxy_config, _ctx):
+            scenario = copy.deepcopy(proxy_config)
+            scenario["coin_overrides"] = copy.deepcopy(overrides["coin_overrides"])
+            return scenario
+
+    prepared = _gpu_suite_scenario_inputs(config, Suite())
+
+    assert prepared[0]["overrides"] == overrides
+    assert prepared[0]["config"]["coin_overrides"]["ETH"]["bot"]["long"][
+        "strategy"
+    ]["ema_anchor"]["offset"] == pytest.approx(0.012)
+
+
+def test_gpu_suite_inputs_reject_unmodeled_scenario_coin_override_leaves():
+    config = _long_only_ema_config()
+    config["backtest"]["suite_enabled"] = True
+    config["live"]["approved_coins"]["long"] = ["BTC", "ETH"]
+    config["bot"]["long"]["risk"]["n_positions"] = 2
+    overrides = {
+        "coin_overrides": {
+            "ETH": {"bot": {"long": {"hsl": {"enabled": True}}}}
+        }
+    }
+    ctx = SimpleNamespace(
+        label="unsupported_coin_risk",
+        overrides=overrides,
+        exchanges=["bybit"],
+        msss={"bybit": {"BTC": {}, "ETH": {}, "__meta__": {}}},
+        timestamps={"bybit": np.arange(10, dtype=np.int64)},
+    )
+
+    class Suite:
+        contexts = [ctx]
+
+        @staticmethod
+        def get_prepared_context_data(_ctx, _exchange):
+            return np.zeros((10, 2, 4)), np.ones(10), [0, 1]
+
+        @staticmethod
+        def build_scenario_candidate_config(proxy_config, _ctx):
+            scenario = copy.deepcopy(proxy_config)
+            scenario["coin_overrides"] = copy.deepcopy(overrides["coin_overrides"])
+            return scenario
+
+    with pytest.raises(ValueError, match="coin_overrides do not model"):
+        _gpu_suite_scenario_inputs(config, Suite())
+
+
+def test_gpu_suite_inputs_revalidate_scenario_hedge_mode():
+    config = _directional_ema_config(long_enabled=True, short_enabled=True)
+    config["backtest"]["suite_enabled"] = True
+    config["backtest"]["dynamic_wel_by_tradability"] = True
+    config["live"]["hedge_mode"] = True
+    config["live"]["approved_coins"] = {
+        "long": ["BTC", "ETH"],
+        "short": ["BTC", "ETH"],
+    }
+    ctx = SimpleNamespace(
+        label="one_way_multi",
+        overrides={"live.hedge_mode": False},
+        exchanges=["bybit"],
+        msss={"bybit": {"BTC": {}, "ETH": {}, "__meta__": {}}},
+        timestamps={"bybit": np.arange(10, dtype=np.int64)},
+    )
+
+    class Suite:
+        contexts = [ctx]
+
+        @staticmethod
+        def get_prepared_context_data(_ctx, _exchange):
+            return np.zeros((10, 2, 4)), np.ones(10), [0, 1]
+
+        @staticmethod
+        def build_scenario_candidate_config(proxy_config, _ctx):
+            scenario = copy.deepcopy(proxy_config)
+            scenario["live"]["hedge_mode"] = False
+            return scenario
+
+    with pytest.raises(ValueError, match="requires live.hedge_mode=true"):
         _gpu_suite_scenario_inputs(config, Suite())
 
 


### PR DESCRIPTION
## Summary
- allow scenario-local GPU suite overrides for canonical proxy inputs: starting balance, maker fee, liquidation threshold, Forager hysteresis, and hedge mode
- allow scenario-local coin overrides within the existing fail-closed multi-coin EMA Anchor override contract
- retain rejection of unmodeled non-bot paths, unsupported coin-override leaves, per-coin source routing, and unsupported topology changes

## Validation
- full Python pytest suite
- cargo test --offline --no-default-features (260 passed)
- cargo fmt --check
- Apple MPS pytest file (38 passed on M3)
- real MPS dual-side two-coin suite: 2 scenarios, distinct runtime and coin overrides, 2048 proxy + 64 exact validations, 14.6s, no halt
- real MPS dual-side single-coin one-way/hedge suite: 2048 proxy + 64 exact validations, 6.1s, no halt