### PR TITLE
Support asymmetric GPU multicoin side universes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added asymmetric long/short coin universes to non-suite dual-side Apple MPS multi-coin EMA
+  Anchor and Trailing Martingale optimization. The proxy now preserves exact payload `entry_eligible`
+  decisions as side-specific zero-exposure coin overrides, so Forager selection, dynamic wallet
+  exposure, HSL, auto-unstuck, and one-way arbitration exclude the same side-ineligible coins as
+  exact Rust without requiring matching long and short approved or ignored lists.
+
 - Added baseline multi-coin Trailing Martingale ordinary market execution to Apple MPS
   optimization for long-only, short-only, fused long+short, hedge-mode, one-way, and compatible
   suite runs whose entry and close modes remain wholly trailing or wholly recursive. Metal retains

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -107,8 +107,8 @@ The supported slice is intentionally narrow:
 - long-only, short-only, or dual-side hedge-mode and one-way multi-coin EMA-anchor and
   trailing-martingale runs
   for up to 64 coins, with dynamic wallet-exposure allocation and independent per-side Forager
-  selection; dual-side runs require matching long/short approved and ignored coin sets, and all
-  multi-coin runs require `backtest.dynamic_wel_by_tradability: true`;
+  selection; non-suite dual-side runs may use different effective long and short coin universes,
+  and all multi-coin runs require `backtest.dynamic_wel_by_tradability: true`;
   `live.forager_score_hysteresis_pct` preserves flat incumbent candidates when a challenger's
   normalized Forager-score lead is within the configured gap
 - each enabled side's `n_positions` pinned to `1` and wallet-exposure limit kept positive

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -991,7 +991,7 @@ def _validate_tm_multicoin_market_runtime_scope(
             "GPU multi-coin Trailing Martingale ordinary market execution "
             "currently supports wholly trailing or wholly recursive ordinary "
             "entries and closes plus position/TWEL/auto-unstuck reducers; "
-            "realized-loss gating remains unsupported; settings: "
+            "settings: "
             + ", ".join(unsupported)
         )
 
