### PR TITLE
feat(gpu): add fused multicoin HSL controller

### DIFF
--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -108,12 +108,18 @@ mod tests {
             "inline float joint_hsl_realized_pnl(",
             "inline float joint_hsl_unrealized_pnl(",
             "inline bool joint_portfolio_can_generate(",
+            "inline bool update_joint_pside_hsl(",
+            "inline void try_restart_joint_pside_hsl(",
+            "inline int joint_pside_hsl_global_tier(",
         ] {
             assert_eq!(source.matches(signature).count(), 1, "{signature}");
         }
         assert_eq!(source.matches("struct JointPortfolioAccount").count(), 1);
         assert!(source.contains("if (is_long) account.realized_pnl_long += net_pnl"));
         assert!(source.contains("else account.realized_pnl_short += net_pnl"));
+        assert!(source.contains("long_hsl.signal_mode != short_hsl.signal_mode"));
+        assert!(source.contains("joint_hsl_realized_pnl(account, unified, true)"));
+        assert!(source.contains("joint_hsl_realized_pnl(account, unified, false)"));
     }
 
     fn assert_directional_hsl_accounting_contract(source: &str) {
@@ -166,6 +172,20 @@ mod tests {
             assert!(!body.contains("float balance = starting_balance"));
             assert!(!body.contains("balance += net_pnl"));
             assert!(!body.contains("balance -= fee"));
+        }
+    }
+
+    #[test]
+    fn multicoin_sources_compose_hsl_before_joint_controller_helpers() {
+        for source in [
+            mps_ema_anchor_multicoin_source(),
+            mps_trailing_martingale_multicoin_source(),
+        ] {
+            let hsl = source.find("struct HslState").unwrap();
+            let joint = source.find("inline bool update_joint_pside_hsl(").unwrap();
+            assert!(hsl < joint);
+            assert_shared_hsl_contract(source);
+            assert_shared_multicoin_contract(source);
         }
     }
 

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -118,6 +118,12 @@ mod tests {
         assert!(source.contains("if (is_long) account.realized_pnl_long += net_pnl"));
         assert!(source.contains("else account.realized_pnl_short += net_pnl"));
         assert!(source.contains("long_hsl.signal_mode != short_hsl.signal_mode"));
+        assert!(source.contains(
+            "const bool shared_has_position = has_position_long || has_position_short"
+        ));
+        assert!(source.contains(
+            "const bool shared_has_blocking_orders = has_blocking_orders_long"
+        ));
         assert!(source.contains("joint_hsl_realized_pnl(account, unified, true)"));
         assert!(source.contains("joint_hsl_realized_pnl(account, unified, false)"));
     }

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -10,9 +10,9 @@ constant int DAILY_COLS = 9;
 constant int SCALAR_COLS = 57;
 constant int GAP_BINS = 128;
 
-// PASSIVBOT_MULTICOIN_COMMON
-
 // PASSIVBOT_HSL_COMMON
