### PR TITLE
feat(optimize): add MPS fill symbol metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added active-symbol count and top-symbol fill-share scoring and limits to Apple MPS optimization
+  for single-coin and one-sided multi-coin EMA Anchor and Trailing Martingale runs. Multi-coin
+  kernels emit per-symbol fill counts only when either metric is requested, preserving the normal
+  proxy's buffer and transfer cost; exact Rust validation remains authoritative.
+
 - Added analyzed-start-anchored active fill-day count and ratio scoring and limits to Apple MPS
   optimization for single-coin and one-sided multi-coin EMA Anchor and Trailing Martingale runs.
   Metal counts distinct 24-hour fill buckets within the candidate's analyzed equity window; exact

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -337,11 +337,12 @@ Full-run fill activity is supported for single-coin and one-sided multi-coin top
 duration; total, entry, close, long, and short counts; their daily rates; entry-to-close ratio; and
 combined or side-specific per-configured-position-slot daily rates. Active fill-day count and ratio
 use distinct 24-hour buckets anchored to the analyzed equity start, matching Rust rather than the
-UTC buckets used by the compact daily equity surface. Metal classifies every actual proxy fill by
-role and position side, then Python applies each candidate's configured active slot counts and
-Rust's mean-of-enabled-sides contract. All rates use the same first-to-last analyzed-equity
-timestamp span as Rust. Dual-side multi-coin runs fail closed because independent directional
-summaries cannot reconstruct the intraday shared-liquidation cutoff.
+UTC buckets used by the compact daily equity surface. Active-symbol count and top-symbol fill share
+use per-coin counters emitted only when either metric is requested. Metal classifies every actual
+proxy fill by role, position side, and—when needed—coin, then Python applies each candidate's
+configured active slot counts and Rust's mean-of-enabled-sides contract. All rates use the same
+first-to-last analyzed-equity timestamp span as Rust. Dual-side multi-coin runs fail closed because
+independent directional summaries cannot reconstruct the intraday shared-liquidation cutoff.
 Initial-entry allocation uses the candidate's effective position count and the same
 first-coin strategy/allowance override precedence as exact Rust. Fill-gap longest, mean, median,
 p95, and p99 metrics are also supported. Metal coalesces multiple fills in the same candle and

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -129,6 +129,14 @@ mod tests {
         assert!(source.contains("scalars[scalar_offset + 25] = fill_count_entry"));
         assert!(source.contains("scalars[scalar_offset + 26] = fill_count_long"));
         assert!(source.contains("scalars[scalar_offset + 27] = fills_active_days_count"));
+        assert!(source.contains("const bool collect_coin_fill_counts = run_settings[6] > 0.5f"));
+        assert!(source.contains("device float* coin_fill_counts"));
+        assert_eq!(
+            source
+                .matches("coin_fill_counts[int(b) * C + c] += 1.0f")
+                .count(),
+            2
+        );
         assert!(source.contains("close_tick[c] <= fill_ticks[tick_offset + 0]"));
         assert!(source.contains("entry_tick[c] > fill_ticks[tick_offset + 1]"));
         assert!(source.contains("const float volume_drop = clamp(params[po + 14]"));
@@ -292,6 +300,14 @@ mod tests {
         assert!(source.contains("scalars[scalar_offset + 25] = fill_count_entry"));
         assert!(source.contains("scalars[scalar_offset + 26] = fill_count_long"));
         assert!(source.contains("scalars[scalar_offset + 27] = fills_active_days_count"));
+        assert!(source.contains("const bool collect_coin_fill_counts = run_settings[6] > 0.5f"));
+        assert!(source.contains("device float* coin_fill_counts"));
+        assert_eq!(
+            source
+                .matches("coin_fill_counts[int(b) * C + c] += 1.0f")
+                .count(),
+            4
+        );
         assert!(source.contains("coin_wel_enforcer_enabled"));
         assert!(source.contains("coin_wel_enforcer_threshold"));
         assert!(source.contains("twel_enforcer_enabled"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -205,6 +205,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
     device float* daily,
     device float* scalars,
     device int* gap_hist,
+    device float* coin_fill_counts,
     uint b,
     bool short_side
 ) {
@@ -216,7 +217,13 @@ inline void passivbot_ema_anchor_multicoin_impl(
     const int global_warmup = sizes[5];
     const int start_day_minute = sizes[6];
     const int start_hour_minute = sizes[7];
+    const bool collect_coin_fill_counts = run_settings[6] > 0.5f;
     if (b >= uint(B)) return;
+    if (collect_coin_fill_counts) {
+        for (int c = 0; c < C; ++c) {
+            coin_fill_counts[int(b) * C + c] = 0.0f;
+        }
+    }
 
     const int po = int(b) * PARAM_COLS;
     const float base_qty_pct = params[po + 0];
@@ -529,6 +536,9 @@ inline void passivbot_ema_anchor_multicoin_impl(
                     day_fill_count, fill_count, fill_count_entry, fill_count_long,
                     false, !short_side
                 );
+                if (collect_coin_fill_counts) {
+                    coin_fill_counts[int(b) * C + c] += 1.0f;
+                }
                 float new_size = fmax(round_step(psize[c] - adjusted, qty_step), 0.0f);
                 bool went_flat = new_size <= 0.0f;
                 psize[c] = new_size;
@@ -568,6 +578,9 @@ inline void passivbot_ema_anchor_multicoin_impl(
                     day_fill_count, fill_count, fill_count_entry, fill_count_long,
                     true, !short_side
                 );
+                if (collect_coin_fill_counts) {
+                    coin_fill_counts[int(b) * C + c] += 1.0f;
+                }
                 float new_size = round_step(psize[c] + adjusted, qty_step);
                 float new_price = was_flat ? fill_price
                     : pprice[c] * (psize[c] / fmax(new_size, 1.0e-12f))
@@ -1570,12 +1583,13 @@ kernel void passivbot_ema_anchor_multicoin(
     device float* daily,
     device float* scalars,
     device int* gap_hist,
+    device float* coin_fill_counts,
     uint b [[thread_position_in_grid]]
 ) {
     const bool short_side = run_settings[3] > 0.5f;
     passivbot_ema_anchor_multicoin_impl(
         bars, fill_ticks, touch_ticks, coin_settings, coin_overrides, params, run_settings,
-        sizes, daily, scalars, gap_hist, b, short_side
+        sizes, daily, scalars, gap_hist, coin_fill_counts, b, short_side
     );
 }
 
@@ -1591,10 +1605,11 @@ kernel void passivbot_ema_anchor_multicoin_long(
     device float* daily,
     device float* scalars,
     device int* gap_hist,
+    device float* coin_fill_counts,
     uint b [[thread_position_in_grid]]
 ) {
     passivbot_ema_anchor_multicoin_impl(
         bars, fill_ticks, touch_ticks, coin_settings, coin_overrides, params, run_settings,
-        sizes, daily, scalars, gap_hist, b, false
+        sizes, daily, scalars, gap_hist, coin_fill_counts, b, false
     );
 }

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -433,6 +433,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     device float* daily,
     device float* scalars,
     device int* gap_hist,
+    device float* coin_fill_counts,
     uint b,
     bool short_side
 ) {
@@ -444,7 +445,13 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     const int global_warmup = sizes[5];
     const int start_day_minute = sizes[6];
     const int start_hour_minute = sizes[7];
+    const bool collect_coin_fill_counts = run_settings[6] > 0.5f;
     if (b >= uint(B)) return;
+    if (collect_coin_fill_counts) {
+        for (int c = 0; c < C; ++c) {
+            coin_fill_counts[int(b) * C + c] = 0.0f;
+        }
+    }
 
     const int po = int(b) * PARAM_COLS;
     const float span_a = params[po + 0];
@@ -977,6 +984,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                                 day_fill_count, fill_count, fill_count_entry,
                                 fill_count_long, false, !short_side
                             );
+                            if (collect_coin_fill_counts) {
+                                coin_fill_counts[int(b) * C + c] += 1.0f;
+                            }
                             psize[c] = fmax(
                                 round_step(psize[c] - qty, qty_step), 0.0f
                             );
@@ -1013,6 +1023,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                         day_fill_count, fill_count, fill_count_entry,
                         fill_count_long, false, !short_side
                     );
+                    if (collect_coin_fill_counts) {
+                        coin_fill_counts[int(b) * C + c] += 1.0f;
+                    }
                     psize[c] = fmax(
                         round_step(psize[c] - grid_qty, qty_step), 0.0f
                     );
@@ -1063,6 +1076,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                         day_fill_count, fill_count, fill_count_entry,
                         fill_count_long, false, !short_side
                     );
+                    if (collect_coin_fill_counts) {
+                        coin_fill_counts[int(b) * C + c] += 1.0f;
+                    }
                     psize[c] = fmax(
                         round_step(psize[c] - qty, qty_step), 0.0f
                     );
@@ -1107,6 +1123,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     day_fill_count, fill_count, fill_count_entry,
                     fill_count_long, true, !short_side
                 );
+                if (collect_coin_fill_counts) {
+                    coin_fill_counts[int(b) * C + c] += 1.0f;
+                }
                 float new_size = round_step(psize[c] + adjusted, qty_step);
                 float new_price = was_flat ? fill_price
                     : pprice[c] * (psize[c] / fmax(new_size, 1.0e-12f))
@@ -2385,6 +2404,7 @@ kernel void passivbot_trailing_martingale_multicoin(
     device float* daily,
     device float* scalars,
     device int* gap_hist,
+    device float* coin_fill_counts,
     uint b [[thread_position_in_grid]]
 ) {
     const bool short_side = run_settings[3] > 0.5f;
@@ -2392,7 +2412,7 @@ kernel void passivbot_trailing_martingale_multicoin(
         bars, fill_ticks, touch_ticks, touch_nearest_ticks,
         touch_min_qty_bits, touch_min_qty_relation, coin_settings,
         coin_overrides, params, run_settings,
-        sizes, daily, scalars, gap_hist, b, short_side
+        sizes, daily, scalars, gap_hist, coin_fill_counts, b, short_side
     );
 }
 
@@ -2411,12 +2431,13 @@ kernel void passivbot_trailing_martingale_multicoin_long(
     device float* daily,
     device float* scalars,
     device int* gap_hist,
+    device float* coin_fill_counts,
     uint b [[thread_position_in_grid]]
 ) {
     passivbot_trailing_martingale_multicoin_impl(
         bars, fill_ticks, touch_ticks, touch_nearest_ticks,
         touch_min_qty_bits, touch_min_qty_relation, coin_settings,
         coin_overrides, params, run_settings,
-        sizes, daily, scalars, gap_hist, b, false
+        sizes, daily, scalars, gap_hist, coin_fill_counts, b, false
     );
 }

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -66,6 +66,7 @@ SUPPORTED_METRICS = (
     "fills_analysis_duration_days",
     "fills_active_days_count",
     "fills_active_days_ratio",
+    "fills_active_symbols_count",
     "fills_count",
     "fills_count_close",
     "fills_count_entry",
@@ -85,6 +86,7 @@ SUPPORTED_METRICS = (
     "fills_per_day_per_position_slot_long",
     "fills_per_day_per_position_slot_short",
     "fills_per_day_short",
+    "fills_top_symbol_share",
     "gain_strategy_eq",
     "hard_stop_duration_minutes_max",
     "hard_stop_duration_minutes_mean",
@@ -163,6 +165,7 @@ _FILL_ACTIVITY_METRICS = {
     "fills_analysis_duration_days",
     "fills_active_days_count",
     "fills_active_days_ratio",
+    "fills_active_symbols_count",
     "fills_count",
     "fills_count_close",
     "fills_count_entry",
@@ -177,6 +180,7 @@ _FILL_ACTIVITY_METRICS = {
     "fills_per_day_per_position_slot_long",
     "fills_per_day_per_position_slot_short",
     "fills_per_day_short",
+    "fills_top_symbol_share",
 }
 
 
@@ -711,6 +715,17 @@ def _fill_activity_metrics(out: dict, run, requested: set[str]) -> dict:
     fills_count_close = (fill_count - fills_count_entry).clamp(min=0.0)
     fills_count_short = (fill_count - fills_count_long).clamp(min=0.0)
     fills_active_days_count = out["fills_active_days_count"].to(torch.float64)
+    coin_fill_counts = out.get("coin_fill_counts")
+    if coin_fill_counts is None:
+        coin_fill_counts = fill_count.unsqueeze(1)
+    else:
+        coin_fill_counts = coin_fill_counts.to(torch.float64)
+    fills_active_symbols_count = (coin_fill_counts > 0.0).sum(dim=1).to(torch.float64)
+    fills_top_symbol_share = torch.where(
+        fill_count > 0.0,
+        coin_fill_counts.max(dim=1).values / fill_count.clamp(min=1.0),
+        torch.zeros_like(fill_count),
+    )
     first_eq_ts = out["first_eq_ts"].to(torch.float64)
     last_eq_ts = out["last_eq_ts"].to(torch.float64)
     has_span = (
@@ -751,6 +766,7 @@ def _fill_activity_metrics(out: dict, run, requested: set[str]) -> dict:
         "fills_active_days_count": fills_active_days_count,
         "fills_active_days_ratio": fills_active_days_count
         / duration_days.ceil().clamp(min=1.0),
+        "fills_active_symbols_count": fills_active_symbols_count,
         "fills_analysis_duration_days": duration_days,
         "fills_count": fill_count,
         "fills_count_close": fills_count_close,
@@ -764,6 +780,7 @@ def _fill_activity_metrics(out: dict, run, requested: set[str]) -> dict:
         "fills_per_day_entry": fills_per_day_entry,
         "fills_per_day_long": fills_per_day_long,
         "fills_per_day_short": fills_per_day_short,
+        "fills_top_symbol_share": fills_top_symbol_share,
     }
     slot_metrics = {
         "fills_per_day_per_position_slot",

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -429,12 +429,14 @@ class MpsEmaAnchorMulticoinRunner:
         coin_overrides: np.ndarray | None = None,
         forager_score_hysteresis_pct: float = 0.0,
         max_realized_loss_pct: float = 1.0,
+        collect_coin_fill_counts: bool = False,
     ):
         if side not in {"long", "short"}:
             raise ValueError(
                 f"MPS multicoin runner side must be long or short, got {side!r}"
             )
         self.side = side
+        self.collect_coin_fill_counts = bool(collect_coin_fill_counts)
         self.run_config = run
         self.n = int(data["n"])
         self.n_coins = int(data["n_coins"])
@@ -486,11 +488,12 @@ class MpsEmaAnchorMulticoinRunner:
                 float(side == "short"),
                 forager_score_hysteresis_pct,
                 encoded_max_realized_loss_pct,
+                float(self.collect_coin_fill_counts),
             ],
             dtype=torch.float32,
             device="mps",
         )
-        self._buffers: dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = {}
+        self._buffers: dict[int, tuple[torch.Tensor, ...]] = {}
         self._sizes: dict[tuple[int, int], torch.Tensor] = {}
         self.last_profile: dict[str, float] = {}
         self.start_minute_of_day = int(data["start_minute_of_day"])
@@ -529,6 +532,13 @@ class MpsEmaAnchorMulticoinRunner:
                     torch.zeros(
                         (batch_size, GAP_BINS), dtype=torch.int32, device="mps"
                     ),
+                    torch.zeros(
+                        (batch_size, self.n_coins)
+                        if self.collect_coin_fill_counts
+                        else (1,),
+                        dtype=torch.float32,
+                        device="mps",
+                    ),
                 )
             }
         else:
