### PR TITLE
feat(optimize): add MPS fill activity metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `fills_count`, `fills_analysis_duration_days`, and `fills_per_day` scoring and limits to
+  Apple MPS optimization for single- and multi-coin EMA Anchor and Trailing Martingale runs. The
+  proxy reuses Metal's authoritative per-fill daily counts and the analyzed equity timestamp span;
+  exact Rust validation and drift gates remain authoritative.
+
 - Added weighted `adg_pnl_w`, `mdg_pnl_w`, `sharpe_ratio_pnl_w`, and
   `sortino_ratio_pnl_w` scoring and limits to Apple MPS optimization for single-coin and one-sided
   multi-coin runs. Metal counts every proxy fill, including multiple same-candle ladder fills, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable user-facing changes will be documented in this file.
 ## Unreleased
 
 - Added `fills_count`, `fills_analysis_duration_days`, and `fills_per_day` scoring and limits to
-  Apple MPS optimization for single- and multi-coin EMA Anchor and Trailing Martingale runs. The
-  proxy reuses Metal's authoritative per-fill daily counts and the analyzed equity timestamp span;
-  exact Rust validation and drift gates remain authoritative.
+  Apple MPS optimization for single-coin and one-sided multi-coin EMA Anchor and Trailing
+  Martingale runs. The proxy reuses Metal's authoritative per-fill daily counts and the analyzed
+  equity timestamp span; exact Rust validation and drift gates remain authoritative. Dual-side
+  multi-coin runs fail closed because independent directional summaries cannot reconstruct the
+  intraday shared-liquidation cutoff.
 
 - Added weighted `adg_pnl_w`, `mdg_pnl_w`, `sharpe_ratio_pnl_w`, and
   `sortino_ratio_pnl_w` scoring and limits to Apple MPS optimization for single-coin and one-sided

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -333,9 +333,11 @@ multiple same-candle ladder fills, and applies Rust's full-run minimum fill coun
 rules across the same ten minute-position suffix boundaries. The compact daily surface includes
 the complete UTC day containing each suffix boundary, so exact Rust validation and drift gates
 remain authoritative for that screening approximation.
-Full-run `fills_count`, `fills_analysis_duration_days`, and `fills_per_day` are supported across
-single- and multi-coin topologies. The proxy sums every actual Metal fill and divides by the same
-first-to-last analyzed-equity timestamp span used by Rust.
+Full-run `fills_count`, `fills_analysis_duration_days`, and `fills_per_day` are supported for
+single-coin and one-sided multi-coin topologies. The proxy sums every actual Metal fill and divides
+by the same first-to-last analyzed-equity timestamp span used by Rust. Dual-side multi-coin runs
+fail closed because independent directional summaries cannot reconstruct the intraday
+shared-liquidation cutoff.
 Initial-entry allocation uses the candidate's effective position count and the same
 first-coin strategy/allowance override precedence as exact Rust. Fill-gap longest, mean, median,
 p95, and p99 metrics are also supported. Metal coalesces multiple fills in the same candle and

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -333,6 +333,9 @@ multiple same-candle ladder fills, and applies Rust's full-run minimum fill coun
 rules across the same ten minute-position suffix boundaries. The compact daily surface includes
 the complete UTC day containing each suffix boundary, so exact Rust validation and drift gates
 remain authoritative for that screening approximation.
