### PR TITLE
Add multi-coin TM recursive market closes on MPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,17 @@ All notable user-facing changes will be documented in this file.
 
 - Added baseline multi-coin Trailing Martingale ordinary market execution to Apple MPS
   optimization for long-only, short-only, fused long+short, hedge-mode, one-way, and compatible
-  suite runs whose entry and close modes remain wholly trailing. Metal retains generation-time
+  suite runs whose entry modes remain wholly trailing and whose close modes remain wholly
+  trailing or wholly recursive. Metal retains generation-time
   market intent, executes promoted orders on the next valid candle with adverse directional
   slippage and taker fees, applies executable-touch minimum sizing to short entries and all closes,
-  and prices the strict portfolio entry cap at the market touch. HSL, static coin overrides, and
-  forager selection remain supported. Recursive entry and close ladders, position- and
-  total-exposure repair, auto-unstuck, and realized-loss gating remain fail closed in multi-coin
-  Trailing Martingale market mode pending dedicated parity slices.
+  and prices the strict portfolio entry cap at the market touch. For recursive closes, passive
+  next-candle reachability alone decides whether to emit only the next close or the immutable
+  recursive suffix; an emitted suffix promotes and minimum-sizes each merged group against its
+  generation market before aggregate position trimming. Static coin overrides may select trailing
+  or recursive close mode independently. HSL and forager selection remain supported. Recursive
+  entry ladders, position- and total-exposure repair, auto-unstuck, and realized-loss gating remain
+  fail closed in multi-coin Trailing Martingale market mode pending dedicated parity slices.
 
 - Added baseline multi-coin EMA Anchor ordinary market execution to Apple MPS optimization for
   long-only, short-only, and fused long+short runs. The proxy retains generation-time entry and

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -323,14 +323,18 @@ The supported slice is intentionally narrow:
   their market slippage and taker fees are included in the projected loss. Static coin overrides
   may enable or tune unstuck. Multi-coin Trailing Martingale supports ordinary market entries and
   ordinary strategy closes for long-only, short-only, fused long+short, hedge-mode, one-way, and
-  compatible suite runs when every enabled entry and close retracement range remains wholly
-  trailing with a float32-positive lower bound. It uses the same retained generation-time intent,
-  next-valid-candle adverse fill, taker-fee, executable-touch minimum sizing for short entries and
-  all closes, and portfolio entry-cap accounting contract. HSL, static coin overrides, and forager
-  selection remain supported.
-  Recursive entry or close modes, position- and total-exposure repair, auto-unstuck, and
-  realized-loss gating remain fail closed for multi-coin Trailing Martingale market mode until
-  their market interactions are modeled
+  compatible suite runs when every enabled entry retracement range remains wholly trailing with a
+  float32-positive lower bound and every close retracement range remains wholly recursive or
+  wholly trailing. Static coin overrides may select either supported close mode per coin. It uses
+  the same retained generation-time intent, next-valid-candle adverse fill, taker-fee,
+  executable-touch minimum sizing for short entries and all closes, and portfolio entry-cap
+  accounting contract. Passive next-candle reachability alone exposes a recursive close suffix;
+  market promotion cannot expose an otherwise unexpanded ladder. Every emitted duplicate-merged
+  group is classified and minimum-sized against the immutable generation market before aggregate
+  trimming to the position. HSL, static coin overrides, and forager selection remain supported.
+  Recursive entry modes, position- and total-exposure repair, auto-unstuck, and realized-loss
+  gating remain fail closed for multi-coin Trailing Martingale market mode until their market
+  interactions are modeled
 - no invalid candle tail after the selected coin's final valid candle
 
 Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor and

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -227,6 +227,7 @@ struct CloseGroup {
     int ticks;
     float price;
     float qty;
+    bool market;
 };
 
 // Rebuild Rust's post-reducer recursive grid and return its number of
@@ -258,11 +259,16 @@ inline int recursive_grid_close_groups_after_reducer(
     float c_mult,
     int max_rungs,
     int wanted_group,
+    float generation_market_price,
+    bool market_orders_allowed,
+    float market_order_near_touch_threshold,
+    float market_resize_psize,
     thread CloseGroup& selected
 ) {
     selected.ticks = 0;
     selected.price = 0.0f;
     selected.qty = 0.0f;
+    selected.market = false;
     float sim_psize = psize;
     bool have_group = false;
     int group_count = 0;
@@ -336,7 +342,101 @@ inline int recursive_grid_close_groups_after_reducer(
         }
         ++group_count;
     }
+    if (selected.qty > 0.0f && selected.ticks > 0) {
+        selected.market = should_use_ordinary_market_execution(
+            selected.ticks, short_side, generation_market_price,
+            price_step, market_orders_allowed,
+            market_order_near_touch_threshold
+        );
+        if (selected.market) {
+            selected.qty = resize_market_close_qty(
+                selected.qty, market_resize_psize,
+                generation_market_price,
+                qty_step, min_qty, min_cost, c_mult
+            );
+        }
+    }
     return group_count;
