### PR TITLE
feat(gpu): route dual EMA multicoin through fused MPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added fused shared-account dual-side multi-coin EMA Anchor screening to Apple MPS optimization.
+  Unified, pside, and coin HSL now run inside one portfolio kernel, including per-coin HSL
+  overrides and shared event/tier scoring metrics. Exact Rust remains authoritative, dual-side
+  auto-unstuck and exposure repair remain fail closed, and dual-side multi-coin Trailing
+  Martingale remains on its existing pside-only directional proxy.
+
 - Added dual-side single-coin `unified` HSL to Apple MPS optimization for EMA Anchor and
   Trailing Martingale. Both Metal controllers now consume account-wide realized and unrealized
   PnL and require positions and blocking orders on both sides to be flat before ending a RED

--- a/docs/equity_hard_stop_loss_reference.md
+++ b/docs/equity_hard_stop_loss_reference.md
@@ -134,7 +134,8 @@ These are the main parity surfaces that should be reviewed together:
    - Coin-mode lifecycle and panic-loss metrics aggregate across coin episodes, while warning-tier time samples the worst active coin tier once per minute, matching exact Rust reporting
    - Multi-coin limit and market panic closes flatten every open coin on the enabled side and export the same lifecycle and panic-loss metric surface as single-coin HSL; market execution uses each coin's taker fee and directionally quantized configured slippage
    - One-sided multi-coin coin mode resolves all ten canonical per-coin HSL settings independently, including enablement, thresholds, restart/tier behavior, and limit/market panic execution; compatible suites may supply scenario-local overrides
-   - Dual-side multi-coin HSL supports pside signals; coin and unified signals remain fail closed pending a fused shared-balance strategy kernel
+   - Dual-side multi-coin EMA Anchor uses a fused shared-account strategy kernel for unified, pside, and coin signals, including shared lifecycle/panic-loss metrics and per-coin HSL overrides in coin mode
+   - Dual-side multi-coin Trailing Martingale remains limited to pside signals through independent directional kernels; shared event-loss and warning-tier overlap metrics remain fail closed
 
 ### Confirmed Gaps / Risks
 
@@ -145,15 +146,15 @@ These are the main parity surfaces that should be reviewed together:
    - Runtime decisions are made per `pside`
    - Global `*_strategy_eq` metrics are canonical for risk inspection and optimizer use
    - Deprecated `*_hsl` metric names remain accepted as aliases for older configs/results
-3. GPU HSL topology is intentionally narrow
-   - Dual-side multi-coin coin and unified HSL need one shared-balance strategy kernel that owns both directional state machines without duplicating account balance or liquidation decisions
+3. Remaining GPU HSL topology gap
+   - Dual-side multi-coin Trailing Martingale coin and unified HSL still need one shared-balance strategy kernel that owns both directional state machines without duplicating account balance or liquidation decisions
 
 ### Missing or Weak Test Coverage
 
 1. End-to-end replay of one identical fill/candle history through live reconstruction and exact backtest orchestration; shared Rust primitive tests cover the calculations but not the complete orchestration trace
 2. Connector-level restart races while protective panic-close orders are live on an exchange
 3. Manual or external trading during downtime across the full exchange-adapter matrix
-4. Apple MPS parity for dual-side multi-coin coin and unified HSL scopes
+4. Apple MPS parity for dual-side multi-coin Trailing Martingale coin and unified HSL scopes
 
 ## Optimizer Work
 

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -134,7 +134,9 @@ The supported slice is intentionally narrow:
   `risk.position_exposure_enforcer_threshold`; per-coin
   `risk.we_excess_allowance_mode`, trailing-martingale `entry.ema_gate_mode`, disabled sides, and
   other override leaves fail closed. In one-sided `live.hsl_signal_mode: coin` runs, all ten HSL
-  leaves documented in `coin_overrides.md` are also supported; other HSL topologies fail closed
+  leaves documented in `coin_overrides.md` are also supported. Fused dual-side EMA Anchor coin
+  mode resolves the same HSL leaves independently for long and short; dual-side Trailing
+  Martingale coin-mode HSL overrides remain fail closed
 - one-sided single-coin and multi-coin EMA Anchor and Trailing Martingale runs support HSL with
   `coin`, `pside`, or `unified` signals and both resting-limit and market panic closes. Unified and
   pside multi-coin runs use one portfolio controller; coin mode uses an independent controller per
@@ -157,7 +159,11 @@ The supported slice is intentionally narrow:
   post-restart retriggers) and panic-loss metrics (loss sum/max, per-episode loss
   drawdown min/mean/max, and halt-to-restart equity loss) may be used for scoring and limits.
   One-sided coin-mode multi-coin runs may resolve all canonical HSL settings independently per