@@ -1088,17 +1088,6 @@ def _validate_scope_config(
             raise ValueError(
                 "GPU multicoin foundation requires one or two enabled sides"
             )
-        if len(enabled_sides) == 2:
-            approved = config.get("live", {}).get("approved_coins", {}) or {}
-            ignored = config.get("live", {}).get("ignored_coins", {}) or {}
-            for label, values in (("approved", approved), ("ignored", ignored)):
-                if set(values.get("long", []) or []) != set(
-                    values.get("short", []) or []
-                ):
-                    raise ValueError(
-                        "GPU dual-side multicoin optimization currently requires "
-                        f"matching long/short {label}_coins"
-                    )
         if not bool(config.get("backtest", {}).get("dynamic_wel_by_tradability")):
             raise ValueError(
                 "GPU multicoin foundation requires "

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -1538,7 +1538,13 @@ def _build_multicoin_ema_coin_overrides(
             matrix[coin_index, 10] = float(
                 effective_bot.get("entry_cooldown_minutes", 0.0) or 0.0
             )
-        if "wallet_exposure_limit" in side_patch:
+        # Exact payload construction keeps per-side universe eligibility in
+        # entry_eligible and uses a zero WEL sentinel for an ineligible coin.
+        # Preserve that sentinel even when no explicit coin override exists so
+        # fused long/short proxies may screen different side universes.
+        if not bool(effective_bot.get("entry_eligible", True)) or (
+            "wallet_exposure_limit" in side_patch
+        ):
             matrix[coin_index, 11] = float(effective_bot["wallet_exposure_limit"])
         if "we_excess_allowance_pct" in risk_patch:
             matrix[coin_index, 12] = float(
@@ -1635,7 +1641,9 @@ def _build_multicoin_tm_coin_overrides(
             matrix[coin_index, cooldown_column] = float(
                 effective_bot.get("entry_cooldown_minutes", 0.0) or 0.0
             )
-        if "wallet_exposure_limit" in side_patch:
+        if not bool(effective_bot.get("entry_eligible", True)) or (
+            "wallet_exposure_limit" in side_patch
+        ):
             matrix[coin_index, wallet_exposure_column] = float(
                 effective_bot["wallet_exposure_limit"]
             )
@@ -1787,21 +1795,6 @@ class MpsMulticoinProxy:
             self.needed_metrics,
             shared_account_controller=self.shared_account_fused,
         )
-        if len(enabled_sides) == 2:
-            approved = config.get("live", {}).get("approved_coins", {}) or {}
-            ignored = config.get("live", {}).get("ignored_coins", {}) or {}
-            for label, values_by_side in (
-                ("approved", approved),
-                ("ignored", ignored),
-            ):
-                if set(values_by_side.get("long", []) or []) != set(
-                    values_by_side.get("short", []) or []
-                ):
-                    raise ValueError(
-                        "MPS dual-side multicoin proxy requires matching "
-                        f"long/short {label}_coins"
-                    )
-
         payload = build_backtest_payload(
             np.ascontiguousarray(values),
             mss,

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -3105,7 +3105,7 @@ def test_gpu_multicoin_foundation_accepts_dual_side_coin_overrides():
 
 
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
-def test_gpu_multicoin_foundation_rejects_asymmetric_dual_side_coins(strategy_kind):
+def test_gpu_multicoin_foundation_accepts_asymmetric_dual_side_coins(strategy_kind):
     builder = (
         _directional_tm_config
         if strategy_kind == "trailing_martingale"
@@ -3120,8 +3120,12 @@ def test_gpu_multicoin_foundation_rejects_asymmetric_dual_side_coins(strategy_ki
     config["live"]["forager_score_hysteresis_pct"] = 0.0
     config["backtest"]["dynamic_wel_by_tradability"] = True
 
-    with pytest.raises(ValueError, match="matching long/short approved_coins"):
-        _validate_scope(config, _MulticoinEvaluator())
+    config["live"]["ignored_coins"] = {
+        "long": [],
+        "short": ["DOGE"],
+    }
+
+    assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
 @pytest.mark.parametrize(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -966,10 +966,10 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
         {
             "strategy_kind": strategy_kind,
             "approved_coins": {
-                "long": ["BTC", "ETH"],
-                "short": ["BTC", "ETH"],
+                "long": ["BTC"],
+                "short": ["ETH"],
             },
-            "ignored_coins": {"long": [], "short": []},
+            "ignored_coins": {"long": ["ETH"], "short": ["BTC"]},
             "hedge_mode": False,
             "hsl_signal_mode": "coin",
         }
@@ -998,9 +998,12 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
             {key: value for key, value in flat.items() if key.startswith("unstuck_")}
         )
 
-    def bot_payload(side):
+    def bot_payload(side, coin):
         flat = flatten_shared_bot_side(config["bot"][side])
+        entry_eligible = (side, coin) in {("long", "BTC"), ("short", "ETH")}
         return {
+            "entry_eligible": entry_eligible,
+            "wallet_exposure_limit": -1.0 if entry_eligible else 0.0,
             "entry_cooldown_minutes": flat["risk_entry_cooldown_minutes"],
             "filter_volume_ema_span_1m": flat[
                 "forager_volume_ema_span_1m"
@@ -1034,8 +1037,8 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
 
     payload = SimpleNamespace(
         bot_params_list=[
-            {side: bot_payload(side) for side in ("long", "short")}
-            for _ in range(2)
+            {side: bot_payload(side, coin) for side in ("long", "short")}
+            for coin in ("BTC", "ETH")
         ],
         strategy_params_list=[
             {
@@ -1119,6 +1122,13 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
         2,
         override_cols,
     )
+    wallet_exposure_column = 11 if strategy_kind == "ema_anchor" else 24
+    long_overrides = constructed["kwargs"]["long_coin_overrides"]
+    short_overrides = constructed["kwargs"]["short_coin_overrides"]
+    assert np.isnan(long_overrides[0, wallet_exposure_column])
+    assert long_overrides[1, wallet_exposure_column] == 0.0
+    assert short_overrides[0, wallet_exposure_column] == 0.0
+    assert np.isnan(short_overrides[1, wallet_exposure_column])
     assert constructed["kwargs"]["hsl_ema_tail_enabled"] is tail_enabled
     assert (
         constructed["kwargs"]["hsl_raw_drawdown_enabled"]
@@ -1953,6 +1963,59 @@ def test_multicoin_coin_overrides_pack_dual_sides_independently():
     assert short_matrix[1, offset_index] == pytest.approx(0.5)
     assert short_matrix[1, 10] == pytest.approx(30.0)
     assert np.isnan(short_matrix[1, 11])
+
+
+@pytest.mark.parametrize(
+    ("builder", "wallet_exposure_column"),
+    [
+        (_build_multicoin_ema_coin_overrides, 11),
+        (_build_multicoin_tm_coin_overrides, 24),
+    ],
+)
+def test_multicoin_coin_overrides_preserve_side_entry_eligibility(
+    builder, wallet_exposure_column
+):
+    strategy = {
+        "entry": {},
+        "close": {},
+    }
+    payload = SimpleNamespace(
+        strategy_params_list=[
+            {"long": strategy},
+            {"long": strategy},
+        ],
+        bot_params_list=[
+            {
+                "long": {
+                    "entry_eligible": False,
+                    "total_wallet_exposure_limit": 1.0,
+                    "wallet_exposure_limit": 0.0,
+                }
+            },
+            {
+                "long": {
+                    "entry_eligible": True,
+                    "total_wallet_exposure_limit": 1.0,
+                    "wallet_exposure_limit": -1.0,
+                }
+            },
+        ],
+    )
+
+    matrix, contract = builder(
+        config={"coin_overrides": {}},
+        mss={"BTC": {}, "ETH": {}},
+        exchange="bybit",
+        coins=["BTC", "ETH"],
+        payload=payload,
+        side="long",
+        resolve_override=lambda *_args: {},
+    )
+
+    assert matrix[0, wallet_exposure_column] == 0.0
+    assert np.isnan(matrix[1, wallet_exposure_column])
+    assert contract["values"][0][wallet_exposure_column] == 0.0
+    assert contract["values"][1][wallet_exposure_column] is None
 
 
 def test_multicoin_coin_overrides_pack_complete_hsl_group():


### PR DESCRIPTION
## Summary
- allow non-suite dual-side Apple MPS multi-coin runs to use different effective long and short coin universes
- preserve exact payload `entry_eligible` decisions as side-specific zero-WEL Metal overrides for EMA Anchor and Trailing Martingale
- remove obsolete matching-list validators and stale realized-loss-gate error wording
- document the supported topology and add packing/constructor/backend regressions

## Contract
Exact Rust remains authoritative. Config hydration already removes ignored coins from each side's approved set; payload construction then marks every coin/side pair with `entry_eligible`. The GPU packer now carries false eligibility into the existing zero-WEL override column, which the fused kernels already use for side-specific tradable counts, Forager selection, entry generation, dynamic WEL, and one-way arbitration. No Metal kernel changes or CPU-path changes are required. Suite behavior is unchanged.

## Validation
- `python -m pytest -q tests/optimization`
- physical MPS: `test_mps_fused_multicoin_one_way_arbitrates_each_flat_symbol` (EMA Anchor and Trailing Martingale)
- exact extension rebuilt/stamped and source fingerprint verified
- `cargo test --no-default-features` (267 passed)
- `cargo check --tests`
- Trailing Martingale end-to-end asymmetric smoke: BTC long only, ETH short only, 16 generations / 256 proxy / 32 exact, no safety halt
- EMA Anchor end-to-end asymmetric smoke: BTC long only, ETH short only, 16 generations / 256 proxy / 32 exact, no safety halt

## Notes
This is additive to the experimental Apple MPS backend. CPU optimization, backtesting, and live operation are unchanged.