### PR TITLE
Support TM market loss gating on Apple MPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,9 @@ All notable user-facing changes will be documented in this file.
   taker fees. Auto-unstuck now follows the same contract: the one globally selected reducer may be
   enabled by the side template or a static coin override, is resized at the executable touch while
   preserving the independently generated ordinary recursive ladder, and fills with adverse
-  slippage and taker fees. Realized-loss gating remains fail closed in multi-coin Trailing
-  Martingale market mode pending its dedicated parity slice.
+  slippage and taker fees. Realized-loss gating now also composes with market execution: proxy
+  screening projects adverse slippage and taker fees for ordinary closes and protective reducers,
+  while exact Rust remains authoritative for the shared peak-balance allowance.
 
 - Added baseline multi-coin EMA Anchor ordinary market execution to Apple MPS optimization for
   long-only, short-only, and fused long+short runs. The proxy retains generation-time entry and

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -341,8 +341,10 @@ The supported slice is intentionally narrow:
   auto-unstuck reducer may promote to market, executable-touch-size before finalized reducer
   selection, and retain adverse slippage plus taker fees. Static coin overrides may enable or tune
   unstuck; recursive-grid reconstruction keeps the independently generated ordinary strategy
-  ladder when market sizing enlarges the external reducer. Realized-loss gating remains fail closed
-  for multi-coin Trailing Martingale market mode until its shared-budget interactions are modeled.
+  ladder when market sizing enlarges the external reducer. Realized-loss gating composes with these
+  market paths: the proxy projects adverse slippage and taker fees and keeps a conservative
+  zero-loss envelope for ordinary and exposure-repair closes, while exact Rust applies the shared
+  peak-balance allowance to every validation.
 - no invalid candle tail after the selected coin's final valid candle
 
 Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor and

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -1083,6 +1083,9 @@ mod tests {
         assert!(source.contains("twel_close_qty"));
         assert!(source.contains("realized_loss_proxy_allows_close"));
         assert!(source.contains("const bool loss_gate_enabled = run_settings[5] < 1.0f"));
+        assert!(source.contains("float projected_close_fee = close_market[c]"));
+        assert!(source.contains("float twel_gate_fee = twel_reducer_market"));
+        assert!(source.contains("float unstuck_gate_fee = unstuck_reducer_market"));
         assert!(source.contains(
             "const bool post_fill_balance_depleted = isfinite(balance) && balance <= 0.0f"
         ));

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -3128,6 +3128,7 @@ inline void generate_tm_multicoin_side_orders(
     float max_realized_loss_pct,
     bool market_orders_allowed,
     float market_order_near_touch_threshold,
+    float market_order_slippage_pct,
     int forced_unstuck_coin,
     ulong one_way_initial_blocked_mask
 ) {
@@ -3345,15 +3346,8 @@ inline void generate_tm_multicoin_side_orders(
                 psize[best], ceil_step(reducer_qty, qty_step)
             );
             if (reducer_qty <= 1.0e-9f) continue;
-            bool reducer_allowed = realized_loss_proxy_allows_close(
-                    reducer_qty, reducer_price, pprice[best], short_side,
-                    c_mult, coin_settings[coin_offset + 5],
-                    loss_gate_enabled
-                );
-            if (reducer_allowed) {
-                twel_close_qty[best] = reducer_qty;
-                twel_close_tick[best] = reducer_tick;
-            }
+            twel_close_qty[best] = reducer_qty;
+            twel_close_tick[best] = reducer_tick;
             // Match exact Rust's two-stage contract: TWEL chooses and
             // accounts for its action set before the realized-loss
             // gate filters those actions.  A filtered reducer must
@@ -3858,13 +3852,6 @@ inline void generate_tm_multicoin_side_orders(
                 psize[c], pprice[c], balance, wel_target,
                 wel_reducer_price, qty_step, min_qty, min_cost, c_mult
             );
-            if (!realized_loss_proxy_allows_close(
-                    wel_reducer_qty, wel_reducer_price, pprice[c],
-                    short_side, c_mult, coin_settings[coin_offset + 5],
-                    loss_gate_enabled
-                )) {
-                wel_reducer_qty = 0.0f;
-            }
         }
         // Recursive strategy generation reserves the original passive WEL
         // request.  Market execution may enlarge the emitted candidate to an
@@ -3991,9 +3978,18 @@ inline void generate_tm_multicoin_side_orders(
             );
             minimum_close_relation = 0;
         }
