### PR TITLE
Route fused TM multicoin MPS optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,17 @@ All notable user-facing changes will be documented in this file.
   same rolling-window rule as exact Rust instead of retaining an all-history peak; bounded GPU
   scratch overflow fails the affected candidate closed, and exact Rust remains authoritative.
 
+- Added fused shared-account dual-side multi-coin Trailing Martingale screening to Apple MPS
+  optimization. Long and short candidates now run in one portfolio kernel for unified, pside,
+  and coin HSL, including shared event/tier metrics, directional PnL, coin overrides, forager
+  selection, and the existing TM entry/close behavior. Exact Rust remains authoritative;
+  dual-side auto-unstuck and exposure repair remain fail closed pending their global cross-side
+  parity slices.
+
 - Added fused shared-account dual-side multi-coin EMA Anchor screening to Apple MPS optimization.
   Unified, pside, and coin HSL now run inside one portfolio kernel, including per-coin HSL
   overrides and shared event/tier scoring metrics. Exact Rust remains authoritative, dual-side
-  auto-unstuck and exposure repair remain fail closed, and dual-side multi-coin Trailing
-  Martingale remains on its existing pside-only directional proxy.
+  auto-unstuck and exposure repair remain fail closed.
 
 - Added dual-side single-coin `unified` HSL to Apple MPS optimization for EMA Anchor and
   Trailing Martingale. Both Metal controllers now consume account-wide realized and unrealized

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -134,9 +134,8 @@ The supported slice is intentionally narrow:
   `risk.position_exposure_enforcer_threshold`; per-coin
   `risk.we_excess_allowance_mode`, trailing-martingale `entry.ema_gate_mode`, disabled sides, and
   other override leaves fail closed. In one-sided `live.hsl_signal_mode: coin` runs, all ten HSL
-  leaves documented in `coin_overrides.md` are also supported. Fused dual-side EMA Anchor coin
-  mode resolves the same HSL leaves independently for long and short; dual-side Trailing
-  Martingale coin-mode HSL overrides remain fail closed
+  leaves documented in `coin_overrides.md` are also supported. Fused dual-side EMA Anchor and
+  Trailing Martingale coin mode resolve the same HSL leaves independently for long and short
 - one-sided single-coin and multi-coin EMA Anchor and Trailing Martingale runs support HSL with
   `coin`, `pside`, or `unified` signals and both resting-limit and market panic closes. Unified and
   pside multi-coin runs use one portfolio controller; coin mode uses an independent controller per
@@ -162,11 +161,9 @@ The supported slice is intentionally narrow:
   drawdown min/mean/max, and halt-to-restart equity loss) may be used for scoring and limits.
   One-sided coin-mode multi-coin runs may resolve all canonical HSL settings independently per
   coin, including HSL enablement and limit/market panic execution. Dual-side multi-coin EMA Anchor
-  uses one fused shared-account kernel for unified, pside, and coin signals, so shared event-loss,
-  warning-tier overlap, and the other HSL lifecycle/panic-loss metrics are available. Dual-side
-  multi-coin Trailing Martingale remains limited to pside signals; shared event-loss and
-  warning-tier overlap metrics remain fail closed on its independent directional proxy. HSL
-  strategy-equity EMA/recovery-distribution metrics remain fail closed for now.
+  and Trailing Martingale use fused shared-account kernels for unified, pside, and coin signals,
+  so shared event-loss, warning-tier overlap, and the other HSL lifecycle/panic-loss metrics are
+  available. HSL strategy-equity EMA/recovery-distribution metrics remain fail closed for now.
   Compatible suites may use the supported topologies.
 - single-coin EMA Anchor and Trailing Martingale support auto-unstuck for long-only,
   short-only, hedge-mode dual-side, one-way, and compatible suite runs. One-sided multi-coin runs
@@ -192,17 +189,15 @@ The supported slice is intentionally narrow:
   permits aggregate entries beyond TWEL while each symbol remains subject to its allowed WEL
 - `position_held_hours_mean`, `position_held_days_mean`, `positions_held_per_day`,
   `position_unchanged_hours_max`, and `position_unchanged_days_max` may be used for scoring and
-  limits in single-coin and one-sided multi-coin runs. Metal counts each completed position and
-  open tail, sums its holding duration, and tracks the latest fill independently for each coin and
-  position side. Dual-side multi-coin runs fail closed for these metrics and held-duration maxima
-  because independent directional summaries cannot truncate pre-reduced duration aggregates at
-  shared portfolio liquidation; exact Rust validation remains authoritative
+  limits in single-coin and multi-coin runs. Metal counts each completed position and open tail,
+  sums its holding duration, and tracks the latest fill independently for each coin and position
+  side. Fused dual-side multi-coin kernels truncate those aggregates at shared portfolio
+  liquidation; exact Rust validation remains authoritative
 - `total_wallet_exposure_max` and `total_wallet_exposure_mean` may be used for scoring and limits
-  in single-coin and one-sided multi-coin runs. Metal samples absolute net long-minus-short wallet
+  in single-coin and multi-coin runs. Metal samples absolute net long-minus-short wallet
   exposure after every non-liquidating equity update, including flat zero-exposure samples, and
-  reduces it with bounded maximum and online-mean accumulators. Dual-side multi-coin runs fail
-  closed because independent directional kernels cannot reconstruct the shared minute-level net
-  exposure series
+  reduces it with bounded maximum and online-mean accumulators. Fused dual-side multi-coin kernels
+  maintain the shared minute-level net exposure series
 - canonical USD account-equity metrics may use the same MPS surface as their strategy-equity
   counterparts while BTC collateral is disabled: `gain_usd`, `adg_usd`, `mdg_usd`,
   `sharpe_ratio_usd`, `sortino_ratio_usd`, `omega_ratio_usd`,
