### PR TITLE
feat(optimize): support MPS HSL market panic closes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added HSL market panic-close execution to the supported one-sided single-coin EMA Anchor and
+  Trailing Martingale Apple MPS optimizer path. The Metal proxy guarantees the persisted panic
+  order on the next valid bar, uses that bar's close with directionally adverse configured
+  slippage and price-step rounding, and charges the resolved taker fee. Resting-limit behavior is
+  unchanged, while exact Rust validation and drift gates remain authoritative.
+
 - Added resting-limit HSL panic-loss scoring and limit metrics to the supported one-sided
   single-coin Apple MPS optimizer path: panic-close loss sum/max, per-episode loss drawdown
   min/mean/max, and halt-to-restart equity loss. The proxy tags only HSL panic fills and retains

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -135,7 +135,10 @@ The supported slice is intentionally narrow:
   `risk.we_excess_allowance_mode`, trailing-martingale `entry.ema_gate_mode`, disabled sides, and
   other override leaves fail closed
 - one-sided single-coin EMA Anchor and Trailing Martingale runs support HSL with `coin`, `pside`,
-  or `unified` signals and resting-limit panic closes. The Metal proxy models tunable RED
+  or `unified` signals and both resting-limit and market panic closes. Market panic orders fill on
+  the next valid bar at its close shifted adversely by `backtest.market_order_slippage_pct`, rounded
+  directionally to the exchange price step, and charged the resolved taker fee. The Metal proxy
+  models tunable RED
   threshold, drawdown-EMA span, and cooldown, plus fixed yellow/orange ratios, orange entry
   suppression, RED latching, panic flattening, two-sample flat confirmation,
   positive-cooldown restart, zero-cooldown indefinite halt, cumulative no-restart peak tracking,
@@ -145,10 +148,10 @@ The supported slice is intentionally narrow:
   the float32-unrepresentable interval immediately below `1.0` fail closed. Exact validation and
   drift gates remain authoritative. The non-loss HSL lifecycle metrics (trigger/restart counts and
   yearly rates, time in each warning tier, halt and flatten durations, trigger drawdown, and
-  post-restart retriggers) and resting-limit panic-loss metrics (loss sum/max, per-episode loss
+  post-restart retriggers) and panic-loss metrics (loss sum/max, per-episode loss
   drawdown min/mean/max, and halt-to-restart equity loss) may be used for scoring and limits.
