### PR TITLE
Add multi-coin TM market execution on Apple MPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added baseline multi-coin Trailing Martingale ordinary market execution to Apple MPS
+  optimization for long-only, short-only, fused long+short, hedge-mode, one-way, and compatible
+  suite runs whose entry and close modes remain wholly trailing. Metal retains generation-time
+  market intent, executes promoted orders on the next valid candle with adverse directional
+  slippage and taker fees, applies executable-touch minimum sizing to short entries and all closes,
+  and prices the strict portfolio entry cap at the market touch. HSL, static coin overrides, and
+  forager selection remain supported. Recursive entry and close ladders, position- and
+  total-exposure repair, auto-unstuck, and realized-loss gating remain fail closed in multi-coin
+  Trailing Martingale market mode pending dedicated parity slices.
+
 - Added baseline multi-coin EMA Anchor ordinary market execution to Apple MPS optimization for
   long-only, short-only, and fused long+short runs. The proxy retains generation-time entry and
   ordinary-close intent, executes it on the next valid candle with adverse directional slippage
@@ -13,8 +23,7 @@ All notable user-facing changes will be documented in this file.
   against ordinary closes, ranks their executable quantities globally across symbols and sides,
   advances only a rejected position to its fallback, and spends one shared loss allowance before
   gating ordinary closes. These generation-time decisions include market slippage and taker fees
-  and remain attached to pending orders. Multi-coin Trailing Martingale market mode remains fail
-  closed.
+  and remain attached to pending orders.
 
 - Added single-coin Trailing Martingale recursive-close market execution to Apple MPS
   optimization. Exact passive next-candle expansion remains authoritative: a market-only next
@@ -32,8 +41,7 @@ All notable user-facing changes will be documented in this file.
   retain canonical ordering,
   aggregate position trimming, quantity-relative minimum-size comparisons, adverse slippage, and
   taker fees. Entry and close optimizer bounds must
-  each remain wholly recursive or wholly trailing; mode-crossing ranges and multi-coin Trailing
-  Martingale market execution remain fail closed.
+  each remain wholly recursive or wholly trailing; mode-crossing ranges remain fail closed.
 
 - Added single-coin Trailing Martingale recursive-entry market execution to Apple MPS optimization.
   Every immutable strategy-ladder rung is independently promoted against its generation market
@@ -42,20 +50,17 @@ All notable user-facing changes will be documented in this file.
   total-exposure entry gate at their limit price or market touch. Strategy-ladder sizing retains
   its separate wallet-exposure allowance before that portfolio gate is applied; the retained
   nearest prefix ends at the first partially cropped portfolio-boundary rung. Entry optimizer
-  bounds must remain wholly recursive or wholly trailing; mode-crossing ranges and multi-coin
-  Trailing Martingale market execution remain fail closed.
+  bounds must remain wholly recursive or wholly trailing; mode-crossing ranges remain fail closed.
 
 - Extended single-coin Trailing Martingale ordinary market-order optimization on Apple MPS to
   compatible HSL modes, one-sided minimum-effective-cost filtering, auto-unstuck, position- and
   total-exposure repair, and realized-loss gating. Market-promoted reducers are resized at
   executable touch before selection and aggregate allocation, and adverse slippage plus taker fees
-  participate in the conservative loss projection. Multi-coin Trailing Martingale market
-  execution remains fail closed pending its dedicated slice.
+  participate in the conservative loss projection.
 
 - Added baseline ordinary market-order execution to Apple MPS optimization for single-coin
   Trailing Martingale, covering long, short, and dual-side near-touch trailing entries and closes,
-  executable-touch minimum sizing, adverse slippage, and taker fees. Multi-coin combinations
-  remain fail closed until their Trailing Martingale market-order interactions are implemented.
+  executable-touch minimum sizing, adverse slippage, and taker fees.
 
 - Extended single-coin EMA Anchor ordinary market-order optimization on Apple MPS to compatible
   HSL modes, one-sided minimum-effective-cost filtering, auto-unstuck, total-exposure repair, and

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -321,8 +321,16 @@ The supported slice is intentionally narrow:
   cost while allocating the portfolio entry cap. Protective reducers participate in the same
   finalized-quantity ordering, shared loss budget, and per-position fallback used by exact Rust;
   their market slippage and taker fees are included in the projected loss. Static coin overrides
-  may enable or tune unstuck. Multi-coin Trailing Martingale ordinary market execution remains fail
-  closed
+  may enable or tune unstuck. Multi-coin Trailing Martingale supports ordinary market entries and
+  ordinary strategy closes for long-only, short-only, fused long+short, hedge-mode, one-way, and
+  compatible suite runs when every enabled entry and close retracement range remains wholly
+  trailing with a float32-positive lower bound. It uses the same retained generation-time intent,
+  next-valid-candle adverse fill, taker-fee, executable-touch minimum sizing for short entries and
+  all closes, and portfolio entry-cap accounting contract. HSL, static coin overrides, and forager
+  selection remain supported.
+  Recursive entry or close modes, position- and total-exposure repair, auto-unstuck, and
+  realized-loss gating remain fail closed for multi-coin Trailing Martingale market mode until
+  their market interactions are modeled
 - no invalid candle tail after the selected coin's final valid candle
 
 Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor and

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -1024,7 +1024,13 @@ mod tests {
         );
         assert!(source.contains("coin_hsl_eligibility_changed"));
         assert!(source.contains("coin_hsl_entry_blocked_mask"));
