### PR TITLE
Refactor TM multicoin side selection

### DIFF
--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -632,6 +632,7 @@ mod tests {
         assert!(source.contains("update_tm_multicoin_side_indicators("));
         assert!(source.contains("count_tm_multicoin_tradable_coins("));
         assert!(source.contains("tm_multicoin_side_has_position("));
+        assert!(source.contains("update_tm_multicoin_side_selection("));
         assert!(source.contains(
             "const TrailingMartingaleMulticoinSideConfig config ="
         ));
@@ -644,6 +645,9 @@ mod tests {
         assert!(source.contains(
             "bool any_fill = process_tm_multicoin_side_fills(\n            side, config, account, fills"
         ));
+        assert!(source.contains(
+            "update_tm_multicoin_side_selection(\n                side, config, bars, coin_settings, coin_overrides"
+        ));
         assert!(source.contains("TrailingMartingaleMulticoinSideState side"));
         assert!(source.contains("TrailingMartingaleMulticoinFillState fills"));
         assert!(source.contains("thread HslState& hsl = side.hsl"));
@@ -651,7 +655,6 @@ mod tests {
         assert!(source.contains("thread float* psize = side.psize"));
         assert!(source.contains("thread int* entry_tick = side.entry_tick"));
         assert!(source.contains("thread bool* selected = side.selected"));
-        assert!(source.contains("thread bool& selection_initialized = side.selection_initialized"));
         assert!(source.contains("thread int& max_tradable_seen = side.max_tradable_seen"));
         assert!(source.contains("side.previous_effective_n_positions"));
         assert!(source.contains("load_hsl(params, po, 48)"));

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -1491,6 +1491,210 @@ inline bool tm_multicoin_side_has_position(
     return false;
 }
 
+inline void update_tm_multicoin_side_selection(
+    thread TrailingMartingaleMulticoinSideState& side,
+    thread const TrailingMartingaleMulticoinSideConfig& config,
+    constant float* bars,
+    constant float* coin_settings,
+    constant float* coin_overrides,
+    int k,
+    int coin_count,
+    bool short_side,
+    bool any_fill,
+    int effective_n_positions,
+    float score_hysteresis
+) {
+    thread HslState* coin_hsl = side.coin_hsl;
+    thread ulong& coin_hsl_entry_blocked_mask =
+        side.coin_hsl_entry_blocked_mask;
+    thread float* ema0 = side.ema0;
+    thread float* ema1 = side.ema1;
+    thread float* ema2 = side.ema2;
+    thread float* forager_volume = side.forager_volume;
+    thread float* forager_volatility = side.forager_volatility;
+    thread float* psize = side.psize;
+    thread float* score = side.score;
+    thread bool* selected = side.selected;
+    thread bool* incumbent = side.incumbent;
+    thread bool* survivor = side.survivor;
+
+    // Exact Rust ranks flat candidates every minute. Re-ranking only after
+    // state changes keeps the proxy inexpensive; independent exact
+    // validations and drift gates police this approximation.
+    bool coin_hsl_eligibility_changed = false;
+    if (config.coin_hsl_mode) {
+        ulong blocked_mask = 0ul;
+        for (int c = 0; c < coin_count; ++c) {
+            if (hsl_mode(coin_hsl[c], false) != 0) {
+                blocked_mask |= 1ul << ulong(c);
+            }
+        }
+        coin_hsl_eligibility_changed =
+            blocked_mask != coin_hsl_entry_blocked_mask;
+        coin_hsl_entry_blocked_mask = blocked_mask;
+    }
+    bool reselect = !side.selection_initialized || any_fill
+        || coin_hsl_eligibility_changed
+        || effective_n_positions != side.previous_effective_n_positions;
+    if (!reselect) return;
+
+    int active_count = 0;
+    for (int c = 0; c < coin_count; ++c) {
+        incumbent[c] = selected[c] && psize[c] <= 0.0f;
+        selected[c] = psize[c] > 0.0f;
+        if (selected[c]) active_count += 1;
+        survivor[c] = false;
+    }
+    int slots = max(effective_n_positions - active_count, 0);
+    int enabled_count = 0;
+    for (int c = 0; c < coin_count; ++c) {
+        int coin_offset = c * COIN_COLS;
+        int bar_offset = (k * coin_count + c) * 4;
+        float coin_wel = coin_override_or(coin_overrides, c, 24, -1.0f);
+        bool enabled = !selected[c]
+            && k >= int(coin_settings[coin_offset + 8])
+            && k <= int(coin_settings[coin_offset + 7])
+            && finite_positive(bars[bar_offset + 2])
+            && coin_wel != 0.0f
+            && (!config.coin_hsl_mode || (
+                coin_hsl_entry_blocked_mask & (1ul << ulong(c))
+            ) == 0ul);
+        survivor[c] = enabled;
+        if (enabled) enabled_count += 1;
+    }
+    int keep = int(floor(
+        float(enabled_count) * (1.0f - config.volume_drop) + 0.5f
+    ));
+    keep = min(
+        enabled_count,
+        max(max(keep, slots), enabled_count > 0 ? 1 : 0)
+    );
+    if (keep < enabled_count) {
+        for (int c = 0; c < coin_count; ++c) {
+            if (!survivor[c]) continue;
+            int better = 0;
+            for (int j = 0; j < coin_count; ++j) {
+                if (!survivor[j]) continue;
+                if (forager_volume[j] > forager_volume[c]
+                    || (forager_volume[j] == forager_volume[c] && j < c)) {
+                    better += 1;
+                }
+            }
+            if (better >= keep) survivor[c] = false;
+        }
+    }
+
+    float volume_min = INFINITY;
+    float volume_max = -INFINITY;
+    float ready_min = INFINITY;
+    float ready_max = -INFINITY;
+    float volatility_min = INFINITY;
+    float volatility_max = -INFINITY;
+    for (int c = 0; c < coin_count; ++c) {
+        if (!survivor[c]) continue;
+        int bar_offset = (k * coin_count + c) * 4;
+        float close = bars[bar_offset + 2];
+        float lower = fmin(ema0[c], fmin(ema1[c], ema2[c]));
+        float upper = fmax(ema0[c], fmax(ema1[c], ema2[c]));
+        float coin_initial_ema_dist = coin_override_or(
+            coin_overrides, c, 5, config.initial_ema_dist
+        );
+        float threshold = short_side
+            ? upper * (1.0f + coin_initial_ema_dist)
+            : lower * (1.0f - coin_initial_ema_dist);
+        float readiness = threshold > 0.0f
+            ? (short_side
+                ? 1.0f - close / threshold
+                : close / threshold - 1.0f)
+            : INFINITY;
+        volume_min = fmin(volume_min, forager_volume[c]);
+        volume_max = fmax(volume_max, forager_volume[c]);
+        ready_min = fmin(ready_min, readiness);
+        ready_max = fmax(ready_max, readiness);
+        volatility_min = fmin(volatility_min, forager_volatility[c]);
+        volatility_max = fmax(volatility_max, forager_volatility[c]);
+    }
+    for (int c = 0; c < coin_count; ++c) {
+        score[c] = -INFINITY;
+        if (!survivor[c]) continue;
+        int bar_offset = (k * coin_count + c) * 4;
+        float close = bars[bar_offset + 2];
+        float lower = fmin(ema0[c], fmin(ema1[c], ema2[c]));
+        float upper = fmax(ema0[c], fmax(ema1[c], ema2[c]));
+        float coin_initial_ema_dist = coin_override_or(
+            coin_overrides, c, 5, config.initial_ema_dist
+        );
+        float threshold = short_side
+            ? upper * (1.0f + coin_initial_ema_dist)
+            : lower * (1.0f - coin_initial_ema_dist);
+        float readiness = threshold > 0.0f
+            ? (short_side
+                ? 1.0f - close / threshold
+                : close / threshold - 1.0f)
+            : INFINITY;
+        float volume_component = volume_max > volume_min
+            ? (forager_volume[c] - volume_min) / (volume_max - volume_min)
+            : 1.0f;
+        float ready_component = ready_max > ready_min
+            ? (ready_max - readiness) / (ready_max - ready_min)
+            : 1.0f;
+        float volatility_component = volatility_max > volatility_min
+            ? (forager_volatility[c] - volatility_min)
+                / (volatility_max - volatility_min)
+            : 1.0f;
+        score[c] = config.w_volume * volume_component
+            + config.w_ready * ready_component
+            + config.w_volatility * volatility_component;
+    }
+    for (int pick = 0; pick < slots; ++pick) {
+        int best = -1;
+        for (int c = 0; c < coin_count; ++c) {
+            if (!survivor[c] || selected[c]) continue;
+            if (best < 0 || score[c] > score[best]
+                || (score[c] == score[best] && c < best)) {
+                best = c;
+            }
+        }
+        if (best >= 0) selected[best] = true;
+    }
+    if (score_hysteresis > 0.0f) {
+        // Match Rust's score hysteresis: consider incumbent flat candidates
+        // from best to worst, then displace only the weakest selected
+        // non-incumbent challenger within the configured gap.
+        for (int rank = 0; rank < coin_count; ++rank) {
+            int incumbent_coin = -1;
+            for (int c = 0; c < coin_count; ++c) {
+                if (!survivor[c] || !incumbent[c] || selected[c]) continue;
+                if (incumbent_coin < 0 || score[c] > score[incumbent_coin]
+                    || (score[c] == score[incumbent_coin]
+                        && c < incumbent_coin)) {
+                    incumbent_coin = c;
+                }
+            }
+            if (incumbent_coin < 0) break;
+
+            int challenger = -1;
+            for (int c = 0; c < coin_count; ++c) {
+                if (!selected[c] || incumbent[c] || !survivor[c]) continue;
+                if (challenger < 0 || score[c] < score[challenger]
+                    || (score[c] == score[challenger] && c > challenger)) {
+                    challenger = c;
+                }
+            }
+            if (challenger < 0) break;
+            if (score[challenger] - score[incumbent_coin]
+                <= score_hysteresis) {
+                selected[challenger] = false;
+                selected[incumbent_coin] = true;
+            } else {
+                break;
+            }
+        }
+    }
+    side.selection_initialized = true;
+    side.previous_effective_n_positions = effective_n_positions;
+}
+
 inline void passivbot_trailing_martingale_multicoin_impl(
     constant float* bars,
     constant int* fill_ticks,
@@ -1554,10 +1758,6 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     const float twel = config.twel;
     const bool gate_initial = config.gate_initial;
     const bool gate_reentry = config.gate_reentry;
-    const float volume_drop = config.volume_drop;
-    const float w_volume = config.w_volume;
-    const float w_ready = config.w_ready;
-    const float w_volatility = config.w_volatility;
     const int n_positions = config.n_positions;
     const float allowance_pct = config.allowance_pct;
     const bool legacy_raw_allowance = config.legacy_raw_allowance;
@@ -1582,9 +1782,6 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     thread HslState& hsl = side.hsl;
     const bool coin_hsl_mode = config.coin_hsl_mode;
     thread HslState* coin_hsl = side.coin_hsl;
-    thread ulong& coin_hsl_entry_blocked_mask =
-        side.coin_hsl_entry_blocked_mask;
-
     const float starting_balance = run_settings[0];
     const float liquidation_floor = run_settings[1];
     const float interval_ms = run_settings[2];
@@ -1600,8 +1797,6 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     thread float* ema2 = side.ema2;
     thread float* volatility_1m = side.volatility_1m;
     thread float* volatility_1h = side.volatility_1h;
-    thread float* forager_volume = side.forager_volume;
-    thread float* forager_volatility = side.forager_volatility;
     thread float* psize = side.psize;
     thread float* pprice = side.pprice;
     thread float* last_increase_k = side.last_increase_k;
@@ -1615,7 +1810,6 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     thread float* close_grid_gen_psize = side.close_grid_gen_psize;
     thread float* position_open_k = side.position_open_k;
     thread float* position_last_fill_k = side.position_last_fill_k;
-    thread float* score = side.score;
     thread float* contribution = side.contribution;
     thread float* minimum_entry = side.minimum_entry;
     thread float* min_since_open = side.min_since_open;
@@ -1629,8 +1823,6 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     thread int* unstuck_close_tick = side.unstuck_close_tick;
     thread int* close_grid_max_rungs = side.close_grid_max_rungs;
     thread bool* selected = side.selected;
-    thread bool* incumbent = side.incumbent;
-    thread bool* survivor = side.survivor;
     thread bool* entry_candidate = side.entry_candidate;
     thread bool* close_reconstruct_after_reducer =
         side.close_reconstruct_after_reducer;
@@ -1660,10 +1852,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     int last_active_fill_day = -1;
     bool alive = true;
     bool equity_started = false;
-    thread bool& selection_initialized = side.selection_initialized;
     thread int& max_tradable_seen = side.max_tradable_seen;
-    thread int& previous_effective_n_positions =
-        side.previous_effective_n_positions;
     float run_peak = -INFINITY;
     float max_dd = 0.0f;
     float total_wallet_exposure_max = 0.0f;
@@ -1776,174 +1965,11 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             ? 0 : hsl_mode(hsl, has_hsl_position);
 
         if (can_generate) {
-            // Exact Rust ranks flat candidates every minute. Re-ranking only
-            // after state changes keeps the proxy inexpensive; independent
-            // exact validations and drift gates police this approximation.
-            bool coin_hsl_eligibility_changed = false;
-            if (coin_hsl_mode) {
-                ulong blocked_mask = 0ul;
-                for (int c = 0; c < C; ++c) {
-                    if (hsl_mode(coin_hsl[c], false) != 0) {
-                        blocked_mask |= 1ul << ulong(c);
-                    }
-                }
-                coin_hsl_eligibility_changed =
-                    blocked_mask != coin_hsl_entry_blocked_mask;
-                coin_hsl_entry_blocked_mask = blocked_mask;
-            }
-            bool reselect = !selection_initialized || any_fill
-                || coin_hsl_eligibility_changed
-                || effective_n_positions != previous_effective_n_positions;
-            if (reselect) {
-                int active_count = 0;
-                for (int c = 0; c < C; ++c) {
-                    incumbent[c] = selected[c] && psize[c] <= 0.0f;
-                    selected[c] = psize[c] > 0.0f;
-                    if (selected[c]) active_count += 1;
-                    survivor[c] = false;
-                }
-                int slots = max(effective_n_positions - active_count, 0);
-                int enabled_count = 0;
-                for (int c = 0; c < C; ++c) {
-                    int coin_offset = c * COIN_COLS;
-                    int bar_offset = (k * C + c) * 4;
-                    float coin_wel = coin_override_or(
-                        coin_overrides, c, 24, -1.0f
-                    );
-                    bool enabled = !selected[c]
-                        && k >= int(coin_settings[coin_offset + 8])
-                        && k <= int(coin_settings[coin_offset + 7])
-                        && finite_positive(bars[bar_offset + 2])
-                        && coin_wel != 0.0f
-                        && (!coin_hsl_mode || (
-                            coin_hsl_entry_blocked_mask & (1ul << ulong(c))
-                        ) == 0ul);
-                    survivor[c] = enabled;
-                    if (enabled) enabled_count += 1;
-                }
-                int keep = int(floor(float(enabled_count) * (1.0f - volume_drop) + 0.5f));
-                keep = min(enabled_count, max(max(keep, slots), enabled_count > 0 ? 1 : 0));
-                if (keep < enabled_count) {
-                    for (int c = 0; c < C; ++c) {
-                        if (!survivor[c]) continue;
-                        int better = 0;
-                        for (int j = 0; j < C; ++j) {
-                            if (!survivor[j]) continue;
-                            if (forager_volume[j] > forager_volume[c]
-                                || (forager_volume[j] == forager_volume[c] && j < c)) {
-                                better += 1;
-                            }
-                        }
-                        if (better >= keep) survivor[c] = false;
-                    }
-                }
-
-                float volume_min = INFINITY;
-                float volume_max = -INFINITY;
-                float ready_min = INFINITY;
-                float ready_max = -INFINITY;
-                float volatility_min = INFINITY;
-                float volatility_max = -INFINITY;
-                for (int c = 0; c < C; ++c) {
-                    if (!survivor[c]) continue;
-                    int bar_offset = (k * C + c) * 4;
-                    float close = bars[bar_offset + 2];
-                    float lower = fmin(ema0[c], fmin(ema1[c], ema2[c]));
-                    float upper = fmax(ema0[c], fmax(ema1[c], ema2[c]));
-                    float coin_initial_ema_dist = coin_override_or(
-                        coin_overrides, c, 5, initial_ema_dist
-                    );
-                    float threshold = short_side
-                        ? upper * (1.0f + coin_initial_ema_dist)
-                        : lower * (1.0f - coin_initial_ema_dist);
-                    float readiness = threshold > 0.0f
-                        ? (short_side ? 1.0f - close / threshold : close / threshold - 1.0f)
-                        : INFINITY;
-                    volume_min = fmin(volume_min, forager_volume[c]);
-                    volume_max = fmax(volume_max, forager_volume[c]);
-                    ready_min = fmin(ready_min, readiness);
-                    ready_max = fmax(ready_max, readiness);
-                    volatility_min = fmin(volatility_min, forager_volatility[c]);
-                    volatility_max = fmax(volatility_max, forager_volatility[c]);
-                }
-                for (int c = 0; c < C; ++c) {
-                    score[c] = -INFINITY;
-                    if (!survivor[c]) continue;
-                    int bar_offset = (k * C + c) * 4;
-                    float close = bars[bar_offset + 2];
-                    float lower = fmin(ema0[c], fmin(ema1[c], ema2[c]));
-                    float upper = fmax(ema0[c], fmax(ema1[c], ema2[c]));
-                    float coin_initial_ema_dist = coin_override_or(
-                        coin_overrides, c, 5, initial_ema_dist
-                    );
-                    float threshold = short_side
-                        ? upper * (1.0f + coin_initial_ema_dist)
-                        : lower * (1.0f - coin_initial_ema_dist);
-                    float readiness = threshold > 0.0f
-                        ? (short_side ? 1.0f - close / threshold : close / threshold - 1.0f)
-                        : INFINITY;
-                    float volume_component = volume_max > volume_min
-                        ? (forager_volume[c] - volume_min) / (volume_max - volume_min) : 1.0f;
-                    float ready_component = ready_max > ready_min
-                        ? (ready_max - readiness) / (ready_max - ready_min) : 1.0f;
-                    float volatility_component = volatility_max > volatility_min
-                        ? (forager_volatility[c] - volatility_min)
-                            / (volatility_max - volatility_min) : 1.0f;
-                    score[c] = w_volume * volume_component
-                        + w_ready * ready_component
-                        + w_volatility * volatility_component;
-                }
-                for (int pick = 0; pick < slots; ++pick) {
-                    int best = -1;
-                    for (int c = 0; c < C; ++c) {
-                        if (!survivor[c] || selected[c]) continue;
-                        if (best < 0 || score[c] > score[best]
-                            || (score[c] == score[best] && c < best)) {
-                            best = c;
-                        }
-                    }
-                    if (best >= 0) selected[best] = true;
-                }
-                if (score_hysteresis > 0.0f) {
-                    // Match Rust's score hysteresis: consider incumbent flat
-                    // candidates from best to worst, then displace only the
-                    // weakest selected non-incumbent challenger when its
-                    // normalized-score lead is within the configured gap.
-                    for (int rank = 0; rank < C; ++rank) {
-                        int incumbent_coin = -1;
-                        for (int c = 0; c < C; ++c) {
-                            if (!survivor[c] || !incumbent[c] || selected[c]) continue;
-                            if (incumbent_coin < 0 || score[c] > score[incumbent_coin]
-                                || (score[c] == score[incumbent_coin]
-                                    && c < incumbent_coin)) {
-                                incumbent_coin = c;
-                            }
-                        }
-                        if (incumbent_coin < 0) break;
-
-                        int challenger = -1;
-                        for (int c = 0; c < C; ++c) {
-                            if (!selected[c] || incumbent[c] || !survivor[c]) continue;
-                            if (challenger < 0 || score[c] < score[challenger]
-                                || (score[c] == score[challenger] && c > challenger)) {
-                                challenger = c;
-                            }
-                        }
-                        if (challenger < 0) break;
-                        if (score[challenger] - score[incumbent_coin]
-                            <= score_hysteresis) {
-                            selected[challenger] = false;
-                            selected[incumbent_coin] = true;
-                        } else {
-                            // Rust continues to lower-scored incumbents, but
-                            // none can satisfy the gap once the best cannot.
-                            break;
-                        }
-                    }
-                }
-                selection_initialized = true;
-                previous_effective_n_positions = effective_n_positions;
-            }
+            update_tm_multicoin_side_selection(
+                side, config, bars, coin_settings, coin_overrides,
+                k, C, short_side, any_fill, effective_n_positions,
+                score_hysteresis
+            );
 
             const float effective_wel = twel / fmax(float(effective_n_positions), 1.0f);
             float current_twe = 0.0f;

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -1049,6 +1049,133 @@ kernel void passivbot_tm_multicoin_side_fill_pass_probe(
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+def test_mps_tm_multicoin_selection_phase_keeps_side_local_hsl_rankings():
+    import passivbot_rust
+
+    probe_kernel = r"""
+kernel void passivbot_tm_multicoin_selection_phase_probe(
+    constant float* bars,
+    constant float* coin_settings,
+    constant float* coin_overrides,
+    device float* output,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    TrailingMartingaleMulticoinSideState long_side;
+    TrailingMartingaleMulticoinSideState short_side;
+    TrailingMartingaleMulticoinSideConfig long_config;
+    TrailingMartingaleMulticoinSideConfig short_config;
+    long_config.coin_hsl_mode = true;
+    short_config.coin_hsl_mode = false;
+    long_config.volume_drop = 0.0f;
+    short_config.volume_drop = 0.0f;
+    long_config.w_volume = 1.0f;
+    short_config.w_volume = 1.0f;
+    long_config.w_ready = 0.0f;
+    short_config.w_ready = 0.0f;
+    long_config.w_volatility = 0.0f;
+    short_config.w_volatility = 0.0f;
+    long_config.initial_ema_dist = 0.0f;
+    short_config.initial_ema_dist = 0.0f;
+    long_side.selection_initialized = false;
+    short_side.selection_initialized = false;
+    long_side.previous_effective_n_positions = 0;
+    short_side.previous_effective_n_positions = 0;
+    long_side.coin_hsl_entry_blocked_mask = 0ul;
+    short_side.coin_hsl_entry_blocked_mask = 0ul;
+    for (int c = 0; c < 3; ++c) {
+        long_side.psize[c] = 0.0f;
+        short_side.psize[c] = 0.0f;
+        long_side.selected[c] = false;
+        short_side.selected[c] = false;
+        long_side.incumbent[c] = false;
+        short_side.incumbent[c] = false;
+        long_side.survivor[c] = false;
+        short_side.survivor[c] = false;
+        long_side.ema0[c] = 100.0f;
+        long_side.ema1[c] = 100.0f;
+        long_side.ema2[c] = 100.0f;
+        short_side.ema0[c] = 100.0f;
+        short_side.ema1[c] = 100.0f;
+        short_side.ema2[c] = 100.0f;
+        long_side.forager_volume[c] = float(3 - c) * 100.0f;
+        short_side.forager_volume[c] = float(c + 1) * 100.0f;
+        long_side.forager_volatility[c] = 0.0f;
+        short_side.forager_volatility[c] = 0.0f;
+        long_side.coin_hsl[c].enabled = false;
+        long_side.coin_hsl[c].halted = false;
+        long_side.coin_hsl[c].tier = 0;
+        long_side.coin_hsl[c].red_active_now = false;
+        long_side.coin_hsl[c].orange_graceful_stop = false;
+    }
+    // Block the long side's highest-volume coin without affecting short.
+    long_side.coin_hsl[0].enabled = true;
+    long_side.coin_hsl[0].tier = 2;
+    long_side.coin_hsl[0].orange_graceful_stop = true;
+    update_tm_multicoin_side_selection(
+        long_side, long_config, bars, coin_settings, coin_overrides,
+        1, 3, false, true, 1, 0.0f
+    );
+    update_tm_multicoin_side_selection(
+        short_side, short_config, bars, coin_settings, coin_overrides,
+        1, 3, true, true, 1, 0.0f
+    );
+    for (int c = 0; c < 3; ++c) {
+        output[c] = long_side.selected[c] ? 1.0f : 0.0f;
+        output[3 + c] = short_side.selected[c] ? 1.0f : 0.0f;
+    }
+    output[6] = long_side.selection_initialized ? 1.0f : 0.0f;
+    output[7] = short_side.selection_initialized ? 1.0f : 0.0f;
+    output[8] = float(long_side.previous_effective_n_positions);
+    output[9] = float(short_side.previous_effective_n_positions);
+    output[10] = float(long_side.coin_hsl_entry_blocked_mask);
+    output[11] = float(short_side.coin_hsl_entry_blocked_mask);
+}
+"""
+
+    bars = torch.tensor(
+        [
+            [[100.0, 100.0, 100.0, 1.0]] * 3,
+            [[100.0, 100.0, 100.0, 1.0]] * 3,
+        ],
+        dtype=torch.float32,
+        device="mps",
+    )
+    coin_settings = torch.zeros((3, 12), dtype=torch.float32, device="mps")
+    coin_settings[:, 7] = 10.0
+    coin_overrides = torch.full(
+        (3, 44), float("nan"), dtype=torch.float32, device="mps"
+    )
+    output = torch.zeros(12, dtype=torch.float32, device="mps")
+
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_trailing_martingale_multicoin_source_py()
+        + probe_kernel
+    )
+    library.passivbot_tm_multicoin_selection_phase_probe(
+        bars, coin_settings, coin_overrides, output, threads=(1, 1, 1)
+    )
+    torch.mps.synchronize()
+
+    assert output.cpu().tolist() == [
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+        0.0,
+    ]
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 def test_mps_ema_multicoin_dual_hsl_phase_covers_all_signal_topologies():
     import passivbot_rust
 


### PR DESCRIPTION
## Summary

- extract trailing-martingale multicoin candidate eligibility, volume filtering, normalized scoring, slot selection, and score hysteresis into an explicit side-selection helper
- keep coin-HSL entry blocking and reselection state owned by the directional side state
- add a physical-MPS probe proving side-local long/short rankings and coin-HSL isolation

This is a refactoring prerequisite for the fused trailing-martingale shared-account/HSL runner. It does not widen GPU support and does not change CPU optimization, exact Rust behavior, live trading, or backend routing.

## Validation

- Rust tests: 265 passed
- `cargo check --tests`
- rebuilt extension and verified exact source fingerprint
- focused physical-MPS selection/HSL-isolation probe
- full physical-MPS module: 284 passed
- optimizer/backend CPU regression set passed
- token-normalized extraction audit:
  - `selection_prelude_identical=True`
  - `selection_core_identical=True`

## Review focus

- coin-HSL blocked-mask refresh and reselection triggers
- forager volume filtering and score normalization
- deterministic symbol-index tie breaks
- incumbent/challenger hysteresis semantics
