### PR TITLE
feat(gpu): combine EMA market execution with HSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Extended single-coin EMA Anchor ordinary market-order optimization on Apple MPS to compatible
+  HSL modes and one-sided minimum-effective-cost filtering. Unstuck, exposure-repair, and
+  realized-loss-gate combinations remain fail closed pending their execution-ordering slice.
+
 - Added baseline ordinary market-order execution to Apple MPS optimization for single-coin EMA
   Anchor, including near-touch promotion, next-candle adverse slippage, taker fees, executable-touch
-  sizing, directional and one-way modes, and compatible suites. HSL, auto-unstuck, exposure repair,
-  realized-loss gating, minimum-effective-cost filtering, Trailing Martingale, and multi-coin
-  combinations remain fail closed while their market-order interactions are implemented.
+  sizing, directional and one-way modes, and compatible suites. Auto-unstuck, exposure repair,
+  realized-loss gating, Trailing Martingale, and multi-coin combinations remain fail closed while
+  their market-order interactions are implemented.
 
 - Added Apple MPS suite scenario overrides for `live.hsl_signal_mode`. Coin, position-side, and
   unified HSL signal topology may now vary by scenario when each effective scenario passes the

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -279,9 +279,10 @@ The supported slice is intentionally narrow:
   another flat side or coin
 - `live.market_orders_allowed: false` for the complete strategy/risk surface. Single-coin EMA
   Anchor also supports `true` for long-only, short-only, hedge-mode dual-side, one-way, and
-  compatible suite scenarios when HSL, auto-unstuck, and total-exposure repair are disabled,
-  `live.max_realized_loss_pct >= 1`, and minimum-effective-cost filtering is disabled. The Metal
-  proxy classifies each generated order against the current candle close using
+  compatible suite scenarios when auto-unstuck and total-exposure repair are disabled and
+  `live.max_realized_loss_pct >= 1`. Single-coin HSL and the existing one-sided
+  minimum-effective-cost filter are supported in combination with ordinary market execution. The
+  Metal proxy classifies each generated order against the current candle close using
   `live.market_order_near_touch_threshold`, retains that execution intent for the pending order,
   and fills promoted orders on the next valid candle at its adversely slipped, directionally
   rounded close with the taker fee. Market closes and short entries are resized at the executable

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -971,11 +971,6 @@ def _validate_scope_config(
                 "GPU ordinary market execution currently requires single-coin "
                 "strategy_kind=ema_anchor"
             )
