### PR TITLE
feat(gpu): combine TM market execution with HSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Extended single-coin Trailing Martingale ordinary market-order optimization on Apple MPS to
+  compatible HSL modes and one-sided minimum-effective-cost filtering. Recursive entry/close
+  modes, auto-unstuck, exposure repair, realized-loss gating, and multi-coin market execution
+  remain fail closed pending their execution-ordering slices.
+
 - Added baseline ordinary market-order execution to Apple MPS optimization for single-coin
   Trailing Martingale, covering long, short, and dual-side near-touch trailing entries and closes,
   executable-touch minimum sizing, adverse slippage, and taker fees. Recursive entry/close modes,
-  HSL, auto-unstuck, exposure repair, realized-loss gating, and multi-coin combinations remain fail
+  auto-unstuck, exposure repair, realized-loss gating, and multi-coin combinations remain fail
   closed until their Trailing Martingale market-order interactions are implemented.
 
 - Extended single-coin EMA Anchor ordinary market-order optimization on Apple MPS to compatible

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -278,16 +278,20 @@ The supported slice is intentionally narrow:
   approximate multi-coin selection cannot conservatively bound exact Rust's cash balance for
   another flat side or coin
 - `live.market_orders_allowed: false` for the complete strategy/risk surface. Single-coin EMA
-  Anchor also supports `true` for long-only, short-only, hedge-mode dual-side, one-way, and
-  compatible suite scenarios when auto-unstuck and total-exposure repair are disabled and
-  `live.max_realized_loss_pct >= 1`. Single-coin HSL and the existing one-sided
-  minimum-effective-cost filter are supported in combination with ordinary market execution. The
-  Metal proxy classifies each generated order against the current candle close using
+  Anchor supports `true` for long-only, short-only, hedge-mode dual-side, one-way, and compatible
+  suite scenarios, including HSL, one-sided minimum-effective-cost filtering, auto-unstuck,
+  total-exposure repair, and realized-loss gating. Single-coin Trailing Martingale supports the
+  same directional and position-mode topologies with HSL and one-sided minimum-effective-cost
+  filtering when every enabled side's entry and close retracement lower bounds remain strictly
+  positive, auto-unstuck and exposure repair remain disabled, and
+  `live.max_realized_loss_pct >= 1`. The Metal proxy classifies each generated order against the
+  current candle close using
   `live.market_order_near_touch_threshold`, retains that execution intent for the pending order,
   and fills promoted orders on the next valid candle at its adversely slipped, directionally
   rounded close with the taker fee. Market closes and short entries are resized at the executable
-  touch before they are retained. Trailing Martingale, multi-coin market execution, and the
-  excluded risk-order interactions remain fail closed until their execution ordering is modeled
+  touch before they are retained. Trailing Martingale recursive market ladders, multi-coin market
+  execution, and its excluded risk-order interactions remain fail closed until their execution
+  ordering is modeled
 - no invalid candle tail after the selected coin's final valid candle
 
 Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor and

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -297,6 +297,30 @@ struct CloseGroup {
     float qty;
 };
 
