### PR TITLE
Refactor TM multicoin fill position helpers

### DIFF
--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -624,6 +624,9 @@ mod tests {
         assert!(source.contains("record_tm_multicoin_gross_pnl("));
         assert!(source.contains("record_tm_multicoin_close_fill("));
         assert!(source.contains("record_tm_multicoin_entry_fill("));
+        assert!(source.contains("finalize_tm_multicoin_close_position("));
+        assert!(source.contains("apply_tm_multicoin_entry_position("));
+        assert!(source.contains("update_tm_multicoin_position_fill_timestamp("));
         assert!(source.contains("accumulate_tm_multicoin_side_unrealized_pnl("));
         assert!(source.contains("update_tm_multicoin_side_indicators("));
         assert!(source.contains("count_tm_multicoin_tradable_coins("));
@@ -659,6 +662,24 @@ mod tests {
         assert_eq!(
             MPS_TRAILING_MARTINGALE_MULTICOIN_BODY
                 .matches("record_tm_multicoin_entry_fill(")
+                .count(),
+            2
+        );
+        assert_eq!(
+            MPS_TRAILING_MARTINGALE_MULTICOIN_BODY
+                .matches("finalize_tm_multicoin_close_position(")
+                .count(),
+            2
+        );
+        assert_eq!(
+            MPS_TRAILING_MARTINGALE_MULTICOIN_BODY
+                .matches("apply_tm_multicoin_entry_position(")
+                .count(),
+            2
+        );
+        assert_eq!(
+            MPS_TRAILING_MARTINGALE_MULTICOIN_BODY
+                .matches("update_tm_multicoin_position_fill_timestamp(")
                 .count(),
             2
         );

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -612,6 +612,72 @@ inline void record_tm_multicoin_entry_fill(
     }
 }
 
+inline void finalize_tm_multicoin_close_position(
+    thread TrailingMartingaleMulticoinSideState& side,
+    thread TrailingMartingaleMulticoinFillState& fills,
+    int coin,
+    int k
+) {
+    if (side.psize[coin] <= 0.0f) {
+        side.pprice[coin] = 0.0f;
+        if (side.position_open_k[coin] >= 0.0f) {
+            float held_min = float(k) - side.position_open_k[coin];
+            fills.held_max_min = fmax(fills.held_max_min, held_min);
+            fills.held_sum_min += held_min;
+            fills.held_count += 1.0f;
+        }
+        side.position_open_k[coin] = -1.0f;
+    }
+    side.close_qty[coin] = 0.0f;
+    side.secondary_close_qty[coin] = 0.0f;
+    side.close_reconstruct_after_reducer[coin] = false;
+    side.close_is_unstuck_reducer[coin] = false;
+    side.close_is_hsl_panic[coin] = false;
+    side.filled_coin[coin] = true;
+}
+
+inline void apply_tm_multicoin_entry_position(
+    thread TrailingMartingaleMulticoinSideState& side,
+    thread TrailingMartingaleMulticoinFillState& fills,
+    int coin,
+    int k,
+    float qty,
+    float fill_price,
+    float qty_step,
+    float c_mult,
+    float balance
+) {
+    bool was_flat = side.psize[coin] <= 0.0f;
+    float new_size = round_step(side.psize[coin] + qty, qty_step);
+    float new_price = was_flat ? fill_price
+        : side.pprice[coin]
+            * (side.psize[coin] / fmax(new_size, 1.0e-12f))
+            + fill_price * (qty / fmax(new_size, 1.0e-12f));
+    if (was_flat) side.position_open_k[coin] = float(k);
+    side.psize[coin] = new_size;
+    side.pprice[coin] = new_price;
+    side.last_increase_k[coin] = float(k);
+    fills.day_volume += fabs(qty) * fill_price * c_mult / balance;
+    side.entry_qty[coin] = 0.0f;
+    side.filled_coin[coin] = true;
+}
+
+inline void update_tm_multicoin_position_fill_timestamp(
+    thread TrailingMartingaleMulticoinSideState& side,
+    thread TrailingMartingaleMulticoinFillState& fills,
+    int coin,
+    int k
+) {
+    if (side.position_last_fill_k[coin] >= 0.0f) {
+        fills.position_unchanged_max_min = fmax(
+            fills.position_unchanged_max_min,
+            float(k) - side.position_last_fill_k[coin]
+        );
+    }
+    side.position_last_fill_k[coin] =
+        side.psize[coin] > 0.0f ? float(k) : -1.0f;
+}
+
 inline TrailingMartingaleMulticoinSideConfig
 load_trailing_martingale_multicoin_side_config(
     constant float* params,
@@ -1575,28 +1641,13 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 }
 
                 if (executed_close) {
-                    bool went_flat = psize[c] <= 0.0f;
-                    if (went_flat) {
-                        pprice[c] = 0.0f;
-                        if (position_open_k[c] >= 0.0f) {
-                            float held_min = float(k) - position_open_k[c];
-                            held_max_min = fmax(held_max_min, held_min);
-                            held_sum_min += held_min;
-                            held_count += 1.0f;
-                        }
-                        position_open_k[c] = -1.0f;
-                    }
-                    close_qty[c] = 0.0f;
-                    secondary_close_qty[c] = 0.0f;
-                    close_reconstruct_after_reducer[c] = false;
-                    close_is_unstuck_reducer[c] = false;
-                    close_is_hsl_panic[c] = false;
-                    filled_coin[c] = true;
+                    finalize_tm_multicoin_close_position(
+                        side, fills, c, k
+                    );
                     any_fill = true;
                 }
             }
 
