### PR TITLE
fix(gpu): mirror finite HSL PnL windows on MPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Fixed finite `live.pnls_max_lookback_days` handling for single-coin `coin`-mode HSL on Apple
+  MPS. EMA Anchor and Trailing Martingale screening now expire realized-PnL fill events with the
+  same rolling-window rule as exact Rust instead of retaining an all-history peak; bounded GPU
+  scratch overflow fails the affected candidate closed, and exact Rust remains authoritative.
+
 - Added fused shared-account dual-side multi-coin EMA Anchor screening to Apple MPS optimization.
   Unified, pside, and coin HSL now run inside one portfolio kernel, including per-coin HSL
   overrides and shared event/tier scoring metrics. Exact Rust remains authoritative, dual-side

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -148,12 +148,14 @@ The supported slice is intentionally narrow:
   suppression, RED latching, panic flattening, two-sample flat confirmation,
   positive-cooldown restart, zero-cooldown indefinite halt, cumulative no-restart peak tracking,
   effective coin-slot scaling, and terminal no-restart policy. For a finite
-  `live.pnls_max_lookback_days`, Metal deliberately retains its candidate-local all-history
-  realized-PnL and strategy-equity peaks. This is a conservative envelope over Rust's rolling
-  peak: it may trigger HSL early after an old peak ages out, but cannot suppress a drawdown for
-  that reason. The selected history must have no internal invalid candles between its first and
-  last valid samples. Thresholds in the float32-unrepresentable interval immediately below `1.0`
-  fail closed. Exact validation and drift gates remain authoritative. The non-loss HSL lifecycle
+  `live.pnls_max_lookback_days`, the single-coin `coin`-mode directional kernels expire
+  candidate-local realized-PnL fill events with the same rolling-window rule as exact Rust.
+  Other HSL topologies deliberately retain all-history realized-PnL and strategy-equity peaks as
+  a conservative envelope over Rust's rolling peak: they may trigger HSL early after an old peak
+  ages out, but cannot suppress a drawdown for that reason. The selected history must have no
+  internal invalid candles between its first and last valid samples. Thresholds in the
+  float32-unrepresentable interval immediately below `1.0` fail closed. Exact validation and
+  drift gates remain authoritative. The non-loss HSL lifecycle
   metrics (trigger/restart counts and
   yearly rates, time in each warning tier, halt and flatten durations, trigger drawdown, and
   post-restart retriggers) and panic-loss metrics (loss sum/max, per-episode loss

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -162,6 +162,13 @@ mod tests {
         assert!(source.contains("if (!hsl_update_valid)"));
         assert!(source.contains("alive = false"));
         assert!(source.contains("liq_day = di"));
+        assert!(source.contains("HslRollingPnlWindow long_rolling_pnl"));
+        assert!(source.contains("HslRollingPnlWindow short_rolling_pnl"));
+        assert!(source.contains("prepare_coin_hsl_rolling_signal("));
+        assert!(source.contains("reset_hsl_rolling_pnl_window("));
+        assert!(source.contains("const int pnl_lookback_bars"));
+        assert!(source.contains("device float2* rolling_pnl_values"));
+        assert!(source.contains("device int2* rolling_pnl_indices"));
     }
 
     #[test]

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -164,6 +164,10 @@ mod tests {
         assert!(source.contains("liq_day = di"));
         assert!(source.contains("HslRollingPnlWindow long_rolling_pnl"));
         assert!(source.contains("HslRollingPnlWindow short_rolling_pnl"));
+        assert!(source.contains("const bool long_coin_hsl_rolling"));
+        assert!(source.contains("const bool short_coin_hsl_rolling"));
+        assert!(source.contains("long_coin_hsl_rolling && long_rolling_pnl.overflowed"));
+        assert!(source.contains("short_coin_hsl_rolling && short_rolling_pnl.overflowed"));
         assert!(source.contains("prepare_coin_hsl_rolling_signal("));
         assert!(source.contains("reset_hsl_rolling_pnl_window("));
         assert!(source.contains("const int pnl_lookback_bars"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -828,6 +828,10 @@ inline void passivbot_single_coin_impl(
     EmaSide short_side = load_side(params, po + SIDE_PARAMS, seed_close);
     HslState long_hsl = load_hsl(params, po, 23);
     HslState short_hsl = load_hsl(params, po + SIDE_PARAMS, 23);
+    const bool long_coin_hsl_rolling = long_hsl.enabled
+        && long_hsl.signal_mode == HSL_SIGNAL_COIN && pnl_lookback_bars > 0;
+    const bool short_coin_hsl_rolling = short_hsl.enabled
+        && short_hsl.signal_mode == HSL_SIGNAL_COIN && pnl_lookback_bars > 0;
     HslRollingPnlWindow long_rolling_pnl = init_hsl_rolling_pnl_window();
     HslRollingPnlWindow short_rolling_pnl = init_hsl_rolling_pnl_window();
     const int long_rolling_base = int(b) * 2 * rolling_capacity;
@@ -996,7 +1000,7 @@ inline void passivbot_single_coin_impl(
             record_hsl_rolling_pnl(
                 long_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
                 long_rolling_base, rolling_capacity, int(kf),
-                pnl_lookback_bars, net_pnl
+                pnl_lookback_bars, long_coin_hsl_rolling, net_pnl
             );
             float new_psize = fmax(round_step(long_side.psize - adj, qty_step), 0.0f);
             bool went_flat = new_psize <= 0.0f;
@@ -1039,7 +1043,7 @@ inline void passivbot_single_coin_impl(
             record_hsl_rolling_pnl(
                 long_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
                 long_rolling_base, rolling_capacity, int(kf),
-                pnl_lookback_bars, -fee
+                pnl_lookback_bars, long_coin_hsl_rolling, -fee
             );
             bool was_flat = long_side.psize <= 0.0f;
             float new_psize = round_step(long_side.psize + eq, qty_step);
@@ -1113,7 +1117,7 @@ inline void passivbot_single_coin_impl(
             record_hsl_rolling_pnl(
                 short_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
                 short_rolling_base, rolling_capacity, int(kf),
-                pnl_lookback_bars, net_pnl
+                pnl_lookback_bars, short_coin_hsl_rolling, net_pnl
             );
             float new_psize = fmax(round_step(short_side.psize - adj, qty_step), 0.0f);
             bool went_flat = new_psize <= 0.0f;
@@ -1156,7 +1160,7 @@ inline void passivbot_single_coin_impl(
             record_hsl_rolling_pnl(
                 short_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
                 short_rolling_base, rolling_capacity, int(kf),
-                pnl_lookback_bars, -fee
+                pnl_lookback_bars, short_coin_hsl_rolling, -fee
             );
             bool was_flat = short_side.psize <= 0.0f;
             float new_psize = round_step(short_side.psize + eq, qty_step);
@@ -1448,7 +1452,8 @@ inline void passivbot_single_coin_impl(
         float short_unreal = short_side.psize > 0.0f
             ? short_side.psize * c_mult * (short_side.pprice - close) : 0.0f;
         float equity = balance + long_unreal + short_unreal;
-        if (long_rolling_pnl.overflowed || short_rolling_pnl.overflowed) {
+        if ((long_coin_hsl_rolling && long_rolling_pnl.overflowed)
+            || (short_coin_hsl_rolling && short_rolling_pnl.overflowed)) {
             balance = 0.0f;
             alive = false;
             liq_day = di;

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -59,6 +59,8 @@ inline float float32_floor_nonnegative(float value) {
     return as_type<float>(as_type<uint>(value) - 1u);
 }
 
+// PASSIVBOT_HSL_COMMON
+
 inline void record_realized_net(
     float net_pnl,
     thread float& realized_pnl_cumsum_last,
@@ -168,8 +170,6 @@ struct ReducerVariant {
     int secondary_ticks;
     float secondary_qty;
 };
-
-// PASSIVBOT_HSL_COMMON
 
 inline EmaSide load_side(constant float* params, int po, float seed_close) {
     EmaSide side;
@@ -787,6 +787,8 @@ inline void passivbot_single_coin_impl(
     device float* daily,
     device float* scalars,
     device int* gap_hist,
+    device float2* rolling_pnl_values,
+    device int2* rolling_pnl_indices,
     uint b
 ) {
     const int B = sizes[0];
@@ -815,6 +817,8 @@ inline void passivbot_single_coin_impl(
     const float market_order_slippage_pct = fmax(settings[16], 0.0f);
     const bool long_hsl_panic_market = settings[17] > 0.5f;
     const bool short_hsl_panic_market = settings[18] > 0.5f;
+    const int pnl_lookback_bars = max(sizes[6], 0);
+    const int rolling_capacity = sizes[5];
     const float log_bin_scale = 127.0f / log(4000001.0f);
 
     const int po = int(b) * P;
@@ -824,6 +828,10 @@ inline void passivbot_single_coin_impl(
     EmaSide short_side = load_side(params, po + SIDE_PARAMS, seed_close);
     HslState long_hsl = load_hsl(params, po, 23);
     HslState short_hsl = load_hsl(params, po + SIDE_PARAMS, 23);
+    HslRollingPnlWindow long_rolling_pnl = init_hsl_rolling_pnl_window();
+    HslRollingPnlWindow short_rolling_pnl = init_hsl_rolling_pnl_window();
+    const int long_rolling_base = int(b) * 2 * rolling_capacity;
+    const int short_rolling_base = long_rolling_base + rolling_capacity;
     const bool hsl_modes_valid = long_hsl.signal_mode == short_hsl.signal_mode;
 
     float balance = hsl_modes_valid ? starting_balance : 0.0f;
@@ -985,6 +993,11 @@ inline void passivbot_single_coin_impl(
                 pnl_recovery_max_min, kf,
                 false, true
             );
+            record_hsl_rolling_pnl(
+                long_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
+                long_rolling_base, rolling_capacity, int(kf),
+                pnl_lookback_bars, net_pnl
+            );
             float new_psize = fmax(round_step(long_side.psize - adj, qty_step), 0.0f);
             bool went_flat = new_psize <= 0.0f;
             long_side.psize = new_psize;
@@ -1022,6 +1035,11 @@ inline void passivbot_single_coin_impl(
                 pnl_recovery_peak, pnl_recovery_peak_k,
                 pnl_recovery_max_min, kf,
                 true, true
+            );
+            record_hsl_rolling_pnl(
+                long_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
+                long_rolling_base, rolling_capacity, int(kf),
+                pnl_lookback_bars, -fee
             );
             bool was_flat = long_side.psize <= 0.0f;
             float new_psize = round_step(long_side.psize + eq, qty_step);
@@ -1092,6 +1110,11 @@ inline void passivbot_single_coin_impl(
                 pnl_recovery_max_min, kf,
                 false, false
             );
+            record_hsl_rolling_pnl(
+                short_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
+                short_rolling_base, rolling_capacity, int(kf),
+                pnl_lookback_bars, net_pnl
+            );
             float new_psize = fmax(round_step(short_side.psize - adj, qty_step), 0.0f);
             bool went_flat = new_psize <= 0.0f;
             short_side.psize = new_psize;
@@ -1129,6 +1152,11 @@ inline void passivbot_single_coin_impl(
                 pnl_recovery_peak, pnl_recovery_peak_k,
                 pnl_recovery_max_min, kf,
                 true, false
+            );
+            record_hsl_rolling_pnl(
+                short_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
+                short_rolling_base, rolling_capacity, int(kf),
+                pnl_lookback_bars, -fee
             );
             bool was_flat = short_side.psize <= 0.0f;
             float new_psize = round_step(short_side.psize + eq, qty_step);
@@ -1420,6 +1448,11 @@ inline void passivbot_single_coin_impl(
         float short_unreal = short_side.psize > 0.0f
             ? short_side.psize * c_mult * (short_side.pprice - close) : 0.0f;
         float equity = balance + long_unreal + short_unreal;
+        if (long_rolling_pnl.overflowed || short_rolling_pnl.overflowed) {
+            balance = 0.0f;
+            alive = false;
+            liq_day = di;
+        }
         if (gen && valid && alive && balance > 0.0f && equity > liq_floor) {
             bool long_blocking_orders = long_hsl_mode != 3 && (
                 long_side.entry_qty > 0.0f || long_side.close_qty > 0.0f
@@ -1429,6 +1462,20 @@ inline void passivbot_single_coin_impl(
                 short_side.entry_qty > 0.0f || short_side.close_qty > 0.0f
                     || short_side.secondary_close_qty > 0.0f
             );
+            prepare_coin_hsl_rolling_signal(
+                long_hsl, long_rolling_pnl,
+                rolling_pnl_values, rolling_pnl_indices,
+                long_rolling_base, rolling_capacity, int(kf),
+                pnl_lookback_bars, realized_pnl_cumsum_long
+            );
+            prepare_coin_hsl_rolling_signal(
+                short_hsl, short_rolling_pnl,
+                rolling_pnl_values, rolling_pnl_indices,
+                short_rolling_base, rolling_capacity, int(kf),
+                pnl_lookback_bars, realized_pnl_cumsum_short
+            );
+            float long_triggers_before = long_hsl.triggers;
+            float short_triggers_before = short_hsl.triggers;
             bool hsl_update_valid = update_dual_side_hsl(
                 long_hsl, short_hsl, balance, starting_balance,
                 realized_pnl_cumsum_last,
@@ -1438,6 +1485,12 @@ inline void passivbot_single_coin_impl(
                 long_blocking_orders, short_blocking_orders,
                 kf, interval_ms
             );
+            if (long_hsl.triggers > long_triggers_before) {
+                reset_hsl_rolling_pnl_window(long_rolling_pnl);
+            }
+            if (short_hsl.triggers > short_triggers_before) {
+                reset_hsl_rolling_pnl_window(short_rolling_pnl);
+            }
             if (!hsl_update_valid) {
                 balance = 0.0f;
                 alive = false;
@@ -1668,9 +1721,12 @@ kernel void passivbot_ema_anchor(
     device float* daily,
     device float* scalars,
     device int* gap_hist,
+    device float2* rolling_pnl_values,
+    device int2* rolling_pnl_indices,
     uint b [[thread_position_in_grid]]
 ) {
     passivbot_single_coin_impl(
-        bars, flags, params, settings, sizes, daily, scalars, gap_hist, b
+        bars, flags, params, settings, sizes, daily, scalars, gap_hist,
+        rolling_pnl_values, rolling_pnl_indices, b
     );
 }

--- a/passivbot-rust/src/gpu/mps_hsl_common.metal
+++ b/passivbot-rust/src/gpu/mps_hsl_common.metal
@@ -77,9 +77,10 @@ inline void record_hsl_rolling_pnl(
     int capacity,
     int k,
     int lookback_bars,
+    bool active,
     float pnl
 ) {
-    if (lookback_bars <= 0 || window.overflowed) return;
+    if (!active || lookback_bars <= 0 || window.overflowed) return;
     window.absolute_cumulative += pnl;
     prune_hsl_rolling_pnl_window(
         window, values, indices, base, capacity, k, lookback_bars

--- a/passivbot-rust/src/gpu/mps_hsl_common.metal
+++ b/passivbot-rust/src/gpu/mps_hsl_common.metal
@@ -7,6 +7,132 @@ constant int HSL_SIGNAL_UNIFIED = 0;
 constant int HSL_SIGNAL_PSIDE = 1;
 constant int HSL_SIGNAL_COIN = 2;
 
+// Finite coin-HSL PnL windows are candidate-local.  Their fill events live in
+// device buffers owned by the directional runner; this small thread-local
+// structure keeps only ring/deque cursors and the absolute realized cumsum.
+// The two packed buffers use float2(base_before, cumulative_after) and
+// int2(event_k, monotonic_peak_slot) respectively.
+struct HslRollingPnlWindow {
+    int event_head;
+    int event_count;
+    int peak_head;
+    int peak_count;
+    float absolute_cumulative;
+    bool overflowed;
+};
+
+struct HslRollingPnlSignal {
+    float peak;
+    float current;
+};
+
+inline HslRollingPnlWindow init_hsl_rolling_pnl_window() {
+    HslRollingPnlWindow window;
+    window.event_head = 0;
+    window.event_count = 0;
+    window.peak_head = 0;
+    window.peak_count = 0;
+    window.absolute_cumulative = 0.0f;
+    window.overflowed = false;
+    return window;
+}
+
+inline void reset_hsl_rolling_pnl_window(
+    thread HslRollingPnlWindow& window
+) {
+    window.event_head = 0;
+    window.event_count = 0;
+    window.peak_head = 0;
+    window.peak_count = 0;
+}
+
+inline void prune_hsl_rolling_pnl_window(
+    thread HslRollingPnlWindow& window,
+    device float2* values,
+    device int2* indices,
+    int base,
+    int capacity,
+    int k,
+    int lookback_bars
+) {
+    if (lookback_bars <= 0 || window.overflowed) return;
+    while (window.event_count > 0) {
+        int slot = window.event_head;
+        if (k - indices[base + slot].x <= lookback_bars) break;
+        if (window.peak_count > 0
+            && indices[base + window.peak_head].y == slot) {
+            window.peak_head = (window.peak_head + 1) % capacity;
+            window.peak_count -= 1;
+        }
+        window.event_head = (window.event_head + 1) % capacity;
+        window.event_count -= 1;
+    }
+}
+
+inline void record_hsl_rolling_pnl(
+    thread HslRollingPnlWindow& window,
+    device float2* values,
+    device int2* indices,
+    int base,
+    int capacity,
+    int k,
+    int lookback_bars,
+    float pnl
+) {
+    if (lookback_bars <= 0 || window.overflowed) return;
+    window.absolute_cumulative += pnl;
+    prune_hsl_rolling_pnl_window(
+        window, values, indices, base, capacity, k, lookback_bars
+    );
+    if (window.event_count >= capacity || window.peak_count >= capacity) {
+        window.overflowed = true;
+        return;
+    }
+    int slot = (window.event_head + window.event_count) % capacity;
+    values[base + slot] = float2(
+        window.absolute_cumulative - pnl, window.absolute_cumulative
+    );
+    indices[base + slot].x = k;
+    window.event_count += 1;
+
+    while (window.peak_count > 0) {
+        int back = (window.peak_head + window.peak_count - 1) % capacity;
+        int peak_slot = indices[base + back].y;
+        if (values[base + peak_slot].y > window.absolute_cumulative) break;
+        window.peak_count -= 1;
+    }
+    int peak_tail = (window.peak_head + window.peak_count) % capacity;
+    indices[base + peak_tail].y = slot;
+    window.peak_count += 1;
+}
+
+inline HslRollingPnlSignal effective_hsl_rolling_pnl(
+    thread HslRollingPnlWindow& window,
+    device float2* values,
+    device int2* indices,
+    int base,
+    int capacity,
+    int k,
+    int lookback_bars
+) {
+    HslRollingPnlSignal signal;
+    signal.peak = 0.0f;
+    signal.current = 0.0f;
+    if (lookback_bars <= 0 || window.overflowed) return signal;
+    prune_hsl_rolling_pnl_window(
+        window, values, indices, base, capacity, k, lookback_bars
+    );
+    if (window.event_count == 0) return signal;
+    float base_cumulative = values[base + window.event_head].x;
+    int peak_slot = indices[base + window.peak_head].y;
+    signal.current = window.absolute_cumulative - base_cumulative;
+    signal.peak = fmax(
+        values[base + peak_slot].y - base_cumulative,
+        fmax(signal.current, 0.0f)
+    );
+    return signal;
+}
+
 struct HslState {
     bool enabled;
     float red_threshold;
@@ -61,6 +187,26 @@ struct HslState {
     float panic_loss_drawdown_max;
     float panic_loss_drawdown_count;
 };
+
+inline void prepare_coin_hsl_rolling_signal(
+    thread HslState& h,
+    thread HslRollingPnlWindow& window,
+    device float2* values,
+    device int2* indices,
+    int base,
+    int capacity,
+    int k,
+    int lookback_bars,
+    float realized_pnl
+) {
+    if (!h.enabled || h.signal_mode != HSL_SIGNAL_COIN
+        || lookback_bars <= 0 || window.overflowed) return;
+    HslRollingPnlSignal signal = effective_hsl_rolling_pnl(
+        window, values, indices, base, capacity, k, lookback_bars
+    );
+    h.coin_realized_baseline = realized_pnl - signal.current;
+    h.coin_realized_peak = signal.peak;
+}
 
 struct HslSignal {
     float drawdown_raw;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -119,6 +119,8 @@ inline bool realized_loss_proxy_allows_reducer(
     return -net_pnl + margin <= remaining_loss_budget;
 }
 
+// PASSIVBOT_HSL_COMMON
+
 inline void record_realized_net(
     float net_pnl,
     thread float& realized_pnl_cumsum_last,
@@ -222,8 +224,6 @@ struct CloseGroup {
     float price;
     float qty;
 };
-
-// PASSIVBOT_HSL_COMMON
 
 inline float directional_equity_at_close(
     float balance,
@@ -1073,6 +1073,8 @@ inline void passivbot_single_coin_impl(
     device float* daily,
     device float* scalars,
     device int* gap_hist,
+    device float2* rolling_pnl_values,
+    device int2* rolling_pnl_indices,
     uint b
 ) {
     const int B = sizes[0];
@@ -1101,6 +1103,8 @@ inline void passivbot_single_coin_impl(
     const float market_order_slippage_pct = fmax(settings[16], 0.0f);
     const bool long_hsl_panic_market = settings[17] > 0.5f;
     const bool short_hsl_panic_market = settings[18] > 0.5f;
+    const int pnl_lookback_bars = max(sizes[6], 0);
+    const int rolling_capacity = sizes[5];
     const bool loss_gate_enabled = max_realized_loss_pct < 1.0f;
     const float log_bin_scale = 127.0f / log(4000001.0f);
 
@@ -1111,6 +1115,10 @@ inline void passivbot_single_coin_impl(
     TmSide short_side = load_side(params, po + SIDE_PARAMS, seed_close);
     HslState long_hsl = load_hsl(params, po, 40);
     HslState short_hsl = load_hsl(params, po + SIDE_PARAMS, 40);
+    HslRollingPnlWindow long_rolling_pnl = init_hsl_rolling_pnl_window();
+    HslRollingPnlWindow short_rolling_pnl = init_hsl_rolling_pnl_window();
+    const int long_rolling_base = int(b) * 2 * rolling_capacity;
+    const int short_rolling_base = long_rolling_base + rolling_capacity;
     const bool hsl_modes_valid = long_hsl.signal_mode == short_hsl.signal_mode;
 
     float balance = hsl_modes_valid ? starting_balance : 0.0f;
@@ -1448,6 +1456,12 @@ inline void passivbot_single_coin_impl(
                             false,
                             true
                         );
+                        record_hsl_rolling_pnl(
+                            long_rolling_pnl,
+                            rolling_pnl_values, rolling_pnl_indices,
+                            long_rolling_base, rolling_capacity, int(kf),
+                            pnl_lookback_bars, pnl - fee
+                        );
                         long_side.psize = fmax(
                             round_step(
                                 long_side.psize - reducer_qty, qty_step
@@ -1496,6 +1510,11 @@ inline void passivbot_single_coin_impl(
                     kf,
                     false,
                     true
+                );
+                record_hsl_rolling_pnl(
+                    long_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
+                    long_rolling_base, rolling_capacity, int(kf),
+                    pnl_lookback_bars, pnl - fee
                 );
                 float new_psize = fmax(
                     round_step(long_side.psize - adj, qty_step), 0.0f
@@ -1557,6 +1576,12 @@ inline void passivbot_single_coin_impl(
                         kf,
                         false,
                         true
+                    );
+                    record_hsl_rolling_pnl(
+                        long_rolling_pnl,
+                        rolling_pnl_values, rolling_pnl_indices,
+                        long_rolling_base, rolling_capacity, int(kf),
+                        pnl_lookback_bars, pnl - fee
                     );
                     long_side.psize = fmax(
                         round_step(long_side.psize - adj, qty_step), 0.0f
@@ -1642,6 +1667,11 @@ inline void passivbot_single_coin_impl(
                     false,
                     true
                 );
+                record_hsl_rolling_pnl(
+                    long_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
+                    long_rolling_base, rolling_capacity, int(kf),
+                    pnl_lookback_bars, pnl - fee
+                );
                 long_side.psize = fmax(
                     round_step(long_side.psize - adj, qty_step), 0.0f
                 );
@@ -1704,6 +1734,11 @@ inline void passivbot_single_coin_impl(
                     kf,
                     true,
                     true
+                );
+                record_hsl_rolling_pnl(
+                    long_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
+                    long_rolling_base, rolling_capacity, int(kf),
+                    pnl_lookback_bars, -fee
                 );
                 bool was_flat = long_side.psize <= 0.0f;
                 float new_psize = round_step(long_side.psize + eq, qty_step);
@@ -1964,6 +1999,12 @@ inline void passivbot_single_coin_impl(
                             false,
                             false
                         );
+                        record_hsl_rolling_pnl(
+                            short_rolling_pnl,
+                            rolling_pnl_values, rolling_pnl_indices,
+                            short_rolling_base, rolling_capacity, int(kf),
+                            pnl_lookback_bars, pnl - fee
+                        );
                         short_side.psize = fmax(
                             round_step(
                                 short_side.psize - reducer_qty, qty_step
@@ -2012,6 +2053,12 @@ inline void passivbot_single_coin_impl(
                     kf,
                     false,
                     false
+                );
+                record_hsl_rolling_pnl(
+                    short_rolling_pnl,
+                    rolling_pnl_values, rolling_pnl_indices,
+                    short_rolling_base, rolling_capacity, int(kf),
+                    pnl_lookback_bars, pnl - fee
                 );
                 float new_psize = fmax(
                     round_step(short_side.psize - adj, qty_step), 0.0f
@@ -2073,6 +2120,12 @@ inline void passivbot_single_coin_impl(
                         kf,
                         false,
                         false
+                    );
+                    record_hsl_rolling_pnl(
+                        short_rolling_pnl,
+                        rolling_pnl_values, rolling_pnl_indices,
+                        short_rolling_base, rolling_capacity, int(kf),
+                        pnl_lookback_bars, pnl - fee
                     );
                     short_side.psize = fmax(
                         round_step(short_side.psize - adj, qty_step), 0.0f
@@ -2158,6 +2211,12 @@ inline void passivbot_single_coin_impl(
                     false,
                     false
                 );
+                record_hsl_rolling_pnl(
+                    short_rolling_pnl,
+                    rolling_pnl_values, rolling_pnl_indices,
+                    short_rolling_base, rolling_capacity, int(kf),
+                    pnl_lookback_bars, pnl - fee
+                );
                 short_side.psize = fmax(
                     round_step(short_side.psize - adj, qty_step), 0.0f
                 );
@@ -2220,6 +2279,12 @@ inline void passivbot_single_coin_impl(
                     kf,
                     true,
                     false
+                );
+                record_hsl_rolling_pnl(
+                    short_rolling_pnl,
+                    rolling_pnl_values, rolling_pnl_indices,
+                    short_rolling_base, rolling_capacity, int(kf),
+                    pnl_lookback_bars, -fee
                 );
                 bool was_flat = short_side.psize <= 0.0f;
                 float new_psize = round_step(short_side.psize + eq, qty_step);
@@ -2507,6 +2572,11 @@ inline void passivbot_single_coin_impl(
         float short_unreal = short_side.psize > 0.0f
             ? short_side.psize * c_mult * (short_side.pprice - close) : 0.0f;
         float equity = balance + long_unreal + short_unreal;
+        if (long_rolling_pnl.overflowed || short_rolling_pnl.overflowed) {
+            balance = 0.0f;
+            alive = false;
+            liq_day = di;
+        }
         if (gen && valid && alive && balance > 0.0f && equity > liq_floor) {
             bool long_blocking_orders = long_hsl_mode != 3 && (
                 long_side.entry_qty > 0.0f || long_side.close_qty > 0.0f
@@ -2516,6 +2586,20 @@ inline void passivbot_single_coin_impl(
                 short_side.entry_qty > 0.0f || short_side.close_qty > 0.0f
                     || short_side.secondary_close_qty > 0.0f
             );
+            prepare_coin_hsl_rolling_signal(
+                long_hsl, long_rolling_pnl,
+                rolling_pnl_values, rolling_pnl_indices,
+                long_rolling_base, rolling_capacity, int(kf),
+                pnl_lookback_bars, realized_pnl_cumsum_long
+            );
+            prepare_coin_hsl_rolling_signal(
+                short_hsl, short_rolling_pnl,
+                rolling_pnl_values, rolling_pnl_indices,
+                short_rolling_base, rolling_capacity, int(kf),
+                pnl_lookback_bars, realized_pnl_cumsum_short
+            );
+            float long_triggers_before = long_hsl.triggers;
+            float short_triggers_before = short_hsl.triggers;
             bool hsl_update_valid = update_dual_side_hsl(
                 long_hsl, short_hsl, balance, starting_balance,
                 realized_pnl_cumsum_last,
@@ -2525,6 +2609,12 @@ inline void passivbot_single_coin_impl(
                 long_blocking_orders, short_blocking_orders,
                 kf, interval_ms
             );
+            if (long_hsl.triggers > long_triggers_before) {
+                reset_hsl_rolling_pnl_window(long_rolling_pnl);
+            }
+            if (short_hsl.triggers > short_triggers_before) {
+                reset_hsl_rolling_pnl_window(short_rolling_pnl);
+            }
             if (!hsl_update_valid) {
                 balance = 0.0f;
                 alive = false;
@@ -2755,9 +2845,12 @@ kernel void passivbot_trailing_martingale(
     device float* daily,
     device float* scalars,
     device int* gap_hist,
+    device float2* rolling_pnl_values,
+    device int2* rolling_pnl_indices,
     uint b [[thread_position_in_grid]]
 ) {
     passivbot_single_coin_impl(
-        bars, flags, params, settings, sizes, daily, scalars, gap_hist, b
+        bars, flags, params, settings, sizes, daily, scalars, gap_hist,
+        rolling_pnl_values, rolling_pnl_indices, b
     );
 }

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -1115,6 +1115,10 @@ inline void passivbot_single_coin_impl(
     TmSide short_side = load_side(params, po + SIDE_PARAMS, seed_close);
     HslState long_hsl = load_hsl(params, po, 40);
     HslState short_hsl = load_hsl(params, po + SIDE_PARAMS, 40);
+    const bool long_coin_hsl_rolling = long_hsl.enabled
+        && long_hsl.signal_mode == HSL_SIGNAL_COIN && pnl_lookback_bars > 0;
+    const bool short_coin_hsl_rolling = short_hsl.enabled
+        && short_hsl.signal_mode == HSL_SIGNAL_COIN && pnl_lookback_bars > 0;
     HslRollingPnlWindow long_rolling_pnl = init_hsl_rolling_pnl_window();
     HslRollingPnlWindow short_rolling_pnl = init_hsl_rolling_pnl_window();
     const int long_rolling_base = int(b) * 2 * rolling_capacity;
@@ -1460,7 +1464,7 @@ inline void passivbot_single_coin_impl(
                             long_rolling_pnl,
                             rolling_pnl_values, rolling_pnl_indices,
                             long_rolling_base, rolling_capacity, int(kf),
-                            pnl_lookback_bars, pnl - fee
+                            pnl_lookback_bars, long_coin_hsl_rolling, pnl - fee
                         );
                         long_side.psize = fmax(
                             round_step(
@@ -1514,7 +1518,7 @@ inline void passivbot_single_coin_impl(
                 record_hsl_rolling_pnl(
                     long_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
                     long_rolling_base, rolling_capacity, int(kf),
-                    pnl_lookback_bars, pnl - fee
+                    pnl_lookback_bars, long_coin_hsl_rolling, pnl - fee
                 );
                 float new_psize = fmax(
                     round_step(long_side.psize - adj, qty_step), 0.0f
@@ -1581,7 +1585,7 @@ inline void passivbot_single_coin_impl(
                         long_rolling_pnl,
                         rolling_pnl_values, rolling_pnl_indices,
                         long_rolling_base, rolling_capacity, int(kf),
-                        pnl_lookback_bars, pnl - fee
+                        pnl_lookback_bars, long_coin_hsl_rolling, pnl - fee
                     );
                     long_side.psize = fmax(
                         round_step(long_side.psize - adj, qty_step), 0.0f
@@ -1670,7 +1674,7 @@ inline void passivbot_single_coin_impl(
                 record_hsl_rolling_pnl(
                     long_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
                     long_rolling_base, rolling_capacity, int(kf),
-                    pnl_lookback_bars, pnl - fee
+                    pnl_lookback_bars, long_coin_hsl_rolling, pnl - fee
                 );
                 long_side.psize = fmax(
                     round_step(long_side.psize - adj, qty_step), 0.0f
@@ -1738,7 +1742,7 @@ inline void passivbot_single_coin_impl(
                 record_hsl_rolling_pnl(
                     long_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
                     long_rolling_base, rolling_capacity, int(kf),
-                    pnl_lookback_bars, -fee
+                    pnl_lookback_bars, long_coin_hsl_rolling, -fee
                 );
                 bool was_flat = long_side.psize <= 0.0f;
                 float new_psize = round_step(long_side.psize + eq, qty_step);
@@ -2003,7 +2007,7 @@ inline void passivbot_single_coin_impl(
                             short_rolling_pnl,
                             rolling_pnl_values, rolling_pnl_indices,
                             short_rolling_base, rolling_capacity, int(kf),
-                            pnl_lookback_bars, pnl - fee
+                            pnl_lookback_bars, short_coin_hsl_rolling, pnl - fee
                         );
                         short_side.psize = fmax(
                             round_step(
@@ -2058,7 +2062,7 @@ inline void passivbot_single_coin_impl(
                     short_rolling_pnl,
                     rolling_pnl_values, rolling_pnl_indices,
                     short_rolling_base, rolling_capacity, int(kf),
-                    pnl_lookback_bars, pnl - fee
+                    pnl_lookback_bars, short_coin_hsl_rolling, pnl - fee
                 );
                 float new_psize = fmax(
                     round_step(short_side.psize - adj, qty_step), 0.0f
@@ -2125,7 +2129,7 @@ inline void passivbot_single_coin_impl(
                         short_rolling_pnl,
                         rolling_pnl_values, rolling_pnl_indices,
                         short_rolling_base, rolling_capacity, int(kf),
-                        pnl_lookback_bars, pnl - fee
+                        pnl_lookback_bars, short_coin_hsl_rolling, pnl - fee
                     );
                     short_side.psize = fmax(
                         round_step(short_side.psize - adj, qty_step), 0.0f
@@ -2215,7 +2219,7 @@ inline void passivbot_single_coin_impl(
                     short_rolling_pnl,
                     rolling_pnl_values, rolling_pnl_indices,
                     short_rolling_base, rolling_capacity, int(kf),
-                    pnl_lookback_bars, pnl - fee
+                    pnl_lookback_bars, short_coin_hsl_rolling, pnl - fee
                 );
                 short_side.psize = fmax(
                     round_step(short_side.psize - adj, qty_step), 0.0f
@@ -2284,7 +2288,7 @@ inline void passivbot_single_coin_impl(
                     short_rolling_pnl,
                     rolling_pnl_values, rolling_pnl_indices,
                     short_rolling_base, rolling_capacity, int(kf),
-                    pnl_lookback_bars, -fee
+                    pnl_lookback_bars, short_coin_hsl_rolling, -fee
                 );
                 bool was_flat = short_side.psize <= 0.0f;
                 float new_psize = round_step(short_side.psize + eq, qty_step);
@@ -2572,7 +2576,8 @@ inline void passivbot_single_coin_impl(
         float short_unreal = short_side.psize > 0.0f
             ? short_side.psize * c_mult * (short_side.pprice - close) : 0.0f;
         float equity = balance + long_unreal + short_unreal;
-        if (long_rolling_pnl.overflowed || short_rolling_pnl.overflowed) {
+        if ((long_coin_hsl_rolling && long_rolling_pnl.overflowed)
+            || (short_coin_hsl_rolling && short_rolling_pnl.overflowed)) {
             balance = 0.0f;
             alive = false;
             liq_day = di;

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -999,10 +999,9 @@ def _validate_scope_config(
         side for side in enabled_sides if _gpu_hsl_side_enabled(config, side)
     ]
     if hsl_enabled_sides:
-        # The proxy deliberately keeps an all-history candidate-local peak for
-        # finite windows. That peak is never below Rust's rolling-window peak,
-        # so HSL may trigger early but cannot miss a drawdown solely because an
-        # older peak aged out. Exact validation remains authoritative.
+        # Directional single-coin coin mode mirrors Rust's finite fill-event
+        # PnL window. Other HSL topologies retain the conservative all-history
+        # screening envelope; exact Rust validation remains authoritative.
         parse_pnls_max_lookback_days(
             config.get("live", {}).get("pnls_max_lookback_days", 30.0),
             field_name="live.pnls_max_lookback_days",

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -23,6 +23,7 @@ MPS_SCALAR_COLS = 32
 MPS_MULTICOIN_SCALAR_COLS = 57
 MPS_DIRECTIONAL_SCALAR_COLS = 62
 MPS_MULTICOIN_FUSED_SCALAR_COLS = 62
+MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY = 2048
 
 
 def _encode_max_realized_loss_pct(value: float) -> float:
@@ -285,6 +286,7 @@ class MpsEmaAnchorRunner:
         market_order_slippage_pct: float = 0.0,
         hsl_panic_market_long: bool = False,
         hsl_panic_market_short: bool = False,
+        pnl_lookback_bars: int = 0,
     ):
         self.market = market
         self.run_config = run
@@ -303,6 +305,7 @@ class MpsEmaAnchorRunner:
         )
         taker_fee = market.maker_fee if taker_fee is None else float(taker_fee)
         market_order_slippage_pct = float(market_order_slippage_pct)
+        pnl_lookback_bars = int(pnl_lookback_bars)
         if not np.isfinite(taker_fee):
             raise ValueError("taker_fee must be finite")
         if (
@@ -312,6 +315,14 @@ class MpsEmaAnchorRunner:
             raise ValueError(
                 "market_order_slippage_pct must be finite and non-negative"
             )
+        if pnl_lookback_bars < 0:
+            raise ValueError("pnl_lookback_bars must be non-negative")
+        self.pnl_lookback_bars = pnl_lookback_bars
+        self.rolling_capacity = (
+            MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY
+            if pnl_lookback_bars > 0
+            else 1
+        )
         self.n = int(data["n"])
         self.n_days = int(data["n_days"])
         self.bars = (
@@ -375,6 +386,7 @@ class MpsEmaAnchorRunner:
             device="mps",
         )
         self._buffers: dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = {}
+        self._rolling_buffers: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
         self._sizes: dict[tuple[int, int], torch.Tensor] = {}
         self.last_profile: dict[str, float] = {}
 
@@ -417,6 +429,19 @@ class MpsEmaAnchorRunner:
         self._buffers[batch_size][0][:, :, 1].fill_(float("inf"))
         return self._buffers[batch_size]
 
+    def _hsl_rolling_buffers(self, batch_size: int):
+        if batch_size not in self._rolling_buffers:
+            # The kernel overwrites every active ring/deque slot.  Avoid
+            # zeroing this large scratch allocation between generations.
+            shape = (batch_size, 2, self.rolling_capacity, 2)
+            self._rolling_buffers = {
+                batch_size: (
+                    torch.empty(shape, dtype=torch.float32, device="mps"),
+                    torch.empty(shape, dtype=torch.int32, device="mps"),
+                )
+            }
+        return self._rolling_buffers[batch_size]
+
     def run(self, params: np.ndarray, *, profile: bool = False) -> dict:
         started = time.perf_counter()
         matrix = self._pack_params(params)
@@ -424,6 +449,9 @@ class MpsEmaAnchorRunner:
         params_mps = torch.as_tensor(matrix, device="mps")
         batch_size = int(matrix.shape[0])
         daily, scalars, gaps = self._output_buffers(batch_size)
+        rolling_pnl_values, rolling_pnl_indices = self._hsl_rolling_buffers(
+            batch_size
+        )
         sizes_key = (batch_size, int(matrix.shape[1]))
         if sizes_key not in self._sizes:
             self._sizes[sizes_key] = torch.tensor(
@@ -433,6 +461,8 @@ class MpsEmaAnchorRunner:
                     self.n_days,
                     matrix.shape[1],
                     self.run_config.first_valid_idx,
+                    self.rolling_capacity,
+                    self.pnl_lookback_bars,
                 ],
                 dtype=torch.int32,
                 device="mps",
@@ -454,6 +484,8 @@ class MpsEmaAnchorRunner:
             daily,
             scalars,
             gaps,
+            rolling_pnl_values,
+            rolling_pnl_indices,
             threads=(batch_size, 1, 1),
         )
         if profile:
@@ -1085,6 +1117,9 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
         params_mps = torch.as_tensor(matrix, device="mps")
         batch_size = int(matrix.shape[0])
         daily, scalars, gaps = self._output_buffers(batch_size)
+        rolling_pnl_values, rolling_pnl_indices = self._hsl_rolling_buffers(
+            batch_size
+        )
         sizes_key = (batch_size, int(matrix.shape[1]))
         if sizes_key not in self._sizes:
             self._sizes[sizes_key] = torch.tensor(
@@ -1094,6 +1129,8 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
                     self.n_days,
                     matrix.shape[1],
                     self.run_config.first_valid_idx,
+                    self.rolling_capacity,
+                    self.pnl_lookback_bars,
                 ],
                 dtype=torch.int32,
                 device="mps",
@@ -1115,6 +1152,8 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             daily,
             scalars,
             gaps,
+            rolling_pnl_values,
+            rolling_pnl_indices,
             threads=(batch_size, 1, 1),
         )
         if profile:

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -147,6 +147,26 @@ _ACCOUNT_EQUITY_RECOVERY_METRICS = {
 }
 
 
+def _directional_coin_hsl_lookback_bars(
+    backtest_params: dict,
+    *,
+    signal_mode: str,
+    hsl_enabled: bool,
+) -> int:
+    """Translate Rust's finite coin-HSL PnL window into candle bars."""
+
+    if not hsl_enabled or str(signal_mode).strip().lower() != "coin":
+        return 0
+    lookback_days = float(backtest_params.get("pnls_max_lookback_days", -1.0))
+    if lookback_days < 0.0:
+        return 0
+    interval_minutes = int(backtest_params["candle_interval_minutes"])
+    return max(
+        1,
+        int(np.ceil(lookback_days * 24.0 * 60.0 / interval_minutes)),
+    )
+
+
 def _require_multicoin_metric_topology(sides, needed_metrics) -> None:
     unsupported = (
         set(needed_metrics) & _DUAL_SIDE_MULTICOIN_INTRADAY_CUTOFF_METRICS
@@ -980,6 +1000,11 @@ class MpsSingleCoinProxy:
             taker_fee=float(market_params["taker_fee"]),
         )
         interval_ms = int(backtest_params["candle_interval_minutes"]) * 60_000
+        pnl_lookback_bars = _directional_coin_hsl_lookback_bars(
+            backtest_params,
+            signal_mode=signal_mode,
+            hsl_enabled=bool(hsl_enabled_sides),
+        )
         self.run = ProxyRun(
             starting_balance=float(backtest_params["starting_balance"]),
             warmup_bars=max(1, int(backtest_params.get("global_warmup_bars", 0) or 1)),
@@ -1047,6 +1072,7 @@ class MpsSingleCoinProxy:
             ),
             hsl_panic_market_long=hsl_panic_market["long"],
             hsl_panic_market_short=hsl_panic_market["short"],
+            pnl_lookback_bars=pnl_lookback_bars,
         )
 
     def _parameter_matrix(self, candidates: list[dict]) -> np.ndarray:

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -131,13 +131,13 @@ kernel void passivbot_hsl_rolling_pnl_probe(
     const int capacity = 4;
     const int lookback_bars = 2;
     record_hsl_rolling_pnl(
-        window, values, indices, 0, capacity, 0, lookback_bars, 50.0f
+        window, values, indices, 0, capacity, 0, lookback_bars, true, 50.0f
     );
     HslRollingPnlSignal first = effective_hsl_rolling_pnl(
         window, values, indices, 0, capacity, 0, lookback_bars
     );
     record_hsl_rolling_pnl(
-        window, values, indices, 0, capacity, 1, lookback_bars, -80.0f
+        window, values, indices, 0, capacity, 1, lookback_bars, true, -80.0f
     );
     HslRollingPnlSignal second = effective_hsl_rolling_pnl(
         window, values, indices, 0, capacity, 1, lookback_bars
@@ -146,7 +146,7 @@ kernel void passivbot_hsl_rolling_pnl_probe(
         window, values, indices, 0, capacity, 3, lookback_bars
     );
     record_hsl_rolling_pnl(
-        window, values, indices, 0, capacity, 4, lookback_bars, 55.0f
+        window, values, indices, 0, capacity, 4, lookback_bars, true, 55.0f
     );
     HslRollingPnlSignal final_signal = effective_hsl_rolling_pnl(
         window, values, indices, 0, capacity, 4, lookback_bars
@@ -167,22 +167,34 @@ kernel void passivbot_hsl_rolling_pnl_probe(
     output[8] = reset_signal.peak;
     output[9] = reset_signal.current;
 
+    HslRollingPnlWindow inactive = init_hsl_rolling_pnl_window();
+    record_hsl_rolling_pnl(
+        inactive, values, indices, 4, 2, 0, 10, false, 1.0f
+    );
+    record_hsl_rolling_pnl(
+        inactive, values, indices, 4, 2, 1, 10, false, 1.0f
+    );
+    record_hsl_rolling_pnl(
+        inactive, values, indices, 4, 2, 2, 10, false, 1.0f
+    );
+    output[10] = inactive.overflowed ? 1.0f : 0.0f;
+
     HslRollingPnlWindow overflow = init_hsl_rolling_pnl_window();
     record_hsl_rolling_pnl(
-        overflow, values, indices, 4, 2, 0, 10, 1.0f
+        overflow, values, indices, 4, 2, 0, 10, true, 1.0f
     );
     record_hsl_rolling_pnl(
-        overflow, values, indices, 4, 2, 1, 10, 1.0f
+        overflow, values, indices, 4, 2, 1, 10, true, 1.0f
     );
     record_hsl_rolling_pnl(
-        overflow, values, indices, 4, 2, 2, 10, 1.0f
+        overflow, values, indices, 4, 2, 2, 10, true, 1.0f
     );
-    output[10] = overflow.overflowed ? 1.0f : 0.0f;
+    output[11] = overflow.overflowed ? 1.0f : 0.0f;
 }
 """
     values = torch.empty((6, 2), dtype=torch.float32, device="mps")
     indices = torch.empty((6, 2), dtype=torch.int32, device="mps")
-    output = torch.zeros(11, dtype=torch.float32, device="mps")
+    output = torch.zeros(12, dtype=torch.float32, device="mps")
     library = torch.mps.compile_shader(
         passivbot_rust.mps_ema_anchor_source_py() + probe_kernel
     )
@@ -201,6 +213,7 @@ kernel void passivbot_hsl_rolling_pnl_probe(
         -80.0,
         55.0,
         55.0,
+        0.0,
         0.0,
         0.0,
         1.0,

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -116,6 +116,100 @@ def test_decode_multicoin_fused_outputs_maps_directional_reductions():
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+def test_mps_coin_hsl_rolling_pnl_window_expires_and_resets_fill_events():
+    import passivbot_rust
+
+    probe_kernel = r"""
+kernel void passivbot_hsl_rolling_pnl_probe(
+    device float2* values,
+    device int2* indices,
+    device float* output,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    HslRollingPnlWindow window = init_hsl_rolling_pnl_window();
+    const int capacity = 4;
+    const int lookback_bars = 2;
+    record_hsl_rolling_pnl(
+        window, values, indices, 0, capacity, 0, lookback_bars, 50.0f
+    );
+    HslRollingPnlSignal first = effective_hsl_rolling_pnl(
+        window, values, indices, 0, capacity, 0, lookback_bars
+    );
+    record_hsl_rolling_pnl(
+        window, values, indices, 0, capacity, 1, lookback_bars, -80.0f
+    );
+    HslRollingPnlSignal second = effective_hsl_rolling_pnl(
+        window, values, indices, 0, capacity, 1, lookback_bars
+    );
+    HslRollingPnlSignal expired = effective_hsl_rolling_pnl(
+        window, values, indices, 0, capacity, 3, lookback_bars
+    );
+    record_hsl_rolling_pnl(
+        window, values, indices, 0, capacity, 4, lookback_bars, 55.0f
+    );
+    HslRollingPnlSignal final_signal = effective_hsl_rolling_pnl(
+        window, values, indices, 0, capacity, 4, lookback_bars
+    );
+    reset_hsl_rolling_pnl_window(window);
+    HslRollingPnlSignal reset_signal = effective_hsl_rolling_pnl(
+        window, values, indices, 0, capacity, 4, lookback_bars
+    );
+
+    output[0] = first.peak;
+    output[1] = first.current;
+    output[2] = second.peak;
+    output[3] = second.current;
+    output[4] = expired.peak;
+    output[5] = expired.current;
+    output[6] = final_signal.peak;
+    output[7] = final_signal.current;
+    output[8] = reset_signal.peak;
+    output[9] = reset_signal.current;
+
+    HslRollingPnlWindow overflow = init_hsl_rolling_pnl_window();
+    record_hsl_rolling_pnl(
+        overflow, values, indices, 4, 2, 0, 10, 1.0f
+    );
+    record_hsl_rolling_pnl(
+        overflow, values, indices, 4, 2, 1, 10, 1.0f
+    );
+    record_hsl_rolling_pnl(
+        overflow, values, indices, 4, 2, 2, 10, 1.0f
+    );
+    output[10] = overflow.overflowed ? 1.0f : 0.0f;
+}
+"""
+    values = torch.empty((6, 2), dtype=torch.float32, device="mps")
+    indices = torch.empty((6, 2), dtype=torch.int32, device="mps")
+    output = torch.zeros(11, dtype=torch.float32, device="mps")
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_ema_anchor_source_py() + probe_kernel
+    )
+
+    library.passivbot_hsl_rolling_pnl_probe(
+        values, indices, output, threads=(1, 1, 1)
+    )
+    torch.mps.synchronize()
+
+    assert output.cpu().tolist() == [
+        50.0,
+        50.0,
+        50.0,
+        -30.0,
+        0.0,
+        -80.0,
+        55.0,
+        55.0,
+        0.0,
+        0.0,
+        1.0,
+    ]
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 def test_mps_joint_pside_hsl_contract_routes_unified_and_directional_signals():
     import passivbot_rust
 
@@ -5511,6 +5605,7 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
         data,
         long_enabled=side == "long",
         short_enabled=side == "short",
+        pnl_lookback_bars=5,
     ).run(np.asarray(rows, dtype=np.float64))
     market_runner = runner_cls(
         market,

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -29,6 +29,7 @@ from optimization.gpu.service import (
     _candidate_position_slot_outputs,
     _combine_hedged_multicoin_hsl_outputs,
     _combine_hedged_multicoin_outputs,
+    _directional_coin_hsl_lookback_bars,
     _directional_entry_initial_metrics,
     _directional_gross_pnl_outputs,
     _hsl_params,
@@ -44,6 +45,32 @@ from optimization.gpu.service import (
     _total_exposure_enforcer_params,
     _unstuck_params,
 )
+
+
+@pytest.mark.parametrize(
+    ("lookback_days", "signal_mode", "enabled", "expected"),
+    [
+        (30.0, "coin", True, 43_200),
+        (0.0, "coin", True, 1),
+        (-1.0, "coin", True, 0),
+        (30.0, "pside", True, 0),
+        (30.0, "coin", False, 0),
+    ],
+)
+def test_directional_coin_hsl_lookback_bar_contract(
+    lookback_days, signal_mode, enabled, expected
+):
+    assert (
+        _directional_coin_hsl_lookback_bars(
+            {
+                "pnls_max_lookback_days": lookback_days,
+                "candle_interval_minutes": 1,
+            },
+            signal_mode=signal_mode,
+            hsl_enabled=enabled,
+        )
+        == expected
+    )
 
 
 def test_hsl_params_preserve_grouped_tier_ratios_after_flattening():


### PR DESCRIPTION
## Summary
- mirror exact Rust finite fill-event rolling PnL semantics for single-coin coin-mode HSL in both EMA Anchor and Trailing Martingale Metal kernels
- keep per-candidate rolling state in bounded MPS scratch buffers and fail the affected candidate closed on overflow
- preserve the all-history path and leave exact Rust authoritative

## Failure reproduced
The XMR HSL run halted after 32 validations with constraint agreement 0.562. Replaying the same 32 candidates after this fix produced constraint agreement 1.000 with zero mismatches, overall rho 0.9978, probe rho 1.000, front rho 0.9971, and no drift halt or warning.

## Validation
- focused physical Apple MPS tests: 11 passed
- finite-window production-runner MPS regression: 5 passed
- GPU service and backend tests: passed
- Rust tests: 265 passed
- Python compileall: passed
- git diff --check: passed

cargo fmt --check remains red on unrelated pre-existing formatting in passivbot-rust/src/gpu.rs; this PR does not reformat those lines.