+
+// PASSIVBOT_MULTICOIN_COMMON
 
 inline bool realized_loss_proxy_allows_close(
     float qty, float close_price, float pprice, bool short_side,

--- a/passivbot-rust/src/gpu/mps_multicoin_common.metal
+++ b/passivbot-rust/src/gpu/mps_multicoin_common.metal
@@ -183,3 +183,88 @@ inline bool joint_portfolio_can_generate(
     return isfinite(account.balance) && account.balance > 0.0f
         && isfinite(equity) && equity > liquidation_floor;
 }
+
+// Fused long+short multi-coin kernels own two independent pside controllers.
+// Unified mode feeds the same shared account signal to both controllers while
+// pside mode feeds directional realized and unrealized PnL. Coin mode has a
+// separate per-coin controller topology and is deliberately rejected here.
+inline bool update_joint_pside_hsl(
+    thread HslState& long_hsl,
+    thread HslState& short_hsl,
+    thread const JointPortfolioAccount& account,
+    float starting_balance,
+    float unrealized_pnl_long,
+    float unrealized_pnl_short,
+    bool has_position_long,
+    bool has_position_short,
+    bool has_blocking_orders_long,
+    bool has_blocking_orders_short,
+    float kf,
+    float interval_ms
+) {
+    if (long_hsl.signal_mode == HSL_SIGNAL_COIN
+        || short_hsl.signal_mode == HSL_SIGNAL_COIN
+        || long_hsl.signal_mode != short_hsl.signal_mode) return false;
+    const bool unified = long_hsl.signal_mode == HSL_SIGNAL_UNIFIED;
+    update_hsl(
+        long_hsl,
+        account.balance,
+        starting_balance,
+        joint_hsl_realized_pnl(account, unified, true),
+        joint_hsl_unrealized_pnl(
+            unrealized_pnl_long, unrealized_pnl_short, unified, true
+        ),
+        has_position_long,
+        has_blocking_orders_long,
+        kf,
+        interval_ms
+    );
+    update_hsl(
+        short_hsl,
+        account.balance,
+        starting_balance,
+        joint_hsl_realized_pnl(account, unified, false),
+        joint_hsl_unrealized_pnl(
+            unrealized_pnl_long, unrealized_pnl_short, unified, false
+        ),
+        has_position_short,
+        has_blocking_orders_short,
+        kf,
+        interval_ms
+    );
+    return true;
+}
+
+inline void try_restart_joint_pside_hsl(
+    thread HslState& long_hsl,
+    thread HslState& short_hsl,
+    thread const JointPortfolioAccount& account,
+    float starting_balance,
+    float unrealized_pnl_long,
+    float unrealized_pnl_short,
+    float kf
+) {
+    if (long_hsl.signal_mode == HSL_SIGNAL_COIN
+        || short_hsl.signal_mode == HSL_SIGNAL_COIN
+        || long_hsl.signal_mode != short_hsl.signal_mode) return;
+    const bool unified = long_hsl.signal_mode == HSL_SIGNAL_UNIFIED;
+    float long_equity = starting_balance
+        + joint_hsl_realized_pnl(account, unified, true)
+        + joint_hsl_unrealized_pnl(
+            unrealized_pnl_long, unrealized_pnl_short, unified, true
+        );
+    float short_equity = starting_balance
+        + joint_hsl_realized_pnl(account, unified, false)
+        + joint_hsl_unrealized_pnl(
+            unrealized_pnl_long, unrealized_pnl_short, unified, false
+        );
+    try_restart_hsl(long_hsl, kf, long_equity);
+    try_restart_hsl(short_hsl, kf, short_equity);
+}
+
+inline int joint_pside_hsl_global_tier(
+    thread const HslState& long_hsl,
+    thread const HslState& short_hsl
+) {
+    return max(long_hsl.tier, short_hsl.tier);
+}

--- a/passivbot-rust/src/gpu/mps_multicoin_common.metal
+++ b/passivbot-rust/src/gpu/mps_multicoin_common.metal
@@ -206,6 +206,9 @@ inline bool update_joint_pside_hsl(
         || short_hsl.signal_mode == HSL_SIGNAL_COIN
         || long_hsl.signal_mode != short_hsl.signal_mode) return false;
     const bool unified = long_hsl.signal_mode == HSL_SIGNAL_UNIFIED;
+    const bool shared_has_position = has_position_long || has_position_short;
+    const bool shared_has_blocking_orders = has_blocking_orders_long
+        || has_blocking_orders_short;
     update_hsl(
         long_hsl,
         account.balance,
@@ -214,8 +217,8 @@ inline bool update_joint_pside_hsl(
         joint_hsl_unrealized_pnl(
             unrealized_pnl_long, unrealized_pnl_short, unified, true
         ),
-        has_position_long,
-        has_blocking_orders_long,
+        unified ? shared_has_position : has_position_long,
+        unified ? shared_has_blocking_orders : has_blocking_orders_long,
         kf,
         interval_ms
     );
@@ -227,8 +230,8 @@ inline bool update_joint_pside_hsl(
         joint_hsl_unrealized_pnl(
             unrealized_pnl_long, unrealized_pnl_short, unified, false
         ),
-        has_position_short,
-        has_blocking_orders_short,
+        unified ? shared_has_position : has_position_short,
+        unified ? shared_has_blocking_orders : has_blocking_orders_short,
         kf,
         interval_ms
     );

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -10,9 +10,9 @@ constant int DAILY_COLS = 9;
 constant int SCALAR_COLS = 57;
 constant int GAP_BINS = 128;
 
-// PASSIVBOT_MULTICOIN_COMMON
-
 // PASSIVBOT_HSL_COMMON
+
+// PASSIVBOT_MULTICOIN_COMMON
 
 inline bool realized_loss_proxy_allows_close(
     float qty, float close_price, float pprice, bool short_side,

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -179,17 +179,19 @@ kernel void passivbot_joint_pside_hsl_contract_probe(
             controller(1) + controller(1),
             controller(2) + controller(2),
             controller(0) + controller(1),
+            controller(0) + controller(0),
         ],
         dtype=torch.float32,
         device="mps",
     )
-    samples = torch.zeros((4, 4, 8), dtype=torch.float32, device="mps")
+    samples = torch.zeros((5, 4, 8), dtype=torch.float32, device="mps")
     samples[:, :2, 4] = 1.0
     samples[:, :2, 5] = 1.0
     samples[:, 1:, 3] = -10.0
+    samples[4, :, 4] = 1.0
     settings = torch.tensor([100.0, 60_000.0], device="mps")
-    sizes = torch.tensor([4, 4], dtype=torch.int32, device="mps")
-    output = torch.zeros((4, 8), dtype=torch.float32, device="mps")
+    sizes = torch.tensor([5, 4], dtype=torch.int32, device="mps")
+    output = torch.zeros((5, 8), dtype=torch.float32, device="mps")
 
     library = torch.mps.compile_shader(
         passivbot_rust.mps_ema_anchor_multicoin_source_py() + probe_kernel
@@ -200,7 +202,7 @@ kernel void passivbot_joint_pside_hsl_contract_probe(
         settings,
         sizes,
         output,
-        threads=(4, 1, 1),
+        threads=(5, 1, 1),
     )
     torch.mps.synchronize()
     values = output.cpu().numpy()
@@ -209,8 +211,9 @@ kernel void passivbot_joint_pside_hsl_contract_probe(
     assert values[1, :4].tolist() == [0.0, 3.0, 0.0, 1.0]
     assert values[2, :4].tolist() == [0.0, 0.0, 0.0, 0.0]
     assert values[3, :4].tolist() == [0.0, 0.0, 0.0, 0.0]
-    assert values[:, 6].tolist() == [90.0, 90.0, 90.0, 90.0]
-    assert values[:, 7].tolist() == [3.0, 3.0, 0.0, 0.0]
+    assert values[4, :4].tolist() == [3.0, 3.0, 0.0, 0.0]
+    assert values[:, 6].tolist() == [90.0, 90.0, 90.0, 90.0, 90.0]
+    assert values[:, 7].tolist() == [3.0, 3.0, 0.0, 0.0, 3.0]
 
 
 def _single_coin_exposure_fields(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -89,6 +89,130 @@ def test_mps_disabled_realized_loss_limit_has_finite_float32_encoding(value):
     assert _encode_max_realized_loss_pct(value) == 1.0
 
 
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_joint_pside_hsl_contract_routes_unified_and_directional_signals():
+    import passivbot_rust
+
+    probe_kernel = r"""
+kernel void passivbot_joint_pside_hsl_contract_probe(
+    constant float* hsl_params,
+    constant float* samples,
+    constant float* settings,
+    constant int* sizes,
+    device float* output,
+    uint b [[thread_position_in_grid]]
+) {
+    const int B = sizes[0];
+    const int T = sizes[1];
+    if (b >= uint(B)) return;
+    const int po = int(b) * 22;
+    HslState long_hsl = load_hsl(hsl_params, po, 0);
+    HslState short_hsl = load_hsl(hsl_params, po, 11);
+    const float starting_balance = settings[0];
+    const float interval_ms = settings[1];
+    JointPortfolioAccount account = init_joint_portfolio_account(starting_balance);
+    float unrealized_long = 0.0f;
+    float unrealized_short = 0.0f;
+    bool has_position_long = false;
+    bool has_position_short = false;
+    for (int k = 0; k < T; ++k) {
+        int so = (int(b) * T + k) * 8;
+        account.realized_pnl_long = samples[so + 0];
+        account.realized_pnl_short = samples[so + 1];
+        account.realized_pnl_total = account.realized_pnl_long
+            + account.realized_pnl_short;
+        account.realized_pnl_peak = fmax(
+            account.realized_pnl_peak, account.realized_pnl_total
+        );
+        account.balance = starting_balance + account.realized_pnl_total;
+        unrealized_long = samples[so + 2];
+        unrealized_short = samples[so + 3];
+        has_position_long = samples[so + 4] > 0.5f;
+        has_position_short = samples[so + 5] > 0.5f;
+        bool blocking_long = samples[so + 6] > 0.5f;
+        bool blocking_short = samples[so + 7] > 0.5f;
+        update_joint_pside_hsl(
+            long_hsl, short_hsl, account, starting_balance,
+            unrealized_long, unrealized_short,
+            has_position_long, has_position_short,
+            blocking_long, blocking_short, float(k), interval_ms
+        );
+        try_restart_joint_pside_hsl(
+            long_hsl, short_hsl, account, starting_balance,
+            unrealized_long, unrealized_short, float(k)
+        );
+    }
+    int oo = int(b) * 8;
+    output[oo + 0] = float(long_hsl.tier);
+    output[oo + 1] = float(short_hsl.tier);
+    output[oo + 2] = long_hsl.triggers;
+    output[oo + 3] = short_hsl.triggers;
+    output[oo + 4] = float(hsl_mode(long_hsl, has_position_long));
+    output[oo + 5] = float(hsl_mode(short_hsl, has_position_short));
+    output[oo + 6] = joint_portfolio_equity(
+        account, unrealized_long, unrealized_short
+    );
+    output[oo + 7] = float(joint_pside_hsl_global_tier(long_hsl, short_hsl));
+}
+"""
+
+    def controller(mode):
+        return [
+            1.0,
+            0.05,
+            1.0,
+            0.0,
+            1.0,
+            2.0,
+            0.5,
+            0.75,
+            0.0,
+            float(mode),
+            1.0,
+        ]
+
+    params = torch.tensor(
+        [
+            controller(0) + controller(0),
+            controller(1) + controller(1),
+            controller(2) + controller(2),
+            controller(0) + controller(1),
+        ],
+        dtype=torch.float32,
+        device="mps",
+    )
+    samples = torch.zeros((4, 4, 8), dtype=torch.float32, device="mps")
+    samples[:, :2, 4] = 1.0
+    samples[:, :2, 5] = 1.0
+    samples[:, 1:, 3] = -10.0
+    settings = torch.tensor([100.0, 60_000.0], device="mps")
+    sizes = torch.tensor([4, 4], dtype=torch.int32, device="mps")
+    output = torch.zeros((4, 8), dtype=torch.float32, device="mps")
+
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_ema_anchor_multicoin_source_py() + probe_kernel
+    )
+    library.passivbot_joint_pside_hsl_contract_probe(
+        params,
+        samples,
+        settings,
+        sizes,
+        output,
+        threads=(4, 1, 1),
+    )
+    torch.mps.synchronize()
+    values = output.cpu().numpy()
+
+    assert values[0, :4].tolist() == [3.0, 3.0, 1.0, 1.0]
+    assert values[1, :4].tolist() == [0.0, 3.0, 0.0, 1.0]
+    assert values[2, :4].tolist() == [0.0, 0.0, 0.0, 0.0]
+    assert values[3, :4].tolist() == [0.0, 0.0, 0.0, 0.0]
+    assert values[:, 6].tolist() == [90.0, 90.0, 90.0, 90.0]
+    assert values[:, 7].tolist() == [3.0, 3.0, 0.0, 0.0]
+
+
 def _single_coin_exposure_fields(
     *, allowance_pct=0.0, legacy_raw=False, entry_gate=True, threshold=1.0
 ):


### PR DESCRIPTION
## Summary
- add shared fused long+short multi-coin HSL controller helpers over one joint portfolio account
- route unified and pside realized/unrealized signals in exact long-then-short order
- keep coin topology and mismatched side modes fail-closed; this foundation does not enable a new CLI capability yet
- prove the production helper contract with a test-only Metal probe on physical Apple MPS

Exact Rust remains authoritative; CPU optimization behavior is unchanged.

## Validation
- physical Apple MPS: 266 passed (`tests/optimization/test_gpu_mps.py`)
- Rust: 265 passed (`./cargotest.sh --lib -q`)
- optimizer: 229 passed
- GPU service/backend: 474 passed
- `cargo check`
- rebuilt and stamped the Python Rust extension from the exact branch head