### PR TITLE
feat(optimize): add MPS wallet exposure metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `total_wallet_exposure_max` and `total_wallet_exposure_mean` scoring and limits to Apple
+  MPS optimization for EMA Anchor and Trailing Martingale across single-coin, one-sided multi-coin,
+  and compatible suite runs. Metal samples absolute net long-minus-short exposure after each
+  non-liquidating equity update, matching Rust's analysis series timing. Dual-side multi-coin runs
+  fail closed because independent directional kernels cannot reconstruct the minute-level net
+  portfolio exposure; exact Rust validation and drift gates remain authoritative.
+
 - Added `entry_initial_balance_pct_long` and `entry_initial_balance_pct_short` scoring and limits
   to Apple MPS optimization for EMA Anchor and Trailing Martingale across single-coin,
   one-sided multi-coin, and compatible suite runs. Metal derives the value from each candidate's

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -184,6 +184,12 @@ The supported slice is intentionally narrow:
   tail through the final analyzed sample. Dual-side multi-coin runs fail closed for both unchanged-
   and held-duration maxima because independent directional summaries cannot truncate a pre-reduced
   maximum at shared portfolio liquidation; exact Rust validation remains authoritative
+- `total_wallet_exposure_max` and `total_wallet_exposure_mean` may be used for scoring and limits
+  in single-coin and one-sided multi-coin runs. Metal samples absolute net long-minus-short wallet
+  exposure after every non-liquidating equity update, including flat zero-exposure samples, and
+  reduces it with bounded maximum and online-mean accumulators. Dual-side multi-coin runs fail
+  closed because independent directional kernels cannot reconstruct the shared minute-level net
+  exposure series
 - Trailing Martingale supports `risk.position_exposure_enforcer_enabled` and a tunable
   `risk.position_exposure_enforcer_threshold` for single- and multi-coin long, short, dual-side,
   and compatible suite runs. When current position exposure exceeds the allowance-adjusted WEL
@@ -232,10 +238,11 @@ screening also rejects `fills_gap_longest_days`,
 `strategy_eq_recovery_days_max`, `peak_recovery_hours_strategy_eq`,
 `entry_initial_balance_pct_long`, `entry_initial_balance_pct_short`,
 `position_held_days_max`, `position_held_hours_max`, `position_unchanged_days_max`,
-`position_unchanged_hours_max`, and `volume_pct_per_day_avg`: the independent directional
+`position_unchanged_hours_max`, `total_wallet_exposure_max`, `total_wallet_exposure_mean`, and
+`volume_pct_per_day_avg`: the independent directional
 summaries cannot reconstruct cross-side-only fill gaps, alternating portfolio recovery periods,