+}
+
+// Exact Rust decides whether to expose a recursive close suffix from the
+// immutable passive strategy ladder. Market promotion is intentionally absent
+// here: a market-only next close must fill by itself and must not reveal later
+// recursive rungs.
+inline bool recursive_grid_close_would_expand(
+    bool short_side,
+    float psize,
+    float pprice,
+    float generation_balance,
+    float allowed_wel,
+    int touch_down,
+    int touch_up,
+    int touch_nearest,
+    float touch_min_qty,
+    int touch_min_qty_relation,
+    float close_qty_pct,
+    float close_threshold_base,
+    float close_threshold_we,
+    float close_threshold_v1h,
+    float close_threshold_v1m,
+    float volatility_1h,
+    float volatility_1m,
+    float qty_step,
+    float price_step,
+    float min_qty,
+    float min_cost,
+    float c_mult,
+    int max_rungs,
+    int high_fill_max_tick,
+    int low_nonfill_max_tick
+) {
+    float sim_psize = psize;
+    for (int rung = 0; rung < max_rungs && sim_psize > 0.0f; ++rung) {
+        float we = sim_psize * pprice * c_mult
+            / fmax(generation_balance, 1.0e-9f);
+        float wer = we / fmax(allowed_wel, 1.0e-12f);
+        float threshold = close_threshold_base
+            + wer * close_threshold_we
+            + volatility_1h * close_threshold_v1h
+            + volatility_1m * close_threshold_v1m;
+        float target = pprice * (
+            short_side ? 1.0f - threshold : 1.0f + threshold
+        );
+        int target_tick = short_side
+            ? int(floor(target / price_step + 1.0e-6f))
+            : int(ceil(target / price_step - 1.0e-6f));
+        int close_touch = short_side ? touch_down : touch_up;
+        bool touch_controls = short_side
+            ? close_touch < target_tick : close_touch > target_tick;
+        int order_tick = touch_controls ? touch_nearest : target_tick;
+        float order_price = float(order_tick) * price_step;
+        float minimum_close = touch_controls
+            ? touch_min_qty
+            : min_entry_qty(
+                order_price, qty_step, min_qty, min_cost, c_mult
+            );
+        int minimum_relation = touch_controls ? touch_min_qty_relation : 0;
+        float close_pct = close_threshold_we == 0.0f
+            ? 1.0f : close_qty_pct;
+        float order_qty = round_step(
+            calc_close_qty(
+                sim_psize, pprice, generation_balance, allowed_wel,
+                minimum_close, minimum_relation, close_pct,
+                qty_step, c_mult
+            ),
+            qty_step
+        );
+        if (order_qty <= 0.0f || order_tick <= 0) break;
+        bool reachable = short_side
+            ? order_tick > low_nonfill_max_tick
+            : order_tick <= high_fill_max_tick;
+        if (reachable) return true;
+        sim_psize = fmax(
+            round_step(sim_psize - fmin(order_qty, sim_psize), qty_step),
+            0.0f
+        );
+    }
+    return false;
 }
 
 // One complete directional Trailing Martingale portfolio. Keeping the mutable
