### PR TITLE
feat(optimize): gate TM losses on MPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
-- Added cumulative realized-loss gating to single-coin Apple MPS EMA Anchor screening for long,
-  short, hedge-mode, and one-way runs. Metal tracks a conservative all-history peak-relative
-  realized net-PnL budget, including maker fees, and blocks lossy ordinary or exposure-repair
-  closes that exceed it. Exact Rust remains authoritative for the configured rolling PnL lookback;
-  unsupported Trailing Martingale and multicoin combinations remain fail closed.
+- Added realized-loss gating to single-coin Apple MPS EMA Anchor and Trailing Martingale screening
+  for long, short, hedge-mode, and one-way runs. EMA Anchor tracks a conservative all-history
+  peak-relative realized net-PnL budget, including maker fees, and blocks lossy ordinary or
+  exposure-repair closes that exceed it. To avoid enumerating a recursive 500-rung ladder every
+  candle, Trailing Martingale uses a stricter zero-loss proxy envelope whenever the gate is active.
+  Exact Rust remains authoritative for the configured rolling PnL lookback and allowance;
+  multicoin realized-loss gating remains fail closed.
 
 - Expanded Apple MPS optimizer scoring and limits with weighted strategy-equity MDG, Sharpe,
   Sortino, Omega, Calmar, and Sterling metrics. The proxy maps the exact optimizer's ten-subset

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -155,8 +155,11 @@ The supported slice is intentionally narrow:
 - single-coin EMA Anchor models the cumulative realized-loss gate, including entry and close fees,
   shared long/short loss-budget accounting, and lossy total-exposure repairs. The proxy uses a
   conservative all-history loss envelope, so it may block a close that exact Rust admits after old
