### PR TITLE
Add multi-coin EMA market execution to MPS optimizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added baseline multi-coin EMA Anchor ordinary market execution to Apple MPS optimization for
+  long-only, short-only, and fused long+short runs. The proxy retains generation-time entry and
+  ordinary-close intent, executes it on the next valid candle with adverse directional slippage
+  and taker fees, applies executable-touch minimum sizing, and prices total-exposure entry
+  allocation at the market touch. HSL may coexist with this path. Auto-unstuck, total-exposure
+  repair, and realized-loss gating remain fail closed for multi-coin EMA market mode until their
+  protective reducer ordering is modeled; multi-coin Trailing Martingale market mode also remains
+  fail closed.
+
 - Added single-coin Trailing Martingale recursive-close market execution to Apple MPS
   optimization. Exact passive next-candle expansion remains authoritative: a market-only next
   close does not reveal the recursive suffix, while an expanded immutable ladder classifies and
@@ -20,8 +29,8 @@ All notable user-facing changes will be documented in this file.
   retain canonical ordering,
   aggregate position trimming, quantity-relative minimum-size comparisons, adverse slippage, and
   taker fees. Entry and close optimizer bounds must
-  each remain wholly recursive or wholly trailing; mode-crossing ranges and multi-coin market
-  execution remain fail closed.
+  each remain wholly recursive or wholly trailing; mode-crossing ranges and multi-coin Trailing
+  Martingale market execution remain fail closed.
 
 - Added single-coin Trailing Martingale recursive-entry market execution to Apple MPS optimization.
   Every immutable strategy-ladder rung is independently promoted against its generation market
@@ -31,14 +40,14 @@ All notable user-facing changes will be documented in this file.
   its separate wallet-exposure allowance before that portfolio gate is applied; the retained
   nearest prefix ends at the first partially cropped portfolio-boundary rung. Entry optimizer
   bounds must remain wholly recursive or wholly trailing; mode-crossing ranges and multi-coin
-  market execution remain fail closed.
+  Trailing Martingale market execution remain fail closed.
 
 - Extended single-coin Trailing Martingale ordinary market-order optimization on Apple MPS to
   compatible HSL modes, one-sided minimum-effective-cost filtering, auto-unstuck, position- and
   total-exposure repair, and realized-loss gating. Market-promoted reducers are resized at
   executable touch before selection and aggregate allocation, and adverse slippage plus taker fees
-  participate in the conservative loss projection. Multi-coin market execution remains fail
-  closed pending its dedicated slice.
+  participate in the conservative loss projection. Multi-coin Trailing Martingale market
+  execution remains fail closed pending its dedicated slice.
 
 - Added baseline ordinary market-order execution to Apple MPS optimization for single-coin
   Trailing Martingale, covering long, short, and dual-side near-touch trailing entries and closes,
@@ -55,8 +64,8 @@ All notable user-facing changes will be documented in this file.
 - Added baseline ordinary market-order execution to Apple MPS optimization for single-coin EMA
   Anchor, including near-touch promotion, next-candle adverse slippage, taker fees, executable-touch
   sizing, directional and one-way modes, and compatible suites. Auto-unstuck, exposure repair,
-  realized-loss gating, Trailing Martingale, and multi-coin combinations remain fail closed while
-  their market-order interactions are implemented.
+  realized-loss gating, and Trailing Martingale were added in later slices; baseline multi-coin
+  EMA Anchor support is now also available under the restrictions described above.
 
 - Added Apple MPS suite scenario overrides for `live.hsl_signal_mode`. Coin, position-side, and
   unified HSL signal topology may now vary by scenario when each effective scenario passes the

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -308,8 +308,18 @@ The supported slice is intentionally narrow:
   Strategy WEL reachability remains part of the pre-gate expansion decision even when that reducer
   is subsequently rejected. Its passive quantity seeds the remaining immutable rungs before any
   market minimum resize, and a WEL sharing the following ordinary rung's quantized price is merged
