### PR TITLE
feat(optimize): support dual-side MPS HSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,17 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added dual-side single-coin HSL to Apple MPS optimization for EMA Anchor and Trailing
+  Martingale in `coin` and `pside` signal modes, including compatible suites. Metal now tracks
+  realized net PnL independently for long and short while retaining shared account balance and
+  exact Rust validation. Dual-side `unified` HSL remains fail closed until its documented
+  account-wide flatten contract and exact-backtest finalization scope are reconciled; multi-coin
+  and per-coin-override HSL remain unsupported.
+
 - Consolidated the supported one-sided single-coin HSL Apple MPS screening behavior into one
   Rust-owned Metal controller shared by EMA Anchor and Trailing Martingale. Signal modes now use
   explicit unified, pside, and coin identities, with direct M3 trace conformance against the exact
-  Rust HSL runtime. Supported GPU behavior is unchanged; dual-side, multi-coin, and per-coin-
-  override HSL continue to fail closed.
+  Rust HSL runtime. That foundation did not itself expand GPU support.
 
 - Added directional close-fill PnL scoring and limits to Apple MPS optimization:
   `loss_profit_ratio_long`, `loss_profit_ratio_short`, `pnl_ratio_long_short`, and its

--- a/docs/equity_hard_stop_loss_reference.md
+++ b/docs/equity_hard_stop_loss_reference.md
@@ -128,7 +128,9 @@ These are the main parity surfaces that should be reviewed together:
    - One shared Rust-owned Metal HSL controller is composed into both EMA Anchor and Trailing Martingale directional kernels
    - Unified, pside, and coin signal modes use explicit encoded identities instead of a coin/non-coin boolean
    - Deterministic M3 conformance coverage compares Metal drawdown, EMA, tier, active-RED, latch, and RED-finalization traces against the exact Rust runtime for all three signal modes and restart policies
-   - The supported GPU scope remains one enabled side and one coin; dual-side, multi-coin, and per-coin-override HSL still fail closed
+   - One-sided runs support unified, pside, and coin signals; dual-side runs support pside and coin signals with independent directional realized-PnL state
+   - Dual-side unified HSL remains fail closed because the documented account-wide episode-finalization scope and current exact-backtest per-side flat confirmation disagree
+   - Multi-coin and per-coin-override HSL still fail closed
 
 ### Confirmed Gaps / Risks
 
@@ -140,7 +142,8 @@ These are the main parity surfaces that should be reviewed together:
    - Global `*_strategy_eq` metrics are canonical for risk inspection and optimizer use
    - Deprecated `*_hsl` metric names remain accepted as aliases for older configs/results
 3. GPU HSL topology is intentionally narrow
-   - Dual-side and multi-coin HSL need a shared-balance portfolio controller before they can be screened safely
+   - Dual-side unified HSL needs one resolved account-wide exact-Rust flatten contract before it can be screened safely
+   - Multi-coin HSL needs a shared-balance portfolio controller before it can be screened safely
    - Per-coin HSL overrides require candidate-local resolved settings in that portfolio controller
 
 ### Missing or Weak Test Coverage
@@ -148,7 +151,7 @@ These are the main parity surfaces that should be reviewed together:
 1. End-to-end replay of one identical fill/candle history through live reconstruction and exact backtest orchestration; shared Rust primitive tests cover the calculations but not the complete orchestration trace
 2. Connector-level restart races while protective panic-close orders are live on an exchange
 3. Manual or external trading during downtime across the full exchange-adapter matrix
-4. Apple MPS parity for dual-side, multi-coin, and per-coin-override HSL scopes
+4. Apple MPS parity for dual-side unified, multi-coin, and per-coin-override HSL scopes
 
 ## Optimizer Work
 

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -74,6 +74,19 @@ mod tests {
         assert!(source.contains("int ho = po + hsl_param_offset"));
     }
 
