### PR TITLE
refactor(gpu): encapsulate EMA multicoin side state

### DIFF
--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -313,6 +313,13 @@ mod tests {
         assert!(source.contains("constant int DAILY_COLS = 9"));
         assert!(source.contains("day_min_balance"));
         assert!(source.contains("constant int SCALAR_COLS = 57"));
+        assert_eq!(source.matches("struct EmaMulticoinSideState").count(), 1);
+        assert!(source.contains("EmaMulticoinSideState side"));
+        assert!(source.contains("thread HslState& hsl = side.hsl"));
+        assert!(source.contains("thread HslState* coin_hsl = side.coin_hsl"));
+        assert!(source.contains("thread float* psize = side.psize"));
+        assert!(source.contains("thread int* entry_tick = side.entry_tick"));
+        assert!(source.contains("thread bool* selected = side.selected"));
         assert!(source.contains("load_hsl(params, po, 31)"));
         assert!(source.contains("write_one_side_hsl_outputs("));
         assert!(source.contains("record_hsl_panic_fill("));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -102,6 +102,54 @@ inline float finalized_reducer_qty_with_ordinary(
     return reducer_qty;
 }
 
+// One complete directional EMA portfolio. Keeping the mutable per-coin state
+// behind one thread-local value lets a future fused kernel own long and short
+// portfolios concurrently without changing the proven one-side candle loop.
+struct EmaMulticoinSideState {
+    HslState hsl;
+    HslState coin_hsl[MAX_COINS];
+    ulong coin_hsl_entry_blocked_mask;
+    float ema0[MAX_COINS];
+    float ema1[MAX_COINS];
+    float ema2[MAX_COINS];
+    float volatility_1m[MAX_COINS];
+    float volatility_1h[MAX_COINS];
+    float forager_volume[MAX_COINS];
+    float forager_volatility[MAX_COINS];
+    float hour_high[MAX_COINS];
+    float hour_low[MAX_COINS];
+    float psize[MAX_COINS];
+    float pprice[MAX_COINS];
+    float last_increase_k[MAX_COINS];
+    float entry_qty[MAX_COINS];
+    float close_qty[MAX_COINS];
+    float secondary_close_qty[MAX_COINS];
+    float twel_close_qty[MAX_COINS];
+    float unstuck_close_qty[MAX_COINS];
+    float position_open_k[MAX_COINS];
+    float position_last_fill_k[MAX_COINS];
+    float score[MAX_COINS];
+    float contribution[MAX_COINS];
+    float minimum_entry[MAX_COINS];
+    int entry_tick[MAX_COINS];
+    int close_tick[MAX_COINS];
+    int secondary_close_tick[MAX_COINS];
+    int twel_close_tick[MAX_COINS];
+    int unstuck_close_tick[MAX_COINS];
+    bool close_is_unstuck_reducer[MAX_COINS];
+    bool close_is_hsl_panic[MAX_COINS];
+    bool selected[MAX_COINS];
+    bool incumbent[MAX_COINS];
+    bool survivor[MAX_COINS];
+    bool entry_candidate[MAX_COINS];
+    float alpha0_coin[MAX_COINS];
+    float alpha1_coin[MAX_COINS];
+    float alpha2_coin[MAX_COINS];
+    float alpha_1h_coin[MAX_COINS];
+    float alpha_1m_coin[MAX_COINS];
+    float coin_realized_pnl[MAX_COINS];
+};
+
 inline void passivbot_ema_anchor_multicoin_impl(
     constant float* bars,
     constant int* fill_ticks,
@@ -179,10 +227,13 @@ inline void passivbot_ema_anchor_multicoin_impl(
     const float unstuck_ema_dist = params[po + 28];
     const float unstuck_loss_allowance_pct = params[po + 29];
     const float unstuck_threshold = params[po + 30];
-    HslState hsl = load_hsl(params, po, 31);
+    EmaMulticoinSideState side;
+    thread HslState& hsl = side.hsl;
+    hsl = load_hsl(params, po, 31);
     const bool coin_hsl_mode = hsl.signal_mode == HSL_SIGNAL_COIN;
-    HslState coin_hsl[MAX_COINS];
-    ulong coin_hsl_entry_blocked_mask = 0ul;
+    thread HslState* coin_hsl = side.coin_hsl;
+    thread ulong& coin_hsl_entry_blocked_mask = side.coin_hsl_entry_blocked_mask;
+    coin_hsl_entry_blocked_mask = 0ul;
     const float weight_sum = w_volume + w_ready + w_volatility;
     if (weight_sum > 0.0f) {
         w_volume /= weight_sum;
@@ -208,45 +259,45 @@ inline void passivbot_ema_anchor_multicoin_impl(
     const bool hsl_panic_market = run_settings[8] > 0.5f;
     const float log_bin_scale = 127.0f / log(4000001.0f);
 
-    float ema0[MAX_COINS];
-    float ema1[MAX_COINS];
-    float ema2[MAX_COINS];
-    float volatility_1m[MAX_COINS];
-    float volatility_1h[MAX_COINS];
-    float forager_volume[MAX_COINS];
-    float forager_volatility[MAX_COINS];
-    float hour_high[MAX_COINS];
-    float hour_low[MAX_COINS];
-    float psize[MAX_COINS];
-    float pprice[MAX_COINS];
-    float last_increase_k[MAX_COINS];
-    float entry_qty[MAX_COINS];
-    float close_qty[MAX_COINS];
-    float secondary_close_qty[MAX_COINS];
-    float twel_close_qty[MAX_COINS];
-    float unstuck_close_qty[MAX_COINS];
-    float position_open_k[MAX_COINS];
-    float position_last_fill_k[MAX_COINS];
-    float score[MAX_COINS];
-    float contribution[MAX_COINS];
-    float minimum_entry[MAX_COINS];
-    int entry_tick[MAX_COINS];
-    int close_tick[MAX_COINS];
-    int secondary_close_tick[MAX_COINS];
-    int twel_close_tick[MAX_COINS];
-    int unstuck_close_tick[MAX_COINS];
-    bool close_is_unstuck_reducer[MAX_COINS];
-    bool close_is_hsl_panic[MAX_COINS];
-    bool selected[MAX_COINS];
-    bool incumbent[MAX_COINS];
-    bool survivor[MAX_COINS];
-    bool entry_candidate[MAX_COINS];
-    float alpha0_coin[MAX_COINS];
-    float alpha1_coin[MAX_COINS];
-    float alpha2_coin[MAX_COINS];
-    float alpha_1h_coin[MAX_COINS];
-    float alpha_1m_coin[MAX_COINS];
-    float coin_realized_pnl[MAX_COINS];
+    thread float* ema0 = side.ema0;
+    thread float* ema1 = side.ema1;
+    thread float* ema2 = side.ema2;
+    thread float* volatility_1m = side.volatility_1m;
+    thread float* volatility_1h = side.volatility_1h;
+    thread float* forager_volume = side.forager_volume;
+    thread float* forager_volatility = side.forager_volatility;
+    thread float* hour_high = side.hour_high;
+    thread float* hour_low = side.hour_low;
+    thread float* psize = side.psize;
+    thread float* pprice = side.pprice;
+    thread float* last_increase_k = side.last_increase_k;
+    thread float* entry_qty = side.entry_qty;
+    thread float* close_qty = side.close_qty;
+    thread float* secondary_close_qty = side.secondary_close_qty;
+    thread float* twel_close_qty = side.twel_close_qty;
+    thread float* unstuck_close_qty = side.unstuck_close_qty;
+    thread float* position_open_k = side.position_open_k;
+    thread float* position_last_fill_k = side.position_last_fill_k;
+    thread float* score = side.score;
+    thread float* contribution = side.contribution;
+    thread float* minimum_entry = side.minimum_entry;
+    thread int* entry_tick = side.entry_tick;
+    thread int* close_tick = side.close_tick;
+    thread int* secondary_close_tick = side.secondary_close_tick;
+    thread int* twel_close_tick = side.twel_close_tick;
+    thread int* unstuck_close_tick = side.unstuck_close_tick;
+    thread bool* close_is_unstuck_reducer = side.close_is_unstuck_reducer;
+    thread bool* close_is_hsl_panic = side.close_is_hsl_panic;
+    thread bool* selected = side.selected;
+    thread bool* incumbent = side.incumbent;
+    thread bool* survivor = side.survivor;
+    thread bool* entry_candidate = side.entry_candidate;
+    thread float* alpha0_coin = side.alpha0_coin;
+    thread float* alpha1_coin = side.alpha1_coin;
+    thread float* alpha2_coin = side.alpha2_coin;
+    thread float* alpha_1h_coin = side.alpha_1h_coin;
+    thread float* alpha_1m_coin = side.alpha_1m_coin;
+    thread float* coin_realized_pnl = side.coin_realized_pnl;
 
     for (int c = 0; c < MAX_COINS; ++c) {
         float seed_close = c < C ? coin_settings[c * COIN_COLS + 9] : 0.0f;

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -255,6 +255,60 @@ kernel void passivbot_joint_pside_hsl_contract_probe(
     np.testing.assert_allclose(values[:, 54:58], [[0.1, 0.6, 0.2, 4.0]] * 5)
 
 
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_ema_multicoin_side_states_are_isolated_for_fused_execution():
+    import passivbot_rust
+
+    probe_kernel = r"""
+kernel void passivbot_ema_multicoin_side_state_isolation_probe(
+    device float* output,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    EmaMulticoinSideState long_side;
+    EmaMulticoinSideState short_side;
+    long_side.psize[0] = 1.0f;
+    short_side.psize[0] = 2.0f;
+    long_side.entry_tick[0] = 3;
+    short_side.entry_tick[0] = 4;
+    long_side.selected[0] = true;
+    short_side.selected[0] = false;
+    long_side.hsl.enabled = true;
+    short_side.hsl.enabled = false;
+    long_side.coin_hsl[0].triggers = 5.0f;
+    short_side.coin_hsl[0].triggers = 6.0f;
+    long_side.coin_hsl_entry_blocked_mask = 7ul;
+    short_side.coin_hsl_entry_blocked_mask = 8ul;
+    output[0] = long_side.psize[0];
+    output[1] = short_side.psize[0];
+    output[2] = float(long_side.entry_tick[0]);
+    output[3] = float(short_side.entry_tick[0]);
+    output[4] = long_side.selected[0] && !short_side.selected[0] ? 1.0f : 0.0f;
+    output[5] = long_side.hsl.enabled && !short_side.hsl.enabled ? 1.0f : 0.0f;
+    output[6] = long_side.coin_hsl[0].triggers
+        + short_side.coin_hsl[0].triggers;
+    output[7] = float(
+        long_side.coin_hsl_entry_blocked_mask
+            + short_side.coin_hsl_entry_blocked_mask
+    );
+}
+"""
+
+    output = torch.zeros(8, dtype=torch.float32, device="mps")
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_ema_anchor_multicoin_source_py() + probe_kernel
+    )
+    library.passivbot_ema_multicoin_side_state_isolation_probe(
+        output,
+        threads=(1, 1, 1),
+    )
+    torch.mps.synchronize()
+
+    assert output.cpu().tolist() == [1.0, 2.0, 3.0, 4.0, 1.0, 1.0, 11.0, 15.0]
+
+
 def _single_coin_exposure_fields(
     *, allowance_pct=0.0, legacy_raw=False, entry_gate=True, threshold=1.0
 ):


### PR DESCRIPTION
## Summary

- move the production EMA multicoin kernel's complete mutable directional portfolio into `EmaMulticoinSideState`
- preserve the proven one-side candle loop through typed thread-local aliases
- add a physical Metal probe that instantiates long and short states concurrently and proves isolation across positions, orders, selection flags, HSL controllers, per-coin controllers, and blocked masks

## Scope

This is a behavior-preserving prerequisite for a fused dual-multicoin EMA kernel. It does not relax current optimizer gates. The next slice can instantiate two production-shaped side states in one candidate thread and interleave them around the existing shared account/HSL primitives.

## Validation

- `./cargotest.sh --lib` — 265 passed
- `cargo check`
- `pytest -q tests/optimization/test_gpu_service.py tests/optimization/test_gpu_backend.py` — 474 passed
- `pytest -q tests/optimization/test_optimize.py` — 229 passed
- physical Apple MPS: `pytest -q tests/optimization/test_gpu_mps.py` — 269 passed
- rebuilt and source-stamped the exact-branch Rust extension before MPS validation