### PR TITLE
feat(gpu): support TM recursive close markets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added single-coin Trailing Martingale recursive-close market execution to Apple MPS
+  optimization. Exact passive next-candle expansion remains authoritative: a market-only next
+  close does not reveal the recursive suffix, while an expanded immutable ladder classifies and
+  executable-touch-sizes every emitted price group against its generation market snapshot.
+  Promoted grid groups and protective reducers retain canonical ordering, aggregate allocation,
+  realized-loss gating, adverse slippage, and taker fees. Entry and close optimizer bounds must
+  each remain wholly recursive or wholly trailing; mode-crossing ranges and multi-coin market
+  execution remain fail closed.
+
 - Added single-coin Trailing Martingale recursive-entry market execution to Apple MPS optimization.
   Every immutable strategy-ladder rung is independently promoted against its generation market
   snapshot after the original passive rung is next-candle reachable, short entries are resized to
@@ -11,22 +20,20 @@ All notable user-facing changes will be documented in this file.
   total-exposure entry gate at their limit price or market touch. Strategy-ladder sizing retains
   its separate wallet-exposure allowance before that portfolio gate is applied; the retained
   nearest prefix ends at the first partially cropped portfolio-boundary rung. Entry optimizer
-  bounds must remain wholly recursive or wholly trailing;
-  mode-crossing ranges, recursive close market ladders, and multi-coin market execution remain fail
-  closed.
+  bounds must remain wholly recursive or wholly trailing; mode-crossing ranges and multi-coin
+  market execution remain fail closed.
 
 - Extended single-coin Trailing Martingale ordinary market-order optimization on Apple MPS to
   compatible HSL modes, one-sided minimum-effective-cost filtering, auto-unstuck, position- and
   total-exposure repair, and realized-loss gating. Market-promoted reducers are resized at
   executable touch before selection and aggregate allocation, and adverse slippage plus taker fees
-  participate in the conservative loss projection. Recursive close modes and multi-coin market
-  execution remain fail closed pending their dedicated slices.
+  participate in the conservative loss projection. Multi-coin market execution remains fail
+  closed pending its dedicated slice.
 
 - Added baseline ordinary market-order execution to Apple MPS optimization for single-coin
   Trailing Martingale, covering long, short, and dual-side near-touch trailing entries and closes,
-  executable-touch minimum sizing, adverse slippage, and taker fees. Recursive close modes and
-  multi-coin combinations remain fail closed until their Trailing Martingale market-order
-  interactions are implemented.
+  executable-touch minimum sizing, adverse slippage, and taker fees. Multi-coin combinations
+  remain fail closed until their Trailing Martingale market-order interactions are implemented.
 
 - Extended single-coin EMA Anchor ordinary market-order optimization on Apple MPS to compatible
   HSL modes, one-sided minimum-effective-cost filtering, auto-unstuck, total-exposure repair, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ All notable user-facing changes will be documented in this file.
   executable-touch-sizes every emitted price group against its generation market snapshot.
   Pre-gate WEL reachability still controls expansion when that reducer is later loss-gated.
   Passive WEL quantity seeds later rungs before executable-touch resizing, and a same-price WEL
-  merges into the following ordinary group. Promoted grid groups and protective reducers retain
-  canonical ordering, aggregate position trimming, quantity-relative minimum-size comparisons,
-  realized-loss gating, adverse slippage, and taker fees. Entry and close optimizer bounds must
+  merges into the following ordinary group even when TWEL or unstuck wins reducer selection.
+  Expanded ladders re-finalize the selected reducer's original executable-touch-sized request,
+  and promoted grid groups apply realized-loss gating to their generation-time projected market
+  price while retaining the next-candle price for fills. Promoted grid groups and protective
+  reducers retain canonical ordering, aggregate position trimming, quantity-relative minimum-size
+  comparisons, adverse slippage, and taker fees. Entry and close optimizer bounds must
   each remain wholly recursive or wholly trailing; mode-crossing ranges and multi-coin market
   execution remain fail closed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ All notable user-facing changes will be documented in this file.
   optimization. Exact passive next-candle expansion remains authoritative: a market-only next
   close does not reveal the recursive suffix, while an expanded immutable ladder classifies and
   executable-touch-sizes every emitted price group against its generation market snapshot.
-  Promoted grid groups and protective reducers retain canonical ordering, aggregate allocation,
-  realized-loss gating, adverse slippage, and taker fees. Entry and close optimizer bounds must
-  each remain wholly recursive or wholly trailing; mode-crossing ranges and multi-coin market
-  execution remain fail closed.
+  Pre-gate WEL reachability still controls expansion when that reducer is later loss-gated.
+  Promoted grid groups and protective reducers retain canonical ordering, aggregate position
+  trimming, realized-loss gating, adverse slippage, and taker fees. Entry and close optimizer
+  bounds must each remain wholly recursive or wholly trailing; mode-crossing ranges and
+  multi-coin market execution remain fail closed.
 
 - Added single-coin Trailing Martingale recursive-entry market execution to Apple MPS optimization.
   Every immutable strategy-ladder rung is independently promoted against its generation market

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ All notable user-facing changes will be documented in this file.
   Expanded ladders independently re-finalize every WEL, TWEL, and unstuck request before reducer
   selection, retry the next finalized candidate when the preferred reducer is loss-gated, and gate
   promoted reducers and grid groups at their generation-time projected market price while retaining
-  the next-candle price for fills. Promoted grid groups and protective reducers retain canonical
-  ordering, aggregate position trimming, quantity-relative minimum-size comparisons, adverse
-  slippage, and taker fees. Entry and close optimizer bounds must
+  the next-candle price for fills. Reducer loss budgets retain their generation-time realized-PnL
+  snapshot, and below-minimum reducers are removed and the ordinary ladder reallocated when another
+  close remains executable. Promoted grid groups and protective reducers retain canonical ordering,
+  aggregate position trimming, quantity-relative minimum-size comparisons, adverse slippage, and
+  taker fees. Entry and close optimizer bounds must
   each remain wholly recursive or wholly trailing; mode-crossing ranges and multi-coin market
   execution remain fail closed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,12 @@ All notable user-facing changes will be documented in this file.
   Pre-gate WEL reachability still controls expansion when that reducer is later loss-gated.
   Passive WEL quantity seeds later rungs before executable-touch resizing, and a same-price WEL
   merges into the following ordinary group even when TWEL or unstuck wins reducer selection.
-  Expanded ladders re-finalize the selected reducer's original executable-touch-sized request,
-  and promoted grid groups apply realized-loss gating to their generation-time projected market
-  price while retaining the next-candle price for fills. Promoted grid groups and protective
-  reducers retain canonical ordering, aggregate position trimming, quantity-relative minimum-size
-  comparisons, adverse slippage, and taker fees. Entry and close optimizer bounds must
+  Expanded ladders independently re-finalize every WEL, TWEL, and unstuck request before reducer
+  selection, retry the next finalized candidate when the preferred reducer is loss-gated, and gate
+  promoted reducers and grid groups at their generation-time projected market price while retaining
+  the next-candle price for fills. Promoted grid groups and protective reducers retain canonical
+  ordering, aggregate position trimming, quantity-relative minimum-size comparisons, adverse
+  slippage, and taker fees. Entry and close optimizer bounds must
   each remain wholly recursive or wholly trailing; mode-crossing ranges and multi-coin market
   execution remain fail closed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable user-facing changes will be documented in this file.
   Pre-gate WEL reachability still controls expansion when that reducer is later loss-gated.
   Passive WEL quantity seeds later rungs before executable-touch resizing, and a same-price WEL
   merges into the following ordinary group. Promoted grid groups and protective reducers retain
-  canonical ordering, aggregate position trimming, realized-loss gating, adverse slippage, and
-  taker fees. Entry and close optimizer bounds must each remain wholly recursive or wholly
-  trailing; mode-crossing ranges and multi-coin market execution remain fail closed.
+  canonical ordering, aggregate position trimming, quantity-relative minimum-size comparisons,
+  realized-loss gating, adverse slippage, and taker fees. Entry and close optimizer bounds must
+  each remain wholly recursive or wholly trailing; mode-crossing ranges and multi-coin market
+  execution remain fail closed.
 
 - Added single-coin Trailing Martingale recursive-entry market execution to Apple MPS optimization.
   Every immutable strategy-ladder rung is independently promoted against its generation market

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ All notable user-facing changes will be documented in this file.
   selection, retry the next finalized candidate when the preferred reducer is loss-gated, and gate
   promoted reducers and grid groups at their generation-time projected market price while retaining
   the next-candle price for fills. Reducer loss budgets retain their generation-time realized-PnL
-  snapshot, and below-minimum reducers are removed and the ordinary ladder reallocated when another
-  close remains executable. Promoted grid groups and protective reducers retain canonical ordering,
+  snapshot, and below-minimum reducers are removed while the ordinary ladder remains normalized and
+  is reallocated when another close remains executable. Promoted grid groups and protective reducers
+  retain canonical ordering,
   aggregate position trimming, quantity-relative minimum-size comparisons, adverse slippage, and
   taker fees. Entry and close optimizer bounds must
   each remain wholly recursive or wholly trailing; mode-crossing ranges and multi-coin market

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ All notable user-facing changes will be documented in this file.
   close does not reveal the recursive suffix, while an expanded immutable ladder classifies and
   executable-touch-sizes every emitted price group against its generation market snapshot.
   Pre-gate WEL reachability still controls expansion when that reducer is later loss-gated.
-  Promoted grid groups and protective reducers retain canonical ordering, aggregate position
-  trimming, realized-loss gating, adverse slippage, and taker fees. Entry and close optimizer
-  bounds must each remain wholly recursive or wholly trailing; mode-crossing ranges and
-  multi-coin market execution remain fail closed.
+  Passive WEL quantity seeds later rungs before executable-touch resizing, and a same-price WEL
+  merges into the following ordinary group. Promoted grid groups and protective reducers retain
+  canonical ordering, aggregate position trimming, realized-loss gating, adverse slippage, and
+  taker fees. Entry and close optimizer bounds must each remain wholly recursive or wholly
+  trailing; mode-crossing ranges and multi-coin market execution remain fail closed.
 
 - Added single-coin Trailing Martingale recursive-entry market execution to Apple MPS optimization.
   Every immutable strategy-ladder rung is independently promoted against its generation market

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -284,7 +284,8 @@ The supported slice is intentionally narrow:
   same directional and position-mode topologies with HSL and one-sided minimum-effective-cost
   filtering when every enabled side's entry retracement range is wholly recursive (its upper bound
   is nonpositive) or wholly trailing (its lower bound remains float32-positive), and every close
-  retracement lower bound remains float32-positive. Bounds that cross entry modes fail closed.
+  retracement range is likewise wholly recursive or wholly trailing. Bounds that cross either
+  mode boundary fail closed.
   Auto-unstuck, position- and total-exposure repair, and realized-loss gating may remain enabled or
   tunable. The Metal proxy classifies each generated order against the
   current candle close using
@@ -298,9 +299,13 @@ The supported slice is intentionally narrow:
   is strictly next-candle reachable, then streamed through the strict total-exposure entry gate at
   each limit price or executable market touch. Immutable strategy sizing uses its wallet-exposure
   allowance separately from that portfolio gate; a partially retained TWEL boundary rung ends the
-  nearest-order prefix so no farther rung can reappear. Trailing Martingale recursive close market
-  ladders and multi-coin market execution remain fail closed until their execution ordering is
-  modeled
+  nearest-order prefix so no farther rung can reappear. For recursive Trailing Martingale closes,
+  exact passive next-candle reachability still decides whether Rust emits only the next close or
+  expands the immutable ladder. Market policy cannot expose an unexpanded suffix. Once expanded,
+  every merged price group is classified and executable-touch-sized against the immutable
+  generation market, then ordered and allocated together with any protective reducer before
+  next-candle adverse slippage, taker fees, and realized-loss gating are applied. Multi-coin market
+  execution remains fail closed until its execution ordering is modeled
 - no invalid candle tail after the selected coin's final valid candle
 
 Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor and

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -306,7 +306,9 @@ The supported slice is intentionally narrow:
   generation market, then aggregate-trimmed to the position and ordered with any protective
   reducer before next-candle adverse slippage, taker fees, and realized-loss gating are applied.
   Strategy WEL reachability remains part of the pre-gate expansion decision even when that reducer
-  is subsequently rejected. Multi-coin market execution remains fail closed until its execution
+  is subsequently rejected. Its passive quantity seeds the remaining immutable rungs before any
+  market minimum resize, and a WEL sharing the following ordinary rung's quantized price is merged
+  into that ordinary group. Multi-coin market execution remains fail closed until its execution
   ordering is modeled
 - no invalid candle tail after the selected coin's final valid candle
 

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -303,9 +303,11 @@ The supported slice is intentionally narrow:
   exact passive next-candle reachability still decides whether Rust emits only the next close or
   expands the immutable ladder. Market policy cannot expose an unexpanded suffix. Once expanded,
   every merged price group is classified and executable-touch-sized against the immutable
