### PR TITLE
feat(optimize): accept finite MPS HSL lookbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added finite `live.pnls_max_lookback_days` support to the existing one-sided single-coin HSL
+  Apple MPS optimizer path. Metal deliberately retains an all-history candidate-local peak as a
+  conservative envelope over Rust's rolling peak, so it may trigger HSL early after an old peak
+  expires but cannot hide a drawdown for that reason. Exact Rust validation and drift gates remain
+  authoritative.
+
 - Added HSL market panic-close execution to the supported one-sided single-coin EMA Anchor and
   Trailing Martingale Apple MPS optimizer path. The Metal proxy guarantees the persisted panic
   order on the next valid bar, uses that bar's close with directionally adverse configured

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -142,16 +142,19 @@ The supported slice is intentionally narrow:
   threshold, drawdown-EMA span, and cooldown, plus fixed yellow/orange ratios, orange entry
   suppression, RED latching, panic flattening, two-sample flat confirmation,
   positive-cooldown restart, zero-cooldown indefinite halt, cumulative no-restart peak tracking,
-  effective coin-slot scaling, and terminal no-restart policy. Its candidate-local realized-PnL
-  and strategy-equity peaks require `live.pnls_max_lookback_days: all`, and the selected history
-  must have no internal invalid candles between its first and last valid samples. Thresholds in
-  the float32-unrepresentable interval immediately below `1.0` fail closed. Exact validation and
-  drift gates remain authoritative. The non-loss HSL lifecycle metrics (trigger/restart counts and
+  effective coin-slot scaling, and terminal no-restart policy. For a finite
+  `live.pnls_max_lookback_days`, Metal deliberately retains its candidate-local all-history
+  realized-PnL and strategy-equity peaks. This is a conservative envelope over Rust's rolling
+  peak: it may trigger HSL early after an old peak ages out, but cannot suppress a drawdown for
+  that reason. The selected history must have no internal invalid candles between its first and
+  last valid samples. Thresholds in the float32-unrepresentable interval immediately below `1.0`
+  fail closed. Exact validation and drift gates remain authoritative. The non-loss HSL lifecycle
+  metrics (trigger/restart counts and
   yearly rates, time in each warning tier, halt and flatten durations, trigger drawdown, and
   post-restart retriggers) and panic-loss metrics (loss sum/max, per-episode loss
   drawdown min/mean/max, and halt-to-restart equity loss) may be used for scoring and limits.
-  Finite rolling PnL lookbacks, dual-side and multi-coin HSL, per-coin HSL overrides, and HSL
-  strategy-equity EMA/recovery-distribution metrics remain fail closed for now.
+  Dual-side and multi-coin HSL, per-coin HSL overrides, and HSL strategy-equity
+  EMA/recovery-distribution metrics remain fail closed for now.
   Compatible single-coin suites may use the supported topology.
 - single-coin EMA Anchor and Trailing Martingale support auto-unstuck for long-only,
   short-only, hedge-mode dual-side, one-way, and compatible suite runs. One-sided multi-coin runs

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -992,15 +992,14 @@ def _validate_scope_config(
             raise ValueError(
                 "GPU HSL currently requires one enabled side and one backtest coin"
             )
-        lookback = parse_pnls_max_lookback_days(
+        # The proxy deliberately keeps an all-history candidate-local peak for
+        # finite windows. That peak is never below Rust's rolling-window peak,
+        # so HSL may trigger early but cannot miss a drawdown solely because an
+        # older peak aged out. Exact validation remains authoritative.
+        parse_pnls_max_lookback_days(
             config.get("live", {}).get("pnls_max_lookback_days", 30.0),
             field_name="live.pnls_max_lookback_days",
         )
-        if not lookback.is_all:
-            raise ValueError(
-                "GPU HSL currently requires live.pnls_max_lookback_days='all'; "
-                "finite rolling HSL peaks remain exact-Rust-only"
-            )
         signal_mode = str(
             config.get("live", {}).get("hsl_signal_mode", "unified")
         ).strip().lower()

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1426,12 +1426,13 @@ def test_gpu_foundation_accepts_one_sided_single_coin_hsl():
     assert _validate_scope(config, _Evaluator()) == "bybit"
 
 
-def test_gpu_hsl_fails_closed_for_finite_pnl_lookback():
+@pytest.mark.parametrize("lookback", [0.0, 30.0, "all"])
+def test_gpu_hsl_accepts_conservative_pnl_lookback_envelope(lookback):
     config = _long_only_ema_config()
     config["bot"]["long"]["hsl"]["enabled"] = True
+    config["live"]["pnls_max_lookback_days"] = lookback
 
-    with pytest.raises(ValueError, match="pnls_max_lookback_days='all'"):
-        _validate_scope(config, _Evaluator())
+    assert _validate_scope(config, _Evaluator()) == "bybit"
 
 
 def test_gpu_hsl_accepts_market_panic_close():


### PR DESCRIPTION
## Summary\n\n- allow finite live.pnls_max_lookback_days in the existing one-sided single-coin MPS HSL topology\n- retain the Metal all-history candidate-local peak as a conservative envelope over exact Rust rolling peaks\n- document that the proxy may trigger HSL early after an old peak expires, while exact Rust validation and drift gates remain authoritative\n- keep malformed lookback values fail closed through canonical parsing\n\n## Validation\n\n- full Python optimization test suite\n- cargo fmt check\n- cargo check tests\n- cargo test without default features\n- physical M3 MPS EMA Anchor CLI smoke at the default 30-day lookback: 8 generations, 256 proxy evaluations, 24 exact validations\n- physical M3 MPS Trailing Martingale CLI smoke at the default 30-day lookback: 8 generations, 256 proxy evaluations, 24 exact validations\n- both smokes completed without drift or classification halt