+        float projected_close_price = close_market[c]
+            ? ordinary_market_fill_price(
+                price_now, short_side,
+                market_order_slippage_pct, price_step
+            )
+            : close_price;
+        float projected_close_fee = close_market[c]
+            ? coin_settings[coin_offset + 11]
+            : coin_settings[coin_offset + 5];
         if (!realized_loss_proxy_allows_close(
-                close_qty[c], close_price, pprice[c], short_side,
-                c_mult, coin_settings[coin_offset + 5],
+                close_qty[c], projected_close_price, pprice[c], short_side,
+                c_mult, projected_close_fee,
                 loss_gate_enabled
             )) {
             if (!trailing_close && close_qty[c] > 0.0f) {
@@ -4123,6 +4119,40 @@ inline void generate_tm_multicoin_side_orders(
                 unstuck_reducer_exec_price, qty_step, min_qty, min_cost,
                 c_mult
             );
+        float twel_gate_price = twel_reducer_market
+            ? ordinary_market_fill_price(
+                price_now, short_side,
+                market_order_slippage_pct, price_step
+            )
+            : twel_reducer_price;
+        float twel_gate_fee = twel_reducer_market
+            ? coin_settings[coin_offset + 11]
+            : coin_settings[coin_offset + 5];
+        if (!realized_loss_proxy_allows_close(
+                finalized_twel_reducer_qty, twel_gate_price, pprice[c],
+                short_side, c_mult, twel_gate_fee, loss_gate_enabled
+            )) {
+            raw_twel_reducer_qty = 0.0f;
+            finalized_twel_reducer_qty = 0.0f;
+            twel_reducer_market = false;
+        }
+        float wel_gate_price = wel_reducer_market
+            ? ordinary_market_fill_price(
+                price_now, short_side,
+                market_order_slippage_pct, price_step
+            )
+            : float(wel_reducer_tick) * price_step;
+        float wel_gate_fee = wel_reducer_market
+            ? coin_settings[coin_offset + 11]
+            : coin_settings[coin_offset + 5];
+        if (!realized_loss_proxy_allows_close(
+                finalized_wel_reducer_qty, wel_gate_price, pprice[c],
+                short_side, c_mult, wel_gate_fee, loss_gate_enabled
+            )) {
+            wel_reducer_qty = 0.0f;
+            finalized_wel_reducer_qty = 0.0f;
+            wel_reducer_market = false;
+        }
         bool use_twel = finalized_twel_reducer_qty
             > finalized_wel_reducer_qty;
         float exposure_reducer_qty = use_twel
@@ -4146,10 +4176,19 @@ inline void generate_tm_multicoin_side_orders(
         bool reducer_market = use_unstuck
             ? unstuck_reducer_market
             : (use_twel ? twel_reducer_market : wel_reducer_market);
+        float unstuck_gate_price = unstuck_reducer_market
+            ? ordinary_market_fill_price(
+                price_now, short_side,
+                market_order_slippage_pct, price_step
+            )
+            : float(raw_unstuck_reducer_tick) * price_step;
+        float unstuck_gate_fee = unstuck_reducer_market
+            ? coin_settings[coin_offset + 11]
+            : coin_settings[coin_offset + 5];
         if (use_unstuck && !realized_loss_proxy_allows_reducer(
                 finalized_unstuck_reducer_qty,
-                float(reducer_tick) * price_step, pprice[c], short_side,
-                c_mult, coin_settings[coin_offset + 5], true,
+                unstuck_gate_price, pprice[c], short_side,
+                c_mult, unstuck_gate_fee, true,
                 loss_gate_enabled, balance, realized_pnl_cumsum_last,
                 realized_pnl_cumsum_max, max_realized_loss_pct
             )) {
@@ -4738,6 +4777,7 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
                 loss_gate_enabled, max_realized_loss_pct,
                 market_orders_allowed,
                 market_order_near_touch_threshold,
+                market_order_slippage_pct,
                 long_unstuck_coin, long_one_way_order_blocked_mask
             );
         }
@@ -4758,6 +4798,7 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
                 loss_gate_enabled, max_realized_loss_pct,
                 market_orders_allowed,
                 market_order_near_touch_threshold,
+                market_order_slippage_pct,
                 short_unstuck_coin, short_one_way_order_blocked_mask
             );
         }
