### PR TITLE
feat(optimize): gate multicoin EMA losses on MPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
-- Added realized-loss gating to single-coin Apple MPS EMA Anchor and Trailing Martingale screening
-  for long, short, hedge-mode, and one-way runs. EMA Anchor tracks a conservative all-history
-  peak-relative realized net-PnL budget, including maker fees, and blocks lossy ordinary or
-  exposure-repair closes that exceed it. To avoid enumerating a recursive 500-rung ladder every
-  candle, Trailing Martingale uses a stricter zero-loss proxy envelope whenever the gate is active.
-  Exact Rust remains authoritative for the configured rolling PnL lookback and allowance;
-  multicoin realized-loss gating remains fail closed.
+- Added realized-loss gating to Apple MPS EMA Anchor and single-coin Trailing Martingale screening
+  for long, short, hedge-mode, and one-way runs. Single-coin EMA Anchor tracks a conservative
+  all-history peak-relative realized net-PnL budget, including maker fees, and blocks lossy ordinary
+  or exposure-repair closes that exceed it. Multi-coin EMA Anchor and single-coin Trailing
+  Martingale use a stricter zero-loss proxy envelope whenever the gate is active, avoiding unsafe
+  cross-dispatch loss-budget reservation and per-candle enumeration of TM's recursive 500-rung
+  ladder. Exact Rust remains authoritative for the configured rolling PnL lookback and allowance;
+  multi-coin Trailing Martingale realized-loss gating remains fail closed.
 
 - Expanded Apple MPS optimizer scoring and limits with weighted strategy-equity MDG, Sharpe,
   Sortino, Omega, Calmar, and Sterling metrics. The proxy maps the exact optimizer's ten-subset

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -155,11 +155,12 @@ The supported slice is intentionally narrow:
 - single-coin EMA Anchor models the cumulative realized-loss gate, including entry and close fees,
   shared long/short loss-budget accounting, and lossy total-exposure repairs. The proxy uses a
   conservative all-history loss envelope, so it may block a close that exact Rust admits after old
