### PR TITLE
feat(optimize): support MPS position exposure repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,21 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added Trailing Martingale per-position exposure repair to the Apple MPS optimizer for single- and
+  multi-coin long-only, short-only, dual-side, and compatible suite runs. The Metal proxy models
+  the canonical enable toggle and tunable threshold, gives the passive repair close precedence
+  over normal strategy closes, reduces strictly below the allowance-adjusted WEL target, and
+  honors static per-coin enable/threshold overrides. Exact Rust validation and the existing
+  classification, rank, and drift gates remain authoritative. EMA Anchor position repair and
+  side-wide total-exposure repair remain fail closed.
+
 - Extended Apple MPS exposure-headroom support to multi-coin EMA Anchor and Trailing Martingale
   optimization, including long-only, short-only, dual-side hedge, suites, tunable allowance and
   TWEL-entry thresholds, and per-coin allowance percentage overrides under the globally configured
   bounded or legacy-raw mode. The Metal proxy now separates per-symbol allowed wallet exposure
   from the optional side-wide TWEL entry gate;
   exact Rust validation and the existing classification, rank, and drift gates remain
-  authoritative. Position- and total-exposure repair remain fail closed.
+  authoritative. Total-exposure repair remains fail closed.
 
 - Added single-coin exposure-headroom policy support to the Apple MPS optimizer for EMA Anchor and
   Trailing Martingale, including long-only, short-only, dual-side, and compatible suite runs.

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -128,7 +128,9 @@ The supported slice is intentionally narrow:
   for one of its prepared coins selects another exchange
 - static `coin_overrides` for each enabled side of multi-coin EMA-anchor and trailing-martingale
   runs: active-strategy parameters, `risk.entry_cooldown_minutes`, and explicit
-  `wallet_exposure_limit` and `risk.we_excess_allowance_pct` are supported; per-coin
+  `wallet_exposure_limit` and `risk.we_excess_allowance_pct` are supported. Trailing Martingale
+  also supports per-coin `risk.position_exposure_enforcer_enabled` and
+  `risk.position_exposure_enforcer_threshold`; per-coin
   `risk.we_excess_allowance_mode`, trailing-martingale `entry.ema_gate_mode`, disabled sides, and
   other override leaves fail closed
 - HSL and auto-unstuck disabled
@@ -143,8 +145,14 @@ The supported slice is intentionally narrow:
   unchanged. Legacy-raw mode applies the raw multiplier. The optional side-wide entry gate caps
   aggregate entries at TWEL times its positive threshold (never above raw TWEL). Disabling the gate
   permits aggregate entries beyond TWEL while each symbol remains subject to its allowed WEL
-- BTC collateral, realized-loss gating, position-exposure enforcement, and total-exposure repair
-  remain disabled
+- Trailing Martingale supports `risk.position_exposure_enforcer_enabled` and a tunable
+  `risk.position_exposure_enforcer_threshold` for single- and multi-coin long, short, dual-side,
+  and compatible suite runs. When current position exposure exceeds the allowance-adjusted WEL
+  times the positive threshold, Metal gives the passive reducer precedence over the normal
+  strategy close and sizes it strictly below that target. Static per-coin overrides may change
+  both fields. EMA Anchor position-exposure repair remains fail closed because its exact Rust
+  strategy path does not use this reducer
+- BTC collateral, realized-loss gating, and total-exposure repair remain disabled
 - `backtest.filter_by_min_effective_cost` may be enabled or disabled. When enabled, Metal uses the
   projected initial-entry cost test with the configured wallet-exposure limit. The
   screening proxy compares against the highest executable minimum observed for that coin in the
@@ -186,8 +194,8 @@ overrides: the canonical exact
 suite evaluator still applies them last, after candidate materialization, while each scenario's
 Metal proxy shadows the corresponding candidate parameters with the same effective values. Every
 overridden scenario is rechecked against the directional GPU scope, so an override cannot silently
