### PR TITLE
Add single-coin GPU recovery distributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added global strategy-equity recovery-distribution scoring and limits to single-coin Apple MPS
+  optimization for EMA Anchor and Trailing Martingale. Directional kernels emit opt-in hourly
+  strategy-equity samples, and a bounded Metal postprocessor applies Rust's strict
+  time-to-exceed, percentile, and worst-tail definitions for
+  `strategy_eq_recovery_days_{mean,median,p95,p99,mean_worst_5pct,mean_worst_1pct}`. Exact Rust
+  validation and rolling drift gates remain authoritative; multi-coin recovery distributions
+  remain fail closed.
+
 - Added raw per-side HSL strategy-equity worst-drawdown scoring and limits to Apple MPS
   optimization for EMA Anchor and Trailing Martingale, across single-coin and multi-coin
   topologies. The bounded peak-and-maximum state is compiled into Metal only when either the long
@@ -17,8 +25,7 @@ All notable user-facing changes will be documented in this file.
 - Added per-side HSL strategy-equity peak-recovery scoring and limits to Apple MPS optimization.
   EMA Anchor and Trailing Martingale kernels now retain the longest strict time-to-exceed interval
   for each long and short HSL controller, including an unrecovered tail through the backtest end,
-  and expose it in hours and days. Exact Rust validation remains authoritative;
-  recovery-distribution metrics remain fail closed.
+  and expose it in hours and days. Exact Rust validation remains authoritative.
 
 - Fixed Apple MPS optimization halting when a converged or single-objective proxy front repeats an
   already exact-validated candidate. The backend now revalidates that actual current-front member

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ All notable user-facing changes will be documented in this file.
 ## Unreleased
 
 - Added global strategy-equity recovery-distribution scoring and limits to single-coin Apple MPS
-  optimization for EMA Anchor and Trailing Martingale. Directional kernels emit opt-in hourly
-  strategy-equity samples, and a bounded Metal postprocessor applies Rust's strict
+  optimization for EMA Anchor and Trailing Martingale. Directional kernels emit opt-in
+  candidate-relative hourly strategy-equity samples with mandatory initial and
+  terminal/liquidation endpoints, and a bounded Metal postprocessor applies Rust's strict
   time-to-exceed, percentile, and worst-tail definitions for
   `strategy_eq_recovery_days_{mean,median,p95,p99,mean_worst_5pct,mean_worst_1pct}`. Exact Rust
   validation and rolling drift gates remain authoritative. Histories with internal invalid candles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ All notable user-facing changes will be documented in this file.
   time-to-exceed, percentile, and worst-tail definitions for
   `strategy_eq_recovery_days_{mean,median,p95,p99,mean_worst_5pct,mean_worst_1pct}`. Exact Rust
   validation and rolling drift gates remain authoritative. Histories with internal invalid candles
-  and multi-coin recovery distributions remain fail closed.
+  remain fail closed, a bounded coin-HSL rolling-PnL overflow emits a conservative full-horizon
+  recovery penalty, and multi-coin recovery distributions remain fail closed.
 
 - Added raw per-side HSL strategy-equity worst-drawdown scoring and limits to Apple MPS
   optimization for EMA Anchor and Trailing Martingale, across single-coin and multi-coin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ All notable user-facing changes will be documented in this file.
   strategy-equity samples, and a bounded Metal postprocessor applies Rust's strict
   time-to-exceed, percentile, and worst-tail definitions for
   `strategy_eq_recovery_days_{mean,median,p95,p99,mean_worst_5pct,mean_worst_1pct}`. Exact Rust
-  validation and rolling drift gates remain authoritative; multi-coin recovery distributions
-  remain fail closed.
+  validation and rolling drift gates remain authoritative. Histories with internal invalid candles
+  and multi-coin recovery distributions remain fail closed.
 
 - Added raw per-side HSL strategy-equity worst-drawdown scoring and limits to Apple MPS
   optimization for EMA Anchor and Trailing Martingale, across single-coin and multi-coin

--- a/docs/equity_hard_stop_loss_reference.md
+++ b/docs/equity_hard_stop_loss_reference.md
@@ -150,14 +150,19 @@ These are the main parity surfaces that should be reviewed together:
    - Global `*_strategy_eq` metrics are canonical for risk inspection and optimizer use
    - Deprecated `*_hsl` metric names remain accepted as aliases for older configs/results
 3. Remaining GPU HSL metric gaps
-   - Strategy-equity recovery-distribution metrics need additional bounded per-side time-series state
+   - The per-side HSL controllers expose their longest strict strategy-equity recovery interval,
+     but not a full per-side recovery distribution
+   - Global strategy-equity recovery distributions are available for single-coin EMA Anchor and
+     Trailing Martingale through opt-in hourly proxy samples; multi-coin portfolio kernels do not
+     yet emit equivalent samples and fail closed for those metrics
 
 ### Missing or Weak Test Coverage
 
 1. End-to-end replay of one identical fill/candle history through live reconstruction and exact backtest orchestration; shared Rust primitive tests cover the calculations but not the complete orchestration trace
 2. Connector-level restart races while protective panic-close orders are live on an exchange
 3. Manual or external trading during downtime across the full exchange-adapter matrix
-4. Apple MPS parity for strategy-equity recovery-distribution metrics
+4. Apple MPS parity for per-side HSL-controller recovery distributions and global multi-coin
+   strategy-equity recovery distributions
 
 ## Optimizer Work
 

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -177,9 +177,10 @@ The supported slice is intentionally narrow:
   directional kernels emit opt-in hourly strategy-equity samples, and a bounded Metal
   postprocessor applies the same strict time-to-exceed and percentile/tail definitions as exact
   Rust. The hourly proxy is approximate; exact Rust validation and rolling drift gates remain
-  authoritative. Multi-coin recovery-distribution metrics remain fail closed until the shared
-  portfolio kernels can emit equivalent bounded samples. Compatible suites may use the supported
-  topologies.
+  authoritative. Tracked histories with internal invalid candles fail closed because exact Rust
+  records balance-only strategy equity at those steps. Multi-coin recovery-distribution metrics
+  remain fail closed until the shared portfolio kernels can emit equivalent bounded samples.
+  Compatible suites may use the supported topologies.
 - single-coin EMA Anchor and Trailing Martingale support auto-unstuck for long-only,
   short-only, hedge-mode dual-side, one-way, and compatible suite runs. One-sided multi-coin runs
   and compatible suites also support auto-unstuck, including static per-coin overrides. Metal

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -172,8 +172,14 @@ The supported slice is intentionally narrow:
   strictly exceeds its prior controller peak, including an unrecovered tail through the backtest
   end. Raw per-side `drawdown_worst_strategy_eq_{long,short}` is also available through an opt-in
   bounded peak-and-maximum accumulator, with exact Rust validation retaining authority over the
-  approximate fill path. Recovery-distribution metrics remain fail closed for now. Compatible
-  suites may use the supported topologies.
+  approximate fill path. Single-coin EMA Anchor and Trailing Martingale also support the global
+  `strategy_eq_recovery_days_{mean,median,p95,p99,mean_worst_5pct,mean_worst_1pct}` metrics. The
+  directional kernels emit opt-in hourly strategy-equity samples, and a bounded Metal
+  postprocessor applies the same strict time-to-exceed and percentile/tail definitions as exact
+  Rust. The hourly proxy is approximate; exact Rust validation and rolling drift gates remain
+  authoritative. Multi-coin recovery-distribution metrics remain fail closed until the shared
+  portfolio kernels can emit equivalent bounded samples. Compatible suites may use the supported
+  topologies.
 - single-coin EMA Anchor and Trailing Martingale support auto-unstuck for long-only,
   short-only, hedge-mode dual-side, one-way, and compatible suite runs. One-sided multi-coin runs
   and compatible suites also support auto-unstuck, including static per-coin overrides. Metal

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -174,13 +174,14 @@ The supported slice is intentionally narrow:
   bounded peak-and-maximum accumulator, with exact Rust validation retaining authority over the
   approximate fill path. Single-coin EMA Anchor and Trailing Martingale also support the global
   `strategy_eq_recovery_days_{mean,median,p95,p99,mean_worst_5pct,mean_worst_1pct}` metrics. The
-  directional kernels emit opt-in hourly strategy-equity samples, and a bounded Metal
-  postprocessor applies the same strict time-to-exceed and percentile/tail definitions as exact
-  Rust. The hourly proxy is approximate; exact Rust validation and rolling drift gates remain
-  authoritative. Tracked histories with internal invalid candles fail closed because exact Rust
-  records balance-only strategy equity at those steps. Multi-coin recovery-distribution metrics
-  remain fail closed until the shared portfolio kernels can emit equivalent bounded samples.
-  Compatible suites may use the supported topologies.
+  directional kernels emit opt-in candidate-relative hourly strategy-equity samples plus mandatory
+  initial and terminal/liquidation endpoints, and a bounded Metal postprocessor applies the same
+  strict time-to-exceed and percentile/tail definitions as exact Rust. The hourly proxy is
+  approximate; exact Rust validation and rolling drift gates remain authoritative. Tracked
+  histories with internal invalid candles fail closed because exact Rust records balance-only
+  strategy equity at those steps. Multi-coin recovery-distribution metrics remain fail closed until
+  the shared portfolio kernels can emit equivalent bounded samples. Compatible suites may use the
+  supported topologies.
 - single-coin EMA Anchor and Trailing Martingale support auto-unstuck for long-only,
   short-only, hedge-mode dual-side, one-way, and compatible suite runs. One-sided multi-coin runs
   and compatible suites also support auto-unstuck, including static per-coin overrides. Metal

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -179,9 +179,10 @@ The supported slice is intentionally narrow:
   strict time-to-exceed and percentile/tail definitions as exact Rust. The hourly proxy is
   approximate; exact Rust validation and rolling drift gates remain authoritative. Tracked
   histories with internal invalid candles fail closed because exact Rust records balance-only
