### PR TITLE
feat(optimize): gate multicoin TM losses on MPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,15 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
-- Added realized-loss gating to Apple MPS EMA Anchor and single-coin Trailing Martingale screening
+- Added realized-loss gating to Apple MPS EMA Anchor and Trailing Martingale screening
   for long, short, hedge-mode, and one-way runs. Single-coin EMA Anchor tracks a conservative
   all-history peak-relative realized net-PnL budget, including maker fees, and blocks lossy ordinary
-  or exposure-repair closes that exceed it. Multi-coin EMA Anchor and single-coin Trailing
+  or exposure-repair closes that exceed it. Multi-coin EMA Anchor and Trailing
   Martingale use a stricter zero-loss proxy envelope whenever the gate is active, avoiding unsafe
   cross-dispatch loss-budget reservation and per-candle enumeration of TM's recursive 500-rung
-  ladder. Exact Rust remains authoritative for the configured rolling PnL lookback and allowance;
-  multi-coin Trailing Martingale realized-loss gating remains fail closed.
+  ladder. Multi-coin TM tries the next admissible WEL/TWEL repair candidate when a larger reducer
+  is blocked and screens reachable recursive close groups independently. Exact Rust remains
+  authoritative for the configured rolling PnL lookback and allowance.
 
 - Expanded Apple MPS optimizer scoring and limits with weighted strategy-equity MDG, Sharpe,
   Sortino, Omega, Calmar, and Sterling metrics. The proxy maps the exact optimizer's ten-subset

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -155,12 +155,12 @@ The supported slice is intentionally narrow:
 - single-coin EMA Anchor models the cumulative realized-loss gate, including entry and close fees,
   shared long/short loss-budget accounting, and lossy total-exposure repairs. The proxy uses a
   conservative all-history loss envelope, so it may block a close that exact Rust admits after old
-  PnL ages out of `live.pnls_max_lookback_days`. Multi-coin EMA Anchor and single-coin Trailing
+  PnL ages out of `live.pnls_max_lookback_days`. Multi-coin EMA Anchor and Trailing
   Martingale use a stricter zero-loss envelope whenever the gate is active: only clearly profitable
   closes after maker fees are admitted by Metal. This avoids unsafe cross-coin or cross-side loss-
   budget reservation between independent multi-coin dispatches and per-candle enumeration of TM's
   recursive 500-rung close ladder. Exact validation applies the configured rolling allowance and
