### PR TITLE
Add multi-coin EMA market reducer parity on Apple MPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ All notable user-facing changes will be documented in this file.
   long-only, short-only, and fused long+short runs. The proxy retains generation-time entry and
   ordinary-close intent, executes it on the next valid candle with adverse directional slippage
   and taker fees, applies executable-touch minimum sizing, and prices total-exposure entry
-  allocation at the market touch. HSL may coexist with this path. Auto-unstuck, total-exposure
-  repair, and realized-loss gating remain fail closed for multi-coin EMA market mode until their
-  protective reducer ordering is modeled; multi-coin Trailing Martingale market mode also remains
-  fail closed.
+  allocation at the market touch. HSL, auto-unstuck, TWEL repair, static unstuck overrides, and
+  realized-loss gating may coexist with this path. Metal finalizes TWEL and unstuck candidates
+  against ordinary closes, ranks their executable quantities globally across symbols and sides,
+  advances only a rejected position to its fallback, and spends one shared loss allowance before
+  gating ordinary closes. These generation-time decisions include market slippage and taker fees
+  and remain attached to pending orders. Multi-coin Trailing Martingale market mode remains fail
+  closed.
 
 - Added single-coin Trailing Martingale recursive-close market execution to Apple MPS
   optimization. Exact passive next-candle expansion remains authoritative: a market-only next

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -251,18 +251,21 @@ The supported slice is intentionally narrow:
   WEL and TWEL repair independently for each directional surface against the same pre-fill shared
   account snapshot, matching exact Rust order generation. EMA Anchor position-exposure repair
   remains fail closed because its exact Rust strategy path does not use this reducer
-- single-coin EMA Anchor models the cumulative realized-loss gate, including entry and close fees,
-  shared long/short loss-budget accounting, and lossy total-exposure repairs. The proxy uses a
-  conservative all-history loss envelope, so it may block a close that exact Rust admits after old
-  PnL ages out of `live.pnls_max_lookback_days`. Single-coin and one-sided multi-coin Trailing
-  Martingale permit the one selected auto-unstuck reducer to consume that same conservative budget,
-  while ordinary and exposure-repair closes retain the stricter zero-loss envelope. One-sided
-  multi-coin EMA Anchor applies the conservative budget only to its selected auto-unstuck reducer;
-  its other closes remain zero-loss. Fused dual-side multi-coin runs apply that same shared budget
-  to the one globally selected auto-unstuck reducer; their other closes remain zero-loss. These
-  restrictions avoid unsafe cross-side loss-budget reservation and per-candle
-  enumeration of TM's recursive 500-rung close ladder. Exact
-  validation applies the configured rolling allowance and remains authoritative
+- single- and multi-coin EMA Anchor model the cumulative realized-loss gate, including entry and
+  close fees, shared long/short loss-budget accounting, and lossy total-exposure repairs. For
+  multi-coin runs, Metal executable-touch-sizes each TWEL and unstuck candidate, finalizes it with
+  the ordinary strategy close, and considers the current largest finalized candidate globally
+  across symbols and sides. A rejected candidate advances only that position to its smaller
+  fallback. Accepted protective losses spend one shared allowance before ordinary closes are
+  checked in canonical long-then-short symbol order; HSL panic closes remain exempt. These are
+  generation-time decisions retained with the pending orders rather than reclassified at fill
+  time. The proxy uses a conservative all-history loss envelope, so it may block a close that exact
+  Rust admits after old PnL ages out of `live.pnls_max_lookback_days`. Single-coin and one-sided
+  multi-coin Trailing Martingale permit the one selected auto-unstuck reducer to consume that same
+  conservative budget, while ordinary and exposure-repair closes retain the stricter zero-loss
+  envelope. Those Trailing Martingale restrictions avoid unsafe cross-side loss-budget reservation
+  and per-candle enumeration of its recursive 500-rung close ladder. Exact validation applies the
+  configured rolling allowance and remains authoritative
 - BTC collateral remains disabled
 - `backtest.filter_by_min_effective_cost` may be enabled or disabled. When enabled, Metal uses the
   projected initial-entry cost test with the configured wallet-exposure limit. The
@@ -311,15 +314,15 @@ The supported slice is intentionally narrow:
   into that ordinary group.
   Multi-coin EMA Anchor supports ordinary market entries and ordinary strategy closes for
   long-only, short-only, and fused long+short runs, including compatible suites, static coin