+    fn assert_directional_hsl_accounting_contract(source: &str) {
+        assert!(source.contains("thread float& realized_pnl_cumsum_long"));
+        assert!(source.contains("thread float& realized_pnl_cumsum_short"));
+        assert!(source.contains("if (is_long) realized_pnl_cumsum_long += net_pnl"));
+        assert!(source.contains("else realized_pnl_cumsum_short += net_pnl"));
+        assert!(source.contains("long_hsl.signal_mode == HSL_SIGNAL_UNIFIED"));
+        assert!(source.contains("short_hsl.signal_mode == HSL_SIGNAL_UNIFIED"));
+        assert!(source.contains("? realized_pnl_cumsum_last : realized_pnl_cumsum_long"));
+        assert!(source.contains("? realized_pnl_cumsum_last : realized_pnl_cumsum_short"));
+        assert!(source.contains("? total_unreal : long_unreal"));
+        assert!(source.contains("? total_unreal : short_unreal"));
+    }
+
     #[test]
     fn directional_sources_compose_one_shared_hsl_controller() {
         assert_eq!(MPS_EMA_ANCHOR_BODY.matches(MPS_HSL_MARKER).count(), 1);
@@ -85,12 +98,15 @@ mod tests {
         assert!(!MPS_TRAILING_MARTINGALE_BODY.contains("struct HslState"));
         assert_shared_hsl_contract(mps_ema_anchor_source());
         assert_shared_hsl_contract(mps_trailing_martingale_source());
+        assert_directional_hsl_accounting_contract(mps_ema_anchor_source());
+        assert_directional_hsl_accounting_contract(mps_trailing_martingale_source());
     }
 
     #[test]
     fn ema_anchor_mps_source_exposes_expected_kernel_contract() {
         let source = mps_ema_anchor_source();
         assert_shared_hsl_contract(source);
+        assert_directional_hsl_accounting_contract(source);
         assert!(source.contains("kernel void passivbot_ema_anchor"));
         assert!(source.contains("constant int DAILY_COLS = 8"));
         assert!(source.contains("constant int SCALAR_COLS = 62"));
@@ -236,6 +252,7 @@ mod tests {
     fn trailing_martingale_mps_source_exposes_expected_kernel_contract() {
         let source = mps_trailing_martingale_source();
         assert_shared_hsl_contract(source);
+        assert_directional_hsl_accounting_contract(source);
         assert!(source.contains("kernel void passivbot_trailing_martingale"));
         assert!(source.contains("constant int SIDE_PARAMS = 51"));
         assert!(source.contains("struct HslState"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -63,6 +63,8 @@ inline void record_realized_net(
     float net_pnl,
     thread float& realized_pnl_cumsum_last,
     thread float& realized_pnl_cumsum_max,
+    thread float& realized_pnl_cumsum_long,
+    thread float& realized_pnl_cumsum_short,
     thread float& day_fill_count,
     thread float& fill_count,
     thread float& fill_count_entry,
@@ -79,6 +81,8 @@ inline void record_realized_net(
     if (is_entry) fill_count_entry += 1.0f;
     if (is_long) fill_count_long += 1.0f;
     realized_pnl_cumsum_last += net_pnl;
+    if (is_long) realized_pnl_cumsum_long += net_pnl;
+    else realized_pnl_cumsum_short += net_pnl;
     realized_pnl_cumsum_max = fmax(
         realized_pnl_cumsum_max, realized_pnl_cumsum_last
     );
@@ -824,6 +828,8 @@ inline void passivbot_single_coin_impl(
     float balance = starting_balance;
     float realized_pnl_cumsum_last = 0.0f;
     float realized_pnl_cumsum_max = 0.0f;
+    float realized_pnl_cumsum_long = 0.0f;
+    float realized_pnl_cumsum_short = 0.0f;
     float pnl_recovery_peak = -INFINITY;
     float pnl_recovery_peak_k = -1.0f;
     float pnl_recovery_max_min = 0.0f;
@@ -972,6 +978,7 @@ inline void passivbot_single_coin_impl(
             balance += net_pnl;
             record_realized_net(
                 net_pnl, realized_pnl_cumsum_last, realized_pnl_cumsum_max,
+                realized_pnl_cumsum_long, realized_pnl_cumsum_short,
                 day_fill_count, fill_count, fill_count_entry, fill_count_long,
                 pnl_recovery_peak, pnl_recovery_peak_k,
                 pnl_recovery_max_min, kf,
@@ -1009,6 +1016,7 @@ inline void passivbot_single_coin_impl(
             balance -= fee;
             record_realized_net(
                 -fee, realized_pnl_cumsum_last, realized_pnl_cumsum_max,
+                realized_pnl_cumsum_long, realized_pnl_cumsum_short,
                 day_fill_count, fill_count, fill_count_entry, fill_count_long,
                 pnl_recovery_peak, pnl_recovery_peak_k,
                 pnl_recovery_max_min, kf,
@@ -1077,6 +1085,7 @@ inline void passivbot_single_coin_impl(
             balance += net_pnl;
             record_realized_net(
                 net_pnl, realized_pnl_cumsum_last, realized_pnl_cumsum_max,
+                realized_pnl_cumsum_long, realized_pnl_cumsum_short,
                 day_fill_count, fill_count, fill_count_entry, fill_count_long,
                 pnl_recovery_peak, pnl_recovery_peak_k,
                 pnl_recovery_max_min, kf,
@@ -1114,6 +1123,7 @@ inline void passivbot_single_coin_impl(
             balance -= fee;
             record_realized_net(
                 -fee, realized_pnl_cumsum_last, realized_pnl_cumsum_max,
+                realized_pnl_cumsum_long, realized_pnl_cumsum_short,
                 day_fill_count, fill_count, fill_count_entry, fill_count_long,
                 pnl_recovery_peak, pnl_recovery_peak_k,
                 pnl_recovery_max_min, kf,
@@ -1418,16 +1428,25 @@ inline void passivbot_single_coin_impl(
                 short_side.entry_qty > 0.0f || short_side.close_qty > 0.0f
                     || short_side.secondary_close_qty > 0.0f
             );
+            float total_unreal = long_unreal + short_unreal;
+            float long_hsl_realized = long_hsl.signal_mode == HSL_SIGNAL_UNIFIED
+                ? realized_pnl_cumsum_last : realized_pnl_cumsum_long;
+            float short_hsl_realized = short_hsl.signal_mode == HSL_SIGNAL_UNIFIED
+                ? realized_pnl_cumsum_last : realized_pnl_cumsum_short;
+            float long_hsl_unreal = long_hsl.signal_mode == HSL_SIGNAL_UNIFIED
+                ? total_unreal : long_unreal;
+            float short_hsl_unreal = short_hsl.signal_mode == HSL_SIGNAL_UNIFIED
+                ? total_unreal : short_unreal;
             update_hsl(
                 long_hsl, balance, starting_balance,
-                realized_pnl_cumsum_last,
-                long_unreal, long_side.psize > 0.0f,
+                long_hsl_realized,
+                long_hsl_unreal, long_side.psize > 0.0f,
                 long_blocking_orders, kf, interval_ms
             );
             update_hsl(
                 short_hsl, balance, starting_balance,
-                realized_pnl_cumsum_last,
-                short_unreal, short_side.psize > 0.0f,
+                short_hsl_realized,
+                short_hsl_unreal, short_side.psize > 0.0f,
                 short_blocking_orders, kf, interval_ms
             );
             if (long_hsl.enabled || short_hsl.enabled) {

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -123,6 +123,8 @@ inline void record_realized_net(
     float net_pnl,
     thread float& realized_pnl_cumsum_last,
     thread float& realized_pnl_cumsum_max,
+    thread float& realized_pnl_cumsum_long,
+    thread float& realized_pnl_cumsum_short,
     thread float& day_fill_count,
     thread float& fill_count,
     thread float& fill_count_entry,
@@ -139,6 +141,8 @@ inline void record_realized_net(
     if (is_entry) fill_count_entry += 1.0f;
     if (is_long) fill_count_long += 1.0f;
     realized_pnl_cumsum_last += net_pnl;
+    if (is_long) realized_pnl_cumsum_long += net_pnl;
+    else realized_pnl_cumsum_short += net_pnl;
     realized_pnl_cumsum_max = fmax(
         realized_pnl_cumsum_max, realized_pnl_cumsum_last
     );
@@ -1111,6 +1115,8 @@ inline void passivbot_single_coin_impl(
     float balance = starting_balance;
     float realized_pnl_cumsum_last = 0.0f;
     float realized_pnl_cumsum_max = 0.0f;
+    float realized_pnl_cumsum_long = 0.0f;
+    float realized_pnl_cumsum_short = 0.0f;
     float pnl_recovery_peak = -INFINITY;
     float pnl_recovery_peak_k = -1.0f;
     float pnl_recovery_max_min = 0.0f;
@@ -1428,6 +1434,8 @@ inline void passivbot_single_coin_impl(
                             pnl - fee,
                             realized_pnl_cumsum_last,
                             realized_pnl_cumsum_max,
+                            realized_pnl_cumsum_long,
+                            realized_pnl_cumsum_short,
                             day_fill_count,
                             fill_count,
                             fill_count_entry,
@@ -1475,6 +1483,8 @@ inline void passivbot_single_coin_impl(
                     pnl - fee,
                     realized_pnl_cumsum_last,
                     realized_pnl_cumsum_max,
+                    realized_pnl_cumsum_long,
+                    realized_pnl_cumsum_short,
                     day_fill_count,
                     fill_count,
                     fill_count_entry,
@@ -1534,6 +1544,8 @@ inline void passivbot_single_coin_impl(
                         pnl - fee,
                         realized_pnl_cumsum_last,
                         realized_pnl_cumsum_max,
+                        realized_pnl_cumsum_long,
+                        realized_pnl_cumsum_short,
                         day_fill_count,
                         fill_count,
                         fill_count_entry,
@@ -1616,6 +1628,8 @@ inline void passivbot_single_coin_impl(
                     pnl - fee,
                     realized_pnl_cumsum_last,
                     realized_pnl_cumsum_max,
+                    realized_pnl_cumsum_long,
+                    realized_pnl_cumsum_short,
                     day_fill_count,
                     fill_count,
                     fill_count_entry,
@@ -1677,6 +1691,8 @@ inline void passivbot_single_coin_impl(
                     -fee,
                     realized_pnl_cumsum_last,
                     realized_pnl_cumsum_max,
+                    realized_pnl_cumsum_long,
+                    realized_pnl_cumsum_short,
                     day_fill_count,
                     fill_count,
                     fill_count_entry,
@@ -1934,6 +1950,8 @@ inline void passivbot_single_coin_impl(
                             pnl - fee,
                             realized_pnl_cumsum_last,
                             realized_pnl_cumsum_max,
+                            realized_pnl_cumsum_long,
+                            realized_pnl_cumsum_short,
                             day_fill_count,
                             fill_count,
                             fill_count_entry,
@@ -1981,6 +1999,8 @@ inline void passivbot_single_coin_impl(
                     pnl - fee,
                     realized_pnl_cumsum_last,
                     realized_pnl_cumsum_max,
+                    realized_pnl_cumsum_long,
+                    realized_pnl_cumsum_short,
                     day_fill_count,
                     fill_count,
                     fill_count_entry,
@@ -2040,6 +2060,8 @@ inline void passivbot_single_coin_impl(
                         pnl - fee,
                         realized_pnl_cumsum_last,
                         realized_pnl_cumsum_max,
+                        realized_pnl_cumsum_long,
+                        realized_pnl_cumsum_short,
                         day_fill_count,
                         fill_count,
                         fill_count_entry,
@@ -2122,6 +2144,8 @@ inline void passivbot_single_coin_impl(
                     pnl - fee,
                     realized_pnl_cumsum_last,
                     realized_pnl_cumsum_max,
+                    realized_pnl_cumsum_long,
+                    realized_pnl_cumsum_short,
                     day_fill_count,
                     fill_count,
                     fill_count_entry,
@@ -2183,6 +2207,8 @@ inline void passivbot_single_coin_impl(
                     -fee,
                     realized_pnl_cumsum_last,
                     realized_pnl_cumsum_max,
+                    realized_pnl_cumsum_long,
+                    realized_pnl_cumsum_short,
                     day_fill_count,
                     fill_count,
                     fill_count_entry,
@@ -2489,16 +2515,25 @@ inline void passivbot_single_coin_impl(
                 short_side.entry_qty > 0.0f || short_side.close_qty > 0.0f
                     || short_side.secondary_close_qty > 0.0f
             );
+            float total_unreal = long_unreal + short_unreal;
+            float long_hsl_realized = long_hsl.signal_mode == HSL_SIGNAL_UNIFIED
+                ? realized_pnl_cumsum_last : realized_pnl_cumsum_long;
+            float short_hsl_realized = short_hsl.signal_mode == HSL_SIGNAL_UNIFIED
+                ? realized_pnl_cumsum_last : realized_pnl_cumsum_short;
+            float long_hsl_unreal = long_hsl.signal_mode == HSL_SIGNAL_UNIFIED
+                ? total_unreal : long_unreal;
+            float short_hsl_unreal = short_hsl.signal_mode == HSL_SIGNAL_UNIFIED
+                ? total_unreal : short_unreal;
             update_hsl(
                 long_hsl, balance, starting_balance,
-                realized_pnl_cumsum_last,
-                long_unreal, long_side.psize > 0.0f,
+                long_hsl_realized,
+                long_hsl_unreal, long_side.psize > 0.0f,
                 long_blocking_orders, kf, interval_ms
             );
             update_hsl(
                 short_hsl, balance, starting_balance,
-                realized_pnl_cumsum_last,
-                short_unreal, short_side.psize > 0.0f,
+                short_hsl_realized,
+                short_hsl_unreal, short_side.psize > 0.0f,
                 short_blocking_orders, kf, interval_ms
             );
             if (long_hsl.enabled || short_hsl.enabled) {

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -26,7 +26,10 @@ from optimization.backend_shared import (
 from optimization.bounds import Bound, enforce_bounds
 from optimization.callback import build_pymoo_record_entry
 from optimization.fine_tune_anchors import ANCHOR_GENE_KEY, get_anchor_plan
-from optimization.gpu.model import gpu_side_enabled
+from optimization.gpu.model import (
+    gpu_side_enabled,
+    validate_single_coin_hsl_signal_topology,
+)
 from optimization.interrupts import (
     InterruptCheck,
     OptimizerBackendInterrupted,
@@ -988,9 +991,9 @@ def _validate_scope_config(
         if bool(config["bot"][side].get("hsl", {}).get("enabled"))
     ]
     if hsl_enabled_sides:
-        if coin_count != 1 or len(enabled_sides) != 1:
+        if coin_count != 1:
             raise ValueError(
-                "GPU HSL currently requires one enabled side and one backtest coin"
+                "GPU HSL currently requires one backtest coin"
             )
         # The proxy deliberately keeps an all-history candidate-local peak for
         # finite windows. That peak is never below Rust's rolling-window peak,
@@ -1003,11 +1006,9 @@ def _validate_scope_config(
         signal_mode = str(
             config.get("live", {}).get("hsl_signal_mode", "unified")
         ).strip().lower()
-        if signal_mode not in {"coin", "pside", "unified"}:
-            raise ValueError(
-                "GPU HSL requires live.hsl_signal_mode to be coin, pside, or "
-                f"unified; got {signal_mode!r}"
-            )
+        validate_single_coin_hsl_signal_topology(
+            signal_mode, enabled_side_count=len(enabled_sides)
+        )
         for side in hsl_enabled_sides:
             hsl = config["bot"][side].get("hsl", {})
             panic_order_type = str(

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -9,6 +9,23 @@ import numpy as np
 GAP_BINS = 128
 GAP_MAX_MINUTES = 4_000_000.0
 MPS_MULTICOIN_MAX_COINS = 64
+HSL_SIGNAL_MODES = {"unified", "pside", "coin"}
+
+
+def validate_single_coin_hsl_signal_topology(
+    signal_mode: str, *, enabled_side_count: int
+) -> None:
+    if signal_mode not in HSL_SIGNAL_MODES:
+        raise ValueError(
+            "GPU HSL requires live.hsl_signal_mode to be coin, pside, or "
+            f"unified; got {signal_mode!r}"
+        )
+    if enabled_side_count > 1 and signal_mode == "unified":
+        raise ValueError(
+            "GPU dual-side single-coin HSL currently supports only coin or "
+            "pside signal mode; unified remains fail closed pending an "
+            "account-wide exact-Rust flatten contract"
+        )
 
 EMA_ANCHOR_PARAM_KEYS = (
     "base_qty_pct",

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -19,6 +19,7 @@ from optimization.gpu.model import (
     build_mps_multicoin_data,
     flatten_trailing_martingale_params,
     gpu_side_enabled,
+    validate_single_coin_hsl_signal_topology,
 )
 
 
@@ -306,11 +307,7 @@ def _hsl_params(bot: dict, *, signal_mode: str) -> dict[str, float]:
             f"or never, got {restart_policy!r}"
         )
     signal_mode = str(signal_mode).strip().lower()
-    if signal_mode not in {"coin", "pside", "unified"}:
-        raise ValueError(
-            "MPS HSL requires live.hsl_signal_mode to be coin, pside, or "
-            f"unified, got {signal_mode!r}"
-        )
+    validate_single_coin_hsl_signal_topology(signal_mode, enabled_side_count=1)
     signal_mode_ids = {"unified": 0.0, "pside": 1.0, "coin": 2.0}
     orange_mode = str(
         bot.get("hsl_orange_tier_mode", "tp_only_with_active_entry_cancellation")
@@ -738,14 +735,14 @@ class MpsSingleCoinProxy:
             for side, bot in (("long", long_bot), ("short", short_bot))
             if self.enabled[side] and bool(bot.get("hsl_enabled"))
         ]
-        if hsl_enabled_sides and sum(self.enabled.values()) != 1:
-            raise ValueError(
-                "MPS single-coin HSL currently requires exactly one enabled side"
-            )
         signal_mode = (
             backtest_params.get("equity_hard_stop_loss", {})
             .get("signal_mode", "unified")
         )
+        if hsl_enabled_sides:
+            validate_single_coin_hsl_signal_topology(
+                signal_mode, enabled_side_count=sum(self.enabled.values())
+            )
         hsl_panic_market = {}
         self.base_params = {}
         for side, bot in (("long", long_bot), ("short", short_bot)):

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1456,11 +1456,23 @@ def test_gpu_hsl_fails_closed_for_unknown_panic_close_type():
         _validate_scope(config, _Evaluator())
 
 
-def test_gpu_hsl_fails_closed_for_dual_side_single_coin():
+@pytest.mark.parametrize("signal_mode", ["coin", "pside"])
+def test_gpu_hsl_accepts_dual_side_single_coin_scoped_modes(signal_mode):
     config = _directional_ema_config(long_enabled=True, short_enabled=True)
     config["bot"]["long"]["hsl"]["enabled"] = True
+    config["bot"]["short"]["hsl"]["enabled"] = True
+    config["live"]["hsl_signal_mode"] = signal_mode
 
-    with pytest.raises(ValueError, match="one enabled side"):
+    assert _validate_scope(config, _Evaluator()) == "bybit"
+
+
+def test_gpu_hsl_fails_closed_for_dual_side_single_coin_unified_mode():
+    config = _directional_ema_config(long_enabled=True, short_enabled=True)
+    config["bot"]["long"]["hsl"]["enabled"] = True
+    config["bot"]["short"]["hsl"]["enabled"] = True
+    config["live"]["hsl_signal_mode"] = "unified"
+
+    with pytest.raises(ValueError, match="account-wide exact-Rust flatten contract"):
         _validate_scope(config, _Evaluator())
 
 

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -1966,6 +1966,110 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("signal_mode", ["pside", "coin"])
+def test_mps_dual_side_single_coin_hsl_keeps_directional_state_separate(
+    strategy_kind, signal_mode
+):
+    count = 48
+    close = np.full(count, 100.0)
+    close[8:20] = 70.0
+    close[20:32] = 100.0
+    close[32:] = 130.0
+    high = close * 1.02
+    low = close * 0.98
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    if strategy_kind == "trailing_martingale":
+        baseline = _tm_single_row(initial_ema_dist=0.0)
+        baseline[6] = 0.5
+        baseline[7] = 0.5
+        baseline[16] = 0.5
+        keys = TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS
+        runner_cls = MpsTrailingMartingaleRunner
+    else:
+        baseline = _single_coin_param_row(
+            {
+                "base_qty_pct": 0.5,
+                "ema_span_0": 2.0,
+                "ema_span_1": 3.0,
+                "entry_double_down_factor": 1.0,
+                "offset": 0.0,
+                "offset_psize_weight": 0.0,
+                "offset_volatility_1h_weight": 0.0,
+                "offset_volatility_1m_weight": 0.0,
+                "offset_volatility_ema_span_1h": 2.0,
+                "offset_volatility_ema_span_1m": 2.0,
+                "entry_cooldown_minutes": 0.0,
+                "total_wallet_exposure_limit": 1.0,
+                "we_excess_allowance_pct": 0.0,
+                "we_excess_allowance_legacy_raw": 0.0,
+                "twel_entry_gate_enabled": 1.0,
+                "twel_enforcer_threshold": 1.0,
+                "twel_enforcer_enabled": 0.0,
+            },
+            EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
+        )
+        keys = EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS
+        runner_cls = MpsEmaAnchorRunner
+    hsl = list(baseline)
+    for key, value in {
+        "hsl_enabled": 1.0,
+        "hsl_red_threshold": 0.01,
+        "hsl_ema_span_minutes": 1.0,
+        "hsl_cooldown_minutes_after_red": 0.0,
+        "hsl_no_restart_drawdown_threshold": 1.0,
+        "hsl_restart_policy": 2.0,
+        "hsl_tier_ratio_yellow": 0.5,
+        "hsl_tier_ratio_orange": 0.75,
+        "hsl_orange_graceful_stop": 0.0,
+        "hsl_signal_mode": 1.0 if signal_mode == "pside" else 2.0,
+        "hsl_slot_count": 1.0,
+    }.items():
+        hsl[keys.index(key)] = value
+    rows = np.asarray(
+        [
+            hsl + baseline,
+            baseline + hsl,
+            hsl + hsl,
+        ],
+        dtype=np.float64,
+    )
+    output = runner_cls(
+        market,
+        run,
+        data,
+        long_enabled=True,
+        short_enabled=True,
+    ).run(rows)
+    torch.mps.synchronize()
+
+    assert output["hsl_triggers_long"][0].item() == 1.0
+    assert output["hsl_triggers_short"][0].item() == 0.0
+    assert output["hsl_triggers_long"][1].item() == 0.0
+    assert output["hsl_triggers_short"][1].item() == 1.0
+    assert output["hsl_triggers_long"][2].item() == 1.0
+    assert output["hsl_triggers_short"][2].item() == 1.0
+    assert output["hsl_trigger_drawdown_count"][2].item() == 2.0
+    assert output["hsl_panic_loss_drawdown_count"][2].item() == 2.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
 @pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_single_coin_auto_unstuck_reduces_eligible_position(
     strategy_kind, side

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -11,6 +11,7 @@ from optimization.gpu.model import (
     TRAILING_MARTINGALE_PARAM_KEYS,
     flatten_trailing_martingale_params,
     gpu_side_enabled,
+    validate_single_coin_hsl_signal_topology,
 )
 from optimization.gpu.service import (
     CORE_OUTPUT_KEYS,
@@ -445,6 +446,25 @@ def test_single_coin_hsl_packs_explicit_signal_mode_ids(signal_mode, expected_id
     packed = _hsl_params({"hsl_enabled": False}, signal_mode=signal_mode)
 
     assert packed["hsl_signal_mode"] == expected_id
+
+
+@pytest.mark.parametrize("signal_mode", ["coin", "pside"])
+def test_dual_side_single_coin_hsl_accepts_scoped_signal_modes(signal_mode):
+    validate_single_coin_hsl_signal_topology(signal_mode, enabled_side_count=2)
+
+
+def test_one_sided_single_coin_hsl_accepts_unified_signal_mode():
+    validate_single_coin_hsl_signal_topology("unified", enabled_side_count=1)
+
+
+def test_dual_side_single_coin_hsl_rejects_unified_signal_mode():
+    with pytest.raises(ValueError, match="account-wide exact-Rust flatten contract"):
+        validate_single_coin_hsl_signal_topology("unified", enabled_side_count=2)
+
+
+def test_single_coin_hsl_rejects_unknown_signal_mode():
+    with pytest.raises(ValueError, match="coin, pside, or unified"):
+        validate_single_coin_hsl_signal_topology("portfolio", enabled_side_count=1)
 
 
 def test_directional_parameter_matrix_keeps_side_values_separate():


### PR DESCRIPTION
## Summary

- support dual-side, single-coin Apple MPS HSL for EMA Anchor and Trailing Martingale in pside and coin signal modes
- track realized net PnL independently for long and short while retaining shared account balance and exact Rust validation
- keep dual-side unified HSL fail closed until the documented account-wide episode-finalization scope and current exact-backtest per-side confirmation are reconciled
- keep multi-coin and per-coin-override HSL fail closed

## Safety boundary

This is additive GPU-only behavior. It changes no CPU optimizer, exact Rust backtest, live bot, or exchange behavior. Exact Rust remains authoritative for validated candidates.

## Validation

- cargo fmt --manifest-path passivbot-rust/Cargo.toml --check
- cargo check --manifest-path passivbot-rust/Cargo.toml --tests
- cargo test --manifest-path passivbot-rust/Cargo.toml --no-default-features: 263 passed
- GPU backend and service suites: 430 passed
- physical Apple M3 HSL matrix: 9 passed across shared Rust-to-Metal trace conformance, both strategy kinds, both sides, and dual-side pside/coin isolation
- real dual-side EMA Anchor coin-mode MPS optimization: 9 generations, 288 proxy evaluations, 9 exact validations, constraint agreement 1.000, front rank rho 0.983, clean completion
- real dual-side pside-mode MPS optimization: 9 generations, 288 proxy evaluations, 9 exact validations, clean completion
- dual-side unified CLI check: explicit fail-closed error before kernel execution
- AI documentation check: 0 errors, 2 pre-existing size warnings
- git diff --check