### PR TITLE
Add MPS multicoin one-way arbitration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added Apple MPS GPU optimizer support for dual-side multi-coin one-way mode in EMA Anchor and
+  Trailing Martingale, with per-symbol initial-entry arbitration matching exact Rust.
+
 - Added global strategy-equity recovery-distribution scoring and limits to Apple MPS optimization
   for EMA Anchor and Trailing Martingale across single-coin, one-sided multi-coin, and fused
   shared-account dual-side multi-coin runs. Strategy kernels emit opt-in candidate-relative hourly

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -104,7 +104,8 @@ The supported slice is intentionally narrow:
   dataset may be an individual exchange or the canonical combined multi-exchange dataset
 - `strategy_kind: ema_anchor` or `trailing_martingale`, with long-only, short-only, or
   long+short enabled for one coin
-- long-only, short-only, or dual-side hedge-mode multi-coin EMA-anchor and trailing-martingale runs
+- long-only, short-only, or dual-side hedge-mode and one-way multi-coin EMA-anchor and
+  trailing-martingale runs
   for up to 64 coins, with dynamic wallet-exposure allocation and independent per-side Forager
   selection; dual-side runs require matching long/short approved and ignored coin sets, and all
   multi-coin runs require `backtest.dynamic_wel_by_tradability: true`;
@@ -278,11 +279,10 @@ The supported slice is intentionally narrow:
 - no invalid candle tail after the selected coin's final valid candle
 
 Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor and
