### PR TITLE
feat(optimize): add EMA multicoin MPS TWEL repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,29 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added EMA Anchor side-wide total-exposure repair to multi-coin Apple MPS optimization for
+  long-only, short-only, and compatible suite runs. The Metal proxy models both
+  `reduce_overweight` and `reduce_portfolio`, ranks every open position by projected adverse loss,
+  uses the current eligible-position count and last valid delisted-coin price, and reserves the
+  protective reducer before independently reachable ordinary EMA closes. Exact Rust validation
+  and the existing classification, rank, and drift gates remain authoritative. Dual-side
+  multi-coin repair remains fail closed until a shared-balance portfolio kernel can preserve exact
+  cross-side sizing.
+
 - Added EMA Anchor side-wide total-exposure repair to single-coin Apple MPS optimization for
   long-only, short-only, shared-balance dual-side, and compatible suite runs. The Metal proxy
   models the canonical TWEL reducer price and size, reserves the protective reducer before
   trimming the ordinary EMA close, and executes independently reachable closes in canonical
   order. Exact Rust validation and the existing classification, rank, and drift gates remain
-  authoritative. EMA Anchor multi-coin repair remains fail closed pending a portfolio-ranking
-  kernel.
+  authoritative.
 
 - Added Trailing Martingale side-wide total-exposure repair to the Apple MPS optimizer for
   single- and multi-coin long-only, short-only, and compatible suite runs. The Metal
   proxy models both `reduce_overweight` and `reduce_portfolio`, ranks repair candidates by projected
   adverse loss, applies exchange minimums and quantity steps, and lets the largest WEL/TWEL reducer
   compete before rebuilding the ordinary close ladder. Exact Rust validation and the existing
-  classification, rank, and drift gates remain authoritative. EMA Anchor multi-coin
-  total-exposure repair remains fail closed. Dual-side multi-coin exposure repair also remains
-  fail closed until a shared-balance portfolio kernel can preserve exact cross-side sizing.
+  classification, rank, and drift gates remain authoritative. Dual-side multi-coin exposure repair
+  remains fail closed until a shared-balance portfolio kernel can preserve exact cross-side sizing.
 
 - GPU optimization now latches Ctrl+C received during a native Metal dispatch,
   stops before another generation or exact-validation submission, saves a
@@ -30,8 +37,8 @@ All notable user-facing changes will be documented in this file.
   the canonical enable toggle and tunable threshold, gives the passive repair close precedence
   over normal strategy closes, reduces strictly below the allowance-adjusted WEL target, and
   honors static per-coin enable/threshold overrides. Exact Rust validation and the existing
-  classification, rank, and drift gates remain authoritative. EMA Anchor position repair and
-  multi-coin side-wide total-exposure repair remain fail closed.
+  classification, rank, and drift gates remain authoritative. EMA Anchor position repair remains
+  fail closed.
 
 - Extended Apple MPS exposure-headroom support to multi-coin EMA Anchor and Trailing Martingale
   optimization, including long-only, short-only, dual-side hedge, suites, tunable allowance and
@@ -39,14 +46,13 @@ All notable user-facing changes will be documented in this file.
   bounded or legacy-raw mode. The Metal proxy now separates per-symbol allowed wallet exposure
   from the optional side-wide TWEL entry gate;
   exact Rust validation and the existing classification, rank, and drift gates remain
-  authoritative. EMA Anchor multi-coin total-exposure repair remains fail closed.
+  authoritative.
 
 - Added single-coin exposure-headroom policy support to the Apple MPS optimizer for EMA Anchor and
   Trailing Martingale, including long-only, short-only, dual-side, and compatible suite runs.
   Metal now models bounded and legacy-raw `we_excess_allowance_pct`, the
   `total_exposure_entry_gate_enabled` toggle, and `total_exposure_enforcer_threshold`; exact Rust
   backtests and the existing classification, rank, and drift gates remain authoritative.
