### PR TITLE
Fix GPU optimizer Ctrl+C shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- GPU optimization now latches Ctrl+C received during a native Metal dispatch,
+  stops before another generation or exact-validation submission, saves a
+  resumable checkpoint, and then cleans up optimizer workers and shared memory.
+
 - Added Trailing Martingale per-position exposure repair to the Apple MPS optimizer for single- and
   multi-coin long-only, short-only, dual-side, and compatible suite runs. The Metal proxy models
   the canonical enable toggle and tunable threshold, gives the passive repair close precedence

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -72,6 +72,25 @@ _EMA_SIDE_BOUND_SUFFIXES = {
     "total_wallet_exposure_limit": "total_wallet_exposure_limit",
 }
 
+
+def _ask_gpu_population(algorithm, interrupt_check: InterruptCheck):
+    """Start an ask/tell transaction only when shutdown has not been requested."""
+
+    interrupt_check()
+    return algorithm.ask()
+
+
+def _submit_gpu_exact_validation(
+    pool,
+    vector,
+    interrupt_check: InterruptCheck,
+):
+    """Refuse new exact CPU work once the GPU interrupt latch is set."""
+
+    interrupt_check()
+    return pool.apply_async(_evaluate_pymoo_worker_from_globals, (vector,))
+
+
 _SINGLE_COIN_EXPOSURE_BOUND_SUFFIXES = {
     "risk_we_excess_allowance_pct": "we_excess_allowance_pct",
     "risk_twel_enforcer_threshold": "twel_enforcer_threshold",
@@ -2676,10 +2695,6 @@ def run_backend(
         def evaluate_proxy(candidates):
             return proxy.evaluate(candidates)
 
-    def evaluate_proxy_interruptibly(candidates):
-        interrupt_check()
-        return evaluate_proxy(candidates)
-
     active_low = np.asarray(
         [bound.low for _name, _index, bound in active], dtype=np.float64
     )
@@ -3075,9 +3090,11 @@ def run_backend(
                 consume_ready(wait_for_one=True)
                 continue
 
-            population = algorithm.ask()
+            # Do not poll the latch again until the matching tell() completes;
+            # checkpointing an interrupted ask/tell transaction is not safe.
+            population = _ask_gpu_population(algorithm, interrupt_check)
             rows = np.asarray(population.get("X"), dtype=np.float64)
-            metric_rows = evaluate_proxy_interruptibly(parameter_dicts(rows))
+            metric_rows = evaluate_proxy(parameter_dicts(rows))
             proxy_objectives, proxy_violations = proxy_fitness(metric_rows)
             proxy_evaluations += len(rows)
             if objective_scale.median is None:
@@ -3128,8 +3145,10 @@ def run_backend(
             )
             submitted_this_generation = 0
             for index, is_probe, is_proxy_front, vector, digest in novel_selections:
-                result = pool.apply_async(
-                    _evaluate_pymoo_worker_from_globals, (vector,)
+                result = _submit_gpu_exact_validation(
+                    pool,
+                    vector,
+                    interrupt_check,
                 )
                 pending[result] = (
                     vector,

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -18,11 +18,19 @@ import numpy as np
 from config.metrics import resolve_metric_value
 from limit_utils import compute_limit_violation
 from metrics_schema import flatten_metric_stats
-from optimization.backend_shared import load_starting_individuals
+from optimization.backend_shared import (
+    cancel_pending_async_results,
+    load_starting_individuals,
+)
 from optimization.bounds import Bound, enforce_bounds
 from optimization.callback import build_pymoo_record_entry
 from optimization.fine_tune_anchors import ANCHOR_GENE_KEY, get_anchor_plan
 from optimization.gpu.model import gpu_side_enabled
+from optimization.interrupts import (
+    InterruptCheck,
+    OptimizerBackendInterrupted,
+    no_interrupt_requested,
+)
 from optimization.problem import (
     PymooAsyncRecordingRunner,
     PymooEvaluatorAdapter,
@@ -2284,6 +2292,7 @@ def run_backend(
     overrides_fn=None,
     checkpoint_path: str | None = None,
     resume: bool = False,
+    interrupt_check: InterruptCheck | None = None,
 ) -> dict[str, Any]:
     del duplicate_counter
     del constraint_fitness_cls
@@ -2299,6 +2308,8 @@ def run_backend(
         validate_optimizer_effective_configs,
     )
 
+    interrupt_check = interrupt_check or no_interrupt_requested
+    interrupt_check()
     options = _resolve_options(config)
     logging.info("GPU optimizer options: %s", options)
     validate_optimizer_effective_configs(config)
@@ -2665,6 +2676,10 @@ def run_backend(
         def evaluate_proxy(candidates):
             return proxy.evaluate(candidates)
 
+    def evaluate_proxy_interruptibly(candidates):
+        interrupt_check()
+        return evaluate_proxy(candidates)
+
     active_low = np.asarray(
         [bound.low for _name, _index, bound in active], dtype=np.float64
     )
@@ -2968,6 +2983,7 @@ def run_backend(
     def consume_ready(*, wait_for_one: bool = False) -> None:
         nonlocal exact_done, last_warning, persisted_halt_reason
         while True:
+            interrupt_check()
             # Preserve submission/generation order in the durable evidence
             # stream. Workers may finish out of order, but later completions
             # wait behind the oldest pending result so resume guarantees match
@@ -2980,6 +2996,7 @@ def run_backend(
             PymooAsyncRecordingRunner._raise_if_pool_workers_exited(pool_workers)
             time.sleep(0.05)
         for result in ready:
+            interrupt_check()
             (
                 vector,
                 proxy_score,
@@ -3045,6 +3062,7 @@ def run_backend(
 
     try:
         while exact_done < budget:
+            interrupt_check()
             consume_ready()
             if exact_done + len(pending) >= budget:
                 consume_ready(wait_for_one=True)
@@ -3059,7 +3077,7 @@ def run_backend(
 
             population = algorithm.ask()
             rows = np.asarray(population.get("X"), dtype=np.float64)
-            metric_rows = evaluate_proxy(parameter_dicts(rows))
+            metric_rows = evaluate_proxy_interruptibly(parameter_dicts(rows))
             proxy_objectives, proxy_violations = proxy_fitness(metric_rows)
             proxy_evaluations += len(rows)
             if objective_scale.median is None:
@@ -3076,6 +3094,11 @@ def run_backend(
             )
             algorithm.tell(infills=population)
             generation += 1
+            # PyTorch MPS may consume KeyboardInterrupt while waiting for a
+            # Metal dispatch. Finish the in-progress ask/tell transaction, then
+            # honor the latched signal before exact work is submitted. This is
+            # also a safe point for serializing a resumable checkpoint.
+            interrupt_check()
 
             probe_count = _validation_probe_count(
                 validation_count,
@@ -3149,6 +3172,19 @@ def run_backend(
             time.time() - start_time,
         )
         return {"pool": pool, "pool_terminated": False}
+    except KeyboardInterrupt:
+        cancel_pending_async_results(pending)
+        try:
+            maybe_save_checkpoint(force=True)
+            logging.info(
+                "Saved GPU interrupt checkpoint | generation=%d exact=%d",
+                generation,
+                exact_done,
+            )
+        except Exception:
+            logging.exception("Failed to save GPU checkpoint during interrupt shutdown")
+        pool.terminate()
+        raise OptimizerBackendInterrupted(pool=pool, pool_terminated=True)
     except BaseException:
         pool.terminate()
         pool.join()

--- a/src/optimization/interrupts.py
+++ b/src/optimization/interrupts.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import signal
+import threading
+from types import FrameType
+from typing import Callable
+
+
+class OptimizerInterruptLatch:
+    """Latch SIGINT until optimizer code reaches a safe cancellation point.
+
+    Native runtimes such as PyTorch MPS may return normally after a SIGINT
+    delivered during a native dispatch. Remembering the signal separately
+    prevents the optimizer from silently continuing into another generation.
+    """
+
+    def __init__(self) -> None:
+        self._requested = threading.Event()
+        self._previous_handler = None
+        self._installed = False
+
+    @property
+    def requested(self) -> bool:
+        return self._requested.is_set()
+
+    def _handle_sigint(self, _signum: int, _frame: FrameType | None) -> None:
+        self._requested.set()
+
+    def raise_if_requested(self) -> None:
+        if self._requested.is_set():
+            raise KeyboardInterrupt
+
+    def install(self) -> "OptimizerInterruptLatch":
+        if threading.current_thread() is not threading.main_thread():
+            return self
+        self._previous_handler = signal.getsignal(signal.SIGINT)
+        signal.signal(signal.SIGINT, self._handle_sigint)
+        self._installed = True
+        return self
+
+    def restore(self) -> None:
+        if self._installed:
+            signal.signal(signal.SIGINT, self._previous_handler)
+            self._installed = False
+
+    def __enter__(self) -> "OptimizerInterruptLatch":
+        return self.install()
+
+    def __exit__(self, _exc_type, _exc, _traceback) -> None:
+        self.restore()
+
+
+def no_interrupt_requested() -> None:
+    """Default cancellation checkpoint for callers without a SIGINT latch."""
+
+
+InterruptCheck = Callable[[], None]
+
+
+class OptimizerBackendInterrupted(KeyboardInterrupt):
+    """Carry backend-owned resources into the CLI's common shutdown path."""
+
+    def __init__(self, *, pool, pool_terminated: bool) -> None:
+        super().__init__()
+        self.pool = pool
+        self.pool_terminated = bool(pool_terminated)

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -183,6 +183,7 @@ from optimization.bounds import (
     round_to_sig_digits,
 )
 from optimization.fine_tune_anchors import ANCHOR_GENE_KEY, ANCHOR_PLAN_KEY, get_anchor_plan
+from optimization.interrupts import OptimizerInterruptLatch
 from optimization.backend_shared import cancel_pending_async_results, stream_async_results
 from optimization.backends import get_backend_runner
 from optimization.random_seed import seed_rngs
@@ -3564,7 +3565,7 @@ async def main():
             starting_config_iter = lambda _path: iter(preselected_starting_configs)
         if get_anchor_plan(config) is not None:
             starting_config_iter = lambda _path: iter_anchored_fine_tune_seed_configs(config)
-        backend_result = backend_runner(
+        backend_kwargs = dict(
             config=config,
             evaluator=evaluator,
             evaluator_for_pool=evaluator_for_pool,
@@ -3586,12 +3587,23 @@ async def main():
             build_config_fn=individual_to_config,
             overrides_fn=optimizer_overrides,
         )
+        if backend_name == "gpu":
+            interrupt_latch = OptimizerInterruptLatch()
+            backend_kwargs["interrupt_check"] = interrupt_latch.raise_if_requested
+            with interrupt_latch:
+                backend_result = backend_runner(**backend_kwargs)
+        else:
+            backend_result = backend_runner(**backend_kwargs)
         pool = backend_result.get("pool")
         pool_terminated = backend_result.get("pool_terminated", False)
 
-    except KeyboardInterrupt:
+    except KeyboardInterrupt as exc:
         interrupted = True
         logging.info("SIGINT received; starting graceful shutdown")
+        pool = getattr(exc, "pool", pool)
+        pool_terminated = bool(
+            getattr(exc, "pool_terminated", pool_terminated)
+        )
         pool_terminated = _terminate_optimizer_pool(pool, pool_terminated)
     except Exception as e:
         failed = True

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import subprocess
 import sys
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
@@ -14,6 +15,7 @@ from optimizer_overrides import optimizer_overrides
 from optimization.bounds import Bound
 from optimization.backends.gpu_backend import (
     _apply_gpu_optimizer_overrides,
+    _ask_gpu_population,
     _canonical_candidate_values,
     _canonicalize_mirrored_hash_vector,
     _canonicalize_optimizer_override_hash_vector,
@@ -42,6 +44,7 @@ from optimization.backends.gpu_backend import (
     _update_novelty_stall,
     _validation_probe_count,
     _spearman,
+    _submit_gpu_exact_validation,
     _resolve_options,
     _restore_gpu_result_run_contract,
     _single_scenario_metric_surface,
@@ -77,6 +80,28 @@ class _Evaluator:
 class _MulticoinEvaluator:
     exchanges = ["bybit"]
     shared_hlcvs_np = {"bybit": np.zeros((100, 3, 4), dtype=np.float64)}
+
+
+def test_gpu_generation_checks_interrupt_before_ask():
+    algorithm = MagicMock()
+    interrupt_check = MagicMock(side_effect=KeyboardInterrupt)
+
+    with pytest.raises(KeyboardInterrupt):
+        _ask_gpu_population(algorithm, interrupt_check)
+
+    interrupt_check.assert_called_once_with()
+    algorithm.ask.assert_not_called()
+
+
+def test_gpu_exact_submission_checks_interrupt_before_apply_async():
+    pool = MagicMock()
+    interrupt_check = MagicMock(side_effect=KeyboardInterrupt)
+
+    with pytest.raises(KeyboardInterrupt):
+        _submit_gpu_exact_validation(pool, [1.0], interrupt_check)
+
+    interrupt_check.assert_called_once_with()
+    pool.apply_async.assert_not_called()
 
 
 def _long_only_ema_config():

--- a/tests/optimization/test_interrupts.py
+++ b/tests/optimization/test_interrupts.py
@@ -1,0 +1,46 @@
+import signal
+
+import pytest
+
+from optimization.interrupts import (
+    OptimizerBackendInterrupted,
+    OptimizerInterruptLatch,
+)
+
+
+def test_sigint_latch_survives_native_dispatch_boundary():
+    latch = OptimizerInterruptLatch()
+
+    latch._handle_sigint(signal.SIGINT, None)
+    latch._handle_sigint(signal.SIGINT, None)
+
+    assert latch.requested is True
+    with pytest.raises(KeyboardInterrupt):
+        latch.raise_if_requested()
+
+
+def test_sigint_latch_restores_previous_handler(monkeypatch):
+    previous = object()
+    installed = []
+    monkeypatch.setattr(signal, "getsignal", lambda _signum: previous)
+    monkeypatch.setattr(
+        signal,
+        "signal",
+        lambda signum, handler: installed.append((signum, handler)),
+    )
+    latch = OptimizerInterruptLatch()
+
+    with latch:
+        assert installed == [(signal.SIGINT, latch._handle_sigint)]
+
+    assert installed[-1] == (signal.SIGINT, previous)
+
+
+def test_backend_interrupt_carries_terminated_pool_to_common_cleanup():
+    pool = object()
+
+    exc = OptimizerBackendInterrupted(pool=pool, pool_terminated=True)
+
+    assert isinstance(exc, KeyboardInterrupt)
+    assert exc.pool is pool
+    assert exc.pool_terminated is True


### PR DESCRIPTION
## Summary

- latch SIGINT while the GPU backend is active so Ctrl+C received during a native Metal dispatch cannot be lost
- honor the latched interrupt only at safe optimizer boundaries, before submitting exact Rust validations or starting another generation
- save a resumable GPU checkpoint, cancel pending async results, and transfer the terminated pool to the CLI's common cleanup path
- preserve CPU optimizer behavior by installing the latch only for `optimize.backend=gpu`

## Root cause

PyTorch MPS can return normally after Ctrl+C arrives while Python is waiting on a native Metal dispatch. The previous optimizer relied only on `KeyboardInterrupt`, so that signal could disappear and optimization would continue until another Ctrl+C arrived at a Python polling point.

## Validation

- verified the rebuilt Rust extension source fingerprint against fresh `origin/master`
- `python -m py_compile src/optimization/interrupts.py src/optimization/backends/gpu_backend.py src/optimize.py`
- `pytest -q tests/optimization/test_interrupts.py tests/optimization/test_gpu_backend.py tests/optimization/test_optimize.py`
- real Apple M3/MPS integration using cached ETH/bybit data, 2024-01 through available present, population/batch 4096: one Ctrl+C delivered during the first Metal dispatch stopped the run after that dispatch, exited 130, submitted zero exact validations, joined the terminated worker pool, and released shared memory
- loaded the generated checkpoint and successfully requested the next 4096-candidate population from the restored optimizer state

## Operational note

An already-running Metal dispatch is not preempted. Ctrl+C is now reliably remembered, so shutdown begins when that dispatch returns instead of requiring repeated interrupts. In the integration run, the remaining dispatch time was about 39 seconds.
