### PR TITLE
GPU optimizer: support combined multi-exchange suite datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ All notable user-facing changes will be documented in this file.
 - Added canonical combined multi-exchange datasets and per-coin source assignments to Apple MPS
   optimizer suites. Metal consumes the same prepared per-coin candles and market settings as exact
   Rust, and checkpoint identity now records each coin's resolved OHLCV and market-settings source.
-  Individual-exchange scenarios fail closed if a per-coin assignment selects another exchange.
+  Individual-exchange scenarios fail closed if an assignment for one of their prepared coins
+  selects another exchange.
 
 - Fixed optimizer-suite exchange routing so an explicitly restricted scenario uses its requested
   individual exchange dataset even when only that exchange needed separate materialization. It no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable user-facing changes will be documented in this file.
 - Added canonical combined multi-exchange datasets and per-coin source assignments to Apple MPS
   optimizer suites. Metal consumes the same prepared per-coin candles and market settings as exact
   Rust, and checkpoint identity now records each coin's resolved OHLCV and market-settings source.
+  Individual-exchange scenarios fail closed if a per-coin assignment selects another exchange.
 
 - Fixed optimizer-suite exchange routing so an explicitly restricted scenario uses its requested
   individual exchange dataset even when only that exchange needed separate materialization. It no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added canonical combined multi-exchange datasets and per-coin source assignments to Apple MPS
+  optimizer suites. Metal consumes the same prepared per-coin candles and market settings as exact
+  Rust, and checkpoint identity now records each coin's resolved OHLCV and market-settings source.
+
 - Fixed optimizer-suite exchange routing so an explicitly restricted scenario uses its requested
   individual exchange dataset even when only that exchange needed separate materialization. It no
   longer falls through to a combined dataset whose candles may come from another base exchange.

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -123,7 +123,8 @@ The supported slice is intentionally narrow:
   config overrides are supported; scenario-local `coin_overrides`, starting balance, maker fee,
   liquidation threshold, Forager hysteresis, and hedge mode are also supported, while other
   non-bot override paths remain unsupported; combined scenarios may use canonical per-coin source
-  assignments
+  assignments, while an individual-exchange scenario fails closed if an effective assignment
+  selects another exchange
 - static `coin_overrides` for each enabled side of multi-coin EMA-anchor runs: EMA-anchor strategy
   parameters, `risk.entry_cooldown_minutes`, and explicit `wallet_exposure_limit` are supported;
   disabled sides and other override leaves fail closed

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -124,7 +124,7 @@ The supported slice is intentionally narrow:
   liquidation threshold, Forager hysteresis, and hedge mode are also supported, while other
   non-bot override paths remain unsupported; combined scenarios may use canonical per-coin source
   assignments, while an individual-exchange scenario fails closed if an effective assignment
-  selects another exchange
+  for one of its prepared coins selects another exchange
 - static `coin_overrides` for each enabled side of multi-coin EMA-anchor runs: EMA-anchor strategy
   parameters, `risk.entry_cooldown_minutes`, and explicit `wallet_exposure_limit` are supported;
   disabled sides and other override leaves fail closed

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -100,7 +100,8 @@ and the DEAP/pymoo CPU optimizers do not import or require PyTorch.
 The supported slice is intentionally narrow:
 
 - Apple Silicon with `torch.backends.mps.is_available()`
-- one exchange per independent run or suite scenario, using one-minute candles
+- one prepared dataset per independent run or suite scenario, using one-minute candles; the
+  dataset may be an individual exchange or the canonical combined multi-exchange dataset
 - `strategy_kind: ema_anchor` or `trailing_martingale`, with long-only, short-only, or
   long+short enabled for one coin
 - long-only, short-only, or dual-side hedge-mode multi-coin EMA-anchor runs for up to 64 coins,
