### PR TITLE
Support multicoin GPU recovery distributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,17 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
-- Added global strategy-equity recovery-distribution scoring and limits to single-coin Apple MPS
-  optimization for EMA Anchor and Trailing Martingale. Directional kernels emit opt-in
-  candidate-relative hourly strategy-equity samples with mandatory initial and
-  terminal/liquidation endpoints, and a bounded Metal postprocessor applies Rust's strict
+- Added global strategy-equity recovery-distribution scoring and limits to Apple MPS optimization
+  for EMA Anchor and Trailing Martingale across single-coin, one-sided multi-coin, and fused
+  shared-account dual-side multi-coin runs. Strategy kernels emit opt-in candidate-relative hourly
+  strategy-equity samples with mandatory initial and terminal/liquidation endpoints, and a bounded
+  Metal postprocessor applies Rust's strict
   time-to-exceed, percentile, and worst-tail definitions for
   `strategy_eq_recovery_days_{mean,median,p95,p99,mean_worst_5pct,mean_worst_1pct}`. Exact Rust
   validation and rolling drift gates remain authoritative. Histories with internal invalid candles
-  remain fail closed, a bounded coin-HSL rolling-PnL overflow emits a conservative full-horizon
-  recovery penalty, and multi-coin recovery distributions remain fail closed.
+  remain fail closed, and a bounded single-coin coin-HSL rolling-PnL overflow emits a conservative
+  full-horizon recovery penalty. Independent dual-side multi-coin summaries remain fail closed
+  because they cannot reconstruct one shared portfolio-equity curve.
 
 - Added raw per-side HSL strategy-equity worst-drawdown scoring and limits to Apple MPS
   optimization for EMA Anchor and Trailing Martingale, across single-coin and multi-coin

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -172,17 +172,18 @@ The supported slice is intentionally narrow:
   strictly exceeds its prior controller peak, including an unrecovered tail through the backtest
   end. Raw per-side `drawdown_worst_strategy_eq_{long,short}` is also available through an opt-in
   bounded peak-and-maximum accumulator, with exact Rust validation retaining authority over the
-  approximate fill path. Single-coin EMA Anchor and Trailing Martingale also support the global
+  approximate fill path. Single-coin, one-sided multi-coin, and fused shared-account dual-side
+  multi-coin EMA Anchor and Trailing Martingale also support the global
   `strategy_eq_recovery_days_{mean,median,p95,p99,mean_worst_5pct,mean_worst_1pct}` metrics. The
-  directional kernels emit opt-in candidate-relative hourly strategy-equity samples plus mandatory
+  strategy kernels emit opt-in candidate-relative hourly strategy-equity samples plus mandatory
   initial and terminal/liquidation endpoints, and a bounded Metal postprocessor applies the same
   strict time-to-exceed and percentile/tail definitions as exact Rust. The hourly proxy is
   approximate; exact Rust validation and rolling drift gates remain authoritative. Tracked
   histories with internal invalid candles fail closed because exact Rust records balance-only
   strategy equity at those steps. A bounded coin-HSL rolling-PnL overflow also fails closed with a
