### PR TITLE
feat(optimize): add MPS equity shape metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added daily account-equity choppiness, jerkiness, and exponential-fit-error scoring and limits
+  to Apple MPS optimization. The proxy applies the exact Rust formulas to its existing active daily
+  closing-equity surface for supported EMA Anchor and Trailing Martingale topologies.
+
 - Added peak-recovery day/hour scoring for strategy equity and realized PnL to Apple MPS
   optimization for single-coin and one-sided multi-coin EMA Anchor and Trailing Martingale runs.
   Metal tracks realized-PnL recovery intervals per candidate while exact Rust validation remains

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -203,6 +203,9 @@ The supported slice is intentionally narrow:
   supported for both long and short sides. The proxy divides the matching validated equity metric
   by each candidate's effective side `total_wallet_exposure_limit`, after applying any exact-last
   suite override, and returns zero for a zero-exposure side as the CPU analysis does
+- canonical USD `equity_choppiness`, `equity_jerkiness`, and `exponential_fit_error` scoring and
+  limits use the proxy's active daily closing-equity samples and the exact Rust formulas. Candidates
+  without fills retain Rust's default value of `1.0` for all three metrics
 - Trailing Martingale supports `risk.position_exposure_enforcer_enabled` and a tunable
   `risk.position_exposure_enforcer_threshold` for single- and multi-coin long, short, dual-side,
   and compatible suite runs. When current position exposure exceeds the allowance-adjusted WEL
@@ -325,6 +328,8 @@ position-unchanged duration, initial-entry balance percentage for each side, vol
 total-wallet-exposure maximum and mean, USD exposure ratios, backtest completion, and weighted
 variants of ADG, MDG, Sharpe, Sortino, Omega, Calmar, and Sterling. With BTC collateral disabled,
 the corresponding canonical USD account-equity names share this strategy-equity surface.
+Daily USD equity choppiness, jerkiness, and exponential fit error are reduced from that same active
+daily closing-equity surface with Rust's no-fill defaults and short-series behavior.
 Collateral-agnostic `adg_pnl`, `mdg_pnl`, `sharpe_ratio_pnl`, and `sortino_ratio_pnl` are also
 supported for single-coin and one-sided multi-coin runs. Metal groups realized balance changes by
 UTC fill day and divides by that day's last fill balance, matching exact Rust's unweighted daily

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -355,19 +355,21 @@ def _equity_shape_metrics(day_eq, active):
             "exponential_fit_error_usd": torch.full_like(zeros, float("inf")),
         }
 
-    counts = active.sum(dim=1)
     indices = (
         torch.arange(day_count, device=day_eq.device)
         .unsqueeze(0)
         .expand(batch_size, day_count)
     )
