### PR TITLE
feat(optimize): support one-sided multicoin MPS HSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added one-sided multi-coin HSL to Apple MPS optimization for EMA Anchor and Trailing
+  Martingale in `unified` and `pside` signal modes, including compatible suites. Each Metal
+  candidate now applies one shared-balance portfolio HSL controller across every coin on the
+  enabled side, including warning tiers, RED entry blocking, limit panic flattening, cooldown
+  restart, lifecycle metrics, and panic-loss metrics. Exact Rust validation remains authoritative;
+  dual-side multi-coin HSL, multi-coin `coin` mode, per-coin HSL overrides, and multi-coin market
+  panic closes remain fail closed.
+
 - Added dual-side single-coin HSL to Apple MPS optimization for EMA Anchor and Trailing
   Martingale in `coin` and `pside` signal modes, including compatible suites. Metal now tracks
   realized net PnL independently for long and short while retaining shared account balance and

--- a/docs/equity_hard_stop_loss_reference.md
+++ b/docs/equity_hard_stop_loss_reference.md
@@ -124,13 +124,15 @@ These are the main parity surfaces that should be reviewed together:
 8. Rust-owned HSL primitives
    - Live orchestration and exact backtests share the Rust drawdown-step, coin-signal, and RED-episode-finalization contracts
    - Apple MPS screening remains approximate and is always revalidated by exact Rust
-9. Apple MPS single-coin controller
+9. Apple MPS controller
    - One shared Rust-owned Metal HSL controller is composed into both EMA Anchor and Trailing Martingale directional kernels
    - Unified, pside, and coin signal modes use explicit encoded identities instead of a coin/non-coin boolean
    - Deterministic M3 conformance coverage compares Metal drawdown, EMA, tier, active-RED, latch, and RED-finalization traces against the exact Rust runtime for all three signal modes and restart policies
    - One-sided runs support unified, pside, and coin signals; dual-side runs support pside and coin signals with independent directional realized-PnL state
+   - One-sided multi-coin runs support unified and pside signals through one shared-balance portfolio controller that tracks all positions and blocking orders on the enabled side
+   - Multi-coin limit panic closes flatten every open coin on the enabled side and export the same lifecycle and panic-loss metric surface as single-coin HSL
    - Dual-side unified HSL remains fail closed because the documented account-wide episode-finalization scope and current exact-backtest per-side flat confirmation disagree
-   - Multi-coin and per-coin-override HSL still fail closed
+   - Dual-side multi-coin HSL, multi-coin coin signals, multi-coin market panic closes, and per-coin-override HSL still fail closed
 
 ### Confirmed Gaps / Risks
 
@@ -143,15 +145,17 @@ These are the main parity surfaces that should be reviewed together:
    - Deprecated `*_hsl` metric names remain accepted as aliases for older configs/results
 3. GPU HSL topology is intentionally narrow
    - Dual-side unified HSL needs one resolved account-wide exact-Rust flatten contract before it can be screened safely
-   - Multi-coin HSL needs a shared-balance portfolio controller before it can be screened safely
-   - Per-coin HSL overrides require candidate-local resolved settings in that portfolio controller
+   - Dual-side multi-coin HSL needs one shared-balance controller that owns both directional state machines without duplicating account balance or liquidation decisions
+   - Multi-coin coin mode needs one controller per effective coin+pside scope rather than the single portfolio controller used by unified and pside modes
+   - Per-coin HSL overrides require candidate-local resolved settings in those coin controllers
+   - Multi-coin market panic execution needs explicit taker/slippage parity across every same-candle portfolio flatten
 
 ### Missing or Weak Test Coverage
 
 1. End-to-end replay of one identical fill/candle history through live reconstruction and exact backtest orchestration; shared Rust primitive tests cover the calculations but not the complete orchestration trace
 2. Connector-level restart races while protective panic-close orders are live on an exchange
 3. Manual or external trading during downtime across the full exchange-adapter matrix
-4. Apple MPS parity for dual-side unified, multi-coin, and per-coin-override HSL scopes
+4. Apple MPS parity for dual-side unified, dual-side multi-coin, multi-coin coin-mode/market-panic, and per-coin-override HSL scopes
 
 ## Optimizer Work
 

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -11,36 +11,38 @@ const MPS_HSL_COMMON_SOURCE: &str = include_str!("gpu/mps_hsl_common.metal");
 const MPS_EMA_ANCHOR_BODY: &str = include_str!("gpu/mps_ema_anchor_directional.metal");
 const MPS_TRAILING_MARTINGALE_BODY: &str =
     include_str!("gpu/mps_trailing_martingale_directional.metal");
+const MPS_EMA_ANCHOR_MULTICOIN_BODY: &str = include_str!("gpu/mps_ema_anchor_multicoin_long.metal");
+const MPS_TRAILING_MARTINGALE_MULTICOIN_BODY: &str =
+    include_str!("gpu/mps_trailing_martingale_multicoin.metal");
 
-fn compose_directional_source(body: &str) -> String {
+fn compose_hsl_source(body: &str) -> String {
     assert_eq!(
         body.matches(MPS_HSL_MARKER).count(),
         1,
-        "directional MPS source must contain exactly one shared-HSL marker"
+        "MPS source must contain exactly one shared-HSL marker"
     );
     body.replacen(MPS_HSL_MARKER, MPS_HSL_COMMON_SOURCE, 1)
 }
 
 pub static MPS_EMA_ANCHOR_SOURCE: LazyLock<String> =
-    LazyLock::new(|| compose_directional_source(MPS_EMA_ANCHOR_BODY));
-pub const MPS_EMA_ANCHOR_MULTICOIN_SOURCE: &str =
-    include_str!("gpu/mps_ema_anchor_multicoin_long.metal");
-pub const MPS_EMA_ANCHOR_MULTICOIN_LONG_SOURCE: &str = MPS_EMA_ANCHOR_MULTICOIN_SOURCE;
+    LazyLock::new(|| compose_hsl_source(MPS_EMA_ANCHOR_BODY));
+pub static MPS_EMA_ANCHOR_MULTICOIN_SOURCE: LazyLock<String> =
+    LazyLock::new(|| compose_hsl_source(MPS_EMA_ANCHOR_MULTICOIN_BODY));
 pub static MPS_TRAILING_MARTINGALE_SOURCE: LazyLock<String> =
-    LazyLock::new(|| compose_directional_source(MPS_TRAILING_MARTINGALE_BODY));
-pub const MPS_TRAILING_MARTINGALE_MULTICOIN_SOURCE: &str =
-    include_str!("gpu/mps_trailing_martingale_multicoin.metal");
+    LazyLock::new(|| compose_hsl_source(MPS_TRAILING_MARTINGALE_BODY));
+pub static MPS_TRAILING_MARTINGALE_MULTICOIN_SOURCE: LazyLock<String> =
+    LazyLock::new(|| compose_hsl_source(MPS_TRAILING_MARTINGALE_MULTICOIN_BODY));
 
 pub fn mps_ema_anchor_source() -> &'static str {
     MPS_EMA_ANCHOR_SOURCE.as_str()
 }
 
 pub fn mps_ema_anchor_multicoin_source() -> &'static str {
-    MPS_EMA_ANCHOR_MULTICOIN_SOURCE
+    MPS_EMA_ANCHOR_MULTICOIN_SOURCE.as_str()
 }
 
 pub fn mps_ema_anchor_multicoin_long_source() -> &'static str {
-    MPS_EMA_ANCHOR_MULTICOIN_LONG_SOURCE
+    MPS_EMA_ANCHOR_MULTICOIN_SOURCE.as_str()
 }
 
 pub fn mps_trailing_martingale_source() -> &'static str {
@@ -48,7 +50,7 @@ pub fn mps_trailing_martingale_source() -> &'static str {
 }
 
 pub fn mps_trailing_martingale_multicoin_source() -> &'static str {
-    MPS_TRAILING_MARTINGALE_MULTICOIN_SOURCE
+    MPS_TRAILING_MARTINGALE_MULTICOIN_SOURCE.as_str()
 }
 
 #[cfg(test)]
