### PR TITLE
feat(optimize): support dual multicoin pside HSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added dual-side multi-coin HSL behavior to Apple MPS optimization for EMA Anchor and Trailing
+  Martingale in `pside` signal mode. Each directional Metal controller owns its exact pside
+  realized-plus-unrealized signal while the existing hedged portfolio reducer retains its
+  conservative shared-equity liquidation cutoff; exact Rust validation remains authoritative.
+  Dual-side multi-coin `coin` and `unified` modes, and dual-side multi-coin HSL scoring metrics,
+  remain fail closed until a fused account controller can model their shared state.
+
 - Added all ten canonical per-coin HSL setting overrides to one-sided multi-coin Apple MPS
   optimization for EMA Anchor and Trailing Martingale in `coin` signal mode. Each Metal coin
   controller now resolves its own enablement, thresholds, EMA span, cooldown, restart policy,
@@ -17,7 +24,7 @@ All notable user-facing changes will be documented in this file.
   halt/restart lifecycle, and per-episode metrics. Directional outputs aggregate the same way as
   exact Rust: episode metrics are combined across coins while time-in-tier uses the worst active
   coin tier once per minute. Exact Rust validation remains authoritative; dual-side multi-coin
-  HSL remains fail closed.
+  `coin` mode remains fail closed.
 
 - Added market panic-close execution to one-sided multi-coin HSL Apple MPS optimization for EMA
   Anchor and Trailing Martingale. The portfolio proxy now fills every panic close on the next
@@ -30,14 +37,14 @@ All notable user-facing changes will be documented in this file.
   candidate now applies one shared-balance portfolio HSL controller across every coin on the
   enabled side, including warning tiers, RED entry blocking, limit panic flattening, cooldown
   restart, lifecycle metrics, and panic-loss metrics. Exact Rust validation remains authoritative;
-  dual-side multi-coin HSL remains fail closed.
+  dual-side multi-coin HSL is currently limited to `pside` behavior without HSL scoring metrics.
 
 - Added dual-side single-coin HSL to Apple MPS optimization for EMA Anchor and Trailing
   Martingale in `coin` and `pside` signal modes, including compatible suites. Metal now tracks
   realized net PnL independently for long and short while retaining shared account balance and
   exact Rust validation. Dual-side `unified` HSL remains fail closed until its documented
-  account-wide flatten contract and exact-backtest finalization scope are reconciled; dual-side
-  multi-coin HSL remains unsupported.
+  account-wide flatten contract and exact-backtest finalization scope are reconciled. Dual-side
+  multi-coin HSL currently supports only `pside` behavior without HSL scoring metrics.
 
 - Consolidated the supported one-sided single-coin HSL Apple MPS screening behavior into one
   Rust-owned Metal controller shared by EMA Anchor and Trailing Martingale. Signal modes now use

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -21,9 +21,11 @@ def validate_hsl_signal_topology(
             f"unified; got {signal_mode!r}"
         )
     if coin_count > 1:
-        if enabled_side_count > 1:
+        if enabled_side_count > 1 and signal_mode != "pside":
             raise ValueError(
-                "GPU multi-coin HSL currently requires exactly one enabled side"
+                "GPU dual-side multi-coin HSL currently supports only pside "
+                "signal mode; coin requires a shared-balance denominator and "
+                "unified requires one cross-side episode controller"
             )
         return
     if enabled_side_count > 1 and signal_mode == "unified":

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -1545,6 +1545,13 @@ class MpsMulticoinProxy:
                 },
                 "proxy_mode": "independent-side-hedge-v1",
             }
+            if hsl_enabled_sides:
+                self.coin_override_contract["hsl_proxy_mode"] = (
+                    "independent-pside-v1"
+                )
+                self.coin_override_contract["hsl_signal_mode"] = str(
+                    signal_mode
+                ).strip().lower()
         self.coin_override_contract["forager_score_hysteresis_pct"] = (
             self.forager_score_hysteresis_pct
         )

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1545,7 +1545,7 @@ def test_gpu_hsl_accepts_one_sided_multicoin_market_panic():
     assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
-def test_gpu_hsl_fails_closed_for_dual_side_multicoin():
+def test_gpu_hsl_accepts_dual_side_multicoin_pside_mode():
     config = _directional_ema_config(long_enabled=True, short_enabled=True)
     coins = ["BTC", "ETH", "XRP"]
     config["live"]["approved_coins"] = {"long": coins, "short": coins}
@@ -1555,7 +1555,21 @@ def test_gpu_hsl_fails_closed_for_dual_side_multicoin():
         config["bot"][side]["risk"]["n_positions"] = 3
         config["bot"][side]["hsl"]["enabled"] = True
 
