### PR TITLE
Add Apple MPS active fill-day metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added analyzed-start-anchored active fill-day count and ratio scoring and limits to Apple MPS
+  optimization for single-coin and one-sided multi-coin EMA Anchor and Trailing Martingale runs.
+  Metal counts distinct 24-hour fill buckets within the candidate's analyzed equity window; exact
+  Rust validation remains authoritative, and dual-side multi-coin runs fail closed at the existing
+  intraday shared-liquidation boundary.
+
 - Added entry/close and long/short fill counts and daily rates, entry-to-close ratio, and
   per-configured-position-slot fill rates to Apple MPS optimization for single-coin and one-sided
   multi-coin EMA Anchor and Trailing Martingale runs. Metal records every proxy fill by role and

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -335,11 +335,13 @@ the complete UTC day containing each suffix boundary, so exact Rust validation a
 remain authoritative for that screening approximation.
 Full-run fill activity is supported for single-coin and one-sided multi-coin topologies: analysis
 duration; total, entry, close, long, and short counts; their daily rates; entry-to-close ratio; and
-combined or side-specific per-configured-position-slot daily rates. Metal classifies every actual
-proxy fill by role and position side, then Python applies each candidate's configured active slot
-counts and Rust's mean-of-enabled-sides contract. All rates use the same first-to-last
-analyzed-equity timestamp span as Rust. Dual-side multi-coin runs fail closed because independent
-directional summaries cannot reconstruct the intraday shared-liquidation cutoff.
+combined or side-specific per-configured-position-slot daily rates. Active fill-day count and ratio
+use distinct 24-hour buckets anchored to the analyzed equity start, matching Rust rather than the
+UTC buckets used by the compact daily equity surface. Metal classifies every actual proxy fill by
+role and position side, then Python applies each candidate's configured active slot counts and
+Rust's mean-of-enabled-sides contract. All rates use the same first-to-last analyzed-equity
+timestamp span as Rust. Dual-side multi-coin runs fail closed because independent directional
+summaries cannot reconstruct the intraday shared-liquidation cutoff.
 Initial-entry allocation uses the candidate's effective position count and the same
 first-coin strategy/allowance override precedence as exact Rust. Fill-gap longest, mean, median,
 p95, and p99 metrics are also supported. Metal coalesces multiple fills in the same candle and

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -42,7 +42,7 @@ mod tests {
         let source = mps_ema_anchor_source();
         assert!(source.contains("kernel void passivbot_ema_anchor"));
         assert!(source.contains("constant int DAILY_COLS = 8"));
-        assert!(source.contains("constant int SCALAR_COLS = 53"));
+        assert!(source.contains("constant int SCALAR_COLS = 54"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[so + 44] = loss_sum"));
         assert!(source.contains("scalars[so + 45] = position_unchanged_max_min * interval_ms"));
@@ -53,6 +53,7 @@ mod tests {
         assert!(source.contains("scalars[so + 50] = fill_count"));
         assert!(source.contains("scalars[so + 51] = fill_count_entry"));
         assert!(source.contains("scalars[so + 52] = fill_count_long"));
+        assert!(source.contains("scalars[so + 53] = fills_active_days_count"));
         assert!(source.contains("constant int SIDE_PARAMS = 34"));
         assert!(source.contains("struct HslState"));
         assert!(source.contains("update_hsl("));
@@ -116,7 +117,7 @@ mod tests {
         assert!(source.contains("constant int COIN_COLS = 11"));
         assert!(source.contains("constant int DAILY_COLS = 9"));
         assert!(source.contains("day_min_balance"));
-        assert!(source.contains("constant int SCALAR_COLS = 27"));
+        assert!(source.contains("constant int SCALAR_COLS = 28"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[scalar_offset + 19] = loss_sum"));
         assert!(source
@@ -127,6 +128,7 @@ mod tests {
         assert!(source.contains("scalars[scalar_offset + 24] = fill_count"));
         assert!(source.contains("scalars[scalar_offset + 25] = fill_count_entry"));
         assert!(source.contains("scalars[scalar_offset + 26] = fill_count_long"));
+        assert!(source.contains("scalars[scalar_offset + 27] = fills_active_days_count"));
         assert!(source.contains("close_tick[c] <= fill_ticks[tick_offset + 0]"));
         assert!(source.contains("entry_tick[c] > fill_ticks[tick_offset + 1]"));
         assert!(source.contains("const float volume_drop = clamp(params[po + 14]"));
@@ -164,7 +166,7 @@ mod tests {
         assert!(source.contains("struct HslState"));
         assert!(source.contains("update_hsl("));
         assert!(source.contains("try_restart_hsl("));
-        assert!(source.contains("constant int SCALAR_COLS = 53"));
+        assert!(source.contains("constant int SCALAR_COLS = 54"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[so + 44] = loss_sum"));
         assert!(source.contains("scalars[so + 45] = position_unchanged_max_min * interval_ms"));
@@ -175,6 +177,7 @@ mod tests {
         assert!(source.contains("scalars[so + 50] = fill_count"));
         assert!(source.contains("scalars[so + 51] = fill_count_entry"));
         assert!(source.contains("scalars[so + 52] = fill_count_long"));
+        assert!(source.contains("scalars[so + 53] = fills_active_days_count"));
         assert!(source.contains("hsl_tier_samples_total"));
         assert!(source.contains("h.restart_retrigger_count"));
         assert!(source.contains("h.halt_duration_sum_steps"));
@@ -277,7 +280,7 @@ mod tests {
         assert!(source.contains("constant int MAX_COINS = 64"));
         assert!(source.contains("constant int PARAM_COLS = 48"));
         assert!(source.contains("constant int OVERRIDE_COLS = 34"));
-        assert!(source.contains("constant int SCALAR_COLS = 27"));
+        assert!(source.contains("constant int SCALAR_COLS = 28"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[scalar_offset + 19] = loss_sum"));
         assert!(source
@@ -288,6 +291,7 @@ mod tests {
         assert!(source.contains("scalars[scalar_offset + 24] = fill_count"));
         assert!(source.contains("scalars[scalar_offset + 25] = fill_count_entry"));
         assert!(source.contains("scalars[scalar_offset + 26] = fill_count_long"));
+        assert!(source.contains("scalars[scalar_offset + 27] = fills_active_days_count"));
         assert!(source.contains("coin_wel_enforcer_enabled"));
         assert!(source.contains("coin_wel_enforcer_threshold"));
         assert!(source.contains("twel_enforcer_enabled"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -2,7 +2,7 @@
 using namespace metal;
 
 constant int DAILY_COLS = 8;
-constant int SCALAR_COLS = 53;
+constant int SCALAR_COLS = 54;
 constant int GAP_BINS = 128;
 constant int SIDE_PARAMS = 34;
 
@@ -1111,6 +1111,8 @@ inline void passivbot_single_coin_impl(
     float fill_count = 0.0f;
     float fill_count_entry = 0.0f;
     float fill_count_long = 0.0f;
+    float fills_active_days_count = 0.0f;
+    int last_active_fill_day = -1;
     bool alive = true;
     int liq_day = -1;
     float held_max_min = 0.0f;
@@ -1694,6 +1696,13 @@ inline void passivbot_single_coin_impl(
         if (active) {
             if (first_eq_k < 0.0f) first_eq_k = kf;
             last_eq_k = kf;
+            if (any_fill) {
+                int active_fill_day = int(kf - first_eq_k) / 1440;
+                if (active_fill_day != last_active_fill_day) {
+                    fills_active_days_count += 1.0f;
+                    last_active_fill_day = active_fill_day;
+                }
+            }
             bool liq = balance <= 0.0f || equity <= liq_floor;
             float eqf = liq ? liq_floor : equity;
             if (eqf > run_peak) {
@@ -1856,6 +1865,7 @@ inline void passivbot_single_coin_impl(
     scalars[so + 50] = fill_count;
     scalars[so + 51] = fill_count_entry;
     scalars[so + 52] = fill_count_long;
+    scalars[so + 53] = fills_active_days_count;
 }
 
 kernel void passivbot_ema_anchor(

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -6,7 +6,7 @@ constant int PARAM_COLS = 31;
 constant int COIN_COLS = 11;
 constant int OVERRIDE_COLS = 19;
 constant int DAILY_COLS = 9;
-constant int SCALAR_COLS = 27;
+constant int SCALAR_COLS = 28;
 constant int GAP_BINS = 128;
 
 inline float round_step(float value, float step) {
@@ -398,6 +398,8 @@ inline void passivbot_ema_anchor_multicoin_impl(
     float fill_count = 0.0f;
     float fill_count_entry = 0.0f;
     float fill_count_long = 0.0f;
+    float fills_active_days_count = 0.0f;
+    int last_active_fill_day = -1;
     bool alive = true;
     bool equity_started = false;
     bool selection_initialized = false;
@@ -1435,6 +1437,13 @@ inline void passivbot_ema_anchor_multicoin_impl(
         if (active) {
             if (first_eq_k < 0.0f) first_eq_k = float(k);
             last_eq_k = float(k);
+            if (any_fill) {
+                int active_fill_day = int(float(k) - first_eq_k) / 1440;
+                if (active_fill_day != last_active_fill_day) {
+                    fills_active_days_count += 1.0f;
+                    last_active_fill_day = active_fill_day;
+                }
+            }
             bool liquidated = balance <= 0.0f || equity <= liquidation_floor;
             float effective_equity = liquidated ? liquidation_floor : equity;
             if (effective_equity > run_peak) {
@@ -1546,6 +1555,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
     scalars[scalar_offset + 24] = fill_count;
     scalars[scalar_offset + 25] = fill_count_entry;
     scalars[scalar_offset + 26] = fill_count_long;
+    scalars[scalar_offset + 27] = fills_active_days_count;
 }
 
 kernel void passivbot_ema_anchor_multicoin(

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -2,7 +2,7 @@
 using namespace metal;
 
 constant int DAILY_COLS = 8;
-constant int SCALAR_COLS = 53;
+constant int SCALAR_COLS = 54;
 constant int GAP_BINS = 128;
 constant int SIDE_PARAMS = 51;
 
@@ -1398,6 +1398,8 @@ inline void passivbot_single_coin_impl(
     float fill_count = 0.0f;
     float fill_count_entry = 0.0f;
     float fill_count_long = 0.0f;
+    float fills_active_days_count = 0.0f;
+    int last_active_fill_day = -1;
     bool alive = true;
     int liq_day = -1;
     float held_max_min = 0.0f;
@@ -2715,6 +2717,13 @@ inline void passivbot_single_coin_impl(
         if (active) {
             if (first_eq_k < 0.0f) first_eq_k = kf;
             last_eq_k = kf;
+            if (any_fill) {
+                int active_fill_day = int(kf - first_eq_k) / 1440;
+                if (active_fill_day != last_active_fill_day) {
+                    fills_active_days_count += 1.0f;
+                    last_active_fill_day = active_fill_day;
+                }
+            }
             bool liq = balance <= 0.0f || equity <= liq_floor;
             float eqf = liq ? liq_floor : equity;
             if (eqf > run_peak) {
@@ -2877,6 +2886,7 @@ inline void passivbot_single_coin_impl(
     scalars[so + 50] = fill_count;
     scalars[so + 51] = fill_count_entry;
     scalars[so + 52] = fill_count_long;
+    scalars[so + 53] = fills_active_days_count;
 }
 
 kernel void passivbot_trailing_martingale(

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -6,7 +6,7 @@ constant int PARAM_COLS = 48;
 constant int OVERRIDE_COLS = 34;
 constant int COIN_COLS = 11;
 constant int DAILY_COLS = 9;
-constant int SCALAR_COLS = 27;
+constant int SCALAR_COLS = 28;
 constant int GAP_BINS = 128;
 
 inline float round_step(float value, float step) {
@@ -658,6 +658,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     float fill_count = 0.0f;
     float fill_count_entry = 0.0f;
     float fill_count_long = 0.0f;
+    float fills_active_days_count = 0.0f;
+    int last_active_fill_day = -1;
     bool alive = true;
     bool equity_started = false;
     bool selection_initialized = false;
@@ -2247,6 +2249,13 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         if (active) {
             if (first_eq_k < 0.0f) first_eq_k = float(k);
             last_eq_k = float(k);
+            if (any_fill) {
+                int active_fill_day = int(float(k) - first_eq_k) / 1440;
+                if (active_fill_day != last_active_fill_day) {
+                    fills_active_days_count += 1.0f;
+                    last_active_fill_day = active_fill_day;
+                }
+            }
             bool liquidated = balance <= 0.0f || equity <= liquidation_floor;
             float effective_equity = liquidated ? liquidation_floor : equity;
             if (effective_equity > run_peak) {
@@ -2358,6 +2367,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     scalars[scalar_offset + 24] = fill_count;
     scalars[scalar_offset + 25] = fill_count_entry;
     scalars[scalar_offset + 26] = fill_count_long;
+    scalars[scalar_offset + 27] = fills_active_days_count;
 }
 
 kernel void passivbot_trailing_martingale_multicoin(

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -64,6 +64,8 @@ SUPPORTED_METRICS = (
     "exposure_mean_ratio_usd",
     "exposure_ratio_usd",
     "fills_analysis_duration_days",
+    "fills_active_days_count",
+    "fills_active_days_ratio",
     "fills_count",
     "fills_count_close",
     "fills_count_entry",
@@ -159,6 +161,8 @@ _WEIGHTED_PNL_METRICS = {
 
 _FILL_ACTIVITY_METRICS = {
     "fills_analysis_duration_days",
+    "fills_active_days_count",
+    "fills_active_days_ratio",
     "fills_count",
     "fills_count_close",
     "fills_count_entry",
@@ -706,6 +710,7 @@ def _fill_activity_metrics(out: dict, requested: set[str]) -> dict:
     fills_count_long = out["fill_count_long"].to(torch.float64)
     fills_count_close = (fill_count - fills_count_entry).clamp(min=0.0)
     fills_count_short = (fill_count - fills_count_long).clamp(min=0.0)
+    fills_active_days_count = out["fills_active_days_count"].to(torch.float64)
     first_eq_ts = out["first_eq_ts"].to(torch.float64)
     last_eq_ts = out["last_eq_ts"].to(torch.float64)
     has_span = (
@@ -735,6 +740,9 @@ def _fill_activity_metrics(out: dict, requested: set[str]) -> dict:
     fills_per_day_long = per_day(fills_count_long)
     fills_per_day_short = per_day(fills_count_short)
     metrics = {
+        "fills_active_days_count": fills_active_days_count,
+        "fills_active_days_ratio": fills_active_days_count
+        / duration_days.ceil().clamp(min=1.0),
         "fills_analysis_duration_days": duration_days,
         "fills_count": fill_count,
         "fills_count_close": fills_count_close,

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -702,7 +702,7 @@ def _daily_pnl_stats(day_net_pnl, day_last_fill_balance, mask):
     return adg, mdg, sharpe, sortino, count
 
 
-def _fill_activity_metrics(out: dict, requested: set[str]) -> dict:
+def _fill_activity_metrics(out: dict, run, requested: set[str]) -> dict:
     """Match Rust's full-run fill count and timestamp-span rate contract."""
 
     fill_count = out["fill_count"].to(torch.float64)
@@ -718,9 +718,17 @@ def _fill_activity_metrics(out: dict, requested: set[str]) -> dict:
         & torch.isfinite(last_eq_ts)
         & (last_eq_ts > first_eq_ts)
     )
+    interval_ms = max(float(run.interval_ms), 1.0)
+    # Metal exports integer candle indices multiplied by interval_ms through a
+    # float32 scalar buffer. Recover the indices before subtracting so a span
+    # on a whole-day boundary cannot round slightly upward and add a spurious
+    # active-day denominator bucket.
+    first_eq_step = torch.round(first_eq_ts / interval_ms)
+    last_eq_step = torch.round(last_eq_ts / interval_ms)
     duration_days = torch.where(
         has_span,
-        (last_eq_ts - first_eq_ts) / 86_400_000.0,
+        (last_eq_step - first_eq_step).clamp(min=0.0) * interval_ms
+        / 86_400_000.0,
         torch.zeros_like(first_eq_ts),
     )
     fills_per_day = torch.where(
@@ -1081,7 +1089,7 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
         else {}
     )
     fill_activity_metrics = (
-        _fill_activity_metrics(out, requested)
+        _fill_activity_metrics(out, run, requested)
         if requested & _FILL_ACTIVITY_METRICS
         else {}
     )

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -19,8 +19,8 @@ from optimization.gpu.model import (
 
 MPS_DAILY_COLS = 8
 MPS_MULTICOIN_DAILY_COLS = 9
-MPS_SCALAR_COLS = 27
-MPS_DIRECTIONAL_SCALAR_COLS = 53
+MPS_SCALAR_COLS = 28
+MPS_DIRECTIONAL_SCALAR_COLS = 54
 
 
 def _encode_max_realized_loss_pct(value: float) -> float:
@@ -130,6 +130,7 @@ def _decode_outputs(daily, scalars, gaps) -> dict:
         "fill_count": scalars[:, 24],
         "fill_count_entry": scalars[:, 25],
         "fill_count_long": scalars[:, 26],
+        "fills_active_days_count": scalars[:, 27],
     }
 
 
@@ -207,6 +208,7 @@ def _decode_directional_outputs(daily, scalars, gaps) -> dict:
         "fill_count": scalars[:, 50],
         "fill_count_entry": scalars[:, 51],
         "fill_count_long": scalars[:, 52],
+        "fills_active_days_count": scalars[:, 53],
     }
 
 

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -34,6 +34,7 @@ CORE_OUTPUT_KEYS = {
     "fill_count",
     "fill_count_entry",
     "fill_count_long",
+    "fills_active_days_count",
     "day_min_balance",
     "max_dd",
     "held_max_ms",
@@ -88,6 +89,8 @@ _DUAL_SIDE_MULTICOIN_INTRADAY_CUTOFF_METRICS = {
     "adg_pnl",
     "adg_pnl_w",
     "fills_analysis_duration_days",
+    "fills_active_days_count",
+    "fills_active_days_ratio",
     "fills_count",
     "fills_count_close",
     "fills_count_entry",
@@ -536,6 +539,12 @@ def _combine_hedged_multicoin_outputs(
     combined["fill_count_long"] = (
         long["fill_count_long"] + short["fill_count_long"]
     )
+    # Preserve the core output shape for unrelated dual-side metrics. Requests
+    # for active-day metrics fail closed before this conservative placeholder
+    # can be consumed because overlapping directional buckets need a true union.
+    combined["fills_active_days_count"] = long[
+        "fills_active_days_count"
+    ].maximum(short["fills_active_days_count"])
     return combined
 
 

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -54,6 +54,7 @@ def test_fill_activity_metrics_match_rust_full_timestamp_span_contract():
         "fill_count": torch.tensor([5.0, 0.0]),
         "fill_count_entry": torch.tensor([3.0, 0.0]),
         "fill_count_long": torch.tensor([4.0, 0.0]),
+        "fills_active_days_count": torch.tensor([2.0, 0.0]),
         "position_slots_long": torch.tensor([2.0, 1.0]),
         "position_slots_short": torch.tensor([1.0, 0.0]),
         "max_dd": torch.zeros(2),
@@ -64,12 +65,14 @@ def test_fill_activity_metrics_match_rust_full_timestamp_span_contract():
         "first_fill_ts": torch.tensor([0.0, float("nan")]),
         "last_fill_ts": torch.tensor([3_600_000.0, float("nan")]),
         "recovery_max_ms": torch.zeros(2),
-        "last_high_ts": torch.tensor([14_400_000.0, 14_400_000.0]),
+        "last_high_ts": torch.tensor([216_000_000.0, 14_400_000.0]),
         "first_eq_ts": torch.tensor([0.0, 0.0]),
-        "last_eq_ts": torch.tensor([14_400_000.0, 14_400_000.0]),
+        "last_eq_ts": torch.tensor([216_000_000.0, 14_400_000.0]),
         "liq_step": torch.tensor([-1.0, -1.0]),
     }
     requested = {
+        "fills_active_days_count",
+        "fills_active_days_ratio",
         "fills_analysis_duration_days",
         "fills_count",
         "fills_count_close",
@@ -99,7 +102,11 @@ def test_fill_activity_metrics_match_rust_full_timestamp_span_contract():
     assert set(metrics) == requested
     assert requested <= set(SUPPORTED_METRICS)
     assert metrics["fills_analysis_duration_days"].tolist() == pytest.approx(
-        [4.0 / 24.0, 4.0 / 24.0]
+        [2.5, 4.0 / 24.0]
+    )
+    assert metrics["fills_active_days_count"].tolist() == [2.0, 0.0]
+    assert metrics["fills_active_days_ratio"].tolist() == pytest.approx(
+        [2.0 / 3.0, 0.0]
     )
     assert metrics["fills_count"].tolist() == [5.0, 0.0]
     assert metrics["fills_count_entry"].tolist() == [3.0, 0.0]
@@ -107,19 +114,19 @@ def test_fill_activity_metrics_match_rust_full_timestamp_span_contract():
     assert metrics["fills_count_long"].tolist() == [4.0, 0.0]
     assert metrics["fills_count_short"].tolist() == [1.0, 0.0]
     assert metrics["fills_entry_per_close"].tolist() == [1.5, 0.0]
-    assert metrics["fills_per_day"].tolist() == pytest.approx([30.0, 0.0])
-    assert metrics["fills_per_day_entry"].tolist() == pytest.approx([18.0, 0.0])
-    assert metrics["fills_per_day_close"].tolist() == pytest.approx([12.0, 0.0])
-    assert metrics["fills_per_day_long"].tolist() == pytest.approx([24.0, 0.0])
-    assert metrics["fills_per_day_short"].tolist() == pytest.approx([6.0, 0.0])
+    assert metrics["fills_per_day"].tolist() == pytest.approx([2.0, 0.0])
+    assert metrics["fills_per_day_entry"].tolist() == pytest.approx([1.2, 0.0])
+    assert metrics["fills_per_day_close"].tolist() == pytest.approx([0.8, 0.0])
+    assert metrics["fills_per_day_long"].tolist() == pytest.approx([1.6, 0.0])
+    assert metrics["fills_per_day_short"].tolist() == pytest.approx([0.4, 0.0])
     assert metrics["fills_per_day_per_position_slot_long"].tolist() == pytest.approx(
-        [12.0, 0.0]
+        [0.8, 0.0]
     )
     assert metrics["fills_per_day_per_position_slot_short"].tolist() == pytest.approx(
-        [6.0, 0.0]
+        [0.4, 0.0]
     )
     assert metrics["fills_per_day_per_position_slot"].tolist() == pytest.approx(
-        [9.0, 0.0]
+        [0.6, 0.0]
     )
 
 
@@ -135,6 +142,7 @@ def test_fill_activity_metrics_ignore_inactive_daily_slots_and_zero_single_sampl
         "fill_count": torch.tensor([2.0]),
         "fill_count_entry": torch.tensor([1.0]),
         "fill_count_long": torch.tensor([2.0]),
+        "fills_active_days_count": torch.tensor([0.0]),
         "max_dd": torch.zeros(1),
         "held_max_ms": torch.zeros(1),
         "position_unchanged_max_ms": torch.zeros(1),

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -10,6 +10,7 @@ torch = pytest.importorskip("torch")
 from optimization.gpu.metrics import (
     SUPPORTED_METRICS,
     _GAP_HIST_UPPER_STEPS,
+    _fill_activity_metrics,
     _fill_gap_metrics,
     _hard_stop_lifecycle_metrics,
     _hard_stop_panic_loss_metrics,
@@ -26,6 +27,30 @@ from optimization.gpu.metrics import (
     _weighted_strategy_eq_metrics,
     compute_objectives,
 )
+
+
+def test_fill_activity_ratio_recovers_integer_steps_at_whole_day_boundary():
+    first_step = 7_509
+    last_step = first_step + 1_440
+    first_ts = np.float32(first_step * 60_000)
+    last_ts = np.float32(last_step * 60_000)
+    assert (float(last_ts) - float(first_ts)) / 86_400_000.0 > 1.0
+
+    metrics = _fill_activity_metrics(
+        {
+            "fill_count": torch.tensor([1.0]),
+            "fill_count_entry": torch.tensor([1.0]),
+            "fill_count_long": torch.tensor([1.0]),
+            "fills_active_days_count": torch.tensor([1.0]),
+            "first_eq_ts": torch.tensor([first_ts]),
+            "last_eq_ts": torch.tensor([last_ts]),
+        },
+        SimpleNamespace(interval_ms=60_000),
+        {"fills_active_days_ratio", "fills_analysis_duration_days"},
+    )
+
+    assert metrics["fills_analysis_duration_days"].item() == 1.0
+    assert metrics["fills_active_days_ratio"].item() == 1.0
 
 
 def test_loss_profit_ratio_matches_rust_cap_and_neutral_contract():

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -32,6 +32,13 @@ def _assert_fill_scalar_contract(output):
     assert torch.equal(
         fill_count, output["day_fill_count"].sum(dim=1)
     )
+    active_days = output["fills_active_days_count"]
+    assert torch.equal(active_days, active_days.round())
+    assert (active_days >= 0.0).all()
+    duration_days = (
+        output["last_eq_ts"] - output["first_eq_ts"]
+    ).clamp(min=0.0) / 86_400_000.0
+    assert (active_days <= duration_days.ceil().clamp(min=1.0)).all()
 
 
 @pytest.mark.parametrize(
@@ -300,6 +307,39 @@ def test_mps_multicoin_tracks_position_unchanged_max(strategy_kind, side):
 )
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
 @pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_multicoin_active_fill_days_use_equity_start_buckets(
+    strategy_kind, side
+):
+    runner, row = _multicoin_exposure_fixture(
+        strategy_kind, side, count=3 * 1440 + 32
+    )
+    if strategy_kind == "trailing_martingale":
+        row[
+            TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(
+                "entry_threshold_base_pct"
+            )
+        ] = 0.0
+        row[
+            TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(
+                "close_threshold_base_pct"
+            )
+        ] = 0.0
+
+    output = runner.run(np.asarray([row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    duration_days = (
+        output["last_eq_ts"] - output["first_eq_ts"]
+    ).item() / 86_400_000.0
+    assert output["fills_active_days_count"].item() == int(np.ceil(duration_days))
+    assert output["fills_active_days_count"].item() >= 3.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_multicoin_initial_entry_pct_uses_first_coin_override(
     strategy_kind, side
 ):
@@ -507,10 +547,11 @@ def test_mps_ema_anchor_shader_smoke():
     assert "const bool long_hsl_panic_market = settings[17] > 0.5f" in source
     assert "const bool short_hsl_panic_market = settings[18] > 0.5f" in source
     assert "market_panic ? taker_fee : maker_fee" in source
-    assert "constant int SCALAR_COLS = 53" in source
+    assert "constant int SCALAR_COLS = 54" in source
     assert "scalars[so + 50] = fill_count" in source
     assert "scalars[so + 51] = fill_count_entry" in source
     assert "scalars[so + 52] = fill_count_long" in source
+    assert "scalars[so + 53] = fills_active_days_count" in source
     assert "record_gross_pnl" in source
     assert "hsl_tier_samples_total" in source
     assert "h.restart_retrigger_count" in source

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -50,6 +50,7 @@ def test_core_output_contract_retains_gross_pnl_aggregates():
         "fill_count",
         "fill_count_entry",
         "fill_count_long",
+        "fills_active_days_count",
     } <= CORE_OUTPUT_KEYS
 
 
@@ -59,6 +60,8 @@ def test_core_output_contract_retains_gross_pnl_aggregates():
         "adg_pnl",
         "adg_pnl_w",
         "fills_analysis_duration_days",
+        "fills_active_days_count",
+        "fills_active_days_ratio",
         "fills_count",
         "fills_count_close",
         "fills_count_entry",
@@ -549,6 +552,7 @@ def test_combine_hedged_multicoin_outputs_uses_conservative_surface():
             "fill_count": torch.tensor([float(sum(fill))]),
             "fill_count_entry": torch.tensor([float(sum(fill))]),
             "fill_count_long": torch.tensor([float(sum(fill))]),
+            "fills_active_days_count": torch.tensor([float(any(fill))]),
         }
 
     long = side_output(
@@ -598,6 +602,7 @@ def test_combine_hedged_multicoin_outputs_uses_conservative_surface():
     assert combined["fill_count"].item() == 2.0
     assert combined["fill_count_entry"].item() == 2.0
     assert combined["fill_count_long"].item() == 2.0
+    assert combined["fills_active_days_count"].item() == 1.0
     assert combined["position_unchanged_max_ms"].item() == 250.0
 
     short["day_min_eq"][0, 1] = float("inf")
@@ -653,6 +658,7 @@ def test_combine_hedged_multicoin_outputs_detects_shared_equity_liquidation():
             "fill_count": torch.tensor([3.0]),
             "fill_count_entry": torch.tensor([2.0]),
             "fill_count_long": torch.tensor([2.0]),
+            "fills_active_days_count": torch.tensor([1.0]),
         }
 
     combined = _combine_hedged_multicoin_outputs(
@@ -698,6 +704,7 @@ def test_combine_hedged_multicoin_outputs_detects_shared_balance_depletion():
             "fill_count": torch.tensor([3.0]),
             "fill_count_entry": torch.tensor([2.0]),
             "fill_count_long": torch.tensor([2.0]),
+            "fills_active_days_count": torch.tensor([1.0]),
         }
 
     combined = _combine_hedged_multicoin_outputs(


### PR DESCRIPTION
## Summary
- add `fills_active_days_count` and `fills_active_days_ratio` to Apple MPS optimization for single-coin and one-sided multi-coin EMA Anchor and Trailing Martingale
- count distinct 24-hour buckets anchored to each candidate's analyzed equity start, matching exact Rust semantics rather than UTC daily-summary buckets
- keep exact Rust authoritative and fail closed for dual-side multi-coin, where separate directional summaries cannot reconstruct the active-day union across the shared intraday liquidation boundary
- document the support boundary and user-facing addition

## Validation
- 799 non-MPS optimizer tests passed
- 208 physical Apple MPS tests passed, including a new multi-day active-bucket test across EMA Anchor/Trailing Martingale and long/short
- 262 Rust tests passed with `--no-default-features`
- `cargo check --tests --no-default-features`
- `cargo check --tests`
- `cargo fmt --check`
- AI docs check: 0 errors (2 pre-existing size warnings)
- AI docs tests: 6 passed
- `git diff --check`
- rebuilt extension verified against current sources: SHA-256 `af93840833fa02d93b47dc463abc7d3678a30e673a92ebba9b055af6fb2cc4c0`, source fingerprint `d2c46328783a271ccb3c7aa517ae26b822c37bd3430e5b5d2a437b019dc29156`

## Physical end-to-end MPS evidence
Cached Bybit ETH data, 2024-01-01 through 2024-01-14, both new metrics explicitly scored:
- EMA Anchor both sides: 64 generations, 8,192 proxy evaluations, 1,024 exact Rust validations, 49.1s, no drift or constraint halt
- Trailing Martingale long-only: 64 generations, 8,192 proxy evaluations, 1,024 exact Rust validations, 82.6s, no drift or constraint halt

Symbol-concentration fill metrics remain deliberately out of this slice because they require per-coin state and deserve a separate performance gate.