-            bool was_flat = psize[c] <= 0.0f;
             bool filled_entry = entry_qty[c] > 0.0f
                 && (short_side
                     ? entry_tick[c] <= fill_ticks[tick_offset + 0]
@@ -1611,27 +1662,16 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                     close, c_mult, short_side, collect_coin_fill_counts,
                     hsl_equity_before_fills
                 );
-                float new_size = round_step(psize[c] + adjusted, qty_step);
-                float new_price = was_flat ? fill_price
-                    : pprice[c] * (psize[c] / fmax(new_size, 1.0e-12f))
-                        + fill_price * (adjusted / fmax(new_size, 1.0e-12f));
-                if (was_flat) position_open_k[c] = float(k);
-                psize[c] = new_size;
-                pprice[c] = new_price;
-                last_increase_k[c] = float(k);
-                day_volume += fabs(adjusted) * fill_price * c_mult / balance;
-                entry_qty[c] = 0.0f;
-                filled_coin[c] = true;
+                apply_tm_multicoin_entry_position(
+                    side, fills, c, k, adjusted, fill_price,
+                    qty_step, c_mult, balance
+                );
                 any_fill = true;
             }
             if (filled_coin[c]) {
-                if (position_last_fill_k[c] >= 0.0f) {
-                    position_unchanged_max_min = fmax(
-                        position_unchanged_max_min,
-                        float(k) - position_last_fill_k[c]
-                    );
-                }
-                position_last_fill_k[c] = psize[c] > 0.0f ? float(k) : -1.0f;
+                update_tm_multicoin_position_fill_timestamp(
+                    side, fills, c, k
+                );
             }
         }
         if (any_fill) {

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -751,6 +751,123 @@ kernel void passivbot_tm_multicoin_entry_fill_probe(
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+def test_mps_tm_multicoin_fill_position_helpers_preserve_chronology():
+    import passivbot_rust
+
+    probe_kernel = r"""
+kernel void passivbot_tm_multicoin_fill_position_probe(
+    device float* output,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    TrailingMartingaleMulticoinSideState close_side;
+    TrailingMartingaleMulticoinSideState entry_side;
+    TrailingMartingaleMulticoinFillState fills =
+        init_trailing_martingale_multicoin_fill_state();
+    for (int c = 0; c < 2; ++c) {
+        close_side.psize[c] = c == 0 ? 0.0f : 1.0f;
+        close_side.pprice[c] = 100.0f;
+        close_side.position_open_k[c] = 5.0f;
+        close_side.close_qty[c] = 1.0f;
+        close_side.secondary_close_qty[c] = 2.0f;
+        close_side.close_reconstruct_after_reducer[c] = true;
+        close_side.close_is_unstuck_reducer[c] = true;
+        close_side.close_is_hsl_panic[c] = true;
+        close_side.filled_coin[c] = false;
+    }
+    close_side.position_last_fill_k[0] = 10.0f;
+    finalize_tm_multicoin_close_position(close_side, fills, 0, 20);
+    finalize_tm_multicoin_close_position(close_side, fills, 1, 20);
+    update_tm_multicoin_position_fill_timestamp(close_side, fills, 0, 20);
+
+    entry_side.psize[0] = 0.0f;
+    entry_side.pprice[0] = 0.0f;
+    entry_side.position_open_k[0] = -1.0f;
+    entry_side.position_last_fill_k[0] = 12.0f;
+    entry_side.entry_qty[0] = 1.0f;
+    entry_side.filled_coin[0] = false;
+    apply_tm_multicoin_entry_position(
+        entry_side, fills, 0, 20, 1.0f, 120.0f, 1.0f, 1.0f, 1000.0f
+    );
+    entry_side.entry_qty[0] = 1.0f;
+    apply_tm_multicoin_entry_position(
+        entry_side, fills, 0, 21, 1.0f, 100.0f, 1.0f, 1.0f, 1000.0f
+    );
+    update_tm_multicoin_position_fill_timestamp(entry_side, fills, 0, 21);
+
+    output[0] = close_side.pprice[0];
+    output[1] = close_side.position_open_k[0];
+    output[2] = close_side.close_qty[0];
+    output[3] = close_side.secondary_close_qty[0];
+    output[4] = close_side.close_reconstruct_after_reducer[0] ? 1.0f : 0.0f;
+    output[5] = close_side.close_is_unstuck_reducer[0] ? 1.0f : 0.0f;
+    output[6] = close_side.close_is_hsl_panic[0] ? 1.0f : 0.0f;
+    output[7] = close_side.filled_coin[0] ? 1.0f : 0.0f;
+    output[8] = close_side.position_last_fill_k[0];
+    output[9] = close_side.pprice[1];
+    output[10] = close_side.position_open_k[1];
+    output[11] = close_side.filled_coin[1] ? 1.0f : 0.0f;
+    output[12] = fills.held_max_min;
+    output[13] = fills.held_sum_min;
+    output[14] = fills.held_count;
+    output[15] = fills.position_unchanged_max_min;
+    output[16] = entry_side.psize[0];
+    output[17] = entry_side.pprice[0];
+    output[18] = entry_side.position_open_k[0];
+    output[19] = entry_side.last_increase_k[0];
+    output[20] = entry_side.entry_qty[0];
+    output[21] = entry_side.filled_coin[0] ? 1.0f : 0.0f;
+    output[22] = entry_side.position_last_fill_k[0];
+    output[23] = fills.day_volume;
+}
+"""
+
+    output = torch.zeros(24, dtype=torch.float32, device="mps")
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_trailing_martingale_multicoin_source_py()
+        + probe_kernel
+    )
+    library.passivbot_tm_multicoin_fill_position_probe(
+        output, threads=(1, 1, 1)
+    )
+    torch.mps.synchronize()
+
+    np.testing.assert_allclose(
+        output.cpu().numpy(),
+        [
+            0.0,
+            -1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            -1.0,
+            100.0,
+            5.0,
+            1.0,
+            15.0,
+            15.0,
+            1.0,
+            10.0,
+            2.0,
+            110.0,
+            20.0,
+            21.0,
+            0.0,
+            1.0,
+            21.0,
+            0.22,
+        ],
+        rtol=1e-5,
+        atol=1e-6,
+    )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 def test_mps_ema_multicoin_dual_hsl_phase_covers_all_signal_topologies():
     import passivbot_rust
 


### PR DESCRIPTION
## Summary

- extract TM multicoin close finalization, entry position mutation, and last-fill chronology into side-state helpers
- preserve flat versus partial-close behavior, held-duration accounting, weighted entry price, daily volume, order-state resets, and cooldown timestamps
- add source-contract coverage and a physical-MPS probe covering flat and partial closes plus initial and re-entry fills

Together with #1594-#1596, the TM fill loop now exposes its shared accounting and mutable position boundaries explicitly. This does not widen user-facing GPU support and does not change CPU, exact Rust, live trading, optimizer routing, or one-side outputs.

## Validation

- `cargo test --manifest-path passivbot-rust/Cargo.toml --no-default-features -q` (265 passed)
- `cargo check --manifest-path passivbot-rust/Cargo.toml --tests -q`
- rebuilt and source-stamp verified the Rust extension
- focused physical MPS fill-position chronology probe passed
- full `tests/optimization/test_gpu_mps.py` passed (282 tests)
- optimizer/service/backend matrix passed (711 tests)

## Review focus

- flat versus partial-close state resets
- held-duration and last-fill chronology
- weighted entry-price arithmetic and post-fee volume denominator
- unchanged call order around fill accounting
