### PR TITLE
feat(optimize): add MPS initial entry metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `entry_initial_balance_pct_long` and `entry_initial_balance_pct_short` scoring and limits
+  to Apple MPS optimization for EMA Anchor and Trailing Martingale across single-coin,
+  multi-coin, dual-side, and compatible suite runs. Metal derives the value from each candidate's
+  effective position count, total exposure, initial quantity, bounded or legacy excess allowance,
+  and first-coin override precedence, while exact Rust validation remains authoritative.
+
 - Added `position_unchanged_hours_max` and `position_unchanged_days_max` scoring and limits to
   Apple MPS optimization for EMA
   Anchor and Trailing Martingale across long, short, dual-side, single-coin, multi-coin, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ All notable user-facing changes will be documented in this file.
 
 - Added `entry_initial_balance_pct_long` and `entry_initial_balance_pct_short` scoring and limits
   to Apple MPS optimization for EMA Anchor and Trailing Martingale across single-coin,
-  multi-coin, dual-side, and compatible suite runs. Metal derives the value from each candidate's
+  one-sided multi-coin, and compatible suite runs. Metal derives the value from each candidate's
   effective position count, total exposure, initial quantity, bounded or legacy excess allowance,
-  and first-coin override precedence, while exact Rust validation remains authoritative.
+  and first-coin override precedence, while exact Rust validation remains authoritative. Dual-side
+  multi-coin runs fail closed for these metrics because independent directional summaries cannot
+  truncate their effective coin counts at shared portfolio liquidation.
 
 - Added `position_unchanged_hours_max` and `position_unchanged_days_max` scoring and limits to
   Apple MPS optimization for EMA

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -298,9 +298,12 @@ hash-canonicalizes those dead genes using the same rule as exact candidate mater
 Proxy scoring and limits are likewise fail-closed. The supported strategy-equity surface includes
 gain, ADG, MDG, Sharpe, Sortino, Omega, Calmar, Sterling, expected shortfall, worst and worst-1%
 drawdown, mean and median underwater percentage, maximum recovery and position-held duration,
-volume per active day, backtest completion, and weighted variants of ADG, MDG, Sharpe, Sortino,
-Omega, Calmar, and Sterling. Fill-gap longest, mean, median, p95, and p99 metrics are also
-supported. Metal coalesces multiple fills in the same candle and records positive inter-candle gaps
+position-unchanged duration, initial-entry balance percentage for each side, volume per active day,
+backtest completion, and weighted variants of ADG, MDG, Sharpe, Sortino, Omega, Calmar, and
+Sterling. Initial-entry allocation uses the candidate's effective position count and the same
+first-coin strategy/allowance override precedence as exact Rust. Fill-gap longest, mean, median,
+p95, and p99 metrics are also supported. Metal coalesces multiple fills in the same candle and
+records positive inter-candle gaps
 in a 128-bin logarithmic histogram; the proxy decodes each occupied bin with a float32-safe upper
 edge and adds the exact leading and trailing gaps. This deliberately overestimates the minimizing
 fill-gap summaries when exact Rust has same-candle zero gaps or a value inside a histogram bin.

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -230,11 +230,12 @@ screening also rejects `fills_gap_longest_days`,
 `fills_gap_mean_hours`, `fills_gap_median_hours`, `fills_gap_p95_hours`,
 `fills_gap_p99_hours`,
 `strategy_eq_recovery_days_max`, `peak_recovery_hours_strategy_eq`,
+`entry_initial_balance_pct_long`, `entry_initial_balance_pct_short`,
 `position_held_days_max`, `position_held_hours_max`, `position_unchanged_days_max`,
 `position_unchanged_hours_max`, and `volume_pct_per_day_avg`: the independent directional
 summaries cannot reconstruct cross-side-only fill gaps, alternating portfolio recovery periods,