-  strategy equity at those steps. Multi-coin recovery-distribution metrics remain fail closed until
-  the shared portfolio kernels can emit equivalent bounded samples. Compatible suites may use the
-  supported topologies.
+  strategy equity at those steps. A bounded coin-HSL rolling-PnL overflow also fails closed with a
+  conservative full-horizon recovery penalty. Multi-coin recovery-distribution metrics remain fail
+  closed until the shared portfolio kernels can emit equivalent bounded samples. Compatible suites
+  may use the supported topologies.
 - single-coin EMA Anchor and Trailing Martingale support auto-unstuck for long-only,
   short-only, hedge-mode dual-side, one-way, and compatible suite runs. One-sided multi-coin runs
   and compatible suites also support auto-unstuck, including static per-coin overrides. Metal

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -16,6 +16,8 @@ const MPS_TRAILING_MARTINGALE_BODY: &str =
 const MPS_EMA_ANCHOR_MULTICOIN_BODY: &str = include_str!("gpu/mps_ema_anchor_multicoin_long.metal");
 const MPS_TRAILING_MARTINGALE_MULTICOIN_BODY: &str =
     include_str!("gpu/mps_trailing_martingale_multicoin.metal");
+const MPS_STRATEGY_EQ_RECOVERY_DISTRIBUTION_SOURCE: &str =
+    include_str!("gpu/mps_strategy_eq_recovery_distribution.metal");
 const MPS_TRAILING_LONG_NO_HSL_PREAMBLE: &str =
     "#define PASSIVBOT_TRAILING_LONG_ONLY 1\n#define PASSIVBOT_TRAILING_HSL_DISABLED 1\n";
 const MPS_TRAILING_SHORT_NO_HSL_PREAMBLE: &str =
@@ -85,6 +87,10 @@ pub fn mps_trailing_martingale_short_no_hsl_source() -> &'static str {
 
 pub fn mps_trailing_martingale_multicoin_source() -> &'static str {
     MPS_TRAILING_MARTINGALE_MULTICOIN_SOURCE.as_str()
+}
+
+pub fn mps_strategy_eq_recovery_distribution_source() -> &'static str {
+    MPS_STRATEGY_EQ_RECOVERY_DISTRIBUTION_SOURCE
 }
 
 #[cfg(test)]
