### PR TITLE
refactor(gpu): centralize multicoin fill accounting

### DIFF
--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -145,6 +145,31 @@ mod tests {
     }
 
     #[test]
+    fn multicoin_kernels_route_every_fill_through_joint_account_state() {
+        for (body, expected_fill_paths) in [
+            (MPS_EMA_ANCHOR_MULTICOIN_BODY, 2),
+            (MPS_TRAILING_MARTINGALE_MULTICOIN_BODY, 4),
+        ] {
+            assert!(body.contains(
+                "JointPortfolioAccount account = init_joint_portfolio_account(starting_balance)"
+            ));
+            assert!(body.contains("thread float& balance = account.balance"));
+            assert!(body
+                .contains("thread float& realized_pnl_cumsum_last = account.realized_pnl_total"));
+            assert!(
+                body.contains("thread float& realized_pnl_cumsum_max = account.realized_pnl_peak")
+            );
+            assert_eq!(
+                body.matches("record_realized_net(").count(),
+                expected_fill_paths
+            );
+            assert!(!body.contains("float balance = starting_balance"));
+            assert!(!body.contains("balance += net_pnl"));
+            assert!(!body.contains("balance -= fee"));
+        }
+    }
+
+    #[test]
     fn ema_anchor_mps_source_exposes_expected_kernel_contract() {
         let source = mps_ema_anchor_source();
         assert_shared_hsl_contract(source);

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -325,9 +325,10 @@ inline void passivbot_ema_anchor_multicoin_impl(
         gap_hist[int(b) * GAP_BINS + j] = 0;
     }
 
-    float balance = starting_balance;
-    float realized_pnl_cumsum_last = 0.0f;
-    float realized_pnl_cumsum_max = 0.0f;
+    JointPortfolioAccount account = init_joint_portfolio_account(starting_balance);
+    thread float& balance = account.balance;
+    thread float& realized_pnl_cumsum_last = account.realized_pnl_total;
+    thread float& realized_pnl_cumsum_max = account.realized_pnl_peak;
     float pnl_recovery_peak = -INFINITY;
     float pnl_recovery_peak_k = -1.0f;
     float pnl_recovery_max_min = 0.0f;
@@ -518,10 +519,8 @@ inline void passivbot_ema_anchor_multicoin_impl(
                     }
                 }
                 record_gross_pnl(pnl, profit_sum, loss_sum);
