### PR TITLE
feat(optimize): add MPS realized PnL metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ All notable user-facing changes will be documented in this file.
 
 - Added `adg_pnl`, `mdg_pnl`, `sharpe_ratio_pnl`, and `sortino_ratio_pnl` scoring and limits to
   Apple MPS optimization. Metal emits each UTC fill day's realized balance change and last fill
-  balance, matching Rust's collateral-agnostic daily PnL ratio contract while exact Rust validation
-  and drift gates remain authoritative. Weighted PnL variants remain fail closed until the proxy
-  can reproduce Rust's suffix fill-count gating.
+  balance, matching Rust's collateral-agnostic daily PnL ratio contract. Dual-side multi-coin
+  screening preserves the terminal liquidation day's fills even though its equity surface stops at
+  the preceding complete day. Exact Rust validation and drift gates remain authoritative. Weighted
+  PnL variants remain fail closed until the proxy can reproduce Rust's suffix fill-count gating.
 
 - Added the canonical USD gain, ADG, MDG, weighted ADG, and weighted MDG per-configured-exposure
   metrics for both long and short sides to Apple MPS optimization. They reuse the validated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `adg_pnl`, `mdg_pnl`, `sharpe_ratio_pnl`, and `sortino_ratio_pnl` scoring and limits to
+  Apple MPS optimization. Metal emits each UTC fill day's realized balance change and last fill
+  balance, matching Rust's collateral-agnostic daily PnL ratio contract while exact Rust validation
+  and drift gates remain authoritative. Weighted PnL variants remain fail closed until the proxy
+  can reproduce Rust's suffix fill-count gating.
+
 - Added the canonical USD gain, ADG, MDG, weighted ADG, and weighted MDG per-configured-exposure
   metrics for both long and short sides to Apple MPS optimization. They reuse the validated
   strategy-equity proxy reductions and divide by each candidate's effective side

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ All notable user-facing changes will be documented in this file.
 
 - Added `adg_pnl`, `mdg_pnl`, `sharpe_ratio_pnl`, and `sortino_ratio_pnl` scoring and limits to
   Apple MPS optimization. Metal emits each UTC fill day's realized balance change and last fill
-  balance, matching Rust's collateral-agnostic daily PnL ratio contract. Dual-side multi-coin
-  screening preserves the terminal liquidation day's fills even though its equity surface stops at
-  the preceding complete day. Exact Rust validation and drift gates remain authoritative. Weighted
-  PnL variants remain fail closed until the proxy can reproduce Rust's suffix fill-count gating.
+  balance, matching Rust's collateral-agnostic daily PnL ratio contract for single-coin and
+  one-sided multi-coin runs. Dual-side multi-coin runs remain fail closed because independent
+  directional summaries cannot reconstruct an intraday shared-liquidation cutoff. Exact Rust
+  validation and drift gates remain authoritative. Weighted PnL variants remain fail closed until
+  the proxy can reproduce Rust's suffix fill-count gating.
 
 - Added the canonical USD gain, ADG, MDG, weighted ADG, and weighted MDG per-configured-exposure
   metrics for both long and short sides to Apple MPS optimization. They reuse the validated

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -323,6 +323,11 @@ position-unchanged duration, initial-entry balance percentage for each side, vol
 total-wallet-exposure maximum and mean, USD exposure ratios, backtest completion, and weighted
 variants of ADG, MDG, Sharpe, Sortino, Omega, Calmar, and Sterling. With BTC collateral disabled,
 the corresponding canonical USD account-equity names share this strategy-equity surface.
+Collateral-agnostic `adg_pnl`, `mdg_pnl`, `sharpe_ratio_pnl`, and `sortino_ratio_pnl` are also
+supported. Metal groups realized balance changes by UTC fill day and divides by that day's last
+fill balance, matching exact Rust's unweighted daily PnL ratio contract. Weighted PnL variants
+remain unsupported because Rust applies suffix-specific minimum fill-count gating that the proxy
+does not yet model.
 Initial-entry allocation uses the candidate's effective position count and the same
 first-coin strategy/allowance override precedence as exact Rust. Fill-gap longest, mean, median,
 p95, and p99 metrics are also supported. Metal coalesces multiple fills in the same candle and

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -324,10 +324,12 @@ total-wallet-exposure maximum and mean, USD exposure ratios, backtest completion
 variants of ADG, MDG, Sharpe, Sortino, Omega, Calmar, and Sterling. With BTC collateral disabled,
 the corresponding canonical USD account-equity names share this strategy-equity surface.
 Collateral-agnostic `adg_pnl`, `mdg_pnl`, `sharpe_ratio_pnl`, and `sortino_ratio_pnl` are also
