### PR TITLE
feat(gpu): add fused EMA multicoin kernel

### DIFF
--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -333,6 +333,12 @@ mod tests {
         assert!(source.contains("update_ema_multicoin_dual_side_hsl("));
         assert!(source.contains("if (long_side.hsl.signal_mode != short_side.hsl.signal_mode)"));
         assert!(source.contains("update_joint_pside_hsl("));
+        assert!(source.contains(
+            "const bool long_active = long_effective_n_positions > 0"
+        ));
+        assert!(source.contains(
+            "const bool short_active = short_effective_n_positions > 0"
+        ));
         assert!(source.contains("update_ema_multicoin_side_selection("));
         assert!(source.contains("generate_ema_multicoin_side_orders("));
         assert!(source.contains("passivbot_ema_anchor_multicoin_fused_impl("));

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -340,6 +340,12 @@ mod tests {
         assert!(source.contains("write_dual_side_hsl_outputs("));
         assert!(source.contains("write_dual_side_coin_hsl_outputs("));
         assert!(source.contains("long_coin_overrides, short_coin_overrides"));
+        assert!(source.contains("net_position_cost -= short_side.psize[c]"));
+        assert!(source.contains(
+            "float twe_abs = fabs(net_position_cost / account.balance)"
+        ));
+        assert!(source.contains("account.balance = 0.0f"));
+        assert!(source.contains("alive || hsl_validation_failed"));
         assert!(source.contains(
             "const EmaMulticoinSideConfig config = load_ema_multicoin_side_config(params, po)"
         ));

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -301,6 +301,7 @@ mod tests {
         assert_shared_hsl_contract(source);
         assert_shared_multicoin_contract(source);
         assert!(source.contains("kernel void passivbot_ema_anchor_multicoin"));
+        assert!(source.contains("kernel void passivbot_ema_anchor_multicoin_fused"));
         assert!(source.contains("kernel void passivbot_ema_anchor_multicoin_long"));
         assert!(source.contains("const bool short_side"));
         assert!(source.contains("constant int MAX_COINS = 64"));
@@ -313,6 +314,7 @@ mod tests {
         assert!(source.contains("constant int DAILY_COLS = 9"));
         assert!(source.contains("day_min_balance"));
         assert!(source.contains("constant int SCALAR_COLS = 57"));
+        assert!(source.contains("constant int FUSED_SCALAR_COLS = 62"));
         assert_eq!(source.matches("struct EmaMulticoinSideState").count(), 1);
         assert_eq!(source.matches("struct EmaMulticoinSideConfig").count(), 1);
         assert_eq!(source.matches("struct EmaMulticoinFillState").count(), 1);
@@ -333,6 +335,11 @@ mod tests {
         assert!(source.contains("update_joint_pside_hsl("));
         assert!(source.contains("update_ema_multicoin_side_selection("));
         assert!(source.contains("generate_ema_multicoin_side_orders("));
+        assert!(source.contains("passivbot_ema_anchor_multicoin_fused_impl("));
+        assert!(source.contains("update_ema_multicoin_dual_side_hsl("));
+        assert!(source.contains("write_dual_side_hsl_outputs("));
+        assert!(source.contains("write_dual_side_coin_hsl_outputs("));
+        assert!(source.contains("long_coin_overrides, short_coin_overrides"));
         assert!(source.contains(
             "const EmaMulticoinSideConfig config = load_ema_multicoin_side_config(params, po)"
         ));

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -346,6 +346,8 @@ mod tests {
         ));
         assert!(source.contains("account.balance = 0.0f"));
         assert!(source.contains("alive || hsl_validation_failed"));
+        assert!(source.contains("bool any_unstuck_enabled = false"));
+        assert!(source.contains("&& !any_unstuck_enabled"));
         assert!(source.contains(
             "const EmaMulticoinSideConfig config = load_ema_multicoin_side_config(params, po)"
         ));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -2664,7 +2664,7 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
 
         float long_unrealized = 0.0f;
         float short_unrealized = 0.0f;
-        float position_cost = 0.0f;
+        float net_position_cost = 0.0f;
         bool any_valid = false;
         for (int c = 0; c < C; ++c) {
             int coin_offset = c * COIN_COLS;
@@ -2677,7 +2677,7 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
             }
             float c_mult = coin_settings[coin_offset + 4];
             if (long_side.psize[c] > 0.0f) {
-                position_cost += long_side.psize[c]
+                net_position_cost += long_side.psize[c]
                     * long_side.pprice[c] * c_mult;
                 if (finite_positive(close)) {
                     long_unrealized += long_side.psize[c] * c_mult
@@ -2685,7 +2685,7 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                 }
             }
             if (short_side.psize[c] > 0.0f) {
-                position_cost += short_side.psize[c]
+                net_position_cost -= short_side.psize[c]
                     * short_side.pprice[c] * c_mult;
                 if (finite_positive(close)) {
                     short_unrealized += short_side.psize[c] * c_mult
@@ -2701,6 +2701,7 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
             && joint_portfolio_can_generate(
                 account, equity, liquidation_floor
             );
+        bool hsl_validation_failed = false;
         if (can_sample_hsl) {
             bool sample_enabled = false;
             int sampled_tier = 0;
@@ -2712,8 +2713,10 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                 sample_enabled, sampled_tier
             );
             if (!hsl_valid) {
+                account.balance = 0.0f;
                 alive = false;
                 liquidation_day = day_index;
+                hsl_validation_failed = true;
             } else if (sample_enabled) {
                 hsl_tier_samples_total += 1.0f;
                 hsl_tier_samples_yellow +=
@@ -2725,7 +2728,8 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
             }
         }
 
-        bool active = equity_started && alive && any_valid;
+        bool active = equity_started && any_valid
+            && (alive || hsl_validation_failed);
         if (active) {
             if (first_eq_k < 0.0f) first_eq_k = float(k);
             last_eq_k = float(k);
@@ -2771,7 +2775,7 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
             day_dd = fmax(day_dd, drawdown);
             day_touched = true;
             if (!liquidated) {
-                float twe_abs = position_cost / account.balance;
+                float twe_abs = fabs(net_position_cost / account.balance);
                 total_wallet_exposure_samples += 1.0f;
                 total_wallet_exposure_mean += (
                     twe_abs - total_wallet_exposure_mean

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -2431,12 +2431,25 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
         load_ema_multicoin_side_config(params, po);
     const EmaMulticoinSideConfig short_config =
         load_ema_multicoin_side_config(params, po + PARAM_COLS);
+    bool any_unstuck_enabled = false;
+    for (int c = 0; c < C; ++c) {
+        any_unstuck_enabled = any_unstuck_enabled
+            || coin_override_or(
+                long_coin_overrides, c, 13,
+                long_config.unstuck_enabled ? 1.0f : 0.0f
+            ) > 0.5f
+            || coin_override_or(
+                short_coin_overrides, c, 13,
+                short_config.unstuck_enabled ? 1.0f : 0.0f
+            ) > 0.5f;
+    }
     const int hsl_signal_mode = long_config.hsl_template.signal_mode;
     const bool topology_valid = hsl_signal_mode >= HSL_SIGNAL_UNIFIED
         && hsl_signal_mode <= HSL_SIGNAL_COIN
         && long_config.hsl_template.signal_mode
             == short_config.hsl_template.signal_mode
-        && long_config.coin_hsl_mode == short_config.coin_hsl_mode;
+        && long_config.coin_hsl_mode == short_config.coin_hsl_mode
+        && !any_unstuck_enabled;
     if (!topology_valid) {
         scalars[scalar_offset + 9] = 0.0f;
         scalars[scalar_offset + 13] = 0.0f;

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -8,6 +8,7 @@ constant int OVERRIDE_COLS = 29;
 constant int HSL_OVERRIDE_START = 19;
 constant int DAILY_COLS = 9;
 constant int SCALAR_COLS = 57;
+constant int FUSED_SCALAR_COLS = 62;
 constant int GAP_BINS = 128;
 
 // PASSIVBOT_HSL_COMMON
@@ -205,6 +206,10 @@ struct EmaMulticoinFillState {
     float pnl_recovery_max_min;
     float profit_sum;
     float loss_sum;
+    float profit_sum_long;
+    float loss_sum_long;
+    float profit_sum_short;
+    float loss_sum_short;
     float fill_count;
     float fill_count_entry;
     float fill_count_long;
@@ -223,6 +228,10 @@ inline EmaMulticoinFillState init_ema_multicoin_fill_state() {
     fills.pnl_recovery_max_min = 0.0f;
     fills.profit_sum = 0.0f;
     fills.loss_sum = 0.0f;
+    fills.profit_sum_long = 0.0f;
+    fills.loss_sum_long = 0.0f;
+    fills.profit_sum_short = 0.0f;
+    fills.loss_sum_short = 0.0f;
     fills.fill_count = 0.0f;
     fills.fill_count_entry = 0.0f;
     fills.fill_count_long = 0.0f;
@@ -233,6 +242,23 @@ inline EmaMulticoinFillState init_ema_multicoin_fill_state() {
     fills.day_volume = 0.0f;
     fills.day_fill_count = 0.0f;
     return fills;
+}
+
+inline void record_ema_multicoin_gross_pnl(
+    float pnl,
+    thread EmaMulticoinFillState& fills,
+    bool short_side
+) {
+    record_gross_pnl(pnl, fills.profit_sum, fills.loss_sum);
+    if (short_side) {
+        record_gross_pnl(
+            pnl, fills.profit_sum_short, fills.loss_sum_short
+        );
+    } else {
+        record_gross_pnl(
+            pnl, fills.profit_sum_long, fills.loss_sum_long
+        );
+    }
 }
 
 inline EmaMulticoinSideConfig load_ema_multicoin_side_config(
@@ -1760,7 +1786,7 @@ inline bool process_ema_multicoin_side_fills(
                     );
                 }
             }
-            record_gross_pnl(pnl, fills.profit_sum, fills.loss_sum);
+            record_ema_multicoin_gross_pnl(pnl, fills, short_side);
             record_realized_net(
                 net_pnl, account,
                 fills.day_fill_count, fills.fill_count,
@@ -2334,6 +2360,601 @@ inline void passivbot_ema_anchor_multicoin_impl(
             scalar_offset + 32
         );
     }
+}
+
+inline float ema_multicoin_entry_initial_balance_pct(
+    thread const EmaMulticoinSideConfig& config,
+    constant float* coin_overrides,
+    int effective_n_positions
+) {
+    float base_limit = effective_n_positions > 0
+        ? config.twel / float(effective_n_positions) : 0.0f;
+    float initial_qty_pct = coin_override_or(
+        coin_overrides, 0, 0, config.base_qty_pct
+    );
+    float allowance_pct = coin_override_or(
+        coin_overrides, 0, 12, config.allowance_pct
+    );
+    return allowed_wallet_exposure_limit(
+        base_limit, config.twel, allowance_pct, config.legacy_raw_allowance
+    ) * initial_qty_pct;
+}
+
+inline void passivbot_ema_anchor_multicoin_fused_impl(
+    constant float* bars,
+    constant int* fill_ticks,
+    constant int* touch_ticks,
+    constant float* coin_settings,
+    constant float* long_coin_overrides,
+    constant float* short_coin_overrides,
+    constant float* params,
+    constant float* run_settings,
+    constant int* sizes,
+    constant int* end_steps,
+    device float* daily,
+    device float* scalars,
+    device int* gap_hist,
+    device float* coin_fill_counts,
+    uint b
+) {
+    const int B = sizes[0];
+    const int T = sizes[1];
+    const int C = sizes[2];
+    const int D = sizes[3];
+    const int requested_start_k = sizes[4];
+    const int global_warmup = sizes[5];
+    const int start_day_minute = sizes[6];
+    const int start_hour_minute = sizes[7];
+    if (b >= uint(B)) return;
+    const int stop_k = clamp(end_steps[b], 1, T - 1);
+    const int scalar_offset = int(b) * FUSED_SCALAR_COLS;
+    for (int j = 0; j < FUSED_SCALAR_COLS; ++j) {
+        scalars[scalar_offset + j] = 0.0f;
+    }
+    for (int j = 0; j < GAP_BINS; ++j) {
+        gap_hist[int(b) * GAP_BINS + j] = 0;
+    }
+    if (C < 1 || C > MAX_COINS) {
+        scalars[scalar_offset + 9] = 0.0f;
+        scalars[scalar_offset + 13] = 0.0f;
+        return;
+    }
+    const bool collect_coin_fill_counts = run_settings[6] > 0.5f;
+    if (collect_coin_fill_counts) {
+        for (int c = 0; c < C; ++c) {
+            coin_fill_counts[int(b) * C + c] = 0.0f;
+        }
+    }
+
+    const int po = int(b) * PARAM_COLS * 2;
+    const EmaMulticoinSideConfig long_config =
+        load_ema_multicoin_side_config(params, po);
+    const EmaMulticoinSideConfig short_config =
+        load_ema_multicoin_side_config(params, po + PARAM_COLS);
+    const int hsl_signal_mode = long_config.hsl_template.signal_mode;
+    const bool topology_valid = hsl_signal_mode >= HSL_SIGNAL_UNIFIED
+        && hsl_signal_mode <= HSL_SIGNAL_COIN
+        && long_config.hsl_template.signal_mode
+            == short_config.hsl_template.signal_mode
+        && long_config.coin_hsl_mode == short_config.coin_hsl_mode;
+    if (!topology_valid) {
+        scalars[scalar_offset + 9] = 0.0f;
+        scalars[scalar_offset + 13] = 0.0f;
+        return;
+    }
+
+    EmaMulticoinSideState long_side;
+    EmaMulticoinSideState short_side;
+    init_ema_multicoin_side_state(
+        long_side, long_config, bars, coin_settings,
+        long_coin_overrides, C
+    );
+    init_ema_multicoin_side_state(
+        short_side, short_config, bars, coin_settings,
+        short_coin_overrides, C
+    );
+
+    const float starting_balance = run_settings[0];
+    const float liquidation_floor = run_settings[1];
+    const float interval_ms = run_settings[2];
+    const float score_hysteresis = fmax(run_settings[4], 0.0f);
+    const bool loss_gate_enabled = run_settings[5] < 1.0f;
+    const float max_realized_loss_pct = run_settings[5];
+    const float market_order_slippage_pct = fmax(run_settings[7], 0.0f);
+    const bool long_hsl_panic_market = run_settings[8] > 0.5f;
+    const bool short_hsl_panic_market = run_settings[9] > 0.5f;
+    const float log_bin_scale = 127.0f / log(4000001.0f);
+
+    JointPortfolioAccount account = init_joint_portfolio_account(
+        starting_balance
+    );
+    EmaMulticoinFillState fills = init_ema_multicoin_fill_state();
+    bool alive = true;
+    bool equity_started = false;
+    float fills_active_days_count = 0.0f;
+    int last_active_fill_day = -1;
+    float run_peak = -INFINITY;
+    float max_dd = 0.0f;
+    float total_wallet_exposure_max = 0.0f;
+    float total_wallet_exposure_mean = 0.0f;
+    float total_wallet_exposure_samples = 0.0f;
+    float first_fill_k = -1.0f;
+    float last_fill_k = -1.0f;
+    float gap_max_min = 0.0f;
+    float last_high_k = -1.0f;
+    float recovery_max_min = 0.0f;
+    float account_peak = -INFINITY;
+    float account_peak_k = -1.0f;
+    float account_recovery_max_min = 0.0f;
+    float first_eq_k = -1.0f;
+    float last_eq_k = -1.0f;
+    int liquidation_day = -1;
+    float hsl_tier_samples_total = 0.0f;
+    float hsl_tier_samples_yellow = 0.0f;
+    float hsl_tier_samples_orange = 0.0f;
+    float hsl_tier_samples_red = 0.0f;
+
+    int current_day = 0;
+    bool day_touched = false;
+    float day_end = 0.0f;
+    float day_min = INFINITY;
+    float day_dd = 0.0f;
+    float day_has_fill = 0.0f;
+    float day_min_balance = INFINITY;
+    float day_start_balance = account.balance;
+
+    for (int k = 1; k < stop_k; ++k) {
+        const int day_index = (start_day_minute + k) / 1440;
+        if (day_index != current_day) {
+            if (day_touched && current_day >= 0 && current_day < D) {
+                int output = (int(b) * D + current_day) * DAILY_COLS;
+                daily[output + 0] = day_end;
+                daily[output + 1] = day_min;
+                daily[output + 2] = day_dd;
+                daily[output + 3] = fills.day_volume;
+                daily[output + 4] = day_has_fill;
+                daily[output + 5] = day_min_balance;
+                daily[output + 6] = account.balance - day_start_balance;
+                daily[output + 7] = account.balance;
+                daily[output + 8] = fills.day_fill_count;
+            }
+            current_day = day_index;
+            day_touched = false;
+            day_end = 0.0f;
+            day_min = INFINITY;
+            day_dd = 0.0f;
+            fills.day_volume = 0.0f;
+            day_has_fill = 0.0f;
+            day_min_balance = INFINITY;
+            day_start_balance = account.balance;
+            fills.day_fill_count = 0.0f;
+        }
+
+        float long_hsl_equity_before_fills = account.balance;
+        long_hsl_equity_before_fills =
+            accumulate_ema_multicoin_side_unrealized_pnl(
+                long_side, bars, coin_settings, k, C, false,
+                long_hsl_equity_before_fills
+            );
+        long_hsl_equity_before_fills =
+            accumulate_ema_multicoin_side_unrealized_pnl(
+                short_side, bars, coin_settings, k, C, true,
+                long_hsl_equity_before_fills
+            );
+        bool long_fill = process_ema_multicoin_side_fills(
+            long_side, account, fills,
+            bars, fill_ticks, coin_settings, long_coin_overrides,
+            coin_fill_counts, int(b), k, C, false, alive,
+            collect_coin_fill_counts, loss_gate_enabled,
+            max_realized_loss_pct, market_order_slippage_pct,
+            long_hsl_panic_market, long_hsl_equity_before_fills
+        );
+        float short_hsl_equity_before_fills = account.balance;
+        short_hsl_equity_before_fills =
+            accumulate_ema_multicoin_side_unrealized_pnl(
+                long_side, bars, coin_settings, k, C, false,
+                short_hsl_equity_before_fills
+            );
+        short_hsl_equity_before_fills =
+            accumulate_ema_multicoin_side_unrealized_pnl(
+                short_side, bars, coin_settings, k, C, true,
+                short_hsl_equity_before_fills
+            );
+        bool short_fill = process_ema_multicoin_side_fills(
+            short_side, account, fills,
+            bars, fill_ticks, coin_settings, short_coin_overrides,
+            coin_fill_counts, int(b), k, C, true, alive,
+            collect_coin_fill_counts, loss_gate_enabled,
+            max_realized_loss_pct, market_order_slippage_pct,
+            short_hsl_panic_market, short_hsl_equity_before_fills
+        );
+        bool any_fill = long_fill || short_fill;
+        if (any_fill) {
+            day_has_fill = 1.0f;
+            if (last_fill_k >= 0.0f) {
+                float gap = float(k) - last_fill_k;
+                int bin = clamp(
+                    int(log(fmax(gap, 0.0f) + 1.0f) * log_bin_scale),
+                    0, 127
+                );
+                gap_hist[int(b) * GAP_BINS + bin] += 1;
+                gap_max_min = fmax(gap_max_min, gap);
+            }
+            if (first_fill_k < 0.0f) first_fill_k = float(k);
+            last_fill_k = float(k);
+        }
+
+        update_ema_multicoin_side_indicators(
+            long_side, long_config, bars, coin_settings,
+            k, C, start_hour_minute
+        );
+        update_ema_multicoin_side_indicators(
+            short_side, short_config, bars, coin_settings,
+            k, C, start_hour_minute
+        );
+        int long_tradable_count = count_ema_multicoin_tradable_coins(
+            bars, coin_settings, long_coin_overrides, k, C
+        );
+        int short_tradable_count = count_ema_multicoin_tradable_coins(
+            bars, coin_settings, short_coin_overrides, k, C
+        );
+        const bool post_fill_balance_depleted =
+            isfinite(account.balance) && account.balance <= 0.0f;
+        if (alive && !post_fill_balance_depleted) {
+            long_side.max_tradable_seen = max(
+                long_side.max_tradable_seen, long_tradable_count
+            );
+            short_side.max_tradable_seen = max(
+                short_side.max_tradable_seen, short_tradable_count
+            );
+        }
+        const int long_effective_n_positions = min(
+            long_config.n_positions, long_side.max_tradable_seen
+        );
+        const int short_effective_n_positions = min(
+            short_config.n_positions, short_side.max_tradable_seen
+        );
+        const bool past_warmup =
+            k > max(global_warmup, 1) && k >= requested_start_k;
+        const bool long_can_generate = alive
+            && long_effective_n_positions > 0 && past_warmup;
+        const bool short_can_generate = alive
+            && short_effective_n_positions > 0 && past_warmup;
+        equity_started = equity_started
+            || long_can_generate || short_can_generate;
+
+        int long_hsl_mode = long_config.coin_hsl_mode ? 0
+            : hsl_mode(
+                long_side.hsl,
+                ema_multicoin_side_has_position(long_side, C)
+            );
+        int short_hsl_mode = short_config.coin_hsl_mode ? 0
+            : hsl_mode(
+                short_side.hsl,
+                ema_multicoin_side_has_position(short_side, C)
+            );
+        if (long_can_generate) {
+            update_ema_multicoin_side_selection(
+                long_side, long_config, bars, coin_settings,
+                long_coin_overrides, k, C, false, any_fill,
+                long_effective_n_positions, score_hysteresis
+            );
+            generate_ema_multicoin_side_orders(
+                long_side, long_config, account,
+                bars, touch_ticks, coin_settings, long_coin_overrides,
+                k, C, false, long_tradable_count,
+                long_effective_n_positions, long_hsl_mode,
+                loss_gate_enabled, max_realized_loss_pct
+            );
+        }
+        if (short_can_generate) {
+            update_ema_multicoin_side_selection(
+                short_side, short_config, bars, coin_settings,
+                short_coin_overrides, k, C, true, any_fill,
+                short_effective_n_positions, score_hysteresis
+            );
+            generate_ema_multicoin_side_orders(
+                short_side, short_config, account,
+                bars, touch_ticks, coin_settings, short_coin_overrides,
+                k, C, true, short_tradable_count,
+                short_effective_n_positions, short_hsl_mode,
+                loss_gate_enabled, max_realized_loss_pct
+            );
+        }
+
+        float long_unrealized = 0.0f;
+        float short_unrealized = 0.0f;
+        float position_cost = 0.0f;
+        bool any_valid = false;
+        for (int c = 0; c < C; ++c) {
+            int coin_offset = c * COIN_COLS;
+            int bar_offset = (k * C + c) * 4;
+            float close = bars[bar_offset + 2];
+            if (k >= int(coin_settings[coin_offset + 6])
+                && k <= int(coin_settings[coin_offset + 7])
+                && finite_positive(close)) {
+                any_valid = true;
+            }
+            float c_mult = coin_settings[coin_offset + 4];
+            if (long_side.psize[c] > 0.0f) {
+                position_cost += long_side.psize[c]
+                    * long_side.pprice[c] * c_mult;
+                if (finite_positive(close)) {
+                    long_unrealized += long_side.psize[c] * c_mult
+                        * (close - long_side.pprice[c]);
+                }
+            }
+            if (short_side.psize[c] > 0.0f) {
+                position_cost += short_side.psize[c]
+                    * short_side.pprice[c] * c_mult;
+                if (finite_positive(close)) {
+                    short_unrealized += short_side.psize[c] * c_mult
+                        * (short_side.pprice[c] - close);
+                }
+            }
+        }
+        float equity = joint_portfolio_equity(
+            account, long_unrealized, short_unrealized
+        );
+        bool can_sample_hsl = (long_can_generate || short_can_generate)
+            && any_valid && alive
+            && joint_portfolio_can_generate(
+                account, equity, liquidation_floor
+            );
+        if (can_sample_hsl) {
+            bool sample_enabled = false;
+            int sampled_tier = 0;
+            bool hsl_valid = update_ema_multicoin_dual_side_hsl(
+                long_side, long_config, long_effective_n_positions,
+                short_side, short_config, short_effective_n_positions,
+                account, bars, coin_settings, k, C,
+                starting_balance, interval_ms,
+                sample_enabled, sampled_tier
+            );
+            if (!hsl_valid) {
+                alive = false;
+                liquidation_day = day_index;
+            } else if (sample_enabled) {
+                hsl_tier_samples_total += 1.0f;
+                hsl_tier_samples_yellow +=
+                    sampled_tier == 1 ? 1.0f : 0.0f;
+                hsl_tier_samples_orange +=
+                    sampled_tier == 2 ? 1.0f : 0.0f;
+                hsl_tier_samples_red +=
+                    sampled_tier == 3 ? 1.0f : 0.0f;
+            }
+        }
+
+        bool active = equity_started && alive && any_valid;
+        if (active) {
+            if (first_eq_k < 0.0f) first_eq_k = float(k);
+            last_eq_k = float(k);
+            if (any_fill) {
+                int active_fill_day = int(float(k) - first_eq_k) / 1440;
+                if (active_fill_day != last_active_fill_day) {
+                    fills_active_days_count += 1.0f;
+                    last_active_fill_day = active_fill_day;
+                }
+            }
+            bool liquidated = account.balance <= 0.0f
+                || equity <= liquidation_floor;
+            float effective_equity = liquidated
+                ? liquidation_floor : equity;
+            if (effective_equity >= account_peak) {
+                if (account_peak_k >= 0.0f) {
+                    account_recovery_max_min = fmax(
+                        account_recovery_max_min,
+                        float(k) - account_peak_k
+                    );
+                }
+                account_peak = effective_equity;
+                account_peak_k = float(k);
+            }
+            if (effective_equity > run_peak) {
+                if (last_high_k >= 0.0f) {
+                    recovery_max_min = fmax(
+                        recovery_max_min, float(k) - last_high_k
+                    );
+                }
+                last_high_k = float(k);
+                run_peak = effective_equity;
+            }
+            float drawdown = fmax(
+                (run_peak - effective_equity)
+                    / fmax(fabs(run_peak), 1.0e-12f),
+                0.0f
+            );
+            max_dd = fmax(max_dd, drawdown);
+            day_end = effective_equity;
+            day_min = fmin(day_min, effective_equity);
+            day_min_balance = fmin(day_min_balance, account.balance);
+            day_dd = fmax(day_dd, drawdown);
+            day_touched = true;
+            if (!liquidated) {
+                float twe_abs = position_cost / account.balance;
+                total_wallet_exposure_samples += 1.0f;
+                total_wallet_exposure_mean += (
+                    twe_abs - total_wallet_exposure_mean
+                ) / total_wallet_exposure_samples;
+                total_wallet_exposure_max = fmax(
+                    total_wallet_exposure_max, twe_abs
+                );
+            }
+            if (liquidated) {
+                alive = false;
+                liquidation_day = day_index;
+            }
+        }
+    }
+
+    if (day_touched && current_day >= 0 && current_day < D) {
+        int output = (int(b) * D + current_day) * DAILY_COLS;
+        daily[output + 0] = day_end;
+        daily[output + 1] = day_min;
+        daily[output + 2] = day_dd;
+        daily[output + 3] = fills.day_volume;
+        daily[output + 4] = day_has_fill;
+        daily[output + 5] = day_min_balance;
+        daily[output + 6] = account.balance - day_start_balance;
+        daily[output + 7] = account.balance;
+        daily[output + 8] = fills.day_fill_count;
+    }
+
+    float long_total_size = 0.0f;
+    float long_total_cost = 0.0f;
+    float short_total_size = 0.0f;
+    float short_total_cost = 0.0f;
+    int open_positions = 0;
+    for (int c = 0; c < C; ++c) {
+        float c_mult = coin_settings[c * COIN_COLS + 4];
+        if (long_side.psize[c] > 0.0f) {
+            long_total_size += long_side.psize[c];
+            long_total_cost += long_side.psize[c]
+                * long_side.pprice[c] * c_mult;
+            open_positions += 1;
+            if (long_side.position_open_k[c] >= 0.0f
+                && last_eq_k >= 0.0f) {
+                float held_min = last_eq_k
+                    - long_side.position_open_k[c];
+                fills.held_max_min = fmax(fills.held_max_min, held_min);
+                fills.held_sum_min += held_min;
+                fills.held_count += 1.0f;
+            }
+            if (long_side.position_last_fill_k[c] >= 0.0f
+                && last_eq_k >= 0.0f) {
+                fills.position_unchanged_max_min = fmax(
+                    fills.position_unchanged_max_min,
+                    last_eq_k - long_side.position_last_fill_k[c]
+                );
+            }
+        }
+        if (short_side.psize[c] > 0.0f) {
+            short_total_size += short_side.psize[c];
+            short_total_cost += short_side.psize[c]
+                * short_side.pprice[c] * c_mult;
+            open_positions += 1;
+            if (short_side.position_open_k[c] >= 0.0f
+                && last_eq_k >= 0.0f) {
+                float held_min = last_eq_k
+                    - short_side.position_open_k[c];
+                fills.held_max_min = fmax(fills.held_max_min, held_min);
+                fills.held_sum_min += held_min;
+                fills.held_count += 1.0f;
+            }
+            if (short_side.position_last_fill_k[c] >= 0.0f
+                && last_eq_k >= 0.0f) {
+                fills.position_unchanged_max_min = fmax(
+                    fills.position_unchanged_max_min,
+                    last_eq_k - short_side.position_last_fill_k[c]
+                );
+            }
+        }
+    }
+    if (fills.pnl_recovery_peak_k >= 0.0f && last_eq_k >= 0.0f) {
+        fills.pnl_recovery_max_min = fmax(
+            fills.pnl_recovery_max_min,
+            last_eq_k - fills.pnl_recovery_peak_k
+        );
+    }
+
+    scalars[scalar_offset + 0] = max_dd;
+    scalars[scalar_offset + 1] = fills.held_max_min * interval_ms;
+    scalars[scalar_offset + 2] = gap_max_min * interval_ms;
+    scalars[scalar_offset + 3] = first_fill_k >= 0.0f
+        ? first_fill_k * interval_ms : -1.0f;
+    scalars[scalar_offset + 4] = last_fill_k >= 0.0f
+        ? last_fill_k * interval_ms : -1.0f;
+    scalars[scalar_offset + 5] = recovery_max_min * interval_ms;
+    scalars[scalar_offset + 6] = last_high_k >= 0.0f
+        ? last_high_k * interval_ms : -1.0f;
+    scalars[scalar_offset + 7] = first_eq_k >= 0.0f
+        ? first_eq_k * interval_ms : -1.0f;
+    scalars[scalar_offset + 8] = last_eq_k >= 0.0f
+        ? last_eq_k * interval_ms : -1.0f;
+    scalars[scalar_offset + 9] = float(liquidation_day);
+    scalars[scalar_offset + 10] = account.balance;
+    scalars[scalar_offset + 11] = long_total_size;
+    scalars[scalar_offset + 12] = long_total_cost;
+    scalars[scalar_offset + 13] = alive ? 1.0f : 0.0f;
+    scalars[scalar_offset + 14] = float(open_positions);
+    scalars[scalar_offset + 15] = short_total_size;
+    scalars[scalar_offset + 16] = short_total_cost;
+    // Derive portfolio gross-PnL outputs from their directional reductions so
+    // the public total/directional metric contract stays algebraically exact
+    // despite different float32 accumulation orders.
+    scalars[scalar_offset + 18] =
+        fills.profit_sum_long + fills.profit_sum_short;
+    scalars[scalar_offset + 19] =
+        fills.loss_sum_long + fills.loss_sum_short;
+    scalars[scalar_offset + 20] =
+        fills.position_unchanged_max_min * interval_ms;
+    scalars[scalar_offset + 21] = ema_multicoin_entry_initial_balance_pct(
+        long_config, long_coin_overrides,
+        min(long_config.n_positions, long_side.max_tradable_seen)
+    );
+    scalars[scalar_offset + 22] = total_wallet_exposure_max;
+    scalars[scalar_offset + 23] = total_wallet_exposure_mean;
+    scalars[scalar_offset + 24] = fills.fill_count;
+    scalars[scalar_offset + 25] = fills.fill_count_entry;
+    scalars[scalar_offset + 26] = fills.fill_count_long;
+    scalars[scalar_offset + 27] = fills_active_days_count;
+    scalars[scalar_offset + 28] =
+        fills.pnl_recovery_max_min * interval_ms;
+    scalars[scalar_offset + 29] = fills.held_sum_min * interval_ms;
+    scalars[scalar_offset + 30] = fills.held_count;
+    scalars[scalar_offset + 31] = account_recovery_max_min * interval_ms;
+    if (long_config.coin_hsl_mode) {
+        write_dual_side_coin_hsl_outputs(
+            long_side.coin_hsl, short_side.coin_hsl, C,
+            hsl_tier_samples_total,
+            hsl_tier_samples_yellow,
+            hsl_tier_samples_orange,
+            hsl_tier_samples_red,
+            last_eq_k, scalars, scalar_offset + 32
+        );
+    } else {
+        write_dual_side_hsl_outputs(
+            long_side.hsl, short_side.hsl,
+            hsl_tier_samples_total,
+            hsl_tier_samples_yellow,
+            hsl_tier_samples_orange,
+            hsl_tier_samples_red,
+            last_eq_k, scalars, scalar_offset + 32
+        );
+    }
+    scalars[scalar_offset + 57] = ema_multicoin_entry_initial_balance_pct(
+        short_config, short_coin_overrides,
+        min(short_config.n_positions, short_side.max_tradable_seen)
+    );
+    scalars[scalar_offset + 58] = fills.profit_sum_long;
+    scalars[scalar_offset + 59] = fills.loss_sum_long;
+    scalars[scalar_offset + 60] = fills.profit_sum_short;
+    scalars[scalar_offset + 61] = fills.loss_sum_short;
+}
+
+kernel void passivbot_ema_anchor_multicoin_fused(
+    constant float* bars,
+    constant int* fill_ticks,
+    constant int* touch_ticks,
+    constant float* coin_settings,
+    constant float* long_coin_overrides,
+    constant float* short_coin_overrides,
+    constant float* params,
+    constant float* run_settings,
+    constant int* sizes,
+    constant int* end_steps,
+    device float* daily,
+    device float* scalars,
+    device int* gap_hist,
+    device float* coin_fill_counts,
+    uint b [[thread_position_in_grid]]
+) {
+    passivbot_ema_anchor_multicoin_fused_impl(
+        bars, fill_ticks, touch_ticks, coin_settings,
+        long_coin_overrides, short_coin_overrides,
+        params, run_settings, sizes, end_steps,
+        daily, scalars, gap_hist, coin_fill_counts, b
+    );
 }
 
 kernel void passivbot_ema_anchor_multicoin(

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -634,12 +634,6 @@ inline bool update_ema_multicoin_dual_side_hsl(
     sampled_tier = 0;
     if (long_side.hsl.signal_mode != short_side.hsl.signal_mode) return false;
     if (long_config.coin_hsl_mode != short_config.coin_hsl_mode) return false;
-    if (long_config.coin_hsl_mode && (
-            long_effective_n_positions <= 0
-                || short_effective_n_positions <= 0
-        )) {
-        return false;
-    }
     if (!ema_multicoin_side_held_marks_are_valid(
             long_side, bars, coin_settings, k, coin_count
         ) || !ema_multicoin_side_held_marks_are_valid(
@@ -668,6 +662,8 @@ inline bool update_ema_multicoin_dual_side_hsl(
     );
 
     if (long_config.coin_hsl_mode) {
+        const bool long_active = long_effective_n_positions > 0;
+        const bool short_active = short_effective_n_positions > 0;
         float portfolio_equity = joint_portfolio_equity(
             account, long_unrealized, short_unrealized
         );
@@ -702,37 +698,44 @@ inline bool update_ema_multicoin_dual_side_hsl(
                     || short_side.close_qty[c] > 0.0f
                     || short_side.secondary_close_qty[c] > 0.0f
             );
-            long_side.coin_hsl[c].slot_count = float(
-                long_effective_n_positions
-            );
-            short_side.coin_hsl[c].slot_count = float(
-                short_effective_n_positions
-            );
-            update_hsl(
-                long_side.coin_hsl[c], account.balance, starting_balance,
-                long_side.coin_realized_pnl[c], long_coin_unrealized,
-                long_side.psize[c] > 0.0f,
-                long_coin_has_blocking_orders, float(k), interval_ms
-            );
-            update_hsl(
-                short_side.coin_hsl[c], account.balance, starting_balance,
-                short_side.coin_realized_pnl[c], short_coin_unrealized,
-                short_side.psize[c] > 0.0f,
-                short_coin_has_blocking_orders, float(k), interval_ms
-            );
-            sample_enabled = sample_enabled
-                || long_side.coin_hsl[c].enabled
-                || short_side.coin_hsl[c].enabled;
-            sampled_tier = max(
-                sampled_tier,
-                max(long_side.coin_hsl[c].tier, short_side.coin_hsl[c].tier)
-            );
-            try_restart_hsl(
-                long_side.coin_hsl[c], float(k), portfolio_equity
-            );
-            try_restart_hsl(
-                short_side.coin_hsl[c], float(k), portfolio_equity
-            );
+            if (long_active) {
+                long_side.coin_hsl[c].slot_count = float(
+                    long_effective_n_positions
+                );
+                update_hsl(
+                    long_side.coin_hsl[c], account.balance, starting_balance,
+                    long_side.coin_realized_pnl[c], long_coin_unrealized,
+                    long_side.psize[c] > 0.0f,
+                    long_coin_has_blocking_orders, float(k), interval_ms
+                );
+                sample_enabled = sample_enabled
+                    || long_side.coin_hsl[c].enabled;
+                sampled_tier = max(
+                    sampled_tier, long_side.coin_hsl[c].tier
+                );
+                try_restart_hsl(
+                    long_side.coin_hsl[c], float(k), portfolio_equity
+                );
+            }
+            if (short_active) {
+                short_side.coin_hsl[c].slot_count = float(
+                    short_effective_n_positions
+                );
+                update_hsl(
+                    short_side.coin_hsl[c], account.balance, starting_balance,
+                    short_side.coin_realized_pnl[c], short_coin_unrealized,
+                    short_side.psize[c] > 0.0f,
+                    short_coin_has_blocking_orders, float(k), interval_ms
+                );
+                sample_enabled = sample_enabled
+                    || short_side.coin_hsl[c].enabled;
+                sampled_tier = max(
+                    sampled_tier, short_side.coin_hsl[c].tier
+                );
+                try_restart_hsl(
+                    short_side.coin_hsl[c], float(k), portfolio_equity
+                );
+            }
         }
         return true;
     }

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -2916,6 +2916,8 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
     np.testing.assert_allclose(
         values[:3, 24], daily[:3, :, 8].sum(dim=1).cpu().numpy()
     )
+    # Rust analyzes abs(long TWE + signed short TWE), not gross exposure.
+    assert (values[:3, 22] <= 1.01).all()
     assert (coin_fill_counts[:3].sum(dim=1).cpu().numpy() > 0.0).all()
     # Mixed or unknown signal modes are rejected before any state or fills.
     assert values[3:, 9].tolist() == [0.0, 0.0]

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -2761,6 +2761,171 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
+    import passivbot_rust
+
+    source = passivbot_rust.mps_ema_anchor_multicoin_source_py()
+    assert "kernel void passivbot_ema_anchor_multicoin_fused" in source
+    assert "constant int FUSED_SCALAR_COLS = 62" in source
+
+    count = 512
+    coin_count = 3
+    phase = np.linspace(0.0, 12.0 * np.pi, count)
+    hlcvs = np.empty((count, coin_count, 4), dtype=np.float64)
+    for coin in range(coin_count):
+        close = 100.0 + coin * 20.0 + np.sin(phase + coin) * (4.0 + coin)
+        hlcvs[:, coin, 0] = close * 1.01
+        hlcvs[:, coin, 1] = close * 0.99
+        hlcvs[:, coin, 2] = close
+        hlcvs[:, coin, 3] = 100.0 * (coin + 1)
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    markets = [
+        ProxyMarket(0.001, 0.01, 0.001, 5.0, 1.0, 0.0002)
+        for _ in range(coin_count)
+    ]
+    runs = [
+        ProxyRun(
+            1_000.0,
+            10,
+            10,
+            int(timestamps[0]),
+            int(timestamps[0]),
+            int(timestamps[0]),
+            60_000,
+            0.05,
+            0,
+            count - 1,
+        )
+        for _ in range(coin_count)
+    ]
+    data = build_mps_multicoin_data(hlcvs, timestamps, runs, markets)
+
+    base = [
+        0.1,
+        10.0,
+        30.0,
+        1.5,
+        0.01,
+        0.0,
+        0.0,
+        0.0,
+        60.0,
+        60.0,
+        0.0,
+        1.0,
+        60.0,
+        60.0,
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        2.0,
+    ]
+    base += _single_coin_exposure_fields() + [0.0, 0.0]
+    base += list(_UNSTUCK_DISABLED_VALUES.values())
+
+    def side_row(signal_mode):
+        hsl = dict(_HSL_DISABLED_VALUES)
+        hsl["hsl_enabled"] = 1.0
+        hsl["hsl_red_threshold"] = 0.9
+        hsl["hsl_signal_mode"] = float(signal_mode)
+        row = base + list(hsl.values())
+        assert len(row) == len(EMA_ANCHOR_MULTICOIN_PARAM_KEYS)
+        return row
+
+    rows = [
+        side_row(0) + side_row(0),
+        side_row(1) + side_row(1),
+        side_row(2) + side_row(2),
+        side_row(0) + side_row(1),
+        side_row(3) + side_row(3),
+    ]
+    batch_size = len(rows)
+    params = torch.as_tensor(
+        np.asarray(rows, dtype=np.float32), device="mps"
+    ).contiguous()
+    overrides = torch.full(
+        (coin_count, 29), float("nan"), dtype=torch.float32, device="mps"
+    )
+    run_settings = torch.tensor(
+        [1_000.0, 50.0, 60_000.0, 0.0, 0.02, 0.1, 1.0, 0.0, 0.0, 0.0],
+        dtype=torch.float32,
+        device="mps",
+    )
+    sizes = torch.tensor(
+        [
+            batch_size,
+            data["n"],
+            coin_count,
+            data["n_days"],
+            0,
+            10,
+            data["start_minute_of_day"],
+            data["start_minute_of_hour"],
+        ],
+        dtype=torch.int32,
+        device="mps",
+    )
+    end_steps = torch.full(
+        (batch_size,), data["n"] - 1, dtype=torch.int32, device="mps"
+    )
+    daily = torch.zeros(
+        (batch_size, data["n_days"], 9), dtype=torch.float32, device="mps"
+    )
+    daily[:, :, 1].fill_(float("inf"))
+    daily[:, :, 5].fill_(float("inf"))
+    scalars = torch.zeros((batch_size, 62), dtype=torch.float32, device="mps")
+    gaps = torch.zeros((batch_size, 128), dtype=torch.int32, device="mps")
+    coin_fill_counts = torch.zeros(
+        (batch_size, coin_count), dtype=torch.float32, device="mps"
+    )
+
+    library = torch.mps.compile_shader(source)
+    library.passivbot_ema_anchor_multicoin_fused(
+        data["bars"],
+        data["fill_ticks"],
+        data["touch_ticks"],
+        data["coin_settings"],
+        overrides,
+        overrides,
+        params,
+        run_settings,
+        sizes,
+        end_steps,
+        daily,
+        scalars,
+        gaps,
+        coin_fill_counts,
+        threads=(batch_size, 1, 1),
+    )
+    torch.mps.synchronize()
+    values = scalars.cpu().numpy()
+
+    assert values[:3, 13].tolist() == [1.0, 1.0, 1.0]
+    assert (values[:3, 24] > 0.0).all()
+    assert (values[:3, 26] > 0.0).all()
+    assert (values[:3, 24] - values[:3, 26] > 0.0).all()
+    assert values[:3, 32:34].tolist() == [[1.0, 1.0]] * 3
+    assert (values[:3, 38] > 0.0).all()
+    np.testing.assert_allclose(
+        values[:3, 18], values[:3, 58] + values[:3, 60]
+    )
+    np.testing.assert_allclose(
+        values[:3, 19], values[:3, 59] + values[:3, 61]
+    )
+    np.testing.assert_allclose(
+        values[:3, 24], daily[:3, :, 8].sum(dim=1).cpu().numpy()
+    )
+    assert (coin_fill_counts[:3].sum(dim=1).cpu().numpy() > 0.0).all()
+    # Mixed or unknown signal modes are rejected before any state or fills.
+    assert values[3:, 9].tolist() == [0.0, 0.0]
+    assert values[3:, 13].tolist() == [0.0, 0.0]
+    assert values[3:, 24].tolist() == [0.0, 0.0]
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 @pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_trailing_martingale_multicoin_directional_shader_smoke(side):
     import passivbot_rust

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -2833,12 +2833,16 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
         assert len(row) == len(EMA_ANCHOR_MULTICOIN_PARAM_KEYS)
         return row
 
+    unstuck_long = side_row(0)
+    unstuck_long[EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("unstuck_enabled")] = 1.0
+
     rows = [
         side_row(0) + side_row(0),
         side_row(1) + side_row(1),
         side_row(2) + side_row(2),
         side_row(0) + side_row(1),
         side_row(3) + side_row(3),
+        unstuck_long + side_row(0),
     ]
     batch_size = len(rows)
     params = torch.as_tensor(
@@ -2919,10 +2923,49 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
     # Rust analyzes abs(long TWE + signed short TWE), not gross exposure.
     assert (values[:3, 22] <= 1.01).all()
     assert (coin_fill_counts[:3].sum(dim=1).cpu().numpy() > 0.0).all()
-    # Mixed or unknown signal modes are rejected before any state or fills.
-    assert values[3:, 9].tolist() == [0.0, 0.0]
-    assert values[3:, 13].tolist() == [0.0, 0.0]
-    assert values[3:, 24].tolist() == [0.0, 0.0]
+    # Mixed/unknown signal modes and dual-side auto-unstuck are rejected before
+    # any state or fills; exact Rust requires one global unstuck arbitration.
+    assert values[3:, 9].tolist() == [0.0, 0.0, 0.0]
+    assert values[3:, 13].tolist() == [0.0, 0.0, 0.0]
+    assert values[3:, 24].tolist() == [0.0, 0.0, 0.0]
+
+    # Coin overrides can enable auto-unstuck even when the side template does
+    # not, so the kernel must inspect the effective per-coin setting too.
+    override_unstuck = overrides.clone()
+    override_unstuck[0, 13] = 1.0
+    override_sizes = sizes.clone()
+    override_sizes[0] = 1
+    override_daily = torch.zeros(
+        (1, data["n_days"], 9), dtype=torch.float32, device="mps"
+    )
+    override_daily[:, :, 1].fill_(float("inf"))
+    override_daily[:, :, 5].fill_(float("inf"))
+    override_scalars = torch.zeros((1, 62), dtype=torch.float32, device="mps")
+    override_gaps = torch.zeros((1, 128), dtype=torch.int32, device="mps")
+    override_coin_fills = torch.zeros(
+        (1, coin_count), dtype=torch.float32, device="mps"
+    )
+    library.passivbot_ema_anchor_multicoin_fused(
+        data["bars"],
+        data["fill_ticks"],
+        data["touch_ticks"],
+        data["coin_settings"],
+        override_unstuck,
+        overrides,
+        params[:1],
+        run_settings,
+        override_sizes,
+        end_steps[:1],
+        override_daily,
+        override_scalars,
+        override_gaps,
+        override_coin_fills,
+        threads=(1, 1, 1),
+    )
+    torch.mps.synchronize()
+    assert override_scalars[0, 9].item() == 0.0
+    assert override_scalars[0, 13].item() == 0.0
+    assert override_scalars[0, 24].item() == 0.0
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -324,7 +324,7 @@ kernel void passivbot_ema_multicoin_dual_hsl_phase_probe(
     device float* output,
     uint b [[thread_position_in_grid]]
 ) {
-    if (b >= 6) return;
+    if (b >= 8) return;
     int po = int(b) * 22;
     EmaMulticoinSideState long_side;
     EmaMulticoinSideState short_side;
@@ -363,15 +363,19 @@ kernel void passivbot_ema_multicoin_dual_hsl_phase_probe(
     for (int k = 1; k <= 5; ++k) {
         if (k == 2) {
             account.realized_pnl_total = -10.0f;
-            account.realized_pnl_long = -10.0f;
+            account.realized_pnl_long = b == 7 ? 0.0f : -10.0f;
+            account.realized_pnl_short = b == 7 ? -10.0f : 0.0f;
             account.balance = 90.0f;
-            long_side.coin_realized_pnl[0] = -10.0f;
+            long_side.coin_realized_pnl[0] = b == 7 ? 0.0f : -10.0f;
+            short_side.coin_realized_pnl[0] = b == 7 ? -10.0f : 0.0f;
         }
         if (b == 4 && k == 4) long_side.psize[0] = 0.0f;
         constant float* selected_bars = b == 5 ? invalid_bars : bars;
+        int long_slots = b == 7 ? 0 : 1;
+        int short_slots = b == 6 ? 0 : 1;
         bool valid = update_ema_multicoin_dual_side_hsl(
-            long_side, long_config, 1,
-            short_side, short_config, 1,
+            long_side, long_config, long_slots,
+            short_side, short_config, short_slots,
             account, selected_bars, coin_settings, k, 1,
             100.0f, 60000.0f, sample_enabled, sampled_tier
         );
@@ -419,6 +423,8 @@ kernel void passivbot_ema_multicoin_dual_hsl_phase_probe(
             controller(0) + controller(1),
             controller(0) + controller(0),
             controller(0) + controller(0),
+            controller(2) + controller(2),
+            controller(2) + controller(2),
         ],
         dtype=torch.float32,
         device="mps",
@@ -432,13 +438,13 @@ kernel void passivbot_ema_multicoin_dual_hsl_phase_probe(
     invalid_bars[:, 0, 2] = float("nan")
     coin_settings = torch.zeros((1, 12), dtype=torch.float32, device="mps")
     coin_settings[0, 4] = 1.0
-    output = torch.zeros((6, 12), dtype=torch.float32, device="mps")
+    output = torch.zeros((8, 12), dtype=torch.float32, device="mps")
 
     library = torch.mps.compile_shader(
         passivbot_rust.mps_ema_anchor_multicoin_source_py() + probe_kernel
     )
     library.passivbot_ema_multicoin_dual_hsl_phase_probe(
-        params, bars, invalid_bars, coin_settings, output, threads=(6, 1, 1)
+        params, bars, invalid_bars, coin_settings, output, threads=(8, 1, 1)
     )
     torch.mps.synchronize()
     values = output.cpu().numpy()
@@ -460,6 +466,14 @@ kernel void passivbot_ema_multicoin_dual_hsl_phase_probe(
     # A held coin without a valid mark rejects the sample before mutating any
     # controller instead of fabricating neutral unrealized PnL.
     assert values[5, :11].tolist() == [0.0] * 11
+    # Coin HSL skips a side without an effective slot budget while retaining
+    # the active side's controller, matching exact Rust asymmetric tradability.
+    assert values[6, :11].tolist() == [
+        1.0, 1.0, 3.0, 0.0, 0.0, 0.0, 0.0, 3.0, 0.0, 1.0, 0.0
+    ]
+    assert values[7, :11].tolist() == [
+        1.0, 1.0, 3.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3.0, 0.0, 1.0
+    ]
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary
- add an unexposed fused EMA-anchor multicoin Metal kernel in which one candidate thread owns both long and short strategy state
- execute long then short fills against one shared balance, realized-PnL chronology, liquidation surface, daily metrics, gap histogram, and symbol fill counts
- run both side-specific selection/order phases before the reviewed unified/pside/coin dual-HSL phase
- preserve algebraically exact portfolio/directional gross-PnL outputs and fail closed on mixed, unknown, or oversized topology inputs
- add a physical M3 smoke matrix proving both sides fill, shared/directional reductions reconcile, all HSL modes execute, and invalid modes produce no fills

This kernel is intentionally not routed by the optimizer yet. The next slice will add the Python runner and only then consider widening capability gates. Exact Rust remains authoritative and CPU behavior is untouched.

## Validation
- `./cargotest.sh --lib --quiet` (265 passed)
- `python -m pytest -q tests/optimization/test_gpu_service.py tests/optimization/test_gpu_backend.py` (474 passed)
- `python -m pytest -q tests/optimization/test_optimize.py` (229 passed)
- physical Apple M3/MPS: `PYTHONPATH=src python -m pytest -q tests/optimization/test_gpu_mps.py` (275 passed)