### PR TITLE
Enable dual-side multicoin GPU exposure repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,13 @@ All notable user-facing changes will be documented in this file.
   account kernel admits one global least-stuck candidate across both directional surfaces using
   exact Rust's price-difference, symbol-index, and long-before-short tie ordering, then applies the
   existing conservative realized-loss allowance. Exact Rust validation and drift gates remain
-  authoritative; dual-side multi-coin exposure repair remains fail closed.
+  authoritative.
+
+- Enabled fused dual-side multi-coin exposure repair in Apple MPS optimization. EMA Anchor and
+  Trailing Martingale now support per-side TWEL repair in shared-account runs, and Trailing
+  Martingale also supports its per-position WEL reducer and static coin overrides. Each directional
+  surface computes its exact-Rust-style action set from the same pre-fill shared account snapshot;
+  exact Rust validation and the existing drift gates remain authoritative.
 
 - Fixed finite `live.pnls_max_lookback_days` handling for single-coin `coin`-mode HSL on Apple
   MPS. EMA Anchor and Trailing Martingale screening now expire realized-PnL fill events with the
@@ -67,13 +73,11 @@ All notable user-facing changes will be documented in this file.
 - Added fused shared-account dual-side multi-coin Trailing Martingale screening to Apple MPS
   optimization. Long and short candidates now run in one portfolio kernel for unified, pside,
   and coin HSL, including shared event/tier metrics, directional PnL, coin overrides, forager
-  selection, and the existing TM entry/close behavior. Exact Rust remains authoritative;
-  dual-side exposure repair remains fail closed pending its global cross-side parity slice.
+  selection, and the existing TM entry/close behavior. Exact Rust remains authoritative.
 
 - Added fused shared-account dual-side multi-coin EMA Anchor screening to Apple MPS optimization.
   Unified, pside, and coin HSL now run inside one portfolio kernel, including per-coin HSL
-  overrides and shared event/tier scoring metrics. Exact Rust remains authoritative; dual-side
-  exposure repair remains fail closed.
+  overrides and shared event/tier scoring metrics. Exact Rust remains authoritative.
 
 - Added dual-side single-coin `unified` HSL to Apple MPS optimization for EMA Anchor and
   Trailing Martingale. Both Metal controllers now consume account-wide realized and unrealized

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -241,13 +241,13 @@ The supported slice is intentionally narrow:
   coin's equity tracking starts because Rust records an equity sample on every tracked step
 - Trailing Martingale supports `risk.position_exposure_enforcer_enabled` and a tunable
   `risk.position_exposure_enforcer_threshold` for single-coin long, short, and dual-side runs,
-  one-sided multi-coin runs, and compatible suites. When current position exposure exceeds the
-  allowance-adjusted WEL times the positive threshold, Metal gives the passive reducer precedence
-  over the normal strategy close and sizes it strictly below that target. Static per-coin
-  overrides may change both fields in one-sided multi-coin runs. Dual-side multi-coin repair
-  remains fail closed until global cross-side selection and loss-budget reservation are modeled.
-  EMA Anchor position-exposure repair remains fail closed because its exact Rust strategy path
-  does not use this reducer
+  one- and dual-side multi-coin runs, and compatible suites. When current position exposure
+  exceeds the allowance-adjusted WEL times the positive threshold, Metal gives the passive reducer
+  precedence over the normal strategy close and sizes it strictly below that target. Static per-coin
+  overrides may change both fields in one- and dual-side multi-coin runs. The fused kernel computes
+  WEL and TWEL repair independently for each directional surface against the same pre-fill shared
+  account snapshot, matching exact Rust order generation. EMA Anchor position-exposure repair
+  remains fail closed because its exact Rust strategy path does not use this reducer
 - single-coin EMA Anchor models the cumulative realized-loss gate, including entry and close fees,
   shared long/short loss-budget accounting, and lossy total-exposure repairs. The proxy uses a
   conservative all-history loss envelope, so it may block a close that exact Rust admits after old
@@ -260,7 +260,7 @@ The supported slice is intentionally narrow:
   restrictions avoid unsafe cross-side loss-budget reservation and per-candle
   enumeration of TM's recursive 500-rung close ladder. Exact
   validation applies the configured rolling allowance and remains authoritative
