### PR TITLE
feat(optimize): expand MPS strategy equity metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Expanded Apple MPS optimizer scoring and limits with strategy-equity gain, Omega ratio,
+  expected shortfall, Calmar ratio, Sterling ratio, and median underwater percentage. These
+  metrics are reduced from the existing compact Metal equity summaries, while exact Rust
+  backtests remain authoritative for persisted results and Pareto membership.
+
 - Added EMA Anchor side-wide total-exposure repair to multi-coin Apple MPS optimization for
   long-only, short-only, and compatible suite runs. The Metal proxy models both
   `reduce_overweight` and `reduce_portfolio`, ranks every open position by projected adverse loss,

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -16,15 +16,21 @@ SUPPORTED_METRICS = (
     "adg_strategy_eq",
     "adg_strategy_eq_w",
     "backtest_completion_ratio",
+    "calmar_ratio_strategy_eq",
     "drawdown_worst_mean_1pct_strategy_eq",
     "drawdown_worst_strategy_eq",
+    "expected_shortfall_1pct_strategy_eq",
     "fills_gap_longest_days",
+    "gain_strategy_eq",
     "mdg_strategy_eq",
+    "omega_ratio_strategy_eq",
     "position_held_days_max",
     "sharpe_ratio_strategy_eq",
     "sortino_ratio_strategy_eq",
+    "sterling_ratio_strategy_eq",
     "strategy_eq_recovery_days_max",
     "strategy_eq_underwater_pct_mean",
+    "strategy_eq_underwater_pct_median",
     "volume_pct_per_day_avg",
 )
 
@@ -62,10 +68,11 @@ def _masked_median(values, mask):
     return torch.where(counts > 0, medians, torch.zeros_like(medians))
 
 
-def _smoothed_adg(day_eq, active):
+def _smoothed_gain_adg(day_eq, active):
     batch_size, day_count = day_eq.shape
     if day_count == 0:
-        return torch.zeros(batch_size, dtype=day_eq.dtype, device=day_eq.device)
+        zeros = torch.zeros(batch_size, dtype=day_eq.dtype, device=day_eq.device)
+        return zeros, zeros
     counts = active.sum(dim=1)
     indices = (
         torch.arange(day_count, device=day_eq.device)
@@ -87,14 +94,23 @@ def _smoothed_adg(day_eq, active):
         gather_index = sorted_indices[:, offset].clamp(min=0)
         tail_values += take * day_eq.gather(1, gather_index.unsqueeze(1)).squeeze(1)
     end = tail_values / tail_count.to(day_eq.dtype)
-    gain = end / start.abs().clamp(min=1e-12) * torch.sign(start)
+    gain = torch.where(
+        start > 0.0,
+        torch.where(end > 0.0, end / start, torch.full_like(end, -1.0)),
+        torch.full_like(end, float("inf")),
+    )
     duration_days = counts.clamp(min=1).to(day_eq.dtype)
     adg = torch.where(
-        (gain > 0) & (counts > 0),
+        (gain > 0) & (counts >= 2),
         gain.clamp(min=1e-12) ** (1.0 / duration_days) - 1.0,
-        torch.full_like(gain, -1.0),
+        torch.where(counts >= 2, torch.full_like(gain, -1.0), torch.zeros_like(gain)),
     )
-    return torch.where(counts > 0, adg, torch.zeros_like(adg))
+    gain = torch.where(counts >= 2, gain, torch.zeros_like(gain))
+    return gain, adg
+
+
+def _smoothed_adg(day_eq, active):
+    return _smoothed_gain_adg(day_eq, active)[1]
 
 
 def _sharpe_sortino(changes, mask, adg):
@@ -130,6 +146,36 @@ def _sharpe_sortino(changes, mask, adg):
         torch.zeros_like(adg),
     )
     return sharpe, sortino
