### PR TITLE
feat(optimize): add multicoin MPS HSL coin mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `coin` signal mode to one-sided multi-coin HSL Apple MPS optimization for EMA Anchor
+  and Trailing Martingale. Metal now maintains an independent HSL episode per coin, including
+  realized net PnL and fees, dynamic effective-slot scaling, warning/RED state, panic flattening,
+  halt/restart lifecycle, and per-episode metrics. Directional outputs aggregate the same way as
+  exact Rust: episode metrics are combined across coins while time-in-tier uses the worst active
+  coin tier once per minute. Exact Rust validation remains authoritative; per-coin HSL setting
+  overrides and dual-side multi-coin HSL remain fail closed.
+
 - Added market panic-close execution to one-sided multi-coin HSL Apple MPS optimization for EMA
   Anchor and Trailing Martingale. The portfolio proxy now fills every panic close on the next
   tradable bar using directionally quantized close-price slippage and each coin's taker fee,
@@ -15,7 +23,7 @@ All notable user-facing changes will be documented in this file.
   candidate now applies one shared-balance portfolio HSL controller across every coin on the
   enabled side, including warning tiers, RED entry blocking, limit panic flattening, cooldown
   restart, lifecycle metrics, and panic-loss metrics. Exact Rust validation remains authoritative;
-  dual-side multi-coin HSL, multi-coin `coin` mode, and per-coin HSL overrides remain fail closed.
+  dual-side multi-coin HSL and per-coin HSL overrides remain fail closed.
 
 - Added dual-side single-coin HSL to Apple MPS optimization for EMA Anchor and Trailing
   Martingale in `coin` and `pside` signal modes, including compatible suites. Metal now tracks

--- a/docs/equity_hard_stop_loss_reference.md
+++ b/docs/equity_hard_stop_loss_reference.md
@@ -130,9 +130,11 @@ These are the main parity surfaces that should be reviewed together:
    - Deterministic M3 conformance coverage compares Metal drawdown, EMA, tier, active-RED, latch, and RED-finalization traces against the exact Rust runtime for all three signal modes and restart policies
    - One-sided runs support unified, pside, and coin signals; dual-side runs support pside and coin signals with independent directional realized-PnL state
    - One-sided multi-coin runs support unified and pside signals through one shared-balance portfolio controller that tracks all positions and blocking orders on the enabled side
+   - One-sided multi-coin coin signals use one independent controller per coin, each with coin-local realized net PnL, drawdown EMA, warning/RED episode, panic close, halt, and restart state; the coin drawdown budget uses the dynamic effective position-slot count
+   - Coin-mode lifecycle and panic-loss metrics aggregate across coin episodes, while warning-tier time samples the worst active coin tier once per minute, matching exact Rust reporting
    - Multi-coin limit and market panic closes flatten every open coin on the enabled side and export the same lifecycle and panic-loss metric surface as single-coin HSL; market execution uses each coin's taker fee and directionally quantized configured slippage
    - Dual-side unified HSL remains fail closed because the documented account-wide episode-finalization scope and current exact-backtest per-side flat confirmation disagree
-   - Dual-side multi-coin HSL, multi-coin coin signals, and per-coin-override HSL still fail closed
+   - Dual-side multi-coin HSL and per-coin-override HSL still fail closed
 
 ### Confirmed Gaps / Risks
 
@@ -146,7 +148,6 @@ These are the main parity surfaces that should be reviewed together:
 3. GPU HSL topology is intentionally narrow
    - Dual-side unified HSL needs one resolved account-wide exact-Rust flatten contract before it can be screened safely
    - Dual-side multi-coin HSL needs one shared-balance controller that owns both directional state machines without duplicating account balance or liquidation decisions
-   - Multi-coin coin mode needs one controller per effective coin+pside scope rather than the single portfolio controller used by unified and pside modes
    - Per-coin HSL overrides require candidate-local resolved settings in those coin controllers
 
 ### Missing or Weak Test Coverage
@@ -154,7 +155,7 @@ These are the main parity surfaces that should be reviewed together:
 1. End-to-end replay of one identical fill/candle history through live reconstruction and exact backtest orchestration; shared Rust primitive tests cover the calculations but not the complete orchestration trace
 2. Connector-level restart races while protective panic-close orders are live on an exchange
 3. Manual or external trading during downtime across the full exchange-adapter matrix
-4. Apple MPS parity for dual-side unified, dual-side multi-coin, multi-coin coin-mode, and per-coin-override HSL scopes
+4. Apple MPS parity for dual-side unified, dual-side multi-coin, and per-coin-override HSL scopes
 
 ## Optimizer Work
 

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -134,8 +134,10 @@ The supported slice is intentionally narrow:
   `risk.position_exposure_enforcer_threshold`; per-coin
   `risk.we_excess_allowance_mode`, trailing-martingale `entry.ema_gate_mode`, disabled sides, and
   other override leaves fail closed
-- one-sided single-coin EMA Anchor and Trailing Martingale runs support HSL with `coin`, `pside`,
-  or `unified` signals and both resting-limit and market panic closes. Market panic orders fill on
+- one-sided single-coin and multi-coin EMA Anchor and Trailing Martingale runs support HSL with
+  `coin`, `pside`, or `unified` signals and both resting-limit and market panic closes. Unified and
+  pside multi-coin runs use one portfolio controller; coin mode uses an independent controller per
+  coin and scales its loss budget by the dynamic effective position-slot count. Market panic orders fill on
   the next valid bar at its close shifted adversely by `backtest.market_order_slippage_pct`, rounded
   directionally to the exchange price step, and charged the resolved taker fee. The Metal proxy
   models tunable RED
@@ -153,9 +155,9 @@ The supported slice is intentionally narrow:
   yearly rates, time in each warning tier, halt and flatten durations, trigger drawdown, and
   post-restart retriggers) and panic-loss metrics (loss sum/max, per-episode loss
   drawdown min/mean/max, and halt-to-restart equity loss) may be used for scoring and limits.
-  Dual-side and multi-coin HSL, per-coin HSL overrides, and HSL strategy-equity
+  Dual-side multi-coin HSL, per-coin HSL setting overrides, and HSL strategy-equity
   EMA/recovery-distribution metrics remain fail closed for now.