@@ -5352,6 +5393,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 loss_gate_enabled, max_realized_loss_pct,
                 market_orders_allowed,
                 market_order_near_touch_threshold,
+                market_order_slippage_pct,
                 -2, 0ul
             );
         }

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -928,11 +928,6 @@ def _validate_tm_multicoin_market_runtime_scope(
     """Reject multi-coin TM market features not modeled by this slice."""
 
     unsupported = []
-    max_loss = float(config.get("live", {}).get("max_realized_loss_pct", 1.0))
-    if max_loss != 1.0:
-        unsupported.append(
-            f"live.max_realized_loss_pct={max_loss} (required 1.0)"
-        )
     for side in sorted(set(enabled_sides or ())):
         side_config = config.get("bot", {}).get(side, {}) or {}
         strategy = (

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -2913,17 +2913,32 @@ def test_gpu_multicoin_tm_market_execution_accepts_hsl():
     assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
-def test_gpu_multicoin_tm_market_execution_rejects_realized_loss_gate():
-    config = _directional_tm_config(long_enabled=True, short_enabled=False)
-    config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "SOL"]
+@pytest.mark.parametrize(
+    ("long_enabled", "short_enabled"),
+    [(True, False), (False, True), (True, True)],
+)
+@pytest.mark.parametrize("max_realized_loss_pct", [0.0, 0.05, 0.9999999995])
+def test_gpu_multicoin_tm_market_execution_accepts_realized_loss_gate(
+    long_enabled, short_enabled, max_realized_loss_pct
+):
+    config = _directional_tm_config(
+        long_enabled=long_enabled, short_enabled=short_enabled
+    )
+    coins = ["BTC", "ETH", "SOL"]
+    config["live"]["approved_coins"] = {
+        "long": coins if long_enabled else [],
+        "short": coins if short_enabled else [],
+    }
     config["live"]["market_orders_allowed"] = True
-    strategy = config["bot"]["long"]["strategy"]["trailing_martingale"]
-    strategy["entry"]["retracement_base_pct"] = 0.01
-    strategy["close"]["retracement_base_pct"] = 0.01
-    config["live"]["max_realized_loss_pct"] = 0.05
+    config["live"]["max_realized_loss_pct"] = max_realized_loss_pct
+    for side, enabled in (("long", long_enabled), ("short", short_enabled)):
+        if not enabled:
+            continue
+        strategy = config["bot"][side]["strategy"]["trailing_martingale"]
+        strategy["entry"]["retracement_base_pct"] = 0.01
+        strategy["close"]["retracement_base_pct"] = 0.01
 
-    with pytest.raises(ValueError, match="max_realized_loss_pct"):
-        _validate_scope(config, _MulticoinEvaluator())
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
 @pytest.mark.parametrize("coin_override", [False, True])
@@ -2969,25 +2984,6 @@ def test_gpu_multicoin_tm_market_execution_accepts_exposure_reducers(
         config["bot"]["long"]["risk"][risk_key] = True
 
     assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
-
-
-@pytest.mark.parametrize(
-    "max_realized_loss_pct",
-    [np.nextafter(1.0, 0.0), 0.9999999995, 1.0000000005],
-)
-def test_gpu_multicoin_tm_market_execution_requires_exact_disabled_loss_gate(
-    max_realized_loss_pct,
-):
-    config = _directional_tm_config(long_enabled=True, short_enabled=False)
-    config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "SOL"]
-    config["live"]["market_orders_allowed"] = True
-    config["live"]["max_realized_loss_pct"] = max_realized_loss_pct
-    strategy = config["bot"]["long"]["strategy"]["trailing_martingale"]
-    strategy["entry"]["retracement_base_pct"] = 0.01
-    strategy["close"]["retracement_base_pct"] = 0.01
-
-    with pytest.raises(ValueError, match="max_realized_loss_pct"):
-        _validate_scope(config, _MulticoinEvaluator())
 
 
 def test_gpu_multicoin_tm_recursive_entry_accepts_twel_entry_gate():

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -1761,7 +1761,7 @@ kernel void passivbot_tm_multicoin_order_phase_probe(
         touch_min_qty_bits, touch_min_qty_relation,
         coin_settings, coin_overrides,
         1, 1, false, 1, 1, 0, false, 1.0f,
-        false, 0.001f, -2, 0ul
+        false, 0.001f, 0.0f, -2, 0ul
     );
     generate_tm_multicoin_side_orders(
         short_side, short_config, account,
@@ -1769,7 +1769,7 @@ kernel void passivbot_tm_multicoin_order_phase_probe(
         touch_min_qty_bits, touch_min_qty_relation,
         coin_settings, coin_overrides,
         1, 1, true, 1, 1, 0, false, 1.0f,
-        false, 0.001f, -2, 0ul
+        false, 0.001f, 0.0f, -2, 0ul
     );
     output[0] = long_side.entry_qty[0];
     output[1] = short_side.entry_qty[0];
@@ -1785,7 +1785,7 @@ kernel void passivbot_tm_multicoin_order_phase_probe(
         touch_min_qty_bits, touch_min_qty_relation,
         coin_settings, coin_overrides,
         1, 1, false, 1, 1, 0, false, 1.0f,
-        false, 0.001f, -2, 1ul
+        false, 0.001f, 0.0f, -2, 1ul
     );
     output[8] = long_side.entry_qty[0];
     output[9] = long_side.entry_candidate[0] ? 1.0f : 0.0f;
@@ -12625,7 +12625,7 @@ kernel void passivbot_tm_multicoin_market_wel_reservation_probe(
         touch_min_qty_bits, touch_min_qty_relation,
         coin_settings, coin_overrides,
         1, 1, short_side, 1, 1, 0, false, 1.0f,
-        true, 1.1f, -2, 0ul
+        true, 1.1f, 0.0f, -2, 0ul
     );
     output[0] = side.close_qty[0];
     output[1] = side.close_grid_gen_psize[0];
@@ -12753,7 +12753,7 @@ kernel void passivbot_tm_multicoin_market_unstuck_reservation_probe(
         touch_min_qty_bits, touch_min_qty_relation,
         coin_settings, coin_overrides,
         1, 1, short_side, 1, 1, 0, false, 1.0f,
-        true, 1.1f, 0, 0ul
+        true, 1.1f, 0.0f, 0, 0ul
     );
     output[0] = state.close_qty[0];
     output[1] = state.close_grid_gen_psize[0];
@@ -12865,7 +12865,7 @@ def test_mps_tm_multicoin_market_unstuck_override_pays_slippage_and_taker_fee(
         highs = closes.copy()
         lows = closes - 0.01
 
-    def run_case(*, slippage, taker_fee):
+    def run_case(*, slippage, taker_fee, max_realized_loss_pct=1.0):
         markets = [
             ProxyMarket(1.0, 0.01, 1.0, 0.0, 1.0, 0.0, taker_fee),
             ProxyMarket(1.0, 0.01, 2.0, 0.0, 1.0, 0.0, taker_fee),
@@ -12886,6 +12886,7 @@ def test_mps_tm_multicoin_market_unstuck_override_pays_slippage_and_taker_fee(
             market_orders_allowed=True,
             market_order_near_touch_threshold=0.001,
             market_order_slippage_pct=slippage,
+            max_realized_loss_pct=max_realized_loss_pct,
         )
         values = dict(
             zip(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, candidate)
@@ -12924,6 +12925,9 @@ def test_mps_tm_multicoin_market_unstuck_override_pays_slippage_and_taker_fee(
     no_cost = run_case(slippage=0.0, taker_fee=0.0)
     slipped = run_case(slippage=0.01, taker_fee=0.0)
     charged = run_case(slippage=0.01, taker_fee=0.002)
+    strict = run_case(
+        slippage=0.01, taker_fee=0.002, max_realized_loss_pct=0.0
+    )
     position_key = "psize" if side == "long" else "short_psize"
 
     assert no_cost["fill_count"].item() > 2.0
@@ -12935,8 +12939,10 @@ def test_mps_tm_multicoin_market_unstuck_override_pays_slippage_and_taker_fee(
     assert charged[position_key].item() == pytest.approx(
         slipped[position_key].item(), abs=2.0e-4
     )
+    assert strict[position_key].item() > charged[position_key].item()
     assert slipped["balance"].item() < no_cost["balance"].item()
     assert charged["balance"].item() < slipped["balance"].item()
+    assert strict["balance"].item() >= charged["balance"].item()
 
 
 @pytest.mark.skipif(
@@ -13669,7 +13675,10 @@ def test_mps_tm_multicoin_total_exposure_repair_policy(side):
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("side", ["long", "short"])
-def test_mps_tm_multicoin_loss_gate_blocks_lossy_total_exposure_repair(side):
+@pytest.mark.parametrize("market_orders_allowed", [False, True])
+def test_mps_tm_multicoin_loss_gate_blocks_lossy_total_exposure_repair(
+    side, market_orders_allowed
+):
     overrides = np.full((2, 44), np.nan, dtype=np.float32)
     overrides[0, 24] = 0.1
     runner_kwargs = {
@@ -13678,6 +13687,9 @@ def test_mps_tm_multicoin_loss_gate_blocks_lossy_total_exposure_repair(side):
         "coin_overrides": overrides,
         "count": 10,
         "closes": (100.0, 100.0),
+        "market_orders_allowed": market_orders_allowed,
+        "market_order_near_touch_threshold": 1.1,
+        "market_order_slippage_pct": 0.01,
     }
     ungated_runner, candidate = _multicoin_exposure_fixture(
         max_realized_loss_pct=1.0, **runner_kwargs
@@ -13713,9 +13725,20 @@ def test_mps_tm_multicoin_loss_gate_blocks_lossy_total_exposure_repair(side):
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("side", ["long", "short"])
-def test_mps_tm_multicoin_loss_gate_blocks_fee_only_ordinary_close(side):
+@pytest.mark.parametrize("market_orders_allowed", [False, True])
+def test_mps_tm_multicoin_loss_gate_blocks_fee_only_ordinary_close(
+    side, market_orders_allowed
+):
     markets = [
-        ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.001)
+        ProxyMarket(
+            0.001,
+            0.01,
+            0.001,
+            0.0,
+            1.0,
+            0.0 if market_orders_allowed else 0.001,
+            0.001,
+        )
         for _ in range(2)
     ]
     runner_kwargs = {
@@ -13724,6 +13747,9 @@ def test_mps_tm_multicoin_loss_gate_blocks_fee_only_ordinary_close(side):
         "count": 10,
         "closes": (100.0, 100.0),
         "markets": markets,
+        "market_orders_allowed": market_orders_allowed,
+        "market_order_near_touch_threshold": 1.1,
+        "market_order_slippage_pct": 0.001,
     }
     ungated_runner, candidate = _multicoin_exposure_fixture(
         max_realized_loss_pct=1.0, **runner_kwargs


### PR DESCRIPTION
## Summary

- enable `live.max_realized_loss_pct` for multi-coin Trailing Martingale MPS optimization when ordinary market execution is active
- project adverse market slippage and taker fees before screening ordinary closes, WEL/TWEL repairs, and auto-unstuck reducers
- defer exposure-reducer screening until executable-touch sizing and finalized reducer quantities are known, preserving the immutable WEL-seeded recursive ladder and reducer fallback behavior
- keep the MPS proxy conservative for ordinary/exposure-repair losses while exact Rust remains authoritative for the shared peak-balance allowance

## Validation

- full `tests/optimization` suite, including physical Apple MPS tests
- `cargo test --no-default-features` (267 passed)
- `cargo check --tests`
- rebuilt/stamped extension and verified runtime source fingerprint
- fused BTC+ETH long+short GPU smoke with market execution, HSL, unstuck, and `max_realized_loss_pct=0.05`: 8 generations, 512 proxy evaluations, 64 exact Rust validations, no safety halt

## Safety

GPU support remains additive. CPU optimization/backtesting and bot runtime behavior are unchanged; exact Rust validation remains authoritative.