### PR TITLE
feat(optimize): add MPS directional PnL ratios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added directional close-fill PnL scoring and limits to Apple MPS optimization:
+  `loss_profit_ratio_long`, `loss_profit_ratio_short`, `pnl_ratio_long_short`, and its
+  `long_short_profit_ratio` alias. The proxy preserves long/short gross profit and loss separately
+  across supported single- and multi-coin topologies and applies exact Rust neutral/cap formulas;
+  exact Rust validation remains authoritative.
+
 - Added account-equity peak-recovery hours and days scoring and limits to Apple MPS optimization
   for single-coin and one-sided multi-coin EMA Anchor and Trailing Martingale runs. The proxy
   reuses Metal's full-resolution completed peak-to-peak recovery accumulator; exact Rust

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -350,6 +350,11 @@ multiple same-candle ladder fills, and applies Rust's full-run minimum fill coun
 rules across the same ten minute-position suffix boundaries. The compact daily surface includes
 the complete UTC day containing each suffix boundary, so exact Rust validation and drift gates
 remain authoritative for that screening approximation.
+Gross close-fill loss/profit ratios are supported both in aggregate and separately for long and
+short. `pnl_ratio_long_short` and its `long_short_profit_ratio` alias use each side's signed
+realized PnL and Rust's neutral `0.5` result when combined signed PnL is zero. Directional kernels
+retain the four gross side sums, while one-sided and dual-side multi-coin dispatches preserve the
+same side partition before reduction.
 Full-run fill activity is supported for single-coin and one-sided multi-coin topologies: analysis
 duration; total, entry, close, long, and short counts; their daily rates; entry-to-close ratio; and
 combined or side-specific per-configured-position-slot daily rates. Active fill-day count and ratio

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -42,7 +42,7 @@ mod tests {
         let source = mps_ema_anchor_source();
         assert!(source.contains("kernel void passivbot_ema_anchor"));
         assert!(source.contains("constant int DAILY_COLS = 8"));
-        assert!(source.contains("constant int SCALAR_COLS = 58"));
+        assert!(source.contains("constant int SCALAR_COLS = 62"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[so + 44] = loss_sum"));
         assert!(source.contains("scalars[so + 45] = position_unchanged_max_min * interval_ms"));
@@ -58,6 +58,8 @@ mod tests {
         assert!(source.contains("scalars[so + 55] = held_sum_min * interval_ms"));
         assert!(source.contains("scalars[so + 56] = held_count"));
         assert!(source.contains("scalars[so + 57] = account_recovery_max_min * interval_ms"));
+        assert!(source.contains("scalars[so + 58] = profit_sum_long"));
+        assert!(source.contains("scalars[so + 61] = loss_sum_short"));
         assert!(source.contains("if (eqf >= account_peak)"));
         assert!(source.contains("constant int SIDE_PARAMS = 34"));
         assert!(source.contains("struct HslState"));
@@ -186,7 +188,7 @@ mod tests {
         assert!(source.contains("struct HslState"));
         assert!(source.contains("update_hsl("));
         assert!(source.contains("try_restart_hsl("));
-        assert!(source.contains("constant int SCALAR_COLS = 58"));
+        assert!(source.contains("constant int SCALAR_COLS = 62"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[so + 44] = loss_sum"));
         assert!(source.contains("scalars[so + 45] = position_unchanged_max_min * interval_ms"));
@@ -202,6 +204,8 @@ mod tests {
         assert!(source.contains("scalars[so + 55] = held_sum_min * interval_ms"));
         assert!(source.contains("scalars[so + 56] = held_count"));
         assert!(source.contains("scalars[so + 57] = account_recovery_max_min * interval_ms"));
+        assert!(source.contains("scalars[so + 58] = profit_sum_long"));
+        assert!(source.contains("scalars[so + 61] = loss_sum_short"));
         assert!(source.contains("if (eqf >= account_peak)"));
         assert!(source.contains("hsl_tier_samples_total"));
         assert!(source.contains("h.restart_retrigger_count"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -2,7 +2,7 @@
 using namespace metal;
 
 constant int DAILY_COLS = 8;
-constant int SCALAR_COLS = 58;
+constant int SCALAR_COLS = 62;
 constant int GAP_BINS = 128;
 constant int SIDE_PARAMS = 34;
 
@@ -98,6 +98,17 @@ inline void record_gross_pnl(
 ) {
     if (pnl > 0.0f) profit_sum += pnl;
     else loss_sum += fabs(pnl);
+}
+
+inline void record_directional_gross_pnl(
+    float pnl,
+    thread float& profit_sum,
+    thread float& loss_sum,
+    thread float& side_profit_sum,
+    thread float& side_loss_sum
+) {
+    record_gross_pnl(pnl, profit_sum, loss_sum);
+    record_gross_pnl(pnl, side_profit_sum, side_loss_sum);
 }
 
 struct EmaSide {
@@ -1124,6 +1135,10 @@ inline void passivbot_single_coin_impl(
     float pnl_recovery_max_min = 0.0f;
     float profit_sum = 0.0f;
     float loss_sum = 0.0f;
+    float profit_sum_long = 0.0f;
+    float loss_sum_long = 0.0f;
+    float profit_sum_short = 0.0f;
+    float loss_sum_short = 0.0f;
     float fill_count = 0.0f;
     float fill_count_entry = 0.0f;
     float fill_count_long = 0.0f;
@@ -1257,7 +1272,9 @@ inline void passivbot_single_coin_impl(
                         : 0.0f);
                 record_hsl_panic_fill(long_hsl, net_pnl, current_equity);
             }
-            record_gross_pnl(pnl, profit_sum, loss_sum);
+            record_directional_gross_pnl(
+                pnl, profit_sum, loss_sum, profit_sum_long, loss_sum_long
+            );
             balance += net_pnl;
             record_realized_net(
                 net_pnl, realized_pnl_cumsum_last, realized_pnl_cumsum_max,
@@ -1360,7 +1377,9 @@ inline void passivbot_single_coin_impl(
                     + short_side.psize * c_mult * (short_side.pprice - close);
                 record_hsl_panic_fill(short_hsl, net_pnl, current_equity);
             }
-            record_gross_pnl(pnl, profit_sum, loss_sum);
+            record_directional_gross_pnl(
+                pnl, profit_sum, loss_sum, profit_sum_short, loss_sum_short
+            );
             balance += net_pnl;
             record_realized_net(
                 net_pnl, realized_pnl_cumsum_last, realized_pnl_cumsum_max,
@@ -1925,6 +1944,10 @@ inline void passivbot_single_coin_impl(
     scalars[so + 55] = held_sum_min * interval_ms;
     scalars[so + 56] = held_count;
     scalars[so + 57] = account_recovery_max_min * interval_ms;
+    scalars[so + 58] = profit_sum_long;
+    scalars[so + 59] = loss_sum_long;
+    scalars[so + 60] = profit_sum_short;
+    scalars[so + 61] = loss_sum_short;
 }
 
 kernel void passivbot_ema_anchor(

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -2,7 +2,7 @@
 using namespace metal;
 
 constant int DAILY_COLS = 8;
-constant int SCALAR_COLS = 58;
+constant int SCALAR_COLS = 62;
 constant int GAP_BINS = 128;
 constant int SIDE_PARAMS = 51;
 
@@ -158,6 +158,17 @@ inline void record_gross_pnl(
 ) {
     if (pnl > 0.0f) profit_sum += pnl;
     else loss_sum += fabs(pnl);
+}
+
+inline void record_directional_gross_pnl(
+    float pnl,
+    thread float& profit_sum,
+    thread float& loss_sum,
+    thread float& side_profit_sum,
+    thread float& side_loss_sum
+) {
+    record_gross_pnl(pnl, profit_sum, loss_sum);
+    record_gross_pnl(pnl, side_profit_sum, side_loss_sum);
 }
 
 struct TmSide {
@@ -1411,6 +1422,10 @@ inline void passivbot_single_coin_impl(
     float pnl_recovery_max_min = 0.0f;
     float profit_sum = 0.0f;
     float loss_sum = 0.0f;
+    float profit_sum_long = 0.0f;
+    float loss_sum_long = 0.0f;
+    float profit_sum_short = 0.0f;
+    float loss_sum_short = 0.0f;
     float fill_count = 0.0f;
     float fill_count_entry = 0.0f;
     float fill_count_long = 0.0f;
@@ -1710,7 +1725,10 @@ inline void passivbot_single_coin_impl(
                                 )
                             );
                         }
-                        record_gross_pnl(pnl, profit_sum, loss_sum);
+                        record_directional_gross_pnl(
+                            pnl, profit_sum, loss_sum,
+                            profit_sum_long, loss_sum_long
+                        );
                         balance += pnl - fee;
                         record_realized_net(
                             pnl - fee,
@@ -1755,7 +1773,9 @@ inline void passivbot_single_coin_impl(
                         )
                     );
                 }
-                record_gross_pnl(pnl, profit_sum, loss_sum);
+                record_directional_gross_pnl(
+                    pnl, profit_sum, loss_sum, profit_sum_long, loss_sum_long
+                );
                 balance += pnl - fee;
                 record_realized_net(
                     pnl - fee,
@@ -1812,7 +1832,9 @@ inline void passivbot_single_coin_impl(
                             )
                         );
                     }
-                    record_gross_pnl(pnl, profit_sum, loss_sum);
+                    record_directional_gross_pnl(
+                        pnl, profit_sum, loss_sum, profit_sum_long, loss_sum_long
+                    );
                     balance += pnl - fee;
                     record_realized_net(
                         pnl - fee,
@@ -1892,7 +1914,9 @@ inline void passivbot_single_coin_impl(
                         )
                     );
                 }
-                record_gross_pnl(pnl, profit_sum, loss_sum);
+                record_directional_gross_pnl(
+                    pnl, profit_sum, loss_sum, profit_sum_long, loss_sum_long
+                );
                 balance += pnl - fee;
                 record_realized_net(
                     pnl - fee,
@@ -2207,7 +2231,10 @@ inline void passivbot_single_coin_impl(
                                 )
                             );
                         }
-                        record_gross_pnl(pnl, profit_sum, loss_sum);
+                        record_directional_gross_pnl(
+                            pnl, profit_sum, loss_sum,
+                            profit_sum_short, loss_sum_short
+                        );
                         balance += pnl - fee;
                         record_realized_net(
                             pnl - fee,
@@ -2252,7 +2279,9 @@ inline void passivbot_single_coin_impl(
                         )
                     );
                 }
-                record_gross_pnl(pnl, profit_sum, loss_sum);
+                record_directional_gross_pnl(
+                    pnl, profit_sum, loss_sum, profit_sum_short, loss_sum_short
+                );
                 balance += pnl - fee;
                 record_realized_net(
                     pnl - fee,
@@ -2309,7 +2338,9 @@ inline void passivbot_single_coin_impl(
                             )
                         );
                     }
-                    record_gross_pnl(pnl, profit_sum, loss_sum);
+                    record_directional_gross_pnl(
+                        pnl, profit_sum, loss_sum, profit_sum_short, loss_sum_short
+                    );
                     balance += pnl - fee;
                     record_realized_net(
                         pnl - fee,
@@ -2389,7 +2420,9 @@ inline void passivbot_single_coin_impl(
                         )
                     );
                 }
-                record_gross_pnl(pnl, profit_sum, loss_sum);
+                record_directional_gross_pnl(
+                    pnl, profit_sum, loss_sum, profit_sum_short, loss_sum_short
+                );
                 balance += pnl - fee;
                 record_realized_net(
                     pnl - fee,
@@ -2982,6 +3015,10 @@ inline void passivbot_single_coin_impl(
     scalars[so + 55] = held_sum_min * interval_ms;
     scalars[so + 56] = held_count;
     scalars[so + 57] = account_recovery_max_min * interval_ms;
+    scalars[so + 58] = profit_sum_long;
+    scalars[so + 59] = loss_sum_long;
+    scalars[so + 60] = profit_sum_short;
+    scalars[so + 61] = loss_sum_short;
 }
 
 kernel void passivbot_trailing_martingale(

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -116,12 +116,16 @@ SUPPORTED_METRICS = (
     "hard_stop_triggers_per_year",
     "hard_stop_triggers_short",
     "loss_profit_ratio",
+    "loss_profit_ratio_long",
+    "loss_profit_ratio_short",
+    "long_short_profit_ratio",
     "mdg_strategy_eq",
     "mdg_strategy_eq_w",
     "mdg_pnl",
     "mdg_pnl_w",
     "omega_ratio_strategy_eq",
     "omega_ratio_strategy_eq_w",
+    "pnl_ratio_long_short",
     "position_held_days_mean",
     "position_held_days_max",
     "position_held_hours_mean",
@@ -254,6 +258,31 @@ def _loss_profit_ratio(loss_sum: torch.Tensor, profit_sum: torch.Tensor):
         torch.where(loss > 1.0e-12, cap, neutral),
         finite_ratio,
     )
+
+
+def _directional_pnl_metrics(out: dict) -> dict:
+    """Match Rust's directional gross-loss and signed-PnL ratio contracts."""
+
+    values = {}
+    for side in ("long", "short"):
+        values[f"loss_profit_ratio_{side}"] = _loss_profit_ratio(
+            out[f"loss_sum_{side}"], out[f"profit_sum_{side}"]
+        )
+    long_pnl = out["profit_sum_long"].to(torch.float64) - out[
+        "loss_sum_long"
+    ].to(torch.float64)
+    short_pnl = out["profit_sum_short"].to(torch.float64) - out[
+        "loss_sum_short"
+    ].to(torch.float64)
+    pnl_sum = long_pnl + short_pnl
+    long_short_ratio = torch.where(
+        pnl_sum != 0.0,
+        long_pnl / pnl_sum,
+        torch.full_like(pnl_sum, 0.5),
+    )
+    values["pnl_ratio_long_short"] = long_short_ratio
+    values["long_short_profit_ratio"] = long_short_ratio
+    return values
 # Metal classifies gaps with float32 logarithms. Expand the decoded boundary
 # by 1024 unit roundoffs so a value rounded into the preceding bin cannot make
 # this minimizing proxy optimistic.
@@ -1353,6 +1382,20 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
     if "loss_profit_ratio" in requested:
         objectives["loss_profit_ratio"] = _loss_profit_ratio(
             out["loss_sum"], out["profit_sum"]
+        )
+    directional_pnl_metrics = {
+        "loss_profit_ratio_long",
+        "loss_profit_ratio_short",
+        "long_short_profit_ratio",
+        "pnl_ratio_long_short",
+    }
+    if requested & directional_pnl_metrics:
+        objectives.update(
+            {
+                name: value
+                for name, value in _directional_pnl_metrics(out).items()
+                if name in requested
+            }
         )
     for name in ("total_wallet_exposure_max", "total_wallet_exposure_mean"):
         if name in requested:

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -20,7 +20,7 @@ from optimization.gpu.model import (
 MPS_DAILY_COLS = 8
 MPS_MULTICOIN_DAILY_COLS = 9
 MPS_SCALAR_COLS = 32
-MPS_DIRECTIONAL_SCALAR_COLS = 58
+MPS_DIRECTIONAL_SCALAR_COLS = 62
 
 
 def _encode_max_realized_loss_pct(value: float) -> float:
@@ -217,6 +217,10 @@ def _decode_directional_outputs(daily, scalars, gaps) -> dict:
         "held_sum_ms": scalars[:, 55],
         "held_count": scalars[:, 56],
         "account_recovery_max_ms": scalars[:, 57],
+        "profit_sum_long": scalars[:, 58],
+        "loss_sum_long": scalars[:, 59],
+        "profit_sum_short": scalars[:, 60],
+        "loss_sum_short": scalars[:, 61],
     }
 
 

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -55,6 +55,10 @@ CORE_OUTPUT_KEYS = {
     "liq_step",
     "profit_sum",
     "loss_sum",
+    "profit_sum_long",
+    "loss_sum_long",
+    "profit_sum_short",
+    "loss_sum_short",
     "entry_initial_balance_pct",
     "entry_initial_balance_pct_long",
     "entry_initial_balance_pct_short",
@@ -112,6 +116,9 @@ _DUAL_SIDE_MULTICOIN_INTRADAY_CUTOFF_METRICS = {
     "fills_per_day_per_position_slot_short",
     "fills_per_day_short",
     "fills_top_symbol_share",
+    "long_short_profit_ratio",
+    "loss_profit_ratio_long",
+    "loss_profit_ratio_short",
     "mdg_pnl",
     "mdg_pnl_w",
     "peak_recovery_days_equity_usd",
@@ -121,6 +128,7 @@ _DUAL_SIDE_MULTICOIN_INTRADAY_CUTOFF_METRICS = {
     "position_held_days_mean",
     "position_held_hours_mean",
     "positions_held_per_day",
+    "pnl_ratio_long_short",
     "sharpe_ratio_pnl",
     "sharpe_ratio_pnl_w",
     "sortino_ratio_pnl",
@@ -459,6 +467,20 @@ def _directional_entry_initial_metrics(side: str, entry_pct):
     }
 
 
+def _directional_gross_pnl_outputs(side: str, profit_sum, loss_sum):
+    """Expand one directional gross-PnL pair into the shared two-side surface."""
+
+    if side not in {"long", "short"}:
+        raise ValueError(f"expected long or short gross PnL side, got {side!r}")
+    other_side = "short" if side == "long" else "long"
+    return {
+        f"profit_sum_{side}": profit_sum,
+        f"loss_sum_{side}": loss_sum,
+        f"profit_sum_{other_side}": profit_sum.new_zeros(profit_sum.shape),
+        f"loss_sum_{other_side}": loss_sum.new_zeros(loss_sum.shape),
+    }
+
+
 def _prepared_single_coin_side_enabled(config: dict, side: str, bot: dict) -> bool:
     """Match exact Rust eligibility for the one coin prepared by the payload."""
 
@@ -597,6 +619,10 @@ def _combine_hedged_multicoin_outputs(
     combined["liq_step"] = liquidation_day
     combined["profit_sum"] = long["profit_sum"] + short["profit_sum"]
     combined["loss_sum"] = long["loss_sum"] + short["loss_sum"]
+    combined["profit_sum_long"] = long["profit_sum"]
+    combined["loss_sum_long"] = long["loss_sum"]
+    combined["profit_sum_short"] = short["profit_sum"]
+    combined["loss_sum_short"] = short["loss_sum"]
     combined["fill_count"] = long["fill_count"] + short["fill_count"]
     combined["fill_count_entry"] = (
         long["fill_count_entry"] + short["fill_count_entry"]
@@ -1537,6 +1563,11 @@ class MpsMulticoinProxy:
             if len(self.sides) == 1:
                 side = self.sides[0]
                 output = side_outputs[side]
+                output.update(
+                    _directional_gross_pnl_outputs(
+                        side, output["profit_sum"], output["loss_sum"]
+                    )
+                )
                 output.update(
                     _directional_entry_initial_metrics(
                         side, output["entry_initial_balance_pct"]

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -11,6 +11,7 @@ from optimization.gpu.metrics import (
     SUPPORTED_METRICS,
     _GAP_HIST_UPPER_STEPS,
     _equity_shape_metrics,
+    _directional_pnl_metrics,
     _fill_activity_metrics,
     _fill_gap_metrics,
     _hard_stop_lifecycle_metrics,
@@ -69,6 +70,25 @@ def test_loss_profit_ratio_matches_rust_cap_and_neutral_contract():
 
     assert actual.tolist() == [0.25, 1_000.0, 1.0, 1_000.0]
     assert "loss_profit_ratio" in SUPPORTED_METRICS
+
+
+def test_directional_pnl_metrics_match_rust_neutral_and_alias_contracts():
+    metrics = _directional_pnl_metrics(
+        {
+            "profit_sum_long": torch.tensor([100.0, 0.0, 0.0]),
+            "loss_sum_long": torch.tensor([25.0, 5.0, 0.0]),
+            "profit_sum_short": torch.tensor([50.0, 0.0, 0.0]),
+            "loss_sum_short": torch.tensor([75.0, 0.0, 0.0]),
+        }
+    )
+
+    assert metrics["loss_profit_ratio_long"].tolist() == [0.25, 1_000.0, 1.0]
+    assert metrics["loss_profit_ratio_short"].tolist() == [1.5, 1.0, 1.0]
+    assert metrics["pnl_ratio_long_short"].tolist() == [1.5, 1.0, 0.5]
+    assert torch.equal(
+        metrics["long_short_profit_ratio"], metrics["pnl_ratio_long_short"]
+    )
+    assert set(metrics) <= set(SUPPORTED_METRICS)
 
 
 def test_equity_shape_metrics_match_rust_daily_series_contract():

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -604,7 +604,7 @@ def test_mps_ema_anchor_shader_smoke():
     assert "const bool long_hsl_panic_market = settings[17] > 0.5f" in source
     assert "const bool short_hsl_panic_market = settings[18] > 0.5f" in source
     assert "market_panic ? taker_fee : maker_fee" in source
-    assert "constant int SCALAR_COLS = 58" in source
+    assert "constant int SCALAR_COLS = 62" in source
     assert "scalars[so + 50] = fill_count" in source
     assert "scalars[so + 51] = fill_count_entry" in source
     assert "scalars[so + 52] = fill_count_long" in source
@@ -613,6 +613,8 @@ def test_mps_ema_anchor_shader_smoke():
     assert "scalars[so + 55] = held_sum_min * interval_ms" in source
     assert "scalars[so + 56] = held_count" in source
     assert "scalars[so + 57] = account_recovery_max_min * interval_ms" in source
+    assert "scalars[so + 58] = profit_sum_long" in source
+    assert "scalars[so + 61] = loss_sum_short" in source
     assert "record_gross_pnl" in source
     assert "hsl_tier_samples_total" in source
     assert "h.restart_retrigger_count" in source
@@ -2554,6 +2556,11 @@ def test_mps_tm_position_exposure_repair_reduces_strictly_below_target(side):
         output["day_volume"][1].sum().item()
         > output["day_volume"][0].sum().item()
     )
+    other_side = "short" if side == "long" else "long"
+    assert torch.allclose(output[f"profit_sum_{side}"], output["profit_sum"])
+    assert torch.allclose(output[f"loss_sum_{side}"], output["loss_sum"])
+    assert (output[f"profit_sum_{other_side}"] == 0.0).all()
+    assert (output[f"loss_sum_{other_side}"] == 0.0).all()
 
 
 @pytest.mark.skipif(
@@ -2704,6 +2711,11 @@ def test_mps_ema_single_coin_total_exposure_repair(side):
         output["day_volume"][1].sum().item()
         > output["day_volume"][0].sum().item()
     )
+    other_side = "short" if side == "long" else "long"
+    assert torch.allclose(output[f"profit_sum_{side}"], output["profit_sum"])
+    assert torch.allclose(output[f"loss_sum_{side}"], output["loss_sum"])
+    assert (output[f"profit_sum_{other_side}"] == 0.0).all()
+    assert (output[f"loss_sum_{other_side}"] == 0.0).all()
 
 
 @pytest.mark.skipif(
@@ -3777,6 +3789,13 @@ def test_mps_tm_off_tick_grid_precedes_reducer_for_volume(side):
         grid_pnl + reducer_pnl, abs=3.0e-4
     )
     assert output["loss_sum"].item() == 0.0
+    other_side = "short" if side == "long" else "long"
+    assert output[f"profit_sum_{side}"].item() == pytest.approx(
+        grid_pnl + reducer_pnl, abs=3.0e-4
+    )
+    assert output[f"loss_sum_{side}"].item() == 0.0
+    assert output[f"profit_sum_{other_side}"].item() == 0.0
+    assert output[f"loss_sum_{other_side}"].item() == 0.0
     assert output["day_volume"].sum().item() == pytest.approx(
         expected_volume, rel=2.0e-5
     )

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -24,6 +24,7 @@ from optimization.gpu.service import (
     _candidate_position_slot_outputs,
     _combine_hedged_multicoin_outputs,
     _directional_entry_initial_metrics,
+    _directional_gross_pnl_outputs,
     _hsl_params,
     _position_exposure_enforcer_params,
     _prepared_single_coin_side_enabled,
@@ -82,12 +83,16 @@ def test_core_output_contract_retains_gross_pnl_aggregates():
         "fills_per_day_per_position_slot_short",
         "fills_per_day_short",
         "fills_top_symbol_share",
+        "long_short_profit_ratio",
+        "loss_profit_ratio_long",
+        "loss_profit_ratio_short",
         "mdg_pnl",
         "mdg_pnl_w",
         "peak_recovery_days_equity_usd",
         "peak_recovery_hours_equity_usd",
         "peak_recovery_days_pnl",
         "peak_recovery_hours_pnl",
+        "pnl_ratio_long_short",
         "sharpe_ratio_pnl",
         "sharpe_ratio_pnl_w",
         "sortino_ratio_pnl",
@@ -138,6 +143,21 @@ def test_candidate_wallet_exposure_limits_preserve_sides_and_base_fallback():
         0.5,
         0.75,
     ]
+
+
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_directional_gross_pnl_outputs_zero_the_inactive_side(side):
+    torch = pytest.importorskip("torch")
+    profit = torch.tensor([7.0])
+    loss = torch.tensor([2.0])
+
+    outputs = _directional_gross_pnl_outputs(side, profit, loss)
+    other_side = "short" if side == "long" else "long"
+
+    assert outputs[f"profit_sum_{side}"] is profit
+    assert outputs[f"loss_sum_{side}"] is loss
+    assert outputs[f"profit_sum_{other_side}"].item() == 0.0
+    assert outputs[f"loss_sum_{other_side}"].item() == 0.0
 
 
 def test_candidate_position_slots_follow_candidate_positions_and_enabledness():
@@ -645,6 +665,10 @@ def test_combine_hedged_multicoin_outputs_uses_conservative_surface():
     assert combined["liq_step"].item() == -1
     assert combined["profit_sum"].item() == 40.0
     assert combined["loss_sum"].item() == 10.0
+    assert combined["profit_sum_long"].item() == 20.0
+    assert combined["loss_sum_long"].item() == 5.0
+    assert combined["profit_sum_short"].item() == 20.0
+    assert combined["loss_sum_short"].item() == 5.0
     assert combined["fill_count"].item() == 2.0
     assert combined["fill_count_entry"].item() == 2.0
     assert combined["fill_count_long"].item() == 2.0


### PR DESCRIPTION
## Summary
- add Apple MPS proxy scoring/limits for `loss_profit_ratio_long`, `loss_profit_ratio_short`, `pnl_ratio_long_short`, and `long_short_profit_ratio`
- preserve long/short gross profit and loss independently in EMA Anchor and Trailing Martingale directional kernels, and retain the partition across one- and two-sided multi-coin dispatch
- match exact Rust neutral/cap formulas while keeping exact Rust validation authoritative and CPU behavior unchanged

## Validation
- full non-MPS optimizer test suite
- full physical Apple M3/MPS suite (212 tests) plus focused EMA/TM long/short partition checks
- `cargo test --no-default-features` (262 passed)
- `cargo check --tests` and `cargo fmt --check`
- AI docs checker: 0 errors (two pre-existing size warnings)
- rebuilt/stamped extension verified: source stamp `87255115cc7f810695041f7a2354ad3cc388eae7c7b88883038aae4a6425a2f6`, artifact SHA-256 `6f3755341eedb5e4246660c52d8ef7c30b851a7cb532796681fe9fbfef8fba8f`
- physical multi-coin EMA Anchor smoke: 2,048 proxy / 64 exact, 8 generations, no halt at drift threshold 0.6
- physical multi-coin Trailing Martingale smoke: 2,048 proxy / 64 exact, 8 generations, no halt at drift threshold 0.6

The smoke configs/results remained private under `/private/tmp`. Missing warmup windows were filled through public unauthenticated Bybit OHLCV requests only; no account credentials or private endpoints were used.