### PR TITLE
Refactor TM multicoin close fill accounting

### DIFF
--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -181,9 +181,9 @@ mod tests {
 
     #[test]
     fn multicoin_kernels_route_every_fill_through_joint_account_state() {
-        for (body, expected_fill_paths) in [
+        for (body, expected_account_record_sites) in [
             (MPS_EMA_ANCHOR_MULTICOIN_BODY, 2),
-            (MPS_TRAILING_MARTINGALE_MULTICOIN_BODY, 4),
+            (MPS_TRAILING_MARTINGALE_MULTICOIN_BODY, 2),
         ] {
             assert!(body.contains(
                 "JointPortfolioAccount account = init_joint_portfolio_account(starting_balance)"
@@ -196,7 +196,7 @@ mod tests {
             );
             assert_eq!(
                 body.matches("record_realized_net(").count(),
-                expected_fill_paths
+                expected_account_record_sites
             );
             assert!(!body.contains("float balance = starting_balance"));
             assert!(!body.contains("balance += net_pnl"));
@@ -622,6 +622,7 @@ mod tests {
         assert!(source.contains("init_trailing_martingale_multicoin_side_state("));
         assert!(source.contains("init_trailing_martingale_multicoin_fill_state("));
         assert!(source.contains("record_tm_multicoin_gross_pnl("));
+        assert!(source.contains("record_tm_multicoin_close_fill("));
         assert!(source.contains("accumulate_tm_multicoin_side_unrealized_pnl("));
         assert!(source.contains("update_tm_multicoin_side_indicators("));
         assert!(source.contains("count_tm_multicoin_tradable_coins("));
@@ -650,15 +651,21 @@ mod tests {
         assert!(source.contains("record_hsl_panic_fill("));
         assert_eq!(
             MPS_TRAILING_MARTINGALE_MULTICOIN_BODY
-                .matches("record_coin_hsl_realized_fill(")
+                .matches("record_tm_multicoin_close_fill(")
                 .count(),
             4
         );
         assert_eq!(
             MPS_TRAILING_MARTINGALE_MULTICOIN_BODY
+                .matches("record_coin_hsl_realized_fill(")
+                .count(),
+            2
+        );
+        assert_eq!(
+            MPS_TRAILING_MARTINGALE_MULTICOIN_BODY
                 .matches("advance_coin_hsl_equity_after_close_fill(")
                 .count(),
-            3
+            1
         );
         assert_eq!(
             MPS_TRAILING_MARTINGALE_MULTICOIN_BODY
@@ -693,8 +700,11 @@ mod tests {
             source
                 .matches("coin_fill_counts[int(b) * C + c] += 1.0f")
                 .count(),
-            4
+            1
         );
+        assert!(source.contains(
+            "coin_fill_counts[candidate_index * coin_count + coin] += 1.0f"
+        ));
         assert!(source.contains("coin_wel_enforcer_enabled"));
         assert!(source.contains("coin_wel_enforcer_threshold"));
         assert!(source.contains("twel_enforcer_enabled"));

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -512,6 +512,63 @@ inline void record_tm_multicoin_gross_pnl(
     }
 }
 
+inline void record_tm_multicoin_close_fill(
+    thread TrailingMartingaleMulticoinSideState& side,
+    thread JointPortfolioAccount& account,
+    thread TrailingMartingaleMulticoinFillState& fills,
+    device float* coin_fill_counts,
+    int candidate_index,
+    int coin_count,
+    int coin,
+    int k,
+    float gross_pnl,
+    float net_pnl,
+    float qty,
+    float position_price,
+    float mark_price,
+    float c_mult,
+    bool short_side,
+    bool is_hsl_panic,
+    bool collect_coin_fill_counts,
+    thread float& hsl_equity_before_fills
+) {
+    const bool coin_hsl_mode =
+        side.hsl.signal_mode == HSL_SIGNAL_COIN;
+    if (is_hsl_panic) {
+        if (coin_hsl_mode) {
+            record_hsl_panic_fill(
+                side.coin_hsl[coin], net_pnl, hsl_equity_before_fills
+            );
+        } else {
+            record_hsl_panic_fill(
+                side.hsl, net_pnl, hsl_equity_before_fills
+            );
+        }
+    }
+    record_tm_multicoin_gross_pnl(gross_pnl, fills, short_side);
+    record_realized_net(
+        net_pnl, account,
+        fills.day_fill_count, fills.fill_count,
+        fills.fill_count_entry, fills.fill_count_long,
+        fills.pnl_recovery_peak, fills.pnl_recovery_peak_k,
+        fills.pnl_recovery_max_min, float(k), false, !short_side
+    );
+    side.coin_realized_pnl[coin] += net_pnl;
+    if (coin_hsl_mode) {
+        record_coin_hsl_realized_fill(
+            side.coin_hsl[coin], side.coin_realized_pnl[coin]
+        );
+        advance_coin_hsl_equity_after_close_fill(
+            hsl_equity_before_fills,
+            net_pnl, qty, position_price, mark_price,
+            c_mult, short_side
+        );
+    }
+    if (collect_coin_fill_counts) {
+        coin_fill_counts[candidate_index * coin_count + coin] += 1.0f;
+    }
+}
+
 inline TrailingMartingaleMulticoinSideConfig
 load_trailing_martingale_multicoin_side_config(
     constant float* params,
@@ -1370,30 +1427,13 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                             )) {
                             float net_pnl = pnl
                                 - qty * fill_price * c_mult * maker_fee;
-                            record_tm_multicoin_gross_pnl(
-                                pnl, fills, short_side
+                            record_tm_multicoin_close_fill(
+                                side, account, fills, coin_fill_counts,
+                                int(b), C, c, k, pnl, net_pnl, qty,
+                                pprice[c], close, c_mult, short_side,
+                                false, collect_coin_fill_counts,
+                                hsl_equity_before_fills
                             );
-                            record_realized_net(
-                                net_pnl, account,
-                                day_fill_count, fill_count, fill_count_entry,
-                                fill_count_long, pnl_recovery_peak,
-                                pnl_recovery_peak_k, pnl_recovery_max_min,
-                                float(k), false, !short_side
-                            );
-                            coin_realized_pnl[c] += net_pnl;
-                            if (coin_hsl_mode) {
-                                record_coin_hsl_realized_fill(
-                                    coin_hsl[c], coin_realized_pnl[c]
-                                );
-                                advance_coin_hsl_equity_after_close_fill(
-                                    hsl_equity_before_fills,
-                                    net_pnl, qty, pprice[c], close,
-                                    c_mult, short_side
-                                );
-                            }
-                            if (collect_coin_fill_counts) {
-                                coin_fill_counts[int(b) * C + c] += 1.0f;
-                            }
                             psize[c] = fmax(
                                 round_step(psize[c] - qty, qty_step), 0.0f
                             );
@@ -1422,30 +1462,13 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     }
                     float grid_net_pnl = grid_pnl
                         - grid_qty * group.price * c_mult * maker_fee;
-                    record_tm_multicoin_gross_pnl(
-                        grid_pnl, fills, short_side
+                    record_tm_multicoin_close_fill(
+                        side, account, fills, coin_fill_counts,
+                        int(b), C, c, k, grid_pnl, grid_net_pnl,
+                        grid_qty, pprice[c], close, c_mult, short_side,
+                        false, collect_coin_fill_counts,
+                        hsl_equity_before_fills
                     );
-                    record_realized_net(
-                        grid_net_pnl, account,
-                        day_fill_count, fill_count, fill_count_entry,
-                        fill_count_long, pnl_recovery_peak,
-                        pnl_recovery_peak_k, pnl_recovery_max_min,
-                        float(k), false, !short_side
-                    );
-                    coin_realized_pnl[c] += grid_net_pnl;
-                    if (coin_hsl_mode) {
-                        record_coin_hsl_realized_fill(
-                            coin_hsl[c], coin_realized_pnl[c]
-                        );
-                        advance_coin_hsl_equity_after_close_fill(
-                            hsl_equity_before_fills,
-                            grid_net_pnl, grid_qty, pprice[c], close,
-                            c_mult, short_side
-                        );
-                    }
-                    if (collect_coin_fill_counts) {
-                        coin_fill_counts[int(b) * C + c] += 1.0f;
-                    }
                     psize[c] = fmax(
                         round_step(psize[c] - grid_qty, qty_step), 0.0f
                     );
@@ -1493,42 +1516,13 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     }
                     float net_pnl = pnl - qty * price * c_mult
                         * (market_panic ? taker_fee : maker_fee);
-                    if (is_hsl_panic) {
-                        if (coin_hsl_mode) {
-                            record_hsl_panic_fill(
-                                coin_hsl[c], net_pnl,
-                                hsl_equity_before_fills
-                            );
-                        } else {
-                            record_hsl_panic_fill(
-                                hsl, net_pnl, hsl_equity_before_fills
-                            );
-                        }
-                    }
-                    record_tm_multicoin_gross_pnl(
-                        pnl, fills, short_side
+                    record_tm_multicoin_close_fill(
+                        side, account, fills, coin_fill_counts,
+                        int(b), C, c, k, pnl, net_pnl, qty,
+                        pprice[c], close, c_mult, short_side,
+                        is_hsl_panic, collect_coin_fill_counts,
+                        hsl_equity_before_fills
                     );
-                    record_realized_net(
-                        net_pnl, account,
-                        day_fill_count, fill_count, fill_count_entry,
-                        fill_count_long, pnl_recovery_peak,
-                        pnl_recovery_peak_k, pnl_recovery_max_min,
-                        float(k), false, !short_side
-                    );
-                    coin_realized_pnl[c] += net_pnl;
-                    if (coin_hsl_mode) {
-                        record_coin_hsl_realized_fill(
-                            coin_hsl[c], coin_realized_pnl[c]
-                        );
-                        advance_coin_hsl_equity_after_close_fill(
-                            hsl_equity_before_fills,
-                            net_pnl, qty, pprice[c], close,
-                            c_mult, short_side
-                        );
-                    }
-                    if (collect_coin_fill_counts) {
-                        coin_fill_counts[int(b) * C + c] += 1.0f;
-                    }
                     psize[c] = fmax(
                         round_step(psize[c] - qty, qty_step), 0.0f
                     );

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -509,6 +509,131 @@ kernel void passivbot_tm_multicoin_fill_state_probe(
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+def test_mps_tm_multicoin_close_fill_centralizes_hsl_accounting():
+    import passivbot_rust
+
+    probe_kernel = r"""
+kernel void passivbot_tm_multicoin_close_fill_probe(
+    constant float* hsl_params,
+    device float* coin_fill_counts,
+    device float* output,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    TrailingMartingaleMulticoinSideState long_side;
+    TrailingMartingaleMulticoinSideState short_side;
+    long_side.hsl = load_hsl(hsl_params, 0, 0);
+    long_side.coin_hsl[0] = load_hsl(hsl_params, 0, 0);
+    short_side.hsl = load_hsl(hsl_params, 11, 0);
+    short_side.coin_hsl[0] = load_hsl(hsl_params, 11, 0);
+    long_side.coin_realized_pnl[0] = 0.0f;
+    short_side.coin_realized_pnl[0] = 0.0f;
+    long_side.coin_hsl[0].coin_realized_baseline = -20.0f;
+    JointPortfolioAccount account = init_joint_portfolio_account(1000.0f);
+    TrailingMartingaleMulticoinFillState fills =
+        init_trailing_martingale_multicoin_fill_state();
+    float long_equity = 1000.0f;
+    float short_equity = 989.0f;
+    coin_fill_counts[0] = 0.0f;
+    record_tm_multicoin_close_fill(
+        long_side, account, fills, coin_fill_counts,
+        0, 1, 0, 10, -10.0f, -11.0f, 1.0f,
+        110.0f, 100.0f, 1.0f, false, true, true, long_equity
+    );
+    record_tm_multicoin_close_fill(
+        short_side, account, fills, coin_fill_counts,
+        0, 1, 0, 11, -10.0f, -11.0f, 1.0f,
+        90.0f, 100.0f, 1.0f, true, true, true, short_equity
+    );
+    output[0] = account.balance;
+    output[1] = account.realized_pnl_total;
+    output[2] = account.realized_pnl_long;
+    output[3] = account.realized_pnl_short;
+    output[4] = fills.profit_sum;
+    output[5] = fills.loss_sum;
+    output[6] = fills.fill_count;
+    output[7] = fills.fill_count_entry;
+    output[8] = fills.fill_count_long;
+    output[9] = fills.day_fill_count;
+    output[10] = long_equity;
+    output[11] = short_equity;
+    output[12] = long_side.coin_realized_pnl[0];
+    output[13] = short_side.coin_realized_pnl[0];
+    output[14] = long_side.coin_hsl[0].coin_realized_peak;
+    output[15] = long_side.coin_hsl[0].panic_event_start_equity;
+    output[16] = long_side.coin_hsl[0].panic_event_loss;
+    output[17] = short_side.hsl.panic_event_start_equity;
+    output[18] = short_side.hsl.panic_event_loss;
+    output[19] = coin_fill_counts[0];
+}
+"""
+
+    hsl_params = torch.tensor(
+        [
+            1.0,
+            0.2,
+            60.0,
+            0.0,
+            1.0,
+            1.0,
+            0.5,
+            0.75,
+            0.0,
+            2.0,
+            1.0,
+            1.0,
+            0.2,
+            60.0,
+            0.0,
+            1.0,
+            1.0,
+            0.5,
+            0.75,
+            0.0,
+            1.0,
+            1.0,
+        ],
+        dtype=torch.float32,
+        device="mps",
+    )
+    coin_fill_counts = torch.zeros(1, dtype=torch.float32, device="mps")
+    output = torch.zeros(20, dtype=torch.float32, device="mps")
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_trailing_martingale_multicoin_source_py()
+        + probe_kernel
+    )
+    library.passivbot_tm_multicoin_close_fill_probe(
+        hsl_params, coin_fill_counts, output, threads=(1, 1, 1)
+    )
+    torch.mps.synchronize()
+
+    assert output.cpu().tolist() == [
+        978.0,
+        -22.0,
+        -11.0,
+        -11.0,
+        0.0,
+        20.0,
+        2.0,
+        0.0,
+        1.0,
+        2.0,
+        999.0,
+        989.0,
+        -11.0,
+        -11.0,
+        9.0,
+        1000.0,
+        11.0,
+        989.0,
+        11.0,
+        2.0,
+    ]
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 def test_mps_ema_multicoin_dual_hsl_phase_covers_all_signal_topologies():
     import passivbot_rust
 


### PR DESCRIPTION
## Summary

- centralize all three TM multicoin close-fill accounting paths behind one helper
- preserve HSL panic attribution for coin and pside modes, coin realized baselines, mutable coin-HSL equity, shared account chronology, and optional per-coin fill counts
- add source-contract coverage and a physical-MPS probe spanning long coin-HSL and short pside-HSL fills

This is an HSL/fused-runner prerequisite. It does not widen user-facing GPU support and does not change CPU, exact Rust, live trading, optimizer routing, or one-side output semantics.

## Validation

- `cargo test --manifest-path passivbot-rust/Cargo.toml --no-default-features -q` (265 passed)
- `cargo check --manifest-path passivbot-rust/Cargo.toml --tests -q`
- rebuilt and source-stamp verified the Rust extension at the final head
- focused physical MPS close-fill/HSL probe passed
- full `tests/optimization/test_gpu_mps.py` passed (280 tests)
- optimizer/service/backend matrix passed (711 tests)

## Review focus

- panic bookkeeping order relative to realized fill accounting
- coin-HSL equity advancement and realized-baseline updates
- preservation of reducer, recursive-grid, and primary/secondary close semantics
- shared account and per-direction attribution