-  conservative full-horizon recovery penalty. Multi-coin recovery-distribution metrics remain fail
-  closed until the shared portfolio kernels can emit equivalent bounded samples. Compatible suites
-  may use the supported topologies.
+  conservative full-horizon recovery penalty. Independent dual-side multi-coin summaries remain
+  fail closed for these metrics because they cannot reconstruct one shared portfolio-equity curve.
+  Compatible suites may use the supported topologies.
 - single-coin EMA Anchor and Trailing Martingale support auto-unstuck for long-only,
   short-only, hedge-mode dual-side, one-way, and compatible suite runs. One-sided multi-coin runs
   and compatible suites also support auto-unstuck, including static per-coin overrides. Metal

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -232,6 +232,16 @@ mod tests {
         assert!(source.contains("if (is_long) account.realized_pnl_long += net_pnl"));
         assert!(source.contains("else account.realized_pnl_short += net_pnl"));
         assert!(source.contains("long_hsl.signal_mode != short_hsl.signal_mode"));
+        assert!(source.contains(
+            "#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED"
+        ));
+        assert!(source.contains("const int recovery_stride = sizes[8]"));
+        assert!(source.contains("const int recovery_sample_count = sizes[9]"));
+        assert!(source.contains(
+            "const bool recovery_terminal = liquidated || k == stop_k - 1"
+        ));
+        assert!(source.contains("int(b) * recovery_sample_count + sample_index"));
+        assert!(source.contains("= RECOVERY_FAIL_CLOSED_SENTINEL;"));
         assert!(source.contains("return update_dual_side_hsl("));
         assert!(source.contains("account.realized_pnl_total"));
         assert!(source.contains("account.realized_pnl_long, account.realized_pnl_short"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -18,6 +18,9 @@ constant int SCALAR_COLS = 61;
 constant int FUSED_SCALAR_COLS = 66;
 #endif
 constant int GAP_BINS = 128;
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+constant float RECOVERY_FAIL_CLOSED_SENTINEL = -3.402823466e+38f;
+#endif
 
 // PASSIVBOT_HSL_COMMON
 
@@ -2008,6 +2011,9 @@ inline void passivbot_ema_anchor_multicoin_impl(
     device float* scalars,
     device int* gap_hist,
     device float* coin_fill_counts,
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    device float* recovery_samples,
+#endif
     uint b,
     bool short_side
 ) {
@@ -2019,6 +2025,10 @@ inline void passivbot_ema_anchor_multicoin_impl(
     const int global_warmup = sizes[5];
     const int start_day_minute = sizes[6];
     const int start_hour_minute = sizes[7];
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    const int recovery_stride = sizes[8];
+    const int recovery_sample_count = sizes[9];
+#endif
     if (b >= uint(B)) return;
     const int stop_k = clamp(end_steps[b], 1, T - 1);
     const bool collect_coin_fill_counts = run_settings[6] > 0.5f;
@@ -2099,6 +2109,9 @@ inline void passivbot_ema_anchor_multicoin_impl(
     float account_recovery_max_min = 0.0f;
     float first_eq_k = -1.0f;
     float last_eq_k = -1.0f;
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    int recovery_start_k = -1;
+#endif
     int liquidation_day = -1;
     float hsl_tier_samples_total = 0.0f;
     float hsl_tier_samples_yellow = 0.0f;
@@ -2332,6 +2345,29 @@ inline void passivbot_ema_anchor_multicoin_impl(
             }
             bool liquidated = balance <= 0.0f || equity <= liquidation_floor;
             float effective_equity = liquidated ? liquidation_floor : equity;
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+            if (recovery_stride > 0 && recovery_start_k < 0) {
+                recovery_start_k = k;
+                recovery_samples[int(b) * recovery_sample_count]
+                    = effective_equity;
+            } else if (recovery_stride > 0) {
+                const int recovery_elapsed = k - recovery_start_k;
+                const bool recovery_terminal = liquidated || k == stop_k - 1;
+                const bool recovery_regular =
+                    recovery_elapsed % recovery_stride == 0;
+                if (recovery_regular || recovery_terminal) {
+                    const int sample_index = recovery_terminal
+                        ? (recovery_elapsed + recovery_stride - 1)
+                            / recovery_stride
+                        : recovery_elapsed / recovery_stride;
+                    if (sample_index < recovery_sample_count) {
+                        recovery_samples[
+                            int(b) * recovery_sample_count + sample_index
+                        ] = effective_equity;
+                    }
+                }
+            }
+#endif
             if (effective_equity >= account_peak) {
                 if (account_peak_k >= 0.0f) {
                     account_recovery_max_min = fmax(
@@ -2540,6 +2576,9 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
     device float* scalars,
     device int* gap_hist,
     device float* coin_fill_counts,
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    device float* recovery_samples,
+#endif
     uint b
 ) {
     const int B = sizes[0];
@@ -2550,6 +2589,10 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
     const int global_warmup = sizes[5];
     const int start_day_minute = sizes[6];
     const int start_hour_minute = sizes[7];
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    const int recovery_stride = sizes[8];
+    const int recovery_sample_count = sizes[9];
+#endif
     if (b >= uint(B)) return;
     const int stop_k = clamp(end_steps[b], 1, T - 1);
     const int scalar_offset = int(b) * FUSED_SCALAR_COLS;
@@ -2562,6 +2605,10 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
     if (C < 1 || C > MAX_COINS) {
         scalars[scalar_offset + 9] = 0.0f;
         scalars[scalar_offset + 13] = 0.0f;
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+        recovery_samples[int(b) * recovery_sample_count]
+            = RECOVERY_FAIL_CLOSED_SENTINEL;
+#endif
         return;
     }
     const bool collect_coin_fill_counts = run_settings[6] > 0.5f;
@@ -2598,6 +2645,10 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
     if (!topology_valid) {
         scalars[scalar_offset + 9] = 0.0f;
         scalars[scalar_offset + 13] = 0.0f;
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+        recovery_samples[int(b) * recovery_sample_count]
+            = RECOVERY_FAIL_CLOSED_SENTINEL;
+#endif
         return;
     }
 
@@ -2646,6 +2697,9 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
     float account_recovery_max_min = 0.0f;
     float first_eq_k = -1.0f;
     float last_eq_k = -1.0f;
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    int recovery_start_k = -1;
+#endif
     int liquidation_day = -1;
     float hsl_tier_samples_total = 0.0f;
     float hsl_tier_samples_yellow = 0.0f;
@@ -2902,6 +2956,29 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                 || equity <= liquidation_floor;
             float effective_equity = liquidated
                 ? liquidation_floor : equity;
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+            if (recovery_stride > 0 && recovery_start_k < 0) {
+                recovery_start_k = k;
+                recovery_samples[int(b) * recovery_sample_count]
+                    = effective_equity;
+            } else if (recovery_stride > 0) {
+                const int recovery_elapsed = k - recovery_start_k;
+                const bool recovery_terminal = liquidated || k == stop_k - 1;
+                const bool recovery_regular =
+                    recovery_elapsed % recovery_stride == 0;
+                if (recovery_regular || recovery_terminal) {
+                    const int sample_index = recovery_terminal
+                        ? (recovery_elapsed + recovery_stride - 1)
+                            / recovery_stride
+                        : recovery_elapsed / recovery_stride;
+                    if (sample_index < recovery_sample_count) {
+                        recovery_samples[
+                            int(b) * recovery_sample_count + sample_index
+                        ] = effective_equity;
+                    }
+                }
+            }
+#endif
             if (effective_equity >= account_peak) {
                 if (account_peak_k >= 0.0f) {
                     account_recovery_max_min = fmax(
@@ -3131,13 +3208,20 @@ kernel void passivbot_ema_anchor_multicoin_fused(
     device float* scalars,
     device int* gap_hist,
     device float* coin_fill_counts,
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    device float* recovery_samples,
+#endif
     uint b [[thread_position_in_grid]]
 ) {
     passivbot_ema_anchor_multicoin_fused_impl(
         bars, fill_ticks, touch_ticks, coin_settings,
         long_coin_overrides, short_coin_overrides,
         params, run_settings, sizes, end_steps,
-        daily, scalars, gap_hist, coin_fill_counts, b
+        daily, scalars, gap_hist, coin_fill_counts,
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+        recovery_samples,
+#endif
+        b
     );
 }
 
@@ -3155,12 +3239,19 @@ kernel void passivbot_ema_anchor_multicoin(
     device float* scalars,
     device int* gap_hist,
     device float* coin_fill_counts,
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    device float* recovery_samples,
+#endif
     uint b [[thread_position_in_grid]]
 ) {
     const bool short_side = run_settings[3] > 0.5f;
     passivbot_ema_anchor_multicoin_impl(
         bars, fill_ticks, touch_ticks, coin_settings, coin_overrides, params, run_settings,
-        sizes, end_steps, daily, scalars, gap_hist, coin_fill_counts, b, short_side
+        sizes, end_steps, daily, scalars, gap_hist, coin_fill_counts,
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+        recovery_samples,
+#endif
+        b, short_side
     );
 }
 
@@ -3178,10 +3269,17 @@ kernel void passivbot_ema_anchor_multicoin_long(
     device float* scalars,
     device int* gap_hist,
     device float* coin_fill_counts,
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    device float* recovery_samples,
+#endif
     uint b [[thread_position_in_grid]]
 ) {
     passivbot_ema_anchor_multicoin_impl(
         bars, fill_ticks, touch_ticks, coin_settings, coin_overrides, params, run_settings,
-        sizes, end_steps, daily, scalars, gap_hist, coin_fill_counts, b, false
+        sizes, end_steps, daily, scalars, gap_hist, coin_fill_counts,
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+        recovery_samples,
+#endif
+        b, false
     );
 }

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -18,6 +18,9 @@ constant int SCALAR_COLS = 61;
 constant int FUSED_SCALAR_COLS = 66;
 #endif
 constant int GAP_BINS = 128;
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+constant float RECOVERY_FAIL_CLOSED_SENTINEL = -3.402823466e+38f;
+#endif
 
 // PASSIVBOT_HSL_COMMON
 
@@ -2986,6 +2989,9 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
     device float* scalars,
     device int* gap_hist,
     device float* coin_fill_counts,
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    device float* recovery_samples,
+#endif
     uint b
 ) {
     const int B = sizes[0];
@@ -2996,6 +3002,10 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
     const int global_warmup = sizes[5];
     const int start_day_minute = sizes[6];
     const int start_hour_minute = sizes[7];
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    const int recovery_stride = sizes[8];
+    const int recovery_sample_count = sizes[9];
+#endif
     if (b >= uint(B)) return;
     const int stop_k = clamp(end_steps[b], 1, T - 1);
     const int scalar_offset = int(b) * FUSED_SCALAR_COLS;
@@ -3008,6 +3018,10 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
     if (C < 1 || C > MAX_COINS) {
         scalars[scalar_offset + 9] = 0.0f;
         scalars[scalar_offset + 13] = 0.0f;
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+        recovery_samples[int(b) * recovery_sample_count]
+            = RECOVERY_FAIL_CLOSED_SENTINEL;
+#endif
         return;
     }
     const bool collect_coin_fill_counts = run_settings[6] > 0.5f;
@@ -3046,6 +3060,10 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
     if (!topology_valid) {
         scalars[scalar_offset + 9] = 0.0f;
         scalars[scalar_offset + 13] = 0.0f;
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+        recovery_samples[int(b) * recovery_sample_count]
+            = RECOVERY_FAIL_CLOSED_SENTINEL;
+#endif
         return;
     }
 
@@ -3095,6 +3113,9 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
     float account_recovery_max_min = 0.0f;
     float first_eq_k = -1.0f;
     float last_eq_k = -1.0f;
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    int recovery_start_k = -1;
+#endif
     int liquidation_day = -1;
     float hsl_tier_samples_total = 0.0f;
     float hsl_tier_samples_yellow = 0.0f;
@@ -3359,6 +3380,29 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
                 || equity <= liquidation_floor;
             float effective_equity = liquidated
                 ? liquidation_floor : equity;
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+            if (recovery_stride > 0 && recovery_start_k < 0) {
+                recovery_start_k = k;
+                recovery_samples[int(b) * recovery_sample_count]
+                    = effective_equity;
+            } else if (recovery_stride > 0) {
+                const int recovery_elapsed = k - recovery_start_k;
+                const bool recovery_terminal = liquidated || k == stop_k - 1;
+                const bool recovery_regular =
+                    recovery_elapsed % recovery_stride == 0;
+                if (recovery_regular || recovery_terminal) {
+                    const int sample_index = recovery_terminal
+                        ? (recovery_elapsed + recovery_stride - 1)
+                            / recovery_stride
+                        : recovery_elapsed / recovery_stride;
+                    if (sample_index < recovery_sample_count) {
+                        recovery_samples[
+                            int(b) * recovery_sample_count + sample_index
+                        ] = effective_equity;
+                    }
+                }
+            }
+#endif
             if (effective_equity >= account_peak) {
                 if (account_peak_k >= 0.0f) {
                     account_recovery_max_min = fmax(
@@ -3591,6 +3635,9 @@ kernel void passivbot_trailing_martingale_multicoin_fused(
     device float* scalars,
     device int* gap_hist,
     device float* coin_fill_counts,
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    device float* recovery_samples,
+#endif
     uint b [[thread_position_in_grid]]
 ) {
     passivbot_trailing_martingale_multicoin_fused_impl(
@@ -3598,7 +3645,11 @@ kernel void passivbot_trailing_martingale_multicoin_fused(
         touch_min_qty_bits, touch_min_qty_relation, coin_settings,
         long_coin_overrides, short_coin_overrides,
         params, run_settings, sizes, end_steps,
-        daily, scalars, gap_hist, coin_fill_counts, b
+        daily, scalars, gap_hist, coin_fill_counts,
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+        recovery_samples,
+#endif
+        b
     );
 }
 
@@ -3619,6 +3670,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     device float* scalars,
     device int* gap_hist,
     device float* coin_fill_counts,
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    device float* recovery_samples,
+#endif
     uint b,
     bool short_side
 ) {
@@ -3630,6 +3684,10 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     const int global_warmup = sizes[5];
     const int start_day_minute = sizes[6];
     const int start_hour_minute = sizes[7];
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    const int recovery_stride = sizes[8];
+    const int recovery_sample_count = sizes[9];
+#endif
     if (b >= uint(B)) return;
     const int stop_k = clamp(end_steps[b], 1, T - 1);
     const bool collect_coin_fill_counts = run_settings[6] > 0.5f;
@@ -3715,6 +3773,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     float account_recovery_max_min = 0.0f;
     float first_eq_k = -1.0f;
     float last_eq_k = -1.0f;
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    int recovery_start_k = -1;
+#endif
     int liquidation_day = -1;
     float hsl_tier_samples_total = 0.0f;
     float hsl_tier_samples_yellow = 0.0f;
@@ -3949,6 +4010,29 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             }
             bool liquidated = balance <= 0.0f || equity <= liquidation_floor;
             float effective_equity = liquidated ? liquidation_floor : equity;
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+            if (recovery_stride > 0 && recovery_start_k < 0) {
+                recovery_start_k = k;
+                recovery_samples[int(b) * recovery_sample_count]
+                    = effective_equity;
+            } else if (recovery_stride > 0) {
+                const int recovery_elapsed = k - recovery_start_k;
+                const bool recovery_terminal = liquidated || k == stop_k - 1;
+                const bool recovery_regular =
+                    recovery_elapsed % recovery_stride == 0;
+                if (recovery_regular || recovery_terminal) {
+                    const int sample_index = recovery_terminal
+                        ? (recovery_elapsed + recovery_stride - 1)
+                            / recovery_stride
+                        : recovery_elapsed / recovery_stride;
+                    if (sample_index < recovery_sample_count) {
+                        recovery_samples[
+                            int(b) * recovery_sample_count + sample_index
+                        ] = effective_equity;
+                    }
+                }
+            }
+#endif
             if (effective_equity >= account_peak) {
                 if (account_peak_k >= 0.0f) {
                     account_recovery_max_min = fmax(
@@ -4139,6 +4223,9 @@ kernel void passivbot_trailing_martingale_multicoin(
     device float* scalars,
     device int* gap_hist,
     device float* coin_fill_counts,
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    device float* recovery_samples,
+#endif
     uint b [[thread_position_in_grid]]
 ) {
     const bool short_side = run_settings[3] > 0.5f;
@@ -4146,7 +4233,11 @@ kernel void passivbot_trailing_martingale_multicoin(
         bars, fill_ticks, touch_ticks, touch_nearest_ticks,
         touch_min_qty_bits, touch_min_qty_relation, coin_settings,
         coin_overrides, params, run_settings,
-        sizes, end_steps, daily, scalars, gap_hist, coin_fill_counts, b, short_side
+        sizes, end_steps, daily, scalars, gap_hist, coin_fill_counts,
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+        recovery_samples,
+#endif
+        b, short_side
     );
 }
 
@@ -4167,12 +4258,19 @@ kernel void passivbot_trailing_martingale_multicoin_long(
     device float* scalars,
     device int* gap_hist,
     device float* coin_fill_counts,
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+    device float* recovery_samples,
+#endif
     uint b [[thread_position_in_grid]]
 ) {
     passivbot_trailing_martingale_multicoin_impl(
         bars, fill_ticks, touch_ticks, touch_nearest_ticks,
         touch_min_qty_bits, touch_min_qty_relation, coin_settings,
         coin_overrides, params, run_settings,
-        sizes, end_steps, daily, scalars, gap_hist, coin_fill_counts, b, false
+        sizes, end_steps, daily, scalars, gap_hist, coin_fill_counts,
+#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
+        recovery_samples,
+#endif
+        b, false
     );
 }

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -1132,24 +1132,6 @@ def _validate_dual_multicoin_metrics(
         )
 
 
-def _validate_recovery_distribution_scope(
-    needed_metrics, *, coin_count: int
-) -> None:
-    recovery_distribution_metrics = {
-        "strategy_eq_recovery_days_mean",
-        "strategy_eq_recovery_days_median",
-        "strategy_eq_recovery_days_p95",
-        "strategy_eq_recovery_days_p99",
-        "strategy_eq_recovery_days_mean_worst_5pct",
-        "strategy_eq_recovery_days_mean_worst_1pct",
-    }
-    if int(coin_count) > 1 and set(needed_metrics) & recovery_distribution_metrics:
-        raise ValueError(
-            "GPU strategy-equity recovery-distribution metrics currently require "
-            "a single-coin optimization; use other multicoin metrics or the CPU optimizer"
-        )
-
-
 def _validate_hsl_metric_topology(
     needed_metrics,
     *,
@@ -3297,9 +3279,6 @@ def run_backend(
             f"GPU foundation does not implement optimizer metrics {unsupported}; "
             "use supported metrics or the CPU optimizer"
         )
-    _validate_recovery_distribution_scope(
-        needed_metrics, coin_count=max_coin_count
-    )
     _validate_hsl_metric_topology(
         needed_metrics,
         coin_count=max_coin_count,

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -165,38 +165,46 @@ def _trailing_martingale_short_no_hsl_shader_library(
     )
 
 
-@lru_cache(maxsize=4)
+@lru_cache(maxsize=8)
 def _ema_anchor_multicoin_shader_library(
     hsl_ema_tail_enabled: bool = False,
     hsl_raw_drawdown_enabled: bool = False,
+    recovery_distribution_enabled: bool = False,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
     return torch.mps.compile_shader(
-        _with_hsl_features(
-            passivbot_rust.mps_ema_anchor_multicoin_source_py(),
-            ema_tail_enabled=hsl_ema_tail_enabled,
-            raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+        _with_recovery_distribution(
+            _with_hsl_features(
+                passivbot_rust.mps_ema_anchor_multicoin_source_py(),
+                ema_tail_enabled=hsl_ema_tail_enabled,
+                raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+            ),
+            recovery_distribution_enabled,
         )
     )
 
 
-@lru_cache(maxsize=4)
+@lru_cache(maxsize=8)
 def _trailing_martingale_multicoin_shader_library(
     hsl_ema_tail_enabled: bool = False,
     hsl_raw_drawdown_enabled: bool = False,
+    recovery_distribution_enabled: bool = False,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
     return torch.mps.compile_shader(
-        _with_hsl_features(
-            passivbot_rust.mps_trailing_martingale_multicoin_source_py(),
-            ema_tail_enabled=hsl_ema_tail_enabled,
-            raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+        _with_recovery_distribution(
+            _with_hsl_features(
+                passivbot_rust.mps_trailing_martingale_multicoin_source_py(),
+                ema_tail_enabled=hsl_ema_tail_enabled,
+                raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+            ),
+            recovery_distribution_enabled,
         )
     )
 
@@ -820,6 +828,7 @@ class MpsEmaAnchorMulticoinRunner:
         hsl_panic_market: bool = False,
         hsl_ema_tail_enabled: bool = False,
         hsl_raw_drawdown_enabled: bool = False,
+        recovery_distribution_enabled: bool = False,
     ):
         if side not in {"long", "short"}:
             raise ValueError(
@@ -829,6 +838,7 @@ class MpsEmaAnchorMulticoinRunner:
         self.collect_coin_fill_counts = bool(collect_coin_fill_counts)
         self.hsl_ema_tail_enabled = bool(hsl_ema_tail_enabled)
         self.hsl_raw_drawdown_enabled = bool(hsl_raw_drawdown_enabled)
+        self.recovery_distribution_enabled = bool(recovery_distribution_enabled)
         fused = self.scalar_cols == MPS_MULTICOIN_FUSED_SCALAR_COLS
         if self.hsl_raw_drawdown_enabled:
             self.scalar_cols = (
@@ -852,6 +862,19 @@ class MpsEmaAnchorMulticoinRunner:
         self.n = int(data["n"])
         self.n_coins = int(data["n_coins"])
         self.n_days = int(data["n_days"])
+        self.recovery_stride = (
+            max(1, int(np.ceil(3_600_000.0 / float(run.interval_ms))))
+            if self.recovery_distribution_enabled
+            else 0
+        )
+        self.n_recovery_samples = (
+            max(
+                1,
+                (self.n + self.recovery_stride - 1) // self.recovery_stride + 1,
+            )
+            if self.recovery_distribution_enabled
+            else 1
+        )
         self.bars = data["bars"]
         self.fill_ticks = data["fill_ticks"]
         self.touch_ticks = data["touch_ticks"]
@@ -915,6 +938,7 @@ class MpsEmaAnchorMulticoinRunner:
             device="mps",
         )
         self._buffers: dict[int, tuple[torch.Tensor, ...]] = {}
+        self._recovery_buffers: dict[int, torch.Tensor] = {}
         self._sizes: dict[tuple[int, int], torch.Tensor] = {}
         self._full_end_steps: dict[int, torch.Tensor] = {}
         self.last_profile: dict[str, float] = {}
@@ -997,10 +1021,11 @@ class MpsEmaAnchorMulticoinRunner:
         scalars,
         gaps,
         coin_fill_counts,
+        recovery_samples,
         *,
         batch_size: int,
     ) -> None:
-        library.passivbot_ema_anchor_multicoin(
+        kernel_args = (
             self.bars,
             self.fill_ticks,
             self.touch_ticks,
@@ -1014,6 +1039,11 @@ class MpsEmaAnchorMulticoinRunner:
             scalars,
             gaps,
             coin_fill_counts,
+        )
+        if self.recovery_distribution_enabled:
+            kernel_args += (recovery_samples,)
+        library.passivbot_ema_anchor_multicoin(
+            *kernel_args,
             threads=(batch_size, 1, 1),
         )
 
@@ -1021,10 +1051,23 @@ class MpsEmaAnchorMulticoinRunner:
         return _ema_anchor_multicoin_shader_library(
             self.hsl_ema_tail_enabled,
             self.hsl_raw_drawdown_enabled,
+            self.recovery_distribution_enabled,
         )
 
     def _decode(self, daily, scalars, gaps) -> dict:
         return _decode_outputs(daily, scalars, gaps)
+
+    def _recovery_sample_buffer(self, batch_size: int):
+        if batch_size not in self._recovery_buffers:
+            self._recovery_buffers[batch_size] = torch.full(
+                (batch_size, self.n_recovery_samples),
+                float("nan"),
+                dtype=torch.float32,
+                device="mps",
+            )
+        else:
+            self._recovery_buffers[batch_size].fill_(float("nan"))
+        return self._recovery_buffers[batch_size]
 
     def run(
         self,
@@ -1040,19 +1083,29 @@ class MpsEmaAnchorMulticoinRunner:
         batch_size = int(matrix.shape[0])
         end_steps_mps = self._end_steps(end_steps, batch_size)
         daily, scalars, gaps, coin_fill_counts = self._output_buffers(batch_size)
+        recovery_samples = (
+            self._recovery_sample_buffer(batch_size)
+            if self.recovery_distribution_enabled
+            else None
+        )
         sizes_key = (batch_size, int(matrix.shape[1]))
         if sizes_key not in self._sizes:
+            size_values = [
+                batch_size,
+                self.n,
+                self.n_coins,
+                self.n_days,
+                self.requested_start_idx,
+                self.run_config.warmup_bars,
+                self.start_minute_of_day,
+                self.start_minute_of_hour,
+            ]
+            if self.recovery_distribution_enabled:
+                size_values.extend(
+                    [self.recovery_stride, self.n_recovery_samples]
+                )
             self._sizes[sizes_key] = torch.tensor(
-                [
-                    batch_size,
-                    self.n,
-                    self.n_coins,
-                    self.n_days,
-                    self.requested_start_idx,
-                    self.run_config.warmup_bars,
-                    self.start_minute_of_day,
-                    self.start_minute_of_hour,
-                ],
+                size_values,
                 dtype=torch.int32,
                 device="mps",
             )
@@ -1073,6 +1126,7 @@ class MpsEmaAnchorMulticoinRunner:
             scalars,
             gaps,
             coin_fill_counts,
+            recovery_samples,
             batch_size=batch_size,
         )
         if profile:
@@ -1086,6 +1140,11 @@ class MpsEmaAnchorMulticoinRunner:
             "kernel_seconds": finished - dispatched,
         }
         output = self._decode(daily, scalars, gaps)
+        if self.recovery_distribution_enabled:
+            output["strategy_eq_recovery_samples"] = recovery_samples
+            output["strategy_eq_recovery_sample_interval_days"] = (
+                self.recovery_stride * self.run_config.interval_ms / 86_400_000.0
+            )
         if self.collect_coin_fill_counts:
             output["coin_fill_counts"] = coin_fill_counts
         return output
@@ -1111,6 +1170,7 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
         hsl_panic_market_short: bool = False,
         hsl_ema_tail_enabled: bool = False,
         hsl_raw_drawdown_enabled: bool = False,
+        recovery_distribution_enabled: bool = False,
     ):
         super().__init__(
             run,
@@ -1124,6 +1184,7 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
             hsl_panic_market=hsl_panic_market_long,
             hsl_ema_tail_enabled=hsl_ema_tail_enabled,
             hsl_raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+            recovery_distribution_enabled=recovery_distribution_enabled,
         )
         if short_coin_overrides is None:
             short_coin_overrides = np.full(
@@ -1186,10 +1247,11 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
         scalars,
         gaps,
         coin_fill_counts,
+        recovery_samples,
         *,
         batch_size: int,
     ) -> None:
-        library.passivbot_ema_anchor_multicoin_fused(
+        kernel_args = (
             self.bars,
             self.fill_ticks,
             self.touch_ticks,
@@ -1204,6 +1266,11 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
             scalars,
             gaps,
             coin_fill_counts,
+        )
+        if self.recovery_distribution_enabled:
+            kernel_args += (recovery_samples,)
+        library.passivbot_ema_anchor_multicoin_fused(
+            *kernel_args,
             threads=(batch_size, 1, 1),
         )
 
@@ -1245,6 +1312,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
         hsl_panic_market: bool = False,
         hsl_ema_tail_enabled: bool = False,
         hsl_raw_drawdown_enabled: bool = False,
+        recovery_distribution_enabled: bool = False,
     ):
         super().__init__(
             run,
@@ -1258,6 +1326,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             hsl_panic_market=hsl_panic_market,
             hsl_ema_tail_enabled=hsl_ema_tail_enabled,
             hsl_raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+            recovery_distribution_enabled=recovery_distribution_enabled,
         )
 
     def _pack_params(self, params: np.ndarray) -> np.ndarray:
@@ -1274,6 +1343,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
         return _trailing_martingale_multicoin_shader_library(
             self.hsl_ema_tail_enabled,
             self.hsl_raw_drawdown_enabled,
+            self.recovery_distribution_enabled,
         )
 
     def _dispatch(
@@ -1286,10 +1356,11 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
         scalars,
         gaps,
         coin_fill_counts,
+        recovery_samples,
         *,
         batch_size: int,
     ) -> None:
-        library.passivbot_trailing_martingale_multicoin(
+        kernel_args = (
             self.bars,
             self.fill_ticks,
             self.touch_ticks,
@@ -1306,6 +1377,11 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             scalars,
             gaps,
             coin_fill_counts,
+        )
+        if self.recovery_distribution_enabled:
+            kernel_args += (recovery_samples,)
+        library.passivbot_trailing_martingale_multicoin(
+            *kernel_args,
             threads=(batch_size, 1, 1),
         )
 
@@ -1335,6 +1411,7 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
         hsl_panic_market_short: bool = False,
         hsl_ema_tail_enabled: bool = False,
         hsl_raw_drawdown_enabled: bool = False,
+        recovery_distribution_enabled: bool = False,
     ):
         super().__init__(
             run,
@@ -1348,6 +1425,7 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
             hsl_panic_market=hsl_panic_market_long,
             hsl_ema_tail_enabled=hsl_ema_tail_enabled,
             hsl_raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+            recovery_distribution_enabled=recovery_distribution_enabled,
         )
         if short_coin_overrides is None:
             short_coin_overrides = np.full(
@@ -1408,10 +1486,11 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
         scalars,
         gaps,
         coin_fill_counts,
+        recovery_samples,
         *,
         batch_size: int,
     ) -> None:
-        library.passivbot_trailing_martingale_multicoin_fused(
+        kernel_args = (
             self.bars,
             self.fill_ticks,
             self.touch_ticks,
@@ -1429,6 +1508,11 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
             scalars,
             gaps,
             coin_fill_counts,
+        )
+        if self.recovery_distribution_enabled:
+            kernel_args += (recovery_samples,)
+        library.passivbot_trailing_martingale_multicoin_fused(
+            *kernel_args,
             threads=(batch_size, 1, 1),
         )
 

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -1990,7 +1990,10 @@ class MpsMulticoinProxy:
             last_valid_idx=max(run.last_valid_idx for run in runs),
             trade_start_idx=min(run.trade_start_idx for run in runs),
         )
-        if self.needed_metrics & _ACCOUNT_EQUITY_RECOVERY_METRICS:
+        if self.needed_metrics & (
+            _ACCOUNT_EQUITY_RECOVERY_METRICS
+            | _STRATEGY_EQ_RECOVERY_DISTRIBUTION_METRICS
+        ):
             wallet_exposure_column = (
                 11
                 if self.strategy_kind == "ema_anchor"
@@ -2031,6 +2034,10 @@ class MpsMulticoinProxy:
             ),
             "hsl_raw_drawdown_enabled": bool(
                 self.needed_metrics & _HSL_RAW_DRAWDOWN_METRICS
+            ),
+            "recovery_distribution_enabled": bool(
+                self.needed_metrics
+                & _STRATEGY_EQ_RECOVERY_DISTRIBUTION_METRICS
             ),
         }
         if self.shared_account_fused:

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -66,7 +66,6 @@ from optimization.backends.gpu_backend import (
     _update_probe_shortfall_log,
     _validate_directional_search_space,
     _validate_dual_multicoin_metrics,
-    _validate_recovery_distribution_scope,
     _validate_gpu_optimizer_overrides,
     _validate_gpu_coin_overrides,
     _validate_pinned_scope_bounds,
@@ -2581,10 +2580,24 @@ def test_gpu_dual_multicoin_metric_gate_does_not_narrow_single_side():
         "strategy_eq_recovery_days_mean_worst_1pct",
     ],
 )
-def test_gpu_recovery_distribution_metrics_fail_closed_for_multicoin(metric):
-    _validate_recovery_distribution_scope({metric}, coin_count=1)
-    with pytest.raises(ValueError, match="require a single-coin optimization"):
-        _validate_recovery_distribution_scope({metric}, coin_count=2)
+def test_gpu_recovery_distribution_metrics_accept_supported_multicoin(metric):
+    for enabled in ({"long"}, {"short"}, {"long", "short"}):
+        config = _directional_ema_config(
+            long_enabled="long" in enabled,
+            short_enabled="short" in enabled,
+        )
+        config["live"]["approved_coins"] = {
+            side: ["BTC", "ETH", "SOL"] if side in enabled else []
+            for side in ("long", "short")
+        }
+        config["live"]["hedge_mode"] = True
+        config["live"]["forager_score_hysteresis_pct"] = 0.0
+        config["backtest"]["dynamic_wel_by_tradability"] = True
+        config["optimize"]["scoring"] = [
+            {"goal": "min", "metric": metric}
+        ]
+
+        assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
 @pytest.mark.parametrize(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -4453,6 +4453,7 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
         forager_score_hysteresis_pct=0.02,
         max_realized_loss_pct=0.1,
         hsl_raw_drawdown_enabled=True,
+        recovery_distribution_enabled=True,
     )
     assert runner.settings.cpu()[4].item() == pytest.approx(0.02)
     assert runner.settings.cpu()[5].item() <= 0.1
@@ -4478,6 +4479,14 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
         assert torch.equal(output["fill_count_long"], output["fill_count"])
     else:
         assert (output["fill_count_long"] == 0.0).all()
+    recovery = strategy_eq_recovery_distribution_from_samples(
+        output["strategy_eq_recovery_samples"],
+        sample_interval_days=output[
+            "strategy_eq_recovery_sample_interval_days"
+        ],
+    )
+    assert torch.isfinite(recovery).all().item()
+    assert (recovery[:, 3] > 0.0).all().item()
 
     with pytest.raises(ValueError, match="finite and non-negative"):
         MpsEmaAnchorMulticoinRunner(
@@ -4721,6 +4730,7 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
         collect_coin_fill_counts=True,
         hsl_ema_tail_enabled=True,
         hsl_raw_drawdown_enabled=True,
+        recovery_distribution_enabled=True,
     )
     torch.testing.assert_close(runner.settings, run_settings)
     runner_output = runner.run(
@@ -4773,6 +4783,17 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
         False,
     ]
     assert torch.equal(runner_output["coin_fill_counts"], coin_fill_counts)
+    recovery = strategy_eq_recovery_distribution_from_samples(
+        runner_output["strategy_eq_recovery_samples"],
+        sample_interval_days=runner_output[
+            "strategy_eq_recovery_sample_interval_days"
+        ],
+    )
+    assert torch.isfinite(recovery).all().item()
+    assert (recovery[:3, 3] > 0.0).all().item()
+    assert (
+        runner_output["strategy_eq_recovery_samples"][3:, 0] < 0.0
+    ).all().item()
     assert runner.last_profile["kernel_seconds"] >= 0.0
 
     metric_rows = []
@@ -5160,6 +5181,7 @@ def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
         collect_coin_fill_counts=True,
         hsl_ema_tail_enabled=True,
         hsl_raw_drawdown_enabled=True,
+        recovery_distribution_enabled=True,
     )
     torch.testing.assert_close(runner.settings, run_settings)
     runner_output = runner.run(np.asarray(rows, dtype=np.float64), profile=True)
@@ -5210,6 +5232,17 @@ def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
         False,
     ]
     assert torch.equal(runner_output["coin_fill_counts"], coin_fill_counts)
+    recovery = strategy_eq_recovery_distribution_from_samples(
+        runner_output["strategy_eq_recovery_samples"],
+        sample_interval_days=runner_output[
+            "strategy_eq_recovery_sample_interval_days"
+        ],
+    )
+    assert torch.isfinite(recovery).all().item()
+    assert (recovery[:3, 3] > 0.0).all().item()
+    assert (
+        runner_output["strategy_eq_recovery_samples"][3:, 0] < 0.0
+    ).all().item()
     assert runner.last_profile["kernel_seconds"] >= 0.0
 
     metric_rows = []
@@ -5519,6 +5552,7 @@ def test_mps_trailing_martingale_multicoin_directional_shader_smoke(side):
         forager_score_hysteresis_pct=0.02,
         max_realized_loss_pct=0.1,
         hsl_raw_drawdown_enabled=True,
+        recovery_distribution_enabled=True,
     )
     assert runner.settings.cpu()[5].item() <= 0.1
     output = runner.run(np.array([row, row], dtype=np.float64))
@@ -5532,6 +5566,14 @@ def test_mps_trailing_martingale_multicoin_directional_shader_smoke(side):
     assert torch.isfinite(output["balance"]).all()
     assert output["day_has_fill"].sum().item() > 0
     assert (output["open_positions"] <= 2.0).all()
+    recovery = strategy_eq_recovery_distribution_from_samples(
+        output["strategy_eq_recovery_samples"],
+        sample_interval_days=output[
+            "strategy_eq_recovery_sample_interval_days"
+        ],
+    )
+    assert torch.isfinite(recovery).all().item()
+    assert (recovery[:, 3] > 0.0).all().item()
 
     disabled = np.full((coin_count, 44), np.nan, dtype=np.float32)
     disabled[:, 24] = 0.0

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -821,11 +821,17 @@ def test_multicoin_proxy_routes_dual_side_batch_through_fused_runner(
     ],
 )
 @pytest.mark.parametrize(
-    ("needed_metrics", "tail_enabled", "raw_drawdown_enabled"),
+    (
+        "needed_metrics",
+        "tail_enabled",
+        "raw_drawdown_enabled",
+        "recovery_distribution_enabled",
+    ),
     [
-        ({"hard_stop_time_in_red_pct"}, False, False),
-        ({"drawdown_worst_mean_1pct_ema_strategy_eq"}, True, False),
-        ({"drawdown_worst_strategy_eq_long"}, False, True),
+        ({"hard_stop_time_in_red_pct"}, False, False, False),
+        ({"drawdown_worst_mean_1pct_ema_strategy_eq"}, True, False, False),
+        ({"drawdown_worst_strategy_eq_long"}, False, True, False),
+        ({"strategy_eq_recovery_days_p99"}, False, False, True),
     ],
 )
 def test_multicoin_proxy_constructs_fused_shared_account_runner(
@@ -837,6 +843,7 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
     needed_metrics,
     tail_enabled,
     raw_drawdown_enabled,
+    recovery_distribution_enabled,
 ):
     torch = pytest.importorskip("torch")
 
@@ -995,6 +1002,10 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
     assert (
         constructed["kwargs"]["hsl_raw_drawdown_enabled"]
         is raw_drawdown_enabled
+    )
+    assert (
+        constructed["kwargs"]["recovery_distribution_enabled"]
+        is recovery_distribution_enabled
     )
 
 


### PR DESCRIPTION
## Summary

- extend opt-in strategy-equity recovery-distribution metrics to one-sided multicoin EMA Anchor and Trailing Martingale
- support fused shared-account long+short multicoin kernels while keeping independent dual-side summaries fail closed
- preserve the default Metal ABI and run the bounded recovery postprocessor only when one of the six metrics is requested
- keep exact Rust validation and rolling drift gates authoritative

## Validation

- cargo test --no-default-features -q: 267 passed
- complete GPU backend, metrics, service, and MPS pytest suite: green
- focused physical Apple M3 multicoin kernel tests: 6 passed
- EMA Anchor long-only BTC+ETH, Bybit 2025-01 through 2026-08-15: 8 generations, 4096 proxy, 64 exact, no drift halt
- Trailing Martingale fused long+short BTC+ETH on the same range: 8 generations, 1024 proxy, 64 exact, no drift halt
- py_compile and git diff --check: green

## Safety

GPU support remains additive. Recovery buffers and shader arguments are compiled in only when requested. Histories with internal invalid candles fail closed, unsupported independent dual-side multicoin summaries remain rejected, and exact Rust results remain authoritative.