-supported. Metal groups realized balance changes by UTC fill day and divides by that day's last
-fill balance, matching exact Rust's unweighted daily PnL ratio contract. Weighted PnL variants
-remain unsupported because Rust applies suffix-specific minimum fill-count gating that the proxy
-does not yet model.
+supported for single-coin and one-sided multi-coin runs. Metal groups realized balance changes by
+UTC fill day and divides by that day's last fill balance, matching exact Rust's unweighted daily
+PnL ratio contract. Dual-side multi-coin runs remain unsupported because independent directional
+summaries cannot identify the intraday shared-liquidation cutoff. Weighted PnL variants remain
+unsupported because Rust applies suffix-specific minimum fill-count gating that the proxy does not
+yet model.
 Initial-entry allocation uses the candidate's effective position count and the same
 first-coin strategy/allowance override precedence as exact Rust. Fill-gap longest, mean, median,
 p95, and p99 metrics are also supported. Metal coalesces multiple fills in the same candle and

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -41,7 +41,7 @@ mod tests {
     fn ema_anchor_mps_source_exposes_expected_kernel_contract() {
         let source = mps_ema_anchor_source();
         assert!(source.contains("kernel void passivbot_ema_anchor"));
-        assert!(source.contains("constant int DAILY_COLS = 5"));
+        assert!(source.contains("constant int DAILY_COLS = 7"));
         assert!(source.contains("constant int SCALAR_COLS = 50"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[so + 44] = loss_sum"));
@@ -111,7 +111,7 @@ mod tests {
         assert!(source.contains("constant int OVERRIDE_COLS = 19"));
         assert!(source.contains("coin_override_or"));
         assert!(source.contains("constant int COIN_COLS = 11"));
-        assert!(source.contains("constant int DAILY_COLS = 6"));
+        assert!(source.contains("constant int DAILY_COLS = 8"));
         assert!(source.contains("day_min_balance"));
         assert!(source.contains("constant int SCALAR_COLS = 24"));
         assert!(source.contains("record_gross_pnl"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -1,7 +1,7 @@
 #include <metal_stdlib>
 using namespace metal;
 
-constant int DAILY_COLS = 5;
+constant int DAILY_COLS = 7;
 constant int SCALAR_COLS = 50;
 constant int GAP_BINS = 128;
 constant int SIDE_PARAMS = 34;
@@ -1129,6 +1129,7 @@ inline void passivbot_single_coin_impl(
     float day_dd = 0.0f;
     float day_volume = 0.0f;
     float day_has_fill = 0.0f;
+    float day_start_balance = balance;
 
     for (int j = 0; j < GAP_BINS; ++j) {
         gap_hist[int(b) * GAP_BINS + j] = 0;
@@ -1160,6 +1161,8 @@ inline void passivbot_single_coin_impl(
                 daily[o + 2] = day_dd;
                 daily[o + 3] = day_volume;
                 daily[o + 4] = day_has_fill;
+                daily[o + 5] = balance - day_start_balance;
+                daily[o + 6] = balance;
             }
             cur_day = di;
             day_touched = false;
@@ -1168,6 +1171,7 @@ inline void passivbot_single_coin_impl(
             day_dd = 0.0f;
             day_volume = 0.0f;
             day_has_fill = 0.0f;
+            day_start_balance = balance;
         }
 
         bool long_close_fill = false;
@@ -1711,6 +1715,8 @@ inline void passivbot_single_coin_impl(
         daily[o + 2] = day_dd;
         daily[o + 3] = day_volume;
         daily[o + 4] = day_has_fill;
+        daily[o + 5] = balance - day_start_balance;
+        daily[o + 6] = balance;
     }
 
     if (long_side.pos_open_k >= 0.0f && last_eq_k >= 0.0f) {

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -5,7 +5,7 @@ constant int MAX_COINS = 64;
 constant int PARAM_COLS = 31;
 constant int COIN_COLS = 11;
 constant int OVERRIDE_COLS = 19;
-constant int DAILY_COLS = 6;
+constant int DAILY_COLS = 8;
 constant int SCALAR_COLS = 24;
 constant int GAP_BINS = 128;
 
@@ -414,6 +414,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
     float day_volume = 0.0f;
     float day_has_fill = 0.0f;
     float day_min_balance = INFINITY;
+    float day_start_balance = balance;
 
     for (int k = 1; k < T - 1; ++k) {
         const int day_index = (start_day_minute + k) / 1440;
@@ -426,6 +427,8 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 daily[output + 3] = day_volume;
                 daily[output + 4] = day_has_fill;
                 daily[output + 5] = day_min_balance;
+                daily[output + 6] = balance - day_start_balance;
+                daily[output + 7] = balance;
             }
             current_day = day_index;
             day_touched = false;
@@ -435,6 +438,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
             day_volume = 0.0f;
             day_has_fill = 0.0f;
             day_min_balance = INFINITY;
+            day_start_balance = balance;
         }
 
         bool any_fill = false;
@@ -1456,6 +1460,8 @@ inline void passivbot_ema_anchor_multicoin_impl(
         daily[output + 3] = day_volume;
         daily[output + 4] = day_has_fill;
         daily[output + 5] = day_min_balance;
+        daily[output + 6] = balance - day_start_balance;
+        daily[output + 7] = balance;
     }
 
     float total_size = 0.0f;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -1,7 +1,7 @@
 #include <metal_stdlib>
 using namespace metal;
 
-constant int DAILY_COLS = 5;
+constant int DAILY_COLS = 7;
 constant int SCALAR_COLS = 50;
 constant int GAP_BINS = 128;
 constant int SIDE_PARAMS = 51;
@@ -1416,6 +1416,7 @@ inline void passivbot_single_coin_impl(
     float day_dd = 0.0f;
     float day_volume = 0.0f;
     float day_has_fill = 0.0f;
+    float day_start_balance = balance;
 
     for (int j = 0; j < GAP_BINS; ++j) {
         gap_hist[int(b) * GAP_BINS + j] = 0;
@@ -1450,6 +1451,8 @@ inline void passivbot_single_coin_impl(
                 daily[o + 2] = day_dd;
                 daily[o + 3] = day_volume;
                 daily[o + 4] = day_has_fill;
+                daily[o + 5] = balance - day_start_balance;
+                daily[o + 6] = balance;
             }
             cur_day = di;
             day_touched = false;
@@ -1458,6 +1461,7 @@ inline void passivbot_single_coin_impl(
             day_dd = 0.0f;
             day_volume = 0.0f;
             day_has_fill = 0.0f;
+            day_start_balance = balance;
         }
 
         bool long_close_fill = false;
@@ -2680,6 +2684,8 @@ inline void passivbot_single_coin_impl(
         daily[o + 2] = day_dd;
         daily[o + 3] = day_volume;
         daily[o + 4] = day_has_fill;
+        daily[o + 5] = balance - day_start_balance;
+        daily[o + 6] = balance;
     }
 
     if (long_side.pos_open_k >= 0.0f && last_eq_k >= 0.0f) {

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -5,7 +5,7 @@ constant int MAX_COINS = 64;
 constant int PARAM_COLS = 48;
 constant int OVERRIDE_COLS = 34;
 constant int COIN_COLS = 11;
-constant int DAILY_COLS = 6;
+constant int DAILY_COLS = 8;
 constant int SCALAR_COLS = 24;
 constant int GAP_BINS = 128;
 
@@ -674,6 +674,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     float day_volume = 0.0f;
     float day_has_fill = 0.0f;
     float day_min_balance = INFINITY;
+    float day_start_balance = balance;
 
     for (int k = 1; k < T - 1; ++k) {
         const int day_index = (start_day_minute + k) / 1440;
@@ -686,6 +687,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 daily[output + 3] = day_volume;
                 daily[output + 4] = day_has_fill;
                 daily[output + 5] = day_min_balance;
+                daily[output + 6] = balance - day_start_balance;
+                daily[output + 7] = balance;
             }
             current_day = day_index;
             day_touched = false;
@@ -695,6 +698,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             day_volume = 0.0f;
             day_has_fill = 0.0f;
             day_min_balance = INFINITY;
+            day_start_balance = balance;
         }
 
         bool any_fill = false;
@@ -2264,6 +2268,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         daily[output + 3] = day_volume;
         daily[output + 4] = day_has_fill;
         daily[output + 5] = day_min_balance;
+        daily[output + 6] = balance - day_start_balance;
+        daily[output + 7] = balance;
     }
 
     float total_size = 0.0f;

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -799,12 +799,9 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
     if requested & _PNL_METRICS:
         day_net_pnl = out["day_net_pnl"].to(torch.float64)
         day_last_fill_balance = out["day_last_fill_balance"].to(torch.float64)
-        pnl_fill_days = out.get("day_pnl_has_fill")
-        pnl_day_mask = (
-            day_has_fill & active if pnl_fill_days is None else pnl_fill_days
-        )
         pnl_mask = (
-            pnl_day_mask
+            day_has_fill
+            & active
             & torch.isfinite(day_net_pnl)
             & torch.isfinite(day_last_fill_balance)
         )

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -799,9 +799,12 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
     if requested & _PNL_METRICS:
         day_net_pnl = out["day_net_pnl"].to(torch.float64)
         day_last_fill_balance = out["day_last_fill_balance"].to(torch.float64)
+        pnl_fill_days = out.get("day_pnl_has_fill")
+        pnl_day_mask = (
+            day_has_fill & active if pnl_fill_days is None else pnl_fill_days
+        )
         pnl_mask = (
-            day_has_fill
-            & active
+            pnl_day_mask
             & torch.isfinite(day_net_pnl)
             & torch.isfinite(day_last_fill_balance)
         )

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -49,6 +49,7 @@ _USD_PER_EXPOSURE_METRICS = {
 # still emit the normal complete metric set; this list governs only which
 # metrics may guide Metal screening or proxy-side limits.
 SUPPORTED_METRICS = (
+    "adg_pnl",
     "adg_strategy_eq",
     "adg_strategy_eq_w",
     "backtest_completion_ratio",
@@ -94,6 +95,7 @@ SUPPORTED_METRICS = (
     "loss_profit_ratio",
     "mdg_strategy_eq",
     "mdg_strategy_eq_w",
+    "mdg_pnl",
     "omega_ratio_strategy_eq",
     "omega_ratio_strategy_eq_w",
     "position_held_days_max",
@@ -103,8 +105,10 @@ SUPPORTED_METRICS = (
     "peak_recovery_hours_strategy_eq",
     "sharpe_ratio_strategy_eq",
     "sharpe_ratio_strategy_eq_w",
+    "sharpe_ratio_pnl",
     "sortino_ratio_strategy_eq",
     "sortino_ratio_strategy_eq_w",
+    "sortino_ratio_pnl",
     "sterling_ratio_strategy_eq",
     "sterling_ratio_strategy_eq_w",
     "strategy_eq_recovery_days_max",
@@ -119,6 +123,13 @@ SUPPORTED_METRICS = (
 
 # Metrics backed by additional per-fill aggregates emitted by Metal.
 EXTRA_KERNEL_METRICS = ("loss_profit_ratio",)
+
+_PNL_METRICS = {
+    "adg_pnl",
+    "mdg_pnl",
+    "sharpe_ratio_pnl",
+    "sortino_ratio_pnl",
+}
 
 
 _GAP_HIST_BINS = 128
@@ -783,6 +794,32 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
     volume_days = day_has_fill.sum(dim=1).clamp(min=1).to(torch.float64)
     volume_pct = day_volume.sum(dim=1) / volume_days
 
+    zeros = torch.zeros_like(adg)
+    adg_pnl = mdg_pnl = sharpe_pnl = sortino_pnl = zeros
+    if requested & _PNL_METRICS:
+        day_net_pnl = out["day_net_pnl"].to(torch.float64)
+        day_last_fill_balance = out["day_last_fill_balance"].to(torch.float64)
+        pnl_mask = (
+            day_has_fill
+            & active
+            & torch.isfinite(day_net_pnl)
+            & torch.isfinite(day_last_fill_balance)
+        )
+        daily_pnl_ratios = torch.where(
+            pnl_mask,
+            day_net_pnl / day_last_fill_balance.abs().clamp(min=1e-12),
+            torch.zeros_like(day_net_pnl),
+        )
+        pnl_days = pnl_mask.sum(dim=1)
+        adg_pnl = daily_pnl_ratios.sum(dim=1) / pnl_days.clamp(min=1).to(
+            daily_pnl_ratios.dtype
+        )
+        adg_pnl = torch.where(pnl_days > 0, adg_pnl, torch.zeros_like(adg_pnl))
+        mdg_pnl = _masked_median(daily_pnl_ratios, pnl_mask)
+        sharpe_pnl, sortino_pnl = _sharpe_sortino(
+            daily_pnl_ratios, pnl_mask, adg_pnl
+        )
+
     last_eq_ts = out["last_eq_ts"]
     first_eq_ts = out["first_eq_ts"]
     has_equity = (
@@ -849,6 +886,7 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
     )
 
     objectives = {
+        "adg_pnl": adg_pnl,
         "adg_strategy_eq": adg,
         "backtest_completion_ratio": completion,
         "calmar_ratio_strategy_eq": calmar,
@@ -858,11 +896,14 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
         "fills_gap_longest_days": gap_longest_days,
         "gain_strategy_eq": gain,
         "mdg_strategy_eq": mdg,
+        "mdg_pnl": mdg_pnl,
         "omega_ratio_strategy_eq": omega,
         "position_held_days_max": held_days,
         "position_held_hours_max": held_days * 24.0,
         "sharpe_ratio_strategy_eq": sharpe,
+        "sharpe_ratio_pnl": sharpe_pnl,
         "sortino_ratio_strategy_eq": sortino,
+        "sortino_ratio_pnl": sortino_pnl,
         "sterling_ratio_strategy_eq": sterling,
         "strategy_eq_recovery_days_max": recovery_max_days,
         "peak_recovery_hours_strategy_eq": recovery_max_days * 24.0,

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -17,8 +17,8 @@ from optimization.gpu.model import (
 )
 
 
-MPS_DAILY_COLS = 5
-MPS_MULTICOIN_DAILY_COLS = 6
+MPS_DAILY_COLS = 7
+MPS_MULTICOIN_DAILY_COLS = 8
 MPS_SCALAR_COLS = 24
 MPS_DIRECTIONAL_SCALAR_COLS = 50
 
@@ -100,6 +100,8 @@ def _decode_outputs(daily, scalars, gaps) -> dict:
             daily[:, :, 5],
             torch.full_like(daily[:, :, 5], float("inf")),
         ),
+        "day_net_pnl": daily[:, :, 6],
+        "day_last_fill_balance": daily[:, :, 7],
         "max_dd": scalars[:, 0],
         "held_max_ms": scalars[:, 1],
         "gap_hist": gaps,
@@ -146,6 +148,8 @@ def _decode_directional_outputs(daily, scalars, gaps) -> dict:
         "day_max_dd": daily[:, :, 2],
         "day_volume": daily[:, :, 3],
         "day_has_fill": daily[:, :, 4] > 0.0,
+        "day_net_pnl": daily[:, :, 5],
+        "day_last_fill_balance": daily[:, :, 6],
         "max_dd": scalars[:, 0],
         "held_max_ms": scalars[:, 1],
         "gap_hist": gaps,

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -377,6 +377,10 @@ def _combine_hedged_multicoin_outputs(
     liquidation_day = terminal_day.where(
         liquidated, -no_liquidation.new_ones(())
     )
+    pnl_active = active & (
+        (~liquidated).unsqueeze(1)
+        | (day_ids.unsqueeze(0) <= terminal_day.unsqueeze(1))
+    )
     active &= (~liquidated).unsqueeze(1) | (
         day_ids.unsqueeze(0) < terminal_day.unsqueeze(1)
     )
@@ -401,14 +405,17 @@ def _combine_hedged_multicoin_outputs(
     combined["day_has_fill"] = (
         long["day_has_fill"] | short["day_has_fill"]
     ) & active
+    combined["day_pnl_has_fill"] = (
+        long["day_has_fill"] | short["day_has_fill"]
+    ) & pnl_active
     combined["day_net_pnl"] = (
         long["day_net_pnl"] + short["day_net_pnl"]
-    ).where(active, long["day_net_pnl"].new_zeros(()))
+    ).where(pnl_active, long["day_net_pnl"].new_zeros(()))
     combined["day_last_fill_balance"] = (
         long["day_last_fill_balance"]
         + short["day_last_fill_balance"]
         - float(starting_balance)
-    ).where(active, long["day_last_fill_balance"].new_zeros(()))
+    ).where(pnl_active, long["day_last_fill_balance"].new_zeros(()))
     combined["max_dd"] = (long["max_dd"] + short["max_dd"]).clamp(max=1.0)
     combined["held_max_ms"] = long["held_max_ms"].maximum(short["held_max_ms"])
     combined["position_unchanged_max_ms"] = long[

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -80,6 +80,27 @@ DIRECTIONAL_HSL_OUTPUT_KEYS = {
     "hsl_panic_loss_drawdown_count",
 }
 
+_DUAL_SIDE_MULTICOIN_UNSUPPORTED_PNL_METRICS = {
+    "adg_pnl",
+    "mdg_pnl",
+    "sharpe_ratio_pnl",
+    "sortino_ratio_pnl",
+}
+
+
+def _require_multicoin_metric_topology(sides, needed_metrics) -> None:
+    unsupported = (
+        set(needed_metrics) & _DUAL_SIDE_MULTICOIN_UNSUPPORTED_PNL_METRICS
+        if len(sides) == 2
+        else set()
+    )
+    if unsupported:
+        raise ValueError(
+            "MPS dual-side multicoin proxy cannot reconstruct the intraday "
+            "shared-liquidation cutoff required by realized PnL metrics: "
+            + ", ".join(sorted(unsupported))
+        )
+
 
 def _candidate_wallet_exposure_limit_outputs(
     candidates: list[dict],
@@ -377,10 +398,6 @@ def _combine_hedged_multicoin_outputs(
     liquidation_day = terminal_day.where(
         liquidated, -no_liquidation.new_ones(())
     )
-    pnl_active = active & (
-        (~liquidated).unsqueeze(1)
-        | (day_ids.unsqueeze(0) <= terminal_day.unsqueeze(1))
-    )
     active &= (~liquidated).unsqueeze(1) | (
         day_ids.unsqueeze(0) < terminal_day.unsqueeze(1)
     )
@@ -405,17 +422,14 @@ def _combine_hedged_multicoin_outputs(
     combined["day_has_fill"] = (
         long["day_has_fill"] | short["day_has_fill"]
     ) & active
-    combined["day_pnl_has_fill"] = (
-        long["day_has_fill"] | short["day_has_fill"]
-    ) & pnl_active
     combined["day_net_pnl"] = (
         long["day_net_pnl"] + short["day_net_pnl"]
-    ).where(pnl_active, long["day_net_pnl"].new_zeros(()))
+    ).where(active, long["day_net_pnl"].new_zeros(()))
     combined["day_last_fill_balance"] = (
         long["day_last_fill_balance"]
         + short["day_last_fill_balance"]
         - float(starting_balance)
-    ).where(pnl_active, long["day_last_fill_balance"].new_zeros(()))
+    ).where(active, long["day_last_fill_balance"].new_zeros(()))
     combined["max_dd"] = (long["max_dd"] + short["max_dd"]).clamp(max=1.0)
     combined["held_max_ms"] = long["held_max_ms"].maximum(short["held_max_ms"])
     combined["position_unchanged_max_ms"] = long[
@@ -999,6 +1013,7 @@ class MpsMulticoinProxy:
                 "MPS multicoin proxy requires one or two enabled sides"
             )
         self.sides = enabled_sides
+        _require_multicoin_metric_topology(self.sides, self.needed_metrics)
         if len(enabled_sides) == 2 and not bool(
             config.get("live", {}).get("hedge_mode")
         ):

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -28,6 +28,8 @@ CORE_OUTPUT_KEYS = {
     "day_max_dd",
     "day_volume",
     "day_has_fill",
+    "day_net_pnl",
+    "day_last_fill_balance",
     "day_min_balance",
     "max_dd",
     "held_max_ms",
@@ -399,6 +401,14 @@ def _combine_hedged_multicoin_outputs(
     combined["day_has_fill"] = (
         long["day_has_fill"] | short["day_has_fill"]
     ) & active
+    combined["day_net_pnl"] = (
+        long["day_net_pnl"] + short["day_net_pnl"]
+    ).where(active, long["day_net_pnl"].new_zeros(()))
+    combined["day_last_fill_balance"] = (
+        long["day_last_fill_balance"]
+        + short["day_last_fill_balance"]
+        - float(starting_balance)
+    ).where(active, long["day_last_fill_balance"].new_zeros(()))
     combined["max_dd"] = (long["max_dd"] + short["max_dd"]).clamp(max=1.0)
     combined["held_max_ms"] = long["held_max_ms"].maximum(short["held_max_ms"])
     combined["position_unchanged_max_ms"] = long[

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -174,45 +174,6 @@ def test_daily_pnl_metrics_match_rust_fill_day_contract():
     )
 
 
-def test_daily_pnl_metrics_keep_dual_side_multicoin_liquidation_day():
-    day_end = torch.tensor([[100.0, 0.0, 0.0]], dtype=torch.float64)
-    out = {
-        "day_end_eq": day_end,
-        "day_min_eq": torch.tensor([[100.0, float("inf"), float("inf")]]),
-        "day_max_dd": torch.zeros_like(day_end),
-        "day_volume": torch.zeros_like(day_end),
-        "day_has_fill": torch.tensor([[True, False, False]]),
-        "day_pnl_has_fill": torch.tensor([[True, True, False]]),
-        "day_net_pnl": torch.tensor([[10.0, -90.0, 0.0]]),
-        "day_last_fill_balance": torch.tensor([[110.0, 20.0, 0.0]]),
-        "max_dd": torch.zeros(1),
-        "held_max_ms": torch.zeros(1),
-        "position_unchanged_max_ms": torch.zeros(1),
-        "gap_hist": torch.zeros((1, 128), dtype=torch.int32),
-        "gap_max_ms": torch.zeros(1),
-        "first_fill_ts": torch.tensor([0.0]),
-        "last_fill_ts": torch.tensor([86_400_000.0]),
-        "recovery_max_ms": torch.zeros(1),
-        "last_high_ts": torch.tensor([0.0]),
-        "first_eq_ts": torch.tensor([0.0]),
-        "last_eq_ts": torch.tensor([0.0]),
-        "liq_step": torch.tensor([1]),
-    }
-
-    metrics = compute_objectives(
-        out,
-        SimpleNamespace(
-            requested_start_ts_ms=0, guard_ts_ms=0, interval_ms=60_000
-        ),
-        {"ts0": 0.0, "n": 3},
-        needed={"adg_pnl"},
-    )
-
-    assert metrics["adg_pnl"].item() == pytest.approx(
-        ((10.0 / 110.0) + (-90.0 / 20.0)) / 2.0
-    )
-
-
 def test_empty_median_return_series_matches_rust_zero_contract():
     values = torch.empty((1, 0), dtype=torch.float64)
     mask = torch.empty((1, 0), dtype=torch.bool)

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -118,6 +118,62 @@ def test_zero_variance_sharpe_and_sortino_match_rust_zero_contract():
     assert sortino.item() == 0.0
 
 
+def test_daily_pnl_metrics_match_rust_fill_day_contract():
+    day_end = torch.full((1, 4), 100.0, dtype=torch.float64)
+    day_has_fill = torch.tensor([[True, True, False, True]])
+    out = {
+        "day_end_eq": day_end,
+        "day_min_eq": day_end.clone(),
+        "day_max_dd": torch.zeros_like(day_end),
+        "day_volume": torch.zeros_like(day_end),
+        "day_has_fill": day_has_fill,
+        "day_net_pnl": torch.tensor([[10.0, -5.0, 999.0, 0.0]]),
+        "day_last_fill_balance": torch.tensor([[110.0, 105.0, 1.0, 105.0]]),
+        "max_dd": torch.zeros(1),
+        "held_max_ms": torch.zeros(1),
+        "position_unchanged_max_ms": torch.zeros(1),
+        "gap_hist": torch.zeros((1, 128), dtype=torch.int32),
+        "gap_max_ms": torch.zeros(1),
+        "first_fill_ts": torch.tensor([0.0]),
+        "last_fill_ts": torch.tensor([180_000.0]),
+        "recovery_max_ms": torch.zeros(1),
+        "last_high_ts": torch.tensor([180_000.0]),
+        "first_eq_ts": torch.tensor([0.0]),
+        "last_eq_ts": torch.tensor([180_000.0]),
+        "liq_step": torch.tensor([-1]),
+    }
+    requested = {
+        "adg_pnl",
+        "mdg_pnl",
+        "sharpe_ratio_pnl",
+        "sortino_ratio_pnl",
+    }
+
+    metrics = compute_objectives(
+        out,
+        SimpleNamespace(
+            requested_start_ts_ms=0, guard_ts_ms=0, interval_ms=60_000
+        ),
+        {"ts0": 0.0, "n": 4},
+        needed=requested,
+    )
+
+    ratios = torch.tensor([10.0 / 110.0, -5.0 / 105.0, 0.0])
+    mean = ratios.mean()
+    std = torch.sqrt(((ratios - mean) ** 2).mean())
+    downside = torch.sqrt((ratios[ratios < 0.0] ** 2).mean())
+    assert set(metrics) == requested
+    assert requested <= set(SUPPORTED_METRICS)
+    assert metrics["adg_pnl"].item() == pytest.approx(mean.item())
+    assert metrics["mdg_pnl"].item() == 0.0
+    assert metrics["sharpe_ratio_pnl"].item() == pytest.approx(
+        (mean / std).item()
+    )
+    assert metrics["sortino_ratio_pnl"].item() == pytest.approx(
+        (mean / downside).item()
+    )
+
+
 def test_empty_median_return_series_matches_rust_zero_contract():
     values = torch.empty((1, 0), dtype=torch.float64)
     mask = torch.empty((1, 0), dtype=torch.bool)

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -174,6 +174,45 @@ def test_daily_pnl_metrics_match_rust_fill_day_contract():
     )
 
 
+def test_daily_pnl_metrics_keep_dual_side_multicoin_liquidation_day():
+    day_end = torch.tensor([[100.0, 0.0, 0.0]], dtype=torch.float64)
+    out = {
+        "day_end_eq": day_end,
+        "day_min_eq": torch.tensor([[100.0, float("inf"), float("inf")]]),
+        "day_max_dd": torch.zeros_like(day_end),
+        "day_volume": torch.zeros_like(day_end),
+        "day_has_fill": torch.tensor([[True, False, False]]),
+        "day_pnl_has_fill": torch.tensor([[True, True, False]]),
+        "day_net_pnl": torch.tensor([[10.0, -90.0, 0.0]]),
+        "day_last_fill_balance": torch.tensor([[110.0, 20.0, 0.0]]),
+        "max_dd": torch.zeros(1),
+        "held_max_ms": torch.zeros(1),
+        "position_unchanged_max_ms": torch.zeros(1),
+        "gap_hist": torch.zeros((1, 128), dtype=torch.int32),
+        "gap_max_ms": torch.zeros(1),
+        "first_fill_ts": torch.tensor([0.0]),
+        "last_fill_ts": torch.tensor([86_400_000.0]),
+        "recovery_max_ms": torch.zeros(1),
+        "last_high_ts": torch.tensor([0.0]),
+        "first_eq_ts": torch.tensor([0.0]),
+        "last_eq_ts": torch.tensor([0.0]),
+        "liq_step": torch.tensor([1]),
+    }
+
+    metrics = compute_objectives(
+        out,
+        SimpleNamespace(
+            requested_start_ts_ms=0, guard_ts_ms=0, interval_ms=60_000
+        ),
+        {"ts0": 0.0, "n": 3},
+        needed={"adg_pnl"},
+    )
+
+    assert metrics["adg_pnl"].item() == pytest.approx(
+        ((10.0 / 110.0) + (-90.0 / 20.0)) / 2.0
+    )
+
+
 def test_empty_median_return_series_matches_rust_zero_contract():
     values = torch.empty((1, 0), dtype=torch.float64)
     mask = torch.empty((1, 0), dtype=torch.bool)

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -270,6 +270,9 @@ def test_mps_multicoin_tracks_position_unchanged_max(strategy_kind, side):
         output["total_wallet_exposure_max"].item()
         >= output["total_wallet_exposure_mean"].item()
     )
+    fill_days = output["day_has_fill"].bool()
+    assert torch.isfinite(output["day_net_pnl"][fill_days]).all()
+    assert (output["day_last_fill_balance"][fill_days] > 0.0).all()
 
 
 @pytest.mark.skipif(
@@ -566,6 +569,9 @@ def test_mps_ema_anchor_shader_smoke():
     assert output["balance"].shape == (2,)
     assert torch.isfinite(output["balance"]).all()
     assert output["day_has_fill"].sum().item() > 0
+    fill_days = output["day_has_fill"]
+    assert torch.isfinite(output["day_net_pnl"][fill_days]).all()
+    assert (output["day_last_fill_balance"][fill_days] > 0.0).all()
     assert (output["total_wallet_exposure_max"] > 0.0).all()
     assert (
         output["total_wallet_exposure_max"]
@@ -593,7 +599,7 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
     assert "secondary_close_qty" in source
     assert "realized_loss_proxy_allows_close" in source
     assert "const bool loss_gate_enabled = run_settings[5] < 1.0f" in source
-    assert "constant int DAILY_COLS = 6" in source
+    assert "constant int DAILY_COLS = 8" in source
     assert "day_min_balance" in source
     assert "coin_override_or" in source
     assert "const float score_hysteresis = fmax(run_settings[4], 0.0f)" in source
@@ -2108,6 +2114,9 @@ def test_mps_tm_equal_unstuck_twel_reducers_keep_nearer_twel(side):
     # unstuck, proving selection follows Rust's reachability tie-break.
     assert output[size_key].item() == pytest.approx(5.0)
     assert output["total_wallet_exposure_max"].item() > 0.0
+    fill_days = output["day_has_fill"]
+    assert torch.isfinite(output["day_net_pnl"][fill_days]).all()
+    assert (output["day_last_fill_balance"][fill_days] > 0.0).all()
     assert (
         output["total_wallet_exposure_max"].item()
         >= output["total_wallet_exposure_mean"].item()

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -26,6 +26,7 @@ from optimization.gpu.service import (
     _hsl_params,
     _position_exposure_enforcer_params,
     _prepared_single_coin_side_enabled,
+    _require_multicoin_metric_topology,
     _require_complete_valid_tail,
     _require_no_internal_invalid_hsl_candles,
     _single_coin_exposure_params,
@@ -45,6 +46,18 @@ def test_core_output_contract_retains_gross_pnl_aggregates():
         "total_wallet_exposure_max",
         "total_wallet_exposure_mean",
     } <= CORE_OUTPUT_KEYS
+
+
+@pytest.mark.parametrize(
+    "metric",
+    ["adg_pnl", "mdg_pnl", "sharpe_ratio_pnl", "sortino_ratio_pnl"],
+)
+def test_dual_side_multicoin_realized_pnl_metrics_fail_closed(metric):
+    with pytest.raises(ValueError, match="shared-liquidation cutoff"):
+        _require_multicoin_metric_topology(["long", "short"], {metric})
+
+    _require_multicoin_metric_topology(["long"], {metric})
+    _require_multicoin_metric_topology(["long", "short"], {"adg_strategy_eq"})
 
 
 @pytest.mark.parametrize("side", ["long", "short"])
@@ -564,8 +577,8 @@ def test_combine_hedged_multicoin_outputs_detects_shared_equity_liquidation():
             "day_volume": torch.tensor([[0.1, 0.1, 0.1]]),
             "day_has_fill": torch.tensor([[True, True, True]]),
             "day_min_balance": torch.tensor([[900.0, 900.0, 900.0]]),
-            "day_net_pnl": torch.tensor([[0.0, -240.0, 0.0]]),
-            "day_last_fill_balance": torch.tensor([[1_000.0, 760.0, 760.0]]),
+            "day_net_pnl": torch.zeros((1, 3)),
+            "day_last_fill_balance": torch.full((1, 3), 1_000.0),
             "max_dd": torch.tensor([0.48]),
             "held_max_ms": torch.tensor([100.0]),
             "position_unchanged_max_ms": torch.tensor([150.0]),
@@ -591,9 +604,6 @@ def test_combine_hedged_multicoin_outputs_detects_shared_equity_liquidation():
     assert torch.isinf(combined["day_min_eq"][0, 1])
     assert torch.isinf(combined["day_min_eq"][0, 2])
     assert combined["day_end_eq"][0, 1].item() == 0.0
-    assert combined["day_pnl_has_fill"].tolist() == [[True, True, False]]
-    assert combined["day_net_pnl"].tolist() == [[0.0, -480.0, 0.0]]
-    assert combined["day_last_fill_balance"].tolist() == [[1_000.0, 520.0, 0.0]]
     assert combined["last_eq_ts"].item() == 86_340_000.0
 
 

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -466,6 +466,10 @@ def test_combine_hedged_multicoin_outputs_uses_conservative_surface():
             "day_volume": torch.tensor([[0.4, 0.5]]),
             "day_has_fill": torch.tensor([fill]),
             "day_min_balance": torch.tensor([[1_000.0, 1_000.0]]),
+            "day_net_pnl": torch.tensor(
+                [[end[0] - 1_000.0, end[1] - end[0]]]
+            ),
+            "day_last_fill_balance": torch.tensor([end]),
             "max_dd": torch.tensor([0.20]),
             "held_max_ms": torch.tensor([100.0]),
             "position_unchanged_max_ms": torch.tensor([150.0]),
@@ -517,6 +521,8 @@ def test_combine_hedged_multicoin_outputs_uses_conservative_surface():
     assert combined["max_dd"].item() == pytest.approx(0.50)
     np.testing.assert_allclose(combined["day_volume"].numpy(), [[0.5, 0.7]])
     assert combined["day_has_fill"].tolist() == [[True, True]]
+    assert combined["day_net_pnl"].tolist() == [[50.0, 50.0]]
+    assert combined["day_last_fill_balance"].tolist() == [[1_050.0, 1_100.0]]
     assert combined["first_fill_ts"].item() == 300.0
     assert combined["last_fill_ts"].item() == 700.0
     assert combined["last_high_ts"].item() == 800.0
@@ -558,6 +564,8 @@ def test_combine_hedged_multicoin_outputs_detects_shared_equity_liquidation():
             "day_volume": torch.tensor([[0.1, 0.1, 0.1]]),
             "day_has_fill": torch.tensor([[True, True, True]]),
             "day_min_balance": torch.tensor([[900.0, 900.0, 900.0]]),
+            "day_net_pnl": torch.zeros((1, 3)),
+            "day_last_fill_balance": torch.full((1, 3), 1_000.0),
             "max_dd": torch.tensor([0.48]),
             "held_max_ms": torch.tensor([100.0]),
             "position_unchanged_max_ms": torch.tensor([150.0]),
@@ -597,6 +605,8 @@ def test_combine_hedged_multicoin_outputs_detects_shared_balance_depletion():
             "day_volume": torch.tensor([[0.1, 0.1, 0.1]]),
             "day_has_fill": torch.tensor([[True, True, True]]),
             "day_min_balance": torch.tensor([[900.0, 450.0, 700.0]]),
+            "day_net_pnl": torch.zeros((1, 3)),
+            "day_last_fill_balance": torch.full((1, 3), 1_000.0),
             "max_dd": torch.tensor([0.40]),
             "held_max_ms": torch.tensor([100.0]),
             "position_unchanged_max_ms": torch.tensor([150.0]),

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -564,8 +564,8 @@ def test_combine_hedged_multicoin_outputs_detects_shared_equity_liquidation():
             "day_volume": torch.tensor([[0.1, 0.1, 0.1]]),
             "day_has_fill": torch.tensor([[True, True, True]]),
             "day_min_balance": torch.tensor([[900.0, 900.0, 900.0]]),
-            "day_net_pnl": torch.zeros((1, 3)),
-            "day_last_fill_balance": torch.full((1, 3), 1_000.0),
+            "day_net_pnl": torch.tensor([[0.0, -240.0, 0.0]]),
+            "day_last_fill_balance": torch.tensor([[1_000.0, 760.0, 760.0]]),
             "max_dd": torch.tensor([0.48]),
             "held_max_ms": torch.tensor([100.0]),
             "position_unchanged_max_ms": torch.tensor([150.0]),
@@ -591,6 +591,9 @@ def test_combine_hedged_multicoin_outputs_detects_shared_equity_liquidation():
     assert torch.isinf(combined["day_min_eq"][0, 1])
     assert torch.isinf(combined["day_min_eq"][0, 2])
     assert combined["day_end_eq"][0, 1].item() == 0.0
+    assert combined["day_pnl_has_fill"].tolist() == [[True, True, False]]
+    assert combined["day_net_pnl"].tolist() == [[0.0, -480.0, 0.0]]
+    assert combined["day_last_fill_balance"].tolist() == [[1_000.0, 520.0, 0.0]]
     assert combined["last_eq_ts"].item() == 86_340_000.0
 
 


### PR DESCRIPTION
## Summary
- add Apple MPS proxy scoring and limits for `adg_pnl`, `mdg_pnl`, `sharpe_ratio_pnl`, and `sortino_ratio_pnl`
- emit per-UTC-fill-day net balance change and last fill balance from EMA Anchor and Trailing Martingale single-coin and multi-coin Metal kernels
- support all single-coin topologies and one-sided multi-coin; dual-side multi-coin fails closed because independent kernels cannot reconstruct the intraday shared-liquidation cutoff
- retain exact Rust as authoritative and keep weighted PnL metrics fail closed pending suffix fill-count parity

## Validation
- full `tests/optimization` Python suite
- full physical Apple M3/MPS `tests/optimization/test_gpu_mps.py`
- `cargo fmt --all -- --check`
- `cargo check --tests`
- `cargo test --no-default-features` (262 passed)
- end-to-end ETH EMA Anchor MPS optimization: 576 proxy evaluations, 64 exact validations, all four new objectives, `drift_halt=0.9`, no parity or constraint halt
- `git diff --check`

## Scope
GPU support remains purely additive. CPU optimization, exact Rust backtesting, bot execution, dual-side multicoin proxy behavior for other metrics, and weighted PnL metric behavior are unchanged.