### PR TITLE
GPU: support multi-coin TM candle intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,13 @@ All notable user-facing changes will be documented in this file.
   `backtest.candle_interval_minutes` for long-only, short-only, and fused long+short runs. Global
   and static per-coin minute spans, Forager spans, HSL decay, and cooldowns are converted to
   per-candle equivalents, while hourly windows and elapsed-day accounting retain exact Rust time
-  semantics. Multi-coin Trailing Martingale remains one-minute-only pending its dedicated parity
-  slice.
+  semantics.
+
+- Apple MPS multi-coin Trailing Martingale optimization now supports any positive integer
+  `backtest.candle_interval_minutes` for long-only, short-only, and fused long+short runs. Global
+  and static per-coin minute spans, Forager spans, HSL decay, and cooldowns are converted to
+  per-candle equivalents, while hourly windows and elapsed-day accounting retain exact Rust time
+  semantics.
 
 - Apple MPS single-coin optimization now matches exact Rust hourly volatility windows when an
   aggregated candle interval does not evenly divide an hour, retaining the boundary-crossing

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -100,9 +100,9 @@ and the DEAP/pymoo CPU optimizers do not import or require PyTorch.
 The supported slice is intentionally narrow:
 
 - Apple Silicon with `torch.backends.mps.is_available()`
-- one prepared dataset per independent run or suite scenario; single-coin runs and multi-coin EMA
-  Anchor runs accept any positive integer `backtest.candle_interval_minutes`, while multi-coin
-  Trailing Martingale runs remain restricted to one-minute candles; the dataset may be an
+- one prepared dataset per independent run or suite scenario; single- and multi-coin EMA Anchor
+  and Trailing Martingale runs accept any positive integer
+  `backtest.candle_interval_minutes`; the dataset may be an
   individual exchange or the canonical combined multi-exchange dataset
 - `strategy_kind: ema_anchor` or `trailing_martingale`, with long-only, short-only, or
   long+short enabled for one coin
@@ -797,13 +797,12 @@ Trade-offs:
 
 - Intra-interval fill ordering is lost (fills occur only at the aggregated bar boundaries).
 - Metrics are still time-correct because analysis uses timestamps rather than bar indices.
-- The Apple MPS backend supports aggregated intervals for single-coin EMA Anchor and Trailing
-  Martingale runs, plus multi-coin EMA Anchor runs in long-only, short-only, and fused long+short
-  form. It converts minute-denominated strategy and Forager EMA spans, static per-coin overrides,
+- The Apple MPS backend supports aggregated intervals for single- and multi-coin EMA Anchor and
+  Trailing Martingale runs in long-only, short-only, and fused long+short form. It converts
+  minute-denominated strategy and Forager EMA spans, static per-coin overrides,
   and elapsed-time cooldowns to candle periods, compounds HSL's one-minute EMA decay over each
   candle, and preserves Rust's boundary-crossing behavior when an interval does not evenly divide
-  an hour; exact Rust validation remains authoritative. Multi-coin Trailing Martingale runs
-  currently require one-minute candles.
+  an hour; exact Rust validation remains authoritative.
 
 ### Fine-Tuning Specific Parameters
 

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -988,11 +988,14 @@ mod tests {
             "const TrailingMartingaleMulticoinSideConfig config ="
         ));
         assert!(source.contains(
-            "init_trailing_martingale_multicoin_side_state(\n        side, config, bars, coin_settings, coin_overrides, C"
+            "init_trailing_martingale_multicoin_side_state(\n        side, config, coin_settings, coin_overrides, C"
         ));
         assert!(source.contains(
-            "update_tm_multicoin_side_indicators(\n            side, config, bars, coin_settings, k, C, start_hour_minute"
+            "update_tm_multicoin_side_indicators(\n            side, config, bars, hour_log_ranges, coin_settings, k, C"
         ));
