### PR TITLE
fix(optimize): honor suite exchange restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Fixed optimizer-suite exchange routing so an explicitly restricted scenario uses its requested
+  individual exchange dataset even when only that exchange needed separate materialization. It no
+  longer falls through to a combined dataset whose candles may come from another base exchange.
+
 - Expanded Apple MPS optimizer suites with fail-closed scenario-local overrides for modeled
   runtime inputs: `coin_overrides`, starting balance, maker fee, liquidation threshold, Forager
   hysteresis, and hedge mode. Other non-bot overrides and per-coin source routing remain rejected.

--- a/src/optimize_suite.py
+++ b/src/optimize_suite.py
@@ -172,10 +172,24 @@ async def prepare_suite_contexts(
         raise ValueError("No coins available after preparing master datasets.")
 
     has_combined = "combined" in datasets
-    # Available exchanges exclude "combined" pseudo-exchange
+    # A combined dataset may cover exchanges for which no individual dataset
+    # was prepared. Include its full source identity when deciding whether an
+    # explicit scenario restriction truly selects the whole exchange pool.
+    # Otherwise a bybit-only scenario can be misclassified as "all exchanges"
+    # merely because bybit is the only separately materialized dataset, and it
+    # may then consume combined candles selected from another exchange.
     dataset_available_exchanges = sorted(
-        set(ds.exchange for ds in datasets.values() if ds.exchange != "combined")
-    ) or (datasets["combined"].available_exchanges if has_combined else [])
+        {
+            exchange
+            for dataset in datasets.values()
+            for exchange in (
+                dataset.available_exchanges
+                if dataset.exchange == "combined"
+                else [dataset.exchange]
+            )
+            if exchange != "combined"
+        }
+    )
 
     contexts: List[ScenarioEvalContext] = []
 

--- a/tests/optimization/test_optimize_suite_contexts.py
+++ b/tests/optimization/test_optimize_suite_contexts.py
@@ -313,6 +313,66 @@ async def test_prepare_suite_contexts_expands_scenario_required_exchanges(monkey
 
 
 @pytest.mark.asyncio
+async def test_prepare_suite_contexts_keeps_explicit_exchange_out_of_combined_dataset(
+    monkeypatch,
+):
+    _stub_market_identity_validation(monkeypatch)
+    config = get_template_config()
+    config["backtest"]["start_date"] = "2024-01-01"
+    config["backtest"]["end_date"] = "2024-01-02"
+    config["backtest"]["exchanges"] = ["binance", "bybit"]
+    config["backtest"]["suite_enabled"] = True
+    config["backtest"]["scenarios"] = [
+        {"label": "bybit_only", "exchanges": ["bybit"], "coins": ["HYPE"]},
+    ]
+    config["live"]["approved_coins"] = {"long": ["HYPE"], "short": ["HYPE"]}
+    config["live"]["ignored_coins"] = {"long": [], "short": []}
+
+    async def fake_load_markets(_exchange, verbose=False):
+        return {}
+
+    async def fake_format_approved_ignored_coins(
+        _config, _exchanges, verbose=False, **_kwargs
+    ):
+        return None
+
+    async def fake_prepare_master_datasets(*_args, **_kwargs):
+        return {
+            "combined": _make_lazy_dataset(
+                coins=("HYPE",),
+                coin_exchange={"HYPE": "binance"},
+                available_exchanges=["binance", "bybit"],
+            ),
+            "bybit": _make_lazy_dataset(
+                exchange="bybit",
+                coins=("HYPE",),
+                coin_exchange={"HYPE": "bybit"},
+                available_exchanges=["bybit"],
+            ),
+        }
+
+    monkeypatch.setattr(optimize_suite, "load_markets", fake_load_markets)
+    monkeypatch.setattr(
+        optimize_suite,
+        "format_approved_ignored_coins",
+        fake_format_approved_ignored_coins,
+    )
+    monkeypatch.setattr(
+        optimize_suite, "prepare_master_datasets", fake_prepare_master_datasets
+    )
+
+    suite_cfg = optimize_suite.extract_suite_config(config, suite_override=None)
+    contexts, _reducer_cfg = await optimize_suite.prepare_suite_contexts(
+        config,
+        suite_cfg,
+        shared_array_manager=_NoSharedArrayManager(),
+    )
+
+    assert contexts[0].exchanges == ["bybit"]
+    assert contexts[0].msss["bybit"]["HYPE"]["exchange"] == "bybit"
+
+
+@pytest.mark.asyncio
 async def test_prepare_suite_contexts_rejects_unavailable_scenario_exchange(monkeypatch):
     _stub_market_identity_validation(monkeypatch)
     config = get_template_config()


### PR DESCRIPTION
## Summary
- include a combined dataset's full source-exchange identity when resolving optimizer suite contexts
- keep explicitly restricted scenarios on their requested individual exchange dataset instead of misclassifying them as the whole exchange pool
- prevent a Bybit-only scenario from consuming combined candles selected from another base exchange

## Validation
- focused optimizer suite and GPU backend tests
- full Python pytest suite
- Apple MPS pytest file (38 passed on M3)
- original dual-side two-coin GPU suite with base exchanges binance,bybit and two explicitly Bybit scenarios: 2048 proxy + 64 exact validations, 14.4s, no halt, no CLI exchange workaround

## Note
The first full-suite attempt hit an unrelated UTC-midnight test fixture boundary in test_disk_load_observer_receives_summary_and_is_best_effort; the isolated test and the complete suite both passed after the five-minute boundary.