-  overrides, forager selection, the strict total-exposure entry gate, and HSL. The proxy stores
-  generation-time market intent, fills it on the next valid candle with adverse directional
-  slippage and the coin's taker fee, uses executable-touch minimum sizing for short entries and
-  closes, and accounts for market-touch cost while allocating the portfolio entry cap.
-  Until protective market-reducer ordering is modeled, every effective multi-coin EMA scenario
-  requires `live.max_realized_loss_pct: 1`, `unstuck.enabled: false`, and
-  `risk.total_exposure_enforcer_enabled: false` on each enabled side; optimizer enablement bounds
-  for unstuck and the TWEL enforcer must remain pinned off, and coin overrides may not enable
-  unstuck. Multi-coin Trailing Martingale ordinary market execution remains fail closed
+  overrides, forager selection, the strict total-exposure entry gate, TWEL repair, auto-unstuck,
+  realized-loss gating, and HSL. The proxy stores generation-time market intent, fills it on the
+  next valid candle with adverse directional slippage and the coin's taker fee, uses
+  executable-touch minimum sizing for short entries and all closes, and accounts for market-touch
+  cost while allocating the portfolio entry cap. Protective reducers participate in the same
+  finalized-quantity ordering, shared loss budget, and per-position fallback used by exact Rust;
+  their market slippage and taker fees are included in the projected loss. Static coin overrides
+  may enable or tune unstuck. Multi-coin Trailing Martingale ordinary market execution remains fail
+  closed
 - no invalid candle tail after the selected coin's final valid candle
 
 Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor and

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -633,8 +633,12 @@ mod tests {
         assert!(source.contains("twel_enforcer_reduce_portfolio"));
         assert!(source.contains("clamped_market_price"));
         assert!(source.contains("secondary_close_qty"));
-        assert!(source.contains("realized_loss_proxy_allows_close"));
-        assert!(source.contains("const bool loss_gate_enabled = run_settings[5] < 1.0f"));
+        assert!(source.contains("finalize_ema_multicoin_reducers_one_side("));
+        assert!(source.contains("finalize_ema_multicoin_reducers_fused("));
+        assert!(source.contains("gate_ema_multicoin_close("));
+        assert!(source.contains("candidate.qty > best_candidate.qty"));
+        assert!(source.contains("close_is_protective_reducer[MAX_COINS]"));
+        assert!(!source.contains("realized_loss_proxy_allows_close"));
         assert!(source.contains("current_effective_n_positions"));
         assert!(source.contains("distance == best_distance && c > best"));
         assert!(source.contains("= fma("));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -26,59 +26,6 @@ constant float RECOVERY_FAIL_CLOSED_SENTINEL = -3.402823466e+38f;
 
 // PASSIVBOT_MULTICOIN_COMMON
 
-inline bool realized_loss_proxy_allows_close(
-    float qty, float close_price, float pprice, bool short_side,
-    float c_mult, float maker_fee, bool gate_enabled
-) {
-    if (!gate_enabled) return true;
-    if (!(qty > 0.0f && close_price > 0.0f && pprice > 0.0f)) return false;
-    float gross_pnl = qty * c_mult * (short_side
-        ? pprice - close_price : close_price - pprice);
-    float fee = qty * close_price * c_mult * maker_fee;
-    float net_pnl = gross_pnl - fee;
-    // A zero-loss envelope avoids shared loss-budget reservations across
-    // independently dispatched coins and sides. The float32 margin covers
-    // 1024 unit roundoffs in accumulated position price and this projection.
-    float arithmetic_scale = fabs(gross_pnl) + fabs(fee)
-        + qty * fabs(c_mult) * (fabs(close_price) + fabs(pprice));
-    float margin = 1.220703125e-4f * arithmetic_scale;
-    return isfinite(net_pnl) && net_pnl > margin;
-}
-
-inline bool realized_loss_proxy_allows_reducer(
-    float qty, float close_price, float pprice, bool short_side,
-    float c_mult, float maker_fee, bool is_unstuck,
-    bool gate_enabled, float balance,
-    float realized_pnl_cumsum_last, float realized_pnl_cumsum_max,
-    float max_realized_loss_pct
-) {
-    if (!is_unstuck) {
-        return realized_loss_proxy_allows_close(
-            qty, close_price, pprice, short_side,
-            c_mult, maker_fee, gate_enabled
-        );
-    }
-    if (!(qty > 0.0f && close_price > 0.0f && pprice > 0.0f)) return false;
-    if (!gate_enabled) return true;
-    float gross_pnl = qty * c_mult * (short_side
-        ? pprice - close_price : close_price - pprice);
-    float net_pnl = gross_pnl - qty * close_price * c_mult * maker_fee;
-    if (!isfinite(net_pnl)) return false;
-    if (net_pnl >= 0.0f) return true;
-    float balance_peak = balance
-        + (realized_pnl_cumsum_max - realized_pnl_cumsum_last);
-    float allowed_loss_budget = float32_floor_nonnegative(
-        balance_peak * fmax(max_realized_loss_pct, 0.0f)
-    );
-    float current_realized_loss = fmax(
-        realized_pnl_cumsum_max - realized_pnl_cumsum_last, 0.0f
-    );
-    float remaining_loss_budget = float32_floor_nonnegative(
-        fmax(allowed_loss_budget - current_realized_loss, 0.0f)
-    );
-    return -net_pnl <= remaining_loss_budget;
-}
-
 inline float finalized_reducer_qty_with_ordinary(
     float psize, float ordinary_qty, float ordinary_price,
     float reducer_qty, float reducer_price,
@@ -156,6 +103,7 @@ struct EmaMulticoinSideState {
     bool entry_market[MAX_COINS];
     bool close_market[MAX_COINS];
     bool secondary_close_market[MAX_COINS];
+    bool close_is_protective_reducer[MAX_COINS];
     bool close_is_unstuck_reducer[MAX_COINS];
     bool close_is_hsl_panic[MAX_COINS];
     bool selected[MAX_COINS];
@@ -403,6 +351,7 @@ inline void init_ema_multicoin_side_state(
         side.entry_market[c] = false;
         side.close_market[c] = false;
         side.secondary_close_market[c] = false;
+        side.close_is_protective_reducer[c] = false;
         side.close_is_unstuck_reducer[c] = false;
         side.close_is_hsl_panic[c] = false;
         side.coin_realized_pnl[c] = 0.0f;
@@ -1209,8 +1158,6 @@ inline void generate_ema_multicoin_side_orders(
     int tradable_count,
     int effective_n_positions,
     int current_hsl_mode,
-    bool loss_gate_enabled,
-    float max_realized_loss_pct,
     bool market_orders_allowed,
     float market_order_near_touch_threshold,
     int forced_unstuck_coin,
@@ -1272,10 +1219,8 @@ inline void generate_ema_multicoin_side_orders(
     thread bool* selected = side.selected;
     thread bool* entry_candidate = side.entry_candidate;
     thread float& balance = account.balance;
-    thread float& realized_pnl_cumsum_last =
-        account.realized_pnl_total;
-    thread float& realized_pnl_cumsum_max =
-        account.realized_pnl_peak;
+    thread float& realized_pnl_cumsum_last = account.realized_pnl_total;
+    thread float& realized_pnl_cumsum_max = account.realized_pnl_peak;
 
     const float effective_wel = twel / fmax(float(effective_n_positions), 1.0f);
     float current_twe = 0.0f;
@@ -1402,6 +1347,7 @@ inline void generate_ema_multicoin_side_orders(
     for (int c = 0; c < C; ++c) {
         unstuck_close_qty[c] = 0.0f;
         unstuck_close_tick[c] = 0;
+        side.close_is_protective_reducer[c] = false;
         close_is_unstuck_reducer[c] = false;
     }
     float balance_peak = balance
@@ -1705,147 +1651,10 @@ inline void generate_ema_multicoin_side_orders(
             }
         }
 
-        // Reserve the side-wide protective reducer and trim the
-        // ordinary EMA close first, matching finalized_closes_with_reducer.
-        float raw_twel_qty = twel_close_qty[c];
-        int raw_twel_tick = twel_close_tick[c];
-        float raw_unstuck_qty = unstuck_close_qty[c];
-        int raw_unstuck_tick = unstuck_close_tick[c];
-        float finalized_twel_qty = finalized_reducer_qty_with_ordinary(
-            psize[c], close_qty[c],
-            close_market[c] ? price_now : close_price,
-            raw_twel_qty, float(raw_twel_tick) * price_step,
-            qty_step, min_qty, min_cost, c_mult
-        );
-        float finalized_unstuck_qty = finalized_reducer_qty_with_ordinary(
-            psize[c], close_qty[c],
-            close_market[c] ? price_now : close_price,
-            raw_unstuck_qty, float(raw_unstuck_tick) * price_step,
-            qty_step, min_qty, min_cost, c_mult
-        );
-        bool prefer_unstuck = finalized_unstuck_qty > 0.0f && (
-            finalized_twel_qty <= 0.0f
-            || finalized_unstuck_qty > finalized_twel_qty
-            || (finalized_unstuck_qty == finalized_twel_qty && (
-                raw_unstuck_tick != raw_twel_tick
-                    ? (short_side
-                        ? raw_unstuck_tick > raw_twel_tick
-                        : raw_unstuck_tick < raw_twel_tick)
-                    : true
-            ))
-        );
-        float reducer_qty = prefer_unstuck
-            ? raw_unstuck_qty : raw_twel_qty;
-        int reducer_tick = prefer_unstuck
-            ? raw_unstuck_tick : raw_twel_tick;
-        bool reducer_is_unstuck = prefer_unstuck;
-        for (int reducer_attempt = 0; reducer_attempt < 2;
-                ++reducer_attempt) {
-            if (!(reducer_qty > 0.0f && reducer_tick > 0)) break;
-            float finalized_qty = reducer_is_unstuck
-                ? finalized_unstuck_qty : finalized_twel_qty;
-            if (realized_loss_proxy_allows_reducer(
-                    finalized_qty, float(reducer_tick) * price_step,
-                    pprice[c], short_side, c_mult,
-                    coin_settings[coin_offset + 5],
-                    reducer_is_unstuck, loss_gate_enabled, balance,
-                    realized_pnl_cumsum_last,
-                    realized_pnl_cumsum_max, max_realized_loss_pct
-                )) {
-                break;
-            }
-            if (reducer_attempt > 0) {
-                reducer_qty = 0.0f;
-                reducer_tick = 0;
-                reducer_is_unstuck = false;
-                break;
-            }
-            reducer_is_unstuck = !reducer_is_unstuck;
-            reducer_qty = reducer_is_unstuck
-                ? raw_unstuck_qty : raw_twel_qty;
-            reducer_tick = reducer_is_unstuck
-                ? raw_unstuck_tick : raw_twel_tick;
-        }
-        if (reducer_qty > 0.0f && reducer_tick > 0) {
-            float reducer_price = float(reducer_tick) * price_step;
-            float reducer_min = min_entry_qty(
-                reducer_price, qty_step, min_qty, min_cost, c_mult
-            );
-            float ordinary_qty = close_qty[c];
-            if (ordinary_qty > 0.0f) {
-                float ordinary_min = min_entry_qty(
-                    close_market[c] ? price_now : close_price,
-                    qty_step, min_qty, min_cost, c_mult
-                );
-                if (ordinary_qty + reducer_qty > psize[c]) {
-                    ordinary_qty = fmax(
-                        round_step(
-                            psize[c] - reducer_qty, qty_step
-                        ),
-                        0.0f
-                    );
-                }
-                if (ordinary_qty >= ordinary_min) {
-                    float remainder = fmax(
-                        round_step(
-                            psize[c] - reducer_qty - ordinary_qty,
-                            qty_step
-                        ),
-                        0.0f
-                    );
-                    float minimum_any = fmin(
-                        ordinary_min, reducer_min
-                    );
-                    if (remainder > 0.0f
-                        && remainder < minimum_any) {
-                        ordinary_qty = fmin(
-                            psize[c] - reducer_qty,
-                            round_step(
-                                ordinary_qty + remainder, qty_step
-                            )
-                        );
-                    }
-                    secondary_close_qty[c] = ordinary_qty;
-                    secondary_close_tick[c] = close_tick[c];
-                    secondary_close_market[c] = close_market[c];
-                }
-            }
-            if (secondary_close_qty[c] <= 0.0f) {
-                float remainder = fmax(
-                    round_step(psize[c] - reducer_qty, qty_step),
-                    0.0f
-                );
-                if (remainder > 0.0f && remainder < reducer_min) {
-                    reducer_qty = psize[c];
-                }
-            }
-            close_qty[c] = reducer_qty;
-            close_tick[c] = reducer_tick;
-            close_market[c] = false;
-            close_is_unstuck_reducer[c] = reducer_is_unstuck;
-        }
-        if (close_qty[c] > 0.0f && !realized_loss_proxy_allows_reducer(
-                close_qty[c], float(close_tick[c]) * price_step,
-                pprice[c], short_side, c_mult,
-                coin_settings[coin_offset + 5],
-                close_is_unstuck_reducer[c], loss_gate_enabled,
-                balance, realized_pnl_cumsum_last,
-                realized_pnl_cumsum_max, max_realized_loss_pct
-            )) {
-            close_qty[c] = 0.0f;
-            close_market[c] = false;
-            close_is_unstuck_reducer[c] = false;
-        }
-        if (secondary_close_qty[c] > 0.0f
-            && !realized_loss_proxy_allows_close(
-                secondary_close_qty[c],
-                float(secondary_close_tick[c]) * price_step,
-                pprice[c], short_side, c_mult,
-                coin_settings[coin_offset + 5], loss_gate_enabled
-            )) {
-            secondary_close_qty[c] = 0.0f;
-            secondary_close_market[c] = false;
-        }
+        // Protective reducers are finalized after both sides have generated.
+        // That coordinator classifies market intent, compares finalized
+        // quantities globally, spends one shared realized-loss allowance, and
+        // only then allocates the ordinary close remainder.
     }
 
     float gated_twel = twel;
@@ -1933,6 +1742,7 @@ inline void generate_ema_multicoin_side_orders(
             secondary_close_tick[c] = 0;
             close_market[c] = false;
             secondary_close_market[c] = false;
+            side.close_is_protective_reducer[c] = false;
             close_is_unstuck_reducer[c] = false;
             close_is_hsl_panic[c] = true;
         }
@@ -1941,6 +1751,559 @@ inline void generate_ema_multicoin_side_orders(
         if (!(secondary_close_qty[c] > 0.0f)) {
             secondary_close_market[c] = false;
         }
+    }
+}
+
+struct EmaMulticoinReducerCandidate {
+    bool valid;
+    float qty;
+    int tick;
+    bool market;
+    bool is_unstuck;
+};
+
+inline EmaMulticoinReducerCandidate empty_ema_multicoin_reducer_candidate() {
+    EmaMulticoinReducerCandidate candidate;
+    candidate.valid = false;
+    candidate.qty = 0.0f;
+    candidate.tick = 0;
+    candidate.market = false;
+    candidate.is_unstuck = false;
+    return candidate;
+}
+
+inline EmaMulticoinReducerCandidate make_ema_multicoin_reducer_candidate(
+    float psize,
+    float ordinary_qty,
+    int ordinary_tick,
+    bool ordinary_market,
+    float requested_qty,
+    int requested_tick,
+    bool is_unstuck,
+    bool short_side,
+    float market_price,
+    float qty_step,
+    float price_step,
+    float min_qty,
+    float min_cost,
+    float c_mult,
+    bool market_orders_allowed,
+    float market_order_near_touch_threshold
+) {
+    EmaMulticoinReducerCandidate candidate =
+        empty_ema_multicoin_reducer_candidate();
+    if (!(psize > 0.0f && requested_qty > 0.0f
+        && requested_tick > 0 && market_price > 0.0f)) {
+        return candidate;
+    }
+    candidate.market = should_use_ordinary_market_execution(
+        requested_tick, short_side, market_price, price_step,
+        market_orders_allowed, market_order_near_touch_threshold
+    );
+    float executable_qty = requested_qty;
+    if (candidate.market) {
+        executable_qty = resize_market_close_qty(
+            executable_qty, psize, market_price,
+            qty_step, min_qty, min_cost, c_mult
+        );
+    }
+    float ordinary_price = ordinary_market
+        ? market_price : float(ordinary_tick) * price_step;
+    float reducer_price = candidate.market
+        ? market_price : float(requested_tick) * price_step;
+    candidate.qty = finalized_reducer_qty_with_ordinary(
+        psize, ordinary_qty, ordinary_price,
+        executable_qty, reducer_price,
+        qty_step, min_qty, min_cost, c_mult
+    );
+    candidate.tick = requested_tick;
+    candidate.is_unstuck = is_unstuck;
+    candidate.valid = candidate.qty > 0.0f;
+    return candidate;
+}
+
+inline bool ema_multicoin_reducer_candidate_preferred(
+    EmaMulticoinReducerCandidate left,
+    EmaMulticoinReducerCandidate right,
+    bool short_side
+) {
+    if (!left.valid) return false;
+    if (!right.valid) return true;
+    if (left.qty != right.qty) return left.qty > right.qty;
+    if (left.tick != right.tick) {
+        return short_side ? left.tick > right.tick : left.tick < right.tick;
+    }
+    if (left.is_unstuck != right.is_unstuck) return left.is_unstuck;
+    return false;
+}
+
+inline void prepare_ema_multicoin_reducer_candidates(
+    thread EmaMulticoinSideState& side,
+    constant float* bars,
+    constant float* coin_settings,
+    int k,
+    int coin_count,
+    bool short_side,
+    bool market_orders_allowed,
+    float market_order_near_touch_threshold,
+    thread EmaMulticoinReducerCandidate* preferred,
+    thread EmaMulticoinReducerCandidate* fallback
+) {
+    for (int c = 0; c < MAX_COINS; ++c) {
+        preferred[c] = empty_ema_multicoin_reducer_candidate();
+        fallback[c] = empty_ema_multicoin_reducer_candidate();
+    }
+    for (int c = 0; c < coin_count; ++c) {
+        if (!(side.psize[c] > 0.0f) || side.close_is_hsl_panic[c]) continue;
+        int coin_offset = c * COIN_COLS;
+        float market_price = clamped_market_price(
+            bars, coin_settings, k, c, coin_count
+        );
+        float qty_step = coin_settings[coin_offset + 0];
+        float price_step = coin_settings[coin_offset + 1];
+        float min_qty = coin_settings[coin_offset + 2];
+        float min_cost = coin_settings[coin_offset + 3];
+        float c_mult = coin_settings[coin_offset + 4];
+        EmaMulticoinReducerCandidate twel =
+            make_ema_multicoin_reducer_candidate(
+                side.psize[c], side.close_qty[c], side.close_tick[c],
+                side.close_market[c], side.twel_close_qty[c],
+                side.twel_close_tick[c], false, short_side, market_price,
+                qty_step, price_step, min_qty, min_cost, c_mult,
+                market_orders_allowed, market_order_near_touch_threshold
+            );
+        EmaMulticoinReducerCandidate unstuck =
+            make_ema_multicoin_reducer_candidate(
+                side.psize[c], side.close_qty[c], side.close_tick[c],
+                side.close_market[c], side.unstuck_close_qty[c],
+                side.unstuck_close_tick[c], true, short_side, market_price,
+                qty_step, price_step, min_qty, min_cost, c_mult,
+                market_orders_allowed, market_order_near_touch_threshold
+            );
+        if (ema_multicoin_reducer_candidate_preferred(
+                unstuck, twel, short_side)) {
+            preferred[c] = unstuck;
+            fallback[c] = twel;
+        } else {
+            preferred[c] = twel;
+            fallback[c] = unstuck;
+        }
+    }
+}
+
+inline bool gate_ema_multicoin_close(
+    float qty,
+    int tick,
+    bool market,
+    float pprice,
+    bool short_side,
+    float market_price,
+    float price_step,
+    float c_mult,
+    float maker_fee,
+    float taker_fee,
+    float market_order_slippage_pct,
+    bool gate_enabled,
+    thread float& remaining_loss_budget
+) {
+    if (!(qty > 0.0f && tick > 0 && pprice > 0.0f)) return false;
+    float execution_price = market
+        ? ordinary_market_fill_price(
+            market_price, short_side,
+            market_order_slippage_pct, price_step
+        )
+        : float(tick) * price_step;
+    float fee_rate = market ? taker_fee : maker_fee;
+    float gross_pnl = qty * c_mult * (short_side
+        ? pprice - execution_price : execution_price - pprice);
+    float net_pnl = gross_pnl
+        - qty * execution_price * c_mult * fee_rate;
+    if (!isfinite(net_pnl) || !realized_loss_gate_allows(
+            net_pnl, remaining_loss_budget, gate_enabled)) {
+        return false;
+    }
+    if (gate_enabled && net_pnl < 0.0f) {
+        remaining_loss_budget = float32_floor_nonnegative(
+            fmax(remaining_loss_budget + net_pnl, 0.0f)
+        );
+    }
+    return true;
+}
+
+inline void apply_ema_multicoin_reducer_candidate(
+    thread EmaMulticoinSideState& side,
+    int coin,
+    EmaMulticoinReducerCandidate candidate,
+    constant float* bars,
+    constant float* coin_settings,
+    int k,
+    int coin_count
+) {
+    if (!candidate.valid) return;
+    int coin_offset = coin * COIN_COLS;
+    float market_price = clamped_market_price(
+        bars, coin_settings, k, coin, coin_count
+    );
+    float qty_step = coin_settings[coin_offset + 0];
+    float price_step = coin_settings[coin_offset + 1];
+    float min_qty = coin_settings[coin_offset + 2];
+    float min_cost = coin_settings[coin_offset + 3];
+    float c_mult = coin_settings[coin_offset + 4];
+    float reducer_price = candidate.market
+        ? market_price : float(candidate.tick) * price_step;
+    float reducer_min = min_entry_qty(
+        reducer_price, qty_step, min_qty, min_cost, c_mult
+    );
+    float ordinary_qty = side.close_qty[coin];
+    int ordinary_tick = side.close_tick[coin];
+    bool ordinary_market = side.close_market[coin];
+    side.secondary_close_qty[coin] = 0.0f;
+    side.secondary_close_tick[coin] = 0;
+    side.secondary_close_market[coin] = false;
+    if (ordinary_qty > 0.0f) {
+        float ordinary_price = ordinary_market
+            ? market_price : float(ordinary_tick) * price_step;
+        float ordinary_min = min_entry_qty(
+            ordinary_price, qty_step, min_qty, min_cost, c_mult
+        );
+        if (ordinary_qty + candidate.qty > side.psize[coin]) {
+            ordinary_qty = fmax(
+                round_step(side.psize[coin] - candidate.qty, qty_step),
+                0.0f
+            );
+        }
+        if (ordinary_qty >= ordinary_min) {
+            float remainder = fmax(
+                round_step(
+                    side.psize[coin] - candidate.qty - ordinary_qty,
+                    qty_step
+                ),
+                0.0f
+            );
+            float minimum_any = fmin(ordinary_min, reducer_min);
+            if (remainder > 0.0f && remainder < minimum_any) {
+                ordinary_qty = fmin(
+                    side.psize[coin] - candidate.qty,
+                    round_step(ordinary_qty + remainder, qty_step)
+                );
+            }
+            side.secondary_close_qty[coin] = ordinary_qty;
+            side.secondary_close_tick[coin] = ordinary_tick;
+            side.secondary_close_market[coin] = ordinary_market;
+        }
+    }
+    side.close_qty[coin] = candidate.qty;
+    side.close_tick[coin] = candidate.tick;
+    side.close_market[coin] = candidate.market;
+    side.close_is_protective_reducer[coin] = true;
+    side.close_is_unstuck_reducer[coin] = candidate.is_unstuck;
+}
+
+inline float ema_multicoin_remaining_loss_budget(
+    thread const JointPortfolioAccount& account,
+    float max_realized_loss_pct,
+    thread bool& gate_enabled
+) {
+    gate_enabled = max_realized_loss_pct < 1.0f
+        && isfinite(account.balance) && account.balance > 0.0f
+        && isfinite(account.realized_pnl_total)
+        && isfinite(account.realized_pnl_peak);
+    if (!gate_enabled) return INFINITY;
+    float balance_peak = account.balance
+        + (account.realized_pnl_peak - account.realized_pnl_total);
+    if (!(isfinite(balance_peak) && balance_peak > 0.0f)) {
+        gate_enabled = false;
+        return INFINITY;
+    }
+    float allowed_loss_budget = float32_floor_nonnegative(
+        balance_peak * fmax(max_realized_loss_pct, 0.0f)
+    );
+    float current_realized_loss = fmax(
+        account.realized_pnl_peak - account.realized_pnl_total, 0.0f
+    );
+    return float32_floor_nonnegative(
+        fmax(allowed_loss_budget - current_realized_loss, 0.0f)
+    );
+}
+
+inline void gate_ema_multicoin_side_ordinary_closes(
+    thread EmaMulticoinSideState& side,
+    constant float* bars,
+    constant float* coin_settings,
+    int k,
+    int coin_count,
+    bool short_side,
+    float market_order_slippage_pct,
+    bool gate_enabled,
+    thread float& remaining_loss_budget
+) {
+    for (int c = 0; c < coin_count; ++c) {
+        if (side.close_is_hsl_panic[c]) continue;
+        int coin_offset = c * COIN_COLS;
+        float market_price = clamped_market_price(
+            bars, coin_settings, k, c, coin_count
+        );
+        float price_step = coin_settings[coin_offset + 1];
+        float c_mult = coin_settings[coin_offset + 4];
+        float maker_fee = coin_settings[coin_offset + 5];
+        float taker_fee = coin_settings[coin_offset + 11];
+        bool has_reducer = side.close_is_protective_reducer[c];
+        if (has_reducer) {
+            if (side.secondary_close_qty[c] > 0.0f
+                && !gate_ema_multicoin_close(
+                    side.secondary_close_qty[c],
+                    side.secondary_close_tick[c],
+                    side.secondary_close_market[c], side.pprice[c],
+                    short_side, market_price, price_step, c_mult,
+                    maker_fee, taker_fee, market_order_slippage_pct,
+                    gate_enabled, remaining_loss_budget
+                )) {
+                side.secondary_close_qty[c] = 0.0f;
+                side.secondary_close_market[c] = false;
+            }
+        } else if (side.close_qty[c] > 0.0f
+            && !gate_ema_multicoin_close(
+                side.close_qty[c], side.close_tick[c], side.close_market[c],
+                side.pprice[c], short_side, market_price, price_step,
+                c_mult, maker_fee, taker_fee, market_order_slippage_pct,
+                gate_enabled, remaining_loss_budget
+            )) {
+            side.close_qty[c] = 0.0f;
+            side.close_market[c] = false;
+        }
+    }
+}
+
+inline void finalize_ema_multicoin_reducers_one_side(
+    thread EmaMulticoinSideState& side,
+    thread const JointPortfolioAccount& account,
+    constant float* bars,
+    constant float* coin_settings,
+    int k,
+    int coin_count,
+    bool short_side,
+    bool market_orders_allowed,
+    float market_order_near_touch_threshold,
+    float market_order_slippage_pct,
+    float max_realized_loss_pct
+) {
+    EmaMulticoinReducerCandidate preferred[MAX_COINS];
+    EmaMulticoinReducerCandidate fallback[MAX_COINS];
+    EmaMulticoinReducerCandidate selected[MAX_COINS];
+    int candidate_index[MAX_COINS];
+    bool resolved[MAX_COINS];
+    prepare_ema_multicoin_reducer_candidates(
+        side, bars, coin_settings, k, coin_count, short_side,
+        market_orders_allowed, market_order_near_touch_threshold,
+        preferred, fallback
+    );
+    for (int c = 0; c < MAX_COINS; ++c) {
+        selected[c] = empty_ema_multicoin_reducer_candidate();
+        candidate_index[c] = 0;
+        resolved[c] = !preferred[c].valid;
+    }
+    bool loss_gate_enabled;
+    float remaining_loss_budget = ema_multicoin_remaining_loss_budget(
+        account, max_realized_loss_pct, loss_gate_enabled
+    );
+    for (int attempt = 0; attempt < MAX_COINS * 2; ++attempt) {
+        int best = -1;
+        EmaMulticoinReducerCandidate best_candidate =
+            empty_ema_multicoin_reducer_candidate();
+        for (int c = 0; c < coin_count; ++c) {
+            if (resolved[c]) continue;
+            EmaMulticoinReducerCandidate candidate = candidate_index[c] == 0
+                ? preferred[c] : fallback[c];
+            if (!candidate.valid) {
+                resolved[c] = true;
+                continue;
+            }
+            if (best < 0 || candidate.qty > best_candidate.qty) {
+                best = c;
+                best_candidate = candidate;
+            }
+        }
+        if (best < 0) break;
+        int coin_offset = best * COIN_COLS;
+        float market_price = clamped_market_price(
+            bars, coin_settings, k, best, coin_count
+        );
+        bool allowed = gate_ema_multicoin_close(
+            best_candidate.qty, best_candidate.tick, best_candidate.market,
+            side.pprice[best], short_side, market_price,
+            coin_settings[coin_offset + 1],
+            coin_settings[coin_offset + 4],
+            coin_settings[coin_offset + 5],
+            coin_settings[coin_offset + 11],
+            market_order_slippage_pct, loss_gate_enabled,
+            remaining_loss_budget
+        );
+        if (allowed) {
+            selected[best] = best_candidate;
+            resolved[best] = true;
+        } else {
+            candidate_index[best] += 1;
+            resolved[best] = candidate_index[best] > 1
+                || !fallback[best].valid;
+        }
+    }
+    for (int c = 0; c < coin_count; ++c) {
+        apply_ema_multicoin_reducer_candidate(
+            side, c, selected[c], bars, coin_settings, k, coin_count
+        );
+    }
+    gate_ema_multicoin_side_ordinary_closes(
+        side, bars, coin_settings, k, coin_count, short_side,
+        market_order_slippage_pct, loss_gate_enabled,
+        remaining_loss_budget
+    );
+}
+
+inline void finalize_ema_multicoin_reducers_fused(
+    thread EmaMulticoinSideState& long_side,
+    thread EmaMulticoinSideState& short_side,
+    thread const JointPortfolioAccount& account,
+    constant float* bars,
+    constant float* coin_settings,
+    int k,
+    int coin_count,
+    bool long_enabled,
+    bool short_enabled,
+    bool market_orders_allowed,
+    float market_order_near_touch_threshold,
+    float market_order_slippage_pct,
+    float max_realized_loss_pct
+) {
+    EmaMulticoinReducerCandidate long_preferred[MAX_COINS];
+    EmaMulticoinReducerCandidate long_fallback[MAX_COINS];
+    EmaMulticoinReducerCandidate short_preferred[MAX_COINS];
+    EmaMulticoinReducerCandidate short_fallback[MAX_COINS];
+    EmaMulticoinReducerCandidate long_selected[MAX_COINS];
+    EmaMulticoinReducerCandidate short_selected[MAX_COINS];
+    int long_candidate_index[MAX_COINS];
+    int short_candidate_index[MAX_COINS];
+    bool long_resolved[MAX_COINS];
+    bool short_resolved[MAX_COINS];
+    prepare_ema_multicoin_reducer_candidates(
+        long_side, bars, coin_settings, k, coin_count, false,
+        long_enabled && market_orders_allowed,
+        market_order_near_touch_threshold,
+        long_preferred, long_fallback
+    );
+    prepare_ema_multicoin_reducer_candidates(
+        short_side, bars, coin_settings, k, coin_count, true,
+        short_enabled && market_orders_allowed,
+        market_order_near_touch_threshold,
+        short_preferred, short_fallback
+    );
+    for (int c = 0; c < MAX_COINS; ++c) {
+        long_selected[c] = empty_ema_multicoin_reducer_candidate();
+        short_selected[c] = empty_ema_multicoin_reducer_candidate();
+        long_candidate_index[c] = 0;
+        short_candidate_index[c] = 0;
+        long_resolved[c] = !long_enabled || !long_preferred[c].valid;
+        short_resolved[c] = !short_enabled || !short_preferred[c].valid;
+    }
+    bool loss_gate_enabled;
+    float remaining_loss_budget = ema_multicoin_remaining_loss_budget(
+        account, max_realized_loss_pct, loss_gate_enabled
+    );
+    for (int attempt = 0; attempt < MAX_COINS * 4; ++attempt) {
+        int best_coin = -1;
+        bool best_short = false;
+        EmaMulticoinReducerCandidate best_candidate =
+            empty_ema_multicoin_reducer_candidate();
+        for (int c = 0; c < coin_count; ++c) {
+            if (!long_resolved[c]) {
+                EmaMulticoinReducerCandidate candidate =
+                    long_candidate_index[c] == 0
+                        ? long_preferred[c] : long_fallback[c];
+                if (!candidate.valid) {
+                    long_resolved[c] = true;
+                } else if (best_coin < 0
+                    || candidate.qty > best_candidate.qty) {
+                    best_coin = c;
+                    best_short = false;
+                    best_candidate = candidate;
+                }
+            }
+            if (!short_resolved[c]) {
+                EmaMulticoinReducerCandidate candidate =
+                    short_candidate_index[c] == 0
+                        ? short_preferred[c] : short_fallback[c];
+                if (!candidate.valid) {
+                    short_resolved[c] = true;
+                } else if (best_coin < 0
+                    || candidate.qty > best_candidate.qty) {
+                    best_coin = c;
+                    best_short = true;
+                    best_candidate = candidate;
+                }
+            }
+        }
+        if (best_coin < 0) break;
+        int coin_offset = best_coin * COIN_COLS;
+        float market_price = clamped_market_price(
+            bars, coin_settings, k, best_coin, coin_count
+        );
+        float pprice = best_short
+            ? short_side.pprice[best_coin] : long_side.pprice[best_coin];
+        bool allowed = gate_ema_multicoin_close(
+            best_candidate.qty, best_candidate.tick, best_candidate.market,
+            pprice, best_short, market_price,
+            coin_settings[coin_offset + 1],
+            coin_settings[coin_offset + 4],
+            coin_settings[coin_offset + 5],
+            coin_settings[coin_offset + 11],
+            market_order_slippage_pct, loss_gate_enabled,
+            remaining_loss_budget
+        );
+        if (best_short) {
+            if (allowed) {
+                short_selected[best_coin] = best_candidate;
+                short_resolved[best_coin] = true;
+            } else {
+                short_candidate_index[best_coin] += 1;
+                short_resolved[best_coin] =
+                    short_candidate_index[best_coin] > 1
+                    || !short_fallback[best_coin].valid;
+            }
+        } else if (allowed) {
+            long_selected[best_coin] = best_candidate;
+            long_resolved[best_coin] = true;
+        } else {
+            long_candidate_index[best_coin] += 1;
+            long_resolved[best_coin] = long_candidate_index[best_coin] > 1
+                || !long_fallback[best_coin].valid;
+        }
+    }
+    for (int c = 0; c < coin_count; ++c) {
+        if (long_enabled) {
+            apply_ema_multicoin_reducer_candidate(
+                long_side, c, long_selected[c],
+                bars, coin_settings, k, coin_count
+            );
+        }
+        if (short_enabled) {
+            apply_ema_multicoin_reducer_candidate(
+                short_side, c, short_selected[c],
+                bars, coin_settings, k, coin_count
+            );
+        }
+    }
+    if (long_enabled) {
+        gate_ema_multicoin_side_ordinary_closes(
+            long_side, bars, coin_settings, k, coin_count, false,
+            market_order_slippage_pct, loss_gate_enabled,
+            remaining_loss_budget
+        );
+    }
+    if (short_enabled) {
+        gate_ema_multicoin_side_ordinary_closes(
+            short_side, bars, coin_settings, k, coin_count, true,
+            market_order_slippage_pct, loss_gate_enabled,
+            remaining_loss_budget
+        );
     }
 }
 
@@ -1959,8 +2322,6 @@ inline bool process_ema_multicoin_side_fills(
     bool short_side,
     bool alive,
     bool collect_coin_fill_counts,
-    bool loss_gate_enabled,
-    float max_realized_loss_pct,
     float market_order_slippage_pct,
     bool hsl_panic_market,
     float hsl_equity_before_fills
@@ -1982,12 +2343,12 @@ inline bool process_ema_multicoin_side_fills(
     thread bool* entry_market = side.entry_market;
     thread bool* close_market = side.close_market;
     thread bool* secondary_close_market = side.secondary_close_market;
+    thread bool* close_is_protective_reducer =
+        side.close_is_protective_reducer;
     thread bool* close_is_unstuck_reducer = side.close_is_unstuck_reducer;
     thread bool* close_is_hsl_panic = side.close_is_hsl_panic;
     thread float* coin_realized_pnl = side.coin_realized_pnl;
     thread float& balance = account.balance;
-    thread float& realized_pnl_cumsum_last = account.realized_pnl_total;
-    thread float& realized_pnl_cumsum_max = account.realized_pnl_peak;
 
     bool any_fill = false;
     for (int c = 0; c < coin_count; ++c) {
@@ -2061,19 +2422,8 @@ inline bool process_ema_multicoin_side_fills(
             float net_pnl = pnl
                 - adjusted * fill_price * c_mult
                     * (market_execution ? taker_fee : maker_fee);
-            bool is_unstuck = !use_secondary
-                && close_is_unstuck_reducer[c];
             bool is_hsl_panic = !use_secondary
                 && close_is_hsl_panic[c];
-            if (!is_hsl_panic && !realized_loss_proxy_allows_reducer(
-                    adjusted, fill_price, pprice[c], short_side,
-                    c_mult, market_execution ? taker_fee : maker_fee,
-                    is_unstuck, loss_gate_enabled,
-                    balance, realized_pnl_cumsum_last,
-                    realized_pnl_cumsum_max, max_realized_loss_pct
-                )) {
-                continue;
-            }
             if (is_hsl_panic) {
                 if (coin_hsl_mode) {
                     record_hsl_panic_fill(
@@ -2132,6 +2482,7 @@ inline bool process_ema_multicoin_side_fills(
             } else {
                 close_qty[c] = 0.0f;
                 close_market[c] = false;
+                close_is_protective_reducer[c] = false;
                 close_is_unstuck_reducer[c] = false;
                 close_is_hsl_panic[c] = false;
             }
@@ -2262,7 +2613,6 @@ inline void passivbot_ema_anchor_multicoin_impl(
     const float liquidation_floor = run_settings[1];
     const float interval_ms = run_settings[2];
     const float score_hysteresis = fmax(run_settings[4], 0.0f);
-    const bool loss_gate_enabled = run_settings[5] < 1.0f;
     const float max_realized_loss_pct = run_settings[5];
     const float market_order_slippage_pct = fmax(run_settings[7], 0.0f);
     const bool hsl_panic_market = run_settings[8] > 0.5f;
@@ -2373,8 +2723,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
             side, account, fills,
             bars, fill_ticks, coin_settings, coin_overrides,
             coin_fill_counts, int(b), k, C, short_side, alive,
-            collect_coin_fill_counts, loss_gate_enabled,
-            max_realized_loss_pct, market_order_slippage_pct,
+            collect_coin_fill_counts, market_order_slippage_pct,
             hsl_panic_market, hsl_equity_before_fills
         );
         if (any_fill) {
@@ -2424,9 +2773,13 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 side, config, account,
                 bars, touch_ticks, coin_settings, coin_overrides,
                 k, C, short_side, tradable_count, effective_n_positions,
-                current_hsl_mode, loss_gate_enabled,
-                max_realized_loss_pct, market_orders_allowed,
+                current_hsl_mode, market_orders_allowed,
                 market_order_near_touch_threshold, -2, 0ul
+            );
+            finalize_ema_multicoin_reducers_one_side(
+                side, account, bars, coin_settings, k, C, short_side,
+                market_orders_allowed, market_order_near_touch_threshold,
+                market_order_slippage_pct, max_realized_loss_pct
             );
         }
 
@@ -2974,7 +3327,6 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
     const float liquidation_floor = run_settings[1];
     const float interval_ms = run_settings[2];
     const float score_hysteresis = fmax(run_settings[4], 0.0f);
-    const bool loss_gate_enabled = run_settings[5] < 1.0f;
     const float max_realized_loss_pct = run_settings[5];
     const float market_order_slippage_pct = fmax(run_settings[7], 0.0f);
     const bool long_hsl_panic_market = run_settings[8] > 0.5f;
@@ -3069,8 +3421,7 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
             long_side, account, fills,
             bars, fill_ticks, coin_settings, long_coin_overrides,
             coin_fill_counts, int(b), k, C, false, alive,
-            collect_coin_fill_counts, loss_gate_enabled,
-            max_realized_loss_pct, market_order_slippage_pct,
+            collect_coin_fill_counts, market_order_slippage_pct,
             long_hsl_panic_market, long_hsl_equity_before_fills
         );
         float short_hsl_equity_before_fills = account.balance;
@@ -3088,8 +3439,7 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
             short_side, account, fills,
             bars, fill_ticks, coin_settings, short_coin_overrides,
             coin_fill_counts, int(b), k, C, true, alive,
-            collect_coin_fill_counts, loss_gate_enabled,
-            max_realized_loss_pct, market_order_slippage_pct,
+            collect_coin_fill_counts, market_order_slippage_pct,
             short_hsl_panic_market, short_hsl_equity_before_fills
         );
         bool any_fill = long_fill || short_fill;
@@ -3217,7 +3567,6 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                 bars, touch_ticks, coin_settings, long_coin_overrides,
                 k, C, false, long_tradable_count,
                 long_effective_n_positions, long_hsl_mode,
-                loss_gate_enabled, max_realized_loss_pct,
                 market_orders_allowed, market_order_near_touch_threshold,
                 long_unstuck_coin, long_one_way_order_blocked_mask
             );
@@ -3234,9 +3583,17 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                 bars, touch_ticks, coin_settings, short_coin_overrides,
                 k, C, true, short_tradable_count,
                 short_effective_n_positions, short_hsl_mode,
-                loss_gate_enabled, max_realized_loss_pct,
                 market_orders_allowed, market_order_near_touch_threshold,
                 short_unstuck_coin, short_one_way_order_blocked_mask
+            );
+        }
+        if (long_can_generate || short_can_generate) {
+            finalize_ema_multicoin_reducers_fused(
+                long_side, short_side, account,
+                bars, coin_settings, k, C,
+                long_can_generate, short_can_generate,
+                market_orders_allowed, market_order_near_touch_threshold,
+                market_order_slippage_pct, max_realized_loss_pct
             );
         }
 

--- a/passivbot-rust/src/gpu/mps_multicoin_common.metal
+++ b/passivbot-rust/src/gpu/mps_multicoin_common.metal
@@ -103,6 +103,13 @@ inline float float32_floor_nonnegative(float value) {
     return as_type<float>(as_type<uint>(value) - 1u);
 }
 
+inline bool realized_loss_gate_allows(
+    float net_pnl, float remaining_loss_budget, bool gate_enabled
+) {
+    return !gate_enabled || net_pnl >= 0.0f
+        || -net_pnl <= remaining_loss_budget;
+}
+
 // Joint-side account state for the fused multi-coin portfolio path. Exact
 // Rust processes every long fill before every short fill for a candle; callers
 // preserve that ordering while this state owns the one shared cash balance and

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -972,39 +972,6 @@ def _validate_scope_config(
                     "GPU multicoin ordinary market execution currently supports "
                     "EMA Anchor only"
                 )
-            if not math.isclose(
-                max_realized_loss_pct, 1.0, abs_tol=1.0e-12
-            ):
-                raise ValueError(
-                    "GPU multicoin EMA ordinary market execution currently "
-                    "requires live.max_realized_loss_pct=1.0"
-                )
-            for side in enabled_sides:
-                side_config = config["bot"][side]
-                risk = side_config.get("risk", {}) or {}
-                if bool(risk.get("total_exposure_enforcer_enabled", False)):
-                    raise ValueError(
-                        "GPU multicoin EMA ordinary market execution currently "
-                        f"requires bot.{side}.risk."
-                        "total_exposure_enforcer_enabled=false"
-                    )
-                if bool((side_config.get("unstuck", {}) or {}).get("enabled", False)):
-                    raise ValueError(
-                        "GPU multicoin EMA ordinary market execution currently "
-                        f"requires bot.{side}.unstuck.enabled=false"
-                    )
-            for symbol, patch in (config.get("coin_overrides", {}) or {}).items():
-                bot_patch = (patch or {}).get("bot", {}) or {}
-                for side in enabled_sides:
-                    unstuck_patch = (
-                        (bot_patch.get(side, {}) or {}).get("unstuck", {}) or {}
-                    )
-                    if bool(unstuck_patch.get("enabled", False)):
-                        raise ValueError(
-                            "GPU multicoin EMA ordinary market execution currently "
-                            "requires coin override unstuck.enabled=false; "
-                            f"got {symbol} {side}"
-                        )
     if bool(config.get("backtest", {}).get("filter_by_min_effective_cost")) and len(
         enabled_sides
     ) != 1:
@@ -2743,46 +2710,6 @@ def _validate_pinned_scope_bounds(
             )
 
 
-def _validate_ema_multicoin_market_foundation_bounds(
-    bound_by_key,
-    base_by_key,
-    enabled_sides,
-    config,
-    *,
-    coin_count: int,
-) -> None:
-    if (
-        int(coin_count) <= 1
-        or str(config.get("live", {}).get("strategy_kind", "")).strip().lower()
-        != "ema_anchor"
-        or not bool(config.get("live", {}).get("market_orders_allowed"))
-    ):
-        return
-    pinned = {
-        f"{side}_{suffix}": 0.0
-        for side in set(enabled_sides or ())
-        for suffix in (
-            "risk_twel_enforcer_enabled",
-            "unstuck_enabled",
-        )
-    }
-    for key, expected in sorted(pinned.items()):
-        bound = bound_by_key.get(key)
-        values = (
-            (float(bound.low), float(bound.high))
-            if bound is not None
-            else (float(base_by_key.get(key, expected)),) * 2
-        )
-        if any(
-            not math.isclose(value, expected, abs_tol=1.0e-12)
-            for value in values
-        ):
-            raise ValueError(
-                "GPU multicoin EMA ordinary market execution currently requires "
-                f"{key} to remain pinned at {expected}; got bounds {values}"
-            )
-
-
 def _validate_tm_market_mode_bounds(
     bound_by_key, base_by_key, enabled_sides, config
 ) -> None:
@@ -3379,13 +3306,6 @@ def run_backend(
         coin_count=max_coin_count,
         strategy_kind=strategy_kind,
     )
-    _validate_ema_multicoin_market_foundation_bounds(
-        bound_by_key,
-        base_by_key,
-        enabled_sides,
-        proxy_config,
-        coin_count=max_coin_count,
-    )
     _validate_tm_market_template_bounds(
         bound_by_key,
         base_by_key,
@@ -3430,13 +3350,6 @@ def run_backend(
             scenario_enabled_sides,
             coin_count=item["coin_count"],
             strategy_kind=strategy_kind,
-        )
-        _validate_ema_multicoin_market_foundation_bounds(
-            scenario_bound_by_key,
-            scenario_base_by_key,
-            scenario_enabled_sides,
-            item["config"],
-            coin_count=item["coin_count"],
         )
         _validate_tm_market_mode_bounds(
             scenario_bound_by_key,

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -70,7 +70,6 @@ from optimization.backends.gpu_backend import (
     _validate_dual_multicoin_metrics,
     _validate_gpu_optimizer_overrides,
     _validate_gpu_coin_overrides,
-    _validate_ema_multicoin_market_foundation_bounds,
     _validate_pinned_scope_bounds,
     _validate_resume_evidence_budget,
     _validate_seed_side_match,
@@ -2809,76 +2808,25 @@ def test_gpu_multicoin_ema_market_execution_accepts_hsl():
     assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
-@pytest.mark.parametrize(
-    ("mutate", "message"),
-    [
-        (
-            lambda config: config["live"].__setitem__(
-                "max_realized_loss_pct", 0.5
-            ),
-            "max_realized_loss_pct=1.0",
-        ),
-        (
-            lambda config: config["bot"]["long"]["risk"].__setitem__(
-                "total_exposure_enforcer_enabled", True
-            ),
-            "total_exposure_enforcer_enabled=false",
-        ),
-        (
-            lambda config: config["bot"]["long"]["unstuck"].__setitem__(
-                "enabled", True
-            ),
-            "unstuck.enabled=false",
-        ),
-        (
-            lambda config: config.__setitem__(
-                "coin_overrides",
-                {
-                    "ETH": {
-                        "bot": {"long": {"unstuck": {"enabled": True}}}
-                    }
-                },
-            ),
-            "coin override unstuck.enabled=false",
-        ),
-    ],
-)
-def test_gpu_multicoin_ema_market_execution_rejects_unordered_risk_features(
-    mutate, message
-):
+@pytest.mark.parametrize("feature", ["loss_gate", "twel", "unstuck", "override"])
+def test_gpu_multicoin_ema_market_execution_accepts_protective_reducers(feature):
     config = _directional_ema_config(long_enabled=True, short_enabled=False)
     config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "SOL"]
     config["live"]["market_orders_allowed"] = True
-    mutate(config)
+    if feature == "loss_gate":
+        config["live"]["max_realized_loss_pct"] = 0.05
+    elif feature == "twel":
+        config["bot"]["long"]["risk"][
+            "total_exposure_enforcer_enabled"
+        ] = True
+    elif feature == "unstuck":
+        config["bot"]["long"]["unstuck"]["enabled"] = True
+    else:
+        config["coin_overrides"] = {
+            "ETH": {"bot": {"long": {"unstuck": {"enabled": True}}}}
+        }
 
-    with pytest.raises(ValueError, match=message):
-        _validate_scope(config, _MulticoinEvaluator())
-
-
-@pytest.mark.parametrize(
-    "key",
-    ["long_risk_twel_enforcer_enabled", "long_unstuck_enabled"],
-)
-def test_gpu_multicoin_ema_market_execution_requires_risk_bounds_pinned_off(key):
-    config = _directional_ema_config(long_enabled=True, short_enabled=False)
-    config["live"]["market_orders_allowed"] = True
-    base = {key: 0.0}
-
-    _validate_ema_multicoin_market_foundation_bounds(
-        {key: Bound(0.0, 0.0)},
-        base,
-        {"long"},
-        config,
-        coin_count=3,
-    )
-    with pytest.raises(ValueError, match=key):
-        _validate_ema_multicoin_market_foundation_bounds(
-            {key: Bound(0.0, 1.0)},
-            base,
-            {"long"},
-            config,
-            coin_count=3,
-        )
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -707,6 +707,140 @@ kernel void passivbot_ema_multicoin_side_state_isolation_probe(
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+def test_mps_ema_multicoin_fused_reducers_share_loss_budget_and_fallback():
+    import passivbot_rust
+
+    probe_kernel = r"""
+kernel void passivbot_ema_multicoin_fused_reducer_budget_probe(
+    constant float* bars,
+    constant float* coin_settings,
+    device float* output,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    EmaMulticoinSideState long_side;
+    EmaMulticoinSideState short_side;
+    for (int c = 0; c < MAX_COINS; ++c) {
+        long_side.psize[c] = 0.0f;
+        long_side.pprice[c] = 0.0f;
+        long_side.close_qty[c] = 0.0f;
+        long_side.close_tick[c] = 0;
+        long_side.close_market[c] = false;
+        long_side.secondary_close_qty[c] = 0.0f;
+        long_side.secondary_close_tick[c] = 0;
+        long_side.secondary_close_market[c] = false;
+        long_side.twel_close_qty[c] = 0.0f;
+        long_side.twel_close_tick[c] = 0;
+        long_side.unstuck_close_qty[c] = 0.0f;
+        long_side.unstuck_close_tick[c] = 0;
+        long_side.close_is_protective_reducer[c] = false;
+        long_side.close_is_unstuck_reducer[c] = false;
+        long_side.close_is_hsl_panic[c] = false;
+
+        short_side.psize[c] = 0.0f;
+        short_side.pprice[c] = 0.0f;
+        short_side.close_qty[c] = 0.0f;
+        short_side.close_tick[c] = 0;
+        short_side.close_market[c] = false;
+        short_side.secondary_close_qty[c] = 0.0f;
+        short_side.secondary_close_tick[c] = 0;
+        short_side.secondary_close_market[c] = false;
+        short_side.twel_close_qty[c] = 0.0f;
+        short_side.twel_close_tick[c] = 0;
+        short_side.unstuck_close_qty[c] = 0.0f;
+        short_side.unstuck_close_tick[c] = 0;
+        short_side.close_is_protective_reducer[c] = false;
+        short_side.close_is_unstuck_reducer[c] = false;
+        short_side.close_is_hsl_panic[c] = false;
+    }
+
+    // The long preferred TWEL close loses 15 and cannot spend the 10 budget.
+    // Its unstuck fallback loses 5. The short TWEL close loses 6, wins the
+    // next global quantity comparison, and leaves only 4 for that fallback.
+    long_side.psize[0] = 5.0f;
+    long_side.pprice[0] = 105.0f;
+    long_side.twel_close_qty[0] = 3.0f;
+    long_side.twel_close_tick[0] = 100;
+    long_side.unstuck_close_qty[0] = 1.0f;
+    long_side.unstuck_close_tick[0] = 100;
+
+    short_side.psize[1] = 5.0f;
+    short_side.pprice[1] = 97.0f;
+    short_side.twel_close_qty[1] = 2.0f;
+    short_side.twel_close_tick[1] = 100;
+
+    JointPortfolioAccount account = init_joint_portfolio_account(1000.0f);
+    finalize_ema_multicoin_reducers_fused(
+        long_side, short_side, account,
+        bars, coin_settings, 1, 2,
+        true, true, true, 0.0f, 0.0f, 0.01f
+    );
+
+    output[0] = long_side.close_qty[0];
+    output[1] = long_side.close_market[0] ? 1.0f : 0.0f;
+    output[2] = long_side.close_is_protective_reducer[0] ? 1.0f : 0.0f;
+    output[3] = long_side.close_is_unstuck_reducer[0] ? 1.0f : 0.0f;
+    output[4] = short_side.close_qty[1];
+    output[5] = short_side.close_market[1] ? 1.0f : 0.0f;
+    output[6] = short_side.close_is_protective_reducer[1] ? 1.0f : 0.0f;
+    output[7] = short_side.close_is_unstuck_reducer[1] ? 1.0f : 0.0f;
+}
+"""
+    bars = torch.zeros((2, 2, 4), dtype=torch.float32, device="mps")
+    bars[:, :, :3] = 100.0
+    bars[:, :, 3] = 1.0
+    coin_settings = torch.tensor(
+        [
+            [
+                1.0,
+                1.0,
+                1.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                1.0,
+                60_000.0,
+                100.0,
+                1.0,
+                0.0,
+            ],
+            [
+                1.0,
+                1.0,
+                1.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                1.0,
+                60_000.0,
+                100.0,
+                1.0,
+                0.0,
+            ],
+        ],
+        dtype=torch.float32,
+        device="mps",
+    )
+    output = torch.zeros(8, dtype=torch.float32, device="mps")
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_ema_anchor_multicoin_source_py() + probe_kernel
+    )
+    library.passivbot_ema_multicoin_fused_reducer_budget_probe(
+        bars,
+        coin_settings,
+        output,
+        threads=(1, 1, 1),
+    )
+    torch.mps.synchronize()
+
+    assert output.cpu().tolist() == [0.0, 0.0, 0.0, 0.0, 2.0, 1.0, 1.0, 0.0]
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 def test_mps_tm_multicoin_side_states_are_isolated_for_fused_execution():
     import passivbot_rust
 
@@ -2396,14 +2530,14 @@ kernel void passivbot_ema_multicoin_shared_fill_phase_probe(
         long_side, account, fills,
         bars, fill_ticks, coin_settings, coin_overrides,
         coin_fill_counts, 0, 1, 1, false, true,
-        false, false, 1.0f, 0.0f, false, 1000.0f
+        false, 0.0f, false, 1000.0f
     );
     float balance_after_long = account.balance;
     bool short_filled = process_ema_multicoin_side_fills(
         short_side, account, fills,
         bars, fill_ticks, coin_settings, coin_overrides,
         coin_fill_counts, 0, 1, 1, true, true,
-        false, false, 1.0f, 0.0f, false, balance_after_long
+        false, 0.0f, false, balance_after_long
     );
 
     output[0] = long_filled ? 1.0f : 0.0f;
@@ -2660,17 +2794,17 @@ kernel void passivbot_ema_multicoin_order_phase_probe(
     long_side.selected[0] = true;
     short_side.selected[0] = true;
     JointPortfolioAccount account = init_joint_portfolio_account(1000.0f);
-        generate_ema_multicoin_side_orders(
-            long_side, long_config, account,
-            bars, touch_ticks, coin_settings, coin_overrides,
-            1, 1, false, 1, 1, 0, false, 1.0f,
-            false, 0.001f, -2, 0ul
-        );
-        generate_ema_multicoin_side_orders(
-            short_side, short_config, account,
-            bars, touch_ticks, coin_settings, coin_overrides,
-            1, 1, true, 1, 1, 0, false, 1.0f,
-            false, 0.001f, -2, 0ul
+    generate_ema_multicoin_side_orders(
+        long_side, long_config, account,
+        bars, touch_ticks, coin_settings, coin_overrides,
+        1, 1, false, 1, 1, 0,
+        false, 0.001f, -2, 0ul
+    );
+    generate_ema_multicoin_side_orders(
+        short_side, short_config, account,
+        bars, touch_ticks, coin_settings, coin_overrides,
+        1, 1, true, 1, 1, 0,
+        false, 0.001f, -2, 0ul
     );
     output[0] = long_side.entry_qty[0];
     output[1] = short_side.entry_qty[0];
@@ -2680,12 +2814,12 @@ kernel void passivbot_ema_multicoin_order_phase_probe(
     output[5] = short_side.close_qty[0];
     output[6] = account.balance;
     output[7] = account.realized_pnl_total;
-        generate_ema_multicoin_side_orders(
-            long_side, long_config, account,
-            bars, touch_ticks, coin_settings, coin_overrides,
-            1, 1, false, 1, 1, 0, false, 1.0f,
-            false, 0.001f, -2, 1ul
-        );
+    generate_ema_multicoin_side_orders(
+        long_side, long_config, account,
+        bars, touch_ticks, coin_settings, coin_overrides,
+        1, 1, false, 1, 1, 0,
+        false, 0.001f, -2, 1ul
+    );
     output[8] = long_side.entry_qty[0];
     output[9] = long_side.entry_candidate[0] ? 1.0f : 0.0f;
     output[10] = long_side.contribution[0];
@@ -4679,8 +4813,10 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
     assert "twel_enforcer_reduce_portfolio" in source
     assert "clamped_market_price" in source
     assert "secondary_close_qty" in source
-    assert "realized_loss_proxy_allows_close" in source
-    assert "const bool loss_gate_enabled = run_settings[5] < 1.0f" in source
+    assert "finalize_ema_multicoin_reducers_one_side(" in source
+    assert "finalize_ema_multicoin_reducers_fused(" in source
+    assert "gate_ema_multicoin_close(" in source
+    assert "realized_loss_proxy_allows_close" not in source
     assert "constant int DAILY_COLS = 9" in source
     assert "day_min_balance" in source
     assert "coin_override_or" in source
@@ -9282,6 +9418,9 @@ def test_mps_single_side_multicoin_auto_unstuck_selects_only_one_coin(
         highs=highs,
         lows=lows,
         max_realized_loss_pct=0.05,
+        market_orders_allowed=strategy_kind == "ema_anchor",
+        market_order_near_touch_threshold=0.001,
+        market_order_slippage_pct=0.01,
     )
     keys = (
         EMA_ANCHOR_MULTICOIN_PARAM_KEYS
@@ -9356,6 +9495,9 @@ def test_mps_single_side_multicoin_auto_unstuck_selects_only_one_coin(
         highs=highs,
         lows=lows,
         max_realized_loss_pct=0.0005,
+        market_orders_allowed=strategy_kind == "ema_anchor",
+        market_order_near_touch_threshold=0.001,
+        market_order_slippage_pct=0.01,
     )
     strict_output = strict_runner.run(
         np.asarray([enabled], dtype=np.float64)
@@ -11942,12 +12084,15 @@ def test_mps_ema_multicoin_loss_gate_blocks_lossy_total_exposure_repair(side):
         "closes": closes,
         "highs": highs,
         "lows": lows,
+        "market_orders_allowed": True,
+        "market_order_near_touch_threshold": 0.001,
+        "market_order_slippage_pct": 0.01,
     }
     ungated_runner, candidate = _multicoin_exposure_fixture(
         max_realized_loss_pct=1.0, **runner_kwargs
     )
     gated_runner, _ = _multicoin_exposure_fixture(
-        max_realized_loss_pct=0.1, **runner_kwargs
+        max_realized_loss_pct=0.001, **runner_kwargs
     )
     values = dict(zip(EMA_ANCHOR_MULTICOIN_PARAM_KEYS, candidate))
     values.update(
@@ -11968,7 +12113,10 @@ def test_mps_ema_multicoin_loss_gate_blocks_lossy_total_exposure_repair(side):
 
     size_key = "psize" if side == "long" else "short_psize"
     assert ungated[size_key].item() < gated[size_key].item()
-    assert gated["open_positions"].item() == pytest.approx(2.0)
+    # Both paths keep the same symbol open, but the shared loss allowance
+    # blocks part of the lossy repair and therefore retains more quantity.
+    assert ungated["open_positions"].item() == pytest.approx(1.0)
+    assert gated["open_positions"].item() == pytest.approx(1.0)
     assert gated["balance"].item() >= ungated["balance"].item()
 
 
@@ -11992,7 +12140,7 @@ def test_mps_ema_multicoin_loss_gate_blocks_fee_only_ordinary_close(side):
         max_realized_loss_pct=1.0, **runner_kwargs
     )
     gated_runner, _ = _multicoin_exposure_fixture(
-        max_realized_loss_pct=0.1, **runner_kwargs
+        max_realized_loss_pct=0.0, **runner_kwargs
     )
     candidate[
         EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("entry_cooldown_minutes")


### PR DESCRIPTION
## Summary
- coordinate multi-coin EMA TWEL and unstuck reducers globally across symbols and sides, following exact Rust candidate finalization and tie ordering
- share the realized-loss budget across accepted protective reducers and ordinary closes, with HSL panic bypass and generation-time market intent persistence
- support EMA multi-coin market optimization with TWEL, auto-unstuck, realized-loss limits, and static per-coin unstuck overrides while keeping trailing-martingale restrictions fail closed
- preserve exact Rust as authoritative and leave CPU optimization paths unchanged

## Validation
- cargo test --no-default-features: 267 passed
- cargo check --tests: passed
- non-MPS optimizer suite: 997 passed
- full physical Apple M3/MPS suite: 392 passed
- cached two-coin, both-sides MPS optimization: 576 proxy and 72 exact evaluations completed; Pareto size 19
- runtime extension source stamp: 5207dc8b51d0920089195381497d60c7c0befd8106a02d00c2b426290f478c2a
- runtime extension SHA-256: 3727773dd56b0feb751a0047c469a6b4ca210414fd36f7ef629769802a4ab401
- AI docs validation and diff checks passed

## Scope
This slice covers EMA Anchor multi-coin market protective reducers. Multi-coin Trailing Martingale market reducers remain fail closed for a later slice.