### PR TITLE
Expose fused TM multicoin MPS runner

### DIFF
--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -22,7 +22,7 @@ MPS_MULTICOIN_DAILY_COLS = 9
 MPS_SCALAR_COLS = 32
 MPS_MULTICOIN_SCALAR_COLS = 57
 MPS_DIRECTIONAL_SCALAR_COLS = 62
-MPS_EMA_MULTICOIN_FUSED_SCALAR_COLS = 62
+MPS_MULTICOIN_FUSED_SCALAR_COLS = 62
 
 
 def _encode_max_realized_loss_pct(value: float) -> float:
@@ -165,7 +165,7 @@ def _decode_outputs(daily, scalars, gaps) -> dict:
     }
 
 
-def _decode_ema_multicoin_fused_outputs(daily, scalars, gaps) -> dict:
+def _decode_multicoin_fused_outputs(daily, scalars, gaps) -> dict:
     output = _decode_outputs(daily, scalars, gaps)
     long_entry_initial_balance_pct = output.pop("entry_initial_balance_pct")
     output.update(
@@ -664,6 +664,9 @@ class MpsEmaAnchorMulticoinRunner:
             threads=(batch_size, 1, 1),
         )
 
+    def _library(self):
+        return _ema_anchor_multicoin_shader_library()
+
     def _decode(self, daily, scalars, gaps) -> dict:
         return _decode_outputs(daily, scalars, gaps)
 
@@ -698,7 +701,7 @@ class MpsEmaAnchorMulticoinRunner:
                 device="mps",
             )
         prepared = time.perf_counter()
-        library = _ema_anchor_multicoin_shader_library()
+        library = self._library()
         compiled = time.perf_counter()
         if profile:
             torch.mps.synchronize()
@@ -735,7 +738,7 @@ class MpsEmaAnchorMulticoinRunner:
 class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
     """Persistent dual-side shared-account EMA Anchor runner on Apple MPS."""
 
-    scalar_cols = MPS_EMA_MULTICOIN_FUSED_SCALAR_COLS
+    scalar_cols = MPS_MULTICOIN_FUSED_SCALAR_COLS
 
     def __init__(
         self,
@@ -845,7 +848,7 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
         )
 
     def _decode(self, daily, scalars, gaps) -> dict:
-        return _decode_ema_multicoin_fused_outputs(daily, scalars, gaps)
+        return _decode_multicoin_fused_outputs(daily, scalars, gaps)
 
 
 class MpsEmaAnchorMulticoinLongRunner(MpsEmaAnchorMulticoinRunner):
@@ -903,44 +906,22 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             )
         return np.ascontiguousarray(params, dtype=np.float32)
 
-    def run(
+    def _library(self):
+        return _trailing_martingale_multicoin_shader_library()
+
+    def _dispatch(
         self,
-        params: np.ndarray,
+        library,
+        params_mps,
+        sizes,
+        end_steps,
+        daily,
+        scalars,
+        gaps,
+        coin_fill_counts,
         *,
-        profile: bool = False,
-        end_steps: np.ndarray | None = None,
-    ) -> dict:
-        started = time.perf_counter()
-        matrix = self._pack_params(params)
-        packed = time.perf_counter()
-        params_mps = torch.as_tensor(matrix, device="mps")
-        batch_size = int(matrix.shape[0])
-        end_steps_mps = self._end_steps(end_steps, batch_size)
-        daily, scalars, gaps, coin_fill_counts = self._output_buffers(batch_size)
-        sizes_key = (batch_size, int(matrix.shape[1]))
-        if sizes_key not in self._sizes:
-            self._sizes[sizes_key] = torch.tensor(
-                [
-                    batch_size,
-                    self.n,
-                    self.n_coins,
-                    self.n_days,
-                    self.requested_start_idx,
-                    self.run_config.warmup_bars,
-                    self.start_minute_of_day,
-                    self.start_minute_of_hour,
-                ],
-                dtype=torch.int32,
-                device="mps",
-            )
-        prepared = time.perf_counter()
-        library = _trailing_martingale_multicoin_shader_library()
-        compiled = time.perf_counter()
-        if profile:
-            torch.mps.synchronize()
-            dispatched = time.perf_counter()
-        else:
-            dispatched = compiled
+        batch_size: int,
+    ) -> None:
         library.passivbot_trailing_martingale_multicoin(
             self.bars,
             self.fill_ticks,
@@ -952,28 +933,136 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             self.coin_overrides,
             params_mps,
             self.settings,
-            self._sizes[sizes_key],
-            end_steps_mps,
+            sizes,
+            end_steps,
             daily,
             scalars,
             gaps,
             coin_fill_counts,
             threads=(batch_size, 1, 1),
         )