-effective coin counts and duration maxima truncated at shared portfolio liquidation, or fill volume
-normalized by the shared balance safely.
+effective coin counts and duration maxima truncated at shared portfolio liquidation, minute-level
+net exposure, or fill volume normalized by the shared balance safely.
 
 For a supported suite, each Metal candidate is dispatched across every prepared scenario. The GPU
 path then calls the same canonical suite reducer and scenario-selection logic as the CPU optimizer

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -42,12 +42,14 @@ mod tests {
         let source = mps_ema_anchor_source();
         assert!(source.contains("kernel void passivbot_ema_anchor"));
         assert!(source.contains("constant int DAILY_COLS = 5"));
-        assert!(source.contains("constant int SCALAR_COLS = 48"));
+        assert!(source.contains("constant int SCALAR_COLS = 50"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[so + 44] = loss_sum"));
         assert!(source.contains("scalars[so + 45] = position_unchanged_max_min * interval_ms"));
         assert!(source.contains("scalars[so + 46] = long_enabled"));
         assert!(source.contains("scalars[so + 47] = short_enabled"));
+        assert!(source.contains("scalars[so + 48] = total_wallet_exposure_max"));
+        assert!(source.contains("scalars[so + 49] = total_wallet_exposure_mean"));
         assert!(source.contains("constant int SIDE_PARAMS = 34"));
         assert!(source.contains("struct HslState"));
         assert!(source.contains("update_hsl("));
@@ -111,12 +113,14 @@ mod tests {
         assert!(source.contains("constant int COIN_COLS = 11"));
         assert!(source.contains("constant int DAILY_COLS = 6"));
         assert!(source.contains("day_min_balance"));
-        assert!(source.contains("constant int SCALAR_COLS = 22"));
+        assert!(source.contains("constant int SCALAR_COLS = 24"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[scalar_offset + 19] = loss_sum"));
         assert!(source
             .contains("scalars[scalar_offset + 20] = position_unchanged_max_min * interval_ms"));
         assert!(source.contains("scalars[scalar_offset + 21] = allowed_wallet_exposure_limit"));
+        assert!(source.contains("scalars[scalar_offset + 22] = total_wallet_exposure_max"));
+        assert!(source.contains("scalars[scalar_offset + 23] = total_wallet_exposure_mean"));
         assert!(source.contains("close_tick[c] <= fill_ticks[tick_offset + 0]"));
         assert!(source.contains("entry_tick[c] > fill_ticks[tick_offset + 1]"));
         assert!(source.contains("const float volume_drop = clamp(params[po + 14]"));
@@ -154,12 +158,14 @@ mod tests {
         assert!(source.contains("struct HslState"));
         assert!(source.contains("update_hsl("));
         assert!(source.contains("try_restart_hsl("));
-        assert!(source.contains("constant int SCALAR_COLS = 48"));
+        assert!(source.contains("constant int SCALAR_COLS = 50"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[so + 44] = loss_sum"));
         assert!(source.contains("scalars[so + 45] = position_unchanged_max_min * interval_ms"));
         assert!(source.contains("scalars[so + 46] = long_enabled"));
         assert!(source.contains("scalars[so + 47] = short_enabled"));
+        assert!(source.contains("scalars[so + 48] = total_wallet_exposure_max"));
+        assert!(source.contains("scalars[so + 49] = total_wallet_exposure_mean"));
         assert!(source.contains("hsl_tier_samples_total"));
         assert!(source.contains("h.restart_retrigger_count"));
         assert!(source.contains("h.halt_duration_sum_steps"));
@@ -262,12 +268,14 @@ mod tests {
         assert!(source.contains("constant int MAX_COINS = 64"));
         assert!(source.contains("constant int PARAM_COLS = 48"));
         assert!(source.contains("constant int OVERRIDE_COLS = 34"));
-        assert!(source.contains("constant int SCALAR_COLS = 22"));
+        assert!(source.contains("constant int SCALAR_COLS = 24"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[scalar_offset + 19] = loss_sum"));
         assert!(source
             .contains("scalars[scalar_offset + 20] = position_unchanged_max_min * interval_ms"));
         assert!(source.contains("scalars[scalar_offset + 21] = allowed_wallet_exposure_limit"));
+        assert!(source.contains("scalars[scalar_offset + 22] = total_wallet_exposure_max"));
+        assert!(source.contains("scalars[scalar_offset + 23] = total_wallet_exposure_mean"));
         assert!(source.contains("coin_wel_enforcer_enabled"));
         assert!(source.contains("coin_wel_enforcer_threshold"));
         assert!(source.contains("twel_enforcer_enabled"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -2,7 +2,7 @@
 using namespace metal;
 
 constant int DAILY_COLS = 5;
-constant int SCALAR_COLS = 48;
+constant int SCALAR_COLS = 50;
 constant int GAP_BINS = 128;
 constant int SIDE_PARAMS = 34;
 
@@ -1109,6 +1109,9 @@ inline void passivbot_single_coin_impl(
     float gap_max_min = 0.0f;
     float run_peak = -INFINITY;
     float max_dd = 0.0f;
+    float total_wallet_exposure_max = 0.0f;
+    float total_wallet_exposure_mean = 0.0f;
+    float total_wallet_exposure_samples = 0.0f;
     float last_high_k = -1.0f;
     float recovery_max_min = 0.0f;
     float first_eq_k = -1.0f;
@@ -1680,6 +1683,20 @@ inline void passivbot_single_coin_impl(
             day_min = fmin(day_min, eqf);
             day_dd = fmax(day_dd, dd);
             day_touched = true;
+            if (!liq) {
+                float twe_net = (
+                    long_side.psize * long_side.pprice
+                    - short_side.psize * short_side.pprice
+                ) * c_mult / balance;
+                float twe_abs = fabs(twe_net);
+                total_wallet_exposure_samples += 1.0f;
+                total_wallet_exposure_mean += (
+                    twe_abs - total_wallet_exposure_mean
+                ) / total_wallet_exposure_samples;
+                total_wallet_exposure_max = fmax(
+                    total_wallet_exposure_max, twe_abs
+                );
+            }
             if (liq) {
                 liq_day = di;
                 alive = false;
@@ -1803,6 +1820,8 @@ inline void passivbot_single_coin_impl(
         ? long_side.allowed_wel * long_side.base_qty_pct : 0.0f;
     scalars[so + 47] = short_enabled
         ? short_side.allowed_wel * short_side.base_qty_pct : 0.0f;
+    scalars[so + 48] = total_wallet_exposure_max;
+    scalars[so + 49] = total_wallet_exposure_mean;
 }
 
 kernel void passivbot_ema_anchor(

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -6,7 +6,7 @@ constant int PARAM_COLS = 31;
 constant int COIN_COLS = 11;
 constant int OVERRIDE_COLS = 19;
 constant int DAILY_COLS = 6;
-constant int SCALAR_COLS = 22;
+constant int SCALAR_COLS = 24;
 constant int GAP_BINS = 128;
 
 inline float round_step(float value, float step) {
@@ -392,6 +392,9 @@ inline void passivbot_ema_anchor_multicoin_impl(
     int previous_effective_n_positions = 0;
     float run_peak = -INFINITY;
     float max_dd = 0.0f;
+    float total_wallet_exposure_max = 0.0f;
+    float total_wallet_exposure_mean = 0.0f;
+    float total_wallet_exposure_samples = 0.0f;
     float held_max_min = 0.0f;
     float position_unchanged_max_min = 0.0f;
     float first_fill_k = -1.0f;
@@ -1385,6 +1388,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
         }
 
         float unrealized = 0.0f;
+        float position_cost = 0.0f;
         bool any_valid = false;
         for (int c = 0; c < C; ++c) {
             int coin_offset = c * COIN_COLS;
@@ -1396,6 +1400,8 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 any_valid = true;
             }
             if (psize[c] > 0.0f) {
+                position_cost += psize[c] * pprice[c]
+                    * coin_settings[coin_offset + 4];
                 unrealized += psize[c] * coin_settings[coin_offset + 4]
                     * (short_side ? pprice[c] - close : close - pprice[c]);
             }
@@ -1425,6 +1431,16 @@ inline void passivbot_ema_anchor_multicoin_impl(
             day_min_balance = fmin(day_min_balance, balance);
             day_dd = fmax(day_dd, drawdown);
             day_touched = true;
+            if (!liquidated) {
+                float twe_abs = position_cost / balance;
+                total_wallet_exposure_samples += 1.0f;
+                total_wallet_exposure_mean += (
+                    twe_abs - total_wallet_exposure_mean
+                ) / total_wallet_exposure_samples;
+                total_wallet_exposure_max = fmax(
+                    total_wallet_exposure_max, twe_abs
+                );
+            }
             if (liquidated) {
                 alive = false;
                 liquidation_day = day_index;
@@ -1498,6 +1514,8 @@ inline void passivbot_ema_anchor_multicoin_impl(
     scalars[scalar_offset + 21] = allowed_wallet_exposure_limit(
         entry_base_limit, twel, entry_allowance_pct, legacy_raw_allowance
     ) * entry_initial_qty_pct;
+    scalars[scalar_offset + 22] = total_wallet_exposure_max;
+    scalars[scalar_offset + 23] = total_wallet_exposure_mean;
 }
 
 kernel void passivbot_ema_anchor_multicoin(

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -2,7 +2,7 @@
 using namespace metal;
 
 constant int DAILY_COLS = 5;
-constant int SCALAR_COLS = 48;
+constant int SCALAR_COLS = 50;
 constant int GAP_BINS = 128;
 constant int SIDE_PARAMS = 51;
 
@@ -1396,6 +1396,9 @@ inline void passivbot_single_coin_impl(
     float gap_max_min = 0.0f;
     float run_peak = -INFINITY;
     float max_dd = 0.0f;
+    float total_wallet_exposure_max = 0.0f;
+    float total_wallet_exposure_mean = 0.0f;
+    float total_wallet_exposure_samples = 0.0f;
     float last_high_k = -1.0f;
     float recovery_max_min = 0.0f;
     float first_eq_k = -1.0f;
@@ -2649,6 +2652,20 @@ inline void passivbot_single_coin_impl(
             day_min = fmin(day_min, eqf);
             day_dd = fmax(day_dd, dd);
             day_touched = true;
+            if (!liq) {
+                float twe_net = (
+                    long_side.psize * long_side.pprice
+                    - short_side.psize * short_side.pprice
+                ) * c_mult / balance;
+                float twe_abs = fabs(twe_net);
+                total_wallet_exposure_samples += 1.0f;
+                total_wallet_exposure_mean += (
+                    twe_abs - total_wallet_exposure_mean
+                ) / total_wallet_exposure_samples;
+                total_wallet_exposure_max = fmax(
+                    total_wallet_exposure_max, twe_abs
+                );
+            }
             if (liq) {
                 liq_day = di;
                 alive = false;
@@ -2772,6 +2789,8 @@ inline void passivbot_single_coin_impl(
         ? long_side.allowed_wel * long_side.initial_qty_pct : 0.0f;
     scalars[so + 47] = short_enabled
         ? short_side.allowed_wel * short_side.initial_qty_pct : 0.0f;
+    scalars[so + 48] = total_wallet_exposure_max;
+    scalars[so + 49] = total_wallet_exposure_mean;
 }
 
 kernel void passivbot_trailing_martingale(

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -6,7 +6,7 @@ constant int PARAM_COLS = 48;
 constant int OVERRIDE_COLS = 34;
 constant int COIN_COLS = 11;
 constant int DAILY_COLS = 6;
-constant int SCALAR_COLS = 22;
+constant int SCALAR_COLS = 24;
 constant int GAP_BINS = 128;
 
 inline float round_step(float value, float step) {
@@ -652,6 +652,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     int previous_effective_n_positions = 0;
     float run_peak = -INFINITY;
     float max_dd = 0.0f;
+    float total_wallet_exposure_max = 0.0f;
+    float total_wallet_exposure_mean = 0.0f;
+    float total_wallet_exposure_samples = 0.0f;
     float held_max_min = 0.0f;
     float position_unchanged_max_min = 0.0f;
     float first_fill_k = -1.0f;
@@ -2193,6 +2196,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         }
 
         float unrealized = 0.0f;
+        float position_cost = 0.0f;
         bool any_valid = false;
         for (int c = 0; c < C; ++c) {
             int coin_offset = c * COIN_COLS;
@@ -2204,6 +2208,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 any_valid = true;
             }
             if (psize[c] > 0.0f) {
+                position_cost += psize[c] * pprice[c]
+                    * coin_settings[coin_offset + 4];
                 unrealized += psize[c] * coin_settings[coin_offset + 4]
                     * (short_side ? pprice[c] - close : close - pprice[c]);
             }
@@ -2233,6 +2239,16 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             day_min_balance = fmin(day_min_balance, balance);
             day_dd = fmax(day_dd, drawdown);
             day_touched = true;
+            if (!liquidated) {
+                float twe_abs = position_cost / balance;
+                total_wallet_exposure_samples += 1.0f;
+                total_wallet_exposure_mean += (
+                    twe_abs - total_wallet_exposure_mean
+                ) / total_wallet_exposure_samples;
+                total_wallet_exposure_max = fmax(
+                    total_wallet_exposure_max, twe_abs
+                );
+            }
             if (liquidated) {
                 alive = false;
                 liquidation_day = day_index;
@@ -2306,6 +2322,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     scalars[scalar_offset + 21] = allowed_wallet_exposure_limit(
         entry_base_limit, twel, entry_allowance_pct, legacy_raw_allowance
     ) * entry_initial_qty_pct;
+    scalars[scalar_offset + 22] = total_wallet_exposure_max;
+    scalars[scalar_offset + 23] = total_wallet_exposure_mean;
 }
 
 kernel void passivbot_trailing_martingale_multicoin(

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -1058,6 +1058,8 @@ def _validate_dual_multicoin_metrics(
             "position_unchanged_days_max",
             "position_unchanged_hours_max",
             "strategy_eq_recovery_days_max",
+            "total_wallet_exposure_max",
+            "total_wallet_exposure_mean",
             "volume_pct_per_day_avg",
         }
     )

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -74,6 +74,8 @@ SUPPORTED_METRICS = (
     "strategy_eq_recovery_days_max",
     "strategy_eq_underwater_pct_mean",
     "strategy_eq_underwater_pct_median",
+    "total_wallet_exposure_max",
+    "total_wallet_exposure_mean",
     "volume_pct_per_day_avg",
 )
 
@@ -825,6 +827,9 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
         objectives["loss_profit_ratio"] = _loss_profit_ratio(
             out["loss_sum"], out["profit_sum"]
         )
+    for name in ("total_wallet_exposure_max", "total_wallet_exposure_mean"):
+        if name in requested:
+            objectives[name] = out[name].to(torch.float64)
     if {"position_unchanged_days_max", "position_unchanged_hours_max"} & requested:
         position_unchanged_hours_max = (
             out["position_unchanged_max_ms"] / 3_600_000.0

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -19,8 +19,8 @@ from optimization.gpu.model import (
 
 MPS_DAILY_COLS = 5
 MPS_MULTICOIN_DAILY_COLS = 6
-MPS_SCALAR_COLS = 22
-MPS_DIRECTIONAL_SCALAR_COLS = 48
+MPS_SCALAR_COLS = 24
+MPS_DIRECTIONAL_SCALAR_COLS = 50
 
 
 def _encode_max_realized_loss_pct(value: float) -> float:
@@ -122,6 +122,8 @@ def _decode_outputs(daily, scalars, gaps) -> dict:
         "loss_sum": scalars[:, 19],
         "position_unchanged_max_ms": scalars[:, 20],
         "entry_initial_balance_pct": scalars[:, 21],
+        "total_wallet_exposure_max": scalars[:, 22],
+        "total_wallet_exposure_mean": scalars[:, 23],
     }
 
 
@@ -191,6 +193,8 @@ def _decode_directional_outputs(daily, scalars, gaps) -> dict:
         "position_unchanged_max_ms": scalars[:, 45],
         "entry_initial_balance_pct_long": scalars[:, 46],
         "entry_initial_balance_pct_short": scalars[:, 47],
+        "total_wallet_exposure_max": scalars[:, 48],
+        "total_wallet_exposure_mean": scalars[:, 49],
     }
 
 

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -46,6 +46,8 @@ CORE_OUTPUT_KEYS = {
     "entry_initial_balance_pct",
     "entry_initial_balance_pct_long",
     "entry_initial_balance_pct_short",
+    "total_wallet_exposure_max",
+    "total_wallet_exposure_mean",
 }
 
 DIRECTIONAL_HSL_OUTPUT_KEYS = {

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -2177,6 +2177,8 @@ def test_gpu_multicoin_foundation_rejects_asymmetric_dual_side_coins(strategy_ki
         "position_unchanged_days_max",
         "position_unchanged_hours_max",
         "strategy_eq_recovery_days_max",
+        "total_wallet_exposure_max",
+        "total_wallet_exposure_mean",
         "volume_pct_per_day_avg",
     ],
 )
@@ -2206,6 +2208,8 @@ def test_gpu_dual_multicoin_metric_gate_does_not_narrow_single_side():
             "position_unchanged_days_max",
             "position_unchanged_hours_max",
             "strategy_eq_recovery_days_max",
+            "total_wallet_exposure_max",
+            "total_wallet_exposure_mean",
             "volume_pct_per_day_avg",
         },
         coin_count=3,

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -61,6 +61,8 @@ def test_duration_alias_metrics_match_rust_unit_contracts():
         "liq_step": torch.tensor([-1.0], dtype=torch.float64),
         "entry_initial_balance_pct_long": torch.tensor([0.125]),
         "entry_initial_balance_pct_short": torch.tensor([0.075]),
+        "total_wallet_exposure_max": torch.tensor([1.25]),
+        "total_wallet_exposure_mean": torch.tensor([0.625]),
     }
     run = SimpleNamespace(
         requested_start_ts_ms=0, guard_ts_ms=0, interval_ms=60_000
@@ -74,6 +76,8 @@ def test_duration_alias_metrics_match_rust_unit_contracts():
         "peak_recovery_hours_strategy_eq",
         "entry_initial_balance_pct_long",
         "entry_initial_balance_pct_short",
+        "total_wallet_exposure_max",
+        "total_wallet_exposure_mean",
     }
 
     metrics = compute_objectives(
@@ -92,6 +96,8 @@ def test_duration_alias_metrics_match_rust_unit_contracts():
     assert metrics["peak_recovery_hours_strategy_eq"].item() == pytest.approx(30.0)
     assert metrics["entry_initial_balance_pct_long"].item() == pytest.approx(0.125)
     assert metrics["entry_initial_balance_pct_short"].item() == pytest.approx(0.075)
+    assert metrics["total_wallet_exposure_max"].item() == pytest.approx(1.25)
+    assert metrics["total_wallet_exposure_mean"].item() == pytest.approx(0.625)
     assert requested <= set(SUPPORTED_METRICS)
 
 

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -265,6 +265,11 @@ def test_mps_multicoin_tracks_position_unchanged_max(strategy_kind, side):
     assert unchanged_ms > 0.0
     assert unchanged_ms <= output["held_max_ms"].item()
     assert output["entry_initial_balance_pct"].item() == pytest.approx(0.5)
+    assert output["total_wallet_exposure_max"].item() > 0.0
+    assert (
+        output["total_wallet_exposure_max"].item()
+        >= output["total_wallet_exposure_mean"].item()
+    )
 
 
 @pytest.mark.skipif(
@@ -479,7 +484,7 @@ def test_mps_ema_anchor_shader_smoke():
     assert "const bool long_hsl_panic_market = settings[17] > 0.5f" in source
     assert "const bool short_hsl_panic_market = settings[18] > 0.5f" in source
     assert "market_panic ? taker_fee : maker_fee" in source
-    assert "constant int SCALAR_COLS = 48" in source
+    assert "constant int SCALAR_COLS = 50" in source
     assert "record_gross_pnl" in source
     assert "hsl_tier_samples_total" in source
     assert "h.restart_retrigger_count" in source
@@ -561,6 +566,11 @@ def test_mps_ema_anchor_shader_smoke():
     assert output["balance"].shape == (2,)
     assert torch.isfinite(output["balance"]).all()
     assert output["day_has_fill"].sum().item() > 0
+    assert (output["total_wallet_exposure_max"] > 0.0).all()
+    assert (
+        output["total_wallet_exposure_max"]
+        >= output["total_wallet_exposure_mean"]
+    ).all()
 
 
 @pytest.mark.skipif(
@@ -2097,6 +2107,11 @@ def test_mps_tm_equal_unstuck_twel_reducers_keep_nearer_twel(side):
     # auto-unstuck reducer. The next candle crosses TWEL but only touches
     # unstuck, proving selection follows Rust's reachability tie-break.
     assert output[size_key].item() == pytest.approx(5.0)
+    assert output["total_wallet_exposure_max"].item() > 0.0
+    assert (
+        output["total_wallet_exposure_max"].item()
+        >= output["total_wallet_exposure_mean"].item()
+    )
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -41,6 +41,8 @@ def test_core_output_contract_retains_gross_pnl_aggregates():
         "entry_initial_balance_pct",
         "entry_initial_balance_pct_long",
         "entry_initial_balance_pct_short",
+        "total_wallet_exposure_max",
+        "total_wallet_exposure_mean",
     } <= CORE_OUTPUT_KEYS
 
 


### PR DESCRIPTION
## Summary
- add total_wallet_exposure_max and total_wallet_exposure_mean as MPS proxy outputs for EMA Anchor and Trailing Martingale
- support single-coin, one-sided multi-coin, and compatible suites while failing closed for dual-side multi-coin net exposure
- retain exact Rust validation and drift gates as authoritative and document the supported boundary

## Validation
- PYTHONPATH=src venv/bin/python -m pytest -q tests/optimization
- cargo fmt --check
- cargo check --tests
- cargo test --no-default-features (262 passed)
- physical MPS: tests/optimization/test_gpu_mps.py (204 passed)
- offline physical-MPS EMA optimization: 512 proxy evaluations, 64 exact validations, both new metrics scored, completed in 7.3s