@@ -182,17 +184,21 @@ mod tests {
     #[test]
     fn ema_anchor_multicoin_mps_source_exposes_expected_kernel_contract() {
         let source = mps_ema_anchor_multicoin_source();
+        assert_shared_hsl_contract(source);
         assert!(source.contains("kernel void passivbot_ema_anchor_multicoin"));
         assert!(source.contains("kernel void passivbot_ema_anchor_multicoin_long"));
         assert!(source.contains("const bool short_side"));
         assert!(source.contains("constant int MAX_COINS = 64"));
-        assert!(source.contains("constant int PARAM_COLS = 31"));
+        assert!(source.contains("constant int PARAM_COLS = 42"));
         assert!(source.contains("constant int OVERRIDE_COLS = 19"));
         assert!(source.contains("coin_override_or"));
         assert!(source.contains("constant int COIN_COLS = 11"));
         assert!(source.contains("constant int DAILY_COLS = 9"));
         assert!(source.contains("day_min_balance"));
-        assert!(source.contains("constant int SCALAR_COLS = 32"));
+        assert!(source.contains("constant int SCALAR_COLS = 57"));
+        assert!(source.contains("load_hsl(params, po, 31)"));
+        assert!(source.contains("write_one_side_hsl_outputs("));
+        assert!(source.contains("record_hsl_panic_fill("));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[scalar_offset + 19] = loss_sum"));
         assert!(source
@@ -376,11 +382,15 @@ mod tests {
     #[test]
     fn trailing_martingale_multicoin_mps_source_exposes_expected_kernel_contract() {
         let source = mps_trailing_martingale_multicoin_source();
+        assert_shared_hsl_contract(source);
         assert!(source.contains("kernel void passivbot_trailing_martingale_multicoin"));
         assert!(source.contains("constant int MAX_COINS = 64"));
-        assert!(source.contains("constant int PARAM_COLS = 48"));
+        assert!(source.contains("constant int PARAM_COLS = 59"));
         assert!(source.contains("constant int OVERRIDE_COLS = 34"));
-        assert!(source.contains("constant int SCALAR_COLS = 32"));
+        assert!(source.contains("constant int SCALAR_COLS = 57"));
+        assert!(source.contains("load_hsl(params, po, 48)"));
+        assert!(source.contains("write_one_side_hsl_outputs("));
+        assert!(source.contains("record_hsl_panic_fill("));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[scalar_offset + 19] = loss_sum"));
         assert!(source

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -1,12 +1,14 @@
 #include <metal_stdlib>
 using namespace metal;
 
+// PASSIVBOT_HSL_COMMON
+
 constant int MAX_COINS = 64;
-constant int PARAM_COLS = 31;
+constant int PARAM_COLS = 42;
 constant int COIN_COLS = 11;
 constant int OVERRIDE_COLS = 19;
 constant int DAILY_COLS = 9;
-constant int SCALAR_COLS = 32;
+constant int SCALAR_COLS = 57;
 constant int GAP_BINS = 128;
 
 inline float round_step(float value, float step) {
@@ -281,6 +283,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
     const float unstuck_ema_dist = params[po + 28];
     const float unstuck_loss_allowance_pct = params[po + 29];
     const float unstuck_threshold = params[po + 30];
+    HslState hsl = load_hsl(params, po, 31);
     const float weight_sum = w_volume + w_ready + w_volatility;
     if (weight_sum > 0.0f) {
         w_volume /= weight_sum;
@@ -332,6 +335,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
     int twel_close_tick[MAX_COINS];
     int unstuck_close_tick[MAX_COINS];
     bool close_is_unstuck_reducer[MAX_COINS];
+    bool close_is_hsl_panic[MAX_COINS];
     bool selected[MAX_COINS];
     bool incumbent[MAX_COINS];
     bool survivor[MAX_COINS];
@@ -377,6 +381,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
         twel_close_tick[c] = 0;
         unstuck_close_tick[c] = 0;
         close_is_unstuck_reducer[c] = false;
+        close_is_hsl_panic[c] = false;
         selected[c] = false;
         incumbent[c] = false;
         survivor[c] = false;
@@ -448,6 +453,10 @@ inline void passivbot_ema_anchor_multicoin_impl(
     float first_eq_k = -1.0f;
     float last_eq_k = -1.0f;
     int liquidation_day = -1;
+    float hsl_tier_samples_total = 0.0f;
+    float hsl_tier_samples_yellow = 0.0f;
+    float hsl_tier_samples_orange = 0.0f;
+    float hsl_tier_samples_red = 0.0f;
 
     int current_day = 0;
     bool day_touched = false;
@@ -488,6 +497,17 @@ inline void passivbot_ema_anchor_multicoin_impl(
         }
 
         bool any_fill = false;
+        float hsl_equity_before_fills = balance;
+        for (int c = 0; c < C; ++c) {
+            int coin_offset = c * COIN_COLS;
+            int bar_offset = (k * C + c) * 4;
+            float close = bars[bar_offset + 2];
+            if (psize[c] > 0.0f && finite_positive(close)) {
+                hsl_equity_before_fills += psize[c]
+                    * coin_settings[coin_offset + 4]
+                    * (short_side ? pprice[c] - close : close - pprice[c]);
+            }
+        }
         for (int c = 0; c < C; ++c) {
             const int coin_offset = c * COIN_COLS;
             const int bar_offset = (k * C + c) * 4;
@@ -541,13 +561,20 @@ inline void passivbot_ema_anchor_multicoin_impl(
                     - adjusted * fill_price * c_mult * maker_fee;
                 bool is_unstuck = !use_secondary
                     && close_is_unstuck_reducer[c];
-                if (!realized_loss_proxy_allows_reducer(
+                bool is_hsl_panic = !use_secondary
+                    && close_is_hsl_panic[c];
+                if (!is_hsl_panic && !realized_loss_proxy_allows_reducer(
                         adjusted, fill_price, pprice[c], short_side,
                         c_mult, maker_fee, is_unstuck, loss_gate_enabled,
                         balance, realized_pnl_cumsum_last,
                         realized_pnl_cumsum_max, max_realized_loss_pct
                     )) {
                     continue;
+                }
+                if (is_hsl_panic) {
+                    record_hsl_panic_fill(
+                        hsl, net_pnl, hsl_equity_before_fills
+                    );
                 }
                 record_gross_pnl(pnl, profit_sum, loss_sum);
                 balance += net_pnl;
@@ -581,6 +608,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 } else {
                     close_qty[c] = 0.0f;
                     close_is_unstuck_reducer[c] = false;
+                    close_is_hsl_panic[c] = false;
                 }
                 executed_close = true;
             }
@@ -718,6 +746,11 @@ inline void passivbot_ema_anchor_multicoin_impl(
         const bool can_generate = alive && effective_n_positions > 0
             && k > max(global_warmup, 1) && k >= requested_start_k;
         equity_started = equity_started || can_generate;
+        bool has_hsl_position = false;
+        for (int c = 0; c < C; ++c) {
+            has_hsl_position = has_hsl_position || psize[c] > 0.0f;
+        }
+        int current_hsl_mode = hsl_mode(hsl, has_hsl_position);
 
         if (can_generate) {
             // Exact Rust ranks flat candidates every minute. Re-ranking only
@@ -1129,6 +1162,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 close_qty[c] = 0.0f;
                 secondary_close_qty[c] = 0.0f;
                 secondary_close_tick[c] = 0;
+                close_is_hsl_panic[c] = false;
                 contribution[c] = 0.0f;
                 entry_candidate[c] = false;
                 int coin_offset = c * COIN_COLS;
@@ -1452,11 +1486,33 @@ inline void passivbot_ema_anchor_multicoin_impl(
                     break;
                 }
             }
+            for (int c = 0; c < C; ++c) {
+                if (current_hsl_mode >= 2
+                    || (current_hsl_mode != 0 && psize[c] <= 0.0f)) {
+                    entry_qty[c] = 0.0f;
+                }
+                if (current_hsl_mode == 3 && psize[c] > 0.0f) {
+                    int tick_offset = (k * C + c) * 2;
+                    close_qty[c] = psize[c];
+                    close_tick[c] = max(
+                        short_side
+                            ? touch_ticks[tick_offset + 1] + 1
+                            : touch_ticks[tick_offset + 0] - 1,
+                        1
+                    );
+                    secondary_close_qty[c] = 0.0f;
+                    secondary_close_tick[c] = 0;
+                    close_is_unstuck_reducer[c] = false;
+                    close_is_hsl_panic[c] = true;
+                }
+            }
         }
 
         float unrealized = 0.0f;
         float position_cost = 0.0f;
         bool any_valid = false;
+        bool has_open_position = false;
+        bool has_blocking_orders = false;
         for (int c = 0; c < C; ++c) {
             int coin_offset = c * COIN_COLS;
             int bar_offset = (k * C + c) * 4;
@@ -1467,13 +1523,36 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 any_valid = true;
             }
             if (psize[c] > 0.0f) {
+                has_open_position = true;
                 position_cost += psize[c] * pprice[c]
                     * coin_settings[coin_offset + 4];
                 unrealized += psize[c] * coin_settings[coin_offset + 4]
                     * (short_side ? pprice[c] - close : close - pprice[c]);
             }
+            if (current_hsl_mode != 3 && (
+                    entry_qty[c] > 0.0f || close_qty[c] > 0.0f
+                        || secondary_close_qty[c] > 0.0f
+                )) {
+                has_blocking_orders = true;
+            }
         }
         float equity = balance + unrealized;
+        if (can_generate && any_valid && alive
+            && balance > 0.0f && equity > liquidation_floor) {
+            update_hsl(
+                hsl, balance, starting_balance,
+                realized_pnl_cumsum_last, unrealized,
+                has_open_position, has_blocking_orders,
+                float(k), interval_ms
+            );
+            if (hsl.enabled) {
+                hsl_tier_samples_total += 1.0f;
+                hsl_tier_samples_yellow += hsl.tier == 1 ? 1.0f : 0.0f;
+                hsl_tier_samples_orange += hsl.tier == 2 ? 1.0f : 0.0f;
+                hsl_tier_samples_red += hsl.tier == 3 ? 1.0f : 0.0f;
+            }
+            try_restart_hsl(hsl, float(k), equity);
+        }
         bool active = equity_started && alive && any_valid;
         if (active) {
             if (first_eq_k < 0.0f) first_eq_k = float(k);
@@ -1618,6 +1697,16 @@ inline void passivbot_ema_anchor_multicoin_impl(
     scalars[scalar_offset + 29] = held_sum_min * interval_ms;
     scalars[scalar_offset + 30] = held_count;
     scalars[scalar_offset + 31] = account_recovery_max_min * interval_ms;
+    write_one_side_hsl_outputs(
+        hsl, short_side,
+        hsl_tier_samples_total,
+        hsl_tier_samples_yellow,
+        hsl_tier_samples_orange,
+        hsl_tier_samples_red,
+        last_eq_k,
+        scalars,
+        scalar_offset + 32
+    );
 }
 
 kernel void passivbot_ema_anchor_multicoin(

--- a/passivbot-rust/src/gpu/mps_hsl_common.metal
+++ b/passivbot-rust/src/gpu/mps_hsl_common.metal
@@ -360,3 +360,48 @@ inline void record_hsl_panic_fill(
     h.panic_close_loss_sum += panic_loss;
     h.panic_close_loss_max = fmax(h.panic_close_loss_max, panic_loss);
 }
+
+inline void write_one_side_hsl_outputs(
+    thread HslState& h,
+    bool short_side,
+    float tier_samples_total,
+    float tier_samples_yellow,
+    float tier_samples_orange,
+    float tier_samples_red,
+    float last_equity_k,
+    device float* scalars,
+    int scalar_offset
+) {
+    float terminal_count = h.halted
+        && h.current_halt_start_k >= 0.0f && last_equity_k >= 0.0f
+        ? 1.0f : 0.0f;
+    float terminal_duration = terminal_count > 0.0f
+        ? fmax(last_equity_k - h.current_halt_start_k, 0.0f) : 0.0f;
+    scalars[scalar_offset + 0] = !short_side && h.enabled ? 1.0f : 0.0f;
+    scalars[scalar_offset + 1] = short_side && h.enabled ? 1.0f : 0.0f;
+    scalars[scalar_offset + 2] = !short_side ? h.triggers : 0.0f;
+    scalars[scalar_offset + 3] = short_side ? h.triggers : 0.0f;
+    scalars[scalar_offset + 4] = !short_side ? h.restarts : 0.0f;
+    scalars[scalar_offset + 5] = short_side ? h.restarts : 0.0f;
+    scalars[scalar_offset + 6] = tier_samples_total;
+    scalars[scalar_offset + 7] = tier_samples_yellow;
+    scalars[scalar_offset + 8] = tier_samples_orange;
+    scalars[scalar_offset + 9] = tier_samples_red;
+    scalars[scalar_offset + 10] = h.halt_duration_sum_steps + terminal_duration;
+    scalars[scalar_offset + 11] = fmax(
+        h.halt_duration_max_steps, terminal_duration
+    );
+    scalars[scalar_offset + 12] = h.halt_duration_count + terminal_count;
+    scalars[scalar_offset + 13] = h.trigger_drawdown_sum;
+    scalars[scalar_offset + 14] = h.trigger_drawdown_count;
+    scalars[scalar_offset + 15] = h.flatten_time_sum_steps;
+    scalars[scalar_offset + 16] = h.flatten_time_count;
+    scalars[scalar_offset + 17] = h.restart_retrigger_count;
+    scalars[scalar_offset + 18] = h.halt_to_restart_equity_loss;
+    scalars[scalar_offset + 19] = h.panic_close_loss_sum;
+    scalars[scalar_offset + 20] = h.panic_close_loss_max;
+    scalars[scalar_offset + 21] = h.panic_loss_drawdown_min;
+    scalars[scalar_offset + 22] = h.panic_loss_drawdown_sum;
+    scalars[scalar_offset + 23] = h.panic_loss_drawdown_max;
+    scalars[scalar_offset + 24] = h.panic_loss_drawdown_count;
+}

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -1,12 +1,14 @@
 #include <metal_stdlib>
 using namespace metal;
 
+// PASSIVBOT_HSL_COMMON
+
 constant int MAX_COINS = 64;
-constant int PARAM_COLS = 48;
+constant int PARAM_COLS = 59;
 constant int OVERRIDE_COLS = 34;
 constant int COIN_COLS = 11;
 constant int DAILY_COLS = 9;
-constant int SCALAR_COLS = 32;
+constant int SCALAR_COLS = 57;
 constant int GAP_BINS = 128;
 
 inline float round_step(float value, float step) {
@@ -515,6 +517,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     const float unstuck_ema_dist = params[po + 45];
     const float unstuck_loss_allowance_pct = params[po + 46];
     const float unstuck_threshold = params[po + 47];
+    HslState hsl = load_hsl(params, po, 48);
     const float weight_sum = w_volume + w_ready + w_volatility;
     if (weight_sum > 0.0f) {
         w_volume /= weight_sum;
@@ -580,6 +583,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     bool close_reconstruct_after_reducer[MAX_COINS];
     bool filled_coin[MAX_COINS];
     bool close_is_unstuck_reducer[MAX_COINS];
+    bool close_is_hsl_panic[MAX_COINS];
     float alpha0_coin[MAX_COINS];
     float alpha1_coin[MAX_COINS];
     float alpha2_coin[MAX_COINS];
@@ -635,6 +639,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         close_reconstruct_after_reducer[c] = false;
         filled_coin[c] = false;
         close_is_unstuck_reducer[c] = false;
+        close_is_hsl_panic[c] = false;
         float coin_span_a = c < C
             ? coin_override_or(coin_overrides, c, 0, span_a) : span_a;
         float coin_span_b = c < C
@@ -708,6 +713,10 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     float first_eq_k = -1.0f;
     float last_eq_k = -1.0f;
     int liquidation_day = -1;
+    float hsl_tier_samples_total = 0.0f;
+    float hsl_tier_samples_yellow = 0.0f;
+    float hsl_tier_samples_orange = 0.0f;
+    float hsl_tier_samples_red = 0.0f;
 
     int current_day = 0;
     bool day_touched = false;
@@ -748,6 +757,17 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         }
 
         bool any_fill = false;
+        float hsl_equity_before_fills = balance;
+        for (int c = 0; c < C; ++c) {
+            int coin_offset = c * COIN_COLS;
+            int bar_offset = (k * C + c) * 4;
+            float close = bars[bar_offset + 2];
+            if (psize[c] > 0.0f && finite_positive(close)) {
+                hsl_equity_before_fills += psize[c]
+                    * coin_settings[coin_offset + 4]
+                    * (short_side ? pprice[c] - close : close - pprice[c]);
+            }
+        }
         for (int c = 0; c < C; ++c) filled_coin[c] = false;
         for (int c = 0; c < C; ++c) {
             const int coin_offset = c * COIN_COLS;
@@ -779,7 +799,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     ? secondary_close_tick[c] > fill_ticks[tick_offset + 1]
                     : secondary_close_tick[c] <= fill_ticks[tick_offset + 0]);
             bool rebuild_grid = psize[c] > 0.0f
-                && close_reconstruct_after_reducer[c];
+                && close_reconstruct_after_reducer[c]
+                && !close_is_hsl_panic[c];
             if (filled_close || filled_secondary_close || rebuild_grid) {
                 float fill_price = float(close_tick[c]) * price_step;
                 float reducer_qty = fmin(
@@ -1084,7 +1105,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                         ? pprice[c] - price : price - pprice[c]);
                     bool is_unstuck = !use_secondary
                         && close_is_unstuck_reducer[c];
-                    if (!realized_loss_proxy_allows_reducer(
+                    bool is_hsl_panic = !use_secondary
+                        && close_is_hsl_panic[c];
+                    if (!is_hsl_panic && !realized_loss_proxy_allows_reducer(
                             qty, price, pprice[c], short_side,
                             c_mult, maker_fee, is_unstuck, loss_gate_enabled,
                             balance, realized_pnl_cumsum_last,
@@ -1093,6 +1116,11 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                         continue;
                     }
                     float net_pnl = pnl - qty * price * c_mult * maker_fee;
+                    if (is_hsl_panic) {
+                        record_hsl_panic_fill(
+                            hsl, net_pnl, hsl_equity_before_fills
+                        );
+                    }
                     record_gross_pnl(pnl, profit_sum, loss_sum);
                     balance += net_pnl;
                     record_realized_net(
@@ -1130,6 +1158,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     secondary_close_qty[c] = 0.0f;
                     close_reconstruct_after_reducer[c] = false;
                     close_is_unstuck_reducer[c] = false;
+                    close_is_hsl_panic[c] = false;
                     filled_coin[c] = true;
                     any_fill = true;
                 }
@@ -1289,6 +1318,11 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         const bool can_generate = alive && effective_n_positions > 0
             && k > max(global_warmup, 1) && k >= requested_start_k;
         equity_started = equity_started || can_generate;
+        bool has_hsl_position = false;
+        for (int c = 0; c < C; ++c) {
+            has_hsl_position = has_hsl_position || psize[c] > 0.0f;
+        }
+        int current_hsl_mode = hsl_mode(hsl, has_hsl_position);
 
         if (can_generate) {
             // Exact Rust ranks flat candidates every minute. Re-ranking only
@@ -1715,6 +1749,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 secondary_close_qty[c] = 0.0f;
                 secondary_close_tick[c] = 0;
                 close_reconstruct_after_reducer[c] = false;
+                close_is_hsl_panic[c] = false;
                 close_grid_gen_psize[c] = 0.0f;
                 close_grid_max_rungs[c] = 500;
                 contribution[c] = 0.0f;
@@ -2272,11 +2307,35 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     break;
                 }
             }
+            for (int c = 0; c < C; ++c) {
+                if (current_hsl_mode >= 2
+                    || (current_hsl_mode != 0 && psize[c] <= 0.0f)) {
+                    entry_qty[c] = 0.0f;
+                }
+                if (current_hsl_mode == 3 && psize[c] > 0.0f) {
+                    int tick_offset = (k * C + c) * 2;
+                    close_qty[c] = psize[c];
+                    close_tick[c] = max(
+                        short_side
+                            ? touch_ticks[tick_offset + 1] + 1
+                            : touch_ticks[tick_offset + 0] - 1,
+                        1
+                    );
+                    secondary_close_qty[c] = 0.0f;
+                    secondary_close_tick[c] = 0;
+                    close_reconstruct_after_reducer[c] = false;
+                    close_grid_gen_psize[c] = 0.0f;
+                    close_is_unstuck_reducer[c] = false;
+                    close_is_hsl_panic[c] = true;
+                }
+            }
         }
 
         float unrealized = 0.0f;
         float position_cost = 0.0f;
         bool any_valid = false;
+        bool has_open_position = false;
+        bool has_blocking_orders = false;
         for (int c = 0; c < C; ++c) {
             int coin_offset = c * COIN_COLS;
             int bar_offset = (k * C + c) * 4;
@@ -2287,13 +2346,36 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 any_valid = true;
             }
             if (psize[c] > 0.0f) {
+                has_open_position = true;
                 position_cost += psize[c] * pprice[c]
                     * coin_settings[coin_offset + 4];
                 unrealized += psize[c] * coin_settings[coin_offset + 4]
                     * (short_side ? pprice[c] - close : close - pprice[c]);
             }
+            if (current_hsl_mode != 3 && (
+                    entry_qty[c] > 0.0f || close_qty[c] > 0.0f
+                        || secondary_close_qty[c] > 0.0f
+                )) {
+                has_blocking_orders = true;
+            }
         }
         float equity = balance + unrealized;
+        if (can_generate && any_valid && alive
+            && balance > 0.0f && equity > liquidation_floor) {
+            update_hsl(
+                hsl, balance, starting_balance,
+                realized_pnl_cumsum_last, unrealized,
+                has_open_position, has_blocking_orders,
+                float(k), interval_ms
+            );
+            if (hsl.enabled) {
+                hsl_tier_samples_total += 1.0f;
+                hsl_tier_samples_yellow += hsl.tier == 1 ? 1.0f : 0.0f;
+                hsl_tier_samples_orange += hsl.tier == 2 ? 1.0f : 0.0f;
+                hsl_tier_samples_red += hsl.tier == 3 ? 1.0f : 0.0f;
+            }
+            try_restart_hsl(hsl, float(k), equity);
+        }
         bool active = equity_started && alive && any_valid;
         if (active) {
             if (first_eq_k < 0.0f) first_eq_k = float(k);
@@ -2438,6 +2520,16 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     scalars[scalar_offset + 29] = held_sum_min * interval_ms;
     scalars[scalar_offset + 30] = held_count;
     scalars[scalar_offset + 31] = account_recovery_max_min * interval_ms;
+    write_one_side_hsl_outputs(
+        hsl, short_side,
+        hsl_tier_samples_total,
+        hsl_tier_samples_yellow,
+        hsl_tier_samples_orange,
+        hsl_tier_samples_red,
+        last_eq_k,
+        scalars,
+        scalar_offset + 32
+    );
 }
 
 kernel void passivbot_trailing_martingale_multicoin(

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -28,7 +28,7 @@ from optimization.callback import build_pymoo_record_entry
 from optimization.fine_tune_anchors import ANCHOR_GENE_KEY, get_anchor_plan
 from optimization.gpu.model import (
     gpu_side_enabled,
-    validate_single_coin_hsl_signal_topology,
+    validate_hsl_signal_topology,
 )
 from optimization.interrupts import (
     InterruptCheck,
@@ -163,6 +163,10 @@ EMA_MULTICOIN_BOUND_MAPS = {
             f"{side}_{bound_suffix}": f"{side}_{parameter}"
             for bound_suffix, parameter in _SINGLE_COIN_UNSTUCK_BOUND_SUFFIXES.items()
         },
+        **{
+            f"{side}_{bound_suffix}": f"{side}_{parameter}"
+            for bound_suffix, parameter in _SINGLE_COIN_HSL_BOUND_SUFFIXES.items()
+        },
     }
     for side in ("long", "short")
 }
@@ -239,6 +243,10 @@ TRAILING_MARTINGALE_MULTICOIN_BOUND_MAPS = {
         **{
             f"{side}_{bound_suffix}": f"{side}_{parameter}"
             for bound_suffix, parameter in _SINGLE_COIN_UNSTUCK_BOUND_SUFFIXES.items()
+        },
+        **{
+            f"{side}_{bound_suffix}": f"{side}_{parameter}"
+            for bound_suffix, parameter in _SINGLE_COIN_HSL_BOUND_SUFFIXES.items()
         },
     }
     for side in ("long", "short")
@@ -991,10 +999,6 @@ def _validate_scope_config(
         if bool(config["bot"][side].get("hsl", {}).get("enabled"))
     ]
     if hsl_enabled_sides:
-        if coin_count != 1:
-            raise ValueError(
-                "GPU HSL currently requires one backtest coin"
-            )
         # The proxy deliberately keeps an all-history candidate-local peak for
         # finite windows. That peak is never below Rust's rolling-window peak,
         # so HSL may trigger early but cannot miss a drawdown solely because an
@@ -1006,8 +1010,10 @@ def _validate_scope_config(
         signal_mode = str(
             config.get("live", {}).get("hsl_signal_mode", "unified")
         ).strip().lower()
-        validate_single_coin_hsl_signal_topology(
-            signal_mode, enabled_side_count=len(enabled_sides)
+        validate_hsl_signal_topology(
+            signal_mode,
+            coin_count=coin_count,
+            enabled_side_count=len(enabled_sides),
         )
         for side in hsl_enabled_sides:
             hsl = config["bot"][side].get("hsl", {})
@@ -1018,6 +1024,11 @@ def _validate_scope_config(
                 raise ValueError(
                     f"GPU HSL requires bot.{side}.hsl.panic_close_order_type "
                     f"to be limit or market, got {panic_order_type!r}"
+                )
+            if coin_count > 1 and panic_order_type != "limit":
+                raise ValueError(
+                    f"GPU multi-coin HSL currently requires bot.{side}.hsl."
+                    "panic_close_order_type=limit"
                 )
     for side in enabled_sides:
         side_config = config["bot"][side]
@@ -1083,13 +1094,13 @@ def _validate_dual_multicoin_metrics(
 
 
 def _validate_hsl_metric_topology(
-    needed_metrics, *, coin_count: int, hard_stop_metrics
+    needed_metrics, *, coin_count: int, enabled_sides, hard_stop_metrics
 ) -> None:
     unsupported = sorted(set(needed_metrics) & set(hard_stop_metrics))
-    if int(coin_count) > 1 and unsupported:
+    if int(coin_count) > 1 and len(set(enabled_sides)) > 1 and unsupported:
         raise ValueError(
-            "GPU HSL optimizer metrics currently require single-coin directional "
-            "Metal output; multi-coin HSL metrics remain unsupported: "
+            "GPU HSL optimizer metrics currently require one shared HSL controller; "
+            "dual-side multi-coin HSL metrics remain unsupported: "
             f"{unsupported}"
         )
 
@@ -2464,7 +2475,7 @@ def _validate_pinned_scope_bounds(
 ) -> None:
     enabled_sides = set(enabled_sides or ("long", "short"))
     pinned = {}
-    if coin_count != 1 or len(enabled_sides) != 1:
+    if len(enabled_sides) != 1:
         pinned.update(
             {f"{side}_hsl_enabled": 0.0 for side in ("long", "short")}
         )
@@ -3129,6 +3140,7 @@ def run_backend(
     _validate_hsl_metric_topology(
         needed_metrics,
         coin_count=max_coin_count,
+        enabled_sides=enabled_sides,
         hard_stop_metrics=HARD_STOP_PROXY_METRICS,
     )
     _validate_dual_multicoin_metrics(

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -12,20 +12,39 @@ MPS_MULTICOIN_MAX_COINS = 64
 HSL_SIGNAL_MODES = {"unified", "pside", "coin"}
 
 
-def validate_single_coin_hsl_signal_topology(
-    signal_mode: str, *, enabled_side_count: int
+def validate_hsl_signal_topology(
+    signal_mode: str, *, coin_count: int, enabled_side_count: int
 ) -> None:
     if signal_mode not in HSL_SIGNAL_MODES:
         raise ValueError(
             "GPU HSL requires live.hsl_signal_mode to be coin, pside, or "
             f"unified; got {signal_mode!r}"
         )
+    if coin_count > 1:
+        if enabled_side_count > 1:
+            raise ValueError(
+                "GPU multi-coin HSL currently requires exactly one enabled side"
+            )
+        if signal_mode == "coin":
+            raise ValueError(
+                "GPU one-sided multi-coin HSL currently supports only unified "
+                "or pside signal mode; per-coin HSL remains fail closed"
+            )
+        return
     if enabled_side_count > 1 and signal_mode == "unified":
         raise ValueError(
             "GPU dual-side single-coin HSL currently supports only coin or "
             "pside signal mode; unified remains fail closed pending an "
             "account-wide exact-Rust flatten contract"
         )
+
+
+def validate_single_coin_hsl_signal_topology(
+    signal_mode: str, *, enabled_side_count: int
+) -> None:
+    validate_hsl_signal_topology(
+        signal_mode, coin_count=1, enabled_side_count=enabled_side_count
+    )
 
 EMA_ANCHOR_PARAM_KEYS = (
     "base_qty_pct",
@@ -109,6 +128,7 @@ EMA_ANCHOR_MULTICOIN_PARAM_KEYS = (
     *EXPOSURE_PARAM_KEYS,
     *MULTICOIN_TOTAL_EXPOSURE_ENFORCER_PARAM_KEYS,
     *UNSTUCK_PARAM_KEYS,
+    *HSL_PARAM_KEYS,
 )
 
 TRAILING_MARTINGALE_PARAM_KEYS = (
@@ -163,6 +183,7 @@ TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS = (
     *POSITION_EXPOSURE_ENFORCER_PARAM_KEYS,
     *MULTICOIN_TOTAL_EXPOSURE_ENFORCER_PARAM_KEYS,
     *UNSTUCK_PARAM_KEYS,
+    *HSL_PARAM_KEYS,
 )
 
 TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS = (

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -20,6 +20,7 @@ from optimization.gpu.model import (
 MPS_DAILY_COLS = 8
 MPS_MULTICOIN_DAILY_COLS = 9
 MPS_SCALAR_COLS = 32
+MPS_MULTICOIN_SCALAR_COLS = 57
 MPS_DIRECTIONAL_SCALAR_COLS = 62
 
 
@@ -135,6 +136,31 @@ def _decode_outputs(daily, scalars, gaps) -> dict:
         "held_sum_ms": scalars[:, 29],
         "held_count": scalars[:, 30],
         "account_recovery_max_ms": scalars[:, 31],
+        "hsl_long_enabled": scalars[:, 32] > 0.0,
+        "hsl_short_enabled": scalars[:, 33] > 0.0,
+        "hsl_triggers_long": scalars[:, 34],
+        "hsl_triggers_short": scalars[:, 35],
+        "hsl_restarts_long": scalars[:, 36],
+        "hsl_restarts_short": scalars[:, 37],
+        "hsl_tier_samples_total": scalars[:, 38],
+        "hsl_tier_samples_yellow": scalars[:, 39],
+        "hsl_tier_samples_orange": scalars[:, 40],
+        "hsl_tier_samples_red": scalars[:, 41],
+        "hsl_duration_sum_steps": scalars[:, 42],
+        "hsl_duration_max_steps": scalars[:, 43],
+        "hsl_duration_count": scalars[:, 44],
+        "hsl_trigger_drawdown_sum": scalars[:, 45],
+        "hsl_trigger_drawdown_count": scalars[:, 46],
+        "hsl_flatten_time_sum_steps": scalars[:, 47],
+        "hsl_flatten_time_count": scalars[:, 48],
+        "hsl_restart_retrigger_count": scalars[:, 49],
+        "hsl_halt_to_restart_equity_loss": scalars[:, 50],
+        "hsl_panic_close_loss_sum": scalars[:, 51],
+        "hsl_panic_close_loss_max": scalars[:, 52],
+        "hsl_panic_loss_drawdown_min": scalars[:, 53],
+        "hsl_panic_loss_drawdown_sum": scalars[:, 54],
+        "hsl_panic_loss_drawdown_max": scalars[:, 55],
+        "hsl_panic_loss_drawdown_count": scalars[:, 56],
     }
 
 
@@ -537,7 +563,7 @@ class MpsEmaAnchorMulticoinRunner:
                         device="mps",
                     ),
                     torch.zeros(
-                        (batch_size, MPS_SCALAR_COLS),
+                        (batch_size, MPS_MULTICOIN_SCALAR_COLS),
                         dtype=torch.float32,
                         device="mps",
                     ),

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -19,6 +19,7 @@ from optimization.gpu.model import (
     build_mps_multicoin_data,
     flatten_trailing_martingale_params,
     gpu_side_enabled,
+    validate_hsl_signal_topology,
     validate_single_coin_hsl_signal_topology,
 )
 
@@ -353,8 +354,8 @@ def _hsl_params(bot: dict, *, signal_mode: str) -> dict[str, float]:
         ),
         "hsl_orange_graceful_stop": float(orange_mode == "graceful_stop"),
         "hsl_signal_mode": signal_mode_ids[signal_mode],
-        # The single-coin GPU search contract pins authoritative candidate
-        # n_positions to one even if the source config is outside its bounds.
+        # Coin-mode GPU HSL is single-coin and therefore has one slot. The
+        # value is inert for the unified/pside portfolio signal modes.
         "hsl_slot_count": 1.0,
     }
 
@@ -382,8 +383,33 @@ def _require_no_internal_invalid_hsl_candles(
     if not bool(np.all(valid)):
         first_invalid = first + int(np.flatnonzero(~valid)[0])
         raise ValueError(
-            "MPS single-coin HSL currently requires contiguous valid candles "
+            "MPS HSL currently requires contiguous valid candles "
             f"between first and last valid indices; invalid candle at {first_invalid}"
+        )
+
+
+def _require_no_internal_invalid_multicoin_hsl_candles(
+    hlcvs, *, first_valid_indices, last_valid_indices
+) -> None:
+    values = np.asarray(hlcvs)
+    if values.ndim != 3 or values.shape[2] < 3:
+        raise ValueError(
+            "MPS multi-coin HSL requires HLCVs shaped [time, coin, fields]"
+        )
+    coin_count = values.shape[1]
+    if not (
+        len(first_valid_indices) == len(last_valid_indices) == coin_count
+    ):
+        raise ValueError(
+            "MPS multi-coin HSL valid-index counts must match the coin count"
+        )
+    for coin in range(coin_count):
+        _require_no_internal_invalid_hsl_candles(
+            values[:, coin, 0],
+            values[:, coin, 1],
+            values[:, coin, 2],
+            first_valid_idx=int(first_valid_indices[coin]),
+            last_valid_idx=int(last_valid_indices[coin]),
         )
 
 
@@ -1274,7 +1300,36 @@ class MpsMulticoinProxy:
             "risk_twel_enforcer_policy",
             "risk_twel_enforcer_threshold",
             "hsl_enabled",
+            "hsl_red_threshold",
+            "hsl_ema_span_minutes",
+            "hsl_cooldown_minutes_after_red",
+            "hsl_no_restart_drawdown_threshold",
+            "hsl_restart_after_red_policy",
+            "hsl_tier_ratio_yellow",
+            "hsl_tier_ratio_orange",
+            "hsl_orange_tier_mode",
+            "hsl_panic_close_order_type",
         )
+        signal_mode = (
+            backtest_params.get("equity_hard_stop_loss", {})
+            .get("signal_mode", "unified")
+        )
+        hsl_enabled_sides = [
+            side
+            for side in self.sides
+            if bool(payload.bot_params_list[0][side].get("hsl_enabled"))
+        ]
+        if hsl_enabled_sides:
+            validate_hsl_signal_topology(
+                signal_mode,
+                coin_count=coin_count,
+                enabled_side_count=len(self.sides),
+            )
+            _require_no_internal_invalid_multicoin_hsl_candles(
+                values,
+                first_valid_indices=backtest_params["first_valid_indices"],
+                last_valid_indices=backtest_params["last_valid_indices"],
+            )
         self.base_total_wallet_exposure_limits = {
             side: float(
                 payload.bot_params_list[0][side]["total_wallet_exposure_limit"]
@@ -1289,9 +1344,11 @@ class MpsMulticoinProxy:
         for side in self.sides:
             first_bot = payload.bot_params_list[0][side]
             first_strategy = dict(payload.strategy_params_list[0][side])
-            if bool(first_bot.get("hsl_enabled")):
+            if bool(first_bot.get("hsl_enabled")) and str(
+                first_bot.get("hsl_panic_close_order_type", "limit")
+            ).strip().lower() != "limit":
                 raise ValueError(
-                    f"MPS multicoin proxy requires {side} HSL disabled"
+                    f"MPS multicoin HSL requires {side} panic_close_order_type=limit"
                 )
             if len(self.sides) == 2 and any(
                 bool(item[side].get("unstuck_enabled"))
@@ -1353,6 +1410,7 @@ class MpsMulticoinProxy:
                     )
                 )
             first_strategy.update(_unstuck_params(config["bot"][side]))
+            first_strategy.update(_hsl_params(first_bot, signal_mode=signal_mode))
             missing = [
                 key for key in self.param_keys if key not in first_strategy
             ]
@@ -1554,7 +1612,7 @@ class MpsMulticoinProxy:
                 side: {
                     key: value.cpu()
                     for key, value in raw_side_outputs[side].items()
-                    if key in CORE_OUTPUT_KEYS
+                    if key in CORE_OUTPUT_KEYS | DIRECTIONAL_HSL_OUTPUT_KEYS
                 }
                 for side in self.sides
             }

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1476,27 +1476,75 @@ def test_gpu_hsl_fails_closed_for_dual_side_single_coin_unified_mode():
         _validate_scope(config, _Evaluator())
 
 
-def test_gpu_hsl_fails_closed_for_multicoin():
+@pytest.mark.parametrize("signal_mode", ["unified", "pside"])
+def test_gpu_hsl_accepts_one_sided_multicoin_account_modes(signal_mode):
     config = _long_only_ema_config()
     config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "XRP"]
+    config["live"]["hsl_signal_mode"] = signal_mode
     config["bot"]["long"]["risk"]["n_positions"] = 3
     config["bot"]["long"]["hsl"]["enabled"] = True
 
-    with pytest.raises(ValueError, match="one backtest coin"):
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
+
+
+def test_gpu_hsl_fails_closed_for_multicoin_coin_mode():
+    config = _long_only_ema_config()
+    config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "XRP"]
+    config["live"]["hsl_signal_mode"] = "coin"
+    config["bot"]["long"]["risk"]["n_positions"] = 3
+    config["bot"]["long"]["hsl"]["enabled"] = True
+
+    with pytest.raises(ValueError, match="per-coin HSL remains fail closed"):
         _validate_scope(config, _MulticoinEvaluator())
 
 
-def test_gpu_hsl_metrics_fail_closed_for_multicoin_proxy_outputs():
-    with pytest.raises(ValueError, match="single-coin directional Metal output"):
+def test_gpu_hsl_fails_closed_for_multicoin_market_panic():
+    config = _long_only_ema_config()
+    config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "XRP"]
+    config["live"]["hsl_signal_mode"] = "unified"
+    config["bot"]["long"]["risk"]["n_positions"] = 3
+    config["bot"]["long"]["hsl"].update(
+        {"enabled": True, "panic_close_order_type": "market"}
+    )
+
+    with pytest.raises(ValueError, match="panic_close_order_type=limit"):
+        _validate_scope(config, _MulticoinEvaluator())
+
+
+def test_gpu_hsl_fails_closed_for_dual_side_multicoin():
+    config = _directional_ema_config(long_enabled=True, short_enabled=True)
+    coins = ["BTC", "ETH", "XRP"]
+    config["live"]["approved_coins"] = {"long": coins, "short": coins}
+    config["live"]["hsl_signal_mode"] = "pside"
+    config["live"]["hedge_mode"] = True
+    for side in ("long", "short"):
+        config["bot"][side]["risk"]["n_positions"] = 3
+        config["bot"][side]["hsl"]["enabled"] = True
+
+    with pytest.raises(ValueError, match="exactly one enabled side"):
+        _validate_scope(config, _MulticoinEvaluator())
+
+
+def test_gpu_hsl_metrics_accept_one_sided_multicoin_proxy_outputs():
+    _validate_hsl_metric_topology(
+        {"hard_stop_panic_close_loss_sum"},
+        coin_count=3,
+        enabled_sides=["long"],
+        hard_stop_metrics={"hard_stop_panic_close_loss_sum"},
+    )
+
+    with pytest.raises(ValueError, match="dual-side multi-coin HSL metrics"):
         _validate_hsl_metric_topology(
             {"hard_stop_panic_close_loss_sum"},
             coin_count=3,
+            enabled_sides=["long", "short"],
             hard_stop_metrics={"hard_stop_panic_close_loss_sum"},
         )
 
     _validate_hsl_metric_topology(
         {"hard_stop_panic_close_loss_sum"},
         coin_count=1,
+        enabled_sides=["long", "short"],
         hard_stop_metrics={"hard_stop_panic_close_loss_sum"},
     )
 
@@ -2283,6 +2331,9 @@ def test_gpu_multicoin_bound_map_exposes_forager_and_position_dimensions(
         "unstuck_ema_dist",
         "unstuck_loss_allowance_pct",
         "unstuck_threshold",
+        "hsl_cooldown_minutes_after_red",
+        "hsl_ema_span_minutes",
+        "hsl_red_threshold",
     ):
         assert bound_map[f"{side}_{suffix}"] == f"{side}_{suffix}"
 
@@ -2317,6 +2368,9 @@ def test_gpu_tm_multicoin_bound_map_exposes_strategy_forager_and_positions(side)
         "unstuck_ema_dist",
         "unstuck_loss_allowance_pct",
         "unstuck_threshold",
+        "hsl_cooldown_minutes_after_red",
+        "hsl_ema_span_minutes",
+        "hsl_red_threshold",
     ):
         assert bound_map[f"{side}_{suffix}"] == f"{side}_{suffix}"
 
@@ -4378,6 +4432,22 @@ def test_gpu_accepts_unstuck_bounds_for_single_side_but_pins_dual_multicoin():
     _validate_pinned_scope_bounds(bounds, base, {"long"}, coin_count=1)
     _validate_pinned_scope_bounds(bounds, base, {"long"}, coin_count=2)
     with pytest.raises(ValueError, match="unstuck_enabled"):
+        _validate_pinned_scope_bounds(
+            bounds, base, {"long", "short"}, coin_count=2
+        )
+
+
+def test_gpu_accepts_hsl_bounds_for_single_side_but_pins_dual_multicoin():
+    bounds = {
+        "long_hsl_enabled": Bound(1.0, 1.0, None),
+        "long_hsl_red_threshold": Bound(0.05, 0.2, None),
+        "long_hsl_ema_span_minutes": Bound(1.0, 720.0, None),
+        "long_hsl_cooldown_minutes_after_red": Bound(0.0, 1440.0, None),
+    }
+    base = {"long_hsl_enabled": 1.0}
+
+    _validate_pinned_scope_bounds(bounds, base, {"long"}, coin_count=2)
+    with pytest.raises(ValueError, match="hsl_enabled"):
         _validate_pinned_scope_bounds(
             bounds, base, {"long", "short"}, coin_count=2
         )

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -236,6 +236,7 @@ def _multicoin_exposure_fixture(
             "twel_enforcer_enabled": 0.0,
             "twel_enforcer_reduce_portfolio": 0.0,
             **_UNSTUCK_DISABLED_VALUES,
+            **_HSL_DISABLED_VALUES,
         }
         row = [values[key] for key in EMA_ANCHOR_MULTICOIN_PARAM_KEYS]
         runner = MpsEmaAnchorMulticoinRunner(
@@ -291,6 +292,7 @@ def _multicoin_exposure_fixture(
             "twel_enforcer_enabled": 0.0,
             "twel_enforcer_reduce_portfolio": 0.0,
             **_UNSTUCK_DISABLED_VALUES,
+            **_HSL_DISABLED_VALUES,
         }
         row = [values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS]
         runner = MpsTrailingMartingaleMulticoinRunner(
@@ -302,6 +304,62 @@ def _multicoin_exposure_fixture(
             collect_coin_fill_counts=collect_coin_fill_counts,
         )
     return runner, row
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("side", ["long", "short"])
+@pytest.mark.parametrize("signal_mode", ["unified", "pside"])
+def test_mps_one_sided_multicoin_hsl_panics_the_portfolio(
+    strategy_kind, side, signal_mode
+):
+    count = 64
+    closes = np.tile(np.asarray([100.0, 120.0]), (count, 1))
+    shock = 0.7 if side == "long" else 1.3
+    closes[20:] *= shock
+    runner, row = _multicoin_exposure_fixture(
+        strategy_kind,
+        side,
+        count=count,
+        closes=closes,
+        collect_coin_fill_counts=True,
+    )
+    keys = (
+        EMA_ANCHOR_MULTICOIN_PARAM_KEYS
+        if strategy_kind == "ema_anchor"
+        else TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+    )
+    for key, value in {
+        "hsl_enabled": 1.0,
+        "hsl_red_threshold": 0.05,
+        "hsl_ema_span_minutes": 1.0,
+        "hsl_cooldown_minutes_after_red": 0.0,
+        "hsl_no_restart_drawdown_threshold": 1.0,
+        "hsl_restart_policy": 2.0,
+        "hsl_tier_ratio_yellow": 0.5,
+        "hsl_tier_ratio_orange": 0.75,
+        "hsl_orange_graceful_stop": 0.0,
+        "hsl_signal_mode": 0.0 if signal_mode == "unified" else 1.0,
+        "hsl_slot_count": 1.0,
+    }.items():
+        row[keys.index(key)] = value
+
+    output = runner.run(np.asarray([row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    enabled_key = f"hsl_{side}_enabled"
+    other_side = "short" if side == "long" else "long"
+    assert output[enabled_key].item()
+    assert not output[f"hsl_{other_side}_enabled"].item()
+    assert output[f"hsl_triggers_{side}"].item() == 1.0
+    assert output[f"hsl_triggers_{other_side}"].item() == 0.0
+    assert output["hsl_trigger_drawdown_count"].item() == 1.0
+    assert output["hsl_panic_loss_drawdown_count"].item() == 1.0
+    assert output["hsl_panic_close_loss_sum"].item() > 0.0
+    assert (output["coin_fill_counts"][0] >= 2.0).all().item()
+    assert output["open_positions"].item() == 0.0
 
 
 @pytest.mark.skipif(
@@ -940,7 +998,7 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
     source = passivbot_rust.mps_ema_anchor_multicoin_source_py()
     assert "kernel void passivbot_ema_anchor_multicoin" in source
     assert "kernel void passivbot_ema_anchor_multicoin_long" in source
-    assert "constant int PARAM_COLS = 31" in source
+    assert "constant int PARAM_COLS = 42" in source
     assert "constant int OVERRIDE_COLS = 19" in source
     assert "allowed_wallet_exposure_limit" in source
     assert "twel_entry_gate_enabled" in source
@@ -1011,6 +1069,7 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
     ]
     row += _single_coin_exposure_fields() + [0.0, 0.0]
     row += list(_UNSTUCK_DISABLED_VALUES.values())
+    row += list(_HSL_DISABLED_VALUES.values())
 
     runner = MpsEmaAnchorMulticoinRunner(
         runs[0],
@@ -1100,7 +1159,7 @@ def test_mps_trailing_martingale_multicoin_directional_shader_smoke(side):
 
     source = passivbot_rust.mps_trailing_martingale_multicoin_source_py()
     assert "kernel void passivbot_trailing_martingale_multicoin" in source
-    assert "constant int PARAM_COLS = 48" in source
+    assert "constant int PARAM_COLS = 59" in source
     assert "effective_n_positions" in source
     assert "min_since_open" in source
     assert "entry_retracement_base" in source
@@ -1194,6 +1253,7 @@ def test_mps_trailing_martingale_multicoin_directional_shader_smoke(side):
         "twel_enforcer_enabled": 0.0,
         "twel_enforcer_reduce_portfolio": 0.0,
         **_UNSTUCK_DISABLED_VALUES,
+        **_HSL_DISABLED_VALUES,
     }
     row = [values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS]
 
@@ -5992,6 +6052,7 @@ def test_mps_trailing_martingale_multicoin_sizes_raw_touch_close_before_price_fi
     row.append(0.0)  # TWEL enforcer disabled
     row.append(0.0)  # TWEL reduce_overweight policy
     row.extend(_UNSTUCK_DISABLED_VALUES.values())
+    row.extend(_HSL_DISABLED_VALUES.values())
 
     output = MpsTrailingMartingaleMulticoinRunner(
         runs[0], data, side=side

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -11,6 +11,7 @@ from optimization.gpu.model import (
     TRAILING_MARTINGALE_PARAM_KEYS,
     flatten_trailing_martingale_params,
     gpu_side_enabled,
+    validate_hsl_signal_topology,
     validate_single_coin_hsl_signal_topology,
 )
 from optimization.gpu.service import (
@@ -33,6 +34,7 @@ from optimization.gpu.service import (
     _require_complete_valid_tail,
     _require_no_internal_invalid_account_recovery_candles,
     _require_no_internal_invalid_hsl_candles,
+    _require_no_internal_invalid_multicoin_hsl_candles,
     _single_coin_exposure_params,
     _total_exposure_enforcer_params,
     _unstuck_params,
@@ -249,6 +251,50 @@ def test_single_coin_proxy_preserves_directional_hsl_outputs_for_reduction():
     assert proxy.evaluate([{}]) == [{"hard_stop_panic_close_loss_sum": 37.5}]
 
 
+def test_multicoin_proxy_preserves_directional_hsl_outputs_for_reduction():
+    torch = pytest.importorskip("torch")
+    proxy = MpsMulticoinEmaProxy.__new__(MpsMulticoinEmaProxy)
+    proxy.batch_size = 1
+    proxy._torch = torch
+    proxy.profile_enabled = False
+    proxy.metrics_data = {"ts0": 0.0}
+    proxy.run = SimpleNamespace()
+    proxy.sides = ["long"]
+    proxy.needed_metrics = {"hard_stop_panic_close_loss_sum"}
+    proxy._parameter_matrix = lambda candidates, side=None: np.zeros(
+        (len(candidates), 0)
+    )
+    raw = {
+        key: torch.zeros(1)
+        for key in (
+            "first_fill_ts",
+            "last_fill_ts",
+            "last_high_ts",
+            "first_eq_ts",
+            "last_eq_ts",
+            "profit_sum",
+            "loss_sum",
+            "entry_initial_balance_pct",
+        )
+    }
+    raw["hsl_triggers_long"] = torch.tensor([2.0])
+    raw["hsl_panic_close_loss_sum"] = torch.tensor([37.5])
+    proxy.runners = {"long": SimpleNamespace(run=lambda *args, **kwargs: raw)}
+
+    def reduce(output, *args, **kwargs):
+        assert output["hsl_triggers_long"].item() == 2.0
+        assert output["hsl_panic_close_loss_sum"].item() == 37.5
+        return {
+            "hard_stop_panic_close_loss_sum": output[
+                "hsl_panic_close_loss_sum"
+            ]
+        }
+
+    proxy._compute_objectives = reduce
+
+    assert proxy.evaluate([{}]) == [{"hard_stop_panic_close_loss_sum": 37.5}]
+
+
 def test_gpu_proxy_requires_complete_valid_tail():
     _require_complete_valid_tail(99, 100)
 
@@ -265,11 +311,21 @@ def test_gpu_hsl_requires_contiguous_valid_candles():
         _require_no_internal_invalid_hsl_candles(
             high, low, close, first_valid_idx=0, last_valid_idx=2
         )
-
     _require_no_internal_invalid_hsl_candles(
         high, low, close, first_valid_idx=2, last_valid_idx=2
     )
 
+
+def test_gpu_multicoin_hsl_requires_each_coin_to_have_contiguous_valid_candles():
+    hlcvs = np.ones((3, 2, 4), dtype=np.float64)
+    hlcvs[1, 1, :3] = np.nan
+
+    with pytest.raises(ValueError, match="invalid candle at 1"):
+        _require_no_internal_invalid_multicoin_hsl_candles(
+            hlcvs,
+            first_valid_indices=[0, 0],
+            last_valid_indices=[2, 2],
+        )
 
 def test_gpu_account_equity_recovery_requires_tracked_candles_to_be_contiguous():
     hlcvs = np.ones((4, 2, 4), dtype=np.float64)
@@ -465,6 +521,27 @@ def test_dual_side_single_coin_hsl_rejects_unified_signal_mode():
 def test_single_coin_hsl_rejects_unknown_signal_mode():
     with pytest.raises(ValueError, match="coin, pside, or unified"):
         validate_single_coin_hsl_signal_topology("portfolio", enabled_side_count=1)
+
+
+@pytest.mark.parametrize("signal_mode", ["unified", "pside"])
+def test_one_sided_multicoin_hsl_accepts_account_modes(signal_mode):
+    validate_hsl_signal_topology(
+        signal_mode, coin_count=3, enabled_side_count=1
+    )
+
+
+def test_one_sided_multicoin_hsl_rejects_coin_mode():
+    with pytest.raises(ValueError, match="per-coin HSL remains fail closed"):
+        validate_hsl_signal_topology(
+            "coin", coin_count=3, enabled_side_count=1
+        )
+
+
+def test_dual_side_multicoin_hsl_remains_fail_closed():
+    with pytest.raises(ValueError, match="exactly one enabled side"):
+        validate_hsl_signal_topology(
+            "pside", coin_count=3, enabled_side_count=2
+        )
 
 
 def test_directional_parameter_matrix_keeps_side_values_separate():


### PR DESCRIPTION
## Summary
- add shared-balance one-sided multi-coin HSL screening to both EMA Anchor and Trailing Martingale MPS kernels
- support unified and pside signals, limit panic flattening across all open coins, cooldown/restart behavior, and HSL lifecycle/panic-loss outputs
- keep dual-side multi-coin HSL, multi-coin coin mode, per-coin HSL overrides, and multi-coin market panic fail closed
- reject internal invalid candles for every HSL portfolio coin

## Validation
- 263 Rust tests
- cargo check --tests and cargo fmt --check
- full GPU backend, service, and metric Python suites
- complete physical Apple MPS kernel suite
- physical M3 matrix: EMA Anchor and Trailing Martingale, long and short, unified and pside, with both coins proven entered and panic-flattened
- offline five-coin trailing-martingale optimizer smoke: 288 MPS proxy evaluations, 9 exact Rust validations, no drift or constraint halt
- AI docs check and docs tests