### PR TITLE
Add MPS market exposure repair to multi-coin TM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,10 @@ All notable user-facing changes will be documented in this file.
   removes the farthest orders with exact deterministic ties, and may retain one minimum-valid
   partial boundary strictly below the TWEL cap. Static coin overrides may select trailing or
   recursive entry and close mode independently. HSL and forager selection remain supported.
-  Position- and total-exposure repair, auto-unstuck, and realized-loss gating remain fail closed in
-  multi-coin Trailing Martingale market mode pending dedicated parity slices.
+  Position- and total-exposure repair may now promote to market execution, resize against the
+  executable-touch minimum before finalized reducer selection, and retain adverse slippage plus
+  taker fees. Auto-unstuck and realized-loss gating remain fail closed in multi-coin Trailing
+  Martingale market mode pending dedicated parity slices.
 
 - Added baseline multi-coin EMA Anchor ordinary market execution to Apple MPS optimization for
   long-only, short-only, and fused long+short runs. The proxy retains generation-time entry and

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -257,6 +257,8 @@ inline int recursive_grid_close_groups_after_reducer(
     float min_qty,
     float min_cost,
     float c_mult,
+    int prefix_merge_tick,
+    float prefix_merge_qty,
     int max_rungs,
     int wanted_group,
     float generation_market_price,
@@ -325,7 +327,10 @@ inline int recursive_grid_close_groups_after_reducer(
             if (group_count == wanted_group) {
                 selected.ticks = group_ticks;
                 selected.price = group_price;
-                selected.qty = group_qty;
+                selected.qty = group_count == 0
+                        && group_ticks == prefix_merge_tick
+                    ? round_step(group_qty + prefix_merge_qty, qty_step)
+                    : group_qty;
             }
             ++group_count;
             group_ticks = order_tick;
@@ -338,7 +343,10 @@ inline int recursive_grid_close_groups_after_reducer(
         if (group_count == wanted_group) {
             selected.ticks = group_ticks;
             selected.price = group_price;
-            selected.qty = group_qty;
+            selected.qty = group_count == 0
+                    && group_ticks == prefix_merge_tick
+                ? round_step(group_qty + prefix_merge_qty, qty_step)
+                : group_qty;
         }
         ++group_count;
     }
@@ -480,6 +488,7 @@ struct TrailingMartingaleMulticoinSideState {
     float close_gen_allowed_wel[MAX_COINS];
     float close_gen_market_price[MAX_COINS];
     float close_grid_gen_psize[MAX_COINS];
+    float close_grid_prefix_qty[MAX_COINS];
     float position_open_k[MAX_COINS];
     float position_last_fill_k[MAX_COINS];
     float score[MAX_COINS];
@@ -500,6 +509,7 @@ struct TrailingMartingaleMulticoinSideState {
     int twel_close_tick[MAX_COINS];
     int unstuck_close_tick[MAX_COINS];
     int close_grid_max_rungs[MAX_COINS];
+    int close_grid_prefix_tick[MAX_COINS];
     bool selected[MAX_COINS];
     bool incumbent[MAX_COINS];
     bool survivor[MAX_COINS];
@@ -1196,6 +1206,8 @@ inline void finalize_tm_multicoin_close_position(
     side.secondary_close_market[coin] = false;
     side.close_reconstruct_after_reducer[coin] = false;
     side.close_recursive_market_mode[coin] = false;
+    side.close_grid_prefix_qty[coin] = 0.0f;
+    side.close_grid_prefix_tick[coin] = 0;
     side.close_is_exposure_reducer[coin] = false;
     side.close_is_unstuck_reducer[coin] = false;
     side.close_is_hsl_panic[coin] = false;
@@ -1295,12 +1307,14 @@ inline bool process_tm_multicoin_side_fills(
     thread float* close_gen_allowed_wel = side.close_gen_allowed_wel;
     thread float* close_gen_market_price = side.close_gen_market_price;
     thread float* close_grid_gen_psize = side.close_grid_gen_psize;
+    thread float* close_grid_prefix_qty = side.close_grid_prefix_qty;
     thread int* entry_tick = side.entry_tick;
     thread int* entry_gen_initial_tick = side.entry_gen_initial_tick;
     thread int* entry_gen_touch_tick = side.entry_gen_touch_tick;
     thread int* close_tick = side.close_tick;
     thread int* secondary_close_tick = side.secondary_close_tick;
     thread int* close_grid_max_rungs = side.close_grid_max_rungs;
+    thread int* close_grid_prefix_tick = side.close_grid_prefix_tick;
     thread bool* close_reconstruct_after_reducer =
         side.close_reconstruct_after_reducer;
     thread bool* close_recursive_market_mode =
@@ -1473,6 +1487,8 @@ inline bool process_tm_multicoin_side_fills(
                     min_qty,
                     min_cost,
                     c_mult,
+                    close_grid_prefix_tick[c],
+                    close_grid_prefix_qty[c],
                     close_grid_max_rungs[c],
                     -1,
                     close_gen_market_price[c],
@@ -1530,6 +1546,8 @@ inline bool process_tm_multicoin_side_fills(
                     min_qty,
                     min_cost,
                     c_mult,
+                    close_grid_prefix_tick[c],
+                    close_grid_prefix_qty[c],
                     close_grid_max_rungs[c],
                     wanted,
                     close_gen_market_price[c],
@@ -1614,6 +1632,8 @@ inline bool process_tm_multicoin_side_fills(
                     min_qty,
                     min_cost,
                     c_mult,
+                    close_grid_prefix_tick[c],
+                    close_grid_prefix_qty[c],
                     close_grid_max_rungs[c],
                     wanted,
                     close_gen_market_price[c],
@@ -2136,6 +2156,7 @@ inline void init_trailing_martingale_multicoin_side_state(
         side.close_gen_allowed_wel[c] = 0.0f;
         side.close_gen_market_price[c] = 0.0f;
         side.close_grid_gen_psize[c] = 0.0f;
+        side.close_grid_prefix_qty[c] = 0.0f;
         side.position_open_k[c] = -1.0f;
         side.position_last_fill_k[c] = -1.0f;
         side.score[c] = -INFINITY;
@@ -2156,6 +2177,7 @@ inline void init_trailing_martingale_multicoin_side_state(
         side.twel_close_tick[c] = 0;
         side.unstuck_close_tick[c] = 0;
         side.close_grid_max_rungs[c] = 500;
+        side.close_grid_prefix_tick[c] = 0;
         side.selected[c] = false;
         side.incumbent[c] = false;
         side.survivor[c] = false;
@@ -3176,6 +3198,7 @@ inline void generate_tm_multicoin_side_orders(
     thread float* close_gen_allowed_wel = side.close_gen_allowed_wel;
     thread float* close_gen_market_price = side.close_gen_market_price;
     thread float* close_grid_gen_psize = side.close_grid_gen_psize;
+    thread float* close_grid_prefix_qty = side.close_grid_prefix_qty;
     thread float* position_open_k = side.position_open_k;
     thread float* position_last_fill_k = side.position_last_fill_k;
     thread float* contribution = side.contribution;
@@ -3193,6 +3216,7 @@ inline void generate_tm_multicoin_side_orders(
     thread int* twel_close_tick = side.twel_close_tick;
     thread int* unstuck_close_tick = side.unstuck_close_tick;
     thread int* close_grid_max_rungs = side.close_grid_max_rungs;
+    thread int* close_grid_prefix_tick = side.close_grid_prefix_tick;
     thread bool* selected = side.selected;
     thread bool* entry_candidate = side.entry_candidate;
     thread bool* entry_recursive_market_mode =
@@ -3508,8 +3532,10 @@ inline void generate_tm_multicoin_side_orders(
         close_recursive_market_mode[c] = false;
         close_is_hsl_panic[c] = false;
         close_grid_gen_psize[c] = 0.0f;
+        close_grid_prefix_qty[c] = 0.0f;
         close_gen_market_price[c] = 0.0f;
         close_grid_max_rungs[c] = 500;
+        close_grid_prefix_tick[c] = 0;
         contribution[c] = 0.0f;
         entry_candidate[c] = false;
         int coin_offset = c * COIN_COLS;
@@ -3850,14 +3876,7 @@ inline void generate_tm_multicoin_side_orders(
                 wel_reducer_tick, short_side, price_now, price_step,
                 market_orders_allowed, market_order_near_touch_threshold
             );
-        if (wel_reducer_market) {
-            wel_reducer_qty = resize_market_close_qty(
-                wel_reducer_qty, psize[c], price_now,
-                qty_step, min_qty, min_cost, c_mult
-            );
-        }
-        float wel_reducer_exec_price = wel_reducer_market
-            ? price_now : float(wel_reducer_tick) * price_step;
+        float wel_reducer_exec_price = float(wel_reducer_tick) * price_step;
         float raw_unstuck_reducer_qty = unstuck_close_qty[c];
         int raw_unstuck_reducer_tick = unstuck_close_tick[c];
 
@@ -3975,6 +3994,86 @@ inline void generate_tm_multicoin_side_orders(
             }
             close_qty[c] = 0.0f;
             close_market[c] = false;
+        }
+
+        // calc_closes_long/short generates WEL as the first strategy close,
+        // then merges the following recursive group when both quantize to
+        // the same tick.  Preserve that passive prefix until the completed
+        // group is known; ordinary market sizing is a later policy step and
+        // must see the merged quantity once, not resize WEL independently.
+        float strategy_grid_psize = fmax(
+            round_step(psize[c] - strategy_wel_reducer_qty, qty_step),
+            0.0f
+        );
+        close_grid_prefix_qty[c] = strategy_wel_reducer_qty;
+        close_grid_prefix_tick[c] = strategy_wel_reducer_qty > 0.0f
+            ? wel_reducer_tick : 0;
+        int strategy_grid_rung_limit = strategy_wel_reducer_qty > 0.0f
+            ? 499 : 500;
+        bool strategy_wel_merged = false;
+        CloseGroup strategy_first_group;
+        if (!trailing_close && strategy_wel_reducer_qty > 0.0f
+            && strategy_grid_psize > 0.0f) {
+            int strategy_group_count =
+                recursive_grid_close_groups_after_reducer(
+                    short_side,
+                    strategy_grid_psize,
+                    pprice[c],
+                    balance,
+                    allowed_coin_wel,
+                    touch_down,
+                    touch_up,
+                    touch_nearest_ticks[k * C + c],
+                    as_type<float>(touch_min_qty_bits[k * C + c]),
+                    touch_min_qty_relation[k * C + c],
+                    coin_close_qty_pct,
+                    coin_close_threshold_base,
+                    coin_close_threshold_we,
+                    coin_close_threshold_v1h,
+                    coin_close_threshold_v1m,
+                    volatility_1h[c],
+                    volatility_1m[c],
+                    qty_step,
+                    price_step,
+                    min_qty,
+                    min_cost,
+                    c_mult,
+                    wel_reducer_tick,
+                    strategy_wel_reducer_qty,
+                    strategy_grid_rung_limit,
+                    0,
+                    price_now,
+                    market_orders_allowed,
+                    market_order_near_touch_threshold,
+                    psize[c],
+                    strategy_first_group
+                );
+            strategy_wel_merged = strategy_group_count > 0
+                && strategy_first_group.ticks == wel_reducer_tick;
+        }
+        if (strategy_wel_merged) {
+            // The merged order retains the later ordinary-grid type in Rust,
+            // so it is no longer a protective WEL candidate.  Keeping it in
+            // the reconstructed ordinary ladder also lets a larger TWEL
+            // reducer coexist with it exactly as the orchestrator does.
+            wel_reducer_qty = 0.0f;
+            wel_reducer_market = false;
+            close_qty[c] = strategy_first_group.qty;
+            close_tick[c] = strategy_first_group.ticks;
+            close_market[c] = strategy_first_group.market;
+            close_reconstruct_after_reducer[c] = true;
+            close_recursive_market_mode[c] = true;
+            close_gen_balance[c] = balance;
+            close_gen_allowed_wel[c] = allowed_coin_wel;
+            close_gen_market_price[c] = price_now;
+            close_grid_gen_psize[c] = strategy_grid_psize;
+            close_grid_max_rungs[c] = strategy_grid_rung_limit;
+        } else if (wel_reducer_market) {
+            wel_reducer_qty = resize_market_close_qty(
+                wel_reducer_qty, psize[c], price_now,
+                qty_step, min_qty, min_cost, c_mult
+            );
+            wel_reducer_exec_price = price_now;
         }
 
         // Exact Rust finalizes protective reducers after reserving an
@@ -4235,7 +4334,9 @@ inline void generate_tm_multicoin_side_orders(
             close_reconstruct_after_reducer[c] = false;
             close_recursive_market_mode[c] = false;
             close_grid_gen_psize[c] = 0.0f;
+            close_grid_prefix_qty[c] = 0.0f;
             close_gen_market_price[c] = 0.0f;
+            close_grid_prefix_tick[c] = 0;
             close_is_unstuck_reducer[c] = false;
             close_is_hsl_panic[c] = true;
         }

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -511,6 +511,7 @@ struct TrailingMartingaleMulticoinSideState {
     bool entry_market[MAX_COINS];
     bool close_market[MAX_COINS];
     bool secondary_close_market[MAX_COINS];
+    bool close_is_exposure_reducer[MAX_COINS];
     bool close_is_unstuck_reducer[MAX_COINS];
     bool close_is_hsl_panic[MAX_COINS];
     bool entry_deferred_twel_gate;
@@ -1195,6 +1196,7 @@ inline void finalize_tm_multicoin_close_position(
     side.secondary_close_market[coin] = false;
     side.close_reconstruct_after_reducer[coin] = false;
     side.close_recursive_market_mode[coin] = false;
+    side.close_is_exposure_reducer[coin] = false;
     side.close_is_unstuck_reducer[coin] = false;
     side.close_is_hsl_panic[coin] = false;
     side.filled_coin[coin] = true;
@@ -1309,6 +1311,8 @@ inline bool process_tm_multicoin_side_fills(
     thread bool* entry_market = side.entry_market;
     thread bool* close_market = side.close_market;
     thread bool* secondary_close_market = side.secondary_close_market;
+    thread bool* close_is_exposure_reducer =
+        side.close_is_exposure_reducer;
     thread bool* close_is_unstuck_reducer =
         side.close_is_unstuck_reducer;
     thread bool* close_is_hsl_panic = side.close_is_hsl_panic;
@@ -1401,7 +1405,9 @@ inline bool process_tm_multicoin_side_fills(
             && close_reconstruct_after_reducer[c]
             && (!close_recursive_market_mode[c] || recursive_market_expand)
             && !close_is_hsl_panic[c];
-        if (recursive_market_expand) filled_close = false;
+        if (recursive_market_expand && !close_is_exposure_reducer[c]) {
+            filled_close = false;
+        }
         if (filled_close || filled_secondary_close || rebuild_grid) {
             float fill_price = primary_market
                 ? ordinary_market_fill_price(
@@ -1411,6 +1417,7 @@ inline bool process_tm_multicoin_side_fills(
                 : float(close_tick[c]) * price_step;
             float reducer_qty = rebuild_grid
                     && close_recursive_market_mode[c]
+                    && !close_is_exposure_reducer[c]
                 ? 0.0f
                 : fmin(round_step(close_qty[c], qty_step), psize[c]);
             float grid_gen_psize = close_grid_gen_psize[c];
@@ -1726,8 +1733,8 @@ inline bool process_tm_multicoin_side_fills(
             bool secondary_first = filled_secondary_close
                 && (!(filled_close && !reducer_executed)
                     || (short_side
-                        ? secondary_price >= fill_price
-                        : secondary_price <= fill_price));
+                        ? secondary_close_tick[c] >= close_tick[c]
+                        : secondary_close_tick[c] <= close_tick[c]));
             for (int close_rank = 0; close_rank < 2; ++close_rank) {
                 bool use_secondary = secondary_first
                     ? close_rank == 0 : close_rank == 1;
@@ -2149,6 +2156,7 @@ inline void init_trailing_martingale_multicoin_side_state(
         side.entry_market[c] = false;
         side.close_market[c] = false;
         side.secondary_close_market[c] = false;
+        side.close_is_exposure_reducer[c] = false;
         side.close_is_unstuck_reducer[c] = false;
         side.close_is_hsl_panic[c] = false;
         side.coin_realized_pnl[c] = 0.0f;
@@ -3185,6 +3193,8 @@ inline void generate_tm_multicoin_side_orders(
     thread bool* entry_market = side.entry_market;
     thread bool* close_market = side.close_market;
     thread bool* secondary_close_market = side.secondary_close_market;
+    thread bool* close_is_exposure_reducer =
+        side.close_is_exposure_reducer;
     thread bool* close_is_unstuck_reducer =
         side.close_is_unstuck_reducer;
     thread bool* close_is_hsl_panic = side.close_is_hsl_panic;
@@ -3481,6 +3491,7 @@ inline void generate_tm_multicoin_side_orders(
         entry_market[c] = false;
         close_market[c] = false;
         secondary_close_market[c] = false;
+        close_is_exposure_reducer[c] = false;
         secondary_close_tick[c] = 0;
         close_reconstruct_after_reducer[c] = false;
         close_recursive_market_mode[c] = false;
@@ -3783,6 +3794,19 @@ inline void generate_tm_multicoin_side_orders(
         float raw_twel_reducer_qty = twel_close_qty[c];
         int twel_reducer_tick = twel_close_tick[c];
         float twel_reducer_price = float(twel_reducer_tick) * price_step;
+        bool twel_reducer_market = raw_twel_reducer_qty > 0.0f
+            && should_use_ordinary_market_execution(
+                twel_reducer_tick, short_side, price_now, price_step,
+                market_orders_allowed, market_order_near_touch_threshold
+            );
+        if (twel_reducer_market) {
+            raw_twel_reducer_qty = resize_market_close_qty(
+                raw_twel_reducer_qty, psize[c], price_now,
+                qty_step, min_qty, min_cost, c_mult
+            );
+        }
+        float twel_reducer_exec_price = twel_reducer_market
+            ? price_now : twel_reducer_price;
         float wel_reducer_qty = 0.0f;
         int wel_reducer_tick = 0;
         float wel_target = allowed_coin_wel
@@ -3805,6 +3829,19 @@ inline void generate_tm_multicoin_side_orders(
                 wel_reducer_qty = 0.0f;
             }
         }
+        bool wel_reducer_market = wel_reducer_qty > 0.0f
+            && should_use_ordinary_market_execution(
+                wel_reducer_tick, short_side, price_now, price_step,
+                market_orders_allowed, market_order_near_touch_threshold
+            );
+        if (wel_reducer_market) {
+            wel_reducer_qty = resize_market_close_qty(
+                wel_reducer_qty, psize[c], price_now,
+                qty_step, min_qty, min_cost, c_mult
+            );
+        }
+        float wel_reducer_exec_price = wel_reducer_market
+            ? price_now : float(wel_reducer_tick) * price_step;
         float raw_unstuck_reducer_qty = unstuck_close_qty[c];
         int raw_unstuck_reducer_tick = unstuck_close_tick[c];
 
@@ -3931,17 +3968,17 @@ inline void generate_tm_multicoin_side_orders(
             && trailing_close && close_qty[c] > 0.0f;
         float finalized_wel_reducer_qty = finalized_reducer_qty(
             psize[c], wel_reducer_qty,
-            float(wel_reducer_tick) * price_step,
+            wel_reducer_exec_price,
             qty_step, min_qty, min_cost, c_mult
         );
         float finalized_twel_reducer_qty = ordinary_can_accompany_reducer
             ? finalized_reducer_qty_with_ordinary(
-                psize[c], raw_twel_reducer_qty, twel_reducer_price,
+                psize[c], raw_twel_reducer_qty, twel_reducer_exec_price,
                 close_qty[c], minimum_close, minimum_close_relation,
                 qty_step, min_qty, min_cost, c_mult
             )
             : finalized_reducer_qty(
-                psize[c], raw_twel_reducer_qty, twel_reducer_price,
+                psize[c], raw_twel_reducer_qty, twel_reducer_exec_price,
                 qty_step, min_qty, min_cost, c_mult
             );
         float unstuck_reducer_price =
@@ -3978,6 +4015,8 @@ inline void generate_tm_multicoin_side_orders(
             ? raw_unstuck_reducer_qty : exposure_reducer_qty;
         int reducer_tick = use_unstuck
             ? raw_unstuck_reducer_tick : exposure_reducer_tick;
+        bool reducer_market = !use_unstuck && (use_twel
+            ? twel_reducer_market : wel_reducer_market);
         if (use_unstuck && !realized_loss_proxy_allows_reducer(
                 finalized_unstuck_reducer_qty,
                 float(reducer_tick) * price_step, pprice[c], short_side,
@@ -3988,11 +4027,15 @@ inline void generate_tm_multicoin_side_orders(
             use_unstuck = false;
             reducer_qty = exposure_reducer_qty;
             reducer_tick = exposure_reducer_tick;
+            reducer_market = use_twel
+                ? twel_reducer_market : wel_reducer_market;
         }
         if (reducer_qty > 0.0f && reducer_tick > 0) {
             float reducer_price = float(reducer_tick) * price_step;
+            float reducer_exec_price = reducer_market
+                ? price_now : reducer_price;
             float reducer_min = min_entry_qty(
-                reducer_price, qty_step, min_qty, min_cost, c_mult
+                reducer_exec_price, qty_step, min_qty, min_cost, c_mult
             );
             if ((use_twel || use_unstuck) && wel_reducer_qty <= 0.0f
                 && trailing_close && close_qty[c] > 0.0f) {
@@ -4057,7 +4100,8 @@ inline void generate_tm_multicoin_side_orders(
             }
             close_qty[c] = reducer_qty;
             close_tick[c] = reducer_tick;
-            close_market[c] = false;
+            close_market[c] = reducer_market;
+            close_is_exposure_reducer[c] = !use_unstuck;
             close_is_unstuck_reducer[c] = use_unstuck;
         }
     }
@@ -4163,6 +4207,7 @@ inline void generate_tm_multicoin_side_orders(
             secondary_close_tick[c] = 0;
             close_market[c] = false;
             secondary_close_market[c] = false;
+            close_is_exposure_reducer[c] = false;
             close_reconstruct_after_reducer[c] = false;
             close_recursive_market_mode[c] = false;
             close_grid_gen_psize[c] = 0.0f;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -1489,8 +1489,17 @@ inline bool process_tm_multicoin_side_fills(
             );
             float remaining_budget = ordinary_budget;
             float kept_ordinary = 0.0f;
+            // A market reducer was sized and admitted against the executable
+            // touch captured when the order was generated.  Keep that same
+            // minimum for recursive-ladder dust allocation; the next
+            // candle's slipped fill price may change realized PnL, but must
+            // not rewrite an already emitted quantity.
+            float reducer_allocation_price = primary_market
+                    && close_is_exposure_reducer[c]
+                ? close_gen_market_price[c] : fill_price;
             float minimum_any = min_entry_qty(
-                fill_price, qty_step, min_qty, min_cost, c_mult
+                reducer_allocation_price,
+                qty_step, min_qty, min_cost, c_mult
             );
             int last_kept_rank = -1;
             bool all_groups_below_min = close_recursive_market_mode[c]
@@ -1655,18 +1664,20 @@ inline bool process_tm_multicoin_side_fills(
                         : close_tick[c] < group.ticks);
                 if (reducer_before_group) {
                     float qty = fmin(reducer_qty, psize[c]);
+                    float reducer_fee_rate = primary_market
+                        ? taker_fee : maker_fee;
                     float pnl = qty * c_mult * (short_side
                         ? pprice[c] - fill_price
                         : fill_price - pprice[c]);
                     if (realized_loss_proxy_allows_reducer(
                             qty, fill_price, pprice[c], short_side,
-                            c_mult, maker_fee,
+                            c_mult, reducer_fee_rate,
                             close_is_unstuck_reducer[c], loss_gate_enabled,
                             balance, realized_pnl_cumsum_last,
                             realized_pnl_cumsum_max, max_realized_loss_pct
                         )) {
                         float net_pnl = pnl
-                            - qty * fill_price * c_mult * maker_fee;
+                            - qty * fill_price * c_mult * reducer_fee_rate;
                         record_tm_multicoin_close_fill(
                             side, account, fills, coin_fill_counts,
                             int(b), C, c, k, pnl, net_pnl, qty,
@@ -1757,16 +1768,16 @@ inline bool process_tm_multicoin_side_fills(
                     && close_is_hsl_panic[c];
                 bool market_execution = use_secondary
                     ? secondary_close_market[c] : primary_market;
+                float fee_rate = market_execution ? taker_fee : maker_fee;
                 if (!is_hsl_panic && !realized_loss_proxy_allows_reducer(
                         qty, price, pprice[c], short_side,
-                        c_mult, maker_fee, is_unstuck, loss_gate_enabled,
+                        c_mult, fee_rate, is_unstuck, loss_gate_enabled,
                         balance, realized_pnl_cumsum_last,
                         realized_pnl_cumsum_max, max_realized_loss_pct
                     )) {
                     continue;
                 }
-                float net_pnl = pnl - qty * price * c_mult
-                    * (market_execution ? taker_fee : maker_fee);
+                float net_pnl = pnl - qty * price * c_mult * fee_rate;
                 record_tm_multicoin_close_fill(
                     side, account, fills, coin_fill_counts,
                     int(b), C, c, k, pnl, net_pnl, qty,
@@ -3829,6 +3840,11 @@ inline void generate_tm_multicoin_side_orders(
                 wel_reducer_qty = 0.0f;
             }
         }
+        // Recursive strategy generation reserves the original passive WEL
+        // request.  Market execution may enlarge the emitted candidate to an
+        // executable-touch minimum, but that policy sizing must not alter the
+        // immutable strategy ladder reconstructed from the remaining size.
+        float strategy_wel_reducer_qty = wel_reducer_qty;
         bool wel_reducer_market = wel_reducer_qty > 0.0f
             && should_use_ordinary_market_execution(
                 wel_reducer_tick, short_side, price_now, price_step,
@@ -4076,7 +4092,7 @@ inline void generate_tm_multicoin_side_orders(
                 }
             } else if (!trailing_close) {
                 float reserved_grid_qty = use_unstuck
-                    ? reducer_qty : wel_reducer_qty;
+                    ? reducer_qty : strategy_wel_reducer_qty;
                 close_reconstruct_after_reducer[c] = true;
                 close_gen_balance[c] = balance;
                 close_gen_allowed_wel[c] = allowed_coin_wel;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -4117,6 +4117,14 @@ inline void generate_tm_multicoin_side_orders(
             close_qty[c] = reducer_qty;
             close_tick[c] = reducer_tick;
             close_market[c] = reducer_market;
+            if (reducer_market && !use_unstuck) {
+                // Generation-time executable-touch sizing remains
+                // authoritative for both trailing and recursive protective
+                // closes. Recursive ordinary generation already captures
+                // this snapshot above; trailing reducers need it persisted
+                // here before next-candle dust allocation as well.
+                close_gen_market_price[c] = price_now;
+            }
             close_is_exposure_reducer[c] = !use_unstuck;
             close_is_unstuck_reducer[c] = use_unstuck;
         }

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -935,15 +935,6 @@ def _validate_tm_multicoin_market_runtime_scope(
         )
     for side in sorted(set(enabled_sides or ())):
         side_config = config.get("bot", {}).get(side, {}) or {}
-        risk = side_config.get("risk", {}) or {}
-        if bool(risk.get("position_exposure_enforcer_enabled", False)):
-            unsupported.append(
-                f"bot.{side}.risk.position_exposure_enforcer_enabled=true"
-            )
-        if bool(risk.get("total_exposure_enforcer_enabled", False)):
-            unsupported.append(
-                f"bot.{side}.risk.total_exposure_enforcer_enabled=true"
-            )
         if bool((side_config.get("unstuck", {}) or {}).get("enabled", False)):
             unsupported.append(f"bot.{side}.unstuck.enabled=true")
         strategy = (
@@ -976,23 +967,6 @@ def _validate_tm_multicoin_market_runtime_scope(
                 side_patch = bot_patch.get(side, {}) or {}
                 if not isinstance(side_patch, dict):
                     continue
-                risk_patch = side_patch.get("risk", {}) or {}
-                if not isinstance(risk_patch, dict):
-                    risk_patch = {}
-                if bool(
-                    risk_patch.get("position_exposure_enforcer_enabled", False)
-                ):
-                    unsupported.append(
-                        f"coin_overrides.{coin}.bot.{side}.risk."
-                        "position_exposure_enforcer_enabled=true"
-                    )
-                if bool(
-                    risk_patch.get("total_exposure_enforcer_enabled", False)
-                ):
-                    unsupported.append(
-                        f"coin_overrides.{coin}.bot.{side}.risk."
-                        "total_exposure_enforcer_enabled=true"
-                    )
                 unstuck_patch = side_patch.get("unstuck", {}) or {}
                 if not isinstance(unstuck_patch, dict):
                     unstuck_patch = {}
@@ -1030,9 +1004,8 @@ def _validate_tm_multicoin_market_runtime_scope(
         raise ValueError(
             "GPU multi-coin Trailing Martingale ordinary market execution "
             "currently supports wholly trailing or wholly recursive ordinary "
-            "entries and closes; position/TWEL reducers, auto-unstuck, and "
-            "realized-loss "
-            "gating; unsupported settings: "
+            "entries and closes plus position/TWEL reducers; auto-unstuck "
+            "and realized-loss gating remain unsupported; settings: "
             + ", ".join(unsupported)
         )
 
@@ -2954,11 +2927,7 @@ def _validate_tm_multicoin_market_foundation_bounds(
         return
     unsupported = []
     for side in sorted(set(enabled_sides or ())):
-        for suffix in (
-            "risk_position_exposure_enforcer_enabled",
-            "risk_total_exposure_enforcer_enabled",
-            "unstuck_enabled",
-        ):
+        for suffix in ("unstuck_enabled",):
             key = f"{side}_{suffix}"
             bound = bound_by_key.get(key)
             values = (

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1734,19 +1734,11 @@ def test_gpu_multicoin_tm_market_execution_accepts_recursive_close_bounds(
     )
 
 
-@pytest.mark.parametrize(
-    "suffix",
-    [
-        "unstuck_enabled",
-        "risk_position_exposure_enforcer_enabled",
-        "risk_total_exposure_enforcer_enabled",
-    ],
-)
-def test_gpu_multicoin_tm_market_execution_rejects_reducer_bounds(suffix):
+def test_gpu_multicoin_tm_market_execution_rejects_unstuck_bounds():
     config = _long_only_ema_config()
     config["live"]["strategy_kind"] = "trailing_martingale"
     config["live"]["market_orders_allowed"] = True
-    key = f"long_{suffix}"
+    key = "long_unstuck_enabled"
 
     with pytest.raises(ValueError, match=key):
         _validate_tm_multicoin_market_foundation_bounds(
@@ -1756,6 +1748,30 @@ def test_gpu_multicoin_tm_market_execution_rejects_reducer_bounds(suffix):
             config,
             coin_count=3,
         )
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        "risk_position_exposure_enforcer_enabled",
+        "risk_total_exposure_enforcer_enabled",
+    ],
+)
+def test_gpu_multicoin_tm_market_execution_accepts_exposure_reducer_bounds(
+    suffix,
+):
+    config = _long_only_ema_config()
+    config["live"]["strategy_kind"] = "trailing_martingale"
+    config["live"]["market_orders_allowed"] = True
+    key = f"long_{suffix}"
+
+    _validate_tm_multicoin_market_foundation_bounds(
+        {key: Bound(0.0, 1.0)},
+        {},
+        {"long"},
+        config,
+        coin_count=3,
+    )
 
 
 def test_gpu_multicoin_tm_recursive_entry_accepts_twel_gate_bounds():
@@ -2974,8 +2990,6 @@ def test_gpu_multicoin_tm_market_execution_accepts_hsl():
     ("feature", "message"),
     [
         ("loss_gate", "max_realized_loss_pct"),
-        ("position", "position_exposure_enforcer_enabled"),
-        ("twel", "total_exposure_enforcer_enabled"),
         ("unstuck", "unstuck.enabled"),
         ("override_unstuck", "coin_overrides.ETH"),
     ],
@@ -2991,14 +3005,6 @@ def test_gpu_multicoin_tm_market_execution_fails_closed_for_reducers(
     strategy["close"]["retracement_base_pct"] = 0.01
     if feature == "loss_gate":
         config["live"]["max_realized_loss_pct"] = 0.05
-    elif feature == "position":
-        config["bot"]["long"]["risk"][
-            "position_exposure_enforcer_enabled"
-        ] = True
-    elif feature == "twel":
-        config["bot"]["long"]["risk"][
-            "total_exposure_enforcer_enabled"
-        ] = True
     elif feature == "unstuck":
         config["bot"]["long"]["unstuck"]["enabled"] = True
     else:
@@ -3008,6 +3014,33 @@ def test_gpu_multicoin_tm_market_execution_fails_closed_for_reducers(
 
     with pytest.raises(ValueError, match=message):
         _validate_scope(config, _MulticoinEvaluator())
+
+
+@pytest.mark.parametrize(
+    ("risk_key", "in_override"),
+    [
+        ("position_exposure_enforcer_enabled", False),
+        ("position_exposure_enforcer_enabled", True),
+        ("total_exposure_enforcer_enabled", False),
+    ],
+)
+def test_gpu_multicoin_tm_market_execution_accepts_exposure_reducers(
+    risk_key, in_override
+):
+    config = _directional_tm_config(long_enabled=True, short_enabled=False)
+    config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "SOL"]
+    config["live"]["market_orders_allowed"] = True
+    strategy = config["bot"]["long"]["strategy"]["trailing_martingale"]
+    strategy["entry"]["retracement_base_pct"] = 0.01
+    strategy["close"]["retracement_base_pct"] = 0.01
+    if in_override:
+        config["coin_overrides"] = {
+            "ETH": {"bot": {"long": {"risk": {risk_key: True}}}}
+        }
+    else:
+        config["bot"]["long"]["risk"][risk_key] = True
+
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
 @pytest.mark.parametrize(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -12490,7 +12490,15 @@ def test_mps_tm_same_tick_twel_and_grid_use_separate_volume_denominators(side):
 
 
 def _tm_multicoin_off_tick_reducer_case(
-    side, *, maker_fee, close_qty_pct=1.0, close_threshold_we=0.0
+    side,
+    *,
+    maker_fee,
+    taker_fee=0.0,
+    close_qty_pct=1.0,
+    close_threshold_we=0.0,
+    market_orders_allowed=False,
+    market_order_near_touch_threshold=0.02,
+    market_order_slippage_pct=0.0,
 ):
     count = 6
     timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
@@ -12504,7 +12512,9 @@ def _tm_multicoin_off_tick_reducer_case(
     hlcvs[:, 1, 1] = 119.0
     hlcvs[:, 1, 2] = 120.0
     hlcvs[:, 1, 3] = 100.0
-    market = ProxyMarket(0.001, 1.0, 0.001, 0.0, 1.0, maker_fee)
+    market = ProxyMarket(
+        0.001, 1.0, 0.001, 0.0, 1.0, maker_fee, taker_fee
+    )
     run = ProxyRun(
         1_000.0,
         1,
@@ -12547,7 +12557,13 @@ def _tm_multicoin_off_tick_reducer_case(
     overrides = np.full((2, 44), np.nan, dtype=np.float32)
     overrides[1, 24] = 0.0
     runner = MpsTrailingMartingaleMulticoinRunner(
-        run, data, side=side, coin_overrides=overrides
+        run,
+        data,
+        side=side,
+        coin_overrides=overrides,
+        market_orders_allowed=market_orders_allowed,
+        market_order_near_touch_threshold=market_order_near_touch_threshold,
+        market_order_slippage_pct=market_order_slippage_pct,
     )
     return runner, candidate, market
 
@@ -12642,6 +12658,58 @@ def test_mps_tm_multicoin_off_tick_grid_precedes_reducer_for_volume(side):
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_market_grid_precedes_farther_reducer_for_volume(
+    side,
+):
+    runner, candidate, market = _tm_multicoin_off_tick_reducer_case(
+        side,
+        maker_fee=0.001,
+        taker_fee=0.002,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.006,
+        market_order_slippage_pct=0.01,
+    )
+    output = runner.run(np.asarray([candidate], dtype=np.float64))
+    torch.mps.synchronize()
+
+    entry_price = 99.0 if side == "long" else 101.0
+    entry_qty = 10.101 if side == "long" else 9.9
+    grid_qty = 5.045 if side == "long" else 4.945
+    reducer_qty = entry_qty - grid_qty
+    market_fill_price = 99.0 if side == "long" else 101.0
+    balance = 1_000.0 - entry_qty * entry_price * market.maker_fee
+    expected_volume = entry_qty * entry_price / balance
+    grid_pnl = grid_qty * (
+        market_fill_price - entry_price
+        if side == "long"
+        else entry_price - market_fill_price
+    )
+    balance += (
+        grid_pnl
+        - grid_qty * market_fill_price * market.taker_fee
+    )
+    expected_volume += grid_qty * market_fill_price / balance
+    reducer_pnl = reducer_qty * (
+        market_fill_price - entry_price
+        if side == "long"
+        else entry_price - market_fill_price
+    )
+    balance += (
+        reducer_pnl
+        - reducer_qty * market_fill_price * market.taker_fee
+    )
+    expected_volume += reducer_qty * market_fill_price / balance
+
+    assert output["balance"].item() == pytest.approx(balance, abs=3.0e-4)
+    assert output["day_volume"].sum().item() == pytest.approx(
+        expected_volume, rel=2.0e-5
+    )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_tm_multicoin_reducer_consumes_one_recursive_close_slot(side):
     runner, candidate, _ = _tm_multicoin_off_tick_reducer_case(
         side,
@@ -12687,6 +12755,82 @@ def test_mps_tm_multicoin_global_position_exposure_repair(side):
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+@pytest.mark.parametrize("side", ["long", "short"])
+@pytest.mark.parametrize("repair_kind", ["position", "total"])
+def test_mps_tm_multicoin_market_exposure_repair_uses_slippage_and_taker_fee(
+    side, repair_kind
+):
+    market_no_fee = [
+        ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0, 0.0)
+        for _ in range(2)
+    ]
+    market_with_taker_fee = [
+        ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0, 0.002)
+        for _ in range(2)
+    ]
+    passive_runner, row = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        side,
+        count=10,
+        markets=market_no_fee,
+    )
+    promoted_runner, _ = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        side,
+        count=10,
+        markets=market_no_fee,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.002,
+        market_order_slippage_pct=0.01,
+    )
+    fee_runner, _ = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        side,
+        count=10,
+        markets=market_with_taker_fee,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.002,
+        market_order_slippage_pct=0.01,
+    )
+    values = dict(zip(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, row))
+    values.update(
+        {
+            "entry_cooldown_minutes": 100.0,
+            "twel_entry_gate_enabled": 0.0,
+            "wel_enforcer_threshold": 0.5,
+            "twel_enforcer_threshold": 0.5,
+            "wel_enforcer_enabled": float(repair_kind == "position"),
+            "twel_enforcer_enabled": float(repair_kind == "total"),
+            "twel_enforcer_reduce_portfolio": float(
+                repair_kind == "total"
+            ),
+        }
+    )
+    candidate = np.asarray(
+        [
+            [
+                values[key]
+                for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+            ]
+        ],
+        dtype=np.float64,
+    )
+
+    passive = passive_runner.run(candidate)
+    promoted = promoted_runner.run(candidate)
+    charged = fee_runner.run(candidate)
+    torch.mps.synchronize()
+
+    # The promoted protective reducer crosses immediately at an adverse
+    # directional price; adding a nonzero taker fee then lowers balance again.
+    assert promoted["loss_sum"].item() > passive["loss_sum"].item() + 1.0
+    assert promoted["balance"].item() < passive["balance"].item() - 1.0
+    assert charged["balance"].item() < promoted["balance"].item()
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 @pytest.mark.parametrize(
     ("strategy_kind", "repair_kind"),
     [
@@ -12695,8 +12839,9 @@ def test_mps_tm_multicoin_global_position_exposure_repair(side):
         ("trailing_martingale", "position"),
     ],
 )
+@pytest.mark.parametrize("market_orders_allowed", [False, True])
 def test_mps_fused_dual_multicoin_exposure_repair(
-    strategy_kind, repair_kind
+    strategy_kind, repair_kind, market_orders_allowed
 ):
     fixture_kwargs = {"count": 10}
     if strategy_kind == "ema_anchor":
@@ -12718,10 +12863,22 @@ def test_mps_fused_dual_multicoin_exposure_repair(
         **fixture_kwargs,
     )
     if strategy_kind == "ema_anchor":
-        runner = MpsEmaAnchorMulticoinFusedRunner(run, data)
+        runner = MpsEmaAnchorMulticoinFusedRunner(
+            run,
+            data,
+            market_orders_allowed=market_orders_allowed,
+            market_order_near_touch_threshold=0.002,
+            market_order_slippage_pct=0.01,
+        )
         param_keys = EMA_ANCHOR_MULTICOIN_PARAM_KEYS
     else:
-        runner = MpsTrailingMartingaleMulticoinFusedRunner(run, data)
+        runner = MpsTrailingMartingaleMulticoinFusedRunner(
+            run,
+            data,
+            market_orders_allowed=market_orders_allowed,
+            market_order_near_touch_threshold=0.002,
+            market_order_slippage_pct=0.01,
+        )
         param_keys = TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
 
     baseline = list(baseline)
@@ -12752,6 +12909,90 @@ def test_mps_fused_dual_multicoin_exposure_repair(
     assert output["short_psize"][0].item() > 0.0
     assert output["psize"][1].item() < output["psize"][0].item()
     assert output["short_psize"][1].item() < output["short_psize"][0].item()
+    assert output["fill_count"][1].item() > output["fill_count"][0].item()
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("repair_kind", ["position", "total"])
+def test_mps_tm_fused_one_way_multicoin_market_exposure_repair(repair_kind):
+    _, baseline, run, data = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        "long",
+        count=10,
+        return_context=True,
+    )
+    runner = MpsTrailingMartingaleMulticoinFusedRunner(
+        run,
+        data,
+        hedge_mode=False,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.002,
+        market_order_slippage_pct=0.01,
+    )
+    baseline = list(baseline)
+    baseline[
+        TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(
+            "entry_cooldown_minutes"
+        )
+    ] = 100.0
+    baseline[
+        TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(
+            "entry_initial_ema_dist"
+        )
+    ] = 0.01
+    repaired = list(baseline)
+    if repair_kind == "position":
+        repaired[
+            TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(
+                "wel_enforcer_enabled"
+            )
+        ] = 1.0
+        repaired[
+            TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(
+                "wel_enforcer_threshold"
+            )
+        ] = 0.5
+    else:
+        repaired[
+            TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(
+                "twel_entry_gate_enabled"
+            )
+        ] = 0.0
+        repaired[
+            TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(
+                "twel_enforcer_threshold"
+            )
+        ] = 0.5
+        repaired[
+            TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(
+                "twel_enforcer_enabled"
+            )
+        ] = 1.0
+        repaired[
+            TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(
+                "twel_enforcer_reduce_portfolio"
+            )
+        ] = 1.0
+
+    output = runner.run(
+        np.asarray(
+            [baseline + baseline, repaired + repaired], dtype=np.float64
+        )
+    )
+    torch.mps.synchronize()
+
+    baseline_size = (
+        output["psize"][0].item() + output["short_psize"][0].item()
+    )
+    repaired_size = (
+        output["psize"][1].item() + output["short_psize"][1].item()
+    )
+    assert (output["psize"][0].item() > 0.0) != (
+        output["short_psize"][0].item() > 0.0
+    )
+    assert 0.0 < repaired_size < baseline_size
     assert output["fill_count"][1].item() > output["fill_count"][0].item()
 
 
@@ -13865,15 +14106,27 @@ def test_mps_tm_multicoin_finalized_reducer_tie_keeps_nearer_wel(side):
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("side", ["long", "short"])
-def test_mps_tm_multicoin_static_override_repairs_only_selected_symbol(side):
+@pytest.mark.parametrize("market_orders_allowed", [False, True])
+def test_mps_tm_multicoin_static_override_repairs_only_selected_symbol(
+    side, market_orders_allowed
+):
     overrides = np.full((2, 44), np.nan, dtype=np.float32)
     overrides[0, 26] = 1.0
     overrides[0, 27] = 0.5
     baseline_runner, baseline = _multicoin_exposure_fixture(
-        "trailing_martingale", side, count=10
+        "trailing_martingale",
+        side,
+        count=10,
+        market_orders_allowed=market_orders_allowed,
+        market_order_near_touch_threshold=0.002,
     )
     override_runner, overridden = _multicoin_exposure_fixture(
-        "trailing_martingale", side, overrides, count=10
+        "trailing_martingale",
+        side,
+        overrides,
+        count=10,
+        market_orders_allowed=market_orders_allowed,
+        market_order_near_touch_threshold=0.002,
     )
     baseline_output = baseline_runner.run(
         np.asarray([baseline], dtype=np.float64)

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -12494,8 +12494,12 @@ def _tm_multicoin_off_tick_reducer_case(
     *,
     maker_fee,
     taker_fee=0.0,
+    price_step=1.0,
     close_qty_pct=1.0,
+    close_threshold_base=0.0,
     close_threshold_we=0.0,
+    next_high=101.5,
+    next_low=99.5,
     market_orders_allowed=False,
     market_order_near_touch_threshold=0.02,
     market_order_slippage_pct=0.0,
@@ -12504,8 +12508,8 @@ def _tm_multicoin_off_tick_reducer_case(
     timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
     generation_touch = 100.4 if side == "long" else 100.6
     hlcvs = np.zeros((count, 2, 4), dtype=np.float64)
-    hlcvs[:, 0, 0] = [100.0, 100.0, 100.0, 102.0, 101.5, 100.0]
-    hlcvs[:, 0, 1] = [100.0, 100.0, 100.0, 98.0, 99.5, 100.0]
+    hlcvs[:, 0, 0] = [100.0, 100.0, 100.0, 102.0, next_high, 100.0]
+    hlcvs[:, 0, 1] = [100.0, 100.0, 100.0, 98.0, next_low, 100.0]
     hlcvs[:, 0, 2] = [100.0, 100.0, 100.0, generation_touch, 100.0, 100.0]
     hlcvs[:, 0, 3] = 100.0
     hlcvs[:, 1, 0] = 121.0
@@ -12513,7 +12517,7 @@ def _tm_multicoin_off_tick_reducer_case(
     hlcvs[:, 1, 2] = 120.0
     hlcvs[:, 1, 3] = 100.0
     market = ProxyMarket(
-        0.001, 1.0, 0.001, 0.0, 1.0, maker_fee, taker_fee
+        0.001, price_step, 0.001, 0.0, 1.0, maker_fee, taker_fee
     )
     run = ProxyRun(
         1_000.0,
@@ -12544,7 +12548,7 @@ def _tm_multicoin_off_tick_reducer_case(
             "gate_initial": 1.0,
             "n_positions": 1.0,
             "close_qty_pct": close_qty_pct,
-            "close_threshold_base_pct": 0.0,
+            "close_threshold_base_pct": close_threshold_base,
             "close_threshold_we_weight": close_threshold_we,
             "close_retracement_base_pct": 0.0,
             "wel_enforcer_enabled": 1.0,
@@ -12566,6 +12570,301 @@ def _tm_multicoin_off_tick_reducer_case(
         market_order_slippage_pct=market_order_slippage_pct,
     )
     return runner, candidate, market
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_tm_multicoin_market_wel_keeps_passive_grid_reservation():
+    import passivbot_rust
+
+    probe_kernel = r"""
+kernel void passivbot_tm_multicoin_market_wel_reservation_probe(
+    constant float* bars,
+    constant int* touch_ticks,
+    constant int* touch_nearest_ticks,
+    constant int* touch_min_qty_bits,
+    constant int* touch_min_qty_relation,
+    constant float* coin_settings,
+    constant float* coin_overrides,
+    constant float* params,
+    device float* output,
+    constant int& short_side_raw,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    bool short_side = short_side_raw != 0;
+    TrailingMartingaleMulticoinSideConfig config =
+        load_trailing_martingale_multicoin_side_config(params, 0);
+    TrailingMartingaleMulticoinSideState side;
+    init_trailing_martingale_multicoin_side_state(
+        side, config, bars, coin_settings, coin_overrides, 1
+    );
+    side.selected[0] = true;
+    side.psize[0] = 10.0f;
+    side.pprice[0] = 100.0f;
+    side.position_open_k[0] = 0.0f;
+    side.position_last_fill_k[0] = 0.0f;
+    JointPortfolioAccount account = init_joint_portfolio_account(1000.0f);
+    generate_tm_multicoin_side_orders(
+        side, config, account,
+        bars, touch_ticks, touch_nearest_ticks,
+        touch_min_qty_bits, touch_min_qty_relation,
+        coin_settings, coin_overrides,
+        1, 1, short_side, 1, 1, 0, false, 1.0f,
+        true, 1.1f, -2, 0ul
+    );
+    output[0] = side.close_qty[0];
+    output[1] = side.close_grid_gen_psize[0];
+    output[2] = side.close_market[0] ? 1.0f : 0.0f;
+    output[3] = side.close_is_exposure_reducer[0] ? 1.0f : 0.0f;
+    output[4] = float(side.close_grid_max_rungs[0]);
+}
+"""
+    _, row = _multicoin_exposure_fixture(
+        "trailing_martingale", "long", count=3, closes=(100.0, 100.0)
+    )
+    values = dict(zip(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, row))
+    values.update(
+        {
+            "entry_initial_qty_pct": 0.0,
+            "close_threshold_base_pct": 10.0,
+            "close_threshold_we_weight": 0.0,
+            "close_retracement_base_pct": 0.0,
+            "n_positions": 1.0,
+            "total_wallet_exposure_limit": 1.0,
+            "wel_enforcer_enabled": 1.0,
+            "wel_enforcer_threshold": 0.99,
+        }
+    )
+    params = torch.tensor(
+        [values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS],
+        dtype=torch.float32,
+        device="mps",
+    )
+    bars = torch.tensor(
+        [[[100.0, 100.0, 100.0, 1.0]], [[100.0, 100.0, 100.0, 1.0]]],
+        dtype=torch.float32,
+        device="mps",
+    )
+    touch_ticks = torch.full(
+        (2, 1, 2), 20_000, dtype=torch.int32, device="mps"
+    )
+    touch_nearest_ticks = torch.full(
+        (2, 1), 20_000, dtype=torch.int32, device="mps"
+    )
+    touch_min_qty_bits = torch.zeros(
+        (2, 1), dtype=torch.int32, device="mps"
+    )
+    touch_min_qty_relation = torch.zeros(
+        (2, 1), dtype=torch.int32, device="mps"
+    )
+    coin_settings = torch.zeros((1, 12), dtype=torch.float32, device="mps")
+    coin_settings[0, 0] = 0.001
+    coin_settings[0, 1] = 0.01
+    coin_settings[0, 2] = 0.001
+    coin_settings[0, 3] = 100.0
+    coin_settings[0, 4] = 1.0
+    coin_settings[0, 7] = 10.0
+    coin_overrides = torch.full(
+        (1, 44), float("nan"), dtype=torch.float32, device="mps"
+    )
+    output = torch.zeros(5, dtype=torch.float32, device="mps")
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_trailing_martingale_multicoin_source_py()
+        + probe_kernel
+    )
+    library.passivbot_tm_multicoin_market_wel_reservation_probe(
+        bars,
+        touch_ticks,
+        touch_nearest_ticks,
+        touch_min_qty_bits,
+        touch_min_qty_relation,
+        coin_settings,
+        coin_overrides,
+        params,
+        output,
+        0,
+        threads=(1, 1, 1),
+    )
+    torch.mps.synchronize()
+
+    # The passive strategy request is 0.5 at price 200, while executable-touch
+    # min-cost sizing at market price 100 promotes the emitted reducer to 1.0.
+    # The immutable ladder must still start from 10.0 - 0.5, not 10.0 - 1.0.
+    assert output.cpu().tolist() == pytest.approx(
+        [1.0, 9.5, 1.0, 1.0, 499.0], abs=2.0e-4
+    )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_tm_multicoin_market_reducer_keeps_generation_dust_allocation():
+    import passivbot_rust
+
+    probe_kernel = r"""
+kernel void passivbot_tm_multicoin_market_reducer_dust_probe(
+    constant float* bars,
+    constant int* fill_ticks,
+    constant int* touch_ticks,
+    constant int* touch_nearest_ticks,
+    constant int* touch_min_qty_bits,
+    constant int* touch_min_qty_relation,
+    constant float* coin_settings,
+    constant float* coin_overrides,
+    constant float* params,
+    device float* coin_fill_counts,
+    device float* output,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    TrailingMartingaleMulticoinSideConfig config =
+        load_trailing_martingale_multicoin_side_config(params, 0);
+    TrailingMartingaleMulticoinSideState side;
+    init_trailing_martingale_multicoin_side_state(
+        side, config, bars, coin_settings, coin_overrides, 1
+    );
+    side.psize[0] = 1.6f;
+    side.pprice[0] = 40.0f;
+    side.position_open_k[0] = 0.0f;
+    side.position_last_fill_k[0] = 0.0f;
+    side.entry_qty[0] = 0.0f;
+    side.close_qty[0] = 1.0f;
+    side.close_tick[0] = 1000;
+    side.close_market[0] = true;
+    side.close_is_exposure_reducer[0] = true;
+    side.close_reconstruct_after_reducer[0] = true;
+    side.close_recursive_market_mode[0] = true;
+    side.close_gen_balance[0] = 1000.0f;
+    side.close_gen_allowed_wel[0] = 0.016f;
+    side.close_gen_market_price[0] = 100.0f;
+    side.close_grid_gen_psize[0] = 0.4f;
+    side.close_grid_max_rungs[0] = 1;
+    CloseGroup probe_group;
+    int probe_group_count = recursive_grid_close_groups_after_reducer(
+        false, 0.4f, 40.0f, 1000.0f, 0.016f,
+        390, 400, 400, 0.0f, 0,
+        config.close_qty_pct, config.close_threshold_base,
+        config.close_threshold_we, config.close_threshold_v1h,
+        config.close_threshold_v1m, 0.0f, 0.0f,
+        0.1f, 0.1f, 0.1f, 40.0f, 1.0f, 1, 0,
+        100.0f, true, 0.001f, 0.4f, probe_group
+    );
+    JointPortfolioAccount account = init_joint_portfolio_account(1000.0f);
+    TrailingMartingaleMulticoinFillState fills =
+        init_trailing_martingale_multicoin_fill_state();
+    float hsl_equity_before_fills = 1000.0f;
+    process_tm_multicoin_side_fills(
+        side, config, account, fills,
+        bars, fill_ticks, touch_ticks, touch_nearest_ticks,
+        touch_min_qty_bits, touch_min_qty_relation,
+        coin_settings, coin_overrides, coin_fill_counts,
+        0, 1, 1, false, true, false, false,
+        1.0f, 0.0f, 0.001f, false, hsl_equity_before_fills
+    );
+    output[0] = side.psize[0];
+    output[1] = fills.fill_count;
+    output[2] = float(probe_group_count);
+    output[3] = probe_group.qty;
+    output[4] = probe_group.price;
+    output[5] = min_entry_qty(
+        probe_group.price, 0.1f, 0.1f, 40.0f, 1.0f
+    );
+    output[6] = probe_group.market ? 1.0f : 0.0f;
+}
+"""
+    _, row = _multicoin_exposure_fixture(
+        "trailing_martingale", "long", count=3, closes=(100.0, 100.0)
+    )
+    values = dict(zip(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, row))
+    values.update(
+        {
+            "close_qty_pct": 1.0,
+            "close_threshold_base_pct": 2.75,
+            "close_threshold_we_weight": 0.0,
+            "close_retracement_base_pct": 0.0,
+        }
+    )
+    params = torch.tensor(
+        [values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS],
+        dtype=torch.float32,
+        device="mps",
+    )
+    fill_ticks = torch.tensor(
+        [[[0, 0]], [[2200, 0]]], dtype=torch.int32, device="mps"
+    )
+    touch_ticks = torch.tensor(
+        [[[390, 400]], [[390, 400]]], dtype=torch.int32, device="mps"
+    )
+    touch_nearest_ticks = torch.full(
+        (2, 1), 400, dtype=torch.int32, device="mps"
+    )
+    touch_min_qty_bits = torch.zeros(
+        (2, 1), dtype=torch.int32, device="mps"
+    )
+    touch_min_qty_relation = torch.zeros(
+        (2, 1), dtype=torch.int32, device="mps"
+    )
+    coin_settings = torch.zeros((1, 12), dtype=torch.float32, device="mps")
+    coin_settings[0, 0] = 0.1
+    coin_settings[0, 1] = 0.1
+    coin_settings[0, 2] = 0.1
+    coin_settings[0, 3] = 40.0
+    coin_settings[0, 4] = 1.0
+    coin_settings[0, 7] = 10.0
+    coin_overrides = torch.full(
+        (1, 44), float("nan"), dtype=torch.float32, device="mps"
+    )
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_trailing_martingale_multicoin_source_py()
+        + probe_kernel
+    )
+
+    remaining_sizes = []
+    for next_close in (100.0, 200.0):
+        bars = torch.tensor(
+            [
+                [[100.0, 40.0, 100.0, 1.0]],
+                    [[220.0, 30.0, next_close, 1.0]],
+            ],
+            dtype=torch.float32,
+            device="mps",
+        )
+        coin_fill_counts = torch.zeros(1, dtype=torch.float32, device="mps")
+        output = torch.zeros(7, dtype=torch.float32, device="mps")
+        library.passivbot_tm_multicoin_market_reducer_dust_probe(
+            bars,
+            fill_ticks,
+            touch_ticks,
+            touch_nearest_ticks,
+            touch_min_qty_bits,
+            touch_min_qty_relation,
+            coin_settings,
+            coin_overrides,
+            params,
+            coin_fill_counts,
+            output,
+            threads=(1, 1, 1),
+        )
+        torch.mps.synchronize()
+        remaining_sizes.append(output.cpu().tolist())
+
+    # The passive group keeps 0.4 at price 150 and leaves a 0.2 remainder.
+    # At the generation touch of 100 the minimum across reducer and group is
+    # 0.3, so the remainder is allocated to that group. A later market fill at
+    # 200 lowers the reducer minimum to 0.2, but cannot retroactively revoke
+    # the already emitted dust allocation.
+    np.testing.assert_allclose(
+        np.asarray(remaining_sizes)[:, :2],
+        [[0.0, 2.0], [0.0, 2.0]],
+        atol=2.0e-4,
+    )
+    np.testing.assert_allclose(
+        np.asarray(remaining_sizes)[:, 2:],
+        [[1.0, 0.4, 150.0, 0.3, 0.0]] * 2,
+        atol=2.0e-4,
+    )
 
 
 @pytest.mark.skipif(
@@ -12704,6 +13003,42 @@ def test_mps_tm_multicoin_market_grid_precedes_farther_reducer_for_volume(
     assert output["day_volume"].sum().item() == pytest.approx(
         expected_volume, rel=2.0e-5
     )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_early_market_reducer_charges_taker_fee(side):
+    common = {
+        "side": side,
+        "maker_fee": 0.0,
+        "price_step": 0.1,
+        "close_threshold_base": 0.02,
+        "next_high": 102.5,
+        "next_low": 97.5,
+        "market_orders_allowed": True,
+        "market_order_near_touch_threshold": 0.005,
+    }
+    free_runner, candidate, _ = _tm_multicoin_off_tick_reducer_case(
+        taker_fee=0.0, **common
+    )
+    charged_runner, _, _ = _tm_multicoin_off_tick_reducer_case(
+        taker_fee=0.002, **common
+    )
+
+    free = free_runner.run(np.asarray([candidate], dtype=np.float64))
+    charged = charged_runner.run(np.asarray([candidate], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    assert charged[size_key].item() == pytest.approx(
+        free[size_key].item(), abs=2.0e-4
+    )
+    # Only the near-touch WEL reducer is promoted; the farther recursive
+    # groups stay passive.  The reducer sorts before the first group, so a
+    # lower balance here specifically proves that early path used taker_fee.
+    assert charged["balance"].item() < free["balance"].item() - 0.01
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -13166,6 +13166,56 @@ def test_mps_tm_multicoin_market_exposure_repair_uses_slippage_and_taker_fee(
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_trailing_market_exposure_repair_stays_partial(side):
+    baseline_runner, row = _multicoin_exposure_fixture(
+        "trailing_martingale", side, count=10
+    )
+    promoted_runner, _ = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        side,
+        count=10,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.002,
+    )
+    values = dict(zip(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, row))
+    values.update(
+        {
+            "entry_cooldown_minutes": 100.0,
+            "close_threshold_base_pct": 10.0,
+            "close_retracement_base_pct": 0.01,
+            "wel_enforcer_enabled": 1.0,
+            "wel_enforcer_threshold": 0.5,
+        }
+    )
+    candidate = np.asarray(
+        [
+            [
+                values[key]
+                for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+            ]
+        ],
+        dtype=np.float64,
+    )
+
+    baseline = baseline_runner.run(candidate)
+    promoted = promoted_runner.run(candidate)
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    # A trailing strategy does not otherwise populate the recursive close
+    # snapshot. The promoted WEL reducer must retain its generation touch so
+    # the next-candle allocator cannot interpret zero as an infinite minimum
+    # and absorb the whole remaining position.
+    assert baseline[size_key].item() > 0.0
+    assert promoted[size_key].item() == pytest.approx(
+        baseline[size_key].item(), abs=2.0e-4
+    )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 @pytest.mark.parametrize(
     ("strategy_kind", "repair_kind"),
     [

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -12503,21 +12503,33 @@ def _tm_multicoin_off_tick_reducer_case(
     market_orders_allowed=False,
     market_order_near_touch_threshold=0.02,
     market_order_slippage_pct=0.0,
+    generation_touch=None,
+    next_close=100.0,
+    min_cost=0.0,
+    collect_coin_fill_counts=False,
 ):
     count = 6
     timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
-    generation_touch = 100.4 if side == "long" else 100.6
+    if generation_touch is None:
+        generation_touch = 100.4 if side == "long" else 100.6
     hlcvs = np.zeros((count, 2, 4), dtype=np.float64)
     hlcvs[:, 0, 0] = [100.0, 100.0, 100.0, 102.0, next_high, 100.0]
     hlcvs[:, 0, 1] = [100.0, 100.0, 100.0, 98.0, next_low, 100.0]
-    hlcvs[:, 0, 2] = [100.0, 100.0, 100.0, generation_touch, 100.0, 100.0]
+    hlcvs[:, 0, 2] = [
+        100.0,
+        100.0,
+        100.0,
+        generation_touch,
+        next_close,
+        100.0,
+    ]
     hlcvs[:, 0, 3] = 100.0
     hlcvs[:, 1, 0] = 121.0
     hlcvs[:, 1, 1] = 119.0
     hlcvs[:, 1, 2] = 120.0
     hlcvs[:, 1, 3] = 100.0
     market = ProxyMarket(
-        0.001, price_step, 0.001, 0.0, 1.0, maker_fee, taker_fee
+        0.001, price_step, 0.001, min_cost, 1.0, maker_fee, taker_fee
     )
     run = ProxyRun(
         1_000.0,
@@ -12568,6 +12580,7 @@ def _tm_multicoin_off_tick_reducer_case(
         market_orders_allowed=market_orders_allowed,
         market_order_near_touch_threshold=market_order_near_touch_threshold,
         market_order_slippage_pct=market_order_slippage_pct,
+        collect_coin_fill_counts=collect_coin_fill_counts,
     )
     return runner, candidate, market
 
@@ -12748,7 +12761,7 @@ kernel void passivbot_tm_multicoin_market_reducer_dust_probe(
         config.close_qty_pct, config.close_threshold_base,
         config.close_threshold_we, config.close_threshold_v1h,
         config.close_threshold_v1m, 0.0f, 0.0f,
-        0.1f, 0.1f, 0.1f, 40.0f, 1.0f, 1, 0,
+        0.1f, 0.1f, 0.1f, 40.0f, 1.0f, 0, 0.0f, 1, 0,
         100.0f, true, 0.001f, 0.4f, probe_group
     );
     JointPortfolioAccount account = init_joint_portfolio_account(1000.0f);
@@ -13003,6 +13016,45 @@ def test_mps_tm_multicoin_market_grid_precedes_farther_reducer_for_volume(
     assert output["day_volume"].sum().item() == pytest.approx(
         expected_volume, rel=2.0e-5
     )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_same_tick_wel_resizes_merged_market_group_once(side):
+    runner, candidate, _ = _tm_multicoin_off_tick_reducer_case(
+        side,
+        maker_fee=0.0,
+        price_step=1.0,
+        close_qty_pct=0.1,
+        close_threshold_base=0.01,
+        close_threshold_we=-0.02,
+        next_high=99.0 if side == "long" else 101.0,
+        next_low=99.0 if side == "long" else 101.0,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.005,
+        generation_touch=99.0 if side == "long" else 101.0,
+        next_close=99.0 if side == "long" else 101.0,
+        min_cost=50.0,
+        collect_coin_fill_counts=True,
+    )
+    values = dict(zip(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, candidate))
+    values["wel_enforcer_threshold"] = 0.99
+    candidate = [
+        values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+    ]
+
+    output = runner.run(np.asarray([candidate], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    # Exact calc_closes_* merges the below-executable-minimum WEL prefix with
+    # the first same-tick recursive grid group before market sizing. The
+    # completed group therefore executes once, after the initial entry.
+    assert output["coin_fill_counts"][0, 0].item() == 2.0
+    assert output["fill_count"].item() == 2.0
+    assert output[size_key].item() > 0.0
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary

- add Apple MPS ordinary-market execution parity for multi-coin Trailing Martingale position-WEL and portfolio-TWEL repair reducers
- resize market-promoted reducers against executable-touch minimum quantity before final selection, then apply adverse slippage and taker fees on fills
- preserve exact recursive-grid ordering and reconstruction when a protective market reducer coexists with ordinary close rungs
- permit supported global WEL/TWEL settings and per-coin WEL overrides while keeping auto-unstuck and realized-loss gating fail closed

Exact Rust remains authoritative; this changes only the GPU optimizer path and is additive to CPU operation.

## Validation

- 443 physical Apple MPS tests: passed
- full tests/optimization suite: passed
- cargo test --no-default-features: 267 passed
- cargo check --tests: passed
- rebuilt and source-stamped Python extension: verified exact fingerprint
- BTC+ETH long+short feature-active smoke: 8 generations, 512 MPS proxy evaluations, 64 exact Rust validations, no drift/classification halt, 63.3 s wall
- feature-active versus disabled baseline: approximately 4.3 percent wall overhead for the added repairs; no disabled-path regression intended
- AI documentation check: 0 errors, 2 existing size warnings
- strict MkDocs: only the two existing release-note links to CHANGELOG.md remain warnings

## Remaining fail-closed scope

- multi-coin Trailing Martingale auto-unstuck market execution
- shared realized-loss gating for those reducers