### PR TITLE
Harden GPU checkpoint execution identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ All notable user-facing changes will be documented in this file.
 
 - Hardened Apple MPS optimizer checkpoint/resume identity. GPU checkpoints now bind the complete
   fixed and tunable search shape and each prepared single-run or suite-scenario proxy execution
-  contract, including timestamp identity, starting balance, valid/trade windows, liquidation and
-  exposure policy, resolved market settings and fees, and modeled execution settings. Resume now
-  fails closed after any incompatible input change; older GPU checkpoints are intentionally
-  invalidated.
+  contract, including prepared candle-value and timestamp hashes, starting balance, valid/trade
+  windows, resolved fixed proxy parameters, liquidation and exposure policy, resolved market
+  settings and fees, modeled execution settings, and effective NSGA-II population and variation
+  controls. Resume now fails closed after any incompatible input change; older GPU checkpoints are
+  intentionally invalidated.
 
 - Added Apple MPS GPU optimizer support for dual-side multi-coin one-way mode in EMA Anchor and
   Trailing Martingale, with per-symbol initial-entry arbitration matching exact Rust.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Hardened Apple MPS optimizer checkpoint/resume identity. GPU checkpoints now bind the complete
+  fixed and tunable search shape and each prepared single-run or suite-scenario proxy execution
+  contract, including timestamp identity, starting balance, valid/trade windows, liquidation and
+  exposure policy, resolved market settings and fees, and modeled execution settings. Resume now
+  fails closed after any incompatible input change; older GPU checkpoints are intentionally
+  invalidated.
+
 - Added Apple MPS GPU optimizer support for dual-side multi-coin one-way mode in EMA Anchor and
   Trailing Martingale, with per-symbol initial-entry arbitration matching exact Rust.
 

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -513,10 +513,11 @@ duplicate-elimination controls as the ordinary pymoo optimizer.
    as in an uninterrupted run: recovered truthful probes are retained, and their independent gates
    activate only after enough off-front evidence exists. A final checkpoint is always written on
    successful completion. Checkpoint identity includes the complete optimizer shape (including
-   fixed and dormant dimensions, quantization, and runtime optimizer overrides) plus every
-   prepared proxy's effective execution contract: strategy and side topology, ordered coins,
-   candle/timestamp identity, starting balance, valid/trade windows, liquidation and exposure
-   policy, resolved maker/taker fees and market settings, and other modeled execution settings.
+   fixed and dormant dimensions, quantization, runtime optimizer overrides, and effective NSGA-II
+   population/variation policy) plus every prepared proxy's effective execution contract:
+   strategy and side topology, ordered coins, hashes of prepared candle values and timestamps,
+   starting balance, valid/trade windows, fully resolved fixed proxy parameters, liquidation and
+   exposure policy, resolved maker/taker fees and market settings, and other modeled execution settings.
    Suite checkpoints record that contract independently for every scenario. Changing any of these
    inputs makes resume fail closed instead of mixing evolutionary state from incompatible runs.
    Checkpoints written before this expanded identity contract are intentionally incompatible.

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -512,7 +512,14 @@ duplicate-elimination controls as the ordinary pymoo optimizer.
    no longer reach its minimum sample count. Broad probes remain opportunistic across restart, just
    as in an uninterrupted run: recovered truthful probes are retained, and their independent gates
    activate only after enough off-front evidence exists. A final checkpoint is always written on
-   successful completion.
+   successful completion. Checkpoint identity includes the complete optimizer shape (including
+   fixed and dormant dimensions, quantization, and runtime optimizer overrides) plus every
+   prepared proxy's effective execution contract: strategy and side topology, ordered coins,
+   candle/timestamp identity, starting balance, valid/trade windows, liquidation and exposure
+   policy, resolved maker/taker fees and market settings, and other modeled execution settings.
+   Suite checkpoints record that contract independently for every scenario. Changing any of these
+   inputs makes resume fail closed instead of mixing evolutionary state from incompatible runs.
+   Checkpoints written before this expanded identity contract are intentionally incompatible.
 
 The proxy is a float32 ranking model, not an authoritative simulator. Exact Rust metrics and configs
 remain the only stored optimization results. The screening source is owned and exported by the

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -498,12 +498,42 @@ def _minimum_rank_evidence_samples(halt: float) -> int:
     return math.floor((MIN_DRIFT_PROBES - 1) / float(halt)) + 1
 
 
-def _build_gpu_nsga2(config, *, sampling, population_size: int, n_params: int):
+def _build_gpu_nsga2(
+    config,
+    *,
+    sampling,
+    population_size: int,
+    n_params: int,
+    policy: dict | None = None,
+):
     """Build GPU proposal evolution with the same variation controls as pymoo CPU."""
 
     from pymoo.algorithms.moo.nsga2 import NSGA2
     from pymoo.operators.crossover.sbx import SBX
     from pymoo.operators.mutation.pm import PM