-    first_index = torch.where(
-        active, indices, torch.full_like(indices, day_count)
-    ).min(dim=1).values.clamp(max=day_count - 1)
-    last_index = torch.where(active, indices, torch.full_like(indices, -1)).max(
-        dim=1
-    ).values.clamp(min=0)
-    first = day_eq.gather(1, first_index.unsqueeze(1)).squeeze(1)
+    counts = active.sum(dim=1)
+    # Rust builds a compact Vec of touched UTC-day closes. Preserve that order
+    # when an entirely invalid day leaves a hole in the fixed proxy surface.
+    compact_order = torch.argsort(
+        torch.where(active, indices, indices + day_count), dim=1
+    )
+    day_eq = day_eq.gather(1, compact_order)
+    active = indices < counts.unsqueeze(1)
+    first = day_eq[:, 0]
+    last_index = (counts - 1).clamp(min=0)
     last = day_eq.gather(1, last_index.unsqueeze(1)).squeeze(1)
 
     adjacent = active[:, :-1] & active[:, 1:]

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -58,9 +58,12 @@ SUPPORTED_METRICS = (
     "calmar_ratio_strategy_eq_w",
     "drawdown_worst_mean_1pct_strategy_eq",
     "drawdown_worst_strategy_eq",
+    "equity_choppiness_usd",
+    "equity_jerkiness_usd",
     "expected_shortfall_1pct_strategy_eq",
     "entry_initial_balance_pct_long",
     "entry_initial_balance_pct_short",
+    "exponential_fit_error_usd",
     "exposure_mean_ratio_usd",
     "exposure_ratio_usd",
     "fills_analysis_duration_days",
@@ -338,6 +341,106 @@ def _smoothed_gain_adg(day_eq, active):
 
 def _smoothed_adg(day_eq, active):
     return _smoothed_gain_adg(day_eq, active)[1]
+
+
+def _equity_shape_metrics(day_eq, active):
+    """Match Rust's shape metrics over active daily closing equity samples."""
+
+    batch_size, day_count = day_eq.shape
+    zeros = torch.zeros(batch_size, dtype=day_eq.dtype, device=day_eq.device)
+    if day_count == 0:
+        return {
+            "equity_choppiness_usd": zeros,
+            "equity_jerkiness_usd": zeros,
+            "exponential_fit_error_usd": torch.full_like(zeros, float("inf")),
+        }
+
+    counts = active.sum(dim=1)
+    indices = (
+        torch.arange(day_count, device=day_eq.device)
+        .unsqueeze(0)
+        .expand(batch_size, day_count)
+    )
+    first_index = torch.where(
+        active, indices, torch.full_like(indices, day_count)
+    ).min(dim=1).values.clamp(max=day_count - 1)
+    last_index = torch.where(active, indices, torch.full_like(indices, -1)).max(
+        dim=1
+    ).values.clamp(min=0)
+    first = day_eq.gather(1, first_index.unsqueeze(1)).squeeze(1)
+    last = day_eq.gather(1, last_index.unsqueeze(1)).squeeze(1)
+
+    adjacent = active[:, :-1] & active[:, 1:]
+    variation = torch.where(
+        adjacent,
+        (day_eq[:, 1:] - day_eq[:, :-1]).abs(),
+        torch.zeros_like(day_eq[:, 1:]),
+    ).sum(dim=1)
+    net_gain = (last - first).abs()
+    epsilon = torch.finfo(day_eq.dtype).eps
+    choppiness = torch.where(
+        counts < 2,
+        zeros,
+        torch.where(
+            net_gain < epsilon,
+            torch.full_like(zeros, float("inf")),
+            variation / net_gain.clamp(min=epsilon),
+        ),
+    )
+
+    if day_count < 3:
+        jerkiness = zeros
+    else:
+        triples = active[:, :-2] & active[:, 1:-1] & active[:, 2:]
+        numerator = (
+            day_eq[:, 2:] - 2.0 * day_eq[:, 1:-1] + day_eq[:, :-2]
+        ).abs()
+        denominator = (
+            day_eq[:, :-2] + day_eq[:, 1:-1] + day_eq[:, 2:]
+        ) / 3.0
+        terms = torch.where(
+            triples & (denominator.abs() >= epsilon),
+            numerator / denominator.abs().clamp(min=epsilon),
+            torch.zeros_like(numerator),
+        )
+        jerkiness = terms.sum(dim=1) / (counts - 2).clamp(min=1).to(day_eq.dtype)
+        jerkiness = torch.where(counts >= 3, jerkiness, zeros)
+
+    ordinal = active.cumsum(dim=1).to(day_eq.dtype) - 1.0
+    count_float = counts.to(day_eq.dtype)
+    safe_equity = torch.where(
+        active, day_eq.clamp(min=epsilon), torch.ones_like(day_eq)
+    )
+    log_equity = torch.where(active, safe_equity.log(), torch.zeros_like(day_eq))
+    x = torch.where(active, ordinal, torch.zeros_like(ordinal))
+    sum_x = x.sum(dim=1)
+    sum_y = log_equity.sum(dim=1)
+    sum_xx = (x * x).sum(dim=1)
+    sum_xy = (x * log_equity).sum(dim=1)
+    fit_denominator = count_float * sum_xx - sum_x * sum_x
+    safe_fit_denominator = torch.where(
+        fit_denominator != 0.0, fit_denominator, torch.ones_like(fit_denominator)
+    )
+    slope = (count_float * sum_xy - sum_x * sum_y) / safe_fit_denominator
+    intercept = (sum_y - slope * sum_x) / count_float.clamp(min=1.0)
+    residual = slope.unsqueeze(1) * x + intercept.unsqueeze(1) - log_equity
+    fit_error = torch.where(
+        active, residual * residual, torch.zeros_like(residual)
+    ).sum(dim=1) / count_float.clamp(min=1.0)
+    invalid_fit = (
+        (counts < 2)
+        | (fit_denominator == 0.0)
+        | (active & (day_eq <= 0.0)).any(dim=1)
+    )
+    fit_error = torch.where(
+        invalid_fit, torch.full_like(fit_error, float("inf")), fit_error
+    )
+
+    return {
+        "equity_choppiness_usd": choppiness,
+        "equity_jerkiness_usd": jerkiness,
+        "exponential_fit_error_usd": fit_error,
+    }
 
 
 def _sharpe_sortino(changes, mask, adg):
@@ -1032,6 +1135,19 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
         run.interval_ms,
         requested_sources,
     )
