### PR TITLE
feat(optimize): add multicoin MPS HSL market panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,18 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added market panic-close execution to one-sided multi-coin HSL Apple MPS optimization for EMA
+  Anchor and Trailing Martingale. The portfolio proxy now fills every panic close on the next
+  tradable bar using directionally quantized close-price slippage and each coin's taker fee,
+  matching the exact Rust backtest execution contract. Exact Rust validation remains
+  authoritative.
+
 - Added one-sided multi-coin HSL to Apple MPS optimization for EMA Anchor and Trailing
   Martingale in `unified` and `pside` signal modes, including compatible suites. Each Metal
   candidate now applies one shared-balance portfolio HSL controller across every coin on the
   enabled side, including warning tiers, RED entry blocking, limit panic flattening, cooldown
   restart, lifecycle metrics, and panic-loss metrics. Exact Rust validation remains authoritative;
-  dual-side multi-coin HSL, multi-coin `coin` mode, per-coin HSL overrides, and multi-coin market
-  panic closes remain fail closed.
+  dual-side multi-coin HSL, multi-coin `coin` mode, and per-coin HSL overrides remain fail closed.
 
 - Added dual-side single-coin HSL to Apple MPS optimization for EMA Anchor and Trailing
   Martingale in `coin` and `pside` signal modes, including compatible suites. Metal now tracks

--- a/docs/equity_hard_stop_loss_reference.md
+++ b/docs/equity_hard_stop_loss_reference.md
@@ -130,9 +130,9 @@ These are the main parity surfaces that should be reviewed together:
    - Deterministic M3 conformance coverage compares Metal drawdown, EMA, tier, active-RED, latch, and RED-finalization traces against the exact Rust runtime for all three signal modes and restart policies
    - One-sided runs support unified, pside, and coin signals; dual-side runs support pside and coin signals with independent directional realized-PnL state
    - One-sided multi-coin runs support unified and pside signals through one shared-balance portfolio controller that tracks all positions and blocking orders on the enabled side
-   - Multi-coin limit panic closes flatten every open coin on the enabled side and export the same lifecycle and panic-loss metric surface as single-coin HSL
+   - Multi-coin limit and market panic closes flatten every open coin on the enabled side and export the same lifecycle and panic-loss metric surface as single-coin HSL; market execution uses each coin's taker fee and directionally quantized configured slippage
    - Dual-side unified HSL remains fail closed because the documented account-wide episode-finalization scope and current exact-backtest per-side flat confirmation disagree
-   - Dual-side multi-coin HSL, multi-coin coin signals, multi-coin market panic closes, and per-coin-override HSL still fail closed
+   - Dual-side multi-coin HSL, multi-coin coin signals, and per-coin-override HSL still fail closed
 
 ### Confirmed Gaps / Risks
 
@@ -148,14 +148,13 @@ These are the main parity surfaces that should be reviewed together:
    - Dual-side multi-coin HSL needs one shared-balance controller that owns both directional state machines without duplicating account balance or liquidation decisions
    - Multi-coin coin mode needs one controller per effective coin+pside scope rather than the single portfolio controller used by unified and pside modes
    - Per-coin HSL overrides require candidate-local resolved settings in those coin controllers
-   - Multi-coin market panic execution needs explicit taker/slippage parity across every same-candle portfolio flatten
 
 ### Missing or Weak Test Coverage
 
 1. End-to-end replay of one identical fill/candle history through live reconstruction and exact backtest orchestration; shared Rust primitive tests cover the calculations but not the complete orchestration trace
 2. Connector-level restart races while protective panic-close orders are live on an exchange
 3. Manual or external trading during downtime across the full exchange-adapter matrix
