### PR TITLE
perf(gpu): specialize one-sided TM Metal kernels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Accelerated HSL-disabled, one-sided single-coin Trailing Martingale optimization on Apple MPS
+  with Rust-owned long-only and short-only Metal variants. The backend selects these variants
+  automatically, logs the selected topology, and retains the generic kernel for dual-side or
+  HSL-enabled runs. Exact Rust validation and the existing drift gates remain authoritative.
+
 - Bounded Apple MPS proxy command buffers by candidate-candle workload so large populations and
   long histories cannot monopolize the shared display GPU in one Metal dispatch. The configured
   population and batch retain their optimization semantics while the backend transparently splits

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -414,6 +414,12 @@ The backend is hybrid rather than a replacement backtester:
    price finalization, and their ordering relative to aligned quantity steps is retained across
    float32 transport. Tick-aligned computed targets remain on their exchange tick; residual
    float32 arithmetic drift is measured by exact validation.
+   For HSL-disabled, one-sided single-coin Trailing Martingale runs, the backend automatically
+   selects a Rust-owned long-only or short-only Metal variant. Compile-time side and HSL constants
+   let Metal remove unreachable controller and opposite-side work without changing candidate
+   ordering or optimizer semantics. Dual-side and HSL-enabled runs retain the generic kernel. The
+   selected variant is logged as `GPU MPS specialized kernel selected`; exact Rust validation and
+   the normal drift gates remain authoritative.
 3. In suite mode, the same candidate batch is screened once per scenario and reduced with the
    canonical suite scoring and limit contract.
 4. Diverse proxy-front candidates and broad drift probes are sent to the unchanged Rust backtester.

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -16,6 +16,10 @@ const MPS_TRAILING_MARTINGALE_BODY: &str =
 const MPS_EMA_ANCHOR_MULTICOIN_BODY: &str = include_str!("gpu/mps_ema_anchor_multicoin_long.metal");
 const MPS_TRAILING_MARTINGALE_MULTICOIN_BODY: &str =
     include_str!("gpu/mps_trailing_martingale_multicoin.metal");
+const MPS_TRAILING_LONG_NO_HSL_PREAMBLE: &str =
+    "#define PASSIVBOT_TRAILING_LONG_ONLY 1\n#define PASSIVBOT_TRAILING_HSL_DISABLED 1\n";
+const MPS_TRAILING_SHORT_NO_HSL_PREAMBLE: &str =
+    "#define PASSIVBOT_TRAILING_SHORT_ONLY 1\n#define PASSIVBOT_TRAILING_HSL_DISABLED 1\n";
 
 fn compose_hsl_source(body: &str) -> String {
     assert_eq!(
@@ -35,12 +39,23 @@ fn compose_multicoin_source(body: &str) -> String {
     compose_hsl_source(&body.replacen(MPS_MULTICOIN_MARKER, MPS_MULTICOIN_COMMON_SOURCE, 1))
 }
 
+fn compose_trailing_topology_source(preamble: &str) -> String {
+    format!(
+        "{preamble}{}",
+        compose_hsl_source(MPS_TRAILING_MARTINGALE_BODY)
+    )
+}
+
 pub static MPS_EMA_ANCHOR_SOURCE: LazyLock<String> =
     LazyLock::new(|| compose_hsl_source(MPS_EMA_ANCHOR_BODY));
 pub static MPS_EMA_ANCHOR_MULTICOIN_SOURCE: LazyLock<String> =
     LazyLock::new(|| compose_multicoin_source(MPS_EMA_ANCHOR_MULTICOIN_BODY));
 pub static MPS_TRAILING_MARTINGALE_SOURCE: LazyLock<String> =
     LazyLock::new(|| compose_hsl_source(MPS_TRAILING_MARTINGALE_BODY));
+pub static MPS_TRAILING_MARTINGALE_LONG_NO_HSL_SOURCE: LazyLock<String> =
+    LazyLock::new(|| compose_trailing_topology_source(MPS_TRAILING_LONG_NO_HSL_PREAMBLE));
+pub static MPS_TRAILING_MARTINGALE_SHORT_NO_HSL_SOURCE: LazyLock<String> =
+    LazyLock::new(|| compose_trailing_topology_source(MPS_TRAILING_SHORT_NO_HSL_PREAMBLE));
 pub static MPS_TRAILING_MARTINGALE_MULTICOIN_SOURCE: LazyLock<String> =
     LazyLock::new(|| compose_multicoin_source(MPS_TRAILING_MARTINGALE_MULTICOIN_BODY));
 
@@ -58,6 +73,14 @@ pub fn mps_ema_anchor_multicoin_long_source() -> &'static str {
 
 pub fn mps_trailing_martingale_source() -> &'static str {
     MPS_TRAILING_MARTINGALE_SOURCE.as_str()
+}
+
+pub fn mps_trailing_martingale_long_no_hsl_source() -> &'static str {
+    MPS_TRAILING_MARTINGALE_LONG_NO_HSL_SOURCE.as_str()
+}
+
+pub fn mps_trailing_martingale_short_no_hsl_source() -> &'static str {
+    MPS_TRAILING_MARTINGALE_SHORT_NO_HSL_SOURCE.as_str()
 }
 
 pub fn mps_trailing_martingale_multicoin_source() -> &'static str {
