### PR TITLE
feat(optimize): add MPS fill-gap metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,22 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Expanded Apple MPS optimizer scoring and limits with fill-gap mean, median, p95, and p99 hours.
+  The proxy conservatively decodes its existing logarithmic inter-fill histogram at a float32-safe
+  upper edge, adds exact leading and trailing gaps, and coalesces same-candle fills; exact
+  Rust remains authoritative. Dual-side multi-coin runs keep these metrics fail closed because
+  independent directional summaries cannot reconstruct portfolio fill timing.
+
 - Added realized-loss gating to Apple MPS EMA Anchor and Trailing Martingale screening
   for long, short, hedge-mode, and one-way runs. Single-coin EMA Anchor tracks a conservative
   all-history peak-relative realized net-PnL budget, including maker fees, and blocks lossy ordinary
   or exposure-repair closes that exceed it. Multi-coin EMA Anchor and Trailing
   Martingale use a stricter zero-loss proxy envelope whenever the gate is active, avoiding unsafe
   cross-dispatch loss-budget reservation and per-candle enumeration of TM's recursive 500-rung
-  ladder. Multi-coin TM tries the next admissible WEL/TWEL repair candidate when a larger reducer
-  is blocked and screens reachable recursive close groups independently. Exact Rust remains
-  authoritative for the configured rolling PnL lookback and allowance.
+  ladder. Multi-coin TM preserves the exact TWEL action set before loss screening, so a blocked
+  reducer is not reallocated to another symbol, and screens reachable recursive close groups
+  independently so later profitable rungs remain available when an earlier rung is blocked. Exact
+  Rust remains authoritative for the configured rolling PnL lookback and allowance.
 
 - Expanded Apple MPS optimizer scoring and limits with weighted strategy-equity MDG, Sharpe,
   Sortino, Omega, Calmar, and Sterling metrics. The proxy maps the exact optimizer's ten-subset

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -186,6 +186,8 @@ Rust portfolio backtest, and classification, rank, and drift gates halt material
 Dual-side one-way arbitration, unmodeled non-bot suite scenario overrides, HSL, and auto-unstuck
 are not silently approximated by this release. Dual-side
 multi-coin screening also rejects `fills_gap_longest_days`,
+`fills_gap_mean_hours`, `fills_gap_median_hours`, `fills_gap_p95_hours`,
+`fills_gap_p99_hours`,
 `strategy_eq_recovery_days_max`, and `volume_pct_per_day_avg`: the independent directional
 summaries cannot reconstruct cross-side-only fill gaps, alternating portfolio recovery periods,
 or fill volume normalized by the shared balance safely.
@@ -248,13 +250,17 @@ rejects aliases that resolve to the same setting, and rejects mapping-level repl
 fixed value disables dependent trailing-martingale parameters, the Metal search removes and
 hash-canonicalizes those dead genes using the same rule as exact candidate materialization.
 
