### PR TITLE
Support dual-side multicoin GPU auto-unstuck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ All notable user-facing changes will be documented in this file.
   oversized dispatches, polls Ctrl+C between them, and retains the last complete ask/tell
   checkpoint if an in-progress generation is interrupted.
 
+- Added fused dual-side multi-coin auto-unstuck screening to Apple MPS optimization for EMA Anchor
+  and Trailing Martingale, including static per-coin overrides and compatible suites. The shared
+  account kernel admits one global least-stuck candidate across both directional surfaces using
+  exact Rust's price-difference, symbol-index, and long-before-short tie ordering, then applies the
+  existing conservative realized-loss allowance. Exact Rust validation and drift gates remain
+  authoritative; dual-side multi-coin exposure repair remains fail closed.
+
 - Fixed finite `live.pnls_max_lookback_days` handling for single-coin `coin`-mode HSL on Apple
   MPS. EMA Anchor and Trailing Martingale screening now expire realized-PnL fill events with the
   same rolling-window rule as exact Rust instead of retaining an all-history peak; bounded GPU
@@ -61,13 +68,12 @@ All notable user-facing changes will be documented in this file.
   optimization. Long and short candidates now run in one portfolio kernel for unified, pside,
   and coin HSL, including shared event/tier metrics, directional PnL, coin overrides, forager
   selection, and the existing TM entry/close behavior. Exact Rust remains authoritative;
-  dual-side auto-unstuck and exposure repair remain fail closed pending their global cross-side
-  parity slices.
+  dual-side exposure repair remains fail closed pending its global cross-side parity slice.
 
 - Added fused shared-account dual-side multi-coin EMA Anchor screening to Apple MPS optimization.
   Unified, pside, and coin HSL now run inside one portfolio kernel, including per-coin HSL
-  overrides and shared event/tier scoring metrics. Exact Rust remains authoritative, dual-side
-  auto-unstuck and exposure repair remain fail closed.
+  overrides and shared event/tier scoring metrics. Exact Rust remains authoritative; dual-side
+  exposure repair remains fail closed.
 
 - Added dual-side single-coin `unified` HSL to Apple MPS optimization for EMA Anchor and
   Trailing Martingale. Both Metal controllers now consume account-wide realized and unrealized
@@ -289,8 +295,7 @@ All notable user-facing changes will be documented in this file.
   exchange minimums, competition with WEL/TWEL and ordinary closes, and the realized-loss gate.
   Its all-history realized-PnL envelope is conservative relative to exact Rust's configured rolling
   lookback; exact validations and the existing classification, rank, and drift gates remain
-  authoritative. Dual-side multi-coin auto-unstuck remains fail closed pending a shared-balance
-  portfolio kernel spanning both directional surfaces.
+  authoritative.
 
 - Expanded Apple MPS optimizer scoring and limits with fill-gap mean, median, p95, and p99 hours.
   The proxy conservatively decodes its existing logarithmic inter-fill histogram at a float32-safe

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -185,16 +185,17 @@ The supported slice is intentionally narrow:
   fail closed for these metrics because they cannot reconstruct one shared portfolio-equity curve.
   Compatible suites may use the supported topologies.
 - single-coin EMA Anchor and Trailing Martingale support auto-unstuck for long-only,
-  short-only, hedge-mode dual-side, one-way, and compatible suite runs. One-sided multi-coin runs
-  and compatible suites also support auto-unstuck, including static per-coin overrides. Metal
+  short-only, hedge-mode dual-side, one-way, and compatible suite runs. One- and dual-side
+  multi-coin runs and compatible suites also support auto-unstuck, including static per-coin
+  overrides. Metal
   models the enable and EMA-gating toggles, tunable close percentage, EMA distance, loss allowance,
   and exposure threshold. It derives the allowance from a conservative all-history realized
-  net-PnL peak, admits at most one least-stuck eligible position per one-sided portfolio, scales a
+  net-PnL peak, admits at most one least-stuck eligible position per portfolio, scales a
   losing close to its own allowance subject to exchange minimums, and lets that close compete with
   the position's WEL/TWEL reducer before ordinary closes consume the remaining realized-loss
-  budget. Exact Rust remains authoritative for the configured rolling PnL lookback. Dual-side
-  multi-coin auto-unstuck remains fail closed until one shared portfolio kernel can select across
-  both directional surfaces
+  budget. The fused dual-side multi-coin kernel chooses globally across both directional surfaces
+  using exact Rust's price-difference, symbol-index, and long-before-short tie ordering. Exact Rust
+  remains authoritative for the configured rolling PnL lookback
 - single- and multi-coin EMA Anchor and Trailing Martingale runs support bounded and legacy-raw
   `risk.we_excess_allowance_pct`, `risk.total_exposure_entry_gate_enabled`, and
   `risk.total_exposure_enforcer_threshold` across long-only, short-only, dual-side, and compatible
@@ -254,8 +255,9 @@ The supported slice is intentionally narrow:
   Martingale permit the one selected auto-unstuck reducer to consume that same conservative budget,
   while ordinary and exposure-repair closes retain the stricter zero-loss envelope. One-sided
   multi-coin EMA Anchor applies the conservative budget only to its selected auto-unstuck reducer;
-  its other closes remain zero-loss. Dual-side multi-coin runs retain the strict zero-loss
-  envelope. These restrictions avoid unsafe cross-side loss-budget reservation and per-candle
+  its other closes remain zero-loss. Fused dual-side multi-coin runs apply that same shared budget
+  to the one globally selected auto-unstuck reducer; their other closes remain zero-loss. These
+  restrictions avoid unsafe cross-side loss-budget reservation and per-candle
   enumeration of TM's recursive 500-rung close ladder. Exact
   validation applies the configured rolling allowance and remains authoritative
 - BTC collateral remains disabled; dual-side multicoin total-exposure repair remains disabled
