### PR TITLE
feat(optimize): add weighted MPS PnL metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,19 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added weighted `adg_pnl_w`, `mdg_pnl_w`, `sharpe_ratio_pnl_w`, and
+  `sortino_ratio_pnl_w` scoring and limits to Apple MPS optimization for single-coin and one-sided
+  multi-coin runs. Metal counts every proxy fill, including multiple same-candle ladder fills, so
+  the reducer can reproduce Rust's full-run minimum fill count and empty-suffix behavior across the
+  ten weighted windows. Exact Rust validation and drift gates remain authoritative; dual-side
+  multi-coin runs retain the existing fail-closed shared-liquidation boundary.
+
 - Added `adg_pnl`, `mdg_pnl`, `sharpe_ratio_pnl`, and `sortino_ratio_pnl` scoring and limits to
   Apple MPS optimization. Metal emits each UTC fill day's realized balance change and last fill
   balance, matching Rust's collateral-agnostic daily PnL ratio contract for single-coin and
   one-sided multi-coin runs. Dual-side multi-coin runs remain fail closed because independent
   directional summaries cannot reconstruct an intraday shared-liquidation cutoff. Exact Rust
-  validation and drift gates remain authoritative. Weighted PnL variants remain fail closed until
-  the proxy can reproduce Rust's suffix fill-count gating.
+  validation and drift gates remain authoritative.
 
 - Added the canonical USD gain, ADG, MDG, weighted ADG, and weighted MDG per-configured-exposure
   metrics for both long and short sides to Apple MPS optimization. They reuse the validated

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -327,9 +327,12 @@ Collateral-agnostic `adg_pnl`, `mdg_pnl`, `sharpe_ratio_pnl`, and `sortino_ratio
 supported for single-coin and one-sided multi-coin runs. Metal groups realized balance changes by
 UTC fill day and divides by that day's last fill balance, matching exact Rust's unweighted daily
 PnL ratio contract. Dual-side multi-coin runs remain unsupported because independent directional
-summaries cannot identify the intraday shared-liquidation cutoff. Weighted PnL variants remain
-unsupported because Rust applies suffix-specific minimum fill-count gating that the proxy does not
-yet model.
+summaries cannot identify the intraday shared-liquidation cutoff. The corresponding weighted PnL
+variants are supported in the same safe topologies. Metal counts each actual proxy fill, including
+multiple same-candle ladder fills, and applies Rust's full-run minimum fill count and empty-suffix
+rules across the same ten minute-position suffix boundaries. The compact daily surface includes
+the complete UTC day containing each suffix boundary, so exact Rust validation and drift gates
+remain authoritative for that screening approximation.
 Initial-entry allocation uses the candidate's effective position count and the same
 first-coin strategy/allowance override precedence as exact Rust. Fill-gap longest, mean, median,
 p95, and p99 metrics are also supported. Metal coalesces multiple fills in the same candle and

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -41,7 +41,7 @@ mod tests {
     fn ema_anchor_mps_source_exposes_expected_kernel_contract() {
         let source = mps_ema_anchor_source();
         assert!(source.contains("kernel void passivbot_ema_anchor"));
-        assert!(source.contains("constant int DAILY_COLS = 7"));
+        assert!(source.contains("constant int DAILY_COLS = 8"));
         assert!(source.contains("constant int SCALAR_COLS = 50"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[so + 44] = loss_sum"));
@@ -111,7 +111,7 @@ mod tests {
         assert!(source.contains("constant int OVERRIDE_COLS = 19"));
         assert!(source.contains("coin_override_or"));
         assert!(source.contains("constant int COIN_COLS = 11"));
-        assert!(source.contains("constant int DAILY_COLS = 8"));
+        assert!(source.contains("constant int DAILY_COLS = 9"));
         assert!(source.contains("day_min_balance"));
         assert!(source.contains("constant int SCALAR_COLS = 24"));
         assert!(source.contains("record_gross_pnl"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -1,7 +1,7 @@
 #include <metal_stdlib>
 using namespace metal;
 
-constant int DAILY_COLS = 7;
+constant int DAILY_COLS = 8;
 constant int SCALAR_COLS = 50;
 constant int GAP_BINS = 128;
 constant int SIDE_PARAMS = 34;
@@ -62,8 +62,10 @@ inline float float32_floor_nonnegative(float value) {
 inline void record_realized_net(
     float net_pnl,
     thread float& realized_pnl_cumsum_last,
-    thread float& realized_pnl_cumsum_max
+    thread float& realized_pnl_cumsum_max,
+    thread float& day_fill_count
 ) {
+    day_fill_count += 1.0f;
     realized_pnl_cumsum_last += net_pnl;
     realized_pnl_cumsum_max = fmax(
         realized_pnl_cumsum_max, realized_pnl_cumsum_last
@@ -1130,6 +1132,7 @@ inline void passivbot_single_coin_impl(
     float day_volume = 0.0f;
     float day_has_fill = 0.0f;
     float day_start_balance = balance;
+    float day_fill_count = 0.0f;
 
     for (int j = 0; j < GAP_BINS; ++j) {
         gap_hist[int(b) * GAP_BINS + j] = 0;
@@ -1163,6 +1166,7 @@ inline void passivbot_single_coin_impl(
                 daily[o + 4] = day_has_fill;
                 daily[o + 5] = balance - day_start_balance;
                 daily[o + 6] = balance;
+                daily[o + 7] = day_fill_count;
             }
             cur_day = di;
             day_touched = false;
@@ -1172,6 +1176,7 @@ inline void passivbot_single_coin_impl(
             day_volume = 0.0f;
             day_has_fill = 0.0f;
             day_start_balance = balance;
+            day_fill_count = 0.0f;
         }
 
         bool long_close_fill = false;
@@ -1221,7 +1226,8 @@ inline void passivbot_single_coin_impl(
             record_gross_pnl(pnl, profit_sum, loss_sum);
             balance += net_pnl;
             record_realized_net(
-                net_pnl, realized_pnl_cumsum_last, realized_pnl_cumsum_max
+                net_pnl, realized_pnl_cumsum_last, realized_pnl_cumsum_max,
+                day_fill_count
             );
             float new_psize = fmax(round_step(long_side.psize - adj, qty_step), 0.0f);
             bool went_flat = new_psize <= 0.0f;
@@ -1251,7 +1257,8 @@ inline void passivbot_single_coin_impl(
             float fee = eq * ep * c_mult * maker_fee;
             balance -= fee;
             record_realized_net(
-                -fee, realized_pnl_cumsum_last, realized_pnl_cumsum_max
+                -fee, realized_pnl_cumsum_last, realized_pnl_cumsum_max,
+                day_fill_count
             );
             bool was_flat = long_side.psize <= 0.0f;
             float new_psize = round_step(long_side.psize + eq, qty_step);
@@ -1313,7 +1320,8 @@ inline void passivbot_single_coin_impl(
             record_gross_pnl(pnl, profit_sum, loss_sum);
             balance += net_pnl;
             record_realized_net(
-                net_pnl, realized_pnl_cumsum_last, realized_pnl_cumsum_max
+                net_pnl, realized_pnl_cumsum_last, realized_pnl_cumsum_max,
+                day_fill_count
             );
             float new_psize = fmax(round_step(short_side.psize - adj, qty_step), 0.0f);
             bool went_flat = new_psize <= 0.0f;
@@ -1343,7 +1351,8 @@ inline void passivbot_single_coin_impl(
             float fee = eq * ep * c_mult * maker_fee;
             balance -= fee;
             record_realized_net(
-                -fee, realized_pnl_cumsum_last, realized_pnl_cumsum_max
+                -fee, realized_pnl_cumsum_last, realized_pnl_cumsum_max,
+                day_fill_count
             );
             bool was_flat = short_side.psize <= 0.0f;
             float new_psize = round_step(short_side.psize + eq, qty_step);
@@ -1717,6 +1726,7 @@ inline void passivbot_single_coin_impl(
         daily[o + 4] = day_has_fill;
         daily[o + 5] = balance - day_start_balance;
         daily[o + 6] = balance;
+        daily[o + 7] = day_fill_count;
     }
 
     if (long_side.pos_open_k >= 0.0f && last_eq_k >= 0.0f) {

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -5,7 +5,7 @@ constant int MAX_COINS = 64;
 constant int PARAM_COLS = 31;
 constant int COIN_COLS = 11;
 constant int OVERRIDE_COLS = 19;
-constant int DAILY_COLS = 8;
+constant int DAILY_COLS = 9;
 constant int SCALAR_COLS = 24;
 constant int GAP_BINS = 128;
 
@@ -66,8 +66,10 @@ inline float float32_floor_nonnegative(float value) {
 inline void record_realized_net(
     float net_pnl,
     thread float& realized_pnl_cumsum_last,
-    thread float& realized_pnl_cumsum_max
+    thread float& realized_pnl_cumsum_max,
+    thread float& day_fill_count
 ) {
+    day_fill_count += 1.0f;
     realized_pnl_cumsum_last += net_pnl;
     realized_pnl_cumsum_max = fmax(
         realized_pnl_cumsum_max, realized_pnl_cumsum_last
@@ -415,6 +417,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
     float day_has_fill = 0.0f;
     float day_min_balance = INFINITY;
     float day_start_balance = balance;
+    float day_fill_count = 0.0f;
 
     for (int k = 1; k < T - 1; ++k) {
         const int day_index = (start_day_minute + k) / 1440;
@@ -429,6 +432,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 daily[output + 5] = day_min_balance;
                 daily[output + 6] = balance - day_start_balance;
                 daily[output + 7] = balance;
+                daily[output + 8] = day_fill_count;
             }
             current_day = day_index;
             day_touched = false;
@@ -439,6 +443,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
             day_has_fill = 0.0f;
             day_min_balance = INFINITY;
             day_start_balance = balance;
+            day_fill_count = 0.0f;
         }
 
         bool any_fill = false;
@@ -507,7 +512,8 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 balance += net_pnl;
                 record_realized_net(
                     net_pnl, realized_pnl_cumsum_last,
-                    realized_pnl_cumsum_max
+                    realized_pnl_cumsum_max,
+                    day_fill_count
                 );
                 float new_size = fmax(round_step(psize[c] - adjusted, qty_step), 0.0f);
                 bool went_flat = new_size <= 0.0f;
@@ -544,7 +550,8 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 balance -= fee;
                 record_realized_net(
                     -fee, realized_pnl_cumsum_last,
-                    realized_pnl_cumsum_max
+                    realized_pnl_cumsum_max,
+                    day_fill_count
                 );
                 float new_size = round_step(psize[c] + adjusted, qty_step);
                 float new_price = was_flat ? fill_price
@@ -1462,6 +1469,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
         daily[output + 5] = day_min_balance;
         daily[output + 6] = balance - day_start_balance;
         daily[output + 7] = balance;
+        daily[output + 8] = day_fill_count;
     }
 
     float total_size = 0.0f;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -1,7 +1,7 @@
 #include <metal_stdlib>
 using namespace metal;
 
-constant int DAILY_COLS = 7;
+constant int DAILY_COLS = 8;
 constant int SCALAR_COLS = 50;
 constant int GAP_BINS = 128;
 constant int SIDE_PARAMS = 51;
@@ -122,8 +122,10 @@ inline bool realized_loss_proxy_allows_reducer(
 inline void record_realized_net(
     float net_pnl,
     thread float& realized_pnl_cumsum_last,
-    thread float& realized_pnl_cumsum_max
+    thread float& realized_pnl_cumsum_max,
+    thread float& day_fill_count
 ) {
+    day_fill_count += 1.0f;
     realized_pnl_cumsum_last += net_pnl;
     realized_pnl_cumsum_max = fmax(
         realized_pnl_cumsum_max, realized_pnl_cumsum_last
@@ -1417,6 +1419,7 @@ inline void passivbot_single_coin_impl(
     float day_volume = 0.0f;
     float day_has_fill = 0.0f;
     float day_start_balance = balance;
+    float day_fill_count = 0.0f;
 
     for (int j = 0; j < GAP_BINS; ++j) {
         gap_hist[int(b) * GAP_BINS + j] = 0;
@@ -1453,6 +1456,7 @@ inline void passivbot_single_coin_impl(
                 daily[o + 4] = day_has_fill;
                 daily[o + 5] = balance - day_start_balance;
                 daily[o + 6] = balance;
+                daily[o + 7] = day_fill_count;
             }
             cur_day = di;
             day_touched = false;
@@ -1462,6 +1466,7 @@ inline void passivbot_single_coin_impl(
             day_volume = 0.0f;
             day_has_fill = 0.0f;
             day_start_balance = balance;
+            day_fill_count = 0.0f;
         }
 
         bool long_close_fill = false;
@@ -1676,7 +1681,8 @@ inline void passivbot_single_coin_impl(
                         record_realized_net(
                             pnl - fee,
                             realized_pnl_cumsum_last,
-                            realized_pnl_cumsum_max
+                            realized_pnl_cumsum_max,
+                            day_fill_count
                         );
                         long_side.psize = fmax(
                             round_step(
@@ -1711,7 +1717,8 @@ inline void passivbot_single_coin_impl(
                 record_realized_net(
                     pnl - fee,
                     realized_pnl_cumsum_last,
-                    realized_pnl_cumsum_max
+                    realized_pnl_cumsum_max,
+                    day_fill_count
                 );
                 float new_psize = fmax(
                     round_step(long_side.psize - adj, qty_step), 0.0f
@@ -1757,7 +1764,8 @@ inline void passivbot_single_coin_impl(
                     record_realized_net(
                         pnl - fee,
                         realized_pnl_cumsum_last,
-                        realized_pnl_cumsum_max
+                        realized_pnl_cumsum_max,
+                        day_fill_count
                     );
                     long_side.psize = fmax(
                         round_step(long_side.psize - adj, qty_step), 0.0f
@@ -1826,7 +1834,8 @@ inline void passivbot_single_coin_impl(
                 record_realized_net(
                     pnl - fee,
                     realized_pnl_cumsum_last,
-                    realized_pnl_cumsum_max
+                    realized_pnl_cumsum_max,
+                    day_fill_count
                 );
                 long_side.psize = fmax(
                     round_step(long_side.psize - adj, qty_step), 0.0f
@@ -1874,7 +1883,8 @@ inline void passivbot_single_coin_impl(
                 record_realized_net(
                     -fee,
                     realized_pnl_cumsum_last,
-                    realized_pnl_cumsum_max
+                    realized_pnl_cumsum_max,
+                    day_fill_count
                 );
                 bool was_flat = long_side.psize <= 0.0f;
                 float new_psize = round_step(long_side.psize + eq, qty_step);
@@ -2118,7 +2128,8 @@ inline void passivbot_single_coin_impl(
                         record_realized_net(
                             pnl - fee,
                             realized_pnl_cumsum_last,
-                            realized_pnl_cumsum_max
+                            realized_pnl_cumsum_max,
+                            day_fill_count
                         );
                         short_side.psize = fmax(
                             round_step(
@@ -2153,7 +2164,8 @@ inline void passivbot_single_coin_impl(
                 record_realized_net(
                     pnl - fee,
                     realized_pnl_cumsum_last,
-                    realized_pnl_cumsum_max
+                    realized_pnl_cumsum_max,
+                    day_fill_count
                 );
                 float new_psize = fmax(
                     round_step(short_side.psize - adj, qty_step), 0.0f
@@ -2199,7 +2211,8 @@ inline void passivbot_single_coin_impl(
                     record_realized_net(
                         pnl - fee,
                         realized_pnl_cumsum_last,
-                        realized_pnl_cumsum_max
+                        realized_pnl_cumsum_max,
+                        day_fill_count
                     );
                     short_side.psize = fmax(
                         round_step(short_side.psize - adj, qty_step), 0.0f
@@ -2268,7 +2281,8 @@ inline void passivbot_single_coin_impl(
                 record_realized_net(
                     pnl - fee,
                     realized_pnl_cumsum_last,
-                    realized_pnl_cumsum_max
+                    realized_pnl_cumsum_max,
+                    day_fill_count
                 );
                 short_side.psize = fmax(
                     round_step(short_side.psize - adj, qty_step), 0.0f
@@ -2316,7 +2330,8 @@ inline void passivbot_single_coin_impl(
                 record_realized_net(
                     -fee,
                     realized_pnl_cumsum_last,
-                    realized_pnl_cumsum_max
+                    realized_pnl_cumsum_max,
+                    day_fill_count
                 );
                 bool was_flat = short_side.psize <= 0.0f;
                 float new_psize = round_step(short_side.psize + eq, qty_step);
@@ -2686,6 +2701,7 @@ inline void passivbot_single_coin_impl(
         daily[o + 4] = day_has_fill;
         daily[o + 5] = balance - day_start_balance;
         daily[o + 6] = balance;
+        daily[o + 7] = day_fill_count;
     }
 
     if (long_side.pos_open_k >= 0.0f && last_eq_k >= 0.0f) {

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -5,7 +5,7 @@ constant int MAX_COINS = 64;
 constant int PARAM_COLS = 48;
 constant int OVERRIDE_COLS = 34;
 constant int COIN_COLS = 11;
-constant int DAILY_COLS = 8;
+constant int DAILY_COLS = 9;
 constant int SCALAR_COLS = 24;
 constant int GAP_BINS = 128;
 
@@ -67,8 +67,10 @@ inline float float32_floor_nonnegative(float value) {
 inline void record_realized_net(
     float net_pnl,
     thread float& realized_pnl_cumsum_last,
-    thread float& realized_pnl_cumsum_max
+    thread float& realized_pnl_cumsum_max,
+    thread float& day_fill_count
 ) {
+    day_fill_count += 1.0f;
     realized_pnl_cumsum_last += net_pnl;
     realized_pnl_cumsum_max = fmax(
         realized_pnl_cumsum_max, realized_pnl_cumsum_last
@@ -675,6 +677,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     float day_has_fill = 0.0f;
     float day_min_balance = INFINITY;
     float day_start_balance = balance;
+    float day_fill_count = 0.0f;
 
     for (int k = 1; k < T - 1; ++k) {
         const int day_index = (start_day_minute + k) / 1440;
@@ -689,6 +692,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 daily[output + 5] = day_min_balance;
                 daily[output + 6] = balance - day_start_balance;
                 daily[output + 7] = balance;
+                daily[output + 8] = day_fill_count;
             }
             current_day = day_index;
             day_touched = false;
@@ -699,6 +703,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             day_has_fill = 0.0f;
             day_min_balance = INFINITY;
             day_start_balance = balance;
+            day_fill_count = 0.0f;
         }
 
         bool any_fill = false;
@@ -955,7 +960,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                             balance += net_pnl;
                             record_realized_net(
                                 net_pnl, realized_pnl_cumsum_last,
-                                realized_pnl_cumsum_max
+                                realized_pnl_cumsum_max,
+                                day_fill_count
                             );
                             psize[c] = fmax(
                                 round_step(psize[c] - qty, qty_step), 0.0f
@@ -989,7 +995,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     balance += grid_net_pnl;
                     record_realized_net(
                         grid_net_pnl, realized_pnl_cumsum_last,
-                        realized_pnl_cumsum_max
+                        realized_pnl_cumsum_max,
+                        day_fill_count
                     );
                     psize[c] = fmax(
                         round_step(psize[c] - grid_qty, qty_step), 0.0f
@@ -1037,7 +1044,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     balance += net_pnl;
                     record_realized_net(
                         net_pnl, realized_pnl_cumsum_last,
-                        realized_pnl_cumsum_max
+                        realized_pnl_cumsum_max,
+                        day_fill_count
                     );
                     psize[c] = fmax(
                         round_step(psize[c] - qty, qty_step), 0.0f
@@ -1079,7 +1087,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 balance -= fee;
                 record_realized_net(
                     -fee, realized_pnl_cumsum_last,
-                    realized_pnl_cumsum_max
+                    realized_pnl_cumsum_max,
+                    day_fill_count
                 );
                 float new_size = round_step(psize[c] + adjusted, qty_step);
                 float new_price = was_flat ? fill_price
@@ -2270,6 +2279,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         daily[output + 5] = day_min_balance;
         daily[output + 6] = balance - day_start_balance;
         daily[output + 7] = balance;
+        daily[output + 8] = day_fill_count;
     }
 
     float total_size = 0.0f;

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -487,6 +487,14 @@ def _weighted_subsets(
     interval_ms,
 ):
     finite_timestamps = torch.isfinite(first_eq_ts) & torch.isfinite(last_eq_ts)
+    timestamp_origin = float(first_timestamp)
+    relative_timestamps = finite_timestamps & (first_eq_ts < timestamp_origin)
+    first_eq_ts = torch.where(
+        relative_timestamps, first_eq_ts + timestamp_origin, first_eq_ts
+    )
+    last_eq_ts = torch.where(
+        relative_timestamps, last_eq_ts + timestamp_origin, last_eq_ts
+    )
     sample_span = torch.where(
         finite_timestamps,
         (last_eq_ts - first_eq_ts) / float(interval_ms),
@@ -500,7 +508,7 @@ def _weighted_subsets(
     )
     eligible = finite_timestamps & (sample_count >= 2)
     subsets = [active]
-    first_day = int(first_timestamp) // 86_400_000
+    first_day = int(timestamp_origin) // 86_400_000
     day_ids = torch.arange(active.shape[1], device=active.device) + first_day
     for index in range(1, 10):
         fraction = 1.0 / (1.0 + index)

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -50,6 +50,7 @@ _USD_PER_EXPOSURE_METRICS = {
 # metrics may guide Metal screening or proxy-side limits.
 SUPPORTED_METRICS = (
     "adg_pnl",
+    "adg_pnl_w",
     "adg_strategy_eq",
     "adg_strategy_eq_w",
     "backtest_completion_ratio",
@@ -96,6 +97,7 @@ SUPPORTED_METRICS = (
     "mdg_strategy_eq",
     "mdg_strategy_eq_w",
     "mdg_pnl",
+    "mdg_pnl_w",
     "omega_ratio_strategy_eq",
     "omega_ratio_strategy_eq_w",
     "position_held_days_max",
@@ -106,9 +108,11 @@ SUPPORTED_METRICS = (
     "sharpe_ratio_strategy_eq",
     "sharpe_ratio_strategy_eq_w",
     "sharpe_ratio_pnl",
+    "sharpe_ratio_pnl_w",
     "sortino_ratio_strategy_eq",
     "sortino_ratio_strategy_eq_w",
     "sortino_ratio_pnl",
+    "sortino_ratio_pnl_w",
     "sterling_ratio_strategy_eq",
     "sterling_ratio_strategy_eq_w",
     "strategy_eq_recovery_days_max",
@@ -129,6 +133,13 @@ _PNL_METRICS = {
     "mdg_pnl",
     "sharpe_ratio_pnl",
     "sortino_ratio_pnl",
+}
+
+_WEIGHTED_PNL_METRICS = {
+    "adg_pnl_w",
+    "mdg_pnl_w",
+    "sharpe_ratio_pnl_w",
+    "sortino_ratio_pnl_w",
 }
 
 
@@ -627,6 +638,81 @@ def _weighted_strategy_eq_metrics(
     return {name: value / 10.0 for name, value in totals.items()}
 
 
+def _daily_pnl_stats(day_net_pnl, day_last_fill_balance, mask):
+    finite_mask = (
+        mask
+        & torch.isfinite(day_net_pnl)
+        & torch.isfinite(day_last_fill_balance)
+    )
+    ratios = torch.where(
+        finite_mask,
+        day_net_pnl / day_last_fill_balance.abs().clamp(min=1e-12),
+        torch.zeros_like(day_net_pnl),
+    )
+    count = finite_mask.sum(dim=1)
+    adg = ratios.sum(dim=1) / count.clamp(min=1).to(ratios.dtype)
+    adg = torch.where(count > 0, adg, torch.zeros_like(adg))
+    mdg = _masked_median(ratios, finite_mask)
+    sharpe, sortino = _sharpe_sortino(ratios, finite_mask, adg)
+    return adg, mdg, sharpe, sortino, count
+
+
+def _weighted_pnl_metrics(
+    day_net_pnl,
+    day_last_fill_balance,
+    day_fill_count,
+    active,
+    first_eq_ts,
+    last_eq_ts,
+    first_timestamp,
+    interval_ms,
+    requested,
+):
+    requested = set(requested) & _WEIGHTED_PNL_METRICS
+    if not requested:
+        return {}
+    _, subsets = _weighted_subsets(
+        active,
+        first_eq_ts,
+        last_eq_ts,
+        first_timestamp,
+        interval_ms,
+    )
+    fill_count = torch.where(
+        active, day_fill_count, torch.zeros_like(day_fill_count)
+    )
+    eligible = fill_count.sum(dim=1) > 1.0
+    totals = {
+        name: torch.zeros(
+            day_net_pnl.shape[0],
+            dtype=day_net_pnl.dtype,
+            device=day_net_pnl.device,
+        )
+        for name in requested
+    }
+    for subset in subsets:
+        subset_fill_count = torch.where(
+            subset, fill_count, torch.zeros_like(fill_count)
+        ).sum(dim=1)
+        adg, mdg, sharpe, sortino, _ = _daily_pnl_stats(
+            day_net_pnl,
+            day_last_fill_balance,
+            subset & (fill_count > 0.0),
+        )
+        include = eligible & (subset_fill_count > 0.0)
+        values = {
+            "adg_pnl_w": adg,
+            "mdg_pnl_w": mdg,
+            "sharpe_ratio_pnl_w": sharpe,
+            "sortino_ratio_pnl_w": sortino,
+        }
+        for name in requested:
+            totals[name] += torch.where(
+                include, values[name], torch.zeros_like(values[name])
+            )
+    return {name: value / 10.0 for name, value in totals.items()}
+
+
 def _hard_stop_lifecycle_metrics(out: dict, run) -> dict:
     """Reduce directional HSL counters using the authoritative Rust formulas."""
 
@@ -796,29 +882,28 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
 
     zeros = torch.zeros_like(adg)
     adg_pnl = mdg_pnl = sharpe_pnl = sortino_pnl = zeros
-    if requested & _PNL_METRICS:
+    weighted_pnl_metrics = {}
+    if requested & (_PNL_METRICS | _WEIGHTED_PNL_METRICS):
         day_net_pnl = out["day_net_pnl"].to(torch.float64)
         day_last_fill_balance = out["day_last_fill_balance"].to(torch.float64)
-        pnl_mask = (
-            day_has_fill
-            & active
-            & torch.isfinite(day_net_pnl)
-            & torch.isfinite(day_last_fill_balance)
-        )
-        daily_pnl_ratios = torch.where(
-            pnl_mask,
-            day_net_pnl / day_last_fill_balance.abs().clamp(min=1e-12),
-            torch.zeros_like(day_net_pnl),
-        )
-        pnl_days = pnl_mask.sum(dim=1)
-        adg_pnl = daily_pnl_ratios.sum(dim=1) / pnl_days.clamp(min=1).to(
-            daily_pnl_ratios.dtype
-        )
-        adg_pnl = torch.where(pnl_days > 0, adg_pnl, torch.zeros_like(adg_pnl))
-        mdg_pnl = _masked_median(daily_pnl_ratios, pnl_mask)
-        sharpe_pnl, sortino_pnl = _sharpe_sortino(
-            daily_pnl_ratios, pnl_mask, adg_pnl
-        )
+        if requested & _PNL_METRICS:
+            adg_pnl, mdg_pnl, sharpe_pnl, sortino_pnl, _ = _daily_pnl_stats(
+                day_net_pnl,
+                day_last_fill_balance,
+                day_has_fill & active,
+            )
+        if requested & _WEIGHTED_PNL_METRICS:
+            weighted_pnl_metrics = _weighted_pnl_metrics(
+                day_net_pnl,
+                day_last_fill_balance,
+                out["day_fill_count"].to(torch.float64),
+                active,
+                out["first_eq_ts"],
+                out["last_eq_ts"],
+                data["ts0"],
+                run.interval_ms,
+                requested,
+            )
 
     last_eq_ts = out["last_eq_ts"]
     first_eq_ts = out["first_eq_ts"]
@@ -941,6 +1026,7 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
     objectives.update(hard_stop_metrics)
     objectives.update(hard_stop_panic_loss_metrics)
     objectives.update(weighted_metrics)
+    objectives.update(weighted_pnl_metrics)
     for name, (source, side) in _USD_PER_EXPOSURE_METRICS.items():
         if name not in requested:
             continue

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -17,8 +17,8 @@ from optimization.gpu.model import (
 )
 
 
-MPS_DAILY_COLS = 7
-MPS_MULTICOIN_DAILY_COLS = 8
+MPS_DAILY_COLS = 8
+MPS_MULTICOIN_DAILY_COLS = 9
 MPS_SCALAR_COLS = 24
 MPS_DIRECTIONAL_SCALAR_COLS = 50
 
@@ -102,6 +102,7 @@ def _decode_outputs(daily, scalars, gaps) -> dict:
         ),
         "day_net_pnl": daily[:, :, 6],
         "day_last_fill_balance": daily[:, :, 7],
+        "day_fill_count": daily[:, :, 8],
         "max_dd": scalars[:, 0],
         "held_max_ms": scalars[:, 1],
         "gap_hist": gaps,
@@ -150,6 +151,7 @@ def _decode_directional_outputs(daily, scalars, gaps) -> dict:
         "day_has_fill": daily[:, :, 4] > 0.0,
         "day_net_pnl": daily[:, :, 5],
         "day_last_fill_balance": daily[:, :, 6],
+        "day_fill_count": daily[:, :, 7],
         "max_dd": scalars[:, 0],
         "held_max_ms": scalars[:, 1],
         "gap_hist": gaps,

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -30,6 +30,7 @@ CORE_OUTPUT_KEYS = {
     "day_has_fill",
     "day_net_pnl",
     "day_last_fill_balance",
+    "day_fill_count",
     "day_min_balance",
     "max_dd",
     "held_max_ms",
@@ -82,9 +83,13 @@ DIRECTIONAL_HSL_OUTPUT_KEYS = {
 
 _DUAL_SIDE_MULTICOIN_UNSUPPORTED_PNL_METRICS = {
     "adg_pnl",
+    "adg_pnl_w",
     "mdg_pnl",
+    "mdg_pnl_w",
     "sharpe_ratio_pnl",
+    "sharpe_ratio_pnl_w",
     "sortino_ratio_pnl",
+    "sortino_ratio_pnl_w",
 }
 
 
@@ -430,6 +435,9 @@ def _combine_hedged_multicoin_outputs(
         + short["day_last_fill_balance"]
         - float(starting_balance)
     ).where(active, long["day_last_fill_balance"].new_zeros(()))
+    combined["day_fill_count"] = (
+        long["day_fill_count"] + short["day_fill_count"]
+    ).where(active, long["day_fill_count"].new_zeros(()))
     combined["max_dd"] = (long["max_dd"] + short["max_dd"]).clamp(max=1.0)
     combined["held_max_ms"] = long["held_max_ms"].maximum(short["held_max_ms"])
     combined["position_unchanged_max_ms"] = long[

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -174,6 +174,125 @@ def test_daily_pnl_metrics_match_rust_fill_day_contract():
     )
 
 
+def test_weighted_daily_pnl_metrics_match_rust_suffix_contract():
+    day_ms = 86_400_000
+    ratios = torch.tensor(
+        [0.10, -0.05, 0.02, -0.01, 0.03, 0.04, -0.02, 0.01, 0.05, -0.03],
+        dtype=torch.float64,
+    )
+    balances = torch.full((1, 10), 100.0, dtype=torch.float64)
+    day_end = torch.full((1, 10), 100.0, dtype=torch.float64)
+    out = {
+        "day_end_eq": day_end,
+        "day_min_eq": day_end.clone(),
+        "day_max_dd": torch.zeros_like(day_end),
+        "day_volume": torch.zeros_like(day_end),
+        "day_has_fill": torch.ones((1, 10), dtype=torch.bool),
+        "day_net_pnl": ratios.unsqueeze(0) * balances,
+        "day_last_fill_balance": balances,
+        "day_fill_count": torch.ones((1, 10), dtype=torch.float64),
+        "max_dd": torch.zeros(1),
+        "held_max_ms": torch.zeros(1),
+        "position_unchanged_max_ms": torch.zeros(1),
+        "gap_hist": torch.zeros((1, 128), dtype=torch.int32),
+        "gap_max_ms": torch.zeros(1),
+        "first_fill_ts": torch.tensor([0.0]),
+        "last_fill_ts": torch.tensor([9.0 * day_ms]),
+        "recovery_max_ms": torch.zeros(1),
+        "last_high_ts": torch.tensor([9.0 * day_ms]),
+        "first_eq_ts": torch.tensor([0.0]),
+        "last_eq_ts": torch.tensor([9.0 * day_ms]),
+        "liq_step": torch.tensor([-1]),
+    }
+    requested = {
+        "adg_pnl_w",
+        "mdg_pnl_w",
+        "sharpe_ratio_pnl_w",
+        "sortino_ratio_pnl_w",
+    }
+
+    metrics = compute_objectives(
+        out,
+        SimpleNamespace(requested_start_ts_ms=0, guard_ts_ms=0, interval_ms=day_ms),
+        {"ts0": 0.0, "n": 10},
+        needed=requested,
+    )
+
+    suffixes = [
+        ratios,
+        ratios[5:],
+        ratios[7:],
+        ratios[8:],
+        ratios[8:],
+        ratios[8:],
+        ratios[9:],
+        ratios[9:],
+        ratios[9:],
+        ratios[9:],
+    ]
+    expected = {name: 0.0 for name in requested}
+    for suffix in suffixes:
+        mean = suffix.mean()
+        median = suffix.median() if len(suffix) % 2 else suffix.sort().values[
+            len(suffix) // 2 - 1 : len(suffix) // 2 + 1
+        ].mean()
+        std = torch.sqrt(((suffix - mean) ** 2).mean())
+        downside_values = suffix[suffix < 0.0]
+        downside = (
+            torch.sqrt((downside_values**2).mean())
+            if len(downside_values)
+            else torch.tensor(0.0)
+        )
+        expected["adg_pnl_w"] += mean.item() / 10.0
+        expected["mdg_pnl_w"] += median.item() / 10.0
+        expected["sharpe_ratio_pnl_w"] += (
+            0.0 if std.item() == 0.0 else (mean / std).item() / 10.0
+        )
+        expected["sortino_ratio_pnl_w"] += (
+            0.0 if downside.item() == 0.0 else (mean / downside).item() / 10.0
+        )
+    assert set(metrics) == requested
+    assert requested <= set(SUPPORTED_METRICS)
+    for name, value in expected.items():
+        assert metrics[name].item() == pytest.approx(value)
+
+
+def test_weighted_pnl_uses_fill_count_not_fill_day_count_for_eligibility():
+    day_ms = 86_400_000
+    day_end = torch.full((1, 10), 100.0, dtype=torch.float64)
+    out = {
+        "day_end_eq": day_end,
+        "day_min_eq": day_end.clone(),
+        "day_max_dd": torch.zeros_like(day_end),
+        "day_volume": torch.zeros_like(day_end),
+        "day_has_fill": torch.tensor([[True] + [False] * 9]),
+        "day_net_pnl": torch.tensor([[10.0] + [0.0] * 9]),
+        "day_last_fill_balance": torch.tensor([[110.0] + [100.0] * 9]),
+        "day_fill_count": torch.tensor([[2.0] + [0.0] * 9]),
+        "max_dd": torch.zeros(1),
+        "held_max_ms": torch.zeros(1),
+        "position_unchanged_max_ms": torch.zeros(1),
+        "gap_hist": torch.zeros((1, 128), dtype=torch.int32),
+        "gap_max_ms": torch.zeros(1),
+        "first_fill_ts": torch.tensor([0.0]),
+        "last_fill_ts": torch.tensor([0.0]),
+        "recovery_max_ms": torch.zeros(1),
+        "last_high_ts": torch.tensor([9.0 * day_ms]),
+        "first_eq_ts": torch.tensor([0.0]),
+        "last_eq_ts": torch.tensor([9.0 * day_ms]),
+        "liq_step": torch.tensor([-1]),
+    }
+
+    metrics = compute_objectives(
+        out,
+        SimpleNamespace(requested_start_ts_ms=0, guard_ts_ms=0, interval_ms=day_ms),
+        {"ts0": 0.0, "n": 10},
+        needed={"adg_pnl_w"},
+    )
+
+    assert metrics["adg_pnl_w"].item() == pytest.approx((10.0 / 110.0) / 10.0)
+
+
 def test_empty_median_return_series_matches_rust_zero_contract():
     values = torch.empty((1, 0), dtype=torch.float64)
     mask = torch.empty((1, 0), dtype=torch.bool)

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -22,6 +22,7 @@ from optimization.gpu.metrics import (
     _smoothed_adg,
     _smoothed_gain_adg,
     _weighted_adg,
+    _weighted_subsets,
     _weighted_strategy_eq_metrics,
     compute_objectives,
 )
@@ -255,6 +256,33 @@ def test_weighted_daily_pnl_metrics_match_rust_suffix_contract():
     assert requested <= set(SUPPORTED_METRICS)
     for name, value in expected.items():
         assert metrics[name].item() == pytest.approx(value)
+
+
+def test_weighted_subsets_normalize_relative_timestamps_to_unix_origin():
+    day_ms = 86_400_000
+    origin = 1_704_067_200_000.0
+    active = torch.ones((1, 10), dtype=torch.bool)
+
+    relative_eligible, relative_subsets = _weighted_subsets(
+        active,
+        torch.tensor([0.0]),
+        torch.tensor([9.0 * day_ms]),
+        origin,
+        day_ms,
+    )
+    absolute_eligible, absolute_subsets = _weighted_subsets(
+        active,
+        torch.tensor([origin]),
+        torch.tensor([origin + 9.0 * day_ms]),
+        origin,
+        day_ms,
+    )
+
+    assert relative_eligible.item()
+    assert torch.equal(relative_eligible, absolute_eligible)
+    for relative, absolute in zip(relative_subsets, absolute_subsets):
+        assert torch.equal(relative, absolute)
+    assert relative_subsets[1].tolist() == [[False] * 5 + [True] * 5]
 
 
 def test_weighted_pnl_uses_fill_count_not_fill_day_count_for_eligibility():

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -273,6 +273,10 @@ def test_mps_multicoin_tracks_position_unchanged_max(strategy_kind, side):
     fill_days = output["day_has_fill"].bool()
     assert torch.isfinite(output["day_net_pnl"][fill_days]).all()
     assert (output["day_last_fill_balance"][fill_days] > 0.0).all()
+    assert (output["day_fill_count"][fill_days] >= 1.0).all()
+    assert torch.equal(
+        output["day_fill_count"], output["day_fill_count"].round()
+    )
 
 
 @pytest.mark.skipif(
@@ -572,6 +576,10 @@ def test_mps_ema_anchor_shader_smoke():
     fill_days = output["day_has_fill"]
     assert torch.isfinite(output["day_net_pnl"][fill_days]).all()
     assert (output["day_last_fill_balance"][fill_days] > 0.0).all()
+    assert (output["day_fill_count"][fill_days] >= 1.0).all()
+    assert torch.equal(
+        output["day_fill_count"], output["day_fill_count"].round()
+    )
     assert (output["total_wallet_exposure_max"] > 0.0).all()
     assert (
         output["total_wallet_exposure_max"]
@@ -599,7 +607,7 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
     assert "secondary_close_qty" in source
     assert "realized_loss_proxy_allows_close" in source
     assert "const bool loss_gate_enabled = run_settings[5] < 1.0f" in source
-    assert "constant int DAILY_COLS = 8" in source
+    assert "constant int DAILY_COLS = 9" in source
     assert "day_min_balance" in source
     assert "coin_override_or" in source
     assert "const float score_hysteresis = fmax(run_settings[4], 0.0f)" in source
@@ -2117,6 +2125,10 @@ def test_mps_tm_equal_unstuck_twel_reducers_keep_nearer_twel(side):
     fill_days = output["day_has_fill"]
     assert torch.isfinite(output["day_net_pnl"][fill_days]).all()
     assert (output["day_last_fill_balance"][fill_days] > 0.0).all()
+    assert (output["day_fill_count"][fill_days] >= 1.0).all()
+    assert torch.equal(
+        output["day_fill_count"], output["day_fill_count"].round()
+    )
     assert (
         output["total_wallet_exposure_max"].item()
         >= output["total_wallet_exposure_mean"].item()

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -45,12 +45,22 @@ def test_core_output_contract_retains_gross_pnl_aggregates():
         "entry_initial_balance_pct_short",
         "total_wallet_exposure_max",
         "total_wallet_exposure_mean",
+        "day_fill_count",
     } <= CORE_OUTPUT_KEYS
 
 
 @pytest.mark.parametrize(
     "metric",
-    ["adg_pnl", "mdg_pnl", "sharpe_ratio_pnl", "sortino_ratio_pnl"],
+    [
+        "adg_pnl",
+        "adg_pnl_w",
+        "mdg_pnl",
+        "mdg_pnl_w",
+        "sharpe_ratio_pnl",
+        "sharpe_ratio_pnl_w",
+        "sortino_ratio_pnl",
+        "sortino_ratio_pnl_w",
+    ],
 )
 def test_dual_side_multicoin_realized_pnl_metrics_fail_closed(metric):
     with pytest.raises(ValueError, match="shared-liquidation cutoff"):
@@ -483,6 +493,9 @@ def test_combine_hedged_multicoin_outputs_uses_conservative_surface():
                 [[end[0] - 1_000.0, end[1] - end[0]]]
             ),
             "day_last_fill_balance": torch.tensor([end]),
+            "day_fill_count": torch.tensor(
+                [[float(fill[0]), float(fill[1])]]
+            ),
             "max_dd": torch.tensor([0.20]),
             "held_max_ms": torch.tensor([100.0]),
             "position_unchanged_max_ms": torch.tensor([150.0]),
@@ -536,6 +549,7 @@ def test_combine_hedged_multicoin_outputs_uses_conservative_surface():
     assert combined["day_has_fill"].tolist() == [[True, True]]
     assert combined["day_net_pnl"].tolist() == [[50.0, 50.0]]
     assert combined["day_last_fill_balance"].tolist() == [[1_050.0, 1_100.0]]
+    assert combined["day_fill_count"].tolist() == [[1.0, 1.0]]
     assert combined["first_fill_ts"].item() == 300.0
     assert combined["last_fill_ts"].item() == 700.0
     assert combined["last_high_ts"].item() == 800.0
@@ -579,6 +593,7 @@ def test_combine_hedged_multicoin_outputs_detects_shared_equity_liquidation():
             "day_min_balance": torch.tensor([[900.0, 900.0, 900.0]]),
             "day_net_pnl": torch.zeros((1, 3)),
             "day_last_fill_balance": torch.full((1, 3), 1_000.0),
+            "day_fill_count": torch.ones((1, 3)),
             "max_dd": torch.tensor([0.48]),
             "held_max_ms": torch.tensor([100.0]),
             "position_unchanged_max_ms": torch.tensor([150.0]),
@@ -620,6 +635,7 @@ def test_combine_hedged_multicoin_outputs_detects_shared_balance_depletion():
             "day_min_balance": torch.tensor([[900.0, 450.0, 700.0]]),
             "day_net_pnl": torch.zeros((1, 3)),
             "day_last_fill_balance": torch.full((1, 3), 1_000.0),
+            "day_fill_count": torch.ones((1, 3)),
             "max_dd": torch.tensor([0.40]),
             "held_max_ms": torch.tensor([100.0]),
             "position_unchanged_max_ms": torch.tensor([150.0]),


### PR DESCRIPTION
## Summary
- add Apple MPS scoring and limits for `adg_pnl_w`, `mdg_pnl_w`, `sharpe_ratio_pnl_w`, and `sortino_ratio_pnl_w`
- count every proxy fill in Metal, including multiple same-candle ladder fills, and preserve per-UTC-day counts in the compact output surface
- reproduce Rust full-run `fills.len() > 1`, empty-suffix, ten-window, and divide-by-ten behavior on the daily proxy surface
- support all single-coin topologies and one-sided multi-coin; keep dual-side multi-coin fail closed at the existing intraday shared-liquidation boundary

## Validation
- full `tests/optimization` Python suite
- full physical Apple M3/MPS `tests/optimization/test_gpu_mps.py`
- `cargo fmt --all -- --check`
- `cargo check --tests`
- `cargo test --no-default-features` (262 passed)
- end-to-end ETH EMA Anchor MPS optimization: 512 proxy evaluations, 64 exact validations, all four weighted PnL objectives, `drift_halt=0.9`, no parity or constraint halt, 11.2s optimizer wall time
- `git diff --check`

## Scope
GPU support remains purely additive. CPU optimization, exact Rust backtesting, bot execution, and dual-side multicoin behavior are unchanged. Exact Rust results remain authoritative.