-        if profile:
-            torch.mps.synchronize()
-        finished = time.perf_counter()
-        self.last_profile = {
-            "cpu_pack_seconds": packed - started,
-            "upload_and_zero_seconds": prepared - packed,
-            "compile_seconds": compiled - prepared,
-            "pre_dispatch_sync_seconds": dispatched - compiled,
-            "kernel_seconds": finished - dispatched,
-        }
-        output = _decode_outputs(daily, scalars, gaps)
-        if self.collect_coin_fill_counts:
-            output["coin_fill_counts"] = coin_fill_counts
-        return output
+
+    def _decode(self, daily, scalars, gaps) -> dict:
+        return _decode_outputs(daily, scalars, gaps)
+
+
+class MpsTrailingMartingaleMulticoinFusedRunner(
+    MpsTrailingMartingaleMulticoinRunner
+):
+    """Persistent dual-side shared-account Trailing Martingale runner on MPS."""
+
+    scalar_cols = MPS_MULTICOIN_FUSED_SCALAR_COLS
+
+    def __init__(
+        self,
+        run: ProxyRun,
+        data: dict,
+        *,
+        long_coin_overrides: np.ndarray | None = None,
+        short_coin_overrides: np.ndarray | None = None,
+        forager_score_hysteresis_pct: float = 0.0,
+        max_realized_loss_pct: float = 1.0,
+        collect_coin_fill_counts: bool = False,
+        market_order_slippage_pct: float = 0.0,
+        hsl_panic_market_long: bool = False,
+        hsl_panic_market_short: bool = False,
+    ):
+        super().__init__(
+            run,
+            data,
+            side="long",
+            coin_overrides=long_coin_overrides,
+            forager_score_hysteresis_pct=forager_score_hysteresis_pct,
+            max_realized_loss_pct=max_realized_loss_pct,
+            collect_coin_fill_counts=collect_coin_fill_counts,
+            market_order_slippage_pct=market_order_slippage_pct,
+            hsl_panic_market=hsl_panic_market_long,
+        )
+        if short_coin_overrides is None:
+            short_coin_overrides = np.full(
+                (self.n_coins, self.coin_override_cols),
+                np.nan,
+                dtype=np.float32,
+            )
+        short_coin_overrides = np.asarray(short_coin_overrides, dtype=np.float32)
+        expected_shape = (self.n_coins, self.coin_override_cols)
+        if short_coin_overrides.shape != expected_shape:
+            raise ValueError(
+                "expected fused multicoin Trailing Martingale short override "
+                f"matrix shaped {expected_shape}, got {short_coin_overrides.shape}"
+            )
+        self.short_coin_overrides = torch.as_tensor(
+            np.ascontiguousarray(short_coin_overrides), device="mps"
+        )
+        encoded_max_realized_loss_pct = _encode_max_realized_loss_pct(
+            float(max_realized_loss_pct)
+        )
+        liq_floor = max(0.0, run.starting_balance) * max(
+            0.0, run.liquidation_threshold
+        )
+        self.settings = torch.tensor(
+            [
+                run.starting_balance,
+                liq_floor,
+                run.interval_ms,
+                0.0,
+                float(forager_score_hysteresis_pct),
+                encoded_max_realized_loss_pct,
+                float(self.collect_coin_fill_counts),
+                float(market_order_slippage_pct),
+                float(bool(hsl_panic_market_long)),
+                float(bool(hsl_panic_market_short)),
+            ],
+            dtype=torch.float32,
+            device="mps",
+        )
+
+    def _pack_params(self, params: np.ndarray) -> np.ndarray:
+        expected = len(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS) * 2
+        if params.ndim != 2 or params.shape[1] != expected:
+            got = params.shape[1] if params.ndim == 2 else params.shape
+            raise ValueError(
+                "expected fused multicoin Trailing Martingale parameter matrix "
+                f"with {expected} columns, got {got}"
+            )
+        return np.ascontiguousarray(params, dtype=np.float32)
+
+    def _dispatch(
+        self,
+        library,
+        params_mps,
+        sizes,
+        end_steps,
+        daily,
+        scalars,
+        gaps,
+        coin_fill_counts,
+        *,
+        batch_size: int,
+    ) -> None:
+        library.passivbot_trailing_martingale_multicoin_fused(
+            self.bars,
+            self.fill_ticks,
+            self.touch_ticks,
+            self.touch_nearest_ticks,
+            self.touch_min_qty_bits,
+            self.touch_min_qty_relation,
+            self.coin_settings,
+            self.coin_overrides,
+            self.short_coin_overrides,
+            params_mps,
+            self.settings,
+            sizes,
+            end_steps,
+            daily,
+            scalars,
+            gaps,
+            coin_fill_counts,
+            threads=(batch_size, 1, 1),
+        )
+
+    def _decode(self, daily, scalars, gaps) -> dict:
+        return _decode_multicoin_fused_outputs(daily, scalars, gaps)
 
 
 class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -21,7 +21,8 @@ from optimization.gpu.model import (
 )
 from optimization.gpu.mps_kernel import (
     MpsEmaAnchorMulticoinFusedRunner,
-    _decode_ema_multicoin_fused_outputs,
+    MpsTrailingMartingaleMulticoinFusedRunner,
+    _decode_multicoin_fused_outputs,
     _encode_max_realized_loss_pct,
 )
 from optimization.gpu.metrics import _fill_gap_metrics, compute_objectives
