### PR TITLE
Fix MPS hourly windows for non-divisor candle intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS single-coin optimization now matches exact Rust hourly volatility windows when an
+  aggregated candle interval does not evenly divide an hour, retaining the boundary-crossing
+  candle in the following hourly bucket instead of dropping it.
+
 - Apple MPS single-coin EMA Anchor and Trailing Martingale optimization now supports any positive
   integer `backtest.candle_interval_minutes`. Minute-denominated strategy EMA spans, HSL EMA decay,
   and entry/HSL cooldowns are converted to per-candle equivalents for Metal while timestamp-based

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -799,8 +799,9 @@ Trade-offs:
 - Metrics are still time-correct because analysis uses timestamps rather than bar indices.
 - The Apple MPS backend supports aggregated intervals for single-coin EMA Anchor and Trailing
   Martingale runs. It converts minute-denominated strategy EMA spans and elapsed-time cooldowns to
-  candle periods and compounds HSL's one-minute EMA decay over each candle before dispatch; exact
-  Rust validation remains authoritative. Multi-coin MPS runs currently require one-minute candles.
+  candle periods, compounds HSL's one-minute EMA decay over each candle, and preserves Rust's
+  boundary-crossing behavior when an interval does not evenly divide an hour; exact Rust validation
+  remains authoritative. Multi-coin MPS runs currently require one-minute candles.
 
 ### Fine-Tuning Specific Parameters
 

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -575,7 +575,6 @@ def _build_hourly_log_range(high, low, timestamps, run: ProxyRun):
     boundary[1:] = hour_idx[1:] > hour_idx[:-1]
     hour_log_range = np.zeros(n, dtype=np.float32)
     hour_valid = np.zeros(n, dtype=bool)
-    last_boundary = 0
     last_hour_boundary_ms = (int(timestamps[0]) // 3_600_000) * 3_600_000
     first_valid = max(0, run.first_valid_idx)
     latest = None
@@ -585,7 +584,13 @@ def _build_hourly_log_range(high, low, timestamps, run: ProxyRun):
         current_ts = int(derived_timestamps[k])
         window_start_ms = max(int(timestamps[0]), last_hour_boundary_ms)
         if current_ts > window_start_ms + run.interval_ms:
-            start = max(last_boundary, first_valid)
+            start = max(
+                int(
+                    (window_start_ms - int(timestamps[0]))
+                    // run.interval_ms
+                ),
+                first_valid,
+            )
             end = min(k - 1, run.last_valid_idx)
             if end >= start:
                 h_segment = high[start : end + 1]
@@ -599,7 +604,6 @@ def _build_hourly_log_range(high, low, timestamps, run: ProxyRun):
         if latest is not None:
             hour_log_range[k] = latest
             hour_valid[k] = True
-        last_boundary = k
         last_hour_boundary_ms = (current_ts // 3_600_000) * 3_600_000
     return hour_log_range, hour_valid
 

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -4741,6 +4741,39 @@ def test_initial_single_candle_hour_bucket_matches_rust_skip_contract():
     assert hour_log_range[61] == pytest.approx(np.log(106.0 / 94.0))
 
 
+def test_nondivisor_interval_hour_bucket_matches_rust_boundary_overlap():
+    interval_ms = 7 * 60_000
+    timestamps = np.arange(20, dtype=np.int64) * interval_ms
+    high = np.full(20, 101.0)
+    low = np.full(20, 99.0)
+    # The 00:56 candle crosses the 01:00 boundary. Exact Rust includes it in
+    # both the hour ending at 01:03 and the next window starting from floor(
+    # 01:00 / seven minutes), because an aggregated candle cannot be split.
+    high[8] = 200.0
+    low[8] = 50.0
+    run = ProxyRun(
+        starting_balance=1_000.0,
+        warmup_bars=1,
+        trade_start_idx=1,
+        requested_start_ts_ms=0,
+        guard_ts_ms=0,
+        first_ts_ms=0,
+        interval_ms=interval_ms,
+        liquidation_threshold=0.05,
+        first_valid_idx=0,
+        last_valid_idx=len(timestamps) - 1,
+    )
+
+    hour_log_range, hour_valid = _build_hourly_log_range(
+        high, low, timestamps, run
+    )
+
+    assert hour_valid[9]
+    assert hour_valid[18]
+    assert hour_log_range[9] == pytest.approx(np.log(200.0 / 50.0))
+    assert hour_log_range[18] == pytest.approx(np.log(200.0 / 50.0))
+
+
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )


### PR DESCRIPTION
## Summary

- derive each hourly volatility window start from the exact Rust elapsed timestamp boundary
- retain the aggregated candle crossing an hour boundary when the candle interval does not divide 60 minutes
- add a seven-minute regression while preserving the initial partial-hour skip contract
- document the corrected Apple MPS interval behavior

## Validation

- `pytest -q tests/optimization/test_gpu_mps.py -k hour_bucket_matches_rust`
- `pytest -q tests/optimization`
- full physical Apple MPS `tests/optimization/test_gpu_mps.py`
- seven-minute Trailing Martingale optimization: 8 generations, 1,024 proxy, 64 exact, completed
- seven-minute EMA Anchor optimization: 8 generations, 1,024 proxy, 64 exact, completed
- `git diff --check`
- `mkdocs build --strict` reaches the known baseline failure only: the existing `release_notes_v8.0.0.md` and `release_notes_v8.1.0.md` links to `../CHANGELOG.md`

This is an additive GPU-proxy parity correction; exact Rust optimization and all CPU behavior remain unchanged.