@@ -188,6 +211,33 @@ mod tests {
         assert_shared_hsl_contract(mps_trailing_martingale_source());
         assert_directional_hsl_accounting_contract(mps_ema_anchor_source());
         assert_directional_hsl_accounting_contract(mps_trailing_martingale_source());
+    }
+
+    #[test]
+    fn trailing_martingale_specialized_sources_pin_one_side_without_hsl() {
+        let variants = [
+            (
+                mps_trailing_martingale_long_no_hsl_source(),
+                "#define PASSIVBOT_TRAILING_LONG_ONLY 1",
+            ),
+            (
+                mps_trailing_martingale_short_no_hsl_source(),
+                "#define PASSIVBOT_TRAILING_SHORT_ONLY 1",
+            ),
+        ];
+        for (source, side_define) in variants {
+            assert!(source.starts_with(side_define));
+            assert!(source.contains("#define PASSIVBOT_TRAILING_HSL_DISABLED 1"));
+            assert!(source.contains("#if defined(PASSIVBOT_TRAILING_LONG_ONLY)"));
+            assert!(source.contains("#elif defined(PASSIVBOT_TRAILING_SHORT_ONLY)"));
+            assert!(source.contains("#if defined(PASSIVBOT_TRAILING_HSL_DISABLED)"));
+            assert_shared_hsl_contract(source);
+            assert_directional_hsl_accounting_contract(source);
+        }
+        let generic = mps_trailing_martingale_source();
+        assert!(!generic.contains("#define PASSIVBOT_TRAILING_LONG_ONLY 1"));
+        assert!(!generic.contains("#define PASSIVBOT_TRAILING_SHORT_ONLY 1"));
+        assert!(!generic.contains("#define PASSIVBOT_TRAILING_HSL_DISABLED 1"));
     }
 
     #[test]

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -1093,8 +1093,16 @@ inline void passivbot_single_coin_impl(
     const float starting_balance = settings[6];
     const float liq_floor = settings[7];
     const float interval_ms = settings[8];
+#if defined(PASSIVBOT_TRAILING_LONG_ONLY)
+    const bool long_enabled = true;
+    const bool short_enabled = false;
+#elif defined(PASSIVBOT_TRAILING_SHORT_ONLY)
+    const bool long_enabled = false;
+    const bool short_enabled = true;
+#else
     const bool long_enabled = settings[9] > 0.5f;
     const bool short_enabled = settings[10] > 0.5f;
+#endif
     const bool hedge_mode = settings[11] > 0.5f;
     const bool filter_by_min_effective_cost = settings[12] > 0.5f;
     const float max_effective_min_cost = settings[13];
@@ -1115,6 +1123,10 @@ inline void passivbot_single_coin_impl(
     TmSide short_side = load_side(params, po + SIDE_PARAMS, seed_close);
     HslState long_hsl = load_hsl(params, po, 40);
     HslState short_hsl = load_hsl(params, po + SIDE_PARAMS, 40);
+#if defined(PASSIVBOT_TRAILING_HSL_DISABLED)
+    long_hsl.enabled = false;
+    short_hsl.enabled = false;
+#endif
     const bool long_coin_hsl_rolling = long_hsl.enabled
         && long_hsl.signal_mode == HSL_SIGNAL_COIN && pnl_lookback_bars > 0;
     const bool short_coin_hsl_rolling = short_hsl.enabled

--- a/passivbot-rust/src/lib.rs
+++ b/passivbot-rust/src/lib.rs
@@ -54,6 +54,16 @@ fn mps_trailing_martingale_source_py() -> &'static str {
 }
 
 #[pyfunction]
+fn mps_trailing_martingale_long_no_hsl_source_py() -> &'static str {
+    gpu::mps_trailing_martingale_long_no_hsl_source()
+}
+
+#[pyfunction]
+fn mps_trailing_martingale_short_no_hsl_source_py() -> &'static str {
+    gpu::mps_trailing_martingale_short_no_hsl_source()
+}
+
+#[pyfunction]
 fn mps_trailing_martingale_multicoin_source_py() -> &'static str {
     gpu::mps_trailing_martingale_multicoin_source()
 }
