### PR TITLE
Harden Bitunix live state and candle handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,9 @@ All notable user-facing changes will be documented in this file.
 
 - Hardened Bitunix live support: wallet balance now remains realized and stable across unrealized
   PnL changes, pending-order snapshots retain code-like venue transition statuses until
-  authoritative absence, and forager candidates use the native multiplexed one-minute Kline
-  WebSocket with canonical REST startup and gap recovery, bounded silence detection, and
-  symbol-scoped fallback when a subscription is rejected.
+  authoritative absence, and forager candidates use native sharded one-minute Kline WebSockets
+  with canonical REST startup and gap recovery, per-symbol silence detection, and symbol-scoped
+  fallback when a subscription stalls or is rejected.
 
 - Apple MPS single-coin optimization now matches exact Rust hourly volatility windows when an
   aggregated candle interval does not evenly divide an hour, retaining the boundary-crossing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ All notable user-facing changes will be documented in this file.
   per-candle equivalents, while hourly windows and elapsed-day accounting retain exact Rust time
   semantics.
 
+- Hardened Bitunix live support: wallet balance now remains realized and stable across unrealized
+  PnL changes, pending-order snapshots retain code-like venue transition statuses until
+  authoritative absence, and forager candidates use the native multiplexed one-minute Kline
+  WebSocket with canonical REST startup and gap recovery.
+
 - Apple MPS single-coin optimization now matches exact Rust hourly volatility windows when an
   aggregated candle interval does not evenly divide an hour, retaining the boundary-crossing
   candle in the following hourly bucket instead of dropping it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@ All notable user-facing changes will be documented in this file.
 - Hardened Bitunix live support: wallet balance now remains realized and stable across unrealized
   PnL changes, pending-order snapshots retain code-like venue transition statuses until
   authoritative absence, and forager candidates use the native multiplexed one-minute Kline
-  WebSocket with canonical REST startup and gap recovery.
+  WebSocket with canonical REST startup and gap recovery, bounded silence detection, and
+  symbol-scoped fallback when a subscription is rejected.
 
 - Apple MPS single-coin optimization now matches exact Rust hourly volatility windows when an
   aggregated candle interval does not evenly divide an hour, retaining the boundary-crossing

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -561,9 +561,10 @@ The push timestamp is receipt/update time, so floor it to the one-minute bucket;
 base volume and validate the complete OHLC row. Pass the changing open bucket through the generic
 successor-candle finalization boundary. Drop a transient internally inconsistent update instead of
 clamping exchange values or failing unrelated multiplexed symbols; a bounded consecutive run wakes