+    shape_metric_names = {
+        "equity_choppiness_usd",
+        "equity_jerkiness_usd",
+        "exponential_fit_error_usd",
+    }
+    equity_shape_metrics = {}
+    if requested & shape_metric_names:
+        equity_shape_metrics = _equity_shape_metrics(day_end_eq, active)
+        has_fills = out["fill_count"].to(torch.float64) > 0.0
+        for name, value in equity_shape_metrics.items():
+            equity_shape_metrics[name] = torch.where(
+                has_fills, value, torch.ones_like(value)
+            )
 
     underwater = torch.where(active, day_max_dd, torch.zeros_like(day_max_dd)).sum(
         dim=1
@@ -1211,6 +1327,7 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
     objectives.update(hard_stop_panic_loss_metrics)
     objectives.update(weighted_metrics)
     objectives.update(weighted_pnl_metrics)
+    objectives.update(equity_shape_metrics)
     for name, (source, side) in _USD_PER_EXPOSURE_METRICS.items():
         if name not in requested:
             continue

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -79,6 +79,7 @@ def test_equity_shape_metrics_match_rust_daily_series_contract():
             [100.0, 110.0, float("inf"), float("inf")],
             [100.0, 0.0, 110.0, float("inf")],
             [100.0, float("inf"), float("inf"), float("inf")],
+            [100.0, float("inf"), 110.0, 90.0],
         ],
         dtype=torch.float64,
     )
@@ -104,6 +105,8 @@ def test_equity_shape_metrics_match_rust_daily_series_contract():
     assert metrics["equity_choppiness_usd"][4].item() == 0.0
     assert metrics["equity_jerkiness_usd"][4].item() == 0.0
     assert math.isinf(metrics["exponential_fit_error_usd"][4].item())
