### PR TITLE
GPU: support mixed trailing-martingale market modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS Trailing Martingale optimization with market orders may now search entry and close
+  retracement bounds that cross between recursive and trailing modes. Metal selects the mode per
+  candidate and per coin, with sign-preserving float32 packing for positive underflow values;
+  exact Rust validation and drift gates remain authoritative.
+
 - Added weighted daily-series scoring and limits to Apple MPS optimization for
   `volume_pct_per_day_avg_w`, `equity_choppiness_w`, `equity_jerkiness_w`, and
   `exponential_fit_error_w`. The proxy applies Rust's ten trailing windows to its existing compact
@@ -19,7 +24,8 @@ All notable user-facing changes will be documented in this file.
 
 - Added baseline multi-coin Trailing Martingale ordinary market execution to Apple MPS
   optimization for long-only, short-only, fused long+short, hedge-mode, one-way, and compatible
-  suite runs whose entry and close modes remain wholly trailing or wholly recursive. Metal retains
+  suite runs, with recursive or trailing entry and close mode selected per candidate and coin.
+  Metal retains
   generation-time market intent, executes promoted orders on the next valid candle with adverse
   directional slippage and taker fees, applies executable-touch minimum sizing to short entries and
   all closes, and prices the strict portfolio entry cap at the market touch. For recursive closes,
@@ -68,8 +74,7 @@ All notable user-facing changes will be documented in this file.
   is reallocated when another close remains executable. Promoted grid groups and protective reducers
   retain canonical ordering,
   aggregate position trimming, quantity-relative minimum-size comparisons, adverse slippage, and
-  taker fees. Entry and close optimizer bounds must
-  each remain wholly recursive or wholly trailing; mode-crossing ranges remain fail closed.
+  taker fees. Entry and close optimizer bounds may cross the recursive/trailing mode boundary.
 
 - Added single-coin Trailing Martingale recursive-entry market execution to Apple MPS optimization.
   Every immutable strategy-ladder rung is independently promoted against its generation market
@@ -78,7 +83,7 @@ All notable user-facing changes will be documented in this file.
   total-exposure entry gate at their limit price or market touch. Strategy-ladder sizing retains
   its separate wallet-exposure allowance before that portfolio gate is applied; the retained
   nearest prefix ends at the first partially cropped portfolio-boundary rung. Entry optimizer
-  bounds must remain wholly recursive or wholly trailing; mode-crossing ranges remain fail closed.
+  bounds may cross the recursive/trailing mode boundary.
 
 - Extended single-coin Trailing Martingale ordinary market-order optimization on Apple MPS to
   compatible HSL modes, one-sided minimum-effective-cost filtering, auto-unstuck, position- and

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -288,10 +288,11 @@ The supported slice is intentionally narrow:
   suite scenarios, including HSL, one-sided minimum-effective-cost filtering, auto-unstuck,
   total-exposure repair, and realized-loss gating. Single-coin Trailing Martingale supports the
   same directional and position-mode topologies with HSL and one-sided minimum-effective-cost
-  filtering when every enabled side's entry retracement range is wholly recursive (its upper bound
-  is nonpositive) or wholly trailing (its lower bound remains float32-positive), and every close
-  retracement range is likewise wholly recursive or wholly trailing. Bounds that cross either
-  mode boundary fail closed.
+  filtering. Entry and close retracement bounds may cross the recursive/trailing mode boundary:
+  each candidate independently selects recursive mode at a nonpositive base or trailing mode at a
+  positive base. An extremely small positive float64 value that would underflow during Metal
+  packing is raised to the smallest normal float32 solely in the screening proxy so its mode sign
+  agrees with exact Rust.
   Auto-unstuck, position- and total-exposure repair, and realized-loss gating may remain enabled or
   tunable. The Metal proxy classifies each generated order against the
   current candle close using
@@ -326,9 +327,8 @@ The supported slice is intentionally narrow:
   their market slippage and taker fees are included in the projected loss. Static coin overrides
   may enable or tune unstuck. Multi-coin Trailing Martingale supports ordinary market entries and
   ordinary strategy closes for long-only, short-only, fused long+short, hedge-mode, one-way, and
