### PR TITLE
feat(gpu): order TM market risk closes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,17 @@ All notable user-facing changes will be documented in this file.
 ## Unreleased
 
 - Extended single-coin Trailing Martingale ordinary market-order optimization on Apple MPS to
-  compatible HSL modes and one-sided minimum-effective-cost filtering. Recursive entry/close
-  modes, auto-unstuck, exposure repair, realized-loss gating, and multi-coin market execution
-  remain fail closed pending their execution-ordering slices.
+  compatible HSL modes, one-sided minimum-effective-cost filtering, auto-unstuck, position- and
+  total-exposure repair, and realized-loss gating. Market-promoted reducers are resized at
+  executable touch before selection and aggregate allocation, and adverse slippage plus taker fees
+  participate in the conservative loss projection. Recursive entry/close modes and multi-coin
+  market execution remain fail closed pending their dedicated slices.
 
 - Added baseline ordinary market-order execution to Apple MPS optimization for single-coin
   Trailing Martingale, covering long, short, and dual-side near-touch trailing entries and closes,
   executable-touch minimum sizing, adverse slippage, and taker fees. Recursive entry/close modes,
-  auto-unstuck, exposure repair, realized-loss gating, and multi-coin combinations remain fail
-  closed until their Trailing Martingale market-order interactions are implemented.
+  and multi-coin combinations remain fail closed until their Trailing Martingale market-order
+  interactions are implemented.
 
 - Extended single-coin EMA Anchor ordinary market-order optimization on Apple MPS to compatible
   HSL modes, one-sided minimum-effective-cost filtering, auto-unstuck, total-exposure repair, and

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -283,15 +283,16 @@ The supported slice is intentionally narrow:
   total-exposure repair, and realized-loss gating. Single-coin Trailing Martingale supports the
   same directional and position-mode topologies with HSL and one-sided minimum-effective-cost
   filtering when every enabled side's entry and close retracement lower bounds remain strictly
-  positive, auto-unstuck and exposure repair remain disabled, and
-  `live.max_realized_loss_pct >= 1`. The Metal proxy classifies each generated order against the
+  positive. Auto-unstuck, position- and total-exposure repair, and realized-loss gating may remain
+  enabled or tunable. The Metal proxy classifies each generated order against the
   current candle close using
   `live.market_order_near_touch_threshold`, retains that execution intent for the pending order,
   and fills promoted orders on the next valid candle at its adversely slipped, directionally
   rounded close with the taker fee. Market closes and short entries are resized at the executable