+
+
+def _omega_ratio(changes, mask):
+    gains = torch.where(
+        mask & (changes >= 0.0), changes, torch.zeros_like(changes)
+    ).sum(dim=1)
+    losses = torch.where(
+        mask & (changes < 0.0), -changes, torch.zeros_like(changes)
+    ).sum(dim=1)
+    cap = torch.full_like(gains, 1_000.0)
+    ratio = gains / losses.clamp(min=1e-12)
+    return torch.where(
+        losses <= 1e-12,
+        torch.where(gains > 1e-12, cap, torch.zeros_like(gains)),
+        ratio.clamp(max=1_000.0),
+    )
+
+
+def _mean_worst_one_pct_abs(values, mask):
+    if values.shape[1] == 0:
+        return torch.zeros(values.shape[0], dtype=values.dtype, device=values.device)
+    counts = mask.sum(dim=1)
+    ordered = torch.sort(
+        torch.where(mask, values, torch.full_like(values, float("inf"))), dim=1
+    ).values
+    worst_count = (counts.to(values.dtype) * 0.01).floor().clamp(min=1).to(torch.long)
+    cumulative = torch.cumsum(ordered.abs(), dim=1)
+    result = cumulative.gather(1, (worst_count - 1).unsqueeze(1)).squeeze(1)
+    result = result / worst_count.to(values.dtype)
+    return torch.where(counts > 0, result, torch.zeros_like(result))
 
 
 def _weighted_adg(
@@ -192,11 +238,13 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
     day_has_fill = out["day_has_fill"]
     active = _daily_series_masks(out["day_min_eq"])
 
-    adg = _smoothed_adg(day_end_eq, active)
+    gain, adg = _smoothed_gain_adg(day_end_eq, active)
     daily_changes, change_mask = _pct_change(day_end_eq, active)
     mdg = _masked_median(daily_changes, change_mask)
+    omega = _omega_ratio(daily_changes, change_mask)
     daily_min_changes, min_change_mask = _pct_change(day_min_eq, active)
     sharpe, sortino = _sharpe_sortino(daily_min_changes, min_change_mask, adg)
+    expected_shortfall = _mean_worst_one_pct_abs(daily_min_changes, min_change_mask)
     adg_w = _weighted_adg(
         day_end_eq,
         active,
@@ -209,6 +257,7 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
     underwater = torch.where(active, day_max_dd, torch.zeros_like(day_max_dd)).sum(
         dim=1
     ) / active.sum(dim=1).clamp(min=1)
+    underwater_median = _masked_median(day_max_dd, active)
     sorted_drawdowns, _ = torch.sort(
         torch.where(active, day_max_dd, torch.zeros_like(day_max_dd)),
         dim=1,
@@ -221,6 +270,8 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
     worst_one_pct = cumulative_drawdowns.gather(
         1, (worst_count - 1).unsqueeze(1)
     ).squeeze(1) / worst_count.to(torch.float64)
+    calmar = adg / out["max_dd"].to(torch.float64).clamp(min=1e-12)
+    sterling = adg / worst_one_pct.clamp(min=1e-12)
 
     volume_days = day_has_fill.sum(dim=1).clamp(min=1).to(torch.float64)
     volume_pct = day_volume.sum(dim=1) / volume_days
@@ -279,15 +330,21 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
         "adg_strategy_eq": adg,
         "adg_strategy_eq_w": adg_w,
         "backtest_completion_ratio": completion,
+        "calmar_ratio_strategy_eq": calmar,
         "drawdown_worst_mean_1pct_strategy_eq": worst_one_pct,
         "drawdown_worst_strategy_eq": out["max_dd"],
+        "expected_shortfall_1pct_strategy_eq": expected_shortfall,
         "fills_gap_longest_days": gap_longest_days,
+        "gain_strategy_eq": gain,
         "mdg_strategy_eq": mdg,
+        "omega_ratio_strategy_eq": omega,
         "position_held_days_max": held_days,
         "sharpe_ratio_strategy_eq": sharpe,
         "sortino_ratio_strategy_eq": sortino,
+        "sterling_ratio_strategy_eq": sterling,
         "strategy_eq_recovery_days_max": recovery_max_days,
         "strategy_eq_underwater_pct_mean": underwater,
+        "strategy_eq_underwater_pct_median": underwater_median,
         "volume_pct_per_day_avg": volume_pct,
     }
     if needed is None:

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -8,8 +8,11 @@ torch = pytest.importorskip("torch")
 from optimization.gpu.metrics import (
     SUPPORTED_METRICS,
     _masked_median,
+    _mean_worst_one_pct_abs,
+    _omega_ratio,
     _sharpe_sortino,
     _smoothed_adg,
+    _smoothed_gain_adg,
     _weighted_adg,
     compute_objectives,
 )
@@ -75,6 +78,104 @@ def test_weighted_adg_slices_minutes_before_daily_reduction():
 
 def test_interpolated_fill_gap_percentile_fails_closed_for_gpu_proxy():
     assert "fills_gap_p95_hours" not in SUPPORTED_METRICS
+
+
+def test_strategy_equity_summary_metric_surface_is_supported():
+    assert {
+        "gain_strategy_eq",
+        "omega_ratio_strategy_eq",
+        "expected_shortfall_1pct_strategy_eq",
+        "calmar_ratio_strategy_eq",
+        "sterling_ratio_strategy_eq",
+        "strategy_eq_underwater_pct_median",
+    } <= set(SUPPORTED_METRICS)
+
+
+def test_smoothed_gain_and_adg_match_rust_terminal_contract():
+    gain, adg = _smoothed_gain_adg(
+        torch.tensor([[100.0, 110.0, 120.0, 130.0]], dtype=torch.float64),
+        torch.tensor([[True, True, True, True]]),
+    )
+
+    expected_gain = (110.0 + 120.0 + 130.0) / 3.0 / 100.0
+    assert gain.item() == pytest.approx(expected_gain)
+    assert adg.item() == pytest.approx(expected_gain ** (1.0 / 4.0) - 1.0)
+
+
+def test_omega_ratio_matches_rust_zero_and_cap_contracts():
+    capped = _omega_ratio(
+        torch.tensor([[0.1, 0.2]], dtype=torch.float64),
+        torch.tensor([[True, True]]),
+    )
+    flat = _omega_ratio(
+        torch.tensor([[0.0, 0.0]], dtype=torch.float64),
+        torch.tensor([[True, True]]),
+    )
+
+    assert capped.item() == 1_000.0
+    assert flat.item() == 0.0
+
+
+def test_expected_shortfall_uses_worst_one_percent_daily_min_return():
+    values = torch.tensor([[-0.4, -0.1, 0.2, -0.3]], dtype=torch.float64)
+    mask = torch.tensor([[True, True, True, True]])
+
+    assert _mean_worst_one_pct_abs(values, mask).item() == pytest.approx(0.4)
+
+
+def test_new_strategy_equity_metrics_reduce_existing_compact_surface():
+    day_end = torch.tensor([[100.0, 110.0, 90.0, 120.0]], dtype=torch.float64)
+    day_min = torch.tensor([[100.0, 105.0, 80.0, 100.0]], dtype=torch.float64)
+    day_dd = torch.tensor([[0.0, 0.05, 0.30, 0.20]], dtype=torch.float64)
+    out = {
+        "day_end_eq": day_end,
+        "day_min_eq": day_min,
+        "day_max_dd": day_dd,
+        "day_volume": torch.zeros_like(day_end),
+        "day_has_fill": torch.zeros_like(day_end, dtype=torch.bool),
+        "max_dd": torch.tensor([0.30], dtype=torch.float64),
+        "held_max_ms": torch.zeros(1, dtype=torch.float64),
+        "gap_hist": torch.zeros((1, 128), dtype=torch.int32),
+        "gap_max_ms": torch.zeros(1, dtype=torch.float64),
+        "first_fill_ts": torch.full((1,), float("nan"), dtype=torch.float64),
+        "last_fill_ts": torch.full((1,), float("nan"), dtype=torch.float64),
+        "recovery_max_ms": torch.zeros(1, dtype=torch.float64),
+        "last_high_ts": torch.tensor([180_000.0], dtype=torch.float64),
+        "first_eq_ts": torch.tensor([0.0], dtype=torch.float64),
+        "last_eq_ts": torch.tensor([180_000.0], dtype=torch.float64),
+        "liq_step": torch.tensor([-1.0], dtype=torch.float64),
+    }
+    run = SimpleNamespace(
+        requested_start_ts_ms=0, guard_ts_ms=0, interval_ms=60_000
+    )
+    requested = {
+        "gain_strategy_eq",
+        "omega_ratio_strategy_eq",
+        "expected_shortfall_1pct_strategy_eq",
+        "calmar_ratio_strategy_eq",
+        "sterling_ratio_strategy_eq",
+        "strategy_eq_underwater_pct_median",
+    }
+
+    metrics = compute_objectives(out, run, {"ts0": 0.0, "n": 4}, needed=requested)
+
+    gain, adg = _smoothed_gain_adg(day_end, torch.ones_like(day_end, dtype=torch.bool))
+    assert set(metrics) == requested
+    assert metrics["gain_strategy_eq"].item() == pytest.approx(gain.item())
+    assert metrics["calmar_ratio_strategy_eq"].item() == pytest.approx(
+        adg.item() / 0.30
+    )
+    assert metrics["sterling_ratio_strategy_eq"].item() == pytest.approx(
+        adg.item() / 0.30
+    )
+    assert metrics["strategy_eq_underwater_pct_median"].item() == pytest.approx(0.125)
+    assert metrics["expected_shortfall_1pct_strategy_eq"].item() == pytest.approx(
+        abs((80.0 - 105.0) / 105.0)
+    )
+    expected_omega = ((110.0 - 100.0) / 100.0 + (120.0 - 90.0) / 90.0) / abs(
+        (90.0 - 110.0) / 110.0
+    )
+    assert metrics["omega_ratio_strategy_eq"].item() == pytest.approx(expected_omega)
 
 
 def test_objectives_include_final_active_calendar_day():


### PR DESCRIPTION
## Summary\n- Add Apple MPS proxy support for six strategy-equity scoring and limit metrics already derivable from compact daily Metal outputs.\n- Match exact Rust formulas for terminal gain, Omega zero and cap handling, one-percent expected shortfall, Calmar and Sterling denominators, and median daily underwater drawdown.\n- Keep exact Rust evaluations authoritative. No Metal buffers, kernel inputs, or CPU optimizer paths change.\n\nSupported in this slice:\n- gain_strategy_eq\n- omega_ratio_strategy_eq\n- expected_shortfall_1pct_strategy_eq\n- calmar_ratio_strategy_eq\n- sterling_ratio_strategy_eq\n- strategy_eq_underwater_pct_median\n\n## Validation\n- Full repository pytest: green.\n- Focused GPU metric, backend, and service tests: green.\n- Apple M3 hardware test_gpu_mps.py: 129 passed.\n- Rust tests without default features: 262 passed.\n- Rust checks and formatting: green.\n- Real Apple M3 MPS EMA Anchor optimization, Bybit ETH, 2024-01 through 2024-03, with all six new metrics:\n  - 8 generations.\n  - 512 proxy evaluations.\n  - 64 exact Rust validations.\n  - 8.1 seconds optimizer wall time.\n  - No drift or constraint halt.\n  - Clean shutdown.\n\n## Scope\nPurely additive GPU optimizer support. Normal CPU optimization, backtesting, and bot operation are unchanged. HSL, unstuck, and still-unreconstructable dual-side multicoin metrics remain fail closed.