### PR TITLE
feat(optimize): add MPS HSL panic loss metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ All notable user-facing changes will be documented in this file.
   min/mean/max, and halt-to-restart equity loss. The proxy tags only HSL panic fills and retains
   exact Rust validation and drift gates as authoritative. Trailing Martingale panic closes now
   remain one exclusive full-position order and bypass the ordinary realized-loss gate, matching
-  Rust instead of being reinterpreted as recursive close-grid rungs.
+  Rust instead of being reinterpreted as recursive close-grid rungs. Directional proxy filtering
+  retains every HSL lifecycle and panic-loss accumulator; missing directional output and requests
+  for these metrics on multi-coin kernels fail closed instead of substituting zeros.
 
 - Added non-loss HSL lifecycle scoring and limit metrics to the supported one-sided single-coin
   Apple MPS optimizer path: trigger/restart counts and yearly rates, warning-tier occupancy, halt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,17 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added resting-limit HSL panic-loss scoring and limit metrics to the supported one-sided
+  single-coin Apple MPS optimizer path: panic-close loss sum/max, per-episode loss drawdown
+  min/mean/max, and halt-to-restart equity loss. The proxy tags only HSL panic fills and retains
+  exact Rust validation and drift gates as authoritative. Trailing Martingale panic closes now
+  remain one exclusive full-position order and bypass the ordinary realized-loss gate, matching
+  Rust instead of being reinterpreted as recursive close-grid rungs.
+
 - Added non-loss HSL lifecycle scoring and limit metrics to the supported one-sided single-coin
   Apple MPS optimizer path: trigger/restart counts and yearly rates, warning-tier occupancy, halt
   and flatten durations, trigger drawdown, and post-restart retriggers. Exact Rust validation and
-  drift gates remain authoritative; panic-loss and HSL strategy-equity time-series metrics remain
-  fail closed.
+  drift gates remain authoritative; HSL strategy-equity time-series metrics remain fail closed.
 
 - Added the first HSL slice to Apple MPS optimization for one-sided single-coin EMA Anchor and
   Trailing Martingale runs, in both long and short directions and compatible suites. The Metal
@@ -17,8 +23,8 @@ All notable user-facing changes will be documented in this file.
   flat confirmation; positive-cooldown restart; zero-cooldown indefinite halt; cumulative
   no-restart peak tracking; effective coin-slot scaling; and terminal no-restart. The initial
   slice requires all-history PnL peaks and contiguous valid candles. Market panic execution,
