### PR TITLE
feat(optimize): add MPS USD metric aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added the canonical USD account-equity scoring aliases for gain, ADG, MDG, Sharpe, Sortino,
+  Omega, expected shortfall, Calmar, Sterling, worst drawdown, and worst-1% drawdown, including the
+  available weighted variants, to Apple MPS optimization. With BTC collateral disabled, these
+  aliases reuse the already validated strategy-equity proxy series while exact Rust metrics remain
+  authoritative. Also added `exposure_ratio_usd` and `exposure_mean_ratio_usd` for single-coin and
+  one-sided multi-coin runs; dual-side multi-coin runs fail closed because independent directional
+  kernels cannot reconstruct net portfolio exposure.
+
 - Added `total_wallet_exposure_max` and `total_wallet_exposure_mean` scoring and limits to Apple
   MPS optimization for EMA Anchor and Trailing Martingale across single-coin, one-sided multi-coin,
   and compatible suite runs. Metal samples absolute net long-minus-short exposure after each

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -190,6 +190,15 @@ The supported slice is intentionally narrow:
   reduces it with bounded maximum and online-mean accumulators. Dual-side multi-coin runs fail
   closed because independent directional kernels cannot reconstruct the shared minute-level net
   exposure series
+- canonical USD account-equity metrics may use the same MPS surface as their strategy-equity
+  counterparts while BTC collateral is disabled: `gain_usd`, `adg_usd`, `mdg_usd`,
+  `sharpe_ratio_usd`, `sortino_ratio_usd`, `omega_ratio_usd`,
+  `expected_shortfall_1pct_usd`, `calmar_ratio_usd`, `sterling_ratio_usd`,
+  `drawdown_worst_usd`, and `drawdown_worst_mean_1pct_usd`, plus the available `_w_usd` weighted
+  variants. `exposure_ratio_usd` and `exposure_mean_ratio_usd` combine proxy ADG with the maximum
+  and mean total-wallet-exposure accumulators. The exposure ratios support single-coin and
+  one-sided multi-coin runs; dual-side multi-coin runs fail closed because independent directional
+  kernels cannot reconstruct shared net exposure
 - Trailing Martingale supports `risk.position_exposure_enforcer_enabled` and a tunable
   `risk.position_exposure_enforcer_threshold` for single- and multi-coin long, short, dual-side,
   and compatible suite runs. When current position exposure exceeds the allowance-adjusted WEL
@@ -239,7 +248,7 @@ screening also rejects `fills_gap_longest_days`,
 `entry_initial_balance_pct_long`, `entry_initial_balance_pct_short`,
 `position_held_days_max`, `position_held_hours_max`, `position_unchanged_days_max`,
 `position_unchanged_hours_max`, `total_wallet_exposure_max`, `total_wallet_exposure_mean`, and
-`volume_pct_per_day_avg`: the independent directional
+`exposure_ratio_usd`, `exposure_mean_ratio_usd`, and `volume_pct_per_day_avg`: the independent directional
 summaries cannot reconstruct cross-side-only fill gaps, alternating portfolio recovery periods,
 effective coin counts and duration maxima truncated at shared portfolio liquidation, minute-level
 net exposure, or fill volume normalized by the shared balance safely.
@@ -307,8 +316,10 @@ Proxy scoring and limits are likewise fail-closed. The supported strategy-equity
 gain, ADG, MDG, Sharpe, Sortino, Omega, Calmar, Sterling, expected shortfall, worst and worst-1%
 drawdown, mean and median underwater percentage, maximum recovery and position-held duration,
 position-unchanged duration, initial-entry balance percentage for each side, volume per active day,
