### PR TITLE
Add multi-coin TM recursive entries on MPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,21 @@ All notable user-facing changes will be documented in this file.
 
 - Added baseline multi-coin Trailing Martingale ordinary market execution to Apple MPS
   optimization for long-only, short-only, fused long+short, hedge-mode, one-way, and compatible
-  suite runs whose entry modes remain wholly trailing and whose close modes remain wholly
-  trailing or wholly recursive. Metal retains generation-time
+  suite runs whose entry and close modes remain wholly trailing or wholly recursive. Recursive
+  entry mode currently requires the portfolio TWEL entry gate disabled pending its dedicated
+  cross-coin multi-rung allocation slice. Metal retains generation-time
   market intent, executes promoted orders on the next valid candle with adverse directional
   slippage and taker fees, applies executable-touch minimum sizing to short entries and all closes,
   and prices the strict portfolio entry cap at the market touch. For recursive closes, passive
   next-candle reachability alone decides whether to emit only the next close or the immutable
   recursive suffix; an emitted suffix promotes and minimum-sizes each merged group against its
-  generation market before aggregate position trimming. Static coin overrides may select trailing
-  or recursive close mode independently. HSL and forager selection remain supported. Recursive
-  entry ladders, position- and total-exposure repair, auto-unstuck, and realized-loss gating remain
-  fail closed in multi-coin Trailing Martingale market mode pending dedicated parity slices.
+  generation market before aggregate position trimming. Recursive entries retain immutable
+  strategy sizing, require strict passive first-rung reachability before exposing their suffix,
+  classify every emitted rung against the generation market, and preserve positive-cooldown
+  single-entry staging. Static coin overrides may select trailing or recursive entry and close mode
+  independently. HSL and forager selection remain supported. Recursive-entry portfolio TWEL
+  gating, position- and total-exposure repair, auto-unstuck, and realized-loss gating remain fail
+  closed in multi-coin Trailing Martingale market mode pending dedicated parity slices.
 
 - Added baseline multi-coin EMA Anchor ordinary market execution to Apple MPS optimization for
   long-only, short-only, and fused long+short runs. The proxy retains generation-time entry and

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -323,18 +323,22 @@ The supported slice is intentionally narrow:
   their market slippage and taker fees are included in the projected loss. Static coin overrides
   may enable or tune unstuck. Multi-coin Trailing Martingale supports ordinary market entries and
   ordinary strategy closes for long-only, short-only, fused long+short, hedge-mode, one-way, and
-  compatible suite runs when every enabled entry retracement range remains wholly trailing with a
-  float32-positive lower bound and every close retracement range remains wholly recursive or
-  wholly trailing. Static coin overrides may select either supported close mode per coin. It uses
+  compatible suite runs when every enabled entry and close retracement range remains wholly
+  recursive or wholly trailing. Recursive entry mode currently requires
+  `risk.total_exposure_entry_gate_enabled: false`; cross-coin allocation of multiple recursive
+  rungs remains fail closed until its dedicated slice. Static coin overrides may select either
+  supported entry or close mode per coin. It uses
   the same retained generation-time intent, next-valid-candle adverse fill, taker-fee,
   executable-touch minimum sizing for short entries and all closes, and portfolio entry-cap
   accounting contract. Passive next-candle reachability alone exposes a recursive close suffix;
   market promotion cannot expose an otherwise unexpanded ladder. Every emitted duplicate-merged
   group is classified and minimum-sized against the immutable generation market before aggregate