-  finite rolling PnL lookbacks, dual-side and multi-coin HSL, per-coin HSL overrides, panic-loss
-  metrics, and HSL strategy-equity time-series metrics remain fail closed.
+  finite rolling PnL lookbacks, dual-side and multi-coin HSL, per-coin HSL overrides, and HSL
+  strategy-equity time-series metrics remain fail closed.
 
 - Added auto-unstuck to Apple MPS EMA Anchor and Trailing Martingale optimization for single-coin
   long-only, short-only, dual-side hedge/one-way, and compatible suite runs, plus one-sided

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -145,10 +145,11 @@ The supported slice is intentionally narrow:
   the float32-unrepresentable interval immediately below `1.0` fail closed. Exact validation and
   drift gates remain authoritative. The non-loss HSL lifecycle metrics (trigger/restart counts and
   yearly rates, time in each warning tier, halt and flatten durations, trigger drawdown, and
-  post-restart retriggers) may be used for scoring and limits. Market panic closes, finite rolling
-  PnL lookbacks, dual-side and multi-coin HSL, per-coin HSL overrides, panic-loss metrics, and
-  HSL strategy-equity EMA/recovery-distribution metrics remain fail closed for now. Compatible
-  single-coin suites may use the supported topology.
+  post-restart retriggers) and resting-limit panic-loss metrics (loss sum/max, per-episode loss
+  drawdown min/mean/max, and halt-to-restart equity loss) may be used for scoring and limits.
+  Market panic closes, finite rolling PnL lookbacks, dual-side and multi-coin HSL, per-coin HSL
+  overrides, and HSL strategy-equity EMA/recovery-distribution metrics remain fail closed for now.
+  Compatible single-coin suites may use the supported topology.
 - single-coin EMA Anchor and Trailing Martingale support auto-unstuck for long-only,
   short-only, hedge-mode dual-side, one-way, and compatible suite runs. One-sided multi-coin runs
   and compatible suites also support auto-unstuck, including static per-coin overrides. Metal

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -42,7 +42,7 @@ mod tests {
         let source = mps_ema_anchor_source();
         assert!(source.contains("kernel void passivbot_ema_anchor"));
         assert!(source.contains("constant int DAILY_COLS = 5"));
-        assert!(source.contains("constant int SCALAR_COLS = 36"));
+        assert!(source.contains("constant int SCALAR_COLS = 43"));
         assert!(source.contains("constant int SIDE_PARAMS = 34"));
         assert!(source.contains("struct HslState"));
         assert!(source.contains("update_hsl("));
@@ -50,6 +50,8 @@ mod tests {
         assert!(source.contains("hsl_tier_samples_total"));
         assert!(source.contains("h.restart_retrigger_count"));
         assert!(source.contains("h.halt_duration_sum_steps"));
+        assert!(source.contains("record_hsl_panic_fill("));
+        assert!(source.contains("h.panic_loss_drawdown_sum"));
         assert!(source.contains("h.slot_count"));
         assert!(source.contains("h.no_restart_peak_strategy_equity"));
         assert!(source.contains("terminal || h.cooldown_minutes <= 0.0f"));
@@ -131,10 +133,16 @@ mod tests {
         assert!(source.contains("struct HslState"));
         assert!(source.contains("update_hsl("));
         assert!(source.contains("try_restart_hsl("));
-        assert!(source.contains("constant int SCALAR_COLS = 36"));
+        assert!(source.contains("constant int SCALAR_COLS = 43"));
         assert!(source.contains("hsl_tier_samples_total"));
         assert!(source.contains("h.restart_retrigger_count"));
         assert!(source.contains("h.halt_duration_sum_steps"));
+        assert!(source.contains("record_hsl_panic_fill("));
+        assert!(source.contains("h.panic_loss_drawdown_sum"));
+        assert!(source.contains("&& !long_side.close_is_panic"));
+        assert!(source.contains("&& !short_side.close_is_panic"));
+        assert!(source.contains("if (!long_side.close_is_panic"));
+        assert!(source.contains("if (!short_side.close_is_panic"));
         assert!(source.contains("h.slot_count"));
         assert!(source.contains("h.no_restart_peak_strategy_equity"));
         assert!(source.contains("terminal || h.cooldown_minutes <= 0.0f"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -2,7 +2,7 @@
 using namespace metal;
 
 constant int DAILY_COLS = 5;
-constant int SCALAR_COLS = 36;
+constant int SCALAR_COLS = 43;
 constant int GAP_BINS = 128;
 constant int SIDE_PARAMS = 34;
 
@@ -112,6 +112,7 @@ struct EmaSide {
     int close_without_reducer_ticks;
     float close_without_reducer_qty;
     bool close_is_protective_reducer;
+    bool close_is_panic;
 };
 
 struct ReducerVariant {
@@ -166,6 +167,16 @@ struct HslState {
     float flatten_time_sum_steps;
     float flatten_time_count;
     float restart_retrigger_count;
+    float equity_at_halt;
+    float halt_to_restart_equity_loss;
+    float panic_event_start_equity;
+    float panic_event_loss;
+    float panic_close_loss_sum;
+    float panic_close_loss_max;
+    float panic_loss_drawdown_min;
+    float panic_loss_drawdown_sum;
+    float panic_loss_drawdown_max;
+    float panic_loss_drawdown_count;
 };
 
 inline HslState load_hsl(constant float* params, int po) {
@@ -212,6 +223,16 @@ inline HslState load_hsl(constant float* params, int po) {
     h.flatten_time_sum_steps = 0.0f;
     h.flatten_time_count = 0.0f;
     h.restart_retrigger_count = 0.0f;
+    h.equity_at_halt = 0.0f;
+    h.halt_to_restart_equity_loss = 0.0f;
+    h.panic_event_start_equity = -1.0f;
+    h.panic_event_loss = 0.0f;
+    h.panic_close_loss_sum = 0.0f;
+    h.panic_close_loss_max = 0.0f;
+    h.panic_loss_drawdown_min = 0.0f;
+    h.panic_loss_drawdown_sum = 0.0f;
+    h.panic_loss_drawdown_max = 0.0f;
+    h.panic_loss_drawdown_count = 0.0f;
     return h;
 }
 
@@ -293,6 +314,7 @@ inline void update_hsl(
                 h.halted = true;
                 h.current_halt_start_k = h.pending_stop_k;
                 h.triggers += 1.0f;
+                h.equity_at_halt = strategy_equity;
                 if (h.signal_coin) {
                     h.coin_realized_baseline = realized_pnl;
                     h.coin_realized_peak = 0.0f;
@@ -336,6 +358,23 @@ inline void update_hsl(
                     h.restart_retrigger_count += 1.0f;
                 }
                 h.last_restart_k = -1.0f;
+                if (h.panic_event_start_equity >= 0.0f) {
+                    float loss_drawdown = fmax(
+                        h.panic_event_loss
+                            / fmax(h.panic_event_start_equity, 1.0e-12f),
+                        0.0f
+                    );
+                    h.panic_loss_drawdown_min = h.panic_loss_drawdown_count > 0.0f
+                        ? fmin(h.panic_loss_drawdown_min, loss_drawdown)
+                        : loss_drawdown;
+                    h.panic_loss_drawdown_sum += loss_drawdown;
+                    h.panic_loss_drawdown_max = fmax(
+                        h.panic_loss_drawdown_max, loss_drawdown
+                    );
+                    h.panic_loss_drawdown_count += 1.0f;
+                    h.panic_event_start_equity = -1.0f;
+                    h.panic_event_loss = 0.0f;
+                }
                 bool terminal = h.restart_policy == 2
                     || (h.restart_policy == 1
                         && fmax(no_restart_drawdown_raw, h.pending_drawdown_ema)
@@ -350,7 +389,7 @@ inline void update_hsl(
     }
 }
 
-inline void try_restart_hsl(thread HslState& h, float kf) {
+inline void try_restart_hsl(thread HslState& h, float kf, float current_equity) {
     if (!h.enabled || !h.halted || h.no_restart_latched
         || h.cooldown_until_k < 0.0f || kf < h.cooldown_until_k) return;
     if (h.current_halt_start_k >= 0.0f) {
@@ -361,6 +400,11 @@ inline void try_restart_hsl(thread HslState& h, float kf) {
         h.current_halt_start_k = -1.0f;
     }
     h.restarts += 1.0f;
+    if (!h.signal_coin && h.equity_at_halt > 0.0f) {
+        h.halt_to_restart_equity_loss += fmax(
+            h.equity_at_halt - current_equity, 0.0f
+        );
+    }
     h.last_restart_k = kf;
     h.initialized = false;
     h.drawdown_ema = 0.0f;
@@ -372,6 +416,20 @@ inline void try_restart_hsl(thread HslState& h, float kf) {
     h.cooldown_until_k = -1.0f;
     h.flat_confirmations = 0;
     h.current_red_start_k = -1.0f;
+}
+
+inline void record_hsl_panic_fill(
+    thread HslState& h,
+    float net_pnl,
+    float current_equity
+) {
+    if (h.panic_event_start_equity < 0.0f) {
+        h.panic_event_start_equity = fmax(current_equity, 1.0e-12f);
+    }
+    float panic_loss = fmax(-net_pnl, 0.0f);
+    h.panic_event_loss += panic_loss;
+    h.panic_close_loss_sum += panic_loss;
+    h.panic_close_loss_max = fmax(h.panic_close_loss_max, panic_loss);
 }
 
 inline EmaSide load_side(constant float* params, int po, float seed_close) {
@@ -436,6 +494,7 @@ inline EmaSide load_side(constant float* params, int po, float seed_close) {
     side.close_without_reducer_ticks = 0;
     side.close_without_reducer_qty = 0.0f;
     side.close_is_protective_reducer = false;
+    side.close_is_panic = false;
     return side;
 }
 
@@ -1117,6 +1176,14 @@ inline void passivbot_single_coin_impl(
             float pnl = adj * c_mult * (cp - long_side.pprice);
             float fee = adj * cp * c_mult * maker_fee;
             float net_pnl = pnl - fee;
+            if (!use_secondary && long_side.close_is_panic) {
+                float current_equity = balance
+                    + long_side.psize * c_mult * (close - long_side.pprice)
+                    + (short_side.psize > 0.0f
+                        ? short_side.psize * c_mult * (short_side.pprice - close)
+                        : 0.0f);
+                record_hsl_panic_fill(long_hsl, net_pnl, current_equity);
+            }
             balance += net_pnl;
             record_realized_net(
                 net_pnl, realized_pnl_cumsum_last, realized_pnl_cumsum_max
@@ -1189,6 +1256,14 @@ inline void passivbot_single_coin_impl(
             float pnl = adj * c_mult * (short_side.pprice - cp);
             float fee = adj * cp * c_mult * maker_fee;
             float net_pnl = pnl - fee;
+            if (!use_secondary && short_side.close_is_panic) {
+                float current_equity = balance
+                    + (long_side.psize > 0.0f
+                        ? long_side.psize * c_mult * (close - long_side.pprice)
+                        : 0.0f)
+                    + short_side.psize * c_mult * (short_side.pprice - close);
+                record_hsl_panic_fill(short_hsl, net_pnl, current_equity);
+            }
             balance += net_pnl;
             record_realized_net(
                 net_pnl, realized_pnl_cumsum_last, realized_pnl_cumsum_max
@@ -1265,6 +1340,8 @@ inline void passivbot_single_coin_impl(
         int long_hsl_mode = hsl_mode(long_hsl, long_side.psize > 0.0f);
         int short_hsl_mode = hsl_mode(short_hsl, short_side.psize > 0.0f);
         if (gen) {
+            long_side.close_is_panic = false;
+            short_side.close_is_panic = false;
             // When both sides are flat, an exact Rust path that remains alive has
             // balance above liq_floor. If either side is open, equity cannot bound
             // exact cash balance, so flat-side eligibility uses zero and fails closed.
@@ -1478,12 +1555,14 @@ inline void passivbot_single_coin_impl(
                 long_side.close_qty = long_side.psize;
                 long_side.secondary_close_qty = 0.0f;
                 long_side.close_is_protective_reducer = false;
+                long_side.close_is_panic = true;
             }
             if (short_enabled && short_hsl_mode == 3) {
                 short_side.close_ticks = max(touch_up_tick + 1, 1);
                 short_side.close_qty = short_side.psize;
                 short_side.secondary_close_qty = 0.0f;
                 short_side.close_is_protective_reducer = false;
+                short_side.close_is_panic = true;
             }
         }
 
@@ -1520,8 +1599,8 @@ inline void passivbot_single_coin_impl(
                 hsl_tier_samples_orange += hsl_tier == 2 ? 1.0f : 0.0f;
                 hsl_tier_samples_red += hsl_tier == 3 ? 1.0f : 0.0f;
             }
-            try_restart_hsl(long_hsl, kf);
-            try_restart_hsl(short_hsl, kf);
+            try_restart_hsl(long_hsl, kf, equity);
+            try_restart_hsl(short_hsl, kf, equity);
         }
         bool active = eq_started && alive && valid;
         if (active) {
@@ -1625,6 +1704,31 @@ inline void passivbot_single_coin_impl(
         + short_hsl.flatten_time_count;
     scalars[so + 35] = long_hsl.restart_retrigger_count
         + short_hsl.restart_retrigger_count;
+    float panic_drawdown_count = long_hsl.panic_loss_drawdown_count
+        + short_hsl.panic_loss_drawdown_count;
+    float panic_drawdown_min = long_hsl.panic_loss_drawdown_count > 0.0f
+        ? (short_hsl.panic_loss_drawdown_count > 0.0f
+            ? fmin(
+                long_hsl.panic_loss_drawdown_min,
+                short_hsl.panic_loss_drawdown_min
+            ) : long_hsl.panic_loss_drawdown_min)
+        : (short_hsl.panic_loss_drawdown_count > 0.0f
+            ? short_hsl.panic_loss_drawdown_min : 0.0f);
+    scalars[so + 36] = long_hsl.halt_to_restart_equity_loss
+        + short_hsl.halt_to_restart_equity_loss;
+    scalars[so + 37] = long_hsl.panic_close_loss_sum
+        + short_hsl.panic_close_loss_sum;
+    scalars[so + 38] = fmax(
+        long_hsl.panic_close_loss_max, short_hsl.panic_close_loss_max
+    );
+    scalars[so + 39] = panic_drawdown_min;
+    scalars[so + 40] = long_hsl.panic_loss_drawdown_sum
+        + short_hsl.panic_loss_drawdown_sum;
+    scalars[so + 41] = fmax(
+        long_hsl.panic_loss_drawdown_max,
+        short_hsl.panic_loss_drawdown_max
+    );
+    scalars[so + 42] = panic_drawdown_count;
 }
 
 kernel void passivbot_ema_anchor(

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -2,7 +2,7 @@
 using namespace metal;
 
 constant int DAILY_COLS = 5;
-constant int SCALAR_COLS = 36;
+constant int SCALAR_COLS = 43;
 constant int GAP_BINS = 128;
 constant int SIDE_PARAMS = 51;
 
@@ -156,6 +156,7 @@ struct TmSide {
     bool close_is_exposure_reducer, close_is_twel_reducer;
     bool close_is_unstuck_reducer;
     bool close_loss_gate_disabled_reducers;
+    bool close_is_panic;
     float ema0, ema1, ema2, vol1m, vol1h;
     float psize, pprice, last_inc_k, pos_open_k;
     int entry_ticks, close_ticks, secondary_close_ticks;
@@ -220,6 +221,16 @@ struct HslState {
     float flatten_time_sum_steps;
     float flatten_time_count;
     float restart_retrigger_count;
+    float equity_at_halt;
+    float halt_to_restart_equity_loss;
+    float panic_event_start_equity;
+    float panic_event_loss;
+    float panic_close_loss_sum;
+    float panic_close_loss_max;
+    float panic_loss_drawdown_min;
+    float panic_loss_drawdown_sum;
+    float panic_loss_drawdown_max;
+    float panic_loss_drawdown_count;
 };
 
 inline HslState load_hsl(constant float* params, int po) {
@@ -266,6 +277,16 @@ inline HslState load_hsl(constant float* params, int po) {
     h.flatten_time_sum_steps = 0.0f;
     h.flatten_time_count = 0.0f;
     h.restart_retrigger_count = 0.0f;
+    h.equity_at_halt = 0.0f;
+    h.halt_to_restart_equity_loss = 0.0f;
+    h.panic_event_start_equity = -1.0f;
+    h.panic_event_loss = 0.0f;
+    h.panic_close_loss_sum = 0.0f;
+    h.panic_close_loss_max = 0.0f;
+    h.panic_loss_drawdown_min = 0.0f;
+    h.panic_loss_drawdown_sum = 0.0f;
+    h.panic_loss_drawdown_max = 0.0f;
+    h.panic_loss_drawdown_count = 0.0f;
     return h;
 }
 
@@ -347,6 +368,7 @@ inline void update_hsl(
                 h.halted = true;
                 h.current_halt_start_k = h.pending_stop_k;
                 h.triggers += 1.0f;
+                h.equity_at_halt = strategy_equity;
                 if (h.signal_coin) {
                     h.coin_realized_baseline = realized_pnl;
                     h.coin_realized_peak = 0.0f;
@@ -390,6 +412,23 @@ inline void update_hsl(
                     h.restart_retrigger_count += 1.0f;
                 }
                 h.last_restart_k = -1.0f;
+                if (h.panic_event_start_equity >= 0.0f) {
+                    float loss_drawdown = fmax(
+                        h.panic_event_loss
+                            / fmax(h.panic_event_start_equity, 1.0e-12f),
+                        0.0f
+                    );
+                    h.panic_loss_drawdown_min = h.panic_loss_drawdown_count > 0.0f
+                        ? fmin(h.panic_loss_drawdown_min, loss_drawdown)
+                        : loss_drawdown;
+                    h.panic_loss_drawdown_sum += loss_drawdown;
+                    h.panic_loss_drawdown_max = fmax(
+                        h.panic_loss_drawdown_max, loss_drawdown
+                    );
+                    h.panic_loss_drawdown_count += 1.0f;
+                    h.panic_event_start_equity = -1.0f;
+                    h.panic_event_loss = 0.0f;
+                }
                 bool terminal = h.restart_policy == 2
                     || (h.restart_policy == 1
                         && fmax(no_restart_drawdown_raw, h.pending_drawdown_ema)
@@ -404,7 +443,7 @@ inline void update_hsl(
     }
 }
 
-inline void try_restart_hsl(thread HslState& h, float kf) {
+inline void try_restart_hsl(thread HslState& h, float kf, float current_equity) {
     if (!h.enabled || !h.halted || h.no_restart_latched
         || h.cooldown_until_k < 0.0f || kf < h.cooldown_until_k) return;
     if (h.current_halt_start_k >= 0.0f) {
@@ -415,6 +454,11 @@ inline void try_restart_hsl(thread HslState& h, float kf) {
         h.current_halt_start_k = -1.0f;
     }
     h.restarts += 1.0f;
+    if (!h.signal_coin && h.equity_at_halt > 0.0f) {
+        h.halt_to_restart_equity_loss += fmax(
+            h.equity_at_halt - current_equity, 0.0f
+        );
+    }
     h.last_restart_k = kf;
     h.initialized = false;
     h.drawdown_ema = 0.0f;
@@ -426,6 +470,34 @@ inline void try_restart_hsl(thread HslState& h, float kf) {
     h.cooldown_until_k = -1.0f;
     h.flat_confirmations = 0;
     h.current_red_start_k = -1.0f;
+}
+
+inline void record_hsl_panic_fill(
+    thread HslState& h,
+    float net_pnl,
+    float current_equity
+) {
+    if (h.panic_event_start_equity < 0.0f) {
+        h.panic_event_start_equity = fmax(current_equity, 1.0e-12f);
+    }
+    float panic_loss = fmax(-net_pnl, 0.0f);
+    h.panic_event_loss += panic_loss;
+    h.panic_close_loss_sum += panic_loss;
+    h.panic_close_loss_max = fmax(h.panic_close_loss_max, panic_loss);
+}
+
+inline float directional_equity_at_close(
+    float balance,
+    thread TmSide& long_side,
+    thread TmSide& short_side,
+    float close,
+    float c_mult
+) {
+    return balance
+        + (long_side.psize > 0.0f
+            ? long_side.psize * c_mult * (close - long_side.pprice) : 0.0f)
+        + (short_side.psize > 0.0f
+            ? short_side.psize * c_mult * (short_side.pprice - close) : 0.0f);
 }
 
 inline TmSide load_side(constant float* p, int o, float seed) {
@@ -490,6 +562,7 @@ inline TmSide load_side(constant float* p, int o, float seed) {
     s.close_is_twel_reducer = false;
     s.close_is_unstuck_reducer = false;
     s.close_loss_gate_disabled_reducers = false;
+    s.close_is_panic = false;
     s.ema0 = seed; s.ema1 = seed; s.ema2 = seed;
     s.vol1m = 0.0f; s.vol1h = 0.0f;
     s.psize = 0.0f; s.pprice = 0.0f;
@@ -1404,7 +1477,8 @@ inline void passivbot_single_coin_impl(
             long_scan_close_grid = long_scan_close_grid
                 || nearest_ticks <= high_fill_max_tick;
         }
-        if (long_scan_close_grid && long_recursive_close) {
+        if (long_scan_close_grid && long_recursive_close
+            && !long_side.close_is_panic) {
             TmSide grid_source = long_side;
             if (long_side.close_loss_gate_disabled_reducers) {
                 grid_source.wel_enforcer_enabled = false;
@@ -1565,6 +1639,14 @@ inline void passivbot_single_coin_impl(
                             max_realized_loss_pct)) {
                         reducer_reachable = false;
                     } else {
+                        if (long_side.close_is_panic) {
+                            record_hsl_panic_fill(
+                                long_hsl, pnl - fee,
+                                directional_equity_at_close(
+                                    balance, long_side, short_side, close, c_mult
+                                )
+                            );
+                        }
                         balance += pnl - fee;
                         record_realized_net(
                             pnl - fee,
@@ -1591,6 +1673,14 @@ inline void passivbot_single_coin_impl(
                 if (!realized_loss_proxy_allows_close(
                         adj, group.price, long_side.pprice, true,
                         c_mult, maker_fee, loss_gate_enabled)) continue;
+                if (long_side.close_is_panic) {
+                    record_hsl_panic_fill(
+                        long_hsl, pnl - fee,
+                        directional_equity_at_close(
+                            balance, long_side, short_side, close, c_mult
+                        )
+                    );
+                }
                 balance += pnl - fee;
                 record_realized_net(
                     pnl - fee,
@@ -1628,6 +1718,14 @@ inline void passivbot_single_coin_impl(
                         realized_pnl_cumsum_last,
                         realized_pnl_cumsum_max,
                         max_realized_loss_pct)) {
+                    if (long_side.close_is_panic) {
+                        record_hsl_panic_fill(
+                            long_hsl, pnl - fee,
+                            directional_equity_at_close(
+                                balance, long_side, short_side, close, c_mult
+                            )
+                        );
+                    }
                     balance += pnl - fee;
                     record_realized_net(
                         pnl - fee,
@@ -1673,12 +1771,21 @@ inline void passivbot_single_coin_impl(
                 float fee = adj * cp * c_mult * maker_fee;
                 bool selected_unstuck = !use_secondary
                     && long_side.close_is_unstuck_reducer;
-                if (!realized_loss_proxy_allows_reducer(
+                if (!long_side.close_is_panic
+                    && !realized_loss_proxy_allows_reducer(
                         adj, cp, long_side.pprice, true, selected_unstuck,
                         c_mult, maker_fee, loss_gate_enabled, balance,
                         realized_pnl_cumsum_last,
                         realized_pnl_cumsum_max,
                         max_realized_loss_pct)) continue;
+                if (!use_secondary && long_side.close_is_panic) {
+                    record_hsl_panic_fill(
+                        long_hsl, pnl - fee,
+                        directional_equity_at_close(
+                            balance, long_side, short_side, close, c_mult
+                        )
+                    );
+                }
                 balance += pnl - fee;
                 record_realized_net(
                     pnl - fee,
@@ -1799,7 +1906,8 @@ inline void passivbot_single_coin_impl(
             short_scan_close_grid = short_scan_close_grid
                 || nearest_ticks > low_nonfill_max_tick;
         }
-        if (short_scan_close_grid && short_recursive_close) {
+        if (short_scan_close_grid && short_recursive_close
+            && !short_side.close_is_panic) {
             TmSide grid_source = short_side;
             if (short_side.close_loss_gate_disabled_reducers) {
                 grid_source.wel_enforcer_enabled = false;
@@ -1960,6 +2068,14 @@ inline void passivbot_single_coin_impl(
                             max_realized_loss_pct)) {
                         reducer_reachable = false;
                     } else {
+                        if (short_side.close_is_panic) {
+                            record_hsl_panic_fill(
+                                short_hsl, pnl - fee,
+                                directional_equity_at_close(
+                                    balance, long_side, short_side, close, c_mult
+                                )
+                            );
+                        }
                         balance += pnl - fee;
                         record_realized_net(
                             pnl - fee,
@@ -1986,6 +2102,14 @@ inline void passivbot_single_coin_impl(
                 if (!realized_loss_proxy_allows_close(
                         adj, group.price, short_side.pprice, false,
                         c_mult, maker_fee, loss_gate_enabled)) continue;
+                if (short_side.close_is_panic) {
+                    record_hsl_panic_fill(
+                        short_hsl, pnl - fee,
+                        directional_equity_at_close(
+                            balance, long_side, short_side, close, c_mult
+                        )
+                    );
+                }
                 balance += pnl - fee;
                 record_realized_net(
                     pnl - fee,
@@ -2023,6 +2147,14 @@ inline void passivbot_single_coin_impl(
                         realized_pnl_cumsum_last,
                         realized_pnl_cumsum_max,
                         max_realized_loss_pct)) {
+                    if (short_side.close_is_panic) {
+                        record_hsl_panic_fill(
+                            short_hsl, pnl - fee,
+                            directional_equity_at_close(
+                                balance, long_side, short_side, close, c_mult
+                            )
+                        );
+                    }
                     balance += pnl - fee;
                     record_realized_net(
                         pnl - fee,
@@ -2068,12 +2200,21 @@ inline void passivbot_single_coin_impl(
                 float fee = adj * cp * c_mult * maker_fee;
                 bool selected_unstuck = !use_secondary
                     && short_side.close_is_unstuck_reducer;
-                if (!realized_loss_proxy_allows_reducer(
+                if (!short_side.close_is_panic
+                    && !realized_loss_proxy_allows_reducer(
                         adj, cp, short_side.pprice, false, selected_unstuck,
                         c_mult, maker_fee, loss_gate_enabled, balance,
                         realized_pnl_cumsum_last,
                         realized_pnl_cumsum_max,
                         max_realized_loss_pct)) continue;
+                if (!use_secondary && short_side.close_is_panic) {
+                    record_hsl_panic_fill(
+                        short_hsl, pnl - fee,
+                        directional_equity_at_close(
+                            balance, long_side, short_side, close, c_mult
+                        )
+                    );
+                }
                 balance += pnl - fee;
                 record_realized_net(
                     pnl - fee,
@@ -2201,6 +2342,8 @@ inline void passivbot_single_coin_impl(
         int long_hsl_mode = hsl_mode(long_hsl, long_side.psize > 0.0f);
         int short_hsl_mode = hsl_mode(short_hsl, short_side.psize > 0.0f);
         if (gen) {
+            long_side.close_is_panic = false;
+            short_side.close_is_panic = false;
             // When both sides are flat, an exact Rust path that remains alive has
             // balance above liq_floor. If either side is open, equity cannot bound
             // exact cash balance, so flat-side eligibility uses zero and fails closed.
@@ -2376,6 +2519,7 @@ inline void passivbot_single_coin_impl(
                 long_side.close_is_exposure_reducer = false;
                 long_side.close_is_twel_reducer = false;
                 long_side.close_is_unstuck_reducer = false;
+                long_side.close_is_panic = true;
             }
             if (short_enabled && short_hsl_mode == 3) {
                 short_side.close_ticks = max(touch_up_tick + 1, 1);
@@ -2385,6 +2529,7 @@ inline void passivbot_single_coin_impl(
                 short_side.close_is_exposure_reducer = false;
                 short_side.close_is_twel_reducer = false;
                 short_side.close_is_unstuck_reducer = false;
+                short_side.close_is_panic = true;
             }
         }
 
@@ -2421,8 +2566,8 @@ inline void passivbot_single_coin_impl(
                 hsl_tier_samples_orange += hsl_tier == 2 ? 1.0f : 0.0f;
                 hsl_tier_samples_red += hsl_tier == 3 ? 1.0f : 0.0f;
             }
-            try_restart_hsl(long_hsl, kf);
-            try_restart_hsl(short_hsl, kf);
+            try_restart_hsl(long_hsl, kf, equity);
+            try_restart_hsl(short_hsl, kf, equity);
         }
         bool active = eq_started && alive && valid;
         if (active) {
@@ -2526,6 +2671,31 @@ inline void passivbot_single_coin_impl(
         + short_hsl.flatten_time_count;
     scalars[so + 35] = long_hsl.restart_retrigger_count
         + short_hsl.restart_retrigger_count;
+    float panic_drawdown_count = long_hsl.panic_loss_drawdown_count
+        + short_hsl.panic_loss_drawdown_count;
+    float panic_drawdown_min = long_hsl.panic_loss_drawdown_count > 0.0f
+        ? (short_hsl.panic_loss_drawdown_count > 0.0f
+            ? fmin(
+                long_hsl.panic_loss_drawdown_min,
+                short_hsl.panic_loss_drawdown_min
+            ) : long_hsl.panic_loss_drawdown_min)
+        : (short_hsl.panic_loss_drawdown_count > 0.0f
+            ? short_hsl.panic_loss_drawdown_min : 0.0f);
+    scalars[so + 36] = long_hsl.halt_to_restart_equity_loss
+        + short_hsl.halt_to_restart_equity_loss;
+    scalars[so + 37] = long_hsl.panic_close_loss_sum
+        + short_hsl.panic_close_loss_sum;
+    scalars[so + 38] = fmax(
+        long_hsl.panic_close_loss_max, short_hsl.panic_close_loss_max
+    );
+    scalars[so + 39] = panic_drawdown_min;
+    scalars[so + 40] = long_hsl.panic_loss_drawdown_sum
+        + short_hsl.panic_loss_drawdown_sum;
+    scalars[so + 41] = fmax(
+        long_hsl.panic_loss_drawdown_max,
+        short_hsl.panic_loss_drawdown_max
+    );
+    scalars[so + 42] = panic_drawdown_count;
 }
 
 kernel void passivbot_trailing_martingale(

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -1062,6 +1062,18 @@ def _validate_dual_multicoin_metrics(
         )
 
 
+def _validate_hsl_metric_topology(
+    needed_metrics, *, coin_count: int, hard_stop_metrics
+) -> None:
+    unsupported = sorted(set(needed_metrics) & set(hard_stop_metrics))
+    if int(coin_count) > 1 and unsupported:
+        raise ValueError(
+            "GPU HSL optimizer metrics currently require single-coin directional "
+            "Metal output; multi-coin HSL metrics remain unsupported: "
+            f"{unsupported}"
+        )
+
+
 def _validate_gpu_coin_overrides(
     config: dict,
     *,
@@ -2740,7 +2752,7 @@ def run_backend(
 
     from config.metrics import canonicalize_metric_name
     from config.scoring import extract_objective_specs
-    from optimization.gpu.metrics import SUPPORTED_METRICS
+    from optimization.gpu.metrics import HARD_STOP_PROXY_METRICS, SUPPORTED_METRICS
     from optimization.gpu.service import MpsMulticoinProxy, MpsSingleCoinProxy
     from optimization.warmup import (
         _finalize_optimizer_vector_config,
@@ -3094,6 +3106,11 @@ def run_backend(
             f"GPU foundation does not implement optimizer metrics {unsupported}; "
             "use supported metrics or the CPU optimizer"
         )
+    _validate_hsl_metric_topology(
+        needed_metrics,
+        coin_count=max_coin_count,
+        hard_stop_metrics=HARD_STOP_PROXY_METRICS,
+    )
     _validate_dual_multicoin_metrics(
         needed_metrics,
         coin_count=max_coin_count,

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -32,6 +32,12 @@ SUPPORTED_METRICS = (
     "hard_stop_duration_minutes_max",
     "hard_stop_duration_minutes_mean",
     "hard_stop_flatten_time_minutes_mean",
+    "hard_stop_halt_to_restart_equity_loss_pct",
+    "hard_stop_panic_close_loss_drawdown_pct_max",
+    "hard_stop_panic_close_loss_drawdown_pct_mean",
+    "hard_stop_panic_close_loss_drawdown_pct_min",
+    "hard_stop_panic_close_loss_max",
+    "hard_stop_panic_close_loss_sum",
     "hard_stop_post_restart_retrigger_pct",
     "hard_stop_restarts",
     "hard_stop_restarts_long",
@@ -96,6 +102,14 @@ _HARD_STOP_LIFECYCLE_METRICS = {
     "hard_stop_triggers_long",
     "hard_stop_triggers_per_year",
     "hard_stop_triggers_short",
+}
+_HARD_STOP_PANIC_LOSS_METRICS = {
+    "hard_stop_halt_to_restart_equity_loss_pct",
+    "hard_stop_panic_close_loss_drawdown_pct_max",
+    "hard_stop_panic_close_loss_drawdown_pct_mean",
+    "hard_stop_panic_close_loss_drawdown_pct_min",
+    "hard_stop_panic_close_loss_max",
+    "hard_stop_panic_close_loss_sum",
 }
 # Metal classifies gaps with float32 logarithms. Expand the decoded boundary
 # by 1024 unit roundoffs so a value rounded into the preceding bin cannot make
@@ -613,6 +627,39 @@ def _hard_stop_lifecycle_metrics(out: dict, run) -> dict:
     }
 
 
+def _hard_stop_panic_loss_metrics(out: dict, run) -> dict:
+    """Reduce resting-limit panic-fill losses using the Rust HSL formulas."""
+
+    reference = out["max_dd"].to(torch.float64)
+    zeros = torch.zeros_like(reference)
+    if "hsl_panic_close_loss_sum" not in out:
+        return {name: zeros for name in _HARD_STOP_PANIC_LOSS_METRICS}
+
+    def value(name: str):
+        return out[name].to(torch.float64)
+
+    drawdown_count = value("hsl_panic_loss_drawdown_count")
+    return {
+        "hard_stop_halt_to_restart_equity_loss_pct": value(
+            "hsl_halt_to_restart_equity_loss"
+        )
+        / max(float(run.starting_balance), 1.0e-12),
+        "hard_stop_panic_close_loss_sum": value("hsl_panic_close_loss_sum"),
+        "hard_stop_panic_close_loss_max": value("hsl_panic_close_loss_max"),
+        "hard_stop_panic_close_loss_drawdown_pct_min": value(
+            "hsl_panic_loss_drawdown_min"
+        ),
+        "hard_stop_panic_close_loss_drawdown_pct_mean": torch.where(
+            drawdown_count > 0.0,
+            value("hsl_panic_loss_drawdown_sum") / drawdown_count,
+            zeros,
+        ),
+        "hard_stop_panic_close_loss_drawdown_pct_max": value(
+            "hsl_panic_loss_drawdown_max"
+        ),
+    }
+
+
 def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
     """Reduce compact Metal output into validated proxy objective metrics."""
 
@@ -698,6 +745,11 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
         if requested & _HARD_STOP_LIFECYCLE_METRICS
         else {}
     )
+    hard_stop_panic_loss_metrics = (
+        _hard_stop_panic_loss_metrics(out, run)
+        if requested & _HARD_STOP_PANIC_LOSS_METRICS
+        else {}
+    )
 
     requested_start = float(run.requested_start_ts_ms)
     first_timestamp = data["ts0"]
@@ -736,6 +788,7 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
     }
     objectives.update(fill_gap_metrics)
     objectives.update(hard_stop_metrics)
+    objectives.update(hard_stop_panic_loss_metrics)
     objectives.update(weighted_metrics)
     if needed is None:
         return objectives

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -111,6 +111,9 @@ _HARD_STOP_PANIC_LOSS_METRICS = {
     "hard_stop_panic_close_loss_max",
     "hard_stop_panic_close_loss_sum",
 }
+HARD_STOP_PROXY_METRICS = tuple(
+    sorted(_HARD_STOP_LIFECYCLE_METRICS | _HARD_STOP_PANIC_LOSS_METRICS)
+)
 # Metal classifies gaps with float32 logarithms. Expand the decoded boundary
 # by 1024 unit roundoffs so a value rounded into the preceding bin cannot make
 # this minimizing proxy optimistic.
@@ -553,7 +556,9 @@ def _hard_stop_lifecycle_metrics(out: dict, run) -> dict:
     reference = out["max_dd"].to(torch.float64)
     zeros = torch.zeros_like(reference)
     if "hsl_triggers_long" not in out:
-        return {name: zeros for name in _HARD_STOP_LIFECYCLE_METRICS}
+        raise RuntimeError(
+            "MPS directional HSL lifecycle outputs are missing from proxy results"
+        )
 
     def value(name: str):
         return out[name].to(torch.float64)
@@ -633,7 +638,9 @@ def _hard_stop_panic_loss_metrics(out: dict, run) -> dict:
     reference = out["max_dd"].to(torch.float64)
     zeros = torch.zeros_like(reference)
     if "hsl_panic_close_loss_sum" not in out:
-        return {name: zeros for name in _HARD_STOP_PANIC_LOSS_METRICS}
+        raise RuntimeError(
+            "MPS directional HSL panic-loss outputs are missing from proxy results"
+        )
 
     def value(name: str):
         return out[name].to(torch.float64)

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -20,7 +20,7 @@ from optimization.gpu.model import (
 MPS_DAILY_COLS = 5
 MPS_MULTICOIN_DAILY_COLS = 6
 MPS_SCALAR_COLS = 18
-MPS_DIRECTIONAL_SCALAR_COLS = 36
+MPS_DIRECTIONAL_SCALAR_COLS = 43
 
 
 def _encode_max_realized_loss_pct(value: float) -> float:
@@ -175,6 +175,13 @@ def _decode_directional_outputs(daily, scalars, gaps) -> dict:
         "hsl_flatten_time_sum_steps": scalars[:, 33],
         "hsl_flatten_time_count": scalars[:, 34],
         "hsl_restart_retrigger_count": scalars[:, 35],
+        "hsl_halt_to_restart_equity_loss": scalars[:, 36],
+        "hsl_panic_close_loss_sum": scalars[:, 37],
+        "hsl_panic_close_loss_max": scalars[:, 38],
+        "hsl_panic_loss_drawdown_min": scalars[:, 39],
+        "hsl_panic_loss_drawdown_sum": scalars[:, 40],
+        "hsl_panic_loss_drawdown_max": scalars[:, 41],
+        "hsl_panic_loss_drawdown_count": scalars[:, 42],
     }
 
 

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -42,6 +42,34 @@ CORE_OUTPUT_KEYS = {
     "liq_step",
 }
 
+DIRECTIONAL_HSL_OUTPUT_KEYS = {
+    "hsl_long_enabled",
+    "hsl_short_enabled",
+    "hsl_triggers_long",
+    "hsl_triggers_short",
+    "hsl_restarts_long",
+    "hsl_restarts_short",
+    "hsl_tier_samples_total",
+    "hsl_tier_samples_yellow",
+    "hsl_tier_samples_orange",
+    "hsl_tier_samples_red",
+    "hsl_duration_sum_steps",
+    "hsl_duration_max_steps",
+    "hsl_duration_count",
+    "hsl_trigger_drawdown_sum",
+    "hsl_trigger_drawdown_count",
+    "hsl_flatten_time_sum_steps",
+    "hsl_flatten_time_count",
+    "hsl_restart_retrigger_count",
+    "hsl_halt_to_restart_equity_loss",
+    "hsl_panic_close_loss_sum",
+    "hsl_panic_close_loss_max",
+    "hsl_panic_loss_drawdown_min",
+    "hsl_panic_loss_drawdown_sum",
+    "hsl_panic_loss_drawdown_max",
+    "hsl_panic_loss_drawdown_count",
+}
+
 
 def _single_coin_exposure_params(risk: dict, *, side: str) -> dict[str, float]:
     allowance_mode = str(
@@ -594,7 +622,7 @@ class MpsSingleCoinProxy:
             output = {
                 key: value.cpu()
                 for key, value in output.items()
-                if key in CORE_OUTPUT_KEYS
+                if key in CORE_OUTPUT_KEYS | DIRECTIONAL_HSL_OUTPUT_KEYS
             }
             timestamp_origin = float(self.metrics_data["ts0"])
             for key in (

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -36,6 +36,7 @@ from optimization.backends.gpu_backend import (
     _gpu_hsl_parameter_active,
     _gpu_pinned_hsl_bound_contract,
     _validate_hsl_bound_contracts,
+    _validate_hsl_metric_topology,
     _gpu_suite_enabled,
     _gpu_suite_checkpoint_contract,
     _gpu_runtime_checkpoint_contract,
@@ -1460,6 +1461,21 @@ def test_gpu_hsl_fails_closed_for_multicoin():
 
     with pytest.raises(ValueError, match="one backtest coin"):
         _validate_scope(config, _MulticoinEvaluator())
+
+
+def test_gpu_hsl_metrics_fail_closed_for_multicoin_proxy_outputs():
+    with pytest.raises(ValueError, match="single-coin directional Metal output"):
+        _validate_hsl_metric_topology(
+            {"hard_stop_panic_close_loss_sum"},
+            coin_count=3,
+            hard_stop_metrics={"hard_stop_panic_close_loss_sum"},
+        )
+
+    _validate_hsl_metric_topology(
+        {"hard_stop_panic_close_loss_sum"},
+        coin_count=1,
+        hard_stop_metrics={"hard_stop_panic_close_loss_sum"},
+    )
 
 
 @pytest.mark.parametrize("side", ["long", "short"])

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -273,15 +273,12 @@ def test_hard_stop_lifecycle_reduction_matches_rust_formulas():
     assert metrics["hard_stop_post_restart_retrigger_pct"].tolist() == [0.5, 0.0]
 
 
-def test_hard_stop_lifecycle_metrics_are_zero_without_directional_hsl_outputs():
-    metrics = _hard_stop_lifecycle_metrics(
-        {"max_dd": torch.tensor([0.1, 0.2])},
-        SimpleNamespace(interval_ms=60_000),
-    )
-
-    assert set(metrics) <= set(SUPPORTED_METRICS)
-    assert len(metrics) == 18
-    assert all(metric.tolist() == [0.0, 0.0] for metric in metrics.values())
+def test_hard_stop_lifecycle_metrics_fail_closed_without_directional_outputs():
+    with pytest.raises(RuntimeError, match="lifecycle outputs are missing"):
+        _hard_stop_lifecycle_metrics(
+            {"max_dd": torch.tensor([0.1, 0.2])},
+            SimpleNamespace(interval_ms=60_000),
+        )
 
 
 def test_hard_stop_panic_loss_reduction_matches_rust_formulas():
@@ -317,14 +314,12 @@ def test_hard_stop_panic_loss_reduction_matches_rust_formulas():
     ].tolist() == pytest.approx([0.05, 0.0])
 
 
-def test_hard_stop_panic_loss_metrics_are_zero_without_directional_outputs():
-    metrics = _hard_stop_panic_loss_metrics(
-        {"max_dd": torch.tensor([0.1, 0.2])},
-        SimpleNamespace(starting_balance=1_000.0),
-    )
-
-    assert len(metrics) == 6
-    assert all(metric.tolist() == [0.0, 0.0] for metric in metrics.values())
+def test_hard_stop_panic_loss_metrics_fail_closed_without_directional_outputs():
+    with pytest.raises(RuntimeError, match="panic-loss outputs are missing"):
+        _hard_stop_panic_loss_metrics(
+            {"max_dd": torch.tensor([0.1, 0.2])},
+            SimpleNamespace(starting_balance=1_000.0),
+        )
 
 
 def test_weighted_strategy_equity_metric_surface_is_supported():

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -12,6 +12,7 @@ from optimization.gpu.metrics import (
     _GAP_HIST_UPPER_STEPS,
     _fill_gap_metrics,
     _hard_stop_lifecycle_metrics,
+    _hard_stop_panic_loss_metrics,
     _masked_median,
     _mean_worst_one_pct_abs,
     _omega_ratio,
@@ -212,15 +213,7 @@ def test_hard_stop_lifecycle_metric_surface_is_supported():
         "hard_stop_flatten_time_minutes_mean",
         "hard_stop_post_restart_retrigger_pct",
     } <= set(SUPPORTED_METRICS)
-    assert {
-        "hard_stop_halt_to_restart_equity_loss_pct",
-        "hard_stop_panic_close_loss_sum",
-        "hard_stop_panic_close_loss_max",
-        "hard_stop_panic_close_loss_drawdown_pct_min",
-        "hard_stop_panic_close_loss_drawdown_pct_mean",
-        "hard_stop_panic_close_loss_drawdown_pct_max",
-        "drawdown_worst_ema_strategy_eq",
-    }.isdisjoint(SUPPORTED_METRICS)
+    assert "drawdown_worst_ema_strategy_eq" not in SUPPORTED_METRICS
 
 
 def test_hard_stop_lifecycle_reduction_matches_rust_formulas():
@@ -286,9 +279,51 @@ def test_hard_stop_lifecycle_metrics_are_zero_without_directional_hsl_outputs():
         SimpleNamespace(interval_ms=60_000),
     )
 
-    assert set(metrics) == {
-        name for name in SUPPORTED_METRICS if name.startswith("hard_stop_")
+    assert set(metrics) <= set(SUPPORTED_METRICS)
+    assert len(metrics) == 18
+    assert all(metric.tolist() == [0.0, 0.0] for metric in metrics.values())
+
+
+def test_hard_stop_panic_loss_reduction_matches_rust_formulas():
+    out = {
+        "max_dd": torch.zeros(2, dtype=torch.float32),
+        "hsl_halt_to_restart_equity_loss": torch.tensor([25.0, 0.0]),
+        "hsl_panic_close_loss_sum": torch.tensor([45.0, 0.0]),
+        "hsl_panic_close_loss_max": torch.tensor([30.0, 0.0]),
+        "hsl_panic_loss_drawdown_min": torch.tensor([0.01, 0.0]),
+        "hsl_panic_loss_drawdown_sum": torch.tensor([0.06, 0.0]),
+        "hsl_panic_loss_drawdown_max": torch.tensor([0.05, 0.0]),
+        "hsl_panic_loss_drawdown_count": torch.tensor([2.0, 0.0]),
     }
+
+    metrics = _hard_stop_panic_loss_metrics(
+        out, SimpleNamespace(starting_balance=1_000.0)
+    )
+
+    assert metrics["hard_stop_halt_to_restart_equity_loss_pct"].tolist() == [
+        0.025,
+        0.0,
+    ]
+    assert metrics["hard_stop_panic_close_loss_sum"].tolist() == [45.0, 0.0]
+    assert metrics["hard_stop_panic_close_loss_max"].tolist() == [30.0, 0.0]
+    assert metrics[
+        "hard_stop_panic_close_loss_drawdown_pct_min"
+    ].tolist() == pytest.approx([0.01, 0.0])
+    assert metrics[
+        "hard_stop_panic_close_loss_drawdown_pct_mean"
+    ].tolist() == pytest.approx([0.03, 0.0])
+    assert metrics[
+        "hard_stop_panic_close_loss_drawdown_pct_max"
+    ].tolist() == pytest.approx([0.05, 0.0])
+
+
+def test_hard_stop_panic_loss_metrics_are_zero_without_directional_outputs():
+    metrics = _hard_stop_panic_loss_metrics(
+        {"max_dd": torch.tensor([0.1, 0.2])},
+        SimpleNamespace(starting_balance=1_000.0),
+    )
+
+    assert len(metrics) == 6
     assert all(metric.tolist() == [0.0, 0.0] for metric in metrics.values())
 
 

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -375,9 +375,10 @@ def test_mps_ema_anchor_shader_smoke():
     assert "float32_floor_nonnegative" in source
     assert "record_realized_net" in source
     assert "const float max_realized_loss_pct = settings[14]" in source
-    assert "constant int SCALAR_COLS = 36" in source
+    assert "constant int SCALAR_COLS = 43" in source
     assert "hsl_tier_samples_total" in source
     assert "h.restart_retrigger_count" in source
+    assert "record_hsl_panic_fill(" in source
     assert "side.psize * price_now * c_mult / balance" in source
     assert "short_side.psize * c_mult * (short_side.pprice - close)" in source
     assert "long_close_fill || long_entry_fill" in source
@@ -1280,6 +1281,9 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
     tiny_threshold_hsl[keys.index("hsl_red_threshold")] = 1.0e-8
     negative_span_hsl = list(hsl)
     negative_span_hsl[keys.index("hsl_ema_span_minutes")] = -2.0
+    recursive_close_hsl = list(hsl)
+    if strategy_kind == "trailing_martingale":
+        recursive_close_hsl[keys.index("close_retracement_base_pct")] = 0.0
     inactive = list(baseline)
     rows = (
         [
@@ -1292,6 +1296,7 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
             capped_coin_hsl + inactive,
             tiny_threshold_hsl + inactive,
             negative_span_hsl + inactive,
+            recursive_close_hsl + inactive,
         ]
         if side == "long"
         else [
@@ -1304,6 +1309,7 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
             inactive + capped_coin_hsl,
             inactive + tiny_threshold_hsl,
             inactive + negative_span_hsl,
+            inactive + recursive_close_hsl,
         ]
     )
     output = runner_cls(
@@ -1313,6 +1319,14 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
         long_enabled=side == "long",
         short_enabled=side == "short",
     ).run(np.asarray(rows, dtype=np.float64))
+    gated_output = runner_cls(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+        max_realized_loss_pct=0.0,
+    ).run(np.asarray([rows[9]], dtype=np.float64))
     torch.mps.synchronize()
 
     size_key = "psize" if side == "long" else "short_psize"
@@ -1347,6 +1361,17 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
     assert output["hsl_trigger_drawdown_sum"][1].item() > 0.0
     assert output["hsl_trigger_drawdown_count"][1].item() == 1.0
     assert output["hsl_flatten_time_count"][1].item() == 1.0
+    assert output["hsl_panic_close_loss_sum"][1].item() > 0.0
+    assert output["hsl_panic_close_loss_max"][1].item() > 0.0
+    assert output["hsl_panic_loss_drawdown_count"][1].item() == 1.0
+    assert output["hsl_panic_loss_drawdown_min"][1].item() > 0.0
+    assert output["hsl_panic_loss_drawdown_sum"][1].item() > 0.0
+    assert output["hsl_panic_loss_drawdown_max"][1].item() > 0.0
+    assert output[size_key][9].item() == 0.0
+    assert output["hsl_panic_close_loss_sum"][9].item() > 0.0
+    assert output["hsl_panic_loss_drawdown_count"][9].item() == 1.0
+    assert gated_output[size_key].item() == 0.0
+    assert gated_output["hsl_panic_close_loss_sum"].item() > 0.0
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -13,7 +13,9 @@ from optimization.gpu.model import (
     gpu_side_enabled,
 )
 from optimization.gpu.service import (
+    DIRECTIONAL_HSL_OUTPUT_KEYS,
     MpsEmaAnchorProxy,
+    MpsSingleCoinProxy,
     MpsMulticoinEmaProxy,
     _build_multicoin_ema_coin_overrides,
     _build_multicoin_tm_coin_overrides,
@@ -26,6 +28,56 @@ from optimization.gpu.service import (
     _total_exposure_enforcer_params,
     _unstuck_params,
 )
+
+
+def test_directional_hsl_output_contract_retains_lifecycle_and_panic_scalars():
+    assert {
+        "hsl_triggers_long",
+        "hsl_duration_sum_steps",
+        "hsl_restart_retrigger_count",
+        "hsl_halt_to_restart_equity_loss",
+        "hsl_panic_close_loss_sum",
+        "hsl_panic_loss_drawdown_count",
+    } <= DIRECTIONAL_HSL_OUTPUT_KEYS
+    assert len(DIRECTIONAL_HSL_OUTPUT_KEYS) == 25
+
+
+def test_single_coin_proxy_preserves_directional_hsl_outputs_for_reduction():
+    torch = pytest.importorskip("torch")
+    proxy = MpsSingleCoinProxy.__new__(MpsSingleCoinProxy)
+    proxy.batch_size = 1
+    proxy._torch = torch
+    proxy.profile_enabled = False
+    proxy.metrics_data = {"ts0": 0.0}
+    proxy.run = SimpleNamespace()
+    proxy.needed_metrics = {"hard_stop_panic_close_loss_sum"}
+    proxy._parameter_matrix = lambda candidates: np.zeros((len(candidates), 0))
+    raw = {
+        key: torch.zeros(1)
+        for key in (
+            "first_fill_ts",
+            "last_fill_ts",
+            "last_high_ts",
+            "first_eq_ts",
+            "last_eq_ts",
+        )
+    }
+    raw["hsl_triggers_long"] = torch.tensor([2.0])
+    raw["hsl_panic_close_loss_sum"] = torch.tensor([37.5])
+    proxy.runner = SimpleNamespace(run=lambda *args, **kwargs: raw)
+
+    def reduce(output, *args, **kwargs):
+        assert output["hsl_triggers_long"].item() == 2.0
+        assert output["hsl_panic_close_loss_sum"].item() == 37.5
+        return {
+            "hard_stop_panic_close_loss_sum": output[
+                "hsl_panic_close_loss_sum"
+            ]
+        }
+
+    proxy._compute_objectives = reduce
+
+    assert proxy.evaluate([{}]) == [{"hard_stop_panic_close_loss_sum": 37.5}]
 
 
 def test_gpu_proxy_requires_complete_valid_tail():


### PR DESCRIPTION
## Summary
- add the six resting-limit HSL panic-loss metrics to GPU scoring and limits for the supported one-sided single-coin EMA Anchor and Trailing Martingale topology
- tag only HSL panic fills, capture pre-fill episode equity, aggregate per-fill net losses, and finalize per-episode loss drawdowns at Rust's second-flat-confirmation boundary
- preserve coin-mode zero semantics for halt-to-restart loss and normalize pside/unified loss by starting balance
- keep exact Rust validation and drift gates authoritative

## TM parity fixes discovered by this slice
- HSL panic closes bypass recursive close-grid reconstruction and remain one exclusive full-position order
- HSL panic closes bypass the ordinary realized-loss gate, matching Rust

## Still fail closed
- HSL market panic execution
- finite rolling HSL PnL lookbacks
- dual-side and multi-coin HSL, including per-coin HSL overrides
- HSL strategy-equity EMA/recovery-distribution metrics

## Validation
- `python -m pytest -q tests/optimization`
- targeted GPU metric/backend tests (344 passed)
- physical M3: `python -m pytest -q tests/optimization/test_gpu_mps.py` (184 passed)
- physical long/short EMA/TM HSL panic cases with recursive TM closes and `max_realized_loss_pct=0`
- `cargo fmt --check`
- `cargo check --tests`
- `cargo test --no-default-features` (262 passed)
- rebuilt and runtime-stamped the Python Rust extension before integration/MPS tests

## Scope
Additive GPU optimizer support only. CPU optimization, live trading, and ordinary Rust backtesting paths are unchanged.