### PR TITLE
feat(gpu): support unified dual-side HSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added dual-side single-coin `unified` HSL to Apple MPS optimization for EMA Anchor and
+  Trailing Martingale. Both Metal controllers now consume account-wide realized and unrealized
+  PnL and require positions and blocking orders on both sides to be flat before ending a RED
+  episode, matching exact Rust. Dual-side multi-coin `coin` and `unified` remain fail closed.
+
 - Fixed exact Rust backtests so `unified` HSL confirms the whole account is flat before ending a
   RED episode. A position or blocking order on either side now prevents both unified controllers
   from halting or beginning cooldown, matching the documented live HSL scope.

--- a/docs/equity_hard_stop_loss_reference.md
+++ b/docs/equity_hard_stop_loss_reference.md
@@ -128,14 +128,13 @@ These are the main parity surfaces that should be reviewed together:
    - One shared Rust-owned Metal HSL controller is composed into both EMA Anchor and Trailing Martingale directional kernels
    - Unified, pside, and coin signal modes use explicit encoded identities instead of a coin/non-coin boolean
    - Deterministic M3 conformance coverage compares Metal drawdown, EMA, tier, active-RED, latch, and RED-finalization traces against the exact Rust runtime for all three signal modes and restart policies
-   - One-sided runs support unified, pside, and coin signals; dual-side runs support pside and coin signals with independent directional realized-PnL state
+   - One-sided and dual-side single-coin runs support unified, pside, and coin signals; unified controllers share account PnL and require both sides to be flat, while pside and coin retain directional realized-PnL and flatness state
    - One-sided multi-coin runs support unified and pside signals through one shared-balance portfolio controller that tracks all positions and blocking orders on the enabled side
    - One-sided multi-coin coin signals use one independent controller per coin, each with coin-local realized net PnL, drawdown EMA, warning/RED episode, panic close, halt, and restart state; the coin drawdown budget uses the dynamic effective position-slot count
    - Coin-mode lifecycle and panic-loss metrics aggregate across coin episodes, while warning-tier time samples the worst active coin tier once per minute, matching exact Rust reporting
    - Multi-coin limit and market panic closes flatten every open coin on the enabled side and export the same lifecycle and panic-loss metric surface as single-coin HSL; market execution uses each coin's taker fee and directionally quantized configured slippage
    - One-sided multi-coin coin mode resolves all ten canonical per-coin HSL settings independently, including enablement, thresholds, restart/tier behavior, and limit/market panic execution; compatible suites may supply scenario-local overrides
-   - Dual-side unified HSL remains fail closed because the documented account-wide episode-finalization scope and current exact-backtest per-side flat confirmation disagree
-   - Dual-side multi-coin HSL still fails closed
+   - Dual-side multi-coin HSL supports pside signals; coin and unified signals remain fail closed pending a fused shared-balance strategy kernel
 
 ### Confirmed Gaps / Risks
 
@@ -147,15 +146,14 @@ These are the main parity surfaces that should be reviewed together:
    - Global `*_strategy_eq` metrics are canonical for risk inspection and optimizer use
    - Deprecated `*_hsl` metric names remain accepted as aliases for older configs/results
 3. GPU HSL topology is intentionally narrow
-   - Dual-side unified HSL needs one resolved account-wide exact-Rust flatten contract before it can be screened safely
-   - Dual-side multi-coin HSL needs one shared-balance controller that owns both directional state machines without duplicating account balance or liquidation decisions
+   - Dual-side multi-coin coin and unified HSL need one shared-balance strategy kernel that owns both directional state machines without duplicating account balance or liquidation decisions
 
 ### Missing or Weak Test Coverage
 
 1. End-to-end replay of one identical fill/candle history through live reconstruction and exact backtest orchestration; shared Rust primitive tests cover the calculations but not the complete orchestration trace
 2. Connector-level restart races while protective panic-close orders are live on an exchange
 3. Manual or external trading during downtime across the full exchange-adapter matrix