-the affected watcher into REST fallback. Startup basis, reconnect gaps, persistent malformed data,
-prolonged silence, and periodic integrity checks remain REST-owned; a transport failure wakes every
-affected watcher so provenance is cleared before bounded reconnect and REST fallback.
+the affected watcher into REST fallback and suspends new rows for that symbol until the watcher
+consumes the fallback signal. Startup basis, reconnect gaps, persistent malformed data, prolonged
+silence, and periodic integrity checks remain REST-owned; a transport failure wakes every affected
+watcher so provenance is cleared before bounded reconnect and REST fallback.
 
 Primary references: [ticker WebSocket](https://www.bitunix.com/api-docs/futures/websocket/public/Tickers%20Channel.html),
 [REST depth](https://www.bitunix.com/api-docs/futures/market/get_depth.html), and

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -462,6 +462,8 @@ Handling:
    request spacing below the venue's documented UID/IP rolling limit. Treat the observed
    `code=1, msg=Network Error` envelope like documented network error `10001`, and retry native
    market discovery with bounded backoff so a transient cold-start response is not permanent.
+   Attach the bounded venue code to the mapped exception for structured write diagnostics; do not
+   propagate response bodies, configured headers, or credentials into the public diagnostic path.
 4. Authenticate the private WebSocket with its seconds-based signature, subscribe to `order`, and
    send Bitunix's application-level JSON ping while idle; transport-level WebSocket heartbeats do
    not replace the venue keepalive. Enrich each order notification from REST detail before
@@ -474,8 +476,9 @@ Handling:
 5. Apply custom endpoint domain rewrites and `rest.url_overrides.api` to the native REST base, and
    merge `rest.extra_headers` into every request. Reject authentication header names
    case-insensitively in configured headers so proxy or user headers cannot collide with generated
-   signatures. Honor `disable_ws` for both private orders and public tickers: use REST order
-   polling and request only explicit, bounded symbol sets through REST depth.
+   signatures. Honor `disable_ws` for private orders and public market streams: use REST order
+   polling, request only explicit bounded symbol sets through REST depth, and leave canonical
+   candle refresh and repair to REST.
 6. Keep `bitunix: null` explicit in `broker_codes.hjson`; there is no Passivbot broker payload for
    this connector.
 
@@ -503,7 +506,11 @@ Handling:
    price for every limit order and every open order. Only terminal market-order detail may omit the
    request price.
 5. Bitunix has emitted `NEW_` on live order detail although its schema documents `NEW`. Normalize
-   only trailing underscore padding before applying the closed order-status allowlist.
+   only trailing underscore padding before applying the closed order-status allowlist. Pending
+   endpoint membership is itself authoritative evidence that an order remains pending, so retain
+   an otherwise unknown bounded code-like transition status as open until a later complete
+   pending snapshot removes it, with a rate-limited structured warning. Missing, free-form, and
+   oversized statuses remain invalid, and order-detail normalization keeps the strict allowlist.
 6. Page pending orders by `skip` to the required, stable reported total under one fixed `endTime`
    snapshot. Reject missing, changing, truncated, or duplicate pagination results before treating
    the account-critical open-order set as authoritative.
@@ -513,9 +520,10 @@ Handling:
    fill `clientId` values through order detail, but retain the exchange-truth fill with unknown
    attribution when terminal order detail has expired. This is the canonical fill source for
    realized PnL, unstuck accounting, and HSL replay.
-8. Reconstruct realized wallet balance as
-   `available + frozen + margin - crossUnrealizedPNL - isolationUnrealizedPNL`; do not feed
-   mark-to-market equity into Rust sizing.
+8. Reconstruct realized wallet balance as `available + frozen + margin`. These are the disjoint
+   available, order-locked, and position-margin quantities. Keep
+   `crossUnrealizedPNL + isolationUnrealizedPNL` separate as mark-to-market state so price movement
+   does not change Rust's realized sizing balance.
 
 Primary references: [place order](https://www.bitunix.com/api-docs/futures/trade/place_order.html),
 [pending positions](https://www.bitunix.com/api-docs/futures/position/get_pending_positions.html),
@@ -547,9 +555,18 @@ and deduplicate. This pagination supports live warmup, restart reconstruction, a
 indicators only. Bulk historical Bitunix data for backtesting or optimization is not a supported
 source.
 
+When WebSockets are enabled, use one public socket to multiplex the active forager candidates on
+the official `market_kline_1min` channel, up to the venue's 300-subscription connection limit.
+The push timestamp is receipt/update time, so floor it to the one-minute bucket; normalize `b` as
+base volume and validate the complete OHLC row. Pass the changing open bucket through the generic
+successor-candle finalization boundary. Startup basis, reconnect gaps, malformed streams, prolonged
+silence, and periodic integrity checks remain REST-owned; a stream failure wakes every affected
+watcher so provenance is cleared before bounded reconnect and REST fallback.
+
 Primary references: [ticker WebSocket](https://www.bitunix.com/api-docs/futures/websocket/public/Tickers%20Channel.html),
 [REST depth](https://www.bitunix.com/api-docs/futures/market/get_depth.html), and
-[kline API](https://www.bitunix.com/api-docs/futures/market/get_kline.html).
+[Kline WebSocket](https://www.bitunix.com/api-docs/futures/websocket/public/kline%20channel.html),
+and [kline API](https://www.bitunix.com/api-docs/futures/market/get_kline.html).
 
 ## WEEX Futures
 

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -564,7 +564,11 @@ clamping exchange values or failing unrelated multiplexed symbols; a bounded con
 the affected watcher into REST fallback and suspends new rows for that symbol until the watcher
 consumes the fallback signal. Startup basis, reconnect gaps, persistent malformed data, prolonged
 silence, and periodic integrity checks remain REST-owned; a transport failure wakes every affected
-watcher so provenance is cleared before bounded reconnect and REST fallback.
+watcher so provenance is cleared before bounded reconnect and REST fallback. Enforce public-socket
+silence independently of the short receive polling used for subscription reconciliation. Validate
+subscription acknowledgements and wake only the rejected symbols into REST fallback when the
+response identifies them; an unscoped rejection conservatively wakes the pending subscription
+batch.
 
 Primary references: [ticker WebSocket](https://www.bitunix.com/api-docs/futures/websocket/public/Tickers%20Channel.html),
 [REST depth](https://www.bitunix.com/api-docs/futures/market/get_depth.html), and

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -555,8 +555,9 @@ and deduplicate. This pagination supports live warmup, restart reconstruction, a
 indicators only. Bulk historical Bitunix data for backtesting or optimization is not a supported
 source.
 
-When WebSockets are enabled, use one public socket to multiplex the active forager candidates on
-the official `market_kline_1min` channel, up to the venue's 300-subscription connection limit.
+When WebSockets are enabled, multiplex the active forager candidates on the official
+`market_kline_1min` channel. Deterministically shard the sorted symbol set across public sockets,
+with no more than the venue's 300 subscriptions on each connection.
 The push timestamp is receipt/update time, so floor it to the one-minute bucket; normalize `b` as
 base volume and validate the complete OHLC row. Pass the changing open bucket through the generic
 successor-candle finalization boundary. Drop a transient internally inconsistent update instead of
@@ -564,11 +565,12 @@ clamping exchange values or failing unrelated multiplexed symbols; a bounded con
 the affected watcher into REST fallback and suspends new rows for that symbol until the watcher
 consumes the fallback signal. Startup basis, reconnect gaps, persistent malformed data, prolonged
 silence, and periodic integrity checks remain REST-owned; a transport failure wakes every affected
-watcher so provenance is cleared before bounded reconnect and REST fallback. Enforce public-socket
-silence independently of the short receive polling used for subscription reconciliation. Validate
-subscription acknowledgements and wake only the rejected symbols into REST fallback when the
-response identifies them; an unscoped rejection conservatively wakes the pending subscription
-batch.
+watcher so provenance is cleared before bounded reconnect and REST fallback. Track application-data
+liveness per symbol so unrelated Kline traffic and control frames cannot conceal a stalled
+subscription, while also enforcing connection silence independently of the short receive polling
+used for subscription reconciliation. Validate subscription acknowledgements and wake only the
+rejected symbols into REST fallback when the response identifies them; an unscoped rejection
+conservatively wakes the pending subscription batch.
 
 Primary references: [ticker WebSocket](https://www.bitunix.com/api-docs/futures/websocket/public/Tickers%20Channel.html),
 [REST depth](https://www.bitunix.com/api-docs/futures/market/get_depth.html), and

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -559,9 +559,11 @@ When WebSockets are enabled, use one public socket to multiplex the active forag
 the official `market_kline_1min` channel, up to the venue's 300-subscription connection limit.
 The push timestamp is receipt/update time, so floor it to the one-minute bucket; normalize `b` as
 base volume and validate the complete OHLC row. Pass the changing open bucket through the generic
-successor-candle finalization boundary. Startup basis, reconnect gaps, malformed streams, prolonged
-silence, and periodic integrity checks remain REST-owned; a stream failure wakes every affected
-watcher so provenance is cleared before bounded reconnect and REST fallback.
+successor-candle finalization boundary. Drop a transient internally inconsistent update instead of
+clamping exchange values or failing unrelated multiplexed symbols; a bounded consecutive run wakes
+the affected watcher into REST fallback. Startup basis, reconnect gaps, persistent malformed data,
+prolonged silence, and periodic integrity checks remain REST-owned; a transport failure wakes every
+affected watcher so provenance is cleared before bounded reconnect and REST fallback.
 
 Primary references: [ticker WebSocket](https://www.bitunix.com/api-docs/futures/websocket/public/Tickers%20Channel.html),
 [REST depth](https://www.bitunix.com/api-docs/futures/market/get_depth.html), and

--- a/src/exchanges/bitunix.py
+++ b/src/exchanges/bitunix.py
@@ -27,6 +27,7 @@ from ccxt.base.errors import (
 from config.access import require_live_value
 from custom_endpoint_overrides import CustomEndpointConfigError
 from exchanges.ccxt_bot import CCXTBot, format_exchange_config_response
+from live.balance_composition import normalize_bitunix_balance_composition
 from passivbot import logging
 from utils import symbol_to_coin
 
@@ -116,6 +117,8 @@ class BitunixClient:
     DEFAULT_MAKER_FEE = 0.0002
     DEFAULT_TAKER_FEE = 0.0006
     RESERVED_AUTH_HEADERS = frozenset({"api-key", "nonce", "timestamp", "sign"})
+    ORDER_STATUS_TOKEN_RE = re.compile(r"[A-Z][A-Z0-9_]{0,31}")
+    PENDING_STATUS_WARNING_INTERVAL_SECONDS = 300.0
 
     has = {
         "cancelOrder": True,
@@ -204,6 +207,7 @@ class BitunixClient:
         self._ticker_tasks: list[asyncio.Task] = []
         self._ticker_subscription_ids: tuple[str, ...] = ()
         self._ticker_ready = asyncio.Event()
+        self._pending_status_warning_monotonic: dict[str, float] = {}
         self._closed = False
 
     def milliseconds(self) -> int:
@@ -260,26 +264,34 @@ class BitunixClient:
         code_text = str(code)
         safe_message = str(message or "Bitunix API error")[:240]
         text = f"Bitunix error {code_text}: {safe_message}"
+        error_type: type[Exception]
         if code_text in {"403", "10003", "10004", "10007"}:
-            raise AuthenticationError(text)
+            error_type = AuthenticationError
         # The documented transport code is 10001. The live trading-pairs
         # endpoint also emits code 1 with the same message; classify both as
         # retryable network failures instead of permanent bad requests.
-        if code_text == "10001" or (
+        elif code_text == "10001" or (
             code_text == "1" and safe_message.strip().lower() == "network error"
         ):
-            raise NetworkError(text)
-        if code_text in {"10005", "10006", "429"}:
-            raise RateLimitExceeded(text)
-        if code_text == "20007":
-            raise OrderNotFound(text)
-        if code_text in {"20003", "20004"}:
-            raise InsufficientFunds(text)
-        if code_text.startswith("3"):
-            raise InvalidOrder(text)
-        if code_text.startswith("2") or code_text.startswith("1"):
-            raise BadRequest(text)
-        raise ExchangeError(text)
+            error_type = NetworkError
+        elif code_text in {"10005", "10006", "429"}:
+            error_type = RateLimitExceeded
+        elif code_text == "20007":
+            error_type = OrderNotFound
+        elif code_text in {"20003", "20004"}:
+            error_type = InsufficientFunds
+        elif code_text.startswith("3"):
+            error_type = InvalidOrder
+        elif code_text.startswith("2") or code_text.startswith("1"):
+            error_type = BadRequest
+        else:
+            error_type = ExchangeError
+        error = error_type(text)
+        # Generic live diagnostics read only bounded structured attributes.
+        # Retaining the numeric/code token here makes failed writes actionable
+        # without publishing the response message or payload.
+        error.code = code_text
+        raise error
 
     async def _request(
         self,
@@ -467,7 +479,11 @@ class BitunixClient:
             raw.get("isolationUnrealizedPNL"),
             field="account.isolationUnrealizedPNL",
         )
-        wallet = available + frozen + margin - cross_upnl - isolated_upnl
+        # Bitunix documents these as disjoint available, order-locked, and
+        # position-locked quantities. Unrealized PnL is mark-to-market state,
+        # not a realized wallet component; subtracting it makes sizing move
+        # with every mark-price update.
+        wallet = available + frozen + margin
         if not math.isfinite(wallet) or wallet < 0.0:
             raise ValueError("Bitunix account response produced invalid wallet balance")
         return {
@@ -604,7 +620,32 @@ class BitunixClient:
             raise ValueError(f"Unknown Bitunix order status {status!r}")
         return mapping[status]
 
-    def _normalize_order(self, row: dict) -> dict:
+    def _pending_order_status(self, raw_status: Any) -> str:
+        """Classify one row returned by the authoritative pending endpoint.
+
+        Endpoint membership proves the order is still pending even when the
+        venue introduces a new code-like transition enum. Preserve that order
+        conservatively until a later complete snapshot removes it. Missing or
+        malformed status values remain invalid.
+        """
+        try:
+            return self._order_status(raw_status)
+        except ValueError:
+            token = str(raw_status or "").upper().rstrip("_")
+            if not self.ORDER_STATUS_TOKEN_RE.fullmatch(token):
+                raise
+            now = time.monotonic()
+            last = self._pending_status_warning_monotonic.get(token)
+            if last is None or now - last >= self.PENDING_STATUS_WARNING_INTERVAL_SECONDS:
+                logging.warning(
+                    "[bitunix] [order] pending endpoint returned unrecognized status "
+                    "| status=%s action=retain_as_open_until_authoritative_absence",
+                    token,
+                )
+                self._pending_status_warning_monotonic[token] = now
+            return "open"
+
+    def _normalize_order(self, row: dict, *, pending_snapshot: bool = False) -> dict:
         market_id = str(row.get("symbol") or "")
         symbol = self.safe_symbol(market_id)
         raw_side = str(row.get("side") or "").upper()
@@ -651,8 +692,11 @@ class BitunixClient:
         ).lower()
         if order_type not in {"limit", "market"}:
             raise ValueError("Bitunix order missing LIMIT/MARKET order type")
-        status = self._order_status(
-            row.get("status") or row.get("orderStatus")
+        raw_status = row.get("status") or row.get("orderStatus")
+        status = (
+            self._pending_order_status(raw_status)
+            if pending_snapshot
+            else self._order_status(raw_status)
         )
         price_required = order_type == "limit" or status == "open"
         price = _float(
@@ -780,7 +824,10 @@ class BitunixClient:
                 "Bitunix open-orders pagination returned duplicate or incomplete rows"
             )
         return sorted(
-            (self._normalize_order(row) for row in rows.values()),
+            (
+                self._normalize_order(row, pending_snapshot=True)
+                for row in rows.values()
+            ),
             key=lambda order: order["timestamp"],
         )
 
@@ -1453,17 +1500,24 @@ class BitunixClient:
 
 
 class BitunixOrderStream:
-    """Private Bitunix order websocket enriched through authoritative REST detail."""
+    """Native private-order and multiplexed public-candle WebSocket boundary."""
 
     id = "bitunix"
-    has = {"watchOrders": True}
+    has = {"watchOrders": True, "watchOHLCV": True}
     PING_INTERVAL_SECONDS = 15.0
+    KLINE_CHANNELS = {"1m": "market_kline_1min"}
+    MAX_KLINE_SUBSCRIPTIONS = 300
+    KLINE_QUEUE_SIZE = 4
 
     def __init__(self, rest: BitunixClient):
         self.rest = rest
         self.options: dict[str, Any] = {}
         self._ws: aiohttp.ClientWebSocketResponse | None = None
         self._last_ping_monotonic = time.monotonic()
+        self._ohlcv_ws: aiohttp.ClientWebSocketResponse | None = None
+        self._ohlcv_task: asyncio.Task | None = None
+        self._ohlcv_queues: dict[str, asyncio.Queue] = {}
+        self._ohlcv_closed = False
 
     async def _receive_with_keepalive(
         self, ws: aiohttp.ClientWebSocketResponse
@@ -1568,7 +1622,199 @@ class BitunixOrderStream:
                 self._ws = None
                 raise NetworkError("Bitunix private order websocket disconnected")
 
+    def _normalize_ohlcv_payload(self, payload: Any) -> tuple[str, list[list[float]]]:
+        if not isinstance(payload, dict):
+            raise ValueError("Bitunix kline websocket payload is not an object")
+        if payload.get("ch") != self.KLINE_CHANNELS["1m"]:
+            raise ValueError("Bitunix kline websocket payload has unexpected channel")
+        market_id = str(payload.get("symbol") or "")
+        symbol = self.rest.safe_symbol(market_id)
+        timestamp = _int(payload.get("ts"), field="kline websocket ts")
+        if timestamp <= 0:
+            raise ValueError("Bitunix kline websocket has invalid timestamp")
+        data = payload.get("data")
+        if not isinstance(data, dict):
+            raise ValueError("Bitunix kline websocket data is not an object")
+        open_price = _float(data.get("o"), field="kline websocket open")
+        high = _float(data.get("h"), field="kline websocket high")
+        low = _float(data.get("l"), field="kline websocket low")
+        close = _float(data.get("c"), field="kline websocket close")
+        base_volume = _float(data.get("b"), field="kline websocket base volume")
+        if min(open_price, high, low, close) <= 0.0 or base_volume < 0.0:
+            raise ValueError("Bitunix kline websocket has invalid price or volume")
+        if low > min(open_price, close) or high < max(open_price, close) or low > high:
+            raise ValueError("Bitunix kline websocket has inconsistent OHLC values")
+        bucket_timestamp = timestamp - timestamp % self.rest.timeframe_milliseconds["1m"]
+        return symbol, [
+            [bucket_timestamp, open_price, high, low, close, base_volume]
+        ]
+
+    @staticmethod
+    def _queue_latest(queue: asyncio.Queue, item: Any, *, clear: bool = False) -> None:
+        if clear:
+            while not queue.empty():
+                try:
+                    queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+        while queue.full():
+            try:
+                queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+        queue.put_nowait(item)
+
+    def _broadcast_ohlcv_error(self, error: BaseException) -> None:
+        for queue in tuple(self._ohlcv_queues.values()):
+            self._queue_latest(queue, error, clear=True)
+
+    def _ensure_ohlcv_task(self) -> None:
+        if self._ohlcv_closed:
+            raise NetworkError("Bitunix kline websocket is closed")
+        if self._ohlcv_task is None or self._ohlcv_task.done():
+            self._ohlcv_task = asyncio.create_task(
+                self._ohlcv_loop(), name="bitunix-public-klines"
+            )
+
+    async def _ohlcv_loop(self) -> None:
+        current_task = asyncio.current_task()
+        try:
+            await self.rest._ensure_markets()
+            session = await self.rest._get_session()
+            async with session.ws_connect(
+                self.rest.PUBLIC_WS_URL,
+                heartbeat=20.0,
+                receive_timeout=45.0,
+            ) as ws:
+                self._ohlcv_ws = ws
+                subscribed_ids: set[str] = set()
+                last_ping_monotonic = time.monotonic()
+                while not self._ohlcv_closed:
+                    desired_by_id = {
+                        str(self.rest.market(symbol)["id"]): symbol
+                        for symbol in tuple(self._ohlcv_queues)
+                    }
+                    if len(desired_by_id) > self.MAX_KLINE_SUBSCRIPTIONS:
+                        raise ValueError(
+                            "Bitunix kline websocket subscription limit exceeded"
+                        )
+                    desired_ids = set(desired_by_id)
+                    removed = sorted(subscribed_ids - desired_ids)
+                    added = sorted(desired_ids - subscribed_ids)
+                    if removed:
+                        await ws.send_json(
+                            {
+                                "op": "unsubscribe",
+                                "args": [
+                                    {
+                                        "symbol": market_id,
+                                        "ch": self.KLINE_CHANNELS["1m"],
+                                    }
+                                    for market_id in removed
+                                ],
+                            }
+                        )
+                    if added:
+                        await ws.send_json(
+                            {
+                                "op": "subscribe",
+                                "args": [
+                                    {
+                                        "symbol": market_id,
+                                        "ch": self.KLINE_CHANNELS["1m"],
+                                    }
+                                    for market_id in added
+                                ],
+                            }
+                        )
+                    subscribed_ids = desired_ids
+                    if not desired_ids:
+                        return
+                    now_monotonic = time.monotonic()
+                    if now_monotonic - last_ping_monotonic >= self.PING_INTERVAL_SECONDS:
+                        await ws.send_json({"op": "ping", "ping": int(time.time())})
+                        last_ping_monotonic = now_monotonic
+                    try:
+                        message = await asyncio.wait_for(ws.receive(), timeout=1.0)
+                    except asyncio.TimeoutError:
+                        continue
+                    if message.type == aiohttp.WSMsgType.TEXT:
+                        payload = json.loads(message.data)
+                        if isinstance(payload, dict) and payload.get("op") in {
+                            "connect",
+                            "ping",
+                            "pong",
+                            "subscribe",
+                            "unsubscribe",
+                        }:
+                            continue
+                        symbol, rows = self._normalize_ohlcv_payload(payload)
+                        queue = self._ohlcv_queues.get(symbol)
+                        if queue is not None:
+                            self._queue_latest(queue, rows)
+                    elif message.type in {
+                        aiohttp.WSMsgType.CLOSED,
+                        aiohttp.WSMsgType.ERROR,
+                    }:
+                        raise NetworkError("Bitunix public kline websocket disconnected")
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logging.debug(
+                "[ws] bitunix public kline reconnect | error_type=%s",
+                type(exc).__name__,
+            )
+            self._broadcast_ohlcv_error(
+                NetworkError(
+                    "Bitunix public kline websocket failed: "
+                    f"{type(exc).__name__}"
+                )
+            )
+        finally:
+            self._ohlcv_ws = None
+            if self._ohlcv_task is current_task:
+                self._ohlcv_task = None
+
+    async def watch_ohlcv(self, symbol: str, timeframe: str = "1m") -> list[list[float]]:
+        if timeframe not in self.KLINE_CHANNELS:
+            raise BadRequest(f"Unsupported Bitunix WebSocket OHLCV timeframe {timeframe!r}")
+        await self.rest._ensure_markets()
+        self.rest.market(symbol)
+        queue = self._ohlcv_queues.get(symbol)
+        if queue is None:
+            queue = asyncio.Queue(maxsize=self.KLINE_QUEUE_SIZE)
+            self._ohlcv_queues[symbol] = queue
+        self._ensure_ohlcv_task()
+        item = await queue.get()
+        if isinstance(item, BaseException):
+            raise item
+        if item is None:
+            raise NetworkError("Bitunix kline websocket subscription was removed")
+        return item
+
+    async def un_watch_ohlcv(self, symbol: str, timeframe: str = "1m") -> None:
+        if timeframe not in self.KLINE_CHANNELS:
+            raise BadRequest(f"Unsupported Bitunix WebSocket OHLCV timeframe {timeframe!r}")
+        queue = self._ohlcv_queues.pop(symbol, None)
+        if queue is not None:
+            self._queue_latest(queue, None, clear=True)
+        if not self._ohlcv_queues and self._ohlcv_task is not None:
+            task = self._ohlcv_task
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+            if self._ohlcv_task is task:
+                self._ohlcv_task = None
+
     async def close(self) -> None:
+        self._ohlcv_closed = True
+        for queue in tuple(self._ohlcv_queues.values()):
+            self._queue_latest(queue, None, clear=True)
+        self._ohlcv_queues.clear()
+        ohlcv_task = self._ohlcv_task
+        if ohlcv_task is not None:
+            ohlcv_task.cancel()
+            await asyncio.gather(ohlcv_task, return_exceptions=True)
+        self._ohlcv_task = None
         if self._ws is not None and not self._ws.closed:
             await self._ws.close()
         self._ws = None
@@ -1615,6 +1861,10 @@ class BitunixBot(CCXTBot):
             if isinstance(source, str) and source.strip():
                 ticker["source"] = source.strip()
         return tickers
+
+    def _normalize_balance_diagnostics(self, fetched: object) -> dict:
+        """Expose only documented Bitunix account components for diagnostics."""
+        return normalize_bitunix_balance_composition(fetched)
 
     async def update_exchange_config(self) -> None:
         current = await self.cca.fetch_position_mode()

--- a/src/exchanges/bitunix.py
+++ b/src/exchanges/bitunix.py
@@ -1508,6 +1508,7 @@ class BitunixOrderStream:
     KLINE_CHANNELS = {"1m": "market_kline_1min"}
     MAX_KLINE_SUBSCRIPTIONS = 300
     KLINE_QUEUE_SIZE = 4
+    MAX_CONSECUTIVE_MALFORMED_KLINES = 5
 
     def __init__(self, rest: BitunixClient):
         self.rest = rest
@@ -1688,6 +1689,8 @@ class BitunixOrderStream:
             ) as ws:
                 self._ohlcv_ws = ws
                 subscribed_ids: set[str] = set()
+                malformed_counts: dict[str, int] = {}
+                malformed_warned: set[str] = set()
                 last_ping_monotonic = time.monotonic()
                 while not self._ohlcv_closed:
                     desired_by_id = {
@@ -1748,7 +1751,53 @@ class BitunixOrderStream:
                             "unsubscribe",
                         }:
                             continue
-                        symbol, rows = self._normalize_ohlcv_payload(payload)
+                        try:
+                            symbol, rows = self._normalize_ohlcv_payload(payload)
+                        except ValueError:
+                            # Bitunix has emitted transient internally inconsistent
+                            # OHLC updates (for example, low one tick above open).
+                            # Never clamp or persist them, and do not sacrifice
+                            # unrelated multiplexed symbols. A bounded consecutive
+                            # run wakes only this watcher into generic REST fallback.
+                            market_id = (
+                                str(payload.get("symbol") or "")
+                                if isinstance(payload, dict)
+                                and payload.get("ch") == self.KLINE_CHANNELS["1m"]
+                                else ""
+                            )
+                            malformed_symbol = desired_by_id.get(market_id)
+                            malformed_queue = self._ohlcv_queues.get(
+                                malformed_symbol or ""
+                            )
+                            if malformed_symbol is None or malformed_queue is None:
+                                raise
+                            malformed_counts[malformed_symbol] = (
+                                malformed_counts.get(malformed_symbol, 0) + 1
+                            )
+                            if malformed_symbol not in malformed_warned:
+                                logging.warning(
+                                    "[bitunix] [candle] malformed kline update dropped "
+                                    "| symbol=%s action=drop_update "
+                                    "rest_fallback_after=%d",
+                                    malformed_symbol,
+                                    self.MAX_CONSECUTIVE_MALFORMED_KLINES,
+                                )
+                                malformed_warned.add(malformed_symbol)
+                            if (
+                                malformed_counts[malformed_symbol]
+                                >= self.MAX_CONSECUTIVE_MALFORMED_KLINES
+                            ):
+                                self._queue_latest(
+                                    malformed_queue,
+                                    NetworkError(
+                                        "Bitunix public kline websocket received "
+                                        "consecutive malformed updates"
+                                    ),
+                                    clear=True,
+                                )
+                                malformed_counts[malformed_symbol] = 0
+                            continue
+                        malformed_counts[symbol] = 0
                         queue = self._ohlcv_queues.get(symbol)
                         if queue is not None:
                             self._queue_latest(queue, rows)

--- a/src/exchanges/bitunix.py
+++ b/src/exchanges/bitunix.py
@@ -1509,6 +1509,7 @@ class BitunixOrderStream:
     MAX_KLINE_SUBSCRIPTIONS = 300
     KLINE_QUEUE_SIZE = 4
     MAX_CONSECUTIVE_MALFORMED_KLINES = 5
+    KLINE_SILENCE_TIMEOUT_SECONDS = 45.0
 
     def __init__(self, rest: BitunixClient):
         self.rest = rest
@@ -1670,6 +1671,28 @@ class BitunixOrderStream:
         for queue in tuple(self._ohlcv_queues.values()):
             self._queue_latest(queue, error, clear=True)
 
+    def _queue_ohlcv_fallback(self, symbol: str, error: BaseException) -> bool:
+        queue = self._ohlcv_queues.get(symbol)
+        if queue is None:
+            return False
+        self._ohlcv_fallback_pending.add(symbol)
+        self._queue_latest(queue, error, clear=True)
+        return True
+
+    @staticmethod
+    def _subscription_ack_market_ids(payload: dict[str, Any]) -> set[str]:
+        market_ids: set[str] = set()
+        symbol = payload.get("symbol")
+        if symbol not in (None, ""):
+            market_ids.add(str(symbol))
+        for key in ("arg", "args"):
+            value = payload.get(key)
+            rows = value if isinstance(value, list) else [value]
+            for row in rows:
+                if isinstance(row, dict) and row.get("symbol") not in (None, ""):
+                    market_ids.add(str(row["symbol"]))
+        return market_ids
+
     def _ensure_ohlcv_task(self) -> None:
         if self._ohlcv_closed:
             raise NetworkError("Bitunix kline websocket is closed")
@@ -1693,6 +1716,8 @@ class BitunixOrderStream:
                 malformed_counts: dict[str, int] = {}
                 malformed_warned: set[str] = set()
                 last_ping_monotonic = time.monotonic()
+                last_frame_monotonic = last_ping_monotonic
+                pending_subscribe_ids: set[str] = set()
                 while not self._ohlcv_closed:
                     desired_by_id = {
                         str(self.rest.market(symbol)["id"]): symbol
@@ -1702,7 +1727,11 @@ class BitunixOrderStream:
                         raise ValueError(
                             "Bitunix kline websocket subscription limit exceeded"
                         )
-                    desired_ids = set(desired_by_id)
+                    desired_ids = {
+                        market_id
+                        for market_id, symbol in desired_by_id.items()
+                        if symbol not in self._ohlcv_fallback_pending
+                    }
                     removed = sorted(subscribed_ids - desired_ids)
                     added = sorted(desired_ids - subscribed_ids)
                     if removed:
@@ -1718,6 +1747,7 @@ class BitunixOrderStream:
                                 ],
                             }
                         )
+                        pending_subscribe_ids.difference_update(removed)
                     if added:
                         await ws.send_json(
                             {
@@ -1731,27 +1761,82 @@ class BitunixOrderStream:
                                 ],
                             }
                         )
+                        pending_subscribe_ids.update(added)
                     subscribed_ids = desired_ids
-                    if not desired_ids:
+                    if not desired_by_id:
                         return
                     now_monotonic = time.monotonic()
                     if now_monotonic - last_ping_monotonic >= self.PING_INTERVAL_SECONDS:
                         await ws.send_json({"op": "ping", "ping": int(time.time())})
                         last_ping_monotonic = now_monotonic
+                    silence_remaining = (
+                        self.KLINE_SILENCE_TIMEOUT_SECONDS
+                        - (now_monotonic - last_frame_monotonic)
+                    )
+                    if silence_remaining <= 0.0:
+                        raise NetworkError("Bitunix public kline websocket became silent")
                     try:
-                        message = await asyncio.wait_for(ws.receive(), timeout=1.0)
+                        message = await asyncio.wait_for(
+                            ws.receive(), timeout=min(1.0, silence_remaining)
+                        )
                     except asyncio.TimeoutError:
+                        if (
+                            time.monotonic() - last_frame_monotonic
+                            >= self.KLINE_SILENCE_TIMEOUT_SECONDS
+                        ):
+                            raise NetworkError(
+                                "Bitunix public kline websocket became silent"
+                            )
                         continue
+                    last_frame_monotonic = time.monotonic()
                     if message.type == aiohttp.WSMsgType.TEXT:
                         payload = json.loads(message.data)
-                        if isinstance(payload, dict) and payload.get("op") in {
-                            "connect",
-                            "ping",
-                            "pong",
-                            "subscribe",
-                            "unsubscribe",
-                        }:
-                            continue
+                        if isinstance(payload, dict):
+                            operation = payload.get("op")
+                            if operation == "subscribe":
+                                acknowledged_ids = self._subscription_ack_market_ids(
+                                    payload
+                                )
+                                if not acknowledged_ids:
+                                    acknowledged_ids = set(pending_subscribe_ids)
+                                pending_subscribe_ids.difference_update(
+                                    acknowledged_ids
+                                )
+                                rejected = (
+                                    payload.get("code") not in (None, 0, "0")
+                                    or payload.get("success") is False
+                                )
+                                if rejected:
+                                    if not acknowledged_ids:
+                                        acknowledged_ids = set(subscribed_ids)
+                                    for market_id in sorted(acknowledged_ids):
+                                        symbol = desired_by_id.get(market_id)
+                                        if symbol is None:
+                                            continue
+                                        if self._queue_ohlcv_fallback(
+                                            symbol,
+                                            NetworkError(
+                                                "Bitunix public kline websocket "
+                                                "subscription was rejected"
+                                            ),
+                                        ):
+                                            logging.warning(
+                                                "[bitunix] [candle] websocket "
+                                                "subscription rejected | symbol=%s "
+                                                "action=rest_fallback",
+                                                symbol,
+                                            )
+                                    subscribed_ids.difference_update(
+                                        acknowledged_ids
+                                    )
+                                continue
+                            if operation in {
+                                "connect",
+                                "ping",
+                                "pong",
+                                "unsubscribe",
+                            }:
+                                continue
                         try:
                             symbol, rows = self._normalize_ohlcv_payload(payload)
                         except ValueError:
@@ -1788,16 +1873,12 @@ class BitunixOrderStream:
                                 malformed_counts[malformed_symbol]
                                 >= self.MAX_CONSECUTIVE_MALFORMED_KLINES
                             ):
-                                self._queue_latest(
-                                    malformed_queue,
+                                self._queue_ohlcv_fallback(
+                                    malformed_symbol,
                                     NetworkError(
                                         "Bitunix public kline websocket received "
                                         "consecutive malformed updates"
                                     ),
-                                    clear=True,
-                                )
-                                self._ohlcv_fallback_pending.add(
-                                    malformed_symbol
                                 )
                                 malformed_counts[malformed_symbol] = 0
                             continue

--- a/src/exchanges/bitunix.py
+++ b/src/exchanges/bitunix.py
@@ -1518,6 +1518,7 @@ class BitunixOrderStream:
         self._ohlcv_ws: aiohttp.ClientWebSocketResponse | None = None
         self._ohlcv_task: asyncio.Task | None = None
         self._ohlcv_queues: dict[str, asyncio.Queue] = {}
+        self._ohlcv_fallback_pending: set[str] = set()
         self._ohlcv_closed = False
 
     async def _receive_with_keepalive(
@@ -1795,11 +1796,17 @@ class BitunixOrderStream:
                                     ),
                                     clear=True,
                                 )
+                                self._ohlcv_fallback_pending.add(
+                                    malformed_symbol
+                                )
                                 malformed_counts[malformed_symbol] = 0
                             continue
                         malformed_counts[symbol] = 0
                         queue = self._ohlcv_queues.get(symbol)
-                        if queue is not None:
+                        if (
+                            queue is not None
+                            and symbol not in self._ohlcv_fallback_pending
+                        ):
                             self._queue_latest(queue, rows)
                     elif message.type in {
                         aiohttp.WSMsgType.CLOSED,
@@ -1836,6 +1843,7 @@ class BitunixOrderStream:
         self._ensure_ohlcv_task()
         item = await queue.get()
         if isinstance(item, BaseException):
+            self._ohlcv_fallback_pending.discard(symbol)
             raise item
         if item is None:
             raise NetworkError("Bitunix kline websocket subscription was removed")
@@ -1845,6 +1853,7 @@ class BitunixOrderStream:
         if timeframe not in self.KLINE_CHANNELS:
             raise BadRequest(f"Unsupported Bitunix WebSocket OHLCV timeframe {timeframe!r}")
         queue = self._ohlcv_queues.pop(symbol, None)
+        self._ohlcv_fallback_pending.discard(symbol)
         if queue is not None:
             self._queue_latest(queue, None, clear=True)
         if not self._ohlcv_queues and self._ohlcv_task is not None:
@@ -1859,6 +1868,7 @@ class BitunixOrderStream:
         for queue in tuple(self._ohlcv_queues.values()):
             self._queue_latest(queue, None, clear=True)
         self._ohlcv_queues.clear()
+        self._ohlcv_fallback_pending.clear()
         ohlcv_task = self._ohlcv_task
         if ohlcv_task is not None:
             ohlcv_task.cancel()

--- a/src/exchanges/bitunix.py
+++ b/src/exchanges/bitunix.py
@@ -607,7 +607,10 @@ class BitunixClient:
     def _order_status(raw_status: Any) -> str:
         # Live REST currently emits ``NEW_`` although the public schema says
         # ``NEW``.  Treat only trailing enum padding as equivalent.
-        status = str(raw_status or "").upper().rstrip("_")
+        raw_token = str(raw_status or "").upper()
+        if not BitunixClient.ORDER_STATUS_TOKEN_RE.fullmatch(raw_token):
+            raise ValueError("Unknown Bitunix order status")
+        status = raw_token.rstrip("_")
         mapping = {
             "INIT": "open",
             "NEW": "open",
@@ -631,9 +634,10 @@ class BitunixClient:
         try:
             return self._order_status(raw_status)
         except ValueError:
-            token = str(raw_status or "").upper().rstrip("_")
-            if not self.ORDER_STATUS_TOKEN_RE.fullmatch(token):
+            raw_token = str(raw_status or "").upper()
+            if not self.ORDER_STATUS_TOKEN_RE.fullmatch(raw_token):
                 raise
+            token = raw_token.rstrip("_")
             now = time.monotonic()
             last = self._pending_status_warning_monotonic.get(token)
             if last is None or now - last >= self.PENDING_STATUS_WARNING_INTERVAL_SECONDS:
@@ -1677,9 +1681,7 @@ class BitunixOrderStream:
     ) -> None:
         targets = tuple(self._ohlcv_queues) if symbols is None else tuple(symbols)
         for symbol in targets:
-            queue = self._ohlcv_queues.get(symbol)
-            if queue is not None:
-                self._queue_latest(queue, error, clear=True)
+            self._queue_ohlcv_fallback(symbol, error)
 
     def _queue_ohlcv_fallback(self, symbol: str, error: BaseException) -> bool:
         queue = self._ohlcv_queues.get(symbol)

--- a/src/exchanges/bitunix.py
+++ b/src/exchanges/bitunix.py
@@ -1518,6 +1518,8 @@ class BitunixOrderStream:
         self._last_ping_monotonic = time.monotonic()
         self._ohlcv_ws: aiohttp.ClientWebSocketResponse | None = None
         self._ohlcv_task: asyncio.Task | None = None
+        self._ohlcv_sockets: dict[int, aiohttp.ClientWebSocketResponse] = {}
+        self._ohlcv_tasks: dict[int, asyncio.Task] = {}
         self._ohlcv_queues: dict[str, asyncio.Queue] = {}
         self._ohlcv_fallback_pending: set[str] = set()
         self._ohlcv_closed = False
@@ -1667,9 +1669,17 @@ class BitunixOrderStream:
                 break
         queue.put_nowait(item)
 
-    def _broadcast_ohlcv_error(self, error: BaseException) -> None:
-        for queue in tuple(self._ohlcv_queues.values()):
-            self._queue_latest(queue, error, clear=True)
+    def _broadcast_ohlcv_error(
+        self,
+        error: BaseException,
+        *,
+        symbols: Iterable[str] | None = None,
+    ) -> None:
+        targets = tuple(self._ohlcv_queues) if symbols is None else tuple(symbols)
+        for symbol in targets:
+            queue = self._ohlcv_queues.get(symbol)
+            if queue is not None:
+                self._queue_latest(queue, error, clear=True)
 
     def _queue_ohlcv_fallback(self, symbol: str, error: BaseException) -> bool:
         queue = self._ohlcv_queues.get(symbol)
@@ -1693,16 +1703,37 @@ class BitunixOrderStream:
                     market_ids.add(str(row["symbol"]))
         return market_ids
 
+    def _ohlcv_shard_symbols(self, shard_index: int) -> list[str]:
+        start = shard_index * self.MAX_KLINE_SUBSCRIPTIONS
+        end = start + self.MAX_KLINE_SUBSCRIPTIONS
+        return sorted(self._ohlcv_queues)[start:end]
+
+    def _required_ohlcv_shards(self) -> int:
+        if not self._ohlcv_queues:
+            return 0
+        return (
+            len(self._ohlcv_queues) + self.MAX_KLINE_SUBSCRIPTIONS - 1
+        ) // self.MAX_KLINE_SUBSCRIPTIONS
+
     def _ensure_ohlcv_task(self) -> None:
         if self._ohlcv_closed:
             raise NetworkError("Bitunix kline websocket is closed")
-        if self._ohlcv_task is None or self._ohlcv_task.done():
-            self._ohlcv_task = asyncio.create_task(
-                self._ohlcv_loop(), name="bitunix-public-klines"
+        for shard_index in range(self._required_ohlcv_shards()):
+            task = self._ohlcv_tasks.get(shard_index)
+            if task is not None and not task.done():
+                continue
+            task = asyncio.create_task(
+                self._ohlcv_loop(shard_index),
+                name=f"bitunix-public-klines-{shard_index}",
             )
+            self._ohlcv_tasks[shard_index] = task
+            if shard_index == 0:
+                self._ohlcv_task = task
 
-    async def _ohlcv_loop(self) -> None:
+    async def _ohlcv_loop(self, shard_index: int) -> None:
         current_task = asyncio.current_task()
+        assigned_symbols: set[str] = set()
+        subscribed_symbols_by_id: dict[str, str] = {}
         try:
             await self.rest._ensure_markets()
             session = await self.rest._get_session()
@@ -1711,22 +1742,53 @@ class BitunixOrderStream:
                 heartbeat=20.0,
                 receive_timeout=45.0,
             ) as ws:
-                self._ohlcv_ws = ws
+                self._ohlcv_sockets[shard_index] = ws
+                if shard_index == 0:
+                    self._ohlcv_ws = ws
                 subscribed_ids: set[str] = set()
                 malformed_counts: dict[str, int] = {}
                 malformed_warned: set[str] = set()
                 last_ping_monotonic = time.monotonic()
                 last_frame_monotonic = last_ping_monotonic
+                last_symbol_activity: dict[str, float] = {}
                 pending_subscribe_ids: set[str] = set()
                 while not self._ohlcv_closed:
+                    shard_symbols = self._ohlcv_shard_symbols(shard_index)
+                    assigned_symbols = set(shard_symbols)
                     desired_by_id = {
                         str(self.rest.market(symbol)["id"]): symbol
-                        for symbol in tuple(self._ohlcv_queues)
+                        for symbol in shard_symbols
                     }
-                    if len(desired_by_id) > self.MAX_KLINE_SUBSCRIPTIONS:
-                        raise ValueError(
-                            "Bitunix kline websocket subscription limit exceeded"
+                    if not desired_by_id:
+                        return
+                    now_monotonic = time.monotonic()
+                    for market_id in tuple(subscribed_ids):
+                        symbol = subscribed_symbols_by_id.get(market_id)
+                        if (
+                            symbol is None
+                            or symbol in self._ohlcv_fallback_pending
+                        ):
+                            continue
+                        last_activity = last_symbol_activity.get(
+                            symbol, now_monotonic
                         )
+                        if (
+                            now_monotonic - last_activity
+                            < self.KLINE_SILENCE_TIMEOUT_SECONDS
+                        ):
+                            continue
+                        if self._queue_ohlcv_fallback(
+                            symbol,
+                            NetworkError(
+                                "Bitunix public kline websocket subscription "
+                                "became silent"
+                            ),
+                        ):
+                            logging.warning(
+                                "[bitunix] [candle] websocket subscription silent "
+                                "| symbol=%s action=rest_fallback",
+                                symbol,
+                            )
                     desired_ids = {
                         market_id
                         for market_id, symbol in desired_by_id.items()
@@ -1747,7 +1809,13 @@ class BitunixOrderStream:
                                 ],
                             }
                         )
-                        pending_subscribe_ids.difference_update(removed)
+                        for market_id in removed:
+                            pending_subscribe_ids.discard(market_id)
+                            removed_symbol = subscribed_symbols_by_id.pop(
+                                market_id, None
+                            )
+                            if removed_symbol is not None:
+                                last_symbol_activity.pop(removed_symbol, None)
                     if added:
                         await ws.send_json(
                             {
@@ -1762,10 +1830,15 @@ class BitunixOrderStream:
                             }
                         )
                         pending_subscribe_ids.update(added)
+                        for market_id in added:
+                            symbol = desired_by_id[market_id]
+                            subscribed_symbols_by_id[market_id] = symbol
+                            last_symbol_activity[symbol] = now_monotonic
+                    for market_id in desired_ids & subscribed_ids:
+                        subscribed_symbols_by_id[market_id] = desired_by_id[
+                            market_id
+                        ]
                     subscribed_ids = desired_ids
-                    if not desired_by_id:
-                        return
-                    now_monotonic = time.monotonic()
                     if now_monotonic - last_ping_monotonic >= self.PING_INTERVAL_SECONDS:
                         await ws.send_json({"op": "ping", "ping": int(time.time())})
                         last_ping_monotonic = now_monotonic
@@ -1812,6 +1885,10 @@ class BitunixOrderStream:
                                     for market_id in sorted(acknowledged_ids):
                                         symbol = desired_by_id.get(market_id)
                                         if symbol is None:
+                                            symbol = subscribed_symbols_by_id.get(
+                                                market_id
+                                            )
+                                        if symbol is None:
                                             continue
                                         if self._queue_ohlcv_fallback(
                                             symbol,
@@ -1829,6 +1906,15 @@ class BitunixOrderStream:
                                     subscribed_ids.difference_update(
                                         acknowledged_ids
                                     )
+                                else:
+                                    for market_id in acknowledged_ids:
+                                        symbol = subscribed_symbols_by_id.get(
+                                            market_id
+                                        )
+                                        if symbol is not None:
+                                            last_symbol_activity[symbol] = (
+                                                last_frame_monotonic
+                                            )
                                 continue
                             if operation in {
                                 "connect",
@@ -1856,6 +1942,8 @@ class BitunixOrderStream:
                                 malformed_symbol or ""
                             )
                             if malformed_symbol is None or malformed_queue is None:
+                                if market_id in self.rest.markets_by_id:
+                                    continue
                                 raise
                             malformed_counts[malformed_symbol] = (
                                 malformed_counts.get(malformed_symbol, 0) + 1
@@ -1882,6 +1970,10 @@ class BitunixOrderStream:
                                 )
                                 malformed_counts[malformed_symbol] = 0
                             continue
+                        market_id = str(payload.get("symbol") or "")
+                        if desired_by_id.get(market_id) != symbol:
+                            continue
+                        last_symbol_activity[symbol] = last_frame_monotonic
                         malformed_counts[symbol] = 0
                         queue = self._ohlcv_queues.get(symbol)
                         if (
@@ -1898,19 +1990,29 @@ class BitunixOrderStream:
             raise
         except Exception as exc:
             logging.debug(
-                "[ws] bitunix public kline reconnect | error_type=%s",
+                "[ws] bitunix public kline reconnect | shard=%d error_type=%s",
+                shard_index,
                 type(exc).__name__,
             )
             self._broadcast_ohlcv_error(
                 NetworkError(
                     "Bitunix public kline websocket failed: "
                     f"{type(exc).__name__}"
-                )
+                ),
+                symbols=(
+                    assigned_symbols
+                    | set(subscribed_symbols_by_id.values())
+                ),
             )
         finally:
-            self._ohlcv_ws = None
-            if self._ohlcv_task is current_task:
-                self._ohlcv_task = None
+            if self._ohlcv_sockets.get(shard_index) is not None:
+                self._ohlcv_sockets.pop(shard_index, None)
+            if self._ohlcv_tasks.get(shard_index) is current_task:
+                self._ohlcv_tasks.pop(shard_index, None)
+            if shard_index == 0:
+                self._ohlcv_ws = None
+                if self._ohlcv_task is current_task:
+                    self._ohlcv_task = None
 
     async def watch_ohlcv(self, symbol: str, timeframe: str = "1m") -> list[list[float]]:
         if timeframe not in self.KLINE_CHANNELS:
@@ -1937,12 +2039,19 @@ class BitunixOrderStream:
         self._ohlcv_fallback_pending.discard(symbol)
         if queue is not None:
             self._queue_latest(queue, None, clear=True)
-        if not self._ohlcv_queues and self._ohlcv_task is not None:
-            task = self._ohlcv_task
+        required_shards = self._required_ohlcv_shards()
+        obsolete_tasks = [
+            task
+            for shard_index, task in tuple(self._ohlcv_tasks.items())
+            if shard_index >= required_shards
+        ]
+        for task in obsolete_tasks:
             task.cancel()
-            await asyncio.gather(task, return_exceptions=True)
-            if self._ohlcv_task is task:
-                self._ohlcv_task = None
+        if obsolete_tasks:
+            await asyncio.gather(*obsolete_tasks, return_exceptions=True)
+        if required_shards == 0:
+            self._ohlcv_task = None
+            self._ohlcv_ws = None
 
     async def close(self) -> None:
         self._ohlcv_closed = True
@@ -1950,11 +2059,15 @@ class BitunixOrderStream:
             self._queue_latest(queue, None, clear=True)
         self._ohlcv_queues.clear()
         self._ohlcv_fallback_pending.clear()
-        ohlcv_task = self._ohlcv_task
-        if ohlcv_task is not None:
-            ohlcv_task.cancel()
-            await asyncio.gather(ohlcv_task, return_exceptions=True)
+        ohlcv_tasks = tuple(self._ohlcv_tasks.values())
+        for task in ohlcv_tasks:
+            task.cancel()
+        if ohlcv_tasks:
+            await asyncio.gather(*ohlcv_tasks, return_exceptions=True)
+        self._ohlcv_tasks.clear()
+        self._ohlcv_sockets.clear()
         self._ohlcv_task = None
+        self._ohlcv_ws = None
         if self._ws is not None and not self._ws.closed:
             await self._ws.close()
         self._ws = None

--- a/src/exchanges/bitunix.py
+++ b/src/exchanges/bitunix.py
@@ -1734,7 +1734,9 @@ class BitunixOrderStream:
 
     async def _ohlcv_loop(self, shard_index: int) -> None:
         current_task = asyncio.current_task()
-        assigned_symbols: set[str] = set()
+        # Establish the shard's failure scope before market/session/socket setup.
+        # Any of those awaits may fail and must wake every current watcher.
+        assigned_symbols = set(self._ohlcv_shard_symbols(shard_index))
         subscribed_symbols_by_id: dict[str, str] = {}
         try:
             await self.rest._ensure_markets()
@@ -2003,6 +2005,7 @@ class BitunixOrderStream:
                 ),
                 symbols=(
                     assigned_symbols
+                    | set(self._ohlcv_shard_symbols(shard_index))
                     | set(subscribed_symbols_by_id.values())
                 ),
             )

--- a/src/live/balance_composition.py
+++ b/src/live/balance_composition.py
@@ -270,6 +270,56 @@ def normalize_hyperliquid_unified_balance_composition(fetched: Any) -> dict[str,
     )
 
 
+def normalize_bitunix_balance_composition(fetched: Any) -> dict[str, Any]:
+    """Normalize documented Bitunix futures-account components for diagnostics.
+
+    Bitunix reports disjoint available, order-frozen, and position-margin
+    quantities. Their sum is the realized wallet balance; unrealized PnL is a
+    separate mark-to-market component and must not be subtracted from that sum.
+    """
+    source = "bitunix.info.account"
+    if not isinstance(fetched, Mapping):
+        return malformed_balance_composition(source=source, reason="invalid_payload")
+    info = fetched.get("info")
+    if not isinstance(info, Mapping):
+        return malformed_balance_composition(source=source, reason="missing_info")
+    asset = _asset_name(info.get("marginCoin"))
+    if asset is None:
+        return malformed_balance_composition(source=source, reason="missing_margin_coin")
+    available = _finite_number(info.get("available"))
+    frozen = _finite_number(info.get("frozen"))
+    margin = _finite_number(info.get("margin"))
+    cross_upnl = _finite_number(info.get("crossUnrealizedPNL"))
+    isolated_upnl = _finite_number(info.get("isolationUnrealizedPNL"))
+    if None in (available, frozen, margin, cross_upnl, isolated_upnl):
+        return malformed_balance_composition(source=source, reason="missing_account_fields")
+    wallet = available + frozen + margin
+    used = frozen + margin
+    unrealized_pnl = cross_upnl + isolated_upnl
+    if not all(math.isfinite(value) for value in (wallet, used, unrealized_pnl)):
+        return malformed_balance_composition(source=source, reason="non_finite_account")
+    return _finalize_snapshot(
+        status="available",
+        source=source,
+        assets=[
+            {
+                "asset": asset,
+                "amount": wallet,
+                "free_amount": available,
+                "used_amount": used,
+                "unrealized_pnl": unrealized_pnl,
+                "field_provenance": {
+                    "asset": "marginCoin",
+                    "amount": "account_components",
+                    "free_amount": "available",
+                    "used_amount": "frozen_margin",
+                    "unrealized_pnl": "account_unrealized_pnl",
+                },
+            }
+        ],
+    )
+
+
 def _select_gateio_account_row(fetched: Mapping[str, Any], quote: str) -> Mapping[str, Any] | None:
     """Pick the unique Gate futures-account row for the settle currency when possible.
 
@@ -400,6 +450,7 @@ def public_balance_composition(value: Any) -> dict[str, Any] | None:
         status not in {"available", "unavailable", "malformed"}
         or source
         not in {
+            "bitunix.info.account",
             "unsupported",
             "normalizer",
             "ccxt.unified_balance",
@@ -435,12 +486,23 @@ def public_balance_composition(value: Any) -> dict[str, Any] | None:
         provenance = item.get("field_provenance")
         if isinstance(provenance, Mapping):
             allowed_sources = {
-                "asset": {"ccy", "coin", "currency", "currency_map_key", "quote"},
-                "amount": {"cashBal", "total", "wallet_balance"},
+                "asset": {
+                    "ccy",
+                    "coin",
+                    "currency",
+                    "currency_map_key",
+                    "marginCoin",
+                    "quote",
+                },
+                "amount": {"account_components", "cashBal", "total", "wallet_balance"},
                 "free_amount": {"free", "available", "cross_available"},
-                "used_amount": {"used", "cross_margin"},
+                "used_amount": {"cross_margin", "frozen_margin", "used"},
                 "usd_value": "eqUsd",
-                "unrealized_pnl": {"upl", "cross_unrealised_pnl"},
+                "unrealized_pnl": {
+                    "account_unrealized_pnl",
+                    "cross_unrealised_pnl",
+                    "upl",
+                },
                 "liability": {"debt", "liab"},
                 "collateral_enabled": "collateralEnabled",
             }

--- a/src/live/candle_ws.py
+++ b/src/live/candle_ws.py
@@ -304,6 +304,11 @@ async def watch_forager_ws_symbol(bot: Any, symbol: str) -> None:
     watcher_task = asyncio.current_task()
     try:
         while not bool(getattr(bot, "stop_signal_received", False)):
+            # Retirement may begin while this task is ingesting the previous
+            # row. Do not let that old generation loop back into a connector
+            # after its subscription has already been removed.
+            if _watcher_is_retiring(bot, symbol, watcher_task):
+                break
             try:
                 rows = await bot.ccp.watch_ohlcv(symbol, "1m")
                 if _watcher_is_retiring(bot, symbol, watcher_task):

--- a/tests/exchanges/test_bitunix.py
+++ b/tests/exchanges/test_bitunix.py
@@ -1067,6 +1067,119 @@ async def test_order_stream_public_failure_wakes_all_watchers_for_rest_fallback(
 
 
 @pytest.mark.asyncio
+async def test_order_stream_silence_timeout_wakes_waiter_for_rest_fallback():
+    client = _prepared_client()
+    socket = _PublicKlineSocket()
+    session = _PublicKlineSession(socket)
+    client._get_session = AsyncMock(return_value=session)
+    stream = BitunixOrderStream(client)
+    stream.KLINE_SILENCE_TIMEOUT_SECONDS = 0.02
+
+    waiter = asyncio.create_task(
+        stream.watch_ohlcv("BTC/USDT:USDT", "1m")
+    )
+
+    with pytest.raises(NetworkError, match="failed: NetworkError"):
+        await asyncio.wait_for(waiter, timeout=1.0)
+    assert session.connect_calls[0][1]["receive_timeout"] == 45.0
+    await stream.close()
+
+
+@pytest.mark.parametrize(
+    "rejection_fields",
+    [{"code": 10001}, {"success": False}],
+)
+@pytest.mark.asyncio
+async def test_order_stream_scopes_rejected_subscription_to_affected_watcher(
+    rejection_fields,
+    caplog,
+):
+    client = _prepared_client()
+    eth_symbol = "ETH/USDT:USDT"
+    eth_market = _market_for("ETHUSDT", eth_symbol)
+    client.markets[eth_symbol] = eth_market
+    client.markets_by_id["ETHUSDT"] = eth_market
+    client.symbols.append(eth_symbol)
+    socket = _PublicKlineSocket()
+    client._get_session = AsyncMock(
+        return_value=_PublicKlineSession(socket)
+    )
+    stream = BitunixOrderStream(client)
+
+    btc_waiter = asyncio.create_task(
+        stream.watch_ohlcv("BTC/USDT:USDT", "1m")
+    )
+    eth_waiter = asyncio.create_task(stream.watch_ohlcv(eth_symbol, "1m"))
+    for _ in range(100):
+        subscribed = {
+            arg["symbol"]
+            for message in socket.sent
+            if message.get("op") == "subscribe"
+            for arg in message["args"]
+        }
+        if subscribed == {"BTCUSDT", "ETHUSDT"}:
+            break
+        await asyncio.sleep(0.01)
+
+    await socket.messages.put(
+        SimpleNamespace(
+            type=aiohttp.WSMsgType.TEXT,
+            data=json.dumps(
+                {
+                    "op": "subscribe",
+                    "args": [
+                        {
+                            "symbol": "BTCUSDT",
+                            "ch": "market_kline_1min",
+                        }
+                    ],
+                    "msg": "must not reach logs",
+                    **rejection_fields,
+                }
+            ),
+        )
+    )
+    await socket.messages.put(
+        SimpleNamespace(
+            type=aiohttp.WSMsgType.TEXT,
+            data=json.dumps(_kline_payload("ETHUSDT")),
+        )
+    )
+
+    with pytest.raises(NetworkError, match="subscription was rejected"):
+        await asyncio.wait_for(btc_waiter, timeout=1.0)
+    assert (await asyncio.wait_for(eth_waiter, timeout=1.0))[0][4] == 102.0
+    assert "symbol=BTC/USDT:USDT action=rest_fallback" in caplog.text
+    assert "must not reach logs" not in caplog.text
+    assert stream._ohlcv_task is not None
+    assert not stream._ohlcv_task.done()
+
+    btc_recovery = asyncio.create_task(
+        stream.watch_ohlcv("BTC/USDT:USDT", "1m")
+    )
+    for _ in range(100):
+        btc_subscriptions = sum(
+            1
+            for message in socket.sent
+            if message.get("op") == "subscribe"
+            for arg in message["args"]
+            if arg["symbol"] == "BTCUSDT"
+        )
+        if btc_subscriptions >= 2:
+            break
+        await asyncio.sleep(0.01)
+    assert btc_subscriptions >= 2
+    await socket.messages.put(
+        SimpleNamespace(
+            type=aiohttp.WSMsgType.TEXT,
+            data=json.dumps(_kline_payload("BTCUSDT")),
+        )
+    )
+    assert (await asyncio.wait_for(btc_recovery, timeout=1.0))[0][4] == 102.0
+    await stream.close()
+
+
+@pytest.mark.asyncio
 async def test_order_stream_can_resubscribe_immediately_after_last_unwatch():
     client = _prepared_client()
     first_socket = _PublicKlineSocket()

--- a/tests/exchanges/test_bitunix.py
+++ b/tests/exchanges/test_bitunix.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import logging
 import time
+from copy import deepcopy
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -58,12 +59,79 @@ def _market():
     }
 
 
+def _market_for(market_id: str, symbol: str):
+    market = deepcopy(_market())
+    market["id"] = market_id
+    market["symbol"] = symbol
+    return market
+
+
 def _prepared_client() -> BitunixClient:
     client = BitunixClient({"apiKey": "key", "secret": "secret"})
     client.markets = {"BTC/USDT:USDT": _market()}
     client.markets_by_id = {"BTCUSDT": client.markets["BTC/USDT:USDT"]}
     client.symbols = ["BTC/USDT:USDT"]
     return client
+
+
+def _kline_payload(
+    market_id: str = "BTCUSDT",
+    *,
+    timestamp: int = 1_700_000_065_123,
+    **data_overrides,
+):
+    data = {
+        "o": "100",
+        "h": "103",
+        "l": "99",
+        "c": "102",
+        "b": "4.5",
+        "q": "454.5",
+    }
+    data.update(data_overrides)
+    return {
+        "ch": "market_kline_1min",
+        "symbol": market_id,
+        "ts": timestamp,
+        "data": data,
+    }
+
+
+class _PublicKlineSocket:
+    def __init__(self):
+        self.closed = False
+        self.sent = []
+        self.messages = asyncio.Queue()
+
+    async def send_json(self, payload):
+        self.sent.append(payload)
+
+    async def receive(self):
+        return await self.messages.get()
+
+    async def close(self):
+        self.closed = True
+
+
+class _PublicKlineSocketContext:
+    def __init__(self, socket):
+        self.socket = socket
+
+    async def __aenter__(self):
+        return self.socket
+
+    async def __aexit__(self, *_args):
+        await self.socket.close()
+
+
+class _PublicKlineSession:
+    def __init__(self, socket):
+        self.socket = socket
+        self.connect_calls = []
+
+    def ws_connect(self, url, **kwargs):
+        self.connect_calls.append((url, kwargs))
+        return _PublicKlineSocketContext(self.socket)
 
 
 def _order_row(**overrides):
@@ -196,8 +264,10 @@ def test_private_websocket_signature_uses_seconds(monkeypatch):
     ],
 )
 def test_api_errors_map_to_ccxt_exception_contract(code, error_type):
-    with pytest.raises(error_type):
+    with pytest.raises(error_type) as exc_info:
         BitunixClient._raise_api_error(code, "test")
+
+    assert exc_info.value.code == str(code)
 
 
 def test_observed_code_one_network_envelope_is_retryable():
@@ -243,7 +313,7 @@ async def test_load_markets_retries_observed_network_error(monkeypatch):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("as_list", [False, True])
-async def test_balance_reconstructs_wallet_and_accepts_both_account_shapes(as_list):
+async def test_balance_sums_disjoint_components_and_accepts_both_account_shapes(as_list):
     client = _prepared_client()
     raw = {
         "marginCoin": "USDT",
@@ -260,8 +330,28 @@ async def test_balance_reconstructs_wallet_and_accepts_both_account_shapes(as_li
 
     assert balance["free"]["USDT"] == 1000.0
     assert balance["used"]["USDT"] == 14.0
-    assert balance["total"]["USDT"] == 1013.0
+    assert balance["total"]["USDT"] == 1014.0
     assert client._request.await_args.kwargs["params"] == {"marginCoin": "USDT"}
+
+
+@pytest.mark.asyncio
+async def test_balance_wallet_is_invariant_to_unrealized_pnl():
+    client = _prepared_client()
+    responses = []
+    for upnl in ("-25", "0", "25"):
+        raw = {
+            "marginCoin": "USDT",
+            "available": "90",
+            "frozen": "4",
+            "margin": "6",
+            "positionMode": "HEDGE",
+            "crossUnrealizedPNL": upnl,
+            "isolationUnrealizedPNL": "0",
+        }
+        client._request = AsyncMock(return_value=raw)
+        responses.append(await client.fetch_balance())
+
+    assert [response["total"]["USDT"] for response in responses] == [100.0] * 3
 
 
 def test_hedge_order_normalization_preserves_position_and_action_side():
@@ -301,6 +391,43 @@ def test_hedge_order_normalization_preserves_position_and_action_side():
 def test_order_status_accepts_live_trailing_enum_padding():
     client = _prepared_client()
     assert client._normalize_order(_order_row(status="NEW_"))["status"] == "open"
+
+
+def test_pending_endpoint_conservatively_retains_safe_unknown_status(caplog):
+    client = _prepared_client()
+
+    with caplog.at_level(logging.WARNING):
+        order = client._normalize_order(
+            _order_row(status="CANCELING"), pending_snapshot=True
+        )
+
+    assert order["status"] == "open"
+    assert "status=CANCELING" in caplog.text
+    assert "retain_as_open_until_authoritative_absence" in caplog.text
+    with pytest.raises(ValueError, match="Unknown Bitunix order status"):
+        client._normalize_order(_order_row(status="CANCELING"))
+
+
+@pytest.mark.parametrize("status", [None, "", "bad status", "A" * 33])
+def test_pending_endpoint_rejects_missing_or_malformed_status(status):
+    client = _prepared_client()
+
+    with pytest.raises(ValueError, match="Unknown Bitunix order status"):
+        client._normalize_order(_order_row(status=status), pending_snapshot=True)
+
+
+def test_pending_unknown_status_warning_is_throttled(monkeypatch, caplog):
+    client = _prepared_client()
+    monotonic = iter((100.0, 101.0, 401.0))
+    monkeypatch.setattr("exchanges.bitunix.time.monotonic", lambda: next(monotonic))
+
+    with caplog.at_level(logging.WARNING):
+        for _ in range(3):
+            client._normalize_order(
+                _order_row(status="CANCELING"), pending_snapshot=True
+            )
+
+    assert caplog.text.count("status=CANCELING") == 2
 
 
 @pytest.mark.parametrize("price", [None, "", "0", "-1", "nan"])
@@ -760,6 +887,169 @@ async def test_ohlcv_accepts_explicit_zero_base_volume():
     )
 
     assert candles[0][5] == 0.0
+
+
+def test_order_stream_advertises_native_ohlcv_and_normalizes_push_timestamp():
+    client = _prepared_client()
+    stream = BitunixOrderStream(client)
+
+    symbol, rows = stream._normalize_ohlcv_payload(_kline_payload())
+
+    assert stream.has["watchOHLCV"] is True
+    assert symbol == "BTC/USDT:USDT"
+    assert rows == [[1_700_000_040_000, 100.0, 103.0, 99.0, 102.0, 4.5]]
+
+
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    [
+        ({"b": None}, "base volume"),
+        ({"b": "-1"}, "invalid price or volume"),
+        ({"h": "101"}, "inconsistent OHLC"),
+        ({"l": "103"}, "inconsistent OHLC"),
+    ],
+)
+def test_order_stream_rejects_malformed_kline_payload(overrides, match):
+    client = _prepared_client()
+    stream = BitunixOrderStream(client)
+
+    with pytest.raises(ValueError, match=match):
+        stream._normalize_ohlcv_payload(_kline_payload(**overrides))
+
+
+@pytest.mark.asyncio
+async def test_order_stream_multiplexes_public_klines_and_uses_json_ping(
+    monkeypatch,
+):
+    client = _prepared_client()
+    eth_symbol = "ETH/USDT:USDT"
+    eth_market = _market_for("ETHUSDT", eth_symbol)
+    client.markets[eth_symbol] = eth_market
+    client.markets_by_id["ETHUSDT"] = eth_market
+    client.symbols.append(eth_symbol)
+    socket = _PublicKlineSocket()
+    session = _PublicKlineSession(socket)
+    client._get_session = AsyncMock(return_value=session)
+    stream = BitunixOrderStream(client)
+    stream.PING_INTERVAL_SECONDS = 0.0
+    monkeypatch.setattr("exchanges.bitunix.time.time", lambda: 1_700_000_000.9)
+
+    btc_waiter = asyncio.create_task(stream.watch_ohlcv("BTC/USDT:USDT", "1m"))
+    eth_waiter = asyncio.create_task(stream.watch_ohlcv(eth_symbol, "1m"))
+    for _ in range(100):
+        subscribed = {
+            arg["symbol"]
+            for message in socket.sent
+            if message.get("op") == "subscribe"
+            for arg in message["args"]
+        }
+        if subscribed == {"BTCUSDT", "ETHUSDT"}:
+            break
+        await asyncio.sleep(0.01)
+    assert subscribed == {"BTCUSDT", "ETHUSDT"}
+    assert len(session.connect_calls) == 1
+    assert {"op": "ping", "ping": 1_700_000_000} in socket.sent
+
+    await socket.messages.put(
+        SimpleNamespace(
+            type=aiohttp.WSMsgType.TEXT,
+            data=json.dumps(
+                {"op": "ping", "pong": 1_700_000_000, "ping": 1_700_000_001}
+            ),
+        )
+    )
+    await socket.messages.put(
+        SimpleNamespace(
+            type=aiohttp.WSMsgType.TEXT,
+            data=json.dumps(_kline_payload("BTCUSDT")),
+        )
+    )
+    await socket.messages.put(
+        SimpleNamespace(
+            type=aiohttp.WSMsgType.TEXT,
+            data=json.dumps(_kline_payload("ETHUSDT", c="101")),
+        )
+    )
+
+    btc_rows, eth_rows = await asyncio.gather(btc_waiter, eth_waiter)
+    assert btc_rows[0][4] == 102.0
+    assert eth_rows[0][4] == 101.0
+
+    await stream.un_watch_ohlcv("BTC/USDT:USDT", "1m")
+    await stream.un_watch_ohlcv(eth_symbol, "1m")
+    assert socket.closed is True
+    await stream.close()
+
+
+@pytest.mark.asyncio
+async def test_order_stream_public_failure_wakes_all_watchers_for_rest_fallback():
+    client = _prepared_client()
+    eth_symbol = "ETH/USDT:USDT"
+    eth_market = _market_for("ETHUSDT", eth_symbol)
+    client.markets[eth_symbol] = eth_market
+    client.markets_by_id["ETHUSDT"] = eth_market
+    client.symbols.append(eth_symbol)
+    socket = _PublicKlineSocket()
+    client._get_session = AsyncMock(
+        return_value=_PublicKlineSession(socket)
+    )
+    stream = BitunixOrderStream(client)
+
+    waiters = [
+        asyncio.create_task(stream.watch_ohlcv(symbol, "1m"))
+        for symbol in ("BTC/USDT:USDT", eth_symbol)
+    ]
+    for _ in range(100):
+        if stream._ohlcv_ws is socket:
+            break
+        await asyncio.sleep(0.01)
+    await socket.messages.put(
+        SimpleNamespace(type=aiohttp.WSMsgType.ERROR, data="closed")
+    )
+
+    results = await asyncio.gather(*waiters, return_exceptions=True)
+    assert all(isinstance(result, NetworkError) for result in results)
+    assert all("NetworkError" in str(result) for result in results)
+    await stream.close()
+
+
+@pytest.mark.asyncio
+async def test_order_stream_can_resubscribe_immediately_after_last_unwatch():
+    client = _prepared_client()
+    first_socket = _PublicKlineSocket()
+    second_socket = _PublicKlineSocket()
+    sessions = iter(
+        (_PublicKlineSession(first_socket), _PublicKlineSession(second_socket))
+    )
+    client._get_session = AsyncMock(side_effect=lambda: next(sessions))
+    stream = BitunixOrderStream(client)
+
+    first_waiter = asyncio.create_task(
+        stream.watch_ohlcv("BTC/USDT:USDT", "1m")
+    )
+    for _ in range(100):
+        if stream._ohlcv_ws is first_socket:
+            break
+        await asyncio.sleep(0.01)
+    await stream.un_watch_ohlcv("BTC/USDT:USDT", "1m")
+    with pytest.raises(NetworkError, match="subscription was removed"):
+        await first_waiter
+
+    second_waiter = asyncio.create_task(
+        stream.watch_ohlcv("BTC/USDT:USDT", "1m")
+    )
+    for _ in range(100):
+        if stream._ohlcv_ws is second_socket:
+            break
+        await asyncio.sleep(0.01)
+    await second_socket.messages.put(
+        SimpleNamespace(
+            type=aiohttp.WSMsgType.TEXT,
+            data=json.dumps(_kline_payload()),
+        )
+    )
+    assert (await second_waiter)[0][4] == 102.0
+    await stream.close()
 
 
 @pytest.mark.asyncio

--- a/tests/exchanges/test_bitunix.py
+++ b/tests/exchanges/test_bitunix.py
@@ -997,10 +997,10 @@ async def test_order_stream_routes_persistent_malformed_klines_to_one_watcher():
         return_value=_PublicKlineSession(socket)
     )
     stream = BitunixOrderStream(client)
-
-    waiter = asyncio.create_task(
-        stream.watch_ohlcv("BTC/USDT:USDT", "1m")
-    )
+    symbol = "BTC/USDT:USDT"
+    queue = asyncio.Queue(maxsize=stream.KLINE_QUEUE_SIZE)
+    stream._ohlcv_queues[symbol] = queue
+    stream._ensure_ohlcv_task()
     for _ in range(100):
         if stream._ohlcv_ws is socket:
             break
@@ -1012,9 +1012,23 @@ async def test_order_stream_routes_persistent_malformed_klines_to_one_watcher():
                 data=json.dumps(_kline_payload("BTCUSDT", l="101")),
             )
         )
+    for _ in range(stream.KLINE_QUEUE_SIZE + 2):
+        await socket.messages.put(
+            SimpleNamespace(
+                type=aiohttp.WSMsgType.TEXT,
+                data=json.dumps(_kline_payload("BTCUSDT")),
+            )
+        )
+    for _ in range(100):
+        if socket.messages.empty():
+            break
+        await asyncio.sleep(0.01)
 
+    assert queue.qsize() == 1
+    assert symbol in stream._ohlcv_fallback_pending
     with pytest.raises(NetworkError, match="consecutive malformed updates"):
-        await waiter
+        await stream.watch_ohlcv(symbol, "1m")
+    assert symbol not in stream._ohlcv_fallback_pending
     assert stream._ohlcv_task is not None
     assert not stream._ohlcv_task.done()
     await stream.close()

--- a/tests/exchanges/test_bitunix.py
+++ b/tests/exchanges/test_bitunix.py
@@ -1094,6 +1094,39 @@ async def test_order_stream_public_failure_wakes_all_watchers_for_rest_fallback(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("setup_surface", ["session", "socket"])
+async def test_order_stream_setup_failure_wakes_shard_watchers(setup_surface):
+    client = _prepared_client()
+    eth_symbol = "ETH/USDT:USDT"
+    eth_market = _market_for("ETHUSDT", eth_symbol)
+    client.markets[eth_symbol] = eth_market
+    client.markets_by_id["ETHUSDT"] = eth_market
+    client.symbols.append(eth_symbol)
+    if setup_surface == "session":
+        client._get_session = AsyncMock(
+            side_effect=NetworkError("session unavailable")
+        )
+    else:
+        session = MagicMock()
+        session.ws_connect.side_effect = NetworkError("socket unavailable")
+        client._get_session = AsyncMock(return_value=session)
+    stream = BitunixOrderStream(client)
+
+    results = await asyncio.gather(
+        stream.watch_ohlcv("BTC/USDT:USDT", "1m"),
+        stream.watch_ohlcv(eth_symbol, "1m"),
+        return_exceptions=True,
+    )
+
+    assert all(isinstance(result, NetworkError) for result in results)
+    assert all(
+        f"failed: {type(result).__name__}" in str(result)
+        for result in results
+    )
+    await stream.close()
+
+
+@pytest.mark.asyncio
 async def test_order_stream_transport_failure_preserves_every_fallback_signal():
     client = _prepared_client()
     eth_symbol = "ETH/USDT:USDT"

--- a/tests/exchanges/test_bitunix.py
+++ b/tests/exchanges/test_bitunix.py
@@ -1157,7 +1157,9 @@ async def test_order_stream_scopes_rejected_subscription_to_affected_watcher(
     btc_recovery = asyncio.create_task(
         stream.watch_ohlcv("BTC/USDT:USDT", "1m")
     )
-    for _ in range(100):
+    # Subscription reconciliation polls at one-second intervals. Allow one
+    # complete poll plus scheduler slack before declaring recovery absent.
+    for _ in range(200):
         btc_subscriptions = sum(
             1
             for message in socket.sent

--- a/tests/exchanges/test_bitunix.py
+++ b/tests/exchanges/test_bitunix.py
@@ -134,6 +134,16 @@ class _PublicKlineSession:
         return _PublicKlineSocketContext(self.socket)
 
 
+class _PublicKlineSessionPool:
+    def __init__(self, sockets):
+        self.sockets = iter(sockets)
+        self.connect_calls = []
+
+    def ws_connect(self, url, **kwargs):
+        self.connect_calls.append((url, kwargs))
+        return _PublicKlineSocketContext(next(self.sockets))
+
+
 def _order_row(**overrides):
     row = {
         "orderId": "order-1",
@@ -1082,6 +1092,139 @@ async def test_order_stream_silence_timeout_wakes_waiter_for_rest_fallback():
     with pytest.raises(NetworkError, match="failed: NetworkError"):
         await asyncio.wait_for(waiter, timeout=1.0)
     assert session.connect_calls[0][1]["receive_timeout"] == 45.0
+    await stream.close()
+
+
+@pytest.mark.asyncio
+async def test_order_stream_tracks_kline_silence_per_subscription():
+    client = _prepared_client()
+    eth_symbol = "ETH/USDT:USDT"
+    eth_market = _market_for("ETHUSDT", eth_symbol)
+    client.markets[eth_symbol] = eth_market
+    client.markets_by_id["ETHUSDT"] = eth_market
+    client.symbols.append(eth_symbol)
+    socket = _PublicKlineSocket()
+    client._get_session = AsyncMock(
+        return_value=_PublicKlineSession(socket)
+    )
+    stream = BitunixOrderStream(client)
+    stream.KLINE_SILENCE_TIMEOUT_SECONDS = 0.05
+
+    btc_waiter = asyncio.create_task(
+        stream.watch_ohlcv("BTC/USDT:USDT", "1m")
+    )
+    eth_waiter = asyncio.create_task(stream.watch_ohlcv(eth_symbol, "1m"))
+    for _ in range(100):
+        subscribed = {
+            arg["symbol"]
+            for message in socket.sent
+            if message.get("op") == "subscribe"
+            for arg in message["args"]
+        }
+        if subscribed == {"BTCUSDT", "ETHUSDT"}:
+            break
+        await asyncio.sleep(0.01)
+    assert subscribed == {"BTCUSDT", "ETHUSDT"}
+
+    eth_rows = None
+    for _ in range(8):
+        await socket.messages.put(
+            SimpleNamespace(
+                type=aiohttp.WSMsgType.TEXT,
+                data=json.dumps({"op": "pong"}),
+            )
+        )
+        await socket.messages.put(
+            SimpleNamespace(
+                type=aiohttp.WSMsgType.TEXT,
+                data=json.dumps(_kline_payload("ETHUSDT")),
+            )
+        )
+        if eth_rows is None and eth_waiter.done():
+            eth_rows = eth_waiter.result()
+        await asyncio.sleep(0.01)
+
+    with pytest.raises(NetworkError, match="subscription became silent"):
+        await asyncio.wait_for(btc_waiter, timeout=1.0)
+    if eth_rows is None:
+        eth_rows = await asyncio.wait_for(eth_waiter, timeout=1.0)
+    assert eth_rows[0][4] == 102.0
+    assert eth_symbol not in stream._ohlcv_fallback_pending
+    assert stream._ohlcv_task is not None
+    assert not stream._ohlcv_task.done()
+    await stream.close()
+
+
+@pytest.mark.asyncio
+async def test_order_stream_shards_kline_subscriptions_at_connection_limit():
+    client = _prepared_client()
+    symbols_by_id = {
+        "ETHUSDT": "ETH/USDT:USDT",
+        "SOLUSDT": "SOL/USDT:USDT",
+    }
+    for market_id, symbol in symbols_by_id.items():
+        market = _market_for(market_id, symbol)
+        client.markets[symbol] = market
+        client.markets_by_id[market_id] = market
+        client.symbols.append(symbol)
+    sockets = [_PublicKlineSocket(), _PublicKlineSocket()]
+    session = _PublicKlineSessionPool(sockets)
+    client._get_session = AsyncMock(return_value=session)
+    stream = BitunixOrderStream(client)
+    stream.MAX_KLINE_SUBSCRIPTIONS = 2
+
+    market_symbols = {
+        "BTCUSDT": "BTC/USDT:USDT",
+        **symbols_by_id,
+    }
+    waiters = {
+        market_id: asyncio.create_task(stream.watch_ohlcv(symbol, "1m"))
+        for market_id, symbol in market_symbols.items()
+    }
+    for _ in range(100):
+        subscribed = {
+            arg["symbol"]
+            for socket in sockets
+            for message in socket.sent
+            if message.get("op") == "subscribe"
+            for arg in message["args"]
+        }
+        if subscribed == set(market_symbols):
+            break
+        await asyncio.sleep(0.01)
+
+    assert subscribed == set(market_symbols)
+    assert len(session.connect_calls) == 2
+    assert len(stream._ohlcv_tasks) == 2
+    subscription_counts = {market_id: 0 for market_id in market_symbols}
+    for socket in sockets:
+        socket_subscriptions = {
+            arg["symbol"]
+            for message in socket.sent
+            if message.get("op") == "subscribe"
+            for arg in message["args"]
+        }
+        assert len(socket_subscriptions) <= stream.MAX_KLINE_SUBSCRIPTIONS
+        for market_id in socket_subscriptions:
+            subscription_counts[market_id] += 1
+            await socket.messages.put(
+                SimpleNamespace(
+                    type=aiohttp.WSMsgType.TEXT,
+                    data=json.dumps(_kline_payload(market_id)),
+                )
+            )
+
+    results = await asyncio.gather(*waiters.values())
+    assert all(rows[0][4] == 102.0 for rows in results)
+    assert set(subscription_counts.values()) == {1}
+
+    await stream.un_watch_ohlcv("SOL/USDT:USDT", "1m")
+    assert len(stream._ohlcv_tasks) == 1
+    assert sum(socket.closed for socket in sockets) == 1
+    await stream.un_watch_ohlcv("BTC/USDT:USDT", "1m")
+    await stream.un_watch_ohlcv("ETH/USDT:USDT", "1m")
+    assert not stream._ohlcv_tasks
+    assert all(socket.closed for socket in sockets)
     await stream.close()
 
 

--- a/tests/exchanges/test_bitunix.py
+++ b/tests/exchanges/test_bitunix.py
@@ -418,12 +418,29 @@ def test_pending_endpoint_conservatively_retains_safe_unknown_status(caplog):
         client._normalize_order(_order_row(status="CANCELING"))
 
 
-@pytest.mark.parametrize("status", [None, "", "bad status", "A" * 33])
+@pytest.mark.parametrize(
+    "status",
+    [
+        None,
+        "",
+        "bad status",
+        "A" * 33,
+        "CANCELING" + "_" * 24,
+        "NEW" + "_" * 30,
+    ],
+)
 def test_pending_endpoint_rejects_missing_or_malformed_status(status):
     client = _prepared_client()
 
     with pytest.raises(ValueError, match="Unknown Bitunix order status"):
         client._normalize_order(_order_row(status=status), pending_snapshot=True)
+
+
+def test_detail_endpoint_rejects_oversized_padded_known_status():
+    client = _prepared_client()
+
+    with pytest.raises(ValueError, match="Unknown Bitunix order status"):
+        client._normalize_order(_order_row(status="NEW" + "_" * 30))
 
 
 def test_pending_unknown_status_warning_is_throttled(monkeypatch, caplog):
@@ -1073,6 +1090,46 @@ async def test_order_stream_public_failure_wakes_all_watchers_for_rest_fallback(
     results = await asyncio.gather(*waiters, return_exceptions=True)
     assert all(isinstance(result, NetworkError) for result in results)
     assert all("NetworkError" in str(result) for result in results)
+    await stream.close()
+
+
+@pytest.mark.asyncio
+async def test_order_stream_transport_failure_preserves_every_fallback_signal():
+    client = _prepared_client()
+    eth_symbol = "ETH/USDT:USDT"
+    eth_market = _market_for("ETHUSDT", eth_symbol)
+    client.markets[eth_symbol] = eth_market
+    client.markets_by_id["ETHUSDT"] = eth_market
+    client.symbols.append(eth_symbol)
+    socket = _PublicKlineSocket()
+    client._get_session = AsyncMock(
+        return_value=_PublicKlineSession(socket)
+    )
+    stream = BitunixOrderStream(client)
+    symbols = {"BTC/USDT:USDT", eth_symbol}
+    for symbol in symbols:
+        stream._ohlcv_queues[symbol] = asyncio.Queue(
+            maxsize=stream.KLINE_QUEUE_SIZE
+        )
+    stream._ensure_ohlcv_task()
+    for _ in range(100):
+        if stream._ohlcv_ws is socket:
+            break
+        await asyncio.sleep(0.01)
+
+    await socket.messages.put(
+        SimpleNamespace(type=aiohttp.WSMsgType.ERROR, data="closed")
+    )
+    for _ in range(100):
+        if stream._ohlcv_task is None:
+            break
+        await asyncio.sleep(0.01)
+
+    assert stream._ohlcv_fallback_pending == symbols
+    for symbol in symbols:
+        queue = stream._ohlcv_queues[symbol]
+        assert queue.qsize() == 1
+        assert isinstance(queue.get_nowait(), NetworkError)
     await stream.close()
 
 

--- a/tests/exchanges/test_bitunix.py
+++ b/tests/exchanges/test_bitunix.py
@@ -920,6 +920,7 @@ def test_order_stream_rejects_malformed_kline_payload(overrides, match):
 @pytest.mark.asyncio
 async def test_order_stream_multiplexes_public_klines_and_uses_json_ping(
     monkeypatch,
+    caplog,
 ):
     client = _prepared_client()
     eth_symbol = "ETH/USDT:USDT"
@@ -961,6 +962,12 @@ async def test_order_stream_multiplexes_public_klines_and_uses_json_ping(
     await socket.messages.put(
         SimpleNamespace(
             type=aiohttp.WSMsgType.TEXT,
+            data=json.dumps(_kline_payload("BTCUSDT", l="101")),
+        )
+    )
+    await socket.messages.put(
+        SimpleNamespace(
+            type=aiohttp.WSMsgType.TEXT,
             data=json.dumps(_kline_payload("BTCUSDT")),
         )
     )
@@ -974,10 +981,42 @@ async def test_order_stream_multiplexes_public_klines_and_uses_json_ping(
     btc_rows, eth_rows = await asyncio.gather(btc_waiter, eth_waiter)
     assert btc_rows[0][4] == 102.0
     assert eth_rows[0][4] == 101.0
+    assert "malformed kline update dropped" in caplog.text
 
     await stream.un_watch_ohlcv("BTC/USDT:USDT", "1m")
     await stream.un_watch_ohlcv(eth_symbol, "1m")
     assert socket.closed is True
+    await stream.close()
+
+
+@pytest.mark.asyncio
+async def test_order_stream_routes_persistent_malformed_klines_to_one_watcher():
+    client = _prepared_client()
+    socket = _PublicKlineSocket()
+    client._get_session = AsyncMock(
+        return_value=_PublicKlineSession(socket)
+    )
+    stream = BitunixOrderStream(client)
+
+    waiter = asyncio.create_task(
+        stream.watch_ohlcv("BTC/USDT:USDT", "1m")
+    )
+    for _ in range(100):
+        if stream._ohlcv_ws is socket:
+            break
+        await asyncio.sleep(0.01)
+    for _ in range(stream.MAX_CONSECUTIVE_MALFORMED_KLINES):
+        await socket.messages.put(
+            SimpleNamespace(
+                type=aiohttp.WSMsgType.TEXT,
+                data=json.dumps(_kline_payload("BTCUSDT", l="101")),
+            )
+        )
+
+    with pytest.raises(NetworkError, match="consecutive malformed updates"):
+        await waiter
+    assert stream._ohlcv_task is not None
+    assert not stream._ohlcv_task.done()
     await stream.close()
 
 

--- a/tests/test_balance_composition.py
+++ b/tests/test_balance_composition.py
@@ -10,6 +10,7 @@ from live.balance_composition import (
     balance_composition_signature,
     format_balance_composition_sample,
     malformed_balance_composition,
+    normalize_bitunix_balance_composition,
     normalize_ccxt_balance_composition,
     normalize_gateio_balance_composition,
     normalize_hyperliquid_unified_balance_composition,
@@ -33,6 +34,50 @@ def _okx_payload(details):
 
 def _hyperliquid_unified_payload(balances):
     return {"info": {"balances": balances}}
+
+
+def test_bitunix_balance_composition_keeps_wallet_and_upnl_separate():
+    snapshot = normalize_bitunix_balance_composition(
+        {
+            "info": {
+                "marginCoin": "USDT",
+                "available": "90",
+                "frozen": "4",
+                "margin": "6",
+                "crossUnrealizedPNL": "-3",
+                "isolationUnrealizedPNL": "1",
+            }
+        }
+    )
+
+    assert snapshot["status"] == "available"
+    assert snapshot["asset_balances"] == [
+        {
+            "asset": "USDT",
+            "amount": 100.0,
+            "free_amount": 90.0,
+            "used_amount": 10.0,
+            "unrealized_pnl": -2.0,
+            "field_provenance": {
+                "asset": "marginCoin",
+                "amount": "account_components",
+                "free_amount": "available",
+                "used_amount": "frozen_margin",
+                "unrealized_pnl": "account_unrealized_pnl",
+            },
+        }
+    ]
+    assert public_balance_composition(snapshot)["asset_balances"] == snapshot[
+        "asset_balances"
+    ]
+
+
+def test_bitunix_balance_composition_rejects_missing_account_fields():
+    assert normalize_bitunix_balance_composition(
+        {"info": {"marginCoin": "USDT", "available": "1"}}
+    ) == malformed_balance_composition(
+        source="bitunix.info.account", reason="missing_account_fields"
+    )
 
 
 def test_okx_balance_composition_keeps_only_proven_detail_fields():

--- a/tests/test_forager_ws_candles.py
+++ b/tests/test_forager_ws_candles.py
@@ -1011,6 +1011,55 @@ async def test_unsubscribe_wakeup_exception_is_consumed_before_watcher_retiremen
 
 
 @pytest.mark.asyncio
+async def test_retiring_watcher_does_not_resubscribe_after_inflight_ingestion():
+    ingest_started = asyncio.Event()
+    release_ingest = asyncio.Event()
+    unsubscribe_called = asyncio.Event()
+
+    class _CountingCCP:
+        def __init__(self):
+            self.watch_calls = 0
+
+        async def watch_ohlcv(self, _symbol, _timeframe):
+            self.watch_calls += 1
+            if self.watch_calls > 1:
+                raise AssertionError("retired watcher recreated its subscription")
+            return [[ONE_MIN_MS, 1.0, 1.0, 1.0, 1.0, 1.0]]
+
+        async def un_watch_ohlcv(self, _symbol, _timeframe):
+            unsubscribe_called.set()
+
+    class _BlockingManager:
+        async def ingest_live_ws_ohlcv(self, _symbol, _rows):
+            ingest_started.set()
+            await release_ingest.wait()
+
+    ccp = _CountingCCP()
+    symbol = "BTC/USDT:USDT"
+    bot = SimpleNamespace(
+        ccp=ccp,
+        cm=_BlockingManager(),
+        stop_signal_received=False,
+    )
+    watcher = asyncio.create_task(
+        candle_ws.watch_forager_ws_symbol(bot, symbol)
+    )
+    await asyncio.wait_for(ingest_started.wait(), timeout=1.0)
+    retirement = asyncio.create_task(
+        candle_ws._retire_watcher(bot, symbol, watcher)
+    )
+    await asyncio.wait_for(unsubscribe_called.wait(), timeout=1.0)
+
+    release_ingest.set()
+    await asyncio.wait_for(retirement, timeout=1.0)
+
+    assert watcher.done()
+    assert watcher.cancelled() is False
+    assert ccp.watch_calls == 1
+    assert not candle_ws._watcher_is_retiring(bot, symbol, watcher)
+
+
+@pytest.mark.asyncio
 async def test_bulk_watcher_retirement_uses_one_supported_unsubscribe():
     class _BulkWakeupCCP:
         def __init__(self):


### PR DESCRIPTION
## Summary

- keep Bitunix realized wallet balance stable across unrealized PnL and expose documented account components through bounded diagnostics
- retain bounded code-like unknown statuses from authoritative pending-order snapshots until complete-snapshot absence, while keeping strict order-detail validation and structured venue error codes
- add native sharded 1m Kline WebSocket ingestion with at most 300 subscriptions per connection, per-symbol liveness, validated subscription acknowledgements, and REST-owned recovery
- isolate transient malformed Kline updates per symbol without clamping exchange values; persistent malformed data and transport failures retain non-evictable watcher fallback signals
- document the resulting live connector contracts and supported candle scope

## Validation

- clean full Python test suite with a source-matched rebuilt Rust extension
- focused Bitunix, balance-composition, and forager WebSocket candle suites
- offline regressions for per-symbol silence, subscription rejection, transport failure, malformed updates, and bounded multi-socket sharding
- unauthenticated public Bitunix multi-symbol multiplexing probes
- unauthenticated public HYPE Kline minute-rollover probe, including an observed transient malformed update