-  into that ordinary group. Multi-coin market execution remains fail closed until its execution
-  ordering is modeled
+  into that ordinary group.
+  Multi-coin EMA Anchor supports ordinary market entries and ordinary strategy closes for
+  long-only, short-only, and fused long+short runs, including compatible suites, static coin
+  overrides, forager selection, the strict total-exposure entry gate, and HSL. The proxy stores
+  generation-time market intent, fills it on the next valid candle with adverse directional
+  slippage and the coin's taker fee, uses executable-touch minimum sizing for short entries and
+  closes, and accounts for market-touch cost while allocating the portfolio entry cap.
+  Until protective market-reducer ordering is modeled, every effective multi-coin EMA scenario
+  requires `live.max_realized_loss_pct: 1`, `unstuck.enabled: false`, and
+  `risk.total_exposure_enforcer_enabled: false` on each enabled side; optimizer enablement bounds
+  for unstuck and the TWEL enforcer must remain pinned off, and coin overrides may not enable
+  unstuck. Multi-coin Trailing Martingale ordinary market execution remains fail closed
 - no invalid candle tail after the selected coin's final valid candle
 
 Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor and

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -438,6 +438,8 @@ mod tests {
         assert!(source.contains("market_execution ? taker_fee : maker_fee"));
         assert!(source.contains("ordinary_market_fill_price("));
         assert!(source.contains("resize_market_close_qty("));
+        assert!(source.contains("position_size <= requested_qty"));
+        assert!(source.contains("remainder + tolerance < minimum_qty"));
         assert!(!source.contains("accumulate_min_cost_balance_error"));
         assert_eq!(source.matches("= fma(").count(), 6);
         assert!(!source.contains("alpha0 * close +"));
@@ -570,7 +572,21 @@ mod tests {
         );
         assert!(source.contains("coin_hsl_eligibility_changed"));
         assert!(source.contains("coin_hsl_entry_blocked_mask"));
-        assert!(source.contains("market_panic ? taker_fee : maker_fee"));
+        assert!(source.contains("market_execution ? taker_fee : maker_fee"));
+        assert!(source.contains("const bool market_orders_allowed = run_settings[9] > 0.5f"));
+        assert!(source.contains(
+            "const bool market_orders_allowed = run_settings[11] > 0.5f"
+        ));
+        assert!(source.contains("should_use_ordinary_market_execution("));
+        assert!(source.contains("ordinary_market_fill_price("));
+        assert!(source.contains("resize_market_close_qty("));
+        assert!(source.contains("bool entry_market[MAX_COINS]"));
+        assert!(source.contains("bool close_market[MAX_COINS]"));
+        assert!(source.contains("bool secondary_close_market[MAX_COINS]"));
+        assert!(source.contains(
+            "contribution[c] = quantity * entry_exposure_price"
+        ));
+        assert!(source.contains("float price = entry_market[best]"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[scalar_offset + 19] = loss_sum"));
         assert!(source

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -153,6 +153,9 @@ struct EmaMulticoinSideState {
     int secondary_close_tick[MAX_COINS];
     int twel_close_tick[MAX_COINS];
     int unstuck_close_tick[MAX_COINS];
+    bool entry_market[MAX_COINS];
+    bool close_market[MAX_COINS];
+    bool secondary_close_market[MAX_COINS];
     bool close_is_unstuck_reducer[MAX_COINS];
     bool close_is_hsl_panic[MAX_COINS];
     bool selected[MAX_COINS];
@@ -397,6 +400,9 @@ inline void init_ema_multicoin_side_state(
         side.secondary_close_tick[c] = 0;
         side.twel_close_tick[c] = 0;
         side.unstuck_close_tick[c] = 0;
+        side.entry_market[c] = false;
+        side.close_market[c] = false;
+        side.secondary_close_market[c] = false;
         side.close_is_unstuck_reducer[c] = false;
         side.close_is_hsl_panic[c] = false;
         side.coin_realized_pnl[c] = 0.0f;
@@ -1205,6 +1211,8 @@ inline void generate_ema_multicoin_side_orders(
     int current_hsl_mode,
     bool loss_gate_enabled,
     float max_realized_loss_pct,
+    bool market_orders_allowed,
+    float market_order_near_touch_threshold,
     int forced_unstuck_coin,
     ulong one_way_initial_blocked_mask
 ) {
@@ -1255,6 +1263,9 @@ inline void generate_ema_multicoin_side_orders(
     thread int* secondary_close_tick = side.secondary_close_tick;
     thread int* twel_close_tick = side.twel_close_tick;
     thread int* unstuck_close_tick = side.unstuck_close_tick;
+    thread bool* entry_market = side.entry_market;
+    thread bool* close_market = side.close_market;
+    thread bool* secondary_close_market = side.secondary_close_market;
     thread bool* close_is_unstuck_reducer =
         side.close_is_unstuck_reducer;
     thread bool* close_is_hsl_panic = side.close_is_hsl_panic;
@@ -1529,6 +1540,9 @@ inline void generate_ema_multicoin_side_orders(
         close_qty[c] = 0.0f;
         secondary_close_qty[c] = 0.0f;
         secondary_close_tick[c] = 0;
+        entry_market[c] = false;
+        close_market[c] = false;
+        secondary_close_market[c] = false;
         close_is_hsl_panic[c] = false;
         contribution[c] = 0.0f;
         entry_candidate[c] = false;
@@ -1600,10 +1614,22 @@ inline void generate_ema_multicoin_side_orders(
         int candidate_close_tick = short_side ? bid_tick : ask_tick;
         float entry_price = short_side ? ask_price : bid_price;
         float close_price = short_side ? bid_price : ask_price;
+        bool candidate_entry_market = should_use_ordinary_market_execution(
+            candidate_entry_tick, !short_side, price_now, price_step,
+            market_orders_allowed, market_order_near_touch_threshold
+        );
+        float entry_exposure_price = candidate_entry_market
+            ? price_now : entry_price;
         float minimum = min_entry_qty(
             entry_price, qty_step, min_qty, min_cost, c_mult
         );
-        minimum_entry[c] = minimum;
+        float market_entry_minimum = candidate_entry_market
+            ? min_entry_qty(
+                price_now, qty_step, min_qty, min_cost, c_mult
+            ) : minimum;
+        float effective_entry_minimum = short_side && candidate_entry_market
+            ? market_entry_minimum : minimum;
+        minimum_entry[c] = effective_entry_minimum;
         float coin_cooldown_min = ceil(coin_override_or(
             coin_overrides, c, 10, cooldown_min
         ));
@@ -1630,20 +1656,29 @@ inline void generate_ema_multicoin_side_orders(
                 base_qty * fmax(1.0f + fmax(wallet_ratio, 0.0f) * coin_ddf, 1.0f),
                 qty_step
             );
+            if (short_side && candidate_entry_market
+                && quantity < market_entry_minimum) {
+                quantity = market_entry_minimum;
+            }
             float headroom = (
                 position_cap * balance - psize[c] * pprice[c] * c_mult
-            ) / fmax(entry_price * c_mult, 1.0e-12f);
-            bool over = (psize[c] * pprice[c] + quantity * entry_price) * c_mult
+            ) / fmax(entry_exposure_price * c_mult, 1.0e-12f);
+            bool over = (
+                psize[c] * pprice[c] + quantity * entry_exposure_price
+            ) * c_mult
                 / fmax(balance, 1.0e-9f) >= position_cap;
             if (over) {
                 float capped = floor_step(headroom, qty_step);
-                quantity = capped > 0.0f && capped + 1.0e-6f >= minimum
+                quantity = capped > 0.0f
+                        && capped + 1.0e-6f >= effective_entry_minimum
                     ? capped : 0.0f;
             }
             entry_qty[c] = quantity;
             entry_tick[c] = candidate_entry_tick;
+            entry_market[c] = candidate_entry_market && quantity > 0.0f;
             entry_candidate[c] = quantity > 0.0f;
-            contribution[c] = quantity * entry_price * c_mult / balance;
+            contribution[c] = quantity * entry_exposure_price * c_mult
+                / balance;
         }
         if (psize[c] > 0.0f && close_price > 0.0f) {
             float minimum_close = min_entry_qty(
@@ -1658,6 +1693,16 @@ inline void generate_ema_multicoin_side_orders(
                     || psize[c] - clip < minimum_close
                 ? psize[c] : clip;
             close_tick[c] = candidate_close_tick;
+            close_market[c] = should_use_ordinary_market_execution(
+                candidate_close_tick, short_side, price_now, price_step,
+                market_orders_allowed, market_order_near_touch_threshold
+            );
+            if (close_market[c]) {
+                close_qty[c] = resize_market_close_qty(
+                    close_qty[c], psize[c], price_now,
+                    qty_step, min_qty, min_cost, c_mult
+                );
+            }
         }
 
         // Reserve the side-wide protective reducer and trim the
@@ -1667,12 +1712,14 @@ inline void generate_ema_multicoin_side_orders(
         float raw_unstuck_qty = unstuck_close_qty[c];
         int raw_unstuck_tick = unstuck_close_tick[c];
         float finalized_twel_qty = finalized_reducer_qty_with_ordinary(
-            psize[c], close_qty[c], close_price,
+            psize[c], close_qty[c],
+            close_market[c] ? price_now : close_price,
             raw_twel_qty, float(raw_twel_tick) * price_step,
             qty_step, min_qty, min_cost, c_mult
         );
         float finalized_unstuck_qty = finalized_reducer_qty_with_ordinary(
-            psize[c], close_qty[c], close_price,
+            psize[c], close_qty[c],
+            close_market[c] ? price_now : close_price,
             raw_unstuck_qty, float(raw_unstuck_tick) * price_step,
             qty_step, min_qty, min_cost, c_mult
         );
@@ -1727,7 +1774,8 @@ inline void generate_ema_multicoin_side_orders(
             float ordinary_qty = close_qty[c];
             if (ordinary_qty > 0.0f) {
                 float ordinary_min = min_entry_qty(
-                    close_price, qty_step, min_qty, min_cost, c_mult
+                    close_market[c] ? price_now : close_price,
+                    qty_step, min_qty, min_cost, c_mult
                 );
                 if (ordinary_qty + reducer_qty > psize[c]) {
                     ordinary_qty = fmax(
@@ -1759,6 +1807,7 @@ inline void generate_ema_multicoin_side_orders(
                     }
                     secondary_close_qty[c] = ordinary_qty;
                     secondary_close_tick[c] = close_tick[c];
+                    secondary_close_market[c] = close_market[c];
                 }
             }
             if (secondary_close_qty[c] <= 0.0f) {
@@ -1772,6 +1821,7 @@ inline void generate_ema_multicoin_side_orders(
             }
             close_qty[c] = reducer_qty;
             close_tick[c] = reducer_tick;
+            close_market[c] = false;
             close_is_unstuck_reducer[c] = reducer_is_unstuck;
         }
         if (close_qty[c] > 0.0f && !realized_loss_proxy_allows_reducer(
@@ -1783,6 +1833,7 @@ inline void generate_ema_multicoin_side_orders(
                 realized_pnl_cumsum_max, max_realized_loss_pct
             )) {
             close_qty[c] = 0.0f;
+            close_market[c] = false;
             close_is_unstuck_reducer[c] = false;
         }
         if (secondary_close_qty[c] > 0.0f
@@ -1793,6 +1844,7 @@ inline void generate_ema_multicoin_side_orders(
                 coin_settings[coin_offset + 5], loss_gate_enabled
             )) {
             secondary_close_qty[c] = 0.0f;
+            secondary_close_market[c] = false;
         }
     }
 
@@ -1843,7 +1895,11 @@ inline void generate_ema_multicoin_side_orders(
             float qty_step = coin_settings[coin_offset + 0];
             float price_step = coin_settings[coin_offset + 1];
             float c_mult = coin_settings[coin_offset + 4];
-            float price = float(entry_tick[best]) * price_step;
+            float price = entry_market[best]
+                ? clamped_market_price(
+                    bars, coin_settings, k, best, C
+                )
+                : float(entry_tick[best]) * price_step;
             float room_cost = fmax((total_cap - running_twe) * balance, 0.0f);
             float partial = floor_step(
                 room_cost / fmax(price * c_mult, 1.0e-12f), qty_step
@@ -1875,8 +1931,15 @@ inline void generate_ema_multicoin_side_orders(
             );
             secondary_close_qty[c] = 0.0f;
             secondary_close_tick[c] = 0;
+            close_market[c] = false;
+            secondary_close_market[c] = false;
             close_is_unstuck_reducer[c] = false;
             close_is_hsl_panic[c] = true;
+        }
+        if (!(entry_qty[c] > 0.0f)) entry_market[c] = false;
+        if (!(close_qty[c] > 0.0f)) close_market[c] = false;
+        if (!(secondary_close_qty[c] > 0.0f)) {
+            secondary_close_market[c] = false;
         }
     }
 }
@@ -1916,6 +1979,9 @@ inline bool process_ema_multicoin_side_fills(
     thread int* entry_tick = side.entry_tick;
     thread int* close_tick = side.close_tick;
     thread int* secondary_close_tick = side.secondary_close_tick;
+    thread bool* entry_market = side.entry_market;
+    thread bool* close_market = side.close_market;
+    thread bool* secondary_close_market = side.secondary_close_market;
     thread bool* close_is_unstuck_reducer = side.close_is_unstuck_reducer;
     thread bool* close_is_hsl_panic = side.close_is_hsl_panic;
     thread float* coin_realized_pnl = side.coin_realized_pnl;
@@ -1951,15 +2017,17 @@ inline bool process_ema_multicoin_side_fills(
             : hsl_panic_market;
         bool primary_market_panic = close_is_hsl_panic[c]
             && coin_hsl_panic_market;
+        bool primary_ordinary_market = !close_is_hsl_panic[c]
+            && close_market[c];
         bool filled_close = close_qty[c] > 0.0f && psize[c] > 0.0f
-            && (primary_market_panic || (short_side
+            && (primary_market_panic || primary_ordinary_market || (short_side
                 ? close_tick[c] > fill_ticks[tick_offset + 1]
                 : close_tick[c] <= fill_ticks[tick_offset + 0]));
         bool filled_secondary_close = secondary_close_qty[c] > 0.0f
             && psize[c] > 0.0f
-            && (short_side
+            && (secondary_close_market[c] || (short_side
                 ? secondary_close_tick[c] > fill_ticks[tick_offset + 1]
-                : secondary_close_tick[c] <= fill_ticks[tick_offset + 0]);
+                : secondary_close_tick[c] <= fill_ticks[tick_offset + 0]));
         bool secondary_first = filled_secondary_close
             && (!filled_close || (short_side
                 ? secondary_close_tick[c] > close_tick[c]
@@ -1976,18 +2044,11 @@ inline bool process_ema_multicoin_side_fills(
             float requested_qty = use_secondary
                 ? secondary_close_qty[c] : close_qty[c];
             bool market_panic = !use_secondary && primary_market_panic;
-            float fill_price = market_panic
-                ? fmax(
-                    short_side
-                        ? ceil_step(
-                            close * (1.0f + market_order_slippage_pct),
-                            price_step
-                        )
-                        : floor_step(
-                            close * (1.0f - market_order_slippage_pct),
-                            price_step
-                        ),
-                    price_step
+            bool market_execution = market_panic || (use_secondary
+                ? secondary_close_market[c] : primary_ordinary_market);
+            float fill_price = market_execution
+                ? ordinary_market_fill_price(
+                    close, short_side, market_order_slippage_pct, price_step
                 )
                 : float(executed_tick) * price_step;
             float adjusted = fmin(
@@ -1999,14 +2060,15 @@ inline bool process_ema_multicoin_side_fills(
                 : fill_price - pprice[c]);
             float net_pnl = pnl
                 - adjusted * fill_price * c_mult
-                    * (market_panic ? taker_fee : maker_fee);
+                    * (market_execution ? taker_fee : maker_fee);
             bool is_unstuck = !use_secondary
                 && close_is_unstuck_reducer[c];
             bool is_hsl_panic = !use_secondary
                 && close_is_hsl_panic[c];
             if (!is_hsl_panic && !realized_loss_proxy_allows_reducer(
                     adjusted, fill_price, pprice[c], short_side,
-                    c_mult, maker_fee, is_unstuck, loss_gate_enabled,
+                    c_mult, market_execution ? taker_fee : maker_fee,
+                    is_unstuck, loss_gate_enabled,
                     balance, realized_pnl_cumsum_last,
                     realized_pnl_cumsum_max, max_realized_loss_pct
                 )) {
@@ -2066,8 +2128,10 @@ inline bool process_ema_multicoin_side_fills(
             fills.day_volume += fabs(adjusted) * fill_price * c_mult / balance;
             if (use_secondary) {
                 secondary_close_qty[c] = 0.0f;
+                secondary_close_market[c] = false;
             } else {
                 close_qty[c] = 0.0f;
+                close_market[c] = false;
                 close_is_unstuck_reducer[c] = false;
                 close_is_hsl_panic[c] = false;
             }
@@ -2077,13 +2141,19 @@ inline bool process_ema_multicoin_side_fills(
 
         bool was_flat = psize[c] <= 0.0f;
         bool filled_entry = entry_qty[c] > 0.0f
-            && (short_side
+            && (entry_market[c] || (short_side
                 ? entry_tick[c] <= fill_ticks[tick_offset + 0]
-                : entry_tick[c] > fill_ticks[tick_offset + 1]);
+                : entry_tick[c] > fill_ticks[tick_offset + 1]));
         if (filled_entry) {
-            float fill_price = float(entry_tick[c]) * price_step;
+            float fill_price = entry_market[c]
+                ? ordinary_market_fill_price(
+                    close, !short_side,
+                    market_order_slippage_pct, price_step
+                )
+                : float(entry_tick[c]) * price_step;
             float adjusted = round_step(entry_qty[c], qty_step);
-            float fee = adjusted * fill_price * c_mult * maker_fee;
+            float fee = adjusted * fill_price * c_mult
+                * (entry_market[c] ? taker_fee : maker_fee);
             record_realized_net(
                 -fee, account,
                 fills.day_fill_count, fills.fill_count,
@@ -2116,6 +2186,7 @@ inline bool process_ema_multicoin_side_fills(
             last_increase_k[c] = float(k);
             fills.day_volume += fabs(adjusted) * fill_price * c_mult / balance;
             entry_qty[c] = 0.0f;
+            entry_market[c] = false;
             any_fill = true;
         }
         if (executed_close || filled_entry) {
@@ -2195,6 +2266,10 @@ inline void passivbot_ema_anchor_multicoin_impl(
     const float max_realized_loss_pct = run_settings[5];
     const float market_order_slippage_pct = fmax(run_settings[7], 0.0f);
     const bool hsl_panic_market = run_settings[8] > 0.5f;
+    const bool market_orders_allowed = run_settings[9] > 0.5f;
+    const float market_order_near_touch_threshold = fmax(
+        run_settings[10], 0.0f
+    );
     const float log_bin_scale = 127.0f / log(4000001.0f);
 
     thread float* psize = side.psize;
@@ -2350,7 +2425,8 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 bars, touch_ticks, coin_settings, coin_overrides,
                 k, C, short_side, tradable_count, effective_n_positions,
                 current_hsl_mode, loss_gate_enabled,
-                max_realized_loss_pct, -2, 0ul
+                max_realized_loss_pct, market_orders_allowed,
+                market_order_near_touch_threshold, -2, 0ul
             );
         }
 
@@ -2904,6 +2980,10 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
     const bool long_hsl_panic_market = run_settings[8] > 0.5f;
     const bool short_hsl_panic_market = run_settings[9] > 0.5f;
     const bool hedge_mode = run_settings[10] > 0.5f;
+    const bool market_orders_allowed = run_settings[11] > 0.5f;
+    const float market_order_near_touch_threshold = fmax(
+        run_settings[12], 0.0f
+    );
     const float log_bin_scale = 127.0f / log(4000001.0f);
 
     JointPortfolioAccount account = init_joint_portfolio_account(
@@ -3138,6 +3218,7 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                 k, C, false, long_tradable_count,
                 long_effective_n_positions, long_hsl_mode,
                 loss_gate_enabled, max_realized_loss_pct,
+                market_orders_allowed, market_order_near_touch_threshold,
                 long_unstuck_coin, long_one_way_order_blocked_mask
             );
         }
@@ -3154,6 +3235,7 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                 k, C, true, short_tradable_count,
                 short_effective_n_positions, short_hsl_mode,
                 loss_gate_enabled, max_realized_loss_pct,
+                market_orders_allowed, market_order_near_touch_threshold,
                 short_unstuck_coin, short_one_way_order_blocked_mask
             );
         }

--- a/passivbot-rust/src/gpu/mps_multicoin_common.metal
+++ b/passivbot-rust/src/gpu/mps_multicoin_common.metal
@@ -30,6 +30,70 @@ inline float min_entry_qty(
     return aligned ? fmax(nearest, raw_min) : ceil(raw_steps) * qty_step;
 }
 
+inline bool should_use_ordinary_market_execution(
+    int order_ticks,
+    bool buy_order,
+    float market_price,
+    float price_step,
+    bool market_orders_allowed,
+    float near_touch_threshold
+) {
+    if (!market_orders_allowed || order_ticks <= 0
+        || !(market_price > 0.0f) || !isfinite(market_price)) {
+        return false;
+    }
+    float order_price = float(order_ticks) * price_step;
+    if (buy_order ? order_price >= market_price : order_price <= market_price) {
+        return true;
+    }
+    return fabs(order_price / market_price - 1.0f)
+        <= fmax(near_touch_threshold, 0.0f);
+}
+
+inline float ordinary_market_fill_price(
+    float close,
+    bool buy_order,
+    float market_order_slippage_pct,
+    float price_step
+) {
+    float slipped = close * (
+        buy_order
+            ? 1.0f + market_order_slippage_pct
+            : 1.0f - market_order_slippage_pct
+    );
+    return fmax(
+        buy_order ? ceil_step(slipped, price_step)
+                  : floor_step(slipped, price_step),
+        price_step
+    );
+}
+
+inline float resize_market_close_qty(
+    float requested_qty,
+    float position_size,
+    float executable_touch,
+    float qty_step,
+    float min_qty,
+    float min_cost,
+    float c_mult
+) {
+    if (!(requested_qty > 0.0f) || position_size <= requested_qty) {
+        return requested_qty;
+    }
+    float minimum_qty = min_entry_qty(
+        executable_touch, qty_step, min_qty, min_cost, c_mult
+    );
+    float tolerance = 1.0e-12f
+        * fmax(requested_qty, minimum_qty) * 4.0f;
+    if (requested_qty + tolerance >= minimum_qty) return requested_qty;
+    float resized = fmin(minimum_qty, position_size);
+    float remainder = position_size - resized;
+    if (remainder > 0.0f && remainder + tolerance < minimum_qty) {
+        resized = position_size;
+    }
+    return resized;
+}
+
 inline bool finite_positive(float value) {
     return isfinite(value) && value > 0.0f;
 }

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -966,11 +966,45 @@ def _validate_scope_config(
                 "GPU market execution requires a finite non-negative "
                 "live.market_order_near_touch_threshold"
             )
-        if coin_count != 1:
-            raise ValueError(
-                "GPU ordinary market execution currently requires single-coin "
-                "EMA Anchor or Trailing Martingale"
-            )
+        if coin_count > 1:
+            if strategy_kind != "ema_anchor":
+                raise ValueError(
+                    "GPU multicoin ordinary market execution currently supports "
+                    "EMA Anchor only"
+                )
+            if not math.isclose(
+                max_realized_loss_pct, 1.0, abs_tol=1.0e-12
+            ):
+                raise ValueError(
+                    "GPU multicoin EMA ordinary market execution currently "
+                    "requires live.max_realized_loss_pct=1.0"
+                )
+            for side in enabled_sides:
+                side_config = config["bot"][side]
+                risk = side_config.get("risk", {}) or {}
+                if bool(risk.get("total_exposure_enforcer_enabled", False)):
+                    raise ValueError(
+                        "GPU multicoin EMA ordinary market execution currently "
+                        f"requires bot.{side}.risk."
+                        "total_exposure_enforcer_enabled=false"
+                    )
+                if bool((side_config.get("unstuck", {}) or {}).get("enabled", False)):
+                    raise ValueError(
+                        "GPU multicoin EMA ordinary market execution currently "
+                        f"requires bot.{side}.unstuck.enabled=false"
+                    )
+            for symbol, patch in (config.get("coin_overrides", {}) or {}).items():
+                bot_patch = (patch or {}).get("bot", {}) or {}
+                for side in enabled_sides:
+                    unstuck_patch = (
+                        (bot_patch.get(side, {}) or {}).get("unstuck", {}) or {}
+                    )
+                    if bool(unstuck_patch.get("enabled", False)):
+                        raise ValueError(
+                            "GPU multicoin EMA ordinary market execution currently "
+                            "requires coin override unstuck.enabled=false; "
+                            f"got {symbol} {side}"
+                        )
     if bool(config.get("backtest", {}).get("filter_by_min_effective_cost")) and len(
         enabled_sides
     ) != 1:
@@ -2709,6 +2743,46 @@ def _validate_pinned_scope_bounds(
             )
 
 
+def _validate_ema_multicoin_market_foundation_bounds(
+    bound_by_key,
+    base_by_key,
+    enabled_sides,
+    config,
+    *,
+    coin_count: int,
+) -> None:
+    if (
+        int(coin_count) <= 1
+        or str(config.get("live", {}).get("strategy_kind", "")).strip().lower()
+        != "ema_anchor"
+        or not bool(config.get("live", {}).get("market_orders_allowed"))
+    ):
+        return
+    pinned = {
+        f"{side}_{suffix}": 0.0
+        for side in set(enabled_sides or ())
+        for suffix in (
+            "risk_twel_enforcer_enabled",
+            "unstuck_enabled",
+        )
+    }
+    for key, expected in sorted(pinned.items()):
+        bound = bound_by_key.get(key)
+        values = (
+            (float(bound.low), float(bound.high))
+            if bound is not None
+            else (float(base_by_key.get(key, expected)),) * 2
+        )
+        if any(
+            not math.isclose(value, expected, abs_tol=1.0e-12)
+            for value in values
+        ):
+            raise ValueError(
+                "GPU multicoin EMA ordinary market execution currently requires "
+                f"{key} to remain pinned at {expected}; got bounds {values}"
+            )
+
+
 def _validate_tm_market_mode_bounds(
     bound_by_key, base_by_key, enabled_sides, config
 ) -> None:
@@ -3305,6 +3379,13 @@ def run_backend(
         coin_count=max_coin_count,
         strategy_kind=strategy_kind,
     )
+    _validate_ema_multicoin_market_foundation_bounds(
+        bound_by_key,
+        base_by_key,
+        enabled_sides,
+        proxy_config,
+        coin_count=max_coin_count,
+    )
     _validate_tm_market_template_bounds(
         bound_by_key,
         base_by_key,
@@ -3349,6 +3430,13 @@ def run_backend(
             scenario_enabled_sides,
             coin_count=item["coin_count"],
             strategy_kind=strategy_kind,
+        )
+        _validate_ema_multicoin_market_foundation_bounds(
+            scenario_bound_by_key,
+            scenario_base_by_key,
+            scenario_enabled_sides,
+            item["config"],
+            coin_count=item["coin_count"],
         )
         _validate_tm_market_mode_bounds(
             scenario_bound_by_key,

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -839,6 +839,8 @@ class MpsEmaAnchorMulticoinRunner:
         max_realized_loss_pct: float = 1.0,
         collect_coin_fill_counts: bool = False,
         market_order_slippage_pct: float = 0.0,
+        market_orders_allowed: bool = False,
+        market_order_near_touch_threshold: float = 0.001,
         hsl_panic_market: bool = False,
         hsl_ema_tail_enabled: bool = False,
         hsl_raw_drawdown_enabled: bool = False,
@@ -933,6 +935,16 @@ class MpsEmaAnchorMulticoinRunner:
             raise ValueError(
                 "market_order_slippage_pct must be finite and non-negative"
             )
+        market_order_near_touch_threshold = float(
+            market_order_near_touch_threshold
+        )
+        if (
+            not np.isfinite(market_order_near_touch_threshold)
+            or market_order_near_touch_threshold < 0.0
+        ):
+            raise ValueError(
+                "market_order_near_touch_threshold must be finite and non-negative"
+            )
         liq_floor = max(0.0, run.starting_balance) * max(
             0.0, run.liquidation_threshold
         )
@@ -947,6 +959,8 @@ class MpsEmaAnchorMulticoinRunner:
                 float(self.collect_coin_fill_counts),
                 market_order_slippage_pct,
                 float(bool(hsl_panic_market)),
+                float(bool(market_orders_allowed)),
+                market_order_near_touch_threshold,
             ],
             dtype=torch.float32,
             device="mps",
@@ -1180,6 +1194,8 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
         max_realized_loss_pct: float = 1.0,
         collect_coin_fill_counts: bool = False,
         market_order_slippage_pct: float = 0.0,
+        market_orders_allowed: bool = False,
+        market_order_near_touch_threshold: float = 0.001,
         hsl_panic_market_long: bool = False,
         hsl_panic_market_short: bool = False,
         hsl_ema_tail_enabled: bool = False,
@@ -1196,6 +1212,8 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
             max_realized_loss_pct=max_realized_loss_pct,
             collect_coin_fill_counts=collect_coin_fill_counts,
             market_order_slippage_pct=market_order_slippage_pct,
+            market_orders_allowed=market_orders_allowed,
+            market_order_near_touch_threshold=market_order_near_touch_threshold,
             hsl_panic_market=hsl_panic_market_long,
             hsl_ema_tail_enabled=hsl_ema_tail_enabled,
             hsl_raw_drawdown_enabled=hsl_raw_drawdown_enabled,
@@ -1222,6 +1240,9 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
             max_realized_loss_pct
         )
         market_order_slippage_pct = float(market_order_slippage_pct)
+        market_order_near_touch_threshold = float(
+            market_order_near_touch_threshold
+        )
         liq_floor = max(0.0, run.starting_balance) * max(
             0.0, run.liquidation_threshold
         )
@@ -1238,6 +1259,8 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
                 float(bool(hsl_panic_market_long)),
                 float(bool(hsl_panic_market_short)),
                 float(bool(hedge_mode)),
+                float(bool(market_orders_allowed)),
+                market_order_near_touch_threshold,
             ],
             dtype=torch.float32,
             device="mps",
@@ -1325,6 +1348,8 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
         max_realized_loss_pct: float = 1.0,
         collect_coin_fill_counts: bool = False,
         market_order_slippage_pct: float = 0.0,
+        market_orders_allowed: bool = False,
+        market_order_near_touch_threshold: float = 0.001,
         hsl_panic_market: bool = False,
         hsl_ema_tail_enabled: bool = False,
         hsl_raw_drawdown_enabled: bool = False,
@@ -1339,6 +1364,8 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             max_realized_loss_pct=max_realized_loss_pct,
             collect_coin_fill_counts=collect_coin_fill_counts,
             market_order_slippage_pct=market_order_slippage_pct,
+            market_orders_allowed=market_orders_allowed,
+            market_order_near_touch_threshold=market_order_near_touch_threshold,
             hsl_panic_market=hsl_panic_market,
             hsl_ema_tail_enabled=hsl_ema_tail_enabled,
             hsl_raw_drawdown_enabled=hsl_raw_drawdown_enabled,
@@ -1423,6 +1450,8 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
         max_realized_loss_pct: float = 1.0,
         collect_coin_fill_counts: bool = False,
         market_order_slippage_pct: float = 0.0,
+        market_orders_allowed: bool = False,
+        market_order_near_touch_threshold: float = 0.001,
         hsl_panic_market_long: bool = False,
         hsl_panic_market_short: bool = False,
         hsl_ema_tail_enabled: bool = False,
@@ -1439,6 +1468,8 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
             max_realized_loss_pct=max_realized_loss_pct,
             collect_coin_fill_counts=collect_coin_fill_counts,
             market_order_slippage_pct=market_order_slippage_pct,
+            market_orders_allowed=market_orders_allowed,
+            market_order_near_touch_threshold=market_order_near_touch_threshold,
             hsl_panic_market=hsl_panic_market_long,
             hsl_ema_tail_enabled=hsl_ema_tail_enabled,
             hsl_raw_drawdown_enabled=hsl_raw_drawdown_enabled,

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -2130,6 +2130,12 @@ class MpsMulticoinProxy:
             "market_order_slippage_pct": float(
                 backtest_params.get("market_order_slippage_pct", 0.0)
             ),
+            "market_orders_allowed": bool(
+                backtest_params.get("market_orders_allowed", False)
+            ),
+            "market_order_near_touch_threshold": float(
+                backtest_params.get("market_order_near_touch_threshold", 0.001)
+            ),
             "hsl_ema_tail_enabled": bool(
                 self.needed_metrics & _HSL_EMA_TAIL_METRICS
             ),

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -70,6 +70,7 @@ from optimization.backends.gpu_backend import (
     _validate_dual_multicoin_metrics,
     _validate_gpu_optimizer_overrides,
     _validate_gpu_coin_overrides,
+    _validate_ema_multicoin_market_foundation_bounds,
     _validate_pinned_scope_bounds,
     _validate_resume_evidence_budget,
     _validate_seed_side_match,
@@ -1762,13 +1763,6 @@ def test_gpu_tm_market_suite_validates_effective_scenarios_not_template():
             _Evaluator,
             "finite non-negative",
         ),
-        (
-            lambda config: config["live"]["approved_coins"].__setitem__(
-                "long", ["BTC", "ETH"]
-            ),
-            _MulticoinEvaluator,
-            "single-coin EMA Anchor or Trailing Martingale",
-        ),
     ],
 )
 def test_gpu_market_execution_fails_closed_outside_baseline_scope(
@@ -1780,6 +1774,15 @@ def test_gpu_market_execution_fails_closed_outside_baseline_scope(
 
     with pytest.raises(ValueError, match=message):
         _validate_scope(config, evaluator())
+
+
+def test_gpu_multicoin_tm_market_execution_remains_fail_closed():
+    config = _directional_tm_config(long_enabled=True, short_enabled=False)
+    config["live"]["approved_coins"]["long"] = ["BTC", "ETH"]
+    config["live"]["market_orders_allowed"] = True
+
+    with pytest.raises(ValueError, match="supports EMA Anchor only"):
+        _validate_scope(config, _MulticoinEvaluator())
 
 
 @pytest.mark.parametrize(
@@ -2769,6 +2772,113 @@ def test_gpu_multicoin_foundation_accepts_forager_score_hysteresis():
     config["backtest"]["dynamic_wel_by_tradability"] = True
 
     assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
+
+
+@pytest.mark.parametrize(
+    ("long_enabled", "short_enabled"),
+    [(True, False), (False, True), (True, True)],
+)
+def test_gpu_multicoin_ema_accepts_ordinary_market_execution(
+    long_enabled, short_enabled
+):
+    config = _directional_ema_config(
+        long_enabled=long_enabled, short_enabled=short_enabled
+    )
+    config["live"]["approved_coins"] = {
+        side: ["BTC", "ETH", "SOL"] if enabled else []
+        for side, enabled in (
+            ("long", long_enabled),
+            ("short", short_enabled),
+        )
+    }
+    config["live"]["market_orders_allowed"] = True
+    config["live"]["market_order_near_touch_threshold"] = 0.002
+
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
+
+
+def test_gpu_multicoin_ema_market_execution_accepts_hsl():
+    config = _directional_ema_config(long_enabled=True, short_enabled=True)
+    coins = ["BTC", "ETH", "SOL"]
+    config["live"]["approved_coins"] = {"long": coins, "short": coins}
+    config["live"]["market_orders_allowed"] = True
+    for side in ("long", "short"):
+        config["bot"][side]["risk"]["n_positions"] = 3
+        config["bot"][side]["hsl"]["enabled"] = True
+
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda config: config["live"].__setitem__(
+                "max_realized_loss_pct", 0.5
+            ),
+            "max_realized_loss_pct=1.0",
+        ),
+        (
+            lambda config: config["bot"]["long"]["risk"].__setitem__(
+                "total_exposure_enforcer_enabled", True
+            ),
+            "total_exposure_enforcer_enabled=false",
+        ),
+        (
+            lambda config: config["bot"]["long"]["unstuck"].__setitem__(
+                "enabled", True
+            ),
+            "unstuck.enabled=false",
+        ),
+        (
+            lambda config: config.__setitem__(
+                "coin_overrides",
+                {
+                    "ETH": {
+                        "bot": {"long": {"unstuck": {"enabled": True}}}
+                    }
+                },
+            ),
+            "coin override unstuck.enabled=false",
+        ),
+    ],
+)
+def test_gpu_multicoin_ema_market_execution_rejects_unordered_risk_features(
+    mutate, message
+):
+    config = _directional_ema_config(long_enabled=True, short_enabled=False)
+    config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "SOL"]
+    config["live"]["market_orders_allowed"] = True
+    mutate(config)
+
+    with pytest.raises(ValueError, match=message):
+        _validate_scope(config, _MulticoinEvaluator())
+
+
+@pytest.mark.parametrize(
+    "key",
+    ["long_risk_twel_enforcer_enabled", "long_unstuck_enabled"],
+)
+def test_gpu_multicoin_ema_market_execution_requires_risk_bounds_pinned_off(key):
+    config = _directional_ema_config(long_enabled=True, short_enabled=False)
+    config["live"]["market_orders_allowed"] = True
+    base = {key: 0.0}
+
+    _validate_ema_multicoin_market_foundation_bounds(
+        {key: Bound(0.0, 0.0)},
+        base,
+        {"long"},
+        config,
+        coin_count=3,
+    )
+    with pytest.raises(ValueError, match=key):
+        _validate_ema_multicoin_market_foundation_bounds(
+            {key: Bound(0.0, 1.0)},
+            base,
+            {"long"},
+            config,
+            coin_count=3,
+        )
 
 
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -2660,15 +2660,17 @@ kernel void passivbot_ema_multicoin_order_phase_probe(
     long_side.selected[0] = true;
     short_side.selected[0] = true;
     JointPortfolioAccount account = init_joint_portfolio_account(1000.0f);
-    generate_ema_multicoin_side_orders(
-        long_side, long_config, account,
-        bars, touch_ticks, coin_settings, coin_overrides,
-        1, 1, false, 1, 1, 0, false, 1.0f, -2, 0ul
-    );
-    generate_ema_multicoin_side_orders(
-        short_side, short_config, account,
-        bars, touch_ticks, coin_settings, coin_overrides,
-        1, 1, true, 1, 1, 0, false, 1.0f, -2, 0ul
+        generate_ema_multicoin_side_orders(
+            long_side, long_config, account,
+            bars, touch_ticks, coin_settings, coin_overrides,
+            1, 1, false, 1, 1, 0, false, 1.0f,
+            false, 0.001f, -2, 0ul
+        );
+        generate_ema_multicoin_side_orders(
+            short_side, short_config, account,
+            bars, touch_ticks, coin_settings, coin_overrides,
+            1, 1, true, 1, 1, 0, false, 1.0f,
+            false, 0.001f, -2, 0ul
     );
     output[0] = long_side.entry_qty[0];
     output[1] = short_side.entry_qty[0];
@@ -2678,11 +2680,12 @@ kernel void passivbot_ema_multicoin_order_phase_probe(
     output[5] = short_side.close_qty[0];
     output[6] = account.balance;
     output[7] = account.realized_pnl_total;
-    generate_ema_multicoin_side_orders(
-        long_side, long_config, account,
-        bars, touch_ticks, coin_settings, coin_overrides,
-        1, 1, false, 1, 1, 0, false, 1.0f, -2, 1ul
-    );
+        generate_ema_multicoin_side_orders(
+            long_side, long_config, account,
+            bars, touch_ticks, coin_settings, coin_overrides,
+            1, 1, false, 1, 1, 0, false, 1.0f,
+            false, 0.001f, -2, 1ul
+        );
     output[8] = long_side.entry_qty[0];
     output[9] = long_side.entry_candidate[0] ? 1.0f : 0.0f;
     output[10] = long_side.contribution[0];
@@ -2823,6 +2826,8 @@ def _multicoin_exposure_fixture(
     liquidation_threshold=0.05,
     collect_coin_fill_counts=False,
     market_order_slippage_pct=0.0,
+    market_orders_allowed=False,
+    market_order_near_touch_threshold=0.001,
     hsl_panic_market=False,
     return_context=False,
 ):
@@ -2904,6 +2909,8 @@ def _multicoin_exposure_fixture(
             max_realized_loss_pct=max_realized_loss_pct,
             collect_coin_fill_counts=collect_coin_fill_counts,
             market_order_slippage_pct=market_order_slippage_pct,
+            market_orders_allowed=market_orders_allowed,
+            market_order_near_touch_threshold=market_order_near_touch_threshold,
             hsl_panic_market=hsl_panic_market,
         )
     else:
@@ -2962,6 +2969,8 @@ def _multicoin_exposure_fixture(
             max_realized_loss_pct=max_realized_loss_pct,
             collect_coin_fill_counts=collect_coin_fill_counts,
             market_order_slippage_pct=market_order_slippage_pct,
+            market_orders_allowed=market_orders_allowed,
+            market_order_near_touch_threshold=market_order_near_touch_threshold,
             hsl_panic_market=hsl_panic_market,
         )
     if return_context:
@@ -4741,11 +4750,15 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
         side=side,
         forager_score_hysteresis_pct=0.02,
         max_realized_loss_pct=0.1,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.003,
         hsl_raw_drawdown_enabled=True,
         recovery_distribution_enabled=True,
     )
     assert runner.settings.cpu()[4].item() == pytest.approx(0.02)
     assert runner.settings.cpu()[5].item() <= 0.1
+    assert runner.settings.cpu()[9].item() == 1.0
+    assert runner.settings.cpu()[10].item() == pytest.approx(0.003)
     output = runner.run(np.array([row, row], dtype=np.float64))
     torch.mps.synchronize()
 
@@ -4788,6 +4801,13 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
         MpsEmaAnchorMulticoinRunner(
             runs[0], data, side=side, max_realized_loss_pct=float("nan")
         )
+    with pytest.raises(ValueError, match="market_order_near_touch_threshold"):
+        MpsEmaAnchorMulticoinRunner(
+            runs[0],
+            data,
+            side=side,
+            market_order_near_touch_threshold=float("nan"),
+        )
 
     legacy_long = MpsEmaAnchorMulticoinLongRunner(runs[0], data)
     assert legacy_long.side == "long"
@@ -4827,6 +4847,301 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
     assert torch.equal(
         exact_last_output["day_end_eq"][0], exact_last_output["day_end_eq"][1]
     )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_ema_multicoin_market_entry_uses_stored_next_close_intent(side):
+    count = 5
+    base = np.asarray([100.0, 120.0])
+    closes = np.tile(base, (count, 1))
+    closes[-1] *= 1.1 if side == "long" else 0.9
+    markets = [
+        ProxyMarket(
+            0.001,
+            0.01,
+            0.001,
+            0.0,
+            1.0,
+            maker_fee=0.0,
+            taker_fee=0.01,
+        )
+        for _ in range(2)
+    ]
+    resting_runner, row = _multicoin_exposure_fixture(
+        "ema_anchor",
+        side,
+        count=count,
+        closes=closes,
+        highs=closes,
+        lows=closes,
+        markets=markets,
+        collect_coin_fill_counts=True,
+    )
+    market_runner, _ = _multicoin_exposure_fixture(
+        "ema_anchor",
+        side,
+        count=count,
+        closes=closes,
+        highs=closes,
+        lows=closes,
+        markets=markets,
+        collect_coin_fill_counts=True,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.001,
+        market_order_slippage_pct=0.01,
+    )
+    row[EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("offset")] = 0.0005
+    row[
+        EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("entry_cooldown_minutes")
+    ] = 100.0
+    params = np.asarray([row], dtype=np.float64)
+
+    resting = resting_runner.run(params)
+    promoted = market_runner.run(params)
+    torch.mps.synchronize()
+
+    assert market_runner.settings[9].item() == 1.0
+    assert market_runner.settings[10].item() == pytest.approx(0.001)
+    assert resting["fill_count"].item() == 0.0
+    assert promoted["fill_count"].item() == 2.0
+    assert promoted["open_positions"].item() == 2.0
+    assert promoted["coin_fill_counts"].cpu().tolist() == [[1.0, 1.0]]
+    assert promoted["balance"].item() < 1_000.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_ema_multicoin_short_market_entry_uses_executable_minimum():
+    count = 5
+    closes = np.tile(np.asarray([100.0, 120.0]), (count, 1))
+    markets = [
+        ProxyMarket(0.001, 0.01, 0.001, 100.04, 1.0, 0.0),
+        ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0),
+    ]
+    overrides = np.full((2, 29), np.nan, dtype=np.float32)
+    overrides[1, 11] = 0.0
+    runner, row = _multicoin_exposure_fixture(
+        "ema_anchor",
+        "short",
+        coin_overrides=overrides,
+        count=count,
+        closes=closes,
+        highs=closes,
+        lows=closes,
+        markets=markets,
+        collect_coin_fill_counts=True,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.001,
+    )
+    row[EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("base_qty_pct")] = 0.0001
+    row[EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("offset")] = 0.0005
+    params = np.asarray([row], dtype=np.float64)
+
+    output = runner.run(params)
+    torch.mps.synchronize()
+
+    assert output["fill_count"].item() == 1.0
+    assert output["fill_count_entry"].item() == 1.0
+    assert output["coin_fill_counts"].cpu().tolist() == [[1.0, 0.0]]
+    assert output["short_psize"].item() == pytest.approx(1.001)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_ema_multicoin_market_entry_cap_uses_market_touch(side):
+    count = 5
+    closes = np.full((count, 2), 100.0)
+    highs = closes.copy()
+    lows = closes.copy()
+    if side == "long":
+        lows[-1] = 99.0
+    else:
+        highs[-1] = 101.0
+    markets = [
+        ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
+        for _ in range(2)
+    ]
+    market_runner, row = _multicoin_exposure_fixture(
+        "ema_anchor",
+        side,
+        count=count,
+        closes=closes,
+        highs=highs,
+        lows=lows,
+        markets=markets,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.003,
+    )
+    row[EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("base_qty_pct")] = 1.0
+    row[EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("offset")] = 0.002
+    row[
+        EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("total_wallet_exposure_limit")
+    ] = 0.2
+    row[EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("n_positions")] = 2.0
+    params = np.asarray([row], dtype=np.float64)
+
+    promoted = market_runner.run(params)
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    assert promoted["fill_count"].item() == 2.0
+    expected_size = 1.998 if side == "long" else 1.996
+    assert promoted[size_key].item() == pytest.approx(expected_size)
+    assert promoted["total_wallet_exposure_max"].item() == pytest.approx(
+        expected_size * 100.0 / 1_000.0
+    )
+    assert promoted["total_wallet_exposure_max"].item() < 0.2
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_ema_multicoin_market_close_uses_stored_next_close_intent(side):
+    count = 6
+    base = np.asarray([100.0, 120.0])
+    closes = np.tile(base, (count, 1))
+    closes[-1] *= 0.9 if side == "long" else 1.1
+    markets = [
+        ProxyMarket(
+            0.001,
+            0.01,
+            0.001,
+            0.0,
+            1.0,
+            maker_fee=0.0,
+            taker_fee=0.01,
+        )
+        for _ in range(2)
+    ]
+    resting_runner, row = _multicoin_exposure_fixture(
+        "ema_anchor",
+        side,
+        count=count,
+        closes=closes,
+        highs=closes,
+        lows=closes,
+        markets=markets,
+        collect_coin_fill_counts=True,
+    )
+    market_runner, _ = _multicoin_exposure_fixture(
+        "ema_anchor",
+        side,
+        count=count,
+        closes=closes,
+        highs=closes,
+        lows=closes,
+        markets=markets,
+        collect_coin_fill_counts=True,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.001,
+        market_order_slippage_pct=0.01,
+    )
+    row[EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("offset")] = 0.0005
+    row[
+        EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("entry_cooldown_minutes")
+    ] = 100.0
+    params = np.asarray([row], dtype=np.float64)
+
+    resting = resting_runner.run(params)
+    promoted = market_runner.run(
+        np.asarray([row, row], dtype=np.float64),
+        end_steps=np.asarray([count - 2, count - 1], dtype=np.int32),
+    )
+    torch.mps.synchronize()
+
+    assert resting["fill_count"].item() == 0.0
+    assert promoted["fill_count"].cpu().tolist() == [2.0, 4.0]
+    assert promoted["fill_count_entry"].cpu().tolist() == [2.0, 2.0]
+    assert promoted["coin_fill_counts"].cpu().tolist() == [
+        [1.0, 1.0],
+        [2.0, 2.0],
+    ]
+    size_key = "psize" if side == "long" else "short_psize"
+    assert promoted[size_key][1].item() < promoted[size_key][0].item()
+    assert promoted["balance"][1].item() < promoted["balance"][0].item()
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_ema_multicoin_fused_market_execution_covers_both_sides():
+    count = 6
+    closes = np.tile(np.asarray([100.0, 120.0]), (count, 1))
+    markets = [
+        ProxyMarket(
+            0.001,
+            0.01,
+            0.001,
+            0.0,
+            1.0,
+            maker_fee=0.0,
+            taker_fee=0.01,
+        )
+        for _ in range(2)
+    ]
+    _, row, run, data = _multicoin_exposure_fixture(
+        "ema_anchor",
+        "long",
+        count=count,
+        closes=closes,
+        highs=closes,
+        lows=closes,
+        markets=markets,
+        return_context=True,
+    )
+    row[EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("offset")] = 0.0005
+    row[
+        EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("entry_cooldown_minutes")
+    ] = 100.0
+    params = np.asarray([row + row, row + row], dtype=np.float64)
+    overrides = np.full((2, 29), np.nan, dtype=np.float32)
+    resting_runner = MpsEmaAnchorMulticoinFusedRunner(
+        run,
+        data,
+        long_coin_overrides=overrides,
+        short_coin_overrides=overrides,
+        collect_coin_fill_counts=True,
+        hedge_mode=True,
+    )
+    market_runner = MpsEmaAnchorMulticoinFusedRunner(
+        run,
+        data,
+        long_coin_overrides=overrides,
+        short_coin_overrides=overrides,
+        collect_coin_fill_counts=True,
+        hedge_mode=True,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.001,
+        market_order_slippage_pct=0.01,
+    )
+
+    end_steps = np.asarray([count - 2, count - 1], dtype=np.int32)
+    resting = resting_runner.run(params, end_steps=end_steps)
+    promoted = market_runner.run(params, end_steps=end_steps)
+    torch.mps.synchronize()
+
+    assert market_runner.settings[11].item() == 1.0
+    assert market_runner.settings[12].item() == pytest.approx(0.001)
+    assert resting["fill_count"].cpu().tolist() == [0.0, 0.0]
+    assert promoted["fill_count"].cpu().tolist() == [4.0, 8.0]
+    assert promoted["fill_count_long"].cpu().tolist() == [2.0, 4.0]
+    assert promoted["coin_fill_counts"].cpu().tolist() == [
+        [2.0, 2.0],
+        [4.0, 4.0],
+    ]
+    assert promoted["psize"][1].item() < promoted["psize"][0].item()
+    assert (
+        promoted["short_psize"][1].item()
+        < promoted["short_psize"][0].item()
+    )
+    assert promoted["balance"][1].item() < promoted["balance"][0].item()
 
 
 @pytest.mark.skipif(
@@ -4931,7 +5246,21 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
         (coin_count, 29), float("nan"), dtype=torch.float32, device="mps"
     )
     run_settings = torch.tensor(
-        [1_000.0, 50.0, 60_000.0, 0.0, 0.02, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+        [
+            1_000.0,
+            50.0,
+            60_000.0,
+            0.0,
+            0.02,
+            1.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.001,
+        ],
         dtype=torch.float32,
         device="mps",
     )


### PR DESCRIPTION
## Summary

- add ordinary market entry and ordinary strategy-close execution to the Apple MPS multi-coin EMA Anchor proxy
- support long-only, short-only, and fused long+short runs with stored generation intent, next-valid-candle adverse slippage, taker fees, executable-touch minimum sizing, and market-touch portfolio-cap accounting
- retain HSL compatibility while failing closed on protective reducer combinations whose market ordering is not modeled yet
- keep multi-coin Trailing Martingale market execution fail closed

## Safety and scope

This is a deliberately bounded foundation slice. Multi-coin EMA market mode requires max_realized_loss_pct=1, unstuck disabled, and total-exposure repair disabled on every enabled side. Optimizer bounds for unstuck and the TWEL enforcer must remain pinned off, and coin overrides cannot enable unstuck. Exact Rust backtests remain authoritative for recorded results and rolling drift checks. CPU optimization and all non-GPU behavior are unchanged.

## Validation

- cargo test --no-default-features: 267 passed
- cargo check --tests: passed
- pytest tests/optimization excluding test_gpu_mps.py: passed
- physical Apple M3 MPS pytest tests/optimization/test_gpu_mps.py: passed with no skips
- Python compileall for src and tests/optimization: passed
- AI documentation checker: 0 errors, 2 pre-existing size warnings
- pytest tests/test_ai_docs.py: 5 passed
- git diff --check: passed

Final isolated Rust extension provenance:

- source fingerprint: 678d3f207402c7f6635d09a6e0d27577cc8079f2f21475f84223c9f80c481fe8
- binary SHA-256: a4177562628711081f73fe5cf20278bd600487950ba89b63f6f10712a019eefd

Cached real optimizer integration was also exercised for BTC+SOL dual-side EMA market mode in both base and suite contexts: each completed 12 generations, 192 proxy evaluations, and 24 exact Rust validations without a drift halt. The final source delta after those runs was test-contract placement only; the final isolated artifact subsequently passed the complete physical MPS suite.