-        if bool(config.get("backtest", {}).get("filter_by_min_effective_cost")):
-            raise ValueError(
-                "GPU ordinary market execution currently requires "
-                "backtest.filter_by_min_effective_cost=false"
-            )
         if max_realized_loss_pct < 1.0:
             raise ValueError(
                 "GPU ordinary market execution currently requires "
@@ -984,11 +979,6 @@ def _validate_scope_config(
             )
         for side in enabled_sides:
             side_config = config["bot"][side]
-            if bool(side_config.get("hsl", {}).get("enabled")):
-                raise ValueError(
-                    "GPU ordinary market execution currently requires "
-                    f"bot.{side}.hsl.enabled=false"
-                )
             if bool(side_config.get("unstuck", {}).get("enabled")):
                 raise ValueError(
                     "GPU ordinary market execution currently requires "

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1586,25 +1586,11 @@ def test_gpu_foundation_accepts_baseline_ema_single_coin_market_execution():
             "finite non-negative",
         ),
         (
-            lambda config: config["backtest"].__setitem__(
-                "filter_by_min_effective_cost", True
-            ),
-            _Evaluator,
-            "filter_by_min_effective_cost=false",
-        ),
-        (
             lambda config: config["live"].__setitem__(
                 "max_realized_loss_pct", 0.5
             ),
             _Evaluator,
             "max_realized_loss_pct>=1",
-        ),
-        (
-            lambda config: config["bot"]["long"]["hsl"].__setitem__(
-                "enabled", True
-            ),
-            _Evaluator,
-            "hsl.enabled=false",
         ),
         (
             lambda config: config["bot"]["long"]["unstuck"].__setitem__(
@@ -1638,6 +1624,37 @@ def test_gpu_market_execution_fails_closed_outside_baseline_scope(
 
     with pytest.raises(ValueError, match=message):
         _validate_scope(config, evaluator())
+
+
+@pytest.mark.parametrize("signal_mode", ["unified", "pside", "coin"])
+def test_gpu_market_execution_accepts_single_coin_ema_hsl(signal_mode):
+    config = _long_only_ema_config()
+    config["live"]["market_orders_allowed"] = True
+    config["live"]["hsl_signal_mode"] = signal_mode
+    config["live"]["pnls_max_lookback_days"] = "all"
+    config["bot"]["long"]["hsl"]["enabled"] = True
+
+    assert _validate_scope(config, _Evaluator()) == "bybit"
+
+
+def test_gpu_market_execution_accepts_hsl_with_min_effective_cost_filter():
+    config = _long_only_ema_config()
+    config["live"]["market_orders_allowed"] = True
+    config["live"]["hsl_signal_mode"] = "coin"
+    config["live"]["pnls_max_lookback_days"] = "all"
+    config["bot"]["long"]["hsl"]["enabled"] = True
+    config["backtest"]["filter_by_min_effective_cost"] = True
+
+    assert _validate_scope(config, _Evaluator()) == "bybit"
+
+
+def test_gpu_market_execution_rejects_dual_side_min_effective_cost_filter():
+    config = _directional_ema_config(long_enabled=True, short_enabled=True)
+    config["live"]["market_orders_allowed"] = True
+    config["backtest"]["filter_by_min_effective_cost"] = True
+
+    with pytest.raises(ValueError, match="requires exactly one enabled side"):
+        _validate_scope(config, _Evaluator())
 
 
 def test_gpu_foundation_accepts_one_sided_single_coin_hsl():

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -6706,6 +6706,25 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
     market_output = market_runner.run(
         np.asarray([rows[1]], dtype=np.float64)
     )
+    ordinary_market_runner = None
+    ordinary_market_output = None
+    if strategy_kind == "ema_anchor":
+        ordinary_market_runner = runner_cls(
+            market,
+            run,
+            data,
+            long_enabled=side == "long",
+            short_enabled=side == "short",
+            taker_fee=0.01,
+            market_order_slippage_pct=0.02,
+            market_orders_allowed=True,
+            market_order_near_touch_threshold=0.001,
+            hsl_panic_market_long=side == "long",
+            hsl_panic_market_short=side == "short",
+        )
+        ordinary_market_output = ordinary_market_runner.run(
+            np.asarray([rows[1]], dtype=np.float64)
+        )
     gated_output = runner_cls(
         market,
         run,
@@ -6775,6 +6794,13 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
         market_output["hsl_panic_close_loss_sum"].item()
         > output["hsl_panic_close_loss_sum"][1].item()
     )
+    if strategy_kind == "ema_anchor":
+        assert ordinary_market_runner.settings[19].item() == 1.0
+        assert ordinary_market_output[size_key].item() == 0.0
+        assert ordinary_market_output[trigger_key].item() == 1.0
+        assert ordinary_market_output["hsl_flatten_time_count"].item() == 1.0
+        assert ordinary_market_output["hsl_panic_close_loss_sum"].item() > 0.0
+        assert torch.isfinite(ordinary_market_output["balance"]).all()
 
 
 @pytest.mark.skipif(
@@ -10701,6 +10727,60 @@ def test_mps_min_effective_cost_uses_downward_projected_cost_bound():
 
     assert output["day_has_fill"].sum().item() == 0
     assert output["psize"].item() == 0.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_short_market_entry_respects_eligible_min_effective_cost_filter():
+    count = 5
+    close = np.full(count, 100.0)
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 4.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(close, close, close, timestamps, run, market)
+    row = [
+        0.1,
+        2.0,
+        3.0,
+        0.0,
+        0.0005,
+        0.0,
+        0.0,
+        0.0,
+        2.0,
+        2.0,
+        0.0,
+        1.0,
+    ]
+    row += _single_coin_exposure_fields() + _tm_twel_enforcer_fields()
+
+    output = MpsEmaAnchorRunner(
+        market,
+        run,
+        data,
+        long_enabled=False,
+        short_enabled=True,
+        filter_by_min_effective_cost=True,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.001,
+    ).run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert output["fill_count"].item() == 1.0
+    assert output["short_psize"].item() == pytest.approx(1.0)
+    assert output["short_pprice"].item() == pytest.approx(100.0)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary

- enable single-coin EMA Anchor ordinary market execution with all supported HSL signal modes
- enable the existing conservative one-sided minimum-effective-cost filter alongside market execution, including simultaneous HSL use
- keep auto-unstuck, exposure reducers, realized-loss gating, Trailing Martingale, and multi-coin market combinations fail closed
- document the expanded support boundary and retain the explicit Trailing Grid v7 exclusion

This is an orchestration scope promotion only: the Metal execution semantics landed in #1621 and are now directly validated in these combinations.

## Validation

- optimizer/backend/service/metrics/suite tests: 605 passed
- complete physical Apple M3 MPS module: 313 passed
- focused HSL plus ordinary-market physical tests: passed for long and short EMA Anchor
- bounded two-scenario physical M3 suite smoke: 512 proxy evaluations plus 32 exact Rust validations across market+HSL and market+HSL+min-cost, completed with no drift halt
- Python compileall: passed
- git diff --check: passed