-  touch before they are retained. Trailing Martingale recursive market ladders, multi-coin market
-  execution, and its excluded risk-order interactions remain fail closed until their execution
-  ordering is modeled
+  touch before they are retained. Protective reducers are independently classified and resized
+  before reducer selection and aggregate allocation; adverse slippage and taker fees participate
+  in realized-loss gating. Trailing Martingale recursive market ladders and multi-coin market
+  execution remain fail closed until their execution ordering is modeled
 - no invalid candle tail after the selected coin's final valid candle
 
 Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor and

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -115,13 +115,13 @@ inline bool passes_min_effective_cost(
 
 inline bool realized_loss_proxy_allows_close(
     float qty, float close_price, float pprice, bool is_long,
-    float c_mult, float maker_fee, bool gate_enabled
+    float c_mult, float fee_rate, bool gate_enabled
 ) {
     if (!gate_enabled) return true;
     if (!(qty > 0.0f && close_price > 0.0f && pprice > 0.0f)) return false;
     float gross_pnl = qty * c_mult
         * (is_long ? close_price - pprice : pprice - close_price);
-    float fee = qty * close_price * c_mult * maker_fee;
+    float fee = qty * close_price * c_mult * fee_rate;
     float net_pnl = gross_pnl - fee;
     // Enumerating and reserving the recursive TM close ladder at every candle
     // would make screening proportional to its 500-rung exact upper bound.
@@ -148,7 +148,7 @@ inline bool realized_loss_proxy_allows_reducer(
     bool is_long,
     bool is_unstuck,
     float c_mult,
-    float maker_fee,
+    float fee_rate,
     bool gate_enabled,
     float balance,
     float realized_pnl_cumsum_last,
@@ -159,13 +159,13 @@ inline bool realized_loss_proxy_allows_reducer(
     if (!is_unstuck) {
         return realized_loss_proxy_allows_close(
             qty, close_price, pprice, is_long,
-            c_mult, maker_fee, true
+            c_mult, fee_rate, true
         );
     }
     if (!(qty > 0.0f && close_price > 0.0f && pprice > 0.0f)) return false;
     float gross_pnl = qty * c_mult
         * (is_long ? close_price - pprice : pprice - close_price);
-    float fee = qty * close_price * c_mult * maker_fee;
+    float fee = qty * close_price * c_mult * fee_rate;
     float net_pnl = gross_pnl - fee;
     if (!isfinite(net_pnl)) return false;
     if (net_pnl >= 0.0f) return true;
@@ -957,6 +957,18 @@ inline void generate_orders(
             s.psize, s.pprice, balance, wel_target, wel_price,
             qty_step, min_qty, min_cost, c_mult
         ) : 0.0f;
+    bool wel_market = wel_qty > 0.0f
+        && should_use_ordinary_market_execution(
+            wel_ticks, !is_long, price_now, price_step,
+            s.market_orders_allowed, s.market_order_near_touch_threshold
+        );
+    if (wel_market) {
+        wel_qty = resize_market_close_qty(
+            wel_qty, s.psize, price_now,
+            qty_step, min_qty, min_cost, c_mult
+        );
+    }
+    float wel_exec_price = wel_market ? price_now : wel_price;
 
     float twel_target = s.twel * s.twel_enforcer_threshold;
     int twel_ticks = is_long
@@ -970,6 +982,18 @@ inline void generate_orders(
             s.psize, s.pprice, balance, twel_target, twel_price,
             qty_step, min_qty, min_cost, c_mult
         ) : 0.0f;
+    bool twel_market = twel_qty > 0.0f
+        && should_use_ordinary_market_execution(
+            twel_ticks, !is_long, price_now, price_step,
+            s.market_orders_allowed, s.market_order_near_touch_threshold
+        );
+    if (twel_market) {
+        twel_qty = resize_market_close_qty(
+            twel_qty, s.psize, price_now,
+            qty_step, min_qty, min_cost, c_mult
+        );
+    }
+    float twel_exec_price = twel_market ? price_now : twel_price;
 
     int unstuck_ticks = is_long ? touch_up_ticks : touch_down_ticks;
     float unstuck_price = float(unstuck_ticks) * price_step;
@@ -979,6 +1003,18 @@ inline void generate_orders(
             qty_step, min_qty, min_cost, c_mult
         )
         : 0.0f;
+    bool unstuck_market = unstuck_qty > 0.0f
+        && should_use_ordinary_market_execution(
+            unstuck_ticks, !is_long, price_now, price_step,
+            s.market_orders_allowed, s.market_order_near_touch_threshold
+        );
+    if (unstuck_market) {
+        unstuck_qty = resize_market_close_qty(
+            unstuck_qty, s.psize, price_now,
+            qty_step, min_qty, min_cost, c_mult
+        );
+    }
+    float unstuck_exec_price = unstuck_market ? price_now : unstuck_price;
 
     float ct = s.close_threshold_base + wer * s.close_threshold_we
         + s.vol1h * s.close_threshold_v1h + s.vol1m * s.close_threshold_v1m;
@@ -1045,28 +1081,32 @@ inline void generate_orders(
             qty_step, min_qty, min_cost, c_mult
         );
     }
+    float ordinary_min = s.close_market
+        ? min_entry_qty(price_now, qty_step, min_qty, min_cost, c_mult)
+        : close_mq;
+    int ordinary_min_relation = s.close_market ? 0 : close_mq_relation;
     bool ordinary_can_accompany_reducer = wel_qty <= 0.0f
         && trailing_close && s.close_qty > 0.0f;
     float finalized_wel_qty = finalized_reducer_qty(
-        s.psize, wel_qty, wel_price,
+        s.psize, wel_qty, wel_exec_price,
         qty_step, min_qty, min_cost, c_mult
     );
     float finalized_twel_qty = ordinary_can_accompany_reducer
         ? finalized_reducer_qty_with_ordinary(
-            s.psize, twel_qty, twel_price, s.close_qty, close_mq,
-            close_mq_relation, qty_step, min_qty, min_cost, c_mult
+            s.psize, twel_qty, twel_exec_price, s.close_qty, ordinary_min,
+            ordinary_min_relation, qty_step, min_qty, min_cost, c_mult
         )
         : finalized_reducer_qty(
-            s.psize, twel_qty, twel_price,
+            s.psize, twel_qty, twel_exec_price,
             qty_step, min_qty, min_cost, c_mult
         );
     float finalized_unstuck_qty = ordinary_can_accompany_reducer
         ? finalized_reducer_qty_with_ordinary(
-            s.psize, unstuck_qty, unstuck_price, s.close_qty, close_mq,
-            close_mq_relation, qty_step, min_qty, min_cost, c_mult
+            s.psize, unstuck_qty, unstuck_exec_price, s.close_qty, ordinary_min,
+            ordinary_min_relation, qty_step, min_qty, min_cost, c_mult
         )
         : finalized_reducer_qty(
-            s.psize, unstuck_qty, unstuck_price,
+            s.psize, unstuck_qty, unstuck_exec_price,
             qty_step, min_qty, min_cost, c_mult
         );
     int unstuck_order_type_id = is_long ? 9 : 20;
@@ -1093,9 +1133,12 @@ inline void generate_orders(
         ? unstuck_ticks : (use_twel ? twel_ticks : wel_ticks);
     float reducer_price = use_unstuck
         ? unstuck_price : (use_twel ? twel_price : wel_price);
+    bool reducer_market = use_unstuck
+        ? unstuck_market : (use_twel ? twel_market : wel_market);
+    float reducer_exec_price = reducer_market ? price_now : reducer_price;
     if (reducer_qty > 0.0f && reducer_ticks > 0) {
         float reducer_min = min_entry_qty(
-            reducer_price, qty_step, min_qty, min_cost, c_mult
+            reducer_exec_price, qty_step, min_qty, min_cost, c_mult
         );
         // WEL is emitted by the strategy itself and therefore suppresses a
         // trailing close. TWEL is appended by orchestration, so it retains an
@@ -1109,8 +1152,9 @@ inline void generate_orders(
                     round_step(s.psize - reducer_qty, qty_step), 0.0f
                 );
             }
-            bool ordinary_below_minimum = ordinary_qty < close_mq
-                || (ordinary_qty == close_mq && close_mq_relation > 0);
+            bool ordinary_below_minimum = ordinary_qty < ordinary_min
+                || (ordinary_qty == ordinary_min
+                    && ordinary_min_relation > 0);
             if (!ordinary_below_minimum) {
                 float remainder = fmax(
                     round_step(
@@ -1118,7 +1162,7 @@ inline void generate_orders(
                     ),
                     0.0f
                 );
-                float minimum_any = fmin(close_mq, reducer_min);
+                float minimum_any = fmin(ordinary_min, reducer_min);
                 if (remainder > 0.0f && remainder < minimum_any) {
                     ordinary_qty = fmin(
                         s.psize - reducer_qty,
@@ -1128,6 +1172,7 @@ inline void generate_orders(
                 s.secondary_close_ticks = s.close_ticks;
                 s.secondary_close_price = s.close_price;
                 s.secondary_close_qty = ordinary_qty;
+                s.secondary_close_market = s.close_market;
             }
         }
         if (s.secondary_close_qty <= 0.0f) {
@@ -1141,6 +1186,7 @@ inline void generate_orders(
         s.close_ticks = reducer_ticks;
         s.close_price = reducer_price;
         s.close_qty = reducer_qty;
+        s.close_market = reducer_market;
         s.close_is_exposure_reducer = true;
         s.close_is_twel_reducer = use_twel && !use_unstuck;
         s.close_is_unstuck_reducer = use_unstuck;
@@ -1864,7 +1910,8 @@ inline void passivbot_single_coin_impl(
                 if (!long_side.close_is_panic
                     && !realized_loss_proxy_allows_reducer(
                         adj, cp, long_side.pprice, true, selected_unstuck,
-                        c_mult, maker_fee, loss_gate_enabled, balance,
+                        c_mult, market_execution ? taker_fee : maker_fee,
+                        loss_gate_enabled, balance,
                         realized_pnl_cumsum_last,
                         realized_pnl_cumsum_max,
                         max_realized_loss_pct)) continue;
@@ -2430,7 +2477,8 @@ inline void passivbot_single_coin_impl(
                 if (!short_side.close_is_panic
                     && !realized_loss_proxy_allows_reducer(
                         adj, cp, short_side.pprice, false, selected_unstuck,
-                        c_mult, maker_fee, loss_gate_enabled, balance,
+                        c_mult, market_execution ? taker_fee : maker_fee,
+                        loss_gate_enabled, balance,
                         realized_pnl_cumsum_last,
                         realized_pnl_cumsum_max,
                         max_realized_loss_pct)) continue;
@@ -2748,10 +2796,17 @@ inline void passivbot_single_coin_impl(
                 && loss_gate_enabled
                 && long_side.close_is_exposure_reducer
                 && !realized_loss_proxy_allows_reducer(
-                    long_side.close_qty, long_side.close_price,
+                    long_side.close_qty,
+                    long_side.close_market
+                        ? ordinary_market_fill_price(
+                            close, false, market_order_slippage_pct, price_step
+                        )
+                        : long_side.close_price,
                     long_side.pprice, true,
                     long_side.close_is_unstuck_reducer,
-                    c_mult, maker_fee, true, balance,
+                    c_mult,
+                    long_side.close_market ? taker_fee : maker_fee,
+                    true, balance,
                     realized_pnl_cumsum_last,
                     realized_pnl_cumsum_max,
                     max_realized_loss_pct
@@ -2779,10 +2834,17 @@ inline void passivbot_single_coin_impl(
                 && loss_gate_enabled
                 && short_side.close_is_exposure_reducer
                 && !realized_loss_proxy_allows_reducer(
-                    short_side.close_qty, short_side.close_price,
+                    short_side.close_qty,
+                    short_side.close_market
+                        ? ordinary_market_fill_price(
+                            close, true, market_order_slippage_pct, price_step
+                        )
+                        : short_side.close_price,
                     short_side.pprice, false,
                     short_side.close_is_unstuck_reducer,
-                    c_mult, maker_fee, true, balance,
+                    c_mult,
+                    short_side.close_market ? taker_fee : maker_fee,
+                    true, balance,
                     realized_pnl_cumsum_last,
                     realized_pnl_cumsum_max,
                     max_realized_loss_pct

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -971,52 +971,6 @@ def _validate_scope_config(
                 "GPU ordinary market execution currently requires single-coin "
                 "EMA Anchor or Trailing Martingale"
             )
-        if strategy_kind == "trailing_martingale":
-            unsupported_market_features = []
-            if max_realized_loss_pct < 1.0:
-                unsupported_market_features.append("live.max_realized_loss_pct")
-            for side in enabled_sides:
-                side_config = config.get("bot", {}).get(side, {}) or {}
-                if bool((side_config.get("unstuck", {}) or {}).get("enabled", False)):
-                    unsupported_market_features.append(
-                        f"bot.{side}.unstuck.enabled"
-                    )
-                risk = side_config.get("risk", {}) or {}
-                for key in (
-                    "position_exposure_enforcer_enabled",
-                    "total_exposure_enforcer_enabled",
-                ):
-                    if bool(risk.get(key, False)):
-                        unsupported_market_features.append(f"bot.{side}.risk.{key}")
-                for coin, patch in (config.get("coin_overrides") or {}).items():
-                    if not isinstance(patch, dict):
-                        continue
-                    override_side = (
-                        patch.get("bot", {}).get(side, {}) or {}
-                    )
-                    if bool(
-                        (override_side.get("unstuck", {}) or {}).get(
-                            "enabled", False
-                        )
-                    ):
-                        unsupported_market_features.append(
-                            f"coin_overrides.{coin}.bot.{side}.unstuck.enabled"
-                        )
-                    override_risk = override_side.get("risk", {}) or {}
-                    for key in (
-                        "position_exposure_enforcer_enabled",
-                        "total_exposure_enforcer_enabled",
-                    ):
-                        if bool(override_risk.get(key, False)):
-                            unsupported_market_features.append(
-                                f"coin_overrides.{coin}.bot.{side}.risk.{key}"
-                            )
-            if unsupported_market_features:
-                raise ValueError(
-                    "GPU Trailing Martingale ordinary market execution does not "
-                    "yet support risk ordering for: "
-                    + ", ".join(sorted(unsupported_market_features))
-                )
     if bool(config.get("backtest", {}).get("filter_by_min_effective_cost")) and len(
         enabled_sides
     ) != 1:
@@ -2794,44 +2748,6 @@ def _validate_tm_market_nonrecursive_bounds(
         )
 
 
-def _validate_tm_market_ordering_bounds(
-    bound_by_key, base_by_key, enabled_sides, config
-) -> None:
-    if (
-        str(config.get("live", {}).get("strategy_kind", "")).strip().lower()
-        != "trailing_martingale"
-        or not bool(config.get("live", {}).get("market_orders_allowed"))
-    ):
-        return
-    unsupported = []
-    for side in sorted(set(enabled_sides or ())):
-        for suffix in (
-            "unstuck_enabled",
-            "risk_position_exposure_enforcer_enabled",
-            "risk_total_exposure_enforcer_enabled",
-        ):
-            key = f"{side}_{suffix}"
-            bound = bound_by_key.get(key)
-            values = (
-                (float(bound.low), float(bound.high))
-                if bound is not None
-                else (float(base_by_key.get(key, 0.0)),) * 2
-            )
-            if any(
-                not math.isfinite(value)
-                or not math.isclose(value, 0.0, rel_tol=0.0, abs_tol=1.0e-12)
-                for value in values
-            ):
-                unsupported.append(f"{key} bounds={values}")
-    if unsupported:
-        raise ValueError(
-            "GPU Trailing Martingale ordinary market execution requires "
-            "unstuck and exposure-enforcer enablement bounds to remain pinned "
-            "false until their market ordering is modeled: "
-            + ", ".join(unsupported)
-        )
-
-
 def _validate_tm_market_template_bounds(
     bound_by_key, base_by_key, enabled_sides, config, suite_inputs
 ) -> None:
@@ -2840,9 +2756,6 @@ def _validate_tm_market_template_bounds(
     if suite_inputs:
         return
     _validate_tm_market_nonrecursive_bounds(
-        bound_by_key, base_by_key, enabled_sides, config
-    )
-    _validate_tm_market_ordering_bounds(
         bound_by_key, base_by_key, enabled_sides, config
     )
 
@@ -3408,12 +3321,6 @@ def run_backend(
             strategy_kind=strategy_kind,
         )
         _validate_tm_market_nonrecursive_bounds(
-            scenario_bound_by_key,
-            scenario_base_by_key,
-            scenario_enabled_sides,
-            item["config"],
-        )
-        _validate_tm_market_ordering_bounds(
             scenario_bound_by_key,
             scenario_base_by_key,
             scenario_enabled_sides,

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -75,7 +75,6 @@ from optimization.backends.gpu_backend import (
     _validate_seed_side_match,
     _validate_scope,
     _validate_tm_market_nonrecursive_bounds,
-    _validate_tm_market_ordering_bounds,
     _validate_tm_market_template_bounds,
     _GPU_SUITE_METRICS_KEY,
     _GPU_SUITE_OBJECTIVES_KEY,
@@ -781,7 +780,7 @@ def test_gpu_suite_hsl_signal_override_revalidates_effective_topology():
         _gpu_suite_scenario_inputs(config, Suite())
 
 
-def test_gpu_suite_inputs_accept_single_coin_tm_market_hsl_and_min_cost():
+def test_gpu_suite_inputs_accept_single_coin_tm_market_hsl_min_cost_and_risk():
     config = _directional_tm_config(long_enabled=True, short_enabled=False)
     config["backtest"]["suite_enabled"] = True
     config["backtest"]["filter_by_min_effective_cost"] = True
@@ -789,7 +788,13 @@ def test_gpu_suite_inputs_accept_single_coin_tm_market_hsl_and_min_cost():
     config["live"]["market_orders_allowed"] = True
     config["live"]["hsl_signal_mode"] = "coin"
     config["live"]["pnls_max_lookback_days"] = "all"
+    config["live"]["max_realized_loss_pct"] = 0.05
     config["bot"]["long"]["hsl"]["enabled"] = True
+    config["bot"]["long"]["unstuck"]["enabled"] = True
+    config["bot"]["long"]["risk"][
+        "position_exposure_enforcer_enabled"
+    ] = True
+    config["bot"]["long"]["risk"]["total_exposure_enforcer_enabled"] = True
     ctx = SimpleNamespace(
         label="tm_market_hsl",
         overrides={},
@@ -813,7 +818,15 @@ def test_gpu_suite_inputs_accept_single_coin_tm_market_hsl_and_min_cost():
 
     assert len(prepared) == 1
     assert prepared[0]["config"]["live"]["market_orders_allowed"] is True
+    assert prepared[0]["config"]["live"]["max_realized_loss_pct"] == 0.05
     assert prepared[0]["config"]["bot"]["long"]["hsl"]["enabled"] is True
+    assert prepared[0]["config"]["bot"]["long"]["unstuck"]["enabled"] is True
+    assert (
+        prepared[0]["config"]["bot"]["long"]["risk"][
+            "position_exposure_enforcer_enabled"
+        ]
+        is True
+    )
     assert (
         prepared[0]["config"]["backtest"]["filter_by_min_effective_cost"]
         is True
@@ -1664,58 +1677,26 @@ def test_gpu_tm_market_execution_accepts_trailing_only_mode_bounds():
         "risk_total_exposure_enforcer_enabled",
     ],
 )
-def test_gpu_tm_market_execution_rejects_unmodeled_ordering_bounds(side, suffix):
+def test_gpu_tm_market_execution_accepts_risk_ordering_bounds(side, suffix):
     config = _long_only_ema_config()
     config["live"]["strategy_kind"] = "trailing_martingale"
     config["live"]["market_orders_allowed"] = True
     key = f"{side}_{suffix}"
-
-    with pytest.raises(ValueError, match=key):
-        _validate_tm_market_ordering_bounds(
-            {key: Bound(0.0, 1.0)}, {key: 0.0}, {side}, config
-        )
-
-
-def test_gpu_tm_market_execution_accepts_disabled_ordering_bounds():
-    config = _long_only_ema_config()
-    config["live"]["strategy_kind"] = "trailing_martingale"
-    config["live"]["market_orders_allowed"] = True
     bounds = {
-        f"{side}_{suffix}": Bound(0.0, 0.0)
-        for side in ("long", "short")
-        for suffix in (
-            "unstuck_enabled",
-            "risk_position_exposure_enforcer_enabled",
-            "risk_total_exposure_enforcer_enabled",
-        )
+        f"{side}_entry_retracement_base_pct": Bound(0.001, 0.1),
+        f"{side}_close_retracement_base_pct": Bound(0.001, 0.1),
+        key: Bound(0.0, 1.0),
     }
 
-    _validate_tm_market_ordering_bounds(bounds, {}, {"long", "short"}, config)
+    _validate_tm_market_template_bounds(bounds, {}, {side}, config, [])
 
 
-@pytest.mark.parametrize(
-    ("bounds", "message"),
-    [
-        (
-            {
-                "long_entry_retracement_base_pct": Bound(0.0, 0.1),
-                "long_close_retracement_base_pct": Bound(0.001, 0.1),
-            },
-            "Recursive market ladders",
-        ),
-        (
-            {
-                "long_entry_retracement_base_pct": Bound(0.001, 0.1),
-                "long_close_retracement_base_pct": Bound(0.001, 0.1),
-                "long_unstuck_enabled": Bound(0.0, 1.0),
-            },
-            "long_unstuck_enabled",
-        ),
-    ],
-)
-def test_gpu_tm_market_suite_validates_effective_scenarios_not_template(
-    bounds, message
-):
+def test_gpu_tm_market_suite_validates_effective_scenarios_not_template():
+    bounds = {
+        "long_entry_retracement_base_pct": Bound(0.0, 0.1),
+        "long_close_retracement_base_pct": Bound(0.001, 0.1),
+        "long_unstuck_enabled": Bound(0.0, 1.0),
+    }
     template = _long_only_ema_config()
     template["live"]["strategy_kind"] = "trailing_martingale"
     template["live"]["market_orders_allowed"] = True
@@ -1731,9 +1712,8 @@ def test_gpu_tm_market_suite_validates_effective_scenarios_not_template(
     scenario = copy.deepcopy(template)
     scenario["live"]["market_orders_allowed"] = False
     _validate_tm_market_nonrecursive_bounds(bounds, {}, {"long"}, scenario)
-    _validate_tm_market_ordering_bounds(bounds, {}, {"long"}, scenario)
 
-    with pytest.raises(ValueError, match=message):
+    with pytest.raises(ValueError, match="Recursive market ladders"):
         _validate_tm_market_template_bounds(
             bounds, {}, {"long"}, template, []
         )
@@ -1770,68 +1750,29 @@ def test_gpu_market_execution_fails_closed_outside_baseline_scope(
 
 
 @pytest.mark.parametrize(
-    ("mutate", "message"),
+    "mutate",
     [
-        (
-            lambda config: config["live"].__setitem__(
-                "max_realized_loss_pct", 0.5
-            ),
-            "live.max_realized_loss_pct",
+        lambda config: config["live"].__setitem__(
+            "max_realized_loss_pct", 0.5
         ),
-        (
-            lambda config: config["bot"]["long"]["unstuck"].__setitem__(
-                "enabled", True
-            ),
-            "bot.long.unstuck.enabled",
+        lambda config: config["bot"]["long"]["unstuck"].__setitem__(
+            "enabled", True
         ),
-        (
-            lambda config: config["bot"]["long"]["risk"].__setitem__(
-                "position_exposure_enforcer_enabled", True
-            ),
-            "position_exposure_enforcer_enabled",
+        lambda config: config["bot"]["long"]["risk"].__setitem__(
+            "position_exposure_enforcer_enabled", True
         ),
-        (
-            lambda config: config["bot"]["long"]["risk"].__setitem__(
-                "total_exposure_enforcer_enabled", True
-            ),
-            "total_exposure_enforcer_enabled",
-        ),
-        (
-            lambda config: config.__setitem__(
-                "coin_overrides",
-                {"BTC": {"bot": {"long": {"unstuck": {"enabled": True}}}}},
-            ),
-            "coin_overrides.BTC.bot.long.unstuck.enabled",
-        ),
-        (
-            lambda config: config.__setitem__(
-                "coin_overrides",
-                {
-                    "BTC": {
-                        "bot": {
-                            "long": {
-                                "risk": {
-                                    "total_exposure_enforcer_enabled": True
-                                }
-                            }
-                        }
-                    }
-                },
-            ),
-            "coin_overrides.BTC.bot.long.risk.total_exposure_enforcer_enabled",
+        lambda config: config["bot"]["long"]["risk"].__setitem__(
+            "total_exposure_enforcer_enabled", True
         ),
     ],
 )
-def test_gpu_tm_market_execution_fails_closed_for_unmodeled_ordering(
-    mutate, message
-):
+def test_gpu_tm_market_execution_accepts_risk_ordering(mutate):
     config = _long_only_ema_config()
     config["live"]["strategy_kind"] = "trailing_martingale"
     config["live"]["market_orders_allowed"] = True
     mutate(config)
 
-    with pytest.raises(ValueError, match=message):
-        _validate_scope(config, _Evaluator())
+    assert _validate_scope(config, _Evaluator()) == "bybit"
 
 
 @pytest.mark.parametrize("risk_feature", ["loss_gate", "unstuck", "twel_enforcer"])

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -7508,7 +7508,12 @@ def test_mps_dual_side_single_coin_hsl_respects_signal_scope(
 )
 @pytest.mark.parametrize(
     ("strategy_kind", "market_orders_allowed"),
-    [("ema_anchor", False), ("ema_anchor", True), ("trailing_martingale", False)],
+    [
+        ("ema_anchor", False),
+        ("ema_anchor", True),
+        ("trailing_martingale", False),
+        ("trailing_martingale", True),
+    ],
 )
 @pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_single_coin_auto_unstuck_reduces_eligible_position(
@@ -7556,9 +7561,9 @@ def test_mps_single_coin_auto_unstuck_reduces_eligible_position(
             )
             row[6] = 1.0
             row[7] = 10.0
-            row[11] = 0.0
+            row[11] = 0.001 if market_orders_allowed else 0.0
             row[16] = 0.5
-            row[20] = 0.0
+            row[20] = 0.001 if market_orders_allowed else 0.0
             row[23] = 100.0
             return row + row
         row = [
@@ -8257,7 +8262,10 @@ def test_mps_single_coin_exposure_headroom_and_entry_gate(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("side", ["long", "short"])
-def test_mps_tm_position_exposure_repair_reduces_strictly_below_target(side):
+@pytest.mark.parametrize("market_orders_allowed", [False, True])
+def test_mps_tm_position_exposure_repair_reduces_strictly_below_target(
+    side, market_orders_allowed
+):
     count = 10
     close = np.full(count, 100.0)
     high = np.full(count, 102.0)
@@ -8280,9 +8288,9 @@ def test_mps_tm_position_exposure_repair_reduces_strictly_below_target(side):
     baseline = _tm_single_row()
     baseline[6] = 1.0
     baseline[7] = 10.0
-    baseline[11] = 0.0
+    baseline[11] = 0.001 if market_orders_allowed else 0.0
     baseline[16] = 10.0
-    baseline[20] = 0.0
+    baseline[20] = 0.001 if market_orders_allowed else 0.0
     repaired = list(baseline)
     repaired[
         TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(
@@ -8300,6 +8308,8 @@ def test_mps_tm_position_exposure_repair_reduces_strictly_below_target(side):
         data,
         long_enabled=side == "long",
         short_enabled=side == "short",
+        market_orders_allowed=market_orders_allowed,
+        market_order_near_touch_threshold=0.001,
     ).run(
         np.asarray(
             [baseline + baseline, repaired + repaired], dtype=np.float64
@@ -8332,7 +8342,8 @@ def test_mps_tm_position_exposure_repair_reduces_strictly_below_target(side):
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("side", ["long", "short"])
-def test_mps_tm_single_coin_total_exposure_repair(side):
+@pytest.mark.parametrize("market_orders_allowed", [False, True])
+def test_mps_tm_single_coin_total_exposure_repair(side, market_orders_allowed):
     count = 10
     close = np.full(count, 100.0)
     high = np.full(count, 102.0)
@@ -8358,9 +8369,9 @@ def test_mps_tm_single_coin_total_exposure_repair(side):
     baseline = _tm_single_row(entry_gate=False, threshold=0.5)
     baseline[6] = 1.0
     baseline[7] = 10.0
-    baseline[11] = 0.0
+    baseline[11] = 0.001 if market_orders_allowed else 0.0
     baseline[16] = 10.0
-    baseline[20] = 0.0
+    baseline[20] = 0.001 if market_orders_allowed else 0.0
     repaired = list(baseline)
     repaired[
         TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(
@@ -8373,6 +8384,8 @@ def test_mps_tm_single_coin_total_exposure_repair(side):
         data,
         long_enabled=side == "long",
         short_enabled=side == "short",
+        market_orders_allowed=market_orders_allowed,
+        market_order_near_touch_threshold=0.001,
     ).run(
         np.asarray(
             [baseline + baseline, repaired + repaired], dtype=np.float64
@@ -8767,7 +8780,10 @@ def test_mps_ema_zero_loss_budget_blocks_loss_below_balance_ulp():
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("side", ["long", "short"])
-def test_mps_tm_realized_loss_gate_blocks_lossy_total_exposure_repair(side):
+@pytest.mark.parametrize("market_orders_allowed", [False, True])
+def test_mps_tm_realized_loss_gate_blocks_lossy_total_exposure_repair(
+    side, market_orders_allowed
+):
     count = 8
     close = np.full(count, 100.0)
     high = np.full(count, 100.0)
@@ -8803,12 +8819,16 @@ def test_mps_tm_realized_loss_gate_blocks_lossy_total_exposure_repair(side):
     )
     row[6] = 1.0
     row[7] = 10.0
-    row[11] = 0.0
+    row[11] = 0.001 if market_orders_allowed else 0.0
     row[16] = 10.0
-    row[20] = 0.0
+    row[20] = 0.001 if market_orders_allowed else 0.0
     kwargs = {
         "long_enabled": side == "long",
         "short_enabled": side == "short",
+        "market_orders_allowed": market_orders_allowed,
+        "market_order_near_touch_threshold": 0.001,
+        "market_order_slippage_pct": 0.01,
+        "taker_fee": 0.01,
     }
 
     ungated = MpsTrailingMartingaleRunner(
@@ -8888,7 +8908,10 @@ def test_mps_tm_loss_gate_rebuilds_profitable_ordinary_close_after_reducer(side)
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("side", ["long", "short"])
-def test_mps_tm_realized_loss_gate_blocks_fee_only_ordinary_close(side):
+@pytest.mark.parametrize("market_orders_allowed", [False, True])
+def test_mps_tm_realized_loss_gate_blocks_fee_only_ordinary_close(
+    side, market_orders_allowed
+):
     count = 7
     close = np.full(count, 100.0)
     high = np.full(count, 100.0)
@@ -8930,13 +8953,17 @@ def test_mps_tm_realized_loss_gate_blocks_fee_only_ordinary_close(side):
     )
     row[6] = 0.1
     row[7] = 10.0
-    row[11] = 0.0
+    row[11] = 0.001 if market_orders_allowed else 0.0
     row[16] = -0.005
     row[17] = 0.0
-    row[20] = 0.0
+    row[20] = 0.001 if market_orders_allowed else 0.0
     kwargs = {
         "long_enabled": side == "long",
         "short_enabled": side == "short",
+        "market_orders_allowed": market_orders_allowed,
+        "market_order_near_touch_threshold": 0.001,
+        "market_order_slippage_pct": 0.01,
+        "taker_fee": 0.01,
     }
 
     ungated = MpsTrailingMartingaleRunner(
@@ -11646,6 +11673,12 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert "should_use_ordinary_market_execution(" in source
     assert "ordinary_market_fill_price(" in source
     assert "resize_market_close_qty(" in source
+    assert (
+        "float reducer_exec_price = reducer_market ? price_now : reducer_price"
+        in source
+    )
+    assert "s.secondary_close_market = s.close_market" in source
+    assert "s.close_market = reducer_market" in source
     assert "entry_gen_market_price" in source
     assert "close_gen_market_price" in source
     assert "sim.market_orders_allowed = false" in source


### PR DESCRIPTION
Extends single-coin Trailing Martingale ordinary market execution on Apple MPS to Rust-authoritative risk combinations: auto-unstuck, position and total exposure repair, and realized-loss gating. Protective reducers are independently classified and resized at executable touch before selection and aggregate allocation. Market execution cost projection now uses adverse slippage and taker fees, and ordinary secondary-close market state is preserved when a reducer wins. Recursive TM market ladders and multi-coin market execution remain fail closed. trailing_grid_v7 remains outside GPU scope.\n\nValidation:\n- cargo test --no-default-features: 267 passed\n- cargo check --tests: passed\n- full tests/optimization: passed\n- focused physical Apple M3 Metal matrix: 27 passed\n- bounded cached BTC optimizer smoke: 1024 Metal proxy evaluations, 64 exact Rust validations, no drift or constraint halt, 3.0s optimizer wall\n- native extension source stamp matched exact worktree\n- AI docs check: 0 errors (2 existing size warnings)