### PR TITLE
Expand GPU suite execution overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Expanded Apple MPS suite scenario overrides to the already-modeled taker-fee, market-order
+  slippage, minimum-effective-cost filtering, and PnL-lookback execution settings. Every effective
+  scenario is still scope-validated independently, so unsupported side/coin combinations fail
+  before optimization.
+
 - Hardened Apple MPS optimizer checkpoint/resume identity. GPU checkpoints now bind the complete
   fixed and tunable search shape and each prepared single-run or suite-scenario proxy execution
   contract, including prepared candle-value and timestamp hashes, starting balance, valid/trade

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -123,7 +123,8 @@ The supported slice is intentionally narrow:
   scenario date, coin, ignored-coin, exchange selection, and fail-closed `bot.long`/`bot.short`
   config overrides are supported; scenario-local `coin_overrides` for supported multi-coin
   EMA-anchor and trailing-martingale runs, starting balance, maker fee, liquidation threshold,
-  Forager hysteresis, and hedge mode are also supported, while other
+  taker fee, market-order slippage, minimum-effective-cost filtering, finite or all-history PnL
+  lookback, Forager hysteresis, and hedge mode are also supported, while other
   non-bot override paths remain unsupported; combined scenarios may use canonical per-coin source
   assignments, while an individual-exchange scenario fails closed if an effective assignment
   for one of its prepared coins selects another exchange
@@ -304,7 +305,9 @@ explicit scenario override. Metal uses the strategy-specific single-coin or mult
 independently for each scenario, then feeds all results to the same suite reducer. Scenario-local
 `coin_overrides` for supported
 multi-coin EMA Anchor and Trailing Martingale runs, `backtest.starting_balance`,
-`backtest.maker_fee_override`, `backtest.liquidation_threshold`,
+`backtest.maker_fee_override`, `backtest.taker_fee_override`,
+`backtest.market_order_slippage_pct`, `backtest.filter_by_min_effective_cost`,
+`backtest.liquidation_threshold`, `live.pnls_max_lookback_days`,
 `live.forager_score_hysteresis_pct`, and `live.hedge_mode` are accepted because every scenario
 proxy consumes them through the canonical backtest payload and then passes the same fail-closed
 scope checks. Combined scenario `coin_sources` use the same prepared per-coin candles and market

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -296,13 +296,17 @@ GPU_SUPPORTED_OPTIMIZER_OVERRIDES = {
 # selection and unsupported execution/risk behavior must continue to fail
 # closed instead of being accepted merely because the config path exists.
 GPU_SUPPORTED_SUITE_NON_BOT_OVERRIDE_PATHS = {
+    ("backtest", "filter_by_min_effective_cost"),
     ("backtest", "liquidation_threshold"),
     ("backtest", "maker_fee_override"),
+    ("backtest", "market_order_slippage_pct"),
     ("backtest", "starting_balance"),
+    ("backtest", "taker_fee_override"),
     ("coin_overrides",),
     ("live", "forager_score_hysteresis_pct"),
     ("live", "hedge_mode"),
     ("live", "max_realized_loss_pct"),
+    ("live", "pnls_max_lookback_days"),
 }
 
 

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -668,6 +668,17 @@ def test_gpu_suite_inputs_reject_unsupported_scenario_scope(
     [
         ("backtest.starting_balance", 12_345.0, ("backtest", "starting_balance")),
         ("backtest.maker_fee_override", 0.0002, ("backtest", "maker_fee_override")),
+        ("backtest.taker_fee_override", 0.0007, ("backtest", "taker_fee_override")),
+        (
+            "backtest.market_order_slippage_pct",
+            0.0015,
+            ("backtest", "market_order_slippage_pct"),
+        ),
+        (
+            "backtest.filter_by_min_effective_cost",
+            True,
+            ("backtest", "filter_by_min_effective_cost"),
+        ),
         (
             "backtest.liquidation_threshold",
             0.1,
@@ -683,6 +694,11 @@ def test_gpu_suite_inputs_reject_unsupported_scenario_scope(
             "live.max_realized_loss_pct",
             0.05,
             ("live", "max_realized_loss_pct"),
+        ),
+        (
+            "live.pnls_max_lookback_days",
+            7.0,
+            ("live", "pnls_max_lookback_days"),
         ),
     ],
 )


### PR DESCRIPTION
## Summary

- allow suite scenarios to override backtest.taker_fee_override and backtest.market_order_slippage_pct
- allow suite scenarios to override backtest.filter_by_min_effective_cost and live.pnls_max_lookback_days
- retain per-scenario fail-closed GPU scope validation, including the existing single-side/single-coin restriction for minimum-effective-cost filtering
- document the expanded modeled suite surface and add regression coverage

## Validation

- 398 GPU backend tests passed
- 461 combined GPU backend, suite-runner, and backtest execution-setting tests passed
- all 307 physical Apple MPS tests passed on this M3 MacBook Air
- real two-scenario Trailing Martingale MPS suite: 512 proxy evaluations, 32 exact Rust validations, clean completion
- real two-scenario EMA Anchor MPS suite: 512 proxy evaluations, 32 exact Rust validations, clean completion
- each real stress scenario simultaneously used taker-fee override, 0.2% market-order slippage, minimum-effective-cost filtering, and all-history PnL lookback
- git diff --check passed

CPU optimizer and bot behavior are unchanged; this only expands the additive GPU suite allowlist for settings already consumed by the canonical payload and Metal proxy.