### PR TITLE
Add MPS per-side raw HSL drawdown metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added raw per-side HSL strategy-equity worst-drawdown scoring and limits to Apple MPS
+  optimization for EMA Anchor and Trailing Martingale, across single-coin and multi-coin
+  topologies. The bounded peak-and-maximum state is compiled into Metal only when either the long
+  or short metric is requested; exact Rust validation and rolling drift gates remain authoritative.
+
 - Added mean-worst-1% EMA-smoothed HSL strategy-equity drawdown scoring and limits to Apple MPS
   optimization for the account, long side, and short side. The Metal proxy uses an opt-in bounded
   logarithmic histogram so normal GPU runs do not pay the per-candidate state cost; exact Rust
@@ -12,8 +17,8 @@ All notable user-facing changes will be documented in this file.
 - Added per-side HSL strategy-equity peak-recovery scoring and limits to Apple MPS optimization.
   EMA Anchor and Trailing Martingale kernels now retain the longest strict time-to-exceed interval
   for each long and short HSL controller, including an unrecovered tail through the backtest end,
-  and expose it in hours and days. Exact Rust validation remains authoritative; raw per-side
-  strategy-equity drawdown and recovery-distribution metrics remain fail closed.
+  and expose it in hours and days. Exact Rust validation remains authoritative;
+  recovery-distribution metrics remain fail closed.
 
 - Fixed Apple MPS optimization halting when a converged or single-objective proxy front repeats an
   already exact-validated candidate. The backend now revalidates that actual current-front member

--- a/docs/equity_hard_stop_loss_reference.md
+++ b/docs/equity_hard_stop_loss_reference.md
@@ -137,6 +137,7 @@ These are the main parity surfaces that should be reviewed together:
    - Dual-side multi-coin EMA Anchor uses a fused shared-account strategy kernel for unified, pside, and coin signals, including shared lifecycle/panic-loss metrics and per-coin HSL overrides in coin mode
    - Dual-side multi-coin Trailing Martingale uses a fused shared-account strategy kernel for unified, pside, and coin signals, including shared lifecycle/panic-loss metrics and per-coin HSL overrides in coin mode
    - Apple MPS exports the worst EMA-smoothed strategy-equity drawdown for long and short HSL controllers; the account metric is the same `max(long, short)` reduction as exact Rust
+   - Apple MPS exports the raw worst strategy-equity drawdown for each long and short HSL controller through opt-in bounded peak-and-maximum state; exact Rust validation remains authoritative for proxy-fill drift
    - Apple MPS exports each HSL controller's longest strict strategy-equity time-to-exceed interval as `peak_recovery_{hours,days}_strategy_eq_{long,short}`, including an unrecovered tail through the backtest end
 
 ### Confirmed Gaps / Risks
@@ -150,14 +151,13 @@ These are the main parity surfaces that should be reviewed together:
    - Deprecated `*_hsl` metric names remain accepted as aliases for older configs/results
 3. Remaining GPU HSL metric gaps
    - Strategy-equity recovery-distribution metrics need additional bounded per-side time-series state
-   - Raw per-side worst strategy-equity drawdown remains too sensitive to approximate proxy fill paths and stays fail closed pending a safer representation
 
 ### Missing or Weak Test Coverage
 
 1. End-to-end replay of one identical fill/candle history through live reconstruction and exact backtest orchestration; shared Rust primitive tests cover the calculations but not the complete orchestration trace
 2. Connector-level restart races while protective panic-close orders are live on an exchange
 3. Manual or external trading during downtime across the full exchange-adapter matrix
-4. Apple MPS parity for raw per-side worst drawdown and recovery-distribution metrics
+4. Apple MPS parity for strategy-equity recovery-distribution metrics
 
 ## Optimizer Work
 

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -170,8 +170,10 @@ The supported slice is intentionally narrow:
   `peak_recovery_hours_strategy_eq_{long,short}` and
   `peak_recovery_days_strategy_eq_{long,short}` retain the longest interval until strategy equity
   strictly exceeds its prior controller peak, including an unrecovered tail through the backtest
-  end. Raw per-side worst-drawdown and recovery-distribution metrics remain fail closed for now.
-  Compatible suites may use the supported topologies.
+  end. Raw per-side `drawdown_worst_strategy_eq_{long,short}` is also available through an opt-in
+  bounded peak-and-maximum accumulator, with exact Rust validation retaining authority over the
+  approximate fill path. Recovery-distribution metrics remain fail closed for now. Compatible
+  suites may use the supported topologies.
 - single-coin EMA Anchor and Trailing Martingale support auto-unstuck for long-only,
   short-only, hedge-mode dual-side, one-way, and compatible suite runs. One-sided multi-coin runs
   and compatible suites also support auto-unstuck, including static per-coin overrides. Metal

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -157,6 +157,13 @@ mod tests {
             assert_eq!(source.matches(signature).count(), 1, "{signature}");
         }
         assert!(source.contains("#define PASSIVBOT_HSL_EMA_TAIL_ENABLED 0"));
+        assert!(source.contains("#define PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED 0"));
+        assert_eq!(
+            source
+                .matches("inline float hsl_strategy_equity_drawdown_max(")
+                .count(),
+            1
+        );
         assert!(source
             .contains("const bool shared_has_position = has_position_long || has_position_short"));
         assert!(source.contains("const bool shared_has_blocking_orders = has_blocking_orders_long"));