@@ -72,6 +82,14 @@ fn passivbot_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
         m
     )?)?;
     m.add_function(wrap_pyfunction!(mps_trailing_martingale_source_py, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        mps_trailing_martingale_long_no_hsl_source_py,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(
+        mps_trailing_martingale_short_no_hsl_source_py,
+        m
+    )?)?;
     m.add_function(wrap_pyfunction!(
         mps_trailing_martingale_multicoin_source_py,
         m

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -47,6 +47,21 @@ def validate_single_coin_hsl_signal_topology(
         signal_mode, coin_count=1, enabled_side_count=enabled_side_count
     )
 
+
+def trailing_martingale_shader_topology(
+    *, long_enabled: bool, short_enabled: bool, hsl_enabled: bool
+) -> str:
+    """Select a topology variant only when compile-time assumptions are exact."""
+
+    if hsl_enabled:
+        return "generic"
+    if long_enabled and not short_enabled:
+        return "long_no_hsl"
+    if short_enabled and not long_enabled:
+        return "short_no_hsl"
+    return "generic"
+
+
 EMA_ANCHOR_PARAM_KEYS = (
     "base_qty_pct",
     "ema_span_0",

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -14,6 +14,7 @@ from optimization.gpu.model import (
     ProxyRun,
     TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS,
     TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS,
+    trailing_martingale_shader_topology,
 )
 
 
@@ -77,18 +78,6 @@ def _trailing_martingale_short_no_hsl_shader_library():
     return torch.mps.compile_shader(
         passivbot_rust.mps_trailing_martingale_short_no_hsl_source_py()
     )
-
-
-def _trailing_martingale_shader_topology(
-    *, long_enabled: bool, short_enabled: bool, hsl_enabled: bool
-) -> str:
-    if hsl_enabled:
-        return "generic"
-    if long_enabled and not short_enabled:
-        return "long_no_hsl"
-    if short_enabled and not long_enabled:
-        return "short_no_hsl"
-    return "generic"
 
 
 @lru_cache(maxsize=1)
@@ -1136,7 +1125,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
 
     def __init__(self, *args, hsl_enabled: bool = True, **kwargs):
         super().__init__(*args, **kwargs)
-        self.shader_topology = _trailing_martingale_shader_topology(
+        self.shader_topology = trailing_martingale_shader_topology(
             long_enabled=self.long_enabled,
             short_enabled=self.short_enabled,
             hsl_enabled=bool(hsl_enabled),

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -58,6 +58,40 @@ def _trailing_martingale_shader_library():
 
 
 @lru_cache(maxsize=1)
+def _trailing_martingale_long_no_hsl_shader_library():
+    if not torch.backends.mps.is_available():
+        raise RuntimeError("Apple MPS is not available in this process")
+    import passivbot_rust
+
+    return torch.mps.compile_shader(
+        passivbot_rust.mps_trailing_martingale_long_no_hsl_source_py()
+    )
+
+
+@lru_cache(maxsize=1)
+def _trailing_martingale_short_no_hsl_shader_library():
+    if not torch.backends.mps.is_available():
+        raise RuntimeError("Apple MPS is not available in this process")
+    import passivbot_rust
+
+    return torch.mps.compile_shader(
+        passivbot_rust.mps_trailing_martingale_short_no_hsl_source_py()
+    )
+
+
+def _trailing_martingale_shader_topology(
+    *, long_enabled: bool, short_enabled: bool, hsl_enabled: bool
+) -> str:
+    if hsl_enabled:
+        return "generic"
+    if long_enabled and not short_enabled:
+        return "long_no_hsl"
+    if short_enabled and not long_enabled:
+        return "short_no_hsl"
+    return "generic"
+
+
+@lru_cache(maxsize=1)
 def _ema_anchor_multicoin_shader_library():
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
@@ -1100,6 +1134,21 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
 class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
     """Persistent single-coin trailing-martingale runner on Apple MPS."""
 
+    def __init__(self, *args, hsl_enabled: bool = True, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.shader_topology = _trailing_martingale_shader_topology(
+            long_enabled=self.long_enabled,
+            short_enabled=self.short_enabled,
+            hsl_enabled=bool(hsl_enabled),
+        )
+
+    def _shader_library(self):
+        if self.shader_topology == "long_no_hsl":
+            return _trailing_martingale_long_no_hsl_shader_library()
+        if self.shader_topology == "short_no_hsl":
+            return _trailing_martingale_short_no_hsl_shader_library()
+        return _trailing_martingale_shader_library()
+
     def _pack_params(self, params: np.ndarray) -> np.ndarray:
         expected = len(TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS) * 2
         if params.ndim != 2 or params.shape[1] != expected:
@@ -1136,7 +1185,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
                 device="mps",
             )
         prepared = time.perf_counter()
-        library = _trailing_martingale_shader_library()
+        library = self._shader_library()
         compiled = time.perf_counter()
         if profile:
             torch.mps.synchronize()

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -1002,6 +1002,9 @@ class MpsSingleCoinProxy:
             for side, bot in (("long", long_bot), ("short", short_bot))
             if self.enabled[side] and bool(bot.get("hsl_enabled"))
         ]
+        any_configured_hsl = any(
+            bool(bot.get("hsl_enabled")) for bot in (long_bot, short_bot)
+        )
         signal_mode = (
             backtest_params.get("equity_hard_stop_loss", {})
             .get("signal_mode", "unified")
@@ -1129,10 +1132,7 @@ class MpsSingleCoinProxy:
             if self.strategy_kind == "trailing_martingale"
             else MpsEmaAnchorRunner
         )
-        self.runner = runner_cls(
-            self.market,
-            self.run,
-            self.data,
+        runner_kwargs = dict(
             long_enabled=self.enabled["long"],
             short_enabled=self.enabled["short"],
             hedge_mode=bool(backtest_params["hedge_mode"]),
@@ -1150,6 +1150,21 @@ class MpsSingleCoinProxy:
             hsl_panic_market_short=hsl_panic_market["short"],
             pnl_lookback_bars=pnl_lookback_bars,
         )
+        if self.strategy_kind == "trailing_martingale":
+            runner_kwargs["hsl_enabled"] = any_configured_hsl
+        self.runner = runner_cls(
+            self.market,
+            self.run,
+            self.data,
+            **runner_kwargs,
+        )
+        shader_topology = getattr(self.runner, "shader_topology", "generic")
+        if shader_topology != "generic":
+            logging.info(
+                "GPU MPS specialized kernel selected | strategy=%s topology=%s",
+                self.strategy_kind,
+                shader_topology,
+            )
 
     def _parameter_matrix(self, candidates: list[dict]) -> np.ndarray:
         rows = []

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -17,6 +17,7 @@ from optimization.gpu.model import (
     validate_hsl_signal_topology,
     validate_single_coin_hsl_signal_topology,
 )
+from optimization.gpu.mps_kernel import _trailing_martingale_shader_topology
 from optimization.gpu.service import (
     CORE_OUTPUT_KEYS,
     DIRECTIONAL_HSL_OUTPUT_KEYS,
@@ -70,6 +71,29 @@ def test_directional_coin_hsl_lookback_bar_contract(
             },
             signal_mode=signal_mode,
             hsl_enabled=enabled,
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("long_enabled", "short_enabled", "hsl_enabled", "expected"),
+    [
+        (True, False, False, "long_no_hsl"),
+        (False, True, False, "short_no_hsl"),
+        (True, True, False, "generic"),
+        (True, False, True, "generic"),
+        (False, True, True, "generic"),
+    ],
+)
+def test_trailing_martingale_shader_topology_is_fail_closed(
+    long_enabled, short_enabled, hsl_enabled, expected
+):
+    assert (
+        _trailing_martingale_shader_topology(
+            long_enabled=long_enabled,
+            short_enabled=short_enabled,
+            hsl_enabled=hsl_enabled,
         )
         == expected
     )

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -14,10 +14,10 @@ from optimization.gpu.model import (
     TRAILING_MARTINGALE_PARAM_KEYS,
     flatten_trailing_martingale_params,
     gpu_side_enabled,
+    trailing_martingale_shader_topology,
     validate_hsl_signal_topology,
     validate_single_coin_hsl_signal_topology,
 )
-from optimization.gpu.mps_kernel import _trailing_martingale_shader_topology
 from optimization.gpu.service import (
     CORE_OUTPUT_KEYS,
     DIRECTIONAL_HSL_OUTPUT_KEYS,
@@ -90,7 +90,7 @@ def test_trailing_martingale_shader_topology_is_fail_closed(
     long_enabled, short_enabled, hsl_enabled, expected
 ):
     assert (
-        _trailing_martingale_shader_topology(
+        trailing_martingale_shader_topology(
             long_enabled=long_enabled,
             short_enabled=short_enabled,
             hsl_enabled=hsl_enabled,


### PR DESCRIPTION
## Summary

- add Rust-owned long-only and short-only Metal source variants for single-coin Trailing Martingale
- select the specialized variant automatically only when exactly one side is enabled and HSL is disabled; retain the generic kernel for dual-side or HSL-enabled runs
- keep exact Rust validation, drift gates, optimizer ordering, and CPU paths unchanged

## Performance and parity

On an Apple M3 with 1,924,615 one-minute candles and a 256-candidate batch, the production proxy path improved from 8.94 eval/s with the generic kernel to 19.94 eval/s with the specialized long-only kernel (2.23x). Generic-versus-specialized probes for both long-only and short-only compared all 69 output tensors across 64 candidates and were bit-exact.

## Validation

- `cargo test --no-default-features` (266 passed)
- `cargo check --tests`
- `PYTHONPATH=src python -m pytest tests/optimization -q`
- `PYTHONPATH=src python src/tools/check_ai_docs.py` (0 errors; existing size warnings only)
- generated live-event registry check and AI-doc tests
- rebuilt and source-fingerprint-verified the PyO3 extension
- bounded real-MPS long-only and short-only output-parity probes
- bounded real-MPS production-path performance benchmark