### PR TITLE
feat(optimize): add single-coin MPS HSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ All notable user-facing changes will be documented in this file.
   Trailing Martingale runs, in both long and short directions and compatible suites. The Metal
   proxy models coin, pside, and unified drawdown signals; tunable RED threshold, EMA span, and
   cooldown; yellow/orange entry suppression; RED latching; resting-limit panic flattening;
-  flat confirmation; cooldown restart; and terminal no-restart. Exact Rust remains authoritative,
-  including for finite rolling PnL lookbacks. Market panic execution, dual-side and multi-coin
-  HSL, per-coin HSL overrides, and HSL-specific optimizer metrics remain fail closed.
+  flat confirmation; positive-cooldown restart; zero-cooldown indefinite halt; cumulative
+  no-restart peak tracking; effective coin-slot scaling; and terminal no-restart. Exact Rust
+  remains authoritative, including for finite rolling PnL lookbacks. Market panic execution,
+  dual-side and multi-coin HSL, per-coin HSL overrides, and HSL-specific optimizer metrics remain
+  fail closed.
 
 - Added auto-unstuck to Apple MPS EMA Anchor and Trailing Martingale optimization for single-coin
   long-only, short-only, dual-side hedge/one-way, and compatible suite runs, plus one-sided

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ All notable user-facing changes will be documented in this file.
   proxy models coin, pside, and unified drawdown signals; tunable RED threshold, EMA span, and
   cooldown; yellow/orange entry suppression; RED latching; resting-limit panic flattening;
   flat confirmation; positive-cooldown restart; zero-cooldown indefinite halt; cumulative
-  no-restart peak tracking; effective coin-slot scaling; and terminal no-restart. Exact Rust
-  remains authoritative, including for finite rolling PnL lookbacks. Market panic execution,
-  dual-side and multi-coin HSL, per-coin HSL overrides, and HSL-specific optimizer metrics remain
-  fail closed.
+  no-restart peak tracking; effective coin-slot scaling; and terminal no-restart. The initial
+  slice requires all-history PnL peaks and contiguous valid candles. Market panic execution,
+  finite rolling PnL lookbacks, dual-side and multi-coin HSL, per-coin HSL overrides, and
+  HSL-specific optimizer metrics remain fail closed.
 
 - Added auto-unstuck to Apple MPS EMA Anchor and Trailing Martingale optimization for single-coin
   long-only, short-only, dual-side hedge/one-way, and compatible suite runs, plus one-sided

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added the first HSL slice to Apple MPS optimization for one-sided single-coin EMA Anchor and
+  Trailing Martingale runs, in both long and short directions and compatible suites. The Metal
+  proxy models coin, pside, and unified drawdown signals; tunable RED threshold, EMA span, and
+  cooldown; yellow/orange entry suppression; RED latching; resting-limit panic flattening;
+  flat confirmation; cooldown restart; and terminal no-restart. Exact Rust remains authoritative,
+  including for finite rolling PnL lookbacks. Market panic execution, dual-side and multi-coin
+  HSL, per-coin HSL overrides, and HSL-specific optimizer metrics remain fail closed.
+
 - Added auto-unstuck to Apple MPS EMA Anchor and Trailing Martingale optimization for single-coin
   long-only, short-only, dual-side hedge/one-way, and compatible suite runs, plus one-sided
   multi-coin runs and suites with static per-coin overrides. The Metal proxy models EMA gating,

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -137,8 +137,10 @@ The supported slice is intentionally narrow:
 - one-sided single-coin EMA Anchor and Trailing Martingale runs support HSL with `coin`, `pside`,
   or `unified` signals and resting-limit panic closes. The Metal proxy models tunable RED
   threshold, drawdown-EMA span, and cooldown, plus fixed yellow/orange ratios, orange entry
-  suppression, RED latching, panic flattening, two-sample flat confirmation, cooldown restart, and
-  terminal no-restart policy. Its candidate-local realized-PnL and strategy-equity peaks use an
+  suppression, RED latching, panic flattening, two-sample flat confirmation,
+  positive-cooldown restart, zero-cooldown indefinite halt, cumulative no-restart peak tracking,
+  effective coin-slot scaling, and terminal no-restart policy. Its candidate-local realized-PnL
+  and strategy-equity peaks use an
   all-history envelope when exact Rust is configured with a finite rolling PnL lookback; exact
   validation and drift gates remain authoritative. Market panic closes, dual-side and multi-coin
   HSL, per-coin HSL overrides, and HSL-specific scoring/limit metrics remain fail closed for now.

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -134,7 +134,16 @@ The supported slice is intentionally narrow:
   `risk.position_exposure_enforcer_threshold`; per-coin
   `risk.we_excess_allowance_mode`, trailing-martingale `entry.ema_gate_mode`, disabled sides, and
   other override leaves fail closed
-- HSL disabled. Single-coin EMA Anchor and Trailing Martingale support auto-unstuck for long-only,
+- one-sided single-coin EMA Anchor and Trailing Martingale runs support HSL with `coin`, `pside`,
+  or `unified` signals and resting-limit panic closes. The Metal proxy models tunable RED
+  threshold, drawdown-EMA span, and cooldown, plus fixed yellow/orange ratios, orange entry
+  suppression, RED latching, panic flattening, two-sample flat confirmation, cooldown restart, and
+  terminal no-restart policy. Its candidate-local realized-PnL and strategy-equity peaks use an
+  all-history envelope when exact Rust is configured with a finite rolling PnL lookback; exact
+  validation and drift gates remain authoritative. Market panic closes, dual-side and multi-coin
+  HSL, per-coin HSL overrides, and HSL-specific scoring/limit metrics remain fail closed for now.
+  Compatible single-coin suites may use the supported topology.
+- single-coin EMA Anchor and Trailing Martingale support auto-unstuck for long-only,
   short-only, hedge-mode dual-side, one-way, and compatible suite runs. One-sided multi-coin runs
   and compatible suites also support auto-unstuck, including static per-coin overrides. Metal
   models the enable and EMA-gating toggles, tunable close percentage, EMA distance, loss allowance,

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -140,11 +140,12 @@ The supported slice is intentionally narrow:
   suppression, RED latching, panic flattening, two-sample flat confirmation,
   positive-cooldown restart, zero-cooldown indefinite halt, cumulative no-restart peak tracking,
   effective coin-slot scaling, and terminal no-restart policy. Its candidate-local realized-PnL