-  Market panic closes, finite rolling PnL lookbacks, dual-side and multi-coin HSL, per-coin HSL
-  overrides, and HSL strategy-equity EMA/recovery-distribution metrics remain fail closed for now.
+  Finite rolling PnL lookbacks, dual-side and multi-coin HSL, per-coin HSL overrides, and HSL
+  strategy-equity EMA/recovery-distribution metrics remain fail closed for now.
   Compatible single-coin suites may use the supported topology.
 - single-coin EMA Anchor and Trailing Martingale support auto-unstuck for long-only,
   short-only, hedge-mode dual-side, one-way, and compatible suite runs. One-sided multi-coin runs

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -75,6 +75,13 @@ mod tests {
         assert!(source.contains("float32_floor_nonnegative"));
         assert!(source.contains("record_realized_net"));
         assert!(source.contains("const float max_realized_loss_pct = settings[14]"));
+        assert!(source.contains("const float taker_fee = settings[15]"));
+        assert!(source.contains("const float market_order_slippage_pct = fmax(settings[16], 0.0f)"));
+        assert!(source.contains("const bool long_hsl_panic_market = settings[17] > 0.5f"));
+        assert!(source.contains("const bool short_hsl_panic_market = settings[18] > 0.5f"));
+        assert!(source.contains("market_panic ? taker_fee : maker_fee"));
+        assert!(source.contains("close * (1.0f - market_order_slippage_pct)"));
+        assert!(source.contains("close * (1.0f + market_order_slippage_pct)"));
         assert!(!source.contains("accumulate_min_cost_balance_error"));
         assert_eq!(source.matches("= fma(").count(), 6);
         assert!(!source.contains("alpha0 * close +"));
@@ -198,6 +205,13 @@ mod tests {
         assert!(source.contains("realized_loss_proxy_allows_close"));
         assert!(source.contains("const float max_realized_loss_pct = settings[14]"));
         assert!(source.contains("const bool loss_gate_enabled = max_realized_loss_pct < 1.0f"));
+        assert!(source.contains("const float taker_fee = settings[15]"));
+        assert!(source.contains("const float market_order_slippage_pct = fmax(settings[16], 0.0f)"));
+        assert!(source.contains("const bool long_hsl_panic_market = settings[17] > 0.5f"));
+        assert!(source.contains("const bool short_hsl_panic_market = settings[18] > 0.5f"));
+        assert!(source.contains("market_panic ? taker_fee : maker_fee"));
+        assert!(source.contains("close * (1.0f - market_order_slippage_pct)"));
+        assert!(source.contains("close * (1.0f + market_order_slippage_pct)"));
         assert!(source.contains("the proxy uses a zero-loss envelope"));
         assert!(source.contains("int grid_rung_limit = strategy_wel_qty > 0.0f ? 499 : 500"));
         assert!(source.contains("long_side.close_gen_psize - strategy_wel_qty"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -1072,6 +1072,10 @@ inline void passivbot_single_coin_impl(
     const bool filter_by_min_effective_cost = settings[12] > 0.5f;
     const float max_effective_min_cost = settings[13];
     const float max_realized_loss_pct = settings[14];
+    const float taker_fee = settings[15];
+    const float market_order_slippage_pct = fmax(settings[16], 0.0f);
+    const bool long_hsl_panic_market = settings[17] > 0.5f;
+    const bool short_hsl_panic_market = settings[18] > 0.5f;
     const float log_bin_scale = 127.0f / log(4000001.0f);
 
     const int po = int(b) * P;
@@ -1154,7 +1158,8 @@ inline void passivbot_single_coin_impl(
         bool long_close_fill = false;
         bool long_primary_close_fill = valid && alive && long_enabled
             && long_side.close_qty > 0.0f && long_side.psize > 0.0f
-            && long_side.close_ticks <= high_fill_max_tick;
+            && ((long_side.close_is_panic && long_hsl_panic_market)
+                || long_side.close_ticks <= high_fill_max_tick);
         bool long_secondary_close_fill = valid && alive && long_enabled
             && long_side.secondary_close_qty > 0.0f && long_side.psize > 0.0f
             && long_side.secondary_close_ticks <= high_fill_max_tick;
@@ -1170,11 +1175,21 @@ inline void passivbot_single_coin_impl(
                 ? long_side.secondary_close_ticks : long_side.close_ticks;
             float requested_qty = use_secondary
                 ? long_side.secondary_close_qty : long_side.close_qty;
-            float cp = float(close_ticks) * price_step;
+            bool market_panic = !use_secondary && long_side.close_is_panic
+                && long_hsl_panic_market;
+            float cp = market_panic
+                ? fmax(
+                    floor_step(
+                        close * (1.0f - market_order_slippage_pct), price_step
+                    ),
+                    price_step
+                )
+                : float(close_ticks) * price_step;
             float adj = fmin(round_step(requested_qty, qty_step), long_side.psize);
             if (!(adj > 0.0f)) continue;
             float pnl = adj * c_mult * (cp - long_side.pprice);
-            float fee = adj * cp * c_mult * maker_fee;
+            float fee = adj * cp * c_mult
+                * (market_panic ? taker_fee : maker_fee);
             float net_pnl = pnl - fee;
             if (!use_secondary && long_side.close_is_panic) {
                 float current_equity = balance
@@ -1234,7 +1249,8 @@ inline void passivbot_single_coin_impl(
         bool short_close_fill = false;
         bool short_primary_close_fill = valid && alive && short_enabled
             && short_side.close_qty > 0.0f && short_side.psize > 0.0f
-            && short_side.close_ticks > low_nonfill_max_tick;
+            && ((short_side.close_is_panic && short_hsl_panic_market)
+                || short_side.close_ticks > low_nonfill_max_tick);
         bool short_secondary_close_fill = valid && alive && short_enabled
             && short_side.secondary_close_qty > 0.0f && short_side.psize > 0.0f
             && short_side.secondary_close_ticks > low_nonfill_max_tick;
@@ -1250,11 +1266,21 @@ inline void passivbot_single_coin_impl(
                 ? short_side.secondary_close_ticks : short_side.close_ticks;
             float requested_qty = use_secondary
                 ? short_side.secondary_close_qty : short_side.close_qty;
-            float cp = float(close_ticks) * price_step;
+            bool market_panic = !use_secondary && short_side.close_is_panic
+                && short_hsl_panic_market;
+            float cp = market_panic
+                ? fmax(
+                    ceil_step(
+                        close * (1.0f + market_order_slippage_pct), price_step
+                    ),
+                    price_step
+                )
+                : float(close_ticks) * price_step;
             float adj = fmin(round_step(requested_qty, qty_step), short_side.psize);
             if (!(adj > 0.0f)) continue;
             float pnl = adj * c_mult * (short_side.pprice - cp);
-            float fee = adj * cp * c_mult * maker_fee;
+            float fee = adj * cp * c_mult
+                * (market_panic ? taker_fee : maker_fee);
             float net_pnl = pnl - fee;
             if (!use_secondary && short_side.close_is_panic) {
                 float current_equity = balance

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -1358,6 +1358,10 @@ inline void passivbot_single_coin_impl(
     const bool filter_by_min_effective_cost = settings[12] > 0.5f;
     const float max_effective_min_cost = settings[13];
     const float max_realized_loss_pct = settings[14];
+    const float taker_fee = settings[15];
+    const float market_order_slippage_pct = fmax(settings[16], 0.0f);
+    const bool long_hsl_panic_market = settings[17] > 0.5f;
+    const bool short_hsl_panic_market = settings[18] > 0.5f;
     const bool loss_gate_enabled = max_realized_loss_pct < 1.0f;
     const float log_bin_scale = 127.0f / log(4000001.0f);
 
@@ -1450,7 +1454,8 @@ inline void passivbot_single_coin_impl(
             && long_side.psize > 0.0f;
         bool long_recursive_close = long_side.close_retracement_base <= 0.0f;
         bool long_scan_close_grid = long_close_ready
-            && long_side.close_ticks <= high_fill_max_tick;
+            && ((long_side.close_is_panic && long_hsl_panic_market)
+                || long_side.close_ticks <= high_fill_max_tick);
         if (long_close_ready && long_recursive_close
             && long_side.close_is_exposure_reducer) {
             // A touch-clamped grid order uses nearest-tick quantization while
@@ -1760,15 +1765,23 @@ inline void passivbot_single_coin_impl(
                 bool reachable = use_secondary
                     ? long_secondary_close_fill : long_scan_close_grid;
                 if (!reachable || long_side.psize <= 0.0f) continue;
-                float cp = use_secondary
-                    ? long_side.secondary_close_price : long_side.close_price;
+                bool market_panic = !use_secondary && long_side.close_is_panic
+                    && long_hsl_panic_market;
+                float cp = use_secondary ? long_side.secondary_close_price
+                    : market_panic
+                        ? float(max(directional_ticks(
+                            close * (1.0f - market_order_slippage_pct),
+                            price_step, false
+                        ), 1)) * price_step
+                        : long_side.close_price;
                 float requested_qty = use_secondary
                     ? long_side.secondary_close_qty : long_side.close_qty;
                 float adj = fmin(
                     round_step(requested_qty, qty_step), long_side.psize
                 );
                 float pnl = adj * c_mult * (cp - long_side.pprice);
-                float fee = adj * cp * c_mult * maker_fee;
+                float fee = adj * cp * c_mult
+                    * (market_panic ? taker_fee : maker_fee);
                 bool selected_unstuck = !use_secondary
                     && long_side.close_is_unstuck_reducer;
                 if (!long_side.close_is_panic
@@ -1881,7 +1894,8 @@ inline void passivbot_single_coin_impl(
             && short_side.psize > 0.0f;
         bool short_recursive_close = short_side.close_retracement_base <= 0.0f;
         bool short_scan_close_grid = short_close_ready
-            && short_side.close_ticks > low_nonfill_max_tick;
+            && ((short_side.close_is_panic && short_hsl_panic_market)
+                || short_side.close_ticks > low_nonfill_max_tick);
         if (short_close_ready && short_recursive_close
             && short_side.close_is_exposure_reducer) {
             // Mirror the long-side nearest-tick scan: a touch-clamped grid
@@ -2189,15 +2203,23 @@ inline void passivbot_single_coin_impl(
                 bool reachable = use_secondary
                     ? short_secondary_close_fill : short_scan_close_grid;
                 if (!reachable || short_side.psize <= 0.0f) continue;
-                float cp = use_secondary
-                    ? short_side.secondary_close_price : short_side.close_price;
+                bool market_panic = !use_secondary && short_side.close_is_panic
+                    && short_hsl_panic_market;
+                float cp = use_secondary ? short_side.secondary_close_price
+                    : market_panic
+                        ? float(max(directional_ticks(
+                            close * (1.0f + market_order_slippage_pct),
+                            price_step, true
+                        ), 1)) * price_step
+                        : short_side.close_price;
                 float requested_qty = use_secondary
                     ? short_side.secondary_close_qty : short_side.close_qty;
                 float adj = fmin(
                     round_step(requested_qty, qty_step), short_side.psize
                 );
                 float pnl = adj * c_mult * (short_side.pprice - cp);
-                float fee = adj * cp * c_mult * maker_fee;
+                float fee = adj * cp * c_mult
+                    * (market_panic ? taker_fee : maker_fee);
                 bool selected_unstuck = !use_secondary
                     && short_side.close_is_unstuck_reducer;
                 if (!short_side.close_is_panic

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -1014,10 +1014,10 @@ def _validate_scope_config(
             panic_order_type = str(
                 hsl.get("panic_close_order_type", "limit")
             ).strip().lower()
-            if panic_order_type != "limit":
+            if panic_order_type not in {"limit", "market"}:
                 raise ValueError(
-                    f"GPU HSL currently requires bot.{side}.hsl."
-                    "panic_close_order_type=limit"
+                    f"GPU HSL requires bot.{side}.hsl.panic_close_order_type "
+                    f"to be limit or market, got {panic_order_type!r}"
                 )
     for side in enabled_sides:
         side_config = config["bot"][side]

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -199,6 +199,10 @@ class MpsEmaAnchorRunner:
         hedge_mode: bool = True,
         filter_by_min_effective_cost: bool = False,
         max_realized_loss_pct: float = 1.0,
+        taker_fee: float | None = None,
+        market_order_slippage_pct: float = 0.0,
+        hsl_panic_market_long: bool = False,
+        hsl_panic_market_short: bool = False,
     ):
         self.market = market
         self.run_config = run
@@ -215,6 +219,17 @@ class MpsEmaAnchorRunner:
         encoded_max_realized_loss_pct = _encode_max_realized_loss_pct(
             max_realized_loss_pct
         )
+        taker_fee = market.maker_fee if taker_fee is None else float(taker_fee)
+        market_order_slippage_pct = float(market_order_slippage_pct)
+        if not np.isfinite(taker_fee):
+            raise ValueError("taker_fee must be finite")
+        if (
+            not np.isfinite(market_order_slippage_pct)
+            or market_order_slippage_pct < 0.0
+        ):
+            raise ValueError(
+                "market_order_slippage_pct must be finite and non-negative"
+            )
         self.n = int(data["n"])
         self.n_days = int(data["n_days"])
         self.bars = (
@@ -269,6 +284,10 @@ class MpsEmaAnchorRunner:
                 float(bool(filter_by_min_effective_cost)),
                 data["max_effective_min_cost"],
                 encoded_max_realized_loss_pct,
+                taker_fee,
+                market_order_slippage_pct,
+                float(bool(hsl_panic_market_long)),
+                float(bool(hsl_panic_market_short)),
             ],
             dtype=torch.float32,
             device="mps",

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -489,15 +489,23 @@ class MpsSingleCoinProxy:
             backtest_params.get("equity_hard_stop_loss", {})
             .get("signal_mode", "unified")
         )
+        hsl_panic_market = {}
         self.base_params = {}
         for side, bot in (("long", long_bot), ("short", short_bot)):
-            if self.enabled[side] and bool(bot.get("hsl_enabled")) and str(
+            panic_close_order_type = str(
                 bot.get("hsl_panic_close_order_type", "limit")
-            ).strip().lower() != "limit":
+            ).strip().lower()
+            if panic_close_order_type not in {"limit", "market"}:
                 raise ValueError(
-                    f"MPS single-coin HSL currently requires bot.{side}.hsl."
-                    "panic_close_order_type=limit"
+                    f"MPS single-coin HSL requires bot.{side}.hsl."
+                    "panic_close_order_type to be limit or market, got "
+                    f"{panic_close_order_type!r}"
                 )
+            hsl_panic_market[side] = (
+                self.enabled[side]
+                and bool(bot.get("hsl_enabled"))
+                and panic_close_order_type == "market"
+            )
             strategy = dict(payload.strategy_params_list[0][side])
             risk = config["bot"][side]["risk"]
             if self.strategy_kind == "trailing_martingale":
@@ -591,6 +599,12 @@ class MpsSingleCoinProxy:
             max_realized_loss_pct=float(
                 backtest_params.get("max_realized_loss_pct", 1.0)
             ),
+            taker_fee=float(market_params["taker_fee"]),
+            market_order_slippage_pct=float(
+                backtest_params.get("market_order_slippage_pct", 0.0)
+            ),
+            hsl_panic_market_long=hsl_panic_market["long"],
+            hsl_panic_market_short=hsl_panic_market["short"],
         )
 
     def _parameter_matrix(self, candidates: list[dict]) -> np.ndarray:

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1434,14 +1434,24 @@ def test_gpu_hsl_fails_closed_for_finite_pnl_lookback():
         _validate_scope(config, _Evaluator())
 
 
-def test_gpu_hsl_fails_closed_for_market_panic_close():
+def test_gpu_hsl_accepts_market_panic_close():
     config = _long_only_ema_config()
     config["bot"]["long"]["hsl"].update(
         {"enabled": True, "panic_close_order_type": "market"}
     )
     config["live"]["pnls_max_lookback_days"] = "all"
 
-    with pytest.raises(ValueError, match="panic_close_order_type=limit"):
+    assert _validate_scope(config, _Evaluator()) == "bybit"
+
+
+def test_gpu_hsl_fails_closed_for_unknown_panic_close_type():
+    config = _long_only_ema_config()
+    config["bot"]["long"]["hsl"].update(
+        {"enabled": True, "panic_close_order_type": "immediate_or_cancel"}
+    )
+    config["live"]["pnls_max_lookback_days"] = "all"
+
+    with pytest.raises(ValueError, match="to be limit or market"):
         _validate_scope(config, _Evaluator())
 
 

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -375,6 +375,11 @@ def test_mps_ema_anchor_shader_smoke():
     assert "float32_floor_nonnegative" in source
     assert "record_realized_net" in source
     assert "const float max_realized_loss_pct = settings[14]" in source
+    assert "const float taker_fee = settings[15]" in source
+    assert "const float market_order_slippage_pct = fmax(settings[16], 0.0f)" in source
+    assert "const bool long_hsl_panic_market = settings[17] > 0.5f" in source
+    assert "const bool short_hsl_panic_market = settings[18] > 0.5f" in source
+    assert "market_panic ? taker_fee : maker_fee" in source
     assert "constant int SCALAR_COLS = 43" in source
     assert "hsl_tier_samples_total" in source
     assert "h.restart_retrigger_count" in source
@@ -1319,6 +1324,20 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
         long_enabled=side == "long",
         short_enabled=side == "short",
     ).run(np.asarray(rows, dtype=np.float64))
+    market_runner = runner_cls(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+        taker_fee=0.01,
+        market_order_slippage_pct=0.02,
+        hsl_panic_market_long=side == "long",
+        hsl_panic_market_short=side == "short",
+    )
+    market_output = market_runner.run(
+        np.asarray([rows[1]], dtype=np.float64)
+    )
     gated_output = runner_cls(
         market,
         run,
@@ -1372,6 +1391,16 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
     assert output["hsl_panic_loss_drawdown_count"][9].item() == 1.0
     assert gated_output[size_key].item() == 0.0
     assert gated_output["hsl_panic_close_loss_sum"].item() > 0.0
+    assert market_runner.settings[15].item() == pytest.approx(0.01)
+    assert market_runner.settings[16].item() == pytest.approx(0.02)
+    assert market_runner.settings[17].item() == float(side == "long")
+    assert market_runner.settings[18].item() == float(side == "short")
+    assert market_output[size_key].item() == 0.0
+    assert market_output["balance"].item() < output["balance"][1].item()
+    assert (
+        market_output["hsl_panic_close_loss_sum"].item()
+        > output["hsl_panic_close_loss_sum"][1].item()
+    )
 
 
 @pytest.mark.skipif(
@@ -5313,6 +5342,11 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert "realized_loss_proxy_allows_close" in source
     assert "const float max_realized_loss_pct = settings[14]" in source
     assert "const bool loss_gate_enabled = max_realized_loss_pct < 1.0f" in source
+    assert "const float taker_fee = settings[15]" in source
+    assert "const float market_order_slippage_pct = fmax(settings[16], 0.0f)" in source
+    assert "const bool long_hsl_panic_market = settings[17] > 0.5f" in source
+    assert "const bool short_hsl_panic_market = settings[18] > 0.5f" in source
+    assert "market_panic ? taker_fee : maker_fee" in source
     assert "the proxy uses a zero-loss envelope" in source
     assert "const bool filter_by_min_effective_cost" in source
     assert "passes_min_effective_cost" in source


### PR DESCRIPTION
## Summary\n\n- support HSL panic_close_order_type=market in the one-sided single-coin Apple MPS EMA Anchor and Trailing Martingale proxy\n- execute persisted panic orders on the next valid bar at directionally slipped and price-stepped close with the resolved taker fee\n- keep resting-limit behavior unchanged and retain exact Rust validation and drift gates as authoritative\n- fail closed for unknown panic order types and document the supported scope\n\n## Validation\n\n- Python optimization test suite\n- cargo fmt check\n- cargo check tests\n- cargo test without default features\n- rebuilt the Rust extension from this exact worktree\n- physical M3 MPS test_gpu_mps.py: 184 passed\n- physical M3 MPS end-to-end CLI smoke: long-only ETH EMA Anchor, market HSL, 8 generations, 256 proxy evaluations, 24 exact Rust validations, completed without drift or classification halt