@@ -544,7 +554,7 @@ class MpsEmaAnchorMulticoinRunner:
         packed = time.perf_counter()
         params_mps = torch.as_tensor(matrix, device="mps")
         batch_size = int(matrix.shape[0])
-        daily, scalars, gaps = self._output_buffers(batch_size)
+        daily, scalars, gaps, coin_fill_counts = self._output_buffers(batch_size)
         sizes_key = (batch_size, int(matrix.shape[1]))
         if sizes_key not in self._sizes:
             self._sizes[sizes_key] = torch.tensor(
@@ -581,6 +591,7 @@ class MpsEmaAnchorMulticoinRunner:
             daily,
             scalars,
             gaps,
+            coin_fill_counts,
             threads=(batch_size, 1, 1),
         )
         if profile:
@@ -593,7 +604,10 @@ class MpsEmaAnchorMulticoinRunner:
             "pre_dispatch_sync_seconds": dispatched - compiled,
             "kernel_seconds": finished - dispatched,
         }
-        return _decode_outputs(daily, scalars, gaps)
+        output = _decode_outputs(daily, scalars, gaps)
+        if self.collect_coin_fill_counts:
+            output["coin_fill_counts"] = coin_fill_counts
+        return output
 
 
 class MpsEmaAnchorMulticoinLongRunner(MpsEmaAnchorMulticoinRunner):