@@ -113,14 +114,16 @@ The supported slice is intentionally narrow:
   for single-coin runs; supported multi-coin bounds may vary `n_positions` between `1` and the
   prepared coin count
 - hedge mode and one-way mode; one-way flat-side arbitration uses the active strategy's Rust rule
-- suite mode with exactly one exchange per scenario, including suites spanning exchanges;
+- suite mode with exactly one prepared dataset per scenario, including individual-exchange
+  comparisons and combined multi-exchange scenarios;
   single-coin EMA-anchor and trailing-martingale scenarios keep their existing directional
   support, while EMA-anchor suites may also use different multi-coin subsets of up to 64 coins when
   every effective scenario shares the same one-side or dual-side hedge-mode topology;
   scenario date, coin, ignored-coin, exchange selection, and fail-closed `bot.long`/`bot.short`
   config overrides are supported; scenario-local `coin_overrides`, starting balance, maker fee,
   liquidation threshold, Forager hysteresis, and hedge mode are also supported, while other
-  non-bot override paths and per-coin source assignments remain unsupported
+  non-bot override paths remain unsupported; combined scenarios may use canonical per-coin source
+  assignments
 - static `coin_overrides` for each enabled side of multi-coin EMA-anchor runs: EMA-anchor strategy
   parameters, `risk.entry_cooldown_minutes`, and explicit `wallet_exposure_limit` are supported;
   disabled sides and other override leaves fail closed
@@ -134,9 +137,8 @@ Unsupported combinations fail before optimization begins. Dual-side multi-coin E
 long and one short Metal dispatch per candidate in hedge mode. Their directional surfaces form a
 conservative portfolio screening proxy; every accepted metric still comes from the unchanged exact
 Rust portfolio backtest, and classification, rank, and drift gates halt material disagreement.
-Dual-side one-way arbitration, multi-coin trailing-martingale, combined multi-exchange datasets,
-unmodeled non-bot suite scenario overrides, per-coin source assignments, HSL, and auto-unstuck are
-not silently approximated by this release. Dual-side
+Dual-side one-way arbitration, multi-coin trailing-martingale, unmodeled non-bot suite scenario
+overrides, HSL, and auto-unstuck are not silently approximated by this release. Dual-side
 multi-coin screening also rejects `fills_gap_longest_days`,
 `strategy_eq_recovery_days_max`, and `volume_pct_per_day_avg`: the independent directional
 summaries cannot reconstruct cross-side-only fill gaps, alternating portfolio recovery periods,
@@ -147,7 +149,8 @@ path then calls the same canonical suite reducer and scenario-selection logic as
 for aggregate reducers, named-scenario objectives, and named-scenario or suite-reduced limits.
 Every exact validation still runs the unchanged Rust backtest for every scenario; only those exact
 suite metrics enter `all_results.bin` and the Pareto front. A scenario may select a different coin
-subset, date window, or exchange, but each scenario must use exactly one exchange. Scenario
+subset, date window, individual exchange, or canonical combined multi-exchange dataset, but each
+scenario must resolve to exactly one prepared dataset. Scenario
 `overrides` require
 explicit candidate-shadowing behavior in the proxy. This slice models `bot.long` and `bot.short`
 overrides: the canonical exact