@@ -94,14 +95,14 @@ def test_mps_disabled_realized_loss_limit_has_finite_float32_encoding(value):
     assert _encode_max_realized_loss_pct(value) == 1.0
 
 
-def test_decode_ema_multicoin_fused_outputs_maps_directional_reductions():
+def test_decode_multicoin_fused_outputs_maps_directional_reductions():
     daily = torch.zeros((1, 1, 9), dtype=torch.float32)
     daily[:, :, 1].fill_(float("inf"))
     daily[:, :, 5].fill_(float("inf"))
     scalars = torch.arange(62, dtype=torch.float32).reshape(1, 62)
     gaps = torch.zeros((1, 128), dtype=torch.int32)
 
-    output = _decode_ema_multicoin_fused_outputs(daily, scalars, gaps)
+    output = _decode_multicoin_fused_outputs(daily, scalars, gaps)
 
     assert "entry_initial_balance_pct" not in output
     assert torch.equal(output["entry_initial_balance_pct_long"], scalars[:, 21])
@@ -4623,6 +4624,59 @@ def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
     assert output[3:, 9].tolist() == [0.0, 0.0, 0.0]
     assert output[3:, 13].tolist() == [0.0, 0.0, 0.0]
     assert output[3:, 24].tolist() == [0.0, 0.0, 0.0]
+
+    override_matrix = np.full((coin_count, 44), np.nan, dtype=np.float32)
+    runner = MpsTrailingMartingaleMulticoinFusedRunner(
+        runs[0],
+        data,
+        long_coin_overrides=override_matrix,
+        short_coin_overrides=override_matrix,
+        forager_score_hysteresis_pct=0.02,
+        max_realized_loss_pct=1.0,
+        collect_coin_fill_counts=True,
+    )
+    torch.testing.assert_close(runner.settings, run_settings)
+    runner_output = runner.run(np.asarray(rows, dtype=np.float64), profile=True)
+    torch.mps.synchronize()
+    torch.testing.assert_close(runner_output["day_end_eq"], daily[:, :, 0])
+    torch.testing.assert_close(runner_output["day_min_eq"], daily[:, :, 1])
+    torch.testing.assert_close(runner_output["fill_count"], scalars[:, 24])
+    torch.testing.assert_close(
+        runner_output["entry_initial_balance_pct_long"], scalars[:, 21]
+    )
+    torch.testing.assert_close(
+        runner_output["entry_initial_balance_pct_short"], scalars[:, 57]
+    )
+    torch.testing.assert_close(runner_output["profit_sum_long"], scalars[:, 58])
+    torch.testing.assert_close(runner_output["loss_sum_long"], scalars[:, 59])
+    torch.testing.assert_close(runner_output["profit_sum_short"], scalars[:, 60])
+    torch.testing.assert_close(runner_output["loss_sum_short"], scalars[:, 61])
+    assert runner_output["alive"].cpu().tolist() == [
+        True,
+        True,
+        True,
+        False,
+        False,
+        False,
+    ]
+    assert torch.equal(runner_output["coin_fill_counts"], coin_fill_counts)
+    assert runner.last_profile["kernel_seconds"] >= 0.0
+
+    with pytest.raises(ValueError, match="118 columns"):
+        runner.run(np.asarray([side_row(0)], dtype=np.float64))
+    with pytest.raises(ValueError, match="short override matrix shaped"):
+        MpsTrailingMartingaleMulticoinFusedRunner(
+            runs[0],
+            data,
+            short_coin_overrides=np.empty((coin_count, 43), dtype=np.float32),
+        )
+    truncated = runner.run(
+        np.asarray([rows[0]], dtype=np.float64),
+        end_steps=np.asarray([60], dtype=np.int32),
+    )
+    torch.mps.synchronize()
+    assert truncated["last_eq_ts"].item() <= 59 * 60_000.0
+    assert truncated["fill_count"].item() <= output[0, 24]
 
     override_unstuck = overrides.clone()
     override_unstuck[0, 28] = 1.0


### PR DESCRIPTION
## Summary

- expose `MpsTrailingMartingaleMulticoinFusedRunner` for the merged shared-account TM Metal kernel
- pack and validate the 118-column long-plus-short parameter matrix and independent 44-column coin-override matrices
- dispatch all TM tick-control buffers and decode the shared 62-column directional output contract
- reuse the existing multicoin buffer, sizing, profiling, truncation, and coin-fill-count lifecycle through narrow shader-library and dispatch hooks
- name the fused output width and decoder as a strategy-neutral multicoin contract shared by EMA Anchor and Trailing Martingale

This slice exposes and tests the runner only. It does not widen optimizer/service routing. Exact Rust remains authoritative, the fused TM kernel still fails closed when auto-unstuck is enabled, and existing CPU bot/backtest/optimizer behavior is unchanged.

## Validation

- rebuilt and stamped the exact Python/Rust extension from this worktree
- focused physical Apple M3/MPS fused-runner contract passed
- direct kernel and runner outputs match for daily equity, fills, directional PnL, alive state, and per-coin fill counts
- full physical Apple M3/MPS module — 287 passed
- CPU optimizer/backend regression matrix passed
- Python syntax checks passed
- `git diff --check`
