### PR TITLE
refactor(gpu): share multicoin Metal primitives

### DIFF
--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -8,6 +8,8 @@ use std::sync::LazyLock;
 
 const MPS_HSL_MARKER: &str = "// PASSIVBOT_HSL_COMMON";
 const MPS_HSL_COMMON_SOURCE: &str = include_str!("gpu/mps_hsl_common.metal");
+const MPS_MULTICOIN_MARKER: &str = "// PASSIVBOT_MULTICOIN_COMMON";
+const MPS_MULTICOIN_COMMON_SOURCE: &str = include_str!("gpu/mps_multicoin_common.metal");
 const MPS_EMA_ANCHOR_BODY: &str = include_str!("gpu/mps_ema_anchor_directional.metal");
 const MPS_TRAILING_MARTINGALE_BODY: &str =
     include_str!("gpu/mps_trailing_martingale_directional.metal");
@@ -24,14 +26,23 @@ fn compose_hsl_source(body: &str) -> String {
     body.replacen(MPS_HSL_MARKER, MPS_HSL_COMMON_SOURCE, 1)
 }
 
+fn compose_multicoin_source(body: &str) -> String {
+    assert_eq!(
+        body.matches(MPS_MULTICOIN_MARKER).count(),
+        1,
+        "MPS multi-coin source must contain exactly one shared-common marker"
+    );
+    compose_hsl_source(&body.replacen(MPS_MULTICOIN_MARKER, MPS_MULTICOIN_COMMON_SOURCE, 1))
+}
+
 pub static MPS_EMA_ANCHOR_SOURCE: LazyLock<String> =
     LazyLock::new(|| compose_hsl_source(MPS_EMA_ANCHOR_BODY));
 pub static MPS_EMA_ANCHOR_MULTICOIN_SOURCE: LazyLock<String> =
-    LazyLock::new(|| compose_hsl_source(MPS_EMA_ANCHOR_MULTICOIN_BODY));
+    LazyLock::new(|| compose_multicoin_source(MPS_EMA_ANCHOR_MULTICOIN_BODY));
 pub static MPS_TRAILING_MARTINGALE_SOURCE: LazyLock<String> =
     LazyLock::new(|| compose_hsl_source(MPS_TRAILING_MARTINGALE_BODY));
 pub static MPS_TRAILING_MARTINGALE_MULTICOIN_SOURCE: LazyLock<String> =
-    LazyLock::new(|| compose_hsl_source(MPS_TRAILING_MARTINGALE_MULTICOIN_BODY));
+    LazyLock::new(|| compose_multicoin_source(MPS_TRAILING_MARTINGALE_MULTICOIN_BODY));
 
 pub fn mps_ema_anchor_source() -> &'static str {
     MPS_EMA_ANCHOR_SOURCE.as_str()
