### PR TITLE
feat(optimize): support dual-side multicoin TM MPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,18 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added dual-side hedge-mode multi-coin Trailing Martingale optimization and compatible suites to
+  the experimental Apple MPS backend. Each candidate receives independent long and short Metal
+  screening dispatches which feed the existing conservative combined-equity proxy; exact Rust
+  portfolio backtests and the normal classification, rank, and drift gates remain authoritative.
+  One-way dual-side arbitration and Trailing Martingale coin overrides remain unsupported.
+
 - Added long-only and short-only multi-coin Trailing Martingale optimization to the experimental
   Apple MPS backend, including compatible suites. A dedicated Rust-owned Metal kernel combines
   per-coin trailing-martingale state with the existing dynamic wallet-exposure and Forager
   portfolio model; exact Rust backtests remain authoritative and the existing constraint, rank,
-  and drift gates fail closed on proxy disagreement. Dual-side multi-coin Trailing Martingale and
-  Trailing Martingale coin overrides remain explicitly unsupported.
+  and drift gates fail closed on proxy disagreement. Trailing Martingale coin overrides remain
+  explicitly unsupported.
 
 - Added canonical combined multi-exchange datasets and per-coin source assignments to Apple MPS
   optimizer suites. Metal consumes the same prepared per-coin candles and market settings as exact

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -663,7 +663,7 @@ Risk should be constrained through canonical `*_strategy_eq` metrics instead. De
 - **backend**: Optimizer backend. Default is `pymoo`. Supported values are `deap`, `pymoo`, and
   experimental `gpu`. The GPU backend currently supports Apple MPS, single-coin EMA-anchor and
   trailing-martingale runs in long-only, short-only, and long+short modes; single-side and
-  dual-side hedge-mode multi-coin EMA-anchor runs; anchored fine-tuning with `--start` plus
+  dual-side hedge-mode multi-coin runs for both strategies; anchored fine-tuning with `--start` plus
   `--fine-tune-params`; and the V8
   `mirror_short_from_long` and `lossless_close_trailing` optimizer overrides. See
   `docs/optimizing.md` for its fail-closed scope and `optimize.gpu` settings.

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -104,15 +104,12 @@ The supported slice is intentionally narrow:
   dataset may be an individual exchange or the canonical combined multi-exchange dataset
 - `strategy_kind: ema_anchor` or `trailing_martingale`, with long-only, short-only, or
   long+short enabled for one coin
-- long-only, short-only, or dual-side hedge-mode multi-coin EMA-anchor runs for up to 64 coins,
-  with dynamic wallet-exposure allocation and independent per-side Forager selection; dual-side
-  runs require matching long/short approved and ignored coin sets, and all multi-coin runs require
-  `backtest.dynamic_wel_by_tradability: true`; `live.forager_score_hysteresis_pct` preserves flat
-  incumbent candidates when a challenger's normalized Forager-score lead is within the configured
-  gap
-- long-only or short-only multi-coin trailing-martingale runs for up to 64 coins, using the same
-  dynamic wallet-exposure and Forager-selection contract; dual-side multi-coin trailing martingale
-  remains unsupported
+- long-only, short-only, or dual-side hedge-mode multi-coin EMA-anchor and trailing-martingale runs
+  for up to 64 coins, with dynamic wallet-exposure allocation and independent per-side Forager
+  selection; dual-side runs require matching long/short approved and ignored coin sets, and all
+  multi-coin runs require `backtest.dynamic_wel_by_tradability: true`;
+  `live.forager_score_hysteresis_pct` preserves flat incumbent candidates when a challenger's
+  normalized Forager-score lead is within the configured gap
 - each enabled side's `n_positions` pinned to `1` and wallet-exposure limit kept positive
   for single-coin runs; supported multi-coin bounds may vary `n_positions` between `1` and the
   prepared coin count
@@ -120,9 +117,8 @@ The supported slice is intentionally narrow:
 - suite mode with exactly one prepared dataset per scenario, including individual-exchange
   comparisons and combined multi-exchange scenarios;
   single-coin EMA-anchor and trailing-martingale scenarios keep their existing directional
-  support, while EMA-anchor and single-side trailing-martingale suites may also use different
-  multi-coin subsets of up to 64 coins when every effective scenario shares the same supported
-  side topology;
+  support, while both strategies' suites may also use different multi-coin subsets of up to 64
+  coins when every effective scenario shares the same supported side topology;
   scenario date, coin, ignored-coin, exchange selection, and fail-closed `bot.long`/`bot.short`
   config overrides are supported; scenario-local `coin_overrides` for supported multi-coin
   EMA-anchor runs, starting balance, maker fee, liquidation threshold, Forager hysteresis, and
@@ -139,12 +135,13 @@ The supported slice is intentionally narrow:
 - `live.market_orders_allowed: false`
 - no invalid candle tail after the selected coin's final valid candle
 
-Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor uses one
-long and one short Metal dispatch per candidate in hedge mode. Their directional surfaces form a
+Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor and
+Trailing Martingale use one long and one short Metal dispatch per candidate in hedge mode. Their
+directional surfaces form a
 conservative portfolio screening proxy; every accepted metric still comes from the unchanged exact
 Rust portfolio backtest, and classification, rank, and drift gates halt material disagreement.
-Dual-side one-way arbitration, dual-side multi-coin trailing martingale, trailing-martingale
-`coin_overrides`, unmodeled non-bot suite scenario overrides, HSL, and auto-unstuck are not
+Dual-side one-way arbitration, trailing-martingale `coin_overrides`, unmodeled non-bot suite
+scenario overrides, HSL, and auto-unstuck are not
 silently approximated by this release. Dual-side
 multi-coin screening also rejects `fills_gap_longest_days`,
 `strategy_eq_recovery_days_max`, and `volume_pct_per_day_avg`: the independent directional

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -776,16 +776,11 @@ def _validate_scope_config(
             raise ValueError(
                 "GPU multicoin foundation requires one or two enabled sides"
             )
-        if strategy_kind == "trailing_martingale" and len(enabled_sides) != 1:
-            raise ValueError(
-                "GPU multi-coin Trailing Martingale currently requires exactly "
-                "one enabled side"
-            )
         if len(enabled_sides) == 2 and not bool(
             config.get("live", {}).get("hedge_mode")
         ):
             raise ValueError(
-                "GPU dual-side multicoin EMA Anchor currently requires "
+                "GPU dual-side multicoin optimization currently requires "
                 "live.hedge_mode=true; one-way arbitration is not modeled"
             )
         if len(enabled_sides) == 2:
@@ -796,7 +791,7 @@ def _validate_scope_config(
                     values.get("short", []) or []
                 ):
                     raise ValueError(
-                        "GPU dual-side multicoin EMA Anchor currently requires "
+                        "GPU dual-side multicoin optimization currently requires "
                         f"matching long/short {label}_coins"
                     )
         if not bool(config.get("backtest", {}).get("dynamic_wel_by_tradability")):
@@ -852,7 +847,7 @@ def _validate_dual_multicoin_metrics(
     )
     if unsupported:
         raise ValueError(
-            "GPU dual-side multicoin EMA Anchor cannot safely reconstruct proxy "
+            "GPU dual-side multicoin optimization cannot safely reconstruct proxy "
             f"metrics {unsupported} from independent directional summaries; "
             "use other metrics or the CPU optimizer"
         )
@@ -1081,11 +1076,6 @@ def _gpu_suite_search_context(
             raise ValueError(
                 "GPU multicoin suites require one or two enabled sides in every "
                 f"scenario; {item['ctx'].label!r} has {list(sides)}"
-            )
-        if strategy_kind == "trailing_martingale" and len(sides) != 1:
-            raise ValueError(
-                "GPU multi-coin Trailing Martingale suites currently require "
-                f"exactly one enabled side; {item['ctx'].label!r} has {list(sides)}"
             )
     common_topologies = set(sides_by_label.values())
     if len(common_topologies) != 1:
@@ -2272,11 +2262,6 @@ def run_backend(
         if len(multicoin_sides) not in (1, 2):
             raise ValueError(
                 "GPU multicoin foundation requires one or two enabled sides"
-            )
-        if strategy_kind == "trailing_martingale" and len(multicoin_sides) != 1:
-            raise ValueError(
-                "GPU multi-coin Trailing Martingale currently requires exactly "
-                "one enabled side"
             )
         bound_map = {}
         for multicoin_side in multicoin_sides:

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -537,11 +537,6 @@ class MpsMulticoinProxy:
                 "MPS multicoin proxy requires one or two enabled sides"
             )
         self.sides = enabled_sides
-        if self.strategy_kind == "trailing_martingale" and len(enabled_sides) != 1:
-            raise ValueError(
-                "MPS multi-coin Trailing Martingale currently requires exactly "
-                "one enabled side"
-            )
         if len(enabled_sides) == 2 and not bool(
             config.get("live", {}).get("hedge_mode")
         ):

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -781,11 +781,13 @@ def test_gpu_suite_search_context_accepts_single_side_multicoin_trailing_marting
     ) == (2, 2, ("long",))
 
 
-def test_gpu_suite_search_context_rejects_dual_side_multicoin_trailing_martingale():
+def test_gpu_suite_search_context_accepts_dual_side_multicoin_trailing_martingale():
     config = _directional_tm_config(long_enabled=True, short_enabled=True)
+    config["live"]["hedge_mode"] = True
 
-    with pytest.raises(ValueError, match="exactly one enabled side"):
-        _gpu_suite_search_context([_suite_search_input("multi", config, 2)])
+    assert _gpu_suite_search_context(
+        [_suite_search_input("multi", config, 2)]
+    ) == (2, 2, ("long", "short"))
 
 
 def test_gpu_suite_search_context_rejects_mixed_multicoin_strategy_kinds():
@@ -1434,7 +1436,7 @@ def test_gpu_multicoin_foundation_accepts_single_side_trailing_martingale(side):
     assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
-def test_gpu_multicoin_foundation_rejects_dual_side_trailing_martingale():
+def test_gpu_multicoin_foundation_accepts_dual_side_trailing_martingale():
     config = _directional_tm_config(long_enabled=True, short_enabled=True)
     config["live"]["approved_coins"] = {
         "long": ["BTC", "ETH", "SOL"],
@@ -1444,8 +1446,7 @@ def test_gpu_multicoin_foundation_rejects_dual_side_trailing_martingale():
     config["live"]["forager_score_hysteresis_pct"] = 0.0
     config["backtest"]["dynamic_wel_by_tradability"] = True
 
-    with pytest.raises(ValueError, match="exactly one enabled side"):
-        _validate_scope(config, _MulticoinEvaluator())
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
 def test_gpu_multicoin_foundation_accepts_dual_side_hedge_mode():
@@ -1470,8 +1471,14 @@ def test_gpu_multicoin_foundation_accepts_forager_score_hysteresis():
     assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
-def test_gpu_multicoin_foundation_rejects_dual_side_one_way_mode():
-    config = _directional_ema_config(long_enabled=True, short_enabled=True)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+def test_gpu_multicoin_foundation_rejects_dual_side_one_way_mode(strategy_kind):
+    builder = (
+        _directional_tm_config
+        if strategy_kind == "trailing_martingale"
+        else _directional_ema_config
+    )
+    config = builder(long_enabled=True, short_enabled=True)
     config["live"]["approved_coins"] = {
         "long": ["BTC", "ETH", "SOL"],
         "short": ["BTC", "ETH", "SOL"],
@@ -1511,8 +1518,14 @@ def test_gpu_multicoin_foundation_accepts_dual_side_coin_overrides():
     assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
-def test_gpu_multicoin_foundation_rejects_asymmetric_dual_side_coins():
-    config = _directional_ema_config(long_enabled=True, short_enabled=True)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+def test_gpu_multicoin_foundation_rejects_asymmetric_dual_side_coins(strategy_kind):
+    builder = (
+        _directional_tm_config
+        if strategy_kind == "trailing_martingale"
+        else _directional_ema_config
+    )
+    config = builder(long_enabled=True, short_enabled=True)
     config["live"]["approved_coins"] = {
         "long": ["BTC", "ETH", "SOL"],
         "short": ["BTC", "ETH"],

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -113,6 +113,33 @@ def test_multicoin_tm_parameter_matrix_keeps_forager_and_strategy_values(side):
     ] == 0.25
 
 
+def test_multicoin_tm_parameter_matrix_keeps_dual_side_values_separate():
+    proxy = MpsMulticoinEmaProxy.__new__(MpsMulticoinEmaProxy)
+    proxy.sides = ["long", "short"]
+    proxy.param_keys = TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+    proxy.base_params = {
+        "long": {
+            key: 1.0 for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+        },
+        "short": {
+            key: 2.0 for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+        },
+    }
+    candidate = {
+        "long_entry_threshold_base_pct": 0.125,
+        "short_entry_threshold_base_pct": 0.25,
+    }
+
+    long_matrix = proxy._parameter_matrix([candidate], "long")
+    short_matrix = proxy._parameter_matrix([candidate], "short")
+
+    index = TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(
+        "entry_threshold_base_pct"
+    )
+    assert long_matrix[0, index] == 0.125
+    assert short_matrix[0, index] == 0.25
+
+
 def test_combine_hedged_multicoin_outputs_uses_conservative_surface():
     torch = pytest.importorskip("torch")
 


### PR DESCRIPTION
## Summary

- enable dual-side hedge-mode multi-coin Trailing Martingale on the experimental Apple MPS optimizer
- reuse the existing independent long/short Metal dispatches and conservative combined-equity proxy
- extend compatible suite topology handling and fail-closed scope coverage
- update user-facing GPU support documentation and changelog

Exact Rust portfolio backtests remain authoritative. One-way arbitration, asymmetric long/short coin sets, unsafe combined metrics, Trailing Martingale coin overrides, HSL, unstuck, and unsupported exposure controls still fail closed. CPU optimization and bot/backtest paths are unchanged.

## Validation

- full Python test suite
- 42/42 Apple MPS hardware regression tests
- 261 Rust tests plus `cargo fmt --check` and `cargo check --tests`
- AI docs and generated-event registry checks
- offline cached BTC+ETH dual-side MPS smoke: 512 proxy + 64 exact validations, no halt
- offline cached BTC+ETH two-scenario suite smoke: 512 proxy + 64 exact validations, no halt
