### PR TITLE
feat(optimize): add multicoin MPS HSL coin overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,20 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added all ten canonical per-coin HSL setting overrides to one-sided multi-coin Apple MPS
+  optimization for EMA Anchor and Trailing Martingale in `coin` signal mode. Each Metal coin
+  controller now resolves its own enablement, thresholds, EMA span, cooldown, restart policy,
+  tier ratios, orange behavior, and limit/market panic execution. Compatible suites may also
+  supply scenario-local HSL coin overrides. Exact Rust validation remains authoritative;
+  per-coin HSL overrides outside this topology fail closed.
+
 - Added `coin` signal mode to one-sided multi-coin HSL Apple MPS optimization for EMA Anchor
   and Trailing Martingale. Metal now maintains an independent HSL episode per coin, including
   realized net PnL and fees, dynamic effective-slot scaling, warning/RED state, panic flattening,
   halt/restart lifecycle, and per-episode metrics. Directional outputs aggregate the same way as
   exact Rust: episode metrics are combined across coins while time-in-tier uses the worst active
-  coin tier once per minute. Exact Rust validation remains authoritative; per-coin HSL setting
-  overrides and dual-side multi-coin HSL remain fail closed.
+  coin tier once per minute. Exact Rust validation remains authoritative; dual-side multi-coin
+  HSL remains fail closed.
 
 - Added market panic-close execution to one-sided multi-coin HSL Apple MPS optimization for EMA
   Anchor and Trailing Martingale. The portfolio proxy now fills every panic close on the next
@@ -23,14 +30,14 @@ All notable user-facing changes will be documented in this file.
   candidate now applies one shared-balance portfolio HSL controller across every coin on the
   enabled side, including warning tiers, RED entry blocking, limit panic flattening, cooldown
   restart, lifecycle metrics, and panic-loss metrics. Exact Rust validation remains authoritative;
-  dual-side multi-coin HSL and per-coin HSL overrides remain fail closed.
+  dual-side multi-coin HSL remains fail closed.
 
 - Added dual-side single-coin HSL to Apple MPS optimization for EMA Anchor and Trailing
   Martingale in `coin` and `pside` signal modes, including compatible suites. Metal now tracks
   realized net PnL independently for long and short while retaining shared account balance and
   exact Rust validation. Dual-side `unified` HSL remains fail closed until its documented
-  account-wide flatten contract and exact-backtest finalization scope are reconciled; multi-coin
-  and per-coin-override HSL remain unsupported.
+  account-wide flatten contract and exact-backtest finalization scope are reconciled; dual-side
+  multi-coin HSL remains unsupported.
 
 - Consolidated the supported one-sided single-coin HSL Apple MPS screening behavior into one
   Rust-owned Metal controller shared by EMA Anchor and Trailing Martingale. Signal modes now use

--- a/docs/equity_hard_stop_loss_reference.md
+++ b/docs/equity_hard_stop_loss_reference.md
@@ -133,8 +133,9 @@ These are the main parity surfaces that should be reviewed together:
    - One-sided multi-coin coin signals use one independent controller per coin, each with coin-local realized net PnL, drawdown EMA, warning/RED episode, panic close, halt, and restart state; the coin drawdown budget uses the dynamic effective position-slot count
    - Coin-mode lifecycle and panic-loss metrics aggregate across coin episodes, while warning-tier time samples the worst active coin tier once per minute, matching exact Rust reporting
    - Multi-coin limit and market panic closes flatten every open coin on the enabled side and export the same lifecycle and panic-loss metric surface as single-coin HSL; market execution uses each coin's taker fee and directionally quantized configured slippage
+   - One-sided multi-coin coin mode resolves all ten canonical per-coin HSL settings independently, including enablement, thresholds, restart/tier behavior, and limit/market panic execution; compatible suites may supply scenario-local overrides
    - Dual-side unified HSL remains fail closed because the documented account-wide episode-finalization scope and current exact-backtest per-side flat confirmation disagree
-   - Dual-side multi-coin HSL and per-coin-override HSL still fail closed
+   - Dual-side multi-coin HSL still fails closed
 
 ### Confirmed Gaps / Risks
 
@@ -148,14 +149,13 @@ These are the main parity surfaces that should be reviewed together:
 3. GPU HSL topology is intentionally narrow
    - Dual-side unified HSL needs one resolved account-wide exact-Rust flatten contract before it can be screened safely
    - Dual-side multi-coin HSL needs one shared-balance controller that owns both directional state machines without duplicating account balance or liquidation decisions
-   - Per-coin HSL overrides require candidate-local resolved settings in those coin controllers
 
 ### Missing or Weak Test Coverage
 
 1. End-to-end replay of one identical fill/candle history through live reconstruction and exact backtest orchestration; shared Rust primitive tests cover the calculations but not the complete orchestration trace
 2. Connector-level restart races while protective panic-close orders are live on an exchange
 3. Manual or external trading during downtime across the full exchange-adapter matrix
-4. Apple MPS parity for dual-side unified, dual-side multi-coin, and per-coin-override HSL scopes
+4. Apple MPS parity for dual-side unified and dual-side multi-coin HSL scopes
 
 ## Optimizer Work
 

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -133,7 +133,8 @@ The supported slice is intentionally narrow:
   `risk.position_exposure_enforcer_enabled` and
   `risk.position_exposure_enforcer_threshold`; per-coin
   `risk.we_excess_allowance_mode`, trailing-martingale `entry.ema_gate_mode`, disabled sides, and
-  other override leaves fail closed
+  other override leaves fail closed. In one-sided `live.hsl_signal_mode: coin` runs, all ten HSL
+  leaves documented in `coin_overrides.md` are also supported; other HSL topologies fail closed
 - one-sided single-coin and multi-coin EMA Anchor and Trailing Martingale runs support HSL with
   `coin`, `pside`, or `unified` signals and both resting-limit and market panic closes. Unified and
   pside multi-coin runs use one portfolio controller; coin mode uses an independent controller per
@@ -155,8 +156,9 @@ The supported slice is intentionally narrow:
   yearly rates, time in each warning tier, halt and flatten durations, trigger drawdown, and
   post-restart retriggers) and panic-loss metrics (loss sum/max, per-episode loss
   drawdown min/mean/max, and halt-to-restart equity loss) may be used for scoring and limits.