+inline void install_hsl_panic_close(
+    thread TmSide& side,
+    bool is_long,
+    int touch_down_tick,
+    int touch_up_tick,
+    float price_step
+) {
+    side.close_ticks = is_long
+        ? max(touch_down_tick - 1, 1)
+        : max(touch_up_tick + 1, 1);
+    side.close_price = float(side.close_ticks) * price_step;
+    side.close_qty = side.psize;
+    side.secondary_close_qty = 0.0f;
+    side.close_is_exposure_reducer = false;
+    side.close_is_twel_reducer = false;
+    side.close_is_unstuck_reducer = false;
+    // HSL replaces the generated ordinary close. Panic execution policy is
+    // carried separately by close_is_panic and the side-specific runner
+    // setting; ordinary market flags must not leak into a limit panic.
+    side.close_market = false;
+    side.secondary_close_market = false;
+    side.close_is_panic = true;
+}
+
 inline float directional_equity_at_close(
     float balance,
     thread TmSide& long_side,
@@ -2793,24 +2817,14 @@ inline void passivbot_single_coin_impl(
                 short_side.entry_qty = 0.0f;
             }
             if (long_enabled && long_hsl_mode == 3) {
-                long_side.close_ticks = max(touch_down_tick - 1, 1);
-                long_side.close_price = float(long_side.close_ticks) * price_step;
-                long_side.close_qty = long_side.psize;
-                long_side.secondary_close_qty = 0.0f;
-                long_side.close_is_exposure_reducer = false;
-                long_side.close_is_twel_reducer = false;
-                long_side.close_is_unstuck_reducer = false;
-                long_side.close_is_panic = true;
+                install_hsl_panic_close(
+                    long_side, true, touch_down_tick, touch_up_tick, price_step
+                );
             }
             if (short_enabled && short_hsl_mode == 3) {
-                short_side.close_ticks = max(touch_up_tick + 1, 1);
-                short_side.close_price = float(short_side.close_ticks) * price_step;
-                short_side.close_qty = short_side.psize;
-                short_side.secondary_close_qty = 0.0f;
-                short_side.close_is_exposure_reducer = false;
-                short_side.close_is_twel_reducer = false;
-                short_side.close_is_unstuck_reducer = false;
-                short_side.close_is_panic = true;
+                install_hsl_panic_close(
+                    short_side, false, touch_down_tick, touch_up_tick, price_step
+                );
             }
         }
 

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -977,8 +977,6 @@ def _validate_scope_config(
                 unsupported_market_features.append("live.max_realized_loss_pct")
             for side in enabled_sides:
                 side_config = config.get("bot", {}).get(side, {}) or {}
-                if _gpu_hsl_side_enabled(config, side):
-                    unsupported_market_features.append(f"bot.{side}.hsl.enabled")
                 if bool((side_config.get("unstuck", {}) or {}).get("enabled", False)):
                     unsupported_market_features.append(
                         f"bot.{side}.unstuck.enabled"
@@ -1016,7 +1014,7 @@ def _validate_scope_config(
             if unsupported_market_features:
                 raise ValueError(
                     "GPU Trailing Martingale ordinary market execution does not "
-                    "yet support risk/HSL ordering for: "
+                    "yet support risk ordering for: "
                     + ", ".join(sorted(unsupported_market_features))
                 )
     if bool(config.get("backtest", {}).get("filter_by_min_effective_cost")) and len(

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -781,6 +781,45 @@ def test_gpu_suite_hsl_signal_override_revalidates_effective_topology():
         _gpu_suite_scenario_inputs(config, Suite())
 
 
+def test_gpu_suite_inputs_accept_single_coin_tm_market_hsl_and_min_cost():
+    config = _directional_tm_config(long_enabled=True, short_enabled=False)
+    config["backtest"]["suite_enabled"] = True
+    config["backtest"]["filter_by_min_effective_cost"] = True
+    config["backtest"]["liquidation_threshold"] = 0.05
+    config["live"]["market_orders_allowed"] = True
+    config["live"]["hsl_signal_mode"] = "coin"
+    config["live"]["pnls_max_lookback_days"] = "all"
+    config["bot"]["long"]["hsl"]["enabled"] = True
+    ctx = SimpleNamespace(
+        label="tm_market_hsl",
+        overrides={},
+        exchanges=["bybit"],
+        msss={"bybit": {"BTC": {}, "__meta__": {}}},
+        timestamps={"bybit": np.arange(10, dtype=np.int64)},
+    )
+
+    class Suite:
+        contexts = [ctx]
+
+        @staticmethod
+        def get_prepared_context_data(_ctx, _exchange):
+            return np.zeros((10, 1, 4)), np.ones(10), [0]
+
+        @staticmethod
+        def build_scenario_candidate_config(proxy_config, _ctx):
+            return copy.deepcopy(proxy_config)
+
+    prepared = _gpu_suite_scenario_inputs(config, Suite())
+
+    assert len(prepared) == 1
+    assert prepared[0]["config"]["live"]["market_orders_allowed"] is True
+    assert prepared[0]["config"]["bot"]["long"]["hsl"]["enabled"] is True
+    assert (
+        prepared[0]["config"]["backtest"]["filter_by_min_effective_cost"]
+        is True
+    )
+
+
 def test_gpu_suite_inputs_accept_scenario_local_modeled_coin_overrides():
     config = _long_only_ema_config()
     config["backtest"]["suite_enabled"] = True
@@ -1740,12 +1779,6 @@ def test_gpu_market_execution_fails_closed_outside_baseline_scope(
             "live.max_realized_loss_pct",
         ),
         (
-            lambda config: config["bot"]["long"]["hsl"].__setitem__(
-                "enabled", True
-            ),
-            "bot.long.hsl.enabled",
-        ),
-        (
             lambda config: config["bot"]["long"]["unstuck"].__setitem__(
                 "enabled", True
             ),
@@ -1815,9 +1848,13 @@ def test_gpu_market_execution_accepts_single_coin_ema_risk_ordering(risk_feature
     assert _validate_scope(config, _Evaluator()) == "bybit"
 
 
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
 @pytest.mark.parametrize("signal_mode", ["unified", "pside", "coin"])
-def test_gpu_market_execution_accepts_single_coin_ema_hsl(signal_mode):
+def test_gpu_market_execution_accepts_single_coin_hsl(
+    strategy_kind, signal_mode
+):
     config = _long_only_ema_config()
+    config["live"]["strategy_kind"] = strategy_kind
     config["live"]["market_orders_allowed"] = True
     config["live"]["hsl_signal_mode"] = signal_mode
     config["live"]["pnls_max_lookback_days"] = "all"
@@ -1826,8 +1863,12 @@ def test_gpu_market_execution_accepts_single_coin_ema_hsl(signal_mode):
     assert _validate_scope(config, _Evaluator()) == "bybit"
 
 
-def test_gpu_market_execution_accepts_hsl_with_min_effective_cost_filter():
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+def test_gpu_market_execution_accepts_hsl_with_min_effective_cost_filter(
+    strategy_kind,
+):
     config = _long_only_ema_config()
+    config["live"]["strategy_kind"] = strategy_kind
     config["live"]["market_orders_allowed"] = True
     config["live"]["hsl_signal_mode"] = "coin"
     config["live"]["pnls_max_lookback_days"] = "all"

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -7202,25 +7202,22 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
     market_output = market_runner.run(
         np.asarray([rows[1]], dtype=np.float64)
     )
-    ordinary_market_runner = None
-    ordinary_market_output = None
-    if strategy_kind == "ema_anchor":
-        ordinary_market_runner = runner_cls(
-            market,
-            run,
-            data,
-            long_enabled=side == "long",
-            short_enabled=side == "short",
-            taker_fee=0.01,
-            market_order_slippage_pct=0.02,
-            market_orders_allowed=True,
-            market_order_near_touch_threshold=0.001,
-            hsl_panic_market_long=side == "long",
-            hsl_panic_market_short=side == "short",
-        )
-        ordinary_market_output = ordinary_market_runner.run(
-            np.asarray([rows[1]], dtype=np.float64)
-        )
+    ordinary_market_runner = runner_cls(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+        taker_fee=0.01,
+        market_order_slippage_pct=0.02,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.001,
+        hsl_panic_market_long=side == "long",
+        hsl_panic_market_short=side == "short",
+    )
+    ordinary_market_output = ordinary_market_runner.run(
+        np.asarray([rows[1]], dtype=np.float64)
+    )
     gated_output = runner_cls(
         market,
         run,
@@ -7290,13 +7287,12 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
         market_output["hsl_panic_close_loss_sum"].item()
         > output["hsl_panic_close_loss_sum"][1].item()
     )
-    if strategy_kind == "ema_anchor":
-        assert ordinary_market_runner.settings[19].item() == 1.0
-        assert ordinary_market_output[size_key].item() == 0.0
-        assert ordinary_market_output[trigger_key].item() == 1.0
-        assert ordinary_market_output["hsl_flatten_time_count"].item() == 1.0
-        assert ordinary_market_output["hsl_panic_close_loss_sum"].item() > 0.0
-        assert torch.isfinite(ordinary_market_output["balance"]).all()
+    assert ordinary_market_runner.settings[19].item() == 1.0
+    assert ordinary_market_output[size_key].item() == 0.0
+    assert ordinary_market_output[trigger_key].item() == 1.0
+    assert ordinary_market_output["hsl_flatten_time_count"].item() == 1.0
+    assert ordinary_market_output["hsl_panic_close_loss_sum"].item() > 0.0
+    assert torch.isfinite(ordinary_market_output["balance"]).all()
 
 
 @pytest.mark.skipif(
@@ -11245,7 +11241,10 @@ def test_mps_min_effective_cost_uses_downward_projected_cost_bound():
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
-def test_mps_short_market_entry_respects_eligible_min_effective_cost_filter():
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+def test_mps_short_market_entry_respects_eligible_min_effective_cost_filter(
+    strategy_kind,
+):
     count = 5
     close = np.full(count, 100.0)
     timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
@@ -11263,23 +11262,31 @@ def test_mps_short_market_entry_respects_eligible_min_effective_cost_filter():
         count - 1,
     )
     data = build_mps_data(close, close, close, timestamps, run, market)
-    row = [
-        0.1,
-        2.0,
-        3.0,
-        0.0,
-        0.0005,
-        0.0,
-        0.0,
-        0.0,
-        2.0,
-        2.0,
-        0.0,
-        1.0,
-    ]
-    row += _single_coin_exposure_fields() + _tm_twel_enforcer_fields()
+    if strategy_kind == "trailing_martingale":
+        row = _tm_single_row(initial_ema_dist=0.001)
+        row[6] = 0.2
+        runner_cls = MpsTrailingMartingaleRunner
+        expected_psize = 1.998
+    else:
+        row = [
+            0.1,
+            2.0,
+            3.0,
+            0.0,
+            0.0005,
+            0.0,
+            0.0,
+            0.0,
+            2.0,
+            2.0,
+            0.0,
+            1.0,
+        ]
+        row += _single_coin_exposure_fields() + _tm_twel_enforcer_fields()
+        runner_cls = MpsEmaAnchorRunner
+        expected_psize = 1.0
 
-    output = MpsEmaAnchorRunner(
+    output = runner_cls(
         market,
         run,
         data,
@@ -11287,12 +11294,12 @@ def test_mps_short_market_entry_respects_eligible_min_effective_cost_filter():
         short_enabled=True,
         filter_by_min_effective_cost=True,
         market_orders_allowed=True,
-        market_order_near_touch_threshold=0.001,
+        market_order_near_touch_threshold=0.002,
     ).run(np.asarray([row + row], dtype=np.float64))
     torch.mps.synchronize()
 
     assert output["fill_count"].item() == 1.0
-    assert output["short_psize"].item() == pytest.approx(1.0)
+    assert output["short_psize"].item() == pytest.approx(expected_psize)
     assert output["short_pprice"].item() == pytest.approx(100.0)
 
 

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -6928,6 +6928,68 @@ kernel void passivbot_tm_recursive_close_generation_market_probe(
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_hsl_panic_replacement_clears_ordinary_market_state(side):
+    import passivbot_rust
+
+    params = torch.tensor(
+        _tm_single_row(), dtype=torch.float32, device="mps"
+    )
+    probe_kernel = r"""
+kernel void passivbot_tm_hsl_panic_state_probe(
+    constant float* params,
+    device float* output,
+    constant int& is_long_raw,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    bool is_long = is_long_raw != 0;
+    TmSide side = load_side(params, 0, 100.0f);
+    side.psize = 0.2f;
+    side.close_market = true;
+    side.secondary_close_market = true;
+    side.secondary_close_qty = 0.1f;
+    side.close_is_exposure_reducer = true;
+    side.close_is_twel_reducer = true;
+    side.close_is_unstuck_reducer = true;
+    install_hsl_panic_close(side, is_long, 9999, 10001, 0.01f);
+
+    output[0] = float(side.close_ticks);
+    output[1] = side.close_price;
+    output[2] = side.close_qty;
+    output[3] = side.secondary_close_qty;
+    output[4] = float(side.close_market);
+    output[5] = float(side.secondary_close_market);
+    output[6] = float(side.close_is_exposure_reducer);
+    output[7] = float(side.close_is_twel_reducer);
+    output[8] = float(side.close_is_unstuck_reducer);
+    output[9] = float(side.close_is_panic);
+}
+"""
+    output = torch.zeros(10, dtype=torch.float32, device="mps")
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_trailing_martingale_source_py() + probe_kernel
+    )
+    library.passivbot_tm_hsl_panic_state_probe(
+        params,
+        output,
+        1 if side == "long" else 0,
+        threads=(1, 1, 1),
+    )
+    torch.mps.synchronize()
+
+    values = output.cpu().numpy()
+    expected_ticks = 9998.0 if side == "long" else 10002.0
+    assert values[0] == expected_ticks
+    assert values[1] == pytest.approx(expected_ticks * 0.01)
+    assert values[2] == pytest.approx(0.2)
+    assert values[3:9].tolist() == [0.0] * 6
+    assert values[9] == 1.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 @pytest.mark.parametrize("hedge_mode", [False, True])
 def test_mps_tm_dual_side_market_entries_respect_position_mode(hedge_mode):
     count = 5


### PR DESCRIPTION
## Summary
- allow single-coin Trailing Martingale ordinary-market screening to use the existing Metal HSL controller
- preserve HSL panic-close precedence and one-sided minimum-effective-cost filtering for long and short runs
- cover compatible suite scenarios and document the effective supported surface
- keep recursive TM market ladders, unstuck and exposure-repair and loss-gate ordering, and multi-coin market execution fail closed; trailing_grid_v7 remains outside GPU scope

## Validation
- full tests/optimization pytest suite
- full GPU backend pytest file
- targeted physical Apple MPS tests for the existing TM market baseline, HSL panic precedence on both sides, and eligible minimum-cost market entry
- bounded cached-data GPU optimization: 1,024 MPS proxy evaluations plus 64 exact Rust validations, no drift or constraint halt
- cargo test with no default features: 267 passed
- cargo check tests
- AI documentation checker: 0 errors, repository-size warnings only
- strict MkDocs build reaches the build and reports only the two existing release-note links to the root changelog

Exact Rust validations remain authoritative; this change only expands the additive Apple MPS screening surface.