### PR TITLE
GPU: support suite-local HSL signal modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added Apple MPS suite scenario overrides for `live.hsl_signal_mode`. Coin, position-side, and
+  unified HSL signal topology may now vary by scenario when each effective scenario passes the
+  existing Metal topology and per-coin override checks.
+
 - Expanded Apple MPS suite scenario overrides to the already-modeled taker-fee, market-order
   slippage, minimum-effective-cost filtering, and PnL-lookback execution settings. Every effective
   scenario is still scope-validated independently, so unsupported side/coin combinations fail

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -124,7 +124,7 @@ The supported slice is intentionally narrow:
   config overrides are supported; scenario-local `coin_overrides` for supported multi-coin
   EMA-anchor and trailing-martingale runs, starting balance, maker fee, liquidation threshold,
   taker fee, market-order slippage, minimum-effective-cost filtering, finite or all-history PnL
-  lookback, Forager hysteresis, and hedge mode are also supported, while other
+  lookback, Forager hysteresis, hedge mode, and HSL signal mode are also supported, while other
   non-bot override paths remain unsupported; combined scenarios may use canonical per-coin source
   assignments, while an individual-exchange scenario fails closed if an effective assignment
   for one of its prepared coins selects another exchange
@@ -308,10 +308,11 @@ multi-coin EMA Anchor and Trailing Martingale runs, `backtest.starting_balance`,
 `backtest.maker_fee_override`, `backtest.taker_fee_override`,
 `backtest.market_order_slippage_pct`, `backtest.filter_by_min_effective_cost`,
 `backtest.liquidation_threshold`, `live.pnls_max_lookback_days`,
-`live.forager_score_hysteresis_pct`, and `live.hedge_mode` are accepted because every scenario
-proxy consumes them through the canonical backtest payload and then passes the same fail-closed
-scope checks. Combined scenario `coin_sources` use the same prepared per-coin candles and market
-settings as exact Rust; their resolved OHLCV and market-settings exchanges are part of checkpoint
+`live.forager_score_hysteresis_pct`, `live.hedge_mode`, and `live.hsl_signal_mode` are accepted
+because every scenario proxy consumes them through the canonical backtest payload and then passes
+the same fail-closed scope checks. Combined scenario `coin_sources` use the same prepared per-coin
+candles and market settings as exact Rust; their resolved OHLCV and market-settings exchanges are
+part of checkpoint
 identity. Other non-bot paths remain rejected until their proxy semantics are modeled. The
 effective external suite definition and any `--scenarios` filter are
 stored in the run contract and checkpoint identity, with dynamic scenario dates resolved to the

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -305,6 +305,7 @@ GPU_SUPPORTED_SUITE_NON_BOT_OVERRIDE_PATHS = {
     ("coin_overrides",),
     ("live", "forager_score_hysteresis_pct"),
     ("live", "hedge_mode"),
+    ("live", "hsl_signal_mode"),
     ("live", "max_realized_loss_pct"),
     ("live", "pnls_max_lookback_days"),
 }

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -690,6 +690,7 @@ def test_gpu_suite_inputs_reject_unsupported_scenario_scope(
             ("live", "forager_score_hysteresis_pct"),
         ),
         ("live.hedge_mode", True, ("live", "hedge_mode")),
+        ("live.hsl_signal_mode", "coin", ("live", "hsl_signal_mode")),
         (
             "live.max_realized_loss_pct",
             0.05,
@@ -736,6 +737,35 @@ def test_gpu_suite_inputs_accept_modeled_non_bot_overrides(
     for part in resolved_path:
         target = target[part]
     assert target == value
+
+
+def test_gpu_suite_hsl_signal_override_revalidates_effective_topology():
+    config = _long_only_ema_config()
+    config["backtest"]["suite_enabled"] = True
+    config["bot"]["long"]["hsl"]["enabled"] = True
+    ctx = SimpleNamespace(
+        label="invalid_signal",
+        overrides={"live.hsl_signal_mode": "not-a-mode"},
+        exchanges=["bybit"],
+        msss={"bybit": {"BTC": {}, "__meta__": {}}},
+        timestamps={"bybit": np.arange(10, dtype=np.int64)},
+    )
+
+    class Suite:
+        contexts = [ctx]
+
+        @staticmethod
+        def get_prepared_context_data(_ctx, _exchange):
+            return np.zeros((10, 1, 4)), np.ones(10), [0]
+
+        @staticmethod
+        def build_scenario_candidate_config(proxy_config, _ctx):
+            scenario = copy.deepcopy(proxy_config)
+            scenario["live"]["hsl_signal_mode"] = "not-a-mode"
+            return scenario
+
+    with pytest.raises(ValueError, match="coin, pside, or unified"):
+        _gpu_suite_scenario_inputs(config, Suite())
 
 
 def test_gpu_suite_inputs_accept_scenario_local_modeled_coin_overrides():


### PR DESCRIPTION
## Summary
- allow suite scenarios to override live.hsl_signal_mode for the Apple MPS optimizer
- retain per-scenario topology and coin-override validation so unsupported effective configurations fail closed
- document the newly supported suite setting

## Validation
- 400 tests: tests/optimization/test_gpu_backend.py
- 616 tests: GPU backend, service, suite-context, and suite-runner modules
- 307 tests: full physical Apple MPS parity module
- physical M3 suite smoke: BTC trailing-martingale HSL, coin plus unified scenarios, 512 proxy evaluations and 32 exact Rust validations, clean completion and shutdown