-  trimming to the position. HSL, static coin overrides, and forager selection remain supported.
-  Recursive entry modes, position- and total-exposure repair, auto-unstuck, and realized-loss
-  gating remain fail closed for multi-coin Trailing Martingale market mode until their market
-  interactions are modeled
+  trimming to the position. Recursive entries likewise expose their suffix only after strict
+  passive first-rung reachability, retain immutable strategy sizing, classify each emitted rung at
+  the generation market, and stage one order when entry cooldown is positive. HSL, static coin
+  overrides, and forager selection remain supported. Recursive-entry portfolio TWEL gating,
+  position- and total-exposure repair, auto-unstuck, and realized-loss gating remain fail closed
+  for multi-coin Trailing Martingale market mode until their market interactions are modeled.
 - no invalid candle tail after the selected coin's final valid candle
 
 Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor and

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -984,7 +984,7 @@ mod tests {
             MPS_TRAILING_MARTINGALE_MULTICOIN_BODY
                 .matches("record_tm_multicoin_entry_fill(")
                 .count(),
-            2
+            3
         );
         assert_eq!(
             MPS_TRAILING_MARTINGALE_MULTICOIN_BODY
@@ -996,8 +996,10 @@ mod tests {
             MPS_TRAILING_MARTINGALE_MULTICOIN_BODY
                 .matches("apply_tm_multicoin_entry_position(")
                 .count(),
-            2
+            3
         );
+        assert!(source.contains("next_recursive_grid_entry("));
+        assert!(source.contains("entry_recursive_market_mode"));
         assert_eq!(
             MPS_TRAILING_MARTINGALE_MULTICOIN_BODY
                 .matches("update_tm_multicoin_position_fill_timestamp(")

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -465,6 +465,12 @@ struct TrailingMartingaleMulticoinSideState {
     float pprice[MAX_COINS];
     float last_increase_k[MAX_COINS];
     float entry_qty[MAX_COINS];
+    float entry_strategy_qty[MAX_COINS];
+    float entry_gen_balance[MAX_COINS];
+    float entry_gen_allowed_wel[MAX_COINS];
+    float entry_gen_market_price[MAX_COINS];
+    float entry_gen_psize[MAX_COINS];
+    float entry_gen_pprice[MAX_COINS];
     float close_qty[MAX_COINS];
     float secondary_close_qty[MAX_COINS];
     float twel_close_qty[MAX_COINS];
@@ -483,6 +489,8 @@ struct TrailingMartingaleMulticoinSideState {
     float max_since_open[MAX_COINS];
     float min_since_max[MAX_COINS];
     int entry_tick[MAX_COINS];
+    int entry_gen_initial_tick[MAX_COINS];
+    int entry_gen_touch_tick[MAX_COINS];
     int close_tick[MAX_COINS];
     int secondary_close_tick[MAX_COINS];
     int twel_close_tick[MAX_COINS];
@@ -492,6 +500,7 @@ struct TrailingMartingaleMulticoinSideState {
     bool incumbent[MAX_COINS];
     bool survivor[MAX_COINS];
     bool entry_candidate[MAX_COINS];
+    bool entry_recursive_market_mode[MAX_COINS];
     bool close_reconstruct_after_reducer[MAX_COINS];
     bool close_recursive_market_mode[MAX_COINS];
     bool filled_coin[MAX_COINS];
@@ -568,6 +577,162 @@ struct TrailingMartingaleMulticoinSideConfig {
     HslState hsl_template;
     bool coin_hsl_mode;
 };
+
+struct RecursiveEntryCandidate {
+    int ticks;
+    float price;
+    float strategy_qty;
+    float executable_qty;
+    bool market;
+};
+
+// Rebuild one recursive grid reentry from an immutable generation snapshot.
+// Portfolio TWEL gating is intentionally outside this helper; the baseline
+// multi-coin recursive-entry slice fails closed while that gate is enabled.
+inline RecursiveEntryCandidate next_recursive_grid_entry(
+    thread const TrailingMartingaleMulticoinSideState& side,
+    thread const TrailingMartingaleMulticoinSideConfig& config,
+    constant float* coin_overrides,
+    int coin,
+    bool short_side,
+    float sim_psize,
+    float sim_pprice,
+    float generation_balance,
+    float allowed_wel,
+    int generation_initial_tick,
+    int generation_touch_tick,
+    float generation_market_price,
+    float qty_step,
+    float price_step,
+    float min_qty,
+    float min_cost,
+    float c_mult,
+    bool market_orders_allowed,
+    float market_order_near_touch_threshold
+) {
+    RecursiveEntryCandidate out;
+    out.ticks = 0;
+    out.price = 0.0f;
+    out.strategy_qty = 0.0f;
+    out.executable_qty = 0.0f;
+    out.market = false;
+    if (!(sim_psize > 0.0f && sim_pprice > 0.0f
+        && generation_balance > 0.0f && allowed_wel > 0.0f)) return out;
+
+    float initial_ema_dist = coin_override_or(
+        coin_overrides, coin, 5, config.initial_ema_dist
+    );
+    float initial_qty_pct = coin_override_or(
+        coin_overrides, coin, 6, config.initial_qty_pct
+    );
+    float threshold_base = coin_override_or(
+        coin_overrides, coin, 7, config.entry_threshold_base
+    );
+    float threshold_we = coin_override_or(
+        coin_overrides, coin, 8, config.entry_threshold_we
+    );
+    float threshold_v1h = coin_override_or(
+        coin_overrides, coin, 9, config.entry_threshold_v1h
+    );
+    float threshold_v1m = coin_override_or(
+        coin_overrides, coin, 10, config.entry_threshold_v1m
+    );
+    float ddf = coin_override_or(coin_overrides, coin, 4, config.ddf);
+    float band = short_side
+        ? fmax(side.ema0[coin], fmax(side.ema1[coin], side.ema2[coin]))
+        : fmin(side.ema0[coin], fmin(side.ema1[coin], side.ema2[coin]));
+    int band_tick = short_side
+        ? int(ceil(
+            band * (1.0f + initial_ema_dist) / price_step - 1.0e-6f
+        ))
+        : int(floor(
+            band * (1.0f - initial_ema_dist) / price_step + 1.0e-6f
+        ));
+    int initial_tick = generation_initial_tick;
+    float initial_price = float(initial_tick) * price_step;
+    float min_iq = min_entry_qty(
+        initial_price, qty_step, min_qty, min_cost, c_mult
+    );
+    float iq = fmax(min_iq, round_step(
+        generation_balance * allowed_wel * initial_qty_pct
+            / fmax(initial_price * c_mult, 1.0e-12f),
+        qty_step
+    ));
+    float iq_effective = sim_psize < iq
+        ? fmax(round_step(sim_psize, qty_step), min_iq) : iq;
+    float we = sim_psize * sim_pprice * c_mult / generation_balance;
+    if (we >= allowed_wel * 0.999f) return out;
+    float wer = we / fmax(allowed_wel, 1.0e-12f);
+    float multiplier = fmax(
+        1.0f + side.volatility_1h[coin] * threshold_v1h
+            + side.volatility_1m[coin] * threshold_v1m
+            + wer * threshold_we,
+        1.0f
+    );
+    float threshold = fmax(threshold_base, 0.0f) * multiplier;
+    float target = sim_pprice * (
+        short_side ? 1.0f + threshold : 1.0f - threshold
+    );
+    int raw_tick = short_side
+        ? int(ceil(target / price_step - 1.0e-6f))
+        : int(floor(target / price_step + 1.0e-6f));
+    bool touch_controls = short_side
+        ? generation_touch_tick >= raw_tick
+        : generation_touch_tick <= raw_tick;
+    int entry_tick = touch_controls ? generation_touch_tick : raw_tick;
+    if (config.gate_reentry) {
+        bool band_controls = short_side
+            ? band_tick >= entry_tick : band_tick <= entry_tick;
+        if (band_controls) entry_tick = band_tick;
+    }
+    if (entry_tick <= 1) return out;
+    float entry_price = float(entry_tick) * price_step;
+    float min_rq = min_entry_qty(
+        entry_price, qty_step, min_qty, min_cost, c_mult
+    );
+    float rq = fmax(iq_effective, fmax(min_rq, round_step(
+        fmax(
+            sim_psize * ddf,
+            generation_balance * allowed_wel * initial_qty_pct
+                / fmax(entry_price * c_mult, 1.0e-12f)
+        ),
+        qty_step
+    )));
+    float we_if = (sim_psize * sim_pprice + rq * entry_price)
+        * c_mult / fmax(generation_balance, 1.0e-9f);
+    float crop_fraction = (allowed_wel - we)
+        / fmax(we_if - we, 1.0e-12f);
+    float rq_crop = fmax(
+        round_step(rq * crop_fraction, qty_step), min_rq
+    );
+    if (we_if > allowed_wel * 1.01f && rq_crop < rq) rq = rq_crop;
+    float headroom = (
+        allowed_wel * generation_balance - sim_psize * sim_pprice * c_mult
+    ) / fmax(entry_price * c_mult, 1.0e-12f);
+    if ((sim_psize * sim_pprice + rq * entry_price) * c_mult
+        / fmax(generation_balance, 1.0e-9f) > allowed_wel * 1.01f) {
+        rq = fmin(rq, fmax(floor_step(headroom, qty_step), 0.0f));
+    }
+    if (rq * (1.0f + 1.0e-6f) < min_rq) return out;
+
+    out.ticks = entry_tick;
+    out.price = entry_price;
+    out.strategy_qty = rq;
+    out.executable_qty = rq;
+    out.market = should_use_ordinary_market_execution(
+        entry_tick, !short_side, generation_market_price, price_step,
+        market_orders_allowed, market_order_near_touch_threshold
+    );
+    if (short_side && out.market) {
+        out.executable_qty = fmax(
+            out.executable_qty,
+            min_entry_qty(
+                generation_market_price, qty_step, min_qty, min_cost, c_mult
+            )
+        );
+    }
+    return out;
+}
 
 // Shared fill accounting is separate from strategy-side state so a fused
 // long+short kernel can apply both directional fill passes to one account and
@@ -842,6 +1007,12 @@ inline bool process_tm_multicoin_side_fills(
     thread float* psize = side.psize;
     thread float* pprice = side.pprice;
     thread float* entry_qty = side.entry_qty;
+    thread float* entry_strategy_qty = side.entry_strategy_qty;
+    thread float* entry_gen_balance = side.entry_gen_balance;
+    thread float* entry_gen_allowed_wel = side.entry_gen_allowed_wel;
+    thread float* entry_gen_market_price = side.entry_gen_market_price;
+    thread float* entry_gen_psize = side.entry_gen_psize;
+    thread float* entry_gen_pprice = side.entry_gen_pprice;
     thread float* close_qty = side.close_qty;
     thread float* secondary_close_qty = side.secondary_close_qty;
     thread float* close_gen_balance = side.close_gen_balance;
@@ -849,6 +1020,8 @@ inline bool process_tm_multicoin_side_fills(
     thread float* close_gen_market_price = side.close_gen_market_price;
     thread float* close_grid_gen_psize = side.close_grid_gen_psize;
     thread int* entry_tick = side.entry_tick;
+    thread int* entry_gen_initial_tick = side.entry_gen_initial_tick;
+    thread int* entry_gen_touch_tick = side.entry_gen_touch_tick;
     thread int* close_tick = side.close_tick;
     thread int* secondary_close_tick = side.secondary_close_tick;
     thread int* close_grid_max_rungs = side.close_grid_max_rungs;
@@ -857,6 +1030,8 @@ inline bool process_tm_multicoin_side_fills(
     thread bool* close_recursive_market_mode =
         side.close_recursive_market_mode;
     thread bool* filled_coin = side.filled_coin;
+    thread bool* entry_recursive_market_mode =
+        side.entry_recursive_market_mode;
     thread bool* entry_market = side.entry_market;
     thread bool* close_market = side.close_market;
     thread bool* secondary_close_market = side.secondary_close_market;
@@ -1330,11 +1505,89 @@ inline bool process_tm_multicoin_side_fills(
             }
         }
 
-        bool filled_entry = entry_qty[c] > 0.0f
-            && (entry_market[c] || (short_side
+        bool first_entry_passive_reachable = entry_qty[c] > 0.0f
+            && (short_side
                 ? entry_tick[c] <= fill_ticks[tick_offset + 0]
-                : entry_tick[c] > fill_ticks[tick_offset + 1]));
-        if (filled_entry) {
+                : entry_tick[c] > fill_ticks[tick_offset + 1]);
+        bool filled_entry = entry_qty[c] > 0.0f
+            && (entry_market[c] || first_entry_passive_reachable);
+        if (filled_entry && entry_recursive_market_mode[c]) {
+            float sim_psize = entry_gen_psize[c];
+            float sim_pprice = entry_gen_pprice[c];
+            int sim_touch_tick = entry_gen_touch_tick[c];
+            int previous_ticks = 0;
+            for (int rung = 0; rung < 500; ++rung) {
+                RecursiveEntryCandidate candidate;
+                if (rung == 0) {
+                    candidate.ticks = entry_tick[c];
+                    candidate.price = float(entry_tick[c]) * price_step;
+                    candidate.strategy_qty = entry_strategy_qty[c];
+                    candidate.executable_qty = entry_qty[c];
+                    candidate.market = entry_market[c];
+                } else {
+                    candidate = next_recursive_grid_entry(
+                        side, config, coin_overrides, c, short_side,
+                        sim_psize, sim_pprice, entry_gen_balance[c],
+                        entry_gen_allowed_wel[c], entry_gen_initial_tick[c],
+                        sim_touch_tick, entry_gen_market_price[c],
+                        qty_step, price_step, min_qty, min_cost, c_mult,
+                        true, market_order_near_touch_threshold
+                    );
+                }
+                if (!(candidate.strategy_qty > 0.0f
+                    && candidate.executable_qty > 0.0f
+                    && candidate.ticks > 1)) break;
+                if (rung > 0 && candidate.ticks == previous_ticks) break;
+                bool passive_reachable = short_side
+                    ? candidate.ticks <= fill_ticks[tick_offset + 0]
+                    : candidate.ticks > fill_ticks[tick_offset + 1];
+                if (!candidate.market && !passive_reachable) break;
+                float fill_price = candidate.market
+                    ? ordinary_market_fill_price(
+                        close, !short_side,
+                        market_order_slippage_pct, price_step
+                    )
+                    : candidate.price;
+                float adjusted = round_step(
+                    candidate.executable_qty, qty_step
+                );
+                float fee = adjusted * fill_price * c_mult
+                    * (candidate.market ? taker_fee : maker_fee);
+                record_tm_multicoin_entry_fill(
+                    side, account, fills, coin_fill_counts,
+                    int(b), C, c, k, fee, adjusted, fill_price,
+                    close, c_mult, short_side, collect_coin_fill_counts,
+                    hsl_equity_before_fills
+                );
+                apply_tm_multicoin_entry_position(
+                    side, fills, c, k, adjusted, fill_price,
+                    qty_step, c_mult, balance
+                );
+                any_fill = true;
+
+                float new_sim_psize = round_step(
+                    sim_psize + candidate.strategy_qty, qty_step
+                );
+                sim_pprice = sim_psize <= 0.0f
+                    ? candidate.price
+                    : sim_pprice * (
+                        sim_psize / fmax(new_sim_psize, 1.0e-12f)
+                    ) + candidate.price * (
+                        candidate.strategy_qty
+                            / fmax(new_sim_psize, 1.0e-12f)
+                    );
+                sim_psize = new_sim_psize;
+                previous_ticks = candidate.ticks;
+                sim_touch_tick = short_side
+                    ? max(sim_touch_tick, candidate.ticks)
+                    : min(sim_touch_tick, candidate.ticks);
+                if (rung == 0 && !first_entry_passive_reachable) break;
+                if (coin_override_or(
+                        coin_overrides, c, 23, config.cooldown_min
+                    ) != 0.0f) break;
+            }
+            entry_qty[c] = 0.0f;
+        } else if (filled_entry) {
             float fill_price = entry_market[c]
                 ? ordinary_market_fill_price(
                     close, !short_side,
@@ -1480,6 +1733,12 @@ inline void init_trailing_martingale_multicoin_side_state(
         side.pprice[c] = 0.0f;
         side.last_increase_k[c] = -1.0e20f;
         side.entry_qty[c] = 0.0f;
+        side.entry_strategy_qty[c] = 0.0f;
+        side.entry_gen_balance[c] = 0.0f;
+        side.entry_gen_allowed_wel[c] = 0.0f;
+        side.entry_gen_market_price[c] = 0.0f;
+        side.entry_gen_psize[c] = 0.0f;
+        side.entry_gen_pprice[c] = 0.0f;
         side.close_qty[c] = 0.0f;
         side.secondary_close_qty[c] = 0.0f;
         side.twel_close_qty[c] = 0.0f;
@@ -1498,6 +1757,8 @@ inline void init_trailing_martingale_multicoin_side_state(
         side.max_since_open[c] = 0.0f;
         side.min_since_max[c] = INFINITY;
         side.entry_tick[c] = 0;
+        side.entry_gen_initial_tick[c] = 0;
+        side.entry_gen_touch_tick[c] = 0;
         side.close_tick[c] = 0;
         side.secondary_close_tick[c] = 0;
         side.twel_close_tick[c] = 0;
@@ -1507,6 +1768,7 @@ inline void init_trailing_martingale_multicoin_side_state(
         side.incumbent[c] = false;
         side.survivor[c] = false;
         side.entry_candidate[c] = false;
+        side.entry_recursive_market_mode[c] = false;
         side.close_reconstruct_after_reducer[c] = false;
         side.close_recursive_market_mode[c] = false;
         side.filled_coin[c] = false;
@@ -2507,6 +2769,12 @@ inline void generate_tm_multicoin_side_orders(
     thread float* pprice = side.pprice;
     thread float* last_increase_k = side.last_increase_k;
     thread float* entry_qty = side.entry_qty;
+    thread float* entry_strategy_qty = side.entry_strategy_qty;
+    thread float* entry_gen_balance = side.entry_gen_balance;
+    thread float* entry_gen_allowed_wel = side.entry_gen_allowed_wel;
+    thread float* entry_gen_market_price = side.entry_gen_market_price;
+    thread float* entry_gen_psize = side.entry_gen_psize;
+    thread float* entry_gen_pprice = side.entry_gen_pprice;
     thread float* close_qty = side.close_qty;
     thread float* secondary_close_qty = side.secondary_close_qty;
     thread float* twel_close_qty = side.twel_close_qty;
@@ -2524,6 +2792,8 @@ inline void generate_tm_multicoin_side_orders(
     thread float* max_since_open = side.max_since_open;
     thread float* min_since_max = side.min_since_max;
     thread int* entry_tick = side.entry_tick;
+    thread int* entry_gen_initial_tick = side.entry_gen_initial_tick;
+    thread int* entry_gen_touch_tick = side.entry_gen_touch_tick;
     thread int* close_tick = side.close_tick;
     thread int* secondary_close_tick = side.secondary_close_tick;
     thread int* twel_close_tick = side.twel_close_tick;
@@ -2531,6 +2801,8 @@ inline void generate_tm_multicoin_side_orders(
     thread int* close_grid_max_rungs = side.close_grid_max_rungs;
     thread bool* selected = side.selected;
     thread bool* entry_candidate = side.entry_candidate;
+    thread bool* entry_recursive_market_mode =
+        side.entry_recursive_market_mode;
     thread bool* close_reconstruct_after_reducer =
         side.close_reconstruct_after_reducer;
     thread bool* close_recursive_market_mode =
@@ -2816,6 +3088,15 @@ inline void generate_tm_multicoin_side_orders(
     }
     for (int c = 0; c < C; ++c) {
         entry_qty[c] = 0.0f;
+        entry_strategy_qty[c] = 0.0f;
+        entry_recursive_market_mode[c] = false;
+        entry_gen_balance[c] = 0.0f;
+        entry_gen_allowed_wel[c] = 0.0f;
+        entry_gen_market_price[c] = 0.0f;
+        entry_gen_psize[c] = 0.0f;
+        entry_gen_pprice[c] = 0.0f;
+        entry_gen_initial_tick[c] = 0;
+        entry_gen_touch_tick[c] = 0;
         close_qty[c] = 0.0f;
         secondary_close_qty[c] = 0.0f;
         entry_market[c] = false;
@@ -3064,6 +3345,7 @@ inline void generate_tm_multicoin_side_orders(
         )) {
             quantity = 0.0f;
         }
+        float strategy_quantity = quantity;
         bool candidate_entry_market = quantity > 0.0f
             && should_use_ordinary_market_execution(
                 candidate_entry_tick, !short_side, price_now, price_step,
@@ -3082,8 +3364,20 @@ inline void generate_tm_multicoin_side_orders(
             quantity = executable_entry_min;
         }
         entry_qty[c] = quantity;
+        entry_strategy_qty[c] = strategy_quantity;
         entry_tick[c] = candidate_entry_tick;
         entry_market[c] = candidate_entry_market && quantity > 0.0f;
+        if (coin_entry_retracement_base <= 0.0f && quantity > 0.0f
+            && market_orders_allowed) {
+            entry_recursive_market_mode[c] = true;
+            entry_gen_balance[c] = balance;
+            entry_gen_allowed_wel[c] = allowed_coin_wel;
+            entry_gen_market_price[c] = price_now;
+            entry_gen_psize[c] = psize[c];
+            entry_gen_pprice[c] = pprice[c];
+            entry_gen_initial_tick[c] = initial_tick;
+            entry_gen_touch_tick[c] = entry_touch;
+        }
         minimum_entry[c] = executable_entry_min;
         entry_candidate[c] = quantity > 0.0f;
         contribution[c] = quantity > 0.0f

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -933,6 +933,7 @@ def _validate_tm_multicoin_market_runtime_scope(
         unsupported.append(
             f"live.max_realized_loss_pct={max_loss} (required 1.0)"
         )
+    recursive_entry_sides = set()
     for side in sorted(set(enabled_sides or ())):
         side_config = config.get("bot", {}).get(side, {}) or {}
         risk = side_config.get("risk", {}) or {}
@@ -953,12 +954,13 @@ def _validate_tm_multicoin_market_runtime_scope(
             value = (strategy.get(branch, {}) or {}).get(
                 "retracement_base_pct", 0.0
             )
-            if not _tm_market_mode_value_supported(
-                value, allow_recursive=branch == "close"
-            ):
-                requirement = (
-                    "recursive or trailing" if branch == "close" else "trailing"
-                )
+            mode_supported = _tm_market_mode_value_supported(
+                value, allow_recursive=True
+            )
+            if branch == "entry" and mode_supported and float(value) <= 0.0:
+                recursive_entry_sides.add(side)
+            if not mode_supported:
+                requirement = "recursive or trailing"
                 unsupported.append(
                     f"bot.{side}.strategy.trailing_martingale.{branch}."
                     f"retracement_base_pct={value!r} "
@@ -1016,26 +1018,37 @@ def _validate_tm_multicoin_market_runtime_scope(
                     if "retracement_base_pct" not in branch_patch:
                         continue
                     value = branch_patch["retracement_base_pct"]
-                    if not _tm_market_mode_value_supported(
-                        value, allow_recursive=branch == "close"
+                    mode_supported = _tm_market_mode_value_supported(
+                        value, allow_recursive=True
+                    )
+                    if (
+                        branch == "entry"
+                        and mode_supported
+                        and float(value) <= 0.0
                     ):
-                        requirement = (
-                            "recursive or trailing"
-                            if branch == "close"
-                            else "trailing"
-                        )
+                        recursive_entry_sides.add(side)
+                    if not mode_supported:
+                        requirement = "recursive or trailing"
                         unsupported.append(
                             f"coin_overrides.{coin}.bot.{side}.strategy."
                             f"trailing_martingale.{branch}."
                             f"retracement_base_pct={value!r} "
                             f"(must remain {requirement})"
                         )
+    for side in sorted(recursive_entry_sides):
+        risk = config.get("bot", {}).get(side, {}).get("risk", {}) or {}
+        if bool(risk.get("total_exposure_entry_gate_enabled", True)):
+            unsupported.append(
+                f"bot.{side}.risk.total_exposure_entry_gate_enabled=true "
+                "(must remain false with recursive entry)"
+            )
     if unsupported:
         raise ValueError(
             "GPU multi-coin Trailing Martingale ordinary market execution "
-            "currently supports wholly trailing ordinary entries and wholly "
-            "trailing or wholly recursive ordinary closes "
-            "without position/TWEL reducers, auto-unstuck, or realized-loss "
+            "currently supports wholly trailing or wholly recursive ordinary "
+            "entries and closes; recursive entries require the portfolio "
+            "TWEL entry gate disabled; position/TWEL reducers, auto-unstuck, "
+            "and realized-loss "
             "gating; unsupported settings: "
             + ", ".join(unsupported)
         )
@@ -2870,11 +2883,7 @@ def _validate_tm_market_mode_bounds(
             and np.isfinite(packed_entry_low)
             and packed_entry_low > np.float32(0.0)
         )
-        mode_supported = (
-            trailing_only
-            if coin_count > 1
-            else recursive_only or trailing_only
-        )
+        mode_supported = recursive_only or trailing_only
         if (
             not math.isfinite(entry_low)
             or not math.isfinite(entry_high)
@@ -2910,9 +2919,7 @@ def _validate_tm_market_mode_bounds(
             )
     if unsupported:
         entry_modes = (
-            "wholly trailing with a float32-positive lower bound"
-            if coin_count > 1
-            else "wholly recursive (high<=0) or wholly trailing with a "
+            "wholly recursive (high<=0) or wholly trailing with a "
             "float32-positive lower bound"
         )
         raise ValueError(
@@ -2964,6 +2971,61 @@ def _validate_tm_multicoin_market_foundation_bounds(
         return
     unsupported = []
     for side in sorted(set(enabled_sides or ())):
+        entry_key = f"{side}_entry_retracement_base_pct"
+        entry_bound = bound_by_key.get(entry_key)
+        entry_high = (
+            float(entry_bound.high)
+            if entry_bound is not None
+            else float(base_by_key.get(entry_key, 0.0))
+        )
+        has_recursive_entry = entry_high <= 0.0
+        overrides = config.get("coin_overrides", {}) or {}
+        if not has_recursive_entry and isinstance(overrides, dict):
+            for patch in overrides.values():
+                if not isinstance(patch, dict):
+                    continue
+                side_patch = ((patch.get("bot", {}) or {}).get(side, {}) or {})
+                if not isinstance(side_patch, dict):
+                    continue
+                strategy_root = side_patch.get("strategy", {}) or {}
+                strategy_patch = (
+                    strategy_root.get("trailing_martingale", {}) or {}
+                    if isinstance(strategy_root, dict)
+                    else {}
+                )
+                entry_patch = (
+                    strategy_patch.get("entry", {}) or {}
+                    if isinstance(strategy_patch, dict)
+                    else {}
+                )
+                if not isinstance(entry_patch, dict):
+                    continue
+                value = entry_patch.get("retracement_base_pct")
+                if (
+                    value is not None
+                    and _tm_market_mode_value_supported(
+                        value, allow_recursive=True
+                    )
+                    and float(value) <= 0.0
+                ):
+                    has_recursive_entry = True
+                    break
+        if has_recursive_entry:
+            gate_key = f"{side}_risk_twel_entry_gate_enabled"
+            gate_bound = bound_by_key.get(gate_key)
+            gate_values = (
+                (float(gate_bound.low), float(gate_bound.high))
+                if gate_bound is not None
+                else (float(base_by_key.get(gate_key, 0.0)),) * 2
+            )
+            if any(
+                not math.isclose(value, 0.0, abs_tol=1.0e-12)
+                for value in gate_values
+            ):
+                unsupported.append(
+                    f"{gate_key} bounds={gate_values} "
+                    "(must remain 0.0 with recursive entry)"
+                )
         for suffix in (
             "risk_position_exposure_enforcer_enabled",
             "risk_total_exposure_enforcer_enabled",

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1702,7 +1702,7 @@ def test_gpu_tm_market_execution_accepts_recursive_close_mode_bounds(
     _validate_tm_market_mode_bounds(bounds, {}, {"long"}, config)
 
 
-def test_gpu_multicoin_tm_market_execution_rejects_recursive_entry_mode_bounds():
+def test_gpu_multicoin_tm_market_execution_accepts_recursive_entry_mode_bounds():
     config = _long_only_ema_config()
     config["live"]["strategy_kind"] = "trailing_martingale"
     config["live"]["market_orders_allowed"] = True
@@ -1712,10 +1712,9 @@ def test_gpu_multicoin_tm_market_execution_rejects_recursive_entry_mode_bounds()
     }
     bounds["long_entry_retracement_base_pct"] = Bound(0.0, 0.0)
 
-    with pytest.raises(ValueError, match="wholly trailing"):
-        _validate_tm_market_mode_bounds(
-            bounds, {}, {"long"}, config, coin_count=3
-        )
+    _validate_tm_market_mode_bounds(
+        bounds, {}, {"long"}, config, coin_count=3
+    )
 
 
 @pytest.mark.parametrize("close_bounds", [Bound(0.0, 0.0), Bound(-0.1, 0.0)])
@@ -1756,6 +1755,49 @@ def test_gpu_multicoin_tm_market_execution_rejects_reducer_bounds(suffix):
             {"long"},
             config,
             coin_count=3,
+        )
+
+
+def test_gpu_multicoin_tm_recursive_entry_rejects_twel_gate_bounds():
+    config = _long_only_ema_config()
+    config["live"]["strategy_kind"] = "trailing_martingale"
+    config["live"]["market_orders_allowed"] = True
+    bounds = {
+        "long_entry_retracement_base_pct": Bound(0.0, 0.0),
+        "long_risk_twel_entry_gate_enabled": Bound(0.0, 1.0),
+    }
+
+    with pytest.raises(ValueError, match="twel_entry_gate_enabled"):
+        _validate_tm_multicoin_market_foundation_bounds(
+            bounds, {}, {"long"}, config, coin_count=3
+        )
+
+
+def test_gpu_multicoin_tm_recursive_entry_override_rejects_twel_gate_bounds():
+    config = _long_only_ema_config()
+    config["live"]["strategy_kind"] = "trailing_martingale"
+    config["live"]["market_orders_allowed"] = True
+    config["coin_overrides"] = {
+        "ETH": {
+            "bot": {
+                "long": {
+                    "strategy": {
+                        "trailing_martingale": {
+                            "entry": {"retracement_base_pct": 0.0}
+                        }
+                    }
+                }
+            }
+        }
+    }
+    bounds = {
+        "long_entry_retracement_base_pct": Bound(0.001, 0.1),
+        "long_risk_twel_entry_gate_enabled": Bound(0.0, 1.0),
+    }
+
+    with pytest.raises(ValueError, match="twel_entry_gate_enabled"):
+        _validate_tm_multicoin_market_foundation_bounds(
+            bounds, {}, {"long"}, config, coin_count=3
         )
 
 
@@ -2989,7 +3031,7 @@ def test_gpu_multicoin_tm_market_execution_requires_exact_disabled_loss_gate(
         _validate_scope(config, _MulticoinEvaluator())
 
 
-def test_gpu_multicoin_tm_market_execution_fails_closed_for_recursive_entry():
+def test_gpu_multicoin_tm_recursive_entry_requires_disabled_twel_entry_gate():
     config = _directional_tm_config(long_enabled=True, short_enabled=False)
     config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "SOL"]
     config["live"]["market_orders_allowed"] = True
@@ -2997,9 +3039,30 @@ def test_gpu_multicoin_tm_market_execution_fails_closed_for_recursive_entry():
     strategy["entry"]["retracement_base_pct"] = 0.01
     strategy["close"]["retracement_base_pct"] = 0.01
     strategy["entry"]["retracement_base_pct"] = 0.0
+    config["bot"]["long"]["risk"][
+        "total_exposure_entry_gate_enabled"
+    ] = True
 
-    with pytest.raises(ValueError, match="entry.*must remain trailing"):
+    with pytest.raises(
+        ValueError, match="total_exposure_entry_gate_enabled"
+    ):
         _validate_scope(config, _MulticoinEvaluator())
+
+
+def test_gpu_multicoin_tm_market_execution_accepts_recursive_entry():
+    config = _directional_tm_config(long_enabled=True, short_enabled=True)
+    coins = ["BTC", "ETH", "SOL"]
+    config["live"]["approved_coins"] = {"long": coins, "short": coins}
+    config["live"]["market_orders_allowed"] = True
+    for side in ("long", "short"):
+        config["bot"][side]["risk"][
+            "total_exposure_entry_gate_enabled"
+        ] = False
+        strategy = config["bot"][side]["strategy"]["trailing_martingale"]
+        strategy["entry"]["retracement_base_pct"] = 0.0
+        strategy["close"]["retracement_base_pct"] = 0.01
+
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
 def test_gpu_multicoin_tm_market_execution_accepts_recursive_close():
@@ -3040,11 +3103,12 @@ def test_gpu_multicoin_tm_market_execution_validates_static_override_modes(
         }
     }
 
-    if value > 0.0 or branch == "close":
-        assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
-    else:
-        with pytest.raises(ValueError, match=f"{branch}.*must remain trailing"):
-            _validate_scope(config, _MulticoinEvaluator())
+    if branch == "entry" and value <= 0.0:
+        config["bot"]["long"]["risk"][
+            "total_exposure_entry_gate_enabled"
+        ] = False
+
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -1414,6 +1414,8 @@ kernel void passivbot_tm_multicoin_side_fill_pass_probe(
         short_side.entry_qty[c] = 1.0f;
         long_side.entry_tick[c] = 100;
         short_side.entry_tick[c] = 100;
+        long_side.entry_recursive_market_mode[c] = false;
+        short_side.entry_recursive_market_mode[c] = false;
         long_side.close_qty[c] = 0.0f;
         short_side.close_qty[c] = 0.0f;
         long_side.secondary_close_qty[c] = 0.0f;
@@ -5136,6 +5138,187 @@ def test_mps_tm_multicoin_trailing_market_entry_uses_stored_next_close_intent(si
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_recursive_market_entry_does_not_expose_suffix(side):
+    count = 5
+    closes = np.tile(np.asarray([100.0, 120.0]), (count, 1))
+    runner, row = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        side,
+        count=count,
+        closes=closes,
+        highs=closes,
+        lows=closes,
+        collect_coin_fill_counts=True,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.001,
+    )
+    for key, value in {
+        "entry_initial_qty_pct": 0.1,
+        "entry_initial_ema_dist": 0.0005,
+        "entry_threshold_base_pct": 0.01,
+        "entry_retracement_base_pct": 0.0,
+        "close_retracement_base_pct": 0.01,
+        "twel_entry_gate_enabled": 0.0,
+    }.items():
+        row[TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(key)] = value
+
+    output = runner.run(np.asarray([row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    # The promoted first order executes, but its passive limit did not cross.
+    # Market policy therefore cannot reveal the recursive suffix.
+    assert output["fill_count_entry"].item() == 2.0
+    assert output["coin_fill_counts"].cpu().tolist() == [[1.0, 1.0]]
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+@pytest.mark.parametrize("cooldown, expands", [(0.0, True), (100.0, False)])
+def test_mps_tm_multicoin_recursive_market_entry_passive_suffix(
+    side, cooldown, expands
+):
+    count = 6
+    closes = np.tile(np.asarray([100.0, 120.0]), (count, 1))
+    highs = closes.copy()
+    lows = closes.copy()
+    if side == "long":
+        lows[3] = closes[3] * 0.8
+    else:
+        highs[3] = closes[3] * 1.2
+    runner, row = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        side,
+        count=count,
+        closes=closes,
+        highs=highs,
+        lows=lows,
+        first_valid_indices=(2, 2),
+        collect_coin_fill_counts=True,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.001,
+    )
+    for key, value in {
+        "entry_double_down_factor": 1.0,
+        "entry_initial_qty_pct": 0.1,
+        "entry_initial_ema_dist": 0.0005,
+        "entry_threshold_base_pct": 0.01,
+        "entry_retracement_base_pct": 0.0,
+        "close_retracement_base_pct": 0.01,
+        "twel_entry_gate_enabled": 0.0,
+        "entry_cooldown_minutes": cooldown,
+    }.items():
+        row[TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(key)] = value
+
+    output = runner.run(np.asarray([row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    counts = output["coin_fill_counts"].cpu().tolist()[0]
+    if expands:
+        assert output["fill_count_entry"].item() > 2.0
+        assert all(value > 1.0 for value in counts)
+    else:
+        assert output["fill_count_entry"].item() == 2.0
+        assert counts == [1.0, 1.0]
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_recursive_market_entry_stops_duplicate_tick_suffix(
+    side,
+):
+    count = 5
+    closes = np.tile(np.asarray([100.0, 120.0]), (count, 1))
+    highs = closes.copy()
+    lows = closes.copy()
+    if side == "long":
+        lows[3] = closes[3] * 0.8
+    else:
+        highs[3] = closes[3] * 1.2
+    runner, row = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        side,
+        count=count,
+        closes=closes,
+        highs=highs,
+        lows=lows,
+        first_valid_indices=(2, 2),
+        collect_coin_fill_counts=True,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.001,
+    )
+    for key, value in {
+        "entry_double_down_factor": 1.0,
+        "entry_initial_qty_pct": 0.1,
+        "entry_initial_ema_dist": 0.0005,
+        "entry_threshold_base_pct": 0.0,
+        "entry_retracement_base_pct": 0.0,
+        "close_retracement_base_pct": 0.01,
+        "twel_entry_gate_enabled": 0.0,
+    }.items():
+        row[TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(key)] = value
+
+    output = runner.run(np.asarray([row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert output["fill_count_entry"].item() == 2.0
+    assert output["coin_fill_counts"].cpu().tolist() == [[1.0, 1.0]]
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_coin_override_selects_recursive_market_entry(side):
+    count = 6
+    closes = np.tile(np.asarray([100.0, 120.0]), (count, 1))
+    highs = closes.copy()
+    lows = closes.copy()
+    if side == "long":
+        lows[3] = closes[3] * 0.8
+    else:
+        highs[3] = closes[3] * 1.2
+    overrides = np.full((2, 44), np.nan, dtype=np.float32)
+    overrides[1, 11] = 0.0
+    runner, row = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        side,
+        coin_overrides=overrides,
+        count=count,
+        closes=closes,
+        highs=highs,
+        lows=lows,
+        first_valid_indices=(2, 2),
+        collect_coin_fill_counts=True,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.001,
+    )
+    for key, value in {
+        "entry_double_down_factor": 1.0,
+        "entry_initial_qty_pct": 0.1,
+        "entry_initial_ema_dist": 0.0005,
+        "entry_threshold_base_pct": 0.01,
+        "entry_retracement_base_pct": 0.01,
+        "close_retracement_base_pct": 0.01,
+        "twel_entry_gate_enabled": 0.0,
+    }.items():
+        row[TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(key)] = value
+
+    output = runner.run(np.asarray([row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    counts = output["coin_fill_counts"].cpu().tolist()[0]
+    assert counts[0] == 1.0
+    assert counts[1] > 1.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_tm_multicoin_trailing_market_close_uses_stored_next_close_intent(side):
     count = 8
     base = np.asarray([100.0, 120.0])
@@ -5892,6 +6075,69 @@ def test_mps_tm_multicoin_fused_trailing_market_entries_respect_position_mode(
             promoted["short_psize"].item() > 0.0
         )
     assert promoted["balance"].item() < 1_000.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("hedge_mode", [True, False])
+def test_mps_tm_multicoin_fused_recursive_market_entries_respect_position_mode(
+    hedge_mode,
+):
+    count = 6
+    closes = np.tile(np.asarray([100.0, 120.0]), (count, 1))
+    highs = closes.copy()
+    lows = closes.copy()
+    highs[3] = closes[3] * 1.2
+    lows[3] = closes[3] * 0.8
+    _, row, run, data = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        "long",
+        count=count,
+        closes=closes,
+        highs=highs,
+        lows=lows,
+        first_valid_indices=(2, 2),
+        return_context=True,
+    )
+    for key, value in {
+        "entry_double_down_factor": 1.0,
+        "entry_initial_qty_pct": 0.1,
+        "entry_initial_ema_dist": 0.0005,
+        "entry_threshold_base_pct": 0.01,
+        "entry_retracement_base_pct": 0.0,
+        "close_retracement_base_pct": 0.01,
+        "twel_entry_gate_enabled": 0.0,
+    }.items():
+        row[TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(key)] = value
+    params = np.asarray([row + row], dtype=np.float64)
+    overrides = np.full((2, 44), np.nan, dtype=np.float32)
+    runner = MpsTrailingMartingaleMulticoinFusedRunner(
+        run,
+        data,
+        long_coin_overrides=overrides,
+        short_coin_overrides=overrides,
+        collect_coin_fill_counts=True,
+        hedge_mode=hedge_mode,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.001,
+    )
+
+    output = runner.run(params)
+    torch.mps.synchronize()
+
+    assert output["fill_count_entry"].item() > (4.0 if hedge_mode else 2.0)
+    assert all(
+        value > (2.0 if hedge_mode else 1.0)
+        for value in output["coin_fill_counts"].cpu().tolist()[0]
+    )
+    if hedge_mode:
+        assert output["psize"].item() > 0.0
+        assert output["short_psize"].item() > 0.0
+    else:
+        assert (output["psize"].item() > 0.0) != (
+            output["short_psize"].item() > 0.0
+        )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary
- reconstruct immutable multi-coin Trailing Martingale recursive-entry ladders in the Apple MPS proxy for long, short, fused hedge, and one-way execution
- preserve exact-style passive suffix exposure, per-rung market promotion/minimum sizing, cooldown staging, duplicate-tick termination, and static coin overrides
- fail closed when the portfolio total-exposure entry gate is enabled or can be optimized; cross-coin multi-rung TWEL allocation remains a dedicated follow-up slice

Exact Rust backtests remain authoritative; CPU optimization and bot operation are unchanged.

## Validation
- `cargo test --no-default-features` (267 passed)
- full `tests/optimization` on physical Apple M3 MPS (passed)
- physical MPS recursive-entry long/short, cooldown, duplicate-tick, coin-override, hedge, and one-way regressions (passed)
- cached BTC+ETH recursive-entry GPU optimization: 9 generations, 576 MPS proxy evaluations, 72 exact Rust validations, 22.1s, completed without drift halt
- `python -m compileall -q ...` and `git diff --check`
- `mkdocs build` (passed)
- `mkdocs build --strict` reaches the existing two release-note links to `../CHANGELOG.md`; no new warning from this slice
