### PR TITLE
fix(gpu): revalidate repeated proxy fronts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Fixed Apple MPS optimization halting when a converged or single-objective proxy front repeats an
+  already exact-validated candidate. The backend now revalidates that actual current-front member
+  (or waits for its in-flight exact job) instead of relabeling an off-front candidate, preserving
+  the proxy-front drift gate and exact Rust authority while allowing the search to continue.
+
 - Added worst EMA-smoothed HSL strategy-equity drawdown scoring and limits to Apple MPS
   optimization for the account, long side, and short side. Metal retains each controller's
   maximum across cooldown restarts and coin-mode controllers, then applies the same account-level

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -468,12 +468,14 @@ duplicate-elimination controls as the ordinary pymoo optimizer.
   At least eight samples of a validation class are required before its independent low agreement
   can halt a run, so `drift_window` and `optimize.iters` must be large enough to retain and reach
   eight true proxy-front validations even when the complete feasible proxy front contributes only
-  one novel candidate per generation. Off-front validations stay truthfully classified as broad
+  one candidate per generation. Off-front validations stay truthfully classified as broad
   probes rather than being relabeled as front evidence, and scarce or duplicate probes give their
   unused exact slots back to true-front candidates. Front membership is carried independently
-  through exact-result persistence and resume recovery. A generation still fails closed if
-  duplicate filtering leaves no novel proxy-front candidate, so broad probes cannot silently
-  consume the exact budget needed to activate the front gate. `drift_probes` must remain below
+  through exact-result persistence and resume recovery. If duplicate filtering leaves no novel
+  proxy-front candidate, the optimizer revalidates a previously exact current-front member; if its
+  exact job is still in flight, selection waits for that job first. This preserves truthful front
+  evidence without relabeling broad probes, and repeated front disagreements still activate the
+  rolling front gate. `drift_probes` must remain below
   `validate_per_generation` so each generation requests proxy-front safety evidence. A partial
   final validation batch scales its reserved probe count down proportionally.
 - `exact_workers: 0` inherits `optimize.n_cpus`; a positive value overrides it for this backend.

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -726,17 +726,18 @@ def _resolve_options(config: dict) -> dict:
             "at least optimize.gpu.validate_per_generation so each full validation "
             "batch retains its configured proxy-front/broad-probe allocation"
         )
-    # A complete feasible proxy Pareto front may contain only one novel
-    # candidate. All remaining validation slots are truthfully broad/off-front
-    # evidence, so budget for the worst-case one true-front sample per full
-    # generation rather than assuming a fixed front/probe split.
+    # A complete feasible proxy Pareto front may contain only one candidate.
+    # All remaining validation slots are truthfully broad/off-front evidence,
+    # so budget for the worst-case one true-front sample per full generation
+    # rather than assuming a fixed front/probe split. A repeated member is
+    # exactly revalidated to preserve that sample.
     required_front_window = MIN_DRIFT_PROBES * validations
     if int(options["drift_window"]) < required_front_window:
         raise ValueError(
             "optimize.gpu.drift_window must be at least "
             f"{required_front_window} to retain {MIN_DRIFT_PROBES} true "
-            "proxy-front validations when a complete proxy front contributes "
-            "only one novel candidate per generation"
+            "proxy-front validations when a complete proxy front contains "
+            "only one candidate per generation"
         )
     required_evidence_window = required_front_window
     if int(options["drift_probes"]) > 0:
