### PR TITLE
feat(gpu): add fused EMA multicoin runner

### DIFF
--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -22,6 +22,7 @@ MPS_MULTICOIN_DAILY_COLS = 9
 MPS_SCALAR_COLS = 32
 MPS_MULTICOIN_SCALAR_COLS = 57
 MPS_DIRECTIONAL_SCALAR_COLS = 62
+MPS_EMA_MULTICOIN_FUSED_SCALAR_COLS = 62
 
 
 def _encode_max_realized_loss_pct(value: float) -> float:
@@ -162,6 +163,22 @@ def _decode_outputs(daily, scalars, gaps) -> dict:
         "hsl_panic_loss_drawdown_max": scalars[:, 55],
         "hsl_panic_loss_drawdown_count": scalars[:, 56],
     }
+
+
+def _decode_ema_multicoin_fused_outputs(daily, scalars, gaps) -> dict:
+    output = _decode_outputs(daily, scalars, gaps)
+    long_entry_initial_balance_pct = output.pop("entry_initial_balance_pct")
+    output.update(
+        {
+            "entry_initial_balance_pct_long": long_entry_initial_balance_pct,
+            "entry_initial_balance_pct_short": scalars[:, 57],
+            "profit_sum_long": scalars[:, 58],
+            "loss_sum_long": scalars[:, 59],
+            "profit_sum_short": scalars[:, 60],
+            "loss_sum_short": scalars[:, 61],
+        }
+    )
+    return output
 
 
 def _decode_directional_outputs(daily, scalars, gaps) -> dict:
@@ -457,6 +474,7 @@ class MpsEmaAnchorMulticoinRunner:
 
     coin_override_cols = 29
     coin_override_label = "EMA"
+    scalar_cols = MPS_MULTICOIN_SCALAR_COLS
 
     def __init__(
         self,
@@ -576,7 +594,7 @@ class MpsEmaAnchorMulticoinRunner:
                         device="mps",
                     ),
                     torch.zeros(
-                        (batch_size, MPS_MULTICOIN_SCALAR_COLS),
+                        (batch_size, self.scalar_cols),
                         dtype=torch.float32,
                         device="mps",
                     ),
@@ -616,6 +634,39 @@ class MpsEmaAnchorMulticoinRunner:
             np.ascontiguousarray(values), dtype=torch.int32, device="mps"
         )
 