-- BTC collateral remains disabled; dual-side multicoin total-exposure repair remains disabled
+- BTC collateral remains disabled
 - `backtest.filter_by_min_effective_cost` may be enabled or disabled. When enabled, Metal uses the
   projected initial-entry cost test with the configured wallet-exposure limit. The
   screening proxy compares against the highest executable minimum observed for that coin in the
@@ -281,7 +281,7 @@ Unsupported combinations fail before optimization begins. Dual-side multi-coin E
 Trailing Martingale use fused shared-account Metal kernels in hedge mode. Every accepted metric
 still comes from the unchanged exact Rust portfolio backtest, and classification, rank, and drift
 gates halt material disagreement. Dual-side one-way arbitration, unmodeled non-bot suite scenario
-overrides and dual-side multi-coin exposure repair are not
+overrides are not
 silently approximated by this release.
 
 For a supported suite, each Metal candidate is dispatched across every prepared scenario. The GPU

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -961,46 +961,6 @@ def _validate_scope_config(
                         "GPU dual-side multicoin optimization currently requires "
                         f"matching long/short {label}_coins"
                     )
-        if len(enabled_sides) == 2 and strategy_kind in {
-            "ema_anchor",
-            "trailing_martingale",
-        }:
-            repair_paths = []
-            for side in enabled_sides:
-                risk = config["bot"][side].get("risk", {})
-                for key in (
-                    "position_exposure_enforcer_enabled",
-                    "total_exposure_enforcer_enabled",
-                ):
-                    if bool(risk.get(key)):
-                        repair_paths.append(f"bot.{side}.risk.{key}")
-            for coin, patch in (config.get("coin_overrides") or {}).items():
-                if not isinstance(patch, dict):
-                    continue
-                bot_patch = patch.get("bot", {})
-                if not isinstance(bot_patch, dict):
-                    continue
-                for side in enabled_sides:
-                    side_patch = bot_patch.get(side, {})
-                    risk = (
-                        side_patch.get("risk", {})
-                        if isinstance(side_patch, dict)
-                        else {}
-                    )
-                    if isinstance(risk, dict) and bool(
-                        risk.get("position_exposure_enforcer_enabled")
-                    ):
-                        repair_paths.append(
-                            "coin_overrides."
-                            f"{coin}.bot.{side}.risk."
-                            "position_exposure_enforcer_enabled"
-                        )
-            if repair_paths:
-                raise ValueError(
-                    "GPU dual-side multicoin exposure repair requires shared "
-                    "global cross-side selection semantics; the "
-                    f"current fused proxy does not model {sorted(repair_paths)}"
-                )
         if not bool(config.get("backtest", {}).get("dynamic_wel_by_tradability")):
             raise ValueError(
                 "GPU multicoin foundation requires "
@@ -2615,19 +2575,6 @@ def _validate_pinned_scope_bounds(
             {
                 f"{side}_risk_position_exposure_enforcer_enabled": 0.0
                 for side in ("long", "short")
-            }
-        )
-    if coin_count > 1 and len(enabled_sides) == 2:
-        # The fused runner owns shared account state, but exposure repair still
-        # lacks one global cross-side reducer-selection implementation.
-        pinned.update(
-            {
-                f"{side}_risk_{key}": 0.0
-                for side in enabled_sides
-                for key in (
-                    "position_exposure_enforcer_enabled",
-                    "total_exposure_enforcer_enabled",
-                )
             }
         )
     for key, expected in pinned.items():

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1800,7 +1800,7 @@ def test_gpu_multicoin_accepts_tm_total_exposure_repair(side, policy):
         "total_exposure_enforcer_enabled",
     ],
 )
-def test_gpu_dual_multicoin_rejects_tm_exposure_repair(repair_key):
+def test_gpu_dual_multicoin_accepts_tm_exposure_repair(repair_key):
     config = _directional_tm_config(long_enabled=True, short_enabled=True)
     config["live"]["approved_coins"] = {
         "long": ["BTC", "ETH", "SOL"],
@@ -1813,11 +1813,10 @@ def test_gpu_dual_multicoin_rejects_tm_exposure_repair(repair_key):
         risk["n_positions"] = 2
         risk[repair_key] = True
 
-    with pytest.raises(ValueError, match="global cross-side selection"):
-        _validate_scope(config, _MulticoinEvaluator())
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
-def test_gpu_dual_multicoin_rejects_tm_coin_override_exposure_repair():
+def test_gpu_dual_multicoin_accepts_tm_coin_override_exposure_repair():
     config = _directional_tm_config(long_enabled=True, short_enabled=True)
     config["live"]["approved_coins"] = {
         "long": ["BTC", "ETH", "SOL"],
@@ -1835,8 +1834,7 @@ def test_gpu_dual_multicoin_rejects_tm_coin_override_exposure_repair():
         }
     }
 