+        assert!(source.contains("multicoin_utc_day_index("));
+        assert!(source.contains("multicoin_active_fill_day("));
+        assert!(!MPS_TRAILING_MARTINGALE_MULTICOIN_BODY.contains("start_hour_minute"));
         assert!(source.contains(
             "bool any_fill = process_tm_multicoin_side_fills(\n            side, config, account, fills"
         ));

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -469,8 +469,6 @@ struct TrailingMartingaleMulticoinSideState {
     float volatility_1h[MAX_COINS];
     float forager_volume[MAX_COINS];
     float forager_volatility[MAX_COINS];
-    float hour_high[MAX_COINS];
-    float hour_low[MAX_COINS];
     float psize[MAX_COINS];
     float pprice[MAX_COINS];
     float last_increase_k[MAX_COINS];
@@ -2109,7 +2107,6 @@ load_trailing_martingale_multicoin_side_config(
 inline void init_trailing_martingale_multicoin_side_state(
     thread TrailingMartingaleMulticoinSideState& side,
     thread const TrailingMartingaleMulticoinSideConfig& config,
-    constant float* bars,
     constant float* coin_settings,
     constant float* coin_overrides,
     int coin_count
@@ -2137,12 +2134,6 @@ inline void init_trailing_martingale_multicoin_side_state(
         side.volatility_1h[c] = 0.0f;
         side.forager_volume[c] = seed_volume;
         side.forager_volatility[c] = 0.0f;
-        side.hour_high[c] = -INFINITY;
-        side.hour_low[c] = INFINITY;
-        if (c < coin_count && int(coin_settings[c * COIN_COLS + 6]) == 0) {
-            side.hour_high[c] = bars[c * 4 + 0];
-            side.hour_low[c] = bars[c * 4 + 1];
-        }
         side.psize[c] = 0.0f;
         side.pprice[c] = 0.0f;
         side.last_increase_k[c] = -1.0e20f;
@@ -2273,12 +2264,11 @@ inline void update_tm_multicoin_side_indicators(
     thread TrailingMartingaleMulticoinSideState& side,
     thread const TrailingMartingaleMulticoinSideConfig& config,
     constant float* bars,
+    constant float* hour_log_ranges,
     constant float* coin_settings,
     int k,
-    int coin_count,
-    int start_hour_minute
+    int coin_count
 ) {
-    const bool hour_boundary = ((start_hour_minute + k) % 60) == 0;
     for (int c = 0; c < coin_count; ++c) {
         const int coin_offset = c * COIN_COLS;
         const int bar_offset = (k * coin_count + c) * 4;
@@ -2291,23 +2281,15 @@ inline void update_tm_multicoin_side_indicators(
         const bool valid = k >= first_valid && k <= last_valid
             && finite_positive(high) && finite_positive(low)
             && finite_positive(close);
-        if (hour_boundary) {
-            if (side.hour_high[c] > 0.0f
-                && isfinite(side.hour_low[c]) && side.hour_low[c] > 0.0f
-                && side.alpha_1h_coin[c] > 0.0f) {
-                float hour_range = log(side.hour_high[c] / side.hour_low[c]);
-                side.volatility_1h[c] = fma(
-                    side.alpha_1h_coin[c],
-                    hour_range - side.volatility_1h[c],
-                    side.volatility_1h[c]
-                );
-            }
-            side.hour_high[c] = -INFINITY;
-            side.hour_low[c] = INFINITY;
+        const float hour_range = hour_log_ranges[k * coin_count + c];
+        if (hour_range >= 0.0f && side.alpha_1h_coin[c] > 0.0f) {
+            side.volatility_1h[c] = fma(
+                side.alpha_1h_coin[c],
+                hour_range - side.volatility_1h[c],
+                side.volatility_1h[c]
+            );
         }
         if (!valid) continue;
-        side.hour_high[c] = fmax(side.hour_high[c], high);
-        side.hour_low[c] = fmin(side.hour_low[c], low);
         float log_range = log(high / low);
         side.ema0[c] = fma(
             side.alpha0_coin[c], close - side.ema0[c], side.ema0[c]
@@ -4509,6 +4491,7 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
     constant int* touch_nearest_ticks,
     constant int* touch_min_qty_bits,
     constant int* touch_min_qty_relation,
+    constant float* hour_log_ranges,
     constant float* coin_settings,
     constant float* long_coin_overrides,
     constant float* short_coin_overrides,
@@ -4532,7 +4515,6 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
     const int requested_start_k = sizes[4];
     const int global_warmup = sizes[5];
     const int start_day_minute = sizes[6];
-    const int start_hour_minute = sizes[7];
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
     const int recovery_stride = sizes[8];
     const int recovery_sample_count = sizes[9];
@@ -4588,11 +4570,11 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
     TrailingMartingaleMulticoinSideState long_side;
     TrailingMartingaleMulticoinSideState short_side;
     init_trailing_martingale_multicoin_side_state(
-        long_side, long_config, bars, coin_settings,
+        long_side, long_config, coin_settings,
         long_coin_overrides, C
     );
     init_trailing_martingale_multicoin_side_state(
-        short_side, short_config, bars, coin_settings,
+        short_side, short_config, coin_settings,
         short_coin_overrides, C
     );
 
@@ -4656,7 +4638,9 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
     float day_start_balance = account.balance;
 
     for (int k = 1; k < stop_k; ++k) {
-        const int day_index = (start_day_minute + k) / 1440;
+        const int day_index = multicoin_utc_day_index(
+            start_day_minute, k, interval_ms
+        );
         if (day_index != current_day) {
             if (day_touched && current_day >= 0 && current_day < D) {
                 int output = (int(b) * D + current_day) * DAILY_COLS;
@@ -4743,12 +4727,12 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
         }
 
         update_tm_multicoin_side_indicators(
-            long_side, long_config, bars, coin_settings,
-            k, C, start_hour_minute
+            long_side, long_config, bars, hour_log_ranges,
+            coin_settings, k, C
         );
         update_tm_multicoin_side_indicators(
-            short_side, short_config, bars, coin_settings,
-            k, C, start_hour_minute
+            short_side, short_config, bars, hour_log_ranges,
+            coin_settings, k, C
         );
         int long_tradable_count = count_tm_multicoin_tradable_coins(
             bars, coin_settings, long_coin_overrides, k, C
@@ -5004,7 +4988,9 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
             if (first_eq_k < 0.0f) first_eq_k = float(k);
             last_eq_k = float(k);
             if (any_fill) {
-                int active_fill_day = int(float(k) - first_eq_k) / 1440;
+                int active_fill_day = multicoin_active_fill_day(
+                    k, int(first_eq_k), interval_ms
+                );
                 if (active_fill_day != last_active_fill_day) {
                     fills_active_days_count += 1.0f;
                     last_active_fill_day = active_fill_day;
@@ -5258,6 +5244,7 @@ kernel void passivbot_trailing_martingale_multicoin_fused(
     constant int* touch_nearest_ticks,
     constant int* touch_min_qty_bits,
     constant int* touch_min_qty_relation,
+    constant float* hour_log_ranges,
     constant float* coin_settings,
     constant float* long_coin_overrides,
     constant float* short_coin_overrides,
@@ -5276,7 +5263,8 @@ kernel void passivbot_trailing_martingale_multicoin_fused(
 ) {
     passivbot_trailing_martingale_multicoin_fused_impl(
         bars, fill_ticks, touch_ticks, touch_nearest_ticks,
-        touch_min_qty_bits, touch_min_qty_relation, coin_settings,
+        touch_min_qty_bits, touch_min_qty_relation,
+        hour_log_ranges, coin_settings,
         long_coin_overrides, short_coin_overrides,
         params, run_settings, sizes, end_steps,
         daily, scalars, gap_hist, coin_fill_counts,
@@ -5294,6 +5282,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     constant int* touch_nearest_ticks,
     constant int* touch_min_qty_bits,
     constant int* touch_min_qty_relation,
+    constant float* hour_log_ranges,
     constant float* coin_settings,
     constant float* coin_overrides,
     constant float* params,
@@ -5317,7 +5306,6 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     const int requested_start_k = sizes[4];
     const int global_warmup = sizes[5];
     const int start_day_minute = sizes[6];
-    const int start_hour_minute = sizes[7];
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
     const int recovery_stride = sizes[8];
     const int recovery_sample_count = sizes[9];
@@ -5341,7 +5329,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     const bool legacy_raw_allowance = config.legacy_raw_allowance;
     TrailingMartingaleMulticoinSideState side;
     init_trailing_martingale_multicoin_side_state(
-        side, config, bars, coin_settings, coin_overrides, C
+        side, config, coin_settings, coin_overrides, C
     );
     thread HslState& hsl = side.hsl;
     const bool coin_hsl_mode = config.coin_hsl_mode;
@@ -5433,7 +5421,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     thread float& day_fill_count = fills.day_fill_count;
 
     for (int k = 1; k < stop_k; ++k) {
-        const int day_index = (start_day_minute + k) / 1440;
+        const int day_index = multicoin_utc_day_index(
+            start_day_minute, k, interval_ms
+        );
         if (day_index != current_day) {
             if (day_touched && current_day >= 0 && current_day < D) {
                 int output = (int(b) * D + current_day) * DAILY_COLS;
@@ -5489,7 +5479,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         }
 
         update_tm_multicoin_side_indicators(
-            side, config, bars, coin_settings, k, C, start_hour_minute
+            side, config, bars, hour_log_ranges, coin_settings, k, C
         );
 
         int tradable_count = count_tm_multicoin_tradable_coins(
@@ -5672,7 +5662,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             if (first_eq_k < 0.0f) first_eq_k = float(k);
             last_eq_k = float(k);
             if (any_fill) {
-                int active_fill_day = int(float(k) - first_eq_k) / 1440;
+                int active_fill_day = multicoin_active_fill_day(
+                    k, int(first_eq_k), interval_ms
+                );
                 if (active_fill_day != last_active_fill_day) {
                     fills_active_days_count += 1.0f;
                     last_active_fill_day = active_fill_day;
@@ -5883,6 +5875,7 @@ kernel void passivbot_trailing_martingale_multicoin(
     constant int* touch_nearest_ticks,
     constant int* touch_min_qty_bits,
     constant int* touch_min_qty_relation,
+    constant float* hour_log_ranges,
     constant float* coin_settings,
     constant float* coin_overrides,
     constant float* params,
@@ -5901,7 +5894,8 @@ kernel void passivbot_trailing_martingale_multicoin(
     const bool short_side = run_settings[3] > 0.5f;
     passivbot_trailing_martingale_multicoin_impl(
         bars, fill_ticks, touch_ticks, touch_nearest_ticks,
-        touch_min_qty_bits, touch_min_qty_relation, coin_settings,
+        touch_min_qty_bits, touch_min_qty_relation,
+        hour_log_ranges, coin_settings,
         coin_overrides, params, run_settings,
         sizes, end_steps, daily, scalars, gap_hist, coin_fill_counts,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
@@ -5918,6 +5912,7 @@ kernel void passivbot_trailing_martingale_multicoin_long(
     constant int* touch_nearest_ticks,
     constant int* touch_min_qty_bits,
     constant int* touch_min_qty_relation,
+    constant float* hour_log_ranges,
     constant float* coin_settings,
     constant float* coin_overrides,
     constant float* params,
@@ -5935,7 +5930,8 @@ kernel void passivbot_trailing_martingale_multicoin_long(
 ) {
     passivbot_trailing_martingale_multicoin_impl(
         bars, fill_ticks, touch_ticks, touch_nearest_ticks,
-        touch_min_qty_bits, touch_min_qty_relation, coin_settings,
+        touch_min_qty_bits, touch_min_qty_relation,
+        hour_log_ranges, coin_settings,
         coin_overrides, params, run_settings,
         sizes, end_steps, daily, scalars, gap_hist, coin_fill_counts,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -16,7 +16,10 @@ from optimization.gpu.model import (
     GAP_BINS,
     ProxyMarket,
     ProxyRun,
+    TRAILING_MARTINGALE_COIN_OVERRIDE_COOLDOWN_COLUMN,
     TRAILING_MARTINGALE_COIN_OVERRIDE_COLS,
+    TRAILING_MARTINGALE_COIN_OVERRIDE_HSL_START_COLUMN,
+    TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS,
     TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS,
     TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS,
     encode_tm_retracement_base_pct,
@@ -190,36 +193,33 @@ def _scale_single_coin_minute_parameters(
     )
 
 
-def _scale_ema_multicoin_coin_overrides(
-    coin_overrides: np.ndarray, interval_minutes: float
+def _scale_multicoin_coin_overrides(
+    coin_overrides: np.ndarray,
+    interval_minutes: float,
+    *,
+    expected_cols: int,
+    label: str,
+    minute_columns: set[int],
+    hsl_start_column: int,
 ) -> np.ndarray:
-    """Convert finite exact-last EMA coin overrides to candle periods."""
+    """Convert finite exact-last minute overrides to candle periods."""
 
     scaled = np.array(coin_overrides, dtype=np.float64, copy=True)
-    if scaled.ndim != 2 or scaled.shape[1] != EMA_ANCHOR_COIN_OVERRIDE_COLS:
+    if scaled.ndim != 2 or scaled.shape[1] != expected_cols:
         raise ValueError(
-            "expected multicoin EMA override matrix with "
-            f"{EMA_ANCHOR_COIN_OVERRIDE_COLS} columns, got {scaled.shape}"
+            f"expected multicoin {label} override matrix with "
+            f"{expected_cols} columns, got {scaled.shape}"
         )
     interval_minutes = float(interval_minutes)
     if not np.isfinite(interval_minutes) or interval_minutes < 1.0:
         raise ValueError(
             "MPS candle interval must be finite and at least one minute"
         )
-    minute_columns = {
-        EMA_ANCHOR_COIN_OVERRIDE_STRATEGY_KEYS.index("ema_span_0"),
-        EMA_ANCHOR_COIN_OVERRIDE_STRATEGY_KEYS.index("ema_span_1"),
-        EMA_ANCHOR_COIN_OVERRIDE_STRATEGY_KEYS.index(
-            "offset_volatility_ema_span_1m"
-        ),
-        EMA_ANCHOR_COIN_OVERRIDE_COOLDOWN_COLUMN,
-        EMA_ANCHOR_COIN_OVERRIDE_HSL_START_COLUMN + 3,
-    }
-    for column in minute_columns:
+    for column in minute_columns | {hsl_start_column + 3}:
         finite = np.isfinite(scaled[:, column])
         scaled[finite, column] /= interval_minutes
     if interval_minutes != 1.0:
-        hsl_span_column = EMA_ANCHOR_COIN_OVERRIDE_HSL_START_COLUMN + 2
+        hsl_span_column = hsl_start_column + 2
         finite = np.isfinite(scaled[:, hsl_span_column])
         hsl_spans = scaled[finite, hsl_span_column]
         if np.any(hsl_spans < 1.0):
@@ -235,6 +235,51 @@ def _scale_ema_multicoin_coin_overrides(
         )
         scaled[finite, hsl_span_column] = 2.0 / alpha_per_candle - 1.0
     return np.ascontiguousarray(scaled, dtype=np.float32)
+
+
+def _scale_ema_multicoin_coin_overrides(
+    coin_overrides: np.ndarray, interval_minutes: float
+) -> np.ndarray:
+    """Convert finite exact-last EMA coin overrides to candle periods."""
+
+    return _scale_multicoin_coin_overrides(
+        coin_overrides,
+        interval_minutes,
+        expected_cols=EMA_ANCHOR_COIN_OVERRIDE_COLS,
+        label="EMA",
+        minute_columns={
+            EMA_ANCHOR_COIN_OVERRIDE_STRATEGY_KEYS.index("ema_span_0"),
+            EMA_ANCHOR_COIN_OVERRIDE_STRATEGY_KEYS.index("ema_span_1"),
+            EMA_ANCHOR_COIN_OVERRIDE_STRATEGY_KEYS.index(
+                "offset_volatility_ema_span_1m"
+            ),
+            EMA_ANCHOR_COIN_OVERRIDE_COOLDOWN_COLUMN,
+        },
+        hsl_start_column=EMA_ANCHOR_COIN_OVERRIDE_HSL_START_COLUMN,
+    )
+
+
+def _scale_tm_multicoin_coin_overrides(
+    coin_overrides: np.ndarray, interval_minutes: float
+) -> np.ndarray:
+    """Convert finite exact-last TM coin overrides to candle periods."""
+
+    override_keys = tuple(
+        key for key, _path in TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS
+    )
+    return _scale_multicoin_coin_overrides(
+        coin_overrides,
+        interval_minutes,
+        expected_cols=TRAILING_MARTINGALE_COIN_OVERRIDE_COLS,
+        label="Trailing Martingale",
+        minute_columns={
+            override_keys.index("ema_span_0"),
+            override_keys.index("ema_span_1"),
+            override_keys.index("volatility_ema_span_1m"),
+            TRAILING_MARTINGALE_COIN_OVERRIDE_COOLDOWN_COLUMN,
+        },
+        hsl_start_column=TRAILING_MARTINGALE_COIN_OVERRIDE_HSL_START_COLUMN,
+    )
 
 
 def _scalar_column_or_zero(scalars, index: int):
@@ -997,7 +1042,6 @@ class MpsEmaAnchorMulticoinRunner:
     coin_override_cols = EMA_ANCHOR_COIN_OVERRIDE_COLS
     coin_override_label = "EMA"
     scalar_cols = MPS_MULTICOIN_SCALAR_COLS
-    supports_aggregated_intervals = True
 
     def __init__(
         self,
@@ -1057,11 +1101,6 @@ class MpsEmaAnchorMulticoinRunner:
                 "MPS multicoin runner requires a positive whole-minute candle interval"
             )
         self.interval_minutes = int(interval_minutes)
-        if not self.supports_aggregated_intervals and self.interval_minutes != 1:
-            raise ValueError(
-                "MPS multicoin Trailing Martingale currently supports one-minute "
-                "candles only"
-            )
         self.n = int(data["n"])
         self.n_coins = int(data["n_coins"])
         self.n_days = int(data["n_days"])
@@ -1084,11 +1123,7 @@ class MpsEmaAnchorMulticoinRunner:
         self.touch_nearest_ticks = data["touch_nearest_ticks"]
         self.touch_min_qty_bits = data["touch_min_qty_bits"]
         self.touch_min_qty_relation = data["touch_min_qty_relation"]
-        self.hour_log_ranges = (
-            data["hour_log_ranges"]
-            if self.supports_aggregated_intervals
-            else None
-        )
+        self.hour_log_ranges = data["hour_log_ranges"]
         self.coin_settings = data["coin_settings"]
         if coin_overrides is None:
             coin_overrides = np.full(
@@ -1555,10 +1590,10 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
 
     coin_override_cols = TRAILING_MARTINGALE_COIN_OVERRIDE_COLS
     coin_override_label = "Trailing Martingale"
-    supports_aggregated_intervals = False
-
     def _prepare_coin_overrides(self, coin_overrides: np.ndarray) -> np.ndarray:
-        return np.ascontiguousarray(coin_overrides, dtype=np.float32)
+        return _scale_tm_multicoin_coin_overrides(
+            coin_overrides, self.interval_minutes
+        )
 
     def __init__(
         self,
@@ -1605,8 +1640,14 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
                 "expected multicoin Trailing Martingale parameter matrix with "
                 f"{expected} columns, got {got}"
             )
+        scaled = _scale_directional_minute_parameters(
+            params,
+            TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS,
+            sides=1,
+            interval_minutes=self.interval_minutes,
+        )
         return _pack_tm_parameter_matrix(
-            params, TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, sides=1
+            scaled, TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, sides=1
         )
 
     def _library(self):
@@ -1637,6 +1678,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             self.touch_nearest_ticks,
             self.touch_min_qty_bits,
             self.touch_min_qty_relation,
+            self.hour_log_ranges,
             self.coin_settings,
             self.coin_overrides,
             params_mps,
@@ -1718,7 +1760,7 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
                 f"matrix shaped {expected_shape}, got {short_coin_overrides.shape}"
             )
         self.short_coin_overrides = torch.as_tensor(
-            np.ascontiguousarray(short_coin_overrides), device="mps"
+            self._prepare_coin_overrides(short_coin_overrides), device="mps"
         )
         encoded_max_realized_loss_pct = _encode_max_realized_loss_pct(
             float(max_realized_loss_pct)
@@ -1755,8 +1797,14 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
                 "expected fused multicoin Trailing Martingale parameter matrix "
                 f"with {expected} columns, got {got}"
             )
+        scaled = _scale_directional_minute_parameters(
+            params,
+            TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS,
+            sides=2,
+            interval_minutes=self.interval_minutes,
+        )
         return _pack_tm_parameter_matrix(
-            params, TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, sides=2
+            scaled, TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, sides=2
         )
 
     def _dispatch(
@@ -1780,6 +1828,7 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
             self.touch_nearest_ticks,
             self.touch_min_qty_bits,
             self.touch_min_qty_relation,
+            self.hour_log_ranges,
             self.coin_settings,
             self.coin_overrides,
             self.short_coin_overrides,

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -1882,14 +1882,6 @@ class MpsMulticoinProxy:
         candle_interval_minutes = _single_coin_candle_interval_minutes(
             backtest_params
         )
-        if (
-            self.strategy_kind == "trailing_martingale"
-            and candle_interval_minutes != 1
-        ):
-            raise ValueError(
-                "MPS multicoin Trailing Martingale currently supports one-minute "
-                "candles only"
-            )
         if not bool(backtest_params.get("dynamic_wel_by_tradability")):
             raise ValueError(
                 "MPS multicoin proxy requires backtest.dynamic_wel_by_tradability=true"
@@ -2180,7 +2172,7 @@ class MpsMulticoinProxy:
             timestamps,
             runs=runs,
             markets=markets,
-            include_hourly_ranges=self.strategy_kind == "ema_anchor",
+            include_hourly_ranges=True,
         )
         self.metrics_data = {"ts0": self.data["ts0"], "n": self.data["n"]}
         self.runners = {}

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -14,8 +14,11 @@ from optimization.gpu.model import (
     ProxyMarket,
     ProxyRun,
     TRAILING_MARTINGALE_COIN_OVERRIDE_COLS,
+    TRAILING_MARTINGALE_COIN_OVERRIDE_COOLDOWN_COLUMN,
     TRAILING_MARTINGALE_COIN_OVERRIDE_GATE_INITIAL_COLUMN,
     TRAILING_MARTINGALE_COIN_OVERRIDE_GATE_REENTRY_COLUMN,
+    TRAILING_MARTINGALE_COIN_OVERRIDE_HSL_START_COLUMN,
+    TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS,
     TRAILING_MARTINGALE_COIN_OVERRIDE_ALLOWANCE_PCT_COLUMN,
     TRAILING_MARTINGALE_COIN_OVERRIDE_WALLET_EXPOSURE_COLUMN,
     TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS,
@@ -36,6 +39,7 @@ from optimization.gpu.mps_kernel import (
     _pack_tm_parameter_matrix,
     _scale_directional_minute_parameters,
     _scale_ema_multicoin_coin_overrides,
+    _scale_tm_multicoin_coin_overrides,
     _scale_single_coin_minute_parameters,
     _with_hsl_ema_tail,
     _with_hsl_features,
@@ -1784,10 +1788,10 @@ kernel void passivbot_tm_multicoin_order_phase_probe(
     TrailingMartingaleMulticoinSideState long_side;
     TrailingMartingaleMulticoinSideState short_side;
     init_trailing_martingale_multicoin_side_state(
-        long_side, long_config, bars, coin_settings, coin_overrides, 1
+        long_side, long_config, coin_settings, coin_overrides, 1
     );
     init_trailing_martingale_multicoin_side_state(
-        short_side, short_config, bars, coin_settings, coin_overrides, 1
+        short_side, short_config, coin_settings, coin_overrides, 1
     );
     long_side.selected[0] = true;
     short_side.selected[0] = true;
@@ -2383,6 +2387,7 @@ def test_mps_tm_multicoin_candle_helpers_advance_independent_sides():
     probe_kernel = r"""
 kernel void passivbot_tm_multicoin_candle_helpers_probe(
     constant float* bars,
+    constant float* hour_log_ranges,
     constant float* coin_settings,
     constant float* coin_overrides,
     device float* output,
@@ -2423,10 +2428,6 @@ kernel void passivbot_tm_multicoin_candle_helpers_probe(
         short_side.forager_volume[c] = 0.0f;
         long_side.forager_volatility[c] = 0.0f;
         short_side.forager_volatility[c] = 0.0f;
-        long_side.hour_high[c] = c == 0 ? 105.0f : 205.0f;
-        long_side.hour_low[c] = c == 0 ? 95.0f : 195.0f;
-        short_side.hour_high[c] = long_side.hour_high[c];
-        short_side.hour_low[c] = long_side.hour_low[c];
         long_side.psize[c] = c == 0 ? 2.0f : 0.0f;
         long_side.pprice[c] = 90.0f;
         short_side.psize[c] = c == 0 ? 3.0f : 0.0f;
@@ -2449,10 +2450,10 @@ kernel void passivbot_tm_multicoin_candle_helpers_probe(
         short_side, bars, coin_settings, 1, 2, true, 1000.0f
     );
     update_tm_multicoin_side_indicators(
-        long_side, long_config, bars, coin_settings, 1, 2, 59
+        long_side, long_config, bars, hour_log_ranges, coin_settings, 1, 2
     );
     update_tm_multicoin_side_indicators(
-        short_side, short_config, bars, coin_settings, 1, 2, 59
+        short_side, short_config, bars, hour_log_ranges, coin_settings, 1, 2
     );
     output[2] = float(count_tm_multicoin_tradable_coins(
         bars, coin_settings, coin_overrides, 1, 2
@@ -2492,6 +2493,10 @@ kernel void passivbot_tm_multicoin_candle_helpers_probe(
         (2, TRAILING_MARTINGALE_COIN_OVERRIDE_COLS), float("nan"), dtype=torch.float32, device="mps"
     )
     coin_overrides[1, 24] = 0.0
+    hour_log_ranges = torch.full(
+        (2, 2), -1.0, dtype=torch.float32, device="mps"
+    )
+    hour_log_ranges[1, 0] = np.log(105.0 / 95.0)
     output = torch.zeros(20, dtype=torch.float32, device="mps")
 
     library = torch.mps.compile_shader(
@@ -2499,7 +2504,12 @@ kernel void passivbot_tm_multicoin_candle_helpers_probe(
         + probe_kernel
     )
     library.passivbot_tm_multicoin_candle_helpers_probe(
-        bars, coin_settings, coin_overrides, output, threads=(1, 1, 1)
+        bars,
+        hour_log_ranges,
+        coin_settings,
+        coin_overrides,
+        output,
+        threads=(1, 1, 1),
     )
     torch.mps.synchronize()
 
@@ -3299,6 +3309,103 @@ def test_multicoin_ema_interval_packing_scales_only_finite_coin_overrides():
     assert np.isnan(scaled[1]).all()
 
 
+def test_multicoin_tm_interval_packing_scales_forager_and_directional_spans():
+    values = {
+        key: float(index + 1)
+        for index, key in enumerate(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS)
+    }
+    values.update(
+        {
+            "ema_span_0": 30.0,
+            "ema_span_1": 90.0,
+            "volatility_ema_span_1h": 24.0,
+            "volatility_ema_span_1m": 120.0,
+            "forager_volume_ema_span_1m": 180.0,
+            "forager_volatility_ema_span_1m": 240.0,
+            "entry_cooldown_minutes": 15.0,
+            "hsl_ema_span_minutes": 60.0,
+            "hsl_cooldown_minutes_after_red": 35.0,
+        }
+    )
+    original = np.asarray(
+        [
+            [
+                values[key]
+                for key in TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+            ]
+            * 2
+        ],
+        dtype=np.float64,
+    )
+
+    scaled = _scale_directional_minute_parameters(
+        original,
+        TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS,
+        sides=2,
+        interval_minutes=5.0,
+    )
+
+    for side_index in range(2):
+        offset = side_index * len(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS)
+        for key, expected in (
+            ("ema_span_0", 6.0),
+            ("ema_span_1", 18.0),
+            ("volatility_ema_span_1m", 24.0),
+            ("forager_volume_ema_span_1m", 36.0),
+            ("forager_volatility_ema_span_1m", 48.0),
+            ("entry_cooldown_minutes", 3.0),
+            ("hsl_cooldown_minutes_after_red", 7.0),
+        ):
+            assert scaled[
+                0,
+                offset + TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(key),
+            ] == expected
+        assert scaled[
+            0,
+            offset
+            + TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(
+                "volatility_ema_span_1h"
+            ),
+        ] == 24.0
+
+
+def test_multicoin_tm_interval_packing_scales_only_finite_coin_overrides():
+    overrides = np.full(
+        (2, TRAILING_MARTINGALE_COIN_OVERRIDE_COLS), np.nan, dtype=np.float64
+    )
+    override_keys = tuple(
+        key for key, _path in TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS
+    )
+    ema0_column = override_keys.index("ema_span_0")
+    ema1_column = override_keys.index("ema_span_1")
+    volatility_1m_column = override_keys.index("volatility_ema_span_1m")
+    volatility_1h_column = override_keys.index("volatility_ema_span_1h")
+    hsl_span_column = TRAILING_MARTINGALE_COIN_OVERRIDE_HSL_START_COLUMN + 2
+    hsl_cooldown_column = TRAILING_MARTINGALE_COIN_OVERRIDE_HSL_START_COLUMN + 3
+    overrides[0, ema0_column] = 35.0
+    overrides[0, ema1_column] = 70.0
+    overrides[0, volatility_1m_column] = 140.0
+    overrides[0, volatility_1h_column] = 24.0
+    overrides[0, TRAILING_MARTINGALE_COIN_OVERRIDE_COOLDOWN_COLUMN] = 21.0
+    overrides[0, hsl_span_column] = 60.0
+    overrides[0, hsl_cooldown_column] = 28.0
+
+    scaled = _scale_tm_multicoin_coin_overrides(overrides, 7.0)
+
+    assert scaled[0, ema0_column] == 5.0
+    assert scaled[0, ema1_column] == 10.0
+    assert scaled[0, volatility_1m_column] == 20.0
+    assert scaled[0, volatility_1h_column] == 24.0
+    assert (
+        scaled[0, TRAILING_MARTINGALE_COIN_OVERRIDE_COOLDOWN_COLUMN]
+        == 3.0
+    )
+    assert scaled[0, hsl_cooldown_column] == 4.0
+    alpha_7m = 2.0 / (float(scaled[0, hsl_span_column]) + 1.0)
+    assert alpha_7m == pytest.approx(1.0 - (1.0 - 2.0 / 61.0) ** 7)
+    assert np.isnan(scaled[1]).all()
+
+
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
@@ -3512,7 +3619,7 @@ def _multicoin_exposure_fixture(
         timestamps,
         runs,
         markets,
-        include_hourly_ranges=strategy_kind == "ema_anchor",
+        include_hourly_ranges=True,
     )
     if strategy_kind == "ema_anchor":
         values = {
@@ -3672,17 +3779,46 @@ def test_mps_ema_multicoin_aggregated_interval_fused_smoke(interval_minutes):
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
-def test_mps_tm_multicoin_aggregated_interval_fails_closed():
-    with pytest.raises(
-        ValueError,
-        match="Trailing Martingale currently supports one-minute candles only",
-    ):
-        _multicoin_exposure_fixture(
-            "trailing_martingale",
-            "long",
-            count=32,
-            interval_minutes=5,
-        )
+@pytest.mark.parametrize("interval_minutes", [5, 7])
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_multicoin_aggregated_interval_directional_smoke(
+    interval_minutes, side
+):
+    runner, row = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        side,
+        count=420,
+        interval_minutes=interval_minutes,
+    )
+
+    output = runner.run(np.asarray([row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert runner.interval_minutes == interval_minutes
+    assert torch.isfinite(output["day_end_eq"]).any().item()
+    assert torch.isfinite(output["last_eq_ts"]).all().item()
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("interval_minutes", [5, 7])
+def test_mps_tm_multicoin_aggregated_interval_fused_smoke(interval_minutes):
+    _, row, run, data = _multicoin_exposure_fixture(
+        "trailing_martingale",
+        "long",
+        count=420,
+        interval_minutes=interval_minutes,
+        return_context=True,
+    )
+    runner = MpsTrailingMartingaleMulticoinFusedRunner(run, data)
+
+    output = runner.run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert runner.interval_minutes == interval_minutes
+    assert torch.isfinite(output["day_end_eq"]).any().item()
+    assert torch.isfinite(output["last_eq_ts"]).all().item()
 
 
 @pytest.mark.skipif(
@@ -8203,6 +8339,7 @@ def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
         data["touch_nearest_ticks"],
         data["touch_min_qty_bits"],
         data["touch_min_qty_relation"],
+        data["hour_log_ranges"],
         data["coin_settings"],
         overrides,
         overrides,
@@ -8501,6 +8638,7 @@ def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
         data["touch_nearest_ticks"],
         data["touch_min_qty_bits"],
         data["touch_min_qty_relation"],
+        data["hour_log_ranges"],
         data["coin_settings"],
         override_unstuck,
         overrides,
@@ -13832,7 +13970,7 @@ kernel void passivbot_tm_multicoin_market_wel_reservation_probe(
         load_trailing_martingale_multicoin_side_config(params, 0);
     TrailingMartingaleMulticoinSideState side;
     init_trailing_martingale_multicoin_side_state(
-        side, config, bars, coin_settings, coin_overrides, 1
+        side, config, coin_settings, coin_overrides, 1
     );
     side.selected[0] = true;
     side.psize[0] = 10.0f;
@@ -13960,7 +14098,7 @@ kernel void passivbot_tm_multicoin_market_unstuck_reservation_probe(
         load_trailing_martingale_multicoin_side_config(params, 0);
     TrailingMartingaleMulticoinSideState state;
     init_trailing_martingale_multicoin_side_state(
-        state, config, bars, coin_settings, coin_overrides, 1
+        state, config, coin_settings, coin_overrides, 1
     );
     state.selected[0] = true;
     state.psize[0] = 10.0f;
@@ -14192,7 +14330,7 @@ kernel void passivbot_tm_multicoin_market_reducer_dust_probe(
         load_trailing_martingale_multicoin_side_config(params, 0);
     TrailingMartingaleMulticoinSideState side;
     init_trailing_martingale_multicoin_side_state(
-        side, config, bars, coin_settings, coin_overrides, 1
+        side, config, coin_settings, coin_overrides, 1
     );
     side.psize[0] = 1.6f;
     side.pprice[0] = 40.0f;

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -940,7 +940,6 @@ def test_multicoin_proxy_routes_dual_side_batch_through_fused_runner(
         "override_cols",
         "proxy_mode",
         "interval_minutes",
-        "expected_interval_error",
     ),
     [
         (
@@ -949,7 +948,6 @@ def test_multicoin_proxy_routes_dual_side_batch_through_fused_runner(
             29,
             "shared-account-fused-ema-v1",
             5,
-            False,
         ),
         (
             "trailing_martingale",
@@ -957,7 +955,6 @@ def test_multicoin_proxy_routes_dual_side_batch_through_fused_runner(
             TRAILING_MARTINGALE_COIN_OVERRIDE_COLS,
             "shared-account-fused-tm-v1",
             1,
-            False,
         ),
         (
             "trailing_martingale",
@@ -965,7 +962,6 @@ def test_multicoin_proxy_routes_dual_side_batch_through_fused_runner(
             TRAILING_MARTINGALE_COIN_OVERRIDE_COLS,
             "shared-account-fused-tm-v1",
             5,
-            True,
         ),
     ],
 )
@@ -990,7 +986,6 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
     override_cols,
     proxy_mode,
     interval_minutes,
-    expected_interval_error,
     needed_metrics,
     tail_enabled,
     raw_drawdown_enabled,
@@ -1124,15 +1119,21 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
         },
     )
     backtest.build_backtest_payload = lambda *args, **kwargs: payload
-    monkeypatch.setattr(
-        gpu_service,
-        "build_mps_multicoin_data",
-        lambda *args, **kwargs: {
+    built_data_kwargs = {}
+
+    def fake_build_mps_multicoin_data(*args, **kwargs):
+        built_data_kwargs.update(kwargs)
+        return {
             "n": 4,
             "n_coins": 2,
             "n_days": 1,
             "ts0": 0,
-        },
+        }
+
+    monkeypatch.setattr(
+        gpu_service,
+        "build_mps_multicoin_data",
+        fake_build_mps_multicoin_data,
     )
     constructed = {}
 
@@ -1143,24 +1144,6 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
     monkeypatch.setattr(mps_kernel, runner_name, FakeFusedRunner)
     values = np.ones((4, 2, 4), dtype=np.float64)
     timestamps = np.arange(4, dtype=np.int64) * interval_minutes * 60_000
-
-    if expected_interval_error:
-        with pytest.raises(
-            ValueError,
-            match="Trailing Martingale currently supports one-minute candles only",
-        ):
-            MpsMulticoinEmaProxy(
-                config=config,
-                hlcvs=values,
-                mss={"BTC": {}, "ETH": {}},
-                btc=np.ones(4, dtype=np.float64),
-                timestamps=timestamps,
-                exchange="bybit",
-                batch_size=8,
-                needed_metrics=needed_metrics,
-            )
-        assert constructed == {}
-        return
 
     proxy = MpsMulticoinEmaProxy(
         config=config,
@@ -1174,6 +1157,7 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
     )
 
     assert isinstance(proxy.fused_runner, FakeFusedRunner)
+    assert built_data_kwargs["include_hourly_ranges"] is True
     assert constructed["run"].interval_ms == interval_minutes * 60_000
     assert proxy.runners == {}
     assert proxy.coin_override_contract["proxy_mode"] == proxy_mode


### PR DESCRIPTION
## Summary

- support any positive whole-minute candle interval for Apple MPS multi-coin Trailing Martingale optimization
- convert global and static per-coin minute spans, Forager spans, cooldowns, and HSL decay to candle-period equivalents
- reuse precomputed Rust-compatible hourly ranges and interval-aware UTC-day accounting in directional and fused Metal kernels
- retain exact Rust validation and drift gates as authoritative

## Validation

- `cargo test --no-default-features -q` (267 passed)
- `PYTHONPATH=src .../pytest -q tests/optimization` (passed; MPS tests skipped inside sandbox)
- physical Apple M3/MPS: complete `test_gpu_mps.py` + `test_gpu_service.py` (passed)
- physical Apple M3/MPS real local BTC/SOL fused long+short proxy/exact runs at 5m and 7m: each 512 proxy evaluations + 32 exact Rust validations, drift gate active, completed without halt
- `git diff --check`