@@ -210,8 +205,7 @@ The supported slice is intentionally narrow:
   `drawdown_worst_usd`, and `drawdown_worst_mean_1pct_usd`, plus the available `_w_usd` weighted
   variants. `exposure_ratio_usd` and `exposure_mean_ratio_usd` combine proxy ADG with the maximum
   and mean total-wallet-exposure accumulators. The exposure ratios support single-coin and
-  one-sided multi-coin runs; dual-side multi-coin runs fail closed because independent directional
-  kernels cannot reconstruct shared net exposure
+  multi-coin runs, including fused dual-side kernels
 - canonical USD gain, ADG, MDG, weighted ADG, and weighted MDG per-configured-exposure metrics are
   supported for both long and short sides. The proxy divides the matching validated equity metric
   by each candidate's effective side `total_wallet_exposure_limit`, after applying any exact-last
@@ -221,18 +215,19 @@ The supported slice is intentionally narrow:
   without fills retain Rust's default value of `1.0` for all three metrics
 - canonical USD `peak_recovery_hours_equity` and `peak_recovery_days_equity` scoring and limits
   use Metal's full-resolution maximum completed peak-to-peak recovery interval. As in exact Rust,
-  an unrecovered final tail is not included and a candidate without fills returns zero. Dual-side
-  multi-coin runs fail closed because independent directional kernels cannot reconstruct the
-  shared portfolio equity path. These metrics also require contiguous valid candles for each
-  exposure-eligible coin after that coin's equity tracking starts because Rust records an equity
-  sample on every tracked step
+  an unrecovered final tail is not included and a candidate without fills returns zero. Fused
+  dual-side multi-coin kernels maintain the shared portfolio equity path. These metrics also
+  require contiguous valid candles for every exposure-eligible coin on either side after that
+  coin's equity tracking starts because Rust records an equity sample on every tracked step
 - Trailing Martingale supports `risk.position_exposure_enforcer_enabled` and a tunable
-  `risk.position_exposure_enforcer_threshold` for single- and multi-coin long, short, dual-side,
-  and compatible suite runs. When current position exposure exceeds the allowance-adjusted WEL
-  times the positive threshold, Metal gives the passive reducer precedence over the normal
-  strategy close and sizes it strictly below that target. Static per-coin overrides may change
-  both fields. EMA Anchor position-exposure repair remains fail closed because its exact Rust
-  strategy path does not use this reducer
+  `risk.position_exposure_enforcer_threshold` for single-coin long, short, and dual-side runs,
+  one-sided multi-coin runs, and compatible suites. When current position exposure exceeds the
+  allowance-adjusted WEL times the positive threshold, Metal gives the passive reducer precedence
+  over the normal strategy close and sizes it strictly below that target. Static per-coin
+  overrides may change both fields in one-sided multi-coin runs. Dual-side multi-coin repair
+  remains fail closed until global cross-side selection and loss-budget reservation are modeled.
+  EMA Anchor position-exposure repair remains fail closed because its exact Rust strategy path
+  does not use this reducer
 - single-coin EMA Anchor models the cumulative realized-loss gate, including entry and close fees,
   shared long/short loss-budget accounting, and lossy total-exposure repairs. The proxy uses a
   conservative all-history loss envelope, so it may block a close that exact Rust admits after old
@@ -240,9 +235,9 @@ The supported slice is intentionally narrow:
   Martingale permit the one selected auto-unstuck reducer to consume that same conservative budget,
   while ordinary and exposure-repair closes retain the stricter zero-loss envelope. One-sided
   multi-coin EMA Anchor applies the conservative budget only to its selected auto-unstuck reducer;
-  its other closes remain zero-loss. Dual-side multi-coin runs retain the strict zero-loss envelope
-  across independent directional dispatches. These restrictions avoid unsafe cross-dispatch loss-
-  budget reservation and per-candle enumeration of TM's recursive 500-rung close ladder. Exact
+  its other closes remain zero-loss. Dual-side multi-coin runs retain the strict zero-loss
+  envelope. These restrictions avoid unsafe cross-side loss-budget reservation and per-candle
+  enumeration of TM's recursive 500-rung close ladder. Exact
   validation applies the configured rolling allowance and remains authoritative
 - BTC collateral remains disabled; dual-side multicoin total-exposure repair remains disabled
 - `backtest.filter_by_min_effective_cost` may be enabled or disabled. When enabled, Metal uses the
@@ -262,27 +257,11 @@ The supported slice is intentionally narrow:
 - no invalid candle tail after the selected coin's final valid candle
 
 Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor and
