### PR TITLE
feat(optimize): support dual multicoin HSL metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ All notable user-facing changes will be documented in this file.
 
 - Added dual-side multi-coin `pside` HSL lifecycle and panic-loss scoring/limits to Apple MPS
   optimization. The proxy now reduces directional episode counters, durations, drawdowns,
-  restarts, and panic losses with the same aggregate formulas used by exact Rust, which remains
-  authoritative. Yellow/orange/RED time percentages remain fail closed because two directional
-  histograms cannot reconstruct minute-level cross-side tier overlap.
+  restarts, and absolute panic losses with the same aggregate formulas used by exact Rust, and
+  replays HSL summaries through the conservative combined liquidation cutoff. Exact Rust remains
+  authoritative. Account-normalized event losses and yellow/orange/RED time percentages remain
+  fail closed until the proxy owns shared event-level equity and minute-level tier state.
 
 - Added dual-side multi-coin HSL behavior to Apple MPS optimization for EMA Anchor and Trailing
   Martingale in `pside` signal mode. Each directional Metal controller owns its exact pside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added dual-side multi-coin `pside` HSL lifecycle and panic-loss scoring/limits to Apple MPS
+  optimization. The proxy now reduces directional episode counters, durations, drawdowns,
+  restarts, and panic losses with the same aggregate formulas used by exact Rust, which remains
+  authoritative. Yellow/orange/RED time percentages remain fail closed because two directional
+  histograms cannot reconstruct minute-level cross-side tier overlap.
+
 - Added dual-side multi-coin HSL behavior to Apple MPS optimization for EMA Anchor and Trailing
   Martingale in `pside` signal mode. Each directional Metal controller owns its exact pside
   realized-plus-unrealized signal while the existing hedged portfolio reducer retains its

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -111,6 +111,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
     constant float* params,
     constant float* run_settings,
     constant int* sizes,