-  compatible suite runs when every enabled entry and close retracement range remains wholly
-  recursive or wholly trailing. Static coin overrides may select either supported entry or close
-  mode per coin. It uses
+  compatible suite runs. Entry and close retracement bounds may cross the recursive/trailing mode
+  boundary, and static coin overrides may select either mode per coin. It uses
   the same retained generation-time intent, next-valid-candle adverse fill, taker-fee,
   executable-touch minimum sizing for short entries and all closes, and portfolio entry-cap
   accounting contract. Passive next-candle reachability alone exposes a recursive close suffix;

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -913,13 +913,9 @@ def _tm_market_mode_value_supported(
         value = float(value)
     except (TypeError, ValueError):
         return False
-    with np.errstate(over="ignore", under="ignore", invalid="ignore"):
-        packed = np.float32(value)
-    if not math.isfinite(value) or not np.isfinite(packed):
+    if not math.isfinite(value) or abs(value) > float(np.finfo(np.float32).max):
         return False
-    if allow_recursive and value <= 0.0:
-        return True
-    return value > 0.0 and packed > 0.0
+    return allow_recursive or value > 0.0
 
 
 def _validate_tm_multicoin_market_runtime_scope(
@@ -941,7 +937,7 @@ def _validate_tm_multicoin_market_runtime_scope(
                 value, allow_recursive=True
             )
             if not mode_supported:
-                requirement = "recursive or trailing"
+                requirement = "finite and float32-representable"
                 unsupported.append(
                     f"bot.{side}.strategy.trailing_martingale.{branch}."
                     f"retracement_base_pct={value!r} "
@@ -979,7 +975,7 @@ def _validate_tm_multicoin_market_runtime_scope(
                         value, allow_recursive=True
                     )
                     if not mode_supported:
-                        requirement = "recursive or trailing"
+                        requirement = "finite and float32-representable"
                         unsupported.append(
                             f"coin_overrides.{coin}.bot.{side}.strategy."
                             f"trailing_martingale.{branch}."
@@ -989,8 +985,8 @@ def _validate_tm_multicoin_market_runtime_scope(
     if unsupported:
         raise ValueError(
             "GPU multi-coin Trailing Martingale ordinary market execution "
-            "currently supports wholly trailing or wholly recursive ordinary "
-            "entries and closes plus position/TWEL/auto-unstuck reducers; "
+            "requires finite float32-representable ordinary entry and close "
+            "retracement bases and supports position/TWEL/auto-unstuck reducers; "
             "settings: "
             + ", ".join(unsupported)
         )
@@ -2800,66 +2796,25 @@ def _validate_tm_market_mode_bounds(
         return
     unsupported = []
     for side in sorted(set(enabled_sides or ())):
-        entry_key = f"{side}_entry_retracement_base_pct"
-        entry_bound = bound_by_key.get(entry_key)
-        entry_low, entry_high = (
-            (float(entry_bound.low), float(entry_bound.high))
-            if entry_bound is not None
-            else (float(base_by_key.get(entry_key, 0.0)),) * 2
-        )
-        with np.errstate(over="ignore", under="ignore", invalid="ignore"):
-            packed_entry_low = np.float32(entry_low)
-        recursive_only = entry_high <= 0.0
-        trailing_only = (
-            entry_low > 0.0
-            and np.isfinite(packed_entry_low)
-            and packed_entry_low > np.float32(0.0)
-        )
-        mode_supported = recursive_only or trailing_only
-        if (
-            not math.isfinite(entry_low)
-            or not math.isfinite(entry_high)
-            or not mode_supported
-        ):
-            unsupported.append(
-                f"{entry_key} bounds=({entry_low}, {entry_high})"
+        for phase in ("entry", "close"):
+            key = f"{side}_{phase}_retracement_base_pct"
+            bound = bound_by_key.get(key)
+            low, high = (
+                (float(bound.low), float(bound.high))
+                if bound is not None
+                else (float(base_by_key.get(key, 0.0)),) * 2
             )
-
-        close_key = f"{side}_close_retracement_base_pct"
-        close_bound = bound_by_key.get(close_key)
-        close_low, close_high = (
-            (float(close_bound.low), float(close_bound.high))
-            if close_bound is not None
-            else (float(base_by_key.get(close_key, 0.0)),) * 2
-        )
-        with np.errstate(over="ignore", under="ignore", invalid="ignore"):
-            packed_close_low = np.float32(close_low)
-        recursive_only = close_high <= 0.0
-        trailing_only = (
-            close_low > 0.0
-            and np.isfinite(packed_close_low)
-            and packed_close_low > np.float32(0.0)
-        )
-        mode_supported = recursive_only or trailing_only
-        if (
-            not math.isfinite(close_low)
-            or not math.isfinite(close_high)
-            or not mode_supported
-        ):
-            unsupported.append(
-                f"{close_key} bounds=({close_low}, {close_high})"
-            )
+            if any(
+                not math.isfinite(value)
+                or abs(value) > float(np.finfo(np.float32).max)
+                for value in (low, high)
+            ):
+                unsupported.append(f"{key} bounds=({low}, {high})")
     if unsupported:
-        entry_modes = (
-            "wholly recursive (high<=0) or wholly trailing with a "
-            "float32-positive lower bound"
-        )
         raise ValueError(
             "GPU Trailing Martingale ordinary market execution currently "
-            "requires each enabled side's entry retracement range to remain "
-            f"{entry_modes}, and close retracement to remain wholly recursive "
-            "(high<=0) or wholly trailing with a float32-positive lower bound. "
-            "Entry or close unsupported/mode-crossing bounds remain fail closed: "
+            "requires finite float32-representable entry and close retracement "
+            "bounds. Unsupported bounds remain fail closed: "
             + ", ".join(unsupported)
         )
 

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -402,6 +402,26 @@ TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS = (
     ),
 )
 
+
+def encode_tm_retracement_base_pct(value) -> np.float32:
+    """Pack a TM retracement base without losing its recursive/trailing mode."""
+
+    value = float(value)
+    if not math.isfinite(value) or abs(value) > float(np.finfo(np.float32).max):
+        raise ValueError(
+            "Trailing Martingale retracement_base_pct must be finite and "
+            "representable as float32"
+        )
+    encoded = np.float32(value)
+    if value > 0.0 and encoded == np.float32(0.0):
+        # Rust selects trailing mode from the float64 sign. Preserve that mode
+        # in Metal even when an extremely small positive magnitude underflows
+        # during float32 packing. The smallest normal is used because GPU
+        # arithmetic may flush subnormal values to zero.
+        encoded = np.float32(np.finfo(np.float32).tiny)
+    return encoded
+
+
 GPU_STRATEGY_PARAM_KEYS = {
     "ema_anchor": EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
     "trailing_martingale": TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS,

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -14,6 +14,7 @@ from optimization.gpu.model import (
     ProxyRun,
     TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS,
     TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS,
+    encode_tm_retracement_base_pct,
     trailing_martingale_shader_topology,
 )
 
@@ -81,6 +82,30 @@ def _encode_max_realized_loss_pct(value: float) -> float:
     if float(encoded) > value:
         encoded = np.nextafter(encoded, np.float32(-np.inf))
     return float(encoded)
+
+
+def _pack_tm_parameter_matrix(
+    params: np.ndarray, keys: tuple[str, ...], *, sides: int
+) -> np.ndarray:
+    """Pack TM rows while preserving each candidate's retracement mode sign."""
+
+    matrix = np.ascontiguousarray(params, dtype=np.float32)
+    side_width = len(keys)
+    for side_index in range(sides):
+        offset = side_index * side_width
+        for key in (
+            "entry_retracement_base_pct",
+            "close_retracement_base_pct",
+        ):
+            column = offset + keys.index(key)
+            positive_underflow = (params[:, column] > 0.0) & (
+                matrix[:, column] == np.float32(0.0)
+            )
+            if np.any(positive_underflow):
+                matrix[positive_underflow, column] = encode_tm_retracement_base_pct(
+                    np.finfo(np.float64).tiny
+                )
+    return matrix
 
 
 def _scalar_column_or_zero(scalars, index: int):
@@ -1380,7 +1405,9 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
                 "expected multicoin Trailing Martingale parameter matrix with "
                 f"{expected} columns, got {got}"
             )
-        return np.ascontiguousarray(params, dtype=np.float32)
+        return _pack_tm_parameter_matrix(
+            params, TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, sides=1
+        )
 
     def _library(self):
         return _trailing_martingale_multicoin_shader_library(
@@ -1525,7 +1552,9 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
                 "expected fused multicoin Trailing Martingale parameter matrix "
                 f"with {expected} columns, got {got}"
             )
-        return np.ascontiguousarray(params, dtype=np.float32)
+        return _pack_tm_parameter_matrix(
+            params, TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, sides=2
+        )
 
     def _dispatch(
         self,
@@ -1611,7 +1640,9 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
                 "expected directional trailing-martingale parameter matrix with "
                 f"{expected} columns, got {got}"
             )
-        return np.ascontiguousarray(params, dtype=np.float32)
+        return _pack_tm_parameter_matrix(
+            params, TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS, sides=2
+        )
 
     def run(self, params: np.ndarray, *, profile: bool = False) -> dict:
         started = time.perf_counter()

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -22,6 +22,7 @@ from optimization.gpu.model import (
     build_mps_data,
     build_mps_multicoin_data,
     encode_hsl_panic_order_type,
+    encode_tm_retracement_base_pct,
     flatten_trailing_martingale_params,
     gpu_side_enabled,
     validate_hsl_settings,
@@ -1636,7 +1637,16 @@ def _build_multicoin_tm_coin_overrides(
                 if value is missing:
                     break
             if value is not missing:
-                matrix[coin_index, column] = float(effective_strategy[key])
+                effective_value = float(effective_strategy[key])
+                matrix[coin_index, column] = (
+                    encode_tm_retracement_base_pct(effective_value)
+                    if key
+                    in {
+                        "entry_retracement_base_pct",
+                        "close_retracement_base_pct",
+                    }
+                    else effective_value
+                )
         risk_patch = side_patch.get("risk", {}) or {}
         if "entry_cooldown_minutes" in risk_patch:
             matrix[coin_index, cooldown_column] = float(

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1642,7 +1642,7 @@ def test_gpu_foundation_accepts_baseline_tm_single_coin_market_execution():
         ("long_entry_retracement_base_pct", 1.0e-50, 0.1),
     ],
 )
-def test_gpu_tm_market_execution_rejects_entry_or_close_mode_crossing(
+def test_gpu_tm_market_execution_accepts_entry_or_close_mode_crossing(
     key, low, high
 ):
     config = _long_only_ema_config()
@@ -1654,7 +1654,20 @@ def test_gpu_tm_market_execution_rejects_entry_or_close_mode_crossing(
     }
     bounds[key] = Bound(low, high)
 
-    with pytest.raises(ValueError, match="mode-crossing bounds remain fail closed"):
+    _validate_tm_market_mode_bounds(bounds, {}, {"long"}, config)
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), 1.0e39])
+def test_gpu_tm_market_execution_rejects_unrepresentable_mode_bounds(value):
+    config = _long_only_ema_config()
+    config["live"]["strategy_kind"] = "trailing_martingale"
+    config["live"]["market_orders_allowed"] = True
+    bounds = {
+        "long_entry_retracement_base_pct": Bound(value, value),
+        "long_close_retracement_base_pct": Bound(0.001, 0.1),
+    }
+
+    with pytest.raises(ValueError, match="finite float32-representable"):
         _validate_tm_market_mode_bounds(bounds, {}, {"long"}, config)
 
 
@@ -1787,10 +1800,7 @@ def test_gpu_tm_market_suite_validates_effective_scenarios_not_template():
     scenario["live"]["market_orders_allowed"] = False
     _validate_tm_market_mode_bounds(bounds, {}, {"long"}, scenario)
 
-    with pytest.raises(ValueError, match="mode-crossing"):
-        _validate_tm_market_template_bounds(
-            bounds, {}, {"long"}, template, []
-        )
+    _validate_tm_market_template_bounds(bounds, {}, {"long"}, template, [])
 
 
 @pytest.mark.parametrize(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -24,6 +24,7 @@ from optimization.gpu.mps_kernel import (
     MpsTrailingMartingaleMulticoinFusedRunner,
     _decode_multicoin_fused_outputs,
     _encode_max_realized_loss_pct,
+    _pack_tm_parameter_matrix,
     _with_hsl_ema_tail,
     _with_hsl_features,
     _with_recovery_distribution,
@@ -82,6 +83,28 @@ def _assert_fill_scalar_contract(output):
         account_recovery[has_equity] <= equity_span[has_equity] + 1.0e-6
     ).all()
     assert (account_recovery[~has_equity] == 0.0).all()
+
+
+def test_tm_parameter_packing_preserves_positive_underflow_mode_per_side():
+    width = len(TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS)
+    params = np.zeros((1, width * 2), dtype=np.float64)
+    entry_column = TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(
+        "entry_retracement_base_pct"
+    )
+    close_column = TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(
+        "close_retracement_base_pct"
+    )
+    params[0, entry_column] = 1.0e-50
+    params[0, width + close_column] = 1.0e-50
+
+    packed = _pack_tm_parameter_matrix(
+        params, TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS, sides=2
+    )
+
+    assert packed[0, entry_column] == np.finfo(np.float32).tiny
+    assert packed[0, width + close_column] == np.finfo(np.float32).tiny
+    assert packed[0, close_column] == 0.0
+    assert packed[0, width + entry_column] == 0.0
 
 
 @pytest.mark.parametrize(
@@ -5177,6 +5200,56 @@ def test_mps_tm_multicoin_recursive_market_entry_does_not_expose_suffix(side):
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_batch_selects_market_mode_per_candidate(side):
+    count = 6
+    closes = np.tile(np.asarray([100.0, 120.0]), (count, 1))
+    highs = closes.copy()
+    lows = closes.copy()
+    if side == "long":
+        lows[3] = closes[3] * 0.8
+    else:
+        highs[3] = closes[3] * 1.2
+    runner, recursive = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        side,
+        count=count,
+        closes=closes,
+        highs=highs,
+        lows=lows,
+        first_valid_indices=(2, 2),
+        collect_coin_fill_counts=True,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.001,
+    )
+    for key, value in {
+        "entry_double_down_factor": 1.0,
+        "entry_initial_qty_pct": 0.1,
+        "entry_initial_ema_dist": 0.0005,
+        "entry_threshold_base_pct": 0.01,
+        "entry_retracement_base_pct": 0.0,
+        "close_retracement_base_pct": 0.01,
+        "twel_entry_gate_enabled": 0.0,
+        "entry_cooldown_minutes": 0.0,
+    }.items():
+        recursive[TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(key)] = value
+    trailing = recursive.copy()
+    trailing[
+        TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(
+            "entry_retracement_base_pct"
+        )
+    ] = 0.01
+
+    output = runner.run(np.asarray([recursive, trailing], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert output["fill_count_entry"].cpu().tolist()[0] > 2.0
+    assert output["fill_count_entry"].cpu().tolist()[1] == 2.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
 @pytest.mark.parametrize("cooldown, expands", [(0.0, True), (100.0, False)])
 def test_mps_tm_multicoin_recursive_market_entry_passive_suffix(
     side, cooldown, expands
@@ -8156,6 +8229,68 @@ def test_mps_tm_near_touch_market_entry_uses_taker_fill(
     # Market promotion guarantees rung zero, but exact Rust does not expand a
     # recursive ladder unless the original passive order strictly crosses.
     assert market_output["fill_count_entry"].item() == 1.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_batch_selects_recursive_or_trailing_market_mode_per_candidate(side):
+    count = 5
+    close = np.full(count, 100.0)
+    high = np.full(count, 100.0)
+    low = np.full(count, 100.0)
+    low[3] = 99.89
+    high[3] = 100.11
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0002)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    recursive = _tm_single_row(
+        initial_ema_dist=0.001,
+        gate_initial=False,
+        gate_reentry=False,
+        entry_gate=True,
+        threshold=0.1202,
+    )
+    recursive[4] = 1.0
+    recursive[6] = 0.05
+    recursive[7] = 0.001
+    recursive[11] = 0.0
+    recursive[16] = 10.0
+    recursive[20] = 0.001
+    trailing = recursive.copy()
+    trailing[11] = 0.001
+    params = np.asarray(
+        [recursive + recursive, trailing + trailing], dtype=np.float64
+    )
+
+    output = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+        hsl_enabled=False,
+        taker_fee=0.01,
+        market_order_slippage_pct=0.01,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.003,
+    ).run(params)
+    torch.mps.synchronize()
+
+    assert output["fill_count_entry"].cpu().tolist() == [3.0, 1.0]
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -2149,8 +2149,16 @@ def test_multicoin_tm_coin_overrides_pack_only_explicit_exact_values():
     }
     strategy_override = {
         **strategy_base,
-        "entry": {**strategy_base["entry"], "threshold_base_pct": 0.25},
-        "close": {**strategy_base["close"], "qty_pct": 0.5},
+        "entry": {
+            **strategy_base["entry"],
+            "threshold_base_pct": 0.25,
+            "retracement_base_pct": 1.0e-50,
+        },
+        "close": {
+            **strategy_base["close"],
+            "qty_pct": 0.5,
+            "retracement_base_pct": 1.0e-50,
+        },
     }
     payload = SimpleNamespace(
         strategy_params_list=[
@@ -2190,8 +2198,14 @@ def test_multicoin_tm_coin_overrides_pack_only_explicit_exact_values():
                     "long": {
                         "strategy": {
                             "trailing_martingale": {
-                                "entry": {"threshold_base_pct": 0.25},
-                                "close": {"qty_pct": 0.5},
+                                "entry": {
+                                    "threshold_base_pct": 0.25,
+                                    "retracement_base_pct": 1.0e-50,
+                                },
+                                "close": {
+                                    "qty_pct": 0.5,
+                                    "retracement_base_pct": 1.0e-50,
+                                },
                             }
                         },
                         "risk": {
@@ -2230,7 +2244,9 @@ def test_multicoin_tm_coin_overrides_pack_only_explicit_exact_values():
     assert matrix.shape == (2, 44)
     assert np.isnan(matrix[0]).all()
     assert matrix[1, 7] == pytest.approx(0.25)
+    assert matrix[1, 11] == np.finfo(np.float32).tiny
     assert matrix[1, 15] == pytest.approx(0.5)
+    assert matrix[1, 20] == np.finfo(np.float32).tiny
     assert matrix[1, 23] == pytest.approx(15.0)
     assert matrix[1, 24] == pytest.approx(0.4)
     assert matrix[1, 25] == pytest.approx(0.25)


### PR DESCRIPTION
Summary:
- Allow trailing-martingale entry and close optimizer bounds to cross the recursive/trailing mode boundary on Apple MPS.
- Preserve exact-positive float64 mode selection when screening proxy packing would underflow to float32 zero.
- Cover single-coin, multi-coin, fused sides, and static coin overrides. Exact Rust validation and drift gates remain authoritative.

Validation:
- Affected GPU backend, service, and MPS test modules pass.
- Physical Apple M3 MPS mixed-candidate tests pass for single-coin and multi-coin, long and short.
- Physical five-coin optimize smoke completed 8 generations, 512 proxy evaluations, and 8 exact validations in 47.3 seconds without a drift halt.
- Diff check and Python compilation pass.

CPU optimization and runtime paths are unchanged.