-Trailing Martingale use one long and one short Metal dispatch per candidate in hedge mode. Their
-directional surfaces form a
-conservative portfolio screening proxy; every accepted metric still comes from the unchanged exact
-Rust portfolio backtest, and classification, rank, and drift gates halt material disagreement.
-Dual-side one-way arbitration, unmodeled non-bot suite scenario overrides, HSL, and dual-side
-multi-coin auto-unstuck are not silently approximated by this release. Dual-side multi-coin
-screening also rejects `fills_gap_longest_days`,
-`fills_gap_mean_hours`, `fills_gap_median_hours`, `fills_gap_p95_hours`,
-`fills_gap_p99_hours`,
-`strategy_eq_recovery_days_max`, `peak_recovery_hours_strategy_eq`,
-`peak_recovery_days_strategy_eq`, `peak_recovery_hours_pnl`, `peak_recovery_days_pnl`,
-`entry_initial_balance_pct_long`, `entry_initial_balance_pct_short`,
-`peak_recovery_hours_equity_usd`, `peak_recovery_days_equity_usd`,
-`position_held_days_mean`, `position_held_days_max`, `position_held_hours_mean`,
-`position_held_hours_max`, `positions_held_per_day`, `position_unchanged_days_max`,
-`position_unchanged_hours_max`, `total_wallet_exposure_max`, `total_wallet_exposure_mean`, and
-`exposure_ratio_usd`, `exposure_mean_ratio_usd`, and `volume_pct_per_day_avg`: the independent
-directional
-summaries cannot reconstruct cross-side-only fill gaps, alternating portfolio recovery periods,
-effective coin counts and duration maxima truncated at shared portfolio liquidation, minute-level
-net exposure, or fill volume normalized by the shared balance safely.
+Trailing Martingale use fused shared-account Metal kernels in hedge mode. Every accepted metric
+still comes from the unchanged exact Rust portfolio backtest, and classification, rank, and drift
+gates halt material disagreement. Dual-side one-way arbitration, unmodeled non-bot suite scenario
+overrides, dual-side multi-coin auto-unstuck, and dual-side multi-coin exposure repair are not
+silently approximated by this release.
 
 For a supported suite, each Metal candidate is dispatched across every prepared scenario. The GPU
 path then calls the same canonical suite reducer and scenario-selection logic as the CPU optimizer
@@ -353,21 +332,21 @@ the corresponding canonical USD account-equity names share this strategy-equity 
 Daily USD equity choppiness, jerkiness, and exponential fit error are reduced from that same active
 daily closing-equity surface with Rust's no-fill defaults and short-series behavior.
 Collateral-agnostic `adg_pnl`, `mdg_pnl`, `sharpe_ratio_pnl`, and `sortino_ratio_pnl` are also
-supported for single-coin and one-sided multi-coin runs. Metal groups realized balance changes by
+supported for single-coin and multi-coin runs. Metal groups realized balance changes by
 UTC fill day and divides by that day's last fill balance, matching exact Rust's unweighted daily
-PnL ratio contract. Dual-side multi-coin runs remain unsupported because independent directional
-summaries cannot identify the intraday shared-liquidation cutoff. The corresponding weighted PnL
-variants are supported in the same safe topologies. Metal counts each actual proxy fill, including
-multiple same-candle ladder fills, and applies Rust's full-run minimum fill count and empty-suffix
-rules across the same ten minute-position suffix boundaries. The compact daily surface includes
-the complete UTC day containing each suffix boundary, so exact Rust validation and drift gates
-remain authoritative for that screening approximation.
+PnL ratio contract. Fused dual-side multi-coin kernels retain the shared intraday-liquidation
+cutoff. The corresponding weighted PnL variants are supported in the same safe topologies. Metal
+counts each actual proxy fill, including multiple same-candle ladder fills, and applies Rust's
+full-run minimum fill count and empty-suffix rules across the same ten minute-position suffix
+boundaries. The compact daily surface includes the complete UTC day containing each suffix
+boundary, so exact Rust validation and drift gates remain authoritative for that screening
+approximation.
 Gross close-fill loss/profit ratios are supported both in aggregate and separately for long and
 short. `pnl_ratio_long_short` and its `long_short_profit_ratio` alias use each side's signed
 realized PnL and Rust's neutral `0.5` result when combined signed PnL is zero. Directional kernels
 retain the four gross side sums, while one-sided and dual-side multi-coin dispatches preserve the
 same side partition before reduction.
-Full-run fill activity is supported for single-coin and one-sided multi-coin topologies: analysis
+Full-run fill activity is supported for single-coin and multi-coin topologies: analysis
 duration; total, entry, close, long, and short counts; their daily rates; entry-to-close ratio; and
 combined or side-specific per-configured-position-slot daily rates. Active fill-day count and ratio
 use distinct 24-hour buckets anchored to the analyzed equity start, matching Rust rather than the
@@ -375,13 +354,12 @@ UTC buckets used by the compact daily equity surface. Active-symbol count and to
 use per-coin counters emitted only when either metric is requested. Metal classifies every actual
 proxy fill by role, position side, and—when needed—coin, then Python applies each candidate's
 configured active slot counts and Rust's mean-of-enabled-sides contract. All rates use the same
-first-to-last analyzed-equity timestamp span as Rust. Dual-side multi-coin runs fail closed because
-independent directional summaries cannot reconstruct the intraday shared-liquidation cutoff.
+first-to-last analyzed-equity timestamp span as Rust. Fused dual-side kernels retain the shared
+intraday-liquidation cutoff.
 Peak strategy-equity recovery is available in both hours and days; peak realized-PnL recovery
 tracks the strict cumulative net-PnL peak at every proxy fill and includes the final analyzed tail.
-These metrics support single-coin and one-sided multi-coin topologies. Dual-side multi-coin runs
-fail closed because independent directional dispatches cannot reconstruct the shared fill sequence
-or liquidation cutoff.
+These metrics support single-coin and multi-coin topologies. Fused dual-side kernels retain the
+shared fill sequence and liquidation cutoff.
 Initial-entry allocation uses the candidate's effective position count and the same
 first-coin strategy/allowance override precedence as exact Rust. Fill-gap longest, mean, median,
 p95, and p99 metrics are also supported. Metal coalesces multiple fills in the same candle and

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -1041,9 +1041,7 @@ def _validate_scope_config(
             coin_count=coin_count,
             enabled_side_count=len(enabled_sides),
             shared_account_controller=(
-                coin_count > 1
-                and len(enabled_sides) == 2
-                and strategy_kind == "ema_anchor"
+                coin_count > 1 and len(enabled_sides) == 2
             ),
         )
         for side in hsl_enabled_sides:
@@ -1073,11 +1071,19 @@ def _validate_scope_config(
 
 
 def _validate_dual_multicoin_metrics(
-    needed_metrics, *, coin_count: int, enabled_sides
+    needed_metrics,
+    *,
+    coin_count: int,
+    enabled_sides,
+    shared_account_controller: bool = False,
 ) -> None:
     """Reject metrics which cannot be reconstructed from directional summaries."""
 
-    if int(coin_count) <= 1 or len(set(enabled_sides)) != 2:
+    if (
+        int(coin_count) <= 1
+        or len(set(enabled_sides)) != 2
+        or shared_account_controller
+    ):
         return
     unsupported = sorted(
         set(needed_metrics)
@@ -3247,15 +3253,16 @@ def run_backend(
         enabled_sides=enabled_sides,
         hard_stop_metrics=HARD_STOP_PROXY_METRICS,
         shared_account_controller=(
-            max_coin_count > 1
-            and len(enabled_sides) == 2
-            and strategy_kind == "ema_anchor"
+            max_coin_count > 1 and len(enabled_sides) == 2
         ),
     )
     _validate_dual_multicoin_metrics(
         needed_metrics,
         coin_count=max_coin_count,
         enabled_sides=enabled_sides,
+        shared_account_controller=(
+            max_coin_count > 1 and len(enabled_sides) == 2
+        ),
     )
 
     if suite_enabled:

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -1007,9 +1007,9 @@ def _validate_scope_config(
                         )
             if repair_paths:
                 raise ValueError(
-                    "GPU dual-side multicoin exposure/unstuck repair requires a strategy-"
-                    "complete shared-balance portfolio kernel; the current GPU topology "
-                    f"does not model {sorted(repair_paths)}"
+                    "GPU dual-side multicoin exposure/unstuck repair requires shared "
+                    "global cross-side selection and loss-budget reservation semantics; the "
+                    f"current fused proxy does not model {sorted(repair_paths)}"
                 )
         if not bool(config.get("backtest", {}).get("dynamic_wel_by_tradability")):
             raise ValueError(
@@ -1275,15 +1275,13 @@ def _validate_gpu_coin_overrides(
         signal_mode = str(
             config.get("live", {}).get("hsl_signal_mode", "unified")
         ).strip().lower()
-        dual_fused_ema = (
-            strategy_kind == "ema_anchor" and len(enabled_sides) == 2
-        )
+        fused_dual_side = len(enabled_sides) == 2
         if signal_mode != "coin" or not (
-            len(enabled_sides) == 1 or dual_fused_ema
+            len(enabled_sides) == 1 or fused_dual_side
         ):
             raise ValueError(
                 "GPU per-coin HSL overrides require live.hsl_signal_mode=coin "
-                "and either one enabled side or fused dual-side EMA Anchor; "
+                "and either one enabled side or a fused dual-side proxy; "
                 "unsupported paths: "
                 f"{sorted(hsl_override_paths)}"
             )

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -1562,7 +1562,7 @@ class MpsMulticoinProxy:
         if len(enabled_sides) not in (1, 2):
             raise ValueError(
                 "MPS multicoin proxy requires one or two enabled sides"
-        )
+            )
         self.sides = enabled_sides
         self.dispatch_batch_size = _mps_dispatch_batch_size(
             self.batch_size,
@@ -2000,9 +2000,7 @@ class MpsMulticoinProxy:
                     if key.startswith(f"{side}_")
                 }
             )
-            rows.append(
-                [float(merged[key]) for key in param_keys]
-            )
+            rows.append([float(merged[key]) for key in param_keys])
         return np.asarray(rows, dtype=np.float64)
 
     def evaluate(self, candidates: list[dict]) -> list[dict]:

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -224,10 +224,12 @@ def _directional_coin_hsl_lookback_bars(
     )
 
 
-def _require_multicoin_metric_topology(sides, needed_metrics) -> None:
+def _require_multicoin_metric_topology(
+    sides, needed_metrics, *, shared_account_controller: bool = False
+) -> None:
     unsupported = (
         set(needed_metrics) & _DUAL_SIDE_MULTICOIN_INTRADAY_CUTOFF_METRICS
-        if len(sides) == 2
+        if len(sides) == 2 and not shared_account_controller
         else set()
     )
     if unsupported:
@@ -236,6 +238,21 @@ def _require_multicoin_metric_topology(sides, needed_metrics) -> None:
             "shared-liquidation cutoff required by these metrics: "
             + ", ".join(sorted(unsupported))
         )
+
+
+def _multicoin_exposure_eligible_coins(
+    per_side_coin_overrides: dict[str, np.ndarray],
+    sides,
+    wallet_exposure_column: int,
+) -> np.ndarray:
+    coin_count = next(iter(per_side_coin_overrides.values())).shape[0]
+    eligible = np.zeros(coin_count, dtype=bool)
+    for side in sides:
+        fixed_coin_wels = per_side_coin_overrides[side][
+            :, wallet_exposure_column
+        ]
+        eligible |= ~np.isfinite(fixed_coin_wels) | (fixed_coin_wels != 0.0)
+    return eligible
 
 
 def _candidate_wallet_exposure_limit_outputs(
@@ -1501,6 +1518,7 @@ class MpsMulticoinProxy:
         from optimization.gpu.mps_kernel import (
             MpsEmaAnchorMulticoinFusedRunner,
             MpsEmaAnchorMulticoinRunner,
+            MpsTrailingMartingaleMulticoinFusedRunner,
             MpsTrailingMartingaleMulticoinRunner,
         )
 
@@ -1544,7 +1562,7 @@ class MpsMulticoinProxy:
         if len(enabled_sides) not in (1, 2):
             raise ValueError(
                 "MPS multicoin proxy requires one or two enabled sides"
-            )
+        )
         self.sides = enabled_sides
         self.dispatch_batch_size = _mps_dispatch_batch_size(
             self.batch_size,
@@ -1559,10 +1577,17 @@ class MpsMulticoinProxy:
             n_coins=coin_count,
             n_sides=len(enabled_sides),
         )
-        self.shared_account_fused = (
-            self.strategy_kind == "ema_anchor" and len(self.sides) == 2
+        self.shared_account_fused = len(self.sides) == 2
+        self.shared_account_proxy_mode = (
+            "shared-account-fused-tm-v1"
+            if self.strategy_kind == "trailing_martingale"
+            else "shared-account-fused-ema-v1"
         )
-        _require_multicoin_metric_topology(self.sides, self.needed_metrics)
+        _require_multicoin_metric_topology(
+            self.sides,
+            self.needed_metrics,
+            shared_account_controller=self.shared_account_fused,
+        )
         if len(enabled_sides) == 2 and not bool(
             config.get("live", {}).get("hedge_mode")
         ):
@@ -1689,8 +1714,8 @@ class MpsMulticoinProxy:
                 for item in payload.bot_params_list
             ):
                 raise ValueError(
-                    "MPS dual-side multicoin auto-unstuck requires a shared-balance "
-                    "portfolio kernel"
+                    "MPS dual-side multicoin auto-unstuck is not yet supported; "
+                    "the fused proxy requires one global cross-side selector"
                 )
             if self.strategy_kind == "trailing_martingale":
                 first_strategy = flatten_trailing_martingale_params(
@@ -1808,14 +1833,14 @@ class MpsMulticoinProxy:
                     for side in self.sides
                 },
                 "proxy_mode": (
-                    "shared-account-fused-ema-v1"
+                    self.shared_account_proxy_mode
                     if self.shared_account_fused
                     else "independent-side-hedge-v1"
                 ),
             }
             if hsl_enabled_sides:
                 self.coin_override_contract["hsl_proxy_mode"] = (
-                    "shared-account-fused-ema-v1"
+                    self.shared_account_proxy_mode
                     if self.shared_account_fused
                     else "independent-pside-v1"
                 )