-    with pytest.raises(ValueError, match="global cross-side selection"):
-        _validate_scope(config, _MulticoinEvaluator())
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
 @pytest.mark.parametrize("side", ["long", "short"])
@@ -1911,7 +1909,7 @@ def test_gpu_multicoin_accepts_ema_total_exposure_repair(
     )
 
 
-def test_gpu_dual_multicoin_rejects_ema_total_exposure_repair():
+def test_gpu_dual_multicoin_accepts_ema_total_exposure_repair():
     config = _directional_ema_config(long_enabled=True, short_enabled=True)
     config["live"]["approved_coins"] = {
         "long": ["BTC", "ETH", "SOL"],
@@ -1924,8 +1922,7 @@ def test_gpu_dual_multicoin_rejects_ema_total_exposure_repair():
         risk["n_positions"] = 2
         risk["total_exposure_enforcer_enabled"] = True
 
-    with pytest.raises(ValueError, match="global cross-side selection"):
-        _validate_scope(config, _MulticoinEvaluator())
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
@@ -4720,7 +4717,7 @@ def test_gpu_rejects_pinned_unsupported_exposure_repair_behavior():
         strategy_kind="trailing_martingale",
     )
 
-    with pytest.raises(ValueError, match="total_exposure_enforcer_enabled"):
+    for strategy_kind in ("trailing_martingale", "ema_anchor"):
         _validate_pinned_scope_bounds(
             {
                 "long_risk_total_exposure_enforcer_enabled": Bound(
@@ -4730,20 +4727,7 @@ def test_gpu_rejects_pinned_unsupported_exposure_repair_behavior():
             {"long_risk_total_exposure_enforcer_enabled": 0.0},
             {"long", "short"},
             coin_count=2,
-            strategy_kind="trailing_martingale",
-        )
-
-    with pytest.raises(ValueError, match="total_exposure_enforcer_enabled"):
-        _validate_pinned_scope_bounds(
-            {
-                "long_risk_total_exposure_enforcer_enabled": Bound(
-                    0.0, 1.0, None
-                )
-            },
-            {"long_risk_total_exposure_enforcer_enabled": 0.0},
-            {"long", "short"},
-            coin_count=2,
-            strategy_kind="ema_anchor",
+            strategy_kind=strategy_kind,
         )
 
 

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -2715,6 +2715,7 @@ def _multicoin_exposure_fixture(
     collect_coin_fill_counts=False,
     market_order_slippage_pct=0.0,
     hsl_panic_market=False,
+    return_context=False,
 ):
     coin_count = 2
     timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
@@ -2854,6 +2855,8 @@ def _multicoin_exposure_fixture(
             market_order_slippage_pct=market_order_slippage_pct,
             hsl_panic_market=hsl_panic_market,
         )
+    if return_context:
+        return runner, row, runs[0], data
     return runner, row
 
 
@@ -9061,6 +9064,77 @@ def test_mps_tm_multicoin_global_position_exposure_repair(side):
         output["day_volume"][1].sum().item()
         > output["day_volume"][0].sum().item()
     )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize(
+    ("strategy_kind", "repair_kind"),
+    [
+        ("ema_anchor", "total"),
+        ("trailing_martingale", "total"),
+        ("trailing_martingale", "position"),
+    ],
+)
+def test_mps_fused_dual_multicoin_exposure_repair(
+    strategy_kind, repair_kind
+):
+    fixture_kwargs = {"count": 10}
+    if strategy_kind == "ema_anchor":
+        count = 70
+        highs = np.full((count, 2), 100.5)
+        lows = np.full((count, 2), 99.5)
+        highs[62, :] = 102.0
+        lows[62, :] = 98.0
+        fixture_kwargs = {
+            "count": count,
+            "closes": (100.0, 100.0),
+            "highs": highs,
+            "lows": lows,
+        }
+    _, baseline, run, data = _multicoin_exposure_fixture(
+        strategy_kind,
+        "long",
+        return_context=True,
+        **fixture_kwargs,
+    )
+    if strategy_kind == "ema_anchor":
+        runner = MpsEmaAnchorMulticoinFusedRunner(run, data)
+        param_keys = EMA_ANCHOR_MULTICOIN_PARAM_KEYS
+    else:
+        runner = MpsTrailingMartingaleMulticoinFusedRunner(run, data)
+        param_keys = TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+
+    baseline = list(baseline)
+    baseline[param_keys.index("entry_cooldown_minutes")] = 100.0
+    if strategy_kind == "ema_anchor":
+        baseline[param_keys.index("offset")] = 0.01
+    else:
+        baseline[param_keys.index("entry_initial_ema_dist")] = 0.01
+    repaired = list(baseline)
+    if repair_kind == "total":
+        repaired[param_keys.index("twel_entry_gate_enabled")] = 0.0
+        repaired[param_keys.index("twel_enforcer_threshold")] = 0.5
+        repaired[param_keys.index("twel_enforcer_enabled")] = 1.0
+        repaired[param_keys.index("twel_enforcer_reduce_portfolio")] = 1.0
+    else:
+        repaired[param_keys.index("wel_enforcer_enabled")] = 1.0
+        repaired[param_keys.index("wel_enforcer_threshold")] = 0.5
+
+    output = runner.run(
+        np.asarray(
+            [baseline + baseline, repaired + repaired], dtype=np.float64
+        )
+    )
+    torch.mps.synchronize()
+
+    assert output["alive"].cpu().tolist() == [True, True]
+    assert output["psize"][0].item() > 0.0
+    assert output["short_psize"][0].item() > 0.0
+    assert output["psize"][1].item() < output["psize"][0].item()
+    assert output["short_psize"][1].item() < output["short_psize"][0].item()
+    assert output["fill_count"][1].item() > output["fill_count"][0].item()
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -873,8 +873,13 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
             {
                 "n_positions": 2,
                 "total_wallet_exposure_limit": 1.0,
-                "position_exposure_enforcer_enabled": False,
-                "total_exposure_enforcer_enabled": False,
+                "position_exposure_enforcer_enabled": (
+                    strategy_kind == "trailing_martingale"
+                ),
+                "position_exposure_enforcer_threshold": 0.7,
+                "total_exposure_enforcer_enabled": True,
+                "total_exposure_enforcer_policy": "reduce_portfolio",
+                "total_exposure_enforcer_threshold": 0.8,
             }
         )
         # Construction must retain the fused shared-account path when both
