### PR TITLE
feat(optimize): add MPS per-exposure metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added the canonical USD gain, ADG, MDG, weighted ADG, and weighted MDG per-configured-exposure
+  metrics for both long and short sides to Apple MPS optimization. They reuse the validated
+  strategy-equity proxy reductions and divide by each candidate's effective side
+  `total_wallet_exposure_limit`, including exact-last suite overrides; a zero-exposure side retains
+  the CPU contract's zero value.
+
 - Added the canonical USD account-equity scoring aliases for gain, ADG, MDG, Sharpe, Sortino,
   Omega, expected shortfall, Calmar, Sterling, worst drawdown, and worst-1% drawdown, including the
   available weighted variants, to Apple MPS optimization. With BTC collateral disabled, these

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -199,6 +199,10 @@ The supported slice is intentionally narrow:
   and mean total-wallet-exposure accumulators. The exposure ratios support single-coin and
   one-sided multi-coin runs; dual-side multi-coin runs fail closed because independent directional
   kernels cannot reconstruct shared net exposure
+- canonical USD gain, ADG, MDG, weighted ADG, and weighted MDG per-configured-exposure metrics are
+  supported for both long and short sides. The proxy divides the matching validated equity metric
+  by each candidate's effective side `total_wallet_exposure_limit`, after applying any exact-last
+  suite override, and returns zero for a zero-exposure side as the CPU analysis does
 - Trailing Martingale supports `risk.position_exposure_enforcer_enabled` and a tunable
   `risk.position_exposure_enforcer_threshold` for single- and multi-coin long, short, dual-side,
   and compatible suite runs. When current position exposure exceeds the allowance-adjusted WEL

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -32,6 +32,19 @@ _USD_STRATEGY_EQ_ALIASES = {
     "sterling_ratio_w_usd": "sterling_ratio_strategy_eq_w",
 }
 
+_USD_PER_EXPOSURE_METRICS = {
+    "adg_per_exposure_long_usd": ("adg_strategy_eq", "long"),
+    "adg_per_exposure_short_usd": ("adg_strategy_eq", "short"),
+    "adg_w_per_exposure_long_usd": ("adg_strategy_eq_w", "long"),
+    "adg_w_per_exposure_short_usd": ("adg_strategy_eq_w", "short"),
+    "gain_per_exposure_long_usd": ("gain_strategy_eq", "long"),
+    "gain_per_exposure_short_usd": ("gain_strategy_eq", "short"),
+    "mdg_per_exposure_long_usd": ("mdg_strategy_eq", "long"),
+    "mdg_per_exposure_short_usd": ("mdg_strategy_eq", "short"),
+    "mdg_w_per_exposure_long_usd": ("mdg_strategy_eq_w", "long"),
+    "mdg_w_per_exposure_short_usd": ("mdg_strategy_eq_w", "short"),
+}
+
 # Keep the public proxy surface deliberately narrow. Exact Rust evaluations
 # still emit the normal complete metric set; this list governs only which
 # metrics may guide Metal screening or proxy-side limits.
@@ -101,6 +114,7 @@ SUPPORTED_METRICS = (
     "total_wallet_exposure_mean",
     "volume_pct_per_day_avg",
     *_USD_STRATEGY_EQ_ALIASES,
+    *_USD_PER_EXPOSURE_METRICS,
 )
 
 # Metrics backed by additional per-fill aggregates emitted by Metal.
@@ -733,6 +747,10 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
         source
         for alias, source in _USD_STRATEGY_EQ_ALIASES.items()
         if alias in requested
+    } | {
+        source
+        for metric, (source, _side) in _USD_PER_EXPOSURE_METRICS.items()
+        if metric in requested
     }
 
     gain, adg = _smoothed_gain_adg(day_end_eq, active)
@@ -882,6 +900,17 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
     objectives.update(hard_stop_metrics)
     objectives.update(hard_stop_panic_loss_metrics)
     objectives.update(weighted_metrics)
+    for name, (source, side) in _USD_PER_EXPOSURE_METRICS.items():
+        if name not in requested:
+            continue
+        denominator = out[
+            f"candidate_total_wallet_exposure_limit_{side}"
+        ].to(torch.float64)
+        objectives[name] = torch.where(
+            denominator > 0.0,
+            objectives[source] / denominator,
+            torch.zeros_like(objectives[source]),
+        )
     for alias, source in _USD_STRATEGY_EQ_ALIASES.items():
         if alias in requested:
             objectives[alias] = objectives[source]

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -79,6 +79,29 @@ DIRECTIONAL_HSL_OUTPUT_KEYS = {
 }
 
 
