### PR TITLE
Add weighted daily metrics to Apple MPS optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ All notable user-facing changes will be documented in this file.
 - Added weighted daily-series scoring and limits to Apple MPS optimization for
   `volume_pct_per_day_avg_w`, `equity_choppiness_w`, `equity_jerkiness_w`, and
   `exponential_fit_error_w`. The proxy applies Rust's ten trailing windows to its existing compact
-  fill-volume and account-equity day series, while exact Rust validation and rolling drift gates
-  remain authoritative.
+  fill-volume and account-equity day series, excluding ambiguous partial cutoff-day volume rather
+  than admitting pre-cutoff fills, while exact Rust validation and rolling drift gates remain
+  authoritative.
 
 - Added asymmetric long/short coin universes to non-suite dual-side Apple MPS multi-coin EMA
   Anchor and Trailing Martingale optimization. The proxy now preserves exact payload `entry_eligible`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added weighted daily-series scoring and limits to Apple MPS optimization for
+  `volume_pct_per_day_avg_w`, `equity_choppiness_w`, `equity_jerkiness_w`, and
+  `exponential_fit_error_w`. The proxy applies Rust's ten trailing windows to its existing compact
+  fill-volume and account-equity day series, while exact Rust validation and rolling drift gates
+  remain authoritative.
+
 - Added asymmetric long/short coin universes to non-suite dual-side Apple MPS multi-coin EMA
   Anchor and Trailing Martingale optimization. The proxy now preserves exact payload `entry_eligible`
   decisions as side-specific zero-exposure coin overrides, so Forager selection, dynamic wallet

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -237,7 +237,8 @@ The supported slice is intentionally narrow:
   limits use the proxy's active daily closing-equity samples and the exact Rust formulas. Candidates
   without fills retain Rust's default value of `1.0` for all three metrics. Their weighted variants
   and `volume_pct_per_day_avg_w` apply the same ten trailing slices as exact Rust to the compact
-  daily proxy series; exact validation and rolling drift gates remain authoritative
+  daily proxy series. Weighted volume excludes an ambiguous partial UTC cutoff day instead of
+  admitting pre-cutoff fills; exact validation and rolling drift gates remain authoritative
 - canonical USD `peak_recovery_hours_equity` and `peak_recovery_days_equity` scoring and limits
   use Metal's full-resolution maximum completed peak-to-peak recovery interval. As in exact Rust,
   an unrecovered final tail is not included and a candidate without fills returns zero. Fused

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -235,7 +235,9 @@ The supported slice is intentionally narrow:
   suite override, and returns zero for a zero-exposure side as the CPU analysis does
 - canonical USD `equity_choppiness`, `equity_jerkiness`, and `exponential_fit_error` scoring and
   limits use the proxy's active daily closing-equity samples and the exact Rust formulas. Candidates
-  without fills retain Rust's default value of `1.0` for all three metrics
+  without fills retain Rust's default value of `1.0` for all three metrics. Their weighted variants
+  and `volume_pct_per_day_avg_w` apply the same ten trailing slices as exact Rust to the compact
+  daily proxy series; exact validation and rolling drift gates remain authoritative
 - canonical USD `peak_recovery_hours_equity` and `peak_recovery_days_equity` scoring and limits
   use Metal's full-resolution maximum completed peak-to-peak recovery interval. As in exact Rust,
   an unrecovered final tail is not included and a candidate without fills returns zero. Fused

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -1198,6 +1198,7 @@ def _validate_dual_multicoin_metrics(
             "total_wallet_exposure_max",
             "total_wallet_exposure_mean",
             "volume_pct_per_day_avg",
+            "volume_pct_per_day_avg_w",
         }
     )
     if unsupported:

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -712,7 +712,7 @@ def _fill_gap_metrics(out, run):
     }
 
 