-backtest completion, and weighted variants of ADG, MDG, Sharpe, Sortino, Omega, Calmar, and
-Sterling. Initial-entry allocation uses the candidate's effective position count and the same
+total-wallet-exposure maximum and mean, USD exposure ratios, backtest completion, and weighted
+variants of ADG, MDG, Sharpe, Sortino, Omega, Calmar, and Sterling. With BTC collateral disabled,
+the corresponding canonical USD account-equity names share this strategy-equity surface.
+Initial-entry allocation uses the candidate's effective position count and the same
 first-coin strategy/allowance override precedence as exact Rust. Fill-gap longest, mean, median,
 p95, and p99 metrics are also supported. Metal coalesces multiple fills in the same candle and
 records positive inter-candle gaps

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -1046,6 +1046,8 @@ def _validate_dual_multicoin_metrics(
         & {
             "entry_initial_balance_pct_long",
             "entry_initial_balance_pct_short",
+            "exposure_mean_ratio_usd",
+            "exposure_ratio_usd",
             "fills_gap_longest_days",
             "fills_gap_mean_hours",
             "fills_gap_median_hours",

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -11,6 +11,27 @@ import math
 
 import torch
 
+_USD_STRATEGY_EQ_ALIASES = {
+    "adg_usd": "adg_strategy_eq",
+    "adg_w_usd": "adg_strategy_eq_w",
+    "calmar_ratio_usd": "calmar_ratio_strategy_eq",
+    "calmar_ratio_w_usd": "calmar_ratio_strategy_eq_w",
+    "drawdown_worst_mean_1pct_usd": "drawdown_worst_mean_1pct_strategy_eq",
+    "drawdown_worst_usd": "drawdown_worst_strategy_eq",
+    "expected_shortfall_1pct_usd": "expected_shortfall_1pct_strategy_eq",
+    "gain_usd": "gain_strategy_eq",
+    "mdg_usd": "mdg_strategy_eq",
+    "mdg_w_usd": "mdg_strategy_eq_w",
+    "omega_ratio_usd": "omega_ratio_strategy_eq",
+    "omega_ratio_w_usd": "omega_ratio_strategy_eq_w",
+    "sharpe_ratio_usd": "sharpe_ratio_strategy_eq",
+    "sharpe_ratio_w_usd": "sharpe_ratio_strategy_eq_w",
+    "sortino_ratio_usd": "sortino_ratio_strategy_eq",
+    "sortino_ratio_w_usd": "sortino_ratio_strategy_eq_w",
+    "sterling_ratio_usd": "sterling_ratio_strategy_eq",
+    "sterling_ratio_w_usd": "sterling_ratio_strategy_eq_w",
+}
+
 # Keep the public proxy surface deliberately narrow. Exact Rust evaluations
 # still emit the normal complete metric set; this list governs only which
 # metrics may guide Metal screening or proxy-side limits.
@@ -25,6 +46,8 @@ SUPPORTED_METRICS = (
     "expected_shortfall_1pct_strategy_eq",
     "entry_initial_balance_pct_long",
     "entry_initial_balance_pct_short",
+    "exposure_mean_ratio_usd",
+    "exposure_ratio_usd",
     "fills_gap_longest_days",
     "fills_gap_mean_hours",
     "fills_gap_median_hours",
@@ -77,6 +100,7 @@ SUPPORTED_METRICS = (
     "total_wallet_exposure_max",
     "total_wallet_exposure_mean",
     "volume_pct_per_day_avg",
+    *_USD_STRATEGY_EQ_ALIASES,
 )
 
 # Metrics backed by additional per-fill aggregates emitted by Metal.
@@ -705,6 +729,11 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
     day_has_fill = out["day_has_fill"]
     active = _daily_series_masks(out["day_min_eq"])
     requested = set(SUPPORTED_METRICS if needed is None else needed)
+    requested_sources = requested | {
+        source
+        for alias, source in _USD_STRATEGY_EQ_ALIASES.items()
+        if alias in requested
+    }
 
     gain, adg = _smoothed_gain_adg(day_end_eq, active)
     daily_changes, change_mask = _pct_change(day_end_eq, active)
@@ -722,7 +751,7 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
         out["last_eq_ts"],
         data["ts0"],
         run.interval_ms,
-        requested,
+        requested_sources,
     )
 
     underwater = torch.where(active, day_max_dd, torch.zeros_like(day_max_dd)).sum(
@@ -830,6 +859,15 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
     for name in ("total_wallet_exposure_max", "total_wallet_exposure_mean"):
         if name in requested:
             objectives[name] = out[name].to(torch.float64)
+    exposure_ratio_denominators = {
+        "exposure_ratio_usd": "total_wallet_exposure_max",
+        "exposure_mean_ratio_usd": "total_wallet_exposure_mean",
+    }
+    for name, denominator in exposure_ratio_denominators.items():
+        if name in requested:
+            objectives[name] = adg / out[denominator].to(torch.float64).abs().clamp(
+                min=1e-12
+            )
     if {"position_unchanged_days_max", "position_unchanged_hours_max"} & requested:
         position_unchanged_hours_max = (
             out["position_unchanged_max_ms"] / 3_600_000.0
@@ -844,6 +882,9 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
     objectives.update(hard_stop_metrics)
     objectives.update(hard_stop_panic_loss_metrics)
     objectives.update(weighted_metrics)
+    for alias, source in _USD_STRATEGY_EQ_ALIASES.items():
+        if alias in requested:
+            objectives[alias] = objectives[source]
     if needed is None:
         return objectives
     return {key: value for key, value in objectives.items() if key in requested}

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -2165,6 +2165,8 @@ def test_gpu_multicoin_foundation_rejects_asymmetric_dual_side_coins(strategy_ki
     [
         "entry_initial_balance_pct_long",
         "entry_initial_balance_pct_short",
+        "exposure_mean_ratio_usd",
+        "exposure_ratio_usd",
         "fills_gap_longest_days",
         "fills_gap_mean_hours",
         "fills_gap_median_hours",
@@ -2196,6 +2198,8 @@ def test_gpu_dual_multicoin_metric_gate_does_not_narrow_single_side():
         {
             "entry_initial_balance_pct_long",
             "entry_initial_balance_pct_short",
+            "exposure_mean_ratio_usd",
+            "exposure_ratio_usd",
             "fills_gap_longest_days",
             "fills_gap_mean_hours",
             "fills_gap_median_hours",

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -78,6 +78,9 @@ def test_duration_alias_metrics_match_rust_unit_contracts():
         "entry_initial_balance_pct_short",
         "total_wallet_exposure_max",
         "total_wallet_exposure_mean",
+        "adg_strategy_eq",
+        "exposure_ratio_usd",
+        "exposure_mean_ratio_usd",
     }
 
     metrics = compute_objectives(
@@ -98,6 +101,9 @@ def test_duration_alias_metrics_match_rust_unit_contracts():
     assert metrics["entry_initial_balance_pct_short"].item() == pytest.approx(0.075)
     assert metrics["total_wallet_exposure_max"].item() == pytest.approx(1.25)
     assert metrics["total_wallet_exposure_mean"].item() == pytest.approx(0.625)
+    adg = metrics["adg_strategy_eq"].item()
+    assert metrics["exposure_ratio_usd"].item() == pytest.approx(adg / 1.25)
+    assert metrics["exposure_mean_ratio_usd"].item() == pytest.approx(adg / 0.625)
     assert requested <= set(SUPPORTED_METRICS)
 
 
@@ -265,6 +271,21 @@ def test_strategy_equity_summary_metric_surface_is_supported():
         "sterling_ratio_strategy_eq",
         "strategy_eq_underwater_pct_median",
     } <= set(SUPPORTED_METRICS)
+    assert {
+        "adg_usd",
+        "calmar_ratio_usd",
+        "drawdown_worst_mean_1pct_usd",
+        "drawdown_worst_usd",
+        "expected_shortfall_1pct_usd",
+        "gain_usd",
+        "mdg_usd",
+        "omega_ratio_usd",
+        "sharpe_ratio_usd",
+        "sortino_ratio_usd",
+        "sterling_ratio_usd",
+        "exposure_ratio_usd",
+        "exposure_mean_ratio_usd",
+    } <= set(SUPPORTED_METRICS)
 
 
 def test_hard_stop_lifecycle_metric_surface_is_supported():
@@ -406,6 +427,15 @@ def test_weighted_strategy_equity_metric_surface_is_supported():
         "calmar_ratio_strategy_eq_w",
         "sterling_ratio_strategy_eq_w",
     } <= set(SUPPORTED_METRICS)
+    assert {
+        "adg_w_usd",
+        "calmar_ratio_w_usd",
+        "mdg_w_usd",
+        "omega_ratio_w_usd",
+        "sharpe_ratio_w_usd",
+        "sortino_ratio_w_usd",
+        "sterling_ratio_w_usd",
+    } <= set(SUPPORTED_METRICS)
 
 
 def test_smoothed_gain_and_adg_match_rust_terminal_contract():
@@ -515,13 +545,41 @@ def test_new_strategy_equity_metrics_reduce_existing_compact_surface():
         requested_start_ts_ms=0, guard_ts_ms=0, interval_ms=60_000
     )
     requested = {
+        "adg_strategy_eq",
+        "drawdown_worst_mean_1pct_strategy_eq",
+        "drawdown_worst_strategy_eq",
         "gain_strategy_eq",
+        "mdg_strategy_eq",
         "omega_ratio_strategy_eq",
+        "sharpe_ratio_strategy_eq",
+        "sortino_ratio_strategy_eq",
         "expected_shortfall_1pct_strategy_eq",
         "calmar_ratio_strategy_eq",
         "sterling_ratio_strategy_eq",
         "strategy_eq_underwater_pct_median",
     }
+    alias_sources = {
+        "adg_usd": "adg_strategy_eq",
+        "adg_w_usd": "adg_strategy_eq_w",
+        "calmar_ratio_usd": "calmar_ratio_strategy_eq",
+        "calmar_ratio_w_usd": "calmar_ratio_strategy_eq_w",
+        "drawdown_worst_mean_1pct_usd": "drawdown_worst_mean_1pct_strategy_eq",
+        "drawdown_worst_usd": "drawdown_worst_strategy_eq",
+        "expected_shortfall_1pct_usd": "expected_shortfall_1pct_strategy_eq",
+        "gain_usd": "gain_strategy_eq",
+        "mdg_usd": "mdg_strategy_eq",
+        "mdg_w_usd": "mdg_strategy_eq_w",
+        "omega_ratio_usd": "omega_ratio_strategy_eq",
+        "omega_ratio_w_usd": "omega_ratio_strategy_eq_w",
+        "sharpe_ratio_usd": "sharpe_ratio_strategy_eq",
+        "sharpe_ratio_w_usd": "sharpe_ratio_strategy_eq_w",
+        "sortino_ratio_usd": "sortino_ratio_strategy_eq",
+        "sortino_ratio_w_usd": "sortino_ratio_strategy_eq_w",
+        "sterling_ratio_usd": "sterling_ratio_strategy_eq",
+        "sterling_ratio_w_usd": "sterling_ratio_strategy_eq_w",
+    }
+    requested.update(alias_sources)
+    requested.update(alias_sources.values())
 
     metrics = compute_objectives(out, run, {"ts0": 0.0, "n": 4}, needed=requested)
 
@@ -542,6 +600,8 @@ def test_new_strategy_equity_metrics_reduce_existing_compact_surface():
         (90.0 - 110.0) / 110.0
     )
     assert metrics["omega_ratio_strategy_eq"].item() == pytest.approx(expected_omega)
+    for alias, source in alias_sources.items():
+        assert metrics[alias].item() == pytest.approx(metrics[source].item())
 
 
 def test_objectives_include_final_active_calendar_day():


### PR DESCRIPTION
## Summary
- expose canonical USD account-equity scoring names through the validated strategy-equity MPS proxy while BTC collateral is disabled
- add exposure_ratio_usd and exposure_mean_ratio_usd from proxy ADG and Metal total-wallet-exposure summaries
- fail closed for exposure ratios in dual-side multicoin topology, while preserving single-coin and one-sided multicoin support
- document the topology and exact-Rust authority boundaries

## Validation
- full Python optimizer suite
- cargo fmt --check
- cargo check --tests
- cargo test --no-default-features: 262 passed
- physical Apple MPS suite: 204 passed
- offline physical MPS EMA Anchor smoke: 512 proxy evaluations, 64 exact Rust validations, all 20 added aliases/ratios, no drift halt, 7.5s

Exact Rust evaluations remain authoritative; this change is additive to GPU optimization and does not affect CPU optimization, backtesting, or live operation.