@@ -371,6 +471,7 @@ struct TrailingMartingaleMulticoinSideState {
     float unstuck_close_qty[MAX_COINS];
     float close_gen_balance[MAX_COINS];
     float close_gen_allowed_wel[MAX_COINS];
+    float close_gen_market_price[MAX_COINS];
     float close_grid_gen_psize[MAX_COINS];
     float position_open_k[MAX_COINS];
     float position_last_fill_k[MAX_COINS];
@@ -392,6 +493,7 @@ struct TrailingMartingaleMulticoinSideState {
     bool survivor[MAX_COINS];
     bool entry_candidate[MAX_COINS];
     bool close_reconstruct_after_reducer[MAX_COINS];
+    bool close_recursive_market_mode[MAX_COINS];
     bool filled_coin[MAX_COINS];
     bool entry_market[MAX_COINS];
     bool close_market[MAX_COINS];
@@ -653,6 +755,7 @@ inline void finalize_tm_multicoin_close_position(
     side.close_market[coin] = false;
     side.secondary_close_market[coin] = false;
     side.close_reconstruct_after_reducer[coin] = false;
+    side.close_recursive_market_mode[coin] = false;
     side.close_is_unstuck_reducer[coin] = false;
     side.close_is_hsl_panic[coin] = false;
     side.filled_coin[coin] = true;
@@ -724,6 +827,7 @@ inline bool process_tm_multicoin_side_fills(
     bool loss_gate_enabled,
     float max_realized_loss_pct,
     float market_order_slippage_pct,
+    float market_order_near_touch_threshold,
     bool hsl_panic_market,
     thread float& hsl_equity_before_fills
 ) {
@@ -742,6 +846,7 @@ inline bool process_tm_multicoin_side_fills(
     thread float* secondary_close_qty = side.secondary_close_qty;
     thread float* close_gen_balance = side.close_gen_balance;
     thread float* close_gen_allowed_wel = side.close_gen_allowed_wel;
+    thread float* close_gen_market_price = side.close_gen_market_price;
     thread float* close_grid_gen_psize = side.close_grid_gen_psize;
     thread int* entry_tick = side.entry_tick;
     thread int* close_tick = side.close_tick;
@@ -749,6 +854,8 @@ inline bool process_tm_multicoin_side_fills(
     thread int* close_grid_max_rungs = side.close_grid_max_rungs;
     thread bool* close_reconstruct_after_reducer =
         side.close_reconstruct_after_reducer;
+    thread bool* close_recursive_market_mode =
+        side.close_recursive_market_mode;
     thread bool* filled_coin = side.filled_coin;
     thread bool* entry_market = side.entry_market;
     thread bool* close_market = side.close_market;
@@ -801,10 +908,47 @@ inline bool process_tm_multicoin_side_fills(
             && (secondary_close_market[c] || (short_side
                 ? secondary_close_tick[c] > fill_ticks[tick_offset + 1]
                 : secondary_close_tick[c] <= fill_ticks[tick_offset + 0]));
+        bool recursive_market_expand = psize[c] > 0.0f
+            && close_recursive_market_mode[c]
+            && !close_is_hsl_panic[c]
+            && recursive_grid_close_would_expand(
+                short_side,
+                close_grid_gen_psize[c],
+                pprice[c],
+                close_gen_balance[c],
+                close_gen_allowed_wel[c],
+                touch_ticks[((k - 1) * C + c) * 2 + 0],
+                touch_ticks[((k - 1) * C + c) * 2 + 1],
+                touch_nearest_ticks[(k - 1) * C + c],
+                as_type<float>(touch_min_qty_bits[(k - 1) * C + c]),
+                touch_min_qty_relation[(k - 1) * C + c],
+                coin_override_or(coin_overrides, c, 15, close_qty_pct),
+                coin_override_or(
+                    coin_overrides, c, 16, close_threshold_base
+                ),
+                coin_override_or(coin_overrides, c, 17, close_threshold_we),
+                coin_override_or(
+                    coin_overrides, c, 18, close_threshold_v1h
+                ),
+                coin_override_or(
+                    coin_overrides, c, 19, close_threshold_v1m
+                ),
+                volatility_1h[c],
+                volatility_1m[c],
+                qty_step,
+                price_step,
+                min_qty,
+                min_cost,
+                c_mult,
+                close_grid_max_rungs[c],
+                fill_ticks[tick_offset + 0],
+                fill_ticks[tick_offset + 1]
+            );
         bool rebuild_grid = psize[c] > 0.0f
             && close_reconstruct_after_reducer[c]
-            && !close_market[c]
+            && (!close_recursive_market_mode[c] || recursive_market_expand)
             && !close_is_hsl_panic[c];
+        if (recursive_market_expand) filled_close = false;
         if (filled_close || filled_secondary_close || rebuild_grid) {
             float fill_price = primary_market
                 ? ordinary_market_fill_price(
@@ -812,9 +956,10 @@ inline bool process_tm_multicoin_side_fills(
                     market_order_slippage_pct, price_step
                 )
                 : float(close_tick[c]) * price_step;
-            float reducer_qty = fmin(
-                round_step(close_qty[c], qty_step), psize[c]
-            );
+            float reducer_qty = rebuild_grid
+                    && close_recursive_market_mode[c]
+                ? 0.0f
+                : fmin(round_step(close_qty[c], qty_step), psize[c]);
             float grid_gen_psize = close_grid_gen_psize[c];
             int gen_tick_offset = 0;
             float coin_close_qty_pct = 0.0f;
@@ -870,6 +1015,10 @@ inline bool process_tm_multicoin_side_fills(
                     c_mult,
                     close_grid_max_rungs[c],
                     -1,
+                    close_gen_market_price[c],
+                    close_recursive_market_mode[c],
+                    market_order_near_touch_threshold,
+                    grid_gen_psize,
                     group
                 );
                 reverse = coin_close_threshold_we > 0.0f;
@@ -912,11 +1061,16 @@ inline bool process_tm_multicoin_side_fills(
                     c_mult,
                     close_grid_max_rungs[c],
                     wanted,
+                    close_gen_market_price[c],
+                    close_recursive_market_mode[c],
+                    market_order_near_touch_threshold,
+                    grid_gen_psize,
                     group
                 );
                 float trimmed_qty = fmin(group.qty, remaining_budget);
                 float group_min = min_entry_qty(
-                    group.price, qty_step, min_qty, min_cost, c_mult
+                    group.market ? close_gen_market_price[c] : group.price,
+                    qty_step, min_qty, min_cost, c_mult
                 );
                 bool partial_trim = trimmed_qty + 1.0e-6f < group.qty;
                 if (trimmed_qty + 1.0e-6f < group_min) {
@@ -978,11 +1132,16 @@ inline bool process_tm_multicoin_side_fills(
                     c_mult,
                     close_grid_max_rungs[c],
                     wanted,
+                    close_gen_market_price[c],
+                    close_recursive_market_mode[c],
+                    market_order_near_touch_threshold,
+                    grid_gen_psize,
                     group
                 );
                 if (group.qty <= 0.0f) break;
                 float group_min = min_entry_qty(
-                    group.price, qty_step, min_qty, min_cost, c_mult
+                    group.market ? close_gen_market_price[c] : group.price,
+                    qty_step, min_qty, min_cost, c_mult
                 );
                 float trimmed_group_qty = fmin(
                     group.qty, remaining_budget
@@ -1042,26 +1201,33 @@ inline bool process_tm_multicoin_side_fills(
                         executed_close = true;
                     }
                 }
-                bool reachable = short_side
+                bool reachable = group.market || (short_side
                     ? group.ticks > fill_ticks[tick_offset + 1]
-                    : group.ticks <= fill_ticks[tick_offset + 0];
+                    : group.ticks <= fill_ticks[tick_offset + 0]);
                 if (!reachable) break;
                 float group_qty = trimmed_group_qty;
                 if (group_qty <= 0.0f) continue;
                 float grid_qty = fmin(
                     round_step(group_qty, qty_step), psize[c]
                 );
+                float group_fill_price = group.market
+                    ? ordinary_market_fill_price(
+                        close, short_side,
+                        market_order_slippage_pct, price_step
+                    )
+                    : group.price;
+                float group_fee_rate = group.market ? taker_fee : maker_fee;
                 float grid_pnl = grid_qty * c_mult * (short_side
-                    ? pprice[c] - group.price
-                    : group.price - pprice[c]);
+                    ? pprice[c] - group_fill_price
+                    : group_fill_price - pprice[c]);
                 if (!realized_loss_proxy_allows_close(
-                        grid_qty, group.price, pprice[c], short_side,
-                        c_mult, maker_fee, loss_gate_enabled
+                        grid_qty, group_fill_price, pprice[c], short_side,
+                        c_mult, group_fee_rate, loss_gate_enabled
                     )) {
                     continue;
                 }
                 float grid_net_pnl = grid_pnl
-                    - grid_qty * group.price * c_mult * maker_fee;
+                    - grid_qty * group_fill_price * c_mult * group_fee_rate;
                 record_tm_multicoin_close_fill(
                     side, account, fills, coin_fill_counts,
                     int(b), C, c, k, grid_pnl, grid_net_pnl,
@@ -1072,7 +1238,7 @@ inline bool process_tm_multicoin_side_fills(
                 psize[c] = fmax(
                     round_step(psize[c] - grid_qty, qty_step), 0.0f
                 );
-                day_volume += grid_qty * group.price * c_mult / balance;
+                day_volume += grid_qty * group_fill_price * c_mult / balance;
                 executed_close = true;
                 if (psize[c] <= 0.0f) break;
             }
@@ -1299,6 +1465,7 @@ inline void init_trailing_martingale_multicoin_side_state(
         side.unstuck_close_qty[c] = 0.0f;
         side.close_gen_balance[c] = 0.0f;
         side.close_gen_allowed_wel[c] = 0.0f;
+        side.close_gen_market_price[c] = 0.0f;
         side.close_grid_gen_psize[c] = 0.0f;
         side.position_open_k[c] = -1.0f;
         side.position_last_fill_k[c] = -1.0f;
@@ -1320,6 +1487,7 @@ inline void init_trailing_martingale_multicoin_side_state(
         side.survivor[c] = false;
         side.entry_candidate[c] = false;
         side.close_reconstruct_after_reducer[c] = false;
+        side.close_recursive_market_mode[c] = false;
         side.filled_coin[c] = false;
         side.entry_market[c] = false;
         side.close_market[c] = false;
@@ -2324,6 +2492,7 @@ inline void generate_tm_multicoin_side_orders(
     thread float* unstuck_close_qty = side.unstuck_close_qty;
     thread float* close_gen_balance = side.close_gen_balance;
     thread float* close_gen_allowed_wel = side.close_gen_allowed_wel;
+    thread float* close_gen_market_price = side.close_gen_market_price;
     thread float* close_grid_gen_psize = side.close_grid_gen_psize;
     thread float* position_open_k = side.position_open_k;
     thread float* position_last_fill_k = side.position_last_fill_k;
@@ -2343,6 +2512,8 @@ inline void generate_tm_multicoin_side_orders(
     thread bool* entry_candidate = side.entry_candidate;
     thread bool* close_reconstruct_after_reducer =
         side.close_reconstruct_after_reducer;
+    thread bool* close_recursive_market_mode =
+        side.close_recursive_market_mode;
     thread bool* entry_market = side.entry_market;
     thread bool* close_market = side.close_market;
     thread bool* secondary_close_market = side.secondary_close_market;
@@ -2631,8 +2802,10 @@ inline void generate_tm_multicoin_side_orders(
         secondary_close_market[c] = false;
         secondary_close_tick[c] = 0;
         close_reconstruct_after_reducer[c] = false;
+        close_recursive_market_mode[c] = false;
         close_is_hsl_panic[c] = false;
         close_grid_gen_psize[c] = 0.0f;
+        close_gen_market_price[c] = 0.0f;
         close_grid_max_rungs[c] = 500;
         contribution[c] = 0.0f;
         entry_candidate[c] = false;
@@ -2993,6 +3166,19 @@ inline void generate_tm_multicoin_side_orders(
                 && (!trailing_close || close_triggered)
             ? clip : 0.0f;
         close_tick[c] = candidate_close_tick;
+        if (!trailing_close && close_qty[c] > 0.0f
+            && market_orders_allowed) {
+            // Preserve the passive recursive strategy snapshot. On the next
+            // candle it alone decides whether the full suffix is emitted;
+            // ordinary market promotion is applied only after that decision.
+            close_reconstruct_after_reducer[c] = true;
+            close_recursive_market_mode[c] = true;
+            close_gen_balance[c] = balance;
+            close_gen_allowed_wel[c] = allowed_coin_wel;
+            close_gen_market_price[c] = price_now;
+            close_grid_gen_psize[c] = psize[c];
+            close_grid_max_rungs[c] = 500;
+        }
         close_market[c] = close_qty[c] > 0.0f
             && should_use_ordinary_market_execution(
                 candidate_close_tick, short_side, price_now, price_step,
@@ -3252,7 +3438,9 @@ inline void generate_tm_multicoin_side_orders(
             close_market[c] = false;
             secondary_close_market[c] = false;
             close_reconstruct_after_reducer[c] = false;
+            close_recursive_market_mode[c] = false;
             close_grid_gen_psize[c] = 0.0f;
+            close_gen_market_price[c] = 0.0f;
             close_is_unstuck_reducer[c] = false;
             close_is_hsl_panic[c] = true;
         }
@@ -3479,6 +3667,7 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
             coin_fill_counts, int(b), k, C, false, alive,
             collect_coin_fill_counts, loss_gate_enabled,
             max_realized_loss_pct, market_order_slippage_pct,
+            market_order_near_touch_threshold,
             long_hsl_panic_market, long_hsl_equity_before_fills
         );
         float short_hsl_equity_before_fills = account.balance;
@@ -3500,6 +3689,7 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
             coin_fill_counts, int(b), k, C, true, alive,
             collect_coin_fill_counts, loss_gate_enabled,
             max_realized_loss_pct, market_order_slippage_pct,
+            market_order_near_touch_threshold,
             short_hsl_panic_market, short_hsl_equity_before_fills
         );
         bool any_fill = long_fill || short_fill;
@@ -4193,6 +4383,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             int(b), k, C, short_side, alive,
             collect_coin_fill_counts, loss_gate_enabled,
             max_realized_loss_pct, market_order_slippage_pct,
+            market_order_near_touch_threshold,
             hsl_panic_market, hsl_equity_before_fills
         );
         if (any_fill) {

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -1033,6 +1033,8 @@ inline bool process_tm_multicoin_side_fills(
                 fill_price, qty_step, min_qty, min_cost, c_mult
             );
             int last_kept_rank = -1;
+            bool all_groups_below_min = close_recursive_market_mode[c]
+                && group_count > 0;
             for (int trim_rank = 0; trim_rank < group_count; ++trim_rank) {
                 int wanted = reverse
                     ? group_count - trim_rank - 1 : trim_rank;
@@ -1072,8 +1074,11 @@ inline bool process_tm_multicoin_side_fills(
                     group.market ? close_gen_market_price[c] : group.price,
                     qty_step, min_qty, min_cost, c_mult
                 );
-                bool partial_trim = trimmed_qty + 1.0e-6f < group.qty;
-                if (trimmed_qty + 1.0e-6f < group_min) {
+                all_groups_below_min = all_groups_below_min
+                    && psize[c] * (1.0f + 1.0e-6f) < group_min;
+                bool partial_trim = trimmed_qty * (1.0f + 1.0e-6f)
+                    < group.qty;
+                if (trimmed_qty * (1.0f + 1.0e-6f) < group_min) {
                     trimmed_qty = 0.0f;
                     if (partial_trim) remaining_budget = 0.0f;
                 }
@@ -1088,6 +1093,16 @@ inline bool process_tm_multicoin_side_fills(
                     minimum_any = fmin(minimum_any, group_min);
                     last_kept_rank = trim_rank;
                 }
+            }
+            int collapse_ordinary_rank = -1;
+            if (all_groups_below_min && reducer_qty <= 0.0f) {
+                // Rust preserves one closest-to-fill close at the full
+                // remaining position when every recursive group is below
+                // the executable minimum. This includes market-promoted
+                // groups whose resize already retained that exception.
+                collapse_ordinary_rank = 0;
+                kept_ordinary = psize[c];
+                last_kept_rank = 0;
             }
             float dust_remainder = fmax(
                 round_step(
@@ -1143,28 +1158,34 @@ inline bool process_tm_multicoin_side_fills(
                     group.market ? close_gen_market_price[c] : group.price,
                     qty_step, min_qty, min_cost, c_mult
                 );
-                float trimmed_group_qty = fmin(
-                    group.qty, remaining_budget
-                );
-                bool partial_trim = trimmed_group_qty + 1.0e-6f
-                    < group.qty;
-                if (trimmed_group_qty + 1.0e-6f < group_min) {
-                    trimmed_group_qty = 0.0f;
-                    if (partial_trim) remaining_budget = 0.0f;
-                }
-                if (trimmed_group_qty > 0.0f) {
-                    remaining_budget = fmax(
-                        round_step(
-                            remaining_budget - trimmed_group_qty,
-                            qty_step
-                        ),
-                        0.0f
-                    );
-                    if (rank == last_kept_rank && dust_remainder > 0.0f
-                        && dust_remainder < minimum_any) {
-                        trimmed_group_qty = round_step(
-                            trimmed_group_qty + dust_remainder, qty_step
+                float trimmed_group_qty = 0.0f;
+                if (collapse_ordinary_rank >= 0) {
+                    trimmed_group_qty = rank == collapse_ordinary_rank
+                        ? ordinary_budget : 0.0f;
+                } else {
+                    trimmed_group_qty = fmin(group.qty, remaining_budget);
+                    bool partial_trim = trimmed_group_qty
+                        * (1.0f + 1.0e-6f) < group.qty;
+                    if (trimmed_group_qty * (1.0f + 1.0e-6f)
+                        < group_min) {
+                        trimmed_group_qty = 0.0f;
+                        if (partial_trim) remaining_budget = 0.0f;
+                    }
+                    if (trimmed_group_qty > 0.0f) {
+                        remaining_budget = fmax(
+                            round_step(
+                                remaining_budget - trimmed_group_qty,
+                                qty_step
+                            ),
+                            0.0f
                         );
+                        if (rank == last_kept_rank
+                            && dust_remainder > 0.0f
+                            && dust_remainder < minimum_any) {
+                            trimmed_group_qty = round_step(
+                                trimmed_group_qty + dust_remainder, qty_step
+                            );
+                        }
                     }
                 }
                 bool reducer_before_group = filled_close

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -906,19 +906,20 @@ def _validate_resume_evidence_budget(
         )
 
 
-def _tm_market_trailing_value_supported(value) -> bool:
+def _tm_market_mode_value_supported(
+    value, *, allow_recursive: bool = False
+) -> bool:
     try:
         value = float(value)
     except (TypeError, ValueError):
         return False
     with np.errstate(over="ignore", under="ignore", invalid="ignore"):
         packed = np.float32(value)
-    return (
-        math.isfinite(value)
-        and value > 0.0
-        and np.isfinite(packed)
-        and packed > 0.0
-    )
+    if not math.isfinite(value) or not np.isfinite(packed):
+        return False
+    if allow_recursive and value <= 0.0:
+        return True
+    return value > 0.0 and packed > 0.0
 
 
 def _validate_tm_multicoin_market_runtime_scope(
@@ -952,10 +953,16 @@ def _validate_tm_multicoin_market_runtime_scope(
             value = (strategy.get(branch, {}) or {}).get(
                 "retracement_base_pct", 0.0
             )
-            if not _tm_market_trailing_value_supported(value):
+            if not _tm_market_mode_value_supported(
+                value, allow_recursive=branch == "close"
+            ):
+                requirement = (
+                    "recursive or trailing" if branch == "close" else "trailing"
+                )
                 unsupported.append(
                     f"bot.{side}.strategy.trailing_martingale.{branch}."
-                    f"retracement_base_pct={value!r} (must remain trailing)"
+                    f"retracement_base_pct={value!r} "
+                    f"(must remain {requirement})"
                 )
 
     overrides = config.get("coin_overrides", {}) or {}
@@ -1009,16 +1016,25 @@ def _validate_tm_multicoin_market_runtime_scope(
                     if "retracement_base_pct" not in branch_patch:
                         continue
                     value = branch_patch["retracement_base_pct"]
-                    if not _tm_market_trailing_value_supported(value):
+                    if not _tm_market_mode_value_supported(
+                        value, allow_recursive=branch == "close"
+                    ):
+                        requirement = (
+                            "recursive or trailing"
+                            if branch == "close"
+                            else "trailing"
+                        )
                         unsupported.append(
                             f"coin_overrides.{coin}.bot.{side}.strategy."
                             f"trailing_martingale.{branch}."
-                            f"retracement_base_pct={value!r} (must remain trailing)"
+                            f"retracement_base_pct={value!r} "
+                            f"(must remain {requirement})"
                         )
     if unsupported:
         raise ValueError(
             "GPU multi-coin Trailing Martingale ordinary market execution "
-            "currently supports wholly trailing ordinary entries and closes "
+            "currently supports wholly trailing ordinary entries and wholly "
+            "trailing or wholly recursive ordinary closes "
             "without position/TWEL reducers, auto-unstuck, or realized-loss "
             "gating; unsupported settings: "
             + ", ".join(unsupported)
@@ -2883,11 +2899,7 @@ def _validate_tm_market_mode_bounds(
             and np.isfinite(packed_close_low)
             and packed_close_low > np.float32(0.0)
         )
-        mode_supported = (
-            trailing_only
-            if coin_count > 1
-            else recursive_only or trailing_only
-        )
+        mode_supported = recursive_only or trailing_only
         if (
             not math.isfinite(close_low)
             or not math.isfinite(close_high)
@@ -2897,7 +2909,7 @@ def _validate_tm_market_mode_bounds(
                 f"{close_key} bounds=({close_low}, {close_high})"
             )
     if unsupported:
-        supported_modes = (
+        entry_modes = (
             "wholly trailing with a float32-positive lower bound"
             if coin_count > 1
             else "wholly recursive (high<=0) or wholly trailing with a "
@@ -2906,8 +2918,9 @@ def _validate_tm_market_mode_bounds(
         raise ValueError(
             "GPU Trailing Martingale ordinary market execution currently "
             "requires each enabled side's entry retracement range to remain "
-            f"{supported_modes} for both entry and close retracement. Entry "
-            "or close unsupported/mode-crossing bounds remain fail closed: "
+            f"{entry_modes}, and close retracement to remain wholly recursive "
+            "(high<=0) or wholly trailing with a float32-positive lower bound. "
+            "Entry or close unsupported/mode-crossing bounds remain fail closed: "
             + ", ".join(unsupported)
         )
 

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1702,8 +1702,7 @@ def test_gpu_tm_market_execution_accepts_recursive_close_mode_bounds(
     _validate_tm_market_mode_bounds(bounds, {}, {"long"}, config)
 
 
-@pytest.mark.parametrize("phase", ["entry", "close"])
-def test_gpu_multicoin_tm_market_execution_rejects_recursive_mode_bounds(phase):
+def test_gpu_multicoin_tm_market_execution_rejects_recursive_entry_mode_bounds():
     config = _long_only_ema_config()
     config["live"]["strategy_kind"] = "trailing_martingale"
     config["live"]["market_orders_allowed"] = True
@@ -1711,12 +1710,29 @@ def test_gpu_multicoin_tm_market_execution_rejects_recursive_mode_bounds(phase):
         "long_entry_retracement_base_pct": Bound(0.001, 0.1),
         "long_close_retracement_base_pct": Bound(0.001, 0.1),
     }
-    bounds[f"long_{phase}_retracement_base_pct"] = Bound(0.0, 0.0)
+    bounds["long_entry_retracement_base_pct"] = Bound(0.0, 0.0)
 
     with pytest.raises(ValueError, match="wholly trailing"):
         _validate_tm_market_mode_bounds(
             bounds, {}, {"long"}, config, coin_count=3
         )
+
+
+@pytest.mark.parametrize("close_bounds", [Bound(0.0, 0.0), Bound(-0.1, 0.0)])
+def test_gpu_multicoin_tm_market_execution_accepts_recursive_close_bounds(
+    close_bounds,
+):
+    config = _long_only_ema_config()
+    config["live"]["strategy_kind"] = "trailing_martingale"
+    config["live"]["market_orders_allowed"] = True
+    bounds = {
+        "long_entry_retracement_base_pct": Bound(0.001, 0.1),
+        "long_close_retracement_base_pct": close_bounds,
+    }
+
+    _validate_tm_market_mode_bounds(
+        bounds, {}, {"long"}, config, coin_count=3
+    )
 
 
 @pytest.mark.parametrize(
@@ -2973,18 +2989,30 @@ def test_gpu_multicoin_tm_market_execution_requires_exact_disabled_loss_gate(
         _validate_scope(config, _MulticoinEvaluator())
 
 
-@pytest.mark.parametrize("branch", ["entry", "close"])
-def test_gpu_multicoin_tm_market_execution_fails_closed_for_recursive_mode(branch):
+def test_gpu_multicoin_tm_market_execution_fails_closed_for_recursive_entry():
     config = _directional_tm_config(long_enabled=True, short_enabled=False)
     config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "SOL"]
     config["live"]["market_orders_allowed"] = True
     strategy = config["bot"]["long"]["strategy"]["trailing_martingale"]
     strategy["entry"]["retracement_base_pct"] = 0.01
     strategy["close"]["retracement_base_pct"] = 0.01
-    strategy[branch]["retracement_base_pct"] = 0.0
+    strategy["entry"]["retracement_base_pct"] = 0.0
 
-    with pytest.raises(ValueError, match=f"{branch}.*must remain trailing"):
+    with pytest.raises(ValueError, match="entry.*must remain trailing"):
         _validate_scope(config, _MulticoinEvaluator())
+
+
+def test_gpu_multicoin_tm_market_execution_accepts_recursive_close():
+    config = _directional_tm_config(long_enabled=True, short_enabled=True)
+    coins = ["BTC", "ETH", "SOL"]
+    config["live"]["approved_coins"] = {"long": coins, "short": coins}
+    config["live"]["market_orders_allowed"] = True
+    for side in ("long", "short"):
+        strategy = config["bot"][side]["strategy"]["trailing_martingale"]
+        strategy["entry"]["retracement_base_pct"] = 0.01
+        strategy["close"]["retracement_base_pct"] = 0.0
+
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
 @pytest.mark.parametrize("branch", ["entry", "close"])
@@ -3012,7 +3040,7 @@ def test_gpu_multicoin_tm_market_execution_validates_static_override_modes(
         }
     }
 
-    if value > 0.0:
+    if value > 0.0 or branch == "close":
         assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
     else:
         with pytest.raises(ValueError, match=f"{branch}.*must remain trailing"):

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -5430,6 +5430,62 @@ def test_mps_tm_multicoin_recursive_market_close_uses_executable_minimum(side):
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+def test_mps_tm_multicoin_recursive_market_close_preserves_below_min_position():
+    count = 7
+    closes = np.tile(np.asarray([100.0, 120.0]), (count, 1))
+    closes[3:, 0] = 50.0
+    highs = closes.copy()
+    lows = closes.copy()
+    highs[4, 0] = 100.0
+    markets = [
+        ProxyMarket(0.001, 0.01, 0.001, 600.0, 1.0, 0.0),
+        ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0),
+    ]
+    overrides = np.full((2, 44), np.nan, dtype=np.float32)
+    overrides[1, 24] = 0.0
+    runner, row = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        "short",
+        coin_overrides=overrides,
+        count=count,
+        closes=closes,
+        highs=highs,
+        lows=lows,
+        markets=markets,
+        collect_coin_fill_counts=True,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.02,
+    )
+    for key, value in {
+        "entry_initial_ema_dist": 0.0005,
+        "entry_retracement_base_pct": 0.001,
+        "close_qty_pct": 0.1,
+        "close_threshold_base_pct": 0.0005,
+        "close_threshold_we_weight": 0.01,
+        "close_retracement_base_pct": 0.0,
+        "entry_cooldown_minutes": 100.0,
+    }.items():
+        row[TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(key)] = value
+
+    output = runner.run(
+        np.asarray([row], dtype=np.float64),
+        end_steps=np.asarray([5], dtype=np.int32),
+    )
+    torch.mps.synchronize()
+
+    # The short opens while the executable minimum is six units. After price
+    # halves, the minimum rises to twelve units, above the whole remaining
+    # position. Exact Rust preserves one recursive market close at the full
+    # position size instead of filtering every group and leaving dust open.
+    assert output["fill_count_entry"].item() == 1.0
+    assert output["fill_count"].item() == 2.0
+    assert output["coin_fill_counts"].cpu().tolist() == [[2.0, 0.0]]
+    assert output["short_psize"].item() == 0.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 def test_mps_ema_multicoin_short_market_entry_uses_executable_minimum():
     count = 5
     closes = np.tile(np.asarray([100.0, 120.0]), (count, 1))

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -1420,6 +1420,8 @@ kernel void passivbot_tm_multicoin_side_fill_pass_probe(
         short_side.secondary_close_qty[c] = 0.0f;
         long_side.close_reconstruct_after_reducer[c] = false;
         short_side.close_reconstruct_after_reducer[c] = false;
+        long_side.close_recursive_market_mode[c] = false;
+        short_side.close_recursive_market_mode[c] = false;
         long_side.close_is_unstuck_reducer[c] = false;
         short_side.close_is_unstuck_reducer[c] = false;
         long_side.close_is_hsl_panic[c] = false;
@@ -1439,7 +1441,7 @@ kernel void passivbot_tm_multicoin_side_fill_pass_probe(
         touch_min_qty_bits, touch_min_qty_relation,
         coin_settings, coin_overrides, coin_fill_counts,
         0, 1, 1, false, true, true, false,
-        1.0f, 0.0f, false, long_equity
+        1.0f, 0.0f, 0.0f, false, long_equity
     );
     bool short_entry = process_tm_multicoin_side_fills(
         short_side, short_config, account, fills,
@@ -1447,7 +1449,7 @@ kernel void passivbot_tm_multicoin_side_fill_pass_probe(
         touch_min_qty_bits, touch_min_qty_relation,
         coin_settings, coin_overrides, coin_fill_counts,
         0, 1, 1, true, true, true, false,
-        1.0f, 0.0f, false, short_equity
+        1.0f, 0.0f, 0.0f, false, short_equity
     );
     long_side.close_qty[0] = 1.0f;
     short_side.close_qty[0] = 1.0f;
@@ -1461,7 +1463,7 @@ kernel void passivbot_tm_multicoin_side_fill_pass_probe(
         touch_min_qty_bits, touch_min_qty_relation,
         coin_settings, coin_overrides, coin_fill_counts,
         0, 2, 1, false, true, true, false,
-        1.0f, 0.0f, false, long_equity
+        1.0f, 0.0f, 0.0f, false, long_equity
     );
     bool short_close = process_tm_multicoin_side_fills(
         short_side, short_config, account, fills,
@@ -1469,7 +1471,7 @@ kernel void passivbot_tm_multicoin_side_fill_pass_probe(
         touch_min_qty_bits, touch_min_qty_relation,
         coin_settings, coin_overrides, coin_fill_counts,
         0, 2, 1, true, true, true, false,
-        1.0f, 0.0f, false, short_equity
+        1.0f, 0.0f, 0.0f, false, short_equity
     );
     output[0] = long_entry && short_entry && long_close && short_close
         ? 1.0f : 0.0f;
@@ -5212,6 +5214,222 @@ def test_mps_tm_multicoin_trailing_market_close_uses_stored_next_close_intent(si
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_recursive_next_close_promotes_without_suffix(side):
+    count = 7
+    base = np.asarray([100.0, 120.0])
+    closes = np.tile(base, (count, 1))
+    highs = closes.copy()
+    lows = closes.copy()
+    markets = [
+        ProxyMarket(
+            0.001, 0.01, 0.001, 0.0, 1.0,
+            maker_fee=0.0, taker_fee=0.01,
+        )
+        for _ in range(2)
+    ]
+    runner, row = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        side,
+        count=count,
+        closes=closes,
+        highs=highs,
+        lows=lows,
+        markets=markets,
+        collect_coin_fill_counts=True,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.001,
+    )
+    for key, value in {
+        "entry_initial_ema_dist": 0.0005,
+        "entry_retracement_base_pct": 0.001,
+        "close_qty_pct": 1.0,
+        "close_threshold_base_pct": 0.0005,
+        "close_retracement_base_pct": 0.0,
+        "entry_cooldown_minutes": 100.0,
+    }.items():
+        row[TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(key)] = value
+
+    output = runner.run(np.asarray([row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    # No passive recursive close crosses. Exact Rust emits and promotes only
+    # calc_next_close for each coin, rather than exposing the suffix.
+    assert output["fill_count"].item() == 4.0
+    assert output["fill_count_entry"].item() == 2.0
+    assert output["coin_fill_counts"].cpu().tolist() == [[2.0, 2.0]]
+    assert output[size_key].item() == 0.0
+    assert output["balance"].item() < 1_000.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_expanded_recursive_close_promotes_each_group(side):
+    count = 6
+    base = np.asarray([100.0, 120.0])
+    closes = np.tile(base, (count, 1))
+    highs = closes.copy()
+    lows = closes.copy()
+    trigger_distance = 0.06
+    if side == "long":
+        highs[4] = base * (1.0 + trigger_distance)
+    else:
+        lows[4] = base * (1.0 - trigger_distance)
+    markets = [
+        ProxyMarket(
+            0.001, 0.01, 0.001, 0.0, 1.0,
+            maker_fee=0.0, taker_fee=0.01,
+        )
+        for _ in range(2)
+    ]
+    runner, row = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        side,
+        count=count,
+        closes=closes,
+        highs=highs,
+        lows=lows,
+        markets=markets,
+        collect_coin_fill_counts=True,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.1,
+    )
+    for key, value in {
+        "entry_initial_ema_dist": 0.0005,
+        "entry_initial_qty_pct": 1.0,
+        "entry_retracement_base_pct": 0.001,
+        "close_qty_pct": 0.25,
+        "close_threshold_base_pct": 0.005,
+        "close_threshold_we_weight": 0.01,
+        "close_retracement_base_pct": 0.0,
+        "entry_cooldown_minutes": 100.0,
+    }.items():
+        row[TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(key)] = value
+
+    output = runner.run(np.asarray([row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    # A passive group reaches on the one post-entry execution candle. More
+    # than one close per coin proves the immutable suffix was emitted and its
+    # groups were independently promoted against the generation snapshot.
+    assert output["fill_count_entry"].item() == 2.0
+    assert output["fill_count"].item() > 4.0, (
+        output["coin_fill_counts"].cpu().tolist(),
+        output[size_key].item(),
+        output["first_fill_ts"].item(),
+        output["last_fill_ts"].item(),
+    )
+    assert all(count > 2.0 for count in output["coin_fill_counts"][0].cpu())
+    assert output[size_key].item() == 0.0
+    assert output["balance"].item() < 1_000.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_coin_override_selects_recursive_market_close(side):
+    count = 7
+    base = np.asarray([100.0, 120.0])
+    closes = np.tile(base, (count, 1))
+    overrides = np.full((2, 44), np.nan, dtype=np.float32)
+    overrides[1, 20] = 0.0
+    runner, row = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        side,
+        coin_overrides=overrides,
+        count=count,
+        closes=closes,
+        highs=closes,
+        lows=closes,
+        collect_coin_fill_counts=True,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.001,
+    )
+    for key, value in {
+        "entry_initial_ema_dist": 0.0005,
+        "entry_retracement_base_pct": 0.001,
+        "close_qty_pct": 1.0,
+        "close_threshold_base_pct": 0.0005,
+        "close_retracement_base_pct": 0.01,
+        "entry_cooldown_minutes": 100.0,
+    }.items():
+        row[TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(key)] = value
+
+    output = runner.run(np.asarray([row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    # The base trailing coin never triggers on flat candles. The overridden
+    # recursive coin emits and promotes its ordinary next close.
+    assert output["fill_count_entry"].item() == 2.0
+    assert output["fill_count"].item() == 3.0
+    assert output["coin_fill_counts"].cpu().tolist() == [[1.0, 2.0]]
+    assert output[size_key].item() > 0.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_recursive_market_close_uses_executable_minimum(side):
+    count = 7
+    closes = np.tile(np.asarray([100.0, 120.0]), (count, 1))
+    markets = [
+        ProxyMarket(0.001, 0.01, 0.001, 100.04, 1.0, 0.0),
+        ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0),
+    ]
+    overrides = np.full((2, 44), np.nan, dtype=np.float32)
+    overrides[1, 24] = 0.0
+    runner, row = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        side,
+        coin_overrides=overrides,
+        count=count,
+        closes=closes,
+        highs=closes,
+        lows=closes,
+        markets=markets,
+        collect_coin_fill_counts=True,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.02,
+    )
+    for key, value in {
+        "entry_initial_ema_dist": 0.0005,
+        "entry_retracement_base_pct": 0.001,
+        "close_qty_pct": 0.1,
+        "close_threshold_base_pct": 0.0005,
+        "close_threshold_we_weight": 0.01,
+        "close_retracement_base_pct": 0.0,
+        "entry_cooldown_minutes": 100.0,
+    }.items():
+        row[TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(key)] = value
+
+    output = runner.run(
+        np.asarray([row], dtype=np.float64),
+        end_steps=np.asarray([5], dtype=np.int32),
+    )
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    assert output["fill_count_entry"].item() == 1.0
+    assert output["fill_count"].item() == 2.0
+    assert output["coin_fill_counts"].cpu().tolist() == [[2.0, 0.0]]
+    # The requested 10% close is below the executable market minimum; the
+    # promoted order is raised to that minimum without closing the position.
+    expected_remaining = 8.998 if side == "long" else 8.987
+    assert output[size_key].item() == pytest.approx(
+        expected_remaining, abs=0.002
+    )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 def test_mps_ema_multicoin_short_market_entry_uses_executable_minimum():
     count = 5
     closes = np.tile(np.asarray([100.0, 120.0]), (count, 1))
@@ -5618,6 +5836,77 @@ def test_mps_tm_multicoin_fused_trailing_market_entries_respect_position_mode(
             promoted["short_psize"].item() > 0.0
         )
     assert promoted["balance"].item() < 1_000.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("hedge_mode", [True, False])
+def test_mps_tm_multicoin_fused_recursive_market_closes_respect_position_mode(
+    hedge_mode,
+):
+    count = 6
+    base = np.asarray([100.0, 120.0])
+    closes = np.tile(base, (count, 1))
+    highs = closes.copy()
+    lows = closes.copy()
+    highs[4] = base * 1.06
+    lows[4] = base * 0.94
+    markets = [
+        ProxyMarket(
+            0.001, 0.01, 0.001, 0.0, 1.0,
+            maker_fee=0.0, taker_fee=0.01,
+        )
+        for _ in range(2)
+    ]
+    _, row, run, data = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        "long",
+        count=count,
+        closes=closes,
+        highs=highs,
+        lows=lows,
+        markets=markets,
+        return_context=True,
+    )
+    for key, value in {
+        "entry_initial_ema_dist": 0.0005,
+        "entry_initial_qty_pct": 1.0,
+        "entry_retracement_base_pct": 0.001,
+        "close_qty_pct": 0.25,
+        "close_threshold_base_pct": 0.005,
+        "close_threshold_we_weight": 0.01,
+        "close_retracement_base_pct": 0.0,
+        "entry_cooldown_minutes": 100.0,
+    }.items():
+        row[TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(key)] = value
+    params = np.asarray([row + row], dtype=np.float64)
+    overrides = np.full((2, 44), np.nan, dtype=np.float32)
+    runner = MpsTrailingMartingaleMulticoinFusedRunner(
+        run,
+        data,
+        long_coin_overrides=overrides,
+        short_coin_overrides=overrides,
+        collect_coin_fill_counts=True,
+        hedge_mode=hedge_mode,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.1,
+    )
+
+    output = runner.run(params)
+    torch.mps.synchronize()
+
+    expected_entries = 4.0 if hedge_mode else 2.0
+    assert output["fill_count_entry"].item() == expected_entries
+    assert output["fill_count"].item() > expected_entries * 2.0
+    assert output["psize"].item() == 0.0
+    assert output["short_psize"].item() == 0.0
+    expected_min_coin_fills = 4.0 if hedge_mode else 2.0
+    assert all(
+        count > expected_min_coin_fills
+        for count in output["coin_fill_counts"][0].cpu()
+    )
+    assert output["balance"].item() < 1_000.0
 
 
 @pytest.mark.skipif(
@@ -6694,6 +6983,10 @@ def test_mps_trailing_martingale_multicoin_directional_shader_smoke(side):
     assert "merge_reducer" not in source
     assert "finalized_reducer_qty" in source
     assert "realized_loss_proxy_allows_close" in source
+    assert "recursive_grid_close_would_expand" in source
+    assert "close_recursive_market_mode" in source
+    assert "close_gen_market_price" in source
+    assert "selected.market = should_use_ordinary_market_execution" in source
     assert "const bool loss_gate_enabled = run_settings[5] < 1.0f" in source
 
     count = 512


### PR DESCRIPTION
## Summary

- allow multi-coin Trailing Martingale ordinary-market MPS optimization when close mode is wholly recursive while entry remains wholly trailing
- reconstruct the immutable passive recursive-close ladder, preserve passive next-candle suffix expansion semantics, then classify and resize emitted groups for ordinary market execution
- cover long, short, fused hedge/one-way, HSL, static coin overrides, and executable minimum sizing
- keep recursive entry, exposure reducers, auto-unstuck, and realized-loss gating fail closed for later parity slices

## Validation

- `cargo test --no-default-features` (267 passed)
- `cargo check --no-default-features`
- full `tests/optimization` non-MPS suite
- full physical Apple M3/MPS `tests/optimization/test_gpu_mps.py` suite (411 passed)
- `python -m compileall src tests/optimization`
- `mkdocs build`
- cached Bybit BTC+ETH long-only HSL integration: 9 generations, 576 proxy, 72 exact, no halt
- cached Bybit BTC+ETH fused long+short HSL integration: 9 generations, 576 proxy, 72 exact, no halt

`mkdocs build --strict` still reports the two pre-existing release-note links to `../CHANGELOG.md`; this slice adds no strict-doc warning.