### PR TITLE
Refactor TM multicoin shared fill accounting

### DIFF
--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -612,8 +612,16 @@ mod tests {
                 .count(),
             1
         );
+        assert_eq!(
+            source
+                .matches("struct TrailingMartingaleMulticoinFillState")
+                .count(),
+            1
+        );
         assert!(source.contains("load_trailing_martingale_multicoin_side_config("));
         assert!(source.contains("init_trailing_martingale_multicoin_side_state("));
+        assert!(source.contains("init_trailing_martingale_multicoin_fill_state("));
+        assert!(source.contains("record_tm_multicoin_gross_pnl("));
         assert!(source.contains("accumulate_tm_multicoin_side_unrealized_pnl("));
         assert!(source.contains("update_tm_multicoin_side_indicators("));
         assert!(source.contains("count_tm_multicoin_tradable_coins("));
@@ -628,6 +636,7 @@ mod tests {
             "update_tm_multicoin_side_indicators(\n            side, config, bars, coin_settings, k, C, start_hour_minute"
         ));
         assert!(source.contains("TrailingMartingaleMulticoinSideState side"));
+        assert!(source.contains("TrailingMartingaleMulticoinFillState fills"));
         assert!(source.contains("thread HslState& hsl = side.hsl"));
         assert!(source.contains("thread HslState* coin_hsl = side.coin_hsl"));
         assert!(source.contains("thread float* psize = side.psize"));

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -447,6 +447,71 @@ struct TrailingMartingaleMulticoinSideConfig {
     bool coin_hsl_mode;
 };
 