-Trailing Martingale use fused shared-account Metal kernels in hedge mode. Every accepted metric
-still comes from the unchanged exact Rust portfolio backtest, and classification, rank, and drift
-gates halt material disagreement. Dual-side one-way arbitration, unmodeled non-bot suite scenario
-overrides are not
-silently approximated by this release.
+Trailing Martingale use fused shared-account Metal kernels in hedge and one-way modes. Every
+accepted metric still comes from the unchanged exact Rust portfolio backtest, and classification,
+rank, and drift gates halt material disagreement. Unmodeled non-bot suite scenario overrides are
+not silently approximated by this release.
 
 For a supported suite, each Metal candidate is dispatched across every prepared scenario. The GPU
 path then calls the same canonical suite reducer and scenario-selection logic as the CPU optimizer

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -588,7 +588,7 @@ mod tests {
         assert!(source.contains("if (effective_equity >= account_peak)"));
         assert!(source.contains("const bool collect_coin_fill_counts = run_settings[6] > 0.5f"));
         assert!(source.contains("const bool hedge_mode = run_settings[10] > 0.5f"));
-        assert!(source.contains("apply_ema_multicoin_one_way_initial_arbitration"));
+        assert!(source.contains("compute_ema_multicoin_one_way_initial_blocks"));
         assert!(source.contains("device float* coin_fill_counts"));
         assert_eq!(
             source
@@ -935,7 +935,7 @@ mod tests {
         assert!(source.contains("if (effective_equity >= account_peak)"));
         assert!(source.contains("const bool collect_coin_fill_counts = run_settings[6] > 0.5f"));
         assert!(source.contains("const bool hedge_mode = run_settings[10] > 0.5f"));
-        assert!(source.contains("apply_tm_multicoin_one_way_initial_arbitration"));
+        assert!(source.contains("compute_tm_multicoin_one_way_initial_blocks"));
         assert!(source.contains("device float* coin_fill_counts"));
         assert_eq!(
             source

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -587,6 +587,8 @@ mod tests {
         );
         assert!(source.contains("if (effective_equity >= account_peak)"));
         assert!(source.contains("const bool collect_coin_fill_counts = run_settings[6] > 0.5f"));
+        assert!(source.contains("const bool hedge_mode = run_settings[10] > 0.5f"));
+        assert!(source.contains("apply_ema_multicoin_one_way_initial_arbitration"));
         assert!(source.contains("device float* coin_fill_counts"));
         assert_eq!(
             source
@@ -932,6 +934,8 @@ mod tests {
         );
         assert!(source.contains("if (effective_equity >= account_peak)"));
         assert!(source.contains("const bool collect_coin_fill_counts = run_settings[6] > 0.5f"));
+        assert!(source.contains("const bool hedge_mode = run_settings[10] > 0.5f"));
+        assert!(source.contains("apply_tm_multicoin_one_way_initial_arbitration"));
         assert!(source.contains("device float* coin_fill_counts"));
         assert_eq!(
             source

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -2696,7 +2696,9 @@ inline float ema_multicoin_entry_initial_balance_pct(
 }
 
 // Match exact Rust's per-symbol one-way eligibility before Forager selection
-// and side-wide entry-cap allocation. Reentries and closes remain unblocked.
+// and side-wide entry-cap allocation. Opposite-held coins are excluded from
+// selection; flat/flat arbitration losers retain their selected slot but emit
+// no order. Reentries and closes remain unblocked.
 inline void compute_ema_multicoin_one_way_initial_blocks(
     thread EmaMulticoinSideState& long_side,
     thread const EmaMulticoinSideConfig& long_config,
@@ -2712,26 +2714,34 @@ inline void compute_ema_multicoin_one_way_initial_blocks(
     int short_hsl_mode,
     bool long_can_generate,
     bool short_can_generate,
-    thread ulong& long_blocked_mask,
-    thread ulong& short_blocked_mask
+    thread ulong& long_selection_blocked_mask,
+    thread ulong& short_selection_blocked_mask,
+    thread ulong& long_order_blocked_mask,
+    thread ulong& short_order_blocked_mask
 ) {
-    long_blocked_mask = 0ul;
-    short_blocked_mask = 0ul;
+    long_selection_blocked_mask = 0ul;
+    short_selection_blocked_mask = 0ul;
+    long_order_blocked_mask = 0ul;
+    short_order_blocked_mask = 0ul;
     for (int c = 0; c < coin_count; ++c) {
         const ulong bit = 1ul << ulong(c);
         const bool has_long = long_side.psize[c] > 0.0f;
         const bool has_short = short_side.psize[c] > 0.0f;
         if (has_long && !has_short) {
-            short_blocked_mask |= bit;
+            short_selection_blocked_mask |= bit;
+            short_order_blocked_mask |= bit;
             continue;
         }
         if (has_short && !has_long) {
-            long_blocked_mask |= bit;
+            long_selection_blocked_mask |= bit;
+            long_order_blocked_mask |= bit;
             continue;
         }
         if (has_long && has_short) {
-            long_blocked_mask |= bit;
-            short_blocked_mask |= bit;
+            long_selection_blocked_mask |= bit;
+            short_selection_blocked_mask |= bit;
+            long_order_blocked_mask |= bit;
+            short_order_blocked_mask |= bit;
             continue;
         }
 
@@ -2757,16 +2767,16 @@ inline void compute_ema_multicoin_one_way_initial_blocks(
             && short_wel != 0.0f
             && short_coin_mode == 0;
         if (long_eligible && !short_eligible) {
-            short_blocked_mask |= bit;
+            short_order_blocked_mask |= bit;
             continue;
         }
         if (short_eligible && !long_eligible) {
-            long_blocked_mask |= bit;
+            long_order_blocked_mask |= bit;
             continue;
         }
         if (!long_eligible && !short_eligible) {
-            long_blocked_mask |= bit;
-            short_blocked_mask |= bit;
+            long_order_blocked_mask |= bit;
+            short_order_blocked_mask |= bit;
             continue;
         }
         const float long_lower = fmin(
@@ -2788,9 +2798,9 @@ inline void compute_ema_multicoin_one_way_initial_blocks(
         // Exact Rust blocks the side farther from triggering; stable ties
         // favor long.
         if (dist_long >= dist_short) {
-            short_blocked_mask |= bit;
+            short_order_blocked_mask |= bit;
         } else {
-            long_blocked_mask |= bit;
+            long_order_blocked_mask |= bit;
         }
     }
 }
@@ -3067,8 +3077,10 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                 short_side.hsl,
                 ema_multicoin_side_has_position(short_side, C)
             );
-        ulong long_one_way_blocked_mask = 0ul;
-        ulong short_one_way_blocked_mask = 0ul;
+        ulong long_one_way_selection_blocked_mask = 0ul;
+        ulong short_one_way_selection_blocked_mask = 0ul;
+        ulong long_one_way_order_blocked_mask = 0ul;
+        ulong short_one_way_order_blocked_mask = 0ul;
         if (!hedge_mode) {
             compute_ema_multicoin_one_way_initial_blocks(
                 long_side, long_config, long_coin_overrides,
@@ -3076,7 +3088,10 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                 bars, coin_settings, k, C,
                 long_hsl_mode, short_hsl_mode,
                 long_can_generate, short_can_generate,
-                long_one_way_blocked_mask, short_one_way_blocked_mask
+                long_one_way_selection_blocked_mask,
+                short_one_way_selection_blocked_mask,
+                long_one_way_order_blocked_mask,
+                short_one_way_order_blocked_mask
             );
         }
         float long_unstuck_diff = INFINITY;
@@ -3115,7 +3130,7 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                 long_side, long_config, bars, coin_settings,
                 long_coin_overrides, k, C, false, any_fill,
                 long_effective_n_positions, score_hysteresis,
-                long_one_way_blocked_mask
+                long_one_way_selection_blocked_mask
             );
             generate_ema_multicoin_side_orders(
                 long_side, long_config, account,
@@ -3123,7 +3138,7 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                 k, C, false, long_tradable_count,
                 long_effective_n_positions, long_hsl_mode,
                 loss_gate_enabled, max_realized_loss_pct,
-                long_unstuck_coin, long_one_way_blocked_mask
+                long_unstuck_coin, long_one_way_order_blocked_mask
             );
         }
         if (short_can_generate) {
@@ -3131,7 +3146,7 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                 short_side, short_config, bars, coin_settings,
                 short_coin_overrides, k, C, true, any_fill,
                 short_effective_n_positions, score_hysteresis,
-                short_one_way_blocked_mask
+                short_one_way_selection_blocked_mask
             );
             generate_ema_multicoin_side_orders(
                 short_side, short_config, account,
@@ -3139,7 +3154,7 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                 k, C, true, short_tradable_count,
                 short_effective_n_positions, short_hsl_mode,
                 loss_gate_enabled, max_realized_loss_pct,
-                short_unstuck_coin, short_one_way_blocked_mask
+                short_unstuck_coin, short_one_way_order_blocked_mask
             );
         }
 

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -2683,6 +2683,90 @@ inline float ema_multicoin_entry_initial_balance_pct(
     ) * initial_qty_pct;
 }
 
+// Match exact Rust's per-symbol one-way initial-entry arbitration after both
+// directional generators have observed the same pre-fill account snapshot.
+// Reentries and closes on an existing position remain untouched.
+inline void apply_ema_multicoin_one_way_initial_arbitration(
+    thread EmaMulticoinSideState& long_side,
+    thread const EmaMulticoinSideConfig& long_config,
+    constant float* long_coin_overrides,
+    thread EmaMulticoinSideState& short_side,
+    thread const EmaMulticoinSideConfig& short_config,
+    constant float* short_coin_overrides,
+    constant float* bars,
+    int k,
+    int coin_count,
+    int long_hsl_mode,
+    int short_hsl_mode
+) {
+    for (int c = 0; c < coin_count; ++c) {
+        const bool has_long = long_side.psize[c] > 0.0f;
+        const bool has_short = short_side.psize[c] > 0.0f;
+        if (has_long && !has_short) {
+            short_side.entry_qty[c] = 0.0f;
+            continue;
+        }
+        if (has_short && !has_long) {
+            long_side.entry_qty[c] = 0.0f;
+            continue;
+        }
+        if (has_long || has_short) continue;
+
+        const float close = bars[(k * coin_count + c) * 4 + 2];
+        const float long_wel = coin_override_or(
+            long_coin_overrides, c, 11, -1.0f
+        );
+        const float short_wel = coin_override_or(
+            short_coin_overrides, c, 11, -1.0f
+        );
+        const int long_coin_mode = long_config.coin_hsl_mode
+            ? hsl_mode(long_side.coin_hsl[c], false) : long_hsl_mode;
+        const int short_coin_mode = short_config.coin_hsl_mode
+            ? hsl_mode(short_side.coin_hsl[c], false) : short_hsl_mode;
+        const bool coin_tradable = finite_positive(close);
+        const bool long_eligible = coin_tradable && long_wel != 0.0f
+            && long_coin_mode == 0;
+        const bool short_eligible = coin_tradable && short_wel != 0.0f
+            && short_coin_mode == 0;
+        if (long_eligible && !short_eligible) {
+            short_side.entry_qty[c] = 0.0f;
+            continue;
+        }
+        if (short_eligible && !long_eligible) {
+            long_side.entry_qty[c] = 0.0f;
+            continue;
+        }
+        if (!long_eligible && !short_eligible) {
+            long_side.entry_qty[c] = 0.0f;
+            short_side.entry_qty[c] = 0.0f;
+            continue;
+        }
+        const float long_lower = fmin(
+            long_side.ema0[c], fmin(long_side.ema1[c], long_side.ema2[c])
+        );
+        const float short_upper = fmax(
+            short_side.ema0[c], fmax(short_side.ema1[c], short_side.ema2[c])
+        );
+        const float long_offset = coin_override_or(
+            long_coin_overrides, c, 4, long_config.offset
+        );
+        const float short_offset = coin_override_or(
+            short_coin_overrides, c, 4, short_config.offset
+        );
+        const float dist_long = long_lower * (1.0f - long_offset)
+            / close - 1.0f;
+        const float dist_short = 1.0f
+            - short_upper * (1.0f + short_offset) / close;
+        // Exact Rust blocks the side farther from triggering; stable ties
+        // favor long.
+        if (dist_long >= dist_short) {
+            short_side.entry_qty[c] = 0.0f;
+        } else {
+            long_side.entry_qty[c] = 0.0f;
+        }
+    }
+}
+
 inline void passivbot_ema_anchor_multicoin_fused_impl(
     constant float* bars,
     constant int* fill_ticks,
@@ -2781,6 +2865,7 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
     const float market_order_slippage_pct = fmax(run_settings[7], 0.0f);
     const bool long_hsl_panic_market = run_settings[8] > 0.5f;
     const bool short_hsl_panic_market = run_settings[9] > 0.5f;
+    const bool hedge_mode = run_settings[10] > 0.5f;
     const float log_bin_scale = 127.0f / log(4000001.0f);
 
     JointPortfolioAccount account = init_joint_portfolio_account(
@@ -3013,6 +3098,13 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                 short_effective_n_positions, short_hsl_mode,
                 loss_gate_enabled, max_realized_loss_pct,
                 short_unstuck_coin
+            );
+        }
+        if (!hedge_mode) {
+            apply_ema_multicoin_one_way_initial_arbitration(
+                long_side, long_config, long_coin_overrides,
+                short_side, short_config, short_coin_overrides,
+                bars, k, C, long_hsl_mode, short_hsl_mode
             );
         }
 

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -125,6 +125,7 @@ struct EmaMulticoinSideState {
     HslDrawdownEmaTailStats hsl_ema_tail;
 #endif
     ulong coin_hsl_entry_blocked_mask;
+    ulong one_way_initial_blocked_mask;
     float ema0[MAX_COINS];
     float ema1[MAX_COINS];
     float ema2[MAX_COINS];
@@ -358,6 +359,7 @@ inline void init_ema_multicoin_side_state(
     side.hsl_ema_tail = init_hsl_drawdown_ema_tail_stats();
 #endif
     side.coin_hsl_entry_blocked_mask = 0ul;
+    side.one_way_initial_blocked_mask = 0ul;
     side.selection_initialized = false;
     side.max_tradable_seen = 0;
     side.previous_effective_n_positions = 0;
@@ -871,7 +873,8 @@ inline void update_ema_multicoin_side_selection(
     bool short_side,
     bool any_fill,
     int effective_n_positions,
-    float score_hysteresis
+    float score_hysteresis,
+    ulong one_way_initial_blocked_mask
 ) {
     thread HslState* coin_hsl = side.coin_hsl;
     thread ulong& coin_hsl_entry_blocked_mask =
@@ -902,8 +905,12 @@ inline void update_ema_multicoin_side_selection(
             blocked_mask != coin_hsl_entry_blocked_mask;
         coin_hsl_entry_blocked_mask = blocked_mask;
     }
+    bool one_way_eligibility_changed = one_way_initial_blocked_mask
+        != side.one_way_initial_blocked_mask;
+    side.one_way_initial_blocked_mask = one_way_initial_blocked_mask;
     bool reselect = !side.selection_initialized || any_fill
         || coin_hsl_eligibility_changed
+        || one_way_eligibility_changed
         || effective_n_positions != side.previous_effective_n_positions;
     if (!reselect) return;
 
@@ -925,6 +932,7 @@ inline void update_ema_multicoin_side_selection(
             && k <= int(coin_settings[coin_offset + 7])
             && finite_positive(bars[bar_offset + 2])
             && coin_wel != 0.0f
+            && (one_way_initial_blocked_mask & (1ul << ulong(c))) == 0ul
             && (!config.coin_hsl_mode || (
                 coin_hsl_entry_blocked_mask & (1ul << ulong(c))
             ) == 0ul);
@@ -1197,7 +1205,8 @@ inline void generate_ema_multicoin_side_orders(
     int current_hsl_mode,
     bool loss_gate_enabled,
     float max_realized_loss_pct,
-    int forced_unstuck_coin
+    int forced_unstuck_coin,
+    ulong one_way_initial_blocked_mask
 ) {
     const int C = coin_count;
     const float base_qty_pct = config.base_qty_pct;
@@ -1607,7 +1616,10 @@ inline void generate_ema_multicoin_side_orders(
             coin_overrides, c, 0, base_qty_pct
         );
         float coin_ddf = coin_override_or(coin_overrides, c, 3, ddf);
-        if (selected[c] && !cooldown && entry_price > 0.0f && balance > 0.0f
+        bool initial_entry_allowed = psize[c] > 0.0f
+            || (one_way_initial_blocked_mask & (1ul << ulong(c))) == 0ul;
+        if (selected[c] && initial_entry_allowed
+            && !cooldown && entry_price > 0.0f && balance > 0.0f
             && cost_we < position_cap && coin_base_qty_pct > 0.0f) {
             float base_qty = fmax(minimum, round_step(
                 balance * allowed_coin_wel * coin_base_qty_pct
@@ -2331,14 +2343,14 @@ inline void passivbot_ema_anchor_multicoin_impl(
             update_ema_multicoin_side_selection(
                 side, config, bars, coin_settings, coin_overrides,
                 k, C, short_side, any_fill, effective_n_positions,
-                score_hysteresis
+                score_hysteresis, 0ul
             );
             generate_ema_multicoin_side_orders(
                 side, config, account,
                 bars, touch_ticks, coin_settings, coin_overrides,
                 k, C, short_side, tradable_count, effective_n_positions,
                 current_hsl_mode, loss_gate_enabled,
-                max_realized_loss_pct, -2
+                max_realized_loss_pct, -2, 0ul
             );
         }
 
@@ -2683,10 +2695,9 @@ inline float ema_multicoin_entry_initial_balance_pct(
     ) * initial_qty_pct;
 }
 
-// Match exact Rust's per-symbol one-way initial-entry arbitration after both
-// directional generators have observed the same pre-fill account snapshot.
-// Reentries and closes on an existing position remain untouched.
-inline void apply_ema_multicoin_one_way_initial_arbitration(
+// Match exact Rust's per-symbol one-way eligibility before Forager selection
+// and side-wide entry-cap allocation. Reentries and closes remain unblocked.
+inline void compute_ema_multicoin_one_way_initial_blocks(
     thread EmaMulticoinSideState& long_side,
     thread const EmaMulticoinSideConfig& long_config,
     constant float* long_coin_overrides,
@@ -2694,24 +2705,37 @@ inline void apply_ema_multicoin_one_way_initial_arbitration(
     thread const EmaMulticoinSideConfig& short_config,
     constant float* short_coin_overrides,
     constant float* bars,
+    constant float* coin_settings,
     int k,
     int coin_count,
     int long_hsl_mode,
-    int short_hsl_mode
+    int short_hsl_mode,
+    bool long_can_generate,
+    bool short_can_generate,
+    thread ulong& long_blocked_mask,
+    thread ulong& short_blocked_mask
 ) {
+    long_blocked_mask = 0ul;
+    short_blocked_mask = 0ul;
     for (int c = 0; c < coin_count; ++c) {
+        const ulong bit = 1ul << ulong(c);
         const bool has_long = long_side.psize[c] > 0.0f;
         const bool has_short = short_side.psize[c] > 0.0f;
         if (has_long && !has_short) {
-            short_side.entry_qty[c] = 0.0f;
+            short_blocked_mask |= bit;
             continue;
         }
         if (has_short && !has_long) {
-            long_side.entry_qty[c] = 0.0f;
+            long_blocked_mask |= bit;
             continue;
         }
-        if (has_long || has_short) continue;
+        if (has_long && has_short) {
+            long_blocked_mask |= bit;
+            short_blocked_mask |= bit;
+            continue;
+        }
 
+        const int coin_offset = c * COIN_COLS;
         const float close = bars[(k * coin_count + c) * 4 + 2];
         const float long_wel = coin_override_or(
             long_coin_overrides, c, 11, -1.0f
@@ -2723,22 +2747,26 @@ inline void apply_ema_multicoin_one_way_initial_arbitration(
             ? hsl_mode(long_side.coin_hsl[c], false) : long_hsl_mode;
         const int short_coin_mode = short_config.coin_hsl_mode
             ? hsl_mode(short_side.coin_hsl[c], false) : short_hsl_mode;
-        const bool coin_tradable = finite_positive(close);
-        const bool long_eligible = coin_tradable && long_wel != 0.0f
+        const bool coin_tradable = k >= int(coin_settings[coin_offset + 8])
+            && k <= int(coin_settings[coin_offset + 7])
+            && finite_positive(close);
+        const bool long_eligible = long_can_generate && coin_tradable
+            && long_wel != 0.0f
             && long_coin_mode == 0;
-        const bool short_eligible = coin_tradable && short_wel != 0.0f
+        const bool short_eligible = short_can_generate && coin_tradable
+            && short_wel != 0.0f
             && short_coin_mode == 0;
         if (long_eligible && !short_eligible) {
-            short_side.entry_qty[c] = 0.0f;
+            short_blocked_mask |= bit;
             continue;
         }
         if (short_eligible && !long_eligible) {
-            long_side.entry_qty[c] = 0.0f;
+            long_blocked_mask |= bit;
             continue;
         }
         if (!long_eligible && !short_eligible) {
-            long_side.entry_qty[c] = 0.0f;
-            short_side.entry_qty[c] = 0.0f;
+            long_blocked_mask |= bit;
+            short_blocked_mask |= bit;
             continue;
         }
         const float long_lower = fmin(
@@ -2760,9 +2788,9 @@ inline void apply_ema_multicoin_one_way_initial_arbitration(
         // Exact Rust blocks the side farther from triggering; stable ties
         // favor long.
         if (dist_long >= dist_short) {
-            short_side.entry_qty[c] = 0.0f;
+            short_blocked_mask |= bit;
         } else {
-            long_side.entry_qty[c] = 0.0f;
+            long_blocked_mask |= bit;
         }
     }
 }
@@ -3039,6 +3067,18 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                 short_side.hsl,
                 ema_multicoin_side_has_position(short_side, C)
             );
+        ulong long_one_way_blocked_mask = 0ul;
+        ulong short_one_way_blocked_mask = 0ul;
+        if (!hedge_mode) {
+            compute_ema_multicoin_one_way_initial_blocks(
+                long_side, long_config, long_coin_overrides,
+                short_side, short_config, short_coin_overrides,
+                bars, coin_settings, k, C,
+                long_hsl_mode, short_hsl_mode,
+                long_can_generate, short_can_generate,
+                long_one_way_blocked_mask, short_one_way_blocked_mask
+            );
+        }
         float long_unstuck_diff = INFINITY;
         float short_unstuck_diff = INFINITY;
         const int long_unstuck_candidate = long_can_generate
@@ -3074,7 +3114,8 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
             update_ema_multicoin_side_selection(
                 long_side, long_config, bars, coin_settings,
                 long_coin_overrides, k, C, false, any_fill,
-                long_effective_n_positions, score_hysteresis
+                long_effective_n_positions, score_hysteresis,
+                long_one_way_blocked_mask
             );
             generate_ema_multicoin_side_orders(
                 long_side, long_config, account,
@@ -3082,14 +3123,15 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                 k, C, false, long_tradable_count,
                 long_effective_n_positions, long_hsl_mode,
                 loss_gate_enabled, max_realized_loss_pct,
-                long_unstuck_coin
+                long_unstuck_coin, long_one_way_blocked_mask
             );
         }
         if (short_can_generate) {
             update_ema_multicoin_side_selection(
                 short_side, short_config, bars, coin_settings,
                 short_coin_overrides, k, C, true, any_fill,
-                short_effective_n_positions, score_hysteresis
+                short_effective_n_positions, score_hysteresis,
+                short_one_way_blocked_mask
             );
             generate_ema_multicoin_side_orders(
                 short_side, short_config, account,
@@ -3097,14 +3139,7 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                 k, C, true, short_tradable_count,
                 short_effective_n_positions, short_hsl_mode,
                 loss_gate_enabled, max_realized_loss_pct,
-                short_unstuck_coin
-            );
-        }
-        if (!hedge_mode) {
-            apply_ema_multicoin_one_way_initial_arbitration(
-                long_side, long_config, long_coin_overrides,
-                short_side, short_config, short_coin_overrides,
-                bars, k, C, long_hsl_mode, short_hsl_mode
+                short_unstuck_coin, short_one_way_blocked_mask
             );
         }
 

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -351,6 +351,7 @@ struct TrailingMartingaleMulticoinSideState {
     HslDrawdownEmaTailStats hsl_ema_tail;
 #endif
     ulong coin_hsl_entry_blocked_mask;
+    ulong one_way_initial_blocked_mask;
     float ema0[MAX_COINS];
     float ema1[MAX_COINS];
     float ema2[MAX_COINS];
@@ -1253,6 +1254,7 @@ inline void init_trailing_martingale_multicoin_side_state(
     side.hsl_ema_tail = init_hsl_drawdown_ema_tail_stats();
 #endif
     side.coin_hsl_entry_blocked_mask = 0ul;
+    side.one_way_initial_blocked_mask = 0ul;
     side.selection_initialized = false;
     side.max_tradable_seen = 0;
     side.previous_effective_n_positions = 0;
@@ -1799,7 +1801,8 @@ inline void update_tm_multicoin_side_selection(
     bool short_side,
     bool any_fill,
     int effective_n_positions,
-    float score_hysteresis
+    float score_hysteresis,
+    ulong one_way_initial_blocked_mask
 ) {
     thread HslState* coin_hsl = side.coin_hsl;
     thread ulong& coin_hsl_entry_blocked_mask =
@@ -1830,8 +1833,12 @@ inline void update_tm_multicoin_side_selection(
             blocked_mask != coin_hsl_entry_blocked_mask;
         coin_hsl_entry_blocked_mask = blocked_mask;
     }
+    bool one_way_eligibility_changed = one_way_initial_blocked_mask
+        != side.one_way_initial_blocked_mask;
+    side.one_way_initial_blocked_mask = one_way_initial_blocked_mask;
     bool reselect = !side.selection_initialized || any_fill
         || coin_hsl_eligibility_changed
+        || one_way_eligibility_changed
         || effective_n_positions != side.previous_effective_n_positions;
     if (!reselect) return;
 
@@ -1853,6 +1860,7 @@ inline void update_tm_multicoin_side_selection(
             && k <= int(coin_settings[coin_offset + 7])
             && finite_positive(bars[bar_offset + 2])
             && coin_wel != 0.0f
+            && (one_way_initial_blocked_mask & (1ul << ulong(c))) == 0ul
             && (!config.coin_hsl_mode || (
                 coin_hsl_entry_blocked_mask & (1ul << ulong(c))
             ) == 0ul);
@@ -2109,10 +2117,9 @@ inline int select_tm_multicoin_unstuck_coin(
     return selected_coin;
 }
 
-// Match exact Rust's per-symbol one-way initial-entry arbitration after both
-// directional generators have observed the same pre-fill account snapshot.
-// Reentries and closes on an existing position remain untouched.
-inline void apply_tm_multicoin_one_way_initial_arbitration(
+// Match exact Rust's per-symbol one-way eligibility before Forager selection
+// and side-wide entry-cap allocation. Reentries and closes remain unblocked.
+inline void compute_tm_multicoin_one_way_initial_blocks(
     thread TrailingMartingaleMulticoinSideState& long_side,
     thread const TrailingMartingaleMulticoinSideConfig& long_config,
     constant float* long_coin_overrides,
@@ -2120,24 +2127,37 @@ inline void apply_tm_multicoin_one_way_initial_arbitration(
     thread const TrailingMartingaleMulticoinSideConfig& short_config,
     constant float* short_coin_overrides,
     constant float* bars,
+    constant float* coin_settings,
     int k,
     int coin_count,
     int long_hsl_mode,
-    int short_hsl_mode
+    int short_hsl_mode,
+    bool long_can_generate,
+    bool short_can_generate,
+    thread ulong& long_blocked_mask,
+    thread ulong& short_blocked_mask
 ) {
+    long_blocked_mask = 0ul;
+    short_blocked_mask = 0ul;
     for (int c = 0; c < coin_count; ++c) {
+        const ulong bit = 1ul << ulong(c);
         const bool has_long = long_side.psize[c] > 0.0f;
         const bool has_short = short_side.psize[c] > 0.0f;
         if (has_long && !has_short) {
-            short_side.entry_qty[c] = 0.0f;
+            short_blocked_mask |= bit;
             continue;
         }
         if (has_short && !has_long) {
-            long_side.entry_qty[c] = 0.0f;
+            long_blocked_mask |= bit;
             continue;
         }
-        if (has_long || has_short) continue;
+        if (has_long && has_short) {
+            long_blocked_mask |= bit;
+            short_blocked_mask |= bit;
+            continue;
+        }
 
+        const int coin_offset = c * COIN_COLS;
         const float close = bars[(k * coin_count + c) * 4 + 2];
         const float long_wel = coin_override_or(
             long_coin_overrides, c, 24, -1.0f
@@ -2149,22 +2169,26 @@ inline void apply_tm_multicoin_one_way_initial_arbitration(
             ? hsl_mode(long_side.coin_hsl[c], false) : long_hsl_mode;
         const int short_coin_mode = short_config.coin_hsl_mode
             ? hsl_mode(short_side.coin_hsl[c], false) : short_hsl_mode;
-        const bool coin_tradable = finite_positive(close);
-        const bool long_eligible = coin_tradable && long_wel != 0.0f
+        const bool coin_tradable = k >= int(coin_settings[coin_offset + 8])
+            && k <= int(coin_settings[coin_offset + 7])
+            && finite_positive(close);
+        const bool long_eligible = long_can_generate && coin_tradable
+            && long_wel != 0.0f
             && long_coin_mode == 0;
-        const bool short_eligible = coin_tradable && short_wel != 0.0f
+        const bool short_eligible = short_can_generate && coin_tradable
+            && short_wel != 0.0f
             && short_coin_mode == 0;
         if (long_eligible && !short_eligible) {
-            short_side.entry_qty[c] = 0.0f;
+            short_blocked_mask |= bit;
             continue;
         }
         if (short_eligible && !long_eligible) {
-            long_side.entry_qty[c] = 0.0f;
+            long_blocked_mask |= bit;
             continue;
         }
         if (!long_eligible && !short_eligible) {
-            long_side.entry_qty[c] = 0.0f;
-            short_side.entry_qty[c] = 0.0f;
+            long_blocked_mask |= bit;
+            short_blocked_mask |= bit;
             continue;
         }
         const float long_lower = fmin(
@@ -2184,9 +2208,9 @@ inline void apply_tm_multicoin_one_way_initial_arbitration(
         const float dist_short = 1.0f
             - short_upper * (1.0f + short_dist) / close;
         if (dist_long >= dist_short) {
-            short_side.entry_qty[c] = 0.0f;
+            short_blocked_mask |= bit;
         } else {
-            long_side.entry_qty[c] = 0.0f;
+            long_blocked_mask |= bit;
         }
     }
 }
@@ -2210,7 +2234,8 @@ inline void generate_tm_multicoin_side_orders(
     int current_hsl_mode,
     bool loss_gate_enabled,
     float max_realized_loss_pct,
-    int forced_unstuck_coin
+    int forced_unstuck_coin,
+    ulong one_way_initial_blocked_mask
 ) {
     const int C = coin_count;
     const float ddf = config.ddf;
@@ -2790,7 +2815,10 @@ inline void generate_tm_multicoin_side_orders(
         bool cooldown = coin_cooldown_min > 0.0f
             && last_increase_k[c] > -1.0e19f
             && float(k) < last_increase_k[c] + coin_cooldown_min;
-        if (!selected[c] || cooldown || balance <= 0.0f
+        bool initial_entry_allowed = !flat
+            || (one_way_initial_blocked_mask & (1ul << ulong(c))) == 0ul;
+        if (!selected[c] || !initial_entry_allowed
+            || cooldown || balance <= 0.0f
             || coin_initial_qty_pct <= 0.0f || candidate_entry_tick <= 1) {
             quantity = 0.0f;
         }
@@ -3457,6 +3485,18 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
                 short_side.hsl,
                 tm_multicoin_side_has_position(short_side, C)
             );
+        ulong long_one_way_blocked_mask = 0ul;
+        ulong short_one_way_blocked_mask = 0ul;
+        if (!hedge_mode) {
+            compute_tm_multicoin_one_way_initial_blocks(
+                long_side, long_config, long_coin_overrides,
+                short_side, short_config, short_coin_overrides,
+                bars, coin_settings, k, C,
+                long_hsl_mode, short_hsl_mode,
+                long_can_generate, short_can_generate,
+                long_one_way_blocked_mask, short_one_way_blocked_mask
+            );
+        }
         float long_unstuck_diff = INFINITY;
         float short_unstuck_diff = INFINITY;
         const int long_unstuck_candidate = long_can_generate
@@ -3492,7 +3532,8 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
             update_tm_multicoin_side_selection(
                 long_side, long_config, bars, coin_settings,
                 long_coin_overrides, k, C, false, any_fill,
-                long_effective_n_positions, score_hysteresis
+                long_effective_n_positions, score_hysteresis,
+                long_one_way_blocked_mask
             );
             generate_tm_multicoin_side_orders(
                 long_side, long_config, account,
@@ -3502,14 +3543,15 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
                 k, C, false, long_tradable_count,
                 long_effective_n_positions, long_hsl_mode,
                 loss_gate_enabled, max_realized_loss_pct,
-                long_unstuck_coin
+                long_unstuck_coin, long_one_way_blocked_mask
             );
         }
         if (short_can_generate) {
             update_tm_multicoin_side_selection(
                 short_side, short_config, bars, coin_settings,
                 short_coin_overrides, k, C, true, any_fill,
-                short_effective_n_positions, score_hysteresis
+                short_effective_n_positions, score_hysteresis,
+                short_one_way_blocked_mask
             );
             generate_tm_multicoin_side_orders(
                 short_side, short_config, account,
@@ -3519,14 +3561,7 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
                 k, C, true, short_tradable_count,
                 short_effective_n_positions, short_hsl_mode,
                 loss_gate_enabled, max_realized_loss_pct,
-                short_unstuck_coin
-            );
-        }
-        if (!hedge_mode) {
-            apply_tm_multicoin_one_way_initial_arbitration(
-                long_side, long_config, long_coin_overrides,
-                short_side, short_config, short_coin_overrides,
-                bars, k, C, long_hsl_mode, short_hsl_mode
+                short_unstuck_coin, short_one_way_blocked_mask
             );
         }
 
@@ -4103,7 +4138,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             update_tm_multicoin_side_selection(
                 side, config, bars, coin_settings, coin_overrides,
                 k, C, short_side, any_fill, effective_n_positions,
-                score_hysteresis
+                score_hysteresis, 0ul
             );
 
             generate_tm_multicoin_side_orders(
@@ -4113,7 +4148,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 coin_settings, coin_overrides,
                 k, C, short_side, tradable_count,
                 effective_n_positions, current_hsl_mode,
-                loss_gate_enabled, max_realized_loss_pct, -2
+                loss_gate_enabled, max_realized_loss_pct, -2, 0ul
             );
         }
 

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -2109,6 +2109,88 @@ inline int select_tm_multicoin_unstuck_coin(
     return selected_coin;
 }
 
+// Match exact Rust's per-symbol one-way initial-entry arbitration after both
+// directional generators have observed the same pre-fill account snapshot.
+// Reentries and closes on an existing position remain untouched.
+inline void apply_tm_multicoin_one_way_initial_arbitration(
+    thread TrailingMartingaleMulticoinSideState& long_side,
+    thread const TrailingMartingaleMulticoinSideConfig& long_config,
+    constant float* long_coin_overrides,
+    thread TrailingMartingaleMulticoinSideState& short_side,
+    thread const TrailingMartingaleMulticoinSideConfig& short_config,
+    constant float* short_coin_overrides,
+    constant float* bars,
+    int k,
+    int coin_count,
+    int long_hsl_mode,
+    int short_hsl_mode
+) {
+    for (int c = 0; c < coin_count; ++c) {
+        const bool has_long = long_side.psize[c] > 0.0f;
+        const bool has_short = short_side.psize[c] > 0.0f;
+        if (has_long && !has_short) {
+            short_side.entry_qty[c] = 0.0f;
+            continue;
+        }
+        if (has_short && !has_long) {
+            long_side.entry_qty[c] = 0.0f;
+            continue;
+        }
+        if (has_long || has_short) continue;
+
+        const float close = bars[(k * coin_count + c) * 4 + 2];
+        const float long_wel = coin_override_or(
+            long_coin_overrides, c, 24, -1.0f
+        );
+        const float short_wel = coin_override_or(
+            short_coin_overrides, c, 24, -1.0f
+        );
+        const int long_coin_mode = long_config.coin_hsl_mode
+            ? hsl_mode(long_side.coin_hsl[c], false) : long_hsl_mode;
+        const int short_coin_mode = short_config.coin_hsl_mode
+            ? hsl_mode(short_side.coin_hsl[c], false) : short_hsl_mode;
+        const bool coin_tradable = finite_positive(close);
+        const bool long_eligible = coin_tradable && long_wel != 0.0f
+            && long_coin_mode == 0;
+        const bool short_eligible = coin_tradable && short_wel != 0.0f
+            && short_coin_mode == 0;
+        if (long_eligible && !short_eligible) {
+            short_side.entry_qty[c] = 0.0f;
+            continue;
+        }
+        if (short_eligible && !long_eligible) {
+            long_side.entry_qty[c] = 0.0f;
+            continue;
+        }
+        if (!long_eligible && !short_eligible) {
+            long_side.entry_qty[c] = 0.0f;
+            short_side.entry_qty[c] = 0.0f;
+            continue;
+        }
+        const float long_lower = fmin(
+            long_side.ema0[c], fmin(long_side.ema1[c], long_side.ema2[c])
+        );
+        const float short_upper = fmax(
+            short_side.ema0[c], fmax(short_side.ema1[c], short_side.ema2[c])
+        );
+        const float long_dist = coin_override_or(
+            long_coin_overrides, c, 5, long_config.initial_ema_dist
+        );
+        const float short_dist = coin_override_or(
+            short_coin_overrides, c, 5, short_config.initial_ema_dist
+        );
+        const float dist_long = long_lower * (1.0f - long_dist)
+            / close - 1.0f;
+        const float dist_short = 1.0f
+            - short_upper * (1.0f + short_dist) / close;
+        if (dist_long >= dist_short) {
+            short_side.entry_qty[c] = 0.0f;
+        } else {
+            long_side.entry_qty[c] = 0.0f;
+        }
+    }
+}
+
 inline void generate_tm_multicoin_side_orders(
     thread TrailingMartingaleMulticoinSideState& side,
     thread const TrailingMartingaleMulticoinSideConfig& config,
@@ -3196,6 +3278,7 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
     const float market_order_slippage_pct = fmax(run_settings[7], 0.0f);
     const bool long_hsl_panic_market = run_settings[8] > 0.5f;
     const bool short_hsl_panic_market = run_settings[9] > 0.5f;
+    const bool hedge_mode = run_settings[10] > 0.5f;
     const float log_bin_scale = 127.0f / log(4000001.0f);
 
     JointPortfolioAccount account = init_joint_portfolio_account(
@@ -3437,6 +3520,13 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
                 short_effective_n_positions, short_hsl_mode,
                 loss_gate_enabled, max_realized_loss_pct,
                 short_unstuck_coin
+            );
+        }
+        if (!hedge_mode) {
+            apply_tm_multicoin_one_way_initial_arbitration(
+                long_side, long_config, long_coin_overrides,
+                short_side, short_config, short_coin_overrides,
+                bars, k, C, long_hsl_mode, short_hsl_mode
             );
         }
 

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -2118,7 +2118,9 @@ inline int select_tm_multicoin_unstuck_coin(
 }
 
 // Match exact Rust's per-symbol one-way eligibility before Forager selection
-// and side-wide entry-cap allocation. Reentries and closes remain unblocked.
+// and side-wide entry-cap allocation. Opposite-held coins are excluded from
+// selection; flat/flat arbitration losers retain their selected slot but emit
+// no order. Reentries and closes remain unblocked.
 inline void compute_tm_multicoin_one_way_initial_blocks(
     thread TrailingMartingaleMulticoinSideState& long_side,
     thread const TrailingMartingaleMulticoinSideConfig& long_config,
@@ -2134,26 +2136,34 @@ inline void compute_tm_multicoin_one_way_initial_blocks(
     int short_hsl_mode,
     bool long_can_generate,
     bool short_can_generate,
-    thread ulong& long_blocked_mask,
-    thread ulong& short_blocked_mask
+    thread ulong& long_selection_blocked_mask,
+    thread ulong& short_selection_blocked_mask,
+    thread ulong& long_order_blocked_mask,
+    thread ulong& short_order_blocked_mask
 ) {
-    long_blocked_mask = 0ul;
-    short_blocked_mask = 0ul;
+    long_selection_blocked_mask = 0ul;
+    short_selection_blocked_mask = 0ul;
+    long_order_blocked_mask = 0ul;
+    short_order_blocked_mask = 0ul;
     for (int c = 0; c < coin_count; ++c) {
         const ulong bit = 1ul << ulong(c);
         const bool has_long = long_side.psize[c] > 0.0f;
         const bool has_short = short_side.psize[c] > 0.0f;
         if (has_long && !has_short) {
-            short_blocked_mask |= bit;
+            short_selection_blocked_mask |= bit;
+            short_order_blocked_mask |= bit;
             continue;
         }
         if (has_short && !has_long) {
-            long_blocked_mask |= bit;
+            long_selection_blocked_mask |= bit;
+            long_order_blocked_mask |= bit;
             continue;
         }
         if (has_long && has_short) {
-            long_blocked_mask |= bit;
-            short_blocked_mask |= bit;
+            long_selection_blocked_mask |= bit;
+            short_selection_blocked_mask |= bit;
+            long_order_blocked_mask |= bit;
+            short_order_blocked_mask |= bit;
             continue;
         }
 
@@ -2179,16 +2189,16 @@ inline void compute_tm_multicoin_one_way_initial_blocks(
             && short_wel != 0.0f
             && short_coin_mode == 0;
         if (long_eligible && !short_eligible) {
-            short_blocked_mask |= bit;
+            short_order_blocked_mask |= bit;
             continue;
         }
         if (short_eligible && !long_eligible) {
-            long_blocked_mask |= bit;
+            long_order_blocked_mask |= bit;
             continue;
         }
         if (!long_eligible && !short_eligible) {
-            long_blocked_mask |= bit;
-            short_blocked_mask |= bit;
+            long_order_blocked_mask |= bit;
+            short_order_blocked_mask |= bit;
             continue;
         }
         const float long_lower = fmin(
@@ -2208,9 +2218,9 @@ inline void compute_tm_multicoin_one_way_initial_blocks(
         const float dist_short = 1.0f
             - short_upper * (1.0f + short_dist) / close;
         if (dist_long >= dist_short) {
-            short_blocked_mask |= bit;
+            short_order_blocked_mask |= bit;
         } else {
-            long_blocked_mask |= bit;
+            long_order_blocked_mask |= bit;
         }
     }
 }
@@ -3485,8 +3495,10 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
                 short_side.hsl,
                 tm_multicoin_side_has_position(short_side, C)
             );
-        ulong long_one_way_blocked_mask = 0ul;
-        ulong short_one_way_blocked_mask = 0ul;
+        ulong long_one_way_selection_blocked_mask = 0ul;
+        ulong short_one_way_selection_blocked_mask = 0ul;
+        ulong long_one_way_order_blocked_mask = 0ul;
+        ulong short_one_way_order_blocked_mask = 0ul;
         if (!hedge_mode) {
             compute_tm_multicoin_one_way_initial_blocks(
                 long_side, long_config, long_coin_overrides,
@@ -3494,7 +3506,10 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
                 bars, coin_settings, k, C,
                 long_hsl_mode, short_hsl_mode,
                 long_can_generate, short_can_generate,
-                long_one_way_blocked_mask, short_one_way_blocked_mask
+                long_one_way_selection_blocked_mask,
+                short_one_way_selection_blocked_mask,
+                long_one_way_order_blocked_mask,
+                short_one_way_order_blocked_mask
             );
         }
         float long_unstuck_diff = INFINITY;
@@ -3533,7 +3548,7 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
                 long_side, long_config, bars, coin_settings,
                 long_coin_overrides, k, C, false, any_fill,
                 long_effective_n_positions, score_hysteresis,
-                long_one_way_blocked_mask
+                long_one_way_selection_blocked_mask
             );
             generate_tm_multicoin_side_orders(
                 long_side, long_config, account,
@@ -3543,7 +3558,7 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
                 k, C, false, long_tradable_count,
                 long_effective_n_positions, long_hsl_mode,
                 loss_gate_enabled, max_realized_loss_pct,
-                long_unstuck_coin, long_one_way_blocked_mask
+                long_unstuck_coin, long_one_way_order_blocked_mask
             );
         }
         if (short_can_generate) {
@@ -3551,7 +3566,7 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
                 short_side, short_config, bars, coin_settings,
                 short_coin_overrides, k, C, true, any_fill,
                 short_effective_n_positions, score_hysteresis,
-                short_one_way_blocked_mask
+                short_one_way_selection_blocked_mask
             );
             generate_tm_multicoin_side_orders(
                 short_side, short_config, account,
@@ -3561,7 +3576,7 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
                 k, C, true, short_tradable_count,
                 short_effective_n_positions, short_hsl_mode,
                 loss_gate_enabled, max_realized_loss_pct,
-                short_unstuck_coin, short_one_way_blocked_mask
+                short_unstuck_coin, short_one_way_order_blocked_mask
             );
         }
 

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -943,13 +943,6 @@ def _validate_scope_config(
             raise ValueError(
                 "GPU multicoin foundation requires one or two enabled sides"
             )
-        if len(enabled_sides) == 2 and not bool(
-            config.get("live", {}).get("hedge_mode")
-        ):
-            raise ValueError(
-                "GPU dual-side multicoin optimization currently requires "
-                "live.hedge_mode=true; one-way arbitration is not modeled"
-            )
         if len(enabled_sides) == 2:
             approved = config.get("live", {}).get("approved_coins", {}) or {}
             ignored = config.get("live", {}).get("ignored_coins", {}) or {}

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -1993,6 +1993,9 @@ def _gpu_suite_checkpoint_contract(
     contract["max_realized_loss_pct"] = float(
         config.get("live", {}).get("max_realized_loss_pct", 1.0)
     )
+    contract["hedge_mode"] = bool(
+        config.get("live", {}).get("hedge_mode", True)
+    )
     contract["pnls_max_lookback_days"] = (
         _gpu_pnls_max_lookback_days_checkpoint_value(config)
     )
@@ -2040,6 +2043,9 @@ def _gpu_suite_checkpoint_contract(
                         for side in ("long", "short")
                         if gpu_side_enabled(item["config"], side)
                     ],
+                    "hedge_mode": bool(
+                        item["config"].get("live", {}).get("hedge_mode", True)
+                    ),
                     "max_realized_loss_pct": float(
                         item["config"]
                         .get("live", {})
@@ -2077,6 +2083,9 @@ def _gpu_runtime_checkpoint_contract(
     config: dict, proxy, *, pinned_hsl_bounds=None
 ) -> dict:
     return {
+        "hedge_mode": bool(
+            config.get("live", {}).get("hedge_mode", True)
+        ),
         "max_realized_loss_pct": float(
             config.get("live", {}).get("max_realized_loss_pct", 1.0)
         ),

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -1171,6 +1171,7 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
         hsl_ema_tail_enabled: bool = False,
         hsl_raw_drawdown_enabled: bool = False,
         recovery_distribution_enabled: bool = False,
+        hedge_mode: bool = True,
     ):
         super().__init__(
             run,
@@ -1222,6 +1223,7 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
                 market_order_slippage_pct,
                 float(bool(hsl_panic_market_long)),
                 float(bool(hsl_panic_market_short)),
+                float(bool(hedge_mode)),
             ],
             dtype=torch.float32,
             device="mps",
@@ -1412,6 +1414,7 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
         hsl_ema_tail_enabled: bool = False,
         hsl_raw_drawdown_enabled: bool = False,
         recovery_distribution_enabled: bool = False,
+        hedge_mode: bool = True,
     ):
         super().__init__(
             run,
@@ -1461,6 +1464,7 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
                 float(market_order_slippage_pct),
                 float(bool(hsl_panic_market_long)),
                 float(bool(hsl_panic_market_short)),
+                float(bool(hedge_mode)),
             ],
             dtype=torch.float32,
             device="mps",

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -1682,13 +1682,6 @@ class MpsMulticoinProxy:
             self.needed_metrics,
             shared_account_controller=self.shared_account_fused,
         )
-        if len(enabled_sides) == 2 and not bool(
-            config.get("live", {}).get("hedge_mode")
-        ):
-            raise ValueError(
-                "MPS dual-side multicoin proxy currently requires live.hedge_mode=true; "
-                "one-way arbitration is not modeled"
-            )
         if len(enabled_sides) == 2:
             approved = config.get("live", {}).get("approved_coins", {}) or {}
             ignored = config.get("live", {}).get("ignored_coins", {}) or {}
@@ -2055,6 +2048,7 @@ class MpsMulticoinProxy:
                     )
                 ).strip().lower()
                 == "market",
+                hedge_mode=bool(backtest_params["hedge_mode"]),
                 **common_runner_kwargs,
             )
         else:

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -4297,6 +4297,27 @@ def test_gpu_checkpoint_signature_tracks_realized_loss_gate_contract():
     )
 
 
+def test_gpu_checkpoint_signature_tracks_hedge_mode_contract():
+    active = [("long_offset", 0, Bound(0.01, 0.1, 0.01))]
+    scoring = [{"goal": "max", "metric": "adg_strategy_eq"}]
+    config = _directional_ema_config(long_enabled=True, short_enabled=True)
+    proxy = SimpleNamespace(coin_override_contract={"values": []})
+    original_contract = _gpu_runtime_checkpoint_contract(config, proxy)
+    original = _checkpoint_signature(
+        active, scoring, runtime_contract=original_contract
+    )
+
+    changed = copy.deepcopy(config)
+    changed["live"]["hedge_mode"] = not original_contract["hedge_mode"]
+    changed_contract = _gpu_runtime_checkpoint_contract(changed, proxy)
+
+    assert changed_contract["hedge_mode"] is not original_contract["hedge_mode"]
+    assert (
+        _checkpoint_signature(active, scoring, runtime_contract=changed_contract)
+        != original
+    )
+
+
 def test_gpu_checkpoint_signature_tracks_single_coin_unstuck_contract():
     active = [("long_offset", 0, Bound(0.01, 0.1, 0.01))]
     scoring = [{"goal": "max", "metric": "adg_strategy_eq"}]
@@ -4570,6 +4591,7 @@ def test_gpu_suite_checkpoint_contract_tracks_prepared_scenario_identity():
             "coin_count": 2,
             "strategy_kind": "ema_anchor",
             "enabled_sides": ["long"],
+            "hedge_mode": False,
             "max_realized_loss_pct": 1.0,
             "pnls_max_lookback_days": 30.0,
             "unstuck": original["unstuck"],
@@ -4600,6 +4622,18 @@ def test_gpu_suite_checkpoint_contract_tracks_prepared_scenario_identity():
 
     assert changed != original
     assert changed["prepared_scenarios"][0]["max_realized_loss_pct"] == 0.05
+
+    changed_hedge_mode = copy.deepcopy(item)
+    changed_hedge_mode["config"]["live"]["hedge_mode"] = True
+    changed = _gpu_suite_checkpoint_contract(config, [changed_hedge_mode])
+    assert changed != original
+    assert changed["prepared_scenarios"][0]["hedge_mode"] is True
+
+    changed_base_hedge_mode = copy.deepcopy(config)
+    changed_base_hedge_mode["live"]["hedge_mode"] = True
+    changed = _gpu_suite_checkpoint_contract(changed_base_hedge_mode, [item])
+    assert changed != original
+    assert changed["hedge_mode"] is True
 
     changed_lookback = copy.deepcopy(item)
     changed_lookback["config"]["live"]["pnls_max_lookback_days"] = 7.0

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -886,7 +886,7 @@ def test_gpu_suite_inputs_reject_invalid_scenario_coin_hsl_values():
         _gpu_suite_scenario_inputs(config, Suite())
 
 
-def test_gpu_suite_inputs_revalidate_scenario_hedge_mode():
+def test_gpu_suite_inputs_accept_scenario_one_way_mode():
     config = _directional_ema_config(long_enabled=True, short_enabled=True)
     config["backtest"]["suite_enabled"] = True
     config["backtest"]["dynamic_wel_by_tradability"] = True
@@ -916,8 +916,9 @@ def test_gpu_suite_inputs_revalidate_scenario_hedge_mode():
             scenario["live"]["hedge_mode"] = False
             return scenario
 
-    with pytest.raises(ValueError, match="requires live.hedge_mode=true"):
-        _gpu_suite_scenario_inputs(config, Suite())
+    prepared = _gpu_suite_scenario_inputs(config, Suite())
+
+    assert prepared[0]["config"]["live"]["hedge_mode"] is False
 
 
 def _suite_search_input(label, config, coin_count):
@@ -2405,7 +2406,7 @@ def test_gpu_multicoin_foundation_accepts_forager_score_hysteresis():
 
 
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
-def test_gpu_multicoin_foundation_rejects_dual_side_one_way_mode(strategy_kind):
+def test_gpu_multicoin_foundation_accepts_dual_side_one_way_mode(strategy_kind):
     builder = (
         _directional_tm_config
         if strategy_kind == "trailing_martingale"
@@ -2420,8 +2421,7 @@ def test_gpu_multicoin_foundation_rejects_dual_side_one_way_mode(strategy_kind):
     config["live"]["forager_score_hysteresis_pct"] = 0.0
     config["backtest"]["dynamic_wel_by_tradability"] = True
 
-    with pytest.raises(ValueError, match="one-way arbitration is not modeled"):
-        _validate_scope(config, _MulticoinEvaluator())
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
 def test_gpu_multicoin_foundation_accepts_dual_side_coin_overrides():

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -4645,7 +4645,7 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
         (coin_count, 29), float("nan"), dtype=torch.float32, device="mps"
     )
     run_settings = torch.tensor(
-        [1_000.0, 50.0, 60_000.0, 0.0, 0.02, 1.0, 1.0, 0.0, 0.0, 0.0],
+        [1_000.0, 50.0, 60_000.0, 0.0, 0.02, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0],
         dtype=torch.float32,
         device="mps",
     )
@@ -4988,6 +4988,110 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+@pytest.mark.parametrize(
+    ("runner_cls", "param_keys"),
+    [
+        (MpsEmaAnchorMulticoinFusedRunner, EMA_ANCHOR_MULTICOIN_PARAM_KEYS),
+        (
+            MpsTrailingMartingaleMulticoinFusedRunner,
+            TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS,
+        ),
+    ],
+)
+def test_mps_fused_multicoin_one_way_arbitrates_each_flat_symbol(
+    runner_cls, param_keys
+):
+    count = 16
+    coin_count = 2
+    hlcvs = np.empty((count, coin_count, 4), dtype=np.float64)
+    hlcvs[:, :, 0] = 102.0
+    hlcvs[:, :, 1] = 98.0
+    hlcvs[:, :, 2] = 100.0
+    hlcvs[:, :, 3] = 100.0
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    markets = [
+        ProxyMarket(0.001, 0.01, 0.001, 5.0, 1.0, 0.0002)
+        for _ in range(coin_count)
+    ]
+    runs = [
+        ProxyRun(
+            1_000.0,
+            1,
+            1,
+            int(timestamps[0]),
+            int(timestamps[0]),
+            int(timestamps[0]),
+            60_000,
+            0.05,
+            0,
+            count - 1,
+        )
+        for _ in range(coin_count)
+    ]
+    data = build_mps_multicoin_data(hlcvs, timestamps, runs, markets)
+    values = {key: 0.0 for key in param_keys}
+    values.update(
+        {
+            "n_positions": 2.0,
+            "total_wallet_exposure_limit": 1.0,
+            "forager_score_weights_ema_readiness": 1.0,
+        }
+    )
+    if runner_cls is MpsEmaAnchorMulticoinFusedRunner:
+        values.update(
+            {
+                "base_qty_pct": 0.1,
+                "ema_span_0": 2.0,
+                "ema_span_1": 3.0,
+                "offset": 0.01,
+            }
+        )
+    else:
+        values.update(
+            {
+                "ema_span_0": 2.0,
+                "ema_span_1": 3.0,
+                "entry_initial_ema_dist": 0.01,
+                "entry_initial_qty_pct": 0.1,
+                "gate_initial": 1.0,
+                "gate_reentry": 1.0,
+            }
+        )
+    side_row = [values[key] for key in param_keys]
+    params = np.asarray([side_row + side_row], dtype=np.float64)
+
+    hedge_output = runner_cls(runs[0], data, hedge_mode=True).run(params)
+    one_way_output = runner_cls(runs[0], data, hedge_mode=False).run(params)
+    override_cols = 29 if runner_cls is MpsEmaAnchorMulticoinFusedRunner else 44
+    wel_col = 11 if runner_cls is MpsEmaAnchorMulticoinFusedRunner else 24
+    long_overrides = np.full((coin_count, override_cols), np.nan, dtype=np.float32)
+    short_overrides = np.full((coin_count, override_cols), np.nan, dtype=np.float32)
+    long_overrides[0, wel_col] = 0.0
+    short_overrides[1, wel_col] = 0.0
+    mixed_output = runner_cls(
+        runs[0],
+        data,
+        long_coin_overrides=long_overrides,
+        short_coin_overrides=short_overrides,
+        hedge_mode=False,
+    ).run(params)
+    torch.mps.synchronize()
+
+    assert hedge_output["fill_count"].item() > hedge_output[
+        "fill_count_long"
+    ].item()
+    assert one_way_output["fill_count"].item() > 0.0
+    assert one_way_output["fill_count"].item() == one_way_output[
+        "fill_count_long"
+    ].item()
+    assert 0.0 < mixed_output["fill_count_long"].item() < mixed_output[
+        "fill_count"
+    ].item()
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
     import passivbot_rust
 
@@ -5113,7 +5217,7 @@ def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
         (coin_count, 44), float("nan"), dtype=torch.float32, device="mps"
     )
     run_settings = torch.tensor(
-        [1_000.0, 50.0, 60_000.0, 0.0, 0.02, 1.0, 1.0, 0.0, 0.0, 0.0],
+        [1_000.0, 50.0, 60_000.0, 0.0, 0.02, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0],
         dtype=torch.float32,
         device="mps",
     )

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -1436,6 +1436,8 @@ kernel void passivbot_tm_multicoin_selection_phase_probe(
     short_side.previous_effective_n_positions = 0;
     long_side.coin_hsl_entry_blocked_mask = 0ul;
     short_side.coin_hsl_entry_blocked_mask = 0ul;
+    long_side.one_way_initial_blocked_mask = 0ul;
+    short_side.one_way_initial_blocked_mask = 0ul;
     for (int c = 0; c < 3; ++c) {
         long_side.psize[c] = 0.0f;
         short_side.psize[c] = 0.0f;
@@ -1467,11 +1469,11 @@ kernel void passivbot_tm_multicoin_selection_phase_probe(
     long_side.coin_hsl[0].orange_graceful_stop = true;
     update_tm_multicoin_side_selection(
         long_side, long_config, bars, coin_settings, coin_overrides,
-        1, 3, false, true, 1, 0.0f
+        1, 3, false, true, 1, 0.0f, 0ul
     );
     update_tm_multicoin_side_selection(
         short_side, short_config, bars, coin_settings, coin_overrides,
-        1, 3, true, true, 1, 0.0f
+        1, 3, true, true, 1, 0.0f, 0ul
     );
     for (int c = 0; c < 3; ++c) {
         output[c] = long_side.selected[c] ? 1.0f : 0.0f;
@@ -1483,6 +1485,16 @@ kernel void passivbot_tm_multicoin_selection_phase_probe(
     output[9] = float(short_side.previous_effective_n_positions);
     output[10] = float(long_side.coin_hsl_entry_blocked_mask);
     output[11] = float(short_side.coin_hsl_entry_blocked_mask);
+    // Mimic a new opposite-held block on short's highest-ranked coin.
+    // The changed mask must force reselection onto the next candidate.
+    update_tm_multicoin_side_selection(
+        short_side, short_config, bars, coin_settings, coin_overrides,
+        1, 3, true, false, 1, 0.0f, 4ul
+    );
+    for (int c = 0; c < 3; ++c) {
+        output[12 + c] = short_side.selected[c] ? 1.0f : 0.0f;
+    }
+    output[15] = float(short_side.one_way_initial_blocked_mask);
 }
 """
 
@@ -1499,7 +1511,7 @@ kernel void passivbot_tm_multicoin_selection_phase_probe(
     coin_overrides = torch.full(
         (3, 44), float("nan"), dtype=torch.float32, device="mps"
     )
-    output = torch.zeros(12, dtype=torch.float32, device="mps")
+    output = torch.zeros(16, dtype=torch.float32, device="mps")
 
     library = torch.mps.compile_shader(
         passivbot_rust.mps_trailing_martingale_multicoin_source_py()
@@ -1523,6 +1535,10 @@ kernel void passivbot_tm_multicoin_selection_phase_probe(
         1.0,
         1.0,
         0.0,
+        0.0,
+        1.0,
+        0.0,
+        4.0,
     ]
 
 
@@ -1566,14 +1582,14 @@ kernel void passivbot_tm_multicoin_order_phase_probe(
         bars, touch_ticks, touch_nearest_ticks,
         touch_min_qty_bits, touch_min_qty_relation,
         coin_settings, coin_overrides,
-        1, 1, false, 1, 1, 0, false, 1.0f, -2
+        1, 1, false, 1, 1, 0, false, 1.0f, -2, 0ul
     );
     generate_tm_multicoin_side_orders(
         short_side, short_config, account,
         bars, touch_ticks, touch_nearest_ticks,
         touch_min_qty_bits, touch_min_qty_relation,
         coin_settings, coin_overrides,
-        1, 1, true, 1, 1, 0, false, 1.0f, -2
+        1, 1, true, 1, 1, 0, false, 1.0f, -2, 0ul
     );
     output[0] = long_side.entry_qty[0];
     output[1] = short_side.entry_qty[0];
@@ -1583,6 +1599,16 @@ kernel void passivbot_tm_multicoin_order_phase_probe(
     output[5] = short_side.close_qty[0];
     output[6] = account.balance;
     output[7] = account.realized_pnl_total;
+    generate_tm_multicoin_side_orders(
+        long_side, long_config, account,
+        bars, touch_ticks, touch_nearest_ticks,
+        touch_min_qty_bits, touch_min_qty_relation,
+        coin_settings, coin_overrides,
+        1, 1, false, 1, 1, 0, false, 1.0f, -2, 1ul
+    );
+    output[8] = long_side.entry_qty[0];
+    output[9] = long_side.entry_candidate[0] ? 1.0f : 0.0f;
+    output[10] = long_side.contribution[0];
 }
 """
 
@@ -1626,7 +1652,7 @@ kernel void passivbot_tm_multicoin_order_phase_probe(
     coin_overrides = torch.full(
         (1, 44), float("nan"), dtype=torch.float32, device="mps"
     )
-    output = torch.zeros(8, dtype=torch.float32, device="mps")
+    output = torch.zeros(11, dtype=torch.float32, device="mps")
 
     library = torch.mps.compile_shader(
         passivbot_rust.mps_trailing_martingale_multicoin_source_py()
@@ -1653,6 +1679,7 @@ kernel void passivbot_tm_multicoin_order_phase_probe(
     assert values[5] == 0.0
     assert values[6] == 1_000.0
     assert values[7] == 0.0
+    assert values[8:].tolist() == [0.0, 0.0, 0.0]
 
 
 @pytest.mark.skipif(
@@ -2452,6 +2479,8 @@ kernel void passivbot_ema_multicoin_selection_phase_probe(
     short_side.selection_initialized = false;
     long_side.previous_effective_n_positions = 0;
     short_side.previous_effective_n_positions = 0;
+    long_side.one_way_initial_blocked_mask = 0ul;
+    short_side.one_way_initial_blocked_mask = 0ul;
     for (int c = 0; c < 3; ++c) {
         long_side.psize[c] = 0.0f;
         short_side.psize[c] = 0.0f;
@@ -2474,11 +2503,11 @@ kernel void passivbot_ema_multicoin_selection_phase_probe(
     }
     update_ema_multicoin_side_selection(
         long_side, long_config, bars, coin_settings, coin_overrides,
-        1, 3, false, true, 1, 0.0f
+        1, 3, false, true, 1, 0.0f, 0ul
     );
     update_ema_multicoin_side_selection(
         short_side, short_config, bars, coin_settings, coin_overrides,
-        1, 3, true, true, 1, 0.0f
+        1, 3, true, true, 1, 0.0f, 0ul
     );
     for (int c = 0; c < 3; ++c) {
         output[c] = long_side.selected[c] ? 1.0f : 0.0f;
@@ -2488,6 +2517,16 @@ kernel void passivbot_ema_multicoin_selection_phase_probe(
     output[7] = short_side.selection_initialized ? 1.0f : 0.0f;
     output[8] = float(long_side.previous_effective_n_positions);
     output[9] = float(short_side.previous_effective_n_positions);
+    // Opposite-held eligibility changes outside the side's own fills.
+    // The mask transition must evict the blocked incumbent and promote next.
+    update_ema_multicoin_side_selection(
+        short_side, short_config, bars, coin_settings, coin_overrides,
+        1, 3, true, false, 1, 0.0f, 4ul
+    );
+    for (int c = 0; c < 3; ++c) {
+        output[10 + c] = short_side.selected[c] ? 1.0f : 0.0f;
+    }
+    output[13] = float(short_side.one_way_initial_blocked_mask);
 }
 """
 
@@ -2504,7 +2543,7 @@ kernel void passivbot_ema_multicoin_selection_phase_probe(
     coin_overrides = torch.full(
         (3, 29), float("nan"), dtype=torch.float32, device="mps"
     )
-    output = torch.zeros(10, dtype=torch.float32, device="mps")
+    output = torch.zeros(14, dtype=torch.float32, device="mps")
 
     library = torch.mps.compile_shader(
         passivbot_rust.mps_ema_anchor_multicoin_source_py() + probe_kernel
@@ -2525,6 +2564,10 @@ kernel void passivbot_ema_multicoin_selection_phase_probe(
         1.0,
         1.0,
         1.0,
+        0.0,
+        1.0,
+        0.0,
+        4.0,
     ]
 
 
@@ -2563,12 +2606,12 @@ kernel void passivbot_ema_multicoin_order_phase_probe(
     generate_ema_multicoin_side_orders(
         long_side, long_config, account,
         bars, touch_ticks, coin_settings, coin_overrides,
-        1, 1, false, 1, 1, 0, false, 1.0f, -2
+        1, 1, false, 1, 1, 0, false, 1.0f, -2, 0ul
     );
     generate_ema_multicoin_side_orders(
         short_side, short_config, account,
         bars, touch_ticks, coin_settings, coin_overrides,
-        1, 1, true, 1, 1, 0, false, 1.0f, -2
+        1, 1, true, 1, 1, 0, false, 1.0f, -2, 0ul
     );
     output[0] = long_side.entry_qty[0];
     output[1] = short_side.entry_qty[0];
@@ -2578,6 +2621,14 @@ kernel void passivbot_ema_multicoin_order_phase_probe(
     output[5] = short_side.close_qty[0];
     output[6] = account.balance;
     output[7] = account.realized_pnl_total;
+    generate_ema_multicoin_side_orders(
+        long_side, long_config, account,
+        bars, touch_ticks, coin_settings, coin_overrides,
+        1, 1, false, 1, 1, 0, false, 1.0f, -2, 1ul
+    );
+    output[8] = long_side.entry_qty[0];
+    output[9] = long_side.entry_candidate[0] ? 1.0f : 0.0f;
+    output[10] = long_side.contribution[0];
 }
 """
 
@@ -2609,7 +2660,7 @@ kernel void passivbot_ema_multicoin_order_phase_probe(
     coin_overrides = torch.full(
         (1, 29), float("nan"), dtype=torch.float32, device="mps"
     )
-    output = torch.zeros(8, dtype=torch.float32, device="mps")
+    output = torch.zeros(11, dtype=torch.float32, device="mps")
 
     library = torch.mps.compile_shader(
         passivbot_rust.mps_ema_anchor_multicoin_source_py() + probe_kernel
@@ -2632,6 +2683,7 @@ kernel void passivbot_ema_multicoin_order_phase_probe(
     assert values[5] == 0.0
     assert values[6] == 1_000.0
     assert values[7] == 0.0
+    assert values[8:].tolist() == [0.0, 0.0, 0.0]
 
 
 def _single_coin_exposure_fields(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -1463,6 +1463,17 @@ kernel void passivbot_tm_multicoin_selection_phase_probe(
         long_side.coin_hsl[c].red_active_now = false;
         long_side.coin_hsl[c].orange_graceful_stop = false;
     }
+    ulong long_selection_blocked_mask = 0ul;
+    ulong short_selection_blocked_mask = 0ul;
+    ulong long_order_blocked_mask = 0ul;
+    ulong short_order_blocked_mask = 0ul;
+    compute_tm_multicoin_one_way_initial_blocks(
+        long_side, long_config, coin_overrides,
+        short_side, short_config, coin_overrides,
+        bars, coin_settings, 1, 3, 0, 0, true, true,
+        long_selection_blocked_mask, short_selection_blocked_mask,
+        long_order_blocked_mask, short_order_blocked_mask
+    );
     // Block the long side's highest-volume coin without affecting short.
     long_side.coin_hsl[0].enabled = true;
     long_side.coin_hsl[0].tier = 2;
@@ -1495,6 +1506,10 @@ kernel void passivbot_tm_multicoin_selection_phase_probe(
         output[12 + c] = short_side.selected[c] ? 1.0f : 0.0f;
     }
     output[15] = float(short_side.one_way_initial_blocked_mask);
+    output[16] = float(long_selection_blocked_mask);
+    output[17] = float(short_selection_blocked_mask);
+    output[18] = float(long_order_blocked_mask);
+    output[19] = float(short_order_blocked_mask);
 }
 """
 
@@ -1511,7 +1526,7 @@ kernel void passivbot_tm_multicoin_selection_phase_probe(
     coin_overrides = torch.full(
         (3, 44), float("nan"), dtype=torch.float32, device="mps"
     )
-    output = torch.zeros(16, dtype=torch.float32, device="mps")
+    output = torch.zeros(20, dtype=torch.float32, device="mps")
 
     library = torch.mps.compile_shader(
         passivbot_rust.mps_trailing_martingale_multicoin_source_py()
@@ -1539,6 +1554,10 @@ kernel void passivbot_tm_multicoin_selection_phase_probe(
         1.0,
         0.0,
         4.0,
+        0.0,
+        0.0,
+        0.0,
+        7.0,
     ]
 
 
@@ -2501,6 +2520,17 @@ kernel void passivbot_ema_multicoin_selection_phase_probe(
         long_side.forager_volatility[c] = 0.0f;
         short_side.forager_volatility[c] = 0.0f;
     }
+    ulong long_selection_blocked_mask = 0ul;
+    ulong short_selection_blocked_mask = 0ul;
+    ulong long_order_blocked_mask = 0ul;
+    ulong short_order_blocked_mask = 0ul;
+    compute_ema_multicoin_one_way_initial_blocks(
+        long_side, long_config, coin_overrides,
+        short_side, short_config, coin_overrides,
+        bars, coin_settings, 1, 3, 0, 0, true, true,
+        long_selection_blocked_mask, short_selection_blocked_mask,
+        long_order_blocked_mask, short_order_blocked_mask
+    );
     update_ema_multicoin_side_selection(
         long_side, long_config, bars, coin_settings, coin_overrides,
         1, 3, false, true, 1, 0.0f, 0ul
@@ -2527,6 +2557,10 @@ kernel void passivbot_ema_multicoin_selection_phase_probe(
         output[10 + c] = short_side.selected[c] ? 1.0f : 0.0f;
     }
     output[13] = float(short_side.one_way_initial_blocked_mask);
+    output[14] = float(long_selection_blocked_mask);
+    output[15] = float(short_selection_blocked_mask);
+    output[16] = float(long_order_blocked_mask);
+    output[17] = float(short_order_blocked_mask);
 }
 """
 
@@ -2543,7 +2577,7 @@ kernel void passivbot_ema_multicoin_selection_phase_probe(
     coin_overrides = torch.full(
         (3, 29), float("nan"), dtype=torch.float32, device="mps"
     )
-    output = torch.zeros(14, dtype=torch.float32, device="mps")
+    output = torch.zeros(18, dtype=torch.float32, device="mps")
 
     library = torch.mps.compile_shader(
         passivbot_rust.mps_ema_anchor_multicoin_source_py() + probe_kernel
@@ -2568,6 +2602,10 @@ kernel void passivbot_ema_multicoin_selection_phase_probe(
         1.0,
         0.0,
         4.0,
+        0.0,
+        0.0,
+        0.0,
+        7.0,
     ]
 
 

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -863,7 +863,7 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
                 "short": ["BTC", "ETH"],
             },
             "ignored_coins": {"long": [], "short": []},
-            "hedge_mode": True,
+            "hedge_mode": False,
             "hsl_signal_mode": "coin",
         }
     )
@@ -965,6 +965,7 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
             "liquidation_threshold": 0.05,
             "max_realized_loss_pct": 1.0,
             "market_order_slippage_pct": 0.0,
+            "hedge_mode": config["live"]["hedge_mode"],
         },
     )
     backtest.build_backtest_payload = lambda *args, **kwargs: payload
@@ -1020,6 +1021,7 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
         constructed["kwargs"]["recovery_distribution_enabled"]
         is recovery_distribution_enabled
     )
+    assert constructed["kwargs"]["hedge_mode"] is False
 
 
 def test_gpu_proxy_requires_complete_valid_tail():


### PR DESCRIPTION
## Summary
- enable fused dual-side multicoin Apple MPS optimization in one-way mode for EMA Anchor and Trailing Martingale
- arbitrate flat-symbol initial entries per exact Rust rules while preserving reentries and closes
- honor existing opposite-side positions, per-coin zero exposure overrides, HSL entry blocking, strategy thresholds, and stable long tie-breaking
- keep CPU optimization and exact Rust evaluation unchanged

## Validation
- cargo test --no-default-features --lib: 267 passed
- focused GPU backend, service, and metrics Python suites passed
- full physical Apple M3 MPS suite: 307 passed
- exact-head EMA Anchor one-way multicoin smoke: 8 generations, 2048 proxy evaluations, 64 exact validations, drift threshold 0.6, completed without halt
- exact-head Trailing Martingale one-way multicoin smoke: 8 generations, 512 proxy evaluations, 64 exact validations, drift threshold 0.6, completed in 193.2 seconds without halt
- diff whitespace and Python formatting checks passed

Exact Rust remains authoritative for persisted results, Pareto updates, constraint classification, and drift gates.