### PR TITLE
feat(optimize): add MPS fill breakdown metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added entry/close and long/short fill counts and daily rates, entry-to-close ratio, and
+  per-configured-position-slot fill rates to Apple MPS optimization for single-coin and one-sided
+  multi-coin EMA Anchor and Trailing Martingale runs. Metal records every proxy fill by role and
+  side, while Python applies each candidate's configured active position-slot denominators using
+  the exact Rust averaging contract. Exact Rust validation remains authoritative, and dual-side
+  multi-coin runs fail closed at the existing intraday shared-liquidation boundary.
+
 - Added `fills_count`, `fills_analysis_duration_days`, and `fills_per_day` scoring and limits to
   Apple MPS optimization for single-coin and one-sided multi-coin EMA Anchor and Trailing
   Martingale runs. The proxy reuses Metal's authoritative per-fill daily counts and the analyzed

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -333,11 +333,13 @@ multiple same-candle ladder fills, and applies Rust's full-run minimum fill coun
 rules across the same ten minute-position suffix boundaries. The compact daily surface includes
 the complete UTC day containing each suffix boundary, so exact Rust validation and drift gates
 remain authoritative for that screening approximation.
-Full-run `fills_count`, `fills_analysis_duration_days`, and `fills_per_day` are supported for
-single-coin and one-sided multi-coin topologies. The proxy sums every actual Metal fill and divides
-by the same first-to-last analyzed-equity timestamp span used by Rust. Dual-side multi-coin runs
-fail closed because independent directional summaries cannot reconstruct the intraday
-shared-liquidation cutoff.
+Full-run fill activity is supported for single-coin and one-sided multi-coin topologies: analysis
+duration; total, entry, close, long, and short counts; their daily rates; entry-to-close ratio; and
+combined or side-specific per-configured-position-slot daily rates. Metal classifies every actual
+proxy fill by role and position side, then Python applies each candidate's configured active slot
+counts and Rust's mean-of-enabled-sides contract. All rates use the same first-to-last
+analyzed-equity timestamp span as Rust. Dual-side multi-coin runs fail closed because independent
+directional summaries cannot reconstruct the intraday shared-liquidation cutoff.
 Initial-entry allocation uses the candidate's effective position count and the same
 first-coin strategy/allowance override precedence as exact Rust. Fill-gap longest, mean, median,
 p95, and p99 metrics are also supported. Metal coalesces multiple fills in the same candle and

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -42,7 +42,7 @@ mod tests {
         let source = mps_ema_anchor_source();
         assert!(source.contains("kernel void passivbot_ema_anchor"));
         assert!(source.contains("constant int DAILY_COLS = 8"));
-        assert!(source.contains("constant int SCALAR_COLS = 50"));
+        assert!(source.contains("constant int SCALAR_COLS = 53"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[so + 44] = loss_sum"));
         assert!(source.contains("scalars[so + 45] = position_unchanged_max_min * interval_ms"));
@@ -50,6 +50,9 @@ mod tests {
         assert!(source.contains("scalars[so + 47] = short_enabled"));
         assert!(source.contains("scalars[so + 48] = total_wallet_exposure_max"));
         assert!(source.contains("scalars[so + 49] = total_wallet_exposure_mean"));
+        assert!(source.contains("scalars[so + 50] = fill_count"));
+        assert!(source.contains("scalars[so + 51] = fill_count_entry"));
+        assert!(source.contains("scalars[so + 52] = fill_count_long"));
         assert!(source.contains("constant int SIDE_PARAMS = 34"));
         assert!(source.contains("struct HslState"));
         assert!(source.contains("update_hsl("));
@@ -113,7 +116,7 @@ mod tests {
         assert!(source.contains("constant int COIN_COLS = 11"));
         assert!(source.contains("constant int DAILY_COLS = 9"));
         assert!(source.contains("day_min_balance"));
-        assert!(source.contains("constant int SCALAR_COLS = 24"));
+        assert!(source.contains("constant int SCALAR_COLS = 27"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[scalar_offset + 19] = loss_sum"));
         assert!(source
@@ -121,6 +124,9 @@ mod tests {
         assert!(source.contains("scalars[scalar_offset + 21] = allowed_wallet_exposure_limit"));
         assert!(source.contains("scalars[scalar_offset + 22] = total_wallet_exposure_max"));
         assert!(source.contains("scalars[scalar_offset + 23] = total_wallet_exposure_mean"));
+        assert!(source.contains("scalars[scalar_offset + 24] = fill_count"));
+        assert!(source.contains("scalars[scalar_offset + 25] = fill_count_entry"));
+        assert!(source.contains("scalars[scalar_offset + 26] = fill_count_long"));
         assert!(source.contains("close_tick[c] <= fill_ticks[tick_offset + 0]"));
         assert!(source.contains("entry_tick[c] > fill_ticks[tick_offset + 1]"));
         assert!(source.contains("const float volume_drop = clamp(params[po + 14]"));
@@ -158,7 +164,7 @@ mod tests {
         assert!(source.contains("struct HslState"));
         assert!(source.contains("update_hsl("));
         assert!(source.contains("try_restart_hsl("));
-        assert!(source.contains("constant int SCALAR_COLS = 50"));
+        assert!(source.contains("constant int SCALAR_COLS = 53"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[so + 44] = loss_sum"));
         assert!(source.contains("scalars[so + 45] = position_unchanged_max_min * interval_ms"));
@@ -166,6 +172,9 @@ mod tests {
         assert!(source.contains("scalars[so + 47] = short_enabled"));
         assert!(source.contains("scalars[so + 48] = total_wallet_exposure_max"));
         assert!(source.contains("scalars[so + 49] = total_wallet_exposure_mean"));
+        assert!(source.contains("scalars[so + 50] = fill_count"));
+        assert!(source.contains("scalars[so + 51] = fill_count_entry"));
+        assert!(source.contains("scalars[so + 52] = fill_count_long"));
         assert!(source.contains("hsl_tier_samples_total"));
         assert!(source.contains("h.restart_retrigger_count"));
         assert!(source.contains("h.halt_duration_sum_steps"));
@@ -268,7 +277,7 @@ mod tests {
         assert!(source.contains("constant int MAX_COINS = 64"));
         assert!(source.contains("constant int PARAM_COLS = 48"));
         assert!(source.contains("constant int OVERRIDE_COLS = 34"));
-        assert!(source.contains("constant int SCALAR_COLS = 24"));
+        assert!(source.contains("constant int SCALAR_COLS = 27"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[scalar_offset + 19] = loss_sum"));
         assert!(source
@@ -276,6 +285,9 @@ mod tests {
         assert!(source.contains("scalars[scalar_offset + 21] = allowed_wallet_exposure_limit"));
         assert!(source.contains("scalars[scalar_offset + 22] = total_wallet_exposure_max"));
         assert!(source.contains("scalars[scalar_offset + 23] = total_wallet_exposure_mean"));
+        assert!(source.contains("scalars[scalar_offset + 24] = fill_count"));
+        assert!(source.contains("scalars[scalar_offset + 25] = fill_count_entry"));
+        assert!(source.contains("scalars[scalar_offset + 26] = fill_count_long"));
         assert!(source.contains("coin_wel_enforcer_enabled"));
         assert!(source.contains("coin_wel_enforcer_threshold"));
         assert!(source.contains("twel_enforcer_enabled"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -2,7 +2,7 @@
 using namespace metal;
 
 constant int DAILY_COLS = 8;
-constant int SCALAR_COLS = 50;
+constant int SCALAR_COLS = 53;
 constant int GAP_BINS = 128;
 constant int SIDE_PARAMS = 34;
 
@@ -63,9 +63,17 @@ inline void record_realized_net(
     float net_pnl,
     thread float& realized_pnl_cumsum_last,
     thread float& realized_pnl_cumsum_max,
-    thread float& day_fill_count
+    thread float& day_fill_count,
+    thread float& fill_count,
+    thread float& fill_count_entry,
+    thread float& fill_count_long,
+    bool is_entry,
+    bool is_long
 ) {
     day_fill_count += 1.0f;
+    fill_count += 1.0f;
+    if (is_entry) fill_count_entry += 1.0f;
+    if (is_long) fill_count_long += 1.0f;
     realized_pnl_cumsum_last += net_pnl;
     realized_pnl_cumsum_max = fmax(
         realized_pnl_cumsum_max, realized_pnl_cumsum_last
@@ -1100,6 +1108,9 @@ inline void passivbot_single_coin_impl(
     float realized_pnl_cumsum_max = 0.0f;
     float profit_sum = 0.0f;
     float loss_sum = 0.0f;
+    float fill_count = 0.0f;
+    float fill_count_entry = 0.0f;
+    float fill_count_long = 0.0f;
     bool alive = true;
     int liq_day = -1;
     float held_max_min = 0.0f;
@@ -1227,7 +1238,8 @@ inline void passivbot_single_coin_impl(
             balance += net_pnl;
             record_realized_net(
                 net_pnl, realized_pnl_cumsum_last, realized_pnl_cumsum_max,
-                day_fill_count
+                day_fill_count, fill_count, fill_count_entry, fill_count_long,
+                false, true
             );
             float new_psize = fmax(round_step(long_side.psize - adj, qty_step), 0.0f);
             bool went_flat = new_psize <= 0.0f;
@@ -1258,7 +1270,8 @@ inline void passivbot_single_coin_impl(
             balance -= fee;
             record_realized_net(
                 -fee, realized_pnl_cumsum_last, realized_pnl_cumsum_max,
-                day_fill_count
+                day_fill_count, fill_count, fill_count_entry, fill_count_long,
+                true, true
             );
             bool was_flat = long_side.psize <= 0.0f;
             float new_psize = round_step(long_side.psize + eq, qty_step);
@@ -1321,7 +1334,8 @@ inline void passivbot_single_coin_impl(
             balance += net_pnl;
             record_realized_net(
                 net_pnl, realized_pnl_cumsum_last, realized_pnl_cumsum_max,
-                day_fill_count
+                day_fill_count, fill_count, fill_count_entry, fill_count_long,
+                false, false
             );
             float new_psize = fmax(round_step(short_side.psize - adj, qty_step), 0.0f);
             bool went_flat = new_psize <= 0.0f;
@@ -1352,7 +1366,8 @@ inline void passivbot_single_coin_impl(
             balance -= fee;
             record_realized_net(
                 -fee, realized_pnl_cumsum_last, realized_pnl_cumsum_max,
-                day_fill_count
+                day_fill_count, fill_count, fill_count_entry, fill_count_long,
+                true, false
             );
             bool was_flat = short_side.psize <= 0.0f;
             float new_psize = round_step(short_side.psize + eq, qty_step);
@@ -1838,6 +1853,9 @@ inline void passivbot_single_coin_impl(
         ? short_side.allowed_wel * short_side.base_qty_pct : 0.0f;
     scalars[so + 48] = total_wallet_exposure_max;
     scalars[so + 49] = total_wallet_exposure_mean;
+    scalars[so + 50] = fill_count;
+    scalars[so + 51] = fill_count_entry;
+    scalars[so + 52] = fill_count_long;
 }
 
 kernel void passivbot_ema_anchor(

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -6,7 +6,7 @@ constant int PARAM_COLS = 31;
 constant int COIN_COLS = 11;
 constant int OVERRIDE_COLS = 19;
 constant int DAILY_COLS = 9;
-constant int SCALAR_COLS = 24;
+constant int SCALAR_COLS = 27;
 constant int GAP_BINS = 128;
 
 inline float round_step(float value, float step) {
@@ -67,9 +67,17 @@ inline void record_realized_net(
     float net_pnl,
     thread float& realized_pnl_cumsum_last,
     thread float& realized_pnl_cumsum_max,
-    thread float& day_fill_count
+    thread float& day_fill_count,
+    thread float& fill_count,
+    thread float& fill_count_entry,
+    thread float& fill_count_long,
+    bool is_entry,
+    bool is_long
 ) {
     day_fill_count += 1.0f;
+    fill_count += 1.0f;
+    if (is_entry) fill_count_entry += 1.0f;
+    if (is_long) fill_count_long += 1.0f;
     realized_pnl_cumsum_last += net_pnl;
     realized_pnl_cumsum_max = fmax(
         realized_pnl_cumsum_max, realized_pnl_cumsum_last
@@ -387,6 +395,9 @@ inline void passivbot_ema_anchor_multicoin_impl(
     float realized_pnl_cumsum_max = 0.0f;
     float profit_sum = 0.0f;
     float loss_sum = 0.0f;
+    float fill_count = 0.0f;
+    float fill_count_entry = 0.0f;
+    float fill_count_long = 0.0f;
     bool alive = true;
     bool equity_started = false;
     bool selection_initialized = false;
@@ -513,7 +524,8 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 record_realized_net(
                     net_pnl, realized_pnl_cumsum_last,
                     realized_pnl_cumsum_max,
-                    day_fill_count
+                    day_fill_count, fill_count, fill_count_entry, fill_count_long,
+                    false, !short_side
                 );
                 float new_size = fmax(round_step(psize[c] - adjusted, qty_step), 0.0f);
                 bool went_flat = new_size <= 0.0f;
@@ -551,7 +563,8 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 record_realized_net(
                     -fee, realized_pnl_cumsum_last,
                     realized_pnl_cumsum_max,
-                    day_fill_count
+                    day_fill_count, fill_count, fill_count_entry, fill_count_long,
+                    true, !short_side
                 );
                 float new_size = round_step(psize[c] + adjusted, qty_step);
                 float new_price = was_flat ? fill_price
@@ -1530,6 +1543,9 @@ inline void passivbot_ema_anchor_multicoin_impl(
     ) * entry_initial_qty_pct;
     scalars[scalar_offset + 22] = total_wallet_exposure_max;
     scalars[scalar_offset + 23] = total_wallet_exposure_mean;
+    scalars[scalar_offset + 24] = fill_count;
+    scalars[scalar_offset + 25] = fill_count_entry;
+    scalars[scalar_offset + 26] = fill_count_long;
 }
 
 kernel void passivbot_ema_anchor_multicoin(

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -2,7 +2,7 @@
 using namespace metal;
 
 constant int DAILY_COLS = 8;
-constant int SCALAR_COLS = 50;
+constant int SCALAR_COLS = 53;
 constant int GAP_BINS = 128;
 constant int SIDE_PARAMS = 51;
 
@@ -123,9 +123,17 @@ inline void record_realized_net(
     float net_pnl,
     thread float& realized_pnl_cumsum_last,
     thread float& realized_pnl_cumsum_max,
-    thread float& day_fill_count
+    thread float& day_fill_count,
+    thread float& fill_count,
+    thread float& fill_count_entry,
+    thread float& fill_count_long,
+    bool is_entry,
+    bool is_long
 ) {
     day_fill_count += 1.0f;
+    fill_count += 1.0f;
+    if (is_entry) fill_count_entry += 1.0f;
+    if (is_long) fill_count_long += 1.0f;
     realized_pnl_cumsum_last += net_pnl;
     realized_pnl_cumsum_max = fmax(
         realized_pnl_cumsum_max, realized_pnl_cumsum_last
@@ -1387,6 +1395,9 @@ inline void passivbot_single_coin_impl(
     float realized_pnl_cumsum_max = 0.0f;
     float profit_sum = 0.0f;
     float loss_sum = 0.0f;
+    float fill_count = 0.0f;
+    float fill_count_entry = 0.0f;
+    float fill_count_long = 0.0f;
     bool alive = true;
     int liq_day = -1;
     float held_max_min = 0.0f;
@@ -1682,7 +1693,12 @@ inline void passivbot_single_coin_impl(
                             pnl - fee,
                             realized_pnl_cumsum_last,
                             realized_pnl_cumsum_max,
-                            day_fill_count
+                            day_fill_count,
+                            fill_count,
+                            fill_count_entry,
+                            fill_count_long,
+                            false,
+                            true
                         );
                         long_side.psize = fmax(
                             round_step(
@@ -1718,7 +1734,12 @@ inline void passivbot_single_coin_impl(
                     pnl - fee,
                     realized_pnl_cumsum_last,
                     realized_pnl_cumsum_max,
-                    day_fill_count
+                    day_fill_count,
+                    fill_count,
+                    fill_count_entry,
+                    fill_count_long,
+                    false,
+                    true
                 );
                 float new_psize = fmax(
                     round_step(long_side.psize - adj, qty_step), 0.0f
@@ -1765,7 +1786,12 @@ inline void passivbot_single_coin_impl(
                         pnl - fee,
                         realized_pnl_cumsum_last,
                         realized_pnl_cumsum_max,
-                        day_fill_count
+                        day_fill_count,
+                        fill_count,
+                        fill_count_entry,
+                        fill_count_long,
+                        false,
+                        true
                     );
                     long_side.psize = fmax(
                         round_step(long_side.psize - adj, qty_step), 0.0f
@@ -1835,7 +1861,12 @@ inline void passivbot_single_coin_impl(
                     pnl - fee,
                     realized_pnl_cumsum_last,
                     realized_pnl_cumsum_max,
-                    day_fill_count
+                    day_fill_count,
+                    fill_count,
+                    fill_count_entry,
+                    fill_count_long,
+                    false,
+                    true
                 );
                 long_side.psize = fmax(
                     round_step(long_side.psize - adj, qty_step), 0.0f
@@ -1884,7 +1915,12 @@ inline void passivbot_single_coin_impl(
                     -fee,
                     realized_pnl_cumsum_last,
                     realized_pnl_cumsum_max,
-                    day_fill_count
+                    day_fill_count,
+                    fill_count,
+                    fill_count_entry,
+                    fill_count_long,
+                    true,
+                    true
                 );
                 bool was_flat = long_side.psize <= 0.0f;
                 float new_psize = round_step(long_side.psize + eq, qty_step);
@@ -2129,7 +2165,12 @@ inline void passivbot_single_coin_impl(
                             pnl - fee,
                             realized_pnl_cumsum_last,
                             realized_pnl_cumsum_max,
-                            day_fill_count
+                            day_fill_count,
+                            fill_count,
+                            fill_count_entry,
+                            fill_count_long,
+                            false,
+                            false
                         );
                         short_side.psize = fmax(
                             round_step(
@@ -2165,7 +2206,12 @@ inline void passivbot_single_coin_impl(
                     pnl - fee,
                     realized_pnl_cumsum_last,
                     realized_pnl_cumsum_max,
-                    day_fill_count
+                    day_fill_count,
+                    fill_count,
+                    fill_count_entry,
+                    fill_count_long,
+                    false,
+                    false
                 );
                 float new_psize = fmax(
                     round_step(short_side.psize - adj, qty_step), 0.0f
@@ -2212,7 +2258,12 @@ inline void passivbot_single_coin_impl(
                         pnl - fee,
                         realized_pnl_cumsum_last,
                         realized_pnl_cumsum_max,
-                        day_fill_count
+                        day_fill_count,
+                        fill_count,
+                        fill_count_entry,
+                        fill_count_long,
+                        false,
+                        false
                     );
                     short_side.psize = fmax(
                         round_step(short_side.psize - adj, qty_step), 0.0f
@@ -2282,7 +2333,12 @@ inline void passivbot_single_coin_impl(
                     pnl - fee,
                     realized_pnl_cumsum_last,
                     realized_pnl_cumsum_max,
-                    day_fill_count
+                    day_fill_count,
+                    fill_count,
+                    fill_count_entry,
+                    fill_count_long,
+                    false,
+                    false
                 );
                 short_side.psize = fmax(
                     round_step(short_side.psize - adj, qty_step), 0.0f
@@ -2331,7 +2387,12 @@ inline void passivbot_single_coin_impl(
                     -fee,
                     realized_pnl_cumsum_last,
                     realized_pnl_cumsum_max,
-                    day_fill_count
+                    day_fill_count,
+                    fill_count,
+                    fill_count_entry,
+                    fill_count_long,
+                    true,
+                    false
                 );
                 bool was_flat = short_side.psize <= 0.0f;
                 float new_psize = round_step(short_side.psize + eq, qty_step);
@@ -2813,6 +2874,9 @@ inline void passivbot_single_coin_impl(
         ? short_side.allowed_wel * short_side.initial_qty_pct : 0.0f;
     scalars[so + 48] = total_wallet_exposure_max;
     scalars[so + 49] = total_wallet_exposure_mean;
+    scalars[so + 50] = fill_count;
+    scalars[so + 51] = fill_count_entry;
+    scalars[so + 52] = fill_count_long;
 }
 
 kernel void passivbot_trailing_martingale(

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -6,7 +6,7 @@ constant int PARAM_COLS = 48;
 constant int OVERRIDE_COLS = 34;
 constant int COIN_COLS = 11;
 constant int DAILY_COLS = 9;
-constant int SCALAR_COLS = 24;
+constant int SCALAR_COLS = 27;
 constant int GAP_BINS = 128;
 
 inline float round_step(float value, float step) {
@@ -68,9 +68,17 @@ inline void record_realized_net(
     float net_pnl,
     thread float& realized_pnl_cumsum_last,
     thread float& realized_pnl_cumsum_max,
-    thread float& day_fill_count
+    thread float& day_fill_count,
+    thread float& fill_count,
+    thread float& fill_count_entry,
+    thread float& fill_count_long,
+    bool is_entry,
+    bool is_long
 ) {
     day_fill_count += 1.0f;
+    fill_count += 1.0f;
+    if (is_entry) fill_count_entry += 1.0f;
+    if (is_long) fill_count_long += 1.0f;
     realized_pnl_cumsum_last += net_pnl;
     realized_pnl_cumsum_max = fmax(
         realized_pnl_cumsum_max, realized_pnl_cumsum_last
@@ -647,6 +655,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     float realized_pnl_cumsum_max = 0.0f;
     float profit_sum = 0.0f;
     float loss_sum = 0.0f;
+    float fill_count = 0.0f;
+    float fill_count_entry = 0.0f;
+    float fill_count_long = 0.0f;
     bool alive = true;
     bool equity_started = false;
     bool selection_initialized = false;
@@ -961,7 +972,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                             record_realized_net(
                                 net_pnl, realized_pnl_cumsum_last,
                                 realized_pnl_cumsum_max,
-                                day_fill_count
+                                day_fill_count, fill_count, fill_count_entry,
+                                fill_count_long, false, !short_side
                             );
                             psize[c] = fmax(
                                 round_step(psize[c] - qty, qty_step), 0.0f
@@ -996,7 +1008,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     record_realized_net(
                         grid_net_pnl, realized_pnl_cumsum_last,
                         realized_pnl_cumsum_max,
-                        day_fill_count
+                        day_fill_count, fill_count, fill_count_entry,
+                        fill_count_long, false, !short_side
                     );
                     psize[c] = fmax(
                         round_step(psize[c] - grid_qty, qty_step), 0.0f
@@ -1045,7 +1058,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     record_realized_net(
                         net_pnl, realized_pnl_cumsum_last,
                         realized_pnl_cumsum_max,
-                        day_fill_count
+                        day_fill_count, fill_count, fill_count_entry,
+                        fill_count_long, false, !short_side
                     );
                     psize[c] = fmax(
                         round_step(psize[c] - qty, qty_step), 0.0f
@@ -1088,7 +1102,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 record_realized_net(
                     -fee, realized_pnl_cumsum_last,
                     realized_pnl_cumsum_max,
-                    day_fill_count
+                    day_fill_count, fill_count, fill_count_entry,
+                    fill_count_long, true, !short_side
                 );
                 float new_size = round_step(psize[c] + adjusted, qty_step);
                 float new_price = was_flat ? fill_price
@@ -2340,6 +2355,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     ) * entry_initial_qty_pct;
     scalars[scalar_offset + 22] = total_wallet_exposure_max;
     scalars[scalar_offset + 23] = total_wallet_exposure_mean;
+    scalars[scalar_offset + 24] = fill_count;
+    scalars[scalar_offset + 25] = fill_count_entry;
+    scalars[scalar_offset + 26] = fill_count_long;
 }
 
 kernel void passivbot_trailing_martingale_multicoin(

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -65,12 +65,24 @@ SUPPORTED_METRICS = (
     "exposure_ratio_usd",
     "fills_analysis_duration_days",
     "fills_count",
+    "fills_count_close",
+    "fills_count_entry",
+    "fills_count_long",
+    "fills_count_short",
+    "fills_entry_per_close",
     "fills_gap_longest_days",
     "fills_gap_mean_hours",
     "fills_gap_median_hours",
     "fills_gap_p95_hours",
     "fills_gap_p99_hours",
     "fills_per_day",
+    "fills_per_day_close",
+    "fills_per_day_entry",
+    "fills_per_day_long",
+    "fills_per_day_per_position_slot",
+    "fills_per_day_per_position_slot_long",
+    "fills_per_day_per_position_slot_short",
+    "fills_per_day_short",
     "gain_strategy_eq",
     "hard_stop_duration_minutes_max",
     "hard_stop_duration_minutes_mean",
@@ -148,7 +160,19 @@ _WEIGHTED_PNL_METRICS = {
 _FILL_ACTIVITY_METRICS = {
     "fills_analysis_duration_days",
     "fills_count",
+    "fills_count_close",
+    "fills_count_entry",
+    "fills_count_long",
+    "fills_count_short",
+    "fills_entry_per_close",
     "fills_per_day",
+    "fills_per_day_close",
+    "fills_per_day_entry",
+    "fills_per_day_long",
+    "fills_per_day_per_position_slot",
+    "fills_per_day_per_position_slot_long",
+    "fills_per_day_per_position_slot_short",
+    "fills_per_day_short",
 }
 
 
@@ -674,14 +698,14 @@ def _daily_pnl_stats(day_net_pnl, day_last_fill_balance, mask):
     return adg, mdg, sharpe, sortino, count
 
 
-def _fill_activity_metrics(out: dict, active: torch.Tensor) -> dict:
+def _fill_activity_metrics(out: dict, requested: set[str]) -> dict:
     """Match Rust's full-run fill count and timestamp-span rate contract."""
 
-    fill_count = torch.where(
-        active,
-        out["day_fill_count"].to(torch.float64),
-        torch.zeros_like(out["day_fill_count"], dtype=torch.float64),
-    ).sum(dim=1)
+    fill_count = out["fill_count"].to(torch.float64)
+    fills_count_entry = out["fill_count_entry"].to(torch.float64)
+    fills_count_long = out["fill_count_long"].to(torch.float64)
+    fills_count_close = (fill_count - fills_count_entry).clamp(min=0.0)
+    fills_count_short = (fill_count - fills_count_long).clamp(min=0.0)
     first_eq_ts = out["first_eq_ts"].to(torch.float64)
     last_eq_ts = out["last_eq_ts"].to(torch.float64)
     has_span = (
@@ -699,11 +723,66 @@ def _fill_activity_metrics(out: dict, active: torch.Tensor) -> dict:
         fill_count / duration_days.clamp(min=1.0e-9),
         torch.zeros_like(fill_count),
     )
-    return {
+    def per_day(count):
+        return torch.where(
+            duration_days > 0.0,
+            count / duration_days.clamp(min=1.0e-9),
+            torch.zeros_like(count),
+        )
+
+    fills_per_day_entry = per_day(fills_count_entry)
+    fills_per_day_close = per_day(fills_count_close)
+    fills_per_day_long = per_day(fills_count_long)
+    fills_per_day_short = per_day(fills_count_short)
+    metrics = {
         "fills_analysis_duration_days": duration_days,
         "fills_count": fill_count,
+        "fills_count_close": fills_count_close,
+        "fills_count_entry": fills_count_entry,
+        "fills_count_long": fills_count_long,
+        "fills_count_short": fills_count_short,
+        "fills_entry_per_close": fills_count_entry
+        / fills_count_close.clamp(min=1.0),
         "fills_per_day": fills_per_day,
+        "fills_per_day_close": fills_per_day_close,
+        "fills_per_day_entry": fills_per_day_entry,
+        "fills_per_day_long": fills_per_day_long,
+        "fills_per_day_short": fills_per_day_short,
     }
+    slot_metrics = {
+        "fills_per_day_per_position_slot",
+        "fills_per_day_per_position_slot_long",
+        "fills_per_day_per_position_slot_short",
+    }
+    if requested & slot_metrics:
+        slots_long = out["position_slots_long"].to(torch.float64)
+        slots_short = out["position_slots_short"].to(torch.float64)
+        long_slot_rate = torch.where(
+            slots_long > 0.0,
+            fills_per_day_long / slots_long.clamp(min=1.0),
+            torch.zeros_like(fills_per_day_long),
+        )
+        short_slot_rate = torch.where(
+            slots_short > 0.0,
+            fills_per_day_short / slots_short.clamp(min=1.0),
+            torch.zeros_like(fills_per_day_short),
+        )
+        active_slot_sides = (slots_long > 0.0).to(torch.float64) + (
+            slots_short > 0.0
+        ).to(torch.float64)
+        combined_slot_rate = torch.where(
+            active_slot_sides > 0.0,
+            (long_slot_rate + short_slot_rate) / active_slot_sides.clamp(min=1.0),
+            torch.zeros_like(long_slot_rate),
+        )
+        metrics.update(
+            {
+                "fills_per_day_per_position_slot": combined_slot_rate,
+                "fills_per_day_per_position_slot_long": long_slot_rate,
+                "fills_per_day_per_position_slot_short": short_slot_rate,
+            }
+        )
+    return metrics
 
 
 def _weighted_pnl_metrics(
@@ -994,7 +1073,7 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
         else {}
     )
     fill_activity_metrics = (
-        _fill_activity_metrics(out, active)
+        _fill_activity_metrics(out, requested)
         if requested & _FILL_ACTIVITY_METRICS
         else {}
     )

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -19,8 +19,8 @@ from optimization.gpu.model import (
 
 MPS_DAILY_COLS = 8
 MPS_MULTICOIN_DAILY_COLS = 9
-MPS_SCALAR_COLS = 24
-MPS_DIRECTIONAL_SCALAR_COLS = 50
+MPS_SCALAR_COLS = 27
+MPS_DIRECTIONAL_SCALAR_COLS = 53
 
 
 def _encode_max_realized_loss_pct(value: float) -> float:
@@ -127,6 +127,9 @@ def _decode_outputs(daily, scalars, gaps) -> dict:
         "entry_initial_balance_pct": scalars[:, 21],
         "total_wallet_exposure_max": scalars[:, 22],
         "total_wallet_exposure_mean": scalars[:, 23],
+        "fill_count": scalars[:, 24],
+        "fill_count_entry": scalars[:, 25],
+        "fill_count_long": scalars[:, 26],
     }
 
 
@@ -201,6 +204,9 @@ def _decode_directional_outputs(daily, scalars, gaps) -> dict:
         "entry_initial_balance_pct_short": scalars[:, 47],
         "total_wallet_exposure_max": scalars[:, 48],
         "total_wallet_exposure_mean": scalars[:, 49],
+        "fill_count": scalars[:, 50],
+        "fill_count_entry": scalars[:, 51],
+        "fill_count_long": scalars[:, 52],
     }
 
 

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -31,6 +31,9 @@ CORE_OUTPUT_KEYS = {
     "day_net_pnl",
     "day_last_fill_balance",
     "day_fill_count",
+    "fill_count",
+    "fill_count_entry",
+    "fill_count_long",
     "day_min_balance",
     "max_dd",
     "held_max_ms",
@@ -86,7 +89,19 @@ _DUAL_SIDE_MULTICOIN_INTRADAY_CUTOFF_METRICS = {
     "adg_pnl_w",
     "fills_analysis_duration_days",
     "fills_count",
+    "fills_count_close",
+    "fills_count_entry",
+    "fills_count_long",
+    "fills_count_short",
+    "fills_entry_per_close",
     "fills_per_day",
+    "fills_per_day_close",
+    "fills_per_day_entry",
+    "fills_per_day_long",
+    "fills_per_day_per_position_slot",
+    "fills_per_day_per_position_slot_long",
+    "fills_per_day_per_position_slot_short",
+    "fills_per_day_short",
     "mdg_pnl",
     "mdg_pnl_w",
     "sharpe_ratio_pnl",
@@ -129,6 +144,36 @@ def _candidate_wallet_exposure_limit_outputs(
         )
         outputs[f"candidate_total_wallet_exposure_limit_{side}"] = torch.from_numpy(
             values
+        )
+    return outputs
+
+
+def _candidate_position_slot_outputs(
+    candidates: list[dict],
+    base_n_positions: dict[str, float],
+    base_limits: dict[str, float],
+    *,
+    torch,
+) -> dict:
+    """Expose Rust analysis' configured active position-slot denominators."""
+
+    outputs = {}
+    for side in ("long", "short"):
+        if side not in base_n_positions or side not in base_limits:
+            raise ValueError(f"GPU candidate position-slot context is missing {side}")
+        n_positions_key = f"{side}_n_positions"
+        limit_key = f"{side}_total_wallet_exposure_limit"
+        values = []
+        for candidate in candidates:
+            n_positions = float(
+                candidate.get(n_positions_key, base_n_positions[side])
+            )
+            limit = float(candidate.get(limit_key, base_limits[side]))
+            values.append(
+                n_positions if n_positions > 0.0 and limit > 0.0 else 0.0
+            )
+        outputs[f"position_slots_{side}"] = torch.from_numpy(
+            np.asarray(values, dtype=np.float64)
         )
     return outputs
 
@@ -484,6 +529,13 @@ def _combine_hedged_multicoin_outputs(
     combined["liq_step"] = liquidation_day
     combined["profit_sum"] = long["profit_sum"] + short["profit_sum"]
     combined["loss_sum"] = long["loss_sum"] + short["loss_sum"]
+    combined["fill_count"] = long["fill_count"] + short["fill_count"]
+    combined["fill_count_entry"] = (
+        long["fill_count_entry"] + short["fill_count_entry"]
+    )
+    combined["fill_count_long"] = (
+        long["fill_count_long"] + short["fill_count_long"]
+    )
     return combined
 
 
@@ -641,6 +693,9 @@ class MpsSingleCoinProxy:
             side: float(self.base_params[side]["total_wallet_exposure_limit"])
             for side in ("long", "short")
         }
+        self.base_n_positions = {
+            side: float(self.enabled[side]) for side in ("long", "short")
+        }
 
         market_params = payload.exchange_params[0]
         self.market = ProxyMarket(
@@ -761,6 +816,15 @@ class MpsSingleCoinProxy:
                 output.update(
                     _candidate_wallet_exposure_limit_outputs(
                         chunk,
+                        self.base_total_wallet_exposure_limits,
+                        torch=torch,
+                    )
+                )
+            if any("_per_position_slot" in name for name in self.needed_metrics):
+                output.update(
+                    _candidate_position_slot_outputs(
+                        chunk,
+                        self.base_n_positions,
                         self.base_total_wallet_exposure_limits,
                         torch=torch,
                     )
@@ -1108,6 +1172,10 @@ class MpsMulticoinProxy:
             )
             for side in ("long", "short")
         }
+        self.base_n_positions = {
+            side: float(payload.bot_params_list[0][side]["n_positions"])
+            for side in ("long", "short")
+        }
         self.base_params = {}
         for side in self.sides:
             first_bot = payload.bot_params_list[0][side]
@@ -1397,6 +1465,15 @@ class MpsMulticoinProxy:
                 output.update(
                     _candidate_wallet_exposure_limit_outputs(
                         chunk,
+                        self.base_total_wallet_exposure_limits,
+                        torch=torch,
+                    )
+                )
+            if any("_per_position_slot" in name for name in self.needed_metrics):
+                output.update(
+                    _candidate_position_slot_outputs(
+                        chunk,
+                        self.base_n_positions,
                         self.base_total_wallet_exposure_limits,
                         torch=torch,
                     )

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -51,6 +51,11 @@ def test_fill_activity_metrics_match_rust_full_timestamp_span_contract():
         "day_fill_count": torch.tensor(
             [[1.0, 1.0, 0.0], [0.0, 0.0, 0.0]], dtype=torch.float64
         ),
+        "fill_count": torch.tensor([5.0, 0.0]),
+        "fill_count_entry": torch.tensor([3.0, 0.0]),
+        "fill_count_long": torch.tensor([4.0, 0.0]),
+        "position_slots_long": torch.tensor([2.0, 1.0]),
+        "position_slots_short": torch.tensor([1.0, 0.0]),
         "max_dd": torch.zeros(2),
         "held_max_ms": torch.zeros(2),
         "position_unchanged_max_ms": torch.zeros(2),
@@ -67,7 +72,19 @@ def test_fill_activity_metrics_match_rust_full_timestamp_span_contract():
     requested = {
         "fills_analysis_duration_days",
         "fills_count",
+        "fills_count_close",
+        "fills_count_entry",
+        "fills_count_long",
+        "fills_count_short",
+        "fills_entry_per_close",
         "fills_per_day",
+        "fills_per_day_close",
+        "fills_per_day_entry",
+        "fills_per_day_long",
+        "fills_per_day_per_position_slot",
+        "fills_per_day_per_position_slot_long",
+        "fills_per_day_per_position_slot_short",
+        "fills_per_day_short",
     }
 
     metrics = compute_objectives(
@@ -84,8 +101,26 @@ def test_fill_activity_metrics_match_rust_full_timestamp_span_contract():
     assert metrics["fills_analysis_duration_days"].tolist() == pytest.approx(
         [4.0 / 24.0, 4.0 / 24.0]
     )
-    assert metrics["fills_count"].tolist() == [2.0, 0.0]
-    assert metrics["fills_per_day"].tolist() == pytest.approx([12.0, 0.0])
+    assert metrics["fills_count"].tolist() == [5.0, 0.0]
+    assert metrics["fills_count_entry"].tolist() == [3.0, 0.0]
+    assert metrics["fills_count_close"].tolist() == [2.0, 0.0]
+    assert metrics["fills_count_long"].tolist() == [4.0, 0.0]
+    assert metrics["fills_count_short"].tolist() == [1.0, 0.0]
+    assert metrics["fills_entry_per_close"].tolist() == [1.5, 0.0]
+    assert metrics["fills_per_day"].tolist() == pytest.approx([30.0, 0.0])
+    assert metrics["fills_per_day_entry"].tolist() == pytest.approx([18.0, 0.0])
+    assert metrics["fills_per_day_close"].tolist() == pytest.approx([12.0, 0.0])
+    assert metrics["fills_per_day_long"].tolist() == pytest.approx([24.0, 0.0])
+    assert metrics["fills_per_day_short"].tolist() == pytest.approx([6.0, 0.0])
+    assert metrics["fills_per_day_per_position_slot_long"].tolist() == pytest.approx(
+        [12.0, 0.0]
+    )
+    assert metrics["fills_per_day_per_position_slot_short"].tolist() == pytest.approx(
+        [6.0, 0.0]
+    )
+    assert metrics["fills_per_day_per_position_slot"].tolist() == pytest.approx(
+        [9.0, 0.0]
+    )
 
 
 def test_fill_activity_metrics_ignore_inactive_daily_slots_and_zero_single_sample_span():
@@ -97,6 +132,9 @@ def test_fill_activity_metrics_ignore_inactive_daily_slots_and_zero_single_sampl
         "day_volume": torch.zeros_like(day_min),
         "day_has_fill": torch.tensor([[True, False]]),
         "day_fill_count": torch.tensor([[2.0, 99.0]], dtype=torch.float64),
+        "fill_count": torch.tensor([2.0]),
+        "fill_count_entry": torch.tensor([1.0]),
+        "fill_count_long": torch.tensor([2.0]),
         "max_dd": torch.zeros(1),
         "held_max_ms": torch.zeros(1),
         "position_unchanged_max_ms": torch.zeros(1),

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -23,6 +23,17 @@ from optimization.gpu.mps_kernel import _encode_max_realized_loss_pct
 from optimization.gpu.metrics import _fill_gap_metrics
 
 
+def _assert_fill_scalar_contract(output):
+    fill_count = output["fill_count"]
+    assert torch.equal(fill_count, fill_count.round())
+    assert (fill_count >= 0.0).all()
+    assert (fill_count >= output["fill_count_entry"]).all()
+    assert (fill_count >= output["fill_count_long"]).all()
+    assert torch.equal(
+        fill_count, output["day_fill_count"].sum(dim=1)
+    )
+
+
 @pytest.mark.parametrize(
     "value", [0.0, 0.05, 0.999999999, float(np.nextafter(1.0, 0.0))]
 )
@@ -277,6 +288,11 @@ def test_mps_multicoin_tracks_position_unchanged_max(strategy_kind, side):
     assert torch.equal(
         output["day_fill_count"], output["day_fill_count"].round()
     )
+    _assert_fill_scalar_contract(output)
+    if side == "long":
+        assert torch.equal(output["fill_count_long"], output["fill_count"])
+    else:
+        assert (output["fill_count_long"] == 0.0).all()
 
 
 @pytest.mark.skipif(
@@ -491,7 +507,10 @@ def test_mps_ema_anchor_shader_smoke():
     assert "const bool long_hsl_panic_market = settings[17] > 0.5f" in source
     assert "const bool short_hsl_panic_market = settings[18] > 0.5f" in source
     assert "market_panic ? taker_fee : maker_fee" in source
-    assert "constant int SCALAR_COLS = 50" in source
+    assert "constant int SCALAR_COLS = 53" in source
+    assert "scalars[so + 50] = fill_count" in source
+    assert "scalars[so + 51] = fill_count_entry" in source
+    assert "scalars[so + 52] = fill_count_long" in source
     assert "record_gross_pnl" in source
     assert "hsl_tier_samples_total" in source
     assert "h.restart_retrigger_count" in source
@@ -580,6 +599,7 @@ def test_mps_ema_anchor_shader_smoke():
     assert torch.equal(
         output["day_fill_count"], output["day_fill_count"].round()
     )
+    _assert_fill_scalar_contract(output)
     assert (output["total_wallet_exposure_max"] > 0.0).all()
     assert (
         output["total_wallet_exposure_max"]
@@ -690,6 +710,11 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
     ).all()
     assert output["day_has_fill"].sum().item() > 0
     assert (output["open_positions"] <= 2.0).all()
+    _assert_fill_scalar_contract(output)
+    if side == "long":
+        assert torch.equal(output["fill_count_long"], output["fill_count"])
+    else:
+        assert (output["fill_count_long"] == 0.0).all()
 
     with pytest.raises(ValueError, match="finite and non-negative"):
         MpsEmaAnchorMulticoinRunner(
@@ -5622,6 +5647,11 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert output["day_has_fill"].sum().item() > 0
     assert (output["psize"].item() > 0.0) is long_enabled
     assert (output["short_psize"].item() > 0.0) is short_enabled
+    _assert_fill_scalar_contract(output)
+    if long_enabled and not short_enabled:
+        assert torch.equal(output["fill_count_long"], output["fill_count"])
+    if short_enabled and not long_enabled:
+        assert output["fill_count_long"].item() == 0.0
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -21,6 +21,7 @@ from optimization.gpu.service import (
     _build_multicoin_ema_coin_overrides,
     _build_multicoin_tm_coin_overrides,
     _candidate_wallet_exposure_limit_outputs,
+    _candidate_position_slot_outputs,
     _combine_hedged_multicoin_outputs,
     _directional_entry_initial_metrics,
     _hsl_params,
@@ -46,6 +47,9 @@ def test_core_output_contract_retains_gross_pnl_aggregates():
         "total_wallet_exposure_max",
         "total_wallet_exposure_mean",
         "day_fill_count",
+        "fill_count",
+        "fill_count_entry",
+        "fill_count_long",
     } <= CORE_OUTPUT_KEYS
 
 
@@ -56,7 +60,19 @@ def test_core_output_contract_retains_gross_pnl_aggregates():
         "adg_pnl_w",
         "fills_analysis_duration_days",
         "fills_count",
+        "fills_count_close",
+        "fills_count_entry",
+        "fills_count_long",
+        "fills_count_short",
+        "fills_entry_per_close",
         "fills_per_day",
+        "fills_per_day_close",
+        "fills_per_day_entry",
+        "fills_per_day_long",
+        "fills_per_day_per_position_slot",
+        "fills_per_day_per_position_slot_long",
+        "fills_per_day_per_position_slot_short",
+        "fills_per_day_short",
         "mdg_pnl",
         "mdg_pnl_w",
         "sharpe_ratio_pnl",
@@ -109,6 +125,23 @@ def test_candidate_wallet_exposure_limits_preserve_sides_and_base_fallback():
         0.5,
         0.75,
     ]
+
+
+def test_candidate_position_slots_follow_candidate_positions_and_enabledness():
+    torch = pytest.importorskip("torch")
+
+    outputs = _candidate_position_slot_outputs(
+        [
+            {"long_n_positions": 3.0, "short_total_wallet_exposure_limit": 0.0},
+            {"short_n_positions": 2.0},
+        ],
+        {"long": 2.0, "short": 1.0},
+        {"long": 1.0, "short": 0.5},
+        torch=torch,
+    )
+
+    assert outputs["position_slots_long"].tolist() == [3.0, 2.0]
+    assert outputs["position_slots_short"].tolist() == [0.0, 2.0]
 
 
 def test_single_coin_side_eligibility_uses_prepared_coin_payload():
@@ -513,6 +546,9 @@ def test_combine_hedged_multicoin_outputs_uses_conservative_surface():
             "liq_step": torch.tensor([liq]),
             "profit_sum": torch.tensor([20.0]),
             "loss_sum": torch.tensor([5.0]),
+            "fill_count": torch.tensor([float(sum(fill))]),
+            "fill_count_entry": torch.tensor([float(sum(fill))]),
+            "fill_count_long": torch.tensor([float(sum(fill))]),
         }
 
     long = side_output(
@@ -559,6 +595,9 @@ def test_combine_hedged_multicoin_outputs_uses_conservative_surface():
     assert combined["liq_step"].item() == -1
     assert combined["profit_sum"].item() == 40.0
     assert combined["loss_sum"].item() == 10.0
+    assert combined["fill_count"].item() == 2.0
+    assert combined["fill_count_entry"].item() == 2.0
+    assert combined["fill_count_long"].item() == 2.0
     assert combined["position_unchanged_max_ms"].item() == 250.0
 
     short["day_min_eq"][0, 1] = float("inf")
@@ -611,6 +650,9 @@ def test_combine_hedged_multicoin_outputs_detects_shared_equity_liquidation():
             "liq_step": torch.tensor([-1]),
             "profit_sum": torch.tensor([0.0]),
             "loss_sum": torch.tensor([0.0]),
+            "fill_count": torch.tensor([3.0]),
+            "fill_count_entry": torch.tensor([2.0]),
+            "fill_count_long": torch.tensor([2.0]),
         }
 
     combined = _combine_hedged_multicoin_outputs(
@@ -653,6 +695,9 @@ def test_combine_hedged_multicoin_outputs_detects_shared_balance_depletion():
             "liq_step": torch.tensor([-1]),
             "profit_sum": torch.tensor([0.0]),
             "loss_sum": torch.tensor([0.0]),
+            "fill_count": torch.tensor([3.0]),
+            "fill_count_entry": torch.tensor([2.0]),
+            "fill_count_long": torch.tensor([2.0]),
         }
 
     combined = _combine_hedged_multicoin_outputs(


### PR DESCRIPTION
## Summary

- add Apple MPS proxy support for entry/close and long/short fill counts and daily rates
- add entry-to-close fill ratio and combined/side-specific per-configured-position-slot fill rates using the exact Rust averaging contract
- extend all active EMA Anchor and Trailing Martingale Metal kernels with fill-role/side counters while keeping exact Rust validation authoritative
- fail closed for these metrics in dual-side multi-coin runs at the existing intraday shared-liquidation boundary

## Validation

- Python GPU metrics/service: 96 passed
- Python optimization suite excluding physical MPS: 773 passed
- physical Apple M3 MPS suite: 204 passed
- affected physical MPS rerun after directional classification assertions: 10 passed
- Rust source/unit suite without default features: 262 passed
- cargo fmt --check
- cargo check --tests --no-default-features
- cargo check --tests
- AI docs checks: 0 errors, 2 pre-existing size warnings; generated registry current; 6 docs tests passed
- git diff --check

Exact worktree Rust extension rebuilt and stamped:

- artifact SHA-256: b4e2a9378f66b7d723ecdbb5c0763182eadc9bce811448bc20d746d49844f6b7
- source and stamp fingerprint: 19d083f466d1a57f6de207e789cc8382e860660aa929404ed04f4f9f7cea76ad

End-to-end physical MPS optimization against cached Bybit ETH data (2024-01-01 through 2024-01-14), scoring all 14 added metrics:

- EMA Anchor: 8 generations, 1,024 proxy evaluations, 128 exact validations, 4.9 seconds, no drift or constraint halt
- Trailing Martingale long-only: 8 generations, 1,024 proxy evaluations, 128 exact validations, 5.8 seconds, no drift or constraint halt

## Scope

This is additive GPU optimization support only. CPU optimization, backtesting, and live bot behavior are unchanged. Active-day and symbol-concentration fill metrics remain out of scope for a later parity slice.