+def _candidate_wallet_exposure_limit_outputs(
+    candidates: list[dict],
+    base_limits: dict[str, float],
+    *,
+    torch,
+) -> dict:
+    """Expose each candidate's configured side TWEL to proxy metric reducers."""
+
+    outputs = {}
+    for side in ("long", "short"):
+        if side not in base_limits:
+            raise ValueError(f"GPU candidate TWEL context is missing {side}")
+        key = f"{side}_total_wallet_exposure_limit"
+        values = np.asarray(
+            [float(candidate.get(key, base_limits[side])) for candidate in candidates],
+            dtype=np.float64,
+        )
+        outputs[f"candidate_total_wallet_exposure_limit_{side}"] = torch.from_numpy(
+            values
+        )
+    return outputs
+
+
 def _single_coin_exposure_params(risk: dict, *, side: str) -> dict[str, float]:
     allowance_mode = str(
         risk.get("we_excess_allowance_mode", "bounded")
@@ -572,6 +595,11 @@ class MpsSingleCoinProxy:
                 )
             self.base_params[side] = strategy
 
+        self.base_total_wallet_exposure_limits = {
+            side: float(self.base_params[side]["total_wallet_exposure_limit"])
+            for side in ("long", "short")
+        }
+
         market_params = payload.exchange_params[0]
         self.market = ProxyMarket(
             qty_step=float(market_params["qty_step"]),
@@ -665,8 +693,9 @@ class MpsSingleCoinProxy:
         torch = self._torch
         for start in range(0, len(candidates), self.batch_size):
             chunk = candidates[start : start + self.batch_size]
+            parameter_matrix = self._parameter_matrix(chunk)
             output = self.runner.run(
-                self._parameter_matrix(chunk),
+                parameter_matrix,
                 profile=self.profile_enabled,
             )
             output = {
@@ -685,6 +714,14 @@ class MpsSingleCoinProxy:
                 values = output[key].to(torch.float64)
                 output[key] = torch.where(
                     torch.isfinite(values), values + timestamp_origin, values
+                )
+            if any("_per_exposure_" in name for name in self.needed_metrics):
+                output.update(
+                    _candidate_wallet_exposure_limit_outputs(
+                        chunk,
+                        self.base_total_wallet_exposure_limits,
+                        torch=torch,
+                    )
                 )
             objectives = self._compute_objectives(
                 output,
@@ -1022,6 +1059,12 @@ class MpsMulticoinProxy:
             "risk_twel_enforcer_threshold",
             "hsl_enabled",
         )
+        self.base_total_wallet_exposure_limits = {
+            side: float(
+                payload.bot_params_list[0][side]["total_wallet_exposure_limit"]
+            )
+            for side in ("long", "short")
+        }
         self.base_params = {}
         for side in self.sides:
             first_bot = payload.bot_params_list[0][side]
@@ -1254,9 +1297,12 @@ class MpsMulticoinProxy:
         torch = self._torch
         for start in range(0, len(candidates), self.batch_size):
             chunk = candidates[start : start + self.batch_size]
+            parameter_matrices = {
+                side: self._parameter_matrix(chunk, side) for side in self.sides
+            }
             raw_side_outputs = {
                 side: self.runners[side].run(
-                    self._parameter_matrix(chunk, side),
+                    parameter_matrices[side],
                     profile=self.profile_enabled,
                 )
                 for side in self.sides
@@ -1303,6 +1349,14 @@ class MpsMulticoinProxy:
                 values = output[key].to(torch.float64)
                 output[key] = torch.where(
                     torch.isfinite(values), values + timestamp_origin, values
+                )
+            if any("_per_exposure_" in name for name in self.needed_metrics):
+                output.update(
+                    _candidate_wallet_exposure_limit_outputs(
+                        chunk,
+                        self.base_total_wallet_exposure_limits,
+                        torch=torch,
+                    )
                 )
             objectives = self._compute_objectives(
                 output, self.run, self.metrics_data, needed=self.needed_metrics

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -540,6 +540,12 @@ def test_new_strategy_equity_metrics_reduce_existing_compact_surface():
         "first_eq_ts": torch.tensor([0.0], dtype=torch.float64),
         "last_eq_ts": torch.tensor([180_000.0], dtype=torch.float64),
         "liq_step": torch.tensor([-1.0], dtype=torch.float64),
+        "candidate_total_wallet_exposure_limit_long": torch.tensor(
+            [1.25], dtype=torch.float64
+        ),
+        "candidate_total_wallet_exposure_limit_short": torch.tensor(
+            [0.5], dtype=torch.float64
+        ),
     }
     run = SimpleNamespace(
         requested_start_ts_ms=0, guard_ts_ms=0, interval_ms=60_000
@@ -580,6 +586,20 @@ def test_new_strategy_equity_metrics_reduce_existing_compact_surface():
     }
     requested.update(alias_sources)
     requested.update(alias_sources.values())
+    per_exposure_sources = {
+        "adg_per_exposure_long_usd": ("adg_strategy_eq", 1.25),
+        "adg_per_exposure_short_usd": ("adg_strategy_eq", 0.5),
+        "adg_w_per_exposure_long_usd": ("adg_strategy_eq_w", 1.25),
+        "adg_w_per_exposure_short_usd": ("adg_strategy_eq_w", 0.5),
+        "gain_per_exposure_long_usd": ("gain_strategy_eq", 1.25),
+        "gain_per_exposure_short_usd": ("gain_strategy_eq", 0.5),
+        "mdg_per_exposure_long_usd": ("mdg_strategy_eq", 1.25),
+        "mdg_per_exposure_short_usd": ("mdg_strategy_eq", 0.5),
+        "mdg_w_per_exposure_long_usd": ("mdg_strategy_eq_w", 1.25),
+        "mdg_w_per_exposure_short_usd": ("mdg_strategy_eq_w", 0.5),
+    }
+    requested.update(per_exposure_sources)
+    assert set(per_exposure_sources) <= set(SUPPORTED_METRICS)
 
     metrics = compute_objectives(out, run, {"ts0": 0.0, "n": 4}, needed=requested)
 
@@ -602,6 +622,21 @@ def test_new_strategy_equity_metrics_reduce_existing_compact_surface():
     assert metrics["omega_ratio_strategy_eq"].item() == pytest.approx(expected_omega)
     for alias, source in alias_sources.items():
         assert metrics[alias].item() == pytest.approx(metrics[source].item())
+    for name, (source, denominator) in per_exposure_sources.items():
+        assert metrics[name].item() == pytest.approx(
+            metrics[source].item() / denominator
+        )
+
+    out["candidate_total_wallet_exposure_limit_short"] = torch.zeros(
+        1, dtype=torch.float64
+    )
+    zero_exposure = compute_objectives(
+        out,
+        run,
+        {"ts0": 0.0, "n": 4},
+        needed={"gain_per_exposure_short_usd"},
+    )
+    assert zero_exposure["gain_per_exposure_short_usd"].item() == 0.0
 
 
 def test_objectives_include_final_active_calendar_day():

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -20,6 +20,7 @@ from optimization.gpu.service import (
     MpsMulticoinEmaProxy,
     _build_multicoin_ema_coin_overrides,
     _build_multicoin_tm_coin_overrides,
+    _candidate_wallet_exposure_limit_outputs,
     _combine_hedged_multicoin_outputs,
     _directional_entry_initial_metrics,
     _hsl_params,
@@ -57,6 +58,31 @@ def test_directional_entry_initial_metrics_preserve_candidate_batch_shape(side):
     other = "short" if side == "long" else "long"
     assert metrics[f"entry_initial_balance_pct_{other}"].shape == values.shape
     assert metrics[f"entry_initial_balance_pct_{other}"].tolist() == [0.0, 0.0, 0.0]
+
+
+def test_candidate_wallet_exposure_limits_preserve_sides_and_base_fallback():
+    torch = pytest.importorskip("torch")
+
+    outputs = _candidate_wallet_exposure_limit_outputs(
+        [
+            {"long_total_wallet_exposure_limit": 1.25},
+            {
+                "long_total_wallet_exposure_limit": 1.5,
+                "short_total_wallet_exposure_limit": 0.75,
+            },
+        ],
+        {"long": 1.0, "short": 0.5},
+        torch=torch,
+    )
+
+    assert outputs["candidate_total_wallet_exposure_limit_long"].tolist() == [
+        1.25,
+        1.5,
+    ]
+    assert outputs["candidate_total_wallet_exposure_limit_short"].tolist() == [
+        0.5,
+        0.75,
+    ]
 
 
 def test_single_coin_side_eligibility_uses_prepared_coin_payload():


### PR DESCRIPTION
## Summary
- add canonical USD gain, ADG, MDG, weighted ADG, and weighted MDG per-configured-exposure metrics for long and short
- source each denominator from the effective candidate TWEL, including exact-last suite shadows and trading-disabled sides with positive configured exposure
- preserve the CPU zero-TWEL contract and reuse already validated strategy-equity proxy reductions
- keep exact Rust evaluation authoritative without changing Metal trading behavior

## Validation
- full Python optimizer suite
- cargo fmt --check
- cargo check --tests
- cargo test --no-default-features: 262 passed
- physical Apple MPS suite: 204 passed
- physical single-coin EMA Anchor: 512 proxy, 64 exact, no drift halt, 7.3s
- physical two-coin Trailing Martingale: 512 proxy, 64 exact, no drift halt, 14.2s

This is additive to GPU optimization and does not affect CPU optimization, backtesting, or live operation.