-  PnL ages out of `live.pnls_max_lookback_days`. Single-coin Trailing Martingale uses a stricter
-  zero-loss envelope whenever the gate is active: only clearly profitable closes after maker fees
-  are admitted by Metal, avoiding per-candle enumeration of its recursive 500-rung close ladder.
-  Exact validation applies the configured rolling allowance and remains authoritative. Multicoin
-  realized-loss gating remains fail closed
+  PnL ages out of `live.pnls_max_lookback_days`. Multi-coin EMA Anchor and single-coin Trailing
+  Martingale use a stricter zero-loss envelope whenever the gate is active: only clearly profitable
+  closes after maker fees are admitted by Metal. This avoids unsafe cross-coin or cross-side loss-
+  budget reservation between independent multi-coin dispatches and per-candle enumeration of TM's
+  recursive 500-rung close ladder. Exact validation applies the configured rolling allowance and
+  remains authoritative. Multi-coin Trailing Martingale realized-loss gating remains fail closed
 - BTC collateral remains disabled; dual-side multicoin total-exposure repair remains disabled
 - `backtest.filter_by_min_effective_cost` may be enabled or disabled. When enabled, Metal uses the
   projected initial-entry cost test with the configured wallet-exposure limit. The

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -95,6 +95,8 @@ mod tests {
         assert!(source.contains("twel_enforcer_reduce_portfolio"));
         assert!(source.contains("clamped_market_price"));
         assert!(source.contains("secondary_close_qty"));
+        assert!(source.contains("realized_loss_proxy_allows_close"));
+        assert!(source.contains("const bool loss_gate_enabled = run_settings[5] < 1.0f"));
         assert!(source.contains("current_effective_n_positions"));
         assert!(source.contains("distance == best_distance && c > best"));
         assert!(source.contains("= fma("));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -39,6 +39,25 @@ inline bool finite_positive(float value) {
     return isfinite(value) && value > 0.0f;
 }
 
+inline bool realized_loss_proxy_allows_close(
+    float qty, float close_price, float pprice, bool short_side,
+    float c_mult, float maker_fee, bool gate_enabled
+) {
+    if (!gate_enabled) return true;
+    if (!(qty > 0.0f && close_price > 0.0f && pprice > 0.0f)) return false;
+    float gross_pnl = qty * c_mult * (short_side
+        ? pprice - close_price : close_price - pprice);
+    float fee = qty * close_price * c_mult * maker_fee;
+    float net_pnl = gross_pnl - fee;
+    // A zero-loss envelope avoids shared loss-budget reservations across
+    // independently dispatched coins and sides. The float32 margin covers
+    // 1024 unit roundoffs in accumulated position price and this projection.
+    float arithmetic_scale = fabs(gross_pnl) + fabs(fee)
+        + qty * fabs(c_mult) * (fabs(close_price) + fabs(pprice));
+    float margin = 1.220703125e-4f * arithmetic_scale;
+    return isfinite(net_pnl) && net_pnl > margin;
+}
+
 inline float coin_override_or(
     constant float* coin_overrides, int coin, int column, float fallback
 ) {
@@ -153,6 +172,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
     const float liquidation_floor = run_settings[1];
     const float interval_ms = run_settings[2];
     const float score_hysteresis = fmax(run_settings[4], 0.0f);
+    const bool loss_gate_enabled = run_settings[5] < 1.0f;
     const float log_bin_scale = 127.0f / log(4000001.0f);
 
     float ema0[MAX_COINS];
@@ -887,6 +907,16 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 // ordinary EMA close first, matching finalized_closes_with_reducer.
                 float reducer_qty = twel_close_qty[c];
                 int reducer_tick = twel_close_tick[c];
+                if (reducer_qty > 0.0f && reducer_tick > 0
+                    && !realized_loss_proxy_allows_close(
+                        reducer_qty, float(reducer_tick) * price_step,
+                        pprice[c], short_side, c_mult,
+                        coin_settings[coin_offset + 5], loss_gate_enabled
+                    )) {
+                    reducer_qty = 0.0f;
+                    twel_close_qty[c] = 0.0f;
+                    twel_close_tick[c] = 0;
+                }
                 if (reducer_qty > 0.0f && reducer_tick > 0) {
                     float reducer_price = float(reducer_tick) * price_step;
                     float reducer_min = min_entry_qty(
@@ -940,6 +970,22 @@ inline void passivbot_ema_anchor_multicoin_impl(
                     }
                     close_qty[c] = reducer_qty;
                     close_tick[c] = reducer_tick;
+                }
+                if (close_qty[c] > 0.0f && !realized_loss_proxy_allows_close(
+                        close_qty[c], float(close_tick[c]) * price_step,
+                        pprice[c], short_side, c_mult,
+                        coin_settings[coin_offset + 5], loss_gate_enabled
+                    )) {
+                    close_qty[c] = 0.0f;
+                }
+                if (secondary_close_qty[c] > 0.0f
+                    && !realized_loss_proxy_allows_close(
+                        secondary_close_qty[c],
+                        float(secondary_close_tick[c]) * price_step,
+                        pprice[c], short_side, c_mult,
+                        coin_settings[coin_offset + 5], loss_gate_enabled
+                    )) {
+                    secondary_close_qty[c] = 0.0f;
                 }
             }
 

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -824,10 +824,14 @@ def _validate_scope_config(
             "trailing_martingale only; "
             f"got {strategy_kind!r}"
         )
-    if max_realized_loss_pct < 1.0 and coin_count != 1:
+    if (
+        max_realized_loss_pct < 1.0
+        and coin_count != 1
+        and strategy_kind != "ema_anchor"
+    ):
         raise ValueError(
-            "GPU realized-loss gating currently supports single-coin EMA Anchor "
-            "and Trailing Martingale; multicoin runs require "
+            "GPU realized-loss gating supports EMA Anchor and single-coin "
+            "Trailing Martingale; multicoin Trailing Martingale runs require "
             "live.max_realized_loss_pct>=1.0"
         )
     enabled_sides = [side for side in ("long", "short") if gpu_side_enabled(config, side)]

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -350,6 +350,7 @@ class MpsEmaAnchorMulticoinRunner:
         side: str,
         coin_overrides: np.ndarray | None = None,
         forager_score_hysteresis_pct: float = 0.0,
+        max_realized_loss_pct: float = 1.0,
     ):
         if side not in {"long", "short"}:
             raise ValueError(
@@ -388,6 +389,14 @@ class MpsEmaAnchorMulticoinRunner:
             raise ValueError(
                 "forager_score_hysteresis_pct must be finite and non-negative"
             )
+        max_realized_loss_pct = float(max_realized_loss_pct)
+        if not np.isfinite(max_realized_loss_pct) or max_realized_loss_pct < 0.0:
+            raise ValueError(
+                "max_realized_loss_pct must be finite and non-negative"
+            )
+        encoded_max_realized_loss_pct = _encode_max_realized_loss_pct(
+            max_realized_loss_pct
+        )
         liq_floor = max(0.0, run.starting_balance) * max(
             0.0, run.liquidation_threshold
         )
@@ -398,6 +407,7 @@ class MpsEmaAnchorMulticoinRunner:
                 run.interval_ms,
                 float(side == "short"),
                 forager_score_hysteresis_pct,
+                encoded_max_realized_loss_pct,
             ],
             dtype=torch.float32,
             device="mps",
@@ -536,6 +546,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
         side: str,
         coin_overrides: np.ndarray | None = None,
         forager_score_hysteresis_pct: float = 0.0,
+        max_realized_loss_pct: float = 1.0,
     ):
         super().__init__(
             run,
@@ -543,6 +554,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             side=side,
             coin_overrides=coin_overrides,
             forager_score_hysteresis_pct=forager_score_hysteresis_pct,
+            max_realized_loss_pct=max_realized_loss_pct,
         )
 
     def _pack_params(self, params: np.ndarray) -> np.ndarray:

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -980,6 +980,9 @@ class MpsMulticoinProxy:
             runner_kwargs = {
                 "side": side,
                 "forager_score_hysteresis_pct": self.forager_score_hysteresis_pct,
+                "max_realized_loss_pct": float(
+                    backtest_params.get("max_realized_loss_pct", 1.0)
+                ),
             }
             runner_kwargs["coin_overrides"] = per_side_coin_overrides[side]
             self.runners[side] = runner_cls(

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1442,17 +1442,18 @@ def test_gpu_foundation_rejects_invalid_realized_loss_gate(max_loss_pct):
         _validate_scope(config, _Evaluator())
 
 
-@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
-def test_gpu_realized_loss_gate_remains_fail_closed_for_multicoin(strategy_kind):
-    builder = (
-        _directional_ema_config
-        if strategy_kind == "ema_anchor"
-        else _directional_tm_config
-    )
-    config = builder(long_enabled=True, short_enabled=False)
+def test_gpu_ema_realized_loss_gate_accepts_multicoin():
+    config = _directional_ema_config(long_enabled=True, short_enabled=False)
     config["live"]["max_realized_loss_pct"] = 0.1
 
-    with pytest.raises(ValueError, match="single-coin EMA Anchor and Trailing Martingale"):
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
+
+
+def test_gpu_tm_realized_loss_gate_remains_fail_closed_for_multicoin():
+    config = _directional_tm_config(long_enabled=True, short_enabled=False)
+    config["live"]["max_realized_loss_pct"] = 0.1
+
+    with pytest.raises(ValueError, match="multicoin Trailing Martingale"):
         _validate_scope(config, _MulticoinEvaluator())
 
 

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -66,6 +66,7 @@ def _multicoin_exposure_fixture(
     closes=(100.0, 120.0),
     highs=None,
     lows=None,
+    max_realized_loss_pct=1.0,
 ):
     coin_count = 2
     timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
@@ -136,7 +137,11 @@ def _multicoin_exposure_fixture(
         }
         row = [values[key] for key in EMA_ANCHOR_MULTICOIN_PARAM_KEYS]
         runner = MpsEmaAnchorMulticoinRunner(
-            runs[0], data, side=side, coin_overrides=coin_overrides
+            runs[0],
+            data,
+            side=side,
+            coin_overrides=coin_overrides,
+            max_realized_loss_pct=max_realized_loss_pct,
         )
     else:
         values = {
@@ -185,7 +190,11 @@ def _multicoin_exposure_fixture(
         }
         row = [values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS]
         runner = MpsTrailingMartingaleMulticoinRunner(
-            runs[0], data, side=side, coin_overrides=coin_overrides
+            runs[0],
+            data,
+            side=side,
+            coin_overrides=coin_overrides,
+            max_realized_loss_pct=max_realized_loss_pct,
         )
     return runner, row
 
@@ -415,6 +424,8 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
     assert "twel_enforcer_reduce_portfolio" in source
     assert "clamped_market_price" in source
     assert "secondary_close_qty" in source
+    assert "realized_loss_proxy_allows_close" in source
+    assert "const bool loss_gate_enabled = run_settings[5] < 1.0f" in source
     assert "constant int DAILY_COLS = 6" in source
     assert "day_min_balance" in source
     assert "coin_override_or" in source
@@ -477,9 +488,14 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
     row += _single_coin_exposure_fields() + [0.0, 0.0]
 
     runner = MpsEmaAnchorMulticoinRunner(
-        runs[0], data, side=side, forager_score_hysteresis_pct=0.02
+        runs[0],
+        data,
+        side=side,
+        forager_score_hysteresis_pct=0.02,
+        max_realized_loss_pct=0.1,
     )
     assert runner.settings.cpu()[4].item() == pytest.approx(0.02)
+    assert runner.settings.cpu()[5].item() <= 0.1
     output = runner.run(np.array([row, row], dtype=np.float64))
     torch.mps.synchronize()
 
@@ -499,6 +515,10 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
             data,
             side=side,
             forager_score_hysteresis_pct=-0.01,
+        )
+    with pytest.raises(ValueError, match="max_realized_loss_pct"):
+        MpsEmaAnchorMulticoinRunner(
+            runs[0], data, side=side, max_realized_loss_pct=float("nan")
         )
 
     legacy_long = MpsEmaAnchorMulticoinLongRunner(runs[0], data)
@@ -2917,6 +2937,102 @@ def test_mps_ema_multicoin_total_exposure_repair_policy(side):
     pprice_key = "pprice" if side == "long" else "short_pprice"
     total_twe = (output[pprice_key] / output["balance"]).cpu()
     assert (total_twe < 0.5).all()
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_ema_multicoin_loss_gate_blocks_lossy_total_exposure_repair(side):
+    overrides = np.full((2, 13), np.nan, dtype=np.float32)
+    overrides[0, 11] = 0.1
+    count = 70
+    closes = np.full((count, 2), 100.0)
+    highs = np.full((count, 2), 100.5)
+    lows = np.full((count, 2), 99.5)
+    if side == "long":
+        lows[62, :] = 98.0
+        closes[63:, :] = 98.0
+        highs[63:, :] = 98.0
+        lows[63:, :] = 97.9
+    else:
+        highs[62, :] = 102.0
+        closes[63:, :] = 102.0
+        highs[63:, :] = 102.1
+        lows[63:, :] = 102.0
+
+    runner_kwargs = {
+        "strategy_kind": "ema_anchor",
+        "side": side,
+        "coin_overrides": overrides,
+        "count": count,
+        "closes": closes,
+        "highs": highs,
+        "lows": lows,
+    }
+    ungated_runner, candidate = _multicoin_exposure_fixture(
+        max_realized_loss_pct=1.0, **runner_kwargs
+    )
+    gated_runner, _ = _multicoin_exposure_fixture(
+        max_realized_loss_pct=0.1, **runner_kwargs
+    )
+    values = dict(zip(EMA_ANCHOR_MULTICOIN_PARAM_KEYS, candidate))
+    values.update(
+        {
+            "offset": 0.01,
+            "entry_cooldown_minutes": 100.0,
+            "twel_entry_gate_enabled": 0.0,
+            "twel_enforcer_threshold": 0.5,
+            "twel_enforcer_enabled": 1.0,
+            "twel_enforcer_reduce_portfolio": 1.0,
+        }
+    )
+    candidate = [values[key] for key in EMA_ANCHOR_MULTICOIN_PARAM_KEYS]
+
+    ungated = ungated_runner.run(np.asarray([candidate], dtype=np.float64))
+    gated = gated_runner.run(np.asarray([candidate], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    assert ungated[size_key].item() < gated[size_key].item()
+    assert gated["open_positions"].item() == pytest.approx(2.0)
+    assert gated["balance"].item() >= ungated["balance"].item()
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_ema_multicoin_loss_gate_blocks_fee_only_ordinary_close(side):
+    markets = [
+        ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.001)
+        for _ in range(2)
+    ]
+    runner_kwargs = {
+        "strategy_kind": "ema_anchor",
+        "side": side,
+        "count": 70,
+        "closes": (100.0, 100.0),
+        "markets": markets,
+    }
+    ungated_runner, candidate = _multicoin_exposure_fixture(
+        max_realized_loss_pct=1.0, **runner_kwargs
+    )
+    gated_runner, _ = _multicoin_exposure_fixture(
+        max_realized_loss_pct=0.1, **runner_kwargs
+    )
+    candidate[
+        EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("entry_cooldown_minutes")
+    ] = 100.0
+
+    ungated = ungated_runner.run(np.asarray([candidate], dtype=np.float64))
+    gated = gated_runner.run(np.asarray([candidate], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    assert ungated[size_key].item() == pytest.approx(0.0)
+    assert gated[size_key].item() > 0.0
+    assert gated["balance"].item() >= ungated["balance"].item()
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary

- add conservative realized-loss screening to multi-coin EMA Anchor on Apple MPS
- pass the normalized loss limit through the multi-coin service and runner settings
- keep multi-coin Trailing Martingale fail-closed while preserving all CPU paths
- document the zero-loss proxy envelope and exact-Rust authority

## Safety model

Multi-coin EMA proxy runs dispatch coins and sides independently, so they cannot safely share the exact Rust rolling loss allowance. Whenever `live.max_realized_loss_pct < 1.0`, Metal therefore admits only closes whose projected net PnL is clearly positive after maker fees and a conservative float32 margin. Exact Rust still applies the configured rolling allowance, validates selected candidates, and remains authoritative for persisted results and Pareto membership.

The gate covers ordinary EMA closes and side-wide exposure reducers. Multi-coin Trailing Martingale continues to reject an enabled realized-loss gate.

## Validation

- full Python test suite: pass
- complete real Apple M3/MPS suite: pass
- focused real-MPS long/short regressions for lossy TWEL repair and fee-only ordinary closes: pass
- Rust: `cargo fmt --check`, `cargo check --tests`, and 262 tests pass
- GPU backend/service suites: pass
- AI docs validator: 0 errors, 2 pre-existing size warnings
- real Bybit BTC+SOL long-only EMA smoke, 2024-01 to current, `max_realized_loss_pct=0.1`: 8 generations, 1,024 proxy evaluations, 64 exact validations, clean completion and shutdown in 250.6s

Part of the sequential Apple MPS optimizer parity work. The approach builds on the GPU proof of concept contributed by RustyCZ while retaining Passivbot's exact Rust backtester as the safety authority.
