### PR TITLE
GPU: support multi-coin EMA candle intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS multi-coin EMA Anchor optimization now supports any positive integer
+  `backtest.candle_interval_minutes` for long-only, short-only, and fused long+short runs. Global
+  and static per-coin minute spans, Forager spans, HSL decay, and cooldowns are converted to
+  per-candle equivalents, while hourly windows and elapsed-day accounting retain exact Rust time
+  semantics. Multi-coin Trailing Martingale remains one-minute-only pending its dedicated parity
+  slice.
+
 - Apple MPS single-coin optimization now matches exact Rust hourly volatility windows when an
   aggregated candle interval does not evenly divide an hour, retaining the boundary-crossing
   candle in the following hourly bucket instead of dropping it.
@@ -11,8 +18,7 @@ All notable user-facing changes will be documented in this file.
 - Apple MPS single-coin EMA Anchor and Trailing Martingale optimization now supports any positive
   integer `backtest.candle_interval_minutes`. Minute-denominated strategy EMA spans, HSL EMA decay,
   and entry/HSL cooldowns are converted to per-candle equivalents for Metal while timestamp-based
-  metrics and exact Rust validation retain elapsed-time semantics; multi-coin MPS runs remain
-  one-minute-only.
+  metrics and exact Rust validation retain elapsed-time semantics.
 
 - Apple MPS multi-coin Trailing Martingale optimization now supports static per-coin
   `entry.ema_gate_mode` overrides. Initial entries and recursive reentries independently inherit

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -100,10 +100,10 @@ and the DEAP/pymoo CPU optimizers do not import or require PyTorch.
 The supported slice is intentionally narrow:
 
 - Apple Silicon with `torch.backends.mps.is_available()`
-- one prepared dataset per independent run or suite scenario; single-coin runs accept any
-  positive integer `backtest.candle_interval_minutes`, while multi-coin runs remain restricted to
-  one-minute candles; the dataset may be an individual exchange or the canonical combined
-  multi-exchange dataset
+- one prepared dataset per independent run or suite scenario; single-coin runs and multi-coin EMA
+  Anchor runs accept any positive integer `backtest.candle_interval_minutes`, while multi-coin
+  Trailing Martingale runs remain restricted to one-minute candles; the dataset may be an
+  individual exchange or the canonical combined multi-exchange dataset
 - `strategy_kind: ema_anchor` or `trailing_martingale`, with long-only, short-only, or
   long+short enabled for one coin
 - long-only, short-only, or dual-side hedge-mode and one-way multi-coin EMA-anchor and

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -798,10 +798,12 @@ Trade-offs:
 - Intra-interval fill ordering is lost (fills occur only at the aggregated bar boundaries).
 - Metrics are still time-correct because analysis uses timestamps rather than bar indices.
 - The Apple MPS backend supports aggregated intervals for single-coin EMA Anchor and Trailing
-  Martingale runs. It converts minute-denominated strategy EMA spans and elapsed-time cooldowns to
-  candle periods, compounds HSL's one-minute EMA decay over each candle, and preserves Rust's
-  boundary-crossing behavior when an interval does not evenly divide an hour; exact Rust validation
-  remains authoritative. Multi-coin MPS runs currently require one-minute candles.
+  Martingale runs, plus multi-coin EMA Anchor runs in long-only, short-only, and fused long+short
+  form. It converts minute-denominated strategy and Forager EMA spans, static per-coin overrides,
+  and elapsed-time cooldowns to candle periods, compounds HSL's one-minute EMA decay over each
+  candle, and preserves Rust's boundary-crossing behavior when an interval does not evenly divide
+  an hour; exact Rust validation remains authoritative. Multi-coin Trailing Martingale runs
+  currently require one-minute candles.
 
 ### Fine-Tuning Specific Parameters
 

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -540,11 +540,14 @@ mod tests {
             "const EmaMulticoinSideConfig config = load_ema_multicoin_side_config(params, po)"
         ));
         assert!(source.contains(
-            "init_ema_multicoin_side_state(\n        side, config, bars, coin_settings, coin_overrides, C"
+            "init_ema_multicoin_side_state(\n        side, config, coin_settings, coin_overrides, C"
         ));
         assert!(source.contains(
-            "update_ema_multicoin_side_indicators(\n            side, config, bars, coin_settings, k, C, start_hour_minute"
+            "update_ema_multicoin_side_indicators(\n            side, config, bars, hour_log_ranges,"
         ));