@@ -167,6 +173,27 @@ mod tests {
         assert!(source
             .contains("const bool shared_has_position = has_position_long || has_position_short"));
         assert!(source.contains("const bool shared_has_blocking_orders = has_blocking_orders_long"));
+    }
+
+    fn assert_directional_recovery_sampling_contract(source: &str) {
+        assert_eq!(source.matches("device float* recovery_samples").count(), 2);
+        assert!(source.contains("#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED"));
+        assert!(source.contains("const int recovery_stride = sizes[7]"));
+        assert!(source.contains("const int recovery_sample_count = sizes[8]"));
+        assert!(source.contains("recovery_stride > 0 && k % recovery_stride == 0"));
+        assert!(source
+            .contains("recovery_samples[int(b) * recovery_sample_count + sample_index] = eqf"));
+    }
+
+    #[test]
+    fn strategy_eq_recovery_distribution_source_preserves_strict_rust_contract() {
+        let source = mps_strategy_eq_recovery_distribution_source();
+
+        assert!(source.contains("kernel void passivbot_strategy_eq_recovery_distribution("));
+        assert!(source.contains("if (!(value > strategy_equity_samples[offset + pending_slot]))"));
+        assert!(source.contains("constant int RECOVERY_METRIC_COLS = 7"));
+        assert!(source.contains("recovery_histogram_percentile("));
+        assert!(source.contains("recovery_histogram_mean_worst_pct("));
     }
 
     fn assert_shared_multicoin_contract(source: &str) {
@@ -322,6 +349,7 @@ mod tests {
     fn ema_anchor_mps_source_exposes_expected_kernel_contract() {
         let source = mps_ema_anchor_source();
         assert_shared_hsl_contract(source);
+        assert_directional_recovery_sampling_contract(source);
         assert_directional_hsl_accounting_contract(source);
         assert!(source.contains("kernel void passivbot_ema_anchor"));
         assert!(source.contains("constant int DAILY_COLS = 8"));
@@ -580,6 +608,7 @@ mod tests {
     fn trailing_martingale_mps_source_exposes_expected_kernel_contract() {
         let source = mps_trailing_martingale_source();
         assert_shared_hsl_contract(source);
+        assert_directional_recovery_sampling_contract(source);
         assert_directional_hsl_accounting_contract(source);
         assert!(source.contains("kernel void passivbot_trailing_martingale"));
         assert!(source.contains("constant int SIDE_PARAMS = 51"));

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -184,6 +184,8 @@ mod tests {
         assert!(source.contains("const bool recovery_terminal = liq || k == T - 2"));
         assert!(source.contains("(recovery_elapsed + recovery_stride - 1) / recovery_stride"));
         assert!(source.contains("int(b) * recovery_sample_count + sample_index"));
+        assert!(source.contains("const bool rolling_pnl_overflowed ="));
+        assert!(source.contains("= RECOVERY_FAIL_CLOSED_SENTINEL;"));
     }
 
     #[test]
@@ -195,6 +197,8 @@ mod tests {
         assert!(source.contains("constant int RECOVERY_METRIC_COLS = 7"));
         assert!(source.contains("recovery_histogram_percentile("));
         assert!(source.contains("recovery_histogram_mean_worst_pct("));
+        assert!(source.contains("== RECOVERY_FAIL_CLOSED_SENTINEL"));
+        assert!(source.contains("output[output_offset + metric] = full_horizon"));
     }
 
     fn assert_shared_multicoin_contract(source: &str) {

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -180,9 +180,10 @@ mod tests {
         assert!(source.contains("#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED"));
         assert!(source.contains("const int recovery_stride = sizes[7]"));
         assert!(source.contains("const int recovery_sample_count = sizes[8]"));
-        assert!(source.contains("recovery_stride > 0 && k % recovery_stride == 0"));
-        assert!(source
-            .contains("recovery_samples[int(b) * recovery_sample_count + sample_index] = eqf"));
+        assert!(source.contains("int recovery_start_k = -1"));
+        assert!(source.contains("const bool recovery_terminal = liq || k == T - 2"));
+        assert!(source.contains("(recovery_elapsed + recovery_stride - 1) / recovery_stride"));
+        assert!(source.contains("int(b) * recovery_sample_count + sample_index"));
     }
 
     #[test]

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -11,6 +11,9 @@ constant int SCALAR_COLS = 66;
 #endif
 constant int GAP_BINS = 128;
 constant int SIDE_PARAMS = 34;
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+constant float RECOVERY_FAIL_CLOSED_SENTINEL = -3.402823466e+38f;
+#endif
 
 inline float round_step(float value, float step) {
     return floor(value / step + 0.5f) * step;
@@ -1474,8 +1477,17 @@ inline void passivbot_single_coin_impl(
         float short_unreal = short_side.psize > 0.0f
             ? short_side.psize * c_mult * (short_side.pprice - close) : 0.0f;
         float equity = balance + long_unreal + short_unreal;
-        if ((long_coin_hsl_rolling && long_rolling_pnl.overflowed)
-            || (short_coin_hsl_rolling && short_rolling_pnl.overflowed)) {
+        const bool rolling_pnl_overflowed =
+            (long_coin_hsl_rolling && long_rolling_pnl.overflowed)
+            || (short_coin_hsl_rolling && short_rolling_pnl.overflowed);
+        if (rolling_pnl_overflowed) {
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+            // A bounded rolling-PnL overflow invalidates the proxy candidate.
+            // The postprocessor maps this impossible equity to the maximum
+            // bounded duration for every minimized recovery statistic.
+            recovery_samples[int(b) * recovery_sample_count]
+                = RECOVERY_FAIL_CLOSED_SENTINEL;
+#endif
             balance = 0.0f;
             alive = false;
             liq_day = di;

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -795,6 +795,9 @@ inline void passivbot_single_coin_impl(
     device int* gap_hist,
     device float2* rolling_pnl_values,
     device int2* rolling_pnl_indices,
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    device float* recovery_samples,
+#endif
     uint b
 ) {
     const int B = sizes[0];
@@ -802,6 +805,10 @@ inline void passivbot_single_coin_impl(
     const int D = sizes[2];
     const int P = sizes[3];
     const int first_valid = sizes[4];
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    const int recovery_stride = sizes[7];
+    const int recovery_sample_count = sizes[8];
+#endif
     if (b >= uint(B)) return;
 
     const float qty_step = settings[0];
@@ -1575,6 +1582,14 @@ inline void passivbot_single_coin_impl(
             }
             bool liq = balance <= 0.0f || equity <= liq_floor;
             float eqf = liq ? liq_floor : equity;
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+            if (recovery_stride > 0 && k % recovery_stride == 0) {
+                const int sample_index = k / recovery_stride;
+                if (sample_index < recovery_sample_count) {
+                    recovery_samples[int(b) * recovery_sample_count + sample_index] = eqf;
+                }
+            }
+#endif
             if (eqf >= account_peak) {
                 if (account_peak_k >= 0.0f) {
                     account_recovery_max_min = fmax(
@@ -1793,10 +1808,17 @@ kernel void passivbot_ema_anchor(
     device int* gap_hist,
     device float2* rolling_pnl_values,
     device int2* rolling_pnl_indices,
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    device float* recovery_samples,
+#endif
     uint b [[thread_position_in_grid]]
 ) {
     passivbot_single_coin_impl(
         bars, flags, params, settings, sizes, daily, scalars, gap_hist,
-        rolling_pnl_values, rolling_pnl_indices, b
+        rolling_pnl_values, rolling_pnl_indices,
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+        recovery_samples,
+#endif
+        b
     );
 }

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -900,6 +900,9 @@ inline void passivbot_single_coin_impl(
     float first_eq_k = -1.0f;
     float last_eq_k = -1.0f;
     bool eq_started = false;
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    int recovery_start_k = -1;
+#endif
     float hsl_tier_samples_total = 0.0f;
     float hsl_tier_samples_yellow = 0.0f;
     float hsl_tier_samples_orange = 0.0f;
@@ -1583,10 +1586,22 @@ inline void passivbot_single_coin_impl(
             bool liq = balance <= 0.0f || equity <= liq_floor;
             float eqf = liq ? liq_floor : equity;
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
-            if (recovery_stride > 0 && k % recovery_stride == 0) {
-                const int sample_index = k / recovery_stride;
-                if (sample_index < recovery_sample_count) {
-                    recovery_samples[int(b) * recovery_sample_count + sample_index] = eqf;
+            if (recovery_stride > 0 && recovery_start_k < 0) {
+                recovery_start_k = k;
+                recovery_samples[int(b) * recovery_sample_count] = eqf;
+            } else if (recovery_stride > 0) {
+                const int recovery_elapsed = k - recovery_start_k;
+                const bool recovery_terminal = liq || k == T - 2;
+                const bool recovery_regular = recovery_elapsed % recovery_stride == 0;
+                if (recovery_regular || recovery_terminal) {
+                    const int sample_index = recovery_terminal
+                        ? (recovery_elapsed + recovery_stride - 1) / recovery_stride
+                        : recovery_elapsed / recovery_stride;
+                    if (sample_index < recovery_sample_count) {
+                        recovery_samples[
+                            int(b) * recovery_sample_count + sample_index
+                        ] = eqf;
+                    }
                 }
             }
 #endif

--- a/passivbot-rust/src/gpu/mps_strategy_eq_recovery_distribution.metal
+++ b/passivbot-rust/src/gpu/mps_strategy_eq_recovery_distribution.metal
@@ -1,0 +1,139 @@
+#include <metal_stdlib>
+using namespace metal;
+
+constant int RECOVERY_METRIC_COLS = 7;
+
+inline uint recovery_histogram_value_at_rank(
+    device const uint* histogram,
+    const uint offset,
+    const uint slot_count,
+    const uint rank
+) {
+    uint cumulative = 0;
+    for (uint duration = 0; duration < slot_count; ++duration) {
+        cumulative += histogram[offset + duration];
+        if (cumulative > rank) return duration;
+    }
+    return slot_count > 0 ? slot_count - 1 : 0;
+}
+
+inline float recovery_histogram_percentile(
+    device const uint* histogram,
+    const uint offset,
+    const uint slot_count,
+    const uint sample_count,
+    const float percentile
+) {
+    if (sample_count <= 1) {
+        return float(recovery_histogram_value_at_rank(
+            histogram, offset, slot_count, 0
+        ));
+    }
+    const float rank = clamp(percentile, 0.0f, 100.0f)
+        * 0.01f * float(sample_count - 1);
+    const uint lower_rank = uint(floor(rank));
+    const uint upper_rank = uint(ceil(rank));
+    const float lower = float(recovery_histogram_value_at_rank(
+        histogram, offset, slot_count, lower_rank
+    ));
+    if (lower_rank == upper_rank) return lower;
+    const float upper = float(recovery_histogram_value_at_rank(
+        histogram, offset, slot_count, upper_rank
+    ));
+    return lower + (upper - lower) * (rank - float(lower_rank));
+}
+
+inline float recovery_histogram_mean_worst_pct(
+    device const uint* histogram,
+    const uint offset,
+    const uint slot_count,
+    const uint sample_count,
+    const float percentile
+) {
+    if (sample_count == 0) return 0.0f;
+    const uint worst_count = min(
+        sample_count,
+        max(uint(1), uint(float(sample_count) * percentile * 0.01f))
+    );
+    uint remaining = worst_count;
+    float total = 0.0f;
+    for (uint duration = slot_count; duration > 0 && remaining > 0; --duration) {
+        const uint value = duration - 1;
+        const uint take = min(histogram[offset + value], remaining);
+        total += float(take) * float(value);
+        remaining -= take;
+    }
+    return total / float(worst_count);
+}
+
+kernel void passivbot_strategy_eq_recovery_distribution(
+    device const float* strategy_equity_samples,
+    device uint* stack_indices,
+    device uint* duration_histogram,
+    device float* output,
+    constant int* sizes,
+    uint candidate [[thread_position_in_grid]]
+) {
+    const uint batch_size = uint(sizes[0]);
+    const uint slot_count = uint(sizes[1]);
+    if (candidate >= batch_size || slot_count == 0) return;
+
+    const uint offset = candidate * slot_count;
+    const uint output_offset = candidate * RECOVERY_METRIC_COLS;
+    uint stack_size = 0;
+    uint sample_count = 0;
+    uint final_slot = 0;
+
+    for (uint slot = 0; slot < slot_count; ++slot) {
+        const float value = strategy_equity_samples[offset + slot];
+        if (!isfinite(value)) continue;
+        sample_count += 1;
+        final_slot = slot;
+        while (stack_size > 0) {
+            const uint pending_slot = stack_indices[offset + stack_size - 1];
+            if (!(value > strategy_equity_samples[offset + pending_slot])) break;
+            duration_histogram[offset + slot - pending_slot] += 1;
+            stack_size -= 1;
+        }
+        stack_indices[offset + stack_size] = slot;
+        stack_size += 1;
+    }
+
+    while (stack_size > 0) {
+        const uint pending_slot = stack_indices[offset + stack_size - 1];
+        duration_histogram[offset + final_slot - pending_slot] += 1;
+        stack_size -= 1;
+    }
+
+    if (sample_count == 0) {
+        for (uint metric = 0; metric < RECOVERY_METRIC_COLS; ++metric) {
+            output[output_offset + metric] = 0.0f;
+        }
+        return;
+    }
+
+    float duration_sum = 0.0f;
+    uint duration_max = 0;
+    for (uint duration = 0; duration < slot_count; ++duration) {
+        const uint count = duration_histogram[offset + duration];
+        duration_sum += float(count) * float(duration);
+        if (count > 0) duration_max = duration;
+    }
+    output[output_offset + 0] = duration_sum / float(sample_count);
+    output[output_offset + 1] = recovery_histogram_percentile(
+        duration_histogram, offset, slot_count, sample_count, 50.0f
+    );
+    output[output_offset + 2] = recovery_histogram_percentile(
+        duration_histogram, offset, slot_count, sample_count, 95.0f
+    );
+    output[output_offset + 3] = recovery_histogram_percentile(
+        duration_histogram, offset, slot_count, sample_count, 99.0f
+    );
+    output[output_offset + 4] = recovery_histogram_mean_worst_pct(
+        duration_histogram, offset, slot_count, sample_count, 5.0f
+    );
+    output[output_offset + 5] = recovery_histogram_mean_worst_pct(
+        duration_histogram, offset, slot_count, sample_count, 1.0f
+    );
+    output[output_offset + 6] = float(duration_max);
+}

--- a/passivbot-rust/src/gpu/mps_strategy_eq_recovery_distribution.metal
+++ b/passivbot-rust/src/gpu/mps_strategy_eq_recovery_distribution.metal
@@ -2,6 +2,7 @@
 using namespace metal;
 
 constant int RECOVERY_METRIC_COLS = 7;
+constant float RECOVERY_FAIL_CLOSED_SENTINEL = -3.402823466e+38f;
 
 inline uint recovery_histogram_value_at_rank(
     device const uint* histogram,
@@ -80,6 +81,13 @@ kernel void passivbot_strategy_eq_recovery_distribution(
 
     const uint offset = candidate * slot_count;
     const uint output_offset = candidate * RECOVERY_METRIC_COLS;
+    if (strategy_equity_samples[offset] == RECOVERY_FAIL_CLOSED_SENTINEL) {
+        const float full_horizon = float(slot_count - 1);
+        for (uint metric = 0; metric < RECOVERY_METRIC_COLS; ++metric) {
+            output[output_offset + metric] = full_horizon;
+        }
+        return;
+    }
     uint stack_size = 0;
     uint sample_count = 0;
     uint final_slot = 0;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -1199,6 +1199,9 @@ inline void passivbot_single_coin_impl(
     float first_eq_k = -1.0f;
     float last_eq_k = -1.0f;
     bool eq_started = false;
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    int recovery_start_k = -1;
+#endif
     float hsl_tier_samples_total = 0.0f;
     float hsl_tier_samples_yellow = 0.0f;
     float hsl_tier_samples_orange = 0.0f;
@@ -2719,10 +2722,22 @@ inline void passivbot_single_coin_impl(
             bool liq = balance <= 0.0f || equity <= liq_floor;
             float eqf = liq ? liq_floor : equity;
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
-            if (recovery_stride > 0 && k % recovery_stride == 0) {
-                const int sample_index = k / recovery_stride;
-                if (sample_index < recovery_sample_count) {
-                    recovery_samples[int(b) * recovery_sample_count + sample_index] = eqf;
+            if (recovery_stride > 0 && recovery_start_k < 0) {
+                recovery_start_k = k;
+                recovery_samples[int(b) * recovery_sample_count] = eqf;
+            } else if (recovery_stride > 0) {
+                const int recovery_elapsed = k - recovery_start_k;
+                const bool recovery_terminal = liq || k == T - 2;
+                const bool recovery_regular = recovery_elapsed % recovery_stride == 0;
+                if (recovery_regular || recovery_terminal) {
+                    const int sample_index = recovery_terminal
+                        ? (recovery_elapsed + recovery_stride - 1) / recovery_stride
+                        : recovery_elapsed / recovery_stride;
+                    if (sample_index < recovery_sample_count) {
+                        recovery_samples[
+                            int(b) * recovery_sample_count + sample_index
+                        ] = eqf;
+                    }
                 }
             }
 #endif

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -11,6 +11,9 @@ constant int SCALAR_COLS = 66;
 #endif
 constant int GAP_BINS = 128;
 constant int SIDE_PARAMS = 51;
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+constant float RECOVERY_FAIL_CLOSED_SENTINEL = -3.402823466e+38f;
+#endif
 
 inline float round_step(float value, float step) {
     return floor(value / step + 0.5f) * step;
@@ -2610,8 +2613,17 @@ inline void passivbot_single_coin_impl(
         float short_unreal = short_side.psize > 0.0f
             ? short_side.psize * c_mult * (short_side.pprice - close) : 0.0f;
         float equity = balance + long_unreal + short_unreal;
-        if ((long_coin_hsl_rolling && long_rolling_pnl.overflowed)
-            || (short_coin_hsl_rolling && short_rolling_pnl.overflowed)) {
+        const bool rolling_pnl_overflowed =
+            (long_coin_hsl_rolling && long_rolling_pnl.overflowed)
+            || (short_coin_hsl_rolling && short_rolling_pnl.overflowed);
+        if (rolling_pnl_overflowed) {
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+            // A bounded rolling-PnL overflow invalidates the proxy candidate.
+            // The postprocessor maps this impossible equity to the maximum
+            // bounded duration for every minimized recovery statistic.
+            recovery_samples[int(b) * recovery_sample_count]
+                = RECOVERY_FAIL_CLOSED_SENTINEL;
+#endif
             balance = 0.0f;
             alive = false;
             liq_day = di;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -1081,6 +1081,9 @@ inline void passivbot_single_coin_impl(
     device int* gap_hist,
     device float2* rolling_pnl_values,
     device int2* rolling_pnl_indices,
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    device float* recovery_samples,
+#endif
     uint b
 ) {
     const int B = sizes[0];
@@ -1088,6 +1091,10 @@ inline void passivbot_single_coin_impl(
     const int D = sizes[2];
     const int P = sizes[3];
     const int first_valid = sizes[4];
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    const int recovery_stride = sizes[7];
+    const int recovery_sample_count = sizes[8];
+#endif
     if (b >= uint(B)) return;
 
     const float qty_step = settings[0];
@@ -2711,6 +2718,14 @@ inline void passivbot_single_coin_impl(
             }
             bool liq = balance <= 0.0f || equity <= liq_floor;
             float eqf = liq ? liq_floor : equity;
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+            if (recovery_stride > 0 && k % recovery_stride == 0) {
+                const int sample_index = k / recovery_stride;
+                if (sample_index < recovery_sample_count) {
+                    recovery_samples[int(b) * recovery_sample_count + sample_index] = eqf;
+                }
+            }
+#endif
             if (eqf >= account_peak) {
                 if (account_peak_k >= 0.0f) {
                     account_recovery_max_min = fmax(
@@ -2929,10 +2944,17 @@ kernel void passivbot_trailing_martingale(
     device int* gap_hist,
     device float2* rolling_pnl_values,
     device int2* rolling_pnl_indices,
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    device float* recovery_samples,
+#endif
     uint b [[thread_position_in_grid]]
 ) {
     passivbot_single_coin_impl(
         bars, flags, params, settings, sizes, daily, scalars, gap_hist,
-        rolling_pnl_values, rolling_pnl_indices, b
+        rolling_pnl_values, rolling_pnl_indices,
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+        recovery_samples,
+#endif
+        b
     );
 }

--- a/passivbot-rust/src/lib.rs
+++ b/passivbot-rust/src/lib.rs
@@ -68,6 +68,11 @@ fn mps_trailing_martingale_multicoin_source_py() -> &'static str {
     gpu::mps_trailing_martingale_multicoin_source()
 }
 
+#[pyfunction]
+fn mps_strategy_eq_recovery_distribution_source_py() -> &'static str {
+    gpu::mps_strategy_eq_recovery_distribution_source()
+}
+
 /// A Python module implemented in Rust.
 #[pymodule]
 fn passivbot_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -92,6 +97,10 @@ fn passivbot_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     )?)?;
     m.add_function(wrap_pyfunction!(
         mps_trailing_martingale_multicoin_source_py,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(
+        mps_strategy_eq_recovery_distribution_source_py,
         m
     )?)?;
     m.add_function(wrap_pyfunction!(round_, m)?)?;

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -1113,6 +1113,12 @@ def _validate_dual_multicoin_metrics(
             "position_unchanged_hours_max",
             "positions_held_per_day",
             "strategy_eq_recovery_days_max",
+            "strategy_eq_recovery_days_mean",
+            "strategy_eq_recovery_days_median",
+            "strategy_eq_recovery_days_p95",
+            "strategy_eq_recovery_days_p99",
+            "strategy_eq_recovery_days_mean_worst_5pct",
+            "strategy_eq_recovery_days_mean_worst_1pct",
             "total_wallet_exposure_max",
             "total_wallet_exposure_mean",
             "volume_pct_per_day_avg",
@@ -1123,6 +1129,24 @@ def _validate_dual_multicoin_metrics(
             "GPU dual-side multicoin optimization cannot safely reconstruct proxy "
             f"metrics {unsupported} from independent directional summaries; "
             "use other metrics or the CPU optimizer"
+        )
+
+
+def _validate_recovery_distribution_scope(
+    needed_metrics, *, coin_count: int
+) -> None:
+    recovery_distribution_metrics = {
+        "strategy_eq_recovery_days_mean",
+        "strategy_eq_recovery_days_median",
+        "strategy_eq_recovery_days_p95",
+        "strategy_eq_recovery_days_p99",
+        "strategy_eq_recovery_days_mean_worst_5pct",
+        "strategy_eq_recovery_days_mean_worst_1pct",
+    }
+    if int(coin_count) > 1 and set(needed_metrics) & recovery_distribution_metrics:
+        raise ValueError(
+            "GPU strategy-equity recovery-distribution metrics currently require "
+            "a single-coin optimization; use other multicoin metrics or the CPU optimizer"
         )
 
 
@@ -3273,6 +3297,9 @@ def run_backend(
             f"GPU foundation does not implement optimizer metrics {unsupported}; "
             "use supported metrics or the CPU optimizer"
         )
+    _validate_recovery_distribution_scope(
+        needed_metrics, coin_count=max_coin_count
+    )
     _validate_hsl_metric_topology(
         needed_metrics,
         coin_count=max_coin_count,

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -161,6 +161,12 @@ SUPPORTED_METRICS = (
     "sortino_ratio_pnl_w",
     "sterling_ratio_strategy_eq",
     "sterling_ratio_strategy_eq_w",
+    "strategy_eq_recovery_days_mean",
+    "strategy_eq_recovery_days_median",
+    "strategy_eq_recovery_days_p95",
+    "strategy_eq_recovery_days_p99",
+    "strategy_eq_recovery_days_mean_worst_5pct",
+    "strategy_eq_recovery_days_mean_worst_1pct",
     "strategy_eq_recovery_days_max",
     "strategy_eq_underwater_pct_mean",
     "strategy_eq_underwater_pct_median",
@@ -266,6 +272,14 @@ _HARD_STOP_STRATEGY_EQ_RECOVERY_METRICS = {
     "peak_recovery_hours_strategy_eq_short",
     "peak_recovery_days_strategy_eq_long",
     "peak_recovery_days_strategy_eq_short",
+}
+_STRATEGY_EQ_RECOVERY_DISTRIBUTION_METRICS = {
+    "strategy_eq_recovery_days_mean",
+    "strategy_eq_recovery_days_median",
+    "strategy_eq_recovery_days_p95",
+    "strategy_eq_recovery_days_p99",
+    "strategy_eq_recovery_days_mean_worst_5pct",
+    "strategy_eq_recovery_days_mean_worst_1pct",
 }
 HARD_STOP_PROXY_METRICS = tuple(
     sorted(_HARD_STOP_LIFECYCLE_METRICS | _HARD_STOP_PANIC_LOSS_METRICS)
@@ -1258,6 +1272,25 @@ def _hard_stop_strategy_eq_recovery_metrics(out: dict) -> dict:
     }
 
 
+def _strategy_eq_recovery_distribution_metrics(out: dict) -> dict:
+    """Map strict uniformly sampled time-to-exceed summaries from Apple MPS."""
+
+    if "strategy_eq_recovery_distribution" not in out:
+        raise RuntimeError(
+            "MPS strategy-equity recovery-distribution output is missing from proxy results"
+        )
+    values = out["strategy_eq_recovery_distribution"].to(torch.float64)
+    names = (
+        "strategy_eq_recovery_days_mean",
+        "strategy_eq_recovery_days_median",
+        "strategy_eq_recovery_days_p95",
+        "strategy_eq_recovery_days_p99",
+        "strategy_eq_recovery_days_mean_worst_5pct",
+        "strategy_eq_recovery_days_mean_worst_1pct",
+    )
+    return {name: values[:, index] for index, name in enumerate(names)}
+
+
 def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
     """Reduce compact Metal output into validated proxy objective metrics."""
 
@@ -1468,6 +1501,11 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
         if requested & _HARD_STOP_STRATEGY_EQ_RECOVERY_METRICS
         else {}
     )
+    strategy_eq_recovery_distribution_metrics = (
+        _strategy_eq_recovery_distribution_metrics(out)
+        if requested & _STRATEGY_EQ_RECOVERY_DISTRIBUTION_METRICS
+        else {}
+    )
 
     requested_start = float(run.requested_start_ts_ms)
     first_timestamp = data["ts0"]
@@ -1522,6 +1560,7 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
     objectives.update(hard_stop_raw_drawdown_metrics)
     objectives.update(hard_stop_ema_tail_metrics)
     objectives.update(hard_stop_strategy_eq_recovery_metrics)
+    objectives.update(strategy_eq_recovery_distribution_metrics)
     if "loss_profit_ratio" in requested:
         objectives["loss_profit_ratio"] = _loss_profit_ratio(
             out["loss_sum"], out["profit_sum"]

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -31,9 +31,13 @@ MPS_MULTICOIN_FUSED_BASE_SCALAR_COLS = 66
 MPS_MULTICOIN_FUSED_EMA_TAIL_SCALAR_COLS = 68
 MPS_MULTICOIN_FUSED_SCALAR_COLS = 70
 MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY = 2048
+MPS_STRATEGY_EQ_RECOVERY_METRIC_COLS = 7
 
 _HSL_EMA_TAIL_DEFINE = "#define PASSIVBOT_HSL_EMA_TAIL_ENABLED 1\n"
 _HSL_RAW_DRAWDOWN_DEFINE = "#define PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED 1\n"
+_RECOVERY_DISTRIBUTION_DEFINE = (
+    "#define PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED 1\n"
+)
 
 
 def _with_hsl_ema_tail(source: str, enabled: bool) -> str:
@@ -58,6 +62,16 @@ def _with_hsl_features(
     return _HSL_RAW_DRAWDOWN_DEFINE + source
 
 
+def _with_recovery_distribution(source: str, enabled: bool) -> str:
+    if not enabled:
+        return source
+    if "#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED" not in source:
+        raise RuntimeError(
+            "MPS source is missing the strategy-equity recovery-distribution feature guard"
+        )
+    return _RECOVERY_DISTRIBUTION_DEFINE + source
+
+
 def _encode_max_realized_loss_pct(value: float) -> float:
     """Encode a float64 loss fraction without loosening its Metal budget."""
 
@@ -75,61 +89,79 @@ def _scalar_column_or_zero(scalars, index: int):
     return torch.zeros_like(scalars[:, 0])
 
 
-@lru_cache(maxsize=4)
+@lru_cache(maxsize=8)
 def _shader_library(
     hsl_ema_tail_enabled: bool = False,
     hsl_raw_drawdown_enabled: bool = False,
+    recovery_distribution_enabled: bool = False,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
     return torch.mps.compile_shader(
-        _with_hsl_features(
-            passivbot_rust.mps_ema_anchor_source_py(),
-            ema_tail_enabled=hsl_ema_tail_enabled,
-            raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+        _with_recovery_distribution(
+            _with_hsl_features(
+                passivbot_rust.mps_ema_anchor_source_py(),
+                ema_tail_enabled=hsl_ema_tail_enabled,
+                raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+            ),
+            recovery_distribution_enabled,
         )
     )
 
 
-@lru_cache(maxsize=4)
+@lru_cache(maxsize=8)
 def _trailing_martingale_shader_library(
     hsl_ema_tail_enabled: bool = False,
     hsl_raw_drawdown_enabled: bool = False,
+    recovery_distribution_enabled: bool = False,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
     return torch.mps.compile_shader(
-        _with_hsl_features(
-            passivbot_rust.mps_trailing_martingale_source_py(),
-            ema_tail_enabled=hsl_ema_tail_enabled,
-            raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+        _with_recovery_distribution(
+            _with_hsl_features(
+                passivbot_rust.mps_trailing_martingale_source_py(),
+                ema_tail_enabled=hsl_ema_tail_enabled,
+                raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+            ),
+            recovery_distribution_enabled,
         )
     )
 
 
-@lru_cache(maxsize=1)
-def _trailing_martingale_long_no_hsl_shader_library():
+@lru_cache(maxsize=2)
+def _trailing_martingale_long_no_hsl_shader_library(
+    recovery_distribution_enabled: bool = False,
+):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
     return torch.mps.compile_shader(
-        passivbot_rust.mps_trailing_martingale_long_no_hsl_source_py()
+        _with_recovery_distribution(
+            passivbot_rust.mps_trailing_martingale_long_no_hsl_source_py(),
+            recovery_distribution_enabled,
+        )
     )
 
 
-@lru_cache(maxsize=1)
-def _trailing_martingale_short_no_hsl_shader_library():
+@lru_cache(maxsize=2)
+def _trailing_martingale_short_no_hsl_shader_library(
+    recovery_distribution_enabled: bool = False,
+):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
     return torch.mps.compile_shader(
-        passivbot_rust.mps_trailing_martingale_short_no_hsl_source_py()
+        _with_recovery_distribution(
+            passivbot_rust.mps_trailing_martingale_short_no_hsl_source_py(),
+            recovery_distribution_enabled,
+        )
     )
 
 
@@ -167,6 +199,80 @@ def _trailing_martingale_multicoin_shader_library(
             raw_drawdown_enabled=hsl_raw_drawdown_enabled,
         )
     )
+
+
+@lru_cache(maxsize=1)
+def _strategy_eq_recovery_distribution_shader_library():
+    if not torch.backends.mps.is_available():
+        raise RuntimeError("Apple MPS is not available in this process")
+    import passivbot_rust
+
+    return torch.mps.compile_shader(
+        passivbot_rust.mps_strategy_eq_recovery_distribution_source_py()
+    )
+
+
+@lru_cache(maxsize=2)
+def _strategy_eq_recovery_distribution_buffers(
+    batch_size: int, sample_capacity: int
+):
+    shape = (int(batch_size), int(sample_capacity))
+    return (
+        torch.empty(shape, dtype=torch.int32, device="mps"),
+        torch.empty(shape, dtype=torch.int32, device="mps"),
+        torch.empty(
+            (int(batch_size), MPS_STRATEGY_EQ_RECOVERY_METRIC_COLS),
+            dtype=torch.float32,
+            device="mps",
+        ),
+        torch.tensor(shape, dtype=torch.int32, device="mps"),
+    )
+
+
+def strategy_eq_recovery_distribution_from_samples(
+    strategy_equity_samples, *, sample_interval_days: float = 1.0
+):
+    """Approximate exact recovery summaries from uniformly spaced proxy samples."""
+
+    if strategy_equity_samples.device.type != "mps":
+        raise ValueError("strategy-equity recovery distribution requires an MPS tensor")
+    if strategy_equity_samples.dtype != torch.float32:
+        raise ValueError("strategy-equity recovery distribution requires float32 input")
+    if strategy_equity_samples.ndim != 2:
+        raise ValueError(
+            "strategy-equity recovery distribution expects a batch-by-day matrix"
+        )
+    sample_interval_days = float(sample_interval_days)
+    if not np.isfinite(sample_interval_days) or sample_interval_days <= 0.0:
+        raise ValueError("recovery sample interval must be finite and positive")
+    matrix = strategy_equity_samples.contiguous()
+    batch_size, sample_capacity = (int(value) for value in matrix.shape)
+    if batch_size == 0:
+        return torch.empty(
+            (0, MPS_STRATEGY_EQ_RECOVERY_METRIC_COLS),
+            dtype=torch.float32,
+            device="mps",
+        )
+    if sample_capacity == 0:
+        return torch.zeros(
+            (batch_size, MPS_STRATEGY_EQ_RECOVERY_METRIC_COLS),
+            dtype=torch.float32,
+            device="mps",
+        )
+    stack, histogram, output, sizes = _strategy_eq_recovery_distribution_buffers(
+        batch_size, sample_capacity
+    )
+    histogram.zero_()
+    library = _strategy_eq_recovery_distribution_shader_library()
+    library.passivbot_strategy_eq_recovery_distribution(
+        matrix,
+        stack,
+        histogram,
+        output,
+        sizes,
+        threads=(batch_size, 1, 1),
+    )
+    return output * sample_interval_days
 
 
 def _decode_outputs(daily, scalars, gaps) -> dict:
@@ -413,6 +519,7 @@ class MpsEmaAnchorRunner:
         pnl_lookback_bars: int = 0,
         hsl_ema_tail_enabled: bool = False,
         hsl_raw_drawdown_enabled: bool = False,
+        recovery_distribution_enabled: bool = False,
     ):
         self.market = market
         self.run_config = run
@@ -446,6 +553,7 @@ class MpsEmaAnchorRunner:
         self.pnl_lookback_bars = pnl_lookback_bars
         self.hsl_ema_tail_enabled = bool(hsl_ema_tail_enabled)
         self.hsl_raw_drawdown_enabled = bool(hsl_raw_drawdown_enabled)
+        self.recovery_distribution_enabled = bool(recovery_distribution_enabled)
         self.rolling_capacity = (
             MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY
             if pnl_lookback_bars > 0
@@ -453,6 +561,16 @@ class MpsEmaAnchorRunner:
         )
         self.n = int(data["n"])
         self.n_days = int(data["n_days"])
+        self.recovery_stride = (
+            max(1, int(np.ceil(3_600_000.0 / float(run.interval_ms))))
+            if self.recovery_distribution_enabled
+            else 0
+        )
+        self.n_recovery_samples = (
+            max(1, (self.n + self.recovery_stride - 1) // self.recovery_stride)
+            if self.recovery_distribution_enabled
+            else 1
+        )
         self.bars = (
             torch.stack(
                 [
@@ -515,6 +633,7 @@ class MpsEmaAnchorRunner:
         )
         self._buffers: dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = {}
         self._rolling_buffers: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
+        self._recovery_buffers: dict[int, torch.Tensor] = {}
         self._sizes: dict[tuple[int, int], torch.Tensor] = {}
         self.last_profile: dict[str, float] = {}
 
@@ -579,6 +698,20 @@ class MpsEmaAnchorRunner:
             }
         return self._rolling_buffers[batch_size]
 
+    def _recovery_sample_buffer(self, batch_size: int):
+        if batch_size not in self._recovery_buffers:
+            self._recovery_buffers = {
+                batch_size: torch.full(
+                    (batch_size, self.n_recovery_samples),
+                    float("nan"),
+                    dtype=torch.float32,
+                    device="mps",
+                )
+            }
+        else:
+            self._recovery_buffers[batch_size].fill_(float("nan"))
+        return self._recovery_buffers[batch_size]
+
     def run(self, params: np.ndarray, *, profile: bool = False) -> dict:
         started = time.perf_counter()
         matrix = self._pack_params(params)
@@ -589,18 +722,28 @@ class MpsEmaAnchorRunner:
         rolling_pnl_values, rolling_pnl_indices = self._hsl_rolling_buffers(
             batch_size
         )
+        recovery_samples = (
+            self._recovery_sample_buffer(batch_size)
+            if self.recovery_distribution_enabled
+            else None
+        )
         sizes_key = (batch_size, int(matrix.shape[1]))
         if sizes_key not in self._sizes:
+            size_values = [
+                batch_size,
+                self.n,
+                self.n_days,
+                matrix.shape[1],
+                self.run_config.first_valid_idx,
+                self.rolling_capacity,
+                self.pnl_lookback_bars,
+            ]
+            if self.recovery_distribution_enabled:
+                size_values.extend(
+                    [self.recovery_stride, self.n_recovery_samples]
+                )
             self._sizes[sizes_key] = torch.tensor(
-                [
-                    batch_size,
-                    self.n,
-                    self.n_days,
-                    matrix.shape[1],
-                    self.run_config.first_valid_idx,
-                    self.rolling_capacity,
-                    self.pnl_lookback_bars,
-                ],
+                size_values,
                 dtype=torch.int32,
                 device="mps",
             )
@@ -608,6 +751,7 @@ class MpsEmaAnchorRunner:
         library = _shader_library(
             self.hsl_ema_tail_enabled,
             self.hsl_raw_drawdown_enabled,
+            self.recovery_distribution_enabled,
         )
         compiled = time.perf_counter()
         if profile:
@@ -615,7 +759,7 @@ class MpsEmaAnchorRunner:
             dispatched = time.perf_counter()
         else:
             dispatched = compiled
-        library.passivbot_ema_anchor(
+        kernel_args = (
             self.bars,
             self.flags,
             params_mps,
@@ -626,6 +770,11 @@ class MpsEmaAnchorRunner:
             gaps,
             rolling_pnl_values,
             rolling_pnl_indices,
+        )
+        if self.recovery_distribution_enabled:
+            kernel_args += (recovery_samples,)
+        library.passivbot_ema_anchor(
+            *kernel_args,
             threads=(batch_size, 1, 1),
         )
         if profile:
@@ -638,7 +787,13 @@ class MpsEmaAnchorRunner:
             "pre_dispatch_sync_seconds": dispatched - compiled,
             "kernel_seconds": finished - dispatched,
         }
-        return _decode_directional_outputs(daily, scalars, gaps)
+        output = _decode_directional_outputs(daily, scalars, gaps)
+        if self.recovery_distribution_enabled:
+            output["strategy_eq_recovery_samples"] = recovery_samples
+            output["strategy_eq_recovery_sample_interval_days"] = (
+                self.recovery_stride * self.run_config.interval_ms / 86_400_000.0
+            )
+        return output
 
 
 class MpsEmaAnchorMulticoinRunner:
@@ -1297,12 +1452,17 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
 
     def _shader_library(self):
         if self.shader_topology == "long_no_hsl":
-            return _trailing_martingale_long_no_hsl_shader_library()
+            return _trailing_martingale_long_no_hsl_shader_library(
+                self.recovery_distribution_enabled
+            )
         if self.shader_topology == "short_no_hsl":
-            return _trailing_martingale_short_no_hsl_shader_library()
+            return _trailing_martingale_short_no_hsl_shader_library(
+                self.recovery_distribution_enabled
+            )
         return _trailing_martingale_shader_library(
             self.hsl_ema_tail_enabled,
             self.hsl_raw_drawdown_enabled,
+            self.recovery_distribution_enabled,
         )
 
     def _pack_params(self, params: np.ndarray) -> np.ndarray:
@@ -1325,18 +1485,28 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
         rolling_pnl_values, rolling_pnl_indices = self._hsl_rolling_buffers(
             batch_size
         )
+        recovery_samples = (
+            self._recovery_sample_buffer(batch_size)
+            if self.recovery_distribution_enabled
+            else None
+        )
         sizes_key = (batch_size, int(matrix.shape[1]))
         if sizes_key not in self._sizes:
+            size_values = [
+                batch_size,
+                self.n,
+                self.n_days,
+                matrix.shape[1],
+                self.run_config.first_valid_idx,
+                self.rolling_capacity,
+                self.pnl_lookback_bars,
+            ]
+            if self.recovery_distribution_enabled:
+                size_values.extend(
+                    [self.recovery_stride, self.n_recovery_samples]
+                )
             self._sizes[sizes_key] = torch.tensor(
-                [
-                    batch_size,
-                    self.n,
-                    self.n_days,
-                    matrix.shape[1],
-                    self.run_config.first_valid_idx,
-                    self.rolling_capacity,
-                    self.pnl_lookback_bars,
-                ],
+                size_values,
                 dtype=torch.int32,
                 device="mps",
             )
@@ -1348,7 +1518,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             dispatched = time.perf_counter()
         else:
             dispatched = compiled
-        library.passivbot_trailing_martingale(
+        kernel_args = (
             self.bars,
             self.flags,
             params_mps,
@@ -1359,6 +1529,11 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             gaps,
             rolling_pnl_values,
             rolling_pnl_indices,
+        )
+        if self.recovery_distribution_enabled:
+            kernel_args += (recovery_samples,)
+        library.passivbot_trailing_martingale(
+            *kernel_args,
             threads=(batch_size, 1, 1),
         )
         if profile:
@@ -1371,4 +1546,10 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             "pre_dispatch_sync_seconds": dispatched - compiled,
             "kernel_seconds": finished - dispatched,
         }
-        return _decode_directional_outputs(daily, scalars, gaps)
+        output = _decode_directional_outputs(daily, scalars, gaps)
+        if self.recovery_distribution_enabled:
+            output["strategy_eq_recovery_samples"] = recovery_samples
+            output["strategy_eq_recovery_sample_interval_days"] = (
+                self.recovery_stride * self.run_config.interval_ms / 86_400_000.0
+            )
+        return output

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -567,7 +567,10 @@ class MpsEmaAnchorRunner:
             else 0
         )
         self.n_recovery_samples = (
-            max(1, (self.n + self.recovery_stride - 1) // self.recovery_stride)
+            max(
+                1,
+                (self.n + self.recovery_stride - 1) // self.recovery_stride + 1,
+            )
             if self.recovery_distribution_enabled
             else 1
         )

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -220,6 +220,38 @@ _HSL_RAW_DRAWDOWN_METRICS = {
     "drawdown_worst_strategy_eq_long",
     "drawdown_worst_strategy_eq_short",
 }
+_STRATEGY_EQ_RECOVERY_DISTRIBUTION_METRICS = {
+    "strategy_eq_recovery_days_mean",
+    "strategy_eq_recovery_days_median",
+    "strategy_eq_recovery_days_p95",
+    "strategy_eq_recovery_days_p99",
+    "strategy_eq_recovery_days_mean_worst_5pct",
+    "strategy_eq_recovery_days_mean_worst_1pct",
+}
+
+
+def _mps_strategy_eq_recovery_distribution(output: dict, needed_metrics):
+    """Run the opt-in recovery postprocessor before proxy outputs leave MPS."""
+
+    if not set(needed_metrics) & _STRATEGY_EQ_RECOVERY_DISTRIBUTION_METRICS:
+        return None
+    required = {
+        "strategy_eq_recovery_samples",
+        "strategy_eq_recovery_sample_interval_days",
+    }
+    if missing := required.difference(output):
+        raise RuntimeError(
+            "MPS strategy-equity recovery sampling output is missing: "
+            + ", ".join(sorted(missing))
+        )
+    from optimization.gpu.mps_kernel import (
+        strategy_eq_recovery_distribution_from_samples,
+    )
+
+    return strategy_eq_recovery_distribution_from_samples(
+        output["strategy_eq_recovery_samples"],
+        sample_interval_days=output["strategy_eq_recovery_sample_interval_days"],
+    ).cpu()
 
 
 def _directional_coin_hsl_lookback_bars(
@@ -1198,6 +1230,9 @@ class MpsSingleCoinProxy:
             hsl_raw_drawdown_enabled=bool(
                 self.needed_metrics & _HSL_RAW_DRAWDOWN_METRICS
             ),
+            recovery_distribution_enabled=bool(
+                self.needed_metrics & _STRATEGY_EQ_RECOVERY_DISTRIBUTION_METRICS
+            ),
         )
         if self.strategy_kind == "trailing_martingale":
             runner_kwargs["hsl_enabled"] = any_configured_hsl
@@ -1248,11 +1283,16 @@ class MpsSingleCoinProxy:
                 profile=self.profile_enabled,
             )
             interrupt_check()
+            recovery_distribution = _mps_strategy_eq_recovery_distribution(
+                output, self.needed_metrics
+            )
             output = {
                 key: value.cpu()
                 for key, value in output.items()
                 if key in CORE_OUTPUT_KEYS | DIRECTIONAL_HSL_OUTPUT_KEYS
             }
+            if recovery_distribution is not None:
+                output["strategy_eq_recovery_distribution"] = recovery_distribution
             timestamp_origin = float(self.metrics_data["ts0"])
             for key in (
                 "first_fill_ts",
@@ -2065,6 +2105,9 @@ class MpsMulticoinProxy:
                     profile=self.profile_enabled,
                 )
                 interrupt_check()
+                recovery_distribution = _mps_strategy_eq_recovery_distribution(
+                    raw_output, self.needed_metrics
+                )
                 output = {
                     key: value.cpu()
                     for key, value in raw_output.items()
@@ -2078,6 +2121,13 @@ class MpsMulticoinProxy:
                         profile=self.profile_enabled,
                     )
                     interrupt_check()
+                recovery_distribution = (
+                    _mps_strategy_eq_recovery_distribution(
+                        raw_side_outputs[self.sides[0]], self.needed_metrics
+                    )
+                    if len(self.sides) == 1
+                    else None
+                )
                 side_outputs = {
                     side: {
                         key: value.cpu()
@@ -2134,6 +2184,8 @@ class MpsMulticoinProxy:
                 output["entry_initial_balance_pct_short"] = side_outputs[
                     "short"
                 ]["entry_initial_balance_pct"]
+            if recovery_distribution is not None:
+                output["strategy_eq_recovery_distribution"] = recovery_distribution
             timestamp_origin = float(self.metrics_data["ts0"])
             for key in (
                 "first_fill_ts",

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -619,10 +619,33 @@ def _require_no_internal_invalid_account_recovery_candles(
         if not bool(np.all(valid)):
             first_invalid = first + int(np.flatnonzero(~valid)[0])
             raise ValueError(
-                "MPS account-equity peak-recovery metrics require contiguous "
+                "MPS account/strategy-equity recovery metrics require contiguous "
                 "valid candles after equity tracking starts; "
                 f"coin index {coin}, invalid candle at {first_invalid}"
             )
+
+
+def _require_no_internal_invalid_single_coin_recovery_candles(
+    hlcvs,
+    *,
+    needed_metrics,
+    first_valid_idx: int,
+    last_valid_idx: int,
+    tracking_start_idx: int,
+) -> None:
+    recovery_metrics = (
+        _ACCOUNT_EQUITY_RECOVERY_METRICS
+        | _STRATEGY_EQ_RECOVERY_DISTRIBUTION_METRICS
+    )
+    if not set(needed_metrics) & recovery_metrics:
+        return
+    _require_no_internal_invalid_account_recovery_candles(
+        hlcvs,
+        exposure_eligible_coins=[True],
+        first_valid_indices=[first_valid_idx],
+        last_valid_indices=[last_valid_idx],
+        tracking_start_indices=[tracking_start_idx],
+    )
 
 
 def _nan_min(left, right):
@@ -1184,14 +1207,13 @@ class MpsSingleCoinProxy:
         high = hlcvs[:, 0, 0].astype(np.float64)
         low = hlcvs[:, 0, 1].astype(np.float64)
         close = hlcvs[:, 0, 2].astype(np.float64)
-        if self.needed_metrics & _ACCOUNT_EQUITY_RECOVERY_METRICS:
-            _require_no_internal_invalid_account_recovery_candles(
-                hlcvs,
-                exposure_eligible_coins=[True],
-                first_valid_indices=backtest_params["first_valid_indices"],
-                last_valid_indices=backtest_params["last_valid_indices"],
-                tracking_start_indices=[self.run.trade_start_idx],
-            )
+        _require_no_internal_invalid_single_coin_recovery_candles(
+            hlcvs,
+            needed_metrics=self.needed_metrics,
+            first_valid_idx=self.run.first_valid_idx,
+            last_valid_idx=self.run.last_valid_idx,
+            tracking_start_idx=self.run.trade_start_idx,
+        )
         if hsl_enabled_sides:
             _require_no_internal_invalid_hsl_candles(
                 high,

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -66,6 +66,7 @@ from optimization.backends.gpu_backend import (
     _update_probe_shortfall_log,
     _validate_directional_search_space,
     _validate_dual_multicoin_metrics,
+    _validate_recovery_distribution_scope,
     _validate_gpu_optimizer_overrides,
     _validate_gpu_coin_overrides,
     _validate_pinned_scope_bounds,
@@ -2501,6 +2502,12 @@ def test_gpu_multicoin_foundation_rejects_asymmetric_dual_side_coins(strategy_ki
         "position_unchanged_hours_max",
         "positions_held_per_day",
         "strategy_eq_recovery_days_max",
+        "strategy_eq_recovery_days_mean",
+        "strategy_eq_recovery_days_median",
+        "strategy_eq_recovery_days_p95",
+        "strategy_eq_recovery_days_p99",
+        "strategy_eq_recovery_days_mean_worst_5pct",
+        "strategy_eq_recovery_days_mean_worst_1pct",
         "total_wallet_exposure_max",
         "total_wallet_exposure_mean",
         "volume_pct_per_day_avg",
@@ -2548,6 +2555,12 @@ def test_gpu_dual_multicoin_metric_gate_does_not_narrow_single_side():
             "position_unchanged_hours_max",
             "positions_held_per_day",
             "strategy_eq_recovery_days_max",
+            "strategy_eq_recovery_days_mean",
+            "strategy_eq_recovery_days_median",
+            "strategy_eq_recovery_days_p95",
+            "strategy_eq_recovery_days_p99",
+            "strategy_eq_recovery_days_mean_worst_5pct",
+            "strategy_eq_recovery_days_mean_worst_1pct",
             "total_wallet_exposure_max",
             "total_wallet_exposure_mean",
             "volume_pct_per_day_avg",
@@ -2555,6 +2568,23 @@ def test_gpu_dual_multicoin_metric_gate_does_not_narrow_single_side():
         coin_count=3,
         enabled_sides={"long"},
     )
+
+
+@pytest.mark.parametrize(
+    "metric",
+    [
+        "strategy_eq_recovery_days_mean",
+        "strategy_eq_recovery_days_median",
+        "strategy_eq_recovery_days_p95",
+        "strategy_eq_recovery_days_p99",
+        "strategy_eq_recovery_days_mean_worst_5pct",
+        "strategy_eq_recovery_days_mean_worst_1pct",
+    ],
+)
+def test_gpu_recovery_distribution_metrics_fail_closed_for_multicoin(metric):
+    _validate_recovery_distribution_scope({metric}, coin_count=1)
+    with pytest.raises(ValueError, match="require a single-coin optimization"):
+        _validate_recovery_distribution_scope({metric}, coin_count=2)
 
 
 @pytest.mark.parametrize(

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -16,6 +16,7 @@ from optimization.gpu.metrics import (
     _fill_gap_metrics,
     _hard_stop_lifecycle_metrics,
     _hard_stop_panic_loss_metrics,
+    _strategy_eq_recovery_distribution_metrics,
     _loss_profit_ratio,
     _masked_median,
     _mean_worst_one_pct_abs,
@@ -976,6 +977,31 @@ def test_hard_stop_strategy_equity_recovery_fails_closed_without_raw_outputs():
                 "hsl_strategy_eq_recovery_max_ms_long": torch.tensor([60_000.0]),
             }
         )
+
+
+def test_strategy_eq_recovery_distribution_maps_mps_columns():
+    expected = torch.tensor(
+        [[1.25, 1.0, 3.5, 4.0, 4.5, 5.0, 5.5]], dtype=torch.float32
+    )
+
+    metrics = _strategy_eq_recovery_distribution_metrics(
+        {"strategy_eq_recovery_distribution": expected}
+    )
+
+    assert {name: value.item() for name, value in metrics.items()} == {
+        "strategy_eq_recovery_days_mean": 1.25,
+        "strategy_eq_recovery_days_median": 1.0,
+        "strategy_eq_recovery_days_p95": 3.5,
+        "strategy_eq_recovery_days_p99": 4.0,
+        "strategy_eq_recovery_days_mean_worst_5pct": 4.5,
+        "strategy_eq_recovery_days_mean_worst_1pct": 5.0,
+    }
+    assert set(metrics) <= set(SUPPORTED_METRICS)
+
+
+def test_strategy_eq_recovery_distribution_fails_closed_without_mps_output():
+    with pytest.raises(RuntimeError, match="recovery-distribution output is missing"):
+        _strategy_eq_recovery_distribution_metrics({})
 
 
 def test_hard_stop_lifecycle_reduction_matches_rust_formulas():

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -5850,6 +5850,109 @@ def test_mps_recovery_captures_early_post_fill_liquidation_endpoint():
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+def test_mps_recovery_fails_closed_on_coin_hsl_rolling_overflow(strategy_kind):
+    count = 12
+    close = np.full(count, 100.0)
+    high = np.full(count, 101.0)
+    low = np.full(count, 99.0)
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.001)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    if strategy_kind == "trailing_martingale":
+        row = _tm_single_row(initial_ema_dist=0.0)
+        keys = TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS
+        runner_cls = MpsTrailingMartingaleRunner
+    else:
+        row = _single_coin_param_row(
+            {
+                "base_qty_pct": 0.5,
+                "ema_span_0": 2.0,
+                "ema_span_1": 3.0,
+                "entry_double_down_factor": 1.0,
+                "offset": 0.0,
+                "offset_psize_weight": 0.0,
+                "offset_volatility_1h_weight": 0.0,
+                "offset_volatility_1m_weight": 0.0,
+                "offset_volatility_ema_span_1h": 2.0,
+                "offset_volatility_ema_span_1m": 2.0,
+                "entry_cooldown_minutes": 0.0,
+                "total_wallet_exposure_limit": 1.0,
+                "we_excess_allowance_pct": 0.0,
+                "we_excess_allowance_legacy_raw": 0.0,
+                "twel_entry_gate_enabled": 1.0,
+                "twel_enforcer_threshold": 1.0,
+                "twel_enforcer_enabled": 0.0,
+            },
+            EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
+        )
+        keys = EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS
+        runner_cls = MpsEmaAnchorRunner
+    for key, value in {
+        "hsl_enabled": 1.0,
+        "hsl_red_threshold": 1.0e-8,
+        "hsl_ema_span_minutes": 1.0,
+        "hsl_cooldown_minutes_after_red": 0.0,
+        "hsl_no_restart_drawdown_threshold": 1.0,
+        "hsl_restart_policy": 2.0,
+        "hsl_tier_ratio_yellow": 0.5,
+        "hsl_tier_ratio_orange": 0.75,
+        "hsl_orange_graceful_stop": 0.0,
+        "hsl_signal_mode": 2.0,
+        "hsl_slot_count": 1.0,
+    }.items():
+        row[keys.index(key)] = value
+
+    runner = runner_cls(
+        market,
+        run,
+        data,
+        long_enabled=True,
+        short_enabled=False,
+        pnl_lookback_bars=count,
+        hsl_panic_market_long=True,
+        recovery_distribution_enabled=True,
+    )
+    # Exercise the production overflow path without needing 2,049 fills.
+    runner.rolling_capacity = 1
+    output = runner.run(np.asarray([row + row], dtype=np.float64))
+    recovery = strategy_eq_recovery_distribution_from_samples(
+        output["strategy_eq_recovery_samples"],
+        sample_interval_days=output[
+            "strategy_eq_recovery_sample_interval_days"
+        ],
+    )
+    torch.mps.synchronize()
+
+    assert not output["alive"].item()
+    assert output["balance"].item() == 0.0
+    samples = output["strategy_eq_recovery_samples"][0]
+    assert torch.isfinite(samples[0]).item()
+    assert samples[0].item() < 0.0
+    expected_full_horizon_days = (
+        runner.n_recovery_samples - 1
+    ) * runner.recovery_stride * run.interval_ms / 86_400_000.0
+    assert torch.allclose(
+        recovery[0],
+        torch.full_like(recovery[0], expected_full_horizon_days),
+    )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 @pytest.mark.parametrize("hedge_mode", [False, True])
 def test_mps_dual_side_respects_one_way_initial_arbitration(hedge_mode):
     count = 5

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -5789,7 +5789,7 @@ def test_mps_ema_anchor_directionally_rounds_non_aligned_candle_touch():
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
-def test_mps_volume_uses_raw_non_positive_post_fill_balance():
+def test_mps_recovery_captures_early_post_fill_liquidation_endpoint():
     count = 64
     close = np.full(count, 100.0)
     high = np.full(count, 101.0)
@@ -5823,11 +5823,28 @@ def test_mps_volume_uses_raw_non_positive_post_fill_balance():
         dtype=np.float64,
     )
 
-    output = MpsEmaAnchorRunner(market, run, data).run(parameters)
+    runner = MpsEmaAnchorRunner(
+        market, run, data, recovery_distribution_enabled=True
+    )
+    output = runner.run(parameters)
     torch.mps.synchronize()
 
     assert output["day_has_fill"].sum().item() > 0
     assert output["day_volume"].sum().item() < 0.0
+    assert not output["alive"].item()
+    samples = output["strategy_eq_recovery_samples"][0]
+    finite_samples = samples[torch.isfinite(samples)]
+    assert finite_samples.numel() >= 2
+    assert finite_samples[-1].item() == pytest.approx(
+        run.starting_balance * run.liquidation_threshold
+    )
+    recovery = strategy_eq_recovery_distribution_from_samples(
+        output["strategy_eq_recovery_samples"],
+        sample_interval_days=output[
+            "strategy_eq_recovery_sample_interval_days"
+        ],
+    )
+    assert recovery[0, 3].item() > 0.0
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -26,6 +26,8 @@ from optimization.gpu.mps_kernel import (
     _encode_max_realized_loss_pct,
     _with_hsl_ema_tail,
     _with_hsl_features,
+    _with_recovery_distribution,
+    strategy_eq_recovery_distribution_from_samples,
 )
 from optimization.gpu.metrics import _fill_gap_metrics, compute_objectives
 from optimization.gpu.service import MpsMulticoinEmaProxy
@@ -155,6 +157,43 @@ def test_hsl_raw_drawdown_source_variant_is_opt_in_and_guarded():
         _with_hsl_features(
             "body", ema_tail_enabled=False, raw_drawdown_enabled=True
         )
+
+
+def test_recovery_distribution_source_variant_is_opt_in_and_guarded():
+    source = "#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED\nbody"
+
+    assert _with_recovery_distribution(source, False) is source
+    assert _with_recovery_distribution(source, True) == (
+        "#define PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED 1\n"
+        + source
+    )
+    with pytest.raises(RuntimeError, match="recovery-distribution feature guard"):
+        _with_recovery_distribution("body", True)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_strategy_eq_recovery_distribution_matches_strict_rust_contract():
+    matrix = torch.tensor(
+        [
+            [100.0, 90.0, 95.0, 101.0, 100.0, 102.0],
+            [100.0, 100.0, 101.0, float("nan"), float("nan"), float("nan")],
+        ],
+        dtype=torch.float32,
+        device="mps",
+    )
+
+    actual = strategy_eq_recovery_distribution_from_samples(
+        matrix, sample_interval_days=1.0 / 24.0
+    ).cpu().numpy()
+
+    assert actual[0].tolist() == pytest.approx(
+        [value / 24.0 for value in [8.0 / 6.0, 1.0, 2.75, 2.95, 3.0, 3.0, 3.0]]
+    )
+    assert actual[1].tolist() == pytest.approx(
+        [value / 24.0 for value in [1.0, 1.0, 1.9, 1.98, 2.0, 2.0, 2.0]]
+    )
 
 
 def test_trailing_martingale_no_hsl_specialization_keeps_base_scalar_abi(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -85,11 +85,9 @@ def test_recovery_distribution_postprocessor_is_opt_in_and_fail_closed(monkeypat
     with pytest.raises(RuntimeError, match="recovery sampling output is missing"):
         _mps_strategy_eq_recovery_distribution({}, needed)
 
-    import torch
-    from optimization.gpu import mps_kernel
-
-    samples = torch.tensor([[100.0, 90.0, 101.0]])
-    expected = torch.ones((1, 7))
+    samples = object()
+    expected = SimpleNamespace()
+    expected.cpu = lambda: expected
     called = {}
 
     def fake_postprocessor(values, *, sample_interval_days):
@@ -97,10 +95,12 @@ def test_recovery_distribution_postprocessor_is_opt_in_and_fail_closed(monkeypat
         called["sample_interval_days"] = sample_interval_days
         return expected
 
-    monkeypatch.setattr(
-        mps_kernel,
-        "strategy_eq_recovery_distribution_from_samples",
-        fake_postprocessor,
+    fake_mps_kernel = ModuleType("optimization.gpu.mps_kernel")
+    fake_mps_kernel.strategy_eq_recovery_distribution_from_samples = (
+        fake_postprocessor
+    )
+    monkeypatch.setitem(
+        sys.modules, "optimization.gpu.mps_kernel", fake_mps_kernel
     )
     actual = _mps_strategy_eq_recovery_distribution(
         {

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -36,6 +36,7 @@ from optimization.gpu.service import (
     _directional_gross_pnl_outputs,
     _hsl_params,
     _mps_dispatch_batch_size,
+    _mps_strategy_eq_recovery_distribution,
     _multicoin_exposure_eligible_coins,
     _position_exposure_enforcer_params,
     _prepared_single_coin_side_enabled,
@@ -75,6 +76,45 @@ def test_directional_coin_hsl_lookback_bar_contract(
         )
         == expected
     )
+
+
+def test_recovery_distribution_postprocessor_is_opt_in_and_fail_closed(monkeypatch):
+    needed = {"strategy_eq_recovery_days_p99"}
+
+    assert _mps_strategy_eq_recovery_distribution({}, {"adg_strategy_eq"}) is None
+    with pytest.raises(RuntimeError, match="recovery sampling output is missing"):
+        _mps_strategy_eq_recovery_distribution({}, needed)
+
+    import torch
+    from optimization.gpu import mps_kernel
+
+    samples = torch.tensor([[100.0, 90.0, 101.0]])
+    expected = torch.ones((1, 7))
+    called = {}
+
+    def fake_postprocessor(values, *, sample_interval_days):
+        called["values"] = values
+        called["sample_interval_days"] = sample_interval_days
+        return expected
+
+    monkeypatch.setattr(
+        mps_kernel,
+        "strategy_eq_recovery_distribution_from_samples",
+        fake_postprocessor,
+    )
+    actual = _mps_strategy_eq_recovery_distribution(
+        {
+            "strategy_eq_recovery_samples": samples,
+            "strategy_eq_recovery_sample_interval_days": 1.0 / 24.0,
+        },
+        needed,
+    )
+
+    assert called == {
+        "values": samples,
+        "sample_interval_days": 1.0 / 24.0,
+    }
+    assert actual is expected
 
 
 @pytest.mark.parametrize(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -45,6 +45,7 @@ from optimization.gpu.service import (
     _require_no_internal_invalid_account_recovery_candles,
     _require_no_internal_invalid_hsl_candles,
     _require_no_internal_invalid_multicoin_hsl_candles,
+    _require_no_internal_invalid_single_coin_recovery_candles,
     _refresh_hedged_multicoin_hsl_at_portfolio_cutoff,
     _single_coin_exposure_params,
     _total_exposure_enforcer_params,
@@ -1065,6 +1066,27 @@ def test_gpu_account_equity_recovery_requires_tracked_candles_to_be_contiguous()
         last_valid_indices=[3, 3],
         tracking_start_indices=[1, 1],
     )
+
+
+def test_gpu_strategy_equity_recovery_distribution_rejects_internal_invalid_candle():
+    hlcvs = np.ones((4, 1, 4), dtype=np.float64)
+    hlcvs[2, 0, :3] = np.nan
+
+    _require_no_internal_invalid_single_coin_recovery_candles(
+        hlcvs,
+        needed_metrics={"adg_strategy_eq"},
+        first_valid_idx=0,
+        last_valid_idx=3,
+        tracking_start_idx=1,
+    )
+    with pytest.raises(ValueError, match="invalid candle at 2"):
+        _require_no_internal_invalid_single_coin_recovery_candles(
+            hlcvs,
+            needed_metrics={"strategy_eq_recovery_days_p99"},
+            first_valid_idx=0,
+            last_valid_idx=3,
+            tracking_start_idx=1,
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- add single-coin Apple MPS proxy support for the six global strategy-equity recovery-distribution scoring/limit metrics for EMA Anchor and Trailing Martingale
- emit opt-in hourly strategy-equity samples from guarded directional kernel variants, then apply Rust-compatible strict time-to-exceed, percentile, and worst-tail reductions in a bounded Metal postprocessor
- keep exact Rust validation and rolling drift gates authoritative, preserve the pre-feature kernel ABI for ordinary metrics, and fail closed for multicoin recovery distributions

## Validation

- cargo test --no-default-features: 267 passed
- full test_gpu_backend.py, test_gpu_metrics.py, test_gpu_service.py, and physical test_gpu_mps.py matrix: passed
- physical M3 strict-contract Metal fixture: passed
- EMA Anchor SOL, Bybit 2025-01 through 2025-04, 512 population/batch, 4,096 proxies plus 64 exact validations: all six metrics completed without a safety halt; exact constraint agreement 1.000
- independent EMA Anchor XMR p95 probe and Trailing Martingale six-objective probe completed without safety halts; exact constraint agreement 1.000
- deterministic ordinary-objective comparison against exact pre-slice master: 25.8s branch versus 25.4s master for 4,096 proxies plus 64 exact validations; no material default-path regression

## Scope

This deliberately covers single-coin global strategy-equity recovery distributions only. Multi-coin kernels do not yet emit equivalent bounded samples and reject these metrics with an actionable CPU fallback message.
