### PR TITLE
feat(optimize): add single-coin MPS auto-unstuck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added single-coin auto-unstuck to Apple MPS EMA Anchor and Trailing Martingale optimization for
+  long-only, short-only, dual-side hedge/one-way, and compatible suite runs. The Metal proxy models
+  EMA gating, least-stuck long/short selection, allowance-based loss sizing, exchange minimums,
+  competition with WEL/TWEL and ordinary closes, and the global realized-loss gate. Its all-history
+  realized-PnL envelope is conservative relative to exact Rust's configured rolling lookback;
+  exact validations and the existing classification, rank, and drift gates remain authoritative.
+  Multi-coin auto-unstuck remains fail closed pending a portfolio-wide selector.
+
 - Expanded Apple MPS optimizer scoring and limits with fill-gap mean, median, p95, and p99 hours.
   The proxy conservatively decodes its existing logarithmic inter-fill histogram at a float32-safe
   upper edge, adds exact leading and trailing gaps, and coalesces same-candle fills; exact

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -133,7 +133,15 @@ The supported slice is intentionally narrow:
   `risk.position_exposure_enforcer_threshold`; per-coin
   `risk.we_excess_allowance_mode`, trailing-martingale `entry.ema_gate_mode`, disabled sides, and
   other override leaves fail closed
-- HSL and auto-unstuck disabled
+- HSL disabled. Single-coin EMA Anchor and Trailing Martingale support auto-unstuck for long-only,
+  short-only, hedge-mode dual-side, one-way, and compatible suite runs. Metal models the enable and
+  EMA-gating toggles, tunable close percentage, EMA distance, loss allowance, and exposure
+  threshold. It derives the allowance from a conservative all-history realized net-PnL peak,
+  admits at most one least-stuck long/short candidate, scales a losing close to its own allowance
+  subject to exchange minimums, and lets that close compete with the position's WEL/TWEL reducer
+  before ordinary closes consume the remaining realized-loss budget. Exact Rust remains
+  authoritative for the configured rolling PnL lookback. Multi-coin auto-unstuck remains fail
+  closed until its account-wide least-stuck selector is modeled across all coins and both sides
 - single- and multi-coin EMA Anchor and Trailing Martingale runs support bounded and legacy-raw
   `risk.we_excess_allowance_pct`, `risk.total_exposure_entry_gate_enabled`, and
   `risk.total_exposure_enforcer_threshold` across long-only, short-only, dual-side, and compatible
@@ -155,12 +163,14 @@ The supported slice is intentionally narrow:
 - single-coin EMA Anchor models the cumulative realized-loss gate, including entry and close fees,
   shared long/short loss-budget accounting, and lossy total-exposure repairs. The proxy uses a
   conservative all-history loss envelope, so it may block a close that exact Rust admits after old
-  PnL ages out of `live.pnls_max_lookback_days`. Multi-coin EMA Anchor and Trailing
-  Martingale use a stricter zero-loss envelope whenever the gate is active: only clearly profitable
-  closes after maker fees are admitted by Metal. This avoids unsafe cross-coin or cross-side loss-
-  budget reservation between independent multi-coin dispatches and per-candle enumeration of TM's
-  recursive 500-rung close ladder. Exact validation applies the configured rolling allowance and
-  remains authoritative
+  PnL ages out of `live.pnls_max_lookback_days`. Single-coin Trailing Martingale permits its one
+  selected auto-unstuck reducer to consume that same conservative budget, while its recursive
+  ordinary and exposure-repair closes retain the stricter zero-loss envelope. Multi-coin EMA
+  Anchor and Trailing Martingale use a stricter zero-loss envelope whenever the gate is active:
+  only clearly profitable closes after maker fees are admitted by Metal. This avoids unsafe cross-
+  coin or cross-side loss-budget reservation between independent multi-coin dispatches and per-
+  candle enumeration of TM's recursive 500-rung close ladder. Exact validation applies the
+  configured rolling allowance and remains authoritative
 - BTC collateral remains disabled; dual-side multicoin total-exposure repair remains disabled
 - `backtest.filter_by_min_effective_cost` may be enabled or disabled. When enabled, Metal uses the
   projected initial-entry cost test with the configured wallet-exposure limit. The
@@ -183,9 +193,9 @@ Trailing Martingale use one long and one short Metal dispatch per candidate in h
 directional surfaces form a
 conservative portfolio screening proxy; every accepted metric still comes from the unchanged exact
 Rust portfolio backtest, and classification, rank, and drift gates halt material disagreement.
-Dual-side one-way arbitration, unmodeled non-bot suite scenario overrides, HSL, and auto-unstuck
-are not silently approximated by this release. Dual-side
-multi-coin screening also rejects `fills_gap_longest_days`,
+Dual-side one-way arbitration, unmodeled non-bot suite scenario overrides, HSL, and multi-coin
+auto-unstuck are not silently approximated by this release. Dual-side multi-coin screening also
+rejects `fills_gap_longest_days`,
 `fills_gap_mean_hours`, `fills_gap_median_hours`, `fills_gap_p95_hours`,
 `fills_gap_p99_hours`,
 `strategy_eq_recovery_days_max`, and `volume_pct_per_day_avg`: the independent directional
@@ -205,11 +215,12 @@ overrides: the canonical exact
 suite evaluator still applies them last, after candidate materialization, while each scenario's
 Metal proxy shadows the corresponding candidate parameters with the same effective values. Every
 overridden scenario is rechecked against the directional GPU scope, so an override cannot silently