@@ -1880,9 +1881,9 @@ def _select_validation_indices(
             selected.append((index, not is_front, is_front))
             selected_ids.add(index)
 
-    # Return a complete preference order. The caller may skip candidates whose
-    # quantized exact vectors were already evaluated and continue down this
-    # list until it fills the generation's exact-validation quota.
+    # Return a complete preference order. The caller may skip duplicate probes,
+    # seek novel front members, or deliberately revalidate an already-exact
+    # current-front member without changing its truthful class.
     fallback_order = sorted(
         range(len(objectives)),
         key=lambda index: (
@@ -1899,7 +1900,11 @@ def _select_validation_indices(
     return selected
 
 
-def _select_novel_validations(
+class _ProxyFrontValidationPending(RuntimeError):
+    """The current proxy front has exact work in flight but no ready evidence."""
+
+
+def _select_exact_validations(
     selections,
     *,
     total: int,
@@ -1908,10 +1913,20 @@ def _select_novel_validations(
     completed_hashes,
     submitted_hashes,
 ):
+    """Choose truthful exact evidence, revalidating a covered front if needed.
+
+    Off-front candidates are never relabeled as front evidence. When duplicate
+    filtering leaves no novel front member, a previously completed current-front
+    candidate is deliberately re-run so the rolling front gate remains active.
+    A current-front candidate that is still in flight must complete first.
+    """
+
     novel = []
+    completed_front = []
     seen = set()
     novel_probe_count = 0
     novel_front_count = 0
+    pending_front = False
     # The first ``total`` preferences are the selector's truthful allocation.
     # Later items replace duplicate hashes but must not change that class mix.
     target_probe_count = min(
@@ -1925,10 +1940,17 @@ def _select_novel_validations(
     for index, is_probe, is_front in selections:
         candidate = candidate_for_index(index)
         digest = digest_for_candidate(candidate)
-        if digest in completed_hashes or digest in submitted_hashes or digest in seen:
+        if digest in seen:
             continue
         seen.add(digest)
         item = (index, bool(is_probe), bool(is_front), candidate, digest)
+        if digest in submitted_hashes:
+            pending_front = pending_front or bool(is_front)
+            continue
+        if digest in completed_hashes:
+            if is_front:
+                completed_front.append(item)
+            continue
         novel.append(item)
         novel_probe_count += int(bool(is_probe))
         novel_front_count += int(bool(is_front))
@@ -1940,10 +1962,16 @@ def _select_novel_validations(
 
     probe_items = [item for item in novel if item[1]]
     front_items = [item for item in novel if item[2]]
+    if len(front_items) < target_front_count:
+        front_items.extend(completed_front[: target_front_count - len(front_items)])
     if not front_items:
+        if pending_front:
+            raise _ProxyFrontValidationPending(
+                "GPU proxy-front exact validation is still in flight"
+            )
         raise RuntimeError(
-            "GPU validation cannot provide novel proxy-front safety evidence; "
-            "the current proxy front was already evaluated or submitted"
+            "GPU validation cannot provide truthful proxy-front safety evidence; "
+            "the selector returned no novel or previously exact front candidate"
         )
     chosen = probe_items[:target_probe_count]
     chosen_digests = {item[4] for item in chosen}
@@ -1977,8 +2005,8 @@ def _update_probe_shortfall_log(
         logging.warning(
             "GPU validation has fewer novel candidates outside the complete feasible "
             "proxy Pareto front than requested | requested=%d available=%d | "
-            "filling the exact quota with diverse true-front candidates; broad-probe "
-            "gates use only truthful accumulated off-front evidence",
+            "using truthful true-front candidates (including exact revalidation "
+            "when necessary); broad-probe gates use only accumulated off-front evidence",
             requested,
             actual,
         )
@@ -3674,6 +3702,7 @@ def run_backend(
             )
             exact_done += 1
             completed_hashes.add(digest)
+            submitted_hashes.discard(digest)
             if classification_mismatch:
                 logging.warning(
                     "GPU %s proxy/exact constraint classification disagreed; exact Rust "
@@ -3759,22 +3788,35 @@ def run_backend(
                 total=validation_count,
                 probes=probe_count,
             )
-            novel_selections = _select_novel_validations(
-                selections,
-                total=validation_count,
-                candidate_for_index=lambda index: full_vector(rows[index]),
-                digest_for_candidate=vector_hash,
-                completed_hashes=completed_hashes,
-                submitted_hashes=submitted_hashes,
-            )
-            actual_probe_count = sum(bool(item[1]) for item in novel_selections)
+            while True:
+                try:
+                    exact_selections = _select_exact_validations(
+                        selections,
+                        total=validation_count,
+                        candidate_for_index=lambda index: full_vector(rows[index]),
+                        digest_for_candidate=vector_hash,
+                        completed_hashes=completed_hashes,
+                        submitted_hashes=submitted_hashes,
+                    )
+                    break
+                except _ProxyFrontValidationPending:
+                    if not pending:
+                        raise RuntimeError(
+                            "GPU validation marked proxy-front evidence pending "
+                            "without an exact job in flight"
+                        )
+                    consume_ready(wait_for_one=True)
+                    if exact_done + len(pending) >= budget:
+                        exact_selections = []
+                        break
+            actual_probe_count = sum(bool(item[1]) for item in exact_selections)
             last_probe_shortfall = _update_probe_shortfall_log(
                 last_probe_shortfall,
                 requested=probe_count,
                 actual=actual_probe_count,
             )
             submitted_this_generation = 0
-            for index, is_probe, is_proxy_front, vector, digest in novel_selections:
+            for index, is_probe, is_proxy_front, vector, digest in exact_selections:
                 result = _submit_gpu_exact_validation(
                     pool,
                     vector,

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -60,7 +60,8 @@ from optimization.backends.gpu_backend import (
     _single_scenario_metric_surface,
     _suite_limit_metric_value,
     _trailing_martingale_multicoin_bound_map,
-    _select_novel_validations,
+    _ProxyFrontValidationPending,
+    _select_exact_validations,
     _select_validation_indices,
     _update_probe_shortfall_log,
     _validate_directional_search_space,
@@ -2924,7 +2925,7 @@ def test_duplicate_broad_probe_is_replaced_by_novel_off_front_candidate():
         (3, True, False),
     ]
 
-    chosen = _select_novel_validations(
+    chosen = _select_exact_validations(
         selections,
         total=2,
         candidate_for_index=lambda index: [index],
@@ -2942,7 +2943,7 @@ def test_duplicate_broad_probe_is_replaced_by_novel_off_front_candidate():
 
 
 def test_duplicate_broad_probe_falls_back_to_novel_true_front_candidates():
-    chosen = _select_novel_validations(
+    chosen = _select_exact_validations(
         [(0, False, True), (1, True, False), (2, False, True)],
         total=2,
         candidate_for_index=lambda index: [index],
@@ -2978,7 +2979,7 @@ def test_unallocated_infeasible_fallback_does_not_restore_probe_quota():
     )
 
     assert selections[-1] == (4, True, False)
-    chosen = _select_novel_validations(
+    chosen = _select_exact_validations(
         selections,
         total=3,
         candidate_for_index=lambda index: [index],
@@ -3000,7 +3001,7 @@ def test_duplicate_fronts_do_not_expand_adaptive_probe_allocation():
         *((index, False, True) for index in range(12, 17)),
     ]
 
-    chosen = _select_novel_validations(
+    chosen = _select_exact_validations(
         selections,
         total=8,
         candidate_for_index=lambda index: [index],
@@ -3038,7 +3039,7 @@ def test_validation_batch_preserves_true_front_and_off_front_classification():
 
     # The complete feasible Pareto front has one member. The remaining seven
     # candidates must stay truthfully classified as broad/off-front evidence.
-    chosen = _select_novel_validations(
+    chosen = _select_exact_validations(
         selections,
         total=8,
         candidate_for_index=lambda index: [index],
@@ -3074,20 +3075,50 @@ def test_all_infeasible_validation_fallback_keeps_front_membership_explicit():
     )
 
 
-def test_validation_fails_closed_without_novel_proxy_front_evidence():
-    with pytest.raises(RuntimeError, match="novel proxy-front safety evidence"):
-        _select_novel_validations(
+def test_validation_revalidates_completed_current_front_instead_of_relabeling_probe():
+    chosen = _select_exact_validations(
+        [(0, False, True), (1, True, False), (2, True, False)],
+        total=2,
+        candidate_for_index=lambda index: [index],
+        digest_for_candidate=lambda candidate: f"hash-{candidate[0]}",
+        completed_hashes={"hash-0"},
+        submitted_hashes=set(),
+    )
+
+    assert [item[0] for item in chosen] == [1, 0]
+    assert chosen[0][1:3] == (True, False)
+    assert chosen[1][1:3] == (False, True)
+
+
+def test_validation_waits_for_submitted_current_front():
+    with pytest.raises(
+        _ProxyFrontValidationPending,
+        match="proxy-front exact validation is still in flight",
+    ):
+        _select_exact_validations(
             [(0, False, True), (1, True, False), (2, True, False)],
             total=2,
             candidate_for_index=lambda index: [index],
             digest_for_candidate=lambda candidate: f"hash-{candidate[0]}",
-            completed_hashes={"hash-0"},
+            completed_hashes=set(),
+            submitted_hashes={"hash-0"},
+        )
+
+
+def test_validation_fails_closed_when_selector_contains_no_front_candidate():
+    with pytest.raises(RuntimeError, match="truthful proxy-front safety evidence"):
+        _select_exact_validations(
+            [(0, True, False), (1, True, False)],
+            total=2,
+            candidate_for_index=lambda index: [index],
+            digest_for_candidate=lambda candidate: f"hash-{candidate[0]}",
+            completed_hashes=set(),
             submitted_hashes=set(),
         )
 
 
 def test_validation_scans_fallbacks_for_novel_proxy_front_before_failing():
-    chosen = _select_novel_validations(
+    chosen = _select_exact_validations(
         [
             (0, False, True),
             (1, True, False),


### PR DESCRIPTION
## Summary
- keep single-objective and converged Apple MPS searches running when the current proxy front repeats an already exact-validated candidate
- re-run the actual current-front candidate rather than relabeling an off-front candidate, preserving truthful proxy-front drift evidence
- wait for an in-flight current-front exact job before selecting another validation batch
- retire completed hashes from the in-flight set so exact revalidation is possible

## Safety
Exact Rust remains authoritative. Repeated current-front constraint disagreement continues to feed the proxy-front rolling gate and halts after the configured evidence threshold. Broad/off-front candidates are never relabeled as front evidence, and the existing exact-budget, rolling-window, checkpoint, and resume proofs remain intact. CPU optimization and bot/backtest behavior are unchanged.

## Validation
- full `tests/optimization` suite
- focused repeated/completed/in-flight/no-front selection regressions
- rebuilt and verified the Rust extension against source fingerprint `8015fda2867c40ebd34153fd1d9e93460de4d22c7e770bd4d304e940719d317f`
- AI documentation checks: 0 errors (2 pre-existing size warnings)
- cached Apple M3 single-objective HSL CLI reproducer: completed 71 generations, 1,136 MPS proxy evaluations, and all 142 exact validations in 15.7s; the prior code halted around generation 30 when the one-member front repeated
- `compileall` and `git diff --check`