-Proxy scoring and limits are likewise fail-closed. This slice supports `adg_strategy_eq`,
-`adg_strategy_eq_w`, `mdg_strategy_eq`, `sharpe_ratio_strategy_eq`,
-`sortino_ratio_strategy_eq`, `volume_pct_per_day_avg`, `strategy_eq_recovery_days_max`,
-`position_held_days_max`, `strategy_eq_underwater_pct_mean`, `drawdown_worst_strategy_eq`,
-`drawdown_worst_mean_1pct_strategy_eq`, `fills_gap_longest_days`, and
-`backtest_completion_ratio`. Metrics such as `fills_gap_p95_hours` that require exact per-fill
-interpolation are rejected before a run starts.
+Proxy scoring and limits are likewise fail-closed. The supported strategy-equity surface includes
+gain, ADG, MDG, Sharpe, Sortino, Omega, Calmar, Sterling, expected shortfall, worst and worst-1%
+drawdown, mean and median underwater percentage, maximum recovery and position-held duration,
+volume per active day, backtest completion, and weighted variants of ADG, MDG, Sharpe, Sortino,
+Omega, Calmar, and Sterling. Fill-gap longest, mean, median, p95, and p99 metrics are also
+supported. Metal coalesces multiple fills in the same candle and records positive inter-candle gaps
+in a 128-bin logarithmic histogram; the proxy decodes each occupied bin with a float32-safe upper
+edge and adds the exact leading and trailing gaps. This deliberately overestimates the minimizing
+fill-gap summaries when exact Rust has same-candle zero gaps or a value inside a histogram bin.
+Exact Rust metrics remain authoritative. Other metrics that require unmodeled per-fill, trade, or
+position aggregates are rejected before a run starts.
 
 The backend is hybrid rather than a replacement backtester:
 

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -956,6 +956,10 @@ def _validate_dual_multicoin_metrics(
         set(needed_metrics)
         & {
             "fills_gap_longest_days",
+            "fills_gap_mean_hours",
+            "fills_gap_median_hours",
+            "fills_gap_p95_hours",
+            "fills_gap_p99_hours",
             "strategy_eq_recovery_days_max",
             "volume_pct_per_day_avg",
         }

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -7,6 +7,8 @@ metrics validated for this foundation and integrated with the current schema.
 
 from __future__ import annotations
 
+import math
+
 import torch
 
 # Keep the public proxy surface deliberately narrow. Exact Rust evaluations
@@ -22,6 +24,10 @@ SUPPORTED_METRICS = (
     "drawdown_worst_strategy_eq",
     "expected_shortfall_1pct_strategy_eq",
     "fills_gap_longest_days",
+    "fills_gap_mean_hours",
+    "fills_gap_median_hours",
+    "fills_gap_p95_hours",
+    "fills_gap_p99_hours",
     "gain_strategy_eq",
     "mdg_strategy_eq",
     "mdg_strategy_eq_w",
@@ -43,6 +49,34 @@ SUPPORTED_METRICS = (
 # Reserved for a later PR that validates metrics requiring per-fill/trade
 # aggregates. Keeping this empty avoids allocating the larger Metal buffers.
 EXTRA_KERNEL_METRICS = ()
+
+
+_GAP_HIST_BINS = 128
+_GAP_HIST_LOG_MAX = math.log(4_000_001.0)
+_FILL_GAP_HISTOGRAM_METRICS = {
+    "fills_gap_mean_hours",
+    "fills_gap_median_hours",
+    "fills_gap_p95_hours",
+    "fills_gap_p99_hours",
+}
+# Metal classifies gaps with float32 logarithms. Expand the decoded boundary
+# by 1024 unit roundoffs so a value rounded into the preceding bin cannot make
+# this minimizing proxy optimistic.
+_GAP_HIST_EDGE_MARGIN = 1.220703125e-4
+_GAP_HIST_UPPER_STEPS = tuple(
+    max(
+        0,
+        math.ceil(
+            (
+                math.exp((index + 1) * _GAP_HIST_LOG_MAX / 127.0)
+                - 1.0
+            )
+            * (1.0 + _GAP_HIST_EDGE_MARGIN)
+        )
+        - 1,
+    )
+    for index in range(_GAP_HIST_BINS - 1)
+) + (float("inf"),)
 
 
 def _daily_series_masks(day_min_eq):
@@ -198,6 +232,108 @@ def _mean_worst_one_pct_largest(values, mask):
     result = cumulative.gather(1, (worst_count - 1).unsqueeze(1)).squeeze(1)
     result = result / worst_count.to(values.dtype)
     return torch.where(counts > 0, result, torch.zeros_like(result))
+
+
+def _weighted_percentile(values, counts, percentile):
+    """Interpolate a percentile over sorted values with integer multiplicities."""
+
+    ordered_values, order = torch.sort(values, dim=1)
+    ordered_counts = counts.gather(1, order)
+    cumulative = ordered_counts.cumsum(dim=1)
+    total = ordered_counts.sum(dim=1)
+    rank = float(percentile) * (total - 1).clamp(min=0).to(values.dtype)
+    lower_rank = torch.floor(rank).to(torch.long)
+    upper_rank = torch.ceil(rank).to(torch.long)
+
+    def gather_rank(target):
+        index = (cumulative > target.unsqueeze(1)).to(torch.int64).argmax(dim=1)
+        return ordered_values.gather(1, index.unsqueeze(1)).squeeze(1)
+
+    lower = gather_rank(lower_rank)
+    upper = gather_rank(upper_rank)
+    weight = rank - lower_rank.to(values.dtype)
+    result = lower * (1.0 - weight) + upper * weight
+    return torch.where(total > 0, result, torch.zeros_like(result))
+
+
+def _fill_gap_metrics(out, run):
+    """Conservatively reduce coalesced fill timestamps and log-gap bins."""
+
+    interval_ms = max(float(run.interval_ms), 1.0)
+    first_eq_ts = out["first_eq_ts"].to(torch.float64)
+    last_eq_ts = out["last_eq_ts"].to(torch.float64)
+    first_fill_ts = out["first_fill_ts"].to(torch.float64)
+    last_fill_ts = out["last_fill_ts"].to(torch.float64)
+    has_equity = (
+        torch.isfinite(first_eq_ts)
+        & torch.isfinite(last_eq_ts)
+        & (last_eq_ts >= first_eq_ts)
+    )
+    has_fill = (
+        has_equity
+        & torch.isfinite(first_fill_ts)
+        & torch.isfinite(last_fill_ts)
+    )
+    # Metal exports integer candle indices multiplied by interval_ms through a
+    # float32 scalar buffer. Recover the indices before subtracting so rounding
+    # of large millisecond offsets cannot make a boundary gap optimistic.
+    first_eq_step = torch.round(first_eq_ts / interval_ms)
+    last_eq_step = torch.round(last_eq_ts / interval_ms)
+    first_fill_step = torch.round(first_fill_ts / interval_ms)
+    last_fill_step = torch.round(last_fill_ts / interval_ms)
+    span_ms = torch.where(
+        has_equity,
+        (last_eq_step - first_eq_step).clamp(min=0.0) * interval_ms,
+        torch.zeros_like(first_eq_ts),
+    )
+    span_steps = span_ms / interval_ms
+    upper_steps = torch.tensor(
+        _GAP_HIST_UPPER_STEPS,
+        dtype=torch.float64,
+        device=first_eq_ts.device,
+    ).unsqueeze(0)
+    upper_steps = torch.minimum(upper_steps, span_steps.unsqueeze(1))
+    gap_values = upper_steps * interval_ms / 3_600_000.0
+    gap_counts = out["gap_hist"].to(torch.long)
+    gap_counts = torch.where(
+        has_fill.unsqueeze(1), gap_counts, torch.zeros_like(gap_counts)
+    )
+
+    lead_hours = torch.where(
+        has_fill,
+        (first_fill_step - first_eq_step).clamp(min=0.0)
+        * interval_ms
+        / 3_600_000.0,
+        span_ms / 3_600_000.0,
+    )
+    trail_hours = torch.where(
+        has_fill,
+        (last_eq_step - last_fill_step).clamp(min=0.0)
+        * interval_ms
+        / 3_600_000.0,
+        torch.zeros_like(span_ms),
+    )
+    boundary_values = torch.stack((lead_hours, trail_hours), dim=1)
+    boundary_counts = torch.stack(
+        (
+            has_equity.to(torch.long),
+            has_fill.to(torch.long),
+        ),
+        dim=1,
+    )
+    values = torch.cat((gap_values, boundary_values), dim=1)
+    counts = torch.cat((gap_counts, boundary_counts), dim=1)
+    total = counts.sum(dim=1).clamp(min=1).to(torch.float64)
+    weighted_values = torch.where(
+        counts > 0, values, torch.zeros_like(values)
+    )
+    mean = (weighted_values * counts.to(values.dtype)).sum(dim=1) / total
+    return {
+        "fills_gap_mean_hours": mean,
+        "fills_gap_median_hours": _weighted_percentile(values, counts, 0.50),
+        "fills_gap_p95_hours": _weighted_percentile(values, counts, 0.95),
+        "fills_gap_p99_hours": _weighted_percentile(values, counts, 0.99),
+    }
 
 
 def _weighted_subsets(
@@ -434,6 +570,11 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
     gap_longest_days = torch.where(
         has_equity, gap_longest_days, torch.zeros_like(gap_longest_days)
     )
+    fill_gap_metrics = (
+        _fill_gap_metrics(out, run)
+        if requested & _FILL_GAP_HISTOGRAM_METRICS
+        else {}
+    )
 
     requested_start = float(run.requested_start_ts_ms)
     first_timestamp = data["ts0"]
@@ -470,6 +611,7 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
         "strategy_eq_underwater_pct_median": underwater_median,
         "volume_pct_per_day_avg": volume_pct,
     }
+    objectives.update(fill_gap_metrics)
     objectives.update(weighted_metrics)
     if needed is None:
         return objectives

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -2074,6 +2074,10 @@ def test_gpu_multicoin_foundation_rejects_asymmetric_dual_side_coins(strategy_ki
     "metric",
     [
         "fills_gap_longest_days",
+        "fills_gap_mean_hours",
+        "fills_gap_median_hours",
+        "fills_gap_p95_hours",
+        "fills_gap_p99_hours",
         "strategy_eq_recovery_days_max",
         "volume_pct_per_day_avg",
     ],
@@ -2091,6 +2095,10 @@ def test_gpu_dual_multicoin_metric_gate_does_not_narrow_single_side():
     _validate_dual_multicoin_metrics(
         {
             "fills_gap_longest_days",
+            "fills_gap_mean_hours",
+            "fills_gap_median_hours",
+            "fills_gap_p95_hours",
+            "fills_gap_p99_hours",
             "strategy_eq_recovery_days_max",
             "volume_pct_per_day_avg",
         },

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -1,5 +1,7 @@
+import math
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
 
@@ -7,6 +9,8 @@ torch = pytest.importorskip("torch")
 
 from optimization.gpu.metrics import (
     SUPPORTED_METRICS,
+    _GAP_HIST_UPPER_STEPS,
+    _fill_gap_metrics,
     _masked_median,
     _mean_worst_one_pct_abs,
     _omega_ratio,
@@ -78,8 +82,101 @@ def test_weighted_adg_slices_minutes_before_daily_reduction():
     assert actual.item() == pytest.approx(((full + 2.0 * last_two) / 10.0).item())
 
 
-def test_interpolated_fill_gap_percentile_fails_closed_for_gpu_proxy():
-    assert "fills_gap_p95_hours" not in SUPPORTED_METRICS
+def test_fill_gap_summary_metric_surface_is_supported():
+    assert {
+        "fills_gap_mean_hours",
+        "fills_gap_median_hours",
+        "fills_gap_p95_hours",
+        "fills_gap_p99_hours",
+    } <= set(SUPPORTED_METRICS)
+
+
+def test_fill_gap_summary_without_fills_uses_whole_active_span():
+    out = {
+        "gap_hist": torch.zeros((1, 128), dtype=torch.int32),
+        "first_fill_ts": torch.tensor([float("nan")]),
+        "last_fill_ts": torch.tensor([float("nan")]),
+        "first_eq_ts": torch.tensor([0.0]),
+        "last_eq_ts": torch.tensor([7_200_000.0]),
+    }
+
+    metrics = _fill_gap_metrics(out, SimpleNamespace(interval_ms=60_000))
+
+    assert all(value.item() == pytest.approx(2.0) for value in metrics.values())
+
+
+def test_fill_gap_histogram_is_conservative_for_interpolated_percentiles():
+    gap_hist = torch.zeros((1, 128), dtype=torch.int32)
+    gap_minutes = 120
+    bin_index = int(math.log(gap_minutes + 1.0) * 127.0 / math.log(4_000_001.0))
+    gap_hist[0, bin_index] = 1
+    out = {
+        "gap_hist": gap_hist,
+        "first_fill_ts": torch.tensor([3_600_000.0]),
+        "last_fill_ts": torch.tensor([10_800_000.0]),
+        "first_eq_ts": torch.tensor([0.0]),
+        "last_eq_ts": torch.tensor([14_400_000.0]),
+    }
+
+    metrics = _fill_gap_metrics(out, SimpleNamespace(interval_ms=60_000))
+
+    # Exact distinct-candle gaps are [1h, 2h, 1h]. Log-bin upper edges may
+    # overstate the inter-fill gap but must never make a minimizing proxy
+    # metric more optimistic than exact Rust.
+    assert metrics["fills_gap_mean_hours"].item() >= 4.0 / 3.0
+    assert metrics["fills_gap_median_hours"].item() >= 1.0
+    assert metrics["fills_gap_p95_hours"].item() >= 1.9
+    assert metrics["fills_gap_p99_hours"].item() >= 1.98
+
+
+def test_fill_gap_float32_bin_decode_never_understates_boundary_samples():
+    samples = {0, 1, 4_000_000}
+    log_max = math.log(4_000_001.0)
+    for index in range(127):
+        edge = math.exp((index + 1) * log_max / 127.0) - 1.0
+        center = math.floor(edge)
+        samples.update(max(0, center + delta) for delta in range(-2, 3))
+
+    for gap in samples:
+        encoded = int(
+            np.float32(
+                np.log(np.float32(gap) + np.float32(1.0))
+                * np.float32(127.0)
+                / np.log(np.float32(4_000_001.0))
+            )
+        )
+        encoded = min(max(encoded, 0), 127)
+        assert _GAP_HIST_UPPER_STEPS[encoded] >= gap
+
+
+def test_fill_gap_boundary_decode_recovers_large_float32_candle_offsets():
+    interval_ms = 60_000
+    first_eq_step = 3_900_000
+    first_fill_step = first_eq_step + 1
+    last_fill_step = first_eq_step + 3
+    last_eq_step = first_eq_step + 4
+    out = {
+        "gap_hist": torch.zeros((1, 128), dtype=torch.int32),
+        "first_fill_ts": torch.tensor(
+            [first_fill_step * interval_ms], dtype=torch.float32
+        ),
+        "last_fill_ts": torch.tensor(
+            [last_fill_step * interval_ms], dtype=torch.float32
+        ),
+        "first_eq_ts": torch.tensor(
+            [first_eq_step * interval_ms], dtype=torch.float32
+        ),
+        "last_eq_ts": torch.tensor(
+            [last_eq_step * interval_ms], dtype=torch.float32
+        ),
+    }
+
+    metrics = _fill_gap_metrics(out, SimpleNamespace(interval_ms=interval_ms))
+
+    assert metrics["fills_gap_mean_hours"].item() == pytest.approx(1.0 / 60.0)
+    assert metrics["fills_gap_median_hours"].item() == pytest.approx(1.0 / 60.0)
+    assert metrics["fills_gap_p95_hours"].item() == pytest.approx(1.0 / 60.0)
+    assert metrics["fills_gap_p99_hours"].item() == pytest.approx(1.0 / 60.0)
 
 
 def test_strategy_equity_summary_metric_surface_is_supported():
@@ -344,6 +441,10 @@ def test_completion_is_zero_when_no_equity_sample_exists():
             "adg_strategy_eq_w",
             "backtest_completion_ratio",
             "fills_gap_longest_days",
+            "fills_gap_mean_hours",
+            "fills_gap_median_hours",
+            "fills_gap_p95_hours",
+            "fills_gap_p99_hours",
         },
     )
 
@@ -351,6 +452,13 @@ def test_completion_is_zero_when_no_equity_sample_exists():
     assert metrics["adg_strategy_eq"].item() == 0.0
     assert metrics["adg_strategy_eq_w"].item() == 0.0
     assert metrics["fills_gap_longest_days"].item() == 0.0
+    for name in (
+        "fills_gap_mean_hours",
+        "fills_gap_median_hours",
+        "fills_gap_p95_hours",
+        "fills_gap_p99_hours",
+    ):
+        assert metrics[name].item() == 0.0
 
 
 def test_completion_uses_raw_requested_start_before_available_history():

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -20,6 +20,7 @@ from optimization.gpu.model import (
     build_mps_multicoin_data,
 )
 from optimization.gpu.mps_kernel import _encode_max_realized_loss_pct
+from optimization.gpu.metrics import _fill_gap_metrics
 
 
 @pytest.mark.parametrize(
@@ -4246,6 +4247,26 @@ def test_mps_min_effective_cost_filter_keeps_managing_an_open_position(side):
     assert output["gap_hist"].sum().item() >= 1
     assert output["psize"].item() == 0.0
     assert output["short_psize"].item() == 0.0
+    gap_metrics = _fill_gap_metrics(
+        {
+            key: output[key].cpu()
+            for key in (
+                "gap_hist",
+                "first_fill_ts",
+                "last_fill_ts",
+                "first_eq_ts",
+                "last_eq_ts",
+            )
+        },
+        run,
+    )
+    assert all(
+        torch.isfinite(value).all().item()
+        for value in gap_metrics.values()
+    )
+    assert gap_metrics["fills_gap_p99_hours"].item() >= gap_metrics[
+        "fills_gap_p95_hours"
+    ].item()
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary
- add Apple MPS proxy scoring and limits for fill-gap mean, median, p95, and p99 hours
- conservatively decode the existing 128-bin logarithmic Metal histogram, reconstruct exact candle-index boundary gaps, and account for coalesced same-candle fills
- keep dual-side multi-coin runs fail closed where independent directional summaries cannot reconstruct portfolio fill timing
- update optimizer documentation and correct the net multi-coin TM loss-gating changelog description from PR #1539

Exact Rust evaluations remain authoritative. This adds no Metal buffers or dispatch work and does not affect the CPU optimizer.

## Validation
- full Python test suite
- full real-Apple-MPS `tests/optimization/test_gpu_mps.py`
- focused GPU metrics/backend suites
- real MPS optimizer smoke: public EMA-anchor SOL/Bybit, 2024-01 through 2024-02, 8 generations, 512 proxy evaluations, 64 exact validations, completed in 6.9s without drift or constraint halt
- `git diff --check`