-    with pytest.raises(ValueError, match="exactly one enabled side"):
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
+
+
+@pytest.mark.parametrize("signal_mode", ["coin", "unified"])
+def test_gpu_hsl_rejects_dual_side_multicoin_joint_account_modes(signal_mode):
+    config = _directional_ema_config(long_enabled=True, short_enabled=True)
+    coins = ["BTC", "ETH", "XRP"]
+    config["live"]["approved_coins"] = {"long": coins, "short": coins}
+    config["live"]["hsl_signal_mode"] = signal_mode
+    config["live"]["hedge_mode"] = True
+    for side in ("long", "short"):
+        config["bot"][side]["risk"]["n_positions"] = 3
+        config["bot"][side]["hsl"]["enabled"] = True
+
+    with pytest.raises(ValueError, match="supports only pside"):
         _validate_scope(config, _MulticoinEvaluator())
 
 

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -372,6 +372,60 @@ def test_mps_one_sided_multicoin_hsl_panics_the_portfolio(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+def test_mps_dual_multicoin_pside_hsl_runs_both_directional_controllers(
+    strategy_kind,
+):
+    count = 128
+    closes = np.tile(np.asarray([100.0, 120.0]), (count, 1))
+    closes[20:60] *= 1.3
+    closes[60:] *= 0.65
+    outputs = {}
+    for side in ("long", "short"):
+        runner, row = _multicoin_exposure_fixture(
+            strategy_kind,
+            side,
+            count=count,
+            closes=closes,
+            collect_coin_fill_counts=True,
+        )
+        keys = (
+            EMA_ANCHOR_MULTICOIN_PARAM_KEYS
+            if strategy_kind == "ema_anchor"
+            else TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+        )
+        for key, value in {
+            "hsl_enabled": 1.0,
+            "hsl_red_threshold": 0.05,
+            "hsl_ema_span_minutes": 1.0,
+            "hsl_cooldown_minutes_after_red": 0.0,
+            "hsl_no_restart_drawdown_threshold": 1.0,
+            "hsl_restart_policy": 2.0,
+            "hsl_tier_ratio_yellow": 0.5,
+            "hsl_tier_ratio_orange": 0.75,
+            "hsl_orange_graceful_stop": 0.0,
+            "hsl_signal_mode": 1.0,
+            "hsl_slot_count": 1.0,
+        }.items():
+            row[keys.index(key)] = value
+        outputs[side] = runner.run(np.asarray([row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    for side in ("long", "short"):
+        other_side = "short" if side == "long" else "long"
+        output = outputs[side]
+        assert output[f"hsl_{side}_enabled"].item()
+        assert not output[f"hsl_{other_side}_enabled"].item()
+        assert output[f"hsl_triggers_{side}"].item() == 1.0
+        assert output[f"hsl_triggers_{other_side}"].item() == 0.0
+        assert output["hsl_trigger_drawdown_count"].item() == 1.0
+        assert output["hsl_panic_loss_drawdown_count"].item() == 1.0
+        assert output["open_positions"].item() == 0.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
 @pytest.mark.parametrize("side", ["long", "short"])
 @pytest.mark.parametrize("shock_coin", [0, 1, "both"])
 def test_mps_one_sided_multicoin_coin_hsl_isolates_each_coin_episode(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -587,10 +587,17 @@ def test_one_sided_multicoin_hsl_accepts_all_signal_modes(signal_mode):
     )
 
 
-def test_dual_side_multicoin_hsl_remains_fail_closed():
-    with pytest.raises(ValueError, match="exactly one enabled side"):
+def test_dual_side_multicoin_hsl_accepts_decomposable_pside_mode():
+    validate_hsl_signal_topology(
+        "pside", coin_count=3, enabled_side_count=2
+    )
+
+
+@pytest.mark.parametrize("signal_mode", ["coin", "unified"])
+def test_dual_side_multicoin_hsl_rejects_joint_account_modes(signal_mode):
+    with pytest.raises(ValueError, match="supports only pside"):
         validate_hsl_signal_topology(
-            "pside", coin_count=3, enabled_side_count=2
+            signal_mode, coin_count=3, enabled_side_count=2
         )
 
 


### PR DESCRIPTION
## Summary
- enable dual-side multi-coin Apple MPS HSL behavior in `pside` signal mode for EMA Anchor and Trailing Martingale
- reuse the existing directional Metal controllers because exact `pside` drawdown decomposes into each side's realized plus unrealized PnL
- retain the conservative hedged shared-equity liquidation reducer and exact Rust validation
- keep dual-side multi-coin `coin`, `unified`, and HSL scoring metrics fail-closed pending fused shared state

## Validation
- full physical M3 `tests/optimization/test_gpu_mps.py` (all passed, including new EMA/TM dual-controller cases)
- `tests/optimization/test_gpu_service.py` and `tests/optimization/test_gpu_backend.py` (all passed)
- `tests/optimization/test_optimize.py` (all passed)
- `cargo test --no-default-features` (264 passed)
- `cargo check`
- rebuilt and source-stamped the release Rust extension
- Python compile and diff checks

## Local limitation
- `black --check` was unavailable in the development environment; CI remains authoritative for configured formatting checks
