### PR TITLE
refactor(gpu): encapsulate TM multicoin side state

### DIFF
--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -600,6 +600,21 @@ mod tests {
         assert!(source.contains("apply_coin_hsl_overrides("));
         assert!(source.contains("constant int COIN_COLS = 12"));
         assert!(source.contains("constant int SCALAR_COLS = 57"));
+        assert_eq!(
+            source
+                .matches("struct TrailingMartingaleMulticoinSideState")
+                .count(),
+            1
+        );
+        assert!(source.contains("TrailingMartingaleMulticoinSideState side"));
+        assert!(source.contains("thread HslState& hsl = side.hsl"));
+        assert!(source.contains("thread HslState* coin_hsl = side.coin_hsl"));
+        assert!(source.contains("thread float* psize = side.psize"));
+        assert!(source.contains("thread int* entry_tick = side.entry_tick"));
+        assert!(source.contains("thread bool* selected = side.selected"));
+        assert!(source.contains("thread bool& selection_initialized = side.selection_initialized"));
+        assert!(source.contains("thread int& max_tradable_seen = side.max_tradable_seen"));
+        assert!(source.contains("side.previous_effective_n_positions"));
         assert!(source.contains("load_hsl(params, po, 48)"));
         assert!(source.contains("write_one_side_hsl_outputs("));
         assert!(source.contains("record_hsl_panic_fill("));

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -327,6 +327,68 @@ inline int recursive_grid_close_groups_after_reducer(
     return group_count;
 }
 
+// One complete directional Trailing Martingale portfolio. Keeping the mutable
+// per-coin state behind one thread-local value lets a future fused kernel own
+// long and short portfolios concurrently without changing the proven one-side
+// candle loop.
+struct TrailingMartingaleMulticoinSideState {
+    HslState hsl;
+    HslState coin_hsl[MAX_COINS];
+    ulong coin_hsl_entry_blocked_mask;
+    float ema0[MAX_COINS];
+    float ema1[MAX_COINS];
+    float ema2[MAX_COINS];
+    float volatility_1m[MAX_COINS];
+    float volatility_1h[MAX_COINS];
+    float forager_volume[MAX_COINS];
+    float forager_volatility[MAX_COINS];
+    float hour_high[MAX_COINS];
+    float hour_low[MAX_COINS];
+    float psize[MAX_COINS];
+    float pprice[MAX_COINS];
+    float last_increase_k[MAX_COINS];
+    float entry_qty[MAX_COINS];
+    float close_qty[MAX_COINS];
+    float secondary_close_qty[MAX_COINS];
+    float twel_close_qty[MAX_COINS];
+    float unstuck_close_qty[MAX_COINS];
+    float close_gen_balance[MAX_COINS];
+    float close_gen_allowed_wel[MAX_COINS];
+    float close_grid_gen_psize[MAX_COINS];
+    float position_open_k[MAX_COINS];
+    float position_last_fill_k[MAX_COINS];
+    float score[MAX_COINS];
+    float contribution[MAX_COINS];
+    float minimum_entry[MAX_COINS];
+    float min_since_open[MAX_COINS];
+    float max_since_min[MAX_COINS];
+    float max_since_open[MAX_COINS];
+    float min_since_max[MAX_COINS];
+    int entry_tick[MAX_COINS];
+    int close_tick[MAX_COINS];
+    int secondary_close_tick[MAX_COINS];
+    int twel_close_tick[MAX_COINS];
+    int unstuck_close_tick[MAX_COINS];
+    int close_grid_max_rungs[MAX_COINS];
+    bool selected[MAX_COINS];
+    bool incumbent[MAX_COINS];
+    bool survivor[MAX_COINS];
+    bool entry_candidate[MAX_COINS];
+    bool close_reconstruct_after_reducer[MAX_COINS];
+    bool filled_coin[MAX_COINS];
+    bool close_is_unstuck_reducer[MAX_COINS];
+    bool close_is_hsl_panic[MAX_COINS];
+    bool selection_initialized;
+    int max_tradable_seen;
+    int previous_effective_n_positions;
+    float alpha0_coin[MAX_COINS];
+    float alpha1_coin[MAX_COINS];
+    float alpha2_coin[MAX_COINS];
+    float alpha_1h_coin[MAX_COINS];
+    float alpha_1m_coin[MAX_COINS];
+    float coin_realized_pnl[MAX_COINS];
+};
+
 inline void passivbot_trailing_martingale_multicoin_impl(
     constant float* bars,
     constant int* fill_ticks,
@@ -413,10 +475,14 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     const float unstuck_ema_dist = params[po + 45];
     const float unstuck_loss_allowance_pct = params[po + 46];
     const float unstuck_threshold = params[po + 47];
-    HslState hsl = load_hsl(params, po, 48);
+    TrailingMartingaleMulticoinSideState side;
+    thread HslState& hsl = side.hsl;
+    hsl = load_hsl(params, po, 48);
     const bool coin_hsl_mode = hsl.signal_mode == HSL_SIGNAL_COIN;
-    HslState coin_hsl[MAX_COINS];
-    ulong coin_hsl_entry_blocked_mask = 0ul;
+    thread HslState* coin_hsl = side.coin_hsl;
+    thread ulong& coin_hsl_entry_blocked_mask =
+        side.coin_hsl_entry_blocked_mask;
+    coin_hsl_entry_blocked_mask = 0ul;
     const float weight_sum = w_volume + w_ready + w_volatility;
     if (weight_sum > 0.0f) {
         w_volume /= weight_sum;
@@ -442,55 +508,57 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     const bool hsl_panic_market = run_settings[8] > 0.5f;
     const float log_bin_scale = 127.0f / log(4000001.0f);
 
-    float ema0[MAX_COINS];
-    float ema1[MAX_COINS];
-    float ema2[MAX_COINS];
-    float volatility_1m[MAX_COINS];
-    float volatility_1h[MAX_COINS];
-    float forager_volume[MAX_COINS];
-    float forager_volatility[MAX_COINS];
-    float hour_high[MAX_COINS];
-    float hour_low[MAX_COINS];
-    float psize[MAX_COINS];
-    float pprice[MAX_COINS];
-    float last_increase_k[MAX_COINS];
-    float entry_qty[MAX_COINS];
-    float close_qty[MAX_COINS];
-    float secondary_close_qty[MAX_COINS];
-    float twel_close_qty[MAX_COINS];
-    float unstuck_close_qty[MAX_COINS];
-    float close_gen_balance[MAX_COINS];
-    float close_gen_allowed_wel[MAX_COINS];
-    float close_grid_gen_psize[MAX_COINS];
-    float position_open_k[MAX_COINS];
-    float position_last_fill_k[MAX_COINS];
-    float score[MAX_COINS];
-    float contribution[MAX_COINS];
-    float minimum_entry[MAX_COINS];
-    float min_since_open[MAX_COINS];
-    float max_since_min[MAX_COINS];
-    float max_since_open[MAX_COINS];
-    float min_since_max[MAX_COINS];
-    int entry_tick[MAX_COINS];
-    int close_tick[MAX_COINS];
-    int secondary_close_tick[MAX_COINS];
-    int twel_close_tick[MAX_COINS];
-    int unstuck_close_tick[MAX_COINS];
-    int close_grid_max_rungs[MAX_COINS];
-    bool selected[MAX_COINS];
-    bool incumbent[MAX_COINS];
-    bool survivor[MAX_COINS];
-    bool entry_candidate[MAX_COINS];
-    bool close_reconstruct_after_reducer[MAX_COINS];
-    bool filled_coin[MAX_COINS];
-    bool close_is_unstuck_reducer[MAX_COINS];
-    bool close_is_hsl_panic[MAX_COINS];
-    float alpha0_coin[MAX_COINS];
-    float alpha1_coin[MAX_COINS];
-    float alpha2_coin[MAX_COINS];
-    float alpha_1h_coin[MAX_COINS];
-    float alpha_1m_coin[MAX_COINS];
-    float coin_realized_pnl[MAX_COINS];
+    thread float* ema0 = side.ema0;
+    thread float* ema1 = side.ema1;
+    thread float* ema2 = side.ema2;
+    thread float* volatility_1m = side.volatility_1m;
+    thread float* volatility_1h = side.volatility_1h;
+    thread float* forager_volume = side.forager_volume;
+    thread float* forager_volatility = side.forager_volatility;
+    thread float* hour_high = side.hour_high;
+    thread float* hour_low = side.hour_low;
+    thread float* psize = side.psize;
+    thread float* pprice = side.pprice;
+    thread float* last_increase_k = side.last_increase_k;
+    thread float* entry_qty = side.entry_qty;
+    thread float* close_qty = side.close_qty;
+    thread float* secondary_close_qty = side.secondary_close_qty;
+    thread float* twel_close_qty = side.twel_close_qty;
+    thread float* unstuck_close_qty = side.unstuck_close_qty;
+    thread float* close_gen_balance = side.close_gen_balance;
+    thread float* close_gen_allowed_wel = side.close_gen_allowed_wel;
+    thread float* close_grid_gen_psize = side.close_grid_gen_psize;
+    thread float* position_open_k = side.position_open_k;
+    thread float* position_last_fill_k = side.position_last_fill_k;
+    thread float* score = side.score;
+    thread float* contribution = side.contribution;
+    thread float* minimum_entry = side.minimum_entry;
+    thread float* min_since_open = side.min_since_open;
+    thread float* max_since_min = side.max_since_min;
+    thread float* max_since_open = side.max_since_open;
+    thread float* min_since_max = side.min_since_max;
+    thread int* entry_tick = side.entry_tick;
+    thread int* close_tick = side.close_tick;
+    thread int* secondary_close_tick = side.secondary_close_tick;
+    thread int* twel_close_tick = side.twel_close_tick;
+    thread int* unstuck_close_tick = side.unstuck_close_tick;
+    thread int* close_grid_max_rungs = side.close_grid_max_rungs;
+    thread bool* selected = side.selected;
+    thread bool* incumbent = side.incumbent;
+    thread bool* survivor = side.survivor;
+    thread bool* entry_candidate = side.entry_candidate;
+    thread bool* close_reconstruct_after_reducer =
+        side.close_reconstruct_after_reducer;
+    thread bool* filled_coin = side.filled_coin;
+    thread bool* close_is_unstuck_reducer =
+        side.close_is_unstuck_reducer;
+    thread bool* close_is_hsl_panic = side.close_is_hsl_panic;
+    thread float* alpha0_coin = side.alpha0_coin;
+    thread float* alpha1_coin = side.alpha1_coin;
+    thread float* alpha2_coin = side.alpha2_coin;
+    thread float* alpha_1h_coin = side.alpha_1h_coin;
+    thread float* alpha_1m_coin = side.alpha_1m_coin;
+    thread float* coin_realized_pnl = side.coin_realized_pnl;
 
     for (int c = 0; c < MAX_COINS; ++c) {
         float seed_close = c < C ? coin_settings[c * COIN_COLS + 9] : 0.0f;
@@ -603,9 +671,13 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     int last_active_fill_day = -1;
     bool alive = true;
     bool equity_started = false;
-    bool selection_initialized = false;
-    int max_tradable_seen = 0;
-    int previous_effective_n_positions = 0;
+    thread bool& selection_initialized = side.selection_initialized;
+    thread int& max_tradable_seen = side.max_tradable_seen;
+    thread int& previous_effective_n_positions =
+        side.previous_effective_n_positions;
+    selection_initialized = false;
+    max_tradable_seen = 0;
+    previous_effective_n_positions = 0;
     float run_peak = -INFINITY;
     float max_dd = 0.0f;
     float total_wallet_exposure_max = 0.0f;

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -335,6 +335,92 @@ kernel void passivbot_ema_multicoin_side_state_isolation_probe(
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+def test_mps_tm_multicoin_side_states_are_isolated_for_fused_execution():
+    import passivbot_rust
+
+    probe_kernel = r"""
+kernel void passivbot_tm_multicoin_side_state_isolation_probe(
+    device float* output,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    TrailingMartingaleMulticoinSideState long_side;
+    TrailingMartingaleMulticoinSideState short_side;
+    long_side.psize[0] = 1.0f;
+    short_side.psize[0] = 2.0f;
+    long_side.entry_tick[0] = 3;
+    short_side.entry_tick[0] = 4;
+    long_side.selected[0] = true;
+    short_side.selected[0] = false;
+    long_side.close_grid_gen_psize[0] = 5.0f;
+    short_side.close_grid_gen_psize[0] = 6.0f;
+    long_side.hsl.enabled = true;
+    short_side.hsl.enabled = false;
+    long_side.coin_hsl[0].triggers = 7.0f;
+    short_side.coin_hsl[0].triggers = 8.0f;
+    long_side.coin_hsl_entry_blocked_mask = 9ul;
+    short_side.coin_hsl_entry_blocked_mask = 10ul;
+    long_side.selection_initialized = true;
+    short_side.selection_initialized = false;
+    long_side.max_tradable_seen = 11;
+    short_side.max_tradable_seen = 12;
+    long_side.previous_effective_n_positions = 13;
+    short_side.previous_effective_n_positions = 14;
+    output[0] = long_side.psize[0];
+    output[1] = short_side.psize[0];
+    output[2] = float(long_side.entry_tick[0]);
+    output[3] = float(short_side.entry_tick[0]);
+    output[4] = long_side.selected[0] && !short_side.selected[0] ? 1.0f : 0.0f;
+    output[5] = long_side.close_grid_gen_psize[0]
+        + short_side.close_grid_gen_psize[0];
+    output[6] = long_side.hsl.enabled && !short_side.hsl.enabled ? 1.0f : 0.0f;
+    output[7] = long_side.coin_hsl[0].triggers
+        + short_side.coin_hsl[0].triggers;
+    output[8] = float(
+        long_side.coin_hsl_entry_blocked_mask
+            + short_side.coin_hsl_entry_blocked_mask
+    );
+    output[9] = long_side.selection_initialized
+        && !short_side.selection_initialized ? 1.0f : 0.0f;
+    output[10] = float(long_side.max_tradable_seen);
+    output[11] = float(short_side.max_tradable_seen);
+    output[12] = float(long_side.previous_effective_n_positions);
+    output[13] = float(short_side.previous_effective_n_positions);
+}
+"""
+
+    output = torch.zeros(14, dtype=torch.float32, device="mps")
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_trailing_martingale_multicoin_source_py()
+        + probe_kernel
+    )
+    library.passivbot_tm_multicoin_side_state_isolation_probe(
+        output,
+        threads=(1, 1, 1),
+    )
+    torch.mps.synchronize()
+
+    assert output.cpu().tolist() == [
+        1.0,
+        2.0,
+        3.0,
+        4.0,
+        1.0,
+        11.0,
+        1.0,
+        15.0,
+        19.0,
+        1.0,
+        11.0,
+        12.0,
+        13.0,
+        14.0,
+    ]
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 def test_mps_ema_multicoin_dual_hsl_phase_covers_all_signal_topologies():
     import passivbot_rust
 


### PR DESCRIPTION
## Summary
- encapsulate one complete directional Trailing Martingale multi-coin portfolio in a thread-local Metal side-state struct
- include strategy, Forager, recursive-close-grid, auto-unstuck, and HSL controller state in that boundary
- preserve the existing one-side kernel through aliases, without changing strategy math or widening supported optimizer topology
- add Rust source-contract coverage and a physical MPS probe proving two full directional state instances remain isolated

## Why this slice
Dual-side multi-coin TM coin/unified HSL needs one fused shared-account kernel. This is the first narrow prerequisite: it creates the long/short state ownership boundary while keeping current behavior unchanged and fail closed.

## Safety
- no CPU optimizer, exact Rust backtest, live bot, or exchange path changes
- no GPU scope gates are widened in this PR

## Validation
- Rust: 265 passed with no default features
- Rust default-feature test compile coverage: passed
- physical Apple MPS matrix: 277 passed
- GPU service/backend/optimizer matrix: 711 passed
- loaded Rust extension source stamp matched the exact worktree fingerprint
- git diff --check passed