@@ -1872,20 +1897,19 @@ class MpsMulticoinProxy:
             trade_start_idx=min(run.trade_start_idx for run in runs),
         )
         if self.needed_metrics & _ACCOUNT_EQUITY_RECOVERY_METRICS:
-            side = self.sides[0]
             wallet_exposure_column = (
                 11
                 if self.strategy_kind == "ema_anchor"
                 else len(TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS) + 1
             )
-            fixed_coin_wels = per_side_coin_overrides[side][
-                :, wallet_exposure_column
-            ]
+            exposure_eligible_coins = _multicoin_exposure_eligible_coins(
+                per_side_coin_overrides,
+                self.sides,
+                wallet_exposure_column,
+            )
             _require_no_internal_invalid_account_recovery_candles(
                 values,
-                exposure_eligible_coins=(
-                    ~np.isfinite(fixed_coin_wels) | (fixed_coin_wels != 0.0)
-                ),
+                exposure_eligible_coins=exposure_eligible_coins,
                 first_valid_indices=backtest_params["first_valid_indices"],
                 last_valid_indices=backtest_params["last_valid_indices"],
                 tracking_start_indices=[run.trade_start_idx for run in runs],
@@ -1910,7 +1934,12 @@ class MpsMulticoinProxy:
             ),
         }
         if self.shared_account_fused:
-            self.fused_runner = MpsEmaAnchorMulticoinFusedRunner(
+            fused_runner_cls = (
+                MpsTrailingMartingaleMulticoinFusedRunner
+                if self.strategy_kind == "trailing_martingale"
+                else MpsEmaAnchorMulticoinFusedRunner
+            )
+            self.fused_runner = fused_runner_cls(
                 self.run,
                 self.data,
                 long_coin_overrides=per_side_coin_overrides["long"],

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1590,9 +1590,7 @@ def test_gpu_hsl_accepts_dual_side_multicoin_fused_ema_modes(signal_mode):
 
 
 @pytest.mark.parametrize("signal_mode", ["coin", "unified"])
-def test_gpu_hsl_keeps_dual_side_multicoin_tm_joint_modes_fail_closed(
-    signal_mode,
-):
+def test_gpu_hsl_accepts_dual_side_multicoin_tm_joint_modes(signal_mode):
     config = _directional_tm_config(long_enabled=True, short_enabled=True)
     coins = ["BTC", "ETH", "XRP"]
     config["live"]["approved_coins"] = {"long": coins, "short": coins}
@@ -1602,8 +1600,7 @@ def test_gpu_hsl_keeps_dual_side_multicoin_tm_joint_modes_fail_closed(
         config["bot"][side]["risk"]["n_positions"] = 3
         config["bot"][side]["hsl"]["enabled"] = True
 
-    with pytest.raises(ValueError, match="supports only pside"):
-        _validate_scope(config, _MulticoinEvaluator())
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
 def test_gpu_hsl_metrics_reject_only_dual_multicoin_tier_overlap():
@@ -2522,6 +2519,12 @@ def test_gpu_dual_multicoin_rejects_unreconstructable_metrics(metric):
             coin_count=3,
             enabled_sides={"long", "short"},
         )
+    _validate_dual_multicoin_metrics(
+        {metric, "adg_strategy_eq"},
+        coin_count=3,
+        enabled_sides={"long", "short"},
+        shared_account_controller=True,
+    )
 
 
 def test_gpu_dual_multicoin_metric_gate_does_not_narrow_single_side():

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1812,7 +1812,7 @@ def test_gpu_dual_multicoin_rejects_tm_exposure_repair(repair_key):
         risk["n_positions"] = 2
         risk[repair_key] = True
 
-    with pytest.raises(ValueError, match="shared-balance portfolio kernel"):
+    with pytest.raises(ValueError, match="global cross-side selection"):
         _validate_scope(config, _MulticoinEvaluator())
 
 
@@ -1834,7 +1834,7 @@ def test_gpu_dual_multicoin_rejects_tm_coin_override_exposure_repair():
         }
     }
 
