### PR TITLE
Add MPS market auto-unstuck to multi-coin TM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,11 @@ All notable user-facing changes will be documented in this file.
   recursive entry and close mode independently. HSL and forager selection remain supported.
   Position- and total-exposure repair may now promote to market execution, resize against the
   executable-touch minimum before finalized reducer selection, and retain adverse slippage plus
-  taker fees. Auto-unstuck and realized-loss gating remain fail closed in multi-coin Trailing
-  Martingale market mode pending dedicated parity slices.
+  taker fees. Auto-unstuck now follows the same contract: the one globally selected reducer may be
+  enabled by the side template or a static coin override, is resized at the executable touch while
+  preserving its passive recursive-grid reservation, and fills with adverse slippage and taker
+  fees. Realized-loss gating remains fail closed in multi-coin Trailing Martingale market mode
+  pending its dedicated parity slice.
 
 - Added baseline multi-coin EMA Anchor ordinary market execution to Apple MPS optimization for
   long-only, short-only, and fused long+short runs. The proxy retains generation-time entry and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,9 @@ All notable user-facing changes will be documented in this file.
   executable-touch minimum before finalized reducer selection, and retain adverse slippage plus
   taker fees. Auto-unstuck now follows the same contract: the one globally selected reducer may be
   enabled by the side template or a static coin override, is resized at the executable touch while
-  preserving its passive recursive-grid reservation, and fills with adverse slippage and taker
-  fees. Realized-loss gating remains fail closed in multi-coin Trailing Martingale market mode
-  pending its dedicated parity slice.
+  preserving the independently generated ordinary recursive ladder, and fills with adverse
+  slippage and taker fees. Realized-loss gating remains fail closed in multi-coin Trailing
+  Martingale market mode pending its dedicated parity slice.
 
 - Added baseline multi-coin EMA Anchor ordinary market execution to Apple MPS optimization for
   long-only, short-only, and fused long+short runs. The proxy retains generation-time entry and

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -337,9 +337,12 @@ The supported slice is intentionally narrow:
   `risk.total_exposure_entry_gate_enabled: true`, the proxy performs one deterministic global merge
   of first and recursive suffix rungs across coins, retains nearest orders, and can crop one
   minimum-valid boundary strictly below the TWEL cap. HSL, static coin overrides, and forager
-  selection remain supported. Position- and total-exposure repair, auto-unstuck, and realized-loss
-  gating remain fail closed for multi-coin Trailing Martingale market mode until their market
-  interactions are modeled.
+  selection remain supported. Position- and total-exposure repair plus the one globally selected
+  auto-unstuck reducer may promote to market, executable-touch-size before finalized reducer
+  selection, and retain adverse slippage plus taker fees. Static coin overrides may enable or tune
+  unstuck; recursive-grid reconstruction keeps its passive strategy reservation when market sizing
+  enlarges the emitted reducer. Realized-loss gating remains fail closed for multi-coin Trailing
+  Martingale market mode until its shared-budget interactions are modeled.
 - no invalid candle tail after the selected coin's final valid candle
 
 Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor and

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -340,9 +340,9 @@ The supported slice is intentionally narrow:
   selection remain supported. Position- and total-exposure repair plus the one globally selected
   auto-unstuck reducer may promote to market, executable-touch-size before finalized reducer
   selection, and retain adverse slippage plus taker fees. Static coin overrides may enable or tune