@@ -162,8 +165,10 @@ the same suite reducer. Scenario-local `coin_overrides`, `backtest.starting_bala
 `backtest.maker_fee_override`, `backtest.liquidation_threshold`,
 `live.forager_score_hysteresis_pct`, and `live.hedge_mode` are accepted because every scenario
 proxy consumes them through the canonical backtest payload and then passes the same fail-closed
-scope checks. Other non-bot paths and scenario `coin_sources` remain rejected until their proxy
-semantics are modeled. The effective external suite definition and any `--scenarios` filter are
+scope checks. Combined scenario `coin_sources` use the same prepared per-coin candles and market
+settings as exact Rust; their resolved OHLCV and market-settings exchanges are part of checkpoint
+identity. Other non-bot paths remain rejected until their proxy semantics are modeled. The
+effective external suite definition and any `--scenarios` filter are
 stored in the run contract and checkpoint identity, with dynamic scenario dates resolved to the
 prepared concrete dates. The checkpoint signature also records each scenario's ordered effective
 coins, side topology, and prepared candle window, so resume fails closed if preparation changes.

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -960,6 +960,11 @@ def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict
                 f"got {exchanges}"
             )
         exchange = exchanges[0]
+        scenario_mss = ctx.msss[exchange]
+        effective_coins = [
+            str(coin) for coin in scenario_mss if coin != "__meta__"
+        ]
+        effective_coin_set = set(effective_coins)
         effective_coin_sources = (
             getattr(ctx, "config", {}).get("backtest", {}).get("coin_sources")
             or {}
@@ -969,7 +974,8 @@ def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict
             conflicting_sources = {
                 str(coin): str(source)
                 for coin, source in effective_coin_sources.items()
-                if to_standard_exchange_name(str(source)) != prepared_exchange
+                if str(coin) in effective_coin_set
+                and to_standard_exchange_name(str(source)) != prepared_exchange
             }
             if conflicting_sources:
                 raise ValueError(
@@ -990,9 +996,6 @@ def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict
             coin_count=coin_count,
             allow_suite=True,
         )
-        effective_coins = [
-            str(coin) for coin in ctx.msss[exchange] if coin != "__meta__"
-        ]
         if len(effective_coins) != coin_count:
             raise ValueError(
                 f"GPU suite scenario {ctx.label!r} prepared coin identity "
@@ -1007,7 +1010,7 @@ def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict
                 "coin_count": coin_count,
                 "coins": effective_coins,
                 "hlcvs": values,
-                "mss": ctx.msss[exchange],
+                "mss": scenario_mss,
                 "btc": btc,
                 "timestamps": ctx.timestamps.get(exchange),
             }

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -951,25 +951,14 @@ def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict
                     f"GPU suite scenario {ctx.label!r} override {dotted_path!r} is "
                     "outside the supported modeled scenario scope"
                 )
-        coin_sources = (
-            getattr(ctx, "config", {}).get("backtest", {}).get("coin_sources") or {}
-        )
-        if coin_sources:
-            raise ValueError(
-                f"GPU suite scenario {ctx.label!r} uses coin_sources; this slice "
-                "does not model per-coin source exchanges"
-            )
         exchanges = list(ctx.exchanges)
         if len(exchanges) != 1:
             raise ValueError(
-                f"GPU suite scenario {ctx.label!r} requires exactly one exchange, "
+                f"GPU suite scenario {ctx.label!r} requires exactly one prepared "
+                "dataset, "
                 f"got {exchanges}"
             )
         exchange = exchanges[0]
-        if exchange == "combined":
-            raise ValueError(
-                "GPU suite scenarios do not support combined multi-exchange datasets"
-            )
         hlcvs, btc, coin_indices = get_data(ctx, exchange)
         values = np.asarray(hlcvs)
         if coin_indices is not None:
@@ -1584,6 +1573,22 @@ def _gpu_suite_checkpoint_contract(config: dict, suite_inputs=None) -> dict:
                     f"GPU suite scenario {item['ctx'].label!r} timestamp identity "
                     f"mismatch: timestamps={len(timestamps)}, hlcvs={len(item['hlcvs'])}"
                 )
+            source_contract = []
+            scenario_mss = item.get("mss") or {}
+            for coin in item["coins"]:
+                metadata = scenario_mss.get(coin) or {}
+                market_exchange = str(
+                    metadata.get("exchange") or item["exchange"]
+                )
+                source_contract.append(
+                    {
+                        "coin": coin,
+                        "ohlcv_exchange": str(
+                            metadata.get("ohlcv_source") or market_exchange
+                        ),
+                        "market_settings_exchange": market_exchange,
+                    }
+                )
             prepared_scenarios.append(
                 {
                     "label": item["ctx"].label,
@@ -1607,6 +1612,7 @@ def _gpu_suite_checkpoint_contract(config: dict, suite_inputs=None) -> dict:
                     "last_timestamp": (
                         int(timestamps[-1]) if len(timestamps) else None
                     ),
+                    "coin_sources": source_contract,
                     "coin_overrides": deepcopy(
                         item.get("coin_override_contract")
                         or item["config"].get("coin_overrides", {})

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -29,6 +29,7 @@ from optimization.problem import (
     _evaluate_pymoo_worker_from_globals,
     initialize_pymoo_worker,
 )
+from utils import to_standard_exchange_name
 
 
 GPU_DEFAULTS = {
@@ -959,6 +960,23 @@ def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict
                 f"got {exchanges}"
             )
         exchange = exchanges[0]
+        effective_coin_sources = (
+            getattr(ctx, "config", {}).get("backtest", {}).get("coin_sources")
+            or {}
+        )
+        if exchange != "combined":
+            prepared_exchange = to_standard_exchange_name(exchange)
+            conflicting_sources = {
+                str(coin): str(source)
+                for coin, source in effective_coin_sources.items()
+                if to_standard_exchange_name(str(source)) != prepared_exchange
+            }
+            if conflicting_sources:
+                raise ValueError(
+                    f"GPU suite scenario {ctx.label!r} assigns coin_sources "
+                    f"outside prepared dataset {prepared_exchange!r}: "
+                    f"{conflicting_sources}"
+                )
         hlcvs, btc, coin_indices = get_data(ctx, exchange)
         values = np.asarray(hlcvs)
         if coin_indices is not None:

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -991,6 +991,38 @@ def test_gpu_suite_inputs_accept_matching_individual_dataset_coin_source(source)
     assert prepared[0]["exchange"] == "binance"
 
 
+def test_gpu_suite_inputs_ignore_conflicting_source_for_excluded_coin():
+    config = _long_only_ema_config()
+    config["backtest"]["suite_enabled"] = True
+    ctx = SimpleNamespace(
+        label="bybit_btc_only",
+        config={
+            "backtest": {
+                "coin_sources": {"BTC": "bybit", "ETH": "binance"}
+            }
+        },
+        overrides={},
+        exchanges=["bybit"],
+        msss={"bybit": {"BTC": {}, "__meta__": {}}},
+        timestamps={"bybit": np.arange(10, dtype=np.int64)},
+    )
+
+    class Suite:
+        contexts = [ctx]
+
+        @staticmethod
+        def get_prepared_context_data(_ctx, _exchange):
+            return np.zeros((10, 1, 4)), np.ones(10), [0]
+
+        @staticmethod
+        def build_scenario_candidate_config(proxy_config, _ctx):
+            return copy.deepcopy(proxy_config)
+
+    prepared = _gpu_suite_scenario_inputs(config, Suite())
+
+    assert prepared[0]["coins"] == ["BTC"]
+
+
 def test_gpu_suite_inputs_reject_coin_source_outside_individual_dataset():
     config = _long_only_ema_config()
     config["backtest"]["suite_enabled"] = True

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -962,6 +962,62 @@ def test_gpu_suite_inputs_accept_combined_dataset_and_coin_sources():
     }
 
 
+@pytest.mark.parametrize("source", ["binance", "binanceusdm"])
+def test_gpu_suite_inputs_accept_matching_individual_dataset_coin_source(source):
+    config = _long_only_ema_config()
+    config["backtest"]["suite_enabled"] = True
+    ctx = SimpleNamespace(
+        label="binance_only",
+        config={"backtest": {"coin_sources": {"BTC": source}}},
+        overrides={},
+        exchanges=["binance"],
+        msss={"binance": {"BTC": {}, "__meta__": {}}},
+        timestamps={"binance": np.arange(10, dtype=np.int64)},
+    )
+
+    class Suite:
+        contexts = [ctx]
+
+        @staticmethod
+        def get_prepared_context_data(_ctx, _exchange):
+            return np.zeros((10, 1, 4)), np.ones(10), [0]
+
+        @staticmethod
+        def build_scenario_candidate_config(proxy_config, _ctx):
+            return copy.deepcopy(proxy_config)
+
+    prepared = _gpu_suite_scenario_inputs(config, Suite())
+
+    assert prepared[0]["exchange"] == "binance"
+
+
+def test_gpu_suite_inputs_reject_coin_source_outside_individual_dataset():
+    config = _long_only_ema_config()
+    config["backtest"]["suite_enabled"] = True
+    ctx = SimpleNamespace(
+        label="bybit_only",
+        config={"backtest": {"coin_sources": {"BTC": "binance"}}},
+        overrides={},
+        exchanges=["bybit"],
+        msss={"bybit": {"BTC": {}, "__meta__": {}}},
+        timestamps={"bybit": np.arange(10, dtype=np.int64)},
+    )
+
+    class Suite:
+        contexts = [ctx]
+
+        @staticmethod
+        def get_prepared_context_data(_ctx, _exchange):
+            raise AssertionError("conflicting source must fail before data access")
+
+        @staticmethod
+        def build_scenario_candidate_config(proxy_config, _ctx):
+            return copy.deepcopy(proxy_config)
+
+    with pytest.raises(ValueError, match="outside prepared dataset 'bybit'"):
+        _gpu_suite_scenario_inputs(config, Suite())
+
+
 def test_gpu_suite_inputs_accept_one_exchange_per_scenario():
     config = _long_only_ema_config()
     config["backtest"]["suite_enabled"] = True

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -542,8 +542,7 @@ def test_gpu_suite_inputs_accept_dual_side_multicoin_hedge_scenario():
     ("overrides", "exchanges", "coin_indices", "message"),
     [
         ({"live.strategy_kind": "trailing_martingale"}, ["bybit"], [0], "outside the supported"),
-        ({}, ["bybit", "binance"], [0], "exactly one exchange"),
-        ({}, ["combined"], [0], "combined multi-exchange"),
+        ({}, ["bybit", "binance"], [0], "exactly one prepared dataset"),
     ],
 )
 def test_gpu_suite_inputs_reject_unsupported_scenario_scope(
@@ -919,16 +918,27 @@ def test_gpu_suite_inputs_revalidate_effective_bot_override_scope():
         _gpu_suite_scenario_inputs(config, Suite())
 
 
-def test_gpu_suite_inputs_reject_effective_coin_sources():
+def test_gpu_suite_inputs_accept_combined_dataset_and_coin_sources():
     config = _long_only_ema_config()
     config["backtest"]["suite_enabled"] = True
+    config["live"]["approved_coins"]["long"] = ["BTC", "ETH"]
+    config["bot"]["long"]["risk"]["n_positions"] = 2
+    config["backtest"]["coin_sources"] = {"BTC": "bybit", "ETH": "binance"}
     ctx = SimpleNamespace(
-        label="stress",
-        config={"backtest": {"coin_sources": {"BTC": "binance"}}},
+        label="mixed_sources",
+        config={
+            "backtest": {"coin_sources": {"BTC": "bybit", "ETH": "binance"}}
+        },
         overrides={},
-        exchanges=["bybit"],
-        msss={"bybit": {"BTC": {}, "__meta__": {}}},
-        timestamps={"bybit": np.arange(10, dtype=np.int64)},
+        exchanges=["combined"],
+        msss={
+            "combined": {
+                "BTC": {"exchange": "bybit", "ohlcv_source": "bybit"},
+                "ETH": {"exchange": "binance", "ohlcv_source": "binance"},
+                "__meta__": {},
+            }
+        },
+        timestamps={"combined": np.arange(10, dtype=np.int64)},
     )
 
     class Suite:
@@ -936,14 +946,20 @@ def test_gpu_suite_inputs_reject_effective_coin_sources():
 
         @staticmethod
         def get_prepared_context_data(_ctx, _exchange):
-            return np.zeros((10, 1, 4)), np.ones(10), [0]
+            return np.zeros((10, 2, 4)), np.ones(10), [0, 1]
 
         @staticmethod
         def build_scenario_candidate_config(proxy_config, _ctx):
             return copy.deepcopy(proxy_config)
 
-    with pytest.raises(ValueError, match="coin_sources"):
-        _gpu_suite_scenario_inputs(config, Suite())
+    prepared = _gpu_suite_scenario_inputs(config, Suite())
+
+    assert prepared[0]["exchange"] == "combined"
+    assert prepared[0]["coins"] == ["BTC", "ETH"]
+    assert prepared[0]["config"]["backtest"]["coin_sources"] == {
+        "BTC": "bybit",
+        "ETH": "binance",
+    }
 
 
 def test_gpu_suite_inputs_accept_one_exchange_per_scenario():
@@ -2951,6 +2967,10 @@ def test_gpu_suite_checkpoint_contract_tracks_prepared_scenario_identity():
         "config": config,
         "hlcvs": np.zeros((3, 2, 4)),
         "timestamps": np.array([1000, 2000, 3000]),
+        "mss": {
+            "BTC": {"exchange": "binance", "ohlcv_source": "bybit"},
+            "ETH": {"exchange": "bybit"},
+        },
     }
     original = _gpu_suite_checkpoint_contract(config, [item])
 
@@ -2965,6 +2985,18 @@ def test_gpu_suite_checkpoint_contract_tracks_prepared_scenario_identity():
             "candle_count": 3,
             "first_timestamp": 1000,
             "last_timestamp": 3000,
+            "coin_sources": [
+                {
+                    "coin": "BTC",
+                    "ohlcv_exchange": "bybit",
+                    "market_settings_exchange": "binance",
+                },
+                {
+                    "coin": "ETH",
+                    "ohlcv_exchange": "bybit",
+                    "market_settings_exchange": "bybit",
+                },
+            ],
             "coin_overrides": {},
         }
     ]
@@ -2973,9 +3005,12 @@ def test_gpu_suite_checkpoint_contract_tracks_prepared_scenario_identity():
     changed_coins["coins"] = ["BTC", "SOL"]
     changed_window = copy.deepcopy(item)
     changed_window["timestamps"] = np.array([1000, 2000, 4000])
+    changed_source = copy.deepcopy(item)
+    changed_source["mss"]["BTC"]["ohlcv_source"] = "binance"
 
     assert _gpu_suite_checkpoint_contract(config, [changed_coins]) != original
     assert _gpu_suite_checkpoint_contract(config, [changed_window]) != original
+    assert _gpu_suite_checkpoint_contract(config, [changed_source]) != original
 
 
 def test_gpu_suite_checkpoint_contract_rejects_timestamp_shape_mismatch():


### PR DESCRIPTION
## Summary
- allow GPU suite scenarios backed by one canonical combined multi-exchange dataset
- consume canonical per-coin OHLCV and market settings prepared for exact Rust
- include resolved per-coin OHLCV and market-settings exchanges in checkpoint identity
- retain fail-closed rejection when a scenario exposes more than one prepared dataset

## Validation
- focused GPU backend/service tests
- full Python test suite
- 38 dedicated Apple MPS tests
- real M3/MPS dual-side two-coin, two-scenario run: BTC forced to Bybit, ETH forced to Binance; 2,048 proxy + 64 exact evaluations in 13.7s, no drift/parity halt

GPU support remains additive; CPU optimization and exact Rust backtesting are unchanged.