### PR TITLE
feat(optimize): add EMA MPS realized-loss gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added cumulative realized-loss gating to single-coin Apple MPS EMA Anchor screening for long,
+  short, hedge-mode, and one-way runs. Metal tracks a conservative all-history peak-relative
+  realized net-PnL budget, including maker fees, and blocks lossy ordinary or exposure-repair
+  closes that exceed it. Exact Rust remains authoritative for the configured rolling PnL lookback;
+  unsupported Trailing Martingale and multicoin combinations remain fail closed.
+
 - Expanded Apple MPS optimizer scoring and limits with weighted strategy-equity MDG, Sharpe,
   Sortino, Omega, Calmar, and Sterling metrics. The proxy maps the exact optimizer's ten-subset
   averaging schedule onto its existing compact daily Metal summaries and skips these additional

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -152,7 +152,12 @@ The supported slice is intentionally narrow:
   strategy close and sizes it strictly below that target. Static per-coin overrides may change
   both fields. EMA Anchor position-exposure repair remains fail closed because its exact Rust
   strategy path does not use this reducer
-- BTC collateral, realized-loss gating, and total-exposure repair remain disabled
+- single-coin EMA Anchor models the cumulative realized-loss gate, including entry and close fees,
+  shared long/short loss-budget accounting, and lossy total-exposure repairs. The proxy uses a
+  conservative all-history loss envelope, so it may block a close that exact Rust admits after old
+  PnL ages out of `live.pnls_max_lookback_days`; exact validation remains authoritative. Trailing
+  Martingale and multicoin realized-loss gating remain fail closed
+- BTC collateral remains disabled; dual-side multicoin total-exposure repair remains disabled
 - `backtest.filter_by_min_effective_cost` may be enabled or disabled. When enabled, Metal uses the
   projected initial-entry cost test with the configured wallet-exposure limit. The
   screening proxy compares against the highest executable minimum observed for that coin in the

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -52,6 +52,9 @@ mod tests {
         assert!(source.contains("passes_min_effective_cost"));
         assert!(source.contains("projected_cost_lower"));
         assert!(source.contains("float guaranteed_balance_lower"));
+        assert!(source.contains("realized_loss_gate_allows"));
+        assert!(source.contains("record_realized_net"));
+        assert!(source.contains("const float max_realized_loss_pct = settings[14]"));
         assert!(!source.contains("accumulate_min_cost_balance_error"));
         assert_eq!(source.matches("= fma(").count(), 5);
         assert!(!source.contains("alpha0 * close +"));

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -53,6 +53,7 @@ mod tests {
         assert!(source.contains("projected_cost_lower"));
         assert!(source.contains("float guaranteed_balance_lower"));
         assert!(source.contains("realized_loss_gate_allows"));
+        assert!(source.contains("float32_floor_nonnegative"));
         assert!(source.contains("record_realized_net"));
         assert!(source.contains("const float max_realized_loss_pct = settings[14]"));
         assert!(!source.contains("accumulate_min_cost_balance_error"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -46,6 +46,25 @@ inline bool passes_min_effective_cost(
         && projected_cost_lower >= max_effective_min_cost;
 }
 
+inline bool realized_loss_gate_allows(
+    float net_pnl, float simulated_balance, float balance_floor,
+    bool gate_enabled
+) {
+    return !gate_enabled || net_pnl >= 0.0f
+        || simulated_balance + net_pnl >= balance_floor;
+}
+
+inline void record_realized_net(
+    float net_pnl,
+    thread float& realized_pnl_cumsum_last,
+    thread float& realized_pnl_cumsum_max
+) {
+    realized_pnl_cumsum_last += net_pnl;
+    realized_pnl_cumsum_max = fmax(
+        realized_pnl_cumsum_max, realized_pnl_cumsum_last
+    );
+}
+
 struct EmaSide {
     float alpha0;
     float alpha1;
@@ -79,6 +98,9 @@ struct EmaSide {
     float close_qty;
     int secondary_close_ticks;
     float secondary_close_qty;
+    int close_without_reducer_ticks;
+    float close_without_reducer_qty;
+    bool close_is_twel_reducer;
 };
 
 inline EmaSide load_side(constant float* params, int po, float seed_close) {
@@ -134,6 +156,9 @@ inline EmaSide load_side(constant float* params, int po, float seed_close) {
     side.close_qty = 0.0f;
     side.secondary_close_ticks = 0;
     side.secondary_close_qty = 0.0f;
+    side.close_without_reducer_ticks = 0;
+    side.close_without_reducer_qty = 0.0f;
+    side.close_is_twel_reducer = false;
     return side;
 }
 
@@ -175,6 +200,7 @@ inline void apply_twel_reducer(
 ) {
     side.secondary_close_ticks = 0;
     side.secondary_close_qty = 0.0f;
+    side.close_is_twel_reducer = false;
     float target = side.twel * side.twel_enforcer_threshold;
     int reducer_ticks = is_long
         ? int(floor(price_now * 0.9995f / price_step + 1.0e-6f))
@@ -232,6 +258,7 @@ inline void apply_twel_reducer(
     }
     side.close_ticks = reducer_ticks;
     side.close_qty = reducer_qty;
+    side.close_is_twel_reducer = true;
 }
 
 inline void update_indicators(
@@ -328,6 +355,8 @@ inline void generate_long_orders(
     if (side.psize <= 0.0f || ask_price <= 0.0f) c_qty = 0.0f;
     side.close_ticks = ask_ticks;
     side.close_qty = c_qty;
+    side.close_without_reducer_ticks = ask_ticks;
+    side.close_without_reducer_qty = c_qty;
     apply_twel_reducer(
         side, true, balance, price_now, qty_step, price_step,
         min_qty, min_cost, c_mult
@@ -406,10 +435,37 @@ inline void generate_short_orders(
     if (side.psize <= 0.0f || bid_price <= 0.0f) c_qty = 0.0f;
     side.close_ticks = bid_ticks;
     side.close_qty = c_qty;
+    side.close_without_reducer_ticks = bid_ticks;
+    side.close_without_reducer_qty = c_qty;
     apply_twel_reducer(
         side, false, balance, price_now, qty_step, price_step,
         min_qty, min_cost, c_mult
     );
+}
+
+inline void gate_generated_close(
+    thread float& qty,
+    int ticks,
+    float pprice,
+    bool is_long,
+    float price_step,
+    float c_mult,
+    float maker_fee,
+    float balance_floor,
+    bool gate_enabled,
+    thread float& simulated_balance
+) {
+    if (!(qty > 0.0f && ticks > 0 && pprice > 0.0f)) return;
+    float price = float(ticks) * price_step;
+    float gross_pnl = qty * c_mult
+        * (is_long ? price - pprice : pprice - price);
+    float net_pnl = gross_pnl - qty * price * c_mult * maker_fee;
+    if (!realized_loss_gate_allows(
+            net_pnl, simulated_balance, balance_floor, gate_enabled)) {
+        qty = 0.0f;
+        return;
+    }
+    if (net_pnl < 0.0f) simulated_balance += net_pnl;
 }
 
 inline void passivbot_single_coin_impl(
@@ -444,6 +500,7 @@ inline void passivbot_single_coin_impl(
     const bool hedge_mode = settings[11] > 0.5f;
     const bool filter_by_min_effective_cost = settings[12] > 0.5f;
     const float max_effective_min_cost = settings[13];
+    const float max_realized_loss_pct = settings[14];
     const float log_bin_scale = 127.0f / log(4000001.0f);
 
     const int po = int(b) * P;
@@ -453,6 +510,8 @@ inline void passivbot_single_coin_impl(
     EmaSide short_side = load_side(params, po + SIDE_PARAMS, seed_close);
 
     float balance = starting_balance;
+    float realized_pnl_cumsum_last = 0.0f;
+    float realized_pnl_cumsum_max = 0.0f;
     bool alive = true;
     int liq_day = -1;
     float held_max_min = 0.0f;
@@ -539,7 +598,11 @@ inline void passivbot_single_coin_impl(
             if (!(adj > 0.0f)) continue;
             float pnl = adj * c_mult * (cp - long_side.pprice);
             float fee = adj * cp * c_mult * maker_fee;
-            balance += pnl - fee;
+            float net_pnl = pnl - fee;
+            balance += net_pnl;
+            record_realized_net(
+                net_pnl, realized_pnl_cumsum_last, realized_pnl_cumsum_max
+            );
             float new_psize = fmax(round_step(long_side.psize - adj, qty_step), 0.0f);
             bool went_flat = new_psize <= 0.0f;
             long_side.psize = new_psize;
@@ -567,6 +630,9 @@ inline void passivbot_single_coin_impl(
             float eq = round_step(long_side.entry_qty, qty_step);
             float fee = eq * ep * c_mult * maker_fee;
             balance -= fee;
+            record_realized_net(
+                -fee, realized_pnl_cumsum_last, realized_pnl_cumsum_max
+            );
             bool was_flat = long_side.psize <= 0.0f;
             float new_psize = round_step(long_side.psize + eq, qty_step);
             float new_pprice = was_flat ? ep
@@ -604,7 +670,11 @@ inline void passivbot_single_coin_impl(
             if (!(adj > 0.0f)) continue;
             float pnl = adj * c_mult * (short_side.pprice - cp);
             float fee = adj * cp * c_mult * maker_fee;
-            balance += pnl - fee;
+            float net_pnl = pnl - fee;
+            balance += net_pnl;
+            record_realized_net(
+                net_pnl, realized_pnl_cumsum_last, realized_pnl_cumsum_max
+            );
             float new_psize = fmax(round_step(short_side.psize - adj, qty_step), 0.0f);
             bool went_flat = new_psize <= 0.0f;
             short_side.psize = new_psize;
@@ -632,6 +702,9 @@ inline void passivbot_single_coin_impl(
             float eq = round_step(short_side.entry_qty, qty_step);
             float fee = eq * ep * c_mult * maker_fee;
             balance -= fee;
+            record_realized_net(
+                -fee, realized_pnl_cumsum_last, realized_pnl_cumsum_max
+            );
             bool was_flat = short_side.psize <= 0.0f;
             float new_psize = round_step(short_side.psize + eq, qty_step);
             float new_pprice = was_flat ? ep
@@ -728,6 +801,88 @@ inline void passivbot_single_coin_impl(
                     qty_step, price_step, min_qty, min_cost, c_mult, kf,
                     block_short_initial
                 );
+            }
+
+            bool loss_gate_enabled = max_realized_loss_pct < 1.0f;
+            float balance_peak = balance
+                + (realized_pnl_cumsum_max - realized_pnl_cumsum_last);
+            float balance_floor = balance_peak
+                * (1.0f - fmax(max_realized_loss_pct, 0.0f));
+            float simulated_balance = balance;
+
+            // Exact Rust reserves the shared batch allowance for protective
+            // reducers largest-first, even when an emitted order never fills.
+            bool long_reducer = long_enabled
+                && long_side.close_is_twel_reducer
+                && long_side.close_qty > 0.0f;
+            bool short_reducer = short_enabled
+                && short_side.close_is_twel_reducer
+                && short_side.close_qty > 0.0f;
+            bool short_reducer_first = short_reducer
+                && (!long_reducer
+                    || short_side.close_qty > long_side.close_qty);
+            for (int rank = 0; rank < 2; ++rank) {
+                bool use_short = short_reducer_first ? rank == 0 : rank == 1;
+                if (use_short && short_reducer) {
+                    gate_generated_close(
+                        short_side.close_qty, short_side.close_ticks,
+                        short_side.pprice, false, price_step, c_mult, maker_fee,
+                        balance_floor, loss_gate_enabled, simulated_balance
+                    );
+                } else if (!use_short && long_reducer) {
+                    gate_generated_close(
+                        long_side.close_qty, long_side.close_ticks,
+                        long_side.pprice, true, price_step, c_mult, maker_fee,
+                        balance_floor, loss_gate_enabled, simulated_balance
+                    );
+                }
+            }
+            if (long_reducer && long_side.close_qty <= 0.0f) {
+                long_side.secondary_close_ticks =
+                    long_side.close_without_reducer_ticks;
+                long_side.secondary_close_qty =
+                    long_side.close_without_reducer_qty;
+            }
+            if (short_reducer && short_side.close_qty <= 0.0f) {
+                short_side.secondary_close_ticks =
+                    short_side.close_without_reducer_ticks;
+                short_side.secondary_close_qty =
+                    short_side.close_without_reducer_qty;
+            }
+
+            // Ordinary closes consume any remaining allowance in canonical
+            // long-then-short order after protective reducers are finalized.
+            if (long_enabled) {
+                if (long_side.close_is_twel_reducer) {
+                    gate_generated_close(
+                        long_side.secondary_close_qty,
+                        long_side.secondary_close_ticks, long_side.pprice, true,
+                        price_step, c_mult, maker_fee, balance_floor,
+                        loss_gate_enabled, simulated_balance
+                    );
+                } else {
+                    gate_generated_close(
+                        long_side.close_qty, long_side.close_ticks,
+                        long_side.pprice, true, price_step, c_mult, maker_fee,
+                        balance_floor, loss_gate_enabled, simulated_balance
+                    );
+                }
+            }
+            if (short_enabled) {
+                if (short_side.close_is_twel_reducer) {
+                    gate_generated_close(
+                        short_side.secondary_close_qty,
+                        short_side.secondary_close_ticks, short_side.pprice,
+                        false, price_step, c_mult, maker_fee, balance_floor,
+                        loss_gate_enabled, simulated_balance
+                    );
+                } else {
+                    gate_generated_close(
+                        short_side.close_qty, short_side.close_ticks,
+                        short_side.pprice, false, price_step, c_mult, maker_fee,
+                        balance_floor, loss_gate_enabled, simulated_balance
+                    );
+                }
             }
         }
 

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -47,11 +47,16 @@ inline bool passes_min_effective_cost(
 }
 
 inline bool realized_loss_gate_allows(
-    float net_pnl, float simulated_balance, float balance_floor,
+    float net_pnl, float remaining_loss_budget,
     bool gate_enabled
 ) {
     return !gate_enabled || net_pnl >= 0.0f
-        || simulated_balance + net_pnl >= balance_floor;
+        || -net_pnl <= remaining_loss_budget;
+}
+
+inline float float32_floor_nonnegative(float value) {
+    if (!(value > 0.0f) || !isfinite(value)) return fmax(value, 0.0f);
+    return as_type<float>(as_type<uint>(value) - 1u);
 }
 
 inline void record_realized_net(
@@ -451,9 +456,8 @@ inline void gate_generated_close(
     float price_step,
     float c_mult,
     float maker_fee,
-    float balance_floor,
     bool gate_enabled,
-    thread float& simulated_balance
+    thread float& remaining_loss_budget
 ) {
     if (!(qty > 0.0f && ticks > 0 && pprice > 0.0f)) return;
     float price = float(ticks) * price_step;
@@ -461,11 +465,15 @@ inline void gate_generated_close(
         * (is_long ? price - pprice : pprice - price);
     float net_pnl = gross_pnl - qty * price * c_mult * maker_fee;
     if (!realized_loss_gate_allows(
-            net_pnl, simulated_balance, balance_floor, gate_enabled)) {
+            net_pnl, remaining_loss_budget, gate_enabled)) {
         qty = 0.0f;
         return;
     }
-    if (net_pnl < 0.0f) simulated_balance += net_pnl;
+    if (gate_enabled && net_pnl < 0.0f) {
+        remaining_loss_budget = float32_floor_nonnegative(
+            fmax(remaining_loss_budget + net_pnl, 0.0f)
+        );
+    }
 }
 
 inline void passivbot_single_coin_impl(
@@ -806,9 +814,15 @@ inline void passivbot_single_coin_impl(
             bool loss_gate_enabled = max_realized_loss_pct < 1.0f;
             float balance_peak = balance
                 + (realized_pnl_cumsum_max - realized_pnl_cumsum_last);
-            float balance_floor = balance_peak
-                * (1.0f - fmax(max_realized_loss_pct, 0.0f));
-            float simulated_balance = balance;
+            float allowed_loss_budget = float32_floor_nonnegative(
+                balance_peak * fmax(max_realized_loss_pct, 0.0f)
+            );
+            float current_realized_loss = fmax(
+                realized_pnl_cumsum_max - realized_pnl_cumsum_last, 0.0f
+            );
+            float remaining_loss_budget = float32_floor_nonnegative(
+                fmax(allowed_loss_budget - current_realized_loss, 0.0f)
+            );
 
             // Exact Rust reserves the shared batch allowance for protective
             // reducers largest-first, even when an emitted order never fills.
@@ -827,13 +841,13 @@ inline void passivbot_single_coin_impl(
                     gate_generated_close(
                         short_side.close_qty, short_side.close_ticks,
                         short_side.pprice, false, price_step, c_mult, maker_fee,
-                        balance_floor, loss_gate_enabled, simulated_balance
+                        loss_gate_enabled, remaining_loss_budget
                     );
                 } else if (!use_short && long_reducer) {
                     gate_generated_close(
                         long_side.close_qty, long_side.close_ticks,
                         long_side.pprice, true, price_step, c_mult, maker_fee,
-                        balance_floor, loss_gate_enabled, simulated_balance
+                        loss_gate_enabled, remaining_loss_budget
                     );
                 }
             }
@@ -857,14 +871,14 @@ inline void passivbot_single_coin_impl(
                     gate_generated_close(
                         long_side.secondary_close_qty,
                         long_side.secondary_close_ticks, long_side.pprice, true,
-                        price_step, c_mult, maker_fee, balance_floor,
-                        loss_gate_enabled, simulated_balance
+                        price_step, c_mult, maker_fee, loss_gate_enabled,
+                        remaining_loss_budget
                     );
                 } else {
                     gate_generated_close(
                         long_side.close_qty, long_side.close_ticks,
                         long_side.pprice, true, price_step, c_mult, maker_fee,
-                        balance_floor, loss_gate_enabled, simulated_balance
+                        loss_gate_enabled, remaining_loss_budget
                     );
                 }
             }
@@ -873,14 +887,14 @@ inline void passivbot_single_coin_impl(
                     gate_generated_close(
                         short_side.secondary_close_qty,
                         short_side.secondary_close_ticks, short_side.pprice,
-                        false, price_step, c_mult, maker_fee, balance_floor,
-                        loss_gate_enabled, simulated_balance
+                        false, price_step, c_mult, maker_fee, loss_gate_enabled,
+                        remaining_loss_budget
                     );
                 } else {
                     gate_generated_close(
                         short_side.close_qty, short_side.close_ticks,
                         short_side.pprice, false, price_step, c_mult, maker_fee,
-                        balance_floor, loss_gate_enabled, simulated_balance
+                        loss_gate_enabled, remaining_loss_budget
                     );
                 }
             }

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -1776,6 +1776,9 @@ def _gpu_suite_checkpoint_contract(config: dict, suite_inputs=None) -> dict:
             "volume_normalization",
         )
     }
+    contract["max_realized_loss_pct"] = float(
+        config.get("live", {}).get("max_realized_loss_pct", 1.0)
+    )
     if suite_inputs is not None:
         prepared_scenarios = []
         for item in suite_inputs:
@@ -1817,6 +1820,11 @@ def _gpu_suite_checkpoint_contract(config: dict, suite_inputs=None) -> dict:
                         for side in ("long", "short")
                         if gpu_side_enabled(item["config"], side)
                     ],
+                    "max_realized_loss_pct": float(
+                        item["config"]
+                        .get("live", {})
+                        .get("max_realized_loss_pct", 1.0)
+                    ),
                     "candle_count": int(len(item["hlcvs"])),
                     "first_timestamp": (
                         int(timestamps[0]) if len(timestamps) else None
@@ -1833,6 +1841,17 @@ def _gpu_suite_checkpoint_contract(config: dict, suite_inputs=None) -> dict:
             )
         contract["prepared_scenarios"] = prepared_scenarios
     return contract
+
+
+def _gpu_runtime_checkpoint_contract(config: dict, proxy) -> dict:
+    return {
+        "max_realized_loss_pct": float(
+            config.get("live", {}).get("max_realized_loss_pct", 1.0)
+        ),
+        "coin_override_contract": deepcopy(
+            getattr(proxy, "coin_override_contract", None)
+        ),
+    }
 
 
 def _checkpoint_signature(
@@ -2869,7 +2888,7 @@ def run_backend(
         runtime_contract=(
             None
             if suite_enabled
-            else getattr(proxy, "coin_override_contract", None)
+            else _gpu_runtime_checkpoint_contract(config, proxy)
         ),
     )
     budget = int(config["optimize"]["iters"])
@@ -2883,7 +2902,8 @@ def run_backend(
             checkpoint = pickle.load(file)
         if checkpoint.get("signature") != signature:
             raise ValueError(
-                "GPU checkpoint does not match current bounds, scoring, or suite contract"
+                "GPU checkpoint does not match current bounds, scoring, suite, "
+                "or runtime contract"
             )
         algorithm = checkpoint["algorithm"]
         seed = int(checkpoint.get("seed", seed))

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -220,6 +220,7 @@ GPU_SUPPORTED_SUITE_NON_BOT_OVERRIDE_PATHS = {
     ("coin_overrides",),
     ("live", "forager_score_hysteresis_pct"),
     ("live", "hedge_mode"),
+    ("live", "max_realized_loss_pct"),
 }
 
 
@@ -797,10 +798,13 @@ def _validate_scope_config(
         )
     if float(config.get("backtest", {}).get("btc_collateral_cap", 0.0) or 0.0) > 0.0:
         raise ValueError("GPU foundation does not support backtest.btc_collateral_cap")
-    if float(config.get("live", {}).get("max_realized_loss_pct", 1.0)) != 1.0:
+    max_realized_loss_pct = float(
+        config.get("live", {}).get("max_realized_loss_pct", 1.0)
+    )
+    if not math.isfinite(max_realized_loss_pct) or max_realized_loss_pct < 0.0:
         raise ValueError(
-            "GPU foundation requires live.max_realized_loss_pct=1.0 because the "
-            "screening proxy does not model the realized-loss gate"
+            "GPU foundation requires a finite non-negative "
+            "live.max_realized_loss_pct"
         )
     exchanges = list(exchanges)
     if len(exchanges) != 1:
@@ -819,6 +823,14 @@ def _validate_scope_config(
             "GPU foundation supports strategy_kind=ema_anchor or "
             "trailing_martingale only; "
             f"got {strategy_kind!r}"
+        )
+    if max_realized_loss_pct < 1.0 and not (
+        coin_count == 1 and strategy_kind == "ema_anchor"
+    ):
+        raise ValueError(
+            "GPU realized-loss gating currently supports single-coin EMA Anchor; "
+            "Trailing Martingale and multicoin runs require "
+            "live.max_realized_loss_pct>=1.0"
         )
     enabled_sides = [side for side in ("long", "short") if gpu_side_enabled(config, side)]
     if not enabled_sides:

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -22,6 +22,17 @@ MPS_MULTICOIN_DAILY_COLS = 6
 MPS_SCALAR_COLS = 18
 
 
+def _encode_max_realized_loss_pct(value: float) -> float:
+    """Encode a float64 loss fraction without loosening its Metal budget."""
+
+    if value >= 1.0:
+        return 1.0
+    encoded = np.float32(value)
+    if float(encoded) > value:
+        encoded = np.nextafter(encoded, np.float32(-np.inf))
+    return float(encoded)
+
+
 @lru_cache(maxsize=1)
 def _shader_library():
     if not torch.backends.mps.is_available():
@@ -136,6 +147,9 @@ class MpsEmaAnchorRunner:
             raise ValueError(
                 "max_realized_loss_pct must be finite and non-negative"
             )
+        encoded_max_realized_loss_pct = _encode_max_realized_loss_pct(
+            max_realized_loss_pct
+        )
         self.n = int(data["n"])
         self.n_days = int(data["n_days"])
         self.bars = (
@@ -189,7 +203,7 @@ class MpsEmaAnchorRunner:
                 float(self.hedge_mode),
                 float(bool(filter_by_min_effective_cost)),
                 data["max_effective_min_cost"],
-                max_realized_loss_pct,
+                encoded_max_realized_loss_pct,
             ],
             dtype=torch.float32,
             device="mps",

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -122,6 +122,7 @@ class MpsEmaAnchorRunner:
         short_enabled: bool = False,
         hedge_mode: bool = True,
         filter_by_min_effective_cost: bool = False,
+        max_realized_loss_pct: float = 1.0,
     ):
         self.market = market
         self.run_config = run
@@ -130,6 +131,11 @@ class MpsEmaAnchorRunner:
         self.hedge_mode = bool(hedge_mode)
         if not self.long_enabled and not self.short_enabled:
             raise ValueError("MPS EMA proxy requires at least one enabled side")
+        max_realized_loss_pct = float(max_realized_loss_pct)
+        if not np.isfinite(max_realized_loss_pct) or max_realized_loss_pct < 0.0:
+            raise ValueError(
+                "max_realized_loss_pct must be finite and non-negative"
+            )
         self.n = int(data["n"])
         self.n_days = int(data["n_days"])
         self.bars = (
@@ -183,6 +189,7 @@ class MpsEmaAnchorRunner:
                 float(self.hedge_mode),
                 float(bool(filter_by_min_effective_cost)),
                 data["max_effective_min_cost"],
+                max_realized_loss_pct,
             ],
             dtype=torch.float32,
             device="mps",

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -438,6 +438,9 @@ class MpsSingleCoinProxy:
             filter_by_min_effective_cost=bool(
                 backtest_params["filter_by_min_effective_cost"]
             ),
+            max_realized_loss_pct=float(
+                backtest_params.get("max_realized_loss_pct", 1.0)
+            ),
         )
 
     def _parameter_matrix(self, candidates: list[dict]) -> np.ndarray:

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -618,6 +618,11 @@ def test_gpu_suite_inputs_reject_unsupported_scenario_scope(
             ("live", "forager_score_hysteresis_pct"),
         ),
         ("live.hedge_mode", True, ("live", "hedge_mode")),
+        (
+            "live.max_realized_loss_pct",
+            0.05,
+            ("live", "max_realized_loss_pct"),
+        ),
     ],
 )
 def test_gpu_suite_inputs_accept_modeled_non_bot_overrides(
@@ -1388,12 +1393,6 @@ def test_suite_limit_metric_value_respects_reducer_and_scenario():
             "coin_overrides",
         ),
         (
-            lambda config: config["live"].__setitem__(
-                "max_realized_loss_pct", 0.1
-            ),
-            "max_realized_loss_pct",
-        ),
-        (
             lambda config: config["bot"]["long"]["risk"].__setitem__(
                 "position_exposure_enforcer_enabled", True
             ),
@@ -1411,6 +1410,47 @@ def test_gpu_foundation_fails_closed_for_unsupported_scope(mutate, message):
 
 def test_gpu_foundation_accepts_ema_long_single():
     assert _validate_scope(_long_only_ema_config(), _Evaluator()) == "bybit"
+
+
+@pytest.mark.parametrize("side", ["long", "short"])
+@pytest.mark.parametrize("max_loss_pct", [0.0, 0.1, 0.999, 1.0, 2.0])
+def test_gpu_foundation_accepts_single_coin_ema_realized_loss_gate(
+    side, max_loss_pct
+):
+    config = _directional_ema_config(
+        long_enabled=side == "long", short_enabled=side == "short"
+    )
+    config["live"]["max_realized_loss_pct"] = max_loss_pct
+
+    assert _validate_scope(config, _Evaluator()) == "bybit"
+
+
+@pytest.mark.parametrize("max_loss_pct", [-0.1, float("nan"), float("inf")])
+def test_gpu_foundation_rejects_invalid_realized_loss_gate(max_loss_pct):
+    config = _long_only_ema_config()
+    config["live"]["max_realized_loss_pct"] = max_loss_pct
+
+    with pytest.raises(ValueError, match="finite non-negative"):
+        _validate_scope(config, _Evaluator())
+
+
+@pytest.mark.parametrize(
+    ("config", "evaluator"),
+    [
+        (
+            _directional_tm_config(long_enabled=True, short_enabled=False),
+            _Evaluator(),
+        ),
+        (_long_only_ema_config(), _MulticoinEvaluator()),
+    ],
+)
+def test_gpu_realized_loss_gate_remains_fail_closed_outside_single_ema(
+    config, evaluator
+):
+    config["live"]["max_realized_loss_pct"] = 0.1
+
+    with pytest.raises(ValueError, match="single-coin EMA Anchor"):
+        _validate_scope(config, evaluator)
 
 
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -33,6 +33,7 @@ from optimization.backends.gpu_backend import (
     _gpu_candidate_source_sides,
     _gpu_suite_enabled,
     _gpu_suite_checkpoint_contract,
+    _gpu_runtime_checkpoint_contract,
     _gpu_suite_scenario_override_context,
     _gpu_suite_scenario_inputs,
     _gpu_suite_search_context,
@@ -3634,6 +3635,26 @@ def test_gpu_checkpoint_signature_tracks_effective_suite_contract():
     )
 
 
+def test_gpu_checkpoint_signature_tracks_realized_loss_gate_contract():
+    active = [("long_offset", 0, Bound(0.01, 0.1, 0.01))]
+    scoring = [{"goal": "max", "metric": "adg_strategy_eq"}]
+    config = _long_only_ema_config()
+    proxy = SimpleNamespace(coin_override_contract={"values": []})
+    original_contract = _gpu_runtime_checkpoint_contract(config, proxy)
+    original = _checkpoint_signature(
+        active, scoring, runtime_contract=original_contract
+    )
+
+    config["live"]["max_realized_loss_pct"] = 0.05
+    changed_contract = _gpu_runtime_checkpoint_contract(config, proxy)
+
+    assert changed_contract["max_realized_loss_pct"] == 0.05
+    assert (
+        _checkpoint_signature(active, scoring, runtime_contract=changed_contract)
+        != original
+    )
+
+
 def test_gpu_checkpoint_signature_tracks_prepared_coin_override_contract():
     active = [("long_offset", 0, Bound(0.01, 0.1, 0.01))]
     scoring = [{"goal": "max", "metric": "adg_strategy_eq"}]
@@ -3715,6 +3736,7 @@ def test_gpu_suite_checkpoint_contract_tracks_prepared_scenario_identity():
             "coin_count": 2,
             "strategy_kind": "ema_anchor",
             "enabled_sides": ["long"],
+            "max_realized_loss_pct": 1.0,
             "candle_count": 3,
             "first_timestamp": 1000,
             "last_timestamp": 3000,
@@ -3733,6 +3755,13 @@ def test_gpu_suite_checkpoint_contract_tracks_prepared_scenario_identity():
             "coin_overrides": {},
         }
     ]
+
+    changed_loss_gate = copy.deepcopy(item)
+    changed_loss_gate["config"]["live"]["max_realized_loss_pct"] = 0.05
+    changed = _gpu_suite_checkpoint_contract(config, [changed_loss_gate])
+
+    assert changed != original
+    assert changed["prepared_scenarios"][0]["max_realized_loss_pct"] == 0.05
 
     changed_coins = copy.deepcopy(item)
     changed_coins["coins"] = ["BTC", "SOL"]

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -19,6 +19,22 @@ from optimization.gpu.model import (
     build_mps_data,
     build_mps_multicoin_data,
 )
+from optimization.gpu.mps_kernel import _encode_max_realized_loss_pct
+
+
+@pytest.mark.parametrize(
+    "value", [0.0, 0.05, 0.999999999, float(np.nextafter(1.0, 0.0))]
+)
+def test_mps_realized_loss_limit_float32_encoding_never_loosens(value):
+    encoded = _encode_max_realized_loss_pct(value)
+
+    assert encoded <= value
+    assert encoded < 1.0
+
+
+@pytest.mark.parametrize("value", [1.0, 2.0, 1.0e100])
+def test_mps_disabled_realized_loss_limit_has_finite_float32_encoding(value):
+    assert _encode_max_realized_loss_pct(value) == 1.0
 
 
 def _single_coin_exposure_fields(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -314,6 +314,7 @@ def test_mps_ema_anchor_shader_smoke():
     assert "total_exposure_reducer_qty" in source
     assert "secondary_close_qty" in source
     assert "realized_loss_gate_allows" in source
+    assert "float32_floor_nonnegative" in source
     assert "record_realized_net" in source
     assert "const float max_realized_loss_pct = settings[14]" in source
     assert "constant int SCALAR_COLS = 18" in source
@@ -1610,6 +1611,72 @@ def test_mps_ema_realized_loss_gate_reserves_unfilled_batch_loss():
     assert sizes["ungated_short"] < 8.0, sizes
     assert sizes["gated_long"] > 8.0, sizes
     assert sizes["gated_short"] > 8.0, sizes
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_ema_zero_loss_budget_blocks_loss_below_balance_ulp():
+    count = 6
+    close = np.full(count, 100.0)
+    high = np.array([100.0, 100.0, 100.0, 100.01, 100.01, 100.0])
+    low = np.array([100.0, 100.0, 100.0, 99.99, 99.99, 100.0])
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.000001, 0.01, 0.000001, 0.0, 1.0, 0.001)
+    run = ProxyRun(
+        100_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    values = {
+        "base_qty_pct": 0.000001,
+        "ema_span_0": 2.0,
+        "ema_span_1": 3.0,
+        "entry_double_down_factor": 0.0,
+        "offset": 0.0,
+        "offset_psize_weight": 0.0,
+        "offset_volatility_1h_weight": 0.0,
+        "offset_volatility_1m_weight": 0.0,
+        "offset_volatility_ema_span_1h": 2.0,
+        "offset_volatility_ema_span_1m": 2.0,
+        "entry_cooldown_minutes": 100.0,
+        "total_wallet_exposure_limit": 1.0,
+        "we_excess_allowance_pct": 0.0,
+        "we_excess_allowance_legacy_raw": 0.0,
+        "twel_entry_gate_enabled": 0.0,
+        "twel_enforcer_threshold": 1.0,
+        "twel_enforcer_enabled": 0.0,
+    }
+    row = [values[key] for key in EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS]
+
+    ungated = MpsEmaAnchorRunner(
+        market,
+        run,
+        data,
+        long_enabled=True,
+        short_enabled=False,
+        max_realized_loss_pct=1.0,
+    ).run(np.asarray([row + row], dtype=np.float64))
+    gated = MpsEmaAnchorRunner(
+        market,
+        run,
+        data,
+        long_enabled=True,
+        short_enabled=False,
+        max_realized_loss_pct=0.0,
+    ).run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert ungated["psize"][0].item() == pytest.approx(0.0)
+    assert gated["psize"][0].item() > 0.0009
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -297,6 +297,9 @@ def test_mps_ema_anchor_shader_smoke():
     assert "constant int SIDE_PARAMS = 17" in source
     assert "total_exposure_reducer_qty" in source
     assert "secondary_close_qty" in source
+    assert "realized_loss_gate_allows" in source
+    assert "record_realized_net" in source
+    assert "const float max_realized_loss_pct = settings[14]" in source
     assert "constant int SCALAR_COLS = 18" in source
     assert "side.psize * price_now * c_mult / balance" in source
     assert "short_side.psize * c_mult * (short_side.pprice - close)" in source
@@ -1389,6 +1392,208 @@ def test_mps_ema_single_coin_total_exposure_repair(side):
         output["day_volume"][1].sum().item()
         > output["day_volume"][0].sum().item()
     )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_ema_realized_loss_gate_blocks_lossy_total_exposure_repair(side):
+    count = 10
+    close = np.full(count, 100.0)
+    high = np.full(count, 102.0)
+    low = np.full(count, 98.0)
+    if side == "long":
+        close[2:] = 99.9
+        high[2:] = 99.9
+        low[3] = 98.0
+        low[4:] = 99.9
+    else:
+        close[2:] = 100.1
+        high[3] = 102.0
+        high[4:] = 100.1
+        low[2:] = 100.1
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(1.0, 0.01, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    values = {
+        "base_qty_pct": 1.0,
+        "ema_span_0": 2.0,
+        "ema_span_1": 3.0,
+        "entry_double_down_factor": 0.0,
+        "offset": 0.0,
+        "offset_psize_weight": 0.0,
+        "offset_volatility_1h_weight": 0.0,
+        "offset_volatility_1m_weight": 0.0,
+        "offset_volatility_ema_span_1h": 2.0,
+        "offset_volatility_ema_span_1m": 2.0,
+        "entry_cooldown_minutes": 100.0,
+        "total_wallet_exposure_limit": 1.0,
+        "we_excess_allowance_pct": 0.0,
+        "we_excess_allowance_legacy_raw": 0.0,
+        "twel_entry_gate_enabled": 0.0,
+        "twel_enforcer_threshold": 0.5,
+        "twel_enforcer_enabled": 1.0,
+    }
+    row = [values[key] for key in EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS]
+    kwargs = {
+        "long_enabled": side == "long",
+        "short_enabled": side == "short",
+    }
+
+    ungated = MpsEmaAnchorRunner(
+        market, run, data, max_realized_loss_pct=1.0, **kwargs
+    ).run(np.asarray([row + row], dtype=np.float64))
+    gated = MpsEmaAnchorRunner(
+        market, run, data, max_realized_loss_pct=0.0, **kwargs
+    ).run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    assert ungated[size_key][0].item() < gated[size_key][0].item()
+    assert gated[size_key][0].item() > 8.0
+    assert gated["balance"][0].item() >= ungated["balance"][0].item()
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_ema_realized_loss_gate_shares_budget_between_sides():
+    count = 8
+    close = np.full(count, 100.0)
+    high = np.full(count, 102.0)
+    low = np.full(count, 98.0)
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(1.0, 0.01, 0.001, 0.0, 1.0, 0.001)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    values = {
+        "base_qty_pct": 1.0,
+        "ema_span_0": 2.0,
+        "ema_span_1": 3.0,
+        "entry_double_down_factor": 0.0,
+        "offset": 0.0,
+        "offset_psize_weight": 0.0,
+        "offset_volatility_1h_weight": 0.0,
+        "offset_volatility_1m_weight": 0.0,
+        "offset_volatility_ema_span_1h": 2.0,
+        "offset_volatility_ema_span_1m": 2.0,
+        "entry_cooldown_minutes": 100.0,
+        "total_wallet_exposure_limit": 1.0,
+        "we_excess_allowance_pct": 0.0,
+        "we_excess_allowance_legacy_raw": 0.0,
+        "twel_entry_gate_enabled": 0.0,
+        "twel_enforcer_threshold": 0.5,
+        "twel_enforcer_enabled": 1.0,
+    }
+    row = [values[key] for key in EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS]
+
+    output = MpsEmaAnchorRunner(
+        market,
+        run,
+        data,
+        long_enabled=True,
+        short_enabled=True,
+        hedge_mode=True,
+        max_realized_loss_pct=0.0031,
+    ).run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    sizes = sorted([output["psize"][0].item(), output["short_psize"][0].item()])
+    assert sizes[0] < 8.0
+    assert sizes[1] > 8.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_ema_realized_loss_gate_reserves_unfilled_batch_loss():
+    count = 6
+    close = np.array([100.0, 100.0, 100.0, 100.0, 99.9, 99.9])
+    high = np.array([100.0, 100.0, 100.0, 100.01, 99.9, 99.9])
+    low = np.array([100.0, 100.0, 100.0, 99.99, 99.9, 99.9])
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(1.0, 0.01, 0.001, 0.0, 1.0, 0.001)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    values = {
+        "base_qty_pct": 1.0,
+        "ema_span_0": 2.0,
+        "ema_span_1": 3.0,
+        "entry_double_down_factor": 0.0,
+        "offset": 0.0,
+        "offset_psize_weight": 0.0,
+        "offset_volatility_1h_weight": 0.0,
+        "offset_volatility_1m_weight": 0.0,
+        "offset_volatility_ema_span_1h": 2.0,
+        "offset_volatility_ema_span_1m": 2.0,
+        "entry_cooldown_minutes": 100.0,
+        "total_wallet_exposure_limit": 1.0,
+        "we_excess_allowance_pct": 0.0,
+        "we_excess_allowance_legacy_raw": 0.0,
+        "twel_entry_gate_enabled": 0.0,
+        "twel_enforcer_threshold": 0.5,
+        "twel_enforcer_enabled": 1.0,
+    }
+    row = [values[key] for key in EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS]
+    common = {
+        "long_enabled": True,
+        "short_enabled": True,
+        "hedge_mode": True,
+    }
+
+    ungated = MpsEmaAnchorRunner(
+        market, run, data, max_realized_loss_pct=1.0, **common
+    ).run(np.asarray([row + row], dtype=np.float64))
+    gated = MpsEmaAnchorRunner(
+        market, run, data, max_realized_loss_pct=0.0031, **common
+    ).run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    sizes = {
+        "ungated_long": ungated["psize"][0].item(),
+        "ungated_short": ungated["short_psize"][0].item(),
+        "gated_long": gated["psize"][0].item(),
+        "gated_short": gated["short_psize"][0].item(),
+    }
+    assert sizes["ungated_long"] > 8.0, sizes
+    assert sizes["ungated_short"] < 8.0, sizes
+    assert sizes["gated_long"] > 8.0, sizes
+    assert sizes["gated_short"] > 8.0, sizes
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Summary:
- add cumulative realized-loss gating to the single-coin EMA Anchor Metal proxy for long, short, hedge-mode, and one-way optimization
- account for entry and close maker fees, reserve the shared generation loss budget reducer-first, and preserve the ordinary-close fallback when a TWEL reducer is rejected
- accept suite overrides for the modeled setting while keeping Trailing Martingale and multicoin nondefault gates fail closed
- document the conservative all-history proxy envelope; exact Rust remains authoritative for configured rolling lookback behavior

Validation:
- full Python pytest suite passed
- Apple MPS suite: 133 passed
- focused backend and service suites passed
- Rust: 262 passed with cargo test --no-default-features; cargo check and cargo fmt check passed
- real Bybit ETH EMA Anchor CLI smoke with max_realized_loss_pct 0.05 completed 8 generations, 32768 proxy evaluations, and 64 exact validations in 19.8 seconds without drift halt

This is GPU parity slice 28 and is purely additive to the CPU optimizer and normal bot/backtest paths.