@@ -625,6 +639,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
         coin_overrides: np.ndarray | None = None,
         forager_score_hysteresis_pct: float = 0.0,
         max_realized_loss_pct: float = 1.0,
+        collect_coin_fill_counts: bool = False,
     ):
         super().__init__(
             run,
@@ -633,6 +648,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             coin_overrides=coin_overrides,
             forager_score_hysteresis_pct=forager_score_hysteresis_pct,
             max_realized_loss_pct=max_realized_loss_pct,
+            collect_coin_fill_counts=collect_coin_fill_counts,
         )
 
     def _pack_params(self, params: np.ndarray) -> np.ndarray:
@@ -651,7 +667,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
         packed = time.perf_counter()
         params_mps = torch.as_tensor(matrix, device="mps")
         batch_size = int(matrix.shape[0])
-        daily, scalars, gaps = self._output_buffers(batch_size)
+        daily, scalars, gaps, coin_fill_counts = self._output_buffers(batch_size)
         sizes_key = (batch_size, int(matrix.shape[1]))
         if sizes_key not in self._sizes:
             self._sizes[sizes_key] = torch.tensor(
@@ -691,6 +707,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             daily,
             scalars,
             gaps,
+            coin_fill_counts,
             threads=(batch_size, 1, 1),
         )
         if profile:
@@ -703,7 +720,10 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             "pre_dispatch_sync_seconds": dispatched - compiled,
             "kernel_seconds": finished - dispatched,
         }
-        return _decode_outputs(daily, scalars, gaps)
+        output = _decode_outputs(daily, scalars, gaps)
+        if self.collect_coin_fill_counts:
+            output["coin_fill_counts"] = coin_fill_counts
+        return output
 
 
 class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -35,6 +35,7 @@ CORE_OUTPUT_KEYS = {
     "fill_count_entry",
     "fill_count_long",
     "fills_active_days_count",
+    "coin_fill_counts",
     "day_min_balance",
     "max_dd",
     "held_max_ms",
@@ -91,6 +92,7 @@ _DUAL_SIDE_MULTICOIN_INTRADAY_CUTOFF_METRICS = {
     "fills_analysis_duration_days",
     "fills_active_days_count",
     "fills_active_days_ratio",
+    "fills_active_symbols_count",
     "fills_count",
     "fills_count_close",
     "fills_count_entry",
@@ -105,6 +107,7 @@ _DUAL_SIDE_MULTICOIN_INTRADAY_CUTOFF_METRICS = {
     "fills_per_day_per_position_slot_long",
     "fills_per_day_per_position_slot_short",
     "fills_per_day_short",
+    "fills_top_symbol_share",
     "mdg_pnl",
     "mdg_pnl_w",
     "sharpe_ratio_pnl",
@@ -1380,6 +1383,10 @@ class MpsMulticoinProxy:
                 "forager_score_hysteresis_pct": self.forager_score_hysteresis_pct,
                 "max_realized_loss_pct": float(
                     backtest_params.get("max_realized_loss_pct", 1.0)
+                ),
+                "collect_coin_fill_counts": bool(
+                    self.needed_metrics
+                    & {"fills_active_symbols_count", "fills_top_symbol_share"}
                 ),
             }
             runner_kwargs["coin_overrides"] = per_side_coin_overrides[side]

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -46,11 +46,18 @@ def test_fill_activity_ratio_recovers_integer_steps_at_whole_day_boundary():
             "last_eq_ts": torch.tensor([last_ts]),
         },
         SimpleNamespace(interval_ms=60_000),
-        {"fills_active_days_ratio", "fills_analysis_duration_days"},
+        {
+            "fills_active_days_ratio",
+            "fills_active_symbols_count",
+            "fills_analysis_duration_days",
+            "fills_top_symbol_share",
+        },
     )
 
     assert metrics["fills_analysis_duration_days"].item() == 1.0
     assert metrics["fills_active_days_ratio"].item() == 1.0