+    constant int* end_steps,
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -126,8 +127,9 @@ inline void passivbot_ema_anchor_multicoin_impl(
     const int global_warmup = sizes[5];
     const int start_day_minute = sizes[6];
     const int start_hour_minute = sizes[7];
-    const bool collect_coin_fill_counts = run_settings[6] > 0.5f;
     if (b >= uint(B)) return;
+    const int stop_k = clamp(end_steps[b], 1, T - 1);
+    const bool collect_coin_fill_counts = run_settings[6] > 0.5f;
     if (collect_coin_fill_counts) {
         for (int c = 0; c < C; ++c) {
             coin_fill_counts[int(b) * C + c] = 0.0f;
@@ -380,7 +382,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
     float day_start_balance = balance;
     float day_fill_count = 0.0f;
 
-    for (int k = 1; k < T - 1; ++k) {
+    for (int k = 1; k < stop_k; ++k) {
         const int day_index = (start_day_minute + k) / 1440;
         if (day_index != current_day) {
             if (day_touched && current_day >= 0 && current_day < D) {
@@ -1751,6 +1753,7 @@ kernel void passivbot_ema_anchor_multicoin(
     constant float* params,
     constant float* run_settings,
     constant int* sizes,
+    constant int* end_steps,
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -1760,7 +1763,7 @@ kernel void passivbot_ema_anchor_multicoin(
     const bool short_side = run_settings[3] > 0.5f;
     passivbot_ema_anchor_multicoin_impl(
         bars, fill_ticks, touch_ticks, coin_settings, coin_overrides, params, run_settings,
-        sizes, daily, scalars, gap_hist, coin_fill_counts, b, short_side
+        sizes, end_steps, daily, scalars, gap_hist, coin_fill_counts, b, short_side
     );
 }
 
@@ -1773,6 +1776,7 @@ kernel void passivbot_ema_anchor_multicoin_long(
     constant float* params,
     constant float* run_settings,
     constant int* sizes,
+    constant int* end_steps,
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -1781,6 +1785,6 @@ kernel void passivbot_ema_anchor_multicoin_long(
 ) {
     passivbot_ema_anchor_multicoin_impl(
         bars, fill_ticks, touch_ticks, coin_settings, coin_overrides, params, run_settings,
-        sizes, daily, scalars, gap_hist, coin_fill_counts, b, false
+        sizes, end_steps, daily, scalars, gap_hist, coin_fill_counts, b, false
     );
 }

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -339,6 +339,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     constant float* params,
     constant float* run_settings,
     constant int* sizes,
+    constant int* end_steps,
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -354,8 +355,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     const int global_warmup = sizes[5];
     const int start_day_minute = sizes[6];
     const int start_hour_minute = sizes[7];
-    const bool collect_coin_fill_counts = run_settings[6] > 0.5f;
     if (b >= uint(B)) return;
+    const int stop_k = clamp(end_steps[b], 1, T - 1);
+    const bool collect_coin_fill_counts = run_settings[6] > 0.5f;
     if (collect_coin_fill_counts) {
         for (int c = 0; c < C; ++c) {
             coin_fill_counts[int(b) * C + c] = 0.0f;
@@ -640,7 +642,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     float day_start_balance = balance;
     float day_fill_count = 0.0f;
 
-    for (int k = 1; k < T - 1; ++k) {
+    for (int k = 1; k < stop_k; ++k) {
         const int day_index = (start_day_minute + k) / 1440;
         if (day_index != current_day) {
             if (day_touched && current_day >= 0 && current_day < D) {
@@ -2595,6 +2597,7 @@ kernel void passivbot_trailing_martingale_multicoin(
     constant float* params,
     constant float* run_settings,
     constant int* sizes,
+    constant int* end_steps,
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -2606,7 +2609,7 @@ kernel void passivbot_trailing_martingale_multicoin(
         bars, fill_ticks, touch_ticks, touch_nearest_ticks,
         touch_min_qty_bits, touch_min_qty_relation, coin_settings,
         coin_overrides, params, run_settings,
-        sizes, daily, scalars, gap_hist, coin_fill_counts, b, short_side
+        sizes, end_steps, daily, scalars, gap_hist, coin_fill_counts, b, short_side
     );
 }
 
@@ -2622,6 +2625,7 @@ kernel void passivbot_trailing_martingale_multicoin_long(
     constant float* params,
     constant float* run_settings,
     constant int* sizes,
+    constant int* end_steps,
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -2632,6 +2636,6 @@ kernel void passivbot_trailing_martingale_multicoin_long(
         bars, fill_ticks, touch_ticks, touch_nearest_ticks,
         touch_min_qty_bits, touch_min_qty_relation, coin_settings,
         coin_overrides, params, run_settings,
-        sizes, daily, scalars, gap_hist, coin_fill_counts, b, false
+        sizes, end_steps, daily, scalars, gap_hist, coin_fill_counts, b, false
     );
 }

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -1091,11 +1091,19 @@ def _validate_dual_multicoin_metrics(
 def _validate_hsl_metric_topology(
     needed_metrics, *, coin_count: int, enabled_sides, hard_stop_metrics
 ) -> None:
-    unsupported = sorted(set(needed_metrics) & set(hard_stop_metrics))
+    tier_overlap_metrics = {
+        "hard_stop_time_in_yellow_pct",
+        "hard_stop_time_in_orange_pct",
+        "hard_stop_time_in_red_pct",
+    }
+    unsupported = sorted(
+        set(needed_metrics) & set(hard_stop_metrics) & tier_overlap_metrics
+    )
     if int(coin_count) > 1 and len(set(enabled_sides)) > 1 and unsupported:
         raise ValueError(
-            "GPU HSL optimizer metrics currently require one shared HSL controller; "
-            "dual-side multi-coin HSL metrics remain unsupported: "
+            "GPU dual-side multi-coin HSL time-in-tier metrics require "
+            "minute-level cross-side overlap which directional summaries cannot "
+            "reconstruct: "
             f"{unsupported}"
         )
 

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -1091,19 +1091,27 @@ def _validate_dual_multicoin_metrics(
 def _validate_hsl_metric_topology(
     needed_metrics, *, coin_count: int, enabled_sides, hard_stop_metrics
 ) -> None:
+    shared_account_metrics = {
+        "hard_stop_halt_to_restart_equity_loss_pct",
+        "hard_stop_panic_close_loss_drawdown_pct_max",
+        "hard_stop_panic_close_loss_drawdown_pct_mean",
+        "hard_stop_panic_close_loss_drawdown_pct_min",
+    }
     tier_overlap_metrics = {
         "hard_stop_time_in_yellow_pct",
         "hard_stop_time_in_orange_pct",
         "hard_stop_time_in_red_pct",
     }
     unsupported = sorted(
-        set(needed_metrics) & set(hard_stop_metrics) & tier_overlap_metrics
+        set(needed_metrics)
+        & set(hard_stop_metrics)
+        & (shared_account_metrics | tier_overlap_metrics)
     )
     if int(coin_count) > 1 and len(set(enabled_sides)) > 1 and unsupported:
         raise ValueError(
-            "GPU dual-side multi-coin HSL time-in-tier metrics require "
-            "minute-level cross-side overlap which directional summaries cannot "
-            "reconstruct: "
+            "GPU dual-side multi-coin HSL metrics require shared event-level "
+            "account equity or minute-level cross-side tier overlap which "
+            "directional summaries cannot reconstruct: "
             f"{unsupported}"
         )
 

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -545,6 +545,7 @@ class MpsEmaAnchorMulticoinRunner:
         )
         self._buffers: dict[int, tuple[torch.Tensor, ...]] = {}
         self._sizes: dict[tuple[int, int], torch.Tensor] = {}
+        self._full_end_steps: dict[int, torch.Tensor] = {}
         self.last_profile: dict[str, float] = {}
         self.start_minute_of_day = int(data["start_minute_of_day"])
         self.start_minute_of_hour = int(data["start_minute_of_hour"])
@@ -598,12 +599,36 @@ class MpsEmaAnchorMulticoinRunner:
         self._buffers[batch_size][0][:, :, 5].fill_(float("inf"))
         return self._buffers[batch_size]
 
-    def run(self, params: np.ndarray, *, profile: bool = False) -> dict:
+    def _end_steps(self, end_steps: np.ndarray | None, batch_size: int):
+        if end_steps is None:
+            if batch_size not in self._full_end_steps:
+                self._full_end_steps[batch_size] = torch.full(
+                    (batch_size,), self.n - 1, dtype=torch.int32, device="mps"
+                )
+            return self._full_end_steps[batch_size]
+        values = np.asarray(end_steps, dtype=np.int32)
+        if values.shape != (batch_size,):
+            raise ValueError(
+                f"expected one multi-coin end step per candidate, got {values.shape}"
+            )
+        values = np.clip(values, 1, self.n - 1)
+        return torch.as_tensor(
+            np.ascontiguousarray(values), dtype=torch.int32, device="mps"
+        )
+
+    def run(
+        self,
+        params: np.ndarray,
+        *,
+        profile: bool = False,
+        end_steps: np.ndarray | None = None,
+    ) -> dict:
         started = time.perf_counter()
         matrix = self._pack_params(params)
         packed = time.perf_counter()
         params_mps = torch.as_tensor(matrix, device="mps")
         batch_size = int(matrix.shape[0])
+        end_steps_mps = self._end_steps(end_steps, batch_size)
         daily, scalars, gaps, coin_fill_counts = self._output_buffers(batch_size)
         sizes_key = (batch_size, int(matrix.shape[1]))
         if sizes_key not in self._sizes:
@@ -638,6 +663,7 @@ class MpsEmaAnchorMulticoinRunner:
             params_mps,
             self.settings,
             self._sizes[sizes_key],
+            end_steps_mps,
             daily,
             scalars,
             gaps,
@@ -715,12 +741,19 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             )
         return np.ascontiguousarray(params, dtype=np.float32)
 
-    def run(self, params: np.ndarray, *, profile: bool = False) -> dict:
+    def run(
+        self,
+        params: np.ndarray,
+        *,
+        profile: bool = False,
+        end_steps: np.ndarray | None = None,
+    ) -> dict:
         started = time.perf_counter()
         matrix = self._pack_params(params)
         packed = time.perf_counter()
         params_mps = torch.as_tensor(matrix, device="mps")
         batch_size = int(matrix.shape[0])
+        end_steps_mps = self._end_steps(end_steps, batch_size)
         daily, scalars, gaps, coin_fill_counts = self._output_buffers(batch_size)
         sizes_key = (batch_size, int(matrix.shape[1]))
         if sizes_key not in self._sizes:
@@ -758,6 +791,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             params_mps,
             self.settings,
             self._sizes[sizes_key],
+            end_steps_mps,
             daily,
             scalars,
             gaps,

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -621,6 +621,41 @@ def _combine_hedged_multicoin_hsl_outputs(long: dict, short: dict) -> dict:
     return combined
 
 
+def _refresh_hedged_multicoin_hsl_at_portfolio_cutoff(
+    *,
+    side_outputs: dict,
+    runners: dict,
+    parameter_matrices: dict,
+    combined_output: dict,
+    start_minute_of_day: int,
+) -> bool:
+    """Replace full-run directional HSL summaries at a portfolio cutoff.
+
+    The conservative hedged reducer may stop before either isolated side. Re-run
+    only those candidates through the last complete pre-liquidation day so
+    scalar HSL events after the combined coverage boundary cannot leak into
+    proxy objectives or limits.
+    """
+
+    cutoff_days = combined_output["liq_step"]
+    cutoff_mask = cutoff_days >= 0
+    if not bool(cutoff_mask.any().item()):
+        return False
+    indices = np.flatnonzero(cutoff_mask.cpu().numpy())
+    end_steps = (
+        np.rint(cutoff_days[cutoff_mask].cpu().numpy()).astype(np.int64) * 1440
+        - int(start_minute_of_day)
+    )
+    end_steps = np.maximum(end_steps, 1).astype(np.int32)
+    for side in ("long", "short"):
+        truncated = runners[side].run(
+            parameter_matrices[side][indices], end_steps=end_steps
+        )
+        for key in DIRECTIONAL_HSL_OUTPUT_KEYS:
+            side_outputs[side][key][cutoff_mask] = truncated[key].cpu()
+    return True
+
+
 def _combine_hedged_multicoin_outputs(
     long: dict,
     short: dict,
@@ -1812,6 +1847,25 @@ class MpsMulticoinProxy:
                     self.runners["long"].start_minute_of_day,
                     self.run.interval_ms,
                 )
+                if any(
+                    name.startswith("hard_stop_") for name in self.needed_metrics
+                ) and _refresh_hedged_multicoin_hsl_at_portfolio_cutoff(
+                    side_outputs=side_outputs,
+                    runners=self.runners,
+                    parameter_matrices=parameter_matrices,
+                    combined_output=output,
+                    start_minute_of_day=self.runners[
+                        "long"
+                    ].start_minute_of_day,
+                ):
+                    output = _combine_hedged_multicoin_outputs(
+                        side_outputs["long"],
+                        side_outputs["short"],
+                        self.run.starting_balance,
+                        self.run.liquidation_threshold,
+                        self.runners["long"].start_minute_of_day,
+                        self.run.interval_ms,
+                    )
                 output["entry_initial_balance_pct_long"] = side_outputs[
                     "long"
                 ]["entry_initial_balance_pct"]

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -539,6 +539,88 @@ def _prepared_single_coin_side_enabled(config: dict, side: str, bot: dict) -> bo
     return gpu_side_enabled(config, side) and bool(bot["entry_eligible"])
 
 
+def _combine_hedged_multicoin_hsl_outputs(long: dict, short: dict) -> dict:
+    """Reduce two pside HSL summaries without inventing shared episode state.
+
+    Lifecycle and panic aggregates have the same sum/max/count reductions as
+    exact Rust. Minute-level max-tier overlap is not recoverable from two
+    histograms; the conservative severity-first allocation below is retained
+    only so unrelated lifecycle metrics can share the normal reducer. The
+    optimizer gate rejects all three time-in-tier metrics for this topology.
+    """
+
+    combined = {
+        "hsl_long_enabled": (long["hsl_long_enabled"] > 0)
+        | (short["hsl_long_enabled"] > 0),
+        "hsl_short_enabled": (long["hsl_short_enabled"] > 0)
+        | (short["hsl_short_enabled"] > 0),
+    }
+    for key in (
+        "hsl_triggers_long",
+        "hsl_triggers_short",
+        "hsl_restarts_long",
+        "hsl_restarts_short",
+        "hsl_duration_sum_steps",
+        "hsl_duration_count",
+        "hsl_trigger_drawdown_sum",
+        "hsl_trigger_drawdown_count",
+        "hsl_flatten_time_sum_steps",
+        "hsl_flatten_time_count",
+        "hsl_restart_retrigger_count",
+        "hsl_halt_to_restart_equity_loss",
+        "hsl_panic_close_loss_sum",
+        "hsl_panic_loss_drawdown_sum",
+        "hsl_panic_loss_drawdown_count",
+    ):
+        combined[key] = long[key] + short[key]
+    for key in (
+        "hsl_duration_max_steps",
+        "hsl_panic_close_loss_max",
+        "hsl_panic_loss_drawdown_max",
+    ):
+        combined[key] = long[key].maximum(short[key])
+
+    long_count = long["hsl_panic_loss_drawdown_count"]
+    short_count = short["hsl_panic_loss_drawdown_count"]
+    long_has = long_count > 0.0
+    short_has = short_count > 0.0
+    both_have = long_has & short_has
+    zeros = long_count.new_zeros(long_count.shape)
+    combined["hsl_panic_loss_drawdown_min"] = long[
+        "hsl_panic_loss_drawdown_min"
+    ].minimum(short["hsl_panic_loss_drawdown_min"]).where(
+        both_have,
+        long["hsl_panic_loss_drawdown_min"].where(
+            long_has,
+            short["hsl_panic_loss_drawdown_min"].where(short_has, zeros),
+        ),
+    )
+
+    total = long["hsl_tier_samples_total"].maximum(
+        short["hsl_tier_samples_total"]
+    )
+    red = (long["hsl_tier_samples_red"] + short["hsl_tier_samples_red"]).minimum(
+        total
+    )
+    remaining = (total - red).clamp(min=0.0)
+    orange = (
+        long["hsl_tier_samples_orange"] + short["hsl_tier_samples_orange"]
+    ).minimum(remaining)
+    remaining = (remaining - orange).clamp(min=0.0)
+    yellow = (
+        long["hsl_tier_samples_yellow"] + short["hsl_tier_samples_yellow"]
+    ).minimum(remaining)
+    combined.update(
+        {
+            "hsl_tier_samples_total": total,
+            "hsl_tier_samples_yellow": yellow,
+            "hsl_tier_samples_orange": orange,
+            "hsl_tier_samples_red": red,
+        }
+    )
+    return combined
+
+
 def _combine_hedged_multicoin_outputs(
     long: dict,
     short: dict,
@@ -687,6 +769,10 @@ def _combine_hedged_multicoin_outputs(
     combined["pnl_recovery_max_ms"] = long["pnl_recovery_max_ms"].maximum(
         short["pnl_recovery_max_ms"]
     )
+    if DIRECTIONAL_HSL_OUTPUT_KEYS <= long.keys() and (
+        DIRECTIONAL_HSL_OUTPUT_KEYS <= short.keys()
+    ):
+        combined.update(_combine_hedged_multicoin_hsl_outputs(long, short))
     return combined
 
 

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1573,7 +1573,7 @@ def test_gpu_hsl_rejects_dual_side_multicoin_joint_account_modes(signal_mode):
         _validate_scope(config, _MulticoinEvaluator())
 
 
-def test_gpu_hsl_metrics_accept_one_sided_multicoin_proxy_outputs():
+def test_gpu_hsl_metrics_reject_only_dual_multicoin_tier_overlap():
     _validate_hsl_metric_topology(
         {"hard_stop_panic_close_loss_sum"},
         coin_count=3,
@@ -1581,12 +1581,22 @@ def test_gpu_hsl_metrics_accept_one_sided_multicoin_proxy_outputs():
         hard_stop_metrics={"hard_stop_panic_close_loss_sum"},
     )
 
-    with pytest.raises(ValueError, match="dual-side multi-coin HSL metrics"):
+    _validate_hsl_metric_topology(
+        {"hard_stop_panic_close_loss_sum", "hard_stop_triggers"},
+        coin_count=3,
+        enabled_sides=["long", "short"],
+        hard_stop_metrics={
+            "hard_stop_panic_close_loss_sum",
+            "hard_stop_triggers",
+        },
+    )
+
+    with pytest.raises(ValueError, match="minute-level cross-side overlap"):
         _validate_hsl_metric_topology(
-            {"hard_stop_panic_close_loss_sum"},
+            {"hard_stop_time_in_red_pct"},
             coin_count=3,
             enabled_sides=["long", "short"],
-            hard_stop_metrics={"hard_stop_panic_close_loss_sum"},
+            hard_stop_metrics={"hard_stop_time_in_red_pct"},
         )
 
     _validate_hsl_metric_topology(

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1591,12 +1591,22 @@ def test_gpu_hsl_metrics_reject_only_dual_multicoin_tier_overlap():
         },
     )
 
-    with pytest.raises(ValueError, match="minute-level cross-side overlap"):
+    with pytest.raises(ValueError, match="cross-side tier overlap"):
         _validate_hsl_metric_topology(
             {"hard_stop_time_in_red_pct"},
             coin_count=3,
             enabled_sides=["long", "short"],
             hard_stop_metrics={"hard_stop_time_in_red_pct"},
+        )
+
+    with pytest.raises(ValueError, match="shared event-level account equity"):
+        _validate_hsl_metric_topology(
+            {"hard_stop_panic_close_loss_drawdown_pct_mean"},
+            coin_count=3,
+            enabled_sides=["long", "short"],
+            hard_stop_metrics={
+                "hard_stop_panic_close_loss_drawdown_pct_mean"
+            },
         )
 
     _validate_hsl_metric_topology(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -381,6 +381,7 @@ def test_mps_dual_multicoin_pside_hsl_runs_both_directional_controllers(
     closes[60:] *= 0.65
     outputs = {}
     runners = {}
+    rows = {}
     for side in ("long", "short"):
         runner, row = _multicoin_exposure_fixture(
             strategy_kind,
@@ -409,6 +410,7 @@ def test_mps_dual_multicoin_pside_hsl_runs_both_directional_controllers(
         }.items():
             row[keys.index(key)] = value
         runners[side] = runner
+        rows[side] = row
         outputs[side] = runner.run(np.asarray([row], dtype=np.float64))
     torch.mps.synchronize()
 
@@ -457,6 +459,17 @@ def test_mps_dual_multicoin_pside_hsl_runs_both_directional_controllers(
     assert lifecycle["hard_stop_triggers_short"].item() == 1.0
     assert panic["hard_stop_panic_close_loss_sum"].item() > 0.0
     assert panic["hard_stop_panic_close_loss_drawdown_pct_max"].item() > 0.0
+
+    truncated = {
+        side: runners[side].run(
+            np.asarray([rows[side]], dtype=np.float64),
+            end_steps=np.asarray([60], dtype=np.int32),
+        )
+        for side in ("long", "short")
+    }
+    torch.mps.synchronize()
+    assert truncated["long"]["hsl_triggers_long"].item() == 0.0
+    assert truncated["short"]["hsl_triggers_short"].item() == 1.0
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -380,6 +380,7 @@ def test_mps_dual_multicoin_pside_hsl_runs_both_directional_controllers(
     closes[20:60] *= 1.3
     closes[60:] *= 0.65
     outputs = {}
+    runners = {}
     for side in ("long", "short"):
         runner, row = _multicoin_exposure_fixture(
             strategy_kind,
@@ -407,6 +408,7 @@ def test_mps_dual_multicoin_pside_hsl_runs_both_directional_controllers(
             "hsl_slot_count": 1.0,
         }.items():
             row[keys.index(key)] = value
+        runners[side] = runner
         outputs[side] = runner.run(np.asarray([row], dtype=np.float64))
     torch.mps.synchronize()
 
@@ -420,6 +422,41 @@ def test_mps_dual_multicoin_pside_hsl_runs_both_directional_controllers(
         assert output["hsl_trigger_drawdown_count"].item() == 1.0
         assert output["hsl_panic_loss_drawdown_count"].item() == 1.0
         assert output["open_positions"].item() == 0.0
+
+    from optimization.gpu.metrics import (
+        _hard_stop_lifecycle_metrics,
+        _hard_stop_panic_loss_metrics,
+    )
+    from optimization.gpu.service import (
+        CORE_OUTPUT_KEYS,
+        DIRECTIONAL_HSL_OUTPUT_KEYS,
+        _combine_hedged_multicoin_outputs,
+    )
+
+    side_outputs = {
+        side: {
+            key: value.cpu()
+            for key, value in outputs[side].items()
+            if key in CORE_OUTPUT_KEYS | DIRECTIONAL_HSL_OUTPUT_KEYS
+        }
+        for side in ("long", "short")
+    }
+    run = runners["long"].run_config
+    combined = _combine_hedged_multicoin_outputs(
+        side_outputs["long"],
+        side_outputs["short"],
+        run.starting_balance,
+        run.liquidation_threshold,
+        runners["long"].start_minute_of_day,
+        run.interval_ms,
+    )
+    lifecycle = _hard_stop_lifecycle_metrics(combined, run)
+    panic = _hard_stop_panic_loss_metrics(combined, run)
+    assert lifecycle["hard_stop_triggers"].item() == 2.0
+    assert lifecycle["hard_stop_triggers_long"].item() == 1.0
+    assert lifecycle["hard_stop_triggers_short"].item() == 1.0
+    assert panic["hard_stop_panic_close_loss_sum"].item() > 0.0
+    assert panic["hard_stop_panic_close_loss_drawdown_pct_max"].item() > 0.0
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -25,6 +25,7 @@ from optimization.gpu.service import (
     _build_multicoin_tm_coin_overrides,
     _candidate_wallet_exposure_limit_outputs,
     _candidate_position_slot_outputs,
+    _combine_hedged_multicoin_hsl_outputs,
     _combine_hedged_multicoin_outputs,
     _directional_entry_initial_metrics,
     _directional_gross_pnl_outputs,
@@ -226,6 +227,88 @@ def test_directional_hsl_output_contract_retains_lifecycle_and_panic_scalars():
         "hsl_panic_close_loss_sum",
         "hsl_panic_loss_drawdown_count",
     } <= DIRECTIONAL_HSL_OUTPUT_KEYS
+
+
+def test_combine_hedged_multicoin_hsl_outputs_reduces_pside_episodes():
+    torch = pytest.importorskip("torch")
+    from optimization.gpu.metrics import (
+        _hard_stop_lifecycle_metrics,
+        _hard_stop_panic_loss_metrics,
+    )
+
+    def side_output(*, side, triggers, restarts, minimum, drawdown_count):
+        zeros = torch.zeros(1)
+        output = {key: zeros.clone() for key in DIRECTIONAL_HSL_OUTPUT_KEYS}
+        output[f"hsl_{side}_enabled"] = torch.ones(1, dtype=torch.bool)
+        output[f"hsl_triggers_{side}"] = torch.tensor([triggers])
+        output[f"hsl_restarts_{side}"] = torch.tensor([restarts])
+        output["hsl_tier_samples_total"] = torch.tensor([10.0])
+        output["hsl_tier_samples_yellow"] = torch.tensor([2.0])
+        output["hsl_tier_samples_orange"] = torch.tensor([3.0])
+        output["hsl_tier_samples_red"] = torch.tensor([4.0])
+        output["hsl_duration_sum_steps"] = torch.tensor([7.0])
+        output["hsl_duration_max_steps"] = torch.tensor([5.0])
+        output["hsl_duration_count"] = torch.tensor([2.0])
+        output["hsl_trigger_drawdown_sum"] = torch.tensor([0.3])
+        output["hsl_trigger_drawdown_count"] = torch.tensor([1.0])
+        output["hsl_flatten_time_sum_steps"] = torch.tensor([4.0])
+        output["hsl_flatten_time_count"] = torch.tensor([1.0])
+        output["hsl_restart_retrigger_count"] = torch.tensor([1.0])
+        output["hsl_halt_to_restart_equity_loss"] = torch.tensor([12.0])
+        output["hsl_panic_close_loss_sum"] = torch.tensor([8.0])
+        output["hsl_panic_close_loss_max"] = torch.tensor([6.0])
+        output["hsl_panic_loss_drawdown_min"] = torch.tensor([minimum])
+        output["hsl_panic_loss_drawdown_sum"] = torch.tensor([0.4])
+        output["hsl_panic_loss_drawdown_max"] = torch.tensor([0.3])
+        output["hsl_panic_loss_drawdown_count"] = torch.tensor(
+            [drawdown_count]
+        )
+        return output
+
+    combined = _combine_hedged_multicoin_hsl_outputs(
+        side_output(
+            side="long", triggers=2.0, restarts=1.0, minimum=0.2, drawdown_count=2.0
+        ),
+        side_output(
+            side="short", triggers=3.0, restarts=2.0, minimum=0.1, drawdown_count=1.0
+        ),
+    )
+
+    assert combined["hsl_long_enabled"].item()
+    assert combined["hsl_short_enabled"].item()
+    assert combined["hsl_triggers_long"].item() == 2.0
+    assert combined["hsl_triggers_short"].item() == 3.0
+    assert combined["hsl_restarts_long"].item() == 1.0
+    assert combined["hsl_restarts_short"].item() == 2.0
+    assert combined["hsl_duration_sum_steps"].item() == 14.0
+    assert combined["hsl_duration_max_steps"].item() == 5.0
+    assert combined["hsl_duration_count"].item() == 4.0
+    assert combined["hsl_panic_close_loss_sum"].item() == 16.0
+    assert combined["hsl_panic_close_loss_max"].item() == 6.0
+    assert combined["hsl_panic_loss_drawdown_min"].item() == pytest.approx(0.1)
+    assert combined["hsl_panic_loss_drawdown_count"].item() == 3.0
+    assert combined["hsl_tier_samples_total"].item() == 10.0
+    assert combined["hsl_tier_samples_red"].item() == 8.0
+    assert combined["hsl_tier_samples_orange"].item() == 2.0
+    assert combined["hsl_tier_samples_yellow"].item() == 0.0
+
+    combined.update(
+        {
+            "max_dd": torch.tensor([0.2]),
+            "first_eq_ts": torch.tensor([0.0]),
+            "last_eq_ts": torch.tensor([86_400_000.0]),
+        }
+    )
+    run = SimpleNamespace(interval_ms=60_000, starting_balance=1_000.0)
+    lifecycle = _hard_stop_lifecycle_metrics(combined, run)
+    panic = _hard_stop_panic_loss_metrics(combined, run)
+    assert lifecycle["hard_stop_triggers"].item() == 5.0
+    assert lifecycle["hard_stop_restarts"].item() == 3.0
+    assert lifecycle["hard_stop_duration_minutes_mean"].item() == 3.5
+    assert panic["hard_stop_panic_close_loss_sum"].item() == 16.0
+    assert panic["hard_stop_panic_close_loss_drawdown_pct_mean"].item() == (
+        pytest.approx(0.8 / 3.0)
+    )
     assert len(DIRECTIONAL_HSL_OUTPUT_KEYS) == 25
 
 

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -37,6 +37,7 @@ from optimization.gpu.service import (
     _require_no_internal_invalid_account_recovery_candles,
     _require_no_internal_invalid_hsl_candles,
     _require_no_internal_invalid_multicoin_hsl_candles,
+    _refresh_hedged_multicoin_hsl_at_portfolio_cutoff,
     _single_coin_exposure_params,
     _total_exposure_enforcer_params,
     _unstuck_params,
@@ -310,6 +311,64 @@ def test_combine_hedged_multicoin_hsl_outputs_reduces_pside_episodes():
         pytest.approx(0.8 / 3.0)
     )
     assert len(DIRECTIONAL_HSL_OUTPUT_KEYS) == 25
+
+
+def test_refresh_hedged_multicoin_hsl_replays_only_cutoff_candidates():
+    torch = pytest.importorskip("torch")
+
+    class FakeRunner:
+        def __init__(self, replacement):
+            self.replacement = replacement
+            self.calls = []
+
+        def run(self, params, *, end_steps):
+            self.calls.append((params.copy(), end_steps.copy()))
+            return {
+                key: torch.full(
+                    (len(params),),
+                    bool(self.replacement)
+                    if key.endswith("_enabled")
+                    else self.replacement,
+                    dtype=(
+                        torch.bool if key.endswith("_enabled") else torch.float32
+                    ),
+                )
+                for key in DIRECTIONAL_HSL_OUTPUT_KEYS
+            }
+
+    side_outputs = {
+        side: {
+            key: torch.tensor(
+                [True, True]
+                if key.endswith("_enabled")
+                else [10.0, 20.0],
+                dtype=torch.bool if key.endswith("_enabled") else torch.float32,
+            )
+            for key in DIRECTIONAL_HSL_OUTPUT_KEYS
+        }
+        for side in ("long", "short")
+    }
+    runners = {"long": FakeRunner(3.0), "short": FakeRunner(4.0)}
+    matrices = {
+        "long": np.asarray([[1.0], [2.0]]),
+        "short": np.asarray([[3.0], [4.0]]),
+    }
+
+    refreshed = _refresh_hedged_multicoin_hsl_at_portfolio_cutoff(
+        side_outputs=side_outputs,
+        runners=runners,
+        parameter_matrices=matrices,
+        combined_output={"liq_step": torch.tensor([-1.0, 2.0])},
+        start_minute_of_day=60,
+    )
+
+    assert refreshed
+    assert runners["long"].calls[0][0].tolist() == [[2.0]]
+    assert runners["short"].calls[0][0].tolist() == [[4.0]]
+    assert runners["long"].calls[0][1].tolist() == [2820]
+    assert runners["short"].calls[0][1].tolist() == [2820]
+    assert side_outputs["long"]["hsl_triggers_long"].tolist() == [10.0, 3.0]
+    assert side_outputs["short"]["hsl_triggers_short"].tolist() == [10.0, 4.0]
 
 
 def test_single_coin_proxy_preserves_directional_hsl_outputs_for_reduction():


### PR DESCRIPTION
## Summary
- reduce independent long and short pside HSL episode summaries for metrics that preserve exact Rust sum, count, minimum, and maximum semantics
- replay candidates through the conservative combined portfolio cutoff before reducing HSL summaries, excluding later directional events
- enable dual-side multi-coin lifecycle and absolute panic-loss scoring and limits on Apple MPS
- keep account-normalized event metrics and yellow, orange, and red time percentages fail closed until shared event-level equity and tier state exist

Exact Rust evaluation remains authoritative.

## Validation
- GPU service and backend tests: 474 passed
- optimizer integration tests: 229 passed
- physical Apple M3/MPS tests: 265 passed
- Rust library tests: 264 passed
- cargo check --tests
- exact-branch Rust extension rebuild and provenance stamp
- Python compile and git diff checks