### PR TITLE
feat(optimize): support MPS exposure headroom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added single-coin exposure-headroom policy support to the Apple MPS optimizer for EMA Anchor and
+  Trailing Martingale, including long-only, short-only, dual-side, and compatible suite runs.
+  Metal now models bounded and legacy-raw `we_excess_allowance_pct`, the
+  `total_exposure_entry_gate_enabled` toggle, and `total_exposure_enforcer_threshold`; exact Rust
+  backtests and the existing classification, rank, and drift gates remain authoritative.
+  Multi-coin runs retain their previous fail-closed exposure-policy requirements.
+
 - Added `backtest.filter_by_min_effective_cost` support across the Apple MPS optimizer's EMA Anchor
   and Trailing Martingale single-coin, single-side matrix, including long, short, and compatible
   suites. The Metal proxy conservatively compares projected initial cost against the highest

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -131,7 +131,14 @@ The supported slice is intentionally narrow:
   `wallet_exposure_limit` are supported; trailing-martingale `entry.ema_gate_mode`, disabled sides,
   and other override leaves fail closed
 - HSL and auto-unstuck disabled
-- BTC collateral, realized-loss gating, and exposure enforcers disabled
+- single-coin EMA Anchor and Trailing Martingale runs support bounded and legacy-raw
+  `risk.we_excess_allowance_pct`, `risk.total_exposure_entry_gate_enabled`, and
+  `risk.total_exposure_enforcer_threshold` across long-only, short-only, dual-side, and compatible
+  suites. Bounded allowance cannot raise a single coin above its side TWEL; legacy-raw allowance
+  may do so when the entry gate is disabled. Multi-coin runs still require zero excess allowance,
+  an enabled entry gate, and a threshold pinned to `1.0`
+- BTC collateral, realized-loss gating, position-exposure enforcement, and total-exposure repair
+  remain disabled
 - `backtest.filter_by_min_effective_cost` may be enabled or disabled. When enabled, Metal uses the
   projected initial-entry cost test with the configured wallet-exposure limit. The
   screening proxy compares against the highest executable minimum observed for that coin in the

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -93,13 +93,15 @@ mod tests {
     fn trailing_martingale_mps_source_exposes_expected_kernel_contract() {
         let source = mps_trailing_martingale_source();
         assert!(source.contains("kernel void passivbot_trailing_martingale"));
-        assert!(source.contains("constant int SIDE_PARAMS = 27"));
+        assert!(source.contains("constant int SIDE_PARAMS = 31"));
         assert!(source.contains("min_since_open"));
         assert!(source.contains("max_since_min"));
         assert!(source.contains("max_since_open"));
         assert!(source.contains("min_since_max"));
-        assert!(source.contains("if (we_if <= s.twel * 1.01f) return qty"));
-        assert!(source.contains("s.twel * balance - cost"));
+        assert!(source.contains("if (we_if <= s.entry_cap * 1.01f) return qty"));
+        assert!(source.contains("s.entry_cap * balance - cost"));
+        assert!(source.contains("s.allowed_wel"));
+        assert!(source.contains("twel_entry_gate_enabled"));
         assert_eq!(source.matches("= fma(").count(), 5);
         assert!(!source.contains("alpha0 * close +"));
         assert_eq!(source.matches("const int fo = k * 11").count(), 1);

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -4,7 +4,7 @@ using namespace metal;
 constant int DAILY_COLS = 5;
 constant int SCALAR_COLS = 18;
 constant int GAP_BINS = 128;
-constant int SIDE_PARAMS = 12;
+constant int SIDE_PARAMS = 16;
 
 inline float round_step(float value, float step) {
     return floor(value / step + 0.5f) * step;
@@ -60,6 +60,8 @@ struct EmaSide {
     float w1m;
     float cooldown_min;
     float twel;
+    float allowed_wel;
+    float entry_cap;
     float ema0;
     float ema1;
     float ema2;
@@ -99,6 +101,18 @@ inline EmaSide load_side(constant float* params, int po, float seed_close) {
     side.w1m = params[po + 7];
     side.cooldown_min = ceil(params[po + 10]);
     side.twel = params[po + 11];
+    float allowance_pct = fmax(params[po + 12], 0.0f);
+    bool legacy_raw_allowance = params[po + 13] > 0.5f;
+    side.allowed_wel = side.twel * (
+        1.0f + (legacy_raw_allowance ? allowance_pct : 0.0f)
+    );
+    bool twel_entry_gate_enabled = params[po + 14] > 0.5f;
+    float twel_threshold = params[po + 15];
+    float gate_cap = side.twel;
+    if (isfinite(twel_threshold) && twel_threshold > 0.0f) {
+        gate_cap = fmin(side.twel, side.twel * twel_threshold);
+    }
+    side.entry_cap = twel_entry_gate_enabled ? gate_cap : INFINITY;
     side.ema0 = seed_close;
     side.ema1 = seed_close;
     side.ema2 = seed_close;
@@ -169,7 +183,7 @@ inline void generate_long_orders(
     float bid_price = float(bid_ticks) * price_step;
     float min_q = min_entry_qty(bid_price, qty_step, min_qty, min_cost, c_mult);
     float base_q = fmax(min_q, round_step(
-        balance * side.twel * side.base_qty_pct
+        balance * side.allowed_wel * side.base_qty_pct
             / fmax(bid_price, 1.0e-12f) / c_mult,
         qty_step
     ));
@@ -178,7 +192,7 @@ inline void generate_long_orders(
     );
     bool cooldown = side.cooldown_min > 0.0f && side.last_inc_k >= 0.0f
         && kf < side.last_inc_k + side.cooldown_min;
-    float cap = side.twel - 1.0e-7f;
+    float cap = side.entry_cap - 1.0e-7f;
     float headroom = (cap * balance - side.psize * side.pprice * c_mult)
         / fmax(bid_price * c_mult, 1.0e-12f);
     bool over = (side.psize * side.pprice + e_qty * bid_price) * c_mult
@@ -200,7 +214,7 @@ inline void generate_long_orders(
     float ask_price = float(ask_ticks) * price_step;
     float min_cq = min_entry_qty(ask_price, qty_step, min_qty, min_cost, c_mult);
     float clip = fmin(side.psize, fmax(min_cq, round_step(
-        balance * side.twel * side.base_qty_pct
+        balance * side.allowed_wel * side.base_qty_pct
             / fmax(ask_price, 1.0e-12f) / c_mult,
         qty_step
     )));
@@ -243,7 +257,7 @@ inline void generate_short_orders(
     float ask_price = float(ask_ticks) * price_step;
     float min_q = min_entry_qty(ask_price, qty_step, min_qty, min_cost, c_mult);
     float base_q = fmax(min_q, round_step(
-        balance * side.twel * side.base_qty_pct
+        balance * side.allowed_wel * side.base_qty_pct
             / fmax(ask_price, 1.0e-12f) / c_mult,
         qty_step
     ));
@@ -252,7 +266,7 @@ inline void generate_short_orders(
     );
     bool cooldown = side.cooldown_min > 0.0f && side.last_inc_k >= 0.0f
         && kf < side.last_inc_k + side.cooldown_min;
-    float cap = side.twel - 1.0e-7f;
+    float cap = side.entry_cap - 1.0e-7f;
     float headroom = (cap * balance - side.psize * side.pprice * c_mult)
         / fmax(ask_price * c_mult, 1.0e-12f);
     bool over = (side.psize * side.pprice + e_qty * ask_price) * c_mult
@@ -274,7 +288,7 @@ inline void generate_short_orders(
     float bid_price = float(bid_ticks) * price_step;
     float min_cq = min_entry_qty(bid_price, qty_step, min_qty, min_cost, c_mult);
     float clip = fmin(side.psize, fmax(min_cq, round_step(
-        balance * side.twel * side.base_qty_pct
+        balance * side.allowed_wel * side.base_qty_pct
             / fmax(bid_price, 1.0e-12f) / c_mult,
         qty_step
     )));
@@ -511,11 +525,11 @@ inline void passivbot_single_coin_impl(
                 ? liq_floor : 0.0f;
             bool long_min_cost_eligible = passes_min_effective_cost(
                 filter_by_min_effective_cost, guaranteed_balance_lower,
-                long_side.twel, long_side.base_qty_pct, max_effective_min_cost
+                long_side.allowed_wel, long_side.base_qty_pct, max_effective_min_cost
             );
             bool short_min_cost_eligible = passes_min_effective_cost(
                 filter_by_min_effective_cost, guaranteed_balance_lower,
-                short_side.twel, short_side.base_qty_pct, max_effective_min_cost
+                short_side.allowed_wel, short_side.base_qty_pct, max_effective_min_cost
             );
             bool block_long_initial = !long_min_cost_eligible;
             bool block_short_initial = !short_min_cost_eligible;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -4,7 +4,7 @@ using namespace metal;
 constant int DAILY_COLS = 5;
 constant int SCALAR_COLS = 18;
 constant int GAP_BINS = 128;
-constant int SIDE_PARAMS = 27;
+constant int SIDE_PARAMS = 31;
 
 inline float round_step(float value, float step) {
     return floor(value / step + 0.5f) * step;
@@ -56,7 +56,7 @@ struct TmSide {
     float close_qty_pct, close_threshold_base, close_threshold_we;
     float close_threshold_v1h, close_threshold_v1m;
     float close_retracement_base, close_retracement_v1h, close_retracement_v1m;
-    float cooldown_min, twel;
+    float cooldown_min, twel, allowed_wel, entry_cap;
     bool gate_initial, gate_reentry;
     float ema0, ema1, ema2, vol1m, vol1h;
     float psize, pprice, last_inc_k, pos_open_k;
@@ -112,6 +112,19 @@ inline TmSide load_side(constant float* p, int o, float seed) {
     s.twel = p[o + 24];
     s.gate_initial = p[o + 25] > 0.5f;
     s.gate_reentry = p[o + 26] > 0.5f;
+    float allowance_pct = fmax(p[o + 27], 0.0f);
+    bool legacy_raw_allowance = p[o + 28] > 0.5f;
+    s.allowed_wel = s.twel * (
+        1.0f + (legacy_raw_allowance ? allowance_pct : 0.0f)
+    );
+    bool twel_entry_gate_enabled = p[o + 29] > 0.5f;
+    float twel_threshold = p[o + 30];
+    float gate_cap = s.twel;
+    if (isfinite(twel_threshold) && twel_threshold > 0.0f) {
+        gate_cap = fmin(s.twel, s.twel * twel_threshold);
+    }
+    s.entry_cap = twel_entry_gate_enabled
+        ? fmin(s.allowed_wel, gate_cap) : s.allowed_wel;
     s.ema0 = seed; s.ema1 = seed; s.ema2 = seed;
     s.vol1m = 0.0f; s.vol1h = 0.0f;
     s.psize = 0.0f; s.pprice = 0.0f;
@@ -176,9 +189,9 @@ inline float crop_entry(
     if (qty <= 0.0f) return 0.0f;
     float cost = s.psize * s.pprice * c_mult;
     float we_if = (cost + qty * price * c_mult) / fmax(balance, 1.0e-9f);
-    if (we_if <= s.twel * 1.01f) return qty;
+    if (we_if <= s.entry_cap * 1.01f) return qty;
     float q = round_step(
-        (s.twel * balance - cost) / fmax(price * c_mult, 1.0e-12f), qty_step
+        (s.entry_cap * balance - cost) / fmax(price * c_mult, 1.0e-12f), qty_step
     );
     float mq = min_entry_qty(price, qty_step, min_qty, min_cost, c_mult);
     q = fmax(q, mq);
@@ -189,7 +202,7 @@ inline float calc_close_qty(
     thread TmSide& s, float balance, float mq, int mq_relation, float pct,
     float qty_step, float c_mult
 ) {
-    float full = balance * s.twel / fmax(s.pprice * c_mult, 1.0e-12f);
+    float full = balance * s.allowed_wel / fmax(s.pprice * c_mult, 1.0e-12f);
     float qty = fmin(
         round_step(s.psize, qty_step),
         fmax(mq, ceil_step(full * pct + fmax(s.psize - full, 0.0f), qty_step))
@@ -248,7 +261,7 @@ inline void generate_orders(
     float initial_price = float(initial_ticks) * price_step;
     float min_iq = min_entry_qty(initial_price, qty_step, min_qty, min_cost, c_mult);
     float iq = fmax(min_iq, round_step(
-        balance * s.twel * s.initial_qty_pct
+        balance * s.allowed_wel * s.initial_qty_pct
             / fmax(initial_price * c_mult, 1.0e-12f), qty_step
     ));
     bool flat = s.psize <= 0.0f;
@@ -258,7 +271,7 @@ inline void generate_orders(
         ? fmax(round_step(s.psize, qty_step), min_iq) : iq;
     float we = !flat && balance > 0.0f
         ? s.psize * s.pprice * c_mult / balance : 0.0f;
-    float wer = we / fmax(s.twel, 1.0e-12f);
+    float wer = we / fmax(s.allowed_wel, 1.0e-12f);
     float tm = fmax(
         1.0f + s.vol1h * s.entry_threshold_v1h
             + s.vol1m * s.entry_threshold_v1m + wer * s.entry_threshold_we,
@@ -317,16 +330,17 @@ inline void generate_orders(
     float rq = fmax(iq_effective, fmax(min_rq, round_step(
         fmax(
             s.psize * s.ddf,
-            balance * s.twel * s.initial_qty_pct
+            balance * s.allowed_wel * s.initial_qty_pct
                 / fmax(reentry_price * c_mult, 1.0e-12f)
         ), qty_step
     )));
     float we_if = (s.psize * s.pprice + rq * reentry_price)
         * c_mult / fmax(balance, 1.0e-9f);
-    float crop_fraction = (s.twel - we) / fmax(we_if - we, 1.0e-12f);
+    float crop_fraction = (s.entry_cap - we) / fmax(we_if - we, 1.0e-12f);
     float rq_crop = fmax(round_step(rq * crop_fraction, qty_step), min_rq);
-    if (we_if > s.twel * 1.01f && rq_crop < rq) rq = rq_crop;
-    bool cap_hit = trailing_entry ? we > s.twel * 0.999f : we >= s.twel * 0.999f;
+    if (we_if > s.entry_cap * 1.01f && rq_crop < rq) rq = rq_crop;
+    bool cap_hit = trailing_entry
+        ? we > s.entry_cap * 0.999f : we >= s.entry_cap * 0.999f;
     bool reentry_ok = !flat && !partial && !cap_hit && reentry_ticks > 1
         && (!trailing_entry || entry_triggered);
     float eqty = flat ? iq : (partial ? iq_partial : (reentry_ok ? rq : 0.0f));
@@ -335,7 +349,7 @@ inline void generate_orders(
     bool cooldown = s.cooldown_min > 0.0f && s.last_inc_k >= 0.0f
         && kf < s.last_inc_k + s.cooldown_min;
     if (cooldown || balance <= 0.0f || s.initial_qty_pct <= 0.0f
-        || s.twel <= 0.0f || eticks <= 1
+        || s.allowed_wel <= 0.0f || s.entry_cap <= 0.0f || eticks <= 1
         || (block_initial && flat)) eqty = 0.0f;
     s.entry_ticks = eticks;
     s.entry_price = eprice;
@@ -922,12 +936,12 @@ inline void passivbot_single_coin_impl(
                 ? liq_floor : 0.0f;
             bool long_min_cost_eligible = passes_min_effective_cost(
                 filter_by_min_effective_cost, guaranteed_balance_lower,
-                long_side.twel, long_side.initial_qty_pct,
+                long_side.allowed_wel, long_side.initial_qty_pct,
                 max_effective_min_cost
             );
             bool short_min_cost_eligible = passes_min_effective_cost(
                 filter_by_min_effective_cost, guaranteed_balance_lower,
-                short_side.twel, short_side.initial_qty_pct,
+                short_side.allowed_wel, short_side.initial_qty_pct,
                 max_effective_min_cost
             );
             bool block_long_initial = !long_min_cost_eligible;

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -64,10 +64,24 @@ _EMA_SIDE_BOUND_SUFFIXES = {
     "total_wallet_exposure_limit": "total_wallet_exposure_limit",
 }
 
-EMA_BOUND_MAP = {
+_SINGLE_COIN_EXPOSURE_BOUND_SUFFIXES = {
+    "risk_we_excess_allowance_pct": "we_excess_allowance_pct",
+    "risk_twel_enforcer_threshold": "twel_enforcer_threshold",
+}
+
+EMA_STRATEGY_BOUND_MAP = {
     f"{side}_{bound_suffix}": f"{side}_{parameter}"
     for side in ("long", "short")
     for bound_suffix, parameter in _EMA_SIDE_BOUND_SUFFIXES.items()
+}
+
+EMA_BOUND_MAP = {
+    **EMA_STRATEGY_BOUND_MAP,
+    **{
+        f"{side}_{bound_suffix}": f"{side}_{parameter}"
+        for side in ("long", "short")
+        for bound_suffix, parameter in _SINGLE_COIN_EXPOSURE_BOUND_SUFFIXES.items()
+    },
 }
 
 _EMA_MULTICOIN_SIDE_BOUND_SUFFIXES = {
@@ -82,7 +96,7 @@ _EMA_MULTICOIN_SIDE_BOUND_SUFFIXES = {
 
 EMA_MULTICOIN_BOUND_MAPS = {
     side: {
-        **EMA_BOUND_MAP,
+        **EMA_STRATEGY_BOUND_MAP,
         **{
             f"{side}_{suffix}": f"{side}_{parameter}"
             for suffix, parameter in _EMA_MULTICOIN_SIDE_BOUND_SUFFIXES.items()
@@ -123,15 +137,24 @@ _TM_SIDE_BOUND_SUFFIXES = {
     "total_wallet_exposure_limit": "total_wallet_exposure_limit",
 }
 
-TRAILING_MARTINGALE_BOUND_MAP = {
+TRAILING_MARTINGALE_STRATEGY_BOUND_MAP = {
     f"{side}_{bound_suffix}": f"{side}_{parameter}"
     for side in ("long", "short")
     for bound_suffix, parameter in _TM_SIDE_BOUND_SUFFIXES.items()
 }
 
+TRAILING_MARTINGALE_BOUND_MAP = {
+    **TRAILING_MARTINGALE_STRATEGY_BOUND_MAP,
+    **{
+        f"{side}_{bound_suffix}": f"{side}_{parameter}"
+        for side in ("long", "short")
+        for bound_suffix, parameter in _SINGLE_COIN_EXPOSURE_BOUND_SUFFIXES.items()
+    },
+}
+
 TRAILING_MARTINGALE_MULTICOIN_BOUND_MAPS = {
     side: {
-        **TRAILING_MARTINGALE_BOUND_MAP,
+        **TRAILING_MARTINGALE_STRATEGY_BOUND_MAP,
         **{
             f"{side}_{suffix}": f"{side}_{parameter}"
             for suffix, parameter in _EMA_MULTICOIN_SIDE_BOUND_SUFFIXES.items()
@@ -376,6 +399,13 @@ PINNED_SCOPE_BOUND_VALUES = {
         "unstuck_enabled": 0.0,
         "risk_position_exposure_enforcer_enabled": 0.0,
         "risk_total_exposure_enforcer_enabled": 0.0,
+    }.items()
+}
+
+MULTICOIN_PINNED_SCOPE_BOUND_VALUES = {
+    f"{side}_{suffix}": expected
+    for side in ("long", "short")
+    for suffix, expected in {
         "risk_total_exposure_entry_gate_enabled": 1.0,
         "risk_twel_enforcer_threshold": 1.0,
         "risk_we_excess_allowance_pct": 0.0,
@@ -837,16 +867,22 @@ def _validate_scope_config(
         for key, expected in (
             ("position_exposure_enforcer_enabled", False),
             ("total_exposure_enforcer_enabled", False),
-            ("total_exposure_entry_gate_enabled", True),
         ):
             if bool(risk.get(key, expected)) != expected:
                 raise ValueError(
                     f"GPU foundation requires bot.{side}.risk.{key}={str(expected).lower()}"
                 )
-        if float(risk.get("we_excess_allowance_pct", 0.0) or 0.0) != 0.0:
-            raise ValueError(
-                f"GPU foundation requires bot.{side}.risk.we_excess_allowance_pct=0.0"
-            )
+        if coin_count > 1:
+            if not bool(risk.get("total_exposure_entry_gate_enabled", True)):
+                raise ValueError(
+                    "GPU multicoin foundation requires "
+                    f"bot.{side}.risk.total_exposure_entry_gate_enabled=true"
+                )
+            if float(risk.get("we_excess_allowance_pct", 0.0) or 0.0) != 0.0:
+                raise ValueError(
+                    "GPU multicoin foundation requires "
+                    f"bot.{side}.risk.we_excess_allowance_pct=0.0"
+                )
     return exchange
 
 
@@ -1946,9 +1982,14 @@ def _build_anchor_parameter_context(
     return parameter_overrides, fixed_bounds
 
 
-def _validate_pinned_scope_bounds(bound_by_key, base_by_key, enabled_sides=None) -> None:
+def _validate_pinned_scope_bounds(
+    bound_by_key, base_by_key, enabled_sides=None, *, coin_count: int = 1
+) -> None:
     enabled_sides = set(enabled_sides or ("long", "short"))
-    for key, expected in PINNED_SCOPE_BOUND_VALUES.items():
+    pinned = dict(PINNED_SCOPE_BOUND_VALUES)
+    if int(coin_count) > 1:
+        pinned.update(MULTICOIN_PINNED_SCOPE_BOUND_VALUES)
+    for key, expected in pinned.items():
         if key.split("_", 1)[0] not in enabled_sides:
             continue
         bound = bound_by_key.get(key)
@@ -2449,7 +2490,12 @@ def run_backend(
     )
     if "mirror_short_from_long" in gpu_optimizer_overrides:
         _mirror_short_mapping(bound_by_key)
-    _validate_pinned_scope_bounds(bound_by_key, base_by_key, enabled_sides)
+    _validate_pinned_scope_bounds(
+        bound_by_key,
+        base_by_key,
+        enabled_sides,
+        coin_count=max_coin_count,
+    )
 
     if suite_multicoin_sides is None:
         _validate_directional_search_space(
@@ -2484,6 +2530,7 @@ def run_backend(
             scenario_bound_by_key,
             scenario_base_by_key,
             scenario_enabled_sides,
+            coin_count=item["coin_count"],
         )
         _validate_directional_search_space(
             scenario_bound_by_key,

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -25,6 +25,18 @@ EMA_ANCHOR_PARAM_KEYS = (
     "total_wallet_exposure_limit",
 )
 
+SINGLE_COIN_EXPOSURE_PARAM_KEYS = (
+    "we_excess_allowance_pct",
+    "we_excess_allowance_legacy_raw",
+    "twel_entry_gate_enabled",
+    "twel_enforcer_threshold",
+)
+
+EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS = (
+    *EMA_ANCHOR_PARAM_KEYS,
+    *SINGLE_COIN_EXPOSURE_PARAM_KEYS,
+)
+
 EMA_ANCHOR_MULTICOIN_PARAM_KEYS = (
     *EMA_ANCHOR_PARAM_KEYS,
     "forager_volume_ema_span_1m",
@@ -64,6 +76,11 @@ TRAILING_MARTINGALE_PARAM_KEYS = (
     "total_wallet_exposure_limit",
     "gate_initial",
     "gate_reentry",
+)
+
+TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS = (
+    *TRAILING_MARTINGALE_PARAM_KEYS,
+    *SINGLE_COIN_EXPOSURE_PARAM_KEYS,
 )
 
 TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS = (
@@ -128,8 +145,8 @@ TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS = (
 )
 
 GPU_STRATEGY_PARAM_KEYS = {
-    "ema_anchor": EMA_ANCHOR_PARAM_KEYS,
-    "trailing_martingale": TRAILING_MARTINGALE_PARAM_KEYS,
+    "ema_anchor": EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
+    "trailing_martingale": TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS,
 }
 
 

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -7,13 +7,13 @@ import numpy as np
 import torch
 
 from optimization.gpu.model import (
-    EMA_ANCHOR_PARAM_KEYS,
     EMA_ANCHOR_MULTICOIN_PARAM_KEYS,
+    EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
     GAP_BINS,
     ProxyMarket,
     ProxyRun,
     TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS,
-    TRAILING_MARTINGALE_PARAM_KEYS,
+    TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS,
 )
 
 
@@ -192,7 +192,7 @@ class MpsEmaAnchorRunner:
         self.last_profile: dict[str, float] = {}
 
     def _pack_params(self, params: np.ndarray) -> np.ndarray:
-        expected = len(EMA_ANCHOR_PARAM_KEYS) * 2
+        expected = len(EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS) * 2
         if params.ndim != 2 or params.shape[1] != expected:
             got = params.shape[1] if params.ndim == 2 else params.shape
             raise ValueError(
@@ -599,7 +599,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
     """Persistent single-coin trailing-martingale runner on Apple MPS."""
 
     def _pack_params(self, params: np.ndarray) -> np.ndarray:
-        expected = len(TRAILING_MARTINGALE_PARAM_KEYS) * 2
+        expected = len(TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS) * 2
         if params.ndim != 2 or params.shape[1] != expected:
             got = params.shape[1] if params.ndim == 2 else params.shape
             raise ValueError(

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -43,6 +43,32 @@ CORE_OUTPUT_KEYS = {
 }
 
 
+def _single_coin_exposure_params(risk: dict, *, side: str) -> dict[str, float]:
+    allowance_mode = str(
+        risk.get("we_excess_allowance_mode", "bounded")
+    ).strip().lower()
+    if allowance_mode not in {"bounded", "legacy_raw"}:
+        raise ValueError(
+            "MPS single-coin proxy requires "
+            f"bot.{side}.risk.we_excess_allowance_mode to be bounded or "
+            f"legacy_raw, got {allowance_mode!r}"
+        )
+    return {
+        "we_excess_allowance_pct": float(
+            risk.get("we_excess_allowance_pct", 0.0) or 0.0
+        ),
+        "we_excess_allowance_legacy_raw": float(
+            allowance_mode == "legacy_raw"
+        ),
+        "twel_entry_gate_enabled": float(
+            bool(risk.get("total_exposure_entry_gate_enabled", True))
+        ),
+        "twel_enforcer_threshold": float(
+            risk.get("total_exposure_enforcer_threshold", 1.0) or 0.0
+        ),
+    }
+
+
 def _require_complete_valid_tail(last_valid_idx: int, candle_count: int) -> None:
     if int(last_valid_idx) != int(candle_count) - 1:
         raise ValueError(
@@ -295,6 +321,7 @@ class MpsSingleCoinProxy:
                 strategy["total_wallet_exposure_limit"] = float(
                     risk["total_wallet_exposure_limit"]
                 )
+            strategy.update(_single_coin_exposure_params(risk, side=side))
             missing = [key for key in self.param_keys if key not in strategy]
             if missing:
                 raise ValueError(

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -344,6 +344,8 @@ def test_trailing_martingale_bound_map_covers_both_directional_shapes():
         "close_retracement_volatility_1h_weight",
         "close_retracement_volatility_1m_weight",
         "risk_entry_cooldown_minutes",
+        "risk_twel_enforcer_threshold",
+        "risk_we_excess_allowance_pct",
         "total_wallet_exposure_limit",
     }
 
@@ -1328,18 +1330,6 @@ def test_suite_limit_metric_value_respects_reducer_and_scenario():
             ),
             "total_exposure_enforcer_enabled",
         ),
-        (
-            lambda config: config["bot"]["long"]["risk"].__setitem__(
-                "we_excess_allowance_pct", 0.1
-            ),
-            "we_excess_allowance_pct",
-        ),
-        (
-            lambda config: config["bot"]["long"]["risk"].__setitem__(
-                "total_exposure_entry_gate_enabled", False
-            ),
-            "total_exposure_entry_gate_enabled",
-        ),
     ],
 )
 def test_gpu_foundation_fails_closed_for_unsupported_scope(mutate, message):
@@ -1352,6 +1342,52 @@ def test_gpu_foundation_fails_closed_for_unsupported_scope(mutate, message):
 
 def test_gpu_foundation_accepts_ema_long_single():
     assert _validate_scope(_long_only_ema_config(), _Evaluator()) == "bybit"
+
+
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("side", ["long", "short"])
+@pytest.mark.parametrize("entry_gate", [False, True])
+@pytest.mark.parametrize("allowance_mode", ["bounded", "legacy_raw"])
+def test_gpu_foundation_accepts_single_coin_exposure_headroom_policy(
+    strategy_kind, side, entry_gate, allowance_mode
+):
+    builder = (
+        _directional_tm_config
+        if strategy_kind == "trailing_martingale"
+        else _directional_ema_config
+    )
+    config = builder(long_enabled=side == "long", short_enabled=side == "short")
+    risk = config["bot"][side]["risk"]
+    risk["we_excess_allowance_pct"] = 0.25
+    risk["we_excess_allowance_mode"] = allowance_mode
+    risk["total_exposure_entry_gate_enabled"] = entry_gate
+    risk["total_exposure_enforcer_threshold"] = 0.8
+
+    assert _validate_scope(config, _Evaluator()) == "bybit"
+
+
+@pytest.mark.parametrize(
+    ("key", "value", "message"),
+    [
+        ("we_excess_allowance_pct", 0.1, "we_excess_allowance_pct"),
+        (
+            "total_exposure_entry_gate_enabled",
+            False,
+            "total_exposure_entry_gate_enabled",
+        ),
+    ],
+)
+def test_gpu_multicoin_exposure_headroom_policy_remains_fail_closed(
+    key, value, message
+):
+    config = _directional_ema_config(long_enabled=True, short_enabled=False)
+    config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "SOL"]
+    config["bot"]["long"]["risk"]["n_positions"] = 2
+    config["bot"]["long"]["risk"][key] = value
+    config["backtest"]["dynamic_wel_by_tradability"] = True
+
+    with pytest.raises(ValueError, match=message):
+        _validate_scope(config, _MulticoinEvaluator())
 
 
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
@@ -3107,7 +3143,7 @@ def test_gpu_anchor_context_fails_closed_on_missing_fixed_values():
         _build_anchor_parameter_context(config, {})
 
 
-def test_gpu_anchor_ranges_preserve_pinned_scope_validation():
+def test_gpu_anchor_ranges_support_single_coin_exposure_headroom_only():
     config = {
         ANCHOR_PLAN_KEY: {
             "fixed_keys": ["long_risk_we_excess_allowance_pct"],
@@ -3134,8 +3170,13 @@ def test_gpu_anchor_ranges_preserve_pinned_scope_validation():
 
     _overrides, fixed_bounds = _build_anchor_parameter_context(config, {})
 
+    _validate_pinned_scope_bounds(
+        fixed_bounds, {}, {"long"}, coin_count=1
+    )
     with pytest.raises(ValueError, match="we_excess_allowance_pct"):
-        _validate_pinned_scope_bounds(fixed_bounds, {}, {"long"})
+        _validate_pinned_scope_bounds(
+            fixed_bounds, {}, {"long"}, coin_count=2
+        )
 
 
 def test_gpu_anchor_ranges_cannot_change_side_enablement():
@@ -3384,13 +3425,27 @@ def test_gpu_rejects_pinned_unsupported_risk_behavior():
         _validate_pinned_scope_bounds(
             {"long_risk_we_excess_allowance_pct": Bound(0.2, 0.2, None)},
             {"long_risk_we_excess_allowance_pct": 0.2},
+            coin_count=2,
         )
 
     with pytest.raises(ValueError, match="twel_enforcer_threshold"):
         _validate_pinned_scope_bounds(
             {"long_risk_twel_enforcer_threshold": Bound(0.8, 0.8, None)},
             {"long_risk_twel_enforcer_threshold": 0.8},
+            coin_count=2,
         )
+
+
+def test_gpu_accepts_single_coin_exposure_policy_bounds():
+    _validate_pinned_scope_bounds(
+        {
+            "long_risk_we_excess_allowance_pct": Bound(0.0, 0.5, None),
+            "long_risk_twel_enforcer_threshold": Bound(0.5, 1.0, None),
+        },
+        {},
+        {"long"},
+        coin_count=1,
+    )
 
 def test_gpu_anchor_constant_twel_threshold_fails_closed():
     config = {
@@ -3420,7 +3475,9 @@ def test_gpu_anchor_constant_twel_threshold_fails_closed():
     _overrides, fixed_bounds = _build_anchor_parameter_context(config, {})
 
     with pytest.raises(ValueError, match="twel_enforcer_threshold"):
-        _validate_pinned_scope_bounds(fixed_bounds, {}, {"long"})
+        _validate_pinned_scope_bounds(
+            fixed_bounds, {}, {"long"}, coin_count=2
+        )
 
 
 def test_gpu_directional_search_space_keeps_side_enablement_fixed():

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -5,9 +5,11 @@ import pytest
 torch = pytest.importorskip("torch")
 
 from optimization.gpu.model import (
+    EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
     ProxyMarket,
     ProxyRun,
     TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS,
+    TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS,
     _build_hourly_log_range,
     _directional_touch_ticks,
     _maximum_effective_min_cost,
@@ -16,6 +18,17 @@ from optimization.gpu.model import (
     build_mps_data,
     build_mps_multicoin_data,
 )
+
+
+def _single_coin_exposure_fields(
+    *, allowance_pct=0.0, legacy_raw=False, entry_gate=True, threshold=1.0
+):
+    return [
+        allowance_pct,
+        float(legacy_raw),
+        float(entry_gate),
+        threshold,
+    ]
 
 
 def test_directional_touch_ticks_preserve_alignment_and_round_non_aligned_prices():
@@ -206,6 +219,7 @@ def test_mps_ema_anchor_shader_smoke():
         0.0,
         1.0,
     ]
+    row += _single_coin_exposure_fields()
     parameters = np.array([row + row, row + row], dtype=np.float64)
 
     output = MpsEmaAnchorRunner(market, run, data).run(parameters)
@@ -532,6 +546,7 @@ def test_mps_ema_anchor_preserves_tick_aligned_computed_target():
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
     row = [0.1, 2.0, 3.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 2.0, 0.0, 1.0]
+    row += _single_coin_exposure_fields()
 
     output = MpsEmaAnchorRunner(
         market, run, data, long_enabled=True, short_enabled=False
@@ -567,6 +582,7 @@ def test_mps_ema_anchor_directionally_rounds_non_aligned_candle_touch():
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
     row = [0.1, 2.0, 3.0, 0.0, -0.01, 0.0, 0.0, 0.0, 2.0, 2.0, 0.0, 1.0]
+    row += _single_coin_exposure_fields()
 
     output = MpsEmaAnchorRunner(
         market, run, data, long_enabled=True, short_enabled=False
@@ -609,6 +625,7 @@ def test_mps_volume_uses_raw_non_positive_post_fill_balance():
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
     row = [1.0, 2.0, 3.0, 0.0, 0.0001, 0.0, 0.0, 0.0, 2.0, 2.0, 0.0, 1.0]
+    row += _single_coin_exposure_fields()
     parameters = np.array(
         [row + row],
         dtype=np.float64,
@@ -653,6 +670,7 @@ def test_mps_dual_side_respects_one_way_initial_arbitration(hedge_mode):
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
     row = [0.1, 2.0, 3.0, 0.0, 0.01, 0.0, 0.0, 0.0, 2.0, 2.0, 0.0, 1.0]
+    row += _single_coin_exposure_fields()
 
     output = MpsEmaAnchorRunner(
         market,
@@ -692,6 +710,7 @@ def test_mps_short_only_opens_short_position():
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
     row = [0.1, 2.0, 3.0, 0.0, 0.01, 0.0, 0.0, 0.0, 2.0, 2.0, 0.0, 1.0]
+    row += _single_coin_exposure_fields()
 
     output = MpsEmaAnchorRunner(
         market, run, data, long_enabled=False, short_enabled=True
@@ -732,6 +751,117 @@ def _tm_row(*, initial_ema_dist=0.01, gate_initial=1.0, gate_reentry=1.0):
         gate_initial,
         gate_reentry,
     ]
+
+
+def _tm_single_row(
+    *,
+    initial_ema_dist=0.01,
+    gate_initial=1.0,
+    gate_reentry=1.0,
+    allowance_pct=0.0,
+    legacy_raw=False,
+    entry_gate=True,
+    threshold=1.0,
+):
+    return _tm_row(
+        initial_ema_dist=initial_ema_dist,
+        gate_initial=gate_initial,
+        gate_reentry=gate_reentry,
+    ) + _single_coin_exposure_fields(
+        allowance_pct=allowance_pct,
+        legacy_raw=legacy_raw,
+        entry_gate=entry_gate,
+        threshold=threshold,
+    )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_single_coin_exposure_headroom_and_entry_gate(
+    strategy_kind, side
+):
+    count = 6
+    close = np.full(count, 100.0)
+    high = np.array([100.0, 100.0, 100.0, 102.0, 100.0, 100.0])
+    low = np.array([100.0, 100.0, 100.0, 98.0, 100.0, 100.0])
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+
+    def row(*, legacy_raw, entry_gate):
+        exposure = _single_coin_exposure_fields(
+            allowance_pct=0.5,
+            legacy_raw=legacy_raw,
+            entry_gate=entry_gate,
+            threshold=0.5,
+        )
+        if strategy_kind == "trailing_martingale":
+            values = _tm_row(
+                initial_ema_dist=0.01,
+                gate_initial=1.0,
+                gate_reentry=1.0,
+            )
+            values[6] = 1.0
+            return values + exposure
+        values = [
+            1.0,
+            2.0,
+            3.0,
+            0.0,
+            0.01,
+            0.0,
+            0.0,
+            0.0,
+            2.0,
+            2.0,
+            0.0,
+            1.0,
+        ]
+        return values + exposure
+
+    runner_cls = (
+        MpsTrailingMartingaleRunner
+        if strategy_kind == "trailing_martingale"
+        else MpsEmaAnchorRunner
+    )
+    runner = runner_cls(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+    )
+    rows = [
+        row(legacy_raw=False, entry_gate=False),
+        row(legacy_raw=True, entry_gate=False),
+        row(legacy_raw=True, entry_gate=True),
+    ]
+    output = runner.run(
+        np.asarray([values + values for values in rows], dtype=np.float64)
+    )
+    torch.mps.synchronize()
+    sizes = (
+        output["psize"] if side == "long" else output["short_psize"]
+    ).cpu().numpy()
+
+    assert sizes[0] > 0.0
+    assert sizes[1] > sizes[0] * 1.4
+    assert sizes[2] < sizes[0] * 0.6
 
 
 @pytest.mark.skipif(
@@ -775,7 +905,8 @@ def test_mps_single_coin_min_effective_cost_filter_blocks_only_flat_entries(
         0.0,
         1.0,
     ]
-    row = _tm_row() if strategy_kind == "trailing_martingale" else ema_row
+    ema_row += _single_coin_exposure_fields()
+    row = _tm_single_row() if strategy_kind == "trailing_martingale" else ema_row
     runner_cls = (
         MpsTrailingMartingaleRunner
         if strategy_kind == "trailing_martingale"
@@ -845,6 +976,7 @@ def test_mps_min_effective_cost_uses_downward_projected_cost_bound():
         0.0,
         1.0,
     ]
+    row += _single_coin_exposure_fields()
     guaranteed_balance_lower = run.starting_balance * run.liquidation_threshold
     rounded_projection = np.float32(guaranteed_balance_lower) * np.float32(
         base_qty_pct
@@ -892,8 +1024,8 @@ def test_mps_one_way_min_cost_eligibility_precedes_distance_arbitration(
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
     if strategy_kind == "trailing_martingale":
-        long_row = _tm_row(initial_ema_dist=0.02)
-        short_row = _tm_row(initial_ema_dist=0.01)
+        long_row = _tm_single_row(initial_ema_dist=0.02)
+        short_row = _tm_single_row(initial_ema_dist=0.01)
         short_row[6] = 0.01
         runner_cls = MpsTrailingMartingaleRunner
     else:
@@ -911,6 +1043,7 @@ def test_mps_one_way_min_cost_eligibility_precedes_distance_arbitration(
             0.0,
             1.0,
         ]
+        long_row += _single_coin_exposure_fields()
         short_row = list(long_row)
         short_row[0] = 0.01
         short_row[4] = 0.01
@@ -978,6 +1111,7 @@ def test_mps_min_effective_cost_filter_keeps_managing_an_open_position(side):
         0.0,
         1.0,
     ]
+    row += _single_coin_exposure_fields()
 
     output = MpsEmaAnchorRunner(
         market,
@@ -1083,7 +1217,9 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
 
     source = passivbot_rust.mps_trailing_martingale_source_py()
     assert "kernel void passivbot_trailing_martingale" in source
-    assert "constant int SIDE_PARAMS = 27" in source
+    assert "constant int SIDE_PARAMS = 31" in source
+    assert "s.allowed_wel" in source
+    assert "s.entry_cap" in source
     assert "min_since_open" in source
     assert "max_since_min" in source
     assert "max_since_open" in source
@@ -1127,7 +1263,7 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
         count - 1,
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
-    row = _tm_row()
+    row = _tm_single_row()
 
     output = MpsTrailingMartingaleRunner(
         market,
@@ -1176,7 +1312,7 @@ def test_mps_trailing_martingale_fills_recursive_entry_ladder(is_long):
         count - 1,
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
-    row = _tm_row(initial_ema_dist=0.0, gate_initial=0.0, gate_reentry=0.0)
+    row = _tm_single_row(initial_ema_dist=0.0, gate_initial=0.0, gate_reentry=0.0)
     row[4] = 1.5  # entry double-down factor
     row[6] = 0.05  # initial entry uses 5% of the exposure budget
     row[11] = 0.0  # recursive entry mode
@@ -1225,7 +1361,7 @@ def test_mps_trailing_martingale_fills_recursive_entry_ladders_in_hedge_mode():
         count - 1,
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
-    row = _tm_row(initial_ema_dist=0.0, gate_initial=0.0, gate_reentry=0.0)
+    row = _tm_single_row(initial_ema_dist=0.0, gate_initial=0.0, gate_reentry=0.0)
     row[4], row[6], row[11], row[16] = 1.5, 0.05, 0.0, 1.0
 
     output = MpsTrailingMartingaleRunner(
@@ -1277,7 +1413,7 @@ def test_mps_trailing_martingale_fills_sorted_recursive_close_grid(
         count - 1,
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
-    row = _tm_row(initial_ema_dist=0.0, gate_initial=0.0, gate_reentry=0.0)
+    row = _tm_single_row(initial_ema_dist=0.0, gate_initial=0.0, gate_reentry=0.0)
     row[6] = 0.1  # Open a 1-unit position.
     row[7] = 0.01  # Exposure cap prevents reentries in this fixture.
     row[15] = 0.05  # Two recursive close rungs at the standard lower bound.
@@ -1328,7 +1464,7 @@ def test_mps_trailing_martingale_fills_recursive_close_grids_in_hedge_mode():
         count - 1,
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
-    row = _tm_row(initial_ema_dist=0.0, gate_initial=0.0, gate_reentry=0.0)
+    row = _tm_single_row(initial_ema_dist=0.0, gate_initial=0.0, gate_reentry=0.0)
     row[6], row[7], row[15] = 1.0, 1.0, 0.2
     row[16], row[17], row[20] = 0.005, 0.005, 0.0
 
@@ -1371,7 +1507,7 @@ def test_mps_trailing_martingale_preserves_tick_aligned_computed_target():
         count - 1,
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
-    row = _tm_row(initial_ema_dist=0.0)
+    row = _tm_single_row(initial_ema_dist=0.0)
 
     output = MpsTrailingMartingaleRunner(
         market, run, data, long_enabled=True, short_enabled=False
@@ -1406,7 +1542,7 @@ def test_mps_trailing_martingale_quantizes_non_aligned_entry_down():
         count - 1,
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
-    row = _tm_row(gate_initial=0.0, gate_reentry=0.0)
+    row = _tm_single_row(gate_initial=0.0, gate_reentry=0.0)
 
     output = MpsTrailingMartingaleRunner(
         market, run, data, long_enabled=True, short_enabled=False
@@ -1444,7 +1580,7 @@ def test_mps_trailing_martingale_quantizes_non_aligned_short_entry_up():
         count - 1,
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
-    row = _tm_row(gate_initial=0.0, gate_reentry=0.0)
+    row = _tm_single_row(gate_initial=0.0, gate_reentry=0.0)
 
     output = MpsTrailingMartingaleRunner(
         market, run, data, long_enabled=False, short_enabled=True
@@ -1486,7 +1622,7 @@ def test_mps_trailing_entry_quantizes_before_strict_fill():
         count - 1,
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
-    row = _tm_row(gate_initial=0.0, gate_reentry=0.0)
+    row = _tm_single_row(gate_initial=0.0, gate_reentry=0.0)
 
     output = MpsTrailingMartingaleRunner(
         market, run, data, long_enabled=True, short_enabled=False
@@ -1528,7 +1664,7 @@ def test_mps_trailing_initial_gate_chooses_tick_before_float32_collapse():
         count - 1,
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
-    row = _tm_row(initial_ema_dist=0.0, gate_initial=1.0)
+    row = _tm_single_row(initial_ema_dist=0.0, gate_initial=1.0)
 
     output = MpsTrailingMartingaleRunner(
         market, run, data, long_enabled=True, short_enabled=False
@@ -1574,7 +1710,7 @@ def test_mps_trailing_quantizes_selected_raw_close_to_nearest_tick():
         count - 1,
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
-    row = _tm_row(gate_initial=0.0, gate_reentry=0.0)
+    row = _tm_single_row(gate_initial=0.0, gate_reentry=0.0)
     row[16] = 0.0  # tick-aligned close target at the float32 position price
     row[20] = 0.0  # disable trailing-close touch override
 
@@ -1614,7 +1750,7 @@ def test_mps_trailing_sizes_raw_touch_close_before_price_finalization():
         count - 1,
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
-    row = _tm_row(gate_initial=0.0, gate_reentry=0.0)
+    row = _tm_single_row(gate_initial=0.0, gate_reentry=0.0)
     row[15] = 0.01
     row[16] = 0.199
     row[17] = -2.0  # keep later grid closes above this fixture's high
@@ -1657,7 +1793,7 @@ def test_mps_trailing_preserves_just_above_aligned_raw_touch_minimum():
         count - 1,
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
-    row = _tm_row(gate_initial=0.0, gate_reentry=0.0)
+    row = _tm_single_row(gate_initial=0.0, gate_reentry=0.0)
     row[15] = 0.05
     row[16] = 0.299
     row[17] = -3.0  # keep a possible second grid close above the high
@@ -1713,7 +1849,7 @@ def test_mps_trailing_quantizes_selected_short_close_to_nearest_tick():
         count - 1,
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
-    row = _tm_row(gate_initial=0.0, gate_reentry=0.0)
+    row = _tm_single_row(gate_initial=0.0, gate_reentry=0.0)
     row[16] = 0.0
     row[20] = 0.0
 
@@ -1753,7 +1889,7 @@ def test_mps_trailing_martingale_one_way_arbitrates_initial_entry():
         count - 1,
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
-    row = _tm_row()
+    row = _tm_single_row()
 
     output = MpsTrailingMartingaleRunner(
         market,
@@ -1796,7 +1932,7 @@ def test_mps_trailing_martingale_entry_cap_uses_rust_nearest_step_rounding():
         count - 1,
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
-    row = _tm_row(initial_ema_dist=0.0, gate_initial=0.0, gate_reentry=0.0)
+    row = _tm_single_row(initial_ema_dist=0.0, gate_initial=0.0, gate_reentry=0.0)
     row[6] = 2.0  # Oversize the initial order so the exposure cap crops it.
     row[7] = 0.5  # Keep any subsequent reentry far below the fixture market.
     row[16] = 0.5  # Keep the close above the fixture market.
@@ -1880,7 +2016,7 @@ def test_mps_trailing_martingale_touch_close_preserves_raw_price():
         count - 1,
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
-    row = _tm_row(initial_ema_dist=0.0, gate_initial=0.0, gate_reentry=0.0)
+    row = _tm_single_row(initial_ema_dist=0.0, gate_initial=0.0, gate_reentry=0.0)
     row[7] = 0.5  # Prevent another entry in this fixture.
     row[16] = 0.0  # Use the current touch after the close trail retraces.
     row[20] = 0.000001

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -19,6 +19,7 @@ from optimization.gpu.service import (
     _build_multicoin_tm_coin_overrides,
     _combine_hedged_multicoin_outputs,
     _require_complete_valid_tail,
+    _single_coin_exposure_params,
 )
 
 
@@ -27,6 +28,35 @@ def test_gpu_proxy_requires_complete_valid_tail():
 
     with pytest.raises(ValueError, match="force-realizes open positions"):
         _require_complete_valid_tail(98, 100)
+
+
+@pytest.mark.parametrize(
+    ("mode", "legacy_raw"), [("bounded", 0.0), ("legacy_raw", 1.0)]
+)
+def test_single_coin_exposure_policy_packs_rust_inputs(mode, legacy_raw):
+    packed = _single_coin_exposure_params(
+        {
+            "we_excess_allowance_pct": 0.25,
+            "we_excess_allowance_mode": mode,
+            "total_exposure_entry_gate_enabled": False,
+            "total_exposure_enforcer_threshold": 0.8,
+        },
+        side="long",
+    )
+
+    assert packed == {
+        "we_excess_allowance_pct": 0.25,
+        "we_excess_allowance_legacy_raw": legacy_raw,
+        "twel_entry_gate_enabled": 0.0,
+        "twel_enforcer_threshold": 0.8,
+    }
+
+
+def test_single_coin_exposure_policy_rejects_unknown_allowance_mode():
+    with pytest.raises(ValueError, match="we_excess_allowance_mode"):
+        _single_coin_exposure_params(
+            {"we_excess_allowance_mode": "raw"}, side="short"
+        )
 
 
 def test_directional_parameter_matrix_keeps_side_values_separate():


### PR DESCRIPTION
## Summary

- add single-coin Apple MPS proxy support for bounded and legacy-raw wallet-exposure allowance
- model the total-exposure entry-gate toggle and tunable threshold for EMA Anchor and Trailing Martingale
- preserve existing multicoin fail-closed exposure-policy restrictions and exact-Rust authority

## Scope

Supported for single-coin long-only, short-only, dual-side, and compatible suite runs. Position-exposure enforcement and total-exposure repair remain unsupported. Multicoin runs still require zero allowance, an enabled entry gate, and threshold 1.0.

## Validation

- full Python test suite: pass
- focused GPU backend/service tests: pass
- real Apple MPS kernel tests: 56 passed
- `cargo test --no-default-features`: 261 passed
- `cargo check --tests`: pass
- rebuilt and source-stamp-verified PyO3 extension
- cached-data MPS optimizer smoke with bounded allowance/threshold bounds: 4,096 proxy evaluations and 64 exact validations, no drift or constraint halt
- cached-data MPS optimizer smoke with legacy-raw allowance and disabled entry gate: 4,096 proxy evaluations and 64 exact validations, no drift or constraint halt