### PR TITLE
feat(optimize): add MPS HSL lifecycle metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added non-loss HSL lifecycle scoring and limit metrics to the supported one-sided single-coin
+  Apple MPS optimizer path: trigger/restart counts and yearly rates, warning-tier occupancy, halt
+  and flatten durations, trigger drawdown, and post-restart retriggers. Exact Rust validation and
+  drift gates remain authoritative; panic-loss and HSL strategy-equity time-series metrics remain
+  fail closed.
+
 - Added the first HSL slice to Apple MPS optimization for one-sided single-coin EMA Anchor and
   Trailing Martingale runs, in both long and short directions and compatible suites. The Metal
   proxy models coin, pside, and unified drawdown signals; tunable RED threshold, EMA span, and
@@ -11,8 +17,8 @@ All notable user-facing changes will be documented in this file.
   flat confirmation; positive-cooldown restart; zero-cooldown indefinite halt; cumulative
   no-restart peak tracking; effective coin-slot scaling; and terminal no-restart. The initial
   slice requires all-history PnL peaks and contiguous valid candles. Market panic execution,
-  finite rolling PnL lookbacks, dual-side and multi-coin HSL, per-coin HSL overrides, and
-  HSL-specific optimizer metrics remain fail closed.
+  finite rolling PnL lookbacks, dual-side and multi-coin HSL, per-coin HSL overrides, panic-loss
+  metrics, and HSL strategy-equity time-series metrics remain fail closed.
 
 - Added auto-unstuck to Apple MPS EMA Anchor and Trailing Martingale optimization for single-coin
   long-only, short-only, dual-side hedge/one-way, and compatible suite runs, plus one-sided

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -143,9 +143,12 @@ The supported slice is intentionally narrow:
   and strategy-equity peaks require `live.pnls_max_lookback_days: all`, and the selected history
   must have no internal invalid candles between its first and last valid samples. Thresholds in
   the float32-unrepresentable interval immediately below `1.0` fail closed. Exact validation and