-  Dual-side multi-coin HSL, per-coin HSL setting overrides, and HSL strategy-equity
-  EMA/recovery-distribution metrics remain fail closed for now.
+  One-sided coin-mode multi-coin runs may resolve all canonical HSL settings independently per
+  coin, including HSL enablement and limit/market panic execution. Dual-side multi-coin HSL and HSL
+  strategy-equity EMA/recovery-distribution metrics remain fail closed for now.
   Compatible suites may use the supported topologies.
 - single-coin EMA Anchor and Trailing Martingale support auto-unstuck for long-only,
   short-only, hedge-mode dual-side, one-way, and compatible suite runs. One-sided multi-coin runs

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -190,7 +190,9 @@ mod tests {
         assert!(source.contains("const bool short_side"));
         assert!(source.contains("constant int MAX_COINS = 64"));
         assert!(source.contains("constant int PARAM_COLS = 42"));
-        assert!(source.contains("constant int OVERRIDE_COLS = 19"));
+        assert!(source.contains("constant int OVERRIDE_COLS = 29"));
+        assert!(source.contains("constant int HSL_OVERRIDE_START = 19"));
+        assert!(source.contains("apply_coin_hsl_overrides("));
         assert!(source.contains("coin_override_or"));
         assert!(source.contains("constant int COIN_COLS = 12"));
         assert!(source.contains("constant int DAILY_COLS = 9"));
@@ -408,7 +410,9 @@ mod tests {
         assert!(source.contains("kernel void passivbot_trailing_martingale_multicoin"));
         assert!(source.contains("constant int MAX_COINS = 64"));
         assert!(source.contains("constant int PARAM_COLS = 59"));
-        assert!(source.contains("constant int OVERRIDE_COLS = 34"));
+        assert!(source.contains("constant int OVERRIDE_COLS = 44"));
+        assert!(source.contains("constant int HSL_OVERRIDE_START = 34"));
+        assert!(source.contains("apply_coin_hsl_overrides("));
         assert!(source.contains("constant int COIN_COLS = 12"));
         assert!(source.contains("constant int SCALAR_COLS = 57"));
         assert!(source.contains("load_hsl(params, po, 48)"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -6,7 +6,8 @@ using namespace metal;
 constant int MAX_COINS = 64;
 constant int PARAM_COLS = 42;
 constant int COIN_COLS = 12;
-constant int OVERRIDE_COLS = 19;
+constant int OVERRIDE_COLS = 29;
+constant int HSL_OVERRIDE_START = 19;
 constant int DAILY_COLS = 9;
 constant int SCALAR_COLS = 57;
 constant int GAP_BINS = 128;
@@ -284,8 +285,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
     const float unstuck_loss_allowance_pct = params[po + 29];
     const float unstuck_threshold = params[po + 30];
     HslState hsl = load_hsl(params, po, 31);
-    const bool coin_hsl_mode = hsl.enabled
-        && hsl.signal_mode == HSL_SIGNAL_COIN;
+    const bool coin_hsl_mode = hsl.signal_mode == HSL_SIGNAL_COIN;
     HslState coin_hsl[MAX_COINS];
     ulong coin_hsl_entry_blocked_mask = 0ul;
     const float weight_sum = w_volume + w_ready + w_volatility;
@@ -391,8 +391,14 @@ inline void passivbot_ema_anchor_multicoin_impl(
         close_is_hsl_panic[c] = false;
         coin_realized_pnl[c] = 0.0f;
         coin_hsl[c] = load_hsl(params, po, 31);
-        coin_hsl[c].enabled = coin_hsl_mode && hsl.enabled
-            && c < C;
+        if (coin_hsl_mode && c < C) {
+            apply_coin_hsl_overrides(
+                coin_hsl[c], coin_overrides, c,
+                OVERRIDE_COLS, HSL_OVERRIDE_START
+            );
+        } else {
+            coin_hsl[c].enabled = false;
+        }
         selected[c] = false;
         incumbent[c] = false;
         survivor[c] = false;
@@ -537,8 +543,14 @@ inline void passivbot_ema_anchor_multicoin_impl(
             const float maker_fee = coin_settings[coin_offset + 5];
             const float taker_fee = coin_settings[coin_offset + 11];
 
+            bool coin_hsl_panic_market = coin_hsl_mode
+                ? coin_override_or(
+                    coin_overrides, c, HSL_OVERRIDE_START + 9,
+                    hsl_panic_market ? 1.0f : 0.0f
+                ) > 0.5f
+                : hsl_panic_market;
             bool primary_market_panic = close_is_hsl_panic[c]
-                && hsl_panic_market;
+                && coin_hsl_panic_market;
             bool filled_close = close_qty[c] > 0.0f && psize[c] > 0.0f
                 && (primary_market_panic || (short_side
                     ? close_tick[c] > fill_ticks[tick_offset + 1]
@@ -1622,8 +1634,10 @@ inline void passivbot_ema_anchor_multicoin_impl(
         if (can_generate && any_valid && alive
             && balance > 0.0f && equity > liquidation_floor) {
             int sampled_hsl_tier = 0;
+            bool hsl_sample_enabled = !coin_hsl_mode && hsl.enabled;
             if (coin_hsl_mode) {
                 for (int c = 0; c < C; ++c) {
+                    hsl_sample_enabled = hsl_sample_enabled || coin_hsl[c].enabled;
                     int coin_offset = c * COIN_COLS;
                     int bar_offset = (k * C + c) * 4;
                     float close = bars[bar_offset + 2];
@@ -1655,7 +1669,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 );
                 sampled_hsl_tier = hsl.tier;
             }
-            if (hsl.enabled) {
+            if (hsl_sample_enabled) {
                 hsl_tier_samples_total += 1.0f;
                 hsl_tier_samples_yellow += sampled_hsl_tier == 1 ? 1.0f : 0.0f;
                 hsl_tier_samples_orange += sampled_hsl_tier == 2 ? 1.0f : 0.0f;

--- a/passivbot-rust/src/gpu/mps_hsl_common.metal
+++ b/passivbot-rust/src/gpu/mps_hsl_common.metal
@@ -130,6 +130,37 @@ inline HslState load_hsl(
     return h;
 }
 
+inline void apply_coin_hsl_overrides(
+    thread HslState& h,
+    constant float* coin_overrides,
+    int coin,
+    int override_cols,
+    int start_column
+) {
+    int offset = coin * override_cols + start_column;
+    float value = coin_overrides[offset + 0];
+    if (isfinite(value)) h.enabled = value > 0.5f;
+    value = coin_overrides[offset + 1];
+    if (isfinite(value)) h.red_threshold = value;
+    value = coin_overrides[offset + 2];
+    if (isfinite(value)) {
+        h.alpha = clamp(2.0f / (fmax(value, 1.0f) + 1.0f), 0.0f, 1.0f);
+    }
+    value = coin_overrides[offset + 3];
+    if (isfinite(value)) h.cooldown_minutes = fmax(value, 0.0f);
+    value = coin_overrides[offset + 4];
+    if (isfinite(value)) h.no_restart_threshold = value;
+    value = coin_overrides[offset + 5];
+    if (isfinite(value)) h.restart_policy = int(round(value));
+    value = coin_overrides[offset + 6];
+    if (isfinite(value)) h.yellow_ratio = value;
+    value = coin_overrides[offset + 7];
+    if (isfinite(value)) h.orange_ratio = value;
+    value = coin_overrides[offset + 8];
+    if (isfinite(value)) h.orange_graceful_stop = value > 0.5f;
+    h.no_restart_threshold = fmax(h.no_restart_threshold, h.red_threshold);
+}
+
 inline int hsl_mode(thread HslState& h, bool has_position) {
     if (!h.enabled) return 0;
     if (h.halted) return has_position ? 3 : 1;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -5,7 +5,8 @@ using namespace metal;
 
 constant int MAX_COINS = 64;
 constant int PARAM_COLS = 59;
-constant int OVERRIDE_COLS = 34;
+constant int OVERRIDE_COLS = 44;
+constant int HSL_OVERRIDE_START = 34;
 constant int COIN_COLS = 12;
 constant int DAILY_COLS = 9;
 constant int SCALAR_COLS = 57;
@@ -518,8 +519,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     const float unstuck_loss_allowance_pct = params[po + 46];
     const float unstuck_threshold = params[po + 47];
     HslState hsl = load_hsl(params, po, 48);
-    const bool coin_hsl_mode = hsl.enabled
-        && hsl.signal_mode == HSL_SIGNAL_COIN;
+    const bool coin_hsl_mode = hsl.signal_mode == HSL_SIGNAL_COIN;
     HslState coin_hsl[MAX_COINS];
     ulong coin_hsl_entry_blocked_mask = 0ul;
     const float weight_sum = w_volume + w_ready + w_volatility;
@@ -649,8 +649,14 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         close_is_hsl_panic[c] = false;
         coin_realized_pnl[c] = 0.0f;
         coin_hsl[c] = load_hsl(params, po, 48);
-        coin_hsl[c].enabled = coin_hsl_mode && hsl.enabled
-            && c < C;
+        if (coin_hsl_mode && c < C) {
+            apply_coin_hsl_overrides(
+                coin_hsl[c], coin_overrides, c,
+                OVERRIDE_COLS, HSL_OVERRIDE_START
+            );
+        } else {
+            coin_hsl[c].enabled = false;
+        }
         float coin_span_a = c < C
             ? coin_override_or(coin_overrides, c, 0, span_a) : span_a;
         float coin_span_b = c < C
@@ -801,8 +807,14 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             const float taker_fee = coin_settings[coin_offset + 11];
 
             bool close_ready = close_qty[c] > 0.0f && psize[c] > 0.0f;
+            bool coin_hsl_panic_market = coin_hsl_mode
+                ? coin_override_or(
+                    coin_overrides, c, HSL_OVERRIDE_START + 9,
+                    hsl_panic_market ? 1.0f : 0.0f
+                ) > 0.5f
+                : hsl_panic_market;
             bool primary_market_panic = close_is_hsl_panic[c]
-                && hsl_panic_market;
+                && coin_hsl_panic_market;
             bool filled_close = close_ready
                 && (primary_market_panic || (short_side
                     ? close_tick[c] > fill_ticks[tick_offset + 1]
@@ -2467,8 +2479,10 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         if (can_generate && any_valid && alive
             && balance > 0.0f && equity > liquidation_floor) {
             int sampled_hsl_tier = 0;
+            bool hsl_sample_enabled = !coin_hsl_mode && hsl.enabled;
             if (coin_hsl_mode) {
                 for (int c = 0; c < C; ++c) {
+                    hsl_sample_enabled = hsl_sample_enabled || coin_hsl[c].enabled;
                     int coin_offset = c * COIN_COLS;
                     int bar_offset = (k * C + c) * 4;
                     float close = bars[bar_offset + 2];
@@ -2500,7 +2514,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 );
                 sampled_hsl_tier = hsl.tier;
             }
-            if (hsl.enabled) {
+            if (hsl_sample_enabled) {
                 hsl_tier_samples_total += 1.0f;
                 hsl_tier_samples_yellow += sampled_hsl_tier == 1 ? 1.0f : 0.0f;
                 hsl_tier_samples_orange += sampled_hsl_tier == 2 ? 1.0f : 0.0f;

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -28,8 +28,8 @@ from optimization.callback import build_pymoo_record_entry
 from optimization.fine_tune_anchors import ANCHOR_GENE_KEY, get_anchor_plan
 from optimization.gpu.model import (
     HSL_COIN_OVERRIDE_PATHS,
-    encode_hsl_panic_order_type,
     gpu_side_enabled,
+    validate_hsl_override_patch,
     validate_hsl_signal_topology,
 )
 from optimization.interrupts import (
@@ -1231,14 +1231,11 @@ def _validate_gpu_coin_overrides(
                 hsl_patch = side_patch.get("hsl", {}) or {}
                 if not isinstance(hsl_patch, dict):
                     continue
-                if "panic_close_order_type" in hsl_patch:
-                    encode_hsl_panic_order_type(
-                        hsl_patch["panic_close_order_type"],
-                        field_name=(
-                            f"coin_overrides.{coin}.bot.{side}.hsl."
-                            "panic_close_order_type"
-                        ),
-                    )
+                validate_hsl_override_patch(
+                    config.get("bot", {}).get(side, {}).get("hsl", {}) or {},
+                    hsl_patch,
+                    field_name=f"coin_overrides.{coin}.bot.{side}.hsl",
+                )
     if unsupported:
         supported_risk = (
             "risk.entry_cooldown_minutes, risk.we_excess_allowance_pct"

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -27,6 +27,7 @@ from optimization.bounds import Bound, enforce_bounds
 from optimization.callback import build_pymoo_record_entry
 from optimization.fine_tune_anchors import ANCHOR_GENE_KEY, get_anchor_plan
 from optimization.gpu.model import (
+    HSL_COIN_OVERRIDE_PATHS,
     gpu_side_enabled,
     validate_hsl_signal_topology,
 )
@@ -993,11 +994,22 @@ def _validate_scope_config(
         enabled_sides=enabled_sides,
         coin_count=coin_count,
     )
-    hsl_enabled_sides = [
-        side
-        for side in enabled_sides
-        if bool(config["bot"][side].get("hsl", {}).get("enabled"))
-    ]
+    hsl_enabled_sides = []
+    for side in enabled_sides:
+        globally_enabled = bool(
+            config["bot"][side].get("hsl", {}).get("enabled")
+        )
+        override_enabled = any(
+            bool(
+                (patch.get("bot", {}).get(side, {}).get("hsl", {}) or {}).get(
+                    "enabled", globally_enabled
+                )
+            )
+            for patch in (config.get("coin_overrides") or {}).values()
+            if isinstance(patch, dict)
+        )
+        if globally_enabled or override_enabled:
+            hsl_enabled_sides.append(side)
     if hsl_enabled_sides:
         # The proxy deliberately keeps an all-history candidate-local peak for
         # finite windows. That peak is never below Rust's rolling-window peak,
@@ -1192,16 +1204,32 @@ def _validate_gpu_coin_overrides(
             )
             for path in strategy_paths
         )
+        allowed.update(
+            ("bot", enabled_side, "hsl", *path)
+            for _key, path in HSL_COIN_OVERRIDE_PATHS
+        )
     unsupported = []
+    hsl_override_paths = []
     for coin, patch in overrides.items():
         if not isinstance(patch, dict):
             unsupported.append(f"coin_overrides.{coin}")
             continue
-        unsupported.extend(
-            ".".join(("coin_overrides", str(coin), *path))
-            for path in leaves(patch)
-            if path not in allowed
-        )
+        for path in leaves(patch):
+            rendered = ".".join(("coin_overrides", str(coin), *path))
+            if len(path) >= 3 and path[0] == "bot" and path[2] == "hsl":
+                hsl_override_paths.append(rendered)
+            if path not in allowed:
+                unsupported.append(rendered)
+    if hsl_override_paths:
+        signal_mode = str(
+            config.get("live", {}).get("hsl_signal_mode", "unified")
+        ).strip().lower()
+        if signal_mode != "coin" or len(enabled_sides) != 1:
+            raise ValueError(
+                "GPU per-coin HSL overrides require live.hsl_signal_mode=coin "
+                "and exactly one enabled side; unsupported paths: "
+                f"{sorted(hsl_override_paths)}"
+            )
     if unsupported:
         supported_risk = (
             "risk.entry_cooldown_minutes, risk.we_excess_allowance_pct"
@@ -1215,7 +1243,7 @@ def _validate_gpu_coin_overrides(
             "GPU coin_overrides do not model these paths yet: "
             f"{sorted(unsupported)}; supported leaves are enabled-side "
             f"{strategy_kind} parameters, {supported_risk}, unstuck parameters, "
-            "and wallet_exposure_limit"
+            "HSL parameters in coin signal mode, and wallet_exposure_limit"
         )
 
 

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -28,6 +28,7 @@ from optimization.callback import build_pymoo_record_entry
 from optimization.fine_tune_anchors import ANCHOR_GENE_KEY, get_anchor_plan
 from optimization.gpu.model import (
     HSL_COIN_OVERRIDE_PATHS,
+    encode_hsl_panic_order_type,
     gpu_side_enabled,
     validate_hsl_signal_topology,
 )
@@ -1217,6 +1218,27 @@ def _validate_gpu_coin_overrides(
                 "and exactly one enabled side; unsupported paths: "
                 f"{sorted(hsl_override_paths)}"
             )
+        for coin, patch in overrides.items():
+            if not isinstance(patch, dict):
+                continue
+            bot_patch = patch.get("bot", {})
+            if not isinstance(bot_patch, dict):
+                continue
+            for side in enabled_sides:
+                side_patch = bot_patch.get(side, {})
+                if not isinstance(side_patch, dict):
+                    continue
+                hsl_patch = side_patch.get("hsl", {}) or {}
+                if not isinstance(hsl_patch, dict):
+                    continue
+                if "panic_close_order_type" in hsl_patch:
+                    encode_hsl_panic_order_type(
+                        hsl_patch["panic_close_order_type"],
+                        field_name=(
+                            f"coin_overrides.{coin}.bot.{side}.hsl."
+                            "panic_close_order_type"
+                        ),
+                    )
     if unsupported:
         supported_risk = (
             "risk.entry_cooldown_minutes, risk.we_excess_allowance_pct"

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -994,22 +994,9 @@ def _validate_scope_config(
         enabled_sides=enabled_sides,
         coin_count=coin_count,
     )
-    hsl_enabled_sides = []
-    for side in enabled_sides:
-        globally_enabled = bool(
-            config["bot"][side].get("hsl", {}).get("enabled")
-        )
-        override_enabled = any(
-            bool(
-                (patch.get("bot", {}).get(side, {}).get("hsl", {}) or {}).get(
-                    "enabled", globally_enabled
-                )
-            )
-            for patch in (config.get("coin_overrides") or {}).values()
-            if isinstance(patch, dict)
-        )
-        if globally_enabled or override_enabled:
-            hsl_enabled_sides.append(side)
+    hsl_enabled_sides = [
+        side for side in enabled_sides if _gpu_hsl_side_enabled(config, side)
+    ]
     if hsl_enabled_sides:
         # The proxy deliberately keeps an all-history candidate-local peak for
         # finite windows. That peak is never below Rust's rolling-window peak,
@@ -2107,20 +2094,41 @@ def _gpu_pinned_hsl_bound_contract(bound_by_key) -> dict[str, float]:
     }
 
 
+def _gpu_hsl_side_enabled(config: dict, side: str) -> bool:
+    globally_enabled = bool(
+        config.get("bot", {})
+        .get(side, {})
+        .get("hsl", {})
+        .get("enabled", False)
+    )
+    if globally_enabled:
+        return True
+    for patch in (config.get("coin_overrides") or {}).values():
+        if not isinstance(patch, dict):
+            continue
+        hsl_patch = (
+            patch.get("bot", {}).get(side, {}).get("hsl", {}) or {}
+        )
+        if isinstance(hsl_patch, dict) and bool(hsl_patch.get("enabled", False)):
+            return True
+    return False
+
+
 def _validate_hsl_bound_contracts(bound_by_key, config: dict) -> None:
     float32_below_one = float(
         np.nextafter(np.float32(1.0), np.float32(0.0))
     )
     for side in ("long", "short"):
-        enabled = bool(
+        globally_enabled = bool(
             config.get("bot", {})
             .get(side, {})
             .get("hsl", {})
             .get("enabled", False)
         )
+        enabled = _gpu_hsl_side_enabled(config, side)
         enabled_bound = bound_by_key.get(f"{side}_hsl_enabled")
         if enabled_bound is not None:
-            expected = float(enabled)
+            expected = float(globally_enabled)
             endpoints = (float(enabled_bound.low), float(enabled_bound.high))
             if any(
                 not math.isclose(
@@ -2179,12 +2187,7 @@ def _gpu_hsl_search_sides(
         for side in ("long", "short")
         if any(
             gpu_side_enabled(item, side)
-            and bool(
-                item.get("bot", {})
-                .get(side, {})
-                .get("hsl", {})
-                .get("enabled", False)
-            )
+            and _gpu_hsl_side_enabled(item, side)
             for item in configs
         )
     }

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -108,6 +108,17 @@ HSL_COIN_OVERRIDE_PATHS = (
     ("hsl_panic_market", ("panic_close_order_type",)),
 )
 
+
+def encode_hsl_panic_order_type(value, *, field_name: str) -> float:
+    normalized = str(value).strip().lower()
+    if normalized not in {"limit", "market"}:
+        raise ValueError(
+            f"GPU HSL requires {field_name} to be limit or market, got "
+            f"{value!r}"
+        )
+    return float(normalized == "market")
+
+
 MULTICOIN_TOTAL_EXPOSURE_ENFORCER_PARAM_KEYS = (
     *TOTAL_EXPOSURE_ENFORCER_PARAM_KEYS,
     "twel_enforcer_reduce_portfolio",

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -110,13 +110,14 @@ HSL_COIN_OVERRIDE_PATHS = (
 
 
 def encode_hsl_panic_order_type(value, *, field_name: str) -> float:
-    normalized = str(value).strip().lower()
-    if normalized not in {"limit", "market"}:
+    if not isinstance(value, str):
+        raise TypeError(f"GPU HSL requires {field_name} to be a string")
+    if value not in {"limit", "market"}:
         raise ValueError(
             f"GPU HSL requires {field_name} to be limit or market, got "
             f"{value!r}"
         )
-    return float(normalized == "market")
+    return float(value == "market")
 
 
 def validate_hsl_settings(settings: dict, *, field_name: str) -> dict:
@@ -133,6 +134,10 @@ def validate_hsl_settings(settings: dict, *, field_name: str) -> dict:
             raise TypeError(f"{field_name}.{key} must be numeric") from exc
         if not math.isfinite(value):
             raise ValueError(f"{field_name}.{key} must be finite")
+        if abs(value) > float(np.finfo(np.float32).max):
+            raise ValueError(
+                f"{field_name}.{key} must be representable as float32"
+            )
         return value
 
     red_threshold = finite_float("red_threshold", 0.15)
@@ -174,19 +179,21 @@ def validate_hsl_settings(settings: dict, *, field_name: str) -> dict:
             f"{field_name}.tier_ratios must satisfy 0 < yellow < orange < 1"
         )
 
-    restart_policy = str(
-        settings.get("restart_after_red_policy", "threshold")
-    ).strip().lower()
+    restart_policy = settings.get("restart_after_red_policy", "threshold")
+    if not isinstance(restart_policy, str):
+        raise TypeError(
+            f"{field_name}.restart_after_red_policy must be a string"
+        )
     if restart_policy not in {"always", "threshold", "never"}:
         raise ValueError(
             f"{field_name}.restart_after_red_policy must be always, threshold, "
             f"or never, got {restart_policy!r}"
         )
-    orange_mode = str(
-        settings.get(
-            "orange_tier_mode", "tp_only_with_active_entry_cancellation"
-        )
-    ).strip().lower()
+    orange_mode = settings.get(
+        "orange_tier_mode", "tp_only_with_active_entry_cancellation"
+    )
+    if not isinstance(orange_mode, str):
+        raise TypeError(f"{field_name}.orange_tier_mode must be a string")
     if orange_mode not in {
         "graceful_stop",
         "tp_only_with_active_entry_cancellation",
@@ -196,9 +203,7 @@ def validate_hsl_settings(settings: dict, *, field_name: str) -> dict:
             "tp_only_with_active_entry_cancellation, got "
             f"{orange_mode!r}"
         )
-    panic_order_type = str(
-        settings.get("panic_close_order_type", "limit")
-    ).strip().lower()
+    panic_order_type = settings.get("panic_close_order_type", "limit")
     encode_hsl_panic_order_type(
         panic_order_type,
         field_name=f"{field_name}.panic_close_order_type",

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -95,6 +95,19 @@ HSL_PARAM_KEYS = (
     "hsl_slot_count",
 )
 
+HSL_COIN_OVERRIDE_PATHS = (
+    ("hsl_enabled", ("enabled",)),
+    ("hsl_red_threshold", ("red_threshold",)),
+    ("hsl_ema_span_minutes", ("ema_span_minutes",)),
+    ("hsl_cooldown_minutes_after_red", ("cooldown_minutes_after_red",)),
+    ("hsl_no_restart_drawdown_threshold", ("no_restart_drawdown_threshold",)),
+    ("hsl_restart_policy", ("restart_after_red_policy",)),
+    ("hsl_tier_ratio_yellow", ("tier_ratios", "yellow")),
+    ("hsl_tier_ratio_orange", ("tier_ratios", "orange")),
+    ("hsl_orange_graceful_stop", ("orange_tier_mode",)),
+    ("hsl_panic_market", ("panic_close_order_type",)),
+)
+
 MULTICOIN_TOTAL_EXPOSURE_ENFORCER_PARAM_KEYS = (
     *TOTAL_EXPOSURE_ENFORCER_PARAM_KEYS,
     "twel_enforcer_reduce_portfolio",

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -178,6 +178,13 @@ def validate_hsl_settings(settings: dict, *, field_name: str) -> dict:
         raise ValueError(
             f"{field_name}.tier_ratios must satisfy 0 < yellow < orange < 1"
         )
+    yellow_f32 = float(np.float32(yellow))
+    orange_f32 = float(np.float32(orange))
+    if not 0.0 < yellow_f32 < orange_f32 < 1.0:
+        raise ValueError(
+            f"{field_name}.tier_ratios must remain strictly ordered inside "
+            "(0, 1) when represented as float32"
+        )
 
     restart_policy = settings.get("restart_after_red_policy", "threshold")
     if not isinstance(restart_policy, str):

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -119,6 +119,120 @@ def encode_hsl_panic_order_type(value, *, field_name: str) -> float:
     return float(normalized == "market")
 
 
+def validate_hsl_settings(settings: dict, *, field_name: str) -> dict:
+    if not isinstance(settings, dict):
+        raise TypeError(f"{field_name} must be a dictionary")
+    enabled = settings.get("enabled", False)
+    if not isinstance(enabled, bool):
+        raise TypeError(f"{field_name}.enabled must be a boolean")
+
+    def finite_float(key: str, default: float) -> float:
+        try:
+            value = float(settings.get(key, default))
+        except (TypeError, ValueError) as exc:
+            raise TypeError(f"{field_name}.{key} must be numeric") from exc
+        if not math.isfinite(value):
+            raise ValueError(f"{field_name}.{key} must be finite")
+        return value
+
+    red_threshold = finite_float("red_threshold", 0.15)
+    ema_span_minutes = finite_float("ema_span_minutes", 720.0)
+    cooldown_minutes = finite_float("cooldown_minutes_after_red", 0.0)
+    no_restart_threshold = finite_float(
+        "no_restart_drawdown_threshold", 1.0
+    )
+    if not 0.0 < red_threshold <= 1.0:
+        raise ValueError(
+            f"{field_name}.red_threshold must satisfy 0 < value <= 1"
+        )
+    if ema_span_minutes < 1.0:
+        raise ValueError(f"{field_name}.ema_span_minutes must be >= 1")
+    if cooldown_minutes < 0.0:
+        raise ValueError(
+            f"{field_name}.cooldown_minutes_after_red must be >= 0"
+        )
+    if not red_threshold <= no_restart_threshold <= 1.0:
+        raise ValueError(
+            f"{field_name}.no_restart_drawdown_threshold must satisfy "
+            "red_threshold <= value <= 1"
+        )
+
+    tier_ratios = settings.get(
+        "tier_ratios", {"yellow": 0.5, "orange": 0.75}
+    )
+    if not isinstance(tier_ratios, dict):
+        raise TypeError(f"{field_name}.tier_ratios must be a dictionary")
+    try:
+        yellow = float(tier_ratios.get("yellow", 0.5))
+        orange = float(tier_ratios.get("orange", 0.75))
+    except (TypeError, ValueError) as exc:
+        raise TypeError(f"{field_name}.tier_ratios values must be numeric") from exc
+    if not (math.isfinite(yellow) and math.isfinite(orange)):
+        raise ValueError(f"{field_name}.tier_ratios values must be finite")
+    if not 0.0 < yellow < orange < 1.0:
+        raise ValueError(
+            f"{field_name}.tier_ratios must satisfy 0 < yellow < orange < 1"
+        )
+
+    restart_policy = str(
+        settings.get("restart_after_red_policy", "threshold")
+    ).strip().lower()
+    if restart_policy not in {"always", "threshold", "never"}:
+        raise ValueError(
+            f"{field_name}.restart_after_red_policy must be always, threshold, "
+            f"or never, got {restart_policy!r}"
+        )
+    orange_mode = str(
+        settings.get(
+            "orange_tier_mode", "tp_only_with_active_entry_cancellation"
+        )
+    ).strip().lower()
+    if orange_mode not in {
+        "graceful_stop",
+        "tp_only_with_active_entry_cancellation",
+    }:
+        raise ValueError(
+            f"{field_name}.orange_tier_mode must be graceful_stop or "
+            "tp_only_with_active_entry_cancellation, got "
+            f"{orange_mode!r}"
+        )
+    panic_order_type = str(
+        settings.get("panic_close_order_type", "limit")
+    ).strip().lower()
+    encode_hsl_panic_order_type(
+        panic_order_type,
+        field_name=f"{field_name}.panic_close_order_type",
+    )
+    return {
+        "enabled": enabled,
+        "red_threshold": red_threshold,
+        "ema_span_minutes": ema_span_minutes,
+        "cooldown_minutes_after_red": cooldown_minutes,
+        "no_restart_drawdown_threshold": no_restart_threshold,
+        "restart_after_red_policy": restart_policy,
+        "tier_ratios": {"yellow": yellow, "orange": orange},
+        "orange_tier_mode": orange_mode,
+        "panic_close_order_type": panic_order_type,
+    }
+
+
+def validate_hsl_override_patch(
+    base_hsl: dict, override_hsl: dict, *, field_name: str
+) -> dict:
+    if not isinstance(base_hsl, dict) or not isinstance(override_hsl, dict):
+        raise TypeError(f"{field_name} must be a dictionary")
+    effective = dict(base_hsl)
+    base_ratios = base_hsl.get("tier_ratios", {})
+    override_ratios = override_hsl.get("tier_ratios", {})
+    if not isinstance(base_ratios, dict) or not isinstance(override_ratios, dict):
+        raise TypeError(f"{field_name}.tier_ratios must be a dictionary")
+    effective.update(
+        {key: value for key, value in override_hsl.items() if key != "tier_ratios"}
+    )
+    effective["tier_ratios"] = {**base_ratios, **override_ratios}
+    return validate_hsl_settings(effective, field_name=field_name)
+
+
 MULTICOIN_TOTAL_EXPOSURE_ENFORCER_PARAM_KEYS = (
     *TOTAL_EXPOSURE_ENFORCER_PARAM_KEYS,
     "twel_enforcer_reduce_portfolio",

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -455,7 +455,7 @@ class MpsEmaAnchorRunner:
 class MpsEmaAnchorMulticoinRunner:
     """Persistent single-side multi-coin EMA Anchor screening runner on MPS."""
 
-    coin_override_cols = 19
+    coin_override_cols = 29
     coin_override_label = "EMA"
 
     def __init__(
@@ -677,7 +677,7 @@ class MpsEmaAnchorMulticoinShortRunner(MpsEmaAnchorMulticoinRunner):
 class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
     """Persistent single-side multi-coin Trailing Martingale proxy on MPS."""
 
-    coin_override_cols = 34
+    coin_override_cols = 44
     coin_override_label = "Trailing Martingale"
 
     def __init__(

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -408,7 +408,7 @@ def _require_no_internal_invalid_hsl_candles(
 
 
 def _require_no_internal_invalid_multicoin_hsl_candles(
-    hlcvs, *, first_valid_indices, last_valid_indices
+    hlcvs, *, hsl_enabled_coins, first_valid_indices, last_valid_indices
 ) -> None:
     values = np.asarray(hlcvs)
     if values.ndim != 3 or values.shape[2] < 3:
@@ -417,12 +417,17 @@ def _require_no_internal_invalid_multicoin_hsl_candles(
         )
     coin_count = values.shape[1]
     if not (
-        len(first_valid_indices) == len(last_valid_indices) == coin_count
+        len(hsl_enabled_coins)
+        == len(first_valid_indices)
+        == len(last_valid_indices)
+        == coin_count
     ):
         raise ValueError(
             "MPS multi-coin HSL valid-index counts must match the coin count"
         )
     for coin in range(coin_count):
+        if not bool(hsl_enabled_coins[coin]):
+            continue
         _require_no_internal_invalid_hsl_candles(
             values[:, coin, 0],
             values[:, coin, 1],
@@ -1391,6 +1396,13 @@ class MpsMulticoinProxy:
             )
             _require_no_internal_invalid_multicoin_hsl_candles(
                 values,
+                hsl_enabled_coins=[
+                    any(
+                        bool(item[side].get("hsl_enabled"))
+                        for side in hsl_enabled_sides
+                    )
+                    for item in payload.bot_params_list
+                ],
                 first_valid_indices=backtest_params["first_valid_indices"],
                 last_valid_indices=backtest_params["last_valid_indices"],
             )

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -22,6 +22,7 @@ from optimization.gpu.model import (
     encode_hsl_panic_order_type,
     flatten_trailing_martingale_params,
     gpu_side_enabled,
+    validate_hsl_settings,
     validate_hsl_signal_topology,
     validate_single_coin_hsl_signal_topology,
 )
@@ -301,67 +302,75 @@ def _unstuck_params(bot: dict) -> dict[str, float]:
 
 
 def _hsl_params(bot: dict, *, signal_mode: str) -> dict[str, float]:
-    restart_policy = str(
-        bot.get("hsl_restart_after_red_policy", "threshold")
-    ).strip().lower()
     restart_policy_ids = {"always": 0.0, "threshold": 1.0, "never": 2.0}
-    if restart_policy not in restart_policy_ids:
-        raise ValueError(
-            "MPS HSL requires restart_after_red_policy to be always, threshold, "
-            f"or never, got {restart_policy!r}"
-        )
     signal_mode = str(signal_mode).strip().lower()
     validate_single_coin_hsl_signal_topology(signal_mode, enabled_side_count=1)
     signal_mode_ids = {"unified": 0.0, "pside": 1.0, "coin": 2.0}
-    orange_mode = str(
-        bot.get("hsl_orange_tier_mode", "tp_only_with_active_entry_cancellation")
-    ).strip().lower()
-    if orange_mode not in {
-        "graceful_stop",
-        "tp_only",
-        "tp_only_with_active_entry_cancellation",
-    }:
-        raise ValueError(
-            "MPS HSL requires orange_tier_mode to be graceful_stop or tp_only, "
-            f"got {orange_mode!r}"
-        )
-    tier_ratios = bot.get("hsl_tier_ratios", {}) or {}
-    if not isinstance(tier_ratios, dict):
-        raise ValueError(
-            "MPS HSL requires tier_ratios to be a dictionary, got "
-            f"{type(tier_ratios).__name__}"
-        )
+    tier_ratios = bot.get("hsl_tier_ratios", {})
+    if isinstance(tier_ratios, dict):
+        tier_ratios = dict(tier_ratios)
+        if "hsl_tier_ratio_yellow" in bot:
+            tier_ratios["yellow"] = bot["hsl_tier_ratio_yellow"]
+        if "hsl_tier_ratio_orange" in bot:
+            tier_ratios["orange"] = bot["hsl_tier_ratio_orange"]
+    validated = validate_hsl_settings(
+        {
+            "enabled": bot.get("hsl_enabled", False),
+            "red_threshold": bot.get("hsl_red_threshold", 0.15),
+            "ema_span_minutes": bot.get("hsl_ema_span_minutes", 720.0),
+            "cooldown_minutes_after_red": bot.get(
+                "hsl_cooldown_minutes_after_red", 0.0
+            ),
+            "no_restart_drawdown_threshold": bot.get(
+                "hsl_no_restart_drawdown_threshold", 1.0
+            ),
+            "restart_after_red_policy": bot.get(
+                "hsl_restart_after_red_policy", "threshold"
+            ),
+            "tier_ratios": tier_ratios,
+            "orange_tier_mode": bot.get(
+                "hsl_orange_tier_mode",
+                "tp_only_with_active_entry_cancellation",
+            ),
+            "panic_close_order_type": bot.get(
+                "hsl_panic_close_order_type", "limit"
+            ),
+        },
+        field_name="MPS HSL",
+    )
     float32_below_one = float(
         np.nextafter(np.float32(1.0), np.float32(0.0))
     )
-    for key, default in (
-        ("hsl_red_threshold", 0.15),
-        ("hsl_no_restart_drawdown_threshold", 1.0),
+    for key, value in (
+        ("hsl_red_threshold", validated["red_threshold"]),
+        (
+            "hsl_no_restart_drawdown_threshold",
+            validated["no_restart_drawdown_threshold"],
+        ),
     ):
-        value = float(bot.get(key, default))
         if float32_below_one < value < 1.0:
             raise ValueError(
                 f"MPS HSL cannot represent {key}={value} distinctly from 1.0; "
                 f"use <= {float32_below_one} or exactly 1.0"
             )
     return {
-        "hsl_enabled": float(bool(bot.get("hsl_enabled", False))),
-        "hsl_red_threshold": float(bot.get("hsl_red_threshold", 0.15)),
-        "hsl_ema_span_minutes": float(bot.get("hsl_ema_span_minutes", 720.0)),
-        "hsl_cooldown_minutes_after_red": float(
-            bot.get("hsl_cooldown_minutes_after_red", 0.0)
+        "hsl_enabled": float(validated["enabled"]),
+        "hsl_red_threshold": validated["red_threshold"],
+        "hsl_ema_span_minutes": validated["ema_span_minutes"],
+        "hsl_cooldown_minutes_after_red": validated[
+            "cooldown_minutes_after_red"
+        ],
+        "hsl_no_restart_drawdown_threshold": validated[
+            "no_restart_drawdown_threshold"
+        ],
+        "hsl_restart_policy": restart_policy_ids[
+            validated["restart_after_red_policy"]
+        ],
+        "hsl_tier_ratio_yellow": validated["tier_ratios"]["yellow"],
+        "hsl_tier_ratio_orange": validated["tier_ratios"]["orange"],
+        "hsl_orange_graceful_stop": float(
+            validated["orange_tier_mode"] == "graceful_stop"
         ),
-        "hsl_no_restart_drawdown_threshold": float(
-            bot.get("hsl_no_restart_drawdown_threshold", 1.0)
-        ),
-        "hsl_restart_policy": restart_policy_ids[restart_policy],
-        "hsl_tier_ratio_yellow": float(
-            bot.get("hsl_tier_ratio_yellow", tier_ratios.get("yellow", 0.5))
-        ),
-        "hsl_tier_ratio_orange": float(
-            bot.get("hsl_tier_ratio_orange", tier_ratios.get("orange", 0.75))
-        ),
-        "hsl_orange_graceful_stop": float(orange_mode == "graceful_stop"),
         "hsl_signal_mode": signal_mode_ids[signal_mode],
         # Multi-coin kernels replace this initial value with the dynamic
         # effective slot count before each per-coin HSL sample. The value is

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -19,6 +19,7 @@ from optimization.gpu.model import (
     TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS,
     build_mps_data,
     build_mps_multicoin_data,
+    encode_hsl_panic_order_type,
     flatten_trailing_martingale_params,
     gpu_side_enabled,
     validate_hsl_signal_topology,
@@ -1016,7 +1017,10 @@ def _pack_multicoin_hsl_overrides(
         if value is missing:
             continue
         if key == "hsl_panic_market":
-            encoded = float(str(value).strip().lower() == "market")
+            encoded = encode_hsl_panic_order_type(
+                value,
+                field_name="coin override hsl.panic_close_order_type",
+            )
         else:
             encoded = float(packed[key])
         matrix[row, start_column + offset] = encoded

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -324,6 +324,12 @@ def _hsl_params(bot: dict, *, signal_mode: str) -> dict[str, float]:
             "MPS HSL requires orange_tier_mode to be graceful_stop or tp_only, "
             f"got {orange_mode!r}"
         )
+    tier_ratios = bot.get("hsl_tier_ratios", {}) or {}
+    if not isinstance(tier_ratios, dict):
+        raise ValueError(
+            "MPS HSL requires tier_ratios to be a dictionary, got "
+            f"{type(tier_ratios).__name__}"
+        )
     float32_below_one = float(
         np.nextafter(np.float32(1.0), np.float32(0.0))
     )
@@ -349,10 +355,10 @@ def _hsl_params(bot: dict, *, signal_mode: str) -> dict[str, float]:
         ),
         "hsl_restart_policy": restart_policy_ids[restart_policy],
         "hsl_tier_ratio_yellow": float(
-            bot.get("hsl_tier_ratio_yellow", 0.5)
+            bot.get("hsl_tier_ratio_yellow", tier_ratios.get("yellow", 0.5))
         ),
         "hsl_tier_ratio_orange": float(
-            bot.get("hsl_tier_ratio_orange", 0.75)
+            bot.get("hsl_tier_ratio_orange", tier_ratios.get("orange", 0.75))
         ),
         "hsl_orange_graceful_stop": float(orange_mode == "graceful_stop"),
         "hsl_signal_mode": signal_mode_ids[signal_mode],

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -6,10 +6,12 @@ import os
 
 import numpy as np
 
+from config.shared_bot import flatten_shared_bot_side
 from optimization.gpu.model import (
     EMA_ANCHOR_PARAM_KEYS,
     EMA_ANCHOR_MULTICOIN_PARAM_KEYS,
     GPU_STRATEGY_PARAM_KEYS,
+    HSL_COIN_OVERRIDE_PATHS,
     MPS_MULTICOIN_MAX_COINS,
     ProxyMarket,
     ProxyRun,
@@ -986,6 +988,34 @@ class MpsSingleCoinProxy:
 MpsEmaAnchorProxy = MpsSingleCoinProxy
 
 
+def _pack_multicoin_hsl_overrides(
+    matrix: np.ndarray,
+    *,
+    row: int,
+    start_column: int,
+    side_patch: dict,
+    effective_bot: dict,
+) -> None:
+    hsl_patch = side_patch.get("hsl", {}) or {}
+    if not hsl_patch:
+        return
+    packed = _hsl_params(effective_bot, signal_mode="coin")
+    missing = object()
+    for offset, (key, path) in enumerate(HSL_COIN_OVERRIDE_PATHS):
+        value = hsl_patch
+        for part in path:
+            value = value.get(part, missing) if isinstance(value, dict) else missing
+            if value is missing:
+                break
+        if value is missing:
+            continue
+        if key == "hsl_panic_market":
+            encoded = float(str(value).strip().lower() == "market")
+        else:
+            encoded = float(packed[key])
+        matrix[row, start_column + offset] = encoded
+
+
 def _build_multicoin_ema_coin_overrides(
     *,
     config: dict,
@@ -1004,7 +1034,12 @@ def _build_multicoin_ema_coin_overrides(
         resolve_override = _get_backtest_coin_override
 
     override_keys = tuple(EMA_ANCHOR_PARAM_KEYS[:-2])
-    matrix = np.full((len(coins), 19), np.nan, dtype=np.float32)
+    hsl_start_column = 19
+    matrix = np.full(
+        (len(coins), hsl_start_column + len(HSL_COIN_OVERRIDE_PATHS)),
+        np.nan,
+        dtype=np.float32,
+    )
     for coin_index, coin in enumerate(coins):
         patch = resolve_override(config, mss, exchange, coin) or {}
         side_patch = patch.get("bot", {}).get(side, {})
@@ -1039,6 +1074,13 @@ def _build_multicoin_ema_coin_overrides(
         ):
             if patch_key in unstuck_patch:
                 matrix[coin_index, offset] = float(effective_bot[bot_key])
+        _pack_multicoin_hsl_overrides(
+            matrix,
+            row=coin_index,
+            start_column=hsl_start_column,
+            side_patch=side_patch,
+            effective_bot=effective_bot,
+        )
     contract = {
         "exchange": exchange,
         "coins": coins,
@@ -1074,8 +1116,9 @@ def _build_multicoin_tm_coin_overrides(
     wel_enforcer_enabled_column = allowance_pct_column + 1
     wel_enforcer_threshold_column = wel_enforcer_enabled_column + 1
     unstuck_start_column = wel_enforcer_threshold_column + 1
+    hsl_start_column = unstuck_start_column + 6
     matrix = np.full(
-        (len(coins), unstuck_start_column + 6),
+        (len(coins), hsl_start_column + len(HSL_COIN_OVERRIDE_PATHS)),
         np.nan,
         dtype=np.float32,
     )
@@ -1138,6 +1181,13 @@ def _build_multicoin_tm_coin_overrides(
         ):
             if patch_key in unstuck_patch:
                 matrix[coin_index, offset] = float(effective_bot[bot_key])
+        _pack_multicoin_hsl_overrides(
+            matrix,
+            row=coin_index,
+            start_column=hsl_start_column,
+            side_patch=side_patch,
+            effective_bot=effective_bot,
+        )
     contract = {
         "exchange": exchange,
         "coins": coins,
@@ -1301,16 +1351,6 @@ class MpsMulticoinProxy:
             "risk_twel_enforcer_enabled",
             "risk_twel_enforcer_policy",
             "risk_twel_enforcer_threshold",
-            "hsl_enabled",
-            "hsl_red_threshold",
-            "hsl_ema_span_minutes",
-            "hsl_cooldown_minutes_after_red",
-            "hsl_no_restart_drawdown_threshold",
-            "hsl_restart_after_red_policy",
-            "hsl_tier_ratio_yellow",
-            "hsl_tier_ratio_orange",
-            "hsl_orange_tier_mode",
-            "hsl_panic_close_order_type",
         )
         signal_mode = (
             backtest_params.get("equity_hard_stop_loss", {})
@@ -1319,7 +1359,10 @@ class MpsMulticoinProxy:
         hsl_enabled_sides = [
             side
             for side in self.sides
-            if bool(payload.bot_params_list[0][side].get("hsl_enabled"))
+            if any(
+                bool(item[side].get("hsl_enabled"))
+                for item in payload.bot_params_list
+            )
         ]
         if hsl_enabled_sides:
             validate_hsl_signal_topology(
@@ -1406,7 +1449,8 @@ class MpsMulticoinProxy:
                     )
                 )
             first_strategy.update(_unstuck_params(config["bot"][side]))
-            first_strategy.update(_hsl_params(first_bot, signal_mode=signal_mode))
+            base_bot = flatten_shared_bot_side(config["bot"][side])
+            first_strategy.update(_hsl_params(base_bot, signal_mode=signal_mode))
             missing = [
                 key for key in self.param_keys if key not in first_strategy
             ]
@@ -1562,15 +1606,12 @@ class MpsMulticoinProxy:
                 "market_order_slippage_pct": float(
                     backtest_params.get("market_order_slippage_pct", 0.0)
                 ),
-                "hsl_panic_market": bool(
-                    self.base_params[side]["hsl_enabled"]
-                    and str(
-                        payload.bot_params_list[0][side].get(
-                            "hsl_panic_close_order_type", "limit"
-                        )
-                    ).strip().lower()
-                    == "market"
-                ),
+                "hsl_panic_market": str(
+                    flatten_shared_bot_side(config["bot"][side]).get(
+                        "hsl_panic_close_order_type", "limit"
+                    )
+                ).strip().lower()
+                == "market",
             }
             runner_kwargs["coin_overrides"] = per_side_coin_overrides[side]
             self.runners[side] = runner_cls(

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -811,6 +811,51 @@ def test_gpu_suite_inputs_accept_modeled_scenario_coin_hsl_overrides():
     assert prepared[0]["config"]["coin_overrides"] == overrides["coin_overrides"]
 
 
+def test_gpu_suite_inputs_reject_invalid_scenario_coin_hsl_values():
+    config = _long_only_ema_config()
+    config["backtest"]["suite_enabled"] = True
+    config["live"]["approved_coins"]["long"] = ["BTC", "ETH"]
+    config["bot"]["long"]["risk"]["n_positions"] = 2
+    overrides = {
+        "coin_overrides": {
+            "ETH": {
+                "bot": {
+                    "long": {
+                        "hsl": {
+                            "tier_ratios": {"yellow": 0.9, "orange": 0.2}
+                        }
+                    }
+                }
+            }
+        }
+    }
+    ctx = SimpleNamespace(
+        label="invalid_coin_hsl",
+        overrides=overrides,
+        exchanges=["bybit"],
+        msss={"bybit": {"BTC": {}, "ETH": {}, "__meta__": {}}},
+        timestamps={"bybit": np.arange(10, dtype=np.int64)},
+    )
+
+    class Suite:
+        contexts = [ctx]
+
+        @staticmethod
+        def get_prepared_context_data(_ctx, _exchange):
+            return np.zeros((10, 2, 4)), np.ones(10), [0, 1]
+
+        @staticmethod
+        def build_scenario_candidate_config(proxy_config, _ctx):
+            scenario = copy.deepcopy(proxy_config)
+            scenario["coin_overrides"] = copy.deepcopy(
+                overrides["coin_overrides"]
+            )
+            return scenario
+
+    with pytest.raises(ValueError, match="tier_ratios must satisfy"):
+        _gpu_suite_scenario_inputs(config, Suite())
+
+
 def test_gpu_suite_inputs_revalidate_scenario_hedge_mode():
     config = _directional_ema_config(long_enabled=True, short_enabled=True)
     config["backtest"]["suite_enabled"] = True
@@ -2019,18 +2064,35 @@ def test_gpu_multicoin_accepts_complete_coin_hsl_override_group():
     )
 
 
-def test_gpu_multicoin_rejects_invalid_coin_hsl_panic_order_type():
+@pytest.mark.parametrize(
+    ("hsl_patch", "match"),
+    [
+        ({"enabled": "yes"}, "enabled must be a boolean"),
+        ({"red_threshold": -0.2}, "red_threshold must satisfy"),
+        ({"ema_span_minutes": 0.0}, "ema_span_minutes must be >= 1"),
+        ({"cooldown_minutes_after_red": -1.0}, "cooldown_minutes_after_red"),
+        (
+            {"no_restart_drawdown_threshold": 0.01},
+            "no_restart_drawdown_threshold must satisfy",
+        ),
+        ({"restart_after_red_policy": "sometimes"}, "restart_after_red_policy"),
+        (
+            {"tier_ratios": {"yellow": 0.8, "orange": 0.4}},
+            "tier_ratios must satisfy",
+        ),
+        ({"tier_ratios": None}, "tier_ratios must be a dictionary"),
+        ({"orange_tier_mode": "tp_only"}, "orange_tier_mode"),
+        ({"panic_close_order_type": "makret"}, "to be limit or market"),
+    ],
+)
+def test_gpu_multicoin_rejects_invalid_coin_hsl_values(hsl_patch, match):
     config = _directional_ema_config(long_enabled=True, short_enabled=False)
     config["live"]["hsl_signal_mode"] = "coin"
     config["coin_overrides"] = {
-        "ETH": {
-            "bot": {
-                "long": {"hsl": {"panic_close_order_type": "makret"}}
-            }
-        }
+        "ETH": {"bot": {"long": {"hsl": hsl_patch}}}
     }
 
-    with pytest.raises(ValueError, match="to be limit or market"):
+    with pytest.raises((TypeError, ValueError), match=match):
         _validate_gpu_coin_overrides(
             config,
             strategy_kind="ema_anchor",

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -2019,6 +2019,26 @@ def test_gpu_multicoin_accepts_complete_coin_hsl_override_group():
     )
 
 
+def test_gpu_multicoin_rejects_invalid_coin_hsl_panic_order_type():
+    config = _directional_ema_config(long_enabled=True, short_enabled=False)
+    config["live"]["hsl_signal_mode"] = "coin"
+    config["coin_overrides"] = {
+        "ETH": {
+            "bot": {
+                "long": {"hsl": {"panic_close_order_type": "makret"}}
+            }
+        }
+    }
+
+    with pytest.raises(ValueError, match="to be limit or market"):
+        _validate_gpu_coin_overrides(
+            config,
+            strategy_kind="ema_anchor",
+            enabled_sides=["long"],
+            coin_count=3,
+        )
+
+
 @pytest.mark.parametrize(
     ("signal_mode", "enabled_sides"),
     [("pside", ["long"]), ("unified", ["long"]), ("coin", ["long", "short"])],

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -2070,19 +2070,30 @@ def test_gpu_multicoin_accepts_complete_coin_hsl_override_group():
         ({"enabled": "yes"}, "enabled must be a boolean"),
         ({"red_threshold": -0.2}, "red_threshold must satisfy"),
         ({"ema_span_minutes": 0.0}, "ema_span_minutes must be >= 1"),
+        (
+            {"ema_span_minutes": float(np.finfo(np.float32).max) * 2.0},
+            "representable as float32",
+        ),
         ({"cooldown_minutes_after_red": -1.0}, "cooldown_minutes_after_red"),
+        (
+            {"cooldown_minutes_after_red": float(np.finfo(np.float32).max) * 2.0},
+            "representable as float32",
+        ),
         (
             {"no_restart_drawdown_threshold": 0.01},
             "no_restart_drawdown_threshold must satisfy",
         ),
         ({"restart_after_red_policy": "sometimes"}, "restart_after_red_policy"),
+        ({"restart_after_red_policy": " ALWAYS "}, "restart_after_red_policy"),
         (
             {"tier_ratios": {"yellow": 0.8, "orange": 0.4}},
             "tier_ratios must satisfy",
         ),
         ({"tier_ratios": None}, "tier_ratios must be a dictionary"),
         ({"orange_tier_mode": "tp_only"}, "orange_tier_mode"),
+        ({"orange_tier_mode": "GRACEFUL_STOP"}, "orange_tier_mode"),
         ({"panic_close_order_type": "makret"}, "to be limit or market"),
+        ({"panic_close_order_type": " market "}, "to be limit or market"),
     ],
 )
 def test_gpu_multicoin_rejects_invalid_coin_hsl_values(hsl_patch, match):

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -4171,6 +4171,17 @@ def test_gpu_hsl_gene_activity_and_pinned_contract_helpers():
             config,
         )
 
+    override_enabled = _long_only_ema_config()
+    override_enabled["coin_overrides"] = {
+        "ETH": {"bot": {"long": {"hsl": {"enabled": True}}}}
+    }
+    with pytest.raises(ValueError, match="red_threshold bounds must remain greater"):
+        _validate_hsl_bound_contracts(
+            {"long_hsl_red_threshold": Bound(-0.1, 0.2)},
+            override_enabled,
+        )
+    assert _gpu_hsl_search_sides(override_enabled, [], set()) == {"long"}
+
     base = _long_only_ema_config()
     scenario = copy.deepcopy(base)
     scenario["bot"]["long"]["hsl"]["enabled"] = True

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -2089,6 +2089,15 @@ def test_gpu_multicoin_accepts_complete_coin_hsl_override_group():
             {"tier_ratios": {"yellow": 0.8, "orange": 0.4}},
             "tier_ratios must satisfy",
         ),
+        (
+            {
+                "tier_ratios": {
+                    "yellow": 0.50000001,
+                    "orange": 0.50000002,
+                }
+            },
+            "remain strictly ordered.*float32",
+        ),
         ({"tier_ratios": None}, "tier_ratios must be a dictionary"),
         ({"orange_tier_mode": "tp_only"}, "orange_tier_mode"),
         ({"orange_tier_mode": "GRACEFUL_STOP"}, "orange_tier_mode"),

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -775,7 +775,7 @@ def test_gpu_suite_inputs_accept_scenario_local_tm_coin_overrides():
     )
 
 
-def test_gpu_suite_inputs_reject_unmodeled_scenario_coin_override_leaves():
+def test_gpu_suite_inputs_accept_modeled_scenario_coin_hsl_overrides():
     config = _long_only_ema_config()
     config["backtest"]["suite_enabled"] = True
     config["live"]["approved_coins"]["long"] = ["BTC", "ETH"]
@@ -806,8 +806,9 @@ def test_gpu_suite_inputs_reject_unmodeled_scenario_coin_override_leaves():
             scenario["coin_overrides"] = copy.deepcopy(overrides["coin_overrides"])
             return scenario
 
-    with pytest.raises(ValueError, match="coin_overrides do not model"):
-        _gpu_suite_scenario_inputs(config, Suite())
+    prepared = _gpu_suite_scenario_inputs(config, Suite())
+
+    assert prepared[0]["config"]["coin_overrides"] == overrides["coin_overrides"]
 
 
 def test_gpu_suite_inputs_revalidate_scenario_hedge_mode():
@@ -1983,6 +1984,61 @@ def test_gpu_multicoin_coin_overrides_reject_unmodeled_leaves(patch):
             config,
             strategy_kind="ema_anchor",
             enabled_sides=["long"],
+            coin_count=3,
+        )
+
+
+def test_gpu_multicoin_accepts_complete_coin_hsl_override_group():
+    config = _directional_ema_config(long_enabled=True, short_enabled=False)
+    config["live"]["hsl_signal_mode"] = "coin"
+    config["coin_overrides"] = {
+        "ETH": {
+            "bot": {
+                "long": {
+                    "hsl": {
+                        "enabled": True,
+                        "red_threshold": 0.2,
+                        "ema_span_minutes": 5.5,
+                        "cooldown_minutes_after_red": 12.5,
+                        "no_restart_drawdown_threshold": 0.8,
+                        "restart_after_red_policy": "always",
+                        "tier_ratios": {"yellow": 0.4, "orange": 0.75},
+                        "orange_tier_mode": "graceful_stop",
+                        "panic_close_order_type": "market",
+                    }
+                }
+            }
+        }
+    }
+
+    _validate_gpu_coin_overrides(
+        config,
+        strategy_kind="ema_anchor",
+        enabled_sides=["long"],
+        coin_count=3,
+    )
+
+
+@pytest.mark.parametrize(
+    ("signal_mode", "enabled_sides"),
+    [("pside", ["long"]), ("unified", ["long"]), ("coin", ["long", "short"])],
+)
+def test_gpu_multicoin_coin_hsl_overrides_fail_closed_outside_one_side_coin_mode(
+    signal_mode, enabled_sides
+):
+    config = _directional_ema_config(
+        long_enabled=True, short_enabled="short" in enabled_sides
+    )
+    config["live"]["hsl_signal_mode"] = signal_mode
+    config["coin_overrides"] = {
+        "ETH": {"bot": {"long": {"hsl": {"enabled": True}}}}
+    }
+
+    with pytest.raises(ValueError, match="require live.hsl_signal_mode=coin"):
+        _validate_gpu_coin_overrides(
+            config,
+            strategy_kind="ema_anchor",
+            enabled_sides=enabled_sides,
             coin_count=3,
         )
 

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -475,6 +475,173 @@ def test_mps_one_sided_multicoin_coin_hsl_isolates_each_coin_episode(
 )
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
 @pytest.mark.parametrize("side", ["long", "short"])
+@pytest.mark.parametrize(
+    ("global_enabled", "coin_enabled", "expected_triggers"),
+    [(False, True, 1.0), (True, False, 0.0)],
+)
+def test_mps_multicoin_coin_hsl_override_controls_enablement(
+    strategy_kind, side, global_enabled, coin_enabled, expected_triggers
+):
+    count = 64
+    closes = np.tile(np.asarray([100.0, 120.0]), (count, 1))
+    closes[20:, 1] *= 0.7 if side == "long" else 1.3
+    override_cols = 29 if strategy_kind == "ema_anchor" else 44
+    hsl_start = 19 if strategy_kind == "ema_anchor" else 34
+    overrides = np.full((2, override_cols), np.nan, dtype=np.float32)
+    if coin_enabled:
+        overrides[1, hsl_start:] = [
+            1.0,
+            0.05,
+            1.0,
+            0.0,
+            1.0,
+            2.0,
+            0.5,
+            0.75,
+            0.0,
+            0.0,
+        ]
+    else:
+        overrides[1, hsl_start] = 0.0
+    runner, row = _multicoin_exposure_fixture(
+        strategy_kind,
+        side,
+        coin_overrides=overrides,
+        count=count,
+        closes=closes,
+        collect_coin_fill_counts=True,
+    )
+    keys = (
+        EMA_ANCHOR_MULTICOIN_PARAM_KEYS
+        if strategy_kind == "ema_anchor"
+        else TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+    )
+    for key, value in {
+        "hsl_enabled": float(global_enabled),
+        "hsl_red_threshold": 0.05,
+        "hsl_ema_span_minutes": 1.0,
+        "hsl_cooldown_minutes_after_red": 0.0,
+        "hsl_no_restart_drawdown_threshold": 1.0,
+        "hsl_restart_policy": 2.0,
+        "hsl_tier_ratio_yellow": 0.5,
+        "hsl_tier_ratio_orange": 0.75,
+        "hsl_orange_graceful_stop": 0.0,
+        "hsl_signal_mode": 2.0,
+        "hsl_slot_count": 1.0,
+    }.items():
+        row[keys.index(key)] = value
+
+    output = runner.run(np.asarray([row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert output[f"hsl_triggers_{side}"].item() == expected_triggers
+    if coin_enabled:
+        assert output[f"hsl_{side}_enabled"].item()
+        assert output["hsl_tier_samples_total"].item() > 0.0
+        assert output["coin_fill_counts"][0, 1].item() >= 2.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_multicoin_coin_hsl_overrides_can_disable_every_controller(
+    strategy_kind, side
+):
+    override_cols = 29 if strategy_kind == "ema_anchor" else 44
+    hsl_start = 19 if strategy_kind == "ema_anchor" else 34
+    overrides = np.full((2, override_cols), np.nan, dtype=np.float32)
+    overrides[:, hsl_start] = 0.0
+    runner, row = _multicoin_exposure_fixture(
+        strategy_kind, side, coin_overrides=overrides, count=32
+    )
+    keys = (
+        EMA_ANCHOR_MULTICOIN_PARAM_KEYS
+        if strategy_kind == "ema_anchor"
+        else TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+    )
+    row[keys.index("hsl_enabled")] = 1.0
+    row[keys.index("hsl_signal_mode")] = 2.0
+
+    output = runner.run(np.asarray([row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert not output[f"hsl_{side}_enabled"].item()
+    assert output["hsl_tier_samples_total"].item() == 0.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_multicoin_coin_hsl_override_selects_market_panic(strategy_kind, side):
+    count = 64
+    closes = np.tile(np.asarray([100.0, 120.0]), (count, 1))
+    closes[20:, 1] *= 0.7 if side == "long" else 1.3
+    markets = [
+        ProxyMarket(
+            0.001,
+            0.01,
+            0.001,
+            0.0,
+            1.0,
+            maker_fee=0.0,
+            taker_fee=0.01,
+        )
+        for _ in range(2)
+    ]
+    override_cols = 29 if strategy_kind == "ema_anchor" else 44
+    hsl_start = 19 if strategy_kind == "ema_anchor" else 34
+    outputs = []
+    for market_panic in (0.0, 1.0):
+        overrides = np.full((2, override_cols), np.nan, dtype=np.float32)
+        overrides[1, hsl_start:] = [
+            1.0,
+            0.05,
+            1.0,
+            0.0,
+            1.0,
+            2.0,
+            0.5,
+            0.75,
+            0.0,
+            market_panic,
+        ]
+        runner, row = _multicoin_exposure_fixture(
+            strategy_kind,
+            side,
+            coin_overrides=overrides,
+            count=count,
+            closes=closes,
+            markets=markets,
+            market_order_slippage_pct=0.02,
+            hsl_panic_market=False,
+        )
+        keys = (
+            EMA_ANCHOR_MULTICOIN_PARAM_KEYS
+            if strategy_kind == "ema_anchor"
+            else TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+        )
+        row[keys.index("hsl_signal_mode")] = 2.0
+        outputs.append(runner.run(np.asarray([row], dtype=np.float64)))
+        torch.mps.synchronize()
+
+    limit_output, market_output = outputs
+    assert limit_output[f"hsl_triggers_{side}"].item() == 1.0
+    assert market_output[f"hsl_triggers_{side}"].item() == 1.0
+    assert (
+        market_output["hsl_panic_close_loss_sum"].item()
+        > limit_output["hsl_panic_close_loss_sum"].item()
+    )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_multicoin_coin_hsl_reselects_around_blocked_forager_coin(
     strategy_kind, side
 ):
@@ -689,7 +856,7 @@ def test_mps_multicoin_tracks_fill_counts_by_symbol(strategy_kind, side):
 def test_mps_multicoin_initial_entry_pct_uses_first_coin_override(
     strategy_kind, side
 ):
-    override_cols = 19 if strategy_kind == "ema_anchor" else 34
+    override_cols = 29 if strategy_kind == "ema_anchor" else 44
     initial_qty_column = 0 if strategy_kind == "ema_anchor" else 6
     allowance_column = 12 if strategy_kind == "ema_anchor" else 25
     overrides = np.full((2, override_cols), np.nan, dtype=np.float32)
@@ -1270,7 +1437,7 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
     assert "kernel void passivbot_ema_anchor_multicoin" in source
     assert "kernel void passivbot_ema_anchor_multicoin_long" in source
     assert "constant int PARAM_COLS = 42" in source
-    assert "constant int OVERRIDE_COLS = 19" in source
+    assert "constant int OVERRIDE_COLS = 29" in source
     assert "allowed_wallet_exposure_limit" in source
     assert "twel_entry_gate_enabled" in source
     assert "twel_enforcer_enabled" in source
@@ -1384,7 +1551,7 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
     legacy_long = MpsEmaAnchorMulticoinLongRunner(runs[0], data)
     assert legacy_long.side == "long"
 
-    disabled = np.full((coin_count, 19), np.nan, dtype=np.float32)
+    disabled = np.full((coin_count, 29), np.nan, dtype=np.float32)
     disabled[:, 11] = 0.0
     disabled_output = MpsEmaAnchorMulticoinRunner(
         runs[0], data, side=side, coin_overrides=disabled
@@ -1393,7 +1560,7 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
     assert disabled_output["day_has_fill"].sum().item() == 0
     assert disabled_output["open_positions"].item() == 0.0
 
-    exact_last = np.full((coin_count, 19), np.nan, dtype=np.float32)
+    exact_last = np.full((coin_count, 29), np.nan, dtype=np.float32)
     exact_last[:, :11] = np.asarray(row[:11], dtype=np.float32)
     changed_candidate = list(row)
     changed_candidate[:11] = [
@@ -1436,7 +1603,7 @@ def test_mps_trailing_martingale_multicoin_directional_shader_smoke(side):
     assert "entry_retracement_base" in source
     assert "close_retracement_base" in source
     assert "as_type<float>(touch_min_qty_bits[k * C + c])" in source
-    assert "constant int OVERRIDE_COLS = 34" in source
+    assert "constant int OVERRIDE_COLS = 44" in source
     assert "allowed_wallet_exposure_limit" in source
     assert "twel_entry_gate_enabled" in source
     assert "coin_override_or" in source
@@ -1545,7 +1712,7 @@ def test_mps_trailing_martingale_multicoin_directional_shader_smoke(side):
     assert output["day_has_fill"].sum().item() > 0
     assert (output["open_positions"] <= 2.0).all()
 
-    disabled = np.full((coin_count, 34), np.nan, dtype=np.float32)
+    disabled = np.full((coin_count, 44), np.nan, dtype=np.float32)
     disabled[:, 24] = 0.0
     disabled_output = MpsTrailingMartingaleMulticoinRunner(
         runs[0], data, side=side, coin_overrides=disabled
@@ -1554,7 +1721,7 @@ def test_mps_trailing_martingale_multicoin_directional_shader_smoke(side):
     assert disabled_output["day_has_fill"].sum().item() == 0
     assert disabled_output["open_positions"].item() == 0.0
 
-    exact_last = np.full((coin_count, 34), np.nan, dtype=np.float32)
+    exact_last = np.full((coin_count, 44), np.nan, dtype=np.float32)
     exact_last[:, :25] = np.asarray(row[:25], dtype=np.float32)
     changed_candidate = list(row)
     changed_candidate[:25] = [
@@ -1630,7 +1797,7 @@ def test_mps_multicoin_legacy_raw_allowance_with_gate_disabled_expands_volume(
 )
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
 def test_mps_multicoin_coin_override_allowance_expands_one_symbol(strategy_kind):
-    override_cols = 19 if strategy_kind == "ema_anchor" else 34
+    override_cols = 29 if strategy_kind == "ema_anchor" else 44
     allowance_column = 12 if strategy_kind == "ema_anchor" else 25
     overrides = np.full((2, override_cols), np.nan, dtype=np.float32)
     overrides[0, allowance_column] = 1.0
@@ -1689,7 +1856,7 @@ def test_mps_multicoin_twel_threshold_reduces_entry_volume(strategy_kind):
 def test_mps_multicoin_equal_distance_twel_tie_keeps_higher_coin_index(
     strategy_kind,
 ):
-    override_cols = 19 if strategy_kind == "ema_anchor" else 34
+    override_cols = 29 if strategy_kind == "ema_anchor" else 44
     wallet_exposure_column = 11 if strategy_kind == "ema_anchor" else 24
     overrides = np.full((2, override_cols), np.nan, dtype=np.float32)
     overrides[0, wallet_exposure_column] = 0.4
@@ -3001,7 +3168,7 @@ def test_mps_tm_multicoin_unstuck_finalization_keeps_ordinary_close_remainder():
         ProxyMarket(0.5, 0.01, 0.5, 500.0, 1.0, 0.0),
         ProxyMarket(0.5, 0.01, 0.5, 0.0, 1.0, 0.0),
     ]
-    overrides = np.full((2, 34), np.nan, dtype=np.float32)
+    overrides = np.full((2, 44), np.nan, dtype=np.float32)
     overrides[1, 24] = 0.0
     runner, candidate = _multicoin_exposure_fixture(
         "trailing_martingale",
@@ -4699,7 +4866,7 @@ def _tm_multicoin_off_tick_reducer_case(
     candidate = [
         values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
     ]
-    overrides = np.full((2, 34), np.nan, dtype=np.float32)
+    overrides = np.full((2, 44), np.nan, dtype=np.float32)
     overrides[1, 24] = 0.0
     runner = MpsTrailingMartingaleMulticoinRunner(
         run, data, side=side, coin_overrides=overrides
@@ -4844,7 +5011,7 @@ def test_mps_tm_multicoin_global_position_exposure_repair(side):
 )
 @pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_tm_multicoin_total_exposure_repair_policy(side):
-    overrides = np.full((2, 34), np.nan, dtype=np.float32)
+    overrides = np.full((2, 44), np.nan, dtype=np.float32)
     overrides[0, 24] = 0.1
     runner, baseline = _multicoin_exposure_fixture(
         "trailing_martingale",
@@ -4890,7 +5057,7 @@ def test_mps_tm_multicoin_total_exposure_repair_policy(side):
 )
 @pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_tm_multicoin_loss_gate_blocks_lossy_total_exposure_repair(side):
-    overrides = np.full((2, 34), np.nan, dtype=np.float32)
+    overrides = np.full((2, 44), np.nan, dtype=np.float32)
     overrides[0, 24] = 0.1
     runner_kwargs = {
         "strategy_kind": "trailing_martingale",
@@ -4979,7 +5146,7 @@ def test_mps_tm_multicoin_loss_gate_blocks_fee_only_ordinary_close(side):
 )
 @pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_tm_multicoin_loss_gate_preserves_profitable_close_after_repair(side):
-    overrides = np.full((2, 34), np.nan, dtype=np.float32)
+    overrides = np.full((2, 44), np.nan, dtype=np.float32)
     overrides[0, 24] = 0.1
     count = 10
     blocked_highs = np.full((count, 2), 100.5)
@@ -5043,7 +5210,7 @@ def test_mps_tm_multicoin_loss_gate_scans_past_blocked_recursive_rung(side):
         highs[5:, 0] = 102.0
     else:
         lows[5:, 0] = 98.0
-    overrides = np.full((2, 34), np.nan, dtype=np.float32)
+    overrides = np.full((2, 44), np.nan, dtype=np.float32)
     overrides[1, 24] = 0.0
     runner, candidate = _multicoin_exposure_fixture(
         "trailing_martingale",
@@ -5098,7 +5265,7 @@ def test_mps_tm_multicoin_loss_gate_does_not_reallocate_blocked_twel(side):
         ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.001)
         for _ in range(2)
     ]
-    overrides = np.full((2, 34), np.nan, dtype=np.float32)
+    overrides = np.full((2, 44), np.nan, dtype=np.float32)
     overrides[0, 24] = 0.6
     overrides[1, 24] = 0.4
     runner, candidate = _multicoin_exposure_fixture(
@@ -5148,7 +5315,7 @@ def test_mps_tm_multicoin_loss_gate_does_not_reallocate_blocked_twel(side):
 )
 @pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_ema_multicoin_total_exposure_repair_policy(side):
-    overrides = np.full((2, 19), np.nan, dtype=np.float32)
+    overrides = np.full((2, 29), np.nan, dtype=np.float32)
     overrides[0, 11] = 0.1
     count = 70
     highs = np.full((count, 2), 100.5)
@@ -5201,7 +5368,7 @@ def test_mps_ema_multicoin_total_exposure_repair_policy(side):
 )
 @pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_ema_multicoin_loss_gate_blocks_lossy_total_exposure_repair(side):
-    overrides = np.full((2, 19), np.nan, dtype=np.float32)
+    overrides = np.full((2, 29), np.nan, dtype=np.float32)
     overrides[0, 11] = 0.1
     count = 70
     closes = np.full((count, 2), 100.0)
@@ -5613,7 +5780,7 @@ def test_mps_tm_multicoin_grid_can_fill_without_off_tick_reducer(side):
     candidate = [
         values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
     ]
-    overrides = np.full((2, 34), np.nan, dtype=np.float32)
+    overrides = np.full((2, 44), np.nan, dtype=np.float32)
     overrides[1, 24] = 0.0
     output = MpsTrailingMartingaleMulticoinRunner(
         run, data, side=side, coin_overrides=overrides
@@ -5674,7 +5841,7 @@ def test_mps_tm_multicoin_small_excess_reducer_crosses_strict_target(side):
     candidate = [
         values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
     ]
-    overrides = np.full((2, 34), np.nan, dtype=np.float32)
+    overrides = np.full((2, 44), np.nan, dtype=np.float32)
     overrides[1, 24] = 0.0
     output = MpsTrailingMartingaleMulticoinRunner(
         run, data, side=side, coin_overrides=overrides
@@ -5735,7 +5902,7 @@ def test_mps_tm_multicoin_short_post_repair_grid_uses_negative_target_tick():
     candidate = [
         values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
     ]
-    overrides = np.full((2, 34), np.nan, dtype=np.float32)
+    overrides = np.full((2, 44), np.nan, dtype=np.float32)
     overrides[1, 24] = 0.0
     output = MpsTrailingMartingaleMulticoinRunner(
         run, data, side="short", coin_overrides=overrides
@@ -5926,7 +6093,7 @@ def test_mps_tm_multicoin_finalized_reducer_tie_keeps_nearer_wel(side):
         twel_only_values[key]
         for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
     ]
-    overrides = np.full((2, 34), np.nan, dtype=np.float32)
+    overrides = np.full((2, 44), np.nan, dtype=np.float32)
     overrides[1, 24] = 0.0
     output = MpsTrailingMartingaleMulticoinRunner(
         run, data, side=side, coin_overrides=overrides
@@ -5944,7 +6111,7 @@ def test_mps_tm_multicoin_finalized_reducer_tie_keeps_nearer_wel(side):
 )
 @pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_tm_multicoin_static_override_repairs_only_selected_symbol(side):
-    overrides = np.full((2, 34), np.nan, dtype=np.float32)
+    overrides = np.full((2, 44), np.nan, dtype=np.float32)
     overrides[0, 26] = 1.0
     overrides[0, 27] = 0.5
     baseline_runner, baseline = _multicoin_exposure_fixture(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -1117,6 +1117,44 @@ def test_multicoin_coin_overrides_pack_complete_hsl_group():
     assert contract["values"][1][19:] == pytest.approx(matrix[1, 19:].tolist())
 
 
+def test_multicoin_coin_overrides_reject_invalid_hsl_panic_order_type():
+    strategy = {key: 1.0 for key in EMA_ANCHOR_PARAM_KEYS[:-2]}
+    payload = SimpleNamespace(
+        strategy_params_list=[{"long": strategy}, {"long": strategy}],
+        bot_params_list=[
+            {"long": {}},
+            {
+                "long": {
+                    "hsl_enabled": True,
+                    "hsl_panic_close_order_type": "makret",
+                }
+            },
+        ],
+    )
+    config = {
+        "coin_overrides": {
+            "ETH": {
+                "bot": {
+                    "long": {"hsl": {"panic_close_order_type": "makret"}}
+                }
+            }
+        }
+    }
+
+    with pytest.raises(ValueError, match="to be limit or market"):
+        _build_multicoin_ema_coin_overrides(
+            config=config,
+            mss={"BTC": {}, "ETH": {}},
+            exchange="bybit",
+            coins=["BTC", "ETH"],
+            payload=payload,
+            side="long",
+            resolve_override=lambda config, _mss, _exchange, coin: config[
+                "coin_overrides"
+            ].get(coin, {}),
+        )
+
+
 def test_multicoin_tm_coin_overrides_pack_only_explicit_exact_values():
     assert tuple(
         key for key, _path in TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -339,9 +339,17 @@ def test_gpu_multicoin_hsl_requires_each_coin_to_have_contiguous_valid_candles()
     with pytest.raises(ValueError, match="invalid candle at 1"):
         _require_no_internal_invalid_multicoin_hsl_candles(
             hlcvs,
+            hsl_enabled_coins=[True, True],
             first_valid_indices=[0, 0],
             last_valid_indices=[2, 2],
         )
+    _require_no_internal_invalid_multicoin_hsl_candles(
+        hlcvs,
+        hsl_enabled_coins=[True, False],
+        first_valid_indices=[0, 0],
+        last_valid_indices=[2, 2],
+    )
+
 
 def test_gpu_account_equity_recovery_requires_tracked_candles_to_be_contiguous():
     hlcvs = np.ones((4, 2, 4), dtype=np.float64)

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -962,18 +962,19 @@ def test_multicoin_coin_overrides_pack_only_explicit_exact_values():
         ].get(coin, {}),
     )
 
-    assert matrix.shape == (2, 19)
+    assert matrix.shape == (2, 29)
     assert np.isnan(matrix[0]).all()
     assert matrix[1, EMA_ANCHOR_PARAM_KEYS.index("offset")] == pytest.approx(0.25)
     assert matrix[1, EMA_ANCHOR_PARAM_KEYS.index("ema_span_0")] == pytest.approx(90.0)
     assert matrix[1, 10] == pytest.approx(15.0)
     assert matrix[1, 11] == pytest.approx(0.4)
     assert matrix[1, 12] == pytest.approx(0.25)
-    assert matrix[1, 13:].tolist() == pytest.approx(
+    assert matrix[1, 13:19].tolist() == pytest.approx(
         [1.0, 0.0, 0.125, -0.01, 0.02, 0.85]
     )
+    assert np.isnan(matrix[1, 19:]).all()
     assert contract["coins"] == ["BTC", "ETH"]
-    assert contract["values"][0] == [None] * 19
+    assert contract["values"][0] == [None] * 29
 
 
 def test_multicoin_coin_overrides_pack_dual_sides_independently():
@@ -1042,6 +1043,62 @@ def test_multicoin_coin_overrides_pack_dual_sides_independently():
     assert short_matrix[1, offset_index] == pytest.approx(0.5)
     assert short_matrix[1, 10] == pytest.approx(30.0)
     assert np.isnan(short_matrix[1, 11])
+
+
+def test_multicoin_coin_overrides_pack_complete_hsl_group():
+    strategy = {key: 1.0 for key in EMA_ANCHOR_PARAM_KEYS[:-2]}
+    effective_hsl = {
+        "hsl_enabled": False,
+        "hsl_red_threshold": 0.2,
+        "hsl_ema_span_minutes": 5.5,
+        "hsl_cooldown_minutes_after_red": 12.5,
+        "hsl_no_restart_drawdown_threshold": 0.8,
+        "hsl_restart_after_red_policy": "always",
+        "hsl_tier_ratio_yellow": 0.4,
+        "hsl_tier_ratio_orange": 0.75,
+        "hsl_orange_tier_mode": "graceful_stop",
+        "hsl_panic_close_order_type": "market",
+    }
+    payload = SimpleNamespace(
+        strategy_params_list=[{"long": strategy}, {"long": strategy}],
+        bot_params_list=[
+            {"long": {}},
+            {"long": effective_hsl},
+        ],
+    )
+    hsl_patch = {
+        "enabled": False,
+        "red_threshold": 0.2,
+        "ema_span_minutes": 5.5,
+        "cooldown_minutes_after_red": 12.5,
+        "no_restart_drawdown_threshold": 0.8,
+        "restart_after_red_policy": "always",
+        "tier_ratios": {"yellow": 0.4, "orange": 0.75},
+        "orange_tier_mode": "graceful_stop",
+        "panic_close_order_type": "market",
+    }
+    config = {
+        "coin_overrides": {"ETH": {"bot": {"long": {"hsl": hsl_patch}}}}
+    }
+
+    matrix, contract = _build_multicoin_ema_coin_overrides(
+        config=config,
+        mss={"BTC": {}, "ETH": {}},
+        exchange="bybit",
+        coins=["BTC", "ETH"],
+        payload=payload,
+        side="long",
+        resolve_override=lambda config, _mss, _exchange, coin: config[
+            "coin_overrides"
+        ].get(coin, {}),
+    )
+
+    assert matrix.shape == (2, 29)
+    assert np.isnan(matrix[0]).all()
+    assert matrix[1, 19:].tolist() == pytest.approx(
+        [0.0, 0.2, 5.5, 12.5, 0.8, 0.0, 0.4, 0.75, 1.0, 1.0]
+    )
+    assert contract["values"][1][19:] == pytest.approx(matrix[1, 19:].tolist())
 
 
 def test_multicoin_tm_coin_overrides_pack_only_explicit_exact_values():
@@ -1158,7 +1215,7 @@ def test_multicoin_tm_coin_overrides_pack_only_explicit_exact_values():
         ].get(coin, {}),
     )
 
-    assert matrix.shape == (2, 34)
+    assert matrix.shape == (2, 44)
     assert np.isnan(matrix[0]).all()
     assert matrix[1, 7] == pytest.approx(0.25)
     assert matrix[1, 15] == pytest.approx(0.5)
@@ -1167,10 +1224,11 @@ def test_multicoin_tm_coin_overrides_pack_only_explicit_exact_values():
     assert matrix[1, 25] == pytest.approx(0.25)
     assert matrix[1, 26] == pytest.approx(1.0)
     assert matrix[1, 27] == pytest.approx(0.8)
-    assert matrix[1, 28:].tolist() == pytest.approx(
+    assert matrix[1, 28:34].tolist() == pytest.approx(
         [1.0, 0.0, 0.125, -0.01, 0.02, 0.85]
     )
-    assert contract["values"][0] == [None] * 34
+    assert np.isnan(matrix[1, 34:]).all()
+    assert contract["values"][0] == [None] * 44
 
 
 def test_trailing_parameter_matrix_keeps_nested_flattened_sides_separate():

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 
+from config.shared_bot import flatten_shared_bot_side
 from optimization.gpu.model import (
     EMA_ANCHOR_MULTICOIN_PARAM_KEYS,
     EMA_ANCHOR_PARAM_KEYS,
@@ -39,6 +40,21 @@ from optimization.gpu.service import (
     _total_exposure_enforcer_params,
     _unstuck_params,
 )
+
+
+def test_hsl_params_preserve_grouped_tier_ratios_after_flattening():
+    bot = flatten_shared_bot_side(
+        {
+            "hsl": {
+                "tier_ratios": {"yellow": 0.31, "orange": 0.82},
+            }
+        }
+    )
+
+    packed = _hsl_params(bot, signal_mode="coin")
+
+    assert packed["hsl_tier_ratio_yellow"] == pytest.approx(0.31)
+    assert packed["hsl_tier_ratio_orange"] == pytest.approx(0.82)
 
 
 def test_core_output_contract_retains_gross_pnl_aggregates():

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -539,6 +539,18 @@ def test_hsl_params_reject_invalid_effective_settings(bot_patch, match):
         _hsl_params(bot, signal_mode="coin")
 
 
+def test_hsl_params_reject_tier_ratios_that_collapse_in_float32():
+    with pytest.raises(ValueError, match="remain strictly ordered.*float32"):
+        _hsl_params(
+            {
+                "hsl_enabled": True,
+                "hsl_tier_ratio_yellow": 0.50000001,
+                "hsl_tier_ratio_orange": 0.50000002,
+            },
+            signal_mode="coin",
+        )
+
+
 @pytest.mark.parametrize(
     ("signal_mode", "expected_id"),
     [("unified", 0.0), ("pside", 1.0), ("coin", 2.0)],

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -511,6 +511,27 @@ def test_single_coin_hsl_packs_state_machine_inputs():
 
 
 @pytest.mark.parametrize(
+    ("bot_patch", "match"),
+    [
+        ({"hsl_red_threshold": -0.2}, "red_threshold must satisfy"),
+        ({"hsl_ema_span_minutes": 0.0}, "ema_span_minutes must be >= 1"),
+        (
+            {
+                "hsl_tier_ratio_yellow": 0.9,
+                "hsl_tier_ratio_orange": 0.2,
+            },
+            "tier_ratios must satisfy",
+        ),
+    ],
+)
+def test_hsl_params_reject_invalid_effective_settings(bot_patch, match):
+    bot = {"hsl_enabled": True, **bot_patch}
+
+    with pytest.raises(ValueError, match=match):
+        _hsl_params(bot, signal_mode="coin")
+
+
+@pytest.mark.parametrize(
     ("signal_mode", "expected_id"),
     [("unified", 0.0), ("pside", 1.0), ("coin", 2.0)],
 )


### PR DESCRIPTION
## Summary

- support all ten canonical per-coin HSL override leaves for one-sided multi-coin Apple MPS optimization in `coin` signal mode
- apply independent HSL enablement, thresholds, EMA/cooldown/restart/tier settings, and limit/market panic behavior in both EMA Anchor and Trailing Martingale kernels, long or short
- accept compatible suite scenario overrides while retaining fail-closed validation for unsupported HSL topologies; exact Rust validation remains authoritative and CPU behavior is unchanged

## Validation

- `cargo test --no-default-features` (263 passed)
- `cargo check --tests`
- `cargo fmt --check`
- full physical Apple MPS `tests/optimization/test_gpu_mps.py`
- `tests/optimization/test_gpu_backend.py tests/optimization/test_gpu_service.py tests/optimization/test_gpu_metrics.py`
- AI documentation contract check (0 errors; 2 pre-existing size warnings)
- real-data exact-validation GPU smokes for EMA Anchor and Trailing Martingale, one-sided two-coin HSL coin overrides (both completed without drift/constraint halt)
- verified loaded native extension source fingerprint matches this source tree