-enable HSL, auto-unstuck, an unsupported exposure-repair path, an invalid position count, or
-another unsupported behavior. In a multicoin suite, a scenario with fewer coins must keep the effective `n_positions`
-range within that subset, either through common bounds or an explicit scenario override. Metal
-uses the strategy-specific single-coin or multicoin kernel independently for each scenario, then
-feeds all results to the same suite reducer. Scenario-local `coin_overrides` for supported
+enable HSL, multi-coin auto-unstuck, an unsupported exposure-repair path, an invalid position
+count, or another unsupported behavior. In a multicoin suite, a scenario with fewer coins must
+keep the effective `n_positions` range within that subset, either through common bounds or an
+explicit scenario override. Metal uses the strategy-specific single-coin or multicoin kernel
+independently for each scenario, then feeds all results to the same suite reducer. Scenario-local
+`coin_overrides` for supported
 multi-coin EMA Anchor and Trailing Martingale runs, `backtest.starting_balance`,
 `backtest.maker_fee_override`, `backtest.liquidation_threshold`,
 `live.forager_score_hysteresis_pct`, and `live.hedge_mode` are accepted because every scenario

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -43,8 +43,12 @@ mod tests {
         assert!(source.contains("kernel void passivbot_ema_anchor"));
         assert!(source.contains("constant int DAILY_COLS = 5"));
         assert!(source.contains("constant int SCALAR_COLS = 18"));
-        assert!(source.contains("constant int SIDE_PARAMS = 17"));
+        assert!(source.contains("constant int SIDE_PARAMS = 23"));
         assert!(source.contains("total_exposure_reducer_qty"));
+        assert!(source.contains("unstuck_reducer_variant"));
+        assert!(source.contains("unstuck_ema_gating_enabled"));
+        assert!(source.contains("unstuck_loss_allowance_pct"));
+        assert!(source.contains("Exact Rust emits at most one global unstuck intent"));
         assert!(source.contains("secondary_close_qty"));
         assert!(source.contains("generate_short_orders"));
         assert!(source.contains("const bool hedge_mode"));
@@ -109,7 +113,11 @@ mod tests {
     fn trailing_martingale_mps_source_exposes_expected_kernel_contract() {
         let source = mps_trailing_martingale_source();
         assert!(source.contains("kernel void passivbot_trailing_martingale"));
-        assert!(source.contains("constant int SIDE_PARAMS = 34"));
+        assert!(source.contains("constant int SIDE_PARAMS = 40"));
+        assert!(source.contains("unstuck_reducer_qty"));
+        assert!(source.contains("unstuck_ema_gating_enabled"));
+        assert!(source.contains("unstuck_loss_allowance_pct"));
+        assert!(source.contains("grid_source.unstuck_enabled = false"));
         assert!(source.contains("min_since_open"));
         assert!(source.contains("max_since_min"));
         assert!(source.contains("max_since_open"));
@@ -125,7 +133,8 @@ mod tests {
         assert!(source.contains("finalized_wel_qty = finalized_reducer_qty"));
         assert!(source.contains("finalized_twel_qty = finalized_reducer_qty"));
         assert!(source.contains("finalized_twel_qty > finalized_wel_qty"));
-        assert!(source.contains("reducer_qty = use_twel ? twel_qty : wel_qty"));
+        assert!(source.contains("float reducer_qty = use_unstuck"));
+        assert!(source.contains("? unstuck_qty : (use_twel ? twel_qty : wel_qty)"));
         assert!(source.contains("secondary_close_qty"));
         assert!(source.contains("twel_entry_gate_enabled"));
         assert_eq!(source.matches("= fma(").count(), 5);
@@ -150,12 +159,13 @@ mod tests {
         assert!(source.contains("close_gen_balance"));
         assert!(source.contains("recursive_close_groups"));
         assert!(source.contains("realized_loss_proxy_allows_close"));
-        assert!(source.contains("const bool loss_gate_enabled = settings[14] < 1.0f"));
+        assert!(source.contains("const float max_realized_loss_pct = settings[14]"));
+        assert!(source.contains("const bool loss_gate_enabled = max_realized_loss_pct < 1.0f"));
         assert!(source.contains("the proxy uses a zero-loss envelope"));
         assert!(source.contains("int grid_rung_limit = strategy_wel_qty > 0.0f ? 499 : 500"));
         assert!(source.contains("long_side.close_gen_psize - strategy_wel_qty"));
         assert!(source.contains("short_side.close_gen_psize - strategy_wel_qty"));
-        assert!(source.contains("use_twel && wel_qty <= 0.0f"));
+        assert!(source.contains("(use_twel || use_unstuck) && wel_qty <= 0.0f"));
         assert!(source.contains("long_side.secondary_close_price"));
         assert!(source.contains("short_side.secondary_close_price"));
         assert!(source.contains("dust_remainder"));

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -131,7 +131,8 @@ mod tests {
         assert!(source.contains("twel_target"));
         assert!(source.contains("price_now * 0.9995f / price_step"));
         assert!(source.contains("finalized_wel_qty = finalized_reducer_qty"));
-        assert!(source.contains("finalized_twel_qty = finalized_reducer_qty"));
+        assert!(source.contains("finalized_reducer_qty_with_ordinary"));
+        assert!(source.contains("float finalized_twel_qty = ordinary_can_accompany_reducer"));
         assert!(source.contains("finalized_twel_qty > finalized_wel_qty"));
         assert!(source.contains("float reducer_qty = use_unstuck"));
         assert!(source.contains("? unstuck_qty : (use_twel ? twel_qty : wel_qty)"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -4,7 +4,7 @@ using namespace metal;
 constant int DAILY_COLS = 5;
 constant int SCALAR_COLS = 18;
 constant int GAP_BINS = 128;
-constant int SIDE_PARAMS = 17;
+constant int SIDE_PARAMS = 23;
 
 inline float round_step(float value, float step) {
     return floor(value / step + 0.5f) * step;
@@ -88,6 +88,12 @@ struct EmaSide {
     float entry_cap;
     float twel_enforcer_threshold;
     bool twel_enforcer_enabled;
+    bool unstuck_enabled;
+    bool unstuck_ema_gating_enabled;
+    float unstuck_close_pct;
+    float unstuck_ema_dist;
+    float unstuck_loss_allowance_pct;
+    float unstuck_threshold;
     float ema0;
     float ema1;
     float ema2;
@@ -105,7 +111,16 @@ struct EmaSide {
     float secondary_close_qty;
     int close_without_reducer_ticks;
     float close_without_reducer_qty;
-    bool close_is_twel_reducer;
+    bool close_is_protective_reducer;
+};
+
+struct ReducerVariant {
+    bool valid;
+    bool is_unstuck;
+    int ticks;
+    float qty;
+    int secondary_ticks;
+    float secondary_qty;
 };
 
 inline EmaSide load_side(constant float* params, int po, float seed_close) {
@@ -146,6 +161,12 @@ inline EmaSide load_side(constant float* params, int po, float seed_close) {
     side.entry_cap = twel_entry_gate_enabled ? gate_cap : INFINITY;
     side.twel_enforcer_threshold = twel_threshold;
     side.twel_enforcer_enabled = params[po + 16] > 0.5f;
+    side.unstuck_enabled = params[po + 17] > 0.5f;
+    side.unstuck_ema_gating_enabled = params[po + 18] > 0.5f;
+    side.unstuck_close_pct = params[po + 19];
+    side.unstuck_ema_dist = params[po + 20];
+    side.unstuck_loss_allowance_pct = params[po + 21];
+    side.unstuck_threshold = params[po + 22];
     side.ema0 = seed_close;
     side.ema1 = seed_close;
     side.ema2 = seed_close;
@@ -163,8 +184,110 @@ inline EmaSide load_side(constant float* params, int po, float seed_close) {
     side.secondary_close_qty = 0.0f;
     side.close_without_reducer_ticks = 0;
     side.close_without_reducer_qty = 0.0f;
-    side.close_is_twel_reducer = false;
+    side.close_is_protective_reducer = false;
     return side;
+}
+
+inline ReducerVariant empty_reducer_variant() {
+    ReducerVariant result;
+    result.valid = false;
+    result.is_unstuck = false;
+    result.ticks = 0;
+    result.qty = 0.0f;
+    result.secondary_ticks = 0;
+    result.secondary_qty = 0.0f;
+    return result;
+}
+
+inline ReducerVariant finalize_reducer_variant(
+    float psize,
+    int ordinary_ticks,
+    float ordinary_qty,
+    int reducer_ticks,
+    float reducer_qty,
+    bool is_unstuck,
+    float qty_step,
+    float price_step,
+    float min_qty,
+    float min_cost,
+    float c_mult
+) {
+    ReducerVariant result = empty_reducer_variant();
+    if (!(psize > 0.0f && reducer_ticks > 0 && reducer_qty > 0.0f)) {
+        return result;
+    }
+    float reducer_price = float(reducer_ticks) * price_step;
+    float reducer_min = min_entry_qty(
+        reducer_price, qty_step, min_qty, min_cost, c_mult
+    );
+    reducer_qty = fmin(psize, reducer_qty);
+    if (ordinary_qty > 0.0f && ordinary_ticks > 0) {
+        float ordinary_price = float(ordinary_ticks) * price_step;
+        float ordinary_min = min_entry_qty(
+            ordinary_price, qty_step, min_qty, min_cost, c_mult
+        );
+        if (ordinary_qty + reducer_qty > psize) {
+            ordinary_qty = fmax(round_step(psize - reducer_qty, qty_step), 0.0f);
+        }
+        if (ordinary_qty >= ordinary_min) {
+            float remainder = fmax(
+                round_step(psize - reducer_qty - ordinary_qty, qty_step), 0.0f
+            );
+            float minimum_any = fmin(ordinary_min, reducer_min);
+            if (remainder > 0.0f && remainder < minimum_any) {
+                ordinary_qty = fmin(
+                    psize - reducer_qty,
+                    round_step(ordinary_qty + remainder, qty_step)
+                );
+            }
+            result.secondary_ticks = ordinary_ticks;
+            result.secondary_qty = ordinary_qty;
+        }
+    }
+    if (result.secondary_qty <= 0.0f) {
+        float remainder = fmax(round_step(psize - reducer_qty, qty_step), 0.0f);
+        if (remainder > 0.0f && remainder < reducer_min) {
+            reducer_qty = psize;
+        }
+    }
+    result.valid = reducer_qty > 0.0f;
+    result.is_unstuck = is_unstuck;
+    result.ticks = reducer_ticks;
+    result.qty = reducer_qty;
+    return result;
+}
+
+inline void apply_reducer_variant(
+    thread EmaSide& side,
+    ReducerVariant variant
+) {
+    side.close_ticks = variant.ticks;
+    side.close_qty = variant.qty;
+    side.secondary_close_ticks = variant.secondary_ticks;
+    side.secondary_close_qty = variant.secondary_qty;
+    side.close_is_protective_reducer = variant.valid;
+}
+
+inline void restore_ordinary_close(thread EmaSide& side) {
+    side.close_ticks = side.close_without_reducer_ticks;
+    side.close_qty = side.close_without_reducer_qty;
+    side.secondary_close_ticks = 0;
+    side.secondary_close_qty = 0.0f;
+    side.close_is_protective_reducer = false;
+}
+
+inline ReducerVariant generated_reducer_variant(thread EmaSide& side) {
+    if (!side.close_is_protective_reducer || !(side.close_qty > 0.0f)) {
+        return empty_reducer_variant();
+    }
+    ReducerVariant result;
+    result.valid = true;
+    result.is_unstuck = false;
+    result.ticks = side.close_ticks;
+    result.qty = side.close_qty;
+    result.secondary_ticks = side.secondary_close_ticks;
+    result.secondary_qty = side.secondary_close_qty;
+    return result;
 }
 
 inline float total_exposure_reducer_qty(
@@ -205,7 +328,7 @@ inline void apply_twel_reducer(
 ) {
     side.secondary_close_ticks = 0;
     side.secondary_close_qty = 0.0f;
-    side.close_is_twel_reducer = false;
+    side.close_is_protective_reducer = false;
     float target = side.twel * side.twel_enforcer_threshold;
     int reducer_ticks = is_long
         ? int(floor(price_now * 0.9995f / price_step + 1.0e-6f))
@@ -221,49 +344,179 @@ inline void apply_twel_reducer(
         : 0.0f;
     if (!(reducer_qty > 0.0f)) return;
 
+    apply_reducer_variant(
+        side,
+        finalize_reducer_variant(
+            side.psize, side.close_ticks, side.close_qty,
+            reducer_ticks, reducer_qty, false, qty_step, price_step,
+            min_qty, min_cost, c_mult
+        )
+    );
+}
+
+inline ReducerVariant unstuck_reducer_variant(
+    thread EmaSide& side,
+    bool is_long,
+    float balance,
+    float balance_peak,
+    float price_now,
+    int touch_down_ticks,
+    int touch_up_ticks,
+    float qty_step,
+    float price_step,
+    float min_qty,
+    float min_cost,
+    float c_mult
+) {
+    ReducerVariant none = empty_reducer_variant();
+    if (!(side.unstuck_enabled
+        && side.unstuck_loss_allowance_pct > 0.0f
+        && side.unstuck_close_pct > 0.0f
+        && side.unstuck_threshold > 0.0f
+        && balance > 0.0f
+        && balance_peak > 0.0f
+        && side.psize > 0.0f
+        && side.pprice > 0.0f
+        && side.allowed_wel > 0.0f
+        && price_now > 0.0f)) {
+        return none;
+    }
+    float allowance_pct = side.unstuck_loss_allowance_pct * side.twel;
+    float allowance = float32_floor_nonnegative(
+        fmax(balance - balance_peak * (1.0f - allowance_pct), 0.0f)
+    );
+    if (!(allowance > 0.0f)) return none;
+    float wallet_exposure = side.psize * side.pprice * c_mult / balance;
+    if (!(wallet_exposure / side.allowed_wel > side.unstuck_threshold)) {
+        return none;
+    }
+    if (side.unstuck_ema_gating_enabled) {
+        float lower = fmin(side.ema0, fmin(side.ema1, side.ema2));
+        float upper = fmax(side.ema0, fmax(side.ema1, side.ema2));
+        int trigger_ticks = is_long
+            ? int(ceil(
+                upper * (1.0f + side.unstuck_ema_dist) / price_step
+                    - 1.0e-6f
+            ))
+            : int(floor(
+                lower * (1.0f - side.unstuck_ema_dist) / price_step
+                    + 1.0e-6f
+            ));
+        bool triggered = is_long
+            ? touch_down_ticks >= trigger_ticks
+            : touch_up_ticks <= trigger_ticks;
+        if (!triggered) return none;
+    }
+
+    int reducer_ticks = max(
+        is_long ? touch_up_ticks : touch_down_ticks, 1
+    );
+    float reducer_price = float(reducer_ticks) * price_step;
     float reducer_min = min_entry_qty(
         reducer_price, qty_step, min_qty, min_cost, c_mult
     );
-    float ordinary_qty = side.close_qty;
-    if (ordinary_qty > 0.0f) {
-        float ordinary_price = float(side.close_ticks) * price_step;
-        float ordinary_min = min_entry_qty(
-            ordinary_price, qty_step, min_qty, min_cost, c_mult
+    float target_qty = floor_step(
+        balance * side.allowed_wel * side.unstuck_close_pct
+            / fmax(reducer_price * c_mult, 1.0e-12f),
+        qty_step
+    );
+    float reducer_qty = fmin(
+        side.psize, fmax(reducer_min, target_qty)
+    );
+    float gross_pnl = reducer_qty * c_mult * (
+        is_long ? reducer_price - side.pprice : side.pprice - reducer_price
+    );
+    if (gross_pnl < 0.0f && -gross_pnl > allowance) {
+        float scaled_qty = fmin(
+            side.psize, reducer_qty * allowance / -gross_pnl
         );
-        if (ordinary_qty + reducer_qty > side.psize) {
-            ordinary_qty = fmax(
-                round_step(side.psize - reducer_qty, qty_step), 0.0f
-            );
-        }
-        if (ordinary_qty >= ordinary_min) {
-            float remainder = fmax(
-                round_step(
-                    side.psize - reducer_qty - ordinary_qty, qty_step
-                ),
-                0.0f
-            );
-            float minimum_any = fmin(ordinary_min, reducer_min);
-            if (remainder > 0.0f && remainder < minimum_any) {
-                ordinary_qty = fmin(
-                    side.psize - reducer_qty,
-                    round_step(ordinary_qty + remainder, qty_step)
-                );
-            }
-            side.secondary_close_ticks = side.close_ticks;
-            side.secondary_close_qty = ordinary_qty;
-        }
-    }
-    if (side.secondary_close_qty <= 0.0f) {
-        float remainder = fmax(
-            round_step(side.psize - reducer_qty, qty_step), 0.0f
+        reducer_qty = fmin(
+            side.psize,
+            fmax(reducer_min, floor_step(scaled_qty, qty_step))
         );
-        if (remainder > 0.0f && remainder < reducer_min) {
-            reducer_qty = side.psize;
-        }
     }
-    side.close_ticks = reducer_ticks;
-    side.close_qty = reducer_qty;
-    side.close_is_twel_reducer = true;
+    return finalize_reducer_variant(
+        side.psize,
+        side.close_without_reducer_ticks,
+        side.close_without_reducer_qty,
+        reducer_ticks,
+        reducer_qty,
+        true,
+        qty_step,
+        price_step,
+        min_qty,
+        min_cost,
+        c_mult
+    );
+}
+
+inline bool reducer_variant_preferred(
+    ReducerVariant left,
+    ReducerVariant right,
+    bool is_long
+) {
+    if (!left.valid) return false;
+    if (!right.valid) return true;
+    if (left.qty != right.qty) return left.qty > right.qty;
+    if (left.ticks != right.ticks) {
+        return is_long ? left.ticks < right.ticks : left.ticks > right.ticks;
+    }
+    if (left.is_unstuck != right.is_unstuck) return left.is_unstuck;
+    return false;
+}
+
+inline void order_reducer_variants(
+    ReducerVariant first,
+    ReducerVariant second,
+    bool is_long,
+    thread ReducerVariant& preferred,
+    thread ReducerVariant& fallback
+) {
+    if (reducer_variant_preferred(second, first, is_long)) {
+        preferred = second;
+        fallback = first;
+    } else {
+        preferred = first;
+        fallback = second;
+    }
+}
+
+inline ReducerVariant reducer_variant_at(
+    ReducerVariant preferred,
+    ReducerVariant fallback,
+    int index
+) {
+    return index == 0 ? preferred : fallback;
+}
+
+inline bool gate_reducer_variant(
+    ReducerVariant variant,
+    float pprice,
+    bool is_long,
+    float price_step,
+    float c_mult,
+    float maker_fee,
+    bool gate_enabled,
+    thread float& remaining_loss_budget
+) {
+    if (!variant.valid || !(variant.qty > 0.0f && pprice > 0.0f)) {
+        return false;
+    }
+    float price = float(variant.ticks) * price_step;
+    float gross_pnl = variant.qty * c_mult * (
+        is_long ? price - pprice : pprice - price
+    );
+    float net_pnl = gross_pnl - variant.qty * price * c_mult * maker_fee;
+    if (!realized_loss_gate_allows(
+            net_pnl, remaining_loss_budget, gate_enabled)) {
+        return false;
+    }
+    if (gate_enabled && net_pnl < 0.0f) {
+        remaining_loss_budget = float32_floor_nonnegative(
+            fmax(remaining_loss_budget + net_pnl, 0.0f)
+        );
+    }
+    return true;
 }
 
 inline void update_indicators(
@@ -824,50 +1077,106 @@ inline void passivbot_single_coin_impl(
                 fmax(allowed_loss_budget - current_realized_loss, 0.0f)
             );
 
-            // Exact Rust reserves the shared batch allowance for protective
-            // reducers largest-first, even when an emitted order never fills.
-            bool long_reducer = long_enabled
-                && long_side.close_is_twel_reducer
-                && long_side.close_qty > 0.0f;
-            bool short_reducer = short_enabled
-                && short_side.close_is_twel_reducer
-                && short_side.close_qty > 0.0f;
-            bool short_reducer_first = short_reducer
-                && (!long_reducer
-                    || short_side.close_qty > long_side.close_qty);
-            for (int rank = 0; rank < 2; ++rank) {
-                bool use_short = short_reducer_first ? rank == 0 : rank == 1;
-                if (use_short && short_reducer) {
-                    gate_generated_close(
-                        short_side.close_qty, short_side.close_ticks,
-                        short_side.pprice, false, price_step, c_mult, maker_fee,
-                        loss_gate_enabled, remaining_loss_budget
-                    );
-                } else if (!use_short && long_reducer) {
-                    gate_generated_close(
-                        long_side.close_qty, long_side.close_ticks,
-                        long_side.pprice, true, price_step, c_mult, maker_fee,
-                        loss_gate_enabled, remaining_loss_budget
-                    );
+            ReducerVariant long_twel = generated_reducer_variant(long_side);
+            ReducerVariant short_twel = generated_reducer_variant(short_side);
+            ReducerVariant long_unstuck = long_enabled
+                ? unstuck_reducer_variant(
+                    long_side, true, balance, balance_peak, close,
+                    touch_down_tick, touch_up_tick, qty_step, price_step,
+                    min_qty, min_cost, c_mult
+                )
+                : empty_reducer_variant();
+            ReducerVariant short_unstuck = short_enabled
+                ? unstuck_reducer_variant(
+                    short_side, false, balance, balance_peak, close,
+                    touch_down_tick, touch_up_tick, qty_step, price_step,
+                    min_qty, min_cost, c_mult
+                )
+                : empty_reducer_variant();
+
+            // Exact Rust emits at most one global unstuck intent: the eligible
+            // long/short position with the lowest pside-aware price distance.
+            if (long_unstuck.valid && short_unstuck.valid) {
+                float long_diff = 1.0f - close / long_side.pprice;
+                float short_diff = close / short_side.pprice - 1.0f;
+                if (long_diff <= short_diff) {
+                    short_unstuck = empty_reducer_variant();
+                } else {
+                    long_unstuck = empty_reducer_variant();
                 }
             }
-            if (long_reducer && long_side.close_qty <= 0.0f) {
-                long_side.secondary_close_ticks =
-                    long_side.close_without_reducer_ticks;
-                long_side.secondary_close_qty =
-                    long_side.close_without_reducer_qty;
+
+            ReducerVariant long_preferred, long_fallback;
+            ReducerVariant short_preferred, short_fallback;
+            order_reducer_variants(
+                long_twel, long_unstuck, true,
+                long_preferred, long_fallback
+            );
+            order_reducer_variants(
+                short_twel, short_unstuck, false,
+                short_preferred, short_fallback
+            );
+            restore_ordinary_close(long_side);
+            restore_ordinary_close(short_side);
+
+            ReducerVariant selected_long = empty_reducer_variant();
+            ReducerVariant selected_short = empty_reducer_variant();
+            int long_candidate_index = 0;
+            int short_candidate_index = 0;
+            bool long_resolved = !long_preferred.valid;
+            bool short_resolved = !short_preferred.valid;
+            // Final reducer sizes compete globally largest-first. A blocked
+            // candidate advances only its own position to the next reducer.
+            for (int attempt = 0; attempt < 4; ++attempt) {
+                ReducerVariant long_candidate = reducer_variant_at(
+                    long_preferred, long_fallback, long_candidate_index
+                );
+                ReducerVariant short_candidate = reducer_variant_at(
+                    short_preferred, short_fallback, short_candidate_index
+                );
+                bool long_available = !long_resolved && long_candidate.valid;
+                bool short_available = !short_resolved && short_candidate.valid;
+                if (!long_available && !short_available) break;
+                bool use_long = long_available && (
+                    !short_available || long_candidate.qty >= short_candidate.qty
+                );
+                if (use_long) {
+                    if (gate_reducer_variant(
+                            long_candidate, long_side.pprice, true,
+                            price_step, c_mult, maker_fee, loss_gate_enabled,
+                            remaining_loss_budget)) {
+                        selected_long = long_candidate;
+                        long_resolved = true;
+                    } else {
+                        long_candidate_index += 1;
+                        long_resolved = long_candidate_index > 1
+                            || !long_fallback.valid;
+                    }
+                } else {
+                    if (gate_reducer_variant(
+                            short_candidate, short_side.pprice, false,
+                            price_step, c_mult, maker_fee, loss_gate_enabled,
+                            remaining_loss_budget)) {
+                        selected_short = short_candidate;
+                        short_resolved = true;
+                    } else {
+                        short_candidate_index += 1;
+                        short_resolved = short_candidate_index > 1
+                            || !short_fallback.valid;
+                    }
+                }
             }
-            if (short_reducer && short_side.close_qty <= 0.0f) {
-                short_side.secondary_close_ticks =
-                    short_side.close_without_reducer_ticks;
-                short_side.secondary_close_qty =
-                    short_side.close_without_reducer_qty;
+            if (selected_long.valid) {
+                apply_reducer_variant(long_side, selected_long);
+            }
+            if (selected_short.valid) {
+                apply_reducer_variant(short_side, selected_short);
             }
 
             // Ordinary closes consume any remaining allowance in canonical
             // long-then-short order after protective reducers are finalized.
             if (long_enabled) {
-                if (long_side.close_is_twel_reducer) {
+                if (long_side.close_is_protective_reducer) {
                     gate_generated_close(
                         long_side.secondary_close_qty,
                         long_side.secondary_close_ticks, long_side.pprice, true,
@@ -883,7 +1192,7 @@ inline void passivbot_single_coin_impl(
                 }
             }
             if (short_enabled) {
-                if (short_side.close_is_twel_reducer) {
+                if (short_side.close_is_protective_reducer) {
                     gate_generated_close(
                         short_side.secondary_close_qty,
                         short_side.secondary_close_ticks, short_side.pprice,

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -409,6 +409,53 @@ inline float finalized_reducer_qty(
         ? psize : reducer_qty;
 }
 
+inline float finalized_reducer_qty_with_ordinary(
+    float psize,
+    float reducer_qty,
+    float reducer_price,
+    float ordinary_qty,
+    float ordinary_min,
+    int ordinary_min_relation,
+    float qty_step,
+    float min_qty,
+    float min_cost,
+    float c_mult
+) {
+    if (reducer_qty <= 0.0f || reducer_price <= 0.0f) return 0.0f;
+    reducer_qty = fmin(psize, reducer_qty);
+    float reducer_min = min_entry_qty(
+        reducer_price, qty_step, min_qty, min_cost, c_mult
+    );
+    if (ordinary_qty > 0.0f) {
+        if (ordinary_qty + reducer_qty > psize) {
+            ordinary_qty = fmax(
+                round_step(psize - reducer_qty, qty_step), 0.0f
+            );
+        }
+        bool ordinary_below_minimum = ordinary_qty < ordinary_min
+            || (ordinary_qty == ordinary_min && ordinary_min_relation > 0);
+        if (!ordinary_below_minimum) {
+            float remainder = fmax(
+                round_step(psize - reducer_qty - ordinary_qty, qty_step),
+                0.0f
+            );
+            float minimum_any = fmin(ordinary_min, reducer_min);
+            if (remainder > 0.0f && remainder < minimum_any) {
+                ordinary_qty = fmin(
+                    psize - reducer_qty,
+                    round_step(ordinary_qty + remainder, qty_step)
+                );
+            }
+            if (ordinary_qty > 0.0f) return reducer_qty;
+        }
+    }
+    float remainder = fmax(
+        round_step(psize - reducer_qty, qty_step), 0.0f
+    );
+    return remainder > 0.0f && remainder < reducer_min
+        ? psize : reducer_qty;
+}
+
 inline bool reducer_candidate_preferred(
     float left_qty,
     int left_ticks,
@@ -703,43 +750,6 @@ inline void generate_orders(
         )
         : 0.0f;
 
-    float finalized_wel_qty = finalized_reducer_qty(
-        s.psize, wel_qty, wel_price,
-        qty_step, min_qty, min_cost, c_mult
-    );
-    float finalized_twel_qty = finalized_reducer_qty(
-        s.psize, twel_qty, twel_price,
-        qty_step, min_qty, min_cost, c_mult
-    );
-    float finalized_unstuck_qty = finalized_reducer_qty(
-        s.psize, unstuck_qty, unstuck_price,
-        qty_step, min_qty, min_cost, c_mult
-    );
-    int unstuck_order_type_id = is_long ? 9 : 20;
-    bool use_twel = finalized_twel_qty > finalized_wel_qty;
-    float finalized_exposure_qty = use_twel
-        ? finalized_twel_qty : finalized_wel_qty;
-    int exposure_ticks = use_twel ? twel_ticks : wel_ticks;
-    int exposure_order_type_id = use_twel
-        ? (is_long ? 10 : 21) : (is_long ? 24 : 25);
-    // Rust chooses by finalized size, then strict distance to the executable
-    // touch, and finally stable order fields. Unstuck and WEL share the touch,
-    // so the lower unstuck order-type id wins only that exact-price tie.
-    bool use_unstuck = reducer_candidate_preferred(
-        finalized_unstuck_qty, unstuck_ticks, unstuck_order_type_id,
-        finalized_exposure_qty, exposure_ticks, exposure_order_type_id,
-        is_long
-    );
-    // Final sizing is only the selection key. Preserve the requested quantity
-    // for the winning reducer so the ordinary close allocator below can absorb
-    // dust exactly as Rust does when TWEL is the sole strategy-external close.
-    float reducer_qty = use_unstuck
-        ? unstuck_qty : (use_twel ? twel_qty : wel_qty);
-    int reducer_ticks = use_unstuck
-        ? unstuck_ticks : (use_twel ? twel_ticks : wel_ticks);
-    float reducer_price = use_unstuck
-        ? unstuck_price : (use_twel ? twel_price : wel_price);
-
     float ct = s.close_threshold_base + wer * s.close_threshold_we
         + s.vol1h * s.close_threshold_v1h + s.vol1m * s.close_threshold_v1m;
     float cr = fmax(s.close_retracement_base, 0.0f) * fmax(
@@ -793,6 +803,54 @@ inline void generate_orders(
         ? calc_close_qty(
             s, balance, close_mq, close_mq_relation, pct, qty_step, c_mult
         ) : 0.0f;
+    bool ordinary_can_accompany_reducer = wel_qty <= 0.0f
+        && trailing_close && s.close_qty > 0.0f;
+    float finalized_wel_qty = finalized_reducer_qty(
+        s.psize, wel_qty, wel_price,
+        qty_step, min_qty, min_cost, c_mult
+    );
+    float finalized_twel_qty = ordinary_can_accompany_reducer
+        ? finalized_reducer_qty_with_ordinary(
+            s.psize, twel_qty, twel_price, s.close_qty, close_mq,
+            close_mq_relation, qty_step, min_qty, min_cost, c_mult
+        )
+        : finalized_reducer_qty(
+            s.psize, twel_qty, twel_price,
+            qty_step, min_qty, min_cost, c_mult
+        );
+    float finalized_unstuck_qty = ordinary_can_accompany_reducer
+        ? finalized_reducer_qty_with_ordinary(
+            s.psize, unstuck_qty, unstuck_price, s.close_qty, close_mq,
+            close_mq_relation, qty_step, min_qty, min_cost, c_mult
+        )
+        : finalized_reducer_qty(
+            s.psize, unstuck_qty, unstuck_price,
+            qty_step, min_qty, min_cost, c_mult
+        );
+    int unstuck_order_type_id = is_long ? 9 : 20;
+    bool use_twel = finalized_twel_qty > finalized_wel_qty;
+    float finalized_exposure_qty = use_twel
+        ? finalized_twel_qty : finalized_wel_qty;
+    int exposure_ticks = use_twel ? twel_ticks : wel_ticks;
+    int exposure_order_type_id = use_twel
+        ? (is_long ? 10 : 21) : (is_long ? 24 : 25);
+    // Rust chooses by finalized size, then strict distance to the executable
+    // touch, and finally stable order fields. Unstuck and WEL share the touch,
+    // so the lower unstuck order-type id wins only that exact-price tie.
+    bool use_unstuck = reducer_candidate_preferred(
+        finalized_unstuck_qty, unstuck_ticks, unstuck_order_type_id,
+        finalized_exposure_qty, exposure_ticks, exposure_order_type_id,
+        is_long
+    );
+    // Final sizing is only the selection key. Preserve the requested quantity
+    // for the winning reducer so the ordinary close allocator below can absorb
+    // dust exactly as Rust does when TWEL is the sole strategy-external close.
+    float reducer_qty = use_unstuck
+        ? unstuck_qty : (use_twel ? twel_qty : wel_qty);
+    int reducer_ticks = use_unstuck
+        ? unstuck_ticks : (use_twel ? twel_ticks : wel_ticks);
+    float reducer_price = use_unstuck
+        ? unstuck_price : (use_twel ? twel_price : wel_price);
     if (reducer_qty > 0.0f && reducer_ticks > 0) {
         float reducer_min = min_entry_qty(
             reducer_price, qty_step, min_qty, min_cost, c_mult

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -4,7 +4,7 @@ using namespace metal;
 constant int DAILY_COLS = 5;
 constant int SCALAR_COLS = 18;
 constant int GAP_BINS = 128;
-constant int SIDE_PARAMS = 34;
+constant int SIDE_PARAMS = 40;
 
 inline float round_step(float value, float step) {
     return floor(value / step + 0.5f) * step;
@@ -69,6 +69,67 @@ inline bool realized_loss_proxy_allows_close(
     return isfinite(net_pnl) && net_pnl > margin;
 }
 
+inline float float32_floor_nonnegative(float value) {
+    if (!(value > 0.0f) || !isfinite(value)) return fmax(value, 0.0f);
+    return as_type<float>(as_type<uint>(value) - 1u);
+}
+
+inline bool realized_loss_proxy_allows_reducer(
+    float qty,
+    float close_price,
+    float pprice,
+    bool is_long,
+    bool is_unstuck,
+    float c_mult,
+    float maker_fee,
+    bool gate_enabled,
+    float balance,
+    float realized_pnl_cumsum_last,
+    float realized_pnl_cumsum_max,
+    float max_realized_loss_pct
+) {
+    if (!gate_enabled) return true;
+    if (!is_unstuck) {
+        return realized_loss_proxy_allows_close(
+            qty, close_price, pprice, is_long,
+            c_mult, maker_fee, true
+        );
+    }
+    if (!(qty > 0.0f && close_price > 0.0f && pprice > 0.0f)) return false;
+    float gross_pnl = qty * c_mult
+        * (is_long ? close_price - pprice : pprice - close_price);
+    float fee = qty * close_price * c_mult * maker_fee;
+    float net_pnl = gross_pnl - fee;
+    if (!isfinite(net_pnl)) return false;
+    if (net_pnl >= 0.0f) return true;
+    float balance_peak = balance
+        + (realized_pnl_cumsum_max - realized_pnl_cumsum_last);
+    float allowed_loss_budget = float32_floor_nonnegative(
+        balance_peak * fmax(max_realized_loss_pct, 0.0f)
+    );
+    float current_realized_loss = fmax(
+        realized_pnl_cumsum_max - realized_pnl_cumsum_last, 0.0f
+    );
+    float remaining_loss_budget = float32_floor_nonnegative(
+        fmax(allowed_loss_budget - current_realized_loss, 0.0f)
+    );
+    float arithmetic_scale = fabs(gross_pnl) + fabs(fee)
+        + qty * fabs(c_mult) * (fabs(close_price) + fabs(pprice));
+    float margin = 1.220703125e-4f * arithmetic_scale;
+    return -net_pnl + margin <= remaining_loss_budget;
+}
+
+inline void record_realized_net(
+    float net_pnl,
+    thread float& realized_pnl_cumsum_last,
+    thread float& realized_pnl_cumsum_max
+) {
+    realized_pnl_cumsum_last += net_pnl;
+    realized_pnl_cumsum_max = fmax(
+        realized_pnl_cumsum_max, realized_pnl_cumsum_last
+    );
+}
+
 struct TmSide {
     float alpha0, alpha1, alpha2, alpha1m, alpha1h;
     float ddf, initial_ema_dist, initial_qty_pct;
@@ -85,7 +146,15 @@ struct TmSide {
     float wel_enforcer_threshold;
     bool twel_enforcer_enabled;
     float twel_enforcer_threshold;
+    bool unstuck_enabled;
+    bool unstuck_ema_gating_enabled;
+    float unstuck_close_pct;
+    float unstuck_ema_dist;
+    float unstuck_loss_allowance_pct;
+    float unstuck_threshold;
+    float unstuck_allowance;
     bool close_is_exposure_reducer, close_is_twel_reducer;
+    bool close_is_unstuck_reducer;
     bool close_loss_gate_disabled_reducers;
     float ema0, ema1, ema2, vol1m, vol1h;
     float psize, pprice, last_inc_k, pos_open_k;
@@ -159,8 +228,16 @@ inline TmSide load_side(constant float* p, int o, float seed) {
     s.wel_enforcer_threshold = p[o + 32];
     s.twel_enforcer_enabled = p[o + 33] > 0.5f;
     s.twel_enforcer_threshold = twel_threshold;
+    s.unstuck_enabled = p[o + 34] > 0.5f;
+    s.unstuck_ema_gating_enabled = p[o + 35] > 0.5f;
+    s.unstuck_close_pct = p[o + 36];
+    s.unstuck_ema_dist = p[o + 37];
+    s.unstuck_loss_allowance_pct = p[o + 38];
+    s.unstuck_threshold = p[o + 39];
+    s.unstuck_allowance = 0.0f;
     s.close_is_exposure_reducer = false;
     s.close_is_twel_reducer = false;
+    s.close_is_unstuck_reducer = false;
     s.close_loss_gate_disabled_reducers = false;
     s.ema0 = seed; s.ema1 = seed; s.ema2 = seed;
     s.vol1m = 0.0f; s.vol1h = 0.0f;
@@ -332,6 +409,117 @@ inline float finalized_reducer_qty(
         ? psize : reducer_qty;
 }
 
+inline bool reducer_candidate_preferred(
+    float left_qty,
+    int left_ticks,
+    int left_order_type_id,
+    float right_qty,
+    int right_ticks,
+    int right_order_type_id,
+    bool is_long
+) {
+    if (!(left_qty > 0.0f)) return false;
+    if (!(right_qty > 0.0f)) return true;
+    if (left_qty != right_qty) return left_qty > right_qty;
+    if (left_ticks != right_ticks) {
+        return is_long ? left_ticks < right_ticks : left_ticks > right_ticks;
+    }
+    return left_order_type_id < right_order_type_id;
+}
+
+inline float calc_unstuck_allowance(
+    thread const TmSide& s,
+    float balance,
+    float balance_peak
+) {
+    if (!(s.unstuck_enabled
+        && s.unstuck_loss_allowance_pct > 0.0f
+        && s.twel > 0.0f
+        && balance > 0.0f
+        && balance_peak > 0.0f)) {
+        return 0.0f;
+    }
+    float allowance_pct = s.unstuck_loss_allowance_pct * s.twel;
+    return float32_floor_nonnegative(
+        fmax(balance - balance_peak * (1.0f - allowance_pct), 0.0f)
+    );
+}
+
+inline bool unstuck_eligible(
+    thread const TmSide& s,
+    bool is_long,
+    float balance,
+    float price_now,
+    int touch_down_ticks,
+    int touch_up_ticks,
+    float price_step,
+    float c_mult
+) {
+    if (!(s.unstuck_enabled
+        && s.unstuck_allowance > 0.0f
+        && s.unstuck_close_pct > 0.0f
+        && s.unstuck_threshold > 0.0f
+        && s.psize > 0.0f
+        && s.pprice > 0.0f
+        && s.allowed_wel > 0.0f
+        && balance > 0.0f
+        && price_now > 0.0f)) {
+        return false;
+    }
+    float wallet_exposure = s.psize * s.pprice * c_mult / balance;
+    if (!(wallet_exposure / s.allowed_wel > s.unstuck_threshold)) {
+        return false;
+    }
+    if (!s.unstuck_ema_gating_enabled) return true;
+    float lower = fmin(s.ema0, fmin(s.ema1, s.ema2));
+    float upper = fmax(s.ema0, fmax(s.ema1, s.ema2));
+    int trigger_ticks = is_long
+        ? int(ceil(
+            upper * (1.0f + s.unstuck_ema_dist) / price_step - 1.0e-6f
+        ))
+        : int(floor(
+            lower * (1.0f - s.unstuck_ema_dist) / price_step + 1.0e-6f
+        ));
+    return is_long
+        ? touch_down_ticks >= trigger_ticks
+        : touch_up_ticks <= trigger_ticks;
+}
+
+inline float unstuck_reducer_qty(
+    thread const TmSide& s,
+    bool is_long,
+    float balance,
+    float reducer_price,
+    float qty_step,
+    float min_qty,
+    float min_cost,
+    float c_mult
+) {
+    if (!(s.unstuck_enabled && s.unstuck_allowance > 0.0f)) return 0.0f;
+    float reducer_min = min_entry_qty(
+        reducer_price, qty_step, min_qty, min_cost, c_mult
+    );
+    float target_qty = floor_step(
+        balance * s.allowed_wel * s.unstuck_close_pct
+            / fmax(reducer_price * c_mult, 1.0e-12f),
+        qty_step
+    );
+    float qty = fmin(s.psize, fmax(reducer_min, target_qty));
+    float gross_pnl = qty * c_mult * (
+        is_long ? reducer_price - s.pprice : s.pprice - reducer_price
+    );
+    if (gross_pnl < 0.0f && -gross_pnl > s.unstuck_allowance) {
+        float scaled_qty = fmin(
+            s.psize, qty * s.unstuck_allowance / -gross_pnl
+        );
+        qty = fmin(
+            s.psize,
+            fmax(reducer_min, floor_step(scaled_qty, qty_step))
+        );
+    }
+    return qty;
+}
+
 inline void generate_orders(
     thread TmSide& s, bool is_long, float balance, float price_now,
     int touch_down_ticks, int touch_up_ticks, int touch_nearest_ticks,
@@ -362,6 +550,7 @@ inline void generate_orders(
     s.close_gen_touch_min_qty_relation = touch_min_qty_relation;
     s.close_is_exposure_reducer = false;
     s.close_is_twel_reducer = false;
+    s.close_is_unstuck_reducer = false;
     s.close_loss_gate_disabled_reducers = false;
     s.secondary_close_ticks = 0;
     s.secondary_close_price = 0.0f;
@@ -505,6 +694,15 @@ inline void generate_orders(
             qty_step, min_qty, min_cost, c_mult
         ) : 0.0f;
 
+    int unstuck_ticks = is_long ? touch_up_ticks : touch_down_ticks;
+    float unstuck_price = float(unstuck_ticks) * price_step;
+    float unstuck_qty = s.unstuck_enabled
+        ? unstuck_reducer_qty(
+            s, is_long, balance, unstuck_price,
+            qty_step, min_qty, min_cost, c_mult
+        )
+        : 0.0f;
+
     float finalized_wel_qty = finalized_reducer_qty(
         s.psize, wel_qty, wel_price,
         qty_step, min_qty, min_cost, c_mult
@@ -513,13 +711,34 @@ inline void generate_orders(
         s.psize, twel_qty, twel_price,
         qty_step, min_qty, min_cost, c_mult
     );
+    float finalized_unstuck_qty = finalized_reducer_qty(
+        s.psize, unstuck_qty, unstuck_price,
+        qty_step, min_qty, min_cost, c_mult
+    );
+    int unstuck_order_type_id = is_long ? 9 : 20;
     bool use_twel = finalized_twel_qty > finalized_wel_qty;
+    float finalized_exposure_qty = use_twel
+        ? finalized_twel_qty : finalized_wel_qty;
+    int exposure_ticks = use_twel ? twel_ticks : wel_ticks;
+    int exposure_order_type_id = use_twel
+        ? (is_long ? 10 : 21) : (is_long ? 24 : 25);
+    // Rust chooses by finalized size, then strict distance to the executable
+    // touch, and finally stable order fields. Unstuck and WEL share the touch,
+    // so the lower unstuck order-type id wins only that exact-price tie.
+    bool use_unstuck = reducer_candidate_preferred(
+        finalized_unstuck_qty, unstuck_ticks, unstuck_order_type_id,
+        finalized_exposure_qty, exposure_ticks, exposure_order_type_id,
+        is_long
+    );
     // Final sizing is only the selection key. Preserve the requested quantity
     // for the winning reducer so the ordinary close allocator below can absorb
     // dust exactly as Rust does when TWEL is the sole strategy-external close.
-    float reducer_qty = use_twel ? twel_qty : wel_qty;
-    int reducer_ticks = use_twel ? twel_ticks : wel_ticks;
-    float reducer_price = use_twel ? twel_price : wel_price;
+    float reducer_qty = use_unstuck
+        ? unstuck_qty : (use_twel ? twel_qty : wel_qty);
+    int reducer_ticks = use_unstuck
+        ? unstuck_ticks : (use_twel ? twel_ticks : wel_ticks);
+    float reducer_price = use_unstuck
+        ? unstuck_price : (use_twel ? twel_price : wel_price);
 
     float ct = s.close_threshold_base + wer * s.close_threshold_we
         + s.vol1h * s.close_threshold_v1h + s.vol1m * s.close_threshold_v1m;
@@ -582,7 +801,7 @@ inline void generate_orders(
         // trailing close. TWEL is appended by orchestration, so it retains an
         // independently generated trailing close only when no strategy WEL
         // would have taken precedence during calc_closes_*.
-        if (use_twel && wel_qty <= 0.0f
+        if ((use_twel || use_unstuck) && wel_qty <= 0.0f
             && trailing_close && s.close_qty > 0.0f) {
             float ordinary_qty = s.close_qty;
             if (ordinary_qty + reducer_qty > s.psize) {
@@ -623,7 +842,8 @@ inline void generate_orders(
         s.close_price = reducer_price;
         s.close_qty = reducer_qty;
         s.close_is_exposure_reducer = true;
-        s.close_is_twel_reducer = use_twel;
+        s.close_is_twel_reducer = use_twel && !use_unstuck;
+        s.close_is_unstuck_reducer = use_unstuck;
     }
 }
 
@@ -755,7 +975,8 @@ inline void passivbot_single_coin_impl(
     const bool hedge_mode = settings[11] > 0.5f;
     const bool filter_by_min_effective_cost = settings[12] > 0.5f;
     const float max_effective_min_cost = settings[13];
-    const bool loss_gate_enabled = settings[14] < 1.0f;
+    const float max_realized_loss_pct = settings[14];
+    const bool loss_gate_enabled = max_realized_loss_pct < 1.0f;
     const float log_bin_scale = 127.0f / log(4000001.0f);
 
     const int po = int(b) * P;
@@ -765,6 +986,8 @@ inline void passivbot_single_coin_impl(
     TmSide short_side = load_side(params, po + SIDE_PARAMS, seed_close);
 
     float balance = starting_balance;
+    float realized_pnl_cumsum_last = 0.0f;
+    float realized_pnl_cumsum_max = 0.0f;
     bool alive = true;
     int liq_day = -1;
     float held_max_min = 0.0f;
@@ -871,6 +1094,7 @@ inline void passivbot_single_coin_impl(
             if (long_side.close_loss_gate_disabled_reducers) {
                 grid_source.wel_enforcer_enabled = false;
                 grid_source.twel_enforcer_enabled = false;
+                grid_source.unstuck_enabled = false;
             }
             float reducer_qty = 0.0f;
             int reducer_ticks = 0;
@@ -883,7 +1107,8 @@ inline void passivbot_single_coin_impl(
                 reducer_ticks = long_side.close_ticks;
                 reducer_price = long_side.close_price;
                 strategy_wel_qty = reducer_qty;
-                if (long_side.close_is_twel_reducer) {
+                if (long_side.close_is_twel_reducer
+                    || long_side.close_is_unstuck_reducer) {
                     float wel_price = float(
                         long_side.close_gen_touch_up_ticks
                     ) * price_step;
@@ -905,6 +1130,7 @@ inline void passivbot_single_coin_impl(
                 );
                 grid_source.wel_enforcer_enabled = false;
                 grid_source.twel_enforcer_enabled = false;
+                grid_source.unstuck_enabled = false;
             }
             CloseGroup group;
             int grid_rung_limit = strategy_wel_qty > 0.0f ? 499 : 500;
@@ -1015,12 +1241,21 @@ inline void passivbot_single_coin_impl(
                     float pnl = reducer_qty * c_mult
                         * (reducer_price - long_side.pprice);
                     float fee = reducer_qty * reducer_price * c_mult * maker_fee;
-                    if (!realized_loss_proxy_allows_close(
+                    if (!realized_loss_proxy_allows_reducer(
                             reducer_qty, reducer_price, long_side.pprice, true,
-                            c_mult, maker_fee, loss_gate_enabled)) {
+                            long_side.close_is_unstuck_reducer,
+                            c_mult, maker_fee, loss_gate_enabled, balance,
+                            realized_pnl_cumsum_last,
+                            realized_pnl_cumsum_max,
+                            max_realized_loss_pct)) {
                         reducer_reachable = false;
                     } else {
                         balance += pnl - fee;
+                        record_realized_net(
+                            pnl - fee,
+                            realized_pnl_cumsum_last,
+                            realized_pnl_cumsum_max
+                        );
                         long_side.psize = fmax(
                             round_step(
                                 long_side.psize - reducer_qty, qty_step
@@ -1042,6 +1277,11 @@ inline void passivbot_single_coin_impl(
                         adj, group.price, long_side.pprice, true,
                         c_mult, maker_fee, loss_gate_enabled)) continue;
                 balance += pnl - fee;
+                record_realized_net(
+                    pnl - fee,
+                    realized_pnl_cumsum_last,
+                    realized_pnl_cumsum_max
+                );
                 float new_psize = fmax(
                     round_step(long_side.psize - adj, qty_step), 0.0f
                 );
@@ -1066,10 +1306,19 @@ inline void passivbot_single_coin_impl(
                 float pnl = adj * c_mult
                     * (reducer_price - long_side.pprice);
                 float fee = adj * reducer_price * c_mult * maker_fee;
-                if (realized_loss_proxy_allows_close(
+                if (realized_loss_proxy_allows_reducer(
                         adj, reducer_price, long_side.pprice, true,
-                        c_mult, maker_fee, loss_gate_enabled)) {
+                        long_side.close_is_unstuck_reducer,
+                        c_mult, maker_fee, loss_gate_enabled, balance,
+                        realized_pnl_cumsum_last,
+                        realized_pnl_cumsum_max,
+                        max_realized_loss_pct)) {
                     balance += pnl - fee;
+                    record_realized_net(
+                        pnl - fee,
+                        realized_pnl_cumsum_last,
+                        realized_pnl_cumsum_max
+                    );
                     long_side.psize = fmax(
                         round_step(long_side.psize - adj, qty_step), 0.0f
                     );
@@ -1107,10 +1356,20 @@ inline void passivbot_single_coin_impl(
                 );
                 float pnl = adj * c_mult * (cp - long_side.pprice);
                 float fee = adj * cp * c_mult * maker_fee;
-                if (!realized_loss_proxy_allows_close(
-                        adj, cp, long_side.pprice, true,
-                        c_mult, maker_fee, loss_gate_enabled)) continue;
+                bool selected_unstuck = !use_secondary
+                    && long_side.close_is_unstuck_reducer;
+                if (!realized_loss_proxy_allows_reducer(
+                        adj, cp, long_side.pprice, true, selected_unstuck,
+                        c_mult, maker_fee, loss_gate_enabled, balance,
+                        realized_pnl_cumsum_last,
+                        realized_pnl_cumsum_max,
+                        max_realized_loss_pct)) continue;
                 balance += pnl - fee;
+                record_realized_net(
+                    pnl - fee,
+                    realized_pnl_cumsum_last,
+                    realized_pnl_cumsum_max
+                );
                 long_side.psize = fmax(
                     round_step(long_side.psize - adj, qty_step), 0.0f
                 );
@@ -1154,6 +1413,11 @@ inline void passivbot_single_coin_impl(
 
                 float fee = eq * ep * c_mult * maker_fee;
                 balance -= fee;
+                record_realized_net(
+                    -fee,
+                    realized_pnl_cumsum_last,
+                    realized_pnl_cumsum_max
+                );
                 bool was_flat = long_side.psize <= 0.0f;
                 float new_psize = round_step(long_side.psize + eq, qty_step);
                 float new_pprice = was_flat ? ep
@@ -1225,6 +1489,7 @@ inline void passivbot_single_coin_impl(
             if (short_side.close_loss_gate_disabled_reducers) {
                 grid_source.wel_enforcer_enabled = false;
                 grid_source.twel_enforcer_enabled = false;
+                grid_source.unstuck_enabled = false;
             }
             float reducer_qty = 0.0f;
             int reducer_ticks = 0;
@@ -1237,7 +1502,8 @@ inline void passivbot_single_coin_impl(
                 reducer_ticks = short_side.close_ticks;
                 reducer_price = short_side.close_price;
                 strategy_wel_qty = reducer_qty;
-                if (short_side.close_is_twel_reducer) {
+                if (short_side.close_is_twel_reducer
+                    || short_side.close_is_unstuck_reducer) {
                     float wel_price = float(
                         short_side.close_gen_touch_down_ticks
                     ) * price_step;
@@ -1259,6 +1525,7 @@ inline void passivbot_single_coin_impl(
                 );
                 grid_source.wel_enforcer_enabled = false;
                 grid_source.twel_enforcer_enabled = false;
+                grid_source.unstuck_enabled = false;
             }
             CloseGroup group;
             int grid_rung_limit = strategy_wel_qty > 0.0f ? 499 : 500;
@@ -1369,12 +1636,21 @@ inline void passivbot_single_coin_impl(
                     float pnl = reducer_qty * c_mult
                         * (short_side.pprice - reducer_price);
                     float fee = reducer_qty * reducer_price * c_mult * maker_fee;
-                    if (!realized_loss_proxy_allows_close(
+                    if (!realized_loss_proxy_allows_reducer(
                             reducer_qty, reducer_price, short_side.pprice, false,
-                            c_mult, maker_fee, loss_gate_enabled)) {
+                            short_side.close_is_unstuck_reducer,
+                            c_mult, maker_fee, loss_gate_enabled, balance,
+                            realized_pnl_cumsum_last,
+                            realized_pnl_cumsum_max,
+                            max_realized_loss_pct)) {
                         reducer_reachable = false;
                     } else {
                         balance += pnl - fee;
+                        record_realized_net(
+                            pnl - fee,
+                            realized_pnl_cumsum_last,
+                            realized_pnl_cumsum_max
+                        );
                         short_side.psize = fmax(
                             round_step(
                                 short_side.psize - reducer_qty, qty_step
@@ -1396,6 +1672,11 @@ inline void passivbot_single_coin_impl(
                         adj, group.price, short_side.pprice, false,
                         c_mult, maker_fee, loss_gate_enabled)) continue;
                 balance += pnl - fee;
+                record_realized_net(
+                    pnl - fee,
+                    realized_pnl_cumsum_last,
+                    realized_pnl_cumsum_max
+                );
                 float new_psize = fmax(
                     round_step(short_side.psize - adj, qty_step), 0.0f
                 );
@@ -1420,10 +1701,19 @@ inline void passivbot_single_coin_impl(
                 float pnl = adj * c_mult
                     * (short_side.pprice - reducer_price);
                 float fee = adj * reducer_price * c_mult * maker_fee;
-                if (realized_loss_proxy_allows_close(
+                if (realized_loss_proxy_allows_reducer(
                         adj, reducer_price, short_side.pprice, false,
-                        c_mult, maker_fee, loss_gate_enabled)) {
+                        short_side.close_is_unstuck_reducer,
+                        c_mult, maker_fee, loss_gate_enabled, balance,
+                        realized_pnl_cumsum_last,
+                        realized_pnl_cumsum_max,
+                        max_realized_loss_pct)) {
                     balance += pnl - fee;
+                    record_realized_net(
+                        pnl - fee,
+                        realized_pnl_cumsum_last,
+                        realized_pnl_cumsum_max
+                    );
                     short_side.psize = fmax(
                         round_step(short_side.psize - adj, qty_step), 0.0f
                     );
@@ -1461,10 +1751,20 @@ inline void passivbot_single_coin_impl(
                 );
                 float pnl = adj * c_mult * (short_side.pprice - cp);
                 float fee = adj * cp * c_mult * maker_fee;
-                if (!realized_loss_proxy_allows_close(
-                        adj, cp, short_side.pprice, false,
-                        c_mult, maker_fee, loss_gate_enabled)) continue;
+                bool selected_unstuck = !use_secondary
+                    && short_side.close_is_unstuck_reducer;
+                if (!realized_loss_proxy_allows_reducer(
+                        adj, cp, short_side.pprice, false, selected_unstuck,
+                        c_mult, maker_fee, loss_gate_enabled, balance,
+                        realized_pnl_cumsum_last,
+                        realized_pnl_cumsum_max,
+                        max_realized_loss_pct)) continue;
                 balance += pnl - fee;
+                record_realized_net(
+                    pnl - fee,
+                    realized_pnl_cumsum_last,
+                    realized_pnl_cumsum_max
+                );
                 short_side.psize = fmax(
                     round_step(short_side.psize - adj, qty_step), 0.0f
                 );
@@ -1508,6 +1808,11 @@ inline void passivbot_single_coin_impl(
 
                 float fee = eq * ep * c_mult * maker_fee;
                 balance -= fee;
+                record_realized_net(
+                    -fee,
+                    realized_pnl_cumsum_last,
+                    realized_pnl_cumsum_max
+                );
                 bool was_flat = short_side.psize <= 0.0f;
                 float new_psize = round_step(short_side.psize + eq, qty_step);
                 float new_pprice = was_flat ? ep
@@ -1624,6 +1929,35 @@ inline void passivbot_single_coin_impl(
                     }
                 }
             }
+            float balance_peak = balance
+                + (realized_pnl_cumsum_max - realized_pnl_cumsum_last);
+            long_side.unstuck_allowance = calc_unstuck_allowance(
+                long_side, balance, balance_peak
+            );
+            short_side.unstuck_allowance = calc_unstuck_allowance(
+                short_side, balance, balance_peak
+            );
+            bool configured_long_unstuck = long_side.unstuck_enabled;
+            bool configured_short_unstuck = short_side.unstuck_enabled;
+            bool long_unstuck_selected = long_enabled && unstuck_eligible(
+                long_side, true, balance, close, touch_down_tick,
+                touch_up_tick, price_step, c_mult
+            );
+            bool short_unstuck_selected = short_enabled && unstuck_eligible(
+                short_side, false, balance, close, touch_down_tick,
+                touch_up_tick, price_step, c_mult
+            );
+            if (long_unstuck_selected && short_unstuck_selected) {
+                float long_diff = 1.0f - close / long_side.pprice;
+                float short_diff = close / short_side.pprice - 1.0f;
+                if (long_diff <= short_diff) {
+                    short_unstuck_selected = false;
+                } else {
+                    long_unstuck_selected = false;
+                }
+            }
+            long_side.unstuck_enabled = long_unstuck_selected;
+            short_side.unstuck_enabled = short_unstuck_selected;
             if (long_enabled) {
                 generate_long_orders(
                     long_side, balance, close, qty_step, touch_down_tick,
@@ -1641,18 +1975,25 @@ inline void passivbot_single_coin_impl(
                 );
             }
             // Exact Rust tries the next-largest protective reducer when the
-            // winner is loss-gated, then falls back to the ordinary strategy
-            // ladder. Re-generate only this uncommon gated path; ordinary
-            // recursive groups are screened individually when reachable.
-            if (long_enabled && loss_gate_enabled
+            // winner is loss-gated. Auto-unstuck may consume the conservative
+            // all-history budget; other TM reducers retain the zero-loss envelope.
+            bool long_wel_enabled = long_side.wel_enforcer_enabled;
+            bool long_twel_enabled = long_side.twel_enforcer_enabled;
+            for (int retry = 0; retry < 3 && long_enabled
+                && loss_gate_enabled
                 && long_side.close_is_exposure_reducer
-                && !realized_loss_proxy_allows_close(
+                && !realized_loss_proxy_allows_reducer(
                     long_side.close_qty, long_side.close_price,
-                    long_side.pprice, true, c_mult, maker_fee, true
-                )) {
-                bool wel_enabled = long_side.wel_enforcer_enabled;
-                bool twel_enabled = long_side.twel_enforcer_enabled;
-                if (long_side.close_is_twel_reducer) {
+                    long_side.pprice, true,
+                    long_side.close_is_unstuck_reducer,
+                    c_mult, maker_fee, true, balance,
+                    realized_pnl_cumsum_last,
+                    realized_pnl_cumsum_max,
+                    max_realized_loss_pct
+                ); ++retry) {
+                if (long_side.close_is_unstuck_reducer) {
+                    long_side.unstuck_enabled = false;
+                } else if (long_side.close_is_twel_reducer) {
                     long_side.twel_enforcer_enabled = false;
                 } else {
                     long_side.wel_enforcer_enabled = false;
@@ -1665,33 +2006,25 @@ inline void passivbot_single_coin_impl(
                 );
                 if (!long_side.close_is_exposure_reducer) {
                     long_side.close_loss_gate_disabled_reducers = true;
-                } else if (long_side.close_is_exposure_reducer
-                    && !realized_loss_proxy_allows_close(
-                        long_side.close_qty, long_side.close_price,
-                        long_side.pprice, true, c_mult, maker_fee, true
-                    )) {
-                    long_side.wel_enforcer_enabled = false;
-                    long_side.twel_enforcer_enabled = false;
-                    generate_long_orders(
-                        long_side, balance, close, qty_step, touch_down_tick,
-                        touch_up_tick, touch_nearest_tick, touch_min_qty,
-                        touch_min_qty_relation, price_step, min_qty,
-                        min_cost, c_mult, kf, block_long_initial
-                    );
-                    long_side.close_loss_gate_disabled_reducers = true;
                 }
-                long_side.wel_enforcer_enabled = wel_enabled;
-                long_side.twel_enforcer_enabled = twel_enabled;
             }
-            if (short_enabled && loss_gate_enabled
+            bool short_wel_enabled = short_side.wel_enforcer_enabled;
+            bool short_twel_enabled = short_side.twel_enforcer_enabled;
+            for (int retry = 0; retry < 3 && short_enabled
+                && loss_gate_enabled
                 && short_side.close_is_exposure_reducer
-                && !realized_loss_proxy_allows_close(
+                && !realized_loss_proxy_allows_reducer(
                     short_side.close_qty, short_side.close_price,
-                    short_side.pprice, false, c_mult, maker_fee, true
-                )) {
-                bool wel_enabled = short_side.wel_enforcer_enabled;
-                bool twel_enabled = short_side.twel_enforcer_enabled;
-                if (short_side.close_is_twel_reducer) {
+                    short_side.pprice, false,
+                    short_side.close_is_unstuck_reducer,
+                    c_mult, maker_fee, true, balance,
+                    realized_pnl_cumsum_last,
+                    realized_pnl_cumsum_max,
+                    max_realized_loss_pct
+                ); ++retry) {
+                if (short_side.close_is_unstuck_reducer) {
+                    short_side.unstuck_enabled = false;
+                } else if (short_side.close_is_twel_reducer) {
                     short_side.twel_enforcer_enabled = false;
                 } else {
                     short_side.wel_enforcer_enabled = false;
@@ -1704,24 +2037,14 @@ inline void passivbot_single_coin_impl(
                 );
                 if (!short_side.close_is_exposure_reducer) {
                     short_side.close_loss_gate_disabled_reducers = true;
-                } else if (short_side.close_is_exposure_reducer
-                    && !realized_loss_proxy_allows_close(
-                        short_side.close_qty, short_side.close_price,
-                        short_side.pprice, false, c_mult, maker_fee, true
-                    )) {
-                    short_side.wel_enforcer_enabled = false;
-                    short_side.twel_enforcer_enabled = false;
-                    generate_short_orders(
-                        short_side, balance, close, qty_step, touch_down_tick,
-                        touch_up_tick, touch_nearest_tick, touch_min_qty,
-                        touch_min_qty_relation, price_step, min_qty,
-                        min_cost, c_mult, kf, block_short_initial
-                    );
-                    short_side.close_loss_gate_disabled_reducers = true;
                 }
-                short_side.wel_enforcer_enabled = wel_enabled;
-                short_side.twel_enforcer_enabled = twel_enabled;
             }
+            long_side.wel_enforcer_enabled = long_wel_enabled;
+            long_side.twel_enforcer_enabled = long_twel_enabled;
+            long_side.unstuck_enabled = configured_long_unstuck;
+            short_side.wel_enforcer_enabled = short_wel_enabled;
+            short_side.twel_enforcer_enabled = short_twel_enabled;
+            short_side.unstuck_enabled = configured_short_unstuck;
         }
 
         float long_unreal = long_side.psize > 0.0f

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -96,6 +96,13 @@ _SINGLE_COIN_EXPOSURE_BOUND_SUFFIXES = {
     "risk_twel_enforcer_threshold": "twel_enforcer_threshold",
 }
 
+_SINGLE_COIN_UNSTUCK_BOUND_SUFFIXES = {
+    "unstuck_close_pct": "unstuck_close_pct",
+    "unstuck_ema_dist": "unstuck_ema_dist",
+    "unstuck_loss_allowance_pct": "unstuck_loss_allowance_pct",
+    "unstuck_threshold": "unstuck_threshold",
+}
+
 EMA_STRATEGY_BOUND_MAP = {
     f"{side}_{bound_suffix}": f"{side}_{parameter}"
     for side in ("long", "short")
@@ -108,6 +115,11 @@ EMA_BOUND_MAP = {
         f"{side}_{bound_suffix}": f"{side}_{parameter}"
         for side in ("long", "short")
         for bound_suffix, parameter in _SINGLE_COIN_EXPOSURE_BOUND_SUFFIXES.items()
+    },
+    **{
+        f"{side}_{bound_suffix}": f"{side}_{parameter}"
+        for side in ("long", "short")
+        for bound_suffix, parameter in _SINGLE_COIN_UNSTUCK_BOUND_SUFFIXES.items()
     },
 }
 
@@ -181,6 +193,11 @@ TRAILING_MARTINGALE_BOUND_MAP = {
         f"{side}_{bound_suffix}": f"{side}_{parameter}"
         for side in ("long", "short")
         for bound_suffix, parameter in _SINGLE_COIN_EXPOSURE_BOUND_SUFFIXES.items()
+    },
+    **{
+        f"{side}_{bound_suffix}": f"{side}_{parameter}"
+        for side in ("long", "short")
+        for bound_suffix, parameter in _SINGLE_COIN_UNSTUCK_BOUND_SUFFIXES.items()
     },
 }
 
@@ -433,7 +450,6 @@ PINNED_SCOPE_BOUND_VALUES = {
     for side in ("long", "short")
     for suffix, expected in {
         "hsl_enabled": 0.0,
-        "unstuck_enabled": 0.0,
     }.items()
 }
 
@@ -927,9 +943,10 @@ def _validate_scope_config(
         side_config = config["bot"][side]
         if bool(side_config.get("hsl", {}).get("enabled")):
             raise ValueError(f"GPU foundation requires bot.{side}.hsl.enabled=false")
-        if bool(side_config.get("unstuck", {}).get("enabled")):
+        if coin_count > 1 and bool(side_config.get("unstuck", {}).get("enabled")):
             raise ValueError(
-                f"GPU foundation requires bot.{side}.unstuck.enabled=false"
+                "GPU multicoin foundation requires "
+                f"bot.{side}.unstuck.enabled=false"
             )
         risk = side_config.get("risk", {})
         required_disabled = []
@@ -2100,6 +2117,10 @@ def _validate_pinned_scope_bounds(
 ) -> None:
     enabled_sides = set(enabled_sides or ("long", "short"))
     pinned = dict(PINNED_SCOPE_BOUND_VALUES)
+    if coin_count > 1:
+        pinned.update(
+            {f"{side}_unstuck_enabled": 0.0 for side in ("long", "short")}
+        )
     if strategy_kind != "trailing_martingale":
         pinned.update(
             {
@@ -2689,14 +2710,14 @@ def run_backend(
         ):
             # Forager ranking cannot affect a one-coin backtest.
             continue
-        if any(
-            bound_key.startswith(f"{side}_hsl_")
-            or bound_key.startswith(f"{side}_unstuck_")
-            for side in enabled_sides
+        if any(bound_key.startswith(f"{side}_hsl_") for side in enabled_sides):
+            # HSL remains disabled, so its dormant bounds affect neither path.
+            continue
+        if max_coin_count > 1 and any(
+            bound_key.startswith(f"{side}_unstuck_") for side in enabled_sides
         ):
-            # The enabling flags are not optimizer bounds. Scope validation
-            # requires both features off, so these dormant values cannot affect
-            # either the exact Rust backtest or the proxy.
+            # Multicoin unstuck remains disabled until the proxy owns the same
+            # global least-stuck selector as exact Rust.
             continue
         if (
             max_coin_count == 1

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -1792,6 +1792,7 @@ def _gpu_suite_checkpoint_contract(config: dict, suite_inputs=None) -> dict:
     contract["max_realized_loss_pct"] = float(
         config.get("live", {}).get("max_realized_loss_pct", 1.0)
     )
+    contract["unstuck"] = _gpu_unstuck_checkpoint_contract(config)
     if suite_inputs is not None:
         prepared_scenarios = []
         for item in suite_inputs:
@@ -1838,6 +1839,7 @@ def _gpu_suite_checkpoint_contract(config: dict, suite_inputs=None) -> dict:
                         .get("live", {})
                         .get("max_realized_loss_pct", 1.0)
                     ),
+                    "unstuck": _gpu_unstuck_checkpoint_contract(item["config"]),
                     "candle_count": int(len(item["hlcvs"])),
                     "first_timestamp": (
                         int(timestamps[0]) if len(timestamps) else None
@@ -1864,7 +1866,60 @@ def _gpu_runtime_checkpoint_contract(config: dict, proxy) -> dict:
         "coin_override_contract": deepcopy(
             getattr(proxy, "coin_override_contract", None)
         ),
+        "unstuck": _gpu_unstuck_checkpoint_contract(config),
     }
+
+
+def _gpu_unstuck_checkpoint_contract(config: dict) -> dict:
+    contract = {}
+    for side in ("long", "short"):
+        unstuck = config.get("bot", {}).get(side, {}).get("unstuck", {})
+        contract[side] = {
+            "enabled": bool(unstuck.get("enabled", False)),
+            "ema_gating_enabled": bool(
+                unstuck.get("ema_gating_enabled", True)
+            ),
+            "close_pct": float(unstuck.get("close_pct", 0.0)),
+            "ema_dist": float(unstuck.get("ema_dist", 0.0)),
+            "loss_allowance_pct": float(
+                unstuck.get("loss_allowance_pct", 0.0)
+            ),
+            "threshold": float(unstuck.get("threshold", 0.0)),
+        }
+    return contract
+
+
+def _single_coin_unstuck_search_sides(
+    proxy_config: dict, suite_inputs
+) -> set[str]:
+    configs = (
+        [item["config"] for item in suite_inputs]
+        if suite_inputs
+        else [proxy_config]
+    )
+    return {
+        side
+        for side in ("long", "short")
+        if any(
+            gpu_side_enabled(item, side)
+            and bool(
+                item.get("bot", {})
+                .get(side, {})
+                .get("unstuck", {})
+                .get("enabled", False)
+            )
+            for item in configs
+        )
+    }
+
+
+def _gpu_unstuck_parameter_active(
+    parameter: str, unstuck_search_sides: set[str]
+) -> bool:
+    for side in ("long", "short"):
+        if parameter.startswith(f"{side}_unstuck_"):
+            return side in unstuck_search_sides
+    return True
 
 
 def _checkpoint_signature(
@@ -2602,6 +2657,11 @@ def run_backend(
     candidate_source_sides = _gpu_candidate_source_sides(
         enabled_sides, gpu_optimizer_overrides
     )
+    unstuck_search_sides = (
+        _single_coin_unstuck_search_sides(proxy_config, suite_inputs)
+        if max_coin_count == 1
+        else set()
+    )
     mapped = {
         name: value
         for name, value in mapped_all.items()
@@ -2612,6 +2672,7 @@ def run_backend(
         for name, (index, bound) in sorted(mapped.items(), key=lambda item: item[1][0])
         if bound.high > bound.low
         and name not in fixed_parameter_overrides
+        and _gpu_unstuck_parameter_active(name, unstuck_search_sides)
         and not (
             "mirror_short_from_long" in gpu_optimizer_overrides
             and name.startswith("short_")
@@ -2905,7 +2966,7 @@ def run_backend(
         runtime_contract=(
             None
             if suite_enabled
-            else _gpu_runtime_checkpoint_contract(config, proxy)
+            else _gpu_runtime_checkpoint_contract(proxy_config, proxy)
         ),
     )
     budget = int(config["optimize"]["iters"])

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -1909,14 +1909,16 @@ def _gpu_unstuck_checkpoint_contract(config: dict) -> dict:
 
 
 def _single_coin_unstuck_search_sides(
-    proxy_config: dict, suite_inputs
+    proxy_config: dict, suite_inputs, overrides: set[str] | None = None
 ) -> set[str]:
+    """Return target and mirrored source sides whose unstuck genes affect a scenario."""
+
     configs = (
         [item["config"] for item in suite_inputs]
         if suite_inputs
         else [proxy_config]
     )
-    return {
+    target_sides = {
         side
         for side in ("long", "short")
         if any(
@@ -1930,6 +1932,7 @@ def _single_coin_unstuck_search_sides(
             for item in configs
         )
     }
+    return _gpu_candidate_source_sides(target_sides, overrides or set())
 
 
 def _gpu_unstuck_parameter_active(
@@ -2677,7 +2680,9 @@ def run_backend(
         enabled_sides, gpu_optimizer_overrides
     )
     unstuck_search_sides = (
-        _single_coin_unstuck_search_sides(proxy_config, suite_inputs)
+        _single_coin_unstuck_search_sides(
+            proxy_config, suite_inputs, gpu_optimizer_overrides
+        )
         if max_coin_count == 1
         else set()
     )

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -16,6 +16,7 @@ from typing import Any
 import numpy as np
 
 from config.metrics import resolve_metric_value
+from config.pnl_lookback import parse_pnls_max_lookback_days
 from limit_utils import compute_limit_violation
 from metrics_schema import flatten_metric_stats
 from optimization.backend_shared import (
@@ -1792,6 +1793,9 @@ def _gpu_suite_checkpoint_contract(config: dict, suite_inputs=None) -> dict:
     contract["max_realized_loss_pct"] = float(
         config.get("live", {}).get("max_realized_loss_pct", 1.0)
     )
+    contract["pnls_max_lookback_days"] = (
+        _gpu_pnls_max_lookback_days_checkpoint_value(config)
+    )
     contract["unstuck"] = _gpu_unstuck_checkpoint_contract(config)
     if suite_inputs is not None:
         prepared_scenarios = []
@@ -1839,6 +1843,11 @@ def _gpu_suite_checkpoint_contract(config: dict, suite_inputs=None) -> dict:
                         .get("live", {})
                         .get("max_realized_loss_pct", 1.0)
                     ),
+                    "pnls_max_lookback_days": (
+                        _gpu_pnls_max_lookback_days_checkpoint_value(
+                            item["config"]
+                        )
+                    ),
                     "unstuck": _gpu_unstuck_checkpoint_contract(item["config"]),
                     "candle_count": int(len(item["hlcvs"])),
                     "first_timestamp": (
@@ -1863,11 +1872,21 @@ def _gpu_runtime_checkpoint_contract(config: dict, proxy) -> dict:
         "max_realized_loss_pct": float(
             config.get("live", {}).get("max_realized_loss_pct", 1.0)
         ),
+        "pnls_max_lookback_days": (
+            _gpu_pnls_max_lookback_days_checkpoint_value(config)
+        ),
         "coin_override_contract": deepcopy(
             getattr(proxy, "coin_override_contract", None)
         ),
         "unstuck": _gpu_unstuck_checkpoint_contract(config),
     }
+
+
+def _gpu_pnls_max_lookback_days_checkpoint_value(config: dict) -> float:
+    return parse_pnls_max_lookback_days(
+        config.get("live", {}).get("pnls_max_lookback_days", 30.0),
+        field_name="live.pnls_max_lookback_days",
+    ).to_backtest_days_value()
 
 
 def _gpu_unstuck_checkpoint_contract(config: dict) -> dict:

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -41,6 +41,15 @@ TOTAL_EXPOSURE_ENFORCER_PARAM_KEYS = (
     "twel_enforcer_enabled",
 )
 
+UNSTUCK_PARAM_KEYS = (
+    "unstuck_enabled",
+    "unstuck_ema_gating_enabled",
+    "unstuck_close_pct",
+    "unstuck_ema_dist",
+    "unstuck_loss_allowance_pct",
+    "unstuck_threshold",
+)
+
 MULTICOIN_TOTAL_EXPOSURE_ENFORCER_PARAM_KEYS = (
     *TOTAL_EXPOSURE_ENFORCER_PARAM_KEYS,
     "twel_enforcer_reduce_portfolio",
@@ -53,6 +62,7 @@ EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS = (
     *EMA_ANCHOR_PARAM_KEYS,
     *SINGLE_COIN_EXPOSURE_PARAM_KEYS,
     *TOTAL_EXPOSURE_ENFORCER_PARAM_KEYS,
+    *UNSTUCK_PARAM_KEYS,
 )
 
 EMA_ANCHOR_MULTICOIN_PARAM_KEYS = (
@@ -103,6 +113,7 @@ TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS = (
     *SINGLE_COIN_EXPOSURE_PARAM_KEYS,
     *POSITION_EXPOSURE_ENFORCER_PARAM_KEYS,
     *TOTAL_EXPOSURE_ENFORCER_PARAM_KEYS,
+    *UNSTUCK_PARAM_KEYS,
 )
 
 TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS = (

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -117,6 +117,19 @@ def _total_exposure_enforcer_params(
     }
 
 
+def _unstuck_params(bot: dict) -> dict[str, float]:
+    return {
+        "unstuck_enabled": float(bool(bot["unstuck_enabled"])),
+        "unstuck_ema_gating_enabled": float(
+            bool(bot["unstuck_ema_gating_enabled"])
+        ),
+        "unstuck_close_pct": float(bot["unstuck_close_pct"]),
+        "unstuck_ema_dist": float(bot["unstuck_ema_dist"]),
+        "unstuck_loss_allowance_pct": float(bot["unstuck_loss_allowance_pct"]),
+        "unstuck_threshold": float(bot["unstuck_threshold"]),
+    }
+
+
 def _require_complete_valid_tail(last_valid_idx: int, candle_count: int) -> None:
     if int(last_valid_idx) != int(candle_count) - 1:
         raise ValueError(
@@ -352,10 +365,6 @@ class MpsSingleCoinProxy:
             raise ValueError("GPU foundation requires at least one enabled side")
         self.base_params = {}
         for side, bot in (("long", long_bot), ("short", short_bot)):
-            if self.enabled[side] and bool(bot.get("unstuck_enabled")):
-                raise ValueError(
-                    f"GPU foundation requires bot.{side}.unstuck.enabled=false"
-                )
             if self.enabled[side] and bool(bot.get("hsl_enabled")):
                 raise ValueError(f"GPU foundation requires bot.{side}.hsl.enabled=false")
             strategy = dict(payload.strategy_params_list[0][side])
@@ -378,6 +387,7 @@ class MpsSingleCoinProxy:
                 strategy.update(
                     _total_exposure_enforcer_params(risk, side=side)
                 )
+                strategy.update(_unstuck_params(bot))
             missing = [key for key in self.param_keys if key not in strategy]
             if missing:
                 raise ValueError(

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -34,6 +34,7 @@ from optimization.backends.gpu_backend import (
     _gpu_suite_enabled,
     _gpu_suite_checkpoint_contract,
     _gpu_runtime_checkpoint_contract,
+    _gpu_unstuck_parameter_active,
     _gpu_suite_scenario_override_context,
     _gpu_suite_scenario_inputs,
     _gpu_suite_search_context,
@@ -48,6 +49,7 @@ from optimization.backends.gpu_backend import (
     _submit_gpu_exact_validation,
     _resolve_options,
     _restore_gpu_result_run_contract,
+    _single_coin_unstuck_search_sides,
     _single_scenario_metric_surface,
     _suite_limit_metric_value,
     _trailing_martingale_multicoin_bound_map,
@@ -2227,6 +2229,36 @@ def test_gpu_foundation_accepts_single_coin_unstuck_on_short_side():
     assert _validate_scope(config, _Evaluator()) == "bybit"
 
 
+def test_gpu_single_coin_unstuck_search_excludes_disabled_side_genes():
+    config = _directional_ema_config(long_enabled=True, short_enabled=True)
+
+    assert _single_coin_unstuck_search_sides(config, []) == set()
+    assert not _gpu_unstuck_parameter_active(
+        "long_unstuck_close_pct", set()
+    )
+    assert _gpu_unstuck_parameter_active("long_offset", set())
+
+    config["bot"]["short"]["unstuck"]["enabled"] = True
+    search_sides = _single_coin_unstuck_search_sides(config, [])
+    assert search_sides == {"short"}
+    assert not _gpu_unstuck_parameter_active(
+        "long_unstuck_threshold", search_sides
+    )
+    assert _gpu_unstuck_parameter_active(
+        "short_unstuck_threshold", search_sides
+    )
+
+
+def test_gpu_single_coin_suite_keeps_unstuck_genes_used_by_any_scenario():
+    base = _directional_ema_config(long_enabled=True, short_enabled=False)
+    scenario = copy.deepcopy(base)
+    scenario["bot"]["long"]["unstuck"]["enabled"] = True
+
+    assert _single_coin_unstuck_search_sides(
+        base, [{"config": scenario}]
+    ) == {"long"}
+
+
 def test_gpu_foundation_keeps_multicoin_unstuck_fail_closed():
     config = _directional_ema_config(long_enabled=True, short_enabled=False)
     config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "SOL"]
@@ -3671,6 +3703,48 @@ def test_gpu_checkpoint_signature_tracks_realized_loss_gate_contract():
     )
 
 
+def test_gpu_checkpoint_signature_tracks_single_coin_unstuck_contract():
+    active = [("long_offset", 0, Bound(0.01, 0.1, 0.01))]
+    scoring = [{"goal": "max", "metric": "adg_strategy_eq"}]
+    config = _long_only_ema_config()
+    config["bot"]["long"]["unstuck"]["enabled"] = True
+    proxy = SimpleNamespace(coin_override_contract=None)
+    original_contract = _gpu_runtime_checkpoint_contract(config, proxy)
+    original = _checkpoint_signature(
+        active, scoring, runtime_contract=original_contract
+    )
+
+    edits = {
+        "enabled": False,
+        "ema_gating_enabled": False,
+        "close_pct": 0.234,
+        "ema_dist": -0.012,
+        "loss_allowance_pct": 0.034,
+        "threshold": 0.876,
+    }
+    for key, value in edits.items():
+        changed = copy.deepcopy(config)
+        changed["bot"]["long"]["unstuck"][key] = value
+        changed_contract = _gpu_runtime_checkpoint_contract(changed, proxy)
+        assert changed_contract != original_contract
+        assert (
+            _checkpoint_signature(
+                active, scoring, runtime_contract=changed_contract
+            )
+            != original
+        )
+
+    fixed = _long_only_ema_config()
+    fixed["optimize"]["fixed_runtime_overrides"] = {
+        "bot.long.unstuck.enabled": True,
+        "bot.long.unstuck.threshold": 0.765,
+    }
+    effective = _materialize_gpu_override_template(fixed, [])
+    effective_contract = _gpu_runtime_checkpoint_contract(effective, proxy)
+    assert effective_contract["unstuck"]["long"]["enabled"] is True
+    assert effective_contract["unstuck"]["long"]["threshold"] == 0.765
+
+
 def test_gpu_checkpoint_signature_tracks_prepared_coin_override_contract():
     active = [("long_offset", 0, Bound(0.01, 0.1, 0.01))]
     scoring = [{"goal": "max", "metric": "adg_strategy_eq"}]
@@ -3753,6 +3827,7 @@ def test_gpu_suite_checkpoint_contract_tracks_prepared_scenario_identity():
             "strategy_kind": "ema_anchor",
             "enabled_sides": ["long"],
             "max_realized_loss_pct": 1.0,
+            "unstuck": original["unstuck"],
             "candle_count": 3,
             "first_timestamp": 1000,
             "last_timestamp": 3000,
@@ -3778,6 +3853,10 @@ def test_gpu_suite_checkpoint_contract_tracks_prepared_scenario_identity():
 
     assert changed != original
     assert changed["prepared_scenarios"][0]["max_realized_loss_pct"] == 0.05
+
+    changed_unstuck = copy.deepcopy(item)
+    changed_unstuck["config"]["bot"]["long"]["unstuck"]["enabled"] = True
+    assert _gpu_suite_checkpoint_contract(config, [changed_unstuck]) != original
 
     changed_coins = copy.deepcopy(item)
     changed_coins["coins"] = ["BTC", "SOL"]

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -374,6 +374,10 @@ def test_trailing_martingale_bound_map_covers_both_directional_shapes():
         "risk_we_excess_allowance_pct",
         "risk_wel_enforcer_threshold",
         "total_wallet_exposure_limit",
+        "unstuck_close_pct",
+        "unstuck_ema_dist",
+        "unstuck_loss_allowance_pct",
+        "unstuck_threshold",
     }
 
     assert set(TRAILING_MARTINGALE_BOUND_MAP) == {
@@ -1376,12 +1380,6 @@ def test_suite_limit_metric_value_respects_reducer_and_scenario():
             "hsl",
         ),
         (
-            lambda config: config["bot"]["long"]["unstuck"].__setitem__(
-                "enabled", True
-            ),
-            "unstuck",
-        ),
-        (
             lambda config: config["backtest"].__setitem__(
                 "btc_collateral_cap", 0.5
             ),
@@ -2222,12 +2220,21 @@ def test_gpu_foundation_accepts_recursive_trailing_martingale_bounds():
     assert _validate_scope(config, _Evaluator()) == "bybit"
 
 
-def test_gpu_foundation_checks_unsupported_behavior_on_short_side():
+def test_gpu_foundation_accepts_single_coin_unstuck_on_short_side():
     config = _directional_ema_config(long_enabled=False, short_enabled=True)
     config["bot"]["short"]["unstuck"]["enabled"] = True
 
-    with pytest.raises(ValueError, match=r"bot\.short\.unstuck"):
-        _validate_scope(config, _Evaluator())
+    assert _validate_scope(config, _Evaluator()) == "bybit"
+
+
+def test_gpu_foundation_keeps_multicoin_unstuck_fail_closed():
+    config = _directional_ema_config(long_enabled=True, short_enabled=False)
+    config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "SOL"]
+    config["bot"]["long"]["risk"]["n_positions"] = 2
+    config["bot"]["long"]["unstuck"]["enabled"] = True
+
+    with pytest.raises(ValueError, match=r"multicoin.*bot\.long\.unstuck"):
+        _validate_scope(config, _MulticoinEvaluator())
 
 
 def test_gpu_foundation_rejects_both_sides_disabled():
@@ -3293,7 +3300,7 @@ def test_gpu_fixed_disabled_retracement_canonicalizes_dead_weight_genes():
     assert close["retracement_volatility_1m_weight"] == 0.01
 
 
-def test_gpu_materialized_fixed_runtime_scope_still_fails_closed():
+def test_gpu_materialized_fixed_runtime_scope_accepts_single_coin_unstuck():
     config = _long_only_ema_config()
     config["optimize"]["fixed_runtime_overrides"] = {
         "bot.long.unstuck.enabled": True
@@ -3303,8 +3310,7 @@ def test_gpu_materialized_fixed_runtime_scope_still_fails_closed():
         [],
     )
 
-    with pytest.raises(ValueError, match=r"bot\.long\.unstuck"):
-        _validate_scope(proxy_config, _Evaluator())
+    assert _validate_scope(proxy_config, _Evaluator()) == "bybit"
 
 
 def test_gpu_optimizer_override_scope_fails_closed():
@@ -3889,6 +3895,23 @@ def test_gpu_accepts_single_coin_exposure_policy_bounds():
         {"long"},
         coin_count=1,
     )
+
+
+def test_gpu_accepts_single_coin_unstuck_bounds_but_pins_multicoin_disabled():
+    from optimization.bounds import Bound
+
+    bounds = {
+        "long_unstuck_enabled": Bound(1.0, 1.0, None),
+        "long_unstuck_close_pct": Bound(0.01, 0.2, None),
+        "long_unstuck_ema_dist": Bound(-0.05, 0.05, None),
+        "long_unstuck_loss_allowance_pct": Bound(0.01, 0.1, None),
+        "long_unstuck_threshold": Bound(0.5, 0.95, None),
+    }
+    base = {"long_unstuck_enabled": 1.0}
+
+    _validate_pinned_scope_bounds(bounds, base, {"long"}, coin_count=1)
+    with pytest.raises(ValueError, match="unstuck_enabled"):
+        _validate_pinned_scope_bounds(bounds, base, {"long"}, coin_count=2)
 
 
 def test_gpu_anchor_constant_twel_threshold_is_supported_for_multicoin():

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -3734,15 +3734,36 @@ def test_gpu_checkpoint_signature_tracks_single_coin_unstuck_contract():
             != original
         )
 
+    changed_lookback = copy.deepcopy(config)
+    changed_lookback["live"]["pnls_max_lookback_days"] = 7.0
+    changed_lookback_contract = _gpu_runtime_checkpoint_contract(
+        changed_lookback, proxy
+    )
+    assert changed_lookback_contract["pnls_max_lookback_days"] == 7.0
+    assert (
+        _checkpoint_signature(
+            active, scoring, runtime_contract=changed_lookback_contract
+        )
+        != original
+    )
+
+    all_history = copy.deepcopy(config)
+    all_history["live"]["pnls_max_lookback_days"] = "all"
+    assert _gpu_runtime_checkpoint_contract(all_history, proxy)[
+        "pnls_max_lookback_days"
+    ] == -1.0
+
     fixed = _long_only_ema_config()
     fixed["optimize"]["fixed_runtime_overrides"] = {
         "bot.long.unstuck.enabled": True,
         "bot.long.unstuck.threshold": 0.765,
+        "live.pnls_max_lookback_days": 12.0,
     }
     effective = _materialize_gpu_override_template(fixed, [])
     effective_contract = _gpu_runtime_checkpoint_contract(effective, proxy)
     assert effective_contract["unstuck"]["long"]["enabled"] is True
     assert effective_contract["unstuck"]["long"]["threshold"] == 0.765
+    assert effective_contract["pnls_max_lookback_days"] == 12.0
 
 
 def test_gpu_checkpoint_signature_tracks_prepared_coin_override_contract():
@@ -3827,6 +3848,7 @@ def test_gpu_suite_checkpoint_contract_tracks_prepared_scenario_identity():
             "strategy_kind": "ema_anchor",
             "enabled_sides": ["long"],
             "max_realized_loss_pct": 1.0,
+            "pnls_max_lookback_days": 30.0,
             "unstuck": original["unstuck"],
             "candle_count": 3,
             "first_timestamp": 1000,
@@ -3853,6 +3875,18 @@ def test_gpu_suite_checkpoint_contract_tracks_prepared_scenario_identity():
 
     assert changed != original
     assert changed["prepared_scenarios"][0]["max_realized_loss_pct"] == 0.05
+
+    changed_lookback = copy.deepcopy(item)
+    changed_lookback["config"]["live"]["pnls_max_lookback_days"] = 7.0
+    changed = _gpu_suite_checkpoint_contract(config, [changed_lookback])
+    assert changed != original
+    assert changed["prepared_scenarios"][0]["pnls_max_lookback_days"] == 7.0
+
+    changed_base_lookback = copy.deepcopy(config)
+    changed_base_lookback["live"]["pnls_max_lookback_days"] = "all"
+    changed = _gpu_suite_checkpoint_contract(changed_base_lookback, [item])
+    assert changed != original
+    assert changed["pnls_max_lookback_days"] == -1.0
 
     changed_unstuck = copy.deepcopy(item)
     changed_unstuck["config"]["bot"]["long"]["unstuck"]["enabled"] = True

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -2259,6 +2259,23 @@ def test_gpu_single_coin_suite_keeps_unstuck_genes_used_by_any_scenario():
     ) == {"long"}
 
 
+def test_gpu_single_coin_suite_keeps_mirrored_unstuck_source_genes():
+    base = _directional_ema_config(long_enabled=False, short_enabled=True)
+    scenario = copy.deepcopy(base)
+    scenario["bot"]["short"]["unstuck"]["enabled"] = True
+
+    search_sides = _single_coin_unstuck_search_sides(
+        base,
+        [{"config": scenario}],
+        {"mirror_short_from_long"},
+    )
+
+    assert search_sides == {"long", "short"}
+    assert _gpu_unstuck_parameter_active(
+        "long_unstuck_close_pct", search_sides
+    )
+
+
 def test_gpu_foundation_keeps_multicoin_unstuck_fail_closed():
     config = _directional_ema_config(long_enabled=True, short_enabled=False)
     config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "SOL"]

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -1571,6 +1571,71 @@ def test_mps_tm_equal_unstuck_twel_reducers_keep_nearer_twel(side):
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+def test_mps_tm_unstuck_finalization_keeps_valid_ordinary_close_remainder():
+    count = 7
+    close = np.full(count, 100.0)
+    high = np.full(count, 100.0)
+    low = np.full(count, 100.0)
+    low[3] = 98.0
+    high[4] = 201.0
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.5, 0.01, 0.5, 500.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_single_row(
+        initial_ema_dist=0.01,
+        gate_initial=1.0,
+        gate_reentry=0.0,
+        entry_gate=True,
+        threshold=1.0,
+        wel_enforcer_enabled=True,
+        wel_enforcer_threshold=0.2,
+        unstuck_enabled=True,
+        unstuck_ema_gating_enabled=False,
+        unstuck_close_pct=0.7,
+        unstuck_loss_allowance_pct=0.2,
+        unstuck_threshold=0.5,
+    )
+    row[6] = 1.0
+    row[7] = 10.0
+    row[11] = 0.0
+    row[15] = 0.3
+    row[16] = 1.0
+    row[20] = 0.01
+    row[23] = 100.0
+
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=True,
+        short_enabled=False,
+        max_realized_loss_pct=0.05,
+    ).run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    # At the 100 touch, the requested unstuck close is 7 and its minimum is 5.
+    # The ordinary close near 198 has a 3-unit quantity above its ~2.5 minimum,
+    # so exact finalization keeps the unstuck selection key at 7 instead of
+    # promoting it to the full 10. The genuinely larger WEL reducer therefore
+    # wins and leaves less than the unstuck request would have left.
+    assert output["psize"].item() < 3.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
 @pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_single_coin_exposure_headroom_and_entry_gate(
@@ -4815,6 +4880,7 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert "close_gen_balance" in source
     assert "merge_reducer" not in source
     assert "finalized_reducer_qty" in source
+    assert "finalized_reducer_qty_with_ordinary" in source
     assert "reducer_candidate_preferred" in source
     assert "strict distance to the executable" in source
     assert "for (int rung = 0; rung < 500; ++rung)" in source

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -53,8 +53,40 @@ def _tm_wel_enforcer_fields(*, enabled=False, threshold=1.0):
     return [float(enabled), threshold]
 
 
-def _tm_twel_enforcer_fields(*, enabled=False):
-    return [float(enabled)]
+def _tm_twel_enforcer_fields(
+    *,
+    enabled=False,
+    unstuck_enabled=False,
+    unstuck_ema_gating_enabled=True,
+    unstuck_close_pct=0.1,
+    unstuck_ema_dist=0.0,
+    unstuck_loss_allowance_pct=0.1,
+    unstuck_threshold=0.5,
+):
+    return [
+        float(enabled),
+        float(unstuck_enabled),
+        float(unstuck_ema_gating_enabled),
+        unstuck_close_pct,
+        unstuck_ema_dist,
+        unstuck_loss_allowance_pct,
+        unstuck_threshold,
+    ]
+
+
+_UNSTUCK_DISABLED_VALUES = {
+    "unstuck_enabled": 0.0,
+    "unstuck_ema_gating_enabled": 1.0,
+    "unstuck_close_pct": 0.1,
+    "unstuck_ema_dist": 0.0,
+    "unstuck_loss_allowance_pct": 0.1,
+    "unstuck_threshold": 0.5,
+}
+
+
+def _single_coin_param_row(values, keys):
+    merged = {**_UNSTUCK_DISABLED_VALUES, **values}
+    return [merged[key] for key in keys]
 
 
 def _multicoin_exposure_fixture(
@@ -320,7 +352,7 @@ def test_mps_ema_anchor_shader_smoke():
 
     source = passivbot_rust.mps_ema_anchor_source_py()
     assert "kernel void passivbot_ema_anchor" in source
-    assert "constant int SIDE_PARAMS = 17" in source
+    assert "constant int SIDE_PARAMS = 23" in source
     assert "total_exposure_reducer_qty" in source
     assert "secondary_close_qty" in source
     assert "realized_loss_gate_allows" in source
@@ -1108,6 +1140,12 @@ def _tm_single_row(
     wel_enforcer_enabled=False,
     wel_enforcer_threshold=1.0,
     twel_enforcer_enabled=False,
+    unstuck_enabled=False,
+    unstuck_ema_gating_enabled=True,
+    unstuck_close_pct=0.1,
+    unstuck_ema_dist=0.0,
+    unstuck_loss_allowance_pct=0.1,
+    unstuck_threshold=0.5,
 ):
     return _tm_row(
         initial_ema_dist=initial_ema_dist,
@@ -1123,7 +1161,411 @@ def _tm_single_row(
         threshold=wel_enforcer_threshold,
     ) + _tm_twel_enforcer_fields(
         enabled=twel_enforcer_enabled,
+        unstuck_enabled=unstuck_enabled,
+        unstuck_ema_gating_enabled=unstuck_ema_gating_enabled,
+        unstuck_close_pct=unstuck_close_pct,
+        unstuck_ema_dist=unstuck_ema_dist,
+        unstuck_loss_allowance_pct=unstuck_loss_allowance_pct,
+        unstuck_threshold=unstuck_threshold,
     )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_single_coin_auto_unstuck_reduces_eligible_position(
+    strategy_kind, side
+):
+    count = 6
+    close = np.full(count, 100.0)
+    high = np.full(count, 100.01)
+    low = np.full(count, 100.0)
+    if side == "long":
+        low[3] = 98.0
+    else:
+        high[:] = 100.0
+        high[3] = 102.0
+        low[:] = 99.99
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(1.0, 0.01, 1.0, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+
+    def candidate(unstuck_enabled, *, ema_gating=False, ema_dist=0.0):
+        if strategy_kind == "trailing_martingale":
+            row = _tm_single_row(
+                initial_ema_dist=0.01,
+                gate_initial=1.0,
+                gate_reentry=0.0,
+                entry_gate=True,
+                unstuck_enabled=unstuck_enabled,
+                unstuck_ema_gating_enabled=ema_gating,
+                unstuck_close_pct=0.1,
+                unstuck_ema_dist=ema_dist,
+                unstuck_loss_allowance_pct=0.2,
+                unstuck_threshold=0.5,
+            )
+            row[6] = 1.0
+            row[7] = 10.0
+            row[11] = 0.0
+            row[16] = 0.5
+            row[20] = 0.0
+            row[23] = 100.0
+            return row + row
+        row = [
+            1.0,
+            2.0,
+            3.0,
+            0.0,
+            0.01,
+            0.0,
+            0.0,
+            0.0,
+            2.0,
+            2.0,
+            100.0,
+            1.0,
+        ]
+        row += _single_coin_exposure_fields(entry_gate=True)
+        row += _tm_twel_enforcer_fields(
+            unstuck_enabled=unstuck_enabled,
+            unstuck_ema_gating_enabled=ema_gating,
+            unstuck_close_pct=0.1,
+            unstuck_ema_dist=ema_dist,
+            unstuck_loss_allowance_pct=0.2,
+            unstuck_threshold=0.5,
+        )
+        return row + row
+
+    runner_cls = (
+        MpsTrailingMartingaleRunner
+        if strategy_kind == "trailing_martingale"
+        else MpsEmaAnchorRunner
+    )
+    output = runner_cls(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+        max_realized_loss_pct=0.05,
+    ).run(
+        np.asarray(
+            [
+                candidate(False),
+                candidate(True),
+                candidate(True, ema_gating=True, ema_dist=0.1),
+            ],
+            dtype=np.float64,
+        )
+    )
+    torch.mps.synchronize()
+
+    key = "psize" if side == "long" else "short_psize"
+    remaining = output[key].cpu().numpy()
+    initial_size = (
+        9.0 if strategy_kind == "ema_anchor" and side == "short" else 10.0
+    )
+    assert remaining[0] == pytest.approx(initial_size)
+    assert remaining[1] == pytest.approx(initial_size - 1.0)
+    assert remaining[2] == pytest.approx(initial_size)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_single_coin_auto_unstuck_scales_loss_to_own_allowance(
+    strategy_kind, side
+):
+    count = 6
+    close = np.full(count, 100.0)
+    if side == "long":
+        close[3:] = 98.0
+        high = close + 0.01
+        low = close.copy()
+    else:
+        close[3:] = 102.0
+        high = close.copy()
+        low = close - 0.01
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(1.0, 0.01, 1.0, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+
+    def candidate(*, unstuck_enabled, loss_allowance_pct):
+        if strategy_kind == "trailing_martingale":
+            row = _tm_single_row(
+                initial_ema_dist=0.01,
+                gate_initial=1.0,
+                gate_reentry=0.0,
+                entry_gate=True,
+                unstuck_enabled=unstuck_enabled,
+                unstuck_ema_gating_enabled=False,
+                unstuck_close_pct=1.0,
+                unstuck_loss_allowance_pct=loss_allowance_pct,
+                unstuck_threshold=0.5,
+            )
+            row[6] = 1.0
+            row[7] = 10.0
+            row[11] = 0.0
+            row[16] = 0.5
+            row[20] = 0.0
+            row[23] = 100.0
+            return row + row
+        row = [
+            1.0,
+            2.0,
+            3.0,
+            0.0,
+            0.01,
+            0.0,
+            0.0,
+            0.0,
+            2.0,
+            2.0,
+            100.0,
+            1.0,
+        ]
+        row += _single_coin_exposure_fields(entry_gate=True)
+        row += _tm_twel_enforcer_fields(
+            unstuck_enabled=unstuck_enabled,
+            unstuck_ema_gating_enabled=False,
+            unstuck_close_pct=1.0,
+            unstuck_loss_allowance_pct=loss_allowance_pct,
+            unstuck_threshold=0.5,
+        )
+        return row + row
+
+    runner_cls = (
+        MpsTrailingMartingaleRunner
+        if strategy_kind == "trailing_martingale"
+        else MpsEmaAnchorRunner
+    )
+    output = runner_cls(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+        max_realized_loss_pct=0.05,
+    ).run(
+        np.asarray(
+            [
+                candidate(unstuck_enabled=False, loss_allowance_pct=0.0005),
+                candidate(unstuck_enabled=True, loss_allowance_pct=0.0005),
+                candidate(unstuck_enabled=True, loss_allowance_pct=0.02),
+            ],
+            dtype=np.float64,
+        )
+    )
+    torch.mps.synchronize()
+
+    key = "psize" if side == "long" else "short_psize"
+    remaining = output[key].cpu().numpy()
+    initial_size = (
+        9.0 if strategy_kind == "ema_anchor" and side == "short" else 10.0
+    )
+    assert remaining[0] == pytest.approx(initial_size)
+    assert remaining[1] == pytest.approx(initial_size - 1.0)
+    generous_remainder = (
+        1.0 if strategy_kind == "trailing_martingale" and side == "short" else 0.0
+    )
+    assert remaining[2] == pytest.approx(generous_remainder)
+
+    strict_output = runner_cls(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+        max_realized_loss_pct=0.0005,
+    ).run(
+        np.asarray(
+            [candidate(unstuck_enabled=True, loss_allowance_pct=0.02)],
+            dtype=np.float64,
+        )
+    )
+    torch.mps.synchronize()
+    assert strict_output[key].item() == pytest.approx(initial_size)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+def test_mps_single_coin_auto_unstuck_selects_one_least_stuck_side(strategy_kind):
+    count = 6
+    close = np.full(count, 100.0)
+    high = np.full(count, 100.01)
+    low = np.full(count, 99.99)
+    high[3] = 102.0
+    low[3] = 98.0
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(1.0, 0.01, 1.0, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+
+    if strategy_kind == "trailing_martingale":
+        row = _tm_single_row(
+            initial_ema_dist=0.01,
+            gate_initial=1.0,
+            gate_reentry=0.0,
+            entry_gate=True,
+            unstuck_enabled=True,
+            unstuck_ema_gating_enabled=False,
+            unstuck_close_pct=0.1,
+            unstuck_loss_allowance_pct=0.2,
+            unstuck_threshold=0.5,
+        )
+        row[6] = 1.0
+        row[7] = 10.0
+        row[11] = 0.0
+        row[16] = 0.5
+        row[20] = 0.0
+        row[23] = 100.0
+    else:
+        row = [
+            1.0,
+            2.0,
+            3.0,
+            0.0,
+            0.01,
+            0.0,
+            0.0,
+            0.0,
+            2.0,
+            2.0,
+            100.0,
+            1.0,
+        ]
+        row += _single_coin_exposure_fields(entry_gate=True)
+        row += _tm_twel_enforcer_fields(
+            unstuck_enabled=True,
+            unstuck_ema_gating_enabled=False,
+            unstuck_close_pct=0.1,
+            unstuck_loss_allowance_pct=0.2,
+            unstuck_threshold=0.5,
+        )
+
+    runner_cls = (
+        MpsTrailingMartingaleRunner
+        if strategy_kind == "trailing_martingale"
+        else MpsEmaAnchorRunner
+    )
+    output = runner_cls(
+        market,
+        run,
+        data,
+        long_enabled=True,
+        short_enabled=True,
+    ).run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert output["psize"].item() == pytest.approx(9.0)
+    expected_short = 9.0 if strategy_kind == "ema_anchor" else 10.0
+    assert output["short_psize"].item() == pytest.approx(expected_short)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_equal_unstuck_twel_reducers_keep_nearer_twel(side):
+    count = 6
+    close = np.full(count, 100.0)
+    high = np.full(count, 100.0)
+    low = np.full(count, 100.0)
+    if side == "long":
+        low[3] = 98.0
+    else:
+        high[3] = 102.0
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(1.0, 0.01, 1.0, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_single_row(
+        initial_ema_dist=0.01,
+        gate_initial=1.0,
+        gate_reentry=0.0,
+        entry_gate=True,
+        twel_enforcer_enabled=True,
+        threshold=0.5,
+        unstuck_enabled=True,
+        unstuck_ema_gating_enabled=False,
+        unstuck_close_pct=0.5,
+        unstuck_loss_allowance_pct=0.2,
+        unstuck_threshold=0.5,
+    )
+    row[6] = 1.0
+    row[7] = 10.0
+    row[11] = 0.0
+    row[16] = 10.0
+    row[20] = 0.0
+    row[23] = 100.0
+
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+        max_realized_loss_pct=0.05,
+    ).run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    # The equal-size TWEL reducer is one price band more executable than the
+    # auto-unstuck reducer. The next candle crosses TWEL but only touches
+    # unstuck, proving selection follows Rust's reachability tie-break.
+    assert output[size_key].item() == pytest.approx(5.0)
 
 
 @pytest.mark.skipif(
@@ -1405,11 +1847,11 @@ def test_mps_ema_single_coin_total_exposure_repair(side):
         "twel_enforcer_threshold": 0.5,
         "twel_enforcer_enabled": 0.0,
     }
-    baseline = [values[key] for key in EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS]
+    baseline = _single_coin_param_row(values, EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS)
     repaired_values = dict(values, twel_enforcer_enabled=1.0)
-    repaired = [
-        repaired_values[key] for key in EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS
-    ]
+    repaired = _single_coin_param_row(
+        repaired_values, EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS
+    )
     output = MpsEmaAnchorRunner(
         market,
         run,
@@ -1493,7 +1935,7 @@ def test_mps_ema_realized_loss_gate_blocks_lossy_total_exposure_repair(side):
         "twel_enforcer_threshold": 0.5,
         "twel_enforcer_enabled": 1.0,
     }
-    row = [values[key] for key in EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS]
+    row = _single_coin_param_row(values, EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS)
     kwargs = {
         "long_enabled": side == "long",
         "short_enabled": side == "short",
@@ -1555,7 +1997,7 @@ def test_mps_ema_realized_loss_gate_shares_budget_between_sides():
         "twel_enforcer_threshold": 0.5,
         "twel_enforcer_enabled": 1.0,
     }
-    row = [values[key] for key in EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS]
+    row = _single_coin_param_row(values, EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS)
 
     output = MpsEmaAnchorRunner(
         market,
@@ -1615,7 +2057,7 @@ def test_mps_ema_realized_loss_gate_reserves_unfilled_batch_loss():
         "twel_enforcer_threshold": 0.5,
         "twel_enforcer_enabled": 1.0,
     }
-    row = [values[key] for key in EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS]
+    row = _single_coin_param_row(values, EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS)
     common = {
         "long_enabled": True,
         "short_enabled": True,
@@ -1684,7 +2126,7 @@ def test_mps_ema_zero_loss_budget_blocks_loss_below_balance_ulp():
         "twel_enforcer_threshold": 1.0,
         "twel_enforcer_enabled": 0.0,
     }
-    row = [values[key] for key in EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS]
+    row = _single_coin_param_row(values, EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS)
 
     ungated = MpsEmaAnchorRunner(
         market,
@@ -4330,7 +4772,7 @@ def test_mps_trailing_martingale_multicoin_sizes_raw_touch_close_before_price_fi
     )
     row.extend(_single_coin_exposure_fields())
     row.extend(_tm_wel_enforcer_fields())
-    row.extend(_tm_twel_enforcer_fields())
+    row.append(0.0)  # TWEL enforcer disabled
     row.append(0.0)  # TWEL reduce_overweight policy
 
     output = MpsTrailingMartingaleMulticoinRunner(
@@ -4360,7 +4802,7 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
 
     source = passivbot_rust.mps_trailing_martingale_source_py()
     assert "kernel void passivbot_trailing_martingale" in source
-    assert "constant int SIDE_PARAMS = 34" in source
+    assert "constant int SIDE_PARAMS = 40" in source
     assert "s.allowed_wel" in source
     assert "s.entry_cap" in source
     assert "min_since_open" in source
@@ -4373,11 +4815,14 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert "close_gen_balance" in source
     assert "merge_reducer" not in source
     assert "finalized_reducer_qty" in source
+    assert "reducer_candidate_preferred" in source
+    assert "strict distance to the executable" in source
     assert "for (int rung = 0; rung < 500; ++rung)" in source
     assert "ladder_side, ladder_balance" in source
     assert "recursive_close_groups" in source
     assert "realized_loss_proxy_allows_close" in source
-    assert "const bool loss_gate_enabled = settings[14] < 1.0f" in source
+    assert "const float max_realized_loss_pct = settings[14]" in source
+    assert "const bool loss_gate_enabled = max_realized_loss_pct < 1.0f" in source
     assert "the proxy uses a zero-loss envelope" in source
     assert "const bool filter_by_min_effective_cost" in source
     assert "passes_min_effective_cost" in source

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -22,6 +22,7 @@ from optimization.gpu.service import (
     _require_complete_valid_tail,
     _single_coin_exposure_params,
     _total_exposure_enforcer_params,
+    _unstuck_params,
 )
 
 
@@ -106,6 +107,26 @@ def test_tm_total_exposure_repair_packs_exact_rust_inputs(
             {"total_exposure_enforcer_policy": "largest_loss"},
             side="short",
         )
+
+
+def test_single_coin_unstuck_packs_exact_rust_inputs():
+    assert _unstuck_params(
+        {
+            "unstuck_enabled": True,
+            "unstuck_ema_gating_enabled": False,
+            "unstuck_close_pct": 0.125,
+            "unstuck_ema_dist": -0.01,
+            "unstuck_loss_allowance_pct": 0.02,
+            "unstuck_threshold": 0.85,
+        }
+    ) == {
+        "unstuck_enabled": 1.0,
+        "unstuck_ema_gating_enabled": 0.0,
+        "unstuck_close_pct": 0.125,
+        "unstuck_ema_dist": -0.01,
+        "unstuck_loss_allowance_pct": 0.02,
+        "unstuck_threshold": 0.85,
+    }
 
 
 def test_directional_parameter_matrix_keeps_side_values_separate():


### PR DESCRIPTION
## Summary

- add single-coin auto-unstuck parameters to the Apple MPS EMA Anchor and Trailing Martingale proxy surfaces
- model EMA gating, all-history realized-PnL allowance, minimum-aware close sizing, least-stuck long/short selection, reducer competition, and the global realized-loss gate
- preserve exact Rust as authoritative and keep multi-coin auto-unstuck and HSL fail closed
- cover long-only, short-only, dual-side hedge/one-way, bounds, fixed values, and compatible suite scenarios

## Safety and scope

- CPU optimization, backtesting, and live bot behavior are unchanged
- the Metal allowance is conservative relative to exact Rust rolling-lookback semantics
- exact validation plus classification, rank, constraint, and drift gates remain authoritative
- multi-coin auto-unstuck remains rejected until a portfolio-wide selector is implemented

## Review hardening

- checkpoint identity now includes every effective fixed auto-unstuck setting and the parsed PnL lookback, including prepared suite scenarios
- disabled single-coin unstuck sides no longer retain dormant unstuck optimizer dimensions
- mirrored suite scenarios retain the optimizer source-side unstuck genes consumed by exact candidate materialization
- Trailing Martingale reducer finalization now accounts for an accompanying valid ordinary close before comparing unstuck, TWEL, and WEL candidates

## Validation

- `cargo fmt --all -- --check`
- `cargo test --no-default-features` (262 passed)
- `cargo check --tests`
- `pytest -q tests/optimization/test_gpu_mps.py` (174 passed on Apple M3/MPS)
- `pytest -q tests/optimization/test_gpu_backend.py tests/optimization/test_gpu_service.py` (339 passed)
- full `pytest -q`: all tests outside seven HLCV-cache cases passed; those seven were caused by ignored local market-symbol cache files changing identity after the tests changed cwd, and the complete cache module passed 31/31 from a clean cwd
- real ETH/Bybit Trailing Martingale single-coin MPS optimization, 2024-01 through 2024-02: 64 generations, 4,096 proxy evaluations, 512 exact validations before review hardening; final-head recheck 8 generations, 512 proxy evaluations, 64 exact validations; no halt
- real ETH/Bybit dual-side EMA Anchor single-coin MPS optimization, 2024-01 through 2024-02: final-head recheck 8 generations, 512 proxy evaluations, 64 exact validations; no halt

This continues the incremental Apple MPS optimizer work. The implementation follows the existing exact Rust contracts and the GPU proxy/exact architecture developed from the earlier RustyCZ GPU branch work.
