### PR TITLE
feat(gpu): support EMA ordinary market execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added baseline ordinary market-order execution to Apple MPS optimization for single-coin EMA
+  Anchor, including near-touch promotion, next-candle adverse slippage, taker fees, executable-touch
+  sizing, directional and one-way modes, and compatible suites. HSL, auto-unstuck, exposure repair,
+  realized-loss gating, minimum-effective-cost filtering, Trailing Martingale, and multi-coin
+  combinations remain fail closed while their market-order interactions are implemented.
+
 - Added Apple MPS suite scenario overrides for `live.hsl_signal_mode`. Coin, position-side, and
   unified HSL signal topology may now vary by scenario when each effective scenario passes the
   existing Metal topology and per-coin override checks.

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -124,10 +124,11 @@ The supported slice is intentionally narrow:
   config overrides are supported; scenario-local `coin_overrides` for supported multi-coin
   EMA-anchor and trailing-martingale runs, starting balance, maker fee, liquidation threshold,
   taker fee, market-order slippage, minimum-effective-cost filtering, finite or all-history PnL
-  lookback, Forager hysteresis, hedge mode, and HSL signal mode are also supported, while other
-  non-bot override paths remain unsupported; combined scenarios may use canonical per-coin source
-  assignments, while an individual-exchange scenario fails closed if an effective assignment
-  for one of its prepared coins selects another exchange
+  lookback, Forager hysteresis, hedge mode, HSL signal mode, ordinary-market enablement, and its
+  near-touch threshold are also supported when the resulting scenario remains within the scope
+  below, while other non-bot override paths remain unsupported; combined scenarios may use
+  canonical per-coin source assignments, while an individual-exchange scenario fails closed if
+  an effective assignment for one of its prepared coins selects another exchange
 - static `coin_overrides` for each enabled side of multi-coin EMA-anchor and trailing-martingale
   runs: active-strategy parameters, `risk.entry_cooldown_minutes`, and explicit
   `wallet_exposure_limit`, `risk.we_excess_allowance_pct`, and all six `unstuck` leaves are
@@ -276,7 +277,16 @@ The supported slice is intentionally narrow:
   multi-coin runs still require this option to be disabled because proxy position divergence and
   approximate multi-coin selection cannot conservatively bound exact Rust's cash balance for
   another flat side or coin
-- `live.market_orders_allowed: false`
+- `live.market_orders_allowed: false` for the complete strategy/risk surface. Single-coin EMA
+  Anchor also supports `true` for long-only, short-only, hedge-mode dual-side, one-way, and
+  compatible suite scenarios when HSL, auto-unstuck, and total-exposure repair are disabled,
+  `live.max_realized_loss_pct >= 1`, and minimum-effective-cost filtering is disabled. The Metal
+  proxy classifies each generated order against the current candle close using
+  `live.market_order_near_touch_threshold`, retains that execution intent for the pending order,
+  and fills promoted orders on the next valid candle at its adversely slipped, directionally
+  rounded close with the taker fee. Market closes and short entries are resized at the executable
+  touch before they are retained. Trailing Martingale, multi-coin market execution, and the
+  excluded risk-order interactions remain fail closed until their execution ordering is modeled
 - no invalid candle tail after the selected coin's final valid candle
 
 Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor and
@@ -308,11 +318,12 @@ multi-coin EMA Anchor and Trailing Martingale runs, `backtest.starting_balance`,
 `backtest.maker_fee_override`, `backtest.taker_fee_override`,
 `backtest.market_order_slippage_pct`, `backtest.filter_by_min_effective_cost`,
 `backtest.liquidation_threshold`, `live.pnls_max_lookback_days`,
