### PR TITLE
GPU: support aggregated candles for single-coin MPS optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS single-coin EMA Anchor and Trailing Martingale optimization now supports any positive
+  integer `backtest.candle_interval_minutes`. Minute-denominated strategy EMA spans and entry/HSL
+  cooldowns are converted to candle periods for Metal while timestamp-based metrics and exact Rust
+  validation retain elapsed-time semantics; multi-coin MPS runs remain one-minute-only.
+
 - Apple MPS multi-coin Trailing Martingale optimization now supports static per-coin
   `entry.ema_gate_mode` overrides. Initial entries and recursive reentries independently inherit
   or override their EMA gate for each coin and side, including fused long+short runs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ All notable user-facing changes will be documented in this file.
 ## Unreleased
 
 - Apple MPS single-coin EMA Anchor and Trailing Martingale optimization now supports any positive
-  integer `backtest.candle_interval_minutes`. Minute-denominated strategy EMA spans and entry/HSL
-  cooldowns are converted to candle periods for Metal while timestamp-based metrics and exact Rust
-  validation retain elapsed-time semantics; multi-coin MPS runs remain one-minute-only.
+  integer `backtest.candle_interval_minutes`. Minute-denominated strategy EMA spans, HSL EMA decay,
+  and entry/HSL cooldowns are converted to per-candle equivalents for Metal while timestamp-based
+  metrics and exact Rust validation retain elapsed-time semantics; multi-coin MPS runs remain
+  one-minute-only.
 
 - Apple MPS multi-coin Trailing Martingale optimization now supports static per-coin
   `entry.ema_gate_mode` overrides. Initial entries and recursive reentries independently inherit

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -100,8 +100,10 @@ and the DEAP/pymoo CPU optimizers do not import or require PyTorch.
 The supported slice is intentionally narrow:
 
 - Apple Silicon with `torch.backends.mps.is_available()`
-- one prepared dataset per independent run or suite scenario, using one-minute candles; the
-  dataset may be an individual exchange or the canonical combined multi-exchange dataset
+- one prepared dataset per independent run or suite scenario; single-coin runs accept any
+  positive integer `backtest.candle_interval_minutes`, while multi-coin runs remain restricted to
+  one-minute candles; the dataset may be an individual exchange or the canonical combined
+  multi-exchange dataset
 - `strategy_kind: ema_anchor` or `trailing_martingale`, with long-only, short-only, or
   long+short enabled for one coin
 - long-only, short-only, or dual-side hedge-mode and one-way multi-coin EMA-anchor and
@@ -795,6 +797,10 @@ Trade-offs:
 
 - Intra-interval fill ordering is lost (fills occur only at the aggregated bar boundaries).
 - Metrics are still time-correct because analysis uses timestamps rather than bar indices.
+- The Apple MPS backend supports aggregated intervals for single-coin EMA Anchor and Trailing
+  Martingale runs. It converts minute-denominated strategy EMA spans and elapsed-time cooldowns to
+  candle periods before dispatch; exact Rust validation remains authoritative. Multi-coin MPS runs
+  currently require one-minute candles.
 
 ### Fine-Tuning Specific Parameters
 

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -799,8 +799,8 @@ Trade-offs:
 - Metrics are still time-correct because analysis uses timestamps rather than bar indices.
 - The Apple MPS backend supports aggregated intervals for single-coin EMA Anchor and Trailing
   Martingale runs. It converts minute-denominated strategy EMA spans and elapsed-time cooldowns to