-duration maxima truncated at shared portfolio liquidation, or fill volume normalized by the shared
-balance safely.
+effective coin counts and duration maxima truncated at shared portfolio liquidation, or fill volume
+normalized by the shared balance safely.
 
 For a supported suite, each Metal candidate is dispatched across every prepared scenario. The GPU
 path then calls the same canonical suite reducer and scenario-selection logic as the CPU optimizer

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -42,10 +42,12 @@ mod tests {
         let source = mps_ema_anchor_source();
         assert!(source.contains("kernel void passivbot_ema_anchor"));
         assert!(source.contains("constant int DAILY_COLS = 5"));
-        assert!(source.contains("constant int SCALAR_COLS = 46"));
+        assert!(source.contains("constant int SCALAR_COLS = 48"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[so + 44] = loss_sum"));
         assert!(source.contains("scalars[so + 45] = position_unchanged_max_min * interval_ms"));
+        assert!(source.contains("scalars[so + 46] = long_side.allowed_wel"));
+        assert!(source.contains("scalars[so + 47] = short_side.allowed_wel"));
         assert!(source.contains("constant int SIDE_PARAMS = 34"));
         assert!(source.contains("struct HslState"));
         assert!(source.contains("update_hsl("));
@@ -109,11 +111,12 @@ mod tests {
         assert!(source.contains("constant int COIN_COLS = 11"));
         assert!(source.contains("constant int DAILY_COLS = 6"));
         assert!(source.contains("day_min_balance"));
-        assert!(source.contains("constant int SCALAR_COLS = 21"));
+        assert!(source.contains("constant int SCALAR_COLS = 22"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[scalar_offset + 19] = loss_sum"));
         assert!(source
             .contains("scalars[scalar_offset + 20] = position_unchanged_max_min * interval_ms"));
+        assert!(source.contains("scalars[scalar_offset + 21] = allowed_wallet_exposure_limit"));
         assert!(source.contains("close_tick[c] <= fill_ticks[tick_offset + 0]"));
         assert!(source.contains("entry_tick[c] > fill_ticks[tick_offset + 1]"));
         assert!(source.contains("const float volume_drop = clamp(params[po + 14]"));
@@ -147,10 +150,12 @@ mod tests {
         assert!(source.contains("struct HslState"));
         assert!(source.contains("update_hsl("));
         assert!(source.contains("try_restart_hsl("));
-        assert!(source.contains("constant int SCALAR_COLS = 46"));
+        assert!(source.contains("constant int SCALAR_COLS = 48"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[so + 44] = loss_sum"));
         assert!(source.contains("scalars[so + 45] = position_unchanged_max_min * interval_ms"));
+        assert!(source.contains("scalars[so + 46] = long_side.allowed_wel"));
+        assert!(source.contains("scalars[so + 47] = short_side.allowed_wel"));
         assert!(source.contains("hsl_tier_samples_total"));
         assert!(source.contains("h.restart_retrigger_count"));
         assert!(source.contains("h.halt_duration_sum_steps"));
@@ -253,11 +258,12 @@ mod tests {
         assert!(source.contains("constant int MAX_COINS = 64"));
         assert!(source.contains("constant int PARAM_COLS = 48"));
         assert!(source.contains("constant int OVERRIDE_COLS = 34"));
-        assert!(source.contains("constant int SCALAR_COLS = 21"));
+        assert!(source.contains("constant int SCALAR_COLS = 22"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[scalar_offset + 19] = loss_sum"));
         assert!(source
             .contains("scalars[scalar_offset + 20] = position_unchanged_max_min * interval_ms"));
+        assert!(source.contains("scalars[scalar_offset + 21] = allowed_wallet_exposure_limit"));
         assert!(source.contains("coin_wel_enforcer_enabled"));
         assert!(source.contains("coin_wel_enforcer_threshold"));
         assert!(source.contains("twel_enforcer_enabled"));

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -46,8 +46,8 @@ mod tests {
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[so + 44] = loss_sum"));
         assert!(source.contains("scalars[so + 45] = position_unchanged_max_min * interval_ms"));
-        assert!(source.contains("scalars[so + 46] = long_side.allowed_wel"));
-        assert!(source.contains("scalars[so + 47] = short_side.allowed_wel"));
+        assert!(source.contains("scalars[so + 46] = long_enabled"));
+        assert!(source.contains("scalars[so + 47] = short_enabled"));
         assert!(source.contains("constant int SIDE_PARAMS = 34"));
         assert!(source.contains("struct HslState"));
         assert!(source.contains("update_hsl("));
@@ -121,6 +121,7 @@ mod tests {
         assert!(source.contains("entry_tick[c] > fill_ticks[tick_offset + 1]"));
         assert!(source.contains("const float volume_drop = clamp(params[po + 14]"));
         assert!(source.contains("effective_n_positions"));
+        assert!(source.contains("if (alive) max_tradable_seen = max("));
         assert!(source.contains("const float score_hysteresis = fmax(run_settings[4], 0.0f)"));
         assert!(source.contains("incumbent[c] = selected[c] && psize[c] <= 0.0f"));
         assert!(source.contains("if (!selected[c] || incumbent[c] || !survivor[c]) continue"));
@@ -154,8 +155,8 @@ mod tests {
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[so + 44] = loss_sum"));
         assert!(source.contains("scalars[so + 45] = position_unchanged_max_min * interval_ms"));
-        assert!(source.contains("scalars[so + 46] = long_side.allowed_wel"));
-        assert!(source.contains("scalars[so + 47] = short_side.allowed_wel"));
+        assert!(source.contains("scalars[so + 46] = long_enabled"));
+        assert!(source.contains("scalars[so + 47] = short_enabled"));
         assert!(source.contains("hsl_tier_samples_total"));
         assert!(source.contains("h.restart_retrigger_count"));
         assert!(source.contains("h.halt_duration_sum_steps"));
@@ -271,6 +272,7 @@ mod tests {
         assert!(source.contains("twel_close_qty"));
         assert!(source.contains("realized_loss_proxy_allows_close"));
         assert!(source.contains("const bool loss_gate_enabled = run_settings[5] < 1.0f"));
+        assert!(source.contains("if (alive) max_tradable_seen = max("));
         assert!(source.contains("market_price * 0.9995f / price_step"));
         assert_eq!(source.matches("clamped_market_price(").count(), 3);
         assert!(source.contains("finalized_twel_reducer_qty = ordinary_can_accompany_reducer"));

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -121,7 +121,10 @@ mod tests {
         assert!(source.contains("entry_tick[c] > fill_ticks[tick_offset + 1]"));
         assert!(source.contains("const float volume_drop = clamp(params[po + 14]"));
         assert!(source.contains("effective_n_positions"));
-        assert!(source.contains("if (alive) max_tradable_seen = max("));
+        assert!(source.contains(
+            "const bool post_fill_balance_depleted = isfinite(balance) && balance <= 0.0f"
+        ));
+        assert!(source.contains("if (alive && !post_fill_balance_depleted)"));
         assert!(source.contains("const float score_hysteresis = fmax(run_settings[4], 0.0f)"));
         assert!(source.contains("incumbent[c] = selected[c] && psize[c] <= 0.0f"));
         assert!(source.contains("if (!selected[c] || incumbent[c] || !survivor[c]) continue"));
@@ -272,7 +275,10 @@ mod tests {
         assert!(source.contains("twel_close_qty"));
         assert!(source.contains("realized_loss_proxy_allows_close"));
         assert!(source.contains("const bool loss_gate_enabled = run_settings[5] < 1.0f"));
-        assert!(source.contains("if (alive) max_tradable_seen = max("));
+        assert!(source.contains(
+            "const bool post_fill_balance_depleted = isfinite(balance) && balance <= 0.0f"
+        ));
+        assert!(source.contains("if (alive && !post_fill_balance_depleted)"));
         assert!(source.contains("market_price * 0.9995f / price_step"));
         assert_eq!(source.matches("clamped_market_price(").count(), 3);
         assert!(source.contains("finalized_twel_reducer_qty = ordinary_can_accompany_reducer"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -1799,8 +1799,10 @@ inline void passivbot_single_coin_impl(
     scalars[so + 43] = profit_sum;
     scalars[so + 44] = loss_sum;
     scalars[so + 45] = position_unchanged_max_min * interval_ms;
-    scalars[so + 46] = long_side.allowed_wel * long_side.base_qty_pct;
-    scalars[so + 47] = short_side.allowed_wel * short_side.base_qty_pct;
+    scalars[so + 46] = long_enabled
+        ? long_side.allowed_wel * long_side.base_qty_pct : 0.0f;
+    scalars[so + 47] = short_enabled
+        ? short_side.allowed_wel * short_side.base_qty_pct : 0.0f;
 }
 
 kernel void passivbot_ema_anchor(

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -2,7 +2,7 @@
 using namespace metal;
 
 constant int DAILY_COLS = 5;
-constant int SCALAR_COLS = 46;
+constant int SCALAR_COLS = 48;
 constant int GAP_BINS = 128;
 constant int SIDE_PARAMS = 34;
 
@@ -1799,6 +1799,8 @@ inline void passivbot_single_coin_impl(
     scalars[so + 43] = profit_sum;
     scalars[so + 44] = loss_sum;
     scalars[so + 45] = position_unchanged_max_min * interval_ms;
+    scalars[so + 46] = long_side.allowed_wel * long_side.base_qty_pct;
+    scalars[so + 47] = short_side.allowed_wel * short_side.base_qty_pct;
 }
 
 kernel void passivbot_ema_anchor(

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -640,7 +640,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 tradable_count += 1;
             }
         }
-        max_tradable_seen = max(max_tradable_seen, tradable_count);
+        if (alive) max_tradable_seen = max(max_tradable_seen, tradable_count);
         const int effective_n_positions = min(n_positions, max_tradable_seen);
         const bool can_generate = alive && effective_n_positions > 0
             && k > max(global_warmup, 1) && k >= requested_start_k;

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -6,7 +6,7 @@ constant int PARAM_COLS = 31;
 constant int COIN_COLS = 11;
 constant int OVERRIDE_COLS = 19;
 constant int DAILY_COLS = 6;
-constant int SCALAR_COLS = 21;
+constant int SCALAR_COLS = 22;
 constant int GAP_BINS = 128;
 
 inline float round_step(float value, float step) {
@@ -1483,6 +1483,18 @@ inline void passivbot_ema_anchor_multicoin_impl(
     scalars[scalar_offset + 18] = profit_sum;
     scalars[scalar_offset + 19] = loss_sum;
     scalars[scalar_offset + 20] = position_unchanged_max_min * interval_ms;
+    int entry_effective_n_positions = min(n_positions, max_tradable_seen);
+    float entry_base_limit = entry_effective_n_positions > 0
+        ? twel / float(entry_effective_n_positions) : 0.0f;
+    float entry_initial_qty_pct = coin_override_or(
+        coin_overrides, 0, 0, base_qty_pct
+    );
+    float entry_allowance_pct = coin_override_or(
+        coin_overrides, 0, 12, allowance_pct
+    );
+    scalars[scalar_offset + 21] = allowed_wallet_exposure_limit(
+        entry_base_limit, twel, entry_allowance_pct, legacy_raw_allowance
+    ) * entry_initial_qty_pct;
 }
 
 kernel void passivbot_ema_anchor_multicoin(

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -640,7 +640,10 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 tradable_count += 1;
             }
         }
-        if (alive) max_tradable_seen = max(max_tradable_seen, tradable_count);
+        const bool post_fill_balance_depleted = isfinite(balance) && balance <= 0.0f;
+        if (alive && !post_fill_balance_depleted) {
+            max_tradable_seen = max(max_tradable_seen, tradable_count);
+        }
         const int effective_n_positions = min(n_positions, max_tradable_seen);
         const bool can_generate = alive && effective_n_positions > 0
             && k > max(global_warmup, 1) && k >= requested_start_k;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -2,7 +2,7 @@
 using namespace metal;
 
 constant int DAILY_COLS = 5;
-constant int SCALAR_COLS = 46;
+constant int SCALAR_COLS = 48;
 constant int GAP_BINS = 128;
 constant int SIDE_PARAMS = 51;
 
@@ -2768,6 +2768,8 @@ inline void passivbot_single_coin_impl(
     scalars[so + 43] = profit_sum;
     scalars[so + 44] = loss_sum;
     scalars[so + 45] = position_unchanged_max_min * interval_ms;
+    scalars[so + 46] = long_side.allowed_wel * long_side.initial_qty_pct;
+    scalars[so + 47] = short_side.allowed_wel * short_side.initial_qty_pct;
 }
 
 kernel void passivbot_trailing_martingale(

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -2768,8 +2768,10 @@ inline void passivbot_single_coin_impl(
     scalars[so + 43] = profit_sum;
     scalars[so + 44] = loss_sum;
     scalars[so + 45] = position_unchanged_max_min * interval_ms;
-    scalars[so + 46] = long_side.allowed_wel * long_side.initial_qty_pct;
-    scalars[so + 47] = short_side.allowed_wel * short_side.initial_qty_pct;
+    scalars[so + 46] = long_enabled
+        ? long_side.allowed_wel * long_side.initial_qty_pct : 0.0f;
+    scalars[so + 47] = short_enabled
+        ? short_side.allowed_wel * short_side.initial_qty_pct : 0.0f;
 }
 
 kernel void passivbot_trailing_martingale(

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -1199,7 +1199,10 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 tradable_count += 1;
             }
         }
-        if (alive) max_tradable_seen = max(max_tradable_seen, tradable_count);
+        const bool post_fill_balance_depleted = isfinite(balance) && balance <= 0.0f;
+        if (alive && !post_fill_balance_depleted) {
+            max_tradable_seen = max(max_tradable_seen, tradable_count);
+        }
         const int effective_n_positions = min(n_positions, max_tradable_seen);
         const bool can_generate = alive && effective_n_positions > 0
             && k > max(global_warmup, 1) && k >= requested_start_k;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -1199,7 +1199,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 tradable_count += 1;
             }
         }
-        max_tradable_seen = max(max_tradable_seen, tradable_count);
+        if (alive) max_tradable_seen = max(max_tradable_seen, tradable_count);
         const int effective_n_positions = min(n_positions, max_tradable_seen);
         const bool can_generate = alive && effective_n_positions > 0
             && k > max(global_warmup, 1) && k >= requested_start_k;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -6,7 +6,7 @@ constant int PARAM_COLS = 48;
 constant int OVERRIDE_COLS = 34;
 constant int COIN_COLS = 11;
 constant int DAILY_COLS = 6;
-constant int SCALAR_COLS = 21;
+constant int SCALAR_COLS = 22;
 constant int GAP_BINS = 128;
 
 inline float round_step(float value, float step) {
@@ -2291,6 +2291,18 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     scalars[scalar_offset + 18] = profit_sum;
     scalars[scalar_offset + 19] = loss_sum;
     scalars[scalar_offset + 20] = position_unchanged_max_min * interval_ms;
+    int entry_effective_n_positions = min(n_positions, max_tradable_seen);
+    float entry_base_limit = entry_effective_n_positions > 0
+        ? twel / float(entry_effective_n_positions) : 0.0f;
+    float entry_initial_qty_pct = coin_override_or(
+        coin_overrides, 0, 6, initial_qty_pct
+    );
+    float entry_allowance_pct = coin_override_or(
+        coin_overrides, 0, 25, allowance_pct
+    );
+    scalars[scalar_offset + 21] = allowed_wallet_exposure_limit(
+        entry_base_limit, twel, entry_allowance_pct, legacy_raw_allowance
+    ) * entry_initial_qty_pct;
 }
 
 kernel void passivbot_trailing_martingale_multicoin(

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -1044,6 +1044,8 @@ def _validate_dual_multicoin_metrics(
     unsupported = sorted(
         set(needed_metrics)
         & {
+            "entry_initial_balance_pct_long",
+            "entry_initial_balance_pct_short",
             "fills_gap_longest_days",
             "fills_gap_mean_hours",
             "fills_gap_median_hours",

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -23,6 +23,8 @@ SUPPORTED_METRICS = (
     "drawdown_worst_mean_1pct_strategy_eq",
     "drawdown_worst_strategy_eq",
     "expected_shortfall_1pct_strategy_eq",
+    "entry_initial_balance_pct_long",
+    "entry_initial_balance_pct_short",
     "fills_gap_longest_days",
     "fills_gap_mean_hours",
     "fills_gap_median_hours",
@@ -829,6 +831,10 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
         )
         objectives["position_unchanged_hours_max"] = position_unchanged_hours_max
         objectives["position_unchanged_days_max"] = position_unchanged_hours_max / 24.0
+    for side in ("long", "short"):
+        name = f"entry_initial_balance_pct_{side}"
+        if name in requested:
+            objectives[name] = out[name].to(torch.float64)
     objectives.update(fill_gap_metrics)
     objectives.update(hard_stop_metrics)
     objectives.update(hard_stop_panic_loss_metrics)

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -19,8 +19,8 @@ from optimization.gpu.model import (
 
 MPS_DAILY_COLS = 5
 MPS_MULTICOIN_DAILY_COLS = 6
-MPS_SCALAR_COLS = 21
-MPS_DIRECTIONAL_SCALAR_COLS = 46
+MPS_SCALAR_COLS = 22
+MPS_DIRECTIONAL_SCALAR_COLS = 48
 
 
 def _encode_max_realized_loss_pct(value: float) -> float:
@@ -121,6 +121,7 @@ def _decode_outputs(daily, scalars, gaps) -> dict:
         "profit_sum": scalars[:, 18],
         "loss_sum": scalars[:, 19],
         "position_unchanged_max_ms": scalars[:, 20],
+        "entry_initial_balance_pct": scalars[:, 21],
     }
 
 
@@ -188,6 +189,8 @@ def _decode_directional_outputs(daily, scalars, gaps) -> dict:
         "profit_sum": scalars[:, 43],
         "loss_sum": scalars[:, 44],
         "position_unchanged_max_ms": scalars[:, 45],
+        "entry_initial_balance_pct_long": scalars[:, 46],
+        "entry_initial_balance_pct_short": scalars[:, 47],
     }
 
 

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -43,6 +43,9 @@ CORE_OUTPUT_KEYS = {
     "liq_step",
     "profit_sum",
     "loss_sum",
+    "entry_initial_balance_pct",
+    "entry_initial_balance_pct_long",
+    "entry_initial_balance_pct_short",
 }
 
 DIRECTIONAL_HSL_OUTPUT_KEYS = {
@@ -275,6 +278,18 @@ def _nan_max(left, right):
         left_finite & ~right_finite,
         right.where(right_finite & ~left_finite, left.maximum(right)),
     )
+
+
+def _directional_entry_initial_metrics(side: str, entry_pct):
+    """Expand one directional Metal value into the shared two-side surface."""
+
+    if side not in {"long", "short"}:
+        raise ValueError(f"expected long or short entry metric side, got {side!r}")
+    zeros = entry_pct.new_zeros(entry_pct.shape)
+    return {
+        "entry_initial_balance_pct_long": entry_pct if side == "long" else zeros,
+        "entry_initial_balance_pct_short": entry_pct if side == "short" else zeros,
+    }
 
 
 def _combine_hedged_multicoin_outputs(
@@ -1242,7 +1257,13 @@ class MpsMulticoinProxy:
                 for side in self.sides
             }
             if len(self.sides) == 1:
-                output = side_outputs[self.sides[0]]
+                side = self.sides[0]
+                output = side_outputs[side]
+                output.update(
+                    _directional_entry_initial_metrics(
+                        side, output["entry_initial_balance_pct"]
+                    )
+                )
             else:
                 output = _combine_hedged_multicoin_outputs(
                     side_outputs["long"],
@@ -1252,6 +1273,12 @@ class MpsMulticoinProxy:
                     self.runners["long"].start_minute_of_day,
                     self.run.interval_ms,
                 )
+                output["entry_initial_balance_pct_long"] = side_outputs[
+                    "long"
+                ]["entry_initial_balance_pct"]
+                output["entry_initial_balance_pct_short"] = side_outputs[
+                    "short"
+                ]["entry_initial_balance_pct"]
             timestamp_origin = float(self.metrics_data["ts0"])
             for key in (
                 "first_fill_ts",

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -292,6 +292,16 @@ def _directional_entry_initial_metrics(side: str, entry_pct):
     }
 
 
+def _prepared_single_coin_side_enabled(config: dict, side: str, bot: dict) -> bool:
+    """Match exact Rust eligibility for the one coin prepared by the payload."""
+
+    if "entry_eligible" not in bot:
+        raise ValueError(
+            f"GPU single-coin payload for {side} is missing entry_eligible"
+        )
+    return gpu_side_enabled(config, side) and bool(bot["entry_eligible"])
+
+
 def _combine_hedged_multicoin_outputs(
     long: dict,
     short: dict,
@@ -495,7 +505,8 @@ class MpsSingleCoinProxy:
         long_bot = payload.bot_params_list[0]["long"]
         short_bot = payload.bot_params_list[0]["short"]
         self.enabled = {
-            side: gpu_side_enabled(config, side) for side in ("long", "short")
+            side: _prepared_single_coin_side_enabled(config, side, bot)
+            for side, bot in (("long", long_bot), ("short", short_bot))
         }
         if not any(self.enabled.values()):
             raise ValueError("GPU foundation requires at least one enabled side")

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -2163,6 +2163,8 @@ def test_gpu_multicoin_foundation_rejects_asymmetric_dual_side_coins(strategy_ki
 @pytest.mark.parametrize(
     "metric",
     [
+        "entry_initial_balance_pct_long",
+        "entry_initial_balance_pct_short",
         "fills_gap_longest_days",
         "fills_gap_mean_hours",
         "fills_gap_median_hours",
@@ -2190,6 +2192,8 @@ def test_gpu_dual_multicoin_rejects_unreconstructable_metrics(metric):
 def test_gpu_dual_multicoin_metric_gate_does_not_narrow_single_side():
     _validate_dual_multicoin_metrics(
         {
+            "entry_initial_balance_pct_long",
+            "entry_initial_balance_pct_short",
             "fills_gap_longest_days",
             "fills_gap_mean_hours",
             "fills_gap_median_hours",

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -59,6 +59,8 @@ def test_duration_alias_metrics_match_rust_unit_contracts():
         "first_eq_ts": torch.tensor([0.0], dtype=torch.float64),
         "last_eq_ts": torch.tensor([36 * 3_600_000.0], dtype=torch.float64),
         "liq_step": torch.tensor([-1.0], dtype=torch.float64),
+        "entry_initial_balance_pct_long": torch.tensor([0.125]),
+        "entry_initial_balance_pct_short": torch.tensor([0.075]),
     }
     run = SimpleNamespace(
         requested_start_ts_ms=0, guard_ts_ms=0, interval_ms=60_000
@@ -70,6 +72,8 @@ def test_duration_alias_metrics_match_rust_unit_contracts():
         "position_unchanged_hours_max",
         "strategy_eq_recovery_days_max",
         "peak_recovery_hours_strategy_eq",
+        "entry_initial_balance_pct_long",
+        "entry_initial_balance_pct_short",
     }
 
     metrics = compute_objectives(
@@ -86,6 +90,8 @@ def test_duration_alias_metrics_match_rust_unit_contracts():
     assert metrics["position_unchanged_days_max"].item() == pytest.approx(0.75)
     assert metrics["strategy_eq_recovery_days_max"].item() == pytest.approx(1.25)
     assert metrics["peak_recovery_hours_strategy_eq"].item() == pytest.approx(30.0)
+    assert metrics["entry_initial_balance_pct_long"].item() == pytest.approx(0.125)
+    assert metrics["entry_initial_balance_pct_short"].item() == pytest.approx(0.075)
     assert requested <= set(SUPPORTED_METRICS)
 
 

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -317,6 +317,36 @@ def test_mps_multicoin_initial_entry_pct_freezes_denominator_at_liquidation(
     assert output["entry_initial_balance_pct"].item() == pytest.approx(1.0)
 
 
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_multicoin_initial_entry_pct_freezes_before_post_fill_balance_depletion(
+    strategy_kind, side
+):
+    markets = [
+        ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 2.0),
+        ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 2.0),
+    ]
+    runner, row = _multicoin_exposure_fixture(
+        strategy_kind,
+        side,
+        count=12,
+        markets=markets,
+        first_valid_indices=(0, 3),
+    )
+
+    output = runner.run(np.asarray([row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert not output["alive"].item()
+    # Coin one fills and its fee depletes balance on the same candle that coin
+    # two first becomes tradable. Exact Rust liquidates before growing the
+    # effective-position denominator.
+    assert output["entry_initial_balance_pct"].item() == pytest.approx(1.0)
+
+
 def test_directional_touch_ticks_preserve_alignment_and_round_non_aligned_prices():
     down, up, nearest = _directional_touch_ticks(
         np.array([100.0, 100.006, 0.1 + 0.2]), 0.01

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -262,6 +262,32 @@ def test_mps_multicoin_tracks_position_unchanged_max(strategy_kind, side):
     unchanged_ms = output["position_unchanged_max_ms"].item()
     assert unchanged_ms > 0.0
     assert unchanged_ms <= output["held_max_ms"].item()
+    assert output["entry_initial_balance_pct"].item() == pytest.approx(0.5)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_multicoin_initial_entry_pct_uses_first_coin_override(
+    strategy_kind, side
+):
+    override_cols = 19 if strategy_kind == "ema_anchor" else 34
+    initial_qty_column = 0 if strategy_kind == "ema_anchor" else 6
+    allowance_column = 12 if strategy_kind == "ema_anchor" else 25
+    overrides = np.full((2, override_cols), np.nan, dtype=np.float32)
+    overrides[0, initial_qty_column] = 0.25
+    overrides[0, allowance_column] = 0.5
+    runner, row = _multicoin_exposure_fixture(
+        strategy_kind, side, coin_overrides=overrides, count=16
+    )
+
+    output = runner.run(np.asarray([row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    # TWEL 1.0 / two effective positions, with a bounded 50% allowance.
+    assert output["entry_initial_balance_pct"].item() == pytest.approx(0.1875)
 
 
 def test_directional_touch_ticks_preserve_alignment_and_round_non_aligned_prices():
@@ -396,7 +422,7 @@ def test_mps_ema_anchor_shader_smoke():
     assert "const bool long_hsl_panic_market = settings[17] > 0.5f" in source
     assert "const bool short_hsl_panic_market = settings[18] > 0.5f" in source
     assert "market_panic ? taker_fee : maker_fee" in source
-    assert "constant int SCALAR_COLS = 46" in source
+    assert "constant int SCALAR_COLS = 48" in source
     assert "record_gross_pnl" in source
     assert "hsl_tier_samples_total" in source
     assert "h.restart_retrigger_count" in source
@@ -1286,6 +1312,8 @@ def test_mps_position_unchanged_includes_open_tail(strategy_kind, side):
     assert output["position_unchanged_max_ms"].item() == pytest.approx(
         expected_open_tail_ms.item()
     )
+    assert output["entry_initial_balance_pct_long"].item() == pytest.approx(0.1)
+    assert output["entry_initial_balance_pct_short"].item() == pytest.approx(0.1)
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -114,6 +114,8 @@ def _multicoin_exposure_fixture(
     highs=None,
     lows=None,
     max_realized_loss_pct=1.0,
+    first_valid_indices=(0, 0),
+    liquidation_threshold=0.05,
 ):
     coin_count = 2
     timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
@@ -142,16 +144,16 @@ def _multicoin_exposure_fixture(
         ProxyRun(
             1_000.0,
             1,
-            1,
+            max(1, first_valid_indices[coin]),
             int(timestamps[0]),
             int(timestamps[0]),
             int(timestamps[0]),
             60_000,
-            0.05,
-            0,
+            liquidation_threshold,
+            first_valid_indices[coin],
             count - 1,
         )
-        for _ in range(coin_count)
+        for coin in range(coin_count)
     ]
     data = build_mps_multicoin_data(hlcvs, timestamps, runs, markets)
     if strategy_kind == "ema_anchor":
@@ -288,6 +290,31 @@ def test_mps_multicoin_initial_entry_pct_uses_first_coin_override(
 
     # TWEL 1.0 / two effective positions, with a bounded 50% allowance.
     assert output["entry_initial_balance_pct"].item() == pytest.approx(0.1875)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_multicoin_initial_entry_pct_freezes_denominator_at_liquidation(
+    strategy_kind, side
+):
+    runner, row = _multicoin_exposure_fixture(
+        strategy_kind,
+        side,
+        count=20,
+        first_valid_indices=(0, 12),
+        liquidation_threshold=1.0,
+    )
+
+    output = runner.run(np.asarray([row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert not output["alive"].item()
+    # The liquidation floor terminates before the second coin becomes
+    # tradable, so exact Rust retains a one-position divisor.
+    assert output["entry_initial_balance_pct"].item() == pytest.approx(1.0)
 
 
 def test_directional_touch_ticks_preserve_alignment_and_round_non_aligned_prices():
@@ -1312,8 +1339,14 @@ def test_mps_position_unchanged_includes_open_tail(strategy_kind, side):
     assert output["position_unchanged_max_ms"].item() == pytest.approx(
         expected_open_tail_ms.item()
     )
-    assert output["entry_initial_balance_pct_long"].item() == pytest.approx(0.1)
-    assert output["entry_initial_balance_pct_short"].item() == pytest.approx(0.1)
+    expected_long = 0.1 if side == "long" else 0.0
+    expected_short = 0.1 if side == "short" else 0.0
+    assert output["entry_initial_balance_pct_long"].item() == pytest.approx(
+        expected_long
+    )
+    assert output["entry_initial_balance_pct_short"].item() == pytest.approx(
+        expected_short
+    )
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -21,6 +21,7 @@ from optimization.gpu.service import (
     _build_multicoin_ema_coin_overrides,
     _build_multicoin_tm_coin_overrides,
     _combine_hedged_multicoin_outputs,
+    _directional_entry_initial_metrics,
     _hsl_params,
     _position_exposure_enforcer_params,
     _require_complete_valid_tail,
@@ -32,7 +33,27 @@ from optimization.gpu.service import (
 
 
 def test_core_output_contract_retains_gross_pnl_aggregates():
-    assert {"profit_sum", "loss_sum", "position_unchanged_max_ms"} <= CORE_OUTPUT_KEYS
+    assert {
+        "profit_sum",
+        "loss_sum",
+        "position_unchanged_max_ms",
+        "entry_initial_balance_pct",
+        "entry_initial_balance_pct_long",
+        "entry_initial_balance_pct_short",
+    } <= CORE_OUTPUT_KEYS
+
+
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_directional_entry_initial_metrics_preserve_candidate_batch_shape(side):
+    torch = pytest.importorskip("torch")
+    values = torch.tensor([0.1, 0.2, 0.3])
+
+    metrics = _directional_entry_initial_metrics(side, values)
+
+    assert metrics[f"entry_initial_balance_pct_{side}"].tolist() == values.tolist()
+    other = "short" if side == "long" else "long"
+    assert metrics[f"entry_initial_balance_pct_{other}"].shape == values.shape
+    assert metrics[f"entry_initial_balance_pct_{other}"].tolist() == [0.0, 0.0, 0.0]
 
 
 def test_directional_hsl_output_contract_retains_lifecycle_and_panic_scalars():

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -24,6 +24,7 @@ from optimization.gpu.service import (
     _directional_entry_initial_metrics,
     _hsl_params,
     _position_exposure_enforcer_params,
+    _prepared_single_coin_side_enabled,
     _require_complete_valid_tail,
     _require_no_internal_invalid_hsl_candles,
     _single_coin_exposure_params,
@@ -54,6 +55,27 @@ def test_directional_entry_initial_metrics_preserve_candidate_batch_shape(side):
     other = "short" if side == "long" else "long"
     assert metrics[f"entry_initial_balance_pct_{other}"].shape == values.shape
     assert metrics[f"entry_initial_balance_pct_{other}"].tolist() == [0.0, 0.0, 0.0]
+
+
+def test_single_coin_side_eligibility_uses_prepared_coin_payload():
+    config = {
+        "bot": {
+            "long": {"risk": {"total_wallet_exposure_limit": 1.0, "n_positions": 1}}
+        },
+        "live": {"approved_coins": {"long": ["BTC"]}},
+    }
+
+    assert _prepared_single_coin_side_enabled(
+        config, "long", {"entry_eligible": True}
+    )
+    assert not _prepared_single_coin_side_enabled(
+        config, "long", {"entry_eligible": False}
+    )
+
+
+def test_single_coin_side_eligibility_requires_canonical_payload_flag():
+    with pytest.raises(ValueError, match="entry_eligible"):
+        _prepared_single_coin_side_enabled({}, "short", {})
 
 
 def test_directional_hsl_output_contract_retains_lifecycle_and_panic_scalars():


### PR DESCRIPTION
Adds Apple MPS proxy support for `entry_initial_balance_pct_long` and
`entry_initial_balance_pct_short` across EMA Anchor and Trailing Martingale,
single-coin long/short/dual-side, one-sided multi-coin, and compatible suites.

Metal now exports the per-candidate initial allocation using exact Rust semantics:
effective position count, total wallet exposure, initial quantity percentage, bounded
or legacy excess allowance, and first-coin override precedence. The single-coin path
uses the prepared coin's canonical `entry_eligible` flag, and one-sided multicoin output
preserves full batch shape while emitting zero for the disabled side. Dual-side
multicoin requests for these metrics fail closed because independent directional
summaries cannot truncate effective coin counts at shared portfolio liquidation.
Exact Rust validation, classification, rank, and drift gates remain authoritative.

Validation:
- full `tests/optimization` suite passed
- physical Apple M3 `tests/optimization/test_gpu_mps.py`: 204 passed, including
  same-candle post-fill balance-depletion denominator coverage for both strategies and sides
- focused physical EMA/TM x single/multi x long/short and first-coin override matrix passed
- Rust `cargo fmt`, `cargo check --tests`, and 262 tests passed on the Metal implementation head
- real dual-side single-coin EMA Anchor, Bybit ETH 2024-01 to 2024-02: 128 proxy / 32 exact, 5.2s, no halt
- real one-sided two-coin Trailing Martingale, Bybit BTC+ETH 2024-01 to 2024-02: 128 proxy / 32 exact, 9.4s, no halt; disabled-side zero verified

GPU support remains additive; CPU optimization, backtesting, and live execution paths are unchanged.