@@ -74,6 +85,26 @@ mod tests {
         assert!(source.contains("constant int HSL_SIGNAL_PSIDE = 1"));
         assert!(source.contains("constant int HSL_SIGNAL_COIN = 2"));
         assert!(source.contains("int ho = po + hsl_param_offset"));
+    }
+
+    fn assert_shared_multicoin_contract(source: &str) {
+        assert!(!source.contains(MPS_MULTICOIN_MARKER));
+        assert!(source.contains(MPS_MULTICOIN_COMMON_SOURCE));
+        for signature in [
+            "inline float round_step(",
+            "inline float ceil_step(",
+            "inline float floor_step(",
+            "inline float min_entry_qty(",
+            "inline bool finite_positive(",
+            "inline float float32_floor_nonnegative(",
+            "inline void record_realized_net(",
+            "inline void record_gross_pnl(",
+            "inline float coin_override_or(",
+            "inline float allowed_wallet_exposure_limit(",
+            "inline float clamped_market_price(",
+        ] {
+            assert_eq!(source.matches(signature).count(), 1, "{signature}");
+        }
     }
 
     fn assert_directional_hsl_accounting_contract(source: &str) {
@@ -185,6 +216,7 @@ mod tests {
     fn ema_anchor_multicoin_mps_source_exposes_expected_kernel_contract() {
         let source = mps_ema_anchor_multicoin_source();
         assert_shared_hsl_contract(source);
+        assert_shared_multicoin_contract(source);
         assert!(source.contains("kernel void passivbot_ema_anchor_multicoin"));
         assert!(source.contains("kernel void passivbot_ema_anchor_multicoin_long"));
         assert!(source.contains("const bool short_side"));
@@ -407,6 +439,7 @@ mod tests {
     fn trailing_martingale_multicoin_mps_source_exposes_expected_kernel_contract() {
         let source = mps_trailing_martingale_multicoin_source();
         assert_shared_hsl_contract(source);
+        assert_shared_multicoin_contract(source);
         assert!(source.contains("kernel void passivbot_trailing_martingale_multicoin"));
         assert!(source.contains("constant int MAX_COINS = 64"));
         assert!(source.contains("constant int PARAM_COLS = 59"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -1,8 +1,6 @@
 #include <metal_stdlib>
 using namespace metal;
 
-// PASSIVBOT_HSL_COMMON
-
 constant int MAX_COINS = 64;
 constant int PARAM_COLS = 42;
 constant int COIN_COLS = 12;
@@ -12,35 +10,9 @@ constant int DAILY_COLS = 9;
 constant int SCALAR_COLS = 57;
 constant int GAP_BINS = 128;
 
-inline float round_step(float value, float step) {
-    return floor(value / step + 0.5f) * step;
-}
+// PASSIVBOT_MULTICOIN_COMMON
 
-inline float ceil_step(float value, float step) {
-    return ceil(value / step - 1.0e-6f) * step;
-}
-
-inline float floor_step(float value, float step) {
-    return floor(value / step + 1.0e-6f) * step;
-}
-
-inline float min_entry_qty(
-    float price, float qty_step, float min_qty, float min_cost, float c_mult
-) {
-    float raw_min = fmax(min_qty, min_cost / fmax(price, 1.0e-12f) / c_mult);
-    float raw_steps = raw_min / qty_step;
-    float nearest_count = floor(raw_steps + 0.5f);
-    float nearest = nearest_count * qty_step;
-    float representation_tolerance = 1.1920928955078125e-7f
-        * fmax(fabs(raw_min), fabs(nearest)) * 4.0f;
-    bool aligned = nearest_count > 0.0f && fabs(raw_steps - nearest_count) <= 1.0e-8f
-        && (nearest >= raw_min || raw_min - nearest <= representation_tolerance);
-    return aligned ? fmax(nearest, raw_min) : ceil(raw_steps) * qty_step;
-}
-
-inline bool finite_positive(float value) {
-    return isfinite(value) && value > 0.0f;
-}
+// PASSIVBOT_HSL_COMMON
 
 inline bool realized_loss_proxy_allows_close(
     float qty, float close_price, float pprice, bool short_side,
@@ -59,52 +31,6 @@ inline bool realized_loss_proxy_allows_close(
         + qty * fabs(c_mult) * (fabs(close_price) + fabs(pprice));
     float margin = 1.220703125e-4f * arithmetic_scale;
     return isfinite(net_pnl) && net_pnl > margin;
-}
-
-inline float float32_floor_nonnegative(float value) {
-    if (!(value > 0.0f) || !isfinite(value)) return fmax(value, 0.0f);
-    return as_type<float>(as_type<uint>(value) - 1u);
-}
-
-inline void record_realized_net(
-    float net_pnl,
-    thread float& realized_pnl_cumsum_last,
-    thread float& realized_pnl_cumsum_max,
-    thread float& day_fill_count,
-    thread float& fill_count,
-    thread float& fill_count_entry,
-    thread float& fill_count_long,
-    thread float& pnl_recovery_peak,
-    thread float& pnl_recovery_peak_k,
-    thread float& pnl_recovery_max_min,
-    float fill_k,
-    bool is_entry,
-    bool is_long
-) {
-    day_fill_count += 1.0f;
-    fill_count += 1.0f;
-    if (is_entry) fill_count_entry += 1.0f;
-    if (is_long) fill_count_long += 1.0f;
-    realized_pnl_cumsum_last += net_pnl;
-    realized_pnl_cumsum_max = fmax(
-        realized_pnl_cumsum_max, realized_pnl_cumsum_last
-    );
-    if (realized_pnl_cumsum_last > pnl_recovery_peak) {
-        if (pnl_recovery_peak_k >= 0.0f) {
-            pnl_recovery_max_min = fmax(
-                pnl_recovery_max_min, fill_k - pnl_recovery_peak_k
-            );
-        }
-        pnl_recovery_peak = realized_pnl_cumsum_last;
-        pnl_recovery_peak_k = fill_k;
-    }
-}
-
-inline void record_gross_pnl(
-    float pnl, thread float& profit_sum, thread float& loss_sum
-) {
-    if (pnl > 0.0f) profit_sum += pnl;
-    else loss_sum += fabs(pnl);
 }
 
 inline bool realized_loss_proxy_allows_reducer(
@@ -174,39 +100,6 @@ inline float finalized_reducer_qty_with_ordinary(
         if (remainder > 0.0f && remainder < reducer_min) reducer_qty = psize;
     }
     return reducer_qty;
-}
-
-inline float coin_override_or(
-    constant float* coin_overrides, int coin, int column, float fallback
-) {
-    float value = coin_overrides[coin * OVERRIDE_COLS + column];
-    return isfinite(value) ? value : fallback;
-}
-
-inline float allowed_wallet_exposure_limit(
-    float base_limit, float total_limit, float allowance_pct, bool legacy_raw
-) {
-    if (!(isfinite(base_limit) && base_limit > 0.0f)) return 0.0f;
-    float raw = fmax(allowance_pct, 0.0f);
-    float effective = raw;
-    if (!legacy_raw) {
-        float max_effective = (
-            isfinite(total_limit) && total_limit > 0.0f
-        ) ? fmax(total_limit / base_limit - 1.0f, 0.0f) : 0.0f;
-        effective = fmin(raw, max_effective);
-    }
-    return base_limit * (1.0f + effective);
-}
-
-inline float clamped_market_price(
-    constant float* bars, constant float* coin_settings,
-    int k, int coin, int coin_count
-) {
-    int coin_offset = coin * COIN_COLS;
-    int first_valid = int(coin_settings[coin_offset + 6]);
-    int last_valid = int(coin_settings[coin_offset + 7]);
-    int market_k = clamp(k, first_valid, last_valid);
-    return bars[(market_k * coin_count + coin) * 4 + 2];
 }
 
 inline void passivbot_ema_anchor_multicoin_impl(

--- a/passivbot-rust/src/gpu/mps_multicoin_common.metal
+++ b/passivbot-rust/src/gpu/mps_multicoin_common.metal
@@ -1,0 +1,114 @@
+// Shared Apple Metal multi-coin screening primitives.
+//
+// Exact Rust backtests remain authoritative. EMA Anchor, Trailing Martingale,
+// and the future joint-side portfolio kernel compose this module so rounding,
+// fill accounting, override lookup, and exposure allowance cannot drift apart.
+
+inline float round_step(float value, float step) {
+    return floor(value / step + 0.5f) * step;
+}
+
+inline float ceil_step(float value, float step) {
+    return ceil(value / step - 1.0e-6f) * step;
+}
+
+inline float floor_step(float value, float step) {
+    return floor(value / step + 1.0e-6f) * step;
+}
+
+inline float min_entry_qty(
+    float price, float qty_step, float min_qty, float min_cost, float c_mult
+) {
+    float raw_min = fmax(min_qty, min_cost / fmax(price, 1.0e-12f) / c_mult);
+    float raw_steps = raw_min / qty_step;
+    float nearest_count = floor(raw_steps + 0.5f);
+    float nearest = nearest_count * qty_step;
+    float representation_tolerance = 1.1920928955078125e-7f
+        * fmax(fabs(raw_min), fabs(nearest)) * 4.0f;
+    bool aligned = nearest_count > 0.0f && fabs(raw_steps - nearest_count) <= 1.0e-8f
+        && (nearest >= raw_min || raw_min - nearest <= representation_tolerance);
+    return aligned ? fmax(nearest, raw_min) : ceil(raw_steps) * qty_step;
+}
+
+inline bool finite_positive(float value) {
+    return isfinite(value) && value > 0.0f;
+}
+
+inline float float32_floor_nonnegative(float value) {
+    if (!(value > 0.0f) || !isfinite(value)) return fmax(value, 0.0f);
+    return as_type<float>(as_type<uint>(value) - 1u);
+}
+
+inline void record_realized_net(
+    float net_pnl,
+    thread float& realized_pnl_cumsum_last,
+    thread float& realized_pnl_cumsum_max,
+    thread float& day_fill_count,
+    thread float& fill_count,
+    thread float& fill_count_entry,
+    thread float& fill_count_long,
+    thread float& pnl_recovery_peak,
+    thread float& pnl_recovery_peak_k,
+    thread float& pnl_recovery_max_min,
+    float fill_k,
+    bool is_entry,
+    bool is_long
+) {
+    day_fill_count += 1.0f;
+    fill_count += 1.0f;
+    if (is_entry) fill_count_entry += 1.0f;
+    if (is_long) fill_count_long += 1.0f;
+    realized_pnl_cumsum_last += net_pnl;
+    realized_pnl_cumsum_max = fmax(
+        realized_pnl_cumsum_max, realized_pnl_cumsum_last
+    );
+    if (realized_pnl_cumsum_last > pnl_recovery_peak) {
+        if (pnl_recovery_peak_k >= 0.0f) {
+            pnl_recovery_max_min = fmax(
+                pnl_recovery_max_min, fill_k - pnl_recovery_peak_k
+            );
+        }
+        pnl_recovery_peak = realized_pnl_cumsum_last;
+        pnl_recovery_peak_k = fill_k;
+    }
+}
+
+inline void record_gross_pnl(
+    float pnl, thread float& profit_sum, thread float& loss_sum
+) {
+    if (pnl > 0.0f) profit_sum += pnl;
+    else loss_sum += fabs(pnl);
+}
+
+inline float coin_override_or(
+    constant float* coin_overrides, int coin, int column, float fallback
+) {
+    float value = coin_overrides[coin * OVERRIDE_COLS + column];
+    return isfinite(value) ? value : fallback;
+}
+
+inline float allowed_wallet_exposure_limit(
+    float base_limit, float total_limit, float allowance_pct, bool legacy_raw
+) {
+    if (!(isfinite(base_limit) && base_limit > 0.0f)) return 0.0f;
+    float raw = fmax(allowance_pct, 0.0f);
+    float effective = raw;
+    if (!legacy_raw) {
+        float max_effective = (
+            isfinite(total_limit) && total_limit > 0.0f
+        ) ? fmax(total_limit / base_limit - 1.0f, 0.0f) : 0.0f;
+        effective = fmin(raw, max_effective);
+    }
+    return base_limit * (1.0f + effective);
+}
+
+inline float clamped_market_price(
+    constant float* bars, constant float* coin_settings,
+    int k, int coin, int coin_count
+) {
+    int coin_offset = coin * COIN_COLS;
+    int first_valid = int(coin_settings[coin_offset + 6]);
+    int last_valid = int(coin_settings[coin_offset + 7]);
+    int market_k = clamp(k, first_valid, last_valid);
+    return bars[(market_k * coin_count + coin) * 4 + 2];
+}

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -1,8 +1,6 @@
 #include <metal_stdlib>
 using namespace metal;
 
-// PASSIVBOT_HSL_COMMON
-
 constant int MAX_COINS = 64;
 constant int PARAM_COLS = 59;
 constant int OVERRIDE_COLS = 44;
@@ -12,35 +10,9 @@ constant int DAILY_COLS = 9;
 constant int SCALAR_COLS = 57;
 constant int GAP_BINS = 128;
 
-inline float round_step(float value, float step) {
-    return floor(value / step + 0.5f) * step;
-}
+// PASSIVBOT_MULTICOIN_COMMON
 
-inline float ceil_step(float value, float step) {
-    return ceil(value / step - 1.0e-6f) * step;
-}
-
-inline float floor_step(float value, float step) {
-    return floor(value / step + 1.0e-6f) * step;
-}
-
-inline float min_entry_qty(
-    float price, float qty_step, float min_qty, float min_cost, float c_mult
-) {
-    float raw_min = fmax(min_qty, min_cost / fmax(price, 1.0e-12f) / c_mult);
-    float raw_steps = raw_min / qty_step;
-    float nearest_count = floor(raw_steps + 0.5f);
-    float nearest = nearest_count * qty_step;
-    float representation_tolerance = 1.1920928955078125e-7f
-        * fmax(fabs(raw_min), fabs(nearest)) * 4.0f;
-    bool aligned = nearest_count > 0.0f && fabs(raw_steps - nearest_count) <= 1.0e-8f
-        && (nearest >= raw_min || raw_min - nearest <= representation_tolerance);
-    return aligned ? fmax(nearest, raw_min) : ceil(raw_steps) * qty_step;
-}
-
-inline bool finite_positive(float value) {
-    return isfinite(value) && value > 0.0f;
-}
+// PASSIVBOT_HSL_COMMON
 
 inline bool realized_loss_proxy_allows_close(
     float qty, float close_price, float pprice, bool short_side,
@@ -60,52 +32,6 @@ inline bool realized_loss_proxy_allows_close(
         + qty * fabs(c_mult) * (fabs(close_price) + fabs(pprice));
     float margin = 1.220703125e-4f * arithmetic_scale;
     return isfinite(net_pnl) && net_pnl > margin;
-}
-
-inline float float32_floor_nonnegative(float value) {
-    if (!(value > 0.0f) || !isfinite(value)) return fmax(value, 0.0f);
-    return as_type<float>(as_type<uint>(value) - 1u);
-}
-
-inline void record_realized_net(
-    float net_pnl,
-    thread float& realized_pnl_cumsum_last,
-    thread float& realized_pnl_cumsum_max,
-    thread float& day_fill_count,
-    thread float& fill_count,
-    thread float& fill_count_entry,
-    thread float& fill_count_long,
-    thread float& pnl_recovery_peak,
-    thread float& pnl_recovery_peak_k,
-    thread float& pnl_recovery_max_min,
-    float fill_k,
-    bool is_entry,
-    bool is_long
-) {
-    day_fill_count += 1.0f;
-    fill_count += 1.0f;
-    if (is_entry) fill_count_entry += 1.0f;
-    if (is_long) fill_count_long += 1.0f;
-    realized_pnl_cumsum_last += net_pnl;
-    realized_pnl_cumsum_max = fmax(
-        realized_pnl_cumsum_max, realized_pnl_cumsum_last
-    );
-    if (realized_pnl_cumsum_last > pnl_recovery_peak) {
-        if (pnl_recovery_peak_k >= 0.0f) {
-            pnl_recovery_max_min = fmax(
-                pnl_recovery_max_min, fill_k - pnl_recovery_peak_k
-            );
-        }
-        pnl_recovery_peak = realized_pnl_cumsum_last;
-        pnl_recovery_peak_k = fill_k;
-    }
-}
-
-inline void record_gross_pnl(
-    float pnl, thread float& profit_sum, thread float& loss_sum
-) {
-    if (pnl > 0.0f) profit_sum += pnl;
-    else loss_sum += fabs(pnl);
 }
 
 inline bool realized_loss_proxy_allows_reducer(
@@ -140,28 +66,6 @@ inline bool realized_loss_proxy_allows_reducer(
         fmax(allowed_loss_budget - current_realized_loss, 0.0f)
     );
     return -net_pnl <= remaining_loss_budget;
-}
-
-inline float coin_override_or(
-    constant float* coin_overrides, int coin, int column, float fallback
-) {
-    float value = coin_overrides[coin * OVERRIDE_COLS + column];
-    return isfinite(value) ? value : fallback;
-}
-
-inline float allowed_wallet_exposure_limit(
-    float base_limit, float total_limit, float allowance_pct, bool legacy_raw
-) {
-    if (!(isfinite(base_limit) && base_limit > 0.0f)) return 0.0f;
-    float raw = fmax(allowance_pct, 0.0f);
-    float effective = raw;
-    if (!legacy_raw) {
-        float max_effective = (
-            isfinite(total_limit) && total_limit > 0.0f
-        ) ? fmax(total_limit / base_limit - 1.0f, 0.0f) : 0.0f;
-        effective = fmin(raw, max_effective);
-    }
-    return base_limit * (1.0f + effective);
 }
 
 inline float calc_close_qty(
@@ -305,17 +209,6 @@ inline bool reducer_candidate_preferred(
         return is_long ? left_ticks < right_ticks : left_ticks > right_ticks;
     }
     return left_order_type_id < right_order_type_id;
-}
-
-inline float clamped_market_price(
-    constant float* bars, constant float* coin_settings,
-    int k, int coin, int coin_count
-) {
-    int coin_offset = coin * COIN_COLS;
-    int first_valid = int(coin_settings[coin_offset + 6]);
-    int last_valid = int(coin_settings[coin_offset + 7]);
-    int market_k = clamp(k, first_valid, last_valid);
-    return bars[(market_k * coin_count + coin) * 4 + 2];
 }
 
 struct CloseGroup {


### PR DESCRIPTION
## Summary
- compose one Rust-owned Metal primitive module into both EMA Anchor and Trailing Martingale multicoin kernels
- centralize identical rounding, minimum-quantity, fill-accounting, override, allowance, and delisted-price helpers
- add source-contract assertions that every composed multicoin shader contains exactly one copy of each shared primitive

## Scope
This is a behavior-preserving foundation for the future fused dual-side shared-balance kernel. It does not enable any currently unsupported GPU topology or relax HSL, repair, suite, or CPU behavior gates.

## Validation
- `cargo test --no-default-features` (263 passed)
- `cargo check`
- rebuilt the release Python extension on the local Apple M3
- full physical MPS suite: `tests/optimization/test_gpu_mps.py` (all passed)