### PR TITLE
feat(gpu): support TM ordinary market execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added baseline ordinary market-order execution to Apple MPS optimization for single-coin
+  Trailing Martingale, covering long, short, and dual-side near-touch entries and ordinary closes,
+  recursive entry/close ladders, executable-touch minimum sizing, adverse slippage, and taker fees.
+  HSL, auto-unstuck, exposure repair, realized-loss gating, and multi-coin combinations remain fail
+  closed until their Trailing Martingale market-order interactions are implemented.
+
 - Extended single-coin EMA Anchor ordinary market-order optimization on Apple MPS to compatible
   HSL modes, one-sided minimum-effective-cost filtering, auto-unstuck, total-exposure repair, and
   realized-loss gating. Market-promoted closes are resized at executable touch before reducer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable user-facing changes will be documented in this file.
 ## Unreleased
 
 - Added baseline ordinary market-order execution to Apple MPS optimization for single-coin
-  Trailing Martingale, covering long, short, and dual-side near-touch entries and ordinary closes,
-  recursive entry/close ladders, executable-touch minimum sizing, adverse slippage, and taker fees.
+  Trailing Martingale, covering long, short, and dual-side near-touch trailing entries and closes,
+  executable-touch minimum sizing, adverse slippage, and taker fees. Recursive entry/close modes,
   HSL, auto-unstuck, exposure repair, realized-loss gating, and multi-coin combinations remain fail
   closed until their Trailing Martingale market-order interactions are implemented.
 

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -670,7 +670,7 @@ mod tests {
         assert!(source.contains("h.restart_retrigger_count"));
         assert!(source.contains("h.halt_duration_sum_steps"));
         assert!(source.contains("record_hsl_panic_fill("));
-        assert!(source.contains("market_panic ? taker_fee : maker_fee"));
+        assert!(source.contains("market_execution ? taker_fee : maker_fee"));
         assert!(source.contains("h.panic_loss_drawdown_sum"));
         assert!(source.contains("&& !long_side.close_is_panic"));
         assert!(source.contains("&& !short_side.close_is_panic"));
@@ -736,9 +736,17 @@ mod tests {
         assert!(source.contains("const float market_order_slippage_pct = fmax(settings[16], 0.0f)"));
         assert!(source.contains("const bool long_hsl_panic_market = settings[17] > 0.5f"));
         assert!(source.contains("const bool short_hsl_panic_market = settings[18] > 0.5f"));
-        assert!(source.contains("market_panic ? taker_fee : maker_fee"));
+        assert!(source.contains("market_execution ? taker_fee : maker_fee"));
         assert!(source.contains("close * (1.0f - market_order_slippage_pct)"));
         assert!(source.contains("close * (1.0f + market_order_slippage_pct)"));
+        assert!(source.contains("const bool market_orders_allowed = settings[19] > 0.5f"));
+        assert!(source
+            .contains("const float market_order_near_touch_threshold = fmax(settings[20], 0.0f)"));
+        assert!(source.contains("should_use_ordinary_market_execution("));
+        assert!(source.contains("ordinary_market_fill_price("));
+        assert!(source.contains("resize_market_close_qty("));
+        assert!(source.contains("entry_gen_market_price"));
+        assert!(source.contains("close_gen_market_price"));
         assert!(source.contains("the proxy uses a zero-loss envelope"));
         assert!(source.contains("int grid_rung_limit = strategy_wel_qty > 0.0f ? 499 : 500"));
         assert!(source.contains("long_side.close_gen_psize - strategy_wel_qty"));

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -41,6 +41,64 @@ inline float min_entry_qty(
     return aligned ? fmax(nearest, raw_min) : ceil(raw_steps) * qty_step;
 }
 
+inline bool should_use_ordinary_market_execution(
+    int order_ticks,
+    bool buy_order,
+    float market_price,
+    float price_step,
+    bool market_orders_allowed,
+    float market_order_near_touch_threshold
+) {
+    if (!market_orders_allowed || order_ticks <= 0
+        || !(market_price > 0.0f) || !isfinite(market_price)) {
+        return false;
+    }
+    float order_price = float(order_ticks) * price_step;
+    if (buy_order ? order_price >= market_price : order_price <= market_price) {
+        return true;
+    }
+    return fabs(order_price / market_price - 1.0f)
+        <= fmax(market_order_near_touch_threshold, 0.0f);
+}
+
+inline float ordinary_market_fill_price(
+    float market_price,
+    bool buy_order,
+    float market_order_slippage_pct,
+    float price_step
+) {
+    float slipped = market_price * (
+        buy_order
+            ? 1.0f + market_order_slippage_pct
+            : 1.0f - market_order_slippage_pct
+    );
+    return fmax(
+        buy_order ? ceil_step(slipped, price_step) : floor_step(slipped, price_step),
+        price_step
+    );
+}
+
+inline float resize_market_close_qty(
+    float qty,
+    float psize,
+    float market_price,
+    float qty_step,
+    float min_qty,
+    float min_cost,
+    float c_mult
+) {
+    if (!(qty > 0.0f) || !(psize > 0.0f)) return 0.0f;
+    float minimum = min_entry_qty(
+        market_price, qty_step, min_qty, min_cost, c_mult
+    );
+    float tolerance = 1.0e-12f * fmax(qty, minimum) * 4.0f;
+    if (qty + tolerance >= minimum || psize <= qty) return fmin(qty, psize);
+    float resized = fmin(minimum, psize);
+    float remainder = psize - resized;
+    if (remainder > 0.0f && remainder + tolerance < minimum) resized = psize;
+    return resized;
+}
+
 inline bool passes_min_effective_cost(
     bool enabled, float guaranteed_balance_lower, float wel,
     float initial_qty_pct, float max_effective_min_cost
@@ -213,14 +271,19 @@ struct TmSide {
     bool close_is_unstuck_reducer;
     bool close_loss_gate_disabled_reducers;
     bool close_is_panic;
+    bool entry_market, close_market, secondary_close_market;
+    bool market_orders_allowed;
+    float market_order_near_touch_threshold;
     float ema0, ema1, ema2, vol1m, vol1h;
     float psize, pprice, last_inc_k, pos_open_k;
     int entry_ticks, close_ticks, secondary_close_ticks;
     float entry_price, close_price, entry_qty, close_qty;
     float secondary_close_price, secondary_close_qty;
     float entry_gen_balance, entry_gen_psize, entry_gen_pprice, entry_gen_kf;
+    float entry_gen_market_price;
     int entry_gen_touch_ticks;
     float close_gen_balance, close_gen_psize, close_gen_pprice;
+    float close_gen_market_price;
     int close_gen_touch_down_ticks, close_gen_touch_up_ticks;
     int close_gen_touch_nearest_ticks;
     float close_gen_touch_min_qty;
@@ -311,6 +374,11 @@ inline TmSide load_side(constant float* p, int o, float seed) {
     s.close_is_unstuck_reducer = false;
     s.close_loss_gate_disabled_reducers = false;
     s.close_is_panic = false;
+    s.entry_market = false;
+    s.close_market = false;
+    s.secondary_close_market = false;
+    s.market_orders_allowed = false;
+    s.market_order_near_touch_threshold = 0.0f;
     s.ema0 = seed; s.ema1 = seed; s.ema2 = seed;
     s.vol1m = 0.0f; s.vol1h = 0.0f;
     s.psize = 0.0f; s.pprice = 0.0f;
@@ -323,8 +391,10 @@ inline TmSide load_side(constant float* p, int o, float seed) {
     s.entry_gen_balance = 0.0f;
     s.entry_gen_psize = 0.0f; s.entry_gen_pprice = 0.0f;
     s.entry_gen_kf = -1.0f; s.entry_gen_touch_ticks = 0;
+    s.entry_gen_market_price = 0.0f;
     s.close_gen_balance = 0.0f;
     s.close_gen_psize = 0.0f; s.close_gen_pprice = 0.0f;
+    s.close_gen_market_price = 0.0f;
     s.close_gen_touch_down_ticks = 0; s.close_gen_touch_up_ticks = 0;
     s.close_gen_touch_nearest_ticks = 0;
     s.close_gen_touch_min_qty = 0.0f;
@@ -659,9 +729,11 @@ inline void generate_orders(
     s.entry_gen_pprice = s.pprice;
     s.entry_gen_kf = kf;
     s.entry_gen_touch_ticks = entry_touch;
+    s.entry_gen_market_price = price_now;
     s.close_gen_balance = balance;
     s.close_gen_psize = s.psize;
     s.close_gen_pprice = s.pprice;
+    s.close_gen_market_price = price_now;
     s.close_gen_touch_down_ticks = touch_down_ticks;
     s.close_gen_touch_up_ticks = touch_up_ticks;
     s.close_gen_touch_nearest_ticks = touch_nearest_ticks;
@@ -674,6 +746,7 @@ inline void generate_orders(
     s.secondary_close_ticks = 0;
     s.secondary_close_price = 0.0f;
     s.secondary_close_qty = 0.0f;
+    s.secondary_close_market = false;
     int band_ticks = directional_ticks(
         band * (is_long ? 1.0f - s.initial_ema_dist
                         : 1.0f + s.initial_ema_dist),
@@ -776,6 +849,15 @@ inline void generate_orders(
     float eqty = flat ? iq : (partial ? iq_partial : (reentry_ok ? rq : 0.0f));
     int eticks = flat || partial ? initial_ticks : reentry_ticks;
     float eprice = flat || partial ? initial_price : reentry_price;
+    bool entry_market = should_use_ordinary_market_execution(
+        eticks, is_long, price_now, price_step, s.market_orders_allowed,
+        s.market_order_near_touch_threshold
+    );
+    float entry_exposure_price = entry_market ? price_now : eprice;
+    float market_min_q = entry_market
+        ? min_entry_qty(price_now, qty_step, min_qty, min_cost, c_mult)
+        : min_entry_qty(eprice, qty_step, min_qty, min_cost, c_mult);
+    if (!is_long && entry_market && eqty < market_min_q) eqty = market_min_q;
     bool cooldown = s.cooldown_min > 0.0f && s.last_inc_k >= 0.0f
         && kf < s.last_inc_k + s.cooldown_min;
     if (cooldown || balance <= 0.0f || s.initial_qty_pct <= 0.0f
@@ -784,9 +866,13 @@ inline void generate_orders(
     s.entry_ticks = eticks;
     s.entry_price = eprice;
     s.entry_qty = crop_entry(
-        s, balance, eprice, eqty,
+        s, balance, entry_exposure_price, eqty,
         qty_step, min_qty, min_cost, c_mult
     );
+    if (!is_long && entry_market && s.entry_qty + 1.0e-12f < market_min_q) {
+        s.entry_qty = 0.0f;
+    }
+    s.entry_market = entry_market && s.entry_qty > 0.0f;
 
     // Exact Rust selects the largest protective reducer before allocating the
     // ordinary close ladder.  Model both the per-position WEL repair and the
@@ -875,6 +961,17 @@ inline void generate_orders(
         ? calc_close_qty(
             s, balance, close_mq, close_mq_relation, pct, qty_step, c_mult
         ) : 0.0f;
+    s.close_market = s.close_qty > 0.0f
+        && should_use_ordinary_market_execution(
+            cticks, !is_long, price_now, price_step,
+            s.market_orders_allowed, s.market_order_near_touch_threshold
+        );
+    if (s.close_market) {
+        s.close_qty = resize_market_close_qty(
+            s.close_qty, s.psize, price_now,
+            qty_step, min_qty, min_cost, c_mult
+        );
+    }
     bool ordinary_can_accompany_reducer = wel_qty <= 0.0f
         && trailing_close && s.close_qty > 0.0f;
     float finalized_wel_qty = finalized_reducer_qty(
@@ -1127,6 +1224,8 @@ inline void passivbot_single_coin_impl(
     const float market_order_slippage_pct = fmax(settings[16], 0.0f);
     const bool long_hsl_panic_market = settings[17] > 0.5f;
     const bool short_hsl_panic_market = settings[18] > 0.5f;
+    const bool market_orders_allowed = settings[19] > 0.5f;
+    const float market_order_near_touch_threshold = fmax(settings[20], 0.0f);
     const int pnl_lookback_bars = max(sizes[6], 0);
     const int rolling_capacity = sizes[5];
     const bool loss_gate_enabled = max_realized_loss_pct < 1.0f;
@@ -1137,6 +1236,10 @@ inline void passivbot_single_coin_impl(
     const float seed_close = bars[seed_k * 5 + 2];
     TmSide long_side = load_side(params, po, seed_close);
     TmSide short_side = load_side(params, po + SIDE_PARAMS, seed_close);
+    long_side.market_orders_allowed = market_orders_allowed;
+    long_side.market_order_near_touch_threshold = market_order_near_touch_threshold;
+    short_side.market_orders_allowed = market_orders_allowed;
+    short_side.market_order_near_touch_threshold = market_order_near_touch_threshold;
     HslState long_hsl = load_hsl(params, po, 40);
     HslState short_hsl = load_hsl(params, po + SIDE_PARAMS, 40);
     HslStrategyEquityStats long_hsl_strategy_eq = init_hsl_strategy_equity_stats();
@@ -1273,11 +1376,13 @@ inline void passivbot_single_coin_impl(
             && long_side.close_qty > 0.0f && long_side.psize > 0.0f;
         bool long_secondary_close_fill = valid && alive && long_enabled
             && long_side.secondary_close_qty > 0.0f
-            && long_side.secondary_close_ticks <= high_fill_max_tick
+            && (long_side.secondary_close_market
+                || long_side.secondary_close_ticks <= high_fill_max_tick)
             && long_side.psize > 0.0f;
         bool long_recursive_close = long_side.close_retracement_base <= 0.0f;
         bool long_scan_close_grid = long_close_ready
             && ((long_side.close_is_panic && long_hsl_panic_market)
+                || long_side.close_market
                 || long_side.close_ticks <= high_fill_max_tick);
         if (long_close_ready && long_recursive_close
             && long_side.close_is_exposure_reducer) {
@@ -1514,12 +1619,30 @@ inline void passivbot_single_coin_impl(
                         reducer_executed = true;
                     }
                 }
-                if (group.ticks > high_fill_max_tick) break;
+                bool group_market = should_use_ordinary_market_execution(
+                    group.ticks, false, long_side.close_gen_market_price,
+                    price_step, market_orders_allowed,
+                    market_order_near_touch_threshold
+                );
+                if (!group_market && group.ticks > high_fill_max_tick) break;
                 float group_qty = trimmed_group_qty;
+                if (group_market) {
+                    group_qty = resize_market_close_qty(
+                        group_qty, long_side.psize,
+                        long_side.close_gen_market_price,
+                        qty_step, min_qty, min_cost, c_mult
+                    );
+                }
                 if (group_qty <= 0.0f) continue;
                 float adj = fmin(round_step(group_qty, qty_step), long_side.psize);
-                float pnl = adj * c_mult * (group.price - long_side.pprice);
-                float fee = adj * group.price * c_mult * maker_fee;
+                float group_fill_price = group_market
+                    ? ordinary_market_fill_price(
+                        close, false, market_order_slippage_pct, price_step
+                    ) : group.price;
+                float pnl = adj * c_mult
+                    * (group_fill_price - long_side.pprice);
+                float fee = adj * group_fill_price * c_mult
+                    * (group_market ? taker_fee : maker_fee);
                 if (!realized_loss_proxy_allows_close(
                         adj, group.price, long_side.pprice, true,
                         c_mult, maker_fee, loss_gate_enabled)) continue;
@@ -1562,7 +1685,7 @@ inline void passivbot_single_coin_impl(
                 );
                 bool went_flat = new_psize <= 0.0f;
                 long_side.psize = new_psize;
-                day_volume += fabs(adj) * group.price / balance;
+                day_volume += fabs(adj) * group_fill_price / balance;
                 long_close_fill = true;
                 if (went_flat) {
                     long_side.pprice = 0.0f;
@@ -1655,13 +1778,17 @@ inline void passivbot_single_coin_impl(
                 if (!reachable || long_side.psize <= 0.0f) continue;
                 bool market_panic = !use_secondary && long_side.close_is_panic
                     && long_hsl_panic_market;
-                float cp = use_secondary ? long_side.secondary_close_price
-                    : market_panic
+                bool ordinary_market = use_secondary
+                    ? long_side.secondary_close_market
+                    : long_side.close_market;
+                bool market_execution = market_panic || ordinary_market;
+                float cp = market_execution
                         ? float(max(directional_ticks(
                             close * (1.0f - market_order_slippage_pct),
                             price_step, false
                         ), 1)) * price_step
-                        : long_side.close_price;
+                        : use_secondary ? long_side.secondary_close_price
+                                        : long_side.close_price;
                 float requested_qty = use_secondary
                     ? long_side.secondary_close_qty : long_side.close_qty;
                 float adj = fmin(
@@ -1669,7 +1796,7 @@ inline void passivbot_single_coin_impl(
                 );
                 float pnl = adj * c_mult * (cp - long_side.pprice);
                 float fee = adj * cp * c_mult
-                    * (market_panic ? taker_fee : maker_fee);
+                    * (market_execution ? taker_fee : maker_fee);
                 bool selected_unstuck = !use_secondary
                     && long_side.close_is_unstuck_reducer;
                 if (!long_side.close_is_panic
@@ -1736,7 +1863,8 @@ inline void passivbot_single_coin_impl(
 
         bool long_entry_fill = valid && alive && long_enabled
             && long_side.entry_qty > 0.0f
-            && long_side.entry_ticks > low_nonfill_max_tick;
+            && (long_side.entry_market
+                || long_side.entry_ticks > low_nonfill_max_tick);
         if (long_entry_fill) {
             TmSide ladder_side = long_side;
             ladder_side.psize = long_side.entry_gen_psize;
@@ -1744,6 +1872,7 @@ inline void passivbot_single_coin_impl(
             const float ladder_balance = long_side.entry_gen_balance;
             const float ladder_kf = long_side.entry_gen_kf;
             int ladder_touch_ticks = long_side.entry_gen_touch_ticks;
+            float ladder_market_price = long_side.entry_gen_market_price;
             int previous_ticks = 0;
             for (int rung = 0; rung < 500; ++rung) {
                 int entry_ticks = rung == 0
@@ -1754,10 +1883,20 @@ inline void passivbot_single_coin_impl(
                     rung == 0 ? long_side.entry_qty : ladder_side.entry_qty,
                     qty_step
                 );
-                if (eq <= 0.0f || entry_ticks <= low_nonfill_max_tick
+                bool entry_market = rung == 0 ? long_side.entry_market
+                    : should_use_ordinary_market_execution(
+                        entry_ticks, true, ladder_market_price, price_step,
+                        market_orders_allowed, market_order_near_touch_threshold
+                    );
+                if (eq <= 0.0f
+                    || (!entry_market && entry_ticks <= low_nonfill_max_tick)
                     || (rung > 0 && entry_ticks == previous_ticks)) break;
-
-                float fee = eq * ep * c_mult * maker_fee;
+                float entry_fill_price = entry_market
+                    ? ordinary_market_fill_price(
+                        close, true, market_order_slippage_pct, price_step
+                    ) : ep;
+                float fee = eq * entry_fill_price * c_mult
+                    * (entry_market ? taker_fee : maker_fee);
                 balance -= fee;
                 record_realized_net(
                     -fee,
@@ -1783,14 +1922,14 @@ inline void passivbot_single_coin_impl(
                 );
                 bool was_flat = long_side.psize <= 0.0f;
                 float new_psize = round_step(long_side.psize + eq, qty_step);
-                float new_pprice = was_flat ? ep
+                float new_pprice = was_flat ? entry_fill_price
                     : long_side.pprice * (long_side.psize / fmax(new_psize, 1.0e-12f))
-                        + ep * (eq / fmax(new_psize, 1.0e-12f));
+                        + entry_fill_price * (eq / fmax(new_psize, 1.0e-12f));
                 if (was_flat) long_side.pos_open_k = kf;
                 long_side.psize = new_psize;
                 long_side.pprice = new_pprice;
                 long_side.last_inc_k = kf;
-                day_volume += fabs(eq) * ep / balance;
+                day_volume += fabs(eq) * entry_fill_price / balance;
 
                 bool sim_flat = ladder_side.psize <= 0.0f;
                 float sim_psize = round_step(ladder_side.psize + eq, qty_step);
@@ -1818,11 +1957,13 @@ inline void passivbot_single_coin_impl(
             && short_side.close_qty > 0.0f && short_side.psize > 0.0f;
         bool short_secondary_close_fill = valid && alive && short_enabled
             && short_side.secondary_close_qty > 0.0f
-            && short_side.secondary_close_ticks > low_nonfill_max_tick
+            && (short_side.secondary_close_market
+                || short_side.secondary_close_ticks > low_nonfill_max_tick)
             && short_side.psize > 0.0f;
         bool short_recursive_close = short_side.close_retracement_base <= 0.0f;
         bool short_scan_close_grid = short_close_ready
             && ((short_side.close_is_panic && short_hsl_panic_market)
+                || short_side.close_market
                 || short_side.close_ticks > low_nonfill_max_tick);
         if (short_close_ready && short_recursive_close
             && short_side.close_is_exposure_reducer) {
@@ -2057,12 +2198,30 @@ inline void passivbot_single_coin_impl(
                         reducer_executed = true;
                     }
                 }
-                if (group.ticks <= low_nonfill_max_tick) break;
+                bool group_market = should_use_ordinary_market_execution(
+                    group.ticks, true, short_side.close_gen_market_price,
+                    price_step, market_orders_allowed,
+                    market_order_near_touch_threshold
+                );
+                if (!group_market && group.ticks <= low_nonfill_max_tick) break;
                 float group_qty = trimmed_group_qty;
+                if (group_market) {
+                    group_qty = resize_market_close_qty(
+                        group_qty, short_side.psize,
+                        short_side.close_gen_market_price,
+                        qty_step, min_qty, min_cost, c_mult
+                    );
+                }
                 if (group_qty <= 0.0f) continue;
                 float adj = fmin(round_step(group_qty, qty_step), short_side.psize);
-                float pnl = adj * c_mult * (short_side.pprice - group.price);
-                float fee = adj * group.price * c_mult * maker_fee;
+                float group_fill_price = group_market
+                    ? ordinary_market_fill_price(
+                        close, true, market_order_slippage_pct, price_step
+                    ) : group.price;
+                float pnl = adj * c_mult
+                    * (short_side.pprice - group_fill_price);
+                float fee = adj * group_fill_price * c_mult
+                    * (group_market ? taker_fee : maker_fee);
                 if (!realized_loss_proxy_allows_close(
                         adj, group.price, short_side.pprice, false,
                         c_mult, maker_fee, loss_gate_enabled)) continue;
@@ -2106,7 +2265,7 @@ inline void passivbot_single_coin_impl(
                 );
                 bool went_flat = new_psize <= 0.0f;
                 short_side.psize = new_psize;
-                day_volume += fabs(adj) * group.price / balance;
+                day_volume += fabs(adj) * group_fill_price / balance;
                 short_close_fill = true;
                 if (went_flat) {
                     short_side.pprice = 0.0f;
@@ -2199,13 +2358,17 @@ inline void passivbot_single_coin_impl(
                 if (!reachable || short_side.psize <= 0.0f) continue;
                 bool market_panic = !use_secondary && short_side.close_is_panic
                     && short_hsl_panic_market;
-                float cp = use_secondary ? short_side.secondary_close_price
-                    : market_panic
+                bool ordinary_market = use_secondary
+                    ? short_side.secondary_close_market
+                    : short_side.close_market;
+                bool market_execution = market_panic || ordinary_market;
+                float cp = market_execution
                         ? float(max(directional_ticks(
                             close * (1.0f + market_order_slippage_pct),
                             price_step, true
                         ), 1)) * price_step
-                        : short_side.close_price;
+                        : use_secondary ? short_side.secondary_close_price
+                                        : short_side.close_price;
                 float requested_qty = use_secondary
                     ? short_side.secondary_close_qty : short_side.close_qty;
                 float adj = fmin(
@@ -2213,7 +2376,7 @@ inline void passivbot_single_coin_impl(
                 );
                 float pnl = adj * c_mult * (short_side.pprice - cp);
                 float fee = adj * cp * c_mult
-                    * (market_panic ? taker_fee : maker_fee);
+                    * (market_execution ? taker_fee : maker_fee);
                 bool selected_unstuck = !use_secondary
                     && short_side.close_is_unstuck_reducer;
                 if (!short_side.close_is_panic
@@ -2281,7 +2444,8 @@ inline void passivbot_single_coin_impl(
 
         bool short_entry_fill = valid && alive && short_enabled
             && short_side.entry_qty > 0.0f
-            && short_side.entry_ticks <= high_fill_max_tick;
+            && (short_side.entry_market
+                || short_side.entry_ticks <= high_fill_max_tick);
         if (short_entry_fill) {
             TmSide ladder_side = short_side;
             ladder_side.psize = short_side.entry_gen_psize;
@@ -2289,6 +2453,7 @@ inline void passivbot_single_coin_impl(
             const float ladder_balance = short_side.entry_gen_balance;
             const float ladder_kf = short_side.entry_gen_kf;
             int ladder_touch_ticks = short_side.entry_gen_touch_ticks;
+            float ladder_market_price = short_side.entry_gen_market_price;
             int previous_ticks = 0;
             for (int rung = 0; rung < 500; ++rung) {
                 int entry_ticks = rung == 0
@@ -2299,10 +2464,26 @@ inline void passivbot_single_coin_impl(
                     rung == 0 ? short_side.entry_qty : ladder_side.entry_qty,
                     qty_step
                 );
-                if (eq <= 0.0f || entry_ticks > high_fill_max_tick
+                bool entry_market = rung == 0 ? short_side.entry_market
+                    : should_use_ordinary_market_execution(
+                        entry_ticks, false, ladder_market_price, price_step,
+                        market_orders_allowed, market_order_near_touch_threshold
+                    );
+                if (entry_market) {
+                    float market_min_q = min_entry_qty(
+                        ladder_market_price, qty_step, min_qty, min_cost, c_mult
+                    );
+                    if (eq < market_min_q) eq = market_min_q;
+                }
+                if (eq <= 0.0f
+                    || (!entry_market && entry_ticks > high_fill_max_tick)
                     || (rung > 0 && entry_ticks == previous_ticks)) break;
-
-                float fee = eq * ep * c_mult * maker_fee;
+                float entry_fill_price = entry_market
+                    ? ordinary_market_fill_price(
+                        close, false, market_order_slippage_pct, price_step
+                    ) : ep;
+                float fee = eq * entry_fill_price * c_mult
+                    * (entry_market ? taker_fee : maker_fee);
                 balance -= fee;
                 record_realized_net(
                     -fee,
@@ -2329,14 +2510,14 @@ inline void passivbot_single_coin_impl(
                 );
                 bool was_flat = short_side.psize <= 0.0f;
                 float new_psize = round_step(short_side.psize + eq, qty_step);
-                float new_pprice = was_flat ? ep
+                float new_pprice = was_flat ? entry_fill_price
                     : short_side.pprice * (short_side.psize / fmax(new_psize, 1.0e-12f))
-                        + ep * (eq / fmax(new_psize, 1.0e-12f));
+                        + entry_fill_price * (eq / fmax(new_psize, 1.0e-12f));
                 if (was_flat) short_side.pos_open_k = kf;
                 short_side.psize = new_psize;
                 short_side.pprice = new_pprice;
                 short_side.last_inc_k = kf;
-                day_volume += fabs(eq) * ep / balance;
+                day_volume += fabs(eq) * entry_fill_price / balance;
 
                 bool sim_flat = ladder_side.psize <= 0.0f;
                 float sim_psize = round_step(ladder_side.psize + eq, qty_step);

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -456,6 +456,36 @@ inline float crop_entry(
     return q < qty ? q : qty;
 }
 
+inline float gate_market_entry_by_twel_strict(
+    thread TmSide& s, float balance, float price, float qty,
+    float qty_step, float min_qty, float min_cost, float c_mult
+) {
+    if (!(qty > 0.0f && balance > 0.0f && price > 0.0f
+        && qty_step > 0.0f && c_mult > 0.0f && s.entry_cap > 0.0f)) {
+        return 0.0f;
+    }
+    float current_cost = s.psize * s.pprice * c_mult;
+    float remaining_cost = s.entry_cap * balance - current_cost;
+    if (!(remaining_cost > 0.0f)) return 0.0f;
+    float gated_qty = fmin(
+        qty,
+        floor_step(remaining_cost / (price * c_mult), qty_step)
+    );
+    if (!(gated_qty > 0.0f)) return 0.0f;
+
+    // Exact Rust requires post-fill exposure to remain strictly below the
+    // total-exposure cap.  A quantity exactly on the cap is not eligible.
+    float gated_exposure = (current_cost + gated_qty * price * c_mult)
+        / balance;
+    if (gated_exposure >= s.entry_cap) {
+        gated_qty = floor_step(gated_qty - qty_step, qty_step);
+    }
+    float executable_min = min_entry_qty(
+        price, qty_step, min_qty, min_cost, c_mult
+    );
+    return gated_qty >= executable_min ? gated_qty : 0.0f;
+}
+
 inline float calc_close_qty(
     thread TmSide& s, float balance, float mq, int mq_relation, float pct,
     float qty_step, float c_mult
@@ -873,7 +903,7 @@ inline void generate_orders(
         s.entry_qty = market_min_q;
     }
     if (entry_market && s.twel_entry_gate_enabled) {
-        s.entry_qty = crop_entry(
+        s.entry_qty = gate_market_entry_by_twel_strict(
             s, balance, price_now, s.entry_qty,
             qty_step, min_qty, min_cost, c_mult
         );

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -478,7 +478,16 @@ inline float gate_market_entry_by_twel_strict(
     float gated_exposure = (current_cost + gated_qty * price * c_mult)
         / balance;
     if (gated_exposure >= s.entry_cap) {
-        gated_qty = floor_step(gated_qty - qty_step, qty_step);
+        float previous_qty = gated_qty;
+        float decremented_qty = gated_qty - qty_step;
+        if (!(decremented_qty < gated_qty)) {
+            decremented_qty = gated_qty - fmax(
+                qty_step,
+                fabs(gated_qty) * 1.1920928955078125e-7f
+            );
+        }
+        gated_qty = floor_step(decremented_qty, qty_step);
+        if (!(gated_qty < previous_qty)) return 0.0f;
     }
     float executable_min = min_entry_qty(
         price, qty_step, min_qty, min_cost, c_mult

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -61,6 +61,24 @@ inline bool should_use_ordinary_market_execution(
         <= fmax(market_order_near_touch_threshold, 0.0f);
 }
 
+inline bool recursive_close_bound_requires_scan(
+    int nearest_ticks,
+    bool buy_order,
+    int passive_fill_bound,
+    float generation_market_price,
+    float price_step,
+    bool market_orders_allowed,
+    float market_order_near_touch_threshold
+) {
+    bool passively_reachable = buy_order
+        ? nearest_ticks > passive_fill_bound
+        : nearest_ticks <= passive_fill_bound;
+    return passively_reachable || should_use_ordinary_market_execution(
+        nearest_ticks, buy_order, generation_market_price, price_step,
+        market_orders_allowed, market_order_near_touch_threshold
+    );
+}
+
 inline float ordinary_market_fill_price(
     float market_price,
     bool buy_order,
@@ -1413,7 +1431,11 @@ inline void passivbot_single_coin_impl(
             int nearest_ticks = touch_controls
                 ? long_side.close_gen_touch_nearest_ticks : target_ticks;
             long_scan_close_grid = long_scan_close_grid
-                || nearest_ticks <= high_fill_max_tick;
+                || recursive_close_bound_requires_scan(
+                    nearest_ticks, false, high_fill_max_tick,
+                    long_side.close_gen_market_price, price_step,
+                    market_orders_allowed, market_order_near_touch_threshold
+                );
         }
         if (long_scan_close_grid && long_recursive_close
             && !long_side.close_is_panic) {
@@ -1874,6 +1896,9 @@ inline void passivbot_single_coin_impl(
             TmSide ladder_side = long_side;
             ladder_side.psize = long_side.entry_gen_psize;
             ladder_side.pprice = long_side.entry_gen_pprice;
+            // Rust constructs the immutable recursive strategy ladder before
+            // orchestration promotes individual rungs to market execution.
+            ladder_side.market_orders_allowed = false;
             const float ladder_balance = long_side.entry_gen_balance;
             const float ladder_kf = long_side.entry_gen_kf;
             int ladder_touch_ticks = long_side.entry_gen_touch_ticks;
@@ -1884,15 +1909,23 @@ inline void passivbot_single_coin_impl(
                     ? long_side.entry_ticks : ladder_side.entry_ticks;
                 float ep = rung == 0
                     ? long_side.entry_price : ladder_side.entry_price;
-                float eq = round_step(
+                float strategy_eq = round_step(
                     rung == 0 ? long_side.entry_qty : ladder_side.entry_qty,
                     qty_step
                 );
+                if (strategy_eq <= 0.0f) break;
+                float eq = strategy_eq;
                 bool entry_market = rung == 0 ? long_side.entry_market
                     : should_use_ordinary_market_execution(
                         entry_ticks, true, ladder_market_price, price_step,
                         market_orders_allowed, market_order_near_touch_threshold
                     );
+                if (rung > 0 && entry_market) {
+                    eq = crop_entry(
+                        ladder_side, ladder_balance, ladder_market_price, eq,
+                        qty_step, min_qty, min_cost, c_mult
+                    );
+                }
                 if (eq <= 0.0f
                     || (!entry_market && entry_ticks <= low_nonfill_max_tick)
                     || (rung > 0 && entry_ticks == previous_ticks)) break;
@@ -1937,11 +1970,13 @@ inline void passivbot_single_coin_impl(
                 day_volume += fabs(eq) * entry_fill_price / balance;
 
                 bool sim_flat = ladder_side.psize <= 0.0f;
-                float sim_psize = round_step(ladder_side.psize + eq, qty_step);
+                float sim_psize = round_step(
+                    ladder_side.psize + strategy_eq, qty_step
+                );
                 ladder_side.pprice = sim_flat ? ep
                     : ladder_side.pprice
                         * (ladder_side.psize / fmax(sim_psize, 1.0e-12f))
-                        + ep * (eq / fmax(sim_psize, 1.0e-12f));
+                        + ep * (strategy_eq / fmax(sim_psize, 1.0e-12f));
                 ladder_side.psize = sim_psize;
                 previous_ticks = entry_ticks;
                 ladder_touch_ticks = min(ladder_touch_ticks, entry_ticks);
@@ -1992,7 +2027,11 @@ inline void passivbot_single_coin_impl(
             int nearest_ticks = touch_controls
                 ? short_side.close_gen_touch_nearest_ticks : target_ticks;
             short_scan_close_grid = short_scan_close_grid
-                || nearest_ticks > low_nonfill_max_tick;
+                || recursive_close_bound_requires_scan(
+                    nearest_ticks, true, low_nonfill_max_tick,
+                    short_side.close_gen_market_price, price_step,
+                    market_orders_allowed, market_order_near_touch_threshold
+                );
         }
         if (short_scan_close_grid && short_recursive_close
             && !short_side.close_is_panic) {
@@ -2455,6 +2494,7 @@ inline void passivbot_single_coin_impl(
             TmSide ladder_side = short_side;
             ladder_side.psize = short_side.entry_gen_psize;
             ladder_side.pprice = short_side.entry_gen_pprice;
+            ladder_side.market_orders_allowed = false;
             const float ladder_balance = short_side.entry_gen_balance;
             const float ladder_kf = short_side.entry_gen_kf;
             int ladder_touch_ticks = short_side.entry_gen_touch_ticks;
@@ -2465,10 +2505,12 @@ inline void passivbot_single_coin_impl(
                     ? short_side.entry_ticks : ladder_side.entry_ticks;
                 float ep = rung == 0
                     ? short_side.entry_price : ladder_side.entry_price;
-                float eq = round_step(
+                float strategy_eq = round_step(
                     rung == 0 ? short_side.entry_qty : ladder_side.entry_qty,
                     qty_step
                 );
+                if (strategy_eq <= 0.0f) break;
+                float eq = strategy_eq;
                 bool entry_market = rung == 0 ? short_side.entry_market
                     : should_use_ordinary_market_execution(
                         entry_ticks, false, ladder_market_price, price_step,
@@ -2479,6 +2521,13 @@ inline void passivbot_single_coin_impl(
                         ladder_market_price, qty_step, min_qty, min_cost, c_mult
                     );
                     if (eq < market_min_q) eq = market_min_q;
+                    if (rung > 0) {
+                        eq = crop_entry(
+                            ladder_side, ladder_balance, ladder_market_price, eq,
+                            qty_step, min_qty, min_cost, c_mult
+                        );
+                        if (eq + 1.0e-12f < market_min_q) eq = 0.0f;
+                    }
                 }
                 if (eq <= 0.0f
                     || (!entry_market && entry_ticks > high_fill_max_tick)
@@ -2525,11 +2574,13 @@ inline void passivbot_single_coin_impl(
                 day_volume += fabs(eq) * entry_fill_price / balance;
 
                 bool sim_flat = ladder_side.psize <= 0.0f;
-                float sim_psize = round_step(ladder_side.psize + eq, qty_step);
+                float sim_psize = round_step(
+                    ladder_side.psize + strategy_eq, qty_step
+                );
                 ladder_side.pprice = sim_flat ? ep
                     : ladder_side.pprice
                         * (ladder_side.psize / fmax(sim_psize, 1.0e-12f))
-                        + ep * (eq / fmax(sim_psize, 1.0e-12f));
+                        + ep * (strategy_eq / fmax(sim_psize, 1.0e-12f));
                 ladder_side.psize = sim_psize;
                 previous_ticks = entry_ticks;
                 ladder_touch_ticks = max(ladder_touch_ticks, entry_ticks);

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -61,24 +61,6 @@ inline bool should_use_ordinary_market_execution(
         <= fmax(market_order_near_touch_threshold, 0.0f);
 }
 
-inline bool recursive_close_bound_requires_scan(
-    int nearest_ticks,
-    bool buy_order,
-    int passive_fill_bound,
-    float generation_market_price,
-    float price_step,
-    bool market_orders_allowed,
-    float market_order_near_touch_threshold
-) {
-    bool passively_reachable = buy_order
-        ? nearest_ticks > passive_fill_bound
-        : nearest_ticks <= passive_fill_bound;
-    return passively_reachable || should_use_ordinary_market_execution(
-        nearest_ticks, buy_order, generation_market_price, price_step,
-        market_orders_allowed, market_order_near_touch_threshold
-    );
-}
-
 inline float ordinary_market_fill_price(
     float market_price,
     bool buy_order,
@@ -273,7 +255,7 @@ struct TmSide {
     float close_threshold_v1h, close_threshold_v1m;
     float close_retracement_base, close_retracement_v1h, close_retracement_v1m;
     float cooldown_min, twel, allowed_wel, entry_cap;
-    bool gate_initial, gate_reentry;
+    bool gate_initial, gate_reentry, twel_entry_gate_enabled;
     bool wel_enforcer_enabled;
     float wel_enforcer_threshold;
     bool twel_enforcer_enabled;
@@ -368,13 +350,13 @@ inline TmSide load_side(constant float* p, int o, float seed) {
     s.allowed_wel = s.twel * (
         1.0f + (legacy_raw_allowance ? allowance_pct : 0.0f)
     );
-    bool twel_entry_gate_enabled = p[o + 29] > 0.5f;
+    s.twel_entry_gate_enabled = p[o + 29] > 0.5f;
     float twel_threshold = p[o + 30];
     float gate_cap = s.twel;
     if (isfinite(twel_threshold) && twel_threshold > 0.0f) {
         gate_cap = fmin(s.twel, s.twel * twel_threshold);
     }
-    s.entry_cap = twel_entry_gate_enabled
+    s.entry_cap = s.twel_entry_gate_enabled
         ? fmin(s.allowed_wel, gate_cap) : s.allowed_wel;
     s.wel_enforcer_enabled = p[o + 31] > 0.5f;
     s.wel_enforcer_threshold = p[o + 32];
@@ -867,15 +849,14 @@ inline void generate_orders(
     float eqty = flat ? iq : (partial ? iq_partial : (reentry_ok ? rq : 0.0f));
     int eticks = flat || partial ? initial_ticks : reentry_ticks;
     float eprice = flat || partial ? initial_price : reentry_price;
-    bool entry_market = should_use_ordinary_market_execution(
-        eticks, is_long, price_now, price_step, s.market_orders_allowed,
-        s.market_order_near_touch_threshold
-    );
-    float entry_exposure_price = entry_market ? price_now : eprice;
+    bool entry_market = s.entry_retracement_base > 0.0f
+        && should_use_ordinary_market_execution(
+            eticks, is_long, price_now, price_step, s.market_orders_allowed,
+            s.market_order_near_touch_threshold
+        );
     float market_min_q = entry_market
         ? min_entry_qty(price_now, qty_step, min_qty, min_cost, c_mult)
         : min_entry_qty(eprice, qty_step, min_qty, min_cost, c_mult);
-    if (!is_long && entry_market && eqty < market_min_q) eqty = market_min_q;
     bool cooldown = s.cooldown_min > 0.0f && s.last_inc_k >= 0.0f
         && kf < s.last_inc_k + s.cooldown_min;
     if (cooldown || balance <= 0.0f || s.initial_qty_pct <= 0.0f
@@ -884,9 +865,19 @@ inline void generate_orders(
     s.entry_ticks = eticks;
     s.entry_price = eprice;
     s.entry_qty = crop_entry(
-        s, balance, entry_exposure_price, eqty,
+        s, balance, eprice, eqty,
         qty_step, min_qty, min_cost, c_mult
     );
+    if (!is_long && entry_market && s.entry_qty > 0.0f
+        && s.entry_qty < market_min_q) {
+        s.entry_qty = market_min_q;
+    }
+    if (entry_market && s.twel_entry_gate_enabled) {
+        s.entry_qty = crop_entry(
+            s, balance, price_now, s.entry_qty,
+            qty_step, min_qty, min_cost, c_mult
+        );
+    }
     if (!is_long && entry_market && s.entry_qty + 1.0e-12f < market_min_q) {
         s.entry_qty = 0.0f;
     }
@@ -980,6 +971,7 @@ inline void generate_orders(
             s, balance, close_mq, close_mq_relation, pct, qty_step, c_mult
         ) : 0.0f;
     s.close_market = s.close_qty > 0.0f
+        && s.close_retracement_base > 0.0f
         && should_use_ordinary_market_execution(
             cticks, !is_long, price_now, price_step,
             s.market_orders_allowed, s.market_order_near_touch_threshold
@@ -1431,11 +1423,7 @@ inline void passivbot_single_coin_impl(
             int nearest_ticks = touch_controls
                 ? long_side.close_gen_touch_nearest_ticks : target_ticks;
             long_scan_close_grid = long_scan_close_grid
-                || recursive_close_bound_requires_scan(
-                    nearest_ticks, false, high_fill_max_tick,
-                    long_side.close_gen_market_price, price_step,
-                    market_orders_allowed, market_order_near_touch_threshold
-                );
+                || nearest_ticks <= high_fill_max_tick;
         }
         if (long_scan_close_grid && long_recursive_close
             && !long_side.close_is_panic) {
@@ -1646,30 +1634,14 @@ inline void passivbot_single_coin_impl(
                         reducer_executed = true;
                     }
                 }
-                bool group_market = should_use_ordinary_market_execution(
-                    group.ticks, false, long_side.close_gen_market_price,
-                    price_step, market_orders_allowed,
-                    market_order_near_touch_threshold
-                );
-                if (!group_market && group.ticks > high_fill_max_tick) break;
+                if (group.ticks > high_fill_max_tick) break;
                 float group_qty = trimmed_group_qty;
-                if (group_market) {
-                    group_qty = resize_market_close_qty(
-                        group_qty, long_side.psize,
-                        long_side.close_gen_market_price,
-                        qty_step, min_qty, min_cost, c_mult
-                    );
-                }
                 if (group_qty <= 0.0f) continue;
                 float adj = fmin(round_step(group_qty, qty_step), long_side.psize);
-                float group_fill_price = group_market
-                    ? ordinary_market_fill_price(
-                        close, false, market_order_slippage_pct, price_step
-                    ) : group.price;
+                float group_fill_price = group.price;
                 float pnl = adj * c_mult
                     * (group_fill_price - long_side.pprice);
-                float fee = adj * group_fill_price * c_mult
-                    * (group_market ? taker_fee : maker_fee);
+                float fee = adj * group_fill_price * c_mult * maker_fee;
                 if (!realized_loss_proxy_allows_close(
                         adj, group.price, long_side.pprice, true,
                         c_mult, maker_fee, loss_gate_enabled)) continue;
@@ -1902,7 +1874,6 @@ inline void passivbot_single_coin_impl(
             const float ladder_balance = long_side.entry_gen_balance;
             const float ladder_kf = long_side.entry_gen_kf;
             int ladder_touch_ticks = long_side.entry_gen_touch_ticks;
-            float ladder_market_price = long_side.entry_gen_market_price;
             int previous_ticks = 0;
             for (int rung = 0; rung < 500; ++rung) {
                 int entry_ticks = rung == 0
@@ -1915,17 +1886,7 @@ inline void passivbot_single_coin_impl(
                 );
                 if (strategy_eq <= 0.0f) break;
                 float eq = strategy_eq;
-                bool entry_market = rung == 0 ? long_side.entry_market
-                    : should_use_ordinary_market_execution(
-                        entry_ticks, true, ladder_market_price, price_step,
-                        market_orders_allowed, market_order_near_touch_threshold
-                    );
-                if (rung > 0 && entry_market) {
-                    eq = crop_entry(
-                        ladder_side, ladder_balance, ladder_market_price, eq,
-                        qty_step, min_qty, min_cost, c_mult
-                    );
-                }
+                bool entry_market = rung == 0 && long_side.entry_market;
                 if (eq <= 0.0f
                     || (!entry_market && entry_ticks <= low_nonfill_max_tick)
                     || (rung > 0 && entry_ticks == previous_ticks)) break;
@@ -2027,11 +1988,7 @@ inline void passivbot_single_coin_impl(
             int nearest_ticks = touch_controls
                 ? short_side.close_gen_touch_nearest_ticks : target_ticks;
             short_scan_close_grid = short_scan_close_grid
-                || recursive_close_bound_requires_scan(
-                    nearest_ticks, true, low_nonfill_max_tick,
-                    short_side.close_gen_market_price, price_step,
-                    market_orders_allowed, market_order_near_touch_threshold
-                );
+                || nearest_ticks > low_nonfill_max_tick;
         }
         if (short_scan_close_grid && short_recursive_close
             && !short_side.close_is_panic) {
@@ -2242,30 +2199,14 @@ inline void passivbot_single_coin_impl(
                         reducer_executed = true;
                     }
                 }
-                bool group_market = should_use_ordinary_market_execution(
-                    group.ticks, true, short_side.close_gen_market_price,
-                    price_step, market_orders_allowed,
-                    market_order_near_touch_threshold
-                );
-                if (!group_market && group.ticks <= low_nonfill_max_tick) break;
+                if (group.ticks <= low_nonfill_max_tick) break;
                 float group_qty = trimmed_group_qty;
-                if (group_market) {
-                    group_qty = resize_market_close_qty(
-                        group_qty, short_side.psize,
-                        short_side.close_gen_market_price,
-                        qty_step, min_qty, min_cost, c_mult
-                    );
-                }
                 if (group_qty <= 0.0f) continue;
                 float adj = fmin(round_step(group_qty, qty_step), short_side.psize);
-                float group_fill_price = group_market
-                    ? ordinary_market_fill_price(
-                        close, true, market_order_slippage_pct, price_step
-                    ) : group.price;
+                float group_fill_price = group.price;
                 float pnl = adj * c_mult
                     * (short_side.pprice - group_fill_price);
-                float fee = adj * group_fill_price * c_mult
-                    * (group_market ? taker_fee : maker_fee);
+                float fee = adj * group_fill_price * c_mult * maker_fee;
                 if (!realized_loss_proxy_allows_close(
                         adj, group.price, short_side.pprice, false,
                         c_mult, maker_fee, loss_gate_enabled)) continue;
@@ -2511,23 +2452,12 @@ inline void passivbot_single_coin_impl(
                 );
                 if (strategy_eq <= 0.0f) break;
                 float eq = strategy_eq;
-                bool entry_market = rung == 0 ? short_side.entry_market
-                    : should_use_ordinary_market_execution(
-                        entry_ticks, false, ladder_market_price, price_step,
-                        market_orders_allowed, market_order_near_touch_threshold
-                    );
+                bool entry_market = rung == 0 && short_side.entry_market;
                 if (entry_market) {
                     float market_min_q = min_entry_qty(
                         ladder_market_price, qty_step, min_qty, min_cost, c_mult
                     );
                     if (eq < market_min_q) eq = market_min_q;
-                    if (rung > 0) {
-                        eq = crop_entry(
-                            ladder_side, ladder_balance, ladder_market_price, eq,
-                            qty_step, min_qty, min_cost, c_mult
-                        );
-                        if (eq + 1.0e-12f < market_min_q) eq = 0.0f;
-                    }
                 }
                 if (eq <= 0.0f
                     || (!entry_market && entry_ticks > high_fill_max_tick)

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -1120,6 +1120,11 @@ inline int recursive_close_groups(
     TmSide sim = source;
     sim.psize = source.close_gen_psize;
     sim.pprice = source.close_gen_pprice;
+    // Reconstruct Rust's passive strategy ladder first. Ordinary market
+    // execution is a policy applied to each completed price group against the
+    // market captured at generation time; applying it inside generate_orders
+    // would compare against close_gen_pprice and permanently distort sizing.
+    sim.market_orders_allowed = false;
     bool have_group = false;
     int group_count = 0;
     int group_ticks = 0;

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -2776,7 +2776,14 @@ def _validate_tm_market_nonrecursive_bounds(
                 if bound is not None
                 else float(base_by_key.get(key, 0.0))
             )
-            if not math.isfinite(low) or low <= 0.0:
+            with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+                packed_low = np.float32(low)
+            if (
+                not math.isfinite(low)
+                or low <= 0.0
+                or not np.isfinite(packed_low)
+                or packed_low <= np.float32(0.0)
+            ):
                 unsupported.append(f"{key} lower={low}")
     if unsupported:
         raise ValueError(

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -2757,6 +2757,38 @@ def _validate_pinned_scope_bounds(
             )
 
 
+def _validate_tm_market_nonrecursive_bounds(
+    bound_by_key, base_by_key, enabled_sides, config
+) -> None:
+    if (
+        str(config.get("live", {}).get("strategy_kind", "")).strip().lower()
+        != "trailing_martingale"
+        or not bool(config.get("live", {}).get("market_orders_allowed"))
+    ):
+        return
+    unsupported = []
+    for side in sorted(set(enabled_sides or ())):
+        for phase in ("entry", "close"):
+            key = f"{side}_{phase}_retracement_base_pct"
+            bound = bound_by_key.get(key)
+            low = (
+                float(bound.low)
+                if bound is not None
+                else float(base_by_key.get(key, 0.0))
+            )
+            if not math.isfinite(low) or low <= 0.0:
+                unsupported.append(f"{key} lower={low}")
+    if unsupported:
+        raise ValueError(
+            "GPU Trailing Martingale ordinary market execution currently "
+            "requires trailing-only entry and close modes; pin every enabled "
+            "side's entry_retracement_base_pct and close_retracement_base_pct "
+            "lower bounds above zero. Recursive market ladders remain fail "
+            "closed: "
+            + ", ".join(unsupported)
+        )
+
+
 def _validate_directional_search_space(
     bound_by_key, base_by_key, approved, enabled_sides, *, coin_count: int = 1
 ) -> None:
@@ -3272,6 +3304,9 @@ def run_backend(
         coin_count=max_coin_count,
         strategy_kind=strategy_kind,
     )
+    _validate_tm_market_nonrecursive_bounds(
+        bound_by_key, base_by_key, enabled_sides, proxy_config
+    )
     _validate_hsl_bound_contracts(bound_by_key, proxy_config)
 
     if suite_multicoin_sides is None:
@@ -3309,6 +3344,12 @@ def run_backend(
             scenario_enabled_sides,
             coin_count=item["coin_count"],
             strategy_kind=strategy_kind,
+        )
+        _validate_tm_market_nonrecursive_bounds(
+            scenario_bound_by_key,
+            scenario_base_by_key,
+            scenario_enabled_sides,
+            item["config"],
         )
         _validate_directional_search_space(
             scenario_bound_by_key,

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -2796,6 +2796,44 @@ def _validate_tm_market_nonrecursive_bounds(
         )
 
 
+def _validate_tm_market_ordering_bounds(
+    bound_by_key, base_by_key, enabled_sides, config
+) -> None:
+    if (
+        str(config.get("live", {}).get("strategy_kind", "")).strip().lower()
+        != "trailing_martingale"
+        or not bool(config.get("live", {}).get("market_orders_allowed"))
+    ):
+        return
+    unsupported = []
+    for side in sorted(set(enabled_sides or ())):
+        for suffix in (
+            "unstuck_enabled",
+            "risk_position_exposure_enforcer_enabled",
+            "risk_total_exposure_enforcer_enabled",
+        ):
+            key = f"{side}_{suffix}"
+            bound = bound_by_key.get(key)
+            values = (
+                (float(bound.low), float(bound.high))
+                if bound is not None
+                else (float(base_by_key.get(key, 0.0)),) * 2
+            )
+            if any(
+                not math.isfinite(value)
+                or not math.isclose(value, 0.0, rel_tol=0.0, abs_tol=1.0e-12)
+                for value in values
+            ):
+                unsupported.append(f"{key} bounds={values}")
+    if unsupported:
+        raise ValueError(
+            "GPU Trailing Martingale ordinary market execution requires "
+            "unstuck and exposure-enforcer enablement bounds to remain pinned "
+            "false until their market ordering is modeled: "
+            + ", ".join(unsupported)
+        )
+
+
 def _validate_directional_search_space(
     bound_by_key, base_by_key, approved, enabled_sides, *, coin_count: int = 1
 ) -> None:
@@ -3314,6 +3352,9 @@ def run_backend(
     _validate_tm_market_nonrecursive_bounds(
         bound_by_key, base_by_key, enabled_sides, proxy_config
     )
+    _validate_tm_market_ordering_bounds(
+        bound_by_key, base_by_key, enabled_sides, proxy_config
+    )
     _validate_hsl_bound_contracts(bound_by_key, proxy_config)
 
     if suite_multicoin_sides is None:
@@ -3353,6 +3394,12 @@ def run_backend(
             strategy_kind=strategy_kind,
         )
         _validate_tm_market_nonrecursive_bounds(
+            scenario_bound_by_key,
+            scenario_base_by_key,
+            scenario_enabled_sides,
+            item["config"],
+        )
+        _validate_tm_market_ordering_bounds(
             scenario_bound_by_key,
             scenario_base_by_key,
             scenario_enabled_sides,

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -2834,6 +2834,21 @@ def _validate_tm_market_ordering_bounds(
         )
 
 
+def _validate_tm_market_template_bounds(
+    bound_by_key, base_by_key, enabled_sides, config, suite_inputs
+) -> None:
+    """Validate a directly executed config, not a suite's override template."""
+
+    if suite_inputs:
+        return
+    _validate_tm_market_nonrecursive_bounds(
+        bound_by_key, base_by_key, enabled_sides, config
+    )
+    _validate_tm_market_ordering_bounds(
+        bound_by_key, base_by_key, enabled_sides, config
+    )
+
+
 def _validate_directional_search_space(
     bound_by_key, base_by_key, approved, enabled_sides, *, coin_count: int = 1
 ) -> None:
@@ -3349,11 +3364,12 @@ def run_backend(
         coin_count=max_coin_count,
         strategy_kind=strategy_kind,
     )
-    _validate_tm_market_nonrecursive_bounds(
-        bound_by_key, base_by_key, enabled_sides, proxy_config
-    )
-    _validate_tm_market_ordering_bounds(
-        bound_by_key, base_by_key, enabled_sides, proxy_config
+    _validate_tm_market_template_bounds(
+        bound_by_key,
+        base_by_key,
+        enabled_sides,
+        proxy_config,
+        suite_inputs,
     )
     _validate_hsl_bound_contracts(bound_by_key, proxy_config)
 

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -966,11 +966,59 @@ def _validate_scope_config(
                 "GPU market execution requires a finite non-negative "
                 "live.market_order_near_touch_threshold"
             )
-        if strategy_kind != "ema_anchor" or coin_count != 1:
+        if coin_count != 1:
             raise ValueError(
                 "GPU ordinary market execution currently requires single-coin "
-                "strategy_kind=ema_anchor"
+                "EMA Anchor or Trailing Martingale"
             )
+        if strategy_kind == "trailing_martingale":
+            unsupported_market_features = []
+            if max_realized_loss_pct < 1.0:
+                unsupported_market_features.append("live.max_realized_loss_pct")
+            for side in enabled_sides:
+                side_config = config.get("bot", {}).get(side, {}) or {}
+                if _gpu_hsl_side_enabled(config, side):
+                    unsupported_market_features.append(f"bot.{side}.hsl.enabled")
+                if bool((side_config.get("unstuck", {}) or {}).get("enabled", False)):
+                    unsupported_market_features.append(
+                        f"bot.{side}.unstuck.enabled"
+                    )
+                risk = side_config.get("risk", {}) or {}
+                for key in (
+                    "position_exposure_enforcer_enabled",
+                    "total_exposure_enforcer_enabled",
+                ):
+                    if bool(risk.get(key, False)):
+                        unsupported_market_features.append(f"bot.{side}.risk.{key}")
+                for coin, patch in (config.get("coin_overrides") or {}).items():
+                    if not isinstance(patch, dict):
+                        continue
+                    override_side = (
+                        patch.get("bot", {}).get(side, {}) or {}
+                    )
+                    if bool(
+                        (override_side.get("unstuck", {}) or {}).get(
+                            "enabled", False
+                        )
+                    ):
+                        unsupported_market_features.append(
+                            f"coin_overrides.{coin}.bot.{side}.unstuck.enabled"
+                        )
+                    override_risk = override_side.get("risk", {}) or {}
+                    for key in (
+                        "position_exposure_enforcer_enabled",
+                        "total_exposure_enforcer_enabled",
+                    ):
+                        if bool(override_risk.get(key, False)):
+                            unsupported_market_features.append(
+                                f"coin_overrides.{coin}.bot.{side}.risk.{key}"
+                            )
+            if unsupported_market_features:
+                raise ValueError(
+                    "GPU Trailing Martingale ordinary market execution does not "
+                    "yet support risk/HSL ordering for: "
+                    + ", ".join(sorted(unsupported_market_features))
+                )
     if bool(config.get("backtest", {}).get("filter_by_min_effective_cost")) and len(
         enabled_sides
     ) != 1:

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -1542,10 +1542,6 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
     """Persistent single-coin trailing-martingale runner on Apple MPS."""
 
     def __init__(self, *args, hsl_enabled: bool = True, **kwargs):
-        if bool(kwargs.get("market_orders_allowed", False)):
-            raise ValueError(
-                "MPS trailing-martingale ordinary market execution is not modeled yet"
-            )
         super().__init__(*args, **kwargs)
         self.shader_topology = trailing_martingale_shader_topology(
             long_enabled=self.long_enabled,

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1579,13 +1579,15 @@ def test_gpu_foundation_accepts_baseline_tm_single_coin_market_execution():
 
 
 @pytest.mark.parametrize(
-    "key",
+    ("key", "low"),
     [
-        "long_entry_retracement_base_pct",
-        "long_close_retracement_base_pct",
+        ("long_entry_retracement_base_pct", 0.0),
+        ("long_close_retracement_base_pct", 0.0),
+        ("long_entry_retracement_base_pct", 1.0e-50),
+        ("long_close_retracement_base_pct", 1.0e-50),
     ],
 )
-def test_gpu_tm_market_execution_rejects_recursive_mode_bounds(key):
+def test_gpu_tm_market_execution_rejects_recursive_mode_bounds(key, low):
     config = _long_only_ema_config()
     config["live"]["strategy_kind"] = "trailing_martingale"
     config["live"]["market_orders_allowed"] = True
@@ -1593,7 +1595,7 @@ def test_gpu_tm_market_execution_rejects_recursive_mode_bounds(key):
         "long_entry_retracement_base_pct": Bound(0.001, 0.1),
         "long_close_retracement_base_pct": Bound(0.001, 0.1),
     }
-    bounds[key] = Bound(0.0, 0.1)
+    bounds[key] = Bound(low, 0.1)
 
     with pytest.raises(ValueError, match="Recursive market ladders"):
         _validate_tm_market_nonrecursive_bounds(bounds, {}, {"long"}, config)

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1568,16 +1568,18 @@ def test_gpu_foundation_accepts_baseline_ema_single_coin_market_execution():
     assert _validate_scope(config, _Evaluator()) == "bybit"
 
 
+def test_gpu_foundation_accepts_baseline_tm_single_coin_market_execution():
+    config = _long_only_ema_config()
+    config["live"]["strategy_kind"] = "trailing_martingale"
+    config["live"]["market_orders_allowed"] = True
+    config["live"]["market_order_near_touch_threshold"] = 0.002
+
+    assert _validate_scope(config, _Evaluator()) == "bybit"
+
+
 @pytest.mark.parametrize(
     ("mutate", "evaluator", "message"),
     [
-        (
-            lambda config: config["live"].__setitem__(
-                "strategy_kind", "trailing_martingale"
-            ),
-            _Evaluator,
-            "single-coin strategy_kind=ema_anchor",
-        ),
         (
             lambda config: config["live"].__setitem__(
                 "market_order_near_touch_threshold", -0.1
@@ -1590,7 +1592,7 @@ def test_gpu_foundation_accepts_baseline_ema_single_coin_market_execution():
                 "long", ["BTC", "ETH"]
             ),
             _MulticoinEvaluator,
-            "single-coin strategy_kind=ema_anchor",
+            "single-coin EMA Anchor or Trailing Martingale",
         ),
     ],
 )
@@ -1603,6 +1605,77 @@ def test_gpu_market_execution_fails_closed_outside_baseline_scope(
 
     with pytest.raises(ValueError, match=message):
         _validate_scope(config, evaluator())
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda config: config["live"].__setitem__(
+                "max_realized_loss_pct", 0.5
+            ),
+            "live.max_realized_loss_pct",
+        ),
+        (
+            lambda config: config["bot"]["long"]["hsl"].__setitem__(
+                "enabled", True
+            ),
+            "bot.long.hsl.enabled",
+        ),
+        (
+            lambda config: config["bot"]["long"]["unstuck"].__setitem__(
+                "enabled", True
+            ),
+            "bot.long.unstuck.enabled",
+        ),
+        (
+            lambda config: config["bot"]["long"]["risk"].__setitem__(
+                "position_exposure_enforcer_enabled", True
+            ),
+            "position_exposure_enforcer_enabled",
+        ),
+        (
+            lambda config: config["bot"]["long"]["risk"].__setitem__(
+                "total_exposure_enforcer_enabled", True
+            ),
+            "total_exposure_enforcer_enabled",
+        ),
+        (
+            lambda config: config.__setitem__(
+                "coin_overrides",
+                {"BTC": {"bot": {"long": {"unstuck": {"enabled": True}}}}},
+            ),
+            "coin_overrides.BTC.bot.long.unstuck.enabled",
+        ),
+        (
+            lambda config: config.__setitem__(
+                "coin_overrides",
+                {
+                    "BTC": {
+                        "bot": {
+                            "long": {
+                                "risk": {
+                                    "total_exposure_enforcer_enabled": True
+                                }
+                            }
+                        }
+                    }
+                },
+            ),
+            "coin_overrides.BTC.bot.long.risk.total_exposure_enforcer_enabled",
+        ),
+    ],
+)
+def test_gpu_tm_market_execution_fails_closed_for_unmodeled_ordering(
+    mutate, message
+):
+    config = _long_only_ema_config()
+    config["live"]["strategy_kind"] = "trailing_martingale"
+    config["live"]["market_orders_allowed"] = True
+    mutate(config)
+
+    with pytest.raises(ValueError, match=message):
+        _validate_scope(config, _Evaluator())
 
 
 @pytest.mark.parametrize("risk_feature", ["loss_gate", "unstuck", "twel_enforcer"])

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -74,6 +74,7 @@ from optimization.backends.gpu_backend import (
     _validate_resume_evidence_budget,
     _validate_seed_side_match,
     _validate_scope,
+    _validate_tm_market_nonrecursive_bounds,
     _GPU_SUITE_METRICS_KEY,
     _GPU_SUITE_OBJECTIVES_KEY,
     _GPU_SUITE_VIOLATION_KEY,
@@ -1575,6 +1576,40 @@ def test_gpu_foundation_accepts_baseline_tm_single_coin_market_execution():
     config["live"]["market_order_near_touch_threshold"] = 0.002
 
     assert _validate_scope(config, _Evaluator()) == "bybit"
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "long_entry_retracement_base_pct",
+        "long_close_retracement_base_pct",
+    ],
+)
+def test_gpu_tm_market_execution_rejects_recursive_mode_bounds(key):
+    config = _long_only_ema_config()
+    config["live"]["strategy_kind"] = "trailing_martingale"
+    config["live"]["market_orders_allowed"] = True
+    bounds = {
+        "long_entry_retracement_base_pct": Bound(0.001, 0.1),
+        "long_close_retracement_base_pct": Bound(0.001, 0.1),
+    }
+    bounds[key] = Bound(0.0, 0.1)
+
+    with pytest.raises(ValueError, match="Recursive market ladders"):
+        _validate_tm_market_nonrecursive_bounds(bounds, {}, {"long"}, config)
+
+
+def test_gpu_tm_market_execution_accepts_trailing_only_mode_bounds():
+    config = _long_only_ema_config()
+    config["live"]["strategy_kind"] = "trailing_martingale"
+    config["live"]["market_orders_allowed"] = True
+    bounds = {
+        f"{side}_{phase}_retracement_base_pct": Bound(0.001, 0.1)
+        for side in ("long", "short")
+        for phase in ("entry", "close")
+    }
+
+    _validate_tm_market_nonrecursive_bounds(bounds, {}, {"long"}, config)
 
 
 @pytest.mark.parametrize(

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -75,6 +75,7 @@ from optimization.backends.gpu_backend import (
     _validate_seed_side_match,
     _validate_scope,
     _validate_tm_market_nonrecursive_bounds,
+    _validate_tm_market_ordering_bounds,
     _GPU_SUITE_METRICS_KEY,
     _GPU_SUITE_OBJECTIVES_KEY,
     _GPU_SUITE_VIOLATION_KEY,
@@ -1612,6 +1613,44 @@ def test_gpu_tm_market_execution_accepts_trailing_only_mode_bounds():
     }
 
     _validate_tm_market_nonrecursive_bounds(bounds, {}, {"long"}, config)
+
+
+@pytest.mark.parametrize("side", ["long", "short"])
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        "unstuck_enabled",
+        "risk_position_exposure_enforcer_enabled",
+        "risk_total_exposure_enforcer_enabled",
+    ],
+)
+def test_gpu_tm_market_execution_rejects_unmodeled_ordering_bounds(side, suffix):
+    config = _long_only_ema_config()
+    config["live"]["strategy_kind"] = "trailing_martingale"
+    config["live"]["market_orders_allowed"] = True
+    key = f"{side}_{suffix}"
+
+    with pytest.raises(ValueError, match=key):
+        _validate_tm_market_ordering_bounds(
+            {key: Bound(0.0, 1.0)}, {key: 0.0}, {side}, config
+        )
+
+
+def test_gpu_tm_market_execution_accepts_disabled_ordering_bounds():
+    config = _long_only_ema_config()
+    config["live"]["strategy_kind"] = "trailing_martingale"
+    config["live"]["market_orders_allowed"] = True
+    bounds = {
+        f"{side}_{suffix}": Bound(0.0, 0.0)
+        for side in ("long", "short")
+        for suffix in (
+            "unstuck_enabled",
+            "risk_position_exposure_enforcer_enabled",
+            "risk_total_exposure_enforcer_enabled",
+        )
+    }
+
+    _validate_tm_market_ordering_bounds(bounds, {}, {"long", "short"}, config)
 
 
 @pytest.mark.parametrize(

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -76,6 +76,7 @@ from optimization.backends.gpu_backend import (
     _validate_scope,
     _validate_tm_market_nonrecursive_bounds,
     _validate_tm_market_ordering_bounds,
+    _validate_tm_market_template_bounds,
     _GPU_SUITE_METRICS_KEY,
     _GPU_SUITE_OBJECTIVES_KEY,
     _GPU_SUITE_VIOLATION_KEY,
@@ -1651,6 +1652,52 @@ def test_gpu_tm_market_execution_accepts_disabled_ordering_bounds():
     }
 
     _validate_tm_market_ordering_bounds(bounds, {}, {"long", "short"}, config)
+
+
+@pytest.mark.parametrize(
+    ("bounds", "message"),
+    [
+        (
+            {
+                "long_entry_retracement_base_pct": Bound(0.0, 0.1),
+                "long_close_retracement_base_pct": Bound(0.001, 0.1),
+            },
+            "Recursive market ladders",
+        ),
+        (
+            {
+                "long_entry_retracement_base_pct": Bound(0.001, 0.1),
+                "long_close_retracement_base_pct": Bound(0.001, 0.1),
+                "long_unstuck_enabled": Bound(0.0, 1.0),
+            },
+            "long_unstuck_enabled",
+        ),
+    ],
+)
+def test_gpu_tm_market_suite_validates_effective_scenarios_not_template(
+    bounds, message
+):
+    template = _long_only_ema_config()
+    template["live"]["strategy_kind"] = "trailing_martingale"
+    template["live"]["market_orders_allowed"] = True
+
+    _validate_tm_market_template_bounds(
+        bounds,
+        {},
+        {"long"},
+        template,
+        [{"config": {"effective": True}}],
+    )
+
+    scenario = copy.deepcopy(template)
+    scenario["live"]["market_orders_allowed"] = False
+    _validate_tm_market_nonrecursive_bounds(bounds, {}, {"long"}, scenario)
+    _validate_tm_market_ordering_bounds(bounds, {}, {"long"}, scenario)
+
+    with pytest.raises(ValueError, match=message):
+        _validate_tm_market_template_bounds(
+            bounds, {}, {"long"}, template, []
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -6709,6 +6709,80 @@ def test_mps_tm_recursive_near_touch_market_close_uses_taker_fill(side):
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_recursive_close_sizing_uses_generation_market(side):
+    import passivbot_rust
+
+    row = _tm_single_row(initial_ema_dist=0.0)
+    row[15] = 0.5
+    row[16] = 0.1 if side == "long" else -0.1
+    row[17] = 0.01 if side == "long" else -0.01
+    row[20] = 0.0
+    row[24] = 0.01
+    params = torch.tensor(row, dtype=torch.float32, device="mps")
+    probe_kernel = r"""
+kernel void passivbot_tm_recursive_close_generation_market_probe(
+    constant float* params,
+    device float* output,
+    constant int& is_long_raw,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    bool is_long = is_long_raw != 0;
+    TmSide source = load_side(params, 0, 100.0f);
+    source.close_gen_balance = 1000.0f;
+    source.close_gen_psize = 0.1f;
+    source.close_gen_pprice = 100.0f;
+    source.close_gen_market_price = is_long ? 80.0f : 140.0f;
+    source.close_gen_touch_down_ticks = is_long ? 7999 : 13999;
+    source.close_gen_touch_up_ticks = is_long ? 8001 : 14001;
+    source.close_gen_touch_nearest_ticks = is_long ? 8000 : 14000;
+    source.close_gen_touch_min_qty = is_long ? 0.063f : 0.036f;
+    source.close_gen_touch_min_qty_relation = 0;
+    source.market_order_near_touch_threshold = 0.12f;
+
+    CloseGroup group;
+    source.market_orders_allowed = true;
+    output[0] = float(recursive_close_groups(
+        source, is_long, 0, 0.001f, 0.01f, 0.001f, 5.005f, 1.0f, 500, group
+    ));
+    output[1] = group.qty;
+    recursive_close_groups(
+        source, is_long, 1, 0.001f, 0.01f, 0.001f, 5.005f, 1.0f, 500, group
+    );
+    output[2] = group.qty;
+
+    source.market_orders_allowed = false;
+    output[3] = float(recursive_close_groups(
+        source, is_long, 0, 0.001f, 0.01f, 0.001f, 5.005f, 1.0f, 500, group
+    ));
+    output[4] = group.qty;
+    recursive_close_groups(
+        source, is_long, 1, 0.001f, 0.01f, 0.001f, 5.005f, 1.0f, 500, group
+    );
+    output[5] = group.qty;
+}
+"""
+    output = torch.zeros(6, dtype=torch.float32, device="mps")
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_trailing_martingale_source_py() + probe_kernel
+    )
+    library.passivbot_tm_recursive_close_generation_market_probe(
+        params,
+        output,
+        1 if side == "long" else 0,
+        threads=(1, 1, 1),
+    )
+    torch.mps.synchronize()
+
+    values = output.cpu().numpy()
+    assert values[0] >= 2.0
+    np.testing.assert_allclose(values[:3], values[3:], atol=1.0e-6)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 @pytest.mark.parametrize("hedge_mode", [False, True])
 def test_mps_tm_dual_side_market_entries_respect_position_mode(hedge_mode):
     count = 5
@@ -11360,6 +11434,7 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert "resize_market_close_qty(" in source
     assert "entry_gen_market_price" in source
     assert "close_gen_market_price" in source
+    assert "sim.market_orders_allowed = false" in source
     assert "the proxy uses a zero-loss envelope" in source
     assert "const bool filter_by_min_effective_cost" in source
     assert "passes_min_effective_cost" in source

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -6709,6 +6709,44 @@ def test_mps_tm_recursive_near_touch_market_close_uses_taker_fill(side):
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+def test_mps_tm_recursive_close_scan_includes_near_touch_bound():
+    import passivbot_rust
+
+    probe_kernel = r"""
+kernel void passivbot_tm_recursive_close_scan_probe(
+    device float* output,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    output[0] = recursive_close_bound_requires_scan(
+        10050, false, 10000, 100.0f, 0.01f, true, 0.006f
+    ) ? 1.0f : 0.0f;
+    output[1] = recursive_close_bound_requires_scan(
+        9950, true, 10000, 100.0f, 0.01f, true, 0.006f
+    ) ? 1.0f : 0.0f;
+    output[2] = recursive_close_bound_requires_scan(
+        10100, false, 10000, 100.0f, 0.01f, true, 0.006f
+    ) ? 1.0f : 0.0f;
+    output[3] = recursive_close_bound_requires_scan(
+        9900, true, 10000, 100.0f, 0.01f, true, 0.006f
+    ) ? 1.0f : 0.0f;
+}
+"""
+    output = torch.zeros(4, dtype=torch.float32, device="mps")
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_trailing_martingale_source_py() + probe_kernel
+    )
+    library.passivbot_tm_recursive_close_scan_probe(
+        output, threads=(1, 1, 1)
+    )
+    torch.mps.synchronize()
+
+    assert output.cpu().tolist() == [1.0, 1.0, 0.0, 0.0]
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 @pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_tm_recursive_close_sizing_uses_generation_market(side):
     import passivbot_rust
@@ -11435,6 +11473,9 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert "entry_gen_market_price" in source
     assert "close_gen_market_price" in source
     assert "sim.market_orders_allowed = false" in source
+    assert source.count("ladder_side.market_orders_allowed = false") == 2
+    assert source.count("ladder_side.psize + strategy_eq") == 2
+    assert source.count("recursive_close_bound_requires_scan(") == 3
     assert "the proxy uses a zero-loss envelope" in source
     assert "const bool filter_by_min_effective_cost" in source
     assert "passes_min_effective_cost" in source

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -227,16 +227,23 @@ def test_trailing_martingale_no_hsl_specialization_keeps_base_scalar_abi(
     assert runner.hsl_raw_drawdown_enabled is False
 
 
-def test_trailing_martingale_runner_rejects_unmodeled_ordinary_market_execution():
+def test_trailing_martingale_runner_accepts_ordinary_market_execution(monkeypatch):
+    from optimization.gpu.mps_kernel import MpsEmaAnchorRunner
     from optimization.gpu.mps_kernel import MpsTrailingMartingaleRunner
 
-    with pytest.raises(ValueError, match="ordinary market execution is not modeled"):
-        MpsTrailingMartingaleRunner(
-            None,
-            None,
-            None,
-            market_orders_allowed=True,
-        )
+    def fake_base_init(self, *args, **kwargs):
+        self.long_enabled = True
+        self.short_enabled = False
+        self.hsl_ema_tail_enabled = False
+        self.hsl_raw_drawdown_enabled = False
+        self.recovery_distribution_enabled = False
+
+    monkeypatch.setattr(MpsEmaAnchorRunner, "__init__", fake_base_init)
+    runner = MpsTrailingMartingaleRunner(
+        None, None, None, market_orders_allowed=True, hsl_enabled=False
+    )
+
+    assert runner.shader_topology == "long_no_hsl"
 
 
 @pytest.mark.skipif(
@@ -6565,6 +6572,187 @@ def _tm_single_row(
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+@pytest.mark.parametrize("side", ["long", "short"])
+@pytest.mark.parametrize("recursive_entry", [False, True])
+def test_mps_tm_near_touch_market_entry_uses_taker_fill(
+    side, recursive_entry
+):
+    count = 5
+    close = np.full(count, 100.0)
+    high = np.full(count, 100.0)
+    low = np.full(count, 100.0)
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0002)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_single_row(initial_ema_dist=0.001)
+    row[11] = 0.0 if recursive_entry else 0.001
+    row[16] = 10.0
+    row[20] = 0.001
+    params = np.asarray([row + row], dtype=np.float64)
+    common = {
+        "long_enabled": side == "long",
+        "short_enabled": side == "short",
+        "hsl_enabled": False,
+    }
+
+    resting = MpsTrailingMartingaleRunner(
+        market, run, data, **common
+    ).run(params)
+    market_output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        taker_fee=0.01,
+        market_order_slippage_pct=0.01,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.002,
+        **common,
+    ).run(params)
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    price_key = "pprice" if side == "long" else "short_pprice"
+    assert resting[size_key].item() == 0.0
+    assert market_output[size_key].item() > 0.0
+    assert market_output[price_key].item() == pytest.approx(
+        101.0 if side == "long" else 99.0, abs=1.0e-4
+    )
+    assert market_output["balance"].item() < 1_000.0
+    assert market_output["fill_count_entry"].item() >= 1.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_recursive_near_touch_market_close_uses_taker_fill(side):
+    count = 7
+    close = np.full(count, 99.0 if side == "long" else 101.0)
+    close[:3] = 100.0
+    high = close.copy()
+    low = close.copy()
+    if side == "long":
+        high[3] = 100.0
+        low[3] = 98.0
+    else:
+        high[3] = 102.0
+        low[3] = 100.0
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_single_row(initial_ema_dist=0.01)
+    row[11] = 0.001
+    row[16] = 0.005
+    row[20] = 0.0
+    params = np.asarray([row + row], dtype=np.float64)
+    common = {
+        "long_enabled": side == "long",
+        "short_enabled": side == "short",
+        "hsl_enabled": False,
+    }
+
+    resting = MpsTrailingMartingaleRunner(
+        market, run, data, **common
+    ).run(params)
+    zero_cost_market = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.006,
+        **common,
+    ).run(params)
+    costly_market = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        taker_fee=0.01,
+        market_order_slippage_pct=0.01,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.006,
+        **common,
+    ).run(params)
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    assert resting[size_key].item() > 0.0
+    assert zero_cost_market[size_key].item() == 0.0
+    assert costly_market[size_key].item() == 0.0
+    assert costly_market["balance"].item() < zero_cost_market["balance"].item()
+    assert costly_market["fill_count"].item() >= 2.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("hedge_mode", [False, True])
+def test_mps_tm_dual_side_market_entries_respect_position_mode(hedge_mode):
+    count = 5
+    close = np.full(count, 100.0)
+    high = np.full(count, 100.0)
+    low = np.full(count, 100.0)
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_single_row(initial_ema_dist=0.001)
+    row[16] = 10.0
+
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=True,
+        short_enabled=True,
+        hedge_mode=hedge_mode,
+        hsl_enabled=False,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.002,
+    ).run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert output["psize"].item() > 0.0
+    assert (output["short_psize"].item() > 0.0) is hedge_mode
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
 @pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_position_unchanged_includes_open_tail(strategy_kind, side):
@@ -11161,7 +11349,17 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert "const float market_order_slippage_pct = fmax(settings[16], 0.0f)" in source
     assert "const bool long_hsl_panic_market = settings[17] > 0.5f" in source
     assert "const bool short_hsl_panic_market = settings[18] > 0.5f" in source
-    assert "market_panic ? taker_fee : maker_fee" in source
+    assert "market_execution ? taker_fee : maker_fee" in source
+    assert "const bool market_orders_allowed = settings[19] > 0.5f" in source
+    assert (
+        "const float market_order_near_touch_threshold = fmax(settings[20], 0.0f)"
+        in source
+    )
+    assert "should_use_ordinary_market_execution(" in source
+    assert "ordinary_market_fill_price(" in source
+    assert "resize_market_close_qty(" in source
+    assert "entry_gen_market_price" in source
+    assert "close_gen_market_price" in source
     assert "the proxy uses a zero-loss envelope" in source
     assert "const bool filter_by_min_effective_cost" in source
     assert "passes_min_effective_cost" in source

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -6733,6 +6733,50 @@ def test_mps_tm_market_entry_gate_drops_unexecutable_cap_remainder(side):
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_market_entry_gate_handles_qty_step_below_float32_ulp(side):
+    count = 5
+    close = np.full(count, 1.0e-7)
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(1.0, 1.0e-9, 1.0, 5.0, 1.0, 0.0)
+    run = ProxyRun(
+        10.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(close, close, close, timestamps, run, market)
+    row = _tm_single_row(initial_ema_dist=0.02, entry_gate=True)
+    row[6] = 1.0
+    row[20] = 0.001
+    row[24] = 0.5
+
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+        hsl_enabled=False,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.03,
+    ).run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert np.spacing(np.float32(50_000_000.0)) > market.qty_step
+    assert output["fill_count_entry"].item() == 0.0
+    assert output["psize" if side == "long" else "short_psize"].item() == 0.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_tm_recursive_close_remains_passive_with_market_policy(side):
     count = 7
     close = np.full(count, 99.0 if side == "long" else 101.0)

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -6682,7 +6682,51 @@ def test_mps_tm_long_market_entry_crop_requires_total_exposure_gate():
 
     assert without_gate["psize"].item() > with_gate["psize"].item()
     assert without_gate["psize"].item() == pytest.approx(10.204, abs=1.0e-3)
-    assert with_gate["psize"].item() == pytest.approx(10.0, abs=1.0e-3)
+    assert 9.997 <= with_gate["psize"].item() < 10.0
+    assert with_gate["psize"].item() * 100.0 / run.starting_balance < 1.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_market_entry_gate_drops_unexecutable_cap_remainder(side):
+    count = 5
+    close = np.full(count, 100.0)
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(1.0, 0.01, 1.0, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(close, close, close, timestamps, run, market)
+    row = _tm_single_row(initial_ema_dist=0.02, entry_gate=True)
+    row[6] = 1.0
+    row[20] = 0.001
+    row[24] = 0.05
+
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+        hsl_enabled=False,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.03,
+    ).run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert output["fill_count_entry"].item() == 0.0
+    assert output["psize" if side == "long" else "short_psize"].item() == 0.0
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -6625,6 +6625,11 @@ def test_mps_tm_near_touch_market_entry_uses_taker_fill(
     size_key = "psize" if side == "long" else "short_psize"
     price_key = "pprice" if side == "long" else "short_pprice"
     assert resting[size_key].item() == 0.0
+    if recursive_entry:
+        assert market_output[size_key].item() == 0.0
+        assert market_output["balance"].item() == pytest.approx(1_000.0)
+        assert market_output["fill_count_entry"].item() == 0.0
+        return
     assert market_output[size_key].item() > 0.0
     assert market_output[price_key].item() == pytest.approx(
         101.0 if side == "long" else 99.0, abs=1.0e-4
@@ -6636,8 +6641,55 @@ def test_mps_tm_near_touch_market_entry_uses_taker_fill(
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+def test_mps_tm_long_market_entry_crop_requires_total_exposure_gate():
+    count = 5
+    close = np.full(count, 100.0)
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(close, close, close, timestamps, run, market)
+    disabled = _tm_single_row(initial_ema_dist=0.02, entry_gate=False)
+    enabled = _tm_single_row(initial_ema_dist=0.02, entry_gate=True)
+    disabled[6] = enabled[6] = 1.0
+    disabled[16] = enabled[16] = 10.0
+    disabled[20] = enabled[20] = 0.001
+    common = {
+        "long_enabled": True,
+        "short_enabled": False,
+        "hsl_enabled": False,
+        "market_orders_allowed": True,
+        "market_order_near_touch_threshold": 0.03,
+    }
+
+    without_gate = MpsTrailingMartingaleRunner(
+        market, run, data, **common
+    ).run(np.asarray([disabled + disabled], dtype=np.float64))
+    with_gate = MpsTrailingMartingaleRunner(
+        market, run, data, **common
+    ).run(np.asarray([enabled + enabled], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert without_gate["psize"].item() > with_gate["psize"].item()
+    assert without_gate["psize"].item() == pytest.approx(10.204, abs=1.0e-3)
+    assert with_gate["psize"].item() == pytest.approx(10.0, abs=1.0e-3)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 @pytest.mark.parametrize("side", ["long", "short"])
-def test_mps_tm_recursive_near_touch_market_close_uses_taker_fill(side):
+def test_mps_tm_recursive_close_remains_passive_with_market_policy(side):
     count = 7
     close = np.full(count, 99.0 if side == "long" else 101.0)
     close[:3] = 100.0
@@ -6700,48 +6752,15 @@ def test_mps_tm_recursive_near_touch_market_close_uses_taker_fill(side):
 
     size_key = "psize" if side == "long" else "short_psize"
     assert resting[size_key].item() > 0.0
-    assert zero_cost_market[size_key].item() == 0.0
-    assert costly_market[size_key].item() == 0.0
-    assert costly_market["balance"].item() < zero_cost_market["balance"].item()
-    assert costly_market["fill_count"].item() >= 2.0
-
-
-@pytest.mark.skipif(
-    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
-)
-def test_mps_tm_recursive_close_scan_includes_near_touch_bound():
-    import passivbot_rust
-
-    probe_kernel = r"""
-kernel void passivbot_tm_recursive_close_scan_probe(
-    device float* output,
-    uint b [[thread_position_in_grid]]
-) {
-    if (b > 0) return;
-    output[0] = recursive_close_bound_requires_scan(
-        10050, false, 10000, 100.0f, 0.01f, true, 0.006f
-    ) ? 1.0f : 0.0f;
-    output[1] = recursive_close_bound_requires_scan(
-        9950, true, 10000, 100.0f, 0.01f, true, 0.006f
-    ) ? 1.0f : 0.0f;
-    output[2] = recursive_close_bound_requires_scan(
-        10100, false, 10000, 100.0f, 0.01f, true, 0.006f
-    ) ? 1.0f : 0.0f;
-    output[3] = recursive_close_bound_requires_scan(
-        9900, true, 10000, 100.0f, 0.01f, true, 0.006f
-    ) ? 1.0f : 0.0f;
-}
-"""
-    output = torch.zeros(4, dtype=torch.float32, device="mps")
-    library = torch.mps.compile_shader(
-        passivbot_rust.mps_trailing_martingale_source_py() + probe_kernel
+    assert zero_cost_market[size_key].item() == pytest.approx(
+        resting[size_key].item(), abs=1.0e-6
     )
-    library.passivbot_tm_recursive_close_scan_probe(
-        output, threads=(1, 1, 1)
+    assert costly_market[size_key].item() == pytest.approx(
+        resting[size_key].item(), abs=1.0e-6
     )
-    torch.mps.synchronize()
-
-    assert output.cpu().tolist() == [1.0, 1.0, 0.0, 0.0]
+    assert costly_market["balance"].item() == pytest.approx(
+        resting["balance"].item(), abs=1.0e-6
+    )
 
 
 @pytest.mark.skipif(
@@ -11475,7 +11494,9 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert "sim.market_orders_allowed = false" in source
     assert source.count("ladder_side.market_orders_allowed = false") == 2
     assert source.count("ladder_side.psize + strategy_eq") == 2
-    assert source.count("recursive_close_bound_requires_scan(") == 3
+    assert source.count("bool entry_market = rung == 0 &&") == 2
+    assert "s.entry_retracement_base > 0.0f" in source
+    assert "s.close_retracement_base > 0.0f" in source
     assert "the proxy uses a zero-loss envelope" in source
     assert "const bool filter_by_min_effective_cost" in source
     assert "passes_min_effective_cost" in source


### PR DESCRIPTION
## Summary

- add single-coin Trailing Martingale ordinary market-order execution to the Apple MPS screening kernel for trailing/single-order entry and close modes
- apply near-touch classification, next-candle adverse slippage, taker fees, executable-touch minimum sizing, and optional total-exposure entry gating in Rust orchestration order
- support long-only, short-only, hedge-mode dual-side, and one-way arbitration
- fail closed before optimization when any enabled TM market side can enter recursive entry or close mode; recursive market ladders require a later batch-policy/aggregate-trimming slice
- keep exact Rust validation authoritative and fail closed for TM market execution combined with HSL, auto-unstuck, exposure repair, realized-loss gating, coin-override variants of those features, or multi-coin execution

`trailing_grid_v7` is permanently outside the GPU parity project and is not implemented by this PR.

## Validation

- `cargo test --no-default-features` — 267 passed
- `cargo check --tests` — passed
- `python -m pytest -q tests/optimization` — passed, including physical Apple M3/MPS tests
- focused physical MPS coverage for long/short trailing near-touch entries and closes, disabled-gate sizing, recursive-mode fail-safe behavior, taker fees, adverse slippage, hedge mode, and one-way arbitration
- exact rebuilt extension fingerprint verified before testing
- end-to-end cached-BTC trailing-only M3 smoke — 8 generations, 1,024 proxy evaluations, 64 exact Rust validations, no drift halt