-  unstuck; recursive-grid reconstruction keeps its passive strategy reservation when market sizing
-  enlarges the emitted reducer. Realized-loss gating remains fail closed for multi-coin Trailing
-  Martingale market mode until its shared-budget interactions are modeled.
+  unstuck; recursive-grid reconstruction keeps the independently generated ordinary strategy
+  ladder when market sizing enlarges the external reducer. Realized-loss gating remains fail closed
+  for multi-coin Trailing Martingale market mode until its shared-budget interactions are modeled.
 - no invalid candle tail after the selected coin's final valid candle
 
 Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor and

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -1106,7 +1106,8 @@ mod tests {
         assert!(source.contains("current_effective_n_positions"));
         assert!(source.contains("close_grid_gen_psize"));
         assert!(source.contains("(use_twel || use_unstuck) && wel_reducer_qty <= 0.0f"));
-        assert!(source.contains("float reserved_grid_qty = use_unstuck"));
+        assert!(source.contains("float reserved_grid_qty = strategy_wel_reducer_qty"));
+        assert!(!source.contains("strategy_unstuck_reducer_qty"));
         assert!(source.contains("psize[c] - reserved_grid_qty"));
         assert!(source.contains("dust_remainder"));
         assert!(!source.contains("float primary_diff = fabs"));

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -3879,6 +3879,26 @@ inline void generate_tm_multicoin_side_orders(
         float wel_reducer_exec_price = float(wel_reducer_tick) * price_step;
         float raw_unstuck_reducer_qty = unstuck_close_qty[c];
         int raw_unstuck_reducer_tick = unstuck_close_tick[c];
+        // Auto-unstuck is generated as a passive strategy-external intent.
+        // Preserve that immutable request for recursive-grid reconstruction;
+        // ordinary market policy may enlarge only the emitted reducer to the
+        // executable-touch minimum, exactly as the Rust orchestrator does.
+        float strategy_unstuck_reducer_qty = raw_unstuck_reducer_qty;
+        float unstuck_reducer_price =
+            float(raw_unstuck_reducer_tick) * price_step;
+        bool unstuck_reducer_market = raw_unstuck_reducer_qty > 0.0f
+            && should_use_ordinary_market_execution(
+                raw_unstuck_reducer_tick, short_side, price_now, price_step,
+                market_orders_allowed, market_order_near_touch_threshold
+            );
+        if (unstuck_reducer_market) {
+            raw_unstuck_reducer_qty = resize_market_close_qty(
+                raw_unstuck_reducer_qty, psize[c], price_now,
+                qty_step, min_qty, min_cost, c_mult
+            );
+        }
+        float unstuck_reducer_exec_price = unstuck_reducer_market
+            ? price_now : unstuck_reducer_price;
 
         float close_threshold = coin_close_threshold_base
             + wer * coin_close_threshold_we
@@ -4096,18 +4116,16 @@ inline void generate_tm_multicoin_side_orders(
                 psize[c], raw_twel_reducer_qty, twel_reducer_exec_price,
                 qty_step, min_qty, min_cost, c_mult
             );
-        float unstuck_reducer_price =
-            float(raw_unstuck_reducer_tick) * price_step;
         float finalized_unstuck_reducer_qty = ordinary_can_accompany_reducer
             ? finalized_reducer_qty_with_ordinary(
                 psize[c], raw_unstuck_reducer_qty,
-                unstuck_reducer_price, close_qty[c], minimum_close,
+                unstuck_reducer_exec_price, close_qty[c], minimum_close,
                 minimum_close_relation, qty_step, min_qty, min_cost,
                 c_mult
             )
             : finalized_reducer_qty(
                 psize[c], raw_unstuck_reducer_qty,
-                unstuck_reducer_price, qty_step, min_qty, min_cost,
+                unstuck_reducer_exec_price, qty_step, min_qty, min_cost,
                 c_mult
             );
         bool use_twel = finalized_twel_reducer_qty
@@ -4130,8 +4148,9 @@ inline void generate_tm_multicoin_side_orders(
             ? raw_unstuck_reducer_qty : exposure_reducer_qty;
         int reducer_tick = use_unstuck
             ? raw_unstuck_reducer_tick : exposure_reducer_tick;
-        bool reducer_market = !use_unstuck && (use_twel
-            ? twel_reducer_market : wel_reducer_market);
+        bool reducer_market = use_unstuck
+            ? unstuck_reducer_market
+            : (use_twel ? twel_reducer_market : wel_reducer_market);
         if (use_unstuck && !realized_loss_proxy_allows_reducer(
                 finalized_unstuck_reducer_qty,
                 float(reducer_tick) * price_step, pprice[c], short_side,
@@ -4191,7 +4210,8 @@ inline void generate_tm_multicoin_side_orders(
                 }
             } else if (!trailing_close) {
                 float reserved_grid_qty = use_unstuck
-                    ? reducer_qty : strategy_wel_reducer_qty;
+                    ? strategy_unstuck_reducer_qty
+                    : strategy_wel_reducer_qty;
                 close_reconstruct_after_reducer[c] = true;
                 close_gen_balance[c] = balance;
                 close_gen_allowed_wel[c] = allowed_coin_wel;
@@ -4216,7 +4236,7 @@ inline void generate_tm_multicoin_side_orders(
             close_qty[c] = reducer_qty;
             close_tick[c] = reducer_tick;
             close_market[c] = reducer_market;
-            if (reducer_market && !use_unstuck) {
+            if (reducer_market) {
                 // Generation-time executable-touch sizing remains
                 // authoritative for both trailing and recursive protective
                 // closes. Recursive ordinary generation already captures
@@ -4224,7 +4244,10 @@ inline void generate_tm_multicoin_side_orders(
                 // here before next-candle dust allocation as well.
                 close_gen_market_price[c] = price_now;
             }
-            close_is_exposure_reducer[c] = !use_unstuck;
+            // This flag identifies any protective reducer to the recursive
+            // fill/reconstruction path; unstuck has its own orthogonal flag
+            // for realized-loss allowance semantics.
+            close_is_exposure_reducer[c] = true;
             close_is_unstuck_reducer[c] = use_unstuck;
         }
     }

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -3879,11 +3879,6 @@ inline void generate_tm_multicoin_side_orders(
         float wel_reducer_exec_price = float(wel_reducer_tick) * price_step;
         float raw_unstuck_reducer_qty = unstuck_close_qty[c];
         int raw_unstuck_reducer_tick = unstuck_close_tick[c];
-        // Auto-unstuck is generated as a passive strategy-external intent.
-        // Preserve that immutable request for recursive-grid reconstruction;
-        // ordinary market policy may enlarge only the emitted reducer to the
-        // executable-touch minimum, exactly as the Rust orchestrator does.
-        float strategy_unstuck_reducer_qty = raw_unstuck_reducer_qty;
         float unstuck_reducer_price =
             float(raw_unstuck_reducer_tick) * price_step;
         bool unstuck_reducer_market = raw_unstuck_reducer_qty > 0.0f
@@ -4209,9 +4204,11 @@ inline void generate_tm_multicoin_side_orders(
                     secondary_close_market[c] = close_market[c];
                 }
             } else if (!trailing_close) {
-                float reserved_grid_qty = use_unstuck
-                    ? strategy_unstuck_reducer_qty
-                    : strategy_wel_reducer_qty;
+                // Auto-unstuck is external to strategy generation. Preserve
+                // the immutable ordinary ladder and reserve only its optional
+                // strategy WEL prefix; aggregate allocation below trims that
+                // ladder around whichever external reducer wins.
+                float reserved_grid_qty = strategy_wel_reducer_qty;
                 close_reconstruct_after_reducer[c] = true;
                 close_gen_balance[c] = balance;
                 close_gen_allowed_wel[c] = allowed_coin_wel;

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -935,8 +935,6 @@ def _validate_tm_multicoin_market_runtime_scope(
         )
     for side in sorted(set(enabled_sides or ())):
         side_config = config.get("bot", {}).get(side, {}) or {}
-        if bool((side_config.get("unstuck", {}) or {}).get("enabled", False)):
-            unsupported.append(f"bot.{side}.unstuck.enabled=true")
         strategy = (
             side_config.get("strategy", {}).get("trailing_martingale", {}) or {}
         )
@@ -967,13 +965,6 @@ def _validate_tm_multicoin_market_runtime_scope(
                 side_patch = bot_patch.get(side, {}) or {}
                 if not isinstance(side_patch, dict):
                     continue
-                unstuck_patch = side_patch.get("unstuck", {}) or {}
-                if not isinstance(unstuck_patch, dict):
-                    unstuck_patch = {}
-                if bool(unstuck_patch.get("enabled", False)):
-                    unsupported.append(
-                        f"coin_overrides.{coin}.bot.{side}.unstuck.enabled=true"
-                    )
                 strategy_root = side_patch.get("strategy", {}) or {}
                 strategy_patch = (
                     strategy_root.get("trailing_martingale", {}) or {}
@@ -1004,8 +995,8 @@ def _validate_tm_multicoin_market_runtime_scope(
         raise ValueError(
             "GPU multi-coin Trailing Martingale ordinary market execution "
             "currently supports wholly trailing or wholly recursive ordinary "
-            "entries and closes plus position/TWEL reducers; auto-unstuck "
-            "and realized-loss gating remain unsupported; settings: "
+            "entries and closes plus position/TWEL/auto-unstuck reducers; "
+            "realized-loss gating remains unsupported; settings: "
             + ", ".join(unsupported)
         )
 
@@ -2910,45 +2901,6 @@ def _validate_tm_market_template_bounds(
     )
 
 
-def _validate_tm_multicoin_market_foundation_bounds(
-    bound_by_key,
-    base_by_key,
-    enabled_sides,
-    config,
-    *,
-    coin_count: int,
-) -> None:
-    if (
-        coin_count <= 1
-        or str(config.get("live", {}).get("strategy_kind", "")).strip().lower()
-        != "trailing_martingale"
-        or not bool(config.get("live", {}).get("market_orders_allowed"))
-    ):
-        return
-    unsupported = []
-    for side in sorted(set(enabled_sides or ())):
-        for suffix in ("unstuck_enabled",):
-            key = f"{side}_{suffix}"
-            bound = bound_by_key.get(key)
-            values = (
-                (float(bound.low), float(bound.high))
-                if bound is not None
-                else (float(base_by_key.get(key, 0.0)),) * 2
-            )
-            if any(
-                not math.isclose(value, 0.0, abs_tol=1.0e-12)
-                for value in values
-            ):
-                unsupported.append(f"{key} bounds={values}")
-    if unsupported:
-        raise ValueError(
-            "GPU multi-coin Trailing Martingale ordinary market execution "
-            "currently requires protective reducer enablement bounds pinned "
-            "at 0.0: "
-            + ", ".join(unsupported)
-        )
-
-
 def _validate_directional_search_space(
     bound_by_key, base_by_key, approved, enabled_sides, *, coin_count: int = 1
 ) -> None:
@@ -3401,12 +3353,8 @@ def run_backend(
     candidate_source_sides = _gpu_candidate_source_sides(
         candidate_search_sides, gpu_optimizer_overrides
     )
-    unstuck_search_sides = (
-        _gpu_unstuck_search_sides(
-            proxy_config, suite_inputs, gpu_optimizer_overrides
-        )
-        if max_coin_count == 1 or len(config_enabled_sides) == 1
-        else set()
+    unstuck_search_sides = _gpu_unstuck_search_sides(
+        proxy_config, suite_inputs, gpu_optimizer_overrides
     )
     hsl_search_sides = _gpu_hsl_search_sides(
         proxy_config, suite_inputs, gpu_optimizer_overrides
@@ -3472,13 +3420,6 @@ def run_backend(
         suite_inputs,
         coin_count=max_coin_count,
     )
-    _validate_tm_multicoin_market_foundation_bounds(
-        bound_by_key,
-        base_by_key,
-        enabled_sides,
-        proxy_config,
-        coin_count=max_coin_count,
-    )
     _validate_hsl_bound_contracts(bound_by_key, proxy_config)
 
     if suite_multicoin_sides is None:
@@ -3518,13 +3459,6 @@ def run_backend(
             strategy_kind=strategy_kind,
         )
         _validate_tm_market_mode_bounds(
-            scenario_bound_by_key,
-            scenario_base_by_key,
-            scenario_enabled_sides,
-            item["config"],
-            coin_count=item["coin_count"],
-        )
-        _validate_tm_multicoin_market_foundation_bounds(
             scenario_bound_by_key,
             scenario_base_by_key,
             scenario_enabled_sides,

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -75,7 +75,6 @@ from optimization.backends.gpu_backend import (
     _validate_seed_side_match,
     _validate_scope,
     _validate_tm_market_mode_bounds,
-    _validate_tm_multicoin_market_foundation_bounds,
     _validate_tm_market_template_bounds,
     _GPU_SUITE_METRICS_KEY,
     _GPU_SUITE_OBJECTIVES_KEY,
@@ -1734,85 +1733,13 @@ def test_gpu_multicoin_tm_market_execution_accepts_recursive_close_bounds(
     )
 
 
-def test_gpu_multicoin_tm_market_execution_rejects_unstuck_bounds():
+def test_gpu_multicoin_tm_market_execution_accepts_unstuck_config():
     config = _long_only_ema_config()
     config["live"]["strategy_kind"] = "trailing_martingale"
     config["live"]["market_orders_allowed"] = True
-    key = "long_unstuck_enabled"
+    config["bot"]["long"]["unstuck"]["enabled"] = True
 
-    with pytest.raises(ValueError, match=key):
-        _validate_tm_multicoin_market_foundation_bounds(
-            {key: Bound(0.0, 1.0)},
-            {},
-            {"long"},
-            config,
-            coin_count=3,
-        )
-
-
-@pytest.mark.parametrize(
-    "suffix",
-    [
-        "risk_position_exposure_enforcer_enabled",
-        "risk_total_exposure_enforcer_enabled",
-    ],
-)
-def test_gpu_multicoin_tm_market_execution_accepts_exposure_reducer_bounds(
-    suffix,
-):
-    config = _long_only_ema_config()
-    config["live"]["strategy_kind"] = "trailing_martingale"
-    config["live"]["market_orders_allowed"] = True
-    key = f"long_{suffix}"
-
-    _validate_tm_multicoin_market_foundation_bounds(
-        {key: Bound(0.0, 1.0)},
-        {},
-        {"long"},
-        config,
-        coin_count=3,
-    )
-
-
-def test_gpu_multicoin_tm_recursive_entry_accepts_twel_gate_bounds():
-    config = _long_only_ema_config()
-    config["live"]["strategy_kind"] = "trailing_martingale"
-    config["live"]["market_orders_allowed"] = True
-    bounds = {
-        "long_entry_retracement_base_pct": Bound(0.0, 0.0),
-        "long_risk_twel_entry_gate_enabled": Bound(0.0, 1.0),
-    }
-
-    _validate_tm_multicoin_market_foundation_bounds(
-        bounds, {}, {"long"}, config, coin_count=3
-    )
-
-
-def test_gpu_multicoin_tm_recursive_entry_override_accepts_twel_gate_bounds():
-    config = _long_only_ema_config()
-    config["live"]["strategy_kind"] = "trailing_martingale"
-    config["live"]["market_orders_allowed"] = True
-    config["coin_overrides"] = {
-        "ETH": {
-            "bot": {
-                "long": {
-                    "strategy": {
-                        "trailing_martingale": {
-                            "entry": {"retracement_base_pct": 0.0}
-                        }
-                    }
-                }
-            }
-        }
-    }
-    bounds = {
-        "long_entry_retracement_base_pct": Bound(0.001, 0.1),
-        "long_risk_twel_entry_gate_enabled": Bound(0.0, 1.0),
-    }
-
-    _validate_tm_multicoin_market_foundation_bounds(
-        bounds, {}, {"long"}, config, coin_count=3
-    )
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
 @pytest.mark.parametrize("side", ["long", "short"])
@@ -2986,34 +2913,35 @@ def test_gpu_multicoin_tm_market_execution_accepts_hsl():
     assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
-@pytest.mark.parametrize(
-    ("feature", "message"),
-    [
-        ("loss_gate", "max_realized_loss_pct"),
-        ("unstuck", "unstuck.enabled"),
-        ("override_unstuck", "coin_overrides.ETH"),
-    ],
-)
-def test_gpu_multicoin_tm_market_execution_fails_closed_for_reducers(
-    feature, message
-):
+def test_gpu_multicoin_tm_market_execution_rejects_realized_loss_gate():
     config = _directional_tm_config(long_enabled=True, short_enabled=False)
     config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "SOL"]
     config["live"]["market_orders_allowed"] = True
     strategy = config["bot"]["long"]["strategy"]["trailing_martingale"]
     strategy["entry"]["retracement_base_pct"] = 0.01
     strategy["close"]["retracement_base_pct"] = 0.01
-    if feature == "loss_gate":
-        config["live"]["max_realized_loss_pct"] = 0.05
-    elif feature == "unstuck":
-        config["bot"]["long"]["unstuck"]["enabled"] = True
-    else:
+    config["live"]["max_realized_loss_pct"] = 0.05
+
+    with pytest.raises(ValueError, match="max_realized_loss_pct"):
+        _validate_scope(config, _MulticoinEvaluator())
+
+
+@pytest.mark.parametrize("coin_override", [False, True])
+def test_gpu_multicoin_tm_market_execution_accepts_unstuck(coin_override):
+    config = _directional_tm_config(long_enabled=True, short_enabled=False)
+    config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "SOL"]
+    config["live"]["market_orders_allowed"] = True
+    strategy = config["bot"]["long"]["strategy"]["trailing_martingale"]
+    strategy["entry"]["retracement_base_pct"] = 0.01
+    strategy["close"]["retracement_base_pct"] = 0.01
+    if coin_override:
         config["coin_overrides"] = {
             "ETH": {"bot": {"long": {"unstuck": {"enabled": True}}}}
         }
+    else:
+        config["bot"]["long"]["unstuck"]["enabled"] = True
 
-    with pytest.raises(ValueError, match=message):
-        _validate_scope(config, _MulticoinEvaluator())
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
 @pytest.mark.parametrize(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -12714,7 +12714,7 @@ kernel void passivbot_tm_multicoin_market_wel_reservation_probe(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("side", ["long", "short"])
-def test_mps_tm_multicoin_market_unstuck_sizes_at_touch_and_keeps_strategy_grid(
+def test_mps_tm_multicoin_market_unstuck_sizes_at_touch_without_reseeding_grid(
     side,
 ):
     import passivbot_rust
@@ -12838,10 +12838,10 @@ kernel void passivbot_tm_multicoin_market_unstuck_reservation_probe(
     torch.mps.synchronize()
 
     # The passive unstuck request is 0.5 at price 200. Market policy enlarges
-    # only the emitted reducer to the executable-touch minimum of 1.0 at 100;
-    # the immutable recursive ladder still reserves the passive 0.5 request.
+    # the emitted reducer to the executable-touch minimum of 1.0 at 100, but
+    # external unstuck does not reseed Rust's full-size strategy ladder.
     assert output.cpu().tolist() == pytest.approx(
-        [1.0, 9.5, 1.0, 1.0, 1.0, 100.0, 499.0], abs=2.0e-4
+        [1.0, 10.0, 1.0, 1.0, 1.0, 100.0, 500.0], abs=2.0e-4
     )
 
 
@@ -13106,49 +13106,6 @@ kernel void passivbot_tm_multicoin_market_reducer_dust_probe(
         np.asarray(remaining_sizes)[:, 2:],
         [[1.0, 0.4, 150.0, 0.3, 0.0]] * 2,
         atol=2.0e-4,
-    )
-
-
-@pytest.mark.skipif(
-    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
-)
-def test_mps_tm_multicoin_unstuck_reserves_passive_grid_like_equal_wel():
-    runner, wel_candidate, _ = _tm_multicoin_off_tick_reducer_case(
-        "long", maker_fee=0.0
-    )
-    values = dict(
-        zip(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, wel_candidate)
-    )
-    values.update(
-        {
-            "wel_enforcer_enabled": 0.0,
-            "unstuck_enabled": 1.0,
-            "unstuck_ema_gating_enabled": 0.0,
-            "unstuck_close_pct": 0.5102,
-            "unstuck_loss_allowance_pct": 0.2,
-            "unstuck_threshold": 0.5,
-        }
-    )
-    unstuck_candidate = [
-        values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
-    ]
-
-    output = runner.run(
-        np.asarray([wel_candidate, unstuck_candidate], dtype=np.float64)
-    )
-    torch.mps.synchronize()
-
-    # These candidates request the same touch and finalized reducer quantity.
-    # The ordinary passive grid must therefore be generated from the same
-    # reducer-reserved position size for WEL and unstuck.
-    assert output["psize"][1].item() == pytest.approx(
-        output["psize"][0].item(), abs=2.0e-4
-    )
-    assert output["balance"][1].item() == pytest.approx(
-        output["balance"][0].item(), abs=2.0e-4
-    )
-    assert output["day_volume"][1].sum().item() == pytest.approx(
-        output["day_volume"][0].sum().item(), rel=2.0e-5
     )
 
 

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -12713,6 +12713,235 @@ kernel void passivbot_tm_multicoin_market_wel_reservation_probe(
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_market_unstuck_sizes_at_touch_and_keeps_strategy_grid(
+    side,
+):
+    import passivbot_rust
+
+    probe_kernel = r"""
+kernel void passivbot_tm_multicoin_market_unstuck_reservation_probe(
+    constant float* bars,
+    constant int* touch_ticks,
+    constant int* touch_nearest_ticks,
+    constant int* touch_min_qty_bits,
+    constant int* touch_min_qty_relation,
+    constant float* coin_settings,
+    constant float* coin_overrides,
+    constant float* params,
+    device float* output,
+    constant int& short_side_raw,
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    bool short_side = short_side_raw != 0;
+    TrailingMartingaleMulticoinSideConfig config =
+        load_trailing_martingale_multicoin_side_config(params, 0);
+    TrailingMartingaleMulticoinSideState state;
+    init_trailing_martingale_multicoin_side_state(
+        state, config, bars, coin_settings, coin_overrides, 1
+    );
+    state.selected[0] = true;
+    state.psize[0] = 10.0f;
+    state.pprice[0] = 100.0f;
+    state.position_open_k[0] = 0.0f;
+    state.position_last_fill_k[0] = 0.0f;
+    JointPortfolioAccount account = init_joint_portfolio_account(1000.0f);
+    generate_tm_multicoin_side_orders(
+        state, config, account,
+        bars, touch_ticks, touch_nearest_ticks,
+        touch_min_qty_bits, touch_min_qty_relation,
+        coin_settings, coin_overrides,
+        1, 1, short_side, 1, 1, 0, false, 1.0f,
+        true, 1.1f, 0, 0ul
+    );
+    output[0] = state.close_qty[0];
+    output[1] = state.close_grid_gen_psize[0];
+    output[2] = state.close_market[0] ? 1.0f : 0.0f;
+    output[3] = state.close_is_exposure_reducer[0] ? 1.0f : 0.0f;
+    output[4] = state.close_is_unstuck_reducer[0] ? 1.0f : 0.0f;
+    output[5] = state.close_gen_market_price[0];
+    output[6] = float(state.close_grid_max_rungs[0]);
+}
+"""
+    _, row = _multicoin_exposure_fixture(
+        "trailing_martingale", side, count=3, closes=(100.0, 100.0)
+    )
+    values = dict(zip(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, row))
+    values.update(
+        {
+            "entry_initial_qty_pct": 0.0,
+            "close_threshold_base_pct": 10.0,
+            "close_threshold_we_weight": 0.0,
+            "close_retracement_base_pct": 0.0,
+            "n_positions": 1.0,
+            "total_wallet_exposure_limit": 1.0,
+            "wel_enforcer_enabled": 0.0,
+            "twel_enforcer_enabled": 0.0,
+            "unstuck_enabled": 1.0,
+            "unstuck_ema_gating_enabled": 0.0,
+            "unstuck_close_pct": 0.1,
+            "unstuck_loss_allowance_pct": 0.2,
+            "unstuck_threshold": 0.5,
+        }
+    )
+    params = torch.tensor(
+        [values[key] for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS],
+        dtype=torch.float32,
+        device="mps",
+    )
+    bars = torch.tensor(
+        [[[100.0, 100.0, 100.0, 1.0]], [[100.0, 100.0, 100.0, 1.0]]],
+        dtype=torch.float32,
+        device="mps",
+    )
+    touch_ticks = torch.full(
+        (2, 1, 2), 20_000, dtype=torch.int32, device="mps"
+    )
+    touch_nearest_ticks = torch.full(
+        (2, 1), 20_000, dtype=torch.int32, device="mps"
+    )
+    touch_min_qty_bits = torch.zeros(
+        (2, 1), dtype=torch.int32, device="mps"
+    )
+    touch_min_qty_relation = torch.zeros(
+        (2, 1), dtype=torch.int32, device="mps"
+    )
+    coin_settings = torch.zeros((1, 12), dtype=torch.float32, device="mps")
+    coin_settings[0, 0] = 0.001
+    coin_settings[0, 1] = 0.01
+    coin_settings[0, 2] = 0.001
+    coin_settings[0, 3] = 100.0
+    coin_settings[0, 4] = 1.0
+    coin_settings[0, 7] = 10.0
+    coin_overrides = torch.full(
+        (1, 44), float("nan"), dtype=torch.float32, device="mps"
+    )
+    output = torch.zeros(7, dtype=torch.float32, device="mps")
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_trailing_martingale_multicoin_source_py()
+        + probe_kernel
+    )
+    library.passivbot_tm_multicoin_market_unstuck_reservation_probe(
+        bars,
+        touch_ticks,
+        touch_nearest_ticks,
+        touch_min_qty_bits,
+        touch_min_qty_relation,
+        coin_settings,
+        coin_overrides,
+        params,
+        output,
+        int(side == "short"),
+        threads=(1, 1, 1),
+    )
+    torch.mps.synchronize()
+
+    # The passive unstuck request is 0.5 at price 200. Market policy enlarges
+    # only the emitted reducer to the executable-touch minimum of 1.0 at 100;
+    # the immutable recursive ladder still reserves the passive 0.5 request.
+    assert output.cpu().tolist() == pytest.approx(
+        [1.0, 9.5, 1.0, 1.0, 1.0, 100.0, 499.0], abs=2.0e-4
+    )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_market_unstuck_override_pays_slippage_and_taker_fee(
+    side,
+):
+    count = 6
+    closes = np.full((count, 2), 100.0)
+    if side == "long":
+        closes[3:, 0] = 97.5
+        closes[3:, 1] = 98.5
+        highs = closes + 0.01
+        lows = closes.copy()
+    else:
+        closes[3:, 0] = 102.5
+        closes[3:, 1] = 101.5
+        highs = closes.copy()
+        lows = closes - 0.01
+
+    def run_case(*, slippage, taker_fee):
+        markets = [
+            ProxyMarket(1.0, 0.01, 1.0, 0.0, 1.0, 0.0, taker_fee),
+            ProxyMarket(1.0, 0.01, 2.0, 0.0, 1.0, 0.0, taker_fee),
+        ]
+        overrides = np.full((2, 44), np.nan, dtype=np.float32)
+        # Exercise the effective per-coin runtime: the side template remains
+        # disabled while coin one alone enables auto-unstuck.
+        overrides[1, 28] = 1.0
+        runner, candidate = _multicoin_exposure_fixture(
+            "trailing_martingale",
+            side,
+            coin_overrides=overrides,
+            count=count,
+            markets=markets,
+            closes=closes,
+            highs=highs,
+            lows=lows,
+            market_orders_allowed=True,
+            market_order_near_touch_threshold=0.001,
+            market_order_slippage_pct=slippage,
+        )
+        values = dict(
+            zip(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, candidate)
+        )
+        values.update(
+            {
+                "entry_initial_ema_dist": 0.01,
+                "entry_initial_qty_pct": 1.0,
+                "entry_threshold_base_pct": 10.0,
+                "entry_retracement_base_pct": 0.0,
+                "close_threshold_base_pct": 0.5,
+                "close_retracement_base_pct": 0.0,
+                "entry_cooldown_minutes": 100.0,
+                "gate_initial": 1.0,
+                "unstuck_enabled": 0.0,
+                "unstuck_ema_gating_enabled": 0.0,
+                "unstuck_close_pct": 0.1,
+                "unstuck_loss_allowance_pct": 0.2,
+                "unstuck_threshold": 0.5,
+            }
+        )
+        output = runner.run(
+            np.asarray(
+                [
+                    [
+                        values[key]
+                        for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+                    ]
+                ],
+                dtype=np.float64,
+            )
+        )
+        torch.mps.synchronize()
+        return output
+
+    no_cost = run_case(slippage=0.0, taker_fee=0.0)
+    slipped = run_case(slippage=0.01, taker_fee=0.0)
+    charged = run_case(slippage=0.01, taker_fee=0.002)
+    position_key = "psize" if side == "long" else "short_psize"
+
+    assert no_cost["fill_count"].item() > 2.0
+    assert slipped["fill_count"].item() == no_cost["fill_count"].item()
+    assert charged["fill_count"].item() == slipped["fill_count"].item()
+    assert slipped[position_key].item() == pytest.approx(
+        no_cost[position_key].item(), abs=2.0e-4
+    )
+    assert charged[position_key].item() == pytest.approx(
+        slipped[position_key].item(), abs=2.0e-4
+    )
+    assert slipped["balance"].item() < no_cost["balance"].item()
+    assert charged["balance"].item() < slipped["balance"].item()
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 def test_mps_tm_multicoin_market_reducer_keeps_generation_dust_allocation():
     import passivbot_rust
 


### PR DESCRIPTION
## Summary
- promote the globally selected multi-coin Trailing Martingale auto-unstuck reducer through ordinary market execution on Apple MPS
- executable-touch-size the emitted reducer while preserving its passive recursive-grid reservation and generation market snapshot
- enable side-template and static coin-override unstuck parameters in one- and dual-side multi-coin GPU searches while retaining the fail-closed realized-loss-gate boundary

## Validation
- full physical Apple MPS suite: passed
- full tests/optimization suite: passed
- cargo test --no-default-features: 267 passed
- cargo check --tests: passed
- BTC+ETH fused long+short/HSL/market/unstuck GPU smoke: 8 generations, 512 proxy evaluations, 64 exact Rust validations, no halt, 69.2s

The physical regressions cover long and short executable-touch minimum resizing, passive recursive-grid reservation, adverse market slippage, taker fees, and per-coin override enablement.