-  and strategy-equity peaks use an
-  all-history envelope when exact Rust is configured with a finite rolling PnL lookback; exact
-  validation and drift gates remain authoritative. Market panic closes, dual-side and multi-coin
-  HSL, per-coin HSL overrides, and HSL-specific scoring/limit metrics remain fail closed for now.
-  Compatible single-coin suites may use the supported topology.
+  and strategy-equity peaks require `live.pnls_max_lookback_days: all`, and the selected history
+  must have no internal invalid candles between its first and last valid samples. Thresholds in
+  the float32-unrepresentable interval immediately below `1.0` fail closed. Exact validation and
+  drift gates remain authoritative. Market panic closes, finite rolling PnL lookbacks, dual-side
+  and multi-coin HSL, per-coin HSL overrides, and HSL-specific scoring/limit metrics remain fail
+  closed for now. Compatible single-coin suites may use the supported topology.
 - single-coin EMA Anchor and Trailing Martingale support auto-unstuck for long-only,
   short-only, hedge-mode dual-side, one-way, and compatible suite runs. One-sided multi-coin runs
   and compatible suites also support auto-unstuck, including static per-coin overrides. Metal

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -53,7 +53,7 @@ mod tests {
         assert!(source.contains("h.pending_stop_k + h.cooldown_minutes"));
         assert!(source.contains("fmax(params[po + 25], 1.0f)"));
         assert!(source.contains("const float cmp_eps = 1.0e-12f"));
-        assert_eq!(source.matches("0.9999999403953552f").count(), 2);
+        assert_eq!(source.matches("0.9999999403953552f").count(), 3);
         assert!(source.contains("total_exposure_reducer_qty"));
         assert!(source.contains("unstuck_reducer_variant"));
         assert!(source.contains("unstuck_ema_gating_enabled"));
@@ -134,7 +134,7 @@ mod tests {
         assert!(source.contains("h.pending_stop_k + h.cooldown_minutes"));
         assert!(source.contains("fmax(params[po + 42], 1.0f)"));
         assert!(source.contains("const float cmp_eps = 1.0e-12f"));
-        assert_eq!(source.matches("0.9999999403953552f").count(), 2);
+        assert_eq!(source.matches("0.9999999403953552f").count(), 3);
         assert!(source.contains("unstuck_reducer_qty"));
         assert!(source.contains("unstuck_ema_gating_enabled"));
         assert!(source.contains("unstuck_loss_allowance_pct"));

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -51,6 +51,8 @@ mod tests {
         assert!(source.contains("h.no_restart_peak_strategy_equity"));
         assert!(source.contains("terminal || h.cooldown_minutes <= 0.0f"));
         assert!(source.contains("h.pending_stop_k + h.cooldown_minutes"));
+        assert!(source.contains("fmax(params[po + 25], 1.0f)"));
+        assert!(source.contains("const float cmp_eps = 1.0e-12f"));
         assert!(source.contains("0.9999999403953552f"));
         assert!(source.contains("total_exposure_reducer_qty"));
         assert!(source.contains("unstuck_reducer_variant"));
@@ -130,6 +132,8 @@ mod tests {
         assert!(source.contains("h.no_restart_peak_strategy_equity"));
         assert!(source.contains("terminal || h.cooldown_minutes <= 0.0f"));
         assert!(source.contains("h.pending_stop_k + h.cooldown_minutes"));
+        assert!(source.contains("fmax(params[po + 42], 1.0f)"));
+        assert!(source.contains("const float cmp_eps = 1.0e-12f"));
         assert!(source.contains("0.9999999403953552f"));
         assert!(source.contains("unstuck_reducer_qty"));
         assert!(source.contains("unstuck_ema_gating_enabled"));

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -43,10 +43,13 @@ mod tests {
         assert!(source.contains("kernel void passivbot_ema_anchor"));
         assert!(source.contains("constant int DAILY_COLS = 5"));
         assert!(source.contains("constant int SCALAR_COLS = 18"));
-        assert!(source.contains("constant int SIDE_PARAMS = 33"));
+        assert!(source.contains("constant int SIDE_PARAMS = 34"));
         assert!(source.contains("struct HslState"));
         assert!(source.contains("update_hsl("));
         assert!(source.contains("try_restart_hsl("));
+        assert!(source.contains("h.slot_count"));
+        assert!(source.contains("h.no_restart_peak_strategy_equity"));
+        assert!(source.contains("terminal || h.cooldown_minutes <= 0.0f"));
         assert!(source.contains("total_exposure_reducer_qty"));
         assert!(source.contains("unstuck_reducer_variant"));
         assert!(source.contains("unstuck_ema_gating_enabled"));
@@ -117,10 +120,13 @@ mod tests {
     fn trailing_martingale_mps_source_exposes_expected_kernel_contract() {
         let source = mps_trailing_martingale_source();
         assert!(source.contains("kernel void passivbot_trailing_martingale"));
-        assert!(source.contains("constant int SIDE_PARAMS = 50"));
+        assert!(source.contains("constant int SIDE_PARAMS = 51"));
         assert!(source.contains("struct HslState"));
         assert!(source.contains("update_hsl("));
         assert!(source.contains("try_restart_hsl("));
+        assert!(source.contains("h.slot_count"));
+        assert!(source.contains("h.no_restart_peak_strategy_equity"));
+        assert!(source.contains("terminal || h.cooldown_minutes <= 0.0f"));
         assert!(source.contains("unstuck_reducer_qty"));
         assert!(source.contains("unstuck_ema_gating_enabled"));
         assert!(source.contains("unstuck_loss_allowance_pct"));

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -50,6 +50,8 @@ mod tests {
         assert!(source.contains("h.slot_count"));
         assert!(source.contains("h.no_restart_peak_strategy_equity"));
         assert!(source.contains("terminal || h.cooldown_minutes <= 0.0f"));
+        assert!(source.contains("h.pending_stop_k + h.cooldown_minutes"));
+        assert!(source.contains("0.9999999403953552f"));
         assert!(source.contains("total_exposure_reducer_qty"));
         assert!(source.contains("unstuck_reducer_variant"));
         assert!(source.contains("unstuck_ema_gating_enabled"));
@@ -127,6 +129,8 @@ mod tests {
         assert!(source.contains("h.slot_count"));
         assert!(source.contains("h.no_restart_peak_strategy_equity"));
         assert!(source.contains("terminal || h.cooldown_minutes <= 0.0f"));
+        assert!(source.contains("h.pending_stop_k + h.cooldown_minutes"));
+        assert!(source.contains("0.9999999403953552f"));
         assert!(source.contains("unstuck_reducer_qty"));
         assert!(source.contains("unstuck_ema_gating_enabled"));
         assert!(source.contains("unstuck_loss_allowance_pct"));

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -43,7 +43,10 @@ mod tests {
         assert!(source.contains("kernel void passivbot_ema_anchor"));
         assert!(source.contains("constant int DAILY_COLS = 5"));
         assert!(source.contains("constant int SCALAR_COLS = 18"));
-        assert!(source.contains("constant int SIDE_PARAMS = 23"));
+        assert!(source.contains("constant int SIDE_PARAMS = 33"));
+        assert!(source.contains("struct HslState"));
+        assert!(source.contains("update_hsl("));
+        assert!(source.contains("try_restart_hsl("));
         assert!(source.contains("total_exposure_reducer_qty"));
         assert!(source.contains("unstuck_reducer_variant"));
         assert!(source.contains("unstuck_ema_gating_enabled"));
@@ -61,7 +64,7 @@ mod tests {
         assert!(source.contains("record_realized_net"));
         assert!(source.contains("const float max_realized_loss_pct = settings[14]"));
         assert!(!source.contains("accumulate_min_cost_balance_error"));
-        assert_eq!(source.matches("= fma(").count(), 5);
+        assert_eq!(source.matches("= fma(").count(), 6);
         assert!(!source.contains("alpha0 * close +"));
         assert_eq!(source.matches("const int fo = k * 11").count(), 1);
         assert_eq!(source.matches("const int touch_down_tick").count(), 1);
@@ -114,7 +117,10 @@ mod tests {
     fn trailing_martingale_mps_source_exposes_expected_kernel_contract() {
         let source = mps_trailing_martingale_source();
         assert!(source.contains("kernel void passivbot_trailing_martingale"));
-        assert!(source.contains("constant int SIDE_PARAMS = 40"));
+        assert!(source.contains("constant int SIDE_PARAMS = 50"));
+        assert!(source.contains("struct HslState"));
+        assert!(source.contains("update_hsl("));
+        assert!(source.contains("try_restart_hsl("));
         assert!(source.contains("unstuck_reducer_qty"));
         assert!(source.contains("unstuck_ema_gating_enabled"));
         assert!(source.contains("unstuck_loss_allowance_pct"));
@@ -139,7 +145,7 @@ mod tests {
         assert!(source.contains("? unstuck_qty : (use_twel ? twel_qty : wel_qty)"));
         assert!(source.contains("secondary_close_qty"));
         assert!(source.contains("twel_entry_gate_enabled"));
-        assert_eq!(source.matches("= fma(").count(), 5);
+        assert_eq!(source.matches("= fma(").count(), 6);
         assert!(!source.contains("alpha0 * close +"));
         assert_eq!(source.matches("const int fo = k * 11").count(), 1);
         assert_eq!(source.matches("const int touch_down_tick").count(), 1);

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -53,7 +53,7 @@ mod tests {
         assert!(source.contains("h.pending_stop_k + h.cooldown_minutes"));
         assert!(source.contains("fmax(params[po + 25], 1.0f)"));
         assert!(source.contains("const float cmp_eps = 1.0e-12f"));
-        assert!(source.contains("0.9999999403953552f"));
+        assert_eq!(source.matches("0.9999999403953552f").count(), 2);
         assert!(source.contains("total_exposure_reducer_qty"));
         assert!(source.contains("unstuck_reducer_variant"));
         assert!(source.contains("unstuck_ema_gating_enabled"));
@@ -134,7 +134,7 @@ mod tests {
         assert!(source.contains("h.pending_stop_k + h.cooldown_minutes"));
         assert!(source.contains("fmax(params[po + 42], 1.0f)"));
         assert!(source.contains("const float cmp_eps = 1.0e-12f"));
-        assert!(source.contains("0.9999999403953552f"));
+        assert_eq!(source.matches("0.9999999403953552f").count(), 2);
         assert!(source.contains("unstuck_reducer_qty"));
         assert!(source.contains("unstuck_ema_gating_enabled"));
         assert!(source.contains("unstuck_loss_allowance_pct"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -4,7 +4,7 @@ using namespace metal;
 constant int DAILY_COLS = 5;
 constant int SCALAR_COLS = 18;
 constant int GAP_BINS = 128;
-constant int SIDE_PARAMS = 33;
+constant int SIDE_PARAMS = 34;
 
 inline float round_step(float value, float step) {
     return floor(value / step + 0.5f) * step;
@@ -134,9 +134,11 @@ struct HslState {
     float orange_ratio;
     bool orange_graceful_stop;
     bool signal_coin;
+    float slot_count;
     bool initialized;
     float drawdown_ema;
     float peak_strategy_pnl;
+    float no_restart_peak_strategy_equity;
     float coin_realized_baseline;
     float coin_realized_peak;
     int tier;
@@ -148,6 +150,8 @@ struct HslState {
     int flat_confirmations;
     float pending_drawdown_raw;
     float pending_drawdown_ema;
+    float pending_strategy_equity;
+    float pending_peak_strategy_equity;
 };
 
 inline HslState load_hsl(constant float* params, int po) {
@@ -162,9 +166,11 @@ inline HslState load_hsl(constant float* params, int po) {
     h.orange_ratio = params[po + 30];
     h.orange_graceful_stop = params[po + 31] > 0.5f;
     h.signal_coin = params[po + 32] > 0.5f;
+    h.slot_count = fmax(round(params[po + 33]), 1.0f);
     h.initialized = false;
     h.drawdown_ema = 0.0f;
     h.peak_strategy_pnl = -INFINITY;
+    h.no_restart_peak_strategy_equity = 0.0f;
     h.coin_realized_baseline = 0.0f;
     h.coin_realized_peak = 0.0f;
     h.tier = 0;
@@ -176,6 +182,8 @@ inline HslState load_hsl(constant float* params, int po) {
     h.flat_confirmations = 0;
     h.pending_drawdown_raw = 0.0f;
     h.pending_drawdown_ema = 0.0f;
+    h.pending_strategy_equity = 0.0f;
+    h.pending_peak_strategy_equity = 0.0f;
     return h;
 }
 
@@ -200,16 +208,20 @@ inline void update_hsl(
     if (!h.enabled || h.halted || !(balance > 0.0f)) return;
     float drawdown_raw;
     float strategy_pnl = realized_pnl + unrealized_pnl;
+    float strategy_equity;
+    float peak_strategy_equity;
     if (h.signal_coin) {
         float coin_realized = realized_pnl - h.coin_realized_baseline;
         h.coin_realized_peak = fmax(h.coin_realized_peak, coin_realized);
-        drawdown_raw = fmax(
+        drawdown_raw = fmin(fmax(
             h.coin_realized_peak - (coin_realized + unrealized_pnl), 0.0f
-        ) / balance;
+        ) / (balance / h.slot_count), 1.0f);
+        strategy_equity = fmax(1.0f - drawdown_raw, 1.0e-12f);
+        peak_strategy_equity = 1.0f;
     } else {
         h.peak_strategy_pnl = fmax(h.peak_strategy_pnl, strategy_pnl);
-        float strategy_equity = starting_balance + strategy_pnl;
-        float peak_strategy_equity = fmax(
+        strategy_equity = starting_balance + strategy_pnl;
+        peak_strategy_equity = fmax(
             starting_balance + h.peak_strategy_pnl, strategy_equity
         );
         if (!(strategy_equity > 0.0f && peak_strategy_equity > 0.0f)) return;
@@ -238,6 +250,8 @@ inline void update_hsl(
             if (h.flat_confirmations == 1) {
                 h.pending_drawdown_raw = drawdown_raw;
                 h.pending_drawdown_ema = h.drawdown_ema;
+                h.pending_strategy_equity = strategy_equity;
+                h.pending_peak_strategy_equity = peak_strategy_equity;
             }
             if (h.flat_confirmations >= 2) {
                 h.halted = true;
@@ -245,13 +259,27 @@ inline void update_hsl(
                     h.coin_realized_baseline = realized_pnl;
                     h.coin_realized_peak = 0.0f;
                 }
+                h.no_restart_peak_strategy_equity = fmax(
+                    h.no_restart_peak_strategy_equity,
+                    fmax(
+                        h.pending_peak_strategy_equity,
+                        h.pending_strategy_equity
+                    )
+                );
+                float no_restart_drawdown_raw = h.signal_coin
+                    ? h.pending_drawdown_raw
+                    : fmax(
+                        1.0f - h.pending_strategy_equity
+                            / fmax(h.no_restart_peak_strategy_equity, 1.0e-12f),
+                        0.0f
+                    );
                 bool terminal = h.restart_policy == 2
                     || (h.restart_policy == 1
-                        && fmax(h.pending_drawdown_raw, h.pending_drawdown_ema)
+                        && fmax(no_restart_drawdown_raw, h.pending_drawdown_ema)
                             >= h.no_restart_threshold);
                 h.no_restart_latched = terminal;
-                h.cooldown_until_k = terminal
-                    ? -1.0f : kf + round(h.cooldown_minutes);
+                h.cooldown_until_k = terminal || h.cooldown_minutes <= 0.0f
+                    ? -1.0f : kf + h.cooldown_minutes;
             }
         }
     } else {

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -227,7 +227,10 @@ inline void update_hsl(
             starting_balance + h.peak_strategy_pnl, strategy_equity
         );
         if (!(strategy_equity > 0.0f && peak_strategy_equity > 0.0f)) return;
-        drawdown_raw = fmax(1.0f - strategy_equity / peak_strategy_equity, 0.0f);
+        drawdown_raw = fmin(
+            fmax(1.0f - strategy_equity / peak_strategy_equity, 0.0f),
+            0.9999999403953552f
+        );
     }
     if (!h.initialized) {
         h.initialized = true;

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -275,10 +275,13 @@ inline void update_hsl(
                 );
                 float no_restart_drawdown_raw = h.signal_coin
                     ? h.pending_drawdown_raw
-                    : fmax(
-                        1.0f - h.pending_strategy_equity
-                            / fmax(h.no_restart_peak_strategy_equity, 1.0e-12f),
-                        0.0f
+                    : fmin(
+                        fmax(
+                            1.0f - h.pending_strategy_equity
+                                / fmax(h.no_restart_peak_strategy_equity, 1.0e-12f),
+                            0.0f
+                        ),
+                        0.9999999403953552f
                     );
                 bool terminal = h.restart_policy == 2
                     || (h.restart_policy == 1

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -159,7 +159,7 @@ inline HslState load_hsl(constant float* params, int po) {
     HslState h;
     h.enabled = params[po + 23] > 0.5f;
     h.red_threshold = params[po + 24];
-    h.alpha = clamp(2.0f / (params[po + 25] + 1.0f), 0.0f, 1.0f);
+    h.alpha = clamp(2.0f / (fmax(params[po + 25], 1.0f) + 1.0f), 0.0f, 1.0f);
     h.cooldown_minutes = fmax(params[po + 26], 0.0f);
     h.no_restart_threshold = fmax(params[po + 27], h.red_threshold);
     h.restart_policy = int(round(params[po + 28]));
@@ -237,11 +237,12 @@ inline void update_hsl(
     }
     h.drawdown_ema = fma(h.alpha, drawdown_raw - h.drawdown_ema, h.drawdown_ema);
     float score = fmin(drawdown_raw, fmax(h.drawdown_ema, 0.0f));
-    h.red_active_now = score + 1.0e-7f >= h.red_threshold;
+    const float cmp_eps = 1.0e-12f;
+    h.red_active_now = score + cmp_eps >= h.red_threshold;
     int next_tier = h.red_latched ? 3
         : h.red_active_now ? 3
-        : score + 1.0e-7f >= h.orange_ratio * h.red_threshold ? 2
-        : score + 1.0e-7f >= h.yellow_ratio * h.red_threshold ? 1 : 0;
+        : score + cmp_eps >= h.orange_ratio * h.red_threshold ? 2
+        : score + cmp_eps >= h.yellow_ratio * h.red_threshold ? 1 : 0;
     if (next_tier == 3) h.red_latched = true;
     h.tier = h.red_latched ? 3 : next_tier;
     if (h.tier == 3) {

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -152,6 +152,7 @@ struct HslState {
     float pending_drawdown_ema;
     float pending_strategy_equity;
     float pending_peak_strategy_equity;
+    float pending_stop_k;
 };
 
 inline HslState load_hsl(constant float* params, int po) {
@@ -184,6 +185,7 @@ inline HslState load_hsl(constant float* params, int po) {
     h.pending_drawdown_ema = 0.0f;
     h.pending_strategy_equity = 0.0f;
     h.pending_peak_strategy_equity = 0.0f;
+    h.pending_stop_k = -1.0f;
     return h;
 }
 
@@ -215,7 +217,7 @@ inline void update_hsl(
         h.coin_realized_peak = fmax(h.coin_realized_peak, coin_realized);
         drawdown_raw = fmin(fmax(
             h.coin_realized_peak - (coin_realized + unrealized_pnl), 0.0f
-        ) / (balance / h.slot_count), 1.0f);
+        ) / (balance / h.slot_count), 0.9999999403953552f);
         strategy_equity = fmax(1.0f - drawdown_raw, 1.0e-12f);
         peak_strategy_equity = 1.0f;
     } else {
@@ -252,6 +254,7 @@ inline void update_hsl(
                 h.pending_drawdown_ema = h.drawdown_ema;
                 h.pending_strategy_equity = strategy_equity;
                 h.pending_peak_strategy_equity = peak_strategy_equity;
+                h.pending_stop_k = kf;
             }
             if (h.flat_confirmations >= 2) {
                 h.halted = true;
@@ -279,7 +282,7 @@ inline void update_hsl(
                             >= h.no_restart_threshold);
                 h.no_restart_latched = terminal;
                 h.cooldown_until_k = terminal || h.cooldown_minutes <= 0.0f
-                    ? -1.0f : kf + h.cooldown_minutes;
+                    ? -1.0f : h.pending_stop_k + h.cooldown_minutes;
             }
         }
     } else {

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -4,7 +4,7 @@ using namespace metal;
 constant int DAILY_COLS = 5;
 constant int SCALAR_COLS = 18;
 constant int GAP_BINS = 128;
-constant int SIDE_PARAMS = 23;
+constant int SIDE_PARAMS = 33;
 
 inline float round_step(float value, float step) {
     return floor(value / step + 0.5f) * step;
@@ -122,6 +122,156 @@ struct ReducerVariant {
     int secondary_ticks;
     float secondary_qty;
 };
+
+struct HslState {
+    bool enabled;
+    float red_threshold;
+    float alpha;
+    float cooldown_minutes;
+    float no_restart_threshold;
+    int restart_policy;
+    float yellow_ratio;
+    float orange_ratio;
+    bool orange_graceful_stop;
+    bool signal_coin;
+    bool initialized;
+    float drawdown_ema;
+    float peak_strategy_pnl;
+    float coin_realized_baseline;
+    float coin_realized_peak;
+    int tier;
+    bool red_latched;
+    bool red_active_now;
+    bool halted;
+    bool no_restart_latched;
+    float cooldown_until_k;
+    int flat_confirmations;
+    float pending_drawdown_raw;
+    float pending_drawdown_ema;
+};
+
+inline HslState load_hsl(constant float* params, int po) {
+    HslState h;
+    h.enabled = params[po + 23] > 0.5f;
+    h.red_threshold = params[po + 24];
+    h.alpha = clamp(2.0f / (params[po + 25] + 1.0f), 0.0f, 1.0f);
+    h.cooldown_minutes = fmax(params[po + 26], 0.0f);
+    h.no_restart_threshold = fmax(params[po + 27], h.red_threshold);
+    h.restart_policy = int(round(params[po + 28]));
+    h.yellow_ratio = params[po + 29];
+    h.orange_ratio = params[po + 30];
+    h.orange_graceful_stop = params[po + 31] > 0.5f;
+    h.signal_coin = params[po + 32] > 0.5f;
+    h.initialized = false;
+    h.drawdown_ema = 0.0f;
+    h.peak_strategy_pnl = -INFINITY;
+    h.coin_realized_baseline = 0.0f;
+    h.coin_realized_peak = 0.0f;
+    h.tier = 0;
+    h.red_latched = false;
+    h.red_active_now = false;
+    h.halted = false;
+    h.no_restart_latched = false;
+    h.cooldown_until_k = -1.0f;
+    h.flat_confirmations = 0;
+    h.pending_drawdown_raw = 0.0f;
+    h.pending_drawdown_ema = 0.0f;
+    return h;
+}
+
+inline int hsl_mode(thread HslState& h, bool has_position) {
+    if (!h.enabled) return 0;
+    if (h.halted) return has_position ? 3 : 1;
+    if (h.tier == 3) return h.red_active_now ? 3 : 2;
+    if (h.tier == 2) return h.orange_graceful_stop ? 1 : 2;
+    return 0;
+}
+
+inline void update_hsl(
+    thread HslState& h,
+    float balance,
+    float starting_balance,
+    float realized_pnl,
+    float unrealized_pnl,
+    bool has_position,
+    bool has_blocking_orders,
+    float kf
+) {
+    if (!h.enabled || h.halted || !(balance > 0.0f)) return;
+    float drawdown_raw;
+    float strategy_pnl = realized_pnl + unrealized_pnl;
+    if (h.signal_coin) {
+        float coin_realized = realized_pnl - h.coin_realized_baseline;
+        h.coin_realized_peak = fmax(h.coin_realized_peak, coin_realized);
+        drawdown_raw = fmax(
+            h.coin_realized_peak - (coin_realized + unrealized_pnl), 0.0f
+        ) / balance;
+    } else {
+        h.peak_strategy_pnl = fmax(h.peak_strategy_pnl, strategy_pnl);
+        float strategy_equity = starting_balance + strategy_pnl;
+        float peak_strategy_equity = fmax(
+            starting_balance + h.peak_strategy_pnl, strategy_equity
+        );
+        if (!(strategy_equity > 0.0f && peak_strategy_equity > 0.0f)) return;
+        drawdown_raw = fmax(1.0f - strategy_equity / peak_strategy_equity, 0.0f);
+    }
+    if (!h.initialized) {
+        h.initialized = true;
+        h.drawdown_ema = 0.0f;
+        h.tier = 0;
+        return;
+    }
+    h.drawdown_ema = fma(h.alpha, drawdown_raw - h.drawdown_ema, h.drawdown_ema);
+    float score = fmin(drawdown_raw, fmax(h.drawdown_ema, 0.0f));
+    h.red_active_now = score + 1.0e-7f >= h.red_threshold;
+    int next_tier = h.red_latched ? 3
+        : h.red_active_now ? 3
+        : score + 1.0e-7f >= h.orange_ratio * h.red_threshold ? 2
+        : score + 1.0e-7f >= h.yellow_ratio * h.red_threshold ? 1 : 0;
+    if (next_tier == 3) h.red_latched = true;
+    h.tier = h.red_latched ? 3 : next_tier;
+    if (h.tier == 3) {
+        if (has_position || has_blocking_orders) {
+            h.flat_confirmations = 0;
+        } else {
+            h.flat_confirmations += 1;
+            if (h.flat_confirmations == 1) {
+                h.pending_drawdown_raw = drawdown_raw;
+                h.pending_drawdown_ema = h.drawdown_ema;
+            }
+            if (h.flat_confirmations >= 2) {
+                h.halted = true;
+                if (h.signal_coin) {
+                    h.coin_realized_baseline = realized_pnl;
+                    h.coin_realized_peak = 0.0f;
+                }
+                bool terminal = h.restart_policy == 2
+                    || (h.restart_policy == 1
+                        && fmax(h.pending_drawdown_raw, h.pending_drawdown_ema)
+                            >= h.no_restart_threshold);
+                h.no_restart_latched = terminal;
+                h.cooldown_until_k = terminal
+                    ? -1.0f : kf + round(h.cooldown_minutes);
+            }
+        }
+    } else {
+        h.flat_confirmations = 0;
+    }
+}
+
+inline void try_restart_hsl(thread HslState& h, float kf) {
+    if (!h.enabled || !h.halted || h.no_restart_latched
+        || h.cooldown_until_k < 0.0f || kf < h.cooldown_until_k) return;
+    h.initialized = false;
+    h.drawdown_ema = 0.0f;
+    h.peak_strategy_pnl = -INFINITY;
+    h.tier = 0;
+    h.red_latched = false;
+    h.red_active_now = false;
+    h.halted = false;
+    h.cooldown_until_k = -1.0f;
+    h.flat_confirmations = 0;
+}
 
 inline EmaSide load_side(constant float* params, int po, float seed_close) {
     EmaSide side;
@@ -769,6 +919,8 @@ inline void passivbot_single_coin_impl(
     const float seed_close = bars[seed_k * 5 + 2];
     EmaSide long_side = load_side(params, po, seed_close);
     EmaSide short_side = load_side(params, po + SIDE_PARAMS, seed_close);
+    HslState long_hsl = load_hsl(params, po);
+    HslState short_hsl = load_hsl(params, po + SIDE_PARAMS);
 
     float balance = starting_balance;
     float realized_pnl_cumsum_last = 0.0f;
@@ -1005,6 +1157,8 @@ inline void passivbot_single_coin_impl(
 
         bool gen = can_gen && alive;
         eq_started = eq_started || gen;
+        int long_hsl_mode = hsl_mode(long_hsl, long_side.psize > 0.0f);
+        int short_hsl_mode = hsl_mode(short_hsl, short_side.psize > 0.0f);
         if (gen) {
             // When both sides are flat, an exact Rust path that remains alive has
             // balance above liq_floor. If either side is open, equity cannot bound
@@ -1020,8 +1174,8 @@ inline void passivbot_single_coin_impl(
                 filter_by_min_effective_cost, guaranteed_balance_lower,
                 short_side.allowed_wel, short_side.base_qty_pct, max_effective_min_cost
             );
-            bool block_long_initial = !long_min_cost_eligible;
-            bool block_short_initial = !short_min_cost_eligible;
+            bool block_long_initial = !long_min_cost_eligible || long_hsl_mode != 0;
+            bool block_short_initial = !short_min_cost_eligible || short_hsl_mode != 0;
             if (long_enabled && short_enabled && !hedge_mode) {
                 if (long_side.psize > 0.0f) {
                     block_short_initial = true;
@@ -1207,6 +1361,25 @@ inline void passivbot_single_coin_impl(
                     );
                 }
             }
+
+            if (long_enabled && long_hsl_mode >= 2) {
+                long_side.entry_qty = 0.0f;
+            }
+            if (short_enabled && short_hsl_mode >= 2) {
+                short_side.entry_qty = 0.0f;
+            }
+            if (long_enabled && long_hsl_mode == 3) {
+                long_side.close_ticks = max(touch_down_tick - 1, 1);
+                long_side.close_qty = long_side.psize;
+                long_side.secondary_close_qty = 0.0f;
+                long_side.close_is_protective_reducer = false;
+            }
+            if (short_enabled && short_hsl_mode == 3) {
+                short_side.close_ticks = max(touch_up_tick + 1, 1);
+                short_side.close_qty = short_side.psize;
+                short_side.secondary_close_qty = 0.0f;
+                short_side.close_is_protective_reducer = false;
+            }
         }
 
         float long_unreal = long_side.psize > 0.0f
@@ -1214,6 +1387,30 @@ inline void passivbot_single_coin_impl(
         float short_unreal = short_side.psize > 0.0f
             ? short_side.psize * c_mult * (short_side.pprice - close) : 0.0f;
         float equity = balance + long_unreal + short_unreal;
+        if (gen && valid && alive && balance > 0.0f && equity > liq_floor) {
+            bool long_blocking_orders = long_hsl_mode != 3 && (
+                long_side.entry_qty > 0.0f || long_side.close_qty > 0.0f
+                    || long_side.secondary_close_qty > 0.0f
+            );
+            bool short_blocking_orders = short_hsl_mode != 3 && (
+                short_side.entry_qty > 0.0f || short_side.close_qty > 0.0f
+                    || short_side.secondary_close_qty > 0.0f
+            );
+            update_hsl(
+                long_hsl, balance, starting_balance,
+                realized_pnl_cumsum_last,
+                long_unreal, long_side.psize > 0.0f,
+                long_blocking_orders, kf
+            );
+            update_hsl(
+                short_hsl, balance, starting_balance,
+                realized_pnl_cumsum_last,
+                short_unreal, short_side.psize > 0.0f,
+                short_blocking_orders, kf
+            );
+            try_restart_hsl(long_hsl, kf);
+            try_restart_hsl(short_hsl, kf);
+        }
         bool active = eq_started && alive && valid;
         if (active) {
             if (first_eq_k < 0.0f) first_eq_k = kf;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -213,7 +213,7 @@ inline HslState load_hsl(constant float* params, int po) {
     HslState h;
     h.enabled = params[po + 40] > 0.5f;
     h.red_threshold = params[po + 41];
-    h.alpha = clamp(2.0f / (params[po + 42] + 1.0f), 0.0f, 1.0f);
+    h.alpha = clamp(2.0f / (fmax(params[po + 42], 1.0f) + 1.0f), 0.0f, 1.0f);
     h.cooldown_minutes = fmax(params[po + 43], 0.0f);
     h.no_restart_threshold = fmax(params[po + 44], h.red_threshold);
     h.restart_policy = int(round(params[po + 45]));
@@ -291,11 +291,12 @@ inline void update_hsl(
     }
     h.drawdown_ema = fma(h.alpha, drawdown_raw - h.drawdown_ema, h.drawdown_ema);
     float score = fmin(drawdown_raw, fmax(h.drawdown_ema, 0.0f));
-    h.red_active_now = score + 1.0e-7f >= h.red_threshold;
+    const float cmp_eps = 1.0e-12f;
+    h.red_active_now = score + cmp_eps >= h.red_threshold;
     int next_tier = h.red_latched ? 3
         : h.red_active_now ? 3
-        : score + 1.0e-7f >= h.orange_ratio * h.red_threshold ? 2
-        : score + 1.0e-7f >= h.yellow_ratio * h.red_threshold ? 1 : 0;
+        : score + cmp_eps >= h.orange_ratio * h.red_threshold ? 2
+        : score + cmp_eps >= h.yellow_ratio * h.red_threshold ? 1 : 0;
     if (next_tier == 3) h.red_latched = true;
     h.tier = h.red_latched ? 3 : next_tier;
     if (h.tier == 3) {

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -329,10 +329,13 @@ inline void update_hsl(
                 );
                 float no_restart_drawdown_raw = h.signal_coin
                     ? h.pending_drawdown_raw
-                    : fmax(
-                        1.0f - h.pending_strategy_equity
-                            / fmax(h.no_restart_peak_strategy_equity, 1.0e-12f),
-                        0.0f
+                    : fmin(
+                        fmax(
+                            1.0f - h.pending_strategy_equity
+                                / fmax(h.no_restart_peak_strategy_equity, 1.0e-12f),
+                            0.0f
+                        ),
+                        0.9999999403953552f
                     );
                 bool terminal = h.restart_policy == 2
                     || (h.restart_policy == 1

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -281,7 +281,10 @@ inline void update_hsl(
             starting_balance + h.peak_strategy_pnl, strategy_equity
         );
         if (!(strategy_equity > 0.0f && peak_strategy_equity > 0.0f)) return;
-        drawdown_raw = fmax(1.0f - strategy_equity / peak_strategy_equity, 0.0f);
+        drawdown_raw = fmin(
+            fmax(1.0f - strategy_equity / peak_strategy_equity, 0.0f),
+            0.9999999403953552f
+        );
     }
     if (!h.initialized) {
         h.initialized = true;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -206,6 +206,7 @@ struct HslState {
     float pending_drawdown_ema;
     float pending_strategy_equity;
     float pending_peak_strategy_equity;
+    float pending_stop_k;
 };
 
 inline HslState load_hsl(constant float* params, int po) {
@@ -238,6 +239,7 @@ inline HslState load_hsl(constant float* params, int po) {
     h.pending_drawdown_ema = 0.0f;
     h.pending_strategy_equity = 0.0f;
     h.pending_peak_strategy_equity = 0.0f;
+    h.pending_stop_k = -1.0f;
     return h;
 }
 
@@ -269,7 +271,7 @@ inline void update_hsl(
         h.coin_realized_peak = fmax(h.coin_realized_peak, coin_realized);
         drawdown_raw = fmin(fmax(
             h.coin_realized_peak - (coin_realized + unrealized_pnl), 0.0f
-        ) / (balance / h.slot_count), 1.0f);
+        ) / (balance / h.slot_count), 0.9999999403953552f);
         strategy_equity = fmax(1.0f - drawdown_raw, 1.0e-12f);
         peak_strategy_equity = 1.0f;
     } else {
@@ -306,6 +308,7 @@ inline void update_hsl(
                 h.pending_drawdown_ema = h.drawdown_ema;
                 h.pending_strategy_equity = strategy_equity;
                 h.pending_peak_strategy_equity = peak_strategy_equity;
+                h.pending_stop_k = kf;
             }
             if (h.flat_confirmations >= 2) {
                 h.halted = true;
@@ -333,7 +336,7 @@ inline void update_hsl(
                             >= h.no_restart_threshold);
                 h.no_restart_latched = terminal;
                 h.cooldown_until_k = terminal || h.cooldown_minutes <= 0.0f
-                    ? -1.0f : kf + h.cooldown_minutes;
+                    ? -1.0f : h.pending_stop_k + h.cooldown_minutes;
             }
         }
     } else {

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -4,7 +4,7 @@ using namespace metal;
 constant int DAILY_COLS = 5;
 constant int SCALAR_COLS = 18;
 constant int GAP_BINS = 128;
-constant int SIDE_PARAMS = 50;
+constant int SIDE_PARAMS = 51;
 
 inline float round_step(float value, float step) {
     return floor(value / step + 0.5f) * step;
@@ -188,9 +188,11 @@ struct HslState {
     float orange_ratio;
     bool orange_graceful_stop;
     bool signal_coin;
+    float slot_count;
     bool initialized;
     float drawdown_ema;
     float peak_strategy_pnl;
+    float no_restart_peak_strategy_equity;
     float coin_realized_baseline;
     float coin_realized_peak;
     int tier;
@@ -202,6 +204,8 @@ struct HslState {
     int flat_confirmations;
     float pending_drawdown_raw;
     float pending_drawdown_ema;
+    float pending_strategy_equity;
+    float pending_peak_strategy_equity;
 };
 
 inline HslState load_hsl(constant float* params, int po) {
@@ -216,9 +220,11 @@ inline HslState load_hsl(constant float* params, int po) {
     h.orange_ratio = params[po + 47];
     h.orange_graceful_stop = params[po + 48] > 0.5f;
     h.signal_coin = params[po + 49] > 0.5f;
+    h.slot_count = fmax(round(params[po + 50]), 1.0f);
     h.initialized = false;
     h.drawdown_ema = 0.0f;
     h.peak_strategy_pnl = -INFINITY;
+    h.no_restart_peak_strategy_equity = 0.0f;
     h.coin_realized_baseline = 0.0f;
     h.coin_realized_peak = 0.0f;
     h.tier = 0;
@@ -230,6 +236,8 @@ inline HslState load_hsl(constant float* params, int po) {
     h.flat_confirmations = 0;
     h.pending_drawdown_raw = 0.0f;
     h.pending_drawdown_ema = 0.0f;
+    h.pending_strategy_equity = 0.0f;
+    h.pending_peak_strategy_equity = 0.0f;
     return h;
 }
 
@@ -254,16 +262,20 @@ inline void update_hsl(
     if (!h.enabled || h.halted || !(balance > 0.0f)) return;
     float drawdown_raw;
     float strategy_pnl = realized_pnl + unrealized_pnl;
+    float strategy_equity;
+    float peak_strategy_equity;
     if (h.signal_coin) {
         float coin_realized = realized_pnl - h.coin_realized_baseline;
         h.coin_realized_peak = fmax(h.coin_realized_peak, coin_realized);
-        drawdown_raw = fmax(
+        drawdown_raw = fmin(fmax(
             h.coin_realized_peak - (coin_realized + unrealized_pnl), 0.0f
-        ) / balance;
+        ) / (balance / h.slot_count), 1.0f);
+        strategy_equity = fmax(1.0f - drawdown_raw, 1.0e-12f);
+        peak_strategy_equity = 1.0f;
     } else {
         h.peak_strategy_pnl = fmax(h.peak_strategy_pnl, strategy_pnl);
-        float strategy_equity = starting_balance + strategy_pnl;
-        float peak_strategy_equity = fmax(
+        strategy_equity = starting_balance + strategy_pnl;
+        peak_strategy_equity = fmax(
             starting_balance + h.peak_strategy_pnl, strategy_equity
         );
         if (!(strategy_equity > 0.0f && peak_strategy_equity > 0.0f)) return;
@@ -292,6 +304,8 @@ inline void update_hsl(
             if (h.flat_confirmations == 1) {
                 h.pending_drawdown_raw = drawdown_raw;
                 h.pending_drawdown_ema = h.drawdown_ema;
+                h.pending_strategy_equity = strategy_equity;
+                h.pending_peak_strategy_equity = peak_strategy_equity;
             }
             if (h.flat_confirmations >= 2) {
                 h.halted = true;
@@ -299,13 +313,27 @@ inline void update_hsl(
                     h.coin_realized_baseline = realized_pnl;
                     h.coin_realized_peak = 0.0f;
                 }
+                h.no_restart_peak_strategy_equity = fmax(
+                    h.no_restart_peak_strategy_equity,
+                    fmax(
+                        h.pending_peak_strategy_equity,
+                        h.pending_strategy_equity
+                    )
+                );
+                float no_restart_drawdown_raw = h.signal_coin
+                    ? h.pending_drawdown_raw
+                    : fmax(
+                        1.0f - h.pending_strategy_equity
+                            / fmax(h.no_restart_peak_strategy_equity, 1.0e-12f),
+                        0.0f
+                    );
                 bool terminal = h.restart_policy == 2
                     || (h.restart_policy == 1
-                        && fmax(h.pending_drawdown_raw, h.pending_drawdown_ema)
+                        && fmax(no_restart_drawdown_raw, h.pending_drawdown_ema)
                             >= h.no_restart_threshold);
                 h.no_restart_latched = terminal;
-                h.cooldown_until_k = terminal
-                    ? -1.0f : kf + round(h.cooldown_minutes);
+                h.cooldown_until_k = terminal || h.cooldown_minutes <= 0.0f
+                    ? -1.0f : kf + h.cooldown_minutes;
             }
         }
     } else {

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -4,7 +4,7 @@ using namespace metal;
 constant int DAILY_COLS = 5;
 constant int SCALAR_COLS = 18;
 constant int GAP_BINS = 128;
-constant int SIDE_PARAMS = 40;
+constant int SIDE_PARAMS = 50;
 
 inline float round_step(float value, float step) {
     return floor(value / step + 0.5f) * step;
@@ -176,6 +176,156 @@ struct CloseGroup {
     float price;
     float qty;
 };
+
+struct HslState {
+    bool enabled;
+    float red_threshold;
+    float alpha;
+    float cooldown_minutes;
+    float no_restart_threshold;
+    int restart_policy;
+    float yellow_ratio;
+    float orange_ratio;
+    bool orange_graceful_stop;
+    bool signal_coin;
+    bool initialized;
+    float drawdown_ema;
+    float peak_strategy_pnl;
+    float coin_realized_baseline;
+    float coin_realized_peak;
+    int tier;
+    bool red_latched;
+    bool red_active_now;
+    bool halted;
+    bool no_restart_latched;
+    float cooldown_until_k;
+    int flat_confirmations;
+    float pending_drawdown_raw;
+    float pending_drawdown_ema;
+};
+
+inline HslState load_hsl(constant float* params, int po) {
+    HslState h;
+    h.enabled = params[po + 40] > 0.5f;
+    h.red_threshold = params[po + 41];
+    h.alpha = clamp(2.0f / (params[po + 42] + 1.0f), 0.0f, 1.0f);
+    h.cooldown_minutes = fmax(params[po + 43], 0.0f);
+    h.no_restart_threshold = fmax(params[po + 44], h.red_threshold);
+    h.restart_policy = int(round(params[po + 45]));
+    h.yellow_ratio = params[po + 46];
+    h.orange_ratio = params[po + 47];
+    h.orange_graceful_stop = params[po + 48] > 0.5f;
+    h.signal_coin = params[po + 49] > 0.5f;
+    h.initialized = false;
+    h.drawdown_ema = 0.0f;
+    h.peak_strategy_pnl = -INFINITY;
+    h.coin_realized_baseline = 0.0f;
+    h.coin_realized_peak = 0.0f;
+    h.tier = 0;
+    h.red_latched = false;
+    h.red_active_now = false;
+    h.halted = false;
+    h.no_restart_latched = false;
+    h.cooldown_until_k = -1.0f;
+    h.flat_confirmations = 0;
+    h.pending_drawdown_raw = 0.0f;
+    h.pending_drawdown_ema = 0.0f;
+    return h;
+}
+
+inline int hsl_mode(thread HslState& h, bool has_position) {
+    if (!h.enabled) return 0;
+    if (h.halted) return has_position ? 3 : 1;
+    if (h.tier == 3) return h.red_active_now ? 3 : 2;
+    if (h.tier == 2) return h.orange_graceful_stop ? 1 : 2;
+    return 0;
+}
+
+inline void update_hsl(
+    thread HslState& h,
+    float balance,
+    float starting_balance,
+    float realized_pnl,
+    float unrealized_pnl,
+    bool has_position,
+    bool has_blocking_orders,
+    float kf
+) {
+    if (!h.enabled || h.halted || !(balance > 0.0f)) return;
+    float drawdown_raw;
+    float strategy_pnl = realized_pnl + unrealized_pnl;
+    if (h.signal_coin) {
+        float coin_realized = realized_pnl - h.coin_realized_baseline;
+        h.coin_realized_peak = fmax(h.coin_realized_peak, coin_realized);
+        drawdown_raw = fmax(
+            h.coin_realized_peak - (coin_realized + unrealized_pnl), 0.0f
+        ) / balance;
+    } else {
+        h.peak_strategy_pnl = fmax(h.peak_strategy_pnl, strategy_pnl);
+        float strategy_equity = starting_balance + strategy_pnl;
+        float peak_strategy_equity = fmax(
+            starting_balance + h.peak_strategy_pnl, strategy_equity
+        );
+        if (!(strategy_equity > 0.0f && peak_strategy_equity > 0.0f)) return;
+        drawdown_raw = fmax(1.0f - strategy_equity / peak_strategy_equity, 0.0f);
+    }
+    if (!h.initialized) {
+        h.initialized = true;
+        h.drawdown_ema = 0.0f;
+        h.tier = 0;
+        return;
+    }
+    h.drawdown_ema = fma(h.alpha, drawdown_raw - h.drawdown_ema, h.drawdown_ema);
+    float score = fmin(drawdown_raw, fmax(h.drawdown_ema, 0.0f));
+    h.red_active_now = score + 1.0e-7f >= h.red_threshold;
+    int next_tier = h.red_latched ? 3
+        : h.red_active_now ? 3
+        : score + 1.0e-7f >= h.orange_ratio * h.red_threshold ? 2
+        : score + 1.0e-7f >= h.yellow_ratio * h.red_threshold ? 1 : 0;
+    if (next_tier == 3) h.red_latched = true;
+    h.tier = h.red_latched ? 3 : next_tier;
+    if (h.tier == 3) {
+        if (has_position || has_blocking_orders) {
+            h.flat_confirmations = 0;
+        } else {
+            h.flat_confirmations += 1;
+            if (h.flat_confirmations == 1) {
+                h.pending_drawdown_raw = drawdown_raw;
+                h.pending_drawdown_ema = h.drawdown_ema;
+            }
+            if (h.flat_confirmations >= 2) {
+                h.halted = true;
+                if (h.signal_coin) {
+                    h.coin_realized_baseline = realized_pnl;
+                    h.coin_realized_peak = 0.0f;
+                }
+                bool terminal = h.restart_policy == 2
+                    || (h.restart_policy == 1
+                        && fmax(h.pending_drawdown_raw, h.pending_drawdown_ema)
+                            >= h.no_restart_threshold);
+                h.no_restart_latched = terminal;
+                h.cooldown_until_k = terminal
+                    ? -1.0f : kf + round(h.cooldown_minutes);
+            }
+        }
+    } else {
+        h.flat_confirmations = 0;
+    }
+}
+
+inline void try_restart_hsl(thread HslState& h, float kf) {
+    if (!h.enabled || !h.halted || h.no_restart_latched
+        || h.cooldown_until_k < 0.0f || kf < h.cooldown_until_k) return;
+    h.initialized = false;
+    h.drawdown_ema = 0.0f;
+    h.peak_strategy_pnl = -INFINITY;
+    h.tier = 0;
+    h.red_latched = false;
+    h.red_active_now = false;
+    h.halted = false;
+    h.cooldown_until_k = -1.0f;
+    h.flat_confirmations = 0;
+}
 
 inline TmSide load_side(constant float* p, int o, float seed) {
     TmSide s;
@@ -1042,6 +1192,8 @@ inline void passivbot_single_coin_impl(
     const float seed_close = bars[seed_k * 5 + 2];
     TmSide long_side = load_side(params, po, seed_close);
     TmSide short_side = load_side(params, po + SIDE_PARAMS, seed_close);
+    HslState long_hsl = load_hsl(params, po);
+    HslState short_hsl = load_hsl(params, po + SIDE_PARAMS);
 
     float balance = starting_balance;
     float realized_pnl_cumsum_last = 0.0f;
@@ -1941,6 +2093,8 @@ inline void passivbot_single_coin_impl(
 
         bool gen = can_gen && alive;
         eq_started = eq_started || gen;
+        int long_hsl_mode = hsl_mode(long_hsl, long_side.psize > 0.0f);
+        int short_hsl_mode = hsl_mode(short_hsl, short_side.psize > 0.0f);
         if (gen) {
             // When both sides are flat, an exact Rust path that remains alive has
             // balance above liq_floor. If either side is open, equity cannot bound
@@ -1958,8 +2112,8 @@ inline void passivbot_single_coin_impl(
                 short_side.allowed_wel, short_side.initial_qty_pct,
                 max_effective_min_cost
             );
-            bool block_long_initial = !long_min_cost_eligible;
-            bool block_short_initial = !short_min_cost_eligible;
+            bool block_long_initial = !long_min_cost_eligible || long_hsl_mode != 0;
+            bool block_short_initial = !short_min_cost_eligible || short_hsl_mode != 0;
             if (long_enabled && short_enabled && !hedge_mode) {
                 if (long_side.psize > 0.0f) {
                     block_short_initial = true;
@@ -2103,6 +2257,30 @@ inline void passivbot_single_coin_impl(
             short_side.wel_enforcer_enabled = short_wel_enabled;
             short_side.twel_enforcer_enabled = short_twel_enabled;
             short_side.unstuck_enabled = configured_short_unstuck;
+            if (long_enabled && long_hsl_mode >= 2) {
+                long_side.entry_qty = 0.0f;
+            }
+            if (short_enabled && short_hsl_mode >= 2) {
+                short_side.entry_qty = 0.0f;
+            }
+            if (long_enabled && long_hsl_mode == 3) {
+                long_side.close_ticks = max(touch_down_tick - 1, 1);
+                long_side.close_price = float(long_side.close_ticks) * price_step;
+                long_side.close_qty = long_side.psize;
+                long_side.secondary_close_qty = 0.0f;
+                long_side.close_is_exposure_reducer = false;
+                long_side.close_is_twel_reducer = false;
+                long_side.close_is_unstuck_reducer = false;
+            }
+            if (short_enabled && short_hsl_mode == 3) {
+                short_side.close_ticks = max(touch_up_tick + 1, 1);
+                short_side.close_price = float(short_side.close_ticks) * price_step;
+                short_side.close_qty = short_side.psize;
+                short_side.secondary_close_qty = 0.0f;
+                short_side.close_is_exposure_reducer = false;
+                short_side.close_is_twel_reducer = false;
+                short_side.close_is_unstuck_reducer = false;
+            }
         }
 
         float long_unreal = long_side.psize > 0.0f
@@ -2110,6 +2288,30 @@ inline void passivbot_single_coin_impl(
         float short_unreal = short_side.psize > 0.0f
             ? short_side.psize * c_mult * (short_side.pprice - close) : 0.0f;
         float equity = balance + long_unreal + short_unreal;
+        if (gen && valid && alive && balance > 0.0f && equity > liq_floor) {
+            bool long_blocking_orders = long_hsl_mode != 3 && (
+                long_side.entry_qty > 0.0f || long_side.close_qty > 0.0f
+                    || long_side.secondary_close_qty > 0.0f
+            );
+            bool short_blocking_orders = short_hsl_mode != 3 && (
+                short_side.entry_qty > 0.0f || short_side.close_qty > 0.0f
+                    || short_side.secondary_close_qty > 0.0f
+            );
+            update_hsl(
+                long_hsl, balance, starting_balance,
+                realized_pnl_cumsum_last,
+                long_unreal, long_side.psize > 0.0f,
+                long_blocking_orders, kf
+            );
+            update_hsl(
+                short_hsl, balance, starting_balance,
+                realized_pnl_cumsum_last,
+                short_unreal, short_side.psize > 0.0f,
+                short_blocking_orders, kf
+            );
+            try_restart_hsl(long_hsl, kf);
+            try_restart_hsl(short_hsl, kf);
+        }
         bool active = eq_started && alive && valid;
         if (active) {
             if (first_eq_k < 0.0f) first_eq_k = kf;

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -1837,7 +1837,9 @@ def _update_novelty_stall(
     return current
 
 
-def _gpu_suite_checkpoint_contract(config: dict, suite_inputs=None) -> dict:
+def _gpu_suite_checkpoint_contract(
+    config: dict, suite_inputs=None, *, pinned_hsl_bounds=None
+) -> dict:
     backtest = config.get("backtest", {})
     contract = {
         key: deepcopy(backtest.get(key))
@@ -1857,6 +1859,7 @@ def _gpu_suite_checkpoint_contract(config: dict, suite_inputs=None) -> dict:
     )
     contract["unstuck"] = _gpu_unstuck_checkpoint_contract(config)
     contract["hsl"] = _gpu_hsl_checkpoint_contract(config)
+    contract["pinned_hsl_bounds"] = deepcopy(pinned_hsl_bounds or {})
     if suite_inputs is not None:
         prepared_scenarios = []
         for item in suite_inputs:
@@ -1910,6 +1913,9 @@ def _gpu_suite_checkpoint_contract(config: dict, suite_inputs=None) -> dict:
                     ),
                     "unstuck": _gpu_unstuck_checkpoint_contract(item["config"]),
                     "hsl": _gpu_hsl_checkpoint_contract(item["config"]),
+                    "pinned_hsl_bounds": deepcopy(
+                        item.get("pinned_hsl_bounds", {})
+                    ),
                     "candle_count": int(len(item["hlcvs"])),
                     "first_timestamp": (
                         int(timestamps[0]) if len(timestamps) else None
@@ -1928,7 +1934,9 @@ def _gpu_suite_checkpoint_contract(config: dict, suite_inputs=None) -> dict:
     return contract
 
 
-def _gpu_runtime_checkpoint_contract(config: dict, proxy) -> dict:
+def _gpu_runtime_checkpoint_contract(
+    config: dict, proxy, *, pinned_hsl_bounds=None
+) -> dict:
     return {
         "max_realized_loss_pct": float(
             config.get("live", {}).get("max_realized_loss_pct", 1.0)
@@ -1941,6 +1949,7 @@ def _gpu_runtime_checkpoint_contract(config: dict, proxy) -> dict:
         ),
         "unstuck": _gpu_unstuck_checkpoint_contract(config),
         "hsl": _gpu_hsl_checkpoint_contract(config),
+        "pinned_hsl_bounds": deepcopy(pinned_hsl_bounds or {}),
     }
 
 
@@ -1995,6 +2004,51 @@ def _gpu_hsl_checkpoint_contract(config: dict) -> dict:
             for side in ("long", "short")
         },
     }
+
+
+def _gpu_pinned_hsl_bound_contract(bound_by_key) -> dict[str, float]:
+    return {
+        key: float(bound.low)
+        for key, bound in sorted(bound_by_key.items())
+        if "_hsl_" in key
+        and math.isclose(
+            float(bound.low), float(bound.high), rel_tol=0.0, abs_tol=1.0e-12
+        )
+    }
+
+
+def _gpu_hsl_search_sides(
+    proxy_config: dict, suite_inputs, overrides: set[str] | None = None
+) -> set[str]:
+    configs = (
+        [item["config"] for item in suite_inputs]
+        if suite_inputs
+        else [proxy_config]
+    )
+    target_sides = {
+        side
+        for side in ("long", "short")
+        if any(
+            gpu_side_enabled(item, side)
+            and bool(
+                item.get("bot", {})
+                .get(side, {})
+                .get("hsl", {})
+                .get("enabled", False)
+            )
+            for item in configs
+        )
+    }
+    return _gpu_candidate_source_sides(target_sides, overrides or set())
+
+
+def _gpu_hsl_parameter_active(
+    parameter: str, hsl_search_sides: set[str]
+) -> bool:
+    for side in ("long", "short"):
+        if parameter.startswith(f"{side}_hsl_"):
+            return side in hsl_search_sides
+    return True
 
 
 def _gpu_unstuck_search_sides(
@@ -2791,6 +2845,9 @@ def run_backend(
         if max_coin_count == 1 or len(config_enabled_sides) == 1
         else set()
     )
+    hsl_search_sides = _gpu_hsl_search_sides(
+        proxy_config, suite_inputs, gpu_optimizer_overrides
+    )
     mapped = {
         name: value
         for name, value in mapped_all.items()
@@ -2802,6 +2859,7 @@ def run_backend(
         if bound.high > bound.low
         and name not in fixed_parameter_overrides
         and _gpu_unstuck_parameter_active(name, unstuck_search_sides)
+        and _gpu_hsl_parameter_active(name, hsl_search_sides)
         and not (
             "mirror_short_from_long" in gpu_optimizer_overrides
             and name.startswith("short_")
@@ -2888,6 +2946,9 @@ def run_backend(
             coin_count=item["coin_count"],
         )
         item["parameter_overrides"] = parameter_overrides
+        item["pinned_hsl_bounds"] = _gpu_pinned_hsl_bound_contract(
+            scenario_bound_by_key
+        )
 
     for bound_key, bound in bound_by_key.items():
         if bound_key == ANCHOR_GENE_KEY or bound.high <= bound.low:
@@ -3092,14 +3153,22 @@ def run_backend(
         config["optimize"]["scoring"],
         anchor_plan=get_anchor_plan(config),
         suite_contract=(
-            _gpu_suite_checkpoint_contract(config, suite_inputs)
+            _gpu_suite_checkpoint_contract(
+                config,
+                suite_inputs,
+                pinned_hsl_bounds=_gpu_pinned_hsl_bound_contract(bound_by_key),
+            )
             if suite_enabled
             else None
         ),
         runtime_contract=(
             None
             if suite_enabled
-            else _gpu_runtime_checkpoint_contract(proxy_config, proxy)
+            else _gpu_runtime_checkpoint_contract(
+                proxy_config,
+                proxy,
+                pinned_hsl_bounds=_gpu_pinned_hsl_bound_contract(bound_by_key),
+            )
         ),
     )
     budget = int(config["optimize"]["iters"])

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -977,6 +977,15 @@ def _validate_scope_config(
             raise ValueError(
                 "GPU HSL currently requires one enabled side and one backtest coin"
             )
+        lookback = parse_pnls_max_lookback_days(
+            config.get("live", {}).get("pnls_max_lookback_days", 30.0),
+            field_name="live.pnls_max_lookback_days",
+        )
+        if not lookback.is_all:
+            raise ValueError(
+                "GPU HSL currently requires live.pnls_max_lookback_days='all'; "
+                "finite rolling HSL peaks remain exact-Rust-only"
+            )
         signal_mode = str(
             config.get("live", {}).get("hsl_signal_mode", "unified")
         ).strip().lower()
@@ -2017,6 +2026,49 @@ def _gpu_pinned_hsl_bound_contract(bound_by_key) -> dict[str, float]:
     }
 
 
+def _validate_hsl_bound_contracts(bound_by_key, config: dict) -> None:
+    float32_below_one = float(
+        np.nextafter(np.float32(1.0), np.float32(0.0))
+    )
+    for side in ("long", "short"):
+        enabled = bool(
+            config.get("bot", {})
+            .get(side, {})
+            .get("hsl", {})
+            .get("enabled", False)
+        )
+        enabled_bound = bound_by_key.get(f"{side}_hsl_enabled")
+        if enabled_bound is not None:
+            expected = float(enabled)
+            endpoints = (float(enabled_bound.low), float(enabled_bound.high))
+            if any(
+                not math.isclose(
+                    value, expected, rel_tol=0.0, abs_tol=1.0e-12
+                )
+                for value in endpoints
+            ):
+                raise ValueError(
+                    "GPU HSL requires pinned optimizer enablement to match the "
+                    f"source bot.{side}.hsl.enabled={enabled}; got bounds {endpoints}"
+                )
+        if not enabled:
+            continue
+        for suffix in (
+            "hsl_red_threshold",
+            "hsl_no_restart_drawdown_threshold",
+        ):
+            bound = bound_by_key.get(f"{side}_{suffix}")
+            if bound is None:
+                continue
+            low, high = float(bound.low), float(bound.high)
+            if low < 1.0 and high > float32_below_one:
+                raise ValueError(
+                    f"GPU HSL {side}_{suffix} bounds include values which "
+                    "float32 cannot distinguish from 1.0; require high <= "
+                    f"{float32_below_one} or pin exactly at 1.0, got {(low, high)}"
+                )
+
+
 def _gpu_hsl_search_sides(
     proxy_config: dict, suite_inputs, overrides: set[str] | None = None
 ) -> set[str]:
@@ -2762,6 +2814,11 @@ def run_backend(
         for index, (bound_key, _path) in enumerate(key_paths)
         if bound_key in bound_map
     }
+    for parameter, (_index, bound) in mapped_all.items():
+        if math.isclose(
+            float(bound.low), float(bound.high), rel_tol=0.0, abs_tol=1.0e-12
+        ):
+            fixed_parameter_overrides.setdefault(parameter, float(bound.low))
     missing = sorted(set(bound_map.values()) - set(mapped_all))
     if anchor_parameter_overrides is None and missing:
         raise ValueError(
@@ -2901,6 +2958,7 @@ def run_backend(
         coin_count=max_coin_count,
         strategy_kind=strategy_kind,
     )
+    _validate_hsl_bound_contracts(bound_by_key, proxy_config)
 
     if suite_multicoin_sides is None:
         _validate_directional_search_space(
@@ -2945,6 +3003,7 @@ def run_backend(
             scenario_enabled_sides,
             coin_count=item["coin_count"],
         )
+        _validate_hsl_bound_contracts(scenario_bound_by_key, item["config"])
         item["parameter_overrides"] = parameter_overrides
         item["pinned_hsl_bounds"] = _gpu_pinned_hsl_bound_contract(
             scenario_bound_by_key

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -104,6 +104,12 @@ _SINGLE_COIN_UNSTUCK_BOUND_SUFFIXES = {
     "unstuck_threshold": "unstuck_threshold",
 }
 
+_SINGLE_COIN_HSL_BOUND_SUFFIXES = {
+    "hsl_cooldown_minutes_after_red": "hsl_cooldown_minutes_after_red",
+    "hsl_ema_span_minutes": "hsl_ema_span_minutes",
+    "hsl_red_threshold": "hsl_red_threshold",
+}
+
 EMA_STRATEGY_BOUND_MAP = {
     f"{side}_{bound_suffix}": f"{side}_{parameter}"
     for side in ("long", "short")
@@ -121,6 +127,11 @@ EMA_BOUND_MAP = {
         f"{side}_{bound_suffix}": f"{side}_{parameter}"
         for side in ("long", "short")
         for bound_suffix, parameter in _SINGLE_COIN_UNSTUCK_BOUND_SUFFIXES.items()
+    },
+    **{
+        f"{side}_{bound_suffix}": f"{side}_{parameter}"
+        for side in ("long", "short")
+        for bound_suffix, parameter in _SINGLE_COIN_HSL_BOUND_SUFFIXES.items()
     },
 }
 
@@ -203,6 +214,11 @@ TRAILING_MARTINGALE_BOUND_MAP = {
         f"{side}_{bound_suffix}": f"{side}_{parameter}"
         for side in ("long", "short")
         for bound_suffix, parameter in _SINGLE_COIN_UNSTUCK_BOUND_SUFFIXES.items()
+    },
+    **{
+        f"{side}_{bound_suffix}": f"{side}_{parameter}"
+        for side in ("long", "short")
+        for bound_suffix, parameter in _SINGLE_COIN_HSL_BOUND_SUFFIXES.items()
     },
 }
 
@@ -453,14 +469,6 @@ def _build_gpu_nsga2(config, *, sampling, population_size: int, n_params: int):
         ),
         eliminate_duplicates=bool(shared["eliminate_duplicates"]),
     )
-
-PINNED_SCOPE_BOUND_VALUES = {
-    f"{side}_{suffix}": expected
-    for side in ("long", "short")
-    for suffix, expected in {
-        "hsl_enabled": 0.0,
-    }.items()
-}
 
 GPU_RESULT_BACKTEST_CONTRACT_KEYS = {
     "balance_sample_divider",
@@ -959,10 +967,36 @@ def _validate_scope_config(
         enabled_sides=enabled_sides,
         coin_count=coin_count,
     )
+    hsl_enabled_sides = [
+        side
+        for side in enabled_sides
+        if bool(config["bot"][side].get("hsl", {}).get("enabled"))
+    ]
+    if hsl_enabled_sides:
+        if coin_count != 1 or len(enabled_sides) != 1:
+            raise ValueError(
+                "GPU HSL currently requires one enabled side and one backtest coin"
+            )
+        signal_mode = str(
+            config.get("live", {}).get("hsl_signal_mode", "unified")
+        ).strip().lower()
+        if signal_mode not in {"coin", "pside", "unified"}:
+            raise ValueError(
+                "GPU HSL requires live.hsl_signal_mode to be coin, pside, or "
+                f"unified; got {signal_mode!r}"
+            )
+        for side in hsl_enabled_sides:
+            hsl = config["bot"][side].get("hsl", {})
+            panic_order_type = str(
+                hsl.get("panic_close_order_type", "limit")
+            ).strip().lower()
+            if panic_order_type != "limit":
+                raise ValueError(
+                    f"GPU HSL currently requires bot.{side}.hsl."
+                    "panic_close_order_type=limit"
+                )
     for side in enabled_sides:
         side_config = config["bot"][side]
-        if bool(side_config.get("hsl", {}).get("enabled")):
-            raise ValueError(f"GPU foundation requires bot.{side}.hsl.enabled=false")
         risk = side_config.get("risk", {})
         required_disabled = []
         if strategy_kind != "trailing_martingale":
@@ -2230,7 +2264,11 @@ def _validate_pinned_scope_bounds(
     strategy_kind: str | None = None,
 ) -> None:
     enabled_sides = set(enabled_sides or ("long", "short"))
-    pinned = dict(PINNED_SCOPE_BOUND_VALUES)
+    pinned = {}
+    if coin_count != 1 or len(enabled_sides) != 1:
+        pinned.update(
+            {f"{side}_hsl_enabled": 0.0 for side in ("long", "short")}
+        )
     if coin_count > 1 and len(enabled_sides) == 2:
         pinned.update(
             {f"{side}_unstuck_enabled": 0.0 for side in ("long", "short")}
@@ -2833,8 +2871,12 @@ def run_backend(
             # Forager ranking cannot affect a one-coin backtest.
             continue
         if any(bound_key.startswith(f"{side}_hsl_") for side in enabled_sides):
-            # HSL remains disabled, so its dormant bounds affect neither path.
-            continue
+            bound_side = bound_key.split("_", 1)[0]
+            if not bool(
+                config["bot"][bound_side].get("hsl", {}).get("enabled")
+            ):
+                # Dormant HSL bounds affect neither proxy nor exact Rust.
+                continue
         if max_coin_count > 1 and len(enabled_sides) == 2 and any(
             bound_key.startswith(f"{side}_unstuck_") for side in enabled_sides
         ):

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -1856,6 +1856,7 @@ def _gpu_suite_checkpoint_contract(config: dict, suite_inputs=None) -> dict:
         _gpu_pnls_max_lookback_days_checkpoint_value(config)
     )
     contract["unstuck"] = _gpu_unstuck_checkpoint_contract(config)
+    contract["hsl"] = _gpu_hsl_checkpoint_contract(config)
     if suite_inputs is not None:
         prepared_scenarios = []
         for item in suite_inputs:
@@ -1908,6 +1909,7 @@ def _gpu_suite_checkpoint_contract(config: dict, suite_inputs=None) -> dict:
                         )
                     ),
                     "unstuck": _gpu_unstuck_checkpoint_contract(item["config"]),
+                    "hsl": _gpu_hsl_checkpoint_contract(item["config"]),
                     "candle_count": int(len(item["hlcvs"])),
                     "first_timestamp": (
                         int(timestamps[0]) if len(timestamps) else None
@@ -1938,6 +1940,7 @@ def _gpu_runtime_checkpoint_contract(config: dict, proxy) -> dict:
             getattr(proxy, "coin_override_contract", None)
         ),
         "unstuck": _gpu_unstuck_checkpoint_contract(config),
+        "hsl": _gpu_hsl_checkpoint_contract(config),
     }
 
 
@@ -1965,6 +1968,33 @@ def _gpu_unstuck_checkpoint_contract(config: dict) -> dict:
             "threshold": float(unstuck.get("threshold", 0.0)),
         }
     return contract
+
+
+def _gpu_hsl_checkpoint_contract(config: dict) -> dict:
+    return {
+        "signal_mode": str(
+            config.get("live", {}).get("hsl_signal_mode", "unified")
+        )
+        .strip()
+        .lower(),
+        "dynamic_wel_by_tradability": bool(
+            config.get("backtest", {}).get("dynamic_wel_by_tradability", True)
+        ),
+        "sides": {
+            side: {
+                "config": deepcopy(
+                    config.get("bot", {}).get(side, {}).get("hsl", {})
+                ),
+                "n_positions": deepcopy(
+                    config.get("bot", {})
+                    .get(side, {})
+                    .get("risk", {})
+                    .get("n_positions")
+                ),
+            }
+            for side in ("long", "short")
+        },
+    }
 
 
 def _gpu_unstuck_search_sides(

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -415,6 +415,21 @@ def _gpu_candidate_source_sides(
     return source_sides
 
 
+def _gpu_candidate_search_sides(proxy_config: dict, suite_inputs) -> set[str]:
+    """Return every side enabled by an effective independent scenario."""
+
+    configs = (
+        [item["config"] for item in suite_inputs]
+        if suite_inputs
+        else [proxy_config]
+    )
+    return {
+        side
+        for side in ("long", "short")
+        if any(gpu_side_enabled(item, side) for item in configs)
+    }
+
+
 def _ema_multicoin_bound_map(target_side: str, overrides: set[str]) -> dict:
     """Include all bound families that can feed the enabled multicoin side."""
 
@@ -2908,8 +2923,11 @@ def run_backend(
             "GPU bounds would disable both sides for exact validation; "
             f"effective seed values: {side_values}"
         )
+    candidate_search_sides = _gpu_candidate_search_sides(
+        proxy_config, suite_inputs
+    )
     candidate_source_sides = _gpu_candidate_source_sides(
-        enabled_sides, gpu_optimizer_overrides
+        candidate_search_sides, gpu_optimizer_overrides
     )
     unstuck_search_sides = (
         _gpu_unstuck_search_sides(
@@ -3029,14 +3047,18 @@ def run_backend(
         if bound_key == ANCHOR_GENE_KEY or bound.high <= bound.low:
             continue
         side = bound_key.split("_", 1)[0]
-        if side in {"long", "short"} and side not in enabled_sides:
+        if side in {"long", "short"} and side not in candidate_search_sides:
             continue
         if max_coin_count == 1 and any(
-            bound_key.startswith(f"{side}_forager_") for side in enabled_sides
+            bound_key.startswith(f"{side}_forager_")
+            for side in candidate_search_sides
         ):
             # Forager ranking cannot affect a one-coin backtest.
             continue
-        if any(bound_key.startswith(f"{side}_hsl_") for side in enabled_sides):
+        if any(
+            bound_key.startswith(f"{side}_hsl_")
+            for side in candidate_search_sides
+        ):
             bound_side = bound_key.split("_", 1)[0]
             if bound_side not in hsl_search_sides:
                 # Dormant HSL bounds affect neither proxy nor exact Rust.
@@ -3049,7 +3071,8 @@ def run_backend(
             continue
         if (
             max_coin_count == 1
-            and bound_key in {f"{side}_n_positions" for side in enabled_sides}
+            and bound_key
+            in {f"{side}_n_positions" for side in candidate_search_sides}
         ):
             continue
         if bound_key not in bound_map:

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -2053,6 +2053,22 @@ def _validate_hsl_bound_contracts(bound_by_key, config: dict) -> None:
                 )
         if not enabled:
             continue
+        red_bound = bound_by_key.get(f"{side}_hsl_red_threshold")
+        if red_bound is not None and float(red_bound.low) <= 0.0:
+            raise ValueError(
+                f"GPU HSL {side}_hsl_red_threshold bounds must remain greater "
+                f"than zero, got {(float(red_bound.low), float(red_bound.high))}"
+            )
+        cooldown_bound = bound_by_key.get(
+            f"{side}_hsl_cooldown_minutes_after_red"
+        )
+        if cooldown_bound is not None and float(cooldown_bound.low) < 0.0:
+            raise ValueError(
+                "GPU HSL "
+                f"{side}_hsl_cooldown_minutes_after_red bounds must remain "
+                "non-negative, got "
+                f"{(float(cooldown_bound.low), float(cooldown_bound.high))}"
+            )
         for suffix in (
             "hsl_red_threshold",
             "hsl_no_restart_drawdown_threshold",
@@ -3022,9 +3038,7 @@ def run_backend(
             continue
         if any(bound_key.startswith(f"{side}_hsl_") for side in enabled_sides):
             bound_side = bound_key.split("_", 1)[0]
-            if not bool(
-                config["bot"][bound_side].get("hsl", {}).get("enabled")
-            ):
+            if bound_side not in hsl_search_sides:
                 # Dormant HSL bounds affect neither proxy nor exact Rust.
                 continue
         if max_coin_count > 1 and len(enabled_sides) == 2 and any(

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -61,6 +61,7 @@ HSL_PARAM_KEYS = (
     "hsl_tier_ratio_orange",
     "hsl_orange_graceful_stop",
     "hsl_signal_coin",
+    "hsl_slot_count",
 )
 
 MULTICOIN_TOTAL_EXPOSURE_ENFORCER_PARAM_KEYS = (

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -50,6 +50,19 @@ UNSTUCK_PARAM_KEYS = (
     "unstuck_threshold",
 )
 
+HSL_PARAM_KEYS = (
+    "hsl_enabled",
+    "hsl_red_threshold",
+    "hsl_ema_span_minutes",
+    "hsl_cooldown_minutes_after_red",
+    "hsl_no_restart_drawdown_threshold",
+    "hsl_restart_policy",
+    "hsl_tier_ratio_yellow",
+    "hsl_tier_ratio_orange",
+    "hsl_orange_graceful_stop",
+    "hsl_signal_coin",
+)
+
 MULTICOIN_TOTAL_EXPOSURE_ENFORCER_PARAM_KEYS = (
     *TOTAL_EXPOSURE_ENFORCER_PARAM_KEYS,
     "twel_enforcer_reduce_portfolio",
@@ -63,6 +76,7 @@ EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS = (
     *SINGLE_COIN_EXPOSURE_PARAM_KEYS,
     *TOTAL_EXPOSURE_ENFORCER_PARAM_KEYS,
     *UNSTUCK_PARAM_KEYS,
+    *HSL_PARAM_KEYS,
 )
 
 EMA_ANCHOR_MULTICOIN_PARAM_KEYS = (
@@ -115,6 +129,7 @@ TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS = (
     *POSITION_EXPOSURE_ENFORCER_PARAM_KEYS,
     *TOTAL_EXPOSURE_ENFORCER_PARAM_KEYS,
     *UNSTUCK_PARAM_KEYS,
+    *HSL_PARAM_KEYS,
 )
 
 TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS = (

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -130,7 +130,9 @@ def _unstuck_params(bot: dict) -> dict[str, float]:
     }
 
 
-def _hsl_params(bot: dict, *, signal_mode: str) -> dict[str, float]:
+def _hsl_params(
+    bot: dict, *, signal_mode: str, dynamic_wel_by_tradability: bool = True
+) -> dict[str, float]:
     restart_policy = str(
         bot.get("hsl_restart_after_red_policy", "threshold")
     ).strip().lower()
@@ -158,6 +160,7 @@ def _hsl_params(bot: dict, *, signal_mode: str) -> dict[str, float]:
             "MPS HSL requires orange_tier_mode to be graceful_stop or tp_only, "
             f"got {orange_mode!r}"
         )
+    configured_slots = max(1.0, float(bot.get("n_positions", 1.0)))
     return {
         "hsl_enabled": float(bool(bot.get("hsl_enabled", False))),
         "hsl_red_threshold": float(bot.get("hsl_red_threshold", 0.15)),
@@ -177,6 +180,9 @@ def _hsl_params(bot: dict, *, signal_mode: str) -> dict[str, float]:
         ),
         "hsl_orange_graceful_stop": float(orange_mode == "graceful_stop"),
         "hsl_signal_coin": float(signal_mode == "coin"),
+        "hsl_slot_count": (
+            1.0 if bool(dynamic_wel_by_tradability) else configured_slots
+        ),
     }
 
 
@@ -426,6 +432,9 @@ class MpsSingleCoinProxy:
             backtest_params.get("equity_hard_stop_loss", {})
             .get("signal_mode", "unified")
         )
+        dynamic_wel_by_tradability = bool(
+            backtest_params.get("dynamic_wel_by_tradability", True)
+        )
         self.base_params = {}
         for side, bot in (("long", long_bot), ("short", short_bot)):
             if self.enabled[side] and bool(bot.get("hsl_enabled")) and str(
@@ -456,7 +465,13 @@ class MpsSingleCoinProxy:
                     _total_exposure_enforcer_params(risk, side=side)
                 )
                 strategy.update(_unstuck_params(bot))
-                strategy.update(_hsl_params(bot, signal_mode=signal_mode))
+                strategy.update(
+                    _hsl_params(
+                        bot,
+                        signal_mode=signal_mode,
+                        dynamic_wel_by_tradability=dynamic_wel_by_tradability,
+                    )
+                )
             missing = [key for key in self.param_keys if key not in strategy]
             if missing:
                 raise ValueError(

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -130,9 +130,7 @@ def _unstuck_params(bot: dict) -> dict[str, float]:
     }
 
 
-def _hsl_params(
-    bot: dict, *, signal_mode: str, dynamic_wel_by_tradability: bool = True
-) -> dict[str, float]:
+def _hsl_params(bot: dict, *, signal_mode: str) -> dict[str, float]:
     restart_policy = str(
         bot.get("hsl_restart_after_red_policy", "threshold")
     ).strip().lower()
@@ -160,7 +158,6 @@ def _hsl_params(
             "MPS HSL requires orange_tier_mode to be graceful_stop or tp_only, "
             f"got {orange_mode!r}"
         )
-    configured_slots = max(1.0, float(bot.get("n_positions", 1.0)))
     return {
         "hsl_enabled": float(bool(bot.get("hsl_enabled", False))),
         "hsl_red_threshold": float(bot.get("hsl_red_threshold", 0.15)),
@@ -180,9 +177,9 @@ def _hsl_params(
         ),
         "hsl_orange_graceful_stop": float(orange_mode == "graceful_stop"),
         "hsl_signal_coin": float(signal_mode == "coin"),
-        "hsl_slot_count": (
-            1.0 if bool(dynamic_wel_by_tradability) else configured_slots
-        ),
+        # The single-coin GPU search contract pins authoritative candidate
+        # n_positions to one even if the source config is outside its bounds.
+        "hsl_slot_count": 1.0,
     }
 
 
@@ -432,9 +429,6 @@ class MpsSingleCoinProxy:
             backtest_params.get("equity_hard_stop_loss", {})
             .get("signal_mode", "unified")
         )
-        dynamic_wel_by_tradability = bool(
-            backtest_params.get("dynamic_wel_by_tradability", True)
-        )
         self.base_params = {}
         for side, bot in (("long", long_bot), ("short", short_bot)):
             if self.enabled[side] and bool(bot.get("hsl_enabled")) and str(
@@ -465,13 +459,7 @@ class MpsSingleCoinProxy:
                     _total_exposure_enforcer_params(risk, side=side)
                 )
                 strategy.update(_unstuck_params(bot))
-                strategy.update(
-                    _hsl_params(
-                        bot,
-                        signal_mode=signal_mode,
-                        dynamic_wel_by_tradability=dynamic_wel_by_tradability,
-                    )
-                )
+                strategy.update(_hsl_params(bot, signal_mode=signal_mode))
             missing = [key for key in self.param_keys if key not in strategy]
             if missing:
                 raise ValueError(

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -130,6 +130,56 @@ def _unstuck_params(bot: dict) -> dict[str, float]:
     }
 
 
+def _hsl_params(bot: dict, *, signal_mode: str) -> dict[str, float]:
+    restart_policy = str(
+        bot.get("hsl_restart_after_red_policy", "threshold")
+    ).strip().lower()
+    restart_policy_ids = {"always": 0.0, "threshold": 1.0, "never": 2.0}
+    if restart_policy not in restart_policy_ids:
+        raise ValueError(
+            "MPS HSL requires restart_after_red_policy to be always, threshold, "
+            f"or never, got {restart_policy!r}"
+        )
+    signal_mode = str(signal_mode).strip().lower()
+    if signal_mode not in {"coin", "pside", "unified"}:
+        raise ValueError(
+            "MPS HSL requires live.hsl_signal_mode to be coin, pside, or "
+            f"unified, got {signal_mode!r}"
+        )
+    orange_mode = str(
+        bot.get("hsl_orange_tier_mode", "tp_only_with_active_entry_cancellation")
+    ).strip().lower()
+    if orange_mode not in {
+        "graceful_stop",
+        "tp_only",
+        "tp_only_with_active_entry_cancellation",
+    }:
+        raise ValueError(
+            "MPS HSL requires orange_tier_mode to be graceful_stop or tp_only, "
+            f"got {orange_mode!r}"
+        )
+    return {
+        "hsl_enabled": float(bool(bot.get("hsl_enabled", False))),
+        "hsl_red_threshold": float(bot.get("hsl_red_threshold", 0.15)),
+        "hsl_ema_span_minutes": float(bot.get("hsl_ema_span_minutes", 720.0)),
+        "hsl_cooldown_minutes_after_red": float(
+            bot.get("hsl_cooldown_minutes_after_red", 0.0)
+        ),
+        "hsl_no_restart_drawdown_threshold": float(
+            bot.get("hsl_no_restart_drawdown_threshold", 1.0)
+        ),
+        "hsl_restart_policy": restart_policy_ids[restart_policy],
+        "hsl_tier_ratio_yellow": float(
+            bot.get("hsl_tier_ratio_yellow", 0.5)
+        ),
+        "hsl_tier_ratio_orange": float(
+            bot.get("hsl_tier_ratio_orange", 0.75)
+        ),
+        "hsl_orange_graceful_stop": float(orange_mode == "graceful_stop"),
+        "hsl_signal_coin": float(signal_mode == "coin"),
+    }
+
+
 def _require_complete_valid_tail(last_valid_idx: int, candle_count: int) -> None:
     if int(last_valid_idx) != int(candle_count) - 1:
         raise ValueError(
@@ -363,10 +413,28 @@ class MpsSingleCoinProxy:
         }
         if not any(self.enabled.values()):
             raise ValueError("GPU foundation requires at least one enabled side")
+        hsl_enabled_sides = [
+            side
+            for side, bot in (("long", long_bot), ("short", short_bot))
+            if self.enabled[side] and bool(bot.get("hsl_enabled"))
+        ]
+        if hsl_enabled_sides and sum(self.enabled.values()) != 1:
+            raise ValueError(
+                "MPS single-coin HSL currently requires exactly one enabled side"
+            )
+        signal_mode = (
+            backtest_params.get("equity_hard_stop_loss", {})
+            .get("signal_mode", "unified")
+        )
         self.base_params = {}
         for side, bot in (("long", long_bot), ("short", short_bot)):
-            if self.enabled[side] and bool(bot.get("hsl_enabled")):
-                raise ValueError(f"GPU foundation requires bot.{side}.hsl.enabled=false")
+            if self.enabled[side] and bool(bot.get("hsl_enabled")) and str(
+                bot.get("hsl_panic_close_order_type", "limit")
+            ).strip().lower() != "limit":
+                raise ValueError(
+                    f"MPS single-coin HSL currently requires bot.{side}.hsl."
+                    "panic_close_order_type=limit"
+                )
             strategy = dict(payload.strategy_params_list[0][side])
             risk = config["bot"][side]["risk"]
             if self.strategy_kind == "trailing_martingale":
@@ -388,6 +456,7 @@ class MpsSingleCoinProxy:
                     _total_exposure_enforcer_params(risk, side=side)
                 )
                 strategy.update(_unstuck_params(bot))
+                strategy.update(_hsl_params(bot, signal_mode=signal_mode))
             missing = [key for key in self.param_keys if key not in strategy]
             if missing:
                 raise ValueError(

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -158,6 +158,19 @@ def _hsl_params(bot: dict, *, signal_mode: str) -> dict[str, float]:
             "MPS HSL requires orange_tier_mode to be graceful_stop or tp_only, "
             f"got {orange_mode!r}"
         )
+    float32_below_one = float(
+        np.nextafter(np.float32(1.0), np.float32(0.0))
+    )
+    for key, default in (
+        ("hsl_red_threshold", 0.15),
+        ("hsl_no_restart_drawdown_threshold", 1.0),
+    ):
+        value = float(bot.get(key, default))
+        if float32_below_one < value < 1.0:
+            raise ValueError(
+                f"MPS HSL cannot represent {key}={value} distinctly from 1.0; "
+                f"use <= {float32_below_one} or exactly 1.0"
+            )
     return {
         "hsl_enabled": float(bool(bot.get("hsl_enabled", False))),
         "hsl_red_threshold": float(bot.get("hsl_red_threshold", 0.15)),
@@ -189,6 +202,25 @@ def _require_complete_valid_tail(last_valid_idx: int, candle_count: int) -> None
             "GPU foundation requires the final prepared candle to be valid because "
             "the exact Rust backtest force-realizes open positions at its valid tail; "
             f"last_valid_idx={last_valid_idx}, candle_count={candle_count}"
+        )
+
+
+def _require_no_internal_invalid_hsl_candles(
+    high, low, close, *, first_valid_idx: int, last_valid_idx: int
+) -> None:
+    first = max(0, int(first_valid_idx))
+    last = min(int(last_valid_idx), len(close) - 1)
+    valid = (
+        np.isfinite(high[first : last + 1])
+        & np.isfinite(low[first : last + 1])
+        & np.isfinite(close[first : last + 1])
+        & (np.asarray(close[first : last + 1]) > 0.0)
+    )
+    if not bool(np.all(valid)):
+        first_invalid = first + int(np.flatnonzero(~valid)[0])
+        raise ValueError(
+            "MPS single-coin HSL currently requires contiguous valid candles "
+            f"between first and last valid indices; invalid candle at {first_invalid}"
         )
 
 
@@ -503,6 +535,14 @@ class MpsSingleCoinProxy:
         high = hlcvs[:, 0, 0].astype(np.float64)
         low = hlcvs[:, 0, 1].astype(np.float64)
         close = hlcvs[:, 0, 2].astype(np.float64)
+        if hsl_enabled_sides:
+            _require_no_internal_invalid_hsl_candles(
+                high,
+                low,
+                close,
+                first_valid_idx=self.run.first_valid_idx,
+                last_valid_idx=self.run.last_valid_idx,
+            )
         self.data = build_mps_data(high, low, close, timestamps, self.run, self.market)
         self.metrics_data = {"ts0": self.data["ts0"], "n": self.data["n"]}
         runner_cls = (

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -380,6 +380,9 @@ def test_trailing_martingale_bound_map_covers_both_directional_shapes():
         "unstuck_ema_dist",
         "unstuck_loss_allowance_pct",
         "unstuck_threshold",
+        "hsl_cooldown_minutes_after_red",
+        "hsl_ema_span_minutes",
+        "hsl_red_threshold",
     }
 
     assert set(TRAILING_MARTINGALE_BOUND_MAP) == {
@@ -1378,10 +1381,6 @@ def test_suite_limit_metric_value_respects_reducer_and_scenario():
             "trailing_martingale",
         ),
         (
-            lambda config: config["bot"]["long"]["hsl"].__setitem__("enabled", True),
-            "hsl",
-        ),
-        (
             lambda config: config["backtest"].__setitem__(
                 "btc_collateral_cap", 0.5
             ),
@@ -1411,6 +1410,41 @@ def test_gpu_foundation_fails_closed_for_unsupported_scope(mutate, message):
 
 def test_gpu_foundation_accepts_ema_long_single():
     assert _validate_scope(_long_only_ema_config(), _Evaluator()) == "bybit"
+
+
+def test_gpu_foundation_accepts_one_sided_single_coin_hsl():
+    config = _long_only_ema_config()
+    config["bot"]["long"]["hsl"]["enabled"] = True
+
+    assert _validate_scope(config, _Evaluator()) == "bybit"
+
+
+def test_gpu_hsl_fails_closed_for_market_panic_close():
+    config = _long_only_ema_config()
+    config["bot"]["long"]["hsl"].update(
+        {"enabled": True, "panic_close_order_type": "market"}
+    )
+
+    with pytest.raises(ValueError, match="panic_close_order_type=limit"):
+        _validate_scope(config, _Evaluator())
+
+
+def test_gpu_hsl_fails_closed_for_dual_side_single_coin():
+    config = _directional_ema_config(long_enabled=True, short_enabled=True)
+    config["bot"]["long"]["hsl"]["enabled"] = True
+
+    with pytest.raises(ValueError, match="one enabled side"):
+        _validate_scope(config, _Evaluator())
+
+
+def test_gpu_hsl_fails_closed_for_multicoin():
+    config = _long_only_ema_config()
+    config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "XRP"]
+    config["bot"]["long"]["risk"]["n_positions"] = 3
+    config["bot"]["long"]["hsl"]["enabled"] = True
+
+    with pytest.raises(ValueError, match="one backtest coin"):
+        _validate_scope(config, _MulticoinEvaluator())
 
 
 @pytest.mark.parametrize("side", ["long", "short"])

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -31,6 +31,7 @@ from optimization.backends.gpu_backend import (
     _format_constraint_diagnostics,
     _gpu_fixed_bound_context,
     _gpu_candidate_source_sides,
+    _gpu_hsl_search_sides,
     _gpu_hsl_parameter_active,
     _gpu_pinned_hsl_bound_contract,
     _validate_hsl_bound_contracts,
@@ -3980,6 +3981,28 @@ def test_gpu_hsl_gene_activity_and_pinned_contract_helpers():
         _validate_hsl_bound_contracts(
             {"long_hsl_red_threshold": Bound(0.9, 1.0)}, config
         )
+    with pytest.raises(ValueError, match="red_threshold bounds must remain greater"):
+        _validate_hsl_bound_contracts(
+            {"long_hsl_red_threshold": Bound(-0.1, 0.2)}, config
+        )
+    with pytest.raises(ValueError, match="cooldown_minutes_after_red bounds"):
+        _validate_hsl_bound_contracts(
+            {
+                "long_hsl_cooldown_minutes_after_red": Bound(-10.0, 10.0)
+            },
+            config,
+        )
+
+    base = _long_only_ema_config()
+    scenario = copy.deepcopy(base)
+    scenario["bot"]["long"]["hsl"]["enabled"] = True
+    search_sides = _gpu_hsl_search_sides(
+        base, [{"config": scenario}], set()
+    )
+    assert search_sides == {"long"}
+    assert _gpu_hsl_parameter_active(
+        "long_hsl_no_restart_drawdown_threshold", search_sides
+    )
 
 
 def test_gpu_checkpoint_signature_tracks_prepared_coin_override_contract():

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -31,6 +31,8 @@ from optimization.backends.gpu_backend import (
     _format_constraint_diagnostics,
     _gpu_fixed_bound_context,
     _gpu_candidate_source_sides,
+    _gpu_hsl_parameter_active,
+    _gpu_pinned_hsl_bound_contract,
     _gpu_suite_enabled,
     _gpu_suite_checkpoint_contract,
     _gpu_runtime_checkpoint_contract,
@@ -3921,6 +3923,35 @@ def test_gpu_checkpoint_signature_tracks_single_coin_hsl_contract():
             != original
         )
 
+    pinned = {"long_hsl_red_threshold": 0.2}
+    pinned_contract = _gpu_runtime_checkpoint_contract(
+        config, proxy, pinned_hsl_bounds=pinned
+    )
+    changed_pinned_contract = _gpu_runtime_checkpoint_contract(
+        config,
+        proxy,
+        pinned_hsl_bounds={"long_hsl_red_threshold": 0.25},
+    )
+    assert pinned_contract != changed_pinned_contract
+    assert _checkpoint_signature(
+        active, scoring, runtime_contract=pinned_contract
+    ) != _checkpoint_signature(
+        active, scoring, runtime_contract=changed_pinned_contract
+    )
+
+
+def test_gpu_hsl_gene_activity_and_pinned_contract_helpers():
+    assert not _gpu_hsl_parameter_active("long_hsl_red_threshold", set())
+    assert _gpu_hsl_parameter_active("long_hsl_red_threshold", {"long"})
+    assert _gpu_hsl_parameter_active("long_offset", set())
+    assert _gpu_pinned_hsl_bound_contract(
+        {
+            "long_hsl_red_threshold": Bound(0.2, 0.2),
+            "long_hsl_ema_span_minutes": Bound(30.0, 90.0),
+            "long_offset": Bound(0.01, 0.01),
+        }
+    ) == {"long_hsl_red_threshold": 0.2}
+
 
 def test_gpu_checkpoint_signature_tracks_prepared_coin_override_contract():
     active = [("long_offset", 0, Bound(0.01, 0.1, 0.01))]
@@ -4007,6 +4038,7 @@ def test_gpu_suite_checkpoint_contract_tracks_prepared_scenario_identity():
             "pnls_max_lookback_days": 30.0,
             "unstuck": original["unstuck"],
             "hsl": original["hsl"],
+            "pinned_hsl_bounds": {},
             "candle_count": 3,
             "first_timestamp": 1000,
             "last_timestamp": 3000,
@@ -4052,6 +4084,23 @@ def test_gpu_suite_checkpoint_contract_tracks_prepared_scenario_identity():
     changed_hsl = copy.deepcopy(item)
     changed_hsl["config"]["bot"]["long"]["hsl"]["enabled"] = True
     assert _gpu_suite_checkpoint_contract(config, [changed_hsl]) != original
+
+    changed_pinned_hsl = copy.deepcopy(item)
+    changed_pinned_hsl["pinned_hsl_bounds"] = {
+        "long_hsl_red_threshold": 0.25
+    }
+    assert (
+        _gpu_suite_checkpoint_contract(config, [changed_pinned_hsl])
+        != original
+    )
+    assert (
+        _gpu_suite_checkpoint_contract(
+            config,
+            [item],
+            pinned_hsl_bounds={"long_hsl_red_threshold": 0.25},
+        )
+        != original
+    )
 
     changed_coins = copy.deepcopy(item)
     changed_coins["coins"] = ["BTC", "SOL"]

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -3884,6 +3884,44 @@ def test_gpu_checkpoint_signature_tracks_single_coin_unstuck_contract():
     assert effective_contract["pnls_max_lookback_days"] == 12.0
 
 
+def test_gpu_checkpoint_signature_tracks_single_coin_hsl_contract():
+    active = [("long_offset", 0, Bound(0.01, 0.1, 0.01))]
+    scoring = [{"goal": "max", "metric": "adg_strategy_eq"}]
+    config = _long_only_ema_config()
+    config["bot"]["long"]["hsl"]["enabled"] = True
+    proxy = SimpleNamespace(coin_override_contract=None)
+    original_contract = _gpu_runtime_checkpoint_contract(config, proxy)
+    original = _checkpoint_signature(
+        active, scoring, runtime_contract=original_contract
+    )
+
+    edits = (
+        ("live", "hsl_signal_mode", "unified"),
+        ("backtest", "dynamic_wel_by_tradability", False),
+        ("bot.long.risk", "n_positions", 2),
+        ("bot.long.hsl", "enabled", False),
+        ("bot.long.hsl", "restart_after_red_policy", "never"),
+        ("bot.long.hsl", "no_restart_drawdown_threshold", 0.9),
+        ("bot.long.hsl", "tier_ratio_yellow", 0.4),
+        ("bot.long.hsl", "orange_tier_mode", "graceful_stop"),
+        ("bot.long.hsl", "panic_close_order_type", "market"),
+    )
+    for parent_path, key, value in edits:
+        changed = copy.deepcopy(config)
+        parent = changed
+        for part in parent_path.split("."):
+            parent = parent[part]
+        parent[key] = value
+        changed_contract = _gpu_runtime_checkpoint_contract(changed, proxy)
+        assert changed_contract != original_contract
+        assert (
+            _checkpoint_signature(
+                active, scoring, runtime_contract=changed_contract
+            )
+            != original
+        )
+
+
 def test_gpu_checkpoint_signature_tracks_prepared_coin_override_contract():
     active = [("long_offset", 0, Bound(0.01, 0.1, 0.01))]
     scoring = [{"goal": "max", "metric": "adg_strategy_eq"}]
@@ -3968,6 +4006,7 @@ def test_gpu_suite_checkpoint_contract_tracks_prepared_scenario_identity():
             "max_realized_loss_pct": 1.0,
             "pnls_max_lookback_days": 30.0,
             "unstuck": original["unstuck"],
+            "hsl": original["hsl"],
             "candle_count": 3,
             "first_timestamp": 1000,
             "last_timestamp": 3000,
@@ -4009,6 +4048,10 @@ def test_gpu_suite_checkpoint_contract_tracks_prepared_scenario_identity():
     changed_unstuck = copy.deepcopy(item)
     changed_unstuck["config"]["bot"]["long"]["unstuck"]["enabled"] = True
     assert _gpu_suite_checkpoint_contract(config, [changed_unstuck]) != original
+
+    changed_hsl = copy.deepcopy(item)
+    changed_hsl["config"]["bot"]["long"]["hsl"]["enabled"] = True
+    assert _gpu_suite_checkpoint_contract(config, [changed_hsl]) != original
 
     changed_coins = copy.deepcopy(item)
     changed_coins["coins"] = ["BTC", "SOL"]

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -33,6 +33,7 @@ from optimization.backends.gpu_backend import (
     _gpu_candidate_source_sides,
     _gpu_hsl_parameter_active,
     _gpu_pinned_hsl_bound_contract,
+    _validate_hsl_bound_contracts,
     _gpu_suite_enabled,
     _gpu_suite_checkpoint_contract,
     _gpu_runtime_checkpoint_contract,
@@ -1417,8 +1418,17 @@ def test_gpu_foundation_accepts_ema_long_single():
 def test_gpu_foundation_accepts_one_sided_single_coin_hsl():
     config = _long_only_ema_config()
     config["bot"]["long"]["hsl"]["enabled"] = True
+    config["live"]["pnls_max_lookback_days"] = "all"
 
     assert _validate_scope(config, _Evaluator()) == "bybit"
+
+
+def test_gpu_hsl_fails_closed_for_finite_pnl_lookback():
+    config = _long_only_ema_config()
+    config["bot"]["long"]["hsl"]["enabled"] = True
+
+    with pytest.raises(ValueError, match="pnls_max_lookback_days='all'"):
+        _validate_scope(config, _Evaluator())
 
 
 def test_gpu_hsl_fails_closed_for_market_panic_close():
@@ -1426,6 +1436,7 @@ def test_gpu_hsl_fails_closed_for_market_panic_close():
     config["bot"]["long"]["hsl"].update(
         {"enabled": True, "panic_close_order_type": "market"}
     )
+    config["live"]["pnls_max_lookback_days"] = "all"
 
     with pytest.raises(ValueError, match="panic_close_order_type=limit"):
         _validate_scope(config, _Evaluator())
@@ -3951,6 +3962,24 @@ def test_gpu_hsl_gene_activity_and_pinned_contract_helpers():
             "long_offset": Bound(0.01, 0.01),
         }
     ) == {"long_hsl_red_threshold": 0.2}
+
+    config = _long_only_ema_config()
+    config["bot"]["long"]["hsl"]["enabled"] = True
+    _validate_hsl_bound_contracts(
+        {
+            "long_hsl_enabled": Bound(1.0, 1.0),
+            "long_hsl_red_threshold": Bound(0.2, 0.8),
+        },
+        config,
+    )
+    with pytest.raises(ValueError, match="enablement to match"):
+        _validate_hsl_bound_contracts(
+            {"long_hsl_enabled": Bound(0.0, 0.0)}, config
+        )
+    with pytest.raises(ValueError, match="cannot distinguish from 1.0"):
+        _validate_hsl_bound_contracts(
+            {"long_hsl_red_threshold": Bound(0.9, 1.0)}, config
+        )
 
 
 def test_gpu_checkpoint_signature_tracks_prepared_coin_override_contract():

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -30,6 +30,7 @@ from optimization.backends.gpu_backend import (
     _evaluate_gpu_suite_proxies,
     _format_constraint_diagnostics,
     _gpu_fixed_bound_context,
+    _gpu_candidate_search_sides,
     _gpu_candidate_source_sides,
     _gpu_hsl_search_sides,
     _gpu_hsl_parameter_active,
@@ -4003,6 +4004,17 @@ def test_gpu_hsl_gene_activity_and_pinned_contract_helpers():
     assert _gpu_hsl_parameter_active(
         "long_hsl_no_restart_drawdown_threshold", search_sides
     )
+
+    switched = copy.deepcopy(base)
+    switched["bot"]["long"]["risk"]["n_positions"] = 0
+    switched["bot"]["long"]["risk"]["total_wallet_exposure_limit"] = 0.0
+    switched["bot"]["short"]["risk"]["n_positions"] = 1
+    switched["bot"]["short"]["risk"]["total_wallet_exposure_limit"] = 1.0
+    switched["bot"]["short"]["hsl"]["enabled"] = True
+    switched["live"]["approved_coins"] = {"long": [], "short": ["BTC"]}
+    assert _gpu_candidate_search_sides(
+        base, [{"config": switched}]
+    ) == {"short"}
 
 
 def test_gpu_checkpoint_signature_tracks_prepared_coin_override_contract():

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -1270,6 +1270,10 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
     unscaled_coin_hsl[keys.index("hsl_red_threshold")] = 0.6
     scaled_coin_hsl = list(unscaled_coin_hsl)
     scaled_coin_hsl[keys.index("hsl_slot_count")] = 4.0
+    capped_coin_hsl = list(hsl)
+    capped_coin_hsl[keys.index("hsl_restart_policy")] = 1.0
+    capped_coin_hsl[keys.index("hsl_cooldown_minutes_after_red")] = 2.0
+    capped_coin_hsl[keys.index("hsl_slot_count")] = 4.0
     inactive = list(baseline)
     rows = (
         [
@@ -1279,6 +1283,7 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
             zero_cooldown_hsl + inactive,
             unscaled_coin_hsl + inactive,
             scaled_coin_hsl + inactive,
+            capped_coin_hsl + inactive,
         ]
         if side == "long"
         else [
@@ -1288,6 +1293,7 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
             inactive + zero_cooldown_hsl,
             inactive + unscaled_coin_hsl,
             inactive + scaled_coin_hsl,
+            inactive + capped_coin_hsl,
         ]
     )
     output = runner_cls(
@@ -1306,6 +1312,7 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
     assert output[size_key][3].item() == 0.0
     assert output[size_key][4].item() > 0.0
     assert output[size_key][5].item() == 0.0
+    assert output[size_key][6].item() > 0.0
     assert output["day_volume"][1].sum().item() > 1.0
 
 

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -94,6 +94,7 @@ _HSL_DISABLED_VALUES = {
     "hsl_tier_ratio_orange": 0.75,
     "hsl_orange_graceful_stop": 0.0,
     "hsl_signal_coin": 0.0,
+    "hsl_slot_count": 1.0,
 }
 
 
@@ -367,7 +368,7 @@ def test_mps_ema_anchor_shader_smoke():
 
     source = passivbot_rust.mps_ema_anchor_source_py()
     assert "kernel void passivbot_ema_anchor" in source
-    assert "constant int SIDE_PARAMS = 33" in source
+    assert "constant int SIDE_PARAMS = 34" in source
     assert "total_exposure_reducer_qty" in source
     assert "secondary_close_qty" in source
     assert "realized_loss_gate_allows" in source
@@ -1257,23 +1258,36 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
         "hsl_tier_ratio_orange": 0.75,
         "hsl_orange_graceful_stop": 0.0,
         "hsl_signal_coin": 1.0,
+        "hsl_slot_count": 1.0,
     }.items():
         hsl[keys.index(key)] = value
     restarting_hsl = list(hsl)
     restarting_hsl[keys.index("hsl_restart_policy")] = 0.0
     restarting_hsl[keys.index("hsl_cooldown_minutes_after_red")] = 2.0
+    zero_cooldown_hsl = list(hsl)
+    zero_cooldown_hsl[keys.index("hsl_restart_policy")] = 0.0
+    unscaled_coin_hsl = list(hsl)
+    unscaled_coin_hsl[keys.index("hsl_red_threshold")] = 0.6
+    scaled_coin_hsl = list(unscaled_coin_hsl)
+    scaled_coin_hsl[keys.index("hsl_slot_count")] = 4.0
     inactive = list(baseline)
     rows = (
         [
             baseline + inactive,
             hsl + inactive,
             restarting_hsl + inactive,
+            zero_cooldown_hsl + inactive,
+            unscaled_coin_hsl + inactive,
+            scaled_coin_hsl + inactive,
         ]
         if side == "long"
         else [
             inactive + baseline,
             inactive + hsl,
             inactive + restarting_hsl,
+            inactive + zero_cooldown_hsl,
+            inactive + unscaled_coin_hsl,
+            inactive + scaled_coin_hsl,
         ]
     )
     output = runner_cls(
@@ -1289,6 +1303,9 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
     assert output[size_key][0].item() > 0.0
     assert output[size_key][1].item() == 0.0
     assert output[size_key][2].item() > 0.0
+    assert output[size_key][3].item() == 0.0
+    assert output[size_key][4].item() > 0.0
+    assert output[size_key][5].item() == 0.0
     assert output["day_volume"][1].sum().item() > 1.0
 
 
@@ -5209,7 +5226,7 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
 
     source = passivbot_rust.mps_trailing_martingale_source_py()
     assert "kernel void passivbot_trailing_martingale" in source
-    assert "constant int SIDE_PARAMS = 50" in source
+    assert "constant int SIDE_PARAMS = 51" in source
     assert "s.allowed_wel" in source
     assert "s.entry_cap" in source
     assert "min_since_open" in source

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -1274,6 +1274,10 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
     capped_coin_hsl[keys.index("hsl_restart_policy")] = 1.0
     capped_coin_hsl[keys.index("hsl_cooldown_minutes_after_red")] = 2.0
     capped_coin_hsl[keys.index("hsl_slot_count")] = 4.0
+    tiny_threshold_hsl = list(hsl)
+    tiny_threshold_hsl[keys.index("hsl_red_threshold")] = 1.0e-8
+    negative_span_hsl = list(hsl)
+    negative_span_hsl[keys.index("hsl_ema_span_minutes")] = -2.0
     inactive = list(baseline)
     rows = (
         [
@@ -1284,6 +1288,8 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
             unscaled_coin_hsl + inactive,
             scaled_coin_hsl + inactive,
             capped_coin_hsl + inactive,
+            tiny_threshold_hsl + inactive,
+            negative_span_hsl + inactive,
         ]
         if side == "long"
         else [
@@ -1294,6 +1300,8 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
             inactive + unscaled_coin_hsl,
             inactive + scaled_coin_hsl,
             inactive + capped_coin_hsl,
+            inactive + tiny_threshold_hsl,
+            inactive + negative_span_hsl,
         ]
     )
     output = runner_cls(
@@ -1313,6 +1321,12 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
     assert output[size_key][4].item() > 0.0
     assert output[size_key][5].item() == 0.0
     assert output[size_key][6].item() > 0.0
+    assert output[size_key][7].item() == 0.0
+    assert output["balance"][7].item() < 990.0
+    assert output[size_key][8].item() == 0.0
+    assert output["balance"][8].item() == pytest.approx(
+        output["balance"][1].item(), abs=1.0e-4
+    )
     assert output["day_volume"][1].sum().item() > 1.0
 
 

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -71,7 +71,7 @@ def _tm_twel_enforcer_fields(
         unstuck_ema_dist,
         unstuck_loss_allowance_pct,
         unstuck_threshold,
-    ]
+    ] + list(_HSL_DISABLED_VALUES.values())
 
 
 _UNSTUCK_DISABLED_VALUES = {
@@ -83,9 +83,22 @@ _UNSTUCK_DISABLED_VALUES = {
     "unstuck_threshold": 0.5,
 }
 
+_HSL_DISABLED_VALUES = {
+    "hsl_enabled": 0.0,
+    "hsl_red_threshold": 0.2,
+    "hsl_ema_span_minutes": 60.0,
+    "hsl_cooldown_minutes_after_red": 0.0,
+    "hsl_no_restart_drawdown_threshold": 1.0,
+    "hsl_restart_policy": 1.0,
+    "hsl_tier_ratio_yellow": 0.5,
+    "hsl_tier_ratio_orange": 0.75,
+    "hsl_orange_graceful_stop": 0.0,
+    "hsl_signal_coin": 0.0,
+}
+
 
 def _single_coin_param_row(values, keys):
-    merged = {**_UNSTUCK_DISABLED_VALUES, **values}
+    merged = {**_UNSTUCK_DISABLED_VALUES, **_HSL_DISABLED_VALUES, **values}
     return [merged[key] for key in keys]
 
 
@@ -354,7 +367,7 @@ def test_mps_ema_anchor_shader_smoke():
 
     source = passivbot_rust.mps_ema_anchor_source_py()
     assert "kernel void passivbot_ema_anchor" in source
-    assert "constant int SIDE_PARAMS = 23" in source
+    assert "constant int SIDE_PARAMS = 33" in source
     assert "total_exposure_reducer_qty" in source
     assert "secondary_close_qty" in source
     assert "realized_loss_gate_allows" in source
@@ -1172,6 +1185,111 @@ def _tm_single_row(
         unstuck_loss_allowance_pct=unstuck_loss_allowance_pct,
         unstuck_threshold=unstuck_threshold,
     )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
+    count = 30
+    close = np.full(count, 100.0)
+    close[8:] = 70.0 if side == "long" else 130.0
+    high = close * 1.02
+    low = close * 0.98
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    if strategy_kind == "trailing_martingale":
+        baseline = _tm_single_row(initial_ema_dist=0.0)
+        baseline[6] = 0.5
+        baseline[7] = 0.5
+        baseline[16] = 0.5
+        keys = TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS
+        runner_cls = MpsTrailingMartingaleRunner
+    else:
+        baseline = _single_coin_param_row(
+            {
+                "base_qty_pct": 0.5,
+                "ema_span_0": 2.0,
+                "ema_span_1": 3.0,
+                "entry_double_down_factor": 1.0,
+                "offset": 0.0,
+                "offset_psize_weight": 0.0,
+                "offset_volatility_1h_weight": 0.0,
+                "offset_volatility_1m_weight": 0.0,
+                "offset_volatility_ema_span_1h": 2.0,
+                "offset_volatility_ema_span_1m": 2.0,
+                "entry_cooldown_minutes": 0.0,
+                "total_wallet_exposure_limit": 1.0,
+                "we_excess_allowance_pct": 0.0,
+                "we_excess_allowance_legacy_raw": 0.0,
+                "twel_entry_gate_enabled": 1.0,
+                "twel_enforcer_threshold": 1.0,
+                "twel_enforcer_enabled": 0.0,
+            },
+            EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
+        )
+        keys = EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS
+        runner_cls = MpsEmaAnchorRunner
+    hsl = list(baseline)
+    for key, value in {
+        "hsl_enabled": 1.0,
+        "hsl_red_threshold": 0.01,
+        "hsl_ema_span_minutes": 1.0,
+        "hsl_cooldown_minutes_after_red": 0.0,
+        "hsl_no_restart_drawdown_threshold": 1.0,
+        "hsl_restart_policy": 2.0,
+        "hsl_tier_ratio_yellow": 0.5,
+        "hsl_tier_ratio_orange": 0.75,
+        "hsl_orange_graceful_stop": 0.0,
+        "hsl_signal_coin": 1.0,
+    }.items():
+        hsl[keys.index(key)] = value
+    restarting_hsl = list(hsl)
+    restarting_hsl[keys.index("hsl_restart_policy")] = 0.0
+    restarting_hsl[keys.index("hsl_cooldown_minutes_after_red")] = 2.0
+    inactive = list(baseline)
+    rows = (
+        [
+            baseline + inactive,
+            hsl + inactive,
+            restarting_hsl + inactive,
+        ]
+        if side == "long"
+        else [
+            inactive + baseline,
+            inactive + hsl,
+            inactive + restarting_hsl,
+        ]
+    )
+    output = runner_cls(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+    ).run(np.asarray(rows, dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    assert output[size_key][0].item() > 0.0
+    assert output[size_key][1].item() == 0.0
+    assert output[size_key][2].item() > 0.0
+    assert output["day_volume"][1].sum().item() > 1.0
 
 
 @pytest.mark.skipif(
@@ -5091,7 +5209,7 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
 
     source = passivbot_rust.mps_trailing_martingale_source_py()
     assert "kernel void passivbot_trailing_martingale" in source
-    assert "constant int SIDE_PARAMS = 40" in source
+    assert "constant int SIDE_PARAMS = 50" in source
     assert "s.allowed_wel" in source
     assert "s.entry_cap" in source
     assert "min_since_open" in source

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -21,6 +21,7 @@ from optimization.gpu.service import (
     _hsl_params,
     _position_exposure_enforcer_params,
     _require_complete_valid_tail,
+    _require_no_internal_invalid_hsl_candles,
     _single_coin_exposure_params,
     _total_exposure_enforcer_params,
     _unstuck_params,
@@ -32,6 +33,21 @@ def test_gpu_proxy_requires_complete_valid_tail():
 
     with pytest.raises(ValueError, match="force-realizes open positions"):
         _require_complete_valid_tail(98, 100)
+
+
+def test_gpu_hsl_requires_contiguous_valid_candles():
+    high = np.array([100.0, np.nan, 100.0])
+    low = np.array([99.0, np.nan, 99.0])
+    close = np.array([99.5, np.nan, 99.5])
+
+    with pytest.raises(ValueError, match="invalid candle at 1"):
+        _require_no_internal_invalid_hsl_candles(
+            high, low, close, first_valid_idx=0, last_valid_idx=2
+        )
+
+    _require_no_internal_invalid_hsl_candles(
+        high, low, close, first_valid_idx=2, last_valid_idx=2
+    )
 
 
 @pytest.mark.parametrize(
@@ -160,6 +176,15 @@ def test_single_coin_hsl_packs_state_machine_inputs():
         "hsl_signal_coin": 1.0,
         "hsl_slot_count": 1.0,
     }
+
+    with pytest.raises(ValueError, match="cannot represent"):
+        _hsl_params(
+            {
+                "hsl_enabled": True,
+                "hsl_no_restart_drawdown_threshold": 0.99999999,
+            },
+            signal_mode="coin",
+        )
 
 
 def test_directional_parameter_matrix_keeps_side_values_separate():

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -142,8 +142,10 @@ def test_single_coin_hsl_packs_state_machine_inputs():
             "hsl_tier_ratio_yellow": 0.5,
             "hsl_tier_ratio_orange": 0.75,
             "hsl_orange_tier_mode": "graceful_stop",
+            "n_positions": 4,
         },
         signal_mode="coin",
+        dynamic_wel_by_tradability=False,
     )
 
     assert packed == {
@@ -157,7 +159,14 @@ def test_single_coin_hsl_packs_state_machine_inputs():
         "hsl_tier_ratio_orange": 0.75,
         "hsl_orange_graceful_stop": 1.0,
         "hsl_signal_coin": 1.0,
+        "hsl_slot_count": 4.0,
     }
+
+    assert _hsl_params(
+        {"hsl_enabled": True, "n_positions": 4},
+        signal_mode="coin",
+        dynamic_wel_by_tradability=True,
+    )["hsl_slot_count"] == 1.0
 
 
 def test_directional_parameter_matrix_keeps_side_values_separate():

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -145,7 +145,6 @@ def test_single_coin_hsl_packs_state_machine_inputs():
             "n_positions": 4,
         },
         signal_mode="coin",
-        dynamic_wel_by_tradability=False,
     )
 
     assert packed == {
@@ -159,14 +158,8 @@ def test_single_coin_hsl_packs_state_machine_inputs():
         "hsl_tier_ratio_orange": 0.75,
         "hsl_orange_graceful_stop": 1.0,
         "hsl_signal_coin": 1.0,
-        "hsl_slot_count": 4.0,
+        "hsl_slot_count": 1.0,
     }
-
-    assert _hsl_params(
-        {"hsl_enabled": True, "n_positions": 4},
-        signal_mode="coin",
-        dynamic_wel_by_tradability=True,
-    )["hsl_slot_count"] == 1.0
 
 
 def test_directional_parameter_matrix_keeps_side_values_separate():

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -18,6 +18,7 @@ from optimization.gpu.service import (
     _build_multicoin_ema_coin_overrides,
     _build_multicoin_tm_coin_overrides,
     _combine_hedged_multicoin_outputs,
+    _hsl_params,
     _position_exposure_enforcer_params,
     _require_complete_valid_tail,
     _single_coin_exposure_params,
@@ -126,6 +127,36 @@ def test_single_coin_unstuck_packs_exact_rust_inputs():
         "unstuck_ema_dist": -0.01,
         "unstuck_loss_allowance_pct": 0.02,
         "unstuck_threshold": 0.85,
+    }
+
+
+def test_single_coin_hsl_packs_state_machine_inputs():
+    packed = _hsl_params(
+        {
+            "hsl_enabled": True,
+            "hsl_red_threshold": 0.2,
+            "hsl_ema_span_minutes": 60.0,
+            "hsl_cooldown_minutes_after_red": 120.0,
+            "hsl_no_restart_drawdown_threshold": 0.8,
+            "hsl_restart_after_red_policy": "threshold",
+            "hsl_tier_ratio_yellow": 0.5,
+            "hsl_tier_ratio_orange": 0.75,
+            "hsl_orange_tier_mode": "graceful_stop",
+        },
+        signal_mode="coin",
+    )
+
+    assert packed == {
+        "hsl_enabled": 1.0,
+        "hsl_red_threshold": 0.2,
+        "hsl_ema_span_minutes": 60.0,
+        "hsl_cooldown_minutes_after_red": 120.0,
+        "hsl_no_restart_drawdown_threshold": 0.8,
+        "hsl_restart_policy": 1.0,
+        "hsl_tier_ratio_yellow": 0.5,
+        "hsl_tier_ratio_orange": 0.75,
+        "hsl_orange_graceful_stop": 1.0,
+        "hsl_signal_coin": 1.0,
     }
 
 


### PR DESCRIPTION
## Summary
- add the first Apple MPS HSL proxy slice for one-sided single-coin EMA Anchor and Trailing Martingale, long or short
- model coin/pside/unified signals, yellow/orange/RED state transitions, limit panic flattening, flat confirmation, cooldown restart, and terminal no-restart behavior
- expose HSL threshold/EMA-span/cooldown genes while keeping exact Rust authoritative and unsupported HSL topologies fail closed
- add source-contract, scope, service, synthetic physical-MPS, documentation, and changelog coverage

## Supported scope
- exactly one enabled side and one coin
- EMA Anchor or Trailing Martingale
- coin, pside, or unified HSL signal mode
- resting-limit panic closes
- compatible single-coin suites

## Explicitly still fail closed
- market panic closes
- dual-side or multi-coin HSL
- per-coin HSL overrides
- HSL-specific scoring and limit metrics

## Validation
- `python -m pytest -q tests/optimization`
- physical Apple M3/MPS: full `tests/optimization/test_gpu_mps.py`
- physical Apple M3/MPS synthetic HSL matrix: EMA Anchor and Trailing Martingale, long and short, panic/permanent halt and cooldown restart
- physical Apple M3/MPS real-data HSL optimize smoke: 8 generations, 512 proxy evaluations, 32 exact validations, no drift or classification halt
- `cargo fmt --check`
- `cargo check --tests`
- `cargo test --no-default-features --quiet` (262 passed)
- `git diff --check`