-  drift gates remain authoritative. Market panic closes, finite rolling PnL lookbacks, dual-side
-  and multi-coin HSL, per-coin HSL overrides, and HSL-specific scoring/limit metrics remain fail
-  closed for now. Compatible single-coin suites may use the supported topology.
+  drift gates remain authoritative. The non-loss HSL lifecycle metrics (trigger/restart counts and
+  yearly rates, time in each warning tier, halt and flatten durations, trigger drawdown, and
+  post-restart retriggers) may be used for scoring and limits. Market panic closes, finite rolling
+  PnL lookbacks, dual-side and multi-coin HSL, per-coin HSL overrides, panic-loss metrics, and
+  HSL strategy-equity EMA/recovery-distribution metrics remain fail closed for now. Compatible
+  single-coin suites may use the supported topology.
 - single-coin EMA Anchor and Trailing Martingale support auto-unstuck for long-only,
   short-only, hedge-mode dual-side, one-way, and compatible suite runs. One-sided multi-coin runs
   and compatible suites also support auto-unstuck, including static per-coin overrides. Metal

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -42,11 +42,14 @@ mod tests {
         let source = mps_ema_anchor_source();
         assert!(source.contains("kernel void passivbot_ema_anchor"));
         assert!(source.contains("constant int DAILY_COLS = 5"));
-        assert!(source.contains("constant int SCALAR_COLS = 18"));
+        assert!(source.contains("constant int SCALAR_COLS = 36"));
         assert!(source.contains("constant int SIDE_PARAMS = 34"));
         assert!(source.contains("struct HslState"));
         assert!(source.contains("update_hsl("));
         assert!(source.contains("try_restart_hsl("));
+        assert!(source.contains("hsl_tier_samples_total"));
+        assert!(source.contains("h.restart_retrigger_count"));
+        assert!(source.contains("h.halt_duration_sum_steps"));
         assert!(source.contains("h.slot_count"));
         assert!(source.contains("h.no_restart_peak_strategy_equity"));
         assert!(source.contains("terminal || h.cooldown_minutes <= 0.0f"));
@@ -128,6 +131,10 @@ mod tests {
         assert!(source.contains("struct HslState"));
         assert!(source.contains("update_hsl("));
         assert!(source.contains("try_restart_hsl("));
+        assert!(source.contains("constant int SCALAR_COLS = 36"));
+        assert!(source.contains("hsl_tier_samples_total"));
+        assert!(source.contains("h.restart_retrigger_count"));
+        assert!(source.contains("h.halt_duration_sum_steps"));
         assert!(source.contains("h.slot_count"));
         assert!(source.contains("h.no_restart_peak_strategy_equity"));
         assert!(source.contains("terminal || h.cooldown_minutes <= 0.0f"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -2,7 +2,7 @@
 using namespace metal;
 
 constant int DAILY_COLS = 5;
-constant int SCALAR_COLS = 18;
+constant int SCALAR_COLS = 36;
 constant int GAP_BINS = 128;
 constant int SIDE_PARAMS = 34;
 
@@ -153,6 +153,19 @@ struct HslState {
     float pending_strategy_equity;
     float pending_peak_strategy_equity;
     float pending_stop_k;
+    float current_red_start_k;
+    float current_halt_start_k;
+    float last_restart_k;
+    float triggers;
+    float restarts;
+    float halt_duration_sum_steps;
+    float halt_duration_max_steps;
+    float halt_duration_count;
+    float trigger_drawdown_sum;
+    float trigger_drawdown_count;
+    float flatten_time_sum_steps;
+    float flatten_time_count;
+    float restart_retrigger_count;
 };
 
 inline HslState load_hsl(constant float* params, int po) {
@@ -186,6 +199,19 @@ inline HslState load_hsl(constant float* params, int po) {
     h.pending_strategy_equity = 0.0f;
     h.pending_peak_strategy_equity = 0.0f;
     h.pending_stop_k = -1.0f;
+    h.current_red_start_k = -1.0f;
+    h.current_halt_start_k = -1.0f;
+    h.last_restart_k = -1.0f;
+    h.triggers = 0.0f;
+    h.restarts = 0.0f;
+    h.halt_duration_sum_steps = 0.0f;
+    h.halt_duration_max_steps = 0.0f;
+    h.halt_duration_count = 0.0f;
+    h.trigger_drawdown_sum = 0.0f;
+    h.trigger_drawdown_count = 0.0f;
+    h.flatten_time_sum_steps = 0.0f;
+    h.flatten_time_count = 0.0f;
+    h.restart_retrigger_count = 0.0f;
     return h;
 }
 
@@ -205,7 +231,8 @@ inline void update_hsl(
     float unrealized_pnl,
     bool has_position,
     bool has_blocking_orders,
-    float kf
+    float kf,
+    float interval_ms
 ) {
     if (!h.enabled || h.halted || !(balance > 0.0f)) return;
     float drawdown_raw;
@@ -246,8 +273,10 @@ inline void update_hsl(
         : h.red_active_now ? 3
         : score + cmp_eps >= h.orange_ratio * h.red_threshold ? 2
         : score + cmp_eps >= h.yellow_ratio * h.red_threshold ? 1 : 0;
+    if (next_tier == 3 && h.tier != 3) h.current_red_start_k = kf;
     if (next_tier == 3) h.red_latched = true;
     h.tier = h.red_latched ? 3 : next_tier;
+    if (h.tier != 3) h.current_red_start_k = -1.0f;
     if (h.tier == 3) {
         if (has_position || has_blocking_orders) {
             h.flat_confirmations = 0;
@@ -262,6 +291,8 @@ inline void update_hsl(
             }
             if (h.flat_confirmations >= 2) {
                 h.halted = true;
+                h.current_halt_start_k = h.pending_stop_k;
+                h.triggers += 1.0f;
                 if (h.signal_coin) {
                     h.coin_realized_baseline = realized_pnl;
                     h.coin_realized_peak = 0.0f;
@@ -283,6 +314,28 @@ inline void update_hsl(
                         ),
                         0.9999999403953552f
                     );
+                float stop_drawdown_raw = fmax(
+                    h.pending_drawdown_raw,
+                    fmax(
+                        1.0f - h.pending_strategy_equity
+                            / fmax(h.pending_peak_strategy_equity, 1.0e-12f),
+                        0.0f
+                    )
+                );
+                h.trigger_drawdown_sum += stop_drawdown_raw;
+                h.trigger_drawdown_count += 1.0f;
+                if (h.current_red_start_k >= 0.0f) {
+                    h.flatten_time_sum_steps += fmax(
+                        h.pending_stop_k - h.current_red_start_k, 0.0f
+                    );
+                    h.flatten_time_count += 1.0f;
+                }
+                if (h.last_restart_k >= 0.0f
+                    && (h.pending_stop_k - h.last_restart_k) * interval_ms
+                        <= 86400000.0f) {
+                    h.restart_retrigger_count += 1.0f;
+                }
+                h.last_restart_k = -1.0f;
                 bool terminal = h.restart_policy == 2
                     || (h.restart_policy == 1
                         && fmax(no_restart_drawdown_raw, h.pending_drawdown_ema)
@@ -300,6 +353,15 @@ inline void update_hsl(
 inline void try_restart_hsl(thread HslState& h, float kf) {
     if (!h.enabled || !h.halted || h.no_restart_latched
         || h.cooldown_until_k < 0.0f || kf < h.cooldown_until_k) return;
+    if (h.current_halt_start_k >= 0.0f) {
+        float duration = fmax(kf - h.current_halt_start_k, 0.0f);
+        h.halt_duration_sum_steps += duration;
+        h.halt_duration_max_steps = fmax(h.halt_duration_max_steps, duration);
+        h.halt_duration_count += 1.0f;
+        h.current_halt_start_k = -1.0f;
+    }
+    h.restarts += 1.0f;
+    h.last_restart_k = kf;
     h.initialized = false;
     h.drawdown_ema = 0.0f;
     h.peak_strategy_pnl = -INFINITY;
@@ -309,6 +371,7 @@ inline void try_restart_hsl(thread HslState& h, float kf) {
     h.halted = false;
     h.cooldown_until_k = -1.0f;
     h.flat_confirmations = 0;
+    h.current_red_start_k = -1.0f;
 }
 
 inline EmaSide load_side(constant float* params, int po, float seed_close) {
@@ -976,6 +1039,10 @@ inline void passivbot_single_coin_impl(
     float first_eq_k = -1.0f;
     float last_eq_k = -1.0f;
     bool eq_started = false;
+    float hsl_tier_samples_total = 0.0f;
+    float hsl_tier_samples_yellow = 0.0f;
+    float hsl_tier_samples_orange = 0.0f;
+    float hsl_tier_samples_red = 0.0f;
 
     int cur_day = flags[2];
     bool day_touched = false;
@@ -1438,14 +1505,21 @@ inline void passivbot_single_coin_impl(
                 long_hsl, balance, starting_balance,
                 realized_pnl_cumsum_last,
                 long_unreal, long_side.psize > 0.0f,
-                long_blocking_orders, kf
+                long_blocking_orders, kf, interval_ms
             );
             update_hsl(
                 short_hsl, balance, starting_balance,
                 realized_pnl_cumsum_last,
                 short_unreal, short_side.psize > 0.0f,
-                short_blocking_orders, kf
+                short_blocking_orders, kf, interval_ms
             );
+            if (long_hsl.enabled || short_hsl.enabled) {
+                int hsl_tier = max(long_hsl.tier, short_hsl.tier);
+                hsl_tier_samples_total += 1.0f;
+                hsl_tier_samples_yellow += hsl_tier == 1 ? 1.0f : 0.0f;
+                hsl_tier_samples_orange += hsl_tier == 2 ? 1.0f : 0.0f;
+                hsl_tier_samples_red += hsl_tier == 3 ? 1.0f : 0.0f;
+            }
             try_restart_hsl(long_hsl, kf);
             try_restart_hsl(short_hsl, kf);
         }
@@ -1511,6 +1585,46 @@ inline void passivbot_single_coin_impl(
     scalars[so + 15] = short_side.psize;
     scalars[so + 16] = short_side.pprice;
     scalars[so + 17] = 0.0f;
+    float long_terminal_count = long_hsl.halted
+        && long_hsl.current_halt_start_k >= 0.0f && last_eq_k >= 0.0f
+        ? 1.0f : 0.0f;
+    float short_terminal_count = short_hsl.halted
+        && short_hsl.current_halt_start_k >= 0.0f && last_eq_k >= 0.0f
+        ? 1.0f : 0.0f;
+    float long_terminal_duration = long_terminal_count > 0.0f
+        ? fmax(last_eq_k - long_hsl.current_halt_start_k, 0.0f) : 0.0f;
+    float short_terminal_duration = short_terminal_count > 0.0f
+        ? fmax(last_eq_k - short_hsl.current_halt_start_k, 0.0f) : 0.0f;
+    float terminal_count = long_terminal_count + short_terminal_count;
+    scalars[so + 18] = long_hsl.enabled ? 1.0f : 0.0f;
+    scalars[so + 19] = short_hsl.enabled ? 1.0f : 0.0f;
+    scalars[so + 20] = long_hsl.triggers;
+    scalars[so + 21] = short_hsl.triggers;
+    scalars[so + 22] = long_hsl.restarts;
+    scalars[so + 23] = short_hsl.restarts;
+    scalars[so + 24] = hsl_tier_samples_total;
+    scalars[so + 25] = hsl_tier_samples_yellow;
+    scalars[so + 26] = hsl_tier_samples_orange;
+    scalars[so + 27] = hsl_tier_samples_red;
+    scalars[so + 28] = long_hsl.halt_duration_sum_steps
+        + short_hsl.halt_duration_sum_steps
+        + long_terminal_duration + short_terminal_duration;
+    scalars[so + 29] = fmax(
+        fmax(long_hsl.halt_duration_max_steps, short_hsl.halt_duration_max_steps),
+        fmax(long_terminal_duration, short_terminal_duration)
+    );
+    scalars[so + 30] = long_hsl.halt_duration_count
+        + short_hsl.halt_duration_count + terminal_count;
+    scalars[so + 31] = long_hsl.trigger_drawdown_sum
+        + short_hsl.trigger_drawdown_sum;
+    scalars[so + 32] = long_hsl.trigger_drawdown_count
+        + short_hsl.trigger_drawdown_count;
+    scalars[so + 33] = long_hsl.flatten_time_sum_steps
+        + short_hsl.flatten_time_sum_steps;
+    scalars[so + 34] = long_hsl.flatten_time_count
+        + short_hsl.flatten_time_count;
+    scalars[so + 35] = long_hsl.restart_retrigger_count
+        + short_hsl.restart_retrigger_count;
 }
 
 kernel void passivbot_ema_anchor(

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -2,7 +2,7 @@
 using namespace metal;
 
 constant int DAILY_COLS = 5;
-constant int SCALAR_COLS = 18;
+constant int SCALAR_COLS = 36;
 constant int GAP_BINS = 128;
 constant int SIDE_PARAMS = 51;
 
@@ -207,6 +207,19 @@ struct HslState {
     float pending_strategy_equity;
     float pending_peak_strategy_equity;
     float pending_stop_k;
+    float current_red_start_k;
+    float current_halt_start_k;
+    float last_restart_k;
+    float triggers;
+    float restarts;
+    float halt_duration_sum_steps;
+    float halt_duration_max_steps;
+    float halt_duration_count;
+    float trigger_drawdown_sum;
+    float trigger_drawdown_count;
+    float flatten_time_sum_steps;
+    float flatten_time_count;
+    float restart_retrigger_count;
 };
 
 inline HslState load_hsl(constant float* params, int po) {
@@ -240,6 +253,19 @@ inline HslState load_hsl(constant float* params, int po) {
     h.pending_strategy_equity = 0.0f;
     h.pending_peak_strategy_equity = 0.0f;
     h.pending_stop_k = -1.0f;
+    h.current_red_start_k = -1.0f;
+    h.current_halt_start_k = -1.0f;
+    h.last_restart_k = -1.0f;
+    h.triggers = 0.0f;
+    h.restarts = 0.0f;
+    h.halt_duration_sum_steps = 0.0f;
+    h.halt_duration_max_steps = 0.0f;
+    h.halt_duration_count = 0.0f;
+    h.trigger_drawdown_sum = 0.0f;
+    h.trigger_drawdown_count = 0.0f;
+    h.flatten_time_sum_steps = 0.0f;
+    h.flatten_time_count = 0.0f;
+    h.restart_retrigger_count = 0.0f;
     return h;
 }
 
@@ -259,7 +285,8 @@ inline void update_hsl(
     float unrealized_pnl,
     bool has_position,
     bool has_blocking_orders,
-    float kf
+    float kf,
+    float interval_ms
 ) {
     if (!h.enabled || h.halted || !(balance > 0.0f)) return;
     float drawdown_raw;
@@ -300,8 +327,10 @@ inline void update_hsl(
         : h.red_active_now ? 3
         : score + cmp_eps >= h.orange_ratio * h.red_threshold ? 2
         : score + cmp_eps >= h.yellow_ratio * h.red_threshold ? 1 : 0;
+    if (next_tier == 3 && h.tier != 3) h.current_red_start_k = kf;
     if (next_tier == 3) h.red_latched = true;
     h.tier = h.red_latched ? 3 : next_tier;
+    if (h.tier != 3) h.current_red_start_k = -1.0f;
     if (h.tier == 3) {
         if (has_position || has_blocking_orders) {
             h.flat_confirmations = 0;
@@ -316,6 +345,8 @@ inline void update_hsl(
             }
             if (h.flat_confirmations >= 2) {
                 h.halted = true;
+                h.current_halt_start_k = h.pending_stop_k;
+                h.triggers += 1.0f;
                 if (h.signal_coin) {
                     h.coin_realized_baseline = realized_pnl;
                     h.coin_realized_peak = 0.0f;
@@ -337,6 +368,28 @@ inline void update_hsl(
                         ),
                         0.9999999403953552f
                     );
+                float stop_drawdown_raw = fmax(
+                    h.pending_drawdown_raw,
+                    fmax(
+                        1.0f - h.pending_strategy_equity
+                            / fmax(h.pending_peak_strategy_equity, 1.0e-12f),
+                        0.0f
+                    )
+                );
+                h.trigger_drawdown_sum += stop_drawdown_raw;
+                h.trigger_drawdown_count += 1.0f;
+                if (h.current_red_start_k >= 0.0f) {
+                    h.flatten_time_sum_steps += fmax(
+                        h.pending_stop_k - h.current_red_start_k, 0.0f
+                    );
+                    h.flatten_time_count += 1.0f;
+                }
+                if (h.last_restart_k >= 0.0f
+                    && (h.pending_stop_k - h.last_restart_k) * interval_ms
+                        <= 86400000.0f) {
+                    h.restart_retrigger_count += 1.0f;
+                }
+                h.last_restart_k = -1.0f;
                 bool terminal = h.restart_policy == 2
                     || (h.restart_policy == 1
                         && fmax(no_restart_drawdown_raw, h.pending_drawdown_ema)
@@ -354,6 +407,15 @@ inline void update_hsl(
 inline void try_restart_hsl(thread HslState& h, float kf) {
     if (!h.enabled || !h.halted || h.no_restart_latched
         || h.cooldown_until_k < 0.0f || kf < h.cooldown_until_k) return;
+    if (h.current_halt_start_k >= 0.0f) {
+        float duration = fmax(kf - h.current_halt_start_k, 0.0f);
+        h.halt_duration_sum_steps += duration;
+        h.halt_duration_max_steps = fmax(h.halt_duration_max_steps, duration);
+        h.halt_duration_count += 1.0f;
+        h.current_halt_start_k = -1.0f;
+    }
+    h.restarts += 1.0f;
+    h.last_restart_k = kf;
     h.initialized = false;
     h.drawdown_ema = 0.0f;
     h.peak_strategy_pnl = -INFINITY;
@@ -363,6 +425,7 @@ inline void try_restart_hsl(thread HslState& h, float kf) {
     h.halted = false;
     h.cooldown_until_k = -1.0f;
     h.flat_confirmations = 0;
+    h.current_red_start_k = -1.0f;
 }
 
 inline TmSide load_side(constant float* p, int o, float seed) {
@@ -1249,6 +1312,10 @@ inline void passivbot_single_coin_impl(
     float first_eq_k = -1.0f;
     float last_eq_k = -1.0f;
     bool eq_started = false;
+    float hsl_tier_samples_total = 0.0f;
+    float hsl_tier_samples_yellow = 0.0f;
+    float hsl_tier_samples_orange = 0.0f;
+    float hsl_tier_samples_red = 0.0f;
 
     int cur_day = flags[2];
     bool day_touched = false;
@@ -2339,14 +2406,21 @@ inline void passivbot_single_coin_impl(
                 long_hsl, balance, starting_balance,
                 realized_pnl_cumsum_last,
                 long_unreal, long_side.psize > 0.0f,
-                long_blocking_orders, kf
+                long_blocking_orders, kf, interval_ms
             );
             update_hsl(
                 short_hsl, balance, starting_balance,
                 realized_pnl_cumsum_last,
                 short_unreal, short_side.psize > 0.0f,
-                short_blocking_orders, kf
+                short_blocking_orders, kf, interval_ms
             );
+            if (long_hsl.enabled || short_hsl.enabled) {
+                int hsl_tier = max(long_hsl.tier, short_hsl.tier);
+                hsl_tier_samples_total += 1.0f;
+                hsl_tier_samples_yellow += hsl_tier == 1 ? 1.0f : 0.0f;
+                hsl_tier_samples_orange += hsl_tier == 2 ? 1.0f : 0.0f;
+                hsl_tier_samples_red += hsl_tier == 3 ? 1.0f : 0.0f;
+            }
             try_restart_hsl(long_hsl, kf);
             try_restart_hsl(short_hsl, kf);
         }
@@ -2412,6 +2486,46 @@ inline void passivbot_single_coin_impl(
     scalars[so + 15] = short_side.psize;
     scalars[so + 16] = short_side.pprice;
     scalars[so + 17] = 0.0f;
+    float long_terminal_count = long_hsl.halted
+        && long_hsl.current_halt_start_k >= 0.0f && last_eq_k >= 0.0f
+        ? 1.0f : 0.0f;
+    float short_terminal_count = short_hsl.halted
+        && short_hsl.current_halt_start_k >= 0.0f && last_eq_k >= 0.0f
+        ? 1.0f : 0.0f;
+    float long_terminal_duration = long_terminal_count > 0.0f
+        ? fmax(last_eq_k - long_hsl.current_halt_start_k, 0.0f) : 0.0f;
+    float short_terminal_duration = short_terminal_count > 0.0f
+        ? fmax(last_eq_k - short_hsl.current_halt_start_k, 0.0f) : 0.0f;
+    float terminal_count = long_terminal_count + short_terminal_count;
+    scalars[so + 18] = long_hsl.enabled ? 1.0f : 0.0f;
+    scalars[so + 19] = short_hsl.enabled ? 1.0f : 0.0f;
+    scalars[so + 20] = long_hsl.triggers;
+    scalars[so + 21] = short_hsl.triggers;
+    scalars[so + 22] = long_hsl.restarts;
+    scalars[so + 23] = short_hsl.restarts;
+    scalars[so + 24] = hsl_tier_samples_total;
+    scalars[so + 25] = hsl_tier_samples_yellow;
+    scalars[so + 26] = hsl_tier_samples_orange;
+    scalars[so + 27] = hsl_tier_samples_red;
+    scalars[so + 28] = long_hsl.halt_duration_sum_steps
+        + short_hsl.halt_duration_sum_steps
+        + long_terminal_duration + short_terminal_duration;
+    scalars[so + 29] = fmax(
+        fmax(long_hsl.halt_duration_max_steps, short_hsl.halt_duration_max_steps),
+        fmax(long_terminal_duration, short_terminal_duration)
+    );
+    scalars[so + 30] = long_hsl.halt_duration_count
+        + short_hsl.halt_duration_count + terminal_count;
+    scalars[so + 31] = long_hsl.trigger_drawdown_sum
+        + short_hsl.trigger_drawdown_sum;
+    scalars[so + 32] = long_hsl.trigger_drawdown_count
+        + short_hsl.trigger_drawdown_count;
+    scalars[so + 33] = long_hsl.flatten_time_sum_steps
+        + short_hsl.flatten_time_sum_steps;
+    scalars[so + 34] = long_hsl.flatten_time_count
+        + short_hsl.flatten_time_count;
+    scalars[so + 35] = long_hsl.restart_retrigger_count
+        + short_hsl.restart_retrigger_count;
 }
 
 kernel void passivbot_trailing_martingale(

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -29,6 +29,24 @@ SUPPORTED_METRICS = (
     "fills_gap_p95_hours",
     "fills_gap_p99_hours",
     "gain_strategy_eq",
+    "hard_stop_duration_minutes_max",
+    "hard_stop_duration_minutes_mean",
+    "hard_stop_flatten_time_minutes_mean",
+    "hard_stop_post_restart_retrigger_pct",
+    "hard_stop_restarts",
+    "hard_stop_restarts_long",
+    "hard_stop_restarts_per_year",
+    "hard_stop_restarts_per_year_long",
+    "hard_stop_restarts_per_year_short",
+    "hard_stop_restarts_short",
+    "hard_stop_time_in_orange_pct",
+    "hard_stop_time_in_red_pct",
+    "hard_stop_time_in_yellow_pct",
+    "hard_stop_trigger_drawdown_mean",
+    "hard_stop_triggers",
+    "hard_stop_triggers_long",
+    "hard_stop_triggers_per_year",
+    "hard_stop_triggers_short",
     "mdg_strategy_eq",
     "mdg_strategy_eq_w",
     "omega_ratio_strategy_eq",
@@ -58,6 +76,26 @@ _FILL_GAP_HISTOGRAM_METRICS = {
     "fills_gap_median_hours",
     "fills_gap_p95_hours",
     "fills_gap_p99_hours",
+}
+_HARD_STOP_LIFECYCLE_METRICS = {
+    "hard_stop_duration_minutes_max",
+    "hard_stop_duration_minutes_mean",
+    "hard_stop_flatten_time_minutes_mean",
+    "hard_stop_post_restart_retrigger_pct",
+    "hard_stop_restarts",
+    "hard_stop_restarts_long",
+    "hard_stop_restarts_per_year",
+    "hard_stop_restarts_per_year_long",
+    "hard_stop_restarts_per_year_short",
+    "hard_stop_restarts_short",
+    "hard_stop_time_in_orange_pct",
+    "hard_stop_time_in_red_pct",
+    "hard_stop_time_in_yellow_pct",
+    "hard_stop_trigger_drawdown_mean",
+    "hard_stop_triggers",
+    "hard_stop_triggers_long",
+    "hard_stop_triggers_per_year",
+    "hard_stop_triggers_short",
 }
 # Metal classifies gaps with float32 logarithms. Expand the decoded boundary
 # by 1024 unit roundoffs so a value rounded into the preceding bin cannot make
@@ -495,6 +533,86 @@ def _weighted_strategy_eq_metrics(
     return {name: value / 10.0 for name, value in totals.items()}
 
 
+def _hard_stop_lifecycle_metrics(out: dict, run) -> dict:
+    """Reduce directional HSL counters using the authoritative Rust formulas."""
+
+    reference = out["max_dd"].to(torch.float64)
+    zeros = torch.zeros_like(reference)
+    if "hsl_triggers_long" not in out:
+        return {name: zeros for name in _HARD_STOP_LIFECYCLE_METRICS}
+
+    def value(name: str):
+        return out[name].to(torch.float64)
+
+    triggers_long = value("hsl_triggers_long")
+    triggers_short = value("hsl_triggers_short")
+    restarts_long = value("hsl_restarts_long")
+    restarts_short = value("hsl_restarts_short")
+    triggers = triggers_long + triggers_short
+    restarts = restarts_long + restarts_short
+    sample_count = value("hsl_tier_samples_total")
+    first_eq_ts = out["first_eq_ts"].to(torch.float64)
+    last_eq_ts = out["last_eq_ts"].to(torch.float64)
+    interval_days = float(run.interval_ms) / 86_400_000.0
+    timestamp_days = ((last_eq_ts - first_eq_ts) / 86_400_000.0).clamp(
+        min=interval_days
+    )
+    has_equity = (
+        torch.isfinite(first_eq_ts)
+        & torch.isfinite(last_eq_ts)
+        & (last_eq_ts >= first_eq_ts)
+    )
+    n_days = torch.where(has_equity, timestamp_days, zeros)
+    per_year_scale = torch.where(n_days > 0.0, 365.25 / n_days, zeros)
+
+    total_samples = sample_count.clamp(min=1.0)
+    duration_count = value("hsl_duration_count")
+    trigger_drawdown_count = value("hsl_trigger_drawdown_count")
+    flatten_count = value("hsl_flatten_time_count")
+    minutes_per_step = float(run.interval_ms) / 60_000.0
+
+    return {
+        "hard_stop_triggers": triggers,
+        "hard_stop_triggers_per_year": triggers * per_year_scale,
+        "hard_stop_triggers_long": triggers_long,
+        "hard_stop_triggers_short": triggers_short,
+        "hard_stop_restarts": restarts,
+        "hard_stop_restarts_per_year": restarts * per_year_scale,
+        "hard_stop_restarts_per_year_long": restarts_long * per_year_scale,
+        "hard_stop_restarts_per_year_short": restarts_short * per_year_scale,
+        "hard_stop_restarts_long": restarts_long,
+        "hard_stop_restarts_short": restarts_short,
+        "hard_stop_time_in_yellow_pct": value("hsl_tier_samples_yellow")
+        / total_samples,
+        "hard_stop_time_in_orange_pct": value("hsl_tier_samples_orange")
+        / total_samples,
+        "hard_stop_time_in_red_pct": value("hsl_tier_samples_red")
+        / total_samples,
+        "hard_stop_duration_minutes_mean": torch.where(
+            duration_count > 0.0,
+            value("hsl_duration_sum_steps") / duration_count * minutes_per_step,
+            zeros,
+        ),
+        "hard_stop_duration_minutes_max": value("hsl_duration_max_steps")
+        * minutes_per_step,
+        "hard_stop_trigger_drawdown_mean": torch.where(
+            trigger_drawdown_count > 0.0,
+            value("hsl_trigger_drawdown_sum") / trigger_drawdown_count,
+            zeros,
+        ),
+        "hard_stop_flatten_time_minutes_mean": torch.where(
+            flatten_count > 0.0,
+            value("hsl_flatten_time_sum_steps") / flatten_count * minutes_per_step,
+            zeros,
+        ),
+        "hard_stop_post_restart_retrigger_pct": torch.where(
+            restarts > 0.0,
+            value("hsl_restart_retrigger_count") / restarts,
+            zeros,
+        ),
+    }
+
+
 def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
     """Reduce compact Metal output into validated proxy objective metrics."""
 
@@ -575,6 +693,11 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
         if requested & _FILL_GAP_HISTOGRAM_METRICS
         else {}
     )
+    hard_stop_metrics = (
+        _hard_stop_lifecycle_metrics(out, run)
+        if requested & _HARD_STOP_LIFECYCLE_METRICS
+        else {}
+    )
 
     requested_start = float(run.requested_start_ts_ms)
     first_timestamp = data["ts0"]
@@ -612,6 +735,7 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
         "volume_pct_per_day_avg": volume_pct,
     }
     objectives.update(fill_gap_metrics)
+    objectives.update(hard_stop_metrics)
     objectives.update(weighted_metrics)
     if needed is None:
         return objectives

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -20,6 +20,7 @@ from optimization.gpu.model import (
 MPS_DAILY_COLS = 5
 MPS_MULTICOIN_DAILY_COLS = 6
 MPS_SCALAR_COLS = 18
+MPS_DIRECTIONAL_SCALAR_COLS = 36
 
 
 def _encode_max_realized_loss_pct(value: float) -> float:
@@ -117,6 +118,63 @@ def _decode_outputs(daily, scalars, gaps) -> dict:
         "open_positions": scalars[:, 14],
         "short_psize": scalars[:, 15],
         "short_pprice": scalars[:, 16],
+    }
+
+
+def _decode_directional_outputs(daily, scalars, gaps) -> dict:
+    active_days = torch.isfinite(daily[:, :, 1]) & (daily[:, :, 1] < float("inf"))
+
+    def timestamp_column(index: int):
+        values = scalars[:, index]
+        return torch.where(
+            values >= 0.0, values, torch.full_like(values, float("nan"))
+        )
+
+    return {
+        "day_end_eq": daily[:, :, 0],
+        "day_min_eq": torch.where(
+            active_days,
+            daily[:, :, 1],
+            torch.full_like(daily[:, :, 1], float("inf")),
+        ),
+        "day_max_dd": daily[:, :, 2],
+        "day_volume": daily[:, :, 3],
+        "day_has_fill": daily[:, :, 4] > 0.0,
+        "max_dd": scalars[:, 0],
+        "held_max_ms": scalars[:, 1],
+        "gap_hist": gaps,
+        "gap_max_ms": scalars[:, 2],
+        "first_fill_ts": timestamp_column(3),
+        "last_fill_ts": timestamp_column(4),
+        "recovery_max_ms": scalars[:, 5],
+        "last_high_ts": timestamp_column(6),
+        "first_eq_ts": timestamp_column(7),
+        "last_eq_ts": timestamp_column(8),
+        "liq_step": scalars[:, 9].to(torch.int64),
+        "balance": scalars[:, 10],
+        "psize": scalars[:, 11],
+        "pprice": scalars[:, 12],
+        "alive": scalars[:, 13] > 0.0,
+        "short_psize": scalars[:, 15],
+        "short_pprice": scalars[:, 16],
+        "hsl_long_enabled": scalars[:, 18] > 0.0,
+        "hsl_short_enabled": scalars[:, 19] > 0.0,
+        "hsl_triggers_long": scalars[:, 20],
+        "hsl_triggers_short": scalars[:, 21],
+        "hsl_restarts_long": scalars[:, 22],
+        "hsl_restarts_short": scalars[:, 23],
+        "hsl_tier_samples_total": scalars[:, 24],
+        "hsl_tier_samples_yellow": scalars[:, 25],
+        "hsl_tier_samples_orange": scalars[:, 26],
+        "hsl_tier_samples_red": scalars[:, 27],
+        "hsl_duration_sum_steps": scalars[:, 28],
+        "hsl_duration_max_steps": scalars[:, 29],
+        "hsl_duration_count": scalars[:, 30],
+        "hsl_trigger_drawdown_sum": scalars[:, 31],
+        "hsl_trigger_drawdown_count": scalars[:, 32],
+        "hsl_flatten_time_sum_steps": scalars[:, 33],
+        "hsl_flatten_time_count": scalars[:, 34],
+        "hsl_restart_retrigger_count": scalars[:, 35],
     }
 
 
@@ -234,7 +292,9 @@ class MpsEmaAnchorRunner:
                         device="mps",
                     ),
                     torch.zeros(
-                        (batch_size, MPS_SCALAR_COLS), dtype=torch.float32, device="mps"
+                        (batch_size, MPS_DIRECTIONAL_SCALAR_COLS),
+                        dtype=torch.float32,
+                        device="mps",
                     ),
                     torch.zeros(
                         (batch_size, GAP_BINS), dtype=torch.int32, device="mps"
@@ -298,42 +358,7 @@ class MpsEmaAnchorRunner:
             "pre_dispatch_sync_seconds": dispatched - compiled,
             "kernel_seconds": finished - dispatched,
         }
-        active_days = torch.isfinite(daily[:, :, 1]) & (daily[:, :, 1] < float("inf"))
-
-        def timestamp_column(index: int):
-            values = scalars[:, index]
-            return torch.where(
-                values >= 0.0, values, torch.full_like(values, float("nan"))
-            )
-
-        return {
-            "day_end_eq": daily[:, :, 0],
-            "day_min_eq": torch.where(
-                active_days,
-                daily[:, :, 1],
-                torch.full_like(daily[:, :, 1], float("inf")),
-            ),
-            "day_max_dd": daily[:, :, 2],
-            "day_volume": daily[:, :, 3],
-            "day_has_fill": daily[:, :, 4] > 0.0,
-            "max_dd": scalars[:, 0],
-            "held_max_ms": scalars[:, 1],
-            "gap_hist": gaps,
-            "gap_max_ms": scalars[:, 2],
-            "first_fill_ts": timestamp_column(3),
-            "last_fill_ts": timestamp_column(4),
-            "recovery_max_ms": scalars[:, 5],
-            "last_high_ts": timestamp_column(6),
-            "first_eq_ts": timestamp_column(7),
-            "last_eq_ts": timestamp_column(8),
-            "liq_step": scalars[:, 9].to(torch.int64),
-            "balance": scalars[:, 10],
-            "psize": scalars[:, 11],
-            "pprice": scalars[:, 12],
-            "alive": scalars[:, 13] > 0.0,
-            "short_psize": scalars[:, 15],
-            "short_pprice": scalars[:, 16],
-        }
+        return _decode_directional_outputs(daily, scalars, gaps)
 
 
 class MpsEmaAnchorMulticoinRunner:
@@ -690,41 +715,4 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             "pre_dispatch_sync_seconds": dispatched - compiled,
             "kernel_seconds": finished - dispatched,
         }
-        active_days = torch.isfinite(daily[:, :, 1]) & (
-            daily[:, :, 1] < float("inf")
-        )
-
-        def timestamp_column(index: int):
-            values = scalars[:, index]
-            return torch.where(
-                values >= 0.0, values, torch.full_like(values, float("nan"))
-            )
-
-        return {
-            "day_end_eq": daily[:, :, 0],
-            "day_min_eq": torch.where(
-                active_days,
-                daily[:, :, 1],
-                torch.full_like(daily[:, :, 1], float("inf")),
-            ),
-            "day_max_dd": daily[:, :, 2],
-            "day_volume": daily[:, :, 3],
-            "day_has_fill": daily[:, :, 4] > 0.0,
-            "max_dd": scalars[:, 0],
-            "held_max_ms": scalars[:, 1],
-            "gap_hist": gaps,
-            "gap_max_ms": scalars[:, 2],
-            "first_fill_ts": timestamp_column(3),
-            "last_fill_ts": timestamp_column(4),
-            "recovery_max_ms": scalars[:, 5],
-            "last_high_ts": timestamp_column(6),
-            "first_eq_ts": timestamp_column(7),
-            "last_eq_ts": timestamp_column(8),
-            "liq_step": scalars[:, 9].to(torch.int64),
-            "balance": scalars[:, 10],
-            "psize": scalars[:, 11],
-            "pprice": scalars[:, 12],
-            "alive": scalars[:, 13] > 0.0,
-            "short_psize": scalars[:, 15],
-            "short_pprice": scalars[:, 16],
-        }
+        return _decode_directional_outputs(daily, scalars, gaps)

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -11,6 +11,7 @@ from optimization.gpu.metrics import (
     SUPPORTED_METRICS,
     _GAP_HIST_UPPER_STEPS,
     _fill_gap_metrics,
+    _hard_stop_lifecycle_metrics,
     _masked_median,
     _mean_worst_one_pct_abs,
     _omega_ratio,
@@ -188,6 +189,107 @@ def test_strategy_equity_summary_metric_surface_is_supported():
         "sterling_ratio_strategy_eq",
         "strategy_eq_underwater_pct_median",
     } <= set(SUPPORTED_METRICS)
+
+
+def test_hard_stop_lifecycle_metric_surface_is_supported():
+    assert {
+        "hard_stop_triggers",
+        "hard_stop_triggers_per_year",
+        "hard_stop_triggers_long",
+        "hard_stop_triggers_short",
+        "hard_stop_restarts",
+        "hard_stop_restarts_per_year",
+        "hard_stop_restarts_per_year_long",
+        "hard_stop_restarts_per_year_short",
+        "hard_stop_restarts_long",
+        "hard_stop_restarts_short",
+        "hard_stop_time_in_yellow_pct",
+        "hard_stop_time_in_orange_pct",
+        "hard_stop_time_in_red_pct",
+        "hard_stop_duration_minutes_mean",
+        "hard_stop_duration_minutes_max",
+        "hard_stop_trigger_drawdown_mean",
+        "hard_stop_flatten_time_minutes_mean",
+        "hard_stop_post_restart_retrigger_pct",
+    } <= set(SUPPORTED_METRICS)
+    assert {
+        "hard_stop_halt_to_restart_equity_loss_pct",
+        "hard_stop_panic_close_loss_sum",
+        "hard_stop_panic_close_loss_max",
+        "hard_stop_panic_close_loss_drawdown_pct_min",
+        "hard_stop_panic_close_loss_drawdown_pct_mean",
+        "hard_stop_panic_close_loss_drawdown_pct_max",
+        "drawdown_worst_ema_strategy_eq",
+    }.isdisjoint(SUPPORTED_METRICS)
+
+
+def test_hard_stop_lifecycle_reduction_matches_rust_formulas():
+    out = {
+        "day_end_eq": torch.zeros((2, 1), dtype=torch.float32),
+        "max_dd": torch.zeros(2, dtype=torch.float32),
+        "first_eq_ts": torch.tensor([0.0, 0.0]),
+        "last_eq_ts": torch.tensor([86_400_000.0, 0.0]),
+        "hsl_triggers_long": torch.tensor([2.0, 0.0]),
+        "hsl_triggers_short": torch.tensor([1.0, 0.0]),
+        "hsl_restarts_long": torch.tensor([1.0, 0.0]),
+        "hsl_restarts_short": torch.tensor([1.0, 0.0]),
+        "hsl_tier_samples_total": torch.tensor([1441.0, 1.0]),
+        "hsl_tier_samples_yellow": torch.tensor([144.0, 0.0]),
+        "hsl_tier_samples_orange": torch.tensor([288.0, 0.0]),
+        "hsl_tier_samples_red": torch.tensor([720.0, 0.0]),
+        "hsl_duration_sum_steps": torch.tensor([45.0, 0.0]),
+        "hsl_duration_max_steps": torch.tensor([30.0, 0.0]),
+        "hsl_duration_count": torch.tensor([3.0, 0.0]),
+        "hsl_trigger_drawdown_sum": torch.tensor([0.9, 0.0]),
+        "hsl_trigger_drawdown_count": torch.tensor([3.0, 0.0]),
+        "hsl_flatten_time_sum_steps": torch.tensor([9.0, 0.0]),
+        "hsl_flatten_time_count": torch.tensor([3.0, 0.0]),
+        "hsl_restart_retrigger_count": torch.tensor([1.0, 0.0]),
+    }
+
+    metrics = _hard_stop_lifecycle_metrics(
+        out, SimpleNamespace(interval_ms=60_000)
+    )
+
+    assert metrics["hard_stop_triggers"].tolist() == [3.0, 0.0]
+    assert metrics["hard_stop_triggers_per_year"].tolist() == pytest.approx(
+        [3.0 * 365.25, 0.0]
+    )
+    assert metrics["hard_stop_restarts"].tolist() == [2.0, 0.0]
+    assert metrics["hard_stop_restarts_per_year_long"].tolist() == pytest.approx(
+        [365.25, 0.0]
+    )
+    assert metrics["hard_stop_restarts_per_year_short"].tolist() == pytest.approx(
+        [365.25, 0.0]
+    )
+    assert metrics["hard_stop_time_in_yellow_pct"][0].item() == pytest.approx(
+        144.0 / 1441.0
+    )
+    assert metrics["hard_stop_time_in_orange_pct"][0].item() == pytest.approx(
+        288.0 / 1441.0
+    )
+    assert metrics["hard_stop_time_in_red_pct"][0].item() == pytest.approx(
+        720.0 / 1441.0
+    )
+    assert metrics["hard_stop_duration_minutes_mean"].tolist() == [15.0, 0.0]
+    assert metrics["hard_stop_duration_minutes_max"].tolist() == [30.0, 0.0]
+    assert metrics["hard_stop_trigger_drawdown_mean"].tolist() == pytest.approx(
+        [0.3, 0.0]
+    )
+    assert metrics["hard_stop_flatten_time_minutes_mean"].tolist() == [3.0, 0.0]
+    assert metrics["hard_stop_post_restart_retrigger_pct"].tolist() == [0.5, 0.0]
+
+
+def test_hard_stop_lifecycle_metrics_are_zero_without_directional_hsl_outputs():
+    metrics = _hard_stop_lifecycle_metrics(
+        {"max_dd": torch.tensor([0.1, 0.2])},
+        SimpleNamespace(interval_ms=60_000),
+    )
+
+    assert set(metrics) == {
+        name for name in SUPPORTED_METRICS if name.startswith("hard_stop_")
+    }
+    assert all(metric.tolist() == [0.0, 0.0] for metric in metrics.values())
 
 
 def test_weighted_strategy_equity_metric_surface_is_supported():

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -375,7 +375,9 @@ def test_mps_ema_anchor_shader_smoke():
     assert "float32_floor_nonnegative" in source
     assert "record_realized_net" in source
     assert "const float max_realized_loss_pct = settings[14]" in source
-    assert "constant int SCALAR_COLS = 18" in source
+    assert "constant int SCALAR_COLS = 36" in source
+    assert "hsl_tier_samples_total" in source
+    assert "h.restart_retrigger_count" in source
     assert "side.psize * price_now * c_mult / balance" in source
     assert "short_side.psize * c_mult * (short_side.pprice - close)" in source
     assert "long_close_fill || long_entry_fill" in source
@@ -1328,6 +1330,23 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
         output["balance"][1].item(), abs=1.0e-4
     )
     assert output["day_volume"][1].sum().item() > 1.0
+    trigger_key = f"hsl_triggers_{side}"
+    other_trigger_key = (
+        "hsl_triggers_short" if side == "long" else "hsl_triggers_long"
+    )
+    restart_key = f"hsl_restarts_{side}"
+    assert output[trigger_key][0].item() == 0.0
+    assert output[trigger_key][1].item() == 1.0
+    assert output[other_trigger_key][1].item() == 0.0
+    assert output[restart_key][1].item() == 0.0
+    assert output[restart_key][2].item() >= 1.0
+    assert output["hsl_tier_samples_total"][1].item() > 0.0
+    assert output["hsl_tier_samples_red"][1].item() > 0.0
+    assert output["hsl_duration_count"][1].item() == 1.0
+    assert output["hsl_duration_max_steps"][1].item() > 0.0
+    assert output["hsl_trigger_drawdown_sum"][1].item() > 0.0
+    assert output["hsl_trigger_drawdown_count"][1].item() == 1.0
+    assert output["hsl_flatten_time_count"][1].item() == 1.0
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary
- add compact HSL lifecycle counters and accumulators to the one-sided single-coin EMA Anchor and Trailing Martingale Metal kernels
- expose 18 non-loss HSL lifecycle metrics for GPU scoring and limits using Rust-equivalent reductions
- preserve exact Rust validation/drift authority and keep panic-loss plus HSL EMA/recovery time-series metrics fail closed
- keep multicoin Metal buffer contracts unchanged; HSL-disabled topologies reduce lifecycle metrics to exact zero

## Lifecycle contract
- tier occupancy is sampled after HSL update and before restart
- triggers finalize on the second flat confirmation
- halt duration finalizes on restart or at the terminal equity timestamp
- flatten time anchors at RED entry and the first flat confirmation
- retriggers are classified within 24 hours of the previous restart
- per-year rates use the authoritative equity timestamp span

## Validation
- `python -m pytest -q tests/optimization`
- `python -m pytest -q tests/optimization/test_gpu_metrics.py tests/optimization/test_gpu_backend.py` (342 passed)
- physical M3: `python -m pytest -q tests/optimization/test_gpu_mps.py` (184 passed)
- `cargo fmt --check`
- `cargo check --tests`
- `cargo test --no-default-features` (262 passed)
- rebuilt and runtime-stamped the Python Rust extension before integration/MPS tests

## Scope
Additive GPU optimizer support only. CPU optimization, live trading, and ordinary Rust backtesting paths are unchanged.