### PR TITLE
feat(gpu): support TM recursive market entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable user-facing changes will be documented in this file.
   snapshot after the original passive rung is next-candle reachable, short entries are resized to
   the executable minimum, and executable ladder quantities stream through the strict
   total-exposure entry gate at their limit price or market touch. Strategy-ladder sizing retains
-  its separate wallet-exposure allowance before that portfolio gate is applied. Entry optimizer
+  its separate wallet-exposure allowance before that portfolio gate is applied; the retained
+  nearest prefix ends at the first partially cropped portfolio-boundary rung. Entry optimizer
   bounds must remain wholly recursive or wholly trailing;
   mode-crossing ranges, recursive close market ladders, and multi-coin market execution remain fail
   closed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ All notable user-facing changes will be documented in this file.
 
 - Added single-coin Trailing Martingale recursive-entry market execution to Apple MPS optimization.
   Every immutable strategy-ladder rung is independently promoted against its generation market
-  snapshot, short entries are resized to the executable minimum, and promoted quantities stream
-  through the strict total-exposure entry gate. Entry optimizer bounds must remain wholly recursive
-  or wholly trailing; mode-crossing ranges, recursive close market ladders, and multi-coin market
-  execution remain fail closed.
+  snapshot after the original passive rung is next-candle reachable, short entries are resized to
+  the executable minimum, and executable ladder quantities stream through the strict
+  total-exposure entry gate at their limit price or market touch. Strategy-ladder sizing retains
+  its separate wallet-exposure allowance before that portfolio gate is applied. Entry optimizer
+  bounds must remain wholly recursive or wholly trailing;
+  mode-crossing ranges, recursive close market ladders, and multi-coin market execution remain fail
+  closed.
 
 - Extended single-coin Trailing Martingale ordinary market-order optimization on Apple MPS to
   compatible HSL modes, one-sided minimum-effective-cost filtering, auto-unstuck, position- and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,24 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added single-coin Trailing Martingale recursive-entry market execution to Apple MPS optimization.
+  Every immutable strategy-ladder rung is independently promoted against its generation market
+  snapshot, short entries are resized to the executable minimum, and promoted quantities stream
+  through the strict total-exposure entry gate. Entry optimizer bounds must remain wholly recursive
+  or wholly trailing; mode-crossing ranges, recursive close market ladders, and multi-coin market
+  execution remain fail closed.
+
 - Extended single-coin Trailing Martingale ordinary market-order optimization on Apple MPS to
   compatible HSL modes, one-sided minimum-effective-cost filtering, auto-unstuck, position- and
   total-exposure repair, and realized-loss gating. Market-promoted reducers are resized at
   executable touch before selection and aggregate allocation, and adverse slippage plus taker fees
-  participate in the conservative loss projection. Recursive entry/close modes and multi-coin
-  market execution remain fail closed pending their dedicated slices.
+  participate in the conservative loss projection. Recursive close modes and multi-coin market
+  execution remain fail closed pending their dedicated slices.
 
 - Added baseline ordinary market-order execution to Apple MPS optimization for single-coin
   Trailing Martingale, covering long, short, and dual-side near-touch trailing entries and closes,
-  executable-touch minimum sizing, adverse slippage, and taker fees. Recursive entry/close modes,
-  and multi-coin combinations remain fail closed until their Trailing Martingale market-order
+  executable-touch minimum sizing, adverse slippage, and taker fees. Recursive close modes and
+  multi-coin combinations remain fail closed until their Trailing Martingale market-order
   interactions are implemented.
 
 - Extended single-coin EMA Anchor ordinary market-order optimization on Apple MPS to compatible

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -297,7 +297,8 @@ The supported slice is intentionally narrow:
   classified against the immutable generation market snapshot only when the original passive rung
   is strictly next-candle reachable, then streamed through the strict total-exposure entry gate at
   each limit price or executable market touch. Immutable strategy sizing uses its wallet-exposure
-  allowance separately from that portfolio gate. Trailing Martingale recursive close market
+  allowance separately from that portfolio gate; a partially retained TWEL boundary rung ends the
+  nearest-order prefix so no farther rung can reappear. Trailing Martingale recursive close market
   ladders and multi-coin market execution remain fail closed until their execution ordering is
   modeled
 - no invalid candle tail after the selected coin's final valid candle

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -294,9 +294,12 @@ The supported slice is intentionally narrow:
   touch before they are retained. Protective reducers are independently classified and resized
   before reducer selection and aggregate allocation; adverse slippage and taker fees participate
   in realized-loss gating. For recursive Trailing Martingale entries, every ladder rung is
-  classified against the immutable generation market snapshot and streamed through the strict
-  total-exposure entry gate before execution. Trailing Martingale recursive close market ladders
-  and multi-coin market execution remain fail closed until their execution ordering is modeled
+  classified against the immutable generation market snapshot only when the original passive rung
+  is strictly next-candle reachable, then streamed through the strict total-exposure entry gate at
+  each limit price or executable market touch. Immutable strategy sizing uses its wallet-exposure
+  allowance separately from that portfolio gate. Trailing Martingale recursive close market
+  ladders and multi-coin market execution remain fail closed until their execution ordering is
+  modeled
 - no invalid candle tail after the selected coin's final valid candle
 
 Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor and

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -282,17 +282,21 @@ The supported slice is intentionally narrow:
   suite scenarios, including HSL, one-sided minimum-effective-cost filtering, auto-unstuck,
   total-exposure repair, and realized-loss gating. Single-coin Trailing Martingale supports the
   same directional and position-mode topologies with HSL and one-sided minimum-effective-cost
-  filtering when every enabled side's entry and close retracement lower bounds remain strictly
-  positive. Auto-unstuck, position- and total-exposure repair, and realized-loss gating may remain
-  enabled or tunable. The Metal proxy classifies each generated order against the
+  filtering when every enabled side's entry retracement range is wholly recursive (its upper bound
+  is nonpositive) or wholly trailing (its lower bound remains float32-positive), and every close
+  retracement lower bound remains float32-positive. Bounds that cross entry modes fail closed.
+  Auto-unstuck, position- and total-exposure repair, and realized-loss gating may remain enabled or
+  tunable. The Metal proxy classifies each generated order against the
   current candle close using
   `live.market_order_near_touch_threshold`, retains that execution intent for the pending order,
   and fills promoted orders on the next valid candle at its adversely slipped, directionally
   rounded close with the taker fee. Market closes and short entries are resized at the executable
   touch before they are retained. Protective reducers are independently classified and resized
   before reducer selection and aggregate allocation; adverse slippage and taker fees participate
