### PR TITLE
fix(gpu): bound Apple MPS dispatch duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Bounded Apple MPS proxy command buffers by candidate-candle workload so large populations and
+  long histories cannot monopolize the shared display GPU in one Metal dispatch. The configured
+  population and batch retain their optimization semantics while the backend transparently splits
+  oversized dispatches, polls Ctrl+C between them, and retains the last complete ask/tell
+  checkpoint if an in-progress generation is interrupted.
+
 - Fixed finite `live.pnls_max_lookback_days` handling for single-coin `coin`-mode HSL on Apple
   MPS. EMA Anchor and Trailing Martingale screening now expire realized-PnL fill events with the
   same rolling-window rule as exact Rust instead of retaining an all-history peak; bounded GPU

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -458,7 +458,15 @@ The CPU-side NSGA-II proposal stage uses the same `optimize.pymoo.shared` crosso
 duplicate-elimination controls as the ordinary pymoo optimizer.
 
 - `population_size` is the NSGA-II proxy population.
-- `batch_size` caps candidates per MPS dispatch.
+- `batch_size` is the requested upper bound on candidates per MPS dispatch. Because Apple Silicon
+  shares the GPU with WindowServer, the backend transparently splits a batch when its
+  candidates-by-candles-by-coins-by-enabled-sides workload would make one Metal command buffer too
+  long. The effective dispatch size is logged as `GPU MPS dispatch safety cap active`; population
+  size, candidate order, NSGA-II ask/tell semantics, and the number of proxy evaluations are
+  unchanged. Ctrl+C is polled between those bounded dispatches. If it arrives during a generation,
+  that incomplete ask/tell transaction is discarded and the last complete checkpoint is retained.
+  A topology whose single candidate already exceeds the safety envelope fails closed with guidance
+  to shorten the date range or reduce its coin count.
 - `validate_per_generation` caps exact candidates selected from each proxy generation.
 - `drift_probes` reserves at least part of that validation budget for candidates away from the
   proxy front.

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -97,6 +97,33 @@ def _submit_gpu_exact_validation(
     return pool.apply_async(_evaluate_pymoo_worker_from_globals, (vector,))
 
 
+def _checkpoint_gpu_interrupt(
+    *,
+    generation_in_progress: bool,
+    generation: int,
+    exact_done: int,
+    save_checkpoint,
+) -> bool:
+    """Checkpoint only complete ask/tell state during graceful GPU shutdown."""
+
+    if generation_in_progress:
+        logging.info(
+            "GPU interrupt received between bounded MPS dispatches; "
+            "discarding the incomplete proxy generation and retaining the "
+            "last safe checkpoint | generation=%d exact=%d",
+            generation,
+            exact_done,
+        )
+        return False
+    save_checkpoint(force=True)
+    logging.info(
+        "Saved GPU interrupt checkpoint | generation=%d exact=%d",
+        generation,
+        exact_done,
+    )
+    return True
+
+
 _SINGLE_COIN_EXPOSURE_BOUND_SUFFIXES = {
     "risk_we_excess_allowance_pct": "we_excess_allowance_pct",
     "risk_twel_enforcer_threshold": "twel_enforcer_threshold",
@@ -3247,6 +3274,7 @@ def run_backend(
                 exchange=item["exchange"],
                 batch_size=int(options["batch_size"]),
                 needed_metrics=needed_metrics,
+                interrupt_check=interrupt_check,
             )
             item["coin_override_contract"] = getattr(
                 scenario_proxy, "coin_override_contract", {}
@@ -3273,6 +3301,7 @@ def run_backend(
             exchange=exchange,
             batch_size=int(options["batch_size"]),
             needed_metrics=needed_metrics,
+            interrupt_check=interrupt_check,
         )
 
         def evaluate_proxy(candidates):
@@ -3517,6 +3546,7 @@ def run_backend(
     last_probe_shortfall = None
     last_checkpoint_at = 0.0
     last_checkpoint_exact = exact_done
+    generation_in_progress = False
 
     def checkpoint_state() -> dict:
         return {
@@ -3682,9 +3712,11 @@ def run_backend(
                 consume_ready(wait_for_one=True)
                 continue
 
-            # Do not poll the latch again until the matching tell() completes;
-            # checkpointing an interrupted ask/tell transaction is not safe.
+            # An MPS proxy may poll the latch between bounded Metal dispatches.
+            # If interrupted there, the outer handler discards this incomplete
+            # ask/tell transaction and retains the preceding safe checkpoint.
             population = _ask_gpu_population(algorithm, interrupt_check)
+            generation_in_progress = True
             rows = np.asarray(population.get("X"), dtype=np.float64)
             metric_rows = evaluate_proxy(parameter_dicts(rows))
             proxy_objectives, proxy_violations = proxy_fitness(metric_rows)
@@ -3702,6 +3734,7 @@ def run_backend(
                 ).reshape(-1, 1),
             )
             algorithm.tell(infills=population)
+            generation_in_progress = False
             generation += 1
             # PyTorch MPS may consume KeyboardInterrupt while waiting for a
             # Metal dispatch. Finish the in-progress ask/tell transaction, then
@@ -3786,14 +3819,16 @@ def run_backend(
     except KeyboardInterrupt:
         cancel_pending_async_results(pending)
         try:
-            maybe_save_checkpoint(force=True)
-            logging.info(
-                "Saved GPU interrupt checkpoint | generation=%d exact=%d",
-                generation,
-                exact_done,
+            _checkpoint_gpu_interrupt(
+                generation_in_progress=generation_in_progress,
+                generation=generation,
+                exact_done=exact_done,
+                save_checkpoint=maybe_save_checkpoint,
             )
         except Exception:
-            logging.exception("Failed to save GPU checkpoint during interrupt shutdown")
+            logging.exception(
+                "Failed to save GPU checkpoint during interrupt shutdown"
+            )
         pool.terminate()
         raise OptimizerBackendInterrupted(pool=pool, pool_terminated=True)
     except BaseException:

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 from dataclasses import replace
+import logging
 import os
 
 import numpy as np
@@ -99,6 +100,62 @@ DIRECTIONAL_HSL_OUTPUT_KEYS = {
     "hsl_panic_loss_drawdown_max",
     "hsl_panic_loss_drawdown_count",
 }
+
+
+# One MPS thread simulates one candidate across every candle stream. Long-running
+# command buffers can starve WindowServer because Apple silicon shares the GPU
+# with the desktop. Keep one dispatch below the bounded work envelope measured
+# on the supported M3 target; callers may still use larger evolutionary
+# populations and configured batches, which are split transparently.
+MPS_MAX_DISPATCH_CANDIDATE_BARS = 500_000_000
+
+
+def _mps_dispatch_batch_size(
+    requested_batch_size: int,
+    *,
+    n_bars: int,
+    n_coins: int = 1,
+    n_sides: int = 1,
+) -> int:
+    requested_batch_size = max(1, int(requested_batch_size))
+    n_bars = max(1, int(n_bars))
+    n_coins = max(1, int(n_coins))
+    n_sides = max(1, int(n_sides))
+    per_candidate_work = n_bars * n_coins * n_sides
+    if per_candidate_work > MPS_MAX_DISPATCH_CANDIDATE_BARS:
+        raise ValueError(
+            "one GPU candidate exceeds the Apple MPS dispatch safety envelope "
+            f"(bars={n_bars}, coins={n_coins}, sides={n_sides}, "
+            f"candidate_bars={per_candidate_work}, "
+            f"max_candidate_bars={MPS_MAX_DISPATCH_CANDIDATE_BARS}); "
+            "use a shorter date range or fewer coins"
+        )
+    safe_batch_size = max(
+        1, MPS_MAX_DISPATCH_CANDIDATE_BARS // per_candidate_work
+    )
+    return min(requested_batch_size, safe_batch_size)
+
+
+def _log_mps_dispatch_cap(
+    *,
+    requested_batch_size: int,
+    dispatch_batch_size: int,
+    n_bars: int,
+    n_coins: int,
+    n_sides: int,
+) -> None:
+    if dispatch_batch_size >= requested_batch_size:
+        return
+    logging.warning(
+        "GPU MPS dispatch safety cap active | requested_batch=%d dispatch_batch=%d "
+        "bars=%d coins=%d sides=%d max_candidate_bars=%d",
+        requested_batch_size,
+        dispatch_batch_size,
+        n_bars,
+        n_coins,
+        n_sides,
+        MPS_MAX_DISPATCH_CANDIDATE_BARS,
+    )
 
 _DUAL_SIDE_MULTICOIN_INTRADAY_CUTOFF_METRICS = {
     "adg_pnl",
@@ -845,6 +902,7 @@ class MpsSingleCoinProxy:
         exchange: str,
         batch_size: int,
         needed_metrics,
+        interrupt_check=None,
     ):
         try:
             import torch
@@ -871,6 +929,7 @@ class MpsSingleCoinProxy:
         self._compute_objectives = compute_objectives
         self.needed_metrics = set(needed_metrics)
         self.batch_size = max(1, int(batch_size))
+        self.interrupt_check = interrupt_check or (lambda: None)
         self.profile_enabled = os.environ.get(
             "PASSIVBOT_GPU_PROFILE", ""
         ).strip().lower() in {
@@ -921,6 +980,19 @@ class MpsSingleCoinProxy:
         }
         if not any(self.enabled.values()):
             raise ValueError("GPU foundation requires at least one enabled side")
+        enabled_side_count = sum(self.enabled.values())
+        self.dispatch_batch_size = _mps_dispatch_batch_size(
+            self.batch_size,
+            n_bars=len(hlcvs),
+            n_sides=enabled_side_count,
+        )
+        _log_mps_dispatch_cap(
+            requested_batch_size=self.batch_size,
+            dispatch_batch_size=self.dispatch_batch_size,
+            n_bars=len(hlcvs),
+            n_coins=1,
+            n_sides=enabled_side_count,
+        )
         hsl_enabled_sides = [
             side
             for side, bot in (("long", long_bot), ("short", short_bot))
@@ -1095,13 +1167,19 @@ class MpsSingleCoinProxy:
     def evaluate(self, candidates: list[dict]) -> list[dict]:
         results: list[dict] = []
         torch = self._torch
-        for start in range(0, len(candidates), self.batch_size):
-            chunk = candidates[start : start + self.batch_size]
+        dispatch_batch_size = getattr(
+            self, "dispatch_batch_size", self.batch_size
+        )
+        interrupt_check = getattr(self, "interrupt_check", lambda: None)
+        for start in range(0, len(candidates), dispatch_batch_size):
+            interrupt_check()
+            chunk = candidates[start : start + dispatch_batch_size]
             parameter_matrix = self._parameter_matrix(chunk)
             output = self.runner.run(
                 parameter_matrix,
                 profile=self.profile_enabled,
             )
+            interrupt_check()
             output = {
                 key: value.cpu()
                 for key, value in output.items()
@@ -1385,6 +1463,7 @@ class MpsMulticoinProxy:
         exchange: str,
         batch_size: int,
         needed_metrics,
+        interrupt_check=None,
     ):
         try:
             import torch
@@ -1410,6 +1489,7 @@ class MpsMulticoinProxy:
         self._compute_objectives = compute_objectives
         self.needed_metrics = set(needed_metrics)
         self.batch_size = max(1, int(batch_size))
+        self.interrupt_check = interrupt_check or (lambda: None)
         self.profile_enabled = os.environ.get(
             "PASSIVBOT_GPU_PROFILE", ""
         ).strip().lower() in {"1", "true", "yes", "y"}
@@ -1447,6 +1527,19 @@ class MpsMulticoinProxy:
                 "MPS multicoin proxy requires one or two enabled sides"
             )
         self.sides = enabled_sides
+        self.dispatch_batch_size = _mps_dispatch_batch_size(
+            self.batch_size,
+            n_bars=len(values),
+            n_coins=coin_count,
+            n_sides=len(enabled_sides),
+        )
+        _log_mps_dispatch_cap(
+            requested_batch_size=self.batch_size,
+            dispatch_batch_size=self.dispatch_batch_size,
+            n_bars=len(values),
+            n_coins=coin_count,
+            n_sides=len(enabled_sides),
+        )
         self.shared_account_fused = (
             self.strategy_kind == "ema_anchor" and len(self.sides) == 2
         )
@@ -1868,8 +1961,13 @@ class MpsMulticoinProxy:
         results: list[dict] = []
         torch = self._torch
         fused_runner = getattr(self, "fused_runner", None)
-        for start in range(0, len(candidates), self.batch_size):
-            chunk = candidates[start : start + self.batch_size]
+        dispatch_batch_size = getattr(
+            self, "dispatch_batch_size", self.batch_size
+        )
+        interrupt_check = getattr(self, "interrupt_check", lambda: None)
+        for start in range(0, len(candidates), dispatch_batch_size):
+            interrupt_check()
+            chunk = candidates[start : start + dispatch_batch_size]
             parameter_matrices = {
                 side: self._parameter_matrix(chunk, side) for side in self.sides
             }
@@ -1882,19 +1980,20 @@ class MpsMulticoinProxy:
                     fused_parameters,
                     profile=self.profile_enabled,
                 )
+                interrupt_check()
                 output = {
                     key: value.cpu()
                     for key, value in raw_output.items()
                     if key in CORE_OUTPUT_KEYS | DIRECTIONAL_HSL_OUTPUT_KEYS
                 }
             else:
-                raw_side_outputs = {
-                    side: self.runners[side].run(
+                raw_side_outputs = {}
+                for side in self.sides:
+                    raw_side_outputs[side] = self.runners[side].run(
                         parameter_matrices[side],
                         profile=self.profile_enabled,
                     )
-                    for side in self.sides
-                }
+                    interrupt_check()
                 side_outputs = {
                     side: {
                         key: value.cpu()

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -705,6 +705,7 @@ def _refresh_hedged_multicoin_hsl_at_portfolio_cutoff(
     parameter_matrices: dict,
     combined_output: dict,
     start_minute_of_day: int,
+    interrupt_check=None,
 ) -> bool:
     """Replace full-run directional HSL summaries at a portfolio cutoff.
 
@@ -724,10 +725,13 @@ def _refresh_hedged_multicoin_hsl_at_portfolio_cutoff(
         - int(start_minute_of_day)
     )
     end_steps = np.maximum(end_steps, 1).astype(np.int32)
+    interrupt_check = interrupt_check or (lambda: None)
     for side in ("long", "short"):
+        interrupt_check()
         truncated = runners[side].run(
             parameter_matrices[side][indices], end_steps=end_steps
         )
+        interrupt_check()
         for key in DIRECTIONAL_HSL_OUTPUT_KEYS:
             side_outputs[side][key][cutoff_mask] = truncated[key].cpu()
     return True
@@ -2034,6 +2038,7 @@ class MpsMulticoinProxy:
                     start_minute_of_day=self.runners[
                         "long"
                     ].start_minute_of_day,
+                    interrupt_check=interrupt_check,
                 ):
                     output = _combine_hedged_multicoin_outputs(
                         side_outputs["long"],

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -24,6 +24,7 @@ from optimization.backends.gpu_backend import (
     _build_gpu_nsga2,
     _build_proxy_parameter_dicts,
     _checkpoint_signature,
+    _checkpoint_gpu_interrupt,
     _constraint_classification_mismatch,
     _constraint_diagnostics,
     _ema_multicoin_bound_map,
@@ -111,6 +112,34 @@ def test_gpu_exact_submission_checks_interrupt_before_apply_async():
 
     interrupt_check.assert_called_once_with()
     pool.apply_async.assert_not_called()
+
+
+def test_gpu_interrupt_discards_incomplete_ask_tell_without_checkpointing():
+    save_checkpoint = MagicMock()
+
+    saved = _checkpoint_gpu_interrupt(
+        generation_in_progress=True,
+        generation=7,
+        exact_done=23,
+        save_checkpoint=save_checkpoint,
+    )
+
+    assert not saved
+    save_checkpoint.assert_not_called()
+
+
+def test_gpu_interrupt_checkpoints_complete_generation_state():
+    save_checkpoint = MagicMock()
+
+    saved = _checkpoint_gpu_interrupt(
+        generation_in_progress=False,
+        generation=7,
+        exact_done=23,
+        save_checkpoint=save_checkpoint,
+    )
+
+    assert saved
+    save_checkpoint.assert_called_once_with(force=True)
 
 
 def _long_only_ema_config():

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -483,6 +483,55 @@ def test_refresh_hedged_multicoin_hsl_replays_only_cutoff_candidates():
     assert side_outputs["short"]["hsl_triggers_short"].tolist() == [10.0, 4.0]
 
 
+def test_hedged_multicoin_hsl_cutoff_replay_honors_interrupt_between_sides():
+    torch = pytest.importorskip("torch")
+    calls = []
+    checks = 0
+
+    class FakeRunner:
+        def run(self, params, *, end_steps):
+            calls.append(params.tolist())
+            return {
+                key: torch.zeros(
+                    len(params),
+                    dtype=torch.bool if key.endswith("_enabled") else torch.float32,
+                )
+                for key in DIRECTIONAL_HSL_OUTPUT_KEYS
+            }
+
+    def interrupt_check():
+        nonlocal checks
+        checks += 1
+        if checks == 2:
+            raise KeyboardInterrupt
+
+    side_outputs = {
+        side: {
+            key: torch.zeros(
+                1,
+                dtype=torch.bool if key.endswith("_enabled") else torch.float32,
+            )
+            for key in DIRECTIONAL_HSL_OUTPUT_KEYS
+        }
+        for side in ("long", "short")
+    }
+
+    with pytest.raises(KeyboardInterrupt):
+        _refresh_hedged_multicoin_hsl_at_portfolio_cutoff(
+            side_outputs=side_outputs,
+            runners={"long": FakeRunner(), "short": FakeRunner()},
+            parameter_matrices={
+                "long": np.asarray([[1.0]]),
+                "short": np.asarray([[2.0]]),
+            },
+            combined_output={"liq_step": torch.tensor([1.0])},
+            start_minute_of_day=0,
+            interrupt_check=interrupt_check,
+        )
+
+    assert calls == [[[1.0]]]
+
+
 def test_single_coin_proxy_preserves_directional_hsl_outputs_for_reduction():
     torch = pytest.importorskip("torch")
     proxy = MpsSingleCoinProxy.__new__(MpsSingleCoinProxy)

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -20,6 +20,7 @@ from optimization.gpu.model import (
 from optimization.gpu.service import (
     CORE_OUTPUT_KEYS,
     DIRECTIONAL_HSL_OUTPUT_KEYS,
+    MPS_MAX_DISPATCH_CANDIDATE_BARS,
     MpsEmaAnchorProxy,
     MpsSingleCoinProxy,
     MpsMulticoinEmaProxy,
@@ -33,6 +34,7 @@ from optimization.gpu.service import (
     _directional_entry_initial_metrics,
     _directional_gross_pnl_outputs,
     _hsl_params,
+    _mps_dispatch_batch_size,
     _position_exposure_enforcer_params,
     _prepared_single_coin_side_enabled,
     _require_multicoin_metric_topology,
@@ -71,6 +73,87 @@ def test_directional_coin_hsl_lookback_bar_contract(
         )
         == expected
     )
+
+
+def test_mps_dispatch_batch_size_bounds_single_and_multicoin_work():
+    n_bars = 1_923_175
+
+    assert _mps_dispatch_batch_size(8192, n_bars=n_bars) == 259
+    assert _mps_dispatch_batch_size(8192, n_bars=n_bars, n_coins=4) == 64
+    assert (
+        _mps_dispatch_batch_size(8192, n_bars=n_bars, n_coins=4, n_sides=2)
+        == 32
+    )
+    assert _mps_dispatch_batch_size(32, n_bars=1000, n_coins=4) == 32
+    with pytest.raises(ValueError, match="one GPU candidate exceeds"):
+        _mps_dispatch_batch_size(8192, n_bars=10**9)
+    assert MPS_MAX_DISPATCH_CANDIDATE_BARS == 500_000_000
+
+
+def _minimal_single_coin_proxy(*, interrupt_check=lambda: None):
+    torch = pytest.importorskip("torch")
+    proxy = MpsSingleCoinProxy.__new__(MpsSingleCoinProxy)
+    proxy.batch_size = 8
+    proxy.dispatch_batch_size = 2
+    proxy.interrupt_check = interrupt_check
+    proxy._torch = torch
+    proxy.profile_enabled = False
+    proxy.metrics_data = {"ts0": 0.0}
+    proxy.run = SimpleNamespace()
+    proxy.needed_metrics = {"score"}
+    proxy._parameter_matrix = lambda candidates: np.asarray(
+        [[candidate["value"]] for candidate in candidates], dtype=np.float64
+    )
+    calls = []
+
+    def run(parameters, **kwargs):
+        calls.append(parameters[:, 0].tolist())
+        batch = len(parameters)
+        output = {
+            key: torch.zeros(batch)
+            for key in (
+                "first_fill_ts",
+                "last_fill_ts",
+                "last_high_ts",
+                "first_eq_ts",
+                "last_eq_ts",
+            )
+        }
+        output["max_dd"] = torch.as_tensor(parameters[:, 0])
+        return output
+
+    proxy.runner = SimpleNamespace(run=run)
+    proxy._compute_objectives = lambda output, *args, **kwargs: {
+        "score": output["max_dd"]
+    }
+    return proxy, calls
+
+
+def test_single_coin_proxy_preserves_order_across_bounded_dispatches():
+    proxy, calls = _minimal_single_coin_proxy()
+    candidates = [{"value": float(index)} for index in range(5)]
+
+    assert proxy.evaluate(candidates) == [
+        {"score": float(index)} for index in range(5)
+    ]
+    assert calls == [[0.0, 1.0], [2.0, 3.0], [4.0]]
+
+
+def test_single_coin_proxy_honors_interrupt_between_mps_dispatches():
+    checks = 0
+
+    def interrupt_check():
+        nonlocal checks
+        checks += 1
+        if checks == 2:
+            raise KeyboardInterrupt
+
+    proxy, calls = _minimal_single_coin_proxy(interrupt_check=interrupt_check)
+
+    with pytest.raises(KeyboardInterrupt):
+        proxy.evaluate([{"value": float(index)} for index in range(5)])
+
+    assert calls == [[0.0, 1.0]]
 
 
 def test_hsl_params_preserve_grouped_tier_ratios_after_flattening():


### PR DESCRIPTION
## Summary

- split oversized Apple MPS proxy batches by candidate-candle workload while preserving population, candidate order, and NSGA-II ask/tell semantics
- scale the dispatch envelope by history length, coin count, and enabled-side count; fail closed when one candidate cannot fit
- poll the existing SIGINT latch between bounded Metal commands and retain the last complete checkpoint instead of serializing an interrupted ask/tell transaction
- document the effective `batch_size` contract and safety-cap log

## Motivation

On the M3 MacBook Air, an 8192-candidate trailing-martingale command over 1,923,175 bars held Metal for roughly 269 seconds, drove thermal pressure to Heavy, and caused a WindowServer watchdog restart. This branch bounds individual Metal commands without changing the evolutionary population.

## Validation

- `PYTHONPATH=src .../python -m pytest tests/optimization/test_gpu_service.py tests/optimization/test_gpu_backend.py -q`
- `PYTHONPATH=src .../python -m pytest tests/optimization -q`
- rebuilt and verified the current Rust extension fingerprint with `check_and_maybe_compile(force=True)` (no Rust changes)
- real M3/ALGO cached-data smoke: 512 candidates over 1,923,175 bars logged `requested_batch=512 dispatch_batch=259`, completed as two bounded commands in 58.35s, and kept WindowServer responsive
- real parent-only SIGINT during the first Metal command: honored at the first dispatch boundary; incomplete generation discarded; graceful worker/manager/shared-memory cleanup completed with exit 130
- `mkdocs build --strict` reached only the two pre-existing `release_notes_v8.0.0.md` / `release_notes_v8.1.0.md` CHANGELOG-link warnings; this change added no warning

Exact Rust validation and all CPU operation remain unchanged.