@@ -320,6 +327,7 @@ mod tests {
         assert!(source.contains("constant int DAILY_COLS = 8"));
         assert!(source.contains("constant int SCALAR_COLS = 66"));
         assert!(source.contains("constant int SCALAR_COLS = 68"));
+        assert!(source.contains("constant int SCALAR_COLS = 70"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[so + 44] = loss_sum"));
         assert!(source.contains("scalars[so + 45] = position_unchanged_max_min * interval_ms"));
@@ -341,6 +349,8 @@ mod tests {
         assert!(source.contains("scalars[so + 65] = hsl_strategy_equity_recovery_max_steps("));
         assert!(source.contains("scalars[so + 66] = hsl_drawdown_ema_mean_worst_1pct("));
         assert!(source.contains("scalars[so + 67] = hsl_drawdown_ema_mean_worst_1pct("));
+        assert!(source.contains("scalars[so + 68] = hsl_strategy_equity_drawdown_max("));
+        assert!(source.contains("scalars[so + 69] = hsl_strategy_equity_drawdown_max("));
         assert!(source.contains("if (eqf >= account_peak)"));
         assert!(source.contains("constant int SIDE_PARAMS = 34"));
         assert!(source.contains("struct HslState"));
@@ -413,8 +423,10 @@ mod tests {
         assert!(source.contains("day_min_balance"));
         assert!(source.contains("constant int SCALAR_COLS = 61"));
         assert!(source.contains("constant int SCALAR_COLS = 63"));
+        assert!(source.contains("constant int SCALAR_COLS = 65"));
         assert!(source.contains("constant int FUSED_SCALAR_COLS = 66"));
         assert!(source.contains("constant int FUSED_SCALAR_COLS = 68"));
+        assert!(source.contains("constant int FUSED_SCALAR_COLS = 70"));
         assert_eq!(source.matches("struct EmaMulticoinSideState").count(), 1);
         assert_eq!(source.matches("struct EmaMulticoinSideConfig").count(), 1);
         assert_eq!(source.matches("struct EmaMulticoinFillState").count(), 1);
@@ -447,6 +459,7 @@ mod tests {
         assert!(source.contains("write_dual_side_coin_hsl_outputs("));
         assert!(source.contains("hsl_strategy_equity_recovery_max_steps("));
         assert!(source.contains("hsl_drawdown_ema_mean_worst_1pct("));
+        assert!(source.contains("hsl_strategy_equity_drawdown_max("));
         assert!(source.contains("long_coin_overrides, short_coin_overrides"));
         assert!(source.contains("net_position_cost -= short_side.psize[c]"));
         assert!(source.contains(
@@ -575,6 +588,7 @@ mod tests {
         assert!(source.contains("try_restart_hsl("));
         assert!(source.contains("constant int SCALAR_COLS = 66"));
         assert!(source.contains("constant int SCALAR_COLS = 68"));
+        assert!(source.contains("constant int SCALAR_COLS = 70"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[so + 44] = loss_sum"));
         assert!(source.contains("scalars[so + 45] = position_unchanged_max_min * interval_ms"));
@@ -596,6 +610,8 @@ mod tests {
         assert!(source.contains("scalars[so + 65] = hsl_strategy_equity_recovery_max_steps("));
         assert!(source.contains("scalars[so + 66] = hsl_drawdown_ema_mean_worst_1pct("));
         assert!(source.contains("scalars[so + 67] = hsl_drawdown_ema_mean_worst_1pct("));
+        assert!(source.contains("scalars[so + 68] = hsl_strategy_equity_drawdown_max("));
+        assert!(source.contains("scalars[so + 69] = hsl_strategy_equity_drawdown_max("));
         assert!(source.contains("if (eqf >= account_peak)"));
         assert!(source.contains("hsl_tier_samples_total"));
         assert!(source.contains("h.restart_retrigger_count"));
@@ -708,8 +724,10 @@ mod tests {
         assert!(source.contains("constant int COIN_COLS = 12"));
         assert!(source.contains("constant int SCALAR_COLS = 61"));
         assert!(source.contains("constant int SCALAR_COLS = 63"));
+        assert!(source.contains("constant int SCALAR_COLS = 65"));
         assert!(source.contains("constant int FUSED_SCALAR_COLS = 66"));
         assert!(source.contains("constant int FUSED_SCALAR_COLS = 68"));
+        assert!(source.contains("constant int FUSED_SCALAR_COLS = 70"));
         assert_eq!(
             source
                 .matches("struct TrailingMartingaleMulticoinSideState")

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -2,7 +2,9 @@
 using namespace metal;
 
 constant int DAILY_COLS = 8;
-#if PASSIVBOT_HSL_EMA_TAIL_ENABLED
+#if PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
+constant int SCALAR_COLS = 70;
+#elif PASSIVBOT_HSL_EMA_TAIL_ENABLED
 constant int SCALAR_COLS = 68;
 #else
 constant int SCALAR_COLS = 66;
@@ -1773,6 +1775,10 @@ inline void passivbot_single_coin_impl(
 #if PASSIVBOT_HSL_EMA_TAIL_ENABLED
     scalars[so + 66] = hsl_drawdown_ema_mean_worst_1pct(long_hsl_ema_tail);
     scalars[so + 67] = hsl_drawdown_ema_mean_worst_1pct(short_hsl_ema_tail);
+#endif
+#if PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
+    scalars[so + 68] = hsl_strategy_equity_drawdown_max(long_hsl_strategy_eq);
+    scalars[so + 69] = hsl_strategy_equity_drawdown_max(short_hsl_strategy_eq);
 #endif
 }
 

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -7,7 +7,10 @@ constant int COIN_COLS = 12;
 constant int OVERRIDE_COLS = 29;
 constant int HSL_OVERRIDE_START = 19;
 constant int DAILY_COLS = 9;
-#if PASSIVBOT_HSL_EMA_TAIL_ENABLED
+#if PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
+constant int SCALAR_COLS = 65;
+constant int FUSED_SCALAR_COLS = 70;
+#elif PASSIVBOT_HSL_EMA_TAIL_ENABLED
 constant int SCALAR_COLS = 63;
 constant int FUSED_SCALAR_COLS = 68;
 #else
@@ -2496,6 +2499,12 @@ inline void passivbot_ema_anchor_multicoin_impl(
     scalars[scalar_offset + 62] = short_side
         ? hsl_drawdown_ema_mean_worst_1pct(side.hsl_ema_tail) : 0.0f;
 #endif
+#if PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
+    scalars[scalar_offset + 63] = short_side ? 0.0f
+        : hsl_strategy_equity_drawdown_max(side.hsl_strategy_eq);
+    scalars[scalar_offset + 64] = short_side
+        ? hsl_strategy_equity_drawdown_max(side.hsl_strategy_eq) : 0.0f;
+#endif
 }
 
 inline float ema_multicoin_entry_initial_balance_pct(
@@ -3095,6 +3104,14 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
     );
     scalars[scalar_offset + 67] = hsl_drawdown_ema_mean_worst_1pct(
         short_side.hsl_ema_tail
+    );
+#endif
+#if PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
+    scalars[scalar_offset + 68] = hsl_strategy_equity_drawdown_max(
+        long_side.hsl_strategy_eq
+    );
+    scalars[scalar_offset + 69] = hsl_strategy_equity_drawdown_max(
+        short_side.hsl_strategy_eq
     );
 #endif
 }

--- a/passivbot-rust/src/gpu/mps_hsl_common.metal
+++ b/passivbot-rust/src/gpu/mps_hsl_common.metal
@@ -7,6 +7,10 @@
 #define PASSIVBOT_HSL_EMA_TAIL_ENABLED 0
 #endif
 
+#ifndef PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
+#define PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED 0
+#endif
+
 #define HSL_EMA_TAIL_BINS 32
 
 constant int HSL_SIGNAL_UNIFIED = 0;
@@ -228,6 +232,9 @@ struct HslStrategyEquityStats {
     float peak_sample_k;
     float last_sample_k;
     float recovery_max_steps;
+#if PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
+    float drawdown_max;
+#endif
 };
 
 inline HslStrategyEquityStats init_hsl_strategy_equity_stats() {
@@ -237,6 +244,9 @@ inline HslStrategyEquityStats init_hsl_strategy_equity_stats() {
     stats.peak_sample_k = -1.0f;
     stats.last_sample_k = -1.0f;
     stats.recovery_max_steps = 0.0f;
+#if PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
+    stats.drawdown_max = 0.0f;
+#endif
     return stats;
 }
 
@@ -262,6 +272,22 @@ inline void update_hsl_strategy_equity_stats(
         stats.peak = strategy_equity;
         stats.peak_sample_k = sample_k;
     }
+#if PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
+    stats.drawdown_max = fmax(
+        stats.drawdown_max,
+        (stats.peak - strategy_equity) / fmax(fabs(stats.peak), 1.0e-12f)
+    );
+#endif
+}
+
+inline float hsl_strategy_equity_drawdown_max(
+    thread HslStrategyEquityStats& stats
+) {
+#if PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
+    return stats.drawdown_max;
+#else
+    return 0.0f;
+#endif
 }
 
 inline float hsl_strategy_equity_recovery_max_steps(

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -2,7 +2,9 @@
 using namespace metal;
 
 constant int DAILY_COLS = 8;
-#if PASSIVBOT_HSL_EMA_TAIL_ENABLED
+#if PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
+constant int SCALAR_COLS = 70;
+#elif PASSIVBOT_HSL_EMA_TAIL_ENABLED
 constant int SCALAR_COLS = 68;
 #else
 constant int SCALAR_COLS = 66;
@@ -2909,6 +2911,10 @@ inline void passivbot_single_coin_impl(
 #if PASSIVBOT_HSL_EMA_TAIL_ENABLED
     scalars[so + 66] = hsl_drawdown_ema_mean_worst_1pct(long_hsl_ema_tail);
     scalars[so + 67] = hsl_drawdown_ema_mean_worst_1pct(short_hsl_ema_tail);
+#endif
+#if PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
+    scalars[so + 68] = hsl_strategy_equity_drawdown_max(long_hsl_strategy_eq);
+    scalars[so + 69] = hsl_strategy_equity_drawdown_max(short_hsl_strategy_eq);
 #endif
 }
 

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -7,7 +7,10 @@ constant int OVERRIDE_COLS = 44;
 constant int HSL_OVERRIDE_START = 34;
 constant int COIN_COLS = 12;
 constant int DAILY_COLS = 9;
-#if PASSIVBOT_HSL_EMA_TAIL_ENABLED
+#if PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
+constant int SCALAR_COLS = 65;
+constant int FUSED_SCALAR_COLS = 70;
+#elif PASSIVBOT_HSL_EMA_TAIL_ENABLED
 constant int SCALAR_COLS = 63;
 constant int FUSED_SCALAR_COLS = 68;
 #else
@@ -3560,6 +3563,14 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
         short_side.hsl_ema_tail
     );
 #endif
+#if PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
+    scalars[scalar_offset + 68] = hsl_strategy_equity_drawdown_max(
+        long_side.hsl_strategy_eq
+    );
+    scalars[scalar_offset + 69] = hsl_strategy_equity_drawdown_max(
+        short_side.hsl_strategy_eq
+    );
+#endif
 }
 
 kernel void passivbot_trailing_martingale_multicoin_fused(
@@ -4102,6 +4113,12 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         : hsl_drawdown_ema_mean_worst_1pct(side.hsl_ema_tail);
     scalars[scalar_offset + 62] = short_side
         ? hsl_drawdown_ema_mean_worst_1pct(side.hsl_ema_tail) : 0.0f;
+#endif
+#if PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
+    scalars[scalar_offset + 63] = short_side ? 0.0f
+        : hsl_strategy_equity_drawdown_max(side.hsl_strategy_eq);
+    scalars[scalar_offset + 64] = short_side
+        ? hsl_strategy_equity_drawdown_max(side.hsl_strategy_eq) : 0.0f;
 #endif
 }
 

--- a/src/config/scoring.py
+++ b/src/config/scoring.py
@@ -76,6 +76,8 @@ DEFAULT_OBJECTIVE_GOALS = {
     "calmar_ratio_strategy_eq_w": "max",
     "sterling_ratio_strategy_eq_w": "max",
     "drawdown_worst_strategy_eq": "min",
+    "drawdown_worst_strategy_eq_long": "min",
+    "drawdown_worst_strategy_eq_short": "min",
     "drawdown_worst_ema_strategy_eq": "min",
     "drawdown_worst_ema_strategy_eq_long": "min",
     "drawdown_worst_ema_strategy_eq_short": "min",

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -57,6 +57,8 @@ SUPPORTED_METRICS = (
     "calmar_ratio_strategy_eq",
     "calmar_ratio_strategy_eq_w",
     "drawdown_worst_mean_1pct_strategy_eq",
+    "drawdown_worst_strategy_eq_long",
+    "drawdown_worst_strategy_eq_short",
     "drawdown_worst_mean_1pct_ema_strategy_eq",
     "drawdown_worst_mean_1pct_ema_strategy_eq_long",
     "drawdown_worst_mean_1pct_ema_strategy_eq_short",
@@ -249,6 +251,10 @@ _HARD_STOP_EMA_DRAWDOWN_METRICS = {
     "drawdown_worst_ema_strategy_eq",
     "drawdown_worst_ema_strategy_eq_long",
     "drawdown_worst_ema_strategy_eq_short",
+}
+_HARD_STOP_RAW_DRAWDOWN_METRICS = {
+    "drawdown_worst_strategy_eq_long",
+    "drawdown_worst_strategy_eq_short",
 }
 _HARD_STOP_EMA_TAIL_METRICS = {
     "drawdown_worst_mean_1pct_ema_strategy_eq",
@@ -1186,6 +1192,25 @@ def _hard_stop_ema_drawdown_metrics(out: dict) -> dict:
     }
 
 
+def _hard_stop_raw_drawdown_metrics(out: dict) -> dict:
+    """Expose per-side worst raw HSL strategy-equity drawdown."""
+
+    required = {"hsl_drawdown_raw_max_long", "hsl_drawdown_raw_max_short"}
+    if missing := required.difference(out):
+        raise RuntimeError(
+            "MPS directional HSL raw-drawdown outputs are missing from proxy "
+            "results: " + ", ".join(sorted(missing))
+        )
+    return {
+        "drawdown_worst_strategy_eq_long": out[
+            "hsl_drawdown_raw_max_long"
+        ].to(torch.float64),
+        "drawdown_worst_strategy_eq_short": out[
+            "hsl_drawdown_raw_max_short"
+        ].to(torch.float64),
+    }
+
+
 def _hard_stop_ema_tail_metrics(out: dict) -> dict:
     """Reduce bounded per-side HSL EMA tails using Rust's public contract."""
 
@@ -1428,6 +1453,11 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
         if requested & _HARD_STOP_EMA_DRAWDOWN_METRICS
         else {}
     )
+    hard_stop_raw_drawdown_metrics = (
+        _hard_stop_raw_drawdown_metrics(out)
+        if requested & _HARD_STOP_RAW_DRAWDOWN_METRICS
+        else {}
+    )
     hard_stop_ema_tail_metrics = (
         _hard_stop_ema_tail_metrics(out)
         if requested & _HARD_STOP_EMA_TAIL_METRICS
@@ -1489,6 +1519,7 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
         "volume_pct_per_day_avg": volume_pct,
     }
     objectives.update(hard_stop_ema_drawdown_metrics)
+    objectives.update(hard_stop_raw_drawdown_metrics)
     objectives.update(hard_stop_ema_tail_metrics)
     objectives.update(hard_stop_strategy_eq_recovery_metrics)
     if "loss_profit_ratio" in requested:

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -22,14 +22,18 @@ MPS_DAILY_COLS = 8
 MPS_MULTICOIN_DAILY_COLS = 9
 MPS_SCALAR_COLS = 32
 MPS_MULTICOIN_BASE_SCALAR_COLS = 61
-MPS_MULTICOIN_SCALAR_COLS = 63
+MPS_MULTICOIN_EMA_TAIL_SCALAR_COLS = 63
+MPS_MULTICOIN_SCALAR_COLS = 65
 MPS_DIRECTIONAL_BASE_SCALAR_COLS = 66
-MPS_DIRECTIONAL_SCALAR_COLS = 68
+MPS_DIRECTIONAL_EMA_TAIL_SCALAR_COLS = 68
+MPS_DIRECTIONAL_SCALAR_COLS = 70
 MPS_MULTICOIN_FUSED_BASE_SCALAR_COLS = 66
-MPS_MULTICOIN_FUSED_SCALAR_COLS = 68
+MPS_MULTICOIN_FUSED_EMA_TAIL_SCALAR_COLS = 68
+MPS_MULTICOIN_FUSED_SCALAR_COLS = 70
 MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY = 2048
 
 _HSL_EMA_TAIL_DEFINE = "#define PASSIVBOT_HSL_EMA_TAIL_ENABLED 1\n"
+_HSL_RAW_DRAWDOWN_DEFINE = "#define PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED 1\n"
 
 
 def _with_hsl_ema_tail(source: str, enabled: bool) -> str:
@@ -38,6 +42,20 @@ def _with_hsl_ema_tail(source: str, enabled: bool) -> str:
     if "#ifndef PASSIVBOT_HSL_EMA_TAIL_ENABLED" not in source:
         raise RuntimeError("MPS source is missing the HSL EMA-tail feature guard")
     return _HSL_EMA_TAIL_DEFINE + source
+
+
+def _with_hsl_features(
+    source: str,
+    *,
+    ema_tail_enabled: bool,
+    raw_drawdown_enabled: bool,
+) -> str:
+    source = _with_hsl_ema_tail(source, ema_tail_enabled)
+    if not raw_drawdown_enabled:
+        return source
+    if "#ifndef PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED" not in source:
+        raise RuntimeError("MPS source is missing the HSL raw-drawdown feature guard")
+    return _HSL_RAW_DRAWDOWN_DEFINE + source
 
 
 def _encode_max_realized_loss_pct(value: float) -> float:
@@ -57,29 +75,38 @@ def _scalar_column_or_zero(scalars, index: int):
     return torch.zeros_like(scalars[:, 0])
 
 
-@lru_cache(maxsize=2)
-def _shader_library(hsl_ema_tail_enabled: bool = False):
+@lru_cache(maxsize=4)
+def _shader_library(
+    hsl_ema_tail_enabled: bool = False,
+    hsl_raw_drawdown_enabled: bool = False,
+):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
     return torch.mps.compile_shader(
-        _with_hsl_ema_tail(
-            passivbot_rust.mps_ema_anchor_source_py(), hsl_ema_tail_enabled
+        _with_hsl_features(
+            passivbot_rust.mps_ema_anchor_source_py(),
+            ema_tail_enabled=hsl_ema_tail_enabled,
+            raw_drawdown_enabled=hsl_raw_drawdown_enabled,
         )
     )
 
 
-@lru_cache(maxsize=2)
-def _trailing_martingale_shader_library(hsl_ema_tail_enabled: bool = False):
+@lru_cache(maxsize=4)
+def _trailing_martingale_shader_library(
+    hsl_ema_tail_enabled: bool = False,
+    hsl_raw_drawdown_enabled: bool = False,
+):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
     return torch.mps.compile_shader(
-        _with_hsl_ema_tail(
+        _with_hsl_features(
             passivbot_rust.mps_trailing_martingale_source_py(),
-            hsl_ema_tail_enabled,
+            ema_tail_enabled=hsl_ema_tail_enabled,
+            raw_drawdown_enabled=hsl_raw_drawdown_enabled,
         )
     )
 
@@ -106,32 +133,38 @@ def _trailing_martingale_short_no_hsl_shader_library():
     )
 
 
-@lru_cache(maxsize=2)
-def _ema_anchor_multicoin_shader_library(hsl_ema_tail_enabled: bool = False):
-    if not torch.backends.mps.is_available():
-        raise RuntimeError("Apple MPS is not available in this process")
-    import passivbot_rust
-
-    return torch.mps.compile_shader(
-        _with_hsl_ema_tail(
-            passivbot_rust.mps_ema_anchor_multicoin_source_py(),
-            hsl_ema_tail_enabled,
-        )
-    )
-
-
-@lru_cache(maxsize=2)
-def _trailing_martingale_multicoin_shader_library(
+@lru_cache(maxsize=4)
+def _ema_anchor_multicoin_shader_library(
     hsl_ema_tail_enabled: bool = False,
+    hsl_raw_drawdown_enabled: bool = False,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
     return torch.mps.compile_shader(
-        _with_hsl_ema_tail(
+        _with_hsl_features(
+            passivbot_rust.mps_ema_anchor_multicoin_source_py(),
+            ema_tail_enabled=hsl_ema_tail_enabled,
+            raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+        )
+    )
+
+
+@lru_cache(maxsize=4)
+def _trailing_martingale_multicoin_shader_library(
+    hsl_ema_tail_enabled: bool = False,
+    hsl_raw_drawdown_enabled: bool = False,
+):
+    if not torch.backends.mps.is_available():
+        raise RuntimeError("Apple MPS is not available in this process")
+    import passivbot_rust
+
+    return torch.mps.compile_shader(
+        _with_hsl_features(
             passivbot_rust.mps_trailing_martingale_multicoin_source_py(),
-            hsl_ema_tail_enabled,
+            ema_tail_enabled=hsl_ema_tail_enabled,
+            raw_drawdown_enabled=hsl_raw_drawdown_enabled,
         )
     )
 
@@ -230,6 +263,8 @@ def _decode_outputs(daily, scalars, gaps) -> dict:
         "hsl_drawdown_ema_mean_worst_1pct_short": _scalar_column_or_zero(
             scalars, 62
         ),
+        "hsl_drawdown_raw_max_long": _scalar_column_or_zero(scalars, 63),
+        "hsl_drawdown_raw_max_short": _scalar_column_or_zero(scalars, 64),
     }
 
 
@@ -252,6 +287,8 @@ def _decode_multicoin_fused_outputs(daily, scalars, gaps) -> dict:
             "hsl_drawdown_ema_mean_worst_1pct_short": _scalar_column_or_zero(
                 scalars, 67
             ),
+            "hsl_drawdown_raw_max_long": _scalar_column_or_zero(scalars, 68),
+            "hsl_drawdown_raw_max_short": _scalar_column_or_zero(scalars, 69),
         }
     )
     return output
@@ -350,6 +387,8 @@ def _decode_directional_outputs(daily, scalars, gaps) -> dict:
         "hsl_drawdown_ema_mean_worst_1pct_short": _scalar_column_or_zero(
             scalars, 67
         ),
+        "hsl_drawdown_raw_max_long": _scalar_column_or_zero(scalars, 68),
+        "hsl_drawdown_raw_max_short": _scalar_column_or_zero(scalars, 69),
     }
 
 
@@ -373,6 +412,7 @@ class MpsEmaAnchorRunner:
         hsl_panic_market_short: bool = False,
         pnl_lookback_bars: int = 0,
         hsl_ema_tail_enabled: bool = False,
+        hsl_raw_drawdown_enabled: bool = False,
     ):
         self.market = market
         self.run_config = run
@@ -405,6 +445,7 @@ class MpsEmaAnchorRunner:
             raise ValueError("pnl_lookback_bars must be non-negative")
         self.pnl_lookback_bars = pnl_lookback_bars
         self.hsl_ema_tail_enabled = bool(hsl_ema_tail_enabled)
+        self.hsl_raw_drawdown_enabled = bool(hsl_raw_drawdown_enabled)
         self.rolling_capacity = (
             MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY
             if pnl_lookback_bars > 0
@@ -502,8 +543,12 @@ class MpsEmaAnchorRunner:
                         (
                             batch_size,
                             MPS_DIRECTIONAL_SCALAR_COLS
-                            if self.hsl_ema_tail_enabled
-                            else MPS_DIRECTIONAL_BASE_SCALAR_COLS,
+                            if self.hsl_raw_drawdown_enabled
+                            else (
+                                MPS_DIRECTIONAL_EMA_TAIL_SCALAR_COLS
+                                if self.hsl_ema_tail_enabled
+                                else MPS_DIRECTIONAL_BASE_SCALAR_COLS
+                            ),
                         ),
                         dtype=torch.float32,
                         device="mps",
@@ -560,7 +605,10 @@ class MpsEmaAnchorRunner:
                 device="mps",
             )
         prepared = time.perf_counter()
-        library = _shader_library(self.hsl_ema_tail_enabled)
+        library = _shader_library(
+            self.hsl_ema_tail_enabled,
+            self.hsl_raw_drawdown_enabled,
+        )
         compiled = time.perf_counter()
         if profile:
             torch.mps.synchronize()
@@ -613,6 +661,7 @@ class MpsEmaAnchorMulticoinRunner:
         market_order_slippage_pct: float = 0.0,
         hsl_panic_market: bool = False,
         hsl_ema_tail_enabled: bool = False,
+        hsl_raw_drawdown_enabled: bool = False,
     ):
         if side not in {"long", "short"}:
             raise ValueError(
@@ -621,10 +670,24 @@ class MpsEmaAnchorMulticoinRunner:
         self.side = side
         self.collect_coin_fill_counts = bool(collect_coin_fill_counts)
         self.hsl_ema_tail_enabled = bool(hsl_ema_tail_enabled)
-        if not self.hsl_ema_tail_enabled:
+        self.hsl_raw_drawdown_enabled = bool(hsl_raw_drawdown_enabled)
+        fused = self.scalar_cols == MPS_MULTICOIN_FUSED_SCALAR_COLS
+        if self.hsl_raw_drawdown_enabled:
+            self.scalar_cols = (
+                MPS_MULTICOIN_FUSED_SCALAR_COLS
+                if fused
+                else MPS_MULTICOIN_SCALAR_COLS
+            )
+        elif self.hsl_ema_tail_enabled:
+            self.scalar_cols = (
+                MPS_MULTICOIN_FUSED_EMA_TAIL_SCALAR_COLS
+                if fused
+                else MPS_MULTICOIN_EMA_TAIL_SCALAR_COLS
+            )
+        else:
             self.scalar_cols = (
                 MPS_MULTICOIN_FUSED_BASE_SCALAR_COLS
-                if self.scalar_cols == MPS_MULTICOIN_FUSED_SCALAR_COLS
+                if fused
                 else MPS_MULTICOIN_BASE_SCALAR_COLS
             )
         self.run_config = run
@@ -797,7 +860,10 @@ class MpsEmaAnchorMulticoinRunner:
         )
 
     def _library(self):
-        return _ema_anchor_multicoin_shader_library(self.hsl_ema_tail_enabled)
+        return _ema_anchor_multicoin_shader_library(
+            self.hsl_ema_tail_enabled,
+            self.hsl_raw_drawdown_enabled,
+        )
 
     def _decode(self, daily, scalars, gaps) -> dict:
         return _decode_outputs(daily, scalars, gaps)
@@ -886,6 +952,7 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
         hsl_panic_market_long: bool = False,
         hsl_panic_market_short: bool = False,
         hsl_ema_tail_enabled: bool = False,
+        hsl_raw_drawdown_enabled: bool = False,
     ):
         super().__init__(
             run,
@@ -898,6 +965,7 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
             market_order_slippage_pct=market_order_slippage_pct,
             hsl_panic_market=hsl_panic_market_long,
             hsl_ema_tail_enabled=hsl_ema_tail_enabled,
+            hsl_raw_drawdown_enabled=hsl_raw_drawdown_enabled,
         )
         if short_coin_overrides is None:
             short_coin_overrides = np.full(
@@ -1018,6 +1086,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
         market_order_slippage_pct: float = 0.0,
         hsl_panic_market: bool = False,
         hsl_ema_tail_enabled: bool = False,
+        hsl_raw_drawdown_enabled: bool = False,
     ):
         super().__init__(
             run,
@@ -1030,6 +1099,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             market_order_slippage_pct=market_order_slippage_pct,
             hsl_panic_market=hsl_panic_market,
             hsl_ema_tail_enabled=hsl_ema_tail_enabled,
+            hsl_raw_drawdown_enabled=hsl_raw_drawdown_enabled,
         )
 
     def _pack_params(self, params: np.ndarray) -> np.ndarray:
@@ -1044,7 +1114,8 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
 
     def _library(self):
         return _trailing_martingale_multicoin_shader_library(
-            self.hsl_ema_tail_enabled
+            self.hsl_ema_tail_enabled,
+            self.hsl_raw_drawdown_enabled,
         )
 
     def _dispatch(
@@ -1105,6 +1176,7 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
         hsl_panic_market_long: bool = False,
         hsl_panic_market_short: bool = False,
         hsl_ema_tail_enabled: bool = False,
+        hsl_raw_drawdown_enabled: bool = False,
     ):
         super().__init__(
             run,
@@ -1117,6 +1189,7 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
             market_order_slippage_pct=market_order_slippage_pct,
             hsl_panic_market=hsl_panic_market_long,
             hsl_ema_tail_enabled=hsl_ema_tail_enabled,
+            hsl_raw_drawdown_enabled=hsl_raw_drawdown_enabled,
         )
         if short_coin_overrides is None:
             short_coin_overrides = np.full(
@@ -1220,13 +1293,17 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
         # keep that faster topology and let the decoder synthesize zeroes.
         if self.shader_topology != "generic":
             self.hsl_ema_tail_enabled = False
+            self.hsl_raw_drawdown_enabled = False
 
     def _shader_library(self):
         if self.shader_topology == "long_no_hsl":
             return _trailing_martingale_long_no_hsl_shader_library()
         if self.shader_topology == "short_no_hsl":
             return _trailing_martingale_short_no_hsl_shader_library()
-        return _trailing_martingale_shader_library(self.hsl_ema_tail_enabled)
+        return _trailing_martingale_shader_library(
+            self.hsl_ema_tail_enabled,
+            self.hsl_raw_drawdown_enabled,
+        )
 
     def _pack_params(self, params: np.ndarray) -> np.ndarray:
         expected = len(TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS) * 2

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -105,6 +105,8 @@ DIRECTIONAL_HSL_OUTPUT_KEYS = {
     "hsl_strategy_eq_recovery_max_ms_short",
     "hsl_drawdown_ema_mean_worst_1pct_long",
     "hsl_drawdown_ema_mean_worst_1pct_short",
+    "hsl_drawdown_raw_max_long",
+    "hsl_drawdown_raw_max_short",
 }
 
 
@@ -213,6 +215,10 @@ _HSL_EMA_TAIL_METRICS = {
     "drawdown_worst_mean_1pct_ema_strategy_eq",
     "drawdown_worst_mean_1pct_ema_strategy_eq_long",
     "drawdown_worst_mean_1pct_ema_strategy_eq_short",
+}
+_HSL_RAW_DRAWDOWN_METRICS = {
+    "drawdown_worst_strategy_eq_long",
+    "drawdown_worst_strategy_eq_short",
 }
 
 
@@ -687,6 +693,8 @@ def _combine_hedged_multicoin_hsl_outputs(long: dict, short: dict) -> dict:
         "hsl_drawdown_ema_max_short",
         "hsl_drawdown_ema_mean_worst_1pct_long",
         "hsl_drawdown_ema_mean_worst_1pct_short",
+        "hsl_drawdown_raw_max_long",
+        "hsl_drawdown_raw_max_short",
         "hsl_strategy_eq_recovery_max_ms_long",
         "hsl_strategy_eq_recovery_max_ms_short",
     ):
@@ -1186,6 +1194,9 @@ class MpsSingleCoinProxy:
             pnl_lookback_bars=pnl_lookback_bars,
             hsl_ema_tail_enabled=bool(
                 self.needed_metrics & _HSL_EMA_TAIL_METRICS
+            ),
+            hsl_raw_drawdown_enabled=bool(
+                self.needed_metrics & _HSL_RAW_DRAWDOWN_METRICS
             ),
         )
         if self.strategy_kind == "trailing_martingale":
@@ -1955,6 +1966,9 @@ class MpsMulticoinProxy:
             ),
             "hsl_ema_tail_enabled": bool(
                 self.needed_metrics & _HSL_EMA_TAIL_METRICS
+            ),
+            "hsl_raw_drawdown_enabled": bool(
+                self.needed_metrics & _HSL_RAW_DRAWDOWN_METRICS
             ),
         }
         if self.shared_account_fused:

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -869,6 +869,36 @@ def test_hard_stop_ema_drawdown_metrics_fail_closed_without_directional_outputs(
         )
 
 
+def test_hard_stop_raw_drawdown_metrics_map_each_side():
+    from optimization.gpu.metrics import _hard_stop_raw_drawdown_metrics
+
+    metrics = _hard_stop_raw_drawdown_metrics(
+        {
+            "hsl_drawdown_raw_max_long": torch.tensor([0.17, 0.0]),
+            "hsl_drawdown_raw_max_short": torch.tensor([0.08, 0.23]),
+        }
+    )
+
+    assert metrics["drawdown_worst_strategy_eq_long"].tolist() == pytest.approx(
+        [0.17, 0.0]
+    )
+    assert metrics["drawdown_worst_strategy_eq_short"].tolist() == pytest.approx(
+        [0.08, 0.23]
+    )
+
+
+def test_hard_stop_raw_drawdown_metrics_fail_closed_without_outputs():
+    from optimization.gpu.metrics import _hard_stop_raw_drawdown_metrics
+
+    with pytest.raises(RuntimeError, match="raw-drawdown outputs are missing"):
+        _hard_stop_raw_drawdown_metrics({})
+
+    with pytest.raises(RuntimeError, match="hsl_drawdown_raw_max_short"):
+        _hard_stop_raw_drawdown_metrics(
+            {"hsl_drawdown_raw_max_long": torch.tensor([0.1])}
+        )
+
+
 def test_hard_stop_ema_tail_reduction_matches_rust_side_max_contract():
     from optimization.gpu.metrics import _hard_stop_ema_tail_metrics
 

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -25,6 +25,7 @@ from optimization.gpu.mps_kernel import (
     _decode_multicoin_fused_outputs,
     _encode_max_realized_loss_pct,
     _with_hsl_ema_tail,
+    _with_hsl_features,
 )
 from optimization.gpu.metrics import _fill_gap_metrics, compute_objectives
 from optimization.gpu.service import MpsMulticoinEmaProxy
@@ -100,7 +101,7 @@ def test_decode_multicoin_fused_outputs_maps_directional_reductions():
     daily = torch.zeros((1, 1, 9), dtype=torch.float32)
     daily[:, :, 1].fill_(float("inf"))
     daily[:, :, 5].fill_(float("inf"))
-    scalars = torch.arange(68, dtype=torch.float32).reshape(1, 68)
+    scalars = torch.arange(70, dtype=torch.float32).reshape(1, 70)
     gaps = torch.zeros((1, 128), dtype=torch.int32)
 
     output = _decode_multicoin_fused_outputs(daily, scalars, gaps)
@@ -126,6 +127,8 @@ def test_decode_multicoin_fused_outputs_maps_directional_reductions():
     assert torch.equal(
         output["hsl_drawdown_ema_mean_worst_1pct_short"], scalars[:, 67]
     )
+    assert torch.equal(output["hsl_drawdown_raw_max_long"], scalars[:, 68])
+    assert torch.equal(output["hsl_drawdown_raw_max_short"], scalars[:, 69])
 
 
 def test_hsl_ema_tail_source_variant_is_opt_in_and_guarded():
@@ -137,6 +140,21 @@ def test_hsl_ema_tail_source_variant_is_opt_in_and_guarded():
     )
     with pytest.raises(RuntimeError, match="feature guard"):
         _with_hsl_ema_tail("body", True)
+
+
+def test_hsl_raw_drawdown_source_variant_is_opt_in_and_guarded():
+    source = "#ifndef PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED\nbody"
+
+    assert _with_hsl_features(
+        source, ema_tail_enabled=False, raw_drawdown_enabled=False
+    ) is source
+    assert _with_hsl_features(
+        source, ema_tail_enabled=False, raw_drawdown_enabled=True
+    ) == ("#define PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED 1\n" + source)
+    with pytest.raises(RuntimeError, match="raw-drawdown feature guard"):
+        _with_hsl_features(
+            "body", ema_tail_enabled=False, raw_drawdown_enabled=True
+        )
 
 
 def test_trailing_martingale_no_hsl_specialization_keeps_base_scalar_abi(
@@ -151,6 +169,9 @@ def test_trailing_martingale_no_hsl_specialization_keeps_base_scalar_abi(
         self.long_enabled = True
         self.short_enabled = False
         self.hsl_ema_tail_enabled = bool(kwargs["hsl_ema_tail_enabled"])
+        self.hsl_raw_drawdown_enabled = bool(
+            kwargs["hsl_raw_drawdown_enabled"]
+        )
 
     monkeypatch.setattr(MpsEmaAnchorRunner, "__init__", fake_base_init)
     runner = MpsTrailingMartingaleRunner(
@@ -159,10 +180,12 @@ def test_trailing_martingale_no_hsl_specialization_keeps_base_scalar_abi(
         None,
         hsl_enabled=False,
         hsl_ema_tail_enabled=True,
+        hsl_raw_drawdown_enabled=True,
     )
 
     assert runner.shader_topology == "long_no_hsl"
     assert runner.hsl_ema_tail_enabled is False
+    assert runner.hsl_raw_drawdown_enabled is False
 
 
 @pytest.mark.skipif(
@@ -359,6 +382,46 @@ kernel void passivbot_hsl_drawdown_ema_tail_probe(
 
     # floor(200 * 1%) is two, and the two worst values occupy the highest bin.
     assert output.item() == pytest.approx(0.4, abs=1.0e-6)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_hsl_strategy_equity_raw_drawdown_matches_exact_peak_contract():
+    import passivbot_rust
+
+    probe_kernel = r"""
+kernel void passivbot_hsl_strategy_equity_raw_drawdown_probe(
+    constant float* samples,
+    device float* output,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    HslStrategyEquityStats stats = init_hsl_strategy_equity_stats();
+    for (int k = 0; k < 5; ++k) {
+        update_hsl_strategy_equity_stats(stats, samples[k]);
+    }
+    output[0] = hsl_strategy_equity_drawdown_max(stats);
+}
+"""
+    samples = torch.tensor(
+        [100.0, 90.0, 110.0, 88.0, 120.0],
+        dtype=torch.float32,
+        device="mps",
+    )
+    output = torch.zeros(1, dtype=torch.float32, device="mps")
+    source = _with_hsl_features(
+        passivbot_rust.mps_ema_anchor_source_py(),
+        ema_tail_enabled=False,
+        raw_drawdown_enabled=True,
+    )
+    library = torch.mps.compile_shader(source + probe_kernel)
+    library.passivbot_hsl_strategy_equity_raw_drawdown_probe(
+        samples, output, threads=(1, 1, 1)
+    )
+    torch.mps.synchronize()
+
+    assert output.item() == pytest.approx(0.2, abs=1.0e-6)
 
 
 @pytest.mark.skipif(
@@ -4264,8 +4327,10 @@ def test_mps_ema_anchor_shader_smoke():
 def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
     import passivbot_rust
 
-    source = _with_hsl_ema_tail(
-        passivbot_rust.mps_ema_anchor_multicoin_source_py(), True
+    source = _with_hsl_features(
+        passivbot_rust.mps_ema_anchor_multicoin_source_py(),
+        ema_tail_enabled=True,
+        raw_drawdown_enabled=True,
     )
     assert "kernel void passivbot_ema_anchor_multicoin" in source
     assert "kernel void passivbot_ema_anchor_multicoin_long" in source
@@ -4348,15 +4413,18 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
         side=side,
         forager_score_hysteresis_pct=0.02,
         max_realized_loss_pct=0.1,
+        hsl_raw_drawdown_enabled=True,
     )
     assert runner.settings.cpu()[4].item() == pytest.approx(0.02)
     assert runner.settings.cpu()[5].item() <= 0.1
     output = runner.run(np.array([row, row], dtype=np.float64))
     torch.mps.synchronize()
 
-    assert runner._buffers[2][1].shape == (2, 61)
+    assert runner._buffers[2][1].shape == (2, 65)
     assert (output["hsl_drawdown_ema_mean_worst_1pct_long"] == 0.0).all()
     assert (output["hsl_drawdown_ema_mean_worst_1pct_short"] == 0.0).all()
+    assert (output["hsl_drawdown_raw_max_long"] == 0.0).all()
+    assert (output["hsl_drawdown_raw_max_short"] == 0.0).all()
     assert output["balance"].device.type == "mps"
     assert output["balance"].shape == (2,)
     assert torch.isfinite(output["balance"]).all()
@@ -4430,11 +4498,13 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
 def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
     import passivbot_rust
 
-    source = _with_hsl_ema_tail(
-        passivbot_rust.mps_ema_anchor_multicoin_source_py(), True
+    source = _with_hsl_features(
+        passivbot_rust.mps_ema_anchor_multicoin_source_py(),
+        ema_tail_enabled=True,
+        raw_drawdown_enabled=True,
     )
     assert "kernel void passivbot_ema_anchor_multicoin_fused" in source
-    assert "constant int FUSED_SCALAR_COLS = 68" in source
+    assert "constant int FUSED_SCALAR_COLS = 70" in source
 
     count = 512
     coin_count = 3
@@ -4546,7 +4616,7 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
     )
     daily[:, :, 1].fill_(float("inf"))
     daily[:, :, 5].fill_(float("inf"))
-    scalars = torch.zeros((batch_size, 68), dtype=torch.float32, device="mps")
+    scalars = torch.zeros((batch_size, 70), dtype=torch.float32, device="mps")
     gaps = torch.zeros((batch_size, 128), dtype=torch.int32, device="mps")
     coin_fill_counts = torch.zeros(
         (batch_size, coin_count), dtype=torch.float32, device="mps"
@@ -4581,6 +4651,8 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
     assert (values[:3, 38] > 0.0).all()
     assert (values[:3, 66] > 0.0).all()
     assert (values[:3, 67] > 0.0).all()
+    assert (values[:3, 68] > 0.0).all()
+    assert (values[:3, 69] > 0.0).all()
     np.testing.assert_allclose(
         values[:3, 18], values[:3, 60] + values[:3, 62]
     )
@@ -4609,6 +4681,7 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
         max_realized_loss_pct=1.0,
         collect_coin_fill_counts=True,
         hsl_ema_tail_enabled=True,
+        hsl_raw_drawdown_enabled=True,
     )
     torch.testing.assert_close(runner.settings, run_settings)
     runner_output = runner.run(
@@ -4645,6 +4718,12 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
     )
     torch.testing.assert_close(
         runner_output["hsl_drawdown_ema_mean_worst_1pct_short"], scalars[:, 67]
+    )
+    torch.testing.assert_close(
+        runner_output["hsl_drawdown_raw_max_long"], scalars[:, 68]
+    )
+    torch.testing.assert_close(
+        runner_output["hsl_drawdown_raw_max_short"], scalars[:, 69]
     )
     assert runner_output["alive"].cpu().tolist() == [
         True,
@@ -4690,6 +4769,8 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
         "drawdown_worst_mean_1pct_ema_strategy_eq",
         "drawdown_worst_mean_1pct_ema_strategy_eq_long",
         "drawdown_worst_mean_1pct_ema_strategy_eq_short",
+        "drawdown_worst_strategy_eq_long",
+        "drawdown_worst_strategy_eq_short",
         "peak_recovery_hours_strategy_eq_long",
         "peak_recovery_hours_strategy_eq_short",
         "peak_recovery_days_strategy_eq_long",
@@ -4767,6 +4848,11 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
         for item in service_results
     )
     assert all(
+        item["drawdown_worst_strategy_eq_long"] > 0.0
+        and item["drawdown_worst_strategy_eq_short"] > 0.0
+        for item in service_results
+    )
+    assert all(
         item["peak_recovery_hours_strategy_eq_long"] >= 0.0
         and item["peak_recovery_hours_strategy_eq_short"] >= 0.0
         and item["peak_recovery_days_strategy_eq_long"]
@@ -4797,7 +4883,7 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
     )
     override_daily[:, :, 1].fill_(float("inf"))
     override_daily[:, :, 5].fill_(float("inf"))
-    override_scalars = torch.zeros((1, 68), dtype=torch.float32, device="mps")
+    override_scalars = torch.zeros((1, 70), dtype=torch.float32, device="mps")
     override_gaps = torch.zeros((1, 128), dtype=torch.int32, device="mps")
     override_coin_fills = torch.zeros(
         (1, coin_count), dtype=torch.float32, device="mps"
@@ -4831,11 +4917,13 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
 def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
     import passivbot_rust
 
-    source = _with_hsl_ema_tail(
-        passivbot_rust.mps_trailing_martingale_multicoin_source_py(), True
+    source = _with_hsl_features(
+        passivbot_rust.mps_trailing_martingale_multicoin_source_py(),
+        ema_tail_enabled=True,
+        raw_drawdown_enabled=True,
     )
     assert "kernel void passivbot_trailing_martingale_multicoin_fused" in source
-    assert "constant int FUSED_SCALAR_COLS = 68" in source
+    assert "constant int FUSED_SCALAR_COLS = 70" in source
 
     count = 512
     coin_count = 3
@@ -4971,7 +5059,7 @@ def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
     )
     daily[:, :, 1].fill_(float("inf"))
     daily[:, :, 5].fill_(float("inf"))
-    scalars = torch.zeros((batch_size, 68), dtype=torch.float32, device="mps")
+    scalars = torch.zeros((batch_size, 70), dtype=torch.float32, device="mps")
     gaps = torch.zeros((batch_size, 128), dtype=torch.int32, device="mps")
     coin_fill_counts = torch.zeros(
         (batch_size, coin_count), dtype=torch.float32, device="mps"
@@ -5009,6 +5097,8 @@ def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
     assert (output[:3, 38] > 0.0).all()
     assert (output[:3, 66] > 0.0).all()
     assert (output[:3, 67] > 0.0).all()
+    assert (output[:3, 68] > 0.0).all()
+    assert (output[:3, 69] > 0.0).all()
     np.testing.assert_allclose(output[:3, 18], output[:3, 60] + output[:3, 62])
     np.testing.assert_allclose(output[:3, 19], output[:3, 61] + output[:3, 63])
     np.testing.assert_allclose(
@@ -5030,6 +5120,7 @@ def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
         max_realized_loss_pct=1.0,
         collect_coin_fill_counts=True,
         hsl_ema_tail_enabled=True,
+        hsl_raw_drawdown_enabled=True,
     )
     torch.testing.assert_close(runner.settings, run_settings)
     runner_output = runner.run(np.asarray(rows, dtype=np.float64), profile=True)
@@ -5064,6 +5155,12 @@ def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
     )
     torch.testing.assert_close(
         runner_output["hsl_drawdown_ema_mean_worst_1pct_short"], scalars[:, 67]
+    )
+    torch.testing.assert_close(
+        runner_output["hsl_drawdown_raw_max_long"], scalars[:, 68]
+    )
+    torch.testing.assert_close(
+        runner_output["hsl_drawdown_raw_max_short"], scalars[:, 69]
     )
     assert runner_output["alive"].cpu().tolist() == [
         True,
@@ -5113,6 +5210,8 @@ def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
         "drawdown_worst_mean_1pct_ema_strategy_eq",
         "drawdown_worst_mean_1pct_ema_strategy_eq_long",
         "drawdown_worst_mean_1pct_ema_strategy_eq_short",
+        "drawdown_worst_strategy_eq_long",
+        "drawdown_worst_strategy_eq_short",
         "peak_recovery_hours_strategy_eq_long",
         "peak_recovery_hours_strategy_eq_short",
         "peak_recovery_days_strategy_eq_long",
@@ -5197,6 +5296,11 @@ def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
         for item in service_results
     )
     assert all(
+        item["drawdown_worst_strategy_eq_long"] > 0.0
+        and item["drawdown_worst_strategy_eq_short"] > 0.0
+        for item in service_results
+    )
+    assert all(
         item["peak_recovery_hours_strategy_eq_long"] >= 0.0
         and item["peak_recovery_hours_strategy_eq_short"] >= 0.0
         and item["peak_recovery_days_strategy_eq_long"]
@@ -5231,7 +5335,7 @@ def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
     )
     override_daily[:, :, 1].fill_(float("inf"))
     override_daily[:, :, 5].fill_(float("inf"))
-    override_scalars = torch.zeros((1, 68), dtype=torch.float32, device="mps")
+    override_scalars = torch.zeros((1, 70), dtype=torch.float32, device="mps")
     override_gaps = torch.zeros((1, 128), dtype=torch.int32, device="mps")
     override_coin_fills = torch.zeros(
         (1, coin_count), dtype=torch.float32, device="mps"
@@ -5375,6 +5479,7 @@ def test_mps_trailing_martingale_multicoin_directional_shader_smoke(side):
         side=side,
         forager_score_hysteresis_pct=0.02,
         max_realized_loss_pct=0.1,
+        hsl_raw_drawdown_enabled=True,
     )
     assert runner.settings.cpu()[5].item() <= 0.1
     output = runner.run(np.array([row, row], dtype=np.float64))
@@ -5382,6 +5487,9 @@ def test_mps_trailing_martingale_multicoin_directional_shader_smoke(side):
 
     assert output["balance"].device.type == "mps"
     assert output["balance"].shape == (2,)
+    assert runner._buffers[2][1].shape == (2, 65)
+    assert (output["hsl_drawdown_raw_max_long"] == 0.0).all()
+    assert (output["hsl_drawdown_raw_max_short"] == 0.0).all()
     assert torch.isfinite(output["balance"]).all()
     assert output["day_has_fill"].sum().item() > 0
     assert (output["open_positions"] <= 2.0).all()
@@ -6057,6 +6165,7 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
         short_enabled=side == "short",
         pnl_lookback_bars=5,
         hsl_ema_tail_enabled=True,
+        hsl_raw_drawdown_enabled=True,
     ).run(np.asarray(rows, dtype=np.float64))
     market_runner = runner_cls(
         market,
@@ -6122,6 +6231,7 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
     assert output["hsl_panic_loss_drawdown_max"][1].item() > 0.0
     assert output[f"hsl_strategy_eq_recovery_max_ms_{side}"][1].item() > 0.0
     assert output[f"hsl_drawdown_ema_mean_worst_1pct_{side}"][1].item() > 0.0
+    assert output[f"hsl_drawdown_raw_max_{side}"][1].item() > 0.0
     assert output[
         f"hsl_drawdown_ema_mean_worst_1pct_{'short' if side == 'long' else 'long'}"
     ][1].item() == 0.0
@@ -6254,6 +6364,7 @@ def test_mps_dual_side_single_coin_hsl_respects_signal_scope(
         long_enabled=True,
         short_enabled=True,
         hsl_ema_tail_enabled=True,
+        hsl_raw_drawdown_enabled=True,
     ).run(rows)
     torch.mps.synchronize()
 
@@ -6272,6 +6383,8 @@ def test_mps_dual_side_single_coin_hsl_respects_signal_scope(
     assert output["hsl_strategy_eq_recovery_max_ms_short"][2].item() > 0.0
     assert output["hsl_drawdown_ema_mean_worst_1pct_long"][2].item() > 0.0
     assert output["hsl_drawdown_ema_mean_worst_1pct_short"][2].item() > 0.0
+    assert output["hsl_drawdown_raw_max_long"][2].item() > 0.0
+    assert output["hsl_drawdown_raw_max_short"][2].item() > 0.0
     if signal_mode == "unified":
         assert output["hsl_panic_loss_drawdown_count"][2].item() >= 1.0
     else:

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -490,7 +490,7 @@ def test_combine_hedged_multicoin_hsl_outputs_reduces_pside_episodes():
     assert panic["hard_stop_panic_close_loss_drawdown_pct_mean"].item() == (
         pytest.approx(0.8 / 3.0)
     )
-    assert len(DIRECTIONAL_HSL_OUTPUT_KEYS) == 31
+    assert len(DIRECTIONAL_HSL_OUTPUT_KEYS) == 33
 
 
 def test_refresh_hedged_multicoin_hsl_replays_only_cutoff_candidates():
@@ -780,10 +780,11 @@ def test_multicoin_proxy_routes_dual_side_batch_through_fused_runner(
     ],
 )
 @pytest.mark.parametrize(
-    ("needed_metrics", "tail_enabled"),
+    ("needed_metrics", "tail_enabled", "raw_drawdown_enabled"),
     [
-        ({"hard_stop_time_in_red_pct"}, False),
-        ({"drawdown_worst_mean_1pct_ema_strategy_eq"}, True),
+        ({"hard_stop_time_in_red_pct"}, False, False),
+        ({"drawdown_worst_mean_1pct_ema_strategy_eq"}, True, False),
+        ({"drawdown_worst_strategy_eq_long"}, False, True),
     ],
 )
 def test_multicoin_proxy_constructs_fused_shared_account_runner(
@@ -794,6 +795,7 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
     proxy_mode,
     needed_metrics,
     tail_enabled,
+    raw_drawdown_enabled,
 ):
     torch = pytest.importorskip("torch")
 
@@ -949,6 +951,10 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
         override_cols,
     )
     assert constructed["kwargs"]["hsl_ema_tail_enabled"] is tail_enabled
+    assert (
+        constructed["kwargs"]["hsl_raw_drawdown_enabled"]
+        is raw_drawdown_enabled
+    )
 
 
 def test_gpu_proxy_requires_complete_valid_tail():

--- a/tests/test_config_scoring.py
+++ b/tests/test_config_scoring.py
@@ -46,6 +46,8 @@ def test_default_objective_goal_recognizes_fill_activity_metrics():
 
 
 def test_default_objective_goal_recognizes_strategy_eq_recovery_metrics():
+    assert default_objective_goal("drawdown_worst_strategy_eq_long") == "min"
+    assert default_objective_goal("drawdown_worst_strategy_eq_short") == "min"
     assert default_objective_goal("drawdown_worst_ema_strategy_eq") == "min"
     assert default_objective_goal("drawdown_worst_ema_strategy_eq_long") == "min"
     assert default_objective_goal("drawdown_worst_ema_strategy_eq_short") == "min"


### PR DESCRIPTION
Summary:
- add opt-in bounded peak/max tracking for raw long/short HSL strategy-equity drawdown in EMA Anchor and Trailing Martingale Metal kernels
- cover single-coin, one-sided multi-coin, and fused dual-side multi-coin ABIs while keeping the feature compiled out when unrequested
- expose the two metrics for scoring and limits with exact Rust validation and rolling drift gates authoritative

Validation:
- 298 physical Apple M3 MPS tests passed
- 266 Rust tests passed; cargo check and cargo check --tests passed
- 569 focused Python GPU/config tests passed
- real EMA Anchor single long/short: rolling rho 0.999/0.999, 100% constraint agreement
- real Trailing Martingale single long: rho 0.988, 96.9% constraint agreement; two disagreements were existing HSL restart-rate limits, not the new objectives
- real EMA Anchor one-sided multi: rho 0.983, front rho 0.833, 100% constraint agreement
- real EMA Anchor fused multi long+short: rho 0.990, probe rho 0.997, front rho 0.965, 100% constraint agreement
- matched-seed pre-slice/branch disabled-feature benchmark: 188.8 vs 191.1 proxy eval/s and 24.2s vs 24.1s wall
- requested raw metric: 181.6 proxy eval/s and 24.9s wall, so its small cost is opt-in
- mkdocs strict reaches only the two pre-existing release-note links to CHANGELOG.md warnings