+
+    policy = policy or _gpu_nsga2_checkpoint_contract(
+        config, population_size=population_size, n_params=n_params
+    )
+    return NSGA2(
+        pop_size=int(policy["population_size"]),
+        sampling=sampling,
+        crossover=SBX(
+            prob_var=float(policy["crossover"]["prob_var"]),
+            eta=float(policy["crossover"]["eta"]),
+        ),
+        mutation=PM(
+            prob=float(policy["mutation"]["prob"]),
+            eta=float(policy["mutation"]["eta"]),
+        ),
+        eliminate_duplicates=bool(policy["eliminate_duplicates"]),
+    )
+
+
+def _gpu_nsga2_checkpoint_contract(
+    config: dict, *, population_size: int, n_params: int
+) -> dict:
+    """Return the effective proposal policy serialized inside checkpoints."""
 
     from optimization.backends.pymoo_backend import (
         _resolve_mutation_prob,
@@ -511,19 +541,27 @@ def _build_gpu_nsga2(config, *, sampling, population_size: int, n_params: int):
     )
 
     shared = _resolve_pymoo_shared(config)
-    return NSGA2(
-        pop_size=population_size,
-        sampling=sampling,
-        crossover=SBX(
-            prob_var=float(shared["crossover_prob_var"]),
-            eta=float(shared["crossover_eta"]),
+    configured_seed = config.get("optimize", {}).get("seed")
+    return {
+        "version": 1,
+        "algorithm": "nsga2",
+        "population_size": int(population_size),
+        "configured_seed": (
+            None if configured_seed is None else int(configured_seed)
         ),
-        mutation=PM(
-            prob=_resolve_mutation_prob(shared, n_params),
-            eta=float(shared["mutation_eta"]),
-        ),
-        eliminate_duplicates=bool(shared["eliminate_duplicates"]),
-    )
+        "crossover": {
+            "operator": "sbx",
+            "prob_var": float(shared["crossover_prob_var"]),
+            "eta": float(shared["crossover_eta"]),
+        },
+        "mutation": {
+            "operator": "pm",
+            "prob": float(_resolve_mutation_prob(shared, n_params)),
+            "eta": float(shared["mutation_eta"]),
+        },
+        "eliminate_duplicates": bool(shared["eliminate_duplicates"]),
+    }
+
 
 GPU_RESULT_BACKTEST_CONTRACT_KEYS = {
     "balance_sample_divider",
@@ -2381,6 +2419,7 @@ def _gpu_search_checkpoint_contract(
     fixed_parameter_overrides,
     optimizer_overrides,
     sig_digits,
+    algorithm_contract,
 ) -> dict:
     """Fingerprint fixed and dormant search inputs omitted from active genes."""
 
@@ -2411,6 +2450,7 @@ def _gpu_search_checkpoint_contract(
             for key, value in sorted((fixed_parameter_overrides or {}).items())
         },
         "optimizer_overrides": sorted(str(value) for value in optimizer_overrides),
+        "algorithm": deepcopy(algorithm_contract),
     }
 
 
@@ -3418,11 +3458,17 @@ def run_backend(
         xl=np.zeros(len(active)),
         xu=np.ones(len(active)),
     )
+    algorithm_contract = _gpu_nsga2_checkpoint_contract(
+        config,
+        population_size=population_size,
+        n_params=len(active),
+    )
     algorithm = _build_gpu_nsga2(
         config,
         sampling=sampling,
         population_size=population_size,
         n_params=len(active),
+        policy=algorithm_contract,
     )
     algorithm.setup(problem, termination=NoTermination(), seed=seed, verbose=False)
     generation = 0
@@ -3461,6 +3507,7 @@ def run_backend(
             fixed_parameter_overrides=fixed_parameter_overrides,
             optimizer_overrides=gpu_optimizer_overrides,
             sig_digits=sig_digits,
+            algorithm_contract=algorithm_contract,
         ),
     )
     budget = int(config["optimize"]["iters"])

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -2061,6 +2061,15 @@ def _gpu_suite_checkpoint_contract(
                     "pinned_hsl_bounds": deepcopy(
                         item.get("pinned_hsl_bounds", {})
                     ),
+                    "scenario_fixed_bound_values": deepcopy(
+                        item.get("fixed_bound_values", {})
+                    ),
+                    "scenario_parameter_overrides": deepcopy(
+                        item.get("parameter_overrides", {})
+                    ),
+                    "proxy_execution": deepcopy(
+                        item.get("proxy_checkpoint_contract", {})
+                    ),
                     "candle_count": int(len(item["hlcvs"])),
                     "first_timestamp": (
                         int(timestamps[0]) if len(timestamps) else None
@@ -2098,6 +2107,9 @@ def _gpu_runtime_checkpoint_contract(
         "unstuck": _gpu_unstuck_checkpoint_contract(config),
         "hsl": _gpu_hsl_checkpoint_contract(config),
         "pinned_hsl_bounds": deepcopy(pinned_hsl_bounds or {}),
+        "proxy_execution": deepcopy(
+            getattr(proxy, "checkpoint_contract", {})
+        ),
     }
 
 
@@ -2329,6 +2341,7 @@ def _checkpoint_signature(
     anchor_plan=None,
     suite_contract=None,
     runtime_contract=None,
+    search_contract=None,
 ) -> str:
     payload = {
         "active": [
@@ -2336,7 +2349,7 @@ def _checkpoint_signature(
             for name, index, bound in active
         ],
         "scoring": scoring,
-        "version": 2,
+        "version": 3,
     }
     if anchor_plan is not None:
         payload["anchor_plan"] = {
@@ -2354,7 +2367,51 @@ def _checkpoint_signature(
         payload["suite_contract"] = suite_contract
     if runtime_contract is not None:
         payload["runtime_contract"] = runtime_contract
+    if search_contract is not None:
+        payload["search_contract"] = search_contract
     return hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()
+
+
+def _gpu_search_checkpoint_contract(
+    *,
+    key_paths,
+    bounds,
+    base_vector,
+    fixed_bound_values,
+    fixed_parameter_overrides,
+    optimizer_overrides,
+    sig_digits,
+) -> dict:
+    """Fingerprint fixed and dormant search inputs omitted from active genes."""
+
+    if not (len(key_paths) == len(bounds) == len(base_vector)):
+        raise ValueError("GPU checkpoint search contract shape mismatch")
+    return {
+        "version": 1,
+        "sig_digits": int(sig_digits),
+        "dimensions": [
+            {
+                "key": str(bound_key),
+                "path": [str(part) for part in path],
+                "low": float(bound.low),
+                "high": float(bound.high),
+                "step": None if bound.step is None else float(bound.step),
+                "base": float(base_vector[index]),
+            }
+            for index, ((bound_key, path), bound) in enumerate(
+                zip(key_paths, bounds)
+            )
+        ],
+        "fixed_bound_values": {
+            str(key): float(value)
+            for key, value in sorted((fixed_bound_values or {}).items())
+        },
+        "fixed_parameter_overrides": {
+            str(key): float(value)
+            for key, value in sorted((fixed_parameter_overrides or {}).items())
+        },
+        "optimizer_overrides": sorted(str(value) for value in optimizer_overrides),
+    }
 
 
 def _save_checkpoint(path: str | None, state: dict) -> None:
@@ -3157,6 +3214,7 @@ def run_backend(
         )
         _validate_hsl_bound_contracts(scenario_bound_by_key, item["config"])
         item["parameter_overrides"] = parameter_overrides
+        item["fixed_bound_values"] = fixed_scenario_bounds
         item["pinned_hsl_bounds"] = _gpu_pinned_hsl_bound_contract(
             scenario_bound_by_key
         )
@@ -3244,6 +3302,9 @@ def run_backend(
             )
             item["coin_override_contract"] = getattr(
                 scenario_proxy, "coin_override_contract", {}
+            )
+            item["proxy_checkpoint_contract"] = getattr(
+                scenario_proxy, "checkpoint_contract", {}
             )
             scenario_proxies.append(
                 (item["ctx"], scenario_proxy, item["parameter_overrides"])
@@ -3392,6 +3453,15 @@ def run_backend(
                 pinned_hsl_bounds=_gpu_pinned_hsl_bound_contract(bound_by_key),
             )
         ),
+        search_contract=_gpu_search_checkpoint_contract(
+            key_paths=key_paths,
+            bounds=bounds,
+            base_vector=base_vector,
+            fixed_bound_values=fixed_bound_values,
+            fixed_parameter_overrides=fixed_parameter_overrides,
+            optimizer_overrides=gpu_optimizer_overrides,
+            sig_digits=sig_digits,
+        ),
     )
     budget = int(config["optimize"]["iters"])
     if budget <= 0:
@@ -3404,8 +3474,8 @@ def run_backend(
             checkpoint = pickle.load(file)
         if checkpoint.get("signature") != signature:
             raise ValueError(
-                "GPU checkpoint does not match current bounds, scoring, suite, "
-                "or runtime contract"
+                "GPU checkpoint does not match current search, scoring, suite, "
+                "or prepared execution contract"
             )
         algorithm = checkpoint["algorithm"]
         seed = int(checkpoint.get("seed", seed))

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -124,20 +124,22 @@ def _gpu_proxy_execution_checkpoint_contract(
     strategy_kind: str,
     exchange: str,
     enabled_sides,
-    hlcvs_shape,
+    hlcvs,
     timestamps,
     backtest_params: dict,
     exchange_params,
+    base_params,
 ) -> dict:
     """Return the prepared execution inputs which make proxy state reusable."""
 
+    hlcv_values = np.ascontiguousarray(np.asarray(hlcvs))
     timestamp_values = np.ascontiguousarray(
         np.asarray(timestamps, dtype=np.int64).reshape(-1)
     )
-    if len(timestamp_values) != int(hlcvs_shape[0]):
+    if len(timestamp_values) != int(hlcv_values.shape[0]):
         raise ValueError(
             "GPU proxy checkpoint timestamp identity disagrees with prepared "
-            f"candles: timestamps={len(timestamp_values)}, candles={hlcvs_shape[0]}"
+            f"candles: timestamps={len(timestamp_values)}, candles={hlcv_values.shape[0]}"
         )
     runtime_keys = (
         "starting_balance",
@@ -174,7 +176,13 @@ def _gpu_proxy_execution_checkpoint_contract(
         "exchange": str(exchange),
         "coins": [str(coin) for coin in backtest_params.get("coins", [])],
         "enabled_sides": sorted(str(side) for side in enabled_sides),
-        "hlcvs_shape": [int(value) for value in hlcvs_shape],
+        "hlcvs": {
+            "shape": [int(value) for value in hlcv_values.shape],
+            "dtype": str(hlcv_values.dtype.str),
+            "sha256": hashlib.sha256(
+                memoryview(hlcv_values).cast("B")
+            ).hexdigest(),
+        },
         "timestamps": {
             "count": int(len(timestamp_values)),
             "first": int(timestamp_values[0]) if len(timestamp_values) else None,
@@ -188,6 +196,13 @@ def _gpu_proxy_execution_checkpoint_contract(
             {key: copy.deepcopy(item.get(key)) for key in market_keys}
             for item in exchange_params
         ],
+        "base_params": {
+            str(side): {
+                str(key): float(value)
+                for key, value in sorted((params or {}).items())
+            }
+            for side, params in sorted((base_params or {}).items())
+        },
     }
 
 
@@ -1155,15 +1170,6 @@ class MpsSingleCoinProxy:
         }
         if not any(self.enabled.values()):
             raise ValueError("GPU foundation requires at least one enabled side")
-        self.checkpoint_contract = _gpu_proxy_execution_checkpoint_contract(
-            strategy_kind=self.strategy_kind,
-            exchange=exchange,
-            enabled_sides=[side for side, enabled in self.enabled.items() if enabled],
-            hlcvs_shape=hlcvs.shape,
-            timestamps=timestamps,
-            backtest_params=backtest_params,
-            exchange_params=payload.exchange_params,
-        )
         enabled_side_count = sum(self.enabled.values())
         self.dispatch_batch_size = _mps_dispatch_batch_size(
             self.batch_size,
@@ -1239,6 +1245,17 @@ class MpsSingleCoinProxy:
                     f"parameters: {missing}"
                 )
             self.base_params[side] = strategy
+
+        self.checkpoint_contract = _gpu_proxy_execution_checkpoint_contract(
+            strategy_kind=self.strategy_kind,
+            exchange=exchange,
+            enabled_sides=[side for side, enabled in self.enabled.items() if enabled],
+            hlcvs=hlcvs,
+            timestamps=timestamps,
+            backtest_params=backtest_params,
+            exchange_params=payload.exchange_params,
+            base_params=self.base_params,
+        )
 
         self.base_total_wallet_exposure_limits = {
             side: float(self.base_params[side]["total_wallet_exposure_limit"])
@@ -1808,15 +1825,6 @@ class MpsMulticoinProxy:
             raise ValueError(
                 "MPS multicoin proxy requires backtest.dynamic_wel_by_tradability=true"
             )
-        self.checkpoint_contract = _gpu_proxy_execution_checkpoint_contract(
-            strategy_kind=self.strategy_kind,
-            exchange=exchange,
-            enabled_sides=self.sides,
-            hlcvs_shape=values.shape,
-            timestamps=timestamps,
-            backtest_params=backtest_params,
-            exchange_params=payload.exchange_params,
-        )
         self.forager_score_hysteresis_pct = float(
             backtest_params.get("forager_score_hysteresis_pct", 0.0) or 0.0
         )
@@ -1961,6 +1969,17 @@ class MpsMulticoinProxy:
                         "MPS multicoin proxy requires identical global "
                         f"{side} forager/risk settings across coins"
                     )
+
+        self.checkpoint_contract = _gpu_proxy_execution_checkpoint_contract(
+            strategy_kind=self.strategy_kind,
+            exchange=exchange,
+            enabled_sides=self.sides,
+            hlcvs=values,
+            timestamps=timestamps,
+            backtest_params=backtest_params,
+            exchange_params=payload.exchange_params,
+            base_params=self.base_params,
+        )
 
         coins = list(backtest_params.get("coins") or [])
         if len(coins) != coin_count:

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 from dataclasses import replace
+import hashlib
 import logging
 import os
 
@@ -116,6 +117,78 @@ DIRECTIONAL_HSL_OUTPUT_KEYS = {
 # on the supported M3 target; callers may still use larger evolutionary
 # populations and configured batches, which are split transparently.
 MPS_MAX_DISPATCH_CANDIDATE_BARS = 500_000_000
+
+
+def _gpu_proxy_execution_checkpoint_contract(
+    *,
+    strategy_kind: str,
+    exchange: str,
+    enabled_sides,
+    hlcvs_shape,
+    timestamps,
+    backtest_params: dict,
+    exchange_params,
+) -> dict:
+    """Return the prepared execution inputs which make proxy state reusable."""
+
+    timestamp_values = np.ascontiguousarray(
+        np.asarray(timestamps, dtype=np.int64).reshape(-1)
+    )
+    if len(timestamp_values) != int(hlcvs_shape[0]):
+        raise ValueError(
+            "GPU proxy checkpoint timestamp identity disagrees with prepared "
+            f"candles: timestamps={len(timestamp_values)}, candles={hlcvs_shape[0]}"
+        )
+    runtime_keys = (
+        "starting_balance",
+        "candle_interval_minutes",
+        "requested_start_timestamp_ms",
+        "first_timestamp_ms",
+        "first_valid_indices",
+        "last_valid_indices",
+        "trade_start_indices",
+        "global_warmup_bars",
+        "liquidation_threshold",
+        "filter_by_min_effective_cost",
+        "dynamic_wel_by_tradability",
+        "hedge_mode",
+        "max_realized_loss_pct",
+        "pnls_max_lookback_days",
+        "market_order_slippage_pct",
+        "market_orders_allowed",
+        "market_order_near_touch_threshold",
+        "forager_score_hysteresis_pct",
+    )
+    market_keys = (
+        "qty_step",
+        "price_step",
+        "min_qty",
+        "min_cost",
+        "c_mult",
+        "maker_fee",
+        "taker_fee",
+    )
+    return {
+        "version": 1,
+        "strategy_kind": str(strategy_kind),
+        "exchange": str(exchange),
+        "coins": [str(coin) for coin in backtest_params.get("coins", [])],
+        "enabled_sides": sorted(str(side) for side in enabled_sides),
+        "hlcvs_shape": [int(value) for value in hlcvs_shape],
+        "timestamps": {
+            "count": int(len(timestamp_values)),
+            "first": int(timestamp_values[0]) if len(timestamp_values) else None,
+            "last": int(timestamp_values[-1]) if len(timestamp_values) else None,
+            "sha256": hashlib.sha256(timestamp_values.tobytes()).hexdigest(),
+        },
+        "backtest": {
+            key: copy.deepcopy(backtest_params.get(key)) for key in runtime_keys
+        },
+        "markets": [
+            {key: copy.deepcopy(item.get(key)) for key in market_keys}
+            for item in exchange_params
+        ],
+    }
 
 
 def _mps_dispatch_batch_size(
@@ -1082,6 +1155,15 @@ class MpsSingleCoinProxy:
         }
         if not any(self.enabled.values()):
             raise ValueError("GPU foundation requires at least one enabled side")
+        self.checkpoint_contract = _gpu_proxy_execution_checkpoint_contract(
+            strategy_kind=self.strategy_kind,
+            exchange=exchange,
+            enabled_sides=[side for side, enabled in self.enabled.items() if enabled],
+            hlcvs_shape=hlcvs.shape,
+            timestamps=timestamps,
+            backtest_params=backtest_params,
+            exchange_params=payload.exchange_params,
+        )
         enabled_side_count = sum(self.enabled.values())
         self.dispatch_batch_size = _mps_dispatch_batch_size(
             self.batch_size,
@@ -1726,6 +1808,15 @@ class MpsMulticoinProxy:
             raise ValueError(
                 "MPS multicoin proxy requires backtest.dynamic_wel_by_tradability=true"
             )
+        self.checkpoint_contract = _gpu_proxy_execution_checkpoint_contract(
+            strategy_kind=self.strategy_kind,
+            exchange=exchange,
+            enabled_sides=self.sides,
+            hlcvs_shape=values.shape,
+            timestamps=timestamps,
+            backtest_params=backtest_params,
+            exchange_params=payload.exchange_params,
+        )
         self.forager_score_hysteresis_pct = float(
             backtest_params.get("forager_score_hysteresis_pct", 0.0) or 0.0
         )

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -41,6 +41,7 @@ from optimization.backends.gpu_backend import (
     _gpu_suite_enabled,
     _gpu_suite_checkpoint_contract,
     _gpu_runtime_checkpoint_contract,
+    _gpu_search_checkpoint_contract,
     _gpu_unstuck_parameter_active,
     _gpu_suite_scenario_override_context,
     _gpu_suite_scenario_inputs,
@@ -4597,6 +4598,9 @@ def test_gpu_suite_checkpoint_contract_tracks_prepared_scenario_identity():
             "unstuck": original["unstuck"],
             "hsl": original["hsl"],
             "pinned_hsl_bounds": {},
+            "scenario_fixed_bound_values": {},
+            "scenario_parameter_overrides": {},
+            "proxy_execution": {},
             "candle_count": 3,
             "first_timestamp": 1000,
             "last_timestamp": 3000,
@@ -4663,6 +4667,15 @@ def test_gpu_suite_checkpoint_contract_tracks_prepared_scenario_identity():
         _gpu_suite_checkpoint_contract(config, [changed_pinned_hsl])
         != original
     )
+
+    changed_proxy_execution = copy.deepcopy(item)
+    changed_proxy_execution["proxy_checkpoint_contract"] = {
+        "backtest": {"starting_balance": 20_000.0}
+    }
+    assert (
+        _gpu_suite_checkpoint_contract(config, [changed_proxy_execution])
+        != original
+    )
     assert (
         _gpu_suite_checkpoint_contract(
             config,
@@ -4682,6 +4695,68 @@ def test_gpu_suite_checkpoint_contract_tracks_prepared_scenario_identity():
     assert _gpu_suite_checkpoint_contract(config, [changed_coins]) != original
     assert _gpu_suite_checkpoint_contract(config, [changed_window]) != original
     assert _gpu_suite_checkpoint_contract(config, [changed_source]) != original
+
+
+def test_gpu_checkpoint_signature_tracks_full_fixed_search_contract():
+    key_paths = [
+        ("long_offset", ("bot", "long", "strategy", "ema_anchor", "offset")),
+        (
+            "long_base_qty_pct",
+            ("bot", "long", "strategy", "ema_anchor", "base_qty_pct"),
+        ),
+    ]
+    bounds = [Bound(0.01, 0.1, 0.01), Bound(0.02, 0.02, 0.01)]
+    base = [0.04, 0.02]
+    contract = _gpu_search_checkpoint_contract(
+        key_paths=key_paths,
+        bounds=bounds,
+        base_vector=base,
+        fixed_bound_values={"long_base_qty_pct": 0.02},
+        fixed_parameter_overrides={"long_base_qty_pct": 0.02},
+        optimizer_overrides=set(),
+        sig_digits=3,
+    )
+    active = [("long_offset", 0, bounds[0])]
+    scoring = [{"goal": "max", "metric": "adg_strategy_eq"}]
+    original = _checkpoint_signature(
+        active, scoring, search_contract=contract
+    )
+
+    mutations = []
+    changed_base = copy.deepcopy(contract)
+    changed_base["dimensions"][1]["base"] = 0.03
+    mutations.append(changed_base)
+    changed_fixed = copy.deepcopy(contract)
+    changed_fixed["fixed_parameter_overrides"]["long_base_qty_pct"] = 0.03
+    mutations.append(changed_fixed)
+    changed_digits = copy.deepcopy(contract)
+    changed_digits["sig_digits"] = 4
+    mutations.append(changed_digits)
+    changed_override = copy.deepcopy(contract)
+    changed_override["optimizer_overrides"] = ["mirror_short_from_long"]
+    mutations.append(changed_override)
+
+    assert all(
+        _checkpoint_signature(active, scoring, search_contract=changed)
+        != original
+        for changed in mutations
+    )
+
+
+def test_gpu_runtime_checkpoint_contract_tracks_prepared_proxy_execution():
+    config = _long_only_ema_config()
+    proxy = SimpleNamespace(
+        coin_override_contract=None,
+        checkpoint_contract={
+            "backtest": {"starting_balance": 10_000.0},
+            "markets": [{"maker_fee": 0.0004}],
+        },
+    )
+    original = _gpu_runtime_checkpoint_contract(config, proxy)
+    changed_proxy = copy.deepcopy(proxy)
+    changed_proxy.checkpoint_contract["markets"][0]["maker_fee"] = 0.0005
+
+    assert _gpu_runtime_checkpoint_contract(config, changed_proxy) != original
 
 
 def test_gpu_suite_checkpoint_contract_rejects_timestamp_shape_mismatch():

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -35,6 +35,7 @@ from optimization.backends.gpu_backend import (
     _gpu_candidate_source_sides,
     _gpu_hsl_search_sides,
     _gpu_hsl_parameter_active,
+    _gpu_nsga2_checkpoint_contract,
     _gpu_pinned_hsl_bound_contract,
     _validate_hsl_bound_contracts,
     _validate_hsl_metric_topology,
@@ -381,6 +382,19 @@ def test_gpu_nsga2_uses_configured_pymoo_variation_operators():
     assert algorithm.mating.mutation.eta.value == 13.0
     assert algorithm.mating.mutation.prob.value == 0.2
     assert type(algorithm.eliminate_duplicates).__name__ == "NoDuplicateElimination"
+
+    contract = _gpu_nsga2_checkpoint_contract(
+        config, population_size=8, n_params=5
+    )
+    assert contract == {
+        "version": 1,
+        "algorithm": "nsga2",
+        "population_size": 8,
+        "configured_seed": None,
+        "crossover": {"operator": "sbx", "prob_var": 0.7, "eta": 11.0},
+        "mutation": {"operator": "pm", "prob": 0.2, "eta": 13.0},
+        "eliminate_duplicates": False,
+    }
 
 
 def test_trailing_martingale_bound_map_covers_both_directional_shapes():
@@ -4715,6 +4729,11 @@ def test_gpu_checkpoint_signature_tracks_full_fixed_search_contract():
         fixed_parameter_overrides={"long_base_qty_pct": 0.02},
         optimizer_overrides=set(),
         sig_digits=3,
+        algorithm_contract={
+            "algorithm": "nsga2",
+            "population_size": 64,
+            "mutation": {"prob": 0.5},
+        },
     )
     active = [("long_offset", 0, bounds[0])]
     scoring = [{"goal": "max", "metric": "adg_strategy_eq"}]
@@ -4735,6 +4754,12 @@ def test_gpu_checkpoint_signature_tracks_full_fixed_search_contract():
     changed_override = copy.deepcopy(contract)
     changed_override["optimizer_overrides"] = ["mirror_short_from_long"]
     mutations.append(changed_override)
+    changed_population = copy.deepcopy(contract)
+    changed_population["algorithm"]["population_size"] = 128
+    mutations.append(changed_population)
+    changed_mutation = copy.deepcopy(contract)
+    changed_mutation["algorithm"]["mutation"]["prob"] = 0.25
+    mutations.append(changed_mutation)
 
     assert all(
         _checkpoint_signature(active, scoring, search_contract=changed)

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -35,6 +35,7 @@ from optimization.gpu.service import (
     _directional_entry_initial_metrics,
     _directional_gross_pnl_outputs,
     _hsl_params,
+    _gpu_proxy_execution_checkpoint_contract,
     _mps_dispatch_batch_size,
     _mps_strategy_eq_recovery_distribution,
     _multicoin_exposure_eligible_coins,
@@ -51,6 +52,84 @@ from optimization.gpu.service import (
     _total_exposure_enforcer_params,
     _unstuck_params,
 )
+
+
+def test_gpu_proxy_execution_checkpoint_contract_tracks_effective_inputs():
+    backtest_params = {
+        "coins": ["BTC"],
+        "starting_balance": 10_000.0,
+        "candle_interval_minutes": 1,
+        "requested_start_timestamp_ms": 1_000,
+        "first_timestamp_ms": 1_000,
+        "first_valid_indices": [0],
+        "last_valid_indices": [2],
+        "trade_start_indices": [1],
+        "global_warmup_bars": 1,
+        "liquidation_threshold": 0.05,
+        "filter_by_min_effective_cost": False,
+        "dynamic_wel_by_tradability": True,
+        "hedge_mode": False,
+        "max_realized_loss_pct": 1.0,
+        "pnls_max_lookback_days": 30.0,
+        "market_order_slippage_pct": 0.0005,
+        "market_orders_allowed": False,
+        "market_order_near_touch_threshold": 0.001,
+        "forager_score_hysteresis_pct": 0.02,
+    }
+    market = {
+        "qty_step": 0.001,
+        "price_step": 0.1,
+        "min_qty": 0.001,
+        "min_cost": 5.0,
+        "c_mult": 1.0,
+        "maker_fee": 0.0004,
+        "taker_fee": 0.00055,
+    }
+    original = _gpu_proxy_execution_checkpoint_contract(
+        strategy_kind="ema_anchor",
+        exchange="bybit",
+        enabled_sides=["long"],
+        hlcvs_shape=(3, 1, 4),
+        timestamps=np.array([1_000, 2_000, 3_000], dtype=np.int64),
+        backtest_params=backtest_params,
+        exchange_params=[market],
+    )
+    changed_fee = dict(market, maker_fee=0.0005)
+    changed = _gpu_proxy_execution_checkpoint_contract(
+        strategy_kind="ema_anchor",
+        exchange="bybit",
+        enabled_sides=["long"],
+        hlcvs_shape=(3, 1, 4),
+        timestamps=np.array([1_000, 2_000, 3_000], dtype=np.int64),
+        backtest_params=backtest_params,
+        exchange_params=[changed_fee],
+    )
+    changed_timestamps = _gpu_proxy_execution_checkpoint_contract(
+        strategy_kind="ema_anchor",
+        exchange="bybit",
+        enabled_sides=["long"],
+        hlcvs_shape=(3, 1, 4),
+        timestamps=np.array([1_000, 2_100, 3_000], dtype=np.int64),
+        backtest_params=backtest_params,
+        exchange_params=[market],
+    )
+
+    assert changed != original
+    assert changed_timestamps != original
+    assert original["timestamps"]["count"] == 3
+
+
+def test_gpu_proxy_execution_checkpoint_contract_rejects_timestamp_shape_mismatch():
+    with pytest.raises(ValueError, match="timestamp identity disagrees"):
+        _gpu_proxy_execution_checkpoint_contract(
+            strategy_kind="ema_anchor",
+            exchange="bybit",
+            enabled_sides=["long"],
+            hlcvs_shape=(3, 1, 4),
+            timestamps=np.array([1_000, 2_000], dtype=np.int64),
+            backtest_params={"coins": ["BTC"]},
+            exchange_params=[],
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -89,33 +89,60 @@ def test_gpu_proxy_execution_checkpoint_contract_tracks_effective_inputs():
         strategy_kind="ema_anchor",
         exchange="bybit",
         enabled_sides=["long"],
-        hlcvs_shape=(3, 1, 4),
+        hlcvs=np.arange(12, dtype=np.float64).reshape(3, 1, 4),
         timestamps=np.array([1_000, 2_000, 3_000], dtype=np.int64),
         backtest_params=backtest_params,
         exchange_params=[market],
+        base_params={"long": {"offset": 0.01}},
     )
     changed_fee = dict(market, maker_fee=0.0005)
     changed = _gpu_proxy_execution_checkpoint_contract(
         strategy_kind="ema_anchor",
         exchange="bybit",
         enabled_sides=["long"],
-        hlcvs_shape=(3, 1, 4),
+        hlcvs=np.arange(12, dtype=np.float64).reshape(3, 1, 4),
         timestamps=np.array([1_000, 2_000, 3_000], dtype=np.int64),
         backtest_params=backtest_params,
         exchange_params=[changed_fee],
+        base_params={"long": {"offset": 0.01}},
     )
     changed_timestamps = _gpu_proxy_execution_checkpoint_contract(
         strategy_kind="ema_anchor",
         exchange="bybit",
         enabled_sides=["long"],
-        hlcvs_shape=(3, 1, 4),
+        hlcvs=np.arange(12, dtype=np.float64).reshape(3, 1, 4),
         timestamps=np.array([1_000, 2_100, 3_000], dtype=np.int64),
         backtest_params=backtest_params,
         exchange_params=[market],
+        base_params={"long": {"offset": 0.01}},
+    )
+    changed_hlcvs_values = np.arange(12, dtype=np.float64).reshape(3, 1, 4)
+    changed_hlcvs_values[1, 0, 2] += 0.5
+    changed_hlcvs = _gpu_proxy_execution_checkpoint_contract(
+        strategy_kind="ema_anchor",
+        exchange="bybit",
+        enabled_sides=["long"],
+        hlcvs=changed_hlcvs_values,
+        timestamps=np.array([1_000, 2_000, 3_000], dtype=np.int64),
+        backtest_params=backtest_params,
+        exchange_params=[market],
+        base_params={"long": {"offset": 0.01}},
+    )
+    changed_base_params = _gpu_proxy_execution_checkpoint_contract(
+        strategy_kind="ema_anchor",
+        exchange="bybit",
+        enabled_sides=["long"],
+        hlcvs=np.arange(12, dtype=np.float64).reshape(3, 1, 4),
+        timestamps=np.array([1_000, 2_000, 3_000], dtype=np.int64),
+        backtest_params=backtest_params,
+        exchange_params=[market],
+        base_params={"long": {"offset": 0.02}},
     )
 
     assert changed != original
     assert changed_timestamps != original
+    assert changed_hlcvs != original
+    assert changed_base_params != original
     assert original["timestamps"]["count"] == 3
 
 
@@ -125,10 +152,11 @@ def test_gpu_proxy_execution_checkpoint_contract_rejects_timestamp_shape_mismatc
             strategy_kind="ema_anchor",
             exchange="bybit",
             enabled_sides=["long"],
-            hlcvs_shape=(3, 1, 4),
+            hlcvs=np.zeros((3, 1, 4), dtype=np.float64),
             timestamps=np.array([1_000, 2_000], dtype=np.int64),
             backtest_params={"coins": ["BTC"]},
             exchange_params=[],
+            base_params={},
         )
 
 


### PR DESCRIPTION
## Summary

- bind GPU checkpoints to the complete fixed and tunable search shape, quantization, and optimizer overrides
- fingerprint each prepared single-run or suite-scenario execution contract, including timestamps, valid/trade windows, effective market settings and fees, and modeled execution policy
- fail closed on incompatible resume inputs and intentionally invalidate older GPU checkpoint signatures
- document the expanded contract and add regression coverage

## Validation

- 550 optimizer/backend tests passed
- 307 physical Apple MPS tests passed on this M3 MacBook Air
- real trailing-martingale MPS run wrote a checkpoint at 32 exact evaluations and resumed from generation 8/evaluation 32 through evaluation 40
- changing live.market_order_near_touch_threshold from 0.001 to 0.002 caused the same checkpoint to fail closed before GPU dispatch
- git diff --check passed

CPU optimizer and bot behavior are unchanged; this only hardens the additive GPU backend.