@@ -279,7 +281,7 @@ Unsupported combinations fail before optimization begins. Dual-side multi-coin E
 Trailing Martingale use fused shared-account Metal kernels in hedge mode. Every accepted metric
 still comes from the unchanged exact Rust portfolio backtest, and classification, rank, and drift
 gates halt material disagreement. Dual-side one-way arbitration, unmodeled non-bot suite scenario
-overrides, dual-side multi-coin auto-unstuck, and dual-side multi-coin exposure repair are not
+overrides and dual-side multi-coin exposure repair are not
 silently approximated by this release.
 
 For a supported suite, each Metal candidate is dispatched across every prepared scenario. The GPU
@@ -295,7 +297,7 @@ overrides: the canonical exact
 suite evaluator still applies them last, after candidate materialization, while each scenario's
 Metal proxy shadows the corresponding candidate parameters with the same effective values. Every
 overridden scenario is rechecked against the directional GPU scope, so an override cannot silently
-enable HSL, dual-side multi-coin auto-unstuck, an unsupported exposure-repair path, an invalid
+enable an unsupported exposure-repair path, an invalid
 position count, or another unsupported behavior. In a multicoin suite, a scenario with fewer coins must
 keep the effective `n_positions` range within that subset, either through common bounds or an
 explicit scenario override. Metal uses the strategy-specific single-coin or multicoin kernel

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -510,8 +510,12 @@ mod tests {
         ));
         assert!(source.contains("account.balance = 0.0f"));
         assert!(source.contains("alive || hsl_validation_failed"));
-        assert!(source.contains("bool any_unstuck_enabled = false"));
-        assert!(source.contains("&& !any_unstuck_enabled"));
+        assert!(source.contains("select_ema_multicoin_unstuck_coin("));
+        assert!(source.contains("int forced_unstuck_coin"));
+        assert!(source.contains("long_unstuck_diff < short_unstuck_diff"));
+        assert!(source.contains(
+            "long_unstuck_candidate <= short_unstuck_candidate"
+        ));
         assert!(source.contains(
             "const EmaMulticoinSideConfig config = load_ema_multicoin_side_config(params, po)"
         ));