+// Shared fill accounting is separate from strategy-side state so a fused
+// long+short kernel can apply both directional fill passes to one account and
+// one chronology without reconstructing totals from directional summaries.
+struct TrailingMartingaleMulticoinFillState {
+    float pnl_recovery_peak;
+    float pnl_recovery_peak_k;
+    float pnl_recovery_max_min;
+    float profit_sum;
+    float loss_sum;
+    float profit_sum_long;
+    float loss_sum_long;
+    float profit_sum_short;
+    float loss_sum_short;
+    float fill_count;
+    float fill_count_entry;
+    float fill_count_long;
+    float held_max_min;
+    float held_sum_min;
+    float held_count;
+    float position_unchanged_max_min;
+    float day_volume;
+    float day_fill_count;
+};
+
+inline TrailingMartingaleMulticoinFillState
+init_trailing_martingale_multicoin_fill_state() {
+    TrailingMartingaleMulticoinFillState fills;
+    fills.pnl_recovery_peak = -INFINITY;
+    fills.pnl_recovery_peak_k = -1.0f;
+    fills.pnl_recovery_max_min = 0.0f;
+    fills.profit_sum = 0.0f;
+    fills.loss_sum = 0.0f;
+    fills.profit_sum_long = 0.0f;
+    fills.loss_sum_long = 0.0f;
+    fills.profit_sum_short = 0.0f;
+    fills.loss_sum_short = 0.0f;
+    fills.fill_count = 0.0f;
+    fills.fill_count_entry = 0.0f;
+    fills.fill_count_long = 0.0f;
+    fills.held_max_min = 0.0f;
+    fills.held_sum_min = 0.0f;
+    fills.held_count = 0.0f;
+    fills.position_unchanged_max_min = 0.0f;
+    fills.day_volume = 0.0f;
+    fills.day_fill_count = 0.0f;
+    return fills;
+}
+
+inline void record_tm_multicoin_gross_pnl(
+    float pnl,
+    thread TrailingMartingaleMulticoinFillState& fills,
+    bool short_side
+) {
+    record_gross_pnl(pnl, fills.profit_sum, fills.loss_sum);
+    if (short_side) {
+        record_gross_pnl(
+            pnl, fills.profit_sum_short, fills.loss_sum_short
+        );
+    } else {
+        record_gross_pnl(
+            pnl, fills.profit_sum_long, fills.loss_sum_long
+        );
+    }
+}
+
 inline TrailingMartingaleMulticoinSideConfig
 load_trailing_martingale_multicoin_side_config(
     constant float* params,
@@ -946,14 +1011,16 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     thread float& balance = account.balance;
     thread float& realized_pnl_cumsum_last = account.realized_pnl_total;
     thread float& realized_pnl_cumsum_max = account.realized_pnl_peak;
-    float pnl_recovery_peak = -INFINITY;
-    float pnl_recovery_peak_k = -1.0f;
-    float pnl_recovery_max_min = 0.0f;
-    float profit_sum = 0.0f;
-    float loss_sum = 0.0f;
-    float fill_count = 0.0f;
-    float fill_count_entry = 0.0f;
-    float fill_count_long = 0.0f;
+    TrailingMartingaleMulticoinFillState fills =
+        init_trailing_martingale_multicoin_fill_state();
+    thread float& pnl_recovery_peak = fills.pnl_recovery_peak;
+    thread float& pnl_recovery_peak_k = fills.pnl_recovery_peak_k;
+    thread float& pnl_recovery_max_min = fills.pnl_recovery_max_min;
+    thread float& profit_sum = fills.profit_sum;
+    thread float& loss_sum = fills.loss_sum;
+    thread float& fill_count = fills.fill_count;
+    thread float& fill_count_entry = fills.fill_count_entry;
+    thread float& fill_count_long = fills.fill_count_long;
     float fills_active_days_count = 0.0f;
     int last_active_fill_day = -1;
     bool alive = true;
@@ -967,10 +1034,11 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     float total_wallet_exposure_max = 0.0f;
     float total_wallet_exposure_mean = 0.0f;
     float total_wallet_exposure_samples = 0.0f;
-    float held_max_min = 0.0f;
-    float held_sum_min = 0.0f;
-    float held_count = 0.0f;
-    float position_unchanged_max_min = 0.0f;
+    thread float& held_max_min = fills.held_max_min;
+    thread float& held_sum_min = fills.held_sum_min;
+    thread float& held_count = fills.held_count;
+    thread float& position_unchanged_max_min =
+        fills.position_unchanged_max_min;
     float first_fill_k = -1.0f;
     float last_fill_k = -1.0f;
     float gap_max_min = 0.0f;
@@ -992,11 +1060,11 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     float day_end = 0.0f;
     float day_min = INFINITY;
     float day_dd = 0.0f;
-    float day_volume = 0.0f;
+    thread float& day_volume = fills.day_volume;
     float day_has_fill = 0.0f;
     float day_min_balance = INFINITY;
     float day_start_balance = balance;
-    float day_fill_count = 0.0f;
+    thread float& day_fill_count = fills.day_fill_count;
 
     for (int k = 1; k < stop_k; ++k) {
         const int day_index = (start_day_minute + k) / 1440;
@@ -1302,7 +1370,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                             )) {
                             float net_pnl = pnl
                                 - qty * fill_price * c_mult * maker_fee;
-                            record_gross_pnl(pnl, profit_sum, loss_sum);
+                            record_tm_multicoin_gross_pnl(
+                                pnl, fills, short_side
+                            );
                             record_realized_net(
                                 net_pnl, account,
                                 day_fill_count, fill_count, fill_count_entry,
@@ -1352,7 +1422,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     }
                     float grid_net_pnl = grid_pnl
                         - grid_qty * group.price * c_mult * maker_fee;
-                    record_gross_pnl(grid_pnl, profit_sum, loss_sum);
+                    record_tm_multicoin_gross_pnl(
+                        grid_pnl, fills, short_side
+                    );
                     record_realized_net(
                         grid_net_pnl, account,
                         day_fill_count, fill_count, fill_count_entry,
@@ -1433,7 +1505,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                             );
                         }
                     }