-  Compatible single-coin suites may use the supported topology.
+  Compatible suites may use the supported topologies.
 - single-coin EMA Anchor and Trailing Martingale support auto-unstuck for long-only,
   short-only, hedge-mode dual-side, one-way, and compatible suite runs. One-sided multi-coin runs
   and compatible suites also support auto-unstuck, including static per-coin overrides. Metal

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -199,6 +199,26 @@ mod tests {
         assert!(source.contains("load_hsl(params, po, 31)"));
         assert!(source.contains("write_one_side_hsl_outputs("));
         assert!(source.contains("record_hsl_panic_fill("));
+        assert_eq!(
+            MPS_EMA_ANCHOR_MULTICOIN_BODY
+                .matches("record_coin_hsl_realized_fill(")
+                .count(),
+            2
+        );
+        assert_eq!(
+            MPS_EMA_ANCHOR_MULTICOIN_BODY
+                .matches("advance_coin_hsl_equity_after_close_fill(")
+                .count(),
+            1
+        );
+        assert_eq!(
+            MPS_EMA_ANCHOR_MULTICOIN_BODY
+                .matches("advance_coin_hsl_equity_after_entry_fill(")
+                .count(),
+            1
+        );
+        assert!(source.contains("coin_hsl_eligibility_changed"));
+        assert!(source.contains("coin_hsl_entry_blocked_mask"));
         assert!(source.contains("market_panic ? taker_fee : maker_fee"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[scalar_offset + 19] = loss_sum"));
@@ -394,6 +414,26 @@ mod tests {
         assert!(source.contains("load_hsl(params, po, 48)"));
         assert!(source.contains("write_one_side_hsl_outputs("));
         assert!(source.contains("record_hsl_panic_fill("));
+        assert_eq!(
+            MPS_TRAILING_MARTINGALE_MULTICOIN_BODY
+                .matches("record_coin_hsl_realized_fill(")
+                .count(),
+            4
+        );
+        assert_eq!(
+            MPS_TRAILING_MARTINGALE_MULTICOIN_BODY
+                .matches("advance_coin_hsl_equity_after_close_fill(")
+                .count(),
+            3
+        );
+        assert_eq!(
+            MPS_TRAILING_MARTINGALE_MULTICOIN_BODY
+                .matches("advance_coin_hsl_equity_after_entry_fill(")
+                .count(),
+            1
+        );
+        assert!(source.contains("coin_hsl_eligibility_changed"));
+        assert!(source.contains("coin_hsl_entry_blocked_mask"));
         assert!(source.contains("market_panic ? taker_fee : maker_fee"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[scalar_offset + 19] = loss_sum"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -284,6 +284,9 @@ inline void passivbot_ema_anchor_multicoin_impl(
     const float unstuck_loss_allowance_pct = params[po + 29];
     const float unstuck_threshold = params[po + 30];
     HslState hsl = load_hsl(params, po, 31);
+    const bool coin_hsl_mode = hsl.enabled
+        && hsl.signal_mode == HSL_SIGNAL_COIN;
+    HslState coin_hsl[MAX_COINS];
     const float weight_sum = w_volume + w_ready + w_volatility;
     if (weight_sum > 0.0f) {
         w_volume /= weight_sum;
@@ -347,6 +350,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
     float alpha2_coin[MAX_COINS];
     float alpha_1h_coin[MAX_COINS];
     float alpha_1m_coin[MAX_COINS];
+    float coin_realized_pnl[MAX_COINS];
 
     for (int c = 0; c < MAX_COINS; ++c) {
         float seed_close = c < C ? coin_settings[c * COIN_COLS + 9] : 0.0f;
@@ -384,6 +388,10 @@ inline void passivbot_ema_anchor_multicoin_impl(
         unstuck_close_tick[c] = 0;
         close_is_unstuck_reducer[c] = false;
         close_is_hsl_panic[c] = false;
+        coin_realized_pnl[c] = 0.0f;
+        coin_hsl[c] = load_hsl(params, po, 31);
+        coin_hsl[c].enabled = coin_hsl_mode && hsl.enabled
+            && c < C;
         selected[c] = false;
         incumbent[c] = false;
         survivor[c] = false;
@@ -592,9 +600,15 @@ inline void passivbot_ema_anchor_multicoin_impl(
                     continue;
                 }
                 if (is_hsl_panic) {
-                    record_hsl_panic_fill(
-                        hsl, net_pnl, hsl_equity_before_fills
-                    );
+                    if (coin_hsl_mode) {
+                        record_hsl_panic_fill(
+                            coin_hsl[c], net_pnl, hsl_equity_before_fills
+                        );
+                    } else {
+                        record_hsl_panic_fill(
+                            hsl, net_pnl, hsl_equity_before_fills
+                        );
+                    }
                 }
                 record_gross_pnl(pnl, profit_sum, loss_sum);
                 balance += net_pnl;
@@ -606,6 +620,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
                     pnl_recovery_max_min, float(k),
                     false, !short_side
                 );
+                coin_realized_pnl[c] += net_pnl;
                 if (collect_coin_fill_counts) {
                     coin_fill_counts[int(b) * C + c] += 1.0f;
                 }
@@ -654,6 +669,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
                     pnl_recovery_max_min, float(k),
                     true, !short_side
                 );
+                coin_realized_pnl[c] -= fee;
                 if (collect_coin_fill_counts) {
                     coin_fill_counts[int(b) * C + c] += 1.0f;
                 }
@@ -770,7 +786,8 @@ inline void passivbot_ema_anchor_multicoin_impl(
         for (int c = 0; c < C; ++c) {
             has_hsl_position = has_hsl_position || psize[c] > 0.0f;
         }
-        int current_hsl_mode = hsl_mode(hsl, has_hsl_position);
+        int current_hsl_mode = coin_hsl_mode
+            ? 0 : hsl_mode(hsl, has_hsl_position);
 
         if (can_generate) {
             // Exact Rust ranks flat candidates every minute. Re-ranking only
@@ -1507,11 +1524,14 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 }
             }
             for (int c = 0; c < C; ++c) {
-                if (current_hsl_mode >= 2
-                    || (current_hsl_mode != 0 && psize[c] <= 0.0f)) {
+                int coin_mode = coin_hsl_mode
+                    ? hsl_mode(coin_hsl[c], psize[c] > 0.0f)
+                    : current_hsl_mode;
+                if (coin_mode >= 2
+                    || (coin_mode != 0 && psize[c] <= 0.0f)) {
                     entry_qty[c] = 0.0f;
                 }
-                if (current_hsl_mode == 3 && psize[c] > 0.0f) {
+                if (coin_mode == 3 && psize[c] > 0.0f) {
                     int tick_offset = (k * C + c) * 2;
                     close_qty[c] = psize[c];
                     close_tick[c] = max(
@@ -1549,7 +1569,10 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 unrealized += psize[c] * coin_settings[coin_offset + 4]
                     * (short_side ? pprice[c] - close : close - pprice[c]);
             }
-            if (current_hsl_mode != 3 && (
+            int coin_mode = coin_hsl_mode
+                ? hsl_mode(coin_hsl[c], psize[c] > 0.0f)
+                : current_hsl_mode;
+            if (coin_mode != 3 && (
                     entry_qty[c] > 0.0f || close_qty[c] > 0.0f
                         || secondary_close_qty[c] > 0.0f
                 )) {
@@ -1559,19 +1582,53 @@ inline void passivbot_ema_anchor_multicoin_impl(
         float equity = balance + unrealized;
         if (can_generate && any_valid && alive
             && balance > 0.0f && equity > liquidation_floor) {
-            update_hsl(
-                hsl, balance, starting_balance,
-                realized_pnl_cumsum_last, unrealized,
-                has_open_position, has_blocking_orders,
-                float(k), interval_ms
-            );
+            int sampled_hsl_tier = 0;
+            if (coin_hsl_mode) {
+                for (int c = 0; c < C; ++c) {
+                    int coin_offset = c * COIN_COLS;
+                    int bar_offset = (k * C + c) * 4;
+                    float close = bars[bar_offset + 2];
+                    float coin_unrealized = psize[c] > 0.0f
+                        && finite_positive(close)
+                        ? psize[c] * coin_settings[coin_offset + 4]
+                            * (short_side ? pprice[c] - close : close - pprice[c])
+                        : 0.0f;
+                    int coin_mode = hsl_mode(coin_hsl[c], psize[c] > 0.0f);
+                    bool coin_has_blocking_orders = coin_mode != 3 && (
+                        entry_qty[c] > 0.0f || close_qty[c] > 0.0f
+                            || secondary_close_qty[c] > 0.0f
+                    );
+                    coin_hsl[c].slot_count = float(effective_n_positions);
+                    update_hsl(
+                        coin_hsl[c], balance, starting_balance,
+                        coin_realized_pnl[c], coin_unrealized,
+                        psize[c] > 0.0f, coin_has_blocking_orders,
+                        float(k), interval_ms
+                    );
+                    sampled_hsl_tier = max(sampled_hsl_tier, coin_hsl[c].tier);
+                }
+            } else {
+                update_hsl(
+                    hsl, balance, starting_balance,
+                    realized_pnl_cumsum_last, unrealized,
+                    has_open_position, has_blocking_orders,
+                    float(k), interval_ms
+                );
+                sampled_hsl_tier = hsl.tier;
+            }
             if (hsl.enabled) {
                 hsl_tier_samples_total += 1.0f;
-                hsl_tier_samples_yellow += hsl.tier == 1 ? 1.0f : 0.0f;
-                hsl_tier_samples_orange += hsl.tier == 2 ? 1.0f : 0.0f;
-                hsl_tier_samples_red += hsl.tier == 3 ? 1.0f : 0.0f;
+                hsl_tier_samples_yellow += sampled_hsl_tier == 1 ? 1.0f : 0.0f;
+                hsl_tier_samples_orange += sampled_hsl_tier == 2 ? 1.0f : 0.0f;
+                hsl_tier_samples_red += sampled_hsl_tier == 3 ? 1.0f : 0.0f;
             }
-            try_restart_hsl(hsl, float(k), equity);
+            if (coin_hsl_mode) {
+                for (int c = 0; c < C; ++c) {
+                    try_restart_hsl(coin_hsl[c], float(k), equity);
+                }
+            } else {
+                try_restart_hsl(hsl, float(k), equity);
+            }
         }
         bool active = equity_started && alive && any_valid;
         if (active) {
@@ -1717,16 +1774,29 @@ inline void passivbot_ema_anchor_multicoin_impl(
     scalars[scalar_offset + 29] = held_sum_min * interval_ms;
     scalars[scalar_offset + 30] = held_count;
     scalars[scalar_offset + 31] = account_recovery_max_min * interval_ms;
-    write_one_side_hsl_outputs(
-        hsl, short_side,
-        hsl_tier_samples_total,
-        hsl_tier_samples_yellow,
-        hsl_tier_samples_orange,
-        hsl_tier_samples_red,
-        last_eq_k,
-        scalars,
-        scalar_offset + 32
-    );
+    if (coin_hsl_mode) {
+        write_one_side_coin_hsl_outputs(
+            coin_hsl, C, short_side,
+            hsl_tier_samples_total,
+            hsl_tier_samples_yellow,
+            hsl_tier_samples_orange,
+            hsl_tier_samples_red,
+            last_eq_k,
+            scalars,
+            scalar_offset + 32
+        );
+    } else {
+        write_one_side_hsl_outputs(
+            hsl, short_side,
+            hsl_tier_samples_total,
+            hsl_tier_samples_yellow,
+            hsl_tier_samples_orange,
+            hsl_tier_samples_red,
+            last_eq_k,
+            scalars,
+            scalar_offset + 32
+        );
+    }
 }
 
 kernel void passivbot_ema_anchor_multicoin(

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -287,6 +287,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
     const bool coin_hsl_mode = hsl.enabled
         && hsl.signal_mode == HSL_SIGNAL_COIN;
     HslState coin_hsl[MAX_COINS];
+    ulong coin_hsl_entry_blocked_mask = 0ul;
     const float weight_sum = w_volume + w_ready + w_volatility;
     if (weight_sum > 0.0f) {
         w_volume /= weight_sum;
@@ -602,7 +603,8 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 if (is_hsl_panic) {
                     if (coin_hsl_mode) {
                         record_hsl_panic_fill(
-                            coin_hsl[c], net_pnl, hsl_equity_before_fills
+                            coin_hsl[c], net_pnl,
+                            hsl_equity_before_fills
                         );
                     } else {
                         record_hsl_panic_fill(
@@ -621,6 +623,16 @@ inline void passivbot_ema_anchor_multicoin_impl(
                     false, !short_side
                 );
                 coin_realized_pnl[c] += net_pnl;
+                if (coin_hsl_mode) {
+                    record_coin_hsl_realized_fill(
+                        coin_hsl[c], coin_realized_pnl[c]
+                    );
+                    advance_coin_hsl_equity_after_close_fill(
+                        hsl_equity_before_fills,
+                        net_pnl, adjusted, pprice[c], close,
+                        c_mult, short_side
+                    );
+                }
                 if (collect_coin_fill_counts) {
                     coin_fill_counts[int(b) * C + c] += 1.0f;
                 }
@@ -670,6 +682,16 @@ inline void passivbot_ema_anchor_multicoin_impl(
                     true, !short_side
                 );
                 coin_realized_pnl[c] -= fee;
+                if (coin_hsl_mode) {
+                    record_coin_hsl_realized_fill(
+                        coin_hsl[c], coin_realized_pnl[c]
+                    );
+                    advance_coin_hsl_equity_after_entry_fill(
+                        hsl_equity_before_fills,
+                        fee, adjusted, fill_price, close,
+                        c_mult, short_side
+                    );
+                }
                 if (collect_coin_fill_counts) {
                     coin_fill_counts[int(b) * C + c] += 1.0f;
                 }
@@ -793,7 +815,20 @@ inline void passivbot_ema_anchor_multicoin_impl(
             // Exact Rust ranks flat candidates every minute. Re-ranking only
             // after state changes keeps the proxy inexpensive; independent
             // exact validations and drift gates police this approximation.
+            bool coin_hsl_eligibility_changed = false;
+            if (coin_hsl_mode) {
+                ulong blocked_mask = 0ul;
+                for (int c = 0; c < C; ++c) {
+                    if (hsl_mode(coin_hsl[c], false) != 0) {
+                        blocked_mask |= 1ul << ulong(c);
+                    }
+                }
+                coin_hsl_eligibility_changed =
+                    blocked_mask != coin_hsl_entry_blocked_mask;
+                coin_hsl_entry_blocked_mask = blocked_mask;
+            }
             bool reselect = !selection_initialized || any_fill
+                || coin_hsl_eligibility_changed
                 || effective_n_positions != previous_effective_n_positions;
             if (reselect) {
                 int active_count = 0;
@@ -812,7 +847,11 @@ inline void passivbot_ema_anchor_multicoin_impl(
                     bool enabled = !selected[c]
                         && k >= int(coin_settings[coin_offset + 8])
                         && k <= int(coin_settings[coin_offset + 7])
-                        && finite_positive(bars[bar_offset + 2]) && coin_wel != 0.0f;
+                        && finite_positive(bars[bar_offset + 2])
+                        && coin_wel != 0.0f
+                        && (!coin_hsl_mode || (
+                            coin_hsl_entry_blocked_mask & (1ul << ulong(c))
+                        ) == 0ul);
                     survivor[c] = enabled;
                     if (enabled) enabled_count += 1;
                 }

--- a/passivbot-rust/src/gpu/mps_hsl_common.metal
+++ b/passivbot-rust/src/gpu/mps_hsl_common.metal
@@ -405,3 +405,95 @@ inline void write_one_side_hsl_outputs(
     scalars[scalar_offset + 23] = h.panic_loss_drawdown_max;
     scalars[scalar_offset + 24] = h.panic_loss_drawdown_count;
 }
+
+inline void write_one_side_coin_hsl_outputs(
+    thread HslState* controllers,
+    int controller_count,
+    bool short_side,
+    float tier_samples_total,
+    float tier_samples_yellow,
+    float tier_samples_orange,
+    float tier_samples_red,
+    float last_equity_k,
+    device float* scalars,
+    int scalar_offset
+) {
+    float enabled = 0.0f;
+    float triggers = 0.0f;
+    float restarts = 0.0f;
+    float duration_sum = 0.0f;
+    float duration_max = 0.0f;
+    float duration_count = 0.0f;
+    float trigger_drawdown_sum = 0.0f;
+    float trigger_drawdown_count = 0.0f;
+    float flatten_time_sum = 0.0f;
+    float flatten_time_count = 0.0f;
+    float restart_retrigger_count = 0.0f;
+    float halt_to_restart_equity_loss = 0.0f;
+    float panic_close_loss_sum = 0.0f;
+    float panic_close_loss_max = 0.0f;
+    float panic_loss_drawdown_min = 0.0f;
+    float panic_loss_drawdown_sum = 0.0f;
+    float panic_loss_drawdown_max = 0.0f;
+    float panic_loss_drawdown_count = 0.0f;
+    for (int c = 0; c < controller_count; ++c) {
+        thread HslState& h = controllers[c];
+        if (!h.enabled) continue;
+        enabled = 1.0f;
+        triggers += h.triggers;
+        restarts += h.restarts;
+        float terminal_count = h.halted
+            && h.current_halt_start_k >= 0.0f && last_equity_k >= 0.0f
+            ? 1.0f : 0.0f;
+        float terminal_duration = terminal_count > 0.0f
+            ? fmax(last_equity_k - h.current_halt_start_k, 0.0f) : 0.0f;
+        duration_sum += h.halt_duration_sum_steps + terminal_duration;
+        duration_max = fmax(
+            duration_max, fmax(h.halt_duration_max_steps, terminal_duration)
+        );
+        duration_count += h.halt_duration_count + terminal_count;
+        trigger_drawdown_sum += h.trigger_drawdown_sum;
+        trigger_drawdown_count += h.trigger_drawdown_count;
+        flatten_time_sum += h.flatten_time_sum_steps;
+        flatten_time_count += h.flatten_time_count;
+        restart_retrigger_count += h.restart_retrigger_count;
+        halt_to_restart_equity_loss += h.halt_to_restart_equity_loss;
+        panic_close_loss_sum += h.panic_close_loss_sum;
+        panic_close_loss_max = fmax(panic_close_loss_max, h.panic_close_loss_max);
+        if (h.panic_loss_drawdown_count > 0.0f) {
+            panic_loss_drawdown_min = panic_loss_drawdown_count > 0.0f
+                ? fmin(panic_loss_drawdown_min, h.panic_loss_drawdown_min)
+                : h.panic_loss_drawdown_min;
+        }
+        panic_loss_drawdown_sum += h.panic_loss_drawdown_sum;
+        panic_loss_drawdown_max = fmax(
+            panic_loss_drawdown_max, h.panic_loss_drawdown_max
+        );
+        panic_loss_drawdown_count += h.panic_loss_drawdown_count;
+    }
+    scalars[scalar_offset + 0] = !short_side ? enabled : 0.0f;
+    scalars[scalar_offset + 1] = short_side ? enabled : 0.0f;
+    scalars[scalar_offset + 2] = !short_side ? triggers : 0.0f;
+    scalars[scalar_offset + 3] = short_side ? triggers : 0.0f;
+    scalars[scalar_offset + 4] = !short_side ? restarts : 0.0f;
+    scalars[scalar_offset + 5] = short_side ? restarts : 0.0f;
+    scalars[scalar_offset + 6] = tier_samples_total;
+    scalars[scalar_offset + 7] = tier_samples_yellow;
+    scalars[scalar_offset + 8] = tier_samples_orange;
+    scalars[scalar_offset + 9] = tier_samples_red;
+    scalars[scalar_offset + 10] = duration_sum;
+    scalars[scalar_offset + 11] = duration_max;
+    scalars[scalar_offset + 12] = duration_count;
+    scalars[scalar_offset + 13] = trigger_drawdown_sum;
+    scalars[scalar_offset + 14] = trigger_drawdown_count;
+    scalars[scalar_offset + 15] = flatten_time_sum;
+    scalars[scalar_offset + 16] = flatten_time_count;
+    scalars[scalar_offset + 17] = restart_retrigger_count;
+    scalars[scalar_offset + 18] = halt_to_restart_equity_loss;
+    scalars[scalar_offset + 19] = panic_close_loss_sum;
+    scalars[scalar_offset + 20] = panic_close_loss_max;
+    scalars[scalar_offset + 21] = panic_loss_drawdown_min;
+    scalars[scalar_offset + 22] = panic_loss_drawdown_sum;
+    scalars[scalar_offset + 23] = panic_loss_drawdown_max;
+    scalars[scalar_offset + 24] = panic_loss_drawdown_count;
+}

--- a/passivbot-rust/src/gpu/mps_hsl_common.metal
+++ b/passivbot-rust/src/gpu/mps_hsl_common.metal
@@ -177,6 +177,47 @@ inline bool derive_hsl_signal(
     return true;
 }
 
+inline void record_coin_hsl_realized_fill(
+    thread HslState& h,
+    float realized_pnl
+) {
+    if (!h.enabled || h.signal_mode != HSL_SIGNAL_COIN) return;
+    h.coin_realized_peak = fmax(
+        h.coin_realized_peak,
+        realized_pnl - h.coin_realized_baseline
+    );
+}
+
+inline void advance_coin_hsl_equity_after_close_fill(
+    thread float& equity,
+    float net_pnl,
+    float qty,
+    float position_price,
+    float mark_price,
+    float c_mult,
+    bool short_side
+) {
+    float removed_unrealized = qty * c_mult * (
+        short_side ? position_price - mark_price : mark_price - position_price
+    );
+    equity += net_pnl - removed_unrealized;
+}
+
+inline void advance_coin_hsl_equity_after_entry_fill(
+    thread float& equity,
+    float fee,
+    float qty,
+    float fill_price,
+    float mark_price,
+    float c_mult,
+    bool short_side
+) {
+    float added_unrealized = qty * c_mult * (
+        short_side ? fill_price - mark_price : mark_price - fill_price
+    );
+    equity += added_unrealized - fee;
+}
+
 inline void update_hsl_from_signal(
     thread HslState& h,
     thread HslSignal& signal,

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -518,6 +518,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     const float unstuck_loss_allowance_pct = params[po + 46];
     const float unstuck_threshold = params[po + 47];
     HslState hsl = load_hsl(params, po, 48);
+    const bool coin_hsl_mode = hsl.enabled
+        && hsl.signal_mode == HSL_SIGNAL_COIN;
+    HslState coin_hsl[MAX_COINS];
     const float weight_sum = w_volume + w_ready + w_volatility;
     if (weight_sum > 0.0f) {
         w_volume /= weight_sum;
@@ -591,6 +594,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     float alpha2_coin[MAX_COINS];
     float alpha_1h_coin[MAX_COINS];
     float alpha_1m_coin[MAX_COINS];
+    float coin_realized_pnl[MAX_COINS];
 
     for (int c = 0; c < MAX_COINS; ++c) {
         float seed_close = c < C ? coin_settings[c * COIN_COLS + 9] : 0.0f;
@@ -642,6 +646,10 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         filled_coin[c] = false;
         close_is_unstuck_reducer[c] = false;
         close_is_hsl_panic[c] = false;
+        coin_realized_pnl[c] = 0.0f;
+        coin_hsl[c] = load_hsl(params, po, 48);
+        coin_hsl[c].enabled = coin_hsl_mode && hsl.enabled
+            && c < C;
         float coin_span_a = c < C
             ? coin_override_or(coin_overrides, c, 0, span_a) : span_a;
         float coin_span_b = c < C
@@ -1046,6 +1054,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                                 pnl_recovery_peak_k, pnl_recovery_max_min,
                                 float(k), false, !short_side
                             );
+                            coin_realized_pnl[c] += net_pnl;
                             if (collect_coin_fill_counts) {
                                 coin_fill_counts[int(b) * C + c] += 1.0f;
                             }
@@ -1087,6 +1096,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                         pnl_recovery_peak_k, pnl_recovery_max_min,
                         float(k), false, !short_side
                     );
+                    coin_realized_pnl[c] += grid_net_pnl;
                     if (collect_coin_fill_counts) {
                         coin_fill_counts[int(b) * C + c] += 1.0f;
                     }
@@ -1138,9 +1148,15 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     float net_pnl = pnl - qty * price * c_mult
                         * (market_panic ? taker_fee : maker_fee);
                     if (is_hsl_panic) {
-                        record_hsl_panic_fill(
-                            hsl, net_pnl, hsl_equity_before_fills
-                        );
+                        if (coin_hsl_mode) {
+                            record_hsl_panic_fill(
+                                coin_hsl[c], net_pnl, hsl_equity_before_fills
+                            );
+                        } else {
+                            record_hsl_panic_fill(
+                                hsl, net_pnl, hsl_equity_before_fills
+                            );
+                        }
                     }
                     record_gross_pnl(pnl, profit_sum, loss_sum);
                     balance += net_pnl;
@@ -1152,6 +1168,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                         pnl_recovery_peak_k, pnl_recovery_max_min,
                         float(k), false, !short_side
                     );
+                    coin_realized_pnl[c] += net_pnl;
                     if (collect_coin_fill_counts) {
                         coin_fill_counts[int(b) * C + c] += 1.0f;
                     }
@@ -1203,6 +1220,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     pnl_recovery_peak_k, pnl_recovery_max_min,
                     float(k), true, !short_side
                 );
+                coin_realized_pnl[c] -= fee;
                 if (collect_coin_fill_counts) {
                     coin_fill_counts[int(b) * C + c] += 1.0f;
                 }
@@ -1343,7 +1361,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         for (int c = 0; c < C; ++c) {
             has_hsl_position = has_hsl_position || psize[c] > 0.0f;
         }
-        int current_hsl_mode = hsl_mode(hsl, has_hsl_position);
+        int current_hsl_mode = coin_hsl_mode
+            ? 0 : hsl_mode(hsl, has_hsl_position);
 
         if (can_generate) {
             // Exact Rust ranks flat candidates every minute. Re-ranking only
@@ -2329,11 +2348,14 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 }
             }
             for (int c = 0; c < C; ++c) {
-                if (current_hsl_mode >= 2
-                    || (current_hsl_mode != 0 && psize[c] <= 0.0f)) {
+                int coin_mode = coin_hsl_mode
+                    ? hsl_mode(coin_hsl[c], psize[c] > 0.0f)
+                    : current_hsl_mode;
+                if (coin_mode >= 2
+                    || (coin_mode != 0 && psize[c] <= 0.0f)) {
                     entry_qty[c] = 0.0f;
                 }
-                if (current_hsl_mode == 3 && psize[c] > 0.0f) {
+                if (coin_mode == 3 && psize[c] > 0.0f) {
                     int tick_offset = (k * C + c) * 2;
                     close_qty[c] = psize[c];
                     close_tick[c] = max(
@@ -2373,7 +2395,10 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 unrealized += psize[c] * coin_settings[coin_offset + 4]
                     * (short_side ? pprice[c] - close : close - pprice[c]);
             }
-            if (current_hsl_mode != 3 && (
+            int coin_mode = coin_hsl_mode
+                ? hsl_mode(coin_hsl[c], psize[c] > 0.0f)
+                : current_hsl_mode;
+            if (coin_mode != 3 && (
                     entry_qty[c] > 0.0f || close_qty[c] > 0.0f
                         || secondary_close_qty[c] > 0.0f
                 )) {
@@ -2383,19 +2408,53 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         float equity = balance + unrealized;
         if (can_generate && any_valid && alive
             && balance > 0.0f && equity > liquidation_floor) {
-            update_hsl(
-                hsl, balance, starting_balance,
-                realized_pnl_cumsum_last, unrealized,
-                has_open_position, has_blocking_orders,
-                float(k), interval_ms
-            );
+            int sampled_hsl_tier = 0;
+            if (coin_hsl_mode) {
+                for (int c = 0; c < C; ++c) {
+                    int coin_offset = c * COIN_COLS;
+                    int bar_offset = (k * C + c) * 4;
+                    float close = bars[bar_offset + 2];
+                    float coin_unrealized = psize[c] > 0.0f
+                        && finite_positive(close)
+                        ? psize[c] * coin_settings[coin_offset + 4]
+                            * (short_side ? pprice[c] - close : close - pprice[c])
+                        : 0.0f;
+                    int coin_mode = hsl_mode(coin_hsl[c], psize[c] > 0.0f);
+                    bool coin_has_blocking_orders = coin_mode != 3 && (
+                        entry_qty[c] > 0.0f || close_qty[c] > 0.0f
+                            || secondary_close_qty[c] > 0.0f
+                    );
+                    coin_hsl[c].slot_count = float(effective_n_positions);
+                    update_hsl(
+                        coin_hsl[c], balance, starting_balance,
+                        coin_realized_pnl[c], coin_unrealized,
+                        psize[c] > 0.0f, coin_has_blocking_orders,
+                        float(k), interval_ms
+                    );
+                    sampled_hsl_tier = max(sampled_hsl_tier, coin_hsl[c].tier);
+                }
+            } else {
+                update_hsl(
+                    hsl, balance, starting_balance,
+                    realized_pnl_cumsum_last, unrealized,
+                    has_open_position, has_blocking_orders,
+                    float(k), interval_ms
+                );
+                sampled_hsl_tier = hsl.tier;
+            }
             if (hsl.enabled) {
                 hsl_tier_samples_total += 1.0f;
-                hsl_tier_samples_yellow += hsl.tier == 1 ? 1.0f : 0.0f;
-                hsl_tier_samples_orange += hsl.tier == 2 ? 1.0f : 0.0f;
-                hsl_tier_samples_red += hsl.tier == 3 ? 1.0f : 0.0f;
+                hsl_tier_samples_yellow += sampled_hsl_tier == 1 ? 1.0f : 0.0f;
+                hsl_tier_samples_orange += sampled_hsl_tier == 2 ? 1.0f : 0.0f;
+                hsl_tier_samples_red += sampled_hsl_tier == 3 ? 1.0f : 0.0f;
             }
-            try_restart_hsl(hsl, float(k), equity);
+            if (coin_hsl_mode) {
+                for (int c = 0; c < C; ++c) {
+                    try_restart_hsl(coin_hsl[c], float(k), equity);
+                }
+            } else {
+                try_restart_hsl(hsl, float(k), equity);
+            }
         }
         bool active = equity_started && alive && any_valid;
         if (active) {
@@ -2541,16 +2600,29 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     scalars[scalar_offset + 29] = held_sum_min * interval_ms;
     scalars[scalar_offset + 30] = held_count;
     scalars[scalar_offset + 31] = account_recovery_max_min * interval_ms;
-    write_one_side_hsl_outputs(
-        hsl, short_side,
-        hsl_tier_samples_total,
-        hsl_tier_samples_yellow,
-        hsl_tier_samples_orange,
-        hsl_tier_samples_red,
-        last_eq_k,
-        scalars,
-        scalar_offset + 32
-    );
+    if (coin_hsl_mode) {
+        write_one_side_coin_hsl_outputs(
+            coin_hsl, C, short_side,
+            hsl_tier_samples_total,
+            hsl_tier_samples_yellow,
+            hsl_tier_samples_orange,
+            hsl_tier_samples_red,
+            last_eq_k,
+            scalars,
+            scalar_offset + 32
+        );
+    } else {
+        write_one_side_hsl_outputs(
+            hsl, short_side,
+            hsl_tier_samples_total,
+            hsl_tier_samples_yellow,
+            hsl_tier_samples_orange,
+            hsl_tier_samples_red,
+            last_eq_k,
+            scalars,
+            scalar_offset + 32
+        );
+    }
 }
 
 kernel void passivbot_trailing_martingale_multicoin(

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -521,6 +521,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     const bool coin_hsl_mode = hsl.enabled
         && hsl.signal_mode == HSL_SIGNAL_COIN;
     HslState coin_hsl[MAX_COINS];
+    ulong coin_hsl_entry_blocked_mask = 0ul;
     const float weight_sum = w_volume + w_ready + w_volatility;
     if (weight_sum > 0.0f) {
         w_volume /= weight_sum;
@@ -1055,6 +1056,16 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                                 float(k), false, !short_side
                             );
                             coin_realized_pnl[c] += net_pnl;
+                            if (coin_hsl_mode) {
+                                record_coin_hsl_realized_fill(
+                                    coin_hsl[c], coin_realized_pnl[c]
+                                );
+                                advance_coin_hsl_equity_after_close_fill(
+                                    hsl_equity_before_fills,
+                                    net_pnl, qty, pprice[c], close,
+                                    c_mult, short_side
+                                );
+                            }
                             if (collect_coin_fill_counts) {
                                 coin_fill_counts[int(b) * C + c] += 1.0f;
                             }
@@ -1097,6 +1108,16 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                         float(k), false, !short_side
                     );
                     coin_realized_pnl[c] += grid_net_pnl;
+                    if (coin_hsl_mode) {
+                        record_coin_hsl_realized_fill(
+                            coin_hsl[c], coin_realized_pnl[c]
+                        );
+                        advance_coin_hsl_equity_after_close_fill(
+                            hsl_equity_before_fills,
+                            grid_net_pnl, grid_qty, pprice[c], close,
+                            c_mult, short_side
+                        );
+                    }
                     if (collect_coin_fill_counts) {
                         coin_fill_counts[int(b) * C + c] += 1.0f;
                     }
@@ -1150,7 +1171,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     if (is_hsl_panic) {
                         if (coin_hsl_mode) {
                             record_hsl_panic_fill(
-                                coin_hsl[c], net_pnl, hsl_equity_before_fills
+                                coin_hsl[c], net_pnl,
+                                hsl_equity_before_fills
                             );
                         } else {
                             record_hsl_panic_fill(
@@ -1169,6 +1191,16 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                         float(k), false, !short_side
                     );
                     coin_realized_pnl[c] += net_pnl;
+                    if (coin_hsl_mode) {
+                        record_coin_hsl_realized_fill(
+                            coin_hsl[c], coin_realized_pnl[c]
+                        );
+                        advance_coin_hsl_equity_after_close_fill(
+                            hsl_equity_before_fills,
+                            net_pnl, qty, pprice[c], close,
+                            c_mult, short_side
+                        );
+                    }
                     if (collect_coin_fill_counts) {
                         coin_fill_counts[int(b) * C + c] += 1.0f;
                     }
@@ -1221,6 +1253,16 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     float(k), true, !short_side
                 );
                 coin_realized_pnl[c] -= fee;
+                if (coin_hsl_mode) {
+                    record_coin_hsl_realized_fill(
+                        coin_hsl[c], coin_realized_pnl[c]
+                    );
+                    advance_coin_hsl_equity_after_entry_fill(
+                        hsl_equity_before_fills,
+                        fee, adjusted, fill_price, close,
+                        c_mult, short_side
+                    );
+                }
                 if (collect_coin_fill_counts) {
                     coin_fill_counts[int(b) * C + c] += 1.0f;
                 }
@@ -1368,7 +1410,20 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             // Exact Rust ranks flat candidates every minute. Re-ranking only
             // after state changes keeps the proxy inexpensive; independent
             // exact validations and drift gates police this approximation.
+            bool coin_hsl_eligibility_changed = false;
+            if (coin_hsl_mode) {
+                ulong blocked_mask = 0ul;
+                for (int c = 0; c < C; ++c) {
+                    if (hsl_mode(coin_hsl[c], false) != 0) {
+                        blocked_mask |= 1ul << ulong(c);
+                    }
+                }
+                coin_hsl_eligibility_changed =
+                    blocked_mask != coin_hsl_entry_blocked_mask;
+                coin_hsl_entry_blocked_mask = blocked_mask;
+            }
             bool reselect = !selection_initialized || any_fill
+                || coin_hsl_eligibility_changed
                 || effective_n_positions != previous_effective_n_positions;
             if (reselect) {
                 int active_count = 0;
@@ -1390,7 +1445,10 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                         && k >= int(coin_settings[coin_offset + 8])
                         && k <= int(coin_settings[coin_offset + 7])
                         && finite_positive(bars[bar_offset + 2])
-                        && coin_wel != 0.0f;
+                        && coin_wel != 0.0f
+                        && (!coin_hsl_mode || (
+                            coin_hsl_entry_blocked_mask & (1ul << ulong(c))
+                        ) == 0ul);
                     survivor[c] = enabled;
                     if (enabled) enabled_count += 1;
                 }

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -25,11 +25,6 @@ def validate_hsl_signal_topology(
             raise ValueError(
                 "GPU multi-coin HSL currently requires exactly one enabled side"
             )
-        if signal_mode == "coin":
-            raise ValueError(
-                "GPU one-sided multi-coin HSL currently supports only unified "
-                "or pside signal mode; per-coin HSL remains fail closed"
-            )
         return
     if enabled_side_count > 1 and signal_mode == "unified":
         raise ValueError(

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -354,8 +354,9 @@ def _hsl_params(bot: dict, *, signal_mode: str) -> dict[str, float]:
         ),
         "hsl_orange_graceful_stop": float(orange_mode == "graceful_stop"),
         "hsl_signal_mode": signal_mode_ids[signal_mode],
-        # Coin-mode GPU HSL is single-coin and therefore has one slot. The
-        # value is inert for the unified/pside portfolio signal modes.
+        # Multi-coin kernels replace this initial value with the dynamic
+        # effective slot count before each per-coin HSL sample. The value is
+        # inert for unified/pside and exact for single-coin coin mode.
         "hsl_slot_count": 1.0,
     }
 

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1476,8 +1476,8 @@ def test_gpu_hsl_fails_closed_for_dual_side_single_coin_unified_mode():
         _validate_scope(config, _Evaluator())
 
 
-@pytest.mark.parametrize("signal_mode", ["unified", "pside"])
-def test_gpu_hsl_accepts_one_sided_multicoin_account_modes(signal_mode):
+@pytest.mark.parametrize("signal_mode", ["unified", "pside", "coin"])
+def test_gpu_hsl_accepts_one_sided_multicoin_signal_modes(signal_mode):
     config = _long_only_ema_config()
     config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "XRP"]
     config["live"]["hsl_signal_mode"] = signal_mode
@@ -1485,17 +1485,6 @@ def test_gpu_hsl_accepts_one_sided_multicoin_account_modes(signal_mode):
     config["bot"]["long"]["hsl"]["enabled"] = True
 
     assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
-
-
-def test_gpu_hsl_fails_closed_for_multicoin_coin_mode():
-    config = _long_only_ema_config()
-    config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "XRP"]
-    config["live"]["hsl_signal_mode"] = "coin"
-    config["bot"]["long"]["risk"]["n_positions"] = 3
-    config["bot"]["long"]["hsl"]["enabled"] = True
-
-    with pytest.raises(ValueError, match="per-coin HSL remains fail closed"):
-        _validate_scope(config, _MulticoinEvaluator())
 
 
 def test_gpu_hsl_accepts_one_sided_multicoin_market_panic():

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -373,6 +373,84 @@ def test_mps_one_sided_multicoin_hsl_panics_the_portfolio(
 )
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
 @pytest.mark.parametrize("side", ["long", "short"])
+@pytest.mark.parametrize("shock_coin", [0, 1, "both"])
+def test_mps_one_sided_multicoin_coin_hsl_isolates_each_coin_episode(
+    strategy_kind, side, shock_coin
+):
+    count = 64
+    closes = np.tile(np.asarray([100.0, 120.0]), (count, 1))
+    shock = 0.7 if side == "long" else 1.3
+    if shock_coin == "both":
+        closes[20:] *= shock
+    else:
+        closes[20:, shock_coin] *= shock
+    runner, row = _multicoin_exposure_fixture(
+        strategy_kind,
+        side,
+        count=count,
+        closes=closes,
+        collect_coin_fill_counts=True,
+    )
+    keys = (
+        EMA_ANCHOR_MULTICOIN_PARAM_KEYS
+        if strategy_kind == "ema_anchor"
+        else TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+    )
+    for key, value in {
+        "hsl_enabled": 1.0,
+        "hsl_red_threshold": 0.05,
+        "hsl_ema_span_minutes": 1.0,
+        "hsl_cooldown_minutes_after_red": 0.0,
+        "hsl_no_restart_drawdown_threshold": 1.0,
+        "hsl_restart_policy": 2.0,
+        "hsl_tier_ratio_yellow": 0.5,
+        "hsl_tier_ratio_orange": 0.75,
+        "hsl_orange_graceful_stop": 0.0,
+        "hsl_signal_mode": 2.0,
+        # The kernel must derive the effective value of two; this packed
+        # single-coin default is deliberately not pre-adjusted by Python.
+        "hsl_slot_count": 1.0,
+    }.items():
+        row[keys.index(key)] = value
+
+    packed_slot_variant = list(row)
+    packed_slot_variant[keys.index("hsl_slot_count")] = 64.0
+    output = runner.run(
+        np.asarray([row, packed_slot_variant], dtype=np.float64)
+    )
+    torch.mps.synchronize()
+
+    assert output[f"hsl_{side}_enabled"].all().item()
+    expected_episode_count = 2.0 if shock_coin == "both" else 1.0
+    assert (
+        output[f"hsl_triggers_{side}"] == expected_episode_count
+    ).all().item()
+    assert (
+        output["hsl_trigger_drawdown_count"] == expected_episode_count
+    ).all().item()
+    assert (
+        output["hsl_panic_loss_drawdown_count"] == expected_episode_count
+    ).all().item()
+    assert (output["hsl_panic_close_loss_sum"] > 0.0).all().item()
+    if shock_coin == "both":
+        assert (output["coin_fill_counts"] >= 2.0).all().item()
+        expected_open_positions = 0.0
+    else:
+        assert (output["coin_fill_counts"][:, shock_coin] >= 2.0).all().item()
+        expected_open_positions = (
+            1.0 if strategy_kind == "trailing_martingale" else 0.0
+        )
+    assert (output["open_positions"] == expected_open_positions).all().item()
+    assert output["hsl_trigger_drawdown_sum"][0].item() == pytest.approx(
+        output["hsl_trigger_drawdown_sum"][1].item()
+    )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_one_sided_multicoin_hsl_market_panic_applies_taker_costs(
     strategy_kind, side
 ):

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -382,14 +382,30 @@ def test_mps_one_sided_multicoin_coin_hsl_isolates_each_coin_episode(
     shock = 0.7 if side == "long" else 1.3
     if shock_coin == "both":
         closes[20:] *= shock
+        markets = [
+            ProxyMarket(
+                0.001,
+                0.01,
+                0.001,
+                0.0,
+                1.0,
+                maker_fee=0.0,
+                taker_fee=0.01,
+            )
+            for _ in range(2)
+        ]
     else:
         closes[20:, shock_coin] *= shock
+        markets = None
     runner, row = _multicoin_exposure_fixture(
         strategy_kind,
         side,
         count=count,
         closes=closes,
+        markets=markets,
         collect_coin_fill_counts=True,
+        market_order_slippage_pct=0.02 if shock_coin == "both" else 0.0,
+        hsl_panic_market=shock_coin == "both",
     )
     keys = (
         EMA_ANCHOR_MULTICOIN_PARAM_KEYS
@@ -434,6 +450,14 @@ def test_mps_one_sided_multicoin_coin_hsl_isolates_each_coin_episode(
     assert (output["hsl_panic_close_loss_sum"] > 0.0).all().item()
     if shock_coin == "both":
         assert (output["coin_fill_counts"] >= 2.0).all().item()
+        assert (
+            output["hsl_panic_loss_drawdown_max"]
+            > output["hsl_panic_loss_drawdown_min"]
+        ).all().item()
+        assert output["hsl_panic_loss_drawdown_sum"][0].item() == pytest.approx(
+            output["hsl_panic_loss_drawdown_min"][0].item()
+            + output["hsl_panic_loss_drawdown_max"][0].item()
+        )
         expected_open_positions = 0.0
     else:
         assert (output["coin_fill_counts"][:, shock_coin] >= 2.0).all().item()
@@ -444,6 +468,53 @@ def test_mps_one_sided_multicoin_coin_hsl_isolates_each_coin_episode(
     assert output["hsl_trigger_drawdown_sum"][0].item() == pytest.approx(
         output["hsl_trigger_drawdown_sum"][1].item()
     )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_multicoin_coin_hsl_reselects_around_blocked_forager_coin(
+    strategy_kind, side
+):
+    count = 64
+    closes = np.tile(np.asarray([100.0, 120.0]), (count, 1))
+    closes[20:, 1] *= 0.7 if side == "long" else 1.3
+    runner, row = _multicoin_exposure_fixture(
+        strategy_kind,
+        side,
+        count=count,
+        closes=closes,
+        collect_coin_fill_counts=True,
+    )
+    keys = (
+        EMA_ANCHOR_MULTICOIN_PARAM_KEYS
+        if strategy_kind == "ema_anchor"
+        else TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+    )
+    for key, value in {
+        "n_positions": 1.0,
+        "hsl_enabled": 1.0,
+        "hsl_red_threshold": 0.05,
+        "hsl_ema_span_minutes": 1.0,
+        "hsl_cooldown_minutes_after_red": 0.0,
+        "hsl_no_restart_drawdown_threshold": 1.0,
+        "hsl_restart_policy": 2.0,
+        "hsl_tier_ratio_yellow": 0.5,
+        "hsl_tier_ratio_orange": 0.75,
+        "hsl_orange_graceful_stop": 0.0,
+        "hsl_signal_mode": 2.0,
+        "hsl_slot_count": 1.0,
+    }.items():
+        row[keys.index(key)] = value
+
+    output = runner.run(np.asarray([row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert output[f"hsl_triggers_{side}"].item() == 1.0
+    assert output["coin_fill_counts"][0, 1].item() >= 2.0
+    assert output["coin_fill_counts"][0, 0].item() >= 1.0
 
 
 @pytest.mark.skipif(
@@ -800,6 +871,46 @@ def test_initial_single_candle_hour_bucket_matches_rust_skip_contract():
     assert not hour_valid[1]
     assert hour_valid[61]
     assert hour_log_range[61] == pytest.approx(np.log(106.0 / 94.0))
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_coin_hsl_preserves_intraminute_realized_peak():
+    import passivbot_rust
+
+    trace_kernel = r"""
+kernel void passivbot_hsl_coin_fill_peak(
+    constant float* params [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    HslState h = load_hsl(params, 0, 0);
+    record_coin_hsl_realized_fill(h, 100.0f);
+    record_coin_hsl_realized_fill(h, 90.0f);
+    HslSignal signal;
+    bool valid = derive_hsl_signal(
+        h, 1000.0f, 1000.0f, 90.0f, 0.0f, signal
+    );
+    output[0] = valid ? h.coin_realized_peak : -1.0f;
+    output[1] = valid ? signal.drawdown_raw : -1.0f;
+}
+"""
+    source = passivbot_rust.mps_ema_anchor_source_py() + trace_kernel
+    library = torch.mps.compile_shader(source)
+    params = torch.tensor(
+        [1.0, 0.1, 1.0, 0.0, 1.0, 2.0, 0.5, 0.75, 0.0, 2.0, 2.0],
+        dtype=torch.float32,
+        device="mps",
+    )
+    output = torch.zeros(2, dtype=torch.float32, device="mps")
+
+    library.passivbot_hsl_coin_fill_peak(params, output, threads=(1, 1, 1))
+    actual = output.cpu().numpy()
+
+    assert actual[0] == pytest.approx(100.0)
+    assert actual[1] == pytest.approx(0.02)
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -523,18 +523,11 @@ def test_single_coin_hsl_rejects_unknown_signal_mode():
         validate_single_coin_hsl_signal_topology("portfolio", enabled_side_count=1)
 
 
-@pytest.mark.parametrize("signal_mode", ["unified", "pside"])
-def test_one_sided_multicoin_hsl_accepts_account_modes(signal_mode):
+@pytest.mark.parametrize("signal_mode", ["unified", "pside", "coin"])
+def test_one_sided_multicoin_hsl_accepts_all_signal_modes(signal_mode):
     validate_hsl_signal_topology(
         signal_mode, coin_count=3, enabled_side_count=1
     )
-
-
-def test_one_sided_multicoin_hsl_rejects_coin_mode():
-    with pytest.raises(ValueError, match="per-coin HSL remains fail closed"):
-        validate_hsl_signal_topology(
-            "coin", coin_count=3, enabled_side_count=1
-        )
 
 
 def test_dual_side_multicoin_hsl_remains_fail_closed():


### PR DESCRIPTION
## Summary

- support `coin` HSL signal mode in one-sided multi-coin Apple MPS optimization for EMA Anchor and Trailing Martingale
- maintain independent per-coin HSL realized-PnL, warning/RED, panic-flatten, halt, and restart state while retaining exact Rust as the authoritative validator
- preserve intraminute realized-PnL peaks, advance equity between sequential coin panic episodes, and reselect forager slots whenever HSL eligibility changes
- aggregate per-episode lifecycle and panic metrics across coin controllers and sample the worst active warning tier once per minute
- derive each coin controller's loss budget from the dynamic effective position-slot count
- keep dual-side multi-coin HSL and per-coin HSL setting overrides fail closed

## Validation

- `cargo test --no-default-features` (263 passed)
- `cargo check --tests`
- `cargo fmt --check`
- full GPU backend, service, and metrics Python test suite
- full physical Apple M3 MPS test file
- focused physical M3 coin-controller isolation, sequential-panic accounting, forager reselection, intraminute peak, and aggregate tests for EMA Anchor and Trailing Martingale, long and short
- exact EMA Anchor multi-coin optimizer smoke: 512 proxy evaluations, 32 exact validations, no drift or constraint-classification halt
- exact Trailing Martingale multi-coin optimizer smoke: 512 proxy evaluations, 32 exact validations, no drift or constraint-classification halt
- `PYTHONPATH=src python src/tools/check_ai_docs.py` (0 errors; 2 pre-existing size warnings)
- `git diff --check`

## Performance

Physical M3 benchmark, batch 128, 20,000 bars, 2 coins, two order-balanced seven-run blocks, compared with the merged pre-slice Metal source:

- HSL disabled: 0.4091 s versus 0.3822 s baseline (1.071x, about 7.1% overhead)
- coin-mode HSL enabled: 0.4977 s (1.217x versus the current disabled path)

CPU optimization, backtesting, and bot operation are unchanged.