+        assert!(source.contains("multicoin_utc_day_index("));
+        assert!(source.contains("multicoin_active_fill_day("));
+        assert!(!MPS_EMA_ANCHOR_MULTICOIN_BODY.contains("start_hour_minute"));
         assert!(source.contains(
             "bool any_fill = process_ema_multicoin_side_fills("
         ));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -80,8 +80,6 @@ struct EmaMulticoinSideState {
     float volatility_1h[MAX_COINS];
     float forager_volume[MAX_COINS];
     float forager_volatility[MAX_COINS];
-    float hour_high[MAX_COINS];
-    float hour_low[MAX_COINS];
     float psize[MAX_COINS];
     float pprice[MAX_COINS];
     float last_increase_k[MAX_COINS];
@@ -299,7 +297,6 @@ inline EmaMulticoinSideConfig load_ema_multicoin_side_config(
 inline void init_ema_multicoin_side_state(
     thread EmaMulticoinSideState& side,
     thread const EmaMulticoinSideConfig& config,
-    constant float* bars,
     constant float* coin_settings,
     constant float* coin_overrides,
     int coin_count
@@ -324,12 +321,6 @@ inline void init_ema_multicoin_side_state(
         side.volatility_1h[c] = 0.0f;
         side.forager_volume[c] = seed_volume;
         side.forager_volatility[c] = 0.0f;
-        side.hour_high[c] = -INFINITY;
-        side.hour_low[c] = INFINITY;
-        if (c < coin_count && int(coin_settings[c * COIN_COLS + 6]) == 0) {
-            side.hour_high[c] = bars[c * 4 + 0];
-            side.hour_low[c] = bars[c * 4 + 1];
-        }
         side.psize[c] = 0.0f;
         side.pprice[c] = 0.0f;
         side.last_increase_k[c] = -1.0e20f;
@@ -437,12 +428,11 @@ inline void update_ema_multicoin_side_indicators(
     thread EmaMulticoinSideState& side,
     thread const EmaMulticoinSideConfig& config,
     constant float* bars,
+    constant float* hour_log_ranges,
     constant float* coin_settings,
     int k,
-    int coin_count,
-    int start_hour_minute
+    int coin_count
 ) {
-    const bool hour_boundary = ((start_hour_minute + k) % 60) == 0;
     for (int c = 0; c < coin_count; ++c) {
         const int coin_offset = c * COIN_COLS;
         const int bar_offset = (k * coin_count + c) * 4;
@@ -455,23 +445,15 @@ inline void update_ema_multicoin_side_indicators(
         const bool valid = k >= first_valid && k <= last_valid
             && finite_positive(high) && finite_positive(low)
             && finite_positive(close);
-        if (hour_boundary) {
-            if (side.hour_high[c] > 0.0f
-                && isfinite(side.hour_low[c]) && side.hour_low[c] > 0.0f
-                && side.alpha_1h_coin[c] > 0.0f) {
-                float hour_range = log(side.hour_high[c] / side.hour_low[c]);
-                side.volatility_1h[c] = fma(
-                    side.alpha_1h_coin[c],
-                    hour_range - side.volatility_1h[c],
-                    side.volatility_1h[c]
-                );
-            }
-            side.hour_high[c] = -INFINITY;
-            side.hour_low[c] = INFINITY;
+        const float hour_range = hour_log_ranges[k * coin_count + c];
+        if (hour_range >= 0.0f && side.alpha_1h_coin[c] > 0.0f) {
+            side.volatility_1h[c] = fma(
+                side.alpha_1h_coin[c],
+                hour_range - side.volatility_1h[c],
+                side.volatility_1h[c]
+            );
         }
         if (!valid) continue;
-        side.hour_high[c] = fmax(side.hour_high[c], high);
-        side.hour_low[c] = fmin(side.hour_low[c], low);
         float log_range = log(high / low);
         side.ema0[c] = fma(
             side.alpha0_coin[c], close - side.ema0[c], side.ema0[c]
@@ -2576,6 +2558,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
     constant float* bars,
     constant int* fill_ticks,
     constant int* touch_ticks,
+    constant float* hour_log_ranges,
     constant float* coin_settings,
     constant float* coin_overrides,
     constant float* params,
@@ -2599,7 +2582,6 @@ inline void passivbot_ema_anchor_multicoin_impl(
     const int requested_start_k = sizes[4];
     const int global_warmup = sizes[5];
     const int start_day_minute = sizes[6];
-    const int start_hour_minute = sizes[7];
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
     const int recovery_stride = sizes[8];
     const int recovery_sample_count = sizes[9];
@@ -2622,7 +2604,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
     const bool legacy_raw_allowance = config.legacy_raw_allowance;
     EmaMulticoinSideState side;
     init_ema_multicoin_side_state(
-        side, config, bars, coin_settings, coin_overrides, C
+        side, config, coin_settings, coin_overrides, C
     );
     thread HslState& hsl = side.hsl;
     const bool coin_hsl_mode = config.coin_hsl_mode;
@@ -2710,7 +2692,9 @@ inline void passivbot_ema_anchor_multicoin_impl(
     thread float& day_fill_count = fills.day_fill_count;
 
     for (int k = 1; k < stop_k; ++k) {
-        const int day_index = (start_day_minute + k) / 1440;
+        const int day_index = multicoin_utc_day_index(
+            start_day_minute, k, interval_ms
+        );
         if (day_index != current_day) {
             if (day_touched && current_day >= 0 && current_day < D) {
                 int output = (int(b) * D + current_day) * DAILY_COLS;
@@ -2762,7 +2746,8 @@ inline void passivbot_ema_anchor_multicoin_impl(
         }
 
         update_ema_multicoin_side_indicators(
-            side, config, bars, coin_settings, k, C, start_hour_minute
+            side, config, bars, hour_log_ranges,
+            coin_settings, k, C
         );
 
         int tradable_count = count_ema_multicoin_tradable_coins(
@@ -2947,7 +2932,9 @@ inline void passivbot_ema_anchor_multicoin_impl(
             if (first_eq_k < 0.0f) first_eq_k = float(k);
             last_eq_k = float(k);
             if (any_fill) {
-                int active_fill_day = int(float(k) - first_eq_k) / 1440;
+                int active_fill_day = multicoin_active_fill_day(
+                    k, int(first_eq_k), interval_ms
+                );
                 if (active_fill_day != last_active_fill_day) {
                     fills_active_days_count += 1.0f;
                     last_active_fill_day = active_fill_day;
@@ -3329,6 +3316,7 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
     constant float* bars,
     constant int* fill_ticks,
     constant int* touch_ticks,
+    constant float* hour_log_ranges,
     constant float* coin_settings,
     constant float* long_coin_overrides,
     constant float* short_coin_overrides,
@@ -3352,7 +3340,6 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
     const int requested_start_k = sizes[4];
     const int global_warmup = sizes[5];
     const int start_day_minute = sizes[6];
-    const int start_hour_minute = sizes[7];
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
     const int recovery_stride = sizes[8];
     const int recovery_sample_count = sizes[9];
@@ -3406,11 +3393,11 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
     EmaMulticoinSideState long_side;
     EmaMulticoinSideState short_side;
     init_ema_multicoin_side_state(
-        long_side, long_config, bars, coin_settings,
+        long_side, long_config, coin_settings,
         long_coin_overrides, C
     );
     init_ema_multicoin_side_state(
-        short_side, short_config, bars, coin_settings,
+        short_side, short_config, coin_settings,
         short_coin_overrides, C
     );
 
@@ -3473,7 +3460,9 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
     float day_start_balance = account.balance;
 
     for (int k = 1; k < stop_k; ++k) {
-        const int day_index = (start_day_minute + k) / 1440;
+        const int day_index = multicoin_utc_day_index(
+            start_day_minute, k, interval_ms
+        );
         if (day_index != current_day) {
             if (day_touched && current_day >= 0 && current_day < D) {
                 int output = (int(b) * D + current_day) * DAILY_COLS;
@@ -3552,12 +3541,12 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
         }
 
         update_ema_multicoin_side_indicators(
-            long_side, long_config, bars, coin_settings,
-            k, C, start_hour_minute
+            long_side, long_config, bars, hour_log_ranges,
+            coin_settings, k, C
         );
         update_ema_multicoin_side_indicators(
-            short_side, short_config, bars, coin_settings,
-            k, C, start_hour_minute
+            short_side, short_config, bars, hour_log_ranges,
+            coin_settings, k, C
         );
         int long_tradable_count = count_ema_multicoin_tradable_coins(
             bars, coin_settings, long_coin_overrides, k, C
@@ -3812,7 +3801,9 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
             if (first_eq_k < 0.0f) first_eq_k = float(k);
             last_eq_k = float(k);
             if (any_fill) {
-                int active_fill_day = int(float(k) - first_eq_k) / 1440;
+                int active_fill_day = multicoin_active_fill_day(
+                    k, int(first_eq_k), interval_ms
+                );
                 if (active_fill_day != last_active_fill_day) {
                     fills_active_days_count += 1.0f;
                     last_active_fill_day = active_fill_day;
@@ -4063,6 +4054,7 @@ kernel void passivbot_ema_anchor_multicoin_fused(
     constant float* bars,
     constant int* fill_ticks,
     constant int* touch_ticks,
+    constant float* hour_log_ranges,
     constant float* coin_settings,
     constant float* long_coin_overrides,
     constant float* short_coin_overrides,
@@ -4080,7 +4072,7 @@ kernel void passivbot_ema_anchor_multicoin_fused(
     uint b [[thread_position_in_grid]]
 ) {
     passivbot_ema_anchor_multicoin_fused_impl(
-        bars, fill_ticks, touch_ticks, coin_settings,
+        bars, fill_ticks, touch_ticks, hour_log_ranges, coin_settings,
         long_coin_overrides, short_coin_overrides,
         params, run_settings, sizes, end_steps,
         daily, scalars, gap_hist, coin_fill_counts,
@@ -4095,6 +4087,7 @@ kernel void passivbot_ema_anchor_multicoin(
     constant float* bars,
     constant int* fill_ticks,
     constant int* touch_ticks,
+    constant float* hour_log_ranges,
     constant float* coin_settings,
     constant float* coin_overrides,
     constant float* params,
@@ -4112,7 +4105,8 @@ kernel void passivbot_ema_anchor_multicoin(
 ) {
     const bool short_side = run_settings[3] > 0.5f;
     passivbot_ema_anchor_multicoin_impl(
-        bars, fill_ticks, touch_ticks, coin_settings, coin_overrides, params, run_settings,
+        bars, fill_ticks, touch_ticks, hour_log_ranges,
+        coin_settings, coin_overrides, params, run_settings,
         sizes, end_steps, daily, scalars, gap_hist, coin_fill_counts,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
         recovery_samples,
@@ -4125,6 +4119,7 @@ kernel void passivbot_ema_anchor_multicoin_long(
     constant float* bars,
     constant int* fill_ticks,
     constant int* touch_ticks,
+    constant float* hour_log_ranges,
     constant float* coin_settings,
     constant float* coin_overrides,
     constant float* params,
@@ -4141,7 +4136,8 @@ kernel void passivbot_ema_anchor_multicoin_long(
     uint b [[thread_position_in_grid]]
 ) {
     passivbot_ema_anchor_multicoin_impl(
-        bars, fill_ticks, touch_ticks, coin_settings, coin_overrides, params, run_settings,
+        bars, fill_ticks, touch_ticks, hour_log_ranges,
+        coin_settings, coin_overrides, params, run_settings,
         sizes, end_steps, daily, scalars, gap_hist, coin_fill_counts,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
         recovery_samples,

--- a/passivbot-rust/src/gpu/mps_multicoin_common.metal
+++ b/passivbot-rust/src/gpu/mps_multicoin_common.metal
@@ -98,6 +98,23 @@ inline bool finite_positive(float value) {
     return isfinite(value) && value > 0.0f;
 }
 
+inline int multicoin_interval_minutes(float interval_ms) {
+    return max(1, int(interval_ms / 60000.0f + 0.5f));
+}
+
+inline int multicoin_utc_day_index(
+    int start_day_minute, int k, float interval_ms
+) {
+    return (start_day_minute + k * multicoin_interval_minutes(interval_ms))
+        / 1440;
+}
+
+inline int multicoin_active_fill_day(
+    int k, int first_eq_k, float interval_ms
+) {
+    return ((k - first_eq_k) * multicoin_interval_minutes(interval_ms)) / 1440;
+}
+
 inline float float32_floor_nonnegative(float value) {
     if (!(value > 0.0f) || !isfinite(value)) return fmax(value, 0.0f);
     return as_type<float>(as_type<uint>(value) - 1u);

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -129,6 +129,26 @@ HSL_COIN_OVERRIDE_PATHS = (
     ("hsl_panic_market", ("panic_close_order_type",)),
 )
 
+EMA_ANCHOR_COIN_OVERRIDE_STRATEGY_KEYS = tuple(EMA_ANCHOR_PARAM_KEYS[:-2])
+EMA_ANCHOR_COIN_OVERRIDE_COOLDOWN_COLUMN = len(
+    EMA_ANCHOR_COIN_OVERRIDE_STRATEGY_KEYS
+)
+EMA_ANCHOR_COIN_OVERRIDE_WALLET_EXPOSURE_COLUMN = (
+    EMA_ANCHOR_COIN_OVERRIDE_COOLDOWN_COLUMN + 1
+)
+EMA_ANCHOR_COIN_OVERRIDE_ALLOWANCE_PCT_COLUMN = (
+    EMA_ANCHOR_COIN_OVERRIDE_COOLDOWN_COLUMN + 2
+)
+EMA_ANCHOR_COIN_OVERRIDE_UNSTUCK_START_COLUMN = (
+    EMA_ANCHOR_COIN_OVERRIDE_COOLDOWN_COLUMN + 3
+)
+EMA_ANCHOR_COIN_OVERRIDE_HSL_START_COLUMN = (
+    EMA_ANCHOR_COIN_OVERRIDE_UNSTUCK_START_COLUMN + 6
+)
+EMA_ANCHOR_COIN_OVERRIDE_COLS = (
+    EMA_ANCHOR_COIN_OVERRIDE_HSL_START_COLUMN + len(HSL_COIN_OVERRIDE_PATHS)
+)
+
 
 def encode_hsl_panic_order_type(value, *, field_name: str) -> float:
     if not isinstance(value, str):
@@ -918,6 +938,8 @@ def build_mps_multicoin_data(
     timestamps_ms,
     runs: list[ProxyRun],
     markets: list[ProxyMarket],
+    *,
+    include_hourly_ranges: bool = True,
 ):
     """Pack compact multicoin inputs for the persistent Apple MPS kernel.
 
@@ -959,10 +981,12 @@ def build_mps_multicoin_data(
         raise ValueError("MPS multicoin proxy requires at least three candles")
     intervals = np.diff(timestamps)
     interval_ms = int(runs[0].interval_ms)
+    if interval_ms <= 0 or interval_ms % 60_000 != 0:
+        raise ValueError(
+            "MPS multicoin proxy requires a positive whole-minute candle interval"
+        )
     if np.any(intervals != interval_ms):
         raise ValueError("MPS multicoin proxy requires a continuous candle timeline")
-    if interval_ms != 60_000:
-        raise ValueError("MPS multicoin proxy currently supports one-minute candles only")
 
     bars = np.ascontiguousarray(values[:, :, :4], dtype=np.float32)
     bars[~np.isfinite(bars)] = 0.0
@@ -971,6 +995,14 @@ def build_mps_multicoin_data(
     touch_nearest_ticks = np.empty((candle_count, coin_count), dtype=np.int32)
     touch_min_qty_bits = np.empty((candle_count, coin_count), dtype=np.int32)
     touch_min_qty_relation = np.empty((candle_count, coin_count), dtype=np.int32)
+    if include_hourly_ranges:
+        # A valid log range is always non-negative, so -1.0 is an unambiguous
+        # sentinel and avoids a second dense per-candle/per-coin validity tensor.
+        hour_log_ranges = np.full(
+            (candle_count, coin_count), -1.0, dtype=np.float32
+        )
+    else:
+        hour_log_ranges = None
     coin_settings = np.empty((coin_count, 13), dtype=np.float32)
     for coin, (run, market) in enumerate(zip(runs, markets)):
         if run.interval_ms != interval_ms:
@@ -978,6 +1010,13 @@ def build_mps_multicoin_data(
         high = values[:, coin, 0].astype(np.float64, copy=False)
         low = values[:, coin, 1].astype(np.float64, copy=False)
         close = values[:, coin, 2].astype(np.float64, copy=False)
+        if hour_log_ranges is not None:
+            coin_hour_log_range, coin_hour_valid = _build_hourly_log_range(
+                high, low, timestamps, run
+            )
+            hour_log_ranges[coin_hour_valid, coin] = coin_hour_log_range[
+                coin_hour_valid
+            ]
         high_fill, low_nonfill = _strict_fill_tick_boundaries(
             high, low, market.price_step
         )
@@ -1026,6 +1065,7 @@ def build_mps_multicoin_data(
         + touch_nearest_ticks.nbytes
         + touch_min_qty_bits.nbytes
         + touch_min_qty_relation.nbytes
+        + (hour_log_ranges.nbytes if hour_log_ranges is not None else 0)
     )
     recommended = None
     recommended_fn = getattr(torch.mps, "recommended_max_memory", None)
@@ -1043,7 +1083,7 @@ def build_mps_multicoin_data(
 
     first_day = int(timestamps[0] // 86_400_000)
     last_day = int(timestamps[-1] // 86_400_000)
-    return {
+    packed = {
         "bars": tensor(bars, dtype=torch.float32),
         "fill_ticks": tensor(fill_ticks, dtype=torch.int32),
         "touch_ticks": tensor(touch_ticks, dtype=torch.int32),
@@ -1061,3 +1101,8 @@ def build_mps_multicoin_data(
         "start_minute_of_hour": int((timestamps[0] // 60_000) % 60),
         "invariant_bytes": invariant_bytes,
     }
+    if hour_log_ranges is not None:
+        packed["hour_log_ranges"] = tensor(
+            hour_log_ranges, dtype=torch.float32
+        )
+    return packed

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -7,6 +7,10 @@ import numpy as np
 import torch
 
 from optimization.gpu.model import (
+    EMA_ANCHOR_COIN_OVERRIDE_COLS,
+    EMA_ANCHOR_COIN_OVERRIDE_COOLDOWN_COLUMN,
+    EMA_ANCHOR_COIN_OVERRIDE_HSL_START_COLUMN,
+    EMA_ANCHOR_COIN_OVERRIDE_STRATEGY_KEYS,
     EMA_ANCHOR_MULTICOIN_PARAM_KEYS,
     EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
     GAP_BINS,
@@ -109,7 +113,7 @@ def _pack_tm_parameter_matrix(
     return matrix
 
 
-def _scale_single_coin_minute_parameters(
+def _scale_directional_minute_parameters(
     params: np.ndarray,
     keys: tuple[str, ...],
     *,
@@ -129,7 +133,7 @@ def _scale_single_coin_minute_parameters(
     interval_minutes = float(interval_minutes)
     if not np.isfinite(interval_minutes) or interval_minutes < 1.0:
         raise ValueError(
-            "MPS single-coin candle interval must be finite and at least one minute"
+            "MPS candle interval must be finite and at least one minute"
         )
     scaled = np.array(params, dtype=np.float64, copy=True)
     minute_keys = {
@@ -142,6 +146,10 @@ def _scale_single_coin_minute_parameters(
         minute_keys.add("offset_volatility_ema_span_1m")
     if "volatility_ema_span_1m" in keys:
         minute_keys.add("volatility_ema_span_1m")
+    if "forager_volume_ema_span_1m" in keys:
+        minute_keys.add("forager_volume_ema_span_1m")
+    if "forager_volatility_ema_span_1m" in keys:
+        minute_keys.add("forager_volatility_ema_span_1m")
     side_width = len(keys)
     for side_index in range(sides):
         offset = side_index * side_width
@@ -163,6 +171,70 @@ def _scale_single_coin_minute_parameters(
             )
             scaled[:, hsl_span_column] = 2.0 / alpha_per_candle - 1.0
     return scaled
+
+
+def _scale_single_coin_minute_parameters(
+    params: np.ndarray,
+    keys: tuple[str, ...],
+    *,
+    sides: int,
+    interval_minutes: float,
+) -> np.ndarray:
+    """Compatibility wrapper for the original single-coin helper name."""
+
+    return _scale_directional_minute_parameters(
+        params,
+        keys,
+        sides=sides,
+        interval_minutes=interval_minutes,
+    )
+
+
+def _scale_ema_multicoin_coin_overrides(
+    coin_overrides: np.ndarray, interval_minutes: float
+) -> np.ndarray:
+    """Convert finite exact-last EMA coin overrides to candle periods."""
+
+    scaled = np.array(coin_overrides, dtype=np.float64, copy=True)
+    if scaled.ndim != 2 or scaled.shape[1] != EMA_ANCHOR_COIN_OVERRIDE_COLS:
+        raise ValueError(
+            "expected multicoin EMA override matrix with "
+            f"{EMA_ANCHOR_COIN_OVERRIDE_COLS} columns, got {scaled.shape}"
+        )
+    interval_minutes = float(interval_minutes)
+    if not np.isfinite(interval_minutes) or interval_minutes < 1.0:
+        raise ValueError(
+            "MPS candle interval must be finite and at least one minute"
+        )
+    minute_columns = {
+        EMA_ANCHOR_COIN_OVERRIDE_STRATEGY_KEYS.index("ema_span_0"),
+        EMA_ANCHOR_COIN_OVERRIDE_STRATEGY_KEYS.index("ema_span_1"),
+        EMA_ANCHOR_COIN_OVERRIDE_STRATEGY_KEYS.index(
+            "offset_volatility_ema_span_1m"
+        ),
+        EMA_ANCHOR_COIN_OVERRIDE_COOLDOWN_COLUMN,
+        EMA_ANCHOR_COIN_OVERRIDE_HSL_START_COLUMN + 3,
+    }
+    for column in minute_columns:
+        finite = np.isfinite(scaled[:, column])
+        scaled[finite, column] /= interval_minutes
+    if interval_minutes != 1.0:
+        hsl_span_column = EMA_ANCHOR_COIN_OVERRIDE_HSL_START_COLUMN + 2
+        finite = np.isfinite(scaled[:, hsl_span_column])
+        hsl_spans = scaled[finite, hsl_span_column]
+        if np.any(hsl_spans < 1.0):
+            raise ValueError(
+                "MPS HSL EMA span override must be at least one minute"
+            )
+        alpha_1m = 2.0 / (hsl_spans + 1.0)
+        decay_1m = 1.0 - alpha_1m
+        alpha_per_candle = np.ones_like(decay_1m)
+        positive_decay = decay_1m > 0.0
+        alpha_per_candle[positive_decay] = -np.expm1(
+            interval_minutes * np.log(decay_1m[positive_decay])
+        )
+        scaled[finite, hsl_span_column] = 2.0 / alpha_per_candle - 1.0
+    return np.ascontiguousarray(scaled, dtype=np.float32)
 
 
 def _scalar_column_or_zero(scalars, index: int):
@@ -922,9 +994,10 @@ class MpsEmaAnchorRunner:
 class MpsEmaAnchorMulticoinRunner:
     """Persistent single-side multi-coin EMA Anchor screening runner on MPS."""
 
-    coin_override_cols = 29
+    coin_override_cols = EMA_ANCHOR_COIN_OVERRIDE_COLS
     coin_override_label = "EMA"
     scalar_cols = MPS_MULTICOIN_SCALAR_COLS
+    supports_aggregated_intervals = True
 
     def __init__(
         self,
@@ -974,6 +1047,21 @@ class MpsEmaAnchorMulticoinRunner:
                 else MPS_MULTICOIN_BASE_SCALAR_COLS
             )
         self.run_config = run
+        interval_minutes = float(run.interval_ms) / 60_000.0
+        if (
+            not np.isfinite(interval_minutes)
+            or interval_minutes < 1.0
+            or not interval_minutes.is_integer()
+        ):
+            raise ValueError(
+                "MPS multicoin runner requires a positive whole-minute candle interval"
+            )
+        self.interval_minutes = int(interval_minutes)
+        if not self.supports_aggregated_intervals and self.interval_minutes != 1:
+            raise ValueError(
+                "MPS multicoin Trailing Martingale currently supports one-minute "
+                "candles only"
+            )
         self.n = int(data["n"])
         self.n_coins = int(data["n_coins"])
         self.n_days = int(data["n_days"])
@@ -996,6 +1084,11 @@ class MpsEmaAnchorMulticoinRunner:
         self.touch_nearest_ticks = data["touch_nearest_ticks"]
         self.touch_min_qty_bits = data["touch_min_qty_bits"]
         self.touch_min_qty_relation = data["touch_min_qty_relation"]
+        self.hour_log_ranges = (
+            data["hour_log_ranges"]
+            if self.supports_aggregated_intervals
+            else None
+        )
         self.coin_settings = data["coin_settings"]
         if coin_overrides is None:
             coin_overrides = np.full(
@@ -1009,7 +1102,7 @@ class MpsEmaAnchorMulticoinRunner:
                 f"got {coin_overrides.shape}"
             )
         self.coin_overrides = torch.as_tensor(
-            np.ascontiguousarray(coin_overrides), device="mps"
+            self._prepare_coin_overrides(coin_overrides), device="mps"
         )
         forager_score_hysteresis_pct = float(forager_score_hysteresis_pct)
         if not np.isfinite(forager_score_hysteresis_pct) or (
@@ -1080,6 +1173,11 @@ class MpsEmaAnchorMulticoinRunner:
             ),
         )
 
+    def _prepare_coin_overrides(self, coin_overrides: np.ndarray) -> np.ndarray:
+        return _scale_ema_multicoin_coin_overrides(
+            coin_overrides, self.interval_minutes
+        )
+
     def _pack_params(self, params: np.ndarray) -> np.ndarray:
         expected = len(EMA_ANCHOR_MULTICOIN_PARAM_KEYS)
         if params.ndim != 2 or params.shape[1] != expected:
@@ -1087,7 +1185,15 @@ class MpsEmaAnchorMulticoinRunner:
             raise ValueError(
                 f"expected multicoin EMA parameter matrix with {expected} columns, got {got}"
             )
-        return np.ascontiguousarray(params, dtype=np.float32)
+        return np.ascontiguousarray(
+            _scale_directional_minute_parameters(
+                params,
+                EMA_ANCHOR_MULTICOIN_PARAM_KEYS,
+                sides=1,
+                interval_minutes=self.interval_minutes,
+            ),
+            dtype=np.float32,
+        )
 
     def _output_buffers(self, batch_size: int):
         if batch_size not in self._buffers:
@@ -1157,6 +1263,7 @@ class MpsEmaAnchorMulticoinRunner:
             self.bars,
             self.fill_ticks,
             self.touch_ticks,
+            self.hour_log_ranges,
             self.coin_settings,
             self.coin_overrides,
             params_mps,
@@ -1335,7 +1442,7 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
                 f"{expected_shape}, got {short_coin_overrides.shape}"
             )
         self.short_coin_overrides = torch.as_tensor(
-            np.ascontiguousarray(short_coin_overrides), device="mps"
+            self._prepare_coin_overrides(short_coin_overrides), device="mps"
         )
         max_realized_loss_pct = float(max_realized_loss_pct)
         encoded_max_realized_loss_pct = _encode_max_realized_loss_pct(
@@ -1377,7 +1484,15 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
                 "expected fused multicoin EMA parameter matrix with "
                 f"{expected} columns, got {got}"
             )
-        return np.ascontiguousarray(params, dtype=np.float32)
+        return np.ascontiguousarray(
+            _scale_directional_minute_parameters(
+                params,
+                EMA_ANCHOR_MULTICOIN_PARAM_KEYS,
+                sides=2,
+                interval_minutes=self.interval_minutes,
+            ),
+            dtype=np.float32,
+        )
 
     def _dispatch(
         self,
@@ -1397,6 +1512,7 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
             self.bars,
             self.fill_ticks,
             self.touch_ticks,
+            self.hour_log_ranges,
             self.coin_settings,
             self.coin_overrides,
             self.short_coin_overrides,
@@ -1439,6 +1555,10 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
 
     coin_override_cols = TRAILING_MARTINGALE_COIN_OVERRIDE_COLS
     coin_override_label = "Trailing Martingale"
+    supports_aggregated_intervals = False
+
+    def _prepare_coin_overrides(self, coin_overrides: np.ndarray) -> np.ndarray:
+        return np.ascontiguousarray(coin_overrides, dtype=np.float32)
 
     def __init__(
         self,

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -10,7 +10,13 @@ import numpy as np
 
 from config.shared_bot import flatten_shared_bot_side
 from optimization.gpu.model import (
-    EMA_ANCHOR_PARAM_KEYS,
+    EMA_ANCHOR_COIN_OVERRIDE_ALLOWANCE_PCT_COLUMN,
+    EMA_ANCHOR_COIN_OVERRIDE_COLS,
+    EMA_ANCHOR_COIN_OVERRIDE_COOLDOWN_COLUMN,
+    EMA_ANCHOR_COIN_OVERRIDE_HSL_START_COLUMN,
+    EMA_ANCHOR_COIN_OVERRIDE_STRATEGY_KEYS,
+    EMA_ANCHOR_COIN_OVERRIDE_UNSTUCK_START_COLUMN,
+    EMA_ANCHOR_COIN_OVERRIDE_WALLET_EXPOSURE_COLUMN,
     EMA_ANCHOR_MULTICOIN_PARAM_KEYS,
     GPU_STRATEGY_PARAM_KEYS,
     HSL_COIN_OVERRIDE_PATHS,
@@ -1545,10 +1551,8 @@ def _build_multicoin_ema_coin_overrides(
 
         resolve_override = _get_backtest_coin_override
 
-    override_keys = tuple(EMA_ANCHOR_PARAM_KEYS[:-2])
-    hsl_start_column = 19
     matrix = np.full(
-        (len(coins), hsl_start_column + len(HSL_COIN_OVERRIDE_PATHS)),
+        (len(coins), EMA_ANCHOR_COIN_OVERRIDE_COLS),
         np.nan,
         dtype=np.float32,
     )
@@ -1558,12 +1562,12 @@ def _build_multicoin_ema_coin_overrides(
         strategy_patch = side_patch.get("strategy", {}).get("ema_anchor", {}) or {}
         effective_strategy = payload.strategy_params_list[coin_index][side]
         effective_bot = payload.bot_params_list[coin_index][side]
-        for column, key in enumerate(override_keys):
+        for column, key in enumerate(EMA_ANCHOR_COIN_OVERRIDE_STRATEGY_KEYS):
             if key in strategy_patch:
                 matrix[coin_index, column] = float(effective_strategy[key])
         risk_patch = side_patch.get("risk", {}) or {}
         if "entry_cooldown_minutes" in risk_patch:
-            matrix[coin_index, 10] = float(
+            matrix[coin_index, EMA_ANCHOR_COIN_OVERRIDE_COOLDOWN_COLUMN] = float(
                 effective_bot.get("entry_cooldown_minutes", 0.0) or 0.0
             )
         # Exact payload construction keeps per-side universe eligibility in
@@ -1573,9 +1577,11 @@ def _build_multicoin_ema_coin_overrides(
         if not bool(effective_bot.get("entry_eligible", True)) or (
             "wallet_exposure_limit" in side_patch
         ):
-            matrix[coin_index, 11] = float(effective_bot["wallet_exposure_limit"])
+            matrix[
+                coin_index, EMA_ANCHOR_COIN_OVERRIDE_WALLET_EXPOSURE_COLUMN
+            ] = float(effective_bot["wallet_exposure_limit"])
         if "we_excess_allowance_pct" in risk_patch:
-            matrix[coin_index, 12] = float(
+            matrix[coin_index, EMA_ANCHOR_COIN_OVERRIDE_ALLOWANCE_PCT_COLUMN] = float(
                 effective_bot.get("risk_we_excess_allowance_pct", 0.0) or 0.0
             )
         unstuck_patch = side_patch.get("unstuck", {}) or {}
@@ -1588,14 +1594,14 @@ def _build_multicoin_ema_coin_overrides(
                 ("loss_allowance_pct", "unstuck_loss_allowance_pct"),
                 ("threshold", "unstuck_threshold"),
             ),
-            start=13,
+            start=EMA_ANCHOR_COIN_OVERRIDE_UNSTUCK_START_COLUMN,
         ):
             if patch_key in unstuck_patch:
                 matrix[coin_index, offset] = float(effective_bot[bot_key])
         _pack_multicoin_hsl_overrides(
             matrix,
             row=coin_index,
-            start_column=hsl_start_column,
+            start_column=EMA_ANCHOR_COIN_OVERRIDE_HSL_START_COLUMN,
             side_patch=side_patch,
             effective_bot=effective_bot,
         )
@@ -1873,8 +1879,17 @@ class MpsMulticoinProxy:
                 f"markets={len(payload.exchange_params)}"
             )
         backtest_params = payload.backtest_params
-        if int(backtest_params.get("candle_interval_minutes", 1)) != 1:
-            raise ValueError("MPS multicoin proxy currently supports one-minute candles only")
+        candle_interval_minutes = _single_coin_candle_interval_minutes(
+            backtest_params
+        )
+        if (
+            self.strategy_kind == "trailing_martingale"
+            and candle_interval_minutes != 1
+        ):
+            raise ValueError(
+                "MPS multicoin Trailing Martingale currently supports one-minute "
+                "candles only"
+            )
         if not bool(backtest_params.get("dynamic_wel_by_tradability")):
             raise ValueError(
                 "MPS multicoin proxy requires backtest.dynamic_wel_by_tradability=true"
@@ -2106,7 +2121,7 @@ class MpsMulticoinProxy:
             )
             for item in payload.exchange_params
         ]
-        interval_ms = int(backtest_params["candle_interval_minutes"]) * 60_000
+        interval_ms = candle_interval_minutes * 60_000
         runs = [
             ProxyRun(
                 starting_balance=float(backtest_params["starting_balance"]),
@@ -2144,7 +2159,7 @@ class MpsMulticoinProxy:
             | _STRATEGY_EQ_RECOVERY_DISTRIBUTION_METRICS
         ):
             wallet_exposure_column = (
-                11
+                EMA_ANCHOR_COIN_OVERRIDE_WALLET_EXPOSURE_COLUMN
                 if self.strategy_kind == "ema_anchor"
                 else len(TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS) + 1
             )
@@ -2161,7 +2176,11 @@ class MpsMulticoinProxy:
                 tracking_start_indices=[run.trade_start_idx for run in runs],
             )
         self.data = build_mps_multicoin_data(
-            values, timestamps, runs=runs, markets=markets
+            values,
+            timestamps,
+            runs=runs,
+            markets=markets,
+            include_hourly_ranges=self.strategy_kind == "ema_anchor",
         )
         self.metrics_data = {"ts0": self.data["ts0"], "n": self.data["n"]}
         self.runners = {}

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -5,6 +5,10 @@ import pytest
 torch = pytest.importorskip("torch")
 
 from optimization.gpu.model import (
+    EMA_ANCHOR_COIN_OVERRIDE_COLS,
+    EMA_ANCHOR_COIN_OVERRIDE_COOLDOWN_COLUMN,
+    EMA_ANCHOR_COIN_OVERRIDE_HSL_START_COLUMN,
+    EMA_ANCHOR_COIN_OVERRIDE_STRATEGY_KEYS,
     EMA_ANCHOR_MULTICOIN_PARAM_KEYS,
     EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
     ProxyMarket,
@@ -30,6 +34,8 @@ from optimization.gpu.mps_kernel import (
     _decode_multicoin_fused_outputs,
     _encode_max_realized_loss_pct,
     _pack_tm_parameter_matrix,
+    _scale_directional_minute_parameters,
+    _scale_ema_multicoin_coin_overrides,
     _scale_single_coin_minute_parameters,
     _with_hsl_ema_tail,
     _with_hsl_features,
@@ -2235,6 +2241,7 @@ def test_mps_ema_multicoin_candle_helpers_advance_independent_sides():
     probe_kernel = r"""
 kernel void passivbot_ema_multicoin_candle_helpers_probe(
     constant float* bars,
+    constant float* hour_log_ranges,
     constant float* coin_settings,
     constant float* coin_overrides,
     device float* output,
@@ -2275,10 +2282,6 @@ kernel void passivbot_ema_multicoin_candle_helpers_probe(
         short_side.forager_volume[c] = 0.0f;
         long_side.forager_volatility[c] = 0.0f;
         short_side.forager_volatility[c] = 0.0f;
-        long_side.hour_high[c] = c == 0 ? 105.0f : 205.0f;
-        long_side.hour_low[c] = c == 0 ? 95.0f : 195.0f;
-        short_side.hour_high[c] = long_side.hour_high[c];
-        short_side.hour_low[c] = long_side.hour_low[c];
         long_side.psize[c] = c == 0 ? 2.0f : 0.2f;
         long_side.pprice[c] = c == 0 ? 90.0f : 100.0f;
         short_side.psize[c] = c == 0 ? 3.0f : 0.2f;
@@ -2291,10 +2294,12 @@ kernel void passivbot_ema_multicoin_candle_helpers_probe(
         short_side, bars, coin_settings, 1, 2, true, 1.0e9f
     );
     update_ema_multicoin_side_indicators(
-        long_side, long_config, bars, coin_settings, 1, 2, 59
+        long_side, long_config, bars, hour_log_ranges,
+        coin_settings, 1, 2
     );
     update_ema_multicoin_side_indicators(
-        short_side, short_config, bars, coin_settings, 1, 2, 59
+        short_side, short_config, bars, hour_log_ranges,
+        coin_settings, 1, 2
     );
     output[2] = float(count_ema_multicoin_tradable_coins(
         bars, coin_settings, coin_overrides, 1, 2
@@ -2326,13 +2331,23 @@ kernel void passivbot_ema_multicoin_candle_helpers_probe(
         (2, 29), float("nan"), dtype=torch.float32, device="mps"
     )
     coin_overrides[1, 11] = 0.0
+    hour_log_ranges = torch.tensor(
+        [[-1.0, -1.0], [np.log(105.0 / 95.0), np.log(205.0 / 195.0)]],
+        dtype=torch.float32,
+        device="mps",
+    )
     output = torch.zeros(12, dtype=torch.float32, device="mps")
 
     library = torch.mps.compile_shader(
         passivbot_rust.mps_ema_anchor_multicoin_source_py() + probe_kernel
     )
     library.passivbot_ema_multicoin_candle_helpers_probe(
-        bars, coin_settings, coin_overrides, output, threads=(1, 1, 1)
+        bars,
+        hour_log_ranges,
+        coin_settings,
+        coin_overrides,
+        output,
+        threads=(1, 1, 1),
     )
     torch.mps.synchronize()
 
@@ -2849,10 +2864,10 @@ kernel void passivbot_ema_multicoin_order_phase_probe(
     EmaMulticoinSideState long_side;
     EmaMulticoinSideState short_side;
     init_ema_multicoin_side_state(
-        long_side, long_config, bars, coin_settings, coin_overrides, 1
+        long_side, long_config, coin_settings, coin_overrides, 1
     );
     init_ema_multicoin_side_state(
-        short_side, short_config, bars, coin_settings, coin_overrides, 1
+        short_side, short_config, coin_settings, coin_overrides, 1
     );
     long_side.selected[0] = true;
     short_side.selected[0] = true;
@@ -3203,6 +3218,87 @@ def test_single_coin_interval_packing_rejects_invalid_interval():
         )
 
 
+def test_multicoin_ema_interval_packing_scales_forager_and_directional_spans():
+    values = {
+        key: float(index + 1)
+        for index, key in enumerate(EMA_ANCHOR_MULTICOIN_PARAM_KEYS)
+    }
+    values.update(
+        {
+            "ema_span_0": 30.0,
+            "ema_span_1": 90.0,
+            "offset_volatility_ema_span_1h": 24.0,
+            "offset_volatility_ema_span_1m": 120.0,
+            "forager_volume_ema_span_1m": 180.0,
+            "forager_volatility_ema_span_1m": 240.0,
+            "entry_cooldown_minutes": 15.0,
+            "hsl_ema_span_minutes": 60.0,
+            "hsl_cooldown_minutes_after_red": 35.0,
+        }
+    )
+    original = np.asarray(
+        [[values[key] for key in EMA_ANCHOR_MULTICOIN_PARAM_KEYS] * 2],
+        dtype=np.float64,
+    )
+
+    scaled = _scale_directional_minute_parameters(
+        original,
+        EMA_ANCHOR_MULTICOIN_PARAM_KEYS,
+        sides=2,
+        interval_minutes=5.0,
+    )
+
+    for side_index in range(2):
+        offset = side_index * len(EMA_ANCHOR_MULTICOIN_PARAM_KEYS)
+        for key, expected in (
+            ("ema_span_0", 6.0),
+            ("ema_span_1", 18.0),
+            ("offset_volatility_ema_span_1m", 24.0),
+            ("forager_volume_ema_span_1m", 36.0),
+            ("forager_volatility_ema_span_1m", 48.0),
+            ("entry_cooldown_minutes", 3.0),
+            ("hsl_cooldown_minutes_after_red", 7.0),
+        ):
+            assert scaled[0, offset + EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index(key)] == expected
+        assert scaled[
+            0,
+            offset
+            + EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index(
+                "offset_volatility_ema_span_1h"
+            ),
+        ] == 24.0
+
+
+def test_multicoin_ema_interval_packing_scales_only_finite_coin_overrides():
+    overrides = np.full(
+        (2, EMA_ANCHOR_COIN_OVERRIDE_COLS), np.nan, dtype=np.float64
+    )
+    ema0_column = EMA_ANCHOR_COIN_OVERRIDE_STRATEGY_KEYS.index("ema_span_0")
+    ema1_column = EMA_ANCHOR_COIN_OVERRIDE_STRATEGY_KEYS.index("ema_span_1")
+    volatility_1m_column = EMA_ANCHOR_COIN_OVERRIDE_STRATEGY_KEYS.index(
+        "offset_volatility_ema_span_1m"
+    )
+    hsl_span_column = EMA_ANCHOR_COIN_OVERRIDE_HSL_START_COLUMN + 2
+    hsl_cooldown_column = EMA_ANCHOR_COIN_OVERRIDE_HSL_START_COLUMN + 3
+    overrides[0, ema0_column] = 35.0
+    overrides[0, ema1_column] = 70.0
+    overrides[0, volatility_1m_column] = 140.0
+    overrides[0, EMA_ANCHOR_COIN_OVERRIDE_COOLDOWN_COLUMN] = 21.0
+    overrides[0, hsl_span_column] = 60.0
+    overrides[0, hsl_cooldown_column] = 28.0
+
+    scaled = _scale_ema_multicoin_coin_overrides(overrides, 7.0)
+
+    assert scaled[0, ema0_column] == 5.0
+    assert scaled[0, ema1_column] == 10.0
+    assert scaled[0, volatility_1m_column] == 20.0
+    assert scaled[0, EMA_ANCHOR_COIN_OVERRIDE_COOLDOWN_COLUMN] == 3.0
+    assert scaled[0, hsl_cooldown_column] == 4.0
+    alpha_7m = 2.0 / (float(scaled[0, hsl_span_column]) + 1.0)
+    assert alpha_7m == pytest.approx(1.0 - (1.0 - 2.0 / 61.0) ** 7)
+    assert np.isnan(scaled[1]).all()
+
+
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
@@ -3367,9 +3463,14 @@ def _multicoin_exposure_fixture(
     market_order_near_touch_threshold=0.001,
     hsl_panic_market=False,
     return_context=False,
+    interval_minutes=1,
 ):
     coin_count = 2
-    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    interval_ms = int(interval_minutes) * 60_000
+    timestamps = (
+        1_700_000_000_000
+        + np.arange(count, dtype=np.int64) * interval_ms
+    )
     hlcvs = np.empty((count, coin_count, 4), dtype=np.float64)
     close_matrix = np.asarray(closes, dtype=np.float64)
     for coin in range(coin_count):
@@ -3399,14 +3500,20 @@ def _multicoin_exposure_fixture(
             int(timestamps[0]),
             int(timestamps[0]),
             int(timestamps[0]),
-            60_000,
+            interval_ms,
             liquidation_threshold,
             first_valid_indices[coin],
             count - 1,
         )
         for coin in range(coin_count)
     ]
-    data = build_mps_multicoin_data(hlcvs, timestamps, runs, markets)
+    data = build_mps_multicoin_data(
+        hlcvs,
+        timestamps,
+        runs,
+        markets,
+        include_hourly_ranges=strategy_kind == "ema_anchor",
+    )
     if strategy_kind == "ema_anchor":
         values = {
             "base_qty_pct": 1.0,
@@ -3515,6 +3622,67 @@ def _multicoin_exposure_fixture(
     if return_context:
         return runner, row, runs[0], data
     return runner, row
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("interval_minutes", [5, 7])
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_ema_multicoin_aggregated_interval_directional_smoke(
+    interval_minutes, side
+):
+    runner, row = _multicoin_exposure_fixture(
+        "ema_anchor",
+        side,
+        count=420,
+        interval_minutes=interval_minutes,
+    )
+
+    output = runner.run(np.asarray([row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert runner.interval_minutes == interval_minutes
+    assert torch.isfinite(output["day_end_eq"]).any().item()
+    assert torch.isfinite(output["last_eq_ts"]).all().item()
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("interval_minutes", [5, 7])
+def test_mps_ema_multicoin_aggregated_interval_fused_smoke(interval_minutes):
+    _, row, run, data = _multicoin_exposure_fixture(
+        "ema_anchor",
+        "long",
+        count=420,
+        interval_minutes=interval_minutes,
+        return_context=True,
+    )
+    runner = MpsEmaAnchorMulticoinFusedRunner(run, data)
+
+    output = runner.run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert runner.interval_minutes == interval_minutes
+    assert torch.isfinite(output["day_end_eq"]).any().item()
+    assert torch.isfinite(output["last_eq_ts"]).all().item()
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_tm_multicoin_aggregated_interval_fails_closed():
+    with pytest.raises(
+        ValueError,
+        match="Trailing Martingale currently supports one-minute candles only",
+    ):
+        _multicoin_exposure_fixture(
+            "trailing_martingale",
+            "long",
+            count=32,
+            interval_minutes=5,
+        )
 
 
 @pytest.mark.skipif(
@@ -7436,6 +7604,7 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
         data["bars"],
         data["fill_ticks"],
         data["touch_ticks"],
+        data["hour_log_ranges"],
         data["coin_settings"],
         overrides,
         overrides,
@@ -7720,6 +7889,7 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
         data["bars"],
         data["fill_ticks"],
         data["touch_ticks"],
+        data["hour_log_ranges"],
         data["coin_settings"],
         override_unstuck,
         overrides,

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -934,19 +934,38 @@ def test_multicoin_proxy_routes_dual_side_batch_through_fused_runner(
 
 
 @pytest.mark.parametrize(
-    ("strategy_kind", "runner_name", "override_cols", "proxy_mode"),
+    (
+        "strategy_kind",
+        "runner_name",
+        "override_cols",
+        "proxy_mode",
+        "interval_minutes",
+        "expected_interval_error",
+    ),
     [
         (
             "ema_anchor",
             "MpsEmaAnchorMulticoinFusedRunner",
             29,
             "shared-account-fused-ema-v1",
+            5,
+            False,
         ),
         (
             "trailing_martingale",
             "MpsTrailingMartingaleMulticoinFusedRunner",
             TRAILING_MARTINGALE_COIN_OVERRIDE_COLS,
             "shared-account-fused-tm-v1",
+            1,
+            False,
+        ),
+        (
+            "trailing_martingale",
+            "MpsTrailingMartingaleMulticoinFusedRunner",
+            TRAILING_MARTINGALE_COIN_OVERRIDE_COLS,
+            "shared-account-fused-tm-v1",
+            5,
+            True,
         ),
     ],
 )
@@ -970,6 +989,8 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
     runner_name,
     override_cols,
     proxy_mode,
+    interval_minutes,
+    expected_interval_error,
     needed_metrics,
     tail_enabled,
     raw_drawdown_enabled,
@@ -1083,7 +1104,7 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
             for _ in range(2)
         ],
         backtest_params={
-            "candle_interval_minutes": 1,
+            "candle_interval_minutes": interval_minutes,
             "dynamic_wel_by_tradability": True,
             "forager_score_hysteresis_pct": 0.0,
             "last_valid_indices": [3, 3],
@@ -1121,7 +1142,25 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
 
     monkeypatch.setattr(mps_kernel, runner_name, FakeFusedRunner)
     values = np.ones((4, 2, 4), dtype=np.float64)
-    timestamps = np.arange(4, dtype=np.int64) * 60_000
+    timestamps = np.arange(4, dtype=np.int64) * interval_minutes * 60_000
+
+    if expected_interval_error:
+        with pytest.raises(
+            ValueError,
+            match="Trailing Martingale currently supports one-minute candles only",
+        ):
+            MpsMulticoinEmaProxy(
+                config=config,
+                hlcvs=values,
+                mss={"BTC": {}, "ETH": {}},
+                btc=np.ones(4, dtype=np.float64),
+                timestamps=timestamps,
+                exchange="bybit",
+                batch_size=8,
+                needed_metrics=needed_metrics,
+            )
+        assert constructed == {}
+        return
 
     proxy = MpsMulticoinEmaProxy(
         config=config,
@@ -1135,6 +1174,7 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
     )
 
     assert isinstance(proxy.fused_runner, FakeFusedRunner)
+    assert constructed["run"].interval_ms == interval_minutes * 60_000
     assert proxy.runners == {}
     assert proxy.coin_override_contract["proxy_mode"] == proxy_mode
     assert proxy.coin_override_contract["hsl_proxy_mode"] == proxy_mode


### PR DESCRIPTION
## Summary
- allow Apple MPS multi-coin EMA Anchor optimization on any positive whole-minute candle interval for long-only, short-only, and fused long+short runs
- convert global and finite static per-coin minute spans, Forager spans, entry/HSL cooldowns, and HSL decay to exact per-candle equivalents
- precompute exact Rust-compatible hourly log-range windows, preserve elapsed-day accounting, and keep exact Rust validation authoritative
- keep multi-coin Trailing Martingale one-minute-only and fail closed until its dedicated parity slice

## Validation
- `cargo test --no-default-features -q` (267 passed)
- `cargo check --no-default-features --tests`
- full `tests/optimization` suite
- full physical-MPS `tests/optimization/test_gpu_mps.py` suite
- `git diff --check` and Python compile checks
- physical M3 integration: BTC/ETH/SOL, Bybit, 7-minute candles, fused long+short EMA Anchor, 32 generations / 2048 proxy evals / 64 exact Rust validations, completed in 98.5s without a safety halt
- strict MkDocs reaches only the existing broken `../CHANGELOG.md` links in `release_notes_v8.0.0.md` and `release_notes_v8.1.0.md`; this PR adds no documentation warning

## Scope and safety
This is additive to the CPU optimizer. The Metal kernel remains a screening proxy; exact Rust backtests remain authoritative for persisted results, Pareto membership, constraints, and rolling drift gates. The new hourly tensor is allocated only for EMA Anchor, so the one-minute Trailing Martingale path pays no additional invariant-memory cost.