+    assert metrics["equity_choppiness_usd"][5].item() == pytest.approx(3.0)
+    assert metrics["equity_jerkiness_usd"][5].item() == pytest.approx(0.3)
 
 
 def test_equity_shape_metrics_use_rust_defaults_without_fills():

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -10,6 +10,7 @@ torch = pytest.importorskip("torch")
 from optimization.gpu.metrics import (
     SUPPORTED_METRICS,
     _GAP_HIST_UPPER_STEPS,
+    _equity_shape_metrics,
     _fill_activity_metrics,
     _fill_gap_metrics,
     _hard_stop_lifecycle_metrics,
@@ -68,6 +69,86 @@ def test_loss_profit_ratio_matches_rust_cap_and_neutral_contract():
 
     assert actual.tolist() == [0.25, 1_000.0, 1.0, 1_000.0]
     assert "loss_profit_ratio" in SUPPORTED_METRICS
+
+
+def test_equity_shape_metrics_match_rust_daily_series_contract():
+    day_eq = torch.tensor(
+        [
+            [100.0, 110.0, 90.0, 120.0],
+            [100.0, 100.0, 100.0, 100.0],
+            [100.0, 110.0, float("inf"), float("inf")],
+            [100.0, 0.0, 110.0, float("inf")],
+            [100.0, float("inf"), float("inf"), float("inf")],
+        ],
+        dtype=torch.float64,
+    )
+    active = torch.isfinite(day_eq)
+
+    metrics = _equity_shape_metrics(day_eq, active)
+
+    assert metrics["equity_choppiness_usd"][0].item() == pytest.approx(3.0)
+    assert metrics["equity_jerkiness_usd"][0].item() == pytest.approx(
+        (0.3 + 0.46875) / 2.0
+    )
+    log_equity = np.log(np.array([100.0, 110.0, 90.0, 120.0]))
+    x = np.arange(4, dtype=float)
+    slope, intercept = np.polyfit(x, log_equity, 1)
+    expected_fit_error = np.mean((slope * x + intercept - log_equity) ** 2)
+    assert metrics["exponential_fit_error_usd"][0].item() == pytest.approx(
+        expected_fit_error
+    )
+    assert math.isinf(metrics["equity_choppiness_usd"][1].item())
+    assert metrics["equity_jerkiness_usd"][2].item() == 0.0
+    assert metrics["exponential_fit_error_usd"][2].item() == pytest.approx(0.0)
+    assert math.isinf(metrics["exponential_fit_error_usd"][3].item())
+    assert metrics["equity_choppiness_usd"][4].item() == 0.0
+    assert metrics["equity_jerkiness_usd"][4].item() == 0.0
+    assert math.isinf(metrics["exponential_fit_error_usd"][4].item())
+
+
+def test_equity_shape_metrics_use_rust_defaults_without_fills():
+    day_eq = torch.tensor([[100.0, 110.0, 90.0]], dtype=torch.float64)
+    out = {
+        "day_end_eq": day_eq,
+        "day_min_eq": day_eq.clone(),
+        "day_max_dd": torch.zeros_like(day_eq),
+        "day_volume": torch.zeros_like(day_eq),
+        "day_has_fill": torch.zeros_like(day_eq, dtype=torch.bool),
+        "fill_count": torch.zeros(1),
+        "max_dd": torch.zeros(1),
+        "held_max_ms": torch.zeros(1),
+        "gap_hist": torch.zeros((1, 128), dtype=torch.int32),
+        "gap_max_ms": torch.zeros(1),
+        "first_fill_ts": torch.full((1,), float("nan")),
+        "last_fill_ts": torch.full((1,), float("nan")),
+        "recovery_max_ms": torch.zeros(1),
+        "last_high_ts": torch.tensor([2 * 86_400_000.0]),
+        "first_eq_ts": torch.tensor([0.0]),
+        "last_eq_ts": torch.tensor([2 * 86_400_000.0]),
+        "liq_step": torch.tensor([-1]),
+    }
+    requested = {
+        "equity_choppiness_usd",
+        "equity_jerkiness_usd",
+        "exponential_fit_error_usd",
+    }
+
+    metrics = compute_objectives(
+        out,
+        SimpleNamespace(
+            requested_start_ts_ms=0,
+            guard_ts_ms=0,
+            interval_ms=86_400_000,
+        ),
+        {"ts0": 0.0, "n": 3},
+        needed=requested,
+    )
+
+    assert set(metrics) == requested
+    assert requested <= set(SUPPORTED_METRICS)
+    assert {name: value.item() for name, value in metrics.items()} == {
+        name: 1.0 for name in requested
+    }
 
 
 def test_fill_activity_metrics_match_rust_full_timestamp_span_contract():


### PR DESCRIPTION
## Summary

- add Apple MPS scoring and limits for `equity_choppiness_usd`, `equity_jerkiness_usd`, and `exponential_fit_error_usd`
- apply the exact Rust daily-series formulas to the existing active daily closing-equity proxy surface
- preserve Rust's short-series, non-positive-equity, flat-net-gain, inactive-tail, and no-fill defaults
- support all existing EMA Anchor and Trailing Martingale MPS topologies without changing Metal kernels or CPU behavior

## Validation

- 810 non-MPS optimizer tests passed
- 212 physical Apple MPS tests passed
- bounded cached two-coin EMA Anchor MPS optimization completed 1,024 proxy evaluations and 64 exact validations in eight generations (4.8s), with no safety halt
- bounded cached two-coin Trailing Martingale MPS optimization completed the same 1,024/64 matrix in eight generations (7.0s); broad-probe rank remained sound and no safety halt occurred
- AI documentation validation completed with zero errors and the two pre-existing repository budget warnings
- loaded Rust extension source stamp matched the current source fingerprint `629d241ddba2dbb35751053a318c0bbe55f070131cccaf8934e664bf028b471d`