-  generation market, then ordered and allocated together with any protective reducer before
-  next-candle adverse slippage, taker fees, and realized-loss gating are applied. Multi-coin market
-  execution remains fail closed until its execution ordering is modeled
+  generation market, then aggregate-trimmed to the position and ordered with any protective
+  reducer before next-candle adverse slippage, taker fees, and realized-loss gating are applied.
+  Strategy WEL reachability remains part of the pre-gate expansion decision even when that reducer
+  is subsequently rejected. Multi-coin market execution remains fail closed until its execution
+  ordering is modeled
 - no invalid candle tail after the selected coin's final valid candle
 
 Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor and

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -757,6 +757,20 @@ mod tests {
         assert_eq!(source.matches("bool selected_strategy_wel").count(), 2);
         assert_eq!(
             source
+                .matches("int prefix_merge_ticks = strategy_wel_qty > 0.0f")
+                .count(),
+            2
+        );
+        assert_eq!(
+            source
+                .matches("float prefix_merge_qty = strategy_wel_qty > 0.0f")
+                .count(),
+            2
+        );
+        assert!(!source.contains("int prefix_merge_ticks = selected_strategy_wel"));
+        assert!(!source.contains("float prefix_merge_qty = selected_strategy_wel"));
+        assert_eq!(
+            source
                 .matches("close_gen_psize - strategy_wel_qty")
                 .count(),
             2
@@ -780,6 +794,25 @@ mod tests {
         assert!(source.contains("resize_market_close_qty("));
         assert!(source.contains("entry_gen_market_price"));
         assert!(source.contains("close_gen_market_price"));
+        assert_eq!(
+            source
+                .matches("close_reducer_requested_qty, qty_step")
+                .count(),
+            2
+        );
+        assert_eq!(source.matches("float group_gate_price").count(), 2);
+        assert!(source.contains(
+            "long_side.close_gen_market_price, false,\n                        market_order_slippage_pct"
+        ));
+        assert!(source.contains(
+            "short_side.close_gen_market_price, true,\n                        market_order_slippage_pct"
+        ));
+        assert!(source.contains(
+            "adj, group_gate_price, long_side.pprice, true"
+        ));
+        assert!(source.contains(
+            "adj, group_gate_price, short_side.pprice, false"
+        ));
         assert!(source.contains("the proxy uses a zero-loss envelope"));
         assert!(source.contains("int grid_rung_limit = strategy_wel_qty > 0.0f ? 499 : 500"));
         assert!(source.contains("long_side.close_gen_psize - strategy_wel_qty"));

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -747,7 +747,7 @@ mod tests {
             source
                 .matches("quantity_is_meaningfully_below(")
                 .count(),
-            9
+            10
         );
         assert!(!source.contains("trimmed_qty + 1.0e-6f"));
         assert!(!source.contains("trimmed_group_qty + 1.0e-6f"));
@@ -802,6 +802,14 @@ mod tests {
         assert!(source.contains("preferred.finalized_qty, gate_price"));
         assert!(source.contains("source.close_gen_market_price, !is_long"));
         assert!(source.contains("source.close_gen_balance"));
+        assert!(source.contains("close_gen_realized_pnl_cumsum_last"));
+        assert!(source.contains("close_gen_realized_pnl_cumsum_max"));
+        assert_eq!(source.matches("for (int allocation_pass = 0;").count(), 1);
+        assert!(source.contains("reducer_below_min && !all_below_min"));
+        assert!(source.contains("include_reducer = false"));
+        assert!(source.contains(
+            "source.close_gen_realized_pnl_cumsum_last,\n                source.close_gen_realized_pnl_cumsum_max"
+        ));
         assert!(!source.contains("reducer_qty, reducer_fill_price"));
         assert!(!source.contains("adj, reducer_fill_price"));
         assert_eq!(source.matches("float group_gate_price").count(), 2);

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -742,19 +742,23 @@ mod tests {
         assert!(source.contains("recursive_close_groups"));
         assert!(source.contains("recursive_strategy_close_would_expand"));
         assert!(source.contains("selected.market = should_use_ordinary_market_execution"));
-        assert_eq!(source.matches("bool all_below_min").count(), 2);
+        assert_eq!(source.matches("bool all_below_min").count(), 1);
         assert_eq!(
             source
                 .matches("quantity_is_meaningfully_below(")
                 .count(),
-            13
+            9
         );
         assert!(!source.contains("trimmed_qty + 1.0e-6f"));
         assert!(!source.contains("trimmed_group_qty + 1.0e-6f"));
         assert!(!source.contains("close_gen_psize + 1.0e-6f"));
-        assert_eq!(source.matches("bool normalize_close_groups").count(), 2);
-        assert_eq!(source.matches("int collapse_ordinary_rank").count(), 2);
-        assert_eq!(source.matches("bool selected_strategy_wel").count(), 2);
+        assert_eq!(source.matches("bool normalize_close_groups").count(), 3);
+        assert_eq!(source.matches("int collapse_ordinary_rank").count(), 3);
+        assert_eq!(source.matches("recursive_close_allocation(").count(), 5);
+        assert_eq!(source.matches("select_recursive_close_reducer(").count(), 3);
+        assert_eq!(source.matches("ReducerCandidate candidates[3]").count(), 2);
+        assert_eq!(source.matches("candidate_allocations[candidate_idx]").count(), 4);
+        assert_eq!(source.matches("candidates[candidate_idx].finalized_qty").count(), 4);
         assert_eq!(
             source
                 .matches("int prefix_merge_ticks = strategy_wel_qty > 0.0f")
@@ -794,12 +798,12 @@ mod tests {
         assert!(source.contains("resize_market_close_qty("));
         assert!(source.contains("entry_gen_market_price"));
         assert!(source.contains("close_gen_market_price"));
-        assert_eq!(
-            source
-                .matches("close_reducer_requested_qty, qty_step")
-                .count(),
-            2
-        );
+        assert!(!source.contains("close_reducer_requested_qty, qty_step"));
+        assert!(source.contains("preferred.finalized_qty, gate_price"));
+        assert!(source.contains("source.close_gen_market_price, !is_long"));
+        assert!(source.contains("source.close_gen_balance"));
+        assert!(!source.contains("reducer_qty, reducer_fill_price"));
+        assert!(!source.contains("adj, reducer_fill_price"));
         assert_eq!(source.matches("float group_gate_price").count(), 2);
         assert!(source.contains(
             "long_side.close_gen_market_price, false,\n                        market_order_slippage_pct"

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -743,6 +743,15 @@ mod tests {
         assert!(source.contains("recursive_strategy_close_would_expand"));
         assert!(source.contains("selected.market = should_use_ordinary_market_execution"));
         assert_eq!(source.matches("bool all_below_min").count(), 2);
+        assert_eq!(
+            source
+                .matches("quantity_is_meaningfully_below(")
+                .count(),
+            13
+        );
+        assert!(!source.contains("trimmed_qty + 1.0e-6f"));
+        assert!(!source.contains("trimmed_group_qty + 1.0e-6f"));
+        assert!(!source.contains("close_gen_psize + 1.0e-6f"));
         assert_eq!(source.matches("bool normalize_close_groups").count(), 2);
         assert_eq!(source.matches("int collapse_ordinary_rank").count(), 2);
         assert_eq!(source.matches("bool selected_strategy_wel").count(), 2);

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -745,6 +745,14 @@ mod tests {
         assert_eq!(source.matches("bool all_below_min").count(), 2);
         assert_eq!(source.matches("bool normalize_close_groups").count(), 2);
         assert_eq!(source.matches("int collapse_ordinary_rank").count(), 2);
+        assert_eq!(source.matches("bool selected_strategy_wel").count(), 2);
+        assert_eq!(
+            source
+                .matches("close_gen_psize - strategy_wel_qty")
+                .count(),
+            2
+        );
+        assert!(!source.contains("strategy_wel_qty = reducer_qty"));
         assert!(source.contains("realized_loss_proxy_allows_close"));
         assert!(source.contains("const float max_realized_loss_pct = settings[14]"));
         assert!(source.contains("const bool loss_gate_enabled = max_realized_loss_pct < 1.0f"));

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -807,6 +807,7 @@ mod tests {
         assert_eq!(source.matches("for (int allocation_pass = 0;").count(), 1);
         assert!(source.contains("reducer_below_min && !all_below_min"));
         assert!(source.contains("include_reducer = false"));
+        assert!(source.contains("allocation.normalize_close_groups = allocation_pass > 0"));
         assert!(source.contains(
             "source.close_gen_realized_pnl_cumsum_last,\n                source.close_gen_realized_pnl_cumsum_max"
         ));

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -742,6 +742,9 @@ mod tests {
         assert!(source.contains("recursive_close_groups"));
         assert!(source.contains("recursive_strategy_close_would_expand"));
         assert!(source.contains("selected.market = should_use_ordinary_market_execution"));
+        assert_eq!(source.matches("bool all_below_min").count(), 2);
+        assert_eq!(source.matches("bool normalize_close_groups").count(), 2);
+        assert_eq!(source.matches("int collapse_ordinary_rank").count(), 2);
         assert!(source.contains("realized_loss_proxy_allows_close"));
         assert!(source.contains("const float max_realized_loss_pct = settings[14]"));
         assert!(source.contains("const bool loss_gate_enabled = max_realized_loss_pct < 1.0f"));

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -715,14 +715,17 @@ mod tests {
                 .count(),
             2
         );
-        assert_eq!(source.matches("if (twel_boundary_partial) break;").count(), 2);
+        assert_eq!(
+            source.matches("if (twel_boundary_partial) break;").count(),
+            2
+        );
         assert_eq!(source.matches("= fma(").count(), 6);
         assert!(!source.contains("alpha0 * close +"));
         assert_eq!(source.matches("const int fo = k * 11").count(), 1);
         assert_eq!(source.matches("const int touch_down_tick").count(), 1);
         assert_eq!(source.matches("const int touch_up_tick").count(), 1);
-        assert_eq!(source.matches("high_fill_max_tick").count(), 9);
-        assert_eq!(source.matches("low_nonfill_max_tick").count(), 9);
+        assert_eq!(source.matches("high_fill_max_tick").count(), 14);
+        assert_eq!(source.matches("low_nonfill_max_tick").count(), 14);
         assert!(!source.contains("nextafter("));
         assert!(source.contains("int cticks = touch_controls ? touch_nearest_ticks : target_ticks"));
         assert!(source.contains("remainder == mq && mq_relation > 0"));
@@ -737,6 +740,8 @@ mod tests {
         assert!(source.contains("entry_gen_balance"));
         assert!(source.contains("close_gen_balance"));
         assert!(source.contains("recursive_close_groups"));
+        assert!(source.contains("recursive_strategy_close_would_expand"));
+        assert!(source.contains("selected.market = should_use_ordinary_market_execution"));
         assert!(source.contains("realized_loss_proxy_allows_close"));
         assert!(source.contains("const float max_realized_loss_pct = settings[14]"));
         assert!(source.contains("const bool loss_gate_enabled = max_realized_loss_pct < 1.0f"));
@@ -765,8 +770,8 @@ mod tests {
         assert!(source.contains("dust_remainder"));
         assert!(!source.contains("float primary_diff = fabs"));
         assert_eq!(source.matches("bool reducer_before_group").count(), 2);
-        assert!(source.contains("long_scan_close_grid = long_scan_close_grid"));
-        assert!(source.contains("short_scan_close_grid = short_scan_close_grid"));
+        assert!(source.contains("long_expand_close_grid = long_expand_close_grid"));
+        assert!(source.contains("short_expand_close_grid = short_expand_close_grid"));
         assert!(source.contains("const bool filter_by_min_effective_cost"));
         assert!(source.contains("passes_min_effective_cost"));
         assert!(source.contains("projected_cost_lower"));

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -278,6 +278,7 @@ struct TmSide {
     float psize, pprice, last_inc_k, pos_open_k;
     int entry_ticks, close_ticks, secondary_close_ticks;
     float entry_price, close_price, entry_qty, entry_strategy_qty, close_qty;
+    float close_reducer_requested_qty;
     float secondary_close_price, secondary_close_qty;
     float entry_gen_balance, entry_gen_psize, entry_gen_pprice, entry_gen_kf;
     float entry_gen_market_price;
@@ -310,6 +311,7 @@ inline void install_hsl_panic_close(
         : max(touch_up_tick + 1, 1);
     side.close_price = float(side.close_ticks) * price_step;
     side.close_qty = side.psize;
+    side.close_reducer_requested_qty = 0.0f;
     side.secondary_close_qty = 0.0f;
     side.close_is_exposure_reducer = false;
     side.close_is_twel_reducer = false;
@@ -410,6 +412,7 @@ inline TmSide load_side(constant float* p, int o, float seed) {
     s.last_inc_k = -1.0f; s.pos_open_k = -1.0f;
     s.entry_ticks = 0; s.entry_qty = 0.0f; s.entry_strategy_qty = 0.0f;
     s.close_ticks = 0; s.close_qty = 0.0f;
+    s.close_reducer_requested_qty = 0.0f;
     s.entry_price = 0.0f; s.close_price = 0.0f;
     s.secondary_close_ticks = 0; s.secondary_close_qty = 0.0f;
     s.secondary_close_price = 0.0f;
@@ -813,6 +816,7 @@ inline void generate_orders(
     s.close_is_twel_reducer = false;
     s.close_is_unstuck_reducer = false;
     s.close_loss_gate_disabled_reducers = false;
+    s.close_reducer_requested_qty = 0.0f;
     s.secondary_close_ticks = 0;
     s.secondary_close_price = 0.0f;
     s.secondary_close_qty = 0.0f;
@@ -1147,6 +1151,12 @@ inline void generate_orders(
         ? unstuck_market : (use_twel ? twel_market : wel_market);
     float reducer_exec_price = reducer_market ? price_now : reducer_price;
     if (reducer_qty > 0.0f && reducer_ticks > 0) {
+        // Preserve the selected executable-touch-sized request separately
+        // from singular-order finalization. If the next candle expands the
+        // immutable recursive ladder, Rust re-finalizes this quantity with
+        // the complete ordinary close set instead of carrying forward a
+        // singular close that absorbed the position remainder.
+        s.close_reducer_requested_qty = reducer_qty;
         float reducer_min = min_entry_qty(
             reducer_exec_price, qty_step, min_qty, min_cost, c_mult
         );
@@ -1637,7 +1647,10 @@ inline void passivbot_single_coin_impl(
             bool selected_strategy_wel = false;
             if (long_side.close_is_exposure_reducer) {
                 reducer_qty = fmin(
-                    round_step(long_side.close_qty, qty_step), long_side.psize
+                    round_step(
+                        long_side.close_reducer_requested_qty, qty_step
+                    ),
+                    long_side.psize
                 );
                 reducer_ticks = long_side.close_ticks;
                 reducer_price = long_side.close_price;
@@ -1654,9 +1667,9 @@ inline void passivbot_single_coin_impl(
             grid_source.wel_enforcer_enabled = false;
             grid_source.twel_enforcer_enabled = false;
             grid_source.unstuck_enabled = false;
-            int prefix_merge_ticks = selected_strategy_wel
+            int prefix_merge_ticks = strategy_wel_qty > 0.0f
                 ? strategy_wel_ticks : 0;
-            float prefix_merge_qty = selected_strategy_wel
+            float prefix_merge_qty = strategy_wel_qty > 0.0f
                 ? strategy_wel_qty : 0.0f;
             CloseGroup group;
             int grid_rung_limit = strategy_wel_qty > 0.0f ? 499 : 500;
@@ -1890,12 +1903,17 @@ inline void passivbot_single_coin_impl(
                     ? ordinary_market_fill_price(
                         close, false, market_order_slippage_pct, price_step
                     ) : group.price;
+                float group_gate_price = group.market
+                    ? ordinary_market_fill_price(
+                        long_side.close_gen_market_price, false,
+                        market_order_slippage_pct, price_step
+                    ) : group.price;
                 float group_fee_rate = group.market ? taker_fee : maker_fee;
                 float pnl = adj * c_mult
                     * (group_fill_price - long_side.pprice);
                 float fee = adj * group_fill_price * c_mult * group_fee_rate;
                 if (!realized_loss_proxy_allows_close(
-                        adj, group_fill_price, long_side.pprice, true,
+                        adj, group_gate_price, long_side.pprice, true,
                         c_mult, group_fee_rate, loss_gate_enabled)) continue;
                 if (long_side.close_is_panic) {
                     record_hsl_panic_fill(
@@ -2339,7 +2357,10 @@ inline void passivbot_single_coin_impl(
             bool selected_strategy_wel = false;
             if (short_side.close_is_exposure_reducer) {
                 reducer_qty = fmin(
-                    round_step(short_side.close_qty, qty_step), short_side.psize
+                    round_step(
+                        short_side.close_reducer_requested_qty, qty_step
+                    ),
+                    short_side.psize
                 );
                 reducer_ticks = short_side.close_ticks;
                 reducer_price = short_side.close_price;
@@ -2356,9 +2377,9 @@ inline void passivbot_single_coin_impl(
             grid_source.wel_enforcer_enabled = false;
             grid_source.twel_enforcer_enabled = false;
             grid_source.unstuck_enabled = false;
-            int prefix_merge_ticks = selected_strategy_wel
+            int prefix_merge_ticks = strategy_wel_qty > 0.0f
                 ? strategy_wel_ticks : 0;
-            float prefix_merge_qty = selected_strategy_wel
+            float prefix_merge_qty = strategy_wel_qty > 0.0f
                 ? strategy_wel_qty : 0.0f;
             CloseGroup group;
             int grid_rung_limit = strategy_wel_qty > 0.0f ? 499 : 500;
@@ -2590,12 +2611,17 @@ inline void passivbot_single_coin_impl(
                     ? ordinary_market_fill_price(
                         close, true, market_order_slippage_pct, price_step
                     ) : group.price;
+                float group_gate_price = group.market
+                    ? ordinary_market_fill_price(
+                        short_side.close_gen_market_price, true,
+                        market_order_slippage_pct, price_step
+                    ) : group.price;
                 float group_fee_rate = group.market ? taker_fee : maker_fee;
                 float pnl = adj * c_mult
                     * (short_side.pprice - group_fill_price);
                 float fee = adj * group_fill_price * c_mult * group_fee_rate;
                 if (!realized_loss_proxy_allows_close(
-                        adj, group_fill_price, short_side.pprice, false,
+                        adj, group_gate_price, short_side.pprice, false,
                         c_mult, group_fee_rate, loss_gate_enabled)) continue;
                 if (short_side.close_is_panic) {
                     record_hsl_panic_fill(

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -1320,8 +1320,9 @@ inline int recursive_close_groups(
 // the immutable passive strategy orders would strictly fill. Conservative
 // tick bounds decide when this exact probe is necessary; this reconstruction
 // filters their harmless false positives before market policy can expose the
-// otherwise-unemitted suffix. Portfolio TWEL and unstuck reducers are appended
-// after strategy generation, so they must not decide strategy expansion.
+// otherwise-unemitted suffix. Strategy WEL remains part of this pre-loss-gate
+// decision even if it is rejected later. Portfolio TWEL and unstuck reducers
+// are appended after strategy generation, so they must not decide expansion.
 inline bool recursive_strategy_close_would_expand(
     thread const TmSide& source, bool is_long,
     int high_fill_max_tick, int low_nonfill_max_tick,
@@ -1333,9 +1334,6 @@ inline bool recursive_strategy_close_would_expand(
     sim.market_orders_allowed = false;
     sim.twel_enforcer_enabled = false;
     sim.unstuck_enabled = false;
-    if (source.close_loss_gate_disabled_reducers) {
-        sim.wel_enforcer_enabled = false;
-    }
     for (int rung = 0; rung < 500; ++rung) {
         generate_orders(
             sim, is_long, source.close_gen_balance, source.close_gen_pprice,
@@ -1667,19 +1665,22 @@ inline void passivbot_single_coin_impl(
                 ),
                 0.0f
             );
-            bool trim_for_reducer = long_side.close_is_exposure_reducer
+            bool has_reducer = long_side.close_is_exposure_reducer
                 && reducer_qty > 0.0f;
             float remaining_budget = ordinary_budget;
             float kept_ordinary = 0.0f;
-            float minimum_any = trim_for_reducer
+            float minimum_any = has_reducer
                 ? min_entry_qty(
                     reducer_market ? long_side.close_gen_market_price
                                    : reducer_price,
                     qty_step, min_qty, min_cost, c_mult
-                ) : 0.0f;
+                ) : 1.0e30f;
+            bool all_below_min = !has_reducer
+                || long_side.close_gen_psize + 1.0e-6f < minimum_any;
+            bool any_group_market = false;
             int last_kept_rank = -1;
             for (int trim_rank = 0;
-                trim_for_reducer && trim_rank < group_count;
+                trim_rank < group_count;
                 ++trim_rank) {
                 int wanted = reverse
                     ? group_count - trim_rank - 1 : trim_rank;
@@ -1688,12 +1689,15 @@ inline void passivbot_single_coin_impl(
                     min_qty, min_cost, c_mult, long_side.close_gen_psize,
                     grid_rung_limit, group
                 );
+                any_group_market = any_group_market || group.market;
                 float trimmed_qty = fmin(group.qty, remaining_budget);
                 float group_min = min_entry_qty(
                     group.market ? long_side.close_gen_market_price
                                  : group.price,
                     qty_step, min_qty, min_cost, c_mult
                 );
+                all_below_min = all_below_min
+                    && long_side.close_gen_psize + 1.0e-6f < group_min;
                 bool partial_trim = trimmed_qty + 1.0e-6f < group.qty;
                 if (trimmed_qty + 1.0e-6f < group_min) {
                     trimmed_qty = 0.0f;
@@ -1709,15 +1713,26 @@ inline void passivbot_single_coin_impl(
                     last_kept_rank = trim_rank;
                 }
             }
-            float dust_remainder = fmax(
-                round_step(
-                    long_side.close_gen_psize - reducer_qty - kept_ordinary,
-                    qty_step
-                ),
-                0.0f
-            );
+            bool normalize_close_groups = has_reducer || any_group_market;
+            int collapse_ordinary_rank = -1;
+            if (normalize_close_groups && all_below_min
+                && !has_reducer && group_count > 0) {
+                // Rust's below-minimum position exception collapses an
+                // ordinary ladder to its closest-to-fill order at full size.
+                collapse_ordinary_rank = 0;
+                kept_ordinary = long_side.close_gen_psize;
+                last_kept_rank = 0;
+            }
+            float dust_remainder = normalize_close_groups
+                ? fmax(
+                    round_step(
+                        long_side.close_gen_psize - reducer_qty - kept_ordinary,
+                        qty_step
+                    ),
+                    0.0f
+                ) : 0.0f;
             if (dust_remainder > 0.0f && dust_remainder < minimum_any
-                && last_kept_rank < 0) {
+                && last_kept_rank < 0 && has_reducer) {
                 reducer_qty = fmin(
                     long_side.close_gen_psize,
                     round_step(reducer_qty + dust_remainder, qty_step)
@@ -1737,7 +1752,10 @@ inline void passivbot_single_coin_impl(
                 );
                 if (group.qty <= 0.0f) break;
                 float trimmed_group_qty = group.qty;
-                if (trim_for_reducer) {
+                if (collapse_ordinary_rank >= 0) {
+                    trimmed_group_qty = rank == collapse_ordinary_rank
+                        ? long_side.close_gen_psize : 0.0f;
+                } else if (normalize_close_groups) {
                     float group_min = min_entry_qty(
                         group.market ? long_side.close_gen_market_price
                                      : group.price,
@@ -2331,19 +2349,22 @@ inline void passivbot_single_coin_impl(
                 ),
                 0.0f
             );
-            bool trim_for_reducer = short_side.close_is_exposure_reducer
+            bool has_reducer = short_side.close_is_exposure_reducer
                 && reducer_qty > 0.0f;
             float remaining_budget = ordinary_budget;
             float kept_ordinary = 0.0f;
-            float minimum_any = trim_for_reducer
+            float minimum_any = has_reducer
                 ? min_entry_qty(
                     reducer_market ? short_side.close_gen_market_price
                                    : reducer_price,
                     qty_step, min_qty, min_cost, c_mult
-                ) : 0.0f;
+                ) : 1.0e30f;
+            bool all_below_min = !has_reducer
+                || short_side.close_gen_psize + 1.0e-6f < minimum_any;
+            bool any_group_market = false;
             int last_kept_rank = -1;
             for (int trim_rank = 0;
-                trim_for_reducer && trim_rank < group_count;
+                trim_rank < group_count;
                 ++trim_rank) {
                 int wanted = reverse
                     ? group_count - trim_rank - 1 : trim_rank;
@@ -2352,12 +2373,15 @@ inline void passivbot_single_coin_impl(
                     min_qty, min_cost, c_mult, short_side.close_gen_psize,
                     grid_rung_limit, group
                 );
+                any_group_market = any_group_market || group.market;
                 float trimmed_qty = fmin(group.qty, remaining_budget);
                 float group_min = min_entry_qty(
                     group.market ? short_side.close_gen_market_price
                                  : group.price,
                     qty_step, min_qty, min_cost, c_mult
                 );
+                all_below_min = all_below_min
+                    && short_side.close_gen_psize + 1.0e-6f < group_min;
                 bool partial_trim = trimmed_qty + 1.0e-6f < group.qty;
                 if (trimmed_qty + 1.0e-6f < group_min) {
                     trimmed_qty = 0.0f;
@@ -2373,15 +2397,24 @@ inline void passivbot_single_coin_impl(
                     last_kept_rank = trim_rank;
                 }
             }
-            float dust_remainder = fmax(
-                round_step(
-                    short_side.close_gen_psize - reducer_qty - kept_ordinary,
-                    qty_step
-                ),
-                0.0f
-            );
+            bool normalize_close_groups = has_reducer || any_group_market;
+            int collapse_ordinary_rank = -1;
+            if (normalize_close_groups && all_below_min
+                && !has_reducer && group_count > 0) {
+                collapse_ordinary_rank = 0;
+                kept_ordinary = short_side.close_gen_psize;
+                last_kept_rank = 0;
+            }
+            float dust_remainder = normalize_close_groups
+                ? fmax(
+                    round_step(
+                        short_side.close_gen_psize - reducer_qty - kept_ordinary,
+                        qty_step
+                    ),
+                    0.0f
+                ) : 0.0f;
             if (dust_remainder > 0.0f && dust_remainder < minimum_any
-                && last_kept_rank < 0) {
+                && last_kept_rank < 0 && has_reducer) {
                 reducer_qty = fmin(
                     short_side.close_gen_psize,
                     round_step(reducer_qty + dust_remainder, qty_step)
@@ -2401,7 +2434,10 @@ inline void passivbot_single_coin_impl(
                 );
                 if (group.qty <= 0.0f) break;
                 float trimmed_group_qty = group.qty;
-                if (trim_for_reducer) {
+                if (collapse_ordinary_rank >= 0) {
+                    trimmed_group_qty = rank == collapse_ordinary_rank
+                        ? short_side.close_gen_psize : 0.0f;
+                } else if (normalize_close_groups) {
                     float group_min = min_entry_qty(
                         group.market ? short_side.close_gen_market_price
                                      : group.price,

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -540,6 +540,10 @@ inline float calc_close_qty(
     return qty;
 }
 
+inline bool quantity_is_meaningfully_below(float quantity, float boundary) {
+    return quantity * (1.0f + 1.0e-6f) < boundary;
+}
+
 inline float exposure_reducer_qty(
     float psize, float pprice, float balance, float target_exposure,
     float reducer_price, float qty_step, float min_qty, float min_cost,
@@ -1690,7 +1694,9 @@ inline void passivbot_single_coin_impl(
                     qty_step, min_qty, min_cost, c_mult
                 ) : 1.0e30f;
             bool all_below_min = !has_reducer
-                || long_side.close_gen_psize + 1.0e-6f < minimum_any;
+                || quantity_is_meaningfully_below(
+                    long_side.close_gen_psize, minimum_any
+                );
             bool any_group_market = false;
             int last_kept_rank = -1;
             for (int trim_rank = 0;
@@ -1712,9 +1718,13 @@ inline void passivbot_single_coin_impl(
                     qty_step, min_qty, min_cost, c_mult
                 );
                 all_below_min = all_below_min
-                    && long_side.close_gen_psize + 1.0e-6f < group_min;
-                bool partial_trim = trimmed_qty + 1.0e-6f < group.qty;
-                if (trimmed_qty + 1.0e-6f < group_min) {
+                    && quantity_is_meaningfully_below(
+                        long_side.close_gen_psize, group_min
+                    );
+                bool partial_trim = quantity_is_meaningfully_below(
+                    trimmed_qty, group.qty
+                );
+                if (quantity_is_meaningfully_below(trimmed_qty, group_min)) {
                     trimmed_qty = 0.0f;
                     if (partial_trim) remaining_budget = 0.0f;
                 }
@@ -1778,9 +1788,12 @@ inline void passivbot_single_coin_impl(
                         qty_step, min_qty, min_cost, c_mult
                     );
                     trimmed_group_qty = fmin(group.qty, remaining_budget);
-                    bool partial_trim = trimmed_group_qty + 1.0e-6f
-                        < group.qty;
-                    if (trimmed_group_qty + 1.0e-6f < group_min) {
+                    bool partial_trim = quantity_is_meaningfully_below(
+                        trimmed_group_qty, group.qty
+                    );
+                    if (quantity_is_meaningfully_below(
+                            trimmed_group_qty, group_min
+                        )) {
                         trimmed_group_qty = 0.0f;
                         if (partial_trim) remaining_budget = 0.0f;
                     }
@@ -2383,7 +2396,9 @@ inline void passivbot_single_coin_impl(
                     qty_step, min_qty, min_cost, c_mult
                 ) : 1.0e30f;
             bool all_below_min = !has_reducer
-                || short_side.close_gen_psize + 1.0e-6f < minimum_any;
+                || quantity_is_meaningfully_below(
+                    short_side.close_gen_psize, minimum_any
+                );
             bool any_group_market = false;
             int last_kept_rank = -1;
             for (int trim_rank = 0;
@@ -2405,9 +2420,13 @@ inline void passivbot_single_coin_impl(
                     qty_step, min_qty, min_cost, c_mult
                 );
                 all_below_min = all_below_min
-                    && short_side.close_gen_psize + 1.0e-6f < group_min;
-                bool partial_trim = trimmed_qty + 1.0e-6f < group.qty;
-                if (trimmed_qty + 1.0e-6f < group_min) {
+                    && quantity_is_meaningfully_below(
+                        short_side.close_gen_psize, group_min
+                    );
+                bool partial_trim = quantity_is_meaningfully_below(
+                    trimmed_qty, group.qty
+                );
+                if (quantity_is_meaningfully_below(trimmed_qty, group_min)) {
                     trimmed_qty = 0.0f;
                     if (partial_trim) remaining_budget = 0.0f;
                 }
@@ -2469,9 +2488,12 @@ inline void passivbot_single_coin_impl(
                         qty_step, min_qty, min_cost, c_mult
                     );
                     trimmed_group_qty = fmin(group.qty, remaining_budget);
-                    bool partial_trim = trimmed_group_qty + 1.0e-6f
-                        < group.qty;
-                    if (trimmed_group_qty + 1.0e-6f < group_min) {
+                    bool partial_trim = quantity_is_meaningfully_below(
+                        trimmed_group_qty, group.qty
+                    );
+                    if (quantity_is_meaningfully_below(
+                            trimmed_group_qty, group_min
+                        )) {
                         trimmed_group_qty = 0.0f;
                         if (partial_trim) remaining_budget = 0.0f;
                     }

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -1237,6 +1237,7 @@ inline int recursive_close_groups(
     thread const TmSide& source, bool is_long, int wanted_group,
     float qty_step, float price_step, float min_qty, float min_cost, float c_mult,
     float market_resize_psize,
+    int prefix_merge_ticks, float prefix_merge_qty,
     int max_rungs,
     thread CloseGroup& selected
 ) {
@@ -1280,7 +1281,10 @@ inline int recursive_close_groups(
             if (group_count == wanted_group) {
                 selected.ticks = group_ticks;
                 selected.price = group_price;
-                selected.qty = group_qty;
+                selected.qty = group_count == 0
+                        && group_ticks == prefix_merge_ticks
+                    ? round_step(group_qty + prefix_merge_qty, qty_step)
+                    : group_qty;
             }
             ++group_count;
             group_ticks = sim.close_ticks;
@@ -1295,7 +1299,10 @@ inline int recursive_close_groups(
         if (group_count == wanted_group) {
             selected.ticks = group_ticks;
             selected.price = group_price;
-            selected.qty = group_qty;
+            selected.qty = group_count == 0
+                    && group_ticks == prefix_merge_ticks
+                ? round_step(group_qty + prefix_merge_qty, qty_step)
+                : group_qty;
         }
         ++group_count;
     }
@@ -1608,16 +1615,22 @@ inline void passivbot_single_coin_impl(
         }
         if (long_expand_close_grid) {
             TmSide grid_source = long_side;
-            if (long_side.close_loss_gate_disabled_reducers) {
-                grid_source.wel_enforcer_enabled = false;
-                grid_source.twel_enforcer_enabled = false;
-                grid_source.unstuck_enabled = false;
-            }
+            int strategy_wel_ticks = long_side.close_gen_touch_up_ticks;
+            float strategy_wel_price = float(strategy_wel_ticks) * price_step;
+            float strategy_wel_qty = long_side.wel_enforcer_enabled
+                ? exposure_reducer_qty(
+                    long_side.close_gen_psize,
+                    long_side.close_gen_pprice,
+                    long_side.close_gen_balance,
+                    long_side.allowed_wel * long_side.wel_enforcer_threshold,
+                    strategy_wel_price,
+                    qty_step, min_qty, min_cost, c_mult
+                ) : 0.0f;
             float reducer_qty = 0.0f;
             int reducer_ticks = 0;
             float reducer_price = 0.0f;
             bool reducer_market = false;
-            float strategy_wel_qty = 0.0f;
+            bool selected_strategy_wel = false;
             if (long_side.close_is_exposure_reducer) {
                 reducer_qty = fmin(
                     round_step(long_side.close_qty, qty_step), long_side.psize
@@ -1625,39 +1638,40 @@ inline void passivbot_single_coin_impl(
                 reducer_ticks = long_side.close_ticks;
                 reducer_price = long_side.close_price;
                 reducer_market = long_side.close_market;
-                strategy_wel_qty = reducer_qty;
-                if (long_side.close_is_twel_reducer
-                    || long_side.close_is_unstuck_reducer) {
-                    float wel_price = float(
-                        long_side.close_gen_touch_up_ticks
-                    ) * price_step;
-                    strategy_wel_qty = long_side.wel_enforcer_enabled
-                        ? exposure_reducer_qty(
-                            long_side.close_gen_psize,
-                            long_side.close_gen_pprice,
-                            long_side.close_gen_balance,
-                            long_side.allowed_wel
-                                * long_side.wel_enforcer_threshold,
-                            wel_price, qty_step, min_qty, min_cost, c_mult
-                        ) : 0.0f;
-                }
-                grid_source.close_gen_psize = fmax(
-                    round_step(
-                        long_side.close_gen_psize - strategy_wel_qty, qty_step
-                    ),
-                    0.0f
-                );
-                grid_source.wel_enforcer_enabled = false;
-                grid_source.twel_enforcer_enabled = false;
-                grid_source.unstuck_enabled = false;
+                selected_strategy_wel = !long_side.close_is_twel_reducer
+                    && !long_side.close_is_unstuck_reducer;
             }
+            grid_source.close_gen_psize = fmax(
+                round_step(
+                    long_side.close_gen_psize - strategy_wel_qty, qty_step
+                ),
+                0.0f
+            );
+            grid_source.wel_enforcer_enabled = false;
+            grid_source.twel_enforcer_enabled = false;
+            grid_source.unstuck_enabled = false;
+            int prefix_merge_ticks = selected_strategy_wel
+                ? strategy_wel_ticks : 0;
+            float prefix_merge_qty = selected_strategy_wel
+                ? strategy_wel_qty : 0.0f;
             CloseGroup group;
             int grid_rung_limit = strategy_wel_qty > 0.0f ? 499 : 500;
             int group_count = recursive_close_groups(
                 grid_source, true, -1, qty_step, price_step,
                 min_qty, min_cost, c_mult, long_side.close_gen_psize,
+                prefix_merge_ticks, prefix_merge_qty,
                 grid_rung_limit, group
             );
+            if (selected_strategy_wel && prefix_merge_qty > 0.0f
+                && group_count > 0) {
+                recursive_close_groups(
+                    grid_source, true, 0, qty_step, price_step,
+                    min_qty, min_cost, c_mult, long_side.close_gen_psize,
+                    prefix_merge_ticks, prefix_merge_qty,
+                    grid_rung_limit, group
+                );
+                if (group.ticks == strategy_wel_ticks) reducer_qty = 0.0f;
+            }
             bool reverse = grid_source.close_threshold_we > 0.0f;
             float ordinary_budget = fmax(
                 round_step(
@@ -1687,6 +1701,7 @@ inline void passivbot_single_coin_impl(
                 recursive_close_groups(
                     grid_source, true, wanted, qty_step, price_step,
                     min_qty, min_cost, c_mult, long_side.close_gen_psize,
+                    prefix_merge_ticks, prefix_merge_qty,
                     grid_rung_limit, group
                 );
                 any_group_market = any_group_market || group.market;
@@ -1748,6 +1763,7 @@ inline void passivbot_single_coin_impl(
                 recursive_close_groups(
                     grid_source, true, wanted, qty_step, price_step,
                     min_qty, min_cost, c_mult, long_side.close_gen_psize,
+                    prefix_merge_ticks, prefix_merge_qty,
                     grid_rung_limit, group
                 );
                 if (group.qty <= 0.0f) break;
@@ -2292,16 +2308,22 @@ inline void passivbot_single_coin_impl(
         }
         if (short_expand_close_grid) {
             TmSide grid_source = short_side;
-            if (short_side.close_loss_gate_disabled_reducers) {
-                grid_source.wel_enforcer_enabled = false;
-                grid_source.twel_enforcer_enabled = false;
-                grid_source.unstuck_enabled = false;
-            }
+            int strategy_wel_ticks = short_side.close_gen_touch_down_ticks;
+            float strategy_wel_price = float(strategy_wel_ticks) * price_step;
+            float strategy_wel_qty = short_side.wel_enforcer_enabled
+                ? exposure_reducer_qty(
+                    short_side.close_gen_psize,
+                    short_side.close_gen_pprice,
+                    short_side.close_gen_balance,
+                    short_side.allowed_wel * short_side.wel_enforcer_threshold,
+                    strategy_wel_price,
+                    qty_step, min_qty, min_cost, c_mult
+                ) : 0.0f;
             float reducer_qty = 0.0f;
             int reducer_ticks = 0;
             float reducer_price = 0.0f;
             bool reducer_market = false;
-            float strategy_wel_qty = 0.0f;
+            bool selected_strategy_wel = false;
             if (short_side.close_is_exposure_reducer) {
                 reducer_qty = fmin(
                     round_step(short_side.close_qty, qty_step), short_side.psize
@@ -2309,39 +2331,40 @@ inline void passivbot_single_coin_impl(
                 reducer_ticks = short_side.close_ticks;
                 reducer_price = short_side.close_price;
                 reducer_market = short_side.close_market;
-                strategy_wel_qty = reducer_qty;
-                if (short_side.close_is_twel_reducer
-                    || short_side.close_is_unstuck_reducer) {
-                    float wel_price = float(
-                        short_side.close_gen_touch_down_ticks
-                    ) * price_step;
-                    strategy_wel_qty = short_side.wel_enforcer_enabled
-                        ? exposure_reducer_qty(
-                            short_side.close_gen_psize,
-                            short_side.close_gen_pprice,
-                            short_side.close_gen_balance,
-                            short_side.allowed_wel
-                                * short_side.wel_enforcer_threshold,
-                            wel_price, qty_step, min_qty, min_cost, c_mult
-                        ) : 0.0f;
-                }
-                grid_source.close_gen_psize = fmax(
-                    round_step(
-                        short_side.close_gen_psize - strategy_wel_qty, qty_step
-                    ),
-                    0.0f
-                );
-                grid_source.wel_enforcer_enabled = false;
-                grid_source.twel_enforcer_enabled = false;
-                grid_source.unstuck_enabled = false;
+                selected_strategy_wel = !short_side.close_is_twel_reducer
+                    && !short_side.close_is_unstuck_reducer;
             }
+            grid_source.close_gen_psize = fmax(
+                round_step(
+                    short_side.close_gen_psize - strategy_wel_qty, qty_step
+                ),
+                0.0f
+            );
+            grid_source.wel_enforcer_enabled = false;
+            grid_source.twel_enforcer_enabled = false;
+            grid_source.unstuck_enabled = false;
+            int prefix_merge_ticks = selected_strategy_wel
+                ? strategy_wel_ticks : 0;
+            float prefix_merge_qty = selected_strategy_wel
+                ? strategy_wel_qty : 0.0f;
             CloseGroup group;
             int grid_rung_limit = strategy_wel_qty > 0.0f ? 499 : 500;
             int group_count = recursive_close_groups(
                 grid_source, false, -1, qty_step, price_step,
                 min_qty, min_cost, c_mult, short_side.close_gen_psize,
+                prefix_merge_ticks, prefix_merge_qty,
                 grid_rung_limit, group
             );
+            if (selected_strategy_wel && prefix_merge_qty > 0.0f
+                && group_count > 0) {
+                recursive_close_groups(
+                    grid_source, false, 0, qty_step, price_step,
+                    min_qty, min_cost, c_mult, short_side.close_gen_psize,
+                    prefix_merge_ticks, prefix_merge_qty,
+                    grid_rung_limit, group
+                );
+                if (group.ticks == strategy_wel_ticks) reducer_qty = 0.0f;
+            }
             bool reverse = grid_source.close_threshold_we > 0.0f;
             float ordinary_budget = fmax(
                 round_step(
@@ -2371,6 +2394,7 @@ inline void passivbot_single_coin_impl(
                 recursive_close_groups(
                     grid_source, false, wanted, qty_step, price_step,
                     min_qty, min_cost, c_mult, short_side.close_gen_psize,
+                    prefix_merge_ticks, prefix_merge_qty,
                     grid_rung_limit, group
                 );
                 any_group_market = any_group_market || group.market;
@@ -2430,6 +2454,7 @@ inline void passivbot_single_coin_impl(
                 recursive_close_groups(
                     grid_source, false, wanted, qty_step, price_step,
                     min_qty, min_cost, c_mult, short_side.close_gen_psize,
+                    prefix_merge_ticks, prefix_merge_qty,
                     grid_rung_limit, group
                 );
                 if (group.qty <= 0.0f) break;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -295,6 +295,7 @@ struct CloseGroup {
     int ticks;
     float price;
     float qty;
+    bool market;
 };
 
 inline void install_hsl_panic_close(
@@ -1076,7 +1077,6 @@ inline void generate_orders(
             s, balance, close_mq, close_mq_relation, pct, qty_step, c_mult
         ) : 0.0f;
     s.close_market = s.close_qty > 0.0f
-        && s.close_retracement_base > 0.0f
         && should_use_ordinary_market_execution(
             cticks, !is_long, price_now, price_step,
             s.market_orders_allowed, s.market_order_near_touch_threshold
@@ -1236,12 +1236,14 @@ inline void generate_short_orders(
 inline int recursive_close_groups(
     thread const TmSide& source, bool is_long, int wanted_group,
     float qty_step, float price_step, float min_qty, float min_cost, float c_mult,
+    float market_resize_psize,
     int max_rungs,
     thread CloseGroup& selected
 ) {
     selected.ticks = 0;
     selected.price = 0.0f;
     selected.qty = 0.0f;
+    selected.market = false;
     TmSide sim = source;
     sim.psize = source.close_gen_psize;
     sim.pprice = source.close_gen_pprice;
@@ -1297,7 +1299,61 @@ inline int recursive_close_groups(
         }
         ++group_count;
     }
+    if (selected.qty > 0.0f && selected.ticks > 0) {
+        selected.market = should_use_ordinary_market_execution(
+            selected.ticks, !is_long, source.close_gen_market_price,
+            price_step, source.market_orders_allowed,
+            source.market_order_near_touch_threshold
+        );
+        if (selected.market) {
+            selected.qty = resize_market_close_qty(
+                selected.qty, market_resize_psize,
+                source.close_gen_market_price,
+                qty_step, min_qty, min_cost, c_mult
+            );
+        }
+    }
     return group_count;
+}
+
+// The next-candle strategy contract expands recursive closes only when one of
+// the immutable passive strategy orders would strictly fill. Conservative
+// tick bounds decide when this exact probe is necessary; this reconstruction
+// filters their harmless false positives before market policy can expose the
+// otherwise-unemitted suffix. Portfolio TWEL and unstuck reducers are appended
+// after strategy generation, so they must not decide strategy expansion.
+inline bool recursive_strategy_close_would_expand(
+    thread const TmSide& source, bool is_long,
+    int high_fill_max_tick, int low_nonfill_max_tick,
+    float qty_step, float price_step, float min_qty, float min_cost, float c_mult
+) {
+    TmSide sim = source;
+    sim.psize = source.close_gen_psize;
+    sim.pprice = source.close_gen_pprice;
+    sim.market_orders_allowed = false;
+    sim.twel_enforcer_enabled = false;
+    sim.unstuck_enabled = false;
+    if (source.close_loss_gate_disabled_reducers) {
+        sim.wel_enforcer_enabled = false;
+    }
+    for (int rung = 0; rung < 500; ++rung) {
+        generate_orders(
+            sim, is_long, source.close_gen_balance, source.close_gen_pprice,
+            source.close_gen_touch_down_ticks, source.close_gen_touch_up_ticks,
+            source.close_gen_touch_nearest_ticks, source.close_gen_touch_min_qty,
+            source.close_gen_touch_min_qty_relation, qty_step, price_step,
+            min_qty, min_cost, c_mult, 0.0f, false
+        );
+        float qty = round_step(sim.close_qty, qty_step);
+        if (qty <= 0.0f || sim.close_ticks <= 0) break;
+        bool reachable = is_long
+            ? sim.close_ticks <= high_fill_max_tick
+            : sim.close_ticks > low_nonfill_max_tick;
+        if (reachable) return true;
+        sim.psize = fmax(round_step(sim.psize - qty, qty_step), 0.0f);
+        if (sim.psize <= 0.0f) break;
+    }
+    return false;
 }
 
 inline void passivbot_single_coin_impl(
@@ -1510,16 +1566,22 @@ inline void passivbot_single_coin_impl(
                 || long_side.secondary_close_ticks <= high_fill_max_tick)
             && long_side.psize > 0.0f;
         bool long_recursive_close = long_side.close_retracement_base <= 0.0f;
-        bool long_scan_close_grid = long_close_ready
+        bool long_close_fill_ready = long_close_ready
             && ((long_side.close_is_panic && long_hsl_panic_market)
                 || long_side.close_market
                 || long_side.close_ticks <= high_fill_max_tick);
+        // Exact Rust expands an immutable recursive ladder only when at least
+        // one original passive close would fill the next candle. A market-only
+        // next close remains a single order and must not expose farther rungs.
+        bool long_expand_close_grid = long_close_ready && long_recursive_close
+            && !long_side.close_is_panic
+            && long_side.close_ticks <= high_fill_max_tick;
         if (long_close_ready && long_recursive_close
             && long_side.close_is_exposure_reducer) {
             // A touch-clamped grid order uses nearest-tick quantization while
             // the passive reducer rounds up.  The grid may therefore be one
             // tick nearer and independently reachable.
-            long_scan_close_grid = long_scan_close_grid
+            long_expand_close_grid = long_expand_close_grid
                 || long_side.close_gen_touch_nearest_ticks <= high_fill_max_tick;
         }
         if (long_close_ready && long_recursive_close
@@ -1537,11 +1599,16 @@ inline void passivbot_single_coin_impl(
             bool touch_controls = long_side.close_gen_touch_up_ticks > target_ticks;
             int nearest_ticks = touch_controls
                 ? long_side.close_gen_touch_nearest_ticks : target_ticks;
-            long_scan_close_grid = long_scan_close_grid
+            long_expand_close_grid = long_expand_close_grid
                 || nearest_ticks <= high_fill_max_tick;
         }
-        if (long_scan_close_grid && long_recursive_close
-            && !long_side.close_is_panic) {
+        if (long_expand_close_grid) {
+            long_expand_close_grid = recursive_strategy_close_would_expand(
+                long_side, true, high_fill_max_tick, low_nonfill_max_tick,
+                qty_step, price_step, min_qty, min_cost, c_mult
+            );
+        }
+        if (long_expand_close_grid) {
             TmSide grid_source = long_side;
             if (long_side.close_loss_gate_disabled_reducers) {
                 grid_source.wel_enforcer_enabled = false;
@@ -1551,6 +1618,7 @@ inline void passivbot_single_coin_impl(
             float reducer_qty = 0.0f;
             int reducer_ticks = 0;
             float reducer_price = 0.0f;
+            bool reducer_market = false;
             float strategy_wel_qty = 0.0f;
             if (long_side.close_is_exposure_reducer) {
                 reducer_qty = fmin(
@@ -1558,6 +1626,7 @@ inline void passivbot_single_coin_impl(
                 );
                 reducer_ticks = long_side.close_ticks;
                 reducer_price = long_side.close_price;
+                reducer_market = long_side.close_market;
                 strategy_wel_qty = reducer_qty;
                 if (long_side.close_is_twel_reducer
                     || long_side.close_is_unstuck_reducer) {
@@ -1588,7 +1657,8 @@ inline void passivbot_single_coin_impl(
             int grid_rung_limit = strategy_wel_qty > 0.0f ? 499 : 500;
             int group_count = recursive_close_groups(
                 grid_source, true, -1, qty_step, price_step,
-                min_qty, min_cost, c_mult, grid_rung_limit, group
+                min_qty, min_cost, c_mult, long_side.close_gen_psize,
+                grid_rung_limit, group
             );
             bool reverse = grid_source.close_threshold_we > 0.0f;
             float ordinary_budget = fmax(
@@ -1603,7 +1673,9 @@ inline void passivbot_single_coin_impl(
             float kept_ordinary = 0.0f;
             float minimum_any = trim_for_reducer
                 ? min_entry_qty(
-                    reducer_price, qty_step, min_qty, min_cost, c_mult
+                    reducer_market ? long_side.close_gen_market_price
+                                   : reducer_price,
+                    qty_step, min_qty, min_cost, c_mult
                 ) : 0.0f;
             int last_kept_rank = -1;
             for (int trim_rank = 0;
@@ -1613,11 +1685,14 @@ inline void passivbot_single_coin_impl(
                     ? group_count - trim_rank - 1 : trim_rank;
                 recursive_close_groups(
                     grid_source, true, wanted, qty_step, price_step,
-                    min_qty, min_cost, c_mult, grid_rung_limit, group
+                    min_qty, min_cost, c_mult, long_side.close_gen_psize,
+                    grid_rung_limit, group
                 );
                 float trimmed_qty = fmin(group.qty, remaining_budget);
                 float group_min = min_entry_qty(
-                    group.price, qty_step, min_qty, min_cost, c_mult
+                    group.market ? long_side.close_gen_market_price
+                                 : group.price,
+                    qty_step, min_qty, min_cost, c_mult
                 );
                 bool partial_trim = trimmed_qty + 1.0e-6f < group.qty;
                 if (trimmed_qty + 1.0e-6f < group_min) {
@@ -1650,20 +1725,23 @@ inline void passivbot_single_coin_impl(
                 dust_remainder = 0.0f;
             }
             bool reducer_reachable = reducer_qty > 0.0f
-                && reducer_ticks <= high_fill_max_tick;
+                && (reducer_market || reducer_ticks <= high_fill_max_tick);
             bool reducer_executed = false;
             remaining_budget = ordinary_budget;
             for (int rank = 0; rank < group_count; ++rank) {
                 int wanted = reverse ? group_count - rank - 1 : rank;
                 recursive_close_groups(
                     grid_source, true, wanted, qty_step, price_step,
-                    min_qty, min_cost, c_mult, grid_rung_limit, group
+                    min_qty, min_cost, c_mult, long_side.close_gen_psize,
+                    grid_rung_limit, group
                 );
                 if (group.qty <= 0.0f) break;
                 float trimmed_group_qty = group.qty;
                 if (trim_for_reducer) {
                     float group_min = min_entry_qty(
-                        group.price, qty_step, min_qty, min_cost, c_mult
+                        group.market ? long_side.close_gen_market_price
+                                     : group.price,
+                        qty_step, min_qty, min_cost, c_mult
                     );
                     trimmed_group_qty = fmin(group.qty, remaining_budget);
                     bool partial_trim = trimmed_group_qty + 1.0e-6f
@@ -1690,13 +1768,21 @@ inline void passivbot_single_coin_impl(
                 bool reducer_before_group = reducer_reachable
                     && !reducer_executed && reducer_ticks < group.ticks;
                 if (reducer_before_group) {
+                    float reducer_fill_price = reducer_market
+                        ? ordinary_market_fill_price(
+                            close, false, market_order_slippage_pct, price_step
+                        ) : reducer_price;
+                    float reducer_fee_rate = reducer_market
+                        ? taker_fee : maker_fee;
                     float pnl = reducer_qty * c_mult
-                        * (reducer_price - long_side.pprice);
-                    float fee = reducer_qty * reducer_price * c_mult * maker_fee;
+                        * (reducer_fill_price - long_side.pprice);
+                    float fee = reducer_qty * reducer_fill_price * c_mult
+                        * reducer_fee_rate;
                     if (!realized_loss_proxy_allows_reducer(
-                            reducer_qty, reducer_price, long_side.pprice, true,
+                            reducer_qty, reducer_fill_price,
+                            long_side.pprice, true,
                             long_side.close_is_unstuck_reducer,
-                            c_mult, maker_fee, loss_gate_enabled, balance,
+                            c_mult, reducer_fee_rate, loss_gate_enabled, balance,
                             realized_pnl_cumsum_last,
                             realized_pnl_cumsum_max,
                             max_realized_loss_pct)) {
@@ -1744,22 +1830,26 @@ inline void passivbot_single_coin_impl(
                             ),
                             0.0f
                         );
-                        day_volume += reducer_qty * reducer_price / balance;
+                        day_volume += reducer_qty * reducer_fill_price / balance;
                         long_close_fill = true;
                         reducer_executed = true;
                     }
                 }
-                if (group.ticks > high_fill_max_tick) break;
+                if (!group.market && group.ticks > high_fill_max_tick) break;
                 float group_qty = trimmed_group_qty;
                 if (group_qty <= 0.0f) continue;
                 float adj = fmin(round_step(group_qty, qty_step), long_side.psize);
-                float group_fill_price = group.price;
+                float group_fill_price = group.market
+                    ? ordinary_market_fill_price(
+                        close, false, market_order_slippage_pct, price_step
+                    ) : group.price;
+                float group_fee_rate = group.market ? taker_fee : maker_fee;
                 float pnl = adj * c_mult
                     * (group_fill_price - long_side.pprice);
-                float fee = adj * group_fill_price * c_mult * maker_fee;
+                float fee = adj * group_fill_price * c_mult * group_fee_rate;
                 if (!realized_loss_proxy_allows_close(
-                        adj, group.price, long_side.pprice, true,
-                        c_mult, maker_fee, loss_gate_enabled)) continue;
+                        adj, group_fill_price, long_side.pprice, true,
+                        c_mult, group_fee_rate, loss_gate_enabled)) continue;
                 if (long_side.close_is_panic) {
                     record_hsl_panic_fill(
                         long_hsl, pnl - fee,
@@ -1816,13 +1906,20 @@ inline void passivbot_single_coin_impl(
             if (reducer_reachable && !reducer_executed
                 && long_side.psize > 0.0f) {
                 float adj = fmin(reducer_qty, long_side.psize);
+                float reducer_fill_price = reducer_market
+                    ? ordinary_market_fill_price(
+                        close, false, market_order_slippage_pct, price_step
+                    ) : reducer_price;
+                float reducer_fee_rate = reducer_market
+                    ? taker_fee : maker_fee;
                 float pnl = adj * c_mult
-                    * (reducer_price - long_side.pprice);
-                float fee = adj * reducer_price * c_mult * maker_fee;
+                    * (reducer_fill_price - long_side.pprice);
+                float fee = adj * reducer_fill_price * c_mult
+                    * reducer_fee_rate;
                 if (realized_loss_proxy_allows_reducer(
-                        adj, reducer_price, long_side.pprice, true,
+                        adj, reducer_fill_price, long_side.pprice, true,
                         long_side.close_is_unstuck_reducer,
-                        c_mult, maker_fee, loss_gate_enabled, balance,
+                        c_mult, reducer_fee_rate, loss_gate_enabled, balance,
                         realized_pnl_cumsum_last,
                         realized_pnl_cumsum_max,
                         max_realized_loss_pct)) {
@@ -1864,7 +1961,7 @@ inline void passivbot_single_coin_impl(
                     long_side.psize = fmax(
                         round_step(long_side.psize - adj, qty_step), 0.0f
                     );
-                    day_volume += adj * reducer_price / balance;
+                    day_volume += adj * reducer_fill_price / balance;
                     long_close_fill = true;
                 }
             }
@@ -1880,15 +1977,15 @@ inline void passivbot_single_coin_impl(
                 long_side.pos_open_k = -1.0f;
             }
             if (long_close_fill) long_side.close_qty = 0.0f;
-        } else if (long_scan_close_grid || long_secondary_close_fill) {
+        } else if (long_close_fill_ready || long_secondary_close_fill) {
             bool secondary_first = long_secondary_close_fill
-                && (!long_scan_close_grid
+                && (!long_close_fill_ready
                     || long_side.secondary_close_price
                         <= long_side.close_price);
             for (int rank = 0; rank < 2; ++rank) {
                 bool use_secondary = secondary_first ? rank == 0 : rank == 1;
                 bool reachable = use_secondary
-                    ? long_secondary_close_fill : long_scan_close_grid;
+                    ? long_secondary_close_fill : long_close_fill_ready;
                 if (!reachable || long_side.psize <= 0.0f) continue;
                 bool market_panic = !use_secondary && long_side.close_is_panic
                     && long_hsl_panic_market;
@@ -2138,15 +2235,18 @@ inline void passivbot_single_coin_impl(
                 || short_side.secondary_close_ticks > low_nonfill_max_tick)
             && short_side.psize > 0.0f;
         bool short_recursive_close = short_side.close_retracement_base <= 0.0f;
-        bool short_scan_close_grid = short_close_ready
+        bool short_close_fill_ready = short_close_ready
             && ((short_side.close_is_panic && short_hsl_panic_market)
                 || short_side.close_market
                 || short_side.close_ticks > low_nonfill_max_tick);
+        bool short_expand_close_grid = short_close_ready && short_recursive_close
+            && !short_side.close_is_panic
+            && short_side.close_ticks > low_nonfill_max_tick;
         if (short_close_ready && short_recursive_close
             && short_side.close_is_exposure_reducer) {
             // Mirror the long-side nearest-tick scan: a touch-clamped grid
             // order can sit one tick above the down-rounded reducer.
-            short_scan_close_grid = short_scan_close_grid
+            short_expand_close_grid = short_expand_close_grid
                 || short_side.close_gen_touch_nearest_ticks > low_nonfill_max_tick;
         }
         if (short_close_ready && short_recursive_close
@@ -2163,11 +2263,16 @@ inline void passivbot_single_coin_impl(
             bool touch_controls = short_side.close_gen_touch_down_ticks < target_ticks;
             int nearest_ticks = touch_controls
                 ? short_side.close_gen_touch_nearest_ticks : target_ticks;
-            short_scan_close_grid = short_scan_close_grid
+            short_expand_close_grid = short_expand_close_grid
                 || nearest_ticks > low_nonfill_max_tick;
         }
-        if (short_scan_close_grid && short_recursive_close
-            && !short_side.close_is_panic) {
+        if (short_expand_close_grid) {
+            short_expand_close_grid = recursive_strategy_close_would_expand(
+                short_side, false, high_fill_max_tick, low_nonfill_max_tick,
+                qty_step, price_step, min_qty, min_cost, c_mult
+            );
+        }
+        if (short_expand_close_grid) {
             TmSide grid_source = short_side;
             if (short_side.close_loss_gate_disabled_reducers) {
                 grid_source.wel_enforcer_enabled = false;
@@ -2177,6 +2282,7 @@ inline void passivbot_single_coin_impl(
             float reducer_qty = 0.0f;
             int reducer_ticks = 0;
             float reducer_price = 0.0f;
+            bool reducer_market = false;
             float strategy_wel_qty = 0.0f;
             if (short_side.close_is_exposure_reducer) {
                 reducer_qty = fmin(
@@ -2184,6 +2290,7 @@ inline void passivbot_single_coin_impl(
                 );
                 reducer_ticks = short_side.close_ticks;
                 reducer_price = short_side.close_price;
+                reducer_market = short_side.close_market;
                 strategy_wel_qty = reducer_qty;
                 if (short_side.close_is_twel_reducer
                     || short_side.close_is_unstuck_reducer) {
@@ -2214,7 +2321,8 @@ inline void passivbot_single_coin_impl(
             int grid_rung_limit = strategy_wel_qty > 0.0f ? 499 : 500;
             int group_count = recursive_close_groups(
                 grid_source, false, -1, qty_step, price_step,
-                min_qty, min_cost, c_mult, grid_rung_limit, group
+                min_qty, min_cost, c_mult, short_side.close_gen_psize,
+                grid_rung_limit, group
             );
             bool reverse = grid_source.close_threshold_we > 0.0f;
             float ordinary_budget = fmax(
@@ -2229,7 +2337,9 @@ inline void passivbot_single_coin_impl(
             float kept_ordinary = 0.0f;
             float minimum_any = trim_for_reducer
                 ? min_entry_qty(
-                    reducer_price, qty_step, min_qty, min_cost, c_mult
+                    reducer_market ? short_side.close_gen_market_price
+                                   : reducer_price,
+                    qty_step, min_qty, min_cost, c_mult
                 ) : 0.0f;
             int last_kept_rank = -1;
             for (int trim_rank = 0;
@@ -2239,11 +2349,14 @@ inline void passivbot_single_coin_impl(
                     ? group_count - trim_rank - 1 : trim_rank;
                 recursive_close_groups(
                     grid_source, false, wanted, qty_step, price_step,
-                    min_qty, min_cost, c_mult, grid_rung_limit, group
+                    min_qty, min_cost, c_mult, short_side.close_gen_psize,
+                    grid_rung_limit, group
                 );
                 float trimmed_qty = fmin(group.qty, remaining_budget);
                 float group_min = min_entry_qty(
-                    group.price, qty_step, min_qty, min_cost, c_mult
+                    group.market ? short_side.close_gen_market_price
+                                 : group.price,
+                    qty_step, min_qty, min_cost, c_mult
                 );
                 bool partial_trim = trimmed_qty + 1.0e-6f < group.qty;
                 if (trimmed_qty + 1.0e-6f < group_min) {
@@ -2276,20 +2389,23 @@ inline void passivbot_single_coin_impl(
                 dust_remainder = 0.0f;
             }
             bool reducer_reachable = reducer_qty > 0.0f
-                && reducer_ticks > low_nonfill_max_tick;
+                && (reducer_market || reducer_ticks > low_nonfill_max_tick);
             bool reducer_executed = false;
             remaining_budget = ordinary_budget;
             for (int rank = 0; rank < group_count; ++rank) {
                 int wanted = reverse ? group_count - rank - 1 : rank;
                 recursive_close_groups(
                     grid_source, false, wanted, qty_step, price_step,
-                    min_qty, min_cost, c_mult, grid_rung_limit, group
+                    min_qty, min_cost, c_mult, short_side.close_gen_psize,
+                    grid_rung_limit, group
                 );
                 if (group.qty <= 0.0f) break;
                 float trimmed_group_qty = group.qty;
                 if (trim_for_reducer) {
                     float group_min = min_entry_qty(
-                        group.price, qty_step, min_qty, min_cost, c_mult
+                        group.market ? short_side.close_gen_market_price
+                                     : group.price,
+                        qty_step, min_qty, min_cost, c_mult
                     );
                     trimmed_group_qty = fmin(group.qty, remaining_budget);
                     bool partial_trim = trimmed_group_qty + 1.0e-6f
@@ -2316,13 +2432,21 @@ inline void passivbot_single_coin_impl(
                 bool reducer_before_group = reducer_reachable
                     && !reducer_executed && reducer_ticks > group.ticks;
                 if (reducer_before_group) {
+                    float reducer_fill_price = reducer_market
+                        ? ordinary_market_fill_price(
+                            close, true, market_order_slippage_pct, price_step
+                        ) : reducer_price;
+                    float reducer_fee_rate = reducer_market
+                        ? taker_fee : maker_fee;
                     float pnl = reducer_qty * c_mult
-                        * (short_side.pprice - reducer_price);
-                    float fee = reducer_qty * reducer_price * c_mult * maker_fee;
+                        * (short_side.pprice - reducer_fill_price);
+                    float fee = reducer_qty * reducer_fill_price * c_mult
+                        * reducer_fee_rate;
                     if (!realized_loss_proxy_allows_reducer(
-                            reducer_qty, reducer_price, short_side.pprice, false,
+                            reducer_qty, reducer_fill_price,
+                            short_side.pprice, false,
                             short_side.close_is_unstuck_reducer,
-                            c_mult, maker_fee, loss_gate_enabled, balance,
+                            c_mult, reducer_fee_rate, loss_gate_enabled, balance,
                             realized_pnl_cumsum_last,
                             realized_pnl_cumsum_max,
                             max_realized_loss_pct)) {
@@ -2370,22 +2494,26 @@ inline void passivbot_single_coin_impl(
                             ),
                             0.0f
                         );
-                        day_volume += reducer_qty * reducer_price / balance;
+                        day_volume += reducer_qty * reducer_fill_price / balance;
                         short_close_fill = true;
                         reducer_executed = true;
                     }
                 }
-                if (group.ticks <= low_nonfill_max_tick) break;
+                if (!group.market && group.ticks <= low_nonfill_max_tick) break;
                 float group_qty = trimmed_group_qty;
                 if (group_qty <= 0.0f) continue;
                 float adj = fmin(round_step(group_qty, qty_step), short_side.psize);
-                float group_fill_price = group.price;
+                float group_fill_price = group.market
+                    ? ordinary_market_fill_price(
+                        close, true, market_order_slippage_pct, price_step
+                    ) : group.price;
+                float group_fee_rate = group.market ? taker_fee : maker_fee;
                 float pnl = adj * c_mult
                     * (short_side.pprice - group_fill_price);
-                float fee = adj * group_fill_price * c_mult * maker_fee;
+                float fee = adj * group_fill_price * c_mult * group_fee_rate;
                 if (!realized_loss_proxy_allows_close(
-                        adj, group.price, short_side.pprice, false,
-                        c_mult, maker_fee, loss_gate_enabled)) continue;
+                        adj, group_fill_price, short_side.pprice, false,
+                        c_mult, group_fee_rate, loss_gate_enabled)) continue;
                 if (short_side.close_is_panic) {
                     record_hsl_panic_fill(
                         short_hsl, pnl - fee,
@@ -2443,13 +2571,20 @@ inline void passivbot_single_coin_impl(
             if (reducer_reachable && !reducer_executed
                 && short_side.psize > 0.0f) {
                 float adj = fmin(reducer_qty, short_side.psize);
+                float reducer_fill_price = reducer_market
+                    ? ordinary_market_fill_price(
+                        close, true, market_order_slippage_pct, price_step
+                    ) : reducer_price;
+                float reducer_fee_rate = reducer_market
+                    ? taker_fee : maker_fee;
                 float pnl = adj * c_mult
-                    * (short_side.pprice - reducer_price);
-                float fee = adj * reducer_price * c_mult * maker_fee;
+                    * (short_side.pprice - reducer_fill_price);
+                float fee = adj * reducer_fill_price * c_mult
+                    * reducer_fee_rate;
                 if (realized_loss_proxy_allows_reducer(
-                        adj, reducer_price, short_side.pprice, false,
+                        adj, reducer_fill_price, short_side.pprice, false,
                         short_side.close_is_unstuck_reducer,
-                        c_mult, maker_fee, loss_gate_enabled, balance,
+                        c_mult, reducer_fee_rate, loss_gate_enabled, balance,
                         realized_pnl_cumsum_last,
                         realized_pnl_cumsum_max,
                         max_realized_loss_pct)) {
@@ -2491,7 +2626,7 @@ inline void passivbot_single_coin_impl(
                     short_side.psize = fmax(
                         round_step(short_side.psize - adj, qty_step), 0.0f
                     );
-                    day_volume += adj * reducer_price / balance;
+                    day_volume += adj * reducer_fill_price / balance;
                     short_close_fill = true;
                 }
             }
@@ -2507,15 +2642,15 @@ inline void passivbot_single_coin_impl(
                 short_side.pos_open_k = -1.0f;
             }
             if (short_close_fill) short_side.close_qty = 0.0f;
-        } else if (short_scan_close_grid || short_secondary_close_fill) {
+        } else if (short_close_fill_ready || short_secondary_close_fill) {
             bool secondary_first = short_secondary_close_fill
-                && (!short_scan_close_grid
+                && (!short_close_fill_ready
                     || short_side.secondary_close_price
                         >= short_side.close_price);
             for (int rank = 0; rank < 2; ++rank) {
                 bool use_secondary = secondary_first ? rank == 0 : rank == 1;
                 bool reachable = use_secondary
-                    ? short_secondary_close_fill : short_scan_close_grid;
+                    ? short_secondary_close_fill : short_close_fill_ready;
                 if (!reachable || short_side.psize <= 0.0f) continue;
                 bool market_panic = !use_secondary && short_side.close_is_panic
                     && short_hsl_panic_market;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -278,13 +278,13 @@ struct TmSide {
     float psize, pprice, last_inc_k, pos_open_k;
     int entry_ticks, close_ticks, secondary_close_ticks;
     float entry_price, close_price, entry_qty, entry_strategy_qty, close_qty;
-    float close_reducer_requested_qty;
     float secondary_close_price, secondary_close_qty;
     float entry_gen_balance, entry_gen_psize, entry_gen_pprice, entry_gen_kf;
     float entry_gen_market_price;
     int entry_gen_touch_ticks;
     float close_gen_balance, close_gen_psize, close_gen_pprice;
     float close_gen_market_price;
+    bool close_gen_unstuck_candidate_enabled;
     int close_gen_touch_down_ticks, close_gen_touch_up_ticks;
     int close_gen_touch_nearest_ticks;
     float close_gen_touch_min_qty;
@@ -299,6 +299,40 @@ struct CloseGroup {
     bool market;
 };
 
+struct ReducerCandidate {
+    float requested_qty;
+    float finalized_qty;
+    int ticks;
+    float price;
+    int order_type_id;
+    bool market;
+    bool is_twel;
+    bool is_unstuck;
+};
+
+struct RecursiveCloseAllocation {
+    float reducer_qty;
+    float ordinary_budget;
+    float minimum_any;
+    float dust_remainder;
+    int last_kept_rank;
+    int collapse_ordinary_rank;
+    bool normalize_close_groups;
+};
+
+inline ReducerCandidate empty_reducer_candidate() {
+    ReducerCandidate candidate;
+    candidate.requested_qty = 0.0f;
+    candidate.finalized_qty = 0.0f;
+    candidate.ticks = 0;
+    candidate.price = 0.0f;
+    candidate.order_type_id = 0;
+    candidate.market = false;
+    candidate.is_twel = false;
+    candidate.is_unstuck = false;
+    return candidate;
+}
+
 inline void install_hsl_panic_close(
     thread TmSide& side,
     bool is_long,
@@ -311,7 +345,6 @@ inline void install_hsl_panic_close(
         : max(touch_up_tick + 1, 1);
     side.close_price = float(side.close_ticks) * price_step;
     side.close_qty = side.psize;
-    side.close_reducer_requested_qty = 0.0f;
     side.secondary_close_qty = 0.0f;
     side.close_is_exposure_reducer = false;
     side.close_is_twel_reducer = false;
@@ -412,7 +445,6 @@ inline TmSide load_side(constant float* p, int o, float seed) {
     s.last_inc_k = -1.0f; s.pos_open_k = -1.0f;
     s.entry_ticks = 0; s.entry_qty = 0.0f; s.entry_strategy_qty = 0.0f;
     s.close_ticks = 0; s.close_qty = 0.0f;
-    s.close_reducer_requested_qty = 0.0f;
     s.entry_price = 0.0f; s.close_price = 0.0f;
     s.secondary_close_ticks = 0; s.secondary_close_qty = 0.0f;
     s.secondary_close_price = 0.0f;
@@ -423,6 +455,7 @@ inline TmSide load_side(constant float* p, int o, float seed) {
     s.close_gen_balance = 0.0f;
     s.close_gen_psize = 0.0f; s.close_gen_pprice = 0.0f;
     s.close_gen_market_price = 0.0f;
+    s.close_gen_unstuck_candidate_enabled = false;
     s.close_gen_touch_down_ticks = 0; s.close_gen_touch_up_ticks = 0;
     s.close_gen_touch_nearest_ticks = 0;
     s.close_gen_touch_min_qty = 0.0f;
@@ -816,7 +849,6 @@ inline void generate_orders(
     s.close_is_twel_reducer = false;
     s.close_is_unstuck_reducer = false;
     s.close_loss_gate_disabled_reducers = false;
-    s.close_reducer_requested_qty = 0.0f;
     s.secondary_close_ticks = 0;
     s.secondary_close_price = 0.0f;
     s.secondary_close_qty = 0.0f;
@@ -1151,12 +1183,6 @@ inline void generate_orders(
         ? unstuck_market : (use_twel ? twel_market : wel_market);
     float reducer_exec_price = reducer_market ? price_now : reducer_price;
     if (reducer_qty > 0.0f && reducer_ticks > 0) {
-        // Preserve the selected executable-touch-sized request separately
-        // from singular-order finalization. If the next candle expands the
-        // immutable recursive ladder, Rust re-finalizes this quantity with
-        // the complete ordinary close set instead of carrying forward a
-        // singular close that absorbed the position remainder.
-        s.close_reducer_requested_qty = reducer_qty;
         float reducer_min = min_entry_qty(
             reducer_exec_price, qty_step, min_qty, min_cost, c_mult
         );
@@ -1335,6 +1361,186 @@ inline int recursive_close_groups(
         }
     }
     return group_count;
+}
+
+// Re-run Rust's close allocator for one protective reducer against the fully
+// reconstructed ordinary ladder.  Each WEL, TWEL, and unstuck candidate must
+// be finalized independently: reducer size changes which ordinary closes are
+// trimmed, which in turn changes minimum filtering and dust absorption.
+inline RecursiveCloseAllocation recursive_close_allocation(
+    thread const TmSide& source,
+    bool is_long,
+    int group_count,
+    float position_size,
+    float reducer_requested_qty,
+    float reducer_price,
+    bool reducer_market,
+    float qty_step,
+    float price_step,
+    float min_qty,
+    float min_cost,
+    float c_mult,
+    int prefix_merge_ticks,
+    float prefix_merge_qty,
+    int grid_rung_limit
+) {
+    RecursiveCloseAllocation allocation;
+    allocation.reducer_qty = fmin(
+        round_step(reducer_requested_qty, qty_step), position_size
+    );
+    bool has_reducer = allocation.reducer_qty > 0.0f;
+    allocation.ordinary_budget = fmax(
+        round_step(
+            position_size - allocation.reducer_qty, qty_step
+        ),
+        0.0f
+    );
+    float remaining_budget = allocation.ordinary_budget;
+    float kept_ordinary = 0.0f;
+    allocation.minimum_any = has_reducer
+        ? min_entry_qty(
+            reducer_market ? source.close_gen_market_price : reducer_price,
+            qty_step, min_qty, min_cost, c_mult
+        ) : 1.0e30f;
+    bool all_below_min = !has_reducer
+        || quantity_is_meaningfully_below(
+            position_size, allocation.minimum_any
+        );
+    bool any_group_market = false;
+    allocation.last_kept_rank = -1;
+    bool reverse = source.close_threshold_we > 0.0f;
+    CloseGroup group;
+    for (int trim_rank = 0; trim_rank < group_count; ++trim_rank) {
+        int wanted = reverse ? group_count - trim_rank - 1 : trim_rank;
+        recursive_close_groups(
+            source, is_long, wanted, qty_step, price_step,
+            min_qty, min_cost, c_mult, position_size,
+            prefix_merge_ticks, prefix_merge_qty,
+            grid_rung_limit, group
+        );
+        any_group_market = any_group_market || group.market;
+        float trimmed_qty = fmin(group.qty, remaining_budget);
+        float group_min = min_entry_qty(
+            group.market ? source.close_gen_market_price : group.price,
+            qty_step, min_qty, min_cost, c_mult
+        );
+        all_below_min = all_below_min
+            && quantity_is_meaningfully_below(
+                position_size, group_min
+            );
+        bool partial_trim = quantity_is_meaningfully_below(
+            trimmed_qty, group.qty
+        );
+        if (quantity_is_meaningfully_below(trimmed_qty, group_min)) {
+            trimmed_qty = 0.0f;
+            if (partial_trim) remaining_budget = 0.0f;
+        }
+        if (trimmed_qty > 0.0f) {
+            kept_ordinary += trimmed_qty;
+            remaining_budget = fmax(
+                round_step(remaining_budget - trimmed_qty, qty_step), 0.0f
+            );
+            allocation.minimum_any = fmin(
+                allocation.minimum_any, group_min
+            );
+            allocation.last_kept_rank = trim_rank;
+        }
+    }
+    allocation.normalize_close_groups = has_reducer || any_group_market;
+    allocation.collapse_ordinary_rank = -1;
+    if (allocation.normalize_close_groups && all_below_min
+        && !has_reducer && group_count > 0) {
+        // Rust's below-minimum position exception keeps one closest-to-fill
+        // ordinary close at the full position size.
+        allocation.collapse_ordinary_rank = 0;
+        kept_ordinary = position_size;
+        allocation.last_kept_rank = 0;
+    }
+    allocation.dust_remainder = allocation.normalize_close_groups
+        ? fmax(
+            round_step(
+                position_size - allocation.reducer_qty - kept_ordinary,
+                qty_step
+            ),
+            0.0f
+        ) : 0.0f;
+    if (allocation.dust_remainder > 0.0f
+        && allocation.dust_remainder < allocation.minimum_any
+        && allocation.last_kept_rank < 0 && has_reducer) {
+        allocation.reducer_qty = fmin(
+            position_size,
+            round_step(
+                allocation.reducer_qty + allocation.dust_remainder, qty_step
+            )
+        );
+        allocation.ordinary_budget = fmax(
+            round_step(
+                position_size - allocation.reducer_qty, qty_step
+            ),
+            0.0f
+        );
+        allocation.dust_remainder = 0.0f;
+    }
+    return allocation;
+}
+
+// Select from independently finalized candidates, retrying in Rust's
+// preference order when the generation-time realized-loss gate rejects the
+// current winner.
+inline int select_recursive_close_reducer(
+    thread const ReducerCandidate* candidates,
+    bool is_long,
+    thread const TmSide& source,
+    float price_step,
+    float market_order_slippage_pct,
+    float maker_fee,
+    float taker_fee,
+    float c_mult,
+    bool loss_gate_enabled,
+    float realized_pnl_cumsum_last,
+    float realized_pnl_cumsum_max,
+    float max_realized_loss_pct
+) {
+    bool candidate_available[3] = {true, true, true};
+    for (int attempt = 0; attempt < 3; ++attempt) {
+        int preferred_idx = -1;
+        for (int candidate_idx = 0; candidate_idx < 3; ++candidate_idx) {
+            if (!candidate_available[candidate_idx]
+                || !(candidates[candidate_idx].finalized_qty > 0.0f)) {
+                continue;
+            }
+            if (preferred_idx < 0 || reducer_candidate_preferred(
+                    candidates[candidate_idx].finalized_qty,
+                    candidates[candidate_idx].ticks,
+                    candidates[candidate_idx].order_type_id,
+                    candidates[preferred_idx].finalized_qty,
+                    candidates[preferred_idx].ticks,
+                    candidates[preferred_idx].order_type_id,
+                    is_long)) {
+                preferred_idx = candidate_idx;
+            }
+        }
+        if (preferred_idx < 0) break;
+        ReducerCandidate preferred = candidates[preferred_idx];
+        float gate_price = preferred.market
+            ? ordinary_market_fill_price(
+                source.close_gen_market_price, !is_long,
+                market_order_slippage_pct, price_step
+            ) : preferred.price;
+        float gate_fee_rate = preferred.market ? taker_fee : maker_fee;
+        if (realized_loss_proxy_allows_reducer(
+                preferred.finalized_qty, gate_price,
+                source.close_gen_pprice, is_long,
+                preferred.is_unstuck, c_mult, gate_fee_rate,
+                loss_gate_enabled, source.close_gen_balance,
+                realized_pnl_cumsum_last,
+                realized_pnl_cumsum_max,
+                max_realized_loss_pct)) {
+            return preferred_idx;
+        }
+        candidate_available[preferred_idx] = false;
+    }
+    return -1;
 }
 
 // The next-candle strategy contract expands recursive closes only when one of
@@ -1640,24 +1846,6 @@ inline void passivbot_single_coin_impl(
                     strategy_wel_price,
                     qty_step, min_qty, min_cost, c_mult
                 ) : 0.0f;
-            float reducer_qty = 0.0f;
-            int reducer_ticks = 0;
-            float reducer_price = 0.0f;
-            bool reducer_market = false;
-            bool selected_strategy_wel = false;
-            if (long_side.close_is_exposure_reducer) {
-                reducer_qty = fmin(
-                    round_step(
-                        long_side.close_reducer_requested_qty, qty_step
-                    ),
-                    long_side.psize
-                );
-                reducer_ticks = long_side.close_ticks;
-                reducer_price = long_side.close_price;
-                reducer_market = long_side.close_market;
-                selected_strategy_wel = !long_side.close_is_twel_reducer
-                    && !long_side.close_is_unstuck_reducer;
-            }
             grid_source.close_gen_psize = fmax(
                 round_step(
                     long_side.close_gen_psize - strategy_wel_qty, qty_step
@@ -1679,104 +1867,170 @@ inline void passivbot_single_coin_impl(
                 prefix_merge_ticks, prefix_merge_qty,
                 grid_rung_limit, group
             );
-            if (selected_strategy_wel && prefix_merge_qty > 0.0f
-                && group_count > 0) {
+            bool strategy_wel_merged = false;
+            if (prefix_merge_qty > 0.0f && group_count > 0) {
                 recursive_close_groups(
                     grid_source, true, 0, qty_step, price_step,
                     min_qty, min_cost, c_mult, long_side.close_gen_psize,
                     prefix_merge_ticks, prefix_merge_qty,
                     grid_rung_limit, group
                 );
-                if (group.ticks == strategy_wel_ticks) reducer_qty = 0.0f;
+                strategy_wel_merged = group.ticks == strategy_wel_ticks;
             }
-            bool reverse = grid_source.close_threshold_we > 0.0f;
-            float ordinary_budget = fmax(
-                round_step(
-                    long_side.close_gen_psize - reducer_qty, qty_step
-                ),
-                0.0f
-            );
-            bool has_reducer = long_side.close_is_exposure_reducer
-                && reducer_qty > 0.0f;
-            float remaining_budget = ordinary_budget;
-            float kept_ordinary = 0.0f;
-            float minimum_any = has_reducer
-                ? min_entry_qty(
-                    reducer_market ? long_side.close_gen_market_price
-                                   : reducer_price,
-                    qty_step, min_qty, min_cost, c_mult
-                ) : 1.0e30f;
-            bool all_below_min = !has_reducer
-                || quantity_is_meaningfully_below(
-                    long_side.close_gen_psize, minimum_any
-                );
-            bool any_group_market = false;
-            int last_kept_rank = -1;
-            for (int trim_rank = 0;
-                trim_rank < group_count;
-                ++trim_rank) {
-                int wanted = reverse
-                    ? group_count - trim_rank - 1 : trim_rank;
-                recursive_close_groups(
-                    grid_source, true, wanted, qty_step, price_step,
-                    min_qty, min_cost, c_mult, long_side.close_gen_psize,
-                    prefix_merge_ticks, prefix_merge_qty,
-                    grid_rung_limit, group
-                );
-                any_group_market = any_group_market || group.market;
-                float trimmed_qty = fmin(group.qty, remaining_budget);
-                float group_min = min_entry_qty(
-                    group.market ? long_side.close_gen_market_price
-                                 : group.price,
-                    qty_step, min_qty, min_cost, c_mult
-                );
-                all_below_min = all_below_min
-                    && quantity_is_meaningfully_below(
-                        long_side.close_gen_psize, group_min
-                    );
-                bool partial_trim = quantity_is_meaningfully_below(
-                    trimmed_qty, group.qty
-                );
-                if (quantity_is_meaningfully_below(trimmed_qty, group_min)) {
-                    trimmed_qty = 0.0f;
-                    if (partial_trim) remaining_budget = 0.0f;
-                }
-                if (trimmed_qty > 0.0f) {
-                    kept_ordinary += trimmed_qty;
-                    remaining_budget = fmax(
-                        round_step(remaining_budget - trimmed_qty, qty_step),
-                        0.0f
-                    );
-                    minimum_any = fmin(minimum_any, group_min);
-                    last_kept_rank = trim_rank;
-                }
+
+            ReducerCandidate candidates[3];
+            RecursiveCloseAllocation candidate_allocations[3];
+            for (int candidate_idx = 0; candidate_idx < 3; ++candidate_idx) {
+                candidates[candidate_idx] = empty_reducer_candidate();
             }
-            bool normalize_close_groups = has_reducer || any_group_market;
-            int collapse_ordinary_rank = -1;
-            if (normalize_close_groups && all_below_min
-                && !has_reducer && group_count > 0) {
-                // Rust's below-minimum position exception collapses an
-                // ordinary ladder to its closest-to-fill order at full size.
-                collapse_ordinary_rank = 0;
-                kept_ordinary = long_side.close_gen_psize;
-                last_kept_rank = 0;
-            }
-            float dust_remainder = normalize_close_groups
-                ? fmax(
-                    round_step(
-                        long_side.close_gen_psize - reducer_qty - kept_ordinary,
-                        qty_step
-                    ),
-                    0.0f
-                ) : 0.0f;
-            if (dust_remainder > 0.0f && dust_remainder < minimum_any
-                && last_kept_rank < 0 && has_reducer) {
-                reducer_qty = fmin(
+
+            candidates[0].requested_qty = strategy_wel_merged
+                ? 0.0f : strategy_wel_qty;
+            candidates[0].ticks = strategy_wel_ticks;
+            candidates[0].price = strategy_wel_price;
+            candidates[0].order_type_id = 24;
+            candidates[0].market = candidates[0].requested_qty > 0.0f
+                && should_use_ordinary_market_execution(
+                    candidates[0].ticks, false,
+                    long_side.close_gen_market_price, price_step,
+                    long_side.market_orders_allowed,
+                    long_side.market_order_near_touch_threshold
+                );
+            if (candidates[0].market) {
+                candidates[0].requested_qty = resize_market_close_qty(
+                    candidates[0].requested_qty,
                     long_side.close_gen_psize,
-                    round_step(reducer_qty + dust_remainder, qty_step)
+                    long_side.close_gen_market_price,
+                    qty_step, min_qty, min_cost, c_mult
                 );
-                dust_remainder = 0.0f;
             }
+
+            candidates[1].ticks = max(
+                int(floor(
+                    long_side.close_gen_market_price * 0.9995f / price_step
+                        + 1.0e-6f
+                )),
+                1
+            );
+            candidates[1].price = float(candidates[1].ticks) * price_step;
+            candidates[1].requested_qty = long_side.twel_enforcer_enabled
+                    && long_side.twel_enforcer_threshold > 0.0f
+                ? total_exposure_reducer_qty(
+                    long_side.close_gen_psize,
+                    long_side.close_gen_pprice,
+                    long_side.close_gen_balance,
+                    long_side.twel * long_side.twel_enforcer_threshold,
+                    candidates[1].price,
+                    qty_step, min_qty, min_cost, c_mult
+                ) : 0.0f;
+            candidates[1].order_type_id = 10;
+            candidates[1].is_twel = true;
+            candidates[1].market = candidates[1].requested_qty > 0.0f
+                && should_use_ordinary_market_execution(
+                    candidates[1].ticks, false,
+                    long_side.close_gen_market_price, price_step,
+                    long_side.market_orders_allowed,
+                    long_side.market_order_near_touch_threshold
+                );
+            if (candidates[1].market) {
+                candidates[1].requested_qty = resize_market_close_qty(
+                    candidates[1].requested_qty,
+                    long_side.close_gen_psize,
+                    long_side.close_gen_market_price,
+                    qty_step, min_qty, min_cost, c_mult
+                );
+            }
+
+            TmSide unstuck_source = long_side;
+            unstuck_source.psize = long_side.close_gen_psize;
+            unstuck_source.pprice = long_side.close_gen_pprice;
+            unstuck_source.unstuck_enabled =
+                long_side.close_gen_unstuck_candidate_enabled;
+            candidates[2].ticks = strategy_wel_ticks;
+            candidates[2].price = strategy_wel_price;
+            candidates[2].requested_qty = unstuck_reducer_qty(
+                unstuck_source, true, long_side.close_gen_balance,
+                candidates[2].price,
+                qty_step, min_qty, min_cost, c_mult
+            );
+            candidates[2].order_type_id = 9;
+            candidates[2].is_unstuck = true;
+            candidates[2].market = candidates[2].requested_qty > 0.0f
+                && should_use_ordinary_market_execution(
+                    candidates[2].ticks, false,
+                    long_side.close_gen_market_price, price_step,
+                    long_side.market_orders_allowed,
+                    long_side.market_order_near_touch_threshold
+                );
+            if (candidates[2].market) {
+                candidates[2].requested_qty = resize_market_close_qty(
+                    candidates[2].requested_qty,
+                    long_side.close_gen_psize,
+                    long_side.close_gen_market_price,
+                    qty_step, min_qty, min_cost, c_mult
+                );
+            }
+
+            for (int candidate_idx = 0; candidate_idx < 3; ++candidate_idx) {
+                candidate_allocations[candidate_idx] =
+                    recursive_close_allocation(
+                        grid_source, true, group_count,
+                        long_side.close_gen_psize,
+                        candidates[candidate_idx].requested_qty,
+                        candidates[candidate_idx].price,
+                        candidates[candidate_idx].market,
+                        qty_step, price_step, min_qty, min_cost, c_mult,
+                        prefix_merge_ticks, prefix_merge_qty,
+                        grid_rung_limit
+                    );
+                candidates[candidate_idx].finalized_qty =
+                    candidate_allocations[candidate_idx].reducer_qty;
+            }
+
+            int selected_candidate_idx = select_recursive_close_reducer(
+                candidates, true, long_side, price_step,
+                market_order_slippage_pct, maker_fee, taker_fee, c_mult,
+                loss_gate_enabled, realized_pnl_cumsum_last,
+                realized_pnl_cumsum_max, max_realized_loss_pct
+            );
+
+            ReducerCandidate selected_reducer = empty_reducer_candidate();
+            RecursiveCloseAllocation allocation;
+            if (selected_candidate_idx >= 0) {
+                selected_reducer = candidates[selected_candidate_idx];
+                allocation = candidate_allocations[selected_candidate_idx];
+            } else {
+                allocation = recursive_close_allocation(
+                    grid_source, true, group_count,
+                    long_side.close_gen_psize,
+                    0.0f, 0.0f, false,
+                    qty_step, price_step, min_qty, min_cost, c_mult,
+                    prefix_merge_ticks, prefix_merge_qty,
+                    grid_rung_limit
+                );
+            }
+            long_side.close_is_exposure_reducer =
+                selected_candidate_idx >= 0;
+            long_side.close_is_twel_reducer = selected_reducer.is_twel;
+            long_side.close_is_unstuck_reducer = selected_reducer.is_unstuck;
+            long_side.close_loss_gate_disabled_reducers =
+                selected_candidate_idx < 0
+                && (candidates[0].finalized_qty > 0.0f
+                    || candidates[1].finalized_qty > 0.0f
+                    || candidates[2].finalized_qty > 0.0f);
+
+            float reducer_qty = allocation.reducer_qty;
+            int reducer_ticks = selected_reducer.ticks;
+            float reducer_price = selected_reducer.price;
+            bool reducer_market = selected_reducer.market;
+            bool reverse = grid_source.close_threshold_we > 0.0f;
+            float ordinary_budget = allocation.ordinary_budget;
+            float remaining_budget = ordinary_budget;
+            float minimum_any = allocation.minimum_any;
+            int last_kept_rank = allocation.last_kept_rank;
+            int collapse_ordinary_rank = allocation.collapse_ordinary_rank;
+            float dust_remainder = allocation.dust_remainder;
+            bool normalize_close_groups = allocation.normalize_close_groups;
             bool reducer_reachable = reducer_qty > 0.0f
                 && (reducer_market || reducer_ticks <= high_fill_max_tick);
             bool reducer_executed = false;
@@ -1838,16 +2092,11 @@ inline void passivbot_single_coin_impl(
                         * (reducer_fill_price - long_side.pprice);
                     float fee = reducer_qty * reducer_fill_price * c_mult
                         * reducer_fee_rate;
-                    if (!realized_loss_proxy_allows_reducer(
-                            reducer_qty, reducer_fill_price,
-                            long_side.pprice, true,
-                            long_side.close_is_unstuck_reducer,
-                            c_mult, reducer_fee_rate, loss_gate_enabled, balance,
-                            realized_pnl_cumsum_last,
-                            realized_pnl_cumsum_max,
-                            max_realized_loss_pct)) {
-                        reducer_reachable = false;
-                    } else {
+                    // The finalized reducer was admitted against the order
+                    // book captured at generation.  The next-candle price is
+                    // only the realized fill price; it must not re-gate an
+                    // already emitted market order.
+                    {
                         if (long_side.close_is_panic) {
                             record_hsl_panic_fill(
                                 long_hsl, pnl - fee,
@@ -1981,13 +2230,8 @@ inline void passivbot_single_coin_impl(
                     * (reducer_fill_price - long_side.pprice);
                 float fee = adj * reducer_fill_price * c_mult
                     * reducer_fee_rate;
-                if (realized_loss_proxy_allows_reducer(
-                        adj, reducer_fill_price, long_side.pprice, true,
-                        long_side.close_is_unstuck_reducer,
-                        c_mult, reducer_fee_rate, loss_gate_enabled, balance,
-                        realized_pnl_cumsum_last,
-                        realized_pnl_cumsum_max,
-                        max_realized_loss_pct)) {
+                // Selection already applied the generation-time loss gate.
+                {
                     if (long_side.close_is_panic) {
                         record_hsl_panic_fill(
                             long_hsl, pnl - fee,
@@ -2350,24 +2594,6 @@ inline void passivbot_single_coin_impl(
                     strategy_wel_price,
                     qty_step, min_qty, min_cost, c_mult
                 ) : 0.0f;
-            float reducer_qty = 0.0f;
-            int reducer_ticks = 0;
-            float reducer_price = 0.0f;
-            bool reducer_market = false;
-            bool selected_strategy_wel = false;
-            if (short_side.close_is_exposure_reducer) {
-                reducer_qty = fmin(
-                    round_step(
-                        short_side.close_reducer_requested_qty, qty_step
-                    ),
-                    short_side.psize
-                );
-                reducer_ticks = short_side.close_ticks;
-                reducer_price = short_side.close_price;
-                reducer_market = short_side.close_market;
-                selected_strategy_wel = !short_side.close_is_twel_reducer
-                    && !short_side.close_is_unstuck_reducer;
-            }
             grid_source.close_gen_psize = fmax(
                 round_step(
                     short_side.close_gen_psize - strategy_wel_qty, qty_step
@@ -2389,102 +2615,170 @@ inline void passivbot_single_coin_impl(
                 prefix_merge_ticks, prefix_merge_qty,
                 grid_rung_limit, group
             );
-            if (selected_strategy_wel && prefix_merge_qty > 0.0f
-                && group_count > 0) {
+            bool strategy_wel_merged = false;
+            if (prefix_merge_qty > 0.0f && group_count > 0) {
                 recursive_close_groups(
                     grid_source, false, 0, qty_step, price_step,
                     min_qty, min_cost, c_mult, short_side.close_gen_psize,
                     prefix_merge_ticks, prefix_merge_qty,
                     grid_rung_limit, group
                 );
-                if (group.ticks == strategy_wel_ticks) reducer_qty = 0.0f;
+                strategy_wel_merged = group.ticks == strategy_wel_ticks;
             }
-            bool reverse = grid_source.close_threshold_we > 0.0f;
-            float ordinary_budget = fmax(
-                round_step(
-                    short_side.close_gen_psize - reducer_qty, qty_step
-                ),
-                0.0f
-            );
-            bool has_reducer = short_side.close_is_exposure_reducer
-                && reducer_qty > 0.0f;
-            float remaining_budget = ordinary_budget;
-            float kept_ordinary = 0.0f;
-            float minimum_any = has_reducer
-                ? min_entry_qty(
-                    reducer_market ? short_side.close_gen_market_price
-                                   : reducer_price,
-                    qty_step, min_qty, min_cost, c_mult
-                ) : 1.0e30f;
-            bool all_below_min = !has_reducer
-                || quantity_is_meaningfully_below(
-                    short_side.close_gen_psize, minimum_any
-                );
-            bool any_group_market = false;
-            int last_kept_rank = -1;
-            for (int trim_rank = 0;
-                trim_rank < group_count;
-                ++trim_rank) {
-                int wanted = reverse
-                    ? group_count - trim_rank - 1 : trim_rank;
-                recursive_close_groups(
-                    grid_source, false, wanted, qty_step, price_step,
-                    min_qty, min_cost, c_mult, short_side.close_gen_psize,
-                    prefix_merge_ticks, prefix_merge_qty,
-                    grid_rung_limit, group
-                );
-                any_group_market = any_group_market || group.market;
-                float trimmed_qty = fmin(group.qty, remaining_budget);
-                float group_min = min_entry_qty(
-                    group.market ? short_side.close_gen_market_price
-                                 : group.price,
-                    qty_step, min_qty, min_cost, c_mult
-                );
-                all_below_min = all_below_min
-                    && quantity_is_meaningfully_below(
-                        short_side.close_gen_psize, group_min
-                    );
-                bool partial_trim = quantity_is_meaningfully_below(
-                    trimmed_qty, group.qty
-                );
-                if (quantity_is_meaningfully_below(trimmed_qty, group_min)) {
-                    trimmed_qty = 0.0f;
-                    if (partial_trim) remaining_budget = 0.0f;
-                }
-                if (trimmed_qty > 0.0f) {
-                    kept_ordinary += trimmed_qty;
-                    remaining_budget = fmax(
-                        round_step(remaining_budget - trimmed_qty, qty_step),
-                        0.0f
-                    );
-                    minimum_any = fmin(minimum_any, group_min);
-                    last_kept_rank = trim_rank;
-                }
+
+            ReducerCandidate candidates[3];
+            RecursiveCloseAllocation candidate_allocations[3];
+            for (int candidate_idx = 0; candidate_idx < 3; ++candidate_idx) {
+                candidates[candidate_idx] = empty_reducer_candidate();
             }
-            bool normalize_close_groups = has_reducer || any_group_market;
-            int collapse_ordinary_rank = -1;
-            if (normalize_close_groups && all_below_min
-                && !has_reducer && group_count > 0) {
-                collapse_ordinary_rank = 0;
-                kept_ordinary = short_side.close_gen_psize;
-                last_kept_rank = 0;
-            }
-            float dust_remainder = normalize_close_groups
-                ? fmax(
-                    round_step(
-                        short_side.close_gen_psize - reducer_qty - kept_ordinary,
-                        qty_step
-                    ),
-                    0.0f
-                ) : 0.0f;
-            if (dust_remainder > 0.0f && dust_remainder < minimum_any
-                && last_kept_rank < 0 && has_reducer) {
-                reducer_qty = fmin(
+
+            candidates[0].requested_qty = strategy_wel_merged
+                ? 0.0f : strategy_wel_qty;
+            candidates[0].ticks = strategy_wel_ticks;
+            candidates[0].price = strategy_wel_price;
+            candidates[0].order_type_id = 25;
+            candidates[0].market = candidates[0].requested_qty > 0.0f
+                && should_use_ordinary_market_execution(
+                    candidates[0].ticks, true,
+                    short_side.close_gen_market_price, price_step,
+                    short_side.market_orders_allowed,
+                    short_side.market_order_near_touch_threshold
+                );
+            if (candidates[0].market) {
+                candidates[0].requested_qty = resize_market_close_qty(
+                    candidates[0].requested_qty,
                     short_side.close_gen_psize,
-                    round_step(reducer_qty + dust_remainder, qty_step)
+                    short_side.close_gen_market_price,
+                    qty_step, min_qty, min_cost, c_mult
                 );
-                dust_remainder = 0.0f;
             }
+
+            candidates[1].ticks = max(
+                int(ceil(
+                    short_side.close_gen_market_price * 1.0005f / price_step
+                        - 1.0e-6f
+                )),
+                1
+            );
+            candidates[1].price = float(candidates[1].ticks) * price_step;
+            candidates[1].requested_qty = short_side.twel_enforcer_enabled
+                    && short_side.twel_enforcer_threshold > 0.0f
+                ? total_exposure_reducer_qty(
+                    short_side.close_gen_psize,
+                    short_side.close_gen_pprice,
+                    short_side.close_gen_balance,
+                    short_side.twel * short_side.twel_enforcer_threshold,
+                    candidates[1].price,
+                    qty_step, min_qty, min_cost, c_mult
+                ) : 0.0f;
+            candidates[1].order_type_id = 21;
+            candidates[1].is_twel = true;
+            candidates[1].market = candidates[1].requested_qty > 0.0f
+                && should_use_ordinary_market_execution(
+                    candidates[1].ticks, true,
+                    short_side.close_gen_market_price, price_step,
+                    short_side.market_orders_allowed,
+                    short_side.market_order_near_touch_threshold
+                );
+            if (candidates[1].market) {
+                candidates[1].requested_qty = resize_market_close_qty(
+                    candidates[1].requested_qty,
+                    short_side.close_gen_psize,
+                    short_side.close_gen_market_price,
+                    qty_step, min_qty, min_cost, c_mult
+                );
+            }
+
+            TmSide unstuck_source = short_side;
+            unstuck_source.psize = short_side.close_gen_psize;
+            unstuck_source.pprice = short_side.close_gen_pprice;
+            unstuck_source.unstuck_enabled =
+                short_side.close_gen_unstuck_candidate_enabled;
+            candidates[2].ticks = strategy_wel_ticks;
+            candidates[2].price = strategy_wel_price;
+            candidates[2].requested_qty = unstuck_reducer_qty(
+                unstuck_source, false, short_side.close_gen_balance,
+                candidates[2].price,
+                qty_step, min_qty, min_cost, c_mult
+            );
+            candidates[2].order_type_id = 20;
+            candidates[2].is_unstuck = true;
+            candidates[2].market = candidates[2].requested_qty > 0.0f
+                && should_use_ordinary_market_execution(
+                    candidates[2].ticks, true,
+                    short_side.close_gen_market_price, price_step,
+                    short_side.market_orders_allowed,
+                    short_side.market_order_near_touch_threshold
+                );
+            if (candidates[2].market) {
+                candidates[2].requested_qty = resize_market_close_qty(
+                    candidates[2].requested_qty,
+                    short_side.close_gen_psize,
+                    short_side.close_gen_market_price,
+                    qty_step, min_qty, min_cost, c_mult
+                );
+            }
+
+            for (int candidate_idx = 0; candidate_idx < 3; ++candidate_idx) {
+                candidate_allocations[candidate_idx] =
+                    recursive_close_allocation(
+                        grid_source, false, group_count,
+                        short_side.close_gen_psize,
+                        candidates[candidate_idx].requested_qty,
+                        candidates[candidate_idx].price,
+                        candidates[candidate_idx].market,
+                        qty_step, price_step, min_qty, min_cost, c_mult,
+                        prefix_merge_ticks, prefix_merge_qty,
+                        grid_rung_limit
+                    );
+                candidates[candidate_idx].finalized_qty =
+                    candidate_allocations[candidate_idx].reducer_qty;
+            }
+
+            int selected_candidate_idx = select_recursive_close_reducer(
+                candidates, false, short_side, price_step,
+                market_order_slippage_pct, maker_fee, taker_fee, c_mult,
+                loss_gate_enabled, realized_pnl_cumsum_last,
+                realized_pnl_cumsum_max, max_realized_loss_pct
+            );
+
+            ReducerCandidate selected_reducer = empty_reducer_candidate();
+            RecursiveCloseAllocation allocation;
+            if (selected_candidate_idx >= 0) {
+                selected_reducer = candidates[selected_candidate_idx];
+                allocation = candidate_allocations[selected_candidate_idx];
+            } else {
+                allocation = recursive_close_allocation(
+                    grid_source, false, group_count,
+                    short_side.close_gen_psize,
+                    0.0f, 0.0f, false,
+                    qty_step, price_step, min_qty, min_cost, c_mult,
+                    prefix_merge_ticks, prefix_merge_qty,
+                    grid_rung_limit
+                );
+            }
+            short_side.close_is_exposure_reducer =
+                selected_candidate_idx >= 0;
+            short_side.close_is_twel_reducer = selected_reducer.is_twel;
+            short_side.close_is_unstuck_reducer = selected_reducer.is_unstuck;
+            short_side.close_loss_gate_disabled_reducers =
+                selected_candidate_idx < 0
+                && (candidates[0].finalized_qty > 0.0f
+                    || candidates[1].finalized_qty > 0.0f
+                    || candidates[2].finalized_qty > 0.0f);
+
+            float reducer_qty = allocation.reducer_qty;
+            int reducer_ticks = selected_reducer.ticks;
+            float reducer_price = selected_reducer.price;
+            bool reducer_market = selected_reducer.market;
+            bool reverse = grid_source.close_threshold_we > 0.0f;
+            float ordinary_budget = allocation.ordinary_budget;
+            float remaining_budget = ordinary_budget;
+            float minimum_any = allocation.minimum_any;
+            int last_kept_rank = allocation.last_kept_rank;
+            int collapse_ordinary_rank = allocation.collapse_ordinary_rank;
+            float dust_remainder = allocation.dust_remainder;
+            bool normalize_close_groups = allocation.normalize_close_groups;
             bool reducer_reachable = reducer_qty > 0.0f
                 && (reducer_market || reducer_ticks > low_nonfill_max_tick);
             bool reducer_executed = false;
@@ -2546,16 +2840,11 @@ inline void passivbot_single_coin_impl(
                         * (short_side.pprice - reducer_fill_price);
                     float fee = reducer_qty * reducer_fill_price * c_mult
                         * reducer_fee_rate;
-                    if (!realized_loss_proxy_allows_reducer(
-                            reducer_qty, reducer_fill_price,
-                            short_side.pprice, false,
-                            short_side.close_is_unstuck_reducer,
-                            c_mult, reducer_fee_rate, loss_gate_enabled, balance,
-                            realized_pnl_cumsum_last,
-                            realized_pnl_cumsum_max,
-                            max_realized_loss_pct)) {
-                        reducer_reachable = false;
-                    } else {
+                    // The finalized reducer was admitted against the order
+                    // book captured at generation.  The next-candle price is
+                    // only the realized fill price; it must not re-gate an
+                    // already emitted market order.
+                    {
                         if (short_side.close_is_panic) {
                             record_hsl_panic_fill(
                                 short_hsl, pnl - fee,
@@ -2690,13 +2979,8 @@ inline void passivbot_single_coin_impl(
                     * (short_side.pprice - reducer_fill_price);
                 float fee = adj * reducer_fill_price * c_mult
                     * reducer_fee_rate;
-                if (realized_loss_proxy_allows_reducer(
-                        adj, reducer_fill_price, short_side.pprice, false,
-                        short_side.close_is_unstuck_reducer,
-                        c_mult, reducer_fee_rate, loss_gate_enabled, balance,
-                        realized_pnl_cumsum_last,
-                        realized_pnl_cumsum_max,
-                        max_realized_loss_pct)) {
+                // Selection already applied the generation-time loss gate.
+                {
                     if (short_side.close_is_panic) {
                         record_hsl_panic_fill(
                             short_hsl, pnl - fee,
@@ -3224,6 +3508,13 @@ inline void passivbot_single_coin_impl(
                     short_side.close_loss_gate_disabled_reducers = true;
                 }
             }
+            // Recursive next-candle expansion must reconstruct every reducer
+            // candidate which existed at this generation, even when singular
+            // selection or its loss-gate fallback temporarily disabled it.
+            long_side.close_gen_unstuck_candidate_enabled =
+                long_unstuck_selected;
+            short_side.close_gen_unstuck_candidate_enabled =
+                short_unstuck_selected;
             long_side.wel_enforcer_enabled = long_wel_enabled;
             long_side.twel_enforcer_enabled = long_twel_enabled;
             long_side.unstuck_enabled = configured_long_unstuck;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -1463,7 +1463,11 @@ inline RecursiveCloseAllocation recursive_close_allocation(
             include_reducer = false;
             continue;
         }
-        allocation.normalize_close_groups = has_reducer || any_group_market;
+        // The reducer-drop retry still represents a normalized close set:
+        // minimum filtering and aggregate position trimming above must remain
+        // authoritative even when every surviving ordinary group is passive.
+        allocation.normalize_close_groups = allocation_pass > 0
+            || has_reducer || any_group_market;
         allocation.collapse_ordinary_rank = -1;
         if (allocation.normalize_close_groups && all_below_min
             && !has_reducer && group_count > 0) {

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -284,6 +284,8 @@ struct TmSide {
     int entry_gen_touch_ticks;
     float close_gen_balance, close_gen_psize, close_gen_pprice;
     float close_gen_market_price;
+    float close_gen_realized_pnl_cumsum_last;
+    float close_gen_realized_pnl_cumsum_max;
     bool close_gen_unstuck_candidate_enabled;
     int close_gen_touch_down_ticks, close_gen_touch_up_ticks;
     int close_gen_touch_nearest_ticks;
@@ -455,6 +457,8 @@ inline TmSide load_side(constant float* p, int o, float seed) {
     s.close_gen_balance = 0.0f;
     s.close_gen_psize = 0.0f; s.close_gen_pprice = 0.0f;
     s.close_gen_market_price = 0.0f;
+    s.close_gen_realized_pnl_cumsum_last = 0.0f;
+    s.close_gen_realized_pnl_cumsum_max = 0.0f;
     s.close_gen_unstuck_candidate_enabled = false;
     s.close_gen_touch_down_ticks = 0; s.close_gen_touch_up_ticks = 0;
     s.close_gen_touch_nearest_ticks = 0;
@@ -1385,101 +1389,117 @@ inline RecursiveCloseAllocation recursive_close_allocation(
     int grid_rung_limit
 ) {
     RecursiveCloseAllocation allocation;
-    allocation.reducer_qty = fmin(
+    float requested_reducer_qty = fmin(
         round_step(reducer_requested_qty, qty_step), position_size
     );
-    bool has_reducer = allocation.reducer_qty > 0.0f;
-    allocation.ordinary_budget = fmax(
-        round_step(
-            position_size - allocation.reducer_qty, qty_step
-        ),
-        0.0f
-    );
-    float remaining_budget = allocation.ordinary_budget;
-    float kept_ordinary = 0.0f;
-    allocation.minimum_any = has_reducer
-        ? min_entry_qty(
-            reducer_market ? source.close_gen_market_price : reducer_price,
-            qty_step, min_qty, min_cost, c_mult
-        ) : 1.0e30f;
-    bool all_below_min = !has_reducer
-        || quantity_is_meaningfully_below(
-            position_size, allocation.minimum_any
-        );
-    bool any_group_market = false;
-    allocation.last_kept_rank = -1;
-    bool reverse = source.close_threshold_we > 0.0f;
-    CloseGroup group;
-    for (int trim_rank = 0; trim_rank < group_count; ++trim_rank) {
-        int wanted = reverse ? group_count - trim_rank - 1 : trim_rank;
-        recursive_close_groups(
-            source, is_long, wanted, qty_step, price_step,
-            min_qty, min_cost, c_mult, position_size,
-            prefix_merge_ticks, prefix_merge_qty,
-            grid_rung_limit, group
-        );
-        any_group_market = any_group_market || group.market;
-        float trimmed_qty = fmin(group.qty, remaining_budget);
-        float group_min = min_entry_qty(
-            group.market ? source.close_gen_market_price : group.price,
-            qty_step, min_qty, min_cost, c_mult
-        );
-        all_below_min = all_below_min
-            && quantity_is_meaningfully_below(
-                position_size, group_min
-            );
-        bool partial_trim = quantity_is_meaningfully_below(
-            trimmed_qty, group.qty
-        );
-        if (quantity_is_meaningfully_below(trimmed_qty, group_min)) {
-            trimmed_qty = 0.0f;
-            if (partial_trim) remaining_budget = 0.0f;
-        }
-        if (trimmed_qty > 0.0f) {
-            kept_ordinary += trimmed_qty;
-            remaining_budget = fmax(
-                round_step(remaining_budget - trimmed_qty, qty_step), 0.0f
-            );
-            allocation.minimum_any = fmin(
-                allocation.minimum_any, group_min
-            );
-            allocation.last_kept_rank = trim_rank;
-        }
-    }
-    allocation.normalize_close_groups = has_reducer || any_group_market;
-    allocation.collapse_ordinary_rank = -1;
-    if (allocation.normalize_close_groups && all_below_min
-        && !has_reducer && group_count > 0) {
-        // Rust's below-minimum position exception keeps one closest-to-fill
-        // ordinary close at the full position size.
-        allocation.collapse_ordinary_rank = 0;
-        kept_ordinary = position_size;
-        allocation.last_kept_rank = 0;
-    }
-    allocation.dust_remainder = allocation.normalize_close_groups
-        ? fmax(
-            round_step(
-                position_size - allocation.reducer_qty - kept_ordinary,
-                qty_step
-            ),
-            0.0f
-        ) : 0.0f;
-    if (allocation.dust_remainder > 0.0f
-        && allocation.dust_remainder < allocation.minimum_any
-        && allocation.last_kept_rank < 0 && has_reducer) {
-        allocation.reducer_qty = fmin(
-            position_size,
-            round_step(
-                allocation.reducer_qty + allocation.dust_remainder, qty_step
-            )
-        );
+    bool include_reducer = requested_reducer_qty > 0.0f;
+    // At most one retry is needed: if the reducer itself is below minimum but
+    // a mixed-price ordinary rung is executable, Rust filters that reducer and
+    // trims the ordinary ladder again without reserving any reducer quantity.
+    for (int allocation_pass = 0; allocation_pass < 2; ++allocation_pass) {
+        allocation.reducer_qty = include_reducer
+            ? requested_reducer_qty : 0.0f;
+        bool has_reducer = allocation.reducer_qty > 0.0f;
+        float reducer_min = has_reducer
+            ? min_entry_qty(
+                reducer_market ? source.close_gen_market_price : reducer_price,
+                qty_step, min_qty, min_cost, c_mult
+            ) : 1.0e30f;
         allocation.ordinary_budget = fmax(
             round_step(
                 position_size - allocation.reducer_qty, qty_step
             ),
             0.0f
         );
-        allocation.dust_remainder = 0.0f;
+        float remaining_budget = allocation.ordinary_budget;
+        float kept_ordinary = 0.0f;
+        allocation.minimum_any = reducer_min;
+        bool all_below_min = !has_reducer
+            || quantity_is_meaningfully_below(position_size, reducer_min);
+        bool any_group_market = false;
+        allocation.last_kept_rank = -1;
+        bool reverse = source.close_threshold_we > 0.0f;
+        CloseGroup group;
+        for (int trim_rank = 0; trim_rank < group_count; ++trim_rank) {
+            int wanted = reverse ? group_count - trim_rank - 1 : trim_rank;
+            recursive_close_groups(
+                source, is_long, wanted, qty_step, price_step,
+                min_qty, min_cost, c_mult, position_size,
+                prefix_merge_ticks, prefix_merge_qty,
+                grid_rung_limit, group
+            );
+            any_group_market = any_group_market || group.market;
+            float trimmed_qty = fmin(group.qty, remaining_budget);
+            float group_min = min_entry_qty(
+                group.market ? source.close_gen_market_price : group.price,
+                qty_step, min_qty, min_cost, c_mult
+            );
+            all_below_min = all_below_min
+                && quantity_is_meaningfully_below(position_size, group_min);
+            bool partial_trim = quantity_is_meaningfully_below(
+                trimmed_qty, group.qty
+            );
+            if (quantity_is_meaningfully_below(trimmed_qty, group_min)) {
+                trimmed_qty = 0.0f;
+                if (partial_trim) remaining_budget = 0.0f;
+            }
+            if (trimmed_qty > 0.0f) {
+                kept_ordinary += trimmed_qty;
+                remaining_budget = fmax(
+                    round_step(remaining_budget - trimmed_qty, qty_step),
+                    0.0f
+                );
+                allocation.minimum_any = fmin(
+                    allocation.minimum_any, group_min
+                );
+                allocation.last_kept_rank = trim_rank;
+            }
+        }
+        bool reducer_below_min = has_reducer
+            && quantity_is_meaningfully_below(
+                allocation.reducer_qty, reducer_min
+            );
+        if (reducer_below_min && !all_below_min) {
+            include_reducer = false;
+            continue;
+        }
+        allocation.normalize_close_groups = has_reducer || any_group_market;
+        allocation.collapse_ordinary_rank = -1;
+        if (allocation.normalize_close_groups && all_below_min
+            && !has_reducer && group_count > 0) {
+            // Rust's below-minimum position exception keeps one
+            // closest-to-fill ordinary close at the full position size.
+            allocation.collapse_ordinary_rank = 0;
+            kept_ordinary = position_size;
+            allocation.last_kept_rank = 0;
+        }
+        allocation.dust_remainder = allocation.normalize_close_groups
+            ? fmax(
+                round_step(
+                    position_size - allocation.reducer_qty - kept_ordinary,
+                    qty_step
+                ),
+                0.0f
+            ) : 0.0f;
+        if (allocation.dust_remainder > 0.0f
+            && allocation.dust_remainder < allocation.minimum_any
+            && allocation.last_kept_rank < 0 && has_reducer) {
+            allocation.reducer_qty = fmin(
+                position_size,
+                round_step(
+                    allocation.reducer_qty + allocation.dust_remainder,
+                    qty_step
+                )
+            );
+            allocation.ordinary_budget = fmax(
+                round_step(
+                    position_size - allocation.reducer_qty, qty_step
+                ),
+                0.0f
+            );
+            allocation.dust_remainder = 0.0f;
+        }
+        return allocation;
     }
     return allocation;
 }
@@ -1497,8 +1517,6 @@ inline int select_recursive_close_reducer(
     float taker_fee,
     float c_mult,
     bool loss_gate_enabled,
-    float realized_pnl_cumsum_last,
-    float realized_pnl_cumsum_max,
     float max_realized_loss_pct
 ) {
     bool candidate_available[3] = {true, true, true};
@@ -1533,8 +1551,8 @@ inline int select_recursive_close_reducer(
                 source.close_gen_pprice, is_long,
                 preferred.is_unstuck, c_mult, gate_fee_rate,
                 loss_gate_enabled, source.close_gen_balance,
-                realized_pnl_cumsum_last,
-                realized_pnl_cumsum_max,
+                source.close_gen_realized_pnl_cumsum_last,
+                source.close_gen_realized_pnl_cumsum_max,
                 max_realized_loss_pct)) {
             return preferred_idx;
         }
@@ -1990,8 +2008,7 @@ inline void passivbot_single_coin_impl(
             int selected_candidate_idx = select_recursive_close_reducer(
                 candidates, true, long_side, price_step,
                 market_order_slippage_pct, maker_fee, taker_fee, c_mult,
-                loss_gate_enabled, realized_pnl_cumsum_last,
-                realized_pnl_cumsum_max, max_realized_loss_pct
+                loss_gate_enabled, max_realized_loss_pct
             );
 
             ReducerCandidate selected_reducer = empty_reducer_candidate();
@@ -2738,8 +2755,7 @@ inline void passivbot_single_coin_impl(
             int selected_candidate_idx = select_recursive_close_reducer(
                 candidates, false, short_side, price_step,
                 market_order_slippage_pct, maker_fee, taker_fee, c_mult,
-                loss_gate_enabled, realized_pnl_cumsum_last,
-                realized_pnl_cumsum_max, max_realized_loss_pct
+                loss_gate_enabled, max_realized_loss_pct
             );
 
             ReducerCandidate selected_reducer = empty_reducer_candidate();
@@ -3511,6 +3527,14 @@ inline void passivbot_single_coin_impl(
             // Recursive next-candle expansion must reconstruct every reducer
             // candidate which existed at this generation, even when singular
             // selection or its loss-gate fallback temporarily disabled it.
+            long_side.close_gen_realized_pnl_cumsum_last =
+                realized_pnl_cumsum_last;
+            long_side.close_gen_realized_pnl_cumsum_max =
+                realized_pnl_cumsum_max;
+            short_side.close_gen_realized_pnl_cumsum_last =
+                realized_pnl_cumsum_last;
+            short_side.close_gen_realized_pnl_cumsum_max =
+                realized_pnl_cumsum_max;
             long_side.close_gen_unstuck_candidate_enabled =
                 long_unstuck_selected;
             short_side.close_gen_unstuck_candidate_enabled =

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -2746,28 +2746,34 @@ def _validate_tm_market_mode_bounds(
 
         close_key = f"{side}_close_retracement_base_pct"
         close_bound = bound_by_key.get(close_key)
-        close_low = (
-            float(close_bound.low)
+        close_low, close_high = (
+            (float(close_bound.low), float(close_bound.high))
             if close_bound is not None
-            else float(base_by_key.get(close_key, 0.0))
+            else (float(base_by_key.get(close_key, 0.0)),) * 2
         )
         with np.errstate(over="ignore", under="ignore", invalid="ignore"):
             packed_close_low = np.float32(close_low)
+        recursive_only = close_high <= 0.0
+        trailing_only = (
+            close_low > 0.0
+            and np.isfinite(packed_close_low)
+            and packed_close_low > np.float32(0.0)
+        )
         if (
             not math.isfinite(close_low)
-            or close_low <= 0.0
-            or not np.isfinite(packed_close_low)
-            or packed_close_low <= np.float32(0.0)
+            or not math.isfinite(close_high)
+            or not (recursive_only or trailing_only)
         ):
-            unsupported.append(f"{close_key} lower={close_low}")
+            unsupported.append(
+                f"{close_key} bounds=({close_low}, {close_high})"
+            )
     if unsupported:
         raise ValueError(
             "GPU Trailing Martingale ordinary market execution currently "
             "requires each enabled side's entry retracement range to remain "
             "wholly recursive (high<=0) or wholly trailing with a float32-"
-            "positive lower bound, and close_retracement_base_pct to remain "
-            "strictly trailing. Recursive close market ladders and entry mode-"
-            "crossing bounds remain fail closed: "
+            "positive lower bound for both entry and close retracement. Entry "
+            "or close mode-crossing bounds remain fail closed: "
             + ", ".join(unsupported)
         )
 

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1642,7 +1642,7 @@ def test_gpu_foundation_accepts_baseline_tm_single_coin_market_execution():
         ("long_entry_retracement_base_pct", 1.0e-50, 0.1),
     ],
 )
-def test_gpu_tm_market_execution_rejects_recursive_close_or_entry_mode_crossing(
+def test_gpu_tm_market_execution_rejects_entry_or_close_mode_crossing(
     key, low, high
 ):
     config = _long_only_ema_config()
@@ -1654,7 +1654,7 @@ def test_gpu_tm_market_execution_rejects_recursive_close_or_entry_mode_crossing(
     }
     bounds[key] = Bound(low, high)
 
-    with pytest.raises(ValueError, match="remain fail closed"):
+    with pytest.raises(ValueError, match="mode-crossing bounds remain fail closed"):
         _validate_tm_market_mode_bounds(bounds, {}, {"long"}, config)
 
 
@@ -1681,6 +1681,21 @@ def test_gpu_tm_market_execution_accepts_recursive_entry_mode_bounds(
     bounds = {
         "long_entry_retracement_base_pct": entry_bounds,
         "long_close_retracement_base_pct": Bound(0.001, 0.1),
+    }
+
+    _validate_tm_market_mode_bounds(bounds, {}, {"long"}, config)
+
+
+@pytest.mark.parametrize("close_bounds", [Bound(0.0, 0.0), Bound(-0.1, 0.0)])
+def test_gpu_tm_market_execution_accepts_recursive_close_mode_bounds(
+    close_bounds,
+):
+    config = _long_only_ema_config()
+    config["live"]["strategy_kind"] = "trailing_martingale"
+    config["live"]["market_orders_allowed"] = True
+    bounds = {
+        "long_entry_retracement_base_pct": Bound(0.001, 0.1),
+        "long_close_retracement_base_pct": close_bounds,
     }
 
     _validate_tm_market_mode_bounds(bounds, {}, {"long"}, config)
@@ -1731,7 +1746,7 @@ def test_gpu_tm_market_suite_validates_effective_scenarios_not_template():
     scenario["live"]["market_orders_allowed"] = False
     _validate_tm_market_mode_bounds(bounds, {}, {"long"}, scenario)
 
-    with pytest.raises(ValueError, match="entry mode-crossing"):
+    with pytest.raises(ValueError, match="mode-crossing"):
         _validate_tm_market_template_bounds(
             bounds, {}, {"long"}, template, []
         )

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -7420,6 +7420,48 @@ kernel void passivbot_tm_recursive_close_pregate_wel_probe(
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+def test_mps_tm_recursive_close_quantity_tolerance_scales_with_magnitude():
+    import passivbot_rust
+
+    probe_kernel = r"""
+kernel void passivbot_tm_recursive_close_quantity_tolerance_probe(
+    device float* output,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    output[0] = quantity_is_meaningfully_below(9.5e-6f, 1.0e-5f)
+        ? 1.0f : 0.0f;
+    output[1] = quantity_is_meaningfully_below(9.999995e-6f, 1.0e-5f)
+        ? 1.0f : 0.0f;
+    output[2] = quantity_is_meaningfully_below(1.0e-5f, 1.0e-5f)
+        ? 1.0f : 0.0f;
+    output[3] = quantity_is_meaningfully_below(0.95f, 1.0f)
+        ? 1.0f : 0.0f;
+    output[4] = quantity_is_meaningfully_below(0.9999995f, 1.0f)
+        ? 1.0f : 0.0f;
+    output[5] = quantity_is_meaningfully_below(1.0f, 1.0f)
+        ? 1.0f : 0.0f;
+}
+"""
+    output = torch.zeros(6, dtype=torch.float32, device="mps")
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_trailing_martingale_source_py() + probe_kernel
+    )
+    library.passivbot_tm_recursive_close_quantity_tolerance_probe(
+        output,
+        threads=(1, 1, 1),
+    )
+    torch.mps.synchronize()
+
+    # The first sub-micro-step case was admitted by the former fixed +1e-6
+    # epsilon. The near-boundary cases remain equal within the same 1e-6
+    # relative tolerance at both tested quantity magnitudes.
+    assert output.cpu().tolist() == [1.0, 0.0, 0.0, 1.0, 0.0, 0.0]
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 def test_mps_tm_recursive_market_groups_trim_to_position_before_fill():
     count = 8
     close = np.asarray(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -7153,6 +7153,89 @@ def test_mps_tm_recursive_market_loss_gate_uses_generation_projection(side):
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_market_reducer_is_not_regated_at_next_candle_price(side):
+    count = 7
+    entry_price = 99.0 if side == "long" else 101.0
+    generation_price = 102.0 if side == "long" else 98.0
+    adverse_fill_price = 90.0 if side == "long" else 110.0
+    close = np.asarray(
+        [
+            100.0,
+            100.0,
+            100.0,
+            entry_price,
+            generation_price,
+            adverse_fill_price,
+            adverse_fill_price,
+        ]
+    )
+    high = close.copy()
+    low = close.copy()
+    if side == "long":
+        high[3], low[3] = 100.0, 98.0
+        high[5], low[5] = 105.0, adverse_fill_price
+    else:
+        high[3], low[3] = 102.0, 100.0
+        high[5], low[5] = adverse_fill_price, 95.0
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_single_row(
+        initial_ema_dist=0.01,
+        entry_gate=False,
+        wel_enforcer_enabled=True,
+        wel_enforcer_threshold=0.1,
+    )
+    row[6] = 1.0
+    row[11] = 0.001
+    row[15] = 0.25
+    row[16] = 0.005
+    row[17] = 0.001
+    row[20] = 0.0
+    row[23] = 100.0
+    params = np.asarray([row + row], dtype=np.float64)
+    common = {
+        "long_enabled": side == "long",
+        "short_enabled": side == "short",
+        "hsl_enabled": False,
+        "taker_fee": 0.001,
+        "market_order_slippage_pct": 0.01,
+        "market_orders_allowed": True,
+        "market_order_near_touch_threshold": 0.02,
+        "max_realized_loss_pct": 0.0,
+    }
+
+    output = MpsTrailingMartingaleRunner(
+        market, run, data, **common
+    ).run(params)
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    # The reducer is profitable after projected slippage at generation and is
+    # therefore emitted. Its actual next-candle market fill gaps through the
+    # position price and realizes a loss, but that later price cannot revoke
+    # an order which exact Rust already admitted.
+    assert output["fill_count"].item() > 1.0
+    assert output[size_key].item() < 10.0
+    assert output["balance"].item() < 1_000.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
 @pytest.mark.parametrize("winning_reducer", ["wel", "twel"])
 def test_mps_tm_same_tick_wel_merges_into_recursive_market_group(
     side, winning_reducer
@@ -7656,6 +7739,226 @@ def test_mps_tm_recursive_ladder_refinalizes_requested_reducer_qty():
     # the original TWEL request with the expanded set, yielding two closes.
     assert output["fill_count"].item() == 3.0
     assert output["psize"].item() == 0.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_tm_recursive_reselects_after_candidate_finalization():
+    import passivbot_rust
+
+    row = _tm_single_row(
+        initial_ema_dist=0.01,
+        gate_initial=1.0,
+        gate_reentry=0.0,
+        entry_gate=False,
+        threshold=0.3,
+    )
+    row[6] = 1.0
+    row[7] = 10.0
+    row[11] = 0.0
+    row[15] = 0.3
+    row[16] = 1.0
+    row[17] = 0.0
+    row[20] = 0.0
+    row[23] = 100.0
+    params = torch.tensor(row, dtype=torch.float32, device="mps")
+    probe_kernel = r"""
+kernel void passivbot_tm_recursive_candidate_reselection_probe(
+    constant float* params,
+    device float* output,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    TmSide source = load_side(params, 0, 100.0f);
+    source.close_gen_balance = 1000.0f;
+    source.close_gen_psize = 10.0f;
+    source.close_gen_pprice = 100.0f;
+    source.close_gen_market_price = 100.0f;
+    source.close_gen_touch_down_ticks = 9999;
+    source.close_gen_touch_up_ticks = 10001;
+    source.close_gen_touch_nearest_ticks = 10000;
+    source.close_gen_touch_min_qty = 5.0f;
+    source.close_gen_touch_min_qty_relation = 0;
+    source.wel_enforcer_enabled = false;
+    source.twel_enforcer_enabled = false;
+    source.unstuck_enabled = false;
+    source.market_orders_allowed = true;
+    source.market_order_near_touch_threshold = 0.001f;
+
+    CloseGroup group;
+    int group_count = recursive_close_groups(
+        source, true, -1, 0.5f, 0.01f, 0.5f, 500.0f, 1.0f,
+        10.0f, 0, 0.0f, 500, group
+    );
+    float requested_a = 5.5f;
+    float requested_b = 6.0f;
+    float singular_a = finalized_reducer_qty(
+        10.0f, requested_a, 100.0f,
+        0.5f, 0.5f, 500.0f, 1.0f
+    );
+    float singular_b = finalized_reducer_qty(
+        10.0f, requested_b, 200.0f,
+        0.5f, 0.5f, 500.0f, 1.0f
+    );
+    RecursiveCloseAllocation allocation_a = recursive_close_allocation(
+        source, true, group_count, 10.0f, requested_a, 100.0f, true,
+        0.5f, 0.01f, 0.5f, 500.0f, 1.0f,
+        0, 0.0f, 500
+    );
+    RecursiveCloseAllocation allocation_b = recursive_close_allocation(
+        source, true, group_count, 10.0f, requested_b, 200.0f, false,
+        0.5f, 0.01f, 0.5f, 500.0f, 1.0f,
+        0, 0.0f, 500
+    );
+    output[0] = float(group_count);
+    output[1] = singular_a;
+    output[2] = singular_b;
+    output[3] = allocation_a.reducer_qty;
+    output[4] = allocation_b.reducer_qty;
+    output[5] = reducer_candidate_preferred(
+        allocation_b.reducer_qty, 20000, 10,
+        allocation_a.reducer_qty, 10000, 24, true
+    ) ? 1.0f : 0.0f;
+}
+"""
+    output = torch.zeros(6, dtype=torch.float32, device="mps")
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_trailing_martingale_source_py() + probe_kernel
+    )
+    library.passivbot_tm_recursive_candidate_reselection_probe(
+        params, output, threads=(1, 1, 1)
+    )
+    torch.mps.synchronize()
+
+    values = output.cpu().tolist()
+    assert values[0] >= 1.0
+    # Singular finalization makes A appear larger by absorbing its otherwise
+    # uncloseable remainder. The expanded ordinary ladder can carry that
+    # remainder, so A returns to 5.5 and B's independently finalized 6.0 must
+    # become the preferred reducer.
+    assert values[1:] == [10.0, 6.0, 5.5, 6.0, 1.0]
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_recursive_reducer_gate_falls_back_to_next_candidate(side):
+    import passivbot_rust
+
+    row = _tm_single_row()
+    params = torch.tensor(row, dtype=torch.float32, device="mps")
+    probe_kernel = r"""
+kernel void passivbot_tm_recursive_reducer_gate_fallback_probe(
+    constant float* params,
+    device float* output,
+    constant int& is_long_raw,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    bool is_long = is_long_raw != 0;
+    TmSide source = load_side(params, 0, 100.0f);
+    source.close_gen_balance = 1000.0f;
+    source.close_gen_pprice = 100.0f;
+    source.close_gen_market_price = 100.0f;
+    ReducerCandidate candidates[3];
+    for (int i = 0; i < 3; ++i) {
+        candidates[i] = empty_reducer_candidate();
+    }
+    candidates[0].finalized_qty = 6.0f;
+    candidates[0].ticks = is_long ? 9000 : 11000;
+    candidates[0].price = is_long ? 90.0f : 110.0f;
+    candidates[0].order_type_id = is_long ? 24 : 25;
+    candidates[1].finalized_qty = 5.0f;
+    candidates[1].ticks = is_long ? 11000 : 9000;
+    candidates[1].price = is_long ? 110.0f : 90.0f;
+    candidates[1].order_type_id = is_long ? 10 : 21;
+    int selected = select_recursive_close_reducer(
+        candidates, is_long, source, 0.01f, 0.0f,
+        0.0f, 0.0f, 1.0f, true,
+        0.0f, 0.0f, 0.0f
+    );
+    output[0] = float(selected);
+}
+"""
+    output = torch.zeros(1, dtype=torch.float32, device="mps")
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_trailing_martingale_source_py() + probe_kernel
+    )
+    library.passivbot_tm_recursive_reducer_gate_fallback_probe(
+        params,
+        output,
+        1 if side == "long" else 0,
+        threads=(1, 1, 1),
+    )
+    torch.mps.synchronize()
+
+    assert output.item() == 1.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_recursive_reducer_gate_uses_generation_market_snapshot(side):
+    import passivbot_rust
+
+    row = _tm_single_row()
+    params = torch.tensor(row, dtype=torch.float32, device="mps")
+    probe_kernel = r"""
+kernel void passivbot_tm_recursive_reducer_generation_gate_probe(
+    constant float* params,
+    device float* output,
+    constant int& is_long_raw,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    bool is_long = is_long_raw != 0;
+    TmSide source = load_side(params, 0, 100.0f);
+    source.close_gen_balance = 1000.0f;
+    source.close_gen_pprice = is_long ? 99.0f : 101.0f;
+    source.close_gen_market_price = is_long ? 102.0f : 98.0f;
+    ReducerCandidate candidates[3];
+    for (int i = 0; i < 3; ++i) {
+        candidates[i] = empty_reducer_candidate();
+    }
+    candidates[0].finalized_qty = 1.0f;
+    candidates[0].ticks = is_long ? 10200 : 9800;
+    candidates[0].price = source.close_gen_market_price;
+    candidates[0].order_type_id = is_long ? 24 : 25;
+    candidates[0].market = true;
+    int selected = select_recursive_close_reducer(
+        candidates, is_long, source, 0.01f, 0.01f,
+        0.0f, 0.001f, 1.0f, true,
+        0.0f, 0.0f, 0.0f
+    );
+    float adverse_next_fill = is_long ? 89.1f : 111.1f;
+    bool adverse_next_allowed = realized_loss_proxy_allows_reducer(
+        1.0f, adverse_next_fill, source.close_gen_pprice, is_long,
+        false, 1.0f, 0.001f, true, source.close_gen_balance,
+        0.0f, 0.0f, 0.0f
+    );
+    output[0] = float(selected);
+    output[1] = adverse_next_allowed ? 1.0f : 0.0f;
+}
+"""
+    output = torch.zeros(2, dtype=torch.float32, device="mps")
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_trailing_martingale_source_py() + probe_kernel
+    )
+    library.passivbot_tm_recursive_reducer_generation_gate_probe(
+        params,
+        output,
+        1 if side == "long" else 0,
+        threads=(1, 1, 1),
+    )
+    torch.mps.synchronize()
+
+    # Generation-time projection admits candidate zero. The adverse next-bar
+    # fill would fail the same gate, proving that execution must not consult it
+    # again after the order has already been emitted.
+    assert output.cpu().tolist() == [0.0, 0.0]
 
 
 @pytest.mark.skipif(
@@ -12391,13 +12694,17 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert "recursive_close_groups" in source
     assert "recursive_strategy_close_would_expand" in source
     assert "selected.market = should_use_ordinary_market_execution" in source
-    assert source.count("bool all_below_min") == 2
-    assert source.count("bool normalize_close_groups") == 2
-    assert source.count("int collapse_ordinary_rank") == 2
-    assert source.count("bool selected_strategy_wel") == 2
+    assert source.count("bool all_below_min") == 1
+    assert source.count("bool normalize_close_groups") == 3
+    assert source.count("int collapse_ordinary_rank") == 3
+    assert source.count("recursive_close_allocation(") == 5
+    assert source.count("select_recursive_close_reducer(") == 3
+    assert source.count("ReducerCandidate candidates[3]") == 2
+    assert source.count("candidate_allocations[candidate_idx]") == 4
+    assert source.count("candidates[candidate_idx].finalized_qty") == 4
     assert source.count("close_gen_psize - strategy_wel_qty") == 2
     assert "strategy_wel_qty = reducer_qty" not in source
-    assert source.count("group.market ?") >= 6
+    assert source.count("group.market ?") >= 5
     assert source.count("float reducer_fee_rate = reducer_market") == 4
     assert "realized_loss_proxy_allows_close" in source
     assert "const float max_realized_loss_pct = settings[14]" in source
@@ -12423,6 +12730,10 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert "s.close_market = reducer_market" in source
     assert "entry_gen_market_price" in source
     assert "close_gen_market_price" in source
+    assert "preferred.finalized_qty, gate_price" in source
+    assert "source.close_gen_market_price, !is_long" in source
+    assert "reducer_qty, reducer_fill_price" not in source
+    assert "adj, reducer_fill_price" not in source
     assert "sim.market_orders_allowed = false" in source
     assert source.count("ladder_side.market_orders_allowed = false") == 2
     assert source.count("ladder_side.twel_entry_gate_enabled = false") == 2

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -7843,6 +7843,74 @@ kernel void passivbot_tm_recursive_candidate_reselection_probe(
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+def test_mps_tm_recursive_finalization_drops_mixed_minimum_reducer():
+    import passivbot_rust
+
+    row = _tm_single_row(initial_ema_dist=0.01)
+    row[15] = 0.3
+    row[16] = 1.0
+    row[17] = 0.0
+    row[20] = 0.0
+    params = torch.tensor(row, dtype=torch.float32, device="mps")
+    probe_kernel = r"""
+kernel void passivbot_tm_recursive_mixed_minimum_reducer_probe(
+    constant float* params,
+    device float* output,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    TmSide source = load_side(params, 0, 100.0f);
+    source.close_gen_balance = 1000.0f;
+    source.close_gen_psize = 4.0f;
+    source.close_gen_pprice = 100.0f;
+    source.close_gen_market_price = 100.0f;
+    source.close_gen_touch_down_ticks = 9999;
+    source.close_gen_touch_up_ticks = 10001;
+    source.close_gen_touch_nearest_ticks = 10000;
+    source.close_gen_touch_min_qty = 5.0f;
+    source.close_gen_touch_min_qty_relation = 0;
+    source.wel_enforcer_enabled = false;
+    source.twel_enforcer_enabled = false;
+    source.unstuck_enabled = false;
+    source.market_orders_allowed = true;
+    source.market_order_near_touch_threshold = 0.001f;
+
+    CloseGroup group;
+    int group_count = recursive_close_groups(
+        source, true, -1, 0.5f, 0.01f, 0.5f, 500.0f, 1.0f,
+        4.0f, 0, 0.0f, 500, group
+    );
+    RecursiveCloseAllocation allocation = recursive_close_allocation(
+        source, true, group_count, 4.0f, 4.0f, 100.0f, true,
+        0.5f, 0.01f, 0.5f, 500.0f, 1.0f,
+        0, 0.0f, 500
+    );
+    output[0] = float(group_count);
+    output[1] = allocation.reducer_qty;
+    output[2] = allocation.ordinary_budget;
+}
+"""
+    output = torch.zeros(3, dtype=torch.float32, device="mps")
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_trailing_martingale_source_py() + probe_kernel
+    )
+    library.passivbot_tm_recursive_mixed_minimum_reducer_probe(
+        params, output, threads=(1, 1, 1)
+    )
+    torch.mps.synchronize()
+
+    values = output.cpu().tolist()
+    assert values[0] >= 1.0
+    # The full position is below the reducer's market-touch minimum (5.0),
+    # but the farther 200-price ordinary group has a 2.5 minimum. Exact Rust
+    # therefore filters the reducer and reallocates all 4.0 units to ordinary
+    # closes instead of collapsing to the protective order.
+    assert values[1:] == [0.0, 4.0]
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 @pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_tm_recursive_reducer_gate_falls_back_to_next_candidate(side):
     import passivbot_rust
@@ -7876,8 +7944,7 @@ kernel void passivbot_tm_recursive_reducer_gate_fallback_probe(
     candidates[1].order_type_id = is_long ? 10 : 21;
     int selected = select_recursive_close_reducer(
         candidates, is_long, source, 0.01f, 0.0f,
-        0.0f, 0.0f, 1.0f, true,
-        0.0f, 0.0f, 0.0f
+        0.0f, 0.0f, 1.0f, true, 0.0f
     );
     output[0] = float(selected);
 }
@@ -7930,8 +7997,7 @@ kernel void passivbot_tm_recursive_reducer_generation_gate_probe(
     candidates[0].market = true;
     int selected = select_recursive_close_reducer(
         candidates, is_long, source, 0.01f, 0.01f,
-        0.0f, 0.001f, 1.0f, true,
-        0.0f, 0.0f, 0.0f
+        0.0f, 0.001f, 1.0f, true, 0.0f
     );
     float adverse_next_fill = is_long ? 89.1f : 111.1f;
     bool adverse_next_allowed = realized_loss_proxy_allows_reducer(
@@ -7959,6 +8025,70 @@ kernel void passivbot_tm_recursive_reducer_generation_gate_probe(
     # fill would fail the same gate, proving that execution must not consult it
     # again after the order has already been emitted.
     assert output.cpu().tolist() == [0.0, 0.0]
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_recursive_reducer_gate_uses_generation_pnl_snapshot(side):
+    import passivbot_rust
+
+    row = _tm_single_row()
+    params = torch.tensor(row, dtype=torch.float32, device="mps")
+    probe_kernel = r"""
+kernel void passivbot_tm_recursive_reducer_generation_pnl_probe(
+    constant float* params,
+    device float* output,
+    constant int& is_long_raw,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    bool is_long = is_long_raw != 0;
+    TmSide source = load_side(params, 0, 100.0f);
+    source.close_gen_balance = 1000.0f;
+    source.close_gen_pprice = 100.0f;
+    source.close_gen_market_price = 100.0f;
+    ReducerCandidate candidates[3];
+    for (int i = 0; i < 3; ++i) {
+        candidates[i] = empty_reducer_candidate();
+    }
+    candidates[0].finalized_qty = 1.0f;
+    candidates[0].ticks = is_long ? 9900 : 10100;
+    candidates[0].price = is_long ? 99.0f : 101.0f;
+    candidates[0].order_type_id = is_long ? 9 : 20;
+    candidates[0].is_unstuck = true;
+
+    source.close_gen_realized_pnl_cumsum_last = 0.0f;
+    source.close_gen_realized_pnl_cumsum_max = 0.0f;
+    output[0] = float(select_recursive_close_reducer(
+        candidates, is_long, source, 0.01f, 0.0f,
+        0.0f, 0.0f, 1.0f, true, 0.01f
+    ));
+    source.close_gen_realized_pnl_cumsum_last = -10.0f;
+    source.close_gen_realized_pnl_cumsum_max = 0.0f;
+    output[1] = float(select_recursive_close_reducer(
+        candidates, is_long, source, 0.01f, 0.0f,
+        0.0f, 0.0f, 1.0f, true, 0.01f
+    ));
+}
+"""
+    output = torch.zeros(2, dtype=torch.float32, device="mps")
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_trailing_martingale_source_py() + probe_kernel
+    )
+    library.passivbot_tm_recursive_reducer_generation_pnl_probe(
+        params,
+        output,
+        1 if side == "long" else 0,
+        threads=(1, 1, 1),
+    )
+    torch.mps.synchronize()
+
+    # A fresh 1% budget admits the one-unit losing unstuck close. A generation
+    # snapshot already 10 units below its realized-PnL peak has no remaining
+    # room and rejects it, regardless of fills which occur on the next candle.
+    assert output.cpu().tolist() == [0.0, -1.0]
 
 
 @pytest.mark.skipif(
@@ -12732,6 +12862,11 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert "close_gen_market_price" in source
     assert "preferred.finalized_qty, gate_price" in source
     assert "source.close_gen_market_price, !is_long" in source
+    assert "close_gen_realized_pnl_cumsum_last" in source
+    assert "close_gen_realized_pnl_cumsum_max" in source
+    assert source.count("for (int allocation_pass = 0;") == 1
+    assert "reducer_below_min && !all_below_min" in source
+    assert "include_reducer = false" in source
     assert "reducer_qty, reducer_fill_price" not in source
     assert "adj, reducer_fill_price" not in source
     assert "sim.market_orders_allowed = false" in source

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -7238,6 +7238,124 @@ kernel void passivbot_tm_recursive_close_market_minimum_probe(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_recursive_expansion_keeps_pregate_wel_reachability(side):
+    import passivbot_rust
+
+    row = _tm_single_row(
+        initial_ema_dist=0.0,
+        wel_enforcer_enabled=True,
+        wel_enforcer_threshold=0.05,
+    )
+    row[15] = 0.25
+    row[16] = 0.1
+    row[17] = 0.0
+    row[20] = 0.0
+    params = torch.tensor(row, dtype=torch.float32, device="mps")
+    probe_kernel = r"""
+kernel void passivbot_tm_recursive_close_pregate_wel_probe(
+    constant float* params,
+    device float* output,
+    constant int& is_long_raw,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    bool is_long = is_long_raw != 0;
+    TmSide source = load_side(params, 0, 100.0f);
+    source.close_gen_balance = 1000.0f;
+    source.close_gen_psize = 1.0f;
+    source.close_gen_pprice = 100.0f;
+    source.close_gen_market_price = 100.0f;
+    source.close_gen_touch_down_ticks = 10000;
+    source.close_gen_touch_up_ticks = 10000;
+    source.close_gen_touch_nearest_ticks = 10000;
+    source.close_gen_touch_min_qty = 0.001f;
+    source.close_gen_touch_min_qty_relation = 0;
+
+    source.close_loss_gate_disabled_reducers = false;
+    output[0] = recursive_strategy_close_would_expand(
+        source, is_long, 10000, 9999,
+        0.001f, 0.01f, 0.001f, 0.0f, 1.0f
+    ) ? 1.0f : 0.0f;
+    source.close_loss_gate_disabled_reducers = true;
+    output[1] = recursive_strategy_close_would_expand(
+        source, is_long, 10000, 9999,
+        0.001f, 0.01f, 0.001f, 0.0f, 1.0f
+    ) ? 1.0f : 0.0f;
+}
+"""
+    output = torch.zeros(2, dtype=torch.float32, device="mps")
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_trailing_martingale_source_py() + probe_kernel
+    )
+    library.passivbot_tm_recursive_close_pregate_wel_probe(
+        params,
+        output,
+        1 if side == "long" else 0,
+        threads=(1, 1, 1),
+    )
+    torch.mps.synchronize()
+
+    assert output.cpu().tolist() == [1.0, 1.0]
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_tm_recursive_market_groups_trim_to_position_before_fill():
+    count = 8
+    close = np.asarray(
+        [100.0, 100.0, 100.0, 100.0, 90.0, 90.0, 90.0, 90.0]
+    )
+    high = close.copy()
+    low = close.copy()
+    low[3] = 98.0
+    high[5] = 102.0
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 10.01, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_single_row(initial_ema_dist=0.0)
+    row[6] = 0.041
+    row[15] = 0.01
+    row[16] = 0.005
+    row[17] = -0.01
+    row[20] = 0.0
+    row[23] = 100.0
+    params = np.asarray([row + row], dtype=np.float64)
+
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=True,
+        short_enabled=False,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.2,
+    ).run(params)
+    torch.mps.synchronize()
+
+    # Multiple recursive groups resize against the same generation position.
+    # Rust trims their aggregate first, so no final below-minimum fragment is
+    # executed as a separate fill.
+    assert output["fill_count"].item() == 4.0
+    assert output["psize"].item() == 0.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_tm_hsl_panic_replacement_clears_ordinary_market_state(side):
     import passivbot_rust
 
@@ -11967,6 +12085,9 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert "recursive_close_groups" in source
     assert "recursive_strategy_close_would_expand" in source
     assert "selected.market = should_use_ordinary_market_execution" in source
+    assert source.count("bool all_below_min") == 2
+    assert source.count("bool normalize_close_groups") == 2
+    assert source.count("int collapse_ordinary_rank") == 2
     assert source.count("group.market ?") >= 6
     assert source.count("float reducer_fee_rate = reducer_market") == 4
     assert "realized_loss_proxy_allows_close" in source

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -7888,9 +7888,10 @@ kernel void passivbot_tm_recursive_mixed_minimum_reducer_probe(
     output[0] = float(group_count);
     output[1] = allocation.reducer_qty;
     output[2] = allocation.ordinary_budget;
+    output[3] = allocation.normalize_close_groups ? 1.0f : 0.0f;
 }
 """
-    output = torch.zeros(3, dtype=torch.float32, device="mps")
+    output = torch.zeros(4, dtype=torch.float32, device="mps")
     library = torch.mps.compile_shader(
         passivbot_rust.mps_trailing_martingale_source_py() + probe_kernel
     )
@@ -7905,7 +7906,7 @@ kernel void passivbot_tm_recursive_mixed_minimum_reducer_probe(
     # but the farther 200-price ordinary group has a 2.5 minimum. Exact Rust
     # therefore filters the reducer and reallocates all 4.0 units to ordinary
     # closes instead of collapsing to the protective order.
-    assert values[1:] == [0.0, 4.0]
+    assert values[1:] == [0.0, 4.0, 1.0]
 
 
 @pytest.mark.skipif(
@@ -12867,6 +12868,7 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert source.count("for (int allocation_pass = 0;") == 1
     assert "reducer_below_min && !all_below_min" in source
     assert "include_reducer = false" in source
+    assert "allocation.normalize_close_groups = allocation_pass > 0" in source
     assert "reducer_qty, reducer_fill_price" not in source
     assert "adj, reducer_fill_price" not in source
     assert "sim.market_orders_allowed = false" in source

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -6907,7 +6907,7 @@ def test_mps_tm_market_entry_gate_handles_qty_step_below_float32_ulp(side):
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("side", ["long", "short"])
-def test_mps_tm_recursive_close_remains_passive_with_market_policy(side):
+def test_mps_tm_recursive_next_close_promotes_without_expanding_ladder(side):
     count = 7
     close = np.full(count, 99.0 if side == "long" else 101.0)
     close[:3] = 100.0
@@ -6970,15 +6970,111 @@ def test_mps_tm_recursive_close_remains_passive_with_market_policy(side):
 
     size_key = "psize" if side == "long" else "short_psize"
     assert resting[size_key].item() > 0.0
-    assert zero_cost_market[size_key].item() == pytest.approx(
-        resting[size_key].item(), abs=1.0e-6
+    assert resting["fill_count"].item() == 1.0
+    # No passive recursive close crosses. Exact Rust emits only calc_next_close,
+    # then promotes that one order; market policy must not expose farther rungs.
+    assert zero_cost_market["fill_count"].item() == 2.0
+    assert zero_cost_market[size_key].item() == 0.0
+    assert costly_market["fill_count"].item() == 2.0
+    assert costly_market[size_key].item() == 0.0
+    assert costly_market["balance"].item() < zero_cost_market["balance"].item()
+    assert costly_market["loss_sum"].item() > 0.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+@pytest.mark.parametrize("risk_reducer", [False, True])
+def test_mps_tm_expanded_recursive_close_promotes_each_emitted_group(
+    side, risk_reducer
+):
+    # One post-entry execution candle: multiple close fills therefore prove
+    # that the emitted recursive grid, rather than repeated calc_next_close
+    # generations, was promoted group by group.
+    count = 6
+    close = np.full(count, 99.0 if side == "long" else 101.0)
+    close[:3] = 100.0
+    high = close.copy()
+    low = close.copy()
+    trigger_distance = 0.0054
+    if side == "long":
+        high[3], low[3] = 100.0, 98.0
+        high[4] = 99.0 * (1.0 + trigger_distance)
+    else:
+        high[3], low[3] = 102.0, 100.0
+        low[4] = 101.0 * (1.0 - trigger_distance)
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
     )
-    assert costly_market[size_key].item() == pytest.approx(
-        resting[size_key].item(), abs=1.0e-6
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_single_row(
+        initial_ema_dist=0.01,
+        wel_enforcer_enabled=risk_reducer,
+        wel_enforcer_threshold=0.5,
     )
-    assert costly_market["balance"].item() == pytest.approx(
-        resting["balance"].item(), abs=1.0e-6
-    )
+    row[6] = 1.0
+    row[11] = 0.001
+    row[15] = 0.25
+    row[16] = 0.005
+    row[17] = 0.001
+    row[20] = 0.0
+    params = np.asarray([row + row], dtype=np.float64)
+    common = {
+        "long_enabled": side == "long",
+        "short_enabled": side == "short",
+        "hsl_enabled": False,
+    }
+
+    resting = MpsTrailingMartingaleRunner(
+        market, run, data, **common
+    ).run(params)
+    promoted = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        taker_fee=0.01,
+        market_order_slippage_pct=0.01,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.008,
+        **common,
+    ).run(params)
+    gated = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        taker_fee=0.01,
+        market_order_slippage_pct=0.01,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.008,
+        max_realized_loss_pct=0.0,
+        **common,
+    ).run(params)
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    assert resting["fill_count"].item() == (3.0 if risk_reducer else 2.0)
+    assert resting[size_key].item() > 0.0
+    # One passive group expands the immutable ladder. Market policy promotes
+    # every emitted group against the generation snapshot. With WEL enabled,
+    # the independently promoted reducer executes in canonical price order and
+    # the ordinary ladder is trimmed around its quantity before all closes fill.
+    assert promoted["fill_count"].item() == (4.0 if risk_reducer else 5.0)
+    assert promoted[size_key].item() == 0.0
+    assert promoted["balance"].item() < resting["balance"].item()
+    assert gated["fill_count"].item() == 1.0
+    assert gated[size_key].item() > resting[size_key].item()
 
 
 @pytest.mark.skipif(
@@ -7019,21 +7115,25 @@ kernel void passivbot_tm_recursive_close_generation_market_probe(
     CloseGroup group;
     source.market_orders_allowed = true;
     output[0] = float(recursive_close_groups(
-        source, is_long, 0, 0.001f, 0.01f, 0.001f, 5.005f, 1.0f, 500, group
+        source, is_long, 0, 0.001f, 0.01f, 0.001f, 5.005f, 1.0f,
+        0.1f, 500, group
     ));
     output[1] = group.qty;
     recursive_close_groups(
-        source, is_long, 1, 0.001f, 0.01f, 0.001f, 5.005f, 1.0f, 500, group
+        source, is_long, 1, 0.001f, 0.01f, 0.001f, 5.005f, 1.0f,
+        0.1f, 500, group
     );
     output[2] = group.qty;
 
     source.market_orders_allowed = false;
     output[3] = float(recursive_close_groups(
-        source, is_long, 0, 0.001f, 0.01f, 0.001f, 5.005f, 1.0f, 500, group
+        source, is_long, 0, 0.001f, 0.01f, 0.001f, 5.005f, 1.0f,
+        0.1f, 500, group
     ));
     output[4] = group.qty;
     recursive_close_groups(
-        source, is_long, 1, 0.001f, 0.01f, 0.001f, 5.005f, 1.0f, 500, group
+        source, is_long, 1, 0.001f, 0.01f, 0.001f, 5.005f, 1.0f,
+        0.1f, 500, group
     );
     output[5] = group.qty;
 }
@@ -7053,6 +7153,85 @@ kernel void passivbot_tm_recursive_close_generation_market_probe(
     values = output.cpu().numpy()
     assert values[0] >= 2.0
     np.testing.assert_allclose(values[:3], values[3:], atol=1.0e-6)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_recursive_close_group_uses_market_touch_minimum(side):
+    import passivbot_rust
+
+    row = _tm_single_row(initial_ema_dist=0.0)
+    row[15] = 0.01
+    row[16] = 0.001
+    row[17] = 0.1
+    row[20] = 0.0
+    params = torch.tensor(row, dtype=torch.float32, device="mps")
+    probe_kernel = r"""
+kernel void passivbot_tm_recursive_close_market_minimum_probe(
+    constant float* params,
+    device float* output,
+    constant int& is_long_raw,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    bool is_long = is_long_raw != 0;
+    TmSide source = load_side(params, 0, 100.0f);
+    source.close_gen_balance = 1000.0f;
+    source.close_gen_psize = 1.0f;
+    source.close_gen_pprice = 100.0f;
+    source.close_gen_market_price = 100.0f;
+    source.close_gen_touch_down_ticks = 9999;
+    source.close_gen_touch_up_ticks = 10001;
+    source.close_gen_touch_nearest_ticks = 10000;
+    source.close_gen_touch_min_qty = 0.201f;
+    source.close_gen_touch_min_qty_relation = 0;
+    source.market_order_near_touch_threshold = 0.02f;
+
+    CloseGroup group;
+    source.market_orders_allowed = true;
+    recursive_close_groups(
+        source, is_long, 0, 0.001f, 0.01f, 0.001f, 20.01f, 1.0f,
+        1.0f, 500, group
+    );
+    output[0] = group.qty;
+    output[1] = group.market ? 1.0f : 0.0f;
+
+    source.market_orders_allowed = false;
+    recursive_close_groups(
+        source, is_long, 0, 0.001f, 0.01f, 0.001f, 20.01f, 1.0f,
+        1.0f, 500, group
+    );
+    output[2] = group.qty;
+    output[3] = group.market ? 1.0f : 0.0f;
+}
+"""
+    output = torch.zeros(4, dtype=torch.float32, device="mps")
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_trailing_martingale_source_py() + probe_kernel
+    )
+    library.passivbot_tm_recursive_close_market_minimum_probe(
+        params,
+        output,
+        1 if side == "long" else 0,
+        threads=(1, 1, 1),
+    )
+    torch.mps.synchronize()
+
+    values = output.cpu().numpy()
+    assert values[1] == 1.0
+    assert values[3] == 0.0
+    if side == "long":
+        # The sell limit sits above the market snapshot, so its passive
+        # minimum is smaller. Promotion raises it at executable bid touch.
+        assert values[0] == pytest.approx(0.201, abs=1.0e-6)
+        assert values[2] == pytest.approx(0.198, abs=1.0e-6)
+    else:
+        # The buy limit sits below the market snapshot and already satisfies
+        # the (smaller) executable-ask minimum, so sizing remains unchanged.
+        assert values[0] == pytest.approx(0.203, abs=1.0e-6)
+        assert values[2] == pytest.approx(0.203, abs=1.0e-6)
 
 
 @pytest.mark.skipif(
@@ -11786,6 +11965,10 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert "for (int rung = 0; rung < 500; ++rung)" in source
     assert "ladder_side, ladder_balance" in source
     assert "recursive_close_groups" in source
+    assert "recursive_strategy_close_would_expand" in source
+    assert "selected.market = should_use_ordinary_market_execution" in source
+    assert source.count("group.market ?") >= 6
+    assert source.count("float reducer_fee_rate = reducer_market") == 4
     assert "realized_loss_proxy_allows_close" in source
     assert "const float max_realized_loss_pct = settings[14]" in source
     assert "const bool loss_gate_enabled = max_realized_loss_pct < 1.0f" in source

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -7081,7 +7081,82 @@ def test_mps_tm_expanded_recursive_close_promotes_each_emitted_group(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("side", ["long", "short"])
-def test_mps_tm_same_tick_wel_merges_into_recursive_market_group(side):
+def test_mps_tm_recursive_market_loss_gate_uses_generation_projection(side):
+    count = 6
+    entry_market = 99.0 if side == "long" else 101.0
+    favorable_next = 110.0 if side == "long" else 90.0
+    close = np.asarray(
+        [100.0, 100.0, 100.0, entry_market, favorable_next, favorable_next]
+    )
+    high = close.copy()
+    low = close.copy()
+    if side == "long":
+        high[3], low[3] = 100.0, 98.0
+        high[4], low[4] = 110.0, 99.0
+    else:
+        high[3], low[3] = 102.0, 100.0
+        high[4], low[4] = 101.0, 90.0
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_single_row(initial_ema_dist=0.01)
+    row[6] = 1.0
+    row[11] = 0.001
+    row[15] = 0.25
+    row[16] = 0.005
+    row[17] = 0.001
+    row[20] = 0.0
+    row[23] = 100.0
+    params = np.asarray([row + row], dtype=np.float64)
+    common = {
+        "long_enabled": side == "long",
+        "short_enabled": side == "short",
+        "hsl_enabled": False,
+        "taker_fee": 0.01,
+        "market_order_slippage_pct": 0.01,
+        "market_orders_allowed": True,
+        "market_order_near_touch_threshold": 0.02,
+    }
+
+    ungated = MpsTrailingMartingaleRunner(
+        market, run, data, **common
+    ).run(params)
+    gated = MpsTrailingMartingaleRunner(
+        market, run, data, max_realized_loss_pct=0.0, **common
+    ).run(params)
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    # The next candle gaps far enough to make its actual market fills
+    # profitable. Exact Rust nevertheless removed these recursive market
+    # groups when their generation-time projected slippage and taker fee were
+    # lossy; the favorable next-candle price must not re-admit them.
+    assert ungated["fill_count"].item() > 1.0
+    assert ungated[size_key].item() == 0.0
+    assert gated["fill_count"].item() == 1.0
+    assert gated[size_key].item() > 0.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+@pytest.mark.parametrize("winning_reducer", ["wel", "twel"])
+def test_mps_tm_same_tick_wel_merges_into_recursive_market_group(
+    side, winning_reducer
+):
     count = 6
     close = np.full(count, 99.0 if side == "long" else 101.0)
     close[:3] = 100.0
@@ -7110,8 +7185,11 @@ def test_mps_tm_same_tick_wel_merges_into_recursive_market_group(side):
     data = build_mps_data(high, low, close, timestamps, run, market)
     row = _tm_single_row(
         initial_ema_dist=0.01,
+        entry_gate=False,
         wel_enforcer_enabled=True,
         wel_enforcer_threshold=0.5,
+        twel_enforcer_enabled=winning_reducer == "twel",
+        threshold=0.25 if winning_reducer == "twel" else 1.0,
     )
     row[6] = 1.0
     row[15] = 0.25
@@ -7134,9 +7212,13 @@ def test_mps_tm_same_tick_wel_merges_into_recursive_market_group(side):
 
     size_key = "psize" if side == "long" else "short_psize"
     # calc_closes_* emits WEL first and then an ordinary close at the same
-    # quantized touch. Rust merges them, retaining the later ordinary type, so
-    # market execution and loss gating see one full-position close.
-    assert output["fill_count"].item() == 2.0
+    # quantized touch. Rust merges them before orchestration chooses the
+    # protective reducer, retaining the later ordinary type. The merged WEL
+    # quantity therefore remains in the ordinary group even when larger TWEL
+    # wins; market execution and loss gating still close the full position.
+    assert output["fill_count"].item() == (
+        2.0 if winning_reducer == "wel" else 3.0
+    )
     assert output[size_key].item() == 0.0
 
 
@@ -7510,6 +7592,69 @@ def test_mps_tm_recursive_market_groups_trim_to_position_before_fill():
     # Rust trims their aggregate first, so no final below-minimum fragment is
     # executed as a separate fill.
     assert output["fill_count"].item() == 4.0
+    assert output["psize"].item() == 0.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_tm_recursive_ladder_refinalizes_requested_reducer_qty():
+    count = 7
+    close = np.full(count, 100.0)
+    high = np.full(count, 100.0)
+    low = np.full(count, 100.0)
+    low[3] = 98.0
+    high[4] = 201.0
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.5, 0.01, 0.5, 500.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_single_row(
+        initial_ema_dist=0.01,
+        gate_initial=1.0,
+        gate_reentry=0.0,
+        entry_gate=False,
+        threshold=0.3,
+        twel_enforcer_enabled=True,
+    )
+    row[6] = 1.0
+    row[7] = 10.0
+    row[11] = 0.0
+    row[15] = 0.3
+    row[16] = 1.0
+    row[17] = 0.0
+    row[20] = 0.0
+    row[23] = 100.0
+
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=True,
+        short_enabled=False,
+        hsl_enabled=False,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.001,
+    ).run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    # The near-touch TWEL request leaves a remainder below its own executable
+    # minimum, so singular finalization expands it to the whole position. The
+    # immutable recursive ladder also has a farther passive rung whose lower
+    # price-specific minimum admits that remainder. Exact Rust re-finalizes
+    # the original TWEL request with the expanded set, yielding two closes.
+    assert output["fill_count"].item() == 3.0
     assert output["psize"].item() == 0.0
 
 

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -7081,6 +7081,69 @@ def test_mps_tm_expanded_recursive_close_promotes_each_emitted_group(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_same_tick_wel_merges_into_recursive_market_group(side):
+    count = 6
+    close = np.full(count, 99.0 if side == "long" else 101.0)
+    close[:3] = 100.0
+    high = close.copy()
+    low = close.copy()
+    if side == "long":
+        high[3], low[3] = 100.0, 98.0
+        high[4] = 100.0
+    else:
+        high[3], low[3] = 102.0, 100.0
+        low[4] = 100.0
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_single_row(
+        initial_ema_dist=0.01,
+        wel_enforcer_enabled=True,
+        wel_enforcer_threshold=0.5,
+    )
+    row[6] = 1.0
+    row[15] = 0.25
+    row[16] = -0.01
+    row[17] = 0.0
+    row[20] = 0.0
+    row[23] = 100.0
+
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+        hsl_enabled=False,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.02,
+    ).run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    # calc_closes_* emits WEL first and then an ordinary close at the same
+    # quantized touch. Rust merges them, retaining the later ordinary type, so
+    # market execution and loss gating see one full-position close.
+    assert output["fill_count"].item() == 2.0
+    assert output[size_key].item() == 0.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_tm_recursive_close_sizing_uses_generation_market(side):
     import passivbot_rust
 
@@ -7116,24 +7179,24 @@ kernel void passivbot_tm_recursive_close_generation_market_probe(
     source.market_orders_allowed = true;
     output[0] = float(recursive_close_groups(
         source, is_long, 0, 0.001f, 0.01f, 0.001f, 5.005f, 1.0f,
-        0.1f, 500, group
+        0.1f, 0, 0.0f, 500, group
     ));
     output[1] = group.qty;
     recursive_close_groups(
         source, is_long, 1, 0.001f, 0.01f, 0.001f, 5.005f, 1.0f,
-        0.1f, 500, group
+        0.1f, 0, 0.0f, 500, group
     );
     output[2] = group.qty;
 
     source.market_orders_allowed = false;
     output[3] = float(recursive_close_groups(
         source, is_long, 0, 0.001f, 0.01f, 0.001f, 5.005f, 1.0f,
-        0.1f, 500, group
+        0.1f, 0, 0.0f, 500, group
     ));
     output[4] = group.qty;
     recursive_close_groups(
         source, is_long, 1, 0.001f, 0.01f, 0.001f, 5.005f, 1.0f,
-        0.1f, 500, group
+        0.1f, 0, 0.0f, 500, group
     );
     output[5] = group.qty;
 }
@@ -7193,7 +7256,7 @@ kernel void passivbot_tm_recursive_close_market_minimum_probe(
     source.market_orders_allowed = true;
     recursive_close_groups(
         source, is_long, 0, 0.001f, 0.01f, 0.001f, 20.01f, 1.0f,
-        1.0f, 500, group
+        1.0f, 0, 0.0f, 500, group
     );
     output[0] = group.qty;
     output[1] = group.market ? 1.0f : 0.0f;
@@ -7201,7 +7264,7 @@ kernel void passivbot_tm_recursive_close_market_minimum_probe(
     source.market_orders_allowed = false;
     recursive_close_groups(
         source, is_long, 0, 0.001f, 0.01f, 0.001f, 20.01f, 1.0f,
-        1.0f, 500, group
+        1.0f, 0, 0.0f, 500, group
     );
     output[2] = group.qty;
     output[3] = group.market ? 1.0f : 0.0f;
@@ -7232,6 +7295,62 @@ kernel void passivbot_tm_recursive_close_market_minimum_probe(
         # the (smaller) executable-ask minimum, so sizing remains unchanged.
         assert values[0] == pytest.approx(0.203, abs=1.0e-6)
         assert values[2] == pytest.approx(0.203, abs=1.0e-6)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_tm_recursive_wel_seed_precedes_market_resize():
+    import passivbot_rust
+
+    row = _tm_single_row(
+        initial_ema_dist=0.0,
+        wel_enforcer_enabled=True,
+        wel_enforcer_threshold=0.049,
+    )
+    params = torch.tensor(row, dtype=torch.float32, device="mps")
+    probe_kernel = r"""
+kernel void passivbot_tm_recursive_wel_seed_probe(
+    constant float* params,
+    device float* output,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    TmSide source = load_side(params, 0, 100.0f);
+    float psize = 0.5f;
+    float passive_price = 99.01f;
+    float market_price = 99.004f;
+    float passive_wel_qty = exposure_reducer_qty(
+        psize, 100.0f, 1000.0f,
+        source.allowed_wel * source.wel_enforcer_threshold,
+        passive_price, 0.001f, 0.001f, 19.801f, 1.0f
+    );
+    float executable_wel_qty = resize_market_close_qty(
+        passive_wel_qty, psize, market_price,
+        0.001f, 0.001f, 19.801f, 1.0f
+    );
+    output[0] = passive_wel_qty;
+    output[1] = executable_wel_qty;
+    output[2] = round_step(psize - passive_wel_qty, 0.001f);
+    output[3] = round_step(psize - executable_wel_qty, 0.001f);
+}
+"""
+    output = torch.zeros(4, dtype=torch.float32, device="mps")
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_trailing_martingale_source_py() + probe_kernel
+    )
+    library.passivbot_tm_recursive_wel_seed_probe(
+        params,
+        output,
+        threads=(1, 1, 1),
+    )
+    torch.mps.synchronize()
+
+    values = output.cpu().tolist()
+    assert values[0] == pytest.approx(0.2, abs=1.0e-6)
+    assert values[1] == pytest.approx(0.201, abs=1.0e-6)
+    assert values[2] == pytest.approx(0.3, abs=1.0e-6)
+    assert values[3] == pytest.approx(0.299, abs=1.0e-6)
 
 
 @pytest.mark.skipif(
@@ -12088,6 +12207,9 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert source.count("bool all_below_min") == 2
     assert source.count("bool normalize_close_groups") == 2
     assert source.count("int collapse_ordinary_rank") == 2
+    assert source.count("bool selected_strategy_wel") == 2
+    assert source.count("close_gen_psize - strategy_wel_qty") == 2
+    assert "strategy_wel_qty = reducer_qty" not in source
     assert source.count("group.market ?") >= 6
     assert source.count("float reducer_fee_rate = reducer_market") == 4
     assert "realized_loss_proxy_allows_close" in source


### PR DESCRIPTION
## Summary

- add single-coin Apple MPS market execution for Trailing Martingale recursive-close grids
- preserve exact passive next-candle expansion: a market-only next close remains singular, while an actually expanded immutable ladder classifies and executable-touch-sizes every emitted price group at its generation market snapshot
- preserve reducer ordering, aggregate allocation, realized-loss gating, adverse slippage, taker fees, and long/short symmetry
- accept close optimizer bounds wholly inside recursive or trailing mode while continuing to fail closed on mode crossings and multi-coin market execution

## Safety boundary

Exact Rust validations remain authoritative. This changes only the Apple MPS optimization proxy; CPU bot operation, CPU backtesting, and CPU optimization are untouched. Multi-coin market-order optimization remains rejected.

## Validation

- `cargo test --manifest-path passivbot-rust/Cargo.toml --no-default-features` (267 passed)
- `cargo check --manifest-path passivbot-rust/Cargo.toml --tests --no-default-features`
- full `tests/optimization/test_gpu_backend.py`
- full physical-M3 `tests/optimization/test_gpu_mps.py`
- full `tests/optimization`
- rebuilt, source-stamped, and verified arm64 Python extension; reran full MPS and optimization suites against it
- cached BTC long-only TM GPU optimize smoke: 8 MPS generations, 64 exact Rust validations, 64 drift pairs, no halt
- `python -m compileall` on changed Python files
- `git diff --check`
- AI docs checker: 0 errors; `tests/test_ai_docs.py`: 5 passed

Baseline note: `mkdocs build --strict` still stops on the two pre-existing release-note links to `../CHANGELOG.md`; no new documentation error was introduced.