### PR TITLE
feat(gpu): add EMA multicoin dual HSL phase

### DIFF
--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -326,6 +326,10 @@ mod tests {
         assert!(source.contains("update_ema_multicoin_side_indicators("));
         assert!(source.contains("count_ema_multicoin_tradable_coins("));
         assert!(source.contains("ema_multicoin_side_has_position("));
+        assert!(source.contains("ema_multicoin_side_has_blocking_orders("));
+        assert!(source.contains("update_ema_multicoin_dual_side_hsl("));
+        assert!(source.contains("if (long_side.hsl.signal_mode != short_side.hsl.signal_mode)"));
+        assert!(source.contains("update_joint_pside_hsl("));
         assert!(source.contains("update_ema_multicoin_side_selection("));
         assert!(source.contains("generate_ema_multicoin_side_orders("));
         assert!(source.contains(

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -326,6 +326,7 @@ mod tests {
         assert!(source.contains("update_ema_multicoin_side_indicators("));
         assert!(source.contains("count_ema_multicoin_tradable_coins("));
         assert!(source.contains("ema_multicoin_side_has_position("));
+        assert!(source.contains("ema_multicoin_side_held_marks_are_valid("));
         assert!(source.contains("ema_multicoin_side_has_blocking_orders("));
         assert!(source.contains("update_ema_multicoin_dual_side_hsl("));
         assert!(source.contains("if (long_side.hsl.signal_mode != short_side.hsl.signal_mode)"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -538,6 +538,26 @@ inline bool ema_multicoin_side_has_position(
     return false;
 }
 
+inline bool ema_multicoin_side_held_marks_are_valid(
+    thread const EmaMulticoinSideState& side,
+    constant float* bars,
+    constant float* coin_settings,
+    int k,
+    int coin_count
+) {
+    for (int c = 0; c < coin_count; ++c) {
+        if (!(side.psize[c] > 0.0f)) continue;
+        int coin_offset = c * COIN_COLS;
+        int bar_offset = (k * coin_count + c) * 4;
+        if (!finite_positive(side.pprice[c])
+            || !finite_positive(bars[bar_offset + 2])
+            || !finite_positive(coin_settings[coin_offset + 4])) {
+            return false;
+        }
+    }
+    return true;
+}
+
 inline bool ema_multicoin_side_has_blocking_orders(
     thread EmaMulticoinSideState& side,
     thread const EmaMulticoinSideConfig& config,
@@ -591,6 +611,13 @@ inline bool update_ema_multicoin_dual_side_hsl(
     if (long_config.coin_hsl_mode && (
             long_effective_n_positions <= 0
                 || short_effective_n_positions <= 0
+        )) {
+        return false;
+    }
+    if (!ema_multicoin_side_held_marks_are_valid(
+            long_side, bars, coin_settings, k, coin_count
+        ) || !ema_multicoin_side_held_marks_are_valid(
+            short_side, bars, coin_settings, k, coin_count
         )) {
         return false;
     }

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -538,6 +538,172 @@ inline bool ema_multicoin_side_has_position(
     return false;
 }
 
+inline bool ema_multicoin_side_has_blocking_orders(
+    thread EmaMulticoinSideState& side,
+    thread const EmaMulticoinSideConfig& config,
+    int coin_count
+) {
+    bool side_has_position = config.coin_hsl_mode
+        ? false : ema_multicoin_side_has_position(side, coin_count);
+    int side_mode = config.coin_hsl_mode
+        ? 0 : hsl_mode(side.hsl, side_has_position);
+    for (int c = 0; c < coin_count; ++c) {
+        int mode = config.coin_hsl_mode
+            ? hsl_mode(side.coin_hsl[c], side.psize[c] > 0.0f)
+            : side_mode;
+        if (mode != 3 && (
+                side.entry_qty[c] > 0.0f
+                    || side.close_qty[c] > 0.0f
+                    || side.secondary_close_qty[c] > 0.0f
+            )) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Advance the complete dual-side HSL topology after both directional order
+// phases have run against the same account. Unified and pside modes use the
+// shared account controller. Coin mode keeps one controller per coin/pside,
+// while its sampled tier is the maximum across the full portfolio, matching
+// exact Rust reporting. Mixed signal modes fail closed.
+inline bool update_ema_multicoin_dual_side_hsl(
+    thread EmaMulticoinSideState& long_side,
+    thread const EmaMulticoinSideConfig& long_config,
+    int long_effective_n_positions,
+    thread EmaMulticoinSideState& short_side,
+    thread const EmaMulticoinSideConfig& short_config,
+    int short_effective_n_positions,
+    thread const JointPortfolioAccount& account,
+    constant float* bars,
+    constant float* coin_settings,
+    int k,
+    int coin_count,
+    float starting_balance,
+    float interval_ms,
+    thread bool& sample_enabled,
+    thread int& sampled_tier
+) {
+    sample_enabled = false;
+    sampled_tier = 0;
+    if (long_side.hsl.signal_mode != short_side.hsl.signal_mode) return false;
+    if (long_config.coin_hsl_mode != short_config.coin_hsl_mode) return false;
+    if (long_config.coin_hsl_mode && (
+            long_effective_n_positions <= 0
+                || short_effective_n_positions <= 0
+        )) {
+        return false;
+    }
+
+    float long_unrealized = accumulate_ema_multicoin_side_unrealized_pnl(
+        long_side, bars, coin_settings, k, coin_count, false, 0.0f
+    );
+    float short_unrealized = accumulate_ema_multicoin_side_unrealized_pnl(
+        short_side, bars, coin_settings, k, coin_count, true, 0.0f
+    );
+    bool long_has_position = ema_multicoin_side_has_position(
+        long_side, coin_count
+    );
+    bool short_has_position = ema_multicoin_side_has_position(
+        short_side, coin_count
+    );
+    bool long_has_blocking_orders = ema_multicoin_side_has_blocking_orders(
+        long_side, long_config, coin_count
+    );
+    bool short_has_blocking_orders = ema_multicoin_side_has_blocking_orders(
+        short_side, short_config, coin_count
+    );
+
+    if (long_config.coin_hsl_mode) {
+        float portfolio_equity = joint_portfolio_equity(
+            account, long_unrealized, short_unrealized
+        );
+        for (int c = 0; c < coin_count; ++c) {
+            int coin_offset = c * COIN_COLS;
+            int bar_offset = (k * coin_count + c) * 4;
+            float close = bars[bar_offset + 2];
+            float c_mult = coin_settings[coin_offset + 4];
+            float long_coin_unrealized = long_side.psize[c] > 0.0f
+                    && finite_positive(close)
+                ? long_side.psize[c] * c_mult
+                    * (close - long_side.pprice[c])
+                : 0.0f;
+            float short_coin_unrealized = short_side.psize[c] > 0.0f
+                    && finite_positive(close)
+                ? short_side.psize[c] * c_mult
+                    * (short_side.pprice[c] - close)
+                : 0.0f;
+            int long_mode = hsl_mode(
+                long_side.coin_hsl[c], long_side.psize[c] > 0.0f
+            );
+            int short_mode = hsl_mode(
+                short_side.coin_hsl[c], short_side.psize[c] > 0.0f
+            );
+            bool long_coin_has_blocking_orders = long_mode != 3 && (
+                long_side.entry_qty[c] > 0.0f
+                    || long_side.close_qty[c] > 0.0f
+                    || long_side.secondary_close_qty[c] > 0.0f
+            );
+            bool short_coin_has_blocking_orders = short_mode != 3 && (
+                short_side.entry_qty[c] > 0.0f
+                    || short_side.close_qty[c] > 0.0f
+                    || short_side.secondary_close_qty[c] > 0.0f
+            );
+            long_side.coin_hsl[c].slot_count = float(
+                long_effective_n_positions
+            );
+            short_side.coin_hsl[c].slot_count = float(
+                short_effective_n_positions
+            );
+            update_hsl(
+                long_side.coin_hsl[c], account.balance, starting_balance,
+                long_side.coin_realized_pnl[c], long_coin_unrealized,
+                long_side.psize[c] > 0.0f,
+                long_coin_has_blocking_orders, float(k), interval_ms
+            );
+            update_hsl(
+                short_side.coin_hsl[c], account.balance, starting_balance,
+                short_side.coin_realized_pnl[c], short_coin_unrealized,
+                short_side.psize[c] > 0.0f,
+                short_coin_has_blocking_orders, float(k), interval_ms
+            );
+            sample_enabled = sample_enabled
+                || long_side.coin_hsl[c].enabled
+                || short_side.coin_hsl[c].enabled;
+            sampled_tier = max(
+                sampled_tier,
+                max(long_side.coin_hsl[c].tier, short_side.coin_hsl[c].tier)
+            );
+            try_restart_hsl(
+                long_side.coin_hsl[c], float(k), portfolio_equity
+            );
+            try_restart_hsl(
+                short_side.coin_hsl[c], float(k), portfolio_equity
+            );
+        }
+        return true;
+    }
+
+    if (!update_joint_pside_hsl(
+            long_side.hsl, short_side.hsl, account, starting_balance,
+            long_unrealized, short_unrealized,
+            long_has_position, short_has_position,
+            long_has_blocking_orders, short_has_blocking_orders,
+            float(k), interval_ms
+        )) {
+        return false;
+    }
+    sample_enabled = long_side.hsl.enabled || short_side.hsl.enabled;
+    sampled_tier = joint_pside_hsl_global_tier(
+        long_side.hsl, short_side.hsl
+    );
+    try_restart_joint_pside_hsl(
+        long_side.hsl, short_side.hsl, account, starting_balance,
+        long_unrealized, short_unrealized, float(k)
+    );
+    return true;
+}
+
 inline void update_ema_multicoin_side_selection(
     thread EmaMulticoinSideState& side,
     thread const EmaMulticoinSideConfig& config,

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -312,6 +312,151 @@ kernel void passivbot_ema_multicoin_side_state_isolation_probe(
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+def test_mps_ema_multicoin_dual_hsl_phase_covers_all_signal_topologies():
+    import passivbot_rust
+
+    probe_kernel = r"""
+kernel void passivbot_ema_multicoin_dual_hsl_phase_probe(
+    constant float* params,
+    constant float* bars,
+    constant float* coin_settings,
+    device float* output,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b >= 5) return;
+    int po = int(b) * 22;
+    EmaMulticoinSideState long_side;
+    EmaMulticoinSideState short_side;
+    EmaMulticoinSideConfig long_config;
+    EmaMulticoinSideConfig short_config;
+    long_side.hsl = load_hsl(params, po, 0);
+    short_side.hsl = load_hsl(params, po + 11, 0);
+    long_config.coin_hsl_mode =
+        long_side.hsl.signal_mode == HSL_SIGNAL_COIN;
+    short_config.coin_hsl_mode =
+        short_side.hsl.signal_mode == HSL_SIGNAL_COIN;
+    long_side.coin_hsl[0] = long_side.hsl;
+    short_side.coin_hsl[0] = short_side.hsl;
+    long_side.coin_realized_pnl[0] = 0.0f;
+    short_side.coin_realized_pnl[0] = 0.0f;
+    long_side.psize[0] = b == 4 ? 1.0f : 0.0f;
+    short_side.psize[0] = 0.0f;
+    long_side.pprice[0] = 100.0f;
+    short_side.pprice[0] = 100.0f;
+    long_side.entry_qty[0] = 0.0f;
+    short_side.entry_qty[0] = 0.0f;
+    long_side.close_qty[0] = 0.0f;
+    short_side.close_qty[0] = 0.0f;
+    long_side.secondary_close_qty[0] = 0.0f;
+    short_side.secondary_close_qty[0] = 0.0f;
+
+    JointPortfolioAccount account = init_joint_portfolio_account(100.0f);
+    account.realized_pnl_total = 0.0f;
+    account.realized_pnl_long = 0.0f;
+    account.realized_pnl_short = 0.0f;
+    account.balance = 100.0f;
+    bool all_valid = true;
+    bool sample_enabled = false;
+    int sampled_tier = 0;
+    float triggers_while_long_open = -1.0f;
+    for (int k = 1; k <= 5; ++k) {
+        if (k == 2) {
+            account.realized_pnl_total = -10.0f;
+            account.realized_pnl_long = -10.0f;
+            account.balance = 90.0f;
+            long_side.coin_realized_pnl[0] = -10.0f;
+        }
+        if (b == 4 && k == 4) long_side.psize[0] = 0.0f;
+        bool valid = update_ema_multicoin_dual_side_hsl(
+            long_side, long_config, 1,
+            short_side, short_config, 1,
+            account, bars, coin_settings, k, 1,
+            100.0f, 60000.0f, sample_enabled, sampled_tier
+        );
+        all_valid = all_valid && valid;
+        if (b == 4 && k == 3) {
+            triggers_while_long_open = long_side.hsl.triggers;
+        }
+    }
+    int oo = int(b) * 12;
+    output[oo + 0] = all_valid ? 1.0f : 0.0f;
+    output[oo + 1] = sample_enabled ? 1.0f : 0.0f;
+    output[oo + 2] = float(sampled_tier);
+    output[oo + 3] = float(long_side.hsl.tier);
+    output[oo + 4] = float(short_side.hsl.tier);
+    output[oo + 5] = long_side.hsl.triggers;
+    output[oo + 6] = short_side.hsl.triggers;
+    output[oo + 7] = float(long_side.coin_hsl[0].tier);
+    output[oo + 8] = float(short_side.coin_hsl[0].tier);
+    output[oo + 9] = long_side.coin_hsl[0].triggers;
+    output[oo + 10] = short_side.coin_hsl[0].triggers;
+    output[oo + 11] = triggers_while_long_open;
+}
+"""
+
+    def controller(mode):
+        return [
+            1.0,
+            0.05,
+            1.0,
+            0.0,
+            1.0,
+            2.0,
+            0.5,
+            0.75,
+            0.0,
+            float(mode),
+            1.0,
+        ]
+
+    params = torch.tensor(
+        [
+            controller(0) + controller(0),
+            controller(1) + controller(1),
+            controller(2) + controller(2),
+            controller(0) + controller(1),
+            controller(0) + controller(0),
+        ],
+        dtype=torch.float32,
+        device="mps",
+    )
+    bars = torch.tensor(
+        [[[100.0, 100.0, 100.0, 0.0]]] * 6,
+        dtype=torch.float32,
+        device="mps",
+    )
+    coin_settings = torch.zeros((1, 12), dtype=torch.float32, device="mps")
+    coin_settings[0, 4] = 1.0
+    output = torch.zeros((5, 12), dtype=torch.float32, device="mps")
+
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_ema_anchor_multicoin_source_py() + probe_kernel
+    )
+    library.passivbot_ema_multicoin_dual_hsl_phase_probe(
+        params, bars, coin_settings, output, threads=(5, 1, 1)
+    )
+    torch.mps.synchronize()
+    values = output.cpu().numpy()
+
+    # Unified mode consumes the shared account signal and requires portfolio
+    # flatness before either controller may halt.
+    assert values[0, :7].tolist() == [1.0, 1.0, 3.0, 3.0, 3.0, 1.0, 1.0]
+    # Pside mode isolates directional strategy PnL.
+    assert values[1, :7].tolist() == [1.0, 1.0, 3.0, 3.0, 0.0, 1.0, 0.0]
+    # Coin mode advances the per-coin controllers, not the pside templates.
+    assert values[2, :7].tolist() == [1.0, 1.0, 3.0, 0.0, 0.0, 0.0, 0.0]
+    assert values[2, 7:11].tolist() == [3.0, 0.0, 1.0, 0.0]
+    # Mixed topologies fail closed without advancing state.
+    assert values[3, :7].tolist() == [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    # One open long position blocks both unified controllers until the whole
+    # account is flat for two consecutive samples.
+    assert values[4, 5:7].tolist() == [1.0, 1.0]
+    assert values[4, 11] == 0.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 def test_mps_ema_multicoin_candle_helpers_advance_independent_sides():
     import passivbot_rust
 

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -319,11 +319,12 @@ def test_mps_ema_multicoin_dual_hsl_phase_covers_all_signal_topologies():
 kernel void passivbot_ema_multicoin_dual_hsl_phase_probe(
     constant float* params,
     constant float* bars,
+    constant float* invalid_bars,
     constant float* coin_settings,
     device float* output,
     uint b [[thread_position_in_grid]]
 ) {
-    if (b >= 5) return;
+    if (b >= 6) return;
     int po = int(b) * 22;
     EmaMulticoinSideState long_side;
     EmaMulticoinSideState short_side;
@@ -339,7 +340,7 @@ kernel void passivbot_ema_multicoin_dual_hsl_phase_probe(
     short_side.coin_hsl[0] = short_side.hsl;
     long_side.coin_realized_pnl[0] = 0.0f;
     short_side.coin_realized_pnl[0] = 0.0f;
-    long_side.psize[0] = b == 4 ? 1.0f : 0.0f;
+    long_side.psize[0] = (b == 4 || b == 5) ? 1.0f : 0.0f;
     short_side.psize[0] = 0.0f;
     long_side.pprice[0] = 100.0f;
     short_side.pprice[0] = 100.0f;
@@ -367,10 +368,11 @@ kernel void passivbot_ema_multicoin_dual_hsl_phase_probe(
             long_side.coin_realized_pnl[0] = -10.0f;
         }
         if (b == 4 && k == 4) long_side.psize[0] = 0.0f;
+        constant float* selected_bars = b == 5 ? invalid_bars : bars;
         bool valid = update_ema_multicoin_dual_side_hsl(
             long_side, long_config, 1,
             short_side, short_config, 1,
-            account, bars, coin_settings, k, 1,
+            account, selected_bars, coin_settings, k, 1,
             100.0f, 60000.0f, sample_enabled, sampled_tier
         );
         all_valid = all_valid && valid;
@@ -416,6 +418,7 @@ kernel void passivbot_ema_multicoin_dual_hsl_phase_probe(
             controller(2) + controller(2),
             controller(0) + controller(1),
             controller(0) + controller(0),
+            controller(0) + controller(0),
         ],
         dtype=torch.float32,
         device="mps",
@@ -425,15 +428,17 @@ kernel void passivbot_ema_multicoin_dual_hsl_phase_probe(
         dtype=torch.float32,
         device="mps",
     )
+    invalid_bars = bars.clone()
+    invalid_bars[:, 0, 2] = float("nan")
     coin_settings = torch.zeros((1, 12), dtype=torch.float32, device="mps")
     coin_settings[0, 4] = 1.0
-    output = torch.zeros((5, 12), dtype=torch.float32, device="mps")
+    output = torch.zeros((6, 12), dtype=torch.float32, device="mps")
 
     library = torch.mps.compile_shader(
         passivbot_rust.mps_ema_anchor_multicoin_source_py() + probe_kernel
     )
     library.passivbot_ema_multicoin_dual_hsl_phase_probe(
-        params, bars, coin_settings, output, threads=(5, 1, 1)
+        params, bars, invalid_bars, coin_settings, output, threads=(6, 1, 1)
     )
     torch.mps.synchronize()
     values = output.cpu().numpy()
@@ -452,6 +457,9 @@ kernel void passivbot_ema_multicoin_dual_hsl_phase_probe(
     # account is flat for two consecutive samples.
     assert values[4, 5:7].tolist() == [1.0, 1.0]
     assert values[4, 11] == 0.0
+    # A held coin without a valid mark rejects the sample before mutating any
+    # controller instead of fabricating neutral unrealized PnL.
+    assert values[5, :11].tolist() == [0.0] * 11
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary
- add a reusable EMA multicoin dual-side HSL candle phase over one shared portfolio account
- support unified, pside, and per-coin controller topologies while failing closed on mixed modes or invalid coin slot budgets
- preserve exact global flatness/order scope and report the maximum tier across the full long+short coin topology
- add a physical Apple-MPS matrix covering shared-account signals, pside isolation, coin controllers, mixed-mode rejection, and unified whole-account flatness

This remains an internal foundation slice. Optimizer routing and capability gates are unchanged; exact Rust stays authoritative and CPU behavior is untouched.

## Validation
- `./cargotest.sh --lib --quiet` (265 passed)
- `python -m pytest -q tests/optimization/test_gpu_service.py tests/optimization/test_gpu_backend.py` (474 passed)
- `python -m pytest -q tests/optimization/test_optimize.py` (229 passed)
- physical Apple M3/MPS: `PYTHONPATH=src python -m pytest -q tests/optimization/test_gpu_mps.py` (274 passed)