+Full-run `fills_count`, `fills_analysis_duration_days`, and `fills_per_day` are supported across
+single- and multi-coin topologies. The proxy sums every actual Metal fill and divides by the same
+first-to-last analyzed-equity timestamp span used by Rust.
 Initial-entry allocation uses the candidate's effective position count and the same
 first-coin strategy/allowance override precedence as exact Rust. Fill-gap longest, mean, median,
 p95, and p99 metrics are also supported. Metal coalesces multiple fills in the same candle and

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -63,11 +63,14 @@ SUPPORTED_METRICS = (
     "entry_initial_balance_pct_short",
     "exposure_mean_ratio_usd",
     "exposure_ratio_usd",
+    "fills_analysis_duration_days",
+    "fills_count",
     "fills_gap_longest_days",
     "fills_gap_mean_hours",
     "fills_gap_median_hours",
     "fills_gap_p95_hours",
     "fills_gap_p99_hours",
+    "fills_per_day",
     "gain_strategy_eq",
     "hard_stop_duration_minutes_max",
     "hard_stop_duration_minutes_mean",
@@ -140,6 +143,12 @@ _WEIGHTED_PNL_METRICS = {
     "mdg_pnl_w",
     "sharpe_ratio_pnl_w",
     "sortino_ratio_pnl_w",
+}
+
+_FILL_ACTIVITY_METRICS = {
+    "fills_analysis_duration_days",
+    "fills_count",
+    "fills_per_day",
 }
 
 
@@ -665,6 +674,38 @@ def _daily_pnl_stats(day_net_pnl, day_last_fill_balance, mask):
     return adg, mdg, sharpe, sortino, count
 
 
+def _fill_activity_metrics(out: dict, active: torch.Tensor) -> dict:
+    """Match Rust's full-run fill count and timestamp-span rate contract."""
+
+    fill_count = torch.where(
+        active,
+        out["day_fill_count"].to(torch.float64),
+        torch.zeros_like(out["day_fill_count"], dtype=torch.float64),
+    ).sum(dim=1)
+    first_eq_ts = out["first_eq_ts"].to(torch.float64)
+    last_eq_ts = out["last_eq_ts"].to(torch.float64)
+    has_span = (
+        torch.isfinite(first_eq_ts)
+        & torch.isfinite(last_eq_ts)
+        & (last_eq_ts > first_eq_ts)
+    )
+    duration_days = torch.where(
+        has_span,
+        (last_eq_ts - first_eq_ts) / 86_400_000.0,
+        torch.zeros_like(first_eq_ts),
+    )
+    fills_per_day = torch.where(
+        duration_days > 0.0,
+        fill_count / duration_days.clamp(min=1.0e-9),
+        torch.zeros_like(fill_count),
+    )
+    return {
+        "fills_analysis_duration_days": duration_days,
+        "fills_count": fill_count,
+        "fills_per_day": fills_per_day,
+    }
+
+
 def _weighted_pnl_metrics(
     day_net_pnl,
     day_last_fill_balance,
@@ -952,6 +993,11 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
         if requested & _FILL_GAP_HISTOGRAM_METRICS
         else {}
     )
+    fill_activity_metrics = (
+        _fill_activity_metrics(out, active)
+        if requested & _FILL_ACTIVITY_METRICS
+        else {}
+    )
     hard_stop_metrics = (
         _hard_stop_lifecycle_metrics(out, run)
         if requested & _HARD_STOP_LIFECYCLE_METRICS
@@ -1031,6 +1077,7 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
         if name in requested:
             objectives[name] = out[name].to(torch.float64)
     objectives.update(fill_gap_metrics)
+    objectives.update(fill_activity_metrics)
     objectives.update(hard_stop_metrics)
     objectives.update(hard_stop_panic_loss_metrics)
     objectives.update(weighted_metrics)

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -81,9 +81,12 @@ DIRECTIONAL_HSL_OUTPUT_KEYS = {
     "hsl_panic_loss_drawdown_count",
 }
 
-_DUAL_SIDE_MULTICOIN_UNSUPPORTED_PNL_METRICS = {
+_DUAL_SIDE_MULTICOIN_INTRADAY_CUTOFF_METRICS = {
     "adg_pnl",
     "adg_pnl_w",
+    "fills_analysis_duration_days",
+    "fills_count",
+    "fills_per_day",
     "mdg_pnl",
     "mdg_pnl_w",
     "sharpe_ratio_pnl",
@@ -95,14 +98,14 @@ _DUAL_SIDE_MULTICOIN_UNSUPPORTED_PNL_METRICS = {
 
 def _require_multicoin_metric_topology(sides, needed_metrics) -> None:
     unsupported = (
-        set(needed_metrics) & _DUAL_SIDE_MULTICOIN_UNSUPPORTED_PNL_METRICS
+        set(needed_metrics) & _DUAL_SIDE_MULTICOIN_INTRADAY_CUTOFF_METRICS
         if len(sides) == 2
         else set()
     )
     if unsupported:
         raise ValueError(
             "MPS dual-side multicoin proxy cannot reconstruct the intraday "
-            "shared-liquidation cutoff required by realized PnL metrics: "
+            "shared-liquidation cutoff required by these metrics: "
             + ", ".join(sorted(unsupported))
         )
 

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -38,6 +38,97 @@ def test_loss_profit_ratio_matches_rust_cap_and_neutral_contract():
     assert "loss_profit_ratio" in SUPPORTED_METRICS
 
 
+def test_fill_activity_metrics_match_rust_full_timestamp_span_contract():
+    day_end = torch.full((2, 3), 100.0, dtype=torch.float64)
+    out = {
+        "day_end_eq": day_end,
+        "day_min_eq": day_end.clone(),
+        "day_max_dd": torch.zeros_like(day_end),
+        "day_volume": torch.zeros_like(day_end),
+        "day_has_fill": torch.tensor(
+            [[True, True, False], [False, False, False]]
+        ),
+        "day_fill_count": torch.tensor(
+            [[1.0, 1.0, 0.0], [0.0, 0.0, 0.0]], dtype=torch.float64
+        ),
+        "max_dd": torch.zeros(2),
+        "held_max_ms": torch.zeros(2),
+        "position_unchanged_max_ms": torch.zeros(2),
+        "gap_hist": torch.zeros((2, 128), dtype=torch.int32),
+        "gap_max_ms": torch.zeros(2),
+        "first_fill_ts": torch.tensor([0.0, float("nan")]),
+        "last_fill_ts": torch.tensor([3_600_000.0, float("nan")]),
+        "recovery_max_ms": torch.zeros(2),
+        "last_high_ts": torch.tensor([14_400_000.0, 14_400_000.0]),
+        "first_eq_ts": torch.tensor([0.0, 0.0]),
+        "last_eq_ts": torch.tensor([14_400_000.0, 14_400_000.0]),
+        "liq_step": torch.tensor([-1.0, -1.0]),
+    }
+    requested = {
+        "fills_analysis_duration_days",
+        "fills_count",
+        "fills_per_day",
+    }
+
+    metrics = compute_objectives(
+        out,
+        SimpleNamespace(
+            requested_start_ts_ms=0, guard_ts_ms=0, interval_ms=60_000
+        ),
+        {"ts0": 0.0, "n": 241},
+        needed=requested,
+    )
+
+    assert set(metrics) == requested
+    assert requested <= set(SUPPORTED_METRICS)
+    assert metrics["fills_analysis_duration_days"].tolist() == pytest.approx(
+        [4.0 / 24.0, 4.0 / 24.0]
+    )
+    assert metrics["fills_count"].tolist() == [2.0, 0.0]
+    assert metrics["fills_per_day"].tolist() == pytest.approx([12.0, 0.0])
+
+
+def test_fill_activity_metrics_ignore_inactive_daily_slots_and_zero_single_sample_span():
+    day_min = torch.tensor([[100.0, float("inf")]], dtype=torch.float64)
+    out = {
+        "day_end_eq": torch.tensor([[100.0, 0.0]], dtype=torch.float64),
+        "day_min_eq": day_min,
+        "day_max_dd": torch.zeros_like(day_min),
+        "day_volume": torch.zeros_like(day_min),
+        "day_has_fill": torch.tensor([[True, False]]),
+        "day_fill_count": torch.tensor([[2.0, 99.0]], dtype=torch.float64),
+        "max_dd": torch.zeros(1),
+        "held_max_ms": torch.zeros(1),
+        "position_unchanged_max_ms": torch.zeros(1),
+        "gap_hist": torch.zeros((1, 128), dtype=torch.int32),
+        "gap_max_ms": torch.zeros(1),
+        "first_fill_ts": torch.tensor([0.0]),
+        "last_fill_ts": torch.tensor([0.0]),
+        "recovery_max_ms": torch.zeros(1),
+        "last_high_ts": torch.tensor([0.0]),
+        "first_eq_ts": torch.tensor([0.0]),
+        "last_eq_ts": torch.tensor([0.0]),
+        "liq_step": torch.tensor([-1.0]),
+    }
+
+    metrics = compute_objectives(
+        out,
+        SimpleNamespace(
+            requested_start_ts_ms=0, guard_ts_ms=0, interval_ms=60_000
+        ),
+        {"ts0": 0.0, "n": 1},
+        needed={
+            "fills_analysis_duration_days",
+            "fills_count",
+            "fills_per_day",
+        },
+    )
+
+    assert metrics["fills_count"].item() == 2.0
+    assert metrics["fills_analysis_duration_days"].item() == 0.0
+    assert metrics["fills_per_day"].item() == 0.0
+
+
 def test_duration_alias_metrics_match_rust_unit_contracts():
     day_end = torch.tensor([[100.0]], dtype=torch.float64)
     out = {

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -54,6 +54,9 @@ def test_core_output_contract_retains_gross_pnl_aggregates():
     [
         "adg_pnl",
         "adg_pnl_w",
+        "fills_analysis_duration_days",
+        "fills_count",
+        "fills_per_day",
         "mdg_pnl",
         "mdg_pnl_w",
         "sharpe_ratio_pnl",
@@ -62,7 +65,7 @@ def test_core_output_contract_retains_gross_pnl_aggregates():
         "sortino_ratio_pnl_w",
     ],
 )
-def test_dual_side_multicoin_realized_pnl_metrics_fail_closed(metric):
+def test_dual_side_multicoin_intraday_cutoff_metrics_fail_closed(metric):
     with pytest.raises(ValueError, match="shared-liquidation cutoff"):
         _require_multicoin_metric_topology(["long", "short"], {metric})
 


### PR DESCRIPTION
## Summary

- add Apple MPS proxy support for `fills_count`, `fills_analysis_duration_days`, and `fills_per_day`
- reuse the per-fill daily count surface merged in #1556, with no Metal ABI or hot-kernel expansion
- match Rust's full analyzed-equity timestamp span and keep exact Rust validation plus drift gates authoritative

## Scope

- supports EMA Anchor and Trailing Martingale across single-coin and one-sided multi-coin long or short topologies
- dual-side multi-coin runs fail closed because independent directional summaries cannot reconstruct the intraday shared-liquidation cutoff
- purely additive to the experimental GPU optimizer; CPU optimization, backtesting, and live operation are unchanged

## Validation

- `python -m pytest -q tests/optimization`
- physical Apple M3/MPS: `python -m pytest -q tests/optimization/test_gpu_mps.py` (204 passed)
- `cargo fmt --check`
- `cargo check`
- `cargo test --no-default-features` (262 passed)
- real ETH/Bybit EMA Anchor long-only MPS optimization, 2024-01-01 through 2024-02-28: 512 proxy evaluations, 64 exact validations, `drift_halt=0.9`, no drift or constraint-classification halt, 11.5 seconds
- duration evidence: proxy `57.998611851851855` days versus exact Rust `57.99861111111111`

## Runtime provenance note

The first physical smoke exposed an older installed Metal extension whose daily-column ABI did not match the branch. Rebuilding and source-fingerprint-stamping the extension from this exact branch eliminated the invalid output; the complete physical suite and strict smoke above were rerun against the verified exact-branch artifact.