@@ -909,6 +914,12 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
             "risk_twel_enforcer_policy": flat["risk_twel_enforcer_policy"],
             "risk_twel_enforcer_threshold": flat[
                 "risk_twel_enforcer_threshold"
+            ],
+            "risk_wel_enforcer_enabled": flat[
+                "risk_wel_enforcer_enabled"
+            ],
+            "risk_wel_enforcer_threshold": flat[
+                "risk_wel_enforcer_threshold"
             ],
             "unstuck_enabled": flat["unstuck_enabled"],
             "hsl_enabled": flat["hsl_enabled"],


### PR DESCRIPTION
## Summary
- Remove obsolete dual-side multicoin exposure-repair gates now that EMA Anchor and Trailing Martingale use fused shared-account kernels.
- Enable per-side TWEL repair for both strategies and TM per-position WEL repair, including static coin overrides and compatible suites.
- Add positive backend, service, and physical M3 fused-kernel coverage and update the documented support boundary.

Exact Rust computes repair independently for each directional surface from the same pre-fill account snapshot. The fused proxy now uses the same topology; exact validation and drift gates remain authoritative.

## Validation
- Rust: 267 passed.
- GPU backend, service, and metrics: 572 passed.
- Physical M3 MPS module: 305 passed.
- Cached BTC/ETH TM dual-side run with WEL, TWEL, unstuck, tunable thresholds, and ETH overrides: 1,024 proxy, 32 exact, no halt.
- Cached BTC/ETH/SOL EMA two-scenario suite with dual-side TWEL, unstuck, and scenario coin overrides: 1,024 proxy, 32 exact, no halt.

## Safety boundary
- Additive GPU optimizer path only; CPU bot, backtest, and optimizer behavior is unchanged.
- EMA position-exposure repair remains rejected because exact EMA Anchor does not use that reducer.