-4. Apple MPS parity for dual-side unified, dual-side multi-coin, multi-coin coin-mode/market-panic, and per-coin-override HSL scopes
+4. Apple MPS parity for dual-side unified, dual-side multi-coin, multi-coin coin-mode, and per-coin-override HSL scopes
 
 ## Optimizer Work
 

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -192,13 +192,14 @@ mod tests {
         assert!(source.contains("constant int PARAM_COLS = 42"));
         assert!(source.contains("constant int OVERRIDE_COLS = 19"));
         assert!(source.contains("coin_override_or"));
-        assert!(source.contains("constant int COIN_COLS = 11"));
+        assert!(source.contains("constant int COIN_COLS = 12"));
         assert!(source.contains("constant int DAILY_COLS = 9"));
         assert!(source.contains("day_min_balance"));
         assert!(source.contains("constant int SCALAR_COLS = 57"));
         assert!(source.contains("load_hsl(params, po, 31)"));
         assert!(source.contains("write_one_side_hsl_outputs("));
         assert!(source.contains("record_hsl_panic_fill("));
+        assert!(source.contains("market_panic ? taker_fee : maker_fee"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[scalar_offset + 19] = loss_sum"));
         assert!(source
@@ -287,6 +288,7 @@ mod tests {
         assert!(source.contains("h.restart_retrigger_count"));
         assert!(source.contains("h.halt_duration_sum_steps"));
         assert!(source.contains("record_hsl_panic_fill("));
+        assert!(source.contains("market_panic ? taker_fee : maker_fee"));
         assert!(source.contains("h.panic_loss_drawdown_sum"));
         assert!(source.contains("&& !long_side.close_is_panic"));
         assert!(source.contains("&& !short_side.close_is_panic"));
@@ -387,10 +389,12 @@ mod tests {
         assert!(source.contains("constant int MAX_COINS = 64"));
         assert!(source.contains("constant int PARAM_COLS = 59"));
         assert!(source.contains("constant int OVERRIDE_COLS = 34"));
+        assert!(source.contains("constant int COIN_COLS = 12"));
         assert!(source.contains("constant int SCALAR_COLS = 57"));
         assert!(source.contains("load_hsl(params, po, 48)"));
         assert!(source.contains("write_one_side_hsl_outputs("));
         assert!(source.contains("record_hsl_panic_fill("));
+        assert!(source.contains("market_panic ? taker_fee : maker_fee"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[scalar_offset + 19] = loss_sum"));
         assert!(source

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -5,7 +5,7 @@ using namespace metal;
 
 constant int MAX_COINS = 64;
 constant int PARAM_COLS = 42;
-constant int COIN_COLS = 11;
+constant int COIN_COLS = 12;
 constant int OVERRIDE_COLS = 19;
 constant int DAILY_COLS = 9;
 constant int SCALAR_COLS = 57;
@@ -305,6 +305,8 @@ inline void passivbot_ema_anchor_multicoin_impl(
     const float score_hysteresis = fmax(run_settings[4], 0.0f);
     const bool loss_gate_enabled = run_settings[5] < 1.0f;
     const float max_realized_loss_pct = run_settings[5];
+    const float market_order_slippage_pct = fmax(run_settings[7], 0.0f);
+    const bool hsl_panic_market = run_settings[8] > 0.5f;
     const float log_bin_scale = 127.0f / log(4000001.0f);
 
     float ema0[MAX_COINS];
@@ -524,11 +526,14 @@ inline void passivbot_ema_anchor_multicoin_impl(
             const float price_step = coin_settings[coin_offset + 1];
             const float c_mult = coin_settings[coin_offset + 4];
             const float maker_fee = coin_settings[coin_offset + 5];
+            const float taker_fee = coin_settings[coin_offset + 11];
 
+            bool primary_market_panic = close_is_hsl_panic[c]
+                && hsl_panic_market;
             bool filled_close = close_qty[c] > 0.0f && psize[c] > 0.0f
-                && (short_side
+                && (primary_market_panic || (short_side
                     ? close_tick[c] > fill_ticks[tick_offset + 1]
-                    : close_tick[c] <= fill_ticks[tick_offset + 0]);
+                    : close_tick[c] <= fill_ticks[tick_offset + 0]));
             bool filled_secondary_close = secondary_close_qty[c] > 0.0f
                 && psize[c] > 0.0f
                 && (short_side
@@ -549,7 +554,21 @@ inline void passivbot_ema_anchor_multicoin_impl(
                     ? secondary_close_tick[c] : close_tick[c];
                 float requested_qty = use_secondary
                     ? secondary_close_qty[c] : close_qty[c];
-                float fill_price = float(executed_tick) * price_step;
+                bool market_panic = !use_secondary && primary_market_panic;
+                float fill_price = market_panic
+                    ? fmax(
+                        short_side
+                            ? ceil_step(
+                                close * (1.0f + market_order_slippage_pct),
+                                price_step
+                            )
+                            : floor_step(
+                                close * (1.0f - market_order_slippage_pct),
+                                price_step
+                            ),
+                        price_step
+                    )
+                    : float(executed_tick) * price_step;
                 float adjusted = fmin(
                     round_step(requested_qty, qty_step), psize[c]
                 );
@@ -558,7 +577,8 @@ inline void passivbot_ema_anchor_multicoin_impl(
                     ? pprice[c] - fill_price
                     : fill_price - pprice[c]);
                 float net_pnl = pnl
-                    - adjusted * fill_price * c_mult * maker_fee;
+                    - adjusted * fill_price * c_mult
+                        * (market_panic ? taker_fee : maker_fee);
                 bool is_unstuck = !use_secondary
                     && close_is_unstuck_reducer[c];
                 bool is_hsl_panic = !use_secondary

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -6,7 +6,7 @@ using namespace metal;
 constant int MAX_COINS = 64;
 constant int PARAM_COLS = 59;
 constant int OVERRIDE_COLS = 34;
-constant int COIN_COLS = 11;
+constant int COIN_COLS = 12;
 constant int DAILY_COLS = 9;
 constant int SCALAR_COLS = 57;
 constant int GAP_BINS = 128;
@@ -539,6 +539,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     const float score_hysteresis = fmax(run_settings[4], 0.0f);
     const bool loss_gate_enabled = run_settings[5] < 1.0f;
     const float max_realized_loss_pct = run_settings[5];
+    const float market_order_slippage_pct = fmax(run_settings[7], 0.0f);
+    const bool hsl_panic_market = run_settings[8] > 0.5f;
     const float log_bin_scale = 127.0f / log(4000001.0f);
 
     float ema0[MAX_COINS];
@@ -787,12 +789,15 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             const float min_cost = coin_settings[coin_offset + 3];
             const float c_mult = coin_settings[coin_offset + 4];
             const float maker_fee = coin_settings[coin_offset + 5];
+            const float taker_fee = coin_settings[coin_offset + 11];
 
             bool close_ready = close_qty[c] > 0.0f && psize[c] > 0.0f;
+            bool primary_market_panic = close_is_hsl_panic[c]
+                && hsl_panic_market;
             bool filled_close = close_ready
-                && (short_side
+                && (primary_market_panic || (short_side
                     ? close_tick[c] > fill_ticks[tick_offset + 1]
-                    : close_tick[c] <= fill_ticks[tick_offset + 0]);
+                    : close_tick[c] <= fill_ticks[tick_offset + 0]));
             bool filled_secondary_close = secondary_close_qty[c] > 0.0f
                 && psize[c] > 0.0f
                 && (short_side
@@ -802,7 +807,20 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 && close_reconstruct_after_reducer[c]
                 && !close_is_hsl_panic[c];
             if (filled_close || filled_secondary_close || rebuild_grid) {
-                float fill_price = float(close_tick[c]) * price_step;
+                float fill_price = primary_market_panic
+                    ? fmax(
+                        short_side
+                            ? ceil_step(
+                                close * (1.0f + market_order_slippage_pct),
+                                price_step
+                            )
+                            : floor_step(
+                                close * (1.0f - market_order_slippage_pct),
+                                price_step
+                            ),
+                        price_step
+                    )
+                    : float(close_tick[c]) * price_step;
                 float reducer_qty = fmin(
                     round_step(close_qty[c], qty_step), psize[c]
                 );
@@ -1107,6 +1125,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                         && close_is_unstuck_reducer[c];
                     bool is_hsl_panic = !use_secondary
                         && close_is_hsl_panic[c];
+                    bool market_panic = !use_secondary
+                        && primary_market_panic;
                     if (!is_hsl_panic && !realized_loss_proxy_allows_reducer(
                             qty, price, pprice[c], short_side,
                             c_mult, maker_fee, is_unstuck, loss_gate_enabled,
@@ -1115,7 +1135,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                         )) {
                         continue;
                     }
-                    float net_pnl = pnl - qty * price * c_mult * maker_fee;
+                    float net_pnl = pnl - qty * price * c_mult
+                        * (market_panic ? taker_fee : maker_fee);
                     if (is_hsl_panic) {
                         record_hsl_panic_fill(
                             hsl, net_pnl, hsl_equity_before_fills

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -1025,11 +1025,6 @@ def _validate_scope_config(
                     f"GPU HSL requires bot.{side}.hsl.panic_close_order_type "
                     f"to be limit or market, got {panic_order_type!r}"
                 )
-            if coin_count > 1 and panic_order_type != "limit":
-                raise ValueError(
-                    f"GPU multi-coin HSL currently requires bot.{side}.hsl."
-                    "panic_close_order_type=limit"
-                )
     for side in enabled_sides:
         side_config = config["bot"][side]
         risk = side_config.get("risk", {})

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -329,6 +329,7 @@ class ProxyMarket:
     min_cost: float
     c_mult: float
     maker_fee: float
+    taker_fee: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -747,7 +748,7 @@ def build_mps_multicoin_data(
     touch_nearest_ticks = np.empty((candle_count, coin_count), dtype=np.int32)
     touch_min_qty_bits = np.empty((candle_count, coin_count), dtype=np.int32)
     touch_min_qty_relation = np.empty((candle_count, coin_count), dtype=np.int32)
-    coin_settings = np.empty((coin_count, 11), dtype=np.float32)
+    coin_settings = np.empty((coin_count, 12), dtype=np.float32)
     for coin, (run, market) in enumerate(zip(runs, markets)):
         if run.interval_ms != interval_ms:
             raise ValueError("MPS multicoin runs must use one shared candle interval")
@@ -790,6 +791,7 @@ def build_mps_multicoin_data(
             run.trade_start_idx,
             seed_close if np.isfinite(seed_close) and seed_close > 0.0 else 0.0,
             volume_seed * typical_seed,
+            market.taker_fee,
         )
 
     invariant_bytes = (

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -468,6 +468,8 @@ class MpsEmaAnchorMulticoinRunner:
         forager_score_hysteresis_pct: float = 0.0,
         max_realized_loss_pct: float = 1.0,
         collect_coin_fill_counts: bool = False,
+        market_order_slippage_pct: float = 0.0,
+        hsl_panic_market: bool = False,
     ):
         if side not in {"long", "short"}:
             raise ValueError(
@@ -515,6 +517,14 @@ class MpsEmaAnchorMulticoinRunner:
         encoded_max_realized_loss_pct = _encode_max_realized_loss_pct(
             max_realized_loss_pct
         )
+        market_order_slippage_pct = float(market_order_slippage_pct)
+        if (
+            not np.isfinite(market_order_slippage_pct)
+            or market_order_slippage_pct < 0.0
+        ):
+            raise ValueError(
+                "market_order_slippage_pct must be finite and non-negative"
+            )
         liq_floor = max(0.0, run.starting_balance) * max(
             0.0, run.liquidation_threshold
         )
@@ -527,6 +537,8 @@ class MpsEmaAnchorMulticoinRunner:
                 forager_score_hysteresis_pct,
                 encoded_max_realized_loss_pct,
                 float(self.collect_coin_fill_counts),
+                market_order_slippage_pct,
+                float(bool(hsl_panic_market)),
             ],
             dtype=torch.float32,
             device="mps",
@@ -678,6 +690,8 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
         forager_score_hysteresis_pct: float = 0.0,
         max_realized_loss_pct: float = 1.0,
         collect_coin_fill_counts: bool = False,
+        market_order_slippage_pct: float = 0.0,
+        hsl_panic_market: bool = False,
     ):
         super().__init__(
             run,
@@ -687,6 +701,8 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             forager_score_hysteresis_pct=forager_score_hysteresis_pct,
             max_realized_loss_pct=max_realized_loss_pct,
             collect_coin_fill_counts=collect_coin_fill_counts,
+            market_order_slippage_pct=market_order_slippage_pct,
+            hsl_panic_market=hsl_panic_market,
         )
 
     def _pack_params(self, params: np.ndarray) -> np.ndarray:

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -832,6 +832,7 @@ class MpsSingleCoinProxy:
             min_cost=float(market_params["min_cost"]),
             c_mult=float(market_params["c_mult"]),
             maker_fee=float(market_params["maker_fee"]),
+            taker_fee=float(market_params["taker_fee"]),
         )
         interval_ms = int(backtest_params["candle_interval_minutes"]) * 60_000
         self.run = ProxyRun(
@@ -1344,12 +1345,6 @@ class MpsMulticoinProxy:
         for side in self.sides:
             first_bot = payload.bot_params_list[0][side]
             first_strategy = dict(payload.strategy_params_list[0][side])
-            if bool(first_bot.get("hsl_enabled")) and str(
-                first_bot.get("hsl_panic_close_order_type", "limit")
-            ).strip().lower() != "limit":
-                raise ValueError(
-                    f"MPS multicoin HSL requires {side} panic_close_order_type=limit"
-                )
             if len(self.sides) == 2 and any(
                 bool(item[side].get("unstuck_enabled"))
                 for item in payload.bot_params_list
@@ -1486,6 +1481,7 @@ class MpsMulticoinProxy:
                 min_cost=float(item["min_cost"]),
                 c_mult=float(item["c_mult"]),
                 maker_fee=float(item["maker_fee"]),
+                taker_fee=float(item["taker_fee"]),
             )
             for item in payload.exchange_params
         ]
@@ -1561,6 +1557,18 @@ class MpsMulticoinProxy:
                 "collect_coin_fill_counts": bool(
                     self.needed_metrics
                     & {"fills_active_symbols_count", "fills_top_symbol_share"}
+                ),
+                "market_order_slippage_pct": float(
+                    backtest_params.get("market_order_slippage_pct", 0.0)
+                ),
+                "hsl_panic_market": bool(
+                    self.base_params[side]["hsl_enabled"]
+                    and str(
+                        payload.bot_params_list[0][side].get(
+                            "hsl_panic_close_order_type", "limit"
+                        )
+                    ).strip().lower()
+                    == "market"
                 ),
             }
             runner_kwargs["coin_overrides"] = per_side_coin_overrides[side]

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1498,7 +1498,7 @@ def test_gpu_hsl_fails_closed_for_multicoin_coin_mode():
         _validate_scope(config, _MulticoinEvaluator())
 
 
-def test_gpu_hsl_fails_closed_for_multicoin_market_panic():
+def test_gpu_hsl_accepts_one_sided_multicoin_market_panic():
     config = _long_only_ema_config()
     config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "XRP"]
     config["live"]["hsl_signal_mode"] = "unified"
@@ -1507,8 +1507,7 @@ def test_gpu_hsl_fails_closed_for_multicoin_market_panic():
         {"enabled": True, "panic_close_order_type": "market"}
     )
 
-    with pytest.raises(ValueError, match="panic_close_order_type=limit"):
-        _validate_scope(config, _MulticoinEvaluator())
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
 def test_gpu_hsl_fails_closed_for_dual_side_multicoin():

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -168,6 +168,8 @@ def _multicoin_exposure_fixture(
     first_valid_indices=(0, 0),
     liquidation_threshold=0.05,
     collect_coin_fill_counts=False,
+    market_order_slippage_pct=0.0,
+    hsl_panic_market=False,
 ):
     coin_count = 2
     timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
@@ -246,6 +248,8 @@ def _multicoin_exposure_fixture(
             coin_overrides=coin_overrides,
             max_realized_loss_pct=max_realized_loss_pct,
             collect_coin_fill_counts=collect_coin_fill_counts,
+            market_order_slippage_pct=market_order_slippage_pct,
+            hsl_panic_market=hsl_panic_market,
         )
     else:
         values = {
@@ -302,6 +306,8 @@ def _multicoin_exposure_fixture(
             coin_overrides=coin_overrides,
             max_realized_loss_pct=max_realized_loss_pct,
             collect_coin_fill_counts=collect_coin_fill_counts,
+            market_order_slippage_pct=market_order_slippage_pct,
+            hsl_panic_market=hsl_panic_market,
         )
     return runner, row
 
@@ -360,6 +366,82 @@ def test_mps_one_sided_multicoin_hsl_panics_the_portfolio(
     assert output["hsl_panic_close_loss_sum"].item() > 0.0
     assert (output["coin_fill_counts"][0] >= 2.0).all().item()
     assert output["open_positions"].item() == 0.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_one_sided_multicoin_hsl_market_panic_applies_taker_costs(
+    strategy_kind, side
+):
+    count = 64
+    closes = np.tile(np.asarray([100.0, 120.0]), (count, 1))
+    closes[20:] *= 0.7 if side == "long" else 1.3
+    markets = [
+        ProxyMarket(
+            0.001,
+            0.01,
+            0.001,
+            0.0,
+            1.0,
+            maker_fee=0.0,
+            taker_fee=0.01,
+        )
+        for _ in range(2)
+    ]
+    limit_runner, row = _multicoin_exposure_fixture(
+        strategy_kind, side, count=count, closes=closes, markets=markets
+    )
+    market_runner, _ = _multicoin_exposure_fixture(
+        strategy_kind,
+        side,
+        count=count,
+        closes=closes,
+        markets=markets,
+        market_order_slippage_pct=0.02,
+        hsl_panic_market=True,
+    )
+    keys = (
+        EMA_ANCHOR_MULTICOIN_PARAM_KEYS
+        if strategy_kind == "ema_anchor"
+        else TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+    )
+    for key, value in {
+        "hsl_enabled": 1.0,
+        "hsl_red_threshold": 0.05,
+        "hsl_ema_span_minutes": 1.0,
+        "hsl_cooldown_minutes_after_red": 0.0,
+        "hsl_no_restart_drawdown_threshold": 1.0,
+        "hsl_restart_policy": 2.0,
+        "hsl_tier_ratio_yellow": 0.5,
+        "hsl_tier_ratio_orange": 0.75,
+        "hsl_orange_graceful_stop": 0.0,
+        "hsl_signal_mode": 1.0,
+        "hsl_slot_count": 1.0,
+    }.items():
+        row[keys.index(key)] = value
+    params = np.asarray([row], dtype=np.float64)
+
+    assert market_runner.settings[7].item() == pytest.approx(0.02)
+    assert market_runner.settings[8].item() == 1.0
+    assert torch.allclose(
+        market_runner.coin_settings[:, 11],
+        torch.full((2,), 0.01, device="mps"),
+    )
+    limit_output = limit_runner.run(params)
+    market_output = market_runner.run(params)
+    torch.mps.synchronize()
+
+    assert limit_output[f"hsl_triggers_{side}"].item() == 1.0
+    assert market_output[f"hsl_triggers_{side}"].item() == 1.0
+    assert limit_output["open_positions"].item() == 0.0
+    assert market_output["open_positions"].item() == 0.0
+    assert (
+        market_output["hsl_panic_close_loss_sum"].item()
+        > limit_output["hsl_panic_close_loss_sum"].item()
+    )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary
- add HSL market panic execution to the one-sided multi-coin EMA Anchor and Trailing Martingale MPS kernels
- fill panic closes on the next valid bar with directionally quantized configured slippage and each coin's taker fee
- preserve limit panic and all non-HSL fill behavior while keeping exact Rust validation authoritative

## Validation
- 263 Rust tests
- cargo check --tests and cargo fmt --check
- full GPU backend, service, and metric Python suites
- complete physical Apple MPS kernel suite
- physical M3 market-vs-limit matrix for EMA Anchor and Trailing Martingale, long and short, verifying uploaded slippage/taker inputs, complete flattening, and higher panic loss under market costs
- offline five-coin trailing-martingale market-panic optimizer smoke: 288 MPS proxy evaluations, 9 exact Rust validations, no optimizer halt
- AI docs check and docs tests