-  coin, including HSL enablement and limit/market panic execution. Dual-side multi-coin HSL and HSL
+  coin, including HSL enablement and limit/market panic execution. Dual-side multi-coin EMA Anchor
+  uses one fused shared-account kernel for unified, pside, and coin signals, so shared event-loss,
+  warning-tier overlap, and the other HSL lifecycle/panic-loss metrics are available. Dual-side
+  multi-coin Trailing Martingale remains limited to pside signals; shared event-loss and
+  warning-tier overlap metrics remain fail closed on its independent directional proxy. HSL
   strategy-equity EMA/recovery-distribution metrics remain fail closed for now.
   Compatible suites may use the supported topologies.
 - single-coin EMA Anchor and Trailing Martingale support auto-unstuck for long-only,

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -980,9 +980,9 @@ def _validate_scope_config(
                         )
             if repair_paths:
                 raise ValueError(
-                    "GPU dual-side multicoin exposure/unstuck repair requires a shared-"
-                    "balance portfolio kernel; independent directional runners "
-                    f"cannot model {sorted(repair_paths)}"
+                    "GPU dual-side multicoin exposure/unstuck repair requires a strategy-"
+                    "complete shared-balance portfolio kernel; the current GPU topology "
+                    f"does not model {sorted(repair_paths)}"
                 )
         if not bool(config.get("backtest", {}).get("dynamic_wel_by_tradability")):
             raise ValueError(
@@ -1014,6 +1014,11 @@ def _validate_scope_config(
             signal_mode,
             coin_count=coin_count,
             enabled_side_count=len(enabled_sides),
+            shared_account_controller=(
+                coin_count > 1
+                and len(enabled_sides) == 2
+                and strategy_kind == "ema_anchor"
+            ),
         )
         for side in hsl_enabled_sides:
             hsl = config["bot"][side].get("hsl", {})
@@ -1089,7 +1094,12 @@ def _validate_dual_multicoin_metrics(
 
 
 def _validate_hsl_metric_topology(
-    needed_metrics, *, coin_count: int, enabled_sides, hard_stop_metrics
+    needed_metrics,
+    *,
+    coin_count: int,
+    enabled_sides,
+    hard_stop_metrics,
+    shared_account_controller: bool = False,
 ) -> None:
     shared_account_metrics = {
         "hard_stop_halt_to_restart_equity_loss_pct",
@@ -1107,7 +1117,12 @@ def _validate_hsl_metric_topology(
         & set(hard_stop_metrics)
         & (shared_account_metrics | tier_overlap_metrics)
     )
-    if int(coin_count) > 1 and len(set(enabled_sides)) > 1 and unsupported:
+    if (
+        int(coin_count) > 1
+        and len(set(enabled_sides)) > 1
+        and unsupported
+        and not shared_account_controller
+    ):
         raise ValueError(
             "GPU dual-side multi-coin HSL metrics require shared event-level "
             "account equity or minute-level cross-side tier overlap which "
@@ -1228,10 +1243,16 @@ def _validate_gpu_coin_overrides(
         signal_mode = str(
             config.get("live", {}).get("hsl_signal_mode", "unified")
         ).strip().lower()
-        if signal_mode != "coin" or len(enabled_sides) != 1:
+        dual_fused_ema = (
+            strategy_kind == "ema_anchor" and len(enabled_sides) == 2
+        )
+        if signal_mode != "coin" or not (
+            len(enabled_sides) == 1 or dual_fused_ema
+        ):
             raise ValueError(
                 "GPU per-coin HSL overrides require live.hsl_signal_mode=coin "
-                "and exactly one enabled side; unsupported paths: "
+                "and either one enabled side or fused dual-side EMA Anchor; "
+                "unsupported paths: "
                 f"{sorted(hsl_override_paths)}"
             )
         for coin, patch in overrides.items():
@@ -2536,10 +2557,6 @@ def _validate_pinned_scope_bounds(
 ) -> None:
     enabled_sides = set(enabled_sides or ("long", "short"))
     pinned = {}
-    if len(enabled_sides) != 1:
-        pinned.update(
-            {f"{side}_hsl_enabled": 0.0 for side in ("long", "short")}
-        )
     if coin_count > 1 and len(enabled_sides) == 2:
         pinned.update(
             {f"{side}_unstuck_enabled": 0.0 for side in ("long", "short")}
@@ -3203,6 +3220,11 @@ def run_backend(
         coin_count=max_coin_count,
         enabled_sides=enabled_sides,
         hard_stop_metrics=HARD_STOP_PROXY_METRICS,
+        shared_account_controller=(
+            max_coin_count > 1
+            and len(enabled_sides) == 2
+            and strategy_kind == "ema_anchor"
+        ),
     )
     _validate_dual_multicoin_metrics(
         needed_metrics,

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -13,15 +13,25 @@ HSL_SIGNAL_MODES = {"unified", "pside", "coin"}
 
 
 def validate_hsl_signal_topology(
-    signal_mode: str, *, coin_count: int, enabled_side_count: int
+    signal_mode: str,
+    *,
+    coin_count: int,
+    enabled_side_count: int,
+    shared_account_controller: bool = False,
 ) -> None:
+    """Fail closed unless the selected HSL scope has the state it requires."""
+
     if signal_mode not in HSL_SIGNAL_MODES:
         raise ValueError(
             "GPU HSL requires live.hsl_signal_mode to be coin, pside, or "
             f"unified; got {signal_mode!r}"
         )
     if coin_count > 1:
-        if enabled_side_count > 1 and signal_mode != "pside":
+        if (
+            enabled_side_count > 1
+            and signal_mode != "pside"
+            and not shared_account_controller
+        ):
             raise ValueError(
                 "GPU dual-side multi-coin HSL currently supports only pside "
                 "signal mode; coin requires a shared-balance denominator and "

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -1375,6 +1375,7 @@ class MpsMulticoinProxy:
         from backtest import build_backtest_payload
         from optimization.gpu.metrics import compute_objectives
         from optimization.gpu.mps_kernel import (
+            MpsEmaAnchorMulticoinFusedRunner,
             MpsEmaAnchorMulticoinRunner,
             MpsTrailingMartingaleMulticoinRunner,
         )
@@ -1420,6 +1421,9 @@ class MpsMulticoinProxy:
                 "MPS multicoin proxy requires one or two enabled sides"
             )
         self.sides = enabled_sides
+        self.shared_account_fused = (
+            self.strategy_kind == "ema_anchor" and len(self.sides) == 2
+        )
         _require_multicoin_metric_topology(self.sides, self.needed_metrics)
         if len(enabled_sides) == 2 and not bool(
             config.get("live", {}).get("hedge_mode")
@@ -1514,6 +1518,7 @@ class MpsMulticoinProxy:
                 signal_mode,
                 coin_count=coin_count,
                 enabled_side_count=len(self.sides),
+                shared_account_controller=self.shared_account_fused,
             )
             _require_no_internal_invalid_multicoin_hsl_candles(
                 values,
@@ -1664,11 +1669,17 @@ class MpsMulticoinProxy:
                     side: per_side_override_contracts[side]["values"]
                     for side in self.sides
                 },
-                "proxy_mode": "independent-side-hedge-v1",
+                "proxy_mode": (
+                    "shared-account-fused-ema-v1"
+                    if self.shared_account_fused
+                    else "independent-side-hedge-v1"
+                ),
             }
             if hsl_enabled_sides:
                 self.coin_override_contract["hsl_proxy_mode"] = (
-                    "independent-pside-v1"
+                    "shared-account-fused-ema-v1"
+                    if self.shared_account_fused
+                    else "independent-pside-v1"
                 )
                 self.coin_override_contract["hsl_signal_mode"] = str(
                     signal_mode
@@ -1745,39 +1756,64 @@ class MpsMulticoinProxy:
             values, timestamps, runs=runs, markets=markets
         )
         self.metrics_data = {"ts0": self.data["ts0"], "n": self.data["n"]}
-        runner_cls = (
-            MpsTrailingMartingaleMulticoinRunner
-            if self.strategy_kind == "trailing_martingale"
-            else MpsEmaAnchorMulticoinRunner
-        )
         self.runners = {}
-        for side in self.sides:
-            runner_kwargs = {
-                "side": side,
-                "forager_score_hysteresis_pct": self.forager_score_hysteresis_pct,
-                "max_realized_loss_pct": float(
-                    backtest_params.get("max_realized_loss_pct", 1.0)
-                ),
-                "collect_coin_fill_counts": bool(
-                    self.needed_metrics
-                    & {"fills_active_symbols_count", "fills_top_symbol_share"}
-                ),
-                "market_order_slippage_pct": float(
-                    backtest_params.get("market_order_slippage_pct", 0.0)
-                ),
-                "hsl_panic_market": str(
-                    flatten_shared_bot_side(config["bot"][side]).get(
+        self.fused_runner = None
+        common_runner_kwargs = {
+            "forager_score_hysteresis_pct": self.forager_score_hysteresis_pct,
+            "max_realized_loss_pct": float(
+                backtest_params.get("max_realized_loss_pct", 1.0)
+            ),
+            "collect_coin_fill_counts": bool(
+                self.needed_metrics
+                & {"fills_active_symbols_count", "fills_top_symbol_share"}
+            ),
+            "market_order_slippage_pct": float(
+                backtest_params.get("market_order_slippage_pct", 0.0)
+            ),
+        }
+        if self.shared_account_fused:
+            self.fused_runner = MpsEmaAnchorMulticoinFusedRunner(
+                self.run,
+                self.data,
+                long_coin_overrides=per_side_coin_overrides["long"],
+                short_coin_overrides=per_side_coin_overrides["short"],
+                hsl_panic_market_long=str(
+                    flatten_shared_bot_side(config["bot"]["long"]).get(
                         "hsl_panic_close_order_type", "limit"
                     )
                 ).strip().lower()
                 == "market",
-            }
-            runner_kwargs["coin_overrides"] = per_side_coin_overrides[side]
-            self.runners[side] = runner_cls(
-                self.run,
-                self.data,
-                **runner_kwargs,
+                hsl_panic_market_short=str(
+                    flatten_shared_bot_side(config["bot"]["short"]).get(
+                        "hsl_panic_close_order_type", "limit"
+                    )
+                ).strip().lower()
+                == "market",
+                **common_runner_kwargs,
             )
+        else:
+            runner_cls = (
+                MpsTrailingMartingaleMulticoinRunner
+                if self.strategy_kind == "trailing_martingale"
+                else MpsEmaAnchorMulticoinRunner
+            )
+            for side in self.sides:
+                runner_kwargs = {
+                    "side": side,
+                    "hsl_panic_market": str(
+                        flatten_shared_bot_side(config["bot"][side]).get(
+                            "hsl_panic_close_order_type", "limit"
+                        )
+                    ).strip().lower()
+                    == "market",
+                    **common_runner_kwargs,
+                }
+                runner_kwargs["coin_overrides"] = per_side_coin_overrides[side]
+                self.runners[side] = runner_cls(
+                    self.run,
+                    self.data,
+                    **runner_kwargs,
+                )
 
     def _parameter_matrix(
         self, candidates: list[dict], side: str | None = None
@@ -1805,27 +1841,43 @@ class MpsMulticoinProxy:
     def evaluate(self, candidates: list[dict]) -> list[dict]:
         results: list[dict] = []
         torch = self._torch
+        fused_runner = getattr(self, "fused_runner", None)
         for start in range(0, len(candidates), self.batch_size):
             chunk = candidates[start : start + self.batch_size]
             parameter_matrices = {
                 side: self._parameter_matrix(chunk, side) for side in self.sides
             }
-            raw_side_outputs = {
-                side: self.runners[side].run(
-                    parameter_matrices[side],
+            if fused_runner is not None:
+                fused_parameters = np.concatenate(
+                    (parameter_matrices["long"], parameter_matrices["short"]),
+                    axis=1,
+                )
+                raw_output = fused_runner.run(
+                    fused_parameters,
                     profile=self.profile_enabled,
                 )
-                for side in self.sides
-            }
-            side_outputs = {
-                side: {
+                output = {
                     key: value.cpu()
-                    for key, value in raw_side_outputs[side].items()
+                    for key, value in raw_output.items()
                     if key in CORE_OUTPUT_KEYS | DIRECTIONAL_HSL_OUTPUT_KEYS
                 }
-                for side in self.sides
-            }
-            if len(self.sides) == 1:
+            else:
+                raw_side_outputs = {
+                    side: self.runners[side].run(
+                        parameter_matrices[side],
+                        profile=self.profile_enabled,
+                    )
+                    for side in self.sides
+                }
+                side_outputs = {
+                    side: {
+                        key: value.cpu()
+                        for key, value in raw_side_outputs[side].items()
+                        if key in CORE_OUTPUT_KEYS | DIRECTIONAL_HSL_OUTPUT_KEYS
+                    }
+                    for side in self.sides
+                }
+            if fused_runner is None and len(self.sides) == 1:
                 side = self.sides[0]
                 output = side_outputs[side]
                 output.update(
@@ -1838,7 +1890,7 @@ class MpsMulticoinProxy:
                         side, output["entry_initial_balance_pct"]
                     )
                 )
-            else:
+            elif fused_runner is None:
                 output = _combine_hedged_multicoin_outputs(
                     side_outputs["long"],
                     side_outputs["short"],

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1547,8 +1547,24 @@ def test_gpu_hsl_accepts_dual_side_multicoin_pside_mode():
 
 
 @pytest.mark.parametrize("signal_mode", ["coin", "unified"])
-def test_gpu_hsl_rejects_dual_side_multicoin_joint_account_modes(signal_mode):
+def test_gpu_hsl_accepts_dual_side_multicoin_fused_ema_modes(signal_mode):
     config = _directional_ema_config(long_enabled=True, short_enabled=True)
+    coins = ["BTC", "ETH", "XRP"]
+    config["live"]["approved_coins"] = {"long": coins, "short": coins}
+    config["live"]["hsl_signal_mode"] = signal_mode
+    config["live"]["hedge_mode"] = True
+    for side in ("long", "short"):
+        config["bot"][side]["risk"]["n_positions"] = 3
+        config["bot"][side]["hsl"]["enabled"] = True
+
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
+
+
+@pytest.mark.parametrize("signal_mode", ["coin", "unified"])
+def test_gpu_hsl_keeps_dual_side_multicoin_tm_joint_modes_fail_closed(
+    signal_mode,
+):
+    config = _directional_tm_config(long_enabled=True, short_enabled=True)
     coins = ["BTC", "ETH", "XRP"]
     config["live"]["approved_coins"] = {"long": coins, "short": coins}
     config["live"]["hsl_signal_mode"] = signal_mode
@@ -1596,6 +1612,20 @@ def test_gpu_hsl_metrics_reject_only_dual_multicoin_tier_overlap():
                 "hard_stop_panic_close_loss_drawdown_pct_mean"
             },
         )
+
+    _validate_hsl_metric_topology(
+        {
+            "hard_stop_time_in_red_pct",
+            "hard_stop_panic_close_loss_drawdown_pct_mean",
+        },
+        coin_count=3,
+        enabled_sides=["long", "short"],
+        hard_stop_metrics={
+            "hard_stop_time_in_red_pct",
+            "hard_stop_panic_close_loss_drawdown_pct_mean",
+        },
+        shared_account_controller=True,
+    )
 
     _validate_hsl_metric_topology(
         {"hard_stop_panic_close_loss_sum"},
@@ -2145,7 +2175,7 @@ def test_gpu_multicoin_rejects_invalid_coin_hsl_values(hsl_patch, match):
 
 @pytest.mark.parametrize(
     ("signal_mode", "enabled_sides"),
-    [("pside", ["long"]), ("unified", ["long"]), ("coin", ["long", "short"])],
+    [("pside", ["long"]), ("unified", ["long"])],
 )
 def test_gpu_multicoin_coin_hsl_overrides_fail_closed_outside_one_side_coin_mode(
     signal_mode, enabled_sides
@@ -2163,6 +2193,42 @@ def test_gpu_multicoin_coin_hsl_overrides_fail_closed_outside_one_side_coin_mode
             config,
             strategy_kind="ema_anchor",
             enabled_sides=enabled_sides,
+            coin_count=3,
+        )
+
+
+def test_gpu_multicoin_coin_hsl_overrides_accept_fused_dual_side_ema():
+    config = _directional_ema_config(long_enabled=True, short_enabled=True)
+    config["live"]["hsl_signal_mode"] = "coin"
+    config["coin_overrides"] = {
+        "ETH": {
+            "bot": {
+                "long": {"hsl": {"enabled": True}},
+                "short": {"hsl": {"enabled": True}},
+            }
+        }
+    }
+
+    _validate_gpu_coin_overrides(
+        config,
+        strategy_kind="ema_anchor",
+        enabled_sides=["long", "short"],
+        coin_count=3,
+    )
+
+
+def test_gpu_multicoin_coin_hsl_overrides_keep_dual_side_tm_fail_closed():
+    config = _directional_tm_config(long_enabled=True, short_enabled=True)
+    config["live"]["hsl_signal_mode"] = "coin"
+    config["coin_overrides"] = {
+        "ETH": {"bot": {"long": {"hsl": {"enabled": True}}}}
+    }
+
+    with pytest.raises(ValueError, match="fused dual-side EMA Anchor"):
+        _validate_gpu_coin_overrides(
+            config,
+            strategy_kind="trailing_martingale",
+            enabled_sides=["long", "short"],
             coin_count=3,
         )
 
@@ -4616,7 +4682,7 @@ def test_gpu_accepts_unstuck_bounds_for_single_side_but_pins_dual_multicoin():
         )
 
 
-def test_gpu_accepts_hsl_bounds_for_single_side_but_pins_dual_multicoin():
+def test_gpu_accepts_hsl_bounds_for_single_and_dual_multicoin():
     bounds = {
         "long_hsl_enabled": Bound(1.0, 1.0, None),
         "long_hsl_red_threshold": Bound(0.05, 0.2, None),
@@ -4626,10 +4692,9 @@ def test_gpu_accepts_hsl_bounds_for_single_side_but_pins_dual_multicoin():
     base = {"long_hsl_enabled": 1.0}
 
     _validate_pinned_scope_bounds(bounds, base, {"long"}, coin_count=2)
-    with pytest.raises(ValueError, match="hsl_enabled"):
-        _validate_pinned_scope_bounds(
-            bounds, base, {"long", "short"}, coin_count=2
-        )
+    _validate_pinned_scope_bounds(
+        bounds, base, {"long", "short"}, coin_count=2
+    )
 
 
 def test_gpu_anchor_constant_twel_threshold_is_supported_for_multicoin():

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -24,7 +24,8 @@ from optimization.gpu.mps_kernel import (
     _decode_ema_multicoin_fused_outputs,
     _encode_max_realized_loss_pct,
 )
-from optimization.gpu.metrics import _fill_gap_metrics
+from optimization.gpu.metrics import _fill_gap_metrics, compute_objectives
+from optimization.gpu.service import MpsMulticoinEmaProxy
 
 
 def _assert_fill_scalar_contract(output):
@@ -2888,7 +2889,7 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
         (coin_count, 29), float("nan"), dtype=torch.float32, device="mps"
     )
     run_settings = torch.tensor(
-        [1_000.0, 50.0, 60_000.0, 0.0, 0.02, 0.1, 1.0, 0.0, 0.0, 0.0],
+        [1_000.0, 50.0, 60_000.0, 0.0, 0.02, 1.0, 1.0, 0.0, 0.0, 0.0],
         dtype=torch.float32,
         device="mps",
     )
@@ -2972,9 +2973,10 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
         long_coin_overrides=override_matrix,
         short_coin_overrides=override_matrix,
         forager_score_hysteresis_pct=0.02,
-        max_realized_loss_pct=0.1,
+        max_realized_loss_pct=1.0,
         collect_coin_fill_counts=True,
     )
+    torch.testing.assert_close(runner.settings, run_settings)
     runner_output = runner.run(
         np.asarray(rows, dtype=np.float64), profile=True
     )
@@ -3002,6 +3004,90 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
     ]
     assert torch.equal(runner_output["coin_fill_counts"], coin_fill_counts)
     assert runner.last_profile["kernel_seconds"] >= 0.0
+
+    metric_rows = []
+    red_threshold_index = EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index(
+        "hsl_red_threshold"
+    )
+    restart_policy_index = EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index(
+        "hsl_restart_policy"
+    )
+    for signal_mode in range(3):
+        row = side_row(signal_mode) + side_row(signal_mode)
+        for side_offset in (0, len(EMA_ANCHOR_MULTICOIN_PARAM_KEYS)):
+            row[side_offset + red_threshold_index] = 0.001
+            row[side_offset + restart_policy_index] = 2.0
+        metric_rows.append(row)
+
+    proxy = MpsMulticoinEmaProxy.__new__(MpsMulticoinEmaProxy)
+    proxy.batch_size = 3
+    proxy._torch = torch
+    proxy.profile_enabled = False
+    proxy.metrics_data = {"ts0": data["ts0"], "n": data["n"]}
+    proxy.run = runs[0]
+    proxy.sides = ["long", "short"]
+    proxy.needed_metrics = {
+        "hard_stop_panic_close_loss_drawdown_pct_mean",
+        "hard_stop_time_in_red_pct",
+        "hard_stop_triggers",
+        "hard_stop_triggers_long",
+        "hard_stop_triggers_short",
+    }
+    proxy.param_keys = EMA_ANCHOR_MULTICOIN_PARAM_KEYS
+    width = len(EMA_ANCHOR_MULTICOIN_PARAM_KEYS)
+    proxy.base_params = {
+        "long": dict(
+            zip(EMA_ANCHOR_MULTICOIN_PARAM_KEYS, metric_rows[0][:width])
+        ),
+        "short": dict(
+            zip(EMA_ANCHOR_MULTICOIN_PARAM_KEYS, metric_rows[0][width:])
+        ),
+    }
+    proxy.fused_runner = runner
+    proxy.runners = {}
+    candidates = [
+        {
+            **{
+                f"long_{key}": row[index]
+                for index, key in enumerate(EMA_ANCHOR_MULTICOIN_PARAM_KEYS)
+            },
+            **{
+                f"short_{key}": row[width + index]
+                for index, key in enumerate(EMA_ANCHOR_MULTICOIN_PARAM_KEYS)
+            },
+        }
+        for row in metric_rows
+    ]
+    np.testing.assert_allclose(
+        proxy._parameter_matrix(candidates, "long"),
+        np.asarray(metric_rows, dtype=np.float64)[:, :width],
+    )
+    np.testing.assert_allclose(
+        proxy._parameter_matrix(candidates, "short"),
+        np.asarray(metric_rows, dtype=np.float64)[:, width:],
+    )
+    seen_hsl_triggers = {}
+
+    def reduce_service_output(output, *args, **kwargs):
+        seen_hsl_triggers["long"] = output["hsl_triggers_long"].clone()
+        seen_hsl_triggers["short"] = output["hsl_triggers_short"].clone()
+        return compute_objectives(output, *args, **kwargs)
+
+    proxy._compute_objectives = reduce_service_output
+    service_results = proxy.evaluate(candidates)
+    assert (seen_hsl_triggers["long"] + seen_hsl_triggers["short"] > 0.0).all()
+    assert all(item["hard_stop_triggers"] > 0.0 for item in service_results)
+    assert all(
+        item["hard_stop_triggers"]
+        == item["hard_stop_triggers_long"] + item["hard_stop_triggers_short"]
+        for item in service_results
+    )
+    assert all(item["hard_stop_time_in_red_pct"] > 0.0 for item in service_results)
+    assert all(
+        item["hard_stop_panic_close_loss_drawdown_pct_mean"] > 0.0
+        for item in service_results
+    )
+
     with pytest.raises(ValueError, match="84 columns"):
         runner.run(np.asarray([side_row(0)], dtype=np.float64))
     truncated = runner.run(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -1,9 +1,11 @@
-from types import SimpleNamespace
+import sys
+from types import ModuleType, SimpleNamespace
 
 import numpy as np
 import pytest
 
 from config.shared_bot import flatten_shared_bot_side
+from config.schema import get_template_config
 from optimization.gpu.model import (
     EMA_ANCHOR_MULTICOIN_PARAM_KEYS,
     EMA_ANCHOR_PARAM_KEYS,
@@ -453,6 +455,230 @@ def test_multicoin_proxy_preserves_directional_hsl_outputs_for_reduction():
     assert proxy.evaluate([{}]) == [{"hard_stop_panic_close_loss_sum": 37.5}]
 
 
+def test_multicoin_ema_proxy_routes_dual_side_batch_through_fused_runner():
+    torch = pytest.importorskip("torch")
+    proxy = MpsMulticoinEmaProxy.__new__(MpsMulticoinEmaProxy)
+    proxy.batch_size = 2
+    proxy._torch = torch
+    proxy.profile_enabled = False
+    proxy.metrics_data = {"ts0": 1_000.0}
+    proxy.run = SimpleNamespace()
+    proxy.sides = ["long", "short"]
+    proxy.needed_metrics = {"hard_stop_triggers"}
+    proxy.param_keys = EMA_ANCHOR_MULTICOIN_PARAM_KEYS
+    proxy.base_params = {
+        side: {
+            key: float(index + (100 if side == "short" else 0))
+            for index, key in enumerate(EMA_ANCHOR_MULTICOIN_PARAM_KEYS)
+        }
+        for side in ("long", "short")
+    }
+    seen = {}
+
+    def run(params, **kwargs):
+        seen["params"] = params.copy()
+        seen["kwargs"] = kwargs
+        batch = len(params)
+        raw = {
+            key: torch.zeros(batch)
+            for key in (
+                "first_fill_ts",
+                "last_fill_ts",
+                "last_high_ts",
+                "first_eq_ts",
+                "last_eq_ts",
+            )
+        }
+        raw["hsl_triggers_long"] = torch.tensor([1.0, 2.0])
+        raw["hsl_triggers_short"] = torch.tensor([3.0, 4.0])
+        return raw
+
+    proxy.fused_runner = SimpleNamespace(run=run)
+    proxy.runners = {}
+
+    def reduce(output, *args, **kwargs):
+        return {
+            "hard_stop_triggers": output["hsl_triggers_long"]
+            + output["hsl_triggers_short"]
+        }
+
+    proxy._compute_objectives = reduce
+    candidates = [
+        {"long_offset": 0.25, "short_offset": 0.5},
+        {"long_offset": 0.75, "short_offset": 1.0},
+    ]
+
+    assert proxy.evaluate(candidates) == [
+        {"hard_stop_triggers": 4.0},
+        {"hard_stop_triggers": 6.0},
+    ]
+    assert seen["params"].shape == (
+        2,
+        len(EMA_ANCHOR_MULTICOIN_PARAM_KEYS) * 2,
+    )
+    offset_index = EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("offset")
+    side_width = len(EMA_ANCHOR_MULTICOIN_PARAM_KEYS)
+    assert seen["params"][:, offset_index].tolist() == [0.25, 0.75]
+    assert seen["params"][:, side_width + offset_index].tolist() == [0.5, 1.0]
+    assert seen["kwargs"] == {"profile": False}
+
+
+def test_multicoin_ema_proxy_constructs_fused_shared_account_runner(monkeypatch):
+    torch = pytest.importorskip("torch")
+
+    import optimization.gpu.mps_kernel as mps_kernel
+    import optimization.gpu.service as gpu_service
+
+    monkeypatch.setattr(torch.backends.mps, "is_available", lambda: True)
+    backtest = ModuleType("backtest")
+    backtest._get_backtest_coin_override = lambda *args, **kwargs: {}
+    monkeypatch.setitem(sys.modules, "backtest", backtest)
+    config = get_template_config()
+    config["live"].update(
+        {
+            "strategy_kind": "ema_anchor",
+            "approved_coins": {
+                "long": ["BTC", "ETH"],
+                "short": ["BTC", "ETH"],
+            },
+            "ignored_coins": {"long": [], "short": []},
+            "hedge_mode": True,
+            "hsl_signal_mode": "coin",
+        }
+    )
+    config["backtest"]["dynamic_wel_by_tradability"] = True
+    for side in ("long", "short"):
+        config["bot"][side]["risk"].update(
+            {
+                "n_positions": 2,
+                "total_wallet_exposure_limit": 1.0,
+                "position_exposure_enforcer_enabled": False,
+                "total_exposure_enforcer_enabled": False,
+            }
+        )
+        config["bot"][side]["unstuck"]["enabled"] = False
+        config["bot"][side]["hsl"]["enabled"] = True
+        flat = flatten_shared_bot_side(config["bot"][side])
+        config["bot"][side].update(
+            {key: value for key, value in flat.items() if key.startswith("unstuck_")}
+        )
+
+    def bot_payload(side):
+        flat = flatten_shared_bot_side(config["bot"][side])
+        return {
+            "entry_cooldown_minutes": flat["risk_entry_cooldown_minutes"],
+            "filter_volume_ema_span_1m": flat[
+                "forager_volume_ema_span_1m"
+            ],
+            "filter_volatility_ema_span_1m": flat[
+                "forager_volatility_ema_span_1m"
+            ],
+            "filter_volume_drop_pct": flat["forager_volume_drop_pct"],
+            "forager_score_weights": flat["forager_score_weights"],
+            "n_positions": flat["n_positions"],
+            "total_wallet_exposure_limit": flat[
+                "total_wallet_exposure_limit"
+            ],
+            "risk_twel_entry_gate_enabled": flat[
+                "risk_twel_entry_gate_enabled"
+            ],
+            "risk_twel_enforcer_enabled": flat["risk_twel_enforcer_enabled"],
+            "risk_twel_enforcer_policy": flat["risk_twel_enforcer_policy"],
+            "risk_twel_enforcer_threshold": flat[
+                "risk_twel_enforcer_threshold"
+            ],
+            "unstuck_enabled": flat["unstuck_enabled"],
+            "hsl_enabled": flat["hsl_enabled"],
+        }
+
+    payload = SimpleNamespace(
+        bot_params_list=[
+            {side: bot_payload(side) for side in ("long", "short")}
+            for _ in range(2)
+        ],
+        strategy_params_list=[
+            {
+                side: dict(config["bot"][side]["strategy"]["ema_anchor"])
+                for side in ("long", "short")
+            }
+            for _ in range(2)
+        ],
+        exchange_params=[
+            {
+                "qty_step": 0.001,
+                "price_step": 0.01,
+                "min_qty": 0.001,
+                "min_cost": 5.0,
+                "c_mult": 1.0,
+                "maker_fee": 0.0002,
+                "taker_fee": 0.0006,
+            }
+            for _ in range(2)
+        ],
+        backtest_params={
+            "candle_interval_minutes": 1,
+            "dynamic_wel_by_tradability": True,
+            "forager_score_hysteresis_pct": 0.0,
+            "last_valid_indices": [3, 3],
+            "first_valid_indices": [0, 0],
+            "equity_hard_stop_loss": {"signal_mode": "coin"},
+            "coins": ["BTC", "ETH"],
+            "starting_balance": 1_000.0,
+            "global_warmup_bars": 1,
+            "trade_start_indices": [1, 1],
+            "requested_start_timestamp_ms": 0,
+            "first_timestamp_ms": 0,
+            "liquidation_threshold": 0.05,
+            "max_realized_loss_pct": 1.0,
+            "market_order_slippage_pct": 0.0,
+        },
+    )
+    backtest.build_backtest_payload = lambda *args, **kwargs: payload
+    monkeypatch.setattr(
+        gpu_service,
+        "build_mps_multicoin_data",
+        lambda *args, **kwargs: {
+            "n": 4,
+            "n_coins": 2,
+            "n_days": 1,
+            "ts0": 0,
+        },
+    )
+    constructed = {}
+
+    class FakeFusedRunner:
+        def __init__(self, run, data, **kwargs):
+            constructed.update({"run": run, "data": data, "kwargs": kwargs})
+
+    monkeypatch.setattr(
+        mps_kernel, "MpsEmaAnchorMulticoinFusedRunner", FakeFusedRunner
+    )
+    values = np.ones((4, 2, 4), dtype=np.float64)
+    timestamps = np.arange(4, dtype=np.int64) * 60_000
+
+    proxy = MpsMulticoinEmaProxy(
+        config=config,
+        hlcvs=values,
+        mss={"BTC": {}, "ETH": {}},
+        btc=np.ones(4, dtype=np.float64),
+        timestamps=timestamps,
+        exchange="bybit",
+        batch_size=8,
+        needed_metrics={"hard_stop_time_in_red_pct"},
+    )
+
+    assert isinstance(proxy.fused_runner, FakeFusedRunner)
+    assert proxy.runners == {}
+    assert proxy.coin_override_contract["proxy_mode"] == (
+        "shared-account-fused-ema-v1"
+    )
+    assert proxy.coin_override_contract["hsl_proxy_mode"] == (
+        "shared-account-fused-ema-v1"
+    )
+    assert constructed["kwargs"]["long_coin_overrides"].shape == (2, 29)
+    assert constructed["kwargs"]["short_coin_overrides"].shape == (2, 29)
+
+
 def test_gpu_proxy_requires_complete_valid_tail():
     _require_complete_valid_tail(99, 100)
 
@@ -727,6 +953,16 @@ def test_one_sided_multicoin_hsl_accepts_all_signal_modes(signal_mode):
 def test_dual_side_multicoin_hsl_accepts_decomposable_pside_mode():
     validate_hsl_signal_topology(
         "pside", coin_count=3, enabled_side_count=2
+    )
+
+
+@pytest.mark.parametrize("signal_mode", ["unified", "pside", "coin"])
+def test_dual_side_multicoin_hsl_accepts_shared_account_controller(signal_mode):
+    validate_hsl_signal_topology(
+        signal_mode,
+        coin_count=3,
+        enabled_side_count=2,
+        shared_account_controller=True,
     )
 
 


### PR DESCRIPTION
## Summary
- route dual-side multi-coin EMA Anchor screening through one fused shared-account MPS runner
- support unified, pside, and coin HSL scopes, per-side coin-mode HSL overrides, and shared event/tier HSL metrics
- remove the stale dual-side HSL-enable pin while keeping dual-side Trailing Martingale, auto-unstuck, and exposure repair fail closed where shared strategy state is not yet modeled
- document the supported topology and remaining gaps

## Safety
- GPU screening remains additive and fail closed; CPU optimization, backtesting, and live bot paths are unchanged
- exact Rust validation and drift gates remain authoritative

## Validation
- Rust: 265 passed
- GPU service/backend: 482 passed
- optimizer: 229 passed
- physical Apple MPS matrix: 276 passed
- loaded Rust extension source stamp verified against this worktree
- Python compileall and git diff --check passed