+    assert metrics["fills_active_symbols_count"].item() == 1.0
+    assert metrics["fills_top_symbol_share"].item() == 1.0
 
 
 def test_loss_profit_ratio_matches_rust_cap_and_neutral_contract():
@@ -80,6 +87,7 @@ def test_fill_activity_metrics_match_rust_full_timestamp_span_contract():
         "fill_count_entry": torch.tensor([3.0, 0.0]),
         "fill_count_long": torch.tensor([4.0, 0.0]),
         "fills_active_days_count": torch.tensor([2.0, 0.0]),
+        "coin_fill_counts": torch.tensor([[4.0, 1.0], [0.0, 0.0]]),
         "position_slots_long": torch.tensor([2.0, 1.0]),
         "position_slots_short": torch.tensor([1.0, 0.0]),
         "max_dd": torch.zeros(2),
@@ -98,6 +106,7 @@ def test_fill_activity_metrics_match_rust_full_timestamp_span_contract():
     requested = {
         "fills_active_days_count",
         "fills_active_days_ratio",
+        "fills_active_symbols_count",
         "fills_analysis_duration_days",
         "fills_count",
         "fills_count_close",
@@ -113,6 +122,7 @@ def test_fill_activity_metrics_match_rust_full_timestamp_span_contract():
         "fills_per_day_per_position_slot_long",
         "fills_per_day_per_position_slot_short",
         "fills_per_day_short",
+        "fills_top_symbol_share",
     }
 
     metrics = compute_objectives(
@@ -133,6 +143,8 @@ def test_fill_activity_metrics_match_rust_full_timestamp_span_contract():
     assert metrics["fills_active_days_ratio"].tolist() == pytest.approx(
         [2.0 / 3.0, 0.0]
     )
+    assert metrics["fills_active_symbols_count"].tolist() == [2.0, 0.0]
+    assert metrics["fills_top_symbol_share"].tolist() == pytest.approx([0.8, 0.0])
     assert metrics["fills_count"].tolist() == [5.0, 0.0]
     assert metrics["fills_count_entry"].tolist() == [3.0, 0.0]
     assert metrics["fills_count_close"].tolist() == [2.0, 0.0]

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -134,6 +134,7 @@ def _multicoin_exposure_fixture(
     max_realized_loss_pct=1.0,
     first_valid_indices=(0, 0),
     liquidation_threshold=0.05,
+    collect_coin_fill_counts=False,
 ):
     coin_count = 2
     timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
@@ -210,6 +211,7 @@ def _multicoin_exposure_fixture(
             side=side,
             coin_overrides=coin_overrides,
             max_realized_loss_pct=max_realized_loss_pct,
+            collect_coin_fill_counts=collect_coin_fill_counts,
         )
     else:
         values = {
@@ -264,6 +266,7 @@ def _multicoin_exposure_fixture(
             side=side,
             coin_overrides=coin_overrides,
             max_realized_loss_pct=max_realized_loss_pct,
+            collect_coin_fill_counts=collect_coin_fill_counts,
         )
     return runner, row
 
@@ -279,6 +282,7 @@ def test_mps_multicoin_tracks_position_unchanged_max(strategy_kind, side):
     output = runner.run(np.asarray([row], dtype=np.float64))
     torch.mps.synchronize()
 
+    assert "coin_fill_counts" not in output
     unchanged_ms = output["position_unchanged_max_ms"].item()
     assert unchanged_ms > 0.0
     assert unchanged_ms <= output["held_max_ms"].item()
@@ -333,6 +337,26 @@ def test_mps_multicoin_active_fill_days_use_equity_start_buckets(
     ).item() / 86_400_000.0
     assert output["fills_active_days_count"].item() == int(np.ceil(duration_days))
     assert output["fills_active_days_count"].item() >= 3.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_multicoin_tracks_fill_counts_by_symbol(strategy_kind, side):
+    runner, row = _multicoin_exposure_fixture(
+        strategy_kind, side, count=32, collect_coin_fill_counts=True
+    )
+
+    output = runner.run(np.asarray([row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    coin_counts = output["coin_fill_counts"]
+    assert coin_counts.shape == (1, 2)
+    assert torch.equal(coin_counts, coin_counts.round())
+    assert (coin_counts > 0.0).all()
+    assert coin_counts.sum().item() == output["fill_count"].item()
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -51,6 +51,7 @@ def test_core_output_contract_retains_gross_pnl_aggregates():
         "fill_count_entry",
         "fill_count_long",
         "fills_active_days_count",
+        "coin_fill_counts",
     } <= CORE_OUTPUT_KEYS
 
 
@@ -62,6 +63,7 @@ def test_core_output_contract_retains_gross_pnl_aggregates():
         "fills_analysis_duration_days",
         "fills_active_days_count",
         "fills_active_days_ratio",
+        "fills_active_symbols_count",
         "fills_count",
         "fills_count_close",
         "fills_count_entry",
@@ -76,6 +78,7 @@ def test_core_output_contract_retains_gross_pnl_aggregates():
         "fills_per_day_per_position_slot_long",
         "fills_per_day_per_position_slot_short",
         "fills_per_day_short",
+        "fills_top_symbol_share",
         "mdg_pnl",
         "mdg_pnl_w",
         "sharpe_ratio_pnl",


### PR DESCRIPTION
## Summary
- add Apple MPS proxy support for fills_active_symbols_count and fills_top_symbol_share
- collect per-symbol fill counts only when either metric is requested
- support single-coin and one-sided multi-coin EMA Anchor and Trailing Martingale while preserving the existing fail-closed dual-side multi-coin boundary
- keep exact Rust validation authoritative

## Validation
- full non-MPS optimizer pytest suite
- 262 Rust tests; no-default-features and default-feature test checks
- full physical Apple MPS suite: 212 passed
- focused exact-artifact physical MPS rerun: 8 passed across EMA Anchor and Trailing Martingale, long and short, with collection enabled and disabled
- bounded two-coin end-to-end MPS optimizer smokes: 1,024 proxy and 64 exact evaluations for each strategy, completed without drift or constraint halts
- Rust extension source fingerprint verified against the loaded compiled artifact
- AI docs check: 0 errors (2 pre-existing size warnings); generated registry current; docs tests passed