-  remains authoritative. Multi-coin Trailing Martingale realized-loss gating remains fail closed
+  remains authoritative
 - BTC collateral remains disabled; dual-side multicoin total-exposure repair remains disabled
 - `backtest.filter_by_min_effective_cost` may be enabled or disabled. When enabled, Metal uses the
   projected initial-entry cost test with the configured wallet-exposure limit. The

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -187,6 +187,8 @@ mod tests {
         assert!(source.contains("twel_enforcer_enabled"));
         assert!(source.contains("twel_enforcer_reduce_portfolio"));
         assert!(source.contains("twel_close_qty"));
+        assert!(source.contains("realized_loss_proxy_allows_close"));
+        assert!(source.contains("const bool loss_gate_enabled = run_settings[5] < 1.0f"));
         assert!(source.contains("market_price * 0.9995f / price_step"));
         assert_eq!(source.matches("clamped_market_price(").count(), 3);
         assert!(source.contains("finalized_twel_reducer_qty = finalized_reducer_qty"));

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -39,6 +39,26 @@ inline bool finite_positive(float value) {
     return isfinite(value) && value > 0.0f;
 }
 
+inline bool realized_loss_proxy_allows_close(
+    float qty, float close_price, float pprice, bool short_side,
+    float c_mult, float maker_fee, bool gate_enabled
+) {
+    if (!gate_enabled) return true;
+    if (!(qty > 0.0f && close_price > 0.0f && pprice > 0.0f)) return false;
+    float gross_pnl = qty * c_mult * (short_side
+        ? pprice - close_price : close_price - pprice);
+    float fee = qty * close_price * c_mult * maker_fee;
+    float net_pnl = gross_pnl - fee;
+    // Enumerating and reserving every recursive TM close group across all
+    // independently dispatched coins and sides would make screening scale
+    // with the 500-rung exact bound. Use a conservative zero-loss envelope
+    // whenever Rust's configured loss gate is active.
+    float arithmetic_scale = fabs(gross_pnl) + fabs(fee)
+        + qty * fabs(c_mult) * (fabs(close_price) + fabs(pprice));
+    float margin = 1.220703125e-4f * arithmetic_scale;
+    return isfinite(net_pnl) && net_pnl > margin;
+}
+
 inline float coin_override_or(
     constant float* coin_overrides, int coin, int column, float fallback
 ) {
@@ -360,6 +380,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     const float liquidation_floor = run_settings[1];
     const float interval_ms = run_settings[2];
     const float score_hysteresis = fmax(run_settings[4], 0.0f);
+    const bool loss_gate_enabled = run_settings[5] < 1.0f;
     const float log_bin_scale = 127.0f / log(4000001.0f);
 
     float ema0[MAX_COINS];
@@ -566,7 +587,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 && (short_side
                     ? secondary_close_tick[c] > fill_ticks[tick_offset + 1]
                     : secondary_close_tick[c] <= fill_ticks[tick_offset + 0]);
-            bool rebuild_grid = close_ready
+            bool rebuild_grid = psize[c] > 0.0f
                 && close_reconstruct_after_reducer[c];
             if (filled_close || filled_secondary_close || rebuild_grid) {
                 float fill_price = float(close_tick[c]) * price_step;
@@ -776,14 +797,19 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                         float pnl = qty * c_mult * (short_side
                             ? pprice[c] - fill_price
                             : fill_price - pprice[c]);
-                        balance += pnl
-                            - qty * fill_price * c_mult * maker_fee;
-                        psize[c] = fmax(
-                            round_step(psize[c] - qty, qty_step), 0.0f
-                        );
-                        day_volume += qty * fill_price * c_mult / balance;
-                        reducer_executed = true;
-                        executed_close = true;
+                        if (realized_loss_proxy_allows_close(
+                                qty, fill_price, pprice[c], short_side,
+                                c_mult, maker_fee, loss_gate_enabled
+                            )) {
+                            balance += pnl
+                                - qty * fill_price * c_mult * maker_fee;
+                            psize[c] = fmax(
+                                round_step(psize[c] - qty, qty_step), 0.0f
+                            );
+                            day_volume += qty * fill_price * c_mult / balance;
+                            reducer_executed = true;
+                            executed_close = true;
+                        }
                     }
                     bool reachable = short_side
                         ? group.ticks > fill_ticks[tick_offset + 1]
@@ -797,6 +823,12 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     float grid_pnl = grid_qty * c_mult * (short_side
                         ? pprice[c] - group.price
                         : group.price - pprice[c]);
+                    if (!realized_loss_proxy_allows_close(
+                            grid_qty, group.price, pprice[c], short_side,
+                            c_mult, maker_fee, loss_gate_enabled
+                        )) {
+                        continue;
+                    }
                     balance += grid_pnl
                         - grid_qty * group.price * c_mult * maker_fee;
                     psize[c] = fmax(
@@ -830,6 +862,12 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     );
                     float pnl = qty * c_mult * (short_side
                         ? pprice[c] - price : price - pprice[c]);
+                    if (!realized_loss_proxy_allows_close(
+                            qty, price, pprice[c], short_side,
+                            c_mult, maker_fee, loss_gate_enabled
+                        )) {
+                        continue;
+                    }
                     balance += pnl - qty * price * c_mult * maker_fee;
                     psize[c] = fmax(
                         round_step(psize[c] - qty, qty_step), 0.0f
@@ -1251,8 +1289,19 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                         psize[best], ceil_step(reducer_qty, qty_step)
                     );
                     if (reducer_qty <= 1.0e-9f) continue;
-                    twel_close_qty[best] = reducer_qty;
-                    twel_close_tick[best] = reducer_tick;
+                    bool reducer_allowed = realized_loss_proxy_allows_close(
+                            reducer_qty, reducer_price, pprice[best], short_side,
+                            c_mult, coin_settings[coin_offset + 5],
+                            loss_gate_enabled
+                        );
+                    if (reducer_allowed) {
+                        twel_close_qty[best] = reducer_qty;
+                        twel_close_tick[best] = reducer_tick;
+                    }
+                    // Match exact Rust's two-stage contract: TWEL chooses and
+                    // accounts for its action set before the realized-loss
+                    // gate filters those actions.  A filtered reducer must
+                    // not be reallocated to another symbol.
                     running_twe -= fmax(
                         exposure - fmax(
                             round_step(psize[best] - reducer_qty, qty_step),
@@ -1524,18 +1573,26 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 float reducer_qty = raw_twel_reducer_qty;
                 bool use_twel = raw_twel_reducer_qty > 0.0f;
                 float wel_reducer_qty = 0.0f;
+                int wel_reducer_tick = 0;
                 float wel_target = allowed_coin_wel
                     * coin_wel_enforcer_threshold;
                 if (coin_wel_enforcer_enabled
                     && coin_wel_enforcer_threshold > 0.0f
                     && balance > 0.0f && psize[c] > 0.0f && pprice[c] > 0.0f
                     && wel_target > 0.0f && we > wel_target) {
-                    int wel_reducer_tick = short_side ? touch_down : touch_up;
+                    wel_reducer_tick = short_side ? touch_down : touch_up;
                     float wel_reducer_price = float(wel_reducer_tick) * price_step;
                     wel_reducer_qty = exposure_reducer_qty(
                         psize[c], pprice[c], balance, wel_target,
                         wel_reducer_price, qty_step, min_qty, min_cost, c_mult
                     );
+                    if (!realized_loss_proxy_allows_close(
+                            wel_reducer_qty, wel_reducer_price, pprice[c],
+                            short_side, c_mult, coin_settings[coin_offset + 5],
+                            loss_gate_enabled
+                        )) {
+                        wel_reducer_qty = 0.0f;
+                    }
                     float finalized_wel_reducer_qty = finalized_reducer_qty(
                         psize[c], wel_reducer_qty, wel_reducer_price,
                         qty_step, min_qty, min_cost, c_mult
@@ -1616,6 +1673,24 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                         && (!trailing_close || close_triggered)
                     ? clip : 0.0f;
                 close_tick[c] = candidate_close_tick;
+                if (!realized_loss_proxy_allows_close(
+                        close_qty[c], close_price, pprice[c], short_side,
+                        c_mult, coin_settings[coin_offset + 5],
+                        loss_gate_enabled
+                    )) {
+                    if (!trailing_close && close_qty[c] > 0.0f) {
+                        // Exact Rust builds the complete immutable recursive
+                        // grid before filtering each close independently.  A
+                        // loss-making first rung must therefore not hide later
+                        // profitable rungs generated from lower exposure.
+                        close_reconstruct_after_reducer[c] = true;
+                        close_gen_balance[c] = balance;
+                        close_gen_allowed_wel[c] = allowed_coin_wel;
+                        close_grid_gen_psize[c] = psize[c];
+                        close_grid_max_rungs[c] = 500;
+                    }
+                    close_qty[c] = 0.0f;
+                }
                 if (reducer_qty > 0.0f && reducer_tick > 0) {
                     float reducer_price = float(reducer_tick) * price_step;
                     float reducer_min = min_entry_qty(

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -824,16 +824,6 @@ def _validate_scope_config(
             "trailing_martingale only; "
             f"got {strategy_kind!r}"
         )
-    if (
-        max_realized_loss_pct < 1.0
-        and coin_count != 1
-        and strategy_kind != "ema_anchor"
-    ):
-        raise ValueError(
-            "GPU realized-loss gating supports EMA Anchor and single-coin "
-            "Trailing Martingale; multicoin Trailing Martingale runs require "
-            "live.max_realized_loss_pct>=1.0"
-        )
     enabled_sides = [side for side in ("long", "short") if gpu_side_enabled(config, side)]
     if not enabled_sides:
         raise ValueError("GPU foundation requires at least one enabled side")

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1449,12 +1449,11 @@ def test_gpu_ema_realized_loss_gate_accepts_multicoin():
     assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
-def test_gpu_tm_realized_loss_gate_remains_fail_closed_for_multicoin():
+def test_gpu_tm_realized_loss_gate_accepts_multicoin():
     config = _directional_tm_config(long_enabled=True, short_enabled=False)
     config["live"]["max_realized_loss_pct"] = 0.1
 
-    with pytest.raises(ValueError, match="multicoin Trailing Martingale"):
-        _validate_scope(config, _MulticoinEvaluator())
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -582,6 +582,8 @@ def test_mps_trailing_martingale_multicoin_directional_shader_smoke(side):
     assert "coin_override_or" in source
     assert "merge_reducer" not in source
     assert "finalized_reducer_qty" in source
+    assert "realized_loss_proxy_allows_close" in source
+    assert "const bool loss_gate_enabled = run_settings[5] < 1.0f" in source
 
     count = 512
     coin_count = 3
@@ -664,9 +666,15 @@ def test_mps_trailing_martingale_multicoin_directional_shader_smoke(side):
     }
     row = [values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS]
 
-    output = MpsTrailingMartingaleMulticoinRunner(
-        runs[0], data, side=side, forager_score_hysteresis_pct=0.02
-    ).run(np.array([row, row], dtype=np.float64))
+    runner = MpsTrailingMartingaleMulticoinRunner(
+        runs[0],
+        data,
+        side=side,
+        forager_score_hysteresis_pct=0.02,
+        max_realized_loss_pct=0.1,
+    )
+    assert runner.settings.cpu()[5].item() <= 0.1
+    output = runner.run(np.array([row, row], dtype=np.float64))
     torch.mps.synchronize()
 
     assert output["balance"].device.type == "mps"
@@ -2884,6 +2892,264 @@ def test_mps_tm_multicoin_total_exposure_repair_policy(side):
     pprice_key = "pprice" if side == "long" else "short_pprice"
     total_twe = (output[pprice_key] / output["balance"]).cpu()
     assert (total_twe < 0.5).all()
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_loss_gate_blocks_lossy_total_exposure_repair(side):
+    overrides = np.full((2, 28), np.nan, dtype=np.float32)
+    overrides[0, 24] = 0.1
+    runner_kwargs = {
+        "strategy_kind": "trailing_martingale",
+        "side": side,
+        "coin_overrides": overrides,
+        "count": 10,
+        "closes": (100.0, 100.0),
+    }
+    ungated_runner, candidate = _multicoin_exposure_fixture(
+        max_realized_loss_pct=1.0, **runner_kwargs
+    )
+    gated_runner, _ = _multicoin_exposure_fixture(
+        max_realized_loss_pct=0.1, **runner_kwargs
+    )
+    values = dict(zip(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, candidate))
+    values.update(
+        {
+            "entry_cooldown_minutes": 100.0,
+            "twel_entry_gate_enabled": 0.0,
+            "twel_enforcer_threshold": 0.5,
+            "twel_enforcer_enabled": 1.0,
+            "twel_enforcer_reduce_portfolio": 1.0,
+        }
+    )
+    candidate = [
+        values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+    ]
+
+    ungated = ungated_runner.run(np.asarray([candidate], dtype=np.float64))
+    gated = gated_runner.run(np.asarray([candidate], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    assert ungated[size_key].item() < gated[size_key].item()
+    assert gated["open_positions"].item() == pytest.approx(2.0)
+    assert gated["balance"].item() >= ungated["balance"].item()
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_loss_gate_blocks_fee_only_ordinary_close(side):
+    markets = [
+        ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.001)
+        for _ in range(2)
+    ]
+    runner_kwargs = {
+        "strategy_kind": "trailing_martingale",
+        "side": side,
+        "count": 10,
+        "closes": (100.0, 100.0),
+        "markets": markets,
+    }
+    ungated_runner, candidate = _multicoin_exposure_fixture(
+        max_realized_loss_pct=1.0, **runner_kwargs
+    )
+    gated_runner, _ = _multicoin_exposure_fixture(
+        max_realized_loss_pct=0.1, **runner_kwargs
+    )
+    values = dict(zip(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, candidate))
+    values.update(
+        {
+            "close_qty_pct": 1.0,
+            "close_threshold_base_pct": 0.0,
+            "close_threshold_we_weight": 0.0,
+            "entry_cooldown_minutes": 100.0,
+        }
+    )
+    candidate = [
+        values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+    ]
+
+    ungated = ungated_runner.run(np.asarray([candidate], dtype=np.float64))
+    gated = gated_runner.run(np.asarray([candidate], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    assert ungated[size_key].item() == pytest.approx(0.0)
+    assert gated[size_key].item() > 0.0
+    assert gated["balance"].item() >= ungated["balance"].item()
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_loss_gate_preserves_profitable_close_after_repair(side):
+    overrides = np.full((2, 28), np.nan, dtype=np.float32)
+    overrides[0, 24] = 0.1
+    count = 10
+    blocked_highs = np.full((count, 2), 100.5)
+    blocked_lows = np.full((count, 2), 99.5)
+    recovery_highs = blocked_highs.copy()
+    recovery_lows = blocked_lows.copy()
+    if side == "long":
+        recovery_highs[7:, :] = 102.0
+    else:
+        recovery_lows[7:, :] = 98.0
+    common = {
+        "strategy_kind": "trailing_martingale",
+        "side": side,
+        "coin_overrides": overrides,
+        "count": count,
+        "closes": (100.0, 100.0),
+        "max_realized_loss_pct": 0.1,
+    }
+    blocked_runner, candidate = _multicoin_exposure_fixture(
+        highs=blocked_highs, lows=blocked_lows, **common
+    )
+    recovery_runner, _ = _multicoin_exposure_fixture(
+        highs=recovery_highs, lows=recovery_lows, **common
+    )
+    values = dict(zip(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, candidate))
+    values.update(
+        {
+            "close_qty_pct": 1.0,
+            "close_threshold_base_pct": 0.01,
+            "close_threshold_we_weight": 0.0,
+            "entry_cooldown_minutes": 100.0,
+            "twel_entry_gate_enabled": 0.0,
+            "twel_enforcer_threshold": 0.5,
+            "twel_enforcer_enabled": 1.0,
+            "twel_enforcer_reduce_portfolio": 1.0,
+        }
+    )
+    candidate = [
+        values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+    ]
+
+    blocked = blocked_runner.run(np.asarray([candidate], dtype=np.float64))
+    recovered = recovery_runner.run(np.asarray([candidate], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    assert blocked[size_key].item() > 0.0
+    assert recovered[size_key].item() == pytest.approx(0.0)
+    assert recovered["balance"].item() > blocked["balance"].item()
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_loss_gate_scans_past_blocked_recursive_rung(side):
+    count = 10
+    highs = np.full((count, 2), 100.5)
+    lows = np.full((count, 2), 99.5)
+    if side == "long":
+        highs[5:, 0] = 102.0
+    else:
+        lows[5:, 0] = 98.0
+    overrides = np.full((2, 28), np.nan, dtype=np.float32)
+    overrides[1, 24] = 0.0
+    runner, candidate = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        side,
+        coin_overrides=overrides,
+        count=count,
+        closes=(100.0, 100.0),
+        highs=highs,
+        lows=lows,
+        max_realized_loss_pct=0.1,
+    )
+    values = dict(zip(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, candidate))
+    values.update(
+        {
+            "close_qty_pct": 0.25,
+            "close_threshold_base_pct": 0.015,
+            "close_threshold_we_weight": -0.025,
+            "entry_cooldown_minutes": 100.0,
+            "gate_initial": 1.0,
+            "n_positions": 1.0,
+        }
+    )
+    candidate = [
+        values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+    ]
+
+    output = runner.run(np.asarray([candidate], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    # The first immutable recursive rungs are below break-even, but later
+    # rungs become profitable as their simulated exposure falls. Exact Rust
+    # filters the early rungs independently and retains those later closes.
+    assert output[size_key].item() < 5.0
+    assert output["balance"].item() > 1_000.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_loss_gate_does_not_reallocate_blocked_twel(side):
+    count = 10
+    closes = np.full((count, 2), 100.0)
+    if side == "long":
+        closes[5:, 1] = 102.0
+    else:
+        closes[5:, 1] = 98.0
+    highs = closes * 1.01
+    lows = closes * 0.99
+    markets = [
+        ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.001)
+        for _ in range(2)
+    ]
+    overrides = np.full((2, 28), np.nan, dtype=np.float32)
+    overrides[0, 24] = 0.6
+    overrides[1, 24] = 0.4
+    runner, candidate = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        side,
+        coin_overrides=overrides,
+        count=count,
+        closes=closes,
+        highs=highs,
+        lows=lows,
+        markets=markets,
+        max_realized_loss_pct=0.1,
+    )
+    values = dict(zip(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, candidate))
+    values.update(
+        {
+            "entry_cooldown_minutes": 100.0,
+            "twel_entry_gate_enabled": 0.0,
+            "twel_enforcer_threshold": 0.5,
+            "twel_enforcer_reduce_portfolio": 1.0,
+        }
+    )
+    baseline = [
+        values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+    ]
+    repaired_values = dict(values, twel_enforcer_enabled=1.0)
+    repaired = [
+        repaired_values[key]
+        for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+    ]
+
+    output = runner.run(np.asarray([baseline, repaired], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    # Coin zero wins TWEL's equal-adverse tie and alone reaches the target, but
+    # its fee-only reducer is loss-gated. Exact Rust does not then reallocate
+    # that action to profitable coin one.
+    assert output["open_positions"].cpu().tolist() == pytest.approx([2.0, 2.0])
+    assert output[size_key][1].item() == pytest.approx(
+        output[size_key][0].item(), abs=2.0e-4
+    )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary

- add conservative realized-loss screening to multi-coin Trailing Martingale on Apple MPS
- gate WEL/TWEL reducers, ordinary trailing closes, and reachable recursive grid groups
- continue to the next admissible repair candidate when loss gating rejects a reducer
- remove the multi-coin TM fail-closed scope restriction while preserving all CPU paths

## Safety model

Multi-coin and dual-side proxy dispatches cannot safely share exact Rust's rolling realized-loss allowance. Whenever `live.max_realized_loss_pct < 1.0`, Metal therefore uses the previously reviewed zero-loss envelope: a close must have clearly positive projected net PnL after maker fees and a conservative float32 margin.

TWEL candidates are filtered before they consume the side-wide repair budget. WEL and TWEL candidates are screened independently before reducer arbitration, and recursive ordinary close groups are screened individually when reachable. A blocked repair does not suppress a later profitable strategy close. Exact Rust remains authoritative for the configured rolling allowance, selected-candidate validation, persistence, and Pareto membership.

## Validation

- full Python test suite: pass
- complete real Apple M3/MPS suite: pass
- focused real-MPS long/short regressions for lossy TWEL repairs, maker-fee-only ordinary closes, and profitable-close recovery after a blocked repair: pass
- Rust: `cargo fmt --check`, `cargo check --tests`, and 262 tests pass
- GPU backend scope suite: pass
- AI docs validator: 0 errors, 2 pre-existing size warnings
- real Bybit BTC+SOL long-only TM smoke, 2024-01 to current, `max_realized_loss_pct=0.1`: 8 generations, 1,024 proxy evaluations, 64 exact validations, no drift warnings or constraint mismatches, clean completion and shutdown in 319.6s

Part of the sequential Apple MPS optimizer parity work. The approach builds on the GPU proof of concept contributed by RustyCZ while retaining Passivbot's exact Rust backtester as the safety authority.