-  PnL ages out of `live.pnls_max_lookback_days`; exact validation remains authoritative. Trailing
-  Martingale and multicoin realized-loss gating remain fail closed
+  PnL ages out of `live.pnls_max_lookback_days`. Single-coin Trailing Martingale uses a stricter
+  zero-loss envelope whenever the gate is active: only clearly profitable closes after maker fees
+  are admitted by Metal, avoiding per-candle enumeration of its recursive 500-rung close ladder.
+  Exact validation applies the configured rolling allowance and remains authoritative. Multicoin
+  realized-loss gating remains fail closed
 - BTC collateral remains disabled; dual-side multicoin total-exposure repair remains disabled
 - `backtest.filter_by_min_effective_cost` may be enabled or disabled. When enabled, Metal uses the
   projected initial-entry cost test with the configured wallet-exposure limit. The

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -147,6 +147,9 @@ mod tests {
         assert!(source.contains("entry_gen_balance"));
         assert!(source.contains("close_gen_balance"));
         assert!(source.contains("recursive_close_groups"));
+        assert!(source.contains("realized_loss_proxy_allows_close"));
+        assert!(source.contains("const bool loss_gate_enabled = settings[14] < 1.0f"));
+        assert!(source.contains("the proxy uses a zero-loss envelope"));
         assert!(source.contains("int grid_rung_limit = strategy_wel_qty > 0.0f ? 499 : 500"));
         assert!(source.contains("long_side.close_gen_psize - strategy_wel_qty"));
         assert!(source.contains("short_side.close_gen_psize - strategy_wel_qty"));

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -46,6 +46,29 @@ inline bool passes_min_effective_cost(
         && projected_cost_lower >= max_effective_min_cost;
 }
 
+inline bool realized_loss_proxy_allows_close(
+    float qty, float close_price, float pprice, bool is_long,
+    float c_mult, float maker_fee, bool gate_enabled
+) {
+    if (!gate_enabled) return true;
+    if (!(qty > 0.0f && close_price > 0.0f && pprice > 0.0f)) return false;
+    float gross_pnl = qty * c_mult
+        * (is_long ? close_price - pprice : pprice - close_price);
+    float fee = qty * close_price * c_mult * maker_fee;
+    float net_pnl = gross_pnl - fee;
+    // Enumerating and reserving the recursive TM close ladder at every candle
+    // would make screening proportional to its 500-rung exact upper bound.
+    // Instead, the proxy uses a zero-loss envelope whenever Rust's gate is
+    // active. Require 1024 float32 unit roundoffs: twice the recursive rung
+    // bound, covering accumulated position-price drift plus this projection,
+    // so a rounded break-even result is not admitted as non-loss-making.
+    // Exact Rust remains authoritative.
+    float arithmetic_scale = fabs(gross_pnl) + fabs(fee)
+        + qty * fabs(c_mult) * (fabs(close_price) + fabs(pprice));
+    float margin = 1.220703125e-4f * arithmetic_scale;
+    return isfinite(net_pnl) && net_pnl > margin;
+}
+
 struct TmSide {
     float alpha0, alpha1, alpha2, alpha1m, alpha1h;
     float ddf, initial_ema_dist, initial_qty_pct;
@@ -63,6 +86,7 @@ struct TmSide {
     bool twel_enforcer_enabled;
     float twel_enforcer_threshold;
     bool close_is_exposure_reducer, close_is_twel_reducer;
+    bool close_loss_gate_disabled_reducers;
     float ema0, ema1, ema2, vol1m, vol1h;
     float psize, pprice, last_inc_k, pos_open_k;
     int entry_ticks, close_ticks, secondary_close_ticks;
@@ -137,6 +161,7 @@ inline TmSide load_side(constant float* p, int o, float seed) {
     s.twel_enforcer_threshold = twel_threshold;
     s.close_is_exposure_reducer = false;
     s.close_is_twel_reducer = false;
+    s.close_loss_gate_disabled_reducers = false;
     s.ema0 = seed; s.ema1 = seed; s.ema2 = seed;
     s.vol1m = 0.0f; s.vol1h = 0.0f;
     s.psize = 0.0f; s.pprice = 0.0f;
@@ -337,6 +362,7 @@ inline void generate_orders(
     s.close_gen_touch_min_qty_relation = touch_min_qty_relation;
     s.close_is_exposure_reducer = false;
     s.close_is_twel_reducer = false;
+    s.close_loss_gate_disabled_reducers = false;
     s.secondary_close_ticks = 0;
     s.secondary_close_price = 0.0f;
     s.secondary_close_qty = 0.0f;
@@ -729,6 +755,7 @@ inline void passivbot_single_coin_impl(
     const bool hedge_mode = settings[11] > 0.5f;
     const bool filter_by_min_effective_cost = settings[12] > 0.5f;
     const float max_effective_min_cost = settings[13];
+    const bool loss_gate_enabled = settings[14] < 1.0f;
     const float log_bin_scale = 127.0f / log(4000001.0f);
 
     const int po = int(b) * P;
@@ -841,6 +868,10 @@ inline void passivbot_single_coin_impl(
         }
         if (long_scan_close_grid && long_recursive_close) {
             TmSide grid_source = long_side;
+            if (long_side.close_loss_gate_disabled_reducers) {
+                grid_source.wel_enforcer_enabled = false;
+                grid_source.twel_enforcer_enabled = false;
+            }
             float reducer_qty = 0.0f;
             int reducer_ticks = 0;
             float reducer_price = 0.0f;
@@ -984,16 +1015,22 @@ inline void passivbot_single_coin_impl(
                     float pnl = reducer_qty * c_mult
                         * (reducer_price - long_side.pprice);
                     float fee = reducer_qty * reducer_price * c_mult * maker_fee;
-                    balance += pnl - fee;
-                    long_side.psize = fmax(
-                        round_step(
-                            long_side.psize - reducer_qty, qty_step
-                        ),
-                        0.0f
-                    );
-                    day_volume += reducer_qty * reducer_price / balance;
-                    long_close_fill = true;
-                    reducer_executed = true;
+                    if (!realized_loss_proxy_allows_close(
+                            reducer_qty, reducer_price, long_side.pprice, true,
+                            c_mult, maker_fee, loss_gate_enabled)) {
+                        reducer_reachable = false;
+                    } else {
+                        balance += pnl - fee;
+                        long_side.psize = fmax(
+                            round_step(
+                                long_side.psize - reducer_qty, qty_step
+                            ),
+                            0.0f
+                        );
+                        day_volume += reducer_qty * reducer_price / balance;
+                        long_close_fill = true;
+                        reducer_executed = true;
+                    }
                 }
                 if (group.ticks > high_fill_max_tick) break;
                 float group_qty = trimmed_group_qty;
@@ -1001,6 +1038,9 @@ inline void passivbot_single_coin_impl(
                 float adj = fmin(round_step(group_qty, qty_step), long_side.psize);
                 float pnl = adj * c_mult * (group.price - long_side.pprice);
                 float fee = adj * group.price * c_mult * maker_fee;
+                if (!realized_loss_proxy_allows_close(
+                        adj, group.price, long_side.pprice, true,
+                        c_mult, maker_fee, loss_gate_enabled)) continue;
                 balance += pnl - fee;
                 float new_psize = fmax(
                     round_step(long_side.psize - adj, qty_step), 0.0f
@@ -1026,12 +1066,16 @@ inline void passivbot_single_coin_impl(
                 float pnl = adj * c_mult
                     * (reducer_price - long_side.pprice);
                 float fee = adj * reducer_price * c_mult * maker_fee;
-                balance += pnl - fee;
-                long_side.psize = fmax(
-                    round_step(long_side.psize - adj, qty_step), 0.0f
-                );
-                day_volume += adj * reducer_price / balance;
-                long_close_fill = true;
+                if (realized_loss_proxy_allows_close(
+                        adj, reducer_price, long_side.pprice, true,
+                        c_mult, maker_fee, loss_gate_enabled)) {
+                    balance += pnl - fee;
+                    long_side.psize = fmax(
+                        round_step(long_side.psize - adj, qty_step), 0.0f
+                    );
+                    day_volume += adj * reducer_price / balance;
+                    long_close_fill = true;
+                }
             }
             if (long_close_fill && long_side.psize <= 0.0f
                 && long_side.pprice > 0.0f) {
@@ -1063,6 +1107,9 @@ inline void passivbot_single_coin_impl(
                 );
                 float pnl = adj * c_mult * (cp - long_side.pprice);
                 float fee = adj * cp * c_mult * maker_fee;
+                if (!realized_loss_proxy_allows_close(
+                        adj, cp, long_side.pprice, true,
+                        c_mult, maker_fee, loss_gate_enabled)) continue;
                 balance += pnl - fee;
                 long_side.psize = fmax(
                     round_step(long_side.psize - adj, qty_step), 0.0f
@@ -1175,6 +1222,10 @@ inline void passivbot_single_coin_impl(
         }
         if (short_scan_close_grid && short_recursive_close) {
             TmSide grid_source = short_side;
+            if (short_side.close_loss_gate_disabled_reducers) {
+                grid_source.wel_enforcer_enabled = false;
+                grid_source.twel_enforcer_enabled = false;
+            }
             float reducer_qty = 0.0f;
             int reducer_ticks = 0;
             float reducer_price = 0.0f;
@@ -1318,16 +1369,22 @@ inline void passivbot_single_coin_impl(
                     float pnl = reducer_qty * c_mult
                         * (short_side.pprice - reducer_price);
                     float fee = reducer_qty * reducer_price * c_mult * maker_fee;
-                    balance += pnl - fee;
-                    short_side.psize = fmax(
-                        round_step(
-                            short_side.psize - reducer_qty, qty_step
-                        ),
-                        0.0f
-                    );
-                    day_volume += reducer_qty * reducer_price / balance;
-                    short_close_fill = true;
-                    reducer_executed = true;
+                    if (!realized_loss_proxy_allows_close(
+                            reducer_qty, reducer_price, short_side.pprice, false,
+                            c_mult, maker_fee, loss_gate_enabled)) {
+                        reducer_reachable = false;
+                    } else {
+                        balance += pnl - fee;
+                        short_side.psize = fmax(
+                            round_step(
+                                short_side.psize - reducer_qty, qty_step
+                            ),
+                            0.0f
+                        );
+                        day_volume += reducer_qty * reducer_price / balance;
+                        short_close_fill = true;
+                        reducer_executed = true;
+                    }
                 }
                 if (group.ticks <= low_nonfill_max_tick) break;
                 float group_qty = trimmed_group_qty;
@@ -1335,6 +1392,9 @@ inline void passivbot_single_coin_impl(
                 float adj = fmin(round_step(group_qty, qty_step), short_side.psize);
                 float pnl = adj * c_mult * (short_side.pprice - group.price);
                 float fee = adj * group.price * c_mult * maker_fee;
+                if (!realized_loss_proxy_allows_close(
+                        adj, group.price, short_side.pprice, false,
+                        c_mult, maker_fee, loss_gate_enabled)) continue;
                 balance += pnl - fee;
                 float new_psize = fmax(
                     round_step(short_side.psize - adj, qty_step), 0.0f
@@ -1360,12 +1420,16 @@ inline void passivbot_single_coin_impl(
                 float pnl = adj * c_mult
                     * (short_side.pprice - reducer_price);
                 float fee = adj * reducer_price * c_mult * maker_fee;
-                balance += pnl - fee;
-                short_side.psize = fmax(
-                    round_step(short_side.psize - adj, qty_step), 0.0f
-                );
-                day_volume += adj * reducer_price / balance;
-                short_close_fill = true;
+                if (realized_loss_proxy_allows_close(
+                        adj, reducer_price, short_side.pprice, false,
+                        c_mult, maker_fee, loss_gate_enabled)) {
+                    balance += pnl - fee;
+                    short_side.psize = fmax(
+                        round_step(short_side.psize - adj, qty_step), 0.0f
+                    );
+                    day_volume += adj * reducer_price / balance;
+                    short_close_fill = true;
+                }
             }
             if (short_close_fill && short_side.psize <= 0.0f
                 && short_side.pprice > 0.0f) {
@@ -1397,6 +1461,9 @@ inline void passivbot_single_coin_impl(
                 );
                 float pnl = adj * c_mult * (short_side.pprice - cp);
                 float fee = adj * cp * c_mult * maker_fee;
+                if (!realized_loss_proxy_allows_close(
+                        adj, cp, short_side.pprice, false,
+                        c_mult, maker_fee, loss_gate_enabled)) continue;
                 balance += pnl - fee;
                 short_side.psize = fmax(
                     round_step(short_side.psize - adj, qty_step), 0.0f
@@ -1572,6 +1639,88 @@ inline void passivbot_single_coin_impl(
                     touch_min_qty_relation, price_step, min_qty,
                     min_cost, c_mult, kf, block_short_initial
                 );
+            }
+            // Exact Rust tries the next-largest protective reducer when the
+            // winner is loss-gated, then falls back to the ordinary strategy
+            // ladder. Re-generate only this uncommon gated path; ordinary
+            // recursive groups are screened individually when reachable.
+            if (long_enabled && loss_gate_enabled
+                && long_side.close_is_exposure_reducer
+                && !realized_loss_proxy_allows_close(
+                    long_side.close_qty, long_side.close_price,
+                    long_side.pprice, true, c_mult, maker_fee, true
+                )) {
+                bool wel_enabled = long_side.wel_enforcer_enabled;
+                bool twel_enabled = long_side.twel_enforcer_enabled;
+                if (long_side.close_is_twel_reducer) {
+                    long_side.twel_enforcer_enabled = false;
+                } else {
+                    long_side.wel_enforcer_enabled = false;
+                }
+                generate_long_orders(
+                    long_side, balance, close, qty_step, touch_down_tick,
+                    touch_up_tick, touch_nearest_tick, touch_min_qty,
+                    touch_min_qty_relation, price_step, min_qty,
+                    min_cost, c_mult, kf, block_long_initial
+                );
+                if (!long_side.close_is_exposure_reducer) {
+                    long_side.close_loss_gate_disabled_reducers = true;
+                } else if (long_side.close_is_exposure_reducer
+                    && !realized_loss_proxy_allows_close(
+                        long_side.close_qty, long_side.close_price,
+                        long_side.pprice, true, c_mult, maker_fee, true
+                    )) {
+                    long_side.wel_enforcer_enabled = false;
+                    long_side.twel_enforcer_enabled = false;
+                    generate_long_orders(
+                        long_side, balance, close, qty_step, touch_down_tick,
+                        touch_up_tick, touch_nearest_tick, touch_min_qty,
+                        touch_min_qty_relation, price_step, min_qty,
+                        min_cost, c_mult, kf, block_long_initial
+                    );
+                    long_side.close_loss_gate_disabled_reducers = true;
+                }
+                long_side.wel_enforcer_enabled = wel_enabled;
+                long_side.twel_enforcer_enabled = twel_enabled;
+            }
+            if (short_enabled && loss_gate_enabled
+                && short_side.close_is_exposure_reducer
+                && !realized_loss_proxy_allows_close(
+                    short_side.close_qty, short_side.close_price,
+                    short_side.pprice, false, c_mult, maker_fee, true
+                )) {
+                bool wel_enabled = short_side.wel_enforcer_enabled;
+                bool twel_enabled = short_side.twel_enforcer_enabled;
+                if (short_side.close_is_twel_reducer) {
+                    short_side.twel_enforcer_enabled = false;
+                } else {
+                    short_side.wel_enforcer_enabled = false;
+                }
+                generate_short_orders(
+                    short_side, balance, close, qty_step, touch_down_tick,
+                    touch_up_tick, touch_nearest_tick, touch_min_qty,
+                    touch_min_qty_relation, price_step, min_qty,
+                    min_cost, c_mult, kf, block_short_initial
+                );
+                if (!short_side.close_is_exposure_reducer) {
+                    short_side.close_loss_gate_disabled_reducers = true;
+                } else if (short_side.close_is_exposure_reducer
+                    && !realized_loss_proxy_allows_close(
+                        short_side.close_qty, short_side.close_price,
+                        short_side.pprice, false, c_mult, maker_fee, true
+                    )) {
+                    short_side.wel_enforcer_enabled = false;
+                    short_side.twel_enforcer_enabled = false;
+                    generate_short_orders(
+                        short_side, balance, close, qty_step, touch_down_tick,
+                        touch_up_tick, touch_nearest_tick, touch_min_qty,
+                        touch_min_qty_relation, price_step, min_qty,
+                        min_cost, c_mult, kf, block_short_initial
+                    );
+                    short_side.close_loss_gate_disabled_reducers = true;
+                }
+                short_side.wel_enforcer_enabled = wel_enabled;
+                short_side.twel_enforcer_enabled = twel_enabled;
             }
         }
 

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -824,12 +824,10 @@ def _validate_scope_config(
             "trailing_martingale only; "
             f"got {strategy_kind!r}"
         )
-    if max_realized_loss_pct < 1.0 and not (
-        coin_count == 1 and strategy_kind == "ema_anchor"
-    ):
+    if max_realized_loss_pct < 1.0 and coin_count != 1:
         raise ValueError(
-            "GPU realized-loss gating currently supports single-coin EMA Anchor; "
-            "Trailing Martingale and multicoin runs require "
+            "GPU realized-loss gating currently supports single-coin EMA Anchor "
+            "and Trailing Martingale; multicoin runs require "
             "live.max_realized_loss_pct>=1.0"
         )
     enabled_sides = [side for side in ("long", "short") if gpu_side_enabled(config, side)]

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1414,12 +1414,19 @@ def test_gpu_foundation_accepts_ema_long_single():
 
 
 @pytest.mark.parametrize("side", ["long", "short"])
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
 @pytest.mark.parametrize("max_loss_pct", [0.0, 0.1, 0.999, 1.0, 2.0])
-def test_gpu_foundation_accepts_single_coin_ema_realized_loss_gate(
-    side, max_loss_pct
+def test_gpu_foundation_accepts_single_coin_realized_loss_gate(
+    side, strategy_kind, max_loss_pct
 ):
-    config = _directional_ema_config(
-        long_enabled=side == "long", short_enabled=side == "short"
+    builder = (
+        _directional_ema_config
+        if strategy_kind == "ema_anchor"
+        else _directional_tm_config
+    )
+    config = builder(
+        long_enabled=side == "long",
+        short_enabled=side == "short",
     )
     config["live"]["max_realized_loss_pct"] = max_loss_pct
 
@@ -1435,23 +1442,18 @@ def test_gpu_foundation_rejects_invalid_realized_loss_gate(max_loss_pct):
         _validate_scope(config, _Evaluator())
 
 
-@pytest.mark.parametrize(
-    ("config", "evaluator"),
-    [
-        (
-            _directional_tm_config(long_enabled=True, short_enabled=False),
-            _Evaluator(),
-        ),
-        (_long_only_ema_config(), _MulticoinEvaluator()),
-    ],
-)
-def test_gpu_realized_loss_gate_remains_fail_closed_outside_single_ema(
-    config, evaluator
-):
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+def test_gpu_realized_loss_gate_remains_fail_closed_for_multicoin(strategy_kind):
+    builder = (
+        _directional_ema_config
+        if strategy_kind == "ema_anchor"
+        else _directional_tm_config
+    )
+    config = builder(long_enabled=True, short_enabled=False)
     config["live"]["max_realized_loss_pct"] = 0.1
 
-    with pytest.raises(ValueError, match="single-coin EMA Anchor"):
-        _validate_scope(config, evaluator)
+    with pytest.raises(ValueError, match="single-coin EMA Anchor and Trailing Martingale"):
+        _validate_scope(config, _MulticoinEvaluator())
 
 
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -1683,6 +1683,195 @@ def test_mps_ema_zero_loss_budget_blocks_loss_below_balance_ulp():
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_realized_loss_gate_blocks_lossy_total_exposure_repair(side):
+    count = 8
+    close = np.full(count, 100.0)
+    high = np.full(count, 100.0)
+    low = np.full(count, 100.0)
+    high[3], low[3] = 105.0, 95.0
+    if side == "long":
+        close[4:] = 98.0
+        high[4:] = 98.0
+        low[4:] = 97.9
+    else:
+        close[4:] = 102.0
+        high[4:] = 102.1
+        low[4:] = 102.0
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(1.0, 0.01, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_single_row(
+        entry_gate=False,
+        threshold=0.5,
+        twel_enforcer_enabled=True,
+    )
+    row[6] = 1.0
+    row[7] = 10.0
+    row[11] = 0.0
+    row[16] = 10.0
+    row[20] = 0.0
+    kwargs = {
+        "long_enabled": side == "long",
+        "short_enabled": side == "short",
+    }
+
+    ungated = MpsTrailingMartingaleRunner(
+        market, run, data, max_realized_loss_pct=1.0, **kwargs
+    ).run(np.asarray([row + row], dtype=np.float64))
+    gated = MpsTrailingMartingaleRunner(
+        market, run, data, max_realized_loss_pct=0.1, **kwargs
+    ).run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    assert ungated[size_key][0].item() < gated[size_key][0].item()
+    assert gated[size_key][0].item() > 9.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_loss_gate_rebuilds_profitable_ordinary_close_after_reducer(side):
+    count = 8
+    close = np.full(count, 100.0)
+    high = np.full(count, 100.0)
+    low = np.full(count, 100.0)
+    high[3], low[3] = 105.0, 95.0
+    if side == "long":
+        close[4] = high[4] = 98.0
+        low[4] = 97.9
+        high[5] = 100.1
+        low[5] = 98.0
+    else:
+        close[4] = low[4] = 102.0
+        high[4] = 102.1
+        high[5] = 102.0
+        low[5] = 99.9
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(1.0, 0.01, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_single_row(
+        entry_gate=False,
+        threshold=0.5,
+        twel_enforcer_enabled=True,
+    )
+    row[6] = 1.0
+    row[7] = 10.0
+    row[11] = 0.0
+    row[16] = 0.01
+    row[20] = 0.0
+
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+        max_realized_loss_pct=0.1,
+    ).run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    assert output[size_key][0].item() == pytest.approx(0.0)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_realized_loss_gate_blocks_fee_only_ordinary_close(side):
+    count = 7
+    close = np.full(count, 100.0)
+    high = np.full(count, 100.0)
+    low = np.full(count, 100.0)
+    if side == "long":
+        low[2] = 99.99
+        close[3:] = 99.0
+        high[3] = 99.0
+        low[3] = 98.9
+        high[4] = 99.6
+        low[4] = 99.0
+    else:
+        high[2] = 100.01
+        close[3:] = 101.0
+        high[3] = 101.1
+        low[3] = 101.0
+        high[4] = 101.0
+        low[4] = 100.4
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.001)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_single_row(
+        initial_ema_dist=0.0,
+        gate_initial=False,
+        gate_reentry=False,
+        entry_gate=False,
+    )
+    row[6] = 0.1
+    row[7] = 10.0
+    row[11] = 0.0
+    row[16] = -0.005
+    row[17] = 0.0
+    row[20] = 0.0
+    kwargs = {
+        "long_enabled": side == "long",
+        "short_enabled": side == "short",
+    }
+
+    ungated = MpsTrailingMartingaleRunner(
+        market, run, data, max_realized_loss_pct=1.0, **kwargs
+    ).run(np.asarray([row + row], dtype=np.float64))
+    gated = MpsTrailingMartingaleRunner(
+        market, run, data, max_realized_loss_pct=0.1, **kwargs
+    ).run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    assert ungated[size_key][0].item() == pytest.approx(0.0)
+    assert gated[size_key][0].item() > 0.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_tm_equal_wel_twel_reducers_keep_nearer_wel(side):
     count = 6
     close = np.full(count, 100.0)
@@ -3784,6 +3973,9 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert "for (int rung = 0; rung < 500; ++rung)" in source
     assert "ladder_side, ladder_balance" in source
     assert "recursive_close_groups" in source
+    assert "realized_loss_proxy_allows_close" in source
+    assert "const bool loss_gate_enabled = settings[14] < 1.0f" in source
+    assert "the proxy uses a zero-loss envelope" in source
     assert "const bool filter_by_min_effective_cost" in source
     assert "passes_min_effective_cost" in source
     assert "projected_cost_lower" in source


### PR DESCRIPTION
## Summary

- enable `live.max_realized_loss_pct < 1.0` for single-coin Trailing Martingale Apple MPS optimization
- use a conservative zero-loss proxy envelope instead of enumerating the recursive 500-rung close ladder every candle
- include maker fees and a 1024-ULP float32 safety margin when classifying clearly profitable proxy closes
- preserve exact Rust reducer fallback: try the next protective reducer, then rebuild the ordinary close ladder
- retain fail-closed rejection for all multicoin realized-loss-gate runs
- document the proxy/exact contract and update regression coverage

Exact Rust backtests remain authoritative for the configured peak-relative rolling allowance. CPU optimization/backtesting paths are unchanged.

## Validation

- full Python test suite
- full real Apple MPS suite: 147 passed
- GPU backend/service suites
- Rust: 262 passed with `cargo test --no-default-features`
- `cargo check --tests`
- `cargo fmt --check`
- AI docs validator: 0 errors (pre-existing size warnings only)
- real M3/Bybit ETH single-coin long TM optimization with `max_realized_loss_pct=0.05`: 2,048 proxy evaluations, 32 exact validations, 5.3 seconds, no drift/constraint halt, clean shutdown