-  Multi-coin runs retain their previous fail-closed exposure-policy requirements.
 
 - Added `backtest.filter_by_min_effective_cost` support across the Apple MPS optimizer's EMA Anchor
   and Trailing Martingale single-coin, single-side matrix, including long, short, and compatible

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -70,7 +70,7 @@ mod tests {
         assert!(source.contains("kernel void passivbot_ema_anchor_multicoin_long"));
         assert!(source.contains("const bool short_side"));
         assert!(source.contains("constant int MAX_COINS = 64"));
-        assert!(source.contains("constant int PARAM_COLS = 23"));
+        assert!(source.contains("constant int PARAM_COLS = 25"));
         assert!(source.contains("constant int OVERRIDE_COLS = 13"));
         assert!(source.contains("coin_override_or"));
         assert!(source.contains("constant int COIN_COLS = 11"));
@@ -87,6 +87,11 @@ mod tests {
         assert!(source.contains("score[challenger] - score[incumbent_coin]"));
         assert!(source.contains("allowed_wallet_exposure_limit"));
         assert!(source.contains("twel_entry_gate_enabled"));
+        assert!(source.contains("twel_enforcer_enabled"));
+        assert!(source.contains("twel_enforcer_reduce_portfolio"));
+        assert!(source.contains("clamped_market_price"));
+        assert!(source.contains("secondary_close_qty"));
+        assert!(source.contains("current_effective_n_positions"));
         assert!(source.contains("distance == best_distance && c > best"));
         assert!(source.contains("= fma("));
         assert!(!source.contains("unstuck"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -2,7 +2,7 @@
 using namespace metal;
 
 constant int MAX_COINS = 64;
-constant int PARAM_COLS = 23;
+constant int PARAM_COLS = 25;
 constant int COIN_COLS = 11;
 constant int OVERRIDE_COLS = 13;
 constant int DAILY_COLS = 6;
@@ -59,6 +59,17 @@ inline float allowed_wallet_exposure_limit(
         effective = fmin(raw, max_effective);
     }
     return base_limit * (1.0f + effective);
+}
+
+inline float clamped_market_price(
+    constant float* bars, constant float* coin_settings,
+    int k, int coin, int coin_count
+) {
+    int coin_offset = coin * COIN_COLS;
+    int first_valid = int(coin_settings[coin_offset + 6]);
+    int last_valid = int(coin_settings[coin_offset + 7]);
+    int market_k = clamp(k, first_valid, last_valid);
+    return bars[(market_k * coin_count + coin) * 4 + 2];
 }
 
 inline void passivbot_ema_anchor_multicoin_impl(
@@ -121,6 +132,8 @@ inline void passivbot_ema_anchor_multicoin_impl(
     const bool legacy_raw_allowance = params[po + 20] > 0.5f;
     const bool twel_entry_gate_enabled = params[po + 21] > 0.5f;
     const float twel_threshold = params[po + 22];
+    const bool twel_enforcer_enabled = params[po + 23] > 0.5f;
+    const bool twel_enforcer_reduce_portfolio = params[po + 24] > 0.5f;
     const float weight_sum = w_volume + w_ready + w_volatility;
     if (weight_sum > 0.0f) {
         w_volume /= weight_sum;
@@ -156,12 +169,16 @@ inline void passivbot_ema_anchor_multicoin_impl(
     float last_increase_k[MAX_COINS];
     float entry_qty[MAX_COINS];
     float close_qty[MAX_COINS];
+    float secondary_close_qty[MAX_COINS];
+    float twel_close_qty[MAX_COINS];
     float position_open_k[MAX_COINS];
     float score[MAX_COINS];
     float contribution[MAX_COINS];
     float minimum_entry[MAX_COINS];
     int entry_tick[MAX_COINS];
     int close_tick[MAX_COINS];
+    int secondary_close_tick[MAX_COINS];
+    int twel_close_tick[MAX_COINS];
     bool selected[MAX_COINS];
     bool incumbent[MAX_COINS];
     bool survivor[MAX_COINS];
@@ -193,12 +210,16 @@ inline void passivbot_ema_anchor_multicoin_impl(
         last_increase_k[c] = -1.0e20f;
         entry_qty[c] = 0.0f;
         close_qty[c] = 0.0f;
+        secondary_close_qty[c] = 0.0f;
+        twel_close_qty[c] = 0.0f;
         position_open_k[c] = -1.0f;
         score[c] = -INFINITY;
         contribution[c] = 0.0f;
         minimum_entry[c] = 0.0f;
         entry_tick[c] = 0;
         close_tick[c] = 0;
+        secondary_close_tick[c] = 0;
+        twel_close_tick[c] = 0;
         selected[c] = false;
         incumbent[c] = false;
         survivor[c] = false;
@@ -303,9 +324,31 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 && (short_side
                     ? close_tick[c] > fill_ticks[tick_offset + 1]
                     : close_tick[c] <= fill_ticks[tick_offset + 0]);
-            if (filled_close) {
-                float fill_price = float(close_tick[c]) * price_step;
-                float adjusted = fmin(round_step(close_qty[c], qty_step), psize[c]);
+            bool filled_secondary_close = secondary_close_qty[c] > 0.0f
+                && psize[c] > 0.0f
+                && (short_side
+                    ? secondary_close_tick[c] > fill_ticks[tick_offset + 1]
+                    : secondary_close_tick[c] <= fill_ticks[tick_offset + 0]);
+            bool secondary_first = filled_secondary_close
+                && (!filled_close || (short_side
+                    ? secondary_close_tick[c] > close_tick[c]
+                    : secondary_close_tick[c] < close_tick[c]));
+            bool executed_close = false;
+            for (int close_rank = 0; close_rank < 2; ++close_rank) {
+                bool use_secondary = secondary_first
+                    ? close_rank == 0 : close_rank == 1;
+                bool reachable = use_secondary
+                    ? filled_secondary_close : filled_close;
+                if (!reachable || psize[c] <= 0.0f) continue;
+                int executed_tick = use_secondary
+                    ? secondary_close_tick[c] : close_tick[c];
+                float requested_qty = use_secondary
+                    ? secondary_close_qty[c] : close_qty[c];
+                float fill_price = float(executed_tick) * price_step;
+                float adjusted = fmin(
+                    round_step(requested_qty, qty_step), psize[c]
+                );
+                if (!(adjusted > 0.0f)) continue;
                 float pnl = adjusted * c_mult * (short_side
                     ? pprice[c] - fill_price
                     : fill_price - pprice[c]);
@@ -321,7 +364,14 @@ inline void passivbot_ema_anchor_multicoin_impl(
                     position_open_k[c] = -1.0f;
                 }
                 day_volume += fabs(adjusted) * fill_price * c_mult / balance;
-                close_qty[c] = 0.0f;
+                if (use_secondary) {
+                    secondary_close_qty[c] = 0.0f;
+                } else {
+                    close_qty[c] = 0.0f;
+                }
+                executed_close = true;
+            }
+            if (executed_close) {
                 any_fill = true;
             }
 
@@ -585,16 +635,127 @@ inline void passivbot_ema_anchor_multicoin_impl(
 
             const float effective_wel = twel / fmax(float(effective_n_positions), 1.0f);
             float current_twe = 0.0f;
+            int open_position_count = 0;
             for (int c = 0; c < C; ++c) {
                 int coin_offset = c * COIN_COLS;
                 if (psize[c] > 0.0f && balance > 0.0f) {
                     current_twe += psize[c] * pprice[c]
                         * coin_settings[coin_offset + 4] / balance;
+                    open_position_count += 1;
+                }
+                twel_close_qty[c] = 0.0f;
+                twel_close_tick[c] = 0;
+            }
+
+            // Match calc_twel_enforcer_actions: every open position contributes
+            // to total exposure. Reducible positions are ranked by least
+            // adverse projected loss per exposure, then symbol index.
+            float twel_repair_target = twel * twel_threshold;
+            if (twel_enforcer_enabled && twel_threshold > 0.0f
+                && twel_repair_target > 0.0f && balance > 0.0f
+                && current_twe > twel_repair_target + 1.0e-9f
+                && open_position_count > 0) {
+                // Reduce-overweight uses the current eligible count. The
+                // grow-only maximum remains exclusive to dynamic WEL sizing.
+                int current_effective_n_positions = min(
+                    n_positions, tradable_count
+                );
+                int repair_n_positions = current_effective_n_positions > 0
+                    ? current_effective_n_positions : open_position_count;
+                float overweight_target = twel_repair_target
+                    / fmax(float(repair_n_positions), 1.0f);
+                bool processed[MAX_COINS];
+                for (int c = 0; c < MAX_COINS; ++c) processed[c] = false;
+                float running_twe = current_twe;
+                for (int rank = 0; rank < C; ++rank) {
+                    if (running_twe <= twel_repair_target + 1.0e-9f) break;
+                    int best = -1;
+                    float best_adverse = INFINITY;
+                    for (int c = 0; c < C; ++c) {
+                        if (processed[c] || psize[c] <= 0.0f
+                            || pprice[c] <= 0.0f) continue;
+                        int coin_offset = c * COIN_COLS;
+                        float c_mult = coin_settings[coin_offset + 4];
+                        float exposure = psize[c] * pprice[c] * c_mult
+                            / balance;
+                        if (!(exposure > 1.0e-9f)) continue;
+                        if (!twel_enforcer_reduce_portfolio
+                            && !(exposure > overweight_target + 1.0e-9f)) {
+                            continue;
+                        }
+                        float market_price = clamped_market_price(
+                            bars, coin_settings, k, c, C
+                        );
+                        float projected_loss = psize[c] * c_mult * fmax(
+                            short_side
+                                ? market_price - pprice[c]
+                                : pprice[c] - market_price,
+                            0.0f
+                        );
+                        float adverse = projected_loss / exposure;
+                        if (best < 0 || adverse < best_adverse
+                            || (adverse == best_adverse && c < best)) {
+                            best = c;
+                            best_adverse = adverse;
+                        }
+                    }
+                    if (best < 0) break;
+                    processed[best] = true;
+                    int coin_offset = best * COIN_COLS;
+                    float qty_step = coin_settings[coin_offset + 0];
+                    float price_step = coin_settings[coin_offset + 1];
+                    float min_qty = coin_settings[coin_offset + 2];
+                    float min_cost = coin_settings[coin_offset + 3];
+                    float c_mult = coin_settings[coin_offset + 4];
+                    float exposure = psize[best] * pprice[best] * c_mult
+                        / balance;
+                    float exposure_to_cut = fmin(
+                        fmax(running_twe - twel_repair_target, 0.0f),
+                        exposure
+                    );
+                    float market_price = clamped_market_price(
+                        bars, coin_settings, k, best, C
+                    );
+                    int reducer_tick = short_side
+                        ? int(ceil(
+                            market_price * 1.0005f / price_step - 1.0e-6f
+                        ))
+                        : int(floor(
+                            market_price * 0.9995f / price_step + 1.0e-6f
+                        ));
+                    reducer_tick = max(reducer_tick, 1);
+                    float reducer_price = float(reducer_tick) * price_step;
+                    float requested_qty = ceil_step(
+                        exposure_to_cut * balance
+                            / fmax(pprice[best] * c_mult, 1.0e-12f),
+                        qty_step
+                    );
+                    float reducer_min = min_entry_qty(
+                        reducer_price, qty_step, min_qty, min_cost, c_mult
+                    );
+                    float reducer_qty = fmin(
+                        psize[best], fmax(reducer_min, requested_qty)
+                    );
+                    reducer_qty = fmin(
+                        psize[best], ceil_step(reducer_qty, qty_step)
+                    );
+                    if (reducer_qty <= 1.0e-9f) continue;
+                    twel_close_qty[best] = reducer_qty;
+                    twel_close_tick[best] = reducer_tick;
+                    running_twe -= fmax(
+                        exposure - fmax(
+                            round_step(psize[best] - reducer_qty, qty_step),
+                            0.0f
+                        ) * pprice[best] * c_mult / balance,
+                        0.0f
+                    );
                 }
             }
             for (int c = 0; c < C; ++c) {
                 entry_qty[c] = 0.0f;
                 close_qty[c] = 0.0f;
+                secondary_close_qty[c] = 0.0f;
+                secondary_close_tick[c] = 0;
                 contribution[c] = 0.0f;
                 entry_candidate[c] = false;
                 int coin_offset = c * COIN_COLS;
@@ -720,6 +881,65 @@ inline void passivbot_ema_anchor_multicoin_impl(
                             || psize[c] - clip < minimum_close
                         ? psize[c] : clip;
                     close_tick[c] = candidate_close_tick;
+                }
+
+                // Reserve the side-wide protective reducer and trim the
+                // ordinary EMA close first, matching finalized_closes_with_reducer.
+                float reducer_qty = twel_close_qty[c];
+                int reducer_tick = twel_close_tick[c];
+                if (reducer_qty > 0.0f && reducer_tick > 0) {
+                    float reducer_price = float(reducer_tick) * price_step;
+                    float reducer_min = min_entry_qty(
+                        reducer_price, qty_step, min_qty, min_cost, c_mult
+                    );
+                    float ordinary_qty = close_qty[c];
+                    if (ordinary_qty > 0.0f) {
+                        float ordinary_min = min_entry_qty(
+                            close_price, qty_step, min_qty, min_cost, c_mult
+                        );
+                        if (ordinary_qty + reducer_qty > psize[c]) {
+                            ordinary_qty = fmax(
+                                round_step(
+                                    psize[c] - reducer_qty, qty_step
+                                ),
+                                0.0f
+                            );
+                        }
+                        if (ordinary_qty >= ordinary_min) {
+                            float remainder = fmax(
+                                round_step(
+                                    psize[c] - reducer_qty - ordinary_qty,
+                                    qty_step
+                                ),
+                                0.0f
+                            );
+                            float minimum_any = fmin(
+                                ordinary_min, reducer_min
+                            );
+                            if (remainder > 0.0f
+                                && remainder < minimum_any) {
+                                ordinary_qty = fmin(
+                                    psize[c] - reducer_qty,
+                                    round_step(
+                                        ordinary_qty + remainder, qty_step
+                                    )
+                                );
+                            }
+                            secondary_close_qty[c] = ordinary_qty;
+                            secondary_close_tick[c] = close_tick[c];
+                        }
+                    }
+                    if (secondary_close_qty[c] <= 0.0f) {
+                        float remainder = fmax(
+                            round_step(psize[c] - reducer_qty, qty_step),
+                            0.0f
+                        );
+                        if (remainder > 0.0f && remainder < reducer_min) {
+                            reducer_qty = psize[c];
+                        }
+                    }
+                    close_qty[c] = reducer_qty;
+                    close_tick[c] = reducer_tick;
                 }
             }
 

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -868,7 +868,10 @@ def _validate_scope_config(
                         "GPU dual-side multicoin optimization currently requires "
                         f"matching long/short {label}_coins"
                     )
-        if len(enabled_sides) == 2 and strategy_kind == "trailing_martingale":
+        if len(enabled_sides) == 2 and strategy_kind in {
+            "ema_anchor",
+            "trailing_martingale",
+        }:
             repair_paths = []
             for side in enabled_sides:
                 risk = config["bot"][side].get("risk", {})
@@ -929,10 +932,6 @@ def _validate_scope_config(
         if strategy_kind != "trailing_martingale":
             required_disabled.append(
                 ("position_exposure_enforcer_enabled", False)
-            )
-        if strategy_kind == "ema_anchor" and coin_count > 1:
-            required_disabled.append(
-                ("total_exposure_enforcer_enabled", False)
             )
         for key, expected in required_disabled:
             if bool(risk.get(key, expected)) != expected:
@@ -2081,14 +2080,7 @@ def _validate_pinned_scope_bounds(
                 for side in ("long", "short")
             }
         )
-    if strategy_kind == "ema_anchor" and coin_count > 1:
-        pinned.update(
-            {
-                f"{side}_risk_total_exposure_enforcer_enabled": 0.0
-                for side in ("long", "short")
-            }
-        )
-    elif coin_count > 1 and len(enabled_sides) == 2:
+    if coin_count > 1 and len(enabled_sides) == 2:
         # Directional multicoin runners do not share realized PnL or balance.
         # Until a portfolio kernel owns both sides, any exposure reducer whose
         # sizing depends on account balance must remain disabled.

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -65,6 +65,7 @@ EMA_ANCHOR_MULTICOIN_PARAM_KEYS = (
     "forager_score_weights_volatility",
     "n_positions",
     *EXPOSURE_PARAM_KEYS,
+    *MULTICOIN_TOTAL_EXPOSURE_ENFORCER_PARAM_KEYS,
 )
 
 TRAILING_MARTINGALE_PARAM_KEYS = (

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -846,6 +846,7 @@ class MpsMulticoinProxy:
                         config["bot"][side].get("risk", {}), side=side
                     )
                 )
+            if self.strategy_kind in {"ema_anchor", "trailing_martingale"}:
                 first_strategy.update(
                     _total_exposure_enforcer_params(
                         config["bot"][side].get("risk", {}), side=side

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1584,11 +1584,55 @@ def test_gpu_foundation_accepts_ema_dual_single_coin_total_exposure_repair(
     assert _validate_scope(config, _Evaluator()) == "bybit"
 
 
-def test_gpu_multicoin_keeps_ema_total_exposure_repair_fail_closed():
-    config = _directional_ema_config(long_enabled=True, short_enabled=False)
-    config["bot"]["long"]["risk"]["total_exposure_enforcer_enabled"] = True
+@pytest.mark.parametrize("side", ["long", "short"])
+@pytest.mark.parametrize(
+    "policy", ["reduce_overweight", "reduce_portfolio"]
+)
+@pytest.mark.parametrize("suite_enabled", [False, True])
+def test_gpu_multicoin_accepts_ema_total_exposure_repair(
+    side, policy, suite_enabled
+):
+    config = _directional_ema_config(
+        long_enabled=side == "long", short_enabled=side == "short"
+    )
+    coins = ["BTC", "ETH", "SOL"]
+    config["live"]["approved_coins"][side] = coins
+    if suite_enabled:
+        # Suite materialization requires symmetric coin universes even when
+        # one side is disabled by a zero total-exposure budget.
+        other = "short" if side == "long" else "long"
+        config["live"]["approved_coins"][other] = coins
+        config["bot"][other]["risk"]["total_wallet_exposure_limit"] = 0.0
+    risk = config["bot"][side]["risk"]
+    risk["n_positions"] = 2
+    risk["total_exposure_enforcer_enabled"] = True
+    risk["total_exposure_enforcer_policy"] = policy
+    risk["total_exposure_enforcer_threshold"] = 0.8
+    config["backtest"]["dynamic_wel_by_tradability"] = True
+    config["backtest"]["suite_enabled"] = suite_enabled
 
-    with pytest.raises(ValueError, match="total_exposure_enforcer_enabled"):
+    assert (
+        _validate_scope(
+            config, _MulticoinEvaluator(), allow_suite=suite_enabled
+        )
+        == "bybit"
+    )
+
+
+def test_gpu_dual_multicoin_rejects_ema_total_exposure_repair():
+    config = _directional_ema_config(long_enabled=True, short_enabled=True)
+    config["live"]["approved_coins"] = {
+        "long": ["BTC", "ETH", "SOL"],
+        "short": ["BTC", "ETH", "SOL"],
+    }
+    config["live"]["hedge_mode"] = True
+    config["backtest"]["dynamic_wel_by_tradability"] = True
+    for side in ("long", "short"):
+        risk = config["bot"][side]["risk"]
+        risk["n_positions"] = 2
+        risk["total_exposure_enforcer_enabled"] = True
+
+    with pytest.raises(ValueError, match="shared-balance portfolio kernel"):
         _validate_scope(config, _MulticoinEvaluator())
 
 
@@ -3705,12 +3749,13 @@ def test_gpu_rejects_pinned_unsupported_exposure_repair_behavior():
         strategy_kind="trailing_martingale",
     )
 
-    with pytest.raises(ValueError, match="total_exposure_enforcer_enabled"):
-        _validate_pinned_scope_bounds(
-            {"long_risk_total_exposure_enforcer_enabled": Bound(1.0, 1.0, None)},
-            {"long_risk_total_exposure_enforcer_enabled": 1.0},
-            coin_count=2,
-        )
+    _validate_pinned_scope_bounds(
+        {"long_risk_total_exposure_enforcer_enabled": Bound(1.0, 1.0, None)},
+        {"long_risk_total_exposure_enforcer_enabled": 1.0},
+        {"long"},
+        coin_count=2,
+        strategy_kind="ema_anchor",
+    )
 
     _validate_pinned_scope_bounds(
         {"long_risk_total_exposure_enforcer_enabled": Bound(1.0, 1.0, None)},
@@ -3739,6 +3784,19 @@ def test_gpu_rejects_pinned_unsupported_exposure_repair_behavior():
             {"long", "short"},
             coin_count=2,
             strategy_kind="trailing_martingale",
+        )
+
+    with pytest.raises(ValueError, match="total_exposure_enforcer_enabled"):
+        _validate_pinned_scope_bounds(
+            {
+                "long_risk_total_exposure_enforcer_enabled": Bound(
+                    0.0, 1.0, None
+                )
+            },
+            {"long_risk_total_exposure_enforcer_enabled": 0.0},
+            {"long", "short"},
+            coin_count=2,
+            strategy_kind="ema_anchor",
         )
 
 

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -115,6 +115,8 @@ def _multicoin_exposure_fixture(
             "we_excess_allowance_legacy_raw": 0.0,
             "twel_entry_gate_enabled": 1.0,
             "twel_enforcer_threshold": 1.0,
+            "twel_enforcer_enabled": 0.0,
+            "twel_enforcer_reduce_portfolio": 0.0,
         }
         row = [values[key] for key in EMA_ANCHOR_MULTICOIN_PARAM_KEYS]
         runner = MpsEmaAnchorMulticoinRunner(
@@ -385,10 +387,14 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
     source = passivbot_rust.mps_ema_anchor_multicoin_source_py()
     assert "kernel void passivbot_ema_anchor_multicoin" in source
     assert "kernel void passivbot_ema_anchor_multicoin_long" in source
-    assert "constant int PARAM_COLS = 23" in source
+    assert "constant int PARAM_COLS = 25" in source
     assert "constant int OVERRIDE_COLS = 13" in source
     assert "allowed_wallet_exposure_limit" in source
     assert "twel_entry_gate_enabled" in source
+    assert "twel_enforcer_enabled" in source
+    assert "twel_enforcer_reduce_portfolio" in source
+    assert "clamped_market_price" in source
+    assert "secondary_close_qty" in source
     assert "constant int DAILY_COLS = 6" in source
     assert "day_min_balance" in source
     assert "coin_override_or" in source
@@ -448,7 +454,7 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
         0.0,
         2.0,
     ]
-    row += _single_coin_exposure_fields()
+    row += _single_coin_exposure_fields() + [0.0, 0.0]
 
     runner = MpsEmaAnchorMulticoinRunner(
         runs[0], data, side=side, forager_score_hysteresis_pct=0.02
@@ -2387,6 +2393,59 @@ def test_mps_tm_multicoin_total_exposure_repair_policy(side):
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_ema_multicoin_total_exposure_repair_policy(side):
+    overrides = np.full((2, 13), np.nan, dtype=np.float32)
+    overrides[0, 11] = 0.1
+    count = 70
+    highs = np.full((count, 2), 100.5)
+    lows = np.full((count, 2), 99.5)
+    if side == "long":
+        lows[62, :] = 98.0
+    else:
+        highs[62, :] = 102.0
+    runner, baseline = _multicoin_exposure_fixture(
+        "ema_anchor",
+        side,
+        overrides,
+        count=count,
+        closes=(100.0, 100.0),
+        highs=highs,
+        lows=lows,
+    )
+    overweight = list(baseline)
+    overweight[EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("offset")] = 0.01
+    overweight[
+        EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("entry_cooldown_minutes")
+    ] = 100.0
+    overweight[
+        EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("twel_entry_gate_enabled")
+    ] = 0.0
+    overweight[
+        EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("twel_enforcer_threshold")
+    ] = 0.5
+    overweight[
+        EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("twel_enforcer_enabled")
+    ] = 1.0
+    portfolio = list(overweight)
+    portfolio[
+        EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index(
+            "twel_enforcer_reduce_portfolio"
+        )
+    ] = 1.0
+
+    output = runner.run(np.asarray([overweight, portfolio], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert output["open_positions"].cpu().tolist() == pytest.approx([2.0, 1.0])
+    pprice_key = "pprice" if side == "long" else "short_pprice"
+    total_twe = (output[pprice_key] / output["balance"]).cpu()
+    assert (total_twe < 0.5).all()
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_tm_multicoin_twel_ranking_clamps_delisted_market_price(side):
     count = 7
     timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
@@ -2456,6 +2515,76 @@ def test_mps_tm_multicoin_twel_ranking_clamps_delisted_market_price(side):
     else:
         # The adverse delisted short ranks behind the favorable live short,
         # whose reducer remains reachable and therefore reduces total size.
+        assert sizes[1] < sizes[0]
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_ema_multicoin_twel_ranking_clamps_delisted_market_price(side):
+    count = 70
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    hlcvs = np.zeros((count, 2, 4), dtype=np.float64)
+    hlcvs[:, :, 0] = 101.0
+    hlcvs[:, :, 1] = 99.0
+    hlcvs[:, :, 2] = 100.0
+    hlcvs[:, :, 3] = 100.0
+    # Fill the wide-offset entries, then make coin zero favorable for long
+    # and adverse for short before it delists. Coin one has the inverse rank.
+    hlcvs[62, 0, :3] = [140.0, 70.0, 130.0]
+    hlcvs[62, 1, :3] = [130.0, 70.0, 90.0]
+    hlcvs[63:, 0, :] = 0.0
+    hlcvs[63:, 1, :3] = [101.0, 89.0, 90.0]
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
+    runs = [
+        ProxyRun(
+            1_000.0,
+            1,
+            1,
+            int(timestamps[0]),
+            int(timestamps[0]),
+            int(timestamps[0]),
+            60_000,
+            0.05,
+            0,
+            last_valid,
+        )
+        for last_valid in (62, count - 1)
+    ]
+    data = build_mps_multicoin_data(
+        hlcvs, timestamps, runs, [market, market]
+    )
+    _, row = _multicoin_exposure_fixture("ema_anchor", side, count=count)
+    values = dict(zip(EMA_ANCHOR_MULTICOIN_PARAM_KEYS, row))
+    values.update(
+        {
+            "offset": 0.2,
+            "entry_cooldown_minutes": 100.0,
+            "twel_entry_gate_enabled": 0.0,
+            "twel_enforcer_threshold": 0.75,
+            "twel_enforcer_enabled": 1.0,
+            "twel_enforcer_reduce_portfolio": 1.0,
+        }
+    )
+    repaired = [values[key] for key in EMA_ANCHOR_MULTICOIN_PARAM_KEYS]
+    baseline = list(repaired)
+    baseline[
+        EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("twel_enforcer_enabled")
+    ] = 0.0
+    output = MpsEmaAnchorMulticoinRunner(
+        runs[1], data, side=side
+    ).run(np.asarray([baseline, repaired], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    sizes = output[size_key].cpu().numpy()
+    if side == "long":
+        # The favorable delisted long ranks first; its reducer cannot fill on
+        # invalid bars, so the live coin remains untouched.
+        assert sizes[1] == pytest.approx(sizes[0])
+    else:
+        # The favorable live short ranks before the adverse delisted short.
         assert sizes[1] < sizes[0]
 
 


### PR DESCRIPTION
## Summary

- add EMA Anchor side-wide total-exposure repair to the Apple MPS multicoin proxy for long-only and short-only runs
- model both `reduce_overweight` and `reduce_portfolio`, current eligible-count targeting, deterministic adverse-loss ranking, delisted-position price clamping, and exchange quantity/price minimums
- preserve independently reachable ordinary EMA closes while reserving the protective TWEL reducer and accounting for same-candle fills in canonical order
- allow compatible directional suites while keeping dual-side multicoin repair fail-closed until a shared-balance portfolio kernel exists

Exact Rust backtests remain authoritative through the existing exact-validation, classification, rank, and drift gates.

## Validation

- full repository Python test suite: passed on macOS/M3
- `tests/optimization`: passed on macOS/M3, including the complete real-MPS regression file
- `cargo test --no-default-features`: 262 passed
- `cargo check --tests`: passed
- `cargo check`: passed
- `cargo fmt --all -- --check`: passed
- repository Rust-extension rebuild/stamp verified against source fingerprint `49b4c3ce5a79f64ae21144c58e2b86a9c7664874ac8bbab841c809f4214fcc49`
- real two-coin BTC+ETH long-only GPU optimization: 8 generations, 512 proxy evaluations, 64 exact validations, clean completion
- real two-coin BTC+ETH short-only GPU optimization: 8 generations, 512 proxy evaluations, 64 exact validations, clean completion