-    with pytest.raises(ValueError, match="shared-balance portfolio kernel"):
+    with pytest.raises(ValueError, match="global cross-side selection"):
         _validate_scope(config, _MulticoinEvaluator())
 
 
@@ -1923,7 +1923,7 @@ def test_gpu_dual_multicoin_rejects_ema_total_exposure_repair():
         risk["n_positions"] = 2
         risk["total_exposure_enforcer_enabled"] = True
 
-    with pytest.raises(ValueError, match="shared-balance portfolio kernel"):
+    with pytest.raises(ValueError, match="global cross-side selection"):
         _validate_scope(config, _MulticoinEvaluator())
 
 
@@ -2223,8 +2223,17 @@ def test_gpu_multicoin_coin_hsl_overrides_fail_closed_outside_one_side_coin_mode
         )
 
 
-def test_gpu_multicoin_coin_hsl_overrides_accept_fused_dual_side_ema():
-    config = _directional_ema_config(long_enabled=True, short_enabled=True)
+@pytest.mark.parametrize(
+    ("strategy_kind", "config_factory"),
+    [
+        ("ema_anchor", _directional_ema_config),
+        ("trailing_martingale", _directional_tm_config),
+    ],
+)
+def test_gpu_multicoin_coin_hsl_overrides_accept_fused_dual_side(
+    strategy_kind, config_factory
+):
+    config = config_factory(long_enabled=True, short_enabled=True)
     config["live"]["hsl_signal_mode"] = "coin"
     config["coin_overrides"] = {
         "ETH": {
@@ -2237,26 +2246,10 @@ def test_gpu_multicoin_coin_hsl_overrides_accept_fused_dual_side_ema():
 
     _validate_gpu_coin_overrides(
         config,
-        strategy_kind="ema_anchor",
+        strategy_kind=strategy_kind,
         enabled_sides=["long", "short"],
         coin_count=3,
     )
-
-
-def test_gpu_multicoin_coin_hsl_overrides_keep_dual_side_tm_fail_closed():
-    config = _directional_tm_config(long_enabled=True, short_enabled=True)
-    config["live"]["hsl_signal_mode"] = "coin"
-    config["coin_overrides"] = {
-        "ETH": {"bot": {"long": {"hsl": {"enabled": True}}}}
-    }
-
-    with pytest.raises(ValueError, match="fused dual-side EMA Anchor"):
-        _validate_gpu_coin_overrides(
-            config,
-            strategy_kind="trailing_martingale",
-            enabled_sides=["long", "short"],
-            coin_count=3,
-        )
 
 
 def test_gpu_coin_overrides_reject_single_coin_scope():

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -4769,6 +4769,100 @@ def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
     assert torch.equal(runner_output["coin_fill_counts"], coin_fill_counts)
     assert runner.last_profile["kernel_seconds"] >= 0.0
 
+    metric_rows = []
+    red_threshold_index = TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(
+        "hsl_red_threshold"
+    )
+    restart_policy_index = TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(
+        "hsl_restart_policy"
+    )
+    for signal_mode in range(3):
+        row = side_row(signal_mode) + side_row(signal_mode)
+        for side_offset in (
+            0,
+            len(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS),
+        ):
+            row[side_offset + red_threshold_index] = 0.001
+            row[side_offset + restart_policy_index] = 2.0
+        metric_rows.append(row)
+
+    proxy = MpsMulticoinEmaProxy.__new__(MpsMulticoinEmaProxy)
+    proxy.batch_size = 3
+    proxy._torch = torch
+    proxy.profile_enabled = False
+    proxy.metrics_data = {"ts0": data["ts0"], "n": data["n"]}
+    proxy.run = runs[0]
+    proxy.sides = ["long", "short"]
+    proxy.needed_metrics = {
+        "hard_stop_panic_close_loss_drawdown_pct_mean",
+        "hard_stop_time_in_red_pct",
+        "hard_stop_triggers",
+        "hard_stop_triggers_long",
+        "hard_stop_triggers_short",
+        "fills_count",
+    }
+    proxy.param_keys = TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+    width = len(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS)
+    proxy.base_params = {
+        "long": dict(
+            zip(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, metric_rows[0][:width])
+        ),
+        "short": dict(
+            zip(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, metric_rows[0][width:])
+        ),
+    }
+    proxy.fused_runner = runner
+    proxy.runners = {}
+    candidates = [
+        {
+            **{
+                f"long_{key}": row[index]
+                for index, key in enumerate(
+                    TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+                )
+            },
+            **{
+                f"short_{key}": row[width + index]
+                for index, key in enumerate(
+                    TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+                )
+            },
+        }
+        for row in metric_rows
+    ]
+    np.testing.assert_allclose(
+        proxy._parameter_matrix(candidates, "long"),
+        np.asarray(metric_rows, dtype=np.float64)[:, :width],
+    )
+    np.testing.assert_allclose(
+        proxy._parameter_matrix(candidates, "short"),
+        np.asarray(metric_rows, dtype=np.float64)[:, width:],
+    )
+    seen_hsl_triggers = {}
+
+    def reduce_service_output(output, *args, **kwargs):
+        seen_hsl_triggers["long"] = output["hsl_triggers_long"].clone()
+        seen_hsl_triggers["short"] = output["hsl_triggers_short"].clone()
+        seen_hsl_triggers["samples"] = output["hsl_tier_samples_total"].clone()
+        return compute_objectives(output, *args, **kwargs)
+
+    proxy._compute_objectives = reduce_service_output
+    service_results = proxy.evaluate(candidates)
+    assert (seen_hsl_triggers["samples"] > 0.0).all()
+    assert (seen_hsl_triggers["long"] >= 0.0).all()
+    assert (seen_hsl_triggers["short"] >= 0.0).all()
+    assert all(item["fills_count"] > 0.0 for item in service_results)
+    assert all(
+        item["hard_stop_triggers"]
+        == item["hard_stop_triggers_long"] + item["hard_stop_triggers_short"]
+        for item in service_results
+    )
+    assert all(item["hard_stop_time_in_red_pct"] >= 0.0 for item in service_results)
+    assert all(
+        item["hard_stop_panic_close_loss_drawdown_pct_mean"] >= 0.0
+        for item in service_results
+    )
+
     with pytest.raises(ValueError, match="118 columns"):
         runner.run(np.asarray([side_row(0)], dtype=np.float64))
     with pytest.raises(ValueError, match="short override matrix shaped"):

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -36,6 +36,7 @@ from optimization.gpu.service import (
     _directional_gross_pnl_outputs,
     _hsl_params,
     _mps_dispatch_batch_size,
+    _multicoin_exposure_eligible_coins,
     _position_exposure_enforcer_params,
     _prepared_single_coin_side_enabled,
     _require_multicoin_metric_topology,
@@ -262,6 +263,26 @@ def test_dual_side_multicoin_intraday_cutoff_metrics_fail_closed(metric):
 
     _require_multicoin_metric_topology(["long"], {metric})
     _require_multicoin_metric_topology(["long", "short"], {"adg_strategy_eq"})
+    _require_multicoin_metric_topology(
+        ["long", "short"],
+        {metric},
+        shared_account_controller=True,
+    )
+
+
+def test_multicoin_exposure_eligibility_unions_fused_sides():
+    long = np.zeros((3, 2), dtype=np.float32)
+    short = np.zeros((3, 2), dtype=np.float32)
+    short[1, 1] = 0.5
+    short[2, 1] = np.nan
+
+    eligible = _multicoin_exposure_eligible_coins(
+        {"long": long, "short": short},
+        ["long", "short"],
+        1,
+    )
+
+    assert eligible.tolist() == [False, True, True]
 
 
 @pytest.mark.parametrize("side", ["long", "short"])
@@ -638,7 +659,19 @@ def test_multicoin_proxy_preserves_directional_hsl_outputs_for_reduction():
     assert proxy.evaluate([{}]) == [{"hard_stop_panic_close_loss_sum": 37.5}]
 
 
-def test_multicoin_ema_proxy_routes_dual_side_batch_through_fused_runner():
+@pytest.mark.parametrize(
+    ("param_keys", "candidate_key"),
+    [
+        (EMA_ANCHOR_MULTICOIN_PARAM_KEYS, "offset"),
+        (
+            TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS,
+            "entry_initial_qty_pct",
+        ),
+    ],
+)
+def test_multicoin_proxy_routes_dual_side_batch_through_fused_runner(
+    param_keys, candidate_key
+):
     torch = pytest.importorskip("torch")
     proxy = MpsMulticoinEmaProxy.__new__(MpsMulticoinEmaProxy)
     proxy.batch_size = 2
@@ -648,11 +681,11 @@ def test_multicoin_ema_proxy_routes_dual_side_batch_through_fused_runner():
     proxy.run = SimpleNamespace()
     proxy.sides = ["long", "short"]
     proxy.needed_metrics = {"hard_stop_triggers"}
-    proxy.param_keys = EMA_ANCHOR_MULTICOIN_PARAM_KEYS
+    proxy.param_keys = param_keys
     proxy.base_params = {
         side: {
             key: float(index + (100 if side == "short" else 0))
-            for index, key in enumerate(EMA_ANCHOR_MULTICOIN_PARAM_KEYS)
+            for index, key in enumerate(param_keys)
         }
         for side in ("long", "short")
     }
@@ -687,8 +720,8 @@ def test_multicoin_ema_proxy_routes_dual_side_batch_through_fused_runner():
 
     proxy._compute_objectives = reduce
     candidates = [
-        {"long_offset": 0.25, "short_offset": 0.5},
-        {"long_offset": 0.75, "short_offset": 1.0},
+        {f"long_{candidate_key}": 0.25, f"short_{candidate_key}": 0.5},
+        {f"long_{candidate_key}": 0.75, f"short_{candidate_key}": 1.0},
     ]
 
     assert proxy.evaluate(candidates) == [
@@ -697,16 +730,35 @@ def test_multicoin_ema_proxy_routes_dual_side_batch_through_fused_runner():
     ]
     assert seen["params"].shape == (
         2,
-        len(EMA_ANCHOR_MULTICOIN_PARAM_KEYS) * 2,
+        len(param_keys) * 2,
     )
-    offset_index = EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("offset")
-    side_width = len(EMA_ANCHOR_MULTICOIN_PARAM_KEYS)
-    assert seen["params"][:, offset_index].tolist() == [0.25, 0.75]
-    assert seen["params"][:, side_width + offset_index].tolist() == [0.5, 1.0]
+    parameter_index = param_keys.index(candidate_key)
+    side_width = len(param_keys)
+    assert seen["params"][:, parameter_index].tolist() == [0.25, 0.75]
+    assert seen["params"][:, side_width + parameter_index].tolist() == [0.5, 1.0]
     assert seen["kwargs"] == {"profile": False}
 
 
-def test_multicoin_ema_proxy_constructs_fused_shared_account_runner(monkeypatch):
+@pytest.mark.parametrize(
+    ("strategy_kind", "runner_name", "override_cols", "proxy_mode"),
+    [
+        (
+            "ema_anchor",
+            "MpsEmaAnchorMulticoinFusedRunner",
+            29,
+            "shared-account-fused-ema-v1",
+        ),
+        (
+            "trailing_martingale",
+            "MpsTrailingMartingaleMulticoinFusedRunner",
+            44,
+            "shared-account-fused-tm-v1",
+        ),
+    ],
+)
+def test_multicoin_proxy_constructs_fused_shared_account_runner(
+    monkeypatch, strategy_kind, runner_name, override_cols, proxy_mode
+):
     torch = pytest.importorskip("torch")
 
     import optimization.gpu.mps_kernel as mps_kernel
@@ -719,7 +771,7 @@ def test_multicoin_ema_proxy_constructs_fused_shared_account_runner(monkeypatch)
     config = get_template_config()
     config["live"].update(
         {
-            "strategy_kind": "ema_anchor",
+            "strategy_kind": strategy_kind,
             "approved_coins": {
                 "long": ["BTC", "ETH"],
                 "short": ["BTC", "ETH"],
@@ -781,7 +833,7 @@ def test_multicoin_ema_proxy_constructs_fused_shared_account_runner(monkeypatch)
         ],
         strategy_params_list=[
             {
-                side: dict(config["bot"][side]["strategy"]["ema_anchor"])
+                side: dict(config["bot"][side]["strategy"][strategy_kind])
                 for side in ("long", "short")
             }
             for _ in range(2)
@@ -833,9 +885,7 @@ def test_multicoin_ema_proxy_constructs_fused_shared_account_runner(monkeypatch)
         def __init__(self, run, data, **kwargs):
             constructed.update({"run": run, "data": data, "kwargs": kwargs})
 
-    monkeypatch.setattr(
-        mps_kernel, "MpsEmaAnchorMulticoinFusedRunner", FakeFusedRunner
-    )
+    monkeypatch.setattr(mps_kernel, runner_name, FakeFusedRunner)
     values = np.ones((4, 2, 4), dtype=np.float64)
     timestamps = np.arange(4, dtype=np.int64) * 60_000
 
@@ -852,14 +902,16 @@ def test_multicoin_ema_proxy_constructs_fused_shared_account_runner(monkeypatch)
 
     assert isinstance(proxy.fused_runner, FakeFusedRunner)
     assert proxy.runners == {}
-    assert proxy.coin_override_contract["proxy_mode"] == (
-        "shared-account-fused-ema-v1"
+    assert proxy.coin_override_contract["proxy_mode"] == proxy_mode
+    assert proxy.coin_override_contract["hsl_proxy_mode"] == proxy_mode
+    assert constructed["kwargs"]["long_coin_overrides"].shape == (
+        2,
+        override_cols,
     )
-    assert proxy.coin_override_contract["hsl_proxy_mode"] == (
-        "shared-account-fused-ema-v1"
+    assert constructed["kwargs"]["short_coin_overrides"].shape == (
+        2,
+        override_cols,
     )
-    assert constructed["kwargs"]["long_coin_overrides"].shape == (2, 29)
-    assert constructed["kwargs"]["short_coin_overrides"].shape == (2, 29)
 
 
 def test_gpu_proxy_requires_complete_valid_tail():


### PR DESCRIPTION
## Summary

- route dual-side multi-coin Trailing Martingale GPU candidates through the fused shared-account MPS runner
- enable unified, pside, and coin HSL topology, including per-coin HSL overrides and shared event/tier metrics
- admit fill, recovery, exposure, duration, and PnL metrics produced directly by the fused controller instead of applying stale independent-directional guards
- preserve independent long/short parameter and coin-override matrices while combining them into the fused dispatch
- validate account-recovery candle coverage across the union of exposure-eligible long and short coins
- record a distinct `shared-account-fused-tm-v1` proxy contract and document the updated topology

Exact Rust remains authoritative. Dual-side multi-coin auto-unstuck and exposure repair remain explicitly fail closed until global cross-side selection and loss-budget reservation are modeled. Existing one-sided runners and all CPU bot, backtest, and optimizer paths are unchanged.

## Review finding addressed

- admit dual-side Trailing Martingale per-coin HSL overrides through the fused coin-mode validator, with a regression shared by both fused strategies

## Validation

- rebuilt and source-fingerprint-verified the exact Python/Rust extension
- complete physical Apple M3/MPS module: 288 passed
- focused physical fused-TM kernel, service reduction, and all-HSL-mode smoke
- complete optimizer Python suite
- complete GPU backend and service modules
- AI documentation and generated-registry checks (0 errors; existing size warnings only)
- Python syntax checks and `git diff --check`