### PR TITLE
feat(optimize): support TM coin overrides on MPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,23 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added static per-coin Trailing Martingale overrides to single-side and dual-side multi-coin Apple
+  MPS optimization and compatible suites. The Metal proxy consumes exact-last per-coin strategy,
+  entry-cooldown, and wallet-exposure values; checkpoint identity records each resolved override
+  matrix, while exact Rust backtests and the normal drift gates remain authoritative. Unsupported
+  override leaves continue to fail before optimization begins.
+
 - Added dual-side hedge-mode multi-coin Trailing Martingale optimization and compatible suites to
   the experimental Apple MPS backend. Each candidate receives independent long and short Metal
   screening dispatches which feed the existing conservative combined-equity proxy; exact Rust
   portfolio backtests and the normal classification, rank, and drift gates remain authoritative.
-  One-way dual-side arbitration and Trailing Martingale coin overrides remain unsupported.
+  One-way dual-side arbitration remains unsupported.
 
 - Added long-only and short-only multi-coin Trailing Martingale optimization to the experimental
   Apple MPS backend, including compatible suites. A dedicated Rust-owned Metal kernel combines
   per-coin trailing-martingale state with the existing dynamic wallet-exposure and Forager
   portfolio model; exact Rust backtests remain authoritative and the existing constraint, rank,
-  and drift gates fail closed on proxy disagreement. Trailing Martingale coin overrides remain
-  explicitly unsupported.
+  and drift gates fail closed on proxy disagreement.
 
 - Added canonical combined multi-exchange datasets and per-coin source assignments to Apple MPS
   optimizer suites. Metal consumes the same prepared per-coin candles and market settings as exact

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -121,14 +121,15 @@ The supported slice is intentionally narrow:
   coins when every effective scenario shares the same supported side topology;
   scenario date, coin, ignored-coin, exchange selection, and fail-closed `bot.long`/`bot.short`
   config overrides are supported; scenario-local `coin_overrides` for supported multi-coin
-  EMA-anchor runs, starting balance, maker fee, liquidation threshold, Forager hysteresis, and
-  hedge mode are also supported, while other
+  EMA-anchor and trailing-martingale runs, starting balance, maker fee, liquidation threshold,
+  Forager hysteresis, and hedge mode are also supported, while other
   non-bot override paths remain unsupported; combined scenarios may use canonical per-coin source
   assignments, while an individual-exchange scenario fails closed if an effective assignment
   for one of its prepared coins selects another exchange
-- static `coin_overrides` for each enabled side of multi-coin EMA-anchor runs: EMA-anchor strategy
-  parameters, `risk.entry_cooldown_minutes`, and explicit `wallet_exposure_limit` are supported;
-  disabled sides and other override leaves fail closed
+- static `coin_overrides` for each enabled side of multi-coin EMA-anchor and trailing-martingale
+  runs: active-strategy parameters, `risk.entry_cooldown_minutes`, and explicit
+  `wallet_exposure_limit` are supported; trailing-martingale `entry.ema_gate_mode`, disabled sides,
+  and other override leaves fail closed
 - HSL and auto-unstuck disabled
 - BTC collateral, realized-loss gating, and exposure enforcers disabled
 - `backtest.filter_by_min_effective_cost: false`
@@ -140,9 +141,8 @@ Trailing Martingale use one long and one short Metal dispatch per candidate in h
 directional surfaces form a
 conservative portfolio screening proxy; every accepted metric still comes from the unchanged exact
 Rust portfolio backtest, and classification, rank, and drift gates halt material disagreement.