-`live.forager_score_hysteresis_pct`, `live.hedge_mode`, and `live.hsl_signal_mode` are accepted
-because every scenario proxy consumes them through the canonical backtest payload and then passes
-the same fail-closed scope checks. Combined scenario `coin_sources` use the same prepared per-coin
-candles and market settings as exact Rust; their resolved OHLCV and market-settings exchanges are
-part of checkpoint
+`live.forager_score_hysteresis_pct`, `live.hedge_mode`, `live.hsl_signal_mode`,
+`live.market_orders_allowed`, and `live.market_order_near_touch_threshold` are accepted because
+every scenario proxy consumes them through the canonical backtest payload and then passes the same
+fail-closed scope checks. Combined scenario `coin_sources` use the same prepared per-coin candles
+and market settings as exact Rust; their resolved OHLCV and market-settings exchanges are part of
+checkpoint
 identity. Other non-bot paths remain rejected until their proxy semantics are modeled. The
 effective external suite definition and any `--scenarios` filter are
 stored in the run contract and checkpoint identity, with dynamic scenario dates resolved to the

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -432,9 +432,12 @@ mod tests {
         assert!(source.contains("const float market_order_slippage_pct = fmax(settings[16], 0.0f)"));
         assert!(source.contains("const bool long_hsl_panic_market = settings[17] > 0.5f"));
         assert!(source.contains("const bool short_hsl_panic_market = settings[18] > 0.5f"));
-        assert!(source.contains("market_panic ? taker_fee : maker_fee"));
-        assert!(source.contains("close * (1.0f - market_order_slippage_pct)"));
-        assert!(source.contains("close * (1.0f + market_order_slippage_pct)"));
+        assert!(source.contains("const bool market_orders_allowed = settings[19] > 0.5f"));
+        assert!(source
+            .contains("const float market_order_near_touch_threshold = fmax(settings[20], 0.0f)"));
+        assert!(source.contains("market_execution ? taker_fee : maker_fee"));
+        assert!(source.contains("ordinary_market_fill_price("));
+        assert!(source.contains("resize_market_close_qty("));
         assert!(!source.contains("accumulate_min_cost_balance_error"));
         assert_eq!(source.matches("= fma(").count(), 6);
         assert!(!source.contains("alpha0 * close +"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -41,6 +41,68 @@ inline float min_entry_qty(
     return aligned ? fmax(nearest, raw_min) : ceil(raw_steps) * qty_step;
 }
 
+inline bool should_use_ordinary_market_execution(
+    int order_ticks,
+    bool buy_order,
+    float market_price,
+    float price_step,
+    bool market_orders_allowed,
+    float near_touch_threshold
+) {
+    if (!market_orders_allowed || order_ticks <= 0
+        || !(market_price > 0.0f) || !isfinite(market_price)) {
+        return false;
+    }
+    float order_price = float(order_ticks) * price_step;
+    if (buy_order ? order_price >= market_price : order_price <= market_price) {
+        return true;
+    }
+    return fabs(order_price / market_price - 1.0f)
+        <= fmax(near_touch_threshold, 0.0f);
+}
+
+inline float ordinary_market_fill_price(
+    float close,
+    bool buy_order,
+    float market_order_slippage_pct,
+    float price_step
+) {
+    float slipped = close * (
+        buy_order
+            ? 1.0f + market_order_slippage_pct
+            : 1.0f - market_order_slippage_pct
+    );
+    return fmax(
+        buy_order ? ceil_step(slipped, price_step) : floor_step(slipped, price_step),
+        price_step
+    );
+}
+
+inline float resize_market_close_qty(
+    float requested_qty,
+    float position_size,
+    float executable_touch,
+    float qty_step,
+    float min_qty,
+    float min_cost,
+    float c_mult
+) {
+    if (!(requested_qty > 0.0f) || position_size <= requested_qty) {
+        return requested_qty;
+    }
+    float minimum_qty = min_entry_qty(
+        executable_touch, qty_step, min_qty, min_cost, c_mult
+    );
+    float tolerance = 1.0e-12f * fmax(requested_qty, minimum_qty) * 4.0f;
+    if (requested_qty + tolerance >= minimum_qty) return requested_qty;
+    float resized = fmin(minimum_qty, position_size);
+    float remainder = position_size - resized;
+    if (remainder > 0.0f && remainder + tolerance < minimum_qty) {
+        resized = position_size;
+    }
+    return resized;
+}
+
 inline bool passes_min_effective_cost(
     bool enabled, float guaranteed_balance_lower, float wel,
     float initial_qty_pct, float max_effective_min_cost
@@ -161,10 +223,13 @@ struct EmaSide {
     float pos_open_k;
     int entry_ticks;
     float entry_qty;
+    bool entry_market;
     int close_ticks;
     float close_qty;
+    bool close_market;
     int secondary_close_ticks;
     float secondary_close_qty;
+    bool secondary_close_market;
     int close_without_reducer_ticks;
     float close_without_reducer_qty;
     bool close_is_protective_reducer;
@@ -235,10 +300,13 @@ inline EmaSide load_side(constant float* params, int po, float seed_close) {
     side.pos_open_k = -1.0f;
     side.entry_ticks = 0;
     side.entry_qty = 0.0f;
+    side.entry_market = false;
     side.close_ticks = 0;
     side.close_qty = 0.0f;
+    side.close_market = false;
     side.secondary_close_ticks = 0;
     side.secondary_close_qty = 0.0f;
+    side.secondary_close_market = false;
     side.close_without_reducer_ticks = 0;
     side.close_without_reducer_qty = 0.0f;
     side.close_is_protective_reducer = false;
@@ -610,7 +678,9 @@ inline void generate_long_orders(
     float min_cost,
     float c_mult,
     float kf,
-    bool block_initial
+    bool block_initial,
+    bool market_orders_allowed,
+    float market_order_near_touch_threshold
 ) {
     float lower = fmin(side.ema0, fmin(side.ema1, side.ema2));
     float upper = fmax(side.ema0, fmax(side.ema1, side.ema2));
@@ -629,6 +699,11 @@ inline void generate_long_orders(
         touch_down_ticks
     );
     float bid_price = float(bid_ticks) * price_step;
+    bool entry_market = should_use_ordinary_market_execution(
+        bid_ticks, true, price_now, price_step, market_orders_allowed,
+        market_order_near_touch_threshold
+    );
+    float entry_exposure_price = entry_market ? price_now : bid_price;
     float min_q = min_entry_qty(bid_price, qty_step, min_qty, min_cost, c_mult);
     float base_q = fmax(min_q, round_step(
         balance * side.allowed_wel * side.base_qty_pct
@@ -642,8 +717,8 @@ inline void generate_long_orders(
         && kf < side.last_inc_k + side.cooldown_min;
     float cap = side.entry_cap - 1.0e-7f;
     float headroom = (cap * balance - side.psize * side.pprice * c_mult)
-        / fmax(bid_price * c_mult, 1.0e-12f);
-    bool over = (side.psize * side.pprice + e_qty * bid_price) * c_mult
+        / fmax(entry_exposure_price * c_mult, 1.0e-12f);
+    bool over = (side.psize * side.pprice + e_qty * entry_exposure_price) * c_mult
         / fmax(balance, 1.0e-9f) >= cap;
     float capped = floor_step(headroom, qty_step);
     if (over) e_qty = capped > 0.0f && capped + 1.0e-6f >= min_q ? capped : 0.0f;
@@ -654,6 +729,7 @@ inline void generate_long_orders(
     }
     side.entry_ticks = bid_ticks;
     side.entry_qty = e_qty;
+    side.entry_market = entry_market && e_qty > 0.0f;
 
     int ask_ticks = max(
         int(ceil(upper * (1.0f + eff_off - inv_shift) / price_step - 1.0e-6f)),
@@ -691,7 +767,9 @@ inline void generate_short_orders(
     float min_cost,
     float c_mult,
     float kf,
-    bool block_initial
+    bool block_initial,
+    bool market_orders_allowed,
+    float market_order_near_touch_threshold
 ) {
     float lower = fmin(side.ema0, fmin(side.ema1, side.ema2));
     float upper = fmax(side.ema0, fmax(side.ema1, side.ema2));
@@ -709,6 +787,11 @@ inline void generate_short_orders(
         touch_up_ticks
     );
     float ask_price = float(ask_ticks) * price_step;
+    bool entry_market = should_use_ordinary_market_execution(
+        ask_ticks, false, price_now, price_step, market_orders_allowed,
+        market_order_near_touch_threshold
+    );
+    float entry_exposure_price = entry_market ? price_now : ask_price;
     float min_q = min_entry_qty(ask_price, qty_step, min_qty, min_cost, c_mult);
     float base_q = fmax(min_q, round_step(
         balance * side.allowed_wel * side.base_qty_pct
@@ -718,15 +801,20 @@ inline void generate_short_orders(
     float e_qty = round_step(
         base_q * fmax(1.0f + fmax(-swer, 0.0f) * side.ddf, 1.0f), qty_step
     );
+    float market_min_q = entry_market
+        ? min_entry_qty(price_now, qty_step, min_qty, min_cost, c_mult)
+        : min_q;
+    if (entry_market && e_qty < market_min_q) e_qty = market_min_q;
     bool cooldown = side.cooldown_min > 0.0f && side.last_inc_k >= 0.0f
         && kf < side.last_inc_k + side.cooldown_min;
     float cap = side.entry_cap - 1.0e-7f;
     float headroom = (cap * balance - side.psize * side.pprice * c_mult)
-        / fmax(ask_price * c_mult, 1.0e-12f);
-    bool over = (side.psize * side.pprice + e_qty * ask_price) * c_mult
+        / fmax(entry_exposure_price * c_mult, 1.0e-12f);
+    bool over = (side.psize * side.pprice + e_qty * entry_exposure_price) * c_mult
         / fmax(balance, 1.0e-9f) >= cap;
     float capped = floor_step(headroom, qty_step);
     if (over) e_qty = capped > 0.0f && capped + 1.0e-6f >= min_q ? capped : 0.0f;
+    if (entry_market && e_qty + 1.0e-12f < market_min_q) e_qty = 0.0f;
     if (current_cost_we >= cap || cooldown || ask_price <= 0.0f || balance <= 0.0f
         || side.base_qty_pct <= 0.0f
         || (block_initial && side.psize <= 0.0f)) {
@@ -734,6 +822,7 @@ inline void generate_short_orders(
     }
     side.entry_ticks = ask_ticks;
     side.entry_qty = e_qty;
+    side.entry_market = entry_market && e_qty > 0.0f;
 
     int bid_ticks = min(
         int(floor(lower * (1.0f - eff_off - inv_shift) / price_step + 1.0e-6f)),
@@ -833,6 +922,8 @@ inline void passivbot_single_coin_impl(
     const float market_order_slippage_pct = fmax(settings[16], 0.0f);
     const bool long_hsl_panic_market = settings[17] > 0.5f;
     const bool short_hsl_panic_market = settings[18] > 0.5f;
+    const bool market_orders_allowed = settings[19] > 0.5f;
+    const float market_order_near_touch_threshold = fmax(settings[20], 0.0f);
     const int pnl_lookback_bars = max(sizes[6], 0);
     const int rolling_capacity = sizes[5];
     const float log_bin_scale = 127.0f / log(4000001.0f);
@@ -967,13 +1058,16 @@ inline void passivbot_single_coin_impl(
         }
 
         bool long_close_fill = false;
+        bool long_primary_market = long_side.close_is_panic
+            ? long_hsl_panic_market : long_side.close_market;
         bool long_primary_close_fill = valid && alive && long_enabled
             && long_side.close_qty > 0.0f && long_side.psize > 0.0f
-            && ((long_side.close_is_panic && long_hsl_panic_market)
+            && (long_primary_market
                 || long_side.close_ticks <= high_fill_max_tick);
         bool long_secondary_close_fill = valid && alive && long_enabled
             && long_side.secondary_close_qty > 0.0f && long_side.psize > 0.0f
-            && long_side.secondary_close_ticks <= high_fill_max_tick;
+            && (long_side.secondary_close_market
+                || long_side.secondary_close_ticks <= high_fill_max_tick);
         bool long_secondary_first = long_secondary_close_fill
             && (!long_primary_close_fill
                 || long_side.secondary_close_ticks < long_side.close_ticks);
@@ -986,21 +1080,18 @@ inline void passivbot_single_coin_impl(
                 ? long_side.secondary_close_ticks : long_side.close_ticks;
             float requested_qty = use_secondary
                 ? long_side.secondary_close_qty : long_side.close_qty;
-            bool market_panic = !use_secondary && long_side.close_is_panic
-                && long_hsl_panic_market;
-            float cp = market_panic
-                ? fmax(
-                    floor_step(
-                        close * (1.0f - market_order_slippage_pct), price_step
-                    ),
-                    price_step
+            bool market_execution = use_secondary
+                ? long_side.secondary_close_market : long_primary_market;
+            float cp = market_execution
+                ? ordinary_market_fill_price(
+                    close, false, market_order_slippage_pct, price_step
                 )
                 : float(close_ticks) * price_step;
             float adj = fmin(round_step(requested_qty, qty_step), long_side.psize);
             if (!(adj > 0.0f)) continue;
             float pnl = adj * c_mult * (cp - long_side.pprice);
             float fee = adj * cp * c_mult
-                * (market_panic ? taker_fee : maker_fee);
+                * (market_execution ? taker_fee : maker_fee);
             float net_pnl = pnl - fee;
             if (!use_secondary && long_side.close_is_panic) {
                 float current_equity = balance
@@ -1051,11 +1142,17 @@ inline void passivbot_single_coin_impl(
 
         bool long_entry_fill = valid && alive && long_enabled
             && long_side.entry_qty > 0.0f
-            && long_side.entry_ticks > low_nonfill_max_tick;
+            && (long_side.entry_market
+                || long_side.entry_ticks > low_nonfill_max_tick);
         if (long_entry_fill) {
-            float ep = float(long_side.entry_ticks) * price_step;
+            float ep = long_side.entry_market
+                ? ordinary_market_fill_price(
+                    close, true, market_order_slippage_pct, price_step
+                )
+                : float(long_side.entry_ticks) * price_step;
             float eq = round_step(long_side.entry_qty, qty_step);
-            float fee = eq * ep * c_mult * maker_fee;
+            float fee = eq * ep * c_mult
+                * (long_side.entry_market ? taker_fee : maker_fee);
             balance -= fee;
             record_realized_net(
                 -fee, realized_pnl_cumsum_last, realized_pnl_cumsum_max,
@@ -1084,13 +1181,16 @@ inline void passivbot_single_coin_impl(
         }
 
         bool short_close_fill = false;
+        bool short_primary_market = short_side.close_is_panic
+            ? short_hsl_panic_market : short_side.close_market;
         bool short_primary_close_fill = valid && alive && short_enabled
             && short_side.close_qty > 0.0f && short_side.psize > 0.0f
-            && ((short_side.close_is_panic && short_hsl_panic_market)
+            && (short_primary_market
                 || short_side.close_ticks > low_nonfill_max_tick);
         bool short_secondary_close_fill = valid && alive && short_enabled
             && short_side.secondary_close_qty > 0.0f && short_side.psize > 0.0f
-            && short_side.secondary_close_ticks > low_nonfill_max_tick;
+            && (short_side.secondary_close_market
+                || short_side.secondary_close_ticks > low_nonfill_max_tick);
         bool short_secondary_first = short_secondary_close_fill
             && (!short_primary_close_fill
                 || short_side.secondary_close_ticks > short_side.close_ticks);
@@ -1103,21 +1203,18 @@ inline void passivbot_single_coin_impl(
                 ? short_side.secondary_close_ticks : short_side.close_ticks;
             float requested_qty = use_secondary
                 ? short_side.secondary_close_qty : short_side.close_qty;
-            bool market_panic = !use_secondary && short_side.close_is_panic
-                && short_hsl_panic_market;
-            float cp = market_panic
-                ? fmax(
-                    ceil_step(
-                        close * (1.0f + market_order_slippage_pct), price_step
-                    ),
-                    price_step
+            bool market_execution = use_secondary
+                ? short_side.secondary_close_market : short_primary_market;
+            float cp = market_execution
+                ? ordinary_market_fill_price(
+                    close, true, market_order_slippage_pct, price_step
                 )
                 : float(close_ticks) * price_step;
             float adj = fmin(round_step(requested_qty, qty_step), short_side.psize);
             if (!(adj > 0.0f)) continue;
             float pnl = adj * c_mult * (short_side.pprice - cp);
             float fee = adj * cp * c_mult
-                * (market_panic ? taker_fee : maker_fee);
+                * (market_execution ? taker_fee : maker_fee);
             float net_pnl = pnl - fee;
             if (!use_secondary && short_side.close_is_panic) {
                 float current_equity = balance
@@ -1168,11 +1265,17 @@ inline void passivbot_single_coin_impl(
 
         bool short_entry_fill = valid && alive && short_enabled
             && short_side.entry_qty > 0.0f
-            && short_side.entry_ticks <= high_fill_max_tick;
+            && (short_side.entry_market
+                || short_side.entry_ticks <= high_fill_max_tick);
         if (short_entry_fill) {
-            float ep = float(short_side.entry_ticks) * price_step;
+            float ep = short_side.entry_market
+                ? ordinary_market_fill_price(
+                    close, false, market_order_slippage_pct, price_step
+                )
+                : float(short_side.entry_ticks) * price_step;
             float eq = round_step(short_side.entry_qty, qty_step);
-            float fee = eq * ep * c_mult * maker_fee;
+            float fee = eq * ep * c_mult
+                * (short_side.entry_market ? taker_fee : maker_fee);
             balance -= fee;
             record_realized_net(
                 -fee, realized_pnl_cumsum_last, realized_pnl_cumsum_max,
@@ -1295,14 +1398,16 @@ inline void passivbot_single_coin_impl(
                 generate_long_orders(
                     long_side, balance, close, touch_down_tick, touch_up_tick,
                     qty_step, price_step, min_qty, min_cost, c_mult, kf,
-                    block_long_initial
+                    block_long_initial, market_orders_allowed,
+                    market_order_near_touch_threshold
                 );
             }
             if (short_enabled) {
                 generate_short_orders(
                     short_side, balance, close, touch_down_tick, touch_up_tick,
                     qty_step, price_step, min_qty, min_cost, c_mult, kf,
-                    block_short_initial
+                    block_short_initial, market_orders_allowed,
+                    market_order_near_touch_threshold
                 );
             }
 
@@ -1469,6 +1574,63 @@ inline void passivbot_single_coin_impl(
                 short_side.secondary_close_qty = 0.0f;
                 short_side.close_is_protective_reducer = false;
                 short_side.close_is_panic = true;
+            }
+
+            if (long_enabled) {
+                long_side.close_market = !long_side.close_is_panic
+                    && long_side.close_qty > 0.0f
+                    && should_use_ordinary_market_execution(
+                        long_side.close_ticks, false, close, price_step,
+                        market_orders_allowed,
+                        market_order_near_touch_threshold
+                    );
+                long_side.secondary_close_market =
+                    long_side.secondary_close_qty > 0.0f
+                    && should_use_ordinary_market_execution(
+                        long_side.secondary_close_ticks, false, close, price_step,
+                        market_orders_allowed,
+                        market_order_near_touch_threshold
+                    );
+                if (long_side.close_market) {
+                    long_side.close_qty = resize_market_close_qty(
+                        long_side.close_qty, long_side.psize, close,
+                        qty_step, min_qty, min_cost, c_mult
+                    );
+                }
+                if (long_side.secondary_close_market) {
+                    long_side.secondary_close_qty = resize_market_close_qty(
+                        long_side.secondary_close_qty, long_side.psize, close,
+                        qty_step, min_qty, min_cost, c_mult
+                    );
+                }
+            }
+            if (short_enabled) {
+                short_side.close_market = !short_side.close_is_panic
+                    && short_side.close_qty > 0.0f
+                    && should_use_ordinary_market_execution(
+                        short_side.close_ticks, true, close, price_step,
+                        market_orders_allowed,
+                        market_order_near_touch_threshold
+                    );
+                short_side.secondary_close_market =
+                    short_side.secondary_close_qty > 0.0f
+                    && should_use_ordinary_market_execution(
+                        short_side.secondary_close_ticks, true, close, price_step,
+                        market_orders_allowed,
+                        market_order_near_touch_threshold
+                    );
+                if (short_side.close_market) {
+                    short_side.close_qty = resize_market_close_qty(
+                        short_side.close_qty, short_side.psize, close,
+                        qty_step, min_qty, min_cost, c_mult
+                    );
+                }
+                if (short_side.secondary_close_market) {
+                    short_side.secondary_close_qty = resize_market_close_qty(
+                        short_side.secondary_close_qty, short_side.psize, close,
+                        qty_step, min_qty, min_cost, c_mult
+                    );
+                }
             }
         }
 

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -306,6 +306,8 @@ GPU_SUPPORTED_SUITE_NON_BOT_OVERRIDE_PATHS = {
     ("live", "forager_score_hysteresis_pct"),
     ("live", "hedge_mode"),
     ("live", "hsl_signal_mode"),
+    ("live", "market_order_near_touch_threshold"),
+    ("live", "market_orders_allowed"),
     ("live", "max_realized_loss_pct"),
     ("live", "pnls_max_lookback_days"),
 }
@@ -923,11 +925,6 @@ def _validate_scope_config(
                 "backtest.liquidation_threshold so the proxy has a proven lower "
                 "balance bound"
             )
-    if bool(config.get("live", {}).get("market_orders_allowed")):
-        raise ValueError(
-            "GPU foundation requires live.market_orders_allowed=false because the "
-            "screening proxy models resting maker orders only"
-        )
     if float(config.get("backtest", {}).get("btc_collateral_cap", 0.0) or 0.0) > 0.0:
         raise ValueError("GPU foundation does not support backtest.btc_collateral_cap")
     max_realized_loss_pct = float(
@@ -959,6 +956,53 @@ def _validate_scope_config(
     enabled_sides = [side for side in ("long", "short") if gpu_side_enabled(config, side)]
     if not enabled_sides:
         raise ValueError("GPU foundation requires at least one enabled side")
+    if bool(config.get("live", {}).get("market_orders_allowed")):
+        threshold = float(
+            config.get("live", {}).get("market_order_near_touch_threshold", 0.001)
+            or 0.0
+        )
+        if not math.isfinite(threshold) or threshold < 0.0:
+            raise ValueError(
+                "GPU market execution requires a finite non-negative "
+                "live.market_order_near_touch_threshold"
+            )
+        if strategy_kind != "ema_anchor" or coin_count != 1:
+            raise ValueError(
+                "GPU ordinary market execution currently requires single-coin "
+                "strategy_kind=ema_anchor"
+            )
+        if bool(config.get("backtest", {}).get("filter_by_min_effective_cost")):
+            raise ValueError(
+                "GPU ordinary market execution currently requires "
+                "backtest.filter_by_min_effective_cost=false"
+            )
+        if max_realized_loss_pct < 1.0:
+            raise ValueError(
+                "GPU ordinary market execution currently requires "
+                "live.max_realized_loss_pct>=1 until market-close loss gating "
+                "is modeled"
+            )
+        for side in enabled_sides:
+            side_config = config["bot"][side]
+            if bool(side_config.get("hsl", {}).get("enabled")):
+                raise ValueError(
+                    "GPU ordinary market execution currently requires "
+                    f"bot.{side}.hsl.enabled=false"
+                )
+            if bool(side_config.get("unstuck", {}).get("enabled")):
+                raise ValueError(
+                    "GPU ordinary market execution currently requires "
+                    f"bot.{side}.unstuck.enabled=false"
+                )
+            if bool(
+                side_config.get("risk", {}).get(
+                    "total_exposure_enforcer_enabled", False
+                )
+            ):
+                raise ValueError(
+                    "GPU ordinary market execution currently requires "
+                    f"bot.{side}.risk.total_exposure_enforcer_enabled=false"
+                )
     if bool(config.get("backtest", {}).get("filter_by_min_effective_cost")) and len(
         enabled_sides
     ) != 1:

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -522,6 +522,8 @@ class MpsEmaAnchorRunner:
         max_realized_loss_pct: float = 1.0,
         taker_fee: float | None = None,
         market_order_slippage_pct: float = 0.0,
+        market_orders_allowed: bool = False,
+        market_order_near_touch_threshold: float = 0.001,
         hsl_panic_market_long: bool = False,
         hsl_panic_market_short: bool = False,
         pnl_lookback_bars: int = 0,
@@ -546,6 +548,9 @@ class MpsEmaAnchorRunner:
         )
         taker_fee = market.maker_fee if taker_fee is None else float(taker_fee)
         market_order_slippage_pct = float(market_order_slippage_pct)
+        market_order_near_touch_threshold = float(
+            market_order_near_touch_threshold
+        )
         pnl_lookback_bars = int(pnl_lookback_bars)
         if not np.isfinite(taker_fee):
             raise ValueError("taker_fee must be finite")
@@ -555,6 +560,13 @@ class MpsEmaAnchorRunner:
         ):
             raise ValueError(
                 "market_order_slippage_pct must be finite and non-negative"
+            )
+        if (
+            not np.isfinite(market_order_near_touch_threshold)
+            or market_order_near_touch_threshold < 0.0
+        ):
+            raise ValueError(
+                "market_order_near_touch_threshold must be finite and non-negative"
             )
         if pnl_lookback_bars < 0:
             raise ValueError("pnl_lookback_bars must be non-negative")
@@ -638,6 +650,8 @@ class MpsEmaAnchorRunner:
                 market_order_slippage_pct,
                 float(bool(hsl_panic_market_long)),
                 float(bool(hsl_panic_market_short)),
+                float(bool(market_orders_allowed)),
+                market_order_near_touch_threshold,
             ],
             dtype=torch.float32,
             device="mps",
@@ -1528,6 +1542,10 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
     """Persistent single-coin trailing-martingale runner on Apple MPS."""
 
     def __init__(self, *args, hsl_enabled: bool = True, **kwargs):
+        if bool(kwargs.get("market_orders_allowed", False)):
+            raise ValueError(
+                "MPS trailing-martingale ordinary market execution is not modeled yet"
+            )
         super().__init__(*args, **kwargs)
         self.shader_topology = trailing_martingale_shader_topology(
             long_enabled=self.long_enabled,

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -1342,6 +1342,12 @@ class MpsSingleCoinProxy:
             market_order_slippage_pct=float(
                 backtest_params.get("market_order_slippage_pct", 0.0)
             ),
+            market_orders_allowed=bool(
+                backtest_params.get("market_orders_allowed", False)
+            ),
+            market_order_near_touch_threshold=float(
+                backtest_params.get("market_order_near_touch_threshold", 0.001)
+            ),
             hsl_panic_market_long=hsl_panic_market["long"],
             hsl_panic_market_short=hsl_panic_market["short"],
             pnl_lookback_bars=pnl_lookback_bars,

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -692,6 +692,16 @@ def test_gpu_suite_inputs_reject_unsupported_scenario_scope(
         ("live.hedge_mode", True, ("live", "hedge_mode")),
         ("live.hsl_signal_mode", "coin", ("live", "hsl_signal_mode")),
         (
+            "live.market_order_near_touch_threshold",
+            0.002,
+            ("live", "market_order_near_touch_threshold"),
+        ),
+        (
+            "live.market_orders_allowed",
+            True,
+            ("live", "market_orders_allowed"),
+        ),
+        (
             "live.max_realized_loss_pct",
             0.05,
             ("live", "max_realized_loss_pct"),
@@ -1514,12 +1524,6 @@ def test_suite_limit_metric_value_respects_reducer_and_scenario():
         (lambda config: config["backtest"].__setitem__("suite_enabled", True), "suite"),
         (
             lambda config: config["live"].__setitem__(
-                "market_orders_allowed", True
-            ),
-            "market_orders_allowed",
-        ),
-        (
-            lambda config: config["live"].__setitem__(
                 "strategy_kind", "trailing_grid_v7"
             ),
             "trailing_martingale",
@@ -1554,6 +1558,86 @@ def test_gpu_foundation_fails_closed_for_unsupported_scope(mutate, message):
 
 def test_gpu_foundation_accepts_ema_long_single():
     assert _validate_scope(_long_only_ema_config(), _Evaluator()) == "bybit"
+
+
+def test_gpu_foundation_accepts_baseline_ema_single_coin_market_execution():
+    config = _long_only_ema_config()
+    config["live"]["market_orders_allowed"] = True
+    config["live"]["market_order_near_touch_threshold"] = 0.002
+
+    assert _validate_scope(config, _Evaluator()) == "bybit"
+
+
+@pytest.mark.parametrize(
+    ("mutate", "evaluator", "message"),
+    [
+        (
+            lambda config: config["live"].__setitem__(
+                "strategy_kind", "trailing_martingale"
+            ),
+            _Evaluator,
+            "single-coin strategy_kind=ema_anchor",
+        ),
+        (
+            lambda config: config["live"].__setitem__(
+                "market_order_near_touch_threshold", -0.1
+            ),
+            _Evaluator,
+            "finite non-negative",
+        ),
+        (
+            lambda config: config["backtest"].__setitem__(
+                "filter_by_min_effective_cost", True
+            ),
+            _Evaluator,
+            "filter_by_min_effective_cost=false",
+        ),
+        (
+            lambda config: config["live"].__setitem__(
+                "max_realized_loss_pct", 0.5
+            ),
+            _Evaluator,
+            "max_realized_loss_pct>=1",
+        ),
+        (
+            lambda config: config["bot"]["long"]["hsl"].__setitem__(
+                "enabled", True
+            ),
+            _Evaluator,
+            "hsl.enabled=false",
+        ),
+        (
+            lambda config: config["bot"]["long"]["unstuck"].__setitem__(
+                "enabled", True
+            ),
+            _Evaluator,
+            "unstuck.enabled=false",
+        ),
+        (
+            lambda config: config["bot"]["long"]["risk"].__setitem__(
+                "total_exposure_enforcer_enabled", True
+            ),
+            _Evaluator,
+            "total_exposure_enforcer_enabled=false",
+        ),
+        (
+            lambda config: config["live"]["approved_coins"].__setitem__(
+                "long", ["BTC", "ETH"]
+            ),
+            _MulticoinEvaluator,
+            "single-coin strategy_kind=ema_anchor",
+        ),
+    ],
+)
+def test_gpu_market_execution_fails_closed_outside_baseline_scope(
+    mutate, evaluator, message
+):
+    config = _long_only_ema_config()
+    config["live"]["market_orders_allowed"] = True
+    mutate(config)
+
+    with pytest.raises(ValueError, match=message):
+        _validate_scope(config, evaluator())
 
 
 def test_gpu_foundation_accepts_one_sided_single_coin_hsl():

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -227,6 +227,18 @@ def test_trailing_martingale_no_hsl_specialization_keeps_base_scalar_abi(
     assert runner.hsl_raw_drawdown_enabled is False
 
 
+def test_trailing_martingale_runner_rejects_unmodeled_ordinary_market_execution():
+    from optimization.gpu.mps_kernel import MpsTrailingMartingaleRunner
+
+    with pytest.raises(ValueError, match="ordinary market execution is not modeled"):
+        MpsTrailingMartingaleRunner(
+            None,
+            None,
+            None,
+            market_orders_allowed=True,
+        )
+
+
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
@@ -4337,7 +4349,9 @@ def test_mps_ema_anchor_shader_smoke():
     assert "const float market_order_slippage_pct = fmax(settings[16], 0.0f)" in source
     assert "const bool long_hsl_panic_market = settings[17] > 0.5f" in source
     assert "const bool short_hsl_panic_market = settings[18] > 0.5f" in source
-    assert "market_panic ? taker_fee : maker_fee" in source
+    assert "const bool market_orders_allowed = settings[19] > 0.5f" in source
+    assert "const float market_order_near_touch_threshold = fmax(settings[20], 0.0f)" in source
+    assert "market_execution ? taker_fee : maker_fee" in source
     assert "constant int SCALAR_COLS = 68" in source
     assert "scalars[so + 50] = fill_count" in source
     assert "scalars[so + 51] = fill_count_entry" in source
@@ -4450,6 +4464,92 @@ def test_mps_ema_anchor_shader_smoke():
         output["total_wallet_exposure_max"]
         >= output["total_wallet_exposure_mean"]
     ).all()
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_ema_anchor_near_touch_market_entry_uses_next_close_and_taker_fee(side):
+    count = 5
+    close = np.full(count, 100.0)
+    high = np.full(count, 100.0)
+    low = np.full(count, 100.0)
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(
+        qty_step=0.001,
+        price_step=0.01,
+        min_qty=0.001,
+        min_cost=0.0,
+        c_mult=1.0,
+        maker_fee=0.0,
+        taker_fee=0.01,
+    )
+    run = ProxyRun(
+        starting_balance=1_000.0,
+        warmup_bars=1,
+        trade_start_idx=1,
+        requested_start_ts_ms=int(timestamps[0]),
+        guard_ts_ms=int(timestamps[0]),
+        first_ts_ms=int(timestamps[0]),
+        interval_ms=60_000,
+        liquidation_threshold=0.05,
+        first_valid_idx=0,
+        last_valid_idx=count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = [
+        0.1,
+        2.0,
+        3.0,
+        0.0,
+        0.0005,
+        0.0,
+        0.0,
+        0.0,
+        2.0,
+        2.0,
+        0.0,
+        1.0,
+    ]
+    row += _single_coin_exposure_fields() + _tm_twel_enforcer_fields()
+    parameters = np.asarray([row + row], dtype=np.float64)
+    common = {
+        "long_enabled": side == "long",
+        "short_enabled": side == "short",
+        "hedge_mode": True,
+    }
+
+    resting = MpsEmaAnchorRunner(market, run, data, **common).run(parameters)
+    promoted_runner = MpsEmaAnchorRunner(
+        market,
+        run,
+        data,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.001,
+        market_order_slippage_pct=0.01,
+        taker_fee=market.taker_fee,
+        **common,
+    )
+    promoted = promoted_runner.run(parameters)
+    torch.mps.synchronize()
+
+    assert promoted_runner.settings[19].item() == 1.0
+    assert promoted_runner.settings[20].item() == pytest.approx(0.001)
+    assert resting["fill_count"].item() == 0.0
+    assert promoted["fill_count"].item() == 1.0
+    if side == "long":
+        expected_qty = 1.001
+        expected_price = 101.0
+        assert promoted["psize"].item() == pytest.approx(expected_qty)
+        assert promoted["pprice"].item() == pytest.approx(expected_price)
+    else:
+        expected_qty = 1.0
+        expected_price = 99.0
+        assert promoted["short_psize"].item() == pytest.approx(expected_qty)
+        assert promoted["short_pprice"].item() == pytest.approx(expected_price)
+    expected_balance = 1_000.0 - expected_qty * expected_price * market.taker_fee
+    assert promoted["balance"].item() == pytest.approx(expected_balance, abs=2.0e-4)
 
 
 @pytest.mark.skipif(
@@ -6215,7 +6315,10 @@ def test_mps_recovery_fails_closed_on_coin_hsl_rolling_overflow(strategy_kind):
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("hedge_mode", [False, True])
-def test_mps_dual_side_respects_one_way_initial_arbitration(hedge_mode):
+@pytest.mark.parametrize("market_orders_allowed", [False, True])
+def test_mps_dual_side_respects_one_way_initial_arbitration(
+    hedge_mode, market_orders_allowed
+):
     count = 5
     close = np.full(count, 100.0)
     high = np.array([100.0, 100.0, 100.0, 102.0, 100.0])
@@ -6252,6 +6355,8 @@ def test_mps_dual_side_respects_one_way_initial_arbitration(hedge_mode):
         long_enabled=True,
         short_enabled=True,
         hedge_mode=hedge_mode,
+        market_orders_allowed=market_orders_allowed,
+        market_order_near_touch_threshold=0.02,
     ).run(np.array([row + row], dtype=np.float64))
     torch.mps.synchronize()
 


### PR DESCRIPTION
## Summary

- add ordinary market-order promotion to the single-coin EMA Anchor Metal proxy
- preserve next-candle execution, adverse directional slippage, taker fees, executable-touch sizing, and one-way arbitration
- allow compatible suite overrides while keeping Trailing Martingale, multi-coin, HSL, unstuck, exposure repair, realized-loss gating, and minimum-effective-cost combinations fail closed
- document the supported boundary and add changelog coverage

Trailing Grid v7 remains intentionally outside GPU optimizer scope.

## Validation

- cargo test --no-default-features: 267 passed
- cargo check --tests: passed
- focused optimizer/backend/service/metrics/suite tests: 602 passed
- complete physical Apple M3 MPS module: 312 passed
- repository-managed Rust extension rebuild and source fingerprint verification: matched
- physical Apple M3 suite smoke: 512 Metal proxy evaluations plus 32 exact Rust validations, completed cleanly with no drift halt
- git diff --check: passed