### PR TITLE
Refactor TM multicoin entry fill accounting

### DIFF
--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -623,6 +623,7 @@ mod tests {
         assert!(source.contains("init_trailing_martingale_multicoin_fill_state("));
         assert!(source.contains("record_tm_multicoin_gross_pnl("));
         assert!(source.contains("record_tm_multicoin_close_fill("));
+        assert!(source.contains("record_tm_multicoin_entry_fill("));
         assert!(source.contains("accumulate_tm_multicoin_side_unrealized_pnl("));
         assert!(source.contains("update_tm_multicoin_side_indicators("));
         assert!(source.contains("count_tm_multicoin_tradable_coins("));
@@ -654,6 +655,12 @@ mod tests {
                 .matches("record_tm_multicoin_close_fill(")
                 .count(),
             4
+        );
+        assert_eq!(
+            MPS_TRAILING_MARTINGALE_MULTICOIN_BODY
+                .matches("record_tm_multicoin_entry_fill(")
+                .count(),
+            2
         );
         assert_eq!(
             MPS_TRAILING_MARTINGALE_MULTICOIN_BODY
@@ -700,11 +707,16 @@ mod tests {
             source
                 .matches("coin_fill_counts[int(b) * C + c] += 1.0f")
                 .count(),
-            1
+            0
         );
-        assert!(source.contains(
-            "coin_fill_counts[candidate_index * coin_count + coin] += 1.0f"
-        ));
+        assert_eq!(
+            source
+                .matches(
+                    "coin_fill_counts[candidate_index * coin_count + coin] += 1.0f"
+                )
+                .count(),
+            2
+        );
         assert!(source.contains("coin_wel_enforcer_enabled"));
         assert!(source.contains("coin_wel_enforcer_threshold"));
         assert!(source.contains("twel_enforcer_enabled"));

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -569,6 +569,49 @@ inline void record_tm_multicoin_close_fill(
     }
 }
 
+inline void record_tm_multicoin_entry_fill(
+    thread TrailingMartingaleMulticoinSideState& side,
+    thread JointPortfolioAccount& account,
+    thread TrailingMartingaleMulticoinFillState& fills,
+    device float* coin_fill_counts,
+    int candidate_index,
+    int coin_count,
+    int coin,
+    int k,
+    float fee,
+    float qty,
+    float fill_price,
+    float mark_price,
+    float c_mult,
+    bool short_side,
+    bool collect_coin_fill_counts,
+    thread float& hsl_equity_before_fills
+) {
+    const bool coin_hsl_mode =
+        side.hsl.signal_mode == HSL_SIGNAL_COIN;
+    record_realized_net(
+        -fee, account,
+        fills.day_fill_count, fills.fill_count,
+        fills.fill_count_entry, fills.fill_count_long,
+        fills.pnl_recovery_peak, fills.pnl_recovery_peak_k,
+        fills.pnl_recovery_max_min, float(k), true, !short_side
+    );
+    side.coin_realized_pnl[coin] -= fee;
+    if (coin_hsl_mode) {
+        record_coin_hsl_realized_fill(
+            side.coin_hsl[coin], side.coin_realized_pnl[coin]
+        );
+        advance_coin_hsl_equity_after_entry_fill(
+            hsl_equity_before_fills,
+            fee, qty, fill_price, mark_price,
+            c_mult, short_side
+        );
+    }
+    if (collect_coin_fill_counts) {
+        coin_fill_counts[candidate_index * coin_count + coin] += 1.0f;
+    }
+}
+
 inline TrailingMartingaleMulticoinSideConfig
 load_trailing_martingale_multicoin_side_config(
     constant float* params,
@@ -1562,27 +1605,12 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 float fill_price = float(entry_tick[c]) * price_step;
                 float adjusted = round_step(entry_qty[c], qty_step);
                 float fee = adjusted * fill_price * c_mult * maker_fee;
-                record_realized_net(
-                    -fee, account,
-                    day_fill_count, fill_count, fill_count_entry,
-                    fill_count_long, pnl_recovery_peak,
-                    pnl_recovery_peak_k, pnl_recovery_max_min,
-                    float(k), true, !short_side
+                record_tm_multicoin_entry_fill(
+                    side, account, fills, coin_fill_counts,
+                    int(b), C, c, k, fee, adjusted, fill_price,
+                    close, c_mult, short_side, collect_coin_fill_counts,
+                    hsl_equity_before_fills
                 );
-                coin_realized_pnl[c] -= fee;
-                if (coin_hsl_mode) {
-                    record_coin_hsl_realized_fill(
-                        coin_hsl[c], coin_realized_pnl[c]
-                    );
-                    advance_coin_hsl_equity_after_entry_fill(
-                        hsl_equity_before_fills,
-                        fee, adjusted, fill_price, close,
-                        c_mult, short_side
-                    );
-                }
-                if (collect_coin_fill_counts) {
-                    coin_fill_counts[int(b) * C + c] += 1.0f;
-                }
                 float new_size = round_step(psize[c] + adjusted, qty_step);
                 float new_price = was_flat ? fill_price
                     : pprice[c] * (psize[c] / fmax(new_size, 1.0e-12f))

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -634,6 +634,123 @@ kernel void passivbot_tm_multicoin_close_fill_probe(
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+def test_mps_tm_multicoin_entry_fill_centralizes_hsl_accounting():
+    import passivbot_rust
+
+    probe_kernel = r"""
+kernel void passivbot_tm_multicoin_entry_fill_probe(
+    constant float* hsl_params,
+    device float* coin_fill_counts,
+    device float* output,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    TrailingMartingaleMulticoinSideState long_side;
+    TrailingMartingaleMulticoinSideState short_side;
+    long_side.hsl = load_hsl(hsl_params, 0, 0);
+    long_side.coin_hsl[0] = load_hsl(hsl_params, 0, 0);
+    short_side.hsl = load_hsl(hsl_params, 11, 0);
+    short_side.coin_hsl[0] = load_hsl(hsl_params, 11, 0);
+    long_side.coin_realized_pnl[0] = 0.0f;
+    short_side.coin_realized_pnl[0] = 0.0f;
+    long_side.coin_hsl[0].coin_realized_baseline = -20.0f;
+    JointPortfolioAccount account = init_joint_portfolio_account(1000.0f);
+    TrailingMartingaleMulticoinFillState fills =
+        init_trailing_martingale_multicoin_fill_state();
+    float long_equity = 1000.0f;
+    float short_equity = 990.0f;
+    coin_fill_counts[0] = 0.0f;
+    record_tm_multicoin_entry_fill(
+        long_side, account, fills, coin_fill_counts,
+        0, 1, 0, 10, 10.0f, 1.0f,
+        110.0f, 100.0f, 1.0f, false, true, long_equity
+    );
+    record_tm_multicoin_entry_fill(
+        short_side, account, fills, coin_fill_counts,
+        0, 1, 0, 11, 10.0f, 1.0f,
+        90.0f, 100.0f, 1.0f, true, true, short_equity
+    );
+    output[0] = account.balance;
+    output[1] = account.realized_pnl_total;
+    output[2] = account.realized_pnl_long;
+    output[3] = account.realized_pnl_short;
+    output[4] = fills.fill_count;
+    output[5] = fills.fill_count_entry;
+    output[6] = fills.fill_count_long;
+    output[7] = fills.day_fill_count;
+    output[8] = long_equity;
+    output[9] = short_equity;
+    output[10] = long_side.coin_realized_pnl[0];
+    output[11] = short_side.coin_realized_pnl[0];
+    output[12] = long_side.coin_hsl[0].coin_realized_peak;
+    output[13] = fills.profit_sum;
+    output[14] = fills.loss_sum;
+    output[15] = coin_fill_counts[0];
+}
+"""
+
+    hsl_params = torch.tensor(
+        [
+            1.0,
+            0.2,
+            60.0,
+            0.0,
+            1.0,
+            1.0,
+            0.5,
+            0.75,
+            0.0,
+            2.0,
+            1.0,
+            1.0,
+            0.2,
+            60.0,
+            0.0,
+            1.0,
+            1.0,
+            0.5,
+            0.75,
+            0.0,
+            1.0,
+            1.0,
+        ],
+        dtype=torch.float32,
+        device="mps",
+    )
+    coin_fill_counts = torch.zeros(1, dtype=torch.float32, device="mps")
+    output = torch.zeros(16, dtype=torch.float32, device="mps")
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_trailing_martingale_multicoin_source_py()
+        + probe_kernel
+    )
+    library.passivbot_tm_multicoin_entry_fill_probe(
+        hsl_params, coin_fill_counts, output, threads=(1, 1, 1)
+    )
+    torch.mps.synchronize()
+
+    assert output.cpu().tolist() == [
+        980.0,
+        -20.0,
+        -10.0,
+        -10.0,
+        2.0,
+        2.0,
+        1.0,
+        2.0,
+        980.0,
+        990.0,
+        -10.0,
+        -10.0,
+        10.0,
+        0.0,
+        0.0,
+        2.0,
+    ]
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 def test_mps_ema_multicoin_dual_hsl_phase_covers_all_signal_topologies():
     import passivbot_rust
 


### PR DESCRIPTION
## Summary

- centralize TM multicoin entry-fee accounting behind one helper
- preserve shared account chronology, long/short attribution, coin realized baselines, coin-HSL entry-equity adjustment, and optional per-coin fill counts
- add source-contract coverage and a physical-MPS probe spanning long coin-HSL and short pside-HSL entries

Together with #1595, all TM multicoin close and entry accounting now crosses explicit shared-state seams. This does not widen user-facing GPU support and does not change CPU, exact Rust, live trading, optimizer routing, position mutation, or one-side output semantics.

## Validation

- `cargo test --manifest-path passivbot-rust/Cargo.toml --no-default-features -q` (265 passed)
- `cargo check --manifest-path passivbot-rust/Cargo.toml --tests -q`
- rebuilt and source-stamp verified the Rust extension
- focused physical MPS entry-fill/HSL probe passed
- full `tests/optimization/test_gpu_mps.py` passed (281 tests)
- optimizer/service/backend matrix passed (711 tests)

## Review focus

- fee sign and account attribution
- coin-HSL realized-baseline and entry-equity adjustment
- preservation of entry position mutation order after accounting
- per-coin fill-count indexing