-                balance += net_pnl;
                 record_realized_net(
-                    net_pnl, realized_pnl_cumsum_last,
-                    realized_pnl_cumsum_max,
+                    net_pnl, account,
                     day_fill_count, fill_count, fill_count_entry, fill_count_long,
                     pnl_recovery_peak, pnl_recovery_peak_k,
                     pnl_recovery_max_min, float(k),
@@ -577,10 +576,8 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 float fill_price = float(entry_tick[c]) * price_step;
                 float adjusted = round_step(entry_qty[c], qty_step);
                 float fee = adjusted * fill_price * c_mult * maker_fee;
-                balance -= fee;
                 record_realized_net(
-                    -fee, realized_pnl_cumsum_last,
-                    realized_pnl_cumsum_max,
+                    -fee, account,
                     day_fill_count, fill_count, fill_count_entry, fill_count_long,
                     pnl_recovery_peak, pnl_recovery_peak_k,
                     pnl_recovery_max_min, float(k),

--- a/passivbot-rust/src/gpu/mps_multicoin_common.metal
+++ b/passivbot-rust/src/gpu/mps_multicoin_common.metal
@@ -39,10 +39,47 @@ inline float float32_floor_nonnegative(float value) {
     return as_type<float>(as_type<uint>(value) - 1u);
 }
 
+// Joint-side account state for the fused multi-coin portfolio path. Exact
+// Rust processes every long fill before every short fill for a candle; callers
+// preserve that ordering while this state owns the one shared cash balance and
+// the realized-PnL scopes consumed by liquidation, loss gates, and HSL.
+struct JointPortfolioAccount {
+    float balance;
+    float realized_pnl_total;
+    float realized_pnl_peak;
+    float realized_pnl_long;
+    float realized_pnl_short;
+};
+
+inline JointPortfolioAccount init_joint_portfolio_account(
+    float starting_balance
+) {
+    JointPortfolioAccount account;
+    account.balance = starting_balance;
+    account.realized_pnl_total = 0.0f;
+    account.realized_pnl_peak = 0.0f;
+    account.realized_pnl_long = 0.0f;
+    account.realized_pnl_short = 0.0f;
+    return account;
+}
+
+inline void record_joint_portfolio_fill(
+    thread JointPortfolioAccount& account,
+    float net_pnl,
+    bool is_long
+) {
+    account.balance += net_pnl;
+    account.realized_pnl_total += net_pnl;
+    account.realized_pnl_peak = fmax(
+        account.realized_pnl_peak, account.realized_pnl_total
+    );
+    if (is_long) account.realized_pnl_long += net_pnl;
+    else account.realized_pnl_short += net_pnl;
+}
+
 inline void record_realized_net(
     float net_pnl,
-    thread float& realized_pnl_cumsum_last,
-    thread float& realized_pnl_cumsum_max,
+    thread JointPortfolioAccount& account,
     thread float& day_fill_count,
     thread float& fill_count,
     thread float& fill_count_entry,
@@ -54,21 +91,18 @@ inline void record_realized_net(
     bool is_entry,
     bool is_long
 ) {
+    record_joint_portfolio_fill(account, net_pnl, is_long);
     day_fill_count += 1.0f;
     fill_count += 1.0f;
     if (is_entry) fill_count_entry += 1.0f;
     if (is_long) fill_count_long += 1.0f;
-    realized_pnl_cumsum_last += net_pnl;
-    realized_pnl_cumsum_max = fmax(
-        realized_pnl_cumsum_max, realized_pnl_cumsum_last
-    );
-    if (realized_pnl_cumsum_last > pnl_recovery_peak) {
+    if (account.realized_pnl_total > pnl_recovery_peak) {
         if (pnl_recovery_peak_k >= 0.0f) {
             pnl_recovery_max_min = fmax(
                 pnl_recovery_max_min, fill_k - pnl_recovery_peak_k
             );
         }
-        pnl_recovery_peak = realized_pnl_cumsum_last;
+        pnl_recovery_peak = account.realized_pnl_total;
         pnl_recovery_peak_k = fill_k;
     }
 }
@@ -111,44 +145,6 @@ inline float clamped_market_price(
     int last_valid = int(coin_settings[coin_offset + 7]);
     int market_k = clamp(k, first_valid, last_valid);
     return bars[(market_k * coin_count + coin) * 4 + 2];
-}
-
-// Joint-side account state for the fused multi-coin portfolio path. Exact
-// Rust processes every long fill before every short fill for a candle; callers
-// preserve that ordering while this state owns the one shared cash balance and
-// the realized-PnL scopes consumed by liquidation, loss gates, and HSL.
-struct JointPortfolioAccount {
-    float balance;
-    float realized_pnl_total;
-    float realized_pnl_peak;
-    float realized_pnl_long;
-    float realized_pnl_short;
-};
-
-inline JointPortfolioAccount init_joint_portfolio_account(
-    float starting_balance
-) {
-    JointPortfolioAccount account;
-    account.balance = starting_balance;
-    account.realized_pnl_total = 0.0f;
-    account.realized_pnl_peak = 0.0f;
-    account.realized_pnl_long = 0.0f;
-    account.realized_pnl_short = 0.0f;
-    return account;
-}
-
-inline void record_joint_portfolio_fill(
-    thread JointPortfolioAccount& account,
-    float net_pnl,
-    bool is_long
-) {
-    account.balance += net_pnl;
-    account.realized_pnl_total += net_pnl;
-    account.realized_pnl_peak = fmax(
-        account.realized_pnl_peak, account.realized_pnl_total
-    );
-    if (is_long) account.realized_pnl_long += net_pnl;
-    else account.realized_pnl_short += net_pnl;
 }
 
 inline float joint_portfolio_equity(

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -585,9 +585,10 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         gap_hist[int(b) * GAP_BINS + j] = 0;
     }
 
-    float balance = starting_balance;
-    float realized_pnl_cumsum_last = 0.0f;
-    float realized_pnl_cumsum_max = 0.0f;
+    JointPortfolioAccount account = init_joint_portfolio_account(starting_balance);
+    thread float& balance = account.balance;
+    thread float& realized_pnl_cumsum_last = account.realized_pnl_total;
+    thread float& realized_pnl_cumsum_max = account.realized_pnl_peak;
     float pnl_recovery_peak = -INFINITY;
     float pnl_recovery_peak_k = -1.0f;
     float pnl_recovery_max_min = 0.0f;
@@ -951,10 +952,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                             float net_pnl = pnl
                                 - qty * fill_price * c_mult * maker_fee;
                             record_gross_pnl(pnl, profit_sum, loss_sum);
-                            balance += net_pnl;
                             record_realized_net(
-                                net_pnl, realized_pnl_cumsum_last,
-                                realized_pnl_cumsum_max,
+                                net_pnl, account,
                                 day_fill_count, fill_count, fill_count_entry,
                                 fill_count_long, pnl_recovery_peak,
                                 pnl_recovery_peak_k, pnl_recovery_max_min,
@@ -1003,10 +1002,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     float grid_net_pnl = grid_pnl
                         - grid_qty * group.price * c_mult * maker_fee;
                     record_gross_pnl(grid_pnl, profit_sum, loss_sum);
-                    balance += grid_net_pnl;
                     record_realized_net(
-                        grid_net_pnl, realized_pnl_cumsum_last,
-                        realized_pnl_cumsum_max,
+                        grid_net_pnl, account,
                         day_fill_count, fill_count, fill_count_entry,
                         fill_count_long, pnl_recovery_peak,
                         pnl_recovery_peak_k, pnl_recovery_max_min,
@@ -1086,10 +1083,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                         }
                     }
                     record_gross_pnl(pnl, profit_sum, loss_sum);
-                    balance += net_pnl;
                     record_realized_net(
-                        net_pnl, realized_pnl_cumsum_last,
-                        realized_pnl_cumsum_max,
+                        net_pnl, account,
                         day_fill_count, fill_count, fill_count_entry,
                         fill_count_long, pnl_recovery_peak,
                         pnl_recovery_peak_k, pnl_recovery_max_min,
@@ -1148,10 +1143,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 float fill_price = float(entry_tick[c]) * price_step;
                 float adjusted = round_step(entry_qty[c], qty_step);
                 float fee = adjusted * fill_price * c_mult * maker_fee;
-                balance -= fee;
                 record_realized_net(
-                    -fee, realized_pnl_cumsum_last,
-                    realized_pnl_cumsum_max,
+                    -fee, account,
                     day_fill_count, fill_count, fill_count_entry,
                     fill_count_long, pnl_recovery_peak,
                     pnl_recovery_peak_k, pnl_recovery_max_min,


### PR DESCRIPTION
## Summary
- make the shared joint portfolio account the sole balance and realized-PnL owner in both multicoin Metal kernels
- route every EMA Anchor and Trailing Martingale entry/close fill through one accounting primitive
- retain directional realized-PnL scopes needed by a future fused dual-side HSL controller
- add source-contract coverage preventing fill paths from bypassing the shared account

## Scope
Behavior-preserving foundation only. This does not enable dual-side multicoin HSL or relax any optimizer fail-closed gate.

## Validation
- `cargo test --no-default-features` (264 passed)
- `cargo check`
- rebuilt the release extension on Apple M3
- full physical M3 `tests/optimization/test_gpu_mps.py` (all passed)
- `tests/optimization/test_gpu_service.py` and `tests/optimization/test_gpu_backend.py` (all passed)