-  candle periods before dispatch; exact Rust validation remains authoritative. Multi-coin MPS runs
-  currently require one-minute candles.
+  candle periods and compounds HSL's one-minute EMA decay over each candle before dispatch; exact
+  Rust validation remains authoritative. Multi-coin MPS runs currently require one-minute candles.
 
 ### Fine-Tuning Specific Parameters
 

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -382,6 +382,10 @@ mod tests {
         assert!(source.contains("scalars[so + 51] = fill_count_entry"));
         assert!(source.contains("scalars[so + 52] = fill_count_long"));
         assert!(source.contains("scalars[so + 53] = fills_active_days_count"));
+        assert!(source.contains("const float fill_day_candles = 86400000.0f / interval_ms"));
+        assert!(source.contains(
+            "int active_fill_day = elapsed_fill_day_bucket(\n                    kf, first_eq_k, interval_ms"
+        ));
         assert!(source.contains("scalars[so + 54] = pnl_recovery_max_min * interval_ms"));
         assert!(source.contains("scalars[so + 55] = held_sum_min * interval_ms"));
         assert!(source.contains("scalars[so + 56] = held_count"));
@@ -684,6 +688,10 @@ mod tests {
         assert!(source.contains("scalars[so + 51] = fill_count_entry"));
         assert!(source.contains("scalars[so + 52] = fill_count_long"));
         assert!(source.contains("scalars[so + 53] = fills_active_days_count"));
+        assert!(source.contains("const float fill_day_candles = 86400000.0f / interval_ms"));
+        assert!(source.contains(
+            "int active_fill_day = elapsed_fill_day_bucket(\n                    kf, first_eq_k, interval_ms"
+        ));
         assert!(source.contains("scalars[so + 54] = pnl_recovery_max_min * interval_ms"));
         assert!(source.contains("scalars[so + 55] = held_sum_min * interval_ms"));
         assert!(source.contains("scalars[so + 56] = held_count"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -15,6 +15,11 @@ constant int SIDE_PARAMS = 34;
 constant float RECOVERY_FAIL_CLOSED_SENTINEL = -3.402823466e+38f;
 #endif
 
+inline int elapsed_fill_day_bucket(float k, float first_eq_k, float interval_ms) {
+    const float fill_day_candles = 86400000.0f / interval_ms;
+    return int((k - first_eq_k) / fill_day_candles);
+}
+
 inline float round_step(float value, float step) {
     return floor(value / step + 0.5f) * step;
 }
@@ -1872,7 +1877,9 @@ inline void passivbot_single_coin_impl(
             if (first_eq_k < 0.0f) first_eq_k = kf;
             last_eq_k = kf;
             if (any_fill) {
-                int active_fill_day = int(kf - first_eq_k) / 1440;
+                int active_fill_day = elapsed_fill_day_bucket(
+                    kf, first_eq_k, interval_ms
+                );
                 if (active_fill_day != last_active_fill_day) {
                     fills_active_days_count += 1.0f;
                     last_active_fill_day = active_fill_day;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -15,6 +15,11 @@ constant int SIDE_PARAMS = 51;
 constant float RECOVERY_FAIL_CLOSED_SENTINEL = -3.402823466e+38f;
 #endif
 
+inline int elapsed_fill_day_bucket(float k, float first_eq_k, float interval_ms) {
+    const float fill_day_candles = 86400000.0f / interval_ms;
+    return int((k - first_eq_k) / fill_day_candles);
+}
+
 inline float round_step(float value, float step) {
     return floor(value / step + 0.5f) * step;
 }
@@ -3706,7 +3711,9 @@ inline void passivbot_single_coin_impl(
             if (first_eq_k < 0.0f) first_eq_k = kf;
             last_eq_k = kf;
             if (any_fill) {
-                int active_fill_day = int(kf - first_eq_k) / 1440;
+                int active_fill_day = elapsed_fill_day_bucket(
+                    kf, first_eq_k, interval_ms
+                );
                 if (active_fill_day != last_active_fill_day) {
                     fills_active_days_count += 1.0f;
                     last_active_fill_day = active_fill_day;

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -109,6 +109,46 @@ def _pack_tm_parameter_matrix(
     return matrix
 
 
+def _scale_single_coin_minute_parameters(
+    params: np.ndarray,
+    keys: tuple[str, ...],
+    *,
+    sides: int,
+    interval_minutes: float,
+) -> np.ndarray:
+    """Convert minute-denominated directional inputs to candle periods.
+
+    Exact Rust divides strategy EMA spans by the configured candle interval
+    before calculating their alphas. Entry and HSL cooldowns remain expressed
+    in elapsed minutes, so the single-coin Metal kernels consume their
+    equivalent fractional candle counts. Hour-denominated volatility spans and
+    HSL's sample-based drawdown EMA deliberately remain unchanged.
+    """
+
+    interval_minutes = float(interval_minutes)
+    if not np.isfinite(interval_minutes) or interval_minutes < 1.0:
+        raise ValueError(
+            "MPS single-coin candle interval must be finite and at least one minute"
+        )
+    scaled = np.array(params, dtype=np.float64, copy=True)
+    minute_keys = {
+        "ema_span_0",
+        "ema_span_1",
+        "entry_cooldown_minutes",
+        "hsl_cooldown_minutes_after_red",
+    }
+    if "offset_volatility_ema_span_1m" in keys:
+        minute_keys.add("offset_volatility_ema_span_1m")
+    if "volatility_ema_span_1m" in keys:
+        minute_keys.add("volatility_ema_span_1m")
+    side_width = len(keys)
+    for side_index in range(sides):
+        offset = side_index * side_width
+        for key in minute_keys:
+            scaled[:, offset + keys.index(key)] /= interval_minutes
+    return scaled
+
+
 def _scalar_column_or_zero(scalars, index: int):
     if scalars.shape[1] > index:
         return scalars[:, index]
@@ -559,6 +599,16 @@ class MpsEmaAnchorRunner:
     ):
         self.market = market
         self.run_config = run
+        self.interval_minutes = float(run.interval_ms) / 60_000.0
+        if (
+            not np.isfinite(self.interval_minutes)
+            or self.interval_minutes < 1.0
+            or not self.interval_minutes.is_integer()
+        ):
+            raise ValueError(
+                "MPS single-coin runner requires an integer candle interval "
+                "of at least one minute"
+            )
         self.long_enabled = bool(long_enabled)
         self.short_enabled = bool(short_enabled)
         self.hedge_mode = bool(hedge_mode)
@@ -695,7 +745,13 @@ class MpsEmaAnchorRunner:
             raise ValueError(
                 f"expected directional EMA parameter matrix with {expected} columns, got {got}"
             )
-        return np.ascontiguousarray(params, dtype=np.float32)
+        scaled = _scale_single_coin_minute_parameters(
+            params,
+            EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
+            sides=2,
+            interval_minutes=self.interval_minutes,
+        )
+        return np.ascontiguousarray(scaled, dtype=np.float32)
 
     def _output_buffers(self, batch_size: int):
         if batch_size not in self._buffers:
@@ -1651,8 +1707,14 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
                 "expected directional trailing-martingale parameter matrix with "
                 f"{expected} columns, got {got}"
             )
+        scaled = _scale_single_coin_minute_parameters(
+            params,
+            TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS,
+            sides=2,
+            interval_minutes=self.interval_minutes,
+        )
         return _pack_tm_parameter_matrix(
-            params, TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS, sides=2
+            scaled, TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS, sides=2
         )
 
     def run(self, params: np.ndarray, *, profile: bool = False) -> dict:

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -119,10 +119,11 @@ def _scale_single_coin_minute_parameters(
     """Convert minute-denominated directional inputs to candle periods.
 
     Exact Rust divides strategy EMA spans by the configured candle interval
-    before calculating their alphas. Entry and HSL cooldowns remain expressed
-    in elapsed minutes, so the single-coin Metal kernels consume their
-    equivalent fractional candle counts. Hour-denominated volatility spans and
-    HSL's sample-based drawdown EMA deliberately remain unchanged.
+    before calculating their alphas. It separately compounds HSL's one-minute
+    EMA decay over the elapsed minutes, so HSL spans are converted to the
+    equivalent per-candle alpha. Entry and HSL cooldowns remain expressed in
+    elapsed minutes and are converted to candle counts. Hour-denominated
+    volatility spans remain unchanged.
     """
 
     interval_minutes = float(interval_minutes)
@@ -146,6 +147,21 @@ def _scale_single_coin_minute_parameters(
         offset = side_index * side_width
         for key in minute_keys:
             scaled[:, offset + keys.index(key)] /= interval_minutes
+        if interval_minutes != 1.0:
+            hsl_span_column = offset + keys.index("hsl_ema_span_minutes")
+            hsl_spans = scaled[:, hsl_span_column]
+            if np.any(~np.isfinite(hsl_spans)) or np.any(hsl_spans < 1.0):
+                raise ValueError(
+                    "MPS HSL EMA span must be finite and at least one minute"
+                )
+            alpha_1m = 2.0 / (hsl_spans + 1.0)
+            decay_1m = 1.0 - alpha_1m
+            alpha_per_candle = np.ones_like(decay_1m)
+            positive_decay = decay_1m > 0.0
+            alpha_per_candle[positive_decay] = -np.expm1(
+                interval_minutes * np.log(decay_1m[positive_decay])
+            )
+            scaled[:, hsl_span_column] = 2.0 / alpha_per_candle - 1.0
     return scaled
 
 

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -243,6 +243,23 @@ def _mps_dispatch_batch_size(
     return min(requested_batch_size, safe_batch_size)
 
 
+def _single_coin_candle_interval_minutes(backtest_params: dict) -> int:
+    raw_interval = backtest_params.get("candle_interval_minutes", 1)
+    try:
+        interval = float(raw_interval)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "MPS single-coin proxy requires candle_interval_minutes to be an "
+            "integer >= 1"
+        ) from exc
+    if not np.isfinite(interval) or interval < 1.0 or not interval.is_integer():
+        raise ValueError(
+            "MPS single-coin proxy requires candle_interval_minutes to be an "
+            "integer >= 1"
+        )
+    return int(interval)
+
+
 def _log_mps_dispatch_cap(
     *,
     requested_batch_size: int,
@@ -1166,10 +1183,9 @@ class MpsSingleCoinProxy:
                 f"prepared {len(payload.bot_params_list)}"
             )
         backtest_params = payload.backtest_params
-        if int(backtest_params.get("candle_interval_minutes", 1)) != 1:
-            raise ValueError(
-                "GPU foundation currently supports one-minute candles only"
-            )
+        candle_interval_minutes = _single_coin_candle_interval_minutes(
+            backtest_params
+        )
         _require_complete_valid_tail(
             int(backtest_params["last_valid_indices"][0]), len(hlcvs)
         )
@@ -1287,7 +1303,7 @@ class MpsSingleCoinProxy:
             maker_fee=float(market_params["maker_fee"]),
             taker_fee=float(market_params["taker_fee"]),
         )
-        interval_ms = int(backtest_params["candle_interval_minutes"]) * 60_000
+        interval_ms = candle_interval_minutes * 60_000
         pnl_lookback_bars = _directional_coin_hsl_lookback_bars(
             backtest_params,
             signal_mode=signal_mode,

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -3064,7 +3064,129 @@ def test_single_coin_interval_packing_scales_only_elapsed_minute_inputs(
             == 1.5
         )
         assert scaled[0, offset + keys.index(hour_span_key)] == 24.0
-        assert scaled[0, offset + keys.index("hsl_ema_span_minutes")] == 60.0
+        hsl_span = scaled[0, offset + keys.index("hsl_ema_span_minutes")]
+        alpha_1m = 2.0 / 61.0
+        alpha_5m = 2.0 / (hsl_span + 1.0)
+        assert alpha_5m == pytest.approx(1.0 - (1.0 - alpha_1m) ** 5)
+
+
+@pytest.mark.parametrize("span", [1.0, 5.5, 60.0, 720.0])
+def test_single_coin_interval_packing_compounds_hsl_elapsed_minute_decay(span):
+    side = {
+        key: float(index + 1)
+        for index, key in enumerate(EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS)
+    }
+    side["hsl_ema_span_minutes"] = span
+    original = np.asarray(
+        [[side[key] for key in EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS] * 2],
+        dtype=np.float64,
+    )
+
+    scaled = _scale_single_coin_minute_parameters(
+        original,
+        EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
+        sides=2,
+        interval_minutes=5.0,
+    )
+
+    alpha_1m = 2.0 / (span + 1.0)
+    for side_index in range(2):
+        offset = side_index * len(EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS)
+        effective_span = scaled[
+            0,
+            offset + EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS.index(
+                "hsl_ema_span_minutes"
+            ),
+        ]
+        alpha_5m = 2.0 / (effective_span + 1.0)
+        assert alpha_5m == pytest.approx(1.0 - (1.0 - alpha_1m) ** 5)
+
+
+def test_single_coin_interval_packing_preserves_one_minute_hsl_span_exactly():
+    values = np.arange(
+        1,
+        len(EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS) * 2 + 1,
+        dtype=np.float64,
+    ).reshape(1, -1)
+    for side_index in range(2):
+        values[
+            0,
+            side_index * len(EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS)
+            + EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS.index("hsl_ema_span_minutes"),
+        ] = 5.5
+
+    scaled = _scale_single_coin_minute_parameters(
+        values,
+        EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
+        sides=2,
+        interval_minutes=1.0,
+    )
+
+    assert np.array_equal(scaled, values)
+
+
+def test_single_coin_interval_packing_matches_exact_rust_hsl_elapsed_decay():
+    import passivbot_rust
+
+    side = {
+        key: float(index + 1)
+        for index, key in enumerate(EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS)
+    }
+    side["hsl_ema_span_minutes"] = 60.0
+    original = np.asarray(
+        [[side[key] for key in EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS] * 2],
+        dtype=np.float64,
+    )
+    scaled = _scale_single_coin_minute_parameters(
+        original,
+        EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
+        sides=2,
+        interval_minutes=5.0,
+    )
+    effective_span = scaled[
+        0,
+        EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS.index("hsl_ema_span_minutes"),
+    ]
+    exact = passivbot_rust.EquityHardStopRuntime()
+    packed = passivbot_rust.EquityHardStopRuntime()
+    common = {
+        "red_threshold": 0.25,
+        "tier_ratio_yellow": 0.5,
+        "tier_ratio_orange": 0.75,
+    }
+    exact.apply_sample(
+        timestamp_ms=0,
+        equity=100.0,
+        peak_strategy_equity=100.0,
+        ema_span_minutes=60.0,
+        **common,
+    )
+    packed.apply_sample(
+        timestamp_ms=0,
+        equity=100.0,
+        peak_strategy_equity=100.0,
+        ema_span_minutes=effective_span,
+        **common,
+    )
+
+    exact_step = exact.apply_sample(
+        timestamp_ms=5 * 60_000,
+        equity=90.0,
+        peak_strategy_equity=100.0,
+        ema_span_minutes=60.0,
+        **common,
+    )
+    packed_step = packed.apply_sample(
+        timestamp_ms=60_000,
+        equity=90.0,
+        peak_strategy_equity=100.0,
+        ema_span_minutes=effective_span,
+        **common,
+    )
+
+    assert exact_step["drawdown_ema"] == pytest.approx(
+        packed_step["drawdown_ema"]
+    )
 
 
 def test_single_coin_interval_packing_rejects_invalid_interval():
@@ -3164,6 +3286,10 @@ def test_mps_single_coin_five_minute_shader_smoke(strategy_kind):
     assert packed[0, keys.index("ema_span_0")] == pytest.approx(2.0)
     assert packed[0, keys.index("entry_cooldown_minutes")] == pytest.approx(
         0.4
+    )
+    packed_hsl_span = packed[0, keys.index("hsl_ema_span_minutes")]
+    assert 2.0 / (packed_hsl_span + 1.0) == pytest.approx(
+        1.0 - (1.0 - 2.0 / 61.0) ** 5
     )
     assert output["balance"].device.type == "mps"
     assert torch.isfinite(output["balance"]).all()

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -3295,6 +3295,58 @@ def test_mps_single_coin_five_minute_shader_smoke(strategy_kind):
     assert torch.isfinite(output["balance"]).all()
 
 
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+def test_mps_single_coin_active_fill_day_bucket_uses_elapsed_time(
+    strategy_kind,
+):
+    import passivbot_rust
+
+    cases = np.asarray(
+        [
+            [1_439.0, 0.0, 60_000.0],
+            [1_440.0, 0.0, 60_000.0],
+            [297.0, 10.0, 5.0 * 60_000.0],
+            [298.0, 10.0, 5.0 * 60_000.0],
+            [215.0, 10.0, 7.0 * 60_000.0],
+            [216.0, 10.0, 7.0 * 60_000.0],
+        ],
+        dtype=np.float32,
+    )
+    expected = [0, 1, 0, 1, 0, 1]
+    probe_kernel = r"""
+kernel void passivbot_elapsed_fill_day_bucket_probe(
+    constant float* cases [[buffer(0)]],
+    device int* output [[buffer(1)]],
+    uint b [[thread_position_in_grid]]
+) {
+    int offset = int(b) * 3;
+    output[b] = elapsed_fill_day_bucket(
+        cases[offset], cases[offset + 1], cases[offset + 2]
+    );
+}
+"""
+    source = (
+        passivbot_rust.mps_ema_anchor_source_py()
+        if strategy_kind == "ema_anchor"
+        else passivbot_rust.mps_trailing_martingale_source_py()
+    )
+    library = torch.mps.compile_shader(source + probe_kernel)
+    inputs = torch.tensor(cases, dtype=torch.float32, device="mps").contiguous()
+    output = torch.zeros(len(cases), dtype=torch.int32, device="mps")
+
+    library.passivbot_elapsed_fill_day_bucket_probe(
+        inputs,
+        output,
+        threads=(len(cases), 1, 1),
+    )
+    torch.mps.synchronize()
+
+    assert output.cpu().tolist() == expected
+
+
 def _multicoin_exposure_fixture(
     strategy_kind,
     side,

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -30,6 +30,7 @@ from optimization.gpu.mps_kernel import (
     _decode_multicoin_fused_outputs,
     _encode_max_realized_loss_pct,
     _pack_tm_parameter_matrix,
+    _scale_single_coin_minute_parameters,
     _with_hsl_ema_tail,
     _with_hsl_features,
     _with_recovery_distribution,
@@ -3005,6 +3006,167 @@ _HSL_DISABLED_VALUES = {
 def _single_coin_param_row(values, keys):
     merged = {**_UNSTUCK_DISABLED_VALUES, **_HSL_DISABLED_VALUES, **values}
     return [merged[key] for key in keys]
+
+
+@pytest.mark.parametrize(
+    ("keys", "minute_span_key", "hour_span_key"),
+    [
+        (
+            EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
+            "offset_volatility_ema_span_1m",
+            "offset_volatility_ema_span_1h",
+        ),
+        (
+            TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS,
+            "volatility_ema_span_1m",
+            "volatility_ema_span_1h",
+        ),
+    ],
+)
+def test_single_coin_interval_packing_scales_only_elapsed_minute_inputs(
+    keys, minute_span_key, hour_span_key
+):
+    side = {key: float(index + 1) for index, key in enumerate(keys)}
+    side.update(
+        {
+            "ema_span_0": 30.0,
+            "ema_span_1": 90.0,
+            minute_span_key: 120.0,
+            hour_span_key: 24.0,
+            "entry_cooldown_minutes": 2.0,
+            "hsl_ema_span_minutes": 60.0,
+            "hsl_cooldown_minutes_after_red": 7.5,
+        }
+    )
+    original = np.asarray(
+        [[side[key] for key in keys] * 2], dtype=np.float64
+    )
+
+    scaled = _scale_single_coin_minute_parameters(
+        original, keys, sides=2, interval_minutes=5.0
+    )
+
+    assert np.array_equal(
+        original,
+        np.asarray([[side[key] for key in keys] * 2], dtype=np.float64),
+    )
+    for side_index in range(2):
+        offset = side_index * len(keys)
+        assert scaled[0, offset + keys.index("ema_span_0")] == 6.0
+        assert scaled[0, offset + keys.index("ema_span_1")] == 18.0
+        assert scaled[0, offset + keys.index(minute_span_key)] == 24.0
+        assert scaled[0, offset + keys.index("entry_cooldown_minutes")] == 0.4
+        assert (
+            scaled[
+                0,
+                offset + keys.index("hsl_cooldown_minutes_after_red"),
+            ]
+            == 1.5
+        )
+        assert scaled[0, offset + keys.index(hour_span_key)] == 24.0
+        assert scaled[0, offset + keys.index("hsl_ema_span_minutes")] == 60.0
+
+
+def test_single_coin_interval_packing_rejects_invalid_interval():
+    values = np.zeros(
+        (1, len(EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS) * 2), dtype=np.float64
+    )
+
+    with pytest.raises(ValueError, match="at least one minute"):
+        _scale_single_coin_minute_parameters(
+            values,
+            EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
+            sides=2,
+            interval_minutes=0.0,
+        )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+def test_mps_single_coin_five_minute_shader_smoke(strategy_kind):
+    from optimization.gpu.mps_kernel import (
+        MpsEmaAnchorRunner,
+        MpsTrailingMartingaleRunner,
+    )
+
+    count = 32
+    interval_ms = 5 * 60_000
+    phase = np.linspace(0.0, 4.0 * np.pi, count)
+    close = 100.0 + np.sin(phase)
+    high = close * 1.01
+    low = close * 0.99
+    timestamps = (
+        1_700_000_000_000
+        + np.arange(count, dtype=np.int64) * interval_ms
+    )
+    market = ProxyMarket(0.001, 0.01, 0.001, 5.0, 1.0, 0.0002)
+    run = ProxyRun(
+        1_000.0,
+        2,
+        2,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        interval_ms,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    if strategy_kind == "ema_anchor":
+        row = _single_coin_param_row(
+            {
+                "base_qty_pct": 0.1,
+                "ema_span_0": 10.0,
+                "ema_span_1": 30.0,
+                "entry_double_down_factor": 1.5,
+                "offset": 0.01,
+                "offset_psize_weight": 0.0,
+                "offset_volatility_1h_weight": 0.0,
+                "offset_volatility_1m_weight": 0.0,
+                "offset_volatility_ema_span_1h": 60.0,
+                "offset_volatility_ema_span_1m": 60.0,
+                "entry_cooldown_minutes": 2.0,
+                "total_wallet_exposure_limit": 1.0,
+                "we_excess_allowance_pct": 0.0,
+                "we_excess_allowance_legacy_raw": 0.0,
+                "twel_entry_gate_enabled": 1.0,
+                "twel_enforcer_threshold": 1.0,
+                "twel_enforcer_enabled": 0.0,
+            },
+            EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
+        )
+        runner_cls = MpsEmaAnchorRunner
+        keys = EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS
+    else:
+        row = _tm_single_row(initial_ema_dist=0.01)
+        row[TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index("ema_span_0")] = 10.0
+        row[TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index("ema_span_1")] = 30.0
+        row[
+            TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(
+                "entry_cooldown_minutes"
+            )
+        ] = 2.0
+        runner_cls = MpsTrailingMartingaleRunner
+        keys = TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS
+    params = np.asarray([row + row], dtype=np.float64)
+
+    runner = runner_cls(
+        market, run, data, long_enabled=True, short_enabled=False
+    )
+    packed = runner._pack_params(params)
+    output = runner.run(params)
+    torch.mps.synchronize()
+
+    assert runner.interval_minutes == 5.0
+    assert packed[0, keys.index("ema_span_0")] == pytest.approx(2.0)
+    assert packed[0, keys.index("entry_cooldown_minutes")] == pytest.approx(
+        0.4
+    )
+    assert output["balance"].device.type == "mps"
+    assert torch.isfinite(output["balance"]).all()
 
 
 def _multicoin_exposure_fixture(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -51,10 +51,29 @@ from optimization.gpu.service import (
     _require_no_internal_invalid_multicoin_hsl_candles,
     _require_no_internal_invalid_single_coin_recovery_candles,
     _refresh_hedged_multicoin_hsl_at_portfolio_cutoff,
+    _single_coin_candle_interval_minutes,
     _single_coin_exposure_params,
     _total_exposure_enforcer_params,
     _unstuck_params,
 )
+
+
+@pytest.mark.parametrize("raw_interval", [5, 5.0, "5"])
+def test_single_coin_candle_interval_accepts_positive_integers(raw_interval):
+    assert (
+        _single_coin_candle_interval_minutes(
+            {"candle_interval_minutes": raw_interval}
+        )
+        == 5
+    )
+
+
+@pytest.mark.parametrize("raw_interval", [0, -1, 1.5, float("nan"), None, "bad"])
+def test_single_coin_candle_interval_rejects_invalid_values(raw_interval):
+    with pytest.raises(ValueError, match="integer >= 1"):
+        _single_coin_candle_interval_minutes(
+            {"candle_interval_minutes": raw_interval}
+        )
 
 
 def test_gpu_proxy_execution_checkpoint_contract_tracks_effective_inputs():


### PR DESCRIPTION
## Summary
- allow positive integer candle intervals for single-coin EMA Anchor and Trailing Martingale MPS runs
- convert minute-denominated strategy EMA spans, one-minute volatility spans, and entry/HSL cooldowns into candle periods before Metal dispatch
- preserve hour-sampled spans, HSL drawdown EMA sampling, timestamp-based metrics, and exact Rust authority
- keep multi-coin MPS explicitly restricted to one-minute candles

## Safety
- additive GPU-only change; CPU backtesting and optimization paths are untouched
- service and runner inputs fail closed on invalid or non-integral intervals
- exact Rust validation and rolling drift gates remain authoritative

## Validation
- `cargo test --no-default-features -q`: 267 passed
- `cargo check --no-default-features --tests`: passed
- full `tests/optimization`: passed (MPS tests separately exercised outside sandbox)
- full physical-M3 `tests/optimization/test_gpu_mps.py`: passed
- focused final-source physical-M3 interval tests: 5 passed
- 5-minute EMA Anchor end-to-end: 8 generations, 1,024 proxy evaluations, 64 exact validations, completed without drift halt
- 5-minute Trailing Martingale + HSL end-to-end: 8 generations, 1,024 proxy evaluations, 64 exact validations, completed without drift halt
- Rust extension source fingerprint matched the tested worktree
- `git diff --check`: passed
- strict MkDocs reached only the two pre-existing unrelated `release_notes_v8.0.0.md` / `release_notes_v8.1.0.md` CHANGELOG-link warnings