-Dual-side one-way arbitration, trailing-martingale `coin_overrides`, unmodeled non-bot suite
-scenario overrides, HSL, and auto-unstuck are not
-silently approximated by this release. Dual-side
+Dual-side one-way arbitration, unmodeled non-bot suite scenario overrides, HSL, and auto-unstuck
+are not silently approximated by this release. Dual-side
 multi-coin screening also rejects `fills_gap_longest_days`,
 `strategy_eq_recovery_days_max`, and `volume_pct_per_day_avg`: the independent directional
 summaries cannot reconstruct cross-side-only fill gaps, alternating portfolio recovery periods,

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -129,6 +129,8 @@ mod tests {
         assert!(source.contains("kernel void passivbot_trailing_martingale_multicoin"));
         assert!(source.contains("constant int MAX_COINS = 64"));
         assert!(source.contains("constant int PARAM_COLS = 34"));
+        assert!(source.contains("constant int OVERRIDE_COLS = 25"));
+        assert!(source.contains("coin_override_or"));
         assert!(source.contains("min_since_open"));
         assert!(source.contains("max_since_min"));
         assert!(source.contains("max_since_open"));

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -3,6 +3,7 @@ using namespace metal;
 
 constant int MAX_COINS = 64;
 constant int PARAM_COLS = 34;
+constant int OVERRIDE_COLS = 25;
 constant int COIN_COLS = 11;
 constant int DAILY_COLS = 6;
 constant int SCALAR_COLS = 18;
@@ -36,6 +37,13 @@ inline float min_entry_qty(
 
 inline bool finite_positive(float value) {
     return isfinite(value) && value > 0.0f;
+}
+
+inline float coin_override_or(
+    constant float* coin_overrides, int coin, int column, float fallback
+) {
+    float value = coin_overrides[coin * OVERRIDE_COLS + column];
+    return isfinite(value) ? value : fallback;
 }
 
 inline float calc_close_qty(
@@ -77,6 +85,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     constant int* touch_min_qty_bits,
     constant int* touch_min_qty_relation,
     constant float* coin_settings,
+    constant float* coin_overrides,
     constant float* params,
     constant float* run_settings,
     constant int* sizes,
@@ -99,19 +108,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     const int po = int(b) * PARAM_COLS;
     const float span_a = params[po + 0];
     const float span_b = params[po + 1];
-    const float span_c = sqrt(fmax(span_a * span_b, 1.0f));
-    const float span_lo = fmin(span_a, fmin(span_b, span_c));
-    const float span_hi = fmax(span_a, fmax(span_b, span_c));
-    const float span_mid = span_a + span_b + span_c - span_lo - span_hi;
-    const float alpha0 = clamp(2.0f / (span_lo + 1.0f), 0.0f, 1.0f);
-    const float alpha1 = clamp(2.0f / (span_mid + 1.0f), 0.0f, 1.0f);
-    const float alpha2 = clamp(2.0f / (span_hi + 1.0f), 0.0f, 1.0f);
     const float span_1h = params[po + 2];
     const float span_1m = params[po + 3];
-    const float alpha_1h = span_1h > 0.0f
-        ? 2.0f / (fmax(span_1h, 1.0f) + 1.0f) : 0.0f;
-    const float alpha_1m = span_1m > 0.0f
-        ? clamp(2.0f / (span_1m + 1.0f), 0.0f, 1.0f) : 0.0f;
     const float ddf = params[po + 4];
     const float initial_ema_dist = params[po + 5];
     const float initial_qty_pct = params[po + 6];
@@ -234,11 +232,36 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         survivor[c] = false;
         entry_candidate[c] = false;
         filled_coin[c] = false;
-        alpha0_coin[c] = alpha0;
-        alpha1_coin[c] = alpha1;
-        alpha2_coin[c] = alpha2;
-        alpha_1h_coin[c] = alpha_1h;
-        alpha_1m_coin[c] = alpha_1m;
+        float coin_span_a = c < C
+            ? coin_override_or(coin_overrides, c, 0, span_a) : span_a;
+        float coin_span_b = c < C
+            ? coin_override_or(coin_overrides, c, 1, span_b) : span_b;
+        float coin_span_c = sqrt(fmax(coin_span_a * coin_span_b, 1.0f));
+        float coin_span_lo = fmin(
+            coin_span_a, fmin(coin_span_b, coin_span_c)
+        );
+        float coin_span_hi = fmax(
+            coin_span_a, fmax(coin_span_b, coin_span_c)
+        );
+        float coin_span_mid = coin_span_a + coin_span_b + coin_span_c
+            - coin_span_lo - coin_span_hi;
+        alpha0_coin[c] = clamp(
+            2.0f / (coin_span_lo + 1.0f), 0.0f, 1.0f
+        );
+        alpha1_coin[c] = clamp(
+            2.0f / (coin_span_mid + 1.0f), 0.0f, 1.0f
+        );
+        alpha2_coin[c] = clamp(
+            2.0f / (coin_span_hi + 1.0f), 0.0f, 1.0f
+        );
+        float coin_span_1h = c < C
+            ? coin_override_or(coin_overrides, c, 2, span_1h) : span_1h;
+        float coin_span_1m = c < C
+            ? coin_override_or(coin_overrides, c, 3, span_1m) : span_1m;
+        alpha_1h_coin[c] = coin_span_1h > 0.0f
+            ? 2.0f / (fmax(coin_span_1h, 1.0f) + 1.0f) : 0.0f;
+        alpha_1m_coin[c] = coin_span_1m > 0.0f
+            ? clamp(2.0f / (coin_span_1m + 1.0f), 0.0f, 1.0f) : 0.0f;
     }
     for (int j = 0; j < GAP_BINS; ++j) {
         gap_hist[int(b) * GAP_BINS + j] = 0;
@@ -455,9 +478,12 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             int coin_offset = c * COIN_COLS;
             int bar_offset = (k * C + c) * 4;
             float close = bars[bar_offset + 2];
+            float coin_wel = coin_override_or(
+                coin_overrides, c, 24, -1.0f
+            );
             if (k >= int(coin_settings[coin_offset + 8])
                 && k <= int(coin_settings[coin_offset + 7])
-                && finite_positive(close) && twel > 0.0f) {
+                && finite_positive(close) && coin_wel != 0.0f) {
                 tradable_count += 1;
             }
         }
@@ -486,10 +512,14 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 for (int c = 0; c < C; ++c) {
                     int coin_offset = c * COIN_COLS;
                     int bar_offset = (k * C + c) * 4;
+                    float coin_wel = coin_override_or(
+                        coin_overrides, c, 24, -1.0f
+                    );
                     bool enabled = !selected[c]
                         && k >= int(coin_settings[coin_offset + 8])
                         && k <= int(coin_settings[coin_offset + 7])
-                        && finite_positive(bars[bar_offset + 2]) && twel > 0.0f;
+                        && finite_positive(bars[bar_offset + 2])
+                        && coin_wel != 0.0f;
                     survivor[c] = enabled;
                     if (enabled) enabled_count += 1;
                 }
@@ -522,9 +552,12 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     float close = bars[bar_offset + 2];
                     float lower = fmin(ema0[c], fmin(ema1[c], ema2[c]));
                     float upper = fmax(ema0[c], fmax(ema1[c], ema2[c]));
+                    float coin_initial_ema_dist = coin_override_or(
+                        coin_overrides, c, 5, initial_ema_dist
+                    );
                     float threshold = short_side
-                        ? upper * (1.0f + initial_ema_dist)
-                        : lower * (1.0f - initial_ema_dist);
+                        ? upper * (1.0f + coin_initial_ema_dist)
+                        : lower * (1.0f - coin_initial_ema_dist);
                     float readiness = threshold > 0.0f
                         ? (short_side ? 1.0f - close / threshold : close / threshold - 1.0f)
                         : INFINITY;
@@ -542,9 +575,12 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     float close = bars[bar_offset + 2];
                     float lower = fmin(ema0[c], fmin(ema1[c], ema2[c]));
                     float upper = fmax(ema0[c], fmax(ema1[c], ema2[c]));
+                    float coin_initial_ema_dist = coin_override_or(
+                        coin_overrides, c, 5, initial_ema_dist
+                    );
                     float threshold = short_side
-                        ? upper * (1.0f + initial_ema_dist)
-                        : lower * (1.0f - initial_ema_dist);
+                        ? upper * (1.0f + coin_initial_ema_dist)
+                        : lower * (1.0f - coin_initial_ema_dist);
                     float readiness = threshold > 0.0f
                         ? (short_side ? 1.0f - close / threshold : close / threshold - 1.0f)
                         : INFINITY;
@@ -629,7 +665,11 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 int bar_offset = (k * C + c) * 4;
                 int tick_offset = (k * C + c) * 2;
                 float price_now = bars[bar_offset + 2];
-                const float coin_wel = effective_wel;
+                float fixed_coin_wel = coin_override_or(
+                    coin_overrides, c, 24, -1.0f
+                );
+                float coin_wel = fixed_coin_wel >= 0.0f
+                    ? fixed_coin_wel : effective_wel;
                 bool tradable = k >= int(coin_settings[coin_offset + 8])
                     && k <= int(coin_settings[coin_offset + 7])
                     && finite_positive(price_now) && coin_wel > 0.0f;
@@ -641,13 +681,73 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 float c_mult = coin_settings[coin_offset + 4];
                 float lower = fmin(ema0[c], fmin(ema1[c], ema2[c]));
                 float upper = fmax(ema0[c], fmax(ema1[c], ema2[c]));
+                float coin_ddf = coin_override_or(
+                    coin_overrides, c, 4, ddf
+                );
+                float coin_initial_ema_dist = coin_override_or(
+                    coin_overrides, c, 5, initial_ema_dist
+                );
+                float coin_initial_qty_pct = coin_override_or(
+                    coin_overrides, c, 6, initial_qty_pct
+                );
+                float coin_entry_threshold_base = coin_override_or(
+                    coin_overrides, c, 7, entry_threshold_base
+                );
+                float coin_entry_threshold_we = coin_override_or(
+                    coin_overrides, c, 8, entry_threshold_we
+                );
+                float coin_entry_threshold_v1h = coin_override_or(
+                    coin_overrides, c, 9, entry_threshold_v1h
+                );
+                float coin_entry_threshold_v1m = coin_override_or(
+                    coin_overrides, c, 10, entry_threshold_v1m
+                );
+                float coin_entry_retracement_base = coin_override_or(
+                    coin_overrides, c, 11, entry_retracement_base
+                );
+                float coin_entry_retracement_we = coin_override_or(
+                    coin_overrides, c, 12, entry_retracement_we
+                );
+                float coin_entry_retracement_v1h = coin_override_or(
+                    coin_overrides, c, 13, entry_retracement_v1h
+                );
+                float coin_entry_retracement_v1m = coin_override_or(
+                    coin_overrides, c, 14, entry_retracement_v1m
+                );
+                float coin_close_qty_pct = coin_override_or(
+                    coin_overrides, c, 15, close_qty_pct
+                );
+                float coin_close_threshold_base = coin_override_or(
+                    coin_overrides, c, 16, close_threshold_base
+                );
+                float coin_close_threshold_we = coin_override_or(
+                    coin_overrides, c, 17, close_threshold_we
+                );
+                float coin_close_threshold_v1h = coin_override_or(
+                    coin_overrides, c, 18, close_threshold_v1h
+                );
+                float coin_close_threshold_v1m = coin_override_or(
+                    coin_overrides, c, 19, close_threshold_v1m
+                );
+                float coin_close_retracement_base = coin_override_or(
+                    coin_overrides, c, 20, close_retracement_base
+                );
+                float coin_close_retracement_v1h = coin_override_or(
+                    coin_overrides, c, 21, close_retracement_v1h
+                );
+                float coin_close_retracement_v1m = coin_override_or(
+                    coin_overrides, c, 22, close_retracement_v1m
+                );
+                float coin_cooldown_min = ceil(coin_override_or(
+                    coin_overrides, c, 23, cooldown_min
+                ));
                 int touch_down = touch_ticks[tick_offset + 0];
                 int touch_up = touch_ticks[tick_offset + 1];
                 int entry_touch = short_side ? touch_up : touch_down;
                 int band_tick = short_side
-                    ? int(ceil(upper * (1.0f + initial_ema_dist)
+                    ? int(ceil(upper * (1.0f + coin_initial_ema_dist)
                         / price_step - 1.0e-6f))
-                    : int(floor(lower * (1.0f - initial_ema_dist)
+                    : int(floor(lower * (1.0f - coin_initial_ema_dist)
                         / price_step + 1.0e-6f));
                 bool initial_touch_controls = !gate_initial || (short_side
                     ? touch_down >= band_tick : touch_up <= band_tick);
@@ -657,7 +757,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     initial_price, qty_step, min_qty, min_cost, c_mult
                 );
                 float iq = fmax(min_iq, round_step(
-                    balance * coin_wel * initial_qty_pct
+                    balance * coin_wel * coin_initial_qty_pct
                         / fmax(initial_price * c_mult, 1.0e-12f),
                     qty_step
                 ));
@@ -672,22 +772,22 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     ? psize[c] * pprice[c] * c_mult / balance : 0.0f;
                 float wer = we / fmax(coin_wel, 1.0e-12f);
                 float threshold_multiplier = fmax(
-                    1.0f + volatility_1h[c] * entry_threshold_v1h
-                        + volatility_1m[c] * entry_threshold_v1m
-                        + wer * entry_threshold_we,
+                    1.0f + volatility_1h[c] * coin_entry_threshold_v1h
+                        + volatility_1m[c] * coin_entry_threshold_v1m
+                        + wer * coin_entry_threshold_we,
                     1.0f
                 );
                 float retracement_multiplier = fmax(
-                    1.0f + volatility_1h[c] * entry_retracement_v1h
-                        + volatility_1m[c] * entry_retracement_v1m
-                        + wer * entry_retracement_we,
+                    1.0f + volatility_1h[c] * coin_entry_retracement_v1h
+                        + volatility_1m[c] * coin_entry_retracement_v1m
+                        + wer * coin_entry_retracement_we,
                     1.0f
                 );
-                float entry_threshold = fmax(entry_threshold_base, 0.0f)
+                float entry_threshold = fmax(coin_entry_threshold_base, 0.0f)
                     * threshold_multiplier;
-                float entry_retracement = fmax(entry_retracement_base, 0.0f)
+                float entry_retracement = fmax(coin_entry_retracement_base, 0.0f)
                     * retracement_multiplier;
-                bool trailing_entry = entry_retracement_base > 0.0f;
+                bool trailing_entry = coin_entry_retracement_base > 0.0f;
                 bool retraced_entry = short_side
                     ? min_since_max[c] < max_since_open[c]
                         * (1.0f - entry_retracement)
@@ -733,8 +833,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 );
                 float rq = fmax(iq_effective, fmax(min_rq, round_step(
                     fmax(
-                        psize[c] * ddf,
-                        balance * coin_wel * initial_qty_pct
+                        psize[c] * coin_ddf,
+                        balance * coin_wel * coin_initial_qty_pct
                             / fmax(reentry_price * c_mult, 1.0e-12f)
                     ),
                     qty_step
@@ -757,11 +857,11 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 int candidate_entry_tick = flat || partial
                     ? initial_tick : reentry_tick;
                 float entry_price = float(candidate_entry_tick) * price_step;
-                bool cooldown = cooldown_min > 0.0f
+                bool cooldown = coin_cooldown_min > 0.0f
                     && last_increase_k[c] > -1.0e19f
-                    && float(k) < last_increase_k[c] + cooldown_min;
+                    && float(k) < last_increase_k[c] + coin_cooldown_min;
                 if (!selected[c] || cooldown || balance <= 0.0f
-                    || initial_qty_pct <= 0.0f || candidate_entry_tick <= 1) {
+                    || coin_initial_qty_pct <= 0.0f || candidate_entry_tick <= 1) {
                     quantity = 0.0f;
                 }
                 float headroom = (
@@ -787,17 +887,19 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 contribution[c] = quantity > 0.0f
                     ? quantity * entry_price * c_mult / balance : 0.0f;
 
-                float close_threshold = close_threshold_base
-                    + wer * close_threshold_we
-                    + volatility_1h[c] * close_threshold_v1h
-                    + volatility_1m[c] * close_threshold_v1m;
-                float close_retracement = fmax(close_retracement_base, 0.0f)
+                float close_threshold = coin_close_threshold_base
+                    + wer * coin_close_threshold_we
+                    + volatility_1h[c] * coin_close_threshold_v1h
+                    + volatility_1m[c] * coin_close_threshold_v1m;
+                float close_retracement = fmax(
+                    coin_close_retracement_base, 0.0f
+                )
                     * fmax(
-                        1.0f + volatility_1h[c] * close_retracement_v1h
-                            + volatility_1m[c] * close_retracement_v1m,
+                        1.0f + volatility_1h[c] * coin_close_retracement_v1h
+                            + volatility_1m[c] * coin_close_retracement_v1m,
                         1.0f
                     );
-                bool trailing_close = close_retracement_base > 0.0f;
+                bool trailing_close = coin_close_retracement_base > 0.0f;
                 bool retraced_close = short_side
                     ? max_since_min[c] > min_since_open[c]
                         * (1.0f + close_retracement)
@@ -841,8 +943,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     );
                 int minimum_close_relation = close_touch_controls
                     ? touch_min_qty_relation[k * C + c] : 0;
-                float close_pct = trailing_close ? close_qty_pct
-                    : (close_threshold_we == 0.0f ? 1.0f : close_qty_pct);
+                float close_pct = trailing_close ? coin_close_qty_pct
+                    : (coin_close_threshold_we == 0.0f
+                        ? 1.0f : coin_close_qty_pct);
                 float clip = calc_close_qty(
                     psize[c], pprice[c], balance, coin_wel,
                     minimum_close, minimum_close_relation, close_pct,
@@ -1012,6 +1115,7 @@ kernel void passivbot_trailing_martingale_multicoin(
     constant int* touch_min_qty_bits,
     constant int* touch_min_qty_relation,
     constant float* coin_settings,
+    constant float* coin_overrides,
     constant float* params,
     constant float* run_settings,
     constant int* sizes,
@@ -1024,7 +1128,7 @@ kernel void passivbot_trailing_martingale_multicoin(
     passivbot_trailing_martingale_multicoin_impl(
         bars, fill_ticks, touch_ticks, touch_nearest_ticks,
         touch_min_qty_bits, touch_min_qty_relation, coin_settings,
-        params, run_settings,
+        coin_overrides, params, run_settings,
         sizes, daily, scalars, gap_hist, b, short_side
     );
 }
@@ -1037,6 +1141,7 @@ kernel void passivbot_trailing_martingale_multicoin_long(
     constant int* touch_min_qty_bits,
     constant int* touch_min_qty_relation,
     constant float* coin_settings,
+    constant float* coin_overrides,
     constant float* params,
     constant float* run_settings,
     constant int* sizes,
@@ -1048,7 +1153,7 @@ kernel void passivbot_trailing_martingale_multicoin_long(
     passivbot_trailing_martingale_multicoin_impl(
         bars, fill_ticks, touch_ticks, touch_nearest_ticks,
         touch_min_qty_bits, touch_min_qty_relation, coin_settings,
-        params, run_settings,
+        coin_overrides, params, run_settings,
         sizes, daily, scalars, gap_hist, b, false
     );
 }

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -865,18 +865,31 @@ def _validate_gpu_coin_overrides(
     overrides = config.get("coin_overrides") or {}
     if not overrides:
         return
-    if coin_count <= 1 or strategy_kind != "ema_anchor" or not enabled_sides:
+    if (
+        coin_count <= 1
+        or strategy_kind not in {"ema_anchor", "trailing_martingale"}
+        or not enabled_sides
+    ):
         raise ValueError(
-            "GPU coin_overrides currently require multi-coin EMA Anchor with at "
-            "least one enabled side"
+            "GPU coin_overrides currently require a supported multi-coin strategy "
+            "with at least one enabled side"
         )
     enabled_sides = set(enabled_sides)
-    from optimization.gpu.model import EMA_ANCHOR_PARAM_KEYS
+    from optimization.gpu.model import (
+        EMA_ANCHOR_PARAM_KEYS,
+        TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS,
+    )
 
-    strategy_keys = set(EMA_ANCHOR_PARAM_KEYS) - {
-        "entry_cooldown_minutes",
-        "total_wallet_exposure_limit",
-    }
+    if strategy_kind == "ema_anchor":
+        strategy_paths = {
+            (key,)
+            for key in set(EMA_ANCHOR_PARAM_KEYS)
+            - {"entry_cooldown_minutes", "total_wallet_exposure_limit"}
+        }
+    else:
+        strategy_paths = {
+            path for _key, path in TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS
+        }
 
     def leaves(value, prefix=()):
         if isinstance(value, dict):
@@ -894,8 +907,14 @@ def _validate_gpu_coin_overrides(
             }
         )
         allowed.update(
-            ("bot", enabled_side, "strategy", "ema_anchor", key)
-            for key in strategy_keys
+            (
+                "bot",
+                enabled_side,
+                "strategy",
+                strategy_kind,
+                *path,
+            )
+            for path in strategy_paths
         )
     unsupported = []
     for coin, patch in overrides.items():
@@ -910,8 +929,9 @@ def _validate_gpu_coin_overrides(
     if unsupported:
         raise ValueError(
             "GPU coin_overrides do not model these paths yet: "
-            f"{sorted(unsupported)}; supported leaves are enabled-side EMA Anchor "
-            "parameters, risk.entry_cooldown_minutes, and wallet_exposure_limit"
+            f"{sorted(unsupported)}; supported leaves are enabled-side "
+            f"{strategy_kind} parameters, risk.entry_cooldown_minutes, and "
+            "wallet_exposure_limit"
         )
 
 

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -77,6 +77,56 @@ TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS = (
     "n_positions",
 )
 
+TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS = (
+    ("ema_span_0", ("ema_span_0",)),
+    ("ema_span_1", ("ema_span_1",)),
+    ("volatility_ema_span_1h", ("volatility_ema_span_1h",)),
+    ("volatility_ema_span_1m", ("volatility_ema_span_1m",)),
+    ("entry_double_down_factor", ("entry", "double_down_factor")),
+    ("entry_initial_ema_dist", ("entry", "initial_ema_dist")),
+    ("entry_initial_qty_pct", ("entry", "initial_qty_pct")),
+    ("entry_threshold_base_pct", ("entry", "threshold_base_pct")),
+    ("entry_threshold_we_weight", ("entry", "threshold_we_weight")),
+    (
+        "entry_threshold_volatility_1h_weight",
+        ("entry", "threshold_volatility_1h_weight"),
+    ),
+    (
+        "entry_threshold_volatility_1m_weight",
+        ("entry", "threshold_volatility_1m_weight"),
+    ),
+    ("entry_retracement_base_pct", ("entry", "retracement_base_pct")),
+    ("entry_retracement_we_weight", ("entry", "retracement_we_weight")),
+    (
+        "entry_retracement_volatility_1h_weight",
+        ("entry", "retracement_volatility_1h_weight"),
+    ),
+    (
+        "entry_retracement_volatility_1m_weight",
+        ("entry", "retracement_volatility_1m_weight"),
+    ),
+    ("close_qty_pct", ("close", "qty_pct")),
+    ("close_threshold_base_pct", ("close", "threshold_base_pct")),
+    ("close_threshold_we_weight", ("close", "threshold_we_weight")),
+    (
+        "close_threshold_volatility_1h_weight",
+        ("close", "threshold_volatility_1h_weight"),
+    ),
+    (
+        "close_threshold_volatility_1m_weight",
+        ("close", "threshold_volatility_1m_weight"),
+    ),
+    ("close_retracement_base_pct", ("close", "retracement_base_pct")),
+    (
+        "close_retracement_volatility_1h_weight",
+        ("close", "retracement_volatility_1h_weight"),
+    ),
+    (
+        "close_retracement_volatility_1m_weight",
+        ("close", "retracement_volatility_1m_weight"),
+    ),
+)
+
 GPU_STRATEGY_PARAM_KEYS = {
     "ema_anchor": EMA_ANCHOR_PARAM_KEYS,
     "trailing_martingale": TRAILING_MARTINGALE_PARAM_KEYS,

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -315,6 +315,9 @@ class MpsEmaAnchorRunner:
 class MpsEmaAnchorMulticoinRunner:
     """Persistent single-side multi-coin EMA Anchor screening runner on MPS."""
 
+    coin_override_cols = 12
+    coin_override_label = "EMA"
+
     def __init__(
         self,
         run: ProxyRun,
@@ -341,12 +344,15 @@ class MpsEmaAnchorMulticoinRunner:
         self.touch_min_qty_relation = data["touch_min_qty_relation"]
         self.coin_settings = data["coin_settings"]
         if coin_overrides is None:
-            coin_overrides = np.full((self.n_coins, 12), np.nan, dtype=np.float32)
+            coin_overrides = np.full(
+                (self.n_coins, self.coin_override_cols), np.nan, dtype=np.float32
+            )
         coin_overrides = np.asarray(coin_overrides, dtype=np.float32)
-        if coin_overrides.shape != (self.n_coins, 12):
+        if coin_overrides.shape != (self.n_coins, self.coin_override_cols):
             raise ValueError(
-                "expected multicoin EMA override matrix shaped "
-                f"({self.n_coins}, 12), got {coin_overrides.shape}"
+                f"expected multicoin {self.coin_override_label} override matrix shaped "
+                f"({self.n_coins}, {self.coin_override_cols}), "
+                f"got {coin_overrides.shape}"
             )
         self.coin_overrides = torch.as_tensor(
             np.ascontiguousarray(coin_overrides), device="mps"
@@ -495,18 +501,23 @@ class MpsEmaAnchorMulticoinShortRunner(MpsEmaAnchorMulticoinRunner):
 class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
     """Persistent single-side multi-coin Trailing Martingale proxy on MPS."""
 
+    coin_override_cols = 25
+    coin_override_label = "Trailing Martingale"
+
     def __init__(
         self,
         run: ProxyRun,
         data: dict,
         *,
         side: str,
+        coin_overrides: np.ndarray | None = None,
         forager_score_hysteresis_pct: float = 0.0,
     ):
         super().__init__(
             run,
             data,
             side=side,
+            coin_overrides=coin_overrides,
             forager_score_hysteresis_pct=forager_score_hysteresis_pct,
         )
 
@@ -559,6 +570,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             self.touch_min_qty_bits,
             self.touch_min_qty_relation,
             self.coin_settings,
+            self.coin_overrides,
             params_mps,
             self.settings,
             self._sizes[sizes_key],

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -13,6 +13,7 @@ from optimization.gpu.model import (
     MPS_MULTICOIN_MAX_COINS,
     ProxyMarket,
     ProxyRun,
+    TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS,
     TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS,
     build_mps_data,
     build_mps_multicoin_data,
@@ -462,6 +463,74 @@ def _build_multicoin_ema_coin_overrides(
     return matrix, contract
 
 
+def _build_multicoin_tm_coin_overrides(
+    *,
+    config: dict,
+    mss: dict,
+    exchange: str,
+    coins: list[str],
+    payload,
+    side: str,
+    resolve_override=None,
+) -> tuple[np.ndarray, dict]:
+    """Pack exact-last static coin overrides for the Metal TM proxy."""
+
+    if resolve_override is None:
+        from backtest import _get_backtest_coin_override
+
+        resolve_override = _get_backtest_coin_override
+
+    cooldown_column = len(TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS)
+    wallet_exposure_column = cooldown_column + 1
+    matrix = np.full(
+        (len(coins), wallet_exposure_column + 1),
+        np.nan,
+        dtype=np.float32,
+    )
+    missing = object()
+    for coin_index, coin in enumerate(coins):
+        patch = resolve_override(config, mss, exchange, coin) or {}
+        side_patch = patch.get("bot", {}).get(side, {})
+        strategy_patch = (
+            side_patch.get("strategy", {}).get("trailing_martingale", {}) or {}
+        )
+        effective_strategy = flatten_trailing_martingale_params(
+            payload.strategy_params_list[coin_index][side],
+            payload.bot_params_list[coin_index][side],
+        )
+        effective_bot = payload.bot_params_list[coin_index][side]
+        for column, (key, path) in enumerate(
+            TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS
+        ):
+            value = strategy_patch
+            for part in path:
+                value = (
+                    value.get(part, missing) if isinstance(value, dict) else missing
+                )
+                if value is missing:
+                    break
+            if value is not missing:
+                matrix[coin_index, column] = float(effective_strategy[key])
+        if "entry_cooldown_minutes" in (side_patch.get("risk", {}) or {}):
+            matrix[coin_index, cooldown_column] = float(
+                effective_bot.get("entry_cooldown_minutes", 0.0) or 0.0
+            )
+        if "wallet_exposure_limit" in side_patch:
+            matrix[coin_index, wallet_exposure_column] = float(
+                effective_bot["wallet_exposure_limit"]
+            )
+    contract = {
+        "exchange": exchange,
+        "coins": coins,
+        "side": side,
+        "values": [
+            [None if not np.isfinite(value) else float(value) for value in row]
+            for row in matrix
+        ],
+    }
+    return matrix, contract
+
+
 class MpsMulticoinProxy:
     """Batched multi-coin MPS proxy for the supported strategy topology."""
 
@@ -695,14 +764,14 @@ class MpsMulticoinProxy:
                     side=side,
                 )
             else:
-                overrides = np.full((coin_count, 12), np.nan, dtype=np.float32)
-                contract = {
-                    "exchange": exchange,
-                    "coins": coins,
-                    "side": side,
-                    "values": {},
-                    "proxy_mode": "trailing-martingale-global-params-v1",
-                }
+                overrides, contract = _build_multicoin_tm_coin_overrides(
+                    config=config,
+                    mss=mss,
+                    exchange=exchange,
+                    coins=coins,
+                    payload=payload,
+                    side=side,
+                )
             per_side_coin_overrides[side] = overrides
             per_side_override_contracts[side] = contract
         if len(self.sides) == 1:
@@ -781,8 +850,7 @@ class MpsMulticoinProxy:
                 "side": side,
                 "forager_score_hysteresis_pct": self.forager_score_hysteresis_pct,
             }
-            if self.strategy_kind == "ema_anchor":
-                runner_kwargs["coin_overrides"] = per_side_coin_overrides[side]
+            runner_kwargs["coin_overrides"] = per_side_coin_overrides[side]
             self.runners[side] = runner_cls(
                 self.run,
                 self.data,

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -674,6 +674,58 @@ def test_gpu_suite_inputs_accept_scenario_local_modeled_coin_overrides():
     ]["ema_anchor"]["offset"] == pytest.approx(0.012)
 
 
+def test_gpu_suite_inputs_accept_scenario_local_tm_coin_overrides():
+    config = _directional_tm_config(long_enabled=True, short_enabled=False)
+    config["backtest"]["suite_enabled"] = True
+    config["live"]["approved_coins"]["long"] = ["BTC", "ETH"]
+    config["bot"]["long"]["risk"]["n_positions"] = 2
+    overrides = {
+        "coin_overrides": {
+            "ETH": {
+                "bot": {
+                    "long": {
+                        "strategy": {
+                            "trailing_martingale": {
+                                "entry": {"threshold_base_pct": 0.012}
+                            }
+                        },
+                        "wallet_exposure_limit": 0.4,
+                    }
+                }
+            }
+        }
+    }
+    ctx = SimpleNamespace(
+        label="eth_tm_override",
+        overrides=overrides,
+        exchanges=["bybit"],
+        msss={"bybit": {"BTC": {}, "ETH": {}, "__meta__": {}}},
+        timestamps={"bybit": np.arange(10, dtype=np.int64)},
+    )
+
+    class Suite:
+        contexts = [ctx]
+
+        @staticmethod
+        def get_prepared_context_data(_ctx, _exchange):
+            return np.zeros((10, 2, 4)), np.ones(10), [0, 1]
+
+        @staticmethod
+        def build_scenario_candidate_config(proxy_config, _ctx):
+            scenario = copy.deepcopy(proxy_config)
+            scenario["coin_overrides"] = copy.deepcopy(overrides["coin_overrides"])
+            return scenario
+
+    prepared = _gpu_suite_scenario_inputs(config, Suite())
+
+    assert prepared[0]["overrides"] == overrides
+    assert prepared[0]["config"]["coin_overrides"]["ETH"]["bot"]["long"][
+        "strategy"
+    ]["trailing_martingale"]["entry"]["threshold_base_pct"] == pytest.approx(
+        0.012
+    )
+
+
 def test_gpu_suite_inputs_reject_unmodeled_scenario_coin_override_leaves():
     config = _long_only_ema_config()
     config["backtest"]["suite_enabled"] = True
@@ -1370,27 +1422,62 @@ def test_gpu_coin_overrides_reject_single_coin_scope():
         "BTC": {"bot": {"long": {"wallet_exposure_limit": 0.5}}}
     }
 
-    with pytest.raises(ValueError, match="require multi-coin EMA Anchor"):
+    with pytest.raises(ValueError, match="require a supported multi-coin strategy"):
         _validate_scope(config, _Evaluator())
 
 
-def test_gpu_multicoin_tm_coin_overrides_fail_closed():
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_gpu_multicoin_accepts_static_tm_coin_overrides(side):
     config = _directional_tm_config(long_enabled=True, short_enabled=False)
+    if side == "short":
+        config = _directional_tm_config(long_enabled=False, short_enabled=True)
     config["coin_overrides"] = {
         "ETH": {
             "bot": {
-                "long": {
+                side: {
                     "strategy": {
                         "trailing_martingale": {
-                            "entry": {"threshold_base_pct": 0.02}
+                            "entry": {
+                                "threshold_base_pct": 0.02,
+                                "retracement_base_pct": 0.005,
+                            },
+                            "close": {"qty_pct": 0.25},
                         }
-                    }
+                    },
+                    "risk": {"entry_cooldown_minutes": 15},
+                    "wallet_exposure_limit": 0.4,
                 }
             }
         }
     }
 
-    with pytest.raises(ValueError, match="require multi-coin EMA Anchor"):
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
+
+
+@pytest.mark.parametrize(
+    "patch",
+    [
+        {"live": {"leverage": 3}},
+        {"bot": {"long": {"risk": {"n_positions": 2}}}},
+        {"bot": {"long": {"unstuck": {"enabled": True}}}},
+        {
+            "bot": {
+                "long": {
+                    "strategy": {
+                        "trailing_martingale": {
+                            "entry": {"ema_gate_mode": "disabled"}
+                        }
+                    }
+                }
+            }
+        },
+    ],
+)
+def test_gpu_multicoin_tm_coin_overrides_reject_unmodeled_leaves(patch):
+    config = _directional_tm_config(long_enabled=True, short_enabled=False)
+    config["coin_overrides"] = {"ETH": patch}
+
+    with pytest.raises(ValueError, match="do not model these paths yet"):
         _validate_gpu_coin_overrides(
             config,
             strategy_kind="trailing_martingale",

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -351,6 +351,8 @@ def test_mps_trailing_martingale_multicoin_directional_shader_smoke(side):
     assert "entry_retracement_base" in source
     assert "close_retracement_base" in source
     assert "as_type<float>(touch_min_qty_bits[k * C + c])" in source
+    assert "constant int OVERRIDE_COLS = 25" in source
+    assert "coin_override_or" in source
 
     count = 512
     coin_count = 3
@@ -435,6 +437,58 @@ def test_mps_trailing_martingale_multicoin_directional_shader_smoke(side):
     assert torch.isfinite(output["balance"]).all()
     assert output["day_has_fill"].sum().item() > 0
     assert (output["open_positions"] <= 2.0).all()
+
+    disabled = np.full((coin_count, 25), np.nan, dtype=np.float32)
+    disabled[:, 24] = 0.0
+    disabled_output = MpsTrailingMartingaleMulticoinRunner(
+        runs[0], data, side=side, coin_overrides=disabled
+    ).run(np.array([row], dtype=np.float64))
+    torch.mps.synchronize()
+    assert disabled_output["day_has_fill"].sum().item() == 0
+    assert disabled_output["open_positions"].item() == 0.0
+
+    exact_last = np.full((coin_count, 25), np.nan, dtype=np.float32)
+    exact_last[:, :25] = np.asarray(row[:25], dtype=np.float32)
+    changed_candidate = list(row)
+    changed_candidate[:25] = [
+        200.0,
+        400.0,
+        240.0,
+        180.0,
+        0.0,
+        0.05,
+        0.01,
+        0.1,
+        2.0,
+        5.0,
+        5.0,
+        0.02,
+        3.0,
+        5.0,
+        5.0,
+        0.8,
+        0.05,
+        2.0,
+        5.0,
+        5.0,
+        0.02,
+        5.0,
+        5.0,
+        120.0,
+        1.0,
+    ]
+    exact_last_output = MpsTrailingMartingaleMulticoinRunner(
+        runs[0], data, side=side, coin_overrides=exact_last
+    ).run(np.array([row, changed_candidate], dtype=np.float64))
+    torch.mps.synchronize()
+    assert torch.equal(
+        exact_last_output["day_has_fill"][0],
+        exact_last_output["day_has_fill"][1],
+    )
+    assert torch.equal(
+        exact_last_output["day_end_eq"][0],
+        exact_last_output["day_end_eq"][1],
+    )
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -6,6 +6,7 @@ import pytest
 from optimization.gpu.model import (
     EMA_ANCHOR_MULTICOIN_PARAM_KEYS,
     EMA_ANCHOR_PARAM_KEYS,
+    TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS,
     TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS,
     TRAILING_MARTINGALE_PARAM_KEYS,
     flatten_trailing_martingale_params,
@@ -15,6 +16,7 @@ from optimization.gpu.service import (
     MpsEmaAnchorProxy,
     MpsMulticoinEmaProxy,
     _build_multicoin_ema_coin_overrides,
+    _build_multicoin_tm_coin_overrides,
     _combine_hedged_multicoin_outputs,
     _require_complete_valid_tail,
 )
@@ -414,6 +416,107 @@ def test_multicoin_coin_overrides_pack_dual_sides_independently():
     assert short_matrix[1, offset_index] == pytest.approx(0.5)
     assert short_matrix[1, 10] == pytest.approx(30.0)
     assert np.isnan(short_matrix[1, 11])
+
+
+def test_multicoin_tm_coin_overrides_pack_only_explicit_exact_values():
+    assert tuple(
+        key for key, _path in TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS
+    ) == TRAILING_MARTINGALE_PARAM_KEYS[:23]
+    strategy_base = {
+        "ema_span_0": 10.0,
+        "ema_span_1": 20.0,
+        "volatility_ema_span_1h": 30.0,
+        "volatility_ema_span_1m": 40.0,
+        "entry": {
+            "ema_gate_mode": "all",
+            "double_down_factor": 1.1,
+            "initial_ema_dist": 0.01,
+            "initial_qty_pct": 0.02,
+            "threshold_base_pct": 0.03,
+            "threshold_we_weight": 0.04,
+            "threshold_volatility_1h_weight": 0.05,
+            "threshold_volatility_1m_weight": 0.06,
+            "retracement_base_pct": 0.007,
+            "retracement_we_weight": 0.08,
+            "retracement_volatility_1h_weight": 0.09,
+            "retracement_volatility_1m_weight": 0.1,
+        },
+        "close": {
+            "qty_pct": 0.2,
+            "threshold_base_pct": 0.03,
+            "threshold_we_weight": 0.04,
+            "threshold_volatility_1h_weight": 0.05,
+            "threshold_volatility_1m_weight": 0.06,
+            "retracement_base_pct": 0.007,
+            "retracement_volatility_1h_weight": 0.09,
+            "retracement_volatility_1m_weight": 0.1,
+        },
+    }
+    strategy_override = {
+        **strategy_base,
+        "entry": {**strategy_base["entry"], "threshold_base_pct": 0.25},
+        "close": {**strategy_base["close"], "qty_pct": 0.5},
+    }
+    payload = SimpleNamespace(
+        strategy_params_list=[
+            {"long": strategy_base},
+            {"long": strategy_override},
+        ],
+        bot_params_list=[
+            {
+                "long": {
+                    "entry_cooldown_minutes": 0.0,
+                    "total_wallet_exposure_limit": 1.0,
+                    "wallet_exposure_limit": -1.0,
+                }
+            },
+            {
+                "long": {
+                    "entry_cooldown_minutes": 15.0,
+                    "total_wallet_exposure_limit": 1.0,
+                    "wallet_exposure_limit": 0.4,
+                }
+            },
+        ],
+    )
+    config = {
+        "coin_overrides": {
+            "ETH": {
+                "bot": {
+                    "long": {
+                        "strategy": {
+                            "trailing_martingale": {
+                                "entry": {"threshold_base_pct": 0.25},
+                                "close": {"qty_pct": 0.5},
+                            }
+                        },
+                        "risk": {"entry_cooldown_minutes": 15.0},
+                        "wallet_exposure_limit": 0.4,
+                    }
+                }
+            }
+        }
+    }
+
+    matrix, contract = _build_multicoin_tm_coin_overrides(
+        config=config,
+        mss={"BTC": {}, "ETH": {}},
+        exchange="bybit",
+        coins=["BTC", "ETH"],
+        payload=payload,
+        side="long",
+        resolve_override=lambda config, _mss, _exchange, coin: config[
+            "coin_overrides"
+        ].get(coin, {}),
+    )
+
+    assert matrix.shape == (2, 25)
+    assert np.isnan(matrix[0]).all()
+    assert matrix[1, 7] == pytest.approx(0.25)
+    assert matrix[1, 15] == pytest.approx(0.5)
+    assert matrix[1, 23] == pytest.approx(15.0)
+    assert matrix[1, 24] == pytest.approx(0.4)
+    assert contract["values"][0] == [None] * 25
 
 
 def test_trailing_parameter_matrix_keeps_nested_flattened_sides_separate():


### PR DESCRIPTION
## Summary

- support static Trailing Martingale coin overrides in single-side and dual-side multi-coin Apple MPS optimization
- pack the 23 canonical per-coin TM strategy leaves plus entry cooldown and wallet exposure into an exact-last Metal buffer
- support distinct scenario-local TM override matrices in compatible optimizer suites and checkpoint identity
- keep unsupported override leaves fail-closed and exact Rust portfolio backtests authoritative

CPU optimization, backtesting, and bot operation are unchanged.

## Validation

- full Python test suite
- 42/42 Apple MPS hardware regression tests
- 261 Rust tests plus `cargo fmt --check` and `cargo check --tests`
- AI docs and generated-event registry checks
- rebuilt Rust extension fingerprint verified against the exact source tree
- offline cached BTC+ETH dual-side override smoke: 512 proxy + 64 exact validations, no halt
- offline cached BTC+ETH two-scenario smoke with distinct override matrices: 512 proxy + 64 exact validations, no halt