-enable HSL, auto-unstuck, an exposure enforcer, an invalid position count, or another unsupported
-behavior. In a multicoin suite, a scenario with fewer coins must keep the effective `n_positions`
+enable HSL, auto-unstuck, an unsupported exposure-repair path, an invalid position count, or
+another unsupported behavior. In a multicoin suite, a scenario with fewer coins must keep the effective `n_positions`
 range within that subset, either through common bounds or an explicit scenario override. Metal
 uses the strategy-specific single-coin or multicoin kernel independently for each scenario, then
 feeds all results to the same suite reducer. Scenario-local `coin_overrides` for supported

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -95,7 +95,7 @@ mod tests {
     fn trailing_martingale_mps_source_exposes_expected_kernel_contract() {
         let source = mps_trailing_martingale_source();
         assert!(source.contains("kernel void passivbot_trailing_martingale"));
-        assert!(source.contains("constant int SIDE_PARAMS = 31"));
+        assert!(source.contains("constant int SIDE_PARAMS = 33"));
         assert!(source.contains("min_since_open"));
         assert!(source.contains("max_since_min"));
         assert!(source.contains("max_since_open"));
@@ -103,6 +103,8 @@ mod tests {
         assert!(source.contains("if (we_if <= s.entry_cap * 1.01f) return qty"));
         assert!(source.contains("s.entry_cap * balance - cost"));
         assert!(source.contains("s.allowed_wel"));
+        assert!(source.contains("s.wel_enforcer_enabled"));
+        assert!(source.contains("wel_target"));
         assert!(source.contains("twel_entry_gate_enabled"));
         assert_eq!(source.matches("= fma(").count(), 5);
         assert!(!source.contains("alpha0 * close +"));
@@ -142,8 +144,10 @@ mod tests {
         let source = mps_trailing_martingale_multicoin_source();
         assert!(source.contains("kernel void passivbot_trailing_martingale_multicoin"));
         assert!(source.contains("constant int MAX_COINS = 64"));
-        assert!(source.contains("constant int PARAM_COLS = 38"));
-        assert!(source.contains("constant int OVERRIDE_COLS = 26"));
+        assert!(source.contains("constant int PARAM_COLS = 40"));
+        assert!(source.contains("constant int OVERRIDE_COLS = 28"));
+        assert!(source.contains("coin_wel_enforcer_enabled"));
+        assert!(source.contains("coin_wel_enforcer_threshold"));
         assert!(source.contains("coin_override_or"));
         assert!(source.contains("min_since_open"));
         assert!(source.contains("max_since_min"));

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -150,9 +150,9 @@ mod tests {
         assert!(source.contains("constant int OVERRIDE_COLS = 28"));
         assert!(source.contains("coin_wel_enforcer_enabled"));
         assert!(source.contains("coin_wel_enforcer_threshold"));
-        assert!(source.contains("recursive_close_aggregate_after_reducer"));
-        assert!(source.contains("close_notional"));
-        assert!(source.contains("close_prefiltered"));
+        assert!(source.contains("recursive_grid_close_groups_after_reducer"));
+        assert!(source.contains("close_reconstruct_after_reducer"));
+        assert!(source.contains("close_gen_allowed_wel"));
         assert!(source.contains("coin_override_or"));
         assert!(source.contains("min_since_open"));
         assert!(source.contains("max_since_min"));

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -127,6 +127,8 @@ mod tests {
         assert!(source.contains("entry_gen_balance"));
         assert!(source.contains("close_gen_balance"));
         assert!(source.contains("recursive_close_groups"));
+        assert!(source.contains("long_scan_close_grid = long_scan_close_grid"));
+        assert!(source.contains("short_scan_close_grid = short_scan_close_grid"));
         assert!(source.contains("const bool filter_by_min_effective_cost"));
         assert!(source.contains("passes_min_effective_cost"));
         assert!(source.contains("projected_cost_lower"));
@@ -148,6 +150,9 @@ mod tests {
         assert!(source.contains("constant int OVERRIDE_COLS = 28"));
         assert!(source.contains("coin_wel_enforcer_enabled"));
         assert!(source.contains("coin_wel_enforcer_threshold"));
+        assert!(source.contains("recursive_close_aggregate_after_reducer"));
+        assert!(source.contains("close_notional"));
+        assert!(source.contains("close_prefiltered"));
         assert!(source.contains("coin_override_or"));
         assert!(source.contains("min_since_open"));
         assert!(source.contains("max_since_min"));

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -111,8 +111,8 @@ mod tests {
         assert_eq!(source.matches("const int fo = k * 11").count(), 1);
         assert_eq!(source.matches("const int touch_down_tick").count(), 1);
         assert_eq!(source.matches("const int touch_up_tick").count(), 1);
-        assert_eq!(source.matches("high_fill_max_tick").count(), 6);
-        assert_eq!(source.matches("low_nonfill_max_tick").count(), 6);
+        assert_eq!(source.matches("high_fill_max_tick").count(), 8);
+        assert_eq!(source.matches("low_nonfill_max_tick").count(), 8);
         assert!(!source.contains("nextafter("));
         assert!(source.contains("int cticks = touch_controls ? touch_nearest_ticks : target_ticks"));
         assert!(source.contains("remainder == mq && mq_relation > 0"));

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -127,6 +127,11 @@ mod tests {
         assert!(source.contains("entry_gen_balance"));
         assert!(source.contains("close_gen_balance"));
         assert!(source.contains("recursive_close_groups"));
+        assert!(source.contains("int grid_rung_limit = long_side.close_is_wel_reducer ? 499 : 500"));
+        assert!(
+            source.contains("int grid_rung_limit = short_side.close_is_wel_reducer ? 499 : 500")
+        );
+        assert_eq!(source.matches("bool reducer_before_group").count(), 2);
         assert!(source.contains("long_scan_close_grid = long_scan_close_grid"));
         assert!(source.contains("short_scan_close_grid = short_scan_close_grid"));
         assert!(source.contains("const bool filter_by_min_effective_cost"));
@@ -151,6 +156,8 @@ mod tests {
         assert!(source.contains("coin_wel_enforcer_enabled"));
         assert!(source.contains("coin_wel_enforcer_threshold"));
         assert!(source.contains("recursive_grid_close_groups_after_reducer"));
+        assert!(source.contains("for (int rung = 0; rung < 499"));
+        assert!(source.contains("bool reducer_before_group"));
         assert!(source.contains("close_reconstruct_after_reducer"));
         assert!(source.contains("close_gen_allowed_wel"));
         assert!(source.contains("coin_override_or"));

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -382,18 +382,21 @@ inline void generate_orders(
             float target_psize = wel_target * balance
                 / fmax(s.pprice * c_mult, 1.0e-12f);
             float reduce_qty = fmax(s.psize - target_psize, 0.0f);
-            if (reduce_qty <= 1.1920928955078125e-7f) reduce_qty = qty_step;
-            float reducer_qty = fmin(
-                s.psize,
-                fmax(reducer_min, ceil_step(reduce_qty, qty_step))
-            );
-            float new_we = fmax(s.psize - reducer_qty, 0.0f)
-                * s.pprice * c_mult / balance;
-            if (new_we >= wel_target - 1.0e-12f && reducer_qty < s.psize) {
+            if (reduce_qty <= 2.220446e-16f) reduce_qty = qty_step;
+            float reducer_qty = 0.0f;
+            for (int steps = 0; steps <= 10000; ++steps) {
                 reducer_qty = fmin(
                     s.psize,
-                    fmax(reducer_min, ceil_step(reducer_qty + qty_step, qty_step))
+                    fmax(reducer_min, ceil_step(reduce_qty, qty_step))
                 );
+                float new_psize = fmax(
+                    round_step(s.psize - reducer_qty, qty_step), 0.0f
+                );
+                if (new_psize < target_psize
+                    || new_psize <= 2.220446e-16f) {
+                    break;
+                }
+                reduce_qty += qty_step;
             }
             s.close_ticks = reducer_ticks;
             s.close_price = reducer_price;
@@ -666,6 +669,14 @@ inline void passivbot_single_coin_impl(
         bool long_scan_close_grid = long_close_ready
             && long_side.close_ticks <= high_fill_max_tick;
         if (long_close_ready && long_recursive_close
+            && long_side.close_is_wel_reducer) {
+            // A touch-clamped grid order uses nearest-tick quantization while
+            // the passive reducer rounds up.  The grid may therefore be one
+            // tick nearer and independently reachable.
+            long_scan_close_grid = long_scan_close_grid
+                || long_side.close_gen_touch_nearest_ticks <= high_fill_max_tick;
+        }
+        if (long_close_ready && long_recursive_close
             && long_side.close_threshold_we > 0.0f) {
             // Positive WE weight makes later generated long closes nearer.
             // The zero-WE target is a conservative lower bound: reconstruct
@@ -708,8 +719,10 @@ inline void passivbot_single_coin_impl(
                 min_qty, min_cost, c_mult, group
             );
             bool reverse = grid_source.close_threshold_we > 0.0f;
+            bool reducer_reachable = reducer_qty > 0.0f
+                && reducer_ticks <= high_fill_max_tick;
             bool merge_reducer_with_first = false;
-            if (reducer_qty > 0.0f && group_count > 0) {
+            if (reducer_reachable && group_count > 0) {
                 int first_wanted = reverse ? group_count - 1 : 0;
                 recursive_close_groups(
                     grid_source, true, first_wanted, qty_step, price_step,
@@ -717,7 +730,7 @@ inline void passivbot_single_coin_impl(
                 );
                 merge_reducer_with_first = group.ticks == reducer_ticks;
             }
-            if (reducer_qty > 0.0f && !merge_reducer_with_first) {
+            if (reducer_reachable && !merge_reducer_with_first) {
                 float pnl = reducer_qty * c_mult
                     * (reducer_price - long_side.pprice);
                 float fee = reducer_qty * reducer_price * c_mult * maker_fee;
@@ -857,6 +870,13 @@ inline void passivbot_single_coin_impl(
         bool short_scan_close_grid = short_close_ready
             && short_side.close_ticks > low_nonfill_max_tick;
         if (short_close_ready && short_recursive_close
+            && short_side.close_is_wel_reducer) {
+            // Mirror the long-side nearest-tick scan: a touch-clamped grid
+            // order can sit one tick above the down-rounded reducer.
+            short_scan_close_grid = short_scan_close_grid
+                || short_side.close_gen_touch_nearest_ticks > low_nonfill_max_tick;
+        }
+        if (short_close_ready && short_recursive_close
             && short_side.close_threshold_we > 0.0f) {
             // Positive WE weight makes later generated short closes nearer.
             // The zero-WE target is a conservative upper bound.
@@ -898,8 +918,10 @@ inline void passivbot_single_coin_impl(
                 min_qty, min_cost, c_mult, group
             );
             bool reverse = grid_source.close_threshold_we > 0.0f;
+            bool reducer_reachable = reducer_qty > 0.0f
+                && reducer_ticks > low_nonfill_max_tick;
             bool merge_reducer_with_first = false;
-            if (reducer_qty > 0.0f && group_count > 0) {
+            if (reducer_reachable && group_count > 0) {
                 int first_wanted = reverse ? group_count - 1 : 0;
                 recursive_close_groups(
                     grid_source, false, first_wanted, qty_step, price_step,
@@ -907,7 +929,7 @@ inline void passivbot_single_coin_impl(
                 );
                 merge_reducer_with_first = group.ticks == reducer_ticks;
             }
-            if (reducer_qty > 0.0f && !merge_reducer_with_first) {
+            if (reducer_reachable && !merge_reducer_with_first) {
                 float pnl = reducer_qty * c_mult
                     * (short_side.pprice - reducer_price);
                 float fee = reducer_qty * reducer_price * c_mult * maker_fee;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -498,6 +498,7 @@ inline void generate_short_orders(
 inline int recursive_close_groups(
     thread const TmSide& source, bool is_long, int wanted_group,
     float qty_step, float price_step, float min_qty, float min_cost, float c_mult,
+    int max_rungs,
     thread CloseGroup& selected
 ) {
     selected.ticks = 0;
@@ -512,7 +513,7 @@ inline int recursive_close_groups(
     float group_price = 0.0f;
     float group_qty = 0.0f;
 
-    for (int rung = 0; rung < 500; ++rung) {
+    for (int rung = 0; rung < max_rungs; ++rung) {
         generate_orders(
             sim, is_long, source.close_gen_balance, source.close_gen_pprice,
             source.close_gen_touch_down_ticks, source.close_gen_touch_up_ticks,
@@ -714,43 +715,46 @@ inline void passivbot_single_coin_impl(
                 grid_source.wel_enforcer_enabled = false;
             }
             CloseGroup group;
+            int grid_rung_limit = long_side.close_is_wel_reducer ? 499 : 500;
             int group_count = recursive_close_groups(
                 grid_source, true, -1, qty_step, price_step,
-                min_qty, min_cost, c_mult, group
+                min_qty, min_cost, c_mult, grid_rung_limit, group
             );
             bool reverse = grid_source.close_threshold_we > 0.0f;
             bool reducer_reachable = reducer_qty > 0.0f
                 && reducer_ticks <= high_fill_max_tick;
-            bool merge_reducer_with_first = false;
-            if (reducer_reachable && group_count > 0) {
-                int first_wanted = reverse ? group_count - 1 : 0;
-                recursive_close_groups(
-                    grid_source, true, first_wanted, qty_step, price_step,
-                    min_qty, min_cost, c_mult, group
-                );
-                merge_reducer_with_first = group.ticks == reducer_ticks;
-            }
-            if (reducer_reachable && !merge_reducer_with_first) {
-                float pnl = reducer_qty * c_mult
-                    * (reducer_price - long_side.pprice);
-                float fee = reducer_qty * reducer_price * c_mult * maker_fee;
-                balance += pnl - fee;
-                long_side.psize = fmax(
-                    round_step(long_side.psize - reducer_qty, qty_step), 0.0f
-                );
-                day_volume += reducer_qty * reducer_price / balance;
-                long_close_fill = true;
-            }
+            bool reducer_executed = false;
             for (int rank = 0; rank < group_count; ++rank) {
                 int wanted = reverse ? group_count - rank - 1 : rank;
                 recursive_close_groups(
                     grid_source, true, wanted, qty_step, price_step,
-                    min_qty, min_cost, c_mult, group
+                    min_qty, min_cost, c_mult, grid_rung_limit, group
                 );
-                if (group.qty <= 0.0f || group.ticks > high_fill_max_tick) break;
+                if (group.qty <= 0.0f) break;
+                bool merge_reducer = reducer_reachable
+                    && !reducer_executed && group.ticks == reducer_ticks;
+                bool reducer_before_group = reducer_reachable
+                    && !reducer_executed && reducer_ticks < group.ticks;
+                if (reducer_before_group) {
+                    float pnl = reducer_qty * c_mult
+                        * (reducer_price - long_side.pprice);
+                    float fee = reducer_qty * reducer_price * c_mult * maker_fee;
+                    balance += pnl - fee;
+                    long_side.psize = fmax(
+                        round_step(
+                            long_side.psize - reducer_qty, qty_step
+                        ),
+                        0.0f
+                    );
+                    day_volume += reducer_qty * reducer_price / balance;
+                    long_close_fill = true;
+                    reducer_executed = true;
+                }
+                if (group.ticks > high_fill_max_tick) break;
                 float group_qty = group.qty;
-                if (rank == 0 && merge_reducer_with_first) {
+                if (merge_reducer) {
                     group_qty = round_step(group_qty + reducer_qty, qty_step);
+                    reducer_executed = true;
                 }
                 float adj = fmin(round_step(group_qty, qty_step), long_side.psize);
                 float pnl = adj * c_mult * (group.price - long_side.pprice);
@@ -773,6 +777,19 @@ inline void passivbot_single_coin_impl(
                     long_side.pos_open_k = -1.0f;
                     break;
                 }
+            }
+            if (reducer_reachable && !reducer_executed
+                && long_side.psize > 0.0f) {
+                float adj = fmin(reducer_qty, long_side.psize);
+                float pnl = adj * c_mult
+                    * (reducer_price - long_side.pprice);
+                float fee = adj * reducer_price * c_mult * maker_fee;
+                balance += pnl - fee;
+                long_side.psize = fmax(
+                    round_step(long_side.psize - adj, qty_step), 0.0f
+                );
+                day_volume += adj * reducer_price / balance;
+                long_close_fill = true;
             }
             if (long_close_fill && long_side.psize <= 0.0f
                 && long_side.pprice > 0.0f) {
@@ -913,43 +930,46 @@ inline void passivbot_single_coin_impl(
                 grid_source.wel_enforcer_enabled = false;
             }
             CloseGroup group;
+            int grid_rung_limit = short_side.close_is_wel_reducer ? 499 : 500;
             int group_count = recursive_close_groups(
                 grid_source, false, -1, qty_step, price_step,
-                min_qty, min_cost, c_mult, group
+                min_qty, min_cost, c_mult, grid_rung_limit, group
             );
             bool reverse = grid_source.close_threshold_we > 0.0f;
             bool reducer_reachable = reducer_qty > 0.0f
                 && reducer_ticks > low_nonfill_max_tick;
-            bool merge_reducer_with_first = false;
-            if (reducer_reachable && group_count > 0) {
-                int first_wanted = reverse ? group_count - 1 : 0;
-                recursive_close_groups(
-                    grid_source, false, first_wanted, qty_step, price_step,
-                    min_qty, min_cost, c_mult, group
-                );
-                merge_reducer_with_first = group.ticks == reducer_ticks;
-            }
-            if (reducer_reachable && !merge_reducer_with_first) {
-                float pnl = reducer_qty * c_mult
-                    * (short_side.pprice - reducer_price);
-                float fee = reducer_qty * reducer_price * c_mult * maker_fee;
-                balance += pnl - fee;
-                short_side.psize = fmax(
-                    round_step(short_side.psize - reducer_qty, qty_step), 0.0f
-                );
-                day_volume += reducer_qty * reducer_price / balance;
-                short_close_fill = true;
-            }
+            bool reducer_executed = false;
             for (int rank = 0; rank < group_count; ++rank) {
                 int wanted = reverse ? group_count - rank - 1 : rank;
                 recursive_close_groups(
                     grid_source, false, wanted, qty_step, price_step,
-                    min_qty, min_cost, c_mult, group
+                    min_qty, min_cost, c_mult, grid_rung_limit, group
                 );
-                if (group.qty <= 0.0f || group.ticks <= low_nonfill_max_tick) break;
+                if (group.qty <= 0.0f) break;
+                bool merge_reducer = reducer_reachable
+                    && !reducer_executed && group.ticks == reducer_ticks;
+                bool reducer_before_group = reducer_reachable
+                    && !reducer_executed && reducer_ticks > group.ticks;
+                if (reducer_before_group) {
+                    float pnl = reducer_qty * c_mult
+                        * (short_side.pprice - reducer_price);
+                    float fee = reducer_qty * reducer_price * c_mult * maker_fee;
+                    balance += pnl - fee;
+                    short_side.psize = fmax(
+                        round_step(
+                            short_side.psize - reducer_qty, qty_step
+                        ),
+                        0.0f
+                    );
+                    day_volume += reducer_qty * reducer_price / balance;
+                    short_close_fill = true;
+                    reducer_executed = true;
+                }
+                if (group.ticks <= low_nonfill_max_tick) break;
                 float group_qty = group.qty;
-                if (rank == 0 && merge_reducer_with_first) {
+                if (merge_reducer) {
                     group_qty = round_step(group_qty + reducer_qty, qty_step);
+                    reducer_executed = true;
                 }
                 float adj = fmin(round_step(group_qty, qty_step), short_side.psize);
                 float pnl = adj * c_mult * (short_side.pprice - group.price);
@@ -972,6 +992,19 @@ inline void passivbot_single_coin_impl(
                     short_side.pos_open_k = -1.0f;
                     break;
                 }
+            }
+            if (reducer_reachable && !reducer_executed
+                && short_side.psize > 0.0f) {
+                float adj = fmin(reducer_qty, short_side.psize);
+                float pnl = adj * c_mult
+                    * (short_side.pprice - reducer_price);
+                float fee = adj * reducer_price * c_mult * maker_fee;
+                balance += pnl - fee;
+                short_side.psize = fmax(
+                    round_step(short_side.psize - adj, qty_step), 0.0f
+                );
+                day_volume += adj * reducer_price / balance;
+                short_close_fill = true;
             }
             if (short_close_fill && short_side.psize <= 0.0f
                 && short_side.pprice > 0.0f) {

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -4,7 +4,7 @@ using namespace metal;
 constant int DAILY_COLS = 5;
 constant int SCALAR_COLS = 18;
 constant int GAP_BINS = 128;
-constant int SIDE_PARAMS = 31;
+constant int SIDE_PARAMS = 33;
 
 inline float round_step(float value, float step) {
     return floor(value / step + 0.5f) * step;
@@ -58,6 +58,8 @@ struct TmSide {
     float close_retracement_base, close_retracement_v1h, close_retracement_v1m;
     float cooldown_min, twel, allowed_wel, entry_cap;
     bool gate_initial, gate_reentry;
+    bool wel_enforcer_enabled;
+    float wel_enforcer_threshold;
     float ema0, ema1, ema2, vol1m, vol1h;
     float psize, pprice, last_inc_k, pos_open_k;
     int entry_ticks, close_ticks;
@@ -125,6 +127,8 @@ inline TmSide load_side(constant float* p, int o, float seed) {
     }
     s.entry_cap = twel_entry_gate_enabled
         ? fmin(s.allowed_wel, gate_cap) : s.allowed_wel;
+    s.wel_enforcer_enabled = p[o + 31] > 0.5f;
+    s.wel_enforcer_threshold = p[o + 32];
     s.ema0 = seed; s.ema1 = seed; s.ema2 = seed;
     s.vol1m = 0.0f; s.vol1h = 0.0f;
     s.psize = 0.0f; s.pprice = 0.0f;
@@ -357,6 +361,43 @@ inline void generate_orders(
         s, balance, eprice, eqty,
         qty_step, min_qty, min_cost, c_mult
     );
+
+    // Exact Trailing Martingale gives per-position exposure repair precedence
+    // over its normal close. Reduce strictly below the configured fraction of
+    // the allowance-adjusted WEL, using the passive ask for longs and bid for
+    // shorts just like calc_wel_auto_reduce_long/short in closes.rs.
+    float wel_target = s.allowed_wel * s.wel_enforcer_threshold;
+    if (s.wel_enforcer_enabled && s.wel_enforcer_threshold > 0.0f
+        && balance > 0.0f && s.psize > 0.0f && s.pprice > 0.0f
+        && wel_target > 0.0f && we > wel_target) {
+        int reducer_ticks = is_long ? touch_up_ticks : touch_down_ticks;
+        float reducer_price = float(reducer_ticks) * price_step;
+        if (reducer_ticks > 0 && reducer_price > 0.0f) {
+            float reducer_min = min_entry_qty(
+                reducer_price, qty_step, min_qty, min_cost, c_mult
+            );
+            float target_psize = wel_target * balance
+                / fmax(s.pprice * c_mult, 1.0e-12f);
+            float reduce_qty = fmax(s.psize - target_psize, 0.0f);
+            if (reduce_qty <= 1.1920928955078125e-7f) reduce_qty = qty_step;
+            float reducer_qty = fmin(
+                s.psize,
+                fmax(reducer_min, ceil_step(reduce_qty, qty_step))
+            );
+            float new_we = fmax(s.psize - reducer_qty, 0.0f)
+                * s.pprice * c_mult / balance;
+            if (new_we >= wel_target - 1.0e-12f && reducer_qty < s.psize) {
+                reducer_qty = fmin(
+                    s.psize,
+                    fmax(reducer_min, ceil_step(reducer_qty + qty_step, qty_step))
+                );
+            }
+            s.close_ticks = reducer_ticks;
+            s.close_price = reducer_price;
+            s.close_qty = reducer_qty;
+            return;
+        }
+    }
 
     float ct = s.close_threshold_base + wer * s.close_threshold_we
         + s.vol1h * s.close_threshold_v1h + s.vol1m * s.close_threshold_v1m;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -60,6 +60,7 @@ struct TmSide {
     bool gate_initial, gate_reentry;
     bool wel_enforcer_enabled;
     float wel_enforcer_threshold;
+    bool close_is_wel_reducer;
     float ema0, ema1, ema2, vol1m, vol1h;
     float psize, pprice, last_inc_k, pos_open_k;
     int entry_ticks, close_ticks;
@@ -129,6 +130,7 @@ inline TmSide load_side(constant float* p, int o, float seed) {
         ? fmin(s.allowed_wel, gate_cap) : s.allowed_wel;
     s.wel_enforcer_enabled = p[o + 31] > 0.5f;
     s.wel_enforcer_threshold = p[o + 32];
+    s.close_is_wel_reducer = false;
     s.ema0 = seed; s.ema1 = seed; s.ema2 = seed;
     s.vol1m = 0.0f; s.vol1h = 0.0f;
     s.psize = 0.0f; s.pprice = 0.0f;
@@ -248,6 +250,7 @@ inline void generate_orders(
     s.close_gen_touch_nearest_ticks = touch_nearest_ticks;
     s.close_gen_touch_min_qty = touch_min_qty;
     s.close_gen_touch_min_qty_relation = touch_min_qty_relation;
+    s.close_is_wel_reducer = false;
     int band_ticks = directional_ticks(
         band * (is_long ? 1.0f - s.initial_ema_dist
                         : 1.0f + s.initial_ema_dist),
@@ -395,6 +398,7 @@ inline void generate_orders(
             s.close_ticks = reducer_ticks;
             s.close_price = reducer_price;
             s.close_qty = reducer_qty;
+            s.close_is_wel_reducer = true;
             return;
         }
     }
@@ -676,19 +680,48 @@ inline void passivbot_single_coin_impl(
             bool touch_controls = long_side.close_gen_touch_up_ticks > target_ticks;
             int nearest_ticks = touch_controls
                 ? long_side.close_gen_touch_nearest_ticks : target_ticks;
-            long_scan_close_grid = nearest_ticks <= high_fill_max_tick;
+            long_scan_close_grid = long_scan_close_grid
+                || nearest_ticks <= high_fill_max_tick;
         }
         if (long_scan_close_grid && long_recursive_close) {
+            TmSide grid_source = long_side;
+            if (long_side.close_is_wel_reducer) {
+                float cp = long_side.close_price;
+                float adj = fmin(
+                    round_step(long_side.close_qty, qty_step), long_side.psize
+                );
+                float pnl = adj * c_mult * (cp - long_side.pprice);
+                float fee = adj * cp * c_mult * maker_fee;
+                balance += pnl - fee;
+                float new_psize = fmax(
+                    round_step(long_side.psize - adj, qty_step), 0.0f
+                );
+                bool went_flat = new_psize <= 0.0f;
+                long_side.psize = new_psize;
+                day_volume += fabs(adj) * cp / balance;
+                long_close_fill = true;
+                if (went_flat) {
+                    long_side.pprice = 0.0f;
+                    if (long_side.pos_open_k >= 0.0f) {
+                        held_max_min = fmax(
+                            held_max_min, kf - long_side.pos_open_k
+                        );
+                    }
+                    long_side.pos_open_k = -1.0f;
+                }
+                grid_source.close_gen_psize = new_psize;
+                grid_source.wel_enforcer_enabled = false;
+            }
             CloseGroup group;
             int group_count = recursive_close_groups(
-                long_side, true, -1, qty_step, price_step,
+                grid_source, true, -1, qty_step, price_step,
                 min_qty, min_cost, c_mult, group
             );
-            bool reverse = long_side.close_threshold_we > 0.0f;
+            bool reverse = grid_source.close_threshold_we > 0.0f;
             for (int rank = 0; rank < group_count; ++rank) {
                 int wanted = reverse ? group_count - rank - 1 : rank;
                 recursive_close_groups(
-                    long_side, true, wanted, qty_step, price_step,
+                    grid_source, true, wanted, qty_step, price_step,
                     min_qty, min_cost, c_mult, group
                 );
                 if (group.qty <= 0.0f || group.ticks > high_fill_max_tick) break;
@@ -813,19 +846,48 @@ inline void passivbot_single_coin_impl(
             bool touch_controls = short_side.close_gen_touch_down_ticks < target_ticks;
             int nearest_ticks = touch_controls
                 ? short_side.close_gen_touch_nearest_ticks : target_ticks;
-            short_scan_close_grid = nearest_ticks > low_nonfill_max_tick;
+            short_scan_close_grid = short_scan_close_grid
+                || nearest_ticks > low_nonfill_max_tick;
         }
         if (short_scan_close_grid && short_recursive_close) {
+            TmSide grid_source = short_side;
+            if (short_side.close_is_wel_reducer) {
+                float cp = short_side.close_price;
+                float adj = fmin(
+                    round_step(short_side.close_qty, qty_step), short_side.psize
+                );
+                float pnl = adj * c_mult * (short_side.pprice - cp);
+                float fee = adj * cp * c_mult * maker_fee;
+                balance += pnl - fee;
+                float new_psize = fmax(
+                    round_step(short_side.psize - adj, qty_step), 0.0f
+                );
+                bool went_flat = new_psize <= 0.0f;
+                short_side.psize = new_psize;
+                day_volume += fabs(adj) * cp / balance;
+                short_close_fill = true;
+                if (went_flat) {
+                    short_side.pprice = 0.0f;
+                    if (short_side.pos_open_k >= 0.0f) {
+                        held_max_min = fmax(
+                            held_max_min, kf - short_side.pos_open_k
+                        );
+                    }
+                    short_side.pos_open_k = -1.0f;
+                }
+                grid_source.close_gen_psize = new_psize;
+                grid_source.wel_enforcer_enabled = false;
+            }
             CloseGroup group;
             int group_count = recursive_close_groups(
-                short_side, false, -1, qty_step, price_step,
+                grid_source, false, -1, qty_step, price_step,
                 min_qty, min_cost, c_mult, group
             );
-            bool reverse = short_side.close_threshold_we > 0.0f;
+            bool reverse = grid_source.close_threshold_we > 0.0f;
             for (int rank = 0; rank < group_count; ++rank) {
                 int wanted = reverse ? group_count - rank - 1 : rank;
                 recursive_close_groups(
-                    short_side, false, wanted, qty_step, price_step,
+                    grid_source, false, wanted, qty_step, price_step,
                     min_qty, min_cost, c_mult, group
                 );
                 if (group.qty <= 0.0f || group.ticks <= low_nonfill_max_tick) break;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -685,31 +685,21 @@ inline void passivbot_single_coin_impl(
         }
         if (long_scan_close_grid && long_recursive_close) {
             TmSide grid_source = long_side;
+            float reducer_qty = 0.0f;
+            int reducer_ticks = 0;
+            float reducer_price = 0.0f;
             if (long_side.close_is_wel_reducer) {
-                float cp = long_side.close_price;
-                float adj = fmin(
+                reducer_qty = fmin(
                     round_step(long_side.close_qty, qty_step), long_side.psize
                 );
-                float pnl = adj * c_mult * (cp - long_side.pprice);
-                float fee = adj * cp * c_mult * maker_fee;
-                balance += pnl - fee;
-                float new_psize = fmax(
-                    round_step(long_side.psize - adj, qty_step), 0.0f
+                reducer_ticks = long_side.close_ticks;
+                reducer_price = long_side.close_price;
+                grid_source.close_gen_psize = fmax(
+                    round_step(
+                        long_side.close_gen_psize - reducer_qty, qty_step
+                    ),
+                    0.0f
                 );
-                bool went_flat = new_psize <= 0.0f;
-                long_side.psize = new_psize;
-                day_volume += fabs(adj) * cp / balance;
-                long_close_fill = true;
-                if (went_flat) {
-                    long_side.pprice = 0.0f;
-                    if (long_side.pos_open_k >= 0.0f) {
-                        held_max_min = fmax(
-                            held_max_min, kf - long_side.pos_open_k
-                        );
-                    }
-                    long_side.pos_open_k = -1.0f;
-                }
-                grid_source.close_gen_psize = new_psize;
                 grid_source.wel_enforcer_enabled = false;
             }
             CloseGroup group;
@@ -718,6 +708,26 @@ inline void passivbot_single_coin_impl(
                 min_qty, min_cost, c_mult, group
             );
             bool reverse = grid_source.close_threshold_we > 0.0f;
+            bool merge_reducer_with_first = false;
+            if (reducer_qty > 0.0f && group_count > 0) {
+                int first_wanted = reverse ? group_count - 1 : 0;
+                recursive_close_groups(
+                    grid_source, true, first_wanted, qty_step, price_step,
+                    min_qty, min_cost, c_mult, group
+                );
+                merge_reducer_with_first = group.ticks == reducer_ticks;
+            }
+            if (reducer_qty > 0.0f && !merge_reducer_with_first) {
+                float pnl = reducer_qty * c_mult
+                    * (reducer_price - long_side.pprice);
+                float fee = reducer_qty * reducer_price * c_mult * maker_fee;
+                balance += pnl - fee;
+                long_side.psize = fmax(
+                    round_step(long_side.psize - reducer_qty, qty_step), 0.0f
+                );
+                day_volume += reducer_qty * reducer_price / balance;
+                long_close_fill = true;
+            }
             for (int rank = 0; rank < group_count; ++rank) {
                 int wanted = reverse ? group_count - rank - 1 : rank;
                 recursive_close_groups(
@@ -725,7 +735,11 @@ inline void passivbot_single_coin_impl(
                     min_qty, min_cost, c_mult, group
                 );
                 if (group.qty <= 0.0f || group.ticks > high_fill_max_tick) break;
-                float adj = fmin(round_step(group.qty, qty_step), long_side.psize);
+                float group_qty = group.qty;
+                if (rank == 0 && merge_reducer_with_first) {
+                    group_qty = round_step(group_qty + reducer_qty, qty_step);
+                }
+                float adj = fmin(round_step(group_qty, qty_step), long_side.psize);
                 float pnl = adj * c_mult * (group.price - long_side.pprice);
                 float fee = adj * group.price * c_mult * maker_fee;
                 balance += pnl - fee;
@@ -746,6 +760,16 @@ inline void passivbot_single_coin_impl(
                     long_side.pos_open_k = -1.0f;
                     break;
                 }
+            }
+            if (long_close_fill && long_side.psize <= 0.0f
+                && long_side.pprice > 0.0f) {
+                long_side.pprice = 0.0f;
+                if (long_side.pos_open_k >= 0.0f) {
+                    held_max_min = fmax(
+                        held_max_min, kf - long_side.pos_open_k
+                    );
+                }
+                long_side.pos_open_k = -1.0f;
             }
             if (long_close_fill) long_side.close_qty = 0.0f;
         } else if (long_scan_close_grid) {
@@ -851,31 +875,21 @@ inline void passivbot_single_coin_impl(
         }
         if (short_scan_close_grid && short_recursive_close) {
             TmSide grid_source = short_side;
+            float reducer_qty = 0.0f;
+            int reducer_ticks = 0;
+            float reducer_price = 0.0f;
             if (short_side.close_is_wel_reducer) {
-                float cp = short_side.close_price;
-                float adj = fmin(
+                reducer_qty = fmin(
                     round_step(short_side.close_qty, qty_step), short_side.psize
                 );
-                float pnl = adj * c_mult * (short_side.pprice - cp);
-                float fee = adj * cp * c_mult * maker_fee;
-                balance += pnl - fee;
-                float new_psize = fmax(
-                    round_step(short_side.psize - adj, qty_step), 0.0f
+                reducer_ticks = short_side.close_ticks;
+                reducer_price = short_side.close_price;
+                grid_source.close_gen_psize = fmax(
+                    round_step(
+                        short_side.close_gen_psize - reducer_qty, qty_step
+                    ),
+                    0.0f
                 );
-                bool went_flat = new_psize <= 0.0f;
-                short_side.psize = new_psize;
-                day_volume += fabs(adj) * cp / balance;
-                short_close_fill = true;
-                if (went_flat) {
-                    short_side.pprice = 0.0f;
-                    if (short_side.pos_open_k >= 0.0f) {
-                        held_max_min = fmax(
-                            held_max_min, kf - short_side.pos_open_k
-                        );
-                    }
-                    short_side.pos_open_k = -1.0f;
-                }
-                grid_source.close_gen_psize = new_psize;
                 grid_source.wel_enforcer_enabled = false;
             }
             CloseGroup group;
@@ -884,6 +898,26 @@ inline void passivbot_single_coin_impl(
                 min_qty, min_cost, c_mult, group
             );
             bool reverse = grid_source.close_threshold_we > 0.0f;
+            bool merge_reducer_with_first = false;
+            if (reducer_qty > 0.0f && group_count > 0) {
+                int first_wanted = reverse ? group_count - 1 : 0;
+                recursive_close_groups(
+                    grid_source, false, first_wanted, qty_step, price_step,
+                    min_qty, min_cost, c_mult, group
+                );
+                merge_reducer_with_first = group.ticks == reducer_ticks;
+            }
+            if (reducer_qty > 0.0f && !merge_reducer_with_first) {
+                float pnl = reducer_qty * c_mult
+                    * (short_side.pprice - reducer_price);
+                float fee = reducer_qty * reducer_price * c_mult * maker_fee;
+                balance += pnl - fee;
+                short_side.psize = fmax(
+                    round_step(short_side.psize - reducer_qty, qty_step), 0.0f
+                );
+                day_volume += reducer_qty * reducer_price / balance;
+                short_close_fill = true;
+            }
             for (int rank = 0; rank < group_count; ++rank) {
                 int wanted = reverse ? group_count - rank - 1 : rank;
                 recursive_close_groups(
@@ -891,7 +925,11 @@ inline void passivbot_single_coin_impl(
                     min_qty, min_cost, c_mult, group
                 );
                 if (group.qty <= 0.0f || group.ticks <= low_nonfill_max_tick) break;
-                float adj = fmin(round_step(group.qty, qty_step), short_side.psize);
+                float group_qty = group.qty;
+                if (rank == 0 && merge_reducer_with_first) {
+                    group_qty = round_step(group_qty + reducer_qty, qty_step);
+                }
+                float adj = fmin(round_step(group_qty, qty_step), short_side.psize);
                 float pnl = adj * c_mult * (short_side.pprice - group.price);
                 float fee = adj * group.price * c_mult * maker_fee;
                 balance += pnl - fee;
@@ -912,6 +950,16 @@ inline void passivbot_single_coin_impl(
                     short_side.pos_open_k = -1.0f;
                     break;
                 }
+            }
+            if (short_close_fill && short_side.psize <= 0.0f
+                && short_side.pprice > 0.0f) {
+                short_side.pprice = 0.0f;
+                if (short_side.pos_open_k >= 0.0f) {
+                    held_max_min = fmax(
+                        held_max_min, kf - short_side.pos_open_k
+                    );
+                }
+                short_side.pos_open_k = -1.0f;
             }
             if (short_close_fill) short_side.close_qty = 0.0f;
         } else if (short_scan_close_grid) {

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -92,18 +92,22 @@ inline float calc_close_qty(
     return quantity;
 }
 
-// Rebuild the immutable recursive close grid after a WEL reducer and retain
-// only the orders reachable by the next candle. Exact Rust expands the whole
-// grid whenever any rung is reachable; aggregating reachable quantity and
-// notional preserves the resulting position and balance without a large
-// per-thread order matrix.
-inline void recursive_close_aggregate_after_reducer(
+struct CloseGroup {
+    int ticks;
+    float price;
+    float qty;
+};
+
+// Rebuild Rust's post-reducer recursive grid and return its number of
+// duplicate-merged price groups. Selecting one generated-order group at a
+// time keeps GPU memory bounded; the caller reorders positive-WE grids before
+// applying reachable fills, matching calc_closes_long/short.
+inline int recursive_grid_close_groups_after_reducer(
     bool short_side,
     float psize,
     float pprice,
-    float balance,
+    float generation_balance,
     float allowed_wel,
-    float wel_enforcer_threshold,
     int touch_down,
     int touch_up,
     int touch_nearest,
@@ -121,92 +125,86 @@ inline void recursive_close_aggregate_after_reducer(
     float min_qty,
     float min_cost,
     float c_mult,
-    int high_fill_max_tick,
-    int low_nonfill_max_tick,
-    thread float& reachable_qty,
-    thread float& reachable_notional
+    int wanted_group,
+    thread CloseGroup& selected
 ) {
-    reachable_qty = 0.0f;
-    reachable_notional = 0.0f;
+    selected.ticks = 0;
+    selected.price = 0.0f;
+    selected.qty = 0.0f;
     float sim_psize = psize;
+    bool have_group = false;
+    int group_count = 0;
+    int group_ticks = 0;
+    float group_price = 0.0f;
+    float group_qty = 0.0f;
     for (int rung = 0; rung < 500 && sim_psize > 0.0f; ++rung) {
-        float we = sim_psize * pprice * c_mult / fmax(balance, 1.0e-9f);
-        float order_qty = 0.0f;
-        int order_tick = 0;
-
-        float wel_target = allowed_wel * wel_enforcer_threshold;
-        if (rung == 0 && wel_target > 0.0f && we > wel_target) {
-            order_tick = short_side ? touch_down : touch_up;
-            float order_price = float(order_tick) * price_step;
-            float reducer_min = min_entry_qty(
+        float we = sim_psize * pprice * c_mult
+            / fmax(generation_balance, 1.0e-9f);
+        float wer = we / fmax(allowed_wel, 1.0e-12f);
+        float threshold = close_threshold_base
+            + wer * close_threshold_we
+            + volatility_1h * close_threshold_v1h
+            + volatility_1m * close_threshold_v1m;
+        float target = pprice * (
+            short_side ? 1.0f - threshold : 1.0f + threshold
+        );
+        int target_tick = short_side
+            ? int(floor(target / price_step + 1.0e-6f))
+            : int(ceil(target / price_step - 1.0e-6f));
+        int close_touch = short_side ? touch_down : touch_up;
+        bool touch_controls = short_side
+            ? close_touch < target_tick
+            : close_touch > target_tick;
+        int order_tick = touch_controls ? touch_nearest : target_tick;
+        float order_price = float(order_tick) * price_step;
+        float minimum_close = touch_controls
+            ? touch_min_qty
+            : min_entry_qty(
                 order_price, qty_step, min_qty, min_cost, c_mult
             );
-            float target_psize = wel_target * balance
-                / fmax(pprice * c_mult, 1.0e-12f);
-            float reduce_qty = fmax(sim_psize - target_psize, 0.0f);
-            if (reduce_qty <= 1.1920928955078125e-7f) reduce_qty = qty_step;
-            order_qty = fmin(
-                sim_psize,
-                fmax(reducer_min, ceil_step(reduce_qty, qty_step))
-            );
-            float new_we = fmax(sim_psize - order_qty, 0.0f)
-                * pprice * c_mult / balance;
-            if (new_we >= wel_target - 1.0e-12f && order_qty < sim_psize) {
-                order_qty = fmin(
-                    sim_psize,
-                    fmax(
-                        reducer_min,
-                        ceil_step(order_qty + qty_step, qty_step)
-                    )
-                );
-            }
-        } else {
-            float wer = we / fmax(allowed_wel, 1.0e-12f);
-            float threshold = close_threshold_base
-                + wer * close_threshold_we
-                + volatility_1h * close_threshold_v1h
-                + volatility_1m * close_threshold_v1m;
-            float target = pprice * (
-                short_side ? 1.0f - threshold : 1.0f + threshold
-            );
-            int target_tick = short_side
-                ? int(floor(target / price_step + 1.0e-6f))
-                : int(ceil(target / price_step - 1.0e-6f));
-            int close_touch = short_side ? touch_down : touch_up;
-            bool touch_controls = (short_side && threshold <= 0.0f)
-                || (short_side
-                    ? close_touch < target_tick
-                    : close_touch > target_tick);
-            order_tick = touch_controls ? touch_nearest : target_tick;
-            float order_price = float(order_tick) * price_step;
-            float minimum_close = touch_controls
-                ? touch_min_qty
-                : min_entry_qty(
-                    order_price, qty_step, min_qty, min_cost, c_mult
-                );
-            int minimum_relation = touch_controls
-                ? touch_min_qty_relation : 0;
-            float close_pct = close_threshold_we == 0.0f
-                ? 1.0f : close_qty_pct;
-            order_qty = calc_close_qty(
-                sim_psize, pprice, balance, allowed_wel,
-                minimum_close, minimum_relation, close_pct,
-                qty_step, c_mult
-            );
-        }
+        int minimum_relation = touch_controls
+            ? touch_min_qty_relation : 0;
+        float close_pct = close_threshold_we == 0.0f
+            ? 1.0f : close_qty_pct;
+        float order_qty = calc_close_qty(
+            sim_psize, pprice, generation_balance, allowed_wel,
+            minimum_close, minimum_relation, close_pct,
+            qty_step, c_mult
+        );
 
         order_qty = round_step(order_qty, qty_step);
         if (order_qty <= 0.0f || order_tick <= 0) break;
         order_qty = fmin(order_qty, sim_psize);
-        bool reachable = short_side
-            ? order_tick > low_nonfill_max_tick
-            : order_tick <= high_fill_max_tick;
-        if (reachable) {
-            reachable_qty = round_step(reachable_qty + order_qty, qty_step);
-            reachable_notional += order_qty * float(order_tick) * price_step;
+
+        if (!have_group) {
+            have_group = true;
+            group_ticks = order_tick;
+            group_price = order_price;
+            group_qty = order_qty;
+        } else if (order_tick == group_ticks) {
+            group_qty = round_step(group_qty + order_qty, qty_step);
+        } else {
+            if (group_count == wanted_group) {
+                selected.ticks = group_ticks;
+                selected.price = group_price;
+                selected.qty = group_qty;
+            }
+            ++group_count;
+            group_ticks = order_tick;
+            group_price = order_price;
+            group_qty = order_qty;
         }
         sim_psize = fmax(round_step(sim_psize - order_qty, qty_step), 0.0f);
     }
+    if (have_group) {
+        if (group_count == wanted_group) {
+            selected.ticks = group_ticks;
+            selected.price = group_price;
+            selected.qty = group_qty;
+        }
+        ++group_count;
+    }
+    return group_count;
 }
 
 inline void passivbot_trailing_martingale_multicoin_impl(
@@ -313,7 +311,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     float last_increase_k[MAX_COINS];
     float entry_qty[MAX_COINS];
     float close_qty[MAX_COINS];
-    float close_notional[MAX_COINS];
+    float close_gen_balance[MAX_COINS];
+    float close_gen_allowed_wel[MAX_COINS];
     float position_open_k[MAX_COINS];
     float score[MAX_COINS];
     float contribution[MAX_COINS];
@@ -328,7 +327,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     bool incumbent[MAX_COINS];
     bool survivor[MAX_COINS];
     bool entry_candidate[MAX_COINS];
-    bool close_prefiltered[MAX_COINS];
+    bool close_reconstruct_after_reducer[MAX_COINS];
     bool filled_coin[MAX_COINS];
     float alpha0_coin[MAX_COINS];
     float alpha1_coin[MAX_COINS];
@@ -357,7 +356,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         last_increase_k[c] = -1.0e20f;
         entry_qty[c] = 0.0f;
         close_qty[c] = 0.0f;
-        close_notional[c] = 0.0f;
+        close_gen_balance[c] = 0.0f;
+        close_gen_allowed_wel[c] = 0.0f;
         position_open_k[c] = -1.0f;
         score[c] = -INFINITY;
         contribution[c] = 0.0f;
@@ -372,7 +372,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         incumbent[c] = false;
         survivor[c] = false;
         entry_candidate[c] = false;
-        close_prefiltered[c] = false;
+        close_reconstruct_after_reducer[c] = false;
         filled_coin[c] = false;
         float coin_span_a = c < C
             ? coin_override_or(coin_overrides, c, 0, span_a) : span_a;
@@ -474,24 +474,122 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             if (!valid || !alive) continue;
             const float qty_step = coin_settings[coin_offset + 0];
             const float price_step = coin_settings[coin_offset + 1];
+            const float min_qty = coin_settings[coin_offset + 2];
+            const float min_cost = coin_settings[coin_offset + 3];
             const float c_mult = coin_settings[coin_offset + 4];
             const float maker_fee = coin_settings[coin_offset + 5];
 
             bool filled_close = close_qty[c] > 0.0f && psize[c] > 0.0f
-                && (close_prefiltered[c] || (short_side
+                && (short_side
                     ? close_tick[c] > fill_ticks[tick_offset + 1]
-                    : close_tick[c] <= fill_ticks[tick_offset + 0]));
+                    : close_tick[c] <= fill_ticks[tick_offset + 0]);
             if (filled_close) {
+                float fill_price = float(close_tick[c]) * price_step;
                 float adjusted = fmin(round_step(close_qty[c], qty_step), psize[c]);
-                float scale = adjusted / fmax(close_qty[c], 1.0e-12f);
-                float adjusted_notional = close_notional[c] * scale;
-                float pnl = c_mult * (short_side
-                    ? adjusted * pprice[c] - adjusted_notional
-                    : adjusted_notional - adjusted * pprice[c]);
-                balance += pnl - adjusted_notional * c_mult * maker_fee;
-                float new_size = fmax(round_step(psize[c] - adjusted, qty_step), 0.0f);
-                bool went_flat = new_size <= 0.0f;
-                psize[c] = new_size;
+                float pnl = adjusted * c_mult * (short_side
+                    ? pprice[c] - fill_price
+                    : fill_price - pprice[c]);
+                balance += pnl - adjusted * fill_price * c_mult * maker_fee;
+                psize[c] = fmax(
+                    round_step(psize[c] - adjusted, qty_step), 0.0f
+                );
+                day_volume += adjusted * fill_price * c_mult / balance;
+
+                if (close_reconstruct_after_reducer[c] && psize[c] > 0.0f) {
+                    const float grid_gen_psize = psize[c];
+                    const int gen_tick_offset = ((k - 1) * C + c) * 2;
+                    float coin_close_qty_pct = coin_override_or(
+                        coin_overrides, c, 15, close_qty_pct
+                    );
+                    float coin_close_threshold_base = coin_override_or(
+                        coin_overrides, c, 16, close_threshold_base
+                    );
+                    float coin_close_threshold_we = coin_override_or(
+                        coin_overrides, c, 17, close_threshold_we
+                    );
+                    float coin_close_threshold_v1h = coin_override_or(
+                        coin_overrides, c, 18, close_threshold_v1h
+                    );
+                    float coin_close_threshold_v1m = coin_override_or(
+                        coin_overrides, c, 19, close_threshold_v1m
+                    );
+                    CloseGroup group;
+                    int group_count = recursive_grid_close_groups_after_reducer(
+                        short_side,
+                        grid_gen_psize,
+                        pprice[c],
+                        close_gen_balance[c],
+                        close_gen_allowed_wel[c],
+                        touch_ticks[gen_tick_offset + 0],
+                        touch_ticks[gen_tick_offset + 1],
+                        touch_nearest_ticks[(k - 1) * C + c],
+                        as_type<float>(touch_min_qty_bits[(k - 1) * C + c]),
+                        touch_min_qty_relation[(k - 1) * C + c],
+                        coin_close_qty_pct,
+                        coin_close_threshold_base,
+                        coin_close_threshold_we,
+                        coin_close_threshold_v1h,
+                        coin_close_threshold_v1m,
+                        volatility_1h[c],
+                        volatility_1m[c],
+                        qty_step,
+                        price_step,
+                        min_qty,
+                        min_cost,
+                        c_mult,
+                        -1,
+                        group
+                    );
+                    bool reverse = coin_close_threshold_we > 0.0f;
+                    for (int rank = 0; rank < group_count; ++rank) {
+                        int wanted = reverse ? group_count - rank - 1 : rank;
+                        recursive_grid_close_groups_after_reducer(
+                            short_side,
+                            grid_gen_psize,
+                            pprice[c],
+                            close_gen_balance[c],
+                            close_gen_allowed_wel[c],
+                            touch_ticks[gen_tick_offset + 0],
+                            touch_ticks[gen_tick_offset + 1],
+                            touch_nearest_ticks[(k - 1) * C + c],
+                            as_type<float>(touch_min_qty_bits[(k - 1) * C + c]),
+                            touch_min_qty_relation[(k - 1) * C + c],
+                            coin_close_qty_pct,
+                            coin_close_threshold_base,
+                            coin_close_threshold_we,
+                            coin_close_threshold_v1h,
+                            coin_close_threshold_v1m,
+                            volatility_1h[c],
+                            volatility_1m[c],
+                            qty_step,
+                            price_step,
+                            min_qty,
+                            min_cost,
+                            c_mult,
+                            wanted,
+                            group
+                        );
+                        bool reachable = short_side
+                            ? group.ticks > fill_ticks[tick_offset + 1]
+                            : group.ticks <= fill_ticks[tick_offset + 0];
+                        if (group.qty <= 0.0f || !reachable) break;
+                        float grid_qty = fmin(
+                            round_step(group.qty, qty_step), psize[c]
+                        );
+                        float grid_pnl = grid_qty * c_mult * (short_side
+                            ? pprice[c] - group.price
+                            : group.price - pprice[c]);
+                        balance += grid_pnl
+                            - grid_qty * group.price * c_mult * maker_fee;
+                        psize[c] = fmax(
+                            round_step(psize[c] - grid_qty, qty_step), 0.0f
+                        );
+                        day_volume += grid_qty * group.price * c_mult / balance;
+                        if (psize[c] <= 0.0f) break;
+                    }
+                }
+
+                bool went_flat = psize[c] <= 0.0f;
                 if (went_flat) {
                     pprice[c] = 0.0f;
                     if (position_open_k[c] >= 0.0f) {
@@ -499,10 +597,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     }
                     position_open_k[c] = -1.0f;
                 }
-                day_volume += adjusted_notional * c_mult / balance;
                 close_qty[c] = 0.0f;
-                close_notional[c] = 0.0f;
-                close_prefiltered[c] = false;
+                close_reconstruct_after_reducer[c] = false;
                 filled_coin[c] = true;
                 any_fill = true;
             }
@@ -804,8 +900,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             for (int c = 0; c < C; ++c) {
                 entry_qty[c] = 0.0f;
                 close_qty[c] = 0.0f;
-                close_notional[c] = 0.0f;
-                close_prefiltered[c] = false;
+                close_reconstruct_after_reducer[c] = false;
                 contribution[c] = 0.0f;
                 entry_candidate[c] = false;
                 int coin_offset = c * COIN_COLS;
@@ -1085,42 +1180,12 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                             );
                         }
                         if (coin_close_retracement_base <= 0.0f) {
-                            int next_tick_offset = ((k + 1) * C + c) * 2;
-                            recursive_close_aggregate_after_reducer(
-                                short_side,
-                                psize[c],
-                                pprice[c],
-                                balance,
-                                allowed_coin_wel,
-                                coin_wel_enforcer_threshold,
-                                touch_down,
-                                touch_up,
-                                touch_nearest_ticks[k * C + c],
-                                as_type<float>(touch_min_qty_bits[k * C + c]),
-                                touch_min_qty_relation[k * C + c],
-                                coin_close_qty_pct,
-                                coin_close_threshold_base,
-                                coin_close_threshold_we,
-                                coin_close_threshold_v1h,
-                                coin_close_threshold_v1m,
-                                volatility_1h[c],
-                                volatility_1m[c],
-                                qty_step,
-                                price_step,
-                                min_qty,
-                                min_cost,
-                                c_mult,
-                                fill_ticks[next_tick_offset + 0],
-                                fill_ticks[next_tick_offset + 1],
-                                close_qty[c],
-                                close_notional[c]
-                            );
-                            close_prefiltered[c] = close_qty[c] > 0.0f;
-                        } else {
-                            close_qty[c] = reducer_qty;
-                            close_tick[c] = reducer_tick;
-                            close_notional[c] = reducer_qty * reducer_price;
+                            close_reconstruct_after_reducer[c] = true;
+                            close_gen_balance[c] = balance;
+                            close_gen_allowed_wel[c] = allowed_coin_wel;
                         }
+                        close_qty[c] = reducer_qty;
+                        close_tick[c] = reducer_tick;
                         continue;
                     }
                 }
@@ -1193,7 +1258,6 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                         && (!trailing_close || close_triggered)
                     ? clip : 0.0f;
                 close_tick[c] = candidate_close_tick;
-                close_notional[c] = close_qty[c] * close_price;
             }
 
             float gated_twel = twel;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -485,36 +485,42 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     : close_tick[c] <= fill_ticks[tick_offset + 0]);
             if (filled_close) {
                 float fill_price = float(close_tick[c]) * price_step;
-                float adjusted = fmin(round_step(close_qty[c], qty_step), psize[c]);
-                float pnl = adjusted * c_mult * (short_side
-                    ? pprice[c] - fill_price
-                    : fill_price - pprice[c]);
-                balance += pnl - adjusted * fill_price * c_mult * maker_fee;
-                psize[c] = fmax(
-                    round_step(psize[c] - adjusted, qty_step), 0.0f
+                float reducer_qty = fmin(
+                    round_step(close_qty[c], qty_step), psize[c]
                 );
-                day_volume += adjusted * fill_price * c_mult / balance;
+                float grid_gen_psize = fmax(
+                    round_step(psize[c] - reducer_qty, qty_step), 0.0f
+                );
+                int gen_tick_offset = 0;
+                float coin_close_qty_pct = 0.0f;
+                float coin_close_threshold_base = 0.0f;
+                float coin_close_threshold_we = 0.0f;
+                float coin_close_threshold_v1h = 0.0f;
+                float coin_close_threshold_v1m = 0.0f;
+                CloseGroup group;
+                int group_count = 0;
+                bool reverse = false;
+                bool merge_reducer_with_first = false;
 
-                if (close_reconstruct_after_reducer[c] && psize[c] > 0.0f) {
-                    const float grid_gen_psize = psize[c];
-                    const int gen_tick_offset = ((k - 1) * C + c) * 2;
-                    float coin_close_qty_pct = coin_override_or(
+                if (close_reconstruct_after_reducer[c]
+                    && grid_gen_psize > 0.0f) {
+                    gen_tick_offset = ((k - 1) * C + c) * 2;
+                    coin_close_qty_pct = coin_override_or(
                         coin_overrides, c, 15, close_qty_pct
                     );
-                    float coin_close_threshold_base = coin_override_or(
+                    coin_close_threshold_base = coin_override_or(
                         coin_overrides, c, 16, close_threshold_base
                     );
-                    float coin_close_threshold_we = coin_override_or(
+                    coin_close_threshold_we = coin_override_or(
                         coin_overrides, c, 17, close_threshold_we
                     );
-                    float coin_close_threshold_v1h = coin_override_or(
+                    coin_close_threshold_v1h = coin_override_or(
                         coin_overrides, c, 18, close_threshold_v1h
                     );
-                    float coin_close_threshold_v1m = coin_override_or(
+                    coin_close_threshold_v1m = coin_override_or(
                         coin_overrides, c, 19, close_threshold_v1m
                     );
-                    CloseGroup group;
-                    int group_count = recursive_grid_close_groups_after_reducer(
+                    group_count = recursive_grid_close_groups_after_reducer(
                         short_side,
                         grid_gen_psize,
                         pprice[c],
@@ -540,9 +546,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                         -1,
                         group
                     );
-                    bool reverse = coin_close_threshold_we > 0.0f;
-                    for (int rank = 0; rank < group_count; ++rank) {
-                        int wanted = reverse ? group_count - rank - 1 : rank;
+                    reverse = coin_close_threshold_we > 0.0f;
+                    if (group_count > 0) {
+                        int first_wanted = reverse ? group_count - 1 : 0;
                         recursive_grid_close_groups_after_reducer(
                             short_side,
                             grid_gen_psize,
@@ -566,27 +572,74 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                             min_qty,
                             min_cost,
                             c_mult,
-                            wanted,
+                            first_wanted,
                             group
                         );
-                        bool reachable = short_side
-                            ? group.ticks > fill_ticks[tick_offset + 1]
-                            : group.ticks <= fill_ticks[tick_offset + 0];
-                        if (group.qty <= 0.0f || !reachable) break;
-                        float grid_qty = fmin(
-                            round_step(group.qty, qty_step), psize[c]
-                        );
-                        float grid_pnl = grid_qty * c_mult * (short_side
-                            ? pprice[c] - group.price
-                            : group.price - pprice[c]);
-                        balance += grid_pnl
-                            - grid_qty * group.price * c_mult * maker_fee;
-                        psize[c] = fmax(
-                            round_step(psize[c] - grid_qty, qty_step), 0.0f
-                        );
-                        day_volume += grid_qty * group.price * c_mult / balance;
-                        if (psize[c] <= 0.0f) break;
+                        merge_reducer_with_first = group.ticks == close_tick[c];
                     }
+                }
+
+                if (!merge_reducer_with_first) {
+                    float pnl = reducer_qty * c_mult * (short_side
+                        ? pprice[c] - fill_price
+                        : fill_price - pprice[c]);
+                    balance += pnl
+                        - reducer_qty * fill_price * c_mult * maker_fee;
+                    psize[c] = grid_gen_psize;
+                    day_volume += reducer_qty * fill_price * c_mult / balance;
+                }
+
+                for (int rank = 0; rank < group_count; ++rank) {
+                    int wanted = reverse ? group_count - rank - 1 : rank;
+                    recursive_grid_close_groups_after_reducer(
+                        short_side,
+                        grid_gen_psize,
+                        pprice[c],
+                        close_gen_balance[c],
+                        close_gen_allowed_wel[c],
+                        touch_ticks[gen_tick_offset + 0],
+                        touch_ticks[gen_tick_offset + 1],
+                        touch_nearest_ticks[(k - 1) * C + c],
+                        as_type<float>(touch_min_qty_bits[(k - 1) * C + c]),
+                        touch_min_qty_relation[(k - 1) * C + c],
+                        coin_close_qty_pct,
+                        coin_close_threshold_base,
+                        coin_close_threshold_we,
+                        coin_close_threshold_v1h,
+                        coin_close_threshold_v1m,
+                        volatility_1h[c],
+                        volatility_1m[c],
+                        qty_step,
+                        price_step,
+                        min_qty,
+                        min_cost,
+                        c_mult,
+                        wanted,
+                        group
+                    );
+                    bool reachable = short_side
+                        ? group.ticks > fill_ticks[tick_offset + 1]
+                        : group.ticks <= fill_ticks[tick_offset + 0];
+                    if (group.qty <= 0.0f || !reachable) break;
+                    float group_qty = group.qty;
+                    if (rank == 0 && merge_reducer_with_first) {
+                        group_qty = round_step(
+                            group_qty + reducer_qty, qty_step
+                        );
+                    }
+                    float grid_qty = fmin(
+                        round_step(group_qty, qty_step), psize[c]
+                    );
+                    float grid_pnl = grid_qty * c_mult * (short_side
+                        ? pprice[c] - group.price
+                        : group.price - pprice[c]);
+                    balance += grid_pnl
+                        - grid_qty * group.price * c_mult * maker_fee;
+                    psize[c] = fmax(
+                        round_step(psize[c] - grid_qty, qty_step), 0.0f
+                    );
+                    day_volume += grid_qty * group.price * c_mult / balance;
+                    if (psize[c] <= 0.0f) break;
                 }
 
                 bool went_flat = psize[c] <= 0.0f;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -92,6 +92,123 @@ inline float calc_close_qty(
     return quantity;
 }
 
+// Rebuild the immutable recursive close grid after a WEL reducer and retain
+// only the orders reachable by the next candle. Exact Rust expands the whole
+// grid whenever any rung is reachable; aggregating reachable quantity and
+// notional preserves the resulting position and balance without a large
+// per-thread order matrix.
+inline void recursive_close_aggregate_after_reducer(
+    bool short_side,
+    float psize,
+    float pprice,
+    float balance,
+    float allowed_wel,
+    float wel_enforcer_threshold,
+    int touch_down,
+    int touch_up,
+    int touch_nearest,
+    float touch_min_qty,
+    int touch_min_qty_relation,
+    float close_qty_pct,
+    float close_threshold_base,
+    float close_threshold_we,
+    float close_threshold_v1h,
+    float close_threshold_v1m,
+    float volatility_1h,
+    float volatility_1m,
+    float qty_step,
+    float price_step,
+    float min_qty,
+    float min_cost,
+    float c_mult,
+    int high_fill_max_tick,
+    int low_nonfill_max_tick,
+    thread float& reachable_qty,
+    thread float& reachable_notional
+) {
+    reachable_qty = 0.0f;
+    reachable_notional = 0.0f;
+    float sim_psize = psize;
+    for (int rung = 0; rung < 500 && sim_psize > 0.0f; ++rung) {
+        float we = sim_psize * pprice * c_mult / fmax(balance, 1.0e-9f);
+        float order_qty = 0.0f;
+        int order_tick = 0;
+
+        float wel_target = allowed_wel * wel_enforcer_threshold;
+        if (rung == 0 && wel_target > 0.0f && we > wel_target) {
+            order_tick = short_side ? touch_down : touch_up;
+            float order_price = float(order_tick) * price_step;
+            float reducer_min = min_entry_qty(
+                order_price, qty_step, min_qty, min_cost, c_mult
+            );
+            float target_psize = wel_target * balance
+                / fmax(pprice * c_mult, 1.0e-12f);
+            float reduce_qty = fmax(sim_psize - target_psize, 0.0f);
+            if (reduce_qty <= 1.1920928955078125e-7f) reduce_qty = qty_step;
+            order_qty = fmin(
+                sim_psize,
+                fmax(reducer_min, ceil_step(reduce_qty, qty_step))
+            );
+            float new_we = fmax(sim_psize - order_qty, 0.0f)
+                * pprice * c_mult / balance;
+            if (new_we >= wel_target - 1.0e-12f && order_qty < sim_psize) {
+                order_qty = fmin(
+                    sim_psize,
+                    fmax(
+                        reducer_min,
+                        ceil_step(order_qty + qty_step, qty_step)
+                    )
+                );
+            }
+        } else {
+            float wer = we / fmax(allowed_wel, 1.0e-12f);
+            float threshold = close_threshold_base
+                + wer * close_threshold_we
+                + volatility_1h * close_threshold_v1h
+                + volatility_1m * close_threshold_v1m;
+            float target = pprice * (
+                short_side ? 1.0f - threshold : 1.0f + threshold
+            );
+            int target_tick = short_side
+                ? int(floor(target / price_step + 1.0e-6f))
+                : int(ceil(target / price_step - 1.0e-6f));
+            int close_touch = short_side ? touch_down : touch_up;
+            bool touch_controls = (short_side && threshold <= 0.0f)
+                || (short_side
+                    ? close_touch < target_tick
+                    : close_touch > target_tick);
+            order_tick = touch_controls ? touch_nearest : target_tick;
+            float order_price = float(order_tick) * price_step;
+            float minimum_close = touch_controls
+                ? touch_min_qty
+                : min_entry_qty(
+                    order_price, qty_step, min_qty, min_cost, c_mult
+                );
+            int minimum_relation = touch_controls
+                ? touch_min_qty_relation : 0;
+            float close_pct = close_threshold_we == 0.0f
+                ? 1.0f : close_qty_pct;
+            order_qty = calc_close_qty(
+                sim_psize, pprice, balance, allowed_wel,
+                minimum_close, minimum_relation, close_pct,
+                qty_step, c_mult
+            );
+        }
+
+        order_qty = round_step(order_qty, qty_step);
+        if (order_qty <= 0.0f || order_tick <= 0) break;
+        order_qty = fmin(order_qty, sim_psize);
+        bool reachable = short_side
+            ? order_tick > low_nonfill_max_tick
+            : order_tick <= high_fill_max_tick;
+        if (reachable) {
+            reachable_qty = round_step(reachable_qty + order_qty, qty_step);
+            reachable_notional += order_qty * float(order_tick) * price_step;
+        }
+        sim_psize = fmax(round_step(sim_psize - order_qty, qty_step), 0.0f);
+    }
+}
+
 inline void passivbot_trailing_martingale_multicoin_impl(
     constant float* bars,
     constant int* fill_ticks,
@@ -196,6 +313,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     float last_increase_k[MAX_COINS];
     float entry_qty[MAX_COINS];
     float close_qty[MAX_COINS];
+    float close_notional[MAX_COINS];
     float position_open_k[MAX_COINS];
     float score[MAX_COINS];
     float contribution[MAX_COINS];
@@ -210,6 +328,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     bool incumbent[MAX_COINS];
     bool survivor[MAX_COINS];
     bool entry_candidate[MAX_COINS];
+    bool close_prefiltered[MAX_COINS];
     bool filled_coin[MAX_COINS];
     float alpha0_coin[MAX_COINS];
     float alpha1_coin[MAX_COINS];
@@ -238,6 +357,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         last_increase_k[c] = -1.0e20f;
         entry_qty[c] = 0.0f;
         close_qty[c] = 0.0f;
+        close_notional[c] = 0.0f;
         position_open_k[c] = -1.0f;
         score[c] = -INFINITY;
         contribution[c] = 0.0f;
@@ -252,6 +372,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         incumbent[c] = false;
         survivor[c] = false;
         entry_candidate[c] = false;
+        close_prefiltered[c] = false;
         filled_coin[c] = false;
         float coin_span_a = c < C
             ? coin_override_or(coin_overrides, c, 0, span_a) : span_a;
@@ -357,16 +478,17 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             const float maker_fee = coin_settings[coin_offset + 5];
 
             bool filled_close = close_qty[c] > 0.0f && psize[c] > 0.0f
-                && (short_side
+                && (close_prefiltered[c] || (short_side
                     ? close_tick[c] > fill_ticks[tick_offset + 1]
-                    : close_tick[c] <= fill_ticks[tick_offset + 0]);
+                    : close_tick[c] <= fill_ticks[tick_offset + 0]));
             if (filled_close) {
-                float fill_price = float(close_tick[c]) * price_step;
                 float adjusted = fmin(round_step(close_qty[c], qty_step), psize[c]);
-                float pnl = adjusted * c_mult * (short_side
-                    ? pprice[c] - fill_price
-                    : fill_price - pprice[c]);
-                balance += pnl - adjusted * fill_price * c_mult * maker_fee;
+                float scale = adjusted / fmax(close_qty[c], 1.0e-12f);
+                float adjusted_notional = close_notional[c] * scale;
+                float pnl = c_mult * (short_side
+                    ? adjusted * pprice[c] - adjusted_notional
+                    : adjusted_notional - adjusted * pprice[c]);
+                balance += pnl - adjusted_notional * c_mult * maker_fee;
                 float new_size = fmax(round_step(psize[c] - adjusted, qty_step), 0.0f);
                 bool went_flat = new_size <= 0.0f;
                 psize[c] = new_size;
@@ -377,8 +499,10 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     }
                     position_open_k[c] = -1.0f;
                 }
-                day_volume += fabs(adjusted) * fill_price * c_mult / balance;
+                day_volume += adjusted_notional * c_mult / balance;
                 close_qty[c] = 0.0f;
+                close_notional[c] = 0.0f;
+                close_prefiltered[c] = false;
                 filled_coin[c] = true;
                 any_fill = true;
             }
@@ -680,6 +804,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             for (int c = 0; c < C; ++c) {
                 entry_qty[c] = 0.0f;
                 close_qty[c] = 0.0f;
+                close_notional[c] = 0.0f;
+                close_prefiltered[c] = false;
                 contribution[c] = 0.0f;
                 entry_candidate[c] = false;
                 int coin_offset = c * COIN_COLS;
@@ -958,8 +1084,43 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                                 )
                             );
                         }
-                        close_qty[c] = reducer_qty;
-                        close_tick[c] = reducer_tick;
+                        if (coin_close_retracement_base <= 0.0f) {
+                            int next_tick_offset = ((k + 1) * C + c) * 2;
+                            recursive_close_aggregate_after_reducer(
+                                short_side,
+                                psize[c],
+                                pprice[c],
+                                balance,
+                                allowed_coin_wel,
+                                coin_wel_enforcer_threshold,
+                                touch_down,
+                                touch_up,
+                                touch_nearest_ticks[k * C + c],
+                                as_type<float>(touch_min_qty_bits[k * C + c]),
+                                touch_min_qty_relation[k * C + c],
+                                coin_close_qty_pct,
+                                coin_close_threshold_base,
+                                coin_close_threshold_we,
+                                coin_close_threshold_v1h,
+                                coin_close_threshold_v1m,
+                                volatility_1h[c],
+                                volatility_1m[c],
+                                qty_step,
+                                price_step,
+                                min_qty,
+                                min_cost,
+                                c_mult,
+                                fill_ticks[next_tick_offset + 0],
+                                fill_ticks[next_tick_offset + 1],
+                                close_qty[c],
+                                close_notional[c]
+                            );
+                            close_prefiltered[c] = close_qty[c] > 0.0f;
+                        } else {
+                            close_qty[c] = reducer_qty;
+                            close_tick[c] = reducer_tick;
+                            close_notional[c] = reducer_qty * reducer_price;
+                        }
                         continue;
                     }
                 }
@@ -1032,6 +1193,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                         && (!trailing_close || close_triggered)
                     ? clip : 0.0f;
                 close_tick[c] = candidate_close_tick;
+                close_notional[c] = close_qty[c] * close_price;
             }
 
             float gated_twel = twel;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -479,11 +479,14 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             const float c_mult = coin_settings[coin_offset + 4];
             const float maker_fee = coin_settings[coin_offset + 5];
 
-            bool filled_close = close_qty[c] > 0.0f && psize[c] > 0.0f
+            bool close_ready = close_qty[c] > 0.0f && psize[c] > 0.0f;
+            bool filled_close = close_ready
                 && (short_side
                     ? close_tick[c] > fill_ticks[tick_offset + 1]
                     : close_tick[c] <= fill_ticks[tick_offset + 0]);
-            if (filled_close) {
+            bool rebuild_grid = close_ready
+                && close_reconstruct_after_reducer[c];
+            if (filled_close || rebuild_grid) {
                 float fill_price = float(close_tick[c]) * price_step;
                 float reducer_qty = fmin(
                     round_step(close_qty[c], qty_step), psize[c]
@@ -501,9 +504,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 int group_count = 0;
                 bool reverse = false;
                 bool merge_reducer_with_first = false;
+                bool executed_close = false;
 
-                if (close_reconstruct_after_reducer[c]
-                    && grid_gen_psize > 0.0f) {
+                if (rebuild_grid && grid_gen_psize > 0.0f) {
                     gen_tick_offset = ((k - 1) * C + c) * 2;
                     coin_close_qty_pct = coin_override_or(
                         coin_overrides, c, 15, close_qty_pct
@@ -575,11 +578,12 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                             first_wanted,
                             group
                         );
-                        merge_reducer_with_first = group.ticks == close_tick[c];
+                        merge_reducer_with_first = filled_close
+                            && group.ticks == close_tick[c];
                     }
                 }
 
-                if (!merge_reducer_with_first) {
+                if (filled_close && !merge_reducer_with_first) {
                     float pnl = reducer_qty * c_mult * (short_side
                         ? pprice[c] - fill_price
                         : fill_price - pprice[c]);
@@ -587,6 +591,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                         - reducer_qty * fill_price * c_mult * maker_fee;
                     psize[c] = grid_gen_psize;
                     day_volume += reducer_qty * fill_price * c_mult / balance;
+                    executed_close = true;
                 }
 
                 for (int rank = 0; rank < group_count; ++rank) {
@@ -639,21 +644,26 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                         round_step(psize[c] - grid_qty, qty_step), 0.0f
                     );
                     day_volume += grid_qty * group.price * c_mult / balance;
+                    executed_close = true;
                     if (psize[c] <= 0.0f) break;
                 }
 
-                bool went_flat = psize[c] <= 0.0f;
-                if (went_flat) {
-                    pprice[c] = 0.0f;
-                    if (position_open_k[c] >= 0.0f) {
-                        held_max_min = fmax(held_max_min, float(k) - position_open_k[c]);
+                if (executed_close) {
+                    bool went_flat = psize[c] <= 0.0f;
+                    if (went_flat) {
+                        pprice[c] = 0.0f;
+                        if (position_open_k[c] >= 0.0f) {
+                            held_max_min = fmax(
+                                held_max_min, float(k) - position_open_k[c]
+                            );
+                        }
+                        position_open_k[c] = -1.0f;
                     }
-                    position_open_k[c] = -1.0f;
+                    close_qty[c] = 0.0f;
+                    close_reconstruct_after_reducer[c] = false;
+                    filled_coin[c] = true;
+                    any_fill = true;
                 }
-                close_qty[c] = 0.0f;
-                close_reconstruct_after_reducer[c] = false;
-                filled_coin[c] = true;
-                any_fill = true;
             }
 
             bool was_flat = psize[c] <= 0.0f;
@@ -1213,24 +1223,29 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                         float target_psize = wel_target * balance
                             / fmax(pprice[c] * c_mult, 1.0e-12f);
                         float reduce_qty = fmax(psize[c] - target_psize, 0.0f);
-                        if (reduce_qty <= 1.1920928955078125e-7f) {
+                        if (reduce_qty <= 2.220446e-16f) {
                             reduce_qty = qty_step;
                         }
-                        float reducer_qty = fmin(
-                            psize[c],
-                            fmax(reducer_min, ceil_step(reduce_qty, qty_step))
-                        );
-                        float new_we = fmax(psize[c] - reducer_qty, 0.0f)
-                            * pprice[c] * c_mult / balance;
-                        if (new_we >= wel_target - 1.0e-12f
-                            && reducer_qty < psize[c]) {
+                        float reducer_qty = 0.0f;
+                        for (int steps = 0; steps <= 10000; ++steps) {
                             reducer_qty = fmin(
                                 psize[c],
                                 fmax(
                                     reducer_min,
-                                    ceil_step(reducer_qty + qty_step, qty_step)
+                                    ceil_step(reduce_qty, qty_step)
                                 )
                             );
+                            float new_psize = fmax(
+                                round_step(
+                                    psize[c] - reducer_qty, qty_step
+                                ),
+                                0.0f
+                            );
+                            if (new_psize < target_psize
+                                || new_psize <= 2.220446e-16f) {
+                                break;
+                            }
+                            reduce_qty += qty_step;
                         }
                         if (coin_close_retracement_base <= 0.0f) {
                             close_reconstruct_after_reducer[c] = true;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -137,7 +137,9 @@ inline int recursive_grid_close_groups_after_reducer(
     int group_ticks = 0;
     float group_price = 0.0f;
     float group_qty = 0.0f;
-    for (int rung = 0; rung < 500 && sim_psize > 0.0f; ++rung) {
+    // Exact calc_closes_long/short spends the first of its 500 iterations on
+    // the reducer before generating this post-repair grid.
+    for (int rung = 0; rung < 499 && sim_psize > 0.0f; ++rung) {
         float we = sim_psize * pprice * c_mult
             / fmax(generation_balance, 1.0e-9f);
         float wer = we / fmax(allowed_wel, 1.0e-12f);
@@ -503,7 +505,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 CloseGroup group;
                 int group_count = 0;
                 bool reverse = false;
-                bool merge_reducer_with_first = false;
+                bool reducer_executed = false;
                 bool executed_close = false;
 
                 if (rebuild_grid && grid_gen_psize > 0.0f) {
@@ -550,48 +552,6 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                         group
                     );
                     reverse = coin_close_threshold_we > 0.0f;
-                    if (group_count > 0) {
-                        int first_wanted = reverse ? group_count - 1 : 0;
-                        recursive_grid_close_groups_after_reducer(
-                            short_side,
-                            grid_gen_psize,
-                            pprice[c],
-                            close_gen_balance[c],
-                            close_gen_allowed_wel[c],
-                            touch_ticks[gen_tick_offset + 0],
-                            touch_ticks[gen_tick_offset + 1],
-                            touch_nearest_ticks[(k - 1) * C + c],
-                            as_type<float>(touch_min_qty_bits[(k - 1) * C + c]),
-                            touch_min_qty_relation[(k - 1) * C + c],
-                            coin_close_qty_pct,
-                            coin_close_threshold_base,
-                            coin_close_threshold_we,
-                            coin_close_threshold_v1h,
-                            coin_close_threshold_v1m,
-                            volatility_1h[c],
-                            volatility_1m[c],
-                            qty_step,
-                            price_step,
-                            min_qty,
-                            min_cost,
-                            c_mult,
-                            first_wanted,
-                            group
-                        );
-                        merge_reducer_with_first = filled_close
-                            && group.ticks == close_tick[c];
-                    }
-                }
-
-                if (filled_close && !merge_reducer_with_first) {
-                    float pnl = reducer_qty * c_mult * (short_side
-                        ? pprice[c] - fill_price
-                        : fill_price - pprice[c]);
-                    balance += pnl
-                        - reducer_qty * fill_price * c_mult * maker_fee;
-                    psize[c] = grid_gen_psize;
-                    day_volume += reducer_qty * fill_price * c_mult / balance;
-                    executed_close = true;
                 }
 
                 for (int rank = 0; rank < group_count; ++rank) {
@@ -622,15 +582,39 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                         wanted,
                         group
                     );
+                    if (group.qty <= 0.0f) break;
+                    bool merge_reducer = filled_close
+                        && !reducer_executed
+                        && group.ticks == close_tick[c];
+                    bool reducer_before_group = filled_close
+                        && !reducer_executed
+                        && (short_side
+                            ? close_tick[c] > group.ticks
+                            : close_tick[c] < group.ticks);
+                    if (reducer_before_group) {
+                        float qty = fmin(reducer_qty, psize[c]);
+                        float pnl = qty * c_mult * (short_side
+                            ? pprice[c] - fill_price
+                            : fill_price - pprice[c]);
+                        balance += pnl
+                            - qty * fill_price * c_mult * maker_fee;
+                        psize[c] = fmax(
+                            round_step(psize[c] - qty, qty_step), 0.0f
+                        );
+                        day_volume += qty * fill_price * c_mult / balance;
+                        reducer_executed = true;
+                        executed_close = true;
+                    }
                     bool reachable = short_side
                         ? group.ticks > fill_ticks[tick_offset + 1]
                         : group.ticks <= fill_ticks[tick_offset + 0];
-                    if (group.qty <= 0.0f || !reachable) break;
+                    if (!reachable) break;
                     float group_qty = group.qty;
-                    if (rank == 0 && merge_reducer_with_first) {
+                    if (merge_reducer) {
                         group_qty = round_step(
                             group_qty + reducer_qty, qty_step
                         );
+                        reducer_executed = true;
                     }
                     float grid_qty = fmin(
                         round_step(group_qty, qty_step), psize[c]
@@ -646,6 +630,20 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     day_volume += grid_qty * group.price * c_mult / balance;
                     executed_close = true;
                     if (psize[c] <= 0.0f) break;
+                }
+
+                if (filled_close && !reducer_executed && psize[c] > 0.0f) {
+                    float qty = fmin(reducer_qty, psize[c]);
+                    float pnl = qty * c_mult * (short_side
+                        ? pprice[c] - fill_price
+                        : fill_price - pprice[c]);
+                    balance += pnl
+                        - qty * fill_price * c_mult * maker_fee;
+                    psize[c] = fmax(
+                        round_step(psize[c] - qty, qty_step), 0.0f
+                    );
+                    day_volume += qty * fill_price * c_mult / balance;
+                    executed_close = true;
                 }
 
                 if (executed_close) {

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -2,8 +2,8 @@
 using namespace metal;
 
 constant int MAX_COINS = 64;
-constant int PARAM_COLS = 38;
-constant int OVERRIDE_COLS = 26;
+constant int PARAM_COLS = 40;
+constant int OVERRIDE_COLS = 28;
 constant int COIN_COLS = 11;
 constant int DAILY_COLS = 6;
 constant int SCALAR_COLS = 18;
@@ -159,6 +159,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     const bool legacy_raw_allowance = params[po + 35] > 0.5f;
     const bool twel_entry_gate_enabled = params[po + 36] > 0.5f;
     const float twel_threshold = params[po + 37];
+    const bool wel_enforcer_enabled = params[po + 38] > 0.5f;
+    const float wel_enforcer_threshold = params[po + 39];
     const float weight_sum = w_volume + w_ready + w_volatility;
     if (weight_sum > 0.0f) {
         w_volume /= weight_sum;
@@ -692,6 +694,13 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 float coin_allowance_pct = coin_override_or(
                     coin_overrides, c, 25, allowance_pct
                 );
+                bool coin_wel_enforcer_enabled = coin_override_or(
+                    coin_overrides, c, 26,
+                    wel_enforcer_enabled ? 1.0f : 0.0f
+                ) > 0.5f;
+                float coin_wel_enforcer_threshold = coin_override_or(
+                    coin_overrides, c, 27, wel_enforcer_threshold
+                );
                 float allowed_coin_wel = allowed_wallet_exposure_limit(
                     coin_wel, twel, coin_allowance_pct, legacy_raw_allowance
                 );
@@ -912,6 +921,48 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 entry_candidate[c] = quantity > 0.0f;
                 contribution[c] = quantity > 0.0f
                     ? quantity * entry_price * c_mult / balance : 0.0f;
+
+                // Per-position exposure repair has exact-Rust precedence over
+                // the normal Trailing Martingale close.
+                float wel_target = allowed_coin_wel
+                    * coin_wel_enforcer_threshold;
+                if (coin_wel_enforcer_enabled
+                    && coin_wel_enforcer_threshold > 0.0f
+                    && balance > 0.0f && psize[c] > 0.0f && pprice[c] > 0.0f
+                    && wel_target > 0.0f && we > wel_target) {
+                    int reducer_tick = short_side ? touch_down : touch_up;
+                    float reducer_price = float(reducer_tick) * price_step;
+                    if (reducer_tick > 0 && reducer_price > 0.0f) {
+                        float reducer_min = min_entry_qty(
+                            reducer_price, qty_step, min_qty, min_cost, c_mult
+                        );
+                        float target_psize = wel_target * balance
+                            / fmax(pprice[c] * c_mult, 1.0e-12f);
+                        float reduce_qty = fmax(psize[c] - target_psize, 0.0f);
+                        if (reduce_qty <= 1.1920928955078125e-7f) {
+                            reduce_qty = qty_step;
+                        }
+                        float reducer_qty = fmin(
+                            psize[c],
+                            fmax(reducer_min, ceil_step(reduce_qty, qty_step))
+                        );
+                        float new_we = fmax(psize[c] - reducer_qty, 0.0f)
+                            * pprice[c] * c_mult / balance;
+                        if (new_we >= wel_target - 1.0e-12f
+                            && reducer_qty < psize[c]) {
+                            reducer_qty = fmin(
+                                psize[c],
+                                fmax(
+                                    reducer_min,
+                                    ceil_step(reducer_qty + qty_step, qty_step)
+                                )
+                            );
+                        }
+                        close_qty[c] = reducer_qty;
+                        close_tick[c] = reducer_tick;
+                        continue;
+                    }
+                }
 
                 float close_threshold = coin_close_threshold_base
                     + wer * coin_close_threshold_we

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -138,6 +138,7 @@ _TM_SIDE_BOUND_SUFFIXES = {
     "close_retracement_volatility_1h_weight": "close_retracement_volatility_1h_weight",
     "close_retracement_volatility_1m_weight": "close_retracement_volatility_1m_weight",
     "risk_entry_cooldown_minutes": "entry_cooldown_minutes",
+    "risk_wel_enforcer_threshold": "wel_enforcer_threshold",
     "total_wallet_exposure_limit": "total_wallet_exposure_limit",
 }
 
@@ -405,7 +406,6 @@ PINNED_SCOPE_BOUND_VALUES = {
     for suffix, expected in {
         "hsl_enabled": 0.0,
         "unstuck_enabled": 0.0,
-        "risk_position_exposure_enforcer_enabled": 0.0,
         "risk_total_exposure_enforcer_enabled": 0.0,
     }.items()
 }
@@ -862,10 +862,12 @@ def _validate_scope_config(
                 f"GPU foundation requires bot.{side}.unstuck.enabled=false"
             )
         risk = side_config.get("risk", {})
-        for key, expected in (
-            ("position_exposure_enforcer_enabled", False),
-            ("total_exposure_enforcer_enabled", False),
-        ):
+        required_disabled = [("total_exposure_enforcer_enabled", False)]
+        if strategy_kind != "trailing_martingale":
+            required_disabled.append(
+                ("position_exposure_enforcer_enabled", False)
+            )
+        for key, expected in required_disabled:
             if bool(risk.get(key, expected)) != expected:
                 raise ValueError(
                     f"GPU foundation requires bot.{side}.risk.{key}={str(expected).lower()}"
@@ -950,6 +952,23 @@ def _validate_gpu_coin_overrides(
                 ("bot", enabled_side, "wallet_exposure_limit"),
             }
         )
+        if strategy_kind == "trailing_martingale":
+            allowed.update(
+                {
+                    (
+                        "bot",
+                        enabled_side,
+                        "risk",
+                        "position_exposure_enforcer_enabled",
+                    ),
+                    (
+                        "bot",
+                        enabled_side,
+                        "risk",
+                        "position_exposure_enforcer_threshold",
+                    ),
+                }
+            )
         allowed.update(
             (
                 "bot",
@@ -971,11 +990,18 @@ def _validate_gpu_coin_overrides(
             if path not in allowed
         )
     if unsupported:
+        supported_risk = (
+            "risk.entry_cooldown_minutes, risk.we_excess_allowance_pct"
+        )
+        if strategy_kind == "trailing_martingale":
+            supported_risk += (
+                ", risk.position_exposure_enforcer_enabled, "
+                "risk.position_exposure_enforcer_threshold"
+            )
         raise ValueError(
             "GPU coin_overrides do not model these paths yet: "
             f"{sorted(unsupported)}; supported leaves are enabled-side "
-            f"{strategy_kind} parameters, risk.entry_cooldown_minutes, "
-            "risk.we_excess_allowance_pct, and "
+            f"{strategy_kind} parameters, {supported_risk}, and "
             "wallet_exposure_limit"
         )
 
@@ -1972,10 +1998,23 @@ def _build_anchor_parameter_context(
 
 
 def _validate_pinned_scope_bounds(
-    bound_by_key, base_by_key, enabled_sides=None, *, coin_count: int = 1
+    bound_by_key,
+    base_by_key,
+    enabled_sides=None,
+    *,
+    coin_count: int = 1,
+    strategy_kind: str | None = None,
 ) -> None:
     enabled_sides = set(enabled_sides or ("long", "short"))
-    for key, expected in PINNED_SCOPE_BOUND_VALUES.items():
+    pinned = dict(PINNED_SCOPE_BOUND_VALUES)
+    if strategy_kind != "trailing_martingale":
+        pinned.update(
+            {
+                f"{side}_risk_position_exposure_enforcer_enabled": 0.0
+                for side in ("long", "short")
+            }
+        )
+    for key, expected in pinned.items():
         if key.split("_", 1)[0] not in enabled_sides:
             continue
         bound = bound_by_key.get(key)
@@ -2481,6 +2520,7 @@ def run_backend(
         base_by_key,
         enabled_sides,
         coin_count=max_coin_count,
+        strategy_kind=strategy_kind,
     )
 
     if suite_multicoin_sides is None:
@@ -2517,6 +2557,7 @@ def run_backend(
             scenario_base_by_key,
             scenario_enabled_sides,
             coin_count=item["coin_count"],
+            strategy_kind=strategy_kind,
         )
         _validate_directional_search_space(
             scenario_bound_by_key,

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -32,6 +32,11 @@ EXPOSURE_PARAM_KEYS = (
     "twel_enforcer_threshold",
 )
 
+POSITION_EXPOSURE_ENFORCER_PARAM_KEYS = (
+    "wel_enforcer_enabled",
+    "wel_enforcer_threshold",
+)
+
 # Compatibility name retained for imports from the first exposure-policy slice.
 SINGLE_COIN_EXPOSURE_PARAM_KEYS = EXPOSURE_PARAM_KEYS
 
@@ -85,6 +90,7 @@ TRAILING_MARTINGALE_PARAM_KEYS = (
 TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS = (
     *TRAILING_MARTINGALE_PARAM_KEYS,
     *SINGLE_COIN_EXPOSURE_PARAM_KEYS,
+    *POSITION_EXPOSURE_ENFORCER_PARAM_KEYS,
 )
 
 TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS = (
@@ -97,6 +103,7 @@ TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS = (
     "forager_score_weights_volatility",
     "n_positions",
     *EXPOSURE_PARAM_KEYS,
+    *POSITION_EXPOSURE_ENFORCER_PARAM_KEYS,
 )
 
 TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS = (

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -504,7 +504,7 @@ class MpsEmaAnchorMulticoinShortRunner(MpsEmaAnchorMulticoinRunner):
 class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
     """Persistent single-side multi-coin Trailing Martingale proxy on MPS."""
 
-    coin_override_cols = 26
+    coin_override_cols = 28
     coin_override_label = "Trailing Martingale"
 
     def __init__(

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -69,6 +69,34 @@ def _single_coin_exposure_params(risk: dict, *, side: str) -> dict[str, float]:
     }
 
 
+def _position_exposure_enforcer_params(
+    risk: dict, *, side: str
+) -> dict[str, float]:
+    enabled = bool(
+        risk.get(
+            "position_exposure_enforcer_enabled",
+            risk.get("risk_wel_enforcer_enabled", False),
+        )
+    )
+    threshold = float(
+        risk.get(
+            "position_exposure_enforcer_threshold",
+            risk.get("risk_wel_enforcer_threshold", 0.0),
+        )
+        or 0.0
+    )
+    if enabled and (not np.isfinite(threshold) or threshold <= 0.0):
+        raise ValueError(
+            "MPS proxy requires a finite positive "
+            f"bot.{side}.risk.position_exposure_enforcer_threshold when the "
+            "position exposure enforcer is enabled"
+        )
+    return {
+        "wel_enforcer_enabled": float(enabled),
+        "wel_enforcer_threshold": threshold,
+    }
+
+
 def _require_complete_valid_tail(last_valid_idx: int, candle_count: int) -> None:
     if int(last_valid_idx) != int(candle_count) - 1:
         raise ValueError(
@@ -322,6 +350,10 @@ class MpsSingleCoinProxy:
                     risk["total_wallet_exposure_limit"]
                 )
             strategy.update(_single_coin_exposure_params(risk, side=side))
+            if self.strategy_kind == "trailing_martingale":
+                strategy.update(
+                    _position_exposure_enforcer_params(risk, side=side)
+                )
             missing = [key for key in self.param_keys if key not in strategy]
             if missing:
                 raise ValueError(
@@ -518,8 +550,10 @@ def _build_multicoin_tm_coin_overrides(
     cooldown_column = len(TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS)
     wallet_exposure_column = cooldown_column + 1
     allowance_pct_column = wallet_exposure_column + 1
+    wel_enforcer_enabled_column = allowance_pct_column + 1
+    wel_enforcer_threshold_column = wel_enforcer_enabled_column + 1
     matrix = np.full(
-        (len(coins), allowance_pct_column + 1),
+        (len(coins), wel_enforcer_threshold_column + 1),
         np.nan,
         dtype=np.float32,
     )
@@ -559,6 +593,14 @@ def _build_multicoin_tm_coin_overrides(
         if "we_excess_allowance_pct" in risk_patch:
             matrix[coin_index, allowance_pct_column] = float(
                 effective_bot.get("risk_we_excess_allowance_pct", 0.0) or 0.0
+            )
+        if "position_exposure_enforcer_enabled" in risk_patch:
+            matrix[coin_index, wel_enforcer_enabled_column] = float(
+                bool(effective_bot.get("risk_wel_enforcer_enabled", False))
+            )
+        if "position_exposure_enforcer_threshold" in risk_patch:
+            matrix[coin_index, wel_enforcer_threshold_column] = float(
+                effective_bot.get("risk_wel_enforcer_threshold", 0.0) or 0.0
             )
     contract = {
         "exchange": exchange,
@@ -772,6 +814,12 @@ class MpsMulticoinProxy:
                     config["bot"][side].get("risk", {}), side=side
                 )
             )
+            if self.strategy_kind == "trailing_martingale":
+                first_strategy.update(
+                    _position_exposure_enforcer_params(
+                        config["bot"][side].get("risk", {}), side=side
+                    )
+                )
             missing = [
                 key for key in self.param_keys if key not in first_strategy
             ]

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -346,6 +346,7 @@ def test_trailing_martingale_bound_map_covers_both_directional_shapes():
         "risk_entry_cooldown_minutes",
         "risk_twel_enforcer_threshold",
         "risk_we_excess_allowance_pct",
+        "risk_wel_enforcer_threshold",
         "total_wallet_exposure_limit",
     }
 
@@ -1366,6 +1367,30 @@ def test_gpu_foundation_accepts_single_coin_exposure_headroom_policy(
     assert _validate_scope(config, _Evaluator()) == "bybit"
 
 
+@pytest.mark.parametrize("side", ["long", "short"])
+@pytest.mark.parametrize("suite_enabled", [False, True])
+def test_gpu_foundation_accepts_tm_position_exposure_repair(side, suite_enabled):
+    config = _directional_tm_config(
+        long_enabled=side == "long", short_enabled=side == "short"
+    )
+    config["bot"][side]["risk"]["position_exposure_enforcer_enabled"] = True
+    config["bot"][side]["risk"]["position_exposure_enforcer_threshold"] = 0.8
+    config["backtest"]["suite_enabled"] = suite_enabled
+
+    assert (
+        _validate_scope(config, _Evaluator(), allow_suite=suite_enabled) == "bybit"
+    )
+
+
+def test_gpu_foundation_keeps_ema_position_exposure_repair_fail_closed():
+    config = _directional_ema_config(long_enabled=True, short_enabled=False)
+    config["bot"]["long"]["risk"]["position_exposure_enforcer_enabled"] = True
+    config["bot"]["long"]["risk"]["position_exposure_enforcer_threshold"] = 0.8
+
+    with pytest.raises(ValueError, match="position_exposure_enforcer_enabled"):
+        _validate_scope(config, _Evaluator())
+
+
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
 @pytest.mark.parametrize("side", ["long", "short"])
 @pytest.mark.parametrize("entry_gate", [False, True])
@@ -1519,6 +1544,13 @@ def test_gpu_multicoin_accepts_static_ema_coin_overrides(side):
                 }
             }
         },
+        {
+            "bot": {
+                "long": {
+                    "risk": {"position_exposure_enforcer_enabled": True}
+                }
+            }
+        },
         {"bot": {"long": {"unstuck": {"enabled": True}}}},
         {"bot": {"short": {"strategy": {"ema_anchor": {"offset": 0.02}}}}},
     ],
@@ -1567,6 +1599,8 @@ def test_gpu_multicoin_accepts_static_tm_coin_overrides(side):
                     "risk": {
                         "entry_cooldown_minutes": 15,
                         "we_excess_allowance_pct": 0.25,
+                        "position_exposure_enforcer_enabled": True,
+                        "position_exposure_enforcer_threshold": 0.8,
                     },
                     "wallet_exposure_limit": 0.4,
                 }
@@ -3456,6 +3490,19 @@ def test_gpu_rejects_pinned_unsupported_exposure_repair_behavior():
             {"long_risk_position_exposure_enforcer_enabled": 1.0},
             coin_count=2,
         )
+
+    _validate_pinned_scope_bounds(
+        {
+            "long_risk_position_exposure_enforcer_enabled": Bound(
+                1.0, 1.0, None
+            ),
+            "long_risk_wel_enforcer_threshold": Bound(0.5, 1.0, None),
+        },
+        {"long_risk_position_exposure_enforcer_enabled": 1.0},
+        {"long"},
+        coin_count=2,
+        strategy_kind="trailing_martingale",
+    )
 
     with pytest.raises(ValueError, match="total_exposure_enforcer_enabled"):
         _validate_pinned_scope_bounds(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -1197,6 +1197,57 @@ def test_mps_tm_position_exposure_repair_reduces_strictly_below_target(side):
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_position_reducer_reachability_survives_grid_pruning(side):
+    count = 6
+    close = np.full(count, 100.0)
+    high = np.full(count, 102.0)
+    low = np.full(count, 98.0)
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    candidate = _tm_single_row(
+        wel_enforcer_enabled=True, wel_enforcer_threshold=0.5
+    )
+    candidate[6] = 1.0
+    candidate[7] = 10.0
+    candidate[11] = 0.0
+    candidate[16] = 0.10
+    candidate[17] = 0.10
+    candidate[20] = 0.0
+    candidate[23] = 100.0
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+    ).run(np.asarray([candidate + candidate], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    pprice_key = "pprice" if side == "long" else "short_pprice"
+    size = output[size_key].item()
+    repaired_we = size * output[pprice_key].item() / output["balance"].item()
+    assert 0.0 < repaired_we < 0.5
+    assert output["day_volume"].sum().item() > 1.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_tm_multicoin_global_position_exposure_repair(side):
     runner, baseline = _multicoin_exposure_fixture(
         "trailing_martingale", side, count=10
@@ -1218,6 +1269,50 @@ def test_mps_tm_multicoin_global_position_exposure_repair(side):
         output["day_volume"][1].sum().item()
         > output["day_volume"][0].sum().item()
     )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_reducer_retains_reachable_post_repair_grid(side):
+    runner, row = _multicoin_exposure_fixture(
+        "trailing_martingale", side, count=6
+    )
+    enabled = list(row)
+    enabled[
+        TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index("wel_enforcer_enabled")
+    ] = 1.0
+    enabled[
+        TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index("wel_enforcer_threshold")
+    ] = 0.5
+    enabled[
+        TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index("entry_cooldown_minutes")
+    ] = 100.0
+    reducer_only = list(enabled)
+    reducer_only[
+        TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(
+            "close_retracement_base_pct"
+        )
+    ] = 0.001
+    repaired_grid = list(enabled)
+    repaired_grid[
+        TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index("close_threshold_base_pct")
+    ] = 0.0
+    repaired_grid[
+        TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index("close_threshold_we_weight")
+    ] = 0.0
+    output = runner.run(
+        np.asarray([reducer_only, repaired_grid], dtype=np.float64)
+    )
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    sizes = output[size_key].cpu().numpy()
+    volumes = output["day_volume"].sum(dim=1).cpu().numpy()
+    assert sizes[0] > 0.0
+    assert sizes[1] == pytest.approx(0.0)
+    assert volumes[1] > volumes[0]
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -1248,6 +1248,113 @@ def test_mps_tm_position_reducer_reachability_survives_grid_pruning(side):
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_grid_can_fill_without_off_tick_reducer(side):
+    count = 6
+    generation_touch = 100.4 if side == "long" else 100.6
+    close = np.array([100.0, 100.0, 100.0, generation_touch, 100.0, 100.0])
+    high = np.array([100.0, 100.0, 100.0, 102.0, 100.5, 100.0])
+    low = np.array([100.0, 100.0, 100.0, 98.0, 100.5, 100.0])
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 1.0, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    candidate = _tm_single_row(
+        wel_enforcer_enabled=True, wel_enforcer_threshold=0.5
+    )
+    candidate[6] = 1.0
+    candidate[7] = 10.0
+    candidate[11] = 0.0
+    candidate[16] = 0.0
+    candidate[17] = 0.0
+    candidate[20] = 0.0
+    candidate[23] = 100.0
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+    ).run(np.asarray([candidate + candidate], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    # Long: the 100.4 touch makes a reducer at 101 and rebuilt grid at 100;
+    # high=100.5 reaches only the grid.  Short is the mirror image: reducer
+    # 100, grid 101, low=100.5.  The residual grid quantity therefore closes
+    # while the reducer-sized half remains open.
+    assert output[size_key].item() == pytest.approx(5.05, abs=0.1)
+    assert 1.0 < output["day_volume"].sum().item() < 2.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_small_excess_reducer_crosses_strict_target(side):
+    count = 6
+    entry_price = 99.0 if side == "long" else 101.0
+    close = np.array([100.0, 100.0, 100.0, entry_price, entry_price, entry_price])
+    high = np.array([100.0, 100.0, 100.0, 102.0, 102.0, 102.0])
+    low = np.array([100.0, 100.0, 100.0, 98.0, 98.0, 98.0])
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(1.0e-8, 1.0, 1.0e-8, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    target = 0.99999
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    candidate = _tm_single_row(
+        wel_enforcer_enabled=True, wel_enforcer_threshold=target
+    )
+    candidate[6] = 1.0
+    candidate[7] = 10.0
+    candidate[11] = 0.0
+    candidate[20] = 0.001
+    candidate[23] = 100.0
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+    ).run(np.asarray([candidate + candidate], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    pprice_key = "pprice" if side == "long" else "short_pprice"
+    exposure = (
+        output[size_key].item()
+        * output[pprice_key].item()
+        / output["balance"].item()
+    )
+    assert output[size_key].item() > 0.0
+    assert exposure < target
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_tm_same_tick_reducer_and_grid_merge_before_volume(side):
     count = 6
     close = np.full(count, 100.0)
@@ -1377,6 +1484,132 @@ def test_mps_tm_multicoin_reducer_retains_reachable_post_repair_grid(side):
     assert sizes[0] > 0.0
     assert sizes[1] == pytest.approx(0.0)
     assert volumes[1] > volumes[0]
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_grid_can_fill_without_off_tick_reducer(side):
+    count = 6
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    generation_touch = 100.4 if side == "long" else 100.6
+    hlcvs = np.zeros((count, 2, 4), dtype=np.float64)
+    hlcvs[:, 0, 0] = [100.0, 100.0, 100.0, 102.0, 100.5, 100.0]
+    hlcvs[:, 0, 1] = [100.0, 100.0, 100.0, 98.0, 100.5, 100.0]
+    hlcvs[:, 0, 2] = [100.0, 100.0, 100.0, generation_touch, 100.0, 100.0]
+    hlcvs[:, 0, 3] = 100.0
+    hlcvs[:, 1, 0] = 121.0
+    hlcvs[:, 1, 1] = 119.0
+    hlcvs[:, 1, 2] = 120.0
+    hlcvs[:, 1, 3] = 100.0
+    market = ProxyMarket(0.001, 1.0, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_multicoin_data(
+        hlcvs, timestamps, [run, run], [market, market]
+    )
+    _, row = _multicoin_exposure_fixture(
+        "trailing_martingale", side, count=count
+    )
+    values = dict(zip(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, row))
+    values.update(
+        {
+            "entry_initial_ema_dist": 0.01,
+            "entry_cooldown_minutes": 100.0,
+            "gate_initial": 1.0,
+            "n_positions": 1.0,
+            "close_threshold_base_pct": 0.0,
+            "close_threshold_we_weight": 0.0,
+            "wel_enforcer_enabled": 1.0,
+            "wel_enforcer_threshold": 0.5,
+        }
+    )
+    candidate = [
+        values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+    ]
+    overrides = np.full((2, 28), np.nan, dtype=np.float32)
+    overrides[1, 24] = 0.0
+    output = MpsTrailingMartingaleMulticoinRunner(
+        run, data, side=side, coin_overrides=overrides
+    ).run(np.asarray([candidate], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    assert output[size_key].item() == pytest.approx(5.0, abs=0.1)
+    assert 1.0 < output["day_volume"].sum().item() < 2.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_small_excess_reducer_crosses_strict_target(side):
+    count = 6
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    hlcvs = np.zeros((count, 2, 4), dtype=np.float64)
+    hlcvs[:, 0, 0] = [100.0, 100.0, 100.0, 101.0, 101.0, 101.0]
+    hlcvs[:, 0, 1] = [100.0, 100.0, 100.0, 99.0, 99.0, 99.0]
+    hlcvs[:, 0, 2] = 100.0
+    hlcvs[:, 0, 3] = 100.0
+    hlcvs[:, 1, 0] = 121.0
+    hlcvs[:, 1, 1] = 119.0
+    hlcvs[:, 1, 2] = 120.0
+    hlcvs[:, 1, 3] = 100.0
+    market = ProxyMarket(1.0e-8, 1.0, 1.0e-8, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_multicoin_data(
+        hlcvs, timestamps, [run, run], [market, market]
+    )
+    _, row = _multicoin_exposure_fixture(
+        "trailing_martingale", side, count=count
+    )
+    target = 0.99999
+    values = dict(zip(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, row))
+    values.update(
+        {
+            "entry_cooldown_minutes": 100.0,
+            "n_positions": 1.0,
+            "close_retracement_base_pct": 0.001,
+            "wel_enforcer_enabled": 1.0,
+            "wel_enforcer_threshold": target,
+        }
+    )
+    candidate = [
+        values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+    ]
+    overrides = np.full((2, 28), np.nan, dtype=np.float32)
+    overrides[1, 24] = 0.0
+    output = MpsTrailingMartingaleMulticoinRunner(
+        run, data, side=side, coin_overrides=overrides
+    ).run(np.asarray([candidate], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    exposure = output[size_key].item() * 100.0 / output["balance"].item()
+    assert output[size_key].item() > 0.0
+    assert exposure < target
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -1248,6 +1248,70 @@ def test_mps_tm_position_reducer_reachability_survives_grid_pruning(side):
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_same_tick_reducer_and_grid_merge_before_volume(side):
+    count = 6
+    close = np.full(count, 100.0)
+    high = np.full(count, 102.0)
+    low = np.full(count, 98.0)
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.001)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    candidate = _tm_single_row(
+        wel_enforcer_enabled=True, wel_enforcer_threshold=0.5
+    )
+    candidate[6] = 1.0
+    candidate[7] = 10.0
+    candidate[11] = 0.0
+    candidate[16] = 0.0
+    candidate[17] = 0.0
+    candidate[20] = 0.0
+    candidate[23] = 100.0
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+    ).run(np.asarray([candidate + candidate], dtype=np.float64))
+    torch.mps.synchronize()
+
+    # The initial EMA band places the long at 99 and the short at 101.  Qty is
+    # cropped to one wallet exposure at those prices.  The reducer and the
+    # reconstructed close grid both land at 100, so exact Rust executes their
+    # combined quantity as one fill with one post-fill volume denominator.
+    entry_price = 99.0 if side == "long" else 101.0
+    entry_qty = 10.101 if side == "long" else 9.901
+    balance_after_entry = 1_000.0 - entry_qty * entry_price * 0.001
+    pnl = entry_qty * (
+        100.0 - entry_price if side == "long" else entry_price - 100.0
+    )
+    balance_after_close = balance_after_entry + pnl - entry_qty * 100.0 * 0.001
+    expected_volume = entry_qty * entry_price / balance_after_entry
+    expected_volume += entry_qty * 100.0 / balance_after_close
+    assert output["balance"].item() == pytest.approx(
+        balance_after_close, abs=2.0e-4
+    )
+    assert output["day_volume"].sum().item() == pytest.approx(
+        expected_volume, rel=2.0e-5
+    )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_tm_multicoin_global_position_exposure_repair(side):
     runner, baseline = _multicoin_exposure_fixture(
         "trailing_martingale", side, count=10
@@ -1423,6 +1487,54 @@ def test_mps_tm_multicoin_post_repair_grid_volume_uses_per_fill_balance(side):
     expected_volume += second_reducer_qty * reducer_price / balance_1
     expected_volume += grid_qty * grid_price / balance_2
 
+    assert output["day_volume"].sum().item() == pytest.approx(
+        expected_volume, rel=2.0e-5
+    )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_same_tick_reducer_and_grid_merge_before_volume(side):
+    markets = [
+        ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.001),
+        ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.001),
+    ]
+    runner, row = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        side,
+        count=6,
+        markets=markets,
+        closes=(100.0, 100.0),
+    )
+    values = dict(zip(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, row))
+    values.update(
+        {
+            "entry_cooldown_minutes": 100.0,
+            "close_threshold_base_pct": 0.0,
+            "close_threshold_we_weight": 0.0,
+            "wel_enforcer_enabled": 1.0,
+            "wel_enforcer_threshold": 0.5,
+        }
+    )
+    candidate = [
+        values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+    ]
+    output = runner.run(np.asarray([candidate], dtype=np.float64))
+    torch.mps.synchronize()
+
+    balance_after_first_entry = 999.5
+    balance_after_second_entry = 999.0001
+    balance_after_first_close = 998.5001
+    balance_after_second_close = 998.0002
+    expected_volume = 500.0 / balance_after_first_entry
+    expected_volume += 499.9 / balance_after_second_entry
+    expected_volume += 500.0 / balance_after_first_close
+    expected_volume += 499.9 / balance_after_second_close
+    assert output["balance"].item() == pytest.approx(
+        balance_after_second_close, abs=3.0e-4
+    )
     assert output["day_volume"].sum().item() == pytest.approx(
         expected_volume, rel=2.0e-5
     )

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -1301,6 +1301,130 @@ def test_mps_tm_grid_can_fill_without_off_tick_reducer(side):
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_off_tick_grid_precedes_reducer_for_volume(side):
+    count = 6
+    generation_touch = 100.4 if side == "long" else 100.6
+    close = np.array([100.0, 100.0, 100.0, generation_touch, 100.0, 100.0])
+    high = np.array([100.0, 100.0, 100.0, 102.0, 101.5, 100.0])
+    low = np.array([100.0, 100.0, 100.0, 98.0, 99.5, 100.0])
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 1.0, 0.001, 0.0, 1.0, 0.001)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    candidate = _tm_single_row(
+        wel_enforcer_enabled=True, wel_enforcer_threshold=0.5
+    )
+    candidate[6] = 1.0
+    candidate[7] = 10.0
+    candidate[11] = 0.0
+    candidate[16] = 0.0
+    candidate[17] = 0.0
+    candidate[20] = 0.0
+    candidate[23] = 100.0
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+    ).run(np.asarray([candidate + candidate], dtype=np.float64))
+    torch.mps.synchronize()
+
+    entry_price = 99.0 if side == "long" else 101.0
+    entry_qty = 10.101 if side == "long" else 9.901
+    grid_price = 100.0 if side == "long" else 101.0
+    grid_qty = 5.045 if side == "long" else 4.945
+    reducer_price = 101.0 if side == "long" else 100.0
+    reducer_qty = entry_qty - grid_qty
+    balance = 1_000.0 - entry_qty * entry_price * market.maker_fee
+    expected_volume = entry_qty * entry_price / balance
+    grid_pnl = grid_qty * (
+        grid_price - entry_price if side == "long" else entry_price - grid_price
+    )
+    balance += grid_pnl - grid_qty * grid_price * market.maker_fee
+    expected_volume += grid_qty * grid_price / balance
+    reducer_pnl = reducer_qty * (
+        reducer_price - entry_price
+        if side == "long"
+        else entry_price - reducer_price
+    )
+    balance += reducer_pnl - reducer_qty * reducer_price * market.maker_fee
+    expected_volume += reducer_qty * reducer_price / balance
+
+    assert output["balance"].item() == pytest.approx(balance, abs=3.0e-4)
+    assert output["day_volume"].sum().item() == pytest.approx(
+        expected_volume, rel=2.0e-5
+    )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_reducer_consumes_one_recursive_close_slot(side):
+    count = 6
+    generation_touch = 100.4 if side == "long" else 100.6
+    close = np.array([100.0, 100.0, 100.0, generation_touch, 100.0, 100.0])
+    high = np.array([100.0, 100.0, 100.0, 102.0, 101.5, 100.0])
+    low = np.array([100.0, 100.0, 100.0, 98.0, 99.5, 100.0])
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 1.0, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    candidate = _tm_single_row(
+        wel_enforcer_enabled=True, wel_enforcer_threshold=0.5
+    )
+    candidate[6] = 1.0
+    candidate[7] = 10.0
+    candidate[11] = 0.0
+    candidate[15] = 0.0001
+    candidate[16] = 0.0
+    candidate[17] = 1.0e-6
+    candidate[20] = 0.0
+    candidate[23] = 100.0
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+    ).run(np.asarray([candidate + candidate], dtype=np.float64))
+    torch.mps.synchronize()
+
+    # One reducer plus 499 ordinary closes exhausts Rust's shared 500-order
+    # generation loop.  A fresh 500-rung proxy loop would remove one extra
+    # quantity step here.
+    expected_size = 4.052 if side == "long" else 4.451
+    size_key = "psize" if side == "long" else "short_psize"
+    assert output[size_key].item() == pytest.approx(expected_size, abs=2.0e-4)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_tm_small_excess_reducer_crosses_strict_target(side):
     count = 6
     entry_price = 99.0 if side == "long" else 101.0
@@ -1413,6 +1537,127 @@ def test_mps_tm_same_tick_reducer_and_grid_merge_before_volume(side):
     assert output["day_volume"].sum().item() == pytest.approx(
         expected_volume, rel=2.0e-5
     )
+
+
+def _tm_multicoin_off_tick_reducer_case(
+    side, *, maker_fee, close_qty_pct=1.0, close_threshold_we=0.0
+):
+    count = 6
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    generation_touch = 100.4 if side == "long" else 100.6
+    hlcvs = np.zeros((count, 2, 4), dtype=np.float64)
+    hlcvs[:, 0, 0] = [100.0, 100.0, 100.0, 102.0, 101.5, 100.0]
+    hlcvs[:, 0, 1] = [100.0, 100.0, 100.0, 98.0, 99.5, 100.0]
+    hlcvs[:, 0, 2] = [100.0, 100.0, 100.0, generation_touch, 100.0, 100.0]
+    hlcvs[:, 0, 3] = 100.0
+    hlcvs[:, 1, 0] = 121.0
+    hlcvs[:, 1, 1] = 119.0
+    hlcvs[:, 1, 2] = 120.0
+    hlcvs[:, 1, 3] = 100.0
+    market = ProxyMarket(0.001, 1.0, 0.001, 0.0, 1.0, maker_fee)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_multicoin_data(
+        hlcvs, timestamps, [run, run], [market, market]
+    )
+    _, row = _multicoin_exposure_fixture(
+        "trailing_martingale", side, count=count
+    )
+    values = dict(zip(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, row))
+    values.update(
+        {
+            "entry_initial_ema_dist": 0.01,
+            "entry_initial_qty_pct": 1.0,
+            "entry_threshold_base_pct": 10.0,
+            "entry_retracement_base_pct": 0.0,
+            "entry_cooldown_minutes": 100.0,
+            "gate_initial": 1.0,
+            "n_positions": 1.0,
+            "close_qty_pct": close_qty_pct,
+            "close_threshold_base_pct": 0.0,
+            "close_threshold_we_weight": close_threshold_we,
+            "close_retracement_base_pct": 0.0,
+            "wel_enforcer_enabled": 1.0,
+            "wel_enforcer_threshold": 0.5,
+        }
+    )
+    candidate = [
+        values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+    ]
+    overrides = np.full((2, 28), np.nan, dtype=np.float32)
+    overrides[1, 24] = 0.0
+    runner = MpsTrailingMartingaleMulticoinRunner(
+        run, data, side=side, coin_overrides=overrides
+    )
+    return runner, candidate, market
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_off_tick_grid_precedes_reducer_for_volume(side):
+    runner, candidate, market = _tm_multicoin_off_tick_reducer_case(
+        side, maker_fee=0.001
+    )
+    output = runner.run(np.asarray([candidate], dtype=np.float64))
+    torch.mps.synchronize()
+
+    entry_price = 99.0 if side == "long" else 101.0
+    # Multicoin's shared total-entry headroom floors the short by one step.
+    entry_qty = 10.101 if side == "long" else 9.9
+    grid_price = 100.0 if side == "long" else 101.0
+    grid_qty = 5.045 if side == "long" else 4.945
+    reducer_price = 101.0 if side == "long" else 100.0
+    reducer_qty = entry_qty - grid_qty
+    balance = 1_000.0 - entry_qty * entry_price * market.maker_fee
+    expected_volume = entry_qty * entry_price / balance
+    grid_pnl = grid_qty * (
+        grid_price - entry_price if side == "long" else entry_price - grid_price
+    )
+    balance += grid_pnl - grid_qty * grid_price * market.maker_fee
+    expected_volume += grid_qty * grid_price / balance
+    reducer_pnl = reducer_qty * (
+        reducer_price - entry_price
+        if side == "long"
+        else entry_price - reducer_price
+    )
+    balance += reducer_pnl - reducer_qty * reducer_price * market.maker_fee
+    expected_volume += reducer_qty * reducer_price / balance
+
+    assert output["balance"].item() == pytest.approx(balance, abs=3.0e-4)
+    assert output["day_volume"].sum().item() == pytest.approx(
+        expected_volume, rel=2.0e-5
+    )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_reducer_consumes_one_recursive_close_slot(side):
+    runner, candidate, _ = _tm_multicoin_off_tick_reducer_case(
+        side,
+        maker_fee=0.0,
+        close_qty_pct=0.0001,
+        close_threshold_we=1.0e-6,
+    )
+    output = runner.run(np.asarray([candidate], dtype=np.float64))
+    torch.mps.synchronize()
+
+    expected_size = 4.052 if side == "long" else 4.451
+    size_key = "psize" if side == "long" else "short_psize"
+    assert output[size_key].item() == pytest.approx(expected_size, abs=2.0e-4)
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -32,6 +32,10 @@ def _single_coin_exposure_fields(
     ]
 
 
+def _tm_wel_enforcer_fields(*, enabled=False, threshold=1.0):
+    return [float(enabled), threshold]
+
+
 def _multicoin_exposure_fixture(
     strategy_kind,
     side,
@@ -140,6 +144,8 @@ def _multicoin_exposure_fixture(
             "we_excess_allowance_legacy_raw": 0.0,
             "twel_entry_gate_enabled": 1.0,
             "twel_enforcer_threshold": 1.0,
+            "wel_enforcer_enabled": 0.0,
+            "wel_enforcer_threshold": 1.0,
         }
         row = [values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS]
         runner = MpsTrailingMartingaleMulticoinRunner(
@@ -497,13 +503,13 @@ def test_mps_trailing_martingale_multicoin_directional_shader_smoke(side):
 
     source = passivbot_rust.mps_trailing_martingale_multicoin_source_py()
     assert "kernel void passivbot_trailing_martingale_multicoin" in source
-    assert "constant int PARAM_COLS = 38" in source
+    assert "constant int PARAM_COLS = 40" in source
     assert "effective_n_positions" in source
     assert "min_since_open" in source
     assert "entry_retracement_base" in source
     assert "close_retracement_base" in source
     assert "as_type<float>(touch_min_qty_bits[k * C + c])" in source
-    assert "constant int OVERRIDE_COLS = 26" in source
+    assert "constant int OVERRIDE_COLS = 28" in source
     assert "allowed_wallet_exposure_limit" in source
     assert "twel_entry_gate_enabled" in source
     assert "coin_override_or" in source
@@ -582,6 +588,8 @@ def test_mps_trailing_martingale_multicoin_directional_shader_smoke(side):
         "we_excess_allowance_legacy_raw": 0.0,
         "twel_entry_gate_enabled": 1.0,
         "twel_enforcer_threshold": 1.0,
+        "wel_enforcer_enabled": 0.0,
+        "wel_enforcer_threshold": 1.0,
     }
     row = [values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS]
 
@@ -596,7 +604,7 @@ def test_mps_trailing_martingale_multicoin_directional_shader_smoke(side):
     assert output["day_has_fill"].sum().item() > 0
     assert (output["open_positions"] <= 2.0).all()
 
-    disabled = np.full((coin_count, 26), np.nan, dtype=np.float32)
+    disabled = np.full((coin_count, 28), np.nan, dtype=np.float32)
     disabled[:, 24] = 0.0
     disabled_output = MpsTrailingMartingaleMulticoinRunner(
         runs[0], data, side=side, coin_overrides=disabled
@@ -605,7 +613,7 @@ def test_mps_trailing_martingale_multicoin_directional_shader_smoke(side):
     assert disabled_output["day_has_fill"].sum().item() == 0
     assert disabled_output["open_positions"].item() == 0.0
 
-    exact_last = np.full((coin_count, 26), np.nan, dtype=np.float32)
+    exact_last = np.full((coin_count, 28), np.nan, dtype=np.float32)
     exact_last[:, :25] = np.asarray(row[:25], dtype=np.float32)
     changed_candidate = list(row)
     changed_candidate[:25] = [
@@ -681,7 +689,7 @@ def test_mps_multicoin_legacy_raw_allowance_with_gate_disabled_expands_volume(
 )
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
 def test_mps_multicoin_coin_override_allowance_expands_one_symbol(strategy_kind):
-    override_cols = 13 if strategy_kind == "ema_anchor" else 26
+    override_cols = 13 if strategy_kind == "ema_anchor" else 28
     allowance_column = 12 if strategy_kind == "ema_anchor" else 25
     overrides = np.full((2, override_cols), np.nan, dtype=np.float32)
     overrides[0, allowance_column] = 1.0
@@ -740,7 +748,7 @@ def test_mps_multicoin_twel_threshold_reduces_entry_volume(strategy_kind):
 def test_mps_multicoin_equal_distance_twel_tie_keeps_higher_coin_index(
     strategy_kind,
 ):
-    override_cols = 13 if strategy_kind == "ema_anchor" else 26
+    override_cols = 13 if strategy_kind == "ema_anchor" else 28
     wallet_exposure_column = 11 if strategy_kind == "ema_anchor" else 24
     overrides = np.full((2, override_cols), np.nan, dtype=np.float32)
     overrides[0, wallet_exposure_column] = 0.4
@@ -1017,6 +1025,8 @@ def _tm_single_row(
     legacy_raw=False,
     entry_gate=True,
     threshold=1.0,
+    wel_enforcer_enabled=False,
+    wel_enforcer_threshold=1.0,
 ):
     return _tm_row(
         initial_ema_dist=initial_ema_dist,
@@ -1027,6 +1037,9 @@ def _tm_single_row(
         legacy_raw=legacy_raw,
         entry_gate=entry_gate,
         threshold=threshold,
+    ) + _tm_wel_enforcer_fields(
+        enabled=wel_enforcer_enabled,
+        threshold=wel_enforcer_threshold,
     )
 
 
@@ -1072,7 +1085,7 @@ def test_mps_single_coin_exposure_headroom_and_entry_gate(
                 gate_reentry=1.0,
             )
             values[6] = 1.0
-            return values + exposure
+            return values + exposure + _tm_wel_enforcer_fields()
         values = [
             1.0,
             2.0,
@@ -1117,6 +1130,128 @@ def test_mps_single_coin_exposure_headroom_and_entry_gate(
     assert sizes[0] > 0.0
     assert sizes[1] > sizes[0] * 1.4
     assert sizes[2] < sizes[0] * 0.6
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_position_exposure_repair_reduces_strictly_below_target(side):
+    count = 10
+    close = np.full(count, 100.0)
+    high = np.full(count, 102.0)
+    low = np.full(count, 98.0)
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    baseline = _tm_single_row()
+    baseline[6] = 1.0
+    baseline[7] = 10.0
+    baseline[11] = 0.0
+    baseline[16] = 10.0
+    baseline[20] = 0.0
+    repaired = list(baseline)
+    repaired[-2:] = _tm_wel_enforcer_fields(enabled=True, threshold=0.5)
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+    ).run(
+        np.asarray(
+            [baseline + baseline, repaired + repaired], dtype=np.float64
+        )
+    )
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    sizes = output[size_key].cpu().numpy()
+    assert sizes[0] > 9.0
+    repaired_we = (
+        sizes[1]
+        * output["pprice" if side == "long" else "short_pprice"][1].item()
+        / output["balance"][1].item()
+    )
+    assert 0.0 < sizes[1] < sizes[0]
+    assert 0.45 < repaired_we < 0.5
+    assert (
+        output["day_volume"][1].sum().item()
+        > output["day_volume"][0].sum().item()
+    )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_global_position_exposure_repair(side):
+    runner, baseline = _multicoin_exposure_fixture(
+        "trailing_martingale", side, count=10
+    )
+    repaired = list(baseline)
+    repaired[
+        TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index("wel_enforcer_enabled")
+    ] = 1.0
+    repaired[
+        TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index("wel_enforcer_threshold")
+    ] = 0.5
+    output = runner.run(np.asarray([baseline, repaired], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    sizes = output[size_key].cpu().numpy()
+    assert 0.0 < sizes[1] < sizes[0]
+    assert (
+        output["day_volume"][1].sum().item()
+        > output["day_volume"][0].sum().item()
+    )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_static_override_repairs_only_selected_symbol(side):
+    overrides = np.full((2, 28), np.nan, dtype=np.float32)
+    overrides[0, 26] = 1.0
+    overrides[0, 27] = 0.5
+    baseline_runner, baseline = _multicoin_exposure_fixture(
+        "trailing_martingale", side, count=10
+    )
+    override_runner, overridden = _multicoin_exposure_fixture(
+        "trailing_martingale", side, overrides, count=10
+    )
+    baseline_output = baseline_runner.run(
+        np.asarray([baseline], dtype=np.float64)
+    )
+    override_output = override_runner.run(
+        np.asarray([overridden], dtype=np.float64)
+    )
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    assert (
+        0.0
+        < override_output[size_key].item()
+        < baseline_output[size_key].item()
+    )
+    assert (
+        override_output["day_volume"].sum().item()
+        > baseline_output["day_volume"].sum().item()
+    )
 
 
 @pytest.mark.skipif(
@@ -1445,6 +1580,7 @@ def test_mps_trailing_martingale_multicoin_sizes_raw_touch_close_before_price_fi
         ]
     )
     row.extend(_single_coin_exposure_fields())
+    row.extend(_tm_wel_enforcer_fields())
 
     output = MpsTrailingMartingaleMulticoinRunner(
         runs[0], data, side=side
@@ -1473,7 +1609,7 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
 
     source = passivbot_rust.mps_trailing_martingale_source_py()
     assert "kernel void passivbot_trailing_martingale" in source
-    assert "constant int SIDE_PARAMS = 31" in source
+    assert "constant int SIDE_PARAMS = 33" in source
     assert "s.allowed_wel" in source
     assert "s.entry_cap" in source
     assert "min_since_open" in source

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -1318,6 +1318,119 @@ def test_mps_tm_multicoin_reducer_retains_reachable_post_repair_grid(side):
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+def test_mps_tm_multicoin_short_post_repair_grid_uses_negative_target_tick():
+    count = 6
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    hlcvs = np.zeros((count, 2, 4), dtype=np.float64)
+    hlcvs[:, 0, 0] = [100.0, 100.0, 100.0, 102.5, 103.0, 103.0]
+    hlcvs[:, 0, 1] = [100.0, 100.0, 100.0, 99.0, 101.5, 101.5]
+    hlcvs[:, 0, 2] = [100.0, 100.0, 100.0, 102.0, 102.0, 102.0]
+    hlcvs[:, 0, 3] = 100.0
+    hlcvs[:, 1, 0] = 121.0
+    hlcvs[:, 1, 1] = 119.0
+    hlcvs[:, 1, 2] = 120.0
+    hlcvs[:, 1, 3] = 100.0
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_multicoin_data(
+        hlcvs, timestamps, [run, run], [market, market]
+    )
+    _, row = _multicoin_exposure_fixture(
+        "trailing_martingale", "short", count=count
+    )
+    values = dict(zip(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, row))
+    values.update(
+        {
+            "entry_cooldown_minutes": 100.0,
+            "n_positions": 1.0,
+            "close_threshold_base_pct": -0.01,
+            "close_threshold_we_weight": 0.0,
+            "wel_enforcer_enabled": 1.0,
+            "wel_enforcer_threshold": 0.5,
+        }
+    )
+    candidate = [
+        values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+    ]
+    overrides = np.full((2, 28), np.nan, dtype=np.float32)
+    overrides[1, 24] = 0.0
+    output = MpsTrailingMartingaleMulticoinRunner(
+        run, data, side="short", coin_overrides=overrides
+    ).run(np.asarray([candidate], dtype=np.float64))
+    torch.mps.synchronize()
+
+    # The reducer at the 102 bid fills, while Rust's 101 target grid order
+    # remains below the next candle's 101.5 low and must not fill.
+    assert output["short_psize"].item() == pytest.approx(4.999, abs=0.002)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_post_repair_grid_volume_uses_per_fill_balance(side):
+    markets = [
+        ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0),
+        ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0),
+    ]
+    runner, row = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        side,
+        count=6,
+        markets=markets,
+        closes=(100.0, 100.0),
+    )
+    values = dict(zip(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, row))
+    values.update(
+        {
+            "entry_cooldown_minutes": 100.0,
+            "close_threshold_base_pct": 0.009,
+            "close_threshold_we_weight": 0.0,
+            "wel_enforcer_enabled": 1.0,
+            "wel_enforcer_threshold": 0.5,
+        }
+    )
+    candidate = [
+        values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+    ]
+    output = runner.run(np.asarray([candidate], dtype=np.float64))
+    torch.mps.synchronize()
+
+    first_reducer_qty = 2.501
+    second_reducer_qty = 2.5
+    grid_qty = 2.499
+    reducer_price = 100.0
+    grid_price = 100.9 if side == "long" else 99.1
+    grid_pnl = grid_qty * abs(grid_price - 100.0)
+    balance_0 = 1_000.0
+    balance_1 = balance_0 + grid_pnl
+    balance_2 = balance_1 + grid_pnl
+    # Total-entry headroom clips the second exact-0.5-WEL entry by one step.
+    expected_volume = 0.5 + 0.4999
+    expected_volume += first_reducer_qty * reducer_price / balance_0
+    expected_volume += grid_qty * grid_price / balance_1
+    expected_volume += second_reducer_qty * reducer_price / balance_1
+    expected_volume += grid_qty * grid_price / balance_2
+
+    assert output["day_volume"].sum().item() == pytest.approx(
+        expected_volume, rel=2.0e-5
+    )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 @pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_tm_multicoin_static_override_repairs_only_selected_symbol(side):
     overrides = np.full((2, 28), np.nan, dtype=np.float32)

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -18,6 +18,7 @@ from optimization.gpu.service import (
     _build_multicoin_ema_coin_overrides,
     _build_multicoin_tm_coin_overrides,
     _combine_hedged_multicoin_outputs,
+    _position_exposure_enforcer_params,
     _require_complete_valid_tail,
     _single_coin_exposure_params,
 )
@@ -56,6 +57,28 @@ def test_single_coin_exposure_policy_rejects_unknown_allowance_mode():
     with pytest.raises(ValueError, match="we_excess_allowance_mode"):
         _single_coin_exposure_params(
             {"we_excess_allowance_mode": "raw"}, side="short"
+        )
+
+
+def test_tm_position_exposure_repair_packs_exact_rust_inputs():
+    assert _position_exposure_enforcer_params(
+        {
+            "position_exposure_enforcer_enabled": True,
+            "position_exposure_enforcer_threshold": 0.8,
+        },
+        side="short",
+    ) == {
+        "wel_enforcer_enabled": 1.0,
+        "wel_enforcer_threshold": 0.8,
+    }
+
+    with pytest.raises(ValueError, match="finite positive"):
+        _position_exposure_enforcer_params(
+            {
+                "position_exposure_enforcer_enabled": True,
+                "position_exposure_enforcer_threshold": 0.0,
+            },
+            side="long",
         )
 
 
@@ -543,6 +566,8 @@ def test_multicoin_tm_coin_overrides_pack_only_explicit_exact_values():
                     "total_wallet_exposure_limit": 1.0,
                     "wallet_exposure_limit": 0.4,
                     "risk_we_excess_allowance_pct": 0.25,
+                    "risk_wel_enforcer_enabled": True,
+                    "risk_wel_enforcer_threshold": 0.8,
                 }
             },
         ],
@@ -561,6 +586,8 @@ def test_multicoin_tm_coin_overrides_pack_only_explicit_exact_values():
                         "risk": {
                             "entry_cooldown_minutes": 15.0,
                             "we_excess_allowance_pct": 0.25,
+                            "position_exposure_enforcer_enabled": True,
+                            "position_exposure_enforcer_threshold": 0.8,
                         },
                         "wallet_exposure_limit": 0.4,
                     }
@@ -581,14 +608,16 @@ def test_multicoin_tm_coin_overrides_pack_only_explicit_exact_values():
         ].get(coin, {}),
     )
 
-    assert matrix.shape == (2, 26)
+    assert matrix.shape == (2, 28)
     assert np.isnan(matrix[0]).all()
     assert matrix[1, 7] == pytest.approx(0.25)
     assert matrix[1, 15] == pytest.approx(0.5)
     assert matrix[1, 23] == pytest.approx(15.0)
     assert matrix[1, 24] == pytest.approx(0.4)
     assert matrix[1, 25] == pytest.approx(0.25)
-    assert contract["values"][0] == [None] * 26
+    assert matrix[1, 26] == pytest.approx(1.0)
+    assert matrix[1, 27] == pytest.approx(0.8)
+    assert contract["values"][0] == [None] * 28
 
 
 def test_trailing_parameter_matrix_keeps_nested_flattened_sides_separate():


### PR DESCRIPTION
Summary:
- model Trailing Martingale per-position exposure repair in the single- and multi-coin Metal proxies for long, short, dual-side, and suite-compatible runs
- preserve exact Rust precedence, passive pricing, strict below-target sizing, tunable thresholds, and static per-coin enable/threshold overrides
- keep EMA Anchor position repair and side-wide total-exposure repair fail closed; document the supported boundary

Validation:
- 262 Rust tests passed with no default features
- cargo check with tests and cargo fmt check passed
- full Python suite passed
- 72 real Apple MPS tests passed on this M3 MacBook Air
- focused single/multi, long/short, global/per-coin reducer regressions passed on real MPS
- extension source fingerprint verified after rebuild
- end-to-end ETH long-only MPS optimization over 68 days completed: 1,024 proxy evaluations, 16 exact Rust validations, 8 generations, no optimizer halt; Pareto configs persisted enabled repair with optimized thresholds

Scope:
- GPU-only additive path; CPU optimization, backtesting, and bot operation are unchanged
- exact Rust results remain authoritative through existing feasibility, rank, and drift gates