+    def _dispatch(
+        self,
+        library,
+        params_mps,
+        sizes,
+        end_steps,
+        daily,
+        scalars,
+        gaps,
+        coin_fill_counts,
+        *,
+        batch_size: int,
+    ) -> None:
+        library.passivbot_ema_anchor_multicoin(
+            self.bars,
+            self.fill_ticks,
+            self.touch_ticks,
+            self.coin_settings,
+            self.coin_overrides,
+            params_mps,
+            self.settings,
+            sizes,
+            end_steps,
+            daily,
+            scalars,
+            gaps,
+            coin_fill_counts,
+            threads=(batch_size, 1, 1),
+        )
+
+    def _decode(self, daily, scalars, gaps) -> dict:
+        return _decode_outputs(daily, scalars, gaps)
+
     def run(
         self,
         params: np.ndarray,
@@ -654,21 +705,16 @@ class MpsEmaAnchorMulticoinRunner:
             dispatched = time.perf_counter()
         else:
             dispatched = compiled
-        library.passivbot_ema_anchor_multicoin(
-            self.bars,
-            self.fill_ticks,
-            self.touch_ticks,
-            self.coin_settings,
-            self.coin_overrides,
+        self._dispatch(
+            library,
             params_mps,
-            self.settings,
             self._sizes[sizes_key],
             end_steps_mps,
             daily,
             scalars,
             gaps,
             coin_fill_counts,
-            threads=(batch_size, 1, 1),
+            batch_size=batch_size,
         )
         if profile:
             torch.mps.synchronize()
@@ -680,10 +726,126 @@ class MpsEmaAnchorMulticoinRunner:
             "pre_dispatch_sync_seconds": dispatched - compiled,
             "kernel_seconds": finished - dispatched,
         }
-        output = _decode_outputs(daily, scalars, gaps)
+        output = self._decode(daily, scalars, gaps)
         if self.collect_coin_fill_counts:
             output["coin_fill_counts"] = coin_fill_counts
         return output
+
+
+class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
+    """Persistent dual-side shared-account EMA Anchor runner on Apple MPS."""
+
+    scalar_cols = MPS_EMA_MULTICOIN_FUSED_SCALAR_COLS
+
+    def __init__(
+        self,
+        run: ProxyRun,
+        data: dict,
+        *,
+        long_coin_overrides: np.ndarray | None = None,
+        short_coin_overrides: np.ndarray | None = None,
+        forager_score_hysteresis_pct: float = 0.0,
+        max_realized_loss_pct: float = 1.0,
+        collect_coin_fill_counts: bool = False,
+        market_order_slippage_pct: float = 0.0,
+        hsl_panic_market_long: bool = False,
+        hsl_panic_market_short: bool = False,
+    ):
+        super().__init__(
+            run,
+            data,
+            side="long",
+            coin_overrides=long_coin_overrides,
+            forager_score_hysteresis_pct=forager_score_hysteresis_pct,
+            max_realized_loss_pct=max_realized_loss_pct,
+            collect_coin_fill_counts=collect_coin_fill_counts,
+            market_order_slippage_pct=market_order_slippage_pct,
+            hsl_panic_market=hsl_panic_market_long,
+        )
+        if short_coin_overrides is None:
+            short_coin_overrides = np.full(
+                (self.n_coins, self.coin_override_cols),
+                np.nan,
+                dtype=np.float32,
+            )
+        short_coin_overrides = np.asarray(short_coin_overrides, dtype=np.float32)
+        expected_shape = (self.n_coins, self.coin_override_cols)
+        if short_coin_overrides.shape != expected_shape:
+            raise ValueError(
+                "expected fused multicoin EMA short override matrix shaped "
+                f"{expected_shape}, got {short_coin_overrides.shape}"
+            )
+        self.short_coin_overrides = torch.as_tensor(
+            np.ascontiguousarray(short_coin_overrides), device="mps"
+        )
+        max_realized_loss_pct = float(max_realized_loss_pct)
+        encoded_max_realized_loss_pct = _encode_max_realized_loss_pct(
+            max_realized_loss_pct
+        )
+        market_order_slippage_pct = float(market_order_slippage_pct)
+        liq_floor = max(0.0, run.starting_balance) * max(
+            0.0, run.liquidation_threshold
+        )
+        self.settings = torch.tensor(
+            [
+                run.starting_balance,
+                liq_floor,
+                run.interval_ms,
+                0.0,
+                float(forager_score_hysteresis_pct),
+                encoded_max_realized_loss_pct,
+                float(self.collect_coin_fill_counts),
+                market_order_slippage_pct,
+                float(bool(hsl_panic_market_long)),
+                float(bool(hsl_panic_market_short)),
+            ],
+            dtype=torch.float32,
+            device="mps",
+        )
+
+    def _pack_params(self, params: np.ndarray) -> np.ndarray:
+        expected = len(EMA_ANCHOR_MULTICOIN_PARAM_KEYS) * 2
+        if params.ndim != 2 or params.shape[1] != expected:
+            got = params.shape[1] if params.ndim == 2 else params.shape
+            raise ValueError(
+                "expected fused multicoin EMA parameter matrix with "
+                f"{expected} columns, got {got}"
+            )
+        return np.ascontiguousarray(params, dtype=np.float32)
+
+    def _dispatch(
+        self,
+        library,
+        params_mps,
+        sizes,
+        end_steps,
+        daily,
+        scalars,
+        gaps,
+        coin_fill_counts,
+        *,
+        batch_size: int,
+    ) -> None:
+        library.passivbot_ema_anchor_multicoin_fused(
+            self.bars,
+            self.fill_ticks,
+            self.touch_ticks,
+            self.coin_settings,
+            self.coin_overrides,
+            self.short_coin_overrides,
+            params_mps,
+            self.settings,
+            sizes,
+            end_steps,
+            daily,
+            scalars,
+            gaps,
+            coin_fill_counts,
+            threads=(batch_size, 1, 1),
+        )
+
+    def _decode(self, daily, scalars, gaps) -> dict:
+        return _decode_ema_multicoin_fused_outputs(daily, scalars, gaps)
 
 
 class MpsEmaAnchorMulticoinLongRunner(MpsEmaAnchorMulticoinRunner):

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -19,7 +19,11 @@ from optimization.gpu.model import (
     build_mps_data,
     build_mps_multicoin_data,
 )
-from optimization.gpu.mps_kernel import _encode_max_realized_loss_pct
+from optimization.gpu.mps_kernel import (
+    MpsEmaAnchorMulticoinFusedRunner,
+    _decode_ema_multicoin_fused_outputs,
+    _encode_max_realized_loss_pct,
+)
 from optimization.gpu.metrics import _fill_gap_metrics
 
 
@@ -87,6 +91,24 @@ def test_mps_realized_loss_limit_float32_encoding_never_loosens(value):
 @pytest.mark.parametrize("value", [1.0, 2.0, 1.0e100])
 def test_mps_disabled_realized_loss_limit_has_finite_float32_encoding(value):
     assert _encode_max_realized_loss_pct(value) == 1.0
+
+
+def test_decode_ema_multicoin_fused_outputs_maps_directional_reductions():
+    daily = torch.zeros((1, 1, 9), dtype=torch.float32)
+    daily[:, :, 1].fill_(float("inf"))
+    daily[:, :, 5].fill_(float("inf"))
+    scalars = torch.arange(62, dtype=torch.float32).reshape(1, 62)
+    gaps = torch.zeros((1, 128), dtype=torch.int32)
+
+    output = _decode_ema_multicoin_fused_outputs(daily, scalars, gaps)
+
+    assert "entry_initial_balance_pct" not in output
+    assert torch.equal(output["entry_initial_balance_pct_long"], scalars[:, 21])
+    assert torch.equal(output["entry_initial_balance_pct_short"], scalars[:, 57])
+    assert torch.equal(output["profit_sum_long"], scalars[:, 58])
+    assert torch.equal(output["loss_sum_long"], scalars[:, 59])
+    assert torch.equal(output["profit_sum_short"], scalars[:, 60])
+    assert torch.equal(output["loss_sum_short"], scalars[:, 61])
 
 
 @pytest.mark.skipif(
@@ -2942,6 +2964,53 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
     assert values[3:, 9].tolist() == [0.0, 0.0, 0.0]
     assert values[3:, 13].tolist() == [0.0, 0.0, 0.0]
     assert values[3:, 24].tolist() == [0.0, 0.0, 0.0]
+
+    override_matrix = np.full((coin_count, 29), np.nan, dtype=np.float32)
+    runner = MpsEmaAnchorMulticoinFusedRunner(
+        runs[0],
+        data,
+        long_coin_overrides=override_matrix,
+        short_coin_overrides=override_matrix,
+        forager_score_hysteresis_pct=0.02,
+        max_realized_loss_pct=0.1,
+        collect_coin_fill_counts=True,
+    )
+    runner_output = runner.run(
+        np.asarray(rows, dtype=np.float64), profile=True
+    )
+    torch.mps.synchronize()
+    torch.testing.assert_close(runner_output["day_end_eq"], daily[:, :, 0])
+    torch.testing.assert_close(runner_output["day_min_eq"], daily[:, :, 1])
+    torch.testing.assert_close(runner_output["fill_count"], scalars[:, 24])
+    torch.testing.assert_close(
+        runner_output["entry_initial_balance_pct_long"], scalars[:, 21]
+    )
+    torch.testing.assert_close(
+        runner_output["entry_initial_balance_pct_short"], scalars[:, 57]
+    )
+    torch.testing.assert_close(runner_output["profit_sum_long"], scalars[:, 58])
+    torch.testing.assert_close(runner_output["loss_sum_long"], scalars[:, 59])
+    torch.testing.assert_close(runner_output["profit_sum_short"], scalars[:, 60])
+    torch.testing.assert_close(runner_output["loss_sum_short"], scalars[:, 61])
+    assert runner_output["alive"].cpu().tolist() == [
+        True,
+        True,
+        True,
+        False,
+        False,
+        False,
+    ]
+    assert torch.equal(runner_output["coin_fill_counts"], coin_fill_counts)
+    assert runner.last_profile["kernel_seconds"] >= 0.0
+    with pytest.raises(ValueError, match="84 columns"):
+        runner.run(np.asarray([side_row(0)], dtype=np.float64))
+    truncated = runner.run(
+        np.asarray([rows[0]], dtype=np.float64),
+        end_steps=np.asarray([60], dtype=np.int32),
+    )
+    torch.mps.synchronize()
+    assert truncated["last_eq_ts"].item() <= 59 * 60_000.0
+    assert truncated["fill_count"].item() <= values[0, 24]
 
     # Coin overrides can enable auto-unstuck even when the side template does
     # not, so the kernel must inspect the effective per-coin setting too.


### PR DESCRIPTION
## Summary

- add a persistent Python MPS runner for the fused dual-side, shared-account EMA Anchor multicoin kernel
- decode the fused 62-scalar output contract, including side-specific entry balance and profit/loss reductions
- reuse the existing batching, buffer, end-step, and profiling lifecycle without exposing service routing yet
- prove unified, pside, and coin HSL modes plus fail-closed invalid topology and auto-unstuck behavior on physical Apple MPS

This is an additive internal runner slice. It does not change optimizer service routing, CLI/config behavior, CPU optimization, or exact Rust authority.

## Validation

- Rust: 265 passed
- GPU service/backend: 474 passed
- optimizer: 229 passed
- physical Apple MPS: 276 passed
- Python compile check and `git diff --check`