-4. Apple MPS parity for dual-side unified and dual-side multi-coin HSL scopes
+4. Apple MPS parity for dual-side multi-coin coin and unified HSL scopes
 
 ## Optimizer Work
 

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -81,10 +81,18 @@ mod tests {
             1
         );
         assert_eq!(source.matches("inline void update_hsl(").count(), 1);
+        assert_eq!(
+            source.matches("inline bool update_dual_side_hsl(").count(),
+            1
+        );
         assert!(source.contains("constant int HSL_SIGNAL_UNIFIED = 0"));
         assert!(source.contains("constant int HSL_SIGNAL_PSIDE = 1"));
         assert!(source.contains("constant int HSL_SIGNAL_COIN = 2"));
         assert!(source.contains("int ho = po + hsl_param_offset"));
+        assert!(source.contains("long_hsl.signal_mode != short_hsl.signal_mode"));
+        assert!(source
+            .contains("const bool shared_has_position = has_position_long || has_position_short"));
+        assert!(source.contains("const bool shared_has_blocking_orders = has_blocking_orders_long"));
     }
 
     fn assert_shared_multicoin_contract(source: &str) {
@@ -118,12 +126,9 @@ mod tests {
         assert!(source.contains("if (is_long) account.realized_pnl_long += net_pnl"));
         assert!(source.contains("else account.realized_pnl_short += net_pnl"));
         assert!(source.contains("long_hsl.signal_mode != short_hsl.signal_mode"));
-        assert!(source.contains(
-            "const bool shared_has_position = has_position_long || has_position_short"
-        ));
-        assert!(source.contains(
-            "const bool shared_has_blocking_orders = has_blocking_orders_long"
-        ));
+        assert!(source.contains("return update_dual_side_hsl("));
+        assert!(source.contains("account.realized_pnl_total"));
+        assert!(source.contains("account.realized_pnl_long, account.realized_pnl_short"));
         assert!(source.contains("joint_hsl_realized_pnl(account, unified, true)"));
         assert!(source.contains("joint_hsl_realized_pnl(account, unified, false)"));
     }
@@ -133,12 +138,11 @@ mod tests {
         assert!(source.contains("thread float& realized_pnl_cumsum_short"));
         assert!(source.contains("if (is_long) realized_pnl_cumsum_long += net_pnl"));
         assert!(source.contains("else realized_pnl_cumsum_short += net_pnl"));
-        assert!(source.contains("long_hsl.signal_mode == HSL_SIGNAL_UNIFIED"));
-        assert!(source.contains("short_hsl.signal_mode == HSL_SIGNAL_UNIFIED"));
-        assert!(source.contains("? realized_pnl_cumsum_last : realized_pnl_cumsum_long"));
-        assert!(source.contains("? realized_pnl_cumsum_last : realized_pnl_cumsum_short"));
-        assert!(source.contains("? total_unreal : long_unreal"));
-        assert!(source.contains("? total_unreal : short_unreal"));
+        assert_eq!(source.matches("update_dual_side_hsl(").count(), 2);
+        assert!(source.contains("realized_pnl_cumsum_long, realized_pnl_cumsum_short"));
+        assert!(source.contains("long_unreal, short_unreal"));
+        assert!(source.contains("long_side.psize > 0.0f, short_side.psize > 0.0f"));
+        assert!(source.contains("long_blocking_orders, short_blocking_orders"));
     }
 
     #[test]

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -143,6 +143,13 @@ mod tests {
         assert!(source.contains("long_unreal, short_unreal"));
         assert!(source.contains("long_side.psize > 0.0f, short_side.psize > 0.0f"));
         assert!(source.contains("long_blocking_orders, short_blocking_orders"));
+        assert!(source.contains(
+            "const bool hsl_modes_valid = long_hsl.signal_mode == short_hsl.signal_mode"
+        ));
+        assert!(source.contains("bool hsl_update_valid = update_dual_side_hsl("));
+        assert!(source.contains("if (!hsl_update_valid)"));
+        assert!(source.contains("alive = false"));
+        assert!(source.contains("liq_day = di"));
     }
 
     #[test]

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -1428,26 +1428,14 @@ inline void passivbot_single_coin_impl(
                 short_side.entry_qty > 0.0f || short_side.close_qty > 0.0f
                     || short_side.secondary_close_qty > 0.0f
             );
-            float total_unreal = long_unreal + short_unreal;
-            float long_hsl_realized = long_hsl.signal_mode == HSL_SIGNAL_UNIFIED
-                ? realized_pnl_cumsum_last : realized_pnl_cumsum_long;
-            float short_hsl_realized = short_hsl.signal_mode == HSL_SIGNAL_UNIFIED
-                ? realized_pnl_cumsum_last : realized_pnl_cumsum_short;
-            float long_hsl_unreal = long_hsl.signal_mode == HSL_SIGNAL_UNIFIED
-                ? total_unreal : long_unreal;
-            float short_hsl_unreal = short_hsl.signal_mode == HSL_SIGNAL_UNIFIED
-                ? total_unreal : short_unreal;
-            update_hsl(
-                long_hsl, balance, starting_balance,
-                long_hsl_realized,
-                long_hsl_unreal, long_side.psize > 0.0f,
-                long_blocking_orders, kf, interval_ms
-            );
-            update_hsl(
-                short_hsl, balance, starting_balance,
-                short_hsl_realized,
-                short_hsl_unreal, short_side.psize > 0.0f,
-                short_blocking_orders, kf, interval_ms
+            update_dual_side_hsl(
+                long_hsl, short_hsl, balance, starting_balance,
+                realized_pnl_cumsum_last,
+                realized_pnl_cumsum_long, realized_pnl_cumsum_short,
+                long_unreal, short_unreal,
+                long_side.psize > 0.0f, short_side.psize > 0.0f,
+                long_blocking_orders, short_blocking_orders,
+                kf, interval_ms
             );
             if (long_hsl.enabled || short_hsl.enabled) {
                 int hsl_tier = max(long_hsl.tier, short_hsl.tier);

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -824,8 +824,9 @@ inline void passivbot_single_coin_impl(
     EmaSide short_side = load_side(params, po + SIDE_PARAMS, seed_close);
     HslState long_hsl = load_hsl(params, po, 23);
     HslState short_hsl = load_hsl(params, po + SIDE_PARAMS, 23);
+    const bool hsl_modes_valid = long_hsl.signal_mode == short_hsl.signal_mode;
 
-    float balance = starting_balance;
+    float balance = hsl_modes_valid ? starting_balance : 0.0f;
     float realized_pnl_cumsum_last = 0.0f;
     float realized_pnl_cumsum_max = 0.0f;
     float realized_pnl_cumsum_long = 0.0f;
@@ -844,8 +845,8 @@ inline void passivbot_single_coin_impl(
     float fill_count_long = 0.0f;
     float fills_active_days_count = 0.0f;
     int last_active_fill_day = -1;
-    bool alive = true;
-    int liq_day = -1;
+    bool alive = hsl_modes_valid;
+    int liq_day = hsl_modes_valid ? -1 : 0;
     float held_max_min = 0.0f;
     float held_sum_min = 0.0f;
     float held_count = 0.0f;
@@ -1428,7 +1429,7 @@ inline void passivbot_single_coin_impl(
                 short_side.entry_qty > 0.0f || short_side.close_qty > 0.0f
                     || short_side.secondary_close_qty > 0.0f
             );
-            update_dual_side_hsl(
+            bool hsl_update_valid = update_dual_side_hsl(
                 long_hsl, short_hsl, balance, starting_balance,
                 realized_pnl_cumsum_last,
                 realized_pnl_cumsum_long, realized_pnl_cumsum_short,
@@ -1437,15 +1438,22 @@ inline void passivbot_single_coin_impl(
                 long_blocking_orders, short_blocking_orders,
                 kf, interval_ms
             );
-            if (long_hsl.enabled || short_hsl.enabled) {
+            if (!hsl_update_valid) {
+                balance = 0.0f;
+                alive = false;
+                liq_day = di;
+            }
+            if (hsl_update_valid && (long_hsl.enabled || short_hsl.enabled)) {
                 int hsl_tier = max(long_hsl.tier, short_hsl.tier);
                 hsl_tier_samples_total += 1.0f;
                 hsl_tier_samples_yellow += hsl_tier == 1 ? 1.0f : 0.0f;
                 hsl_tier_samples_orange += hsl_tier == 2 ? 1.0f : 0.0f;
                 hsl_tier_samples_red += hsl_tier == 3 ? 1.0f : 0.0f;
             }
-            try_restart_hsl(long_hsl, kf, equity);
-            try_restart_hsl(short_hsl, kf, equity);
+            if (hsl_update_valid) {
+                try_restart_hsl(long_hsl, kf, equity);
+                try_restart_hsl(short_hsl, kf, equity);
+            }
         }
         bool active = eq_started && alive && valid;
         if (active) {

--- a/passivbot-rust/src/gpu/mps_hsl_common.metal
+++ b/passivbot-rust/src/gpu/mps_hsl_common.metal
@@ -390,6 +390,51 @@ inline void update_hsl(
     );
 }
 
+// Fused long+short kernels share account PnL and flatness in unified mode,
+// while pside and single-coin coin modes retain directional scope.
+inline bool update_dual_side_hsl(
+    thread HslState& long_hsl,
+    thread HslState& short_hsl,
+    float balance,
+    float starting_balance,
+    float realized_pnl_total,
+    float realized_pnl_long,
+    float realized_pnl_short,
+    float unrealized_pnl_long,
+    float unrealized_pnl_short,
+    bool has_position_long,
+    bool has_position_short,
+    bool has_blocking_orders_long,
+    bool has_blocking_orders_short,
+    float kf,
+    float interval_ms
+) {
+    if (long_hsl.signal_mode != short_hsl.signal_mode) return false;
+    const bool unified = long_hsl.signal_mode == HSL_SIGNAL_UNIFIED;
+    const bool shared_has_position = has_position_long || has_position_short;
+    const bool shared_has_blocking_orders = has_blocking_orders_long
+        || has_blocking_orders_short;
+    update_hsl(
+        long_hsl, balance, starting_balance,
+        unified ? realized_pnl_total : realized_pnl_long,
+        unified ? unrealized_pnl_long + unrealized_pnl_short
+            : unrealized_pnl_long,
+        unified ? shared_has_position : has_position_long,
+        unified ? shared_has_blocking_orders : has_blocking_orders_long,
+        kf, interval_ms
+    );
+    update_hsl(
+        short_hsl, balance, starting_balance,
+        unified ? realized_pnl_total : realized_pnl_short,
+        unified ? unrealized_pnl_long + unrealized_pnl_short
+            : unrealized_pnl_short,
+        unified ? shared_has_position : has_position_short,
+        unified ? shared_has_blocking_orders : has_blocking_orders_short,
+        kf, interval_ms
+    );
+    return true;
+}
+
 inline void try_restart_hsl(thread HslState& h, float kf, float current_equity) {
     if (!h.enabled || !h.halted || h.no_restart_latched
         || h.cooldown_until_k < 0.0f || kf < h.cooldown_until_k) return;

--- a/passivbot-rust/src/gpu/mps_multicoin_common.metal
+++ b/passivbot-rust/src/gpu/mps_multicoin_common.metal
@@ -205,37 +205,15 @@ inline bool update_joint_pside_hsl(
     if (long_hsl.signal_mode == HSL_SIGNAL_COIN
         || short_hsl.signal_mode == HSL_SIGNAL_COIN
         || long_hsl.signal_mode != short_hsl.signal_mode) return false;
-    const bool unified = long_hsl.signal_mode == HSL_SIGNAL_UNIFIED;
-    const bool shared_has_position = has_position_long || has_position_short;
-    const bool shared_has_blocking_orders = has_blocking_orders_long
-        || has_blocking_orders_short;
-    update_hsl(
-        long_hsl,
-        account.balance,
-        starting_balance,
-        joint_hsl_realized_pnl(account, unified, true),
-        joint_hsl_unrealized_pnl(
-            unrealized_pnl_long, unrealized_pnl_short, unified, true
-        ),
-        unified ? shared_has_position : has_position_long,
-        unified ? shared_has_blocking_orders : has_blocking_orders_long,
-        kf,
-        interval_ms
+    return update_dual_side_hsl(
+        long_hsl, short_hsl, account.balance, starting_balance,
+        account.realized_pnl_total,
+        account.realized_pnl_long, account.realized_pnl_short,
+        unrealized_pnl_long, unrealized_pnl_short,
+        has_position_long, has_position_short,
+        has_blocking_orders_long, has_blocking_orders_short,
+        kf, interval_ms
     );
-    update_hsl(
-        short_hsl,
-        account.balance,
-        starting_balance,
-        joint_hsl_realized_pnl(account, unified, false),
-        joint_hsl_unrealized_pnl(
-            unrealized_pnl_long, unrealized_pnl_short, unified, false
-        ),
-        unified ? shared_has_position : has_position_short,
-        unified ? shared_has_blocking_orders : has_blocking_orders_short,
-        kf,
-        interval_ms
-    );
-    return true;
 }
 
 inline void try_restart_joint_pside_hsl(

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -2515,26 +2515,14 @@ inline void passivbot_single_coin_impl(
                 short_side.entry_qty > 0.0f || short_side.close_qty > 0.0f
                     || short_side.secondary_close_qty > 0.0f
             );
-            float total_unreal = long_unreal + short_unreal;
-            float long_hsl_realized = long_hsl.signal_mode == HSL_SIGNAL_UNIFIED
-                ? realized_pnl_cumsum_last : realized_pnl_cumsum_long;
-            float short_hsl_realized = short_hsl.signal_mode == HSL_SIGNAL_UNIFIED
-                ? realized_pnl_cumsum_last : realized_pnl_cumsum_short;
-            float long_hsl_unreal = long_hsl.signal_mode == HSL_SIGNAL_UNIFIED
-                ? total_unreal : long_unreal;
-            float short_hsl_unreal = short_hsl.signal_mode == HSL_SIGNAL_UNIFIED
-                ? total_unreal : short_unreal;
-            update_hsl(
-                long_hsl, balance, starting_balance,
-                long_hsl_realized,
-                long_hsl_unreal, long_side.psize > 0.0f,
-                long_blocking_orders, kf, interval_ms
-            );
-            update_hsl(
-                short_hsl, balance, starting_balance,
-                short_hsl_realized,
-                short_hsl_unreal, short_side.psize > 0.0f,
-                short_blocking_orders, kf, interval_ms
+            update_dual_side_hsl(
+                long_hsl, short_hsl, balance, starting_balance,
+                realized_pnl_cumsum_last,
+                realized_pnl_cumsum_long, realized_pnl_cumsum_short,
+                long_unreal, short_unreal,
+                long_side.psize > 0.0f, short_side.psize > 0.0f,
+                long_blocking_orders, short_blocking_orders,
+                kf, interval_ms
             );
             if (long_hsl.enabled || short_hsl.enabled) {
                 int hsl_tier = max(long_hsl.tier, short_hsl.tier);

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -1111,8 +1111,9 @@ inline void passivbot_single_coin_impl(
     TmSide short_side = load_side(params, po + SIDE_PARAMS, seed_close);
     HslState long_hsl = load_hsl(params, po, 40);
     HslState short_hsl = load_hsl(params, po + SIDE_PARAMS, 40);
+    const bool hsl_modes_valid = long_hsl.signal_mode == short_hsl.signal_mode;
 
-    float balance = starting_balance;
+    float balance = hsl_modes_valid ? starting_balance : 0.0f;
     float realized_pnl_cumsum_last = 0.0f;
     float realized_pnl_cumsum_max = 0.0f;
     float realized_pnl_cumsum_long = 0.0f;
@@ -1131,8 +1132,8 @@ inline void passivbot_single_coin_impl(
     float fill_count_long = 0.0f;
     float fills_active_days_count = 0.0f;
     int last_active_fill_day = -1;
-    bool alive = true;
-    int liq_day = -1;
+    bool alive = hsl_modes_valid;
+    int liq_day = hsl_modes_valid ? -1 : 0;
     float held_max_min = 0.0f;
     float held_sum_min = 0.0f;
     float held_count = 0.0f;
@@ -2515,7 +2516,7 @@ inline void passivbot_single_coin_impl(
                 short_side.entry_qty > 0.0f || short_side.close_qty > 0.0f
                     || short_side.secondary_close_qty > 0.0f
             );
-            update_dual_side_hsl(
+            bool hsl_update_valid = update_dual_side_hsl(
                 long_hsl, short_hsl, balance, starting_balance,
                 realized_pnl_cumsum_last,
                 realized_pnl_cumsum_long, realized_pnl_cumsum_short,
@@ -2524,15 +2525,22 @@ inline void passivbot_single_coin_impl(
                 long_blocking_orders, short_blocking_orders,
                 kf, interval_ms
             );
-            if (long_hsl.enabled || short_hsl.enabled) {
+            if (!hsl_update_valid) {
+                balance = 0.0f;
+                alive = false;
+                liq_day = di;
+            }
+            if (hsl_update_valid && (long_hsl.enabled || short_hsl.enabled)) {
                 int hsl_tier = max(long_hsl.tier, short_hsl.tier);
                 hsl_tier_samples_total += 1.0f;
                 hsl_tier_samples_yellow += hsl_tier == 1 ? 1.0f : 0.0f;
                 hsl_tier_samples_orange += hsl_tier == 2 ? 1.0f : 0.0f;
                 hsl_tier_samples_red += hsl_tier == 3 ? 1.0f : 0.0f;
             }
-            try_restart_hsl(long_hsl, kf, equity);
-            try_restart_hsl(short_hsl, kf, equity);
+            if (hsl_update_valid) {
+                try_restart_hsl(long_hsl, kf, equity);
+                try_restart_hsl(short_hsl, kf, equity);
+            }
         }
         bool active = eq_started && alive && valid;
         if (active) {

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -28,12 +28,6 @@ def validate_hsl_signal_topology(
                 "unified requires one cross-side episode controller"
             )
         return
-    if enabled_side_count > 1 and signal_mode == "unified":
-        raise ValueError(
-            "GPU dual-side single-coin HSL currently supports only coin or "
-            "pside signal mode; unified remains fail closed pending an "
-            "account-wide exact-Rust flatten contract"
-        )
 
 
 def validate_single_coin_hsl_signal_topology(

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1502,26 +1502,14 @@ def test_gpu_hsl_fails_closed_for_unknown_panic_close_type():
         _validate_scope(config, _Evaluator())
 
 
-@pytest.mark.parametrize("signal_mode", ["coin", "pside"])
-def test_gpu_hsl_accepts_dual_side_single_coin_scoped_modes(signal_mode):
+@pytest.mark.parametrize("signal_mode", ["unified", "coin", "pside"])
+def test_gpu_hsl_accepts_dual_side_single_coin_signal_modes(signal_mode):
     config = _directional_ema_config(long_enabled=True, short_enabled=True)
     config["bot"]["long"]["hsl"]["enabled"] = True
     config["bot"]["short"]["hsl"]["enabled"] = True
     config["live"]["hsl_signal_mode"] = signal_mode
 
     assert _validate_scope(config, _Evaluator()) == "bybit"
-
-
-def test_gpu_hsl_fails_closed_for_dual_side_single_coin_unified_mode():
-    config = _directional_ema_config(long_enabled=True, short_enabled=True)
-    config["bot"]["long"]["hsl"]["enabled"] = True
-    config["bot"]["short"]["hsl"]["enabled"] = True
-    config["live"]["hsl_signal_mode"] = "unified"
-
-    with pytest.raises(ValueError, match="account-wide exact-Rust flatten contract"):
-        _validate_scope(config, _Evaluator())
-
-
 @pytest.mark.parametrize("signal_mode", ["unified", "pside", "coin"])
 def test_gpu_hsl_accepts_one_sided_multicoin_signal_modes(signal_mode):
     config = _long_only_ema_config()

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -2749,6 +2749,7 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
         )
         keys = EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS
         runner_cls = MpsEmaAnchorRunner
+    baseline[keys.index("hsl_signal_mode")] = 2.0
     hsl = list(baseline)
     for key, value in {
         "hsl_enabled": 1.0,
@@ -2902,8 +2903,8 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
-@pytest.mark.parametrize("signal_mode", ["pside", "coin"])
-def test_mps_dual_side_single_coin_hsl_keeps_directional_state_separate(
+@pytest.mark.parametrize("signal_mode", ["unified", "pside", "coin"])
+def test_mps_dual_side_single_coin_hsl_respects_signal_scope(
     strategy_kind, signal_mode
 ):
     count = 48
@@ -2971,15 +2972,30 @@ def test_mps_dual_side_single_coin_hsl_keeps_directional_state_separate(
         "hsl_tier_ratio_yellow": 0.5,
         "hsl_tier_ratio_orange": 0.75,
         "hsl_orange_graceful_stop": 0.0,
-        "hsl_signal_mode": 1.0 if signal_mode == "pside" else 2.0,
+        "hsl_signal_mode": {"unified": 0.0, "pside": 1.0, "coin": 2.0}[
+            signal_mode
+        ],
         "hsl_slot_count": 1.0,
     }.items():
         hsl[keys.index(key)] = value
+    inactive = list(baseline)
+    inactive[keys.index("hsl_signal_mode")] = hsl[
+        keys.index("hsl_signal_mode")
+    ]
+    long_hsl = list(hsl)
+    short_hsl = list(hsl)
+    if signal_mode == "unified":
+        qty_key = (
+            "entry_initial_qty_pct"
+            if strategy_kind == "trailing_martingale"
+            else "base_qty_pct"
+        )
+        short_hsl[keys.index(qty_key)] = 0.1
     rows = np.asarray(
         [
-            hsl + baseline,
-            baseline + hsl,
-            hsl + hsl,
+            long_hsl + inactive,
+            inactive + short_hsl,
+            long_hsl + short_hsl,
         ],
         dtype=np.float64,
     )
@@ -2992,14 +3008,24 @@ def test_mps_dual_side_single_coin_hsl_keeps_directional_state_separate(
     ).run(rows)
     torch.mps.synchronize()
 
-    assert output["hsl_triggers_long"][0].item() == 1.0
+    assert output["hsl_triggers_long"][0].item() == (
+        0.0 if signal_mode == "unified" else 1.0
+    )
     assert output["hsl_triggers_short"][0].item() == 0.0
     assert output["hsl_triggers_long"][1].item() == 0.0
-    assert output["hsl_triggers_short"][1].item() == 1.0
+    assert output["hsl_triggers_short"][1].item() == (
+        0.0 if signal_mode == "unified" else 1.0
+    )
     assert output["hsl_triggers_long"][2].item() == 1.0
     assert output["hsl_triggers_short"][2].item() == 1.0
     assert output["hsl_trigger_drawdown_count"][2].item() == 2.0
-    assert output["hsl_panic_loss_drawdown_count"][2].item() == 2.0
+    if signal_mode == "unified":
+        assert output["hsl_panic_loss_drawdown_count"][2].item() >= 1.0
+    else:
+        assert output["hsl_panic_loss_drawdown_count"][2].item() == 2.0
+    if signal_mode == "unified":
+        assert output["short_psize"][0].item() > 0.0
+        assert output["psize"][1].item() > 0.0
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -2991,11 +2991,16 @@ def test_mps_dual_side_single_coin_hsl_respects_signal_scope(
             else "base_qty_pct"
         )
         short_hsl[keys.index(qty_key)] = 0.1
+    mismatched_short_hsl = list(short_hsl)
+    mismatched_short_hsl[keys.index("hsl_signal_mode")] = (
+        hsl[keys.index("hsl_signal_mode")] + 1.0
+    ) % 3.0
     rows = np.asarray(
         [
             long_hsl + inactive,
             inactive + short_hsl,
             long_hsl + short_hsl,
+            long_hsl + mismatched_short_hsl,
         ],
         dtype=np.float64,
     )
@@ -3026,6 +3031,10 @@ def test_mps_dual_side_single_coin_hsl_respects_signal_scope(
     if signal_mode == "unified":
         assert output["short_psize"][0].item() > 0.0
         assert output["psize"][1].item() > 0.0
+    assert not output["alive"][3].item()
+    assert output["liq_step"][3].item() == 0
+    assert output["balance"][3].item() == 0.0
+    assert output["fill_count"][3].item() == 0.0
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -703,18 +703,13 @@ def test_single_coin_hsl_packs_explicit_signal_mode_ids(signal_mode, expected_id
     assert packed["hsl_signal_mode"] == expected_id
 
 
-@pytest.mark.parametrize("signal_mode", ["coin", "pside"])
-def test_dual_side_single_coin_hsl_accepts_scoped_signal_modes(signal_mode):
+@pytest.mark.parametrize("signal_mode", ["unified", "coin", "pside"])
+def test_dual_side_single_coin_hsl_accepts_all_signal_modes(signal_mode):
     validate_single_coin_hsl_signal_topology(signal_mode, enabled_side_count=2)
 
 
 def test_one_sided_single_coin_hsl_accepts_unified_signal_mode():
     validate_single_coin_hsl_signal_topology("unified", enabled_side_count=1)
-
-
-def test_dual_side_single_coin_hsl_rejects_unified_signal_mode():
-    with pytest.raises(ValueError, match="account-wide exact-Rust flatten contract"):
-        validate_single_coin_hsl_signal_topology("unified", enabled_side_count=2)
 
 
 def test_single_coin_hsl_rejects_unknown_signal_mode():


### PR DESCRIPTION
## Summary
- enable dual-side single-coin `unified` HSL for EMA Anchor and Trailing Martingale on Apple MPS
- centralize fused long+short signal and scope routing in the shared Rust-owned Metal HSL controller
- feed both unified controllers account-wide realized/unrealized PnL and require positions/blocking orders on both sides to be flat
- preserve directional `pside` and single-coin `coin` behavior, with mismatched packed side modes failing closed
- update capability tests and HSL documentation; dual-side multi-coin `coin`/`unified` remain fail closed

Exact Rust remains authoritative; CPU optimization behavior is unchanged.

## Validation
- physical Apple MPS: 268 passed (`tests/optimization/test_gpu_mps.py`)
- focused physical unified/pside/coin scope matrix and asymmetric probe: 7 passed
- Rust: 265 passed (`./cargotest.sh --lib -q`)
- optimizer: 229 passed
- GPU service/backend: 474 passed
- `cargo check`
- rebuilt and stamped the Python Rust extension from the exact branch head