### PR TITLE
fix(hsl): require unified account flatness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Fixed exact Rust backtests so `unified` HSL confirms the whole account is flat before ending a
+  RED episode. A position or blocking order on either side now prevents both unified controllers
+  from halting or beginning cooldown, matching the documented live HSL scope.
+
 - Added dual-side multi-coin `pside` HSL lifecycle and panic-loss scoring/limits to Apple MPS
   optimization. The proxy now reduces directional episode counters, durations, drawdowns,
   restarts, and absolute panic losses with the same aggregate formulas used by exact Rust, and

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -2648,6 +2648,15 @@ impl<'a> Backtest<'a> {
     }
 
     #[inline(always)]
+    fn hard_stop_scope_has_open_position(&self, pside: usize) -> bool {
+        if self.hard_stop_signal_mode() == "unified" {
+            self.has_open_position_pside(LONG) || self.has_open_position_pside(SHORT)
+        } else {
+            self.has_open_position_pside(pside)
+        }
+    }
+
+    #[inline(always)]
     fn has_open_position_coin_pside(&self, idx: usize, pside: usize) -> bool {
         match pside {
             LONG => self.positions.long[idx].size != 0.0,
@@ -2670,6 +2679,15 @@ impl<'a> Backtest<'a> {
                 .iter()
                 .any(Self::bundle_has_blocking_open_orders),
             _ => unreachable!("invalid pside"),
+        }
+    }
+
+    #[inline(always)]
+    fn hard_stop_scope_has_blocking_open_orders(&self, pside: usize) -> bool {
+        if self.hard_stop_signal_mode() == "unified" {
+            self.has_blocking_open_orders_pside(LONG) || self.has_blocking_open_orders_pside(SHORT)
+        } else {
+            self.has_blocking_open_orders_pside(pside)
         }
     }
 
@@ -3594,8 +3612,8 @@ impl<'a> Backtest<'a> {
                 k, timestamp_ms, strategy_equity, peak_strategy_equity, pside, e
             )
         })?;
-        let has_open_position = self.has_open_position_pside(pside);
-        let has_blocking_open_orders = self.has_blocking_open_orders_pside(pside);
+        let has_open_position = self.hard_stop_scope_has_open_position(pside);
+        let has_blocking_open_orders = self.hard_stop_scope_has_blocking_open_orders(pside);
         let drawdown_ema = self.hard_stop_pside[pside]
             .state
             .as_ref()
@@ -8836,7 +8854,7 @@ mod tests {
     }
 
     #[test]
-    fn hard_stop_flat_confirmation_ignores_open_panic_close_orders() {
+    fn hard_stop_flat_confirmation_ignores_panic_orders_but_requires_unified_scope_flat() {
         let hlcvs = Array3::from_shape_vec((2, 1, 4), vec![1.0; 2 * 1 * 4]).unwrap();
         let btc_usd_prices = Array1::from_vec(vec![20_000.0, 20_000.0]);
 
@@ -8921,6 +8939,21 @@ mod tests {
 
         assert_eq!(bt.hard_stop_flat_confirmations, 1);
         assert!(bt.hard_stop_pending_stop.is_some());
+
+        // Unified scope is the whole account. A position on the opposite side
+        // invalidates the pending flat confirmation even though this side has
+        // no position and its panic-only close order is non-blocking.
+        bt.positions.short[0] = Position {
+            size: -1.0,
+            price: 100.0,
+        };
+        bt.equities.timestamps_ms.push(120_000);
+        bt.equities.usd_total_equity.push(90.0);
+        bt.update_hard_stop_state(1).unwrap();
+
+        assert_eq!(bt.hard_stop_flat_confirmations, 0);
+        assert!(bt.hard_stop_pending_stop.is_none());
+        assert!(!bt.hard_stop_halted);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- make exact Rust unified HSL treat both sides as one flatness scope
- prevent either unified controller from halting or starting cooldown while any account position or blocking order remains
- preserve side-local `pside` behavior and per-coin `coin` behavior
- extend the hard-stop flat-confirmation regression with an asymmetric opposite-side position

This restores the canonical and live unified HSL contract before enabling the matching Apple MPS path.

## Validation
- `./cargotest.sh --lib -q`: 265 passed
- focused asymmetric Rust regression: passed
- `cargo check`
- rebuilt and stamped the Python Rust extension from the exact branch head
- `pytest -q tests/test_backtest_analysis.py tests/test_hsl_metric_regression.py`: 40 passed
- `rustfmt --edition 2021 --check src/backtest.rs`