-def _weighted_subsets(
+def _weighted_subset_context(
     active,
     first_eq_ts,
     last_eq_ts,
@@ -741,6 +741,7 @@ def _weighted_subsets(
     )
     eligible = finite_timestamps & (sample_count >= 2)
     subsets = [active]
+    subset_start_timestamps = [first_eq_ts]
     first_day = int(timestamp_origin) // 86_400_000
     day_ids = torch.arange(active.shape[1], device=active.device) + first_day
     for index in range(1, 10):
@@ -757,6 +758,24 @@ def _weighted_subsets(
         subsets.append(
             active & (day_ids.unsqueeze(0) >= subset_start_day.unsqueeze(1))
         )
+        subset_start_timestamps.append(subset_start_ts)
+    return eligible, subsets, subset_start_timestamps, day_ids
+
+
+def _weighted_subsets(
+    active,
+    first_eq_ts,
+    last_eq_ts,
+    first_timestamp,
+    interval_ms,
+):
+    eligible, subsets, _, _ = _weighted_subset_context(
+        active,
+        first_eq_ts,
+        last_eq_ts,
+        first_timestamp,
+        interval_ms,
+    )
     return eligible, subsets
 
 
@@ -811,6 +830,7 @@ def _weighted_daily_series_metrics(
     day_has_fill,
     active,
     fill_count,
+    last_fill_ts,
     first_eq_ts,
     last_eq_ts,
     first_timestamp,
@@ -822,7 +842,7 @@ def _weighted_daily_series_metrics(
     requested = set(requested) & WEIGHTED_DAILY_SERIES_METRICS
     if not requested:
         return {}
-    _, subsets = _weighted_subsets(
+    _, subsets, subset_start_timestamps, day_ids = _weighted_subset_context(
         active,
         first_eq_ts,
         last_eq_ts,
@@ -830,6 +850,13 @@ def _weighted_daily_series_metrics(
         interval_ms,
     )
     fill_eligible = fill_count.to(torch.float64) > 1.0
+    timestamp_origin = float(first_timestamp)
+    finite_last_fill = torch.isfinite(last_fill_ts)
+    normalized_last_fill_ts = torch.where(
+        finite_last_fill & (last_fill_ts < timestamp_origin),
+        last_fill_ts + timestamp_origin,
+        last_fill_ts,
+    )
     # Unlike weighted equity-return metrics, Rust's weighted shape and volume
     # analysis admits a one-sample equity run when it has multiple fills. The
     # full-run analysis contributes one tenth, then the first empty suffix ends
@@ -860,15 +887,42 @@ def _weighted_daily_series_metrics(
         "equity_jerkiness_w_usd": "equity_jerkiness_usd",
         "exponential_fit_error_w_usd": "exponential_fit_error_usd",
     }
-    for subset in subsets:
-        subset_fill_mask = day_has_fill & subset
-        subset_eligible = eligible & subset_fill_mask.any(dim=1)
+    for subset_index, (subset, subset_start_ts) in enumerate(
+        zip(subsets, subset_start_timestamps)
+    ):
+        subset_eligible = eligible & (
+            normalized_last_fill_ts >= subset_start_ts
+        )
         if "volume_pct_per_day_avg_w" in requested:
-            fill_days = subset_fill_mask.sum(dim=1)
+            if subset_index == 0:
+                volume_fill_mask = day_has_fill & subset
+            else:
+                subset_start_day = torch.floor(
+                    subset_start_ts / 86_400_000.0
+                ).to(torch.long)
+                day_start_ts = (
+                    subset_start_day.to(subset_start_ts.dtype) * 86_400_000.0
+                )
+                at_day_boundary = (
+                    (subset_start_ts - day_start_ts).abs()
+                    < max(float(interval_ms) * 0.5, 1.0)
+                )
+                complete_day_mask = (
+                    day_ids.unsqueeze(0) > subset_start_day.unsqueeze(1)
+                )
+                complete_day_mask |= at_day_boundary.unsqueeze(1) & (
+                    day_ids.unsqueeze(0) == subset_start_day.unsqueeze(1)
+                )
+                # Daily volume cannot distinguish fills before and after an
+                # intra-day cutoff. Exclude that ambiguous boundary day rather
+                # than admitting pre-cutoff fills; exact Rust validation owns
+                # the partial-day contribution.
+                volume_fill_mask = day_has_fill & subset & complete_day_mask
+            fill_days = volume_fill_mask.sum(dim=1)
             value = torch.where(
                 fill_days > 0,
                 torch.where(
-                    subset_fill_mask,
+                    volume_fill_mask,
                     day_volume,
                     torch.zeros_like(day_volume),
                 ).sum(dim=1)
@@ -876,7 +930,9 @@ def _weighted_daily_series_metrics(
                 torch.zeros_like(totals["volume_pct_per_day_avg_w"]),
             )
             totals["volume_pct_per_day_avg_w"] += torch.where(
-                subset_eligible, value, torch.zeros_like(value)
+                subset_eligible & (fill_days > 0),
+                value,
+                torch.zeros_like(value),
             )
         if shape_names:
             values = _equity_shape_metrics(day_end_eq, subset)
@@ -1439,6 +1495,7 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
             day_has_fill,
             active,
             out["fill_count"],
+            out["last_fill_ts"],
             out["first_eq_ts"],
             out["last_eq_ts"],
             data["ts0"],

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -721,45 +721,58 @@ def _weighted_subset_context(
 ):
     finite_timestamps = torch.isfinite(first_eq_ts) & torch.isfinite(last_eq_ts)
     timestamp_origin = float(first_timestamp)
-    relative_timestamps = finite_timestamps & (first_eq_ts < timestamp_origin)
-    first_eq_ts = torch.where(
-        relative_timestamps, first_eq_ts + timestamp_origin, first_eq_ts
-    )
-    last_eq_ts = torch.where(
-        relative_timestamps, last_eq_ts + timestamp_origin, last_eq_ts
-    )
-    sample_span = torch.where(
+    interval_ms_int = int(interval_ms)
+    timestamp_origin_int = int(round(timestamp_origin))
+
+    def relative_steps(timestamps):
+        relative_ms = torch.where(
+            timestamps < timestamp_origin,
+            timestamps,
+            timestamps - timestamp_origin,
+        )
+        return torch.floor(relative_ms / float(interval_ms_int) + 0.5).to(
+            torch.long
+        )
+
+    first_eq_steps = relative_steps(first_eq_ts)
+    last_eq_steps = relative_steps(last_eq_ts)
+    sample_count = torch.where(
         finite_timestamps,
-        (last_eq_ts - first_eq_ts) / float(interval_ms),
-        torch.zeros_like(first_eq_ts),
-    )
-    sample_count = (
-        torch.floor(sample_span + 0.5)
-        .to(torch.long)
-        .add(1)
-        .clamp(min=1)
-    )
+        last_eq_steps - first_eq_steps + 1,
+        torch.ones_like(first_eq_steps),
+    ).clamp(min=1)
     eligible = finite_timestamps & (sample_count >= 2)
     subsets = [active]
-    subset_start_timestamps = [first_eq_ts]
-    first_day = int(timestamp_origin) // 86_400_000
+    subset_start_steps = [first_eq_steps]
+    subset_start_timestamps = [
+        first_eq_steps * interval_ms_int + timestamp_origin_int
+    ]
+    first_day = timestamp_origin_int // 86_400_000
     day_ids = torch.arange(active.shape[1], device=active.device) + first_day
     for index in range(1, 10):
         fraction = 1.0 / (1.0 + index)
         start_position = torch.floor(
             sample_count.to(first_eq_ts.dtype) * (1.0 - fraction) + 0.5
         ).to(torch.long)
-        subset_start_ts = first_eq_ts + start_position.to(first_eq_ts.dtype) * float(
-            interval_ms
+        subset_start_step = first_eq_steps + start_position
+        subset_start_ts = (
+            subset_start_step * interval_ms_int + timestamp_origin_int
         )
-        subset_start_day = torch.floor(subset_start_ts / 86_400_000.0).to(
-            torch.long
+        subset_start_day = torch.div(
+            subset_start_ts, 86_400_000, rounding_mode="floor"
         )
         subsets.append(
             active & (day_ids.unsqueeze(0) >= subset_start_day.unsqueeze(1))
         )
+        subset_start_steps.append(subset_start_step)
         subset_start_timestamps.append(subset_start_ts)
-    return eligible, subsets, subset_start_timestamps, day_ids
+    return (
+        eligible,
+        subsets,
+        subset_start_steps,
+        subset_start_timestamps,
+        day_ids,
+    )
 
 
 def _weighted_subsets(
@@ -769,7 +782,7 @@ def _weighted_subsets(
     first_timestamp,
     interval_ms,
 ):
-    eligible, subsets, _, _ = _weighted_subset_context(
+    eligible, subsets, _, _, _ = _weighted_subset_context(
         active,
         first_eq_ts,
         last_eq_ts,
@@ -842,7 +855,13 @@ def _weighted_daily_series_metrics(
     requested = set(requested) & WEIGHTED_DAILY_SERIES_METRICS
     if not requested:
         return {}
-    _, subsets, subset_start_timestamps, day_ids = _weighted_subset_context(
+    (
+        _,
+        subsets,
+        subset_start_steps,
+        subset_start_timestamps,
+        day_ids,
+    ) = _weighted_subset_context(
         active,
         first_eq_ts,
         last_eq_ts,
@@ -852,11 +871,14 @@ def _weighted_daily_series_metrics(
     fill_eligible = fill_count.to(torch.float64) > 1.0
     timestamp_origin = float(first_timestamp)
     finite_last_fill = torch.isfinite(last_fill_ts)
-    normalized_last_fill_ts = torch.where(
-        finite_last_fill & (last_fill_ts < timestamp_origin),
-        last_fill_ts + timestamp_origin,
+    relative_last_fill_ms = torch.where(
+        last_fill_ts < timestamp_origin,
         last_fill_ts,
+        last_fill_ts - timestamp_origin,
     )
+    last_fill_steps = torch.floor(
+        relative_last_fill_ms / float(interval_ms) + 0.5
+    ).to(torch.long)
     # Unlike weighted equity-return metrics, Rust's weighted shape and volume
     # analysis admits a one-sample equity run when it has multiple fills. The
     # full-run analysis contributes one tenth, then the first empty suffix ends
@@ -887,26 +909,20 @@ def _weighted_daily_series_metrics(
         "equity_jerkiness_w_usd": "equity_jerkiness_usd",
         "exponential_fit_error_w_usd": "exponential_fit_error_usd",
     }
-    for subset_index, (subset, subset_start_ts) in enumerate(
-        zip(subsets, subset_start_timestamps)
+    for subset_index, (subset, subset_start_step, subset_start_ts) in enumerate(
+        zip(subsets, subset_start_steps, subset_start_timestamps)
     ):
-        subset_eligible = eligible & (
-            normalized_last_fill_ts >= subset_start_ts
+        subset_eligible = (
+            eligible & finite_last_fill & (last_fill_steps >= subset_start_step)
         )
         if "volume_pct_per_day_avg_w" in requested:
             if subset_index == 0:
                 volume_fill_mask = day_has_fill & subset
             else:
-                subset_start_day = torch.floor(
-                    subset_start_ts / 86_400_000.0
-                ).to(torch.long)
-                day_start_ts = (
-                    subset_start_day.to(subset_start_ts.dtype) * 86_400_000.0
+                subset_start_day = torch.div(
+                    subset_start_ts, 86_400_000, rounding_mode="floor"
                 )
-                at_day_boundary = (
-                    (subset_start_ts - day_start_ts).abs()
-                    < max(float(interval_ms) * 0.5, 1.0)
-                )
+                at_day_boundary = subset_start_ts.remainder(86_400_000) == 0
                 complete_day_mask = (
                     day_ids.unsqueeze(0) > subset_start_day.unsqueeze(1)
                 )

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -67,11 +67,14 @@ SUPPORTED_METRICS = (
     "drawdown_worst_ema_strategy_eq_short",
     "drawdown_worst_strategy_eq",
     "equity_choppiness_usd",
+    "equity_choppiness_w_usd",
     "equity_jerkiness_usd",
+    "equity_jerkiness_w_usd",
     "expected_shortfall_1pct_strategy_eq",
     "entry_initial_balance_pct_long",
     "entry_initial_balance_pct_short",
     "exponential_fit_error_usd",
+    "exponential_fit_error_w_usd",
     "exposure_mean_ratio_usd",
     "exposure_ratio_usd",
     "fills_analysis_duration_days",
@@ -173,6 +176,7 @@ SUPPORTED_METRICS = (
     "total_wallet_exposure_max",
     "total_wallet_exposure_mean",
     "volume_pct_per_day_avg",
+    "volume_pct_per_day_avg_w",
     *_USD_STRATEGY_EQ_ALIASES,
     *_USD_PER_EXPOSURE_METRICS,
 )
@@ -793,6 +797,87 @@ WEIGHTED_STRATEGY_EQ_METRICS = {
     "sterling_ratio_strategy_eq_w",
 }
 
+WEIGHTED_DAILY_SERIES_METRICS = {
+    "equity_choppiness_w_usd",
+    "equity_jerkiness_w_usd",
+    "exponential_fit_error_w_usd",
+    "volume_pct_per_day_avg_w",
+}
+
+
+def _weighted_daily_series_metrics(
+    day_end_eq,
+    day_volume,
+    day_has_fill,
+    active,
+    fill_count,
+    first_eq_ts,
+    last_eq_ts,
+    first_timestamp,
+    interval_ms,
+    requested,
+):
+    """Reduce Rust's weighted fill-day volume and daily equity-shape metrics."""
+
+    requested = set(requested) & WEIGHTED_DAILY_SERIES_METRICS
+    if not requested:
+        return {}
+    eligible, subsets = _weighted_subsets(
+        active,
+        first_eq_ts,
+        last_eq_ts,
+        first_timestamp,
+        interval_ms,
+    )
+    # Rust returns before populating any weighted fields when there are fewer
+    # than two fills. Empty trailing fill suffixes end the subset loop and
+    # therefore contribute the same zero implied by the fixed /10 divisor.
+    eligible &= fill_count.to(torch.float64) > 1.0
+    totals = {
+        name: torch.zeros(
+            day_end_eq.shape[0],
+            dtype=day_end_eq.dtype,
+            device=day_end_eq.device,
+        )
+        for name in requested
+    }
+    shape_names = requested & {
+        "equity_choppiness_w_usd",
+        "equity_jerkiness_w_usd",
+        "exponential_fit_error_w_usd",
+    }
+    shape_sources = {
+        "equity_choppiness_w_usd": "equity_choppiness_usd",
+        "equity_jerkiness_w_usd": "equity_jerkiness_usd",
+        "exponential_fit_error_w_usd": "exponential_fit_error_usd",
+    }
+    for subset in subsets:
+        subset_fill_mask = day_has_fill & subset
+        subset_eligible = eligible & subset_fill_mask.any(dim=1)
+        if "volume_pct_per_day_avg_w" in requested:
+            fill_days = subset_fill_mask.sum(dim=1)
+            value = torch.where(
+                fill_days > 0,
+                torch.where(
+                    subset_fill_mask,
+                    day_volume,
+                    torch.zeros_like(day_volume),
+                ).sum(dim=1)
+                / fill_days.clamp(min=1).to(day_volume.dtype),
+                torch.zeros_like(totals["volume_pct_per_day_avg_w"]),
+            )
+            totals["volume_pct_per_day_avg_w"] += torch.where(
+                subset_eligible, value, torch.zeros_like(value)
+            )
+        if shape_names:
+            values = _equity_shape_metrics(day_end_eq, subset)
+            for name in shape_names:
+                value = values[shape_sources[name]]
+                totals[name] += torch.where(
+                    subset_eligible, value, torch.zeros_like(value)
+                )
+    return {name: value / 10.0 for name, value in totals.items()}
+
 
 def _weighted_strategy_eq_metrics(
     day_end_eq,
@@ -1329,6 +1414,20 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
         run.interval_ms,
         requested_sources,
     )
+    weighted_daily_series_metrics = {}
+    if requested & WEIGHTED_DAILY_SERIES_METRICS:
+        weighted_daily_series_metrics = _weighted_daily_series_metrics(
+            day_end_eq,
+            day_volume,
+            day_has_fill,
+            active,
+            out["fill_count"],
+            out["first_eq_ts"],
+            out["last_eq_ts"],
+            data["ts0"],
+            run.interval_ms,
+            requested,
+        )
     shape_metric_names = {
         "equity_choppiness_usd",
         "equity_jerkiness_usd",
@@ -1606,6 +1705,7 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
     objectives.update(hard_stop_metrics)
     objectives.update(hard_stop_panic_loss_metrics)
     objectives.update(weighted_metrics)
+    objectives.update(weighted_daily_series_metrics)
     objectives.update(weighted_pnl_metrics)
     objectives.update(equity_shape_metrics)
     for name, (source, side) in _USD_PER_EXPOSURE_METRICS.items():

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -822,17 +822,26 @@ def _weighted_daily_series_metrics(
     requested = set(requested) & WEIGHTED_DAILY_SERIES_METRICS
     if not requested:
         return {}
-    eligible, subsets = _weighted_subsets(
+    _, subsets = _weighted_subsets(
         active,
         first_eq_ts,
         last_eq_ts,
         first_timestamp,
         interval_ms,
     )
-    # Rust returns before populating any weighted fields when there are fewer
-    # than two fills. Empty trailing fill suffixes end the subset loop and
-    # therefore contribute the same zero implied by the fixed /10 divisor.
-    eligible &= fill_count.to(torch.float64) > 1.0
+    fill_eligible = fill_count.to(torch.float64) > 1.0
+    # Unlike weighted equity-return metrics, Rust's weighted shape and volume
+    # analysis admits a one-sample equity run when it has multiple fills. The
+    # full-run analysis contributes one tenth, then the first empty suffix ends
+    # the loop. Only finite, ordered timestamps and one active sample are
+    # required here.
+    eligible = (
+        fill_eligible
+        & torch.isfinite(first_eq_ts)
+        & torch.isfinite(last_eq_ts)
+        & (last_eq_ts >= first_eq_ts)
+        & active.any(dim=1)
+    )
     totals = {
         name: torch.zeros(
             day_end_eq.shape[0],
@@ -876,7 +885,15 @@ def _weighted_daily_series_metrics(
                 totals[name] += torch.where(
                     subset_eligible, value, torch.zeros_like(value)
                 )
-    return {name: value / 10.0 for name, value in totals.items()}
+    result = {name: value / 10.0 for name, value in totals.items()}
+    # analyze_backtest returns early for zero or one fill. Preserve the custom
+    # Analysis defaults for weighted shape metrics; weighted volume defaults
+    # to zero.
+    for name in shape_names:
+        result[name] = torch.where(
+            fill_eligible, result[name], torch.ones_like(result[name])
+        )
+    return result
 
 
 def _weighted_strategy_eq_metrics(

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -292,6 +292,7 @@ _DUAL_SIDE_MULTICOIN_INTRADAY_CUTOFF_METRICS = {
     "sharpe_ratio_pnl_w",
     "sortino_ratio_pnl",
     "sortino_ratio_pnl_w",
+    "volume_pct_per_day_avg_w",
 }
 
 _ACCOUNT_EQUITY_RECOVERY_METRICS = {

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -3129,6 +3129,22 @@ def test_gpu_multicoin_foundation_accepts_asymmetric_dual_side_coins(strategy_ki
 
 
 @pytest.mark.parametrize(
+    ("metric", "goal"),
+    [
+        ("equity_choppiness_w", "min"),
+        ("equity_jerkiness_w", "min"),
+        ("exponential_fit_error_w", "min"),
+        ("volume_pct_per_day_avg_w", "max"),
+    ],
+)
+def test_gpu_foundation_accepts_weighted_daily_series_metrics(metric, goal):
+    config = _long_only_ema_config()
+    config["optimize"]["scoring"] = [{"goal": goal, "metric": metric}]
+
+    assert _validate_scope(config, _Evaluator()) == "bybit"
+
+
+@pytest.mark.parametrize(
     "metric",
     [
         "entry_initial_balance_pct_long",
@@ -3164,6 +3180,7 @@ def test_gpu_multicoin_foundation_accepts_asymmetric_dual_side_coins(strategy_ki
         "total_wallet_exposure_max",
         "total_wallet_exposure_mean",
         "volume_pct_per_day_avg",
+        "volume_pct_per_day_avg_w",
     ],
 )
 def test_gpu_dual_multicoin_rejects_unreconstructable_metrics(metric):
@@ -3217,6 +3234,7 @@ def test_gpu_dual_multicoin_metric_gate_does_not_narrow_single_side():
             "total_wallet_exposure_max",
             "total_wallet_exposure_mean",
             "volume_pct_per_day_avg",
+            "volume_pct_per_day_avg_w",
         },
         coin_count=3,
         enabled_sides={"long"},

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -26,6 +26,7 @@ from optimization.gpu.metrics import (
     _smoothed_adg,
     _smoothed_gain_adg,
     _weighted_adg,
+    _weighted_daily_series_metrics,
     _weighted_subsets,
     _weighted_strategy_eq_metrics,
     compute_objectives,
@@ -567,6 +568,103 @@ def test_weighted_daily_pnl_metrics_match_rust_suffix_contract():
     assert requested <= set(SUPPORTED_METRICS)
     for name, value in expected.items():
         assert metrics[name].item() == pytest.approx(value)
+
+
+def test_weighted_daily_series_metrics_match_rust_suffix_contract():
+    day_ms = 86_400_000
+    day_count = 100
+    day_index = torch.arange(day_count, dtype=torch.float64)
+    day_end = (100.0 * torch.exp(day_index * 0.001)).unsqueeze(0)
+    day_volume = (day_index + 1.0).unsqueeze(0)
+    active = torch.ones_like(day_end, dtype=torch.bool)
+    day_has_fill = torch.ones_like(active)
+    requested = {
+        "equity_choppiness_w_usd",
+        "equity_jerkiness_w_usd",
+        "exponential_fit_error_w_usd",
+        "volume_pct_per_day_avg_w",
+    }
+
+    metrics = _weighted_daily_series_metrics(
+        day_end,
+        day_volume,
+        day_has_fill,
+        active,
+        torch.tensor([float(day_count)]),
+        torch.tensor([0.0]),
+        torch.tensor([(day_count - 1) * day_ms], dtype=torch.float64),
+        0.0,
+        day_ms,
+        requested,
+    )
+
+    starts = [0, 50, 67, 75, 80, 83, 86, 88, 89, 90]
+
+    def reference_shape(values):
+        values = np.asarray(values, dtype=np.float64)
+        choppiness = np.abs(np.diff(values)).sum() / abs(values[-1] - values[0])
+        jerkiness = np.mean(
+            np.abs(values[2:] - 2.0 * values[1:-1] + values[:-2])
+            / np.abs((values[:-2] + values[1:-1] + values[2:]) / 3.0)
+        )
+        x = np.arange(len(values), dtype=np.float64)
+        y = np.log(values)
+        slope = (
+            len(values) * np.sum(x * y) - np.sum(x) * np.sum(y)
+        ) / (len(values) * np.sum(x * x) - np.sum(x) ** 2)
+        intercept = (np.sum(y) - slope * np.sum(x)) / len(values)
+        fit_error = np.mean((slope * x + intercept - y) ** 2)
+        return choppiness, jerkiness, fit_error
+
+    expected_shape = np.asarray(
+        [reference_shape(day_end[0, start:].numpy()) for start in starts]
+    ).mean(axis=0)
+    expected_volume = np.mean(
+        [day_volume[0, start:].mean().item() for start in starts]
+    )
+
+    assert set(metrics) == requested
+    assert requested <= set(SUPPORTED_METRICS)
+    assert metrics["equity_choppiness_w_usd"].item() == pytest.approx(
+        expected_shape[0]
+    )
+    assert metrics["equity_jerkiness_w_usd"].item() == pytest.approx(
+        expected_shape[1]
+    )
+    assert metrics["exponential_fit_error_w_usd"].item() == pytest.approx(
+        expected_shape[2], abs=1e-24
+    )
+    assert metrics["volume_pct_per_day_avg_w"].item() == pytest.approx(
+        expected_volume
+    )
+
+
+def test_weighted_daily_series_metrics_require_two_fills_like_rust():
+    day_end = torch.tensor([[100.0, 101.0]], dtype=torch.float64)
+    requested = set(
+        [
+            "equity_choppiness_w_usd",
+            "equity_jerkiness_w_usd",
+            "exponential_fit_error_w_usd",
+            "volume_pct_per_day_avg_w",
+        ]
+    )
+
+    metrics = _weighted_daily_series_metrics(
+        day_end,
+        torch.tensor([[0.5, 0.0]], dtype=torch.float64),
+        torch.tensor([[True, False]]),
+        torch.ones_like(day_end, dtype=torch.bool),
+        torch.tensor([1.0]),
+        torch.tensor([0.0]),
+        torch.tensor([86_400_000.0]),
+        0.0,
+        86_400_000,
+        requested,
+    )
+
+    assert set(metrics) == requested
+    assert all(value.item() == 0.0 for value in metrics.values())
 
 
 def test_weighted_subsets_normalize_relative_timestamps_to_unix_origin():

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -27,6 +27,7 @@ from optimization.gpu.metrics import (
     _smoothed_gain_adg,
     _weighted_adg,
     _weighted_daily_series_metrics,
+    _weighted_subset_context,
     _weighted_subsets,
     _weighted_strategy_eq_metrics,
     compute_objectives,
@@ -718,6 +719,57 @@ def test_weighted_volume_excludes_ambiguous_intraday_cutoff_day():
     # contains pre-cutoff volume, so only the unambiguous full-run tenth is
     # admitted; exact Rust validation owns partial-day volume after a cutoff.
     assert metrics["volume_pct_per_day_avg_w"].item() == pytest.approx(0.05)
+
+
+def test_weighted_suffix_admission_uses_integer_candle_steps():
+    interval_ms = 60_000
+    sample_count = 17_898
+    first_step = 1
+    last_step = first_step + sample_count - 1
+    active = torch.ones((1, 13), dtype=torch.bool)
+
+    _, _, subset_start_steps, _, _ = _weighted_subset_context(
+        active,
+        torch.tensor([np.float32(first_step * interval_ms)]),
+        torch.tensor([np.float32(last_step * interval_ms)]),
+        0.0,
+        interval_ms,
+    )
+    last_fill_ts = torch.tensor(
+        [np.float32((first_step + sample_count // 2) * interval_ms)]
+    )
+    last_fill_step = torch.floor(
+        last_fill_ts / float(interval_ms) + 0.5
+    ).to(torch.long)
+
+    # The equivalent float32 timestamp expressions differ by 64 ms at this
+    # realistic span. Integer candle-step admission still includes Rust's
+    # exact half-window boundary fill.
+    assert np.float32(first_step * interval_ms) + np.float32(
+        (sample_count // 2) * interval_ms
+    ) != last_fill_ts.item()
+    assert subset_start_steps[1].item() == last_fill_step.item()
+
+    day_end = torch.arange(100.0, 113.0).unsqueeze(0)
+    day_has_fill = torch.zeros_like(day_end, dtype=torch.bool)
+    day_has_fill[:, 6] = True
+    metrics = _weighted_daily_series_metrics(
+        day_end,
+        torch.zeros_like(day_end),
+        day_has_fill,
+        active,
+        torch.tensor([2.0]),
+        last_fill_ts,
+        torch.tensor([np.float32(first_step * interval_ms)]),
+        torch.tensor([np.float32(last_step * interval_ms)]),
+        0.0,
+        interval_ms,
+        {"equity_choppiness_w_usd"},
+    )
+
+    # Linear full and half-window daily series both have choppiness 1.0;
+    # Rust admits both and stops at the next suffix, for a weighted 0.2.
+    assert metrics["equity_choppiness_w_usd"].item() == pytest.approx(0.2)
 
 
 def test_weighted_subsets_normalize_relative_timestamps_to_unix_origin():

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -591,6 +591,7 @@ def test_weighted_daily_series_metrics_match_rust_suffix_contract():
         day_has_fill,
         active,
         torch.tensor([float(day_count)]),
+        torch.tensor([(day_count - 1) * day_ms], dtype=torch.float64),
         torch.tensor([0.0]),
         torch.tensor([(day_count - 1) * day_ms], dtype=torch.float64),
         0.0,
@@ -657,6 +658,7 @@ def test_weighted_daily_series_metrics_preserve_sparse_fill_rust_defaults():
         torch.ones_like(day_end, dtype=torch.bool),
         torch.tensor([1.0]),
         torch.tensor([0.0]),
+        torch.tensor([0.0]),
         torch.tensor([86_400_000.0]),
         0.0,
         86_400_000,
@@ -685,14 +687,36 @@ def test_weighted_daily_series_metrics_keep_one_sample_full_run_tenth():
         torch.tensor([2.0]),
         torch.tensor([0.0]),
         torch.tensor([0.0]),
+        torch.tensor([0.0]),
         0.0,
-        86_400_000,
+        60_000,
         requested,
     )
 
     assert metrics["equity_choppiness_w_usd"].item() == 0.0
     assert metrics["equity_jerkiness_w_usd"].item() == 0.0
     assert math.isinf(metrics["exponential_fit_error_w_usd"].item())
+    assert metrics["volume_pct_per_day_avg_w"].item() == pytest.approx(0.05)
+
+
+def test_weighted_volume_excludes_ambiguous_intraday_cutoff_day():
+    metrics = _weighted_daily_series_metrics(
+        torch.tensor([[100.0]], dtype=torch.float64),
+        torch.tensor([[0.5]], dtype=torch.float64),
+        torch.tensor([[True]]),
+        torch.tensor([[True]]),
+        torch.tensor([2.0]),
+        torch.tensor([3_600_000.0]),
+        torch.tensor([0.0]),
+        torch.tensor([3_600_000.0]),
+        0.0,
+        60_000,
+        {"volume_pct_per_day_avg_w"},
+    )
+
+    # Every trailing cutoff is inside the same UTC day. The daily aggregate
+    # contains pre-cutoff volume, so only the unambiguous full-run tenth is
+    # admitted; exact Rust validation owns partial-day volume after a cutoff.
     assert metrics["volume_pct_per_day_avg_w"].item() == pytest.approx(0.05)
 
 

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -639,7 +639,7 @@ def test_weighted_daily_series_metrics_match_rust_suffix_contract():
     )
 
 
-def test_weighted_daily_series_metrics_require_two_fills_like_rust():
+def test_weighted_daily_series_metrics_preserve_sparse_fill_rust_defaults():
     day_end = torch.tensor([[100.0, 101.0]], dtype=torch.float64)
     requested = set(
         [
@@ -664,7 +664,36 @@ def test_weighted_daily_series_metrics_require_two_fills_like_rust():
     )
 
     assert set(metrics) == requested
-    assert all(value.item() == 0.0 for value in metrics.values())
+    assert metrics["volume_pct_per_day_avg_w"].item() == 0.0
+    for name in requested - {"volume_pct_per_day_avg_w"}:
+        assert metrics[name].item() == 1.0
+
+
+def test_weighted_daily_series_metrics_keep_one_sample_full_run_tenth():
+    requested = {
+        "equity_choppiness_w_usd",
+        "equity_jerkiness_w_usd",
+        "exponential_fit_error_w_usd",
+        "volume_pct_per_day_avg_w",
+    }
+
+    metrics = _weighted_daily_series_metrics(
+        torch.tensor([[100.0]], dtype=torch.float64),
+        torch.tensor([[0.5]], dtype=torch.float64),
+        torch.tensor([[True]]),
+        torch.tensor([[True]]),
+        torch.tensor([2.0]),
+        torch.tensor([0.0]),
+        torch.tensor([0.0]),
+        0.0,
+        86_400_000,
+        requested,
+    )
+
+    assert metrics["equity_choppiness_w_usd"].item() == 0.0
+    assert metrics["equity_jerkiness_w_usd"].item() == 0.0
+    assert math.isinf(metrics["exponential_fit_error_w_usd"].item())
+    assert metrics["volume_pct_per_day_avg_w"].item() == pytest.approx(0.05)
 
 
 def test_weighted_subsets_normalize_relative_timestamps_to_unix_origin():

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -403,6 +403,7 @@ def test_core_output_contract_retains_gross_pnl_aggregates():
         "sharpe_ratio_pnl_w",
         "sortino_ratio_pnl",
         "sortino_ratio_pnl_w",
+        "volume_pct_per_day_avg_w",
     ],
 )
 def test_dual_side_multicoin_intraday_cutoff_metrics_fail_closed(metric):


### PR DESCRIPTION
## Summary
- support `volume_pct_per_day_avg_w` plus weighted USD equity choppiness, jerkiness, and exponential-fit error in the Apple MPS screening proxy
- preserve Rust weighted-analysis semantics for the two-fill minimum, empty trailing suffixes, and the fixed ten-window divisor
- keep exact Rust evaluations and rolling drift gates authoritative; no CPU optimizer or trading-path changes

## Validation
- `PYTHONPATH=src .../python -m pytest -q`
- focused GPU metric/backend/service tests
- rebuilt and fingerprint-verified the local Rust extension
- physical Apple MPS smoke using `configs/examples/BTC_ETH_XRP_SOL_ADA_long.json`: five-coin long-only Trailing Martingale, 8 generations / 512 proxy / 8 exact, completed in 40.8s without drift or classification halt; exact Pareto updates emitted non-default `volume_pct_per_day_avg_w` values
- `git diff --check`

RustyCZ GPU branch remains credited in the existing reducer module provenance.