-        assert!(source.contains("market_panic ? taker_fee : maker_fee"));
+        assert!(source.contains("market_execution ? taker_fee : maker_fee"));
+        assert!(source.contains("bool entry_market[MAX_COINS]"));
+        assert!(source.contains("bool close_market[MAX_COINS]"));
+        assert!(source.contains("bool secondary_close_market[MAX_COINS]"));
+        assert!(source.contains("should_use_ordinary_market_execution("));
+        assert!(source.contains("ordinary_market_fill_price("));
+        assert!(source.contains("resize_market_close_qty("));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[scalar_offset + 19] = loss_sum"));
         assert!(source
@@ -1045,6 +1051,8 @@ mod tests {
         assert!(source.contains("if (effective_equity >= account_peak)"));
         assert!(source.contains("const bool collect_coin_fill_counts = run_settings[6] > 0.5f"));
         assert!(source.contains("const bool hedge_mode = run_settings[10] > 0.5f"));
+        assert!(source.contains("const bool market_orders_allowed = run_settings[9] > 0.5f"));
+        assert!(source.contains("const bool market_orders_allowed = run_settings[11] > 0.5f"));
         assert!(source.contains("compute_tm_multicoin_one_way_initial_blocks"));
         assert!(source.contains("device float* coin_fill_counts"));
         assert_eq!(
@@ -1073,7 +1081,7 @@ mod tests {
         ));
         assert!(source.contains("if (alive && !post_fill_balance_depleted)"));
         assert!(source.contains("market_price * 0.9995f / price_step"));
-        assert_eq!(source.matches("clamped_market_price(").count(), 3);
+        assert!(source.matches("clamped_market_price(").count() >= 4);
         assert!(source.contains("finalized_twel_reducer_qty = ordinary_can_accompany_reducer"));
         assert!(source.contains("finalized_reducer_qty_with_ordinary"));
         assert!(source.contains("finalized_wel_reducer_qty = finalized_reducer_qty"));

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -393,6 +393,9 @@ struct TrailingMartingaleMulticoinSideState {
     bool entry_candidate[MAX_COINS];
     bool close_reconstruct_after_reducer[MAX_COINS];
     bool filled_coin[MAX_COINS];
+    bool entry_market[MAX_COINS];
+    bool close_market[MAX_COINS];
+    bool secondary_close_market[MAX_COINS];
     bool close_is_unstuck_reducer[MAX_COINS];
     bool close_is_hsl_panic[MAX_COINS];
     bool selection_initialized;
@@ -647,6 +650,8 @@ inline void finalize_tm_multicoin_close_position(
     }
     side.close_qty[coin] = 0.0f;
     side.secondary_close_qty[coin] = 0.0f;
+    side.close_market[coin] = false;
+    side.secondary_close_market[coin] = false;
     side.close_reconstruct_after_reducer[coin] = false;
     side.close_is_unstuck_reducer[coin] = false;
     side.close_is_hsl_panic[coin] = false;
@@ -676,6 +681,7 @@ inline void apply_tm_multicoin_entry_position(
     side.last_increase_k[coin] = float(k);
     fills.day_volume += fabs(qty) * fill_price * c_mult / balance;
     side.entry_qty[coin] = 0.0f;
+    side.entry_market[coin] = false;
     side.filled_coin[coin] = true;
 }
 
@@ -744,6 +750,9 @@ inline bool process_tm_multicoin_side_fills(
     thread bool* close_reconstruct_after_reducer =
         side.close_reconstruct_after_reducer;
     thread bool* filled_coin = side.filled_coin;
+    thread bool* entry_market = side.entry_market;
+    thread bool* close_market = side.close_market;
+    thread bool* secondary_close_market = side.secondary_close_market;
     thread bool* close_is_unstuck_reducer =
         side.close_is_unstuck_reducer;
     thread bool* close_is_hsl_panic = side.close_is_hsl_panic;
@@ -782,31 +791,25 @@ inline bool process_tm_multicoin_side_fills(
             : hsl_panic_market;
         bool primary_market_panic = close_is_hsl_panic[c]
             && coin_hsl_panic_market;
+        bool primary_market = primary_market_panic || close_market[c];
         bool filled_close = close_ready
-            && (primary_market_panic || (short_side
+            && (primary_market || (short_side
                 ? close_tick[c] > fill_ticks[tick_offset + 1]
                 : close_tick[c] <= fill_ticks[tick_offset + 0]));
         bool filled_secondary_close = secondary_close_qty[c] > 0.0f
             && psize[c] > 0.0f
-            && (short_side
+            && (secondary_close_market[c] || (short_side
                 ? secondary_close_tick[c] > fill_ticks[tick_offset + 1]
-                : secondary_close_tick[c] <= fill_ticks[tick_offset + 0]);
+                : secondary_close_tick[c] <= fill_ticks[tick_offset + 0]));
         bool rebuild_grid = psize[c] > 0.0f
             && close_reconstruct_after_reducer[c]
+            && !close_market[c]
             && !close_is_hsl_panic[c];
         if (filled_close || filled_secondary_close || rebuild_grid) {
-            float fill_price = primary_market_panic
-                ? fmax(
-                    short_side
-                        ? ceil_step(
-                            close * (1.0f + market_order_slippage_pct),
-                            price_step
-                        )
-                        : floor_step(
-                            close * (1.0f - market_order_slippage_pct),
-                            price_step
-                        ),
-                    price_step
+            float fill_price = primary_market
+                ? ordinary_market_fill_price(
+                    close, short_side,
+                    market_order_slippage_pct, price_step
                 )
                 : float(close_tick[c]) * price_step;
             float reducer_qty = fmin(
@@ -1074,8 +1077,12 @@ inline bool process_tm_multicoin_side_fills(
                 if (psize[c] <= 0.0f) break;
             }
 
-            float secondary_price = float(secondary_close_tick[c])
-                * price_step;
+            float secondary_price = secondary_close_market[c]
+                ? ordinary_market_fill_price(
+                    close, short_side,
+                    market_order_slippage_pct, price_step
+                )
+                : float(secondary_close_tick[c]) * price_step;
             bool secondary_first = filled_secondary_close
                 && (!(filled_close && !reducer_executed)
                     || (short_side
@@ -1101,8 +1108,8 @@ inline bool process_tm_multicoin_side_fills(
                     && close_is_unstuck_reducer[c];
                 bool is_hsl_panic = !use_secondary
                     && close_is_hsl_panic[c];
-                bool market_panic = !use_secondary
-                    && primary_market_panic;
+                bool market_execution = use_secondary
+                    ? secondary_close_market[c] : primary_market;
                 if (!is_hsl_panic && !realized_loss_proxy_allows_reducer(
                         qty, price, pprice[c], short_side,
                         c_mult, maker_fee, is_unstuck, loss_gate_enabled,
@@ -1112,7 +1119,7 @@ inline bool process_tm_multicoin_side_fills(
                     continue;
                 }
                 float net_pnl = pnl - qty * price * c_mult
-                    * (market_panic ? taker_fee : maker_fee);
+                    * (market_execution ? taker_fee : maker_fee);
                 record_tm_multicoin_close_fill(
                     side, account, fills, coin_fill_counts,
                     int(b), C, c, k, pnl, net_pnl, qty,
@@ -1137,13 +1144,19 @@ inline bool process_tm_multicoin_side_fills(
         }
 
         bool filled_entry = entry_qty[c] > 0.0f
-            && (short_side
+            && (entry_market[c] || (short_side
                 ? entry_tick[c] <= fill_ticks[tick_offset + 0]
-                : entry_tick[c] > fill_ticks[tick_offset + 1]);
+                : entry_tick[c] > fill_ticks[tick_offset + 1]));
         if (filled_entry) {
-            float fill_price = float(entry_tick[c]) * price_step;
+            float fill_price = entry_market[c]
+                ? ordinary_market_fill_price(
+                    close, !short_side,
+                    market_order_slippage_pct, price_step
+                )
+                : float(entry_tick[c]) * price_step;
             float adjusted = round_step(entry_qty[c], qty_step);
-            float fee = adjusted * fill_price * c_mult * maker_fee;
+            float fee = adjusted * fill_price * c_mult
+                * (entry_market[c] ? taker_fee : maker_fee);
             record_tm_multicoin_entry_fill(
                 side, account, fills, coin_fill_counts,
                 int(b), C, c, k, fee, adjusted, fill_price,
@@ -1308,6 +1321,9 @@ inline void init_trailing_martingale_multicoin_side_state(
         side.entry_candidate[c] = false;
         side.close_reconstruct_after_reducer[c] = false;
         side.filled_coin[c] = false;
+        side.entry_market[c] = false;
+        side.close_market[c] = false;
+        side.secondary_close_market[c] = false;
         side.close_is_unstuck_reducer[c] = false;
         side.close_is_hsl_panic[c] = false;
         side.coin_realized_pnl[c] = 0.0f;
@@ -2244,6 +2260,8 @@ inline void generate_tm_multicoin_side_orders(
     int current_hsl_mode,
     bool loss_gate_enabled,
     float max_realized_loss_pct,
+    bool market_orders_allowed,
+    float market_order_near_touch_threshold,
     int forced_unstuck_coin,
     ulong one_way_initial_blocked_mask
 ) {
@@ -2325,6 +2343,9 @@ inline void generate_tm_multicoin_side_orders(
     thread bool* entry_candidate = side.entry_candidate;
     thread bool* close_reconstruct_after_reducer =
         side.close_reconstruct_after_reducer;
+    thread bool* entry_market = side.entry_market;
+    thread bool* close_market = side.close_market;
+    thread bool* secondary_close_market = side.secondary_close_market;
     thread bool* close_is_unstuck_reducer =
         side.close_is_unstuck_reducer;
     thread bool* close_is_hsl_panic = side.close_is_hsl_panic;
@@ -2605,6 +2626,9 @@ inline void generate_tm_multicoin_side_orders(
         entry_qty[c] = 0.0f;
         close_qty[c] = 0.0f;
         secondary_close_qty[c] = 0.0f;
+        entry_market[c] = false;
+        close_market[c] = false;
+        secondary_close_market[c] = false;
         secondary_close_tick[c] = 0;
         close_reconstruct_after_reducer[c] = false;
         close_is_hsl_panic[c] = false;
@@ -2846,14 +2870,30 @@ inline void generate_tm_multicoin_side_orders(
         )) {
             quantity = 0.0f;
         }
+        bool candidate_entry_market = quantity > 0.0f
+            && should_use_ordinary_market_execution(
+                candidate_entry_tick, !short_side, price_now, price_step,
+                market_orders_allowed, market_order_near_touch_threshold
+            );
+        float executable_entry_price = candidate_entry_market
+            ? price_now : entry_price;
+        float executable_entry_min = min_entry_qty(
+            executable_entry_price,
+            qty_step, min_qty, min_cost, c_mult
+        );
+        // Exact Rust sizes the immutable strategy order first. Promotion to a
+        // short market entry may require a larger executable-touch minimum.
+        if (short_side && candidate_entry_market && quantity > 0.0f
+            && quantity < executable_entry_min) {
+            quantity = executable_entry_min;
+        }
         entry_qty[c] = quantity;
         entry_tick[c] = candidate_entry_tick;
-        minimum_entry[c] = min_entry_qty(
-            entry_price, qty_step, min_qty, min_cost, c_mult
-        );
+        entry_market[c] = candidate_entry_market && quantity > 0.0f;
+        minimum_entry[c] = executable_entry_min;
         entry_candidate[c] = quantity > 0.0f;
         contribution[c] = quantity > 0.0f
-            ? quantity * entry_price * c_mult / balance : 0.0f;
+            ? quantity * executable_entry_price * c_mult / balance : 0.0f;
 
         // Exact Rust keeps only the largest protective reducer for a
         // position before allocating its ordinary close ladder.
@@ -2953,6 +2993,21 @@ inline void generate_tm_multicoin_side_orders(
                 && (!trailing_close || close_triggered)
             ? clip : 0.0f;
         close_tick[c] = candidate_close_tick;
+        close_market[c] = close_qty[c] > 0.0f
+            && should_use_ordinary_market_execution(
+                candidate_close_tick, short_side, price_now, price_step,
+                market_orders_allowed, market_order_near_touch_threshold
+            );
+        if (close_market[c]) {
+            close_qty[c] = resize_market_close_qty(
+                close_qty[c], psize[c], price_now,
+                qty_step, min_qty, min_cost, c_mult
+            );
+            minimum_close = min_entry_qty(
+                price_now, qty_step, min_qty, min_cost, c_mult
+            );
+            minimum_close_relation = 0;
+        }
         if (!realized_loss_proxy_allows_close(
                 close_qty[c], close_price, pprice[c], short_side,
                 c_mult, coin_settings[coin_offset + 5],
@@ -2970,6 +3025,7 @@ inline void generate_tm_multicoin_side_orders(
                 close_grid_max_rungs[c] = 500;
             }
             close_qty[c] = 0.0f;
+            close_market[c] = false;
         }
 
         // Exact Rust finalizes protective reducers after reserving an
@@ -3077,6 +3133,7 @@ inline void generate_tm_multicoin_side_orders(
                     }
                     secondary_close_qty[c] = ordinary_qty;
                     secondary_close_tick[c] = close_tick[c];
+                    secondary_close_market[c] = close_market[c];
                 }
             } else if (!trailing_close) {
                 float reserved_grid_qty = use_unstuck
@@ -3104,6 +3161,7 @@ inline void generate_tm_multicoin_side_orders(
             }
             close_qty[c] = reducer_qty;
             close_tick[c] = reducer_tick;
+            close_market[c] = false;
             close_is_unstuck_reducer[c] = use_unstuck;
         }
     }
@@ -3155,7 +3213,11 @@ inline void generate_tm_multicoin_side_orders(
             float qty_step = coin_settings[coin_offset + 0];
             float price_step = coin_settings[coin_offset + 1];
             float c_mult = coin_settings[coin_offset + 4];
-            float price = float(entry_tick[best]) * price_step;
+            float price = entry_market[best]
+                ? clamped_market_price(
+                    bars, coin_settings, k, best, C
+                )
+                : float(entry_tick[best]) * price_step;
             float room_cost = fmax((total_cap - running_twe) * balance, 0.0f);
             float partial = floor_step(
                 room_cost / fmax(price * c_mult, 1.0e-12f), qty_step
@@ -3187,10 +3249,17 @@ inline void generate_tm_multicoin_side_orders(
             );
             secondary_close_qty[c] = 0.0f;
             secondary_close_tick[c] = 0;
+            close_market[c] = false;
+            secondary_close_market[c] = false;
             close_reconstruct_after_reducer[c] = false;
             close_grid_gen_psize[c] = 0.0f;
             close_is_unstuck_reducer[c] = false;
             close_is_hsl_panic[c] = true;
+        }
+        if (!(entry_qty[c] > 0.0f)) entry_market[c] = false;
+        if (!(close_qty[c] > 0.0f)) close_market[c] = false;
+        if (!(secondary_close_qty[c] > 0.0f)) {
+            secondary_close_market[c] = false;
         }
     }
 }
@@ -3317,6 +3386,9 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
     const bool long_hsl_panic_market = run_settings[8] > 0.5f;
     const bool short_hsl_panic_market = run_settings[9] > 0.5f;
     const bool hedge_mode = run_settings[10] > 0.5f;
+    const bool market_orders_allowed = run_settings[11] > 0.5f;
+    const float market_order_near_touch_threshold =
+        fmax(run_settings[12], 0.0f);
     const float log_bin_scale = 127.0f / log(4000001.0f);
 
     JointPortfolioAccount account = init_joint_portfolio_account(
@@ -3558,6 +3630,8 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
                 k, C, false, long_tradable_count,
                 long_effective_n_positions, long_hsl_mode,
                 loss_gate_enabled, max_realized_loss_pct,
+                market_orders_allowed,
+                market_order_near_touch_threshold,
                 long_unstuck_coin, long_one_way_order_blocked_mask
             );
         }
@@ -3576,6 +3650,8 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
                 k, C, true, short_tradable_count,
                 short_effective_n_positions, short_hsl_mode,
                 loss_gate_enabled, max_realized_loss_pct,
+                market_orders_allowed,
+                market_order_near_touch_threshold,
                 short_unstuck_coin, short_one_way_order_blocked_mask
             );
         }
@@ -4002,6 +4078,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     const float max_realized_loss_pct = run_settings[5];
     const float market_order_slippage_pct = fmax(run_settings[7], 0.0f);
     const bool hsl_panic_market = run_settings[8] > 0.5f;
+    const bool market_orders_allowed = run_settings[9] > 0.5f;
+    const float market_order_near_touch_threshold =
+        fmax(run_settings[10], 0.0f);
     const float log_bin_scale = 127.0f / log(4000001.0f);
 
     thread float* psize = side.psize;
@@ -4163,7 +4242,10 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 coin_settings, coin_overrides,
                 k, C, short_side, tradable_count,
                 effective_n_positions, current_hsl_mode,
-                loss_gate_enabled, max_realized_loss_pct, -2, 0ul
+                loss_gate_enabled, max_realized_loss_pct,
+                market_orders_allowed,
+                market_order_near_touch_threshold,
+                -2, 0ul
             );
         }
 

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -928,7 +928,7 @@ def _validate_tm_multicoin_market_runtime_scope(
 
     unsupported = []
     max_loss = float(config.get("live", {}).get("max_realized_loss_pct", 1.0))
-    if not math.isclose(max_loss, 1.0, abs_tol=1.0e-12):
+    if max_loss != 1.0:
         unsupported.append(
             f"live.max_realized_loss_pct={max_loss} (required 1.0)"
         )

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -906,6 +906,125 @@ def _validate_resume_evidence_budget(
         )
 
 
+def _tm_market_trailing_value_supported(value) -> bool:
+    try:
+        value = float(value)
+    except (TypeError, ValueError):
+        return False
+    with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+        packed = np.float32(value)
+    return (
+        math.isfinite(value)
+        and value > 0.0
+        and np.isfinite(packed)
+        and packed > 0.0
+    )
+
+
+def _validate_tm_multicoin_market_runtime_scope(
+    config: dict, enabled_sides
+) -> None:
+    """Reject multi-coin TM market features not modeled by this slice."""
+
+    unsupported = []
+    max_loss = float(config.get("live", {}).get("max_realized_loss_pct", 1.0))
+    if not math.isclose(max_loss, 1.0, abs_tol=1.0e-12):
+        unsupported.append(
+            f"live.max_realized_loss_pct={max_loss} (required 1.0)"
+        )
+    for side in sorted(set(enabled_sides or ())):
+        side_config = config.get("bot", {}).get(side, {}) or {}
+        risk = side_config.get("risk", {}) or {}
+        if bool(risk.get("position_exposure_enforcer_enabled", False)):
+            unsupported.append(
+                f"bot.{side}.risk.position_exposure_enforcer_enabled=true"
+            )
+        if bool(risk.get("total_exposure_enforcer_enabled", False)):
+            unsupported.append(
+                f"bot.{side}.risk.total_exposure_enforcer_enabled=true"
+            )
+        if bool((side_config.get("unstuck", {}) or {}).get("enabled", False)):
+            unsupported.append(f"bot.{side}.unstuck.enabled=true")
+        strategy = (
+            side_config.get("strategy", {}).get("trailing_martingale", {}) or {}
+        )
+        for branch in ("entry", "close"):
+            value = (strategy.get(branch, {}) or {}).get(
+                "retracement_base_pct", 0.0
+            )
+            if not _tm_market_trailing_value_supported(value):
+                unsupported.append(
+                    f"bot.{side}.strategy.trailing_martingale.{branch}."
+                    f"retracement_base_pct={value!r} (must remain trailing)"
+                )
+
+    overrides = config.get("coin_overrides", {}) or {}
+    if isinstance(overrides, dict):
+        for coin, patch in overrides.items():
+            if not isinstance(patch, dict):
+                continue
+            bot_patch = patch.get("bot", {}) or {}
+            if not isinstance(bot_patch, dict):
+                continue
+            for side in sorted(set(enabled_sides or ())):
+                side_patch = bot_patch.get(side, {}) or {}
+                if not isinstance(side_patch, dict):
+                    continue
+                risk_patch = side_patch.get("risk", {}) or {}
+                if not isinstance(risk_patch, dict):
+                    risk_patch = {}
+                if bool(
+                    risk_patch.get("position_exposure_enforcer_enabled", False)
+                ):
+                    unsupported.append(
+                        f"coin_overrides.{coin}.bot.{side}.risk."
+                        "position_exposure_enforcer_enabled=true"
+                    )
+                if bool(
+                    risk_patch.get("total_exposure_enforcer_enabled", False)
+                ):
+                    unsupported.append(
+                        f"coin_overrides.{coin}.bot.{side}.risk."
+                        "total_exposure_enforcer_enabled=true"
+                    )
+                unstuck_patch = side_patch.get("unstuck", {}) or {}
+                if not isinstance(unstuck_patch, dict):
+                    unstuck_patch = {}
+                if bool(unstuck_patch.get("enabled", False)):
+                    unsupported.append(
+                        f"coin_overrides.{coin}.bot.{side}.unstuck.enabled=true"
+                    )
+                strategy_root = side_patch.get("strategy", {}) or {}
+                strategy_patch = (
+                    strategy_root.get("trailing_martingale", {}) or {}
+                    if isinstance(strategy_root, dict)
+                    else {}
+                )
+                if not isinstance(strategy_patch, dict):
+                    strategy_patch = {}
+                for branch in ("entry", "close"):
+                    branch_patch = strategy_patch.get(branch, {}) or {}
+                    if not isinstance(branch_patch, dict):
+                        continue
+                    if "retracement_base_pct" not in branch_patch:
+                        continue
+                    value = branch_patch["retracement_base_pct"]
+                    if not _tm_market_trailing_value_supported(value):
+                        unsupported.append(
+                            f"coin_overrides.{coin}.bot.{side}.strategy."
+                            f"trailing_martingale.{branch}."
+                            f"retracement_base_pct={value!r} (must remain trailing)"
+                        )
+    if unsupported:
+        raise ValueError(
+            "GPU multi-coin Trailing Martingale ordinary market execution "
+            "currently supports wholly trailing ordinary entries and closes "
+            "without position/TWEL reducers, auto-unstuck, or realized-loss "
+            "gating; unsupported settings: "
+            + ", ".join(unsupported)
+        )
+
+
 def _validate_scope_config(
     config: dict,
     *,
@@ -967,10 +1086,9 @@ def _validate_scope_config(
                 "live.market_order_near_touch_threshold"
             )
         if coin_count > 1:
-            if strategy_kind != "ema_anchor":
-                raise ValueError(
-                    "GPU multicoin ordinary market execution currently supports "
-                    "EMA Anchor only"
+            if strategy_kind == "trailing_martingale":
+                _validate_tm_multicoin_market_runtime_scope(
+                    config, enabled_sides
                 )
     if bool(config.get("backtest", {}).get("filter_by_min_effective_cost")) and len(
         enabled_sides
@@ -2711,7 +2829,7 @@ def _validate_pinned_scope_bounds(
 
 
 def _validate_tm_market_mode_bounds(
-    bound_by_key, base_by_key, enabled_sides, config
+    bound_by_key, base_by_key, enabled_sides, config, *, coin_count: int = 1
 ) -> None:
     if (
         str(config.get("live", {}).get("strategy_kind", "")).strip().lower()
@@ -2736,10 +2854,15 @@ def _validate_tm_market_mode_bounds(
             and np.isfinite(packed_entry_low)
             and packed_entry_low > np.float32(0.0)
         )
+        mode_supported = (
+            trailing_only
+            if coin_count > 1
+            else recursive_only or trailing_only
+        )
         if (
             not math.isfinite(entry_low)
             or not math.isfinite(entry_high)
-            or not (recursive_only or trailing_only)
+            or not mode_supported
         ):
             unsupported.append(
                 f"{entry_key} bounds=({entry_low}, {entry_high})"
@@ -2760,35 +2883,98 @@ def _validate_tm_market_mode_bounds(
             and np.isfinite(packed_close_low)
             and packed_close_low > np.float32(0.0)
         )
+        mode_supported = (
+            trailing_only
+            if coin_count > 1
+            else recursive_only or trailing_only
+        )
         if (
             not math.isfinite(close_low)
             or not math.isfinite(close_high)
-            or not (recursive_only or trailing_only)
+            or not mode_supported
         ):
             unsupported.append(
                 f"{close_key} bounds=({close_low}, {close_high})"
             )
     if unsupported:
+        supported_modes = (
+            "wholly trailing with a float32-positive lower bound"
+            if coin_count > 1
+            else "wholly recursive (high<=0) or wholly trailing with a "
+            "float32-positive lower bound"
+        )
         raise ValueError(
             "GPU Trailing Martingale ordinary market execution currently "
             "requires each enabled side's entry retracement range to remain "
-            "wholly recursive (high<=0) or wholly trailing with a float32-"
-            "positive lower bound for both entry and close retracement. Entry "
-            "or close mode-crossing bounds remain fail closed: "
+            f"{supported_modes} for both entry and close retracement. Entry "
+            "or close unsupported/mode-crossing bounds remain fail closed: "
             + ", ".join(unsupported)
         )
 
 
 def _validate_tm_market_template_bounds(
-    bound_by_key, base_by_key, enabled_sides, config, suite_inputs
+    bound_by_key,
+    base_by_key,
+    enabled_sides,
+    config,
+    suite_inputs,
+    *,
+    coin_count: int = 1,
 ) -> None:
     """Validate a directly executed config, not a suite's override template."""
 
     if suite_inputs:
         return
     _validate_tm_market_mode_bounds(
-        bound_by_key, base_by_key, enabled_sides, config
+        bound_by_key,
+        base_by_key,
+        enabled_sides,
+        config,
+        coin_count=coin_count,
     )
+
+
+def _validate_tm_multicoin_market_foundation_bounds(
+    bound_by_key,
+    base_by_key,
+    enabled_sides,
+    config,
+    *,
+    coin_count: int,
+) -> None:
+    if (
+        coin_count <= 1
+        or str(config.get("live", {}).get("strategy_kind", "")).strip().lower()
+        != "trailing_martingale"
+        or not bool(config.get("live", {}).get("market_orders_allowed"))
+    ):
+        return
+    unsupported = []
+    for side in sorted(set(enabled_sides or ())):
+        for suffix in (
+            "risk_position_exposure_enforcer_enabled",
+            "risk_total_exposure_enforcer_enabled",
+            "unstuck_enabled",
+        ):
+            key = f"{side}_{suffix}"
+            bound = bound_by_key.get(key)
+            values = (
+                (float(bound.low), float(bound.high))
+                if bound is not None
+                else (float(base_by_key.get(key, 0.0)),) * 2
+            )
+            if any(
+                not math.isclose(value, 0.0, abs_tol=1.0e-12)
+                for value in values
+            ):
+                unsupported.append(f"{key} bounds={values}")
+    if unsupported:
+        raise ValueError(
+            "GPU multi-coin Trailing Martingale ordinary market execution "
+            "currently requires protective reducer enablement bounds pinned "
+            "at 0.0: "
+            + ", ".join(unsupported)
+        )
 
 
 def _validate_directional_search_space(
@@ -3312,6 +3498,14 @@ def run_backend(
         enabled_sides,
         proxy_config,
         suite_inputs,
+        coin_count=max_coin_count,
+    )
+    _validate_tm_multicoin_market_foundation_bounds(
+        bound_by_key,
+        base_by_key,
+        enabled_sides,
+        proxy_config,
+        coin_count=max_coin_count,
     )
     _validate_hsl_bound_contracts(bound_by_key, proxy_config)
 
@@ -3356,6 +3550,14 @@ def run_backend(
             scenario_base_by_key,
             scenario_enabled_sides,
             item["config"],
+            coin_count=item["coin_count"],
+        )
+        _validate_tm_multicoin_market_foundation_bounds(
+            scenario_bound_by_key,
+            scenario_base_by_key,
+            scenario_enabled_sides,
+            item["config"],
+            coin_count=item["coin_count"],
         )
         _validate_directional_search_space(
             scenario_bound_by_key,

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -1510,6 +1510,8 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
                 float(bool(hsl_panic_market_long)),
                 float(bool(hsl_panic_market_short)),
                 float(bool(hedge_mode)),
+                float(bool(market_orders_allowed)),
+                float(market_order_near_touch_threshold),
             ],
             dtype=torch.float32,
             device="mps",

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -75,6 +75,7 @@ from optimization.backends.gpu_backend import (
     _validate_seed_side_match,
     _validate_scope,
     _validate_tm_market_mode_bounds,
+    _validate_tm_multicoin_market_foundation_bounds,
     _validate_tm_market_template_bounds,
     _GPU_SUITE_METRICS_KEY,
     _GPU_SUITE_OBJECTIVES_KEY,
@@ -1701,6 +1702,47 @@ def test_gpu_tm_market_execution_accepts_recursive_close_mode_bounds(
     _validate_tm_market_mode_bounds(bounds, {}, {"long"}, config)
 
 
+@pytest.mark.parametrize("phase", ["entry", "close"])
+def test_gpu_multicoin_tm_market_execution_rejects_recursive_mode_bounds(phase):
+    config = _long_only_ema_config()
+    config["live"]["strategy_kind"] = "trailing_martingale"
+    config["live"]["market_orders_allowed"] = True
+    bounds = {
+        "long_entry_retracement_base_pct": Bound(0.001, 0.1),
+        "long_close_retracement_base_pct": Bound(0.001, 0.1),
+    }
+    bounds[f"long_{phase}_retracement_base_pct"] = Bound(0.0, 0.0)
+
+    with pytest.raises(ValueError, match="wholly trailing"):
+        _validate_tm_market_mode_bounds(
+            bounds, {}, {"long"}, config, coin_count=3
+        )
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        "unstuck_enabled",
+        "risk_position_exposure_enforcer_enabled",
+        "risk_total_exposure_enforcer_enabled",
+    ],
+)
+def test_gpu_multicoin_tm_market_execution_rejects_reducer_bounds(suffix):
+    config = _long_only_ema_config()
+    config["live"]["strategy_kind"] = "trailing_martingale"
+    config["live"]["market_orders_allowed"] = True
+    key = f"long_{suffix}"
+
+    with pytest.raises(ValueError, match=key):
+        _validate_tm_multicoin_market_foundation_bounds(
+            {key: Bound(0.0, 1.0)},
+            {},
+            {"long"},
+            config,
+            coin_count=3,
+        )
+
+
 @pytest.mark.parametrize("side", ["long", "short"])
 @pytest.mark.parametrize(
     "suffix",
@@ -1775,13 +1817,12 @@ def test_gpu_market_execution_fails_closed_outside_baseline_scope(
         _validate_scope(config, evaluator())
 
 
-def test_gpu_multicoin_tm_market_execution_remains_fail_closed():
+def test_gpu_multicoin_tm_market_execution_accepts_trailing_baseline():
     config = _directional_tm_config(long_enabled=True, short_enabled=False)
     config["live"]["approved_coins"]["long"] = ["BTC", "ETH"]
     config["live"]["market_orders_allowed"] = True
 
-    with pytest.raises(ValueError, match="supports EMA Anchor only"):
-        _validate_scope(config, _MulticoinEvaluator())
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
 @pytest.mark.parametrize(
@@ -2827,6 +2868,136 @@ def test_gpu_multicoin_ema_market_execution_accepts_protective_reducers(feature)
         }
 
     assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
+
+
+@pytest.mark.parametrize(
+    ("long_enabled", "short_enabled"),
+    [(True, False), (False, True), (True, True)],
+)
+def test_gpu_multicoin_tm_accepts_trailing_only_ordinary_market_execution(
+    long_enabled, short_enabled
+):
+    config = _directional_tm_config(
+        long_enabled=long_enabled, short_enabled=short_enabled
+    )
+    coins = ["BTC", "ETH", "SOL"]
+    config["live"]["approved_coins"] = {
+        side: coins if enabled else []
+        for side, enabled in (
+            ("long", long_enabled),
+            ("short", short_enabled),
+        )
+    }
+    config["live"]["market_orders_allowed"] = True
+    config["live"]["market_order_near_touch_threshold"] = 0.002
+    for side, enabled in (("long", long_enabled), ("short", short_enabled)):
+        if not enabled:
+            continue
+        strategy = config["bot"][side]["strategy"]["trailing_martingale"]
+        strategy["entry"]["retracement_base_pct"] = 0.01
+        strategy["close"]["retracement_base_pct"] = 0.01
+
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
+
+
+def test_gpu_multicoin_tm_market_execution_accepts_hsl():
+    config = _directional_tm_config(long_enabled=True, short_enabled=True)
+    coins = ["BTC", "ETH", "SOL"]
+    config["live"]["approved_coins"] = {"long": coins, "short": coins}
+    config["live"]["market_orders_allowed"] = True
+    for side in ("long", "short"):
+        strategy = config["bot"][side]["strategy"]["trailing_martingale"]
+        strategy["entry"]["retracement_base_pct"] = 0.01
+        strategy["close"]["retracement_base_pct"] = 0.01
+        config["bot"][side]["hsl"]["enabled"] = True
+
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
+
+
+@pytest.mark.parametrize(
+    ("feature", "message"),
+    [
+        ("loss_gate", "max_realized_loss_pct"),
+        ("position", "position_exposure_enforcer_enabled"),
+        ("twel", "total_exposure_enforcer_enabled"),
+        ("unstuck", "unstuck.enabled"),
+        ("override_unstuck", "coin_overrides.ETH"),
+    ],
+)
+def test_gpu_multicoin_tm_market_execution_fails_closed_for_reducers(
+    feature, message
+):
+    config = _directional_tm_config(long_enabled=True, short_enabled=False)
+    config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "SOL"]
+    config["live"]["market_orders_allowed"] = True
+    strategy = config["bot"]["long"]["strategy"]["trailing_martingale"]
+    strategy["entry"]["retracement_base_pct"] = 0.01
+    strategy["close"]["retracement_base_pct"] = 0.01
+    if feature == "loss_gate":
+        config["live"]["max_realized_loss_pct"] = 0.05
+    elif feature == "position":
+        config["bot"]["long"]["risk"][
+            "position_exposure_enforcer_enabled"
+        ] = True
+    elif feature == "twel":
+        config["bot"]["long"]["risk"][
+            "total_exposure_enforcer_enabled"
+        ] = True
+    elif feature == "unstuck":
+        config["bot"]["long"]["unstuck"]["enabled"] = True
+    else:
+        config["coin_overrides"] = {
+            "ETH": {"bot": {"long": {"unstuck": {"enabled": True}}}}
+        }
+
+    with pytest.raises(ValueError, match=message):
+        _validate_scope(config, _MulticoinEvaluator())
+
+
+@pytest.mark.parametrize("branch", ["entry", "close"])
+def test_gpu_multicoin_tm_market_execution_fails_closed_for_recursive_mode(branch):
+    config = _directional_tm_config(long_enabled=True, short_enabled=False)
+    config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "SOL"]
+    config["live"]["market_orders_allowed"] = True
+    strategy = config["bot"]["long"]["strategy"]["trailing_martingale"]
+    strategy["entry"]["retracement_base_pct"] = 0.01
+    strategy["close"]["retracement_base_pct"] = 0.01
+    strategy[branch]["retracement_base_pct"] = 0.0
+
+    with pytest.raises(ValueError, match=f"{branch}.*must remain trailing"):
+        _validate_scope(config, _MulticoinEvaluator())
+
+
+@pytest.mark.parametrize("branch", ["entry", "close"])
+@pytest.mark.parametrize("value", [0.005, 0.0])
+def test_gpu_multicoin_tm_market_execution_validates_static_override_modes(
+    branch, value
+):
+    config = _directional_tm_config(long_enabled=True, short_enabled=False)
+    config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "SOL"]
+    config["live"]["market_orders_allowed"] = True
+    strategy = config["bot"]["long"]["strategy"]["trailing_martingale"]
+    strategy["entry"]["retracement_base_pct"] = 0.01
+    strategy["close"]["retracement_base_pct"] = 0.01
+    config["coin_overrides"] = {
+        "ETH": {
+            "bot": {
+                "long": {
+                    "strategy": {
+                        "trailing_martingale": {
+                            branch: {"retracement_base_pct": value}
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if value > 0.0:
+        assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
+    else:
+        with pytest.raises(ValueError, match=f"{branch}.*must remain trailing"):
+            _validate_scope(config, _MulticoinEvaluator())
 
 
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -2954,6 +2954,25 @@ def test_gpu_multicoin_tm_market_execution_fails_closed_for_reducers(
         _validate_scope(config, _MulticoinEvaluator())
 
 
+@pytest.mark.parametrize(
+    "max_realized_loss_pct",
+    [np.nextafter(1.0, 0.0), 0.9999999995, 1.0000000005],
+)
+def test_gpu_multicoin_tm_market_execution_requires_exact_disabled_loss_gate(
+    max_realized_loss_pct,
+):
+    config = _directional_tm_config(long_enabled=True, short_enabled=False)
+    config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "SOL"]
+    config["live"]["market_orders_allowed"] = True
+    config["live"]["max_realized_loss_pct"] = max_realized_loss_pct
+    strategy = config["bot"]["long"]["strategy"]["trailing_martingale"]
+    strategy["entry"]["retracement_base_pct"] = 0.01
+    strategy["close"]["retracement_base_pct"] = 0.01
+
+    with pytest.raises(ValueError, match="max_realized_loss_pct"):
+        _validate_scope(config, _MulticoinEvaluator())
+
+
 @pytest.mark.parametrize("branch", ["entry", "close"])
 def test_gpu_multicoin_tm_market_execution_fails_closed_for_recursive_mode(branch):
     config = _directional_tm_config(long_enabled=True, short_enabled=False)

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -1754,14 +1754,16 @@ kernel void passivbot_tm_multicoin_order_phase_probe(
         bars, touch_ticks, touch_nearest_ticks,
         touch_min_qty_bits, touch_min_qty_relation,
         coin_settings, coin_overrides,
-        1, 1, false, 1, 1, 0, false, 1.0f, -2, 0ul
+        1, 1, false, 1, 1, 0, false, 1.0f,
+        false, 0.001f, -2, 0ul
     );
     generate_tm_multicoin_side_orders(
         short_side, short_config, account,
         bars, touch_ticks, touch_nearest_ticks,
         touch_min_qty_bits, touch_min_qty_relation,
         coin_settings, coin_overrides,
-        1, 1, true, 1, 1, 0, false, 1.0f, -2, 0ul
+        1, 1, true, 1, 1, 0, false, 1.0f,
+        false, 0.001f, -2, 0ul
     );
     output[0] = long_side.entry_qty[0];
     output[1] = short_side.entry_qty[0];
@@ -1776,7 +1778,8 @@ kernel void passivbot_tm_multicoin_order_phase_probe(
         bars, touch_ticks, touch_nearest_ticks,
         touch_min_qty_bits, touch_min_qty_relation,
         coin_settings, coin_overrides,
-        1, 1, false, 1, 1, 0, false, 1.0f, -2, 1ul
+        1, 1, false, 1, 1, 0, false, 1.0f,
+        false, 0.001f, -2, 1ul
     );
     output[8] = long_side.entry_qty[0];
     output[9] = long_side.entry_candidate[0] ? 1.0f : 0.0f;
@@ -5051,6 +5054,164 @@ def test_mps_ema_multicoin_market_entry_uses_stored_next_close_intent(side):
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_trailing_market_entry_uses_stored_next_close_intent(side):
+    count = 5
+    base = np.asarray([100.0, 120.0])
+    closes = np.tile(base, (count, 1))
+    closes[-1] *= 1.1 if side == "long" else 0.9
+    markets = [
+        ProxyMarket(
+            0.001,
+            0.01,
+            0.001,
+            0.0,
+            1.0,
+            maker_fee=0.0,
+            taker_fee=0.01,
+        )
+        for _ in range(2)
+    ]
+    resting_runner, row = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        side,
+        count=count,
+        closes=closes,
+        highs=closes,
+        lows=closes,
+        markets=markets,
+        collect_coin_fill_counts=True,
+    )
+    market_runner, _ = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        side,
+        count=count,
+        closes=closes,
+        highs=closes,
+        lows=closes,
+        markets=markets,
+        collect_coin_fill_counts=True,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.001,
+        market_order_slippage_pct=0.01,
+    )
+    row[
+        TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(
+            "entry_retracement_base_pct"
+        )
+    ] = 0.01
+    row[
+        TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(
+            "close_retracement_base_pct"
+        )
+    ] = 0.01
+    row[
+        TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(
+            "entry_initial_ema_dist"
+        )
+    ] = 0.0005
+    row[
+        TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(
+            "entry_cooldown_minutes"
+        )
+    ] = 100.0
+    params = np.asarray([row], dtype=np.float64)
+
+    resting = resting_runner.run(params)
+    promoted = market_runner.run(params)
+    torch.mps.synchronize()
+
+    assert market_runner.settings[9].item() == 1.0
+    assert market_runner.settings[10].item() == pytest.approx(0.001)
+    assert resting["fill_count"].item() == 0.0
+    assert promoted["fill_count"].item() == 2.0
+    assert promoted["open_positions"].item() == 2.0
+    assert promoted["coin_fill_counts"].cpu().tolist() == [[1.0, 1.0]]
+    assert promoted["balance"].item() < 1_000.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_trailing_market_close_uses_stored_next_close_intent(side):
+    count = 8
+    base = np.asarray([100.0, 120.0])
+    closes = np.tile(base, (count, 1))
+    highs = closes.copy()
+    lows = closes.copy()
+    if side == "long":
+        closes[5] = base * 1.08
+        highs[5] = base * 1.10
+        lows[5] = base * 1.08
+        closes[6] = base * 0.90
+        highs[6] = closes[6]
+        lows[6] = closes[6]
+    else:
+        closes[5] = base * 0.92
+        highs[5] = base * 0.92
+        lows[5] = base * 0.90
+        closes[6] = base * 1.10
+        highs[6] = closes[6]
+        lows[6] = closes[6]
+    markets = [
+        ProxyMarket(
+            0.001,
+            0.01,
+            0.001,
+            0.0,
+            1.0,
+            maker_fee=0.0,
+            taker_fee=0.01,
+        )
+        for _ in range(2)
+    ]
+    runner, row = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        side,
+        count=count,
+        closes=closes,
+        highs=highs,
+        lows=lows,
+        markets=markets,
+        collect_coin_fill_counts=True,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.001,
+        market_order_slippage_pct=0.01,
+    )
+    for key, value in {
+        "entry_initial_ema_dist": 0.0005,
+        "entry_threshold_base_pct": 10.0,
+        "entry_retracement_base_pct": 0.01,
+        "close_qty_pct": 1.0,
+        "close_threshold_base_pct": 0.02,
+        "close_retracement_base_pct": 0.01,
+        "entry_cooldown_minutes": 100.0,
+    }.items():
+        row[TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(key)] = value
+    params = np.asarray([row, row], dtype=np.float64)
+
+    output = runner.run(
+        params,
+        end_steps=np.asarray([count - 2, count - 1], dtype=np.int32),
+    )
+    torch.mps.synchronize()
+
+    assert output["fill_count"].cpu().tolist() == [2.0, 4.0]
+    assert output["fill_count_entry"].cpu().tolist() == [2.0, 2.0]
+    assert output["coin_fill_counts"].cpu().tolist() == [
+        [1.0, 1.0],
+        [2.0, 2.0],
+    ]
+    size_key = "psize" if side == "long" else "short_psize"
+    assert output[size_key][0].item() > 0.0
+    assert output[size_key][1].item() == 0.0
+    assert output["balance"][1].item() < output["balance"][0].item()
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 def test_mps_ema_multicoin_short_market_entry_uses_executable_minimum():
     count = 5
     closes = np.tile(np.asarray([100.0, 120.0]), (count, 1))
@@ -5078,6 +5239,48 @@ def test_mps_ema_multicoin_short_market_entry_uses_executable_minimum():
     params = np.asarray([row], dtype=np.float64)
 
     output = runner.run(params)
+    torch.mps.synchronize()
+
+    assert output["fill_count"].item() == 1.0
+    assert output["fill_count_entry"].item() == 1.0
+    assert output["coin_fill_counts"].cpu().tolist() == [[1.0, 0.0]]
+    assert output["short_psize"].item() == pytest.approx(1.001)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_tm_multicoin_short_market_entry_uses_executable_minimum():
+    count = 5
+    closes = np.tile(np.asarray([100.0, 120.0]), (count, 1))
+    markets = [
+        ProxyMarket(0.001, 0.01, 0.001, 100.04, 1.0, 0.0),
+        ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0),
+    ]
+    overrides = np.full((2, 44), np.nan, dtype=np.float32)
+    overrides[1, 24] = 0.0
+    runner, row = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        "short",
+        coin_overrides=overrides,
+        count=count,
+        closes=closes,
+        highs=closes,
+        lows=closes,
+        markets=markets,
+        collect_coin_fill_counts=True,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.001,
+    )
+    for key, value in {
+        "entry_initial_qty_pct": 0.0001,
+        "entry_initial_ema_dist": 0.0005,
+        "entry_retracement_base_pct": 0.01,
+        "close_retracement_base_pct": 0.01,
+    }.items():
+        row[TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(key)] = value
+
+    output = runner.run(np.asarray([row], dtype=np.float64))
     torch.mps.synchronize()
 
     assert output["fill_count"].item() == 1.0
@@ -5129,6 +5332,59 @@ def test_mps_ema_multicoin_market_entry_cap_uses_market_touch(side):
     assert promoted["fill_count"].item() == 2.0
     expected_size = 1.998 if side == "long" else 1.996
     assert promoted[size_key].item() == pytest.approx(expected_size)
+    assert promoted["total_wallet_exposure_max"].item() == pytest.approx(
+        expected_size * 100.0 / 1_000.0
+    )
+    assert promoted["total_wallet_exposure_max"].item() < 0.2
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_market_entry_cap_uses_market_touch(side):
+    count = 5
+    closes = np.full((count, 2), 100.0)
+    highs = closes.copy()
+    lows = closes.copy()
+    if side == "long":
+        lows[-1] = 99.0
+    else:
+        highs[-1] = 101.0
+    markets = [
+        ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
+        for _ in range(2)
+    ]
+    market_runner, row = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        side,
+        count=count,
+        closes=closes,
+        highs=highs,
+        lows=lows,
+        markets=markets,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.003,
+    )
+    for key, value in {
+        "entry_initial_qty_pct": 1.0,
+        "entry_initial_ema_dist": 0.002,
+        "entry_retracement_base_pct": 0.01,
+        "close_retracement_base_pct": 0.01,
+        "total_wallet_exposure_limit": 0.2,
+        "n_positions": 2.0,
+    }.items():
+        row[TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(key)] = value
+
+    promoted = market_runner.run(np.asarray([row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    assert promoted["fill_count"].item() == 2.0
+    expected_size = 1.999
+    assert promoted[size_key].item() == pytest.approx(expected_size)
+    passive_limit_size = 2.003 if side == "long" else 1.995
+    assert promoted[size_key].item() != pytest.approx(passive_limit_size)
     assert promoted["total_wallet_exposure_max"].item() == pytest.approx(
         expected_size * 100.0 / 1_000.0
     )
@@ -5278,6 +5534,90 @@ def test_mps_ema_multicoin_fused_market_execution_covers_both_sides():
         < promoted["short_psize"][0].item()
     )
     assert promoted["balance"][1].item() < promoted["balance"][0].item()
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("hedge_mode", [True, False])
+def test_mps_tm_multicoin_fused_trailing_market_entries_respect_position_mode(
+    hedge_mode,
+):
+    count = 5
+    closes = np.tile(np.asarray([100.0, 120.0]), (count, 1))
+    markets = [
+        ProxyMarket(
+            0.001,
+            0.01,
+            0.001,
+            0.0,
+            1.0,
+            maker_fee=0.0,
+            taker_fee=0.01,
+        )
+        for _ in range(2)
+    ]
+    _, row, run, data = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        "long",
+        count=count,
+        closes=closes,
+        highs=closes,
+        lows=closes,
+        markets=markets,
+        return_context=True,
+    )
+    for key, value in {
+        "entry_initial_ema_dist": 0.0005,
+        "entry_retracement_base_pct": 0.01,
+        "close_retracement_base_pct": 0.01,
+        "entry_cooldown_minutes": 100.0,
+    }.items():
+        row[TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(key)] = value
+    params = np.asarray([row + row], dtype=np.float64)
+    overrides = np.full((2, 44), np.nan, dtype=np.float32)
+    resting_runner = MpsTrailingMartingaleMulticoinFusedRunner(
+        run,
+        data,
+        long_coin_overrides=overrides,
+        short_coin_overrides=overrides,
+        collect_coin_fill_counts=True,
+        hedge_mode=hedge_mode,
+    )
+    market_runner = MpsTrailingMartingaleMulticoinFusedRunner(
+        run,
+        data,
+        long_coin_overrides=overrides,
+        short_coin_overrides=overrides,
+        collect_coin_fill_counts=True,
+        hedge_mode=hedge_mode,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.001,
+        market_order_slippage_pct=0.01,
+    )
+
+    resting = resting_runner.run(params)
+    promoted = market_runner.run(params)
+    torch.mps.synchronize()
+
+    assert market_runner.settings[11].item() == 1.0
+    assert market_runner.settings[12].item() == pytest.approx(0.001)
+    assert resting["fill_count"].item() == 0.0
+    expected_fills = 4.0 if hedge_mode else 2.0
+    assert promoted["fill_count"].item() == expected_fills
+    assert promoted["fill_count_entry"].item() == expected_fills
+    expected_coin_fills = [2.0, 2.0] if hedge_mode else [1.0, 1.0]
+    assert promoted["coin_fill_counts"].cpu().tolist() == [expected_coin_fills]
+    if hedge_mode:
+        assert promoted["fill_count_long"].item() == 2.0
+        assert promoted["psize"].item() > 0.0
+        assert promoted["short_psize"].item() > 0.0
+    else:
+        assert promoted["fill_count_long"].item() in (0.0, 2.0)
+        assert (promoted["psize"].item() > 0.0) != (
+            promoted["short_psize"].item() > 0.0
+        )
+    assert promoted["balance"].item() < 1_000.0
 
 
 @pytest.mark.skipif(
@@ -5968,7 +6308,21 @@ def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
         (coin_count, 44), float("nan"), dtype=torch.float32, device="mps"
     )
     run_settings = torch.tensor(
-        [1_000.0, 50.0, 60_000.0, 0.0, 0.02, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+        [
+            1_000.0,
+            50.0,
+            60_000.0,
+            0.0,
+            0.02,
+            1.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.001,
+        ],
         dtype=torch.float32,
         device="mps",
     )


### PR DESCRIPTION
## Summary
- add baseline ordinary market execution to the multi-coin Trailing Martingale Metal proxy for long-only, short-only, fused long+short, hedge, and one-way runs
- retain generation-time market intent through the next valid candle, apply adverse directional slippage/taker fees, executable-touch minimum sizing, and market-touch portfolio entry allocation
- keep recursive entry/close modes, exposure reducers, auto-unstuck, and realized-loss gating fail closed until their dedicated parity slices
- document the supported scope and add runtime/bounds/static-override rejection coverage

Exact Rust remains authoritative; the CPU optimizer and normal bot/backtest paths are unchanged.

## Validation
- `cargo test --no-default-features` (267 passed)
- `cargo check --tests`
- full non-MPS Python suite
- `pytest -q tests/optimization/test_gpu_backend.py`
- full physical Apple M3 MPS suite (401 passed)
- Rust source fingerprint and isolated ABI3 artifact stamp match
- cached Bybit BTC+ETH HSL long-only smoke: 576 proxy / 72 exact
- cached Bybit BTC+ETH HSL fused long+short one-way smoke: 576 proxy / 72 exact
- `python src/tools/check_ai_docs.py`
- `python -m compileall -q src tests/optimization/test_gpu_backend.py tests/optimization/test_gpu_mps.py`
- `git diff --check`