-                    record_gross_pnl(pnl, profit_sum, loss_sum);
+                    record_tm_multicoin_gross_pnl(
+                        pnl, fills, short_side
+                    );
                     record_realized_net(
                         net_pnl, account,
                         day_fill_count, fill_count, fill_count_entry,

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -421,6 +421,94 @@ kernel void passivbot_tm_multicoin_side_state_isolation_probe(
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+def test_mps_tm_multicoin_fill_state_shares_directional_accounting():
+    import passivbot_rust
+
+    probe_kernel = r"""
+kernel void passivbot_tm_multicoin_fill_state_probe(
+    device float* output,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    JointPortfolioAccount account = init_joint_portfolio_account(1000.0f);
+    TrailingMartingaleMulticoinFillState fills =
+        init_trailing_martingale_multicoin_fill_state();
+    record_tm_multicoin_gross_pnl(4.0f, fills, false);
+    record_tm_multicoin_gross_pnl(-2.0f, fills, false);
+    record_tm_multicoin_gross_pnl(3.0f, fills, true);
+    record_tm_multicoin_gross_pnl(-5.0f, fills, true);
+    record_realized_net(
+        -1.0f, account,
+        fills.day_fill_count, fills.fill_count,
+        fills.fill_count_entry, fills.fill_count_long,
+        fills.pnl_recovery_peak, fills.pnl_recovery_peak_k,
+        fills.pnl_recovery_max_min, 10.0f, true, true
+    );
+    record_realized_net(
+        2.0f, account,
+        fills.day_fill_count, fills.fill_count,
+        fills.fill_count_entry, fills.fill_count_long,
+        fills.pnl_recovery_peak, fills.pnl_recovery_peak_k,
+        fills.pnl_recovery_max_min, 20.0f, false, false
+    );
+    output[0] = account.balance;
+    output[1] = account.realized_pnl_total;
+    output[2] = account.realized_pnl_long;
+    output[3] = account.realized_pnl_short;
+    output[4] = fills.profit_sum;
+    output[5] = fills.loss_sum;
+    output[6] = fills.profit_sum_long;
+    output[7] = fills.loss_sum_long;
+    output[8] = fills.profit_sum_short;
+    output[9] = fills.loss_sum_short;
+    output[10] = fills.fill_count;
+    output[11] = fills.fill_count_entry;
+    output[12] = fills.fill_count_long;
+    output[13] = fills.day_fill_count;
+    output[14] = fills.pnl_recovery_peak;
+    output[15] = fills.pnl_recovery_peak_k;
+    output[16] = fills.pnl_recovery_max_min;
+    output[17] = fills.held_max_min + fills.held_sum_min
+        + fills.held_count + fills.position_unchanged_max_min
+        + fills.day_volume;
+}
+"""
+
+    output = torch.zeros(18, dtype=torch.float32, device="mps")
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_trailing_martingale_multicoin_source_py()
+        + probe_kernel
+    )
+    library.passivbot_tm_multicoin_fill_state_probe(
+        output, threads=(1, 1, 1)
+    )
+    torch.mps.synchronize()
+
+    assert output.cpu().tolist() == [
+        1001.0,
+        1.0,
+        -1.0,
+        2.0,
+        7.0,
+        7.0,
+        4.0,
+        2.0,
+        3.0,
+        5.0,
+        2.0,
+        1.0,
+        1.0,
+        2.0,
+        1.0,
+        20.0,
+        10.0,
+        0.0,
+    ]
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 def test_mps_ema_multicoin_dual_hsl_phase_covers_all_signal_topologies():
     import passivbot_rust
 


### PR DESCRIPTION
## Summary

- move TM multicoin realized-PnL recovery, gross-PnL, fill counts, holding durations, and daily fill totals into one explicit fill-accounting state
- retain total gross PnL while adding side-attributed long/short scopes needed by the future fused runner
- add Rust source-contract coverage and a physical-MPS probe that applies both directional fills to one account and chronology

This is an HSL/fused-runner prerequisite. It does not widen user-facing GPU support and does not change CPU, exact Rust, live trading, optimizer routing, or one-side output semantics.

## Validation

- `cargo test --manifest-path passivbot-rust/Cargo.toml --no-default-features -q` (265 passed)
- `cargo check --manifest-path passivbot-rust/Cargo.toml --tests -q`
- rebuilt and source-stamp verified the Rust extension
- focused physical MPS shared-accounting probe passed
- full `tests/optimization/test_gpu_mps.py` passed (279 tests)
- optimizer/service/backend matrix passed (711 tests)

## Review focus

- initialization parity with the former local counters
- unchanged one-side total gross-PnL and scalar semantics
- shared account chronology and long/short attribution