@@ -822,8 +826,12 @@ mod tests {
         assert!(source.contains("long_coin_overrides, short_coin_overrides"));
         assert!(source.contains("net_position_cost -= short_side.psize[c]"));
         assert!(source.contains("alive || hsl_validation_failed"));
-        assert!(source.contains("bool any_unstuck_enabled = false"));
-        assert!(source.contains("&& !any_unstuck_enabled"));
+        assert!(source.contains("select_tm_multicoin_unstuck_coin("));
+        assert!(source.contains("int forced_unstuck_coin"));
+        assert!(source.contains("long_unstuck_diff < short_unstuck_diff"));
+        assert!(source.contains(
+            "long_unstuck_candidate <= short_unstuck_candidate"
+        ));
         assert!(source.contains(
             "const TrailingMartingaleMulticoinSideConfig config ="
         ));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -1064,6 +1064,123 @@ inline void update_ema_multicoin_side_selection(
     side.previous_effective_n_positions = effective_n_positions;
 }
 
+// Preselect one side's best eligible candidate without creating an order.
+// The fused caller compares both sides before allowing either generator to
+// consume the shared realized-loss allowance.
+inline int select_ema_multicoin_unstuck_coin(
+    thread EmaMulticoinSideState& side,
+    thread const EmaMulticoinSideConfig& config,
+    thread const JointPortfolioAccount& account,
+    constant float* bars,
+    constant int* touch_ticks,
+    constant float* coin_settings,
+    constant float* coin_overrides,
+    int k,
+    int coin_count,
+    bool short_side,
+    int effective_n_positions,
+    thread float& selected_diff
+) {
+    selected_diff = INFINITY;
+    if (effective_n_positions <= 0 || account.balance <= 0.0f) return -1;
+    const float effective_wel = config.twel
+        / fmax(float(effective_n_positions), 1.0f);
+    const float balance_peak = account.balance
+        + (account.realized_pnl_peak - account.realized_pnl_total);
+    if (!(balance_peak > 0.0f)) return -1;
+
+    int selected_coin = -1;
+    for (int c = 0; c < coin_count; ++c) {
+        const int coin_offset = c * COIN_COLS;
+        const int bar_offset = (k * coin_count + c) * 4;
+        const int tick_offset = (k * coin_count + c) * 2;
+        const float price_now = bars[bar_offset + 2];
+        const float c_mult = coin_settings[coin_offset + 4];
+        const float price_step = coin_settings[coin_offset + 1];
+        const bool coin_unstuck_enabled = coin_override_or(
+            coin_overrides, c, 13,
+            config.unstuck_enabled ? 1.0f : 0.0f
+        ) > 0.5f;
+        const bool coin_ema_gate = coin_override_or(
+            coin_overrides, c, 14,
+            config.unstuck_ema_gating_enabled ? 1.0f : 0.0f
+        ) > 0.5f;
+        const float coin_close_pct = coin_override_or(
+            coin_overrides, c, 15, config.unstuck_close_pct
+        );
+        const float coin_ema_dist = coin_override_or(
+            coin_overrides, c, 16, config.unstuck_ema_dist
+        );
+        const float coin_loss_allowance_pct = coin_override_or(
+            coin_overrides, c, 17, config.unstuck_loss_allowance_pct
+        );
+        const float coin_threshold = coin_override_or(
+            coin_overrides, c, 18, config.unstuck_threshold
+        );
+        const float fixed_coin_wel = coin_override_or(
+            coin_overrides, c, 11, -1.0f
+        );
+        const float coin_wel = fixed_coin_wel >= 0.0f
+            ? fixed_coin_wel : effective_wel;
+        const float coin_allowance_pct = coin_override_or(
+            coin_overrides, c, 12, config.allowance_pct
+        );
+        const float allowed_coin_wel = allowed_wallet_exposure_limit(
+            coin_wel, config.twel, coin_allowance_pct,
+            config.legacy_raw_allowance
+        );
+        if (!(coin_unstuck_enabled && coin_close_pct > 0.0f
+            && coin_loss_allowance_pct > 0.0f && coin_threshold > 0.0f
+            && side.psize[c] > 0.0f && side.pprice[c] > 0.0f
+            && allowed_coin_wel > 0.0f && price_now > 0.0f)) {
+            continue;
+        }
+        const float allowance = float32_floor_nonnegative(fmax(
+            account.balance - balance_peak * (
+                1.0f - coin_loss_allowance_pct * config.twel
+            ),
+            0.0f
+        ));
+        const float wallet_exposure = side.psize[c] * side.pprice[c]
+            * c_mult / account.balance;
+        if (!(allowance > 0.0f
+            && wallet_exposure / allowed_coin_wel > coin_threshold)) {
+            continue;
+        }
+        if (coin_ema_gate) {
+            const float lower = fmin(
+                side.ema0[c], fmin(side.ema1[c], side.ema2[c])
+            );
+            const float upper = fmax(
+                side.ema0[c], fmax(side.ema1[c], side.ema2[c])
+            );
+            const int trigger_tick = short_side
+                ? int(floor(
+                    lower * (1.0f - coin_ema_dist) / price_step
+                        + 1.0e-6f
+                ))
+                : int(ceil(
+                    upper * (1.0f + coin_ema_dist) / price_step
+                        - 1.0e-6f
+                ));
+            const bool triggered = short_side
+                ? touch_ticks[tick_offset + 1] <= trigger_tick
+                : touch_ticks[tick_offset + 0] >= trigger_tick;
+            if (!triggered) continue;
+        }
+        const float pprice_diff = short_side
+            ? price_now / side.pprice[c] - 1.0f
+            : 1.0f - price_now / side.pprice[c];
+        if (!isfinite(pprice_diff)) continue;
+        if (selected_coin < 0 || pprice_diff < selected_diff
+            || (pprice_diff == selected_diff && c < selected_coin)) {
+            selected_coin = c;
+            selected_diff = pprice_diff;
+        }
+    }
+    return selected_coin;
+}
+
 inline void generate_ema_multicoin_side_orders(
     thread EmaMulticoinSideState& side,
     thread const EmaMulticoinSideConfig& config,
@@ -1079,7 +1196,8 @@ inline void generate_ema_multicoin_side_orders(
     int effective_n_positions,
     int current_hsl_mode,
     bool loss_gate_enabled,
-    float max_realized_loss_pct
+    float max_realized_loss_pct,
+    int forced_unstuck_coin
 ) {
     const int C = coin_count;
     const float base_qty_pct = config.base_qty_pct;
@@ -1273,6 +1391,10 @@ inline void generate_ema_multicoin_side_orders(
     float selected_unstuck_qty = 0.0f;
     int selected_unstuck_tick = 0;
     for (int c = 0; c < C; ++c) {
+        if (forced_unstuck_coin == -1
+            || (forced_unstuck_coin >= 0 && c != forced_unstuck_coin)) {
+            continue;
+        }
         int coin_offset = c * COIN_COLS;
         int bar_offset = (k * C + c) * 4;
         int tick_offset = (k * C + c) * 2;
@@ -2216,7 +2338,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 bars, touch_ticks, coin_settings, coin_overrides,
                 k, C, short_side, tradable_count, effective_n_positions,
                 current_hsl_mode, loss_gate_enabled,
-                max_realized_loss_pct
+                max_realized_loss_pct, -2
             );
         }
 
@@ -2623,25 +2745,12 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
         load_ema_multicoin_side_config(params, po);
     const EmaMulticoinSideConfig short_config =
         load_ema_multicoin_side_config(params, po + PARAM_COLS);
-    bool any_unstuck_enabled = false;
-    for (int c = 0; c < C; ++c) {
-        any_unstuck_enabled = any_unstuck_enabled
-            || coin_override_or(
-                long_coin_overrides, c, 13,
-                long_config.unstuck_enabled ? 1.0f : 0.0f
-            ) > 0.5f
-            || coin_override_or(
-                short_coin_overrides, c, 13,
-                short_config.unstuck_enabled ? 1.0f : 0.0f
-            ) > 0.5f;
-    }
     const int hsl_signal_mode = long_config.hsl_template.signal_mode;
     const bool topology_valid = hsl_signal_mode >= HSL_SIGNAL_UNIFIED
         && hsl_signal_mode <= HSL_SIGNAL_COIN
         && long_config.hsl_template.signal_mode
             == short_config.hsl_template.signal_mode
-        && long_config.coin_hsl_mode == short_config.coin_hsl_mode
-        && !any_unstuck_enabled;
+        && long_config.coin_hsl_mode == short_config.coin_hsl_mode;
     if (!topology_valid) {
         scalars[scalar_offset + 9] = 0.0f;
         scalars[scalar_offset + 13] = 0.0f;
@@ -2845,6 +2954,37 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                 short_side.hsl,
                 ema_multicoin_side_has_position(short_side, C)
             );
+        float long_unstuck_diff = INFINITY;
+        float short_unstuck_diff = INFINITY;
+        const int long_unstuck_candidate = long_can_generate
+            ? select_ema_multicoin_unstuck_coin(
+                long_side, long_config, account,
+                bars, touch_ticks, coin_settings, long_coin_overrides,
+                k, C, false, long_effective_n_positions,
+                long_unstuck_diff
+            )
+            : -1;
+        const int short_unstuck_candidate = short_can_generate
+            ? select_ema_multicoin_unstuck_coin(
+                short_side, short_config, account,
+                bars, touch_ticks, coin_settings, short_coin_overrides,
+                k, C, true, short_effective_n_positions,
+                short_unstuck_diff
+            )
+            : -1;
+        // Exact Rust ranks by price difference, then symbol index. Its stable
+        // long-first input order makes long win an equal-symbol tie.
+        const bool long_unstuck_wins = long_unstuck_candidate >= 0
+            && (
+                short_unstuck_candidate < 0
+                || long_unstuck_diff < short_unstuck_diff
+                || (long_unstuck_diff == short_unstuck_diff
+                    && long_unstuck_candidate <= short_unstuck_candidate)
+            );
+        const int long_unstuck_coin = long_unstuck_wins
+            ? long_unstuck_candidate : -1;
+        const int short_unstuck_coin = !long_unstuck_wins
+            ? short_unstuck_candidate : -1;
         if (long_can_generate) {
             update_ema_multicoin_side_selection(
                 long_side, long_config, bars, coin_settings,
@@ -2856,7 +2996,8 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                 bars, touch_ticks, coin_settings, long_coin_overrides,
                 k, C, false, long_tradable_count,
                 long_effective_n_positions, long_hsl_mode,
-                loss_gate_enabled, max_realized_loss_pct
+                loss_gate_enabled, max_realized_loss_pct,
+                long_unstuck_coin
             );
         }
         if (short_can_generate) {
@@ -2870,7 +3011,8 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                 bars, touch_ticks, coin_settings, short_coin_overrides,
                 k, C, true, short_tradable_count,
                 short_effective_n_positions, short_hsl_mode,
-                loss_gate_enabled, max_realized_loss_pct
+                loss_gate_enabled, max_realized_loss_pct,
+                short_unstuck_coin
             );
         }
 

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -1992,6 +1992,123 @@ inline void update_tm_multicoin_side_selection(
     side.previous_effective_n_positions = effective_n_positions;
 }
 
+// Preselect one side's best eligible candidate without creating an order.
+// The fused caller compares both sides before allowing either generator to
+// consume the shared realized-loss allowance.
+inline int select_tm_multicoin_unstuck_coin(
+    thread TrailingMartingaleMulticoinSideState& side,
+    thread const TrailingMartingaleMulticoinSideConfig& config,
+    thread const JointPortfolioAccount& account,
+    constant float* bars,
+    constant int* touch_ticks,
+    constant float* coin_settings,
+    constant float* coin_overrides,
+    int k,
+    int coin_count,
+    bool short_side,
+    int effective_n_positions,
+    thread float& selected_diff
+) {
+    selected_diff = INFINITY;
+    if (effective_n_positions <= 0 || account.balance <= 0.0f) return -1;
+    const float effective_wel = config.twel
+        / fmax(float(effective_n_positions), 1.0f);
+    const float balance_peak = account.balance
+        + (account.realized_pnl_peak - account.realized_pnl_total);
+    if (!(balance_peak > 0.0f)) return -1;
+
+    int selected_coin = -1;
+    for (int c = 0; c < coin_count; ++c) {
+        const int coin_offset = c * COIN_COLS;
+        const int bar_offset = (k * coin_count + c) * 4;
+        const int tick_offset = (k * coin_count + c) * 2;
+        const float price_now = bars[bar_offset + 2];
+        const float c_mult = coin_settings[coin_offset + 4];
+        const float price_step = coin_settings[coin_offset + 1];
+        const bool coin_unstuck_enabled = coin_override_or(
+            coin_overrides, c, 28,
+            config.unstuck_enabled ? 1.0f : 0.0f
+        ) > 0.5f;
+        const bool coin_ema_gate = coin_override_or(
+            coin_overrides, c, 29,
+            config.unstuck_ema_gating_enabled ? 1.0f : 0.0f
+        ) > 0.5f;
+        const float coin_close_pct = coin_override_or(
+            coin_overrides, c, 30, config.unstuck_close_pct
+        );
+        const float coin_ema_dist = coin_override_or(
+            coin_overrides, c, 31, config.unstuck_ema_dist
+        );
+        const float coin_loss_allowance_pct = coin_override_or(
+            coin_overrides, c, 32, config.unstuck_loss_allowance_pct
+        );
+        const float coin_threshold = coin_override_or(
+            coin_overrides, c, 33, config.unstuck_threshold
+        );
+        const float fixed_coin_wel = coin_override_or(
+            coin_overrides, c, 24, -1.0f
+        );
+        const float coin_wel = fixed_coin_wel >= 0.0f
+            ? fixed_coin_wel : effective_wel;
+        const float coin_allowance_pct = coin_override_or(
+            coin_overrides, c, 25, config.allowance_pct
+        );
+        const float allowed_coin_wel = allowed_wallet_exposure_limit(
+            coin_wel, config.twel, coin_allowance_pct,
+            config.legacy_raw_allowance
+        );
+        if (!(coin_unstuck_enabled && coin_close_pct > 0.0f
+            && coin_loss_allowance_pct > 0.0f && coin_threshold > 0.0f
+            && side.psize[c] > 0.0f && side.pprice[c] > 0.0f
+            && allowed_coin_wel > 0.0f && price_now > 0.0f)) {
+            continue;
+        }
+        const float allowance = float32_floor_nonnegative(fmax(
+            account.balance - balance_peak * (
+                1.0f - coin_loss_allowance_pct * config.twel
+            ),
+            0.0f
+        ));
+        const float wallet_exposure = side.psize[c] * side.pprice[c]
+            * c_mult / account.balance;
+        if (!(allowance > 0.0f
+            && wallet_exposure / allowed_coin_wel > coin_threshold)) {
+            continue;
+        }
+        if (coin_ema_gate) {
+            const float lower = fmin(
+                side.ema0[c], fmin(side.ema1[c], side.ema2[c])
+            );
+            const float upper = fmax(
+                side.ema0[c], fmax(side.ema1[c], side.ema2[c])
+            );
+            const int trigger_tick = short_side
+                ? int(floor(
+                    lower * (1.0f - coin_ema_dist) / price_step
+                        + 1.0e-6f
+                ))
+                : int(ceil(
+                    upper * (1.0f + coin_ema_dist) / price_step
+                        - 1.0e-6f
+                ));
+            const bool triggered = short_side
+                ? touch_ticks[tick_offset + 1] <= trigger_tick
+                : touch_ticks[tick_offset + 0] >= trigger_tick;
+            if (!triggered) continue;
+        }
+        const float pprice_diff = short_side
+            ? price_now / side.pprice[c] - 1.0f
+            : 1.0f - price_now / side.pprice[c];
+        if (!isfinite(pprice_diff)) continue;
+        if (selected_coin < 0 || pprice_diff < selected_diff
+            || (pprice_diff == selected_diff && c < selected_coin)) {
+            selected_coin = c;
+            selected_diff = pprice_diff;
+        }
+    }
+    return selected_coin;
+}
+
 inline void generate_tm_multicoin_side_orders(
     thread TrailingMartingaleMulticoinSideState& side,
     thread const TrailingMartingaleMulticoinSideConfig& config,
@@ -2010,7 +2127,8 @@ inline void generate_tm_multicoin_side_orders(
     int effective_n_positions,
     int current_hsl_mode,
     bool loss_gate_enabled,
-    float max_realized_loss_pct
+    float max_realized_loss_pct,
+    int forced_unstuck_coin
 ) {
     const int C = coin_count;
     const float ddf = config.ddf;
@@ -2242,6 +2360,10 @@ inline void generate_tm_multicoin_side_orders(
     float selected_unstuck_qty = 0.0f;
     int selected_unstuck_tick = 0;
     for (int c = 0; c < C; ++c) {
+        if (forced_unstuck_coin == -1
+            || (forced_unstuck_coin >= 0 && c != forced_unstuck_coin)) {
+            continue;
+        }
         int coin_offset = c * COIN_COLS;
         int bar_offset = (k * C + c) * 4;
         int tick_offset = (k * C + c) * 2;
@@ -3038,25 +3160,12 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
         load_trailing_martingale_multicoin_side_config(
             params, po + PARAM_COLS
         );
-    bool any_unstuck_enabled = false;
-    for (int c = 0; c < C; ++c) {
-        any_unstuck_enabled = any_unstuck_enabled
-            || coin_override_or(
-                long_coin_overrides, c, 28,
-                long_config.unstuck_enabled ? 1.0f : 0.0f
-            ) > 0.5f
-            || coin_override_or(
-                short_coin_overrides, c, 28,
-                short_config.unstuck_enabled ? 1.0f : 0.0f
-            ) > 0.5f;
-    }
     const int hsl_signal_mode = long_config.hsl_template.signal_mode;
     const bool topology_valid = hsl_signal_mode >= HSL_SIGNAL_UNIFIED
         && hsl_signal_mode <= HSL_SIGNAL_COIN
         && long_config.hsl_template.signal_mode
             == short_config.hsl_template.signal_mode
-        && long_config.coin_hsl_mode == short_config.coin_hsl_mode
-        && !any_unstuck_enabled;
+        && long_config.coin_hsl_mode == short_config.coin_hsl_mode;
     if (!topology_valid) {
         scalars[scalar_offset + 9] = 0.0f;
         scalars[scalar_offset + 13] = 0.0f;
@@ -3265,6 +3374,37 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
                 short_side.hsl,
                 tm_multicoin_side_has_position(short_side, C)
             );
+        float long_unstuck_diff = INFINITY;
+        float short_unstuck_diff = INFINITY;
+        const int long_unstuck_candidate = long_can_generate
+            ? select_tm_multicoin_unstuck_coin(
+                long_side, long_config, account,
+                bars, touch_ticks, coin_settings, long_coin_overrides,
+                k, C, false, long_effective_n_positions,
+                long_unstuck_diff
+            )
+            : -1;
+        const int short_unstuck_candidate = short_can_generate
+            ? select_tm_multicoin_unstuck_coin(
+                short_side, short_config, account,
+                bars, touch_ticks, coin_settings, short_coin_overrides,
+                k, C, true, short_effective_n_positions,
+                short_unstuck_diff
+            )
+            : -1;
+        // Exact Rust ranks by price difference, then symbol index. Its stable
+        // long-first input order makes long win an equal-symbol tie.
+        const bool long_unstuck_wins = long_unstuck_candidate >= 0
+            && (
+                short_unstuck_candidate < 0
+                || long_unstuck_diff < short_unstuck_diff
+                || (long_unstuck_diff == short_unstuck_diff
+                    && long_unstuck_candidate <= short_unstuck_candidate)
+            );
+        const int long_unstuck_coin = long_unstuck_wins
+            ? long_unstuck_candidate : -1;
+        const int short_unstuck_coin = !long_unstuck_wins
+            ? short_unstuck_candidate : -1;
         if (long_can_generate) {
             update_tm_multicoin_side_selection(
                 long_side, long_config, bars, coin_settings,
@@ -3278,7 +3418,8 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
                 coin_settings, long_coin_overrides,
                 k, C, false, long_tradable_count,
                 long_effective_n_positions, long_hsl_mode,
-                loss_gate_enabled, max_realized_loss_pct
+                loss_gate_enabled, max_realized_loss_pct,
+                long_unstuck_coin
             );
         }
         if (short_can_generate) {
@@ -3294,7 +3435,8 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
                 coin_settings, short_coin_overrides,
                 k, C, true, short_tradable_count,
                 short_effective_n_positions, short_hsl_mode,
-                loss_gate_enabled, max_realized_loss_pct
+                loss_gate_enabled, max_realized_loss_pct,
+                short_unstuck_coin
             );
         }
 
@@ -3881,7 +4023,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 coin_settings, coin_overrides,
                 k, C, short_side, tradable_count,
                 effective_n_positions, current_hsl_mode,
-                loss_gate_enabled, max_realized_loss_pct
+                loss_gate_enabled, max_realized_loss_pct, -2
             );
         }
 

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -967,8 +967,6 @@ def _validate_scope_config(
         }:
             repair_paths = []
             for side in enabled_sides:
-                if bool(config["bot"][side].get("unstuck", {}).get("enabled")):
-                    repair_paths.append(f"bot.{side}.unstuck.enabled")
                 risk = config["bot"][side].get("risk", {})
                 for key in (
                     "position_exposure_enforcer_enabled",
@@ -984,15 +982,6 @@ def _validate_scope_config(
                     continue
                 for side in enabled_sides:
                     side_patch = bot_patch.get(side, {})
-                    unstuck = (
-                        side_patch.get("unstuck", {})
-                        if isinstance(side_patch, dict)
-                        else {}
-                    )
-                    if isinstance(unstuck, dict) and bool(unstuck.get("enabled")):
-                        repair_paths.append(
-                            f"coin_overrides.{coin}.bot.{side}.unstuck.enabled"
-                        )
                     risk = (
                         side_patch.get("risk", {})
                         if isinstance(side_patch, dict)
@@ -1008,8 +997,8 @@ def _validate_scope_config(
                         )
             if repair_paths:
                 raise ValueError(
-                    "GPU dual-side multicoin exposure/unstuck repair requires shared "
-                    "global cross-side selection and loss-budget reservation semantics; the "
+                    "GPU dual-side multicoin exposure repair requires shared "
+                    "global cross-side selection semantics; the "
                     f"current fused proxy does not model {sorted(repair_paths)}"
                 )
         if not bool(config.get("backtest", {}).get("dynamic_wel_by_tradability")):
@@ -2621,10 +2610,6 @@ def _validate_pinned_scope_bounds(
 ) -> None:
     enabled_sides = set(enabled_sides or ("long", "short"))
     pinned = {}
-    if coin_count > 1 and len(enabled_sides) == 2:
-        pinned.update(
-            {f"{side}_unstuck_enabled": 0.0 for side in ("long", "short")}
-        )
     if strategy_kind != "trailing_martingale":
         pinned.update(
             {
@@ -2633,9 +2618,8 @@ def _validate_pinned_scope_bounds(
             }
         )
     if coin_count > 1 and len(enabled_sides) == 2:
-        # Directional multicoin runners do not share realized PnL or balance.
-        # Until a portfolio kernel owns both sides, any exposure reducer whose
-        # sizing depends on account balance must remain disabled.
+        # The fused runner owns shared account state, but exposure repair still
+        # lacks one global cross-side reducer-selection implementation.
         pinned.update(
             {
                 f"{side}_risk_{key}": 0.0
@@ -3248,12 +3232,6 @@ def run_backend(
             if bound_side not in hsl_search_sides:
                 # Dormant HSL bounds affect neither proxy nor exact Rust.
                 continue
-        if max_coin_count > 1 and len(enabled_sides) == 2 and any(
-            bound_key.startswith(f"{side}_unstuck_") for side in enabled_sides
-        ):
-            # Dual-side multicoin unstuck remains disabled until one shared
-            # portfolio kernel owns the global selector across both sides.
-            continue
         if (
             max_coin_count == 1
             and bound_key

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -1803,14 +1803,6 @@ class MpsMulticoinProxy:
         for side in self.sides:
             first_bot = payload.bot_params_list[0][side]
             first_strategy = dict(payload.strategy_params_list[0][side])
-            if len(self.sides) == 2 and any(
-                bool(item[side].get("unstuck_enabled"))
-                for item in payload.bot_params_list
-            ):
-                raise ValueError(
-                    "MPS dual-side multicoin auto-unstuck is not yet supported; "
-                    "the fused proxy requires one global cross-side selector"
-                )
             if self.strategy_kind == "trailing_martingale":
                 first_strategy = flatten_trailing_martingale_params(
                     first_strategy, first_bot

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -2812,7 +2812,7 @@ def test_gpu_foundation_accepts_single_side_multicoin_unstuck():
     assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
-def test_gpu_foundation_keeps_dual_side_multicoin_unstuck_fail_closed():
+def test_gpu_foundation_accepts_dual_side_multicoin_unstuck():
     config = _directional_ema_config(long_enabled=True, short_enabled=True)
     config["live"]["hedge_mode"] = True
     for side in ("long", "short"):
@@ -2820,11 +2820,10 @@ def test_gpu_foundation_keeps_dual_side_multicoin_unstuck_fail_closed():
         config["bot"][side]["risk"]["n_positions"] = 2
     config["bot"]["long"]["unstuck"]["enabled"] = True
 
-    with pytest.raises(ValueError, match=r"dual-side.*unstuck.*shared"):
-        _validate_scope(config, _MulticoinEvaluator())
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
-def test_gpu_foundation_keeps_dual_side_multicoin_override_unstuck_fail_closed():
+def test_gpu_foundation_accepts_dual_side_multicoin_override_unstuck():
     config = _directional_ema_config(long_enabled=True, short_enabled=True)
     config["live"]["hedge_mode"] = True
     for side in ("long", "short"):
@@ -2834,8 +2833,7 @@ def test_gpu_foundation_keeps_dual_side_multicoin_override_unstuck_fail_closed()
         "ETH": {"bot": {"short": {"unstuck": {"enabled": True}}}}
     }
 
-    with pytest.raises(ValueError, match=r"dual-side.*unstuck.*shared"):
-        _validate_scope(config, _MulticoinEvaluator())
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
 def test_gpu_foundation_rejects_both_sides_disabled():
@@ -4761,7 +4759,7 @@ def test_gpu_accepts_single_coin_exposure_policy_bounds():
     )
 
 
-def test_gpu_accepts_unstuck_bounds_for_single_side_but_pins_dual_multicoin():
+def test_gpu_accepts_unstuck_bounds_for_single_and_dual_multicoin():
     from optimization.bounds import Bound
 
     bounds = {
@@ -4775,10 +4773,9 @@ def test_gpu_accepts_unstuck_bounds_for_single_side_but_pins_dual_multicoin():
 
     _validate_pinned_scope_bounds(bounds, base, {"long"}, coin_count=1)
     _validate_pinned_scope_bounds(bounds, base, {"long"}, coin_count=2)
-    with pytest.raises(ValueError, match="unstuck_enabled"):
-        _validate_pinned_scope_bounds(
-            bounds, base, {"long", "short"}, coin_count=2
-        )
+    _validate_pinned_scope_bounds(
+        bounds, base, {"long", "short"}, coin_count=2
+    )
 
 
 def test_gpu_accepts_hsl_bounds_for_single_and_dual_multicoin():

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -1566,14 +1566,14 @@ kernel void passivbot_tm_multicoin_order_phase_probe(
         bars, touch_ticks, touch_nearest_ticks,
         touch_min_qty_bits, touch_min_qty_relation,
         coin_settings, coin_overrides,
-        1, 1, false, 1, 1, 0, false, 1.0f
+        1, 1, false, 1, 1, 0, false, 1.0f, -2
     );
     generate_tm_multicoin_side_orders(
         short_side, short_config, account,
         bars, touch_ticks, touch_nearest_ticks,
         touch_min_qty_bits, touch_min_qty_relation,
         coin_settings, coin_overrides,
-        1, 1, true, 1, 1, 0, false, 1.0f
+        1, 1, true, 1, 1, 0, false, 1.0f, -2
     );
     output[0] = long_side.entry_qty[0];
     output[1] = short_side.entry_qty[0];
@@ -2563,12 +2563,12 @@ kernel void passivbot_ema_multicoin_order_phase_probe(
     generate_ema_multicoin_side_orders(
         long_side, long_config, account,
         bars, touch_ticks, coin_settings, coin_overrides,
-        1, 1, false, 1, 1, 0, false, 1.0f
+        1, 1, false, 1, 1, 0, false, 1.0f, -2
     );
     generate_ema_multicoin_side_orders(
         short_side, short_config, account,
         bars, touch_ticks, coin_settings, coin_overrides,
-        1, 1, true, 1, 1, 0, false, 1.0f
+        1, 1, true, 1, 1, 0, false, 1.0f, -2
     );
     output[0] = long_side.entry_qty[0];
     output[1] = short_side.entry_qty[0];
@@ -4621,6 +4621,8 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
 
     unstuck_long = side_row(0)
     unstuck_long[EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("unstuck_enabled")] = 1.0
+    unstuck_short = side_row(0)
+    unstuck_short[EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("unstuck_enabled")] = 1.0
 
     rows = [
         side_row(0) + side_row(0),
@@ -4629,6 +4631,8 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
         side_row(0) + side_row(1),
         side_row(3) + side_row(3),
         unstuck_long + side_row(0),
+        side_row(0) + unstuck_short,
+        unstuck_long + unstuck_short,
     ]
     batch_size = len(rows)
     params = torch.as_tensor(
@@ -4713,11 +4717,16 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
     # Rust analyzes abs(long TWE + signed short TWE), not gross exposure.
     assert (values[:3, 22] <= 1.01).all()
     assert (coin_fill_counts[:3].sum(dim=1).cpu().numpy() > 0.0).all()
-    # Mixed/unknown signal modes and dual-side auto-unstuck are rejected before
-    # any state or fills; exact Rust requires one global unstuck arbitration.
-    assert values[3:, 9].tolist() == [0.0, 0.0, 0.0]
-    assert values[3:, 13].tolist() == [0.0, 0.0, 0.0]
-    assert values[3:, 24].tolist() == [0.0, 0.0, 0.0]
+    # Mixed/unknown signal modes remain fail closed. Auto-unstuck is valid on
+    # either or both directional surfaces; the fused kernel chooses only one
+    # global least-stuck candidate before generating side orders.
+    assert values[3:5, 9].tolist() == [0.0, 0.0]
+    assert values[3:5, 13].tolist() == [0.0, 0.0]
+    assert values[3:5, 24].tolist() == [0.0, 0.0]
+    assert values[5:, 9].tolist() == [-1.0, -1.0, -1.0]
+    assert values[5:, 13].tolist() == [1.0, 1.0, 1.0]
+    assert (values[5:, 24] > 0.0).all()
+    assert values[5, 24] > values[0, 24]
 
     override_matrix = np.full((coin_count, 29), np.nan, dtype=np.float32)
     runner = MpsEmaAnchorMulticoinFusedRunner(
@@ -4780,7 +4789,9 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
         True,
         False,
         False,
-        False,
+        True,
+        True,
+        True,
     ]
     assert torch.equal(runner_output["coin_fill_counts"], coin_fill_counts)
     recovery = strategy_eq_recovery_distribution_from_samples(
@@ -4790,9 +4801,9 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
         ],
     )
     assert torch.isfinite(recovery).all().item()
-    assert (recovery[:3, 3] > 0.0).all().item()
+    assert (recovery[[0, 1, 2, 5, 6, 7], 3] > 0.0).all().item()
     assert (
-        runner_output["strategy_eq_recovery_samples"][3:, 0] < 0.0
+        runner_output["strategy_eq_recovery_samples"][3:5, 0] < 0.0
     ).all().item()
     assert runner.last_profile["kernel_seconds"] >= 0.0
 
@@ -4966,9 +4977,9 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
         threads=(1, 1, 1),
     )
     torch.mps.synchronize()
-    assert override_scalars[0, 9].item() == 0.0
-    assert override_scalars[0, 13].item() == 0.0
-    assert override_scalars[0, 24].item() == 0.0
+    assert override_scalars[0, 9].item() == -1.0
+    assert override_scalars[0, 13].item() == 1.0
+    assert override_scalars[0, 24].item() > 0.0
 
 
 @pytest.mark.skipif(
@@ -5077,6 +5088,10 @@ def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
     unstuck_long[
         TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index("unstuck_enabled")
     ] = 1.0
+    unstuck_short = side_row(0)
+    unstuck_short[
+        TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index("unstuck_enabled")
+    ] = 1.0
     rows = [
         side_row(0) + side_row(0),
         side_row(1) + side_row(1),
@@ -5084,6 +5099,8 @@ def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
         side_row(0) + side_row(1),
         side_row(3) + side_row(3),
         unstuck_long + side_row(0),
+        side_row(0) + unstuck_short,
+        unstuck_long + unstuck_short,
     ]
     batch_size = len(rows)
     params = torch.as_tensor(
@@ -5166,9 +5183,12 @@ def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
     )
     assert (output[:3, 22] <= 1.01).all()
     assert (coin_fill_counts[:3].sum(dim=1).cpu().numpy() > 0.0).all()
-    assert output[3:, 9].tolist() == [0.0, 0.0, 0.0]
-    assert output[3:, 13].tolist() == [0.0, 0.0, 0.0]
-    assert output[3:, 24].tolist() == [0.0, 0.0, 0.0]
+    assert output[3:5, 9].tolist() == [0.0, 0.0]
+    assert output[3:5, 13].tolist() == [0.0, 0.0]
+    assert output[3:5, 24].tolist() == [0.0, 0.0]
+    assert output[5:, 9].tolist() == [-1.0, -1.0, -1.0]
+    assert output[5:, 13].tolist() == [1.0, 1.0, 1.0]
+    assert (output[5:, 24] > 0.0).all()
 
     override_matrix = np.full((coin_count, 44), np.nan, dtype=np.float32)
     runner = MpsTrailingMartingaleMulticoinFusedRunner(
@@ -5229,7 +5249,9 @@ def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
         True,
         False,
         False,
-        False,
+        True,
+        True,
+        True,
     ]
     assert torch.equal(runner_output["coin_fill_counts"], coin_fill_counts)
     recovery = strategy_eq_recovery_distribution_from_samples(
@@ -5239,9 +5261,9 @@ def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
         ],
     )
     assert torch.isfinite(recovery).all().item()
-    assert (recovery[:3, 3] > 0.0).all().item()
+    assert (recovery[[0, 1, 2, 5, 6, 7], 3] > 0.0).all().item()
     assert (
-        runner_output["strategy_eq_recovery_samples"][3:, 0] < 0.0
+        runner_output["strategy_eq_recovery_samples"][3:5, 0] < 0.0
     ).all().item()
     assert runner.last_profile["kernel_seconds"] >= 0.0
 
@@ -5433,9 +5455,9 @@ def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
         threads=(1, 1, 1),
     )
     torch.mps.synchronize()
-    assert override_scalars[0, 9].item() == 0.0
-    assert override_scalars[0, 13].item() == 0.0
-    assert override_scalars[0, 24].item() == 0.0
+    assert override_scalars[0, 9].item() == -1.0
+    assert override_scalars[0, 13].item() == 1.0
+    assert override_scalars[0, 24].item() > 0.0
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -877,7 +877,9 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
                 "total_exposure_enforcer_enabled": False,
             }
         )
-        config["bot"][side]["unstuck"]["enabled"] = False
+        # Construction must retain the fused shared-account path when both
+        # directional surfaces participate in global auto-unstuck selection.
+        config["bot"][side]["unstuck"]["enabled"] = True
         config["bot"][side]["hsl"]["enabled"] = True
         flat = flatten_shared_bot_side(config["bot"][side])
         config["bot"][side].update(


### PR DESCRIPTION
## Summary
- Add one global least-stuck selector across long and short surfaces in the fused EMA Anchor and Trailing Martingale multicoin Metal kernels.
- Enable tunable auto-unstuck and static coin overrides for dual-side multicoin runs and compatible suites while keeping exposure repair fail closed.
- Extend backend, service, physical MPS, source-contract, docs, and changelog coverage.

Exact Rust backtesting remains authoritative. Metal uses the existing conservative all-history realized-loss allowance, and the existing exact classification, rank, and drift gates remain unchanged.

## Validation
- Rust: 267 passed.
- GPU backend, service, and metrics: 572 passed.
- Physical M3 MPS module: 302 passed.
- Cached BTC/ETH Trailing Martingale fused dual-side run: 72 proxy, 32 exact, no halt.
- Cached BTC/ETH/SOL EMA Anchor two-scenario suite with scenario coin overrides: 1,024 proxy, 32 exact, no halt.

## Safety boundary
- Additive GPU optimizer path only; CPU bot, backtest, and optimizer behavior is unchanged.
- Dual-side multicoin exposure repair remains rejected before optimization.