-  in realized-loss gating. Trailing Martingale recursive market ladders and multi-coin market
-  execution remain fail closed until their execution ordering is modeled
+  in realized-loss gating. For recursive Trailing Martingale entries, every ladder rung is
+  classified against the immutable generation market snapshot and streamed through the strict
+  total-exposure entry gate before execution. Trailing Martingale recursive close market ladders
+  and multi-coin market execution remain fail closed until their execution ordering is modeled
 - no invalid candle tail after the selected coin's final valid candle
 
 Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor and

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -709,6 +709,13 @@ mod tests {
         assert!(source.contains("? unstuck_qty : (use_twel ? twel_qty : wel_qty)"));
         assert!(source.contains("secondary_close_qty"));
         assert!(source.contains("twel_entry_gate_enabled"));
+        assert_eq!(
+            source
+                .matches("ladder_side.twel_entry_gate_enabled = false")
+                .count(),
+            2
+        );
+        assert_eq!(source.matches("if (twel_boundary_partial) break;").count(), 2);
         assert_eq!(source.matches("= fma(").count(), 6);
         assert!(!source.contains("alpha0 * close +"));
         assert_eq!(source.matches("const int fo = k * 11").count(), 1);

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -692,8 +692,9 @@ mod tests {
         assert!(source.contains("max_since_min"));
         assert!(source.contains("max_since_open"));
         assert!(source.contains("min_since_max"));
-        assert!(source.contains("if (we_if <= s.entry_cap * 1.01f) return qty"));
-        assert!(source.contains("s.entry_cap * balance - cost"));
+        assert!(source.contains("if (we_if <= s.allowed_wel * 1.01f) return qty"));
+        assert!(source.contains("s.allowed_wel * balance - cost"));
+        assert!(source.contains("s.entry_cap * balance - current_cost"));
         assert!(source.contains("s.allowed_wel"));
         assert!(source.contains("s.wel_enforcer_enabled"));
         assert!(source.contains("wel_target"));

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -471,16 +471,18 @@ inline float crop_entry(
     if (qty <= 0.0f) return 0.0f;
     float cost = s.psize * s.pprice * c_mult;
     float we_if = (cost + qty * price * c_mult) / fmax(balance, 1.0e-9f);
-    if (we_if <= s.entry_cap * 1.01f) return qty;
+    if (we_if <= s.allowed_wel * 1.01f) return qty;
     float q = round_step(
-        (s.entry_cap * balance - cost) / fmax(price * c_mult, 1.0e-12f), qty_step
+        (s.allowed_wel * balance - cost)
+            / fmax(price * c_mult, 1.0e-12f),
+        qty_step
     );
     float mq = min_entry_qty(price, qty_step, min_qty, min_cost, c_mult);
     q = fmax(q, mq);
     return q < qty ? q : qty;
 }
 
-inline float gate_market_entry_by_twel_strict(
+inline float gate_entry_by_twel_strict(
     thread TmSide& s, float balance, float price, float qty,
     float qty_step, float min_qty, float min_cost, float c_mult
 ) {
@@ -902,11 +904,12 @@ inline void generate_orders(
     )));
     float we_if = (s.psize * s.pprice + rq * reentry_price)
         * c_mult / fmax(balance, 1.0e-9f);
-    float crop_fraction = (s.entry_cap - we) / fmax(we_if - we, 1.0e-12f);
+    float crop_fraction = (s.allowed_wel - we)
+        / fmax(we_if - we, 1.0e-12f);
     float rq_crop = fmax(round_step(rq * crop_fraction, qty_step), min_rq);
-    if (we_if > s.entry_cap * 1.01f && rq_crop < rq) rq = rq_crop;
+    if (we_if > s.allowed_wel * 1.01f && rq_crop < rq) rq = rq_crop;
     bool cap_hit = trailing_entry
-        ? we > s.entry_cap * 0.999f : we >= s.entry_cap * 0.999f;
+        ? we > s.allowed_wel * 0.999f : we >= s.allowed_wel * 0.999f;
     bool reentry_ok = !flat && !partial && !cap_hit && reentry_ticks > 1
         && (!trailing_entry || entry_triggered);
     float eqty = flat ? iq : (partial ? iq_partial : (reentry_ok ? rq : 0.0f));
@@ -922,7 +925,7 @@ inline void generate_orders(
     bool cooldown = s.cooldown_min > 0.0f && s.last_inc_k >= 0.0f
         && kf < s.last_inc_k + s.cooldown_min;
     if (cooldown || balance <= 0.0f || s.initial_qty_pct <= 0.0f
-        || s.allowed_wel <= 0.0f || s.entry_cap <= 0.0f || eticks <= 1
+        || s.allowed_wel <= 0.0f || eticks <= 1
         || (block_initial && flat)) eqty = 0.0f;
     s.entry_ticks = eticks;
     s.entry_price = eprice;
@@ -937,9 +940,10 @@ inline void generate_orders(
         && s.entry_qty < market_min_q) {
         s.entry_qty = market_min_q;
     }
-    if (entry_market && s.twel_entry_gate_enabled) {
-        s.entry_qty = gate_market_entry_by_twel_strict(
-            s, balance, price_now, s.entry_qty,
+    if (s.twel_entry_gate_enabled) {
+        float entry_gate_price = entry_market ? price_now : eprice;
+        s.entry_qty = gate_entry_by_twel_strict(
+            s, balance, entry_gate_price, s.entry_qty,
             qty_step, min_qty, min_cost, c_mult
         );
     }
@@ -1972,10 +1976,12 @@ inline void passivbot_single_coin_impl(
             long_side.secondary_close_qty = 0.0f;
         }
 
+        bool long_entry_passive_reachable = long_side.entry_qty > 0.0f
+            && long_side.entry_ticks > low_nonfill_max_tick;
         bool long_entry_fill = valid && alive && long_enabled
             && long_side.entry_qty > 0.0f
             && (long_side.entry_market
-                || long_side.entry_ticks > low_nonfill_max_tick);
+                || long_entry_passive_reachable);
         if (long_entry_fill) {
             long_entry_fill = false;
             TmSide ladder_side = long_side;
@@ -2008,10 +2014,11 @@ inline void passivbot_single_coin_impl(
                     long_side.market_orders_allowed,
                     long_side.market_order_near_touch_threshold
                 );
-                if (entry_market && rung > 0
-                    && gate_side.twel_entry_gate_enabled) {
-                    eq = gate_market_entry_by_twel_strict(
-                        gate_side, ladder_balance, ladder_market_price, eq,
+                if (rung > 0 && gate_side.twel_entry_gate_enabled) {
+                    float entry_gate_price = entry_market
+                        ? ladder_market_price : ep;
+                    eq = gate_entry_by_twel_strict(
+                        gate_side, ladder_balance, entry_gate_price, eq,
                         qty_step, min_qty, min_cost, c_mult
                     );
                     // Exact Rust removes farthest entries first.  A rejected
@@ -2068,15 +2075,17 @@ inline void passivbot_single_coin_impl(
                     day_volume += fabs(eq) * entry_fill_price / balance;
                     long_entry_fill = true;
 
-                    if (entry_market && gate_side.twel_entry_gate_enabled) {
+                    if (gate_side.twel_entry_gate_enabled) {
+                        float entry_gate_price = entry_market
+                            ? ladder_market_price : ep;
                         bool gate_flat = gate_side.psize <= 0.0f;
                         float gate_psize = round_step(
                             gate_side.psize + eq, qty_step
                         );
-                        gate_side.pprice = gate_flat ? ladder_market_price
+                        gate_side.pprice = gate_flat ? entry_gate_price
                             : gate_side.pprice * (
                                 gate_side.psize / fmax(gate_psize, 1.0e-12f)
-                            ) + ladder_market_price * (
+                            ) + entry_gate_price * (
                                 eq / fmax(gate_psize, 1.0e-12f)
                             );
                         gate_side.psize = gate_psize;
@@ -2094,6 +2103,11 @@ inline void passivbot_single_coin_impl(
                 ladder_side.psize = sim_psize;
                 previous_ticks = entry_ticks;
                 ladder_touch_ticks = min(ladder_touch_ticks, entry_ticks);
+                // Exact Rust expands the immutable recursive ladder only when
+                // the original passive next entry strictly crosses the next
+                // candle. Market promotion guarantees rung zero's execution,
+                // but does not itself authorize expansion.
+                if (rung == 0 && !long_entry_passive_reachable) break;
                 if (long_side.entry_retracement_base > 0.0f
                     || long_side.cooldown_min != 0.0f) break;
                 generate_long_orders(
@@ -2581,10 +2595,12 @@ inline void passivbot_single_coin_impl(
             short_side.secondary_close_qty = 0.0f;
         }
 
+        bool short_entry_passive_reachable = short_side.entry_qty > 0.0f
+            && short_side.entry_ticks <= high_fill_max_tick;
         bool short_entry_fill = valid && alive && short_enabled
             && short_side.entry_qty > 0.0f
             && (short_side.entry_market
-                || short_side.entry_ticks <= high_fill_max_tick);
+                || short_entry_passive_reachable);
         if (short_entry_fill) {
             short_entry_fill = false;
             TmSide ladder_side = short_side;
@@ -2621,10 +2637,11 @@ inline void passivbot_single_coin_impl(
                     );
                     if (eq < market_min_q) eq = market_min_q;
                 }
-                if (entry_market && rung > 0
-                    && gate_side.twel_entry_gate_enabled) {
-                    eq = gate_market_entry_by_twel_strict(
-                        gate_side, ladder_balance, ladder_market_price, eq,
+                if (rung > 0 && gate_side.twel_entry_gate_enabled) {
+                    float entry_gate_price = entry_market
+                        ? ladder_market_price : ep;
+                    eq = gate_entry_by_twel_strict(
+                        gate_side, ladder_balance, entry_gate_price, eq,
                         qty_step, min_qty, min_cost, c_mult
                     );
                     if (!(eq > 0.0f)) break;
@@ -2678,15 +2695,17 @@ inline void passivbot_single_coin_impl(
                     day_volume += fabs(eq) * entry_fill_price / balance;
                     short_entry_fill = true;
 
-                    if (entry_market && gate_side.twel_entry_gate_enabled) {
+                    if (gate_side.twel_entry_gate_enabled) {
+                        float entry_gate_price = entry_market
+                            ? ladder_market_price : ep;
                         bool gate_flat = gate_side.psize <= 0.0f;
                         float gate_psize = round_step(
                             gate_side.psize + eq, qty_step
                         );
-                        gate_side.pprice = gate_flat ? ladder_market_price
+                        gate_side.pprice = gate_flat ? entry_gate_price
                             : gate_side.pprice * (
                                 gate_side.psize / fmax(gate_psize, 1.0e-12f)
-                            ) + ladder_market_price * (
+                            ) + entry_gate_price * (
                                 eq / fmax(gate_psize, 1.0e-12f)
                             );
                         gate_side.psize = gate_psize;
@@ -2704,6 +2723,7 @@ inline void passivbot_single_coin_impl(
                 ladder_side.psize = sim_psize;
                 previous_ticks = entry_ticks;
                 ladder_touch_ticks = max(ladder_touch_ticks, entry_ticks);
+                if (rung == 0 && !short_entry_passive_reachable) break;
                 if (short_side.entry_retracement_base > 0.0f
                     || short_side.cooldown_min != 0.0f) break;
                 generate_short_orders(

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -277,7 +277,7 @@ struct TmSide {
     float ema0, ema1, ema2, vol1m, vol1h;
     float psize, pprice, last_inc_k, pos_open_k;
     int entry_ticks, close_ticks, secondary_close_ticks;
-    float entry_price, close_price, entry_qty, close_qty;
+    float entry_price, close_price, entry_qty, entry_strategy_qty, close_qty;
     float secondary_close_price, secondary_close_qty;
     float entry_gen_balance, entry_gen_psize, entry_gen_pprice, entry_gen_kf;
     float entry_gen_market_price;
@@ -407,7 +407,7 @@ inline TmSide load_side(constant float* p, int o, float seed) {
     s.vol1m = 0.0f; s.vol1h = 0.0f;
     s.psize = 0.0f; s.pprice = 0.0f;
     s.last_inc_k = -1.0f; s.pos_open_k = -1.0f;
-    s.entry_ticks = 0; s.entry_qty = 0.0f;
+    s.entry_ticks = 0; s.entry_qty = 0.0f; s.entry_strategy_qty = 0.0f;
     s.close_ticks = 0; s.close_qty = 0.0f;
     s.entry_price = 0.0f; s.close_price = 0.0f;
     s.secondary_close_ticks = 0; s.secondary_close_qty = 0.0f;
@@ -912,11 +912,10 @@ inline void generate_orders(
     float eqty = flat ? iq : (partial ? iq_partial : (reentry_ok ? rq : 0.0f));
     int eticks = flat || partial ? initial_ticks : reentry_ticks;
     float eprice = flat || partial ? initial_price : reentry_price;
-    bool entry_market = s.entry_retracement_base > 0.0f
-        && should_use_ordinary_market_execution(
-            eticks, is_long, price_now, price_step, s.market_orders_allowed,
-            s.market_order_near_touch_threshold
-        );
+    bool entry_market = should_use_ordinary_market_execution(
+        eticks, is_long, price_now, price_step, s.market_orders_allowed,
+        s.market_order_near_touch_threshold
+    );
     float market_min_q = entry_market
         ? min_entry_qty(price_now, qty_step, min_qty, min_cost, c_mult)
         : min_entry_qty(eprice, qty_step, min_qty, min_cost, c_mult);
@@ -931,6 +930,9 @@ inline void generate_orders(
         s, balance, eprice, eqty,
         qty_step, min_qty, min_cost, c_mult
     );
+    // Rust builds the immutable recursive strategy ladder before market
+    // executable-minimum sizing and portfolio TWEL gating mutate its orders.
+    s.entry_strategy_qty = s.entry_qty;
     if (!is_long && entry_market && s.entry_qty > 0.0f
         && s.entry_qty < market_min_q) {
         s.entry_qty = market_min_q;
@@ -1975,6 +1977,7 @@ inline void passivbot_single_coin_impl(
             && (long_side.entry_market
                 || long_side.entry_ticks > low_nonfill_max_tick);
         if (long_entry_fill) {
+            long_entry_fill = false;
             TmSide ladder_side = long_side;
             ladder_side.psize = long_side.entry_gen_psize;
             ladder_side.pprice = long_side.entry_gen_pprice;
@@ -1984,6 +1987,8 @@ inline void passivbot_single_coin_impl(
             const float ladder_balance = long_side.entry_gen_balance;
             const float ladder_kf = long_side.entry_gen_kf;
             int ladder_touch_ticks = long_side.entry_gen_touch_ticks;
+            float ladder_market_price = long_side.entry_gen_market_price;
+            TmSide gate_side = ladder_side;
             int previous_ticks = 0;
             for (int rung = 0; rung < 500; ++rung) {
                 int entry_ticks = rung == 0
@@ -1991,54 +1996,92 @@ inline void passivbot_single_coin_impl(
                 float ep = rung == 0
                     ? long_side.entry_price : ladder_side.entry_price;
                 float strategy_eq = round_step(
-                    rung == 0 ? long_side.entry_qty : ladder_side.entry_qty,
+                    rung == 0
+                        ? long_side.entry_strategy_qty
+                        : ladder_side.entry_qty,
                     qty_step
                 );
                 if (strategy_eq <= 0.0f) break;
-                float eq = strategy_eq;
-                bool entry_market = rung == 0 && long_side.entry_market;
-                if (eq <= 0.0f
-                    || (!entry_market && entry_ticks <= low_nonfill_max_tick)
+                float eq = rung == 0 ? long_side.entry_qty : strategy_eq;
+                bool entry_market = should_use_ordinary_market_execution(
+                    entry_ticks, true, ladder_market_price, price_step,
+                    long_side.market_orders_allowed,
+                    long_side.market_order_near_touch_threshold
+                );
+                if (entry_market && rung > 0
+                    && gate_side.twel_entry_gate_enabled) {
+                    eq = gate_market_entry_by_twel_strict(
+                        gate_side, ladder_balance, ladder_market_price, eq,
+                        qty_step, min_qty, min_cost, c_mult
+                    );
+                    // Exact Rust removes farthest entries first.  A rejected
+                    // boundary rung therefore closes the retained prefix;
+                    // smaller later quantities may not reappear behind it.
+                    if (!(eq > 0.0f)) break;
+                }
+                if ((!entry_market && entry_ticks <= low_nonfill_max_tick)
                     || (rung > 0 && entry_ticks == previous_ticks)) break;
-                float entry_fill_price = entry_market
-                    ? ordinary_market_fill_price(
-                        close, true, market_order_slippage_pct, price_step
-                    ) : ep;
-                float fee = eq * entry_fill_price * c_mult
-                    * (entry_market ? taker_fee : maker_fee);
-                balance -= fee;
-                record_realized_net(
-                    -fee,
-                    realized_pnl_cumsum_last,
-                    realized_pnl_cumsum_max,
-                    realized_pnl_cumsum_long,
-                    realized_pnl_cumsum_short,
-                    day_fill_count,
-                    fill_count,
-                    fill_count_entry,
-                    fill_count_long,
-                    pnl_recovery_peak,
-                    pnl_recovery_peak_k,
-                    pnl_recovery_max_min,
-                    kf,
-                    true,
-                    true
-                );
-                record_hsl_rolling_pnl(
-                    long_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
-                    long_rolling_base, rolling_capacity, int(kf),
-                    pnl_lookback_bars, long_coin_hsl_rolling, -fee
-                );
-                bool was_flat = long_side.psize <= 0.0f;
-                float new_psize = round_step(long_side.psize + eq, qty_step);
-                float new_pprice = was_flat ? entry_fill_price
-                    : long_side.pprice * (long_side.psize / fmax(new_psize, 1.0e-12f))
-                        + entry_fill_price * (eq / fmax(new_psize, 1.0e-12f));
-                if (was_flat) long_side.pos_open_k = kf;
-                long_side.psize = new_psize;
-                long_side.pprice = new_pprice;
-                long_side.last_inc_k = kf;
-                day_volume += fabs(eq) * entry_fill_price / balance;
+                if (eq > 0.0f) {
+                    float entry_fill_price = entry_market
+                        ? ordinary_market_fill_price(
+                            close, true, market_order_slippage_pct, price_step
+                        ) : ep;
+                    float fee = eq * entry_fill_price * c_mult
+                        * (entry_market ? taker_fee : maker_fee);
+                    balance -= fee;
+                    record_realized_net(
+                        -fee,
+                        realized_pnl_cumsum_last,
+                        realized_pnl_cumsum_max,
+                        realized_pnl_cumsum_long,
+                        realized_pnl_cumsum_short,
+                        day_fill_count,
+                        fill_count,
+                        fill_count_entry,
+                        fill_count_long,
+                        pnl_recovery_peak,
+                        pnl_recovery_peak_k,
+                        pnl_recovery_max_min,
+                        kf,
+                        true,
+                        true
+                    );
+                    record_hsl_rolling_pnl(
+                        long_rolling_pnl, rolling_pnl_values,
+                        rolling_pnl_indices, long_rolling_base,
+                        rolling_capacity, int(kf), pnl_lookback_bars,
+                        long_coin_hsl_rolling, -fee
+                    );
+                    bool was_flat = long_side.psize <= 0.0f;
+                    float new_psize = round_step(
+                        long_side.psize + eq, qty_step
+                    );
+                    float new_pprice = was_flat ? entry_fill_price
+                        : long_side.pprice
+                            * (long_side.psize / fmax(new_psize, 1.0e-12f))
+                            + entry_fill_price
+                                * (eq / fmax(new_psize, 1.0e-12f));
+                    if (was_flat) long_side.pos_open_k = kf;
+                    long_side.psize = new_psize;
+                    long_side.pprice = new_pprice;
+                    long_side.last_inc_k = kf;
+                    day_volume += fabs(eq) * entry_fill_price / balance;
+                    long_entry_fill = true;
+
+                    if (entry_market && gate_side.twel_entry_gate_enabled) {
+                        bool gate_flat = gate_side.psize <= 0.0f;
+                        float gate_psize = round_step(
+                            gate_side.psize + eq, qty_step
+                        );
+                        gate_side.pprice = gate_flat ? ladder_market_price
+                            : gate_side.pprice * (
+                                gate_side.psize / fmax(gate_psize, 1.0e-12f)
+                            ) + ladder_market_price * (
+                                eq / fmax(gate_psize, 1.0e-12f)
+                            );
+                        gate_side.psize = gate_psize;
+                    }
+                }
 
                 bool sim_flat = ladder_side.psize <= 0.0f;
                 float sim_psize = round_step(
@@ -2543,6 +2586,7 @@ inline void passivbot_single_coin_impl(
             && (short_side.entry_market
                 || short_side.entry_ticks <= high_fill_max_tick);
         if (short_entry_fill) {
+            short_entry_fill = false;
             TmSide ladder_side = short_side;
             ladder_side.psize = short_side.entry_gen_psize;
             ladder_side.pprice = short_side.entry_gen_pprice;
@@ -2551,6 +2595,7 @@ inline void passivbot_single_coin_impl(
             const float ladder_kf = short_side.entry_gen_kf;
             int ladder_touch_ticks = short_side.entry_gen_touch_ticks;
             float ladder_market_price = short_side.entry_gen_market_price;
+            TmSide gate_side = ladder_side;
             int previous_ticks = 0;
             for (int rung = 0; rung < 500; ++rung) {
                 int entry_ticks = rung == 0
@@ -2558,61 +2603,95 @@ inline void passivbot_single_coin_impl(
                 float ep = rung == 0
                     ? short_side.entry_price : ladder_side.entry_price;
                 float strategy_eq = round_step(
-                    rung == 0 ? short_side.entry_qty : ladder_side.entry_qty,
+                    rung == 0
+                        ? short_side.entry_strategy_qty
+                        : ladder_side.entry_qty,
                     qty_step
                 );
                 if (strategy_eq <= 0.0f) break;
-                float eq = strategy_eq;
-                bool entry_market = rung == 0 && short_side.entry_market;
+                float eq = rung == 0 ? short_side.entry_qty : strategy_eq;
+                bool entry_market = should_use_ordinary_market_execution(
+                    entry_ticks, false, ladder_market_price, price_step,
+                    short_side.market_orders_allowed,
+                    short_side.market_order_near_touch_threshold
+                );
                 if (entry_market) {
                     float market_min_q = min_entry_qty(
                         ladder_market_price, qty_step, min_qty, min_cost, c_mult
                     );
                     if (eq < market_min_q) eq = market_min_q;
                 }
-                if (eq <= 0.0f
-                    || (!entry_market && entry_ticks > high_fill_max_tick)
+                if (entry_market && rung > 0
+                    && gate_side.twel_entry_gate_enabled) {
+                    eq = gate_market_entry_by_twel_strict(
+                        gate_side, ladder_balance, ladder_market_price, eq,
+                        qty_step, min_qty, min_cost, c_mult
+                    );
+                    if (!(eq > 0.0f)) break;
+                }
+                if ((!entry_market && entry_ticks > high_fill_max_tick)
                     || (rung > 0 && entry_ticks == previous_ticks)) break;
-                float entry_fill_price = entry_market
-                    ? ordinary_market_fill_price(
-                        close, false, market_order_slippage_pct, price_step
-                    ) : ep;
-                float fee = eq * entry_fill_price * c_mult
-                    * (entry_market ? taker_fee : maker_fee);
-                balance -= fee;
-                record_realized_net(
-                    -fee,
-                    realized_pnl_cumsum_last,
-                    realized_pnl_cumsum_max,
-                    realized_pnl_cumsum_long,
-                    realized_pnl_cumsum_short,
-                    day_fill_count,
-                    fill_count,
-                    fill_count_entry,
-                    fill_count_long,
-                    pnl_recovery_peak,
-                    pnl_recovery_peak_k,
-                    pnl_recovery_max_min,
-                    kf,
-                    true,
-                    false
-                );
-                record_hsl_rolling_pnl(
-                    short_rolling_pnl,
-                    rolling_pnl_values, rolling_pnl_indices,
-                    short_rolling_base, rolling_capacity, int(kf),
-                    pnl_lookback_bars, short_coin_hsl_rolling, -fee
-                );
-                bool was_flat = short_side.psize <= 0.0f;
-                float new_psize = round_step(short_side.psize + eq, qty_step);
-                float new_pprice = was_flat ? entry_fill_price
-                    : short_side.pprice * (short_side.psize / fmax(new_psize, 1.0e-12f))
-                        + entry_fill_price * (eq / fmax(new_psize, 1.0e-12f));
-                if (was_flat) short_side.pos_open_k = kf;
-                short_side.psize = new_psize;
-                short_side.pprice = new_pprice;
-                short_side.last_inc_k = kf;
-                day_volume += fabs(eq) * entry_fill_price / balance;
+                if (eq > 0.0f) {
+                    float entry_fill_price = entry_market
+                        ? ordinary_market_fill_price(
+                            close, false, market_order_slippage_pct, price_step
+                        ) : ep;
+                    float fee = eq * entry_fill_price * c_mult
+                        * (entry_market ? taker_fee : maker_fee);
+                    balance -= fee;
+                    record_realized_net(
+                        -fee,
+                        realized_pnl_cumsum_last,
+                        realized_pnl_cumsum_max,
+                        realized_pnl_cumsum_long,
+                        realized_pnl_cumsum_short,
+                        day_fill_count,
+                        fill_count,
+                        fill_count_entry,
+                        fill_count_long,
+                        pnl_recovery_peak,
+                        pnl_recovery_peak_k,
+                        pnl_recovery_max_min,
+                        kf,
+                        true,
+                        false
+                    );
+                    record_hsl_rolling_pnl(
+                        short_rolling_pnl, rolling_pnl_values,
+                        rolling_pnl_indices, short_rolling_base,
+                        rolling_capacity, int(kf), pnl_lookback_bars,
+                        short_coin_hsl_rolling, -fee
+                    );
+                    bool was_flat = short_side.psize <= 0.0f;
+                    float new_psize = round_step(
+                        short_side.psize + eq, qty_step
+                    );
+                    float new_pprice = was_flat ? entry_fill_price
+                        : short_side.pprice
+                            * (short_side.psize / fmax(new_psize, 1.0e-12f))
+                            + entry_fill_price
+                                * (eq / fmax(new_psize, 1.0e-12f));
+                    if (was_flat) short_side.pos_open_k = kf;
+                    short_side.psize = new_psize;
+                    short_side.pprice = new_pprice;
+                    short_side.last_inc_k = kf;
+                    day_volume += fabs(eq) * entry_fill_price / balance;
+                    short_entry_fill = true;
+
+                    if (entry_market && gate_side.twel_entry_gate_enabled) {
+                        bool gate_flat = gate_side.psize <= 0.0f;
+                        float gate_psize = round_step(
+                            gate_side.psize + eq, qty_step
+                        );
+                        gate_side.pprice = gate_flat ? ladder_market_price
+                            : gate_side.pprice * (
+                                gate_side.psize / fmax(gate_psize, 1.0e-12f)
+                            ) + ladder_market_price * (
+                                eq / fmax(gate_psize, 1.0e-12f)
+                            );
+                        gate_side.psize = gate_psize;
+                    }
+                }
 
                 bool sim_flat = ladder_side.psize <= 0.0f;
                 float sim_psize = round_step(

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -1995,6 +1995,9 @@ inline void passivbot_single_coin_impl(
             int ladder_touch_ticks = long_side.entry_gen_touch_ticks;
             float ladder_market_price = long_side.entry_gen_market_price;
             TmSide gate_side = ladder_side;
+            // Rebuild the immutable strategy ladder against allowed WEL only.
+            // Portfolio TWEL gating is streamed separately through gate_side.
+            ladder_side.twel_entry_gate_enabled = false;
             int previous_ticks = 0;
             for (int rung = 0; rung < 500; ++rung) {
                 int entry_ticks = rung == 0
@@ -2009,6 +2012,7 @@ inline void passivbot_single_coin_impl(
                 );
                 if (strategy_eq <= 0.0f) break;
                 float eq = rung == 0 ? long_side.entry_qty : strategy_eq;
+                float ungated_eq = strategy_eq;
                 bool entry_market = should_use_ordinary_market_execution(
                     entry_ticks, true, ladder_market_price, price_step,
                     long_side.market_orders_allowed,
@@ -2026,6 +2030,8 @@ inline void passivbot_single_coin_impl(
                     // smaller later quantities may not reappear behind it.
                     if (!(eq > 0.0f)) break;
                 }
+                bool twel_boundary_partial = gate_side.twel_entry_gate_enabled
+                    && eq > 0.0f && eq < ungated_eq;
                 if ((!entry_market && entry_ticks <= low_nonfill_max_tick)
                     || (rung > 0 && entry_ticks == previous_ticks)) break;
                 if (eq > 0.0f) {
@@ -2091,6 +2097,9 @@ inline void passivbot_single_coin_impl(
                         gate_side.psize = gate_psize;
                     }
                 }
+                // Exact Rust keeps at most one partially retained boundary
+                // order after removing the farther suffix.
+                if (twel_boundary_partial) break;
 
                 bool sim_flat = ladder_side.psize <= 0.0f;
                 float sim_psize = round_step(
@@ -2612,6 +2621,7 @@ inline void passivbot_single_coin_impl(
             int ladder_touch_ticks = short_side.entry_gen_touch_ticks;
             float ladder_market_price = short_side.entry_gen_market_price;
             TmSide gate_side = ladder_side;
+            ladder_side.twel_entry_gate_enabled = false;
             int previous_ticks = 0;
             for (int rung = 0; rung < 500; ++rung) {
                 int entry_ticks = rung == 0
@@ -2626,6 +2636,7 @@ inline void passivbot_single_coin_impl(
                 );
                 if (strategy_eq <= 0.0f) break;
                 float eq = rung == 0 ? short_side.entry_qty : strategy_eq;
+                float ungated_eq = strategy_eq;
                 bool entry_market = should_use_ordinary_market_execution(
                     entry_ticks, false, ladder_market_price, price_step,
                     short_side.market_orders_allowed,
@@ -2636,6 +2647,7 @@ inline void passivbot_single_coin_impl(
                         ladder_market_price, qty_step, min_qty, min_cost, c_mult
                     );
                     if (eq < market_min_q) eq = market_min_q;
+                    if (ungated_eq < market_min_q) ungated_eq = market_min_q;
                 }
                 if (rung > 0 && gate_side.twel_entry_gate_enabled) {
                     float entry_gate_price = entry_market
@@ -2646,6 +2658,8 @@ inline void passivbot_single_coin_impl(
                     );
                     if (!(eq > 0.0f)) break;
                 }
+                bool twel_boundary_partial = gate_side.twel_entry_gate_enabled
+                    && eq > 0.0f && eq < ungated_eq;
                 if ((!entry_market && entry_ticks > high_fill_max_tick)
                     || (rung > 0 && entry_ticks == previous_ticks)) break;
                 if (eq > 0.0f) {
@@ -2711,6 +2725,7 @@ inline void passivbot_single_coin_impl(
                         gate_side.psize = gate_psize;
                     }
                 }
+                if (twel_boundary_partial) break;
 
                 bool sim_flat = ladder_side.psize <= 0.0f;
                 float sim_psize = round_step(

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -2709,7 +2709,7 @@ def _validate_pinned_scope_bounds(
             )
 
 
-def _validate_tm_market_nonrecursive_bounds(
+def _validate_tm_market_mode_bounds(
     bound_by_key, base_by_key, enabled_sides, config
 ) -> None:
     if (
@@ -2720,30 +2720,54 @@ def _validate_tm_market_nonrecursive_bounds(
         return
     unsupported = []
     for side in sorted(set(enabled_sides or ())):
-        for phase in ("entry", "close"):
-            key = f"{side}_{phase}_retracement_base_pct"
-            bound = bound_by_key.get(key)
-            low = (
-                float(bound.low)
-                if bound is not None
-                else float(base_by_key.get(key, 0.0))
+        entry_key = f"{side}_entry_retracement_base_pct"
+        entry_bound = bound_by_key.get(entry_key)
+        entry_low, entry_high = (
+            (float(entry_bound.low), float(entry_bound.high))
+            if entry_bound is not None
+            else (float(base_by_key.get(entry_key, 0.0)),) * 2
+        )
+        with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+            packed_entry_low = np.float32(entry_low)
+        recursive_only = entry_high <= 0.0
+        trailing_only = (
+            entry_low > 0.0
+            and np.isfinite(packed_entry_low)
+            and packed_entry_low > np.float32(0.0)
+        )
+        if (
+            not math.isfinite(entry_low)
+            or not math.isfinite(entry_high)
+            or not (recursive_only or trailing_only)
+        ):
+            unsupported.append(
+                f"{entry_key} bounds=({entry_low}, {entry_high})"
             )
-            with np.errstate(over="ignore", under="ignore", invalid="ignore"):
-                packed_low = np.float32(low)
-            if (
-                not math.isfinite(low)
-                or low <= 0.0
-                or not np.isfinite(packed_low)
-                or packed_low <= np.float32(0.0)
-            ):
-                unsupported.append(f"{key} lower={low}")
+
+        close_key = f"{side}_close_retracement_base_pct"
+        close_bound = bound_by_key.get(close_key)
+        close_low = (
+            float(close_bound.low)
+            if close_bound is not None
+            else float(base_by_key.get(close_key, 0.0))
+        )
+        with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+            packed_close_low = np.float32(close_low)
+        if (
+            not math.isfinite(close_low)
+            or close_low <= 0.0
+            or not np.isfinite(packed_close_low)
+            or packed_close_low <= np.float32(0.0)
+        ):
+            unsupported.append(f"{close_key} lower={close_low}")
     if unsupported:
         raise ValueError(
             "GPU Trailing Martingale ordinary market execution currently "
-            "requires trailing-only entry and close modes; pin every enabled "
-            "side's entry_retracement_base_pct and close_retracement_base_pct "
-            "lower bounds above zero. Recursive market ladders remain fail "
-            "closed: "
+            "requires each enabled side's entry retracement range to remain "
+            "wholly recursive (high<=0) or wholly trailing with a float32-"
+            "positive lower bound, and close_retracement_base_pct to remain "
+            "strictly trailing. Recursive close market ladders and entry mode-"
+            "crossing bounds remain fail closed: "
             + ", ".join(unsupported)
         )
 
@@ -2755,7 +2779,7 @@ def _validate_tm_market_template_bounds(
 
     if suite_inputs:
         return
-    _validate_tm_market_nonrecursive_bounds(
+    _validate_tm_market_mode_bounds(
         bound_by_key, base_by_key, enabled_sides, config
     )
 
@@ -3320,7 +3344,7 @@ def run_backend(
             coin_count=item["coin_count"],
             strategy_kind=strategy_kind,
         )
-        _validate_tm_market_nonrecursive_bounds(
+        _validate_tm_market_mode_bounds(
             scenario_bound_by_key,
             scenario_base_by_key,
             scenario_enabled_sides,

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -74,7 +74,7 @@ from optimization.backends.gpu_backend import (
     _validate_resume_evidence_budget,
     _validate_seed_side_match,
     _validate_scope,
-    _validate_tm_market_nonrecursive_bounds,
+    _validate_tm_market_mode_bounds,
     _validate_tm_market_template_bounds,
     _GPU_SUITE_METRICS_KEY,
     _GPU_SUITE_OBJECTIVES_KEY,
@@ -1633,15 +1633,18 @@ def test_gpu_foundation_accepts_baseline_tm_single_coin_market_execution():
 
 
 @pytest.mark.parametrize(
-    ("key", "low"),
+    ("key", "low", "high"),
     [
-        ("long_entry_retracement_base_pct", 0.0),
-        ("long_close_retracement_base_pct", 0.0),
-        ("long_entry_retracement_base_pct", 1.0e-50),
-        ("long_close_retracement_base_pct", 1.0e-50),
+        ("long_close_retracement_base_pct", 0.0, 0.1),
+        ("long_close_retracement_base_pct", 1.0e-50, 0.1),
+        ("long_entry_retracement_base_pct", 0.0, 0.1),
+        ("long_entry_retracement_base_pct", -0.1, 0.1),
+        ("long_entry_retracement_base_pct", 1.0e-50, 0.1),
     ],
 )
-def test_gpu_tm_market_execution_rejects_recursive_mode_bounds(key, low):
+def test_gpu_tm_market_execution_rejects_recursive_close_or_entry_mode_crossing(
+    key, low, high
+):
     config = _long_only_ema_config()
     config["live"]["strategy_kind"] = "trailing_martingale"
     config["live"]["market_orders_allowed"] = True
@@ -1649,10 +1652,10 @@ def test_gpu_tm_market_execution_rejects_recursive_mode_bounds(key, low):
         "long_entry_retracement_base_pct": Bound(0.001, 0.1),
         "long_close_retracement_base_pct": Bound(0.001, 0.1),
     }
-    bounds[key] = Bound(low, 0.1)
+    bounds[key] = Bound(low, high)
 
-    with pytest.raises(ValueError, match="Recursive market ladders"):
-        _validate_tm_market_nonrecursive_bounds(bounds, {}, {"long"}, config)
+    with pytest.raises(ValueError, match="remain fail closed"):
+        _validate_tm_market_mode_bounds(bounds, {}, {"long"}, config)
 
 
 def test_gpu_tm_market_execution_accepts_trailing_only_mode_bounds():
@@ -1665,7 +1668,22 @@ def test_gpu_tm_market_execution_accepts_trailing_only_mode_bounds():
         for phase in ("entry", "close")
     }
 
-    _validate_tm_market_nonrecursive_bounds(bounds, {}, {"long"}, config)
+    _validate_tm_market_mode_bounds(bounds, {}, {"long"}, config)
+
+
+@pytest.mark.parametrize("entry_bounds", [Bound(0.0, 0.0), Bound(-0.1, 0.0)])
+def test_gpu_tm_market_execution_accepts_recursive_entry_mode_bounds(
+    entry_bounds,
+):
+    config = _long_only_ema_config()
+    config["live"]["strategy_kind"] = "trailing_martingale"
+    config["live"]["market_orders_allowed"] = True
+    bounds = {
+        "long_entry_retracement_base_pct": entry_bounds,
+        "long_close_retracement_base_pct": Bound(0.001, 0.1),
+    }
+
+    _validate_tm_market_mode_bounds(bounds, {}, {"long"}, config)
 
 
 @pytest.mark.parametrize("side", ["long", "short"])
@@ -1711,9 +1729,9 @@ def test_gpu_tm_market_suite_validates_effective_scenarios_not_template():
 
     scenario = copy.deepcopy(template)
     scenario["live"]["market_orders_allowed"] = False
-    _validate_tm_market_nonrecursive_bounds(bounds, {}, {"long"}, scenario)
+    _validate_tm_market_mode_bounds(bounds, {}, {"long"}, scenario)
 
-    with pytest.raises(ValueError, match="Recursive market ladders"):
+    with pytest.raises(ValueError, match="entry mode-crossing"):
         _validate_tm_market_template_bounds(
             bounds, {}, {"long"}, template, []
         )

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -6625,17 +6625,82 @@ def test_mps_tm_near_touch_market_entry_uses_taker_fill(
     size_key = "psize" if side == "long" else "short_psize"
     price_key = "pprice" if side == "long" else "short_pprice"
     assert resting[size_key].item() == 0.0
-    if recursive_entry:
-        assert market_output[size_key].item() == 0.0
-        assert market_output["balance"].item() == pytest.approx(1_000.0)
-        assert market_output["fill_count_entry"].item() == 0.0
-        return
     assert market_output[size_key].item() > 0.0
     assert market_output[price_key].item() == pytest.approx(
         101.0 if side == "long" else 99.0, abs=1.0e-4
     )
     assert market_output["balance"].item() < 1_000.0
     assert market_output["fill_count_entry"].item() >= 1.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_recursive_entry_promotes_each_near_touch_rung(side):
+    count = 5
+    close = np.full(count, 100.0)
+    high = np.full(count, 100.0)
+    low = np.full(count, 100.0)
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0002)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_single_row(
+        initial_ema_dist=0.001,
+        gate_initial=False,
+        gate_reentry=False,
+        entry_gate=True,
+        threshold=0.12,
+    )
+    row[4] = 1.0
+    row[6] = 0.05
+    row[7] = 0.001
+    row[11] = 0.0
+    row[16] = 10.0
+    row[20] = 0.001
+    params = np.asarray([row + row], dtype=np.float64)
+    common = {
+        "long_enabled": side == "long",
+        "short_enabled": side == "short",
+        "hsl_enabled": False,
+    }
+
+    resting = MpsTrailingMartingaleRunner(
+        market, run, data, **common
+    ).run(params)
+    promoted = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        taker_fee=0.01,
+        market_order_slippage_pct=0.01,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.003,
+        **common,
+    ).run(params)
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    assert resting["fill_count_entry"].item() == 0.0
+    assert resting[size_key].item() == 0.0
+    assert promoted["fill_count_entry"].item() >= 2.0
+    assert promoted[size_key].item() > 0.0
+    # Rust's entry gate measures wallet exposure at the executable market
+    # snapshot, before backtest-only adverse slippage is applied to the fill.
+    assert promoted[size_key].item() * 100.0 / 1_000.0 < 0.12
+    assert promoted["balance"].item() < 1_000.0
 
 
 @pytest.mark.skipif(
@@ -11684,7 +11749,11 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert "sim.market_orders_allowed = false" in source
     assert source.count("ladder_side.market_orders_allowed = false") == 2
     assert source.count("ladder_side.psize + strategy_eq") == 2
-    assert source.count("bool entry_market = rung == 0 &&") == 2
+    assert "bool entry_market = rung == 0" not in source
+    assert "entry_ticks, true, ladder_market_price" in source
+    assert "entry_ticks, false, ladder_market_price" in source
+    assert source.count("entry_strategy_qty") == 5
+    assert source.count("if (!(eq > 0.0f)) break;") == 2
     assert "s.entry_retracement_base > 0.0f" in source
     assert "s.close_retracement_base > 0.0f" in source
     assert "the proxy uses a zero-loss envelope" in source

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -6630,7 +6630,9 @@ def test_mps_tm_near_touch_market_entry_uses_taker_fill(
         101.0 if side == "long" else 99.0, abs=1.0e-4
     )
     assert market_output["balance"].item() < 1_000.0
-    assert market_output["fill_count_entry"].item() >= 1.0
+    # Market promotion guarantees rung zero, but exact Rust does not expand a
+    # recursive ladder unless the original passive order strictly crosses.
+    assert market_output["fill_count_entry"].item() == 1.0
 
 
 @pytest.mark.skipif(
@@ -6642,6 +6644,11 @@ def test_mps_tm_recursive_entry_promotes_each_near_touch_rung(side):
     close = np.full(count, 100.0)
     high = np.full(count, 100.0)
     low = np.full(count, 100.0)
+    # Strictly cross the near passive prefix on the next candle. Exact Rust
+    # then expands the immutable ladder; near-touch promotion makes one later
+    # rung executable without requiring its passive price to cross.
+    low[3] = 99.89
+    high[3] = 100.11
     timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
     market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0002)
     run = ProxyRun(
@@ -6693,14 +6700,65 @@ def test_mps_tm_recursive_entry_promotes_each_near_touch_rung(side):
     torch.mps.synchronize()
 
     size_key = "psize" if side == "long" else "short_psize"
-    assert resting["fill_count_entry"].item() == 0.0
-    assert resting[size_key].item() == 0.0
+    assert resting["fill_count_entry"].item() >= 1.0
     assert promoted["fill_count_entry"].item() >= 2.0
-    assert promoted[size_key].item() > 0.0
+    assert promoted["fill_count_entry"].item() > resting[
+        "fill_count_entry"
+    ].item()
+    assert promoted[size_key].item() > resting[size_key].item()
     # Rust's entry gate measures wallet exposure at the executable market
     # snapshot, before backtest-only adverse slippage is applied to the fill.
     assert promoted[size_key].item() * 100.0 / 1_000.0 < 0.12
     assert promoted["balance"].item() < 1_000.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_recursive_market_entry_applies_twel_at_executable_touch(side):
+    count = 5
+    close = np.full(count, 100.0)
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(close, close, close, timestamps, run, market)
+    row = _tm_single_row(
+        initial_ema_dist=0.001,
+        entry_gate=True,
+        threshold=0.12,
+    )
+    row[6] = 1.0
+    row[11] = 0.0
+    row[16] = 10.0
+    params = np.asarray([row + row], dtype=np.float64)
+
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+        hsl_enabled=False,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.003,
+    ).run(params)
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    assert output["fill_count_entry"].item() == 1.0
+    assert output[size_key].item() == pytest.approx(1.199, abs=1.0e-4)
 
 
 @pytest.mark.skipif(
@@ -11754,6 +11812,9 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert "entry_ticks, false, ladder_market_price" in source
     assert source.count("entry_strategy_qty") == 5
     assert source.count("if (!(eq > 0.0f)) break;") == 2
+    assert source.count("entry_passive_reachable") >= 6
+    assert "gate_market_entry_by_twel_strict" not in source
+    assert source.count("gate_entry_by_twel_strict(") == 4
     assert "s.entry_retracement_base > 0.0f" in source
     assert "s.close_retracement_base > 0.0f" in source
     assert "the proxy uses a zero-loss envelope" in source

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -6638,8 +6638,13 @@ def test_mps_tm_near_touch_market_entry_uses_taker_fill(
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
-@pytest.mark.parametrize("side", ["long", "short"])
-def test_mps_tm_recursive_entry_promotes_each_near_touch_rung(side):
+@pytest.mark.parametrize(
+    ("side", "threshold", "expected_size"),
+    [("long", 0.1202, 1.201), ("short", 0.15, 1.499)],
+)
+def test_mps_tm_recursive_market_entry_retains_exact_twel_prefix(
+    side, threshold, expected_size
+):
     count = 5
     close = np.full(count, 100.0)
     high = np.full(count, 100.0)
@@ -6669,7 +6674,7 @@ def test_mps_tm_recursive_entry_promotes_each_near_touch_rung(side):
         gate_initial=False,
         gate_reentry=False,
         entry_gate=True,
-        threshold=0.12,
+        threshold=threshold,
     )
     row[4] = 1.0
     row[6] = 0.05
@@ -6701,14 +6706,16 @@ def test_mps_tm_recursive_entry_promotes_each_near_touch_rung(side):
 
     size_key = "psize" if side == "long" else "short_psize"
     assert resting["fill_count_entry"].item() >= 1.0
-    assert promoted["fill_count_entry"].item() >= 2.0
+    # Exact Rust retains the nearest full rungs plus at most one partially
+    # TWEL-cropped boundary rung.  It never lets a farther order reappear.
+    assert promoted["fill_count_entry"].item() == 3.0
     assert promoted["fill_count_entry"].item() > resting[
         "fill_count_entry"
     ].item()
-    assert promoted[size_key].item() > resting[size_key].item()
+    assert promoted[size_key].item() == pytest.approx(expected_size, abs=1.0e-4)
     # Rust's entry gate measures wallet exposure at the executable market
     # snapshot, before backtest-only adverse slippage is applied to the fill.
-    assert promoted[size_key].item() * 100.0 / 1_000.0 < 0.12
+    assert promoted[size_key].item() * 100.0 / 1_000.0 < threshold
     assert promoted["balance"].item() < 1_000.0
 
 
@@ -7742,9 +7749,9 @@ def test_mps_single_coin_auto_unstuck_reduces_eligible_position(
 
     key = "psize" if side == "long" else "short_psize"
     remaining = output[key].cpu().numpy()
-    initial_size = (
-        9.0 if strategy_kind == "ema_anchor" and side == "short" else 10.0
-    )
+    # At the 101 short-entry limit, exact Rust's strict TWEL gate retains 9
+    # whole contracts; both strategy kernels must share that result.
+    initial_size = 9.0 if side == "short" else 10.0
     assert remaining[0] == pytest.approx(initial_size)
     assert remaining[1] == pytest.approx(initial_size - 1.0)
     assert remaining[2] == pytest.approx(initial_size)
@@ -7854,15 +7861,10 @@ def test_mps_single_coin_auto_unstuck_scales_loss_to_own_allowance(
 
     key = "psize" if side == "long" else "short_psize"
     remaining = output[key].cpu().numpy()
-    initial_size = (
-        9.0 if strategy_kind == "ema_anchor" and side == "short" else 10.0
-    )
+    initial_size = 9.0 if side == "short" else 10.0
     assert remaining[0] == pytest.approx(initial_size)
     assert remaining[1] == pytest.approx(initial_size - 1.0)
-    generous_remainder = (
-        1.0 if strategy_kind == "trailing_martingale" and side == "short" else 0.0
-    )
-    assert remaining[2] == pytest.approx(generous_remainder)
+    assert remaining[2] == pytest.approx(0.0)
 
     strict_output = runner_cls(
         market,
@@ -8080,8 +8082,7 @@ def test_mps_single_coin_auto_unstuck_selects_one_least_stuck_side(strategy_kind
     torch.mps.synchronize()
 
     assert output["psize"].item() == pytest.approx(9.0)
-    expected_short = 9.0 if strategy_kind == "ema_anchor" else 10.0
-    assert output["short_psize"].item() == pytest.approx(expected_short)
+    assert output["short_psize"].item() == pytest.approx(9.0)
 
 
 @pytest.mark.skipif(
@@ -8146,7 +8147,10 @@ def test_mps_tm_equal_unstuck_twel_reducers_keep_nearer_twel(side):
     # The equal-size TWEL reducer is one price band more executable than the
     # auto-unstuck reducer. The next candle crosses TWEL but only touches
     # unstuck, proving selection follows Rust's reachability tie-break.
-    assert output[size_key].item() == pytest.approx(5.0)
+    # The strict entry gate starts the short fixture at 9 rather than 10, so
+    # its equal-size selected reducer leaves 4 contracts instead of 5.
+    expected_size = 5.0 if side == "long" else 4.0
+    assert output[size_key].item() == pytest.approx(expected_size)
     assert output["total_wallet_exposure_max"].item() > 0.0
     fill_days = output["day_has_fill"]
     assert torch.isfinite(output["day_net_pnl"][fill_days]).all()
@@ -9691,7 +9695,9 @@ def test_mps_tm_off_tick_grid_precedes_reducer_for_volume(side):
     torch.mps.synchronize()
 
     entry_price = 99.0 if side == "long" else 101.0
-    entry_qty = 10.101 if side == "long" else 9.901
+    # Exact Rust's strict TWEL gate floors the short entry from the strategy's
+    # nearest-rounded 9.901 to 9.900 at the 101 limit price.
+    entry_qty = 10.101 if side == "long" else 9.9
     grid_price = 100.0 if side == "long" else 101.0
     grid_qty = 5.045 if side == "long" else 4.945
     reducer_price = 101.0 if side == "long" else 100.0
@@ -11806,12 +11812,14 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert "close_gen_market_price" in source
     assert "sim.market_orders_allowed = false" in source
     assert source.count("ladder_side.market_orders_allowed = false") == 2
+    assert source.count("ladder_side.twel_entry_gate_enabled = false") == 2
     assert source.count("ladder_side.psize + strategy_eq") == 2
     assert "bool entry_market = rung == 0" not in source
     assert "entry_ticks, true, ladder_market_price" in source
     assert "entry_ticks, false, ladder_market_price" in source
     assert source.count("entry_strategy_qty") == 5
     assert source.count("if (!(eq > 0.0f)) break;") == 2
+    assert source.count("if (twel_boundary_partial) break;") == 2
     assert source.count("entry_passive_reachable") >= 6
     assert "gate_market_entry_by_twel_strict" not in source
     assert source.count("gate_entry_by_twel_strict(") == 4
@@ -12524,7 +12532,12 @@ def test_mps_trailing_martingale_entry_cap_uses_rust_nearest_step_rounding():
         count - 1,
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
-    row = _tm_single_row(initial_ema_dist=0.0, gate_initial=0.0, gate_reentry=0.0)
+    row = _tm_single_row(
+        initial_ema_dist=0.0,
+        gate_initial=0.0,
+        gate_reentry=0.0,
+        entry_gate=False,
+    )
     row[6] = 2.0  # Oversize the initial order so the exposure cap crops it.
     row[7] = 0.5  # Keep any subsequent reentry far below the fixture market.
     row[16] = 0.5  # Keep the close above the fixture market.


### PR DESCRIPTION
## Summary

- support single-coin Trailing Martingale recursive-entry ladders with ordinary market execution on Apple MPS
- preserve Rust ordering by separating immutable strategy-ladder quantities from executable sizing and by retaining the nearest exposure-admissible promoted prefix
- accept wholly recursive or wholly trailing entry-bound ranges while continuing to fail closed on mode-crossing entry bounds, recursive market closes, and multi-coin market execution
- document the supported scope and remaining exclusions

## Validation

- `cargo test --no-default-features` (267 passed)
- `cargo check --tests`
- `pytest tests/optimization/test_gpu_backend.py tests/optimization/test_gpu_service.py -q`
- `pytest tests/optimization -q`
- physical Apple MPS TM market/recursive matrix (53 passed)
- cached BTC GPU optimizer smoke: 8 generations, 1,024 proxy evaluations, 64 exact Rust validations, no drift or safety halt
- AI docs checks and generated registry check